### PR TITLE
docs: renumber ADR stub 0081 to 0082, resolve collision

### DIFF
--- a/docs/adrs/0081-provisioning-shard-count-drift-tolerance.md
+++ b/docs/adrs/0081-provisioning-shard-count-drift-tolerance.md
@@ -1,3 +1,0 @@
-# ADR-0081: Provisioning shard-count drift tolerance for an evolving default
-
-Status: claimed

--- a/docs/adrs/0082-provisioning-shard-count-drift-tolerance.md
+++ b/docs/adrs/0082-provisioning-shard-count-drift-tolerance.md
@@ -1,0 +1,3 @@
+# ADR-0082: Provisioning shard-count drift tolerance for an evolving default
+
+Status: claimed


### PR DESCRIPTION
PR #178 claimed 0081 for provisioning shard-count drift tolerance. A concurrent session's PR #172 landed full ADR-0081 content (container-first quickstart) after that, leaving a duplicate number. This stub yields and renumbers to 0082, the next free slot as of this push.

Refs: #166