### PR TITLE
feat: fold retention-frontier reconcile honors deployment retention default

### DIFF
--- a/crates/ravel-bench/src/bin/catalog_resolve_bench.rs
+++ b/crates/ravel-bench/src/bin/catalog_resolve_bench.rs
@@ -367,7 +367,14 @@ async fn run_resolve_scenario(raw_store: Arc<dyn ObjectStoreBackend>, args: &Arg
 
     let fold_catalog = build_catalog(Arc::clone(&raw_store), shards);
     let fold_report = fold_catalog
-        .fold(&tenant_hash, Signal::Metrics, Uuid::new_v4(), now_ns, &[])
+        .fold(
+            &tenant_hash,
+            Signal::Metrics,
+            Uuid::new_v4(),
+            now_ns,
+            &[],
+            None,
+        )
         .await
         .expect("fold");
 
@@ -458,7 +465,14 @@ async fn run_gate_scenario(raw_store: Arc<dyn ObjectStoreBackend>, args: &Args) 
     // fold does NOT eliminate, since it prunes by hour, not by name).
     let fold_catalog = build_catalog(Arc::clone(&raw_store), 1);
     fold_catalog
-        .fold(&tenant_hash, Signal::Metrics, Uuid::new_v4(), now_ns, &[])
+        .fold(
+            &tenant_hash,
+            Signal::Metrics,
+            Uuid::new_v4(),
+            now_ns,
+            &[],
+            None,
+        )
         .await
         .expect("fold gate bucket");
 

--- a/crates/ravel-catalog/src/cache.rs
+++ b/crates/ravel-catalog/src/cache.rs
@@ -901,6 +901,7 @@ mod tests {
                 uuid::Uuid::new_v4(),
                 now_ns,
                 &[],
+                None,
             )
             .await
             .expect("fold produces a snapshot part");
@@ -958,6 +959,7 @@ mod tests {
                 uuid::Uuid::new_v4(),
                 now_ns,
                 &[],
+                None,
             )
             .await
             .expect("fold produces a snapshot part");
@@ -999,6 +1001,7 @@ mod tests {
                 uuid::Uuid::new_v4(),
                 now_ns,
                 &[],
+                None,
             )
             .await
             .expect("fold produces a snapshot part");
@@ -1070,6 +1073,7 @@ mod tests {
                 uuid::Uuid::new_v4(),
                 now_ns,
                 &[],
+                None,
             )
             .await
             .expect("fold produces a snapshot part");
@@ -1172,6 +1176,7 @@ mod tests {
                 uuid::Uuid::new_v4(),
                 now_ns,
                 &[],
+                None,
             )
             .await
             .expect("fold produces a snapshot part");

--- a/crates/ravel-catalog/src/covering_postings.rs
+++ b/crates/ravel-catalog/src/covering_postings.rs
@@ -331,6 +331,7 @@ mod tests {
                 Uuid::new_v4(),
                 now_ns,
                 &[],
+                None,
             )
             .await
             .expect("fold produces a HEAD");

--- a/crates/ravel-catalog/src/fold.rs
+++ b/crates/ravel-catalog/src/fold.rs
@@ -730,6 +730,16 @@ impl Catalog {
     /// offending key/identity, and skipped (see the bucket-processing loop
     /// below). Only a malformed commit record or exhausted HEAD CAS retries
     /// surface as [`CatalogError`].
+    ///
+    /// `default_retention_ns` is the caller-resolved deployment-level default
+    /// retention window for this tenant (from the CLI-derived `RetentionConfig`
+    /// in ravel-maintain, resolved by the caller via `window_for`), or `None`
+    /// if no deployment default is configured. `ravel-catalog` never sees
+    /// `RetentionConfig` itself: the dependency runs the other way (see
+    /// [`crate::config::DEFAULT_PROTECTION_HORIZON_NS`] for the same
+    /// one-directional mirroring precedent). The frontier reconcile below
+    /// overlays the durable per-tenant `TenantConfig.retention_ns` on top of
+    /// this default.
     pub async fn fold(
         &self,
         tenant: &TenantHash,
@@ -737,6 +747,7 @@ impl Catalog {
         folder_id: Uuid,
         now_ns: i64,
         _transactions: &[Transaction],
+        default_retention_ns: Option<i64>,
     ) -> Result<FoldReport, CatalogError> {
         let head_key = head_object_key(tenant, signal);
         // The generation history for the read-side scan rule (ADR-0052 section
@@ -752,29 +763,37 @@ impl Catalog {
         // shared cache/load API's `QueryAccounting` parameter and is discarded.
         let accounting = QueryAccounting::new();
 
-        // The tenant's durable retention window (TenantConfig.retention_ns),
-        // read once per fold (loop-invariant). Bounds the retention-frontier
-        // reconcile pass below (ADR-0020 delete-blocker). A tenant with no
-        // per-tenant window, or a transient config-read fault, degrades to "no
-        // frontier reconcile this fold": the fold's index role is a pure
+        // The tenant's effective retention window, read once per fold
+        // (loop-invariant). Bounds the retention-frontier reconcile pass below
+        // (ADR-0020 delete-blocker). Resolution mirrors the admission-limit
+        // overlay in crates/ravel-ingest/src/lifecycle.rs (ADR-0078): the
+        // durable per-tenant `TenantConfig.retention_ns` override wins when the
+        // record exists and carries `Some`; otherwise the effective window is
+        // `default_retention_ns`, the caller-resolved deployment-wide default.
+        // A `TenantConfig` read failure or absent record is NOT "skip the
+        // frontier reconcile": it means "fall back to the deployment default,"
+        // which does not depend on that read at all. Only a tenant with neither
+        // a per-tenant override nor a deployment default gets no frontier
+        // reconcile (nothing is being retired). The fold's index role is a pure
         // optimization and the sweep's HEAD-reachability gate is the durable
-        // delete blocker, so this never fails the fold. (A tenant retired only
-        // by a deployment-wide RetentionConfig default, with no per-tenant
-        // config record, is not frontier-reconciled here; its sweep still
-        // blocks safely on the HEAD gate.)
-        let tenant_retention_ns: Option<i64> =
-            match crate::tenant_config::read_config_values(self.store(), tenant).await {
-                Ok(Some(cfg)) => cfg.retention_ns,
-                Ok(None) => None,
-                Err(err) => {
-                    tracing::warn!(
-                        error = %err,
-                        tenant = %tenant.to_hex(),
-                        "tenant config read failed; skipping retention-frontier reconcile this fold"
-                    );
-                    None
-                }
-            };
+        // delete blocker, so a config-read fault never fails the fold.
+        let tenant_retention_ns: Option<i64> = match crate::tenant_config::read_config_values(
+            self.store(),
+            tenant,
+        )
+        .await
+        {
+            Ok(Some(cfg)) => cfg.retention_ns.or(default_retention_ns),
+            Ok(None) => default_retention_ns,
+            Err(err) => {
+                tracing::warn!(
+                    error = %err,
+                    tenant = %tenant.to_hex(),
+                    "tenant config read failed; falling back to deployment-default retention for frontier reconcile"
+                );
+                default_retention_ns
+            }
+        };
 
         loop {
             let head_state = self.get_head(&head_key, &mut counters).await?;
@@ -989,9 +1008,11 @@ impl Catalog {
                 // at `frontier_reconcile_max_hours`; the remainder is carried to
                 // the next fold via `frontier_hours_deferred` (the snapshot still
                 // names those hours, so the next fold recomputes them), never
-                // dropped. `tenant_retention_ns` is the tenant's durable
-                // TenantConfig.retention_ns; a tenant with no per-tenant window
-                // gets no frontier reconcile (nothing is being retired).
+                // dropped. `tenant_retention_ns` is the tenant's effective
+                // retention window: the durable `TenantConfig.retention_ns`
+                // override when present, else the deployment-wide default
+                // (ADR-0078). A tenant with neither gets no frontier reconcile
+                // (nothing is being retired).
                 if let Some(retention_window_ns) = tenant_retention_ns
                     && let Some(frontier_hi_raw) = retirement_frontier_hour(
                         now_ns,
@@ -2254,7 +2275,7 @@ mod tests {
         let store = Arc::new(MemoryStore::new());
         let catalog = Catalog::new(store, config(1)).expect("catalog");
         let report = catalog
-            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), 0, &[])
+            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), 0, &[], None)
             .await
             .expect("fold");
         assert!(report.no_op);
@@ -2273,6 +2294,7 @@ mod tests {
                 Uuid::new_v4(),
                 now_at_seal(5),
                 &[],
+                None,
             )
             .await
             .expect("fold");
@@ -2291,7 +2313,7 @@ mod tests {
         publish_segment(&store, 0, Uuid::new_v4(), 2, 10, now - NS_PER_HOUR).await;
 
         let first = catalog
-            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now, &[])
+            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now, &[], None)
             .await
             .expect("first fold");
         assert!(first.rebuilt);
@@ -2303,7 +2325,7 @@ mod tests {
         // Same now_ns: nothing new sealed, so this must be a clean no-op
         // that touches neither the part nor HEAD.
         let second = catalog
-            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now, &[])
+            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now, &[], None)
             .await
             .expect("second fold");
         assert!(second.no_op);
@@ -2318,7 +2340,7 @@ mod tests {
         let now_1 = now_at_seal(10);
         publish_segment(&store, 0, Uuid::new_v4(), 1, 10, now_1 - NS_PER_HOUR).await;
         let first = catalog
-            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_1, &[])
+            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_1, &[], None)
             .await
             .expect("first fold");
         assert_eq!(first.entry_count, 1);
@@ -2326,7 +2348,7 @@ mod tests {
         let now_2 = now_at_seal(12);
         publish_segment(&store, 0, Uuid::new_v4(), 1, 12, now_2 - NS_PER_HOUR).await;
         let second = catalog
-            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_2, &[])
+            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_2, &[], None)
             .await
             .expect("second fold");
         assert!(!second.rebuilt, "a valid HEAD must fold incrementally");
@@ -2346,7 +2368,7 @@ mod tests {
         let now_1 = now_at_seal(10);
         publish_segment(&store, 0, Uuid::new_v4(), 1, 10, now_1 - NS_PER_HOUR).await;
         catalog
-            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_1, &[])
+            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_1, &[], None)
             .await
             .expect("first fold");
 
