### PR TITLE
fix(ingest-router): supervise background tasks, redact secret Debug

### DIFF
--- a/services/ravel-ingest-router/src/config.rs
+++ b/services/ravel-ingest-router/src/config.rs
@@ -40,7 +40,13 @@ pub enum KeySource {
 }
 
 /// Ravel-native subset-affinity ingest router (ADR-0080 decision 3).
-#[derive(Debug, Parser)]
+///
+/// `Debug` is implemented by hand rather than derived: `tenant_tokens` holds
+/// raw bearer tokens (`--tenant-token TOKEN=TENANT`), and a derived `Debug`
+/// would dump them verbatim into any `tracing::debug!(?cli)` at startup. The
+/// manual impl redacts that field and prints every other flag normally, the
+/// same no-leak discipline [`crate::key::TenantKey`]'s own `Debug` follows.
+#[derive(Parser)]
 #[command(
     name = "ravel-ingest-router",
     about = "Ravel-native subset-affinity ingest router (ADR-0080)"
@@ -146,6 +152,43 @@ pub struct Cli {
     pub mtls_header: Option<String>,
 }
 
+impl std::fmt::Debug for Cli {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Cli")
+            .field("gateway_service_name", &self.gateway_service_name)
+            .field("gateway_service_namespace", &self.gateway_service_namespace)
+            .field("gateway_port_name", &self.gateway_port_name)
+            .field("subset_size", &self.subset_size)
+            .field("key_source", &self.key_source)
+            .field("key_header_name", &self.key_header_name)
+            .field("listen_http", &self.listen_http)
+            .field("listen_grpc", &self.listen_grpc)
+            .field("round_robin_max_entries", &self.round_robin_max_entries)
+            .field("round_robin_idle_ttl", &self.round_robin_idle_ttl)
+            // Never print the raw bearer tokens: this is the load-bearing
+            // no-leak property (each entry is a `TOKEN=TENANT` string).
+            .field(
+                "tenant_tokens",
+                &format_args!("[redacted {} entries]", self.tenant_tokens.len()),
+            )
+            .field(
+                "dev_insecure_tenant_header",
+                &self.dev_insecure_tenant_header,
+            )
+            .field("oidc_issuer", &self.oidc_issuer)
+            .field("oidc_jwks_url", &self.oidc_jwks_url)
+            .field("oidc_audiences", &self.oidc_audiences)
+            .field("oidc_tenant_claim", &self.oidc_tenant_claim)
+            .field(
+                "oidc_jwks_refresh_interval_secs",
+                &self.oidc_jwks_refresh_interval_secs,
+            )
+            .field("mtls_enabled", &self.mtls_enabled)
+            .field("mtls_header", &self.mtls_header)
+            .finish()
+    }
+}
+
 /// Validated OIDC settings, present only when both `--oidc-issuer` and
 /// `--oidc-jwks-url` are configured.
 #[derive(Debug, Clone)]
@@ -159,13 +202,33 @@ pub struct OidcSettings {
 
 /// The canonical-tenant resolver chain configuration, built only under
 /// `--key-source canonical-tenant`.
-#[derive(Debug, Clone, Default)]
+///
+/// `Debug` is manual (not derived) so `tokens` -- the raw bearer tokens paired
+/// with their tenant -- is redacted rather than printed. This is also what
+/// keeps [`KeyConfig`] and [`RouterConfig`], which embed this type, safe to
+/// `Debug`-format.
+#[derive(Clone, Default)]
 pub struct CanonicalAuthSettings {
     pub tokens: Vec<(String, String)>,
     pub dev_header: bool,
     pub oidc: Option<OidcSettings>,
     /// The trusted client-cert header, `Some` only when `--mtls-enabled`.
     pub mtls_header: Option<String>,
+}
+
+impl std::fmt::Debug for CanonicalAuthSettings {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CanonicalAuthSettings")
+            // Never print the raw bearer tokens (or their tenant mappings).
+            .field(
+                "tokens",
+                &format_args!("[redacted {} entries]", self.tokens.len()),
+            )
+            .field("dev_header", &self.dev_header)
+            .field("oidc", &self.oidc)
+            .field("mtls_header", &self.mtls_header)
+            .finish()
+    }
 }
 
 /// How the router derives the routing key: either raw header bytes, or the
@@ -180,7 +243,12 @@ pub enum KeyConfig {
 }
 
 /// The fully-validated runtime configuration.
