### PR TITLE
Drop remaining bare provenance references

### DIFF
--- a/.github/workflows/bench-s3.yml
+++ b/.github/workflows/bench-s3.yml
@@ -1,7 +1,7 @@
 name: bench-s3
 
-# Real-S3 benchmark lane (epic #1053, T2). Runs the `bench_report` bin against
-# the real object-storage backend and uploads the machine-readable JSON so a
+# Real-S3 benchmark lane. Runs the `bench_report` bin against the real
+# object-storage backend and uploads the machine-readable JSON so a
 # performance/cost number can be committed alongside the command and
 # environment that produced it. ADR-0075 decision 3: a request-budget defect is
 # free on a store with no request charges and billable on real S3, so published

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,7 @@ ENTRYPOINT ["/usr/local/bin/ravel-server"]
 # ---- Runtime: operator image ------------------------------------------------
 # The Kubernetes operator (ADR-0034 decision 5): same distroless/cc:nonroot
 # base and the same CARGO_BUILD_JOBS=2 builder stage as the server image, so it
-# inherits the OOM fix (issue #251) without a second build configuration.
+# inherits the OOM fix without a second build configuration.
 # `--target operator` builds only this image.
 FROM gcr.io/distroless/cc-debian12:nonroot AS operator
 

--- a/crates/ravel-bench/src/bin/bench_report.rs
+++ b/crates/ravel-bench/src/bin/bench_report.rs
@@ -1,8 +1,7 @@
-//! Machine-readable benchmark report CLI (epic #1053, T2). Runs one
-//! ingest-then-query workload via `ravel_bench::report::run` and writes a
-//! single JSON document to `--out`, so a performance/cost number can be
-//! committed next to the command and environment that produced it instead of
-//! pasted from a log.
+//! Machine-readable benchmark report CLI. Runs one ingest-then-query
+//! workload via `ravel_bench::report::run` and writes a single JSON document
+//! to `--out`, so a performance/cost number can be committed next to the
+//! command and environment that produced it instead of pasted from a log.
 //!
 //! `--store memory|s3` selects the backend (`ravel_bench::harness`); the `s3`
 //! store reads `RAVEL_S3_*` env vars. The emitted `environment.store_backend`

--- a/crates/ravel-bench/src/report.rs
+++ b/crates/ravel-bench/src/report.rs
@@ -1,9 +1,8 @@
-//! Machine-readable benchmark report (epic #1053, T2). Drives one
-//! ingest-then-query workload against a real or in-memory object store and
-//! emits a single JSON document that carries the measured numbers *together
-//! with the environment that produced them*, so a performance or cost figure
-//! can be committed alongside the command and machine that measured it instead
-//! of pasted from a log.
+//! Machine-readable benchmark report. Drives one ingest-then-query workload
+//! against a real or in-memory object store and emits a single JSON document
+//! that carries the measured numbers *together with the environment that
+//! produced them*, so a performance or cost figure can be committed alongside
+//! the command and machine that measured it instead of pasted from a log.
 //!
 //! Report-only: like the rest of `ravel-bench`, this never changes library
 //! behavior, it only measures it. It reuses `ravel_bench::generator` for the
@@ -583,9 +582,9 @@ mod tests {
         assert!(l.max > 0.0, "{what}: max must be > 0");
     }
 
-    /// Acceptance test (epic #1053 T2): a run against `MemoryStore` populates
-    /// every field of the schema -- no nulls (guaranteed structurally: no
-    /// `Option` in `BenchReport`), and no zero standing in for "not measured".
+    /// Acceptance test: a run against `MemoryStore` populates every field of
+    /// the schema -- no nulls (guaranteed structurally: no `Option` in
+    /// `BenchReport`), and no zero standing in for "not measured".
     ///
     /// Request counts are the field that "cannot be measured as a billable S3
     /// cost" on `MemoryStore`. The schema represents that explicitly with

--- a/crates/ravel-cache/src/tiered.rs
+++ b/crates/ravel-cache/src/tiered.rs
@@ -15,7 +15,7 @@
 //! be the one that never admits a payload under a key that does not describe
 //! it (decision 4's amendment). A successful upstream fetch populates *both*
 //! tiers (decision 3), not RAM alone, so a later RAM eviction is served from
-//! disk instead of re-paying the S3 round trip this epic exists to remove.
+//! disk instead of re-paying the S3 round trip the disk tier exists to remove.
 //!
 //! **Single-flight spans both tiers** (decision 5). A RAM hit is the fast
 //! path and needs no coordination. Every RAM miss for one key collapses onto
@@ -29,7 +29,7 @@
 //! mode), a disk-served hit is corrupted by the identical byte transform a
 //! RAM hit uses (see [`crate::cache::corrupt_bytes`]), applied at serve time
 //! only -- the bytes admitted to either tier stay clean, so corruption is a
-//! read-time view, never stored. Without this, the epic's "correctness never
+//! read-time view, never stored. Without this, ADR-0046's "correctness never
 //! depends on cached state" gate would silently stop covering the disk tier
 //! the moment the funnels started serving hits from it. Clean bytes freshly
 //! returned by an upstream fetch are never corrupted: they did not come from a
@@ -216,13 +216,13 @@ mod fixtures {
     }
 }
 
-/// The named acceptance test for issue #1135, at the exact path the task
-/// specifies (`ravel_cache::tiered::corrupted_disk_hit_is_corrupted_through_ram_readthrough`):
+/// The named acceptance test, at the exact required path
+/// (`ravel_cache::tiered::corrupted_disk_hit_is_corrupted_through_ram_readthrough`):
 /// a key resident only on disk, RAM empty, corruption mode on. The bytes it
 /// serves must arrive corrupted -- not the clean disk bytes -- proving
 /// ADR-0046 decision 4's gate reaches a disk-served hit read through this
 /// handle and not just a RAM hit. Placed at module scope (not under a `tests`
-/// child) so its path is exactly the one the epic's gate cites.
+/// child) so its path is exactly the one the acceptance gate cites.
 #[cfg(test)]
 #[tokio::test]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
