### PR TITLE
Correct stale capability claims in guides and ADR-0043

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ its local disk.
 
 Metrics and logs run end to end today, from OTLP or Remote Write ingest through
 PromQL, SQL, and Flight SQL query. Traces ingest, compact, and retain end to
-end; a query surface over them is not built yet.
+end, and are queryable through the `spans` SQL table on `POST /api/v1/sql`.
 
 ## Run it
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -105,9 +105,11 @@ code, not only to use it.
 - [object-store-contract.md](object-store-contract.md): the
   `ObjectStoreBackend` trait that every storage vendor (memory, S3/MinIO) must
   satisfy, and the durability arguments made against it.
-- [otap-ingest.md](otap-ingest.md): plan for OTAP (OpenTelemetry Arrow)
-  ingest. It describes a feature-gated crate and gateway wiring. It is not yet
-  wired into `ravel-server`.
+- [otap-ingest.md](otap-ingest.md): OTAP (OpenTelemetry Arrow) ingest. The
+  decode stack is a feature-gated crate, linked by `ravel-server`'s `otap`
+  cargo feature, and the service is registered at runtime only when the
+  process is started with `--otap` (ADR-0011). An end-to-end test drives a
+  real OpenTelemetry collector against that endpoint.
 
 ## Decision records
 

--- a/docs/adrs/0043-unified-alerting-engine.md
+++ b/docs/adrs/0043-unified-alerting-engine.md
@@ -123,6 +123,32 @@ evaluator scheduler mirrors, not a new scheduling mechanism.
   same assumption the rest of the system makes about its own
   strict-mode acknowledgement.
 
