### PR TITLE
ci: assert the quickstart collector is actually delivering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1326,7 +1326,7 @@ jobs:
           fi
           merge_base=$(git merge-base "$base" "${{ github.sha }}")
           changed=$(git diff --name-only "$merge_base" "${{ github.sha }}")
-          filter='^README\.md$|^deploy/docker-compose/|^deploy/otel/|^deploy/grafana/|^demo/|^scripts/check-readme-commands\.sh$|^scripts/check_readme_commands\.py$|^Dockerfile\.prebuilt$|^services/ravel-server/'
+          filter='^README\.md$|^deploy/docker-compose/|^deploy/otel/|^deploy/grafana/|^demo/|^scripts/check-readme-commands\.sh$|^scripts/check_readme_commands\.py$|^scripts/check-collector-delivery\.sh$|^Dockerfile\.prebuilt$|^services/ravel-server/'
           if echo "$changed" | grep -qE "$filter"; then
             echo "::notice::quickstart-relevant path changed, running the job"
             echo "run=true" >> "$GITHUB_OUTPUT"
@@ -1400,6 +1400,16 @@ jobs:
             --otlp-header 'Authorization="Bearer demo-token"' \
             --metric-type Gauge \
             --metrics 500
+      # Assert the collector is actually delivering, from its own counters
+      # (#209). telemetrygen supplies the series the README assertions query, so
+      # without this step a total collector failure is invisible to this job:
+      # that is exactly how a gzip rejection (#115) kept the quickstart's
+      # Grafana dashboard empty while CI stayed green. Runs BEFORE the README
+      # blocks so a delivery fault is reported as a delivery fault rather than
+      # as a confusing query failure downstream.
+      - name: Assert the collector is delivering to Ravel
+        if: steps.filter.outputs.run == 'true'
+        run: scripts/check-collector-delivery.sh
       # Waits for readiness (health, then a non-empty `gen` query), then runs
       # every marked README block and asserts its declared outcome.
       - name: Assert the README's marked command blocks

--- a/deploy/docker-compose/ravel.yml
+++ b/deploy/docker-compose/ravel.yml
@@ -125,6 +125,17 @@ services:
     image: otel/opentelemetry-collector-contrib:latest
     depends_on: [ravel-server]
     command: ["--config=/etc/otel/collector-config.yaml"]
+    # The collector's own metrics, for answering "is it delivering?" without
+    # guessing from an empty dashboard (#209). Read the delivery counters with:
+    #   curl -s localhost:18888/metrics | grep otelcol_exporter
+    # A non-zero `send_failed` means Ravel is refusing the exports.
+    #
+    # Published on 18888 rather than the collector's own 8888: that port is the
+    # collector default and is contended on a developer machine, and a
+    # quickstart that fails on `docker compose up` with "port is already
+    # allocated" is a bad first command. The container side stays 8888.
+    ports:
+      - "127.0.0.1:18888:8888"
     volumes:
       - ../otel/collector-config.yaml:/etc/otel/collector-config.yaml:ro
 

--- a/deploy/otel/collector-config.yaml
+++ b/deploy/otel/collector-config.yaml
@@ -50,3 +50,22 @@ service:
       receivers: [hostmetrics]
       processors: [batch]
       exporters: [otlphttp]
+  # The collector's own delivery counters, on a Prometheus endpoint.
+  #
+  # This exists so that "is the collector actually delivering?" is a question
+  # with a numeric answer. It is the assertion CI needs (#209) and the first
+  # thing to read when the Grafana dashboard is empty: a non-zero
+  # `otelcol_exporter_send_failed_metric_points` says the collector is running
+  # and Ravel is refusing its exports, which is a different fault from the
+  # collector not scraping at all.
+  #
+  # The address must be 0.0.0.0, not the default localhost. localhost binds the
+  # container's own loopback, which no port mapping can reach.
+  telemetry:
+    metrics:
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: 0.0.0.0
+                port: 8888

