### PR TITLE
feat(alert-sink): attach optional Authorization credential on delivery (ADR-0083)

### DIFF
--- a/services/ravel-server/src/alert_sink.rs
+++ b/services/ravel-server/src/alert_sink.rs
@@ -26,20 +26,112 @@ pub const DEFAULT_SINK_TIMEOUT: Duration = Duration::from_secs(10);
 /// that does not already end in it.
 pub const ALERTMANAGER_PATH: &str = "/api/v2/alerts";
 
+/// A credential a sink attaches to its POST as an `Authorization` header
+/// (ADR-0083).
+///
+/// The secret material -- a bearer token, or Basic's password -- never crosses
+/// a `Debug` or `Serialize` boundary: only the scheme, and Basic's username,
+/// are printed or serialized. That keeps the secret out of the control-plane
+/// record, the database, and any log line, which is what the ADR means by
+/// storing it in the secret envelope. `deliver` reads the live secret straight
+/// off this value and hands it to reqwest; it is never rendered to a string
+/// anywhere else.
+#[derive(Clone, PartialEq, Eq)]
+pub enum Credential {
+    /// Sent as `Authorization: Bearer <token>`.
+    Bearer(String),
+    /// Sent as `Authorization: Basic base64(user:pass)`.
+    Basic { user: String, pass: String },
+}
+
+impl Credential {
+    /// A short static name for the auth scheme, for log lines and the
+    /// non-secret serialized form.
+    pub fn scheme(&self) -> &'static str {
+        match self {
+            Credential::Bearer(_) => "bearer",
+            Credential::Basic { .. } => "basic",
+        }
+    }
+
+    /// Attach this credential to `request` as an `Authorization` header.
+    /// reqwest builds `Bearer <token>` and `Basic base64(user:pass)`
+    /// respectively, so the secret is encoded by the HTTP client and never
+    /// formatted into a string this crate holds.
+    fn attach(&self, request: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        match self {
+            Credential::Bearer(token) => request.bearer_auth(token),
+            Credential::Basic { user, pass } => request.basic_auth(user, Some(pass)),
+        }
+    }
+}
+
+impl std::fmt::Debug for Credential {
+    /// Redacts the secret. A derived `Debug` would print the bearer token or
+    /// the Basic password into any log or error that formats a sink; never
+    /// widen this back to a derive.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Credential::Bearer(_) => f.debug_tuple("Bearer").field(&"<redacted>").finish(),
+            Credential::Basic { user, .. } => f
+                .debug_struct("Basic")
+                .field("user", user)
+                .field("pass", &"<redacted>")
+                .finish(),
+        }
+    }
+}
+
+impl serde::Serialize for Credential {
+    /// Serializes only the non-secret parts (the scheme, and Basic's
+    /// username). The token and password are omitted, so a serialized sink
+    /// record carries no secret; the live secret is supplied out of band from
+    /// the secret envelope, exactly as the ADR requires.
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeStruct;
+        match self {
+            Credential::Bearer(_) => {
+                let mut s = serializer.serialize_struct("Credential", 1)?;
+                s.serialize_field("scheme", "bearer")?;
+                s.end()
+            }
+            Credential::Basic { user, .. } => {
+                let mut s = serializer.serialize_struct("Credential", 2)?;
+                s.serialize_field("scheme", "basic")?;
+                s.serialize_field("user", user)?;
+                s.end()
+            }
+        }
+    }
+}
+
 /// One configured notification target.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AlertSink {
     /// POSTs [`webhook_payload`] to `url`.
-    Webhook { url: String },
+    Webhook {
+        url: String,
+        /// An optional credential attached to every POST (ADR-0083). `None`
+        /// preserves the pre-ADR unauthenticated behavior.
+        credential: Option<Credential>,
+    },
     /// POSTs [`alertmanager_payload`] to `url`, which is already the full
     /// `/api/v2/alerts` endpoint (see [`AlertSink::alertmanager`]).