+  That idempotency assumption is narrower than it reads, so state its
+  limit explicitly. The duplicate suppressor for the repeat pass,
+  `repeat_marks` in `services/ravel-server/src/alerting.rs`, is a
+  process-local map, not a durable record. It is lost whenever the
+  evaluating process changes, which includes a lease handover to
+  another live process, not only a restart. `k` is re-derived from the
+  durable record on every tick, so losing the mark can never cause a
+  silence; it can cause one extra send for the alert's current repeat
+  window.
+
+  What that extra send costs depends on the sink. An Alertmanager sink
+  satisfies the assumption: Alertmanager dedupes on the label set, so
+  the duplicate is absorbed with no operator-visible effect. A plain
+  webhook sink does not: it forwards both POSTs, and a consumer that
+  opens a ticket or pages per POST sees two distinct events. A
+  webhook-shaped sink must therefore dedupe on its own, but nothing in
+  the payload distinguishes the duplicate from an intended repeat: a
+  repeat and its duplicate carry the same `alert_id`, `ts_unix_nano`,
+  and `generation`, and a `null` `previous_state`, because every repeat
+  is built from the same durable record for the whole firing episode.
+  Dedupe on `alert_id` within a window shorter than the rule's
+  `repeat_interval` instead, or set `repeat_interval: 0s` (the
+  amendment's decision 3) to disable repeats for that rule entirely.
+  This ADR does not guarantee exactly-once delivery to a sink that does
+  neither.
+
 ## Consequences
 
 - No new frozen format beyond ADR-0040's `Signal::Alerts` (already
@@ -234,10 +260,13 @@ This amendment gives that mechanism a cadence.
    already emits `startsAt` and omits `endsAt` for a `Firing` record,
    which is exactly the shape of a Prometheus re-send, and Alertmanager
    identity is the label set, so a re-POST simply refreshes its timer.
-   The webhook body shape is also unchanged; a repeat sets
-   `previous_state` equal to `state` (firing to firing is the truthful
-   description of a non-transition send), so an idempotent consumer can
-   discard repeats on one comparison. One documented approximation: a
+   The webhook body shape is also unchanged; a repeat carries a `null`
+   `previous_state` (there is no prior transition to report for a
+   non-transition send), the same shape a fresh bootstrap re-send uses.
+   This means a repeat is not distinguishable from an unintended
+   duplicate by payload alone - see the idempotency-assumption
+   narrowing in "Rejected alternatives" above for what a webhook-shaped
+   sink needs to dedupe on instead. One documented approximation: a
    repeat built from the folded latest record alone reports
    `started_at_ns` as the firing record's `ts_ns`, which for an episode
    with a pending phase is slightly later than the original

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -49,8 +49,8 @@ ravel-types
   <- ravel-analytics    (types only; pure post-evaluation compute stage)
   <- ravel-alerting     (types, logseg; pure rule/condition/state/record
                           logic, no I/O and no scheduler)
-  <- ravel-sql          (query, catalog, types; arrow + datafusion, in
-                          progress -- see below)
+  <- ravel-sql          (query, catalog, types; arrow + datafusion,
+                          shipped -- see below)
   <- services/ravel-server, services/ravel-cli
 ravel-test-util (types, object-store) used by all dev-deps
 ```
@@ -204,7 +204,7 @@ contract is that only a TLS-terminating, header-stripping proxy is network-
 reachable on the mTLS listener's address; the public listeners are safe
 against header forgery by construction, independent of that proxy hygiene.
 
-## SQL query path (in progress)
+## SQL query path
 
 `ravel-sql` (ADR-0013) adds a second query
 path alongside PromQL: `RsegScanExec -> SortPreservingMergeExec ->
@@ -214,13 +214,15 @@ same total order as `is_greater` in `ravel-query` (bit-for-bit, including
 the `value.to_bits()` tiebreak). Arrow and DataFusion stay isolated to this
 crate; PromQL numerics never lower to SQL, and vice versa.
 
-Status: the scan/merge/dedup pipeline and predicate/projection pushdown
-under a pruning-soundness invariant (pruning may only ever widen the read
-set, never narrow it) are implemented and tested against an independent
-oracle. Not yet built: the HTTP endpoint (`POST /api/v1/sql`, feature
-`sql`) and Flight SQL (feature `flight-sql`) -- both follow-up work, gated
-behind cargo features so the default build stays free of Arrow and DataFusion
-outside `ravel-otap`.
+Status: shipped. The scan/merge/dedup pipeline and predicate/projection
+pushdown under a pruning-soundness invariant (pruning may only ever widen
+the read set, never narrow it) are implemented and tested against an
+independent oracle. Both transports are served too: the HTTP endpoint
+(`POST /api/v1/sql`, feature `sql`) on `--listen-http`, and Flight SQL
+(feature `flight-sql`) on `--listen-grpc`, as the Listener topology section
+above lists. Both stay behind cargo features, off by default, so the default
+build stays free of Arrow and DataFusion outside `ravel-otap`; a build that
+does not enable them serves neither surface.
 
 ## Distributed reads and cross-cluster federation (ADR-0071)
 

--- a/docs/guides/caching.md
+++ b/docs/guides/caching.md
@@ -25,10 +25,13 @@ metric path. SQL queries over the `logs` table use the log path.
 
 Two query surfaces do not use the cache today:
 
-- **Spans (traces).** There is no SQL query surface over spans yet (see
-  the main [README](../../README.md#whats-next)). When that surface
-  lands, it will need its own cache wiring; the trace fetcher has none
-  yet.
+- **Spans (traces).** The `spans` SQL table is queryable on
+  `POST /api/v1/sql`, but its reads are uncached. The span scan fetches
+  each RSPAN segment straight from the object store on every query: the
+  fetch is accounted and tenant-checked, and the tenant identity the log
+  path uses to key its cache entries serves only as that tenant check
+  here. A repeated span query therefore re-reads the same objects. Wiring
+  spans into this cache is still open work.
 - **The `alerts` and `audit` SQL tables.** These tables exist in
   `ravel-sql`, but nothing in production reaches them through a real SQL
   query today, so they have no cached read path to speak of.
@@ -134,6 +137,8 @@ bytes_admitted)`. Filter by the `cache` label for one cache's rate, or omit it
   as a crate, but the query fetchers only accept a RAM cache today. Until
   that attachment point is added, `--cache-dir` fails startup instead of
   silently doing nothing.
-- **Spans have no cache path**, because spans have no query surface yet.
+- **Spans have no cache path**, because span reads are not wired into the
+  cache layer yet: the `spans` SQL table's fetcher has no `with_cache`
+  seam, unlike the RSEG/RLOG fetchers.
 - **The `alerts` and `audit` SQL tables are not reachable in
   production**, so caching them is not meaningful yet.

--- a/docs/guides/inspecting-data.md
+++ b/docs/guides/inspecting-data.md
@@ -26,7 +26,11 @@ t/<tenant_hash>/m/c/<shard>/<ingest_hour>/<writer_id>.<epoch>.<seq>.cmt commit r
 ```
 
 `tenant_hash` is BLAKE3 of the tenant name, hex-encoded. `m` is the signal
-(metrics; logs and spans would be `l`/`s`, not implemented yet). `shard` is
+letter for metrics; logs use `l` and spans use `s`, and all three are
+implemented. Logs have their own RLOG object format and an `rlog inspect`
+walkthrough further down this guide; spans have the RSPAN format
+([span-segment-format.md](../span-segment-format.md), ADR-0041) and a SQL
+query path over the `spans` table. `shard` is
 the ingest shard, zero-padded to 4 digits. `ingest_hour` is the UTC hour the
 commit landed in (`YYYYMMDDTHH`). This lets the catalog find recent
 commits by listing a small, bounded set of prefixes instead of the whole
@@ -169,10 +173,11 @@ Field by field:
 Log data lives in RLOG objects (`.rlog`), the columnar log segment format
 (docs/log-segment-format.md, ADR-0029; trailer version 2, ADR-0032). RLOG is
 a sibling of RSEG. It shares the same 16-byte trailer, protobuf footer, and
-crc32c discipline, but it has its own sections and none of the bytes. As of
-log storage phase 1, the format crate (`ravel-logseg`) ships on its own.
-Ingest, query, and lifecycle are later phases. Today the writer produces an
-RLOG object directly (in tests and tooling), not the ingest path. The
+crc32c discipline, but it has its own sections and none of the bytes. Ingest, query, and lifecycle all run today: the production ingest path writes
+RLOG objects through `ravel-ingest`'s log shard, the `logs` SQL table on
+`POST /api/v1/sql` reads them back, and `ravel-maintain` compacts and retains
+them. The walkthrough below drives the writer directly (in tests and
+tooling), not through the ingest path, to show the format in isolation. The
 command is:
 
 ```sh

--- a/docs/guides/query.md
+++ b/docs/guides/query.md
@@ -231,13 +231,14 @@ limit is on the query's *start*: a narrow `start`/`end` pair costs little
 however recent it is, so the fix is always to move `start` forward, never to
 change `end`.
 
-## SQL over the `logs` table
+## SQL over `samples`, `logs`, and `spans`
 
-`POST /api/v1/sql` (see README "SQL") serves two tables from one endpoint:
-`samples` (metrics) and `logs`. The server parses the query's `FROM` clause
-before it plans, and registers only that one table for the query. A single
-query may reference one table or the other, never both; a query that names
-both gets an HTTP 400. The request body, auth, window
+`POST /api/v1/sql` (see README "SQL") serves three tables from one endpoint:
+`samples` (metrics), `logs`, and `spans`. The server parses the query's `FROM`
+clause before it plans, and registers only that one table for the query. A
+single query may reference exactly one of the three; naming two or more of
+them crosses signals and is rejected with an HTTP 400, before any catalog
+listing. The request body, auth, window
 (`start`/`end`), and `min_commit_token` handling are identical to the `samples`
 case.
 
@@ -300,8 +301,10 @@ one, for any window a retry may have touched. The `x-ravel-idempotency-key`
 suppresses this for keyed sequential retries; unkeyed ingest gets plain
 at-least-once. See
 [consistency-model.md](../consistency-model.md#duplicates-and-idempotency)
-for the full contract. The same applies to spans once a span query surface
-lands.
+for the full contract. The same applies to spans, which are queryable through
+the `spans` table on the same endpoint: span rows are at-least-once with no
+query-time dedup either, so a `COUNT` over `spans` is a lower-bounded count on
+the same terms.
 
 ## HTTP status codes
 

--- a/docs/ingest.md
+++ b/docs/ingest.md
@@ -364,11 +364,11 @@ since `finish()` does not report it back), and `segment_format_version` is
 renames that follow the unit change: `buffered_records_total` for
 `buffered_points_total`, `stream_id_collisions` for `series_id_collisions`.
 
-Snapshot resolution for logs is not wired: `services/ravel-server/src/fold.rs`
-still folds `Signal::Metrics` only, so `catalog/l/HEAD` is never produced
-and there is no query path over log objects yet. Ingest durability does not
-depend on it (a commit token resolves to its commit record directly), but a
-catalog-based read does; that is the log query phase's prerequisite.
+Snapshot resolution for logs is wired: `services/ravel-server/src/fold.rs`
+folds `Signal::Logs` alongside metrics, so `catalog/l/HEAD` and its snapshot
+parts are produced the same way they are for metrics, and a catalog-based
+read over log objects works from them. Ingest durability never depended on
+it either way (a commit token resolves to its commit record directly).
 
 ## Span pipeline
 
@@ -430,10 +430,10 @@ commit record advertises the same interval RSPAN's skip index prunes with.
 `stream_id_collisions` and with `buffered_spans_total` in place of
 `buffered_records_total`.
 
-Snapshot resolution for spans is not wired: `services/ravel-server/src/fold.rs`
-folds metrics and logs only, so `catalog/s/HEAD` is never produced and there is
-no query path over span objects yet (ADR-0041 phases 3 and 5). Ingest
-durability does not depend on it.
+Spans fold and are queryable the same way logs are:
+`services/ravel-server/src/fold.rs` folds metrics, logs, and spans, and the
+`spans` SQL table on `POST /api/v1/sql` reads them back. Ingest durability
+never depended on this fold either way.
 
 ## Admission control (ADR-0051)
 


### PR DESCRIPTION
Several operator guides described shipped capabilities as unbuilt:
architecture.md called the SQL HTTP endpoint and Flight SQL
not-yet-built when both ship (its crate-list "in progress" tag for
ravel-sql now matches); README.md said OTAP ingest was not wired into
ravel-server when it is, behind --otap; query.md described
/api/v1/sql as serving only the samples and logs tables and span
queries as pending, when a third spans table already shipped (heading
now matches); inspecting-data.md called the l/s object-key signal
slots unimplemented when both are, including a walkthrough preamble
that still described log ingest/query/lifecycle as later phases;
caching.md said there was no SQL query surface over spans, and it
does exist, though its reads are uncached.

Also corrects places this same change would otherwise leave
self-contradictory: README.md's own top-level summary still denied a
traces query surface existed; caching.md's "known gaps" list still
justified the missing cache path by claiming spans have no query
surface, right below the paragraph that says they do; and
docs/ingest.md claimed spans (and, in a sibling paragraph, logs) are
not folded and have no query path, when fold.rs already folds both
and their SQL tables already read them back.

Separately, ADR-0043's rejected-alternatives section assumed webhook
and Alertmanager sinks are equally idempotent. Alertmanager dedupes
on the label set; a plain webhook sink does not, and a lease handover
(not just a restart) can duplicate one notification for the alert's
current repeat window, since the repeat suppressor is process-local.
States that limit explicitly, and gives a webhook sink the dedupe key
that actually distinguishes an unintended duplicate from an intended
repeat: alert_id within a window shorter than repeat_interval, since
a repeat and its duplicate are otherwise byte-identical (same
alert_id, ts_unix_nano, and generation, and a null previous_state).
Corrects the amendment's decision 6, which claimed a repeat sets
previous_state equal to state; the code sends null, the same shape a
bootstrap re-send uses, which is exactly why payload alone can't
distinguish a repeat from a duplicate.

A handful of related stale claims were found but left alone as
pre-existing and out of this task's scope; tracked in #137.

Fixes: #131
