### PR TITLE
feat(ingest-router): add transparent gRPC (HTTP/2) proxying

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4504,6 +4504,7 @@ dependencies = [
  "k8s-openapi",
  "kube",
  "kube-runtime",
+ "opentelemetry-proto",
  "ravel-affinity",
  "ravel-tenant-resolve",
  "ravel-types",
@@ -4512,6 +4513,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
+ "tonic",
  "tracing",
  "tracing-subscriber",
 ]

--- a/services/ravel-ingest-router/Cargo.toml
+++ b/services/ravel-ingest-router/Cargo.toml
@@ -27,15 +27,30 @@ kube = { workspace = true }
 kube-runtime = { workspace = true }
 k8s-openapi = { workspace = true }
 
-axum = { workspace = true }
+# `http2` is added on top of the workspace pin (axum 0.8's default feature set is
+# HTTP/1 only) so the gRPC listener can speak cleartext HTTP/2 (h2c); the gateway
+# pods serve gRPC over h2c internally, no TLS (#184).
+axum = { workspace = true, features = ["http2"] }
 tokio = { workspace = true }
 # StreamExt over the watcher event stream and the response byte stream.
 futures = { workspace = true }
 # The reverse-proxy HTTP client. `stream` adds streaming request/response bodies
 # (Body::wrap_stream / Response::bytes_stream) so the router proxies bytes
-# without buffering a whole ingest payload in memory. Unions with the workspace
-# pin's `json` feature; the version is unchanged.
-reqwest = { workspace = true, features = ["stream"] }
+# without buffering a whole ingest payload in memory. `http2` enables the
+# cleartext HTTP/2 client mode used by the gRPC proxy (built with
+# `http2_prior_knowledge()`); it is already in reqwest's default feature set, but
+# is named explicitly so a future default change cannot silently drop it (#184).
+# Unions with the workspace pin's `json` feature; the version is unchanged.
+reqwest = { workspace = true, features = ["stream", "http2"] }
+# gRPC status projection only: `tonic::Code`/`tonic::Status` map a RouteError to
+# a gRPC status and build the trailers-only reject response. No service codegen,
+# no `.proto` files: this is a byte-transparent HTTP/2 proxy, not a decoded gRPC
+# service, so the default server/transport/codegen features are turned off (#184).
+# Pinned directly rather than via `workspace = true` because a workspace-inherited
+# dependency cannot turn off `default-features` (cargo rejects the override); the
+# version matches the workspace `tonic` pin, the same convention this crate
+# already uses for `rustls` above.
+tonic = { version = "0.14", default-features = false }
 # blake3 keys the bounded round-robin map by a hash of the tenant key rather
 # than the raw bytes, so no raw bearer token is ever held as a map key.
 blake3 = { workspace = true }
@@ -61,6 +76,16 @@ serde_json = { workspace = true }
 # A local axum backend stands in for a gateway pod; the test client drives the
 # router over a real loopback socket.
 tokio = { workspace = true, features = ["test-util"] }
+# gRPC end-to-end tests: `channel` (a client) and the default server/transport
+# features let a real tonic gRPC server stand in for a gateway pod and a real
+# tonic gRPC client drive the router, proving the transparent proxy round-trips
+# status and trailers with an actual gRPC/HTTP2 stack rather than a byte double.
+tonic = { workspace = true, features = ["channel"] }
+# The OTLP metrics gRPC service definition (generated tonic server + client)
+# reused as the concrete gRPC surface the transparent-proxy tests exercise; it is
+# the real ingest gRPC surface the gateway serves, so no throwaway `.proto` is
+# needed.
+opentelemetry-proto = { workspace = true }
 
 [lints]
 workspace = true

--- a/services/ravel-ingest-router/src/config.rs
+++ b/services/ravel-ingest-router/src/config.rs
@@ -80,6 +80,13 @@ pub struct Cli {
     #[arg(long, default_value = "0.0.0.0:8080")]
     pub listen_http: SocketAddr,
 
+    /// Address the gRPC (HTTP/2 cleartext, h2c) transparent proxy listens on.
+    /// Unset binds no gRPC listener at all: "absent means off", matching this
+    /// crate's existing optional-listener convention. A router that only proxies
+    /// HTTP needs no gRPC socket (#184).
+    #[arg(long, value_name = "ADDR")]
+    pub listen_grpc: Option<SocketAddr>,
+
     // --- Bounded per-tenant round-robin state (ADR-0069 idle eviction) --------
     /// Hard cap on distinct tenant-key entries in the round-robin map. Under
     /// `authorization-header` every distinct token mints an entry and tokens
@@ -181,6 +188,7 @@ pub struct RouterConfig {
     pub subset_size: usize,
     pub key: KeyConfig,
     pub listen_http: SocketAddr,
+    pub listen_grpc: Option<SocketAddr>,
     pub round_robin_max_entries: usize,
     pub round_robin_idle_ttl: Duration,
 }
@@ -240,6 +248,7 @@ impl Cli {
             subset_size: self.subset_size as usize,
             key,
             listen_http: self.listen_http,
+            listen_grpc: self.listen_grpc,
             round_robin_max_entries: self.round_robin_max_entries,
             round_robin_idle_ttl,
         })
