### PR TITLE
docs: amend ADR-0037 to publish multi-arch container images

### DIFF
--- a/docs/adrs/0037-container-image-ci-registry.md
+++ b/docs/adrs/0037-container-image-ci-registry.md
@@ -376,3 +376,197 @@ symlink pointing outside the repository.
   on them.
 - The next publish changes every moving tag's digest, as every publish
   always has.
+
+## Amendment: multi-architecture publishing
+
+The original ADR deferred multi-arch rather than rejecting it, on two
+conditions that have both changed. It said nothing in the deploy targets
+required arm64, and it said cross-building arm64 on an amd64 runner
+re-introduces the QEMU-versus-rustc SIGSEGV this ADR exists to route
+around, so the work needed native arm64-hosted runners and a manifest
+list, as a larger independently reviewable change.
+
+That change is this amendment.
+
+### Context
+
+ADR-0081 made `docker compose -f deploy/docker-compose/ravel.yml up -d`
+the first command in the README, pulling `ghcr.io/nofireai/ravel-server`.
+An amd64-only image turned the project's front door into an immediate
+failure on Apple Silicon:
+
+```
+Error response from daemon: no matching manifest for linux/arm64/v8
+in the manifest list entries: no match for platform in manifest: not found
+```
+
+CI never saw it. `ubuntu-latest` is amd64, so the `quickstart` job was
+genuinely green, and three checkpoint reviews read the compose file and the
+workflow with no reason to question the image's platform list. It surfaced
+the first time the stack ran on a machine that was not a GitHub runner.
+
+The compose file now pins `platform: linux/amd64` on the services that use
+the published image, so Docker runs it under emulation on arm64 and the
+quickstart works. That is a usability floor, not a fix. Emulated ingest is
+slower than native and is not the performance story a first-time reader
+should measure, which is exactly what a quickstart invites them to do.
+
+The deferral's second condition is also satisfied: GitHub now offers
+arm64-hosted runners, free for public repositories, and this repository is
+public.
+
+### Decision 12: build each platform on its native runner (amends decision 3)
+
+The publish matrix gains a platform dimension. `linux/amd64` builds on
+`ubuntu-latest` and `linux/arm64` on `ubuntu-24.04-arm`. Neither build invokes
+QEMU.
+
+GitHub's arm64-hosted runners are generally available and free for public
+repositories, which this one is, and releases publish from the public mirror.
+The label is `ubuntu-24.04-arm` or `ubuntu-22.04-arm`; there is no
+`ubuntu-latest-arm`, so the version is part of the label and pinning it is not
+optional.
+
+This is not a performance preference. The original ADR records that
+QEMU-emulated rustc SIGSEGVs on this workspace, which is why the publish
+job exists on a native runner at all. Emulating the arm64 half would
+reintroduce the exact failure the whole ADR routes around, so a native
+runner is a correctness requirement here, not an optimization.
+
+The runner label must be confirmed by a real run before this is relied on.
+No local gate compiles a workflow file, and a label that does not exist
+fails at job start rather than at review.
+
+### Decision 13: push by digest, then assemble a manifest list
+
+Each platform build pushes by digest and no tag, using
+`outputs: type=image,push-by-digest=true,name-canonical=true`. A per-target
+merge job then assembles the two digests into one manifest list with
+`docker buildx imagetools create`, and that index carries the tags decision
+3 defines.
+
+The per-platform digests reach the merge job as uploaded artifacts, one file
+per build, not as job outputs. A matrix's job outputs collapse to a single
+last-writer-wins value, so a two-platform matrix would silently publish an
+index containing whichever build finished last.
+
+### Decision 14: cosign signs the assembled index, not a per-platform digest (amends decision 7)
+
+This is the part of the amendment most able to fail silently, so it is
+called out as its own decision.
+
+Decision 7 signs `steps.build.outputs.digest`, which today is the index the
+single build produced. After decision 13 that same expression is a
+*per-platform* digest. Left unchanged, the workflow would sign two manifests
+nobody pulls by digest and leave the published, tagged index unsigned, while
+every log line still reads as a successful signature.
+
+The signing step therefore moves into the merge job and signs the digest
+`imagetools create` reports for the assembled index. The signing identity is
+unchanged, so the `cosign verify` invocation documented in README.md stays
+correct as written.
+
+The publish must fail if the signed digest is not the digest the tags
+resolve to. A verification step re-resolves the tag and compares, so a
+future refactor that reintroduces the wrong-digest bug is caught by the
+workflow rather than by a user.
+
+That comparison resolves the run's **immutable** identity tag: `X.Y.Z` on a
+tag push, `manual-<short-sha>` on a dispatch. Never `latest`, `X`, or `X.Y`.
+Those move, so a concurrent publish can re-point one between the merge and the
+check, which fails a correct release or, worse, passes against an index this
+run did not produce.
+
+The digest check has a blind spot worth naming, because it is the failure this
+decision would otherwise invite. It proves the thing that was signed is the
+thing the tag resolves to. It cannot prove the index was assembled from the
+right inputs: a cross-target artifact mix-up, a server index built from an
+operator platform digest, yields a consistently wrong index that passes the
+equality check. Three cheap guards close it:
+
+- Artifact names are scoped per target and per platform. `upload-artifact` v4
+  rejects duplicate names, so a collision fails the run instead of silently
+  overwriting a digest.
+- The verification asserts, via `imagetools inspect`, that the assembled index
+  carries exactly the `linux/amd64` and `linux/arm64` platform entries and no
+  others.
+- A `cosign verify` against the just-published identity tag runs before the job
+  ends. It is one command and it closes the loop: the published artifact
+  verifies under the same invocation README.md tells a user to run.
+
+### Decision 15: SBOM and provenance stay attached to what ships (amends decision 8)
+
+Decision 8 attaches an SBOM and max-mode provenance. With per-platform
+builds these attach per platform, and the merge must carry them into the
+assembled index rather than dropping them.
+
+Whether `imagetools create` preserves the attestation manifests is a
+property of the tooling, not of this decision, so the rollout verifies it
+against the published index rather than assuming it: after the first
+`workflow_dispatch` publish, `docker buildx imagetools inspect --raw` must
+show both platform manifests and their attestation manifests. If they do not
+survive the merge, the fix is to attach at merge time; publishing an index
+whose attestations silently vanished would defeat decision 8 while appearing
+to satisfy it.
+
+### Decision 16: the compose platform pins come out
+
+`deploy/docker-compose/ravel.yml` pins `platform: linux/amd64` on the
+`qualify` and `ravel-server` services. Those pins exist only because the
+image was amd64-only, and they force emulation on an arm64 host even once a
+native image is available.
+
+They are removed once a multi-arch image is published and verified on arm64,
+and not before. Removing them against an amd64-only image restores the
+original failure, so the ordering matters: publish first, verify, then unpin.
+
+"Verified" means the bar #197's own mitigation met, not merely a successful
+pull. A pull proves the manifest exists; it does not prove the native binary
+runs. The bar is the stack up natively on an arm64 host, `/healthz` returning
+200, and `demo/kill-and-recover.sh` passing.
+
+The same change removes the documentation that describes the limitation:
+README.md states the amd64-only scope in two places (the capability list and
+the container-images section), and the two compose services carry comments
+explaining the pins and pointing at #197. A pin removed while the prose still
+says amd64-only leaves a reader with contradictory instructions.
+
+### Decision 17: `id-token: write` moves to the merge job
+
+Decision 7's consequence recorded `id-token: write` on the publish job, for
+Fulcio to bind the signature to the workflow identity. Signing now happens in
+the merge job, so that permission moves there, alongside `packages: write`.
+The per-platform build jobs keep `packages: write` to push by digest and drop
+`id-token` entirely: they no longer sign anything, and a build job holding a
+signing-capable token is exactly the least-privilege drift the first amendment
+set out to avoid.
+
+![Two native builds push by digest, one merge job assembles the manifest list, and cosign signs that assembled index rather than either per-platform digest.](assets/0037-multiarch-publish.svg)
+
+### Consequences (multi-arch amendment)
+
+- The quickstart works natively on Apple Silicon. This is the point.
+- Publish cost roughly doubles: six full workspace compiles per release
+  instead of three, since each target's build recompiles the builder stage.
+  That waste predates this amendment and is not addressed here; halving it
+  by building the workspace once and deriving all three runtime images
+  belongs in its own change.
+- arm64 build time is unmeasured. The publish job carries no explicit
+  timeout today and inherits the six-hour default, so the first run's real
+  duration must be recorded and an explicit timeout set from it.
+- More moving parts between build and signature: two builds, an artifact
+  hop, a merge, then signing. Decision 14's digest check exists because that
+  chain has more places to sign the wrong thing than the single-build
+  version did.
+- Anyone pinning by digest keeps working unchanged. The digest of an index
+  is stable; consumers pinning the old amd64-only index continue to resolve
+  it.
+- Publish wall-clock becomes the slower of the two platform builds plus the
+  merge, rather than the amd64 build alone. Worth knowing when a release looks
+  slow: the arm64 leg is likely the long pole and its duration is unmeasured.
+- README.md changes in the same commit that publishes multi-arch, in both
+  places it currently states the amd64-only scope. The `cosign verify`
+  invocation it documents is unaffected: the signing identity does not change,
+  only which digest is signed.
+- No frozen format changes, no crate changes, no runtime behavior change.
+  This amendment is CI configuration, a compose file, and documentation.

