### PR TITLE
feat(ravel-server): accept gzip-compressed OTLP ingest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1141,6 +1141,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "criterion"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2134,6 +2143,7 @@ version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
+ "crc32fast",
  "miniz_oxide",
  "zlib-rs",
 ]
@@ -4802,6 +4812,7 @@ dependencies = [
  "blake3",
  "bytes",
  "clap",
+ "flate2",
  "futures",
  "hex",
  "http",
@@ -5933,6 +5944,7 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bytes",
+ "flate2",
  "h2",
  "http",
  "http-body",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,7 @@ crc32c = "0.6"
 zstd = "0.13"
 lz4_flex = "0.14"
 snap = "1.1"
+flate2 = "1"
 
 # query
 promql-parser = "0.10"

--- a/crates/ravel-ingest/src/admission.rs
+++ b/crates/ravel-ingest/src/admission.rs
@@ -225,6 +225,25 @@ impl TokenBucket {
             Err(i64::try_from(retry_after_ns).unwrap_or(i64::MAX))
         }
     }
+
+    /// Whether `amount` tokens are currently available, taking none. Refills
+    /// first (crediting elapsed time) exactly as [`Self::try_take`], so a peek
+    /// and an immediately following take at the same `now_ns` agree; on
+    /// insufficient tokens the error carries the same wait `try_take` reports.
+    fn peek(&mut self, amount: u64, now_ns: i64) -> Result<(), i64> {
+        self.refill(now_ns);
+        if self.tokens >= amount {
+            Ok(())
+        } else if self.rate_per_sec == 0 {
+            Err(i64::MAX)
+        } else {
+            let deficit = (amount - self.tokens) as u128;
+            let retry_after_ns = deficit
+                .saturating_mul(1_000_000_000)
+                .div_ceil(self.rate_per_sec as u128);
+            Err(i64::try_from(retry_after_ns).unwrap_or(i64::MAX))
+        }
+    }
 }
 
 /// Exact active-identity tracker over two rotating one-hour epochs
@@ -581,6 +600,42 @@ impl AdmissionController {
                         usage.bytes_admitted_total += request_bytes;
                         Ok(())
                     }
