### PR TITLE
feat(ravel-operator): wire backend ravelNative end to end

### DIFF
--- a/deploy/k8s/operator/crd.yaml
+++ b/deploy/k8s/operator/crd.yaml
@@ -186,12 +186,18 @@
                                 "enum": [
                                   "authorizationHeader",
                                   "header",
-                                  "mtlsSubject"
+                                  "mtlsSubject",
+                                  "canonicalTenant"
                                 ],
                                 "type": "string"
                               }
                             },
                             "type": "object"
+                          },
+                          "routerImage": {
+                            "description": "Container image for the `ravel-ingest-router` Deployment rendered under\n[`AffinityBackend::RavelNative`] (ADR-0080 decision 3).\n\nThe router is a DIFFERENT binary from `spec.image` (which is\n`ravel-server`), so its image cannot be derived from `spec.image` and is\nnamed explicitly here. Deriving it by string-manipulating `spec.image`\nwould be fragile: an image reference host can carry a port\n(`localhost:5000/ravel-server:v1`), so any split-on-`:` guess breaks.\n\nRequired when `backend: ravelNative`: the operator surfaces a `Degraded`\nstatus condition (reason `RouterImageMissing`) and renders no router\nobjects when it is absent, rather than a Deployment with an empty\n`image:` that would never schedule. Has no effect under\n`backend: ingressNginx`.",
+                            "nullable": true,
+                            "type": "string"
                           },
                           "subsetSize": {
                             "default": 2,
@@ -250,6 +256,10 @@
                       {
                         "message": "gateway.exposure.gatewayApi cannot be combined with an enabled gateway.ingestAffinity on backend: ingressNginx -- traffic on the Gateway API path would bypass the nginx subset annotations entirely; use backend: ravelNative or disable ingestAffinity",
                         "rule": "!has(self.exposure) || !has(self.exposure.gatewayApi) || !has(self.ingestAffinity) || !has(self.ingestAffinity.enabled) || !self.ingestAffinity.enabled || !has(self.ingestAffinity.backend) || self.ingestAffinity.backend != 'ingressNginx'"
+                      },
+                      {
+                        "message": "gateway.ingestAffinity.key.source canonicalTenant requires backend: ravelNative -- ingress-nginx cannot run the ravel-tenant-resolve auth chain that canonical-tenant hashing needs",
+                        "rule": "!has(self.ingestAffinity) || !has(self.ingestAffinity.key) || !has(self.ingestAffinity.key.source) || self.ingestAffinity.key.source != 'canonicalTenant' || !has(self.ingestAffinity.backend) || self.ingestAffinity.backend != 'ingressNginx'"
                       }
                     ]
                   },

--- a/deploy/k8s/operator/rbac.yaml
+++ b/deploy/k8s/operator/rbac.yaml
@@ -13,6 +13,12 @@
 #   - RavelCluster (and its status subresource): watch the spec, write status.
 #   - Secrets: get only. The operator reads the credentials and tenant-token
 #     Secrets to resolve tenant names; it never lists, writes, or watches them.
+#   - ServiceAccounts, Roles, and RoleBindings: the same lifecycle, for the
+#     ravel-native ingest router's own ServiceAccount and its namespaced,
+#     least-privilege Role/RoleBinding (ADR-0080 decision 3). The operator's own
+#     identity needs these verbs to create those objects for the router; delete
+#     is what lets backend: ravelNative be switched away without leaving the
+#     router's RBAC orphaned.
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -42,6 +48,12 @@ rules:
     verbs: ["create", "update", "patch", "get", "list", "watch", "delete"]
   - apiGroups: ["gateway.networking.k8s.io"]
     resources: ["httproutes", "grpcroutes"]
+    verbs: ["create", "update", "patch", "get", "list", "watch", "delete"]
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["create", "update", "patch", "get", "list", "watch", "delete"]
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["roles", "rolebindings"]
     verbs: ["create", "update", "patch", "get", "list", "watch", "delete"]
   - apiGroups: ["ravel.nofire.ai"]
     resources: ["ravelclusters"]

--- a/deploy/k8s/operator/rbac.yaml
+++ b/deploy/k8s/operator/rbac.yaml
@@ -19,6 +19,14 @@
 #     identity needs these verbs to create those objects for the router; delete
 #     is what lets backend: ravelNative be switched away without leaving the
 #     router's RBAC orphaned.
+#   - EndpointSlices (discovery.k8s.io): get/list/watch only. The operator never
+#     reads EndpointSlices itself; it needs this grant because Kubernetes RBAC
+#     escalation prevention forbids creating a Role that grants a permission the
+#     creator does not already hold, and the router's own Role
+#     (crate::reconcile::desired_router_role) grants exactly this on
+#     EndpointSlices. Without it every backend: ravelNative reconcile 403s when
+#     it tries to create the router's Role. Direct grant, not escalate/bind:
+#     least privilege.
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -55,6 +63,9 @@ rules:
   - apiGroups: ["rbac.authorization.k8s.io"]
     resources: ["roles", "rolebindings"]
     verbs: ["create", "update", "patch", "get", "list", "watch", "delete"]
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["ravel.nofire.ai"]
     resources: ["ravelclusters"]
     verbs: ["get", "list", "watch", "update", "patch"]

--- a/docs/adrs/0080-gateway-api-ingest-affinity.md
+++ b/docs/adrs/0080-gateway-api-ingest-affinity.md
@@ -257,9 +257,13 @@ independently testable:
    configured. When
    `backend: RavelNative`, the operator renders this service's
    Deployment/Service (parameterized with `subset_size` and `key`) and, if
