### PR TITLE
Publish maintainer tooling and drop unpublished-file references

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,10 @@
+{
+  "enabledPlugins": {
+    "cc-skills-golang@samber": false,
+    "chrome-devtools-mcp@claude-plugins-official": false
+  },
+  "skillOverrides": {
+    "claude-in-chrome": "off",
+    "dataviz": "off"
+  }
+}

--- a/.claude/skills/deliver-epic/SKILL.md
+++ b/.claude/skills/deliver-epic/SKILL.md
@@ -1,0 +1,273 @@
+---
+name: deliver-epic
+description: Use when the user gives a paragraph of feature intent and wants the whole epic delivered - ADR through fleet execution to merged main - with one approval gate. Triggers: "deliver this epic", "take this feature end to end", "run deliver-epic on ...".
+---
+
+# Delivering an epic end to end
+
+One paragraph of intent in, merged epic out. Five stages; exactly one
+human gate (ADR approval, end of stage 1). Every other decision is yours.
+The ledger in the epic issue is the source of truth for resume: write it
+before acting, not after, so a dropped session loses nothing.
+
+This skill orchestrates; it does not restate. Specs come from the
+fleet-task-spec skill, merges from the merge-fleet-result skill, frozen
+formats from the format-change skill. Read those when you reach their
+stage.
+
+## Quick reference
+
+| Stage | Output | Gate |
+|---|---|---|
+| 1 Design | ADR + epic issue | HUMAN APPROVAL (only one) |
+| 2 Decompose | Task table, DAG, waves, sub-issues | waves have zero file overlap |
+| 3 Execute | Fleet dispatch per wave, ledger entries | all tasks terminal |
+| 4 Checkpoint | Opus adversarial review of wave diff | review passes |
+| 5 Land | Merged main, closed sub-issues, ledger | gates green in worktree |
+
+Stages 3-5 loop per wave. Wave N+1 is not dispatched until wave N has
+landed on main.
+
+## Stage 1 - Design
+
+1. Research against the actual codebase: Explore subagents over the
+   crates the intent touches, plus their normative docs from the
+   CLAUDE.md doc map. Never read vendored dependency sources.
+2. Claim the ADR number the moment you pick it, before writing the full
+   ADR. Commit a one-line stub at `docs/adrs/NNNN-<slug>.md` (next free
+   number) containing just a title line and `Status: claimed`, and land
+   it on main through its own small PR right away. The reservation is
+   then visible on main to every other in-flight epic, so two parallel
+   epics cannot pick the same number. A number reserved only locally
+   collides: nothing hits main until after the approval gate, and two
+   parallel epics pick the same next-free number. Then write the full
+   ADR (Context, Decision, Rejected alternatives, each with the
+   concrete reason it lost, Consequences) into the same path,
+   overwriting the stub's content. Include at least one diagram
+   (Mermaid: component or data-flow; trust-boundary for anything
+   security-shaped). The approval gate is the most expensive place in
+   the pipeline to loop back, and a prose-only ADR has cost an extra
+   approval round trip there when the approver sent it back for
+   diagrams. If any frozen format is touched,
+   follow the format-change skill before writing the full ADR.
+3. Open the epic issue:
+   `gh issue create --title "Epic: <feature>" --body-file <body>`
+   Body: intent paragraph, ADR path, empty `## Tasks` checklist, empty
+   `## Ledger` section.
+4. STOP. Present ADR summary, rejected alternatives, and issue number.
+   The stub from step 2 is already on main (that only reserves the
+   number); do not commit the full ADR content yet. This is the only
+   mandatory human gate; on approval, commit the full ADR over the stub
+   (`docs: add ADR-NNNN <title>`, trailer `Refs: #<epic>`), push, and
+   proceed without further confirmation.
+
+## Stage 2 - Decompose
+
+For each task emit a row:
+
+```
+ID | title | crates | predicted files | deps | acceptance test | risk
+```
+
+- Acceptance test: a named test (`crate::module::test_name`) that must
+  exist and pass in the task's result. It goes verbatim into the spec's
+  Tests section and is re-run at checkpoint.
+- Risk tier: low / medium / high. High = touches durability, commit
+  protocol, or a persistent format boundary.
+- End-to-end reachability: at least one task in the table must carry an
+  acceptance test that proves the epic's delivered capability is actually
+  constructed and reachable from a real caller in the shipping binary,
+  not merely unit- or crate-tested in isolation. Crate-level tests pass
+  against code no production path ever builds: a merged, crate-tested
+  cache has shipped that no caller constructed. The reachability
+  test drives the capability through a real entry point (a service
+  handler, a query path, a startup wire-up), so a green result means the
+  feature is truly usable, not just present. Point the executor at an
+  existing reachability test in the tree (one that attaches the feature
+  through a real entry point) as the pattern to follow, without
+  repeating its diff.
+
+Build the DAG from deps, then cut into waves:
+
+- A wave is a set of ready tasks (all deps landed) with **zero overlap
+  in predicted files, and no two tasks in the same crate** - same-crate
+  tasks collide on lib.rs mod declarations and Cargo.toml even when
+  their file lists look disjoint.
+- Two tasks predicted to touch the same file are not "serialized", they
+  are ONE fleet task with combined deliverables. Splitting same-file
+  work across dispatches produces two divergent rewrites of the same
+  code that then need manual reconciliation.
+- High-risk tasks ride solo in their wave (isolates the checkpoint
+  review) and get `effort: high` on dispatch.
+- Prediction is conservative: unsure whether a task touches a file,
+  assume it does.
+
+Create one sub-issue per task (body: scope, acceptance test, risk),
+tick-list them in the epic's `## Tasks`, and write the full wave plan as
+the first ledger entry.
+
+## Stage 3 - Execute (per wave)
+
+1. Confirm local main == origin/main and clean; the wave dispatches from
+   this HEAD.
+2. Write each spec with the fleet-task-spec skill. The harness-override
+   and UNATTENDED paragraphs are not optional. Spec's Tests section
+   names the acceptance test.
+3. Dispatch the whole wave in parallel `fleet_dispatch` calls. Record
+   every task_id in the ledger IMMEDIATELY, before watching anything - a
+   dropped session with unrecorded task_ids orphans running work.
+4. Watch with `scripts/fleet-watch.sh <watch-url> <interval>` in
+   background, one per task. Pass the bare command straight to the
+   background-execution tool with its own backgrounding flag (e.g. the
+   Bash tool's `run_in_background: true`) - do not wrap it in `nohup
+   ... &` yourself first. Backgrounding it manually returns control to
+   the shell the instant the `&` is issued, so the tool marks that call
+   "complete" right then, before the watch loop has run at all; every
+   later terminal-event notification is then silently lost, and nothing
+   tells you the wave finished. Watchers launched with
+   `nohup fleet-watch.sh ... & echo $!` show "completed" within a
+   second while `fleet_status` still reports
+   `running` for every task. Interval: 120s for tasks expected under an
+   hour, 300s otherwise. Never poll `fleet_status` in a foreground loop
+   and never rely on a single SSE connection - it drops within seconds
+   in this environment.
+
+Failure playbook (in order of check):
+
+| Signal | Action |
+|---|---|
+| done, but `git ls-remote origin refs/heads/task/<id>/result` empty | Work lost. Re-dispatch same spec once. |
+| rate limit / auth / transient executor error | Retry once as-is. Second failure: re-dispatch with `label_selector` naming a different executor. |
+| runtime ceiling (~4h kill) | Fleet recovers committed work. Fetch the recovered ref, re-dispatch as a CONTINUATION from that ref (`ref:` param, spec says what remains). Never restart from scratch. |
+| second re-dispatch also fails | Stop the wave, ledger `blocked`, report to user. Do not silently drop the task from the epic. |
+
+Every dispatch, retry, and terminal event gets a ledger line when it
+happens.
+
+## Stage 4 - Checkpoint (per wave)
+
+Runs after every wave task is terminal with a verified result ref, and
+BEFORE any merge.
+
+1. Fetch all result branches. Build the combined diff against **current
+   origin/main**, not the dispatch-time HEAD - main moves under you.
+2. Spawn one adversarial review subagent: Agent tool, general-purpose,
+   `model: opus`, `isolation: "worktree"`. The reviewer runs real git
+   commands (checkouts, scratch clones, rebase drills against edge
+   cases) in the course of verifying scripts; without worktree isolation
+   it operates on the dispatching session's own shared checkout and can
+   silently discard uncommitted local edits as collateral: a reviewer
+   dispatched without isolation has reverted a hand-authored,
+   uncommitted fix to its committed state,
+   with no stash and no reflog entry, the exact corruption CLAUDE.md's
+   workspace-isolation section warns about. Prompt it to hunt ONLY
+   correctness bugs and invariant violations - not style, not naming,
+   not structure:
+   - durability depending on local disk; recovery reading another
+     process's local state
+   - mutation of data objects, commit records, manifests, index objects
+   - in-place edits to frozen formats (RSEG, proto/, series identity,
+     commit tokens, key layout) without ADR + version bump
+   - unwrap/expect on production paths; `unsafe`
+   - silent approximation; placeholder implementations on critical paths
+   - acceptance tests that don't genuinely assert the claimed behavior
+   Require findings as `file:line - claim - why it's wrong`, and a
+   verdict: pass or block.
+3. Block verdict: fix before merging anything. Small and mechanical fix
+   locally (in a worktree); otherwise a fix task to the fleet. Re-review
+   the changed area. Wave N+1 does not dispatch until pass.
+4. Ledger the verdict, findings count, and fix commits.
+5. Remove the reviewer's worktree. `isolation: "worktree"` only
+   auto-removes it when the agent made no changes; a reviewer that ran
+   scratch clones, rebase drills, or a block-verdict fix leaves it behind
+   and returns its path in the result instead. Once its verdict and any
+   fix commits are captured in the ledger (step 4), nothing reads that
+   worktree again: `git worktree remove <path>` from outside it. Same
+   failure shape as Stage 5's: an instruction living only in the tool
+   description, not a numbered step here, is an instruction that gets
+   skipped, and each skipped removal leaves a worktree carrying up to
+   tens of gigabytes of build cache.
+
+## Stage 5 - Land (per wave)
+
+Work in a dedicated worktree of main (`git worktree add`), per CLAUDE.md.
+
+1. Per task, in DAG order: `scripts/fleet-result-inspect.sh <task-id>`,
+   write the PR message file (first line = PR title, body after the blank
+   line carries `Fixes: #<sub-issue>`), then
+   `scripts/fleet-result-merge.sh <task-id> <message-file> -p <crates>`.
+   `main` is protected, so the script never pushes it: it cleans the
+   result branch's history, runs local pre-flight gates, opens a PR, and
+   enables auto-merge (`--rebase`) so GitHub lands it once the required
+   checks pass. The merge-fleet-result skill covers gate failures, scope
+   creep, and confirming the PR actually merged.
+2. Real merge conflict: STOP and read the conflicting main commits first
+   (`git log <merge-base>..origin/main -- <paths>`, full bodies). If a
+   structural decision killed the task's premise (an ADR, a format
+   version change, a rewrite), do not force it through: preserve the
+   branch, comment on the sub-issue with the pointer, ledger it, move
+   on. Only overlapping-edit conflicts get resolved textually.
+3. Verify each sub-issue actually closed (`Fixes:` closes, `Refs:` does
+   not); close stragglers with a comment linking the merge.
+4. Ledger the wave: merge SHAs, new main SHA, closed issues. Tick the
+   epic checklist.
+5. Remove this wave's worktree now (`git worktree remove <path>`), from
+   outside it: every task's PR is open (or landed) and wave N+1 lands
+   against a moved main anyway, so it creates its own fresh worktree in
+   step 1 rather than reusing this one. Do this before starting wave N+1,
+   not batched at epic end: a multi-wave epic that waits lets these
+   pile up (each wave's worktree carrying its own build-cache
+   target dir) instead of shedding them wave by wave.
+6. Last wave only: update README and docs per CLAUDE.md's
+   doc-currency rule, final ledger entry, close the epic.
+
+## Ledger format
+
+One `### Wave N` block in the epic issue's `## Ledger` section, edited
+in place (`gh issue edit --body-file`, or a comment per wave if body
+edits race):
+
+```
+### Wave N - <planned|dispatched|review|blocked|landed>
+plan: T4 #103, T7 #106 (from main <sha>)
+T4 #103 task=<task_id> done result=<sha>
+T7 #106 task=<task_id> ceiling-killed; continued as task=<task_id2> from <recovered-sha>
+review: pass (opus, 2 findings fixed in <sha>)
+landed: <merge-sha> <merge-sha2>; main=<sha>; closed #103 #106
+```
+
+## Resume after a dropped session
+
+1. Read the epic issue ledger; find the last wave block and its status.
+2. Any task_id without a terminal ledger line: `fleet_status` it, verify
+   its result ref with `git ls-remote`, resume that stage's procedure.
+3. `planned` -> dispatch it; `dispatched` -> re-arm watches;
+   `review` -> rerun checkpoint (results are fetched, diff is cheap);
+   `blocked` -> the block reason is in the ledger, resolve it;
+   `landed` -> next wave.
+Never re-dispatch a task whose result ref exists; merge it.
+
+## Red flags - stop and reread the relevant stage
+
+- "Executor reported gates green" - not the gate; local gates on the
+  merged tree are.
+- "Conflict, I'll just resolve it" - premise check first (stage 5.2).
+- "These two tasks touch the same file but different functions" - one
+  task or different waves. No exceptions.
+- "Same crate, but their file lists are disjoint" - still one wave apart.
+  Two tasks dispatched concurrently into one crate on this reasoning
+  have collided: one added a parameter to a function the other grew a new
+  call site for, the merge was textually clean, and the build broke on
+  `E0061`. When one task changes a public signature, grep the other
+  task's predicted files for that name before calling the waves disjoint.
+- "Diff is small, skip the checkpoint" - checkpoint runs every wave.
+- "I'll ask the user before wave 2" - the only gate is ADR approval.
+  Asking mid-flight strands the epic (unattended rule).
+- "I'll record the task_ids after they finish" - ledger before watch,
+  always.
+- "I'll clean up all the wave worktrees at the end" - remove each one at
+  the end of its own wave (Stage 5 step 5); waiting compounds disk use
+  across every wave still to come.
+- "The reviewer's worktree is the harness's problem" - it's only
+  auto-removed when the agent made no changes; a review that ran scratch
+  git commands or applied a fix leaves it behind (Stage 4 step 5).