-#[derive(Debug, Clone)]
+///
+/// `Debug` is manual (not derived) so a `tracing::debug!(?config)` at startup
+/// cannot leak secrets. The only secret-bearing field is `key`, whose
+/// [`CanonicalAuthSettings`] already redacts its tokens; every other field is
+/// non-secret and printed normally.
+#[derive(Clone)]
 pub struct RouterConfig {
     pub gateway_service_name: String,
     pub gateway_service_namespace: String,
@@ -191,6 +259,23 @@ pub struct RouterConfig {
     pub listen_grpc: Option<SocketAddr>,
     pub round_robin_max_entries: usize,
     pub round_robin_idle_ttl: Duration,
+}
+
+impl std::fmt::Debug for RouterConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RouterConfig")
+            .field("gateway_service_name", &self.gateway_service_name)
+            .field("gateway_service_namespace", &self.gateway_service_namespace)
+            .field("gateway_port_name", &self.gateway_port_name)
+            .field("subset_size", &self.subset_size)
+            // `key`'s own Debug (via CanonicalAuthSettings) redacts any tokens.
+            .field("key", &self.key)
+            .field("listen_http", &self.listen_http)
+            .field("listen_grpc", &self.listen_grpc)
+            .field("round_robin_max_entries", &self.round_robin_max_entries)
+            .field("round_robin_idle_ttl", &self.round_robin_idle_ttl)
+            .finish()
+    }
 }
 
 impl Cli {
@@ -552,6 +637,49 @@ mod tests {
         assert_eq!(
             config.listen_grpc,
             Some("0.0.0.0:4317".parse().expect("addr"))
+        );
+    }
+
+    #[test]
+    fn debug_redacts_tenant_token_across_config_types() {
+        // A `tracing::debug!(?cli)` / `?config` at startup must never dump a raw
+        // bearer token. Prove the token bytes appear in none of the three types'
+        // Debug output. (Against `#[derive(Debug)]` this fails: the derive prints
+        // `tenant_tokens: ["super-...=acme"]` verbatim.)
+        const SECRET: &str = "super-secret-bearer-token-value";
+        let token_arg = format!("{SECRET}=acme");
+
+        let cli = cli(&[
+            "--key-source",
+            "canonical-tenant",
+            "--tenant-token",
+            token_arg.as_str(),
+        ]);
+        let rendered = format!("{cli:?}");
+        assert!(
+            !rendered.contains(SECRET),
+            "Cli Debug leaked the raw token: {rendered}"
+        );
+
+        let config = cli
+            .into_config()
+            .expect("canonical-tenant with a token is valid");
+        let rendered = format!("{config:?}");
+        assert!(
+            !rendered.contains(SECRET),
+            "RouterConfig Debug leaked the raw token: {rendered}"
+        );
+
+        let settings = CanonicalAuthSettings {
+            tokens: vec![(SECRET.to_string(), "acme".to_string())],
+            dev_header: false,
+            oidc: None,
+            mtls_header: None,
+        };
+        let rendered = format!("{settings:?}");
+        assert!(
+            !rendered.contains(SECRET),
+            "CanonicalAuthSettings Debug leaked the raw token: {rendered}"
         );
     }
 

--- a/services/ravel-ingest-router/src/lib.rs
+++ b/services/ravel-ingest-router/src/lib.rs
@@ -86,13 +86,18 @@ pub async fn run(config: RouterConfig) -> anyhow::Result<()> {
     let watch_handle = tokio::spawn(watch::run(api, watch_config, store.clone()));
 
     // Key resolution (deliverable 3). Resolver wiring is built only for the
-    // canonical-tenant key source.
+    // canonical-tenant key source. When OIDC is configured the JWKS refresh task
+    // is spawned and its JoinHandle kept (never dropped): a dead refresh task
+    // silently stops picking up key rotation, so it joins the watcher race below
+    // and tears the process down if it ends or panics. `None` when OIDC is not
+    // configured, so its `select!` arm parks forever and never fires.
+    let mut jwks_handle: Option<tokio::task::JoinHandle<()>> = None;
     let key_resolver = match config.key {
         KeyConfig::Header(name) => key::KeyResolver::Header(name),
         KeyConfig::CanonicalTenant(settings) => {
             let built = auth::build(&settings)?;
             if let Some(refresh) = built.oidc_refresh {
-                auth::spawn_jwks_refresh(refresh);
+                jwks_handle = Some(auth::spawn_jwks_refresh(refresh));
             }
             key::KeyResolver::Canonical(built.resolver)
         }
@@ -152,7 +157,11 @@ pub async fn run(config: RouterConfig) -> anyhow::Result<()> {
     // (and, after enough pod churn, wrong) set of addresses while /readyz kept
     // reporting healthy. Race it against BOTH listeners and exit on any arm, so a
     // dead watcher tears the whole process down regardless of which listener(s)
-    // are active.
+    // are active. The JWKS refresh task (when OIDC is configured) joins the same
+    // race: fail-closed resolution means a dead refresh task degrades silently
+    // (rotated-key requests eventually 401 with no signal), so treat its exit or
+    // panic as fatal too. When OIDC is off the arm parks forever and never fires,
+    // so an HTTP-only router is not torn down for a task that was never spawned.
     tokio::select! {
         result = axum::serve(listener, proxy::build_app(state)) => {
             result?;
@@ -169,8 +178,30 @@ pub async fn run(config: RouterConfig) -> anyhow::Result<()> {
                 }
             }
         }
+        jwks_result = join_optional_jwks(jwks_handle) => {
+            match jwks_result {
+                Ok(()) => anyhow::bail!("JWKS refresh task ended unexpectedly"),
+                Err(join_error) => {
+                    return Err(anyhow::Error::from(join_error))
+                        .context("JWKS refresh task panicked");
+                }
+            }
+        }
     }
     Ok(())
+}
+
+/// Await the JWKS refresh task's JoinHandle when OIDC is configured, or park
+/// forever when it is not, so this can be a `tokio::select!` arm whether or not
+/// the refresh task was spawned. When `None`, it never resolves, so the process
+/// is never torn down for a JWKS refresh task that was never enabled.
+async fn join_optional_jwks(
+    handle: Option<tokio::task::JoinHandle<()>>,
+) -> Result<(), tokio::task::JoinError> {
+    match handle {
+        Some(handle) => handle.await,
+        None => std::future::pending().await,
+    }
 }
 
 /// Serve the gRPC listener when one is bound, or park forever when it is not, so
@@ -190,16 +221,46 @@ async fn serve_optional_grpc(
 /// Periodically evict idle round-robin entries. A swept entry restarts at
 /// offset 0 on the tenant's next request, so this only bounds memory and never
 /// affects correctness.
+///
+/// Unlike the watcher and JWKS refresh tasks, a dead sweep task is not fatal:
+/// the round-robin map's own hard cap in [`select`] still bounds it, so a
+/// stopped sweep only slows eviction. Racing it in the `select!` above would
+/// make a purely cosmetic degradation kill the whole router, the wrong tradeoff.
+/// Instead each sweep runs under [`run_sweep_guarded`], which catches a panic in
+/// `evict_idle` and logs it loudly so the loop keeps running and the failure is
+/// visible in logs rather than silently terminating the task.
 fn spawn_round_robin_sweep(state: Arc<router::RouterState>, interval: std::time::Duration) {
     tokio::spawn(async move {
         let mut ticker = tokio::time::interval(interval);
         ticker.tick().await; // consume the immediate first tick
         loop {
             ticker.tick().await;
-            let evicted = state.round_robin.evict_idle(state.clock.now_ns());
+            let now_ns = state.clock.now_ns();
+            run_sweep_guarded(|| state.round_robin.evict_idle(now_ns));
+        }
+    });
+}
+
+/// Run one round-robin sweep under a panic guard. `evict_idle` is synchronous
+/// (no `.await` inside), so a plain [`std::panic::catch_unwind`] suffices: a
+/// panic is caught and logged with `tracing::error!` and the caller's loop
+/// continues, rather than the panic unwinding the whole sweep task and letting
+/// it vanish silently. Returns the number of entries the sweep evicted, or `0`
+/// if the sweep panicked.
+fn run_sweep_guarded<F>(sweep: F) -> usize
+where
+    F: FnOnce() -> usize,
+{
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(sweep)) {
+        Ok(evicted) => {
             if evicted > 0 {
                 tracing::debug!(evicted, "swept idle round-robin entries");
             }
+            evicted
         }
-    });
+        Err(_) => {
+            tracing::error!("round-robin sweep panicked; continuing sweep loop");
+            0
+        }
+    }
 }