-    Alertmanager { url: String },
+    Alertmanager {
+        url: String,
+        /// An optional credential attached to every POST (ADR-0083). `None`
+        /// preserves the pre-ADR unauthenticated behavior.
+        credential: Option<Credential>,
+    },
 }
 
 impl AlertSink {
-    /// A webhook sink posting to `url` verbatim.
+    /// A webhook sink posting to `url` verbatim, unauthenticated.
     pub fn webhook(url: impl Into<String>) -> AlertSink {
-        AlertSink::Webhook { url: url.into() }
+        AlertSink::Webhook {
+            url: url.into(),
+            credential: None,
+        }
     }
 
     /// An Alertmanager sink for `base`, which may be either an Alertmanager
@@ -54,13 +146,37 @@ impl AlertSink {
         } else {
             format!("{trimmed}{ALERTMANAGER_PATH}")
         };
-        AlertSink::Alertmanager { url }
+        AlertSink::Alertmanager {
+            url,
+            credential: None,
+        }
+    }
+
+    /// Attach `credential` to this sink, returning the sink (builder style).
+    /// Keeps the plain [`AlertSink::webhook`] / [`AlertSink::alertmanager`]
+    /// constructors backward-compatible while letting authenticated sinks be
+    /// built with one call.
+    pub fn with_credential(mut self, credential: Credential) -> AlertSink {
+        match &mut self {
+            AlertSink::Webhook { credential: c, .. }
+            | AlertSink::Alertmanager { credential: c, .. } => *c = Some(credential),
+        }
+        self
     }
 
     /// The URL this sink POSTs to.
     pub fn url(&self) -> &str {
         match self {
-            AlertSink::Webhook { url } | AlertSink::Alertmanager { url } => url,
+            AlertSink::Webhook { url, .. } | AlertSink::Alertmanager { url, .. } => url,
+        }
+    }
+
+    /// The credential this sink attaches to its POST, if any.
+    pub fn credential(&self) -> Option<&Credential> {
+        match self {
+            AlertSink::Webhook { credential, .. } | AlertSink::Alertmanager { credential, .. } => {
+                credential.as_ref()
+            }
         }
     }
 
