### PR TITLE
docs: remove the quickstart gzip workaround and document compressed ingest

### DIFF
--- a/crates/ravel-ingest/src/admission.rs
+++ b/crates/ravel-ingest/src/admission.rs
@@ -1360,4 +1360,144 @@ mod tests {
             .expect("a logs usage row exists after a clock rejection");
         assert_eq!(logs_row.requests_rejected_clock_total, 1);
     }
+
+    /// ADR-0084 decision 4: `TokenBucket::peek` and an immediately following
+    /// `try_take` at the SAME `now_ns` must agree on whether `amount` is
+    /// available. This is the correctness contract the gzip pre-check relies on:
+    /// a peek that says "would fit" must be followed by a take that does fit
+    /// (and vice versa), or the gzip path would 429 a request the charge would
+    /// have admitted, or admit one the charge then rejects.
+    ///
+    /// Non-vacuity: change `peek`'s `self.refill(now_ns)` to a no-op (drop the
+    /// line) and the "drained then refilled, amount exactly the refilled
+    /// balance" case fails: peek sees 0 tokens and reports unavailable while the
+    /// refilling `try_take` accepts. Change `peek`'s `self.tokens >= amount` to
+    /// `>` and the same exact-balance case fails the other way.
+    #[test]
+    fn peek_and_take_agree_at_same_instant() {
+        // Peek then take on ONE bucket at the same instant, exactly as the
+        // gzip path calls peek_byte_rate then check_byte_rate. peek takes no
+        // tokens, so the following take at the same `now_ns` sees the same
+        // balance; their Ok/Err verdict must match.
+        fn assert_agree(mut bucket: TokenBucket, amount: u64, now_ns: i64) {
+            let peeked = bucket.peek(amount, now_ns).is_ok();
+            let taken = bucket.try_take(amount, now_ns).is_ok();
+            assert_eq!(
+                peeked, taken,
+                "peek/try_take disagree for amount={amount} at now={now_ns}"
+            );
+        }
+
+        // Fresh bucket: burst 100, rate 100/s, full at t=0.
+        let fresh = TokenBucket::new(100, 100, 0);
+        assert_agree(fresh, 0, 0); // trivially available
+        assert_agree(fresh, 100, 0); // exactly the full burst: available
+        assert_agree(fresh, 101, 0); // one past burst: unavailable
+
+        // Drained, then refilled by exactly 50 tokens after 0.5s at 100/s. The
+        // exact-balance amount (50) is the discriminating case: it catches both
+        // a peek that fails to refill and a peek using `>` instead of `>=`.
+        let mut drained = TokenBucket::new(100, 100, 0);
+        drained.try_take(100, 0).expect("drain the fresh burst");
+        assert_agree(drained, 50, 500_000_000); // exactly the refilled balance
+        assert_agree(drained, 51, 500_000_000); // one past it: unavailable
+        assert_agree(drained, 0, 500_000_000);
+    }
+
+    /// ADR-0084 decision 4: a `peek` that fails reports the same `retry_after`
+    /// wait a `try_take` would, so the gzip pre-check's 429 `Retry-After` is the
+    /// value the tenant would really wait. Neither consumes on failure, so the
+    /// take at the same instant sees the identical deficit.
+    #[test]
+    fn peek_failure_reports_same_retry_after_as_try_take() {
+        let mut bucket = TokenBucket::new(100, 100, 0);
+        bucket.try_take(100, 0).expect("drain the burst");
+        // 100 short at 100/s is a 1s wait; assert peek and take agree on it
+        // exactly rather than hard-coding the arithmetic.
+        let peek_err = bucket.peek(100, 0).expect_err("empty bucket, peek fails");
+        let take_err = bucket
+            .try_take(100, 0)
+            .expect_err("empty bucket, take fails");
+        assert_eq!(
+            peek_err, take_err,
+            "peek and try_take must report the same retry_after"
+        );
+        assert!(peek_err > 0);
+    }
+
+    /// ADR-0084 decision 4: the `rate_per_sec == 0` branch behaves identically
+    /// in `peek` and `try_take`. A zero-rate bucket never refills, so an amount
+    /// over the current balance is unsatisfiable and both report `i64::MAX`.
+    #[test]
+    fn peek_and_take_agree_when_rate_is_zero() {
+        // rate 0, burst 10, full at t=0.
+        let mut within = TokenBucket::new(0, 10, 0);
+        assert!(within.peek(10, 0).is_ok());
+        assert!(within.try_take(10, 0).is_ok(), "within burst is available");
+
+        let mut over = TokenBucket::new(0, 10, 1_000_000_000);
+        // Elapsed time credits nothing at rate 0, so 20 stays unsatisfiable.
+        let peek_err = over
+            .peek(20, 2_000_000_000)
+            .expect_err("rate 0, over burst");
+        let take_err = over
+            .try_take(20, 2_000_000_000)
+            .expect_err("rate 0, over burst");
+        assert_eq!(peek_err, i64::MAX, "rate 0 reports an unbounded wait");
+        assert_eq!(
+            peek_err, take_err,
+            "the rate==0 branch must match in peek and try_take"
+        );
+    }
+
+    /// ADR-0084 decision 4: a request that PASSES the compressed-size pre-check
+    /// (`peek_byte_rate`) and then FAILS the real charge (`check_byte_rate` on
+    /// the larger decompressed size) is counted as exactly one byte-rate
+    /// rejection, not two. The pre-check consumes nothing and, on success,
+    /// records nothing; only the failing charge increments the counter.
+    ///
+    /// Non-vacuity: make `peek_byte_rate`'s success arm increment
+    /// `requests_rejected_byte_rate_total` (or count on the pass path at all)
+    /// and this reads 2.
+    #[test]
+    fn peek_pass_then_charge_fail_counts_one_rejection() {
+        let clock = TestClock::new(0);
+        let controller = AdmissionController::new(clock.clone(), AdmissionLimits::default());
+        let tenant = TenantId::new("acme");
+        controller.set_tenant_limits(
+            tenant.clone(),
+            AdmissionLimits {
+                ingest_byte_rate: RateLimit::Bounded {
+                    per_sec: 1,
+                    burst: 100,
+                },
+                ..tight_limits(u64::MAX)
+            },
+        );
+
+        // Pre-check on a small compressed size (50 <= 100): passes, no charge,
+        // no counter.
+        controller
+            .peek_byte_rate(&tenant, Signal::Metrics, 50, clock.now())
+            .expect("the compressed-size pre-check passes");
+        // Real charge on the larger decompressed size (200 > 100): rejected.
+        let rejection = controller
+            .check_byte_rate(&tenant, Signal::Metrics, 200, clock.now())
+            .expect_err("the decompressed charge exceeds the burst");
+        assert_eq!(rejection.reason, RequestRejectionReason::ByteRate);
+
+        let snapshot = controller.usage_snapshot();
+        let row = snapshot
+            .iter()
+            .find(|row| row.tenant_hash == tenant.hash() && row.signal == Signal::Metrics)
+            .expect("a metrics usage row after the rejection");
+        assert_eq!(
+            row.requests_rejected_byte_rate_total, 1,
+            "a peek-pass then charge-fail is exactly one rejection, not two"
+        );
+        assert_eq!(
+            row.bytes_admitted_total, 0,
+            "nothing is admitted when the charge is rejected"
+        );
+    }
 }

