### PR TITLE
docs: replace ADR-0080 mermaid diagrams with hand-drawn SVGs

### DIFF
--- a/docs/adrs/0080-gateway-api-ingest-affinity.md
+++ b/docs/adrs/0080-gateway-api-ingest-affinity.md
@@ -274,36 +274,9 @@ independently testable:
    whichever objects the previous mode created instead of leaving them
    orphaned.
 
-```mermaid
-flowchart TB
-    subgraph CR["RavelCluster spec.gateway"]
-        exposure["exposure.gatewayAPI\n(hostnames, gateway ref)"]
-        affinity["ingestAffinity\n(enabled, subsetSize, key, backend)"]
-    end
+![Exposure and affinity, decoupled: the CR's exposure.gatewayAPI and ingestAffinity fields feed independent rendering paths — standard HTTPRoute/GRPCRoute to a user-provided Gateway, versus legacy Ingress (deprecated) or the new ravel-ingest-router, both of which dial gateway pods directly rather than through the Service VIP.](assets/0080-architecture.svg)
 
-    exposure --> HR["HTTPRoute"]
-    exposure --> GR["GRPCRoute"]
-    HR --> GW["Gateway\n(Envoy Gateway / NGF / Cilium / Istio / managed)"]
-    GR --> GW
-
-    affinity -- "backend: ingressNginx (legacy, deprecated)" --> ING["Ingress x2\n(upstream-hash-by-subset annotations)"]
-    affinity -- "backend: ravelNative" --> RTR["ravel-ingest-router\n(watches EndpointSlices,\nravel-affinity HRW subset)"]
-
-    GW -.->|"backendRef, when ravelNative\n(CEL rule forbids gatewayAPI\nexposure + legacy backend together)"| RTR
-    GW -->|"backendRef, when affinity off"| GWSVC["gateway Service"]
-    GWSVC --> PODS["gateway pod endpoints"]
-    ING -->|"service-upstream: false —\nbalances endpoints directly,\nbypassing the Service VIP"| PODS
-    RTR -->|"dials the chosen pod's\nEndpointSlice address directly\n(never the Service VIP)"| PODS
-```
-
-```mermaid
-flowchart LR
-    T["canonical tenant ID\n(or legacy key source)"] --> H["blake3(tenant_key, replica_id)\nper Ready replica"]
-    R["Ready gateway replicas\n(EndpointSlice watch)"] --> H
-    H --> TOPK["sort by score,\ntake top S"]
-    TOPK --> PICK["pick one member\nfor this request"]
-    PICK --> FWD["proxy HTTP/gRPC"]
-```
+![ravel-affinity's rendezvous (HRW) subset selection: a canonical tenant ID and the Ready replica set both feed a per-pair blake3 score; rank() produces the full deterministic order, subset() takes the top S, and the router picks one member, falling back through the rank order if a subset member isn't Ready.](assets/0080-hrw-flow.svg)
 
 ## Rejected alternatives
 

