### PR TITLE
feat(deploy): container-first quickstart with an executable README gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1264,3 +1264,157 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
           fail_ci_if_error: false
+
+  # Container-first quickstart verification (ADR-0081 decisions 5, 6, 7). Builds
+  # the pull request's OWN ravel-server (--features sql) and ravel-cli on the
+  # runner with the shared sccache/rust-cache, assembles a runtime image from
+  # them via Dockerfile.prebuilt (both binaries, because that file's `server`
+  # target COPYs ravel-cli for the store-qualification path too), brings up
+  # deploy/docker-compose/ravel.yml pointed at that image, drives real telemetry
+  # through it, then asserts the README's marked command blocks and the
+  # read-your-write walkthrough against the live stack.
+  #
+  # This is the epic's end-to-end reachability gate: OTLP ingest and PromQL/SQL
+  # query through the shipping binary inside the shipping image over a real
+  # network entry point, not a crate-level unit test.
+  #
+  # EXEMPT from the docs_only short-circuit (decision 7): a README-only edit is
+  # exactly the change this job exists to catch, so it does not gate on the
+  # `changes` job's docs_only/area outputs. It carries its own merge-base path
+  # filter inline (the same technique docker-build uses), and its heavy steps run
+  # only when a path in that filter changed.
+  #
+  # ADVISORY (ADR-0081 Consequences): deliberately NOT added to main's
+  # required-checks set. Its warm-cache budget is observed first, then it is
+  # promoted, matching how ADR-0070's Tier B gate was introduced.
+  quickstart:
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+      # The tag the assemble step writes and compose consumes via RAVEL_IMAGE.
+      RAVEL_IMAGE: ravel-server:quickstart-ci
+      COMPOSE_FILE: deploy/docker-compose/ravel.yml
+      # The readiness query has NO default in check-readme-commands.sh and hard
+      # errors when empty. `gen` is the series telemetrygen emits, which this job
+      # runs deterministically alongside the collector (ADR-0081 D5); no host
+      # metric name is guaranteed non-empty across both generators.
+      RAVEL_HTTP_BASE: http://127.0.0.1:4318
+      RAVEL_TENANT_TOKEN: demo-token
+      RAVEL_READY_QUERY_URL: http://127.0.0.1:4318/api/v1/query?query=gen
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          fetch-depth: 0
+      # Inline merge-base path filter (decision 7). Runs on a README-only change
+      # but skips the expensive build/bring-up when nothing this job covers
+      # changed, the same shape docker-build uses for its Dockerfile guard.
+      - id: filter
+        run: |
+          if [ "${{ github.event_name }}" = "merge_group" ]; then
+            base="${{ github.event.merge_group.base_sha }}"
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            base="${{ github.event.pull_request.base.sha }}"
+          else
+            base="${{ github.event.before }}"
+          fi
+          if [ -z "$base" ] || ! git cat-file -e "$base" 2>/dev/null; then
+            echo "::notice::no usable base commit, running quickstart to be safe"
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          merge_base=$(git merge-base "$base" "${{ github.sha }}")
+          changed=$(git diff --name-only "$merge_base" "${{ github.sha }}")
+          filter='^README\.md$|^deploy/docker-compose/|^deploy/otel/|^deploy/grafana/|^demo/|^scripts/check-readme-commands\.sh$|^scripts/check_readme_commands\.py$|^Dockerfile\.prebuilt$|^services/ravel-server/'
+          if echo "$changed" | grep -qE "$filter"; then
+            echo "::notice::quickstart-relevant path changed, running the job"
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::no quickstart-relevant path changed, skipping build/bring-up"
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Free disk space
+        if: steps.filter.outputs.run == 'true'
+        uses: ./.github/actions/free-disk-space
+      - name: Install toolchain from rust-toolchain.toml
+        if: steps.filter.outputs.run == 'true'
+        run: rustup show
+      - name: Install sccache
+        id: sccache
+        if: steps.filter.outputs.run == 'true'
+        continue-on-error: true
+        uses: ./.github/actions/setup-sccache
+      - name: Disable sccache if its install flaked
+        if: steps.filter.outputs.run == 'true' && steps.sccache.outcome == 'failure'
+        run: echo "RUSTC_WRAPPER=" >> "$GITHUB_ENV"
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        if: steps.filter.outputs.run == 'true'
+      # Both binaries: Dockerfile.prebuilt's `server` target COPYs ravel-server
+      # AND ravel-cli, so a context missing the CLI fails the docker build.
+      - name: Build ravel-server (sql) and ravel-cli on the host
+        if: steps.filter.outputs.run == 'true'
+        run: |
+          cargo build --release --locked -p ravel-server --features sql
+          cargo build --release --locked -p ravel-cli
+      - name: Assemble the runtime image from the prebuilt binaries
+        if: steps.filter.outputs.run == 'true'
+        run: |
+          # A staging dir as the context: the repo root cannot be used because
+          # .dockerignore excludes target/ from it. Only the two binaries the
+          # server target COPYs are needed.
+          ctx=$(mktemp -d)
+          cp target/release/ravel-server target/release/ravel-cli "$ctx/"
+          docker build --file Dockerfile.prebuilt --target server \
+            --tag "$RAVEL_IMAGE" "$ctx"
+          rm -rf "$ctx"
+      - name: Bring up the compose stack
+        if: steps.filter.outputs.run == 'true'
+        run: docker compose -f "$COMPOSE_FILE" up -d
+      - name: Wait for ravel-server readiness
+        if: steps.filter.outputs.run == 'true'
+        run: |
+          for i in $(seq 1 60); do
+            if curl -fsS "${RAVEL_HTTP_BASE}/readyz" >/dev/null 2>&1; then
+              echo "ravel-server ready"
+              exit 0
+            fi
+            sleep 3
+          done
+          echo "::error::ravel-server did not become ready in time"
+          docker compose -f "$COMPOSE_FILE" logs --no-color || true
+          exit 1
+      # telemetrygen injects a deterministic series (`gen`) for the assertions,
+      # alongside the collector's host metrics (ADR-0081 D5). OTLP/HTTP to the
+      # published loopback port, with the demo bearer token; --network host so
+      # 127.0.0.1:4318 resolves to the mapped port.
+      - name: Generate deterministic telemetry with telemetrygen
+        if: steps.filter.outputs.run == 'true'
+        run: |
+          docker run --rm --network host \
+            ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:latest \
+            metrics \
+            --otlp-http \
+            --otlp-endpoint 127.0.0.1:4318 \
+            --otlp-insecure \
+            --otlp-header 'Authorization="Bearer demo-token"' \
+            --metric-type Gauge \
+            --metrics 500
+      # Waits for readiness (health, then a non-empty `gen` query), then runs
+      # every marked README block and asserts its declared outcome.
+      - name: Assert the README's marked command blocks
+        if: steps.filter.outputs.run == 'true'
+        run: scripts/check-readme-commands.sh README.md
+      # The read-your-write walkthrough: ingest one export, capture its commit
+      # token, read that exact write back. Assertive on its own.
+      - name: Run the read-your-write walkthrough
+        if: steps.filter.outputs.run == 'true'
+        run: demo/walkthrough.sh
+      # Always capture logs on failure: a CI failure nobody can diagnose is a job
+      # that gets disabled (ADR-0081 D6).
+      - name: Dump compose logs on failure
+        if: failure() && steps.filter.outputs.run == 'true'
+        run: docker compose -f "$COMPOSE_FILE" logs --no-color || true
+      - name: Tear down the compose stack
+        if: always() && steps.filter.outputs.run == 'true'
+        run: docker compose -f "$COMPOSE_FILE" down -v || true

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: check fmt clippy test test-python doc-drift build minio minio-down demo kind-up kind-demo kind-down bench audit difftest
+.PHONY: check fmt clippy test test-python doc-drift build minio minio-down demo quickstart quickstart-down kind-up kind-demo kind-down bench audit difftest
 
 check: fmt clippy test
 