@@ -524,6 +533,26 @@ mod tests {
         .into_config()
         .expect_err("OIDC without an audience must fail");
         assert!(err.to_string().contains("--oidc-audience"));
+    }
+
+    #[test]
+    fn listen_grpc_absent_by_default() {
+        let config = cli(&[]).into_config().expect("valid config");
+        assert!(
+            config.listen_grpc.is_none(),
+            "no --listen-grpc means no gRPC listener is bound"
+        );
+    }
+
+    #[test]
+    fn listen_grpc_parses_when_set() {
+        let config = cli(&["--listen-grpc", "0.0.0.0:4317"])
+            .into_config()
+            .expect("valid config");
+        assert_eq!(
+            config.listen_grpc,
+            Some("0.0.0.0:4317".parse().expect("addr"))
+        );
     }
 
     #[test]

--- a/services/ravel-ingest-router/src/grpc.rs
+++ b/services/ravel-ingest-router/src/grpc.rs
@@ -1,0 +1,162 @@
+//! gRPC (HTTP/2 cleartext) transparent proxy (#184, deliverable 3).
+//!
+//! This is the gRPC-transport analogue of [`crate::proxy`], not a second
+//! selection implementation: it calls the exact same
+//! [`RouterState::resolve_and_select`](crate::router::RouterState::resolve_and_select)
+//! boundary the HTTP proxy uses, then forwards the request as raw HTTP/2 frames
+//! to the selected pod's dial address without decoding the gRPC message envelope
+//! (ADR-0080 decision 3: a transparent HTTP/2-level proxy that preserves gRPC
+//! framing is sufficient; the router never parses OTLP proto here).
+//!
+//! # Framing of a router-rejected request
+//!
+//! When selection itself fails (cold start, exhausted subset, canonical-tenant
+//! resolution failure, or a forwarding failure to the chosen backend), the
+//! router has not read a single gRPC frame, so there is nothing to stream back.
+//! It answers with a **trailers-only** gRPC response: HTTP 200,
+//! `content-type: application/grpc`, and the `grpc-status`/`grpc-message`
+//! carried in the initial HEADERS frame (an empty body, so that frame also ends
+//! the stream). This is the canonical gRPC error encoding for an immediate
+//! error, and a gRPC client reads `grpc-status` straight from the response
+//! headers in this case (see `tonic::Status::from_header_map`, exercised by the
+//! `grpc_canonical_tenant_resolution_failure_rejects_with_unauthenticated`
+//! test). [`tonic::Status::into_http`] builds exactly this shape from the
+//! [`RouteError::grpc_code`](crate::select::RouteError) mapping, so the reject
+//! path reuses the same status projection deliverable 2 defines rather than
+//! hand-assembling headers.
+//!
+//! # Trailer transparency on the success path
+//!
+//! A real gRPC response carries its outcome in HTTP/2 *trailers*
+//! (`grpc-status`/`grpc-message` after the message body). `reqwest`'s
+//! `bytes_stream()` yields only data frames and would silently drop those
+//! trailers, so this module instead converts the upstream response into
+//! `http::Response<reqwest::Body>` (whose body forwards trailer frames untouched)
+//! and re-wraps it as an [`axum::body::Body`], leaving the backend's trailers to
+//! reach the client unmodified whenever this router did not itself reject the
+//! request.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use axum::Router;
+use axum::body::Body;
+use axum::extract::{Request, State};
+use axum::http::{HeaderMap, HeaderName};
+use axum::response::Response;
+use axum::routing::any;
+
+use crate::router::RouterState;
+use crate::select::RouteError;
+
+/// Build the gRPC proxy app: a single catch-all handler over every path, since a
+/// transparent proxy routes by tenant key, not by gRPC method path.
+pub(crate) fn build_app(state: Arc<RouterState>) -> Router {
+    Router::new().fallback(any(proxy)).with_state(state)
+}
+
+/// The catch-all gRPC handler: select, then forward, mirroring
+/// [`crate::proxy::proxy`] but over HTTP/2 with gRPC-aware framing.
+async fn proxy(State(state): State<Arc<RouterState>>, req: Request) -> Response {
+    let (parts, body) = req.into_parts();
+    let selection = match state.resolve_and_select(&parts.headers) {
+        Ok(sel) => sel,
+        // The router rejected before reading any gRPC frame: answer with a
+        // trailers-only gRPC error carrying the mapped status. No key bytes ever
+        // reach the response (RouteError's Display strings carry none).
+        Err(err) => return reject(&err),
+    };
+
+    match forward(&state.grpc_http, selection.addr, parts, body).await {
+        Ok(response) => response,
+        Err(err) => {
+            tracing::warn!(addr = %selection.addr, error = %err, "grpc upstream forward failed");
+            reject(&RouteError::Upstream)
+        }
+    }
+}
+
+/// Encode a [`RouteError`] as a trailers-only gRPC error response the client
+/// parses as the mapped [`tonic::Code`].
+fn reject(err: &RouteError) -> Response {
+    // `into_http` sets HTTP 200, `content-type: application/grpc`, and the
+    // `grpc-status`/`grpc-message` headers over an empty (`Body::default`) body.
+    tonic::Status::new(err.grpc_code(), err.to_string()).into_http::<Body>()
+}
+
+/// Forward the request to `addr` over cleartext HTTP/2 and stream the response
+/// back, preserving gRPC response trailers.
+async fn forward(
+    client: &reqwest::Client,
+    addr: SocketAddr,
+    parts: axum::http::request::Parts,
+    body: Body,
+) -> Result<Response, reqwest::Error> {
+    let path_and_query = parts
+        .uri
+        .path_and_query()
+        .map(|pq| pq.as_str())
+        .unwrap_or("/");
+    // Dial the pod address directly, exactly like the HTTP proxy: the authority
+    // is the endpoint IP:port from the EndpointSlice, never a Service name, so
+    // kube-proxy cannot re-spread the connection and undo the subset selection.
+    let url = format!("http://{addr}{path_and_query}");
+
+    let mut headers = parts.headers.clone();
+    strip_hop_by_hop(&mut headers);
+    // reqwest sets Host from the URL authority (the pod address); a forwarded
+    // client Host would conflict with it.
+    headers.remove(axum::http::header::HOST);
+
+    // gRPC requests carry their payload (and end-of-stream) in DATA frames, not
+    // trailers, so streaming the data frames through is fully transparent for the
+    // request direction. The `http2_prior_knowledge()` client sends this over
+    // h2c to the tonic backend.
+    let upstream = client
+        .request(parts.method, url)
+        .headers(headers)
+        .body(reqwest::Body::wrap_stream(body.into_data_stream()))
+        .send()
+        .await?;
+
+    // Convert into `http::Response<reqwest::Body>` so the response body still
+    // yields trailer frames (`grpc-status`/`grpc-message`); `bytes_stream()`
+    // would drop them. `Body::new` re-wraps that body for axum, preserving the
+    // frames end to end.
+    let http_resp: axum::http::Response<reqwest::Body> = axum::http::Response::from(upstream);
+    let (mut resp_parts, resp_body) = http_resp.into_parts();
+    // Strip hop-by-hop response headers. gRPC trailers live in body frames, not
+    // here, so they are untouched.
+    strip_hop_by_hop(&mut resp_parts.headers);
+    Ok(Response::from_parts(resp_parts, Body::new(resp_body)))
+}
+
+/// Connection-management headers that must not be forwarded across a proxy hop.
+///
+/// Unlike the HTTP proxy's list ([`crate::proxy`]), this deliberately keeps `te`
+/// and `trailer`: gRPC-over-HTTP/2 relies on `te: trailers`, and stripping it
+/// would break trailer negotiation with a strict backend. The remaining
+/// connection-specific headers are illegal in HTTP/2 anyway, so removing them
+/// keeps the forwarded request well-formed.
+fn is_hop_by_hop(name: &HeaderName) -> bool {
+    matches!(
+        name.as_str(),
+        "connection"
+            | "keep-alive"
+            | "proxy-authenticate"
+            | "proxy-authorization"
+            | "transfer-encoding"
+            | "upgrade"
+    )
+}
+
+fn strip_hop_by_hop(headers: &mut HeaderMap) {
+    let drop: Vec<HeaderName> = headers
+        .keys()
+        .filter(|n| is_hop_by_hop(n))
+        .cloned()
+        .collect();
+    for name in drop {
+        headers.remove(name);
+    }
+}

