### PR TITLE
feat(ravel-ingest,ravel-server): expose flush cadence as operator setting

### DIFF
--- a/crates/ravel-catalog/src/lib.rs
+++ b/crates/ravel-catalog/src/lib.rs
@@ -46,13 +46,13 @@ pub use key_epoch::{
     epoch_for_write, read_epochs, read_epochs_checked, read_epochs_from_store, record_key_epoch,
 };
 pub use provisioning::{
-    AbsentPolicy, DEFAULT_SCAN_SLACK_HOURS, FloorDefect, FloorRaiseOutcome, FormatFloor,
-    GenerationDefect, MAX_SHARD_COUNT, PROVISIONING_FORMAT_VERSION, ProvisioningCheck,
-    ProvisioningError, ReshardOutcome, ShardGeneration, active_shard_count, append_generation,
-    current_floor, current_floor_from_store, max_scan_count_over_range, provisioning_key,
-    raise_format_floor, read_floors, read_floors_checked, read_floors_from_store, read_generations,
-    read_generations_checked, read_generations_from_store, scan_count, shard_ceiling,
-    validate_or_adopt,
+    AbsentPolicy, DEFAULT_SCAN_SLACK_HOURS, FLUSH_BOUND_SLACK_HOURS, FloorDefect,
+    FloorRaiseOutcome, FormatFloor, GenerationDefect, MAX_SHARD_COUNT, PROVISIONING_FORMAT_VERSION,
+    ProvisioningCheck, ProvisioningError, ReshardOutcome, ShardGeneration, active_shard_count,
+    append_generation, current_floor, current_floor_from_store, max_scan_count_over_range,
+    provisioning_key, raise_format_floor, read_floors, read_floors_checked, read_floors_from_store,
+    read_generations, read_generations_checked, read_generations_from_store, scan_count,
+    shard_ceiling, validate_or_adopt,
 };
 pub use seal_divergence::{
     EntryIdentity, SealDivergenceError, SealDivergenceReport, verify_seal_divergence,

--- a/crates/ravel-catalog/src/provisioning.rs
+++ b/crates/ravel-catalog/src/provisioning.rs
@@ -342,8 +342,11 @@ impl std::fmt::Display for FloorDefect {
 pub const MAX_SHARD_COUNT: u32 = 10_000;
 
 /// The flush-timing component of the read-side scan slack `S`, in ingest
-/// hours: `ceil(max_flush_delay + max_flush_lifetime)` with today's ingest
-/// defaults (`max_flush_delay` 500ms + `max_flush_lifetime` 3600s) = 2. Held
+/// hours: `ceil(max_flush_delay_idle + max_flush_lifetime)` with today's
+/// ingest defaults (`max_flush_delay_idle` 40s + `max_flush_lifetime` 3600s)
+/// = 2. `max_flush_delay_idle`, not `max_flush_delay`, is the real worst-case
+/// buffer age before a forced flush (ADR-0076 decision 4): a buffer with no
+/// strict waiter can age all the way to the idle ceiling. Held
 /// separately from [`TOLERATED_CLOCK_SKEW_HOURS`] so the two components of the
 /// ADR-0052 section 3 formula (below) are each named and independently
 /// reviewable, rather than folded into one unexplained literal.

--- a/crates/ravel-ingest/src/config.rs
+++ b/crates/ravel-ingest/src/config.rs
@@ -170,6 +170,17 @@ pub struct IngestConfig {
     /// (the default) keeps today's fixed-delay behavior for a clean A/B
     /// against the adaptive corridor in the ingest bench.
     pub adaptive_flush_delay: bool,
+    /// Strict-mode visibility budget (ADR-0067 decision 3's corridor
+    /// ceiling, ADR-0076 decision 4): `visibility_ceiling_ns` subtracts two
+    /// PUT round trips plus retry headroom from this to get the adaptive
+    /// corridor's cap. Metrics-only; the log and span actors do not read
+    /// this field. Must follow whatever `max_flush_delay` is actually
+    /// configured to, or the adaptive corridor contradicts the operator's
+    /// chosen visibility budget (a 2s cadence next to a stale 1s corridor
+    /// ceiling being exactly the contradiction the ADR warns against); the
+    /// default therefore matches the new `max_flush_delay` default (2s)
+    /// rather than retaining the old hard-coded 1s value.
+    pub strict_visibility_budget_ns: i64,
 }
 
 impl Default for IngestConfig {
@@ -178,10 +189,16 @@ impl Default for IngestConfig {
             shard_count: 4,
             channel_depth: 256,
             target_bytes: 8 * 1024 * 1024,
-            max_flush_delay: Duration::from_millis(500),
+            // ADR-0076 decision 4: the three flush-cadence knobs move as a
+            // set, scaled 4x together (500ms/10s/64KiB -> 2s/40s/256KiB). At
+            // the ~9.6 KB/s buffer fill rate the ADR measures, 256KiB is
+            // reached in ~27s, comfortably under the new 40s idle ceiling,
+            // so buffered-mode tenants keep the same "size trigger fires
+            // before the idle timer" property they had before the bump.
+            max_flush_delay: Duration::from_secs(2),
             flush_tick: Duration::from_millis(200),
-            max_flush_delay_idle: Duration::from_secs(10),
-            min_flush_bytes: 64 * 1024,
+            max_flush_delay_idle: Duration::from_secs(40),
+            min_flush_bytes: 256 * 1024,
             put_retry_max_attempts: 4,
             put_retry_base_delay: Duration::from_millis(100),
             put_retry_max_delay: Duration::from_secs(2),
@@ -189,6 +206,7 @@ impl Default for IngestConfig {
             exemplar_cap_window_ns: ravel_types::ExemplarCap::DEFAULT_WINDOW_NS,
             max_inflight_flushes: 1,
             adaptive_flush_delay: false,
+            strict_visibility_budget_ns: 2_000_000_000,
         }
     }
 }
@@ -203,10 +221,10 @@ mod tests {
         assert_eq!(cfg.shard_count, 4);
         assert_eq!(cfg.channel_depth, 256);
         assert_eq!(cfg.target_bytes, 8 * 1024 * 1024);
-        assert_eq!(cfg.max_flush_delay, Duration::from_millis(500));
+        assert_eq!(cfg.max_flush_delay, Duration::from_secs(2));
         assert_eq!(cfg.flush_tick, Duration::from_millis(200));
-        assert_eq!(cfg.max_flush_delay_idle, Duration::from_secs(10));
-        assert_eq!(cfg.min_flush_bytes, 64 * 1024);
+        assert_eq!(cfg.max_flush_delay_idle, Duration::from_secs(40));
+        assert_eq!(cfg.min_flush_bytes, 256 * 1024);
         assert_eq!(cfg.put_retry_max_attempts, 4);
         assert_eq!(cfg.put_retry_base_delay, Duration::from_millis(100));
         assert_eq!(cfg.put_retry_max_delay, Duration::from_secs(2));
@@ -221,6 +239,9 @@ mod tests {
         // behavior bit for bit; the flip to 3 is a later measured decision.
         assert_eq!(cfg.max_inflight_flushes, 1);
         assert!(!cfg.adaptive_flush_delay);
+        // ADR-0076 decision 4: must follow the new max_flush_delay default
+        // (2s), not the old hard-coded 1s STRICT_VISIBILITY_BUDGET_NS.
+        assert_eq!(cfg.strict_visibility_budget_ns, 2_000_000_000);
     }
 
     #[test]

--- a/crates/ravel-ingest/src/config.rs
+++ b/crates/ravel-ingest/src/config.rs
@@ -34,6 +34,19 @@ pub const SPAN_SEGMENT_FORMAT_VERSION: u16 = ravel_rspan::footer::VERSION;
 /// Nanoseconds per hour, the unit `ingest_hour_bucket` counts in.
 pub(crate) const NS_PER_HOUR: i64 = 3_600_000_000_000;
 
+/// Reserve `strict_visibility_budget_ns` must exceed `max_flush_delay` by
+/// (ADR-0076 decision 4): two PUT round trips (data object, then commit
+/// record) plus one retry's base backoff, with margin. `visibility_ceiling_ns`
+/// subtracts those same costs from the budget to get the adaptive corridor's
+/// cap; setting the budget equal to `max_flush_delay` (as the pre-fix default
+/// and the `ravel-server` call site both did) leaves nothing for that
+/// subtraction to work with, so the ceiling collapses to the floor
+/// unconditionally and `FlushTrigger::AgeAdaptive` becomes unreachable. This
+/// preserves the same absolute corridor width the original hard-coded values
+/// had (1s budget over a 500ms floor = 500ms of headroom before RTT/retry
+/// subtraction).
+pub const STRICT_VISIBILITY_RESERVE_NS: i64 = 500_000_000;
+
 /// Receiver-clock plausibility floor: 2020-01-01T00:00:00Z in nanoseconds
 /// (ADR-0051 amendment). No host legitimately
 /// runs Ravel with a clock reading before the system existed, so a reading
@@ -185,17 +198,18 @@ pub struct IngestConfig {
 
 impl Default for IngestConfig {
     fn default() -> Self {
+        // ADR-0076 decision 4: the three flush-cadence knobs move as a
+        // set, scaled 4x together (500ms/10s/64KiB -> 2s/40s/256KiB). At
+        // the ~9.6 KB/s buffer fill rate the ADR measures, 256KiB is
+        // reached in ~27s, comfortably under the new 40s idle ceiling,
+        // so buffered-mode tenants keep the same "size trigger fires
+        // before the idle timer" property they had before the bump.
+        let max_flush_delay = Duration::from_secs(2);
         IngestConfig {
             shard_count: 4,
             channel_depth: 256,
             target_bytes: 8 * 1024 * 1024,
-            // ADR-0076 decision 4: the three flush-cadence knobs move as a
-            // set, scaled 4x together (500ms/10s/64KiB -> 2s/40s/256KiB). At
-            // the ~9.6 KB/s buffer fill rate the ADR measures, 256KiB is
-            // reached in ~27s, comfortably under the new 40s idle ceiling,
-            // so buffered-mode tenants keep the same "size trigger fires
-            // before the idle timer" property they had before the bump.
-            max_flush_delay: Duration::from_secs(2),
+            max_flush_delay,
             flush_tick: Duration::from_millis(200),
             max_flush_delay_idle: Duration::from_secs(40),
             min_flush_bytes: 256 * 1024,
@@ -206,7 +220,12 @@ impl Default for IngestConfig {
             exemplar_cap_window_ns: ravel_types::ExemplarCap::DEFAULT_WINDOW_NS,
             max_inflight_flushes: 1,
             adaptive_flush_delay: false,
-            strict_visibility_budget_ns: 2_000_000_000,
+            // Must exceed max_flush_delay by STRICT_VISIBILITY_RESERVE_NS, not
+            // equal it: equal leaves visibility_ceiling_ns's subtraction with
+            // no headroom, collapsing the adaptive corridor to the floor
+            // unconditionally.
+            strict_visibility_budget_ns: max_flush_delay.as_nanos() as i64
+                + STRICT_VISIBILITY_RESERVE_NS,
         }
     }
 }
@@ -239,9 +258,13 @@ mod tests {
         // behavior bit for bit; the flip to 3 is a later measured decision.
         assert_eq!(cfg.max_inflight_flushes, 1);
         assert!(!cfg.adaptive_flush_delay);
-        // ADR-0076 decision 4: must follow the new max_flush_delay default
-        // (2s), not the old hard-coded 1s STRICT_VISIBILITY_BUDGET_NS.
-        assert_eq!(cfg.strict_visibility_budget_ns, 2_000_000_000);
+        // ADR-0076 decision 4: must exceed the max_flush_delay default (2s)
+        // by STRICT_VISIBILITY_RESERVE_NS, not equal it -- equal collapses
+        // the adaptive corridor to the floor unconditionally.
+        assert_eq!(
+            cfg.strict_visibility_budget_ns,
+            cfg.max_flush_delay.as_nanos() as i64 + STRICT_VISIBILITY_RESERVE_NS
+        );
     }
 
     #[test]

--- a/crates/ravel-ingest/src/lib.rs
+++ b/crates/ravel-ingest/src/lib.rs
@@ -38,7 +38,8 @@ pub use budget::{IngestByteBudget, IngestByteBudgetLimit, IngestByteCharge, Inge
 pub use clock::{Clock, SystemClock};
 pub use config::{
     IngestConfig, LOG_SEGMENT_FORMAT_VERSION, MIN_PLAUSIBLE_INGEST_CLOCK_NS,
-    SEGMENT_FORMAT_VERSION, SPAN_SEGMENT_FORMAT_VERSION, plausible_ingest_clock,
+    SEGMENT_FORMAT_VERSION, SPAN_SEGMENT_FORMAT_VERSION, STRICT_VISIBILITY_RESERVE_NS,
+    plausible_ingest_clock,
 };
 pub use error::WriteError;
 pub use generation::{DEFAULT_REFRESH_INTERVAL_NS, GenerationSwitch, Routed};

--- a/crates/ravel-ingest/src/shard.rs
+++ b/crates/ravel-ingest/src/shard.rs
@@ -373,8 +373,8 @@ fn visibility_ceiling_ns(
 
 /// The adaptive age threshold for one (shard, tenant): the tenant's observed
 /// inter-arrival gap, clamped into `[floor_ns, ceiling_ns]`. A bursty tenant
-/// (small gap) clamps up to `floor_ns` -- today's fixed 500 ms behavior,
-/// unchanged; a trickle tenant (large gap) clamps down to `ceiling_ns`
+/// (small gap) clamps up to `floor_ns` -- the fixed `max_flush_delay`
+/// behavior, unchanged; a trickle tenant (large gap) clamps down to `ceiling_ns`
 /// instead of waiting indefinitely for a full `target_bytes` batch.
 fn adaptive_age_threshold_ns(avg_gap_ns: i64, floor_ns: i64, ceiling_ns: i64) -> i64 {
     avg_gap_ns.clamp(floor_ns, ceiling_ns)
@@ -1023,8 +1023,8 @@ impl ShardActor {
     /// section 7). Strict-mode ack latency is unaffected: a strict
     /// write always leaves `waiters` non-empty for its whole flush window.
     ///
-    /// The fast clock itself is either the fixed `max_flush_delay` (today's
-    /// 500 ms, and always the value used when `adaptive_flush_delay` is
+    /// The fast clock itself is either the fixed `max_flush_delay` (2 s
+    /// default, and always the value used when `adaptive_flush_delay` is
     /// off) or, with adaptive delay on, a per-tenant threshold within
     /// `[max_flush_delay, ceiling]` derived from this tenant's observed
     /// arrival rate and this shard's observed PUT RTT (ADR-0067 decision 3).
@@ -1238,7 +1238,7 @@ impl ShardActor {
 
 #[cfg(test)]
 mod adaptive_delay_tests {
-    use super::{adaptive_age_threshold_ns, visibility_ceiling_ns};
+    use super::{IngestConfig, adaptive_age_threshold_ns, visibility_ceiling_ns};
 
     const FLOOR_NS: i64 = 500_000_000;
     const RETRY_HEADROOM_NS: i64 = 100_000_000;
@@ -1340,5 +1340,36 @@ mod adaptive_delay_tests {
             ceiling_ns,
             "the corridor must cap a large observed gap at the ceiling, not pass it through"
         );
+    }
+
+    /// Regression for the checkpoint-review bug: `IngestConfig::default()`
+    /// once set `strict_visibility_budget_ns` exactly equal to
+    /// `max_flush_delay`, so `visibility_ceiling_ns`'s subtraction always
+    /// left the ceiling at the floor regardless of RTT, making
+    /// `FlushTrigger::AgeAdaptive` permanently unreachable. Built on
+    /// `IngestConfig::default()` directly (not a hand-assembled config the
+    /// real server can never build), across a range of plausible observed
+    /// RTTs, so a regression in the real default is what this test would
+    /// catch.
+    #[test]
+    fn default_config_visibility_ceiling_clears_the_floor() {
+        let cfg = IngestConfig::default();
+        let floor_ns = cfg.max_flush_delay.as_nanos() as i64;
+        let retry_headroom_ns = cfg.put_retry_base_delay.as_nanos() as i64;
+        for rtt_p99_ns in [0i64, 10_000_000, 50_000_000] {
+            let ceiling_ns = visibility_ceiling_ns(
+                floor_ns,
+                Some(rtt_p99_ns),
+                retry_headroom_ns,
+                cfg.strict_visibility_budget_ns,
+            );
+            assert!(
+                ceiling_ns > floor_ns,
+                "IngestConfig::default()'s visibility_ceiling_ns must clear max_flush_delay's \
+                 floor ({floor_ns}ns) at rtt_p99_ns={rtt_p99_ns}, got {ceiling_ns}ns -- a \
+                 strict_visibility_budget_ns equal to max_flush_delay collapses the corridor \
+                 unconditionally"
+            );
+        }
     }
 }

--- a/crates/ravel-ingest/src/shard.rs
+++ b/crates/ravel-ingest/src/shard.rs
@@ -345,24 +345,27 @@ impl RttTracker {
     }
 }
 
-/// Strict-mode visibility p99 budget the adaptive ceiling is derived from
-/// (ADR-0067 decision 3, docs/consistency-model.md's strict-mode ack
-/// contract), never a free-standing constant chosen for this feature alone.
-const STRICT_VISIBILITY_BUDGET_NS: i64 = 1_000_000_000;
-
-/// Corridor ceiling for the adaptive age trigger: the strict visibility
-/// budget minus two PUT round trips (data object, then commit record) at
+/// Corridor ceiling for the adaptive age trigger: `budget_ns` (the caller's
+/// `IngestConfig::strict_visibility_budget_ns`, ADR-0067 decision 3 /
+/// ADR-0076 decision 4, docs/consistency-model.md's strict-mode ack
+/// contract -- never a free-standing constant chosen for this feature
+/// alone) minus two PUT round trips (data object, then commit record) at
 /// their observed p99, minus one retry's base backoff as headroom, floored
 /// at `floor_ns` so the corridor never inverts. `None` RTT (no observations
 /// yet) collapses the ceiling to `floor_ns`: with nothing measured,
 /// adapting upward would be a guess the budget cannot back, and a bursty
 /// tenant must keep today's behavior from the first flush, not just after
 /// warm-up.
-fn visibility_ceiling_ns(floor_ns: i64, rtt_p99_ns: Option<i64>, retry_headroom_ns: i64) -> i64 {
+fn visibility_ceiling_ns(
+    floor_ns: i64,
+    rtt_p99_ns: Option<i64>,
+    retry_headroom_ns: i64,
+    budget_ns: i64,
+) -> i64 {
     let Some(rtt_p99_ns) = rtt_p99_ns else {
         return floor_ns;
     };
-    let ceiling = STRICT_VISIBILITY_BUDGET_NS
+    let ceiling = budget_ns
         .saturating_sub(2 * rtt_p99_ns)
         .saturating_sub(retry_headroom_ns);
     ceiling.max(floor_ns)
@@ -1042,7 +1045,12 @@ impl ShardActor {
             return (floor_ns, FlushTrigger::Age);
         }
         let retry_headroom_ns = self.config.put_retry_base_delay.as_nanos() as i64;
-        let ceiling_ns = visibility_ceiling_ns(floor_ns, self.rtt.p99_ns(), retry_headroom_ns);
+        let ceiling_ns = visibility_ceiling_ns(
+            floor_ns,
+            self.rtt.p99_ns(),
+            retry_headroom_ns,
+            self.config.strict_visibility_budget_ns,
+        );
         let threshold_ns = adaptive_age_threshold_ns(buf.avg_gap_ns, floor_ns, ceiling_ns);
         let trigger = if threshold_ns > floor_ns {
             FlushTrigger::AgeAdaptive
@@ -1230,10 +1238,14 @@ impl ShardActor {
 
 #[cfg(test)]
 mod adaptive_delay_tests {
-    use super::{STRICT_VISIBILITY_BUDGET_NS, adaptive_age_threshold_ns, visibility_ceiling_ns};
+    use super::{adaptive_age_threshold_ns, visibility_ceiling_ns};
 
     const FLOOR_NS: i64 = 500_000_000;
     const RETRY_HEADROOM_NS: i64 = 100_000_000;
+    // Mirrors `IngestConfig::default().strict_visibility_budget_ns`
+    // (ADR-0076 decision 4); not read from `IngestConfig` directly since
+    // these tests exercise the pure corridor functions in isolation.
+    const BUDGET_NS: i64 = 2_000_000_000;
 
     /// ADR-0067 decision 3's corridor, `[max_flush_delay, ceiling]`, exercised
     /// directly against the two pure functions it is built from rather than
@@ -1256,17 +1268,18 @@ mod adaptive_delay_tests {
         // trickle tenant gets today's fixed-delay behavior until at least
         // one PUT has been timed.
         assert_eq!(
-            visibility_ceiling_ns(FLOOR_NS, None, RETRY_HEADROOM_NS),
+            visibility_ceiling_ns(FLOOR_NS, None, RETRY_HEADROOM_NS, BUDGET_NS),
             FLOOR_NS
         );
 
-        // A cheap, fast backend leaves most of the 1s strict-visibility
+        // A cheap, fast backend leaves most of the 2s strict-visibility
         // budget spare, so the ceiling sits well above the floor.
         let cheap_rtt_ns = 50_000_000; // 50ms
-        let ceiling_cheap = visibility_ceiling_ns(FLOOR_NS, Some(cheap_rtt_ns), RETRY_HEADROOM_NS);
+        let ceiling_cheap =
+            visibility_ceiling_ns(FLOOR_NS, Some(cheap_rtt_ns), RETRY_HEADROOM_NS, BUDGET_NS);
         assert_eq!(
             ceiling_cheap,
-            STRICT_VISIBILITY_BUDGET_NS - 2 * cheap_rtt_ns - RETRY_HEADROOM_NS
+            BUDGET_NS - 2 * cheap_rtt_ns - RETRY_HEADROOM_NS
         );
         assert!(ceiling_cheap > FLOOR_NS);
 
@@ -1274,7 +1287,7 @@ mod adaptive_delay_tests {
         // into the budget, so the ceiling shrinks monotonically.
         let pricier_rtt_ns = 200_000_000; // 200ms
         let ceiling_pricier =
-            visibility_ceiling_ns(FLOOR_NS, Some(pricier_rtt_ns), RETRY_HEADROOM_NS);
+            visibility_ceiling_ns(FLOOR_NS, Some(pricier_rtt_ns), RETRY_HEADROOM_NS, BUDGET_NS);
         assert!(
             ceiling_pricier < ceiling_cheap,
             "a slower observed backend must narrow the corridor, not widen it"
@@ -1283,9 +1296,14 @@ mod adaptive_delay_tests {
         // A backend slow enough that 2*rtt plus retry headroom would eat the
         // whole budget (or overshoot it) must never invert the corridor: the
         // ceiling is floored at floor_ns, exactly like the None case.
-        let very_slow_rtt_ns = 600_000_000; // 600ms: 2*rtt alone exceeds the 1s budget
+        let very_slow_rtt_ns = 1_100_000_000; // 1.1s: 2*rtt alone exceeds the 2s budget
         assert_eq!(
-            visibility_ceiling_ns(FLOOR_NS, Some(very_slow_rtt_ns), RETRY_HEADROOM_NS),
+            visibility_ceiling_ns(
+                FLOOR_NS,
+                Some(very_slow_rtt_ns),
+                RETRY_HEADROOM_NS,
+                BUDGET_NS
+            ),
             FLOOR_NS,
             "a corridor that inverted (ceiling < floor) would make an already-slow \
              backend flush even less often; the floor must win"

--- a/docs/consistency-model.md
+++ b/docs/consistency-model.md
@@ -30,8 +30,10 @@ rejected point counts and reasons.
 - A batch becomes visible to queries when its commit record exists; commit
   record creation is atomic (create-if-absent), so visibility is atomic per
   L0 object.
-- Visibility latency = flush delay + data PUT + commit PUT. The p99 target in
-  strict mode under target load is < 1 s.
+- Visibility latency = flush delay + data PUT + commit PUT. The flush delay
+  is a configurable operator budget (`--max-flush-delay`), default 2 s in
+  strict mode (ADR-0076 decision 4); the p99 visibility target under target
+  load tracks that budget, not a fixed sub-second constant.
 - There is no cross-shard ordering guarantee. A query snapshot may include
   commit N+1 of shard A and not commit M of shard B, regardless of wall-clock
   order. Per (writer, shard), commits are sequenced by `seq`.

--- a/docs/ingest.md
+++ b/docs/ingest.md
@@ -177,9 +177,9 @@ Loop over `select!`:
   (ADR-0005 fail-loud rule).
 - flush tick (interval default 200 ms): flush if `oldest_ns` older than an
   age threshold, and buffer non-empty. The threshold is `max_flush_delay`
-  (default 500 ms) when the buffer has a strict-mode waiter or already holds
-  at least `min_flush_bytes` (default 64 KiB); otherwise the buffer is idle
-  and the threshold is `max_flush_delay_idle` (default 10 s) instead
+  (default 2 s) when the buffer has a strict-mode waiter or already holds
+  at least `min_flush_bytes` (default 256 KiB); otherwise the buffer is idle
+  and the threshold is `max_flush_delay_idle` (default 40 s) instead
   (ADR-0051 section 7). Strict-mode ack latency is unaffected, since a
   strict write always leaves a waiter in the buffer for its whole flush
   window; only a low-volume buffered-mode tenant's PUT cadence changes.
@@ -278,9 +278,10 @@ flush task, and the same shutdown join. Only the adaptive flush delay
 or already past `min_flush_bytes`, with a per-(shard, tenant) threshold
 clamped into a corridor `[max_flush_delay, ceiling]`:
 
-- **Floor**: `max_flush_delay` (500 ms default), unchanged from today.
-- **Ceiling**: the strict-mode visibility budget (1 s, the same budget
-  docs/consistency-model.md's strict-mode ack contract names) minus two
+- **Floor**: `max_flush_delay` (2 s default), unchanged from today.
+- **Ceiling**: the strict-mode visibility budget (`IngestConfig::strict_visibility_budget_ns`,
+  2 s default, following `max_flush_delay` -- ADR-0076 decision 4; the same
+  budget docs/consistency-model.md's strict-mode ack contract names) minus two
   PUT round trips at their observed p99 (data object, then commit
   record) minus one retry's base backoff as headroom, floored at
   `max_flush_delay` so the corridor never inverts. With no PUT RTT
@@ -603,9 +604,9 @@ carries max token per shard).
 | shard_count | 4 (dev), scale with cores |
 | channel depth | 256 msgs |
 | target_bytes | 8 MiB |
-| max_flush_delay | 500 ms |
-| max_flush_delay_idle | 10 s |
-| min_flush_bytes | 64 KiB |
+| max_flush_delay | 2 s (`--max-flush-delay`) |
+| max_flush_delay_idle | 40 s (`--max-flush-delay-idle`) |
+| min_flush_bytes | 256 KiB (`--min-flush-bytes`) |
 | put retry budget | 4 attempts, 100ms..2s jittered backoff |
 | max in-flight ingest requests (process-wide) | 1024 (`--max-inflight-ingest-requests`, 0 = unlimited) |
 | max ingest buffer bytes (process-wide, all signals) | 512 MiB (`--max-ingest-buffer-bytes`, 0 = unlimited) |

--- a/docs/ingest.md
+++ b/docs/ingest.md
@@ -280,17 +280,20 @@ clamped into a corridor `[max_flush_delay, ceiling]`:
 
 - **Floor**: `max_flush_delay` (2 s default), unchanged from today.
 - **Ceiling**: the strict-mode visibility budget (`IngestConfig::strict_visibility_budget_ns`,
-  2 s default, following `max_flush_delay` -- ADR-0076 decision 4; the same
-  budget docs/consistency-model.md's strict-mode ack contract names) minus two
+  2.5 s default -- `max_flush_delay` plus `STRICT_VISIBILITY_RESERVE_NS` (500 ms),
+  following `max_flush_delay` -- ADR-0076 decision 4; the same budget
+  docs/consistency-model.md's strict-mode ack contract names) minus two
   PUT round trips at their observed p99 (data object, then commit
   record) minus one retry's base backoff as headroom, floored at
-  `max_flush_delay` so the corridor never inverts. With no PUT RTT
-  observed yet, the ceiling collapses to the floor: adapting upward
-  would be a guess the budget cannot back, so a tenant sees today's
-  fixed 500 ms from its very first flush, not just after warm-up. RTT is
-  sampled from both PUTs of every flush (from spawned tasks, concurrently
-  with the actor and with each other), kept as a bounded p99 estimate
-  (last 64 samples) per shard.
+  `max_flush_delay` so the corridor never inverts. The reserve keeps the
+  corridor's width non-zero: a budget set exactly equal to `max_flush_delay`
+  would leave the subtraction nothing to work with, collapsing the ceiling to
+  the floor unconditionally. With no PUT RTT observed yet, the ceiling still
+  collapses to the floor: adapting upward would be a guess the budget cannot
+  back, so a tenant sees the fixed `max_flush_delay` from its very first
+  flush, not just after warm-up. RTT is sampled from both PUTs of every flush
+  (from spawned tasks, concurrently with the actor and with each other), kept
+  as a bounded p99 estimate (last 64 samples) per shard.
 - **Threshold**: the tenant's own observed inter-arrival gap, clamped
   into `[floor, ceiling]`. A bursty tenant (small gap) clamps up to the
   floor -- today's behavior, unchanged. A trickle tenant (large gap)

--- a/services/ravel-server/src/config.rs
+++ b/services/ravel-server/src/config.rs
@@ -809,15 +809,19 @@ pub struct FlushCadence {
     pub min_flush_bytes: usize,
 }
 
-/// Upper bound on `--max-flush-delay` derived from the read-side scan-slack
-/// arithmetic `ravel_catalog::FLUSH_BOUND_SLACK_HOURS` encodes (ADR-0076
-/// decision 4): `FLUSH_BOUND_SLACK_HOURS` is `ceil(max_flush_delay +
+/// Upper bound on `--max-flush-delay-idle` derived from the read-side
+/// scan-slack arithmetic `ravel_catalog::FLUSH_BOUND_SLACK_HOURS` encodes
+/// (ADR-0076 decision 4): `FLUSH_BOUND_SLACK_HOURS` is `ceil(max_flush_delay +
 /// max_flush_lifetime)` at the defaults it was last derived against, and
 /// governs how long the read side keeps scanning a retiring shard-count
-/// generation after an activation (docs/catalog-and-mvcc.md). Raising
-/// `--max-flush-delay` past what keeps that sum under
-/// `FLUSH_BOUND_SLACK_HOURS` hours would silently shrink the straggler
-/// window below what a flush can actually take, without `S`
+/// generation after an activation (docs/catalog-and-mvcc.md). The real
+/// worst-case buffer age before a forced flush is `max_flush_delay_idle` (the
+/// ceiling for a buffer with no strict waiter), not `max_flush_delay` (the
+/// fast-tier floor); [`Cli::validate`]'s tier-ordering check guarantees
+/// `max_flush_delay_idle >= max_flush_delay`, so it is always the correct
+/// bound to use here. Raising `--max-flush-delay-idle` past what keeps that
+/// sum under `FLUSH_BOUND_SLACK_HOURS` hours would silently shrink the
+/// straggler window below what a flush can actually take, without `S`
 /// (`ravel_catalog::DEFAULT_SCAN_SLACK_HOURS`) ever being told to grow to
 /// compensate -- a straggler flush pinned under a retiring generation could
 /// then land outside the window the read side still scans, an invisibility
@@ -1698,33 +1702,78 @@ impl Cli {
         // flush.
         let flush_cadence = self.resolve_flush_cadence()?;
 
-        let flush_bound_ns = flush_cadence.max_flush_delay.as_nanos() as i64
+        // ADR-0076 decision 4: the idle tier (no strict waiter, below
+        // min_flush_bytes) must never flush faster than the fast tier (a
+        // strict waiter present, or already at min_flush_bytes) -- strict
+        // acks are supposed to be the fast path. Equal is fine (both tiers
+        // then share one threshold); only a strictly smaller idle ceiling
+        // inverts the design.
+        if flush_cadence.max_flush_delay_idle < flush_cadence.max_flush_delay {
+            anyhow::bail!(
+                "--max-flush-delay-idle {:?} is less than --max-flush-delay {:?}: the idle/no- \
+                 waiter tier would flush faster than the strict/waiter-present tier, inverting \
+                 ADR-0076 decision 4's design where strict acks are the fast path. Raise \
+                 --max-flush-delay-idle to at least --max-flush-delay.",
+                flush_cadence.max_flush_delay_idle,
+                flush_cadence.max_flush_delay,
+            );
+        }
+
+        // Bug3's check above makes max_flush_delay_idle the validated
+        // larger-or-equal worst-case bound: a buffer with no strict waiter is
+        // the one that can age all the way to max_flush_delay_idle before a
+        // forced flush, so that (not max_flush_delay, the fast-tier floor) is
+        // the real worst-case age FLUSH_BOUND_SLACK_HOURS must cover.
+        let flush_bound_ns = flush_cadence.max_flush_delay_idle.as_nanos() as i64
             + ravel_ingest::IngestConfig::default()
                 .max_flush_lifetime
                 .as_nanos() as i64;
         if flush_bound_ns > FLUSH_BOUND_SLACK_HOURS_NS {
             anyhow::bail!(
-                "--max-flush-delay {:?} plus the ingest pipeline's max_flush_lifetime ({:?}) \
+                "--max-flush-delay-idle {:?} plus the ingest pipeline's max_flush_lifetime ({:?}) \
                  exceeds FLUSH_BOUND_SLACK_HOURS ({} h): the read-side scan slack \
                  ravel_catalog::FLUSH_BOUND_SLACK_HOURS encodes would no longer cover a \
                  straggler flush pinned under a retiring shard-count generation, an \
-                 invisibility hazard. Lower --max-flush-delay, or revisit \
+                 invisibility hazard. Lower --max-flush-delay-idle, or revisit \
                  FLUSH_BOUND_SLACK_HOURS in ravel-catalog in lockstep (ADR-0076 decision 4).",
-                flush_cadence.max_flush_delay,
+                flush_cadence.max_flush_delay_idle,
                 ravel_ingest::IngestConfig::default().max_flush_lifetime,
                 ravel_catalog::FLUSH_BOUND_SLACK_HOURS,
             );
         }
 
-        if flush_cadence.max_flush_delay.as_nanos() as i64 > MAX_STRICT_VISIBILITY_BUDGET_NS {
+        let strict_visibility_budget_ns = flush_cadence.max_flush_delay.as_nanos() as i64
+            + ravel_ingest::STRICT_VISIBILITY_RESERVE_NS;
+        if strict_visibility_budget_ns >= MAX_STRICT_VISIBILITY_BUDGET_NS {
             anyhow::bail!(
-                "--max-flush-delay {:?} exceeds MAX_STRICT_VISIBILITY_BUDGET_NS ({}s): in strict \
-                 mode a client waits for the flush delay plus two PUT round trips before its ack \
-                 returns, and a value this high risks the OTLP client's own export timeout \
-                 firing first, producing retries and duplicate logs/spans instead of the fewer \
-                 requests this ADR is for. Lower --max-flush-delay.",
+                "--max-flush-delay {:?} derives a strict_visibility_budget_ns of {:?}ns, which \
+                 meets or exceeds MAX_STRICT_VISIBILITY_BUDGET_NS ({}s): in strict mode a client \
+                 waits for that budget plus two PUT round trips before its ack returns, and a \
+                 value this high risks the OTLP client's own export timeout firing first, \
+                 producing retries and duplicate logs/spans instead of the fewer requests this \
+                 ADR is for. Lower --max-flush-delay.",
                 flush_cadence.max_flush_delay,
+                strict_visibility_budget_ns,
                 MAX_STRICT_VISIBILITY_BUDGET_NS as f64 / 1e9,
+            );
+        }
+
+        // `target_bytes` (8 MiB default, ADR-0076's size-trigger that never
+        // fires at realistic loads) is not itself an operator-facing flag in
+        // this ADR's scope, so compare against its compiled-in default, the
+        // same pattern the FLUSH_BOUND_SLACK_HOURS check above uses for
+        // max_flush_lifetime. A `min_flush_bytes` at or above it makes the
+        // idle-tier byte-priority trigger unreachable, defeating its
+        // purpose.
+        let target_bytes = ravel_ingest::IngestConfig::default().target_bytes;
+        if flush_cadence.min_flush_bytes >= target_bytes {
+            anyhow::bail!(
+                "--min-flush-bytes {} meets or exceeds the ingest pipeline's target_bytes ({}): \
+                 a buffer would always hit target_bytes' own size trigger before it could ever \
+                 be treated as idle, making the min_flush_bytes byte-priority trigger \
+                 unreachable. Lower --min-flush-bytes below target_bytes.",
+                flush_cadence.min_flush_bytes,
+                target_bytes,
             );
         }
 
@@ -3079,38 +3128,32 @@ mod tests {
             .expect("all three omitted must fall back to IngestConfig::default()");
     }
 
-    /// ADR-0076 decision 4: a `--max-flush-delay` that, combined with the
-    /// ingest pipeline's fixed `max_flush_lifetime`, exceeds
+    /// ADR-0076 decision 4: a `--max-flush-delay-idle` that, combined with
+    /// the ingest pipeline's fixed `max_flush_lifetime`, exceeds
     /// `ravel_catalog::FLUSH_BOUND_SLACK_HOURS` must fail startup, not
     /// silently under-cover a straggler flush pinned under a retiring
-    /// shard-count generation.
-    ///
-    /// Proof this test can fail: with the `flush_bound_ns >
-    /// FLUSH_BOUND_SLACK_HOURS_NS` check at src/config.rs:1714 disabled
-    /// (guarded with `if false &&`), `cli.validate()` still returned `Err`
-    /// -- 3601s also trips the separate MAX_STRICT_VISIBILITY_BUDGET_NS
-    /// check below it -- but the message assertion caught the missing
-    /// check specifically: the panic was "expected a FLUSH_BOUND_SLACK_HOURS
-    /// error, got: --max-flush-delay 3601s exceeds
-    /// MAX_STRICT_VISIBILITY_BUDGET_NS (3s): ...". Restoring the check made
-    /// it pass again.
+    /// shard-count generation. The bound is computed from
+    /// `max_flush_delay_idle` (the real worst-case buffer age), not
+    /// `max_flush_delay` (the fast-tier floor) -- Bug 4's fix.
     #[test]
     fn flush_delay_exceeding_flush_bound_slack_hours_is_rejected_at_startup() {
         // FLUSH_BOUND_SLACK_HOURS is 2h = 7200s; max_flush_lifetime defaults
-        // to 3600s, so 3601s of --max-flush-delay pushes the sum to 7201s,
-        // one second over the ceiling.
+        // to 3600s, so an idle ceiling of 3601s pushes the sum to 7201s, one
+        // second over the ceiling. --max-flush-delay stays small so this
+        // exercises the idle-based bound, not the (still-present) delay-based
+        // strict-visibility-budget check below.
         let cli = Cli::try_parse_from([
             "ravel-server",
             "--max-flush-delay",
-            "3601s",
+            "1s",
             "--max-flush-delay-idle",
-            "2h",
+            "3601s",
             "--min-flush-bytes",
             "131072",
         ])
         .expect("flags parse at the CLI layer");
         let err = cli.validate().expect_err(
-            "startup must reject --max-flush-delay 3601s: exceeds FLUSH_BOUND_SLACK_HOURS",
+            "startup must reject --max-flush-delay-idle 3601s: exceeds FLUSH_BOUND_SLACK_HOURS",
         );
         assert!(
             err.to_string().contains("FLUSH_BOUND_SLACK_HOURS"),
@@ -3118,22 +3161,93 @@ mod tests {
         );
     }
 
-    /// ADR-0076 decision 4: a `--max-flush-delay` exceeding
-    /// `MAX_STRICT_VISIBILITY_BUDGET_NS` (the smallest OTLP client timeout
-    /// minus an assumed PUT p99 tail) must fail startup, since it risks the
-    /// client's own export timeout firing before the strict ack returns.
-    ///
-    /// Proof this test can fail: with the max-flush-delay-exceeds-budget
-    /// check at src/config.rs:1728 disabled (guarded with `if false &&`),
-    /// this test failed with "startup must reject --max-flush-delay 4s:
-    /// exceeds MAX_STRICT_VISIBILITY_BUDGET_NS" because `cli.validate()`
-    /// returned `Ok(())` instead of erroring. Restoring the check made it
-    /// pass again.
+    /// Bug 4 regression: before the fix, `flush_bound_ns` was computed from
+    /// `max_flush_delay` alone, so a `--max-flush-delay-idle` of 5h (a real
+    /// operator-facing flag with no upper bound of its own) passed every
+    /// existing check -- an invisibility hazard for a decrease-reshard
+    /// straggler. `--max-flush-delay` here is small enough (1s) that only the
+    /// idle knob can trip the bound, so this exercises the fixed line, not
+    /// the pre-existing `max_flush_delay`-only path.
+    #[test]
+    fn flush_delay_idle_exceeding_flush_bound_slack_hours_is_rejected_at_startup() {
+        let cli = Cli::try_parse_from([
+            "ravel-server",
+            "--max-flush-delay",
+            "1s",
+            "--max-flush-delay-idle",
+            "5h",
+            "--min-flush-bytes",
+            "131072",
+        ])
+        .expect("flags parse at the CLI layer");
+        let err = cli.validate().expect_err(
+            "startup must reject --max-flush-delay-idle 5h: exceeds FLUSH_BOUND_SLACK_HOURS",
+        );
+        assert!(
+            err.to_string().contains("FLUSH_BOUND_SLACK_HOURS"),
+            "expected a FLUSH_BOUND_SLACK_HOURS error, got: {err}"
+        );
+    }
+
+    /// Bug 3 regression: the idle tier must never flush faster than the
+    /// strict/waiter-present tier, since strict acks are supposed to be the
+    /// fast path. `max_flush_delay_idle < max_flush_delay` must fail startup.
+    #[test]
+    fn flush_delay_idle_below_flush_delay_is_rejected_at_startup() {
+        let cli = Cli::try_parse_from([
+            "ravel-server",
+            "--max-flush-delay",
+            "3s",
+            "--max-flush-delay-idle",
+            "1s",
+            "--min-flush-bytes",
+            "262144",
+        ])
+        .expect("flags parse at the CLI layer");
+        let err = cli
+            .validate()
+            .expect_err("startup must reject --max-flush-delay-idle 1s < --max-flush-delay 3s");
+        assert!(
+            err.to_string().contains("--max-flush-delay-idle")
+                && err.to_string().contains("less than"),
+            "expected the tier-inversion error, got: {err}"
+        );
+    }
+
+    /// Boundary case for Bug 3's fix: `max_flush_delay_idle ==
+    /// max_flush_delay` is the inclusive edge and must be accepted, not
+    /// rejected.
+    #[test]
+    fn flush_delay_idle_equal_to_flush_delay_is_accepted_at_startup() {
+        let cli = Cli::try_parse_from([
+            "ravel-server",
+            "--max-flush-delay",
+            "2s",
+            "--max-flush-delay-idle",
+            "2s",
+            "--min-flush-bytes",
+            "262144",
+        ])
+        .expect("flags parse at the CLI layer");
+        cli.validate().expect(
+            "--max-flush-delay-idle == --max-flush-delay must be accepted (inclusive boundary)",
+        );
+    }
+
+    /// ADR-0076 decision 4: a `--max-flush-delay` whose DERIVED
+    /// `strict_visibility_budget_ns` (`max_flush_delay +
+    /// STRICT_VISIBILITY_RESERVE_NS`) meets or exceeds
+    /// `MAX_STRICT_VISIBILITY_BUDGET_NS` must fail startup, since it risks
+    /// the client's own export timeout firing before the strict ack returns.
+    /// `>=` matters here (Bug 1+2's fix), not `>`: a derived budget exactly
+    /// equal to the ceiling is "5s smallest OTLP client timeout minus 2s
+    /// assumed PUT tail", not "well clear of" it.
     #[test]
     fn flush_delay_exceeding_max_strict_visibility_budget_is_rejected_at_startup() {
-        // MAX_STRICT_VISIBILITY_BUDGET_NS is 3s; 4s clears
-        // FLUSH_BOUND_SLACK_HOURS (4s + 3600s well under 7200s) but must
-        // still be refused by the visibility-budget ceiling.
+        // MAX_STRICT_VISIBILITY_BUDGET_NS is 3s; derived budget = 4s + 0.5s
+        // reserve = 4.5s. 4s alone clears FLUSH_BOUND_SLACK_HOURS (4s + 3600s
+        // well under 7200s) but the derived budget must still be refused by
+        // the visibility-budget ceiling.
         let cli = Cli::try_parse_from([
             "ravel-server",
             "--max-flush-delay",
@@ -3145,7 +3259,8 @@ mod tests {
         ])
         .expect("flags parse at the CLI layer");
         let err = cli.validate().expect_err(
-            "startup must reject --max-flush-delay 4s: exceeds MAX_STRICT_VISIBILITY_BUDGET_NS",
+            "startup must reject --max-flush-delay 4s: derived budget exceeds \
+             MAX_STRICT_VISIBILITY_BUDGET_NS",
         );
         assert!(
             err.to_string().contains("MAX_STRICT_VISIBILITY_BUDGET_NS"),
@@ -3153,10 +3268,11 @@ mod tests {
         );
     }
 
-    /// The shipped default (2s, ADR-0076 decision 4) must pass both new
-    /// startup validations: it is well under both FLUSH_BOUND_SLACK_HOURS
-    /// (2s + 3600s = 3602s, under the 7200s ceiling) and
-    /// MAX_STRICT_VISIBILITY_BUDGET_NS (2s, under the 3s ceiling).
+    /// The shipped default (2s max_flush_delay, 40s max_flush_delay_idle,
+    /// ADR-0076 decision 4) must pass all startup validations: the idle-based
+    /// FLUSH_BOUND_SLACK_HOURS check (40s + 3600s = 3640s, under the 7200s
+    /// ceiling) and the derived strict_visibility_budget_ns check (2s + 0.5s
+    /// reserve = 2.5s, under the 3s MAX_STRICT_VISIBILITY_BUDGET_NS ceiling).
     #[test]
     fn shipped_default_flush_delay_passes_both_startup_validations() {
         let cli = Cli::try_parse_from(["ravel-server"]).expect("defaults parse");
@@ -3166,6 +3282,32 @@ mod tests {
         assert_eq!(flush_cadence.max_flush_delay, Duration::from_secs(2));
         cli.validate()
             .expect("shipped default --max-flush-delay (2s) must pass startup validation");
+    }
+
+    /// `--min-flush-bytes` at or above `target_bytes` (8 MiB default) makes
+    /// the idle-tier byte-priority trigger unreachable: a buffer would always
+    /// hit `target_bytes`' own size trigger first. Must be rejected at
+    /// startup.
+    #[test]
+    fn min_flush_bytes_at_or_above_target_bytes_is_rejected_at_startup() {
+        let target_bytes = ravel_ingest::IngestConfig::default().target_bytes;
+        let cli = Cli::try_parse_from([
+            "ravel-server",
+            "--max-flush-delay",
+            "2s",
+            "--max-flush-delay-idle",
+            "40s",
+            "--min-flush-bytes",
+            &target_bytes.to_string(),
+        ])
+        .expect("flags parse at the CLI layer");
+        let err = cli
+            .validate()
+            .expect_err("startup must reject --min-flush-bytes == target_bytes");
+        assert!(
+            err.to_string().contains("target_bytes"),
+            "expected a target_bytes error, got: {err}"
+        );
     }
 
     #[test]

--- a/services/ravel-server/src/config.rs
+++ b/services/ravel-server/src/config.rs
@@ -388,25 +388,24 @@ pub struct Cli {
     #[arg(long = "max-ingest-buffer-bytes", default_value_t = 512 * 1024 * 1024)]
     pub max_ingest_buffer_bytes: u64,
 
-    /// Per-shard bound on concurrently in-flight flushes for the metrics
-    /// ingest pipeline (ADR-0067 decision 2). Each shard's flush
-    /// runs in a spawned task the shard actor no longer waits on; this caps
-    /// how many such tasks a single shard may have outstanding at once, so
-    /// pipelining trades bounded extra memory (buffers held by in-flight
+    /// Per-shard bound on concurrently in-flight flushes, for all three
+    /// ingest pipelines (metrics, logs, spans -- ADR-0067 decision 2,
+    /// extended to logs and spans by ADR-0076 decision 3). Each shard's
+    /// flush runs in a spawned task the shard actor no longer waits on; this
+    /// caps how many such tasks a single shard may have outstanding at once,
+    /// so pipelining trades bounded extra memory (buffers held by in-flight
     /// flushes) for overlapped PUT latency instead of unbounded fan-out.
     /// Matches [`ravel_ingest::IngestConfig::max_inflight_flushes`]'s own
     /// default of 1 (today's non-pipelined behavior). `0` is rejected by
     /// [`Cli::validate`]: it would deadlock every flush, since a shard could
-    /// never acquire a permit to run one. Applies only to the metrics ingest
-    /// pipeline; log and span shard actors are unaffected (they keep their
-    /// existing inline flush).
+    /// never acquire a permit to run one.
     #[arg(long = "max-inflight-flushes", default_value_t = 1)]
     pub max_inflight_flushes: u32,
 
     /// Enables the adaptive flush-delay corridor for the metrics ingest
     /// pipeline (ADR-0067 decision 3): instead of always
     /// flushing a tenant's buffer on the fixed `--max-flush-delay` age, the
-    /// age threshold adapts within `[500ms floor, ceiling]`, where the
+    /// age threshold adapts within `[max_flush_delay, ceiling]`, where the
     /// ceiling derives from the shard's observed PUT p99 RTT and the
     /// strict-write visibility budget. Off by default
     /// (matches [`ravel_ingest::IngestConfig::adaptive_flush_delay`]'s own
@@ -415,6 +414,50 @@ pub struct Cli {
     /// log and span shard actors are unaffected.
     #[arg(long = "adaptive-flush-delay")]
     pub adaptive_flush_delay: bool,
+
+    /// Fast-tier flush age threshold, shared by all three ingest pipelines
+    /// (ADR-0076 decision 4), as a humantime duration (e.g. `2s`). Applied
+    /// to a tenant's buffer once it has a strict-mode waiter or already
+    /// holds at least `--min-flush-bytes`; also the floor (and, off
+    /// adaptive delay, the whole corridor) of the metrics pipeline's
+    /// strict-mode visibility budget. Moves as a set with
+    /// `--max-flush-delay-idle` and `--min-flush-bytes`: [`Cli::validate`]
+    /// rejects setting only one or two of the three, since raising this one
+    /// alone while leaving the byte threshold at its old, smaller value
+    /// would not actually slow the fast tier down for a buffered tenant
+    /// that crosses it sooner. Omitted, along with the other two, defaults
+    /// to [`ravel_ingest::IngestConfig::default().max_flush_delay`] (2s). A
+    /// zero or unparseable duration fails startup.
+    #[arg(long = "max-flush-delay", value_name = "DURATION")]
+    pub max_flush_delay: Option<String>,
+
+    /// Idle-tier flush age threshold, shared by all three ingest pipelines
+    /// (ADR-0076 decision 4), as a humantime duration (e.g. `40s`). Applied
+    /// instead of `--max-flush-delay` to a tenant's buffer with no
+    /// strict-mode waiter and fewer than `--min-flush-bytes` buffered, so a
+    /// low-volume buffered-mode tenant is not flushed on the fast cadence
+    /// regardless of how little data it holds. Moves as a set with
+    /// `--max-flush-delay` and `--min-flush-bytes`; see `--max-flush-delay`
+    /// for the partial-override rejection. Omitted, along with the other
+    /// two, defaults to
+    /// [`ravel_ingest::IngestConfig::default().max_flush_delay_idle`] (40s).
+    /// A zero or unparseable duration fails startup.
+    #[arg(long = "max-flush-delay-idle", value_name = "DURATION")]
+    pub max_flush_delay_idle: Option<String>,
+
+    /// Byte threshold, shared by all three ingest pipelines (ADR-0076
+    /// decision 4), at or above which a tenant's buffer is never treated as
+    /// idle for the age trigger even with no strict-mode waiter: it is
+    /// already worth the PUT cost `--max-flush-delay` pays for. Moves as a
+    /// set with `--max-flush-delay` and `--max-flush-delay-idle`; see
+    /// `--max-flush-delay` for the partial-override rejection. Omitted,
+    /// along with the other two, defaults to
+    /// [`ravel_ingest::IngestConfig::default().min_flush_bytes`] (256 KiB).
+    /// `0` fails startup: every buffer would count as at-or-above it, which
+    /// is not "idle detection", it is "idle detection disabled" spelled as
+    /// a size.
+    #[arg(long = "min-flush-bytes", value_name = "BYTES")]
+    pub min_flush_bytes: Option<u64>,
 
     /// The at-rest scrub period `P` (ADR-0059 decision 1), as a humantime
     /// duration (e.g. `7d`). The content-tier scrubber rotates through the
@@ -754,6 +797,49 @@ pub struct Cli {
 /// recently fetched segment/log byte ranges across a handful of concurrent
 /// queries, small enough that a dev process does not need tuning to pick it.
 pub const DEFAULT_CACHE_MAX_BYTES: u64 = 256 * 1024 * 1024;
+
+/// The resolved ADR-0076 decision 4 flush-cadence knobs
+/// (`--max-flush-delay`, `--max-flush-delay-idle`, `--min-flush-bytes`), all
+/// three either at their `IngestConfig` defaults or all three overridden
+/// together ([`Cli::resolve_flush_cadence`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FlushCadence {
+    pub max_flush_delay: Duration,
+    pub max_flush_delay_idle: Duration,
+    pub min_flush_bytes: usize,
+}
+
+/// Upper bound on `--max-flush-delay` derived from the read-side scan-slack
+/// arithmetic `ravel_catalog::FLUSH_BOUND_SLACK_HOURS` encodes (ADR-0076
+/// decision 4): `FLUSH_BOUND_SLACK_HOURS` is `ceil(max_flush_delay +
+/// max_flush_lifetime)` at the defaults it was last derived against, and
+/// governs how long the read side keeps scanning a retiring shard-count
+/// generation after an activation (docs/catalog-and-mvcc.md). Raising
+/// `--max-flush-delay` past what keeps that sum under
+/// `FLUSH_BOUND_SLACK_HOURS` hours would silently shrink the straggler
+/// window below what a flush can actually take, without `S`
+/// (`ravel_catalog::DEFAULT_SCAN_SLACK_HOURS`) ever being told to grow to
+/// compensate -- a straggler flush pinned under a retiring generation could
+/// then land outside the window the read side still scans, an invisibility
+/// hazard. `ravel_ingest::IngestConfig::max_flush_lifetime` is not itself an
+/// operator-facing flag in this ADR's scope, so [`Cli::validate`] uses its
+/// compiled-in default (1h) as the fixed half of the sum.
+pub const FLUSH_BOUND_SLACK_HOURS_NS: i64 =
+    ravel_catalog::FLUSH_BOUND_SLACK_HOURS as i64 * 3_600_000_000_000;
+
+/// Upper bound on `--max-flush-delay` (and, in strict mode, the
+/// `strict_visibility_budget_ns` that follows it) derived from client-side
+/// export timeouts rather than from `FLUSH_BOUND_SLACK_HOURS_NS` (ADR-0076
+/// decision 4). OTLP collector and SDK exporter timeout defaults sit in the
+/// 5-10 s range; this uses the SMALLEST of that range (5 s) as the client
+/// budget a strict ack must fit inside before the client's own export
+/// timeout could fire, then subtracts an assumed 2 s PUT p99 tail (the data-
+/// object PUT plus the commit-record PUT, the same two round trips
+/// `visibility_ceiling_ns` accounts for) as headroom: 5s - 2s = 3s. A flush
+/// delay above this ceiling risks the client timing out and retrying before
+/// the strict ack returns, which produces duplicate logs/spans and more
+/// requests, not fewer -- the opposite of this ADR's goal.
+pub const MAX_STRICT_VISIBILITY_BUDGET_NS: i64 = 3_000_000_000;
 
 /// Validated OIDC settings, present only when `--oidc-issuer`/`--oidc-jwks-url`
 /// are configured.
@@ -1192,24 +1278,81 @@ impl Cli {
         }
     }
 
+    /// Resolve the three ADR-0076 decision 4 flush-cadence knobs
+    /// (`--max-flush-delay`, `--max-flush-delay-idle`, `--min-flush-bytes`),
+    /// which move as a set. All three omitted resolves to
+    /// [`ravel_ingest::IngestConfig::default()`]'s own values; any other
+    /// count set (one or two of three) is rejected, since raising one alone
+    /// leaves the other two at their old cadence, defeating the point of
+    /// moving them together. Each individually-set value is further
+    /// rejected if it parses to zero (a zero delay or byte threshold has no
+    /// sensible "idle" meaning). This is the single source [`Self::validate`]
+    /// and every `IngestConfig`-construction call site in `start` both call,
+    /// so the value validated is the value enforced.
+    pub fn resolve_flush_cadence(&self) -> anyhow::Result<FlushCadence> {
+        let (max_flush_delay, max_flush_delay_idle, min_flush_bytes) = match (
+            self.max_flush_delay.as_deref(),
+            self.max_flush_delay_idle.as_deref(),
+            self.min_flush_bytes,
+        ) {
+            (None, None, None) => {
+                let default = ravel_ingest::IngestConfig::default();
+                return Ok(FlushCadence {
+                    max_flush_delay: default.max_flush_delay,
+                    max_flush_delay_idle: default.max_flush_delay_idle,
+                    min_flush_bytes: default.min_flush_bytes,
+                });
+            }
+            (Some(delay), Some(idle), Some(bytes)) => (delay, idle, bytes),
+            _ => anyhow::bail!(
+                "--max-flush-delay, --max-flush-delay-idle, and --min-flush-bytes must be set \
+                 together or not at all (ADR-0076 decision 4): they move as a set, and \
+                 overriding only some of them would leave the rest at their old cadence, \
+                 defeating the point of raising the ones you did set."
+            ),
+        };
+        let max_flush_delay = humantime::parse_duration(max_flush_delay)
+            .map_err(|e| anyhow::anyhow!("invalid --max-flush-delay: {e}"))?;
+        if max_flush_delay.is_zero() {
+            anyhow::bail!("--max-flush-delay must be a positive duration");
+        }
+        let max_flush_delay_idle = humantime::parse_duration(max_flush_delay_idle)
+            .map_err(|e| anyhow::anyhow!("invalid --max-flush-delay-idle: {e}"))?;
+        if max_flush_delay_idle.is_zero() {
+            anyhow::bail!("--max-flush-delay-idle must be a positive duration");
+        }
+        if min_flush_bytes == 0 {
+            anyhow::bail!(
+                "--min-flush-bytes '0' disables idle detection entirely (every buffer is at or \
+                 above zero bytes); set a positive byte count"
+            );
+        }
+        Ok(FlushCadence {
+            max_flush_delay,
+            max_flush_delay_idle,
+            min_flush_bytes: min_flush_bytes as usize,
+        })
+    }
+
     /// Resolve the per-query S3 request budget (ADR-0075). An explicit
     /// `--max-s3-requests` is used verbatim; otherwise the budget is DERIVED
-    /// from `--shards` and the ingest pipeline's flush cadence
-    /// (`ravel_ingest::IngestConfig::default().max_flush_delay`, the value the
-    /// server's own metrics ingest pipeline runs with, since `start` builds
-    /// `IngestConfig` with `..IngestConfig::default()`). This is the one place
+    /// from `--shards` and the ingest pipeline's actually-configured flush
+    /// cadence ([`Self::resolve_flush_cadence`], the value the server's own
+    /// ingest pipelines run with -- not `IngestConfig::default()`, so an
+    /// operator who raises `--max-flush-delay` gets a budget derived from
+    /// what they configured, not the shipped default). This is the one place
     /// the derivation is wired into the real startup path: `main.rs` calls it
     /// to fill [`crate::ServerConfig::max_s3_requests`], which `start` threads
     /// into the process-wide `EngineConfig` both query surfaces share. A `0`
     /// override is rejected by [`Self::validate`], not here.
-    pub fn resolve_max_s3_requests(&self) -> ravel_query::RequestLimit {
-        match self.max_s3_requests {
+    pub fn resolve_max_s3_requests(&self) -> anyhow::Result<ravel_query::RequestLimit> {
+        Ok(match self.max_s3_requests {
             Some(n) => ravel_query::RequestLimit::Bounded(n),
             None => ravel_query::RequestLimit::Bounded(ravel_query::derive_max_s3_requests(
                 self.shards,
-                ravel_ingest::IngestConfig::default().max_flush_delay,
+                self.resolve_flush_cadence()?.max_flush_delay,
             )),
-        }
+        })
     }
 
     /// Parse `--max-inflight-ingest-requests` into an
@@ -1547,6 +1690,41 @@ impl Cli {
             anyhow::bail!(
                 "--max-s3-requests '0' would reject every query; omit the flag to derive the \
                  budget from --shards and the flush cadence, or set a positive count"
+            );
+        }
+
+        // ADR-0076 decision 4: parsed and range-checked here so a malformed
+        // or partially-overridden flush cadence fails startup, not the first
+        // flush.
+        let flush_cadence = self.resolve_flush_cadence()?;
+
+        let flush_bound_ns = flush_cadence.max_flush_delay.as_nanos() as i64
+            + ravel_ingest::IngestConfig::default()
+                .max_flush_lifetime
+                .as_nanos() as i64;
+        if flush_bound_ns > FLUSH_BOUND_SLACK_HOURS_NS {
+            anyhow::bail!(
+                "--max-flush-delay {:?} plus the ingest pipeline's max_flush_lifetime ({:?}) \
+                 exceeds FLUSH_BOUND_SLACK_HOURS ({} h): the read-side scan slack \
+                 ravel_catalog::FLUSH_BOUND_SLACK_HOURS encodes would no longer cover a \
+                 straggler flush pinned under a retiring shard-count generation, an \
+                 invisibility hazard. Lower --max-flush-delay, or revisit \
+                 FLUSH_BOUND_SLACK_HOURS in ravel-catalog in lockstep (ADR-0076 decision 4).",
+                flush_cadence.max_flush_delay,
+                ravel_ingest::IngestConfig::default().max_flush_lifetime,
+                ravel_catalog::FLUSH_BOUND_SLACK_HOURS,
+            );
+        }
+
+        if flush_cadence.max_flush_delay.as_nanos() as i64 > MAX_STRICT_VISIBILITY_BUDGET_NS {
+            anyhow::bail!(
+                "--max-flush-delay {:?} exceeds MAX_STRICT_VISIBILITY_BUDGET_NS ({}s): in strict \
+                 mode a client waits for the flush delay plus two PUT round trips before its ack \
+                 returns, and a value this high risks the OTLP client's own export timeout \
+                 firing first, producing retries and duplicate logs/spans instead of the fewer \
+                 requests this ADR is for. Lower --max-flush-delay.",
+                flush_cadence.max_flush_delay,
+                MAX_STRICT_VISIBILITY_BUDGET_NS as f64 / 1e9,
             );
         }
 
@@ -2786,18 +2964,19 @@ mod tests {
         let flush = ravel_ingest::IngestConfig::default().max_flush_delay;
         let expected = ravel_query::derive_max_s3_requests(cli.shards, flush);
         assert_eq!(
-            cli.resolve_max_s3_requests(),
+            cli.resolve_max_s3_requests()
+                .expect("defaults resolve a bounded budget"),
             RequestLimit::Bounded(expected)
         );
-        let open_hour_cost = 4 * (3_600_000u64 / 500);
-        assert_eq!(open_hour_cost, 28_800);
+        let open_hour_cost = 4 * (3_600_000u64 / 2_000);
+        assert_eq!(open_hour_cost, 7_200);
         assert!(
             !RequestLimit::Bounded(expected).is_exceeded_by(open_hour_cost),
             "the derived budget {expected} must admit the 4-shard open hour ({open_hour_cost})"
         );
         assert!(
-            RequestLimit::Bounded(25_000).is_exceeded_by(open_hour_cost),
-            "sanity: the old flat 25,000 default rejected the 4-shard open hour"
+            RequestLimit::Bounded(1_000).is_exceeded_by(open_hour_cost),
+            "sanity: an overly tight 1,000 budget rejects the 4-shard open hour"
         );
         // And the derived cap must still bound a runaway query (three GETs per
         // recent segment across shards).
@@ -2806,7 +2985,11 @@ mod tests {
         // Explicit override: used verbatim, the derivation does not apply.
         let cli = Cli::try_parse_from(["ravel-server", "--max-s3-requests", "999"])
             .expect("explicit flag parses");
-        assert_eq!(cli.resolve_max_s3_requests(), RequestLimit::Bounded(999));
+        assert_eq!(
+            cli.resolve_max_s3_requests()
+                .expect("explicit override resolves"),
+            RequestLimit::Bounded(999)
+        );
 
         // Zero is rejected at validation, never silently used as a budget that
         // rejects every query.
@@ -2816,6 +2999,173 @@ mod tests {
             cli.validate().is_err(),
             "--max-s3-requests 0 must fail startup"
         );
+
+        // The call site must derive from the actually-configured flush
+        // cadence, not `IngestConfig::default()`: a non-default
+        // --max-flush-delay must change the derived budget.
+        let cli = Cli::try_parse_from([
+            "ravel-server",
+            "--max-flush-delay",
+            "1s",
+            "--max-flush-delay-idle",
+            "20s",
+            "--min-flush-bytes",
+            "131072",
+        ])
+        .expect("flush-cadence override parses");
+        let configured_flush = std::time::Duration::from_secs(1);
+        let expected_for_override =
+            ravel_query::derive_max_s3_requests(cli.shards, configured_flush);
+        assert_ne!(
+            expected_for_override, expected,
+            "guard: the override must actually change the derived budget vs. the default flush delay"
+        );
+        assert_eq!(
+            cli.resolve_max_s3_requests()
+                .expect("configured flush cadence resolves"),
+            RequestLimit::Bounded(expected_for_override),
+            "derive_max_s3_requests call site must use the configured --max-flush-delay, not IngestConfig::default()"
+        );
+    }
+
+    /// ADR-0076 decision 4: the three flush-cadence knobs move as a set.
+    /// Setting only one or two of `--max-flush-delay`,
+    /// `--max-flush-delay-idle`, `--min-flush-bytes` must be rejected,
+    /// since raising one alone leaves the others at their old cadence.
+    #[test]
+    fn flush_cadence_partial_set_is_rejected() {
+        let one = Cli::try_parse_from(["ravel-server", "--max-flush-delay", "1s"])
+            .expect("flag parses at the CLI layer");
+        let err = one
+            .resolve_flush_cadence()
+            .expect_err("setting only --max-flush-delay must be rejected");
+        assert!(
+            err.to_string().contains("together or not at all"),
+            "expected the move-as-a-set message, got: {err}"
+        );
+
+        let two = Cli::try_parse_from([
+            "ravel-server",
+            "--max-flush-delay",
+            "1s",
+            "--max-flush-delay-idle",
+            "20s",
+        ])
+        .expect("flags parse at the CLI layer");
+        let err = two
+            .resolve_flush_cadence()
+            .expect_err("setting only two of three must be rejected");
+        assert!(
+            err.to_string().contains("together or not at all"),
+            "expected the move-as-a-set message, got: {err}"
+        );
+
+        let three = Cli::try_parse_from([
+            "ravel-server",
+            "--max-flush-delay",
+            "1s",
+            "--max-flush-delay-idle",
+            "20s",
+            "--min-flush-bytes",
+            "131072",
+        ])
+        .expect("flags parse at the CLI layer");
+        three
+            .resolve_flush_cadence()
+            .expect("all three set together must be accepted");
+
+        let none = Cli::try_parse_from(["ravel-server"]).expect("defaults parse");
+        none.resolve_flush_cadence()
+            .expect("all three omitted must fall back to IngestConfig::default()");
+    }
+
+    /// ADR-0076 decision 4: a `--max-flush-delay` that, combined with the
+    /// ingest pipeline's fixed `max_flush_lifetime`, exceeds
+    /// `ravel_catalog::FLUSH_BOUND_SLACK_HOURS` must fail startup, not
+    /// silently under-cover a straggler flush pinned under a retiring
+    /// shard-count generation.
+    ///
+    /// Proof this test can fail: with the `flush_bound_ns >
+    /// FLUSH_BOUND_SLACK_HOURS_NS` check at src/config.rs:1714 disabled
+    /// (guarded with `if false &&`), `cli.validate()` still returned `Err`
+    /// -- 3601s also trips the separate MAX_STRICT_VISIBILITY_BUDGET_NS
+    /// check below it -- but the message assertion caught the missing
+    /// check specifically: the panic was "expected a FLUSH_BOUND_SLACK_HOURS
+    /// error, got: --max-flush-delay 3601s exceeds
+    /// MAX_STRICT_VISIBILITY_BUDGET_NS (3s): ...". Restoring the check made
+    /// it pass again.
+    #[test]
+    fn flush_delay_exceeding_flush_bound_slack_hours_is_rejected_at_startup() {
+        // FLUSH_BOUND_SLACK_HOURS is 2h = 7200s; max_flush_lifetime defaults
+        // to 3600s, so 3601s of --max-flush-delay pushes the sum to 7201s,
+        // one second over the ceiling.
+        let cli = Cli::try_parse_from([
+            "ravel-server",
+            "--max-flush-delay",
+            "3601s",
+            "--max-flush-delay-idle",
+            "2h",
+            "--min-flush-bytes",
+            "131072",
+        ])
+        .expect("flags parse at the CLI layer");
+        let err = cli.validate().expect_err(
+            "startup must reject --max-flush-delay 3601s: exceeds FLUSH_BOUND_SLACK_HOURS",
+        );
+        assert!(
+            err.to_string().contains("FLUSH_BOUND_SLACK_HOURS"),
+            "expected a FLUSH_BOUND_SLACK_HOURS error, got: {err}"
+        );
+    }
+
+    /// ADR-0076 decision 4: a `--max-flush-delay` exceeding
+    /// `MAX_STRICT_VISIBILITY_BUDGET_NS` (the smallest OTLP client timeout
+    /// minus an assumed PUT p99 tail) must fail startup, since it risks the
+    /// client's own export timeout firing before the strict ack returns.
+    ///
+    /// Proof this test can fail: with the max-flush-delay-exceeds-budget
+    /// check at src/config.rs:1728 disabled (guarded with `if false &&`),
+    /// this test failed with "startup must reject --max-flush-delay 4s:
+    /// exceeds MAX_STRICT_VISIBILITY_BUDGET_NS" because `cli.validate()`
+    /// returned `Ok(())` instead of erroring. Restoring the check made it
+    /// pass again.
+    #[test]
+    fn flush_delay_exceeding_max_strict_visibility_budget_is_rejected_at_startup() {
+        // MAX_STRICT_VISIBILITY_BUDGET_NS is 3s; 4s clears
+        // FLUSH_BOUND_SLACK_HOURS (4s + 3600s well under 7200s) but must
+        // still be refused by the visibility-budget ceiling.
+        let cli = Cli::try_parse_from([
+            "ravel-server",
+            "--max-flush-delay",
+            "4s",
+            "--max-flush-delay-idle",
+            "40s",
+            "--min-flush-bytes",
+            "262144",
+        ])
+        .expect("flags parse at the CLI layer");
+        let err = cli.validate().expect_err(
+            "startup must reject --max-flush-delay 4s: exceeds MAX_STRICT_VISIBILITY_BUDGET_NS",
+        );
+        assert!(
+            err.to_string().contains("MAX_STRICT_VISIBILITY_BUDGET_NS"),
+            "expected a MAX_STRICT_VISIBILITY_BUDGET_NS error, got: {err}"
+        );
+    }
+
+    /// The shipped default (2s, ADR-0076 decision 4) must pass both new
+    /// startup validations: it is well under both FLUSH_BOUND_SLACK_HOURS
+    /// (2s + 3600s = 3602s, under the 7200s ceiling) and
+    /// MAX_STRICT_VISIBILITY_BUDGET_NS (2s, under the 3s ceiling).
+    #[test]
+    fn shipped_default_flush_delay_passes_both_startup_validations() {
+        let cli = Cli::try_parse_from(["ravel-server"]).expect("defaults parse");
+        let flush_cadence = cli
+            .resolve_flush_cadence()
+            .expect("all three omitted resolves to IngestConfig::default()");
+        assert_eq!(flush_cadence.max_flush_delay, Duration::from_secs(2));
+        cli.validate()
+            .expect("shipped default --max-flush-delay (2s) must pass startup validation");
     }
 
     #[test]

--- a/services/ravel-server/src/config.rs
+++ b/services/ravel-server/src/config.rs
@@ -978,6 +978,20 @@ impl std::fmt::Debug for RemoteClusterConfig {
     }
 }
 
+/// Convert a `Duration` to nanoseconds as `i64`, saturating to `i64::MAX`
+/// instead of the truncating wraparound a plain `as i64` cast on
+/// `Duration::as_nanos()` (a `u128`) performs when the value exceeds
+/// `i64::MAX` nanoseconds (about 292 years). An operator-supplied
+/// `--max-flush-delay`/`--max-flush-delay-idle` has no upper bound at the
+/// parse layer (humantime accepts `"1000y"`), so every fail-closed
+/// comparison against these durations in [`Cli::validate`] must use this
+/// instead of a bare cast: a wraparound can silently produce a small or
+/// negative `i64` that passes a "must be below this bound" check the
+/// duration was actually meant to fail.
+pub(crate) fn duration_nanos_saturating(d: std::time::Duration) -> i64 {
+    i64::try_from(d.as_nanos()).unwrap_or(i64::MAX)
+}
+
 /// Parse a `true`/`false` value from a `--remote-cluster` boolean field,
 /// erroring with the spec and key in context rather than a bare parse failure.
 fn parse_bool_field(spec: &str, key: &str, value: &str) -> anyhow::Result<bool> {
@@ -1724,10 +1738,10 @@ impl Cli {
         // the one that can age all the way to max_flush_delay_idle before a
         // forced flush, so that (not max_flush_delay, the fast-tier floor) is
         // the real worst-case age FLUSH_BOUND_SLACK_HOURS must cover.
-        let flush_bound_ns = flush_cadence.max_flush_delay_idle.as_nanos() as i64
-            + ravel_ingest::IngestConfig::default()
-                .max_flush_lifetime
-                .as_nanos() as i64;
+        let flush_bound_ns = duration_nanos_saturating(flush_cadence.max_flush_delay_idle)
+            .saturating_add(duration_nanos_saturating(
+                ravel_ingest::IngestConfig::default().max_flush_lifetime,
+            ));
         if flush_bound_ns > FLUSH_BOUND_SLACK_HOURS_NS {
             anyhow::bail!(
                 "--max-flush-delay-idle {:?} plus the ingest pipeline's max_flush_lifetime ({:?}) \
@@ -1742,8 +1756,8 @@ impl Cli {
             );
         }
 
-        let strict_visibility_budget_ns = flush_cadence.max_flush_delay.as_nanos() as i64
-            + ravel_ingest::STRICT_VISIBILITY_RESERVE_NS;
+        let strict_visibility_budget_ns = duration_nanos_saturating(flush_cadence.max_flush_delay)
+            .saturating_add(ravel_ingest::STRICT_VISIBILITY_RESERVE_NS);
         if strict_visibility_budget_ns >= MAX_STRICT_VISIBILITY_BUDGET_NS {
             anyhow::bail!(
                 "--max-flush-delay {:?} derives a strict_visibility_budget_ns of {:?}ns, which \
@@ -3186,6 +3200,67 @@ mod tests {
         assert!(
             err.to_string().contains("FLUSH_BOUND_SLACK_HOURS"),
             "expected a FLUSH_BOUND_SLACK_HOURS error, got: {err}"
+        );
+    }
+
+    /// Overflow regression, found during re-review of Bug 4's fix: a plain
+    /// `Duration::as_nanos() as i64` cast truncates rather than saturates
+    /// when the value exceeds `i64::MAX` nanoseconds (~292 years).
+    /// `--max-flush-delay-idle` has no upper bound at the parse layer
+    /// (humantime accepts `"1000y"`), so an absurd value wraps to an
+    /// arbitrary (possibly small or negative) `i64` and can silently pass
+    /// the `FLUSH_BOUND_SLACK_HOURS` check the duration was meant to fail --
+    /// the exact invisibility hazard Bug 4's fix exists to prevent, reopened
+    /// by the cast it introduced. `--max-flush-delay` stays small so this
+    /// exercises only the idle-based bound.
+    #[test]
+    fn flush_delay_idle_overflowing_i64_nanos_is_rejected_at_startup() {
+        let cli = Cli::try_parse_from([
+            "ravel-server",
+            "--max-flush-delay",
+            "1s",
+            "--max-flush-delay-idle",
+            "1000y",
+            "--min-flush-bytes",
+            "262144",
+        ])
+        .expect("flags parse at the CLI layer: humantime accepts absurd durations");
+        let err = cli.validate().expect_err(
+            "startup must reject --max-flush-delay-idle 1000y: a naive `as i64` cast \
+             overflows and wraps, silently passing FLUSH_BOUND_SLACK_HOURS",
+        );
+        assert!(
+            err.to_string().contains("FLUSH_BOUND_SLACK_HOURS"),
+            "expected a FLUSH_BOUND_SLACK_HOURS error, got: {err}"
+        );
+    }
+
+    /// Same overflow class as above, on the other cast this fix touches:
+    /// `--max-flush-delay` itself feeds `strict_visibility_budget_ns`'s
+    /// derivation. `--max-flush-delay-idle` is set to the same absurd value
+    /// so Bug 3's tier-ordering check (idle must be >= delay) does not
+    /// intercept this case before it reaches the visibility-budget check.
+    #[test]
+    fn flush_delay_overflowing_i64_nanos_is_rejected_at_startup() {
+        let cli = Cli::try_parse_from([
+            "ravel-server",
+            "--max-flush-delay",
+            "1000y",
+            "--max-flush-delay-idle",
+            "1000y",
+            "--min-flush-bytes",
+            "262144",
+        ])
+        .expect("flags parse at the CLI layer: humantime accepts absurd durations");
+        let err = cli.validate().expect_err(
+            "startup must reject --max-flush-delay 1000y: an overflowing derived budget \
+             must not silently pass either bound",
+        );
+        assert!(
+            err.to_string().contains("FLUSH_BOUND_SLACK_HOURS")
+                || err.to_string().contains("MAX_STRICT_VISIBILITY_BUDGET_NS"),
+            "expected a FLUSH_BOUND_SLACK_HOURS or MAX_STRICT_VISIBILITY_BUDGET_NS error, got: \
+             {err}"
         );
     }
 

--- a/services/ravel-server/src/lib.rs
+++ b/services/ravel-server/src/lib.rs
@@ -626,8 +626,10 @@ pub async fn start(
                     // IngestConfig::default() uses -- setting it equal (as
                     // this call site once did) collapses the adaptive
                     // corridor to the floor unconditionally.
-                    strict_visibility_budget_ns: config.max_flush_delay.as_nanos() as i64
-                        + ravel_ingest::STRICT_VISIBILITY_RESERVE_NS,
+                    strict_visibility_budget_ns: crate::config::duration_nanos_saturating(
+                        config.max_flush_delay,
+                    )
+                    .saturating_add(ravel_ingest::STRICT_VISIBILITY_RESERVE_NS),
                     ..IngestConfig::default()
                 },
                 store.clone(),

--- a/services/ravel-server/src/lib.rs
+++ b/services/ravel-server/src/lib.rs
@@ -622,7 +622,12 @@ pub async fn start(
                     // ADR-0076 decision 4: follows the actually-configured
                     // max_flush_delay, not just its default, so the adaptive
                     // corridor never contradicts the operator's chosen budget.
-                    strict_visibility_budget_ns: config.max_flush_delay.as_nanos() as i64,
+                    // Must exceed max_flush_delay by the same reserve
+                    // IngestConfig::default() uses -- setting it equal (as
+                    // this call site once did) collapses the adaptive
+                    // corridor to the floor unconditionally.
+                    strict_visibility_budget_ns: config.max_flush_delay.as_nanos() as i64
+                        + ravel_ingest::STRICT_VISIBILITY_RESERVE_NS,
                     ..IngestConfig::default()
                 },
                 store.clone(),

--- a/services/ravel-server/src/lib.rs
+++ b/services/ravel-server/src/lib.rs
@@ -168,17 +168,29 @@ pub struct ServerConfig {
     pub listen_http: SocketAddr,
     pub listen_grpc: SocketAddr,
     pub shard_count: u32,
-    /// Per-shard in-flight flush bound for the metrics ingest pipeline
-    /// (ADR-0067 decision 2), forwarded to
-    /// [`ravel_ingest::IngestConfig::max_inflight_flushes`]. Does not apply
-    /// to the log or span ingest pipelines, which keep their existing inline
-    /// flush. See `--max-inflight-flushes`.
+    /// Per-shard in-flight flush bound, forwarded to
+    /// [`ravel_ingest::IngestConfig::max_inflight_flushes`] on all three
+    /// ingest pipelines (metrics, logs, spans -- ADR-0067 decision 2,
+    /// extended to logs and spans by ADR-0076 decision 3). See
+    /// `--max-inflight-flushes`.
     pub max_inflight_flushes: u32,
     /// Enables the adaptive flush-delay corridor for the metrics ingest
     /// pipeline (ADR-0067 decision 3), forwarded to
     /// [`ravel_ingest::IngestConfig::adaptive_flush_delay`]. Does not apply
     /// to the log or span ingest pipelines. See `--adaptive-flush-delay`.
     pub adaptive_flush_delay: bool,
+    /// Fast-tier flush age threshold, forwarded to
+    /// [`ravel_ingest::IngestConfig::max_flush_delay`] on all three ingest
+    /// pipelines (ADR-0076 decision 4). See `--max-flush-delay`.
+    pub max_flush_delay: Duration,
+    /// Idle-tier flush age threshold, forwarded to
+    /// [`ravel_ingest::IngestConfig::max_flush_delay_idle`] on all three
+    /// ingest pipelines (ADR-0076 decision 4). See `--max-flush-delay-idle`.
+    pub max_flush_delay_idle: Duration,
+    /// Byte threshold below which a buffer is idle-eligible, forwarded to
+    /// [`ravel_ingest::IngestConfig::min_flush_bytes`] on all three ingest
+    /// pipelines (ADR-0076 decision 4). See `--min-flush-bytes`.
+    pub min_flush_bytes: usize,
     pub tenant_resolver: Arc<dyn TenantResolver>,
     /// The dedicated mTLS listener (ADR-0050 section 1), `None` unless
     /// `--mtls-enabled`. Serves the same ingest and query surface as the
@@ -604,6 +616,13 @@ pub async fn start(
                     shard_count: config.shard_count,
                     max_inflight_flushes: config.max_inflight_flushes,
                     adaptive_flush_delay: config.adaptive_flush_delay,
+                    max_flush_delay: config.max_flush_delay,
+                    max_flush_delay_idle: config.max_flush_delay_idle,
+                    min_flush_bytes: config.min_flush_bytes,
+                    // ADR-0076 decision 4: follows the actually-configured
+                    // max_flush_delay, not just its default, so the adaptive
+                    // corridor never contradicts the operator's chosen budget.
+                    strict_visibility_budget_ns: config.max_flush_delay.as_nanos() as i64,
                     ..IngestConfig::default()
                 },
                 store.clone(),
@@ -634,6 +653,10 @@ pub async fn start(
             LogIngestRouter::new_with_indexed_fields(
                 IngestConfig {
                     shard_count: config.shard_count,
+                    max_inflight_flushes: config.max_inflight_flushes,
+                    max_flush_delay: config.max_flush_delay,
+                    max_flush_delay_idle: config.max_flush_delay_idle,
+                    min_flush_bytes: config.min_flush_bytes,
                     ..IngestConfig::default()
                 },
                 store.clone(),
@@ -656,6 +679,10 @@ pub async fn start(
             SpanIngestRouter::new(
                 IngestConfig {
                     shard_count: config.shard_count,
+                    max_inflight_flushes: config.max_inflight_flushes,
+                    max_flush_delay: config.max_flush_delay,
+                    max_flush_delay_idle: config.max_flush_delay_idle,
+                    min_flush_bytes: config.min_flush_bytes,
                     ..IngestConfig::default()
                 },
                 store.clone(),

--- a/services/ravel-server/src/main.rs
+++ b/services/ravel-server/src/main.rs
@@ -384,6 +384,10 @@ async fn main() -> anyhow::Result<()> {
         .context("failed to resolve --remote-cluster settings")?;
     ravel_server::warn_plaintext_federation(&remote_clusters);
 
+    let flush_cadence = cli
+        .resolve_flush_cadence()
+        .context("failed to resolve flush-cadence flags")?;
+
     let config = ServerConfig {
         mode: cli.mode,
         listen_http: cli.listen_http,
@@ -391,6 +395,9 @@ async fn main() -> anyhow::Result<()> {
         shard_count: cli.shards,
         max_inflight_flushes: cli.max_inflight_flushes,
         adaptive_flush_delay: cli.adaptive_flush_delay,
+        max_flush_delay: flush_cadence.max_flush_delay,
+        max_flush_delay_idle: flush_cadence.max_flush_delay_idle,
+        min_flush_bytes: flush_cadence.min_flush_bytes,
         tenant_resolver: resolver_bundle.resolver,
         mtls_listener,
         fold_tenants,
@@ -432,7 +439,9 @@ async fn main() -> anyhow::Result<()> {
         query_concurrency_limit: cli
             .parse_query_concurrency_limit()
             .context("failed to parse --max-concurrent-queries")?,
-        max_s3_requests: cli.resolve_max_s3_requests(),
+        max_s3_requests: cli
+            .resolve_max_s3_requests()
+            .context("failed to resolve --max-s3-requests")?,
         scrub_period: cli
             .parse_scrub_period()
             .context("failed to parse --scrub-period")?,

--- a/services/ravel-server/tests/admission_e2e.rs
+++ b/services/ravel-server/tests/admission_e2e.rs
@@ -98,6 +98,9 @@ async fn start_test_server_with_limits(tenant_limits: AdmissionLimits) -> ravel_
     let config = ServerConfig {
         max_inflight_flushes: 1,
         adaptive_flush_delay: false,
+        max_flush_delay: std::time::Duration::from_secs(2),
+        max_flush_delay_idle: std::time::Duration::from_secs(40),
+        min_flush_bytes: 256 * 1024,
         mode: Mode::All,
         listen_http: "127.0.0.1:0".parse().expect("valid loopback addr"),
         listen_grpc: "127.0.0.1:0".parse().expect("valid loopback addr"),

--- a/services/ravel-server/tests/deadline_shared_across_selectors.rs
+++ b/services/ravel-server/tests/deadline_shared_across_selectors.rs
@@ -85,6 +85,9 @@ async fn start_test_server(store: Arc<dyn ObjectStoreBackend>) -> Running {
     let config = ServerConfig {
         max_inflight_flushes: 1,
         adaptive_flush_delay: false,
+        max_flush_delay: std::time::Duration::from_secs(2),
+        max_flush_delay_idle: std::time::Duration::from_secs(40),
+        min_flush_bytes: 256 * 1024,
         mode: Mode::All,
         listen_http: "127.0.0.1:0".parse().expect("valid loopback addr"),
         listen_grpc: "127.0.0.1:0".parse().expect("valid loopback addr"),

--- a/services/ravel-server/tests/distributed_query_e2e.rs
+++ b/services/ravel-server/tests/distributed_query_e2e.rs
@@ -245,6 +245,9 @@ async fn start_server_with_query_cap(
     let config = ServerConfig {
         max_inflight_flushes: 1,
         adaptive_flush_delay: false,
+        max_flush_delay: std::time::Duration::from_secs(2),
+        max_flush_delay_idle: std::time::Duration::from_secs(40),
+        min_flush_bytes: 256 * 1024,
         mode: Mode::All,
         listen_http: "127.0.0.1:0".parse().expect("valid loopback addr"),
         listen_grpc: "127.0.0.1:0".parse().expect("valid loopback addr"),

--- a/services/ravel-server/tests/error_body_redacts_internal_identifiers.rs
+++ b/services/ravel-server/tests/error_body_redacts_internal_identifiers.rs
@@ -116,6 +116,9 @@ async fn start_test_server() -> (Running, Arc<MemoryStore>) {
     let config = ServerConfig {
         max_inflight_flushes: 1,
         adaptive_flush_delay: false,
+        max_flush_delay: std::time::Duration::from_secs(2),
+        max_flush_delay_idle: std::time::Duration::from_secs(40),
+        min_flush_bytes: 256 * 1024,
         mode: Mode::All,
         listen_http: "127.0.0.1:0".parse().expect("valid loopback addr"),
         listen_grpc: "127.0.0.1:0".parse().expect("valid loopback addr"),

--- a/services/ravel-server/tests/flight_sql.rs
+++ b/services/ravel-server/tests/flight_sql.rs
@@ -665,6 +665,9 @@ async fn the_server_registers_the_real_flight_sql_service() {
     let config = ServerConfig {
         max_inflight_flushes: 1,
         adaptive_flush_delay: false,
+        max_flush_delay: std::time::Duration::from_secs(2),
+        max_flush_delay_idle: std::time::Duration::from_secs(40),
+        min_flush_bytes: 256 * 1024,
         mode: Mode::Query,
         listen_http: "127.0.0.1:0".parse().expect("valid loopback addr"),
         listen_grpc: "127.0.0.1:0".parse().expect("valid loopback addr"),

--- a/services/ravel-server/tests/flight_sql_e2e.rs
+++ b/services/ravel-server/tests/flight_sql_e2e.rs
@@ -322,6 +322,9 @@ async fn flight_sql_against_minio_returns_rows_and_isolates_tenants() {
     let config = ServerConfig {
         max_inflight_flushes: 1,
         adaptive_flush_delay: false,
+        max_flush_delay: std::time::Duration::from_secs(2),
+        max_flush_delay_idle: std::time::Duration::from_secs(40),
+        min_flush_bytes: 256 * 1024,
         mode: Mode::Query,
         listen_http: "127.0.0.1:0".parse().expect("valid loopback addr"),
         listen_grpc: "127.0.0.1:0".parse().expect("valid loopback addr"),

--- a/services/ravel-server/tests/fold_e2e.rs
+++ b/services/ravel-server/tests/fold_e2e.rs
@@ -343,6 +343,9 @@ async fn background_fold_writes_logs_head_independently_of_metrics() {
     let config = ServerConfig {
         max_inflight_flushes: 1,
         adaptive_flush_delay: false,
+        max_flush_delay: std::time::Duration::from_secs(2),
+        max_flush_delay_idle: std::time::Duration::from_secs(40),
+        min_flush_bytes: 256 * 1024,
         mode: Mode::All,
         listen_http: "127.0.0.1:0".parse().expect("valid loopback addr"),
         listen_grpc: "127.0.0.1:0".parse().expect("valid loopback addr"),
@@ -481,6 +484,9 @@ async fn background_fold_writes_head_for_a_sealed_hour() {
     let config = ServerConfig {
         max_inflight_flushes: 1,
         adaptive_flush_delay: false,
+        max_flush_delay: std::time::Duration::from_secs(2),
+        max_flush_delay_idle: std::time::Duration::from_secs(40),
+        min_flush_bytes: 256 * 1024,
         mode: Mode::All,
         listen_http: "127.0.0.1:0".parse().expect("valid loopback addr"),
         listen_grpc: "127.0.0.1:0".parse().expect("valid loopback addr"),

--- a/services/ravel-server/tests/health_endpoints.rs
+++ b/services/ravel-server/tests/health_endpoints.rs
@@ -34,6 +34,9 @@ async fn start_test_server(mode: Mode) -> ravel_server::Running {
     let config = ServerConfig {
         max_inflight_flushes: 1,
         adaptive_flush_delay: false,
+        max_flush_delay: std::time::Duration::from_secs(2),
+        max_flush_delay_idle: std::time::Duration::from_secs(40),
+        min_flush_bytes: 256 * 1024,
         mode,
         listen_http: "127.0.0.1:0".parse().expect("valid loopback addr"),
         listen_grpc: "127.0.0.1:0".parse().expect("valid loopback addr"),

--- a/services/ravel-server/tests/ingest_concurrency_e2e.rs
+++ b/services/ravel-server/tests/ingest_concurrency_e2e.rs
@@ -89,6 +89,9 @@ async fn start_test_server(
     let config = ServerConfig {
         max_inflight_flushes: 1,
         adaptive_flush_delay: false,
+        max_flush_delay: std::time::Duration::from_secs(2),
+        max_flush_delay_idle: std::time::Duration::from_secs(40),
+        min_flush_bytes: 256 * 1024,
         mode: Mode::All,
         listen_http: "127.0.0.1:0".parse().expect("valid loopback addr"),
         listen_grpc: "127.0.0.1:0".parse().expect("valid loopback addr"),

--- a/services/ravel-server/tests/integration.rs
+++ b/services/ravel-server/tests/integration.rs
@@ -79,6 +79,9 @@ async fn start_test_server() -> ravel_server::Running {
     let config = ServerConfig {
         max_inflight_flushes: 1,
         adaptive_flush_delay: false,
+        max_flush_delay: std::time::Duration::from_secs(2),
+        max_flush_delay_idle: std::time::Duration::from_secs(40),
+        min_flush_bytes: 256 * 1024,
         mode: Mode::All,
         listen_http: "127.0.0.1:0".parse().expect("valid loopback addr"),
         listen_grpc: "127.0.0.1:0".parse().expect("valid loopback addr"),

--- a/services/ravel-server/tests/log_ingest_e2e.rs
+++ b/services/ravel-server/tests/log_ingest_e2e.rs
@@ -88,6 +88,9 @@ async fn start_test_server() -> (ravel_server::Running, Arc<MemoryStore>) {
     let config = ServerConfig {
         max_inflight_flushes: 1,
         adaptive_flush_delay: false,
+        max_flush_delay: std::time::Duration::from_secs(2),
+        max_flush_delay_idle: std::time::Duration::from_secs(40),
+        min_flush_bytes: 256 * 1024,
         mode: Mode::All,
         listen_http: "127.0.0.1:0".parse().expect("valid loopback addr"),
         listen_grpc: "127.0.0.1:0".parse().expect("valid loopback addr"),

--- a/services/ravel-server/tests/maintain_ownership_metrics_e2e.rs
+++ b/services/ravel-server/tests/maintain_ownership_metrics_e2e.rs
@@ -51,6 +51,9 @@ fn maintain_config(tenant: &TenantId) -> ServerConfig {
     ServerConfig {
         max_inflight_flushes: 1,
         adaptive_flush_delay: false,
+        max_flush_delay: std::time::Duration::from_secs(2),
+        max_flush_delay_idle: std::time::Duration::from_secs(40),
+        min_flush_bytes: 256 * 1024,
         mode: Mode::Maintain,
         listen_http: "127.0.0.1:0".parse().expect("valid loopback addr"),
         listen_grpc: "127.0.0.1:0".parse().expect("valid loopback addr"),

--- a/services/ravel-server/tests/metrics_endpoint.rs
+++ b/services/ravel-server/tests/metrics_endpoint.rs
@@ -24,6 +24,9 @@ async fn start_test_server(mode: Mode) -> ravel_server::Running {
     let config = ServerConfig {
         max_inflight_flushes: 1,
         adaptive_flush_delay: false,
+        max_flush_delay: std::time::Duration::from_secs(2),
+        max_flush_delay_idle: std::time::Duration::from_secs(40),
+        min_flush_bytes: 256 * 1024,
         mode,
         listen_http: "127.0.0.1:0".parse().expect("valid loopback addr"),
         listen_grpc: "127.0.0.1:0".parse().expect("valid loopback addr"),
@@ -290,6 +293,9 @@ async fn start_admission_server(tenant_labels: bool) -> ravel_server::Running {
     let config = ServerConfig {
         max_inflight_flushes: 1,
         adaptive_flush_delay: false,
+        max_flush_delay: std::time::Duration::from_secs(2),
+        max_flush_delay_idle: std::time::Duration::from_secs(40),
+        min_flush_bytes: 256 * 1024,
         mode: Mode::All,
         listen_http: "127.0.0.1:0".parse().expect("valid loopback addr"),
         listen_grpc: "127.0.0.1:0".parse().expect("valid loopback addr"),
@@ -501,6 +507,9 @@ async fn start_attribution_server() -> ravel_server::Running {
     let config = ServerConfig {
         max_inflight_flushes: 1,
         adaptive_flush_delay: false,
+        max_flush_delay: std::time::Duration::from_secs(2),
+        max_flush_delay_idle: std::time::Duration::from_secs(40),
+        min_flush_bytes: 256 * 1024,
         mode: Mode::All,
         listen_http: "127.0.0.1:0".parse().expect("valid loopback addr"),
         listen_grpc: "127.0.0.1:0".parse().expect("valid loopback addr"),

--- a/services/ravel-server/tests/otap_collector_e2e.rs
+++ b/services/ravel-server/tests/otap_collector_e2e.rs
@@ -89,6 +89,9 @@ async fn start_test_server() -> ravel_server::Running {
     let config = ServerConfig {
         max_inflight_flushes: 1,
         adaptive_flush_delay: false,
+        max_flush_delay: std::time::Duration::from_secs(2),
+        max_flush_delay_idle: std::time::Duration::from_secs(40),
+        min_flush_bytes: 256 * 1024,
         mode: Mode::All,
         // Bound to loopback but reachable from the collector container via
         // `--network host` (Linux only; no Docker Desktop fallback).

--- a/services/ravel-server/tests/otap_grpc.rs
+++ b/services/ravel-server/tests/otap_grpc.rs
@@ -48,6 +48,9 @@ async fn start_test_server() -> ravel_server::Running {
     let config = ServerConfig {
         max_inflight_flushes: 1,
         adaptive_flush_delay: false,
+        max_flush_delay: std::time::Duration::from_secs(2),
+        max_flush_delay_idle: std::time::Duration::from_secs(40),
+        min_flush_bytes: 256 * 1024,
         mode: Mode::All,
         listen_http: "127.0.0.1:0".parse().expect("valid loopback addr"),
         listen_grpc: "127.0.0.1:0".parse().expect("valid loopback addr"),
@@ -107,6 +110,9 @@ async fn start_test_server_with_limits(tenant_limits: AdmissionLimits) -> ravel_
     let config = ServerConfig {
         max_inflight_flushes: 1,
         adaptive_flush_delay: false,
+        max_flush_delay: std::time::Duration::from_secs(2),
+        max_flush_delay_idle: std::time::Duration::from_secs(40),
+        min_flush_bytes: 256 * 1024,
         mode: Mode::All,
         listen_http: "127.0.0.1:0".parse().expect("valid loopback addr"),
         listen_grpc: "127.0.0.1:0".parse().expect("valid loopback addr"),
@@ -172,6 +178,9 @@ async fn start_test_server_fault(
     let config = ServerConfig {
         max_inflight_flushes: 1,
         adaptive_flush_delay: false,
+        max_flush_delay: std::time::Duration::from_secs(2),
+        max_flush_delay_idle: std::time::Duration::from_secs(40),
+        min_flush_bytes: 256 * 1024,
         mode: Mode::All,
         listen_http: "127.0.0.1:0".parse().expect("valid loopback addr"),
         listen_grpc: "127.0.0.1:0".parse().expect("valid loopback addr"),

--- a/services/ravel-server/tests/otlp_trace_export_e2e.rs
+++ b/services/ravel-server/tests/otlp_trace_export_e2e.rs
@@ -222,6 +222,9 @@ fn server_config(tokens: HashMap<String, TenantId>) -> ServerConfig {
     ServerConfig {
         max_inflight_flushes: 1,
         adaptive_flush_delay: false,
+        max_flush_delay: std::time::Duration::from_secs(2),
+        max_flush_delay_idle: std::time::Duration::from_secs(40),
+        min_flush_bytes: 256 * 1024,
         mode: Mode::All,
         listen_http: "127.0.0.1:0".parse().expect("addr"),
         listen_grpc: "127.0.0.1:0".parse().expect("addr"),

--- a/services/ravel-server/tests/prometheus_compat.rs
+++ b/services/ravel-server/tests/prometheus_compat.rs
@@ -34,6 +34,9 @@ async fn start_test_server() -> ravel_server::Running {
     let config = ServerConfig {
         max_inflight_flushes: 1,
         adaptive_flush_delay: false,
+        max_flush_delay: std::time::Duration::from_secs(2),
+        max_flush_delay_idle: std::time::Duration::from_secs(40),
+        min_flush_bytes: 256 * 1024,
         mode: Mode::All,
         listen_http: "127.0.0.1:0".parse().expect("valid loopback addr"),
         listen_grpc: "127.0.0.1:0".parse().expect("valid loopback addr"),

--- a/services/ravel-server/tests/provisioning_e2e.rs
+++ b/services/ravel-server/tests/provisioning_e2e.rs
@@ -98,6 +98,9 @@ async fn start_server(
     let config = ServerConfig {
         max_inflight_flushes: 1,
         adaptive_flush_delay: false,
+        max_flush_delay: std::time::Duration::from_secs(2),
+        max_flush_delay_idle: std::time::Duration::from_secs(40),
+        min_flush_bytes: 256 * 1024,
         mode: Mode::All,
         listen_http: "127.0.0.1:0".parse().expect("valid loopback addr"),
         listen_grpc: "127.0.0.1:0".parse().expect("valid loopback addr"),

--- a/services/ravel-server/tests/query_byte_budget_e2e.rs
+++ b/services/ravel-server/tests/query_byte_budget_e2e.rs
@@ -162,6 +162,9 @@ async fn start_server(
     let config = ServerConfig {
         max_inflight_flushes: 1,
         adaptive_flush_delay: false,
+        max_flush_delay: std::time::Duration::from_secs(2),
+        max_flush_delay_idle: std::time::Duration::from_secs(40),
+        min_flush_bytes: 256 * 1024,
         mode: Mode::All,
         listen_http: "127.0.0.1:0".parse().expect("valid loopback addr"),
         listen_grpc: "127.0.0.1:0".parse().expect("valid loopback addr"),

--- a/services/ravel-server/tests/readyz_e2e.rs
+++ b/services/ravel-server/tests/readyz_e2e.rs
@@ -106,6 +106,9 @@ async fn start_server(store: Arc<dyn ObjectStoreBackend>) -> ravel_server::Runni
     let config = ServerConfig {
         max_inflight_flushes: 1,
         adaptive_flush_delay: false,
+        max_flush_delay: std::time::Duration::from_secs(2),
+        max_flush_delay_idle: std::time::Duration::from_secs(40),
+        min_flush_bytes: 256 * 1024,
         mode: Mode::All,
         listen_http: "127.0.0.1:0".parse().expect("valid loopback addr"),
         listen_grpc: "127.0.0.1:0".parse().expect("valid loopback addr"),

--- a/services/ravel-server/tests/real_authn_e2e.rs
+++ b/services/ravel-server/tests/real_authn_e2e.rs
@@ -58,6 +58,9 @@ async fn start_with_mtls(
     let config = ServerConfig {
         max_inflight_flushes: 1,
         adaptive_flush_delay: false,
+        max_flush_delay: std::time::Duration::from_secs(2),
+        max_flush_delay_idle: std::time::Duration::from_secs(40),
+        min_flush_bytes: 256 * 1024,
         mode: Mode::All,
         listen_http: "127.0.0.1:0".parse().expect("valid loopback addr"),
         listen_grpc: "127.0.0.1:0".parse().expect("valid loopback addr"),

--- a/services/ravel-server/tests/remote_write.rs
+++ b/services/ravel-server/tests/remote_write.rs
@@ -179,6 +179,9 @@ async fn start_test_server_with_limits(tenant_limits: AdmissionLimits) -> ravel_
     let config = ServerConfig {
         max_inflight_flushes: 1,
         adaptive_flush_delay: false,
+        max_flush_delay: std::time::Duration::from_secs(2),
+        max_flush_delay_idle: std::time::Duration::from_secs(40),
+        min_flush_bytes: 256 * 1024,
         mode: Mode::All,
         listen_http: "127.0.0.1:0".parse().expect("valid loopback addr"),
         listen_grpc: "127.0.0.1:0".parse().expect("valid loopback addr"),
@@ -238,6 +241,9 @@ async fn start_test_server() -> ravel_server::Running {
     let config = ServerConfig {
         max_inflight_flushes: 1,
         adaptive_flush_delay: false,
+        max_flush_delay: std::time::Duration::from_secs(2),
+        max_flush_delay_idle: std::time::Duration::from_secs(40),
+        min_flush_bytes: 256 * 1024,
         mode: Mode::All,
         listen_http: "127.0.0.1:0".parse().expect("valid loopback addr"),
         listen_grpc: "127.0.0.1:0".parse().expect("valid loopback addr"),

--- a/services/ravel-server/tests/remote_write_prometheus_e2e.rs
+++ b/services/ravel-server/tests/remote_write_prometheus_e2e.rs
@@ -47,6 +47,9 @@ async fn start_test_server() -> ravel_server::Running {
     let config = ServerConfig {
         max_inflight_flushes: 1,
         adaptive_flush_delay: false,
+        max_flush_delay: std::time::Duration::from_secs(2),
+        max_flush_delay_idle: std::time::Duration::from_secs(40),
+        min_flush_bytes: 256 * 1024,
         mode: Mode::All,
         // Bound to loopback but reachable from the Prometheus container via
         // `--network host`, which puts the container on the host's network

--- a/services/ravel-server/tests/revocation_reachability_e2e.rs
+++ b/services/ravel-server/tests/revocation_reachability_e2e.rs
@@ -53,6 +53,9 @@ async fn start_keyed_server(store: Arc<dyn ObjectStoreBackend>) -> ravel_server:
     let config = ServerConfig {
         max_inflight_flushes: 1,
         adaptive_flush_delay: false,
+        max_flush_delay: std::time::Duration::from_secs(2),
+        max_flush_delay_idle: std::time::Duration::from_secs(40),
+        min_flush_bytes: 256 * 1024,
         mode: Mode::All,
         listen_http: "127.0.0.1:0".parse().expect("valid loopback addr"),
         listen_grpc: "127.0.0.1:0".parse().expect("valid loopback addr"),

--- a/services/ravel-server/tests/scrub_e2e.rs
+++ b/services/ravel-server/tests/scrub_e2e.rs
@@ -40,6 +40,9 @@ fn maintain_config(mode: Mode, tenant: &TenantId) -> ServerConfig {
     ServerConfig {
         max_inflight_flushes: 1,
         adaptive_flush_delay: false,
+        max_flush_delay: std::time::Duration::from_secs(2),
+        max_flush_delay_idle: std::time::Duration::from_secs(40),
+        min_flush_bytes: 256 * 1024,
         mode,
         listen_http: "127.0.0.1:0".parse().expect("valid loopback addr"),
         listen_grpc: "127.0.0.1:0".parse().expect("valid loopback addr"),

--- a/services/ravel-server/tests/trace_ingest_e2e.rs
+++ b/services/ravel-server/tests/trace_ingest_e2e.rs
@@ -100,6 +100,9 @@ async fn start_test_server() -> (ravel_server::Running, Arc<MemoryStore>) {
     let config = ServerConfig {
         max_inflight_flushes: 1,
         adaptive_flush_delay: false,
+        max_flush_delay: std::time::Duration::from_secs(2),
+        max_flush_delay_idle: std::time::Duration::from_secs(40),
+        min_flush_bytes: 256 * 1024,
         mode: Mode::All,
         listen_http: "127.0.0.1:0".parse().expect("valid loopback addr"),
         listen_grpc: "127.0.0.1:0".parse().expect("valid loopback addr"),
@@ -386,6 +389,9 @@ async fn spans_of_one_trace_land_under_one_shard_directory() {
     let config = ServerConfig {
         max_inflight_flushes: 1,
         adaptive_flush_delay: false,
+        max_flush_delay: std::time::Duration::from_secs(2),
+        max_flush_delay_idle: std::time::Duration::from_secs(40),
+        min_flush_bytes: 256 * 1024,
         mode: Mode::All,
         listen_http: "127.0.0.1:0".parse().expect("valid loopback addr"),
         listen_grpc: "127.0.0.1:0".parse().expect("valid loopback addr"),


### PR DESCRIPTION
Exposes the three flush-cadence knobs (max_flush_delay,
max_flush_delay_idle, min_flush_bytes) as bounded operator settings that
move together as a set, per ADR-0076 decision 4. Flips the shipped
default 4x (500ms/10s/64KiB to 2s/40s/256KiB), the lever the epic's
measured-before/after acceptance requirement depends on since the
per-tenant shard mechanism (T4) deliberately left the global shard
default untouched.

Adds fail-closed startup validation: the derived strict-mode
visibility budget must stay under FLUSH_BOUND_SLACK_HOURS and a named
client-timeout ceiling, the idle tier must never flush faster than the
strict tier, and min_flush_bytes must stay reachable below the ingest
pipeline's own size trigger.

Two rounds of adversarial checkpoint review found and fixed real bugs
in the validation logic before this landed:

- The adaptive-delay corridor (ADR-0067 decision 3) was silently
  collapsed to zero width by an operator-controlled visibility budget
  that landed exactly equal to max_flush_delay instead of exceeding it
  by a reserve; a related boundary check used > where >= was needed.
- No check prevented the idle tier from flushing faster than the
  strict tier, an inversion of the design.
- The FLUSH_BOUND_SLACK_HOURS check bounded the wrong knob
  (max_flush_delay instead of max_flush_delay_idle, the real worst-case
  buffer age), leaving max_flush_delay_idle with no upper bound at all.
- A second pass found the fix for that last item had its own gap: a
  plain Duration-to-nanos cast truncates rather than saturates on
  overflow, so an absurd idle value like "1000y" could wrap to a small
  or negative number and silently pass the very check meant to catch
  it. Fixed with a saturating conversion at every reachable call site.

Every fix is backed by a regression test proven to fail against the
prior code before the fix landed.

Fixes: #148
