### PR TITLE
Wire OTLP HTTP exemplars end to end

### DIFF
--- a/crates/ravel-otlp/src/lib.rs
+++ b/crates/ravel-otlp/src/lib.rs
@@ -29,7 +29,8 @@ pub use limits::{IngestLimits, Rejection};
 pub use logs_limits::{LogIngestLimits, LogRejection};
 pub use logs_normalize::{LogNormalizeOutput, NormalizedLogRecord, normalize_logs};
 pub use normalize::{
-    NormalizeOutput, NormalizedHistogramPoint, NormalizedPoint, normalize_metrics,
+    MetricsNormalizeResult, NormalizeOutput, NormalizedHistogramPoint, NormalizedPoint,
+    normalize_metrics, normalize_metrics_with_exemplars,
 };
 pub use traces_limits::{SpanIngestLimits, SpanRejection};
 pub use traces_normalize::{NormalizedSpan, SpanNormalizeOutput, normalize_traces};

--- a/docs/adrs/0069-global-ingest-memory-bounds.md
+++ b/docs/adrs/0069-global-ingest-memory-bounds.md
@@ -120,5 +120,18 @@ the sweep drives with the injected `now_ns` and the TTL:
   concurrent queries). Last touch is stamped in the shared `resolve` funnel, so
   both the HTTP and Flight SQL paths keep an active tenant out of the sweep.
 
-The admission-controller maps are not evictors and are never registered with
-the sweep, so decision 2's exclusion is structural, not merely a convention.
+The admission-controller maps (active-series/stream sets, token buckets,
+usage counters) are the one long-lived per-tenant map family that is
+deliberately *not* an evictor and never registered with the sweep, so its
+exclusion from decision 2 is structural, not merely a convention.
+
+The OTLP HTTP handler's exemplar admission (`services/ravel-server/src/ingest.rs`,
+wired through `normalize_metrics_with_exemplars`) does not add a second one:
+its `ExemplarCap` (ADR-0047 decision 2) is built fresh per request and
+dropped at the end of the call, the same shape every other OTLP normalize
+entry point already uses. The real per-series-per-window budget is enforced
+per shard actor with no cross-shard coordination (`crates/ravel-ingest/src/shard.rs`),
+which already builds and drops its own cap per flush -- a shard-lived (or
+longer) cap was considered and rejected there as an unbounded memory-growth
+vector, since `ExemplarCap`'s per-series map has no eviction. Nothing at the
+transport layer needs to, or should, outlive one request.

