### PR TITLE
feat: apply durable per-tenant indexed-field override

### DIFF
--- a/crates/ravel-ingest/src/indexed_fields.rs
+++ b/crates/ravel-ingest/src/indexed_fields.rs
@@ -1,0 +1,600 @@
+//! Durable per-tenant indexed-field override, applied to the log flush path via
+//! a cache-aside overlay (ADR-0079).
+//!
+//! [`crate::LogIndexedFields`] resolves the CLI-derived base/override
+//! (`--indexed-field-default` / `--indexed-field-tenant`), the only thing that
+//! decided which attribute fields a log object indexed before this module. ADR-0066
+//! decision 6 promised `TenantConfig.indexed_fields` (the durable per-tenant
+//! record at `t/<tenant_hash>/config`) as a no-restart runtime override of that
+//! list, but nothing read it. [`IndexedFieldsOverlay`] is that reader.
+//!
+//! It wraps the existing `Arc<dyn LogIndexedFields>` base unchanged (the public
+//! trait is deliberately not reshaped, ADR-0079 rejected alternatives) plus a
+//! per-tenant cache, mirroring [`crate::GenerationSwitch`]'s cache-aside shape: a
+//! synchronous fast path ([`IndexedFieldsOverlay::fields_for_cached`]) and an
+//! async, caller-driven refresh on a stale/missing entry
+//! ([`IndexedFieldsOverlay::refresh`]), populated lazily the first time a tenant
+//! flushes. [`crate::log_router::LogIngestRouter`]'s `active_set` is the existing
+//! precedent for the two-step dance; `LogFlushCtx::run_flush` follows it.
+//!
+//! **Failure discipline (ADR-0079 Safety), deliberately unlike
+//! `GenerationSwitch::try_grace_extend`.** A failed `TenantConfig` read or a
+//! validation failure never blocks or fails the flush and never fails closed:
+//! the overlay serves the last successfully-resolved value for that tenant, or
+//! the wrapped base's CLI-only resolution if the tenant has never refreshed. This
+//! is safe because indexed-field config is an advisory, per-object, self-describing
+//! write-time pruning hint the query side never consults, so stale or CLI-only
+//! resolution can only cost extra scan work, never a wrong query result. A failed
+//! read stamps a backoff so a sustained store outage costs at most one failed GET
+//! per tenant per backoff window, and the read never borrows from the flush's own
+//! `deadline_ns` PUT budget. Every flush served from a stale value or a
+//! failed-read/validation fallback increments a metric (the caller's job, mirroring
+//! `active_set`'s grace-extended-stale counter), so a permanently unreadable or
+//! malformed override is never silent.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, Mutex};
+
+use ravel_catalog::read_config_values;
+use ravel_object_store::ObjectStoreBackend;
+use ravel_types::TenantHash;
+
+use crate::lifecycle::DEFAULT_LIFECYCLE_REFRESH_INTERVAL_NS;
+use crate::log_router::LogIndexedFields;
+
+/// Backoff after a failed durable re-read before the overlay will attempt that
+/// tenant's `TenantConfig` GET again (ADR-0079 deliverable 5). Mirrors the shape
+/// and magnitude of `lifecycle_refresh.rs`'s `DEFAULT_ON_MISS_INTERVAL_NS`: one
+/// second, an order of magnitude below the staleness horizon, so a degraded
+/// object store adds at most one failed GET per tenant per second, never one per
+/// flush (which at default ingest settings is several per second per tenant).
+pub const DEFAULT_INDEXED_FIELDS_REREAD_BACKOFF_NS: i64 = 1_000_000_000;
+
+/// Sentinel `refreshed_at_ns`/`attempted_at_ns` value meaning "no such event
+/// yet". `now_ns.saturating_sub(i64::MIN)` saturates to `i64::MAX`, so a sentinel
+/// entry is neither fresh (age exceeds any horizon) nor in backoff (age exceeds
+/// any window) without a separate branch.
+const NEVER: i64 = i64::MIN;
+
+/// One tenant's cached resolved indexed-field list plus the timestamps the fast
+/// path, the backoff, and idle eviction key off.
+///
+/// The three ADR-0079 deliverable-2 timestamps have distinct jobs:
+/// - `refreshed_at_ns` advances only on a successful durable resolution; the fast
+///   path compares it against the staleness horizon. [`NEVER`] for an entry that
+///   only ever recorded a failed read (so the fast path never trusts it and each
+///   flush re-enters `refresh`, where the backoff short-circuits).
+/// - `attempted_at_ns` stamps the last *failed* read; the backoff compares it so a
+///   sustained outage does not re-GET on every flush. Reset to [`NEVER`] on a
+///   success so a recovered tenant is not held in backoff.
+/// - `last_touched_ns` advances on *any* access (fast-path hit, refresh, or
+///   failure-serve), and is the only stamp idle eviction reads. It exists for the
+///   same reason [`crate::generation`]'s `TenantView` carries one: a base-only
+///   failure entry has `refreshed_at_ns == NEVER`, so eviction cannot key off that
+///   without evicting live entries every sweep.
+#[derive(Debug, Clone)]
+struct CacheEntry {
+    fields: Vec<String>,
+    refreshed_at_ns: i64,
+    attempted_at_ns: i64,
+    last_touched_ns: i64,
+}
+
+/// Per-tenant cache behind a `Mutex`, mirroring [`crate::generation`]'s `Inner`
+/// (a lock, not `ArcSwap`/`RwLock`: the read side already tolerates a lock, and a
+/// lock lets the miss path install a freshly-read value without a lost-update
+/// race).
+#[derive(Default)]
+struct Inner {
+    cache: HashMap<TenantHash, CacheEntry>,
+}
+
+/// The outcome of an [`IndexedFieldsOverlay::refresh`]: the resolved field list
+/// plus whether it came from a fresh durable read (or genuine absence) or from a
+/// stale/failed-read/validation fallback. The caller (`run_flush`) counts the
+/// stale-fallback metric on [`RefreshOutcome::Fallback`] and leaves it untouched
+/// on [`RefreshOutcome::Fresh`], exactly as `active_set` counts its
+/// grace-extended-stale metric only on the degraded arm.
+pub(crate) enum RefreshOutcome {
+    /// A durable read (or a genuine absence, itself a valid state) resolved the
+    /// list this tick.
+    Fresh(Vec<String>),
+    /// The durable read failed, was skipped for backoff, or produced a list that
+    /// failed validation; the overlay served the last-known-good value or the
+    /// base's CLI-only resolution.
+    Fallback(Vec<String>),
+}
+
+impl RefreshOutcome {
+    /// The resolved field list, regardless of how it was resolved.
+    pub(crate) fn into_fields(self) -> Vec<String> {
+        match self {
+            RefreshOutcome::Fresh(fields) | RefreshOutcome::Fallback(fields) => fields,
+        }
+    }
+
+    /// Whether the caller should count the stale-fallback metric for this flush.
+    pub(crate) fn is_fallback(&self) -> bool {
+        matches!(self, RefreshOutcome::Fallback(_))
+    }
+}
+
+/// A concrete cache-aside overlay over a base [`LogIndexedFields`] resolver
+/// (ADR-0079). `LogFlushCtx` holds one directly, shared across shards by `Arc`;
+/// it is not a trait object and the `LogIndexedFields` trait is untouched.
+pub struct IndexedFieldsOverlay {
+    /// The CLI-derived base/override, resolved unchanged when a tenant has no
+    /// durable override (or its durable read has never yet succeeded).
+    base: Arc<dyn LogIndexedFields>,
+    inner: Mutex<Inner>,
+    /// The staleness horizon: a cached entry newer than this is served by the
+    /// sync fast path without a durable read. Reuses the lifecycle horizon rather
+    /// than minting a new constant.
+    horizon_ns: i64,
+    /// The failed-read backoff window (see [`DEFAULT_INDEXED_FIELDS_REREAD_BACKOFF_NS`]).
+    backoff_ns: i64,
+}
+
+impl IndexedFieldsOverlay {
+    /// Wrap `base` with the default staleness horizon
+    /// ([`DEFAULT_LIFECYCLE_REFRESH_INTERVAL_NS`], the same `C` every other
+    /// bounded-staleness overlay in this crate uses) and the default failed-read
+    /// backoff.
+    pub fn new(base: Arc<dyn LogIndexedFields>) -> Self {
+        Self::with_intervals(
+            base,
+            DEFAULT_LIFECYCLE_REFRESH_INTERVAL_NS,
+            DEFAULT_INDEXED_FIELDS_REREAD_BACKOFF_NS,
+        )
+    }
+
+    /// Wrap `base` with an explicit horizon and backoff. Both are clamped to at
+    /// least 1 ns so a zero (mis)configuration can never make every entry
+    /// instantly stale or disable the backoff. For tests that need a small,
+    /// deterministic horizon; production uses [`IndexedFieldsOverlay::new`].
+    pub fn with_intervals(
+        base: Arc<dyn LogIndexedFields>,
+        horizon_ns: i64,
+        backoff_ns: i64,
+    ) -> Self {
+        IndexedFieldsOverlay {
+            base,
+            inner: Mutex::new(Inner::default()),
+            horizon_ns: horizon_ns.max(1),
+            backoff_ns: backoff_ns.max(1),
+        }
+    }
+
+    /// Lock the inner state, recovering a poisoned guard rather than propagating a
+    /// panic: the cache is plain per-tenant state with no cross-entry invariant a
+    /// panic mid-update could half-break, and indexed-field resolution must never
+    /// take a flush down (ADR-0079 Safety). Mirrors [`crate::generation`]'s `lock`.
+    fn lock(&self) -> std::sync::MutexGuard<'_, Inner> {
+        self.inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    /// Synchronous fast path: the cached resolved list for `tenant` if a
+    /// successful refresh is still within the staleness horizon
+    /// (`now_ns - refreshed_at_ns <= horizon`, the inclusive-fresh boundary
+    /// [`crate::generation::GenerationSwitch::route_cached`] uses), else `None` so
+    /// the caller drives [`IndexedFieldsOverlay::refresh`]. A cache hit stamps
+    /// `last_touched_ns` so idle eviction never reaps an entry still serving
+    /// flushes, even one whose `refreshed_at_ns` has not moved since its last
+    /// re-read. `now_ns` is the flush's pinned `flush_open_ns`; this type reads no
+    /// clock.
+    pub(crate) fn fields_for_cached(
+        &self,
+        tenant: &TenantHash,
+        now_ns: i64,
+    ) -> Option<Vec<String>> {
+        let mut inner = self.lock();
+        let entry = inner.cache.get_mut(tenant)?;
+        if now_ns.saturating_sub(entry.refreshed_at_ns) <= self.horizon_ns {
+            entry.last_touched_ns = now_ns;
+            Some(entry.fields.clone())
+        } else {
+            None
+        }
+    }
+
+    /// Async refresh on a miss or stale entry: read this one tenant's
+    /// `TenantConfig`, validate a present durable list, overlay it onto the base,
+    /// install the result, and return it. Reads the store at most once per call,
+    /// and never at all while a prior failed read for this tenant is still inside
+    /// the backoff window (it serves the cached value instead). The read is a
+    /// single plain GET, never wrapped in the flush's `deadline_ns` race and never
+    /// retried here, so it cannot borrow from the flush's PUT budget (ADR-0079
+    /// deliverable 5); a store error returns at once to the fallback path.
+    ///
+    /// Overlay semantics (ADR-0079): a durable `indexed_fields = Some(list)` (a
+    /// possibly-empty list, a valid explicit opt-out) replaces the base's resolved
+    /// list outright once validated; `None` (no record, or a record without the
+    /// field) leaves the base's own `fields_for(tenant)` resolution unchanged. A
+    /// list that fails validation is treated exactly like a failed read.
+    ///
+    /// `now_ns` is the flush's pinned `flush_open_ns`.
+    pub(crate) async fn refresh(
+        &self,
+        store: &dyn ObjectStoreBackend,
+        tenant: &TenantHash,
+        now_ns: i64,
+    ) -> RefreshOutcome {
+        // Backoff short-circuit: a recent failed read means the store is degraded;
+        // serve the cached value (last-known-good, or the base captured at failure
+        // time) without hitting the store again this window.
+        {
+            let mut inner = self.lock();
+            if let Some(entry) = inner.cache.get_mut(tenant)
+                && now_ns.saturating_sub(entry.attempted_at_ns) < self.backoff_ns
+            {
+                entry.last_touched_ns = now_ns;
+                return RefreshOutcome::Fallback(entry.fields.clone());
+            }
+        }
+
+        // A single durable GET. Success (present or genuinely absent) is the only
+        // path that installs a fresh value and clears the backoff.
+        match read_config_values(store, tenant).await {
+            Ok(config) => {
+                let durable = config.and_then(|c| c.indexed_fields);
+                match durable {
+                    // A present durable override: validate before it can replace
+                    // the resolved list, exactly as the CLI path validates its
+                    // parsed policy. A malformed record is treated as a failed read.
+                    Some(list) if validate_indexed_list(&list).is_err() => {
+                        self.serve_on_failure(tenant, now_ns)
+                    }
+                    Some(list) => self.install_fresh(tenant, list, now_ns),
+                    // No override: the base's own tenant-override-or-default
+                    // resolution stands unchanged.
+                    None => {
+                        let base_fields = self.base.fields_for(tenant);
+                        self.install_fresh(tenant, base_fields, now_ns)
+                    }
+                }
+            }
+            Err(_) => self.serve_on_failure(tenant, now_ns),
+        }
+    }
+
+    /// Install a freshly-resolved list for `tenant`, stamping the refresh time and
+    /// clearing any pending failed-read backoff.
+    fn install_fresh(
+        &self,
+        tenant: &TenantHash,
+        fields: Vec<String>,
+        now_ns: i64,
+    ) -> RefreshOutcome {
+        let mut inner = self.lock();
+        inner.cache.insert(
+            *tenant,
+            CacheEntry {
+                fields: fields.clone(),
+                refreshed_at_ns: now_ns,
+                attempted_at_ns: NEVER,
+                last_touched_ns: now_ns,
+            },
+        );
+        RefreshOutcome::Fresh(fields)
+    }
+
+    /// The failed-read/validation-failure path (ADR-0079 Safety): serve the last
+    /// successfully-resolved value for this tenant if one exists, else the base's
+    /// CLI-only resolution, and stamp `attempted_at_ns` so the backoff bites. Never
+    /// fails closed and never has a horizon cutoff. A base-captured entry keeps
+    /// `refreshed_at_ns == NEVER` so the fast path never trusts it and every flush
+    /// re-enters `refresh` (where the backoff makes the re-GET cheap) until a read
+    /// finally succeeds.
+    fn serve_on_failure(&self, tenant: &TenantHash, now_ns: i64) -> RefreshOutcome {
+        let mut inner = self.lock();
+        if let Some(entry) = inner.cache.get_mut(tenant)
+            && entry.refreshed_at_ns != NEVER
+        {
+            // A last-known-good value exists: keep serving it, only stamp the
+            // failed attempt.
+            entry.attempted_at_ns = now_ns;
+            entry.last_touched_ns = now_ns;
+            return RefreshOutcome::Fallback(entry.fields.clone());
+        }
+        // Never successfully refreshed: capture the base resolution so a
+        // stale-serve inside the backoff window is cheap, and stamp the attempt.
+        let base_fields = self.base.fields_for(tenant);
+        inner.cache.insert(
+            *tenant,
+            CacheEntry {
+                fields: base_fields.clone(),
+                refreshed_at_ns: NEVER,
+                attempted_at_ns: now_ns,
+                last_touched_ns: now_ns,
+            },
+        );
+        RefreshOutcome::Fallback(base_fields)
+    }
+
+    /// Evict every cached entry last touched before `now_ns - ttl_ns` (ADR-0069
+    /// decision 2, the same idle-tenant sweep [`crate::generation::GenerationSwitch::evict_idle`]
+    /// feeds). Returns the number of entries dropped. An evicted entry is
+    /// re-derivable: the tenant's next flush is a miss that re-reads its config.
+    /// `now_ns`/`ttl_ns` are injected; this type reads no clock, so eviction is
+    /// deterministic under test.
+    pub(crate) fn evict_idle(&self, now_ns: i64, ttl_ns: i64) -> usize {
+        let mut inner = self.lock();
+        let before = inner.cache.len();
+        inner
+            .cache
+            .retain(|_, entry| now_ns.saturating_sub(entry.last_touched_ns) <= ttl_ns);
+        before - inner.cache.len()
+    }
+}
+
+/// Reject an empty or duplicate field name in a durable indexed-field list, the
+/// SAME check `services/ravel-server`'s `postings_config::validate_list` applies
+/// to the CLI-parsed policy (empty name, duplicate name). Reimplemented here
+/// rather than shared because `ravel-ingest` cannot depend on the server crate; a
+/// durable list that fails this is treated exactly like a failed read, so a
+/// malformed record never produces a writer that indexes the wrong set or panics
+/// on an empty name. Returns `Ok(())` for a valid list, including the empty list
+/// (a valid explicit opt-out).
+fn validate_indexed_list(list: &[String]) -> Result<(), ()> {
+    let mut seen: HashSet<&str> = HashSet::with_capacity(list.len());
+    for field in list {
+        if field.is_empty() {
+            return Err(());
+        }
+        if !seen.insert(field.as_str()) {
+            return Err(());
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use ravel_catalog::{TenantConfig, TenantLifecycleState, set_tenant_config};
+    use ravel_object_store::fault::{
+        FaultKind, FaultPlan, FaultStore, Occurrence, Op, Rule, ScriptedFault,
+    };
+    use ravel_object_store::memory::MemoryStore;
+
+    use super::*;
+
+    fn tenant(byte: u8) -> TenantHash {
+        TenantHash([byte; 16])
+    }
+
+    /// A base resolver returning a fixed non-empty list for every tenant, so a
+    /// test can tell "override to empty" (index nothing) apart from "no override"
+    /// (fall through to this list) -- [`crate::NoIndexedFields`] returns empty for
+    /// both, which cannot distinguish them.
+    struct FixedFields(Vec<String>);
+    impl LogIndexedFields for FixedFields {
+        fn fields_for(&self, _tenant: &TenantHash) -> Vec<String> {
+            self.0.clone()
+        }
+    }
+
+    fn overlay_over(base: Arc<dyn LogIndexedFields>) -> IndexedFieldsOverlay {
+        // A tiny horizon and backoff so the staleness/backoff boundaries are easy
+        // to straddle with injected `now_ns`.
+        IndexedFieldsOverlay::with_intervals(base, 1_000, 1_000)
+    }
+
+    async fn write_override(
+        store: &dyn ObjectStoreBackend,
+        t: &TenantHash,
+        indexed_fields: Option<Vec<String>>,
+    ) {
+        set_tenant_config(
+            store,
+            t,
+            &TenantConfig {
+                indexed_fields,
+                ..TenantConfig::new(TenantLifecycleState::Active)
+            },
+            1,
+        )
+        .await
+        .expect("write config");
+    }
+
+    /// A present durable override replaces the base's resolved list outright; the
+    /// fast path then serves it from cache within the horizon.
+    #[tokio::test]
+    async fn present_override_replaces_base_and_is_cached() {
+        let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+        let overlay = overlay_over(Arc::new(FixedFields(vec!["base.field".into()])));
+        let t = tenant(1);
+        write_override(store.as_ref(), &t, Some(vec!["http.status_code".into()])).await;
+
+        // Miss -> refresh reads the durable override.
+        let out = overlay.refresh(store.as_ref(), &t, 10_000).await;
+        assert!(matches!(out, RefreshOutcome::Fresh(_)));
+        assert_eq!(out.into_fields(), vec!["http.status_code".to_string()]);
+
+        // Within the horizon the fast path serves the same list with no read.
+        assert_eq!(
+            overlay.fields_for_cached(&t, 10_500),
+            Some(vec!["http.status_code".to_string()])
+        );
+    }
+
+    /// ADR-0079 deliverable-test: a present-but-empty override ("index nothing")
+    /// is distinct from an absent override ("leave the base"). The empty list wins
+    /// outright; the absent tenant falls through to the base's non-empty list.
+    #[tokio::test]
+    async fn empty_override_indexes_nothing_absent_leaves_base() {
+        let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+        let overlay = overlay_over(Arc::new(FixedFields(vec!["base.field".into()])));
+
+        // Present-but-empty override: resolves to an empty list, not the base.
+        let empty_tenant = tenant(1);
+        write_override(store.as_ref(), &empty_tenant, Some(vec![])).await;
+        let out = overlay.refresh(store.as_ref(), &empty_tenant, 10_000).await;
+        assert!(
+            matches!(out, RefreshOutcome::Fresh(_)),
+            "a valid empty override is a fresh resolution, not a fallback"
+        );
+        assert!(
+            out.into_fields().is_empty(),
+            "present-but-empty override must index nothing, not fall back to the base"
+        );
+
+        // Absent override (no record at all): the base's own resolution stands.
+        let absent_tenant = tenant(2);
+        let out = overlay
+            .refresh(store.as_ref(), &absent_tenant, 10_000)
+            .await;
+        assert!(matches!(out, RefreshOutcome::Fresh(_)));
+        assert_eq!(
+            out.into_fields(),
+            vec!["base.field".to_string()],
+            "an absent override must leave the base resolution untouched"
+        );
+    }
+
+    /// ADR-0079 deliverable-5 test: under a sustained store outage, a second
+    /// cache-miss refresh inside the backoff window must NOT issue a second
+    /// `read_config_values` GET. Proven with a `FaultStore` that fails every GET
+    /// and asserting its fired-fault count is exactly one across two refresh calls.
+    #[tokio::test]
+    async fn failed_read_backs_off_and_issues_one_get_per_window() {
+        let plan = FaultPlan::empty().with_rule(
+            Rule::new(
+                Op::Get,
+                ScriptedFault::Transient("simulated sustained store latency".into()),
+            )
+            .with_occurrence(Occurrence::Always),
+        );
+        let fault = Arc::new(FaultStore::new(MemoryStore::new(), plan));
+        let store: Arc<dyn ObjectStoreBackend> = fault.clone();
+        // Backoff of 1_000 ns; the base indexes nothing, so a first-touch failure
+        // serves the (empty) base resolution.
+        let overlay =
+            IndexedFieldsOverlay::with_intervals(Arc::new(crate::NoIndexedFields), 1_000, 1_000);
+        let t = tenant(7);
+
+        // First miss: the read fails, the overlay serves the base and stamps the
+        // backoff. Exactly one GET has fired.
+        let out = overlay.refresh(store.as_ref(), &t, 10_000).await;
+        assert!(matches!(out, RefreshOutcome::Fallback(_)));
+        assert_eq!(
+            fault.fault_count(Op::Get, FaultKind::Transient),
+            1,
+            "the first failed refresh issues exactly one GET"
+        );
+
+        // Second miss inside the backoff window (10_000 + 500 < 10_000 + 1_000):
+        // served from cache, NO second GET issued.
+        let out = overlay.refresh(store.as_ref(), &t, 10_500).await;
+        assert!(matches!(out, RefreshOutcome::Fallback(_)));
+        assert_eq!(
+            fault.fault_count(Op::Get, FaultKind::Transient),
+            1,
+            "a refresh inside the backoff window must not issue a second GET"
+        );
+
+        // Once the backoff has elapsed, a re-GET is allowed again (still failing).
+        let out = overlay.refresh(store.as_ref(), &t, 11_001).await;
+        assert!(matches!(out, RefreshOutcome::Fallback(_)));
+        assert_eq!(
+            fault.fault_count(Op::Get, FaultKind::Transient),
+            2,
+            "past the backoff window a second GET is attempted"
+        );
+    }
+
+    /// A read that succeeds installs a fresh value and clears the backoff, so the
+    /// very next stale flush re-reads (picks up a change) instead of staying
+    /// parked in a stale backoff.
+    #[tokio::test]
+    async fn success_clears_backoff() {
+        let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+        let overlay = overlay_over(Arc::new(FixedFields(vec!["base.field".into()])));
+        let t = tenant(3);
+        write_override(store.as_ref(), &t, Some(vec!["a".into()])).await;
+
+        overlay.refresh(store.as_ref(), &t, 10_000).await;
+        // Change the durable override, then refresh past the horizon: a fresh read
+        // must pick it up (backoff cleared by the prior success).
+        write_override(store.as_ref(), &t, Some(vec!["b".into()])).await;
+        let out = overlay.refresh(store.as_ref(), &t, 20_000).await;
+        assert_eq!(out.into_fields(), vec!["b".to_string()]);
+    }
+
+    /// A malformed durable list (a duplicate field name) is treated exactly like a
+    /// failed read: the overlay falls back rather than passing the bad list to the
+    /// writer, and the outcome is a fallback the caller counts. The empty-name case
+    /// is covered by `validate_indexed_list`'s unit assertions below.
+    #[tokio::test]
+    async fn malformed_durable_list_falls_back() {
+        let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+        let overlay = overlay_over(Arc::new(FixedFields(vec!["base.field".into()])));
+        let t = tenant(4);
+        // A duplicate field name: invalid.
+        write_override(store.as_ref(), &t, Some(vec!["dup".into(), "dup".into()])).await;
+
+        let out = overlay.refresh(store.as_ref(), &t, 10_000).await;
+        assert!(
+            matches!(out, RefreshOutcome::Fallback(_)),
+            "a malformed durable list must fall back, not resolve fresh"
+        );
+        assert_eq!(
+            out.into_fields(),
+            vec!["base.field".to_string()],
+            "the fallback serves the base resolution, never the malformed list"
+        );
+    }
+
+    #[test]
+    fn validate_indexed_list_matches_the_cli_rules() {
+        assert!(
+            validate_indexed_list(&[]).is_ok(),
+            "empty list is a valid opt-out"
+        );
+        assert!(validate_indexed_list(&["a".into(), "b".into()]).is_ok());
+        assert!(
+            validate_indexed_list(&["".into()]).is_err(),
+            "an empty field name is rejected"
+        );
+        assert!(
+            validate_indexed_list(&["a".into(), "a".into()]).is_err(),
+            "a duplicate field name is rejected"
+        );
+    }
+
+    /// Idle eviction (ADR-0069 decision 2): an entry untouched past the TTL is
+    /// dropped, one still being touched survives, and an evicted entry re-derives
+    /// on the next refresh.
+    #[tokio::test]
+    async fn idle_entry_evicted_active_entry_survives() {
+        let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+        let overlay = overlay_over(Arc::new(FixedFields(vec!["base.field".into()])));
+        let idle = tenant(1);
+        let active = tenant(2);
+        write_override(store.as_ref(), &idle, Some(vec!["x".into()])).await;
+        write_override(store.as_ref(), &active, Some(vec!["y".into()])).await;
+
+        let t0 = 1_000;
+        overlay.refresh(store.as_ref(), &idle, t0).await;
+        overlay.refresh(store.as_ref(), &active, t0).await;
+
+        let ttl_ns = 10_000;
+        // The active tenant is touched (a fast-path hit) just before the sweep, so
+        // its last-touch advances even though its refresh time does not.
+        let sweep_ns = t0 + ttl_ns + 1;
+        assert!(overlay.fields_for_cached(&active, sweep_ns).is_none());
+        // Its horizon lapsed, so re-establish a fresh, touched entry right before
+        // the sweep.
+        overlay.refresh(store.as_ref(), &active, sweep_ns).await;
+
+        let evicted = overlay.evict_idle(sweep_ns, ttl_ns);
+        assert_eq!(evicted, 1, "only the idle tenant's entry is evicted");
+        assert!(
+            overlay.fields_for_cached(&active, sweep_ns).is_some(),
+            "the active tenant's entry survives the sweep"
+        );
+    }
+}

--- a/crates/ravel-ingest/src/lib.rs
+++ b/crates/ravel-ingest/src/lib.rs
@@ -13,6 +13,7 @@ mod config;
 mod error;
 mod generation;
 mod idempotency;
+mod indexed_fields;
 mod lifecycle;
 mod log_error;
 mod log_metrics;
@@ -46,6 +47,7 @@ pub use idempotency::{
     MarkerError, MarkerWriteError, WriteOutcome, decode_marker, keyhash32, marker_key, read_marker,
     write_marker,
 };
+pub use indexed_fields::{DEFAULT_INDEXED_FIELDS_REREAD_BACKOFF_NS, IndexedFieldsOverlay};
 pub use lifecycle::{
     DEFAULT_HARD_STALENESS_MULTIPLE, DEFAULT_LIFECYCLE_REFRESH_INTERVAL_NS, StalenessGate,
     overlay_admission_limits, refresh_tenant_limits_once,

--- a/crates/ravel-ingest/src/log_metrics.rs
+++ b/crates/ravel-ingest/src/log_metrics.rs
@@ -102,6 +102,16 @@ pub struct LogIngestMetrics {
     /// rather than fleet-wide-outed; the log-pipeline counterpart of
     /// `IngestMetrics::grace_extended_stale_flushes`.
     grace_extended_stale_flushes: AtomicU64,
+    /// Flushes whose per-tenant indexed-field list resolved from a stale cached
+    /// value or a failed-re-read/validation fallback rather than a fresh durable
+    /// `TenantConfig` read this tick (ADR-0079 deliverable 6). Degraded, not
+    /// failed: the flush still indexes on the last-known-good or CLI-only list.
+    /// A sustained rise means a tenant's durable override is unreadable or
+    /// malformed and its override is silently not applying -- the exact
+    /// silent-gap class ADR-0079 exists to close, so it must be visible. Mirrors
+    /// `grace_extended_stale_flushes` (a snapshot-only counter, read via
+    /// [`LogIngestMetrics::snapshot`]).
+    indexed_fields_stale_fallbacks: AtomicU64,
     /// Objects flushed carrying a non-empty POSTINGS section (ADR-0049). The denominator for average section bytes per indexed object; an
     /// object whose resolved indexed-field list produced no section is not
     /// counted here.
@@ -154,6 +164,7 @@ pub struct LogIngestMetricsSnapshot {
     pub shard_deaths: u64,
     pub stale_provisioning_flushes: u64,
     pub grace_extended_stale_flushes: u64,
+    pub indexed_fields_stale_fallbacks: u64,
     pub postings_objects: u64,
     pub postings_bytes_total: u64,
     pub postings_indexed_fields_total: u64,
@@ -268,6 +279,15 @@ impl LogIngestMetrics {
             .fetch_add(1, Ordering::Relaxed);
     }
 
+    /// One flush resolved its indexed-field list from a stale cached value or a
+    /// failed-re-read/validation fallback rather than a fresh durable read
+    /// (ADR-0079 deliverable 6). Called from `run_flush` on the overlay's
+    /// fallback arm, mirroring [`Self::record_grace_extended_stale_flush`].
+    pub(crate) fn record_indexed_fields_stale_fallback(&self) {
+        self.indexed_fields_stale_fallbacks
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
     /// Fold one flushed object's write-side POSTINGS counters
     /// ([`ravel_logseg::writer::WriteStats`]) into the cumulative totals
     /// (ADR-0049). An object with no POSTINGS section
@@ -305,6 +325,9 @@ impl LogIngestMetrics {
             shard_deaths: self.shard_deaths.load(Ordering::Relaxed),
             stale_provisioning_flushes: self.stale_provisioning_flushes.load(Ordering::Relaxed),
             grace_extended_stale_flushes: self.grace_extended_stale_flushes.load(Ordering::Relaxed),
+            indexed_fields_stale_fallbacks: self
+                .indexed_fields_stale_fallbacks
+                .load(Ordering::Relaxed),
             postings_objects: self.postings_objects.load(Ordering::Relaxed),
             postings_bytes_total: self.postings_bytes_total.load(Ordering::Relaxed),
             postings_indexed_fields_total: self
@@ -395,6 +418,13 @@ mod tests {
             LogIngestMetrics::record_shard_death,
             LogIngestMetricsSnapshot {
                 shard_deaths: 1,
+                ..Default::default()
+            },
+        );
+        assert_only(
+            LogIngestMetrics::record_indexed_fields_stale_fallback,
+            LogIngestMetricsSnapshot {
+                indexed_fields_stale_fallbacks: 1,
                 ..Default::default()
             },
         );

--- a/crates/ravel-ingest/src/log_router.rs
+++ b/crates/ravel-ingest/src/log_router.rs
@@ -21,6 +21,7 @@ use crate::budget::{IngestByteBudget, IngestByteBudgetLimit};
 use crate::clock::Clock;
 use crate::config::IngestConfig;
 use crate::generation::{DEFAULT_REFRESH_INTERVAL_NS, GenerationSwitch, Routed, load_generations};
+use crate::indexed_fields::IndexedFieldsOverlay;
 use crate::log_error::LogWriteError;
 use crate::log_metrics::LogIngestMetrics;
 use crate::log_shard::{LogShardActor, LogShardMsg, est_record_bytes};
@@ -80,6 +81,11 @@ pub struct LogIngestRouter {
     store: Arc<dyn ObjectStoreBackend>,
     clock: Arc<dyn Clock>,
     metrics: Arc<LogIngestMetrics>,
+    /// The durable-override indexed-field overlay (ADR-0079), shared by `Arc`
+    /// with every shard's flush context (via the [`GenerationSwitch`] factory).
+    /// The router holds its own clone only so the idle-tenant sweep can evict its
+    /// per-tenant cache (ADR-0069 decision 2) alongside the generation views.
+    indexed_fields: Arc<IndexedFieldsOverlay>,
     config: IngestConfig,
     /// Process-wide ingest buffer byte budget (ADR-0069 decision 1), shared by
     /// `Arc` with the metrics and span routers. Defaults to `Unlimited`;
@@ -97,18 +103,25 @@ impl LogIngestRouter {
         store: Arc<dyn ObjectStoreBackend>,
         clock: Arc<dyn Clock>,
     ) -> Self {
-        Self::new_with_indexed_fields(config, store, clock, Arc::new(NoIndexedFields))
+        Self::new_with_indexed_fields(
+            config,
+            store,
+            clock,
+            Arc::new(IndexedFieldsOverlay::new(Arc::new(NoIndexedFields))),
+        )
     }
 
     /// Like [`Self::new`], but every shard resolves each tenant's POSTINGS
     /// indexed-field list through `indexed_fields` at flush time (ADR-0049
-    /// decision 3). This is the production constructor; the server
-    /// passes its per-tenant `IndexedFieldConfig` here.
+    /// decision 3, ADR-0079). This is the production constructor; the server
+    /// wraps its CLI-derived `IndexedFieldConfig` in an [`IndexedFieldsOverlay`]
+    /// (so a durable `TenantConfig.indexed_fields` override is read without a
+    /// restart) and passes it here.
     pub fn new_with_indexed_fields(
         config: IngestConfig,
         store: Arc<dyn ObjectStoreBackend>,
         clock: Arc<dyn Clock>,
-        indexed_fields: Arc<dyn LogIndexedFields>,
+        indexed_fields: Arc<IndexedFieldsOverlay>,
     ) -> Self {
         let metrics = Arc::new(LogIngestMetrics::default());
         // Production OS-entropy source for writer ids and PUT-retry jitter
@@ -159,6 +172,7 @@ impl LogIngestRouter {
             store,
             clock,
             metrics,
+            indexed_fields,
             config,
             budget: IngestByteBudget::shared(IngestByteBudgetLimit::Unlimited),
         }
@@ -236,6 +250,15 @@ impl LogIngestRouter {
     /// tenant's next log write.
     pub fn evict_idle_generation_views(&self, now_ns: i64, ttl_ns: i64) -> usize {
         self.switch.evict_idle(now_ns, ttl_ns)
+    }
+
+    /// Evict every idle entry from the durable-override indexed-field cache
+    /// (ADR-0079, wired into the same ADR-0069 decision 2 idle-tenant sweep as
+    /// [`Self::evict_idle_generation_views`]). Returns the number of entries
+    /// dropped; an evicted entry re-derives from `TenantConfig` on the tenant's
+    /// next flush.
+    pub fn evict_idle_indexed_field_cache(&self, now_ns: i64, ttl_ns: i64) -> usize {
+        self.indexed_fields.evict_idle(now_ns, ttl_ns)
     }
 
     /// Groups `records` by `shard_for_log`, sends one `LogShardMsg::Write` per

--- a/crates/ravel-ingest/src/log_shard.rs
+++ b/crates/ravel-ingest/src/log_shard.rs
@@ -45,7 +45,7 @@ use ravel_proto::commit::v1::CommitRecord;
 use ravel_types::logstream::{AttrValue, LogStreamId};
 use ravel_types::{CommitToken, Signal, TenantId};
 
-use crate::log_router::LogIndexedFields;
+use crate::indexed_fields::IndexedFieldsOverlay;
 use tokio::sync::{Semaphore, mpsc, oneshot};
 use tokio::task::JoinSet;
 use tokio::time::Duration;
@@ -190,8 +190,10 @@ struct LogFlushCtx {
     config: IngestConfig,
     metrics: Arc<LogIngestMetrics>,
     /// Resolves each tenant's POSTINGS indexed-field list at flush time
-    /// (ADR-0049 decision 3). Shared across shards.
-    indexed_fields: Arc<dyn LogIndexedFields>,
+    /// (ADR-0049 decision 3), now via the durable-override cache-aside overlay
+    /// (ADR-0079). Shared across shards by `Arc`; its per-tenant cache is the
+    /// one place a tenant's `TenantConfig.indexed_fields` override is read.
+    indexed_fields: Arc<IndexedFieldsOverlay>,
 }
 
 /// One log flush's identity and payload, pinned by the actor before the flush
@@ -269,7 +271,32 @@ impl LogFlushCtx {
         // Resolve this tenant's POSTINGS indexed-field list (ADR-0049 decision
         // 3) once per object and hand it to the writer. An empty list leaves the
         // object without a POSTINGS section, which is always legal (decision 5).
-        let indexed_fields = self.indexed_fields.fields_for(&tenant_hash);
+        //
+        // Cache-aside over the durable per-tenant override (ADR-0079), the same
+        // two-step dance `log_router.rs::active_set` uses: a sync fast path on a
+        // fresh cached entry, else an async single-GET refresh installed and
+        // proceeded on. `now_ns` is the flush's own pinned `flush_open_ns`
+        // (log_shard.rs's pinned-identity contract forbids re-reading the clock
+        // in `run_flush`), which also keeps the cache deterministic under test.
+        // A stale-cache/failed-read/validation fallback is degraded, never fatal:
+        // it counts the visibility metric and proceeds on the last-known-good or
+        // CLI-only list, never failing the flush closed (ADR-0079 Safety).
+        let indexed_fields = match self
+            .indexed_fields
+            .fields_for_cached(&tenant_hash, flush_open_ns)
+        {
+            Some(fields) => fields,
+            None => {
+                let outcome = self
+                    .indexed_fields
+                    .refresh(self.store.as_ref(), &tenant_hash, flush_open_ns)
+                    .await;
+                if outcome.is_fallback() {
+                    self.metrics.record_indexed_fields_stale_fallback();
+                }
+                outcome.into_fields()
+            }
+        };
         let mut writer =
             RlogWriter::new(RlogConfig::default(), identity).with_indexed_fields(indexed_fields);
         for rec in records {
@@ -574,7 +601,7 @@ impl LogShardActor {
         config: IngestConfig,
         metrics: Arc<LogIngestMetrics>,
         rx: mpsc::Receiver<LogShardMsg>,
-        indexed_fields: Arc<dyn LogIndexedFields>,
+        indexed_fields: Arc<IndexedFieldsOverlay>,
     ) -> Self {
         let ctx = Arc::new(LogFlushCtx {
             shard,
@@ -999,7 +1026,9 @@ mod tests {
                 config,
                 Arc::clone(&metrics),
                 rx,
-                Arc::new(crate::log_router::NoIndexedFields),
+                Arc::new(IndexedFieldsOverlay::new(Arc::new(
+                    crate::log_router::NoIndexedFields,
+                ))),
             );
             let task = tokio::spawn(actor.run());
             Harness {
@@ -1646,7 +1675,9 @@ mod tests {
             exhaustion_config(4),
             Arc::clone(&metrics),
             rx,
-            Arc::new(crate::log_router::NoIndexedFields),
+            Arc::new(IndexedFieldsOverlay::new(Arc::new(
+                crate::log_router::NoIndexedFields,
+            ))),
         );
         let task = tokio::spawn(actor.run());
 
@@ -1758,5 +1789,145 @@ mod tests {
             "seq1's record resolves to its own body"
         );
         h.shutdown().await;
+    }
+
+    /// A log record on a fixed stream carrying one per-record attribute, so a
+    /// durable indexed-field override on that attribute has something to index.
+    fn norm_record_with_status(status: &str) -> NormalizedLogRecord {
+        let mut rec = norm_record(&[("service.name", "api")], "scope", 1_000, "x");
+        rec.attrs = vec![(
+            "http.status_code".to_string(),
+            AttrValue::Str(status.to_string()),
+        )];
+        rec
+    }
+
+    /// ADR-0079 acceptance test: a durable `TenantConfig.indexed_fields` override
+    /// genuinely changes what a REAL log flush indexes, driven end to end through
+    /// `LogFlushCtx::run_flush` (not a bare overlay unit test). The overlay's base
+    /// is `NoIndexedFields` (indexes nothing), so any indexing observed comes
+    /// solely from the durable override the overlay read off the store the flush
+    /// path passes it. Then the override is cleared and, once the cache goes stale
+    /// past the horizon, a second real flush reverts to indexing nothing -- a
+    /// no-restart change in both directions.
+    ///
+    /// Observed through the write-side POSTINGS counters, the same "observable
+    /// behaviour changed" signal `postings_config.rs`'s acceptance tests use, and
+    /// templated on `lifecycle.rs`'s
+    /// `refresh_reinvokes_set_tenant_limits_and_admission_behaviour_changes`
+    /// (write override, drive the real refresh, assert live behaviour changed,
+    /// clear it, assert it reverts).
+    ///
+    /// Prove-the-test: stubbing the overlay's durable branch to always resolve the
+    /// base (i.e. ignoring `TenantConfig.indexed_fields`) makes the first
+    /// assertion below fail -- `postings_indexed_fields_total` stays 0 because the
+    /// `NoIndexedFields` base indexes nothing, so the override never took effect.
+    #[tokio::test]
+    async fn durable_indexed_fields_override_changes_a_real_flush_then_reverts() {
+        use ravel_catalog::{TenantConfig, TenantLifecycleState, set_tenant_config};
+
+        let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+        let tenant = TenantId::new("acme");
+
+        // Write the durable override: index `http.status_code`. The overlay's base
+        // is NoIndexedFields, so this is the only thing that can index anything.
+        set_tenant_config(
+            store.as_ref(),
+            &tenant.hash(),
+            &TenantConfig {
+                indexed_fields: Some(vec!["http.status_code".to_string()]),
+                ..TenantConfig::new(TenantLifecycleState::Active)
+            },
+            1,
+        )
+        .await
+        .expect("write durable override");
+
+        let h = Harness::spawn_with_store(flush_on_first(), Arc::clone(&store));
+
+        // First real flush: the override applies, so the object carries a POSTINGS
+        // section indexing exactly the one overridden field.
+        let (ack_tx, ack_rx) = oneshot::channel();
+        h.tx.send(LogShardMsg::Write {
+            tenant: tenant.clone(),
+            records: vec![
+                norm_record_with_status("200"),
+                norm_record_with_status("500"),
+            ],
+            ack: Some(ack_tx),
+            charge: None,
+        })
+        .await
+        .expect("send first write");
+        ack_rx.await.expect("ack").expect("first flush commits");
+
+        let snap = h.metrics.snapshot();
+        assert_eq!(
+            snap.postings_objects, 1,
+            "the durable override made the first flush index a field, so the object \
+             carries a POSTINGS section"
+        );
+        assert_eq!(
+            snap.postings_indexed_fields_total, 1,
+            "exactly the one overridden field (http.status_code) is indexed"
+        );
+        assert_eq!(
+            snap.indexed_fields_stale_fallbacks, 0,
+            "a healthy store resolves the override from a fresh durable read, not a fallback"
+        );
+
+        // Clear the override (no per-tenant indexed-field record => the base
+        // NoIndexedFields governs again).
+        set_tenant_config(
+            store.as_ref(),
+            &tenant.hash(),
+            &TenantConfig::new(TenantLifecycleState::Active),
+            2,
+        )
+        .await
+        .expect("clear durable override");
+
+        // Age the overlay's cached entry past the staleness horizon so the next
+        // flush re-reads the (now cleared) durable config rather than serving the
+        // still-fresh cached override.
+        h.clock
+            .advance_ns(ravel_ingest_default_lifecycle_horizon_ns().saturating_add(1_000_000_000));
+
+        // Second real flush: the override is gone, so the object indexes nothing
+        // and the POSTINGS counters do not move.
+        let (ack_tx, ack_rx) = oneshot::channel();
+        h.tx.send(LogShardMsg::Write {
+            tenant: tenant.clone(),
+            records: vec![norm_record_with_status("200")],
+            ack: Some(ack_tx),
+            charge: None,
+        })
+        .await
+        .expect("send second write");
+        ack_rx.await.expect("ack").expect("second flush commits");
+
+        let snap = h.metrics.snapshot();
+        assert_eq!(
+            snap.postings_objects, 1,
+            "clearing the override reverts to indexing nothing: the second object \
+             carries no POSTINGS section, so the object count does not move"
+        );
+        assert_eq!(
+            snap.postings_indexed_fields_total, 1,
+            "the second flush indexed no field, so the cumulative indexed-fields \
+             count stays at the first flush's 1"
+        );
+        assert_eq!(
+            snap.indexed_fields_stale_fallbacks, 0,
+            "both re-reads succeeded against a healthy store; nothing fell back"
+        );
+        h.shutdown().await;
+    }
+
+    /// The staleness horizon the overlay uses by default, restated here so the
+    /// acceptance test can age the cache past it without depending on the private
+    /// constant. Kept in sync with `IndexedFieldsOverlay::new`'s horizon.
+    fn ravel_ingest_default_lifecycle_horizon_ns() -> i64 {
+        crate::DEFAULT_LIFECYCLE_REFRESH_INTERVAL_NS
     }
 }

--- a/services/ravel-server/src/idle_tenant_state.rs
+++ b/services/ravel-server/src/idle_tenant_state.rs
@@ -83,7 +83,11 @@ impl IdleTenantEvictor for ravel_ingest::IngestRouter {
 
 impl IdleTenantEvictor for ravel_ingest::LogIngestRouter {
     fn evict_idle(&self, now_ns: i64, ttl_ns: i64) -> usize {
+        // The log router owns two re-derivable per-tenant caches: the generation
+        // views (ADR-0052) and the durable-override indexed-field cache
+        // (ADR-0079). Sweep both under the one sweep, summing the evictions.
         self.evict_idle_generation_views(now_ns, ttl_ns)
+            + self.evict_idle_indexed_field_cache(now_ns, ttl_ns)
     }
     fn label(&self) -> &'static str {
         "generation-views-logs"

--- a/services/ravel-server/src/lib.rs
+++ b/services/ravel-server/src/lib.rs
@@ -621,11 +621,15 @@ pub async fn start(
     // `l` keyspace (docs/ingest.md "Log pipeline"). It exists in exactly the
     // modes that serve ingest, so the two options are always Some together.
     let log_ingest_router = if matches!(config.mode, Mode::All | Mode::Gateway) {
-        // The per-tenant POSTINGS indexed-field resolver reaches
-        // the writer here: the router hands it to every shard, which resolves
-        // `fields_for(tenant_hash)` at flush time.
-        let indexed_fields: Arc<dyn ravel_ingest::LogIndexedFields> =
+        // The per-tenant POSTINGS indexed-field resolver reaches the writer here:
+        // the router hands it to every shard, which resolves the list at flush
+        // time. The CLI-derived `IndexedFieldConfig` is the base; wrapping it in
+        // an `IndexedFieldsOverlay` (ADR-0079) makes a durable
+        // `TenantConfig.indexed_fields` override apply per tenant without a
+        // restart, read cache-aside off the flush path.
+        let indexed_fields_base: Arc<dyn ravel_ingest::LogIndexedFields> =
             Arc::new(config.indexed_fields.clone());
+        let indexed_fields = Arc::new(ravel_ingest::IndexedFieldsOverlay::new(indexed_fields_base));
         Some(Arc::new(
             LogIngestRouter::new_with_indexed_fields(
                 IngestConfig {


### PR DESCRIPTION
TenantConfig.indexed_fields (a durable per-tenant proto field ADR-0066
promised as a runtime-overridable, no-restart per-tenant override) had
zero production readers. Only CLI-flag-derived IndexedFieldConfig,
resolved once per log flush, decided what got indexed.

Adds IndexedFieldsOverlay, a cache-aside wrapper modeled on
GenerationSwitch's pattern: a sync fast-path cache read and an async
caller-driven refresh on a stale/missing entry, with a per-tenant
backoff on a failed re-read so a sustained object-store outage costs at
most one failed GET per tenant per backoff window, never one per flush.
Unlike GenerationSwitch, a failed re-read serves the last-known-good
value unbounded rather than failing closed, since indexed-field
staleness has no query-side correctness hazard (postings are per-object,
self-describing pruning hints; nothing on the query side reads this
config). A durable list is validated the same way the CLI-parsed policy
already is before it's trusted, and every stale/fallback-resolved flush
increments a visibility metric.

See docs/adrs/0079-indexed-fields-durable-override-cache.md for the
full design, safety argument, and rejected alternatives.

Fixes: #145
Refs: #139
