### PR TITLE
docs: claim ADR-0081 for the container-first quickstart

### DIFF
--- a/docs/adrs/0081-container-first-quickstart.md
+++ b/docs/adrs/0081-container-first-quickstart.md
@@ -1,0 +1,3 @@
+# 0081. Container-first quickstart and executable README verification
+
+Status: claimed

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -83,3 +83,4 @@ One decision per document. Status: Proposed | Accepted | Superseded.
 | [0078](0078-fold-retention-frontier-deployment-default.md) | Fold retention-frontier reconcile honors the deployment-wide retention default | Accepted |
 | [0079](0079-indexed-fields-durable-override-cache.md) | Indexed-fields durable override cache: cache-aside overlay over TenantConfig.indexed_fields | Accepted |
 | [0080](0080-gateway-api-ingest-affinity.md) | Gateway API exposure and Ravel-native subset affinity: additive backend enum deprecating ingress-nginx, exposure/affinity split, HRW subset selection via a new ravel-affinity crate and ravel-ingest-router service | Accepted |
+| [0081](0081-container-first-quickstart.md) | Container-first quickstart: a published-image `docker compose` path as the documented first run, with README command blocks executed in CI | Claimed |


### PR DESCRIPTION
Reserves ADR number 0081 before the full decision record is written, so a
parallel session cannot pick the same number. Stub only: a title line and
`Status: claimed`, plus the index row.

The decision it will hold: make a published-image `docker compose` stack the
documented first run instead of a from-source release build, and execute the
README's command blocks in CI so the landing page cannot drift from the binary.

Refs: #170