### PR TITLE
feat(scripts): add the README command verifier behind ADR-0081

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ test:
 # environment beyond the interpreter. Run from scripts/ so the tests'
 # `from process_metrics import ...` resolves without a package layout.
 test-python:
-	cd scripts && python3 -m unittest test_process_metrics -v
+	cd scripts && python3 -m unittest discover -p 'test_*.py' -v
 
 # Derived counts in docs/query-engine.md's generated conformance block
 # (ADR-0053 decision 6). No build, so it is cheap enough to run before a

--- a/scripts/check-readme-commands.sh
+++ b/scripts/check-readme-commands.sh
@@ -37,16 +37,37 @@ py_module="$here/check_readme_commands.py"
 # The compose stack from ADR-0081 binds loopback; #175 wires the real values.
 RAVEL_HTTP_BASE=${RAVEL_HTTP_BASE:-http://127.0.0.1:4318}
 RAVEL_TENANT_TOKEN=${RAVEL_TENANT_TOKEN:-demo-token}
-RAVEL_HEALTH_PATH=${RAVEL_HEALTH_PATH:-/health}
-# Query the readiness poll uses to decide the stack has data. It must be an
-# outcome both the collector and telemetrygen produce (ADR-0081 D5); the
-# default is a shape-only instant query whose result set is non-empty once any
-# series exists.
-RAVEL_READY_QUERY_URL=${RAVEL_READY_QUERY_URL:-$RAVEL_HTTP_BASE/api/v1/query?query=up}
+# Liveness route. ravel-server registers /healthz, /readyz, /-/healthy, and
+# /-/ready (services/ravel-server/src/health.rs); /healthz returns 200 as soon
+# as the axum server can route, which is what the readiness wait needs. There is
+# no /health route, so it is not a usable default.
+RAVEL_HEALTH_PATH=${RAVEL_HEALTH_PATH:-/healthz}
+# Query the readiness poll uses to decide the stack has data. It must return a
+# non-empty result set for an outcome both the collector and telemetrygen
+# produce (ADR-0081 D5). There is NO usable default: ravel-server has no scrape
+# loop and never synthesizes a `up` series, the collector's hostmetrics receiver
+# emits `system_*`, and telemetrygen emits `gen*`, so no single series name is
+# non-empty across both generators. The caller (#175's CI job, wiring the real
+# compose stack) MUST supply this explicitly; an empty value is a hard error
+# when the readiness poll runs, never a silent skip.
+RAVEL_READY_QUERY_URL=${RAVEL_READY_QUERY_URL:-}
 
 # Readiness timeout is a NAMED CONSTANT, never a fixed sleep (ADR-0081 D5).
 READINESS_TIMEOUT_SECONDS=${RAVEL_READINESS_TIMEOUT_SECONDS:-120}
 READINESS_POLL_SECONDS=${RAVEL_READINESS_POLL_SECONDS:-2}
+# Per-request bounds (ADR-0081 D5: a bounded poll, not just a bounded loop). A
+# server that accepts a connection and never responds must not hang a single
+# request past these, so the overall READINESS_TIMEOUT_SECONDS budget stays the
+# real ceiling. These apply to every curl this script issues, including the ones
+# that run marked README blocks: a hung server otherwise hangs the whole CI job,
+# not just the readiness phase. Timing out is a failure, never a pass.
+CONNECT_TIMEOUT_SECONDS=${RAVEL_CONNECT_TIMEOUT_SECONDS:-5}
+REQUEST_TIMEOUT_SECONDS=${RAVEL_REQUEST_TIMEOUT_SECONDS:-10}
+
+# Real curl path and the on-PATH shim dir that fronts it while a marked block
+# runs. Resolved once, before any shim is on PATH. See setup_curl_shim.
+REAL_CURL=$(command -v curl || true)
+CURL_SHIM_DIR=""
 
 # --- Readiness ------------------------------------------------------------
 # Poll health, then poll a first query until it returns a non-empty result,
@@ -56,11 +77,20 @@ wait_for_ready() {
   local health_url="$RAVEL_HTTP_BASE$RAVEL_HEALTH_PATH"
   local deadline=$(( $(date +%s) + READINESS_TIMEOUT_SECONDS ))
 
+  if [[ -z $RAVEL_READY_QUERY_URL ]]; then
+    echo "readiness: RAVEL_READY_QUERY_URL is unset; it has no working default" \
+         "(no series is non-empty across both the collector and telemetrygen)." \
+         "Set it to a query the running stack answers non-empty." >&2
+    return 1
+  fi
+
   echo "readiness: waiting for health at $health_url"
   while true; do
     local http_code=000
     local curl_rc=0
-    http_code=$(curl -s -o /dev/null -w '%{http_code}' "$health_url") || curl_rc=$?
+    http_code=$(curl -s -o /dev/null -w '%{http_code}' \
+      --connect-timeout "$CONNECT_TIMEOUT_SECONDS" \
+      --max-time "$REQUEST_TIMEOUT_SECONDS" "$health_url") || curl_rc=$?
     if [[ $curl_rc -eq 0 && $http_code == "200" ]]; then
       break
     fi
@@ -74,7 +104,9 @@ wait_for_ready() {
   echo "readiness: waiting for first non-empty query at $RAVEL_READY_QUERY_URL"
   while true; do
     local body=""
-    body=$(curl -s -H "Authorization: Bearer $RAVEL_TENANT_TOKEN" "$RAVEL_READY_QUERY_URL") || body=""
+    body=$(curl -s -H "Authorization: Bearer $RAVEL_TENANT_TOKEN" \
+      --connect-timeout "$CONNECT_TIMEOUT_SECONDS" \
+      --max-time "$REQUEST_TIMEOUT_SECONDS" "$RAVEL_READY_QUERY_URL") || body=""
     local eval_rc=0
     printf '%s' "$body" | python3 "$py_module" evaluate 'nonempty:.data.result' \
       --exit 0 --http 200 >/dev/null 2>&1 || eval_rc=$?
@@ -91,12 +123,60 @@ wait_for_ready() {
   echo "readiness: stack healthy and first query non-empty"
 }
 
+# --- The curl shim --------------------------------------------------------
+# Capturing the HTTP status must be OUT OF BAND: it may never be recoverable
+# from the response body (the body is produced by the very thing being gated, so
+# any status parsed out of it is forgeable), and appending flags to the tail of
+# an arbitrary command string is unsafe (a trailing `#`, `;`, or `|` in a README
+# line detaches them). Instead we front the real curl with a shim on PATH while
+# a marked block runs. The block command is executed verbatim; when it invokes
+# `curl` the shim receives the arguments as real argv, injects the timeouts and
+# a `%{http_code}` write-out, sends the body to its own stdout, and writes the
+# status to RAVEL_STATUS_FILE. Because the injected options are argv inside the
+# shim rather than text appended to the command string, they survive a trailing
+# `#` (the shim never sees it), a `;` (the shell runs `curl ...` as its own
+# simple command, which resolves to the shim), and a `|` (curl is one stage of
+# the pipeline; the shim still runs and still writes the status file). A 000
+# code (connection refused, or a --max-time timeout with no response) is written
+# as-is, so a timeout fails a `status=` assertion rather than passing it.
+setup_curl_shim() {
+  [[ -n $CURL_SHIM_DIR ]] && return 0
+  if [[ -z $REAL_CURL ]]; then
+    echo "curl not found on PATH" >&2
+    return 1
+  fi
+  CURL_SHIM_DIR=$(mktemp -d)
+  cat >"$CURL_SHIM_DIR/curl" <<'SHIM'
+#!/usr/bin/env bash
+# On-PATH shim for scripts/check-readme-commands.sh. Injects request timeouts
+# and captures the HTTP status out of band into RAVEL_STATUS_FILE.
+set -uo pipefail
+body=$(mktemp)
+code=$("$RAVEL_REAL_CURL" \
+  --silent \
+  --connect-timeout "$RAVEL_CURL_CONNECT_TIMEOUT_SECONDS" \
+  --max-time "$RAVEL_CURL_MAX_TIME_SECONDS" \
+  --output "$body" \
+  --write-out '%{http_code}' \
+  "$@")
+rc=$?
+printf '%s' "$code" >"$RAVEL_STATUS_FILE"
+cat "$body"
+rm -f "$body"
+exit "$rc"
+SHIM
+  chmod +x "$CURL_SHIM_DIR/curl"
+  # shellcheck disable=SC2064
+  trap "rm -rf '$CURL_SHIM_DIR'" EXIT
+}
+
 # --- Running one command --------------------------------------------------
 # Runs `cmd`, writes its stdout to `body_file`, and prints two space-separated
 # tokens on one line: the captured HTTP status (or "none") and the command's
-# own exit code. For a curl command it appends a write-out directive so the
-# HTTP status is captured even when curl exits 0 on a 4xx/5xx; the sentinel
-# line is stripped from the body before evaluation.
+# own exit code. A curl command runs with the shim on PATH so the HTTP status is
+# captured out of band even when curl exits 0 on a 4xx/5xx. If the status cannot
+# be determined, "none" is reported and a `status=` assertion fails on it, never
+# passes.
 run_one_command() {
   local cmd=$1
   local body_file=$2
@@ -104,14 +184,22 @@ run_one_command() {
   local captured="none"
 
   if [[ $cmd == curl* ]]; then
-    bash -c "$cmd --silent --write-out '\nRAVEL_HTTP_STATUS=%{http_code}'" \
-      >"$body_file" 2>/dev/null || run_code=$?
-    local line
-    line=$(sed -n 's/^RAVEL_HTTP_STATUS=//p' "$body_file")
-    [[ -n $line ]] && captured=$line
-    local cleaned
-    cleaned=$(sed '/^RAVEL_HTTP_STATUS=/d' "$body_file")
-    printf '%s' "$cleaned" >"$body_file"
+    setup_curl_shim
+    local status_file
+    status_file=$(mktemp)
+    : >"$status_file"
+    PATH="$CURL_SHIM_DIR:$PATH" \
+      RAVEL_REAL_CURL="$REAL_CURL" \
+      RAVEL_STATUS_FILE="$status_file" \
+      RAVEL_CURL_CONNECT_TIMEOUT_SECONDS="$CONNECT_TIMEOUT_SECONDS" \
+      RAVEL_CURL_MAX_TIME_SECONDS="$REQUEST_TIMEOUT_SECONDS" \
+      bash -c "$cmd" >"$body_file" 2>/dev/null || run_code=$?
+    local code_read
+    code_read=$(cat "$status_file")
+    rm -f "$status_file"
+    if [[ -n $code_read ]]; then
+      captured=$code_read
+    fi
   else
     bash -c "$cmd" >"$body_file" 2>/dev/null || run_code=$?
   fi
@@ -123,6 +211,21 @@ run_blocks() {
   local md=$1
   local found=0
   local line_no exp_raw cmd_b64
+
+  # Extract to a file and capture the extractor's exit code before looping.
+  # `done < <(python3 ... )` would discard it: a producer that exits non-zero
+  # would leave the loop at rc 0 (a fail-open channel, the exact shape CLAUDE.md
+  # warns about). Unreachable from markdown today (a MarkerError emits zero
+  # records, so found=0 already fails), but closed here regardless.
+  local rec_file
+  rec_file=$(mktemp)
+  local extract_rc=0
+  python3 "$py_module" extract "$md" >"$rec_file" || extract_rc=$?
+  if [[ $extract_rc -ne 0 ]]; then
+    rm -f "$rec_file"
+    echo "extractor failed for $md (rc=$extract_rc)" >&2
+    return "$extract_rc"
+  fi
 
   while IFS= read -r -d '' line_no \
      && IFS= read -r -d '' exp_raw \
@@ -153,7 +256,8 @@ run_blocks() {
       return 1
     fi
     echo "PASS: ${md}:${line_no}"
-  done < <(python3 "$py_module" extract "$md")
+  done <"$rec_file"
+  rm -f "$rec_file"
 
   if [[ $found -eq 0 ]]; then
     echo "no marked (ravel:run) blocks found in $md" >&2

--- a/scripts/check-readme-commands.sh
+++ b/scripts/check-readme-commands.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# Run the marked runnable command blocks in a markdown file against an
+# ALREADY-RUNNING stack and assert each block's documented outcome. This is the
+# executable side of ADR-0081 decision 5.
+#
+# This script does NOT bring up the stack. Bringing MinIO, ravel-server, the
+# collector, and Grafana up is the compose file's job and the CI job's job
+# (ticket #175); this script assumes they are already reachable and only checks
+# that the README's commands do what the README says.
+#
+# Usage:
+#   scripts/check-readme-commands.sh <markdown-path>   # wait for readiness, run blocks
+#   scripts/check-readme-commands.sh --wait            # readiness wait only (for #175's CI)
+#
+# Marker convention and expectation vocabulary are documented in the header of
+# scripts/check_readme_commands.py, the pure logic this script drives. In short:
+# a block is runnable when the line immediately above its opening fence is
+#   <!-- ravel:run <expectation>[; <expectation> ...] -->
+# with expectations drawn from: status=<code>, json:<path>=<value>,
+# nonempty:<path>. An unparseable marker, a marker with no expectation, or an
+# unknown keyword is a hard error, never a skip.
+#
+# Outcome, not exit code: `curl` exits 0 on an HTTP 401 and on a
+# `{"status":"error"}` JSON envelope, so this script asserts the declared
+# expectation (parsed and evaluated by check_readme_commands.py) rather than
+# trusting the process exit status.
+#
+# Shell-safety (CLAUDE.md "Writing gate and poll shell"): exit codes are
+# captured as `cmd || code=$?` on the same line; no variable is named `status`,
+# `path`, `argv`, or `PWD`; no checked command is piped through grep/head/tail.
+set -euo pipefail
+
+here=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+py_module="$here/check_readme_commands.py"
+
+# --- Configuration (env overrides, documented defaults) --------------------
+# The compose stack from ADR-0081 binds loopback; #175 wires the real values.
+RAVEL_HTTP_BASE=${RAVEL_HTTP_BASE:-http://127.0.0.1:4318}
+RAVEL_TENANT_TOKEN=${RAVEL_TENANT_TOKEN:-demo-token}
+RAVEL_HEALTH_PATH=${RAVEL_HEALTH_PATH:-/health}
+# Query the readiness poll uses to decide the stack has data. It must be an
+# outcome both the collector and telemetrygen produce (ADR-0081 D5); the
+# default is a shape-only instant query whose result set is non-empty once any
+# series exists.
+RAVEL_READY_QUERY_URL=${RAVEL_READY_QUERY_URL:-$RAVEL_HTTP_BASE/api/v1/query?query=up}
+
+# Readiness timeout is a NAMED CONSTANT, never a fixed sleep (ADR-0081 D5).
+READINESS_TIMEOUT_SECONDS=${RAVEL_READINESS_TIMEOUT_SECONDS:-120}
+READINESS_POLL_SECONDS=${RAVEL_READINESS_POLL_SECONDS:-2}
+
+# --- Readiness ------------------------------------------------------------
+# Poll health, then poll a first query until it returns a non-empty result,
+# bounded by READINESS_TIMEOUT_SECONDS. Callable independently via `--wait` so
+# #175's CI job can gate on it before running the blocks.
+wait_for_ready() {
+  local health_url="$RAVEL_HTTP_BASE$RAVEL_HEALTH_PATH"
+  local deadline=$(( $(date +%s) + READINESS_TIMEOUT_SECONDS ))
+
+  echo "readiness: waiting for health at $health_url"
+  while true; do
+    local http_code=000
+    local curl_rc=0
+    http_code=$(curl -s -o /dev/null -w '%{http_code}' "$health_url") || curl_rc=$?
+    if [[ $curl_rc -eq 0 && $http_code == "200" ]]; then
+      break
+    fi
+    if (( $(date +%s) >= deadline )); then
+      echo "readiness: health not 200 within ${READINESS_TIMEOUT_SECONDS}s (last=$http_code)" >&2
+      return 1
+    fi
+    sleep "$READINESS_POLL_SECONDS"
+  done
+
+  echo "readiness: waiting for first non-empty query at $RAVEL_READY_QUERY_URL"
+  while true; do
+    local body=""
+    body=$(curl -s -H "Authorization: Bearer $RAVEL_TENANT_TOKEN" "$RAVEL_READY_QUERY_URL") || body=""
+    local eval_rc=0
+    printf '%s' "$body" | python3 "$py_module" evaluate 'nonempty:.data.result' \
+      --exit 0 --http 200 >/dev/null 2>&1 || eval_rc=$?
+    if [[ $eval_rc -eq 0 ]]; then
+      break
+    fi
+    if (( $(date +%s) >= deadline )); then
+      echo "readiness: query returned no data within ${READINESS_TIMEOUT_SECONDS}s" >&2
+      return 1
+    fi
+    sleep "$READINESS_POLL_SECONDS"
+  done
+
+  echo "readiness: stack healthy and first query non-empty"
+}
+
+# --- Running one command --------------------------------------------------
+# Runs `cmd`, writes its stdout to `body_file`, and prints two space-separated
+# tokens on one line: the captured HTTP status (or "none") and the command's
+# own exit code. For a curl command it appends a write-out directive so the
+# HTTP status is captured even when curl exits 0 on a 4xx/5xx; the sentinel
+# line is stripped from the body before evaluation.
+run_one_command() {
+  local cmd=$1
+  local body_file=$2
+  local run_code=0
+  local captured="none"
+
+  if [[ $cmd == curl* ]]; then
+    bash -c "$cmd --silent --write-out '\nRAVEL_HTTP_STATUS=%{http_code}'" \
+      >"$body_file" 2>/dev/null || run_code=$?
+    local line
+    line=$(sed -n 's/^RAVEL_HTTP_STATUS=//p' "$body_file")
+    [[ -n $line ]] && captured=$line
+    local cleaned
+    cleaned=$(sed '/^RAVEL_HTTP_STATUS=/d' "$body_file")
+    printf '%s' "$cleaned" >"$body_file"
+  else
+    bash -c "$cmd" >"$body_file" 2>/dev/null || run_code=$?
+  fi
+  printf '%s %s' "$captured" "$run_code"
+}
+
+# --- Running all marked blocks --------------------------------------------
+run_blocks() {
+  local md=$1
+  local found=0
+  local line_no exp_raw cmd_b64
+
+  while IFS= read -r -d '' line_no \
+     && IFS= read -r -d '' exp_raw \
+     && IFS= read -r -d '' cmd_b64; do
+    found=1
+    local cmd
+    cmd=$(printf '%s' "$cmd_b64" | base64 -d)
+
+    echo "----------------------------------------------------------------"
+    echo "block ${md}:${line_no}  expect: ${exp_raw}"
+    printf 'command:\n%s\n' "$cmd"
+
+    local body_file
+    body_file=$(mktemp)
+    local run_out http_status run_code
+    run_out=$(run_one_command "$cmd" "$body_file")
+    http_status=${run_out%% *}
+    run_code=${run_out##* }
+    echo "exit=${run_code} http=${http_status}"
+
+    local eval_rc=0
+    python3 "$py_module" evaluate "$exp_raw" \
+      --exit "$run_code" --http "$http_status" <"$body_file" || eval_rc=$?
+    rm -f "$body_file"
+
+    if [[ $eval_rc -ne 0 ]]; then
+      echo "FAIL: block at ${md}:${line_no} did not meet its expectation" >&2
+      return 1
+    fi
+    echo "PASS: ${md}:${line_no}"
+  done < <(python3 "$py_module" extract "$md")
+
+  if [[ $found -eq 0 ]]; then
+    echo "no marked (ravel:run) blocks found in $md" >&2
+    return 1
+  fi
+  echo "================================================================"
+  echo "all marked blocks in $md passed"
+}
+
+usage() {
+  echo "usage: $0 [--wait] <markdown-path>" >&2
+}
+
+main() {
+  local md=""
+  local wait_only=0
+  while [[ $# -gt 0 ]]; do
+    case $1 in
+      --wait) wait_only=1; shift ;;
+      -h|--help) usage; exit 0 ;;
+      --) shift; break ;;
+      -*) echo "unknown option: $1" >&2; usage; exit 2 ;;
+      *) md=$1; shift ;;
+    esac
+  done
+  if [[ $# -gt 0 && -z $md ]]; then
+    md=$1
+  fi
+
+  if [[ $wait_only -eq 1 ]]; then
+    local rc=0
+    wait_for_ready || rc=$?
+    exit $rc
+  fi
+
+  if [[ -z $md ]]; then
+    usage
+    exit 2
+  fi
+  if [[ ! -r $md ]]; then
+    echo "cannot read markdown file: $md" >&2
+    exit 2
+  fi
+
+  wait_for_ready
+  run_blocks "$md"
+}
+
+main "$@"

--- a/scripts/check-readme-commands.sh
+++ b/scripts/check-readme-commands.sh
@@ -58,11 +58,28 @@ READINESS_POLL_SECONDS=${RAVEL_READINESS_POLL_SECONDS:-2}
 # Per-request bounds (ADR-0081 D5: a bounded poll, not just a bounded loop). A
 # server that accepts a connection and never responds must not hang a single
 # request past these, so the overall READINESS_TIMEOUT_SECONDS budget stays the
-# real ceiling. These apply to every curl this script issues, including the ones
-# that run marked README blocks: a hung server otherwise hangs the whole CI job,
-# not just the readiness phase. Timing out is a failure, never a pass.
+# real ceiling. These reach the readiness curls (issued directly here) and every
+# curl invocation the shim fronts while a marked block runs, because the shim
+# injects them as argv. They do NOT reach a block that never resolves to the
+# shim: a first token that is not the literal `curl` (`env curl ...`,
+# `RAVEL_TOKEN=demo curl ...`, `/usr/bin/curl ...`, a leading comment) runs a
+# bare curl with no --max-time. BLOCK_TIMEOUT_SECONDS below is the bound that
+# covers those, so a hung request in any block shape still fails the job rather
+# than hanging it. Timing out is a failure, never a pass.
 CONNECT_TIMEOUT_SECONDS=${RAVEL_CONNECT_TIMEOUT_SECONDS:-5}
 REQUEST_TIMEOUT_SECONDS=${RAVEL_REQUEST_TIMEOUT_SECONDS:-10}
+
+# Wall-clock ceiling for one marked block, enforced with `timeout` regardless of
+# the block's text: the per-request bounds above only reach curls the shim
+# fronts, so a block whose first token is not `curl` (and therefore bypasses the
+# shim) would otherwise run an unbounded bare curl and hang the whole CI job. It
+# must exceed the sum of per-request budgets a legitimate block can incur (a
+# handful of sequential requests, each up to REQUEST_TIMEOUT_SECONDS); the
+# default leaves generous headroom over that. Hitting it is a hard failure that
+# names the block, never a pass. `-k` escalates to SIGKILL if the block ignores
+# SIGTERM, so a `trap '' TERM` in README text cannot outlast the bound.
+BLOCK_TIMEOUT_SECONDS=${RAVEL_BLOCK_TIMEOUT_SECONDS:-90}
+BLOCK_TIMEOUT_KILL_SECONDS=${RAVEL_BLOCK_TIMEOUT_KILL_SECONDS:-5}
 
 # Real curl path and the on-PATH shim dir that fronts it while a marked block
 # runs. Resolved once, before any shim is on PATH. See setup_curl_shim.
@@ -139,6 +156,14 @@ wait_for_ready() {
 # the pipeline; the shim still runs and still writes the status file). A 000
 # code (connection refused, or a --max-time timeout with no response) is written
 # as-is, so a timeout fails a `status=` assertion rather than passing it.
+#
+# A block may issue MORE THAN ONE request (the README's ingest-then-query
+# shape). One truncating status slot would keep only the last request's status,
+# so a failing ingest followed by a healthy query would look healthy. The shim
+# therefore APPENDS one status line per invocation to RAVEL_STATUS_FILE and one
+# body-file path per invocation to RAVEL_BODY_INDEX, both in execution order, so
+# run_one_command sees every request. Each body is kept in RAVEL_CAPTURE_DIR (not
+# deleted here) for the driver to evaluate and reap.
 setup_curl_shim() {
   [[ -n $CURL_SHIM_DIR ]] && return 0
   if [[ -z $REAL_CURL ]]; then
@@ -151,7 +176,7 @@ setup_curl_shim() {
 # On-PATH shim for scripts/check-readme-commands.sh. Injects request timeouts
 # and captures the HTTP status out of band into RAVEL_STATUS_FILE.
 set -uo pipefail
-body=$(mktemp)
+body=$(mktemp "$RAVEL_CAPTURE_DIR/body.XXXXXX")
 code=$("$RAVEL_REAL_CURL" \
   --silent \
   --connect-timeout "$RAVEL_CURL_CONNECT_TIMEOUT_SECONDS" \
@@ -160,9 +185,11 @@ code=$("$RAVEL_REAL_CURL" \
   --write-out '%{http_code}' \
   "$@")
 rc=$?
-printf '%s' "$code" >"$RAVEL_STATUS_FILE"
+# Append (not overwrite): a block may make several requests, and every one must
+# be accounted for. One status line and one body-file path per invocation.
+printf '%s\n' "$code" >>"$RAVEL_STATUS_FILE"
+printf '%s\n' "$body" >>"$RAVEL_BODY_INDEX"
 cat "$body"
-rm -f "$body"
 exit "$rc"
 SHIM
   chmod +x "$CURL_SHIM_DIR/curl"
@@ -171,12 +198,44 @@ SHIM
 }
 
 # --- Running one command --------------------------------------------------
-# Runs `cmd`, writes its stdout to `body_file`, and prints two space-separated
-# tokens on one line: the captured HTTP status (or "none") and the command's
-# own exit code. A curl command runs with the shim on PATH so the HTTP status is
-# captured out of band even when curl exits 0 on a 4xx/5xx. If the status cannot
-# be determined, "none" is reported and a `status=` assertion fails on it, never
-# passes.
+# Reduce the per-request statuses a block captured to a single token for the
+# `status=` assertion. Reads one code per line (execution order) from
+# `status_file` and prints:
+#   "none"      no request was captured (a shim-bypassed or non-curl block)
+#   "mismatch"  the block's requests returned two or more DIFFERENT codes, so a
+#               single `status=` cannot map to them: fail closed, never guess
+#   <code>      every request returned this one code; the assertion applies to
+#               all of them, not to whichever ran last
+resolve_block_status() {
+  local status_file=$1
+  local -a codes=()
+  mapfile -t codes <"$status_file"
+  if (( ${#codes[@]} == 0 )); then
+    printf 'none'
+    return 0
+  fi
+  local first=${codes[0]}
+  local c
+  for c in "${codes[@]}"; do
+    if [[ $c != "$first" ]]; then
+      printf 'mismatch'
+      return 0
+    fi
+  done
+  printf '%s' "$first"
+}
+
+# Runs `cmd`, writes the body to evaluate into `body_file`, and prints two
+# space-separated tokens on one line: the block's status token (see
+# resolve_block_status, or "timeout") and the command's own exit code. A curl
+# command runs with the shim on PATH so every request's HTTP status is captured
+# out of band even when curl exits 0 on a 4xx/5xx. When the shim fronted at least
+# one request, `body_file` is overwritten with the LAST request's body, so a
+# `json:`/`nonempty:` assertion evaluates one coherent response rather than the
+# concatenation of every request's output (which let an empty 401 body followed
+# by a valid 200 envelope satisfy the check vacuously). Every block, whatever its
+# text, runs under a BLOCK_TIMEOUT_SECONDS wall-clock bound; a block that exceeds
+# it reports "timeout" and fails.
 run_one_command() {
   local cmd=$1
   local body_file=$2
@@ -185,23 +244,39 @@ run_one_command() {
 
   if [[ $cmd == curl* ]]; then
     setup_curl_shim
-    local status_file
-    status_file=$(mktemp)
+    local cap_dir
+    cap_dir=$(mktemp -d)
+    local status_file="$cap_dir/status"
+    local body_index="$cap_dir/bodyindex"
     : >"$status_file"
+    : >"$body_index"
     PATH="$CURL_SHIM_DIR:$PATH" \
       RAVEL_REAL_CURL="$REAL_CURL" \
       RAVEL_STATUS_FILE="$status_file" \
+      RAVEL_BODY_INDEX="$body_index" \
+      RAVEL_CAPTURE_DIR="$cap_dir" \
       RAVEL_CURL_CONNECT_TIMEOUT_SECONDS="$CONNECT_TIMEOUT_SECONDS" \
       RAVEL_CURL_MAX_TIME_SECONDS="$REQUEST_TIMEOUT_SECONDS" \
+      timeout -k "$BLOCK_TIMEOUT_KILL_SECONDS" "$BLOCK_TIMEOUT_SECONDS" \
       bash -c "$cmd" >"$body_file" 2>/dev/null || run_code=$?
-    local code_read
-    code_read=$(cat "$status_file")
-    rm -f "$status_file"
-    if [[ -n $code_read ]]; then
-      captured=$code_read
+    if [[ $run_code -eq 124 || $run_code -eq 137 ]]; then
+      captured="timeout"
+    else
+      captured=$(resolve_block_status "$status_file")
+      # Evaluate the last request's body, not the concatenated block stdout.
+      local -a body_paths=()
+      mapfile -t body_paths <"$body_index"
+      if (( ${#body_paths[@]} > 0 )); then
+        cp "${body_paths[-1]}" "$body_file"
+      fi
     fi
+    rm -rf "$cap_dir"
   else
-    bash -c "$cmd" >"$body_file" 2>/dev/null || run_code=$?
+    timeout -k "$BLOCK_TIMEOUT_KILL_SECONDS" "$BLOCK_TIMEOUT_SECONDS" \
+      bash -c "$cmd" >"$body_file" 2>/dev/null || run_code=$?
+    if [[ $run_code -eq 124 || $run_code -eq 137 ]]; then
+      captured="timeout"
+    fi
   fi
   printf '%s %s' "$captured" "$run_code"
 }
@@ -245,6 +320,23 @@ run_blocks() {
     http_status=${run_out%% *}
     run_code=${run_out##* }
     echo "exit=${run_code} http=${http_status}"
+
+    # Fail closed BEFORE evaluation on the two shapes the evaluator cannot judge:
+    # a block that outran its wall-clock bound, and a block whose requests
+    # returned differing statuses (a single `status=` cannot map to N requests,
+    # and a body-only marker would otherwise pass on the last request while an
+    # earlier one had already failed).
+    if [[ $http_status == "timeout" ]]; then
+      rm -f "$body_file"
+      echo "FAIL: block at ${md}:${line_no} exceeded the ${BLOCK_TIMEOUT_SECONDS}s wall-clock bound" >&2
+      return 1
+    fi
+    if [[ $http_status == "mismatch" ]]; then
+      rm -f "$body_file"
+      echo "FAIL: block at ${md}:${line_no} issued requests with differing HTTP statuses;" \
+           "a single status= cannot map to them (fail closed, not a guess)" >&2
+      return 1
+    fi
 
     local eval_rc=0
     python3 "$py_module" evaluate "$exp_raw" \

--- a/scripts/check_readme_commands.py
+++ b/scripts/check_readme_commands.py
@@ -1,0 +1,411 @@
+#!/usr/bin/env python3
+"""Extractor and expectation evaluator for marked runnable command blocks.
+
+This module holds the pure, hermetic logic behind
+``scripts/check-readme-commands.sh``: it parses the marker convention out of a
+markdown file, extracts the fenced command blocks the reader is meant to run,
+and evaluates each block's declared expectation against a command result. The
+shell driver owns everything that touches a live stack (readiness waiting and
+running the commands); this module owns everything that can be unit tested with
+no network, no docker, and no MinIO. See scripts/test_check_readme_commands.py.
+
+Marker convention (justification)
+---------------------------------
+A runnable block is marked by an HTML comment on the line IMMEDIATELY before the
+opening fence::
+
+    <!-- ravel:run <expectation>[; <expectation> ...] -->
+    ```
+    curl -s -H "Authorization: Bearer demo-token" http://127.0.0.1:4318/...
+    ```
+
+Why an HTML comment: it renders to nothing in GitHub-flavored markdown, so the
+README a reader sees is unchanged, yet it is trivially greppable
+(``grep -n 'ravel:run'``) and unambiguous. ADR-0081 decision 5 requires an
+explicit marker precisely so the executable set stays auditable and an unmarked
+block that should have been marked is a reviewable omission rather than a silent
+one; a doctest-style "run every fence" approach was rejected there because the
+README legitimately contains blocks that must not run (a `cosign verify` naming
+a historical tag, a `docker pull` of a moving tag). The ``ravel:`` prefix
+namespaces the token so it does not collide with ordinary prose comments.
+
+The marker must sit on the line directly above the fence, with no blank line
+between. That rule is what makes the convention unambiguous: a comment floating
+elsewhere in the document is not a marker and never runs a block.
+
+Expectation vocabulary (small and closed)
+------------------------------------------
+Each expectation is one of exactly three keywords. A marker may carry several,
+separated by ``;``; all must hold for the block to pass.
+
+    status=<code>       The HTTP status code equals <code>. curl exits 0 on an
+                        HTTP 401 or 500, so this is the assertion an exit-code
+                        check cannot make. Requires the runner to have captured
+                        a status (the shell driver does this for curl commands).
+
+    json:<path>=<value> The command's stdout parses as JSON and the value at
+                        <path> equals <value> (compared as text). <path> is a
+                        minimal dotted path: `.status`, `.data.resultType`,
+                        `.data.result.0`. A `{"status":"error"}` envelope thus
+                        fails `json:.status=success` even though the process
+                        exited 0 -- the whole point of the gate.
+
+    nonempty:<path>     The command's stdout parses as JSON and the value at
+                        <path> is present and non-empty (a non-empty array,
+                        object, or string; any number is non-empty).
+
+Fail closed: an empty expectation list, an unparseable marker, or an unknown
+keyword raises MarkerError. A block with no expectation is an error, never a
+silent skip -- a silent skip is how this class of check rots (ADR-0081 D5).
+"""
+
+import argparse
+import base64
+import json
+import sys
+
+
+class MarkerError(Exception):
+    """A marker or expectation that cannot be parsed. Always fatal, never a skip."""
+
+
+class Block:
+    """A marked, runnable command block extracted from a markdown file."""
+
+    __slots__ = ("line", "command", "expectations", "raw_expectation")
+
+    def __init__(self, line, command, expectations, raw_expectation):
+        self.line = line  # 1-indexed source line of the opening fence
+        self.command = command  # verbatim inner text of the fence
+        self.expectations = expectations  # list of dicts, see parse_expectations
+        self.raw_expectation = raw_expectation
+
+    def __repr__(self):
+        return f"Block(line={self.line}, expectations={self.expectations!r})"
+
+
+_MARKER_PREFIX = "<!--"
+_MARKER_TOKEN = "ravel:run"
+
+
+def _marker_expectation_text(line):
+    """Return the expectation text if `line` is a run marker, else None.
+
+    Recognizes `<!-- ravel:run ... -->` with arbitrary surrounding whitespace.
+    """
+    stripped = line.strip()
+    if not stripped.startswith(_MARKER_PREFIX) or not stripped.endswith("-->"):
+        return None
+    inner = stripped[len(_MARKER_PREFIX) : -len("-->")].strip()
+    if not inner.startswith(_MARKER_TOKEN):
+        return None
+    return inner[len(_MARKER_TOKEN) :].strip()
+
+
+def _is_fence(line):
+    return line.lstrip().startswith("```")
+
+
+def parse_expectations(raw):
+    """Parse the marker's expectation text into a list of expectation dicts.
+
+    Raises MarkerError on an empty list, an unknown keyword, or a malformed
+    expectation. Never returns an empty list.
+    """
+    if raw is None or not raw.strip():
+        raise MarkerError("marker carries no expectation (fail closed, not a skip)")
+    out = []
+    for piece in raw.split(";"):
+        token = piece.strip()
+        if not token:
+            raise MarkerError(f"empty expectation in marker {raw!r}")
+        out.append(_parse_one_expectation(token))
+    if not out:
+        raise MarkerError(f"marker {raw!r} produced no expectations")
+    return out
+
+
+def _parse_one_expectation(token):
+    if token.startswith("status="):
+        code = token[len("status=") :].strip()
+        if not code.isdigit():
+            raise MarkerError(f"status= expects an integer code, got {token!r}")
+        return {"kind": "status", "code": int(code)}
+    if token.startswith("json:"):
+        rest = token[len("json:") :]
+        if "=" not in rest:
+            raise MarkerError(f"json: expects <path>=<value>, got {token!r}")
+        path_text, value = rest.split("=", 1)
+        segments = _parse_path(path_text)
+        if not segments:
+            raise MarkerError(f"json: expects a non-empty path, got {token!r}")
+        return {"kind": "json", "path": segments, "value": value}
+    if token.startswith("nonempty:"):
+        segments = _parse_path(token[len("nonempty:") :])
+        if not segments:
+            raise MarkerError(f"nonempty: expects a non-empty path, got {token!r}")
+        return {"kind": "nonempty", "path": segments}
+    raise MarkerError(
+        f"unknown expectation keyword in {token!r}; "
+        "known: status=, json:<path>=<value>, nonempty:<path>"
+    )
+
+
+def _parse_path(text):
+    """Split a dotted JSON path into segments. `.a.b.0` -> ['a', 'b', '0']."""
+    return [seg for seg in text.strip().lstrip(".").split(".") if seg != ""]
+
+
+def extract_blocks(text):
+    """Return the ordered list of marked Blocks in `text`.
+
+    Unmarked fenced blocks are ignored (not an error). A marker not immediately
+    followed by an opening fence, or a marker with a bad expectation, raises
+    MarkerError -- fail closed.
+    """
+    lines = text.split("\n")
+    blocks = []
+    i = 0
+    n = len(lines)
+    while i < n:
+        line = lines[i]
+        expectation_text = _marker_expectation_text(line)
+        if expectation_text is not None:
+            marker_lineno = i + 1
+            if i + 1 >= n or not _is_fence(lines[i + 1]):
+                raise MarkerError(
+                    f"line {marker_lineno}: run marker is not immediately "
+                    "followed by a code fence"
+                )
+            expectations = parse_expectations(expectation_text)
+            fence_lineno = i + 2
+            body, closed_at = _read_fence(lines, i + 1)
+            if closed_at is None:
+                raise MarkerError(
+                    f"line {fence_lineno}: code fence opened but never closed"
+                )
+            blocks.append(
+                Block(
+                    line=fence_lineno,
+                    command="\n".join(body),
+                    expectations=expectations,
+                    raw_expectation=expectation_text,
+                )
+            )
+            i = closed_at + 1
+            continue
+        if _is_fence(line):
+            # Unmarked fence: skip its whole body so a `ravel:run` string inside
+            # a code sample is never mistaken for a marker.
+            _, closed_at = _read_fence(lines, i)
+            i = (closed_at + 1) if closed_at is not None else n
+            continue
+        i += 1
+    return blocks
+
+
+def _read_fence(lines, open_index):
+    """Given the index of an opening fence line, return (body_lines, close_index).
+
+    close_index is the index of the closing fence, or None if unterminated.
+    """
+    body = []
+    j = open_index + 1
+    while j < len(lines):
+        if _is_fence(lines[j]):
+            return body, j
+        body.append(lines[j])
+        j += 1
+    return body, None
+
+
+def _resolve_path(obj, segments):
+    """Walk `segments` into a parsed-JSON object. Raises LookupError if absent."""
+    cur = obj
+    for seg in segments:
+        if isinstance(cur, dict):
+            if seg not in cur:
+                raise LookupError(seg)
+            cur = cur[seg]
+        elif isinstance(cur, list):
+            if not seg.lstrip("-").isdigit():
+                raise LookupError(seg)
+            idx = int(seg)
+            if idx < -len(cur) or idx >= len(cur):
+                raise LookupError(seg)
+            cur = cur[idx]
+        else:
+            raise LookupError(seg)
+    return cur
+
+
+def _as_text(value):
+    """Render a JSON scalar the way an expectation value is written in a marker."""
+    if value is True:
+        return "true"
+    if value is False:
+        return "false"
+    if value is None:
+        return "null"
+    if isinstance(value, float) and value.is_integer():
+        return str(int(value))
+    return str(value)
+
+
+def _is_empty(value):
+    return value is None or value == "" or value == [] or value == {}
+
+
+def evaluate(expectations, result):
+    """Evaluate expectations against a command result.
+
+    `result` is a dict: {"exit": int, "http_status": int|None, "body": str}.
+    Returns a list of (ok: bool, detail: str), one per expectation, in order.
+    """
+    outcomes = []
+    parsed_json = _NOT_PARSED
+    for exp in expectations:
+        kind = exp["kind"]
+        if kind == "status":
+            outcomes.append(_eval_status(exp, result))
+            continue
+        # json and nonempty both need the body parsed as JSON, once.
+        if parsed_json is _NOT_PARSED:
+            parsed_json = _try_parse_json(result.get("body", ""))
+        if isinstance(parsed_json, _ParseFailure):
+            outcomes.append((False, f"{kind}: stdout is not valid JSON ({parsed_json.msg})"))
+            continue
+        if kind == "json":
+            outcomes.append(_eval_json_equals(exp, parsed_json))
+        elif kind == "nonempty":
+            outcomes.append(_eval_nonempty(exp, parsed_json))
+        else:  # pragma: no cover - parse_expectations guards this
+            outcomes.append((False, f"unknown expectation kind {kind!r}"))
+    return outcomes
+
+
+def evaluate_ok(expectations, result):
+    """True only if every expectation holds."""
+    return all(ok for ok, _ in evaluate(expectations, result))
+
+
+class _ParseFailure:
+    def __init__(self, msg):
+        self.msg = msg
+
+
+_NOT_PARSED = object()
+
+
+def _try_parse_json(body):
+    try:
+        return json.loads(body)
+    except (ValueError, TypeError) as exc:
+        return _ParseFailure(str(exc))
+
+
+def _eval_status(exp, result):
+    got = result.get("http_status")
+    want = exp["code"]
+    if got is None:
+        return (False, f"status: expected {want} but no HTTP status was captured")
+    if got == want:
+        return (True, f"status={got}")
+    return (False, f"status: expected {want}, got {got}")
+
+
+def _eval_json_equals(exp, parsed):
+    path = exp["path"]
+    dotted = "." + ".".join(path)
+    try:
+        value = _resolve_path(parsed, path)
+    except LookupError:
+        return (False, f"json: path {dotted} is absent")
+    got = _as_text(value)
+    if got == exp["value"]:
+        return (True, f"json {dotted} == {got!r}")
+    return (False, f"json: {dotted} expected {exp['value']!r}, got {got!r}")
+
+
+def _eval_nonempty(exp, parsed):
+    path = exp["path"]
+    dotted = "." + ".".join(path)
+    try:
+        value = _resolve_path(parsed, path)
+    except LookupError:
+        return (False, f"nonempty: path {dotted} is absent")
+    if _is_empty(value):
+        return (False, f"nonempty: {dotted} is empty")
+    return (True, f"nonempty {dotted}")
+
+
+# --------------------------------------------------------------------------
+# CLI: a thin shell-facing wrapper. All logic above is import-testable.
+# --------------------------------------------------------------------------
+
+
+def _cmd_extract(md_path):
+    """Emit one NUL-delimited record per marked block for the shell driver.
+
+    Fields per block, each NUL-terminated: line number, raw expectation text,
+    base64 of the command (base64 so a multi-line command survives the pipe).
+    """
+    with open(md_path, "r", encoding="utf-8") as handle:
+        text = handle.read()
+    blocks = extract_blocks(text)  # MarkerError propagates: fail closed, exit 2
+    out = sys.stdout.buffer
+    for block in blocks:
+        cmd_b64 = base64.b64encode(block.command.encode("utf-8"))
+        out.write(str(block.line).encode("ascii") + b"\0")
+        out.write(block.raw_expectation.encode("utf-8") + b"\0")
+        out.write(cmd_b64 + b"\0")
+    out.flush()
+
+
+def _cmd_evaluate(raw, exit_code, http_text):
+    body = sys.stdin.read()
+    if http_text is None or http_text == "none":
+        http_status = None
+    elif http_text.isdigit():
+        http_status = int(http_text)
+    else:
+        print(f"evaluate: bad --http value {http_text!r}", file=sys.stderr)
+        return 2
+    expectations = parse_expectations(raw)  # MarkerError -> caught in main
+    result = {"exit": exit_code, "http_status": http_status, "body": body}
+    outcomes = evaluate(expectations, result)
+    ok = True
+    for passed, detail in outcomes:
+        marker = "ok  " if passed else "FAIL"
+        print(f"    [{marker}] {detail}")
+        ok = ok and passed
+    return 0 if ok else 1
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_extract = sub.add_parser("extract", help="emit marked blocks for the shell driver")
+    p_extract.add_argument("markdown")
+
+    p_eval = sub.add_parser("evaluate", help="evaluate one block's expectation")
+    p_eval.add_argument("expectation")
+    p_eval.add_argument("--exit", dest="exit_code", type=int, default=0)
+    p_eval.add_argument("--http", dest="http", default="none")
+
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "extract":
+            _cmd_extract(args.markdown)
+            return 0
+        if args.command == "evaluate":
+            return _cmd_evaluate(args.expectation, args.exit_code, args.http)
+    except MarkerError as exc:
+        print(f"marker error: {exc}", file=sys.stderr)
+        return 2
+    return 2  # pragma: no cover
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_readme_commands.py
+++ b/scripts/check_readme_commands.py
@@ -102,8 +102,24 @@ def _marker_expectation_text(line):
     return inner[len(_MARKER_TOKEN) :].strip()
 
 
+def _fence_info(line):
+    """Return (marker_char, run_length) if `line` opens/closes a code fence, else None.
+
+    A fence is 3 or more backticks or 3 or more tildes (CommonMark), which is why
+    tildes must be recognized too: a ``~~~`` documentation sample is a fenced code
+    block just like a backtick one, and its whole body -- including any nested
+    ``ravel:run`` marker and inner backtick fence -- must be skipped, not scanned.
+    """
+    stripped = line.lstrip()
+    for char in ("`", "~"):
+        if stripped.startswith(char * 3):
+            run = len(stripped) - len(stripped.lstrip(char))
+            return (char, run)
+    return None
+
+
 def _is_fence(line):
-    return line.lstrip().startswith("```")
+    return _fence_info(line) is not None
 
 
 def parse_expectations(raw):
@@ -195,8 +211,9 @@ def extract_blocks(text):
             i = closed_at + 1
             continue
         if _is_fence(line):
-            # Unmarked fence: skip its whole body so a `ravel:run` string inside
-            # a code sample is never mistaken for a marker.
+            # Unmarked fence (backtick or tilde): skip its whole body so a
+            # `ravel:run` string inside a code sample -- even one wrapping a
+            # nested fence of the other kind -- is never mistaken for a marker.
             _, closed_at = _read_fence(lines, i)
             i = (closed_at + 1) if closed_at is not None else n
             continue
@@ -207,13 +224,22 @@ def extract_blocks(text):
 def _read_fence(lines, open_index):
     """Given the index of an opening fence line, return (body_lines, close_index).
 
-    close_index is the index of the closing fence, or None if unterminated.
+    close_index is the index of the closing fence, or None if unterminated. A
+    fence is closed only by a fence of the SAME marker character and at least the
+    same length, with no trailing info text (CommonMark). This is what lets a
+    ``~~~`` block contain a ``` ```sh ``` fence in its body without closing early,
+    so a marker nested inside a tilde sample never leaks out as runnable.
     """
+    open_char, open_len = _fence_info(lines[open_index])
     body = []
     j = open_index + 1
     while j < len(lines):
-        if _is_fence(lines[j]):
-            return body, j
+        info = _fence_info(lines[j])
+        if info is not None:
+            close_char, close_len = info
+            after = lines[j].lstrip()[close_len:].strip()
+            if close_char == open_char and close_len >= open_len and after == "":
+                return body, j
         body.append(lines[j])
         j += 1
     return body, None

--- a/scripts/fixtures/readme-commands.md
+++ b/scripts/fixtures/readme-commands.md
@@ -1,0 +1,42 @@
+# Fixture: marked runnable command blocks
+
+This file exercises scripts/check_readme_commands.py. It is not the README; it
+is a controlled sample covering each case the extractor and evaluator must
+handle. Ticket #175 owns the real README.
+
+## A marked block
+
+<!-- ravel:run json:.status=success -->
+```sh
+curl -s -H "Authorization: Bearer demo-token" http://127.0.0.1:4318/api/v1/query?query=up
+```
+
+## An unmarked block that must never run
+
+This fence has no `ravel:run` marker, so the extractor must ignore it. If it
+ever runs, the extractor is broken.
+
+```sh
+echo THIS_MUST_NEVER_RUN
+```
+
+## A marked block whose command spans multiple lines
+
+<!-- ravel:run status=200 -->
+```sh
+curl -s \
+  -H "Authorization: Bearer demo-token" \
+  "http://127.0.0.1:4318/api/v1/query?query=up"
+```
+
+## A marked block that exits 0 but returns an error envelope
+
+The command below exits 0 (curl succeeds), yet the server answers with a
+`{"status":"error"}` body. The block asserts `json:.status=success`, so the
+check must FAIL here even though the process exit status is 0. This is the
+exact defect ADR-0081 exists to catch.
+
+<!-- ravel:run json:.status=success -->
+```sh
+curl -s -H "Authorization: Bearer demo-token" "http://127.0.0.1:4318/api/v1/query?query=broken"
+```

--- a/scripts/test_check_readme_commands.py
+++ b/scripts/test_check_readme_commands.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Hermetic unit tests for scripts/check_readme_commands.py.
+
+No network, no docker, no MinIO: the extractor is tested against the fixture
+markdown, and the evaluator is fed canned command results. The live command
+runner lives in check-readme-commands.sh and is deliberately not exercised here.
+
+Run: cd scripts && python3 -m unittest test_check_readme_commands -v
+"""
+
+import os
+import unittest
+
+from check_readme_commands import (
+    MarkerError,
+    extract_blocks,
+    parse_expectations,
+    evaluate,
+    evaluate_ok,
+)
+
+FIXTURE = os.path.join(os.path.dirname(__file__), "fixtures", "readme-commands.md")
+
+
+def load_fixture():
+    with open(FIXTURE, "r", encoding="utf-8") as handle:
+        return handle.read()
+
+
+class TestExtractor(unittest.TestCase):
+    def setUp(self):
+        self.blocks = extract_blocks(load_fixture())
+
+    def test_extracts_only_marked_blocks(self):
+        # Three marked blocks; the unmarked `echo` block is ignored.
+        self.assertEqual(len(self.blocks), 3)
+
+    def test_unmarked_block_never_extracted(self):
+        for block in self.blocks:
+            self.assertNotIn("THIS_MUST_NEVER_RUN", block.command)
+
+    def test_multiline_command_survives_intact(self):
+        multiline = [b for b in self.blocks if "\n" in b.command]
+        self.assertEqual(len(multiline), 1)
+        cmd = multiline[0].command
+        # Every source line of the block is preserved, backslash continuations
+        # and all.
+        self.assertIn("curl -s \\", cmd)
+        self.assertIn('-H "Authorization: Bearer demo-token"', cmd)
+        self.assertIn('"http://127.0.0.1:4318/api/v1/query?query=up"', cmd)
+        self.assertEqual(cmd.count("\n"), 2)
+
+    def test_reports_source_line_numbers(self):
+        for block in self.blocks:
+            self.assertGreater(block.line, 0)
+        # Blocks are returned in document order.
+        lines = [b.line for b in self.blocks]
+        self.assertEqual(lines, sorted(lines))
+
+    def test_error_envelope_block_asserts_success(self):
+        # The last marked block is the error-envelope case.
+        block = self.blocks[-1]
+        self.assertEqual(block.raw_expectation, "json:.status=success")
+
+
+class TestExtractorFailsClosed(unittest.TestCase):
+    def test_marker_without_expectation_is_error(self):
+        text = "<!-- ravel:run -->\n```\ncurl x\n```\n"
+        with self.assertRaises(MarkerError):
+            extract_blocks(text)
+
+    def test_unknown_keyword_is_error(self):
+        text = "<!-- ravel:run teapot=418brew -->\n```\ncurl x\n```\n"
+        with self.assertRaises(MarkerError):
+            extract_blocks(text)
+
+    def test_marker_not_before_fence_is_error(self):
+        text = "<!-- ravel:run status=200 -->\n\nprose, not a fence\n"
+        with self.assertRaises(MarkerError):
+            extract_blocks(text)
+
+    def test_unterminated_fence_is_error(self):
+        text = "<!-- ravel:run status=200 -->\n```\ncurl x\n"
+        with self.assertRaises(MarkerError):
+            extract_blocks(text)
+
+    def test_ravel_run_inside_unmarked_fence_is_not_a_marker(self):
+        # A `ravel:run` string that lives inside an unmarked code sample must
+        # not be picked up: it is body, not a marker.
+        text = "```\n<!-- ravel:run status=200 -->\necho hi\n```\n"
+        self.assertEqual(extract_blocks(text), [])
+
+
+class TestParseExpectations(unittest.TestCase):
+    def test_empty_raises(self):
+        with self.assertRaises(MarkerError):
+            parse_expectations("")
+        with self.assertRaises(MarkerError):
+            parse_expectations("   ")
+
+    def test_unknown_keyword_raises(self):
+        with self.assertRaises(MarkerError):
+            parse_expectations("definitely-not-a-keyword")
+
+    def test_status_requires_integer(self):
+        with self.assertRaises(MarkerError):
+            parse_expectations("status=twohundred")
+        self.assertEqual(parse_expectations("status=200"), [{"kind": "status", "code": 200}])
+
+    def test_json_requires_path_and_value(self):
+        with self.assertRaises(MarkerError):
+            parse_expectations("json:.status")  # no =value
+        self.assertEqual(
+            parse_expectations("json:.data.resultType=vector"),
+            [{"kind": "json", "path": ["data", "resultType"], "value": "vector"}],
+        )
+
+    def test_nonempty_requires_path(self):
+        with self.assertRaises(MarkerError):
+            parse_expectations("nonempty:")
+        self.assertEqual(
+            parse_expectations("nonempty:.data.result"),
+            [{"kind": "nonempty", "path": ["data", "result"]}],
+        )
+
+    def test_multiple_expectations_semicolon_separated(self):
+        parsed = parse_expectations("status=200; json:.status=success")
+        self.assertEqual(len(parsed), 2)
+        self.assertEqual(parsed[0]["kind"], "status")
+        self.assertEqual(parsed[1]["kind"], "json")
+
+
+def result(body="", http_status=200, exit_code=0):
+    return {"exit": exit_code, "http_status": http_status, "body": body}
+
+
+class TestEvaluateStatus(unittest.TestCase):
+    def test_matching_status_passes(self):
+        exp = parse_expectations("status=200")
+        self.assertTrue(evaluate_ok(exp, result(http_status=200)))
+
+    def test_wrong_status_fails(self):
+        exp = parse_expectations("status=200")
+        # curl exits 0 on a 401; the exit code would pass, the status must not.
+        self.assertFalse(evaluate_ok(exp, result(http_status=401, exit_code=0)))
+
+    def test_missing_status_fails(self):
+        exp = parse_expectations("status=200")
+        self.assertFalse(evaluate_ok(exp, result(http_status=None)))
+
+
+class TestEvaluateJson(unittest.TestCase):
+    def test_field_equals_passes(self):
+        exp = parse_expectations("json:.status=success")
+        self.assertTrue(evaluate_ok(exp, result(body='{"status":"success"}')))
+
+    def test_error_envelope_fails_despite_exit_zero(self):
+        # THE assertion the whole epic depends on: exit 0, HTTP 200, but the
+        # body is an error envelope. An exit-code-only check would pass this.
+        exp = parse_expectations("json:.status=success")
+        res = result(body='{"status":"error","error":"boom"}', http_status=200, exit_code=0)
+        self.assertFalse(evaluate_ok(exp, res))
+        # And the failure detail names what went wrong.
+        outcomes = evaluate(exp, res)
+        self.assertEqual(len(outcomes), 1)
+        ok, detail = outcomes[0]
+        self.assertFalse(ok)
+        self.assertIn("status", detail)
+
+    def test_error_envelope_from_fixture_block(self):
+        # Drive it through the actual fixture block, not a hand-written body,
+        # so the marker the fixture declares is the marker under test.
+        block = extract_blocks(load_fixture())[-1]
+        res = result(body='{"status":"error","error":"bad query"}')
+        self.assertFalse(evaluate_ok(block.expectations, res))
+
+    def test_absent_path_fails(self):
+        exp = parse_expectations("json:.status=success")
+        self.assertFalse(evaluate_ok(exp, result(body='{"other":"success"}')))
+
+    def test_non_json_body_fails(self):
+        exp = parse_expectations("json:.status=success")
+        self.assertFalse(evaluate_ok(exp, result(body="<html>401 Unauthorized</html>")))
+
+    def test_array_index_path(self):
+        exp = parse_expectations("json:.data.0=first")
+        self.assertTrue(evaluate_ok(exp, result(body='{"data":["first","second"]}')))
+
+
+class TestEvaluateNonEmpty(unittest.TestCase):
+    def test_non_empty_array_passes(self):
+        exp = parse_expectations("nonempty:.data.result")
+        self.assertTrue(evaluate_ok(exp, result(body='{"data":{"result":[1,2]}}')))
+
+    def test_empty_array_fails(self):
+        exp = parse_expectations("nonempty:.data.result")
+        self.assertFalse(evaluate_ok(exp, result(body='{"data":{"result":[]}}')))
+
+    def test_absent_path_fails(self):
+        exp = parse_expectations("nonempty:.data.result")
+        self.assertFalse(evaluate_ok(exp, result(body='{"data":{}}')))
+
+
+class TestEvaluateCombined(unittest.TestCase):
+    def test_all_must_hold(self):
+        exp = parse_expectations("status=200; json:.status=success")
+        good = result(body='{"status":"success"}', http_status=200)
+        self.assertTrue(evaluate_ok(exp, good))
+        # Right body, wrong status: still a failure.
+        bad = result(body='{"status":"success"}', http_status=500)
+        self.assertFalse(evaluate_ok(exp, bad))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_check_readme_commands.py
+++ b/scripts/test_check_readme_commands.py
@@ -86,9 +86,24 @@ class TestExtractorFailsClosed(unittest.TestCase):
 
     def test_ravel_run_inside_unmarked_fence_is_not_a_marker(self):
         # A `ravel:run` string that lives inside an unmarked code sample must
-        # not be picked up: it is body, not a marker.
-        text = "```\n<!-- ravel:run status=200 -->\necho hi\n```\n"
-        self.assertEqual(extract_blocks(text), [])
+        # not be picked up: it is body, not a marker. This holds for both fence
+        # kinds, and for a tilde sample that wraps a nested backtick fence (the
+        # shape that leaked a runnable `curl` when only backticks were fences).
+        backtick = "```\n<!-- ravel:run status=200 -->\necho hi\n```\n"
+        self.assertEqual(extract_blocks(backtick), [])
+
+        tilde = "~~~\n<!-- ravel:run status=200 -->\necho hi\n~~~\n"
+        self.assertEqual(extract_blocks(tilde), [])
+
+        nested = (
+            "~~~\n"
+            "<!-- ravel:run status=200 -->\n"
+            "```sh\n"
+            "curl http://evil.example/DANGEROUS\n"
+            "```\n"
+            "~~~\n"
+        )
+        self.assertEqual(extract_blocks(nested), [])
 
 
 class TestParseExpectations(unittest.TestCase):

--- a/scripts/test_check_readme_commands_shell.py
+++ b/scripts/test_check_readme_commands_shell.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Integration tests for the shell driver scripts/check-readme-commands.sh.
+
+Unlike test_check_readme_commands.py (which unit-tests the pure Python), these
+drive the whole shell script against a local stub HTTP server. They are still
+hermetic: no docker, no MinIO, no network beyond loopback. The stub stands in
+for the live stack so the status-capture and readiness-timeout behaviour can be
+exercised end to end.
+
+Run: cd scripts && python3 -m unittest test_check_readme_commands_shell -v
+"""
+
+import os
+import socket
+import subprocess
+import tempfile
+import threading
+import unittest
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SCRIPT = os.path.join(HERE, "check-readme-commands.sh")
+
+# A response that FORGES the out-of-band sentinel inside the body: the real HTTP
+# status is 401, but the body carries a `RAVEL_HTTP_STATUS=200` line. A gate that
+# recovers the status by parsing the body would be fooled into reporting 200.
+FORGED_BODY = b'{"status":"error"}\nRAVEL_HTTP_STATUS=200\n'
+
+# A non-empty instant-query envelope so the readiness poll's `nonempty:` check
+# passes on the first try and the script proceeds to run the marked blocks.
+READY_BODY = b'{"status":"success","data":{"result":[{"value":[0,"1"]}]}}'
+
+
+class _Handler(BaseHTTPRequestHandler):
+    # Behaviour is selected by path so one server serves health, readiness, and
+    # the forging endpoint.
+    def do_GET(self):  # noqa: N802 (name mandated by BaseHTTPRequestHandler)
+        if self.path.startswith("/healthz"):
+            self._respond(200, b"ok")
+        elif self.path.startswith("/forge"):
+            self._respond(401, FORGED_BODY)
+        elif self.path.startswith("/api/v1/query"):
+            self._respond(200, READY_BODY)
+        else:
+            self._respond(404, b"not found")
+
+    def _respond(self, code, body):
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *_args):
+        pass  # keep test output clean
+
+
+class _StubServer:
+    def __init__(self):
+        self.httpd = HTTPServer(("127.0.0.1", 0), _Handler)
+        self.port = self.httpd.server_address[1]
+        self.thread = threading.Thread(target=self.httpd.serve_forever, daemon=True)
+
+    def __enter__(self):
+        self.thread.start()
+        return self
+
+    def __exit__(self, *_exc):
+        self.httpd.shutdown()
+        self.thread.join(timeout=5)
+        self.httpd.server_close()
+
+    @property
+    def base(self):
+        return f"http://127.0.0.1:{self.port}"
+
+
+def _run_script(md_text, base, extra_env=None, set_health_path=True, timeout=60):
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".md", delete=False, encoding="utf-8"
+    ) as handle:
+        handle.write(md_text)
+        md_path = handle.name
+    env = dict(os.environ)
+    env["RAVEL_HTTP_BASE"] = base
+    if set_health_path:
+        env["RAVEL_HEALTH_PATH"] = "/healthz"
+    else:
+        env.pop("RAVEL_HEALTH_PATH", None)  # exercise the built-in default
+    env["RAVEL_READY_QUERY_URL"] = f"{base}/api/v1/query?query=probe"
+    env["RAVEL_READINESS_TIMEOUT_SECONDS"] = "10"
+    env["RAVEL_READINESS_POLL_SECONDS"] = "1"
+    if extra_env:
+        env.update(extra_env)
+    try:
+        return subprocess.run(
+            ["bash", SCRIPT, md_path],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    finally:
+        os.unlink(md_path)
+
+
+class TestStatusCaptureIsUnforgeable(unittest.TestCase):
+    def test_body_cannot_forge_status_even_with_trailing_comment(self):
+        # THE assertion this epic rests on. The block asserts status=200 against
+        # an endpoint that answers 401 with a body forging
+        # `RAVEL_HTTP_STATUS=200`, and the curl line ends in a `#` comment. The
+        # pre-fix driver appended its write-out flags to the command string,
+        # where the trailing `#` detached them, then recovered the status from
+        # the body and PASSED (exit 0). The fix captures the real status out of
+        # band via the curl shim, so the check must FAIL (non-zero exit).
+        md = (
+            "# forge test\n\n"
+            "<!-- ravel:run status=200 -->\n"
+            "```sh\n"
+            f"curl -s {{base}}/forge  # trailing comment detaches appended flags\n"
+            "```\n"
+        )
+        with _StubServer() as server:
+            md = md.replace("{base}", server.base)
+            result = _run_script(md, server.base)
+        self.assertNotEqual(
+            result.returncode,
+            0,
+            msg=(
+                "status=200 must FAIL against a real 401; a pass means the body "
+                f"forged the status.\nstdout:\n{result.stdout}\n"
+                f"stderr:\n{result.stderr}"
+            ),
+        )
+
+    def test_semicolon_after_curl_does_not_detach_capture(self):
+        # A `;` in the command line must not detach the status capture either:
+        # the shim resolves as its own simple command regardless.
+        md = (
+            "# semicolon test\n\n"
+            "<!-- ravel:run status=200 -->\n"
+            "```sh\n"
+            f"curl -s {{base}}/forge ; true\n"
+            "```\n"
+        )
+        with _StubServer() as server:
+            md = md.replace("{base}", server.base)
+            result = _run_script(md, server.base)
+        self.assertNotEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+
+    def test_real_success_still_passes(self):
+        # Control: a genuine 200 with a success envelope passes, so the fix is
+        # not merely failing everything.
+        md = (
+            "# ok test\n\n"
+            "<!-- ravel:run status=200; json:.status=success -->\n"
+            "```sh\n"
+            f"curl -s {{base}}/api/v1/query?query=probe\n"
+            "```\n"
+        )
+        with _StubServer() as server:
+            md = md.replace("{base}", server.base)
+            result = _run_script(md, server.base)
+        self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+
+
+class TestReadinessIsBounded(unittest.TestCase):
+    def test_server_that_accepts_but_never_responds_times_out(self):
+        # A socket that accepts connections and never writes must not hang the
+        # readiness wait past its budget. Per-request --max-time bounds each
+        # curl; the overall timeout then fires. Without per-request timeouts this
+        # blocks until the harness timeout kills it.
+        listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        listener.bind(("127.0.0.1", 0))
+        listener.listen(8)
+        port = listener.getsockname()[1]
+        accepted = []
+
+        def accept_loop():
+            listener.settimeout(0.5)
+            while True:
+                try:
+                    conn, _ = listener.accept()
+                except OSError:
+                    return
+                accepted.append(conn)  # hold it open, never respond
+
+        thread = threading.Thread(target=accept_loop, daemon=True)
+        thread.start()
+        base = f"http://127.0.0.1:{port}"
+        md = "# unused\n"
+        try:
+            result = _run_script(
+                md,
+                base,
+                extra_env={
+                    "RAVEL_READINESS_TIMEOUT_SECONDS": "6",
+                    "RAVEL_CONNECT_TIMEOUT_SECONDS": "2",
+                    "RAVEL_REQUEST_TIMEOUT_SECONDS": "2",
+                },
+                timeout=25,
+            )
+        finally:
+            listener.close()
+            for conn in accepted:
+                conn.close()
+            thread.join(timeout=5)
+        # It must fail (readiness never satisfied), and it must have returned
+        # rather than hung: the 60s subprocess timeout would have raised
+        # TimeoutExpired instead of reaching here.
+        self.assertNotEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+
+
+class TestHealthPathDefault(unittest.TestCase):
+    def test_default_health_path_is_a_real_route(self):
+        # With RAVEL_HEALTH_PATH unset, the built-in default must hit a route the
+        # server actually serves. The stub serves /healthz (200) and 404s
+        # /health, so the default must be /healthz for readiness to complete and
+        # the block to run. The pre-fix default /health 404s forever and times
+        # out (non-zero exit); the fixed default reaches health and passes.
+        md = (
+            "# health default\n\n"
+            "<!-- ravel:run status=200 -->\n"
+            "```sh\n"
+            f"curl -s {{base}}/api/v1/query?query=probe\n"
+            "```\n"
+        )
+        with _StubServer() as server:
+            md = md.replace("{base}", server.base)
+            result = _run_script(md, server.base, set_health_path=False)
+        self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+
+
+class TestReadinessQueryRequired(unittest.TestCase):
+    def test_missing_ready_query_url_is_hard_error(self):
+        # An unset readiness query URL has no working default (no series is
+        # non-empty across both generators), so it must be a distinct hard error
+        # with a named cause, never a silent skip and never masquerading as a
+        # health timeout. Asserting the specific stderr distinguishes the fix
+        # from the pre-fix behaviour, where an empty value fell through to the
+        # `?query=up` default and failed later at the health poll instead.
+        md = "# unused\n"
+        with tempfile.NamedTemporaryFile(
+            "w", suffix=".md", delete=False, encoding="utf-8"
+        ) as handle:
+            handle.write(md)
+            md_path = handle.name
+        env = dict(os.environ)
+        env["RAVEL_READY_QUERY_URL"] = ""
+        env["RAVEL_READINESS_TIMEOUT_SECONDS"] = "5"
+        try:
+            result = subprocess.run(
+                ["bash", SCRIPT, md_path],
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+        finally:
+            os.unlink(md_path)
+        self.assertNotEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+        self.assertIn("RAVEL_READY_QUERY_URL is unset", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_check_readme_commands_shell.py
+++ b/scripts/test_check_readme_commands_shell.py
@@ -44,6 +44,20 @@ class _Handler(BaseHTTPRequestHandler):
         else:
             self._respond(404, b"not found")
 
+    def do_POST(self):  # noqa: N802 (name mandated by BaseHTTPRequestHandler)
+        # The README-realistic ingest endpoint, unauthenticated here: it answers
+        # 401 with an EMPTY body. That empty body is exactly what made the pre-fix
+        # concatenation vacuous -- an empty 401 body followed by a valid 200
+        # envelope left the concatenated buffer valid JSON. Draining the request
+        # body first keeps the connection well-behaved.
+        length = int(self.headers.get("Content-Length", 0) or 0)
+        if length:
+            self.rfile.read(length)
+        if self.path.startswith("/v1/metrics"):
+            self._respond(401, b"")
+        else:
+            self._respond(404, b"not found")
+
     def _respond(self, code, body):
         self.send_response(code)
         self.send_header("Content-Type", "application/json")
@@ -261,6 +275,130 @@ class TestReadinessQueryRequired(unittest.TestCase):
             os.unlink(md_path)
         self.assertNotEqual(result.returncode, 0, msg=result.stdout + result.stderr)
         self.assertIn("RAVEL_READY_QUERY_URL is unset", result.stderr)
+
+
+class TestMultiRequestBlockIsAccountedFor(unittest.TestCase):
+    def test_ingest_401_then_query_200_fails(self):
+        # F1: a single block issuing two requests -- an ingest that is rejected
+        # 401 with an empty body, then a query that answers 200 with a success
+        # envelope -- under ONE `status=200; json:.status=success` marker. The
+        # pre-fix driver kept only the LAST request's status (200) in its single
+        # truncating slot and concatenated both bodies (the empty 401 body left
+        # the buffer valid JSON), so it reported PASS while the documented ingest
+        # command was being rejected. The fix records every request's status; the
+        # two differ (401, 200), which a single `status=` cannot map to, so the
+        # block must FAIL closed.
+        md = (
+            "# ingest then query\n\n"
+            "<!-- ravel:run status=200; json:.status=success -->\n"
+            "```sh\n"
+            "curl -s {base}/v1/metrics --data-binary '{}' -X POST\n"
+            "curl -s {base}/api/v1/query?query=probe\n"
+            "```\n"
+        )
+        with _StubServer() as server:
+            md = md.replace("{base}", server.base)
+            result = _run_script(md, server.base)
+        self.assertNotEqual(
+            result.returncode,
+            0,
+            msg=(
+                "an ingest rejected 401 inside a two-request block must fail the "
+                "block; a pass means the query's status/body masked the ingest.\n"
+                f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+            ),
+        )
+        self.assertIn("differing HTTP statuses", result.stderr)
+
+    def test_both_requests_200_still_passes(self):
+        # Control: when both requests in the block return the same status, the
+        # block is judged normally (status against all requests, body against the
+        # last), so a genuine ingest(200)-then-query(200) flow still passes.
+        md = (
+            "# query twice\n\n"
+            "<!-- ravel:run status=200; json:.status=success -->\n"
+            "```sh\n"
+            "curl -s {base}/api/v1/query?query=a\n"
+            "curl -s {base}/api/v1/query?query=b\n"
+            "```\n"
+        )
+        with _StubServer() as server:
+            md = md.replace("{base}", server.base)
+            result = _run_script(md, server.base)
+        self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+
+
+class TestBlockWallClockBound(unittest.TestCase):
+    def test_shim_bypassing_block_that_hangs_is_bounded(self):
+        # F2: a block whose first token is not the literal `curl`
+        # (`RAVEL_TOKEN=demo curl ...`) never resolves to the shim, so the
+        # per-request --max-time is never injected. Pointed at a socket that
+        # accepts and never writes, the bare curl hangs. The per-block wall-clock
+        # bound must terminate it and fail the block; without it the whole CI job
+        # hangs. Readiness runs against a healthy stub so the run reaches the
+        # block at all.
+        listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        listener.bind(("127.0.0.1", 0))
+        listener.listen(8)
+        dead_port = listener.getsockname()[1]
+        accepted = []
+
+        def accept_loop():
+            listener.settimeout(0.5)
+            while True:
+                try:
+                    conn, _ = listener.accept()
+                except OSError:
+                    return
+                accepted.append(conn)  # hold open, never respond
+
+        thread = threading.Thread(target=accept_loop, daemon=True)
+        thread.start()
+        dead_base = f"http://127.0.0.1:{dead_port}"
+
+        md = (
+            "# hang\n\n"
+            "<!-- ravel:run status=200 -->\n"
+            "```sh\n"
+            f"RAVEL_TOKEN=demo curl -s {dead_base}/x\n"
+            "```\n"
+        )
+        with tempfile.NamedTemporaryFile(
+            "w", suffix=".md", delete=False, encoding="utf-8"
+        ) as handle:
+            handle.write(md)
+            md_path = handle.name
+
+        try:
+            with _StubServer() as server:
+                env = dict(os.environ)
+                env["RAVEL_HTTP_BASE"] = server.base
+                env["RAVEL_HEALTH_PATH"] = "/healthz"
+                env["RAVEL_READY_QUERY_URL"] = f"{server.base}/api/v1/query?query=probe"
+                env["RAVEL_READINESS_TIMEOUT_SECONDS"] = "10"
+                env["RAVEL_READINESS_POLL_SECONDS"] = "1"
+                env["RAVEL_BLOCK_TIMEOUT_SECONDS"] = "3"
+                env["RAVEL_BLOCK_TIMEOUT_KILL_SECONDS"] = "2"
+                # A subprocess timeout well under a hang but well over the block
+                # bound: with the fix the script returns in ~3s; against the
+                # pre-fix code the bare curl hangs and this raises TimeoutExpired.
+                result = subprocess.run(
+                    ["bash", SCRIPT, md_path],
+                    env=env,
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                )
+        finally:
+            os.unlink(md_path)
+            listener.close()
+            for conn in accepted:
+                conn.close()
+            thread.join(timeout=5)
+
+        self.assertNotEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+        self.assertIn("wall-clock bound", result.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Ravel's README ships three copy-pasteable commands that do not work: they name
port 8080 (the default bind is 127.0.0.1:4318), query a `metrics` table that
does not exist (the registered tables are `samples`, `logs`, `spans`), and omit
the required Authorization header. No CI job executes a README command, so the
landing page is the one untested surface in a repository with 16 CI jobs.

This adds the extractor and expectation evaluator that close that gap, per
ADR-0081 decision 5. Blocks a reader is meant to run carry an HTML-comment
marker directly above the fence; the script extracts only those, runs them
against an already-running stack, and asserts each block's documented outcome.

Asserting the outcome rather than the exit status is the whole point: curl exits
0 on an HTTP 401 and on a `{"status":"error"}` envelope, so an exit-code check
would have passed the exact broken README this work exists to fix. The status is
captured out of band through a PATH-prepended curl shim, so no response body can
forge it, and every request in a block is accounted for rather than only the
last one. Unparseable markers, missing expectations, and unknown keywords are
hard errors, never skips.

Three adversarial review rounds shaped this. The first two each reproduced a
false green with a live stub server: a body line impersonating the status
sentinel, then a multi-request block asserting against whichever request ran
last. Both are now regression-tested, each test demonstrated failing against the
implementation it pins.

This ships ahead of its caller. Nothing on main runs the script yet; the
quickstart CI job that brings up the compose stack and invokes it is #175, and
the epic does not count the README gate closed until that lands.

The Makefile change switches test-python from naming one module to discovery, so
the new tests run at all; all 19 pre-existing test_process_metrics tests still
execute.

Fixes: #174
Refs: #170