@@ -411,7 +411,7 @@ mod tests {
     /// A successful upstream fetch populates BOTH tiers (ADR-0046 decision 3),
     /// not RAM alone. Proven by evicting the RAM entry and reading again: the
     /// key is served from disk with no second upstream fetch, the exact cold
-    /// -path round trip this epic removes.
+    /// -path round trip the disk tier removes.
     #[tokio::test]
     async fn upstream_fetch_populates_both_tiers_and_disk_serves_after_ram_eviction() {
         let tmp = TempDir::new().unwrap();

--- a/crates/ravel-maintain/src/audit_retention.rs
+++ b/crates/ravel-maintain/src/audit_retention.rs
@@ -89,8 +89,8 @@ pub struct AuditRetentionOutcome {
     /// horizon, or lease/legal-hold protected.
     pub kept: usize,
     /// L0 commit records whose GET+decode was skipped because the key's
-    /// `ingest_hour_bucket` alone proved the record cannot be expired (issue
-    /// #850). A subset of `kept`.
+    /// `ingest_hour_bucket` alone proved the record cannot be expired. A
+    /// subset of `kept`.
     pub gets_skipped_by_hour_prefilter: usize,
 }
 
@@ -340,8 +340,8 @@ mod tests {
         list_all(store, &prefix).await.unwrap().len()
     }
 
-    /// Deliverable 1: Signal::Audit / QUERY_AUDIT_SHARD records compact through
-    /// the existing RLOG machinery, parameterized only by the new signal/shard.
+    /// Signal::Audit / QUERY_AUDIT_SHARD records compact through the existing
+    /// RLOG machinery, parameterized only by the new signal/shard.
     /// Two L0 audit records in one sealed bucket merge into one L1 part carrying
     /// both records (conservation), proving the codec seam handles Audit.
     #[tokio::test]
@@ -414,8 +414,8 @@ mod tests {
         assert!(matches!(err, MaintainError::Invariant(_)), "got {err:?}");
     }
 
-    /// Deliverable 2: an expired query-audit record (past the 90-day window and
-    /// past the horizon) is swept; one still inside the window is not.
+    /// An expired query-audit record (past the 90-day window and past the
+    /// horizon) is swept; one still inside the window is not.
     #[tokio::test]
     async fn expired_record_swept_recent_kept() {
         let store = MemoryStore::new();
@@ -447,8 +447,8 @@ mod tests {
         assert_eq!(commit_count(&store, &tenant).await, 1);
     }
 
-    /// Issue #850: on a shard with many hours of retained-but-unexpired audit
-    /// records, the sweep must not GET or decode any of them -- the key's
+    /// On a shard with many hours of retained-but-unexpired audit records,
+    /// the sweep must not GET or decode any of them -- the key's
     /// `ingest_hour_bucket` alone proves every one of them is still within
     /// the 90-day window. Before the fix, `sweep_audit_retention` GET'd and
     /// decoded every commit record to read `max_event_ts_ns`; this asserts
@@ -488,12 +488,12 @@ mod tests {
         assert_eq!(outcome.records_deleted, 0);
     }
 
-    /// Issue #850: GET volume must scale with the number of records whose
-    /// hour could plausibly hold expired data, not with the total record
-    /// count. 50 recent (unexpired) records plus 3 genuinely-expired records
-    /// (past both the window and the horizon) must cost exactly 3 GETs, and
-    /// the 3 expired records must still be swept -- exact retention
-    /// semantics are preserved, the prefilter only removes wasted GETs.
+    /// GET volume must scale with the number of records whose hour could
+    /// plausibly hold expired data, not with the total record count. 50
+    /// recent (unexpired) records plus 3 genuinely-expired records (past
+    /// both the window and the horizon) must cost exactly 3 GETs, and the 3
+    /// expired records must still be swept -- exact retention semantics are
+    /// preserved, the prefilter only removes wasted GETs.
     #[tokio::test]
     async fn hour_prefilter_get_count_bounded_by_expired_hours_not_total_records() {
         let store = InstrumentedStore::new(MemoryStore::new());
@@ -541,10 +541,10 @@ mod tests {
         );
     }
 
-    /// Issue #850: a record whose hour straddles `expiry_floor` (the hour's
-    /// start is before the floor, so the prefilter cannot clear it, but the
-    /// record's own timestamp may fall on either side) must be resolved by
-    /// the authoritative GET+decode check, never by the hour alone. Two
+    /// A record whose hour straddles `expiry_floor` (the hour's start is
+    /// before the floor, so the prefilter cannot clear it, but the record's
+    /// own timestamp may fall on either side) must be resolved by the
+    /// authoritative GET+decode check, never by the hour alone. Two
     /// records share one ambiguous hour: one just past `expiry_floor` (not
     /// expired, must be kept) and one just before it (expired, must be
     /// swept). Both must cost a GET; neither may be decided by the prefilter.
@@ -658,8 +658,8 @@ mod tests {
         );
     }
 
-    /// Deliverable 3: the legal-hold shard (shard 0) is excluded from the delete
-    /// path forever. An old hold record on shard 0 survives a sweep that would
+    /// The legal-hold shard (shard 0) is excluded from the delete path forever.
+    /// An old hold record on shard 0 survives a sweep that would
     /// have deleted it by age if the sweep ever reached shard 0.
     #[tokio::test]
     async fn legal_hold_shard_zero_survives_the_sweep() {
@@ -707,7 +707,7 @@ mod tests {
         );
     }
 
-    /// Deliverable: LegalHoldCheck genuinely gates the new sweep. A held
+    /// LegalHoldCheck genuinely gates the new sweep. A held
     /// query-audit record past its retention window is NOT deleted; the same
     /// record with no hold IS deleted (the control), so the assertion is not
     /// vacuous.

--- a/crates/ravel-maintain/src/compact.rs
+++ b/crates/ravel-maintain/src/compact.rs
@@ -614,7 +614,7 @@ mod tests {
         }
     }
 
-    /// Issue #558: exemplars on the sparse-catalog decode path.
+    /// Exemplars on the sparse-catalog decode path.
     ///
     /// `read.rs` routes an input with `series_count >= V5_SPARSE_THRESHOLD`
     /// (4096) to the whole-object `decode_catalog_v5`, and every other test

--- a/crates/ravel-maintain/src/gc_config.rs
+++ b/crates/ravel-maintain/src/gc_config.rs
@@ -3,24 +3,25 @@
 //!
 //! `protection_horizon >= max_query_duration + grace + clock_skew_allowance`
 //! protects every pinned reader from the GC sweeper, including one whose clock
-//! leads the reader's by up to `clock_skew_allowance` (without
-//! the skew term a sweeper skewed ahead reaches its deletion
-//! threshold `now >= anchor + protection_horizon` in true time before a
-//! reader's still-active snapshot, held up to `max_query_duration`, is
-//! released). Before this object the bound lived in three unlinked
-//! per-process configs (the maintain sweep config, the query deadline, the
-//! Flight ticket ceiling) that could be deployed independently, with nothing
-//! validating the constraint anywhere. This
-//! module makes the four deployment-wide values a single durable truth:
+//! leads the reader's by up to `clock_skew_allowance` (without the skew term a
+//! sweeper skewed ahead reaches its deletion threshold
+//! `now >= anchor + protection_horizon` in true time before a reader's
+//! still-active snapshot, held up to `max_query_duration`, is released).
+//! Before this object the bound lived in three unlinked per-process configs
+//! (the maintain sweep config, the query deadline, the Flight ticket ceiling)
+//! that could be deployed independently, with nothing validating the
+//! constraint anywhere. This module makes the four deployment-wide values a
+//! single durable truth:
 //!
 //! - **Bootstrap.** On the first touch of a fresh bucket, [`bootstrap_gc_config`]
 //!   writes `sys/gc` via `CreateIfAbsent` from the maintain defaults
 //!   ([`GcConfigValues::maintain_defaults`], which satisfy the constraint by
 //!   construction). It never refuses to start because the object is merely
 //!   absent: an absent object on a fresh bucket is bootstrapped, not a fault
-//!   (the fail-open-avoidance lesson). A racing loser (`AlreadyExists`) re-reads and
-//!   returns the winner's object, exactly the race-loser pattern established (`write_marker` / `resolve_and_pin` / the provisioning
-//!   record), so two processes bootstrapping one fresh bucket both start.
+//!   (the fail-open-avoidance lesson). A racing loser (`AlreadyExists`)
+//!   re-reads and returns the winner's object, the same race-loser pattern
+//!   `write_marker`, `resolve_and_pin`, and the provisioning record already
+//!   use, so two processes bootstrapping one fresh bucket both start.
 //! - **Mutation.** Only [`set_gc_config`] (behind `ravel-cli gc-config set`)
 //!   changes it. It enforces the constraint at write time and swaps with
 //!   `CasVersion`, so a concurrent mutation is caught, never silently
@@ -81,10 +82,10 @@ pub struct GcConfigValues {
 
 impl GcConfigValues {
     /// The maintain defaults, which satisfy the constraint by construction
-    /// (`protection_horizon = max_query_duration + grace + clock_skew_allowance`). This is
-    /// what the first process to touch a fresh bucket bootstraps `sys/gc` from
-    /// (ADR-0050 section 4), and it matches [`crate::CompactorConfig::default`]'s
-    /// horizon, grace, and flush lifetime.
+    /// (`protection_horizon = max_query_duration + grace + clock_skew_allowance`).
+    /// This is what the first process to touch a fresh bucket bootstraps
+    /// `sys/gc` from (ADR-0050 section 4), and it matches
+    /// [`crate::CompactorConfig::default`]'s horizon, grace, and flush lifetime.
     pub fn maintain_defaults() -> Self {
         GcConfigValues {
             protection_horizon_ns: DEFAULT_PROTECTION_HORIZON_NS,
@@ -291,13 +292,13 @@ pub async fn read_gc_config(
 /// bootstrapped one, returning the values every mode then validates against
 /// (ADR-0050 section 4).
 ///
-/// The critical fail-open-avoidance property: a
-/// never-bootstrapped bucket does not refuse startup. The object is written from
-/// `defaults` (the caller's maintain-config-derived values, which satisfy the
-/// constraint), and validation then runs against the object this process just
-/// wrote, which trivially matches. A concurrent bootstrap that wins the race is
-/// handled by re-reading and returning the winner's object, so a loser never
-/// errors and never proceeds with its own unwritten values.
+/// The critical fail-open-avoidance property: a never-bootstrapped bucket does
+/// not refuse startup. The object is written from `defaults` (the caller's
+/// maintain-config-derived values, which satisfy the constraint), and
+/// validation then runs against the object this process just wrote, which
+/// trivially matches. A concurrent bootstrap that wins the race is handled by
+/// re-reading and returning the winner's object, so a loser never errors and
+/// never proceeds with its own unwritten values.
 pub async fn bootstrap_gc_config(
     store: &dyn ObjectStoreBackend,
     defaults: GcConfigValues,
@@ -422,20 +423,21 @@ pub fn validate_maintain(
 }
 
 /// Maintain-mode startup RE-ASSERT of the skew-covering horizon bound against
-/// the RUNNING sweeper's own clock-skew allowance. The write fence in [`set_gc_config`] validates a proposed `sys/gc`
-/// against the *CLI's* declared `clock_skew_allowance`, but that knob and the
-/// running sweeper's [`crate::CompactorConfig::clock_skew_allowance_ns`] are
-/// independent: a deployment can write `sys/gc` with a 5 min skew while running
-/// sweepers configured with a larger skew, leaving the durable horizon
-/// skew-uncovered for the sweeper that actually deletes. [`validate_maintain`]
-/// does not catch it -- it only checks that the configured horizon and grace
-/// EQUAL the stored ones; the skew term appears in neither. This check re-runs
-/// the bound `protection_horizon >= max_query_duration + grace +
-/// clock_skew_allowance` with `clock_skew_allowance_ns` taken from the running
-/// sweeper's config, so the config fence holds against the process that actually
-/// deletes. Reuses [`GcConfigValues::satisfies_constraint`] (same saturating
-/// arithmetic). Called fail-closed at maintain startup: a violation refuses to
-/// enter the sweep loop rather than delete a pinned reader's snapshot.
+/// the RUNNING sweeper's own clock-skew allowance. The write fence in
+/// [`set_gc_config`] validates a proposed `sys/gc` against the *CLI's* declared
+/// `clock_skew_allowance`, but that knob and the running sweeper's
+/// [`crate::CompactorConfig::clock_skew_allowance_ns`] are independent: a
+/// deployment can write `sys/gc` with a 5 min skew while running sweepers
+/// configured with a larger skew, leaving the durable horizon skew-uncovered
+/// for the sweeper that actually deletes. [`validate_maintain`] does not catch
+/// it -- it only checks that the configured horizon and grace EQUAL the stored
+/// ones; the skew term appears in neither. This check re-runs the bound
+/// `protection_horizon >= max_query_duration + grace + clock_skew_allowance`
+/// with `clock_skew_allowance_ns` taken from the running sweeper's config, so
+/// the config fence holds against the process that actually deletes. Reuses
+/// [`GcConfigValues::satisfies_constraint`] (same saturating arithmetic).
+/// Called fail-closed at maintain startup: a violation refuses to enter the
+/// sweep loop rather than delete a pinned reader's snapshot.
 pub fn validate_maintain_skew(
     stored: &GcConfigValues,
     clock_skew_allowance_ns: i64,
@@ -635,8 +637,8 @@ mod tests {
         );
     }
 
-    /// FAILURE SUITE (the "disagreeing-config" row): a
-    /// config whose `protection_horizon` meets the OLD bound
+    /// FAILURE SUITE (the "disagreeing-config" row): a config whose
+    /// `protection_horizon` meets the OLD bound
     /// (`= max_query_duration + grace`) but NOT the skew-covering bound
     /// (`+ clock_skew_allowance`) is REJECTED by `set_gc_config` validation with
     /// `ConstraintViolation`, proving a skew-uncovered sweeper config can never
@@ -910,11 +912,12 @@ mod tests {
             .expect("the exact stored values match");
     }
 
-    /// Issue #993, the #904-gap closer: a stored `sys/gc` that satisfies its
-    /// OWN declared skew (the CLI's `--clock-skew-allowance` at write time) is
-    /// still rejected at maintain startup when the RUNNING sweeper is configured
-    /// with a LARGER `clock_skew_allowance`, because the durable horizon no
-    /// longer covers the skew of the process that actually deletes.
+    /// The gap the write-time fence leaves open: a stored `sys/gc` that
+    /// satisfies its OWN declared skew (the CLI's `--clock-skew-allowance` at
+    /// write time) is still rejected at maintain startup when the RUNNING
+    /// sweeper is configured with a LARGER `clock_skew_allowance`, because the
+    /// durable horizon no longer covers the skew of the process that actually
+    /// deletes.
     /// `validate_maintain` (horizon/grace must-match) passes it -- the skew term
     /// is in neither field -- so `validate_maintain_skew` is what bites.
     ///
@@ -928,8 +931,8 @@ mod tests {
     fn maintain_skew_reassert_refuses_when_running_sweeper_skew_exceeds_stored_horizon() {
         let write_time_skew = DEFAULT_CLOCK_SKEW_ALLOWANCE_NS; // what the CLI declared
         // A stored config that meets the bound for the write-time skew exactly:
-        // horizon = max_query_duration + grace + 5m. Written by a #904 write
-        // fence that was told the skew was 5m.
+        // horizon = max_query_duration + grace + 5m. Written by a write fence
+        // that was told the skew was 5m.
         let stored = GcConfigValues {
             protection_horizon_ns: DEFAULT_MAX_QUERY_DURATION_NS
                 + DEFAULT_GRACE_NS

--- a/crates/ravel-maintain/src/migrate.rs
+++ b/crates/ravel-maintain/src/migrate.rs
@@ -1001,17 +1001,18 @@ mod tests {
         assert_eq!((l0_below, l1_below), (0, 0));
     }
 
-    /// Slice B end to end (ADR-0066 decision 5, issue #1111): a
-    /// below-output-recorded RSEG input migrates to the current version and the
-    /// format floor is then raised. Before slice B this was unreachable for RSEG
-    /// -- its rewrite could only re-publish at the current writer version, so
-    /// reaching "below target" eligibility required a target *above* the writer
+    /// Slice B end to end (ADR-0066 decision 5): a below-output-recorded RSEG
+    /// input migrates to the current version and the format floor is then
+    /// raised. Before slice B this was unreachable for RSEG -- its rewrite
+    /// could only re-publish at the current writer version, so reaching
+    /// "below target" eligibility required a target *above* the writer
     /// ([`FUTURE_VERSION`]), which then made the rewrite's own output count as
-    /// below target and blocked the floor. Now, targeting the current version, an
-    /// input recorded at `VERSION_V6 - 1` (real v6 bytes, older recorded version
-    /// -- the synthetic-N-1 shape, since no real N-1 RSEG version has shipped) is
-    /// decoded and re-encoded to `VERSION_V6 == target`, the fresh re-audit finds
-    /// nothing below the target, and the floor is raised to `VERSION_V6`.
+    /// below target and blocked the floor. Now, targeting the current version,
+    /// an input recorded at `VERSION_V6 - 1` (real v6 bytes, older recorded
+    /// version -- the synthetic-N-1 shape, since no real N-1 RSEG version has
+    /// shipped) is decoded and re-encoded to `VERSION_V6 == target`, the fresh
+    /// re-audit finds nothing below the target, and the floor is raised to
+    /// `VERSION_V6`.
     #[tokio::test]
     async fn rseg_below_output_input_migrates_and_raises_floor() {
         let store = MemoryStore::new();

--- a/crates/ravel-maintain/src/rewrite.rs
+++ b/crates/ravel-maintain/src/rewrite.rs
@@ -8,11 +8,11 @@
 //! exact match. That one generalization is what lets a single primitive serve
 //! two epics:
 //!
-//! - EM (#463, this crate's caller below): format migration. An old-format
+//! - EM (this crate's caller below): format migration. An old-format
 //!   object is decoded and re-encoded into the current format, conserving the
 //!   record count exactly ([`crate::publish::conserve_exact`]). Nothing is
 //!   dropped; the bytes change format, not content.
-//! - EJ (#460, a later task, not built here): selective erasure. The same read
+//! - EJ (a later task, not built here): selective erasure. The same read
 //!   -> re-encode -> publish shape, but the writer drops the erased subject's
 //!   records and the predicate is "input equals output plus the erased count"
 //!   (ADR-0064 decision 3 point 4). EJ supplies that predicate; it does not
@@ -28,12 +28,12 @@
 //! public release), the codec's read path accepts the older version and this
 //! primitive migrates real old-version objects with no change here.
 //!
-//! RSEG is now the same shape: since ADR-0066 decision 5 (issue #1111), its
-//! `build_parts` (`build.rs`) still copies a *current*-version input's pages
-//! verbatim, but decodes and re-encodes an input recorded *below* the current
-//! output version at the current version before the shared merge/plan step, so
-//! an RSEG rewrite is a real format migration, not just a same-version round
-//! trip. [`RsegCodec::validate_rewrite_inputs`] no longer refuses an older
+//! RSEG is now the same shape: since ADR-0066 decision 5, its `build_parts`
+//! (`build.rs`) still copies a *current*-version input's pages verbatim, but
+//! decodes and re-encodes an input recorded *below* the current output version
+//! at the current version before the shared merge/plan step, so an RSEG
+//! rewrite is a real format migration, not just a same-version round trip.
+//! [`RsegCodec::validate_rewrite_inputs`] no longer refuses an older
 //! input; it now fails closed only on an input recorded *newer* than the
 //! current output version (ADR-0066 decision 2), which a forward migration
 //! cannot write. Whether an older object's bytes are actually decodable is the
@@ -599,11 +599,11 @@ mod tests {
         assert_eq!(got, want, "L1 carries exactly the inputs' series");
     }
 
-    /// Slice B headline (ADR-0066 decision 5, issue #1111): the
-    /// synthetic-N-1 mixed-fleet convergence case. An RSEG object recorded
-    /// *below* the current output version is genuinely decoded and re-encoded to
-    /// the current version by the rewrite primitive -- not refused (the
-    /// pre-slice-B guard), and not verbatim-copied under a mislabeled trailer.
+    /// Slice B headline (ADR-0066 decision 5): the synthetic-N-1 mixed-fleet
+    /// convergence case. An RSEG object recorded *below* the current output
+    /// version is genuinely decoded and re-encoded to the current version by
+    /// the rewrite primitive -- not refused (the pre-slice-B guard), and not
+    /// verbatim-copied under a mislabeled trailer.
     ///
     /// No real N-1 RSEG version has ever shipped, so the "old" object is built
     /// the way slice A's window tests use a synthetic version number

--- a/crates/ravel-maintain/src/rlog.rs
+++ b/crates/ravel-maintain/src/rlog.rs
@@ -87,13 +87,13 @@
 //! `Vec<LogRecord>` batch.
 //!
 //! Peak resident memory is then: per-input catalog metadata (KBs per input,
-//! unchanged from #275), plus at most one decoded block per input carrying the
-//! current stream (`O(input_count * block_size)`, independent of stream size),
-//! plus the in-progress part's writer buffer. The writer buffer is bounded by
-//! `max_l1_part_bytes` -- a part is flushed on a stream boundary once its
-//! record-byte estimate reaches the cap -- and holding a whole part before its
-//! content-addressed key exists is unavoidable, not a regression. The
-//! [`MergeMemoryTracker`] seam accounts these terms at their real
+//! unchanged by the k-way merge), plus at most one decoded block per input
+//! carrying the current stream (`O(input_count * block_size)`, independent of
+//! stream size), plus the in-progress part's writer buffer. The writer buffer
+//! is bounded by `max_l1_part_bytes` -- a part is flushed on a stream boundary
+//! once its record-byte estimate reaches the cap -- and holding a whole part
+//! before its content-addressed key exists is unavoidable, not a regression.
+//! The [`MergeMemoryTracker`] seam accounts these terms at their real
 //! allocation/decode points and records a high-water mark; the acceptance test
 //! asserts that mark stays under a fixed bound while a hot stream grows.
 //!
@@ -563,9 +563,9 @@ async fn merge_stream_into_part(
 ///
 /// The writer was built with the same [`RlogWriter::with_indexed_fields`] the
 /// L0 write path uses, so this part's POSTINGS is built by the one writer
-/// implementation from this part's own blocks (ADR-0049 decision 6, issue
-/// #509). The per-field distinct-value cap therefore applies to the merged
-/// part; when it fires the writer drops that field's postings and reports it in
+/// implementation from this part's own blocks (ADR-0049 decision 6). The
+/// per-field distinct-value cap therefore applies to the merged part; when it
+/// fires the writer drops that field's postings and reports it in
 /// `WriteStats`, which is logged here because a silently unindexed field is
 /// invisible in the object bytes (they are simply absent, which is always
 /// legal).
@@ -715,11 +715,11 @@ fn attr_value_estimate(v: &AttrValue) -> u64 {
 /// past corruption because absence is legal, but a compactor rewriting the
 /// object should not quietly bake a corrupt input's damage into the output.
 ///
-/// Issue #511 replaces this whole function with a read of the tenant's
-/// configured list. That changes behaviour in two ways the inputs cannot express:
-/// a newly configured field becomes indexed at the next compaction even though
-/// no input indexed it, and a de-configured field stops being indexed even
-/// though its inputs still carry postings.
+/// Once per-tenant configuration of the indexed-field list exists, a read of
+/// that list replaces this whole function. That changes behaviour in two ways
+/// the inputs cannot express: a newly configured field becomes indexed at the
+/// next compaction even though no input indexed it, and a de-configured field
+/// stops being indexed even though its inputs still carry postings.
 async fn input_indexed_fields(
     store: &dyn ObjectStoreBackend,
     object_key: &str,

--- a/crates/ravel-maintain/src/rspan_codec.rs
+++ b/crates/ravel-maintain/src/rspan_codec.rs
@@ -52,8 +52,8 @@
 //!
 //! The merge itself is a **k-way block-streaming merge**, so its peak resident
 //! memory is bounded independently of any one trace's size, the same fix RLOG
-//! got in #745. Unlike RLOG, there is no per-stream (here, per-trace) outer
-//! loop: RSPAN's SKIP_IDX has no directory of the distinct `trace_id`s an
+//! got. Unlike RLOG, there is no per-stream (here, per-trace) outer loop:
+//! RSPAN's SKIP_IDX has no directory of the distinct `trace_id`s an
 //! object holds (a block entry records only its own boundary
 //! `min_trace_id`/`max_trace_id`, not every trace_id that starts inside it),
 //! so "the next trace_id in this object" cannot be discovered without decoding
@@ -370,8 +370,8 @@ impl PartBuilder {
 /// stored (already `(trace_id, start_ts_ns)`-ascending) order one block at a
 /// time. At most one decoded block is resident: `head` is the next record to
 /// merge, `block` holds the rest of the current block, and the next block's
-/// bytes are fetched by range only once the current block is drained (issue
-/// #908). Unlike RLOG's `StreamCursor`, this walks *every* block of the input
+/// bytes are fetched by range only once the current block is drained. Unlike
+/// RLOG's `StreamCursor`, this walks *every* block of the input
 /// unconditionally -- there is no per-trace filter, because RSPAN has no
 /// directory of which traces a block holds (see the module memory note).
 /// `input_index` is the cursor's canonical position in `catalogs`, the k-way
@@ -1128,9 +1128,9 @@ mod tests {
         Bytes::from(out)
     }
 
-    /// Issue #926: a CRC-valid RSPAN input whose footer `record_count`
-    /// over-declares its actual body (footer says N+1, body decodes to N) must
-    /// fail the streaming compaction loud with the typed
+    /// A CRC-valid RSPAN input whose footer `record_count` over-declares its
+    /// actual body (footer says N+1, body decodes to N) must fail the
+    /// streaming compaction loud with the typed
     /// [`MaintainError::SpanInputRecordCountMismatch`], never a silent merge
     /// that drops the discrepancy.
     ///
@@ -1228,11 +1228,11 @@ mod tests {
     /// one fetched raw block plus one decoded block per input -- must stay
     /// under a fixed bound and must NOT grow with the trace. Flipped-line
     /// proof: reverting `BlockCursor::refill`'s one-block-at-a-time discipline
-    /// to whole-object decode (the pre-#908 shape, e.g. by making `refill`
-    /// eagerly decode every remaining block into `self.block` on first call
-    /// instead of one block per call) makes `decoded` scale with the trace and
-    /// pushes `transient` over `TRANSIENT_BOUND` at the 10x scale -- this test
-    /// fails against that whole-read shape.
+    /// to whole-object decode (e.g. by making `refill` eagerly decode every
+    /// remaining block into `self.block` on first call instead of one block
+    /// per call) makes `decoded` scale with the trace and pushes `transient`
+    /// over `TRANSIENT_BOUND` at the 10x scale -- this test fails against that
+    /// whole-read shape.
     ///
     /// Deterministic: it asserts on the tracker's accounting, never on process
     /// RSS or allocator hooks, and runs against [`MemoryStore`].

--- a/crates/ravel-maintain/tests/retention.rs
+++ b/crates/ravel-maintain/tests/retention.rs
@@ -3,7 +3,7 @@
 //! compactor-racing-tombstone ordering interlock, partial-sweep crash
 //! convergence, and the config validation floor. The convergence/interlock
 //! tests run once over an RSEG (metrics) fixture and once over an RLOG (logs)
-//! fixture through one seeding helper, per the issue text.
+//! fixture through one seeding helper.
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
 mod common;
@@ -582,7 +582,7 @@ async fn no_policy_is_a_noop() {
     assert!(!bucket_is_empty(&store, &bucket).await);
 }
 
-// --- HEAD-reachability delete blocker (ADR-0020, issue #1075) ----------------
+// --- HEAD-reachability delete blocker (ADR-0020) ---------------------------
 
 /// The catalog HEAD key for the shared test tenant/signal (frozen key layout).
 fn head_key(signal: Signal) -> String {
@@ -858,14 +858,14 @@ async fn sweep_respects_pre_fold_head_then_deletes_after_fold_drops_bucket() {
     assert!(bucket_is_empty(store.as_ref(), &bucket).await);
 }
 
-/// The epic exit criterion (issue #1075): retention of an hour whose tombstone
-/// lands FAR behind the fold watermark (outside the fixed reconcile window)
-/// never leaves the snapshot naming a deleted object. The fold's
-/// retention-frontier reconcile drops the out-of-window hour, then the sweep
-/// deletes it; a resolve spanning the retired hour returns only live segments,
-/// never a reference to a deleted object (the catalog-layer condition that
-/// produces `SnapshotInvalidated` / 503 downstream), and it stays true across
-/// repeated resolves.
+/// The epic exit criterion: retention of an hour whose tombstone lands FAR
+/// behind the fold watermark (outside the fixed reconcile window) never leaves
+/// the snapshot naming a deleted object. The fold's retention-frontier
+/// reconcile drops the out-of-window hour, then the sweep deletes it; a
+/// resolve spanning the retired hour returns only live segments, never a
+/// reference to a deleted object (the catalog-layer condition that produces
+/// `SnapshotInvalidated` / 503 downstream), and it stays true across repeated
+/// resolves.
 ///
 /// To watch this FAIL against pre-fix code, disable the fold's frontier
 /// reconcile (`frontier_reconcile_max_hours: 0`) AND the sweep's HEAD gate

--- a/crates/ravel-maintain/tests/sweep_crash_matrix.rs
+++ b/crates/ravel-maintain/tests/sweep_crash_matrix.rs
@@ -648,7 +648,7 @@ async fn sweep_unreferenced_result(
     .await
 }
 
-// --- Issue #273: abandoned-compaction L1 leak (option (b)) ------------------
+// --- Abandoned-compaction L1 leak (option (b)) ------------------------------
 //
 // The fix collects record-less `l1/` parts ONLY in buckets that hold a
 // retention tombstone (which makes any future compaction impossible), and

--- a/crates/ravel-promql-difftest/corpus/aggregate.txt
+++ b/crates/ravel-promql-difftest/corpus/aggregate.txt
@@ -1,5 +1,5 @@
-# Aggregation operator corpus (ticket #129, docs/promql-evaluator-plan.md
-# section P8), against crates/ravel-promql-difftest/src/generator.rs's
+# Aggregation operator corpus (docs/promql-evaluator-plan.md section P8),
+# against crates/ravel-promql-difftest/src/generator.rs's
 # `diff_agg_group` and `diff_agg_special` series. Every offset is relative
 # to the dataset's base_ts_ms.
 #
@@ -10,20 +10,20 @@
 # against the combined six-series vector, where the tied maximum (job a's
 # two 20s) and tied minimum (job b's two 5s) are each fully retained by
 # `k=2` rather than split at a tie boundary. These two entries are
-# `mode: unordered`, not `ordered`: issue #177 found that the two engines'
-# tie-break order among exactly-equal boundary values genuinely differs
-# (see crates/ravel-promql/src/aggregate.rs's module doc comment), which
-# has no defined PromQL semantics to begin with; retention (the right set
-# of members survives the tie) is what these entries test, and unordered
+# `mode: unordered`, not `ordered`: the two engines' tie-break order
+# among exactly-equal boundary values genuinely differs (see
+# crates/ravel-promql/src/aggregate.rs's module doc comment), which has
+# no defined PromQL semantics to begin with; retention (the right set of
+# members survives the tie) is what these entries test, and unordered
 # comparison still verifies that.
 #
 # `diff_agg_special` (NaN, -0.0, 1.0, one series each, all present at the
 # same instant) exercises NaN-skipping min/max, NaN-propagating sum, and
 # NaN-sorts-last topk/bottomk. Three entries that would otherwise exercise
-# this dataset's -0.0 member are excluded below (issue #177): the pinned
-# Prometheus binary does not preserve the sign of zero through its own
+# this dataset's -0.0 member are excluded below: the pinned Prometheus
+# binary does not preserve the sign of zero through its own
 # aggregation/storage path the way this project's comparator requires
-# (ADR-0025, issue #170's `instant_special_values_negative_zero`), an
+# (ADR-0025, recorded by `instant_special_values_negative_zero`), an
 # already-accepted divergence recurring here rather than a new one.
 
 name: agg_sum_no_modifier
@@ -54,7 +54,7 @@ mode: unordered
 # predict_linear entries): measured 1 ULP off Prometheus on job "b"'s
 # average. avg's Kahan-compensated fold is a deliberate port (module doc),
 # so this is very likely the same kind of findable-but-unfound divergence,
-# not an inherent limit; not investigated further here (issue #177).
+# not an inherent limit; not investigated further here.
 # tolerance: 2 is 1 ULP of headroom over the measured gap.
 name: agg_avg_by_job
 query: avg by (job) (diff_agg_group)
@@ -106,10 +106,10 @@ time: +0s
 mode: unordered
 
 # quantile(1.5, ...) clamps to +Inf on both sides, and both now emit the
-# out-of-range warning (issue #178 gave Ravel the annotation channel and
-# wired this InvalidQuantileWarning through it; the comparator checks
-# warning presence). Removed under issue #177 while Ravel had no warning
-# mechanism; re-added here now that it does.
+# out-of-range warning (Ravel's annotation channel carries this
+# InvalidQuantileWarning; the comparator checks warning presence). This
+# entry was removed while Ravel had no warning mechanism, and re-added
+# here now that it has one.
 name: agg_quantile_out_of_range_clamps
 query: quantile(1.5, diff_agg_group)
 kind: instant
@@ -154,12 +154,12 @@ kind: instant
 time: +0s
 mode: unordered
 
-# agg_special_min_skips_nan removed (issue #177): min(diff_agg_special)'s
-# winning value here is the dataset's -0.0 member itself (nothing in the
-# group beats it under `<`), so this is the same -0.0-preservation
-# divergence as the header comment above, not a NaN-skipping bug; NaN-
-# skipping itself is still exercised by agg_special_max_skips_nan, whose
-# winner (1.0) is unambiguous.
+# agg_special_min_skips_nan removed: min(diff_agg_special)'s winning
+# value here is the dataset's -0.0 member itself (nothing in the group
+# beats it under `<`), so this is the same -0.0-preservation divergence
+# as the header comment above, not a NaN-skipping bug; NaN-skipping
+# itself is still exercised by agg_special_max_skips_nan, whose winner
+# (1.0) is unambiguous.
 
 name: agg_special_sum_propagates_nan
 query: sum(diff_agg_special)
@@ -168,8 +168,8 @@ time: +0s
 mode: unordered
 
 # agg_special_topk_nan_sorts_last and agg_special_bottomk_nan_sorts_last
-# removed (issue #177): both engines already agree on order (one, negzero,
-# nan for topk; nan last either way) -- the mismatch was purely the
+# removed: both engines already agree on order (one, negzero, nan for
+# topk; nan last either way), and the mismatch was purely the
 # -0.0-preservation divergence on the "negzero" member's value, the same
 # class as agg_special_min_skips_nan above. Removing loses this dataset's
 # cross-engine check of "NaN sorts last under topk/bottomk"; that behavior

--- a/crates/ravel-promql-difftest/corpus/binop.txt
+++ b/crates/ravel-promql-difftest/corpus/binop.txt
@@ -1,6 +1,6 @@
-# Binary operator corpus (ticket #128, docs/promql-evaluator-plan.md
-# section P7), against crates/ravel-promql-difftest/src/generator.rs's
-# fixed dataset. Every offset is relative to the dataset's base_ts_ms
+# Binary operator corpus (docs/promql-evaluator-plan.md section P7),
+# against crates/ravel-promql-difftest/src/generator.rs's fixed dataset.
+# Every offset is relative to the dataset's base_ts_ms
 # (1_700_000_000_000 ms, i.e. 2023-11-14T22:13:20Z).
 #
 # Covers: scalar/scalar and scalar/vector arithmetic (including atan2),
@@ -62,8 +62,8 @@ mode: unordered
 # `diff_agg_group` rather than `diff_gauge_walk`: the walk's sign at any
 # instant depends on the dataset seed, so `diff_gauge_walk > 0` answered with
 # an empty vector for the default seed and this entry pinned nothing about
-# keeping the metric name (issue #262). The agg-group values are fixed
-# (10/20/20 and 5/5/15), so `> 10` always drops three series and keeps three.
+# keeping the metric name. The agg-group values are fixed (10/20/20 and
+# 5/5/15), so `> 10` always drops three series and keeps three.
 name: instant_filter_comparison_keeps_name
 query: diff_agg_group > 10
 kind: instant

--- a/crates/ravel-promql-difftest/corpus/histogram_classic.txt
+++ b/crates/ravel-promql-difftest/corpus/histogram_classic.txt
@@ -1,27 +1,26 @@
-# Classic-bucket histogram function corpus (ticket P9,
-# docs/promql-evaluator-plan.md section 8): histogram_quantile and
-# histogram_fraction over `le`-labeled classic bucket series, against
-# crates/ravel-promql-difftest/src/generator.rs's fixed dataset. Every
-# offset is relative to the dataset's base_ts_ms.
+# Classic-bucket histogram function corpus (docs/promql-evaluator-plan.md
+# section 8): histogram_quantile and histogram_fraction over `le`-labeled
+# classic bucket series, against the fixed dataset in
+# crates/ravel-promql-difftest/src/generator.rs. Every offset is relative
+# to the dataset's base_ts_ms.
 #
 # generator.rs's classic_histogram_family has no "missing +Inf bucket"
-# variant (adding one is out of this ticket's corpus/-only scope); that
+# variant (adding one is out of scope for this corpus/-only change); that
 # scenario is instead synthesized here with a `le!="+Inf"` matcher against
 # the "wellformed" series.
 #
 # histogram_quantile/histogram_fraction have no matrix-reducing shape, so
-# they are not usable at a range query's top level (see this ticket's final
-# report); the "rate of buckets" composition below is written as an instant
-# query for the same reason. Every entry is `mode: unordered` for the same
-# reason as selectors.txt (ADR-0021 decision 3).
+# they are not usable at a range query's top level; the "rate of buckets"
+# composition below is written as an instant query for the same reason.
+# Every entry is `mode: unordered` for the same reason as selectors.txt
+# (ADR-0021 decision 3).
 #
-# `ravel-promql` now carries warning/info annotations (issue #178): the
-# missing-+Inf and non-monotonic entries below are scenarios Prometheus
-# attaches a warning to, and `ravel-promql` now raises the matching warning
-# through the same evaluator path, so the differential comparator's
-# presence-equality check on both passes rather than being an expected
-# failure. Verified against the real pinned Prometheus binary after #178
-# landed (0 mismatches on this file's entries).
+# `ravel-promql` carries warning/info annotations: the missing-+Inf and
+# non-monotonic entries below are scenarios Prometheus attaches a warning
+# to, and `ravel-promql` raises the matching warning through the same
+# evaluator path, so the differential comparator's presence-equality check
+# on both passes rather than being an expected failure. Verified against
+# the real pinned Prometheus binary (0 mismatches on this file's entries).
 
 name: instant_histogram_quantile_wellformed_buckets
 query: histogram_quantile(0.9, diff_histogram_bucket{variant="wellformed"})

--- a/crates/ravel-promql-difftest/corpus/rate.txt
+++ b/crates/ravel-promql-difftest/corpus/rate.txt
@@ -1,4 +1,4 @@
-# Counter/regression function corpus (ticket P4, docs/promql-evaluator-plan.md
+# Counter/regression function corpus (docs/promql-evaluator-plan.md
 # section 8): rate, irate, increase, delta, idelta, resets, changes, deriv,
 # predict_linear, all against crates/ravel-promql-difftest/src/generator.rs's
 # fixed dataset. Every offset is relative to the dataset's base_ts_ms.
@@ -7,7 +7,7 @@
 # (generator.rs's own doc comment) means a zero-sampled-interval scenario
 # (irate/idelta's shared "last two samples share a timestamp" guard) cannot
 # be expressed here without changing the generator, which is out of scope
-# for this ticket; that edge is covered instead by
+# for this corpus; that edge is covered instead by
 # `functions::rate::tests::zero_sampled_interval_drops_the_series_for_irate_and_idelta`.
 #
 # `mode: unordered` is correct for every entry here, for the same reason as
@@ -29,7 +29,7 @@ mode: unordered
 # extrapolated_rate is a deliberate operation-for-operation port
 # (rate.rs's module doc), so this is very likely a real, findable
 # arithmetic difference upstream of this function, not an inherent
-# limit; tracked separately in issue #170 rather than investigated here.
+# limit; it is left for a separate investigation rather than pursued here.
 # tolerance: 2 is 1 ULP of headroom over the measured gap.
 name: range_rate_across_reset_at_boundary
 query: rate(diff_counter_total{shape="reset_at_boundary"}[5m])
@@ -76,7 +76,7 @@ mode: unordered
 # the five allowlisted cases). linear_regression's operation order
 # reads as a faithful port, so this is very likely upstream input
 # drift or a subtle order difference not yet found, not an inherent
-# limit; see ADR-0025 and issue #170 rather than re-deriving here.
+# limit; see ADR-0025 rather than re-deriving here.
 # tolerance: 1024 rounds up to the next power of two over the measured gap.
 name: instant_deriv_gauge_walk
 query: deriv(diff_gauge_walk[5m])

--- a/crates/ravel-promql-difftest/corpus/selectors.txt
+++ b/crates/ravel-promql-difftest/corpus/selectors.txt
@@ -130,7 +130,7 @@ mode: unordered
 # Prometheus here
 # would mean Ravel deliberately discarding a bit it currently preserves
 # correctly. This is a real, accepted engine-behavior divergence, not a
-# corpus mistake; see issue #170.
+# corpus mistake.
 
 name: instant_stale_marker_is_absent
 query: diff_stale

--- a/crates/ravel-promql-difftest/corpus/subquery.txt
+++ b/crates/ravel-promql-difftest/corpus/subquery.txt
@@ -58,10 +58,9 @@ mode: unordered
 # rate/deriv/predict_linear entries): avg_over_time sums the subquery
 # grid's values then divides by the count, using only IEEE 754 +/- and /,
 # so any gap is arithmetic residue, not a transcendental libm difference.
-# Measured up to 5 ULPs across this range's grid points (issue #224
-# mismatch #2); the representative pair there, -4.242539167465618 vs
-# -4.242539167465619, is 1 ULP by f64::to_bits, and only that one grid
-# point is observable from the issue text.
+# Measured up to 5 ULPs across this range's grid points; the
+# representative pair, -4.242539167465618 vs -4.242539167465619, is 1 ULP
+# by f64::to_bits, and it is the only grid point directly observed.
 # tolerance: 8 is the next power of two above the 5-ULP worst case;
 # tighten it if a live run shows a smaller observed max (ADR-0025
 # Consequences: a tightenable tolerance is a signal worth checking).
@@ -83,7 +82,7 @@ mode: unordered
 # ADR-0025 allowlist (arithmetic residue, same class as rate.txt's
 # rate/deriv/predict_linear entries): avg_over_time sums then divides,
 # IEEE 754 arithmetic only, so this is residue rather than a libm
-# difference. Measured 1 ULP: the exact values in issue #224 mismatch #3
+# difference. Measured 1 ULP: the exact values
 # (-3.4712031303800788 vs -3.4712031303800783) are adjacent doubles by
 # f64::to_bits. This is a single, fully observed value (one instant
 # result), not a sampled worst case, so the measurement is exact.
@@ -100,9 +99,9 @@ tolerance: 2
 # 30_000ms or 60_000ms, see the epoch-aligned entry above), so choosing a
 # 20s step plus offsets/ranges that are themselves whole multiples of 20s
 # makes every `end - range` target land exactly on a step boundary in
-# absolute epoch time. Before issue #190's fix, `align_up_to_step` used a
-# closed `>=` rule and would have admitted that boundary point into the
-# grid; the corrected left-open `>` rule excludes it. Every corpus entry
+# absolute epoch time. Before the fix, `align_up_to_step` used a closed
+# `>=` rule and would have admitted that boundary point into the grid;
+# the corrected left-open `>` rule excludes it. Every corpus entry
 # above this point has a target that is never step-aligned (by construction
 # or by accident), so none of them actually exercised the closed-vs-open
 # difference; these two are chosen specifically so they do.
@@ -111,7 +110,7 @@ name: instant_subquery_grid_start_excludes_a_step_aligned_boundary
 # time=+600s, range=2m, step=20s: target = base + 600s - 120s = base +
 # 480s, a multiple of 20s in absolute epoch time. Left-open start is
 # base + 500s, giving grid points {500, 520, 540, 560, 580, 600}s relative
-# to base_ts_ms -- 6 points. Before #190's fix the closed rule would have
+# to base_ts_ms -- 6 points. Before the fix the closed rule would have
 # also admitted 480s, giving 7. Every point is well inside the dataset's
 # continuous 30s-sampled span (0..1170s) and the default 5m lookback, so
 # `diff_gauge_walk` resolves at every grid instant and count_over_time
@@ -127,8 +126,9 @@ name: nested_subquery_grid_start_excludes_a_step_aligned_boundary_at_both_levels
 # multiples of 20s and base_ts_ms is itself a multiple of 20s, the outer
 # target (base + 480s) *and* the inner target at every one of the outer's
 # 6 grid instants (t - 120s, for t in {500..600}s step 20s, i.e.
-# {380..480}s) each land exactly on a 20s epoch boundary -- the left-open
-# rule (#190) excludes all of them, at both nesting levels simultaneously.
+# {380..480}s) each land exactly on a 20s epoch boundary -- the
+# left-open rule excludes all of them, at both nesting levels
+# simultaneously.
 # Outer grid: {500, 520, 540, 560, 580, 600}s (6 points, as above). At each
 # outer instant t, the inner count_over_time(diff_gauge_walk[2m:20s])
 # grid is {t-100, t-80, t-60, t-40, t-20, t}s (6 points), all within
@@ -142,14 +142,14 @@ time: +600s
 mode: unordered
 
 # Cap-exceeded entries: Ravel enforces a resolution cap (11_000 points,
-# docs/query-engine.md "Budgets", issue #77) independently at every
-# subquery evaluation node, before that node's grid is built. Both
-# entries below ask for a single node's grid alone to exceed it, one
-# directly and one through one level of nesting.
+# docs/query-engine.md "Budgets") independently at every subquery
+# evaluation node, before that node's grid is built. Both entries below
+# ask for a single node's grid alone to exceed it, one directly and one
+# through one level of nesting.
 #
-# Verified against the pinned Prometheus v3.13.1 binary (issue #224
-# mismatches #4 and #5): Prometheus SUCCEEDS on both, Ravel errors by
-# design. This is intentional, documented divergence, not a bug and not
+# Verified against the pinned Prometheus v3.13.1 binary: Prometheus
+# SUCCEEDS on both, Ravel errors by design. This is intentional,
+# documented divergence, not a bug and not
 # a missing prometheus_process.rs flag. Prometheus has no per-subquery-
 # node step-count cap, and neither of its query resource limits fires
 # here: --query.max-samples is a yielded-sample memory budget (these
@@ -168,8 +168,8 @@ mode: unordered
 # shape, Ravel errors by design and Prometheus succeeds, and treats any
 # other outcome (both erroring, both succeeding, Prometheus erroring) as a
 # real mismatch. ADR-0030 recorded this as a follow-up when it first
-# accepted the divergence with the entries still `mode: error`; issue #228
-# is that follow-up, adding the comparator mode so the entries turn green
+# accepted the divergence with the entries still `mode: error`, and a
+# later follow-up added the comparator mode so the entries turn green
 # rather than staying manually known-divergent. The per-node cap itself
 # stays covered by ravel-promql's eval.rs unit tests.
 

--- a/crates/ravel-promql-difftest/corpus/transform.txt
+++ b/crates/ravel-promql-difftest/corpus/transform.txt
@@ -1,28 +1,27 @@
-# Elementwise math, clamp, sort, label, time/calendar function corpus
-# (ticket P6, docs/promql-evaluator-plan.md section 9/10/11), against
-# crates/ravel-promql-difftest/src/generator.rs's fixed dataset. Every
-# offset is relative to the dataset's base_ts_ms (1_700_000_000_000 ms,
-# i.e. 2023-11-14T22:13:20Z).
+# Elementwise math, clamp, sort, label, and time/calendar function
+# corpus, against crates/ravel-promql-difftest/src/generator.rs's fixed
+# dataset. Every offset is relative to the dataset's base_ts_ms
+# (1_700_000_000_000 ms, i.e. 2023-11-14T22:13:20Z).
 #
 # sort/sort_desc entries are deliberately kind: instant with mode: ordered
-# only (plan section 4/9): a real Prometheus sort is not stable, so tied or
-# NaN-valued inputs would make an ordered comparison flaky. Every sort/
-# sort_desc query here selects series whose values are continuous random
-# walks (vanishingly unlikely to tie) and excludes any NaN-bearing series.
+# only: a real Prometheus sort is not stable, so tied or NaN-valued
+# inputs would make an ordered comparison flaky. Every sort/sort_desc
+# query here selects series whose values are continuous random walks
+# (vanishingly unlikely to tie) and excludes any NaN-bearing series.
 #
 # label_replace's dst-validation and regex-compile errors are runtime
 # errors (the query parses fine on both sides, validation fails only at
 # eval time), not the syntax errors errors.txt is scoped to, so they live
-# here instead alongside the rest of P6's own semantics.
+# here instead alongside the rest of this corpus's own semantics.
 #
 # No entry here relies on a binary expression (arithmetic or set operator:
 # `or`/`and`/`unless`, `+`, `/`, ...) or an aggregation: eval.rs does not
 # implement Expr::Binary or Expr::Aggregate yet (both return a typed
 # Unsupported error), which is a different phase's scope, not this one's.
-# Where P6's own semantics call for a NaN scalar (clamp's NaN-bound cases),
-# the bare `NaN` number literal is used instead of a `0/0` binary
-# expression, since PromQL's grammar (and this evaluator's parser) accepts
-# `NaN`/`Inf`/`-Inf` directly as number tokens.
+# Where this corpus's own semantics call for a NaN scalar (clamp's
+# NaN-bound cases), the bare `NaN` number literal is used instead of a
+# `0/0` binary expression, since PromQL's grammar (and this evaluator's
+# parser) accepts `NaN`/`Inf`/`-Inf` directly as number tokens.
 
 name: instant_abs_over_special_values
 query: abs(diff_special_values)
@@ -269,8 +268,7 @@ mode: unordered
 # same check from Prometheus' own `model.LabelNameRE`. Ravel deliberately
 # keeps the stricter legacy-name validation and rejects it. This is a
 # real, accepted engine divergence pending its own decision (relax Ravel
-# to match, or keep the stricter check), not a corpus mistake; see
-# issue #170.
+# to match, or keep the stricter check), not a corpus mistake.
 
 name: error_label_replace_invalid_regex
 query: label_replace(diff_match_left, "region", "$1", "job", "(unterminated")
@@ -292,7 +290,7 @@ mode: unordered
 
 # Same accepted divergence as error_label_replace_invalid_dst_label_name
 # above (Prometheus v3.13.1 accepts an invalid destination label name;
-# Ravel deliberately keeps stricter validation): see issue #170.
+# Ravel deliberately keeps stricter validation).
 
 name: instant_absent_over_present_series_is_empty
 query: absent(diff_gauge_walk)

--- a/crates/ravel-promql-difftest/tests/difftest_selectors.rs
+++ b/crates/ravel-promql-difftest/tests/difftest_selectors.rs
@@ -29,13 +29,13 @@ const HISTOGRAM_NATIVE_CORPUS: &str = include_str!("../corpus/histogram_native.t
 const OVER_TIME_CORPUS: &str = include_str!("../corpus/over_time.txt");
 const HISTOGRAM_CLASSIC_CORPUS: &str = include_str!("../corpus/histogram_classic.txt");
 
-/// Issue #947 exclusion: the exact PromQL queries whose difference from the
-/// pinned Prometheus binary is a 1-ULP summation-order residue in the last
-/// digit (e.g. `-4.235967390124592` vs `-4.235967390124591`), not a semantic
-/// bug. `avg_over_time`'s incremental Kahan mean and `rate()`'s Kahan sum
+/// The exact PromQL queries whose difference from the pinned Prometheus
+/// binary is a 1-ULP summation-order residue in the last digit (e.g.
+/// `-4.235967390124592` vs `-4.235967390124591`), not a semantic bug.
+/// `avg_over_time`'s incremental Kahan mean and `rate()`'s Kahan sum
 /// reduce their windows in an order Prometheus does not reproduce bit-for-bit;
 /// making the output bit-exact would mean changing Ravel's reduction strategy,
-/// a decision epic #947 owns and gates behind a not-yet-written tolerance ADR.
+/// a decision deferred to a tolerance ADR that is not yet written.
 /// Until then these two queries (and only these two) compare within a small
 /// ULP tolerance instead of exact bits. Every other corpus entry, in both new
 /// files and the existing ones, stays exact-match. Keyed by query text so it
@@ -64,7 +64,7 @@ const ISSUE_947_ULP_TOLERANCE_QUERIES: &[&str] = &[
 /// bug.
 const ISSUE_947_ULP_TOLERANCE: u32 = 8;
 
-/// Apply the issue #947 exclusion in place: any entry whose query is one of
+/// Apply the ULP-tolerance exclusion in place: any entry whose query is one of
 /// [`ISSUE_947_ULP_TOLERANCE_QUERIES`] and that has not already declared its
 /// own `tolerance:` gets [`ISSUE_947_ULP_TOLERANCE`]. Returns how many entries
 /// were adjusted so the caller can assert the allowlist actually matched
@@ -132,15 +132,15 @@ async fn selector_and_error_corpus_match_pinned_prometheus() {
     entries.extend(parse_corpus(OVER_TIME_CORPUS).expect("parse over_time corpus"));
     entries.extend(parse_corpus(HISTOGRAM_CLASSIC_CORPUS).expect("parse histogram_classic corpus"));
 
-    // Issue #947: two named queries carry a last-digit summation-order residue
-    // that is out of scope to make bit-exact here; everything else stays
+    // Two named queries carry a last-digit summation-order residue that is
+    // out of scope to make bit-exact here; everything else stays
     // exact-match. Assert the allowlist matched so a future rename cannot
     // silently drop the exclusion and turn this into a spurious failure.
     let applied = apply_issue_947_tolerance(&mut entries);
     assert!(
         applied >= 2,
-        "issue #947 float-tolerance allowlist matched {applied} entries, expected at least the \
-         two named queries; a corpus query was likely renamed"
+        "float-tolerance allowlist matched {applied} entries, expected at least the two \
+         named queries; a corpus query was likely renamed"
     );
 
     let report = run_corpus(

--- a/crates/ravel-promql/src/eval.rs
+++ b/crates/ravel-promql/src/eval.rs
@@ -251,8 +251,7 @@ pub(crate) fn invalid_quantile_warning(q: f64) -> String {
 /// be computed and the group evaluates to `NaN`. A warning: the `NaN` result
 /// signals a malformed input, not a benign one. Note this fires only for the
 /// too-few-buckets case; a group that is merely missing its `+Inf` top bucket
-/// is NaN with no annotation, matching the pinned Prometheus binary (issue
-/// #1099).
+/// is NaN with no annotation, matching the pinned Prometheus binary.
 pub(crate) fn classic_histogram_bad_buckets_warning() -> String {
     "input to histogram function was not a valid classic histogram: it needs \
      at least two buckets, the highest being a +Inf bucket"
@@ -1610,7 +1609,7 @@ mod tests {
         // A classic histogram with two or more buckets but no +Inf top bucket
         // (an incomplete shape, e.g. a `le!="+Inf"` matcher) is NaN, and,
         // matching the pinned Prometheus binary, raises NO warning: its
-        // `bucketQuantile` returns NaN silently for that shape (issue #1099).
+        // `bucketQuantile` returns NaN silently for that shape.
         // Before this fix Ravel emitted an extra bad-buckets warning here,
         // which is the divergence the over_time/histogram_classic difftest
         // corpora surfaced.
@@ -1637,8 +1636,8 @@ mod tests {
     fn histogram_quantile_single_bucket_still_surfaces_a_bad_buckets_warning() {
         // A genuinely degenerate group (fewer than two usable buckets) is a
         // distinct case from the missing-+Inf shape above: it keeps the
-        // bad-buckets warning. This pins that the #1099 narrowing touched only
-        // the missing-+Inf reason, not the too-few-buckets one.
+        // bad-buckets warning. This pins that the missing-+Inf narrowing
+        // touched only that reason, not the too-few-buckets one.
         let source = TestSource::new()
             .with_series(&[("__name__", "http_bucket"), ("le", "+Inf")], &[(0, 10.0)])
             .expect("valid series");

--- a/crates/ravel-promql/src/functions/histogram_classic.rs
+++ b/crates/ravel-promql/src/functions/histogram_classic.rs
@@ -22,10 +22,10 @@
 //! quantile argument are `warnings`; a forced monotonicity fixup is an
 //! `info`. A group that is merely missing its `+Inf` top bucket is the one
 //! `NaN` case that raises NO annotation, matching the pinned Prometheus
-//! binary (issue #1099): its `bucketQuantile` returns `NaN` silently for that
-//! incomplete shape. See [`crate::Annotations`] for the warning/info
-//! distinction. The native-histogram path's own Prometheus annotations are
-//! not wired here yet.
+//! binary: its `bucketQuantile` returns `NaN` silently for that incomplete
+//! shape. See [`crate::Annotations`] for the warning/info distinction. The
+//! native-histogram path's own Prometheus annotations are not wired here
+//! yet.
 
 use std::collections::{HashMap, HashSet};
 
@@ -147,8 +147,8 @@ struct Prepared {
 ///   not `+Inf` (an incomplete classic histogram, e.g. a `le!="+Inf"`
 ///   matcher). Prometheus' `bucketQuantile` returns `NaN` for this shape and
 ///   raises NO warning; matching that silence is the whole point of keeping
-///   this reason separate (issue #1099: the pinned binary emits no annotation
-///   here, so neither may Ravel).
+///   this reason separate: the pinned binary emits no annotation here, so
+///   neither may Ravel.
 /// * `TooFewBuckets` — fewer than two usable buckets before or after
 ///   coalescing duplicate `le` values: too degenerate to interpolate at all.
 ///   This still carries the bad-buckets warning.
@@ -275,7 +275,7 @@ fn quantile_for_group(phi: f64, buckets: Vec<Bucket>) -> (f64, ClassicGroupDiag)
             },
         ),
         // Missing the `+Inf` top bucket: NaN with no annotation, matching
-        // Prometheus' `bucketQuantile` (issue #1099).
+        // Prometheus' `bucketQuantile`.
         PrepareOutcome::MissingInfBucket => (f64::NAN, ClassicGroupDiag::default()),
         PrepareOutcome::TooFewBuckets => (
             f64::NAN,
@@ -421,7 +421,7 @@ fn fraction_for_group(lower: f64, upper: f64, buckets: Vec<Bucket>) -> (f64, Cla
     let prepared = match prepare(buckets) {
         PrepareOutcome::Ready(prepared) => prepared,
         // Missing the `+Inf` top bucket: NaN with no annotation, matching
-        // Prometheus (issue #1099).
+        // Prometheus.
         PrepareOutcome::MissingInfBucket => return (f64::NAN, ClassicGroupDiag::default()),
         PrepareOutcome::TooFewBuckets => {
             return (

--- a/crates/ravel-query/proto/queryfrag_service.proto
+++ b/crates/ravel-query/proto/queryfrag_service.proto
@@ -1,7 +1,7 @@
 // The ADR-0071 fragment RPC service. The message contract is frozen in
-// proto/ravel/queryfrag.proto (ravel.queryfrag.v1, ticket #863); this file adds
-// only the gRPC service that carries those messages, in a separate package so
-// the frozen message file needs no service block. The message types are reused
+// proto/ravel/queryfrag.proto (ravel.queryfrag.v1); this file adds only the
+// gRPC service that carries those messages, in a separate package so the
+// frozen message file needs no service block. The message types are reused
 // verbatim from ravel-proto via a build-time extern_path mapping, never
 // regenerated here.
 //

--- a/crates/ravel-query/src/distrib/codec.rs
+++ b/crates/ravel-query/src/distrib/codec.rs
@@ -33,13 +33,12 @@ use crate::fetcher::FetchedSeriesSoa;
 /// falls back to fully local execution (ADR-0071 version-skew rule), never
 /// misinterprets a future frame layout.
 ///
-/// Bumped 1 -> 2 for the ADR-0071 amendment (epic #1055 finding F-1): the shared
-/// bearer token on `Pinned` fetches is replaced by a per-tenant, per-query
-/// fragment capability ([`FragmentClaims`]). This is a version bump on an
-/// existing versioned wire field, not a frozen persistent-format change. A
-/// version-skewed worker is dropped at routing time (never a hard error), so a
-/// rolling deploy degrades to coordinator-local execution, never to a wrong
-/// answer.
+/// Bumped 1 -> 2 for the ADR-0071 amendment: the shared bearer token on
+/// `Pinned` fetches is replaced by a per-tenant, per-query fragment capability
+/// ([`FragmentClaims`]). This is a version bump on an existing versioned wire
+/// field, not a frozen persistent-format change. A version-skewed worker is
+/// dropped at routing time (never a hard error), so a rolling deploy degrades
+/// to coordinator-local execution, never to a wrong answer.
 pub const PROTOCOL_VERSION: u32 = 2;
 
 /// The fragment-capability claim-set version (ADR-0071 amendment, decision 2).

--- a/crates/ravel-query/tests/partial_coverage_gate.rs
+++ b/crates/ravel-query/tests/partial_coverage_gate.rs
@@ -1,10 +1,10 @@
 //! Acceptance proof for ADR-0071's "partial results are consent-gated and
-//! envelope-visible" amendment (epic #1063, decisions 1-3): the read HTTP
-//! surface refuses partial coverage unless the client opted in with
-//! `allow_partial`, and when it does return partial data it flags it with a
-//! required top-level `partial` field.
+//! envelope-visible" amendment (decisions 1-3): the read HTTP surface refuses
+//! partial coverage unless the client opted in with `allow_partial`, and when
+//! it does return partial data it flags it with a required top-level `partial`
+//! field.
 //!
-//! The epic's verbatim acceptance property: **a client which ignores warnings
+//! The amendment's acceptance property: **a client which ignores warnings
 //! cannot mistake partial for complete.** This is proven two ways here:
 //!
 //! 1. Without `allow_partial`, a partial-coverage request fails with the typed
@@ -216,12 +216,12 @@ async fn series_complete_is_200_partial_false_present() {
 
 // ---- the load-bearing proof ----------------------------------------------
 
-/// The epic's acceptance property, made executable: a naive client that reads
-/// only `status` and `data` sees an IDENTICAL shape for an opted-in partial
-/// response and a complete response. The `partial` field is therefore the sole
-/// top-level signal distinguishing them; without it (the pre-amendment wire, or
-/// any regression that drops/omits it) the two are indistinguishable and the
-/// client silently accepts partial as complete.
+/// The amendment's acceptance property, made executable: a naive client that
+/// reads only `status` and `data` sees an IDENTICAL shape for an opted-in
+/// partial response and a complete response. The `partial` field is therefore
+/// the sole top-level signal distinguishing them; without it (the
+/// pre-amendment wire, or any regression that drops/omits it) the two are
+/// indistinguishable and the client silently accepts partial as complete.
 #[tokio::test]
 async fn partial_field_is_the_sole_top_level_discriminator() {
     let (_, partial_json) = get(&app(true), "/api/v1/query?query=up&allow_partial=true").await;

--- a/docs/adrs/0037-container-image-ci-registry.md
+++ b/docs/adrs/0037-container-image-ci-registry.md
@@ -187,8 +187,8 @@ repo config).
 
 ## Amendment: verifiable release artifacts
 
-An independent due-diligence review (epic #1056, findings K-1 and K-2)
-rated the release artifact itself as the weak half of an otherwise strong
+An independent due-diligence review (findings K-1 and K-2) rated the
+release artifact itself as the weak half of an otherwise strong
 build-and-test story: images publish under mutable tags, unsigned, with
 no SBOM, and nothing gates the release tag on CI. This amendment adds
 signing, SBOM and provenance attestation, an explicit CI gate on tag
@@ -232,9 +232,9 @@ current `main` rather than assumed:
   mirror has already shipped `v0.9.0`; the Prometheus-compat buildinfo
   endpoint reports `env!("CARGO_PKG_VERSION")`
   (crates/ravel-query/src/http/compat.rs:67), so the `0.9.0` release
-  reported itself as `0.1.0`. Contrary to the epic's text, PR #1050
-  fixed only the committed symlink; the version mismatch is still live
-  and is addressed by decision 11.
+  reported itself as `0.1.0`. Contrary to the review's text, the change
+  that landed fixed only the committed symlink; the version mismatch is
+  still live and is addressed by decision 11.
 
 ### Decision 7: signing is cosign keyless (Sigstore), not a managed key
 

--- a/docs/adrs/0043-unified-alerting-engine.md
+++ b/docs/adrs/0043-unified-alerting-engine.md
@@ -147,8 +147,7 @@ nothing for as long as the condition holds. Alertmanager auto-resolves
 any alert it has not heard about within `resolve_timeout` (default 5
 minutes), so at default configuration every persistently firing alert
 produces a false all-clear to on-call while the problem continues. That
-is worse than no alerting. (Epic #1052 finding G-2, risk R3: P1, high
-likelihood.)
+is worse than no alerting. The risk was rated P1 at high likelihood.
 
 The gap is in delivery cadence, not in the data model. Decision 4 is
 correct and unchanged: the durable record is state, and "still firing"
@@ -301,16 +300,16 @@ flowchart TB
 
 ### Consequences
 
-- Closes #1052 G-2 / risk R3. The interim mitigation (raising
+- Closes the false all-clear gap. The interim mitigation (raising
   `resolve_timeout` per deployment) is no longer required.
-- The acceptance proof is the epic's exit criterion verbatim: a test
-  that holds a rule firing across injected-clock advances spanning more
-  than one default `resolve_timeout` and asserts the notification count
-  grows, plus a restart-mid-episode test asserting repeats resume on
-  the schedule derived from the durable record.
+- The acceptance proof is a test that holds a rule firing across
+  injected-clock advances spanning more than one default
+  `resolve_timeout` and asserts the notification count grows, plus a
+  restart-mid-episode test asserting repeats resume on the schedule
+  derived from the durable record.
 - `docs/architecture.md`'s alerting section gains one sentence on
   repeat cadence in the same commit that implements it.
 - The rules file grows an optional field; existing files parse
   unchanged and silently gain the 1-minute default, which is the point:
-  the safe behavior must be the default, because R3's likelihood was
-  rated high specifically at default configuration.
+  the safe behavior must be the default, because this failure's
+  likelihood was rated high specifically at default configuration.

--- a/docs/adrs/0053-ci-latency-and-delivery-process-hardening.md
+++ b/docs/adrs/0053-ci-latency-and-delivery-process-hardening.md
@@ -195,10 +195,10 @@ script pair is deleted.
 
 ## Amendment: main-push coverage ratchet
 
-External review finding J-7 (epic #1061) observes that coverage is
-measured and badged but never gated, so the number can only fall
-silently. Read quickly, that asks this ADR to reverse one of its own
-rejected alternatives:
+External review finding J-7 observes that coverage is measured and
+badged but never gated, so the number can only fall silently. Read
+quickly, that asks this ADR to reverse one of its own rejected
+alternatives:
 
 > Keep `coverage` required with a threshold gate: a hard threshold on a
 > codebase growing 2,000+ lines/day generates noise merges can trip
@@ -270,8 +270,8 @@ wording targets unobserved decay, not the existence of a PR gate. If a
 recurring pattern emerges of drops that a PR-time signal would have
 cheaply prevented, that is new evidence, and a future amendment can
 weigh a diff-coverage advisory comment (never a required check) against
-it. Epic #1061's exit criterion "a floor that fails the build" is met
-by the main-push build failing; the epic ledger should read it so.
+it. The epic exit criterion "a floor that fails the build" is met by
+the main-push build failing; the epic ledger should read it so.
 
 ### Consequences
 

--- a/docs/adrs/0071-distributed-read-fanout.md
+++ b/docs/adrs/0071-distributed-read-fanout.md
@@ -161,7 +161,7 @@ credentials lacks.
 > **Superseded in part** for `Pinned` fetches by the amendment below
 > ("Dedicated fragment listener and per-tenant fragment capabilities"):
 > the shared-listener, shared-token design this section describes is the
-> defect epic #1055 finding F-1 identified. `Resolve` (federation)
+> defect finding F-1 identified. `Resolve` (federation)
 > authorization is unchanged. Remote endpoints come only from operator config, never
 from query text. Remote responses are size- and shape-validated data; a
 remote cannot escalate through the coordinator.
@@ -270,7 +270,7 @@ exists).
 
 ## Amendment: dedicated fragment listener and per-tenant fragment capabilities
 
-Epic #1055, finding F-1 (risk R7, P2). The Security section above made two
+Finding F-1 (risk R7, P2). The Security section above made two
 claims that the adversarial review showed compose into a fleet-wide
 cross-tenant read credential. This ADR said:
 
@@ -469,8 +469,8 @@ into the rollout:
    window requires a token leaked *during* the rollout itself. (Token
    rotation is itself a rolling restart of the v1 fleet; the sequence is
    two rolls, not one, and both are bounded.)
-2. Land the H-1 NetworkPolicy (epic #1055, restricting fragment-port
-   reachability to cluster peers) before the rollout, so network reach,
+2. Land the H-1 NetworkPolicy (restricting fragment-port reachability to
+   cluster peers) before the rollout, so network reach,
    the second precondition of R7, is already withdrawn from
    outside-cluster holders.
 
@@ -529,9 +529,9 @@ KMS templates, per the doc-currency rule.
 
 ### Amendment-adjacent fixes that need no ADR
 
-Two epic #1055 items are deliberately *not* gated on this amendment,
+Two related review items are deliberately *not* gated on this amendment,
 because they decide nothing architectural; they are recorded here only so
-the epic's scope reads in one place:
+that work reads in one place:
 
 - `crates/ravel-query/src/http/tenant.rs` line 51:
   `StaticBearerTokenResolver` resolves by `HashMap` lookup keyed on the
@@ -596,7 +596,7 @@ the epic's scope reads in one place:
 
 ## Amendment: partial results are consent-gated and envelope-visible
 
-Status: Accepted. Epic #1063. Amends the response-contract halves of two
+Status: Accepted. Amends the response-contract halves of two
 sentences above: the Decision's "a per-remote `skip_unavailable` opt-in
 returns partial results marked in the response `warnings` plus a `partial`
 stats block", and the Security section's "The query stats carry
@@ -671,8 +671,8 @@ stats block to bury one in (`crates/ravel-query/src/http/handlers.rs`).
    failure path (log, count `rules_failed`, keep prior state, retry next
    tick), so no transition record is ever written from partial data. Any
    richer policy - a per-rule opt-in to evaluate on partial coverage -
-   belongs to epic #1052, which owns alerting; this amendment only
-   guarantees the safe default and makes the signal reachable.
+   belongs with the alerting work that owns that surface; this amendment
+   only guarantees the safe default and makes the signal reachable.
 
 ### Grafana compatibility
 
@@ -706,18 +706,19 @@ shipped, and the cost of changing this contract only grows.
 ### Out of scope
 
 - The fragment surface's listener, transport encryption, and credential
-  model: a separate amendment to this ADR (epic #1055) owns those; this
-  amendment neither depends on nor constrains it.
+  model: the "Dedicated fragment listener and per-tenant fragment
+  capabilities" amendment above owns those; this amendment neither
+  depends on nor constrains it.
 - The `--remote-cluster` federation TLS default (currently off). Flipping
   it is federation transport hardening, not response honesty; it was
-  bundled into epic #1063 but belongs with #1055's transport work, and
-  this amendment recommends re-homing it there rather than deciding it
-  here.
-- The dead-endpoint ranking window after mass worker death (epic #1063's
-  P3 item): a recovery-latency tuning, no response-contract impact, stays
-  a separate task.
-- Per-rule partial-coverage policy in alerting: epic #1052, as decided
-  above.
+  bundled into this amendment's scope but belongs with the
+  fragment-listener amendment's transport work above, and this amendment
+  recommends re-homing it there rather than deciding it here.
+- The dead-endpoint ranking window after mass worker death (a P3 item): a
+  recovery-latency tuning, no response-contract impact, stays a separate
+  task.
+- Per-rule partial-coverage policy in alerting: belongs with the alerting
+  work that owns that surface, as decided above.
 
 ### Consequences
 
@@ -735,8 +736,8 @@ shipped, and the cost of changing this contract only grows.
 
 ## Amendment: federation TLS by default, engine-direct caller honesty, and dead-endpoint quarantine
 
-Status: Accepted. Epic #1063, the three remaining items. This amendment
-decides: (1) the `--remote-cluster` federation transport default flips
+Status: Accepted. This amendment decides the three remaining items:
+(1) the `--remote-cluster` federation transport default flips
 from plaintext to TLS, with plaintext demoted to an explicit, loudly
 logged choice; (2) the two production callers that reach the query engine
 directly, bypassing the HTTP-boundary consent gate the previous amendment
@@ -749,9 +750,9 @@ worker's own next heartbeat.
 
 One prior thread is resolved here rather than left dangling: the previous
 amendment's Out-of-scope section recommended re-homing the federation TLS
-default under epic #1055's transport work. The epic kept it in #1063, and
-this amendment decides it under #1063; that recommendation is superseded,
-not silently dropped.
+default under the fragment-listener amendment's transport work. That
+re-homing was not taken up there, and this amendment decides the default
+here instead; the recommendation is superseded, not silently dropped.
 
 ### 1. Federation TLS on by default; plaintext is an explicit, logged choice
 
@@ -908,8 +909,8 @@ reasoning the epic asked for, having weighed the alternative honestly:
   meta-alert on, instead of a silent gap.
 
 Any richer policy — a per-rule opt-in to evaluate on partial coverage,
-with a marked notification — remains assigned to epic #1052, which owns
-alerting, exactly as the previous amendment already recorded.
+with a marked notification — remains assigned to the alerting work that
+owns that surface, exactly as the previous amendment already recorded.
 
 **Decision (analytics): a request-body opt-in, mirroring the HTTP gate.**
 `AnalyticsBody` (`analytics.rs`) gains `allow_partial: bool`
@@ -935,8 +936,8 @@ different channel than all the others.
    partial-coverage-derived.* Rejected for the reasons argued above:
    false resolves are confident silence, durable records written from
    partial data need later reconciliation, and a marker cannot un-page or
-   un-silence. Revisit per-rule under #1052 if a concrete rule class
-   needs it.
+   un-silence. Revisit per-rule under that alerting work if a concrete
+   rule class needs it.
 2. *Skip the analytics gate and rely on the stats block.* That is the
    exact defect class the previous amendment removed from the query
    endpoints: an incompleteness signal buried where naive consumers never

--- a/proto/ravel/queryfrag.proto
+++ b/proto/ravel/queryfrag.proto
@@ -47,16 +47,16 @@ message FetchRequest {
   string trace_context = 13;    // propagated tracing context (e.g. traceparent)
 
   // The per-tenant, per-query fragment capability for a Pinned fetch (ADR-0071
-  // amendment, epic #1055 finding F-1): a fixed-width canonical claim set
-  // (capability version, tenant_hash, signal, query_id, expires_unix_ns)
-  // followed by a keyed-BLAKE3 MAC over it. The coordinator mints one per query
-  // and attaches it to every slice; the worker recomputes the MAC and requires
-  // this request's tenant_hash/signal/query_id to equal the claims, so a
-  // capability minted for one tenant cannot authorize a fetch naming another.
-  // Replaces the shared bearer token that guarded Pinned fetches in protocol
-  // version 1. Empty on a Resolve (federation) request, which authenticates
-  // through an ordinary tenant credential instead. Additive field on this
-  // transient wire contract, exactly the evolution this file's header sanctions.
+  // amendment): a fixed-width canonical claim set (capability version,
+  // tenant_hash, signal, query_id, expires_unix_ns) followed by a keyed-BLAKE3
+  // MAC over it. The coordinator mints one per query and attaches it to every
+  // slice; the worker recomputes the MAC and requires this request's
+  // tenant_hash/signal/query_id to equal the claims, so a capability minted
+  // for one tenant cannot authorize a fetch naming another. Replaces the
+  // shared bearer token that guarded Pinned fetches in protocol version 1.
+  // Empty on a Resolve (federation) request, which authenticates through an
+  // ordinary tenant credential instead. Additive field on this transient wire
+  // contract, exactly the evolution this file's header sanctions.
   bytes fragment_capability = 14;
 }
 

--- a/services/ravel-server/src/exemplars.rs
+++ b/services/ravel-server/src/exemplars.rs
@@ -449,15 +449,14 @@ async fn collect_once(
         .map_err(|e| CollectError::Api(ApiError::from_query(e)))?;
 
     // Pending selective-erasure predicates carried on the resolved snapshot
-    // (ADR-0064 decision 1, issue #915). The resolver attaches every pending
-    // request to `Snapshot::pending_erasure`; this converts them into the
-    // scan-time predicate shape once, here, and the record loop excludes any
-    // exemplar an erased subject owns. Without this pass an erased subject's
-    // exemplars (trace ids included) would still be served, while the sample,
-    // series, and log surfaces exclude them: the same data-deletion leak #928
-    // closed for the log-family scan. A snapshot with no pending erasure yields
-    // an empty set and the loop below is a no-op, so the common path is
-    // unchanged.
+    // (ADR-0064 decision 1). The resolver attaches every pending request to
+    // `Snapshot::pending_erasure`; this converts them into the scan-time
+    // predicate shape once, here, and the record loop excludes any exemplar an
+    // erased subject owns. Without this pass an erased subject's exemplars
+    // (trace ids included) would still be served, while the sample, series, and
+    // log surfaces exclude them: the same data-deletion leak already closed for
+    // the log-family scan. A snapshot with no pending erasure yields an empty
+    // set and the loop below is a no-op, so the common path is unchanged.
     let preds = snapshot_erasure_predicates(&snapshot);
 
     // Segments are read sequentially. The sample path fans this out under a
@@ -506,11 +505,11 @@ async fn collect_once(
 }
 
 /// Whether an exemplar owned by `labels` at `ts_ns` is erased by any pending
-/// predicate (ADR-0064 decision 1, issue #915). Erased when a predicate's
-/// conjunction matches the series labels and, if the predicate is windowed,
-/// `ts_ns` falls in its half-open window; a windowless predicate erases every
-/// matching record regardless of timestamp. This is the metric-shape analogue
-/// of `ravel_query::erasure::is_erased_span`, which `ravel_query` keeps for the
+/// predicate (ADR-0064 decision 1). Erased when a predicate's conjunction
+/// matches the series labels and, if the predicate is windowed, `ts_ns` falls
+/// in its half-open window; a windowless predicate erases every matching record
+/// regardless of timestamp. This is the metric-shape analogue of
+/// `ravel_query::erasure::is_erased_span`, which `ravel_query` keeps for the
 /// span surface but does not expose for a bare `(LabelSet, ts_ns)` pair.
 fn is_erased_exemplar(labels: &LabelSet, ts_ns: i64, preds: &[ErasurePredicate]) -> bool {
     preds
@@ -667,14 +666,14 @@ async fn read_segment_exemplars(
         if !matched[idx] {
             continue;
         }
-        // Exclude a record owned by an erased subject (ADR-0064 decision 1,
-        // issue #915). This filters against `entry.entry.labels`, the exact
-        // series-label view this endpoint materializes into `seriesLabels`
-        // below, so a green result means the shipping surface never emits the
-        // erased subject's exemplars: a windowless predicate erases every
-        // matching record regardless of timestamp, a windowed one only records
-        // whose `ts_ns` fall in its half-open window. Mirrors `is_erased_span`
-        // and the metric `retain_*` rule in `ravel_query::erasure`.
+        // Exclude a record owned by an erased subject (ADR-0064 decision 1).
+        // This filters against `entry.entry.labels`, the exact series-label
+        // view this endpoint materializes into `seriesLabels` below, so a green
+        // result means the shipping surface never emits the erased subject's
+        // exemplars: a windowless predicate erases every matching record
+        // regardless of timestamp, a windowed one only records whose `ts_ns`
+        // fall in its half-open window. Mirrors `is_erased_span` and the metric
+        // `retain_*` rule in `ravel_query::erasure`.
         if is_erased_exemplar(&entry.entry.labels, rec.ts_ns, preds) {
             continue;
         }
@@ -1590,9 +1589,9 @@ mod tests {
     /// Writes a real metrics `.dreq` erasure request into `tenant`'s `del/`
     /// prefix, exactly as the erasure submit path does, so the next
     /// `Catalog::resolve` attaches it to `Snapshot::pending_erasure` and the
-    /// exemplar surface excludes the matching subject (ADR-0064 decision 1,
-    /// issue #915). The predicate is the conjunction of every `(key, value)` in
-    /// `matchers`; `window_start_ns`/`window_end_ns` are `0` for a windowless
+    /// exemplar surface excludes the matching subject (ADR-0064 decision 1).
+    /// The predicate is the conjunction of every `(key, value)` in `matchers`;
+    /// `window_start_ns`/`window_end_ns` are `0` for a windowless
     /// (whole-subject) request, the same zero-as-unset convention
     /// `ErasurePredicate` uses.
     async fn put_dreq(
@@ -1977,15 +1976,15 @@ mod tests {
         assert_eq!(ex0["timestamp"], (NOW - 30 * NS_PER_SEC) / NS_PER_SEC);
     }
 
-    /// Data-deletion regression (issue #915): a pending selective-erasure
-    /// request must exclude the erased subject's exemplars from
-    /// `query_exemplars`, while a non-erased subject matched by the same
-    /// selector keeps its exemplars. Drives the real handler end to end (a real
-    /// `.dreq` in the store, the real resolve that attaches it to
-    /// `Snapshot::pending_erasure`, and the shipping `run`/`collect_once` path),
-    /// so a filter dropped from the record loop serves the erased trace ids and
-    /// fails here. Two subjects, not one, so a filter-everything bug (which
-    /// would also make the erased subject "absent") fails on the retained one.
+    /// Data-deletion regression: a pending selective-erasure request must
+    /// exclude the erased subject's exemplars from `query_exemplars`, while a
+    /// non-erased subject matched by the same selector keeps its exemplars.
+    /// Drives the real handler end to end (a real `.dreq` in the store, the
+    /// real resolve that attaches it to `Snapshot::pending_erasure`, and the
+    /// shipping `run`/`collect_once` path), so a filter dropped from the record
+    /// loop serves the erased trace ids and fails here. Two subjects, not one,
+    /// so a filter-everything bug (which would also make the erased subject
+    /// "absent") fails on the retained one.
     #[tokio::test]
     async fn erased_subject_exemplars_are_excluded() {
         let store = Arc::new(MemoryStore::new());

--- a/services/ravel-server/src/metrics.rs
+++ b/services/ravel-server/src/metrics.rs
@@ -3518,14 +3518,14 @@ mod tests {
         assert!(body.contains("# TYPE ravel_store_probe_failures_total counter"));
     }
 
-    /// THE deliverable-4 test (issue #1079): all three durable-auth
-    /// refresh-loop counters reach `/metrics` and carry the real values their
-    /// underlying conditions produced, not zero placeholders. Each of the three
-    /// is driven by its genuine trigger on a real [`DurableAuthState`] -- a
-    /// failed refresh (a faulting sys/auth GET), an on-miss re-read, and a
-    /// hard-stale fail-closed resolution -- then that state's counters are
-    /// snapshotted and rendered exactly as the `/metrics` handler does, so the
-    /// full condition->counter->exposition chain is asserted end to end.
+    /// Proves all three durable-auth refresh-loop counters reach `/metrics`
+    /// and carry the real values their underlying conditions produced, not
+    /// zero placeholders. Each of the three is driven by its genuine trigger
+    /// on a real [`DurableAuthState`] -- a failed refresh (a faulting
+    /// sys/auth GET), an on-miss re-read, and a hard-stale fail-closed
+    /// resolution -- then that state's counters are snapshotted and rendered
+    /// exactly as the `/metrics` handler does, so the full
+    /// condition->counter->exposition chain is asserted end to end.
     #[tokio::test]
     async fn render_includes_durable_auth_counters_that_incremented() {
         use ravel_object_store::ObjectStoreBackend;


### PR DESCRIPTION
Epic 1035 wave 2 stripped issue-number citations from most of the tree
before the public push, but 34 files still carried private-tracker
references in comments and doc prose: `(epic #NNNN)`, `(issue #NNNN)`,
`ticket #NNN`, scattered through crate doc comments, ADRs, the PromQL
differential corpus, a workflow, and the Dockerfile.

Each reference is rewritten to keep the fact, measurement, or ULP
tolerance it carried and drop only the dead pointer. Where a nearby
ADR reference already existed, the sentence now leans on that instead.
Comment and doc prose only; no executable line, test assertion, corpus
query, or proto field changed. Verified: fmt, workspace clippy,
doc-drift check, actionlint all clean.