--- a/scripts/check-collector-delivery.sh
+++ b/scripts/check-collector-delivery.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Assert that the quickstart's OpenTelemetry Collector is actually delivering to
+# Ravel, by reading the collector's own counters rather than inferring delivery
+# from query results (#209).
+#
+# Why this exists. The `quickstart` CI job runs telemetrygen beside the
+# collector and polls readiness on telemetrygen's series. That made a total
+# collector failure invisible: the collector defaulted to gzip, Ravel's OTLP
+# HTTP ingest rejected every export with HTTP 400 (#115), and the job stayed
+# green while the quickstart's Grafana dashboard was empty from the day it
+# shipped. Nothing asserted the collector's own delivery, so nothing failed.
+#
+# Querying for a specific series cannot fix that. ADR-0081 decision 5 is right
+# that no `hostmetrics` series name is assertable across a CI runner and a
+# developer's laptop. The collector's counters are, because they are about the
+# collector rather than about what it happened to scrape.
+#
+# Assertions:
+#   1. otelcol_exporter_sent_metric_points  > 0   (it delivered something)
+#   2. otelcol_exporter_send_failed_metric_points == 0   (nothing was dropped)
+#
+# The first alone would pass a collector that delivers one point and drops a
+# thousand. The second alone would pass a collector that is scraping nothing.
+#
+# Shell-safety (CLAUDE.md "Writing gate and poll shell"): exit codes are
+# captured as `cmd || code=$?` on the same line; no variable is named `status`,
+# `path`, `argv`, or `PWD`; no checked command is piped through grep/head/tail.
+set -euo pipefail
+
+COLLECTOR_METRICS_URL="${RAVEL_COLLECTOR_METRICS_URL:-http://127.0.0.1:18888/metrics}"
+# The collector exports on a batch timer, so a scrape immediately after start-up
+# legitimately shows zero sent points. Poll instead of sleeping a guessed
+# duration, and fail on the budget rather than on the first empty read.
+DELIVERY_TIMEOUT_SECONDS="${RAVEL_COLLECTOR_TIMEOUT_SECONDS:-120}"
+DELIVERY_POLL_SECONDS="${RAVEL_COLLECTOR_POLL_SECONDS:-3}"
+CONNECT_TIMEOUT_SECONDS="${RAVEL_CONNECT_TIMEOUT_SECONDS:-5}"
+REQUEST_TIMEOUT_SECONDS="${RAVEL_REQUEST_TIMEOUT_SECONDS:-10}"
+
+log() { echo "[collector-delivery] $*" >&2; }
+
+fail() {
+  log "FAILED: $*"
+  exit 1
+}
+
+# Sum every sample of a counter family, ignoring its labels. The collector
+# reports one series per exporter, so a deployment with more than one exporter
+# must not have its first series mistaken for the total.
+metric_total() {
+  local body="$1" name="$2"
+  # `python3 -c`, not `python3 -` with a heredoc: the heredoc would claim stdin,
+  # leaving no way to pipe the metrics body in.
+  printf '%s' "$body" | python3 -c '
+import sys
+name = sys.argv[1]
+total = 0.0
+found = False
+for line in sys.stdin:
+    line = line.strip()
+    if not line or line.startswith("#"):
+        continue
+    if not (line.startswith(name + " ") or line.startswith(name + "{")):
+        continue
+    value = line.rsplit(" ", 1)[-1]
+    try:
+        total += float(value)
+    except ValueError:
+        continue
+    found = True
+print(f"{total:.0f}" if found else "absent")
+' "$name"
+}
+
+log "reading collector counters from $COLLECTOR_METRICS_URL"
+
+deadline=$(( SECONDS + DELIVERY_TIMEOUT_SECONDS ))
+sent="absent"
+failed="absent"
+body=""
+
+while (( SECONDS < deadline )); do
+  code=0
+  body=$(curl --silent --show-error \
+    --connect-timeout "$CONNECT_TIMEOUT_SECONDS" --max-time "$REQUEST_TIMEOUT_SECONDS" \
+    "$COLLECTOR_METRICS_URL") || code=$?
+  if (( code == 0 )); then
+    sent=$(metric_total "$body" otelcol_exporter_sent_metric_points)
+    failed=$(metric_total "$body" otelcol_exporter_send_failed_metric_points)
+    # A drop is already a verdict. Stop polling rather than waiting out the
+    # whole budget for a `sent` count that a rejecting server will never
+    # produce: under a total rejection `sent` stays 0 forever, and burning the
+    # full timeout only delays a failure that is already known.
+    if [[ "$failed" != "absent" && "$failed" != "0" ]]; then
+      break
+    fi
+    if [[ "$sent" != "absent" && "$sent" != "0" ]]; then
+      break
+    fi
+  fi
+  sleep "$DELIVERY_POLL_SECONDS"
+done
+
+# Check the drop count before the sent count. Under a total rejection both are
+# wrong, and "Ravel refused these exports" is the diagnosis, while "nothing was
+# delivered" is only the symptom.
+if [[ "$failed" != "absent" && "$failed" != "0" ]]; then
+  fail "the collector dropped $failed metric points (delivered $sent)." \
+    "Ravel is rejecting its exports. Read the HTTP status it received with:" \
+    "docker compose -f deploy/docker-compose/ravel.yml logs otel-collector"
+fi
+
+if [[ "$sent" == "absent" ]]; then
+  fail "the collector never reported otelcol_exporter_sent_metric_points." \
+    "Either its metrics endpoint is unreachable at $COLLECTOR_METRICS_URL," \
+    "or the collector is not running at all."
+fi
+
+if [[ "$sent" == "0" ]]; then
+  fail "the collector delivered 0 metric points within ${DELIVERY_TIMEOUT_SECONDS}s." \
+    "It is running but nothing reached Ravel."
+fi
+
+# The collector omits the failure counter entirely until something fails, so
+# "absent" is the healthy reading and means zero.
+if [[ "$failed" == "absent" ]]; then
+  failed=0
+fi
+
+log "PASSED: the collector delivered $sent metric points, $failed dropped."


