### PR TITLE
chore: ship 0.9.3 multi-arch release and drop compose platform pins

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -130,6 +130,7 @@ jobs:
   # runner build both.
   build:
     needs: gate
+    timeout-minutes: 60
     # Decision 17: a build job no longer signs anything, so it holds
     # packages: write to push by digest and DROPS id-token entirely. A build
     # job carrying a signing-capable token is exactly the least-privilege drift
@@ -237,6 +238,7 @@ jobs:
   # list, applies the tags, signs the assembled index, and verifies the result.
   merge:
     needs: [gate, build]
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     # Decision 17: signing moved here, so id-token: write lives here alongside
     # packages: write. The build jobs dropped id-token; this is the only job

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4268,14 +4268,14 @@ dependencies = [
 
 [[package]]
 name = "ravel-affinity"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "blake3",
 ]
 
 [[package]]
 name = "ravel-alerting"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "blake3",
  "hex",
@@ -4287,14 +4287,14 @@ dependencies = [
 
 [[package]]
 name = "ravel-analytics"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "ravel-bench"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "arrow 59.1.0",
  "arrow-flight",
@@ -4335,7 +4335,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-cache"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "bytes",
  "crc32c",
@@ -4346,7 +4346,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-catalog"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "async-trait",
  "blake3",
@@ -4372,7 +4372,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-cli"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4403,7 +4403,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-codec"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "blake3",
  "crc32c",
@@ -4413,7 +4413,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-commit"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "blake3",
  "bytes",
@@ -4435,7 +4435,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-failure-tests"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "bytes",
  "futures",
@@ -4456,7 +4456,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-fleet"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "blake3",
  "futures",
@@ -4473,7 +4473,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-ingest"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "async-trait",
  "blake3",
@@ -4503,7 +4503,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-ingest-router"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "axum",
@@ -4530,7 +4530,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-logseg"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "blake3",
  "crc32c",
@@ -4546,7 +4546,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-maintain"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "async-trait",
  "blake3",
@@ -4574,7 +4574,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-object-store"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "async-trait",
  "axum",
@@ -4594,7 +4594,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-operator"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "clap",
  "futures",
@@ -4618,7 +4618,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-otap"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "arrow 59.1.0",
  "arrow-ipc 59.1.0",
@@ -4644,7 +4644,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-otlp"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "blake3",
  "hex",
@@ -4661,7 +4661,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-promql"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "blake3",
  "promql-parser",
@@ -4674,7 +4674,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-promql-difftest"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "axum",
  "bytes",
@@ -4702,7 +4702,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-proto"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "prost",
  "prost-build",
@@ -4711,7 +4711,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-query"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "async-trait",
  "axum",
@@ -4751,7 +4751,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-remote-write"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "bytes",
  "hex",
@@ -4769,7 +4769,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-rspan"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "crc32c",
  "proptest",
@@ -4783,7 +4783,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-segment"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "blake3",
  "bytes",
@@ -4801,7 +4801,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-server"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "arrow 59.1.0",
@@ -4865,7 +4865,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-sim"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4886,7 +4886,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-sql"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -4922,7 +4922,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-tenant-resolve"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "axum",
  "base64 0.23.0",
@@ -4937,7 +4937,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-tracing-export"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
@@ -4953,7 +4953,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-types"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "base64 0.23.0",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*", "services/*"]
 
 [workspace.package]
-version = "0.9.2"
+version = "0.9.3"
 edition = "2024"
 license = "Apache-2.0"
 rust-version = "1.97"
@@ -26,29 +26,29 @@ expect_used = "warn"
 # Version fields pin each path dependency so cargo-deny does not count them as
 # wildcards. allow-wildcard-paths is not usable here because these
 # crates are not marked publish = false, so it does not exempt them.