--- a/docs/guides/ingest.md
+++ b/docs/guides/ingest.md
@@ -94,8 +94,7 @@ Every rejection reason ([crates/ravel-otlp/src/limits.rs](../../crates/ravel-otl
 | `DuplicateLabelName` | Two attributes sanitize to the same label name (or a data-point attribute collides with a synthesized `job`/`instance` label). |
 | `ComplexAttributeValue` | An attribute value is an array, kvlist, or bytes value, which has no label representation. For a resource attribute, this rejects every point under that resource. |
 | `MissingValue` | The data point has neither an int nor a double value set. |
-| `UnsupportedMetricType` | The metric is a Histogram, ExponentialHistogram, or Summary. Phase 1 supports only Gauge and cumulative Sum. Ravel rejects the whole metric's points; it never drops them as if they did not exist. |
-| `UnsupportedTemporality` | A Sum metric has delta (or unspecified) temporality. Ravel accepts only cumulative sums. |
+| `UnsupportedTemporality` | A Sum, Histogram, or ExponentialHistogram metric has delta (or unspecified) temporality. Ravel accepts only cumulative aggregations. |
 | `ZeroTimestamp` | The data point's event timestamp is zero. |
 | `FutureSkew` | The event timestamp is ahead of ingest time by more than `max_future_skew_ns`. |
 | `TooOld` | The event timestamp is behind ingest time by more than `max_ingest_lag_ns`. |

--- a/services/ravel-server/src/exemplars.rs
+++ b/services/ravel-server/src/exemplars.rs
@@ -1976,6 +1976,167 @@ mod tests {
         assert_eq!(ex0["timestamp"], (NOW - 30 * NS_PER_SEC) / NS_PER_SEC);
     }
 
+    /// Epic acceptance criterion (#130): the real OTLP HTTP metrics ingest
+    /// handler stores an exemplar carried on a histogram data point, and the
+    /// real `/api/v1/query_exemplars` handler returns it over that window with
+    /// the tenant, series, trace id, span id, and filtered attribute intact.
+    ///
+    /// This drives the shipping ingest handler (`crate::ingest::handle_export`,
+    /// the function `POST /v1/metrics` calls after decoding wire bytes) writing
+    /// through a real `IngestRouter` into a `MemoryStore`, then the shipping
+    /// exemplars router reading that same store. Storage is never constructed
+    /// directly.
+    ///
+    /// Non-vacuity (prove-the-test): reverting `handle_export` to the old
+    /// `normalize_metrics` + `write_values` pair -- which discards admitted
+    /// exemplars and counts them dropped -- makes this fail, because nothing
+    /// exemplar-shaped is ever written and `data` comes back with no matching
+    /// exemplar.
+    #[tokio::test]
+    async fn otlp_http_histogram_exemplar_round_trips_to_query_exemplars() {
+        use opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest;
+        use opentelemetry_proto::tonic::common::v1::any_value::Value as AnyValueVariant;
+        use opentelemetry_proto::tonic::common::v1::{AnyValue, KeyValue};
+        use opentelemetry_proto::tonic::metrics::v1::exemplar::Value as ExemplarValue;
+        use opentelemetry_proto::tonic::metrics::v1::metric::Data as MetricData;
+        use opentelemetry_proto::tonic::metrics::v1::{
+            AggregationTemporality, Exemplar as OtlpExemplar, Histogram, HistogramDataPoint,
+            Metric, ResourceMetrics, ScopeMetrics,
+        };
+        use ravel_ingest::{
+            AdmissionController, AdmissionLimits, IngestConfig, IngestRouter, WriteMode,
+        };
+
+        use crate::ingest::{IngestState, handle_export};
+
+        let store = Arc::new(MemoryStore::new());
+        let backend: Arc<dyn ObjectStoreBackend> = store.clone();
+
+        // A router that flushes synchronously under a strict write (small
+        // target, fixed clock at NOW so the commit record's hour bucket matches
+        // the query window), writing into the same store the query side reads.
+        let router = Arc::new(IngestRouter::new(
+            IngestConfig {
+                shard_count: 1,
+                target_bytes: 8,
+                max_flush_delay: Duration::from_secs(3600),
+                flush_tick: Duration::from_millis(20),
+                ..IngestConfig::default()
+            },
+            backend.clone(),
+            Signal::Metrics,
+            Arc::new(FixedClock(NOW)),
+        ));
+        let limits = ravel_otlp::IngestLimits::default();
+        let ingest = IngestState {
+            router: router.clone(),
+            limits,
+            ack_deadline: Duration::from_secs(5),
+            admission: Arc::new(AdmissionController::new(
+                Arc::new(FixedClock(NOW)),
+                AdmissionLimits::default(),
+            )),
+            recovery: None,
+            provisioning: None,
+        };
+
+        // A classic histogram data point (le bounds [0.5]) carrying one
+        // exemplar for value 0.25, which attaches to the
+        // `latency_bucket{le="0.5"}` series (smallest bound at or above 0.25).
+        let ex = OtlpExemplar {
+            time_unix_nano: (NOW - 30 * NS_PER_SEC) as u64,
+            value: Some(ExemplarValue::AsDouble(0.25)),
+            trace_id: TRACE_ID.to_vec(),
+            span_id: SPAN_ID.to_vec(),
+            filtered_attributes: vec![KeyValue {
+                key: "region".to_string(),
+                value: Some(AnyValue {
+                    value: Some(AnyValueVariant::StringValue("us-east-1".to_string())),
+                }),
+                ..Default::default()
+            }],
+        };
+        let dp = HistogramDataPoint {
+            time_unix_nano: (NOW - 60 * NS_PER_SEC) as u64,
+            count: 1,
+            sum: Some(0.25),
+            bucket_counts: vec![1, 0],
+            explicit_bounds: vec![0.5],
+            exemplars: vec![ex],
+            ..Default::default()
+        };
+        let request = ExportMetricsServiceRequest {
+            resource_metrics: vec![ResourceMetrics {
+                scope_metrics: vec![ScopeMetrics {
+                    metrics: vec![Metric {
+                        name: "latency".to_string(),
+                        data: Some(MetricData::Histogram(Histogram {
+                            data_points: vec![dp],
+                            aggregation_temporality: AggregationTemporality::Cumulative as i32,
+                        })),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+        };
+
+        let outcome = handle_export(&ingest, tenant(), WriteMode::Strict, request, NOW)
+            .await
+            .expect("ingest accepts the histogram and its exemplar");
+        assert_eq!(
+            outcome.tokens.len(),
+            1,
+            "the strict write flushed one shard's object"
+        );
+        // Drop the state's router clone so the last `Arc` can be unwrapped and
+        // the shard actors drained.
+        drop(ingest);
+        match Arc::try_unwrap(router) {
+            Ok(router) => router.shutdown().await,
+            Err(_) => panic!("router still shared after ingest"),
+        }
+
+        // Query the real exemplars handler over the same store. `latency_bucket`
+        // (equality `__name__`) matches every le-bucket series, so the exemplar
+        // comes back whichever bucket its value landed in.
+        let app = build_router(store, Duration::from_secs(30), 1000);
+        let (status, body) = query(&app, "latency_bucket").await;
+        assert_eq!(status, StatusCode::OK, "body: {body}");
+        assert_eq!(body["status"], "success");
+
+        let data = body["data"].as_array().expect("data array");
+        // Find the series carrying our ingested exemplar.
+        let mut found = None;
+        for series in data {
+            assert_eq!(
+                series["seriesLabels"]["__name__"], "latency_bucket",
+                "every matched series is a histogram bucket"
+            );
+            for exemplar in series["exemplars"].as_array().expect("exemplars array") {
+                if exemplar["labels"]["trace_id"] == "0a1b2c3d4e5f60718293a4b5c6d7e8f9" {
+                    found = Some((series.clone(), exemplar.clone()));
+                }
+            }
+        }
+        let (series, exemplar) =
+            found.expect("the ingested exemplar is returned by query_exemplars");
+
+        // Series identity intact: the matched series is the histogram bucket,
+        // so it carries an `le` label.
+        assert!(
+            series["seriesLabels"]["le"].is_string(),
+            "the matched series is a histogram bucket: {series}"
+        );
+        // Exemplar identity intact: span id and the filtered attribute survive
+        // the full ingest-to-query round trip.
+        assert_eq!(exemplar["labels"]["span_id"], "1122334455667788");
+        assert_eq!(exemplar["labels"]["region"], "us-east-1");
+        assert_eq!(exemplar["value"], "0.25");
+        assert_eq!(exemplar["timestamp"], (NOW - 30 * NS_PER_SEC) / NS_PER_SEC);
+    }
+
     /// Data-deletion regression: a pending selective-erasure request must
     /// exclude the erased subject's exemplars from `query_exemplars`, while a
     /// non-erased subject matched by the same selector keeps its exemplars.

--- a/services/ravel-server/src/ingest.rs
+++ b/services/ravel-server/src/ingest.rs
@@ -9,11 +9,11 @@ use opentelemetry_proto::tonic::collector::metrics::v1::{
     ExportMetricsPartialSuccess, ExportMetricsServiceRequest, ExportMetricsServiceResponse,
 };
 use ravel_ingest::{
-    AdmissionController, IngestPoint, IngestRouter, RequestRejection, WriteError, WriteMode,
-    plausible_ingest_clock,
+    AdmissionController, IngestExemplar, IngestPoint, IngestRouter, RequestRejection, WriteError,
+    WriteMode, plausible_ingest_clock,
 };
-use ravel_otlp::{IngestLimits, Rejection, normalize_metrics};
-use ravel_types::{CommitToken, SeriesId, TenantId};
+use ravel_otlp::{IngestLimits, Rejection, normalize_metrics_with_exemplars};
+use ravel_types::{CommitToken, ExemplarCap, SeriesId, TenantId};
 
 pub struct IngestState {
     pub router: Arc<IngestRouter>,
@@ -136,7 +136,29 @@ pub async fn handle_export(
     .await
     .map_err(|e| IngestRequestError::Provisioning(e.to_string()))?;
 
-    let normalized = normalize_metrics(&tenant, request, &state.limits, ingest_ts_ns);
+    // Admit points AND exemplars through a per-request cap, rather than the
+    // `normalize_metrics` wrapper that builds the same throwaway cap and then
+    // counts every admitted exemplar as dropped because it has nowhere to
+    // store them. ADR-0047 decision 2 enforces the real per-series-per-window
+    // budget per shard actor, with no cross-shard coordination
+    // (`crates/ravel-ingest/src/shard.rs`); a transport-level cap only needs
+    // to exist long enough to admit this request's exemplars into that path,
+    // so it is built fresh here and dropped at the end of the call, exactly
+    // like every other OTLP normalize entry point. A tenant-lived cap at this
+    // layer was tried and reverted: `ExemplarCap`'s per-series map has no
+    // eviction, so anything that outlives one request grows unbounded with
+    // tenant x lifetime series cardinality (the same growth vector
+    // `shard.rs`'s per-flush cap comment already rejected building one layer
+    // lower).
+    let mut cap = ExemplarCap::new(state.limits.exemplar_cap_window_ns);
+    let result =
+        normalize_metrics_with_exemplars(&tenant, request, &state.limits, ingest_ts_ns, &mut cap);
+    let exemplars: Vec<IngestExemplar> = result
+        .exemplars
+        .into_iter()
+        .map(IngestExemplar::from)
+        .collect();
+    let normalized = result.output;
     let mut rejected_count: usize = normalized.rejected.iter().map(|r| r.rejected_count()).sum();
 
     // Scalar and native-histogram points arrive in separate vectors; both
@@ -172,7 +194,7 @@ pub async fn handle_export(
 
     let receipt = state
         .router
-        .write_values(tenant, points, mode, state.ack_deadline)
+        .write_values_with_exemplars(tenant, points, exemplars, mode, state.ack_deadline)
         .await
         .map_err(IngestRequestError::Write)?;
 


### PR DESCRIPTION
Every real ingest transport called the plain write path, never the
exemplar-carrying one, so /api/v1/query_exemplars was structurally
empty in production even though ADR-0047 already designed storage,
routing, and query for exemplars.

The OTLP HTTP handler now admits points and exemplars through
normalize_metrics_with_exemplars with a per-request ExemplarCap,
matching the shape every other OTLP normalize entry point already
uses, and writes through router.write_values_with_exemplars so the
admitted exemplars flush alongside their parent sample. The real
per-series-per-window budget stays enforced per shard actor with no
cross-shard coordination (ADR-0047 decision 2), which already builds
and drops its own cap per flush; a longer-lived cap at the transport
layer would grow unbounded with tenant x lifetime series cardinality,
so none is introduced here.

Also corrects docs/guides/ingest.md: Histogram, ExponentialHistogram,
and Summary metrics are accepted and stored today, rejecting only on
non-cumulative temporality, not on type as the guide claimed.

Fixes: #130
