### PR TITLE
feat(ingest-router): add Ravel-native subset-affinity HTTP router

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4492,6 +4492,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "ravel-ingest-router"
+version = "0.9.2"
+dependencies = [
+ "anyhow",
+ "axum",
+ "blake3",
+ "clap",
+ "futures",
+ "humantime",
+ "k8s-openapi",
+ "kube",
+ "kube-runtime",
+ "ravel-affinity",
+ "ravel-tenant-resolve",
+ "ravel-types",
+ "reqwest 0.13.4",
+ "rustls",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "ravel-logseg"
 version = "0.9.2"
 dependencies = [

--- a/services/ravel-ingest-router/Cargo.toml
+++ b/services/ravel-ingest-router/Cargo.toml
@@ -1,0 +1,66 @@
+[package]
+name = "ravel-ingest-router"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[[bin]]
+name = "ravel-ingest-router"
+path = "src/main.rs"
+
+[dependencies]
+# Ravel-native subset affinity (ADR-0080 decision 3): `rank` gives the full HRW
+# order, which the unready-member fallback walks past position S.
+ravel-affinity = { workspace = true }
+# Shared tenant resolution, used only to build the canonical-tenant resolver
+# chain (ADR-0080 decision 3): one resolver implementation shared with
+# ravel-server rather than a second copy that can drift.
+ravel-tenant-resolve = { workspace = true }
+# TenantId, whose bytes are the canonical-tenant hash input.
+ravel-types = { workspace = true }
+
+# EndpointSlice watch. kube pulls the client + rustls TLS stack; kube-runtime is
+# the streaming-watch helper; k8s-openapi carries the generated EndpointSlice
+# type. Same pins the operator already uses.
+kube = { workspace = true }
+kube-runtime = { workspace = true }
+k8s-openapi = { workspace = true }
+
+axum = { workspace = true }
+tokio = { workspace = true }
+# StreamExt over the watcher event stream and the response byte stream.
+futures = { workspace = true }
+# The reverse-proxy HTTP client. `stream` adds streaming request/response bodies
+# (Body::wrap_stream / Response::bytes_stream) so the router proxies bytes
+# without buffering a whole ingest payload in memory. Unions with the workspace
+# pin's `json` feature; the version is unchanged.
+reqwest = { workspace = true, features = ["stream"] }
+# blake3 keys the bounded round-robin map by a hash of the tenant key rather
+# than the raw bytes, so no raw bearer token is ever held as a map key.
+blake3 = { workspace = true }
+clap = { workspace = true, features = ["env"] }
+humantime = { workspace = true }
+anyhow = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+# rustls 0.23 crypto-provider selection, mirroring services/ravel-operator: the
+# kube client's rustls-tls feature pins `ring`, and ravel-tenant-resolve pulls
+# `aws-lc-rs` transitively via the workspace jsonwebtoken pin, so both providers
+# link into this binary and rustls refuses to guess between them. Pinned to
+# `ring` here (the operator's selection); the workspace root Cargo.toml is out
+# of this task's scope, so it is pinned directly, the same convention
+# ravel-server and ravel-operator use for rustls.
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
+
+[dev-dependencies]
+# Build synthetic EndpointSlice objects for the injectable watch source, no real
+# cluster needed.
+serde_json = { workspace = true }
+# A local axum backend stands in for a gateway pod; the test client drives the
+# router over a real loopback socket.
+tokio = { workspace = true, features = ["test-util"] }
+
+[lints]
+workspace = true

--- a/services/ravel-ingest-router/src/auth.rs
+++ b/services/ravel-ingest-router/src/auth.rs
@@ -1,0 +1,108 @@
+//! Builds the canonical-tenant resolver chain from [`CanonicalAuthSettings`],
+//! reusing the shared [`ravel_tenant_resolve`] implementation so the router and
+//! `ravel-server` never drift on what the canonical tenant is (ADR-0080
+//! decision 3).
+//!
+//! The chain mirrors `ravel_server::tenant::build_auth_resolver`: a static
+//! bearer map, optionally a dev-header resolver, optionally OIDC, and -- unlike
+//! `ravel-server`, which keeps mTLS on a dedicated listener -- optionally the
+//! mTLS resolver folded into the one chain, since this router terminates a
+//! single ingest path rather than separate public/mTLS listeners. The mTLS
+//! resolver still reads a proxy-forwarded header and is only as trustworthy as
+//! the proxy that sets it (see [`ravel_tenant_resolve::MtlsResolver`]).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use ravel_tenant_resolve::{
+    DevHeaderTenantResolver, FallbackResolver, MtlsResolver, OidcJwksCache, OidcResolver,
+    StaticBearerTokenResolver, TenantResolver,
+};
+use ravel_types::TenantId;
+use tokio::task::JoinHandle;
+
+use crate::config::CanonicalAuthSettings;
+
+/// The built resolver plus, when OIDC is configured, the shared JWKS cache and
+/// refresh parameters the caller drives on a background task.
+pub(crate) struct CanonicalResolver {
+    pub resolver: Arc<dyn TenantResolver>,
+    pub oidc_refresh: Option<OidcRefresh>,
+}
+
+/// Inputs for the JWKS refresh loop: the cache the request-path resolver reads,
+/// the URL to fetch, and the refetch interval.
+pub(crate) struct OidcRefresh {
+    pub cache: Arc<OidcJwksCache>,
+    pub jwks_url: String,
+    pub interval: Duration,
+}
+
+/// Build the canonical-tenant resolver chain.
+pub(crate) fn build(settings: &CanonicalAuthSettings) -> anyhow::Result<CanonicalResolver> {
+    let tokens: HashMap<String, TenantId> = settings
+        .tokens
+        .iter()
+        .map(|(token, tenant)| (token.clone(), TenantId::new(tenant.clone())))
+        .collect();
+
+    let mut resolvers: Vec<Arc<dyn TenantResolver>> =
+        vec![Arc::new(StaticBearerTokenResolver::new(tokens))];
+
+    if settings.dev_header {
+        resolvers.push(Arc::new(DevHeaderTenantResolver::default()));
+    }
+
+    let mut oidc_refresh = None;
+    if let Some(oidc) = &settings.oidc {
+        let cache = Arc::new(
+            OidcJwksCache::new().map_err(|e| anyhow::anyhow!("failed to build OIDC cache: {e}"))?,
+        );
+        resolvers.push(Arc::new(OidcResolver::new(
+            cache.clone(),
+            oidc.issuer.clone(),
+            oidc.audiences.clone(),
+            oidc.tenant_claim.clone(),
+        )));
+        oidc_refresh = Some(OidcRefresh {
+            cache,
+            jwks_url: oidc.jwks_url.clone(),
+            interval: oidc.refresh_interval,
+        });
+    }
+
+    if let Some(header) = &settings.mtls_header {
+        resolvers.push(Arc::new(MtlsResolver::new(header.clone())));
+    }
+
+    let resolver: Arc<dyn TenantResolver> = Arc::new(FallbackResolver::new(resolvers));
+    Ok(CanonicalResolver {
+        resolver,
+        oidc_refresh,
+    })
+}
+
+/// Spawn the periodic JWKS refresh loop. Does one best-effort refresh up front
+/// so an OIDC router does not reject every request for a full interval at
+/// startup, then refetches on `interval`. A failed refresh keeps the previously
+/// cached keys (a transient JWKS outage does not start rejecting every token).
+pub(crate) fn spawn_jwks_refresh(params: OidcRefresh) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        if let Err(err) = params.cache.refresh(&params.jwks_url).await {
+            tracing::warn!(error = %err, "initial JWKS refresh failed; will retry on interval");
+        }
+        let mut ticker = tokio::time::interval(params.interval);
+        // Skip the immediate first tick: the up-front refresh above already ran.
+        ticker.tick().await;
+        loop {
+            ticker.tick().await;
+            match params.cache.refresh(&params.jwks_url).await {
+                Ok(()) => tracing::debug!("JWKS refresh complete"),
+                Err(err) => {
+                    tracing::warn!(error = %err, "JWKS refresh failed; keeping cached keys")
+                }
+            }
+        }
+    })
+}

--- a/services/ravel-ingest-router/src/clock.rs
+++ b/services/ravel-ingest-router/src/clock.rs
@@ -1,0 +1,26 @@
+//! Injected clock, so the round-robin idle-eviction logic reads no wall clock
+//! itself and every eviction rule is deterministic under test (the repo's
+//! "time is injected" testing convention).
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// A source of the current time in nanoseconds since the Unix epoch.
+pub(crate) trait Clock: Send + Sync {
+    fn now_ns(&self) -> i64;
+}
+
+/// The one blessed wall-clock reader. Library logic never calls
+/// `SystemTime::now` directly; only this wrapper does, so tests inject a fake
+/// [`Clock`] instead.
+pub(crate) struct SystemClock;
+
+impl Clock for SystemClock {
+    fn now_ns(&self) -> i64 {
+        // Saturate rather than panic on a pre-epoch or absurd clock: the value
+        // only orders idle eviction, so a clamp is harmless and unwrap-free.
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| i64::try_from(d.as_nanos()).unwrap_or(i64::MAX))
+            .unwrap_or(0)
+    }
+}

