### PR TITLE
Bump workspace version to 0.9.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4258,7 +4258,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-alerting"
-version = "0.1.0"
+version = "0.9.2"
 dependencies = [
  "blake3",
  "hex",
@@ -4270,14 +4270,14 @@ dependencies = [
 
 [[package]]
 name = "ravel-analytics"
-version = "0.1.0"
+version = "0.9.2"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "ravel-bench"
-version = "0.1.0"
+version = "0.9.2"
 dependencies = [
  "arrow 59.1.0",
  "arrow-flight",
@@ -4318,7 +4318,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-cache"
-version = "0.1.0"
+version = "0.9.2"
 dependencies = [
  "bytes",
  "crc32c",
@@ -4329,7 +4329,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-catalog"
-version = "0.1.0"
+version = "0.9.2"
 dependencies = [
  "async-trait",
  "blake3",
@@ -4355,7 +4355,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-cli"
-version = "0.1.0"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4386,7 +4386,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-codec"
-version = "0.1.0"
+version = "0.9.2"
 dependencies = [
  "blake3",
  "crc32c",
@@ -4396,7 +4396,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-commit"
-version = "0.1.0"
+version = "0.9.2"
 dependencies = [
  "blake3",
  "bytes",
@@ -4418,7 +4418,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-failure-tests"
-version = "0.1.0"
+version = "0.9.2"
 dependencies = [
  "bytes",
  "futures",
@@ -4439,7 +4439,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-fleet"
-version = "0.1.0"
+version = "0.9.2"
 dependencies = [
  "blake3",
  "futures",
@@ -4456,7 +4456,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-ingest"
-version = "0.1.0"
+version = "0.9.2"
 dependencies = [
  "async-trait",
  "blake3",
@@ -4486,7 +4486,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-logseg"
-version = "0.1.0"
+version = "0.9.2"
 dependencies = [
  "blake3",
  "crc32c",
@@ -4502,7 +4502,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-maintain"
-version = "0.1.0"
+version = "0.9.2"
 dependencies = [
  "async-trait",
  "blake3",
@@ -4530,7 +4530,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-object-store"
-version = "0.1.0"
+version = "0.9.2"
 dependencies = [
  "async-trait",
  "axum",
@@ -4550,7 +4550,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-operator"
-version = "0.1.0"
+version = "0.9.2"
 dependencies = [
  "clap",
  "futures",
@@ -4573,7 +4573,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-otap"
-version = "0.1.0"
+version = "0.9.2"
 dependencies = [
  "arrow 59.1.0",
  "arrow-ipc 59.1.0",
@@ -4599,7 +4599,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-otlp"
-version = "0.1.0"
+version = "0.9.2"
 dependencies = [
  "blake3",
  "hex",
@@ -4616,7 +4616,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-promql"
-version = "0.1.0"
+version = "0.9.2"
 dependencies = [
  "blake3",
  "promql-parser",
@@ -4629,7 +4629,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-promql-difftest"
-version = "0.1.0"
+version = "0.9.2"
 dependencies = [
  "axum",
  "bytes",
@@ -4657,7 +4657,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-proto"
-version = "0.1.0"
+version = "0.9.2"
 dependencies = [
  "prost",
  "prost-build",
@@ -4666,7 +4666,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-query"
-version = "0.1.0"
+version = "0.9.2"
 dependencies = [
  "async-trait",
  "axum",
@@ -4708,7 +4708,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-remote-write"
-version = "0.1.0"
+version = "0.9.2"
 dependencies = [
  "bytes",
  "hex",
@@ -4726,7 +4726,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-rspan"
-version = "0.1.0"
+version = "0.9.2"
 dependencies = [
  "crc32c",
  "proptest",
@@ -4740,7 +4740,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-segment"
-version = "0.1.0"
+version = "0.9.2"
 dependencies = [
  "blake3",
  "bytes",
@@ -4758,7 +4758,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-server"
-version = "0.1.0"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "arrow 59.1.0",
@@ -4820,7 +4820,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-sim"
-version = "0.1.0"
+version = "0.9.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4841,7 +4841,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-sql"
-version = "0.1.0"
+version = "0.9.2"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -4877,7 +4877,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-tracing-export"
-version = "0.1.0"
+version = "0.9.2"
 dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
@@ -4893,7 +4893,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-types"
-version = "0.1.0"
+version = "0.9.2"
 dependencies = [
  "base64 0.23.0",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*", "services/*"]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.9.2"
 edition = "2024"
 license = "Apache-2.0"
 rust-version = "1.97"
@@ -26,27 +26,27 @@ expect_used = "warn"
 # Version fields pin each path dependency so cargo-deny does not count them as
 # wildcards. allow-wildcard-paths is not usable here because these
 # crates are not marked publish = false, so it does not exempt them.
-ravel-types = { path = "crates/ravel-types", version = "0.1.0" }
-ravel-proto = { path = "crates/ravel-proto", version = "0.1.0" }
-ravel-codec = { path = "crates/ravel-codec", version = "0.1.0" }
-ravel-object-store = { path = "crates/ravel-object-store", version = "0.1.0" }
-ravel-segment = { path = "crates/ravel-segment", version = "0.1.0" }
-ravel-logseg = { path = "crates/ravel-logseg", version = "0.1.0" }
-ravel-rspan = { path = "crates/ravel-rspan", version = "0.1.0" }
-ravel-commit = { path = "crates/ravel-commit", version = "0.1.0" }
-ravel-catalog = { path = "crates/ravel-catalog", version = "0.1.0" }
-ravel-cache = { path = "crates/ravel-cache", version = "0.1.0" }
-ravel-maintain = { path = "crates/ravel-maintain", version = "0.1.0" }
-ravel-fleet = { path = "crates/ravel-fleet", version = "0.1.0" }
-ravel-otlp = { path = "crates/ravel-otlp", version = "0.1.0" }
-ravel-otap = { path = "crates/ravel-otap", version = "0.1.0" }
-ravel-remote-write = { path = "crates/ravel-remote-write", version = "0.1.0" }
-ravel-alerting = { path = "crates/ravel-alerting", version = "0.1.0" }
-ravel-ingest = { path = "crates/ravel-ingest", version = "0.1.0" }
-ravel-promql = { path = "crates/ravel-promql", version = "0.1.0" }
-ravel-query = { path = "crates/ravel-query", version = "0.1.0" }
-ravel-analytics = { path = "crates/ravel-analytics", version = "0.1.0" }
-ravel-tracing-export = { path = "crates/ravel-tracing-export", version = "0.1.0" }
+ravel-types = { path = "crates/ravel-types", version = "0.9.2" }
+ravel-proto = { path = "crates/ravel-proto", version = "0.9.2" }
+ravel-codec = { path = "crates/ravel-codec", version = "0.9.2" }
+ravel-object-store = { path = "crates/ravel-object-store", version = "0.9.2" }
+ravel-segment = { path = "crates/ravel-segment", version = "0.9.2" }
+ravel-logseg = { path = "crates/ravel-logseg", version = "0.9.2" }
+ravel-rspan = { path = "crates/ravel-rspan", version = "0.9.2" }
+ravel-commit = { path = "crates/ravel-commit", version = "0.9.2" }
+ravel-catalog = { path = "crates/ravel-catalog", version = "0.9.2" }
+ravel-cache = { path = "crates/ravel-cache", version = "0.9.2" }
+ravel-maintain = { path = "crates/ravel-maintain", version = "0.9.2" }
+ravel-fleet = { path = "crates/ravel-fleet", version = "0.9.2" }
+ravel-otlp = { path = "crates/ravel-otlp", version = "0.9.2" }
+ravel-otap = { path = "crates/ravel-otap", version = "0.9.2" }
+ravel-remote-write = { path = "crates/ravel-remote-write", version = "0.9.2" }
+ravel-alerting = { path = "crates/ravel-alerting", version = "0.9.2" }
+ravel-ingest = { path = "crates/ravel-ingest", version = "0.9.2" }
+ravel-promql = { path = "crates/ravel-promql", version = "0.9.2" }
+ravel-query = { path = "crates/ravel-query", version = "0.9.2" }
+ravel-analytics = { path = "crates/ravel-analytics", version = "0.9.2" }
+ravel-tracing-export = { path = "crates/ravel-tracing-export", version = "0.9.2" }
 
 # async runtime / rpc / http
 tokio = { version = "1.53", features = ["rt-multi-thread", "macros", "sync", "time", "signal", "net", "io-util"] }

--- a/crates/ravel-bench/Cargo.toml
+++ b/crates/ravel-bench/Cargo.toml
@@ -63,7 +63,7 @@ futures = { workspace = true, optional = true }
 # ravel-sql is an internal path crate not yet listed in the workspace
 # `[workspace.dependencies]`, so it is named by path here; every other dep
 # below reuses a workspace pin.
-ravel-sql = { path = "../ravel-sql", version = "0.1.0", optional = true, features = ["flight-sql"] }
+ravel-sql = { path = "../ravel-sql", version = "0.9.2", optional = true, features = ["flight-sql"] }
 arrow-flight = { workspace = true, optional = true }
 
 [features]

--- a/crates/ravel-ingest/Cargo.toml
+++ b/crates/ravel-ingest/Cargo.toml
@@ -22,7 +22,7 @@ ravel-catalog = { workspace = true }
 # [workspace.dependencies]; the root Cargo.toml is out of this task's scope, so
 # this is a version-pinned path dependency (the pin keeps cargo-deny from
 # counting it as a wildcard, matching the workspace's path-dep convention).
-ravel-rspan = { path = "../ravel-rspan", version = "0.1.0" }
+ravel-rspan = { path = "../ravel-rspan", version = "0.9.2" }
 # The router live switch (ADR-0052) decodes the provisioning record read for a
 # generation refresh; prost's Message trait provides `decode`.
 prost = { workspace = true }

--- a/crates/ravel-otlp/Cargo.toml
+++ b/crates/ravel-otlp/Cargo.toml
@@ -16,7 +16,7 @@ ravel-logseg = { workspace = true }
 # Used for the span record's StatusCode and the frozen resource+scope+span
 # attribute merge rule, so trace normalization and the RSPAN writer cannot
 # drift apart on either.
-ravel-rspan = { path = "../ravel-rspan", version = "0.1.0" }
+ravel-rspan = { path = "../ravel-rspan", version = "0.9.2" }
 opentelemetry-proto = { workspace = true }
 # Span events and links are stored as an opaque serialized blob in RSPAN v1
 # (ADR-0041 decision 4), which needs prost's own length-delimited encoding.

--- a/crates/ravel-query/Cargo.toml
+++ b/crates/ravel-query/Cargo.toml
@@ -80,7 +80,7 @@ ravel-cache = { workspace = true }
 # proof (tests/differential_compaction.rs) drives P4's real compactor to
 # produce write_v4 L1 parts. ravel-maintain does not depend on ravel-query,
 # so this is acyclic.
-ravel-maintain = { path = "../ravel-maintain", version = "0.1.0" }
+ravel-maintain = { path = "../ravel-maintain", version = "0.9.2" }
 proptest = { workspace = true }
 tokio = { workspace = true }
 tower = { workspace = true, features = ["util"] }

--- a/services/ravel-server/Cargo.toml
+++ b/services/ravel-server/Cargo.toml
@@ -140,14 +140,14 @@ reqwest = { version = "0.13", features = ["json"] }
 # ravel-rspan below are: the workspace root Cargo.toml is outside this task's
 # scope. The pin keeps cargo-deny from counting it as a wildcard path
 # dependency.
-ravel-alerting = { path = "../../crates/ravel-alerting", version = "0.1.0" }
+ravel-alerting = { path = "../../crates/ravel-alerting", version = "0.9.2" }
 
 # ravel-sql is declared here as a path dependency rather than through
 # `[workspace.dependencies]` because the workspace root Cargo.toml is outside
 # this task's scope. The version is pinned so cargo-deny does not count it as
 # a wildcard path dependency, matching how every other
 # internal crate is pinned.
-ravel-sql = { path = "../../crates/ravel-sql", version = "0.1.0", optional = true }
+ravel-sql = { path = "../../crates/ravel-sql", version = "0.9.2", optional = true }
 
 # Flight service codegen for the `flight-sql` feature. This is arrow 58's
 # arrow-flight, a different arrow major than the `arrow` dev-dependency below;
@@ -194,7 +194,7 @@ tokio = { workspace = true, features = ["test-util"] }
 # listed in the workspace [workspace.dependencies]; the root Cargo.toml is out
 # of this task's scope, so this is a version-pinned path dependency (the pin
 # keeps cargo-deny from counting it as a wildcard).
-ravel-rspan = { path = "../../crates/ravel-rspan", version = "0.1.0" }
+ravel-rspan = { path = "../../crates/ravel-rspan", version = "0.9.2" }
 uuid = { workspace = true }
 # Real-authn end-to-end test (tests/real_authn_e2e.rs): mint a JWT and build a
 # local oct (HMAC) JWKS so the OIDC resolver runs through a real HTTP request


### PR DESCRIPTION
v0.9.1's published images were built from a stale main missing 50
commits merged after the tag was cut, and the workspace version was
never bumped past the 0.1.0 placeholder for either 0.9.0 or 0.9.1, so
publish-images' own "workspace version matches tag" gate has failed
every time it ran since the check was added.

Set [workspace.package].version to 0.9.2 and bump every internal
path-dependency version pin to match, since cargo enforces path-dep
version compatibility even for workspace-local crates. No dependency
graph change; Cargo.lock only shows the 29 internal crates' own
version strings moving.

After this merges: retag v0.9.2 at the new tip and push the tag to
trigger a real, version-matched image publish.
