### PR TITLE
feat(operator): drive per-tenant shard overrides via ADR-0052 resharding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4561,6 +4561,7 @@ dependencies = [
  "ravel-catalog",
  "ravel-object-store",
  "ravel-tracing-export",
+ "ravel-types",
  "rustls",
  "schemars",
  "serde",

--- a/deploy/k8s/operator/crd.yaml
+++ b/deploy/k8s/operator/crd.yaml
@@ -337,6 +337,29 @@
                     },
                     "type": "object"
                   },
+                  "shardOverrides": {
+                    "description": "Per-tenant shard-count overrides (#147, ADR-0076 decision 2): the\nprimary operator-facing cost control, wired to the already-shipped\nADR-0052 online-resharding mechanism. Distinct from the immutable,\ncluster-wide `shards` field above: this drives a durable\n`append_generation` call per named tenant, never a Deployment\n`--shards` flag, and does not relax `shards`'s own CEL immutability\nrule (see [`ravel_cluster_crd`]).",
+                    "nullable": true,
+                    "properties": {
+                      "leadHours": {
+                        "default": 2,
+                        "description": "Hours of lead time before the new count activates, passed to\n`append_generation` as `activation_hour = now_hour + leadHours`.\nEnforced to be at least [`MIN_RESHARD_LEAD_HOURS`] -- the same bound\n`ravel-cli provision reshard` enforces (`services/ravel-cli/src/\nprovision.rs`) -- rejected outright rather than silently clamped up,\nsince a shorter lead could let a live writer route past the\nactivation on a view it had not yet refreshed.",
+                        "format": "uint32",
+                        "minimum": 0.0,
+                        "type": "integer"
+                      },
+                      "tenants": {
+                        "additionalProperties": {
+                          "format": "uint32",
+                          "minimum": 0.0,
+                          "type": "integer"
+                        },
+                        "description": "Per-tenant shard-count targets: tenant name to desired shard count.\nApplied independently to every ingested signal (metrics, logs, spans).\nA tenant absent here keeps whatever count its provisioning record (or,\nabsent one, the cluster's day-one `spec.shards`) already has.",
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  },
                   "shards": {
                     "description": "Shard count, rendered into `--shards` for gateway, query, and maintain\nalike so the must-match invariant is unrepresentable to break\n(ADR-0034 decision 2). Immutable after creation, enforced by a CEL\ntransition rule on this field's schema (see [`ravel_cluster_crd`]).",
                     "format": "uint32",
@@ -344,7 +367,7 @@
                     "type": "integer",
                     "x-kubernetes-validations": [
                       {
-                        "message": "shards is immutable after creation; resharding is out of scope (ADR-0034)",
+                        "message": "shards is immutable after creation; use spec.shardOverrides for per-tenant resharding (ADR-0052)",
                         "rule": "self == oldSelf"
                       }
                     ]

--- a/docs/README.md
+++ b/docs/README.md
@@ -58,6 +58,11 @@ Start here to run Ravel, ingest into it, or query it.
   the throughput ceiling it costs, how to size the subset, and what a rolling
   restart or replica loss does. Read this to cut object-storage request cost
   without touching latency or any format.
+- [guides/shard-overrides.md](guides/shard-overrides.md): lowering one
+  tenant's shard count via `spec.shardOverrides` (ADR-0076 decision 2,
+  ADR-0052's online resharding) -- the request-cost savings, the throughput
+  ceiling and shard-0 concentration it costs, and coarser ADR-0065
+  maintenance units. Read this to cut per-tenant object-storage request cost.
 - [guides/disaster-recovery.md](guides/disaster-recovery.md): recovering a
   deployment from object storage alone -- what state is reconstructable, the
   commit-record and catalog rebuild path, and the operator steps. Read this

--- a/docs/guides/kubernetes.md
+++ b/docs/guides/kubernetes.md
@@ -167,7 +167,9 @@ A minimal example is in
 |---|---|---|---|
 | `spec.image` | string | required | Server image for all three tiers. |
 | `spec.imagePullPolicy` | string | — | Standard Kubernetes values. |
-| `spec.shards` | integer | required | Feeds `--shards` to the gateway, query, and maintain from one field, so nothing can break the must-match invariant. **Immutable after creation** through a CEL rule; resharding is out of scope. |
+| `spec.shards` | integer | required | Feeds `--shards` to the gateway, query, and maintain from one field, so nothing can break the must-match invariant. **Immutable after creation** through a CEL rule; use `spec.shardOverrides` for per-tenant resharding. |
+| `spec.shardOverrides.leadHours` | integer | `2` | Minimum hours of lead time an override needs before its shard count takes effect (ADR-0052 activation-hour semantics). Rejected below the mechanism's own floor. |
+| `spec.shardOverrides.tenants` | map | — | Per-tenant target shard count, tenant name to integer. A target that differs from the tenant's current active shard count drives a durable `append_generation` reshard (ADR-0052); a target equal to the current count is a no-op. Lowering a tenant's shard count is the primary operator-facing cost control from ADR-0076 decision 2 -- see the documented costs (single-actor throughput ceiling, shard-0 concentration, coarser ADR-0065 maintenance units) in [shard-overrides.md](shard-overrides.md). |
 | `spec.storage.s3.bucket` | string | required | |
 | `spec.storage.s3.region` | string | `us-east-1` | |
 | `spec.storage.s3.endpoint` | string | — | Omit for real AWS S3. Path-style addressing is always used. |

--- a/docs/guides/shard-overrides.md
+++ b/docs/guides/shard-overrides.md
@@ -1,0 +1,102 @@
+# Per-tenant shard overrides: cutting request cost per tenant
+
+`spec.shardOverrides` lets an operator lower (or raise) one tenant's shard
+count without touching the cluster-wide, immutable `spec.shards`. It is the
+operator wiring for the resharding mechanism ADR-0052 already shipped, and it
+is ADR-0076 decision 2's primary operator-facing cost control: cost is linear
+in shards, so four shards to one is a 4x reduction in ingest PUTs and a 4x
+reduction in read LIST cost for that tenant.
+
+This changes no format, no protocol, and no query result. It changes how many
+shards a tenant's data is spread across from a future hour onward.
+
+## Turning it on
+
+```yaml
+apiVersion: ravel.nofire.ai/v1alpha1
+kind: RavelCluster
+metadata:
+  name: prod
+spec:
+  # ... image, shards, storage, tenantTokensSecretRef ...
+  shardOverrides:
+    leadHours: 4
+    tenants:
+      acme: 1
+      globex: 2
+```
+
+Each reconcile cycle, the operator compares every named tenant's current
+shard count (the last generation already recorded for that tenant, per
+signal) against its target here. When they differ, it drives one
+`append_generation` call per `(tenant, signal)` — metrics, logs, and spans
+independently — through the same object store the operator already uses for
+`sys/auth` reconciliation. The new count activates `leadHours` hours after
+the reconcile that scheduled it, never immediately: this is the same future
+activation ADR-0052 and `ravel-cli provision reshard` both require, so a
+router already mid-flight with the old count keeps routing correctly until
+the boundary passes.
+
+### Fields
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `tenants` | map | `{}` | Tenant name to target shard count. A tenant absent here is left alone. |
+| `leadHours` | integer | `2` | Hours of lead time before the new count activates. Rejected outright below 2 (never silently clamped up) — the same minimum `ravel-cli provision reshard` enforces. |
+
+A tenant named here that has never ingested anything yet (no provisioning
+record) is not silently skipped: the attempt still runs and is refused with
+the same `NoRecordToReshard` error `ravel-cli provision reshard` would give,
+visible in the operator's logs. A misconfigured or not-yet-provisioned
+tenant never blocks the rest of the cluster's reconcile, or that tenant's
+other signals: each `(tenant, signal)` reshard attempt is independent and
+best-effort, exactly like the existing `sys/auth` reconcile step.
+
+## What actually changes
+
+`spec.shards` still renders into every tier's `--shards` flag and stays
+immutable after creation (ADR-0034 decision 2) — that invariant is unrelated
+to this feature and is not relaxed by it. `shardOverrides` does not touch a
+Deployment at all. It writes directly to each tenant's durable provisioning
+record in object storage, the same record `ravel-ingest`'s router and
+`ravel-query`'s scan planner already read on every request. Lowering shards
+for one tenant therefore changes what those already-running pods do for
+that tenant, without a rollout.
+
+## What it costs
+
+These costs are real and must be weighed before lowering a tenant's count,
+not discovered afterward.
+
+- **A tenant's ingest throughput is bounded by its shard count.** Each shard
+  is a separate flush stream owned by one shard actor and one single-threaded
+  merge loop. A tenant at one shard funnels its entire ingest volume through
+  that one actor no matter how many gateway replicas or CPU cores the cluster
+  has. If a low-shard tenant's traffic grows, the correct response is raising
+  its shard count back up (also via `shardOverrides`), not adding replicas.
+- **A tenant at one shard concentrates onto shard index 0.** Every one-shard
+  tenant hashes to the same shard index, so several tenants pinned to one
+  shard apiece all land their entire volume on shard 0 of whichever replica
+  hosts it, while sibling shard indices on that replica idle for those
+  tenants. This is the mirror image of `ingestAffinity`'s subset concentration
+  (`docs/guides/ingest-affinity.md`): there it is replicas, here it is shard
+  indices within a tenant.
+- **Maintenance and compaction units get coarser.** ADR-0065's ownership
+  protocol partitions work as `(tenant, signal, shard)` units. Fewer shards
+  means fewer, larger units per tenant-signal: less parallelism available to
+  the maintain tier for that tenant, and a single compaction or GC pass over
+  a bigger slice of data.
+- **This lever does not reach logs or spans' own request-cost drivers.**
+  Shard count divides PUT and LIST cost the same way for every signal, but
+  logs and spans carry additional per-record cost structure that a future
+  ADR-0076 decision addresses separately; lowering shard count here is not a
+  substitute for that.
+
+## Reading it back
+
+The override is a target, not an instantaneous state. To see what a tenant is
+actually routing under right now, read its provisioning record's generation
+history directly (`docs/guides/inspecting-data.md`) rather than assuming
+`shardOverrides` took effect the instant it was applied — it takes effect at
+the scheduled activation hour, `leadHours` after the reconcile that appended
+it.

--- a/services/ravel-operator/Cargo.toml
+++ b/services/ravel-operator/Cargo.toml
@@ -28,6 +28,13 @@ clap = { workspace = true, features = ["env"] }
 # deploymentKeySecretRef is configured. Already a workspace pin; adds no new
 # external crate.
 ravel-catalog = { workspace = true }
+# TenantId/TenantHashScheme/Signal for the shardOverrides reconcile step
+# (#147, ADR-0052/ADR-0076 decision 2): computes a per-cluster tenant hash
+# explicitly rather than relying on the global ambient scheme, since one
+# operator process may reconcile several RavelClusters with different
+# deployment-key configurations concurrently. Already a workspace pin (used
+# by ravel-catalog and ravel-cli); adds no new external crate.
+ravel-types = { workspace = true }
 # Builds the S3 backend sys/auth reconciliation reads and writes, from the
 # same spec.storage.s3 fields ravel-server itself uses. Already a workspace
 # pin; adds no new external crate.

--- a/services/ravel-operator/src/controller.rs
+++ b/services/ravel-operator/src/controller.rs
@@ -21,11 +21,15 @@ use kube_runtime::controller::{Action, Controller};
 use kube_runtime::watcher;
 use ravel_object_store::ObjectStoreBackend;
 use ravel_object_store::s3::{S3Config, S3Store};
+use ravel_types::{Signal, TenantHash, TenantHashScheme, TenantId};
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 use tracing::{info, warn};
 
-use crate::crd::{Condition, LocalSecretRef, RavelCluster, RavelClusterSpec, RavelClusterStatus};
+use crate::crd::{
+    Condition, LocalSecretRef, MIN_RESHARD_LEAD_HOURS, RavelCluster, RavelClusterSpec,
+    RavelClusterStatus, ShardOverridesSpec,
+};
 use crate::reconcile::{
     DEPLOYMENT_KEY_SECRET_KEY, RenderCtx, S3_ACCESS_KEY_ID_KEY, S3_SECRET_ACCESS_KEY_KEY,
     desired_objects, possible_ingest_ingress_names,
@@ -387,8 +391,10 @@ async fn resolve_s3_credentials(
     ))
 }
 
-/// Build the S3 backend `sys/auth` reconciliation reads and writes, from
-/// `spec.storage.s3` plus its credential Secret. Mirrors `ravel-server`'s
+/// Build the S3 backend a reconcile step needs its own store handle for --
+/// `sys/auth` reconciliation and the `shardOverrides` reshard step both use
+/// this -- from `spec.storage.s3` plus its credential Secret. Mirrors
+/// `ravel-server`'s
 /// `build_store` S3 branch: `force_path_style: true` (path-style addressing,
 /// what MinIO/most S3-compatible endpoints expect), `allow_http:
 /// endpoint.is_some()` (only a custom endpoint may be plain HTTP; real AWS S3
@@ -584,8 +590,196 @@ async fn reconcile_sys_auth_best_effort(
     }
 }
 
-/// Current Unix time in nanoseconds, for `sys/auth` CAS-record timestamps.
-/// Direct `SystemTime::now()` use is acceptable here: this is the binary/
+/// The signals a `shardOverrides` entry reshards independently (#147,
+/// ADR-0076 decision 2): ADR-0052 resharding is per `(tenant, signal)`, each
+/// with its own provisioning record and generation history.
+const RESHARDED_SIGNALS: [Signal; 3] = [Signal::Metrics, Signal::Logs, Signal::Spans];
+
+/// Nanoseconds per unix hour, the unit `activation_hour` counts in
+/// (`services/ravel-cli/src/provision.rs` uses the same constant).
+const RESHARD_NS_PER_HOUR: i64 = 3_600_000_000_000;
+
+/// Bounded retry budget for an `append_generation` `ReshardCasConflict`:
+/// another writer (another operator replica's own reconcile cycle, or a
+/// concurrent `ravel-cli provision reshard`) appended its own generation
+/// between this attempt's read and write. `append_generation` re-reads the
+/// record fresh on every call, so retrying here is a fresh read-modify-write,
+/// not a blind replay of a stale one -- the same shape as [`retry_cas`]
+/// above, but a separate constant/loop since it retries a different error
+/// type (`ravel_catalog::ProvisioningError`, not `AuthTokenMapError`).
+/// `ravel-cli provision reshard` itself has no retry loop (it is a
+/// one-shot, human-invoked command); the operator adds one because its
+/// reconcile is periodic and unattended, so a transient conflict should
+/// self-heal within one cycle rather than wait for the next resync.
+const RESHARD_CAS_ATTEMPTS: u32 = 3;
+
+/// Errors from attempting one `(tenant, signal)` reshard via
+/// [`reshard_tenant_signal`].
+#[derive(Debug, thiserror::Error)]
+enum ShardOverrideError {
+    /// Mirrors `ravel-cli provision reshard`'s own refusal
+    /// (`services/ravel-cli/src/provision.rs`): a lead shorter than
+    /// [`MIN_RESHARD_LEAD_HOURS`] could let a live writer route past the
+    /// activation on a view it had not yet refreshed. Rejected outright, not
+    /// clamped up to the minimum.
+    #[error("shardOverrides.leadHours {lead_hours} is below the minimum {MIN_RESHARD_LEAD_HOURS}")]
+    LeadHoursTooShort {
+        /// The rejected lead-hours value.
+        lead_hours: u32,
+    },
+
+    /// One of `append_generation`'s own fail-closed preconditions (no
+    /// existing record, an out-of-range or no-op target count, an
+    /// activation that already landed in the past) or a CAS conflict that
+    /// survived [`RESHARD_CAS_ATTEMPTS`].
+    #[error("append_generation failed: {0}")]
+    Provisioning(#[from] ravel_catalog::ProvisioningError),
+}
+
+/// Resolve a `(cluster, tenant)`'s tenant hash directly from the cluster's own
+/// deployment key, rather than through `ravel_types`'s global
+/// `install_tenant_hash_scheme` singleton: this operator process may
+/// reconcile several `RavelCluster`s concurrently, each with its own
+/// (possibly absent) deployment key, and the ambient global scheme cannot
+/// represent more than one at a time.
+fn tenant_hash_for(tenant: &str, deployment_key: Option<&[u8; 32]>) -> TenantHash {
+    let id = TenantId::new(tenant);
+    match deployment_key {
+        Some(key) => TenantHashScheme::v2_from_deployment_key(key).hash(&id),
+        None => TenantHashScheme::V1Unkeyed.hash(&id),
+    }
+}
+
+/// Reshard one `(tenant, signal)` to `target_shard_count`, enforcing exactly
+/// the fail-closed preconditions `ravel-cli provision reshard` enforces
+/// (`services/ravel-cli/src/provision.rs`): a lead below
+/// [`MIN_RESHARD_LEAD_HOURS`] is refused before any store access; existing
+/// record, shard-count range, and same-count (no-op) are enforced by
+/// [`ravel_catalog::append_generation`] itself, which this calls directly
+/// rather than reimplementing. A `ReshardCasConflict` is retried up to
+/// [`RESHARD_CAS_ATTEMPTS`] times.
+async fn reshard_tenant_signal(
+    store: &dyn ObjectStoreBackend,
+    tenant_hash: &TenantHash,
+    signal: Signal,
+    target_shard_count: u32,
+    lead_hours: u32,
+    now_ns: i64,
+) -> Result<ravel_catalog::ReshardOutcome, ShardOverrideError> {
+    if lead_hours < MIN_RESHARD_LEAD_HOURS {
+        return Err(ShardOverrideError::LeadHoursTooShort { lead_hours });
+    }
+    let now_hour = u32::try_from(now_ns.div_euclid(RESHARD_NS_PER_HOUR).max(0)).unwrap_or(u32::MAX);
+    let activation_hour = now_hour.saturating_add(lead_hours);
+
+    let mut attempt = 0;
+    loop {
+        attempt += 1;
+        match ravel_catalog::append_generation(
+            store,
+            tenant_hash,
+            signal,
+            target_shard_count,
+            activation_hour,
+            now_ns,
+        )
+        .await
+        {
+            Err(ravel_catalog::ProvisioningError::ReshardCasConflict { .. })
+                if attempt < RESHARD_CAS_ATTEMPTS =>
+            {
+                continue;
+            }
+            other => return other.map_err(ShardOverrideError::from),
+        }
+    }
+}
+
+/// Converge every tenant named in `overrides` toward its target shard count
+/// (#147, ADR-0076 decision 2), one independent `append_generation` attempt
+/// per `(tenant, signal)` in [`RESHARDED_SIGNALS`].
+///
+/// "Current" is read as the LAST recorded generation's shard count, never the
+/// instantaneous count active at this hour: a reshard already appended (whose
+/// activation is still in the future) already matches the target, and
+/// comparing against the instantaneous active count would re-append a new
+/// generation every reconcile cycle until the activation hour finally
+/// arrived. A signal with no provisioning record yet compares against the
+/// cluster's day-one default (`spec.shards`, what every tenant is pinned to
+/// before its first write); when the override differs, the attempt is still
+/// made and surfaces `append_generation`'s own `NoRecordToReshard` refusal,
+/// rather than silently skipping a real difference.
+///
+/// Every failure (a too-short lead, a not-yet-provisioned tenant, an
+/// out-of-range or no-op target, a CAS conflict that survived its retry
+/// budget) is logged and skipped, never propagated: a misconfigured override
+/// for one tenant or signal must not block Deployment/Service reconciliation
+/// for the rest of the cluster, or the same tenant's other signals.
+async fn reconcile_shard_overrides(
+    spec: &RavelClusterSpec,
+    overrides: &ShardOverridesSpec,
+    deployment_key: Option<&[u8; 32]>,
+    store: &dyn ObjectStoreBackend,
+    now_ns: i64,
+) {
+    for (tenant, &target) in &overrides.tenants {
+        let tenant_hash = tenant_hash_for(tenant, deployment_key);
+        for signal in RESHARDED_SIGNALS {
+            let current =
+                match ravel_catalog::read_generations_from_store(store, &tenant_hash, signal).await
+                {
+                    Ok(Some(generations)) => {
+                        generations.last().map_or(spec.shards, |g| g.shard_count)
+                    }
+                    Ok(None) => spec.shards,
+                    Err(err) => {
+                        warn!(
+                            %tenant,
+                            signal = signal.key_prefix(),
+                            %err,
+                            "shardOverrides reconcile: failed to read the current shard-generation \
+                             history; skipping this tenant/signal this cycle"
+                        );
+                        continue;
+                    }
+                };
+            if current == target {
+                continue;
+            }
+            match reshard_tenant_signal(
+                store,
+                &tenant_hash,
+                signal,
+                target,
+                overrides.lead_hours,
+                now_ns,
+            )
+            .await
+            {
+                Ok(outcome) => info!(
+                    %tenant,
+                    signal = signal.key_prefix(),
+                    from = current,
+                    to = target,
+                    generation = outcome.generation,
+                    "shardOverrides reconcile: appended a new shard generation"
+                ),
+                Err(err) => warn!(
+                    %tenant,
+                    signal = signal.key_prefix(),
+                    from = current,
+                    to = target,
+                    %err,
+                    "shardOverrides reconcile: reshard attempt refused"
+                ),
+            }
+        }
+    }
+}
+
+/// Current Unix time in nanoseconds, for `sys/auth` and `shardOverrides`
+/// CAS-record timestamps. Direct `SystemTime::now()` use is acceptable here:
+/// this is the binary/
 /// wiring layer (analogous to `ravel-cli`'s own `now_ns()`), not the injected-
 /// clock-only "library logic" the testing-patterns rule governs.
 fn now_ns() -> i64 {
@@ -694,6 +888,24 @@ async fn reconcile_inner(
         reconcile_sys_auth_best_effort(
             &deployment_key,
             &token_secret.token_values,
+            &store,
+            now_ns(),
+        )
+        .await;
+    }
+
+    // Converge shardOverrides to the ADR-0052 resharding mechanism (#147,
+    // ADR-0076 decision 2), whenever the spec names at least one tenant.
+    // Best-effort per (tenant, signal): see reconcile_shard_overrides's doc
+    // comment for why a misconfigured override cannot block reconciliation.
+    if let Some(shard_overrides) = obj.spec.shard_overrides.as_ref()
+        && !shard_overrides.tenants.is_empty()
+    {
+        let store = build_auth_store(client, namespace, &obj.spec).await?;
+        reconcile_shard_overrides(
+            &obj.spec,
+            shard_overrides,
+            deployment_key_secret.key.as_ref(),
             &store,
             now_ns(),
         )
@@ -1510,5 +1722,293 @@ mod tests {
 
         assert_eq!(secret_value(&secret, "key"), Some(b"from-data".to_vec()));
         assert_eq!(secret_value(&secret, "missing"), None);
+    }
+
+    /// #147 (ADR-0076 decision 2 / ADR-0052): `reconcile_shard_overrides` is
+    /// the exact function `reconcile_inner` calls when `spec.shardOverrides`
+    /// names at least one tenant, so testing it directly here exercises the
+    /// real controller entry point rather than a test-only stand-in
+    /// (mirroring how `reconcile_sys_auth`, not a mocked `reconcile_inner`,
+    /// is the unit under test above -- a full `kube::Client` is out of scope
+    /// to mock either way).
+    mod shard_overrides {
+        use ravel_catalog::AbsentPolicy;
+
+        use super::*;
+
+        fn test_spec(shards: u32) -> RavelClusterSpec {
+            RavelClusterSpec {
+                image: "ravel:dev".to_string(),
+                image_pull_policy: None,
+                shards,
+                storage: crate::crd::StorageSpec {
+                    s3: crate::crd::S3Spec {
+                        bucket: "b".to_string(),
+                        region: "us-east-1".to_string(),
+                        endpoint: None,
+                        credentials_secret_ref: LocalSecretRef {
+                            name: "creds".to_string(),
+                        },
+                    },
+                },
+                tenant_tokens_secret_ref: None,
+                deployment_key_secret_ref: None,
+                gateway: Default::default(),
+                query: Default::default(),
+                maintain: Default::default(),
+                retention: None,
+                shard_overrides: None,
+            }
+        }
+
+        fn overrides(tenants: &[(&str, u32)], lead_hours: u32) -> ShardOverridesSpec {
+            ShardOverridesSpec {
+                tenants: tenants
+                    .iter()
+                    .map(|(name, count)| (name.to_string(), *count))
+                    .collect(),
+                lead_hours,
+            }
+        }
+
+        async fn seed_record(store: &dyn ObjectStoreBackend, tenant: &str, shard_count: u32) {
+            let hash = tenant_hash_for(tenant, None);
+            ravel_catalog::validate_or_adopt(
+                store,
+                &hash,
+                Signal::Metrics,
+                shard_count,
+                1_000,
+                AbsentPolicy::CreateFromConfig,
+            )
+            .await
+            .expect("seed generation-0 record");
+        }
+
+        async fn last_shard_count(store: &dyn ObjectStoreBackend, tenant: &str) -> Option<u32> {
+            let hash = tenant_hash_for(tenant, None);
+            ravel_catalog::read_generations_from_store(store, &hash, Signal::Metrics)
+                .await
+                .expect("read succeeds")
+                .and_then(|gens| gens.last().map(|g| g.shard_count))
+        }
+
+        #[tokio::test]
+        async fn appends_a_generation_when_the_target_differs_from_the_last_generation() {
+            let store = memory_store();
+            seed_record(&store, "acme", 4).await;
+
+            let spec = test_spec(4);
+            let ovr = overrides(&[("acme", 1)], MIN_RESHARD_LEAD_HOURS);
+            reconcile_shard_overrides(&spec, &ovr, None, &store, 10 * RESHARD_NS_PER_HOUR).await;
+
+            assert_eq!(
+                last_shard_count(&store, "acme").await,
+                Some(1),
+                "the reconcile step must drive a real append_generation call"
+            );
+        }
+
+        #[tokio::test]
+        async fn is_a_no_op_when_the_target_already_matches_the_last_generation() {
+            let store = memory_store();
+            seed_record(&store, "acme", 4).await;
+
+            let spec = test_spec(4);
+            let ovr = overrides(&[("acme", 4)], MIN_RESHARD_LEAD_HOURS);
+            reconcile_shard_overrides(&spec, &ovr, None, &store, 10 * RESHARD_NS_PER_HOUR).await;
+
+            let hash = tenant_hash_for("acme", None);
+            let generations =
+                ravel_catalog::read_generations_from_store(&store, &hash, Signal::Metrics)
+                    .await
+                    .expect("read succeeds")
+                    .expect("record exists");
+            assert_eq!(
+                generations.len(),
+                1,
+                "an already-converged tenant must not append a redundant generation"
+            );
+        }
+
+        /// One tenant with no provisioning record must not block a sibling
+        /// tenant's reshard: best-effort per (tenant, signal), matching
+        /// `reconcile_sys_auth`'s per-tenant-collision property.
+        #[tokio::test]
+        async fn one_unprovisioned_tenant_does_not_block_another_tenants_reshard() {
+            let store = memory_store();
+            seed_record(&store, "acme", 4).await;
+            // "globex" never had a provisioning record written.
+
+            let spec = test_spec(4);
+            let ovr = overrides(&[("acme", 1), ("globex", 2)], MIN_RESHARD_LEAD_HOURS);
+            reconcile_shard_overrides(&spec, &ovr, None, &store, 10 * RESHARD_NS_PER_HOUR).await;
+
+            assert_eq!(last_shard_count(&store, "acme").await, Some(1));
+            assert_eq!(
+                last_shard_count(&store, "globex").await,
+                None,
+                "globex has no record to reshard and must stay untouched"
+            );
+        }
+
+        #[tokio::test]
+        async fn reshard_tenant_signal_rejects_lead_hours_below_the_minimum_before_any_store_access()
+         {
+            let store = memory_store();
+            // No record seeded at all: the lead-hours check must fire before
+            // reshard_tenant_signal ever reaches the store.
+            let hash = tenant_hash_for("acme", None);
+
+            let err = reshard_tenant_signal(
+                &store,
+                &hash,
+                Signal::Metrics,
+                8,
+                MIN_RESHARD_LEAD_HOURS - 1,
+                10 * RESHARD_NS_PER_HOUR,
+            )
+            .await
+            .expect_err("a lead below the minimum must be rejected, not clamped up");
+            assert!(
+                matches!(err, ShardOverrideError::LeadHoursTooShort { lead_hours: 1 }),
+                "err: {err}"
+            );
+            assert_eq!(
+                last_shard_count(&store, "acme").await,
+                None,
+                "the rejection must happen before any store access"
+            );
+        }
+
+        #[tokio::test]
+        async fn reshard_tenant_signal_rejects_when_no_provisioning_record_exists() {
+            let store = memory_store();
+            let hash = tenant_hash_for("acme", None);
+
+            let err = reshard_tenant_signal(
+                &store,
+                &hash,
+                Signal::Metrics,
+                8,
+                MIN_RESHARD_LEAD_HOURS,
+                10 * RESHARD_NS_PER_HOUR,
+            )
+            .await
+            .expect_err("resharding a tenant with no provisioning record must be refused");
+            assert!(
+                matches!(
+                    err,
+                    ShardOverrideError::Provisioning(
+                        ravel_catalog::ProvisioningError::NoRecordToReshard { .. }
+                    )
+                ),
+                "err: {err}"
+            );
+        }
+
+        #[tokio::test]
+        async fn reshard_tenant_signal_rejects_a_same_count_target_without_clamping() {
+            let store = memory_store();
+            seed_record(&store, "acme", 4).await;
+            let hash = tenant_hash_for("acme", None);
+
+            let err = reshard_tenant_signal(
+                &store,
+                &hash,
+                Signal::Metrics,
+                4,
+                MIN_RESHARD_LEAD_HOURS,
+                10 * RESHARD_NS_PER_HOUR,
+            )
+            .await
+            .expect_err("a same-count target is a no-op and must be refused, not silently ok");
+            assert!(
+                matches!(
+                    err,
+                    ShardOverrideError::Provisioning(
+                        ravel_catalog::ProvisioningError::ReshardSameCount { shard_count: 4 }
+                    )
+                ),
+                "err: {err}"
+            );
+            assert_eq!(
+                last_shard_count(&store, "acme").await,
+                Some(4),
+                "no new generation must have been appended"
+            );
+        }
+
+        #[tokio::test]
+        async fn reshard_tenant_signal_rejects_an_out_of_range_count() {
+            let store = memory_store();
+            seed_record(&store, "acme", 4).await;
+            let hash = tenant_hash_for("acme", None);
+
+            let err = reshard_tenant_signal(
+                &store,
+                &hash,
+                Signal::Metrics,
+                0,
+                MIN_RESHARD_LEAD_HOURS,
+                10 * RESHARD_NS_PER_HOUR,
+            )
+            .await
+            .expect_err("shard count 0 is out of range and must be refused");
+            assert!(
+                matches!(
+                    err,
+                    ShardOverrideError::Provisioning(
+                        ravel_catalog::ProvisioningError::ReshardCountOutOfRange { shard_count: 0 }
+                    )
+                ),
+                "err: {err}"
+            );
+        }
+
+        /// A transient CAS conflict on the first `append_generation` write
+        /// must be absorbed by `reshard_tenant_signal`'s own retry loop (the
+        /// operator's, not `ravel-cli provision reshard`'s -- that CLI
+        /// command has no retry loop of its own).
+        #[tokio::test]
+        async fn reshard_tenant_signal_retries_a_transient_cas_conflict() {
+            use ravel_object_store::fault::{
+                FaultKind, FaultPlan, FaultStore, Occurrence, Op, Rule, ScriptedFault,
+            };
+
+            let base = memory_store();
+            seed_record(&base, "acme", 4).await;
+            let hash = tenant_hash_for("acme", None);
+
+            let plan = FaultPlan::empty().with_rule(
+                Rule::new(Op::Put, ScriptedFault::FailedConditionalWrite)
+                    .with_key_contains("prov")
+                    .with_occurrence(Occurrence::Nth(1)),
+            );
+            let store = FaultStore::new(base, plan);
+
+            let outcome = reshard_tenant_signal(
+                &store,
+                &hash,
+                Signal::Metrics,
+                8,
+                MIN_RESHARD_LEAD_HOURS,
+                10 * RESHARD_NS_PER_HOUR,
+            )
+            .await
+            .expect("the retry must absorb one transient CAS conflict");
+            assert_eq!(outcome.generation, 1);
+
+            assert_eq!(
+                store.fault_count(Op::Put, FaultKind::FailedConditionalWrite),
+                1,
+                "the injected conflict must actually have fired"
+            );
+            assert_eq!(
+                last_shard_count(&store, "acme").await,
+                Some(8),
+                "the retried attempt must have succeeded"
+            );
+        }
     }
 }

--- a/services/ravel-operator/src/crd.rs
+++ b/services/ravel-operator/src/crd.rs
@@ -98,6 +98,16 @@ pub struct RavelClusterSpec {
     /// only by the maintain tier, so these render onto the maintain Deployment.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub retention: Option<RetentionSpec>,
+
+    /// Per-tenant shard-count overrides (#147, ADR-0076 decision 2): the
+    /// primary operator-facing cost control, wired to the already-shipped
+    /// ADR-0052 online-resharding mechanism. Distinct from the immutable,
+    /// cluster-wide `shards` field above: this drives a durable
+    /// `append_generation` call per named tenant, never a Deployment
+    /// `--shards` flag, and does not relax `shards`'s own CEL immutability
+    /// rule (see [`ravel_cluster_crd`]).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub shard_overrides: Option<ShardOverridesSpec>,
 }
 
 /// Reference to a Secret in the same namespace as the `RavelCluster`.
@@ -453,6 +463,44 @@ pub struct RetentionSpec {
     pub tenants: BTreeMap<String, String>,
 }
 
+/// Per-tenant shard-count overrides (#147, ADR-0076 decision 2), patterned on
+/// [`RetentionSpec`]'s per-tenant map.
+///
+/// Costs an operator takes on by lowering a tenant's count are documented in
+/// `docs/guides/shard-overrides.md` (single-actor throughput ceiling,
+/// shard-0 concentration at one shard, coarser ADR-0065 maintenance units),
+/// not just discovered after the fact.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ShardOverridesSpec {
+    /// Per-tenant shard-count targets: tenant name to desired shard count.
+    /// Applied independently to every ingested signal (metrics, logs, spans).
+    /// A tenant absent here keeps whatever count its provisioning record (or,
+    /// absent one, the cluster's day-one `spec.shards`) already has.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub tenants: BTreeMap<String, u32>,
+
+    /// Hours of lead time before the new count activates, passed to
+    /// `append_generation` as `activation_hour = now_hour + leadHours`.
+    /// Enforced to be at least [`MIN_RESHARD_LEAD_HOURS`] -- the same bound
+    /// `ravel-cli provision reshard` enforces (`services/ravel-cli/src/
+    /// provision.rs`) -- rejected outright rather than silently clamped up,
+    /// since a shorter lead could let a live writer route past the
+    /// activation on a view it had not yet refreshed.
+    #[serde(default = "default_reshard_lead_hours")]
+    pub lead_hours: u32,
+}
+
+/// Minimum lead hours accepted for a `shardOverrides` reshard, mirroring
+/// `ravel-cli provision reshard`'s own `MIN_LEAD_HOURS`
+/// (`services/ravel-cli/src/provision.rs`): `ceil(C) + 1` with the router's
+/// default 60s refresh interval `C` (ADR-0052 section 3).
+pub const MIN_RESHARD_LEAD_HOURS: u32 = 2;
+
+fn default_reshard_lead_hours() -> u32 {
+    MIN_RESHARD_LEAD_HOURS
+}
+
 /// Container resource requests and limits, mapping onto the Kubernetes
 /// `ResourceRequirements` shape (`cpu`/`memory` quantity strings).
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema, Default)]
@@ -560,8 +608,15 @@ pub fn ravel_cluster_crd() -> CustomResourceDefinition {
 }
 
 /// Immutability message surfaced to a user who tries to change `shards`.