--- a/docs/adrs/assets/0080-architecture.svg
+++ b/docs/adrs/assets/0080-architecture.svg
@@ -1,0 +1,108 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1020 760" font-family="'Segoe Print','Bradley Hand','Comic Sans MS',cursive" font-size="15">
+  <defs>
+    <marker id="arr" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 1 1.5 Q 6 4 8.5 5 Q 6 6 1 8.5" fill="none" stroke="#444" stroke-width="1.6" stroke-linecap="round"/>
+    </marker>
+    <marker id="arrG" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 1 1.5 Q 6 4 8.5 5 Q 6 6 1 8.5" fill="none" stroke="#4c6b45" stroke-width="1.6" stroke-linecap="round"/>
+    </marker>
+    <marker id="arrO" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 1 1.5 Q 6 4 8.5 5 Q 6 6 1 8.5" fill="none" stroke="#8a6d1f" stroke-width="1.6" stroke-linecap="round"/>
+    </marker>
+  </defs>
+  <rect width="1020" height="760" fill="#fdfcf8"/>
+  <text x="24" y="34" font-size="20" fill="#1b2230">ADR-0080: exposure and affinity, decoupled</text>
+
+  <!-- CR outer box -->
+  <path d="M 30 60 Q 27 57 33 57 L 640 55 Q 648 56 647 63 L 649 240 Q 648 247 641 246 L 34 248 Q 28 247 29 240 Z" fill="none" stroke="#1b2230" stroke-width="2" stroke-dasharray="2 6" stroke-linecap="round"/>
+  <text x="46" y="82" fill="#1b2230">RavelCluster spec.gateway</text>
+
+  <!-- exposure box -->
+  <path d="M 55 100 Q 52 97 58 97 L 300 95 Q 307 96 306 103 L 307 168 Q 306 174 300 173 L 59 175 Q 54 174 55 168 Z" fill="#eaf5f3" stroke="#0e7c86" stroke-width="2.2" stroke-linecap="round"/>
+  <text x="70" y="124" fill="#0e7c86">exposure.gatewayAPI</text>
+  <text x="70" y="146" font-size="12" fill="#5b6472">hostnames, gatewayRef</text>
+  <text x="70" y="163" font-size="12" fill="#5b6472">independent of affinity</text>
+
+  <!-- affinity box -->
+  <path d="M 330 100 Q 327 97 333 97 L 625 96 Q 632 97 631 103 L 632 220 Q 631 226 625 225 L 334 227 Q 328 226 329 220 Z" fill="#eef3f7" stroke="#31536b" stroke-width="2.2" stroke-linecap="round"/>
+  <text x="346" y="124" fill="#31536b">ingestAffinity</text>
+  <text x="346" y="146" font-size="12" fill="#5b6472">enabled, subsetSize, key</text>
+  <text x="346" y="166" font-size="12" fill="#5b6472">backend: ingressNginx (default)</text>
+  <text x="346" y="184" font-size="12" fill="#5b6472">        | ravelNative</text>
+  <text x="346" y="207" font-size="11" fill="#b3423a">CEL: gatewayAPI + legacy backend forbidden</text>
+
+  <!-- HTTPRoute / GRPCRoute -->
+  <path d="M 70 300 Q 67 297 73 297 L 210 296 Q 217 297 216 303 L 217 348 Q 216 354 210 353 L 74 355 Q 68 354 69 348 Z" fill="#fff" stroke="#0e7c86" stroke-width="2" stroke-linecap="round"/>
+  <text x="86" y="322" fill="#0e7c86">HTTPRoute</text>
+  <text x="86" y="342" font-size="11" fill="#5b6472">standard kind</text>
+
+  <path d="M 240 300 Q 237 297 243 297 L 380 296 Q 387 297 386 303 L 387 348 Q 386 354 380 353 L 244 355 Q 238 354 239 348 Z" fill="#fff" stroke="#0e7c86" stroke-width="2" stroke-linecap="round"/>
+  <text x="256" y="322" fill="#0e7c86">GRPCRoute</text>
+  <text x="256" y="342" font-size="11" fill="#5b6472">standard kind</text>
+
+  <!-- Gateway -->
+  <path d="M 500 290 Q 496 286 504 286 L 810 284 Q 819 285 818 293 L 820 360 Q 819 368 811 367 L 504 369 Q 497 368 498 360 Z" fill="#f5f3ee" stroke="#5b6472" stroke-width="2.2" stroke-linecap="round"/>
+  <text x="518" y="315" fill="#3a3f47">Gateway (user-provided)</text>
+  <text x="518" y="335" font-size="12" fill="#5b6472">Envoy Gateway / NGF / Cilium /</text>
+  <text x="518" y="353" font-size="12" fill="#5b6472">Istio / managed cloud impl</text>
+
+  <!-- Ingress legacy -->
+  <path d="M 60 430 Q 56 426 64 426 L 300 424 Q 309 425 308 433 L 310 508 Q 309 516 301 515 L 64 517 Q 57 516 58 508 Z" fill="#f5eede" stroke="#8a6d1f" stroke-width="2.2" stroke-linecap="round"/>
+  <text x="78" y="454" fill="#8a6d1f">Ingress x2 (legacy, deprecated)</text>
+  <text x="78" y="474" font-size="11" fill="#5b6472">upstream-hash-by-subset*</text>
+  <text x="78" y="491" font-size="11" fill="#5b6472">service-upstream: false</text>
+  <text x="78" y="507" font-size="11" fill="#8a6d1f">Condition: IngestAffinityBackendDeprecated</text>
+
+  <!-- ravel-ingest-router -->
+  <path d="M 400 430 Q 396 426 404 426 L 700 424 Q 709 425 708 433 L 710 520 Q 709 528 701 527 L 404 529 Q 397 528 398 520 Z" fill="#eaf1ea" stroke="#4c6b45" stroke-width="2.4" stroke-linecap="round"/>
+  <text x="418" y="454" fill="#4c6b45">ravel-ingest-router</text>
+  <text x="418" y="474" font-size="12" fill="#5b6472">watches EndpointSlices</text>
+  <text x="418" y="492" font-size="12" fill="#5b6472">ravel-affinity HRW rank</text>
+  <text x="418" y="510" font-size="12" fill="#5b6472">canonical tenant (fail-closed)</text>
+
+  <!-- gateway Service -->
+  <path d="M 760 430 Q 757 427 762 427 L 920 426 Q 926 427 925 432 L 926 490 Q 925 496 919 495 L 764 496 Q 758 495 759 490 Z" fill="#fff" stroke="#5b6472" stroke-width="2" stroke-linecap="round"/>
+  <text x="775" y="454" fill="#3a3f47">gateway Service</text>
+  <text x="775" y="474" font-size="11" fill="#5b6472">only when affinity off</text>
+
+  <!-- pods -->
+  <path d="M 400 610 Q 396 606 404 606 L 700 604 Q 709 605 708 613 L 710 680 Q 709 688 701 687 L 404 689 Q 397 688 398 680 Z" fill="#f4f6f2" stroke="#3a3f47" stroke-width="2.4" stroke-linecap="round"/>
+  <text x="440" y="640" fill="#1b2230">gateway pod endpoints</text>
+  <text x="440" y="660" font-size="12" fill="#5b6472">(EndpointSlice addresses, keyed by pod UID)</text>
+
+  <!-- arrows: CR internals to routes -->
+  <path d="M 150 175 Q 130 230 145 296" fill="none" stroke="#0e7c86" stroke-width="1.8" marker-end="url(#arr)" stroke-linecap="round"/>
+  <path d="M 210 175 Q 260 235 280 296" fill="none" stroke="#0e7c86" stroke-width="1.8" marker-end="url(#arr)" stroke-linecap="round"/>
+  <path d="M 216 325 Q 230 322 239 322" fill="none" stroke="#0e7c86" stroke-width="1.6" marker-end="url(#arr)" stroke-linecap="round"/>
+  <path d="M 386 322 Q 440 305 498 315" fill="none" stroke="#0e7c86" stroke-width="1.8" marker-end="url(#arr)" stroke-linecap="round"/>
+  <path d="M 216 340 Q 400 355 498 345" fill="none" stroke="#0e7c86" stroke-width="1.8" marker-end="url(#arr)" stroke-linecap="round"/>
+
+  <!-- affinity to legacy / ravelNative -->
+  <path d="M 400 227 Q 260 320 200 424" fill="none" stroke="#8a6d1f" stroke-width="1.9" marker-end="url(#arrO)" stroke-linecap="round"/>
+  <text x="230" y="350" font-size="12" fill="#8a6d1f" transform="rotate(58 230 350)">backend: ingressNginx</text>
+  <path d="M 500 227 Q 540 320 545 424" fill="none" stroke="#4c6b45" stroke-width="1.9" marker-end="url(#arrG)" stroke-linecap="round"/>
+  <text x="548" y="350" font-size="12" fill="#4c6b45">backend: ravelNative</text>
+
+  <!-- Gateway to router (dashed, when ravelNative) -->
+  <path d="M 640 369 Q 660 400 660 424" fill="none" stroke="#4c6b45" stroke-width="1.8" stroke-dasharray="6 5" marker-end="url(#arrG)" stroke-linecap="round"/>
+  <text x="670" y="400" font-size="11" fill="#4c6b45">backendRef, when ravelNative</text>
+
+  <!-- Gateway to gateway Service (affinity off) -->
+  <path d="M 790 369 Q 850 400 845 426" fill="none" stroke="#5b6472" stroke-width="1.8" marker-end="url(#arr)" stroke-linecap="round"/>
+  <text x="800" y="400" font-size="11" fill="#5b6472">backendRef, affinity off</text>
+
+  <!-- gateway Service to pods -->
+  <path d="M 830 496 Q 780 560 660 606" fill="none" stroke="#5b6472" stroke-width="1.8" marker-end="url(#arr)" stroke-linecap="round"/>
+
+  <!-- Ingress to pods (bypass VIP) -->
+  <path d="M 260 517 Q 320 570 400 630" fill="none" stroke="#8a6d1f" stroke-width="1.8" marker-end="url(#arrO)" stroke-linecap="round"/>
+  <text x="270" y="565" font-size="11" fill="#8a6d1f" transform="rotate(28 270 565)">service-upstream: false —</text>
+  <text x="270" y="580" font-size="11" fill="#8a6d1f" transform="rotate(28 270 580)">bypasses the Service VIP</text>
+
+  <!-- router to pods (direct dial) -->
+  <path d="M 550 529 Q 550 570 550 604" fill="none" stroke="#4c6b45" stroke-width="2" marker-end="url(#arrG)" stroke-linecap="round"/>
+  <text x="558" y="570" font-size="11" fill="#4c6b45">dials chosen pod directly —</text>
+  <text x="558" y="586" font-size="11" fill="#4c6b45">never the Service VIP</text>
+
+  <text x="30" y="730" font-size="12" fill="#5b6472">Legacy (amber) stays functional but deprecated. Ravel-native (green) is the new, controller-independent path.</text>
+</svg>