--- a/docs/adrs/assets/0037-multiarch-publish.svg
+++ b/docs/adrs/assets/0037-multiarch-publish.svg
@@ -1,0 +1,70 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1060 625" font-family="'Segoe Print','Bradley Hand','Comic Sans MS',cursive" font-size="15">
+  <defs>
+    <marker id="m37" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 1 1.5 Q 6 4 8.5 5 Q 6 6 1 8.5" fill="none" stroke="#444" stroke-width="1.6" stroke-linecap="round"/>
+    </marker>
+  </defs>
+  <rect width="1060" height="625" fill="#fdfcf8"/>
+  <text x="24" y="34" font-size="20" fill="#1b2230">Multi-arch publish: two native builds, one signed index</text>
+  <text x="24" y="54" font-size="12" fill="#5b6472">Per target (server, operator, ingest-router). Nothing is emulated: QEMU-run rustc SIGSEGVs on this workspace.</text>
+
+  <!-- amd64 build -->
+  <path d="M 28 96 Q 25 93 31 93 L 288 91 Q 295 92 294 99 L 295 176 Q 294 182 288 181 L 32 183 Q 26 182 27 176 Z" fill="#eef3f7" stroke="#31536b" stroke-width="2.4" stroke-linecap="round"/>
+  <text x="46" y="120" fill="#31536b">build linux/amd64</text>
+  <text x="46" y="142" font-size="12" fill="#5b6472">ubuntu-latest, native</text>
+  <text x="46" y="159" font-size="12" fill="#5b6472">push-by-digest, NO tag</text>
+  <text x="46" y="176" font-size="12" fill="#5b6472">+ SBOM, provenance=max</text>
+
+  <!-- arm64 build -->
+  <path d="M 28 216 Q 25 213 31 213 L 288 211 Q 295 212 294 219 L 295 296 Q 294 302 288 301 L 32 303 Q 26 302 27 296 Z" fill="#eaf1ea" stroke="#4c6b45" stroke-width="2.4" stroke-linecap="round"/>
+  <text x="46" y="240" fill="#4c6b45">build linux/arm64</text>
+  <text x="46" y="262" font-size="12" fill="#5b6472">arm64-hosted runner, native</text>
+  <text x="46" y="279" font-size="12" fill="#5b6472">push-by-digest, NO tag</text>
+  <text x="46" y="296" font-size="12" fill="#5b6472">+ SBOM, provenance=max</text>
+
+  <line x1="297" y1="138" x2="352" y2="180" stroke="#383e46" stroke-width="2" marker-end="url(#m37)"/>
+  <line x1="297" y1="256" x2="352" y2="214" stroke="#383e46" stroke-width="2" marker-end="url(#m37)"/>
+  <text x="300" y="130" font-size="11" fill="#a04040">digest as an ARTIFACT,</text>
+  <text x="300" y="290" font-size="11" fill="#a04040">never a job output</text>
+
+  <!-- merge -->
+  <path d="M 356 156 Q 352 152 360 152 L 610 150 Q 619 151 618 159 L 620 240 Q 619 248 611 247 L 360 249 Q 353 248 354 240 Z" fill="#fff" stroke="#8a5a10" stroke-width="2.6" stroke-linecap="round"/>
+  <text x="374" y="180" fill="#8a5a10">imagetools create</text>
+  <text x="374" y="202" font-size="12" fill="#5b6472">assembles ONE manifest list</text>
+  <text x="374" y="219" font-size="12" fill="#5b6472">from the two digests, and</text>
+  <text x="374" y="236" font-size="12" fill="#5b6472">this index carries the tags</text>
+
+  <line x1="622" y1="198" x2="678" y2="198" stroke="#383e46" stroke-width="2" marker-end="url(#m37)"/>
+
+  <!-- sign -->
+  <path d="M 682 156 Q 678 152 686 152 L 1010 150 Q 1019 151 1018 159 L 1020 240 Q 1019 248 1011 247 L 686 249 Q 679 248 680 240 Z" fill="#f9eeee" stroke="#a04040" stroke-width="2.6" stroke-linecap="round"/>
+  <text x="700" y="180" fill="#a04040">cosign signs the INDEX digest</text>
+  <text x="700" y="202" font-size="12" fill="#5b6472">not either per-platform digest. Signing one of</text>
+  <text x="700" y="219" font-size="12" fill="#5b6472">those leaves the tagged index unsigned while</text>
+  <text x="700" y="236" font-size="12" fill="#5b6472">every log line still reads as success.</text>
+
+  <!-- verify -->
+  <path d="M 682 286 Q 678 282 686 282 L 1010 280 Q 1019 281 1018 289 L 1020 352 Q 1019 360 1011 359 L 686 361 Q 679 360 680 352 Z" fill="#dde1e7" stroke="#454b54" stroke-width="2.2" stroke-linecap="round"/>
+  <text x="700" y="310" fill="#3a3f47">then verify, against the IMMUTABLE tag</text>
+  <text x="700" y="332" font-size="12" fill="#5b6472">X.Y.Z or manual-&lt;sha&gt;, never latest/X/X.Y: those move.</text>
+  <text x="700" y="349" font-size="12" fill="#5b6472">Assert both platform entries, then cosign verify.</text>
+
+  <line x1="850" y1="251" x2="850" y2="278" stroke="#383e46" stroke-width="2" marker-end="url(#m37)"/>
+
+  <!-- before/after -->
+  <path d="M 28 396 Q 25 393 31 393 L 500 391 Q 507 392 506 399 L 507 468 Q 506 474 500 473 L 32 475 Q 26 474 27 468 Z" fill="#f9eeee" stroke="#a04040" stroke-width="2.2" stroke-linecap="round"/>
+  <text x="46" y="420" fill="#a04040">before: amd64 only</text>
+  <text x="46" y="442" font-size="12" fill="#5b6472">quickstart dies on Apple Silicon with a manifest error,</text>
+  <text x="46" y="459" font-size="12" fill="#5b6472">or runs emulated behind a compose platform: pin</text>
+
+  <path d="M 542 396 Q 538 393 546 393 L 1010 391 Q 1019 392 1018 399 L 1020 468 Q 1019 474 1011 473 L 546 475 Q 539 474 540 468 Z" fill="#eaf1ea" stroke="#4c6b45" stroke-width="2.2" stroke-linecap="round"/>
+  <text x="560" y="420" fill="#4c6b45">after: index with both platforms</text>
+  <text x="560" y="442" font-size="12" fill="#5b6472">docker pulls the native image on either host, and the</text>
+  <text x="560" y="459" font-size="12" fill="#5b6472">compose pins come out (decision 16, publish first)</text>
+
+  <text x="28" y="516" font-size="13" fill="#5b6472">Ordering matters at the end: publish multi-arch, verify the arm64 pull, THEN remove the pins. Unpinning against an</text>
+  <text x="28" y="536" font-size="13" fill="#5b6472">amd64-only image restores the original failure on every arm64 reader's first command.</text>
+  <text x="28" y="562" font-size="13" fill="#a04040">The digest check cannot catch a cross-target artifact mix-up: per-target/per-platform artifact names and the</text>
+  <text x="28" y="582" font-size="13" fill="#a04040">platform-entry assertion are what close that. Cost: six workspace compiles per release, pre-existing waste.</text>
+  <text x="28" y="604" font-size="13" fill="#8a5a10">arm64 build time is unmeasured; the first run sets the explicit timeout the job currently lacks.</text>
+</svg>


