### PR TITLE
docs: add ADR-0084 gzip-compressed OTLP ingest

### DIFF
--- a/docs/adrs/0084-otlp-gzip-ingest.md
+++ b/docs/adrs/0084-otlp-gzip-ingest.md
@@ -1,3 +1,307 @@
 # 0084. Accept gzip-compressed OTLP ingest
 
-Status: claimed
+Status: accepted
+
+## Context
+
+Ravel's OTLP ingest does not accept compressed bodies on either transport.
+
+On HTTP, `export_metrics`, `export_logs`, and `export_traces`
+(`services/ravel-server/src/otlp_http.rs`) pass the raw request `Bytes`
+straight to `ExportMetricsServiceRequest::decode` and its siblings. Nothing
+reads `Content-Encoding`. A gzip body reaches prost as compressed bytes and
+fails with `invalid OTLP payload: failed to decode Protobuf message: buffer
+underflow`, returned as HTTP 400.
+
+On gRPC, the three tonic services are built with `max_decoding_message_size`
+but no `accept_compressed`, so tonic rejects a compressed message outright.
+
+**The OpenTelemetry Collector's `otlphttp` exporter defaults to gzip.** So does
+Grafana Alloy. Pointed at Ravel with default settings, every export fails. The
+client sees a 400 and drops the batch; Ravel logs nothing unusual, because from
+its side the request was simply malformed.
+
+This is not hypothetical. Ravel's own container-first quickstart shipped with
+this defect and nobody noticed for a day: the Collector dropped every export it
+made, the Grafana dashboard the quickstart tells the reader to open stayed
+empty, and CI stayed green because a `telemetrygen` process alongside the
+Collector supplied the series the assertions queried. The quickstart now carries
+`compression: none` as a workaround, which is a setting no user should have to
+discover.
+
+### What already exists, and why it constrains this
+
+Ravel already ingests a compressed body on one path. Remote Write
+(`services/ravel-server/src/remote_write.rs`) accepts Snappy and bounds it with
+two separate caps:
+
+```rust
+const MAX_COMPRESSED_REQUEST_BODY_BYTES: usize = 16 * 1024 * 1024;
+const MAX_DECOMPRESSED_PAYLOAD_BYTES: usize = 64 * 1024 * 1024;
+```
+
+ADR-0051 section 1 names both in its Layer 1 description: "an explicit
+compressed-body cap on `/api/v1/write` (16 MiB) ahead of its existing 64 MiB
+decompressed cap." OTAP does the same per `ArrowPayload.record` with
+`max_decompressed_payload_bytes`, enforced *during* decompression through
+`decompress_capped`, which wraps the decoder in `take(cap + 1)` so the buffer is
+never allowed to grow past the cap before the check runs.
+
+Two properties of the existing admission design matter here, and accepting gzip
+disturbs both.
+
+**Layer 1 caps the wire message, not the decoded one.** The 16 MiB
+`DefaultBodyLimit` on `/v1/metrics` and the 16 MiB `max_decoding_message_size`
+on each tonic service exist to bound what Ravel buffers and decodes. Once a body
+may be compressed, the wire cap stops bounding the decode: 16 MiB of gzip can
+expand past 1 GiB at achievable ratios, and gzip's theoretical ceiling is over
+1000:1. Without a second cap, Layer 1 no longer does the job it was written for.
+
+**Layer 2 charges the ingest byte rate on wire bytes.** ADR-0051 section 1 is
+explicit: "charged on wire body bytes after tenant resolution and before
+decode." Remote Write follows it literally, calling `check_byte_rate` with
+`body.len()`, the compressed length. That is a deliberate property (charge for
+what the tenant made the server buffer) but it means a compressing tenant gets
+several times the effective ingest allowance of a non-compressing one for the
+same real telemetry. Today only Remote Write has that property. Accepting gzip
+on OTLP extends it to the main ingest path, and the choice should be made
+deliberately rather than inherited by copying the call.
+
+## Decision
+
+**1. Accept gzip on the OTLP HTTP endpoints, dispatched on `Content-Encoding`.**
+
+`/v1/metrics`, `/v1/logs`, and `/v1/traces` decompress the body when
+`Content-Encoding: gzip` is present, then decode as now. An absent or `identity`
+encoding keeps the current path byte for byte, so an uncompressed client sees no
+behavior change and no new allocation.
+
+Any other `Content-Encoding` value is rejected with HTTP 415 and a message
+naming what is supported. Silently treating an unknown encoding as identity
+would hand prost a compressed body and produce the same misleading
+`invalid OTLP payload` 400 this ADR exists to remove.
+
+Header parsing rules, written down so the implementation does not decide them
+by accident:
+
+- The comparison is case-insensitive, per RFC 9110. `GZIP` and `gzip` are the
+  same coding.
+- `x-gzip` is accepted as an alias for `gzip`, which RFC 9110 treats as
+  equivalent. Rejecting a legacy alias that the RFC calls the same thing would
+  produce exactly the mystery 415 this decision exists to avoid.
+- A single coding only. A multi-coding list, including `gzip, gzip` and
+  `deflate, gzip`, is 415. Ravel does not implement chained decoding, and
+  guessing at one member of a list would be a silent approximation.
+
+**A gzip body must decode as a whole stream.** `flate2`'s `GzDecoder` stops at
+the end of the first gzip member, so a concatenated multi-member stream (legal
+gzip, and produced by ordinary tooling) would decode member one, acknowledge it,
+and drop the rest. That is silent data loss on an acknowledged write, which
+Ravel does not do. The implementation uses multi-member semantics
+(`MultiGzDecoder`), under the same cap across all members, and any trailing
+bytes after a well-formed stream ends are HTTP 400. Truncating silently is not
+an option at any size.
+
+**2. Accept gzip on the OTLP gRPC services.**
+
+`MetricsServiceServer`, `LogsServiceServer`, and `TraceServiceServer` gain
+`.accept_compressed(CompressionEncoding::Gzip)`.
+
+What tonic 0.14 does with `max_decoding_message_size`, stated precisely because
+an implementer writing tests from a vaguer sentence would write the wrong ones:
+it checks the compressed frame length from the 5-byte gRPC prefix against the
+cap first and answers `out_of_range` if that alone exceeds it, then decompresses
+into a buffer limited to the *same* value, where an overrun during expansion
+becomes `resource_exhausted`. The cap therefore applies to both the compressed
+frame and the decompressed output, and the decompressed half is enforced while
+expanding. That is the safety property this ADR wants, and it already holds on
+gRPC without new code: no gzip bomb gets through.
+
+It also means the gRPC decompressed ceiling is 16 MiB, not the 64 MiB decision 3
+sets for HTTP. See the transport-asymmetry consequence below; this ADR accepts
+that gap rather than closing it, because raising `max_decoding_message_size` to
+64 MiB would also raise the cap on uncompressed gRPC messages, which nothing
+asked for.
+
+Ravel does not enable `send_compressed`. Response bodies are small
+(`ExportMetricsServiceResponse` is a partial-success record), so compressing
+them buys nothing and adds a per-response CPU cost.
+
+**3. A decompressed-size cap, enforced during decompression, not after.**
+
+HTTP decompression is bounded by a new `MAX_DECOMPRESSED_OTLP_BODY_BYTES` of
+64 MiB, matching Remote Write's post-Snappy cap. The enforcement follows
+`ravel-otap`'s `decompress_capped` exactly: read through `take(cap + 1)` and
+fail if the output exceeds the cap, so a decompression bomb is refused while it
+is being expanded rather than after Ravel has already allocated a gigabyte.
+
+Exceeding it is HTTP 413, the same status Layer 1 uses for an oversized body.
+
+The 16 MiB `DefaultBodyLimit` stays exactly as it is and continues to bound the
+compressed body. The two caps are independent, as they are for Remote Write.
+
+**4. The ingest byte rate charges the decompressed size.**
+
+This is the one place this ADR deliberately diverges from the Remote Write
+precedent, so the reasoning is stated rather than assumed.
+
+Layer 2 exists to bound a tenant's ingest volume. The quantity a tenant cares
+about, that Ravel's shards buffer, that segments store, and that the object
+store is billed for, is the decompressed size. Charging the compressed size
+would let a tenant multiply its effective allowance by its compression ratio,
+which for OTLP protobuf is routinely 5x to 10x. Two tenants sending identical
+telemetry would be charged differently based only on a client-side setting.
+
+The check therefore moves to after decompression on the gzip path. On the
+identity path it stays exactly where it is, charging the same bytes as today,
+so nothing changes for an uncompressed client.
+
+**This applies to gRPC too, and that takes real work rather than a copied
+line.** gRPC Layer 2 does not charge a decoded size today: `WireByteCountLayer`
+(`services/ravel-server/src/wire_byte_count.rs`) parses gRPC framing off the
+request body as tonic's decoder reads it, counting each frame's total length
+including its 1-byte compression flag and 4-byte length prefix. That count is
+the *compressed* frame length. Enabling `accept_compressed` without touching it
+would leave gRPC charging compressed bytes while HTTP charges decompressed, so
+two tenants sending identical telemetry would be charged differently based only
+on which transport they chose. That is precisely the failure this decision
+exists to prevent, reintroduced one layer down.
+
+For a frame whose compression flag is set, gRPC therefore charges the decoded
+message size rather than the counted wire length. The counting layer already
+parses that flag per frame, so which basis applies is available where the
+decision has to be made. An uncompressed frame keeps the wire count exactly as
+today.
+
+The layer's own docstring says it "aligns the charged quantity with the HTTP
+ingest path, which has always charged wire body bytes." After this ADR that
+sentence is stale, and the alignment it describes now holds on the decompressed
+quantity instead. It must be updated in the same change.
+
+**A compressed-size pre-check keeps rejection cheap.** ADR-0051's stated Layer 2
+property is that "a request whose size exceeds the available tokens is rejected
+whole without consuming tokens", so an over-rate tenant costs one buffered body
+and nothing more. Charging after decompression would weaken that to one buffered
+body plus one inflate: a tenant already over its rate could stream 16 MiB bombs
+and bill the gateway up to 64 MiB of decompression each, bounded only by the
+ingest concurrency ceiling.
+
+The compressed size is a strict lower bound on the decompressed size, so it can
+be checked first for free. If the compressed length alone exceeds the tenant's
+available tokens, the request is rejected 429 without inflating anything and
+without consuming tokens. Otherwise decompression proceeds and the real charge
+is made on the decompressed size. The charging basis is unchanged by this; it
+only restores the cheap-rejection property against the adversarial case this
+path invites.
+
+Remote Write is left alone. Changing its charging basis is a behavior change for
+existing deployments and belongs in its own decision, not smuggled in here.
+This ADR records the inconsistency rather than hiding it.
+
+**5. Metrics distinguish the compressed and decompressed size.**
+
+Per-tenant ingest metrics gain the decompressed byte count alongside the
+existing wire count. Without it an operator reading `/metrics` cannot tell a
+tenant that doubled its telemetry from one that turned compression off, and the
+two need very different responses.
+
+**6. The quickstart drops its workaround.**
+
+`deploy/otel/collector-config.yaml` currently sets `compression: none` with a
+comment pointing at this issue. That line is removed once gzip lands, which
+returns the quickstart to a stock Collector configuration and turns the
+`check-collector-delivery.sh` assertion (#209) into a live regression test for
+this ADR.
+
+![Where a gzip body meets each admission layer: the compressed cap bounds what is buffered, capped decompression bounds what is expanded, and the byte rate is charged on the decompressed size before anything reaches a shard buffer.](assets/0084-gzip-admission.svg)
+
+## Rejected alternatives
+
+**Document the collector setting instead of supporting gzip.** The issue offers
+this as an option. It fails the test the quickstart already ran: a default
+Collector pointed at Ravel produces a 400 and an empty dashboard, and the reader
+has no reason to suspect compression. Documentation does not help someone who
+does not know a question needs asking, and every OTLP client that defaults to
+gzip has to be told separately. Ravel would be the only backend in the ecosystem
+requiring it.
+
+**Accept gzip without a decompressed cap.** Smallest diff, and it reintroduces
+the exact hazard Layer 1 exists to prevent. A 16 MiB compressed body expands
+past a gigabyte at achievable ratios, so an unauthenticated-shaped resource
+attack becomes available to any tenant with a valid token. ADR-0051 already
+rejected this shape twice, for Remote Write and OTAP.
+
+**Decompress into a buffer and check the size afterwards.** Simpler than a
+capped reader, and useless: the allocation has already happened by the time the
+check runs, which is what the attack targets. `ravel-otap`'s `decompress_capped`
+solved this correctly and this ADR copies it rather than inventing a second
+approach.
+
+**Charge the ingest byte rate on the compressed size, matching Remote Write.**
+Consistent with the one existing precedent, and one line rather than a moved
+check. Rejected because it makes a tenant's allowance depend on a client-side
+setting: a tenant that enables compression gets 5x to 10x the real ingest volume
+for the same nominal rate, and two tenants sending identical data are charged
+differently. Ravel's admission limits are a cost-control mechanism, and
+compressed bytes are not what the cost tracks.
+
+**Support zstd and deflate as well.** The OTLP specification permits gzip and
+zstd, and zstd compresses better. Rejected for now on evidence: gzip is what the
+Collector and Alloy send by default, and it is what the failure reports are
+about. Adding a second codec doubles the decompression surface for a case nobody
+has hit. `Content-Encoding` dispatch makes zstd a small follow-up if a real
+client needs it, and the 415 message names exactly what is supported so the gap
+is legible rather than mysterious.
+
+**Put decompression in a `tower` layer instead of the handlers.** Architecturally
+tidier and it would cover future endpoints automatically. Rejected because the
+byte-rate check needs the decompressed length (decision 4) and lives inside the
+handler after tenant resolution. A layer that decompressed earlier would either
+duplicate tenant resolution or hand the handler a body whose original wire size
+it can no longer report, and the metrics in decision 5 need both numbers.
+
+## Consequences
+
+- A stock OpenTelemetry Collector and a stock Grafana Alloy work against Ravel
+  with no configuration. This is the single most common first-contact failure
+  the project has, and it stops being one.
+- The quickstart returns to a stock Collector config, and #209's
+  delivery assertion becomes a standing regression test for this path.
+- A new dependency for gzip decompression (`flate2`, which is not currently in
+  the workspace). Rust gzip decoders are well-audited and `flate2` is the
+  ecosystem default, but it is a genuinely new dependency and is flagged as one.
+  The workspace's existing `zstd` cannot decode gzip, so there is no in-tree
+  alternative.
+- The two transports cap decompressed size differently: 64 MiB on HTTP
+  (decision 3), 16 MiB on gRPC, because tonic applies
+  `max_decoding_message_size` to both the compressed frame and the decompressed
+  output. A batch that inflates to 40 MiB is accepted over HTTP and rejected
+  over gRPC with `resource_exhausted`. This ADR accepts the asymmetry: closing
+  it by raising the gRPC cap to 64 MiB would also raise the ceiling on
+  uncompressed gRPC messages, which is a separate change nobody has asked for.
+  The gap is documented so an operator hitting it can recognize it.
+- Peak transient memory grows by the ingest concurrency ceiling times the 64 MiB
+  HTTP cap, in the worst case. That memory is held while a concurrency permit is
+  held, and ADR-0069's ingest buffer budget does not account for it. On the
+  small hosts this project targets, that product belongs in an operator's sizing
+  arithmetic, so the operations guide must state it.
+- OTLP HTTP and Remote Write now charge the ingest byte rate on different bases:
+  decompressed for OTLP, compressed for Remote Write. This is a real
+  inconsistency, recorded here deliberately. It should be resolved by moving
+  Remote Write to the decompressed basis in its own decision, which is a
+  behavior change for existing deployments.
+- A tenant sending gzip sees its effective byte-rate allowance drop relative to
+  what an uncompressed client of the same nominal rate gets today, because it is
+  now charged for what it actually sends rather than what it put on the wire.
+  This is the intent of decision 4, and it is a visible change for anyone who
+  was already working around the rejection by compressing elsewhere.
+- CPU cost on the ingest path for compressed requests, bounded by the caps.
+  Decompression is not free, and a gateway sized on today's uncompressed traffic
+  should be re-measured once clients start sending gzip.
+- No frozen format changes. No RSEG, RLOG, or RSPAN layout change, no protobuf
+  schema change, no series-identity or commit-token change, no object-key layout
+  change. The wire encoding of a request is not a persisted format.
+
+## Refs
+
+Refs: #115

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -86,4 +86,4 @@ One decision per document. Status: Proposed | Accepted | Superseded.
 | [0081](0081-container-first-quickstart.md) | Container-first quickstart: a published-image `docker compose` path as the documented first run, with README command blocks executed in CI | Accepted |
 | [0082](0082-provisioning-shard-count-drift-tolerance.md) | Provisioning shard-count drift tolerance for an evolving default | Accepted |
 | [0083](0083-alert-sink-auth.md) | Alert sink delivery supports optional credentials | Accepted |
-| [0084](0084-otlp-gzip-ingest.md) | Accept gzip-compressed OTLP ingest on HTTP and gRPC, with a decompressed-size cap and an explicit decision on which bytes the ingest byte-rate charges | Claimed |
+| [0084](0084-otlp-gzip-ingest.md) | Accept gzip-compressed OTLP ingest on HTTP and gRPC, with a decompressed-size cap and an explicit decision on which bytes the ingest byte-rate charges | Accepted |

--- a/docs/adrs/assets/0084-gzip-admission.svg
+++ b/docs/adrs/assets/0084-gzip-admission.svg
@@ -1,0 +1,75 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1040 610" font-family="'Segoe Print','Bradley Hand','Comic Sans MS',cursive" font-size="15">
+  <defs>
+    <marker id="a84" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 1 1.5 Q 6 4 8.5 5 Q 6 6 1 8.5" fill="none" stroke="#444" stroke-width="1.6" stroke-linecap="round"/>
+    </marker>
+  </defs>
+  <rect width="1040" height="610" fill="#fdfcf8"/>
+  <text x="24" y="34" font-size="20" fill="#1b2230">A gzip OTLP body against each admission layer</text>
+  <text x="24" y="54" font-size="12" fill="#5b6472">Every cap bounds an allocation before it happens. Nothing reaches a shard buffer without passing all of them.</text>
+
+  <!-- client -->
+  <path d="M 28 110 Q 25 107 31 107 L 172 105 Q 179 106 178 113 L 179 168 Q 178 174 172 173 L 32 175 Q 26 174 27 168 Z" fill="#eef3f7" stroke="#31536b" stroke-width="2.2" stroke-linecap="round"/>
+  <text x="44" y="132" fill="#31536b">OTel Collector</text>
+  <text x="44" y="152" font-size="12" fill="#5b6472">gzip by default,</text>
+  <text x="44" y="168" font-size="12" fill="#5b6472">Content-Encoding: gzip</text>
+
+  <line x1="180" y1="140" x2="228" y2="140" stroke="#383e46" stroke-width="2" marker-end="url(#a84)"/>
+
+  <!-- layer 1 compressed cap -->
+  <path d="M 232 100 Q 228 96 236 96 L 428 94 Q 437 95 436 103 L 438 178 Q 437 186 429 185 L 236 187 Q 229 186 230 178 Z" fill="#fff" stroke="#8a5a10" stroke-width="2.4" stroke-linecap="round"/>
+  <text x="250" y="124" fill="#8a5a10">Layer 1a: compressed cap</text>
+  <text x="250" y="146" font-size="12" fill="#5b6472">DefaultBodyLimit 16 MiB,</text>
+  <text x="250" y="163" font-size="12" fill="#5b6472">unchanged. Bounds what</text>
+  <text x="250" y="180" font-size="12" fill="#5b6472">the server buffers. 413.</text>
+
+  <line x1="440" y1="140" x2="488" y2="140" stroke="#383e46" stroke-width="2" marker-end="url(#a84)"/>
+
+  <!-- capped decompression -->
+  <path d="M 492 100 Q 488 96 496 96 L 706 94 Q 715 95 714 103 L 716 178 Q 715 186 707 185 L 496 187 Q 489 186 490 178 Z" fill="#f9eeee" stroke="#a04040" stroke-width="2.6" stroke-linecap="round"/>
+  <text x="510" y="124" fill="#a04040">Layer 1b: capped decompress</text>
+  <text x="510" y="146" font-size="12" fill="#5b6472">NEW. take(cap + 1), 64 MiB.</text>
+  <text x="510" y="163" font-size="12" fill="#5b6472">Refused WHILE expanding,</text>
+  <text x="510" y="180" font-size="12" fill="#5b6472">never after. 413.</text>
+
+  <line x1="718" y1="140" x2="766" y2="140" stroke="#383e46" stroke-width="2" marker-end="url(#a84)"/>
+
+  <!-- byte rate -->
+  <path d="M 770 100 Q 766 96 774 96 L 996 94 Q 1005 95 1004 103 L 1006 178 Q 1005 186 997 185 L 774 187 Q 767 186 768 178 Z" fill="#eaf1ea" stroke="#4c6b45" stroke-width="2.6" stroke-linecap="round"/>
+  <text x="788" y="124" fill="#4c6b45">Layer 2: ingest byte rate</text>
+  <text x="788" y="146" font-size="12" fill="#5b6472">MOVED. Charged on the</text>
+  <text x="788" y="163" font-size="12" fill="#5b6472">DECOMPRESSED size, so a</text>
+  <text x="788" y="180" font-size="12" fill="#5b6472">ratio cannot buy allowance. 429.</text>
+
+  <line x1="888" y1="189" x2="888" y2="243" stroke="#383e46" stroke-width="2" marker-end="url(#a84)"/>
+
+  <!-- shard buffer -->
+  <path d="M 770 246 Q 766 242 774 242 L 996 240 Q 1005 241 1004 249 L 1006 306 Q 1005 314 997 313 L 774 315 Q 767 314 768 306 Z" fill="#dde1e7" stroke="#454b54" stroke-width="2.2" stroke-linecap="round"/>
+  <text x="788" y="272" fill="#3a3f47">decode, then shard buffer</text>
+  <text x="788" y="294" font-size="12" fill="#5b6472">the allocation Layer 2 protects</text>
+
+  <!-- identity path -->
+  <path d="M 28 300 Q 25 297 31 297 L 172 295 Q 179 296 178 303 L 179 358 Q 178 364 172 363 L 32 365 Q 26 364 27 358 Z" fill="#eef3f7" stroke="#31536b" stroke-width="2.2" stroke-linecap="round"/>
+  <text x="44" y="322" fill="#31536b">uncompressed client</text>
+  <text x="44" y="342" font-size="12" fill="#5b6472">no Content-Encoding,</text>
+  <text x="44" y="358" font-size="12" fill="#5b6472">or identity</text>
+
+  <path d="M 232 300 Q 228 296 236 296 L 706 294 Q 715 295 714 303 L 716 358 Q 715 366 707 365 L 236 367 Q 229 366 230 358 Z" fill="#f5f3ee" stroke="#5b6472" stroke-width="2.2" stroke-linecap="round" stroke-dasharray="7,4"/>
+  <text x="250" y="324" fill="#3a3f47">unchanged path: no decompression, byte rate charged where it is today</text>
+  <text x="250" y="348" font-size="12" fill="#5b6472">Byte for byte identical to current behavior. No new allocation, no new branch cost.</text>
+
+  <line x1="180" y1="330" x2="228" y2="330" stroke="#383e46" stroke-width="2" marker-end="url(#a84)"/>
+  <line x1="718" y1="330" x2="766" y2="330" stroke="#383e46" stroke-width="2" marker-end="url(#a84)"/>
+
+  <!-- rejected encoding -->
+  <path d="M 232 396 Q 228 392 236 392 L 706 390 Q 715 391 714 399 L 716 452 Q 715 460 707 459 L 236 461 Q 229 460 230 452 Z" fill="#f9eeee" stroke="#a04040" stroke-width="2.2" stroke-linecap="round"/>
+  <text x="250" y="420" fill="#a04040">any other Content-Encoding: 415, naming what is supported</text>
+  <text x="250" y="444" font-size="12" fill="#5b6472">Never treated as identity. That would hand prost a compressed body and produce the</text>
+  <text x="250" y="460" font-size="12" fill="#5b6472">same misleading "invalid OTLP payload" 400 this decision exists to remove.</text>
+
+  <text x="28" y="506" font-size="13" fill="#5b6472">gRPC: tonic checks max_decoding_message_size against the COMPRESSED frame, then limits the inflate to the same</text>
+  <text x="28" y="526" font-size="13" fill="#5b6472">value, so both halves are bounded at 16 MiB (not 64) and the refuse-while-expanding property already holds there.</text>
+  <text x="28" y="546" font-size="13" fill="#a04040">gRPC Layer 2 counts COMPRESSED frame bytes today (WireByteCountLayer). A compressed frame must charge the</text>
+  <text x="28" y="566" font-size="13" fill="#a04040">decoded size instead, or the split this decision removes from HTTP reappears between the two transports.</text>
+  <text x="28" y="588" font-size="13" fill="#8a5a10">Remote Write keeps charging compressed bytes. That inconsistency is recorded, not hidden, and is its own decision.</text>
+</svg>


### PR DESCRIPTION
Ravel's OTLP ingest rejects gzip on both transports. The OpenTelemetry
Collector and Grafana Alloy send gzip by default, so a stock client fails
on every export with an HTTP 400 that says "invalid OTLP payload" and
gives no hint that compression is the cause. Ravel's own quickstart
shipped with this defect and carries a `compression: none` workaround.

Accept gzip on HTTP (dispatched on Content-Encoding) and on gRPC
(accept_compressed), and bound what that lets through.

Two admission properties break when bodies may be compressed, and the ADR
answers both rather than adding a decompression call and moving on. Layer
1's 16 MiB wire cap stops bounding the decode, so HTTP gains a 64 MiB
decompressed cap enforced while expanding, copying ravel-otap's
decompress_capped. Layer 2 charges wire bytes, which would let a
compressing tenant multiply its allowance by its compression ratio, so
the charge moves to the decompressed size, with a compressed-size
pre-check that keeps an over-rate rejection cheap.

That charging change has to reach gRPC too: WireByteCountLayer counts
compressed frame bytes, so enabling accept_compressed alone would charge
the two transports differently for identical telemetry.

Records what it does not fix: Remote Write keeps charging compressed
bytes, and the two transports cap decompressed size differently because
tonic applies max_decoding_message_size to both halves of a compressed
frame.

Refs: #115
Refs: #212

Reviewed and approved with changes. Seven amendments applied before commit, the two load-bearing ones being that gRPC's WireByteCountLayer charges compressed frame bytes (so decision 4 had to reach gRPC explicitly, or the split it removes from HTTP would reappear between transports), and a corrected description of what tonic 0.14 actually does with max_decoding_message_size on a compressed frame.