@@ -2364,7 +2386,7 @@ mod tests {
         let now_2 = now_at_seal(12);
         publish_segment(&store, 0, Uuid::new_v4(), 1, 12, now_2 - NS_PER_HOUR).await;
         let report = catalog
-            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_2, &[])
+            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_2, &[], None)
             .await
             .expect("fold after corruption");
         assert!(report.rebuilt);
@@ -2414,7 +2436,7 @@ mod tests {
 
         let now = now_at_seal(12);
         let err = catalog
-            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now, &[])
+            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now, &[], None)
             .await
             .expect_err("fold must fail on a newer-format HEAD");
         assert!(
@@ -2481,7 +2503,7 @@ mod tests {
         let now_2 = now_at_seal(12);
         publish_segment(&store, 0, Uuid::new_v4(), 1, 12, now_2 - NS_PER_HOUR).await;
         let report = catalog
-            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_2, &[])
+            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_2, &[], None)
             .await
             .expect("corrupt head self-heals via rebuild");
         assert!(report.rebuilt);
@@ -2511,7 +2533,7 @@ mod tests {
         let now_1 = now_at_seal(10);
         publish_segment(store.inner(), 0, Uuid::new_v4(), 1, 10, now_1 - NS_PER_HOUR).await;
         let first = catalog
-            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_1, &[])
+            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_1, &[], None)
             .await
             .expect("first fold");
         assert_eq!(first.entry_count, 1);
@@ -2519,7 +2541,7 @@ mod tests {
         let now_2 = now_at_seal(12);
         publish_segment(store.inner(), 0, Uuid::new_v4(), 1, 12, now_2 - NS_PER_HOUR).await;
         let second = catalog
-            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_2, &[])
+            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_2, &[], None)
             .await
             .expect("fold falls back to rebuild");
         assert!(second.rebuilt);
@@ -2559,7 +2581,7 @@ mod tests {
         .await;
 
         let report = catalog
-            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now, &[])
+            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now, &[], None)
             .await
             .expect("fold succeeds despite postings-build fault");
 
@@ -2590,8 +2612,8 @@ mod tests {
         let catalog_b = Catalog::new(store.clone(), config(1)).expect("catalog b");
         let tenant = tenant();
         let (result_a, result_b) = tokio::join!(
-            catalog_a.fold(&tenant, Signal::Metrics, Uuid::new_v4(), now, &[]),
-            catalog_b.fold(&tenant, Signal::Metrics, Uuid::new_v4(), now, &[]),
+            catalog_a.fold(&tenant, Signal::Metrics, Uuid::new_v4(), now, &[], None),
+            catalog_b.fold(&tenant, Signal::Metrics, Uuid::new_v4(), now, &[], None),
         );
         let report_a = result_a.expect("fold a");
         let report_b = result_b.expect("fold b");
@@ -2663,7 +2685,7 @@ mod tests {
             .expect("put b");
 
         let report = catalog
-            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now, &[])
+            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now, &[], None)
             .await
             .expect("duplicate identity must not be fold-fatal");
         assert!(!report.no_op);
@@ -2696,7 +2718,7 @@ mod tests {
             .expect("put unrecognized key");
 
         let report = catalog
-            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now, &[])
+            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now, &[], None)
             .await
             .expect("unrecognized key shape must not be fold-fatal");
         assert!(!report.no_op);
@@ -2733,7 +2755,7 @@ mod tests {
         )
         .await;
         let first = catalog
-            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_1, &[])
+            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_1, &[], None)
             .await
             .expect("first fold");
         assert!(!first.no_op);
@@ -2755,7 +2777,7 @@ mod tests {
         )
         .await;
         let second = catalog
-            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_2, &[])
+            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_2, &[], None)
             .await
             .expect("second fold");
         assert!(!second.rebuilt, "a valid HEAD must fold incrementally");
@@ -2835,7 +2857,7 @@ mod tests {
         publish_segment(&store, 0, Uuid::new_v4(), 1, 11, now_1 - NS_PER_HOUR).await;
 
         let first = catalog
-            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_1, &[])
+            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_1, &[], None)
             .await
             .expect("first fold");
         assert!(!first.no_op);
@@ -2880,7 +2902,7 @@ mod tests {
         // part is carried by reference, no PUT for it.
         let now_2 = now_at_seal(13);
         let second = catalog
-            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_2, &[])
+            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_2, &[], None)
             .await
             .expect("second fold");
         assert!(!second.no_op);
@@ -2937,7 +2959,7 @@ mod tests {
         publish_segment(&store, 0, Uuid::new_v4(), 1, 11, now_1 - NS_PER_HOUR).await;
 
         let first = catalog
-            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_1, &[])
+            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_1, &[], None)
             .await
             .expect("first fold");
         assert_eq!(
@@ -2964,7 +2986,7 @@ mod tests {
         let now_2 = now_at_seal(13);
         publish_segment(&store, 0, Uuid::new_v4(), 1, 12, now_2 - NS_PER_HOUR).await;
         let second = catalog
-            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_2, &[])
+            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_2, &[], None)
             .await
             .expect("fold falls back to rebuild and restores the missing part");
         assert!(
@@ -3032,7 +3054,7 @@ mod tests {
         .await;
         publish_segment(store.inner(), 0, Uuid::new_v4(), 1, 11, now_1 - NS_PER_HOUR).await;
         let first = catalog
-            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_1, &[])
+            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_1, &[], None)
             .await
             .expect("first fold");
         assert_eq!(first.parts_total, 2);
@@ -3050,7 +3072,7 @@ mod tests {
         let now_2 = now_at_seal(13);
         publish_segment(store.inner(), 0, Uuid::new_v4(), 1, 13, now_2 - NS_PER_HOUR).await;
         let err = catalog
-            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_2, &[])
+            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_2, &[], None)
             .await
             .expect_err("HEAD CAS crash must surface as an error");
         assert!(matches!(err, CatalogError::Store(_)), "got {err:?}");
@@ -3110,7 +3132,7 @@ mod tests {
         .await;
         publish_segment(store.inner(), 0, Uuid::new_v4(), 1, 20, now - NS_PER_HOUR).await;
         let report = catalog
-            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now, &[])
+            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now, &[], None)
             .await
             .expect("fold");
         assert_eq!(report.parts_total, 2);
@@ -3294,7 +3316,7 @@ mod tests {
         let seg_a = publish_segment(&store, 0, writer_a, 1, 10, now_1 - 2 * NS_PER_HOUR).await;
         publish_segment(&store, 0, Uuid::new_v4(), 1, 11, now_1 - NS_PER_HOUR).await;
         let first = catalog
-            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_1, &[])
+            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_1, &[], None)
             .await
             .expect("first fold");
         assert_eq!(first.parts_total, 2);
@@ -3316,7 +3338,7 @@ mod tests {
         // A later fold: the reconcile window covers hour 10 and applies it.
         let now_2 = now_at_seal(13);
         let second = catalog
-            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_2, &[])
+            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_2, &[], None)
             .await
             .expect("second fold");
         assert!(!second.no_op);
@@ -3416,7 +3438,7 @@ mod tests {
         publish_segment(&store, 0, Uuid::new_v4(), 1, 11, now_1 - NS_PER_HOUR).await;
 
         let first = catalog
-            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_1, &[])
+            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_1, &[], None)
             .await
             .expect("first fold");
         assert_eq!(
@@ -3436,6 +3458,7 @@ mod tests {
                 Uuid::new_v4(),
                 now_at_seal(13),
                 &[],
+                None,
             )
             .await
             .expect("reconcile must not fail with DuplicateEntry");
@@ -3469,6 +3492,7 @@ mod tests {
                 Uuid::new_v4(),
                 now_at_seal(14),
                 &[],
+                None,
             )
             .await
             .expect("a third fold must also succeed, not fail forever");
@@ -3494,6 +3518,7 @@ mod tests {
                 Uuid::new_v4(),
                 now_at_seal(40),
                 &[],
+                None,
             )
             .await
             .expect("first fold");
@@ -3510,6 +3535,7 @@ mod tests {
                 Uuid::new_v4(),
                 now_at_seal(41),
                 &[],
+                None,
             )
             .await
             .expect("second fold");
@@ -3545,7 +3571,7 @@ mod tests {
         publish_segment(&store, 0, Uuid::new_v4(), 1, 10, now_1 - 2 * NS_PER_HOUR).await;
         publish_segment(&store, 0, Uuid::new_v4(), 1, 11, now_1 - NS_PER_HOUR).await;
         let first = catalog
-            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_1, &[])
+            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_1, &[], None)
             .await
             .expect("first fold");
         assert_eq!(first.entry_count, 2);