--- a/deploy/otel/collector-config.yaml
+++ b/deploy/otel/collector-config.yaml
@@ -37,11 +37,6 @@ exporters:
     endpoint: http://ravel-server:4318
     auth:
       authenticator: bearertokenauth
-    # The exporter defaults to gzip. Ravel's OTLP HTTP ingest does not decode
-    # compressed bodies yet (#115), and rejects them with HTTP 400 "invalid
-    # OTLP payload". Without this, every export the collector sends is dropped
-    # and the quickstart's Grafana dashboard stays empty.
-    compression: none
 
 service:
   extensions: [bearertokenauth]

--- a/docs/guides/ingest.md
+++ b/docs/guides/ingest.md
@@ -25,6 +25,87 @@ underneath. Traces are also ingested, over the same two transports: `POST
 /v1/traces` over HTTP and `opentelemetry.proto.collector.trace.v1.TraceService/Export`
 over gRPC. No transport accepts profiles yet.
 
+## Compressed requests (ADR-0084)
+
+Ravel accepts gzip-compressed OTLP bodies on both transports. A stock
+OpenTelemetry Collector and a stock Grafana Alloy both default to gzip, so no
+client configuration is needed.
+
+### OTLP HTTP
+
+`POST /v1/metrics`, `/v1/logs`, and `/v1/traces` dispatch on `Content-Encoding`:
+
+- `gzip`, or its RFC 9110 alias `x-gzip`, is decompressed and then decoded.
+  The comparison is case-insensitive: `GZIP`, `gzip`, and `X-Gzip` are the same
+  coding.
+- An absent header, an empty value, or `identity` is the body as-is, byte for
+  byte the pre-ADR-0084 path. An uncompressed client sees no change.
+- Any other single coding (`deflate`, `br`, ...), and any multi-coding list
+  (`gzip, gzip`, `deflate, gzip`), is rejected with `415 Unsupported Media
+  Type`. Ravel chains no decoders and never guesses at one member of a list.
+  The 415 body names what is supported.
+
+Two independent size caps bound a gzip request:
+
+- The **compressed** body is capped at 16 MiB by the existing wire body limit
+  (`DefaultBodyLimit`). This is the same Layer 1 cap that bounds an
+  uncompressed body.
+- The **decompressed** body is capped at 64 MiB, returning `413 Payload Too
+  Large`. The cap is enforced *while* the body is inflated, not after: the
+  decoder is read through `take(cap + 1)`, so a decompression bomb is refused
+  as it expands rather than after 64 MiB has been allocated.
+
+The two caps are independent, exactly as they are for Remote Write. A 16 MiB
+compressed body that would inflate past 64 MiB is a 413; a body over 16 MiB
+compressed never reaches the decompressor.
+
+A gzip body is decoded as a whole stream with multi-member semantics: a
+concatenated multi-member gzip stream (legal gzip that ordinary tooling
+produces) is decoded in full, under the single 64 MiB cap across all members.
+Trailing bytes after a well-formed stream ends are `400 Bad Request`, never
+silently truncated: silent truncation would be data loss on an acknowledged
+write.
+
+### OTLP gRPC
+
+The three gRPC services accept gzip via tonic's `accept_compressed`. Here the
+decompressed size is bounded at **16 MiB**, not HTTP's 64 MiB. tonic applies
+`max_decoding_message_size` to both the compressed frame and the decompressed
+output (checking the framed length first, then limiting the inflate buffer to
+the same value), so the one 16 MiB knob caps both halves. Raising it to match
+HTTP would also raise the ceiling on uncompressed gRPC messages, which is a
+separate change; ADR-0084 accepts the asymmetry. A batch that inflates to
+40 MiB is accepted over HTTP and rejected over gRPC with `resource_exhausted`.
+
+Ravel does not compress responses (`send_compressed` is off): OTLP export
+responses are small partial-success records, so compressing them buys nothing.
+
+### Byte-rate charging differs by path
+
+The per-tenant ingest byte rate (Layer 2) is charged on **different bases** by
+path, and an operator sizing limits must know it:
+
+| Path | Charged quantity |
+|---|---|
+| OTLP HTTP / gRPC | Decompressed size |
+| Prometheus Remote Write | Compressed size |
+
+OTLP charges the decompressed size (ADR-0084 decision 4) so that two tenants
+sending identical telemetry are charged identically regardless of a client-side
+compression setting. Remote Write still charges the compressed body length;
+ADR-0084 deliberately leaves that alone, and the inconsistency is recorded
+there rather than papered over. The practical effect: a gzip OTLP client's
+effective byte-rate allowance drops relative to an uncompressed client of the
+same nominal rate, because it is now charged for what it actually sent rather
+than what it put on the wire.
+
+To keep rejection cheap for an already-over-rate tenant, the gzip path does a
+compressed-size pre-check first: the compressed length is a strict lower bound
+on the decompressed length, so if even the compressed size exceeds the tenant's
+available tokens the request is rejected `429 Too Many Requests` before
+anything is decompressed and without consuming tokens. Only if the pre-check
+passes is the body inflated and the real charge made on the decompressed size.
+
 ## Authentication
 
 Every request must resolve to a tenant. If it does not, Ravel rejects it with

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -257,12 +257,24 @@ gives its alert rules.
 |---|---|
 | `ravel_admission_active_series` | Gauge. Active series (metrics) or streams (logs) tracked for the active cap, by tenant and signal. |
 | `ravel_admission_admitted_total` | Requests admitted past the ingest byte-rate layer, by tenant and signal. |