--- a/docs/adrs/assets/0080-hrw-flow.svg
+++ b/docs/adrs/assets/0080-hrw-flow.svg
@@ -1,0 +1,54 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1020 380" font-family="'Segoe Print','Bradley Hand','Comic Sans MS',cursive" font-size="15">
+  <defs>
+    <marker id="arr" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 1 1.5 Q 6 4 8.5 5 Q 6 6 1 8.5" fill="none" stroke="#444" stroke-width="1.6" stroke-linecap="round"/>
+    </marker>
+  </defs>
+  <rect width="1020" height="380" fill="#fdfcf8"/>
+  <text x="24" y="34" font-size="20" fill="#1b2230">ravel-affinity: rendezvous (HRW) subset selection</text>
+
+  <!-- tenant key -->
+  <path d="M 30 90 Q 27 87 33 87 L 190 85 Q 197 86 196 93 L 197 148 Q 196 154 190 153 L 34 155 Q 28 154 29 148 Z" fill="#eef3f7" stroke="#31536b" stroke-width="2.2" stroke-linecap="round"/>
+  <text x="45" y="112" fill="#31536b">canonical tenant ID</text>
+  <text x="45" y="132" font-size="12" fill="#5b6472">(or legacy key source)</text>
+
+  <!-- ready replicas -->
+  <path d="M 30 230 Q 27 227 33 227 L 190 225 Q 197 226 196 233 L 197 300 Q 196 306 190 305 L 34 307 Q 28 306 29 300 Z" fill="#eaf1ea" stroke="#4c6b45" stroke-width="2.2" stroke-linecap="round"/>
+  <text x="45" y="252" fill="#4c6b45">Ready gateway replicas</text>
+  <text x="45" y="272" font-size="12" fill="#5b6472">EndpointSlice watch</text>
+  <text x="45" y="290" font-size="12" fill="#5b6472">keyed by pod UID</text>
+
+  <!-- scoring -->
+  <path d="M 260 150 Q 256 146 264 146 L 440 144 Q 449 145 448 153 L 450 230 Q 449 238 441 237 L 264 239 Q 257 238 258 230 Z" fill="#fff" stroke="#0e7c86" stroke-width="2.4" stroke-linecap="round"/>
+  <text x="278" y="178" fill="#0e7c86">blake3(tenant, replica)</text>
+  <text x="278" y="200" font-size="12" fill="#5b6472">one score per Ready</text>
+  <text x="278" y="218" font-size="12" fill="#5b6472">replica, every instance</text>
+
+  <!-- rank -->
+  <path d="M 500 150 Q 496 146 504 146 L 660 144 Q 668 145 667 153 L 669 230 Q 668 238 660 237 L 504 239 Q 497 238 498 230 Z" fill="#fff" stroke="#0e7c86" stroke-width="2.4" stroke-linecap="round"/>
+  <text x="518" y="178" fill="#0e7c86">rank()</text>
+  <text x="518" y="200" font-size="12" fill="#5b6472">sort by score, full</text>
+  <text x="518" y="218" font-size="12" fill="#5b6472">order, ties by replica id</text>
+
+  <!-- subset top S -->
+  <path d="M 720 150 Q 716 146 724 146 L 860 144 Q 868 145 867 153 L 869 230 Q 868 238 860 237 L 724 239 Q 717 238 718 230 Z" fill="#eef3f7" stroke="#31536b" stroke-width="2.4" stroke-linecap="round"/>
+  <text x="736" y="178" fill="#31536b">subset(S)</text>
+  <text x="736" y="200" font-size="12" fill="#5b6472">top S of rank(),</text>
+  <text x="736" y="218" font-size="12" fill="#5b6472">order-independent</text>
+
+  <!-- pick + proxy -->
+  <path d="M 720 260 Q 716 256 724 256 L 950 254 Q 959 255 958 263 L 960 340 Q 959 348 951 347 L 724 349 Q 717 348 718 340 Z" fill="#f5f3ee" stroke="#5b6472" stroke-width="2.2" stroke-linecap="round"/>
+  <text x="738" y="288" fill="#3a3f47">pick one member</text>
+  <text x="738" y="308" font-size="12" fill="#5b6472">round-robin, skip not-Ready,</text>
+  <text x="738" y="326" font-size="12" fill="#5b6472">fall to rank S+1 if needed</text>
+  <text x="738" y="342" font-size="12" fill="#5b6472">-&gt; proxy HTTP/gRPC to pod</text>
+
+  <!-- arrows -->
+  <path d="M 197 130 Q 230 160 258 185" fill="none" stroke="#31536b" stroke-width="1.8" marker-end="url(#arr)" stroke-linecap="round"/>
+  <path d="M 197 265 Q 230 230 258 200" fill="none" stroke="#4c6b45" stroke-width="1.8" marker-end="url(#arr)" stroke-linecap="round"/>
+  <path d="M 450 190 Q 475 190 498 190" fill="none" stroke="#0e7c86" stroke-width="1.8" marker-end="url(#arr)" stroke-linecap="round"/>
+  <path d="M 669 190 Q 695 190 718 190" fill="none" stroke="#0e7c86" stroke-width="1.8" marker-end="url(#arr)" stroke-linecap="round"/>
+  <path d="M 800 239 Q 810 248 815 254" fill="none" stroke="#31536b" stroke-width="1.8" marker-end="url(#arr)" stroke-linecap="round"/>
+
+  <text x="30" y="368" font-size="12" fill="#5b6472">Same Ready set -&gt; same result on every routing instance. Adding/removing one replica moves only tenants whose rank crosses position S.</text>
+</svg>


### PR DESCRIPTION
Swaps the two mermaid flowcharts in ADR-0080 for hand-drawn SVG diagrams matching the existing docs/adrs/assets convention (0070/0072/0073). Refs #150.