### PR DESCRIPTION
The quickstart's first README command fails on Apple Silicon because
ghcr.io/nofireai/ravel-server publishes linux/amd64 only. The compose
file pins platform: linux/amd64 so the image runs under emulation, which
is a usability floor rather than a fix: emulated ingest is not the
performance story a first-time reader should measure, and a quickstart
invites exactly that measurement.

ADR-0037 deferred multi-arch on two conditions that have both changed.
Nothing in the deploy targets required arm64, until ADR-0081 made this
image the front door. And the work needed GitHub's native arm64-hosted
runners, which are now generally available and free for public
repositories.

The approach is fixed by that ADR's own evidence rather than by
preference: it records that QEMU-emulated rustc SIGSEGVs on this
workspace, which is why the publish job runs on a native runner at all.
Emulating the arm64 half would reintroduce the failure the ADR routes
around. So each platform builds natively, pushes by digest, and one merge
job assembles the manifest list.

Decisions 12 through 17. The signing change is the one that can fail
silently: decision 7 signs the digest a single build produced, and after
the split that expression is a per-platform digest, so an unchanged
workflow would sign manifests nobody pulls and leave the tagged index
unsigned while logging success. Signing moves to the merge job and is
verified against the run's immutable identity tag, never a moving one.

Reviewed and approved with changes. Six amendments applied before commit,
including the two that closed real gaps: the digest check cannot catch a
cross-target artifact mix-up, so artifact names are scoped per target and
platform and the index's platform entries are asserted; and README.md
states the amd64-only scope in two places, which must change in the same
commit that publishes multi-arch.

Refs: #197
Refs: #218