@@ -37,6 +37,16 @@ minio-down:
 
 demo: build
 	./scripts/demo.sh
+
+# Container-first quickstart (ADR-0081): the whole stack from published images
+# -- MinIO, ravel-server, an OpenTelemetry Collector, and Grafana -- with no
+# cargo build. Override the pinned server image with RAVEL_IMAGE. This is the
+# documented first run; `demo` above stays the from-source contributor path.
+quickstart:
+	docker compose -f deploy/docker-compose/ravel.yml up -d
+
+quickstart-down:
+	docker compose -f deploy/docker-compose/ravel.yml down
 
 # The same ingest/query round trip on a real local Kubernetes cluster, driven
 # by the operator (ADR-0034 decision 6; docs/guides/kubernetes.md). No `build`

--- a/README.md
+++ b/README.md
@@ -8,6 +8,74 @@
 An OpenTelemetry-native observability database whose only durable backend is
 object storage.
 
+## Quickstart
+
+One command brings up the whole stack from published images — MinIO for
+object storage, `ravel-server`, an OpenTelemetry Collector feeding it your
+host's own metrics, and Grafana with a provisioned Ravel datasource. No Rust
+toolchain, no cargo, no compile.
+
+```sh
+docker compose -f deploy/docker-compose/ravel.yml up -d
+```
+
+Open Grafana at <http://127.0.0.1:3000> (`admin` / `admin`); the Ravel
+datasource is already wired up and the first dashboard shows your machine's
+metrics within a few scrape intervals.
+
+Query the data back over Ravel's Prometheus-compatible API. Every query needs
+the demo bearer token, exactly as a real deployment requires a real one:
+
+<!-- ravel:run status=200; json:.status=success -->
+```sh
+curl -s -H "Authorization: Bearer demo-token" \
+  'http://127.0.0.1:4318/api/v1/query?query=system_cpu_load_average_1m'
+```
+
+The published image is built with `--features sql`, so `POST /api/v1/sql`
+answers out of the box. The registered tables are `samples` (metrics), `logs`,
+and `spans`:
+
+<!-- ravel:run status=200; nonempty:.data.rows -->
+```sh
+curl -s -X POST http://127.0.0.1:4318/api/v1/sql \
+  -H "Authorization: Bearer demo-token" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"SELECT * FROM samples LIMIT 5"}'
+```
+
+To see Ravel's read-your-write path directly — ingest one export, capture its
+commit token, and read that exact write back — run
+[demo/walkthrough.sh](demo/walkthrough.sh) while the stack is up. Stop the
+stack with:
+
+```sh
+docker compose -f deploy/docker-compose/ravel.yml down
+```
+
+The [getting started guide](docs/guides/getting-started.md) walks the same path
+with expected output.
+
+### Capabilities and the from-source path
+
+The quickstart's SQL surface exists because the published image carries
+`--features sql`. The from-source contributor path, `make demo`, does **not**
+build that feature, so `POST /api/v1/sql` is unavailable there; PromQL,
+ingest, and the rest work on both. If you are changing Ravel's code and need to
+run your own build, use `make demo` — see the
+[development guide](docs/guides/development.md).
+
+### Security
+
+Everything in [deploy/docker-compose/ravel.yml](deploy/docker-compose/ravel.yml)
+is a fixed **development** value: the demo bearer token (`demo-token`) and the
+MinIO credentials (`ravel` / `ravel-dev-secret`). Every published host port
+binds loopback (`127.0.0.1`) only, so the checked-in token never fronts an
+ingest endpoint on your LAN. None of these values are for any deployment
+reachable from a network.
+
+## Why object storage
+
 Metrics, logs, and traces land as immutable segments and commit records on S3
 or MinIO. Every Ravel process — gateway, ingest shard, query frontend,
 maintenance worker — is disposable: when Ravel acknowledges a write in strict