-ravel-types = { path = "crates/ravel-types", version = "0.9.2" }
-ravel-tenant-resolve = { path = "crates/ravel-tenant-resolve", version = "0.9.2" }
-ravel-proto = { path = "crates/ravel-proto", version = "0.9.2" }
-ravel-codec = { path = "crates/ravel-codec", version = "0.9.2" }
-ravel-object-store = { path = "crates/ravel-object-store", version = "0.9.2" }
-ravel-segment = { path = "crates/ravel-segment", version = "0.9.2" }
-ravel-logseg = { path = "crates/ravel-logseg", version = "0.9.2" }
-ravel-rspan = { path = "crates/ravel-rspan", version = "0.9.2" }
-ravel-commit = { path = "crates/ravel-commit", version = "0.9.2" }
-ravel-catalog = { path = "crates/ravel-catalog", version = "0.9.2" }
-ravel-cache = { path = "crates/ravel-cache", version = "0.9.2" }
-ravel-maintain = { path = "crates/ravel-maintain", version = "0.9.2" }
-ravel-fleet = { path = "crates/ravel-fleet", version = "0.9.2" }
-ravel-otlp = { path = "crates/ravel-otlp", version = "0.9.2" }
-ravel-otap = { path = "crates/ravel-otap", version = "0.9.2" }
-ravel-remote-write = { path = "crates/ravel-remote-write", version = "0.9.2" }
-ravel-alerting = { path = "crates/ravel-alerting", version = "0.9.2" }
-ravel-ingest = { path = "crates/ravel-ingest", version = "0.9.2" }
-ravel-promql = { path = "crates/ravel-promql", version = "0.9.2" }
-ravel-query = { path = "crates/ravel-query", version = "0.9.2" }
-ravel-analytics = { path = "crates/ravel-analytics", version = "0.9.2" }
-ravel-tracing-export = { path = "crates/ravel-tracing-export", version = "0.9.2" }
-ravel-affinity = { path = "crates/ravel-affinity", version = "0.9.2" }
+ravel-types = { path = "crates/ravel-types", version = "0.9.3" }
+ravel-tenant-resolve = { path = "crates/ravel-tenant-resolve", version = "0.9.3" }
+ravel-proto = { path = "crates/ravel-proto", version = "0.9.3" }
+ravel-codec = { path = "crates/ravel-codec", version = "0.9.3" }
+ravel-object-store = { path = "crates/ravel-object-store", version = "0.9.3" }
+ravel-segment = { path = "crates/ravel-segment", version = "0.9.3" }
+ravel-logseg = { path = "crates/ravel-logseg", version = "0.9.3" }
+ravel-rspan = { path = "crates/ravel-rspan", version = "0.9.3" }
+ravel-commit = { path = "crates/ravel-commit", version = "0.9.3" }
+ravel-catalog = { path = "crates/ravel-catalog", version = "0.9.3" }
+ravel-cache = { path = "crates/ravel-cache", version = "0.9.3" }
+ravel-maintain = { path = "crates/ravel-maintain", version = "0.9.3" }
+ravel-fleet = { path = "crates/ravel-fleet", version = "0.9.3" }
+ravel-otlp = { path = "crates/ravel-otlp", version = "0.9.3" }
+ravel-otap = { path = "crates/ravel-otap", version = "0.9.3" }
+ravel-remote-write = { path = "crates/ravel-remote-write", version = "0.9.3" }
+ravel-alerting = { path = "crates/ravel-alerting", version = "0.9.3" }
+ravel-ingest = { path = "crates/ravel-ingest", version = "0.9.3" }
+ravel-promql = { path = "crates/ravel-promql", version = "0.9.3" }
+ravel-query = { path = "crates/ravel-query", version = "0.9.3" }
+ravel-analytics = { path = "crates/ravel-analytics", version = "0.9.3" }
+ravel-tracing-export = { path = "crates/ravel-tracing-export", version = "0.9.3" }
+ravel-affinity = { path = "crates/ravel-affinity", version = "0.9.3" }
 
 # async runtime / rpc / http
 tokio = { version = "1.53", features = ["rt-multi-thread", "macros", "sync", "time", "signal", "net", "io-util"] }