@@ -3560,6 +3586,7 @@ mod tests {
                 Uuid::new_v4(),
                 now_at_seal(13),
                 &[],
+                None,
             )
             .await
             .expect("second fold");
@@ -3637,7 +3664,7 @@ mod tests {
         )
         .await;
         let first = catalog
-            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_1, &[])
+            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_1, &[], None)
             .await
             .expect("first fold");
         assert!(first.rebuilt, "first fold rebuilds from the commit layout");
@@ -3658,6 +3685,7 @@ mod tests {
                 Uuid::new_v4(),
                 now_at_seal(202),
                 &[],
+                None,
             )
             .await
             .expect("second fold");
@@ -3740,6 +3768,7 @@ mod tests {
                 Uuid::new_v4(),
                 now_at_seal(200),
                 &[],
+                None,
             )
             .await
             .expect("first fold");
@@ -3751,6 +3780,7 @@ mod tests {
                 Uuid::new_v4(),
                 now_at_seal(202),
                 &[],
+                None,
             )
             .await
             .expect("second fold");
@@ -3777,6 +3807,137 @@ mod tests {
         }
     }
 
+    /// Run the out-of-window frontier scenario (hour 5 retired far behind an
+    /// hour-200 watermark) with a chosen `TenantConfig.retention_ns` state and a
+    /// chosen deployment default, and return the second fold's
+    /// `frontier_hours_reconciled`. `tenant_config` is `None` to write no config
+    /// record at all, `Some(inner)` to write a record whose `retention_ns` is
+    /// `inner`. `default_retention_ns` is the value the caller (the production
+    /// fold loop) resolves from `RetentionConfig::window_for` and passes into
+    /// `Catalog::fold`; it is passed to both folds, as a real tick would.
+    async fn frontier_reconciled_with(
+        tenant_config: Option<Option<i64>>,
+        default_retention_ns: Option<i64>,
+    ) -> u64 {
+        let store = Arc::new(MemoryStore::new());
+        let cfg = CatalogConfig {
+            shard_count: 1,
+            frontier_reconcile_max_hours: 168,
+            ..Default::default()
+        };
+        let catalog = Catalog::new(store.clone(), cfg).expect("catalog");
+
+        if let Some(inner) = tenant_config {
+            let tc = crate::tenant_config::TenantConfig {
+                retention_ns: inner,
+                ..crate::tenant_config::TenantConfig::new(
+                    crate::tenant_config::TenantLifecycleState::Active,
+                )
+            };
+            crate::tenant_config::set_tenant_config(store.as_ref(), &tenant(), &tc, 1)
+                .await
+                .expect("write tenant config");
+        }
+
+        publish_segment(
+            &store,
+            0,
+            Uuid::new_v4(),
+            1,
+            5,
+            5 * NS_PER_HOUR + 60_000_000_000,
+        )
+        .await;
+        publish_segment(
+            &store,
+            0,
+            Uuid::new_v4(),
+            1,
+            200,
+            200 * NS_PER_HOUR + 60_000_000_000,
+        )
+        .await;
+        catalog
+            .fold(
+                &tenant(),
+                Signal::Metrics,
+                Uuid::new_v4(),
+                now_at_seal(200),
+                &[],
+                default_retention_ns,
+            )
+            .await
+            .expect("first fold");
+
+        publish_tombstone(&store, 0, 5).await;
+
+        let second = catalog
+            .fold(
+                &tenant(),
+                Signal::Metrics,
+                Uuid::new_v4(),
+                now_at_seal(202),
+                &[],
+                default_retention_ns,
+            )
+            .await
+            .expect("second fold");
+        second.frontier_hours_reconciled
+    }
+
+    /// The retention-window overlay (ADR-0078, deliverable 2): the frontier
+    /// reconcile resolves its window as the durable `TenantConfig.retention_ns`
+    /// override when present, else the caller-supplied deployment default. A
+    /// window of 200h retires hour 5 (frontier ~hour 28); a window of 100_000h
+    /// pushes the frontier before the epoch, so `retirement_frontier_hour`
+    /// returns `None` and no frontier reconcile runs. That gap makes each
+    /// precedence branch observable through `frontier_hours_reconciled`.
+    ///
+    /// To watch this FAIL against pre-fix code, restore the old resolution
+    /// (`Ok(None) => None`, `Err(..) => None`, and `Ok(Some(cfg)) =>
+    /// cfg.retention_ns` without `.or(default_retention_ns)`): the two
+    /// deployment-default-only cases below then report 0 reconciled hours.
+    #[tokio::test]
+    async fn retention_overlay_precedence() {
+        const RETIRES: i64 = 200 * NS_PER_HOUR;
+        // A window so large the retirement frontier predates the epoch, so no
+        // frontier pass runs even though a window is set.
+        const NO_FRONTIER: i64 = 100_000 * NS_PER_HOUR;
+
+        // 1. TenantConfig override present wins over the deployment default:
+        //    override retires (200h) while the default would not (NO_FRONTIER).
+        assert!(
+            frontier_reconciled_with(Some(Some(RETIRES)), Some(NO_FRONTIER)).await >= 1,
+            "the TenantConfig override must win over the deployment default"
+        );
+
+        // 2. No TenantConfig record at all: the deployment default applies.
+        assert!(
+            frontier_reconciled_with(None, Some(RETIRES)).await >= 1,
+            "the deployment default must apply when no TenantConfig record exists"
+        );
+
+        // 3. TenantConfig record present but retention_ns is None: the
+        //    deployment default applies (the record does not veto the default).
+        assert!(
+            frontier_reconciled_with(Some(None), Some(RETIRES)).await >= 1,
+            "the deployment default must apply when TenantConfig.retention_ns is None"
+        );
+
+        // 4. Neither a per-tenant override nor a deployment default: no frontier
+        //    reconcile, identical to pre-ADR-0078 behavior.
+        assert_eq!(
+            frontier_reconciled_with(None, None).await,
+            0,
+            "no override and no default means no frontier reconcile"
+        );
+        assert_eq!(
+            frontier_reconciled_with(Some(None), None).await,
+            0,
+            "a None-valued TenantConfig record with no default still means no reconcile"
+        );
+    }
+
     /// A fold whose reconcile window finds nothing changed carries every
     /// untouched sealed part forward by reference: no spurious PUT; the
     /// carry-forward optimization is not regressed by the reconcile pass.
@@ -3794,7 +3955,7 @@ mod tests {
         publish_segment(&store, 0, Uuid::new_v4(), 1, 10, now_1 - 2 * NS_PER_HOUR).await;
         publish_segment(&store, 0, Uuid::new_v4(), 1, 11, now_1 - NS_PER_HOUR).await;
         catalog
-            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_1, &[])
+            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_1, &[], None)
             .await
             .expect("first fold");
 
@@ -3819,6 +3980,7 @@ mod tests {
                 Uuid::new_v4(),
                 now_at_seal(13),
                 &[],
+                None,
             )
             .await
             .expect("second fold");
@@ -3867,7 +4029,7 @@ mod tests {
         let now_1 = now_at_seal(10);
         publish_segment(store.inner(), 0, Uuid::new_v4(), 1, 10, now_1 - NS_PER_HOUR).await;
         let first = catalog
-            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_1, &[])
+            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_1, &[], None)
             .await
             .expect("first fold");
         assert!(first.rebuilt);
@@ -3891,7 +4053,7 @@ mod tests {
         let now_2 = now_at_seal(12);
         publish_segment(store.inner(), 0, Uuid::new_v4(), 1, 12, now_2 - NS_PER_HOUR).await;
         let second = catalog
-            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_2, &[])
+            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_2, &[], None)
             .await
             .expect("second fold");
         assert!(second.rebuilt);
@@ -3931,7 +4093,7 @@ mod tests {
             publish_segment(store.inner(), 0, writer_a, 1, 10, now_1 - 2 * NS_PER_HOUR).await;
         publish_segment(store.inner(), 0, Uuid::new_v4(), 1, 11, now_1 - NS_PER_HOUR).await;
         catalog
-            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_1, &[])
+            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_1, &[], None)
             .await
             .expect("first fold");
 
@@ -3944,6 +4106,7 @@ mod tests {
                 Uuid::new_v4(),
                 now_at_seal(13),
                 &[],
+                None,
             )
             .await
             .expect("second fold applies reconcile under one HEAD CAS");

--- a/crates/ravel-catalog/src/seal_divergence.rs
+++ b/crates/ravel-catalog/src/seal_divergence.rs
@@ -332,7 +332,14 @@ mod tests {
         .expect("catalog")
         .with_provisioning_enforcement();
         catalog
-            .fold(&tenant_hash, Signal::Metrics, Uuid::new_v4(), now_ns, &[])
+            .fold(
+                &tenant_hash,
+                Signal::Metrics,
+                Uuid::new_v4(),
+                now_ns,
+                &[],
+                None,
+            )
             .await
             .expect("fold");
     }

--- a/crates/ravel-catalog/tests/erasure_resolution.rs
+++ b/crates/ravel-catalog/tests/erasure_resolution.rs
@@ -617,7 +617,7 @@ async fn fold_recognizes_rewrite_records_and_matches_resolve() {
     assert_eq!(before.segments.len(), 1);
 
     let report = catalog
-        .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now, &[])
+        .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now, &[], None)
         .await
         .expect("fold");
     assert_eq!(report.watermark_hour, Some(HOUR));
@@ -682,7 +682,7 @@ async fn reconcile_picks_up_a_rewrite_published_into_an_already_folded_bucket() 
 
     let now_1 = now_at_seal(HOUR + 1);
     let first = catalog