-const SHARDS_IMMUTABLE_MESSAGE: &str =
-    "shards is immutable after creation; resharding is out of scope (ADR-0034)";
+///
+/// `shards` itself stays immutable: it renders into every tier's `--shards`
+/// flag (ADR-0034 decision 2), and editing it directly would desync that
+/// must-match invariant across the gateway/query/maintain Deployments. This is
+/// not a claim that resharding at large is out of scope -- ADR-0052 shipped
+/// online resharding, and `spec.shardOverrides` (#147, ADR-0076 decision 2)
+/// reaches it through a distinct field this CEL rule does not touch.
+const SHARDS_IMMUTABLE_MESSAGE: &str = "shards is immutable after creation; use \
+    spec.shardOverrides for per-tenant resharding (ADR-0052)";
 
 /// Attach the `self == oldSelf` CEL transition rule to the `shards` property of
 /// every stored version's schema.
@@ -1050,6 +1105,55 @@ mod tests {
                 serde_json::Value::String(text.to_string())
             );
         }
+    }
+
+    #[test]
+    fn shard_overrides_is_optional_and_lead_hours_defaults_to_the_minimum() {
+        // #147, ADR-0076 decision 2. Absent by default, like retention: an
+        // existing RavelCluster that never heard of shardOverrides
+        // deserializes with None and the reconcile step (controller.rs) does
+        // nothing. Declaring an empty tenants map still surfaces
+        // leadHours == MIN_RESHARD_LEAD_HOURS.
+        let crd = ravel_cluster_crd();
+        let spec_props = crd.spec.versions[0]
+            .schema
+            .as_ref()
+            .expect("schema")
+            .open_api_v3_schema
+            .as_ref()
+            .expect("root schema")
+            .properties
+            .as_ref()
+            .expect("root props")
+            .get("spec")
+            .expect("spec prop")
+            .properties
+            .as_ref()
+            .expect("spec props");
+        assert!(
+            spec_props.contains_key("shardOverrides"),
+            "spec must expose shardOverrides in its schema"
+        );
+
+        let base = serde_json::json!({
+            "image": "ravel:dev",
+            "shards": 4,
+            "storage": { "s3": { "bucket": "b", "credentialsSecretRef": { "name": "creds" } } }
+        });
+        let spec: RavelClusterSpec = serde_json::from_value(base.clone()).expect("deserialize");
+        assert_eq!(spec.shard_overrides, None);
+
+        let mut with_overrides = base;
+        with_overrides["shardOverrides"] = serde_json::json!({
+            "tenants": { "tenant-a": 1 }
+        });
+        let spec: RavelClusterSpec = serde_json::from_value(with_overrides).expect("deserialize");
+        let overrides = spec.shard_overrides.expect("shardOverrides present");
+        assert_eq!(overrides.tenants.get("tenant-a"), Some(&1));
+        assert_eq!(
+            overrides.lead_hours, MIN_RESHARD_LEAD_HOURS,
+            "omitting leadHours must default to the minimum, not zero"
+        );
     }
 
     #[test]