-   `exposure.gateway_api` is set, points the rendered `HTTPRoute`/
-   `GRPCRoute` at the router's Service instead of the gateway Service
-   directly; it also renders a namespaced `Role`/`RoleBinding` granting the
+   `exposure.gateway_api` is set, points the rendered `HTTPRoute` at the
+   router's Service instead of the gateway Service directly; the `GRPCRoute`
+   continues to target the gateway Service, because the router serves HTTP
+   only today (a single `port_name` per process cannot proxy HTTP and gRPC
+   to the gateway's distinct listener ports at once) — wiring gRPC through
+   the router (a per-listener-port surface or a two-Deployment split) is
+   tracked as follow-up #194. It also renders a namespaced `Role`/`RoleBinding` granting the
    router's `ServiceAccount` `get`/`list`/`watch` on `endpointslices` and
    `services` in that namespace only — least-privilege, consistent with
    this repo's existing per-tenant/per-role credential scoping conventions

--- a/services/ravel-operator/src/controller.rs
+++ b/services/ravel-operator/src/controller.rs
@@ -13,8 +13,9 @@ use std::time::Duration;
 
 use futures::StreamExt;
 use k8s_openapi::api::apps::v1::Deployment;
-use k8s_openapi::api::core::v1::{Secret, Service};
+use k8s_openapi::api::core::v1::{Secret, Service, ServiceAccount};
 use k8s_openapi::api::networking::v1::Ingress;
+use k8s_openapi::api::rbac::v1::{Role, RoleBinding};
 use kube::api::{DeleteParams, Patch, PatchParams};
 use kube::core::DynamicObject;
 use kube::{Api, Client, Resource, ResourceExt};
@@ -32,9 +33,9 @@ use crate::crd::{
     RavelClusterSpec, RavelClusterStatus, ShardOverridesSpec,
 };
 use crate::reconcile::{
-    DEPLOYMENT_KEY_SECRET_KEY, RenderCtx, S3_ACCESS_KEY_ID_KEY, S3_SECRET_ACCESS_KEY_KEY,
-    desired_objects, grpcroute_api_resource, httproute_api_resource, possible_gateway_route_names,
-    possible_ingest_ingress_names,
+    DEPLOYMENT_KEY_SECRET_KEY, RenderCtx, RenderError, S3_ACCESS_KEY_ID_KEY,
+    S3_SECRET_ACCESS_KEY_KEY, desired_objects, grpcroute_api_resource, httproute_api_resource,
+    possible_gateway_route_names, possible_ingest_ingress_names, possible_router_object_names,
 };
 
 /// Server-side-apply field manager name.
@@ -101,6 +102,13 @@ pub enum Error {
     /// Building the S3 backend for `sys/auth` reconciliation failed.
     #[error("object store error: {0}")]
     Store(#[from] ravel_object_store::StoreError),
+
+    /// The spec cannot be rendered into a valid object set (ADR-0080 decision
+    /// 3): e.g. `backend: ravelNative` with no `routerImage`. Surfaced as a
+    /// `Degraded` status condition before the error propagates, so a
+    /// misconfigured CR fails visibly at reconcile time.
+    #[error("invalid spec: {0}")]
+    Render(#[from] RenderError),
 }
 
 /// Shared reconcile context.
@@ -836,6 +844,22 @@ async fn apply_dynamic(
     Ok(())
 }
 
+/// Delete `name` via `api`, treating a 404 as success. Used by the delete-sweeps
+/// that converge a resource kind back to "not present" when the spec stops
+/// asking for it: the object may never have existed, which is the steady state
+/// for a cluster that never enables the feature that renders it.
+async fn delete_if_present<K>(api: &Api<K>, name: &str) -> Result<(), Error>
+where
+    K: Resource<DynamicType = ()> + Clone + DeserializeOwned + std::fmt::Debug,
+{
+    if let Err(err) = api.delete(name, &DeleteParams::default()).await
+        && !is_not_found(&err)
+    {
+        return Err(err.into());
+    }
+    Ok(())
+}
+
 /// Reconcile one `RavelCluster` to its desired Deployments and Services.
 ///
 /// Wraps [`reconcile_inner`] so that any failure before the success-path status
@@ -973,8 +997,10 @@ async fn reconcile_inner(
     let ingresses: Api<Ingress> = Api::namespaced(client.clone(), namespace);
 
     // One render call produces everything this reconcile applies, so a test
-    // asserting on `desired_objects` is asserting on what actually ships.
-    let desired = desired_objects(&obj.spec, instance, &render_ctx);
+    // asserting on `desired_objects` is asserting on what actually ships. A
+    // render error (e.g. backend: ravelNative with no routerImage, ADR-0080
+    // decision 3) propagates to `reconcile`, which records a Degraded status.
+    let desired = desired_objects(&obj.spec, instance, namespace, &render_ctx)?;
 
     // Gateway.
     let mut gateway = desired.gateway_deployment;
@@ -1051,6 +1077,67 @@ async fn reconcile_inner(
         {
             return Err(err.into());
         }
+    }
+
+    // Ravel-native ingest router (ADR-0080 decision 3): apply the router's
+    // Deployment/Service/ServiceAccount/Role/RoleBinding when
+    // backend: ravelNative, then delete every router-owned name the render did
+    // not produce, so switching backend away (or disabling affinity) cleans up
+    // every router object instead of orphaning it. The RBAC kinds get their own
+    // namespaced Api clients; the Deployment/Service reuse the clients above.
+    // All five share one base name (`possible_router_object_names`), so the
+    // sweep deletes that name from every kind.
+    let service_accounts: Api<ServiceAccount> = Api::namespaced(client.clone(), namespace);
+    let roles: Api<Role> = Api::namespaced(client.clone(), namespace);
+    let role_bindings: Api<RoleBinding> = Api::namespaced(client.clone(), namespace);
+    let mut desired_router_names: BTreeSet<String> = BTreeSet::new();
+    if let Some(mut sa) = desired.router_service_account {
+        let name = sa.name_any();
+        sa.metadata.namespace = Some(namespace.to_string());
+        sa.metadata.owner_references = owner.clone();
+        apply(&service_accounts, &name, &sa).await?;
+        desired_router_names.insert(name);
+    }
+    if let Some(mut role) = desired.router_role {
+        let name = role.name_any();
+        role.metadata.namespace = Some(namespace.to_string());
+        role.metadata.owner_references = owner.clone();
+        apply(&roles, &name, &role).await?;
+        desired_router_names.insert(name);
+    }
+    if let Some(mut binding) = desired.router_role_binding {
+        let name = binding.name_any();
+        binding.metadata.namespace = Some(namespace.to_string());
+        binding.metadata.owner_references = owner.clone();
+        apply(&role_bindings, &name, &binding).await?;
+        desired_router_names.insert(name);
+    }
+    if let Some(mut router) = desired.router_deployment {
+        let name = router.name_any();
+        router.metadata.namespace = Some(namespace.to_string());
+        router.metadata.owner_references = owner.clone();
+        apply(&deployments, &name, &router).await?;
+        desired_router_names.insert(name);
+    }
+    if let Some(mut router_svc) = desired.router_service {
+        let name = router_svc.name_any();
+        router_svc.metadata.namespace = Some(namespace.to_string());
+        router_svc.metadata.owner_references = owner.clone();
+        apply(&services, &name, &router_svc).await?;
+        desired_router_names.insert(name);
+    }
+    for name in possible_router_object_names(instance) {
+        if desired_router_names.contains(&name) {
+            continue;
+        }
+        // Delete this name from every router-owned kind. Ignore not-found: the
+        // object may never have existed (the steady state for a cluster that
+        // never selects backend: ravelNative).
+        delete_if_present(&deployments, &name).await?;
+        delete_if_present(&services, &name).await?;
+        delete_if_present(&service_accounts, &name).await?;
+        delete_if_present(&roles, &name).await?;
+        delete_if_present(&role_bindings, &name).await?;
     }
 
     // Query.
@@ -1313,6 +1400,9 @@ fn degraded_reason(err: &Error) -> (String, String) {
             "InvalidSecretValue".to_string(),
             format!("Secret \"{name}\" field \"{field}\": {reason}"),
         ),
+        Error::Render(RenderError::RouterImageMissing) => {
+            ("RouterImageMissing".to_string(), err.to_string())
+        }
         other => ("ReconcileError".to_string(), other.to_string()),
     }
 }

--- a/services/ravel-operator/src/controller.rs
+++ b/services/ravel-operator/src/controller.rs
@@ -920,7 +920,7 @@ async fn reconcile_inner(
     client: &Client,
     namespace: &str,
     instance: &str,
-    extra_conditions: Vec<Condition>,
+    mut extra_conditions: Vec<Condition>,
 ) -> Result<Action, Error> {
     let token_secret = resolve_token_secret(
         client,
@@ -1090,6 +1090,22 @@ async fn reconcile_inner(
     let service_accounts: Api<ServiceAccount> = Api::namespaced(client.clone(), namespace);
     let roles: Api<Role> = Api::namespaced(client.clone(), namespace);
     let role_bindings: Api<RoleBinding> = Api::namespaced(client.clone(), namespace);
+    // A router RENDER error (a missing routerImage, or canonicalTenant with no
+    // resolver) degrades ONLY the router: record a Degraded condition and render
+    // none of its objects, but let every other tier below still reconcile.
+    // `desired_objects` already captured the error here rather than aborting the
+    // whole reconcile, so all `router_*` fields are None and the apply blocks
+    // below are no-ops; the sweep then removes any stale router objects.
+    if let Some(err) = desired.router_render_error {
+        let (reason, message) = degraded_reason(&Error::Render(err));
+        extra_conditions.push(condition(
+            "Degraded",
+            true,
+            obj.metadata.generation,
+            &reason,
+            &message,
+        ));
+    }
     let mut desired_router_names: BTreeSet<String> = BTreeSet::new();
     if let Some(mut sa) = desired.router_service_account {
         let name = sa.name_any();
@@ -1403,6 +1419,10 @@ fn degraded_reason(err: &Error) -> (String, String) {
         Error::Render(RenderError::RouterImageMissing) => {
             ("RouterImageMissing".to_string(), err.to_string())
         }
+        Error::Render(RenderError::CanonicalTenantResolverMissing) => (
+            "CanonicalTenantResolverMissing".to_string(),
+            err.to_string(),
+        ),
         other => ("ReconcileError".to_string(), other.to_string()),
     }
 }
@@ -1506,6 +1526,21 @@ mod tests {
         let (reason, message) = degraded_reason(&err);
         assert_eq!(reason, "SecretNotFound");
         assert!(message.contains("ravel-tokens"), "message names the Secret");
+    }
+
+    #[test]
+    fn degraded_reason_maps_router_render_errors() {
+        // A router render error degrades only the router (Fix 5), with a reason
+        // string naming the exact misconfiguration so `kubectl describe` shows
+        // what to fix. Both render-error variants map to their own reason.
+        let (reason, message) = degraded_reason(&Error::Render(RenderError::RouterImageMissing));
+        assert_eq!(reason, "RouterImageMissing");
+        assert!(!message.is_empty(), "message carries the error text");
+
+        let (reason, message) =
+            degraded_reason(&Error::Render(RenderError::CanonicalTenantResolverMissing));
+        assert_eq!(reason, "CanonicalTenantResolverMissing");
+        assert!(!message.is_empty(), "message carries the error text");
     }
 
     /// A minimal spec whose only interesting field is `gateway.ingestAffinity`.

--- a/services/ravel-operator/src/controller.rs
+++ b/services/ravel-operator/src/controller.rs
@@ -998,8 +998,12 @@ async fn reconcile_inner(
 
     // One render call produces everything this reconcile applies, so a test
     // asserting on `desired_objects` is asserting on what actually ships. A
-    // render error (e.g. backend: ravelNative with no routerImage, ADR-0080
-    // decision 3) propagates to `reconcile`, which records a Degraded status.
+    // router render error (e.g. backend: ravelNative with no routerImage, or
+    // canonicalTenant with no resolver, ADR-0080 decision 3) does NOT abort the
+    // reconcile: `desired_objects` captures it in `router_render_error` (all
+    // `router_*` fields then `None`) rather than propagating it, so only the
+    // router degrades -- the block below records a Degraded condition for it while
+    // every other tier's apply and sweep still runs this pass.
     let desired = desired_objects(&obj.spec, instance, namespace, &render_ctx)?;
 
     // Gateway.

--- a/services/ravel-operator/src/crd.rs
+++ b/services/ravel-operator/src/crd.rs
@@ -306,6 +306,23 @@ pub struct IngestAffinitySpec {
     #[serde(default)]
     pub backend: AffinityBackend,
 
+    /// Container image for the `ravel-ingest-router` Deployment rendered under
+    /// [`AffinityBackend::RavelNative`] (ADR-0080 decision 3).
+    ///
+    /// The router is a DIFFERENT binary from `spec.image` (which is
+    /// `ravel-server`), so its image cannot be derived from `spec.image` and is
+    /// named explicitly here. Deriving it by string-manipulating `spec.image`
+    /// would be fragile: an image reference host can carry a port
+    /// (`localhost:5000/ravel-server:v1`), so any split-on-`:` guess breaks.
+    ///
+    /// Required when `backend: ravelNative`: the operator surfaces a `Degraded`
+    /// status condition (reason `RouterImageMissing`) and renders no router
+    /// objects when it is absent, rather than a Deployment with an empty
+    /// `image:` that would never schedule. Has no effect under
+    /// `backend: ingressNginx`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub router_image: Option<String>,
+
     /// How many replicas a tenant's traffic is pinned to. Defaults to
     /// [`DEFAULT_AFFINITY_SUBSET_SIZE`] (two), not one, so a single replica
     /// loss does not concentrate a tenant on one process.
@@ -384,6 +401,7 @@ impl Default for IngestAffinitySpec {
         Self {
             enabled: default_true(),
             backend: AffinityBackend::default(),
+            router_image: None,
             subset_size: default_subset_size(),
             key: AffinityKeySpec::default(),
             ingress_class_name: None,
@@ -456,6 +474,16 @@ pub enum AffinityKeySource {
     /// authentication configured; the variable is empty otherwise, which
     /// collapses every tenant onto one subset.
     MtlsSubject,
+
+    /// Hash the canonical `TenantId` resolved by the `ravel-tenant-resolve`
+    /// auth chain (ADR-0080 decision 3), immune to bearer-token rotation unlike
+    /// hashing the raw `Authorization` header.
+    ///
+    /// Only meaningful under [`AffinityBackend::RavelNative`]: ingress-nginx has
+    /// no way to run the tenant-resolution chain, so this key source combined
+    /// with `backend: ingressNginx` is rejected at admission by a CEL rule on
+    /// the `ingestAffinity` object (see [`ravel_cluster_crd`]).
+    CanonicalTenant,
 }
 
 /// Catalog fold tuning (`--disable-fold`, `--fold-interval-secs`).
@@ -722,6 +750,7 @@ pub fn ravel_cluster_crd() -> CustomResourceDefinition {
     inject_minimum_bounds(&mut crd);
     inject_ingest_affinity_constraints(&mut crd);
     inject_gateway_exposure_affinity_guard(&mut crd);
+    inject_canonical_tenant_backend_guard(&mut crd);
     crd
 }
 
@@ -952,6 +981,75 @@ fn inject_gateway_exposure_affinity_guard(crd: &mut CustomResourceDefinition) {
         };
         // Append rather than replace: leave room for a future rule on `gateway`
         // without silently dropping this one.
+        let mut rules = gateway.x_kubernetes_validations.take().unwrap_or_default();
+        rules.push(rule.clone());
+        gateway.x_kubernetes_validations = Some(rules);
+    }
+}
+
+/// Message surfaced to a user who selects the `canonicalTenant` key source on
+/// the legacy `ingressNginx` backend (ADR-0080 decision 3).
+const CANONICAL_TENANT_BACKEND_MESSAGE: &str = "gateway.ingestAffinity.key.source \
+    canonicalTenant requires backend: ravelNative -- ingress-nginx cannot run the \
+    ravel-tenant-resolve auth chain that canonical-tenant hashing needs";
+
+/// The CEL rule rejecting the `canonicalTenant` key source under
+/// `backend: ingressNginx` (ADR-0080 decision 3), kept as a constant so the
+/// injected rule and the logic unit test cannot drift.
+///
+/// It is attached at the `gateway` object level (so `self` is the gateway
+/// struct), following the exact shape of the exposure guard rather than nesting
+/// inside `ingestAffinity`: that keeps `ingestAffinity`'s own rule set to just
+/// its `headerName` rule. It passes (no rejection) unless BOTH
+/// `ingestAffinity.key.source` is `canonicalTenant` and `ingestAffinity.backend`
+/// is `ingressNginx`. The disjunction reads as "the combination is fine if any
+/// precondition of the bad case is absent". `backend` is materialized to
+/// `ingressNginx` by the schema default before CEL evaluates, so a manifest that
+/// sets `key.source: canonicalTenant` while omitting `backend` is still rejected
+/// (the omitted default IS `ingressNginx`); the `has()` guards are a defensive
+/// belt against a missing serde default, matching the other injectors.
+const CANONICAL_TENANT_BACKEND_RULE: &str = "!has(self.ingestAffinity) || \
+    !has(self.ingestAffinity.key) || !has(self.ingestAffinity.key.source) || \
+    self.ingestAffinity.key.source != 'canonicalTenant' || \
+    !has(self.ingestAffinity.backend) || self.ingestAffinity.backend != 'ingressNginx'";
+
+/// Attach the canonical-tenant-versus-legacy-backend guard (ADR-0080
+/// decision 3) to the `gateway` property.
+///
+/// Attached at the `gateway` level and APPENDED (not replaced), the exact shape
+/// of [`inject_gateway_exposure_affinity_guard`], so the exposure guard already
+/// on `gateway` is preserved and `ingestAffinity`'s own rule set stays at just
+/// its `headerName` rule. Injected post-hoc for the same reason the other
+/// injectors are, and every step bails out rather than panicking if the schema
+/// shape is not what it expects.
+fn inject_canonical_tenant_backend_guard(crd: &mut CustomResourceDefinition) {
+    let rule = ValidationRule {
+        rule: CANONICAL_TENANT_BACKEND_RULE.to_string(),
+        message: Some(CANONICAL_TENANT_BACKEND_MESSAGE.to_string()),
+        ..Default::default()
+    };
+    for version in &mut crd.spec.versions {
+        let Some(schema) = version.schema.as_mut() else {
+            continue;
+        };
+        let Some(root) = schema.open_api_v3_schema.as_mut() else {
+            continue;
+        };
+        let Some(props) = root.properties.as_mut() else {
+            continue;
+        };
+        let Some(spec) = props.get_mut("spec") else {
+            continue;
+        };
+        let Some(spec_props) = spec.properties.as_mut() else {
+            continue;
+        };
+        let Some(gateway) = spec_props.get_mut("gateway") else {
+            continue;
+        };
+        // Append rather than replace: the exposure guard is already on `gateway`
+        // and dropping it would silently re-admit the exposure+ingressNginx
+        // combination.
         let mut rules = gateway.x_kubernetes_validations.take().unwrap_or_default();
         rules.push(rule.clone());
         gateway.x_kubernetes_validations = Some(rules);
@@ -1360,12 +1458,162 @@ mod tests {
             ),
             (AffinityKeySource::Header, "header"),
             (AffinityKeySource::MtlsSubject, "mtlsSubject"),
+            (AffinityKeySource::CanonicalTenant, "canonicalTenant"),
         ] {
             assert_eq!(
                 serde_json::to_value(source).expect("serialize"),
                 serde_json::Value::String(text.to_string())
             );
         }
+    }
+
+    /// Rust mirror of [`CANONICAL_TENANT_BACKEND_RULE`]: returns whether the
+    /// combination is ADMITTED (the CEL rule evaluates true). `backend` is
+    /// always materialized when the affinity block is present (serde/schema
+    /// default `ingressNginx`), so it is modeled as always present. The exact
+    /// rule string is pinned separately in
+    /// [`canonical_tenant_key_source_rejected_with_ingress_nginx_backend`], so a
+    /// change to the real rule that diverges from this model is caught there.
+    fn canonical_tenant_cel_admits(key_source: &str, backend: &str) -> bool {
+        key_source != "canonicalTenant" || backend != "ingressNginx"
+    }
+
+    #[test]
+    fn canonical_tenant_key_source_rejected_with_ingress_nginx_backend() {
+        // ADR-0080 decision 3. Test venue: schema assertion plus a plain-Rust
+        // logic mirror, the same venue #156/T2 established for this repo's CEL
+        // rules (no envtest exists here; x-kubernetes-validations runs in the
+        // API server, which a reconcile unit test cannot reach).
+
+        // The one rejected combination:
+        assert!(
+            !canonical_tenant_cel_admits("canonicalTenant", "ingressNginx"),
+            "canonicalTenant + ingressNginx must be rejected"
+        );
+
+        // Every allowed combination named in the deliverable:
+        assert!(
+            canonical_tenant_cel_admits("canonicalTenant", "ravelNative"),
+            "canonicalTenant + ravelNative is allowed"
+        );
+        for backend in ["ingressNginx", "ravelNative"] {
+            for source in ["authorizationHeader", "header", "mtlsSubject"] {
+                assert!(
+                    canonical_tenant_cel_admits(source, backend),
+                    "{source} + {backend} is allowed"
+                );
+            }
+        }
+
+        // The schema carries the exact rule and message on the `gateway`
+        // property (the same shape as the exposure guard), appended alongside it
+        // rather than nested inside ingestAffinity.
+        let gateway = ravel_cluster_crd().spec.versions[0]
+            .schema
+            .as_ref()
+            .expect("schema")
+            .open_api_v3_schema
+            .as_ref()
+            .expect("root schema")
+            .properties
+            .as_ref()
+            .expect("root props")
+            .get("spec")
+            .expect("spec prop")
+            .properties
+            .as_ref()
+            .expect("spec props")
+            .get("gateway")
+            .expect("gateway prop")
+            .clone();
+        let rules = gateway
+            .x_kubernetes_validations
+            .as_ref()
+            .expect("gateway must carry CEL rules");
+        let guard = rules
+            .iter()
+            .find(|r| r.rule == CANONICAL_TENANT_BACKEND_RULE)
+            .expect("gateway must carry the exact canonical-tenant/backend rule");
+        assert_eq!(
+            guard.message.as_deref(),
+            Some(CANONICAL_TENANT_BACKEND_MESSAGE)
+        );
+        // The exposure guard already on `gateway` is not dropped by appending.
+        assert!(
+            rules
+                .iter()
+                .any(|r| r.rule == GATEWAY_EXPOSURE_AFFINITY_RULE),
+            "appending the canonical-tenant rule must not drop the exposure guard"
+        );
+        // ingestAffinity still carries only its own headerName rule (the
+        // canonical-tenant rule lives on gateway, not here).
+        let affinity_rules = gateway
+            .properties
+            .as_ref()
+            .expect("gateway props")
+            .get("ingestAffinity")
+            .expect("ingestAffinity prop")
+            .x_kubernetes_validations
+            .clone()
+            .unwrap_or_default();
+        assert!(
+            affinity_rules
+                .iter()
+                .all(|r| r.rule != CANONICAL_TENANT_BACKEND_RULE),
+            "the canonical-tenant rule must live on `gateway`, not on `ingestAffinity`"
+        );
+    }
+
+    #[test]
+    fn router_image_is_optional_and_defaults_to_none() {
+        // ADR-0080 decision 3, deliverable 1. A sibling of `backend`, optional
+        // and skipped when None so an existing CR is byte-identical.
+        assert_eq!(IngestAffinitySpec::default().router_image, None);
+
+        let affinity: IngestAffinitySpec = serde_json::from_value(serde_json::json!({
+            "backend": "ravelNative",
+            "routerImage": "registry.example/ravel-ingest-router:v1"
+        }))
+        .expect("deserialize");
+        assert_eq!(
+            affinity.router_image.as_deref(),
+            Some("registry.example/ravel-ingest-router:v1")
+        );
+
+        // Omitted routerImage deserializes to None, and the schema exposes it.
+        let affinity: IngestAffinitySpec =
+            serde_json::from_value(serde_json::json!({ "backend": "ravelNative" }))
+                .expect("deserialize");
+        assert_eq!(affinity.router_image, None);
+        let affinity_props = ravel_cluster_crd().spec.versions[0]
+            .schema
+            .as_ref()
+            .expect("schema")
+            .open_api_v3_schema
+            .as_ref()
+            .expect("root schema")
+            .properties
+            .as_ref()
+            .expect("root props")
+            .get("spec")
+            .expect("spec prop")
+            .properties
+            .as_ref()
+            .expect("spec props")
+            .get("gateway")
+            .expect("gateway prop")
+            .properties
+            .as_ref()
+            .expect("gateway props")
+            .get("ingestAffinity")
+            .expect("ingestAffinity prop")
+            .properties
+            .clone()
+            .expect("affinity props");
+        assert!(
+            affinity_props.contains_key("routerImage"),
+            "ingestAffinity must expose routerImage in its schema"
+        );
     }
 
     #[test]

--- a/services/ravel-operator/src/crd.rs
+++ b/services/ravel-operator/src/crd.rs
@@ -483,6 +483,13 @@ pub enum AffinityKeySource {
     /// no way to run the tenant-resolution chain, so this key source combined
     /// with `backend: ingressNginx` is rejected at admission by a CEL rule on
     /// the `ingestAffinity` object (see [`ravel_cluster_crd`]).
+    ///
+    /// Requires a resolver: `ravel-ingest-router` refuses to start under
+    /// `canonical-tenant` unless at least one resolver is configured. The only
+    /// resolver surface this CRD exposes today is `tenantTokensSecretRef`;
+    /// selecting `canonicalTenant` without it makes the operator surface a
+    /// `Degraded` condition (reason `CanonicalTenantResolverMissing`) and render
+    /// no router objects, rather than a Deployment that would crashloop.
     CanonicalTenant,
 }
 

--- a/services/ravel-operator/src/reconcile.rs
+++ b/services/ravel-operator/src/reconcile.rs
@@ -1194,9 +1194,11 @@ pub fn desired_router_deployment(
     // `tenant_token_args`, which emits one `--tenant-token` per
     // `ctx.tenant_names`, and `tenant_names` is the tenant-tokens Secret's live
     // keys (see controller.rs). The Secret ref can be SET on the spec while the
-    // Secret is absent or has zero keys this cycle (a normal, already-anticipated
-    // live state that controller.rs just warns on and continues) -- in which case
-    // no `--tenant-token` renders and the router crashloops just the same. If no
+    // Secret itself resolves to zero keys this cycle -- a reachable live state
+    // distinct from the Secret being absent entirely (an absent Secret is a hard
+    // `Error::SecretNotFound` that aborts the reconcile before this function is
+    // ever called; a present-but-empty Secret is not). In the zero-keys case no
+    // `--tenant-token` renders and the router crashloops just the same. If no
     // resolver flags would actually render, reject at render time (see
     // RenderError::CanonicalTenantResolverMissing) rather than ship a
     // guaranteed-crashlooping Deployment.
@@ -3637,12 +3639,15 @@ mod tests {
     fn canonical_tenant_with_secret_ref_but_no_live_tenants_is_a_typed_error() {
         // F1: the resolver guard must check the ACTUAL rendered resolver flags,
         // not `tenant_tokens_secret_ref.is_none()`. A Secret ref SET on the spec
-        // while the Secret is absent or has zero keys this cycle is a normal live
-        // state (controller.rs derives ctx.tenant_names from the Secret's live
-        // keys and just warns on empty). In that case `tenant_token_args` renders
-        // zero `--tenant-token` flags and the router's own CLI still crashloops at
-        // startup -- the exact case the spec-field guard missed. The render must
-        // reject it, not ship a crashlooping Deployment.
+        // while the Secret resolves to zero live keys this cycle is a reachable
+        // state distinct from the Secret being absent entirely (controller.rs
+        // derives ctx.tenant_names from the Secret's live keys; an absent Secret
+        // is a hard error that aborts the reconcile before rendering is ever
+        // reached, a present-but-empty one is not). In the zero-keys case
+        // `tenant_token_args` renders zero `--tenant-token` flags and the
+        // router's own CLI still crashloops at startup -- the exact case the
+        // spec-field guard missed. The render must reject it, not ship a
+        // crashlooping Deployment.
         let mut spec = ravel_native_spec(2, AffinityKeySource::CanonicalTenant);
         spec.tenant_tokens_secret_ref = Some(LocalSecretRef {
             name: "ravel-tokens".to_string(),
@@ -3864,6 +3869,57 @@ mod tests {
                 "fallback uses the gateway's HTTP port, not the router's"
             );
         }
+    }
+
+    #[test]
+    fn httproute_targets_router_service_through_desired_objects_when_router_renders() {
+        // The positive half of the F2 wiring: `gateway_route_backend_ref_
+        // targets_router_service_under_ravel_native` above passes
+        // `router_available` as a literal `true` straight to
+        // `desired_gateway_routes`, so it only proves that function's own
+        // internal branch -- it does not prove `desired_objects` ever computes
+        // `router_available = true` on a genuinely successful router render. A
+        // mutation to `desired_objects` that always passed `false` through (permanently
+        // disabling the ADR-0080 decision 3 / deliverable 4 switch) would leave
+        // that test green. Go through `desired_objects`, the render the
+        // controller actually calls, so this wiring is what's under test.
+        let mut spec = ravel_native_spec(2, AffinityKeySource::CanonicalTenant);
+        spec.tenant_tokens_secret_ref = Some(LocalSecretRef {
+            name: "ravel-tokens".to_string(),
+        });
+        spec.gateway.exposure = exposure_with(
+            GatewayReference {
+                name: "public-gw".to_string(),
+                namespace: None,
+            },
+            Vec::new(),
+            true,
+        )
+        .exposure;
+
+        let objects = desired_objects(&spec, "prod", "default", &ctx()).expect("render");
+        assert!(
+            objects.router_render_error.is_none(),
+            "precondition: the router renders cleanly this pass"
+        );
+        assert!(
+            objects.router_service.is_some(),
+            "precondition: a router Service will exist after this pass"
+        );
+
+        let (http, _grpc) = objects.gateway_routes;
+        let http = http.expect("HTTPRoute");
+        assert_eq!(
+            route_spec(&http)["rules"][0]["backendRefs"][0]["name"],
+            serde_json::json!("prod-ingest-router"),
+            "on a clean router render, desired_objects must switch the HTTPRoute \
+             to the router Service -- this is the deliverable, not just \
+             desired_gateway_routes's own internal branch"
+        );
+        assert_eq!(
+            route_spec(&http)["rules"][0]["backendRefs"][0]["port"],
+            serde_json::json!(ROUTER_HTTP_PORT)
+        );
     }
 
     #[test]

--- a/services/ravel-operator/src/reconcile.rs
+++ b/services/ravel-operator/src/reconcile.rs
@@ -51,6 +51,22 @@ pub enum RenderError {
          is not set; set routerImage to the ravel-ingest-router container image"
     )]
     RouterImageMissing,
+
+    /// `key.source: canonicalTenant` is selected but no resolver is configured.
+    /// `ravel-ingest-router`'s own CLI refuses to start with `--key-source
+    /// canonical-tenant` unless at least one resolver flag is set (a
+    /// `--tenant-token`, `--oidc-issuer`/`--oidc-jwks-url`, `--mtls-enabled`, or
+    /// `--dev-insecure-tenant-header`). The only resolver surface this CRD
+    /// exposes today is `tenantTokensSecretRef`, which renders the
+    /// `--tenant-token` flags; with it absent the rendered command line would
+    /// crashloop the router at startup, so the operator renders no router
+    /// objects and surfaces this instead (mirrors [`Self::RouterImageMissing`]).
+    #[error(
+        "gateway.ingestAffinity.key.source is canonicalTenant but no resolver is configured; \
+         set tenantTokensSecretRef so the router renders at least one --tenant-token resolver \
+         (canonical-tenant cannot start with no resolver)"
+    )]
+    CanonicalTenantResolverMissing,
 }
 
 /// HTTP listener port (OTLP/HTTP, query API, and the `/healthz` `/readyz`
@@ -1107,6 +1123,13 @@ fn router_args(
         child_name(instance, "gateway"),
         "--gateway-service-namespace".to_string(),
         namespace.to_string(),
+        // Pin the gateway port explicitly. The gateway Service exposes two named
+        // ports (`http`/4318, `grpc`/4317); an unset `--gateway-port-name` uses
+        // the endpoint's first port, which is not guaranteed to be `http`. The
+        // router only ever proxies HTTP today (see desired_gateway_routes: the
+        // GRPCRoute still targets the gateway Service directly), so pin `http`.
+        "--gateway-port-name".to_string(),
+        "http".to_string(),
         "--subset-size".to_string(),
         affinity.subset_size.to_string(),
         "--key-source".to_string(),
@@ -1159,6 +1182,16 @@ pub fn desired_router_deployment(
     let Some(image) = affinity.router_image.as_ref() else {
         return Err(RenderError::RouterImageMissing);
     };
+    // canonical-tenant needs at least one resolver or the router's own CLI
+    // crashloops at startup. tenantTokensSecretRef is the only resolver surface
+    // this CRD exposes today, so its absence under canonical-tenant is a
+    // render-time rejection, not a rendered Deployment (see
+    // RenderError::CanonicalTenantResolverMissing).
+    if affinity.key.source == AffinityKeySource::CanonicalTenant
+        && spec.tenant_tokens_secret_ref.is_none()
+    {
+        return Err(RenderError::CanonicalTenantResolverMissing);
+    }
     let args = router_args(affinity, instance, namespace, spec, ctx);
     let env = if affinity.key.source == AffinityKeySource::CanonicalTenant {
         tenant_token_env(spec, ctx)
@@ -1450,25 +1483,28 @@ pub fn desired_gateway_routes(
     else {
         return (None, None);
     };
-    // Backend-aware backendRef (ADR-0080 decision 3, deliverable 4). Under
-    // `backend: ravelNative` the routes point at the router's Service so ingest
-    // traffic is subset-pinned; for every other CR (affinity absent, disabled,
-    // or ingressNginx) they keep targeting the gateway Service exactly as
-    // before -- zero behavior change. The router listens HTTP-only on
-    // ROUTER_HTTP_PORT today; the GRPCRoute still targets the router by name (so
-    // gRPC traffic does not silently bypass affinity by hitting the gateway
-    // directly), but at the router's HTTP port until #184 adds the router's gRPC
-    // listener and a dedicated port -- a documented follow-up.
-    let (http_backend, http_port, grpc_backend, grpc_port) = match ravel_native_affinity(spec) {
-        Some(_) => {
-            let router = child_name(instance, ROUTER_COMPONENT);
-            (router.clone(), ROUTER_HTTP_PORT, router, ROUTER_HTTP_PORT)
-        }
-        None => {
-            let gateway = child_name(instance, "gateway");
-            (gateway.clone(), HTTP_PORT, gateway, GRPC_PORT)
-        }
+    let gateway = child_name(instance, "gateway");
+    // HTTPRoute backendRef (ADR-0080 decision 3, deliverable 4): under
+    // `backend: ravelNative` the HTTP route points at the router's Service so
+    // OTLP/HTTP ingest is subset-pinned; for every other CR (affinity absent,
+    // disabled, or ingressNginx) it keeps targeting the gateway Service exactly
+    // as before -- zero behavior change.
+    let (http_backend, http_port) = match ravel_native_affinity(spec) {
+        Some(_) => (child_name(instance, ROUTER_COMPONENT), ROUTER_HTTP_PORT),
+        None => (gateway.clone(), HTTP_PORT),
     };
+    // GRPCRoute backendRef ALWAYS targets the gateway Service, regardless of
+    // backend. The router deliberately renders an HTTP-only Deployment today
+    // (one container port, no --listen-grpc): #184 has since added a
+    // --listen-grpc flag, but ravel-ingest-router's EndpointStore holds a single
+    // `port_name` per snapshot, shared by the HTTP and gRPC listeners in the
+    // same process, so one router Deployment cannot proxy HTTP to the gateway's
+    // `http` port and gRPC to its `grpc` port at once. Wiring gRPC through the
+    // router (two Deployments pinned to different --gateway-port-name, or a
+    // per-listener port surface in ravel-ingest-router) is a follow-up, not a
+    // gap here; until then the GRPCRoute must keep hitting the gateway Service
+    // directly so gRPC ingest keeps working exactly as it does on main.
+    let (grpc_backend, grpc_port) = (gateway, GRPC_PORT);
     let httproute = gateway_route(
         instance,
         GATEWAY_HTTPROUTE_COMPONENT,
@@ -1521,6 +1557,18 @@ pub struct DesiredObjects {
     pub router_role: Option<Role>,
     /// The router's namespaced RoleBinding.
     pub router_role_binding: Option<RoleBinding>,
+    /// A render error from the router path (a missing `routerImage`, or
+    /// `canonicalTenant` with no resolver), or `None` when the router rendered
+    /// cleanly or was not requested.
+    ///
+    /// Captured here rather than propagated out of [`desired_objects`] so a
+    /// misconfigured router degrades ONLY the router: when this is `Some`, every
+    /// `router_*` field above is `None` (render nothing for the router), the
+    /// controller records a `Degraded` condition, and every other tier
+    /// (gateway/query/maintain) still reconciles. Propagating it instead would
+    /// abort the whole reconcile (ADR-0080 decision 3; crd.rs documents "renders
+    /// no router objects" when misconfigured, i.e. everything else still runs).
+    pub router_render_error: Option<RenderError>,
     /// The query Deployment.
     pub query_deployment: Deployment,
     /// The query Service.
@@ -1532,26 +1580,52 @@ pub struct DesiredObjects {
 
 /// Render every Kubernetes object a `RavelCluster` reconcile applies.
 ///
-/// Fallible because the ravel-native router cannot be rendered without a
-/// `routerImage` (ADR-0080 decision 3, deliverable 1): a misconfigured CR yields
-/// [`RenderError::RouterImageMissing`], which the controller turns into a
-/// `Degraded` status rather than applying a broken Deployment.
+/// Returns `Result` for forward compatibility with a render error that must
+/// fail the whole reconcile, but is infallible today: the one render error that
+/// currently exists (the ravel-native router's, ADR-0080 decision 3) is
+/// captured in [`DesiredObjects::router_render_error`] rather than propagated,
+/// so a misconfigured router degrades only the router and every other tier
+/// still reconciles. The controller turns a captured router error into a
+/// `Degraded` condition rather than applying a broken Deployment.
 pub fn desired_objects(
     spec: &RavelClusterSpec,
     instance: &str,
     namespace: &str,
     ctx: &RenderCtx,
 ) -> Result<DesiredObjects, RenderError> {
+    // Capture the router render result instead of `?`-propagating it: a router
+    // misconfiguration must not abort the gateway/query/maintain tiers below.
+    // On error, render none of the router objects (all `None`) and surface the
+    // error for the controller to degrade the router alone.
+    let (
+        router_deployment,
+        router_service,
+        router_service_account,
+        router_role,
+        router_role_binding,
+        router_render_error,
+    ) = match desired_router_deployment(spec, instance, namespace, ctx) {
+        Ok(deployment) => (
+            deployment,
+            desired_router_service(spec, instance),
+            desired_router_service_account(spec, instance),
+            desired_router_role(spec, instance),
+            desired_router_role_binding(spec, instance, namespace),
+            None,
+        ),
+        Err(err) => (None, None, None, None, None, Some(err)),
+    };
     Ok(DesiredObjects {
         gateway_deployment: desired_gateway_deployment(spec, instance, ctx),
         gateway_service: desired_gateway_service(spec, instance),
         gateway_ingresses: desired_gateway_ingresses(spec, instance),
         gateway_routes: desired_gateway_routes(spec, instance),
-        router_deployment: desired_router_deployment(spec, instance, namespace, ctx)?,
-        router_service: desired_router_service(spec, instance),
-        router_service_account: desired_router_service_account(spec, instance),
-        router_role: desired_router_role(spec, instance),
-        router_role_binding: desired_router_role_binding(spec, instance, namespace),
+        router_deployment,
+        router_service,
+        router_service_account,
+        router_role,
+        router_role_binding,
+        router_render_error,
         query_deployment: desired_query_deployment(spec, instance, ctx),
         query_service: desired_query_service(spec, instance),
         maintain_deployment: desired_maintain_deployment(spec, instance, ctx),
@@ -3267,7 +3341,17 @@ mod tests {
         // #184's crate) becomes a caught test failure here instead of a
         // crashlooping pod. The args are pinned as a full ordered vector, not a
         // contains-check.
-        let spec = ravel_native_spec(3, AffinityKeySource::CanonicalTenant);
+        //
+        // canonical-tenant needs a resolver, so this fixture carries a
+        // tenantTokensSecretRef (a valid, non-crashing config): the router
+        // renders --tenant-token resolver flags, and the frozen vector pins them
+        // too. The render-time rejection of canonical-tenant WITHOUT a resolver
+        // is proven separately in
+        // `canonical_tenant_without_resolver_is_a_typed_error_not_a_panic`.
+        let mut spec = ravel_native_spec(3, AffinityKeySource::CanonicalTenant);
+        spec.tenant_tokens_secret_ref = Some(LocalSecretRef {
+            name: "ravel-tokens".to_string(),
+        });
         let objects = desired_objects(&spec, "prod", "default", &ctx()).expect("render");
         let deployment = objects
             .router_deployment
@@ -3280,12 +3364,20 @@ mod tests {
                 "prod-gateway",
                 "--gateway-service-namespace",
                 "default",
+                "--gateway-port-name",
+                "http",
                 "--subset-size",
                 "3",
                 "--key-source",
                 "canonical-tenant",
                 "--listen-http",
                 "0.0.0.0:8080",
+                // canonical-tenant with a resolver renders the --tenant-token
+                // flags, one per tenant in ctx() order.
+                "--tenant-token",
+                "$(RAVEL_TENANT_TOKEN_0)=acme",
+                "--tenant-token",
+                "$(RAVEL_TENANT_TOKEN_1)=globex",
             ]
         );
 
@@ -3454,26 +3546,130 @@ mod tests {
             desired_router_deployment(&spec, "prod", "default", &ctx()),
             Err(RenderError::RouterImageMissing)
         );
-        // DesiredObjects holds DynamicObjects (no PartialEq), so match the Err
-        // arm rather than comparing the whole Result.
-        assert!(matches!(
-            desired_objects(&spec, "prod", "default", &ctx()),
-            Err(RenderError::RouterImageMissing)
-        ));
+        // desired_objects captures the router error rather than propagating it
+        // (Fix 5): it returns Ok, the router objects are None, and the error is
+        // surfaced in router_render_error for the controller to degrade the
+        // router alone.
+        let objects =
+            desired_objects(&spec, "prod", "default", &ctx()).expect("render never aborts");
+        assert_eq!(
+            objects.router_render_error,
+            Some(RenderError::RouterImageMissing)
+        );
+        assert!(objects.router_deployment.is_none());
+    }
+
+    #[test]
+    fn canonical_tenant_without_resolver_is_a_typed_error_not_a_panic() {
+        // Fix 1 (B1): canonical-tenant with no resolver would render a command
+        // line the router's own CLI rejects at startup (a guaranteed crashloop).
+        // tenantTokensSecretRef is the only resolver surface this CRD exposes
+        // today; absent it, the operator renders no router objects and surfaces a
+        // typed error, never a panic and never a crash-looping Deployment.
+        let spec = ravel_native_spec(2, AffinityKeySource::CanonicalTenant);
+        assert!(spec.tenant_tokens_secret_ref.is_none());
+        assert_eq!(
+            desired_router_deployment(&spec, "prod", "default", &ctx()),
+            Err(RenderError::CanonicalTenantResolverMissing)
+        );
+        // Captured, not propagated (Fix 5): every other tier still renders.
+        let objects =
+            desired_objects(&spec, "prod", "default", &ctx()).expect("render never aborts");
+        assert_eq!(
+            objects.router_render_error,
+            Some(RenderError::CanonicalTenantResolverMissing)
+        );
+        assert!(objects.router_deployment.is_none());
+        assert!(objects.router_service.is_none());
+        assert!(objects.router_service_account.is_none());
+        assert!(objects.router_role.is_none());
+        assert!(objects.router_role_binding.is_none());
+
+        // Happy path: the same config WITH a resolver renders a router
+        // Deployment cleanly.
+        let mut ok = spec.clone();
+        ok.tenant_tokens_secret_ref = Some(LocalSecretRef {
+            name: "ravel-tokens".to_string(),
+        });
+        assert!(
+            desired_router_deployment(&ok, "prod", "default", &ctx())
+                .expect("render")
+                .is_some(),
+            "canonical-tenant with a resolver must render a router Deployment"
+        );
+    }
+
+    #[test]
+    fn router_render_failure_still_renders_every_other_tier() {
+        // Fix 5 (non-blocking): a router render error must degrade ONLY the
+        // router, never abort the whole reconcile. desired_objects returns the
+        // gateway/query/maintain tiers as usual for BOTH router render errors,
+        // with zero router objects and the error captured for the controller to
+        // turn into a Degraded condition (see degraded_reason tests in
+        // controller.rs). Proving it at the render layer is the testable proof:
+        // the controller applies exactly desired_objects' contents (no live API
+        // server in this crate's tests, see the module doc).
+        let router_image_missing = {
+            let mut s = base_spec();
+            s.gateway.ingest_affinity = Some(IngestAffinitySpec {
+                backend: AffinityBackend::RavelNative,
+                router_image: None,
+                ..IngestAffinitySpec::default()
+            });
+            s
+        };
+        let canonical_no_resolver = {
+            let mut s = ravel_native_spec(2, AffinityKeySource::CanonicalTenant);
+            s.tenant_tokens_secret_ref = None;
+            s
+        };
+        for spec in [router_image_missing, canonical_no_resolver] {
+            let objects =
+                desired_objects(&spec, "prod", "default", &ctx()).expect("render never aborts");
+            assert!(
+                objects.router_render_error.is_some(),
+                "the router error is captured, not propagated"
+            );
+            assert!(objects.router_deployment.is_none());
+            assert!(objects.router_service.is_none());
+            assert!(objects.router_service_account.is_none());
+            assert!(objects.router_role.is_none());
+            assert!(objects.router_role_binding.is_none());
+            // Every other tier still renders.
+            assert_eq!(
+                objects.gateway_deployment.metadata.name.as_deref(),
+                Some("prod-gateway"),
+                "gateway still renders when the router render fails"
+            );
+            assert_eq!(
+                objects.query_deployment.metadata.name.as_deref(),
+                Some("prod-query"),
+                "query still renders when the router render fails"
+            );
+            assert!(
+                objects.maintain_deployment.is_some(),
+                "maintain still renders when the router render fails"
+            );
+        }
     }
 
     #[test]
     fn gateway_route_backend_ref_targets_router_service_under_ravel_native() {
-        // ADR-0080 decision 3, deliverable 4. Exposure + ravelNative affinity:
-        // both routes point at the router Service. The same exposure under the
-        // default ingressNginx backend still targets the gateway Service
-        // (regression guard on Wave 2 behavior).
+        // ADR-0080 decision 3, deliverable 4, as corrected by Fix 3 (B3). Under
+        // exposure + ravelNative affinity, ONLY the HTTPRoute switches to the
+        // router Service; the GRPCRoute keeps targeting the gateway Service,
+        // because the router serves HTTP only today (single port_name per
+        // process) and switching gRPC to it would break gRPC ingest that works
+        // now. The same exposure under the default ingressNginx backend still
+        // targets the gateway Service for both (regression guard on Wave 2
+        // behavior).
         let router_gw = GatewayReference {
             name: "public-gw".to_string(),
             namespace: None,
         };
 
-        // ravelNative: backendRefs -> router Service, on the router's HTTP port.
+        // ravelNative: HTTPRoute -> router Service on the router's HTTP port;
+        // GRPCRoute -> STILL the gateway Service on the gateway's gRPC port.
         let mut spec = ravel_native_spec(2, AffinityKeySource::CanonicalTenant);
         spec.gateway.exposure = exposure_with(router_gw.clone(), Vec::new(), true).exposure;
         let (http, grpc) = desired_gateway_routes(&spec, "prod");
@@ -3489,9 +3685,14 @@ mod tests {
         );
         assert_eq!(
             route_spec(&grpc)["rules"][0]["backendRefs"][0]["name"],
-            serde_json::json!("prod-ingest-router"),
-            "GRPCRoute must also target the router by name so gRPC does not \
-             silently bypass affinity by hitting the gateway"
+            serde_json::json!("prod-gateway"),
+            "GRPCRoute must keep targeting the gateway Service: the router serves \
+             HTTP only today, so routing gRPC through it would break gRPC ingest"
+        );
+        assert_eq!(
+            route_spec(&grpc)["rules"][0]["backendRefs"][0]["port"],
+            serde_json::json!(GRPC_PORT),
+            "GRPCRoute must keep the gateway's gRPC port, exactly as on main"
         );
 
         // Default ingressNginx backend + same exposure: still the gateway
@@ -3521,8 +3722,10 @@ mod tests {
         let sweep = possible_router_object_names("prod");
         assert_eq!(sweep, vec!["prod-ingest-router".to_string()]);
 
-        // Active: every router object carries the swept name.
-        let spec = ravel_native_spec(2, AffinityKeySource::CanonicalTenant);
+        // Active: every router object carries the swept name. Key source is
+        // authorization-header (needs no resolver) since this test is about
+        // object naming and the sweep, not the key source.
+        let spec = ravel_native_spec(2, AffinityKeySource::AuthorizationHeader);
         let objects = desired_objects(&spec, "prod", "default", &ctx()).expect("render");
         assert_eq!(
             objects
@@ -3543,8 +3746,9 @@ mod tests {
         // Switched back to ingressNginx: nothing rendered under that name, so
         // the sweep (which iterates `possible_router_object_names` and deletes
         // whatever the render omitted) removes every router-owned object. The
-        // key source is reset to a legacy-valid one too, since canonicalTenant +
-        // ingressNginx is a CEL-rejected combination that cannot reach reconcile.
+        // key source stays authorization-header, a legacy-valid source (a
+        // canonicalTenant + ingressNginx combination is CEL-rejected and cannot
+        // reach reconcile).
         let mut switched = spec.clone();
         if let Some(a) = switched.gateway.ingest_affinity.as_mut() {
             a.backend = AffinityBackend::IngressNginx;

--- a/services/ravel-operator/src/reconcile.rs
+++ b/services/ravel-operator/src/reconcile.rs
@@ -16,21 +16,42 @@ use k8s_openapi::api::apps::v1::{Deployment, DeploymentSpec, DeploymentStrategy}
 use k8s_openapi::api::core::v1::{
     Container, ContainerPort, EnvVar, EnvVarSource, HTTPGetAction, KeyToPath, PodSpec,
     PodTemplateSpec, Probe, ResourceRequirements, SecretKeySelector, SecretVolumeSource, Service,
-    ServicePort, ServiceSpec, Volume, VolumeMount,
+    ServiceAccount, ServicePort, ServiceSpec, Volume, VolumeMount,
 };
 use k8s_openapi::api::networking::v1::{
     HTTPIngressPath, HTTPIngressRuleValue, Ingress, IngressBackend, IngressRule,
     IngressServiceBackend, IngressSpec, IngressTLS, ServiceBackendPort,
 };
+use k8s_openapi::api::rbac::v1::{PolicyRule, Role, RoleBinding, RoleRef, Subject};
 use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::{LabelSelector, ObjectMeta};
 use k8s_openapi::apimachinery::pkg::util::intstr::IntOrString;
 use kube::core::{ApiResource, DynamicObject, GroupVersionKind};
 
 use crate::crd::{
-    AffinityKeySource, GatewayReference, IngestAffinitySpec, LocalSecretRef, RavelClusterSpec,
-    ResourceRequirementsSpec,
+    AffinityBackend, AffinityKeySource, GatewayReference, IngestAffinitySpec, LocalSecretRef,
+    RavelClusterSpec, ResourceRequirementsSpec,
 };
+
+/// A spec that cannot be rendered into a valid object set.
+///
+/// Surfaced by [`desired_objects`] (and the router renderers it calls) rather
+/// than panicking or emitting a broken object, so the controller records a
+/// `Degraded` status the same way a missing Secret does (ADR-0080 decision 3,
+/// deliverable 1). Kept typed and `PartialEq` so a reconcile unit test can
+/// assert the exact variant.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum RenderError {
+    /// `backend: ravelNative` is selected but `ingestAffinity.routerImage` is
+    /// unset. The router is a different binary from `spec.image`, so there is no
+    /// image to fall back to; rendering a Deployment with an empty `image:`
+    /// would never schedule and hide the misconfiguration.
+    #[error(
+        "gateway.ingestAffinity.backend is ravelNative but gateway.ingestAffinity.routerImage \
+         is not set; set routerImage to the ravel-ingest-router container image"
+    )]
+    RouterImageMissing,
+}
 
 /// HTTP listener port (OTLP/HTTP, query API, and the `/healthz` `/readyz`
 /// probes). Fixed to match the Dockerfile's `EXPOSE` and the server's default.
@@ -386,12 +407,19 @@ fn resources(spec: Option<&ResourceRequirementsSpec>) -> Option<ResourceRequirem
 }
 
 /// Liveness and readiness probes pointed at `/healthz` and `/readyz` on the
-/// HTTP port (ADR-0034 decision 4). Returned as
-/// `(liveness, readiness)`.
+/// gateway/query/maintain HTTP port ([`HTTP_PORT`], ADR-0034 decision 4).
+/// Returned as `(liveness, readiness)`.
 fn probes() -> (Probe, Probe) {
+    probes_on(HTTP_PORT)
+}
+
+/// [`probes`] parameterized by port, so the ravel-native router (which listens
+/// on its own [`ROUTER_HTTP_PORT`], not the ravel-server `HTTP_PORT`) shares the
+/// exact same `/healthz` `/readyz` probe shape.
+fn probes_on(port: i32) -> (Probe, Probe) {
     let http_get = |path: &str| HTTPGetAction {
         path: Some(path.to_string()),
-        port: IntOrString::Int(HTTP_PORT),
+        port: IntOrString::Int(port),
         ..Default::default()
     };
     let liveness = Probe {
@@ -815,6 +843,13 @@ fn affinity_hash_variable(key: &crate::crd::AffinityKeySpec) -> String {
     match key.source {
         AffinityKeySource::AuthorizationHeader => "$http_authorization".to_string(),
         AffinityKeySource::MtlsSubject => "$ssl_client_s_dn".to_string(),
+        // canonical-tenant hashing is a ravel-native-router concern; ingress-nginx
+        // cannot run the resolver chain, and the CANONICAL_TENANT_BACKEND_RULE CEL
+        // rule (crd.rs) rejects this key source under backend: ingressNginx at
+        // admission, so this ingress-nginx-only renderer can never see it.
+        AffinityKeySource::CanonicalTenant => {
+            unreachable!("CEL admission rejects canonical-tenant under backend: ingressNginx")
+        }
         AffinityKeySource::Header => {
             let name = key.header_name.as_deref().unwrap_or("authorization");
             let mangled: String = name
@@ -967,7 +1002,11 @@ pub fn desired_gateway_ingresses(spec: &RavelClusterSpec, instance: &str) -> Vec
     let Some(affinity) = spec.gateway.ingest_affinity.as_ref() else {
         return Vec::new();
     };
-    if !affinity.enabled {
+    // nginx Ingress objects are the `ingressNginx` backend's exposure. Under
+    // `backend: ravelNative` the router renders instead (ADR-0080 decision 3),
+    // so this path renders nothing -- and would otherwise reach
+    // `affinity_hash_variable`'s `CanonicalTenant` unreachable arm.
+    if !affinity.enabled || !matches!(affinity.backend, AffinityBackend::IngressNginx) {
         return Vec::new();
     }
     let mut ingresses = vec![ingest_ingress(
@@ -989,6 +1028,305 @@ pub fn desired_gateway_ingresses(spec: &RavelClusterSpec, instance: &str) -> Vec
         ));
     }
     ingresses
+}
+
+/// Component suffix of the ravel-native ingest router's managed objects:
+/// `<cluster>-ingest-router`. The Deployment, Service, ServiceAccount, Role, and
+/// RoleBinding all share this one base name (ADR-0080 decision 3).
+const ROUTER_COMPONENT: &str = "ingest-router";
+
+/// The router's HTTP listener and container port, matching the frozen
+/// `services/ravel-ingest-router` CLI default (`--listen-http 0.0.0.0:8080`).
+///
+/// There is intentionally no gRPC port: the router has no `--listen-grpc` flag
+/// on main (#184, T6b, adds it concurrently in a different crate), so this task
+/// renders an HTTP-only Deployment with this single container port. Wiring the
+/// gRPC listener and a second container port once #184 lands is a documented
+/// follow-up, not guessed at here.
+pub const ROUTER_HTTP_PORT: i32 = 8080;
+
+/// Default replica count for the router Deployment.
+///
+/// The CRD has no per-router replica field yet (a `ingestAffinity.routerReplicas`
+/// surface is a documented follow-up); two, so a single router pod loss does not
+/// take ingest down.
+const DEFAULT_ROUTER_REPLICAS: i32 = 2;
+
+/// The ingest-affinity spec when the ravel-native router should be rendered:
+/// affinity present, `enabled`, and `backend: ravelNative`. `None` otherwise.
+///
+/// Every router renderer and the Gateway-API backendRef switch
+/// ([`desired_gateway_routes`]) share this one gate, so they cannot disagree
+/// about when the router exists: a route can only point at a router Service the
+/// renderers also produce.
+fn ravel_native_affinity(spec: &RavelClusterSpec) -> Option<&IngestAffinitySpec> {
+    let affinity = spec.gateway.ingest_affinity.as_ref()?;
+    (affinity.enabled && matches!(affinity.backend, AffinityBackend::RavelNative))
+        .then_some(affinity)
+}
+
+/// The `--key-source` CLI value for a key source, matching the frozen
+/// `services/ravel-ingest-router` contract byte for byte.
+///
+/// A mismatch here compiles and passes CI yet crashloops the router pod (its own
+/// CLI rejects an unknown value at startup), which is exactly why
+/// [`backend_ravel_native_renders_router_deployment_with_frozen_cli_args`] pins
+/// the whole rendered arg list against a hardcoded expected vector.
+fn router_key_source_value(source: AffinityKeySource) -> &'static str {
+    match source {
+        AffinityKeySource::AuthorizationHeader => "authorization-header",
+        AffinityKeySource::Header => "header",
+        AffinityKeySource::MtlsSubject => "mtls-subject",
+        AffinityKeySource::CanonicalTenant => "canonical-tenant",
+    }
+}
+
+/// The router container's args, rendered from the frozen CLI contract.
+///
+/// `--gateway-service-name`/`--gateway-service-namespace` name this
+/// `RavelCluster`'s own gateway Service (the router watches its EndpointSlices);
+/// `--subset-size` and `--key-source` come from the affinity spec. The
+/// OIDC/mTLS/tenant-token/dev-header flags are REJECTED by the router's own CLI
+/// unless `--key-source canonical-tenant`, so the only such flag rendered here
+/// (`--tenant-token`, when a `tenantTokensSecretRef` exists) is gated on that
+/// source. The router's OIDC and mTLS configuration has NO operator-side CRD
+/// surface today -- `ravel-server`'s own OIDC/mTLS config is CLI-flag-only with
+/// no CRD field the operator threads -- so those flags are intentionally not
+/// rendered; giving the canonical-tenant resolver its OIDC/mTLS config is a
+/// separate, larger CRD design task (documented in the task report), not
+/// invented here.
+fn router_args(
+    affinity: &IngestAffinitySpec,
+    instance: &str,
+    namespace: &str,
+    spec: &RavelClusterSpec,
+    ctx: &RenderCtx,
+) -> Vec<String> {
+    let mut args = vec![
+        "--gateway-service-name".to_string(),
+        child_name(instance, "gateway"),
+        "--gateway-service-namespace".to_string(),
+        namespace.to_string(),
+        "--subset-size".to_string(),
+        affinity.subset_size.to_string(),
+        "--key-source".to_string(),
+        router_key_source_value(affinity.key.source).to_string(),
+    ];
+    // The router CLI requires --key-header-name iff --key-source header.
+    if affinity.key.source == AffinityKeySource::Header
+        && let Some(header_name) = affinity.key.header_name.as_ref()
+    {
+        args.push("--key-header-name".to_string());
+        args.push(header_name.clone());
+    }
+    args.push("--listen-http".to_string());
+    args.push(format!("0.0.0.0:{ROUTER_HTTP_PORT}"));
+    // tenant-token flags are rejected by the router CLI unless the key source is
+    // canonical-tenant, so render them only then. Reuses the same
+    // $(VAR)-expansion machinery ravel-server's tiers use (see
+    // [`tenant_token_args`]/[`tenant_token_env`]), so a raw token never appears
+    // in the Pod spec.
+    if affinity.key.source == AffinityKeySource::CanonicalTenant {
+        args.extend(tenant_token_args(spec, ctx));
+    }
+    args
+}
+
+/// The ravel-native ingest router's Deployment (ADR-0080 decision 3), or `None`
+/// when `backend` is not `ravelNative` or affinity is absent/disabled.
+///
+/// Returns [`RenderError::RouterImageMissing`] when the router is called for but
+/// `ingestAffinity.routerImage` is unset: the router is a different binary from
+/// `spec.image`, so there is nothing to fall back to, and rendering an empty
+/// `image:` would only surface as an un-schedulable pod. The controller turns
+/// this error into a `Degraded` status condition (deliverable 1), so a
+/// misconfigured CR fails visibly at reconcile time rather than silently.
+///
+/// The container image is always `routerImage`, never `spec.image`. Health
+/// probes hit `/healthz` `/readyz` on [`ROUTER_HTTP_PORT`], and the pod runs
+/// under the router's own ServiceAccount ([`desired_router_service_account`]) so
+/// its EndpointSlice/Service reads use the least-privilege Role, not the
+/// operator's identity.
+pub fn desired_router_deployment(
+    spec: &RavelClusterSpec,
+    instance: &str,
+    namespace: &str,
+    ctx: &RenderCtx,
+) -> Result<Option<Deployment>, RenderError> {
+    let Some(affinity) = ravel_native_affinity(spec) else {
+        return Ok(None);
+    };
+    let Some(image) = affinity.router_image.as_ref() else {
+        return Err(RenderError::RouterImageMissing);
+    };
+    let args = router_args(affinity, instance, namespace, spec, ctx);
+    let env = if affinity.key.source == AffinityKeySource::CanonicalTenant {
+        tenant_token_env(spec, ctx)
+    } else {
+        Vec::new()
+    };
+    let labels = labels(instance, ROUTER_COMPONENT);
+    let (liveness, readiness) = probes_on(ROUTER_HTTP_PORT);
+    let container = Container {
+        name: "ravel-ingest-router".to_string(),
+        image: Some(image.clone()),
+        image_pull_policy: spec.image_pull_policy.clone(),
+        args: Some(args),
+        env: if env.is_empty() { None } else { Some(env) },
+        ports: Some(vec![ContainerPort {
+            name: Some("http".to_string()),
+            container_port: ROUTER_HTTP_PORT,
+            ..Default::default()
+        }]),
+        liveness_probe: Some(liveness),
+        readiness_probe: Some(readiness),
+        ..Default::default()
+    };
+    Ok(Some(Deployment {
+        metadata: ObjectMeta {
+            name: Some(child_name(instance, ROUTER_COMPONENT)),
+            labels: Some(labels.clone()),
+            ..Default::default()
+        },
+        spec: Some(DeploymentSpec {
+            replicas: Some(DEFAULT_ROUTER_REPLICAS),
+            selector: LabelSelector {
+                match_labels: Some(labels.clone()),
+                ..Default::default()
+            },
+            strategy: Some(DeploymentStrategy {
+                type_: Some("RollingUpdate".to_string()),
+                rolling_update: None,
+            }),
+            template: PodTemplateSpec {
+                metadata: Some(ObjectMeta {
+                    labels: Some(labels),
+                    ..Default::default()
+                }),
+                spec: Some(PodSpec {
+                    containers: vec![container],
+                    // The router reads EndpointSlices/Services under its own
+                    // least-privilege ServiceAccount (deliverable 7).
+                    service_account_name: Some(child_name(instance, ROUTER_COMPONENT)),
+                    ..Default::default()
+                }),
+            },
+            ..Default::default()
+        }),
+        status: None,
+    }))
+}
+
+/// The router's ClusterIP Service on [`ROUTER_HTTP_PORT`], or `None` when the
+/// router is not rendered. The Gateway-API routes point their backendRef at this
+/// Service under `backend: ravelNative` (deliverable 4).
+pub fn desired_router_service(spec: &RavelClusterSpec, instance: &str) -> Option<Service> {
+    ravel_native_affinity(spec)?;
+    Some(service(
+        instance,
+        ROUTER_COMPONENT,
+        vec![ServicePort {
+            name: Some("http".to_string()),
+            port: ROUTER_HTTP_PORT,
+            target_port: Some(IntOrString::Int(ROUTER_HTTP_PORT)),
+            ..Default::default()
+        }],
+    ))
+}
+
+/// The router's ServiceAccount, or `None` when the router is not rendered. The
+/// Deployment runs as this account and the Role/RoleBinding
+/// ([`desired_router_role`]/[`desired_router_role_binding`]) scope its
+/// permissions to EndpointSlices and Services in its own namespace only.
+pub fn desired_router_service_account(
+    spec: &RavelClusterSpec,
+    instance: &str,
+) -> Option<ServiceAccount> {
+    ravel_native_affinity(spec)?;
+    Some(ServiceAccount {
+        metadata: ObjectMeta {
+            name: Some(child_name(instance, ROUTER_COMPONENT)),
+            labels: Some(labels(instance, ROUTER_COMPONENT)),
+            ..Default::default()
+        },
+        ..Default::default()
+    })
+}
+
+/// The router's namespaced Role granting `get`/`list`/`watch` on
+/// `endpointslices` (discovery.k8s.io) and `services` (core) ONLY, or `None`
+/// when the router is not rendered.
+///
+/// Least-privilege, consistent with this repo's per-role credential-scoping
+/// convention (ADR-0055, ADR-0072): no cluster-wide grant, no other resource,
+/// and no write verbs. This is exactly what the router's EndpointSlice watcher
+/// needs to compute subsets and dial gateway pods directly.
+pub fn desired_router_role(spec: &RavelClusterSpec, instance: &str) -> Option<Role> {
+    ravel_native_affinity(spec)?;
+    Some(Role {
+        metadata: ObjectMeta {
+            name: Some(child_name(instance, ROUTER_COMPONENT)),
+            labels: Some(labels(instance, ROUTER_COMPONENT)),
+            ..Default::default()
+        },
+        rules: Some(vec![
+            PolicyRule {
+                api_groups: Some(vec!["discovery.k8s.io".to_string()]),
+                resources: Some(vec!["endpointslices".to_string()]),
+                verbs: vec!["get".to_string(), "list".to_string(), "watch".to_string()],
+                ..Default::default()
+            },
+            PolicyRule {
+                api_groups: Some(vec![String::new()]),
+                resources: Some(vec!["services".to_string()]),
+                verbs: vec!["get".to_string(), "list".to_string(), "watch".to_string()],
+                ..Default::default()
+            },
+        ]),
+    })
+}
+
+/// The router's namespaced RoleBinding tying its ServiceAccount to its Role, or
+/// `None` when the router is not rendered. `namespace` scopes the Subject to the
+/// `RavelCluster`'s own namespace.
+pub fn desired_router_role_binding(
+    spec: &RavelClusterSpec,
+    instance: &str,
+    namespace: &str,
+) -> Option<RoleBinding> {
+    ravel_native_affinity(spec)?;
+    let name = child_name(instance, ROUTER_COMPONENT);
+    Some(RoleBinding {
+        metadata: ObjectMeta {
+            name: Some(name.clone()),
+            labels: Some(labels(instance, ROUTER_COMPONENT)),
+            ..Default::default()
+        },
+        role_ref: RoleRef {
+            api_group: "rbac.authorization.k8s.io".to_string(),
+            kind: "Role".to_string(),
+            name: name.clone(),
+        },
+        subjects: Some(vec![Subject {
+            kind: "ServiceAccount".to_string(),
+            name,
+            namespace: Some(namespace.to_string()),
+            ..Default::default()
+        }]),
+    })
+}
+
+/// Every router-owned object name the render can produce for `instance`, in a
+/// fixed order, whether or not the current spec asks for them.
+///
+/// The Deployment, Service, ServiceAccount, Role, and RoleBinding all share this
+/// one base name, so a single-element list covers every kind: the controller
+/// sweeps this name across each kind's own `Api`, deleting whichever objects the
+/// current mode did not render (deliverable 6). Switching `backend` away from
+/// `ravelNative`, or disabling affinity, therefore cleans up every router-owned
+/// object instead of orphaning it.
+pub fn possible_router_object_names(instance: &str) -> Vec<String> {
+    vec![child_name(instance, ROUTER_COMPONENT)]
 }
 
 /// Gateway API group for the exposure routes (ADR-0080 decision 2).
@@ -1049,13 +1387,15 @@ pub fn possible_gateway_route_names(instance: &str) -> Vec<String> {
 /// API, to the route's own namespace, which the controller renders into the
 /// `RavelCluster`'s namespace -- exactly the "defaults to the CR's own
 /// namespace" contract, without this pure function needing to know the
-/// namespace. `backendRefs` always points at the gateway Service directly (ADR-
-/// 0080 decision 2); pointing it at the ravel-native router's Service under
-/// `backend: RavelNative` is a later task (#158), not anticipated here.
+/// namespace. `backendRefs` targets `backend_name` on `port`: the gateway
+/// Service directly for every existing CR, or the ravel-native router's Service
+/// under `backend: ravelNative` (ADR-0080 decision 3, deliverable 4), decided by
+/// the one caller [`desired_gateway_routes`].
 fn gateway_route(
     instance: &str,
     component: &str,
     api_resource: &ApiResource,
+    backend_name: &str,
     port: i32,
     gateway_ref: &GatewayReference,
     hostnames: &[String],
@@ -1068,9 +1408,9 @@ fn gateway_route(
         "parentRefs": [parent_ref],
         "rules": [{
             "backendRefs": [{
-                // The gateway Service, by numeric port: Gateway API backendRefs
-                // reference a port number, not the named port an Ingress uses.
-                "name": child_name(instance, "gateway"),
+                // By numeric port: Gateway API backendRefs reference a port
+                // number, not the named port an Ingress uses.
+                "name": backend_name,
                 "port": port,
             }],
         }],
@@ -1110,11 +1450,31 @@ pub fn desired_gateway_routes(
     else {
         return (None, None);
     };
+    // Backend-aware backendRef (ADR-0080 decision 3, deliverable 4). Under
+    // `backend: ravelNative` the routes point at the router's Service so ingest
+    // traffic is subset-pinned; for every other CR (affinity absent, disabled,
+    // or ingressNginx) they keep targeting the gateway Service exactly as
+    // before -- zero behavior change. The router listens HTTP-only on
+    // ROUTER_HTTP_PORT today; the GRPCRoute still targets the router by name (so
+    // gRPC traffic does not silently bypass affinity by hitting the gateway
+    // directly), but at the router's HTTP port until #184 adds the router's gRPC
+    // listener and a dedicated port -- a documented follow-up.
+    let (http_backend, http_port, grpc_backend, grpc_port) = match ravel_native_affinity(spec) {
+        Some(_) => {
+            let router = child_name(instance, ROUTER_COMPONENT);
+            (router.clone(), ROUTER_HTTP_PORT, router, ROUTER_HTTP_PORT)
+        }
+        None => {
+            let gateway = child_name(instance, "gateway");
+            (gateway.clone(), HTTP_PORT, gateway, GRPC_PORT)
+        }
+    };
     let httproute = gateway_route(
         instance,
         GATEWAY_HTTPROUTE_COMPONENT,
         &httproute_api_resource(),
-        HTTP_PORT,
+        &http_backend,
+        http_port,
         &gateway_api.gateway_ref,
         &gateway_api.hostnames,
     );
@@ -1123,7 +1483,8 @@ pub fn desired_gateway_routes(
             instance,
             GATEWAY_GRPCROUTE_COMPONENT,
             &grpcroute_api_resource(),
-            GRPC_PORT,
+            &grpc_backend,
+            grpc_port,
             &gateway_api.gateway_ref,
             &gateway_api.hostnames,
         )
@@ -1148,6 +1509,18 @@ pub struct DesiredObjects {
     /// decision 2); each `None` when exposure is off or, for the GRPCRoute, when
     /// `grpc` is false.
     pub gateway_routes: (Option<DynamicObject>, Option<DynamicObject>),
+    /// The ravel-native ingest router's objects (ADR-0080 decision 3); every
+    /// field `None` unless `backend: ravelNative` affinity is enabled. Rendered
+    /// as a set so the controller applies (and sweeps) them together.
+    pub router_deployment: Option<Deployment>,
+    /// The router's Service.
+    pub router_service: Option<Service>,
+    /// The router's ServiceAccount.
+    pub router_service_account: Option<ServiceAccount>,
+    /// The router's namespaced Role.
+    pub router_role: Option<Role>,
+    /// The router's namespaced RoleBinding.
+    pub router_role_binding: Option<RoleBinding>,
     /// The query Deployment.
     pub query_deployment: Deployment,
     /// The query Service.
@@ -1158,16 +1531,31 @@ pub struct DesiredObjects {
 }
 
 /// Render every Kubernetes object a `RavelCluster` reconcile applies.
-pub fn desired_objects(spec: &RavelClusterSpec, instance: &str, ctx: &RenderCtx) -> DesiredObjects {
-    DesiredObjects {
+///
+/// Fallible because the ravel-native router cannot be rendered without a
+/// `routerImage` (ADR-0080 decision 3, deliverable 1): a misconfigured CR yields
+/// [`RenderError::RouterImageMissing`], which the controller turns into a
+/// `Degraded` status rather than applying a broken Deployment.
+pub fn desired_objects(
+    spec: &RavelClusterSpec,
+    instance: &str,
+    namespace: &str,
+    ctx: &RenderCtx,
+) -> Result<DesiredObjects, RenderError> {
+    Ok(DesiredObjects {
         gateway_deployment: desired_gateway_deployment(spec, instance, ctx),
         gateway_service: desired_gateway_service(spec, instance),
         gateway_ingresses: desired_gateway_ingresses(spec, instance),
         gateway_routes: desired_gateway_routes(spec, instance),
+        router_deployment: desired_router_deployment(spec, instance, namespace, ctx)?,
+        router_service: desired_router_service(spec, instance),
+        router_service_account: desired_router_service_account(spec, instance),
+        router_role: desired_router_role(spec, instance),
+        router_role_binding: desired_router_role_binding(spec, instance, namespace),
         query_deployment: desired_query_deployment(spec, instance, ctx),
         query_service: desired_query_service(spec, instance),
         maintain_deployment: desired_maintain_deployment(spec, instance, ctx),
-    }
+    })
 }
 
 #[cfg(test)]
@@ -2138,7 +2526,7 @@ mod tests {
             tls_secret_name: Some("ingest-tls".to_string()),
             ..default_affinity()
         });
-        let objects = desired_objects(&spec, "prod", &ctx());
+        let objects = desired_objects(&spec, "prod", "default", &ctx()).expect("render");
 
         let names: Vec<String> = objects
             .gateway_ingresses
@@ -2391,7 +2779,7 @@ mod tests {
         // this change (it managed only Deployments and Services).
         let spec = base_spec();
         assert!(spec.gateway.ingest_affinity.is_none());
-        let objects = desired_objects(&spec, "prod", &ctx());
+        let objects = desired_objects(&spec, "prod", "default", &ctx()).expect("render");
         assert!(
             objects.gateway_ingresses.is_empty(),
             "a RavelCluster with no affinity field must render no Ingress"
@@ -2404,7 +2792,8 @@ mod tests {
         // render of every other object is necessarily unchanged from today.
         let mut affinity_spec = base_spec();
         affinity_spec.gateway.ingest_affinity = Some(default_affinity());
-        let with_affinity = desired_objects(&affinity_spec, "prod", &ctx());
+        let with_affinity =
+            desired_objects(&affinity_spec, "prod", "default", &ctx()).expect("render");
         for (off, on, what) in [
             (
                 serde_json::to_value(&objects.gateway_deployment),
@@ -2712,7 +3101,7 @@ mod tests {
             vec!["ingest.example.com".to_string()],
             true,
         );
-        let objects = desired_objects(&spec, "prod", &ctx());
+        let objects = desired_objects(&spec, "prod", "default", &ctx()).expect("render");
         let (http, grpc) = objects.gateway_routes;
         let http = http.expect("HTTPRoute always rendered when exposure is set");
         let grpc = grpc.expect("GRPCRoute rendered when grpc is true");
@@ -2851,5 +3240,324 @@ mod tests {
             ],
             "the delete-sweep must name both route kinds so both are removed"
         );
+    }
+
+    /// A spec with `backend: ravelNative` affinity, `routerImage` set, and no
+    /// tenant-tokens Secret (so the frozen-args assertion stays clean).
+    fn ravel_native_spec(subset_size: u32, source: AffinityKeySource) -> RavelClusterSpec {
+        let mut spec = base_spec();
+        spec.tenant_tokens_secret_ref = None;
+        spec.gateway.ingest_affinity = Some(IngestAffinitySpec {
+            backend: AffinityBackend::RavelNative,
+            router_image: Some("registry.example/ravel-ingest-router:v1".to_string()),
+            subset_size,
+            key: AffinityKeySpec {
+                source,
+                header_name: None,
+            },
+            ..IngestAffinitySpec::default()
+        });
+        spec
+    }
+
+    #[test]
+    fn backend_ravel_native_renders_router_deployment_with_frozen_cli_args() {
+        // ADR-0080 decision 3, deliverables 3 and 5. The whole point of this
+        // test: a future accidental rename of the router's own flag names (in
+        // #184's crate) becomes a caught test failure here instead of a
+        // crashlooping pod. The args are pinned as a full ordered vector, not a
+        // contains-check.
+        let spec = ravel_native_spec(3, AffinityKeySource::CanonicalTenant);
+        let objects = desired_objects(&spec, "prod", "default", &ctx()).expect("render");
+        let deployment = objects
+            .router_deployment
+            .expect("ravelNative renders a router Deployment");
+
+        assert_eq!(
+            args_of(&deployment),
+            vec![
+                "--gateway-service-name",
+                "prod-gateway",
+                "--gateway-service-namespace",
+                "default",
+                "--subset-size",
+                "3",
+                "--key-source",
+                "canonical-tenant",
+                "--listen-http",
+                "0.0.0.0:8080",
+            ]
+        );
+
+        // The image is routerImage, NEVER spec.image (a different binary).
+        let container = container_of(&deployment);
+        assert_eq!(
+            container.image.as_deref(),
+            Some("registry.example/ravel-ingest-router:v1")
+        );
+        assert_ne!(container.image.as_deref(), Some(spec.image.as_str()));
+        assert_eq!(container.name, "ravel-ingest-router");
+
+        // HTTP-only: exactly one container port, 8080, no gRPC port (#184).
+        let ports = container.ports.as_ref().expect("router ports");
+        assert_eq!(ports.len(), 1);
+        assert_eq!(ports[0].container_port, ROUTER_HTTP_PORT);
+
+        // Runs under its own ServiceAccount (deliverable 7).
+        let pod = deployment
+            .spec
+            .as_ref()
+            .expect("spec")
+            .template
+            .spec
+            .as_ref()
+            .expect("pod spec");
+        assert_eq!(
+            pod.service_account_name.as_deref(),
+            Some("prod-ingest-router")
+        );
+
+        // The full router object set is rendered.
+        assert!(objects.router_service.is_some());
+        assert!(objects.router_service_account.is_some());
+        assert!(objects.router_role.is_some());
+        assert!(objects.router_role_binding.is_some());
+
+        // The Role is least-privilege: get/list/watch on endpointslices and
+        // services only, no write verbs, no other resource.
+        let role = objects.router_role.expect("router Role");
+        let rules = role.rules.expect("role rules");
+        assert_eq!(rules.len(), 2);
+        for rule in &rules {
+            assert_eq!(
+                rule.verbs,
+                vec!["get".to_string(), "list".to_string(), "watch".to_string()]
+            );
+        }
+        assert_eq!(
+            rules[0].api_groups.as_deref(),
+            Some(["discovery.k8s.io".to_string()].as_slice())
+        );
+        assert_eq!(
+            rules[0].resources.as_deref(),
+            Some(["endpointslices".to_string()].as_slice())
+        );
+        assert_eq!(
+            rules[1].api_groups.as_deref(),
+            Some([String::new()].as_slice())
+        );
+        assert_eq!(
+            rules[1].resources.as_deref(),
+            Some(["services".to_string()].as_slice())
+        );
+
+        // The RoleBinding subject is the router SA in this namespace, bound to
+        // the router Role.
+        let binding = objects.router_role_binding.expect("router RoleBinding");
+        assert_eq!(binding.role_ref.kind, "Role");
+        assert_eq!(binding.role_ref.name, "prod-ingest-router");
+        let subjects = binding.subjects.expect("subjects");
+        assert_eq!(subjects[0].kind, "ServiceAccount");
+        assert_eq!(subjects[0].name, "prod-ingest-router");
+        assert_eq!(subjects[0].namespace.as_deref(), Some("default"));
+    }
+
+    #[test]
+    fn router_renders_key_header_name_and_tenant_tokens_only_where_valid() {
+        // key.source header renders --key-header-name; a non-canonical source
+        // renders NO --tenant-token even with a tenant-tokens Secret (the router
+        // CLI rejects those flags unless --key-source canonical-tenant).
+        let mut spec = ravel_native_spec(2, AffinityKeySource::Header);
+        spec.tenant_tokens_secret_ref = Some(LocalSecretRef {
+            name: "ravel-tokens".to_string(),
+        });
+        if let Some(a) = spec.gateway.ingest_affinity.as_mut() {
+            a.key.header_name = Some("X-Scope-OrgID".to_string());
+        }
+        let args = args_of(
+            &desired_router_deployment(&spec, "prod", "ns", &ctx())
+                .expect("render")
+                .expect("router deployment"),
+        );
+        assert_eq!(arg_value(&args, "--key-source").as_deref(), Some("header"));
+        assert_eq!(
+            arg_value(&args, "--key-header-name").as_deref(),
+            Some("X-Scope-OrgID")
+        );
+        assert!(
+            !args.iter().any(|a| a == "--tenant-token"),
+            "non-canonical key source must render no --tenant-token: {args:?}"
+        );
+
+        // canonical-tenant WITH a tenant-tokens Secret renders --tenant-token.
+        let mut spec = ravel_native_spec(2, AffinityKeySource::CanonicalTenant);
+        spec.tenant_tokens_secret_ref = Some(LocalSecretRef {
+            name: "ravel-tokens".to_string(),
+        });
+        let deployment = desired_router_deployment(&spec, "prod", "ns", &ctx())
+            .expect("render")
+            .expect("router deployment");
+        let args = args_of(&deployment);
+        assert!(
+            args.iter().any(|a| a == "--tenant-token"),
+            "canonical-tenant with a tokens Secret must render --tenant-token: {args:?}"
+        );
+        // And the token reaches the container via $(VAR) env, never inline.
+        assert!(
+            container_of(&deployment)
+                .env
+                .as_ref()
+                .expect("token env")
+                .iter()
+                .any(|e| e.name.starts_with("RAVEL_TENANT_TOKEN_"))
+        );
+    }
+
+    #[test]
+    fn backend_ingress_nginx_renders_no_router_objects() {
+        // Default backend: zero router objects, zero behavior change for every
+        // existing CR. Also true when affinity is absent entirely.
+        for affinity in [
+            None,
+            Some(IngestAffinitySpec::default()), // backend: ingressNginx (default)
+            Some(IngestAffinitySpec {
+                enabled: false,
+                backend: AffinityBackend::RavelNative,
+                router_image: Some("x".to_string()),
+                ..IngestAffinitySpec::default()
+            }), // ravelNative but disabled
+        ] {
+            let mut spec = base_spec();
+            spec.gateway.ingest_affinity = affinity;
+            let objects = desired_objects(&spec, "prod", "default", &ctx()).expect("render");
+            assert!(objects.router_deployment.is_none());
+            assert!(objects.router_service.is_none());
+            assert!(objects.router_service_account.is_none());
+            assert!(objects.router_role.is_none());
+            assert!(objects.router_role_binding.is_none());
+        }
+    }
+
+    #[test]
+    fn router_image_absent_under_ravel_native_is_a_typed_error_not_a_panic() {
+        // ADR-0080 decision 3, deliverable 1: routerImage is required under
+        // ravelNative. Absent -> a typed RenderError (which the controller turns
+        // into a Degraded condition), never a panic and never a Deployment with
+        // an empty image.
+        let mut spec = base_spec();
+        spec.gateway.ingest_affinity = Some(IngestAffinitySpec {
+            backend: AffinityBackend::RavelNative,
+            router_image: None,
+            ..IngestAffinitySpec::default()
+        });
+        assert_eq!(
+            desired_router_deployment(&spec, "prod", "default", &ctx()),
+            Err(RenderError::RouterImageMissing)
+        );
+        // DesiredObjects holds DynamicObjects (no PartialEq), so match the Err
+        // arm rather than comparing the whole Result.
+        assert!(matches!(
+            desired_objects(&spec, "prod", "default", &ctx()),
+            Err(RenderError::RouterImageMissing)
+        ));
+    }
+
+    #[test]
+    fn gateway_route_backend_ref_targets_router_service_under_ravel_native() {
+        // ADR-0080 decision 3, deliverable 4. Exposure + ravelNative affinity:
+        // both routes point at the router Service. The same exposure under the
+        // default ingressNginx backend still targets the gateway Service
+        // (regression guard on Wave 2 behavior).
+        let router_gw = GatewayReference {
+            name: "public-gw".to_string(),
+            namespace: None,
+        };
+
+        // ravelNative: backendRefs -> router Service, on the router's HTTP port.
+        let mut spec = ravel_native_spec(2, AffinityKeySource::CanonicalTenant);
+        spec.gateway.exposure = exposure_with(router_gw.clone(), Vec::new(), true).exposure;
+        let (http, grpc) = desired_gateway_routes(&spec, "prod");
+        let http = http.expect("HTTPRoute");
+        let grpc = grpc.expect("GRPCRoute");
+        assert_eq!(
+            route_spec(&http)["rules"][0]["backendRefs"][0]["name"],
+            serde_json::json!("prod-ingest-router")
+        );
+        assert_eq!(
+            route_spec(&http)["rules"][0]["backendRefs"][0]["port"],
+            serde_json::json!(ROUTER_HTTP_PORT)
+        );
+        assert_eq!(
+            route_spec(&grpc)["rules"][0]["backendRefs"][0]["name"],
+            serde_json::json!("prod-ingest-router"),
+            "GRPCRoute must also target the router by name so gRPC does not \
+             silently bypass affinity by hitting the gateway"
+        );
+
+        // Default ingressNginx backend + same exposure: still the gateway
+        // Service on 4318/4317, exactly as before.
+        let mut spec = base_spec();
+        spec.gateway = exposure_with(router_gw, Vec::new(), true);
+        let (http, grpc) = desired_gateway_routes(&spec, "prod");
+        assert_eq!(
+            route_spec(&http.expect("HTTPRoute"))["rules"][0]["backendRefs"][0]["name"],
+            serde_json::json!("prod-gateway")
+        );
+        assert_eq!(
+            route_spec(&grpc.expect("GRPCRoute"))["rules"][0]["backendRefs"][0]["name"],
+            serde_json::json!("prod-gateway")
+        );
+    }
+
+    #[test]
+    fn switching_backend_away_from_ravel_native_sweeps_router_objects() {
+        // ADR-0080 decision 3, deliverable 6. When ravelNative is active the
+        // render produces the router objects under one shared name; the
+        // controller's apply-then-sweep (controller.rs) deletes every name in
+        // `possible_router_object_names` the current render did NOT produce.
+        // Prove both halves: the names produced under ravelNative, and that
+        // switching back renders nothing under those very names (so the sweep
+        // deletes them), rather than merely that the possible-names list grew.
+        let sweep = possible_router_object_names("prod");
+        assert_eq!(sweep, vec!["prod-ingest-router".to_string()]);
+
+        // Active: every router object carries the swept name.
+        let spec = ravel_native_spec(2, AffinityKeySource::CanonicalTenant);
+        let objects = desired_objects(&spec, "prod", "default", &ctx()).expect("render");
+        assert_eq!(
+            objects
+                .router_deployment
+                .as_ref()
+                .and_then(|d| d.metadata.name.as_deref()),
+            Some("prod-ingest-router")
+        );
+        assert_eq!(
+            objects
+                .router_service
+                .as_ref()
+                .and_then(|s| s.metadata.name.as_deref()),
+            Some("prod-ingest-router")
+        );
+        assert!(sweep.contains(&"prod-ingest-router".to_string()));
+
+        // Switched back to ingressNginx: nothing rendered under that name, so
+        // the sweep (which iterates `possible_router_object_names` and deletes
+        // whatever the render omitted) removes every router-owned object. The
+        // key source is reset to a legacy-valid one too, since canonicalTenant +
+        // ingressNginx is a CEL-rejected combination that cannot reach reconcile.
+        let mut switched = spec.clone();
+        if let Some(a) = switched.gateway.ingest_affinity.as_mut() {
+            a.backend = AffinityBackend::IngressNginx;
+            a.key.source = AffinityKeySource::AuthorizationHeader;
+        }
+        let objects = desired_objects(&switched, "prod", "default", &ctx()).expect("render");
+        assert!(objects.router_deployment.is_none());
+        assert!(objects.router_service.is_none());
+        assert!(objects.router_service_account.is_none());
+        assert!(objects.router_role.is_none());
+        assert!(objects.router_role_binding.is_none());
+        // The name the previous mode created is still in the sweep list, so the
+        // controller deletes it on this pass.
+        assert!(possible_router_object_names("prod").contains(&"prod-ingest-router".to_string()));
     }
 }

--- a/services/ravel-operator/src/reconcile.rs
+++ b/services/ravel-operator/src/reconcile.rs
@@ -1071,10 +1071,16 @@ const DEFAULT_ROUTER_REPLICAS: i32 = 2;
 /// The ingest-affinity spec when the ravel-native router should be rendered:
 /// affinity present, `enabled`, and `backend: ravelNative`. `None` otherwise.
 ///
-/// Every router renderer and the Gateway-API backendRef switch
-/// ([`desired_gateway_routes`]) share this one gate, so they cannot disagree
-/// about when the router exists: a route can only point at a router Service the
-/// renderers also produce.
+/// Every router renderer shares this one gate, so they cannot disagree about
+/// which objects the router set contains. The Gateway-API backendRef switch
+/// ([`desired_gateway_routes`]) needs a STRICTER condition than this, though:
+/// affinity being `ravelNative` is necessary but not sufficient for the router's
+/// Service to exist after a reconcile pass, because the router's own render can
+/// fail this pass (missing `routerImage`, or a canonical-tenant resolver that
+/// resolves to zero tenants). So the route switch keys off the router's actual
+/// render outcome (`router_available`, threaded from [`desired_objects`]), not
+/// this gate alone -- otherwise a route could point at a router Service the same
+/// pass deletes.
 fn ravel_native_affinity(spec: &RavelClusterSpec) -> Option<&IngestAffinitySpec> {
     let affinity = spec.gateway.ingest_affinity.as_ref()?;
     (affinity.enabled && matches!(affinity.backend, AffinityBackend::RavelNative))
@@ -1183,12 +1189,19 @@ pub fn desired_router_deployment(
         return Err(RenderError::RouterImageMissing);
     };
     // canonical-tenant needs at least one resolver or the router's own CLI
-    // crashloops at startup. tenantTokensSecretRef is the only resolver surface
-    // this CRD exposes today, so its absence under canonical-tenant is a
-    // render-time rejection, not a rendered Deployment (see
-    // RenderError::CanonicalTenantResolverMissing).
+    // crashloops at startup. Gate on the ACTUAL rendered resolver flags, not on
+    // `tenant_tokens_secret_ref.is_none()`: the flags come from
+    // `tenant_token_args`, which emits one `--tenant-token` per
+    // `ctx.tenant_names`, and `tenant_names` is the tenant-tokens Secret's live
+    // keys (see controller.rs). The Secret ref can be SET on the spec while the
+    // Secret is absent or has zero keys this cycle (a normal, already-anticipated
+    // live state that controller.rs just warns on and continues) -- in which case
+    // no `--tenant-token` renders and the router crashloops just the same. If no
+    // resolver flags would actually render, reject at render time (see
+    // RenderError::CanonicalTenantResolverMissing) rather than ship a
+    // guaranteed-crashlooping Deployment.
     if affinity.key.source == AffinityKeySource::CanonicalTenant
-        && spec.tenant_tokens_secret_ref.is_none()
+        && tenant_token_args(spec, ctx).is_empty()
     {
         return Err(RenderError::CanonicalTenantResolverMissing);
     }
@@ -1474,6 +1487,7 @@ fn gateway_route(
 pub fn desired_gateway_routes(
     spec: &RavelClusterSpec,
     instance: &str,
+    router_available: bool,
 ) -> (Option<DynamicObject>, Option<DynamicObject>) {
     let Some(gateway_api) = spec
         .gateway
@@ -1484,14 +1498,24 @@ pub fn desired_gateway_routes(
         return (None, None);
     };
     let gateway = child_name(instance, "gateway");
-    // HTTPRoute backendRef (ADR-0080 decision 3, deliverable 4): under
-    // `backend: ravelNative` the HTTP route points at the router's Service so
-    // OTLP/HTTP ingest is subset-pinned; for every other CR (affinity absent,
-    // disabled, or ingressNginx) it keeps targeting the gateway Service exactly
-    // as before -- zero behavior change.
-    let (http_backend, http_port) = match ravel_native_affinity(spec) {
-        Some(_) => (child_name(instance, ROUTER_COMPONENT), ROUTER_HTTP_PORT),
-        None => (gateway.clone(), HTTP_PORT),
+    // HTTPRoute backendRef (ADR-0080 decision 3, deliverable 4): point the HTTP
+    // route at the router's Service ONLY when the router's Service will actually
+    // exist after this reconcile pass -- `router_available` is threaded in from
+    // `desired_objects`, which computes it from the router's own render outcome
+    // this pass. A static `ravel_native_affinity(spec).is_some()` check is NOT
+    // enough: on a router render error (RouterImageMissing, or F1's
+    // CanonicalTenantResolverMissing from a transiently-empty token Secret) the
+    // controller applies routes BEFORE the router block and its delete-sweep
+    // removes every router-owned object that did not render this pass. Pointing
+    // the HTTPRoute at the router Service in that pass would apply a route at a
+    // Service the same pass then deletes -- an ingest outage that does not
+    // self-heal. So for every other case (affinity absent/disabled, ingressNginx,
+    // OR a router that will not be present this pass) fall back to the gateway
+    // Service exactly as before -- zero behavior change on the healthy paths.
+    let (http_backend, http_port) = if router_available {
+        (child_name(instance, ROUTER_COMPONENT), ROUTER_HTTP_PORT)
+    } else {
+        (gateway.clone(), HTTP_PORT)
     };
     // GRPCRoute backendRef ALWAYS targets the gateway Service, regardless of
     // backend. The router deliberately renders an HTTP-only Deployment today
@@ -1615,11 +1639,18 @@ pub fn desired_objects(
         ),
         Err(err) => (None, None, None, None, None, Some(err)),
     };
+    // The HTTPRoute may only point at the router's Service when that Service will
+    // actually exist after this pass. `router_service.is_some()` is exactly that:
+    // it is `Some` only under `backend: ravelNative` AND a clean router render
+    // (the error branch above set it to `None`), so it flips to `false` on any
+    // router render error this pass. See `desired_gateway_routes` for why a static
+    // spec check would strand the route at a deleted Service.
+    let router_available = router_service.is_some();
     Ok(DesiredObjects {
         gateway_deployment: desired_gateway_deployment(spec, instance, ctx),
         gateway_service: desired_gateway_service(spec, instance),
         gateway_ingresses: desired_gateway_ingresses(spec, instance),
-        gateway_routes: desired_gateway_routes(spec, instance),
+        gateway_routes: desired_gateway_routes(spec, instance, router_available),
         router_deployment,
         router_service,
         router_service_account,
@@ -3250,7 +3281,8 @@ mod tests {
             Vec::new(),
             false,
         );
-        let (http, grpc) = desired_gateway_routes(&spec, "prod");
+        // Affinity absent: router not present, HTTPRoute stays on the gateway.
+        let (http, grpc) = desired_gateway_routes(&spec, "prod", false);
         assert!(
             http.is_some(),
             "HTTPRoute still rendered when grpc is false"
@@ -3282,7 +3314,9 @@ mod tests {
                 true,
             )
         };
-        let (http, grpc) = desired_gateway_routes(&spec, "prod");
+        // Routes render independent of affinity; router_available is irrelevant
+        // to this assertion (it checks parentRefs, not the backendRef).
+        let (http, grpc) = desired_gateway_routes(&spec, "prod", false);
         let http = http.expect("HTTPRoute rendered alongside ravelNative affinity");
         assert!(
             grpc.is_some(),
@@ -3301,7 +3335,7 @@ mod tests {
         let mut spec = base_spec();
         spec.gateway = GatewaySpec::default();
         assert_eq!(
-            desired_gateway_routes(&spec, "prod"),
+            desired_gateway_routes(&spec, "prod", false),
             (None, None),
             "exposure absent renders no routes"
         );
@@ -3600,6 +3634,51 @@ mod tests {
     }
 
     #[test]
+    fn canonical_tenant_with_secret_ref_but_no_live_tenants_is_a_typed_error() {
+        // F1: the resolver guard must check the ACTUAL rendered resolver flags,
+        // not `tenant_tokens_secret_ref.is_none()`. A Secret ref SET on the spec
+        // while the Secret is absent or has zero keys this cycle is a normal live
+        // state (controller.rs derives ctx.tenant_names from the Secret's live
+        // keys and just warns on empty). In that case `tenant_token_args` renders
+        // zero `--tenant-token` flags and the router's own CLI still crashloops at
+        // startup -- the exact case the spec-field guard missed. The render must
+        // reject it, not ship a crashlooping Deployment.
+        let mut spec = ravel_native_spec(2, AffinityKeySource::CanonicalTenant);
+        spec.tenant_tokens_secret_ref = Some(LocalSecretRef {
+            name: "ravel-tokens".to_string(),
+        });
+        // The Secret resolves to zero tenants this cycle.
+        let empty_ctx = RenderCtx {
+            tenant_names: Vec::new(),
+            ..ctx()
+        };
+        assert_eq!(
+            desired_router_deployment(&spec, "prod", "default", &empty_ctx),
+            Err(RenderError::CanonicalTenantResolverMissing),
+            "a set secret_ref that resolves to zero live tenants must still be a \
+             typed resolver-missing error, not a crashlooping Deployment"
+        );
+        // And it is captured (not propagated) by desired_objects, exactly like the
+        // secret-ref-absent case: router objects None, error surfaced.
+        let objects =
+            desired_objects(&spec, "prod", "default", &empty_ctx).expect("render never aborts");
+        assert_eq!(
+            objects.router_render_error,
+            Some(RenderError::CanonicalTenantResolverMissing)
+        );
+        assert!(objects.router_deployment.is_none());
+
+        // Sanity: the same spec with a non-empty live tenant set (the existing
+        // fixture shape) still renders cleanly -- the guard did not over-reject.
+        assert!(
+            desired_router_deployment(&spec, "prod", "default", &ctx())
+                .expect("render")
+                .is_some(),
+            "non-empty tenant_names must still render a router Deployment"
+        );
+    }
+
+    #[test]
     fn router_render_failure_still_renders_every_other_tier() {
         // Fix 5 (non-blocking): a router render error must degrade ONLY the
         // router, never abort the whole reconcile. desired_objects returns the
@@ -3672,7 +3751,9 @@ mod tests {
         // GRPCRoute -> STILL the gateway Service on the gateway's gRPC port.
         let mut spec = ravel_native_spec(2, AffinityKeySource::CanonicalTenant);
         spec.gateway.exposure = exposure_with(router_gw.clone(), Vec::new(), true).exposure;
-        let (http, grpc) = desired_gateway_routes(&spec, "prod");
+        // Router renders cleanly here (router_available = true): the HTTPRoute
+        // switches to the router Service.
+        let (http, grpc) = desired_gateway_routes(&spec, "prod", true);
         let http = http.expect("HTTPRoute");
         let grpc = grpc.expect("GRPCRoute");
         assert_eq!(
@@ -3699,7 +3780,8 @@ mod tests {
         // Service on 4318/4317, exactly as before.
         let mut spec = base_spec();
         spec.gateway = exposure_with(router_gw, Vec::new(), true);
-        let (http, grpc) = desired_gateway_routes(&spec, "prod");
+        // ingressNginx backend: no router, HTTPRoute stays on the gateway Service.
+        let (http, grpc) = desired_gateway_routes(&spec, "prod", false);
         assert_eq!(
             route_spec(&http.expect("HTTPRoute"))["rules"][0]["backendRefs"][0]["name"],
             serde_json::json!("prod-gateway")
@@ -3708,6 +3790,80 @@ mod tests {
             route_spec(&grpc.expect("GRPCRoute"))["rules"][0]["backendRefs"][0]["name"],
             serde_json::json!("prod-gateway")
         );
+    }
+
+    #[test]
+    fn httproute_falls_back_to_gateway_service_on_router_render_error() {
+        // F2: on ANY router render error the same reconcile pass would apply the
+        // router's objects as no-ops and the delete-sweep removes the router's
+        // Service, yet a static `backend: ravelNative` check would still point the
+        // HTTPRoute at that (now-deleted) Service -- an ingest outage that does not
+        // self-heal. The route renderer must instead fall back to the gateway
+        // Service whenever the router will not be present this pass. Asserted
+        // through `desired_objects`, the exact render the controller applies, so
+        // the router-outcome-to-route wiring is what is under test.
+        for spec in [
+            // CanonicalTenantResolverMissing (F1's path): ravelNative + canonical,
+            // no tenant-tokens Secret ref.
+            {
+                let mut s = ravel_native_spec(2, AffinityKeySource::CanonicalTenant);
+                s.tenant_tokens_secret_ref = None;
+                s.gateway.exposure = exposure_with(
+                    GatewayReference {
+                        name: "public-gw".to_string(),
+                        namespace: None,
+                    },
+                    Vec::new(),
+                    true,
+                )
+                .exposure;
+                s
+            },
+            // RouterImageMissing: ravelNative with routerImage unset.
+            {
+                let mut s = base_spec();
+                s.gateway.ingest_affinity = Some(IngestAffinitySpec {
+                    backend: AffinityBackend::RavelNative,
+                    router_image: None,
+                    ..IngestAffinitySpec::default()
+                });
+                s.gateway.exposure = exposure_with(
+                    GatewayReference {
+                        name: "public-gw".to_string(),
+                        namespace: None,
+                    },
+                    Vec::new(),
+                    true,
+                )
+                .exposure;
+                s
+            },
+        ] {
+            let objects =
+                desired_objects(&spec, "prod", "default", &ctx()).expect("render never aborts");
+            assert!(
+                objects.router_render_error.is_some(),
+                "precondition: the router render failed this pass"
+            );
+            assert!(
+                objects.router_service.is_none(),
+                "precondition: no router Service will exist after this pass"
+            );
+            let (http, _grpc) = objects.gateway_routes;
+            let http = http.expect("HTTPRoute still rendered");
+            assert_eq!(
+                route_spec(&http)["rules"][0]["backendRefs"][0]["name"],
+                serde_json::json!("prod-gateway"),
+                "on a router render error the HTTPRoute must fall back to the \
+                 gateway Service, never point at the router Service the same pass \
+                 deletes"
+            );
+            assert_eq!(
+                route_spec(&http)["rules"][0]["backendRefs"][0]["port"],
+                serde_json::json!(HTTP_PORT),
+                "fallback uses the gateway's HTTP port, not the router's"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Makes AffinityBackend::RavelNative (landed in Wave 1, unused until now)
actually do something: when set, the operator renders
services/ravel-ingest-router's Deployment/Service, a dedicated
ServiceAccount, and a namespaced Role/RoleBinding scoped to only
get/list/watch on endpointslices and services in that namespace (no
cluster-wide grant). Adds AffinityKeySource::CanonicalTenant, gated by a
CEL rule rejecting it under the legacy ingressNginx backend (that backend
has no way to run the canonical-tenant resolver chain). When
exposure.gatewayAPI is combined with RavelNative, the rendered HTTPRoute's
backendRef switches to the router's Service; the GRPCRoute intentionally
keeps targeting the gateway Service directly for now (see below). Switching
backend away from RavelNative, or disabling ingest_affinity, sweeps every
router-owned object via the same apply-then-sweep pattern the existing
Ingress/HTTPRoute rendering already uses.

The router Deployment's container args are rendered from
ravel-ingest-router's frozen CLI contract as literal strings (no
compile-time link between the two crates), so a test pins the exact
argument vector against the real flag names -- a typo here compiles,
passes CI, and crashloops the pod, which is exactly the failure class this
test exists to catch. A misconfigured cluster (no routerImage, or
key.source: canonicalTenant with no live tenant-token resolver) fails
visibly: a typed render error and a degraded status Condition, never a
panic and never a broken Deployment -- and critically, that failure
degrades only the router's own objects. Every other tier (gateway, query,
maintain) keeps reconciling normally, and if exposure.gatewayAPI is set the
HTTPRoute falls back to targeting the gateway Service directly rather than
being left pointed at a router Service the same reconcile pass just swept
away.

This PR renders an HTTP-only router Deployment (container port 8080 only).
#184, gRPC support for the router, lands alongside this PR in the same
wave; wiring gRPC traffic through the router is a separate follow-up
(#194), since ravel-ingest-router currently resolves one gateway port per
process shared by every listener -- routing both HTTP and gRPC through one
router Deployment needs a real design decision (two Deployments, or a
per-listener port surface), not a rendering change. Until #194 lands, the
GRPCRoute keeps targeting the gateway Service directly, so gRPC ingest is
unaffected by this PR either way.

This PR went through three rounds of adversarial review before landing.
The first found four issues: the crashloop above; the operator's own
RBAC lacking a discovery.k8s.io/endpointslices rule (Kubernetes' RBAC
escalation prevention blocks creating a Role granting a permission the
creator doesn't hold, so every RavelNative reconcile would have 403'd
permanently); the GRPCRoute originally switching to the router's Service
before #184 existed (would have broken working gRPC ingest); and an
unpinned gateway port. The second found that the first fix's crashloop
guard checked a spec field instead of the actually-rendered resolver
arguments, missing a live state where the Secret reference is set but
resolves to zero tenants, plus the HTTPRoute-fallback gap described above.
The third closed a coverage gap where a test proved the route-switching
logic's own internal branch but not that the real render path ever
computes the switch correctly -- confirmed by mutation testing.

Fixes: #158
Refs: #150