--- a/.claude/skills/fleet-task-spec/SKILL.md
+++ b/.claude/skills/fleet-task-spec/SKILL.md
@@ -1,0 +1,212 @@
+---
+name: fleet-task-spec
+description: Use when writing a fleet_dispatch spec for this repo - templates the unattended rules, sizing, and scoping so specs stay short and tasks stay alive
+---
+
+# Writing a fleet task spec for Ravel
+
+Fleet executors are unattended and context-limited. Two real failures shape
+this skill: an agent finished hours of work, asked "want me to commit?",
+and died unpushed; another burned its entire context window grepping
+arrow-rs sources.
+
+The repo CLAUDE.md already tells executors the gates, commit conventions,
+invariants, testing patterns, and context discipline. Do not restate those
+in specs. A spec carries only what is task-specific.
+
+CLAUDE.md's "Workspace isolation" section tells every agent working in
+this repo to commit inside a dedicated git worktree, never directly on the
+primary checkout. That rule targets local subagents sharing one session's
+tree. A fleet executor's dispatched checkout already is its own isolated
+workspace; if it also obeys the literal instruction and creates a *second*
+worktree/branch inside that checkout, the harness, which only collects
+what ends up on the checkout's own HEAD, never sees those commits.
+`fleet_status` will still report `done` with what looks like a result ref,
+but the ref was never pushed and the workdir is gone: the work is silently
+lost. This has destroyed finished work in practice. Every spec for this
+repo must therefore open with the harness-override paragraph below, not
+just the unattended one.
+
+## Template
+
+```
+HARNESS REQUIREMENT (overrides CLAUDE.md's workspace-isolation section for
+you specifically -- you are a fleet executor, not a local subagent sharing
+someone else's session tree): commit directly on this dispatched checkout's
+HEAD. Detached HEAD is fine. Do not create a separate git worktree or a
+side branch for your own commits -- the harness only collects what is on
+this checkout's HEAD; anything committed elsewhere is invisible to it and
+lost when your workdir is torn down.
+
+UNATTENDED TASK: never ask for confirmation or approval; when your work
+passes the gates, commit it and end with a report. Committing
+(git commit -s) is part of the deliverable.
+
+Implement <issue ref> for the Ravel project: <one sentence>. Work ONLY
+inside <crates/dirs>.
+
+Read first: <the minimal normative docs, with section hints>.
+Already on main: <the building blocks the task consumes, one line each>.
+
+Deliverables:
+1..n. <numbered, concrete, with file paths and API shapes>
+
+Reachability: <the caller that will exercise this, named. If the task adds
+a capability no existing caller reaches, say so here and say which ticket
+wires it.>
+
+Tests: <the specific behaviors to prove, including failure paths>.
+
+Gates: format and lint IN PLACE before the commit you will gate -- run
+`cargo fmt --all` (not just --check) and, where it applies, scoped
+`cargo clippy --fix -p <crate>` -- then verify with `cargo fmt --all
+--check`; cargo clippy --workspace --all-targets -- -D warnings;
+scripts/affected-tests.sh -p <crate> [-p <crate2>]. Do NOT run
+`cargo test --workspace`: full-workspace tests are verified at merge
+time (verify-dispatch cold gate and PR CI); your job is the blast
+radius of your own change, and affected-tests.sh computes it (the
+named crates plus every crate that depends on them). The commit that
+gets gated must already be formatted; never append a formatting-only
+fixup commit after a failed --check.
+Commit with trailer "Refs: #N".
+Report: <what the orchestrator needs to merge: deviations, counts,
+ambiguities found>.
+```
+
+## Executor test scope
+
+The Gates template scopes executor tests with affected-tests.sh on
+purpose. A fleet task used to end with `cargo test --workspace` on an
+8 GB 4-core host: 1-2 hours of cold compile and test time per task,
+almost all of it re-verifying crates the change cannot affect, and all
+of it re-verified anyway at merge (the orchestrator's cold
+verify-dispatch run and the PR's required CI checks are the trust
+boundary; the executor's own green is never trusted). The executor-side
+run exists for fast self-feedback, so it covers exactly the changed
+crates and their reverse dependencies. Workspace clippy stays: it is
+check-mode (no codegen or link) and is the cheap whole-workspace
+compile-break detector.
+
+## Format before you commit, not after
+
+The Gates line above says to run `cargo fmt --all` (write mode, not
+`--check`) before the commit for a reason. Executors that gate first and
+format second land a second, formatting-only fixup commit on the result
+branch when the check fails, and those fixups ride the result branch all
+the way toward main. The merge path squashes such commits (see the
+merge-fleet-result skill), but the spec is the right place to stop them
+being created: a result branch should never contain a commit whose only
+content is a formatting fix. Formatting is not a gate you react to; it is
+a step you run before the commit exists.
+
+## Reachability
+
+Every spec names the caller. Tasks have delivered correct, tested code
+that no user could reach: a merged, crate-tested cache that no caller
+constructed; a normalize entry point nothing invoked; an attribute-postings
+index that shipped with nothing in production building an attribute
+predicate; a prune channel whose intended caller still used the old scan
+path. Each passed its own gates. Each looked done on the ticket.
+
+The question is not "does it compile and test". It is "which existing call
+site changes behaviour when this lands". If the honest answer is none, the
+spec says so and names the follow-up, and the orchestrator does not record
+the epic as having closed the gap. A capability with no caller is a
+half-finished feature that reads as a finished one.
+
+## Soundness claims need a failing test
+
+When a spec asks for a prune, a pushdown, a cache, or any other
+optimization, require the executor to prove the sound case with a test that
+FAILS against the unsound implementation, and to say in its report which
+line it flipped to watch it fail.
+
+"I reasoned it is sound" and "I proved it is unsound" get very different
+scrutiny, and the first is where the defects live. Results that rest on the
+executor's own soundness reasoning have been right, partly right, and wrong;
+the wrong one silently dropped half the rows of a query and was described in
+its own report as unreachable. It was reachable, and a fifteen-line test
+showed it.
+
+The same applies to a test that claims to pin a fix. A tie-break test built
+on two elements passed against the unfixed code, because the standard
+library's unstable sort preserves order on short inputs. Require the test to
+be demonstrated failing, not merely written. The prove-the-test skill (in
+this repo, so executors have it too) lists the known vacuity shapes; point
+the spec's Tests section at it when the task is fix-shaped.
+
+## Sizing rules
+
+- One task must fit one context window: one crate, or one module cluster
+  within a crate. If deliverables exceed roughly five numbered items or
+  two modules plus tests, split into sequential tasks and dispatch part 2
+  after part 1 merges to main.
+- Tasks that sit near heavy dependencies (arrow, datafusion, tonic
+  internals) get an explicit context-discipline paragraph even though
+  CLAUDE.md covers it: name the dependency and forbid reading its sources.
+- Parallel tasks must have disjoint file scopes. If two tasks need a
+  shared artifact (filenames, trait signatures), fix the names in both
+  specs so merge order does not matter.
+- Split a ticket along the compile/no-compile seam when it bundles a
+  cargo-loop half (code, tests) with a doc/diagram half (spec rewrite,
+  SVG redraw) that needs no cargo at all. Bundled into one task, the doc
+  half serializes behind the build loop for no reason, and one executor
+  holds both for the full duration. Dispatch the doc task in parallel,
+  dependent only on the design decision (the ADR), not on the code
+  landing. Merge order handles any cross-references.
+
+## Before dispatch: two mechanical preflights
+
+Both failure modes below have burned real dispatches. Run both checks in
+the same turn as the `fleet_dispatch` call, every time.
+
+1. **Resolve the ref with git, never from memory.** For the common case:
+   `git fetch origin main --quiet && git rev-parse origin/main`, and pipe
+   that output straight into the `ref` parameter. Never type a 40-char
+   SHA by hand and never complete a short SHA from memory: a dispatch has
+   carried a SHA whose first 8 hex digits were real and whose remaining
+   32 were invented, and the task expired unclaimed. For any other ref
+   shape (a short SHA, a remote-only branch name, another task's result
+   ref) run `git fetch origin <ref> --quiet && git rev-parse FETCH_HEAD`
+   first; dispatch only pushes objects the local repo already has.
+2. **Check `git status --short` on the primary checkout.** The dispatch
+   push refuses to run on ANY uncommitted or untracked file, including a
+   stray build artifact (a leftover `__pycache__/` has blocked dispatch
+   after dispatch before anyone looked). Remove a file only when you can
+   attribute it to a command you ran yourself (a `__pycache__/` from your
+   own compile check). Any file you cannot attribute to yourself is
+   another session's: wait 30 s and retry, up to 3 times, since it
+   reliably self-clears, and never touch it and never ask the user.
+
+## After dispatch
+
+Record the returned task_id, arm the watch command from the dispatch
+response as a persistent Monitor, and merge with the merge-fleet-result
+skill when it lands. `fleet_status` needs the full task UUID; an 8-char
+short form returns "not found". Result branches appear at
+refs/heads/task/<task-id>/result; a done status with no result ref means
+the agent never committed, and the workdir is already gone. Re-dispatch;
+do not try to recover.
+
+Do not trust `fleet_status`'s text at face value: it has printed a
+`result at refs/heads/task/<id>/result` line even when that ref was never
+pushed (the executor committed to its own side worktree/branch instead of
+the checkout's HEAD; see the harness-override paragraph above). Verify
+with `git ls-remote origin refs/heads/task/<task-id>/result` before
+fetching; if it's empty, the work is gone and the only path forward is
+re-dispatching the same ticket with the harness-override paragraph in
+place.
+
+Two more verification rules, both learned the expensive way:
+
+- Always use `git ls-remote` for result refs, never
+  `gh api repos/.../branches/<name>`: the REST branch listing lags the
+  git protocol by minutes and has returned 404 on a ref that `ls-remote`
+  showed correctly the whole time.
+- When an executor's report says its final push failed (control-plane
+  502s do this), check `git ls-remote` for the result ref BEFORE
+  re-dispatching: a retried push may have landed after the report was
+  written. Re-dispatching on an assumed loss destroys completed,
+  gate-green work, so confirm loss, never assume it. Repeated 502s from
+  the control plane also warrant a cooldown (minutes, not seconds)
+  before the next dispatch attempt.

--- a/.claude/skills/format-change/SKILL.md
+++ b/.claude/skills/format-change/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: format-change
+description: Use before changing any persistent format - RSEG layout, proto schemas, series identity, commit tokens, object key layout - these are frozen contracts with a mandatory procedure
+---
+
+# Changing a persistent format
+
+Persistent formats outlive processes and deployments. Data written today
+must be readable by every future version. The frozen contracts:
+
+- RSEG segment layout (docs/segment-format.md)
+- Protobuf schemas under proto/ (field numbers are frozen; only additive
+  changes with new field numbers are allowed)
+- Canonical series identity and commit token encoding (crates/ravel-types;
+  both carry version domain strings)
+- Object key layout (docs/catalog-and-mvcc.md)
+
+## Procedure
+
+1. Write the ADR first: context, alternatives, decision, consequences.
+   Get the format doc amended in the same change so doc and code never
+   diverge.
+2. Version explicitly. RSEG bumps the trailer version; identity encodings
+   get a new domain string (ravel-series-v2, not an edit to v1); protos
+   add fields, never renumber or reuse; key layouts add new prefixes.
+3. Answer the dual-reader question in the ADR: does deployed code need to
+   read both versions? If any stored data exists in the old format, the
+   answer is yes, and the reader keeps both paths until retention clears
+   the old data.
+4. Review checksum coverage. Every byte a reader interprets must be under
+   a checksum the reader can afford to verify on its access path (ADR-0010
+   section 4 is the precedent: a page crc that skipped the encoding byte
+   allowed silent misdecoding).
+5. Extend fuzz and property tests to cover both versions, plus corrupt
+   and truncated inputs for the new one.
+6. Update ravel-cli inspectors to print the new version's fields.
+
+If a change cannot follow this procedure, it does not happen. There is no
+fast path for format changes.

--- a/.claude/skills/merge-fleet-result/SKILL.md
+++ b/.claude/skills/merge-fleet-result/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: merge-fleet-result
+description: Use when a fleet task finishes - fetch its result branch, re-run gates locally, merge to main, push, and clean up; never trust executor-claimed green
+---
+
+# Merging a fleet result branch
+
+Executor gate claims are not the gate. An executor can report fmt/clippy/
+test clean while its branch does not compile from a cold build, because an
+incremental build cache can mask an error (a stale-cache lifetime error is
+the known shape). Local gates on the merged tree are the only acceptance.
+
+**Run the verify-dispatch skill on the result branch before merging.** It
+runs the same gates this skill's procedure below runs, but in an isolated
+worktree with a cold `CARGO_TARGET_DIR` (defeating exactly that
+incremental-cache masking) instead of on the primary checkout after the
+merge has already landed there, plus a set of narrow adversarial checks
+for defect classes this repo has shipped before. On a tier-1 FAIL,
+verify-dispatch's own procedure covers filing an issue and re-dispatching
+a fix; don't duplicate that here. Once verify-dispatch reports tier-1
+PASS, continue with the procedure below.
+
+## main is landed through a PR, never a direct push
+
+`main` has required branch protection: a PR is mandatory, required status
+checks must pass, and history is linear (rebase-merge only). No process,
+`fleet-result-merge.sh` included, pushes `main` directly. The script
+lands a result branch by cleaning its history, pushing that cleaned history
+to a `task/<id>/merge` head branch, opening a PR against `main`, and
+enabling auto-merge (`gh pr merge --auto --rebase`) so GitHub lands it the
+moment the required checks pass. The rebase-merge keeps each commit's own
+message, so per-commit `Fixes:`/`Refs:` trailers still close their issues
+when they land.
+
+## Result-branch history is cleaned before the PR is opened
+
+Before it pushes anything, `fleet-result-merge.sh` scans the result
+branch's own commits (everything between its merge base against
+`origin/main` and its tip) and rewrites two classes of commit out so they
+never reach main:
+
+- `wip:` headers. Work-in-progress snapshot commits have reached
+  protected main when the merge path carried a result branch through
+  verbatim.
+- Pure formatting/style fixups. When an executor gates first and formats
+  second, a formatting-only commit rides along on top of the real work
+  and ends up on main as noise.
+
+The rewrite rebuilds the branch linearly with `cherry-pick` onto a
+throwaway `_fleet_rewrite_<id>` branch (a merge commit anywhere in the
+range aborts the whole run with a clear message, because cherry-pick
+cannot replay a merge). Each flagged commit is folded into the previous *retained*
+commit, but its own `Refs:`/`Fixes:`/`Signed-off-by:` trailers are carried
+into that commit's message first (via `git interpret-trailers
+--if-exists addIfDifferent`), so a required trailer that lived only on a
+`wip:` snapshot is never dropped. A flagged commit that is the *first*
+retained commit has nothing to fold into, so it is reworded instead: the
+`wip:` prefix is stripped and, if what remains has no Conventional Commits
+type, a `chore:` type is prepended so the subject stays a valid header. The
+formatting-fixup detector is deliberately conservative: it fires only when
+the subject mentions `fmt`/`style fix` AND the diff is empty under
+`git diff -w`, so a commit that reformats and also changes real content is
+left alone. A branch with no flagged commits is left byte-for-byte
+untouched and pushed as-is. The cleaned history is what becomes the PR
+head, so the PR only ever contains clean commits. The fleet-task-spec skill
+stops these commits being created in the first place (specs tell executors
+to format before the gated commit); this step is the backstop for branches
+written before that discipline, or that slip.
+
+## Procedure
+
+`fleet-result-merge.sh` is the path: it enforces the pre-flight guard
+(refuses unless HEAD is a clean `main`/`origin/main`, so a stale HEAD can
+never produce a too-old merge base), does the history clean above, runs the
+local pre-flight gates on the cleaned tree, and only then pushes the PR
+head, opens the PR, and turns on auto-merge.
+
+```sh
+TASK=<task-id>
+git fetch origin refs/heads/task/$TASK/result
+git log --oneline origin/main..FETCH_HEAD   # exactly the expected commits?
+git diff --stat origin/main...FETCH_HEAD    # scope: only the task's dirs?
+
+# Write the PR message: first line is the PR title, everything after the
+# blank line is the PR body (put Fixes: #<issue> / Refs: #<issue> here).
+scripts/fleet-result-merge.sh $TASK message.txt   # add -p CRATE to scope local gates
+```
+
+- Scope creep in the diff (files outside the task's stated dirs): stop and
+  review those hunks before running the script; do not open the PR if they
+  are wrong.
+- The PR's required status checks are the real gate. The script's local
+  pre-flight gate run only catches obvious breakage before a PR is opened;
+  a failure there means fix the branch (or re-dispatch) before retrying,
+  not push anything. Never try to bypass the required checks.
+- When the exact tree being merged already passed the full gates locally
+  (the orchestrator gated the result branch before or after a local fix
+  commit), `FLEET_MERGE_SKIP_GATES=1` skips the script's repeat run and
+  lets the PR checks carry it. Not for conflict resolutions or any tree
+  that differs from what was gated.
+- Commit header not in repo convention: amend on the branch before running
+  the script (the script only rewrites `wip:`/fixup subjects, not arbitrary
+  non-conforming ones).
+
+## Recurring mechanical conflicts and gotchas
+
+- Run the script from a clean `main` checkout (or a fresh worktree of
+  `origin/main`), not from the worktree you reviewed or fixed the branch
+  in. The script's own guard exists because that mistake recurs; it
+  refuses any other HEAD.
+- Append-heavy index files (`docs/adrs/README.md` is the usual one)
+  conflict on almost every landing, because `main` moves with unrelated
+  entries. This is not a premise conflict. Mechanical resolve: keep both
+  sides' entries, delete the duplicate of your own entry, keep the file's
+  existing order, re-run the gates.
+- Before running cargo on any hand-combined tree (a rebase, a multi-branch
+  land), do a textual pass first: for every struct whose field list the
+  combined diff changes, `grep -rn '<StructName> {'` across the whole
+  workspace and fix every literal. Otherwise a changed field list surfaces
+  as a long series of `E0063` (missing field) errors, one full cargo cycle
+  at a time; the grep finds the whole class at once.
+- `gh api` sends every `-f` value as a string. A boolean or number field
+  needs `-F` (`-F strict=false`), or the API answers with
+  `"false" is not a boolean`.
+- `gh pr merge --auto --rebase` can fail once with a GraphQL error naming
+  a merge method you never requested ("squash merging is not allowed").
+  That is API flakiness around enabling auto-merge: retry once before
+  investigating repo settings.
+
+## After the PR is open
+
+Auto-merge lands the PR once the required checks pass; `--delete-branch`
+removes the `task/$TASK/merge` head once it merges. The script deliberately
+leaves `task/$TASK/result` and `task/$TASK/start` in place: enabling
+auto-merge is not landing, and deleting them before the checks finish would
+mean a failed check leaves the PR open with no way to recover the original
+result branch.
+
+Watch the PR (`gh pr view <number> --json state,mergedAt`) until it reports
+merged. Once merged, delete the task refs yourself:
+
+```sh
+git push origin --delete task/$TASK/result task/$TASK/start
+```
+
+If a required check fails instead, the PR stays open with the task refs
+still intact; fix the branch (or re-dispatch) and retry, do not delete
+anything.
+
+Close the issue if no landed commit trailer did (`Fixes:` closes it,
+`Refs:` does not). Update the in-flight task ledger. If the agent's report
+listed deviations, ambiguities, or discovered bugs, file follow-up issues
+now, before the context is lost.

--- a/.claude/skills/profile-hotspot/SKILL.md
+++ b/.claude/skills/profile-hotspot/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: profile-hotspot
+description: Use when something is slow, or flaky in a way that smells like slow, and nobody knows which phase owns the time. Timer bisection plus the discipline rules that keep a measurement on a loaded machine from producing a confident wrong answer. Triggers: "why is this slow", "profile this", "where does the time go", a test that flakes on timing.
+---
+
+# Finding where the time goes
+
+Use this when something is slow, or flaky in a way that smells like slow, and
+nobody knows which phase owns the time. It is a measurement procedure, not a
+fix procedure. It ends when you can name the dominant phase with a number.
+
+The method is timer bisection: time the top-level phases, find the one that
+dominates, descend into it, repeat. It is crude and it works. What makes it
+work is not the timers, it is the discipline rules in "Measuring on a machine
+you do not control" below. Skipping those is how a measurement produces a
+confident wrong answer.
+
+## The procedure
+
+1. **Find the cheapest reproducer.** A single test beats a benchmark beats a
+   running server. If a test already exhibits it, use that test. Prebuild the
+   binary (`cargo build --tests`) so compile time is not inside your numbers.
+
+2. **Time the top-level phases.** Wrap each with `std::time::Instant` and
+   print. Do not guess which phase matters; time all of them, including the
+   ones you are certain are fast. In one real investigation the three phases
+   everyone suspected summed to under 10 ms out of 4,670 ms.
+
+3. **Read the share, not the duration.** One phase at >90% means descend into
+   it and ignore everything else. Several phases at 20-30% means you are
+   measuring at the wrong granularity, or the cost is genuinely spread and
+   this method will not find a single answer.
+
+4. **Descend and repeat** until the dominant leaf is a loop, a call, or an
+   allocation you can name and count.
+
+5. **Count the thing, do not just time it.** Once you reach the leaf, print
+   the count as well as the duration. `bucket_listing 4705 ms` is a symptom;
+   `buckets=496089` is the root cause. A per-item cost of 9.5 microseconds is
+   fine and says the item cost is not the problem, the count is.
+
+6. **Revert the instrumentation.** It is scaffolding. Do not commit timers.
+   If the codebase should have emitted this without you, that is its own
+   ticket (see "The durable fix" below).
+
+## Measuring on a machine you do not control
+
+These are the rules that separate a measurement from an anecdote. Every one
+of them exists because breaking it has produced a confident wrong answer
+that reached a user.
+
+- **Report the load average next to every number.** `uptime`. A developer box
+  shared with other tenants swings between load 1 and load 60, and every
+  timing swings with it.
+- **Never conclude from one run.** Five runs minimum, report the spread. A
+  single sample on a moving machine tells you about the machine.
+- **Never compare two numbers taken at different times.** This is the one that
+  bites hardest. "Branch takes 30s, main takes 5.7s" was measured minutes
+  apart and was pure load difference; interleaved A/B runs showed the two were
+  identical and that *main failed too*.
+- **Interleave any A/B.** Alternate the two arms within one loop so drift
+  cannot favour either:
+  ```sh
+  for i in 1 2 3; do
+    for arm in branch main; do ... ; done
+  done
+  ```
+- **A passing run is not evidence your change fixed it.** If the failure is
+  load-dependent, every arm passes sometimes. Two "isolating" experiments
+  can both get lucky draws and be read as proof of a fix that is not there.
+
+## When the reproducer will not reproduce
+
+An idle machine often will not hit the threshold (a deadline, a timeout) that
+made the problem visible. That does not block the work, and it must not be
+reported as "cannot reproduce".
+
+The threshold breach and the fixed cost are different things. The fixed cost
+is present at any load; it is simply smaller than the threshold when the box
+is quiet. Measure the fixed cost. In one real case the breach needed load
+40-60, but the 4.7-second `resolve` was plainly visible at load 1.
+
+## Before you widen a test timeout
+
+A flaky concurrent test invites one reflex fix: make the window bigger.
+Run one check first. If every assertion before the failing wait already
+passed, the operation itself completed, and the test is missing a
+completion signal, not margin. Widening then reproduces the same failure
+at a larger number: a real case widened 2 s to 6 s and failed at 6.76 s,
+because each reader's polling loop was bounded by a wall clock set before
+the writers were joined. No window fixes a race between two independently
+bounded clocks. The real fix was a `writers_flushed` completion flag the
+readers wait on.
+
+So: widen a timeout only after you can say which synchronization signal
+already proves the waited-for work is done. If no such signal exists,
+add one; that is the fix.
+
+## What is not an answer
+
+- Raising the deadline or timeout.
+- `#[ignore]`, `#[serial]`, or a retry.
+- Reducing what the reproducer does until it fits.
+
+Each hides the measurement instead of making it. If one of them is
+nonetheless the right call, that is a recommendation to report, not a change
+to make quietly. "The cost is irreducible, and here are the numbers that show
+it" is a complete and successful outcome.
+
+## The durable fix
+
+Hand-rolled timers answer one question and are thrown away. The next question
+starts from zero.
+
+ADR-0044 decision 5 specifies `tracing` spans on the query path for exactly
+this reason, and notes that without them "a slow query cannot be attributed to
+a phase". Once those spans are implemented, steps 2-4 above become reading
+span durations from a documented command, and this skill shrinks to its
+discipline rules.
+
+Until then: if you find yourself hand-instrumenting a path that a shipped span
+should already cover, say so in your report. That is a finding about the
+codebase, not just about your bug.
+
+## The shape of a good report
+
+A phase table with min/median/max, the dominant phase named with its share,
+the descent to a root cause with a count, and an explicit list of which prior
+hypotheses the measurement refuted.
+
+That last part matters. An investigation can be driven by several confident
+hypotheses that all turn out wrong. Recording which leads died saves the next
+person from re-walking them.

