### PR TITLE
feat(operator): add Gateway API exposure independent of ingest affinity

### DIFF
--- a/deploy/k8s/operator/crd.yaml
+++ b/deploy/k8s/operator/crd.yaml
@@ -59,6 +59,54 @@
                         ],
                         "type": "object"
                       },
+                      "exposure": {
+                        "description": "Gateway API exposure (ADR-0080 decision 2), independent of\n[`GatewaySpec::ingest_affinity`]. Omit to keep today's behavior exactly:\nno `HTTPRoute`/`GRPCRoute` is rendered and exposure for a plain\ndeployment stays entirely user-managed outside Ravel.\n\nUnlike `ingest_affinity`, this renders standard\n`gateway.networking.k8s.io` routes onto a user-provided `Gateway`; it can\nbe set with affinity disabled (plain routing, no tenant pinning) or\ncombined with `backend: ravelNative`. It cannot be combined with an\nenabled `ingestAffinity` on `backend: ingressNginx`: the Gateway API path\nand the annotation-driven Ingress path are two independent routes to the\nsame Service, so traffic on the Gateway API route would bypass the nginx\nsubset annotations entirely. That combination is rejected at admission by\na CEL rule attached to the `gateway` object (see [`ravel_cluster_crd`]).",
+                        "nullable": true,
+                        "properties": {
+                          "gatewayApi": {
+                            "description": "Gateway API (`gateway.networking.k8s.io`) exposure: the operator renders\none `HTTPRoute` and, when `grpc` is true, one `GRPCRoute` attached to an\nexisting `Gateway`. Omit for no Gateway API routing.",
+                            "nullable": true,
+                            "properties": {
+                              "gatewayRef": {
+                                "description": "The existing `Gateway` the rendered routes attach to via `parentRefs`.",
+                                "properties": {
+                                  "name": {
+                                    "description": "Name of the `Gateway`.",
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "description": "Namespace of the `Gateway`. Defaults to the `RavelCluster`'s own\nnamespace when omitted (Gateway API resolves an omitted `parentRefs`\nnamespace to the route's own namespace, which the operator renders into\nthe `RavelCluster`'s namespace).",
+                                    "nullable": true,
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object"
+                              },
+                              "grpc": {
+                                "default": true,
+                                "description": "Also render a `GRPCRoute` for OTLP/gRPC (port 4317). Defaults to true,\nmirroring [`IngestAffinitySpec::grpc`]: gRPC is the main OTLP ingest\npath.",
+                                "type": "boolean"
+                              },
+                              "hostnames": {
+                                "default": [],
+                                "description": "Hostnames the rendered routes answer on. Empty renders routes with no\n`hostnames`, which match every hostname the parent `Gateway`'s listeners\naccept.",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "required": [
+                              "gatewayRef"
+                            ],
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
                       "fold": {
                         "description": "Catalog fold tuning. Fold is a pure query-cost optimization and only\nruns in the gateway tier, so it is a gateway-only field.",
                         "nullable": true,
@@ -197,7 +245,13 @@
                         "type": "object"
                       }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "x-kubernetes-validations": [
+                      {
+                        "message": "gateway.exposure.gatewayApi cannot be combined with an enabled gateway.ingestAffinity on backend: ingressNginx -- traffic on the Gateway API path would bypass the nginx subset annotations entirely; use backend: ravelNative or disable ingestAffinity",
+                        "rule": "!has(self.exposure) || !has(self.exposure.gatewayApi) || !has(self.ingestAffinity) || !has(self.ingestAffinity.enabled) || !self.ingestAffinity.enabled || !has(self.ingestAffinity.backend) || self.ingestAffinity.backend != 'ingressNginx'"
+                      }
+                    ]
                   },
                   "image": {
                     "description": "Container image for every mode's pod (`ravel-server`).",

--- a/deploy/k8s/operator/crd.yaml
+++ b/deploy/k8s/operator/crd.yaml
@@ -157,14 +157,14 @@
                             "type": "boolean"
                           },
                           "hosts": {
-                            "description": "Hostnames the ingest Ingress answers on. Empty renders a single\nhost-less rule, which matches any host reaching the controller.",
+                            "description": "Hostnames the ingest Ingress answers on. Empty renders a single\nhost-less rule, which matches any host reaching the controller.\n\nLegacy `backend: ingressNginx` only. `gateway.exposure.gatewayAPI\n.hostnames` is the equivalent field for Gateway API exposure; the two\nare independent and neither reads the other.",
                             "items": {
                               "type": "string"
                             },
                             "type": "array"
                           },
                           "ingressClassName": {
-                            "description": "`spec.ingressClassName` on the rendered Ingress objects. Omit to let the\ncluster's default IngressClass apply.",
+                            "description": "`spec.ingressClassName` on the rendered Ingress objects. Omit to let the\ncluster's default IngressClass apply.\n\nLegacy `backend: ingressNginx` only. Has no effect under\n`backend: ravelNative`, and no effect on `gateway.exposure.gatewayAPI`\nrouting (Gateway API attachment goes through `exposure.gatewayAPI\n.gatewayRef` instead, ADR-0080 decision 2).",
                             "nullable": true,
                             "type": "string"
                           },
@@ -201,7 +201,7 @@
                             "type": "integer"
                           },
                           "tlsSecretName": {
-                            "description": "TLS Secret for `spec.tls` on the rendered Ingress objects. Strongly\nrecommended and effectively required for the gRPC Ingress: ingress-nginx\nserves HTTP/2 to clients over TLS, and OTLP/gRPC needs HTTP/2. Tenant\ntokens are bearer tokens, so plaintext ingest exposes them.",
+                            "description": "TLS Secret for `spec.tls` on the rendered Ingress objects. Strongly\nrecommended and effectively required for the gRPC Ingress: ingress-nginx\nserves HTTP/2 to clients over TLS, and OTLP/gRPC needs HTTP/2. Tenant\ntokens are bearer tokens, so plaintext ingest exposes them.\n\nLegacy `backend: ingressNginx` only. Gateway API exposure terminates\nTLS at the referenced `Gateway`'s own listener, which this operator\ndoes not render; configure `tls.certificateRefs` on that Gateway\ndirectly (ADR-0080 decision 2).",
                             "nullable": true,
                             "type": "string"
                           }

--- a/deploy/k8s/operator/rbac.yaml
+++ b/deploy/k8s/operator/rbac.yaml
@@ -6,6 +6,10 @@
 #   - Ingresses: the same lifecycle, for the ingest-affinity Ingress objects
 #     (ADR-0076 decision 1). Delete is what lets gateway.ingestAffinity.enabled
 #     go back to false without leaving an orphan routing live ingest traffic.
+#   - HTTPRoutes/GRPCRoutes (gateway.networking.k8s.io): the same lifecycle, for
+#     the Gateway API exposure routes (ADR-0080 decision 2). Delete is what lets
+#     gateway.exposure be removed without leaving an orphan route attached to
+#     the Gateway.
 #   - RavelCluster (and its status subresource): watch the spec, write status.
 #   - Secrets: get only. The operator reads the credentials and tenant-token
 #     Secrets to resolve tenant names; it never lists, writes, or watches them.
@@ -35,6 +39,9 @@ rules:
     verbs: ["create", "update", "patch", "get", "list", "watch", "delete"]
   - apiGroups: ["networking.k8s.io"]
     resources: ["ingresses"]
+    verbs: ["create", "update", "patch", "get", "list", "watch", "delete"]
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["httproutes", "grpcroutes"]
     verbs: ["create", "update", "patch", "get", "list", "watch", "delete"]
   - apiGroups: ["ravel.nofire.ai"]
     resources: ["ravelclusters"]

--- a/docs/guides/ingest-affinity.md
+++ b/docs/guides/ingest-affinity.md
@@ -129,6 +129,49 @@ change; until it does, `ravelNative` is accepted by the CRD and silences the
 condition but the rendered objects are still today's. Do not switch a production
 cluster to it before its own release note says the router is rendered.
 
+### Gateway API exposure
+
+`gateway.exposure.gatewayAPI` is a separate, independent field from
+`ingestAffinity` (ADR-0080 decision 2): it renders standard
+`gateway.networking.k8s.io` `HTTPRoute` and `GRPCRoute` objects attached to an
+existing `Gateway`, instead of the ingress-nginx-specific `Ingress` objects
+above. It carries no vendor extension, so it works with any conformant
+Gateway API implementation (Envoy Gateway, NGINX Gateway Fabric, Cilium,
+Istio, a managed cloud implementation) — Ravel does not couple its CRD to one.
+
+```yaml
+spec:
+  gateway:
+    exposure:
+      gatewayAPI:
+        gatewayRef:
+          name: public-gateway
+          # namespace: defaults to this RavelCluster's own namespace
+        hostnames: [ingest.example.com]
+        grpc: true   # also render a GRPCRoute; default true
+```
+
+This has no tenant-affinity effect by itself: routing goes straight to the
+gateway Service, load-balanced however the Gateway implementation load-balances
+a Service backendRef (typically endpoint-aware round robin, not subset-of-`S`).
+It can be combined with `backend: ravelNative` affinity once that backend ships
+(a later change points the rendered routes at the router's Service instead);
+it **cannot** be combined with an *enabled* `backend: ingressNginx` affinity —
+the CRD rejects that combination at admission with a CEL rule, because traffic
+on the Gateway API path would bypass the nginx subset annotations entirely,
+silently losing tenant pinning on that path while the Ingress objects keep
+enforcing it on theirs. If you need Gateway API exposure today, either leave
+`ingestAffinity` unset/disabled, or wait for `backend: ravelNative`.
+
+TLS is not rendered by the operator here: Gateway API exposure terminates TLS
+at the referenced `Gateway`'s own listener, which you configure directly
+(`tls.certificateRefs`) — there is no `tlsSecretName` equivalent under
+`exposure.gatewayAPI`, unlike the legacy `ingestAffinity.tlsSecretName`.
+
+Requires Gateway API **v1.1 or newer** in the cluster: `GRPCRoute` only
+reached the stable `v1` API version in Gateway API v1.1 (it was `v1alpha2`
+in v1.0), and the operator renders it at `v1`.
+
 ## Turning it on
 
 ```yaml

--- a/services/ravel-operator/src/controller.rs
+++ b/services/ravel-operator/src/controller.rs
@@ -16,6 +16,7 @@ use k8s_openapi::api::apps::v1::Deployment;
 use k8s_openapi::api::core::v1::{Secret, Service};
 use k8s_openapi::api::networking::v1::Ingress;
 use kube::api::{DeleteParams, Patch, PatchParams};
+use kube::core::DynamicObject;
 use kube::{Api, Client, Resource, ResourceExt};
 use kube_runtime::controller::{Action, Controller};
 use kube_runtime::watcher;
@@ -32,7 +33,8 @@ use crate::crd::{
 };
 use crate::reconcile::{
     DEPLOYMENT_KEY_SECRET_KEY, RenderCtx, S3_ACCESS_KEY_ID_KEY, S3_SECRET_ACCESS_KEY_KEY,
-    desired_objects, possible_ingest_ingress_names,
+    desired_objects, grpcroute_api_resource, httproute_api_resource, possible_gateway_route_names,
+    possible_ingest_ingress_names,
 };
 
 /// Server-side-apply field manager name.
@@ -816,6 +818,24 @@ where
     Ok(applied)
 }
 
+/// Server-side-apply a [`DynamicObject`], used for the Gateway API routes
+/// (ADR-0080 decision 2) whose CRD the operator does not own and so cannot model
+/// as a typed [`Resource<DynamicType = ()>`] the generic [`apply`] requires.
+///
+/// The object already carries its `apiVersion`/`kind` in `types` (set by
+/// `DynamicObject::new` from the [`crate::reconcile::httproute_api_resource`] /
+/// [`crate::reconcile::grpcroute_api_resource`] `ApiResource`), so the applied
+/// document is self-describing, as server-side apply requires.
+async fn apply_dynamic(
+    api: &Api<DynamicObject>,
+    name: &str,
+    obj: &DynamicObject,
+) -> Result<(), Error> {
+    let params = PatchParams::apply(FIELD_MANAGER).force();
+    api.patch(name, &params, &Patch::Apply(obj)).await?;
+    Ok(())
+}
+
 /// Reconcile one `RavelCluster` to its desired Deployments and Services.
 ///
 /// Wraps [`reconcile_inner`] so that any failure before the success-path status
@@ -986,6 +1006,47 @@ async fn reconcile_inner(
         // Ignore not-found: the Ingress may never have existed, which is the
         // steady state for every cluster that never enables affinity.
         if let Err(err) = ingresses.delete(&name, &DeleteParams::default()).await
+            && !is_not_found(&err)
+        {
+            return Err(err.into());
+        }
+    }
+
+    // Gateway API exposure (ADR-0080 decision 2): apply the HTTPRoute/GRPCRoute
+    // the spec asks for, then delete every route name it does not, mirroring the
+    // Ingress apply-then-sweep above. Separate Api<DynamicObject> clients per
+    // kind because HTTPRoute and GRPCRoute are distinct resource kinds whose CRD
+    // the operator does not own (rendered as DynamicObjects, k8s-openapi does
+    // not vendor the gateway.networking.k8s.io group).
+    let httproutes: Api<DynamicObject> =
+        Api::namespaced_with(client.clone(), namespace, &httproute_api_resource());
+    let grpcroutes: Api<DynamicObject> =
+        Api::namespaced_with(client.clone(), namespace, &grpcroute_api_resource());
+    let (desired_httproute, desired_grpcroute) = desired.gateway_routes;
+    let mut desired_route_names: BTreeSet<String> = BTreeSet::new();
+    for (route, api) in [
+        (desired_httproute, &httproutes),
+        (desired_grpcroute, &grpcroutes),
+    ] {
+        let Some(mut route) = route else { continue };
+        let name = route.name_any();
+        route.metadata.namespace = Some(namespace.to_string());
+        route.metadata.owner_references = owner.clone();
+        apply_dynamic(api, &name, &route).await?;
+        desired_route_names.insert(name);
+    }
+    // possible_gateway_route_names returns [httproute, grpcroute] in a fixed
+    // order, so delete index 0 via the HTTPRoute Api and index 1 via the
+    // GRPCRoute Api. Ignore not-found: a route may never have existed, which is
+    // the steady state for every cluster that never sets exposure.
+    for (name, api) in possible_gateway_route_names(instance)
+        .into_iter()
+        .zip([&httproutes, &grpcroutes])
+    {
+        if desired_route_names.contains(&name) {
+            continue;
+        }
+        if let Err(err) = api.delete(&name, &DeleteParams::default()).await
             && !is_not_found(&err)
         {
             return Err(err.into());

--- a/services/ravel-operator/src/crd.rs
+++ b/services/ravel-operator/src/crd.rs
@@ -188,6 +188,23 @@ pub struct GatewaySpec {
     /// object key, so a reroute is always correct.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ingest_affinity: Option<IngestAffinitySpec>,
+
+    /// Gateway API exposure (ADR-0080 decision 2), independent of
+    /// [`GatewaySpec::ingest_affinity`]. Omit to keep today's behavior exactly:
+    /// no `HTTPRoute`/`GRPCRoute` is rendered and exposure for a plain
+    /// deployment stays entirely user-managed outside Ravel.
+    ///
+    /// Unlike `ingest_affinity`, this renders standard
+    /// `gateway.networking.k8s.io` routes onto a user-provided `Gateway`; it can
+    /// be set with affinity disabled (plain routing, no tenant pinning) or
+    /// combined with `backend: ravelNative`. It cannot be combined with an
+    /// enabled `ingestAffinity` on `backend: ingressNginx`: the Gateway API path
+    /// and the annotation-driven Ingress path are two independent routes to the
+    /// same Service, so traffic on the Gateway API route would bypass the nginx
+    /// subset annotations entirely. That combination is rejected at admission by
+    /// a CEL rule attached to the `gateway` object (see [`ravel_cluster_crd`]).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exposure: Option<GatewayExposureSpec>,
 }
 
 impl Default for GatewaySpec {
@@ -198,8 +215,61 @@ impl Default for GatewaySpec {
             credentials_secret_ref: None,
             fold: None,
             ingest_affinity: None,
+            exposure: None,
         }
     }
+}
+
+/// Ravel-owned exposure for the gateway tier (ADR-0080 decision 2), separate
+/// from ingest affinity.
+///
+/// A single wrapper struct so a later exposure mechanism (an alternative to
+/// Gateway API) becomes a new sibling field here rather than another optional
+/// on `GatewaySpec`.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct GatewayExposureSpec {
+    /// Gateway API (`gateway.networking.k8s.io`) exposure: the operator renders
+    /// one `HTTPRoute` and, when `grpc` is true, one `GRPCRoute` attached to an
+    /// existing `Gateway`. Omit for no Gateway API routing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gateway_api: Option<GatewayApiExposureSpec>,
+}
+
+/// Gateway API exposure config (ADR-0080 decision 2).
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct GatewayApiExposureSpec {
+    /// The existing `Gateway` the rendered routes attach to via `parentRefs`.
+    pub gateway_ref: GatewayReference,
+
+    /// Hostnames the rendered routes answer on. Empty renders routes with no
+    /// `hostnames`, which match every hostname the parent `Gateway`'s listeners
+    /// accept.
+    #[serde(default)]
+    pub hostnames: Vec<String>,
+
+    /// Also render a `GRPCRoute` for OTLP/gRPC (port 4317). Defaults to true,
+    /// mirroring [`IngestAffinitySpec::grpc`]: gRPC is the main OTLP ingest
+    /// path.
+    #[serde(default = "default_true")]
+    pub grpc: bool,
+}
+
+/// Reference to an existing `Gateway` (`gateway.networking.k8s.io`) the rendered
+/// routes attach to.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct GatewayReference {
+    /// Name of the `Gateway`.
+    pub name: String,
+
+    /// Namespace of the `Gateway`. Defaults to the `RavelCluster`'s own
+    /// namespace when omitted (Gateway API resolves an omitted `parentRefs`
+    /// namespace to the route's own namespace, which the operator renders into
+    /// the `RavelCluster`'s namespace).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub namespace: Option<String>,
 }
 
 /// Layer-7 ingest affinity for the gateway tier (ADR-0076 decision 1).
@@ -637,6 +707,7 @@ pub fn ravel_cluster_crd() -> CustomResourceDefinition {
     inject_shards_immutability(&mut crd);
     inject_minimum_bounds(&mut crd);
     inject_ingest_affinity_constraints(&mut crd);
+    inject_gateway_exposure_affinity_guard(&mut crd);
     crd
 }
 
@@ -799,6 +870,77 @@ fn inject_ingest_affinity_constraints(crd: &mut CustomResourceDefinition) {
         {
             header_name.pattern = Some(AFFINITY_HEADER_NAME_PATTERN.to_string());
         }
+    }
+}
+
+/// Message surfaced to a user who combines Gateway API exposure with an enabled
+/// ingress-nginx ingest affinity (ADR-0080 decision 2).
+const GATEWAY_EXPOSURE_AFFINITY_MESSAGE: &str = "gateway.exposure.gatewayApi cannot be \
+    combined with an enabled gateway.ingestAffinity on backend: ingressNginx -- traffic on the \
+    Gateway API path would bypass the nginx subset annotations entirely; use backend: \
+    ravelNative or disable ingestAffinity";
+
+/// The CEL rule rejecting Gateway API exposure alongside an enabled
+/// ingress-nginx affinity (ADR-0080 decision 2), kept as a constant so the
+/// injected rule and the logic unit test cannot drift.
+///
+/// It passes (no rejection) unless ALL of these hold at once: `exposure.gatewayApi`
+/// is set, `ingestAffinity` is present and `enabled`, and its `backend` is
+/// `ingressNginx`. The disjunction reads as "the combination is fine if any
+/// precondition of the bad case is absent".
+const GATEWAY_EXPOSURE_AFFINITY_RULE: &str = "!has(self.exposure) || \
+    !has(self.exposure.gatewayApi) || !has(self.ingestAffinity) || \
+    !has(self.ingestAffinity.enabled) || !self.ingestAffinity.enabled || \
+    !has(self.ingestAffinity.backend) || self.ingestAffinity.backend != 'ingressNginx'";
+
+/// Attach the Gateway-API-exposure-versus-legacy-affinity guard (ADR-0080
+/// decision 2) to the `gateway` property itself.
+///
+/// The rule spans two sibling fields (`exposure` and `ingestAffinity`) rather
+/// than validating one struct against its own fields as the `headerName`
+/// precedent does, so it is attached at the `gateway` object level, not nested
+/// inside `ingestAffinity`. Injected post-hoc for the same reason the other
+/// injectors are: it keeps the rule directly unit-testable without a live API
+/// server, and does not depend on which validation attributes this `schemars`
+/// major happens to emit. Every step bails out rather than panicking if the
+/// schema shape is not what it expects, matching the existing injectors.
+fn inject_gateway_exposure_affinity_guard(crd: &mut CustomResourceDefinition) {
+    // `has()` guards on every field in the path -- exposure, exposure.gatewayApi,
+    // ingestAffinity, ingestAffinity.enabled, ingestAffinity.backend -- because
+    // each is optional or carries a serde default: a submitted manifest may omit
+    // any of them, and a CEL rule that reads a missing field errors instead of
+    // passing. `backend` is materialized to `ingressNginx` by the schema default
+    // before CEL evaluates, so the `has(self.ingestAffinity.backend)` guard is a
+    // defensive belt, not the load-bearing check.
+    let rule = ValidationRule {
+        rule: GATEWAY_EXPOSURE_AFFINITY_RULE.to_string(),
+        message: Some(GATEWAY_EXPOSURE_AFFINITY_MESSAGE.to_string()),
+        ..Default::default()
+    };
+    for version in &mut crd.spec.versions {
+        let Some(schema) = version.schema.as_mut() else {
+            continue;
+        };
+        let Some(root) = schema.open_api_v3_schema.as_mut() else {
+            continue;
+        };
+        let Some(props) = root.properties.as_mut() else {
+            continue;
+        };
+        let Some(spec) = props.get_mut("spec") else {
+            continue;
+        };
+        let Some(spec_props) = spec.properties.as_mut() else {
+            continue;
+        };
+        let Some(gateway) = spec_props.get_mut("gateway") else {
+            continue;
+        };
+        // Append rather than replace: leave room for a future rule on `gateway`
+        // without silently dropping this one.
+        let mut rules = gateway.x_kubernetes_validations.take().unwrap_or_default();
+        rules.push(rule.clone());
+        gateway.x_kubernetes_validations = Some(rules);
     }
 }
 
@@ -1279,5 +1421,188 @@ mod tests {
         assert_eq!(spec.maintain.replicas, 1);
         assert!(spec.maintain.enabled);
         assert_eq!(spec.image_pull_policy, None);
+    }
+
+    /// The `gateway` schema property for `ravel_cluster_crd()`.
+    fn gateway_schema_props() -> BTreeMap<
+        String,
+        k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::JSONSchemaProps,
+    > {
+        ravel_cluster_crd().spec.versions[0]
+            .schema
+            .as_ref()
+            .expect("schema")
+            .open_api_v3_schema
+            .as_ref()
+            .expect("root schema")
+            .properties
+            .as_ref()
+            .expect("root props")
+            .get("spec")
+            .expect("spec prop")
+            .properties
+            .as_ref()
+            .expect("spec props")
+            .get("gateway")
+            .expect("gateway prop")
+            .properties
+            .clone()
+            .expect("gateway props")
+    }
+
+    #[test]
+    fn exposure_is_optional_and_defaults_to_none_with_grpc_defaulting_true() {
+        // ADR-0080 decision 2. The block is a new sibling of ingestAffinity and
+        // is optional: an existing RavelCluster that never heard of exposure
+        // deserializes with None, so it renders zero routes -- zero behavior
+        // change. GatewaySpec::default() also carries exposure: None.
+        assert_eq!(GatewaySpec::default().exposure, None);
+        assert!(
+            gateway_schema_props().contains_key("exposure"),
+            "gateway must expose the exposure block in its schema"
+        );
+
+        let base = serde_json::json!({
+            "image": "ravel:dev",
+            "shards": 4,
+            "storage": { "s3": { "bucket": "b", "credentialsSecretRef": { "name": "creds" } } }
+        });
+        let spec: RavelClusterSpec = serde_json::from_value(base.clone()).expect("deserialize");
+        assert_eq!(spec.gateway.exposure, None);
+
+        // Declaring gatewayApi with only a gatewayRef enables it with grpc
+        // defaulting to true and empty hostnames, and the gatewayRef namespace
+        // defaulting to None (rendered as the CR's own namespace).
+        let mut with_exposure = base;
+        with_exposure["gateway"] = serde_json::json!({
+            "exposure": { "gatewayApi": { "gatewayRef": { "name": "public-gw" } } }
+        });
+        let spec: RavelClusterSpec = serde_json::from_value(with_exposure).expect("deserialize");
+        let gateway_api = spec
+            .gateway
+            .exposure
+            .expect("exposure present")
+            .gateway_api
+            .expect("gatewayApi present");
+        assert_eq!(gateway_api.gateway_ref.name, "public-gw");
+        assert_eq!(gateway_api.gateway_ref.namespace, None);
+        assert!(gateway_api.grpc, "grpc defaults to true");
+        assert_eq!(gateway_api.hostnames, Vec::<String>::new());
+    }
+
+    #[test]
+    fn exposure_gateway_api_carries_the_cel_guard_at_the_gateway_property() {
+        // ADR-0080 decision 2: the rule spans two sibling fields (exposure and
+        // ingestAffinity), so it must sit on the `gateway` object itself, NOT
+        // nested inside ingestAffinity where the headerName rule lives. A
+        // reconcile unit test cannot exercise admission-time CEL at all; this
+        // asserts the generated schema carries the correct rule and message.
+        let crd = ravel_cluster_crd();
+        let gateway = crd.spec.versions[0]
+            .schema
+            .as_ref()
+            .expect("schema")
+            .open_api_v3_schema
+            .as_ref()
+            .expect("root schema")
+            .properties
+            .as_ref()
+            .expect("root props")
+            .get("spec")
+            .expect("spec prop")
+            .properties
+            .as_ref()
+            .expect("spec props")
+            .get("gateway")
+            .expect("gateway prop")
+            .clone();
+
+        let rules = gateway
+            .x_kubernetes_validations
+            .as_ref()
+            .expect("gateway must carry the exposure/affinity CEL rule");
+        let guard = rules
+            .iter()
+            .find(|r| r.rule == GATEWAY_EXPOSURE_AFFINITY_RULE)
+            .expect("gateway must carry the exact exposure/affinity rule");
+        assert_eq!(
+            guard.message.as_deref(),
+            Some(GATEWAY_EXPOSURE_AFFINITY_MESSAGE)
+        );
+        // The rule keys off both sibling fields.
+        assert!(guard.rule.contains("self.exposure.gatewayApi"));
+        assert!(guard.rule.contains("self.ingestAffinity"));
+        assert!(guard.rule.contains("ingressNginx"));
+
+        // The rule is NOT nested inside ingestAffinity (that property keeps only
+        // its own headerName rule).
+        let affinity_rules = gateway
+            .properties
+            .as_ref()
+            .expect("gateway props")
+            .get("ingestAffinity")
+            .expect("ingestAffinity prop")
+            .x_kubernetes_validations
+            .clone()
+            .unwrap_or_default();
+        assert!(
+            affinity_rules
+                .iter()
+                .all(|r| r.rule != GATEWAY_EXPOSURE_AFFINITY_RULE),
+            "the cross-field guard must live on `gateway`, not on `ingestAffinity`"
+        );
+    }
+
+    /// Rust mirror of [`GATEWAY_EXPOSURE_AFFINITY_RULE`]: returns whether the
+    /// combination is ADMITTED (the CEL rule evaluates true). `enabled` and
+    /// `backend` are always materialized when the affinity block is present
+    /// (serde/schema defaults), so they are modeled as present whenever the
+    /// block is. A separate test
+    /// ([`exposure_gateway_api_carries_the_cel_guard_at_the_gateway_property`])
+    /// pins the exact rule string in the schema, so a change to the real rule
+    /// that diverges from this model is caught there.
+    fn cel_admits(exposure_gateway_api: bool, affinity: Option<(bool, &str)>) -> bool {
+        if !exposure_gateway_api {
+            return true; // !has(self.exposure.gatewayApi)
+        }
+        let Some((enabled, backend)) = affinity else {
+            return true; // !has(self.ingestAffinity)
+        };
+        if !enabled {
+            return true; // !self.ingestAffinity.enabled
+        }
+        backend != "ingressNginx"
+    }
+
+    #[test]
+    fn cel_rule_rejects_only_exposure_plus_enabled_ingress_nginx_affinity() {
+        // ADR-0080 decision 2. The one rejected combination:
+        assert!(
+            !cel_admits(true, Some((true, "ingressNginx"))),
+            "exposure + enabled ingressNginx affinity must be rejected"
+        );
+
+        // Every allowed combination named in the deliverable:
+        assert!(
+            cel_admits(true, None),
+            "exposure alone (affinity absent) is allowed"
+        );
+        assert!(
+            cel_admits(true, Some((true, "ravelNative"))),
+            "exposure + enabled ravelNative affinity is allowed"
+        );
+        assert!(
+            cel_admits(false, Some((true, "ingressNginx"))),
+            "ingressNginx affinity alone (no exposure) is allowed"
+        );
+        assert!(
+            cel_admits(true, Some((false, "ingressNginx"))),
+            "exposure + disabled ingressNginx affinity is allowed"
+        );
+        // And the remaining benign corner: exposure + disabled ravelNative.
+        assert!(
+            cel_admits(true, Some((false, "ravelNative"))),
+            "exposure + disabled ravelNative affinity is allowed"
+        );
     }
 }

--- a/services/ravel-operator/src/crd.rs
+++ b/services/ravel-operator/src/crd.rs
@@ -330,11 +330,20 @@ pub struct IngestAffinitySpec {
 
     /// `spec.ingressClassName` on the rendered Ingress objects. Omit to let the
     /// cluster's default IngressClass apply.
+    ///
+    /// Legacy `backend: ingressNginx` only. Has no effect under
+    /// `backend: ravelNative`, and no effect on `gateway.exposure.gatewayAPI`
+    /// routing (Gateway API attachment goes through `exposure.gatewayAPI
+    /// .gatewayRef` instead, ADR-0080 decision 2).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ingress_class_name: Option<String>,
 
     /// Hostnames the ingest Ingress answers on. Empty renders a single
     /// host-less rule, which matches any host reaching the controller.
+    ///
+    /// Legacy `backend: ingressNginx` only. `gateway.exposure.gatewayAPI
+    /// .hostnames` is the equivalent field for Gateway API exposure; the two
+    /// are independent and neither reads the other.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub hosts: Vec<String>,
 
@@ -342,6 +351,11 @@ pub struct IngestAffinitySpec {
     /// recommended and effectively required for the gRPC Ingress: ingress-nginx
     /// serves HTTP/2 to clients over TLS, and OTLP/gRPC needs HTTP/2. Tenant
     /// tokens are bearer tokens, so plaintext ingest exposes them.
+    ///
+    /// Legacy `backend: ingressNginx` only. Gateway API exposure terminates
+    /// TLS at the referenced `Gateway`'s own listener, which this operator
+    /// does not render; configure `tls.certificateRefs` on that Gateway
+    /// directly (ADR-0080 decision 2).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tls_secret_name: Option<String>,
 
@@ -1550,6 +1564,45 @@ mod tests {
                 .iter()
                 .all(|r| r.rule != GATEWAY_EXPOSURE_AFFINITY_RULE),
             "the cross-field guard must live on `gateway`, not on `ingestAffinity`"
+        );
+
+        // The rule's `!has(...)` guards fail OPEN (admit) when `backend` or
+        // `enabled` is omitted from a submitted manifest, relying entirely on
+        // schema defaulting (which the API server applies before CEL runs) to
+        // materialize `backend: ingressNginx` and `enabled: true` first. If
+        // either default is ever removed, the rejected combination
+        // (exposure.gatewayAPI + an omitted-affinity-config CR) silently
+        // starts being admitted instead -- exactly the silent degrade this
+        // rule exists to forbid -- with every other test here still green.
+        // Pin both defaults so that regression fails loudly.
+        let affinity_props = gateway
+            .properties
+            .as_ref()
+            .expect("gateway props")
+            .get("ingestAffinity")
+            .expect("ingestAffinity prop")
+            .properties
+            .as_ref()
+            .expect("ingestAffinity props");
+        assert_eq!(
+            affinity_props
+                .get("backend")
+                .expect("backend prop")
+                .default
+                .as_ref()
+                .map(|j| &j.0),
+            Some(&serde_json::json!("ingressNginx")),
+            "the omitted-backend CEL case relies on this default"
+        );
+        assert_eq!(
+            affinity_props
+                .get("enabled")
+                .expect("enabled prop")
+                .default
+                .as_ref()
+                .map(|j| &j.0),
+            Some(&serde_json::json!(true)),
+            "the omitted-enabled CEL case relies on this default"
         );
     }
 

--- a/services/ravel-operator/src/reconcile.rs
+++ b/services/ravel-operator/src/reconcile.rs
@@ -25,9 +25,10 @@ use k8s_openapi::api::networking::v1::{
 use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::{LabelSelector, ObjectMeta};
 use k8s_openapi::apimachinery::pkg::util::intstr::IntOrString;
+use kube::core::{ApiResource, DynamicObject, GroupVersionKind};
 
 use crate::crd::{
-    AffinityKeySource, IngestAffinitySpec, LocalSecretRef, RavelClusterSpec,
+    AffinityKeySource, GatewayReference, IngestAffinitySpec, LocalSecretRef, RavelClusterSpec,
     ResourceRequirementsSpec,
 };
 
@@ -990,6 +991,146 @@ pub fn desired_gateway_ingresses(spec: &RavelClusterSpec, instance: &str) -> Vec
     ingresses
 }
 
+/// Gateway API group for the exposure routes (ADR-0080 decision 2).
+///
+/// `k8s-openapi` does not vendor this CRD group and there is no `gateway-api`
+/// crate in the workspace, so the operator renders `HTTPRoute`/`GRPCRoute` as
+/// [`DynamicObject`]s built from a [`GroupVersionKind`] rather than typed
+/// structs, the standard `kube` approach for a resource kind whose CRD the
+/// operator does not own.
+pub const GATEWAY_API_GROUP: &str = "gateway.networking.k8s.io";
+
+/// Gateway API version the operator targets for the exposure routes.
+pub const GATEWAY_API_VERSION: &str = "v1";
+
+/// Component suffix of the exposure HTTPRoute: `<cluster>-gateway-route`.
+const GATEWAY_HTTPROUTE_COMPONENT: &str = "gateway-route";
+
+/// Component suffix of the exposure GRPCRoute: `<cluster>-gateway-route-grpc`.
+const GATEWAY_GRPCROUTE_COMPONENT: &str = "gateway-route-grpc";
+
+/// The [`ApiResource`] for the exposure `HTTPRoute` kind, with the plural given
+/// explicitly rather than guessed.
+pub fn httproute_api_resource() -> ApiResource {
+    ApiResource::from_gvk_with_plural(
+        &GroupVersionKind::gvk(GATEWAY_API_GROUP, GATEWAY_API_VERSION, "HTTPRoute"),
+        "httproutes",
+    )
+}
+
+/// The [`ApiResource`] for the exposure `GRPCRoute` kind, with the plural given
+/// explicitly rather than guessed.
+pub fn grpcroute_api_resource() -> ApiResource {
+    ApiResource::from_gvk_with_plural(
+        &GroupVersionKind::gvk(GATEWAY_API_GROUP, GATEWAY_API_VERSION, "GRPCRoute"),
+        "grpcroutes",
+    )
+}
+
+/// Every Gateway API route name the exposure render can produce for `instance`,
+/// in a fixed order, whether or not the current spec asks for them.
+///
+/// The controller applies the ones [`desired_gateway_routes`] returns and
+/// deletes every other name in this list, so removing `exposure` (or turning
+/// `grpc` off) converges back to the exposure-absent state instead of leaving an
+/// orphaned route attached to the Gateway.
+pub fn possible_gateway_route_names(instance: &str) -> Vec<String> {
+    vec![
+        child_name(instance, GATEWAY_HTTPROUTE_COMPONENT),
+        child_name(instance, GATEWAY_GRPCROUTE_COMPONENT),
+    ]
+}
+
+/// One Gateway API route ([`DynamicObject`]) attached to `gateway_ref`, backing
+/// onto the gateway Service's `port`.
+///
+/// `parentRefs` carries the referenced `Gateway`'s name, and its namespace only
+/// when explicitly set: an omitted `parentRefs` namespace resolves, per Gateway
+/// API, to the route's own namespace, which the controller renders into the
+/// `RavelCluster`'s namespace -- exactly the "defaults to the CR's own
+/// namespace" contract, without this pure function needing to know the
+/// namespace. `backendRefs` always points at the gateway Service directly (ADR-
+/// 0080 decision 2); pointing it at the ravel-native router's Service under
+/// `backend: RavelNative` is a later task (#158), not anticipated here.
+fn gateway_route(
+    instance: &str,
+    component: &str,
+    api_resource: &ApiResource,
+    port: i32,
+    gateway_ref: &GatewayReference,
+    hostnames: &[String],
+) -> DynamicObject {
+    let mut parent_ref = serde_json::json!({ "name": gateway_ref.name });
+    if let Some(namespace) = gateway_ref.namespace.as_ref() {
+        parent_ref["namespace"] = serde_json::Value::String(namespace.clone());
+    }
+    let mut route_spec = serde_json::json!({
+        "parentRefs": [parent_ref],
+        "rules": [{
+            "backendRefs": [{
+                // The gateway Service, by numeric port: Gateway API backendRefs
+                // reference a port number, not the named port an Ingress uses.
+                "name": child_name(instance, "gateway"),
+                "port": port,
+            }],
+        }],
+    });
+    // Empty hostnames renders no `hostnames`, which matches every hostname the
+    // parent Gateway's listeners accept -- the route-level analogue of the
+    // host-less Ingress rule.
+    if !hostnames.is_empty() {
+        route_spec["hostnames"] = serde_json::json!(hostnames);
+    }
+    let mut route = DynamicObject::new(&child_name(instance, component), api_resource)
+        .data(serde_json::json!({ "spec": route_spec }));
+    // The gateway component labels, matching the Ingress objects, so the
+    // controller's managed-by-scoped watch sees these objects.
+    route.metadata.labels = Some(labels(instance, "gateway"));
+    route
+}
+
+/// The Gateway API exposure routes (ADR-0080 decision 2): `(HTTPRoute, GRPCRoute)`.
+///
+/// Returns `(None, None)` when `gateway.exposure.gatewayApi` is absent, exactly
+/// mirroring [`desired_gateway_ingresses`]'s affinity-absent-renders-nothing
+/// contract. When present, the HTTPRoute is always rendered and the GRPCRoute is
+/// rendered only when `grpc` is true. Exposure is independent of affinity: this
+/// renders whether affinity is absent, disabled, or enabled on
+/// `backend: RavelNative` (the CEL rule rejects the one forbidden combination,
+/// enabled `backend: ingressNginx`, at admission).
+pub fn desired_gateway_routes(
+    spec: &RavelClusterSpec,
+    instance: &str,
+) -> (Option<DynamicObject>, Option<DynamicObject>) {
+    let Some(gateway_api) = spec
+        .gateway
+        .exposure
+        .as_ref()
+        .and_then(|exposure| exposure.gateway_api.as_ref())
+    else {
+        return (None, None);
+    };
+    let httproute = gateway_route(
+        instance,
+        GATEWAY_HTTPROUTE_COMPONENT,
+        &httproute_api_resource(),
+        HTTP_PORT,
+        &gateway_api.gateway_ref,
+        &gateway_api.hostnames,
+    );
+    let grpcroute = gateway_api.grpc.then(|| {
+        gateway_route(
+            instance,
+            GATEWAY_GRPCROUTE_COMPONENT,
+            &grpcroute_api_resource(),
+            GRPC_PORT,
+            &gateway_api.gateway_ref,
+            &gateway_api.hostnames,
+        )
+    });
+    (Some(httproute), grpcroute)
+}
+
 /// Everything one `RavelCluster` reconcile applies, rendered in one place.
 ///
 /// [`crate::controller`] builds this and applies exactly its contents, so a
@@ -1003,6 +1144,10 @@ pub struct DesiredObjects {
     pub gateway_service: Service,
     /// The ingest-affinity Ingress objects; empty when affinity is off.
     pub gateway_ingresses: Vec<Ingress>,
+    /// The Gateway API exposure routes `(HTTPRoute, GRPCRoute)` (ADR-0080
+    /// decision 2); each `None` when exposure is off or, for the GRPCRoute, when
+    /// `grpc` is false.
+    pub gateway_routes: (Option<DynamicObject>, Option<DynamicObject>),
     /// The query Deployment.
     pub query_deployment: Deployment,
     /// The query Service.
@@ -1018,6 +1163,7 @@ pub fn desired_objects(spec: &RavelClusterSpec, instance: &str, ctx: &RenderCtx)
         gateway_deployment: desired_gateway_deployment(spec, instance, ctx),
         gateway_service: desired_gateway_service(spec, instance),
         gateway_ingresses: desired_gateway_ingresses(spec, instance),
+        gateway_routes: desired_gateway_routes(spec, instance),
         query_deployment: desired_query_deployment(spec, instance, ctx),
         query_service: desired_query_service(spec, instance),
         maintain_deployment: desired_maintain_deployment(spec, instance, ctx),
@@ -1029,8 +1175,10 @@ pub fn desired_objects(spec: &RavelClusterSpec, instance: &str, ctx: &RenderCtx)
 mod tests {
     use super::*;
     use crate::crd::{
-        AffinityKeySpec, DEFAULT_AFFINITY_SUBSET_SIZE, FoldSpec, GatewaySpec, IngestAffinitySpec,
-        LocalSecretRef, MaintainSpec, QuerySpec, RetentionSpec, S3Spec, StorageSpec,
+        AffinityBackend, AffinityKeySpec, DEFAULT_AFFINITY_SUBSET_SIZE, FoldSpec,
+        GatewayApiExposureSpec, GatewayExposureSpec, GatewayReference, GatewaySpec,
+        IngestAffinitySpec, LocalSecretRef, MaintainSpec, QuerySpec, RetentionSpec, S3Spec,
+        StorageSpec,
     };
     use std::collections::BTreeMap;
 
@@ -1064,6 +1212,7 @@ mod tests {
                     interval_secs: Some(120),
                 }),
                 ingest_affinity: None,
+                exposure: None,
             },
             query: QuerySpec {
                 replicas: 2,
@@ -2512,6 +2661,195 @@ mod tests {
             checksum_of(&mb),
             checksum_of(&ma),
             "maintain must roll when the deployment key rotates"
+        );
+    }
+
+    /// The `spec` body of a rendered Gateway API route.
+    fn route_spec(route: &DynamicObject) -> serde_json::Value {
+        route
+            .data
+            .get("spec")
+            .expect("route must carry a spec")
+            .clone()
+    }
+
+    /// A rendered route's `kind` from its `TypeMeta`.
+    fn route_kind(route: &DynamicObject) -> String {
+        route.types.as_ref().expect("route types").kind.clone()
+    }
+
+    /// An exposure spec pointing at a `Gateway`, for the render tests.
+    fn exposure_with(
+        gateway_ref: GatewayReference,
+        hostnames: Vec<String>,
+        grpc: bool,
+    ) -> GatewaySpec {
+        GatewaySpec {
+            exposure: Some(GatewayExposureSpec {
+                gateway_api: Some(GatewayApiExposureSpec {
+                    gateway_ref,
+                    hostnames,
+                    grpc,
+                }),
+            }),
+            ..GatewaySpec::default()
+        }
+    }
+
+    #[test]
+    fn exposure_gateway_api_renders_httproute_and_grpcroute_independent_of_affinity() {
+        // ADR-0080 decision 2, the acceptance test. Asserted through
+        // `desired_objects`, which is the exact render the controller applies.
+        //
+        // Case 1: exposure with affinity absent (plain routing, no pinning),
+        // grpc default true, one hostname, gatewayRef namespace omitted.
+        let mut spec = base_spec();
+        spec.gateway = exposure_with(
+            GatewayReference {
+                name: "public-gw".to_string(),
+                namespace: None,
+            },
+            vec!["ingest.example.com".to_string()],
+            true,
+        );
+        let objects = desired_objects(&spec, "prod", &ctx());
+        let (http, grpc) = objects.gateway_routes;
+        let http = http.expect("HTTPRoute always rendered when exposure is set");
+        let grpc = grpc.expect("GRPCRoute rendered when grpc is true");
+
+        // Kinds, versions, and names.
+        assert_eq!(route_kind(&http), "HTTPRoute");
+        assert_eq!(route_kind(&grpc), "GRPCRoute");
+        for route in [&http, &grpc] {
+            assert_eq!(
+                route.types.as_ref().expect("types").api_version,
+                "gateway.networking.k8s.io/v1"
+            );
+            assert_eq!(
+                route.metadata.labels.as_ref().expect("labels")["app.kubernetes.io/component"],
+                "gateway"
+            );
+        }
+        assert_eq!(http.metadata.name.as_deref(), Some("prod-gateway-route"));
+        assert_eq!(
+            grpc.metadata.name.as_deref(),
+            Some("prod-gateway-route-grpc")
+        );
+
+        // parentRefs name only (namespace omitted -> Gateway API defaults it to
+        // the route's own namespace, i.e. the CR's namespace).
+        let http_spec = route_spec(&http);
+        assert_eq!(
+            http_spec["parentRefs"][0]["name"],
+            serde_json::json!("public-gw")
+        );
+        assert!(
+            http_spec["parentRefs"][0].get("namespace").is_none(),
+            "omitted gatewayRef namespace must not render a parentRef namespace"
+        );
+
+        // backendRefs point at the gateway Service, HTTP route on 4318, gRPC on
+        // 4317.
+        assert_eq!(
+            http_spec["rules"][0]["backendRefs"][0]["name"],
+            serde_json::json!("prod-gateway")
+        );
+        assert_eq!(
+            http_spec["rules"][0]["backendRefs"][0]["port"],
+            serde_json::json!(HTTP_PORT)
+        );
+        assert_eq!(
+            route_spec(&grpc)["rules"][0]["backendRefs"][0]["port"],
+            serde_json::json!(GRPC_PORT)
+        );
+        assert_eq!(
+            route_spec(&grpc)["rules"][0]["backendRefs"][0]["name"],
+            serde_json::json!("prod-gateway")
+        );
+
+        // Hostnames carried on both route kinds.
+        assert_eq!(
+            http_spec["hostnames"],
+            serde_json::json!(["ingest.example.com"])
+        );
+        assert_eq!(
+            route_spec(&grpc)["hostnames"],
+            serde_json::json!(["ingest.example.com"])
+        );
+
+        // Case 2: grpc: false renders only the HTTPRoute.
+        let mut spec = base_spec();
+        spec.gateway = exposure_with(
+            GatewayReference {
+                name: "public-gw".to_string(),
+                namespace: None,
+            },
+            Vec::new(),
+            false,
+        );
+        let (http, grpc) = desired_gateway_routes(&spec, "prod");
+        assert!(
+            http.is_some(),
+            "HTTPRoute still rendered when grpc is false"
+        );
+        assert!(grpc.is_none(), "no GRPCRoute when grpc is false");
+        // Empty hostnames renders no `hostnames` key.
+        assert!(
+            route_spec(&http.expect("HTTPRoute"))
+                .get("hostnames")
+                .is_none(),
+            "empty hostnames must not render a hostnames key"
+        );
+
+        // Case 3: exposure combined with affinity enabled on backend
+        // ravelNative (allowed by the CEL rule) still renders both routes,
+        // independent of affinity, with an explicit gatewayRef namespace.
+        let mut spec = base_spec();
+        spec.gateway = GatewaySpec {
+            ingest_affinity: Some(IngestAffinitySpec {
+                backend: AffinityBackend::RavelNative,
+                ..IngestAffinitySpec::default()
+            }),
+            ..exposure_with(
+                GatewayReference {
+                    name: "public-gw".to_string(),
+                    namespace: Some("gw-ns".to_string()),
+                },
+                Vec::new(),
+                true,
+            )
+        };
+        let (http, grpc) = desired_gateway_routes(&spec, "prod");
+        let http = http.expect("HTTPRoute rendered alongside ravelNative affinity");
+        assert!(
+            grpc.is_some(),
+            "GRPCRoute rendered alongside ravelNative affinity"
+        );
+        // The gateway also still renders its affinity nothing here (ravelNative
+        // renders no Ingress), and the route parentRefs carry the explicit
+        // namespace.
+        assert_eq!(
+            route_spec(&http)["parentRefs"][0]["namespace"],
+            serde_json::json!("gw-ns")
+        );
+
+        // Case 4: removing exposure renders nothing, and the delete-sweep names
+        // both route kinds so the controller can remove an existing pair.
+        let mut spec = base_spec();
+        spec.gateway = GatewaySpec::default();
+        assert_eq!(
+            desired_gateway_routes(&spec, "prod"),
+            (None, None),
+            "exposure absent renders no routes"
+        );
+        let sweep = possible_gateway_route_names("prod");
+        assert_eq!(
+            sweep,
+            vec![
+                "prod-gateway-route".to_string(),
+                "prod-gateway-route-grpc".to_string()
+            ],
+            "the delete-sweep must name both route kinds so both are removed"
         );
     }
 }


### PR DESCRIPTION
Adds gateway.exposure.gatewayAPI to the CRD per ADR-0080 decision 2:
the operator renders standard HTTPRoute and, when grpc is true,
GRPCRoute objects (gateway.networking.k8s.io) attached to an existing
Gateway, with no vendor extension. Independent of ingestAffinity -- it
works standalone or combined with backend: ravelNative -- but a new
CEL admission rule rejects combining it with an enabled ingestAffinity
still on the legacy backend: ingressNginx, since traffic on the Gateway
API path would bypass the nginx subset annotations entirely and
silently drop tenant pinning on that path. The rule sits on the
gateway property itself, since it spans both sibling fields.

Existing CRs without exposure set get zero behavior change: the new
field defaults to None and desired_gateway_routes renders nothing.
Switching modes cleans up via the same apply-then-sweep pattern the
existing Ingress rendering already uses.

Also documents gateway.exposure.gatewayAPI in
docs/guides/ingest-affinity.md (independence from ingestAffinity, the
CEL restriction, TLS being the referenced Gateway's own responsibility,
and the Gateway API >= v1.1 prerequisite for GRPCRoute at v1) and
qualifies the legacy Ingress-only fields (hosts, tlsSecretName,
ingressClassName) as backend: ingressNginx-only, per ADR-0080 decision
2's requirement that this land in the same commit that introduces the
second exposure mechanism.

Fixes: #156
Refs: #150