-| `ravel_admission_admitted_bytes_total` | Wire body bytes admitted past the ingest byte-rate layer, by tenant and signal. |
+| `ravel_admission_admitted_bytes_total` | Charged (decompressed) bytes admitted past the ingest byte-rate layer, by tenant and signal. For a gzip OTLP request this is the decompressed size (ADR-0084 decision 4); for an uncompressed request it equals the wire size. |
+| `ravel_ingest_wire_bytes_total` | Wire (on-the-wire, compressed when the client compressed) OTLP request-body bytes admitted, by tenant and signal (ADR-0084 decision 5). |
 | `ravel_admission_rejected_total` | Admission rejections, by tenant, signal, and reason. |
 
 The `reason` label carries `byte_rate`, `series_rate`, or `series_cap`. The
 active-streams count for logs renders under `ravel_admission_active_series`
 with `signal="logs"`, not under a separate metric name.
+
+`ravel_ingest_wire_bytes_total` is emitted from the ingest byte-metrics tracker
+rather than the admission snapshot, so its name carries the `ravel_ingest_`
+prefix, but it folds tenants by the same allowlist and is read alongside the
+admission counters. The ratio
+`ravel_admission_admitted_bytes_total / ravel_ingest_wire_bytes_total` is the
+tenant's effective compression factor. It distinguishes two situations a raw
+admitted-bytes rise cannot: a tenant that genuinely grew its telemetry (the
+ratio holds roughly steady) from one that turned client-side compression off
+(admitted bytes flat, wire bytes jump, ratio falls toward 1). The two need
+different responses, so read the ratio, not either counter alone.
 
 ### Per-query cost (`ravel_query_*`)
 