@@ -19,34 +87,15 @@ Metrics and logs run end to end today, from OTLP or Remote Write ingest through
 PromQL, SQL, and Flight SQL query. Traces ingest, compact, and retain end to
 end, and are queryable through the `spans` SQL table on `POST /api/v1/sql`.
 
-## Run it
-
-```sh
-make minio   # MinIO plus bucket creation, via docker compose
-make demo    # ingest one OTLP export and query it back
-```
-
-`make demo` starts `ravel-server` against MinIO, sends a generated OTLP metrics
-export, prints the commit token it receives, and queries the metric back by
-`min_commit_token`. For the walkthrough with expected output, see the
-[getting started guide](docs/guides/getting-started.md).
-
-The same round trip on a real Kubernetes cluster, driven by the operator, needs
-`docker`, `kind`, and `kubectl`:
-
-```sh
-scripts/kind-up.sh     # cluster, images, fake S3, operator, RavelCluster
-scripts/kind-demo.sh   # ingest via the gateway, query via the query tier
-scripts/kind-down.sh
-```
-
 ## Container images
 
 `ravel-server` and `ravel-operator` publish to the GitHub Container Registry
 (GHCR) on every `vX.Y.Z` release tag, built from the root `Dockerfile` (see
 [ADR-0037](docs/adrs/0037-container-image-ci-registry.md)). Only `linux/amd64`
 is published; each published object is an OCI image index carrying an SBOM and
