### PR TITLE
docs: claim ADR-0085 metric-metadata-and-otlp-suffixing

### DIFF
--- a/docs/adrs/0085-metric-metadata-and-otlp-suffixing.md
+++ b/docs/adrs/0085-metric-metadata-and-otlp-suffixing.md
@@ -1,0 +1,3 @@
+# ADR-0085: metric metadata store and OTLP name suffixing
+
+Status: claimed


### PR DESCRIPTION
Reserves ADR-0085 for the epic-119 design (metric metadata store + OTLP
name suffixing). Stub only; full ADR content lands after design approval.

Refs: #119