### PR DESCRIPTION
The `quickstart` job runs `telemetrygen` beside the OpenTelemetry Collector and
polls readiness on telemetrygen's series. Nothing asserted the collector's own
delivery, so the job stayed green while the collector delivered nothing at all.
That is how a gzip rejection (#115) left the quickstart's Grafana dashboard
empty from the day it shipped, through three checkpoint reviews and a green CI
run.

This asserts the collector's own counters instead of inferring delivery from
query results:

- `otelcol_exporter_sent_metric_points` must be above zero.
- `otelcol_exporter_send_failed_metric_points` must be zero.

Either alone is weak. The first passes a collector that delivers one point and
drops a thousand. The second passes a collector that is scraping nothing.

Querying for a specific series could not have closed this gap. ADR-0081
decision 5 is right that no `hostmetrics` series name is assertable across a CI
runner and a developer's laptop. The collector's counters are, because they
describe the collector rather than what it happened to scrape.

## Verified in both directions

Against a live stack, not by reading:

| Condition | Result |
|---|---|
| Healthy | `PASSED: 826 delivered, 0 dropped`, exit 0 |
| `compression: none` removed, restoring the gzip bug | `FAILED: dropped 118 (delivered 0)`, exit 1 in under a second |

118 is the same drop count as the original failure. The check breaks early on a
non-zero drop count rather than waiting out its budget for a `sent` count a
rejecting server will never produce, and it reports the drop before the
empty-delivery message, because "Ravel refused these exports" is the diagnosis
while "nothing arrived" is only the symptom.

## Two notes on the endpoint

The collector's telemetry endpoint binds `0.0.0.0`, not the default `localhost`,
which binds the container's own loopback where no port mapping reaches it.

It is published on host port 18888 rather than the collector's own 8888. That
port is the collector default and is contended on a developer machine: it was
already taken on the machine this was written on, and `docker compose up`
failed with "port is already allocated". A quickstart whose first command dies
that way is the failure this work exists to prevent.

The endpoint is useful beyond CI. It is the first thing to read when the
dashboard is empty, and it separates "the collector is not scraping" from
"Ravel is refusing its exports".

Fixes: #209
Refs: #115
Refs: #170