### PR TITLE
feat(operator): add affinity backend field and deprecation condition

### DIFF
--- a/deploy/k8s/operator/crd.yaml
+++ b/deploy/k8s/operator/crd.yaml
@@ -89,6 +89,15 @@
                             "description": "Extra annotations merged onto both rendered Ingress objects, for an\ningress controller other than ingress-nginx or for tuning\n(`nginx.ingress.kubernetes.io/proxy-body-size` is the common one: the\ningress-nginx default of 1m rejects larger OTLP/HTTP payloads).\n\nThe affinity annotations the operator computes are applied AFTER this\nmap, so an entry here can never silently disable the affinity it is\nmeant to configure.",
                             "type": "object"
                           },
+                          "backend": {
+                            "default": "ingressNginx",
+                            "description": "Which implementation carries out the pinning (ADR-0080 decision 1).\nDefaults to [`AffinityBackend::IngressNginx`], so a CR written before\nthis field existed keeps the backend it already runs, with the same\n`subsetSize` and `key` semantics.\n\n`ingressNginx` is deprecated: ingress-nginx is retiring upstream, and a\ncluster using it gets an `IngestAffinityBackendDeprecated` condition on\nits `RavelCluster` status.",
+                            "enum": [
+                              "ingressNginx",
+                              "ravelNative"
+                            ],
+                            "type": "string"
+                          },
                           "enabled": {
                             "default": true,
                             "description": "Whether affinity is active. Defaults to true, so declaring the block is\nenough. Set it to false to turn affinity off during an incident without\ndeleting the rest of the configuration; the Ingress objects are then\nremoved and rendering returns to the affinity-absent baseline.",

--- a/docs/guides/ingest-affinity.md
+++ b/docs/guides/ingest-affinity.md
@@ -95,13 +95,39 @@ the hash has nothing to distribute over. The affinity would silently do nothing.
 The controller's own default is `false`, but it is settable cluster-wide in the
 ingress-nginx ConfigMap, so the operator always renders it explicitly.
 
-If you run HAProxy, Traefik, Istio, or a cloud L7 load balancer instead, the
-equivalent configuration exists (`balance hdr(...)` with consistent hashing;
-Istio's `DestinationRule.trafficPolicy.loadBalancer.consistentHash.httpHeaderName`)
-but the operator does not generate it. Use
-`spec.gateway.ingestAffinity.annotations` to carry your controller's
-annotations onto the same Ingress objects, or configure that layer yourself and
-leave `ingestAffinity` unset.
+If you run HAProxy, Traefik, Istio, Envoy, or a cloud L7 load balancer instead,
+**there is no equivalent configuration, and the closest thing is weaker.** What
+those layers offer is single-backend consistent hashing: HAProxy's
+`balance hdr(...)`, Istio's
+`DestinationRule.trafficPolicy.loadBalancer.consistentHash.httpHeaderName`,
+Envoy's ring-hash and Maglev policies, and the session-persistence extensions in
+Gateway API implementations all map one key onto **one** backend. That is `S=1`.
+It is a real and useful mode — it still divides the flush cost by `replicas` —
+but it is not what `subsetSize: 2` means: a tenant pinned to a single replica
+loses all of its capacity when that replica restarts and has to be rehashed
+somewhere else, which is exactly the failure the default subset of two exists to
+avoid. Ravel does not present those configurations as a migration of subset
+affinity, and neither should a runbook. The operator does not generate them
+either. You can use `spec.gateway.ingestAffinity.annotations` to carry your
+controller's own annotations onto the same Ingress objects, or configure that
+layer yourself and leave `ingestAffinity` unset — but read what you configure as
+`S=1` unless the layer genuinely implements subset-of-`S` selection.
+
+### The ingress-nginx backend is deprecated
+
+`backend: ingressNginx` is the default and it keeps working unchanged, but
+ingress-nginx is retiring upstream, so it is deprecated (ADR-0080 decision 1).
+A cluster on it gets an `IngestAffinityBackendDeprecated` condition on its
+`RavelCluster` status, with reason `IngressNginxRetired`; the condition
+disappears once the cluster moves off that backend. Nothing about an existing CR
+changes on upgrade: a CR that never set `backend` deserializes to
+`ingressNginx`, with the same `subsetSize` and the same key. The migration
+target is `backend: ravelNative`, Ravel's own subset router, which does
+rendezvous-hash subset-of-`S` selection independent of whichever ingress or
+Gateway implementation terminates the connection. That backend ships in a later
+change; until it does, `ravelNative` is accepted by the CRD and silences the
+condition but the rendered objects are still today's. Do not switch a production
+cluster to it before its own release note says the router is rendered.
 
 ## Turning it on
 
@@ -128,6 +154,7 @@ That is the whole thing. Everything else defaults: enabled, subset size 2, key
 | Field | Type | Default | Notes |
 |---|---|---|---|
 | `enabled` | boolean | `true` | `false` deletes the Ingress objects and returns to the pre-affinity render. The incident switch. |
+| `backend` | enum | `ingressNginx` | `ingressNginx` (deprecated, see above) or `ravelNative`. Omitting it keeps the backend an existing CR already runs. |
 | `subsetSize` | integer | `2` | Replicas per tenant. Must be at least 1. |
 | `key.source` | enum | `authorizationHeader` | `authorizationHeader`, `header`, or `mtlsSubject`. |
 | `key.headerName` | string | — | Required when `key.source` is `header`. |

--- a/services/ravel-operator/src/controller.rs
+++ b/services/ravel-operator/src/controller.rs
@@ -27,8 +27,8 @@ use serde::de::DeserializeOwned;
 use tracing::{info, warn};
 
 use crate::crd::{
-    Condition, LocalSecretRef, MIN_RESHARD_LEAD_HOURS, RavelCluster, RavelClusterSpec,
-    RavelClusterStatus, ShardOverridesSpec,
+    AffinityBackend, Condition, LocalSecretRef, MIN_RESHARD_LEAD_HOURS, RavelCluster,
+    RavelClusterSpec, RavelClusterStatus, ShardOverridesSpec,
 };
 use crate::reconcile::{
     DEPLOYMENT_KEY_SECRET_KEY, RenderCtx, S3_ACCESS_KEY_ID_KEY, S3_SECRET_ACCESS_KEY_KEY,
@@ -829,7 +829,22 @@ async fn reconcile(obj: Arc<RavelCluster>, ctx: Arc<Context>) -> Result<Action, 
     let instance = obj.name_any();
     let client = &ctx.client;
 
-    match reconcile_inner(&obj, client, &namespace, &instance).await {
+    // Conditions this pass owns beyond `Available`/`Degraded`, computed once
+    // here because either status writer may be the one that runs, and each
+    // PATCHes the whole `conditions` array (RFC 7386 merge patch replaces it
+    // wholesale). Computing them at one call site only would mean the other
+    // writer silently drops them.
+    let extra_conditions = spec_conditions(&obj.spec, obj.metadata.generation);
+
+    match reconcile_inner(
+        &obj,
+        client,
+        &namespace,
+        &instance,
+        extra_conditions.clone(),
+    )
+    .await
+    {
         Ok(action) => Ok(action),
         Err(err) => {
             let (reason, message) = degraded_reason(&err);
@@ -842,6 +857,7 @@ async fn reconcile(obj: Arc<RavelCluster>, ctx: Arc<Context>) -> Result<Action, 
                 obj.metadata.generation,
                 &reason,
                 &message,
+                extra_conditions,
             )
             .await
             {
@@ -860,6 +876,7 @@ async fn reconcile_inner(
     client: &Client,
     namespace: &str,
     instance: &str,
+    extra_conditions: Vec<Condition>,
 ) -> Result<Action, Error> {
     let token_secret = resolve_token_secret(
         client,
@@ -1016,6 +1033,7 @@ async fn reconcile_inner(
         ready_replicas(&gateway_applied),
         ready_replicas(&query_applied),
         maintain_ready,
+        extra_conditions,
     )
     .await?;
 
@@ -1064,21 +1082,51 @@ fn condition(
     }
 }
 
-/// Write the status subresource: observed generation, per-mode ready replicas,
-/// and an `Available` condition derived from whether the gateway and query
-/// tiers report ready replicas.
-#[allow(clippy::too_many_arguments)]
-async fn write_status(
-    client: &Client,
-    namespace: &str,
-    instance: &str,
+/// Conditions derived from the spec alone, independent of whether this pass
+/// succeeds or fails (ADR-0080 decision 1).
+///
+/// Today that is exactly one: `IngestAffinityBackendDeprecated`, set while
+/// ingest affinity is enabled on the legacy ingress-nginx backend, whether that
+/// backend was chosen explicitly or came from the schema default. Absent,
+/// disabled, or `ravelNative` affinity produces no condition at all, so the
+/// deprecation notice disappears the moment a cluster migrates.
+///
+/// The reconcile pass hands the result to whichever status writer runs; there
+/// is deliberately no read-modify-write against live status, which would race
+/// a concurrent writer.
+fn spec_conditions(spec: &RavelClusterSpec, observed_generation: Option<i64>) -> Vec<Condition> {
+    let legacy_backend = spec
+        .gateway
+        .ingest_affinity
+        .as_ref()
+        .is_some_and(|a| a.enabled && matches!(a.backend, AffinityBackend::IngressNginx));
+    if !legacy_backend {
+        return Vec::new();
+    }
+    vec![condition(
+        "IngestAffinityBackendDeprecated",
+        true,
+        observed_generation,
+        "IngressNginxRetired",
+        "ingestAffinity is using the ingress-nginx backend, which is \
+         retired upstream; migrate to backend: ravelNative or an \
+         equivalent Gateway API exposure (see docs/guides/ingest-affinity.md)",
+    )]
+}
+
+/// Build the success-path status: observed generation, per-mode ready replicas,
+/// an `Available` condition derived from whether the gateway and query tiers
+/// report ready replicas, and whatever spec-derived conditions this pass
+/// computed. Pure, so the condition set is testable without a cluster.
+fn build_status(
     observed_generation: Option<i64>,
     gateway_ready: Option<i32>,
     query_ready: Option<i32>,
     maintain_ready: Option<i32>,
-) -> Result<(), Error> {
+    extra_conditions: Vec<Condition>,
+) -> RavelClusterStatus {
     let available = gateway_ready.unwrap_or(0) > 0 && query_ready.unwrap_or(0) > 0;
-    let condition = if available {
+    let available_condition = if available {
         condition(
             "Available",
             true,
@@ -1095,13 +1143,61 @@ async fn write_status(
             "waiting for gateway and query tiers to become ready",
         )
     };
-    let status = RavelClusterStatus {
+    let mut conditions = vec![available_condition];
+    conditions.extend(extra_conditions);
+    RavelClusterStatus {
         observed_generation,
         gateway_ready_replicas: gateway_ready,
         query_ready_replicas: query_ready,
         maintain_ready_replicas: maintain_ready,
-        conditions: vec![condition],
-    };
+        conditions,
+    }
+}
+
+/// Build the failure-path status. Pure counterpart of [`build_status`].
+fn build_degraded_status(
+    observed_generation: Option<i64>,
+    reason: &str,
+    message: &str,
+    extra_conditions: Vec<Condition>,
+) -> RavelClusterStatus {
+    let mut conditions = vec![
+        condition("Degraded", true, observed_generation, reason, message),
+        condition("Available", false, observed_generation, reason, message),
+    ];
+    conditions.extend(extra_conditions);
+    RavelClusterStatus {
+        observed_generation,
+        gateway_ready_replicas: None,
+        query_ready_replicas: None,
+        maintain_ready_replicas: None,
+        conditions,
+    }
+}
+
+/// Write the status subresource: observed generation, per-mode ready replicas,
+/// and an `Available` condition derived from whether the gateway and query
+/// tiers report ready replicas. `extra_conditions` are the spec-derived
+/// conditions this reconcile pass computed (see [`spec_conditions`]); they are
+/// appended because the PATCH replaces the whole `conditions` array.
+#[allow(clippy::too_many_arguments)]
+async fn write_status(
+    client: &Client,
+    namespace: &str,
+    instance: &str,
+    observed_generation: Option<i64>,
+    gateway_ready: Option<i32>,
+    query_ready: Option<i32>,
+    maintain_ready: Option<i32>,
+    extra_conditions: Vec<Condition>,
+) -> Result<(), Error> {
+    let status = build_status(
+        observed_generation,
+        gateway_ready,
+        query_ready,
+        maintain_ready,
+        extra_conditions,
+    );
     patch_status(client, namespace, instance, &status).await
 }
 
@@ -1109,7 +1205,9 @@ async fn write_status(
 /// status write (finding 3), so the failure is visible on `.status` rather than
 /// only in operator logs. Also flips `Available` to `False` with the same
 /// reason so a `kubectl wait --for=condition=Available` fails fast with an
-/// explanation instead of silently timing out.
+/// explanation instead of silently timing out. `extra_conditions` carries the
+/// same spec-derived conditions the success path appends, so a failing
+/// reconcile does not drop them.
 async fn write_degraded_status(
     client: &Client,
     namespace: &str,
@@ -1117,17 +1215,9 @@ async fn write_degraded_status(
     observed_generation: Option<i64>,
     reason: &str,
     message: &str,
+    extra_conditions: Vec<Condition>,
 ) -> Result<(), Error> {
-    let status = RavelClusterStatus {
-        observed_generation,
-        gateway_ready_replicas: None,
-        query_ready_replicas: None,
-        maintain_ready_replicas: None,
-        conditions: vec![
-            condition("Degraded", true, observed_generation, reason, message),
-            condition("Available", false, observed_generation, reason, message),
-        ],
-    };
+    let status = build_degraded_status(observed_generation, reason, message, extra_conditions);
     patch_status(client, namespace, instance, &status).await
 }
 
@@ -1245,6 +1335,9 @@ pub async fn run() -> Result<(), Error> {
 #[allow(clippy::expect_used)]
 mod tests {
     use super::*;
+    use crate::crd::{
+        GatewaySpec, IngestAffinitySpec, MaintainSpec, QuerySpec, S3Spec, StorageSpec,
+    };
 
     #[test]
     fn rfc3339_formats_known_instants() {
@@ -1262,6 +1355,145 @@ mod tests {
         let (reason, message) = degraded_reason(&err);
         assert_eq!(reason, "SecretNotFound");
         assert!(message.contains("ravel-tokens"), "message names the Secret");
+    }
+
+    /// A minimal spec whose only interesting field is `gateway.ingestAffinity`.
+    fn spec_with_affinity(affinity: Option<IngestAffinitySpec>) -> RavelClusterSpec {
+        RavelClusterSpec {
+            image: "registry.example/ravel:v1".to_string(),
+            image_pull_policy: None,
+            shards: 4,
+            storage: StorageSpec {
+                s3: S3Spec {
+                    bucket: "ravel-data".to_string(),
+                    region: "eu-west-1".to_string(),
+                    endpoint: None,
+                    credentials_secret_ref: LocalSecretRef {
+                        name: "ravel-s3".to_string(),
+                    },
+                },
+            },
+            tenant_tokens_secret_ref: None,
+            deployment_key_secret_ref: None,
+            gateway: GatewaySpec {
+                ingest_affinity: affinity,
+                ..GatewaySpec::default()
+            },
+            query: QuerySpec::default(),
+            maintain: MaintainSpec::default(),
+            retention: None,
+            shard_overrides: None,
+        }
+    }
+
+    /// Condition `type`s in order, which is what the assertions below are
+    /// really about: a condition present at all, and no other one dropped.
+    fn condition_types(conditions: &[Condition]) -> Vec<&str> {
+        conditions.iter().map(|c| c.r#type.as_str()).collect()
+    }
+
+    fn find<'a>(conditions: &'a [Condition], condition_type: &str) -> &'a Condition {
+        conditions
+            .iter()
+            .find(|c| c.r#type == condition_type)
+            .expect("condition present")
+    }
+
+    /// The legacy-backend deprecation condition rides alongside `Available` on
+    /// the success path and alongside both `Degraded` and `Available` on the
+    /// failure path. Both status writers PATCH the whole `conditions` array, so
+    /// the failure-path assertion is the one that catches a regression where
+    /// only the success path learned about the new condition.
+    #[test]
+    fn legacy_backend_condition_appears_without_dropping_available_or_degraded() {
+        let spec = spec_with_affinity(Some(IngestAffinitySpec::default()));
+        let extra = spec_conditions(&spec, Some(7));
+        assert_eq!(
+            condition_types(&extra),
+            vec!["IngestAffinityBackendDeprecated"]
+        );
+
+        let ok = build_status(Some(7), Some(3), Some(2), Some(1), extra.clone());
+        assert_eq!(
+            condition_types(&ok.conditions),
+            vec!["Available", "IngestAffinityBackendDeprecated"]
+        );
+        assert_eq!(find(&ok.conditions, "Available").status, "True");
+
+        let deprecated = find(&ok.conditions, "IngestAffinityBackendDeprecated");
+        assert_eq!(deprecated.status, "True");
+        assert_eq!(deprecated.reason, "IngressNginxRetired");
+        assert_eq!(deprecated.observed_generation, Some(7));
+        assert!(
+            deprecated.message.contains("backend: ravelNative"),
+            "message names the migration target: {}",
+            deprecated.message
+        );
+
+        let degraded = build_degraded_status(Some(7), "SecretNotFound", "no such Secret", extra);
+        assert_eq!(
+            condition_types(&degraded.conditions),
+            vec!["Degraded", "Available", "IngestAffinityBackendDeprecated"]
+        );
+        assert_eq!(find(&degraded.conditions, "Degraded").status, "True");
+        assert_eq!(find(&degraded.conditions, "Available").status, "False");
+    }
+
+    /// An existing CR, whose serialized spec predates the `backend` field
+    /// entirely, still gets the deprecation condition: the field defaults to
+    /// `ingressNginx`, which is exactly the backend that CR is running.
+    #[test]
+    fn legacy_backend_condition_appears_for_a_cr_that_never_set_backend() {
+        let affinity: IngestAffinitySpec = serde_json::from_value(serde_json::json!({
+            "ingressClassName": "nginx",
+            "hosts": ["ingest.example.com"],
+        }))
+        .expect("legacy ingestAffinity JSON deserializes");
+        assert_eq!(affinity.backend, AffinityBackend::IngressNginx);
+
+        let spec = spec_with_affinity(Some(affinity));
+        assert_eq!(
+            condition_types(&spec_conditions(&spec, Some(1))),
+            vec!["IngestAffinityBackendDeprecated"]
+        );
+    }
+
+    /// No deprecation condition when there is no legacy backend in play, and
+    /// the rest of the status is unchanged in each case: `Available` alone on
+    /// success, `Degraded` + `Available` on failure, exactly as before this
+    /// condition existed.
+    #[test]
+    fn no_legacy_backend_condition_when_affinity_is_native_disabled_or_absent() {
+        let native = spec_with_affinity(Some(IngestAffinitySpec {
+            backend: AffinityBackend::RavelNative,
+            ..IngestAffinitySpec::default()
+        }));
+        let disabled = spec_with_affinity(Some(IngestAffinitySpec {
+            enabled: false,
+            ..IngestAffinitySpec::default()
+        }));
+        let disabled_native = spec_with_affinity(Some(IngestAffinitySpec {
+            enabled: false,
+            backend: AffinityBackend::RavelNative,
+            ..IngestAffinitySpec::default()
+        }));
+        let absent = spec_with_affinity(None);
+
+        for spec in [&native, &disabled, &disabled_native, &absent] {
+            let extra = spec_conditions(spec, Some(2));
+            assert!(
+                extra.is_empty(),
+                "no spec-derived condition, got {:?}",
+                condition_types(&extra)
+            );
+            let ok = build_status(Some(2), Some(1), Some(1), None, extra.clone());
+            assert_eq!(condition_types(&ok.conditions), vec!["Available"]);
+            let degraded = build_degraded_status(Some(2), "ReconcileError", "boom", extra);
+            assert_eq!(
+                condition_types(&degraded.conditions),
+                vec!["Degraded", "Available"]
+            );
+        }
     }
 
     #[test]

--- a/services/ravel-operator/src/crd.rs
+++ b/services/ravel-operator/src/crd.rs
@@ -225,6 +225,17 @@ pub struct IngestAffinitySpec {
     #[serde(default = "default_true")]
     pub enabled: bool,
 
+    /// Which implementation carries out the pinning (ADR-0080 decision 1).
+    /// Defaults to [`AffinityBackend::IngressNginx`], so a CR written before
+    /// this field existed keeps the backend it already runs, with the same
+    /// `subsetSize` and `key` semantics.
+    ///
+    /// `ingressNginx` is deprecated: ingress-nginx is retiring upstream, and a
+    /// cluster using it gets an `IngestAffinityBackendDeprecated` condition on
+    /// its `RavelCluster` status.
+    #[serde(default)]
+    pub backend: AffinityBackend,
+
     /// How many replicas a tenant's traffic is pinned to. Defaults to
     /// [`DEFAULT_AFFINITY_SUBSET_SIZE`] (two), not one, so a single replica
     /// loss does not concentrate a tenant on one process.
@@ -288,6 +299,7 @@ impl Default for IngestAffinitySpec {
     fn default() -> Self {
         Self {
             enabled: default_true(),
+            backend: AffinityBackend::default(),
             subset_size: default_subset_size(),
             key: AffinityKeySpec::default(),
             ingress_class_name: None,
@@ -297,6 +309,27 @@ impl Default for IngestAffinitySpec {
             annotations: BTreeMap::new(),
         }
     }
+}
+
+/// Which implementation carries out subset pinning (ADR-0080 decision 1).
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, JsonSchema, Default)]
+#[serde(rename_all = "camelCase")]
+pub enum AffinityBackend {
+    /// Render ingress-nginx `Ingress` objects carrying the
+    /// `upstream-hash-by-subset` annotation family. The default, so an existing
+    /// CR that never set `backend` keeps running exactly what it runs today.
+    ///
+    /// Deprecated: ingress-nginx is retiring upstream. A cluster on this
+    /// backend gets an `IngestAffinityBackendDeprecated` condition on its
+    /// status; migrate to [`AffinityBackend::RavelNative`] or to an equivalent
+    /// Gateway API exposure (`docs/guides/ingest-affinity.md`).
+    #[default]
+    IngressNginx,
+
+    /// Ravel's own subset router: deterministic rendezvous-hash selection over
+    /// the gateway's live endpoints, independent of which ingress or Gateway
+    /// implementation terminates the connection.
+    RavelNative,
 }
 
 /// Which piece of authentication material the load balancer hashes to identify
@@ -1086,6 +1119,78 @@ mod tests {
             rules[0].message.as_deref(),
             Some(AFFINITY_HEADER_NAME_MESSAGE)
         );
+    }
+
+    #[test]
+    fn affinity_backend_defaults_to_ingress_nginx_for_an_existing_cr() {
+        // ADR-0080 decision 1: `backend` is additive. A CR serialized before
+        // the field existed must deserialize onto the backend it already runs,
+        // with subsetSize and key semantics untouched -- an upgrade that
+        // silently moved either would be a behavior change.
+        let affinity: IngestAffinitySpec = serde_json::from_value(serde_json::json!({
+            "enabled": true,
+            "subsetSize": 3,
+            "key": { "source": "header", "headerName": "x-tenant" },
+            "ingressClassName": "nginx",
+            "hosts": ["ingest.example.com"],
+            "tlsSecretName": "ingest-tls",
+            "grpc": true,
+        }))
+        .expect("legacy ingestAffinity JSON deserializes");
+        assert_eq!(affinity.backend, AffinityBackend::IngressNginx);
+        assert_eq!(affinity.subset_size, 3);
+        assert_eq!(affinity.key.source, AffinityKeySource::Header);
+        assert_eq!(affinity.key.header_name.as_deref(), Some("x-tenant"));
+
+        assert_eq!(
+            IngestAffinitySpec::default().backend,
+            AffinityBackend::IngressNginx
+        );
+
+        // The schema exposes the field, so a CR can opt into the new backend.
+        let affinity_props = ravel_cluster_crd().spec.versions[0]
+            .schema
+            .as_ref()
+            .expect("schema")
+            .open_api_v3_schema
+            .as_ref()
+            .expect("root schema")
+            .properties
+            .as_ref()
+            .expect("root props")
+            .get("spec")
+            .expect("spec prop")
+            .properties
+            .as_ref()
+            .expect("spec props")
+            .get("gateway")
+            .expect("gateway prop")
+            .properties
+            .as_ref()
+            .expect("gateway props")
+            .get("ingestAffinity")
+            .expect("ingestAffinity prop")
+            .properties
+            .clone()
+            .expect("affinity props");
+        assert!(
+            affinity_props.contains_key("backend"),
+            "ingestAffinity must expose backend in its schema"
+        );
+    }
+
+    #[test]
+    fn affinity_backends_serialize_as_documented_camel_case() {
+        // Public CRD enum values, quoted in the guide and in manifests.
+        for (backend, text) in [
+            (AffinityBackend::IngressNginx, "ingressNginx"),
+            (AffinityBackend::RavelNative, "ravelNative"),
+        ] {
+            assert_eq!(
+                serde_json::to_value(backend).expect("serialize"),
+                serde_json::Value::String(text.to_string())
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Adds AffinityBackend (IngressNginx default, RavelNative) to
IngestAffinitySpec per ADR-0080. An existing CR that never set this
field deserializes to IngressNginx unchanged, so no upgrade silently
changes subsetSize or key behavior. When the effective backend is
IngressNginx, the reconcile loop now also surfaces an
IngestAffinityBackendDeprecated status Condition (reason
IngressNginxRetired), computed once per pass and threaded into both
write_status and write_degraded_status via a new extra_conditions
parameter so it coexists with Available/Degraded instead of replacing
them.

Also corrects docs/guides/ingest-affinity.md's false claim that
HAProxy/Istio/Envoy consistent hashing is equivalent to ingress-nginx's
upstream-hash-by-subset-size; those give single-backend (S=1) behavior,
not subset-of-S.

Fixes: #153
Refs: #150

(Recreated: original PR #167's CI never triggered - zero check-runs on the commit even after close/reopen. Same branch, same commit.)