--- a/.claude/skills/prove-the-test/SKILL.md
+++ b/.claude/skills/prove-the-test/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: prove-the-test
+description: Use when writing a regression test, a fault-injection test, a differential or property test, or when citing any test as evidence that a bug is fixed or a path is covered - before the claim, not after review finds the test vacuous
+---
+
+# Prove the test can fail
+
+A test proves something only after you watch it fail for the stated
+reason. A test that cannot detect the defect it is named for passes
+review, ships, and then costs extra fleet dispatches and review rounds
+when the "covered" path turns out to be untested.
+
+## The one required step
+
+Before you cite a test as proof, break the code and watch the test catch
+it. Revert only the production fix (or flip the one line the test
+guards), run the test, and record: the line you flipped, and the failure
+message. If you cannot name a single production line that makes the test
+fail, the test is vacuous. Rewrite it.
+
+## Known vacuity shapes (each one has shipped in a real test)
+
+- A fault-injection test that never asserts the fault fired. A
+  `FaultStore` test must assert the occurrence counter, not only the
+  call's success.
+- A fixture below the threshold that gates the path under test. A
+  370-byte segment "tested" the paged-fetch path that only runs above
+  `DEFAULT_WHOLE_OBJECT_THRESHOLD`; the fetch loop never executed.
+- One literal reused across cases that claim separation. Every call site
+  passed `TenantHash([7u8; 16])`, so no test could catch a cross-tenant
+  leak.
+- An input too small to exercise the property. A tie-break test on two
+  elements passed against the unfixed code, because unstable sort keeps
+  order on short inputs.
+- A multi-shard or multi-part scenario whose fixture fits in one shard
+  or one block, so both compared sets are `{0}` and always equal.
+
+## Red flags - stop and run the required step
+
+- "The test passes, so the fix works."
+- "I reasoned it is sound." (Reasoned-sound is where the defects live;
+  proved-unsound gets different scrutiny.)
+- "The fixture is smaller but the logic is the same."
+- Reusing one constant everywhere because it is convenient.
+
+When a spec asks for this proof (fleet-task-spec's "Soundness claims need
+a failing test"), the report must name the flipped line. When you review
+someone else's test, ask the same question: which line flips to make this
+fail?

--- a/.claude/skills/verify-dispatch/SKILL.md
+++ b/.claude/skills/verify-dispatch/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: verify-dispatch
+description: Use before merging any fleet-dispatched branch, or to audit one retroactively - runs a cold-cache workspace-wide gate in an isolated worktree plus narrow adversarial subagents per known defect class, and reports PASS/FAIL with file:line evidence; never trust an executor's own "gates green" claim
+---
+
+# Verifying a fleet-dispatched branch
+
+An executor's own report that gates passed is not evidence. Real defects
+have shipped behind that exact claim: a cross-crate field rename that
+broke an untouched crate's build, a stale test fixture after a type
+gained a required field, an unguarded array index that panics on a
+corrupt-but-plausible input, a grouped-aggregate UDAF that silently used
+the wrong float ordering, an error-redaction catch-all that swallowed
+real 422s as fake 503s, and a format writer that dropped a sort
+invariant its own reader still required. None of those would have shown
+up if the only check was "did the executor say clippy was clean."
+
+This skill runs two tiers. Tier 1 is deterministic and has zero false
+positives: a named command exited nonzero, full stop. Tier 2 is a set of
+narrow, scoped semantic checks that flag things worth five minutes of a
+human's attention; it is not proof, and a tier-2-only finding never
+triggers automatic action on its own. Keep these separate in the report
+and in what happens next.
+
+## When to use this
+
+- Before merging any fleet task's result branch (this supersedes plain
+  "re-run gates locally" in the merge-fleet-result skill; run this
+  first, then follow merge-fleet-result's merge/push/cleanup steps once
+  tier 1 passes).
+- To retroactively audit a branch, or to check a specific historical
+  commit (useful for validating this skill itself against a known-bad
+  state; see "Validating this skill" below).
+
+## Inputs
+
+Accepts, in order of preference:
+
+1. A fleet task-id: resolve via `git ls-remote origin
+   refs/heads/task/<id>/result`. If that comes back empty, the branch was
+   already merged and its remote ref deleted (the merge workflow deletes
+   task refs right after a successful merge); fall back to asking
+   for the merge commit instead, and verify `<merge>^2` (the second parent,
+   the branch's own tip before the merge), not the merge commit itself.
+2. A merge-commit SHA: verify `<merge>^2`, diff against `<merge>^1` (main
+   before the merge) for the tier-2 hunk scope.
+3. Any other ref `git worktree add` accepts (a branch, a tag, a raw SHA).
+
+Always print the exact SHA resolved before doing anything else: an
+ambiguous or moved ref is a debugging trap later.
+
+## Procedure
+
+### Tier 1: deterministic gates
+
+Run `scripts/verify-dispatch-gates.sh <ref> <scratchpad-dir>`, where
+`<scratchpad-dir>` is a path **outside this repo's working tree** (the
+session's scratchpad directory is exactly right for this; never a
+subdirectory of the repo itself: an untracked worktree left inside the
+repo blocks the next `fleet_dispatch` call, which refuses to run against
+a dirty primary checkout).
+
+The script:
+
+- Resolves `<ref>` to a SHA and creates a detached-HEAD worktree at that
+  exact commit under the scratchpad path (not the ref name: a branch
+  already checked out elsewhere, including `main` in the primary
+  checkout, cannot be checked out a second time by `git worktree add`).
+- Sets a **fresh `CARGO_TARGET_DIR`** for this run only, not the repo's
+  shared target directory. This is what "cold cache" means here: it
+  defeats incremental-compile masking, which is a real, previously
+  observed failure mode (an executor's own claimed-green branch that
+  didn't actually compile once the incremental cache was invalidated).
+  It does **not** mean disabling sccache: sccache is keyed on inputs and
+  doesn't mask a genuine compile error, it just avoids redoing
+  already-correct work, so leave `RUSTC_WRAPPER` alone.
+- Runs, workspace-wide regardless of which crate the branch touched (a
+  crate-scoped `-p` run is exactly what let a cross-crate rename break an
+  untouched crate's build):
+  `cargo fmt --all --check`, `cargo build --workspace --all-targets`,
+  `cargo clippy --workspace --all-targets -- -D warnings`,
+  `cargo test --workspace`, `cargo test --doc --workspace`.
+- Stops at the first failure, printing the exact command and its real
+  exit code, and always removes the worktree on exit (pass or fail).
+
+Treat the script's own exit code as authoritative. If it's nonzero, tier 1
+is FAIL: capture the command, exit code, and the last ~40 lines of its
+output as evidence, and skip tier 2 entirely (there's nothing to review
+if it doesn't build).
+
+### Tier 2: narrow adversarial review (only on tier-1 PASS)
+
+Get the diff scope first: `git diff <merge-base-or-parent>...<ref>
+--stat` and the full hunks for anything non-trivial. Then dispatch one
+subagent per failure class below, in parallel (Agent tool, all
+invocations in a single message), scoped to **only the diff's changed
+hunks**, not the whole codebase, and not "find bugs in this diff"
+generically. A generic adversarial pass produces plausible-sounding
+findings that then have to be individually disproven; a narrow,
+concretely-specified check is what actually catches something.
+
+Give each subagent this framing: it is reviewing a diff for one specific,
+narrow pattern; it must cite file:line for any finding; if the pattern
+does not appear in the diff at all, say so plainly rather than reaching
+for something else to flag.
+
+1. **Grouped/aggregate float correctness.** Any new or modified
+   aggregate, UDAF, or `GROUP BY` accumulator: check that NaN, `-0.0`
+   vs `0.0`, and an all-equal or all-infinite group are handled through a
+   documented *total* order (`f64::total_cmp` or equivalent) rather than
+   `partial_cmp` seeded from `f64::MAX`/`f64::MIN`. (This class is real:
+   DataFusion's own grouped `MIN`/`MAX` shipped exactly this bug. A NaN
+   poisoned later comparisons, `-0.0`/`0.0` compared `Equal` so arrival
+   order decided the winner, and an all-infinite group never displaced
+   the seed.)
+2. **Error redaction.** Any new or modified catch-all / wildcard match
+   arm that maps an internal error type to a generic client-facing status
+   (`Internal`, `Unavailable`, a bare 5xx): check that every variant
+   folded into that arm actually needs redaction (its `Display` text can
+   carry backend-derived content) rather than being swept in only
+   because it wasn't explicitly handled. A real evaluator-level error
+   (a bad regex argument, an ambiguous match) reported back as a fake
+   "storage unavailable" hides the actual, fixable problem from the
+   caller.
+3. **Fail-open validation asymmetry.** Any new decode/reader path for a
+   persistent, versioned format: check that every invariant the format's
+   writer, or a sibling version's reader, already enforces is enforced
+   here too, not silently trusted because "the writer wouldn't produce
+   that." A tampered or buggy object exercises exactly the path that
+   skipped the check.
+4. **Sort/ordering invariant drift.** Any new writer for a format section
+   documented as sorted or otherwise order-dependent (a dictionary, a
+   monotonic index): check the new writer actually sorts, rather than
+   using first-occurrence or insertion order because it's "similar
+   enough." Silent drift here doesn't fail a test; it fails a byte-size
+   or performance gate much later, far from the change that caused it.
+5. **Cross-crate rename/field drift in non-compiled references.** Any
+   renamed or removed public field, function, or type: grep the *whole
+   workspace*, not just the touched crate, for the old name, including
+   doc comments, a bench binary gated behind a feature so it isn't in the
+   default build, or a fixture file. Most of this class is already tier
+   1 (if it's compiled code, `cargo build --workspace --all-targets`
+   already caught it); this subagent only adds value for references
+   tier 1's compiler pass cannot see.
+6. **Unguarded indexing / bounds on adversarial input.** Any new code
+   that indexes a collection (an array, a dictionary, a decoded buffer)
+   using a value that came from parsed or otherwise untrusted input:
+   check there's an explicit bounds check before the index, not just a
+   type-level `usize` cast that only rejects negative values. (The known
+   shape of this bug: a `usize::try_from` guarded negative keys but not
+   out-of-range positive ones, and the panic path only surfaced once a
+   fuzz/property test was added; ordinary unit tests
+   never construct a corrupt key. Tier 1 will **not** catch this class
+   unless a test already exercises the malicious input; that gap is
+   exactly why this check exists.)
+
+7. **Vacuous tests.** Any new or modified test the branch cites as proof
+   of a fix or of coverage: check it can actually detect the defect it
+   names. Concrete tells, all shipped before: a fault-injection test that
+   never asserts the FaultStore occurrence counter fired; a fixture
+   sized below the threshold constant that gates the path under test
+   (a 370-byte segment "testing" the paged-fetch path that only runs
+   above `DEFAULT_WHOLE_OBJECT_THRESHOLD`); one identical literal (a
+   tenant hash, a key) reused across cases that claim to prove
+   cross-tenant separation; a tie-break test on an input so small the
+   unfixed code passes it too. The question to answer per test: which
+   single line of production code flips to make this test fail? If no
+   such line exists, flag it. A vacuous test found after merge costs a
+   full extra dispatch round to replace.
+8. **Diff scope vs declared scope.** Compare `git diff --name-status
+   <merge-base>..<ref>` against the task's stated crates and docs. Flag
+   every deletion and every touched path outside the declared scope. A
+   result branch can silently delete diagrams and their references from
+   unrelated docs with every CI gate passing; only a scope comparison
+   catches it. Deletions of files the task never mentions are a flag
+   at any confidence level.
+
+Each subagent returns: verdict (clean / flag), confidence (high / medium
+/ low), and file:line evidence if flagged. A "clean" verdict from a
+narrow, well-specified check is worth something; a "clean" verdict from
+"did you find any bugs" is not; don't ask the latter.
+
+## Report format
+
+```
+VERDICT: PASS | FAIL
+REF: <resolved SHA>, <one-line source description>
+
+TIER 1: PASS | FAIL
+  <if FAIL: exact command, exit code, evidence (file:line or output tail)>
+
+TIER 2: <n> findings (only run if tier 1 passed)
+  [class] file:line — one-line claim (confidence: high/medium/low)
+  ...
+  Tier 2 findings need a human read before acting. They are narrow
+  heuristic checks, not proof. Never auto-file or auto-redispatch on a
+  tier-2-only result.
+```
+
+## Wiring into the dispatch flow
+
+Only a **tier-1 FAIL** drives the auto-retry loop below. A tier-2 finding
+alongside a tier-1 PASS surfaces directly to the user in the same turn;
+it never triggers automatic filing or redispatch, because most of the
+real defects listed above (everything except the cross-crate build
+breakage) needed a dedicated audit or a differential test harness to
+surface, not a generic reviewer, and a subagent's narrow check is a
+lead, not a verdict.
+
+On tier-1 FAIL:
+
+1. `gh issue create` with the full tier-1 report (command, exit code,
+   evidence), linked to the originating ticket if one exists.
+2. Re-dispatch a fix task to the fleet. The spec must include the exact
+   failure (not "gates failed, fix it"; include the command and its
+   output), so the executor isn't guessing at what broke.
+3. Re-run this skill against the fix's result branch.
+4. Tier-1 PASS now: proceed to the normal merge flow
+   (`scripts/fleet-result-merge.sh` / the merge-fleet-result skill).
+5. Tier-1 FAIL again (2nd consecutive failure): stop. Surface both
+   reports to the user directly. Do not dispatch a third attempt without
+   explicit direction.
+
+## Validating this skill
+
+Before trusting a change to this skill or its script, don't just run it
+against branches that already merged clean: a known-good branch passing
+proves nothing (it would pass with a tier-1 gate that never actually ran
+anything, too). Validate against real pre-fix regressions instead: check
+out a commit one step before a known fix (its parent, or the specific
+buggy commit itself) and confirm tier 1 correctly fails with the same
+symptom the fix commit's message describes. The repo's history has
+ready-made cases: search `git log --grep` for `fix(` commits
+with detailed bodies, then verify against `<fix-commit>^` or the specific
+commit the fix's own message names as the root cause.

--- a/.dockerignore
+++ b/.dockerignore
@@ -25,9 +25,6 @@ node_modules/
 .github/
 .gitignore
 
-# Benchmark outputs and large reports.
-bench/reports/
-
 # Docs and top-level markdown: not read by any build.rs or by cargo.
 docs/
 *.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,11 +94,9 @@ jobs:
             exit 0
           fi
           # docs-only: every changed path ends in .md or .svg (prose plus the
-          # diagrams that illustrate it) or lives under bench/reports/ (raw
-          # benchmark output committed as evidence; nothing compiles it).
-          # Areas are irrelevant then -- no compiling job runs at all -- so
-          # report them false.
-          if ! echo "$changed" | grep -qvE '\.(md|svg)$|^bench/reports/'; then
+          # diagrams that illustrate it). Areas are irrelevant then -- no
+          # compiling job runs at all -- so report them false.
+          if ! echo "$changed" | grep -qvE '\.(md|svg)$'; then
             echo "::notice::docs-only change, skipping compiling jobs"
             emit true false false false false
             exit 0

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 /target
 **/*.rs.bk
 *.profraw
-/bench/reports/*.raw
 .DS_Store
 /minio-data
 /examples/otlp_metrics_fixture.pb

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,16 +24,15 @@ executors.
   two subagents sharing one tree, corrupts both in-flight edits and any
   concurrent `cargo` build cache. One worktree per unit of work, always.
   This rule has no small-change exception. A doc-only edit and a one-file
-  fixup follow it too: both commits that ever bypassed it were rationalized
-  as "just a doc" and "just one file", and a concurrent session can sit on
-  the primary checkout at any moment.
+  fixup follow it too: every bypass gets rationalized as "just a doc" or
+  "just one file", and a concurrent session can sit on the primary
+  checkout at any moment.
 - Exception: fleet executors working in a dedicated clone. The clone is
   already the isolated workspace; commit directly on the dispatched
   checkout's HEAD (detached HEAD is fine). Do not create a side worktree
   or branch: the fleet harness collects only the dispatched checkout's
   HEAD as the result, and work committed anywhere else is lost when the
-  workdir is destroyed (this happened; see the 2026-07-27 audit report,
-  section 10).
+  workdir is destroyed.
 
 ## Merging fleet results
 
@@ -42,19 +41,18 @@ executors.
   textually), or a structural decision landed on `main` while the task was
   in flight and the task's whole premise is now stale (an ADR, a format
   version change, a crate rewritten from scratch). Before resolving, read
-  the commit(s) on `main` that conflict — `git log --oneline
+  the commit(s) on `main` that conflict: `git log --oneline
   <merge-base>..origin/main -- <conflicting paths>`, then the full commit
   body of whatever touched the same files. Forcing a stale-premise branch
   through reintroduces code or assumptions a deliberate decision already
   removed.
-- This happened twice on 2026-07-28: ADR-0027 (single-RSEG-version
-  pre-release) landed mid-flight under two long-running tickets built on
-  the multi-version model it deleted. One had a partial file-level
-  collision (some files merged clean, one file conflicted because it had
-  already been rewritten for the new reality); the other's whole
-  dependency chain (a path dev-dependency on a crate independently
-  rewritten from scratch) needed re-targeting, not just conflict
-  resolution.
+- The failure shape: a single-RSEG-version ADR (ADR-0027) landed mid-flight
+  under two long-running tasks built on the multi-version model it deleted.
+  One had a partial file-level collision (some files merged clean, one file
+  conflicted because it had already been rewritten for the new reality);
+  the other's whole dependency chain (a path dev-dependency on a crate
+  independently rewritten from scratch) needed re-targeting, not just
+  conflict resolution.
 - If the underlying logic (not the version/format-specific plumbing) is
   still valuable once the premise moves, don't discard it and don't force
   it through: preserve the branch, comment on the relevant issue with a
@@ -96,9 +94,9 @@ cargo clippy -p ravel-server -p ravel-sql --features flight-sql --all-targets --
 cargo test   -p ravel-server -p ravel-sql --features flight-sql
 ```
 
-`scripts/gates.sh` runs these when the crates are in scope. Do not skip them:
-a workspace gate has printed "All gates passed" on a tree where
-`--features sql` failed to compile, because the broken call site sat in a
+`scripts/gates.sh` runs these when the crates are in scope. Do not skip
+them: a workspace gate can print "All gates passed" on a tree where
+`--features sql` fails to compile, because the broken call site sits in a
 target the default feature set never builds.
 
 ### Fast local iteration
@@ -114,13 +112,13 @@ nextest run` is an accepted equivalent of `cargo test` (CI's check job
 runs it with the `ci` profile); doctests still need `cargo test --doc`.
 
 One narrowing for commits that can only land through a PR on protected
-`main` (every commit since 2026-07-30): when the exact tree was already
-taken through the full gate list once this session, later mechanical
-steps on that same tree (the merge script's pre-flight, a re-push) may
-skip the repeat run and let the PR's required checks enforce it —
-that is what `FLEET_MERGE_SKIP_GATES=1` above is for. The full list
-still runs at least once locally before the commit exists; protection
-makes the repeats redundant, not the first run.
+`main`: when the exact tree was already taken through the full gate list
+once this session, later mechanical steps on that same tree (the merge
+script's pre-flight, a re-push) may skip the repeat run and let the PR's
+required checks enforce it; that is what `FLEET_MERGE_SKIP_GATES=1`
+(described under Scripts below) is for. The full list still runs at least
+once locally before the commit exists; protection makes the repeats
+redundant, not the first run.
 
 ### Long commands and the Bash tool
 
@@ -130,8 +128,8 @@ runs, and the `sql`/`flight-sql` lanes, routinely run longer than 2
 minutes: pass a long `timeout` on the call, or use `run_in_background`
 and wait for the notification. Do not emulate waiting with repeated
 `sleep N && tail` calls: a sleep of 120 s or more times out itself, and
-each poll turn resends the full session context (one measured executor
-session spent 39 of 205 turns on pure poll turns).
+each poll turn resends the full session context, so a long wait spent
+polling can consume a large share of a session's turns.
 
 On an 8 GB host, default cargo parallelism gets ld killed with signal 9;
 `gates.sh` caps build jobs there automatically. If you invoke cargo
@@ -153,37 +151,36 @@ Use these instead of retyping the same shell each time; they exist
 because the ad-hoc version of each has broken in practice (a stale SSE
 connection, a pushed-but-broken main).
 
-- `scripts/gates.sh [-p CRATE ...]` — the Gates list above. No args runs
+- `scripts/gates.sh [-p CRATE ...]`: the Gates list above. No args runs
   the full workspace gate; `-p CRATE` (repeatable) scopes clippy/test/doc
   to specific crates for fast iteration. It also runs the `sql` and
   `flight-sql` feature lanes, always in workspace mode and in scoped mode
   when `ravel-server` or `ravel-sql` is named.
-- `scripts/disk-reap.sh [-y]` — reclaims disk from merged clean worktrees
+- `scripts/disk-reap.sh [-y]`: reclaims disk from merged clean worktrees
   and orphaned cargo target dirs (dry run by default; `-y` applies). Run
   it when free space drops below ~20 GB, and after a land worktree's PR
-  merges. Multi-session days have filled this volume to zero bytes free,
-  at which point no Bash command can run at all and gates fail with fake
-  errors; each manual cleanup used exactly the heuristics this script
-  encodes.
-- `scripts/fleet-watch.sh <watch-url> [poll-interval-seconds]` — waits on
+  merges. A volume filled to zero bytes free stops every Bash command
+  and makes gates fail with fake errors; the script encodes the cleanup
+  heuristics that reclaim the space safely.
+- `scripts/fleet-watch.sh <watch-url> [poll-interval-seconds]`: waits on
   a `fleet_dispatch`/`fleet_status` task by polling its watch endpoint in
   a loop. The SSE stream it wraps drops the connection almost immediately
   in this environment, so a single long-lived `curl -N` never sees the
   terminal event; this retries instead. Prints the terminal event and
   exits 0 once one arrives.
-- `scripts/fleet-result-inspect.sh <task-id>` — fetches a dispatched
+- `scripts/fleet-result-inspect.sh <task-id>`: fetches a dispatched
   task's result branch and prints its commits and diff scope vs `main`,
   for review before merging. Never trust an executor's own "gates green"
   claim; look at what actually landed.
-- `scripts/fleet-result-merge.sh <task-id> <message-file> [-p CRATE ...]`
-  — cleans `wip:`/fixup commits out of the reviewed result branch, runs
+- `scripts/fleet-result-merge.sh <task-id> <message-file> [-p CRATE ...]`:
+  cleans `wip:`/fixup commits out of the reviewed result branch, runs
   `gates.sh`, and opens a PR against `main` with auto-merge enabled
   (`main` is protected; the script never pushes or merges it directly).
   Task refs are left on origin until the PR is confirmed merged; see the
   merge-fleet-result skill for that step. Write the PR message to
   `<message-file>` first (trailers included; line 1 is the title, the
   body starts at line 3); this script does not construct one for you.
-  Run `fleet-result-inspect.sh` first — this script does not pause for
+  Run `fleet-result-inspect.sh` first: this script does not pause for
   review, it assumes you already decided the scope is correct.
   `FLEET_MERGE_SKIP_GATES=1` skips the local `gates.sh` run and lets the
   PR's required checks be the gate. Use it only when the tree being
@@ -192,14 +189,14 @@ connection, a pushed-but-broken main).
   branch minutes earlier); the cost is learning about a red PR from CI
   instead of immediately. Never combine it with a conflict resolution
   or any manual edit to the branch.
-- `scripts/verify-dispatch-gates.sh <ref> <scratchpad-dir>` — the tier-1
+- `scripts/verify-dispatch-gates.sh <ref> <scratchpad-dir>`: the tier-1
   gate check behind the `verify-dispatch` skill: an isolated worktree
   outside the repo, a cold `CARGO_TARGET_DIR`, and the full workspace
   gate list, regardless of which crate the branch touched. Run this (via
   the `verify-dispatch` skill, which adds narrow adversarial checks on
-  top) before merging any fleet result — a crate-scoped or warm-cache
-  gate run has let a broken branch through before.
-- `scripts/affected-tests.sh [-n] -p CRATE [-p CRATE ...]` — runs tests
+  top) before merging any fleet result: a crate-scoped or warm-cache
+  gate run can let a broken branch through.
+- `scripts/affected-tests.sh [-n] -p CRATE [-p CRATE ...]`: runs tests
   for the named crates plus every workspace crate that depends on them
   (transitively), with the `ci` cargo profile; `-n` prints the affected
   set without running. This is the executor-side test gate in fleet
@@ -211,24 +208,24 @@ connection, a pushed-but-broken main).
 ### Guard scripts (mechanical preconditions)
 
 Fast, dependency-free checks that fail closed BEFORE a known-expensive
-mistake. Each encodes a failure class that has recurred across sessions;
-run the relevant one as a precondition, not after the damage.
+mistake. Each encodes a failure class that recurs; run the relevant one
+as a precondition, not after the damage.
 
-- `scripts/guards/assert-worktree.sh` — exits non-zero if the cwd is the
+- `scripts/guards/assert-worktree.sh`: exits non-zero if the cwd is the
   PRIMARY checkout rather than a linked worktree. Run it before the first
   edit/commit of any isolated unit of work. A concurrent session can hold
   in-flight state on the primary checkout at any moment, and an edit or a
   stray `git checkout -- .` / `git reset --hard` there clobbers it
   silently; the workspace-isolation rule has no doc-only/one-file
   exception.
-- `scripts/guards/check-disk-headroom.sh [dir] [min_gb]` — exits non-zero
+- `scripts/guards/check-disk-headroom.sh [dir] [min_gb]`: exits non-zero
   when the volume backing `dir` has less than `min_gb` free (default 20).
   Run it before any cold `--all-targets`/`--workspace`/feature-lane build
   or verify-dispatch gate: ENOSPC surfaces mid-link as a FAKE
   `linking with cc failed` (errno 28) that reads as a code bug, and a full
   disk can break the harness's own output capture so nothing runs at all.
   `FLEET_DISK_REAP=1` auto-runs `disk-reap.sh -y` when below the floor.
-- `scripts/guards/assert-fresh-dispatch-ref.sh <ref-sha>` — exits non-zero
+- `scripts/guards/assert-fresh-dispatch-ref.sh <ref-sha>`: exits non-zero
   unless `<ref-sha>` is the tip of `origin/main` fetched in THIS
   invocation. Run it against the ref you are about to `fleet_dispatch`: a
   SHA read earlier in the session goes stale the moment another PR merges,
@@ -245,8 +242,7 @@ into a false green. When you write or edit any such script:
   (this exact bug made a draft of `verify-dispatch-gates.sh` report PASS
   on everything).
 - Never name a variable `status`, `path`, `argv`, or `PWD`: zsh reserves
-  them, and assignment kills the loop with `read-only variable` (killed
-  the same Monitor poll loop twice).
+  them, and assignment kills the loop with `read-only variable`.
 - Never pipe a gate through `grep`, `head`, or `tail`, and never append
   `&& echo MARKER`: the pipeline's exit code masks the gate's.
 
@@ -272,16 +268,15 @@ and error, one wasted turn (or one lost result) at a time:
   the control plane, wait 30 s and retry, and report the retries. Do NOT
   treat 5 retries as a bound: the fleet-cp git proxy returns intermittent
   502s on both an executor's final result push and on `fleet_dispatch`
-  start pushes, and an outage can run far longer than 5 attempts (9+
-  consecutive 502s have been observed in one window, losing two
-  already-completed, gate-green results). Keep the 30 s backoff-and-retry
-  loop running until the proxy recovers or you escalate to the user. A 502
-  on the FINAL push discards finished work outright — no result ref exists
-  to fetch — which is exactly why an executor MUST have committed its HEAD
-  before the push step (see the commit-before-gates rule): a lost push then
-  costs a redispatch of push time, not of the work. When you detect a lost
-  final push, redispatch from current `origin/main`, not the stale
-  dispatch-time ref.
+  start pushes, and an outage can run far longer than five attempts, long
+  enough that a bounded retry loop gives up and loses an already-completed,
+  gate-green result. Keep the 30 s backoff-and-retry loop running until
+  the proxy recovers or you escalate to the user. A 502 on the FINAL push
+  discards finished work outright (no result ref exists to fetch), which
+  is exactly why an executor MUST have committed its HEAD before the push
+  step: a lost push then costs a redispatch of push time, not of the work.
+  When you detect a lost final push, redispatch from current
+  `origin/main`, not the stale dispatch-time ref.
 
 ## Fleet ledger reconciliation (orchestrator sessions)
 
@@ -320,10 +315,9 @@ em-dashes, no filler adjectives, no AI footers or self-references.
 
 Update documentation in the same commit as the behavior it describes, not
 as a follow-up. A new endpoint or query capability updates README.md; a
-status change updates PROGRESS.md; a format or protocol change updates its
-normative doc below. A stale doc is a bug like any other, and the same
-"report, don't silently fix" rule applies if you find one outside your
-task scope.
+format or protocol change updates its normative doc below. A stale doc is
+a bug like any other, and the same "report, don't silently fix" rule
+applies if you find one outside your task scope.
 
 ### Doc map (read the doc that governs your crate; skip the rest)
 
@@ -352,8 +346,6 @@ file.
 | Project overview, quickstart, PromQL/SQL query examples | README.md |
 | Index of every guide and spec | docs/README.md |
 | Getting started, ingest, query, operations, inspecting data | docs/guides/ |
-| Living log of what shipped, broke, and what's next | PROGRESS.md |
-| Measured benchmark numbers, with the commands/environment that produced them | BENCHMARKS.md |
 
 ## Testing patterns
 

--- a/docs/adrs/0003-catalog-discovery.md
+++ b/docs/adrs/0003-catalog-discovery.md
@@ -33,8 +33,8 @@ included, giving read-your-write after an ack.
 ## Consequences
 
 - Phase 1 queries pay one LIST per (shard, ingest-hour bucket) in range;
-  acceptable for the vertical slice, called out in PROGRESS.md as a bottleneck
-  gate before Phase 2 load tests.
+  acceptable for the vertical slice, and a known bottleneck gate before
+  Phase 2 load tests.
 - Catalog nodes cache decoded snapshots in memory only; losing them costs
   latency, never correctness.
 - HEAD CAS requires etag/generation preconditions, a mandatory capability.

--- a/docs/adrs/0017-native-histograms-rseg-v3.md
+++ b/docs/adrs/0017-native-histograms-rseg-v3.md
@@ -105,8 +105,8 @@ and the writer default is still v1.
    verbatim.
 3. Defer entirely; keep rejecting native histograms at admission.
    Honest but wrong on the merits: native histograms are the default
-   direction of the Prometheus ecosystem, PROGRESS.md names them as
-   Phase 2 scope, and rejection is sender-visible loss (ADR-0015
+   direction of the Prometheus ecosystem, they are Phase 2 scope, and
+   rejection is sender-visible loss (ADR-0015
    documents that RW senders do not retry admission-rejected
    histograms). Deferral of the *storage* is however exactly what
    happens until v3 lands: ingest rejects native histograms at

--- a/docs/adrs/0018-l0-l1-compaction.md
+++ b/docs/adrs/0018-l0-l1-compaction.md
@@ -14,8 +14,8 @@ stored byte today.
 Phase 1 never deletes or rewrites anything. Every flush leaves one L0
 object and one commit record forever. At one flush per second per shard
 that is 3,600 objects per (tenant, shard, hour) and 86,400 per day;
-PROGRESS.md already names listing-based discovery unscalable past ~10^4
-commits per bucket, and the query budget (max_segments = 1024,
+listing-based discovery is known to be unscalable past ~10^4 commits
+per bucket, and the query budget (max_segments = 1024,
 docs/query-engine.md) makes an hour of such data unqueryable outright.
 ADR-0027 (RSEG v2) additionally accepted a permanent dual-reader burden
 "until a compactor exists". This ADR is that compactor.

--- a/docs/adrs/0020-metric-index.md
+++ b/docs/adrs/0020-metric-index.md
@@ -11,8 +11,8 @@ Phase 1 discovery is pure listing (ADR-0003 option 2): every
 `Catalog::resolve` issues one LIST per (shard, ingest-hour bucket) in the
 window `[range.start - max_ingest_lag, now + clock_skew_allowance]` and
 GETs every commit record it has not cached
-(crates/ravel-catalog/src/catalog.rs). PROGRESS.md names the bottleneck:
-this will not scale past ~10^4 commits per (tenant, shard, hour) bucket,
+(crates/ravel-catalog/src/catalog.rs). The bottleneck is known: this
+will not scale past ~10^4 commits per (tenant, shard, hour) bucket,
 and it must be fixed before Phase 2 load tests. The cost has two axes:
 commit density per bucket (paginated LISTs plus per-record GETs) and
 window width (a 24 h query over 4 shards lists ~108 buckets because the

--- a/docs/adrs/0032-rlog-compaction-and-generic-maintain.md
+++ b/docs/adrs/0032-rlog-compaction-and-generic-maintain.md
@@ -199,6 +199,6 @@ construction once the codec seam exists.
   crash-matrix coverage for the merge/publish/sweep paths specific to
   RLOG's merge (STREAM_DIR remap correctness under partial-input
   crashes).
-- `docs/log-segment-format.md`, `proto/ravel/logseg.proto`, and
-  `docs/PROGRESS.md` are amended in the same commits as the code that
-  implements each change, per the doc-currency rule.
+- `docs/log-segment-format.md` and `proto/ravel/logseg.proto` are
+  amended in the same commits as the code that implements each change,
+  per the doc-currency rule.

--- a/docs/adrs/0034-k8s-operator.md
+++ b/docs/adrs/0034-k8s-operator.md
@@ -209,8 +209,8 @@ exists for disk-hungry jobs.
    `docs/guides/kubernetes.md` (operator install, CRD field reference,
    kind quickstart, probe semantics), a deployment section and the
    liveness correction in `docs/architecture.md` (which already governs
-   `services/*` in the doc map), an index entry in `docs/README.md`, a
-   README.md pointer, and a PROGRESS.md entry.
+   `services/*` in the doc map), an index entry in `docs/README.md`,
+   and a README.md pointer.
 
 ## Rejected alternatives
 

--- a/docs/adrs/0039-prometheus-http-api-compat.md
+++ b/docs/adrs/0039-prometheus-http-api-compat.md
@@ -4,8 +4,8 @@ Status: Accepted
 
 ## Context
 
-Ravel's PromQL query surface is further along than README.md and
-PROGRESS.md currently claim. A codebase survey found:
+Ravel's PromQL query surface is further along than README.md
+currently claims. A codebase survey found:
 
 - Aggregation operators (`sum`, `avg`, `min`, `max`, `count`, `group`,
   `stddev`, `stdvar`, `topk`, `bottomk`, `quantile`, `count_values`) are
@@ -65,10 +65,8 @@ additive only, no existing route changed:
    Prometheus datasource at a running `ravel-server`, confirm "Save &
    Test" succeeds, and that Explore / a basic dashboard panel render a
    query. This is acceptance evidence, not a new code surface.
-5. Fix README.md and PROGRESS.md to state the true current status of
-   aggregations, subqueries, and Remote Write (done, not planned), and
-   correct PROGRESS.md's stale `## Failing tests - (none yet; no tests
-   written)` line.
+5. Fix README.md to state the true current status of aggregations,
+   subqueries, and Remote Write (done, not planned).
 
 ## Rejected alternatives
 

--- a/docs/adrs/0062-encryption-posture-and-evidential-audit.md
+++ b/docs/adrs/0062-encryption-posture-and-evidential-audit.md
@@ -110,7 +110,7 @@ Gaps closed: per-tenant KMS by 1a-1e; coverage by 2a; lossiness by 2b; unbounded
 - **IAM/role interaction**: per-tenant BYOK key policies must grant the ADR-0055 role principals (Gateway/Query/Maintain) usage; operations.md's policy templates gain the KMS statements. Revoked key = that tenant fails closed, others unaffected (new failure-path tests with `FaultStore` asserting the injected fault fired).
 - **verify-custody** gains key-epoch consistency checking; audit records for admin actions (key configured/rotated) are written like every other admin audit record.
 - **The legal-hold shard remains unbounded** — deliberately: growth is per operator action, and its deny-delete protection is load-bearing. Recorded so a successor review doesn't re-flag it as an oversight.
-- **PROGRESS.md, README, docs/guides/operations.md, docs/catalog-and-mvcc.md (new `enc` key), and the query-audit module docs** update in the same commits as the behavior, per doc-currency rule.
+- **README, docs/guides/operations.md, docs/catalog-and-mvcc.md (new `enc` key), and the query-audit module docs** update in the same commits as the behavior, per doc-currency rule.
 
 ## Amendment: correct section 2d's audit-prefix transcription
 

--- a/docs/adrs/0072-tenant-scoped-credentials-and-control-plane-protection.md
+++ b/docs/adrs/0072-tenant-scoped-credentials-and-control-plane-protection.md
@@ -227,8 +227,7 @@ tenant's resulting entry set against its current one and returns
 rewrote the whole map every call), and the operator wraps each `sys/auth`
 primitive call in a bounded CAS retry and no longer aborts Deployment/
 Service reconciliation on a sys/auth failure -- both were reconcile-loop
-defects the ownership marker didn't by itself fix. See PROGRESS.md for
-the full defect list.
+defects the ownership marker didn't by itself fix.
 
 ## Amendment: `token_hash` is globally unique; last writer takes ownership
 

--- a/scripts/fleet-result-inspect.sh
+++ b/scripts/fleet-result-inspect.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Fetch a claude-fleet dispatched task's result branch and print what's on
+# it, so the caller can review scope before merging (never trust an
+# executor's own "gates green" claim; see the merge-fleet-result skill).
+#
+# Usage: fleet-result-inspect.sh <task-id>
+#
+# Prints: commits on the result branch not yet on main, and the diff stat
+# vs main. Exits nonzero (from `git fetch`/`git ls-remote`) if the result
+# ref does not exist: a `done` status with no result ref means the
+# executor never committed and the work is gone; re-dispatch instead of
+# retrying this script.
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 <task-id>" >&2
+  exit 64
+fi
+
+task_id="$1"
+result_ref="refs/heads/task/${task_id}/result"
+
+echo "==> Verifying ${result_ref} exists on origin"
+git ls-remote --exit-code origin "${result_ref}" >/dev/null
+
+echo "==> Fetching ${result_ref}"
+git fetch origin "${result_ref}"
+
+echo "==> Commits on the result branch not yet on main:"
+git log --oneline "main..FETCH_HEAD"
+
+echo
+echo "==> Diff scope vs main:"
+git diff --stat "main...FETCH_HEAD"
+
+echo
+echo "Review the above. If scope matches what was dispatched, merge with:"
+echo "  scripts/fleet-result-merge.sh ${task_id} <message-file>"

--- a/scripts/fleet-result-merge.sh
+++ b/scripts/fleet-result-merge.sh
@@ -1,0 +1,377 @@
+#!/usr/bin/env bash
+# Land a claude-fleet dispatched task's result branch on main via a pull
+# request. `main` has required branch protection (PR required, required
+# status checks, linear history / rebase-merge only, no direct pushes), so
+# this script never merges or pushes to main itself. It cleans the result
+# branch's history (see the squash step below), pushes the cleaned history
+# to a PR head branch, opens a PR, and enables auto-merge (--rebase) so
+# GitHub lands it once the required checks pass.
+#
+# Run fleet-result-inspect.sh first and review its output; this script
+# does not pause for review, it assumes you already decided the diff scope
+# is correct.
+#
+# Usage: fleet-result-merge.sh <task-id> <message-file> [-p CRATE ...]
+#
+# <message-file> is a path to a file already containing the full commit
+# message (write it with your editor / the Write tool first; this script
+# does not construct one). Its first line becomes the PR title and the rest
+# (after the blank line) becomes the PR body, so put any "Fixes: #N" /
+# "Refs: #N" trailers in that file yourself.
+#
+# Trailing "-p CRATE ..." arguments are passed through to gates.sh to scope
+# the local pre-flight gate run; omit them to run the full workspace gates
+# (the default, and the right choice whenever the merge touches more than
+# one crate). CI re-runs the full required checks on the PR regardless.
+#
+# FLEET_MERGE_DRY_RUN=1 stops after the history-cleaning step and prints the
+# cleaned commits without running gates, pushing, or opening a PR. Useful for
+# previewing the cleaned history; harmless in production but never lands
+# anything.
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "usage: $0 <task-id> <message-file> [-p CRATE ...]" >&2
+  exit 64
+fi
+
+task_id="$1"
+message_file="$2"
+shift 2
+
+if [[ ! -f "${message_file}" ]]; then
+  echo "fleet-result-merge.sh: message file not found: ${message_file}" >&2
+  exit 66
+fi
+
+result_ref="refs/heads/task/${task_id}/result"
+start_ref="refs/heads/task/${task_id}/start"
+pr_branch="task/${task_id}/merge"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+dry_run="${FLEET_MERGE_DRY_RUN:-0}"
+
+# --- Recovery trap -------------------------------------------------------
+# A failure anywhere below (a cherry-pick conflict, an aborted gate run, a
+# killed process) must never leave the caller's checkout mid-rewrite or on
+# a stray detached HEAD. This aborts any in-progress cherry-pick/rebase,
+# restores the ref the script started on, and drops the temp rewrite branch.
+start_checkout=""
+rewrite_branch=""
+_cleaned=0
+cleanup() {
+  [[ ${_cleaned} -eq 1 ]] && return
+  _cleaned=1
+  local gp
+  gp="$(git rev-parse --git-path rebase-merge 2>/dev/null || true)"
+  if [[ -n "${gp}" && -d "${gp}" ]]; then git rebase --abort 2>/dev/null || true; fi
+  gp="$(git rev-parse --git-path rebase-apply 2>/dev/null || true)"
+  if [[ -n "${gp}" && -d "${gp}" ]]; then git rebase --abort 2>/dev/null || true; fi
+  gp="$(git rev-parse --git-path CHERRY_PICK_HEAD 2>/dev/null || true)"
+  if [[ -n "${gp}" && -f "${gp}" ]]; then git cherry-pick --abort 2>/dev/null || true; fi
+  if [[ -n "${start_checkout}" ]]; then git checkout -q "${start_checkout}" 2>/dev/null || true; fi
+  if [[ -n "${rewrite_branch}" ]]; then git branch -D "${rewrite_branch}" 2>/dev/null || true; fi
+}
+trap cleanup EXIT
+trap cleanup ERR
+
+# --- Pre-flight guard ----------------------------------------------------
+# Compute the merge base against main, not against whatever HEAD happens to
+# be: a HEAD pointing at an old commit would yield a too-old base and replay
+# already-landed commits as duplicates. Require HEAD to be main (or a
+# detached HEAD sitting exactly on origin/main) and the tree to be clean.
+git fetch -q origin main
+current_branch="$(git rev-parse --abbrev-ref HEAD)"
+if [[ "${current_branch}" != "main" ]]; then
+  if [[ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]]; then
+    echo "fleet-result-merge.sh: refusing to run from '${current_branch}':" >&2
+    echo "  HEAD is neither 'main' nor a detached checkout of origin/main." >&2
+    echo "  Check out main (git checkout main && git pull) and retry." >&2
+    exit 65
+  fi
+fi
+if [[ -n "$(git status --porcelain --untracked-files=no)" ]]; then
+  echo "fleet-result-merge.sh: working tree has uncommitted changes; commit or stash first." >&2
+  exit 65
+fi
+start_checkout="${current_branch}"
+if [[ "${start_checkout}" == "HEAD" ]]; then
+  start_checkout="$(git rev-parse HEAD)"
+fi
+
+echo "==> Fetching ${result_ref}"
+git fetch origin "${result_ref}"
+result_sha="$(git rev-parse FETCH_HEAD)"
+
+base="$(git merge-base origin/main "${result_sha}")"
+
+# --- Reject branches with merge commits ----------------------------------
+# The squash step below rebuilds history linearly with cherry-pick, which
+# cannot replay a merge commit. Detect that up front and abort with a clear
+# message rather than corrupting history halfway through.
+if [[ -n "$(git rev-list --merges "${base}..${result_sha}")" ]]; then
+  echo "fleet-result-merge.sh: result branch contains merge commit(s):" >&2
+  git log --oneline --merges "${base}..${result_sha}" >&2
+  echo "  This script only handles linear result branches. Flatten the" >&2
+  echo "  branch manually (or re-dispatch without the merge) and retry." >&2
+  exit 65
+fi
+
+# --- Squash wip:/formatting-fixup commits out of the result branch -------
+#
+# Two classes of commit have reached protected main through fleet result
+# branches and must never survive into the merge:
+#
+#   1. `wip:` headers: executors that commit work-in-progress snapshots
+#      and never reword them.
+#   2. Pure formatting/style fixups: a commit appended after a failed
+#      `cargo fmt --all --check` whose only content is reformatting.
+#
+# Detection heuristic (documented so it can be tuned):
+#   - wip: subject line begins with `wip:` (case-insensitive).
+#   - formatting fixup: subject contains `fmt` or `style fix`
+#     (case-insensitive) AND the commit's diff against its parent is empty
+#     under `git diff -w` (all changes are whitespace/indentation only).
+#     `-w` will not catch a reformat that rewraps lines, so this is a
+#     conservative filter: it squashes only the unambiguous cases and
+#     leaves anything with a real content change untouched.
+#
+# Rewrite: history is rebuilt linearly with cherry-pick. Each flagged commit
+# is folded (`fixup`-style) into the previous retained commit, but its own
+# Refs:/Fixes:/Signed-off-by: trailers are carried into that commit's
+# message if they are not already there, so a required trailer that lived
+# only on a `wip:` snapshot is never dropped. A flagged commit that is the
+# FIRST retained commit has nothing to fold into, so it is reworded instead:
+# its `wip:` prefix is stripped and, if what remains has no Conventional
+# Commits type, a `chore:` type is prepended so the subject stays valid.
+branch_commits=()
+while IFS= read -r c; do
+  branch_commits+=("${c}")
+done < <(git rev-list --reverse "${base}..${result_sha}")
+
+# Return the leading `wip:` (case-insensitive) stripped from a subject.
+strip_wip() {
+  local s="$1"
+  s="${s#"${s%%[![:space:]]*}"}"
+  shopt -s nocasematch
+  if [[ "${s}" == wip:* ]]; then
+    s="${s#*:}"
+  fi
+  shopt -u nocasematch
+  s="${s#"${s%%[![:space:]]*}"}"
+  printf '%s' "${s}"
+}
+
+# True if a subject already opens with a Conventional Commits type token.
+has_cc_type() {
+  [[ "$1" =~ ^[a-zA-Z]+(\([^\)]+\))?!?:[[:space:]] ]]
+}
+
+need_rewrite=0
+for sha in "${branch_commits[@]+"${branch_commits[@]}"}"; do
+  subject="$(git log -1 --format=%s "${sha}")"
+  shopt -s nocasematch
+  if [[ "${subject}" == wip:* ]]; then
+    need_rewrite=1
+  elif [[ "${subject}" == *fmt* || "${subject}" == *"style fix"* ]]; then
+    parent="$(git rev-parse "${sha}^")"
+    if [[ -z "$(git diff -w "${parent}" "${sha}")" ]]; then
+      need_rewrite=1
+    fi
+  fi
+  shopt -u nocasematch
+done
+
+clean_ref="${result_sha}"
+
+if [[ ${need_rewrite} -eq 1 ]]; then
+  echo "==> Squashing wip:/formatting-fixup commits out of the result branch"
+  rewrite_branch="_fleet_rewrite_${task_id//\//_}"
+  git checkout -q -B "${rewrite_branch}" "${base}"
+
+  have_real=0
+  for sha in "${branch_commits[@]+"${branch_commits[@]}"}"; do
+    subject="$(git log -1 --format=%s "${sha}")"
+    flagged=0
+    shopt -s nocasematch
+    if [[ "${subject}" == wip:* ]]; then
+      flagged=1
+    elif [[ "${subject}" == *fmt* || "${subject}" == *"style fix"* ]]; then
+      parent="$(git rev-parse "${sha}^")"
+      if [[ -z "$(git diff -w "${parent}" "${sha}")" ]]; then
+        flagged=1
+      fi
+    fi
+    shopt -u nocasematch
+
+    if [[ ${flagged} -eq 0 ]]; then
+      # Ordinary commit: replay verbatim (author preserved by cherry-pick).
+      git cherry-pick "${sha}"
+      have_real=1
+      continue
+    fi
+
+    if [[ ${have_real} -eq 0 ]]; then
+      # First retained commit is flagged: reword it into a valid subject.
+      stripped="$(strip_wip "${subject}")"
+      if [[ -z "${stripped}" ]]; then
+        new_subject="chore: fleet result for task ${task_id}"
+      elif has_cc_type "${stripped}"; then
+        new_subject="${stripped}"
+      else
+        new_subject="chore: ${stripped}"
+      fi
+      body="$(git log -1 --format=%b "${sha}")"
+      msg_file="$(mktemp)"
+      if [[ -n "${body}" ]]; then
+        printf '%s\n\n%s\n' "${new_subject}" "${body}" >"${msg_file}"
+      else
+        printf '%s\n' "${new_subject}" >"${msg_file}"
+      fi
+      git cherry-pick -n "${sha}"
+      GIT_AUTHOR_NAME="$(git log -1 --format=%an "${sha}")" \
+      GIT_AUTHOR_EMAIL="$(git log -1 --format=%ae "${sha}")" \
+      GIT_AUTHOR_DATE="$(git log -1 --format=%aI "${sha}")" \
+        git commit --no-verify -F "${msg_file}"
+      rm -f "${msg_file}"
+      have_real=1
+    else
+      # Fold into the previous retained commit, preserving its trailers.
+      git cherry-pick -n "${sha}"
+      targs=()
+      while IFS= read -r tl; do
+        [[ -n "${tl}" ]] && targs+=(--trailer "${tl}")
+      done < <(git log -1 --format=%B "${sha}" | git interpret-trailers --parse)
+      cur_msg="$(git log -1 --format=%B HEAD)"
+      msg_file="$(mktemp)"
+      if [[ ${#targs[@]} -gt 0 ]]; then
+        printf '%s\n' "${cur_msg}" | git interpret-trailers \
+          --if-exists addIfDifferent --if-missing add \
+          "${targs[@]}" >"${msg_file}"
+      else
+        printf '%s\n' "${cur_msg}" >"${msg_file}"
+      fi
+      git commit --amend --no-verify --allow-empty -F "${msg_file}"
+      rm -f "${msg_file}"
+    fi
+  done
+
+  clean_ref="$(git rev-parse HEAD)"
+  git checkout -q "${start_checkout}"
+fi
+# --- end squash step -----------------------------------------------------
+
+# --- Rewrite authorship and sign-off to the merging identity -------------
+# Every commit that lands on main is authored by the person landing it, not
+# by the disposable fleet-executor identity the dispatched clone committed
+# under (fleet clones set user.email=fleet-executor@nofire.ai for their own
+# commits; that identity must never reach main). The squash step above
+# preserves the executor author on cherry-pick, and a clean result branch
+# (no wip/fmt commits) skips that step entirely and would otherwise land
+# verbatim as <fleet-executor@nofire.ai>. Once such a commit lands on
+# protected main it cannot be rewritten, so this pass must catch it first.
+#
+# This pass ALWAYS runs. It replays every retained commit onto the base with
+# the merger's git identity as author and committer, preserving the original
+# author date, dropping any fleet-executor sign-off, and adding the merger's
+# own DCO sign-off. The result is the cleaned, correctly-attributed history
+# that gets pushed to the PR branch.
+merge_name="$(git config user.name || true)"
+merge_email="$(git config user.email || true)"
+if [[ -z "${merge_name}" || -z "${merge_email}" ]]; then
+  echo "fleet-result-merge.sh: git user.name and user.email must be set so" >&2
+  echo "  the landed commits are authored under the merger's identity, not" >&2
+  echo "  the fleet-executor identity. Set them and retry." >&2
+  exit 65
+fi
+prev_rewrite_branch="${rewrite_branch}"
+authorship_branch="_fleet_authorship_${task_id//\//_}"
+rewrite_branch="${authorship_branch}"
+git checkout -q -B "${authorship_branch}" "${base}"
+while IFS= read -r sha; do
+  git cherry-pick -n "${sha}"
+  msg_file="$(mktemp)"
+  # Keep every trailer except a sign-off from the fleet-executor identity;
+  # the merger's sign-off is (re)added by `git commit -s` below.
+  git log -1 --format=%B "${sha}" \
+    | grep -viE '^Signed-off-by:[[:space:]]+.*<fleet-executor@nofire\.ai>[[:space:]]*$' \
+    >"${msg_file}"
+  GIT_AUTHOR_NAME="${merge_name}" GIT_AUTHOR_EMAIL="${merge_email}" \
+  GIT_AUTHOR_DATE="$(git log -1 --format=%aI "${sha}")" \
+  GIT_COMMITTER_NAME="${merge_name}" GIT_COMMITTER_EMAIL="${merge_email}" \
+    git commit --no-verify -s -F "${msg_file}"
+  rm -f "${msg_file}"
+done < <(git rev-list --reverse "${base}..${clean_ref}")
+clean_ref="$(git rev-parse HEAD)"
+git checkout -q "${start_checkout}"
+# The squash step's temp branch (if any) is no longer needed: its commits
+# have been re-authored onto the authorship branch.
+if [[ -n "${prev_rewrite_branch}" && "${prev_rewrite_branch}" != "${authorship_branch}" ]]; then
+  git branch -D "${prev_rewrite_branch}" 2>/dev/null || true
+fi
+# --- end authorship rewrite ----------------------------------------------
+
+if [[ "${dry_run}" == "1" ]]; then
+  echo "==> DRY RUN: cleaned history (${base}..${clean_ref}):"
+  git log --reverse --format='commit %h  %an <%ae>%n%B%n----' "${base}..${clean_ref}"
+  if [[ -n "${rewrite_branch}" ]]; then
+    git branch -D "${rewrite_branch}" 2>/dev/null || true
+    rewrite_branch=""
+  fi
+  echo "DRY RUN complete; nothing pushed, no PR opened."
+  exit 0
+fi
+
+# main's branch protection (required status checks plus auto-merge) means a
+# broken branch cannot land: CI fails, the PR just sits. What the local
+# pre-flight run buys is EARLIER failure detection, at the price of
+# re-running the same lanes CI is about to run (and often the same lanes
+# the orchestrator just ran on the identical tree).
+# FLEET_MERGE_SKIP_GATES=1 skips them and lets the PR's required checks be
+# the gate; the failure mode is discovering a red PR ~15 minutes later
+# instead of a red gate now. Never use it when the merged tree diverges
+# from what was already gated (a conflict resolution, a manual edit).
+if [[ "${FLEET_MERGE_SKIP_GATES:-0}" == "1" ]]; then
+  echo "==> Skipping local pre-flight gates (FLEET_MERGE_SKIP_GATES=1); PR required checks are the gate"
+else
+  echo "==> Running local pre-flight gates"
+  git checkout -q --detach "${clean_ref}"
+  "${script_dir}/gates.sh" "$@"
+  git checkout -q "${start_checkout}"
+fi
+
+echo "==> Pushing cleaned history to ${pr_branch}"
+git push --force-with-lease origin "${clean_ref}:refs/heads/${pr_branch}"
+
+echo "==> Opening pull request and enabling auto-merge (--rebase)"
+pr_title="$(head -n 1 "${message_file}")"
+second_line="$(sed -n '2p' "${message_file}")"
+if [[ -n "${second_line}" ]]; then
+  echo "fleet-result-merge.sh: ${message_file} line 2 must be blank" >&2
+  echo "  (line 1 is the PR title, the body starts at line 3)." >&2
+  exit 66
+fi
+body_file="$(mktemp)"
+tail -n +3 "${message_file}" >"${body_file}"
+gh pr create --base main --head "${pr_branch}" \
+  --title "${pr_title}" --body-file "${body_file}"
+rm -f "${body_file}"
+gh pr merge --auto --rebase --delete-branch "${pr_branch}"
+
+# Do NOT delete the task/<id>/result and task/<id>/start refs here: auto-merge
+# only enables the merge, it does not wait for required checks. Deleting them
+# now, before the PR has actually landed, reintroduces the exact silent-loss
+# shape this script exists to prevent: if a required check later fails, the
+# PR sits open with no way to recover the original result branch, and this
+# script would already have reported success. The task refs are cleaned up by
+# the merge-fleet-result skill's "after the PR is open" step, once it has
+# confirmed via `gh pr view --json state,mergedAt` that the PR actually merged.
+
+# Drop the temp rewrite branch now that it is safely pushed.
+if [[ -n "${rewrite_branch}" ]]; then
+  git branch -D "${rewrite_branch}" 2>/dev/null || true
+  rewrite_branch=""
+fi
+
+echo "Opened PR for task ${task_id}; auto-merge (--rebase) will land it once required checks pass."
+echo "Task refs (task/${task_id}/result, task/${task_id}/start) are left in place;"
+echo "delete them only after confirming the PR merged (see merge-fleet-result skill)."

--- a/scripts/fleet-watch.sh
+++ b/scripts/fleet-watch.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Poll a fleet_dispatch watch endpoint until a terminal event arrives.
+#
+# The SSE stream this URL serves can drop the connection almost immediately,
+# so a single long-lived `curl -N | grep` never sees the terminal event. This
+# retries the connection in a loop instead of trusting one that stays open.
+#
+# Usage: fleet-watch.sh <watch-url> [poll-interval-seconds]
+#
+# <watch-url> is the URL fleet_dispatch's response prints after "watch for
+# completion instantly with:". Prints the first `data:` line it receives
+# (the terminal status/result JSON) and exits 0.
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 <watch-url> [poll-interval-seconds]" >&2
+  exit 64
+fi
+
+watch_url="$1"
+poll_interval="${2:-60}"
+
+while true; do
+  event_line="$(curl -sN "${watch_url}" 2>/dev/null | grep '^data:' | head -1 || true)"
+  if [[ -n "${event_line}" ]]; then
+    echo "${event_line}"
+    exit 0
+  fi
+  sleep "${poll_interval}"
+done

--- a/scripts/verify-dispatch-gates.sh
+++ b/scripts/verify-dispatch-gates.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Tier-1 deterministic verification for a fleet-dispatched branch: an
+# isolated worktree, a cold CARGO_TARGET_DIR, and the full workspace gate
+# list. Not a crate-scoped subset, and not the repo's warm shared target
+# dir: either shortcut can pass a broken branch, because a crate-scoped
+# clippy run misses a cross-crate break in an untouched crate, and a warm
+# incremental target dir can mask a real compile error behind stale
+# cached artifacts (see the verify-dispatch skill).
+#
+# Usage: verify-dispatch-gates.sh <ref> <worktree-parent-dir>
+#
+# <ref> is anything `git worktree add` accepts: a branch, a tag, a SHA.
+# <worktree-parent-dir> MUST be outside this repo's working tree: an
+# untracked worktree left inside the repo blocks the next fleet_dispatch,
+# which refuses to run against a dirty primary checkout.
+#
+# Prints each gate command as it runs. Exits 0 only if every gate passes;
+# on the first failure, prints which command failed and its exit code,
+# then exits with that code. Always removes the worktree on exit, success
+# or failure.
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "usage: $0 <ref> <worktree-parent-dir>" >&2
+  exit 64
+fi
+
+ref="$1"
+parent_dir="$2"
+
+repo_root="$(git rev-parse --show-toplevel)"
+mkdir -p "${parent_dir}"
+parent_dir_abs="$(cd "${parent_dir}" && pwd)"
+case "${parent_dir_abs}" in
+  "${repo_root}" | "${repo_root}"/*)
+    echo "verify-dispatch-gates.sh: worktree-parent-dir must be outside the repo tree (${repo_root}), got: ${parent_dir_abs}" >&2
+    exit 65
+    ;;
+esac
+
+sha="$(git rev-parse "${ref}")"
+short_sha="$(git rev-parse --short "${ref}")"
+worktree_dir="${parent_dir_abs}/verify-${short_sha}"
+
+cleanup() {
+  git worktree remove "${worktree_dir}" --force >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+echo "==> Resolved ref ${ref} to ${sha}"
+echo "==> Creating worktree at ${worktree_dir}"
+# Check out the resolved SHA (detached), not the ref name: if ${ref} is a
+# branch already checked out elsewhere (including main in the primary
+# checkout), `git worktree add <path> <branch>` refuses with "already
+# used by worktree". Checking out the SHA directly sidesteps that and is
+# the more correct thing for a verification run to do anyway: it pins the
+# exact commit being verified rather than tracking a branch that could move.
+git worktree add --detach "${worktree_dir}" "${sha}"
+
+export CARGO_TARGET_DIR="${worktree_dir}/target"
+echo "==> Cold CARGO_TARGET_DIR: ${CARGO_TARGET_DIR}"
+
+run_gate() {
+  echo "==> (cd ${worktree_dir} && $*)"
+  local code=0
+  (cd "${worktree_dir}" && "$@") || code=$?
+  if [[ ${code} -ne 0 ]]; then
+    echo "TIER1 FAIL: '$*' exited ${code}" >&2
+    return "${code}"
+  fi
+  return 0
+}
+
+# --locked pins the committed Cargo.lock so this cold-cache verification
+# resolves exactly what CI does; a divergent resolve here would defeat the
+# purpose of the isolated run. `cargo fmt` (rustfmt) rejects --locked after
+# the subcommand, so it takes the global-flag position.
+run_gate cargo --locked fmt --all --check
+run_gate cargo build --locked --workspace --all-targets
+run_gate cargo clippy --locked --workspace --all-targets -- -D warnings
+run_gate cargo test --locked --workspace
+run_gate cargo test --locked --doc --workspace
+
+echo "TIER1 PASS"


### PR DESCRIPTION
Publishes the maintainer tooling the private executor fleet uses to
develop this repository, and removes the last references to files that
were deliberately not published.

Commit 1 adds .claude/ (agent settings plus seven skills: deliver-epic,
fleet-task-spec, format-change, merge-fleet-result, profile-hotspot,
prove-the-test, verify-dispatch) and the four fleet scripts
(fleet-result-inspect.sh, fleet-result-merge.sh, fleet-watch.sh,
verify-dispatch-gates.sh). Every file is sanitized: private-tracker
ticket numbers, dated incident notes, and references to unpublished
documents are replaced with the lesson each carried, stated plainly.
Procedures, gate commands, and templates are unchanged. Contributors do
not need any of this to build or test Ravel; it documents how the
project is maintained.

Commit 2 rewrites CLAUDE.md as the public working agreement (same rules
and gates, no diary bookkeeping, doc map verified against the actual
tree), rewords nine ADRs that cited the unpublished PROGRESS.md, and
drops bench/reports/ residue from .gitignore, .dockerignore, and the
docs-only CI filter.

With this PR, scripts/affected-tests.sh's reference to
verify-dispatch-gates.sh and the two source doc-comments referencing
.claude/skills/format-change point at files that exist again.

deploy/ needed no changes: it was already published in full.