--- a/services/ravel-ingest-router/src/lib.rs
+++ b/services/ravel-ingest-router/src/lib.rs
@@ -1,11 +1,18 @@
-//! Ravel-native subset-affinity ingest router (ADR-0080 decision 3, T6a).
+//! Ravel-native subset-affinity ingest router (ADR-0080 decision 3, T6a/T6b).
 //!
-//! A horizontally-scalable HTTP reverse proxy that pins each tenant's ingest
-//! traffic to a stable subset-of-`S` gateway pods, computed with rendezvous
-//! (HRW) hashing over the pods' own `EndpointSlice` identities. Requests are
-//! dialed **directly to the chosen pod address**, never through the gateway
-//! Service's cluster IP, so kube-proxy's own load balancing cannot undo the
-//! subset selection.
+//! A horizontally-scalable reverse proxy that pins each tenant's ingest traffic
+//! to a stable subset-of-`S` gateway pods, computed with rendezvous (HRW)
+//! hashing over the pods' own `EndpointSlice` identities. Requests are dialed
+//! **directly to the chosen pod address**, never through the gateway Service's
+//! cluster IP, so kube-proxy's own load balancing cannot undo the subset
+//! selection.
+//!
+//! Two transports share one selection core: an HTTP reverse proxy on
+//! `--listen-http` ([`proxy`]) and, when `--listen-grpc` is set, a transparent
+//! gRPC (HTTP/2 cleartext) proxy ([`grpc`]) that preserves gRPC framing and
+//! trailers without decoding the message envelope. Both call the same
+//! [`router::RouterState::resolve_and_select`]; the gRPC path is the transport
+//! analogue of the HTTP one, not a second selection implementation.
 //!
 //! # Request path
 //!
