### PR TITLE
feat(ravel-server): expose per-tenant PUT attribution via metrics

### DIFF
--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -65,11 +65,12 @@ the dimension Ravel controls least.
 
 ### The `tenant_hash="other"` fold
 
-Two families can carry a `tenant_hash` label: the admission family and the
-per-query cost family. By default every tenant folds into the single bucket
-`tenant_hash="other"`, and that bucket sums every folded tenant's counters.
-The scrape then holds one series per (signal or workload class), never one per
-tenant, regardless of how many tenants send traffic.
+Three families can carry a `tenant_hash` label: the admission family, the
+per-query cost family, and the ingest PUT attribution family. By default
+every tenant folds into the single bucket `tenant_hash="other"`, and that
+bucket sums every folded tenant's counters. The scrape then holds one series
+per (signal or workload class), never one per tenant, regardless of how many
+tenants send traffic.
 
 The `--metrics-tenant-labels` flag opts out of the fold (ADR-0051 section 6).
 With the flag on, each configured tenant keeps its own real `tenant_hash`, and
@@ -128,6 +129,23 @@ Labels: `mode` and `signal`. The `signal` label carries `metrics`, `logs`, or
 
 The collisions family carries no `signal="spans"` series. Spans derive no
 identity that can collide, so that sample is structurally absent, not zero.
+
+#### Per-tenant PUT attribution (ADR-0076 decision 2)
+
+| Metric | Meaning |
+|---|---|
+| `ravel_ingest_attribution_puts_total` | Object-store PUT requests attributed to completed flushes, by tenant and signal. |
+
+Labels: `mode`, `tenant_hash`, `signal`. This is the answer to "which tenant is
+generating the PUT bill": each completed flush charges 2 PUTs (a data object
+and a commit record) to the flushing tenant, tracked per signal by a bounded
+top-K structure in the ingest router (`MAX_TRACKED_TENANTS = 1024`, see
+`crates/ravel-ingest/src/attribution.rs`). That top-K bound protects the
+router's internal accounting; the `tenant_hash` label on this family is
+bounded separately, by the same `--metrics-tenant-labels` allowlist and the
+same `tenant_hash="other"` fold described above — a tenant outside the
+allowlist never gets a series of its own here, regardless of how much it
+contributes to the top-K table.
 
 ### Catalog integrity (`ravel_catalog_*`)
 