--- a/README.md
+++ b/README.md
@@ -56,8 +56,6 @@ Not there yet:
 
 - No downsampled tier. A wide-range query reads every raw hour ([#118](https://github.com/NOFireAI/ravel/issues/118)).
 - Flight SQL runs ad-hoc statements. Prepared statements return `unimplemented`.
-- Published images are `linux/amd64` only. On arm64 the quickstart runs them
-  under emulation ([#197](https://github.com/NOFireAI/ravel/issues/197)).
 
 The [SQL conformance table](docs/sql-conformance.md) and the PromQL conformance
 table in the [query engine spec](docs/query-engine.md) classify every construct
@@ -185,10 +183,10 @@ See the [Kubernetes guide](docs/guides/kubernetes.md).
 
 `ravel-server` and `ravel-operator` publish to the GitHub Container Registry on
 every `vX.Y.Z` release tag, built from the root `Dockerfile`
-(see [ADR-0037](docs/adrs/0037-container-image-ci-registry.md)). Only
-`linux/amd64` is published today ([#197](https://github.com/NOFireAI/ravel/issues/197)).
+(see [ADR-0037](docs/adrs/0037-container-image-ci-registry.md)). Both
+`linux/amd64` and `linux/arm64` are published.
 Each published object is an OCI image index that carries an SBOM and full build
-provenance. The quickstart pins `ghcr.io/nofireai/ravel-server:0.9.2`. Override
+provenance. The quickstart pins `ghcr.io/nofireai/ravel-server:0.9.3`. Override
 it with `RAVEL_IMAGE`.
 
 ```sh

--- a/crates/ravel-bench/Cargo.toml
+++ b/crates/ravel-bench/Cargo.toml
@@ -63,7 +63,7 @@ futures = { workspace = true, optional = true }
 # ravel-sql is an internal path crate not yet listed in the workspace
 # `[workspace.dependencies]`, so it is named by path here; every other dep
 # below reuses a workspace pin.
-ravel-sql = { path = "../ravel-sql", version = "0.9.2", optional = true, features = ["flight-sql"] }
+ravel-sql = { path = "../ravel-sql", version = "0.9.3", optional = true, features = ["flight-sql"] }
 arrow-flight = { workspace = true, optional = true }
 
 [features]

--- a/crates/ravel-ingest/Cargo.toml
+++ b/crates/ravel-ingest/Cargo.toml
@@ -22,7 +22,7 @@ ravel-catalog = { workspace = true }
 # [workspace.dependencies]; the root Cargo.toml is out of this task's scope, so
 # this is a version-pinned path dependency (the pin keeps cargo-deny from
 # counting it as a wildcard, matching the workspace's path-dep convention).
-ravel-rspan = { path = "../ravel-rspan", version = "0.9.2" }
+ravel-rspan = { path = "../ravel-rspan", version = "0.9.3" }
 # The router live switch (ADR-0052) decodes the provisioning record read for a
 # generation refresh; prost's Message trait provides `decode`.
 prost = { workspace = true }

--- a/crates/ravel-otlp/Cargo.toml
+++ b/crates/ravel-otlp/Cargo.toml
@@ -16,7 +16,7 @@ ravel-logseg = { workspace = true }
 # Used for the span record's StatusCode and the frozen resource+scope+span
 # attribute merge rule, so trace normalization and the RSPAN writer cannot
 # drift apart on either.
-ravel-rspan = { path = "../ravel-rspan", version = "0.9.2" }
+ravel-rspan = { path = "../ravel-rspan", version = "0.9.3" }
 opentelemetry-proto = { workspace = true }
 # Span events and links are stored as an opaque serialized blob in RSPAN v1
 # (ADR-0041 decision 4), which needs prost's own length-delimited encoding.

--- a/crates/ravel-query/Cargo.toml
+++ b/crates/ravel-query/Cargo.toml
@@ -81,7 +81,7 @@ ravel-cache = { workspace = true }
 # proof (tests/differential_compaction.rs) drives P4's real compactor to
 # produce write_v4 L1 parts. ravel-maintain does not depend on ravel-query,
 # so this is acyclic.
-ravel-maintain = { path = "../ravel-maintain", version = "0.9.2" }
+ravel-maintain = { path = "../ravel-maintain", version = "0.9.3" }
 proptest = { workspace = true }
 tokio = { workspace = true }
 tower = { workspace = true, features = ["util"] }

--- a/deploy/docker-compose/ravel.yml
+++ b/deploy/docker-compose/ravel.yml
@@ -50,16 +50,7 @@ services:
   # already-qualified bucket it reports the existing record and exits 0, so this
   # tolerates a populated `minio-data/` across runs.
   qualify:
-    image: ${RAVEL_IMAGE:-ghcr.io/nofireai/ravel-server:0.9.2}
-    # The published image is linux/amd64 only (ADR-0037). Without this, `docker
-    # compose up` on an Apple Silicon Mac fails with "no matching manifest for
-    # linux/arm64/v8" before anything starts, which is an opaque way to greet a
-    # reader running the first command in the README. Pinning the platform makes
-    # Docker run the amd64 image under emulation there; it is a no-op on an
-    # amd64 host, including CI. Emulated ingest is slower than native and is not
-    # the performance story Ravel wants a first-time reader to measure, so this
-    # is a usability floor, not the fix: publishing multi-arch images is #197.
-    platform: linux/amd64
+    image: ${RAVEL_IMAGE:-ghcr.io/nofireai/ravel-server:0.9.3}
     depends_on:
       createbucket:
         condition: service_completed_successfully
@@ -81,9 +72,7 @@ services:
   # container boundary forbids, so the demo authenticates with a real bearer
   # token against a real tenant map, exactly as a deployment does.
   ravel-server:
-    image: ${RAVEL_IMAGE:-ghcr.io/nofireai/ravel-server:0.9.2}
-    # linux/amd64 only; see the note on the qualify service above; tracked in #197.
-    platform: linux/amd64
+    image: ${RAVEL_IMAGE:-ghcr.io/nofireai/ravel-server:0.9.3}
     depends_on:
       qualify:
         condition: service_completed_successfully

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -26,7 +26,7 @@ This brings up, all from published images:
 - MinIO on `127.0.0.1:9000` (S3 API) and `127.0.0.1:9001` (console), plus a
   one-shot that creates the `ravel-dev` bucket and a one-shot that qualifies the
   store (ADR-0050 section 6) so `ravel-server` will start against it.
-- `ravel-server` from `ghcr.io/nofireai/ravel-server:0.9.2` (override the pin
+- `ravel-server` from `ghcr.io/nofireai/ravel-server:0.9.3` (override the pin
   with the `RAVEL_IMAGE` environment variable), listening on `127.0.0.1:4318`
   (HTTP/OTLP) and `127.0.0.1:4317` (gRPC/OTLP), with the tenant token
   `demo-token` mapped to tenant `demo-tenant`.

--- a/services/ravel-server/Cargo.toml
+++ b/services/ravel-server/Cargo.toml
@@ -154,14 +154,14 @@ reqwest = { version = "0.13", features = ["json"] }
 # ravel-rspan below are: the workspace root Cargo.toml is outside this task's
 # scope. The pin keeps cargo-deny from counting it as a wildcard path
 # dependency.
-ravel-alerting = { path = "../../crates/ravel-alerting", version = "0.9.2" }
+ravel-alerting = { path = "../../crates/ravel-alerting", version = "0.9.3" }
 
 # ravel-sql is declared here as a path dependency rather than through
 # `[workspace.dependencies]` because the workspace root Cargo.toml is outside
 # this task's scope. The version is pinned so cargo-deny does not count it as
 # a wildcard path dependency, matching how every other
 # internal crate is pinned.
-ravel-sql = { path = "../../crates/ravel-sql", version = "0.9.2", optional = true }
+ravel-sql = { path = "../../crates/ravel-sql", version = "0.9.3", optional = true }
 
 # Flight service codegen for the `flight-sql` feature. This is arrow 58's
 # arrow-flight, a different arrow major than the `arrow` dev-dependency below;
@@ -208,7 +208,7 @@ tokio = { workspace = true, features = ["test-util"] }
 # listed in the workspace [workspace.dependencies]; the root Cargo.toml is out
 # of this task's scope, so this is a version-pinned path dependency (the pin
 # keeps cargo-deny from counting it as a wildcard).
-ravel-rspan = { path = "../../crates/ravel-rspan", version = "0.9.2" }
+ravel-rspan = { path = "../../crates/ravel-rspan", version = "0.9.3" }
 uuid = { workspace = true }
 # Real-authn end-to-end test (tests/real_authn_e2e.rs): mint a JWT and build a
 # local oct (HMAC) JWKS so the OIDC resolver runs through a real HTTP request


### PR DESCRIPTION
ADR-0037 decision 16: the compose `platform: linux/amd64` pins come out once a
multi-arch image is published and verified on arm64, and not before. Both
conditions are now met, so this removes the pins and the prose that described
the limitation.

Verified on an Apple Silicon host against this branch, with the pins already
gone, using the multi-arch index published by run 32119696003
(`manual-b8fb052`):

- the stack comes up from an empty `minio-data/`, and Docker resolves
  `linux/arm64` with no platform pin present
- `/healthz` returns 200
- `demo/kill-and-recover.sh` passes: SIGKILL, the container replaced by a
  different container id, and the sample acknowledged before the kill read back
  by its own commit token

That is the bar decision 16 sets rather than a successful pull, which proves
only that the manifest exists.

The compose default moves to `0.9.3`, a tag that does not exist until the
release is cut immediately after this lands. That ordering is deliberate: the
workspace version must equal the tag before decision 11's publish gate will
allow the tag push, so the bump has to land first. The per-PR `quickstart` job
overrides `RAVEL_IMAGE` with the image it builds and is unaffected;
`quickstart-published.yml`'s `pinned-default` leg is weekly and gates nothing.

The version bump also reaches seven path dependencies in the per-crate
manifests that still required `0.9.2`, and the image tag in
`docs/guides/getting-started.md`. A caret requirement on `0.9.2` is satisfied by
a `0.9.3` path crate, so those compile either way today, but leaving them behind
turns the next minor bump into a resolution failure.

`timeout-minutes` comes from the first multi-arch run's measured durations
rather than a guess: 60 on the build job (arm64 legs ran 28 to 31 minutes,
amd64 legs 23 to 28) and 15 on the merge job (each merge under a minute). The
ADR predicted arm64 would be the long pole; measured, it runs within about ten
percent of amd64.

Fixes: #226
Closes: #197
Refs: #218