-        .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_1, &[])
+        .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_1, &[], None)
         .await
         .expect("first fold");
     assert_eq!(first.watermark_hour, Some(HOUR + 1));
@@ -721,7 +721,7 @@ async fn reconcile_picks_up_a_rewrite_published_into_an_already_folded_bucket() 
     // the rewrite.
     let now_2 = now_at_seal(HOUR + 3);
     let second = catalog
-        .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_2, &[])
+        .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_2, &[], None)
         .await
         .expect("second fold");
     assert!(
@@ -1033,7 +1033,7 @@ async fn reconciled_rewrite_part_resolves_to_the_real_part_key() {
 
     let now_1 = now_at_seal(HOUR + 1);
     catalog
-        .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_1, &[])
+        .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_1, &[], None)
         .await
         .expect("first fold");
 
@@ -1050,7 +1050,7 @@ async fn reconciled_rewrite_part_resolves_to_the_real_part_key() {
 
     let now_2 = now_at_seal(HOUR + 3);
     let second = catalog
-        .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_2, &[])
+        .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_2, &[], None)
         .await
         .expect("second fold");
     assert!(!second.rebuilt);
@@ -1115,7 +1115,7 @@ async fn sibling_rewrites_alarm_on_the_folded_snapshot_path_too() {
 
     let now_1 = now_at_seal(HOUR + 1);
     catalog
-        .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_1, &[])
+        .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_1, &[], None)
         .await
         .expect("first fold");
 
@@ -1143,7 +1143,7 @@ async fn sibling_rewrites_alarm_on_the_folded_snapshot_path_too() {
 
     let now_2 = now_at_seal(HOUR + 3);
     catalog
-        .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_2, &[])
+        .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_2, &[], None)
         .await
         .expect("second fold");
 

--- a/crates/ravel-catalog/tests/fold_compaction_differential.rs
+++ b/crates/ravel-catalog/tests/fold_compaction_differential.rs
@@ -313,7 +313,7 @@ async fn fold_then_resolve_matches_direct_listing_with_compaction_and_tombstone(
     // Fold, then resolve from the snapshot through a store that counts LISTs.
     let fold_catalog = Catalog::new(inner.clone(), config(1)).expect("catalog");
     let report = fold_catalog
-        .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now, &[])
+        .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now, &[], None)
         .await
         .expect("fold");
     assert!(!report.no_op);

--- a/crates/ravel-catalog/tests/postings_exactness.rs
+++ b/crates/ravel-catalog/tests/postings_exactness.rs
@@ -242,7 +242,14 @@ async fn postings_match_brute_force_scan_across_v1_and_v2_segments() {
     .await;
 
     let report = catalog
-        .fold(&tenant_hash, Signal::Metrics, Uuid::new_v4(), now, &[])
+        .fold(
+            &tenant_hash,
+            Signal::Metrics,
+            Uuid::new_v4(),
+            now,
+            &[],
+            None,
+        )
         .await
         .expect("fold");
     assert!(!report.no_op);

--- a/crates/ravel-catalog/tests/postings_get_gating.rs
+++ b/crates/ravel-catalog/tests/postings_get_gating.rs
@@ -222,7 +222,14 @@ async fn postings_get_is_skipped_without_a_name_filter_and_issued_with_one() {
 
     let fold_catalog = Catalog::new(inner.clone(), config(1)).expect("catalog");
     let report = fold_catalog
-        .fold(&tenant_hash, Signal::Metrics, Uuid::new_v4(), now_ns, &[])
+        .fold(
+            &tenant_hash,
+            Signal::Metrics,
+            Uuid::new_v4(),
+            now_ns,
+            &[],
+            None,
+        )
         .await
         .expect("fold");
     assert!(

--- a/crates/ravel-catalog/tests/resharding.rs
+++ b/crates/ravel-catalog/tests/resharding.rs
@@ -254,6 +254,7 @@ async fn fold_records_ceiling_and_generation_count() {
             Uuid::new_v4(),
             now_at_seal(watermark),
             &[],
+            None,
         )
         .await
         .expect("fold");
@@ -305,6 +306,7 @@ async fn pre_reshard_head_is_accepted_after_a_later_reshard() {
             Uuid::new_v4(),
             now_at_seal(folded_hour),
             &[],
+            None,
         )
         .await
         .expect("fold under a single generation");

--- a/crates/ravel-catalog/tests/snapshot_resolve.rs
+++ b/crates/ravel-catalog/tests/snapshot_resolve.rs
@@ -242,7 +242,7 @@ proptest! {
 
             let fold_catalog = Catalog::new(store.clone(), config(3)).expect("catalog");
             fold_catalog
-                .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_ns, &[])
+                .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_ns, &[], None)
                 .await
                 .expect("fold");
 
@@ -287,7 +287,14 @@ async fn snapshot_watermark_serves_sealed_hours_without_listing() {
 
     let fold_catalog = Catalog::new(inner.clone(), config(1)).expect("catalog");
     let report = fold_catalog
-        .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_ns, &[])
+        .fold(
+            &tenant(),
+            Signal::Metrics,
+            Uuid::new_v4(),
+            now_ns,
+            &[],
+            None,
+        )
         .await
         .expect("fold");
     assert_eq!(report.watermark_hour, Some(base_hour + 1));
@@ -336,7 +343,14 @@ async fn hours_above_watermark_are_listed_not_snapshot_served() {
 
     let fold_catalog = Catalog::new(inner.clone(), config(1)).expect("catalog");
     fold_catalog
-        .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_ns, &[])
+        .fold(
+            &tenant(),
+            Signal::Metrics,
+            Uuid::new_v4(),
+            now_ns,
+            &[],
+            None,
+        )
         .await
         .expect("fold");
 
@@ -420,7 +434,14 @@ async fn corrupt_head_falls_back_to_full_listing() {
 
     let fold_catalog = Catalog::new(store.clone(), config(1)).expect("catalog");
     fold_catalog
-        .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_ns, &[])
+        .fold(
+            &tenant(),
+            Signal::Metrics,
+            Uuid::new_v4(),
+            now_ns,
+            &[],
+            None,
+        )
         .await
         .expect("fold");
 
@@ -463,7 +484,14 @@ async fn corrupt_part_falls_back_to_full_listing() {
 
     let fold_catalog = Catalog::new(store.clone(), config(1)).expect("catalog");
     fold_catalog
-        .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_ns, &[])
+        .fold(
+            &tenant(),
+            Signal::Metrics,
+            Uuid::new_v4(),
+            now_ns,
+            &[],
+            None,
+        )
         .await
         .expect("first fold never reads an existing part");
 
@@ -502,7 +530,14 @@ async fn part_notfound_race_recovers_after_one_head_reread() {
 
     let fold_catalog = Catalog::new(store.clone(), config(1)).expect("catalog");
     fold_catalog
-        .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_ns, &[])
+        .fold(
+            &tenant(),
+            Signal::Metrics,
+            Uuid::new_v4(),
+            now_ns,
+            &[],
+            None,
+        )
         .await
         .expect("first fold");
 
@@ -546,7 +581,14 @@ async fn second_part_notfound_after_head_reread_gives_up_without_further_retry()
 
     let fold_catalog = Catalog::new(store.clone(), config(1)).expect("catalog");
     fold_catalog
-        .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_ns, &[])
+        .fold(
+            &tenant(),
+            Signal::Metrics,
+            Uuid::new_v4(),
+            now_ns,
+            &[],
+            None,
+        )
         .await
         .expect("first fold");
 
@@ -581,7 +623,14 @@ async fn shard_count_mismatch_against_snapshot_head_is_a_loud_error() {
 
     let fold_catalog = Catalog::new(store.clone(), config(1)).expect("catalog");
     fold_catalog
-        .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_ns, &[])
+        .fold(
+            &tenant(),
+            Signal::Metrics,
+            Uuid::new_v4(),
+            now_ns,
+            &[],
+            None,
+        )
         .await
         .expect("fold");
 
@@ -630,7 +679,7 @@ async fn stale_head_cache_widens_listed_suffix_but_stays_correct() {
     let (counting, log) = CountingStore::new(inner.clone());
     let catalog = Catalog::new(counting, config(1)).expect("catalog");
     catalog
-        .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_1, &[])
+        .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now_1, &[], None)
         .await
         .expect("first fold seals base_hour");
 
@@ -662,6 +711,7 @@ async fn stale_head_cache_widens_listed_suffix_but_stays_correct() {
             Uuid::new_v4(),
             now_at_seal(base_hour + 1),
             &[],
+            None,
         )
         .await
         .expect("second fold advances the watermark in the store to base_hour + 1");