+                    Err(retry_after_ns) => {
+                        usage.requests_rejected_byte_rate_total += 1;
+                        Err(RequestRejection {
+                            reason: RequestRejectionReason::ByteRate,
+                            retry_after_ns,
+                        })
+                    }
+                },
+            }
+        })
+    }
+
+    /// Non-consuming pre-check of `request_bytes` against the tenant's ingest
+    /// byte-rate bucket, for the OTLP gzip path (ADR-0084 decision 4). The
+    /// compressed body length is a strict lower bound on the decompressed
+    /// length, so if even the compressed size exceeds the available tokens the
+    /// gateway rejects 429 before inflating anything; the real charge is then
+    /// made on the decompressed size via [`Self::check_byte_rate`].
+    ///
+    /// Unlike [`Self::check_byte_rate`] this takes no tokens and increments no
+    /// admitted counter on success; on rejection it records the same
+    /// `requests_rejected_byte_rate_total` a consuming rejection would, so a
+    /// pre-check 429 is attributed identically in `/metrics`.
+    pub fn peek_byte_rate(
+        &self,
+        tenant: &TenantId,
+        signal: Signal,
+        request_bytes: u64,
+        now_ns: i64,
+    ) -> Result<(), RequestRejection> {
+        self.with_tenant(tenant, now_ns, |state| {
+            let usage = state.usage.entry(signal).or_default();
+            match &mut state.byte_rate {
+                None => Ok(()),
+                Some(bucket) => match bucket.peek(request_bytes, now_ns) {
+                    Ok(()) => Ok(()),
                     Err(retry_after_ns) => {
                         usage.requests_rejected_byte_rate_total += 1;
                         Err(RequestRejection {

--- a/services/ravel-server/Cargo.toml
+++ b/services/ravel-server/Cargo.toml
@@ -86,7 +86,10 @@ tokio = { workspace = true }
 # come from these features. They are additive over `channel` and inert for a
 # plaintext (`tls=off`) remote and for the intra-cluster coordinator, which
 # stays plaintext `http://`.
-tonic = { workspace = true, features = ["channel", "tls-ring", "tls-native-roots"] }
+# `gzip` links tonic's server-side gzip decoder so the OTLP services can
+# `.accept_compressed(CompressionEncoding::Gzip)` (ADR-0084 decision 2); the
+# OpenTelemetry Collector and Grafana Alloy send gzip by default.
+tonic = { workspace = true, features = ["channel", "tls-ring", "tls-native-roots", "gzip"] }
 tonic-prost = { workspace = true }
 # rustls 0.23 links a process-level default crypto provider that must be
 # installed before the first TLS endpoint is built. This binary transitively
@@ -127,6 +130,12 @@ tracing-subscriber = { workspace = true }
 # are unchanged.
 ravel-tracing-export = { workspace = true }
 bytes = { workspace = true }
+# gzip decompression for OTLP HTTP ingest (ADR-0084). A genuinely new external
+# dependency: the workspace's existing zstd/snap/lz4 codecs cannot decode gzip,
+# and the OpenTelemetry Collector and Grafana Alloy send gzip by default. Used
+# for its `MultiGzDecoder`, which decodes concatenated multi-member streams
+# under one capped reader.
+flate2 = { workspace = true }
 uuid = { workspace = true }
 rand = { workspace = true }
 # The alert evaluator hashes the RLOG object it writes to build the commit

--- a/services/ravel-server/src/ingest_byte_metrics.rs
+++ b/services/ravel-server/src/ingest_byte_metrics.rs
@@ -1,0 +1,68 @@
+//! Per-tenant wire (compressed) request-body byte counting for OTLP ingest
+//! (ADR-0084 decision 5).
+//!
+//! Layer-2 admission charges the byte-rate bucket on the *decompressed* size
+//! for a compressed request (ADR-0084 decision 4), and that charged quantity is
+//! what `ravel_admission_admitted_bytes_total` reports. On its own that number
+//! cannot distinguish a tenant that doubled its telemetry from one that turned
+//! compression off: both raise the charged (decompressed) bytes the same way.
+//! This collector records the *wire* bytes each tenant actually sent alongside
+//! it, so `/metrics` exposes both and their ratio is the tenant's effective
+//! compression factor.
+//!
+//! It is a `ravel-server`-local counter, separate from the `ravel-ingest`
+//! `AdmissionController`'s per-tenant usage: the byte-rate bucket and its
+//! admitted/charged counters live there, and the charged basis is the
+//! decompressed size, so the wire quantity has no home in that snapshot.
+
+use std::collections::HashMap;
+
+use parking_lot::Mutex;
+use ravel_types::{Signal, TenantHash, TenantId};
+
+/// Accumulated wire request-body bytes per `(tenant, signal)`. Keyed by the
+/// tenant hash (not the full id), matching how the admission `/metrics` family
+/// folds tenants, so the rendered cardinality is bounded the same way.
+#[derive(Default)]
+pub struct IngestByteMetrics {
+    rows: Mutex<HashMap<(TenantHash, Signal), u64>>,
+}
+
+/// One `(tenant, signal)` row of accumulated wire bytes, for the `/metrics`
+/// renderer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TenantWireBytes {
+    pub tenant_hash: TenantHash,
+    pub signal: Signal,
+    pub wire_bytes_total: u64,
+}
+
+impl IngestByteMetrics {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Adds `bytes` of wire request body (the on-the-wire size, i.e. the
+    /// compressed size when the client compressed) to `(tenant, signal)`.
+    /// Called on the admitted path only, right after the byte-rate charge
+    /// succeeds, so it counts exactly what a tenant successfully ingested.
+    pub fn record_wire_bytes(&self, tenant: &TenantId, signal: Signal, bytes: u64) {
+        let mut rows = self.rows.lock();
+        *rows.entry((tenant.hash(), signal)).or_insert(0) += bytes;
+    }
+
+    /// A point-in-time copy of every accumulated row, for `/metrics` rendering.
+    pub fn snapshot(&self) -> Vec<TenantWireBytes> {
+        self.rows
+            .lock()
+            .iter()
+            .map(
+                |(&(tenant_hash, signal), &wire_bytes_total)| TenantWireBytes {
+                    tenant_hash,
+                    signal,
+                    wire_bytes_total,
+                },
+            )
+            .collect()
+    }
+}

--- a/services/ravel-server/src/lib.rs
+++ b/services/ravel-server/src/lib.rs
@@ -22,6 +22,7 @@ pub mod gc_config;
 pub mod health;
 pub mod idle_tenant_state;
 pub mod ingest;
+pub mod ingest_byte_metrics;
 pub mod ingest_concurrency;
 pub mod lifecycle_refresh;
 pub mod logs_ingest;
@@ -512,6 +513,7 @@ fn gateway_state(
     recovery: &Option<Arc<tenancy::RecoveryManifestWriter>>,
     provisioning: &Option<Arc<provisioning::ProvisioningRecordWriter>>,
     ingest_concurrency: &Arc<ingest_concurrency::IngestConcurrencyController>,
+    ingest_byte_metrics: &Arc<ingest_byte_metrics::IngestByteMetrics>,
 ) -> Arc<otlp_http::GatewayState> {
     Arc::new(otlp_http::GatewayState {
         tenant_resolver,
@@ -543,6 +545,7 @@ fn gateway_state(
         },
         admission: admission.clone(),
         ingest_concurrency: ingest_concurrency.clone(),
+        ingest_byte_metrics: ingest_byte_metrics.clone(),
     })
 }
 
@@ -800,6 +803,12 @@ pub async fn start(
     let ingest_concurrency =
         ingest_concurrency::IngestConcurrencyController::shared(config.ingest_concurrency_limit);
 
+    // Per-tenant wire (compressed) request-body byte counter (ADR-0084 decision
+    // 5): one shared instance per process, threaded into every `GatewayState`
+    // (public and mTLS listeners) and read at scrape time by `/metrics`, so the
+    // wire-bytes family sums the same tenants the admission family does.
+    let ingest_byte_metrics = Arc::new(ingest_byte_metrics::IngestByteMetrics::new());
+
     // Per-query cost aggregator (ADR-0044 section 4): one per
     // process, shared with every query handler below and read at scrape time by
     // the `/metrics` route. Its per-tenant allowlist is the tenants an operator
@@ -854,6 +863,7 @@ pub async fn start(
             &recovery,
             &provisioning_writer,
             &ingest_concurrency,
+            &ingest_byte_metrics,
         );
         http_router = http_router.merge(otlp_http::router(state));
         let rw_state = remote_write_state(
@@ -877,6 +887,7 @@ pub async fn start(
                 &recovery,
                 &provisioning_writer,
                 &ingest_concurrency,
+                &ingest_byte_metrics,
             );
             let mtls_rw_state = remote_write_state(
                 router,
@@ -1041,6 +1052,7 @@ pub async fn start(
         ingest_buffer_budget: ingest_buffer_budget.clone(),
         distrib: distrib_metrics.clone(),
         durable_auth: durable_auth.clone(),
+        ingest_byte_metrics: ingest_byte_metrics.clone(),
     };
     http_router = http_router.merge(metrics::router(metrics_state));
 
@@ -1358,6 +1370,7 @@ pub async fn start(
             &recovery,
             &provisioning_writer,
             &ingest_concurrency,
+            &ingest_byte_metrics,
         )),
         _ => None,
     };
@@ -1365,17 +1378,27 @@ pub async fn start(
     // 2): the cap is on the wire message, before OTLP protobuf decode, on
     // every service equally regardless of transport.
     const MAX_DECODED_MESSAGE_BYTES: usize = 16 * 1024 * 1024;
+    // Accept gzip-compressed request messages (ADR-0084 decision 2). Not
+    // `send_compressed`: response bodies are tiny partial-success records, so
+    // compressing them only costs CPU. `max_decoding_message_size` is left at
+    // 16 MiB deliberately: tonic 0.14 checks that cap against the compressed
+    // frame length AND limits the decompression output to the same value, so a
+    // compressed gRPC message's decompressed ceiling is 16 MiB by design (the
+    // asymmetry against HTTP's 64 MiB is recorded in the ADR's consequences).
     let metrics_service = otlp_grpc_state.as_ref().map(|state| {
         MetricsServiceServer::new(otlp_grpc::GrpcMetricsService::new(state.clone()))
             .max_decoding_message_size(MAX_DECODED_MESSAGE_BYTES)
+            .accept_compressed(tonic::codec::CompressionEncoding::Gzip)
     });
     let logs_service = otlp_grpc_state.as_ref().map(|state| {
         LogsServiceServer::new(otlp_grpc_logs::GrpcLogsService::new(state.clone()))
             .max_decoding_message_size(MAX_DECODED_MESSAGE_BYTES)
+            .accept_compressed(tonic::codec::CompressionEncoding::Gzip)
     });
     let traces_service = otlp_grpc_state.as_ref().map(|state| {
         TraceServiceServer::new(otlp_grpc_traces::GrpcTraceService::new(state.clone()))
             .max_decoding_message_size(MAX_DECODED_MESSAGE_BYTES)
+            .accept_compressed(tonic::codec::CompressionEncoding::Gzip)
     });
 
     // OTAP metrics ride the same gRPC listener and share the same

--- a/services/ravel-server/src/metrics.rs
+++ b/services/ravel-server/src/metrics.rs
@@ -1847,6 +1847,14 @@ fn render_cache_family(
 pub struct AdmissionCountersSnapshot {
     pub usage: Vec<TenantUsage>,
     pub tenant_labels: bool,
+    /// Per-tenant wire (compressed) request-body bytes (ADR-0084 decision 5),
+    /// rendered as `ravel_ingest_wire_bytes_total` alongside this family's
+    /// charged-bytes counter. Sourced from
+    /// [`crate::ingest_byte_metrics::IngestByteMetrics`], not the admission
+    /// `usage_snapshot`: the byte-rate bucket charges the decompressed size for
+    /// a compressed request, so the wire quantity has no home in that snapshot.
+    /// Folded by the same `tenant_labels` gate as `usage`.
+    pub wire_bytes: Vec<crate::ingest_byte_metrics::TenantWireBytes>,
 }
 
 /// The counters this family sums per rendered series. Split out so the fold
@@ -1976,7 +1984,11 @@ fn render_admission_family(out: &mut String, mode: Mode, snapshot: &AdmissionCou
     write_header(
         out,
         "ravel_admission_admitted_bytes_total",
-        "Wire body bytes admitted past the ingest byte-rate layer, by tenant and signal.",
+        "Bytes charged against the ingest byte-rate layer for admitted requests, by tenant and \
+         signal. For a gzip-compressed OTLP request this is the decompressed size (ADR-0084 \
+         decision 4); for an uncompressed request it equals the wire size. Compare with \
+         ravel_ingest_wire_bytes_total to distinguish a tenant that increased telemetry from one \
+         that turned compression off.",
         "counter",
     );
     for ((hash, signal), acc) in &ordered {
@@ -1985,6 +1997,48 @@ fn render_admission_family(out: &mut String, mode: Mode, snapshot: &AdmissionCou
             "ravel_admission_admitted_bytes_total",
             &labels(mode, *hash, *signal),
             acc.bytes_admitted,
+        );
+    }
+
+    // Wire (compressed) request-body bytes per tenant/signal (ADR-0084 decision
+    // 5), sourced from `IngestByteMetrics`, not the admission usage snapshot.
+    // Folded by the same `tenant_labels` gate as the counters above so its
+    // cardinality is bounded identically. Its ratio to
+    // `ravel_admission_admitted_bytes_total` is a tenant's effective
+    // compression factor.
+    let mut wire_rows: std::collections::HashMap<(Option<TenantHash>, Signal), u64> =
+        std::collections::HashMap::new();
+    for row in &snapshot.wire_bytes {
+        let key = (
+            snapshot.tenant_labels.then_some(row.tenant_hash),
+            row.signal,
+        );
+        let acc = wire_rows.entry(key).or_default();
+        *acc = acc.saturating_add(row.wire_bytes_total);
+    }
+    let mut wire_ordered: Vec<((Option<TenantHash>, Signal), u64)> =
+        wire_rows.into_iter().collect();
+    wire_ordered.sort_by(|(a_key, _), (b_key, _)| {
+        tenant_label(a_key.0)
+            .value()
+            .cmp(&tenant_label(b_key.0).value())
+            .then_with(|| signal_name(a_key.1).cmp(signal_name(b_key.1)))
+    });
+    write_header(
+        out,
+        "ravel_ingest_wire_bytes_total",
+        "Wire (on-the-wire, compressed when the client compressed) OTLP request body bytes \
+         admitted, by tenant and signal (ADR-0084 decision 5). Divide \
+         ravel_admission_admitted_bytes_total by this to read a tenant's effective compression \
+         factor.",
+        "counter",
+    );
+    for ((hash, signal), wire_bytes) in &wire_ordered {
+        write_sample(
+            out,
+            "ravel_ingest_wire_bytes_total",
+            &labels(mode, *hash, *signal),
+            *wire_bytes,
         );
     }
 
@@ -2772,6 +2826,12 @@ pub struct MetricsState {
     /// (`Mode::All`/`Gateway`/`Query`); `None` otherwise leaves the whole
     /// `ravel_durable_auth_*` family off the exposition.
     pub durable_auth: Option<Arc<crate::lifecycle_refresh::DurableAuthState>>,
+    /// Per-tenant wire (compressed) request-body bytes (ADR-0084 decision 5),
+    /// rendered alongside the admission family's charged (decompressed) bytes so
+    /// the two together distinguish a tenant that increased telemetry from one
+    /// that turned compression off. Always present; empty until an OTLP request
+    /// is admitted. Folded by the same `--metrics-tenant-labels` gate.
+    pub ingest_byte_metrics: Arc<crate::ingest_byte_metrics::IngestByteMetrics>,
 }
 
 /// `GET /metrics`, mounted in every mode (ADR-0044 section 4). Reads only
@@ -2873,6 +2933,7 @@ async fn metrics_handler(State(state): State<MetricsState>) -> impl IntoResponse
     let admission_snapshot = AdmissionCountersSnapshot {
         usage: state.admission.usage_snapshot(),
         tenant_labels: state.metrics_tenant_labels,
+        wire_bytes: state.ingest_byte_metrics.snapshot(),
     };
 
     // Per-query cost rows, read at scrape time like every other family (a
@@ -4432,6 +4493,7 @@ mod tests {
         let snapshot = AdmissionCountersSnapshot {
             usage,
             tenant_labels: false,
+            wire_bytes: Vec::new(),
         };
         let body = render(
             Mode::Gateway,
@@ -4505,6 +4567,7 @@ mod tests {
         let snapshot = AdmissionCountersSnapshot {
             usage: vec![byte_rate, series_rate, series_cap],
             tenant_labels: true,
+            wire_bytes: Vec::new(),
         };
         let body = render(
             Mode::Gateway,
@@ -4576,6 +4639,7 @@ mod tests {
         let snapshot = AdmissionCountersSnapshot {
             usage: vec![row],
             tenant_labels: true,
+            wire_bytes: Vec::new(),
         };
         let hash = ravel_types::TenantId::new("skewed").hash().to_hex();
         let body = render(

--- a/services/ravel-server/src/otlp_grpc.rs
+++ b/services/ravel-server/src/otlp_grpc.rs
@@ -82,17 +82,25 @@ impl MetricsService for GrpcMetricsService {
             .map_err(|_| Status::unauthenticated("invalid or missing tenant credentials"))?;
         let mode = write_mode_from_headers(&headers);
 
-        // Layer 2 (ADR-0051 section 2): byte rate on wire bytes, counted by
-        // `WireByteCountLayer` as tonic's decoder reads them off the request
-        // body, before this request reaches `handle_export`.
-        let request_bytes = wire_request_bytes(&request)?;
-        if let Err(rejection) =
-            self.state
-                .admission
-                .check_byte_rate(&tenant, Signal::Metrics, request_bytes, now_ns())
-        {
+        // Layer 2 (ADR-0051 section 2): byte rate counted by
+        // `WireByteCountLayer` as tonic's decoder reads the request body. For a
+        // gzip-compressed frame the charge is the decoded message size, not the
+        // compressed wire length (ADR-0084 decision 4), so gRPC and HTTP charge
+        // the same for identical telemetry.
+        let charge = wire_request_bytes(&request)?;
+        if let Err(rejection) = self.state.admission.check_byte_rate(
+            &tenant,
+            Signal::Metrics,
+            charge.charge_bytes,
+            now_ns(),
+        ) {
             return Err(admission_rejection_status(rejection));
         }
+        self.state.ingest_byte_metrics.record_wire_bytes(
+            &tenant,
+            Signal::Metrics,
+            charge.wire_bytes,
+        );
 
         let outcome = crate::ingest::handle_export(
             &self.state.ingest,

--- a/services/ravel-server/src/otlp_grpc_logs.rs
+++ b/services/ravel-server/src/otlp_grpc_logs.rs
@@ -53,17 +53,22 @@ impl LogsService for GrpcLogsService {
             .map_err(|_| Status::unauthenticated("invalid or missing tenant credentials"))?;
         let mode = write_mode_from_headers(&headers);
 
-        // Layer 2 (ADR-0051 section 2): byte rate on wire bytes, counted by
-        // `WireByteCountLayer` as tonic's decoder reads them off the request
-        // body, before this request reaches `handle_export_logs`.
-        let request_bytes = wire_request_bytes(&request)?;
-        if let Err(rejection) =
-            self.state
-                .admission
-                .check_byte_rate(&tenant, Signal::Logs, request_bytes, now_ns())
-        {
+        // Layer 2 (ADR-0051 section 2): byte rate counted by
+        // `WireByteCountLayer` as tonic's decoder reads the request body. A
+        // gzip-compressed frame is charged its decoded message size, not the
+        // compressed wire length (ADR-0084 decision 4).
+        let charge = wire_request_bytes(&request)?;
+        if let Err(rejection) = self.state.admission.check_byte_rate(
+            &tenant,
+            Signal::Logs,
+            charge.charge_bytes,
+            now_ns(),
+        ) {
             return Err(admission_rejection_status(rejection));
         }
+        self.state
+            .ingest_byte_metrics
+            .record_wire_bytes(&tenant, Signal::Logs, charge.wire_bytes);
 
         let idempotency_key = idempotency_key_from_headers(&headers);
 

--- a/services/ravel-server/src/otlp_grpc_traces.rs
+++ b/services/ravel-server/src/otlp_grpc_traces.rs
@@ -56,16 +56,21 @@ impl TraceService for GrpcTraceService {
         // Layer 2 (ADR-0051 section 2): byte rate applies uniformly to every
         // signal including spans, even though spans get no layer-4 admission
         // (ADR-0051 excludes spans from series/stream admission). Counted by
-        // `WireByteCountLayer` on wire bytes, not the decoded message's
-        // encoded length.
-        let request_bytes = wire_request_bytes(&request)?;
-        if let Err(rejection) =
-            self.state
-                .admission
-                .check_byte_rate(&tenant, Signal::Spans, request_bytes, now_ns())
-        {
+        // `WireByteCountLayer` off the request body; a gzip-compressed frame is
+        // charged its decoded message size, not the compressed wire length
+        // (ADR-0084 decision 4).
+        let charge = wire_request_bytes(&request)?;
+        if let Err(rejection) = self.state.admission.check_byte_rate(
+            &tenant,
+            Signal::Spans,
+            charge.charge_bytes,
+            now_ns(),
+        ) {
             return Err(admission_rejection_status(rejection));
         }
+        self.state
+            .ingest_byte_metrics
+            .record_wire_bytes(&tenant, Signal::Spans, charge.wire_bytes);
 
         let idempotency_key = idempotency_key_from_headers(&headers);
 

--- a/services/ravel-server/src/otlp_http.rs
+++ b/services/ravel-server/src/otlp_http.rs
@@ -21,7 +21,7 @@ use ravel_ingest::{
     AdmissionController, LogWriteError, RequestRejection, SpanWriteError, WriteError, WriteMode,
 };
 use ravel_query::http::TenantResolver;
-use ravel_types::Signal;
+use ravel_types::{Signal, TenantId};
 
 use crate::ingest::{IngestRequestError, IngestState};
 use crate::ingest_concurrency::IngestConcurrencyController;
@@ -49,8 +49,213 @@ pub const MAX_IDEMPOTENCY_KEY_BYTES: usize = 128;
 const NS_PER_HOUR: i64 = 3_600_000_000_000;
 
 /// Layer 1 (ADR-0051 section 2): the wire-body cap on every OTLP HTTP
-/// endpoint, ahead of protobuf decode.
+/// endpoint, ahead of protobuf decode. This bounds the *compressed* body when a
+/// client sends gzip; the decompressed size is bounded independently by
+/// [`MAX_DECOMPRESSED_OTLP_BODY_BYTES`], exactly as Remote Write pairs its two
+/// caps (ADR-0084 decision 3).
 const MAX_REQUEST_BODY_BYTES: usize = 16 * 1024 * 1024;
+
+/// Cap on the decompressed size of a gzip OTLP body (ADR-0084 decision 3),
+/// matching Remote Write's post-Snappy cap. Enforced *while* expanding, not
+/// after, by reading the decoder through `take(cap + 1)`: a decompression bomb
+/// is refused as it is being inflated rather than after Ravel has already
+/// allocated it (the same discipline as `ravel-otap`'s `decompress_capped`).
+const MAX_DECOMPRESSED_OTLP_BODY_BYTES: usize = 64 * 1024 * 1024;
+
+/// The `Content-Encoding` a request declared, after RFC 9110 parsing. Only the
+/// codings Ravel actually decodes are named; everything else is
+/// [`ContentCoding::Unsupported`] and answered with 415 rather than being
+/// guessed at, so an unknown coding never reaches prost as a compressed body
+/// and produces the misleading `invalid OTLP payload` 400 ADR-0084 exists to
+/// remove.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ContentCoding {
+    /// Absent header, empty value, or the literal `identity`: the body is the
+    /// payload as-is.
+    Identity,
+    /// `gzip` or its RFC 9110 alias `x-gzip`, compared case-insensitively.
+    Gzip,
+    /// Any other single coding, or any multi-coding list (`gzip, gzip`,
+    /// `deflate, gzip`): Ravel does not chain decoders, so this is a 415.
+    Unsupported,
+}
+
+/// Parses `Content-Encoding` per RFC 9110: case-insensitive, `x-gzip` an alias
+/// for `gzip`, a single coding only. A comma-separated list is unsupported
+/// because Ravel implements no chained decoding and guessing at one member
+/// would be a silent approximation.
+fn parse_content_encoding(headers: &HeaderMap) -> ContentCoding {
+    let Some(value) = headers.get(header::CONTENT_ENCODING) else {
+        return ContentCoding::Identity;
+    };
+    let Ok(value) = value.to_str() else {
+        return ContentCoding::Unsupported;
+    };
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return ContentCoding::Identity;
+    }
+    // A list is always unsupported, even `gzip, gzip`: no chained decoding.
+    if trimmed.contains(',') {
+        return ContentCoding::Unsupported;
+    }
+    let coding = trimmed.to_ascii_lowercase();
+    match coding.as_str() {
+        "identity" => ContentCoding::Identity,
+        "gzip" | "x-gzip" => ContentCoding::Gzip,
+        _ => ContentCoding::Unsupported,
+    }
+}
+
+/// Why a gzip body could not be turned into OTLP bytes.
+#[derive(Debug)]
+enum GzipDecodeError {
+    /// The decompressed stream exceeded [`MAX_DECOMPRESSED_OTLP_BODY_BYTES`]:
+    /// HTTP 413. Detected while expanding, before the full expansion is
+    /// allocated.
+    TooLarge,
+    /// The bytes were not a well-formed gzip stream, or carried trailing bytes
+    /// after a well-formed stream ended: HTTP 400. Truncating silently is not
+    /// an option at any size.
+    Invalid(String),
+}
+
+/// Decompresses a gzip `body` under a single hard cap across all members,
+/// copying `ravel-otap`'s `decompress_capped` discipline: the decoder is read
+/// through `take(cap + 1)` so the output buffer can never grow past `cap + 1`
+/// before the check runs, which refuses a bomb as it inflates rather than after
+/// the allocation the attack targets has already happened.
+///
+/// Uses [`MultiGzDecoder`], not `GzDecoder`: a concatenated multi-member stream
+/// is legal gzip that ordinary tooling produces, and a plain `GzDecoder` would
+/// decode member one, acknowledge it, and silently drop the rest. Trailing
+/// bytes after the final member surface as [`GzipDecodeError::Invalid`] (400).
+fn decompress_gzip_capped(body: &[u8], cap: usize) -> Result<Vec<u8>, GzipDecodeError> {
+    use std::io::Read;
+
+    use flate2::read::MultiGzDecoder;
+
+    let cap_u64 = cap as u64;
+    let mut limited = MultiGzDecoder::new(body).take(cap_u64 + 1);
+    let mut out = Vec::new();
+    limited
+        .read_to_end(&mut out)
+        .map_err(|err| GzipDecodeError::Invalid(err.to_string()))?;
+    if out.len() as u64 > cap_u64 {
+        return Err(GzipDecodeError::TooLarge);
+    }
+    Ok(out)
+}
+
+/// HTTP 415 for an unsupported `Content-Encoding`, naming what is supported so
+/// the gap is legible rather than a mystery (ADR-0084 decision 1).
+fn unsupported_encoding_response() -> Response {
+    (
+        StatusCode::UNSUPPORTED_MEDIA_TYPE,
+        "unsupported Content-Encoding; this endpoint accepts only an absent or identity encoding, \
+         or a single gzip (x-gzip) coding",
+    )
+        .into_response()
+}
+
+/// Applies the layer-2 byte-rate charge and returns the OTLP protobuf bytes to
+/// decode, dispatching on `Content-Encoding` (ADR-0084 decisions 1, 3, 4).
+///
+/// - Identity: the current path byte for byte. `check_byte_rate` charges the
+///   wire body length exactly as before, and the returned `Bytes` is the input
+///   with no copy.
+/// - gzip/x-gzip: the compressed length is pre-checked against the tenant's
+///   available tokens without consuming any (`peek_byte_rate`); if even that
+///   lower bound is over rate the request is rejected 429 before anything is
+///   inflated. Otherwise the body is decompressed under the 64 MiB cap and the
+///   real charge is made on the decompressed size.
+/// - anything else: 415.
+///
+/// The wire (compressed) length is recorded per tenant on the admitted path so
+/// `/metrics` can report it alongside the charged (decompressed) size.
+fn admit_and_decode_body(
+    state: &GatewayState,
+    headers: &HeaderMap,
+    tenant: &TenantId,
+    signal: Signal,
+    body: Bytes,
+) -> Result<Bytes, Box<Response>> {
+    match parse_content_encoding(headers) {
+        ContentCoding::Unsupported => Err(Box::new(unsupported_encoding_response())),
+        ContentCoding::Identity => {
+            let wire_len = body.len() as u64;
+            // Layer 2 (ADR-0051 section 2): byte rate on the wire body, before
+            // decode, unchanged from today for an uncompressed client.
+            if let Err(rejection) =
+                state
+                    .admission
+                    .check_byte_rate(tenant, signal, wire_len, now_ns())
+            {
+                return Err(Box::new(admission_rejection_response(rejection)));
+            }
+            state
+                .ingest_byte_metrics
+                .record_wire_bytes(tenant, signal, wire_len);
+            Ok(body)
+        }
+        ContentCoding::Gzip => {
+            let wire_len = body.len() as u64;
+            // Compressed-size pre-check (ADR-0084 decision 4): the compressed
+            // length is a strict lower bound on the decompressed length, so if
+            // even it exceeds the available tokens the request is rejected 429
+            // without inflating anything and without consuming tokens. This
+            // keeps an already-over-rate tenant from billing the gateway up to
+            // 64 MiB of inflate per rejected request.
+            if let Err(rejection) =
+                state
+                    .admission
+                    .peek_byte_rate(tenant, signal, wire_len, now_ns())
+            {
+                return Err(Box::new(admission_rejection_response(rejection)));
+            }
+            let decompressed = match decompress_gzip_capped(&body, MAX_DECOMPRESSED_OTLP_BODY_BYTES)
+            {
+                Ok(bytes) => bytes,
+                Err(GzipDecodeError::TooLarge) => {
+                    return Err(Box::new(
+                        (
+                            StatusCode::PAYLOAD_TOO_LARGE,
+                            format!(
+                                "decompressed OTLP body exceeds {} bytes",
+                                MAX_DECOMPRESSED_OTLP_BODY_BYTES
+                            ),
+                        )
+                            .into_response(),
+                    ));
+                }
+                Err(GzipDecodeError::Invalid(detail)) => {
+                    return Err(Box::new(
+                        (
+                            StatusCode::BAD_REQUEST,
+                            format!("invalid gzip body: {detail}"),
+                        )
+                            .into_response(),
+                    ));
+                }
+            };
+            let decompressed_len = decompressed.len() as u64;
+            // The real charge: the decompressed size (ADR-0084 decision 4), so
+            // a compressing tenant and an uncompressing one sending the same
+            // telemetry are charged the same.
+            if let Err(rejection) =
+                state
+                    .admission
+                    .check_byte_rate(tenant, signal, decompressed_len, now_ns())
+            {
+                return Err(Box::new(admission_rejection_response(rejection)));
+            }
+            state
+                .ingest_byte_metrics
+                .record_wire_bytes(tenant, signal, wire_len);
+            Ok(Bytes::from(decompressed))
+        }
+    }
+}
 
 pub struct GatewayState {
     pub tenant_resolver: Arc<dyn TenantResolver>,
@@ -63,8 +268,17 @@ pub struct GatewayState {
     /// the `s` keyspace, its own router and its own limits (ADR-0041).
     pub traces_ingest: SpanIngestState,
     /// Tenant admission (ADR-0051): shared by all three signals for the
-    /// layer-2 byte-rate check, done here on wire bytes before decode.
+    /// layer-2 byte-rate check. On the identity path this is done on wire bytes
+    /// before decode as before; on the gzip path (ADR-0084) it is done on the
+    /// decompressed size after decompression, behind a compressed-size
+    /// pre-check.
     pub admission: Arc<AdmissionController>,
+    /// Per-tenant wire (compressed) request-body byte counter (ADR-0084
+    /// decision 5). Shared with the gRPC ingest services and the `/metrics`
+    /// renderer, so an operator can compare wire bytes against the charged
+    /// (decompressed) bytes admission reports and tell a tenant that increased
+    /// telemetry from one that turned compression off.
+    pub ingest_byte_metrics: Arc<crate::ingest_byte_metrics::IngestByteMetrics>,
     /// The process-wide in-flight ingest-request ceiling, shared
     /// with every OTLP HTTP/gRPC service and Remote Write on this listener
     /// and the mTLS listener. Checked first in every handler below, ahead of
@@ -257,15 +471,13 @@ async fn export_metrics(
 
     let mode = write_mode_from_headers(&headers);
 
-    // Layer 2 (ADR-0051 section 2): byte rate on the wire body, before
-    // decode, whole-request rejection with no tokens consumed.
-    if let Err(rejection) =
-        state
-            .admission
-            .check_byte_rate(&tenant, Signal::Metrics, body.len() as u64, now_ns())
-    {
-        return admission_rejection_response(rejection);
-    }
+    // Layer 2 (ADR-0051 section 2) plus gzip dispatch (ADR-0084): charge the
+    // byte rate and return the OTLP protobuf bytes, decompressing first when
+    // the client sent gzip. Identity is unchanged from before.
+    let body = match admit_and_decode_body(&state, &headers, &tenant, Signal::Metrics, body) {
+        Ok(body) => body,
+        Err(response) => return *response,
+    };
 
     let request = match ExportMetricsServiceRequest::decode(body.as_ref()) {
         Ok(request) => request,
@@ -324,15 +536,13 @@ async fn export_logs(
 
     let mode = write_mode_from_headers(&headers);
 
-    // Layer 2 (ADR-0051 section 2): byte rate on the wire body, before
-    // decode, whole-request rejection with no tokens consumed.
-    if let Err(rejection) =
-        state
-            .admission
-            .check_byte_rate(&tenant, Signal::Logs, body.len() as u64, now_ns())
-    {
-        return admission_rejection_response(rejection);
-    }
+    // Layer 2 (ADR-0051 section 2) plus gzip dispatch (ADR-0084): charge the
+    // byte rate and return the OTLP protobuf bytes, decompressing first when
+    // the client sent gzip. Identity is unchanged from before.
+    let body = match admit_and_decode_body(&state, &headers, &tenant, Signal::Logs, body) {
+        Ok(body) => body,
+        Err(response) => return *response,
+    };
 
     let request = match ExportLogsServiceRequest::decode(body.as_ref()) {
         Ok(request) => request,
@@ -400,16 +610,13 @@ async fn export_traces(
 
     let mode = write_mode_from_headers(&headers);
 
-    // Layer 2 (ADR-0051 section 2): byte rate applies uniformly to every
-    // signal including spans, even though spans get no layer-4 admission
-    // (ADR-0051 excludes spans from series/stream admission).
-    if let Err(rejection) =
-        state
-            .admission
-            .check_byte_rate(&tenant, Signal::Spans, body.len() as u64, now_ns())
-    {
-        return admission_rejection_response(rejection);
-    }
+    // Layer 2 (ADR-0051 section 2) plus gzip dispatch (ADR-0084): byte rate
+    // applies uniformly to every signal including spans (even though spans get
+    // no layer-4 admission), charged after decompression on the gzip path.
+    let body = match admit_and_decode_body(&state, &headers, &tenant, Signal::Spans, body) {
+        Ok(body) => body,
+        Err(response) => return *response,
+    };
 
     let request = match ExportTraceServiceRequest::decode(body.as_ref()) {
         Ok(request) => request,
@@ -453,5 +660,392 @@ async fn export_traces(
         Err(err @ SpanIngestRequestError::Write(_)) => {
             (StatusCode::SERVICE_UNAVAILABLE, err.to_string()).into_response()
         }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use std::io::Write as _;
+
+    use flate2::Compression;
+    use flate2::write::GzEncoder;
+    use opentelemetry_proto::tonic::metrics::v1::metric::Data as MetricData;
+    use opentelemetry_proto::tonic::metrics::v1::number_data_point::Value as NumberValue;
+    use opentelemetry_proto::tonic::metrics::v1::{
+        Gauge, Metric, NumberDataPoint, ResourceMetrics, ScopeMetrics,
+    };
+    use ravel_ingest::{
+        AdmissionController, AdmissionLimits, IngestConfig, IngestRouter, LogIngestRouter,
+        RateLimit, SpanIngestRouter, SystemClock,
+    };
+    use ravel_object_store::ObjectStoreBackend;
+    use ravel_object_store::memory::MemoryStore;
+    use ravel_otlp::{IngestLimits, LogIngestLimits, SpanIngestLimits};
+    use ravel_query::http::AuthError;
+
+    use super::*;
+    use crate::ingest_byte_metrics::IngestByteMetrics;
+    use crate::ingest_concurrency::{IngestConcurrencyController, IngestConcurrencyLimit};
+
+    const TENANT: &str = "acme";
+
+    /// Resolves every request to the same fixed tenant, so a handler test can
+    /// find that tenant's admission usage row without threading a token.
+    struct FixedTenantResolver(TenantId);
+
+    impl TenantResolver for FixedTenantResolver {
+        fn resolve(&self, _headers: &HeaderMap) -> Result<TenantId, AuthError> {
+            Ok(self.0.clone())
+        }
+    }
+
+    /// A `GatewayState` over `MemoryStore`, whose admission controller carries
+    /// `limits` as its per-tenant defaults (so the fixed tenant gets them). The
+    /// metrics, log, and span routers are all real, so a handler runs the full
+    /// ingest path and returns the same status a client would see.
+    fn state_with_limits(limits: AdmissionLimits) -> Arc<GatewayState> {
+        let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+        let metrics_router = Arc::new(IngestRouter::new(
+            IngestConfig::default(),
+            store.clone(),
+            Signal::Metrics,
+            Arc::new(SystemClock),
+        ));
+        let log_router = Arc::new(LogIngestRouter::new(
+            IngestConfig::default(),
+            store.clone(),
+            Arc::new(SystemClock),
+        ));
+        let span_router = Arc::new(SpanIngestRouter::new(
+            IngestConfig::default(),
+            store.clone(),
+            Arc::new(SystemClock),
+        ));
+        let admission = Arc::new(AdmissionController::new(Arc::new(SystemClock), limits));
+        Arc::new(GatewayState {
+            tenant_resolver: Arc::new(FixedTenantResolver(TenantId::new(TENANT))),
+            ingest: crate::ingest::IngestState {
+                router: metrics_router,
+                limits: IngestLimits::default(),
+                ack_deadline: std::time::Duration::from_secs(5),
+                admission: admission.clone(),
+                recovery: None,
+                provisioning: None,
+            },
+            logs_ingest: crate::logs_ingest::LogIngestState {
+                router: log_router,
+                limits: LogIngestLimits::default(),
+                ack_deadline: std::time::Duration::from_secs(5),
+                admission: admission.clone(),
+                store: store.clone(),
+                recovery: None,
+                provisioning: None,
+            },
+            traces_ingest: crate::traces_ingest::SpanIngestState {
+                router: span_router,
+                limits: SpanIngestLimits::default(),
+                ack_deadline: std::time::Duration::from_secs(5),
+                admission: admission.clone(),
+                store: store.clone(),
+                recovery: None,
+                provisioning: None,
+            },
+            admission,
+            ingest_concurrency: IngestConcurrencyController::shared(
+                IngestConcurrencyLimit::Unlimited,
+            ),
+            ingest_byte_metrics: Arc::new(IngestByteMetrics::new()),
+        })
+    }
+
+    /// A metrics export that compresses well: `points` copies of one gauge data
+    /// point, so the decompressed protobuf is many times the gzip size. The
+    /// distinction matters for the charging tests, which assert the byte rate is
+    /// charged the decompressed length, not the compressed one.
+    fn compressible_request(points: usize) -> ExportMetricsServiceRequest {
+        let data_points = (0..points)
+            .map(|_| NumberDataPoint {
+                time_unix_nano: now_ns() as u64,
+                value: Some(NumberValue::AsDouble(1.0)),
+                ..Default::default()
+            })
+            .collect();
+        ExportMetricsServiceRequest {
+            resource_metrics: vec![ResourceMetrics {
+                scope_metrics: vec![ScopeMetrics {
+                    metrics: vec![Metric {
+                        name: "requests_total".to_string(),
+                        data: Some(MetricData::Gauge(Gauge { data_points })),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+        }
+    }
+
+    /// One-member gzip of `data`.
+    fn gzip(data: &[u8]) -> Vec<u8> {
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(data).expect("gzip write");
+        encoder.finish().expect("gzip finish")
+    }
+
+    /// The fixed tenant's metrics admission usage row, or `None` if untouched.
+    fn metrics_usage(state: &GatewayState) -> Option<ravel_ingest::TenantUsage> {
+        let want = TenantId::new(TENANT).hash();
+        state
+            .admission
+            .usage_snapshot()
+            .into_iter()
+            .find(|row| row.tenant_hash == want && row.signal == Signal::Metrics)
+    }
+
+    fn gzip_headers() -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(header::CONTENT_ENCODING, HeaderValue::from_static("gzip"));
+        headers
+    }
+
+    /// ADR-0084 decision 1/4: a gzip body is decoded and ingested (200), and the
+    /// byte rate is charged the DECOMPRESSED length, not the compressed one.
+    ///
+    /// Non-vacuity: the request is chosen so `compressed_len` is far below
+    /// `decompressed_len`, and the test asserts the charge equals the latter and
+    /// differs from the former. Change `admit_and_decode_body`'s gzip
+    /// `check_byte_rate(decompressed_len)` to charge `wire_len` and this fails.
+    #[tokio::test]
+    async fn gzip_body_is_accepted_and_charged_decompressed() {
+        let state = state_with_limits(AdmissionLimits::default());
+        let encoded = compressible_request(2000).encode_to_vec();
+        let compressed = gzip(&encoded);
+        assert!(
+            compressed.len() < encoded.len(),
+            "fixture must compress: compressed={} decompressed={}",
+            compressed.len(),
+            encoded.len()
+        );
+
+        let response = export_metrics(
+            State(state.clone()),
+            gzip_headers(),
+            Bytes::from(compressed.clone()),
+        )
+        .await;
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "gzip body must be accepted"
+        );
+
+        let usage = metrics_usage(&state).expect("a metrics usage row after admitting the request");
+        assert_eq!(
+            usage.bytes_admitted_total,
+            encoded.len() as u64,
+            "the byte rate must charge the decompressed length"
+        );
+        assert_ne!(
+            usage.bytes_admitted_total,
+            compressed.len() as u64,
+            "the charge must not be the compressed length"
+        );
+
+        // The wire (compressed) size is recorded separately for /metrics.
+        let wire = state.ingest_byte_metrics.snapshot();
+        let row = wire
+            .iter()
+            .find(|r| r.tenant_hash == TenantId::new(TENANT).hash() && r.signal == Signal::Metrics)
+            .expect("a wire-bytes row");
+        assert_eq!(row.wire_bytes_total, compressed.len() as u64);
+    }
+
+    /// ADR-0084 decision 3: a body inflating past 64 MiB is rejected 413 while
+    /// expanding, without the process allocating the full expansion (the decoder
+    /// is read through `take(cap + 1)`, so at most 64 MiB + 1 is ever buffered).
+    ///
+    /// Non-vacuity: revert `decompress_gzip_capped`'s `if out.len() as u64 >
+    /// cap_u64 { return Err(TooLarge) }` and the oversized body flows on to
+    /// prost as a truncated buffer, turning the 413 into a 400.
+    #[tokio::test]
+    async fn gzip_bomb_over_cap_is_rejected_413() {
+        let state = state_with_limits(AdmissionLimits::default());
+        // Zeros compress ~1000:1, so this is a small body that inflates past the
+        // 64 MiB cap. It need not be valid OTLP: the cap trips before decode.
+        let bomb_plain = vec![0u8; MAX_DECOMPRESSED_OTLP_BODY_BYTES + 1024];
+        let compressed = gzip(&bomb_plain);
+        assert!(
+            compressed.len() < 1024 * 1024,
+            "the compressed bomb must stay small: {}",
+            compressed.len()
+        );
+
+        let response = export_metrics(State(state), gzip_headers(), Bytes::from(compressed)).await;
+        assert_eq!(
+            response.status(),
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "an over-cap decompression must be 413"
+        );
+    }
+
+    /// ADR-0084 decision 1: a concatenated multi-member gzip stream ingests ALL
+    /// members. The fixture splits one encoded request across two members, so a
+    /// decoder that stops after member one (`GzDecoder`) yields a truncated,
+    /// undecodable protobuf.
+    ///
+    /// Non-vacuity: swap `decompress_gzip_capped`'s `MultiGzDecoder` for
+    /// `GzDecoder` and only the first half decompresses, so prost sees a
+    /// truncated message and the handler returns 400 instead of 200.
+    #[tokio::test]
+    async fn gzip_multi_member_stream_ingests_all_members() {
+        let state = state_with_limits(AdmissionLimits::default());
+        let encoded = compressible_request(500).encode_to_vec();
+        let mid = encoded.len() / 2;
+        assert!(mid > 0 && mid < encoded.len(), "need a real two-way split");
+        // Two independently-framed gzip members, concatenated. Each is a
+        // complete gzip stream; MultiGzDecoder decodes both and yields the full
+        // `encoded`, GzDecoder would yield only the first half.
+        let mut two_member = gzip(&encoded[..mid]);
+        two_member.extend_from_slice(&gzip(&encoded[mid..]));
+
+        // Sanity: our own capped decoder reconstructs the whole thing.
+        let round_trip =
+            decompress_gzip_capped(&two_member, MAX_DECOMPRESSED_OTLP_BODY_BYTES).expect("decodes");
+        assert_eq!(round_trip, encoded, "both members must decompress");
+
+        let response = export_metrics(
+            State(state.clone()),
+            gzip_headers(),
+            Bytes::from(two_member),
+        )
+        .await;
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "both members must ingest as one request"
+        );
+        let usage = metrics_usage(&state).expect("a metrics usage row");
+        assert_eq!(
+            usage.bytes_admitted_total,
+            encoded.len() as u64,
+            "the charge covers the whole decompressed stream, not one member"
+        );
+    }
+
+    /// ADR-0084 decision 1: trailing bytes after a well-formed gzip stream are a
+    /// 400, never silently truncated.
+    #[tokio::test]
+    async fn gzip_trailing_garbage_is_rejected_400() {
+        let state = state_with_limits(AdmissionLimits::default());
+        let encoded = compressible_request(10).encode_to_vec();
+        let mut body = gzip(&encoded);
+        body.extend_from_slice(b"trailing junk not a gzip header");
+
+        let response = export_metrics(State(state), gzip_headers(), Bytes::from(body)).await;
+        assert_eq!(
+            response.status(),
+            StatusCode::BAD_REQUEST,
+            "trailing bytes after the stream must be 400"
+        );
+    }
+
+    /// ADR-0084 decision 1: an unsupported single coding, and any multi-coding
+    /// list, are 415 (never treated as identity, which would hand prost a
+    /// compressed body and produce the misleading 400 this ADR removes).
+    #[tokio::test]
+    async fn unsupported_content_encoding_is_415() {
+        for value in ["deflate", "br", "gzip, gzip", "deflate, gzip"] {
+            let state = state_with_limits(AdmissionLimits::default());
+            let encoded = compressible_request(10).encode_to_vec();
+            let mut headers = HeaderMap::new();
+            headers.insert(
+                header::CONTENT_ENCODING,
+                HeaderValue::from_str(value).unwrap(),
+            );
+            let response = export_metrics(State(state), headers, Bytes::from(gzip(&encoded))).await;
+            assert_eq!(
+                response.status(),
+                StatusCode::UNSUPPORTED_MEDIA_TYPE,
+                "Content-Encoding {value:?} must be 415"
+            );
+        }
+    }
+
+    /// ADR-0084 decision 1/4: the identity path is byte-for-byte unchanged. An
+    /// uncompressed body (absent Content-Encoding) is charged its wire length,
+    /// exactly as today, and `x-gzip` is honored as a gzip alias.
+    #[tokio::test]
+    async fn identity_path_charge_is_wire_length() {
+        let state = state_with_limits(AdmissionLimits::default());
+        let encoded = compressible_request(50).encode_to_vec();
+
+        let response = export_metrics(
+            State(state.clone()),
+            HeaderMap::new(),
+            Bytes::from(encoded.clone()),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let usage = metrics_usage(&state).expect("a metrics usage row");
+        assert_eq!(
+            usage.bytes_admitted_total,
+            encoded.len() as u64,
+            "identity charge must equal the wire body length, as before this change"
+        );
+    }
+
+    /// ADR-0084 decision 1: `x-gzip` is an accepted alias for `gzip`.
+    #[tokio::test]
+    async fn x_gzip_alias_is_accepted() {
+        let state = state_with_limits(AdmissionLimits::default());
+        let encoded = compressible_request(50).encode_to_vec();
+        let mut headers = HeaderMap::new();
+        headers.insert(header::CONTENT_ENCODING, HeaderValue::from_static("X-Gzip"));
+        let response = export_metrics(State(state), headers, Bytes::from(gzip(&encoded))).await;
+        assert_eq!(response.status(), StatusCode::OK, "x-gzip must be accepted");
+    }
+
+    /// ADR-0084 decision 4: an already-over-rate tenant sending a compressed body
+    /// is rejected 429 by the compressed-size pre-check, WITHOUT the decompressor
+    /// running.
+    ///
+    /// The body is deliberately not valid gzip. If the pre-check runs first (as
+    /// it must), the request is 429 and the bytes are never fed to the decoder;
+    /// if decompression ran before the check, the invalid body would surface as
+    /// a 400. Asserting 429 therefore proves the decompressor did not run.
+    ///
+    /// Non-vacuity: delete the `peek_byte_rate` pre-check in
+    /// `admit_and_decode_body`'s gzip arm and this returns 400 (the invalid body
+    /// reaches the decoder).
+    #[tokio::test]
+    async fn over_rate_compressed_body_pre_check_rejects_429_without_decompressing() {
+        // A tight byte-rate bucket: burst 16 bytes, so any real body is over.
+        let limits = AdmissionLimits {
+            ingest_byte_rate: RateLimit::Bounded {
+                per_sec: 1,
+                burst: 16,
+            },
+            ..AdmissionLimits::default()
+        };
+        let state = state_with_limits(limits);
+        // Not a gzip stream at all, and larger than the 16-byte burst.
+        let not_gzip = Bytes::from(vec![0x42u8; 1024]);
+
+        let response = export_metrics(State(state.clone()), gzip_headers(), not_gzip).await;
+        assert_eq!(
+            response.status(),
+            StatusCode::TOO_MANY_REQUESTS,
+            "the compressed-size pre-check must reject before decompressing"
+        );
+        let usage = metrics_usage(&state).expect("a metrics usage row after the rejection");
+        assert_eq!(
+            usage.requests_rejected_byte_rate_total, 1,
+            "the pre-check rejection is counted as a byte-rate rejection"
+        );
+        assert_eq!(
+            usage.bytes_admitted_total, 0,
+            "nothing is admitted and no tokens are consumed on the pre-check rejection"
+        );
     }
 }

--- a/services/ravel-server/src/tests.rs
+++ b/services/ravel-server/src/tests.rs
@@ -195,6 +195,9 @@ fn harness(store: Arc<dyn ObjectStoreBackend>, configured: HashSet<TenantHash>) 
         ),
         distrib: None,
         durable_auth: None,
+        ingest_byte_metrics: std::sync::Arc::new(
+            crate::ingest_byte_metrics::IngestByteMetrics::new(),
+        ),
     });
 
     Harness {

--- a/services/ravel-server/src/wire_byte_count.rs
+++ b/services/ravel-server/src/wire_byte_count.rs
@@ -8,9 +8,16 @@
 //! for a [`CountingBody`] that parses gRPC's length-delimited message
 //! framing directly off the wire bytes as tonic's decoder reads them, and
 //! places the resulting [`WireByteCounter`] in the request's extensions
-//! before the inner service (and eventually the handler) runs. This also
-//! aligns the charged quantity with the HTTP ingest path, which has always
-//! charged wire body bytes.
+//! before the inner service (and eventually the handler) runs.
+//!
+//! Since ADR-0084 the charged quantity aligns with the HTTP ingest path on the
+//! *decompressed* size, not the wire size. An uncompressed frame is charged its
+//! wire bytes exactly as before; a frame whose 1-byte compression flag is set
+//! is charged the decoded message's size instead (via [`wire_request_bytes`]'s
+//! `encoded_len` of the decoded protobuf), so a tenant that gzips its gRPC
+//! export and one that does not are charged the same for identical telemetry.
+//! The parser already reads that flag per frame, so the basis is available
+//! where the charge is made.
 //!
 //! Parsing frames at the body level rather than reading a single running
 //! total matters for a streaming call (OTAP): the underlying transport can
@@ -40,53 +47,112 @@ use std::task::{Context, Poll};
 use bytes::Bytes;
 use http_body::{Body, Frame, SizeHint};
 use parking_lot::Mutex;
+use prost::Message;
 use tonic::body::Body as TonicBody;
 use tonic::{Request, Status};
 use tower::{Layer, Service};
+
+/// One completed gRPC message frame's admission accounting: whether its 1-byte
+/// compression flag was set, and its total wire length (the 5-byte gRPC frame
+/// header plus payload). For a compressed frame the wire length is the
+/// *compressed* size, which is not what the byte rate charges (ADR-0084
+/// decision 4); the flag is what lets [`wire_request_bytes`] switch the charge
+/// to the decoded message size instead.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct FrameCharge {
+    compressed: bool,
+    wire_bytes: u64,
+}
 
 /// Shared, cloneable handle to the completed gRPC message frames read off one
 /// request's (or stream's) body so far, in arrival order. Placed in the
 /// request's extensions by [`WireByteCountLayer`]; read back by the handler
 /// via [`wire_request_bytes`] or [`wire_byte_counter`].
 #[derive(Clone)]
-pub struct WireByteCounter(Arc<Mutex<VecDeque<u64>>>);
+pub struct WireByteCounter(Arc<Mutex<VecDeque<FrameCharge>>>);
 
 impl WireByteCounter {
     fn new() -> Self {
         WireByteCounter(Arc::new(Mutex::new(VecDeque::new())))
     }
 
-    fn push_message(&self, total_bytes: u64) {
-        self.0.lock().push_back(total_bytes);
+    fn push_message(&self, compressed: bool, total_bytes: u64) {
+        self.0.lock().push_back(FrameCharge {
+            compressed,
+            wire_bytes: total_bytes,
+        });
+    }
+
+    /// Pops the next completed frame's accounting, in the order frames
+    /// completed on the wire. `None` if no complete frame has been counted yet.
+    fn pop_frame(&self) -> Option<FrameCharge> {
+        self.0.lock().pop_front()
     }
 
     /// Pops the next completed message's total wire length (its 5-byte gRPC
-    /// frame header plus payload), in the order frames completed on the
-    /// wire. `None` if no complete frame has been counted yet.
+    /// frame header plus payload), in the order frames completed on the wire.
+    /// `None` if no complete frame has been counted yet. Used by the streaming
+    /// (OTAP) path, which does not enable `accept_compressed` and so never sees
+    /// a compressed frame; the unary OTLP path uses [`wire_request_bytes`],
+    /// which honors the compression flag.
     pub fn pop_message_bytes(&self) -> Option<u64> {
-        self.0.lock().pop_front()
+        self.pop_frame().map(|frame| frame.wire_bytes)
     }
 }
 
-/// Reads the wire-byte count for a unary gRPC request's one message, charged
-/// by [`WireByteCountLayer`]. `Err` if the layer was never installed on the
-/// listener this request arrived on (a wiring bug, not something a client
-/// can trigger), or if, contrary to the gRPC wire format's guarantee of
-/// exactly one message frame per unary call, no complete frame was counted.
-pub fn wire_request_bytes<T>(request: &Request<T>) -> Result<u64, Status> {
+/// The admission accounting for a unary gRPC request's one message
+/// (ADR-0084 decision 4/5): what to charge the byte rate, and the wire size the
+/// tenant actually sent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RequestCharge {
+    /// Bytes to charge the byte-rate bucket: the decoded message size for a
+    /// compressed frame, the wire length otherwise. Equal to `wire_bytes` for
+    /// an uncompressed frame.
+    pub charge_bytes: u64,
+    /// The frame's total wire length (the compressed size when the frame's
+    /// compression flag was set), recorded per tenant for
+    /// `ravel_ingest_wire_bytes_total`.
+    pub wire_bytes: u64,
+}
+
+/// The byte-rate accounting for a unary gRPC request's one message, from the
+/// frame [`WireByteCountLayer`] counted (ADR-0084 decisions 4, 5).
+///
+/// For an uncompressed frame the charge is the wire length exactly as before.
+/// For a frame whose compression flag is set, the wire length is the
+/// *compressed* size, which would charge a compressing tenant less than an
+/// uncompressing one for identical telemetry; so the charge is the decoded
+/// message's size (`request.get_ref().encoded_len()`) instead. Tonic has
+/// already decoded the message by the time the handler runs, so the decoded
+/// value is in hand with no re-decode.
+///
+/// `Err` if the layer was never installed on the listener this request arrived
+/// on (a wiring bug, not something a client can trigger), or if, contrary to
+/// the gRPC wire format's guarantee of exactly one message frame per unary
+/// call, no complete frame was counted.
+pub fn wire_request_bytes<T: Message>(request: &Request<T>) -> Result<RequestCharge, Status> {
     let counter = wire_byte_counter(request)?;
-    let bytes = counter.pop_message_bytes();
+    let frame = counter.pop_frame();
     // Tonic already decoded this request's one message before calling the
     // handler, which means `CountingBody` -- sitting underneath that same
     // decode, watching the same bytes -- must already have a completed frame
     // queued. A `None` here would mean the two disagree about how many bytes
     // make up this message.
     debug_assert!(
-        bytes.is_some(),
+        frame.is_some(),
         "unary gRPC request decoded but WireByteCountLayer counted no complete message frame"
     );
-    bytes.ok_or_else(|| {
+    let frame = frame.ok_or_else(|| {
         Status::internal("ingest admission: wire-byte count unavailable for this request")
+    })?;
+    let charge_bytes = if frame.compressed {
+        request.get_ref().encoded_len() as u64
+    } else {
+        frame.wire_bytes
+    };
+    Ok(RequestCharge {
+        charge_bytes,
+        wire_bytes: frame.wire_bytes,
     })
 }
 
@@ -164,8 +230,15 @@ struct FrameParser {
 }
 
 enum FrameState {
-    Header { buf: [u8; 5], filled: u8 },
-    Payload { remaining: u32, total: u64 },
+    Header {
+        buf: [u8; 5],
+        filled: u8,
+    },
+    Payload {
+        remaining: u32,
+        total: u64,
+        compressed: bool,
+    },
 }
 
 impl FrameParser {
@@ -198,15 +271,26 @@ impl FrameParser {
                     if usize::from(*filled) < 5 {
                         return;
                     }
+                    // Byte 0 is the gRPC compression flag: nonzero means the
+                    // payload is compressed with the call's Message-Encoding
+                    // (ADR-0084 decision 4 charges such a frame its decoded
+                    // size, not this wire length). Bytes 1..5 are the payload
+                    // length, big-endian.
+                    let compressed = buf[0] != 0;
                     let len = u32::from_be_bytes([buf[1], buf[2], buf[3], buf[4]]);
                     self.state = FrameState::Payload {
                         remaining: len,
                         total: 5 + u64::from(len),
+                        compressed,
                     };
                 }
-                FrameState::Payload { remaining, total } => {
+                FrameState::Payload {
+                    remaining,
+                    total,
+                    compressed,
+                } => {
                     if *remaining == 0 {
-                        counter.push_message(*total);
+                        counter.push_message(*compressed, *total);
                         self.state = FrameState::Header {
                             buf: [0; 5],
                             filled: 0,
@@ -260,5 +344,133 @@ impl Body for CountingBody {
 
     fn size_hint(&self) -> SizeHint {
         self.inner.size_hint()
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use opentelemetry_proto::tonic::metrics::v1::metric::Data as MetricData;
+    use opentelemetry_proto::tonic::metrics::v1::number_data_point::Value as NumberValue;
+    use opentelemetry_proto::tonic::metrics::v1::{Gauge, Metric, NumberDataPoint, ScopeMetrics};
+    use opentelemetry_proto::tonic::{
+        collector::metrics::v1::ExportMetricsServiceRequest, metrics::v1::ResourceMetrics,
+    };
+
+    use super::*;
+
+    /// Builds one gRPC length-prefixed frame: a 1-byte compression flag, a
+    /// 4-byte big-endian payload length, then `payload`.
+    fn frame(compressed: bool, payload: &[u8]) -> Vec<u8> {
+        let mut out = Vec::with_capacity(5 + payload.len());
+        out.push(if compressed { 1 } else { 0 });
+        out.extend_from_slice(&(payload.len() as u32).to_be_bytes());
+        out.extend_from_slice(payload);
+        out
+    }
+
+    /// The frame parser reads the 1-byte compression flag per frame, so a
+    /// compressed frame's completed accounting carries `compressed = true` and
+    /// an uncompressed one `false`, each with the full wire length.
+    #[test]
+    fn frame_parser_reports_compression_flag_per_frame() {
+        let counter = WireByteCounter::new();
+        let mut parser = FrameParser::new();
+        parser.feed(&frame(true, &[0xaa; 7]), &counter);
+        parser.feed(&frame(false, &[0xbb; 3]), &counter);
+
+        assert_eq!(
+            counter.pop_frame(),
+            Some(FrameCharge {
+                compressed: true,
+                wire_bytes: 5 + 7,
+            })
+        );
+        assert_eq!(
+            counter.pop_frame(),
+            Some(FrameCharge {
+                compressed: false,
+                wire_bytes: 5 + 3,
+            })
+        );
+        assert_eq!(counter.pop_frame(), None);
+    }
+
+    fn sample_request() -> ExportMetricsServiceRequest {
+        ExportMetricsServiceRequest {
+            resource_metrics: vec![ResourceMetrics {
+                scope_metrics: vec![ScopeMetrics {
+                    metrics: vec![Metric {
+                        name: "requests_total".to_string(),
+                        data: Some(MetricData::Gauge(Gauge {
+                            data_points: vec![NumberDataPoint {
+                                time_unix_nano: 1,
+                                value: Some(NumberValue::AsDouble(1.0)),
+                                ..Default::default()
+                            }],
+                        })),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+        }
+    }
+
+    /// ADR-0084 decision 4: a compressed gRPC frame is charged the DECODED
+    /// message size, not its (compressed) wire length, so a tenant that gzips
+    /// its gRPC export and one that does not are charged the same for identical
+    /// telemetry.
+    ///
+    /// Non-vacuity: replace `wire_request_bytes`'s `if frame.compressed {
+    /// encoded_len } else { wire }` with an unconditional `frame.wire_bytes`,
+    /// and this test sees the (deliberately different) wire length instead of
+    /// the decoded size and fails. The frame here has its compression flag SET;
+    /// a test that left it clear would pass against the unmodified layer.
+    #[test]
+    fn compressed_frame_is_charged_decoded_size_not_wire_size() {
+        let message = sample_request();
+        let decoded_len = message.encoded_len() as u64;
+
+        // A wire length deliberately unequal to the decoded size, standing in
+        // for the compressed frame's on-the-wire size.
+        let wire_len = decoded_len + 4096;
+        let counter = WireByteCounter::new();
+        counter.push_message(true, wire_len);
+
+        let mut request = Request::new(message);
+        request.extensions_mut().insert(counter);
+
+        let charge = wire_request_bytes(&request).expect("charge available");
+        assert_eq!(
+            charge.charge_bytes, decoded_len,
+            "a compressed frame charges the decoded message size"
+        );
+        assert_ne!(
+            charge.charge_bytes, wire_len,
+            "a compressed frame must not charge the compressed wire length"
+        );
+        assert_eq!(
+            charge.wire_bytes, wire_len,
+            "the wire length is still reported for /metrics"
+        );
+    }
+
+    /// An uncompressed frame is charged its wire length exactly as before this
+    /// change, so nothing shifts for a client that does not compress.
+    #[test]
+    fn uncompressed_frame_is_charged_wire_size() {
+        let message = sample_request();
+        let wire_len = message.encoded_len() as u64 + 5;
+        let counter = WireByteCounter::new();
+        counter.push_message(false, wire_len);
+
+        let mut request = Request::new(message);
+        request.extensions_mut().insert(counter);
+
+        let charge = wire_request_bytes(&request).expect("charge available");
+        assert_eq!(charge.charge_bytes, wire_len);
+        assert_eq!(charge.wire_bytes, wire_len);
     }
 }

--- a/services/ravel-server/tests/query_cost_surfaces.rs
+++ b/services/ravel-server/tests/query_cost_surfaces.rs
@@ -204,6 +204,9 @@ fn surfaces(store: Arc<dyn ObjectStoreBackend>, tenant: &TenantId) -> Surfaces {
         ),
         distrib: None,
         durable_auth: None,
+        ingest_byte_metrics: std::sync::Arc::new(
+            ravel_server::ingest_byte_metrics::IngestByteMetrics::new(),
+        ),
     });
 
     Surfaces {
@@ -602,6 +605,9 @@ mod flight {
                 ),
             distrib: None,
             durable_auth: None,
+            ingest_byte_metrics: std::sync::Arc::new(
+                ravel_server::ingest_byte_metrics::IngestByteMetrics::new(),
+            ),
         });
         let scrape = scrape(&metrics).await;
         let expected = vec![


### PR DESCRIPTION
The OpenTelemetry Collector and Grafana Alloy send gzip by default. Ravel
rejected it on both OTLP transports, so a stock client failed on every export
with an HTTP 400 reading "invalid OTLP payload" and no hint that compression
was the cause. Ravel's own quickstart shipped with this defect and carries a
`compression: none` workaround.

HTTP now dispatches on `Content-Encoding`: absent or identity keeps the current
path byte for byte, gzip and its RFC 9110 alias x-gzip are decoded, and any
other coding or any multi-coding list is 415 rather than being silently treated
as identity. gRPC gains accept_compressed on the three OTLP services.

Two things this had to get right beyond adding a decoder.

Decompression is bounded while it expands, not after, following
ravel-otap's decompress_capped: a body inflating past 64 MiB is refused as it
inflates rather than after the allocation the cap exists to prevent. The
decoder is MultiGzDecoder, not GzDecoder, because a plain GzDecoder stops at
the first member of a concatenated stream and would acknowledge a write while
silently dropping the rest.

The ingest byte rate now charges the decompressed size, so a tenant cannot
multiply its allowance by its compression ratio. That change had to reach gRPC
as well: WireByteCountLayer counts compressed frame bytes, so enabling
accept_compressed alone would have charged the two transports differently for
identical telemetry. A compressed frame is now charged its decoded size. A
compressed-size pre-check keeps an over-rate rejection cheap, since the
compressed length is a strict lower bound on the decompressed one.

Adds flate2 to the workspace. The existing zstd cannot decode gzip.

Adds AdmissionController::peek_byte_rate to ravel-ingest, outside this ticket's
named scope and reported rather than hidden: ADR-0084's non-consuming pre-check
was not expressible through check_byte_rate, which both consumes tokens and
increments the admitted counter. The addition is purely additive and mirrors
try_take's refill and retry-after exactly.

Reviewed with both vacuity traps reproduced: swapping MultiGzDecoder for
GzDecoder and forcing the gRPC charge to the wire length each flip their named
test to failing.

The end-to-end proof is #215, which removes the quickstart's workaround so a
stock collector sends gzip through the shipping binary.

Fixes: #214
Refs: #115
Refs: #212