### PR TITLE
docs: claim ADR-0084 for gzip-compressed OTLP ingest

### DIFF
--- a/docs/adrs/0084-otlp-gzip-ingest.md
+++ b/docs/adrs/0084-otlp-gzip-ingest.md
@@ -1,0 +1,3 @@
+# 0084. Accept gzip-compressed OTLP ingest
+
+Status: claimed

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -84,3 +84,6 @@ One decision per document. Status: Proposed | Accepted | Superseded.
 | [0079](0079-indexed-fields-durable-override-cache.md) | Indexed-fields durable override cache: cache-aside overlay over TenantConfig.indexed_fields | Accepted |
 | [0080](0080-gateway-api-ingest-affinity.md) | Gateway API exposure and Ravel-native subset affinity: additive backend enum deprecating ingress-nginx, exposure/affinity split, HRW subset selection via a new ravel-affinity crate and ravel-ingest-router service | Accepted |
 | [0081](0081-container-first-quickstart.md) | Container-first quickstart: a published-image `docker compose` path as the documented first run, with README command blocks executed in CI | Accepted |
+| [0082](0082-provisioning-shard-count-drift-tolerance.md) | Provisioning shard-count drift tolerance for an evolving default | Accepted |
+| [0083](0083-alert-sink-auth.md) | Alert sink delivery supports optional credentials | Accepted |
+| [0084](0084-otlp-gzip-ingest.md) | Accept gzip-compressed OTLP ingest on HTTP and gRPC, with a decompressed-size cap and an explicit decision on which bytes the ingest byte-rate charges | Claimed |


### PR DESCRIPTION
Reserves the number before the full ADR is written, so a parallel
session cannot pick 0084 for something else. The decision it will hold:
accept gzip on the OTLP HTTP and gRPC ingest paths, bound the
decompressed size the way ADR-0051 already bounds Remote Write's, and
say explicitly whether the per-tenant ingest byte rate charges the
compressed or the decompressed size.

Also adds the missing index rows for 0082 and 0083, found while adding
this one.

Refs: #115