--- a/services/ravel-ingest-router/src/tests.rs
+++ b/services/ravel-ingest-router/src/tests.rs
@@ -778,3 +778,72 @@ async fn grpc_unready_subset_member_falls_through_to_next_ranked_replica() {
         "the next-ranked Ready replica received the gRPC request over the fallthrough path"
     );
 }
+
+// --- background-task supervision (#187) --------------------------------------
+
+// Deliverable 1: the JWKS refresh task's JoinHandle is genuinely held and wired
+// into the `run()` `select!` via `join_optional_jwks`, not dropped. Driving the
+// full `run()` path would need a live Kubernetes API server (`kube::Client::
+// try_default`), which is not available in this crate's cluster-free test
+// harness, so these prove the `select!` arm's semantics directly at the
+// `join_optional_jwks` boundary the arm awaits: an absent task never fires, and
+// a present task's end or panic is observable (which is exactly what tears the
+// process down in `run()`).
+
+#[tokio::test]
+async fn jwks_arm_parks_forever_when_oidc_is_not_configured() {
+    // `None` means OIDC was never configured: the arm must never resolve, so an
+    // HTTP-only (or non-OIDC) router is not torn down for a task that was never
+    // spawned. A ready future racing against it must always win.
+    tokio::select! {
+        _ = crate::join_optional_jwks(None) => {
+            panic!("the JWKS arm must park forever when no refresh task was spawned");
+        }
+        _ = std::future::ready(()) => {}
+    }
+}
+
+#[tokio::test]
+async fn jwks_arm_fires_when_the_refresh_task_ends() {
+    // A refresh task that returns (should never happen: the loop is infinite)
+    // resolves the arm with `Ok`, which `run()` turns into a fatal bail.
+    let handle = tokio::spawn(async {});
+    let result = crate::join_optional_jwks(Some(handle)).await;
+    assert!(
+        result.is_ok(),
+        "a JWKS task that ended must resolve the select! arm (fatal in run())"
+    );
+}
+
+#[tokio::test]
+async fn jwks_arm_fires_when_the_refresh_task_panics() {
+    // A panicking refresh task resolves the arm with a JoinError carrying the
+    // panic, which `run()` turns into a fatal error rather than silently serving
+    // a frozen JWKS cache forever.
+    let handle = tokio::spawn(async { panic!("simulated JWKS refresh panic") });
+    let result = crate::join_optional_jwks(Some(handle)).await;
+    let err = result.expect_err("a panicking JWKS task must resolve the arm with an error");
+    assert!(err.is_panic(), "the JoinError must carry the task's panic");
+}
+
+// Deliverable 2: a panic inside the round-robin sweep is caught and logged
+// (`tracing::error!`) instead of silently terminating the sweep task. The sweep
+// is memory-bound only, so it is not raced in the fatal `select!`; instead
+// `run_sweep_guarded` swallows the panic so the loop keeps running.
+
+#[test]
+fn sweep_guard_catches_a_panic_and_does_not_propagate() {
+    // If the guard did not catch the panic, this test would itself unwind and
+    // fail. Reaching the assertion proves the panic was contained.
+    let evicted = crate::run_sweep_guarded(|| panic!("simulated sweep panic"));
+    assert_eq!(
+        evicted, 0,
+        "a panicked sweep reports zero evictions, not a crash"
+    );
+
+    // And the loop can keep sweeping afterward: a subsequent normal sweep runs
+    // and returns its real count, proving the guard is log-and-continue, not
+    // log-and-die.
+    let evicted = crate::run_sweep_guarded(|| 3);
+    assert_eq!(evicted, 3, "a normal sweep after a panicked one still runs");
+}


### PR DESCRIPTION
fix(ingest-router): supervise background tasks, redact secret Debug

Follows the pattern the EndpointSlice watcher already uses since #157:
supervises the JWKS-refresh task the same way, racing its JoinHandle in
the same tokio::select! that already covers the watcher and the HTTP/gRPC
listeners, so a dead or panicked refresh task exits the process instead
of silently leaving OTLP requests failing canonical-tenant resolution
with no explanation. Only fires when OIDC is actually configured; when
it isn't, that select arm just never resolves.

The round-robin sweep task gets a lighter version: its panics are caught
and logged loudly rather than propagated, but it stays outside the fatal
select, since a dead sweep only slows eviction toward the round-robin
map's existing hard cap rather than breaking anything.

Cli, RouterConfig, and CanonicalAuthSettings now have manual Debug impls
that redact bearer-token fields, matching the existing pattern on
key::TenantKey. No caller logs these types' Debug output today, but the
derived Debug was one careless `tracing::debug!(?config)` away from
dumping every configured token.

Refs: #187