--- a/services/ravel-operator/src/reconcile.rs
+++ b/services/ravel-operator/src/reconcile.rs
@@ -1081,6 +1081,7 @@ mod tests {
                 default: Some("30d".to_string()),
                 tenants: BTreeMap::from([("acme".to_string(), "7d".to_string())]),
             }),
+            shard_overrides: None,
         }
     }
 


### PR DESCRIPTION
Wires the operator to the already-shipped ADR-0052 online resharding
mechanism (append_generation in ravel-catalog) instead of adding new
resharding logic. A new spec.shardOverrides CRD field lets an operator
target a per-tenant shard count with a bounded lead time; the reconcile
loop drives append_generation with the same fail-closed preconditions
ravel-cli's provision reshard command already enforces (existing
record required, lead_hours >= 2, no-op and range rejected, bounded
CAS retry).

This is ADR-0076 decision 2, the primary operator-facing cost control:
cutting a tenant's shard count is linear in PUT reduction and read-side
LIST cost. The global --shards default is deliberately untouched here;
flipping it would fail-stop every tenant already pinned at the
current default's generation-0 shard count, so that stays a separate,
fenced follow-up.

Includes two fixes from checkpoint review: the checked-in CRD manifest
(deploy/k8s/operator/crd.yaml) is generated from these Rust types and
was regenerated so shardOverrides actually reaches a real cluster
instead of being pruned by the API server as an unknown field, and
docs/guides/kubernetes.md's RavelCluster reference no longer claims
resharding is out of scope.

Fixes: #147