--- a/crates/ravel-failure-tests/tests/folder_crash_matrix.rs
+++ b/crates/ravel-failure-tests/tests/folder_crash_matrix.rs
@@ -119,7 +119,14 @@ async fn folder_down_for_hours_never_loses_data_only_widens_listing() {
 
     let folder = folder_catalog(Arc::clone(&store));
     folder
-        .fold(&tid.hash(), Signal::Metrics, Uuid::new_v4(), now_ns, &[])
+        .fold(
+            &tid.hash(),
+            Signal::Metrics,
+            Uuid::new_v4(),
+            now_ns,
+            &[],
+            None,
+        )
         .await
         .expect("fold catches up in one shot");
 
@@ -178,7 +185,14 @@ async fn corrupt_head_falls_back_to_listing_never_to_an_error() {
 
     let now_ns = now_sealing(hour);
     folder_catalog(Arc::clone(&store))
-        .fold(&tid.hash(), Signal::Metrics, Uuid::new_v4(), now_ns, &[])
+        .fold(
+            &tid.hash(),
+            Signal::Metrics,
+            Uuid::new_v4(),
+            now_ns,
+            &[],
+            None,
+        )
         .await
         .expect("fold seals hour 10");
 
@@ -234,7 +248,14 @@ async fn missing_snapshot_part_falls_back_to_listing_after_one_head_reread() {
 
     let now_ns = now_sealing(hour);
     folder_catalog(Arc::clone(&store))
-        .fold(&tid.hash(), Signal::Metrics, Uuid::new_v4(), now_ns, &[])
+        .fold(
+            &tid.hash(),
+            Signal::Metrics,
+            Uuid::new_v4(),
+            now_ns,
+            &[],
+            None,
+        )
         .await
         .expect("fold seals hour 10");
 
@@ -297,8 +318,22 @@ async fn concurrent_folders_race_head_cas_without_losing_or_duplicating_data() {
     let folder_b = folder_catalog(Arc::clone(&store));
     let tenant_hash = tid.hash();
     let (result_a, result_b) = tokio::join!(
-        folder_a.fold(&tenant_hash, Signal::Metrics, Uuid::new_v4(), now_ns, &[]),
-        folder_b.fold(&tenant_hash, Signal::Metrics, Uuid::new_v4(), now_ns, &[]),
+        folder_a.fold(
+            &tenant_hash,
+            Signal::Metrics,
+            Uuid::new_v4(),
+            now_ns,
+            &[],
+            None
+        ),
+        folder_b.fold(
+            &tenant_hash,
+            Signal::Metrics,
+            Uuid::new_v4(),
+            now_ns,
+            &[],
+            None
+        ),
     );
     result_a.expect("folder a's fold");
     result_b.expect("folder b's fold");
@@ -358,7 +393,14 @@ async fn stale_head_cache_widens_listing_but_never_misses_new_data() {
 
     let now_1 = now_sealing(hour_a);
     folder_catalog(Arc::clone(&store))
-        .fold(&tid.hash(), Signal::Metrics, Uuid::new_v4(), now_1, &[])
+        .fold(
+            &tid.hash(),
+            Signal::Metrics,
+            Uuid::new_v4(),
+            now_1,
+            &[],
+            None,
+        )
         .await
         .expect("first fold seals hour_a");
 
@@ -414,6 +456,7 @@ async fn stale_head_cache_widens_listing_but_never_misses_new_data() {
             Uuid::new_v4(),
             now_sealing(hour_b),
             &[],
+            None,
         )
         .await
         .expect("second fold advances the real HEAD past hour_b");
@@ -477,7 +520,14 @@ async fn commit_in_wrongly_sealed_bucket_is_invisible_until_head_rebuild_repairs
 
     let now_1 = now_sealing(hour);
     folder_catalog(Arc::clone(&store))
-        .fold(&tid.hash(), Signal::Metrics, Uuid::new_v4(), now_1, &[])
+        .fold(
+            &tid.hash(),
+            Signal::Metrics,
+            Uuid::new_v4(),
+            now_1,
+            &[],
+            None,
+        )
         .await
         .expect("fold seals hour 10 with only the on-time sample");
 
@@ -560,7 +610,14 @@ async fn commit_in_wrongly_sealed_bucket_is_invisible_until_head_rebuild_repairs
         .await
         .expect("delete HEAD to force a rebuild");
     folder_catalog(Arc::clone(&store))
-        .fold(&tid.hash(), Signal::Metrics, Uuid::new_v4(), now_1, &[])
+        .fold(
+            &tid.hash(),
+            Signal::Metrics,
+            Uuid::new_v4(),
+            now_1,
+            &[],
+            None,
+        )
         .await
         .expect("rebuild fold after HEAD deletion");
 

--- a/crates/ravel-maintain/tests/retention.rs
+++ b/crates/ravel-maintain/tests/retention.rs
@@ -595,8 +595,16 @@ fn head_key(signal: Signal) -> String {
 
 /// Fold the seeded commit layout into a catalog HEAD naming the seeded
 /// bucket's segments. `shard_count = SHARD + 1` so the fold's scan set covers
-/// the fixture shard `SHARD`.
-async fn fold_head(store: &Arc<MemoryStore>, signal: Signal, now_ns: i64) {
+/// the fixture shard `SHARD`. `default_retention_ns` is the caller-resolved
+/// deployment-wide retention default (from `RetentionConfig::window_for`) the
+/// production fold loop passes into `Catalog::fold`; `None` for the tests that
+/// rely on the durable `TenantConfig.retention_ns` override instead.
+async fn fold_head(
+    store: &Arc<MemoryStore>,
+    signal: Signal,
+    now_ns: i64,
+    default_retention_ns: Option<i64>,
+) {
     let dyn_store: Arc<dyn ObjectStoreBackend> = store.clone();
     let catalog = ravel_catalog::Catalog::new(
         dyn_store,
@@ -607,7 +615,14 @@ async fn fold_head(store: &Arc<MemoryStore>, signal: Signal, now_ns: i64) {
     )
     .expect("catalog");
     catalog
-        .fold(&tenant_hash(), signal, Uuid::new_v4(), now_ns, &[])
+        .fold(
+            &tenant_hash(),
+            signal,
+            Uuid::new_v4(),
+            now_ns,
+            &[],
+            default_retention_ns,
+        )
         .await
         .expect("fold builds a HEAD naming the seeded bucket");
 }
@@ -639,7 +654,7 @@ async fn sweep_blocked_when_head_names_bucket() {
     let config = cfg();
 
     // A HEAD naming the bucket's segments.
-    fold_head(&store, Signal::Metrics, created).await;
+    fold_head(&store, Signal::Metrics, created, None).await;
     assert!(store.head(&head_key(Signal::Metrics)).await.is_ok());
 
     let retention = retention_at_floor(&config);
@@ -804,7 +819,7 @@ async fn sweep_respects_pre_fold_head_then_deletes_after_fold_drops_bucket() {
     let config = cfg();
 
     // Pre-fold HEAD names the bucket.
-    fold_head(&store, Signal::Metrics, created).await;
+    fold_head(&store, Signal::Metrics, created, None).await;
     let retention = retention_at_floor(&config);
     retention_sweep_bucket(
         store.as_ref(),
@@ -840,7 +855,7 @@ async fn sweep_respects_pre_fold_head_then_deletes_after_fold_drops_bucket() {
     );
 
     // The fold completes and drops the tombstoned bucket from the snapshot.
-    fold_head(&store, Signal::Metrics, clock.now_ns()).await;
+    fold_head(&store, Signal::Metrics, clock.now_ns(), None).await;
 
     // Ordering B: the sweep's gate now reads the post-fold HEAD (bucket
     // dropped) -> proceeds and deletes.
@@ -935,7 +950,7 @@ async fn retention_of_out_of_window_hour_never_leaves_snapshot_naming_deleted_ob
     let old_bucket = bucket_at(old_hour);
 
     // 1. Fold: the snapshot names both hours.
-    fold_head(&store, Signal::Metrics, created).await;
+    fold_head(&store, Signal::Metrics, created, None).await;
 
     // 2. Retire the old hour (tombstone written far behind the watermark).
     let tombstoned = retention_sweep_bucket(
@@ -954,7 +969,7 @@ async fn retention_of_out_of_window_hour_never_leaves_snapshot_naming_deleted_ob
     //    reconcile pass runs (a fold at the same instant seals no new hour and
     //    is a no-op): the retention-frontier reconcile observes the
     //    out-of-window tombstone and drops the old hour from the snapshot.
-    fold_head(&store, Signal::Metrics, created + 3 * NS_PER_HOUR).await;
+    fold_head(&store, Signal::Metrics, created + 3 * NS_PER_HOUR, None).await;
 
     // 4. Past the protection horizon, run the sweep to completion.
     clock.set(created + config.protection_horizon_ns + 1);
@@ -1026,6 +1041,192 @@ async fn retention_of_out_of_window_hour_never_leaves_snapshot_naming_deleted_ob
     }
 }
 
+/// ADR-0078 acceptance test: a deployment configured with ONLY a
+/// `RetentionConfig` deployment default (the CLI-flag path: `--retention-default`
+/// / `--retention-tenant`) and NO durable `TenantConfig.retention_ns` write must
+/// still get the fold's retention-frontier reconcile pass, so the physical sweep
+/// completes the delete. This is the exact gap #134 closes: before the fix, the
+/// fold read only `TenantConfig.retention_ns` (never written by the running
+/// server), so `tenant_retention_ns` was always `None`, the frontier reconcile
+/// never ran, HEAD kept naming the retired hour, and the sweep stayed blocked
+/// forever.
+///
+/// It mirrors `retention_of_out_of_window_hour_never_leaves_snapshot_naming_
+/// deleted_objects` and drives retention through the real `Catalog::fold`
+/// (via `fold_head`) and the real `retention_sweep_bucket`, but resolves the
+/// window from the same `RetentionConfig::window_for` the production fold loop
+/// uses (`services/ravel-server/src/fold.rs`) and passes it as the new
+/// deployment-default parameter -- with no `write_tenant_retention` call at all.
+///
+/// To watch this FAIL against pre-fix code, restore the old resolution in
+/// `crates/ravel-catalog/src/fold.rs` (`Ok(None) => None` and the `Err` arm
+/// returning `None`, ignoring `default_retention_ns`): with no TenantConfig
+/// record present, `tenant_retention_ns` is `None`, the frontier reconcile is
+/// skipped, the old hour is never dropped from the snapshot, the sweep stays
+/// `BlockedBySnapshot`, and the final `RetentionOutcome::Swept` assertion fails.
+#[tokio::test]
+async fn deployment_default_retention_drives_frontier_reconcile_and_sweep() {
+    let store = Arc::new(MemoryStore::new());
+    let config = cfg();
+
+    // Same two-hour layout as the TenantConfig-driven e2e: an old hour far
+    // behind the watermark (outside the fixed 26h reconcile window) that
+    // retention retires, and a recent hour at the watermark that survives.
+    let recent_hour = HOUR;
+    let old_hour = HOUR - 100;
+
+    seed_input(
+        store.as_ref(),
+        &InputSpec::new_at(
+            old_hour,
+            Uuid::from_u128(0xA1),
+            1,
+            1,
+            vec![raw_series(
+                "m",
+                &[("k", "old")],
+                &[(i64::from(old_hour) * NS_PER_HOUR + 1_000, 1.0)],
+            )],
+        ),
+    )
+    .await;
+    seed_input(
+        store.as_ref(),
+        &InputSpec::new_at(
+            recent_hour,
+            Uuid::from_u128(0xB2),
+            1,
+            1,
+            vec![raw_series(
+                "m",
+                &[("k", "recent")],
+                &[(i64::from(recent_hour) * NS_PER_HOUR + 1_000, 2.0)],
+            )],
+        ),
+    )
+    .await;
+
+    // The ONLY retention source: a deployment-wide default (the CLI
+    // `--retention-default` path). No `write_tenant_retention` / TenantConfig
+    // record is written, so the fold's frontier reconcile can only run if it
+    // honors this deployment default (the #134 fix).
+    let retention_window_ns = 90 * NS_PER_HOUR;
+    let retention = RetentionConfig::from_policy(
+        RetentionPolicy {
+            default: Some(retention_window_ns),
+            tenants: vec![],
+        },
+        &config,
+        DEFAULT_MAX_INGEST_LAG_NS,
+    )
+    .expect("retention config");
+    // The value the production fold loop resolves per tenant and hands to
+    // `Catalog::fold` as its new deployment-default parameter.
+    let default_retention_ns = retention.window_for(&tenant_hash());
+    assert_eq!(default_retention_ns, Some(retention_window_ns));
+
+    let created = sealed_now_ns();
+    let clock = FixedClock::new(created);
+    let old_bucket = bucket_at(old_hour);
+
+    // 1. Fold: the snapshot names both hours.
+    fold_head(&store, Signal::Metrics, created, default_retention_ns).await;
+
+    // 2. Retire the old hour (tombstone written far behind the watermark).
+    let tombstoned = retention_sweep_bucket(
+        store.as_ref(),
+        &clock,
+        &config,
+        &retention,
+        &NoLeases,
+        &old_bucket,
+    )
+    .await
+    .expect("tombstone");
+    assert_eq!(tombstoned, RetentionOutcome::Tombstoned);
+
+    // 3. Fold again a few hours later so the watermark advances and the
+    //    reconcile pass runs. With the fix, the frontier reconcile derived from
+    //    the deployment default observes the out-of-window tombstone and drops
+    //    the old hour from the snapshot.
+    fold_head(
+        &store,
+        Signal::Metrics,
+        created + 3 * NS_PER_HOUR,
+        default_retention_ns,
+    )
+    .await;
+
+    // 4. Past the protection horizon, run the sweep to completion. It can only
+    //    reach `Swept` if step 3 dropped the old hour from the HEAD snapshot.
+    clock.set(created + config.protection_horizon_ns + 1);
+    let mut outcome = RetentionOutcome::Tombstoned;
+    for _ in 0..8 {
+        outcome = retention_sweep_bucket(
+            store.as_ref(),
+            &clock,
+            &config,
+            &retention,
+            &NoLeases,
+            &old_bucket,
+        )
+        .await
+        .expect("sweep pass");
+        if outcome == RetentionOutcome::Swept {
+            break;
+        }
+    }
+    assert_eq!(
+        outcome,
+        RetentionOutcome::Swept,
+        "with only a RetentionConfig deployment default (no TenantConfig write), \
+         the fold's frontier reconcile must still drop the retired hour so the \
+         sweep completes -- this is the #134 fix"
+    );
+    assert!(bucket_is_empty(store.as_ref(), &old_bucket).await);
+
+    // 5. A resolve spanning the retired hour never names a deleted object and
+    //    excludes the retired hour, while the recent hour stays resolvable.
+    let resolver = ravel_catalog::Catalog::new(
+        {
+            let s: Arc<dyn ObjectStoreBackend> = store.clone();
+            s
+        },
+        ravel_catalog::CatalogConfig {
+            shard_count: SHARD + 1,
+            ..Default::default()
+        },
+    )
+    .expect("resolver catalog");
+    let range = TimeRange {
+        start_ns: i64::from(old_hour) * NS_PER_HOUR,
+        end_ns: (i64::from(recent_hour) + 1) * NS_PER_HOUR,
+    };
+    let snapshot = resolver
+        .resolve(&tenant_hash(), Signal::Metrics, range, &[], clock.now_ns())
+        .await
+        .expect("resolve must never return a 5xx-shaped error for the retired range");
+    for seg in &snapshot.segments {
+        assert_ne!(
+            seg.ingest_hour_bucket, old_hour,
+            "the retired hour must not be named by any resolved segment"
+        );
+        assert!(
+            store.head(&seg.data_object_key).await.is_ok(),
+            "a resolved segment names a DELETED object ({}): this is the \
+             SnapshotInvalidated condition the fix must prevent",
+            seg.data_object_key
+        );
+    }
+    assert!(
+        snapshot
+            .segments
+            .iter()
+            .any(|s| s.ingest_hour_bucket == recent_hour),
+        "the surviving recent hour is still resolvable"
+    );
+}
+
 /// Deliverable 5 (counters): the blocked-by-snapshot outcome is observable
 /// through `MaintainReport::blocked_by_snapshot`, driven end to end through the
 /// production `scan_and_maintain` pass over the shard.
@@ -1039,7 +1240,7 @@ async fn scan_reports_blocked_by_snapshot_counter() {
     let retention = retention_at_floor(&config);
 
     // A HEAD naming the bucket: the sweep will block on it.
-    fold_head(&store, Signal::Metrics, created).await;
+    fold_head(&store, Signal::Metrics, created, None).await;
 
     // Pass 1: tombstone the expired bucket.
     let r1 = scan_and_maintain(

--- a/crates/ravel-query/tests/postings_prefix_pruning.rs
+++ b/crates/ravel-query/tests/postings_prefix_pruning.rs
@@ -166,7 +166,7 @@ async fn folded_engine(tid: &TenantId, hour: u32) -> (QueryEngine, i64, i64) {
 
     let catalog = Catalog::new(store.clone(), CatalogConfig::default()).expect("catalog");
     let report = catalog
-        .fold(&th, Signal::Metrics, Uuid::new_v4(), now, &[])
+        .fold(&th, Signal::Metrics, Uuid::new_v4(), now, &[], None)
         .await
         .expect("fold");
     assert!(

--- a/crates/ravel-query/tests/postings_pruning.rs
+++ b/crates/ravel-query/tests/postings_pruning.rs
@@ -201,7 +201,7 @@ async fn pruned_and_bypassed_queries_are_bit_identical_across_formats_and_duplic
 
     let catalog = catalog(store.clone());
     let report = catalog
-        .fold(&th, Signal::Metrics, Uuid::new_v4(), now, &[])
+        .fold(&th, Signal::Metrics, Uuid::new_v4(), now, &[], None)
         .await
         .expect("fold");
     assert!(
@@ -276,7 +276,7 @@ async fn negative_name_matcher_bypasses_pruning() {
 
     let catalog = catalog(store.clone());
     catalog
-        .fold(&th, Signal::Metrics, Uuid::new_v4(), now, &[])
+        .fold(&th, Signal::Metrics, Uuid::new_v4(), now, &[], None)
         .await
         .expect("fold");
 
@@ -339,7 +339,7 @@ async fn absent_name_matcher_bypasses_pruning() {
 
     let catalog = catalog(store.clone());
     catalog
-        .fold(&th, Signal::Metrics, Uuid::new_v4(), now, &[])
+        .fold(&th, Signal::Metrics, Uuid::new_v4(), now, &[], None)
         .await
         .expect("fold");
 
@@ -398,7 +398,7 @@ async fn missing_postings_degrade_to_no_pruning() {
 
     let catalog = catalog(store.clone());
     catalog
-        .fold(&th, Signal::Metrics, Uuid::new_v4(), now, &[])
+        .fold(&th, Signal::Metrics, Uuid::new_v4(), now, &[], None)
         .await
         .expect("fold");
 
@@ -461,7 +461,7 @@ async fn corrupt_postings_degrade_to_no_pruning() {
 
     let catalog = catalog(store.clone());
     catalog
-        .fold(&th, Signal::Metrics, Uuid::new_v4(), now, &[])
+        .fold(&th, Signal::Metrics, Uuid::new_v4(), now, &[], None)
         .await
         .expect("fold");
 
@@ -541,7 +541,7 @@ async fn pruning_rescues_a_query_from_the_segment_budget() {
 
     let catalog = catalog(store.clone());
     catalog
-        .fold(&th, Signal::Metrics, Uuid::new_v4(), now, &[])
+        .fold(&th, Signal::Metrics, Uuid::new_v4(), now, &[], None)
         .await
         .expect("fold");
 

--- a/crates/ravel-query/tests/pruning_bench.rs
+++ b/crates/ravel-query/tests/pruning_bench.rs
@@ -130,7 +130,7 @@ async fn measure_selective_query_before_after() {
 
         let catalog = Catalog::new(store.clone(), CatalogConfig::default()).expect("catalog");
         catalog
-            .fold(&th, Signal::Metrics, Uuid::new_v4(), now, &[])
+            .fold(&th, Signal::Metrics, Uuid::new_v4(), now, &[], None)
             .await
             .expect("fold");
         let engine = QueryEngine::new(Arc::new(catalog), store, EngineConfig::default());

--- a/crates/ravel-query/tests/recent_hours_admission.rs
+++ b/crates/ravel-query/tests/recent_hours_admission.rs
@@ -182,7 +182,7 @@ async fn recent_hours_exempt_from_segment_cap() {
     .await;
 
     let cat = catalog(store.clone());
-    cat.fold(&th, Signal::Metrics, Uuid::new_v4(), now, &[])
+    cat.fold(&th, Signal::Metrics, Uuid::new_v4(), now, &[], None)
         .await
         .expect("fold seals sealed_hour");
 
@@ -297,7 +297,7 @@ async fn sealed_set_still_capped_when_oversized() {
         publish_segment(store.as_ref(), &tid, th, seq, hour, "m", ts, seq as f64).await;
     }
     let cat = catalog(store.clone());
-    cat.fold(&th, Signal::Metrics, Uuid::new_v4(), now, &[])
+    cat.fold(&th, Signal::Metrics, Uuid::new_v4(), now, &[], None)
         .await
         .expect("fold");
 
@@ -390,7 +390,7 @@ async fn exactness_stable_across_fold() {
 
     let cat_a = catalog(store.clone());
     cat_a
-        .fold(&th, Signal::Metrics, Uuid::new_v4(), now1, &[])
+        .fold(&th, Signal::Metrics, Uuid::new_v4(), now1, &[], None)
         .await
         .expect("fold seals sealed_hour only");
     let engine_a = QueryEngine::new(Arc::new(cat_a), store.clone(), config);
@@ -405,7 +405,7 @@ async fn exactness_stable_across_fold() {
     let now2 = now_at_seal(recent_hour);
     let cat_b = catalog(store.clone());
     cat_b
-        .fold(&th, Signal::Metrics, Uuid::new_v4(), now2, &[])
+        .fold(&th, Signal::Metrics, Uuid::new_v4(), now2, &[], None)
         .await
         .expect("fold seals recent_hour too");
     let engine_b = QueryEngine::new(Arc::new(cat_b), store, config);

--- a/crates/ravel-sim/src/driver.rs
+++ b/crates/ravel-sim/src/driver.rs
@@ -1040,6 +1040,7 @@ async fn run_cycle_async(
                 fold_rng.new_uuid(),
                 fold_now_ns,
                 &[],
+                None,
             )
             .await
             .map_err(|source| CycleError::Fold { seed, source })?;
@@ -1136,6 +1137,7 @@ async fn run_cycle_async(
                 fold_rng.new_uuid(),
                 compact_now_ns,
                 &[],
+                None,
             )
             .await
             .map_err(|source| CycleError::Fold { seed, source })?;

--- a/crates/ravel-sim/tests/fold_makes_resolve_list_free.rs
+++ b/crates/ravel-sim/tests/fold_makes_resolve_list_free.rs
@@ -243,6 +243,7 @@ fn fold_makes_resolve_list_free() {
                 Uuid::new_v4(),
                 fold_now_ns,
                 &[],
+                None,
             )
             .await
             .expect("fold");

--- a/crates/ravel-sql/tests/admission_parity.rs
+++ b/crates/ravel-sql/tests/admission_parity.rs
@@ -157,7 +157,7 @@ async fn sql_and_promql_agree_recent_hours_are_exempt() {
     .await;
 
     let cat = Arc::new(Catalog::new(store.clone(), CatalogConfig::default()).expect("catalog"));
-    cat.fold(&th, Signal::Metrics, Uuid::new_v4(), now, &[])
+    cat.fold(&th, Signal::Metrics, Uuid::new_v4(), now, &[], None)
         .await
         .expect("fold seals sealed_hour");
 
@@ -245,7 +245,7 @@ async fn sql_and_promql_agree_sealed_set_still_capped() {
         publish_segment(store.as_ref(), &tid, th, seq, hour, "m", ts, seq as f64).await;
     }
     let cat = Arc::new(Catalog::new(store.clone(), CatalogConfig::default()).expect("catalog"));
-    cat.fold(&th, Signal::Metrics, Uuid::new_v4(), now, &[])
+    cat.fold(&th, Signal::Metrics, Uuid::new_v4(), now, &[], None)
         .await
         .expect("fold");
 
@@ -404,7 +404,7 @@ async fn no_recent_hour_data_default_config_is_unaffected() {
         .await;
     }
     let cat = Arc::new(Catalog::new(store.clone(), CatalogConfig::default()).expect("catalog"));
-    cat.fold(&th, Signal::Metrics, Uuid::new_v4(), now, &[])
+    cat.fold(&th, Signal::Metrics, Uuid::new_v4(), now, &[], None)
         .await
         .expect("fold seals hour, leaving no recent-hour data");
 

--- a/crates/ravel-sql/tests/sql_postings_prefix_pruning.rs
+++ b/crates/ravel-sql/tests/sql_postings_prefix_pruning.rs
@@ -44,7 +44,14 @@ async fn folded_fixture() -> Fixture {
 
     let report = fixture
         .catalog
-        .fold(&tenant.hash(), Signal::Metrics, Uuid::new_v4(), NOW_NS, &[])
+        .fold(
+            &tenant.hash(),
+            Signal::Metrics,
+            Uuid::new_v4(),
+            NOW_NS,
+            &[],
+            None,
+        )
         .await
         .expect("fold");
     assert!(

--- a/crates/ravel-sql/tests/sql_postings_pruning.rs
+++ b/crates/ravel-sql/tests/sql_postings_pruning.rs
@@ -42,7 +42,14 @@ async fn sql_pushed_down_name_filter_reaches_resolve_pruned() {
     // at NOW_NS (4h) under the default seal margins (~80m).
     let report = fixture
         .catalog
-        .fold(&tenant.hash(), Signal::Metrics, Uuid::new_v4(), NOW_NS, &[])
+        .fold(
+            &tenant.hash(),
+            Signal::Metrics,
+            Uuid::new_v4(),
+            NOW_NS,
+            &[],
+            None,
+        )
         .await
         .expect("fold");
     assert!(

--- a/docs/catalog-and-mvcc.md
+++ b/docs/catalog-and-mvcc.md
@@ -549,10 +549,16 @@ Because a retention tombstone lands `R` behind the watermark, far outside the
 fixed reconcile window, each incremental fold ALSO reconciles the bounded set
 of snapshot-named hours at or approaching the tenant's retirement frontier:
 
-- **Which hours.** The tenant's retention window `R` comes from its durable
-  per-tenant config record (`t/<tenant_hash>/config`, `retention_ns`). A tenant
-  with no per-tenant window gets no frontier reconcile (nothing is being
-  retired). The retirement frontier is the newest ingest hour at or approaching
+- **Which hours.** The tenant's effective retention window `R` is resolved as an
+  override-over-default overlay (ADR-0078), mirroring how ingest resolves
+  admission limits: the durable per-tenant config record
+  (`t/<tenant_hash>/config`, `retention_ns`) when it exists and carries a value,
+  otherwise the deployment-wide default the caller resolves from the CLI-derived
+  `RetentionConfig` (`--retention-default` / `--retention-tenant`) — the same
+  source the physical sweep uses. A `TenantConfig` read failure or an absent
+  record falls back to that deployment default, not to "skip"; only a tenant with
+  neither a per-tenant override nor a deployment default gets no frontier
+  reconcile (nothing is being retired). The retirement frontier is the newest ingest hour at or approaching
   retirement, `frontier_hi = (now - R + protection_horizon) / hour`: retention
   tombstones a bucket once its newest event is older than `R`, so every hour
   whose end is at or before `now - R` may already be tombstoned, and the

--- a/services/ravel-cli/src/catalog.rs
+++ b/services/ravel-cli/src/catalog.rs
@@ -42,7 +42,7 @@ pub async fn fold(
     let now = crate::now_ns()?;
     let folder_id = Uuid::new_v4();
     let report = catalog
-        .fold(&tenant_hash, Signal::Metrics, folder_id, now, &[])
+        .fold(&tenant_hash, Signal::Metrics, folder_id, now, &[], None)
         .await
         .map_err(|err| anyhow::anyhow!("fold failed: {err}"))?;
 

--- a/services/ravel-server/src/exemplars.rs
+++ b/services/ravel-server/src/exemplars.rs
@@ -2292,7 +2292,14 @@ mod tests {
         let fold_catalog =
             Catalog::new(backend, CatalogConfig::default()).expect("catalog for fold");
         fold_catalog
-            .fold(&tenant().hash(), Signal::Metrics, Uuid::new_v4(), NOW, &[])
+            .fold(
+                &tenant().hash(),
+                Signal::Metrics,
+                Uuid::new_v4(),
+                NOW,
+                &[],
+                None,
+            )
             .await
             .expect("fold seals sealed_hour");
 

--- a/services/ravel-server/src/fold.rs
+++ b/services/ravel-server/src/fold.rs
@@ -25,6 +25,7 @@ use std::time::Duration;
 use ravel_catalog::Catalog;
 use ravel_commit::rng::{RngSource, SystemRng};
 use ravel_ingest::{Clock, SystemClock};
+use ravel_maintain::RetentionConfig;
 use ravel_object_store::{GetRange, ObjectStoreBackend};
 use ravel_types::{Signal, TenantHash};
 use tokio::sync::oneshot;
@@ -117,11 +118,21 @@ const FOLD_SIGNALS: [Signal; 3] = [Signal::Metrics, Signal::Logs, Signal::Spans]
 /// carrying a config record is maintained unconditionally, so no flag can
 /// exclude it. Returns immediately; tasks run in the background until
 /// [`FoldTasks::shutdown`].
+///
+/// `retention` is the same CLI-derived [`RetentionConfig`] the Maintain-mode
+/// physical sweep uses (`main.rs`, threaded into `MaintenanceTaskConfig`).
+/// Each tick resolves `retention.window_for(tenant)` per tenant and passes it
+/// into [`Catalog::fold`] as the deployment-default retention window, so the
+/// fold's retention-frontier reconcile runs for a tenant configured only by
+/// CLI flags with no durable `TenantConfig.retention_ns` record (ADR-0078).
+/// An unconfigured `RetentionConfig` resolves to `None` for every tenant, so
+/// this is inert when no retention flag is set.
 pub fn spawn(
     catalog: Arc<Catalog>,
     store: Arc<dyn ObjectStoreBackend>,
     fallback_allow: &[TenantHash],
     config: FoldTaskConfig,
+    retention: Arc<RetentionConfig>,
 ) -> FoldTasks {
     if !config.enabled {
         return FoldTasks::none();
@@ -150,6 +161,7 @@ pub fn spawn(
         let fallback_allow = fallback_allow.clone();
         let interval = config.fold_interval;
         let rng = Arc::clone(&rng);
+        let retention = Arc::clone(&retention);
         let handle = tokio::spawn(async move {
             run_loop(
                 catalog,
@@ -159,6 +171,7 @@ pub fn spawn(
                 folder_id,
                 interval,
                 rng,
+                retention,
                 rx,
             )
             .await;
@@ -178,6 +191,7 @@ async fn run_loop(
     folder_id: Uuid,
     interval: Duration,
     rng: Arc<dyn RngSource>,
+    retention: Arc<RetentionConfig>,
     mut shutdown: oneshot::Receiver<()>,
 ) {
     loop {
@@ -211,6 +225,10 @@ async fn run_loop(
         }
 
         for tenant in outcome.maintained {
+            // The deployment-default retention window for this tenant, resolved
+            // per tick from the CLI-derived RetentionConfig (ADR-0078). The fold
+            // overlays the durable TenantConfig.retention_ns on top of it.
+            let default_retention_ns = retention.window_for(&tenant);
             run_tenant_tick(
                 catalog.as_ref(),
                 store.as_ref(),
@@ -218,6 +236,7 @@ async fn run_loop(
                 signal,
                 folder_id,
                 interval,
+                default_retention_ns,
             )
             .await;
         }
@@ -235,6 +254,7 @@ async fn run_tenant_tick(
     signal: Signal,
     folder_id: Uuid,
     interval: Duration,
+    default_retention_ns: Option<i64>,
 ) {
     let now_ns = SystemClock.now_ns();
     if head_fresh_enough(store, tenant, signal, interval, now_ns).await {
@@ -246,7 +266,10 @@ async fn run_tenant_tick(
         return;
     }
 
-    match catalog.fold(tenant, signal, folder_id, now_ns, &[]).await {
+    match catalog
+        .fold(tenant, signal, folder_id, now_ns, &[], default_retention_ns)
+        .await
+    {
         Ok(report) => {
             tracing::info!(
                 tenant = %tenant.to_hex(),

--- a/services/ravel-server/src/lib.rs
+++ b/services/ravel-server/src/lib.rs
@@ -1270,11 +1270,17 @@ pub async fn start(
         (fold::FoldTasks::none(), maintenance_tasks)
     } else {
         // Background class (ADR-0070): fold is deferred maintenance traffic.
+        // The fold's retention-frontier reconcile shares the same CLI-derived
+        // RetentionConfig the Maintain-mode sweep uses (ADR-0078), so a tenant
+        // configured only by --retention-default/--retention-tenant still gets
+        // frontier-reconciled even with no durable TenantConfig.retention_ns.
+        let fold_retention = Arc::new(config.maintain.retention.clone());
         let fold_tasks = fold::spawn(
             catalog,
             store_background.clone(),
             &config.fold_tenants,
             config.fold,
+            fold_retention,
         );
         (fold_tasks, maintain::MaintenanceTasks::none())
     };

--- a/services/ravel-server/src/scrub.rs
+++ b/services/ravel-server/src/scrub.rs
@@ -1104,6 +1104,7 @@ mod tests {
                 Uuid::new_v4(),
                 now_ns,
                 &[],
+                None,
             )
             .await
             .expect("fold produces a HEAD with postings");

--- a/services/ravel-server/tests/fold_e2e.rs
+++ b/services/ravel-server/tests/fold_e2e.rs
@@ -888,7 +888,7 @@ async fn multi_part_ceiling_crossing_folds_queries_and_compacts() {
 
     // Fold: crosses the ceiling, producing a multi-part HEAD.
     let report_a = folded
-        .fold(&tenant, Signal::Metrics, Uuid::new_v4(), now_a, &[])
+        .fold(&tenant, Signal::Metrics, Uuid::new_v4(), now_a, &[], None)
         .await
         .expect("first fold");
     assert!(!report_a.no_op, "sealed hours must fold");
@@ -986,7 +986,7 @@ async fn multi_part_ceiling_crossing_folds_queries_and_compacts() {
     // Reconcile fold: discovers the late compaction and tombstone within its
     // window and rewrites only the covering sealed parts.
     let report_b = folded
-        .fold(&tenant, Signal::Metrics, Uuid::new_v4(), now_b, &[])
+        .fold(&tenant, Signal::Metrics, Uuid::new_v4(), now_b, &[], None)
         .await
         .expect("reconcile fold");
     assert!(!report_b.no_op, "the watermark advanced, so not a no-op");

--- a/services/ravel-server/tests/recent_hours_reachability_e2e.rs
+++ b/services/ravel-server/tests/recent_hours_reachability_e2e.rs
@@ -394,7 +394,7 @@ async fn post_compaction_bits(
 
     let fold_cat = Catalog::new(store.clone(), CatalogConfig::default()).expect("catalog");
     fold_cat
-        .fold(&th, Signal::Metrics, Uuid::new_v4(), seal_now_ns, &[])
+        .fold(&th, Signal::Metrics, Uuid::new_v4(), seal_now_ns, &[], None)
         .await
         .expect("fold seals the open hour");
 

--- a/services/ravel-server/tests/reshard_e2e.rs
+++ b/services/ravel-server/tests/reshard_e2e.rs
@@ -838,7 +838,7 @@ async fn pre_reshard_snapshot_head_still_validates_after_reshard() {
     let (catalog, _engine) = engine(store.clone(), 4);
     let fold_now = (BASE_HOUR as i64 + 10) * NS_PER_HOUR;
     let report = catalog
-        .fold(&tenant_hash(), SIGNAL, Uuid::new_v4(), fold_now, &[])
+        .fold(&tenant_hash(), SIGNAL, Uuid::new_v4(), fold_now, &[], None)
         .await
         .expect("fold succeeds");
     let watermark = report

--- a/services/ravel-server/tests/scrub_e2e.rs
+++ b/services/ravel-server/tests/scrub_e2e.rs
@@ -332,7 +332,14 @@ async fn seal_divergence_surfaces_on_metrics_through_the_real_scrub_task() {
     .expect("catalog")
     .with_provisioning_enforcement();
     catalog
-        .fold(&tenant.hash(), Signal::Metrics, Uuid::new_v4(), now, &[])
+        .fold(
+            &tenant.hash(),
+            Signal::Metrics,
+            Uuid::new_v4(),
+            now,
+            &[],
+            None,
+        )
         .await
         .expect("fold produces a HEAD");
 
@@ -413,7 +420,14 @@ async fn postings_disagreement_surfaces_on_metrics_through_the_real_scrub_task()
     .expect("catalog")
     .with_provisioning_enforcement();
     catalog
-        .fold(&tenant.hash(), Signal::Metrics, Uuid::new_v4(), now, &[])
+        .fold(
+            &tenant.hash(),
+            Signal::Metrics,
+            Uuid::new_v4(),
+            now,
+            &[],
+            None,
+        )
         .await
         .expect("fold produces a HEAD with postings");
 


### PR DESCRIPTION
Fold's retention-frontier reconcile only ran when a tenant's durable
TenantConfig.retention_ns record was set. Nothing in the running server
ever wrote that record, so a deployment configured only with
--retention-default / --retention-tenant CLI flags never got the
frontier reconcile pass, and the physical sweep stayed permanently
blocked on every expired bucket.

Catalog::fold() now takes a caller-resolved deployment-default retention
window and overlays it under the durable per-tenant override: the
TenantConfig record wins when present, the deployment default applies
otherwise, including when the TenantConfig read fails or is absent. The
background fold loop in ravel-server resolves this default per tenant
per tick from the RetentionConfig already built from CLI flags at
startup, threaded through to fold::spawn.

See docs/adrs/0078-fold-retention-frontier-deployment-default.md for the
full design and rejected alternatives.

Fixes: #134
Refs: #114