-full build provenance.
+full build provenance. The quickstart pins
+`ghcr.io/nofireai/ravel-server:0.9.2` by default; override it by setting
+`RAVEL_IMAGE` before `docker compose up`.
 
 ```sh
 docker pull ghcr.io/nofireai/ravel-server:latest
@@ -82,6 +131,19 @@ cosign verify \
 Replace `v0.9.0`/`0.9.0` with the release you are verifying; the tag ref in
 `--certificate-identity` must be the exact tag that produced the image.
 
+## Kubernetes
+
+The same ingest/query round trip on a real Kubernetes cluster, driven by the
+operator, needs `docker`, `kind`, and `kubectl`:
+
+```sh
+scripts/kind-up.sh     # cluster, images, fake S3, operator, RavelCluster
+scripts/kind-demo.sh   # ingest via the gateway, query via the query tier
+scripts/kind-down.sh
+```
+
+See the [Kubernetes guide](docs/guides/kubernetes.md) for details.
+
 ## How it fits together
 
 ![architecture](docs/diagrams/architecture.svg)
@@ -95,18 +157,12 @@ acknowledgement, visibility, and crash recovery mean.
 
 ![ingest and commit sequence](docs/diagrams/ingest-commit-sequence.svg)
 
-## Query it
+## Query surfaces
 
-```sh
-# PromQL, instant
-curl -s 'localhost:8080/api/v1/query?query=http_requests_total'
-
-# SQL over metrics, with ravel-server built and run with --features sql
-curl -s localhost:8080/api/v1/sql -d '{"query":"SELECT * FROM metrics LIMIT 10"}'
-```
-
-PromQL, SQL, Flight SQL, exemplars, alerting, and analytics surfaces are each
-covered in the [query guide](docs/guides/query.md) and the
+All query endpoints live under `/api/v1` on the HTTP listener (default bind
+`127.0.0.1:4318`) and require `Authorization: Bearer <token>`, the same as
+ingest. PromQL, SQL, Flight SQL, exemplars, alerting, and analytics surfaces
+are each covered in the [query guide](docs/guides/query.md) and the
 [distributed query guide](docs/guides/distributed-query.md).
 
 ## Where things live
@@ -118,7 +174,8 @@ covered in the [query guide](docs/guides/query.md) and the
   one binary), `ravel-cli` (segment, commit, and catalog inspector), and the
   Kubernetes operator
 - `docs/` — specs, decision records, diagrams, and guides
-- `deploy/` — local MinIO stack and Kubernetes manifests
+- `deploy/` — the container-first compose stack, the local MinIO stack, the
+  OpenTelemetry Collector and Grafana provisioning, and Kubernetes manifests
 
 ## Documentation
 

--- a/demo/walkthrough.sh
+++ b/demo/walkthrough.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Read-your-write walkthrough for the container-first quickstart (ADR-0081).
+#
+# Ingests one OTLP metric export, captures the `x-ravel-commit-token` response
+# header, queries the data back passing that token as `min_commit_token`, and
+# prints both. It is assertive: it exits non-zero if the token is absent or the
+# query does not return the ingested series.
+#
+# It assumes the compose stack is ALREADY UP (same contract as
+# scripts/check-readme-commands.sh); bringing MinIO, ravel-server, the collector,
+# and Grafana up is `docker compose -f deploy/docker-compose/ravel.yml up -d`'s
+# job. Run this after the stack is healthy.
+#
+# The OTLP payload is a minimal ExportMetricsServiceRequest built here in bash
+# with a CURRENT timestamp. The compose quickstart carries no Rust toolchain to
+# run gen_otlp_fixture, and ravel rejects data points more than 2 hours old, so a
+# static checked-in fixture would fail non-deterministically. The field numbers
+# used below are the frozen OTLP metrics wire contract.
+set -euo pipefail
+
+RAVEL_HTTP_BASE="${RAVEL_HTTP_BASE:-http://127.0.0.1:4318}"
+RAVEL_TENANT_TOKEN="${RAVEL_TENANT_TOKEN:-demo-token}"
+METRIC_NAME="${RAVEL_WALKTHROUGH_METRIC:-walkthrough_demo}"
+
+log() { echo "[walkthrough] $*" >&2; }
+
+if ! command -v curl >/dev/null 2>&1; then
+  log "curl not found on PATH"
+  exit 2
+fi
+
+# --- OTLP protobuf assembly ------------------------------------------------
+
+# Space-separated decimal bytes of a base-128 varint.
+varint() {
+  local n=$1 out="" b
+  while :; do
+    b=$(( n & 0x7f ))
+    n=$(( n >> 7 ))
+    if (( n != 0 )); then
+      out+="$(( b | 0x80 )) "
+    else
+      out+="$b "
+      break
+    fi
+  done
+  printf '%s' "$out"
+}
+
+# Eight little-endian decimal bytes of an unsigned 64-bit integer.
+le64() {
+  local n=$1 i out=""
+  for (( i = 0; i < 8; i++ )); do
+    out+="$(( n & 0xff )) "
+    n=$(( n >> 8 ))
+  done
+  printf '%s' "$out"
+}
+
+# A fixed64-wire field: tag, then the eight-byte payload verbatim.
+field_fixed64() {
+  printf '%s %s' "$(( ($1 << 3) | 1 ))" "$2"
+}
+
+# A length-delimited field: tag, varint(len), payload.
+field_len_delimited() {
+  local len
+  len=$(wc -w <<<"$2")
+  printf '%s %s %s' "$(( ($1 << 3) | 2 ))" "$(varint "$len")" "$2"
+}
+
+# Second granularity keeps this portable (BSD `date` has no %N); well inside the
+# 2-hour freshness window ravel enforces.
+now_ns=$(( $(date +%s) * 1000000000 ))
+
+# NumberDataPoint { time_unix_nano = 3 (fixed64); as_double = 4 (double) = 1.0 }.
+# 1.0 as IEEE-754 little-endian is 00 00 00 00 00 00 F0 3F.
+ndp="$(field_fixed64 3 "$(le64 "$now_ns")") $(field_fixed64 4 "0 0 0 0 0 0 240 63")"
+# Gauge { data_points = 1 }.
+gauge="$(field_len_delimited 1 "$ndp")"
+# Metric name bytes as decimals.
+name_bytes=$(printf '%s' "$METRIC_NAME" | od -An -tu1 | tr -s ' \n' ' ')
+# Metric { name = 1 (string); gauge = 5 (message) }.
+metric="$(field_len_delimited 1 "$name_bytes") $(field_len_delimited 5 "$gauge")"
+# ScopeMetrics { metrics = 2 }; ResourceMetrics { scope_metrics = 2 };
+# ExportMetricsServiceRequest { resource_metrics = 1 }.
+scope_metrics="$(field_len_delimited 2 "$metric")"
+resource_metrics="$(field_len_delimited 2 "$scope_metrics")"
+request="$(field_len_delimited 1 "$resource_metrics")"
+
+fixture=$(mktemp)
+headers=$(mktemp)
+cleanup() { rm -f "$fixture" "$headers"; }
+trap cleanup EXIT
+
+# Emit the decimal byte list as raw bytes. Intentional word splitting over the
+# space-separated decimals.
+# shellcheck disable=SC2086
+{
+  for b in $request; do
+    printf "\\$(printf '%03o' "$b")"
+  done
+} >"$fixture"
+
+# --- Ingest ----------------------------------------------------------------
+log "ingesting one OTLP metric export ($METRIC_NAME) to $RAVEL_HTTP_BASE/v1/metrics"
+curl --silent --show-error --fail \
+  --dump-header "$headers" \
+  --output /dev/null \
+  -X POST "$RAVEL_HTTP_BASE/v1/metrics" \
+  -H "Authorization: Bearer $RAVEL_TENANT_TOKEN" \
+  -H "Content-Type: application/x-protobuf" \
+  --data-binary "@$fixture"
+
+commit_token=$(grep -i '^x-ravel-commit-token:' "$headers" | sed 's/^[^:]*:[[:space:]]*//' | tr -d '\r')
+if [[ -z "$commit_token" ]]; then
+  log "ingest succeeded but no x-ravel-commit-token header was returned"
+  exit 1
+fi
+log "ingest accepted; commit token: $commit_token"
+
+# --- Query back with the commit token --------------------------------------
+log "querying $METRIC_NAME back with min_commit_token"
+query_response=$(curl --silent --show-error --fail \
+  -H "Authorization: Bearer $RAVEL_TENANT_TOKEN" \
+  --get "$RAVEL_HTTP_BASE/api/v1/query" \
+  --data-urlencode "query=$METRIC_NAME" \
+  --data-urlencode "min_commit_token=$commit_token")
+
+echo "commit token: $commit_token"
+echo "query result: $query_response"
+
+if ! grep -q '"status":"success"' <<<"$query_response"; then
+  log "query response did not report success"
+  exit 1
+fi
+if ! grep -q "$METRIC_NAME" <<<"$query_response"; then
+  log "query response did not contain the ingested series $METRIC_NAME"
+  exit 1
+fi
+
+log "walkthrough complete: ingested series read back by its own commit token"

--- a/deploy/docker-compose/ravel.yml
+++ b/deploy/docker-compose/ravel.yml
@@ -1,0 +1,137 @@
+# Container-first quickstart stack (ADR-0081 decisions 1-3).
+#
+# `docker compose -f deploy/docker-compose/ravel.yml up -d` brings up a full,
+# self-contained Ravel: MinIO as the S3-compatible object store, a one-shot that
+# creates the bucket, a one-shot that qualifies the store, ravel-server pulled
+# from GHCR, an OpenTelemetry Collector generating real telemetry from the host,
+# and Grafana with a provisioned Ravel datasource. No Rust toolchain, no compile.
+#
+# SECURITY: every credential and token in this file is a fixed DEVELOPMENT value
+# (the MinIO `ravel`/`ravel-dev-secret` pair and the `demo-token` bearer token),
+# and every published host port binds loopback (`127.0.0.1`) only. None of this
+# is for any deployment reachable from a network. The loopback prefixes are what
+# keep the checked-in bearer token off the reader's LAN (ADR-0081 decision 1); do
+# not drop them.
+services:
+  # MinIO and the bucket-creation one-shot mirror deploy/docker-compose/minio.yml
+  # exactly: same credentials, same `ravel-dev` bucket, same `minio-data/` host
+  # dir (gitignored, shared with that stack, and safe to reuse across runs).
+  minio:
+    image: minio/minio:latest
+    command: server /data --console-address ":9001"
+    ports:
+      - "127.0.0.1:9000:9000"
+      - "127.0.0.1:9001:9001"
+    environment:
+      MINIO_ROOT_USER: ravel
+      MINIO_ROOT_PASSWORD: ravel-dev-secret
+    volumes:
+      - ../../minio-data:/data
+
+  createbucket:
+    image: minio/mc:latest
+    depends_on: [minio]
+    # `mc alias set` fails until MinIO is reachable, so the until-loop is the
+    # readiness wait: this service completes successfully only once the bucket
+    # actually exists, which is what the qualify one-shot below depends on.
+    entrypoint: >
+      /bin/sh -c "
+      until mc alias set local http://minio:9000 ravel ravel-dev-secret; do
+        echo 'waiting for minio'; sleep 1;
+      done &&
+      mc mb -p local/ravel-dev || true"
+
+  # Store qualification (ADR-0050 section 6): ravel-server refuses to start on a
+  # non-Memory store until `sys/qualification` is present, and there is
+  # deliberately no bootstrap-and-continue path for it. A freshly `mc mb`'d
+  # bucket has no such record, so it must be written before the server starts.
+  # The published image carries ravel-cli for exactly this (Dockerfile.prebuilt);
+  # override the entrypoint to run it. `store qualify` is idempotent: on an
+  # already-qualified bucket it reports the existing record and exits 0, so this
+  # tolerates a populated `minio-data/` across runs.
+  qualify:
+    image: ${RAVEL_IMAGE:-ghcr.io/nofireai/ravel-server:0.9.2}
+    depends_on:
+      createbucket:
+        condition: service_completed_successfully
+    entrypoint: ["/usr/local/bin/ravel-cli"]
+    command: ["--store", "s3", "store", "qualify"]
+    environment:
+      RAVEL_S3_ENDPOINT: http://minio:9000
+      RAVEL_S3_BUCKET: ravel-dev
+      RAVEL_S3_REGION: us-east-1
+      RAVEL_S3_ACCESS_KEY: ravel
+      RAVEL_S3_SECRET_KEY: ravel-dev-secret
+
+  # ravel-server, pulled from GHCR (override the pin with RAVEL_IMAGE). The image
+  # has no default CMD by design -- the operator supplies every argument -- so the
+  # full vector is passed here (ADR-0081 decision 2). It binds 0.0.0.0 INSIDE the
+  # container namespace; the loopback prefix on the port mapping is what keeps it
+  # off the host's other interfaces. --dev-insecure-tenant-header is deliberately
+  # not used: it refuses to enable unless --listen-http binds loopback, which the
+  # container boundary forbids, so the demo authenticates with a real bearer
+  # token against a real tenant map, exactly as a deployment does.
+  ravel-server:
+    image: ${RAVEL_IMAGE:-ghcr.io/nofireai/ravel-server:0.9.2}
+    depends_on:
+      qualify:
+        condition: service_completed_successfully
+    command:
+      - "--mode"
+      - "all"
+      - "--store"
+      - "s3"
+      - "--listen-http"
+      - "0.0.0.0:4318"
+      - "--listen-grpc"
+      - "0.0.0.0:4317"
+      - "--shards"
+      - "4"
+      - "--tenant-token"
+      - "demo-token=demo-tenant"
+      # A fresh bucket refuses to start unless a tenant-hash scheme is chosen
+      # (services/ravel-server/src/tenancy.rs: keyed is the default, an
+      # unspecified config is FreshBucketNeedsKey). The quickstart is an unkeyed
+      # dev bucket, so opt out explicitly. Safe on a reused minio-data/ too: an
+      # existing unkeyed marker validates against this, keyed would not.
+      - "--tenant-hash-unkeyed"
+    ports:
+      - "127.0.0.1:4318:4318"
+      - "127.0.0.1:4317:4317"
+    environment:
+      RAVEL_S3_ENDPOINT: http://minio:9000
+      RAVEL_S3_BUCKET: ravel-dev
+      RAVEL_S3_REGION: us-east-1
+      RAVEL_S3_ACCESS_KEY: ravel
+      RAVEL_S3_SECRET_KEY: ravel-dev-secret
+
+  # The demo's data generator (ADR-0081 decision 3): a real OpenTelemetry
+  # Collector scraping host metrics and exporting them to Ravel over OTLP/HTTP,
+  # authenticating with the demo bearer token via the bearertokenauth extension.
+  # This exercises the same OTLP path a real user configures, and the first
+  # Grafana screen shows the reader's own machine.
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:latest
+    depends_on: [ravel-server]
+    command: ["--config=/etc/otel/collector-config.yaml"]
+    volumes:
+      - ../otel/collector-config.yaml:/etc/otel/collector-config.yaml:ro
+
+  # Grafana with a provisioned Prometheus-type datasource pointed at
+  # ravel-server's /api/v1 surface, carrying the demo bearer token (ADR-0081
+  # decision 1). The token lives in a checked-in provisioning file; it is a fixed
+  # development credential in the same class as the MinIO secret above.
+  grafana:
+    image: grafana/grafana:latest
+    depends_on: [ravel-server]
+    ports:
+      - "127.0.0.1:3000:3000"
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+      # No sign-up, no telemetry phone-home: this is a throwaway local instance.
+      GF_USERS_ALLOW_SIGN_UP: "false"
+      GF_ANALYTICS_REPORTING_ENABLED: "false"
+    volumes:
+      - ../grafana/provisioning:/etc/grafana/provisioning:ro
+      - ../grafana/dashboards:/var/lib/grafana/dashboards:ro

--- a/deploy/grafana/dashboards/ravel-overview.json
+++ b/deploy/grafana/dashboards/ravel-overview.json
@@ -1,0 +1,28 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "graphTooltip": 0,
+  "title": "Ravel quickstart: host metrics",
+  "uid": "ravel-quickstart",
+  "schemaVersion": 39,
+  "version": 1,
+  "time": { "from": "now-15m", "to": "now" },
+  "timezone": "browser",
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "CPU load average (1m)",
+      "description": "system.cpu.load_average.1m from the bundled OpenTelemetry Collector's hostmetrics receiver.",
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "ravel" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "ravel" },
+          "expr": "system_cpu_load_average_1m"
+        }
+      ]
+    }
+  ]
+}

--- a/deploy/grafana/provisioning/dashboards/ravel.yaml
+++ b/deploy/grafana/provisioning/dashboards/ravel.yaml
@@ -1,0 +1,13 @@
+# Grafana dashboard provider for the quickstart. Loads the JSON dashboards
+# mounted at /var/lib/grafana/dashboards by deploy/docker-compose/ravel.yml.
+apiVersion: 1
+
+providers:
+  - name: Ravel
+    orgId: 1
+    folder: ""
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /var/lib/grafana/dashboards

--- a/deploy/grafana/provisioning/datasources/ravel.yaml
+++ b/deploy/grafana/provisioning/datasources/ravel.yaml
@@ -1,0 +1,29 @@
+# Grafana datasource provisioning for the quickstart (ADR-0081 decision 1).
+#
+# Ravel serves a Prometheus-compatible query API under /api/v1 on its HTTP
+# listener, so a Prometheus-type datasource pointed at ravel-server drives
+# Grafana directly. Grafana appends `/api/v1/query` (etc.) to the URL, so the
+# URL is the base only.
+#
+# SECURITY: the bearer token below is a fixed development credential
+# (`demo-token`, matching ravel-server's --tenant-token in the compose file). It
+# is checked in on purpose, in the same class as the MinIO dev secret; it is not
+# for any network-reachable deployment.
+apiVersion: 1
+
+datasources:
+  - name: Ravel
+    uid: ravel
+    type: prometheus
+    access: proxy
+    url: http://ravel-server:4318
+    isDefault: true
+    editable: true
+    jsonData:
+      httpHeaderName1: Authorization
+      # ravel's query API is not a scrape target, so keep Grafana from probing
+      # the Prometheus buildinfo endpoint it does not serve.
+      prometheusType: Prometheus
+      timeInterval: 10s
+    secureJsonData:
+      httpHeaderValue1: Bearer demo-token

--- a/deploy/otel/collector-config.yaml
+++ b/deploy/otel/collector-config.yaml
@@ -1,0 +1,47 @@
+# OpenTelemetry Collector config for the container-first quickstart
+# (ADR-0081 decision 3). Scrapes host metrics and exports them to ravel-server
+# over OTLP/HTTP, authenticating with the demo bearer token.
+#
+# SECURITY: `demo-token` is a fixed development credential, matching the
+# `--tenant-token demo-token=demo-tenant` ravel-server runs with in
+# deploy/docker-compose/ravel.yml. It is not a secret and is not for any
+# network-reachable deployment.
+extensions:
+  # Injects `Authorization: Bearer demo-token` on the exporter's requests, the
+  # same tenant credential ravel-server maps to `demo-tenant`.
+  bearertokenauth:
+    scheme: Bearer
+    token: demo-token
+
+receivers:
+  # Only scrapers that read /proc work in a container with no host mounts:
+  # cpu (/proc/stat), load (/proc/loadavg), memory (/proc/meminfo), and
+  # network (/proc/net/dev). disk/filesystem are omitted deliberately; they
+  # need host device mounts the quickstart does not grant.
+  hostmetrics:
+    collection_interval: 10s
+    scrapers:
+      cpu:
+      load:
+      memory:
+      network:
+
+processors:
+  batch:
+
+exporters:
+  # OTLP/HTTP posts to ravel-server's /v1/metrics (the exporter appends the
+  # signal path to this base). Protobuf encoding, which is what
+  # ExportMetricsServiceRequest::decode expects.
+  otlphttp:
+    endpoint: http://ravel-server:4318
+    auth:
+      authenticator: bearertokenauth
+
+service:
+  extensions: [bearertokenauth]
+  pipelines:
+    metrics:
+      receivers: [hostmetrics]
+      processors: [batch]
+      exporters: [otlphttp]

--- a/docs/guides/development.md
+++ b/docs/guides/development.md
@@ -3,6 +3,31 @@
 This guide is for contributors who change Ravel's code. It covers the fast
 local iteration loop and how CI accelerates the same gates.
 
+## Running Ravel from your own build (`make demo`)
+
+The container-first quickstart in the [README](../../README.md) and the
+[getting started guide](getting-started.md) runs a published image and needs no
+toolchain. That is the right path for evaluating Ravel; it is the wrong path
+when you are changing Ravel's code, because it does not run your build.
+
+`make demo` is the from-source path for contributors:
+
+```sh
+make demo
+```
+
+It builds `ravel-server` and `ravel-cli` in release mode from the current tree,
+starts `ravel-server --store s3` against the local MinIO stack, ingests one
+generated OTLP export, and queries it back by commit token
+([scripts/demo.sh](../../scripts/demo.sh)).
+
+One capability difference to keep in mind: the published image is built with
+`--features sql`, so `POST /api/v1/sql` works in the compose quickstart. `make
+demo` builds the default feature set and does **not** enable `sql`, so the SQL
+endpoint is unavailable on the from-source path. PromQL, ingest, and the rest
+are identical on both. To exercise the SQL surface from source, run
+`ravel-server` yourself with `--features sql`, or use the compose quickstart.
+
 ## Fast local iteration
 
 Every commit must pass this gate list (it is also in CLAUDE.md):

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -1,5 +1,81 @@
 # Getting started
 
+There are two ways to run Ravel. The **container-first quickstart** pulls a
+published image and needs only Docker — it is the fastest way to see Ravel
+work, and it is presented first. The **from-source path** (`make demo`) builds
+Ravel from the current tree and is for contributors changing the code; it comes
+second here and is covered in more depth in the
+[development guide](development.md).
+
+One capability difference matters up front: the published image is built with
+`--features sql`, so `POST /api/v1/sql` works in the compose quickstart. `make
+demo` builds the default feature set and does not enable `sql`, so the SQL
+endpoint is unavailable on the from-source path. PromQL and ingest behave the
+same on both.
+
+## Container-first quickstart
+
+The only prerequisite is Docker with `docker compose`. No Rust toolchain.
+
+```sh
+docker compose -f deploy/docker-compose/ravel.yml up -d
+```
+
+This brings up, all from published images:
+
+- MinIO on `127.0.0.1:9000` (S3 API) and `127.0.0.1:9001` (console), plus a
+  one-shot that creates the `ravel-dev` bucket and a one-shot that qualifies the
+  store (ADR-0050 section 6) so `ravel-server` will start against it.
+- `ravel-server` from `ghcr.io/nofireai/ravel-server:0.9.2` (override the pin
+  with the `RAVEL_IMAGE` environment variable), listening on `127.0.0.1:4318`
+  (HTTP/OTLP) and `127.0.0.1:4317` (gRPC/OTLP), with the tenant token
+  `demo-token` mapped to tenant `demo-tenant`.
+- An OpenTelemetry Collector scraping your host's CPU, load, memory, and network
+  metrics and exporting them to Ravel over OTLP, authenticating with the demo
+  bearer token.
+- Grafana on `127.0.0.1:3000` (`admin` / `admin`) with the Ravel datasource
+  already provisioned.
+
+Every published port binds loopback (`127.0.0.1`) only, and every credential is
+a fixed development value (`demo-token`, and `ravel` / `ravel-dev-secret` for
+MinIO). None of it is for a network-reachable deployment.
+
+Open Grafana at <http://127.0.0.1:3000> to see your machine's metrics, or query
+Ravel directly. A PromQL instant query (the bearer token is required, the same
+as ingest):
+
+```sh
+curl -s -H "Authorization: Bearer demo-token" \
+  'http://127.0.0.1:4318/api/v1/query?query=system_cpu_load_average_1m'
+```
+
+SQL over the `samples` (metrics) table, which the image serves out of the box
+because it is built `--features sql`:
+
+```sh
+curl -s -X POST http://127.0.0.1:4318/api/v1/sql \
+  -H "Authorization: Bearer demo-token" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"SELECT * FROM samples LIMIT 5"}'
+```
+
+To watch the read-your-write path end to end — ingest one export, capture its
+`x-ravel-commit-token`, and read that exact write back with `min_commit_token` —
+run [demo/walkthrough.sh](../../demo/walkthrough.sh) while the stack is up. Stop
+everything with:
+
+```sh
+docker compose -f deploy/docker-compose/ravel.yml down
+```
+
+`minio-data/` on your machine persists across runs; the store-qualify one-shot
+is idempotent, so bringing the stack up again on the same directory is safe.
+
+## The from-source path
+
+The rest of this guide builds Ravel from the current tree with `make demo`. Use
+it when you are changing Ravel's code; otherwise the quickstart above is faster.
+
 ## Prerequisites
 
 - Rust, pinned by [`rust-toolchain.toml`](../../rust-toolchain.toml) to


### PR DESCRIPTION
Ravel's documented first run was `make demo`, which triggers `cargo build
--workspace --release` over 26 crates. This repository's own Dockerfile.prebuilt
records that build at 57 minutes cold. Meanwhile ghcr.io/nofireai/ravel-server
has been published, publicly pullable, and cosign-signed since ADR-0037, and the
README advertised it twenty lines below the quickstart that told the reader to
compile instead.

`docker compose up -d` is now the first command. It brings up MinIO, the store
qualification one-shot, ravel-server from the published image, an OpenTelemetry
Collector generating real host metrics, and Grafana with a provisioned
datasource. No Rust toolchain, no cargo invocation.

It also fixes the three copy-pasteable commands in the README that did not work.
The port was 8080 where the default bind is 127.0.0.1:4318, the SQL example
queried a `metrics` table that has never existed (the registered tables are
samples, logs, spans), and the required Authorization header was missing. Each
corrected value was verified against the source rather than the documentation.

The new advisory `quickstart` CI job is what stops that happening again. It
builds this branch's own ravel-server and ravel-cli, assembles an image from
them, brings the stack up, and runs scripts/check-readme-commands.sh over the
README's marked blocks. A wrong port, a missing header, or a table that does not
exist now fails CI instead of failing a stranger. The job is exempt from the
docs_only short-circuit, because a README-only edit is exactly the change it
exists to catch.

Two things ADR-0081 omitted turned up during implementation, both mandatory for
the stack to start at all, and both are included here: a store qualification
one-shot, because ravel-server --store s3 refuses to start without
sys/qualification and has no bootstrap-and-continue path, and
--tenant-hash-unkeyed, because a fresh bucket with no tenant-hash scheme returns
FreshBucketNeedsKey and CI always starts with an empty minio-data/. The ADR will
be amended to record both.

Nothing in this change had ever executed when it was written: the environment it
was authored in has neither docker nor MinIO. This pull request's own quickstart
run is the first real execution, which is the point of the job existing.

Fixes: #175
Refs: #170