--- a/services/ravel-server/src/lib.rs
+++ b/services/ravel-server/src/lib.rs
@@ -771,18 +771,22 @@ pub async fn start(
     // opt-in the admission family's per-tenant series are (ADR-0044
     // consequences; ADR-0051 section 6). Off (the default), the allowlist is
     // empty and every tenant folds into `tenant_hash="other"`.
+    let metrics_tenant_allowlist: std::collections::HashSet<_> = if config.metrics_tenant_labels {
+        config
+            .limits
+            .tenants
+            .keys()
+            .map(|tenant| tenant.hash())
+            .collect()
+    } else {
+        std::collections::HashSet::new()
+    };
     let query_accounting = Arc::new(metrics::QueryAccountingMetrics::new(
-        if config.metrics_tenant_labels {
-            config
-                .limits
-                .tenants
-                .keys()
-                .map(|tenant| tenant.hash())
-                .collect()
-        } else {
-            std::collections::HashSet::new()
-        },
+        metrics_tenant_allowlist.clone(),
     ));
+    // Shared with `query_accounting` above: the same allowlist bounds the
+    // ADR-0076 decision 2 per-tenant PUT attribution family the same way.
+    let metrics_tenant_allowlist = Arc::new(metrics_tenant_allowlist);
 
     // Liveness/readiness routes are served in every mode, including
     // maintain (whose router is otherwise empty). `readiness` starts false
@@ -994,6 +998,7 @@ pub async fn start(
         admission: admission.clone(),
         metrics_tenant_labels: config.metrics_tenant_labels,
         query_accounting: query_accounting.clone(),
+        metrics_tenant_allowlist: metrics_tenant_allowlist.clone(),
         ingest_concurrency: ingest_concurrency.clone(),
         ingest_buffer_budget: ingest_buffer_budget.clone(),
         distrib: distrib_metrics.clone(),

--- a/services/ravel-server/src/metrics.rs
+++ b/services/ravel-server/src/metrics.rs
@@ -2384,7 +2384,10 @@ pub fn attribution_rows(
     allowlist: &HashSet<TenantHash>,
 ) -> Vec<TenantAttributionRow> {
     let mut folded: HashMap<Option<TenantHash>, u64> = HashMap::new();
-    for entry in attribution.top_n(attribution.tracked_len()) {
+    // usize::MAX, not tracked_len(): a separate lock-then-len() call here would
+    // race a growing table between the two locks and silently drop the newest
+    // entries from the fold instead of all of them.
+    for entry in attribution.top_n(usize::MAX) {
         let bucket = allowlist.contains(&entry.tenant).then_some(entry.tenant);
         *folded.entry(bucket).or_default() += entry.puts;
     }

--- a/services/ravel-server/src/metrics.rs
+++ b/services/ravel-server/src/metrics.rs
@@ -50,7 +50,8 @@ use ravel_cache::CacheMetricsSnapshot;
 use ravel_catalog::Catalog;
 use ravel_ingest::{
     AdmissionController, IngestMetricsSnapshot, IngestRouter, LogIngestMetricsSnapshot,
-    LogIngestRouter, SpanIngestMetricsSnapshot, SpanIngestRouter, TenantUsage,
+    LogIngestRouter, SpanIngestMetricsSnapshot, SpanIngestRouter, TenantPutAttribution,
+    TenantUsage,
 };
 use ravel_object_store::StoreMetrics;
 use ravel_object_store::instrument::{
@@ -2355,6 +2356,87 @@ fn render_query_family(out: &mut String, mode: Mode, rows: &[QueryAccountingRow]
     }
 }
 
+/// One rendered row of the per-tenant PUT attribution family: the (signal,
+/// tenant bucket) key plus the accounted PUT count. `tenant` is `None` for the
+/// folded `other` bucket and `Some(hash)` for an allowlisted tenant, the same
+/// convention [`tenant_label`] renders everywhere else.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TenantAttributionRow {
+    pub signal: Signal,
+    pub tenant: Option<TenantHash>,
+    pub puts: u64,
+}
+
+/// Fold one signal's [`TenantPutAttribution::top_n`] snapshot into rendered
+/// rows, bounded the same way [`QueryAccountingMetrics`] bounds the per-query
+/// family: `allowlist` is the `--metrics-tenant-labels` (ADR-0051 section 6)
+/// per-tenant set built from `config.limits.tenants` at server start, shared
+/// with `query_accounting`. A tenant outside it folds into the shared `other`
+/// bucket for this signal, summing its PUTs rather than allocating a series of
+/// its own. `TenantPutAttribution` already bounds its own tracked set to
+/// `MAX_TRACKED_TENANTS` (ADR-0076 decision 2); this fold is the second,
+/// narrower bound the unauthenticated `/metrics` route needs on top of that,
+/// matching every other tenant-labeled family here (ADR-0076: "never an
+/// unbounded per-tenant Prometheus label").
+pub fn attribution_rows(
+    signal: Signal,
+    attribution: &TenantPutAttribution,
+    allowlist: &HashSet<TenantHash>,
+) -> Vec<TenantAttributionRow> {
+    let mut folded: HashMap<Option<TenantHash>, u64> = HashMap::new();
+    for entry in attribution.top_n(attribution.tracked_len()) {
+        let bucket = allowlist.contains(&entry.tenant).then_some(entry.tenant);
+        *folded.entry(bucket).or_default() += entry.puts;
+    }
+    let mut rows: Vec<TenantAttributionRow> = folded
+        .into_iter()
+        .map(|(tenant, puts)| TenantAttributionRow {
+            signal,
+            tenant,
+            puts,
+        })
+        .collect();
+    rows.sort_by(|a, b| {
+        tenant_label(a.tenant)
+            .value()
+            .cmp(&tenant_label(b.tenant).value())
+    });
+    rows
+}
+
+/// The per-tenant PUT attribution family (ADR-0076 decision 2 / T3): answers
+/// "which tenant is generating the PUT bill" per signal, the gap the ADR names
+/// as blocking a per-tenant shard-count cost lever. `rows` already folded
+/// unconfigured tenants into `other` in [`attribution_rows`], so this function
+/// only renders whatever it is handed, the same discipline
+/// [`render_query_family`] follows.
+fn render_attribution_family(out: &mut String, mode: Mode, rows: &[TenantAttributionRow]) {
+    fn labels(mode: Mode, row: &TenantAttributionRow) -> [Label; 3] {
+        [
+            Label::Mode(mode),
+            Label::TenantHash(tenant_label(row.tenant)),
+            Label::Signal(row.signal),
+        ]
+    }
+
+    write_header(
+        out,
+        "ravel_ingest_attribution_puts_total",
+        "Object-store PUT requests attributed to completed ingest flushes, by tenant and \
+         signal (ADR-0076 decision 2). Tenants outside --metrics-tenant-labels' allowlist fold \
+         into tenant_hash=\"other\".",
+        "counter",
+    );
+    for row in rows {
+        write_sample(
+            out,
+            "ravel_ingest_attribution_puts_total",
+            &labels(mode, row),
+            row.puts,
+        );
+    }
+}
+
 /// One scrape's ADR-0071 distributed read fan-out counters. Read
 /// at scrape time from [`crate::distrib::FragmentMetrics`]; `Some` only when the
 /// process serves queries with `--distributed-query` on. Carries no per-shard,
@@ -2534,6 +2616,7 @@ pub fn render(
     ingest_buffer_budget: IngestBufferBudgetSnapshot,
     distrib: Option<&DistribSnapshot>,
     durable_auth: Option<&DurableAuthCountersSnapshot>,
+    attribution: &[TenantAttributionRow],
 ) -> String {
     let mut out = String::new();
     render_store_family(&mut out, mode, store);
@@ -2583,6 +2666,7 @@ pub fn render(
     }
     render_admission_family(&mut out, mode, admission);
     render_query_family(&mut out, mode, query_accounting);
+    render_attribution_family(&mut out, mode, attribution);
     render_ingest_concurrency_family(&mut out, mode, ingest_concurrency_shed_total);
     render_ingest_buffer_budget_family(
         &mut out,
@@ -2660,6 +2744,12 @@ pub struct MetricsState {
     /// section 4), written by every query handler and read here at scrape time.
     /// Always present; renders no samples until a query records into it.
     pub query_accounting: Arc<QueryAccountingMetrics>,
+    /// The per-tenant allowlist the PUT attribution family (ADR-0076 decision
+    /// 2) folds against, same set and same `--metrics-tenant-labels` gate as
+    /// `query_accounting`'s `configured` set: empty unless the flag is on, in
+    /// which case it is `config.limits.tenants.keys()`. A tenant outside it
+    /// folds into `tenant_hash="other"` at render time.
+    pub metrics_tenant_allowlist: Arc<HashSet<TenantHash>>,
     /// The process-wide in-flight ingest-request ceiling, shared
     /// with every OTLP HTTP/gRPC service and Remote Write on both the public
     /// and mTLS listeners. Always present; its `shed_total` is simply `0`
@@ -2819,6 +2909,33 @@ async fn metrics_handler(State(state): State<MetricsState>) -> impl IntoResponse
                 stale_fail_closed: auth.stale_fail_closed(),
             });
 
+    // Per-tenant PUT attribution (ADR-0076 decision 2), read at scrape time
+    // from each present router's `TenantPutAttribution` and folded through the
+    // same allowlist `query_accounting` uses. One signal's router missing
+    // (`Mode::Query`/`Mode::Maintain` build none) simply contributes no rows.
+    let mut attribution = Vec::new();
+    if let Some(router) = &state.ingest_router {
+        attribution.extend(attribution_rows(
+            Signal::Metrics,
+            router.metrics().tenant_put_attribution(),
+            &state.metrics_tenant_allowlist,
+        ));
+    }
+    if let Some(router) = &state.log_ingest_router {
+        attribution.extend(attribution_rows(
+            Signal::Logs,
+            router.metrics().tenant_put_attribution(),
+            &state.metrics_tenant_allowlist,
+        ));
+    }
+    if let Some(router) = &state.span_ingest_router {
+        attribution.extend(attribution_rows(
+            Signal::Spans,
+            router.metrics().tenant_put_attribution(),
+            &state.metrics_tenant_allowlist,
+        ));
+    }
+
     let body = render(
         state.mode,
         &store_snapshot,
@@ -2837,6 +2954,7 @@ async fn metrics_handler(State(state): State<MetricsState>) -> impl IntoResponse
         ingest_buffer_budget,
         distrib_snapshot.as_ref(),
         durable_auth_snapshot.as_ref(),
+        &attribution,
     );
     (
         StatusCode::OK,
@@ -2908,6 +3026,7 @@ mod tests {
             IngestBufferBudgetSnapshot::default(),
             None,
             None,
+            &[],
         );
 
         assert!(
@@ -3045,6 +3164,7 @@ mod tests {
             IngestBufferBudgetSnapshot::default(),
             None,
             None,
+            &[],
         );
 
         let postings_lines: Vec<&str> = body
@@ -3175,6 +3295,7 @@ mod tests {
             IngestBufferBudgetSnapshot::default(),
             None,
             None,
+            &[],
         );
 
         let mut declared_types: HashSet<String> = HashSet::new();
@@ -3331,6 +3452,7 @@ mod tests {
             IngestBufferBudgetSnapshot::default(),
             None,
             None,
+            &[],
         );
 
         assert!(
@@ -3359,6 +3481,7 @@ mod tests {
             IngestBufferBudgetSnapshot::default(),
             None,
             None,
+            &[],
         );
 
         assert!(!body.is_empty(), "a zero snapshot must still render text");
@@ -3419,6 +3542,7 @@ mod tests {
             IngestBufferBudgetSnapshot::default(),
             None,
             None,
+            &[],
         );
 
         assert!(
@@ -3465,6 +3589,7 @@ mod tests {
             IngestBufferBudgetSnapshot::default(),
             None,
             None,
+            &[],
         );
 
         assert!(
@@ -3503,6 +3628,7 @@ mod tests {
             IngestBufferBudgetSnapshot::default(),
             None,
             None,
+            &[],
         );
         // Default reachability is healthy (1); the process runs no probe here.
         assert!(
@@ -3599,6 +3725,7 @@ mod tests {
             IngestBufferBudgetSnapshot::default(),
             None,
             Some(&snapshot),
+            &[],
         );
 
         // All three counters appear, mode-labeled, carrying the driven value.
@@ -3644,6 +3771,7 @@ mod tests {
             IngestBufferBudgetSnapshot::default(),
             None,
             None,
+            &[],
         );
         assert!(
             !body.contains("ravel_durable_auth_"),
@@ -3693,6 +3821,7 @@ mod tests {
             IngestBufferBudgetSnapshot::default(),
             None,
             None,
+            &[],
         );
 
         assert!(
@@ -3774,6 +3903,7 @@ mod tests {
             IngestBufferBudgetSnapshot::default(),
             Some(&snapshot),
             None,
+            &[],
         );
 
         for expected in [
@@ -3841,6 +3971,7 @@ mod tests {
             IngestBufferBudgetSnapshot::default(),
             None,
             None,
+            &[],
         );
         assert!(
             !off.contains("ravel_distrib_"),
@@ -3888,6 +4019,7 @@ mod tests {
             IngestBufferBudgetSnapshot::default(),
             None,
             None,
+            &[],
         );
 
         assert!(
@@ -3967,6 +4099,7 @@ mod tests {
             IngestBufferBudgetSnapshot::default(),
             None,
             None,
+            &[],
         );
         assert!(
             !body.contains("ravel_scrub_"),
@@ -4014,6 +4147,7 @@ mod tests {
             IngestBufferBudgetSnapshot::default(),
             None,
             None,
+            &[],
         );
 
         for line in body.lines() {
@@ -4088,6 +4222,7 @@ mod tests {
             IngestBufferBudgetSnapshot::default(),
             None,
             None,
+            &[],
         );
 
         // Fetcher cache, labeled cache="fetch".
@@ -4194,6 +4329,7 @@ mod tests {
             IngestBufferBudgetSnapshot::default(),
             None,
             None,
+            &[],
         );
         assert!(
             body.contains("ravel_cache_hits_total{mode=\"gateway\",cache=\"catalog\"} 7"),
@@ -4227,6 +4363,7 @@ mod tests {
             IngestBufferBudgetSnapshot::default(),
             None,
             None,
+            &[],
         );
 
         assert!(
@@ -4311,6 +4448,7 @@ mod tests {
             IngestBufferBudgetSnapshot::default(),
             None,
             None,
+            &[],
         );
 
         assert_eq!(
@@ -4383,6 +4521,7 @@ mod tests {
             IngestBufferBudgetSnapshot::default(),
             None,
             None,
+            &[],
         );
 
         let rendered = admission_tenant_hashes(&body);
@@ -4454,6 +4593,7 @@ mod tests {
             IngestBufferBudgetSnapshot::default(),
             None,
             None,
+            &[],
         );
         assert!(
             body.contains(&format!(
@@ -4502,6 +4642,7 @@ mod tests {
             IngestBufferBudgetSnapshot::default(),
             None,
             None,
+            &[],
         )
     }
 

--- a/services/ravel-server/src/tests.rs
+++ b/services/ravel-server/src/tests.rs
@@ -185,6 +185,7 @@ fn harness(store: Arc<dyn ObjectStoreBackend>, configured: HashSet<TenantHash>) 
             AdmissionLimits::default(),
         )),
         metrics_tenant_labels: false,
+        metrics_tenant_allowlist: Arc::new(HashSet::new()),
         query_accounting,
         ingest_concurrency: crate::ingest_concurrency::IngestConcurrencyController::shared(
             crate::ingest_concurrency::IngestConcurrencyLimit::Bounded(1024),

--- a/services/ravel-server/tests/metrics_endpoint.rs
+++ b/services/ravel-server/tests/metrics_endpoint.rs
@@ -468,3 +468,179 @@ async fn admission_family_tenant_labels_bounded() {
         );
     }
 }
+
+// --- ADR-0076 decision 2 / #146: the /metrics PUT attribution family ---
+
+const ATTR_CONFIGURED_TENANT: &str = "attr-configured";
+const ATTR_CONFIGURED_TOKEN: &str = "attr-configured-token";
+const ATTR_OTHER_TENANT: &str = "attr-unconfigured";
+const ATTR_OTHER_TOKEN: &str = "attr-unconfigured-token";
+
+/// Starts a server in `Mode::All` with both attribution-test tenants' tokens
+/// installed and `--metrics-tenant-labels` on, but only
+/// `ATTR_CONFIGURED_TENANT` present in `limits.tenants` -- the allowlist the
+/// attribution family folds against, the same set and gate
+/// `query_accounting` uses.
+async fn start_attribution_server() -> ravel_server::Running {
+    let mut tokens = HashMap::new();
+    tokens.insert(
+        ATTR_CONFIGURED_TOKEN.to_string(),
+        TenantId::new(ATTR_CONFIGURED_TENANT),
+    );
+    tokens.insert(
+        ATTR_OTHER_TOKEN.to_string(),
+        TenantId::new(ATTR_OTHER_TENANT),
+    );
+    let mut tenants = HashMap::new();
+    tenants.insert(
+        TenantId::new(ATTR_CONFIGURED_TENANT),
+        AdmissionLimits::default(),
+    );
+    let tenant_resolver = ravel_server::tenant::build_resolver(tokens, false);
+    let store = Arc::new(MemoryStore::new());
+    let config = ServerConfig {
+        max_inflight_flushes: 1,
+        adaptive_flush_delay: false,
+        mode: Mode::All,
+        listen_http: "127.0.0.1:0".parse().expect("valid loopback addr"),
+        listen_grpc: "127.0.0.1:0".parse().expect("valid loopback addr"),
+        shard_count: 1,
+        tenant_resolver,
+        mtls_listener: None,
+        fold_tenants: Vec::new(),
+        fold: FoldTaskConfig {
+            enabled: false,
+            ..FoldTaskConfig::default()
+        },
+        maintain: ravel_server::MaintenanceTaskConfig::default(),
+        alerting: ravel_server::AlertEvalConfig::default(),
+        oidc_refresh: None,
+        otap: false,
+        metrics_tenant_labels: true,
+        deployment_key: None,
+        gc: ravel_maintain::GcConfigValues::maintain_defaults(),
+        query_deadline: ravel_query::EngineConfig::default().deadline,
+        store_probe_interval: ravel_server::store_probe::DEFAULT_STORE_PROBE_INTERVAL,
+        admission_reconcile_interval: ravel_ingest::DEFAULT_ADMISSION_RECONCILE_INTERVAL,
+        query_concurrency_limit: ravel_query::QueryConcurrencyLimit::Unlimited,
+        max_s3_requests: ravel_query::EngineConfig::default().max_s3_requests,
+        scrub_period: std::time::Duration::from_secs(7 * 86_400),
+        indexed_fields: Default::default(),
+        disable_cache: false,
+        cache_max_bytes: 256 * 1024 * 1024,
+        ingest_buffer_budget_limit: ravel_server::IngestByteBudgetLimit::Unlimited,
+        idle_tenant_state_ttl: std::time::Duration::from_secs(3600),
+        distrib: None,
+        remote_clusters: Vec::new(),
+        ingest_concurrency_limit: ravel_server::ingest_concurrency::IngestConcurrencyLimit::Bounded(
+            1024,
+        ),
+        limits: LimitsConfig {
+            defaults: ravel_server::config::limits::shipped_defaults(),
+            tenants,
+            ..LimitsConfig::default()
+        },
+    };
+    ravel_server::start(
+        config,
+        store.clone(),
+        store.clone(),
+        Arc::new(StoreMetrics::default()),
+        None,
+    )
+    .await
+    .expect("server starts")
+}
+
+/// Drives one clean-admit metrics export per attribution tenant. Strict mode
+/// (the default: no `x-ravel-ingest-mode` header) blocks the response until
+/// the flush's commit-token ack, so a completed POST already guarantees
+/// `record_flush` -- and therefore this tenant's `TenantPutAttribution` entry
+/// -- has fired; no sleep or poll is needed to observe it on the next scrape.
+async fn drive_attribution_activity(base: &str) {
+    let client = reqwest::Client::new();
+    for token in [ATTR_CONFIGURED_TOKEN, ATTR_OTHER_TOKEN] {
+        let request = export_request(2, admission_now_ns());
+        let response = client
+            .post(format!("{base}/v1/metrics"))
+            .header("authorization", format!("Bearer {token}"))
+            .header("content-type", "application/x-protobuf")
+            .body(request.encode_to_vec())
+            .send()
+            .await
+            .expect("export request completes");
+        assert_eq!(
+            response.status(),
+            200,
+            "clean-admit attribution scenario must be admitted, not rejected"
+        );
+    }
+}
+
+/// Distinct `tenant_hash` label values across every
+/// `ravel_ingest_attribution_puts_total` sample line for `signal="metrics"`.
+fn attribution_tenant_hashes(body: &str) -> std::collections::HashSet<String> {
+    let mut out = std::collections::HashSet::new();
+    for line in body.lines() {
+        if !line.starts_with("ravel_ingest_attribution_puts_total{") {
+            continue;
+        }
+        if !line.contains("signal=\"metrics\"") {
+            continue;
+        }
+        let brace = line.find('{').expect("attribution sample carries labels");
+        let close = line.find('}').expect("closed label block");
+        for pair in line[brace + 1..close].split(',') {
+            if let Some(value) = pair.strip_prefix("tenant_hash=\"") {
+                out.insert(value.trim_end_matches('"').to_string());
+            }
+        }
+    }
+    out
+}
+
+/// The soundness test for ADR-0076 decision 2 / #146: a tenant outside the
+/// `--metrics-tenant-labels` allowlist must never get its own `tenant_hash`
+/// series on the per-tenant PUT attribution family, no matter how much ingest
+/// traffic it drives through the real router -- it must fold into
+/// `tenant_hash="other"`, the same bounded-cardinality contract
+/// `query_accounting` and the admission family already hold on this
+/// unauthenticated route. This is written to fail against a naive
+/// unbounded-label implementation: an `attribution_rows` that always keeps
+/// `Some(entry.tenant)` regardless of `allowlist` would render
+/// `ATTR_OTHER_TENANT`'s real hash here instead of folding it, and the
+/// "no unlisted hash" assertion below would catch it.
+#[tokio::test]
+async fn attribution_family_folds_unconfigured_tenant_to_other() {
+    let running = start_attribution_server().await;
+    let base = format!("http://{}", running.http_addr);
+    drive_attribution_activity(&base).await;
+
+    let client = reqwest::Client::new();
+    let body = client
+        .get(format!("{base}/metrics"))
+        .send()
+        .await
+        .expect("metrics request completes")
+        .text()
+        .await
+        .expect("metrics body is text");
+    running.shutdown().await.expect("graceful shutdown");
+
+    assert!(
+        body.contains("ravel_ingest_attribution_puts_total{"),
+        "attribution family must be present once ingest has flushed:\n{body}"
+    );
+
+    let hashes = attribution_tenant_hashes(&body);
+    let configured_hash = TenantId::new(ATTR_CONFIGURED_TENANT).hash().to_hex();
+    assert!(
+        hashes.contains(&configured_hash),
+        "the configured tenant must render its real hash:\n{body}"
+    );
+    assert!(
+        hashes.iter().all(|h| h == &configured_hash || h == "other"),
+        "an unconfigured tenant must never get its own tenant_hash series, only fold into \
+         \"other\", got {hashes:?}:\n{body}"
+    );
+}

--- a/services/ravel-server/tests/metrics_endpoint.rs
+++ b/services/ravel-server/tests/metrics_endpoint.rs
@@ -643,4 +643,10 @@ async fn attribution_family_folds_unconfigured_tenant_to_other() {
         "an unconfigured tenant must never get its own tenant_hash series, only fold into \
          \"other\", got {hashes:?}:\n{body}"
     );
+    assert!(
+        hashes.contains("other"),
+        "the unconfigured tenant's traffic must actually appear folded into \"other\" -- \
+         without this, the two asserts above pass vacuously if the unconfigured tenant's \
+         PUTs never rendered at all, got {hashes:?}:\n{body}"
+    );
 }

--- a/services/ravel-server/tests/query_cost_surfaces.rs
+++ b/services/ravel-server/tests/query_cost_surfaces.rs
@@ -195,6 +195,7 @@ fn surfaces(store: Arc<dyn ObjectStoreBackend>, tenant: &TenantId) -> Surfaces {
         )),
         metrics_tenant_labels: false,
         query_accounting: Arc::clone(&query_accounting),
+        metrics_tenant_allowlist: Arc::new(HashSet::new()),
         ingest_buffer_budget: ravel_ingest::IngestByteBudget::shared(
             ravel_ingest::IngestByteBudgetLimit::Unlimited,
         ),
@@ -591,6 +592,7 @@ mod flight {
             )),
             metrics_tenant_labels: false,
             query_accounting: Arc::clone(&query_accounting),
+            metrics_tenant_allowlist: Arc::new(HashSet::new()),
             ingest_buffer_budget: ravel_ingest::IngestByteBudget::shared(
                 ravel_ingest::IngestByteBudgetLimit::Unlimited,
             ),


### PR DESCRIPTION
The per-tenant PUT attribution accounting shipped earlier with the
log/span flush pipelining work but nothing exposed it. This renders
each router's TenantPutAttribution snapshot as a new metric family,
ravel_ingest_attribution_puts_total, through the existing bounded
tenant-hash label mechanism the query-cost family already uses: a
configured tenant gets its real label, everything else folds into
"other". No new unbounded per-tenant label is introduced.

This is the prerequisite ADR-0076 decision 2 named for making
per-tenant shard count an operator-facing cost control: an operator
now has a way to see which tenant is driving PUT volume before
choosing a shard target.

Includes a fix from checkpoint review: the fold test originally never
asserted the "other" bucket was actually populated, so it would have
passed even if the fold silently dropped an unconfigured tenant's
traffic instead of folding it. Also closes a lock-then-lock race in
the fold path that could undercount on a growing tenant table.

Fixes: #146