@@ -260,7 +376,11 @@ pub async fn deliver(
     let Some(body) = sink.payload(notification) else {
         return Ok(());
     };
-    let response = client.post(sink.url()).json(&body).send().await?;
+    let mut request = client.post(sink.url()).json(&body);
+    if let Some(credential) = sink.credential() {
+        request = credential.attach(request);
+    }
+    let response = request.send().await?;
     let status = response.status();
     if !status.is_success() {
         anyhow::bail!("sink {} returned HTTP {}", sink.url(), status);
@@ -440,5 +560,71 @@ mod tests {
     fn pre_epoch_timestamps_clamp_instead_of_panicking() {
         assert_eq!(rfc3339(0), "1970-01-01T00:00:00.000000000Z");
         assert_eq!(rfc3339(-1), "1970-01-01T00:00:00.000000000Z");
+    }
+
+    #[test]
+    fn credential_debug_never_prints_the_secret() {
+        let bearer = Credential::Bearer("super-secret-token".to_string());
+        let rendered = format!("{bearer:?}");
+        assert!(
+            !rendered.contains("super-secret-token"),
+            "the bearer token must not appear in Debug: {rendered}"
+        );
+        assert!(rendered.contains("<redacted>"), "{rendered}");
+
+        let basic = Credential::Basic {
+            user: "alice".to_string(),
+            pass: "hunter2".to_string(),
+        };
+        let rendered = format!("{basic:?}");
+        assert!(
+            !rendered.contains("hunter2"),
+            "the password must not appear in Debug: {rendered}"
+        );
+        // The username is not a secret and stays visible for diagnosis.
+        assert!(rendered.contains("alice"), "{rendered}");
+
+        // The sink's own derived Debug goes through the redacting one.
+        let sink = AlertSink::webhook("http://x").with_credential(basic);
+        let rendered = format!("{sink:?}");
+        assert!(!rendered.contains("hunter2"), "{rendered}");
+    }
+
+    #[test]
+    fn credential_serialize_omits_the_secret() {
+        let bearer =
+            serde_json::to_value(Credential::Bearer("tok".to_string())).expect("serialize");
+        assert_eq!(bearer, serde_json::json!({ "scheme": "bearer" }));
+
+        let basic = serde_json::to_value(Credential::Basic {
+            user: "alice".to_string(),
+            pass: "hunter2".to_string(),
+        })
+        .expect("serialize");
+        assert_eq!(
+            basic,
+            serde_json::json!({ "scheme": "basic", "user": "alice" })
+        );
+        // Belt and braces: the password text is nowhere in the serialized form.
+        assert!(
+            !serde_json::to_string(&basic)
+                .expect("string")
+                .contains("hunter2")
+        );
+    }
+
+    #[test]
+    fn with_credential_attaches_to_either_variant() {
+        let webhook =
+            AlertSink::webhook("http://x").with_credential(Credential::Bearer("t".into()));
+        assert_eq!(
+            webhook.credential(),
+            Some(&Credential::Bearer("t".to_string()))
+        );
+        let am = AlertSink::alertmanager("http://am:9093")
+            .with_credential(Credential::Bearer("t".into()));
+        assert_eq!(am.credential(), Some(&Credential::Bearer("t".to_string())));
+        // The plain constructors stay unauthenticated.
+        assert_eq!(AlertSink::webhook("http://x").credential(), None);
     }
 }

--- a/services/ravel-server/src/config.rs
+++ b/services/ravel-server/src/config.rs
@@ -9,7 +9,7 @@ use clap::{Parser, ValueEnum};
 use ravel_maintain::RetentionPolicy;
 use ravel_types::{TenantHash, TenantId};
 
-use crate::alert_sink::AlertSink;
+use crate::alert_sink::{AlertSink, Credential};
 use crate::postings_config::IndexedFieldPolicy;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
@@ -234,6 +234,22 @@ pub struct Cli {
     /// the well-known path is appended when it is missing.
     #[arg(long = "alertmanager-url", value_name = "URL")]
     pub alertmanager_urls: Vec<String>,
+
+    /// Repeatable authenticated webhook sink (ADR-0083). A comma-separated
+    /// `key=value` spec: `url=...` is required, and exactly one credential is
+    /// given as either `bearer-file=PATH` or `basic-user=NAME,basic-pass-file=
+    /// PATH`. The secret is read from a file, never inline, so it never appears
+    /// in a process listing, the same convention `--remote-cluster` uses. For
+    /// an unauthenticated webhook use `--alert-webhook-url`.
+    #[arg(long = "alert-webhook", value_name = "SPEC")]
+    pub alert_webhooks: Vec<String>,
+
+    /// Repeatable authenticated Alertmanager sink (ADR-0083). Same spec as
+    /// `--alert-webhook`; `url` may be a base URL or the full `/api/v2/alerts`
+    /// endpoint, exactly as `--alertmanager-url` accepts. For an
+    /// unauthenticated Alertmanager use `--alertmanager-url`.
+    #[arg(long = "alertmanager", value_name = "SPEC")]
+    pub alertmanagers: Vec<String>,
 
     /// Event-time window a SQL detection rule's query resolves over, ending at
     /// the tick's clock reading, as a humantime duration (e.g. `5m`). Only
@@ -1124,23 +1140,43 @@ impl Cli {
         Ok(IndexedFieldPolicy { default, tenants })
     }
 
-    /// Build the alert sink list from `--alert-webhook-url` and
-    /// `--alertmanager-url`. Webhooks first, then Alertmanager, so delivery
-    /// order is the flag order within each kind and stable across runs.
+    /// Build the alert sink list from the unauthenticated `--alert-webhook-url`
+    /// / `--alertmanager-url` flags and the authenticated `--alert-webhook` /
+    /// `--alertmanager` specs (ADR-0083). Webhooks first, then Alertmanager, so
+    /// delivery order is stable across runs; within each kind the plain URLs
+    /// come before the authenticated specs, both in flag order.
     pub fn parse_alert_sinks(&self) -> anyhow::Result<Vec<AlertSink>> {
-        let mut sinks =
-            Vec::with_capacity(self.alert_webhook_urls.len() + self.alertmanager_urls.len());
+        let mut sinks = Vec::with_capacity(
+            self.alert_webhook_urls.len()
+                + self.alertmanager_urls.len()
+                + self.alert_webhooks.len()
+                + self.alertmanagers.len(),
+        );
         for url in &self.alert_webhook_urls {
             sinks.push(AlertSink::webhook(validated_sink_url(
                 "--alert-webhook-url",
                 url,
             )?));
         }
+        for spec in &self.alert_webhooks {
+            let (url, credential) = parse_authenticated_sink("--alert-webhook", spec)?;
+            sinks.push(
+                AlertSink::webhook(validated_sink_url("--alert-webhook", &url)?)
+                    .with_credential(credential),
+            );
+        }
         for url in &self.alertmanager_urls {
             sinks.push(AlertSink::alertmanager(validated_sink_url(
                 "--alertmanager-url",
                 url,
             )?));
+        }
+        for spec in &self.alertmanagers {
+            let (url, credential) = parse_authenticated_sink("--alertmanager", spec)?;
+            sinks.push(
+                AlertSink::alertmanager(validated_sink_url("--alertmanager", &url)?)
+                    .with_credential(credential),
+            );
         }
         Ok(sinks)
     }
@@ -2163,6 +2199,96 @@ fn validated_sink_url<'a>(flag: &str, url: &'a str) -> anyhow::Result<&'a str> {
     Ok(url)
 }
 
+/// Parse an authenticated sink spec: a comma-separated `key=value` list with a
+/// required `url` and exactly one credential (ADR-0083). A bearer credential is
+/// `bearer-file=PATH`; HTTP Basic is `basic-user=NAME` plus
+/// `basic-pass-file=PATH`. The secret is read from a file here, failing startup
+/// on an unreadable or empty file, so a delivery failure is not deferred to
+/// once-a-minute-forever and the secret never appears in a process listing --
+/// the same file-backed convention `--remote-cluster` uses.
+fn parse_authenticated_sink(flag: &str, spec: &str) -> anyhow::Result<(String, Credential)> {
+    let mut url = None;
+    let mut bearer_file: Option<PathBuf> = None;
+    let mut basic_user: Option<String> = None;
+    let mut basic_pass_file: Option<PathBuf> = None;
+
+    for field in spec.split(',') {
+        let field = field.trim();
+        if field.is_empty() {
+            continue;
+        }
+        let (key, value) = field.split_once('=').ok_or_else(|| {
+            anyhow::anyhow!("invalid {flag} '{spec}': field '{field}' is not KEY=VALUE")
+        })?;
+        let value = value.trim();
+        match key.trim() {
+            "url" => url = Some(value.to_string()),
+            "bearer-file" => bearer_file = Some(PathBuf::from(value)),
+            "basic-user" => basic_user = Some(value.to_string()),
+            "basic-pass-file" => basic_pass_file = Some(PathBuf::from(value)),
+            other => anyhow::bail!(
+                "invalid {flag} '{spec}': unknown key '{other}' (expected url, bearer-file, \
+                 basic-user, basic-pass-file)"
+            ),
+        }
+    }
+
+    let url = url
+        .filter(|u| !u.is_empty())
+        .ok_or_else(|| anyhow::anyhow!("invalid {flag} '{spec}': missing required key 'url'"))?;
+
+    let has_basic = basic_user.is_some() || basic_pass_file.is_some();
+    let credential = match (bearer_file, has_basic) {
+        (Some(_), true) => anyhow::bail!(
+            "invalid {flag} '{spec}': set either bearer-file or basic-user/basic-pass-file, \
+             not both"
+        ),
+        (Some(path), false) => {
+            let token = read_secret_file(flag, spec, "bearer-file", &path)?;
+            Credential::Bearer(token)
+        }
+        (None, true) => {
+            let user = basic_user.filter(|u| !u.is_empty()).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "invalid {flag} '{spec}': basic-pass-file requires a non-empty basic-user"
+                )
+            })?;
+            let pass_file = basic_pass_file.ok_or_else(|| {
+                anyhow::anyhow!("invalid {flag} '{spec}': basic-user requires basic-pass-file")
+            })?;
+            let pass = read_secret_file(flag, spec, "basic-pass-file", &pass_file)?;
+            Credential::Basic { user, pass }
+        }
+        (None, false) => anyhow::bail!(
+            "invalid {flag} '{spec}': missing a credential (bearer-file or \
+             basic-user/basic-pass-file); use the unauthenticated flag for a plain sink"
+        ),
+    };
+
+    Ok((url, credential))
+}
+
+/// Read and validate a sink secret from `path`: a leading/trailing-newline
+/// tolerant, non-empty string. Mirrors how `--remote-cluster`'s
+/// `credential-file` is read (trim then reject empty), so a stray trailing
+/// newline in the file does not become part of the token or password.
+fn read_secret_file(flag: &str, spec: &str, key: &str, path: &Path) -> anyhow::Result<String> {
+    let raw = std::fs::read_to_string(path).map_err(|e| {
+        anyhow::anyhow!(
+            "invalid {flag} '{spec}': failed to read {key} {}: {e}",
+            path.display()
+        )
+    })?;
+    let secret = raw.trim().to_string();
+    if secret.is_empty() {
+        anyhow::bail!(
+            "invalid {flag} '{spec}': {key} {} is empty; the secret must be non-empty",
+            path.display()
+        );
+    }
+    Ok(secret)
+}
+
 /// Parse a 32-byte deployment key from a `--tenant-hash-key-file`'s raw
 /// bytes. Accepts 64 hex characters (whitespace-trimmed, the operator-friendly
 /// form that tolerates a trailing newline) or exactly 32 raw bytes. Any other