--- a/services/ravel-ingest-router/src/config.rs
+++ b/services/ravel-ingest-router/src/config.rs
@@ -1,0 +1,536 @@
+//! CLI configuration for the ingest router.
+//!
+//! The auth-resolver flags (`--oidc-*`, `--mtls-*`, `--dev-insecure-tenant-header`,
+//! `--tenant-token`) mirror `services/ravel-server`'s flag shape so a later task
+//! (#158) can thread the identical Secret/ConfigMap references the operator
+//! already wires into the gateway Deployment into this router's Deployment as a
+//! mechanical 1:1 translation. They build the canonical-tenant resolver chain
+//! and are only meaningful under `--key-source canonical-tenant`; the CLI
+//! rejects them under any other key source (fail-fast, matching this repo's
+//! dependent-flag validation convention) rather than constructing an unused
+//! resolver chain.
+
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use axum::http::header::{AUTHORIZATION, HeaderName};
+use clap::{Parser, ValueEnum};
+
+use ravel_tenant_resolve::MtlsResolver;
+
+/// Where the router reads the per-tenant routing key from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum KeySource {
+    /// Hash the raw `Authorization` header value bytes. Mirrors the *purpose* of
+    /// the operator's legacy nginx hash-by-header behavior (the affinity key is
+    /// the bearer token), but the HRW score is computed here, not by nginx.
+    #[value(name = "authorization-header")]
+    AuthorizationHeader,
+    /// Hash the raw value bytes of a configured header (`--key-header-name`).
+    Header,
+    /// Hash the raw value bytes of the proxy-forwarded client-certificate
+    /// identity header (`--mtls-header`, default `x-ravel-client-cert-cn`).
+    #[value(name = "mtls-subject")]
+    MtlsSubject,
+    /// Resolve the canonical [`ravel_types::TenantId`] via the shared resolver
+    /// chain and hash its bytes. Immune to bearer-token rotation. Fail-closed:
+    /// a resolution failure is a 401, never a fallback to a weaker key.
+    #[value(name = "canonical-tenant")]
+    CanonicalTenant,
+}
+
+/// Ravel-native subset-affinity ingest router (ADR-0080 decision 3).
+#[derive(Debug, Parser)]
+#[command(
+    name = "ravel-ingest-router",
+    about = "Ravel-native subset-affinity ingest router (ADR-0080)"
+)]
+pub struct Cli {
+    /// Name of the gateway Service whose EndpointSlices this router watches and
+    /// selects subsets from.
+    #[arg(long, env = "RAVEL_GATEWAY_SERVICE_NAME")]
+    pub gateway_service_name: String,
+
+    /// Namespace of that Service (the router watches EndpointSlices here).
+    #[arg(long, env = "RAVEL_GATEWAY_SERVICE_NAMESPACE")]
+    pub gateway_service_namespace: String,
+
+    /// EndpointSlice port to dial by name. Unset uses the endpoint's first port.
+    /// A gateway Service that exposes both HTTP and gRPC has more than one port,
+    /// so name the one this router proxies (#184 adds the gRPC path).
+    #[arg(long, value_name = "NAME")]
+    pub gateway_port_name: Option<String>,
+
+    /// Subset size `S`: the top-`S` HRW-ranked pods a tenant pins to. Matches
+    /// `IngestAffinitySpec.subset_size`'s role (the operator threads this in as
+    /// config in a later task).
+    #[arg(long, default_value_t = 2)]
+    pub subset_size: u32,
+
+    /// Where to read the per-tenant routing key from.
+    #[arg(long, value_enum, default_value = "authorization-header")]
+    pub key_source: KeySource,
+
+    /// Header name to hash under `--key-source header`. Required for that key
+    /// source; setting it under any other key source fails startup.
+    #[arg(long, value_name = "HEADER")]
+    pub key_header_name: Option<String>,
+
+    /// Address the HTTP reverse proxy listens on.
+    #[arg(long, default_value = "0.0.0.0:8080")]
+    pub listen_http: SocketAddr,
+
+    // --- Bounded per-tenant round-robin state (ADR-0069 idle eviction) --------
+    /// Hard cap on distinct tenant-key entries in the round-robin map. Under
+    /// `authorization-header` every distinct token mints an entry and tokens
+    /// rotate, so the map is bounded against client-controlled growth.
+    #[arg(long, default_value_t = 100_000)]
+    pub round_robin_max_entries: usize,
+
+    /// Evict a round-robin entry untouched for longer than this (humantime,
+    /// e.g. `10m`). A swept entry just restarts at offset 0 on the tenant's next
+    /// request, so eviction is never correctness-bearing.
+    #[arg(long, value_name = "DURATION", default_value = "10m")]
+    pub round_robin_idle_ttl: String,
+
+    // --- Canonical-tenant resolver chain (only used under that key source) ----
+    /// Repeatable `token=tenant` pair for the static bearer resolver.
+    #[arg(long = "tenant-token", value_name = "TOKEN=TENANT")]
+    pub tenant_tokens: Vec<String>,
+
+    /// Dev-only tenant resolution via the `x-ravel-tenant` header.
+    #[arg(long)]
+    pub dev_insecure_tenant_header: bool,
+
+    /// OIDC issuer URL (the exact `iss` every JWT must carry). Enables the OIDC
+    /// resolver together with `--oidc-jwks-url`; both must be set together.
+    #[arg(long, value_name = "URL", env = "RAVEL_OIDC_ISSUER")]
+    pub oidc_issuer: Option<String>,
+
+    /// URL of the issuer's JWKS document. Enables OIDC together with
+    /// `--oidc-issuer`.
+    #[arg(long, value_name = "URL", env = "RAVEL_OIDC_JWKS_URL")]
+    pub oidc_jwks_url: Option<String>,
+
+    /// Acceptable JWT `aud` value (repeatable). At least one is required when
+    /// OIDC is enabled.
+    #[arg(long = "oidc-audience", value_name = "AUD")]
+    pub oidc_audiences: Vec<String>,
+
+    /// String claim the tenant id is read from. Defaults to `tenant` when OIDC
+    /// is enabled.
+    #[arg(long, value_name = "CLAIM")]
+    pub oidc_tenant_claim: Option<String>,
+
+    /// How often the JWKS document is refetched, in seconds.
+    #[arg(long, default_value_t = 300)]
+    pub oidc_jwks_refresh_interval_secs: u64,
+
+    /// Enable the mTLS tenant resolver in the canonical-tenant chain, mapping a
+    /// trusted proxy-forwarded client-certificate header to a tenant.
+    #[arg(long)]
+    pub mtls_enabled: bool,
+
+    /// Header the reverse proxy forwards the verified client-certificate
+    /// identity in. Defaults to `x-ravel-client-cert-cn`. Used by the
+    /// `mtls-subject` key source, and by the canonical-tenant chain when
+    /// `--mtls-enabled`.
+    #[arg(long, value_name = "HEADER")]
+    pub mtls_header: Option<String>,
+}
+
+/// Validated OIDC settings, present only when both `--oidc-issuer` and
+/// `--oidc-jwks-url` are configured.
+#[derive(Debug, Clone)]
+pub struct OidcSettings {
+    pub issuer: String,
+    pub jwks_url: String,
+    pub audiences: Vec<String>,
+    pub tenant_claim: String,
+    pub refresh_interval: Duration,
+}
+
+/// The canonical-tenant resolver chain configuration, built only under
+/// `--key-source canonical-tenant`.
+#[derive(Debug, Clone, Default)]
+pub struct CanonicalAuthSettings {
+    pub tokens: Vec<(String, String)>,
+    pub dev_header: bool,
+    pub oidc: Option<OidcSettings>,
+    /// The trusted client-cert header, `Some` only when `--mtls-enabled`.
+    pub mtls_header: Option<String>,
+}
+
+/// How the router derives the routing key: either raw header bytes, or the
+/// canonical tenant resolved by the shared chain.
+#[derive(Debug, Clone)]
+pub enum KeyConfig {
+    /// Hash the raw value bytes of this header
+    /// (`authorization-header`/`header`/`mtls-subject`).
+    Header(HeaderName),
+    /// Resolve the canonical tenant, fail-closed.
+    CanonicalTenant(CanonicalAuthSettings),
+}
+
+/// The fully-validated runtime configuration.
+#[derive(Debug, Clone)]
+pub struct RouterConfig {
+    pub gateway_service_name: String,
+    pub gateway_service_namespace: String,
+    pub gateway_port_name: Option<String>,
+    pub subset_size: usize,
+    pub key: KeyConfig,
+    pub listen_http: SocketAddr,
+    pub round_robin_max_entries: usize,
+    pub round_robin_idle_ttl: Duration,
+}
+
+impl Cli {
+    /// Validate the flags and produce the runtime [`RouterConfig`], failing fast
+    /// on any contradictory combination.
+    pub fn into_config(self) -> anyhow::Result<RouterConfig> {
+        if self.subset_size == 0 {
+            anyhow::bail!("--subset-size must be at least 1");
+        }
+        if self.round_robin_max_entries == 0 {
+            anyhow::bail!("--round-robin-max-entries must be at least 1");
+        }
+        let round_robin_idle_ttl =
+            humantime::parse_duration(&self.round_robin_idle_ttl).map_err(|e| {
+                anyhow::anyhow!(
+                    "invalid --round-robin-idle-ttl '{}': {e}",
+                    self.round_robin_idle_ttl
+                )
+            })?;
+        if round_robin_idle_ttl.is_zero() {
+            anyhow::bail!(
+                "--round-robin-idle-ttl must be a positive duration: a zero ttl would evict \
+                 every entry on the next sweep"
+            );
+        }
+
+        // `--key-header-name` is required by, and only valid for, the `header`
+        // key source.
+        match (self.key_source, self.key_header_name.as_deref()) {
+            (KeySource::Header, None) => {
+                anyhow::bail!("--key-source header requires --key-header-name");
+            }
+            (KeySource::Header, Some("")) => {
+                anyhow::bail!("--key-header-name must be non-empty");
+            }
+            (source, Some(_)) if source != KeySource::Header => {
+                anyhow::bail!("--key-header-name is only valid with --key-source header");
+            }
+            _ => {}
+        }
+
+        let key = if self.key_source == KeySource::CanonicalTenant {
+            KeyConfig::CanonicalTenant(self.canonical_auth_settings()?)
+        } else {
+            // No resolver wiring is built for a header key source. Reject the
+            // canonical-tenant-only flags rather than silently ignoring them.
+            self.reject_canonical_only_flags()?;
+            KeyConfig::Header(self.header_key_name()?)
+        };
+
+        Ok(RouterConfig {
+            gateway_service_name: self.gateway_service_name,
+            gateway_service_namespace: self.gateway_service_namespace,
+            gateway_port_name: self.gateway_port_name,
+            subset_size: self.subset_size as usize,
+            key,
+            listen_http: self.listen_http,
+            round_robin_max_entries: self.round_robin_max_entries,
+            round_robin_idle_ttl,
+        })
+    }
+
+    /// The header a non-canonical key source hashes.
+    fn header_key_name(&self) -> anyhow::Result<HeaderName> {
+        Ok(match self.key_source {
+            KeySource::AuthorizationHeader => AUTHORIZATION,
+            KeySource::Header => {
+                // Presence and non-emptiness already validated above.
+                let name = self.key_header_name.as_deref().unwrap_or_default();
+                HeaderName::try_from(name)
+                    .map_err(|e| anyhow::anyhow!("invalid --key-header-name '{name}': {e}"))?
+            }
+            KeySource::MtlsSubject => {
+                let name = self
+                    .mtls_header
+                    .as_deref()
+                    .unwrap_or(MtlsResolver::DEFAULT_HEADER);
+                HeaderName::try_from(name)
+                    .map_err(|e| anyhow::anyhow!("invalid --mtls-header '{name}': {e}"))?
+            }
+            KeySource::CanonicalTenant => unreachable!("canonical-tenant is not a header source"),
+        })
+    }
+
+    /// Reject flags that only make sense under `--key-source canonical-tenant`.
+    /// `--mtls-header` is exempt: it also names the `mtls-subject` key header.
+    fn reject_canonical_only_flags(&self) -> anyhow::Result<()> {
+        if self.oidc_issuer.is_some() || self.oidc_jwks_url.is_some() {
+            anyhow::bail!("--oidc-* flags are only valid with --key-source canonical-tenant");
+        }
+        if !self.oidc_audiences.is_empty() || self.oidc_tenant_claim.is_some() {
+            anyhow::bail!("--oidc-* flags are only valid with --key-source canonical-tenant");
+        }
+        if self.mtls_enabled {
+            anyhow::bail!("--mtls-enabled is only valid with --key-source canonical-tenant");
+        }
+        if self.dev_insecure_tenant_header {
+            anyhow::bail!(
+                "--dev-insecure-tenant-header is only valid with --key-source canonical-tenant"
+            );
+        }
+        if !self.tenant_tokens.is_empty() {
+            anyhow::bail!("--tenant-token is only valid with --key-source canonical-tenant");
+        }
+        Ok(())
+    }
+
+    /// Parse and validate the canonical-tenant resolver settings, mirroring
+    /// `ravel_server::config::Cli::parse_auth_resolvers`.
+    fn canonical_auth_settings(&self) -> anyhow::Result<CanonicalAuthSettings> {
+        let tokens = self
+            .tenant_tokens
+            .iter()
+            .map(|pair| {
+                let (token, tenant) = pair
+                    .split_once('=')
+                    .ok_or_else(|| anyhow::anyhow!("--tenant-token must be TOKEN=TENANT"))?;
+                if token.is_empty() || tenant.is_empty() {
+                    anyhow::bail!("--tenant-token TOKEN and TENANT must both be non-empty");
+                }
+                Ok((token.to_string(), tenant.to_string()))
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
+
+        let oidc = match (self.oidc_issuer.as_deref(), self.oidc_jwks_url.as_deref()) {
+            (Some(issuer), Some(jwks_url)) => {
+                if issuer.is_empty() || jwks_url.is_empty() {
+                    anyhow::bail!("--oidc-issuer and --oidc-jwks-url must be non-empty");
+                }
+                if !(jwks_url.starts_with("http://") || jwks_url.starts_with("https://")) {
+                    anyhow::bail!(
+                        "invalid --oidc-jwks-url '{jwks_url}', expected an http:// or https:// URL"
+                    );
+                }
+                if self.oidc_audiences.is_empty() {
+                    anyhow::bail!(
+                        "OIDC is enabled but no --oidc-audience is set: without an audience any \
+                         correctly-signed, unexpired token from this issuer authenticates. Set at \
+                         least one --oidc-audience naming this deployment."
+                    );
+                }
+                if self.oidc_audiences.iter().any(|a| a.is_empty()) {
+                    anyhow::bail!("--oidc-audience must be non-empty");
+                }
+                Some(OidcSettings {
+                    issuer: issuer.to_string(),
+                    jwks_url: jwks_url.to_string(),
+                    audiences: self.oidc_audiences.clone(),
+                    tenant_claim: self
+                        .oidc_tenant_claim
+                        .clone()
+                        .unwrap_or_else(|| "tenant".to_string()),
+                    refresh_interval: Duration::from_secs(self.oidc_jwks_refresh_interval_secs),
+                })
+            }
+            (None, None) => None,
+            _ => anyhow::bail!(
+                "--oidc-issuer and --oidc-jwks-url must be set together to enable OIDC auth"
+            ),
+        };
+
+        if oidc.is_none() {
+            if self.oidc_tenant_claim.is_some() {
+                anyhow::bail!("--oidc-tenant-claim was set but OIDC is not enabled");
+            }
+            if !self.oidc_audiences.is_empty() {
+                anyhow::bail!("--oidc-audience was set but OIDC is not enabled");
+            }
+        }
+
+        let mtls_header = if self.mtls_enabled {
+            let header = self
+                .mtls_header
+                .clone()
+                .unwrap_or_else(|| MtlsResolver::DEFAULT_HEADER.to_string());
+            if header.is_empty() {
+                anyhow::bail!("--mtls-header must be non-empty");
+            }
+            Some(header)
+        } else {
+            None
+        };
+
+        let settings = CanonicalAuthSettings {
+            tokens,
+            dev_header: self.dev_insecure_tenant_header,
+            oidc,
+            mtls_header,
+        };
+
+        // A canonical-tenant router with no resolver at all would 401 every
+        // request: a total ingest outage disguised as fail-closed. Refuse to
+        // start rather than serve it.
+        if settings.tokens.is_empty()
+            && !settings.dev_header
+            && settings.oidc.is_none()
+            && settings.mtls_header.is_none()
+        {
+            anyhow::bail!(
+                "--key-source canonical-tenant needs at least one resolver: set --tenant-token, \
+                 --oidc-issuer/--oidc-jwks-url, --mtls-enabled, or --dev-insecure-tenant-header"
+            );
+        }
+
+        Ok(settings)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    fn cli(args: &[&str]) -> Cli {
+        let mut full = vec![
+            "ravel-ingest-router",
+            "--gateway-service-name",
+            "gw",
+            "--gateway-service-namespace",
+            "ns",
+        ];
+        full.extend_from_slice(args);
+        Cli::parse_from(full)
+    }
+
+    #[test]
+    fn header_key_source_requires_header_name() {
+        let err = cli(&["--key-source", "header"])
+            .into_config()
+            .expect_err("header source without a name must fail");
+        assert!(err.to_string().contains("--key-header-name"));
+    }
+
+    #[test]
+    fn header_name_rejected_for_non_header_source() {
+        let err = cli(&[
+            "--key-source",
+            "authorization-header",
+            "--key-header-name",
+            "x-foo",
+        ])
+        .into_config()
+        .expect_err("a header name under a non-header source must fail");
+        assert!(err.to_string().contains("--key-header-name"));
+    }
+
+    #[test]
+    fn authorization_header_source_reads_authorization() {
+        let config = cli(&["--key-source", "authorization-header"])
+            .into_config()
+            .expect("valid config");
+        match config.key {
+            KeyConfig::Header(name) => assert_eq!(name, AUTHORIZATION),
+            other => panic!("expected header key config, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn custom_header_source_reads_named_header() {
+        let config = cli(&["--key-source", "header", "--key-header-name", "x-tenant"])
+            .into_config()
+            .expect("valid config");
+        match config.key {
+            KeyConfig::Header(name) => assert_eq!(name.as_str(), "x-tenant"),
+            other => panic!("expected header key config, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn mtls_subject_source_defaults_to_the_mtls_header() {
+        let config = cli(&["--key-source", "mtls-subject"])
+            .into_config()
+            .expect("valid config");
+        match config.key {
+            KeyConfig::Header(name) => {
+                assert_eq!(name.as_str(), MtlsResolver::DEFAULT_HEADER);
+            }
+            other => panic!("expected header key config, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn canonical_only_flags_rejected_under_header_source() {
+        let err = cli(&["--key-source", "authorization-header", "--mtls-enabled"])
+            .into_config()
+            .expect_err("--mtls-enabled under a header source must fail");
+        assert!(err.to_string().contains("--mtls-enabled"));
+
+        let err = cli(&[
+            "--key-source",
+            "authorization-header",
+            "--tenant-token",
+            "tok=acme",
+        ])
+        .into_config()
+        .expect_err("--tenant-token under a header source must fail");
+        assert!(err.to_string().contains("--tenant-token"));
+    }
+
+    #[test]
+    fn canonical_tenant_needs_at_least_one_resolver() {
+        let err = cli(&["--key-source", "canonical-tenant"])
+            .into_config()
+            .expect_err("canonical-tenant with no resolver must fail");
+        assert!(err.to_string().contains("at least one resolver"));
+    }
+
+    #[test]
+    fn canonical_tenant_with_tokens_builds_settings() {
+        let config = cli(&[
+            "--key-source",
+            "canonical-tenant",
+            "--tenant-token",
+            "tok=acme",
+        ])
+        .into_config()
+        .expect("valid config");
+        match config.key {
+            KeyConfig::CanonicalTenant(settings) => {
+                assert_eq!(
+                    settings.tokens,
+                    vec![("tok".to_string(), "acme".to_string())]
+                );
+            }
+            other => panic!("expected canonical key config, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn oidc_requires_an_audience() {
+        let err = cli(&[
+            "--key-source",
+            "canonical-tenant",
+            "--oidc-issuer",
+            "https://issuer.example.com",
+            "--oidc-jwks-url",
+            "https://issuer.example.com/jwks",
+        ])
+        .into_config()
+        .expect_err("OIDC without an audience must fail");
+        assert!(err.to_string().contains("--oidc-audience"));
+    }
+
+    #[test]
+    fn subset_size_zero_rejected() {
+        let err = cli(&["--subset-size", "0"])
+            .into_config()
+            .expect_err("subset size 0 must fail");
+        assert!(err.to_string().contains("--subset-size"));
+    }
+}

--- a/services/ravel-ingest-router/src/endpoints.rs
+++ b/services/ravel-ingest-router/src/endpoints.rs
@@ -1,0 +1,447 @@
+//! The in-memory, concurrently-readable snapshot of gateway endpoints, kept up
+//! to date by the [`EndpointSlice`] watcher (deliverable 2).
+//!
+//! # Ranking set vs. dial set
+//!
+//! The snapshot carries two things:
+//!
+//! - [`EndpointSnapshot::replicas`]: **every** endpoint the watched slices
+//!   report, Ready or not, in the stable [`ReplicaId`] form
+//!   [`ravel_affinity::rank`] orders. Ranking over the full membership (rather
+//!   than only the currently-Ready pods) keeps a tenant's subset *identity*
+//!   stable across a transient readiness blip: a pod that flaps NotReady is
+//!   skipped at pick time (falling to position `S+1`, `S+2`, ...) rather than
+//!   dropping out of the ranking and reshuffling the subset boundary.
+//! - [`EndpointSnapshot::ready_addr`]: the dial address for **Ready** endpoints
+//!   only. A ranked replica absent from this map is exactly the "not-Ready"
+//!   signal the selection fallback ([`crate::select::pick`]) skips over. This is
+//!   the "Ready snapshot" the router actually dials; Not-Ready endpoints are
+//!   excluded from it (deliverable 2).
+//!
+//! Ranking over the full membership is what makes the unready-member fallback a
+//! genuinely reachable code path: the not-Ready pod ranks into the subset and
+//! is then skipped, rather than never being ranked at all.
+//!
+//! # Concurrency
+//!
+//! The shared snapshot is a `RwLock<Arc<EndpointSnapshot>>`, swapped in whole on
+//! every watch event (`arc_swap` is not a workspace dependency). A reader
+//! ([`EndpointStore::snapshot`]) only ever clones the `Arc` under a brief read
+//! lock and then releases it, so it never holds the lock across the actual
+//! ranking/selection work.
+
+use std::collections::HashMap;
+use std::net::{IpAddr, SocketAddr};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, RwLock};
+
+use k8s_openapi::api::discovery::v1::EndpointSlice;
+use kube::ResourceExt;
+use kube_runtime::watcher::Event;
+use ravel_affinity::ReplicaId;
+
+/// One parsed endpoint: its stable identity plus, when Ready and dialable, its
+/// address.
+#[derive(Clone, Debug)]
+struct ParsedEndpoint {
+    id: ReplicaId,
+    /// `Some` only when the endpoint is Ready and its address parsed to a
+    /// dialable `IP:port`.
+    ready_addr: Option<SocketAddr>,
+}
+
+/// The immutable, atomically-swapped view the request path reads.
+#[derive(Debug, Default)]
+pub(crate) struct EndpointSnapshot {
+    /// Every endpoint (Ready or not) as an HRW ranking candidate.
+    pub replicas: Vec<ReplicaId>,
+    /// Dial address for Ready endpoints only.
+    pub ready_addr: HashMap<ReplicaId, SocketAddr>,
+}
+
+/// Internal per-slice state, plus the `Init`-relist buffer.
+#[derive(Default)]
+struct StoreInner {
+    /// Current per-slice endpoints, keyed by slice object name. A Service's
+    /// endpoints can span several slices, joined here.
+    slices: HashMap<String, Vec<ParsedEndpoint>>,
+    /// During a watcher relist (`Init` .. `InitDone`), endpoints buffer here and
+    /// replace `slices` wholesale at `InitDone`, so a relist is atomic and never
+    /// exposes a partially-listed set.
+    pending: Option<HashMap<String, Vec<ParsedEndpoint>>>,
+}
+
+/// Watches EndpointSlices for one gateway Service and maintains the shared
+/// [`EndpointSnapshot`].
+pub(crate) struct EndpointStore {
+    inner: Mutex<StoreInner>,
+    snapshot: RwLock<Arc<EndpointSnapshot>>,
+    /// Flipped `true` exactly once, at the first `InitDone`. Never reverts: a
+    /// later relist re-buffers but does not un-sync a router that has already
+    /// served.
+    synced: AtomicBool,
+    /// Dial by this port name; `None` uses the endpoint's first port.
+    port_name: Option<String>,
+}
+
+impl EndpointStore {
+    /// A store with an empty snapshot, not yet synced.
+    pub(crate) fn new(port_name: Option<String>) -> Self {
+        EndpointStore {
+            inner: Mutex::new(StoreInner::default()),
+            snapshot: RwLock::new(Arc::new(EndpointSnapshot::default())),
+            synced: AtomicBool::new(false),
+            port_name,
+        }
+    }
+
+    /// Whether the watcher has completed at least one full sync. The proxy and
+    /// `/readyz` both gate on this so no request is served from an empty subset
+    /// during cold start.
+    pub(crate) fn is_synced(&self) -> bool {
+        self.synced.load(Ordering::Acquire)
+    }
+
+    /// Clone the current snapshot `Arc`, holding the read lock only for the
+    /// clone. The caller ranks/selects on the returned `Arc` with no lock held.
+    pub(crate) fn snapshot(&self) -> Arc<EndpointSnapshot> {
+        // A poisoned lock carries only a plain data snapshot with no broken
+        // invariant, so recovering the guard is safe and unwrap-free.
+        self.snapshot
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
+    }
+
+    /// Apply one watcher event, then rebuild and swap the snapshot.
+    pub(crate) fn apply_event(&self, event: Event<EndpointSlice>) {
+        let mut inner = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        match event {
+            Event::Init => {
+                // Start a fresh relist buffer; the live `slices` keep serving
+                // until `InitDone` swaps the buffer in.
+                inner.pending = Some(HashMap::new());
+            }
+            Event::InitApply(slice) => {
+                let (name, endpoints) = self.parse_slice(&slice);
+                inner
+                    .pending
+                    .get_or_insert_with(HashMap::new)
+                    .insert(name, endpoints);
+            }
+            Event::InitDone => {
+                if let Some(pending) = inner.pending.take() {
+                    inner.slices = pending;
+                }
+                self.rebuild(&inner);
+                // Latch synced only after the first complete relist is live.
+                self.synced.store(true, Ordering::Release);
+                return;
+            }
+            Event::Apply(slice) => {
+                let (name, endpoints) = self.parse_slice(&slice);
+                inner.slices.insert(name, endpoints);
+            }
+            Event::Delete(slice) => {
+                inner.slices.remove(&slice.name_any());
+            }
+        }
+        self.rebuild(&inner);
+    }
+
+    /// Recompute the snapshot from the current per-slice state and swap it in.
+    fn rebuild(&self, inner: &StoreInner) {
+        // Join endpoints across slices, deduping by ReplicaId. A pod that
+        // appears more than once resolves to Ready-with-address if any
+        // occurrence is.
+        let mut merged: HashMap<ReplicaId, Option<SocketAddr>> = HashMap::new();
+        for endpoints in inner.slices.values() {
+            for ep in endpoints {
+                let slot = merged.entry(ep.id.clone()).or_insert(None);
+                if slot.is_none() {
+                    *slot = ep.ready_addr;
+                }
+            }
+        }
+
+        let mut replicas = Vec::with_capacity(merged.len());
+        let mut ready_addr = HashMap::new();
+        for (id, addr) in merged {
+            if let Some(addr) = addr {
+                ready_addr.insert(id.clone(), addr);
+            }
+            replicas.push(id);
+        }
+
+        let snapshot = Arc::new(EndpointSnapshot {
+            replicas,
+            ready_addr,
+        });
+        *self.snapshot.write().unwrap_or_else(|e| e.into_inner()) = snapshot;
+    }
+
+    /// Extract `(slice name, endpoints)` from an [`EndpointSlice`].
+    fn parse_slice(&self, slice: &EndpointSlice) -> (String, Vec<ParsedEndpoint>) {
+        let name = slice.name_any();
+        let port = select_port(slice, self.port_name.as_deref());
+        let endpoints = slice
+            .endpoints
+            .iter()
+            .filter_map(|ep| parse_endpoint(ep, &slice.address_type, port))
+            .collect();
+        (name, endpoints)
+    }
+}
+
+/// Parse one [`k8s_openapi::api::discovery::v1::Endpoint`] into a
+/// [`ParsedEndpoint`], or `None` when it has no stable identity (no
+/// `targetRef.uid`) to rank on.
+///
+/// The identity is the pod UID (never the IP: ADR-0080 decision 3 requires
+/// this because an IP can be reused by a different pod after churn). A Ready
+/// endpoint whose address does not parse to a dialable `IP:port` still ranks
+/// (its UID is present) but is not in the dial set.
+fn parse_endpoint(
+    ep: &k8s_openapi::api::discovery::v1::Endpoint,
+    address_type: &str,
+    port: Option<u16>,
+) -> Option<ParsedEndpoint> {
+    let uid = ep.target_ref.as_ref().and_then(|r| r.uid.as_deref())?;
+    if uid.is_empty() {
+        return None;
+    }
+    let id = ReplicaId::new(uid.as_bytes());
+
+    let ready = ep
+        .conditions
+        .as_ref()
+        .and_then(|c| c.ready)
+        .unwrap_or(false);
+
+    let ready_addr = if ready {
+        dial_addr(ep, address_type, port)
+    } else {
+        None
+    };
+
+    Some(ParsedEndpoint { id, ready_addr })
+}
+
+/// The dialable `IP:port` for a Ready endpoint, or `None` when the address is
+/// not an IP (e.g. an `FQDN` slice, which the EndpointSlice controller never
+/// generates for Service endpoints) or there is no usable port.
+fn dial_addr(
+    ep: &k8s_openapi::api::discovery::v1::Endpoint,
+    address_type: &str,
+    port: Option<u16>,
+) -> Option<SocketAddr> {
+    if !address_type.eq_ignore_ascii_case("IPv4") && !address_type.eq_ignore_ascii_case("IPv6") {
+        return None;
+    }
+    let ip: IpAddr = ep.addresses.first()?.parse().ok()?;
+    Some(SocketAddr::new(ip, port?))
+}
+
+/// Select the port to dial from a slice: the one named `port_name`, or the
+/// first port when no name is configured.
+fn select_port(slice: &EndpointSlice, port_name: Option<&str>) -> Option<u16> {
+    let ports = slice.ports.as_ref()?;
+    let chosen = match port_name {
+        Some(name) => ports.iter().find(|p| p.name.as_deref() == Some(name))?,
+        None => ports.first()?,
+    };
+    u16::try_from(chosen.port?).ok()
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+pub(crate) mod test_support {
+    //! Helpers shared by this module's unit tests and the crate integration
+    //! tests, for building synthetic EndpointSlices and driving the store
+    //! without a real cluster.
+
+    use super::*;
+
+    /// A minimal endpoint description for a test slice.
+    pub(crate) struct TestEndpoint {
+        pub uid: &'static str,
+        pub ip: &'static str,
+        pub ready: bool,
+    }
+
+    /// Build an `IPv4` EndpointSlice named `name` for `service`, exposing one
+    /// unnamed port `port`, carrying `endpoints`.
+    pub(crate) fn slice(
+        name: &str,
+        service: &str,
+        port: i32,
+        endpoints: &[TestEndpoint],
+    ) -> EndpointSlice {
+        let eps: Vec<_> = endpoints
+            .iter()
+            .map(|e| {
+                serde_json::json!({
+                    "addresses": [e.ip],
+                    "conditions": { "ready": e.ready },
+                    "targetRef": { "kind": "Pod", "uid": e.uid },
+                })
+            })
+            .collect();
+        let doc = serde_json::json!({
+            "apiVersion": "discovery.k8s.io/v1",
+            "kind": "EndpointSlice",
+            "metadata": {
+                "name": name,
+                "namespace": "ns",
+                "labels": { "kubernetes.io/service-name": service },
+            },
+            "addressType": "IPv4",
+            "ports": [ { "port": port } ],
+            "endpoints": eps,
+        });
+        serde_json::from_value(doc).expect("valid EndpointSlice fixture")
+    }
+
+    /// Drive the store through a one-slice relist (`Init`, `InitApply`,
+    /// `InitDone`), the shape the watcher emits on first connect.
+    pub(crate) fn sync_one_slice(store: &EndpointStore, slice: EndpointSlice) {
+        store.apply_event(Event::Init);
+        store.apply_event(Event::InitApply(slice));
+        store.apply_event(Event::InitDone);
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::test_support::*;
+    use super::*;
+
+    #[test]
+    fn not_synced_until_init_done() {
+        let store = EndpointStore::new(None);
+        assert!(!store.is_synced(), "starts not synced");
+
+        store.apply_event(Event::Init);
+        let slice = slice(
+            "gw-abc",
+            "gw",
+            8080,
+            &[TestEndpoint {
+                uid: "uid-a",
+                ip: "10.0.0.1",
+                ready: true,
+            }],
+        );
+        store.apply_event(Event::InitApply(slice));
+        assert!(!store.is_synced(), "not synced until InitDone");
+
+        store.apply_event(Event::InitDone);
+        assert!(store.is_synced(), "synced after InitDone");
+    }
+
+    #[test]
+    fn ready_endpoints_are_dialable_not_ready_only_rank() {
+        let store = EndpointStore::new(None);
+        let slice = slice(
+            "gw-abc",
+            "gw",
+            8080,
+            &[
+                TestEndpoint {
+                    uid: "uid-ready",
+                    ip: "10.0.0.1",
+                    ready: true,
+                },
+                TestEndpoint {
+                    uid: "uid-unready",
+                    ip: "10.0.0.2",
+                    ready: false,
+                },
+            ],
+        );
+        sync_one_slice(&store, slice);
+
+        let snap = store.snapshot();
+        assert_eq!(snap.replicas.len(), 2, "both endpoints rank");
+        let ready = ReplicaId::new(b"uid-ready".to_vec());
+        let unready = ReplicaId::new(b"uid-unready".to_vec());
+        assert!(snap.replicas.contains(&ready) && snap.replicas.contains(&unready));
+        assert_eq!(
+            snap.ready_addr.get(&ready),
+            Some(&"10.0.0.1:8080".parse().expect("addr"))
+        );
+        assert!(
+            !snap.ready_addr.contains_key(&unready),
+            "a not-Ready endpoint is excluded from the dial set"
+        );
+    }
+
+    #[test]
+    fn delete_removes_a_slice_from_the_snapshot() {
+        let store = EndpointStore::new(None);
+        let s = slice(
+            "gw-abc",
+            "gw",
+            8080,
+            &[TestEndpoint {
+                uid: "uid-a",
+                ip: "10.0.0.1",
+                ready: true,
+            }],
+        );
+        sync_one_slice(&store, s.clone());
+        assert_eq!(store.snapshot().replicas.len(), 1);
+
+        store.apply_event(Event::Delete(s));
+        assert!(
+            store.snapshot().replicas.is_empty(),
+            "deleting the only slice empties the snapshot"
+        );
+    }
+
+    #[test]
+    fn endpoint_without_uid_is_skipped() {
+        let doc = serde_json::json!({
+            "apiVersion": "discovery.k8s.io/v1",
+            "kind": "EndpointSlice",
+            "metadata": { "name": "gw-x", "namespace": "ns" },
+            "addressType": "IPv4",
+            "ports": [ { "port": 8080 } ],
+            "endpoints": [ { "addresses": ["10.0.0.9"], "conditions": { "ready": true } } ],
+        });
+        let s: EndpointSlice = serde_json::from_value(doc).expect("valid slice");
+        let store = EndpointStore::new(None);
+        sync_one_slice(&store, s);
+        assert!(
+            store.snapshot().replicas.is_empty(),
+            "an endpoint with no targetRef.uid has no stable identity and is skipped"
+        );
+    }
+
+    #[test]
+    fn named_port_is_selected() {
+        let doc = serde_json::json!({
+            "apiVersion": "discovery.k8s.io/v1",
+            "kind": "EndpointSlice",
+            "metadata": { "name": "gw-x", "namespace": "ns" },
+            "addressType": "IPv4",
+            "ports": [ { "name": "grpc", "port": 4317 }, { "name": "http", "port": 4318 } ],
+            "endpoints": [ {
+                "addresses": ["10.0.0.5"],
+                "conditions": { "ready": true },
+                "targetRef": { "kind": "Pod", "uid": "uid-a" }
+            } ],
+        });
+        let s: EndpointSlice = serde_json::from_value(doc).expect("valid slice");
+        let store = EndpointStore::new(Some("http".to_string()));
+        sync_one_slice(&store, s);
+        let snap = store.snapshot();
+        let id = ReplicaId::new(b"uid-a".to_vec());
+        assert_eq!(
+            snap.ready_addr.get(&id),
+            Some(&"10.0.0.5:4318".parse().expect("addr")),
+            "the named port, not the first port, is dialed"
+        );
+    }
+}

--- a/services/ravel-ingest-router/src/key.rs
+++ b/services/ravel-ingest-router/src/key.rs
@@ -1,0 +1,167 @@
+//! Tenant-key resolution (deliverable 3): turn a request's headers into the raw
+//! key bytes fed to [`ravel_affinity::rank`].
+//!
+//! # Secrecy
+//!
+//! Under `authorization-header` the key *is* the raw bearer token. [`TenantKey`]
+//! therefore never exposes its bytes through `Debug`/`Display`, and nothing in
+//! this crate logs them or places them in a response or error body. The bounded
+//! round-robin map is keyed by [`TenantKey::hash`] (a blake3 digest), not the
+//! raw bytes, so no raw token is ever held as a map key either.
+
+use axum::http::HeaderMap;
+use axum::http::header::HeaderName;
+
+use ravel_tenant_resolve::TenantResolver;
+use std::sync::Arc;
+
+use crate::select::RouteError;
+
+/// Raw tenant-key bytes. Deliberately opaque: its `Debug` redacts the contents
+/// so a key can never leak into a log line through a `?`-formatted struct.
+#[derive(Clone)]
+pub(crate) struct TenantKey(Vec<u8>);
+
+impl TenantKey {
+    pub(crate) fn new(bytes: Vec<u8>) -> Self {
+        TenantKey(bytes)
+    }
+
+    /// The raw bytes, for [`ravel_affinity::rank`] only.
+    pub(crate) fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+
+    /// A blake3 digest of the key, used as the round-robin map key so the raw
+    /// bytes (a bearer token under `authorization-header`) are never stored.
+    pub(crate) fn hash(&self) -> [u8; 32] {
+        *blake3::hash(&self.0).as_bytes()
+    }
+}
+
+impl std::fmt::Debug for TenantKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Never print the bytes: this is the load-bearing no-leak property.
+        write!(f, "TenantKey(<redacted {} bytes>)", self.0.len())
+    }
+}
+
+/// How a request's headers map to key bytes.
+pub(crate) enum KeyResolver {
+    /// Hash the raw value bytes of this header. A missing header yields an empty
+    /// key (deterministic; matches nginx `upstream-hash-by` on an absent
+    /// variable). Not fail-closed: only `canonical-tenant` fails closed.
+    Header(HeaderName),
+    /// Resolve the canonical tenant via the shared chain; on failure reject the
+    /// request (401), never falling back to a weaker key. This is the
+    /// security-critical fail-closed path (ADR-0080 decision 3).
+    Canonical(Arc<dyn TenantResolver>),
+}
+
+impl KeyResolver {
+    /// Resolve the routing key, or a [`RouteError`] the proxy turns into a
+    /// status code.
+    pub(crate) fn resolve(&self, headers: &HeaderMap) -> Result<TenantKey, RouteError> {
+        match self {
+            KeyResolver::Header(name) => {
+                let bytes = headers
+                    .get(name)
+                    .map(|v| v.as_bytes().to_vec())
+                    .unwrap_or_default();
+                Ok(TenantKey::new(bytes))
+            }
+            KeyResolver::Canonical(resolver) => match resolver.resolve(headers) {
+                Ok(tenant) => Ok(TenantKey::new(tenant.as_str().as_bytes().to_vec())),
+                // Fail-closed: no fallback to a header key or to unpinned
+                // routing. The error carries no key bytes.
+                Err(_) => Err(RouteError::Unauthenticated),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+    use ravel_tenant_resolve::AuthError;
+    use ravel_types::TenantId;
+
+    fn headers(pairs: &[(&str, &str)]) -> HeaderMap {
+        let mut map = HeaderMap::new();
+        for (k, v) in pairs {
+            map.insert(
+                HeaderName::try_from(*k).expect("valid header name"),
+                v.parse().expect("valid header value"),
+            );
+        }
+        map
+    }
+
+    #[test]
+    fn header_source_reads_raw_value_bytes() {
+        let resolver = KeyResolver::Header(HeaderName::from_static("authorization"));
+        let key = resolver
+            .resolve(&headers(&[("authorization", "Bearer secret-token")]))
+            .expect("header present");
+        assert_eq!(key.as_bytes(), b"Bearer secret-token");
+    }
+
+    #[test]
+    fn header_source_missing_header_is_empty_key_not_error() {
+        let resolver = KeyResolver::Header(HeaderName::from_static("x-tenant"));
+        let key = resolver
+            .resolve(&HeaderMap::new())
+            .expect("a missing header is an empty key, not an error");
+        assert!(key.as_bytes().is_empty());
+    }
+
+    #[test]
+    fn different_header_values_produce_different_keys() {
+        let resolver = KeyResolver::Header(HeaderName::from_static("x-tenant"));
+        let a = resolver.resolve(&headers(&[("x-tenant", "a")])).expect("a");
+        let b = resolver.resolve(&headers(&[("x-tenant", "b")])).expect("b");
+        assert_ne!(a.as_bytes(), b.as_bytes());
+        assert_ne!(a.hash(), b.hash());
+    }
+
+    struct AlwaysFail;
+    impl TenantResolver for AlwaysFail {
+        fn resolve(&self, _headers: &HeaderMap) -> Result<TenantId, AuthError> {
+            Err(AuthError)
+        }
+    }
+
+    struct AlwaysTenant(&'static str);
+    impl TenantResolver for AlwaysTenant {
+        fn resolve(&self, _headers: &HeaderMap) -> Result<TenantId, AuthError> {
+            Ok(TenantId::new(self.0))
+        }
+    }
+
+    #[test]
+    fn canonical_success_uses_tenant_bytes() {
+        let resolver = KeyResolver::Canonical(Arc::new(AlwaysTenant("acme")));
+        let key = resolver.resolve(&HeaderMap::new()).expect("resolves");
+        assert_eq!(key.as_bytes(), b"acme");
+    }
+
+    #[test]
+    fn canonical_failure_is_unauthenticated_fail_closed() {
+        let resolver = KeyResolver::Canonical(Arc::new(AlwaysFail));
+        let err = resolver
+            .resolve(&HeaderMap::new())
+            .expect_err("resolution failure rejects");
+        assert!(matches!(err, RouteError::Unauthenticated));
+    }
+
+    #[test]
+    fn debug_never_prints_key_bytes() {
+        let key = TenantKey::new(b"super-secret-token".to_vec());
+        let rendered = format!("{key:?}");
+        assert!(
+            !rendered.contains("super-secret-token"),
+            "TenantKey Debug must never render the raw bytes"
+        );
+    }
+}

--- a/services/ravel-ingest-router/src/lib.rs
+++ b/services/ravel-ingest-router/src/lib.rs
@@ -1,0 +1,130 @@
+//! Ravel-native subset-affinity ingest router (ADR-0080 decision 3, T6a).
+//!
+//! A horizontally-scalable HTTP reverse proxy that pins each tenant's ingest
+//! traffic to a stable subset-of-`S` gateway pods, computed with rendezvous
+//! (HRW) hashing over the pods' own `EndpointSlice` identities. Requests are
+//! dialed **directly to the chosen pod address**, never through the gateway
+//! Service's cluster IP, so kube-proxy's own load balancing cannot undo the
+//! subset selection.
+//!
+//! # Request path
+//!
+//! Every request flows deliverable 3 -> 4 -> 5:
+//!
+//! 1. [`key`]: resolve the raw tenant-key bytes from the request headers. Under
+//!    `canonical-tenant` this runs the shared [`ravel_tenant_resolve`] chain and
+//!    is **fail-closed** (a resolution failure is a 401, never a fallback to a
+//!    weaker key or to unpinned routing).
+//! 2. [`select`]: [`ravel_affinity::rank`] the current endpoint snapshot, take
+//!    the top `subset_size` as the working subset, pick one member by bounded
+//!    per-tenant round-robin, and fall through the HRW order past position `S`
+//!    for any member not present in the Ready snapshot.
+//! 3. [`proxy`]: reverse-proxy the request to the selected pod's dial address.
+//!
+//! The protocol-agnostic core of steps 1-2 is
+//! [`router::RouterState::resolve_and_select`]; the follow-up gRPC task (#184)
+//! calls it directly rather than reimplementing selection.
+//!
+//! # Cold start
+//!
+//! The endpoint snapshot starts empty and the watcher's first sync takes an
+//! observable moment after process start. [`router::RouterState::resolve_and_select`]
+//! rejects with [`select::RouteError::NotSynced`] (a 503) until the first
+//! [`kube_runtime::watcher`] sync completes, and the same latch backs the
+//! `/readyz` probe, so a rolling deploy never serves from an empty subset.
+
+pub mod config;
+
+pub(crate) mod auth;
+pub(crate) mod clock;
+pub(crate) mod endpoints;
+pub(crate) mod key;
+pub(crate) mod proxy;
+pub(crate) mod router;
+pub(crate) mod select;
+pub(crate) mod watch;
+
+#[cfg(test)]
+mod tests;
+
+use std::sync::Arc;
+
+use k8s_openapi::api::discovery::v1::EndpointSlice;
+
+use crate::config::{KeyConfig, RouterConfig};
+
+/// Wire the watcher, resolver, selector, and HTTP proxy into one running
+/// process and serve until the listener closes (deliverable 6).
+///
+/// The stages are wired through [`router::RouterState::resolve_and_select`], the
+/// same boundary a unit test drives directly, so "reachable" here means the real
+/// binary and the tests exercise one code path, not two.
+pub async fn run(config: RouterConfig) -> anyhow::Result<()> {
+    let idle_ttl_ns = i64::try_from(config.round_robin_idle_ttl.as_nanos()).unwrap_or(i64::MAX);
+
+    // EndpointSlice watcher: build the shared store and drive it from the kube
+    // watch stream on a background task. The store starts not-synced, so the
+    // proxy and `/readyz` reject until the first sync completes.
+    let store = Arc::new(endpoints::EndpointStore::new(
+        config.gateway_port_name.clone(),
+    ));
+    let client = kube::Client::try_default().await?;
+    let api: kube::Api<EndpointSlice> =
+        kube::Api::namespaced(client, &config.gateway_service_namespace);
+    let watch_config = watch::watch_config(&config.gateway_service_name);
+    tokio::spawn(watch::run(api, watch_config, store.clone()));
+
+    // Key resolution (deliverable 3). Resolver wiring is built only for the
+    // canonical-tenant key source.
+    let key_resolver = match config.key {
+        KeyConfig::Header(name) => key::KeyResolver::Header(name),
+        KeyConfig::CanonicalTenant(settings) => {
+            let built = auth::build(&settings)?;
+            if let Some(refresh) = built.oidc_refresh {
+                auth::spawn_jwks_refresh(refresh);
+            }
+            key::KeyResolver::Canonical(built.resolver)
+        }
+    };
+
+    // The reverse-proxy client. Redirects are passed back to the client, never
+    // followed here: a proxy that chased a redirect would leave the pinned pod.
+    let http = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()?;
+
+    let state = Arc::new(router::RouterState {
+        endpoints: store,
+        key_resolver,
+        subset_size: config.subset_size,
+        round_robin: select::RoundRobin::new(config.round_robin_max_entries, idle_ttl_ns),
+        clock: Arc::new(clock::SystemClock),
+        http,
+    });
+
+    // Bound the round-robin map over time: sweep entries idle past the TTL on
+    // that same interval (the idle-eviction shape of ADR-0069).
+    spawn_round_robin_sweep(state.clone(), config.round_robin_idle_ttl);
+
+    let listener = tokio::net::TcpListener::bind(config.listen_http).await?;
+    tracing::info!(addr = %config.listen_http, "ravel-ingest-router listening");
+    axum::serve(listener, proxy::build_app(state)).await?;
+    Ok(())
+}
+
+/// Periodically evict idle round-robin entries. A swept entry restarts at
+/// offset 0 on the tenant's next request, so this only bounds memory and never
+/// affects correctness.
+fn spawn_round_robin_sweep(state: Arc<router::RouterState>, interval: std::time::Duration) {
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(interval);
+        ticker.tick().await; // consume the immediate first tick
+        loop {
+            ticker.tick().await;
+            let evicted = state.round_robin.evict_idle(state.clock.now_ns());
+            if evicted > 0 {
+                tracing::debug!(evicted, "swept idle round-robin entries");
+            }
+        }
+    });
+}

--- a/services/ravel-ingest-router/src/lib.rs
+++ b/services/ravel-ingest-router/src/lib.rs
@@ -49,12 +49,14 @@ mod tests;
 
 use std::sync::Arc;
 
+use anyhow::Context;
 use k8s_openapi::api::discovery::v1::EndpointSlice;
 
 use crate::config::{KeyConfig, RouterConfig};
 
 /// Wire the watcher, resolver, selector, and HTTP proxy into one running
-/// process and serve until the listener closes (deliverable 6).
+/// process and serve until the listener closes, or exit with an error if the
+/// EndpointSlice watcher task returns or panics (deliverable 6).
 ///
 /// The stages are wired through [`router::RouterState::resolve_and_select`], the
 /// same boundary a unit test drives directly, so "reachable" here means the real
@@ -72,7 +74,7 @@ pub async fn run(config: RouterConfig) -> anyhow::Result<()> {
     let api: kube::Api<EndpointSlice> =
         kube::Api::namespaced(client, &config.gateway_service_namespace);
     let watch_config = watch::watch_config(&config.gateway_service_name);
-    tokio::spawn(watch::run(api, watch_config, store.clone()));
+    let watch_handle = tokio::spawn(watch::run(api, watch_config, store.clone()));
 
     // Key resolution (deliverable 3). Resolver wiring is built only for the
     // canonical-tenant key source.
@@ -108,7 +110,28 @@ pub async fn run(config: RouterConfig) -> anyhow::Result<()> {
 
     let listener = tokio::net::TcpListener::bind(config.listen_http).await?;
     tracing::info!(addr = %config.listen_http, "ravel-ingest-router listening");
-    axum::serve(listener, proxy::build_app(state)).await?;
+
+    // The watcher normally never returns (kube_runtime::watcher turns errors
+    // into stream items and retries with backoff internally, per watch::run's
+    // own doc comment). If its task does return or panic, the process must not
+    // keep serving on an endpoint snapshot that will never update again: a
+    // silently-dead watcher would route tenant ingest to an increasingly stale
+    // (and, after enough pod churn, wrong) set of addresses while /readyz kept
+    // reporting healthy. Race it against the HTTP server and exit on either.
+    tokio::select! {
+        result = axum::serve(listener, proxy::build_app(state)) => {
+            result?;
+        }
+        watch_result = watch_handle => {
+            match watch_result {
+                Ok(()) => anyhow::bail!("endpointslice watcher task ended unexpectedly"),
+                Err(join_error) => {
+                    return Err(anyhow::Error::from(join_error))
+                        .context("endpointslice watcher task panicked");
+                }
+            }
+        }
+    }
     Ok(())
 }
 

--- a/services/ravel-ingest-router/src/main.rs
+++ b/services/ravel-ingest-router/src/main.rs
@@ -1,0 +1,42 @@
+//! `ravel-ingest-router` entrypoint (ADR-0080 decision 3, T6a).
+//!
+//! Parses the CLI, then hands off to [`ravel_ingest_router::run`], which wires
+//! the EndpointSlice watcher, the tenant-key resolver, the subset selector, and
+//! the HTTP reverse proxy into one running process.
+
+use std::process::ExitCode;
+
+use clap::Parser;
+use ravel_ingest_router::config::Cli;
+use tracing_subscriber::EnvFilter;
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    // rustls 0.23 links a process-level default crypto provider that must be
+    // installed before the first TLS client is built (the kube client below).
+    // This binary transitively links both `ring` (kube's rustls-tls) and
+    // `aws-lc-rs` (ravel-tenant-resolve's jsonwebtoken pin), which rustls
+    // refuses to disambiguate on its own. Install `ring` explicitly, matching
+    // services/ravel-operator and services/ravel-server. `install_default` only
+    // errors if a provider is already installed, which cannot happen this early.
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    tracing_subscriber::fmt().with_env_filter(filter).init();
+
+    let config = match Cli::parse().into_config() {
+        Ok(config) => config,
+        Err(error) => {
+            eprintln!("invalid configuration: {error}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    match ravel_ingest_router::run(config).await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            eprintln!("ravel-ingest-router exited with error: {error}");
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/services/ravel-ingest-router/src/proxy.rs
+++ b/services/ravel-ingest-router/src/proxy.rs
@@ -1,0 +1,136 @@
+//! HTTP reverse proxy (deliverable 5) and the axum app wiring (deliverable 6).
+//!
+//! The proxy forwards an incoming request's method, headers, and body straight
+//! to the selected pod's dial address and streams the response back. It dials
+//! the pod address from the EndpointSlice directly; it never resolves or dials
+//! the gateway Service's cluster IP or DNS name, so kube-proxy's own load
+//! balancing cannot re-spread the request and undo the subset selection.
+
+use std::sync::Arc;
+
+use axum::Router;
+use axum::body::Body;
+use axum::extract::{Request, State};
+use axum::http::{HeaderMap, HeaderName, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::routing::{any, get};
+
+use crate::router::RouterState;
+use crate::select::RouteError;
+
+/// Build the axum app: health probes plus the catch-all proxy.
+///
+/// `/readyz` and `/healthz` (with Prometheus' `/-/ready` and `/-/healthy`
+/// spellings) are the router's own; every other path is proxied.
+pub(crate) fn build_app(state: Arc<RouterState>) -> Router {
+    Router::new()
+        .route("/healthz", get(healthz))
+        .route("/-/healthy", get(healthz))
+        .route("/readyz", get(readyz))
+        .route("/-/ready", get(readyz))
+        .fallback(any(proxy))
+        .with_state(state)
+}
+
+/// Liveness: reachable means alive.
+async fn healthz() -> &'static str {
+    "ok"
+}
+
+/// Readiness: 200 once the watcher has completed its first sync, 503 before
+/// that, so a Deployment readiness probe holds traffic off a router that would
+/// otherwise select from an empty subset (deliverable 2 cold start).
+async fn readyz(State(state): State<Arc<RouterState>>) -> StatusCode {
+    if state.endpoints.is_synced() {
+        StatusCode::OK
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
+    }
+}
+
+/// The catch-all proxy handler: select, then forward.
+async fn proxy(State(state): State<Arc<RouterState>>, req: Request) -> Response {
+    let (parts, body) = req.into_parts();
+    let selection = match state.resolve_and_select(&parts.headers) {
+        Ok(sel) => sel,
+        // The error maps to a status only; no key bytes ever reach the body.
+        Err(err) => return err.status().into_response(),
+    };
+
+    match forward(&state.http, selection.addr, parts, body).await {
+        Ok(response) => response,
+        Err(err) => {
+            tracing::warn!(addr = %selection.addr, error = %err, "upstream forward failed");
+            RouteError::Upstream.status().into_response()
+        }
+    }
+}
+
+/// Forward the request to `addr` and stream the response back.
+async fn forward(
+    client: &reqwest::Client,
+    addr: std::net::SocketAddr,
+    parts: axum::http::request::Parts,
+    body: Body,
+) -> Result<Response, reqwest::Error> {
+    let path_and_query = parts
+        .uri
+        .path_and_query()
+        .map(|pq| pq.as_str())
+        .unwrap_or("/");
+    // Dial the pod address directly. The authority is the endpoint IP:port from
+    // the EndpointSlice, never a Service name, so there is no VIP indirection.
+    let url = format!("http://{addr}{path_and_query}");
+
+    let mut headers = parts.headers.clone();
+    strip_hop_by_hop(&mut headers);
+    // reqwest sets Host from the URL authority (the pod address); a forwarded
+    // client Host would conflict with it.
+    headers.remove(axum::http::header::HOST);
+
+    let upstream = client
+        .request(parts.method, url)
+        .headers(headers)
+        .body(reqwest::Body::wrap_stream(body.into_data_stream()))
+        .send()
+        .await?;
+
+    let mut builder = Response::builder().status(upstream.status());
+    for (name, value) in upstream.headers() {
+        if !is_hop_by_hop(name) {
+            builder = builder.header(name, value);
+        }
+    }
+    // `Body::from_stream` streams the upstream response without buffering it.
+    // A builder error here means an invalid status/header from the upstream;
+    // surface it as a 502 rather than panicking.
+    Ok(builder
+        .body(Body::from_stream(upstream.bytes_stream()))
+        .unwrap_or_else(|_| StatusCode::BAD_GATEWAY.into_response()))
+}
+
+/// Hop-by-hop headers (RFC 9110 sec 7.6.1) that a proxy must not forward.
+fn is_hop_by_hop(name: &HeaderName) -> bool {
+    matches!(
+        name.as_str(),
+        "connection"
+            | "keep-alive"
+            | "proxy-authenticate"
+            | "proxy-authorization"
+            | "te"
+            | "trailer"
+            | "transfer-encoding"
+            | "upgrade"
+    )
+}
+
+fn strip_hop_by_hop(headers: &mut HeaderMap) {
+    let drop: Vec<HeaderName> = headers
+        .keys()
+        .filter(|n| is_hop_by_hop(n))
+        .cloned()
+        .collect();
+    for name in drop {
+        headers.remove(name);
+    }
+}

--- a/services/ravel-ingest-router/src/router.rs
+++ b/services/ravel-ingest-router/src/router.rs
@@ -1,0 +1,71 @@
+//! The shared selection core (deliverables 3-4 wired together) plus its
+//! status-code mapping.
+//!
+//! [`RouterState::resolve_and_select`] is the protocol-agnostic boundary #184
+//! calls to reuse selection for the gRPC listener: it takes a `&HeaderMap`
+//! (gRPC metadata maps to the same type) and returns the chosen
+//! [`Selection`](crate::select::Selection) or a [`RouteError`], with no HTTP
+//! specifics. The HTTP proxy ([`crate::proxy`]) is the only HTTP-aware layer on
+//! top of it.
+
+use std::sync::Arc;
+
+use axum::http::{HeaderMap, StatusCode};
+
+use crate::clock::Clock;
+use crate::endpoints::EndpointStore;
+use crate::key::KeyResolver;
+use crate::select::{RoundRobin, RouteError, Selection, pick};
+
+/// Everything the request path needs, shared behind an `Arc`.
+pub(crate) struct RouterState {
+    pub endpoints: Arc<EndpointStore>,
+    pub key_resolver: KeyResolver,
+    pub subset_size: usize,
+    pub round_robin: RoundRobin,
+    pub clock: Arc<dyn Clock>,
+    pub http: reqwest::Client,
+}
+
+impl RouterState {
+    /// Resolve the tenant key and select the pod to dial (deliverables 3-4).
+    ///
+    /// This is the reuse boundary for #184: it is protocol-agnostic (headers in,
+    /// a [`Selection`] out) and performs the full cold-start gate, fail-closed
+    /// canonical-tenant resolution, HRW ranking, bounded round-robin pick, and
+    /// unready-member fallback. The HTTP proxy and the future gRPC proxy both
+    /// call it rather than reimplementing any of it.
+    pub(crate) fn resolve_and_select(&self, headers: &HeaderMap) -> Result<Selection, RouteError> {
+        // Cold start: reject before the first watcher sync rather than after
+        // failing to find a replica in an empty subset.
+        if !self.endpoints.is_synced() {
+            return Err(RouteError::NotSynced);
+        }
+
+        // Deliverable 3. Fail-closed under canonical-tenant.
+        let key = self.key_resolver.resolve(headers)?;
+
+        // Deliverable 4. Clone the snapshot Arc, then rank/select with no lock
+        // held.
+        let snapshot = self.endpoints.snapshot();
+        if snapshot.replicas.is_empty() {
+            return Err(RouteError::Exhausted);
+        }
+        let ranked = ravel_affinity::rank(key.as_bytes(), &snapshot.replicas);
+        let offset = self.round_robin.tick(key.hash(), self.clock.now_ns());
+        pick(&ranked, &snapshot.ready_addr, self.subset_size, offset)
+    }
+}
+
+impl RouteError {
+    /// The HTTP status a [`RouteError`] maps to. The body carries no key bytes
+    /// (the status alone is returned).
+    pub(crate) fn status(&self) -> StatusCode {
+        match self {
+            RouteError::NotSynced => StatusCode::SERVICE_UNAVAILABLE,
+            RouteError::Unauthenticated => StatusCode::UNAUTHORIZED,
+            RouteError::Exhausted => StatusCode::SERVICE_UNAVAILABLE,
+            RouteError::Upstream => StatusCode::BAD_GATEWAY,
+        }
+    }
+}

--- a/services/ravel-ingest-router/src/select.rs
+++ b/services/ravel-ingest-router/src/select.rs
@@ -1,0 +1,288 @@
+//! Subset selection and the local round-robin pick (deliverable 4).
+//!
+//! [`pick`] is a pure function of the HRW-ranked order, the Ready dial set, the
+//! subset size, and a round-robin offset, so it is unit-testable with no watcher
+//! and no HTTP server. [`RoundRobin`] holds the bounded per-tenant offset state.
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::Mutex;
+
+use ravel_affinity::ReplicaId;
+
+/// A routing decision the proxy layer turns into a status code.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum RouteError {
+    /// The watcher has not completed its first sync yet (cold start). 503.
+    #[error("router not ready: endpoint watcher has not completed its first sync")]
+    NotSynced,
+    /// Canonical-tenant resolution failed. 401. Carries no key bytes.
+    #[error("unauthenticated")]
+    Unauthenticated,
+    /// Every ranked replica was exhausted with none Ready. 503.
+    #[error("no ready gateway replica available")]
+    Exhausted,
+    /// The upstream dial or forward failed. 502.
+    #[error("bad gateway")]
+    Upstream,
+}
+
+/// The chosen replica and the address to dial it at.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Selection {
+    pub id: ReplicaId,
+    pub addr: SocketAddr,
+}
+
+/// Pick one replica for a tenant from the HRW-ranked order.
+///
+/// `ranked` is the full [`ravel_affinity::rank`] order over the current
+/// membership. `ready_addr` maps a replica to its dial address iff it is Ready.
+/// `subset_size` is `S`; `rr_offset` rotates the pick across repeated calls for
+/// the same tenant.
+///
+/// The subset is `ranked[0..S]`. The pick rotates round-robin across the subset
+/// starting at `rr_offset % S`, taking the first member that is Ready. If no
+/// subset member is Ready, it walks the HRW order past position `S`
+/// (`S`, `S+1`, ...) in order, rather than narrowing to a smaller subset or
+/// re-querying. If every ranked replica is exhausted, it returns
+/// [`RouteError::Exhausted`] (never a panic).
+pub(crate) fn pick(
+    ranked: &[&ReplicaId],
+    ready_addr: &HashMap<ReplicaId, SocketAddr>,
+    subset_size: usize,
+    rr_offset: u64,
+) -> Result<Selection, RouteError> {
+    let n = ranked.len();
+    if n == 0 {
+        return Err(RouteError::Exhausted);
+    }
+    // The subset window, clamped to the membership and to at least one so the
+    // modulo below is well-defined.
+    let s = subset_size.min(n).max(1);
+    let start = (rr_offset % s as u64) as usize;
+
+    // Round-robin within the subset: the first Ready member starting at `start`.
+    for i in 0..s {
+        let idx = (start + i) % s;
+        if let Some(addr) = ready_addr.get(ranked[idx]) {
+            return Ok(Selection {
+                id: ranked[idx].clone(),
+                addr: *addr,
+            });
+        }
+    }
+    // No Ready subset member: fall through the HRW order past position `S`.
+    for r in ranked.iter().take(n).skip(s) {
+        if let Some(addr) = ready_addr.get(*r) {
+            return Ok(Selection {
+                id: (*r).clone(),
+                addr: *addr,
+            });
+        }
+    }
+    Err(RouteError::Exhausted)
+}
+
+/// One per-tenant round-robin slot: the next offset and when it was last used.
+#[derive(Clone, Copy)]
+struct Slot {
+    counter: u64,
+    last_used_ns: i64,
+}
+
+/// Bounded per-tenant round-robin offsets (ADR-0069 idle-eviction shape).
+///
+/// Keyed by a blake3 hash of the tenant key (never the raw bytes). Bounded two
+/// ways so client-controlled key churn (a rotating bearer token under
+/// `authorization-header`) cannot grow it without limit: entries idle past
+/// `idle_ttl_ns` are swept, and a hard `max_entries` cap evicts the
+/// least-recently-used entry on overflow. A dropped entry only restarts that
+/// tenant's rotation at offset 0, so eviction is never correctness-bearing.
+pub(crate) struct RoundRobin {
+    slots: Mutex<HashMap<[u8; 32], Slot>>,
+    max_entries: usize,
+    idle_ttl_ns: i64,
+}
+
+impl RoundRobin {
+    pub(crate) fn new(max_entries: usize, idle_ttl_ns: i64) -> Self {
+        RoundRobin {
+            slots: Mutex::new(HashMap::new()),
+            max_entries: max_entries.max(1),
+            idle_ttl_ns: idle_ttl_ns.max(1),
+        }
+    }
+
+    /// Return this tenant's current round-robin offset, then advance it. Records
+    /// `now_ns` as the entry's last use for idle eviction.
+    pub(crate) fn tick(&self, key_hash: [u8; 32], now_ns: i64) -> u64 {
+        let mut slots = self.slots.lock().unwrap_or_else(|e| e.into_inner());
+        if !slots.contains_key(&key_hash) {
+            self.make_room(&mut slots, now_ns);
+        }
+        let slot = slots.entry(key_hash).or_insert(Slot {
+            counter: 0,
+            last_used_ns: now_ns,
+        });
+        let offset = slot.counter;
+        slot.counter = slot.counter.wrapping_add(1);
+        slot.last_used_ns = now_ns;
+        offset
+    }
+
+    /// Evict entries idle longer than the TTL. Returns the number removed.
+    /// Driven by the background sweep and by unit tests.
+    pub(crate) fn evict_idle(&self, now_ns: i64) -> usize {
+        let mut slots = self.slots.lock().unwrap_or_else(|e| e.into_inner());
+        let before = slots.len();
+        slots.retain(|_, slot| now_ns.saturating_sub(slot.last_used_ns) < self.idle_ttl_ns);
+        before - slots.len()
+    }
+
+    /// Current entry count (tests).
+    #[cfg(test)]
+    pub(crate) fn len(&self) -> usize {
+        self.slots.lock().unwrap_or_else(|e| e.into_inner()).len()
+    }
+
+    /// Ensure there is room for one more entry: first sweep idle entries, then,
+    /// if still at the cap, evict the single least-recently-used entry.
+    fn make_room(&self, slots: &mut HashMap<[u8; 32], Slot>, now_ns: i64) {
+        if slots.len() < self.max_entries {
+            return;
+        }
+        slots.retain(|_, slot| now_ns.saturating_sub(slot.last_used_ns) < self.idle_ttl_ns);
+        while slots.len() >= self.max_entries {
+            let Some(oldest) = slots
+                .iter()
+                .min_by_key(|(_, slot)| slot.last_used_ns)
+                .map(|(k, _)| *k)
+            else {
+                break;
+            };
+            slots.remove(&oldest);
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    fn reps(ids: &[&str]) -> Vec<ReplicaId> {
+        ids.iter().map(|s| ReplicaId::new(s.as_bytes())).collect()
+    }
+
+    fn refs(reps: &[ReplicaId]) -> Vec<&ReplicaId> {
+        reps.iter().collect()
+    }
+
+    fn addr(n: u8) -> SocketAddr {
+        format!("10.0.0.{n}:8080").parse().expect("addr")
+    }
+
+    #[test]
+    fn empty_ranking_is_exhausted() {
+        let ready = HashMap::new();
+        assert!(matches!(
+            pick(&[], &ready, 2, 0),
+            Err(RouteError::Exhausted)
+        ));
+    }
+
+    #[test]
+    fn picks_a_ready_subset_member() {
+        let reps = reps(&["a", "b", "c"]);
+        let mut ready = HashMap::new();
+        ready.insert(reps[0].clone(), addr(1));
+        ready.insert(reps[1].clone(), addr(2));
+        ready.insert(reps[2].clone(), addr(3));
+        let sel = pick(&refs(&reps), &ready, 2, 0).expect("pick");
+        assert_eq!(sel.id, reps[0]);
+    }
+
+    #[test]
+    fn round_robin_rotates_within_the_subset() {
+        let reps = reps(&["a", "b", "c"]);
+        let mut ready = HashMap::new();
+        ready.insert(reps[0].clone(), addr(1));
+        ready.insert(reps[1].clone(), addr(2));
+        ready.insert(reps[2].clone(), addr(3));
+        // Subset size 2 -> alternates between ranked[0] and ranked[1].
+        let s0 = pick(&refs(&reps), &ready, 2, 0).expect("0").id;
+        let s1 = pick(&refs(&reps), &ready, 2, 1).expect("1").id;
+        let s2 = pick(&refs(&reps), &ready, 2, 2).expect("2").id;
+        assert_eq!(s0, reps[0]);
+        assert_eq!(s1, reps[1]);
+        assert_eq!(s2, reps[0], "wraps back around the subset");
+        assert_ne!(s0, s1, "consecutive picks rotate, not repeat");
+    }
+
+    #[test]
+    fn unready_subset_member_falls_through_past_position_s() {
+        let reps = reps(&["a", "b", "c"]);
+        // ranked[0] ("a") is NOT ready; subset size 1 means the subset is {a}.
+        let mut ready = HashMap::new();
+        ready.insert(reps[1].clone(), addr(2));
+        ready.insert(reps[2].clone(), addr(3));
+        let sel = pick(&refs(&reps), &ready, 1, 0).expect("falls through");
+        assert_eq!(
+            sel.id, reps[1],
+            "falls to the next-ranked Ready replica past position S"
+        );
+    }
+
+    #[test]
+    fn all_unready_is_exhausted_not_a_panic() {
+        let reps = reps(&["a", "b"]);
+        let ready = HashMap::new();
+        assert!(matches!(
+            pick(&refs(&reps), &ready, 2, 0),
+            Err(RouteError::Exhausted)
+        ));
+    }
+
+    #[test]
+    fn round_robin_tick_advances_and_is_deterministic() {
+        let rr = RoundRobin::new(1024, 1_000_000);
+        let key = [7u8; 32];
+        assert_eq!(rr.tick(key, 0), 0);
+        assert_eq!(rr.tick(key, 1), 1);
+        assert_eq!(rr.tick(key, 2), 2);
+        // A different key has its own independent counter.
+        assert_eq!(rr.tick([9u8; 32], 3), 0);
+    }
+
+    #[test]
+    fn round_robin_evicts_idle_entries() {
+        let ttl = 100;
+        let rr = RoundRobin::new(1024, ttl);
+        rr.tick([1u8; 32], 0);
+        rr.tick([2u8; 32], 50);
+        assert_eq!(rr.len(), 2);
+        // At t=120, entry 1 (idle 120 >= ttl 100) is evicted; entry 2 (idle 70)
+        // is retained.
+        let evicted = rr.evict_idle(120);
+        assert_eq!(evicted, 1);
+        assert_eq!(rr.len(), 1);
+    }
+
+    #[test]
+    fn round_robin_is_bounded_by_max_entries() {
+        let rr = RoundRobin::new(4, i64::MAX);
+        // Insert far more distinct keys than the cap, each newer than the last,
+        // mimicking a stream of rotating bearer tokens.
+        for i in 0..1000u64 {
+            let mut key = [0u8; 32];
+            key[..8].copy_from_slice(&i.to_le_bytes());
+            rr.tick(key, i as i64);
+        }
+        assert!(
+            rr.len() <= 4,
+            "map must stay bounded by max_entries, got {}",
+            rr.len()
+        );
+    }
+}

--- a/services/ravel-ingest-router/src/tests.rs
+++ b/services/ravel-ingest-router/src/tests.rs
@@ -1,0 +1,500 @@
+//! Crate-level integration tests (ADR-0080 decision 3, T6a deliverable 8).
+//!
+//! All tests use an injectable EndpointSlice source (synthetic slices fed
+//! straight into [`EndpointStore::apply_event`]) and, where a proxy hop is
+//! exercised, a local axum backend standing in for a gateway pod. No real
+//! cluster or Kubernetes API server is needed.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
+
+use axum::Router;
+use axum::extract::{Request, State};
+use axum::http::StatusCode;
+use axum::http::header::AUTHORIZATION;
+use kube_runtime::watcher::Event;
+use ravel_affinity::{ReplicaId, rank};
+
+use crate::clock::Clock;
+use crate::endpoints::EndpointStore;
+use crate::endpoints::test_support::{TestEndpoint, slice, sync_one_slice};
+use crate::key::KeyResolver;
+use crate::proxy::build_app;
+use crate::router::RouterState;
+use crate::select::RoundRobin;
+
+// --- test harness ------------------------------------------------------------
+
+/// A fixed clock, so the round-robin idle logic is deterministic in tests.
+struct FakeClock(i64);
+impl Clock for FakeClock {
+    fn now_ns(&self) -> i64 {
+        self.0
+    }
+}
+
+type Hits = Arc<Mutex<Vec<String>>>;
+
+/// A local backend standing in for a gateway pod. Records `"<host> <path>"` for
+/// every request it receives, so a test can prove which pod address the router
+/// actually dialed.
+struct Backend {
+    addr: SocketAddr,
+    hits: Hits,
+}
+
+impl Backend {
+    fn recorded(&self) -> Vec<String> {
+        self.hits.lock().unwrap().clone()
+    }
+}
+
+async fn record(State(hits): State<Hits>, req: Request) -> &'static str {
+    let host = req
+        .headers()
+        .get(axum::http::header::HOST)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .to_string();
+    let path = req.uri().path().to_string();
+    hits.lock().unwrap().push(format!("{host} {path}"));
+    "from-backend"
+}
+
+async fn spawn_backend() -> Backend {
+    let hits: Hits = Arc::new(Mutex::new(Vec::new()));
+    let app = Router::new().fallback(record).with_state(hits.clone());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    Backend { addr, hits }
+}
+
+async fn spawn_router(app: Router) -> SocketAddr {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    addr
+}
+
+fn state(
+    store: Arc<EndpointStore>,
+    key_resolver: KeyResolver,
+    subset_size: usize,
+) -> Arc<RouterState> {
+    Arc::new(RouterState {
+        endpoints: store,
+        key_resolver,
+        subset_size,
+        round_robin: RoundRobin::new(1024, 60_000_000_000),
+        clock: Arc::new(FakeClock(0)),
+        http: reqwest::Client::builder()
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .unwrap(),
+    })
+}
+
+/// Feed a full relist of several slices, the shape the watcher emits on connect.
+fn sync_slices(store: &EndpointStore, slices: Vec<k8s_openapi::api::discovery::v1::EndpointSlice>) {
+    store.apply_event(Event::Init);
+    for s in slices {
+        store.apply_event(Event::InitApply(s));
+    }
+    store.apply_event(Event::InitDone);
+}
+
+// --- deliverable 8 tests -----------------------------------------------------
+
+#[tokio::test]
+async fn request_is_proxied_to_hrw_selected_pod_endpoint_not_service_vip() {
+    // Two real backends on distinct loopback ports stand in for two gateway
+    // pods. Each pod is injected as a Ready endpoint whose dial address IS that
+    // backend's real bound address; the router knows no Service name or VIP,
+    // only these pod addresses.
+    let backend_a = spawn_backend().await;
+    let backend_b = spawn_backend().await;
+
+    let store = Arc::new(EndpointStore::new(None));
+    // One slice per backend, so each pod carries its own port.
+    let slice_a = slice(
+        "gw-a",
+        "gw",
+        backend_a.addr.port() as i32,
+        &[TestEndpoint {
+            uid: "uid-a",
+            ip: "127.0.0.1",
+            ready: true,
+        }],
+    );
+    let slice_b = slice(
+        "gw-b",
+        "gw",
+        backend_b.addr.port() as i32,
+        &[TestEndpoint {
+            uid: "uid-b",
+            ip: "127.0.0.1",
+            ready: true,
+        }],
+    );
+    sync_slices(&store, vec![slice_a, slice_b]);
+
+    // Compute the HRW winner for the tenant key independently of the router, so
+    // the assertion is against `ravel_affinity::rank`'s own answer, not just
+    // "some backend replied".
+    let key = b"Bearer test-token";
+    let id_a = ReplicaId::new(b"uid-a".to_vec());
+    let id_b = ReplicaId::new(b"uid-b".to_vec());
+    let reps = [id_a.clone(), id_b.clone()];
+    let ranked = rank(key, &reps);
+    let winner = ranked[0].clone();
+    let (winner_backend, loser_backend, winner_addr) = if winner == id_a {
+        (&backend_a, &backend_b, backend_a.addr)
+    } else {
+        (&backend_b, &backend_a, backend_b.addr)
+    };
+
+    // subset_size 1: the subset is exactly the HRW winner, so the winner must
+    // receive the request.
+    let state = state(store, KeyResolver::Header(AUTHORIZATION), 1);
+    let router_addr = spawn_router(build_app(state)).await;
+
+    let client = reqwest::Client::new();
+    let response = client
+        .post(format!("http://{router_addr}/v1/metrics"))
+        .header(AUTHORIZATION, "Bearer test-token")
+        .body("payload")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 200);
+    assert_eq!(response.text().await.unwrap(), "from-backend");
+
+    // The HRW-selected pod received the request, at its own address...
+    let winner_hits = winner_backend.recorded();
+    assert_eq!(
+        winner_hits.len(),
+        1,
+        "winner pod received exactly one request"
+    );
+    assert_eq!(
+        winner_hits[0],
+        format!("{winner_addr} /v1/metrics"),
+        "request was dialed directly to the pod address (Host == pod IP:port), not a Service VIP"
+    );
+    // ...and the other pod received nothing: the router did not spray across
+    // endpoints the way a Service VIP would.
+    assert!(
+        loser_backend.recorded().is_empty(),
+        "the non-selected pod must receive no traffic"
+    );
+}
+
+#[tokio::test]
+async fn unready_subset_member_falls_through_to_next_ranked_replica() {
+    // The HRW-ranked top member is marked NotReady (absent from the Ready dial
+    // set). With subset_size 1, the subset is just that top member, so the
+    // request must fall through to the next-ranked replica rather than 503.
+    let backend = spawn_backend().await;
+
+    let key = b"Bearer test-token";
+    let id_a = ReplicaId::new(b"uid-a".to_vec());
+    let id_b = ReplicaId::new(b"uid-b".to_vec());
+    let reps = [id_a.clone(), id_b.clone()];
+    let ranked = rank(key, &reps);
+    let top = ranked[0].clone();
+    let next = ranked[1].clone();
+
+    // Build one slice on the backend's port. The rank-top endpoint is NotReady;
+    // the next-ranked endpoint is Ready and points at the backend.
+    let uid_top: &'static str = if top == id_a { "uid-a" } else { "uid-b" };
+    let uid_next: &'static str = if next == id_a { "uid-a" } else { "uid-b" };
+    let s = slice(
+        "gw",
+        "gw",
+        backend.addr.port() as i32,
+        &[
+            TestEndpoint {
+                uid: uid_top,
+                ip: "127.0.0.1",
+                ready: false,
+            },
+            TestEndpoint {
+                uid: uid_next,
+                ip: "127.0.0.1",
+                ready: true,
+            },
+        ],
+    );
+    let store = Arc::new(EndpointStore::new(None));
+    sync_one_slice(&store, s);
+
+    // Sanity: the top member ranks first but is excluded from the dial set.
+    let snap = store.snapshot();
+    assert!(
+        snap.replicas.contains(&top),
+        "unready top member still ranks"
+    );
+    assert!(
+        !snap.ready_addr.contains_key(&top),
+        "unready top member is not dialable"
+    );
+
+    let state = state(store, KeyResolver::Header(AUTHORIZATION), 1);
+    let router_addr = spawn_router(build_app(state)).await;
+
+    let response = reqwest::Client::new()
+        .post(format!("http://{router_addr}/v1/metrics"))
+        .header(AUTHORIZATION, "Bearer test-token")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        response.status(),
+        200,
+        "the request falls through to the next-ranked Ready replica, not 503"
+    );
+    let hits = backend.recorded();
+    assert_eq!(
+        hits.len(),
+        1,
+        "the next-ranked replica received the request"
+    );
+    assert_eq!(hits[0], format!("{} /v1/metrics", backend.addr));
+}
+
+#[tokio::test]
+async fn canonical_tenant_resolution_failure_rejects_request_fail_closed() {
+    // A backend is registered and Ready, so if the router ever proxied, this
+    // backend would record it. It must not: canonical-tenant resolution failure
+    // is fail-closed (401), never a proxy attempt.
+    let backend = spawn_backend().await;
+    let store = Arc::new(EndpointStore::new(None));
+    let s = slice(
+        "gw",
+        "gw",
+        backend.addr.port() as i32,
+        &[TestEndpoint {
+            uid: "uid-a",
+            ip: "127.0.0.1",
+            ready: true,
+        }],
+    );
+    sync_one_slice(&store, s);
+
+    // A resolver that always fails (no configured credential matches).
+    struct AlwaysFail;
+    impl ravel_tenant_resolve::TenantResolver for AlwaysFail {
+        fn resolve(
+            &self,
+            _headers: &axum::http::HeaderMap,
+        ) -> Result<ravel_types::TenantId, ravel_tenant_resolve::AuthError> {
+            Err(ravel_tenant_resolve::AuthError)
+        }
+    }
+
+    let state = state(store, KeyResolver::Canonical(Arc::new(AlwaysFail)), 2);
+    let router_addr = spawn_router(build_app(state)).await;
+
+    let response = reqwest::Client::new()
+        .post(format!("http://{router_addr}/v1/metrics"))
+        .header(AUTHORIZATION, "Bearer whatever")
+        .body("payload")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        response.status(),
+        401,
+        "canonical-tenant resolution failure must reject with 401"
+    );
+    assert!(
+        backend.recorded().is_empty(),
+        "fail-closed: no request may reach any backend on resolution failure"
+    );
+}
+
+#[tokio::test]
+async fn router_rejects_traffic_before_first_watcher_sync() {
+    // A backend exists but the store has NOT completed a sync (no InitDone).
+    let backend = spawn_backend().await;
+    let store = Arc::new(EndpointStore::new(None));
+    assert!(!store.is_synced());
+
+    let state = state(store, KeyResolver::Header(AUTHORIZATION), 2);
+    let router_addr = spawn_router(build_app(state)).await;
+    let client = reqwest::Client::new();
+
+    // /readyz reports not-ready before the first sync.
+    let readyz = client
+        .get(format!("http://{router_addr}/readyz"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(readyz.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+    // A proxied request is 503 (not-synced), and no backend is dialed.
+    let response = client
+        .post(format!("http://{router_addr}/v1/metrics"))
+        .header(AUTHORIZATION, "Bearer test-token")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    assert!(
+        backend.recorded().is_empty(),
+        "no proxy attempt may happen against an unsynced (empty) subset"
+    );
+}
+
+#[tokio::test]
+async fn readyz_flips_to_ready_after_first_sync() {
+    // Companion to the cold-start test: /readyz is 503 before sync and 200 once
+    // the injected source completes a relist.
+    let store = Arc::new(EndpointStore::new(None));
+    let state = state(store.clone(), KeyResolver::Header(AUTHORIZATION), 2);
+    let router_addr = spawn_router(build_app(state)).await;
+    let client = reqwest::Client::new();
+
+    let before = client
+        .get(format!("http://{router_addr}/readyz"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(before.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+    let s = slice(
+        "gw",
+        "gw",
+        8080,
+        &[TestEndpoint {
+            uid: "uid-a",
+            ip: "10.0.0.1",
+            ready: true,
+        }],
+    );
+    sync_one_slice(&store, s);
+
+    let after = client
+        .get(format!("http://{router_addr}/readyz"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(after.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn different_header_values_route_to_different_subsets() {
+    // The authorization-header/header/mtls-subject sources hash the raw header
+    // bytes, so distinct values pick distinct pods. Use many pods and two keys
+    // that HRW-rank different winners, and prove each key lands on its own
+    // winner.
+    let store = Arc::new(EndpointStore::new(None));
+    let mut backends = Vec::new();
+    let mut slices = Vec::new();
+    for i in 0..6u8 {
+        let backend = spawn_backend().await;
+        let uid: &'static str = Box::leak(format!("uid-{i}").into_boxed_str());
+        slices.push(slice(
+            Box::leak(format!("gw-{i}").into_boxed_str()),
+            "gw",
+            backend.addr.port() as i32,
+            &[TestEndpoint {
+                uid,
+                ip: "127.0.0.1",
+                ready: true,
+            }],
+        ));
+        backends.push((uid, backend));
+    }
+    sync_slices(&store, slices);
+
+    let reps: Vec<ReplicaId> = backends
+        .iter()
+        .map(|(uid, _)| ReplicaId::new(uid.as_bytes()))
+        .collect();
+
+    // Find two header values whose HRW winners differ.
+    let mut chosen: Option<(String, String, ReplicaId, ReplicaId)> = None;
+    for a in 0..50 {
+        for b in (a + 1)..50 {
+            let ka = format!("tenant-{a}");
+            let kb = format!("tenant-{b}");
+            let wa = rank(ka.as_bytes(), &reps)[0].clone();
+            let wb = rank(kb.as_bytes(), &reps)[0].clone();
+            if wa != wb {
+                chosen = Some((ka, kb, wa, wb));
+                break;
+            }
+        }
+        if chosen.is_some() {
+            break;
+        }
+    }
+    let (ka, kb, wa, wb) = chosen.expect("two keys with distinct HRW winners exist");
+
+    let state = state(
+        store,
+        KeyResolver::Header(axum::http::HeaderName::from_static("x-tenant")),
+        1,
+    );
+    let router_addr = spawn_router(build_app(state)).await;
+    let client = reqwest::Client::new();
+
+    for (key, winner) in [(ka, wa), (kb, wb)] {
+        client
+            .post(format!("http://{router_addr}/v1/metrics"))
+            .header("x-tenant", &key)
+            .send()
+            .await
+            .unwrap();
+        let winner_uid = std::str::from_utf8(winner.as_bytes()).unwrap();
+        let (_, backend) = backends.iter().find(|(uid, _)| *uid == winner_uid).unwrap();
+        assert_eq!(
+            backend.recorded().len(),
+            1,
+            "key {key} must land on its HRW winner {winner_uid}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn tenant_key_bytes_never_appear_in_an_error_body() {
+    // authorization-header source with a secret token, forced down an error
+    // path (Exhausted: synced but no Ready endpoint). The 503 body must not
+    // contain the token bytes.
+    let secret = "super-secret-token-value";
+    let store = Arc::new(EndpointStore::new(None));
+    let s = slice(
+        "gw",
+        "gw",
+        8080,
+        &[TestEndpoint {
+            uid: "uid-a",
+            ip: "10.0.0.1",
+            ready: false, // synced, but nothing Ready -> Exhausted
+        }],
+    );
+    sync_one_slice(&store, s);
+
+    let state = state(store, KeyResolver::Header(AUTHORIZATION), 2);
+    let router_addr = spawn_router(build_app(state)).await;
+
+    let response = reqwest::Client::new()
+        .post(format!("http://{router_addr}/v1/metrics"))
+        .header(AUTHORIZATION, format!("Bearer {secret}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    let body = response.text().await.unwrap();
+    assert!(
+        !body.contains(secret),
+        "the tenant key (bearer token) must never appear in an error body; got {body:?}"
+    );
+}

--- a/services/ravel-ingest-router/src/watch.rs
+++ b/services/ravel-ingest-router/src/watch.rs
@@ -1,0 +1,47 @@
+//! Drives the [`kube_runtime::watcher`] event stream for the gateway Service's
+//! EndpointSlices into the shared [`EndpointStore`] (deliverable 2).
+//!
+//! This is the only I/O-bound part of the watcher; the state reduction it feeds
+//! ([`EndpointStore::apply_event`]) is pure and unit-tested without a cluster.
+
+use std::sync::Arc;
+
+use futures::StreamExt;
+use k8s_openapi::api::discovery::v1::EndpointSlice;
+use kube::Api;
+use kube_runtime::watcher;
+
+use crate::endpoints::EndpointStore;
+
+/// The standard label the EndpointSlice controller stamps on every slice it
+/// generates for a Service.
+const SERVICE_NAME_LABEL: &str = "kubernetes.io/service-name";
+
+/// The `kube_runtime::watcher` config selecting only the gateway Service's
+/// slices.
+pub(crate) fn watch_config(service_name: &str) -> watcher::Config {
+    watcher::Config::default().labels(&format!("{SERVICE_NAME_LABEL}={service_name}"))
+}
+
+/// Run the watch loop until the stream ends (it normally does not; the watcher
+/// reconnects with backoff internally). Each event updates the store, which
+/// swaps its snapshot; the first `InitDone` latches readiness.
+pub(crate) async fn run(
+    api: Api<EndpointSlice>,
+    config: watcher::Config,
+    store: Arc<EndpointStore>,
+) {
+    let stream = watcher(api, config);
+    futures::pin_mut!(stream);
+    while let Some(event) = stream.next().await {
+        match event {
+            Ok(event) => store.apply_event(event),
+            // A watch error is transient (the underlying watcher retries with
+            // backoff); log and keep consuming. Readiness only ever latches on a
+            // successful `InitDone`, so a failing watch simply leaves the router
+            // not-ready rather than serving a stale or empty set as ready.
+            Err(error) => tracing::warn!(%error, "endpointslice watch error"),
+        }
+    }
+    tracing::warn!("endpointslice watch stream ended");
+}


### PR DESCRIPTION
Adds services/ravel-ingest-router per ADR-0080 decision 3: a new HTTP
reverse proxy that watches EndpointSlice objects for a gateway Service,
computes each tenant's subset-of-S pods via rendezvous (HRW) hashing
(ravel-affinity, already on main), and dials the selected pod's address
directly -- never through the Service's cluster IP, which would hand
load balancing back to kube-proxy and undo the subset selection.

Replica identity keys on the pod's targetRef.uid, not its IP, since an
IP can be reused by a different pod after churn. Within the chosen
subset, selection round-robins locally and falls through the HRW order
past position S for any member outside the router's own Ready snapshot,
rather than narrowing to a smaller subset. Tenant-key resolution
supports the legacy header-based sources plus a canonical-tenant mode
via ravel-tenant-resolve; canonical-tenant resolution failure rejects
the request outright (401) rather than falling back to a weaker key or
unpinned routing.

Two properties added after the first review pass: the router refuses
traffic until its first EndpointSlice watch sync completes, so a
rolling deploy never serves from an empty subset; and the watcher now
runs raced against the HTTP listener via tokio::select!, so if that
background task ever dies or panics the process exits instead of
silently serving an increasingly stale endpoint snapshot forever.

This is the HTTP half only. gRPC proxying is a separate follow-up
(#184) that reuses this router's selection pipeline rather than
reimplementing it. Wiring the operator to deploy this service is #158,
which needs a published container image for it -- tracked separately
in #188 so it isn't dropped. Two more follow-ups came out of review:
#186 (the round-robin eviction bound is memory-safe but can become a
CPU cliff under rapidly rotating bearer tokens) and #187 (two more
background tasks in this service drop their JoinHandle the same way the
watcher used to, plus a Debug-derive-over-secrets hygiene note).

Fixes: #157
Refs: #150
