### PR TITLE
Bump h2 to 0.4.16 for RUSTSEC-2026-0258

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2076,7 +2076,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2359,9 +2359,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -4169,7 +4169,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5167,7 +5167,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5226,7 +5226,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5723,7 +5723,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6478,7 +6478,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]


### PR DESCRIPTION
`cargo deny check` started failing on an unchanged `main`, so the
`supply-chain` required check is red on every open pull request and nothing
can merge. The RustSec database changed, not this repository: bdcfa00c passed
last night and d45339e9 passed at 08:48 UTC today, and a re-run of that same
tree fails now.

h2 0.4.15 accepts and queues empty DATA frames without limit. A peer that
never drains its streams can grow server memory without bound, or panic when
the queued length overflows. Upstream rates it low severity and patched it in
0.4.16.

It reaches us through hyper, so it sits on the HTTP/2 paths that take
untrusted client connections: OTLP gRPC ingest and the Flight SQL surface,
plus every reqwest and tonic client. That is worth a bump rather than an
allow-list entry.

Lockfile only, no source change and no API change. Verified locally with the
pinned 1.97.1 toolchain: `cargo deny check` reports `advisories ok, bans ok,
licenses ok, sources ok`, against `advisories FAILED` on the same tree before
the bump.

Six crates also move from windows-sys 0.61.2 to 0.52.0 in the lock. That is
cargo re-unifying a duplicate that was already there, not a downgrade this
change asks for, and neither version is built on the Linux and macOS targets
this project ships.

Fixes: #229