@@ -2879,6 +3005,137 @@ mod tests {
         // The non-secret fields are still present, so the redaction did not
         // blank the whole struct.
         assert!(rendered.contains("beta") && rendered.contains("beta.internal:9443"));
+    }
+
+    /// ADR-0083: the plain `--alert-webhook-url` / `--alertmanager-url` flags
+    /// still yield unauthenticated sinks, unchanged.
+    #[test]
+    fn unauthenticated_alert_sinks_carry_no_credential() {
+        let sinks = cli(&[
+            "--alert-webhook-url",
+            "http://hook.internal/x",
+            "--alertmanager-url",
+            "http://am:9093",
+        ])
+        .parse_alert_sinks()
+        .expect("plain sinks parse");
+        assert_eq!(sinks.len(), 2);
+        assert!(
+            sinks.iter().all(|s| s.credential().is_none()),
+            "plain flags stay unauthenticated"
+        );
+        assert_eq!(sinks[0].url(), "http://hook.internal/x");
+        assert_eq!(sinks[1].url(), "http://am:9093/api/v2/alerts");
+    }
+
+    /// A `--alert-webhook` spec with `bearer-file` reads the token from the file
+    /// and attaches it as a bearer credential; a trailing newline is trimmed.
+    #[test]
+    fn alert_webhook_bearer_file_parses() {
+        let token = tempfile::NamedTempFile::new().expect("temp token file");
+        std::fs::write(token.path(), "hook-token\n").expect("write token");
+        let spec = format!(
+            "url=http://hook.internal/x,bearer-file={}",
+            token.path().display()
+        );
+        let sinks = cli(&["--alert-webhook", &spec])
+            .parse_alert_sinks()
+            .expect("bearer webhook parses");
+        assert_eq!(sinks.len(), 1);
+        assert_eq!(sinks[0].url(), "http://hook.internal/x");
+        assert_eq!(
+            sinks[0].credential(),
+            Some(&Credential::Bearer("hook-token".to_string()))
+        );
+    }
+
+    /// A `--alertmanager` spec with a Basic credential reads the password from
+    /// its file, carries the username inline, and still appends the well-known
+    /// Alertmanager path to the URL.
+    #[test]
+    fn alertmanager_basic_spec_parses() {
+        let pass = tempfile::NamedTempFile::new().expect("temp pass file");
+        std::fs::write(pass.path(), "hunter2\n").expect("write pass");
+        let spec = format!(
+            "url=http://am:9093,basic-user=alice,basic-pass-file={}",
+            pass.path().display()
+        );
+        let sinks = cli(&["--alertmanager", &spec])
+            .parse_alert_sinks()
+            .expect("basic alertmanager parses");
+        assert_eq!(sinks.len(), 1);
+        assert_eq!(sinks[0].url(), "http://am:9093/api/v2/alerts");
+        assert_eq!(
+            sinks[0].credential(),
+            Some(&Credential::Basic {
+                user: "alice".to_string(),
+                pass: "hunter2".to_string(),
+            })
+        );
+    }
+
+    /// Configuring both a bearer and a Basic credential on one sink is a config
+    /// error, not a silent pick-one.
+    #[test]
+    fn alert_webhook_rejects_two_credential_schemes() {
+        let token = tempfile::NamedTempFile::new().expect("temp token file");
+        std::fs::write(token.path(), "t\n").expect("write token");
+        let pass = tempfile::NamedTempFile::new().expect("temp pass file");
+        std::fs::write(pass.path(), "p\n").expect("write pass");
+        let spec = format!(
+            "url=http://hook/x,bearer-file={},basic-user=a,basic-pass-file={}",
+            token.path().display(),
+            pass.path().display()
+        );
+        let err = cli(&["--alert-webhook", &spec])
+            .parse_alert_sinks()
+            .expect_err("two schemes must fail");
+        assert!(
+            err.to_string().contains("not both"),
+            "expected the two-scheme error, got: {err}"
+        );
+    }
+
+    /// An authenticated spec with a URL but no credential is a config error:
+    /// the plain flag exists for unauthenticated sinks.
+    #[test]
+    fn alert_webhook_requires_a_credential() {
+        let err = cli(&["--alert-webhook", "url=http://hook/x"])
+            .parse_alert_sinks()
+            .expect_err("a spec with no credential must fail");
+        assert!(
+            err.to_string().contains("missing a credential"),
+            "got: {err}"
+        );
+    }
+
+    /// A missing `url` key fails startup rather than building a sink with no
+    /// target.
+    #[test]
+    fn alert_webhook_requires_a_url() {
+        let token = tempfile::NamedTempFile::new().expect("temp token file");
+        std::fs::write(token.path(), "t\n").expect("write token");
+        let spec = format!("bearer-file={}", token.path().display());
+        let err = cli(&["--alert-webhook", &spec])
+            .parse_alert_sinks()
+            .expect_err("no url must fail");
+        assert!(
+            err.to_string().contains("missing required key 'url'"),
+            "got: {err}"
+        );
+    }
+
+    /// An empty secret file fails startup: an empty token or password would
+    /// authenticate as nobody and fail once a minute forever.
+    #[test]
+    fn alert_webhook_rejects_an_empty_secret_file() {
+        let token = tempfile::NamedTempFile::new().expect("temp token file");
+        std::fs::write(token.path(), "\n").expect("write empty token");
+        let spec = format!("url=http://hook/x,bearer-file={}", token.path().display());
+        let err = cli(&["--alert-webhook", &spec])
+            .parse_alert_sinks()
+            .expect_err("empty secret must fail");
+        assert!(err.to_string().contains("is empty"), "got: {err}");
     }
 
     /// A `--remote-cluster` spec with no `tls` key means TLS ON (ADR-0071