@@ -19,11 +26,12 @@
 //!    the top `subset_size` as the working subset, pick one member by bounded
 //!    per-tenant round-robin, and fall through the HRW order past position `S`
 //!    for any member not present in the Ready snapshot.
-//! 3. [`proxy`]: reverse-proxy the request to the selected pod's dial address.
+//! 3. [`proxy`] (HTTP) or [`grpc`] (gRPC/HTTP2): reverse-proxy the request to
+//!    the selected pod's dial address.
 //!
 //! The protocol-agnostic core of steps 1-2 is
-//! [`router::RouterState::resolve_and_select`]; the follow-up gRPC task (#184)
-//! calls it directly rather than reimplementing selection.
+//! [`router::RouterState::resolve_and_select`]; the gRPC transport ([`grpc`],
+//! #184) calls it directly rather than reimplementing selection.
 //!
 //! # Cold start
 //!
@@ -38,6 +46,7 @@ pub mod config;
 pub(crate) mod auth;
 pub(crate) mod clock;
 pub(crate) mod endpoints;
+pub(crate) mod grpc;
 pub(crate) mod key;
 pub(crate) mod proxy;
 pub(crate) mod router;
@@ -95,6 +104,16 @@ pub async fn run(config: RouterConfig) -> anyhow::Result<()> {
         .redirect(reqwest::redirect::Policy::none())
         .build()?;
 
+    // The gRPC forwarding client. `http2_prior_knowledge()` forces cleartext
+    // HTTP/2 (h2c) with no ALPN/upgrade dance, matching how the gateway pods
+    // serve gRPC internally (the HTTP proxy already dials plain `http://`). It is
+    // a separate client from `http` because prior-knowledge mode cannot also
+    // serve the HTTP/1 proxy path.
+    let grpc_http = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .http2_prior_knowledge()
+        .build()?;
+
     let state = Arc::new(router::RouterState {
         endpoints: store,
         key_resolver,
@@ -102,6 +121,7 @@ pub async fn run(config: RouterConfig) -> anyhow::Result<()> {
         round_robin: select::RoundRobin::new(config.round_robin_max_entries, idle_ttl_ns),
         clock: Arc::new(clock::SystemClock),
         http,
+        grpc_http,
     });
 
     // Bound the round-robin map over time: sweep entries idle past the TTL on
@@ -111,15 +131,33 @@ pub async fn run(config: RouterConfig) -> anyhow::Result<()> {
     let listener = tokio::net::TcpListener::bind(config.listen_http).await?;
     tracing::info!(addr = %config.listen_http, "ravel-ingest-router listening");
 
+    // Bind the gRPC listener only when configured ("absent means off"): an unset
+    // `--listen-grpc` binds no socket and spawns no task. When set, it joins the
+    // same watcher race below as a third arm.
+    let grpc_listener = match config.listen_grpc {
+        Some(addr) => {
+            let l = tokio::net::TcpListener::bind(addr).await?;
+            tracing::info!(addr = %addr, "ravel-ingest-router gRPC listening");
+            Some(l)
+        }
+        None => None,
+    };
+    let grpc_app = grpc::build_app(state.clone());
+
     // The watcher normally never returns (kube_runtime::watcher turns errors
     // into stream items and retries with backoff internally, per watch::run's
     // own doc comment). If its task does return or panic, the process must not
     // keep serving on an endpoint snapshot that will never update again: a
     // silently-dead watcher would route tenant ingest to an increasingly stale
     // (and, after enough pod churn, wrong) set of addresses while /readyz kept
-    // reporting healthy. Race it against the HTTP server and exit on either.
+    // reporting healthy. Race it against BOTH listeners and exit on any arm, so a
+    // dead watcher tears the whole process down regardless of which listener(s)
+    // are active.
     tokio::select! {
         result = axum::serve(listener, proxy::build_app(state)) => {
+            result?;
+        }
+        result = serve_optional_grpc(grpc_listener, grpc_app) => {
             result?;
         }
         watch_result = watch_handle => {
@@ -133,6 +171,20 @@ pub async fn run(config: RouterConfig) -> anyhow::Result<()> {
         }
     }
     Ok(())
+}
+
+/// Serve the gRPC listener when one is bound, or park forever when it is not, so
+/// this can be a `tokio::select!` arm whether or not `--listen-grpc` was set.
+/// When absent, it never resolves, so the select is driven only by the HTTP
+/// server and the watcher, and nothing is bound or spawned for gRPC.
+async fn serve_optional_grpc(
+    listener: Option<tokio::net::TcpListener>,
+    app: axum::Router,
+) -> std::io::Result<()> {
+    match listener {
+        Some(listener) => axum::serve(listener, app).await,
+        None => std::future::pending().await,
+    }
 }
 
 /// Periodically evict idle round-robin entries. A swept entry restarts at

--- a/services/ravel-ingest-router/src/router.rs
+++ b/services/ravel-ingest-router/src/router.rs
@@ -25,6 +25,11 @@ pub(crate) struct RouterState {
     pub round_robin: RoundRobin,
     pub clock: Arc<dyn Clock>,
     pub http: reqwest::Client,
+    /// The forwarding client for the gRPC listener ([`crate::grpc`]). Separate
+    /// from `http` because it is built with `http2_prior_knowledge()`, which
+    /// forces every request onto cleartext HTTP/2 (h2c) and so cannot serve the
+    /// HTTP/1 proxy path.
+    pub grpc_http: reqwest::Client,
 }
 
 impl RouterState {
@@ -66,6 +71,26 @@ impl RouteError {
             RouteError::Unauthenticated => StatusCode::UNAUTHORIZED,
             RouteError::Exhausted => StatusCode::SERVICE_UNAVAILABLE,
             RouteError::Upstream => StatusCode::BAD_GATEWAY,
+        }
+    }
+
+    /// The gRPC status code a [`RouteError`] maps to (deliverable 2 of #184).
+    ///
+    /// This is the same enum's second status-code projection, alongside
+    /// [`RouteError::status`], for the gRPC transport ([`crate::grpc`]). The
+    /// mapping is not identical to the HTTP one: a cold-start/not-ready or
+    /// exhausted-subset condition and an upstream forwarding failure are all
+    /// retryable *availability* problems to a gRPC caller, so they map to
+    /// `Unavailable` (the HTTP projection distinguishes 503 from a 502 bad
+    /// gateway, a distinction gRPC's code space does not carry). A resolution
+    /// failure is `Unauthenticated`, matching the 401 projection and ADR-0080's
+    /// fail-closed rule. Like `status`, it carries no key bytes.
+    pub(crate) fn grpc_code(&self) -> tonic::Code {
+        match self {
+            RouteError::NotSynced => tonic::Code::Unavailable,
+            RouteError::Unauthenticated => tonic::Code::Unauthenticated,
+            RouteError::Exhausted => tonic::Code::Unavailable,
+            RouteError::Upstream => tonic::Code::Unavailable,
         }
     }
 }

--- a/services/ravel-ingest-router/src/tests.rs
+++ b/services/ravel-ingest-router/src/tests.rs
@@ -24,6 +24,18 @@ use crate::proxy::build_app;
 use crate::router::RouterState;
 use crate::select::RoundRobin;
 
+// gRPC transparent-proxy tests (#184) use a real tonic gRPC server as the
+// gateway-pod backend and a real tonic gRPC client to drive the router, so the
+// status/trailer round-trip is proven over an actual gRPC/HTTP2 stack rather
+// than a byte-level double.
+use opentelemetry_proto::tonic::collector::metrics::v1::metrics_service_client::MetricsServiceClient;
+use opentelemetry_proto::tonic::collector::metrics::v1::metrics_service_server::{
+    MetricsService, MetricsServiceServer,
+};
+use opentelemetry_proto::tonic::collector::metrics::v1::{
+    ExportMetricsServiceRequest, ExportMetricsServiceResponse,
+};
+
 // --- test harness ------------------------------------------------------------
 
 /// A fixed clock, so the round-robin idle logic is deterministic in tests.
@@ -95,6 +107,11 @@ fn state(
         clock: Arc::new(FakeClock(0)),
         http: reqwest::Client::builder()
             .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .unwrap(),
+        grpc_http: reqwest::Client::builder()
+            .redirect(reqwest::redirect::Policy::none())
+            .http2_prior_knowledge()
             .build()
             .unwrap(),
     })
@@ -496,5 +513,268 @@ async fn tenant_key_bytes_never_appear_in_an_error_body() {
     assert!(
         !body.contains(secret),
         "the tenant key (bearer token) must never appear in an error body; got {body:?}"
+    );
+}
+
+// --- gRPC transparent-proxy tests (#184) ------------------------------------
+
+/// A real tonic gRPC backend standing in for a gateway pod. It implements the
+/// OTLP `MetricsService`, records each `export` it receives so a test can prove
+/// which pod address the router dialed, and returns a normal success response
+/// (so tonic emits its `grpc-status: 0` trailer). A successful client call
+/// therefore proves the response trailers round-tripped through the router: if
+/// the proxy had dropped them, the tonic client would fail with a missing
+/// `grpc-status`.
+struct GrpcBackend {
+    hits: Hits,
+    tag: &'static str,
+}
+
+#[tonic::async_trait]
+impl MetricsService for GrpcBackend {
+    async fn export(
+        &self,
+        _request: tonic::Request<ExportMetricsServiceRequest>,
+    ) -> Result<tonic::Response<ExportMetricsServiceResponse>, tonic::Status> {
+        self.hits.lock().unwrap().push(self.tag.to_string());
+        Ok(tonic::Response::new(ExportMetricsServiceResponse::default()))
+    }
+}
+
+/// Spawn a real gRPC (h2c) backend on a loopback port. Returns its bound address
+/// and the hits recorder.
+async fn spawn_grpc_backend(tag: &'static str) -> (SocketAddr, Hits) {
+    let hits: Hits = Arc::new(Mutex::new(Vec::new()));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let svc = GrpcBackend {
+        hits: hits.clone(),
+        tag,
+    };
+    tokio::spawn(async move {
+        tonic::transport::Server::builder()
+            .add_service(MetricsServiceServer::new(svc))
+            .serve_with_incoming(tonic::transport::server::TcpIncoming::from(listener))
+            .await
+            .unwrap();
+    });
+    (addr, hits)
+}
+
+/// A gRPC client pointed at the router, carrying `authorization` metadata as the
+/// tenant key (matching `KeyResolver::Header(AUTHORIZATION)`).
+async fn grpc_export_with_auth(
+    router_addr: SocketAddr,
+    auth: &str,
+) -> Result<tonic::Response<ExportMetricsServiceResponse>, tonic::Status> {
+    let channel = tonic::transport::Channel::from_shared(format!("http://{router_addr}"))
+        .unwrap()
+        .connect()
+        .await
+        .unwrap();
+    let mut client = MetricsServiceClient::new(channel);
+    let mut request = tonic::Request::new(ExportMetricsServiceRequest::default());
+    request
+        .metadata_mut()
+        .insert("authorization", auth.parse().unwrap());
+    client.export(request).await
+}
+
+#[tokio::test]
+async fn grpc_request_is_proxied_to_hrw_selected_pod_endpoint_not_service_vip() {
+    // Two real gRPC backends on distinct loopback ports stand in for two gateway
+    // pods. Each is injected as a Ready endpoint whose dial address IS that
+    // backend's real bound address; the router knows no Service name or VIP.
+    let (addr_a, hits_a) = spawn_grpc_backend("a").await;
+    let (addr_b, hits_b) = spawn_grpc_backend("b").await;
+
+    let store = Arc::new(EndpointStore::new(None));
+    let slice_a = slice(
+        "gw-a",
+        "gw",
+        addr_a.port() as i32,
+        &[TestEndpoint {
+            uid: "uid-a",
+            ip: "127.0.0.1",
+            ready: true,
+        }],
+    );
+    let slice_b = slice(
+        "gw-b",
+        "gw",
+        addr_b.port() as i32,
+        &[TestEndpoint {
+            uid: "uid-b",
+            ip: "127.0.0.1",
+            ready: true,
+        }],
+    );
+    sync_slices(&store, vec![slice_a, slice_b]);
+
+    // Compute the HRW winner independently of the router, exactly as the HTTP
+    // test does, so the assertion is against `ravel_affinity::rank`'s own answer.
+    let key = b"Bearer grpc-token";
+    let id_a = ReplicaId::new(b"uid-a".to_vec());
+    let id_b = ReplicaId::new(b"uid-b".to_vec());
+    let reps = [id_a.clone(), id_b.clone()];
+    let ranked = rank(key, &reps);
+    let winner = ranked[0].clone();
+    let (winner_hits, loser_hits) = if winner == id_a {
+        (hits_a.clone(), hits_b.clone())
+    } else {
+        (hits_b.clone(), hits_a.clone())
+    };
+
+    // subset_size 1: the subset is exactly the HRW winner.
+    let state = state(store, KeyResolver::Header(AUTHORIZATION), 1);
+    let router_addr = spawn_router(crate::grpc::build_app(state)).await;
+
+    // A successful unary export proves the backend's `grpc-status: 0` trailer
+    // round-tripped through the router unmodified: tonic errors on a missing one.
+    let response = grpc_export_with_auth(router_addr, "Bearer grpc-token")
+        .await
+        .expect("gRPC export must succeed through the proxy with trailers intact");
+    // The response body itself also round-tripped (decoded by the real client).
+    let _ = response.into_inner();
+
+    assert_eq!(
+        winner_hits.lock().unwrap().len(),
+        1,
+        "the HRW-selected pod received exactly one gRPC request at its own address"
+    );
+    assert!(
+        loser_hits.lock().unwrap().is_empty(),
+        "the non-selected pod must receive no gRPC traffic (no Service-VIP spraying)"
+    );
+}
+
+#[tokio::test]
+async fn grpc_canonical_tenant_resolution_failure_rejects_with_unauthenticated() {
+    // A Ready backend is registered so that any stray proxy attempt would be
+    // recorded. It must not be: canonical-tenant resolution failure is
+    // fail-closed and rejected as gRPC UNAUTHENTICATED, never proxied.
+    let (addr, hits) = spawn_grpc_backend("a").await;
+    let store = Arc::new(EndpointStore::new(None));
+    let s = slice(
+        "gw",
+        "gw",
+        addr.port() as i32,
+        &[TestEndpoint {
+            uid: "uid-a",
+            ip: "127.0.0.1",
+            ready: true,
+        }],
+    );
+    sync_one_slice(&store, s);
+
+    struct AlwaysFail;
+    impl ravel_tenant_resolve::TenantResolver for AlwaysFail {
+        fn resolve(
+            &self,
+            _headers: &axum::http::HeaderMap,
+        ) -> Result<ravel_types::TenantId, ravel_tenant_resolve::AuthError> {
+            Err(ravel_tenant_resolve::AuthError)
+        }
+    }
+
+    let state = state(store, KeyResolver::Canonical(Arc::new(AlwaysFail)), 2);
+    let router_addr = spawn_router(crate::grpc::build_app(state)).await;
+
+    let status = grpc_export_with_auth(router_addr, "Bearer whatever")
+        .await
+        .expect_err("canonical-tenant resolution failure must reject the gRPC call");
+    assert_eq!(
+        status.code(),
+        tonic::Code::Unauthenticated,
+        "fail-closed resolution failure maps to gRPC UNAUTHENTICATED"
+    );
+    assert!(
+        hits.lock().unwrap().is_empty(),
+        "fail-closed: no gRPC request may reach any backend on resolution failure"
+    );
+}
+
+#[tokio::test]
+async fn grpc_rejects_traffic_before_first_watcher_sync() {
+    // The gRPC listener applies the same cold-start gate as the HTTP path: a
+    // request before the first watcher sync is rejected (gRPC UNAVAILABLE) and
+    // no backend is dialed. Prove the gRPC handler actually reaches
+    // resolve_and_select under this condition, not just that the pure function
+    // rejects.
+    let (addr, hits) = spawn_grpc_backend("a").await;
+    let store = Arc::new(EndpointStore::new(None));
+    assert!(!store.is_synced());
+    // Register the backend address so a (buggy) proxy attempt could reach it;
+    // the store is deliberately left un-synced (no InitDone).
+    let _ = addr;
+
+    let state = state(store, KeyResolver::Header(AUTHORIZATION), 2);
+    let router_addr = spawn_router(crate::grpc::build_app(state)).await;
+
+    let status = grpc_export_with_auth(router_addr, "Bearer grpc-token")
+        .await
+        .expect_err("a pre-sync gRPC request must be rejected");
+    assert_eq!(
+        status.code(),
+        tonic::Code::Unavailable,
+        "cold start maps to gRPC UNAVAILABLE"
+    );
+    assert!(
+        hits.lock().unwrap().is_empty(),
+        "no gRPC proxy attempt may happen against an unsynced (empty) subset"
+    );
+}
+
+#[tokio::test]
+async fn grpc_unready_subset_member_falls_through_to_next_ranked_replica() {
+    // The HRW-ranked top member is NotReady; with subset_size 1 the subset is
+    // just that top member, so the gRPC request must fall through to the
+    // next-ranked Ready replica rather than failing. This proves the gRPC
+    // handler reaches the same `resolve_and_select` fallthrough the HTTP path
+    // uses, over the gRPC transport.
+    let (addr, hits) = spawn_grpc_backend("a").await;
+
+    let key = b"Bearer grpc-token";
+    let id_a = ReplicaId::new(b"uid-a".to_vec());
+    let id_b = ReplicaId::new(b"uid-b".to_vec());
+    let reps = [id_a.clone(), id_b.clone()];
+    let ranked = rank(key, &reps);
+    let top = ranked[0].clone();
+    let next = ranked[1].clone();
+
+    // The rank-top endpoint is NotReady; the next-ranked endpoint is Ready and
+    // points at the single running backend.
+    let uid_top: &'static str = if top == id_a { "uid-a" } else { "uid-b" };
+    let uid_next: &'static str = if next == id_a { "uid-a" } else { "uid-b" };
+    let s = slice(
+        "gw",
+        "gw",
+        addr.port() as i32,
+        &[
+            TestEndpoint {
+                uid: uid_top,
+                ip: "127.0.0.1",
+                ready: false,
+            },
+            TestEndpoint {
+                uid: uid_next,
+                ip: "127.0.0.1",
+                ready: true,
+            },
+        ],
+    );
+    let store = Arc::new(EndpointStore::new(None));
+    sync_one_slice(&store, s);
+
+    let state = state(store, KeyResolver::Header(AUTHORIZATION), 1);
+    let router_addr = spawn_router(crate::grpc::build_app(state)).await;
+
+    grpc_export_with_auth(router_addr, "Bearer grpc-token")
+        .await
+        .expect("gRPC request falls through to the next-ranked Ready replica");
+    assert_eq!(
+        hits.lock().unwrap().len(),
+        1,
+        "the next-ranked Ready replica received the gRPC request over the fallthrough path"
     );
 }


### PR DESCRIPTION
Adds a gRPC listener to services/ravel-ingest-router (#157) alongside its
existing HTTP proxy, per ADR-0080 decision 3. Reuses the exact same
selection pipeline (RouterState::resolve_and_select) the HTTP proxy
already calls -- key resolution, HRW subset ranking, bounded round-robin
pick, and the not-Ready fallthrough are shared, not reimplemented for the
new protocol. Dials the selected pod's EndpointSlice address directly,
same as HTTP, never the gateway Service's cluster IP.

A router-rejected gRPC request (cold start, fail-closed canonical-tenant
resolution, or exhaustion) is signaled via trailers-only framing (HTTP 200
plus grpc-status in the initial HEADERS frame, no body) -- canonical
gRPC-over-HTTP/2 error framing, verified against a real tonic client, not
a byte-level test double. A request the router accepts is forwarded as raw
HTTP/2 frames with the gRPC message envelope untouched, so the real
backend's own grpc-status/grpc-message trailers reach the caller
unmodified.

The new --listen-grpc flag is optional; when unset, no gRPC listener binds
at all, matching this crate's existing "absent means off" convention. It
joins the existing watcher/HTTP-listener race as a third arm, so a dead
EndpointSlice watcher still exits the whole process regardless of which
listeners are active.

Wiring this into the operator (rendering a Deployment that actually sets
--listen-grpc, and routing GRPCRoute traffic through the router) is
tracked separately in #194: this crate's EndpointStore resolves one gateway
port per process, shared by every listener, so a single router Deployment
cannot yet proxy HTTP to the gateway's http port and gRPC to its grpc port
at the same time. That's a real design decision (two router Deployments,
or a per-listener port surface), not a rendering tweak, and is why #158
(landing alongside this PR) deliberately keeps the GRPCRoute on the gateway
Service for now.

Fixes: #184
Refs: #150
