### PR TITLE
fix(operator): correct gatewayAPI typo to gatewayApi in docs

### DIFF
--- a/docs/adrs/0080-gateway-api-ingest-affinity.md
+++ b/docs/adrs/0080-gateway-api-ingest-affinity.md
@@ -158,7 +158,7 @@ independently testable:
    the silent degradation the epic's non-goals forbid, so it is rejected
    at admission rather than left as a footgun: a CEL validation rule (the
    same mechanism already guarding `headerName`, `crd.yaml:155-156`)
-   rejects a CR that sets `exposure.gatewayAPI` while
+   rejects a CR that sets `exposure.gatewayApi` while
    `ingestAffinity.enabled && backend == IngressNginx`. The rule spans two
    sibling fields (`exposure` and `ingestAffinity`) rather than validating
    one struct against its own fields as the `headerName` precedent does,
@@ -278,7 +278,7 @@ independently testable:
    whichever objects the previous mode created instead of leaving them
    orphaned.
 
-![Exposure and affinity, decoupled: the CR's exposure.gatewayAPI and ingestAffinity fields feed independent rendering paths — standard HTTPRoute/GRPCRoute to a user-provided Gateway, versus legacy Ingress (deprecated) or the new ravel-ingest-router, both of which dial gateway pods directly rather than through the Service VIP.](assets/0080-architecture.svg)
+![Exposure and affinity, decoupled: the CR's exposure.gatewayApi and ingestAffinity fields feed independent rendering paths — standard HTTPRoute/GRPCRoute to a user-provided Gateway, versus legacy Ingress (deprecated) or the new ravel-ingest-router, both of which dial gateway pods directly rather than through the Service VIP.](assets/0080-architecture.svg)
 
 ![ravel-affinity's rendezvous (HRW) subset selection: a canonical tenant ID and the Ready replica set both feed a per-pair blake3 score; rank() produces the full deterministic order, subset() takes the top S, and the router picks one member, falling back through the rank order if a subset member isn't Ready.](assets/0080-hrw-flow.svg)
 
@@ -357,7 +357,7 @@ or the CRD version bumped.
   lines 98-104 and adding the legacy/Gateway-API/Ravel-native/S=1-vs-S>1
   distinctions the epic requires; it is not deferred to a later phase.
 - Existing ingress-nginx users see no behavior change until they opt into
-  `backend: RavelNative` or add `exposure.gatewayAPI` themselves; they gain
+  `backend: RavelNative` or add `exposure.gatewayApi` themselves; they gain
   only the new `IngestAffinityBackendDeprecated` condition on their
   `RavelCluster` status.
 - Phase 5 (removal criteria and version boundary for the ingress-nginx
@@ -382,7 +382,7 @@ or the CRD version bumped.
   `ravel-affinity` gets property tests for determinism (same inputs, same
   output), ordering-independence (shuffled replica input, same result),
   and bounded reassignment on single add/remove (only tenants whose rank
-  crosses position `S` move); the CEL rejection of `exposure.gatewayAPI` +
+  crosses position `S` move); the CEL rejection of `exposure.gatewayApi` +
   legacy `backend` is proven by an envtest against the real API server (or
   a direct CEL-expression evaluation over the generated schema), since
   `x-kubernetes-validations` runs at admission and no reconcile-loop unit

--- a/docs/adrs/assets/0080-architecture.svg
+++ b/docs/adrs/assets/0080-architecture.svg
@@ -19,7 +19,7 @@
 
   <!-- exposure box -->
   <path d="M 55 100 Q 52 97 58 97 L 300 95 Q 307 96 306 103 L 307 168 Q 306 174 300 173 L 59 175 Q 54 174 55 168 Z" fill="#eaf5f3" stroke="#0e7c86" stroke-width="2.2" stroke-linecap="round"/>
-  <text x="70" y="124" fill="#0e7c86">exposure.gatewayAPI</text>
+  <text x="70" y="124" fill="#0e7c86">exposure.gatewayApi</text>
   <text x="70" y="146" font-size="12" fill="#5b6472">hostnames, gatewayRef</text>
   <text x="70" y="163" font-size="12" fill="#5b6472">independent of affinity</text>
 
@@ -29,7 +29,7 @@
   <text x="346" y="146" font-size="12" fill="#5b6472">enabled, subsetSize, key</text>
   <text x="346" y="166" font-size="12" fill="#5b6472">backend: ingressNginx (default)</text>
   <text x="346" y="184" font-size="12" fill="#5b6472">        | ravelNative</text>
-  <text x="346" y="207" font-size="11" fill="#b3423a">CEL: gatewayAPI + legacy backend forbidden</text>
+  <text x="346" y="207" font-size="11" fill="#b3423a">CEL: gatewayApi + legacy backend forbidden</text>
 
   <!-- HTTPRoute / GRPCRoute -->
   <path d="M 70 300 Q 67 297 73 297 L 210 296 Q 217 297 216 303 L 217 348 Q 216 354 210 353 L 74 355 Q 68 354 69 348 Z" fill="#fff" stroke="#0e7c86" stroke-width="2" stroke-linecap="round"/>

--- a/services/ravel-operator/src/crd.rs
+++ b/services/ravel-operator/src/crd.rs
@@ -349,8 +349,8 @@ pub struct IngestAffinitySpec {
     /// cluster's default IngressClass apply.
     ///
     /// Legacy `backend: ingressNginx` only. Has no effect under
-    /// `backend: ravelNative`, and no effect on `gateway.exposure.gatewayAPI`
-    /// routing (Gateway API attachment goes through `exposure.gatewayAPI
+    /// `backend: ravelNative`, and no effect on `gateway.exposure.gatewayApi`
+    /// routing (Gateway API attachment goes through `exposure.gatewayApi
     /// .gatewayRef` instead, ADR-0080 decision 2).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ingress_class_name: Option<String>,
@@ -358,7 +358,7 @@ pub struct IngestAffinitySpec {
     /// Hostnames the ingest Ingress answers on. Empty renders a single
     /// host-less rule, which matches any host reaching the controller.
     ///
-    /// Legacy `backend: ingressNginx` only. `gateway.exposure.gatewayAPI
+    /// Legacy `backend: ingressNginx` only. `gateway.exposure.gatewayApi
     /// .hostnames` is the equivalent field for Gateway API exposure; the two
     /// are independent and neither reads the other.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -1826,7 +1826,7 @@ mod tests {
         // schema defaulting (which the API server applies before CEL runs) to
         // materialize `backend: ingressNginx` and `enabled: true` first. If
         // either default is ever removed, the rejected combination
-        // (exposure.gatewayAPI + an omitted-affinity-config CR) silently
+        // (exposure.gatewayApi + an omitted-affinity-config CR) silently
         // starts being admitted instead -- exactly the silent degrade this
         // rule exists to forbid -- with every other test here still green.
         // Pin both defaults so that regression fails loudly.


### PR DESCRIPTION
The real CRD field is gatewayApi (serde camelCase rename of
GatewayExposureSpec::gateway_api). Rust doc comments in crd.rs and prose
in ADR-0080 plus its architecture diagram spelled it gatewayAPI instead.
No schema or behavior change, comments and docs only.

Fixes: #206