--- a/services/ravel-server/tests/alerting_e2e.rs
+++ b/services/ravel-server/tests/alerting_e2e.rs
@@ -30,7 +30,7 @@ use ravel_object_store::memory::MemoryStore;
 use ravel_object_store::{GetRange, ObjectStoreBackend, PutOptions, list_all};
 use ravel_query::{EngineConfig, QueryEngine};
 use ravel_segment::{IngestBounds, SegmentIdentity, SegmentWriter, SeriesInput};
-use ravel_server::alert_sink::AlertSink;
+use ravel_server::alert_sink::{AlertSink, Credential};
 use ravel_server::alerting::{
     ALERT_SHARD, AlertEvalConfig, AlertEvaluator, AlertQueryEngines, parse_rules,
 };
@@ -286,6 +286,10 @@ async fn seeded_store_spanning(last_ns: i64) -> Arc<dyn ObjectStoreBackend> {
 /// Everything the in-process sink server saw, plus the status it answers with.
 struct Capture {
     received: Mutex<Vec<(String, Json)>>,
+    /// The `Authorization` header of each call, aligned by index with
+    /// `received`. `None` when the request carried no such header, which is
+    /// what an unauthenticated sink must produce.
+    authorizations: Mutex<Vec<Option<String>>>,
     status: AtomicU16,
 }
 
@@ -293,6 +297,7 @@ impl Capture {
     fn new(status: StatusCode) -> Arc<Capture> {
         Arc::new(Capture {
             received: Mutex::new(Vec::new()),
+            authorizations: Mutex::new(Vec::new()),
             status: AtomicU16::new(status.as_u16()),
         })
     }
@@ -304,19 +309,35 @@ impl Capture {
     fn calls(&self) -> Vec<(String, Json)> {
         self.received.lock().expect("capture lock").clone()
     }
+
+    /// The `Authorization` header seen on each call, in call order.
+    fn authorizations(&self) -> Vec<Option<String>> {
+        self.authorizations.lock().expect("capture lock").clone()
+    }
 }
 
 async fn sink_handler(
     State(capture): State<Arc<Capture>>,
     uri: Uri,
+    headers: axum::http::HeaderMap,
     body: axum::body::Bytes,
 ) -> StatusCode {
     let json: Json = serde_json::from_slice(&body).expect("a sink body must be JSON");
+    let authorization = headers.get(axum::http::header::AUTHORIZATION).map(|v| {
+        v.to_str()
+            .expect("authorization is valid ascii")
+            .to_string()
+    });
     capture
         .received
         .lock()
         .expect("capture lock")
         .push((uri.path().to_string(), json));
+    capture
+        .authorizations
+        .lock()
+        .expect("capture lock")
+        .push(authorization);
     StatusCode::from_u16(capture.status.load(Ordering::SeqCst)).expect("valid status")
 }
 
@@ -608,6 +629,89 @@ async fn the_alertmanager_sink_posts_the_api_v2_alerts_payload() {
         resolved["endsAt"].is_string(),
         "a resolved alert carries endsAt"
     );
+
+    server.stop().await;
+}
+
+/// ADR-0083, proven end to end through the real evaluator: a webhook sink
+/// carrying a bearer credential attaches `Authorization: Bearer <token>` to the
+/// POST, and the header is observed on the bytes that actually crossed the
+/// socket. The unauthenticated sink alongside it sends no such header, so the
+/// header is attached because the credential is present, not unconditionally.
+#[tokio::test]
+async fn authenticated_sink_posts_bearer_header() {
+    let server = SinkServer::start(StatusCode::OK).await;
+    let store = seeded_store().await;
+    let auth_url = format!("{}/authed", server.base_url());
+    let plain_url = format!("{}/plain", server.base_url());
+    let mut evaluator = evaluator(
+        Arc::clone(&store),
+        TestClock::at(NOW_NS),
+        vec![threshold_rule(None)],
+        vec![
+            AlertSink::webhook(auth_url).with_credential(Credential::Bearer("s3cr3t-token".into())),
+            AlertSink::webhook(plain_url),
+        ],
+    );
+
+    let report = evaluator.run_tick().await;
+    assert_eq!(report.records_written, 1);
+    // One transition, delivered to every sink: the count is per notification,
+    // not per sink, so it is 1 even though two POSTs cross the socket below.
+    assert_eq!(report.notifications_delivered, 1);
+    assert_eq!(report.notifications_failed, 0);
+
+    // Pair each call with the Authorization header it carried.
+    let calls = server.capture.calls();
+    let auths = server.capture.authorizations();
+    assert_eq!(calls.len(), 2);
+    assert_eq!(auths.len(), calls.len());
+    let by_path: HashMap<&str, &Option<String>> = calls
+        .iter()
+        .zip(auths.iter())
+        .map(|((path, _), auth)| (path.as_str(), auth))
+        .collect();
+
+    assert_eq!(
+        by_path["/authed"],
+        &Some("Bearer s3cr3t-token".to_string()),
+        "the credentialed sink attaches the bearer header"
+    );
+    assert_eq!(
+        by_path["/plain"], &None,
+        "the unauthenticated sink sends no Authorization header"
+    );
+
+    server.stop().await;
+}
+
+/// ADR-0083 Basic path: a sink with an HTTP Basic credential attaches
+/// `Authorization: Basic base64(user:pass)`, the exact encoding Alertmanager
+/// receivers expect.
+#[tokio::test]
+async fn authenticated_sink_posts_basic_header() {
+    use base64::Engine;
+
+    let server = SinkServer::start(StatusCode::OK).await;
+    let store = seeded_store().await;
+    let url = format!("{}/hook", server.base_url());
+    let mut evaluator = evaluator(
+        Arc::clone(&store),
+        TestClock::at(NOW_NS),
+        vec![threshold_rule(None)],
+        vec![AlertSink::webhook(url).with_credential(Credential::Basic {
+            user: "alice".into(),
+            pass: "hunter2".into(),
+        })],
+    );
+
+    assert_eq!(evaluator.run_tick().await.notifications_delivered, 1);
+
+    let expected = format!(
+        "Basic {}",
+        base64::engine::general_purpose::STANDARD.encode("alice:hunter2")
+    );
+    assert_eq!(server.capture.authorizations(), vec![Some(expected)]);
 
     server.stop().await;
 }


### PR DESCRIPTION
Implements T1 for epic #120 / ADR-0083.

- Credential enum (Bearer / Basic) with secret redaction on Debug/Serialize
- deliver attaches Authorization header via reqwest bearer_auth / basic_auth
- parse_alert_sinks accepts bearer-file=PATH and basic-user=NAME,basic-pass-file=PATH (secrets from files only)
- New e2e: authenticated_sink_posts_bearer_header
- Backward compatible: existing --alert-webhook-url / --alertmanager-url unchanged

Refs: #120, #205, ADR-0083