--- a/docs/guides/operations.md
+++ b/docs/guides/operations.md
@@ -134,6 +134,28 @@ caps it would have been 1.4-2.2 GiB. Operators who need a higher per-tenant
 active-series ceiling can still set it explicitly in `[tenants.<id>]`
 (or `unlimited`), sized against this same formula.
 
+### Transient gzip decompression memory (ADR-0084)
+
+Accepting gzip on OTLP HTTP adds a second, transient, memory demand that
+ADR-0069's ingest buffer budget does not account for. A gzip request is
+decompressed into a fresh buffer bounded by the 64 MiB HTTP decompressed cap,
+held only while the request holds an ingest concurrency permit
+(`--max-inflight-ingest-requests`, default 1024). Worst-case peak decompression
+memory is therefore:
+
+```
+max_inflight_ingest_requests × 64 MiB
+```
+
+At the default 1024 permits that is a 64 GiB worst case, far past what the
+small hosts this project targets have. On such a host, size
+`--max-inflight-ingest-requests` down so this product fits the headroom you
+have alongside the ingest buffer budget and the active-identity memory above;
+the three are additive and none is bounded by the others. gRPC's transient
+decompression is bounded at 16 MiB per in-flight request by
+`max_decoding_message_size`, so the same arithmetic with a 16 MiB factor
+applies to the gRPC side.
+
 ## `ravel-cli` flags
 
 Every subcommand shares the same store flags as `ravel-server`


### PR DESCRIPTION
Ravel now accepts gzip on both OTLP transports, so the quickstart's
collector no longer needs `compression: none`. Removing it returns the
exporter to a stock OpenTelemetry Collector configuration, which sends
gzip by default.

That makes this pull request the epic's end-to-end proof. The quickstart
CI job already asserts, via scripts/check-collector-delivery.sh, that the
collector delivered points and dropped none. With the workaround gone
that assertion runs against real gzip, through the shipping binary, over
a real network entry point. If the gzip implementation were wrong, this
job would fail.

Documents the contract as implemented rather than as intended: the status
codes, the two independent caps, multi-member handling, the gRPC
asymmetry, and the new wire-bytes metric beside the charged one. It says
plainly that OTLP charges the decompressed size while Remote Write still
charges the compressed size, because an operator sizing limits acts on
that difference.

Adds the unit test for peek_byte_rate that the previous wave's review
flagged as missing. That helper decides whether a compressed request is
rejected before it is decompressed, so a disagreement between peek and
try_take would silently reject requests the real charge would admit. The
test was verified non-vacuous against three mutations: dropping peek's
refill, an off-by-one on its comparison, and a double increment of the
rejection counter.

Fixes: #215
Refs: #115
Refs: #212