### PR TITLE
docs: claim ADR-0079 for the durable indexed-field override fix

### DIFF
--- a/docs/adrs/0079-indexed-fields-durable-override-cache.md
+++ b/docs/adrs/0079-indexed-fields-durable-override-cache.md
@@ -1,0 +1,3 @@
+# 0079. Durable per-tenant indexed-field override via a cache-aside overlay
+
+Status: claimed


### PR DESCRIPTION
Reserves ADR-0079 for the fix to issue #139 (TenantConfig.indexed_fields
has zero production readers, so ADR-0066 decision 6's promised durable
per-tenant indexed-field override never applies). Stub only; full ADR
content follows after design approval.

Refs: #139