### PR TITLE
feat(otlp): apply Prometheus name suffixes and surface metric metadata (ADR-0085)

### DIFF
--- a/crates/ravel-otap/src/encode.rs
+++ b/crates/ravel-otap/src/encode.rs
@@ -253,6 +253,10 @@ fn root_schema() -> Schema {
         ),
         Field::new("aggregation_temporality", DataType::Int32, true),
         Field::new("is_monotonic", DataType::Boolean, true),
+        // The metric's UCUM unit (otap-spec.md's METRICS.unit). Nullable and
+        // empty for a metric that carries none; the normalizer maps it to the
+        // Prometheus name suffix (ADR-0085 Decision 2).
+        Field::new("unit", DataType::Utf8, true),
     ])
 }
 
@@ -710,7 +714,60 @@ impl MetricsStreamEncoder {
         histograms: &[HistogramMetricRow],
         summaries: &[SummaryMetricRow],
     ) -> Result<BatchArrowRecords, EncodeError> {
+        self.encode_ext_inner(batch_id, metrics, &[], histograms, &[], summaries, &[])
+    }
+
+    /// Encode gauge/sum `metrics` with a parallel `metric_units` slice
+    /// (`metric_units[i]` is the UCUM unit of `metrics[i]`, or `""` past the
+    /// slice's end). Additive over [`Self::encode_batch`] so existing callers
+    /// need not change; used by the differential gate to exercise the ADR-0085
+    /// name-suffix pass across the OTLP and OTAP paths.
+    pub fn encode_batch_units(
+        &mut self,
+        batch_id: i64,
+        metrics: &[MetricRow],
+        metric_units: &[&str],
+    ) -> Result<BatchArrowRecords, EncodeError> {
+        self.encode_ext_inner(batch_id, metrics, metric_units, &[], &[], &[], &[])
+    }
+
+    /// Encode gauge/sum, histogram, and summary metrics with their parallel
+    /// unit slices. Additive over [`Self::encode_batch_ext`].
+    #[allow(clippy::too_many_arguments)]
+    pub fn encode_batch_ext_units(
+        &mut self,
+        batch_id: i64,
+        metrics: &[MetricRow],
+        metric_units: &[&str],
+        histograms: &[HistogramMetricRow],
+        histogram_units: &[&str],
+        summaries: &[SummaryMetricRow],
+        summary_units: &[&str],
+    ) -> Result<BatchArrowRecords, EncodeError> {
+        self.encode_ext_inner(
+            batch_id,
+            metrics,
+            metric_units,
+            histograms,
+            histogram_units,
+            summaries,
+            summary_units,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn encode_ext_inner(
+        &mut self,
+        batch_id: i64,
+        metrics: &[MetricRow],
+        metric_units: &[&str],
+        histograms: &[HistogramMetricRow],
+        histogram_units: &[&str],
+        summaries: &[SummaryMetricRow],
+        summary_units: &[&str],
+    ) -> Result<BatchArrowRecords, EncodeError> {
         let mut root_ids = Vec::new();
+        let mut root_units: Vec<String> = Vec::new();
         let mut root_types = Vec::new();
         let mut root_names = Vec::new();
         let mut root_temporalities: Vec<Option<i32>> = Vec::new();
@@ -724,11 +781,12 @@ impl MetricsStreamEncoder {
         let mut attr_builder = AttrColumnBuilder::default();
         let mut number_exemplar_builder = ExemplarColumnBuilder::default();
 
-        for metric in metrics {
+        for (mi, metric) in metrics.iter().enumerate() {
             let metric_id = self.next_metric_id;
             self.next_metric_id = self.next_metric_id.wrapping_add(1);
             root_ids.push(metric_id);
             root_names.push(metric.name.clone());
+            root_units.push(metric_units.get(mi).copied().unwrap_or("").to_string());
             match metric.kind {
                 MetricKind::Gauge => {
                     root_types.push(METRIC_TYPE_GAUGE);
@@ -782,12 +840,13 @@ impl MetricsStreamEncoder {
         let mut hist_attr_builder = AttrColumnBuilder::default();
         let mut hist_exemplar_builder = ExemplarColumnBuilder::default();
 
-        for metric in histograms {
+        for (mi, metric) in histograms.iter().enumerate() {
             let metric_id = self.next_metric_id;
             self.next_metric_id = self.next_metric_id.wrapping_add(1);
             root_ids.push(metric_id);
             root_types.push(METRIC_TYPE_HISTOGRAM);
             root_names.push(metric.name.clone());
+            root_units.push(histogram_units.get(mi).copied().unwrap_or("").to_string());
             root_temporalities.push(Some(metric.temporality));
             root_monotonic.push(None);
 
@@ -827,12 +886,13 @@ impl MetricsStreamEncoder {
         let mut summary_dp_flags = Vec::new();
         let mut summary_attr_builder = AttrColumnBuilder::default();
 
-        for metric in summaries {
+        for (mi, metric) in summaries.iter().enumerate() {
             let metric_id = self.next_metric_id;
             self.next_metric_id = self.next_metric_id.wrapping_add(1);
             root_ids.push(metric_id);
             root_types.push(METRIC_TYPE_SUMMARY);
             root_names.push(metric.name.clone());
+            root_units.push(summary_units.get(mi).copied().unwrap_or("").to_string());
             root_temporalities.push(None);
             root_monotonic.push(None);
 
@@ -869,6 +929,7 @@ impl MetricsStreamEncoder {
                 Arc::new(name_builder.finish()),
                 Arc::new(Int32Array::from(root_temporalities)),
                 Arc::new(BooleanArray::from(root_monotonic)),
+                Arc::new(StringArray::from_iter_values(root_units.iter())),
             ],
         )?;
 

--- a/crates/ravel-otap/src/normalize.rs
+++ b/crates/ravel-otap/src/normalize.rs
@@ -3,7 +3,11 @@
 //!
 //! This mirrors `ravel_otlp::normalize::normalize_metrics` point-for-point:
 //! same admission limits (`ravel_otlp::IngestLimits`), same sanitization,
-//! same [`Rejection`] classes, same `is_monotonic_sum` semantics. The
+//! same [`Rejection`] classes, same `is_monotonic_sum` semantics, and the same
+//! ADR-0085 Decision 2 name-suffix pass, applied through the pub
+//! `ravel_otlp::normalize::prometheus_family_name` (called directly, like
+//! `format_float`, rather than re-implemented) so the METRICS `unit` column
+//! and monotonic flag drive the same `foo_bytes_total` name on both paths. The
 //! differential gate (tests/differential.rs) asserts the two paths produce
 //! identical `SeriesId` sets, identical `(series, ts, value)` samples, and
 //! identical rejection classes for the same logical input. Where
@@ -72,7 +76,8 @@ use arrow::array::{
     UInt8Array, UInt16Array, UInt32Array, UInt64Array,
 };
 use arrow::datatypes::UInt8Type;
-use ravel_otlp::normalize::{MetricsNormalizeResult, NormalizedExemplar};
+use ravel_otlp::metadata::MetricKind as PromMetricKind;
+use ravel_otlp::normalize::{MetricsNormalizeResult, NormalizedExemplar, prometheus_family_name};
 use ravel_otlp::promcompat::format_float;
 use ravel_otlp::{IngestLimits, NormalizeOutput, NormalizedPoint, Rejection};
 use ravel_types::{
@@ -852,6 +857,10 @@ fn push_exp_histogram_exemplar_drops(batch: &DecodedBatch, rejected: &mut Vec<Re
 struct RootEntry {
     name: String,
     kind: RootKind,
+    /// The metric's UCUM unit (METRICS.unit column), empty when absent. Fed to
+    /// [`prometheus_family_name`] when building each decision's suffixed name
+    /// (ADR-0085 Decision 2), mirroring `ravel_otlp::normalize_metric`.
+    unit: String,
 }
 
 enum RootKind {
@@ -1084,11 +1093,13 @@ fn build_root_table(
         };
         let temporality_col = column_as::<Int32Array>(rb, "aggregation_temporality");
         let monotonic_col = column_as::<BooleanArray>(rb, "is_monotonic");
+        let unit_col = rb.column_by_name("unit");
 
         for (i, &id) in ids.iter().enumerate() {
             let Some(name) = name_at(name_col, i) else {
                 continue;
             };
+            let unit = unit_col.and_then(|c| name_at(c, i)).unwrap_or_default();
             let kind = match types.value(i) {
                 METRIC_TYPE_GAUGE => RootKind::Gauge,
                 METRIC_TYPE_SUM => {
@@ -1109,7 +1120,7 @@ fn build_root_table(
                 _ => RootKind::Unsupported,
             };
             if (id as usize) < entries.len() {
-                entries[id as usize] = Some(RootEntry { name, kind });
+                entries[id as usize] = Some(RootEntry { name, kind, unit });
             }
         }
     }
@@ -1256,6 +1267,12 @@ fn build_metric_decisions(
                 RootKind::Unsupported => unknown_count += count,
                 RootKind::Gauge => {
                     if let Some(name) = process_metric_name(&entry.name, limits, count, rejected) {
+                        let name = prometheus_family_name(
+                            &name,
+                            &entry.unit,
+                            PromMetricKind::Gauge,
+                            false,
+                        );
                         decisions[id] = Some(MetricDecision {
                             name,
                             is_sum: false,
@@ -1282,6 +1299,12 @@ fn build_metric_decisions(
                         rejected.push(Rejection::UnsupportedTemporality { count });
                         continue;
                     }
+                    let kind = if *is_monotonic {
+                        PromMetricKind::Counter
+                    } else {
+                        PromMetricKind::Gauge
+                    };
+                    let name = prometheus_family_name(&name, &entry.unit, kind, *is_monotonic);
                     decisions[id] = Some(MetricDecision {
                         name,
                         is_sum: true,
@@ -1834,6 +1857,12 @@ fn build_histogram_decisions(
                         rejected.push(Rejection::UnsupportedTemporality { count });
                         continue;
                     }
+                    let name = prometheus_family_name(
+                        &name,
+                        &entry.unit,
+                        PromMetricKind::Histogram,
+                        false,
+                    );
                     decisions[id] = Some(HistogramDecision { name });
                 }
                 _ => unknown_count += count,
@@ -1874,6 +1903,12 @@ fn build_summary_decisions(
             Some(entry) => match &entry.kind {
                 RootKind::Summary => {
                     if let Some(name) = process_metric_name(&entry.name, limits, count, rejected) {
+                        let name = prometheus_family_name(
+                            &name,
+                            &entry.unit,
+                            PromMetricKind::Summary,
+                            false,
+                        );
                         decisions[id] = Some(SummaryDecision { name });
                     }
                 }

--- a/crates/ravel-otap/tests/cross_path_empty_label_identity.rs
+++ b/crates/ravel-otap/tests/cross_path_empty_label_identity.rs
@@ -111,7 +111,7 @@ fn rw_series_id(mut labels: Vec<Label>) -> SeriesId {
             histograms: vec![],
             exemplars: vec![],
         }],
-        metadata_count: 0,
+        metadata: vec![],
         created_timestamps_count: 0,
         exemplars_dropped: 0,
     };

--- a/crates/ravel-otap/tests/differential.rs
+++ b/crates/ravel-otap/tests/differential.rs
@@ -83,6 +83,7 @@ enum WorkloadKind {
 #[derive(Debug, Clone)]
 struct WorkloadMetric {
     name: String,
+    unit: String,
     kind: WorkloadKind,
     points: Vec<WorkloadPoint>,
 }
@@ -166,6 +167,25 @@ fn point_strategy() -> impl Strategy<Value = WorkloadPoint> {
         })
 }
 
+/// A spread of units that exercise the ADR-0085 Decision 2 pass on both
+/// paths: mapped simple units (`By`, `s`, `ms`), the gauge-only ratio (`1`),
+/// compound and annotation forms (`By/s`, `{packet}/s`), an unknown unit
+/// (`furlong`, no suffix), and empty (no suffix). Both paths apply the same
+/// `prometheus_family_name`, so any divergence in how each feeds it a unit or
+/// monotonic flag shows up as a different series-name set.
+fn unit_strategy() -> impl Strategy<Value = String> {
+    prop_oneof![
+        Just(String::new()),
+        Just("By".to_string()),
+        Just("s".to_string()),
+        Just("ms".to_string()),
+        Just("1".to_string()),
+        Just("By/s".to_string()),
+        Just("{packet}/s".to_string()),
+        Just("furlong".to_string()),
+    ]
+}
+
 fn metric_kind_strategy() -> impl Strategy<Value = WorkloadKind> {
     prop_oneof![
         Just(WorkloadKind::Gauge),
@@ -181,10 +201,16 @@ fn metric_kind_strategy() -> impl Strategy<Value = WorkloadKind> {
 fn metric_strategy() -> impl Strategy<Value = WorkloadMetric> {
     (
         metric_name_strategy(),
+        unit_strategy(),
         metric_kind_strategy(),
         prop::collection::vec(point_strategy(), 1..=6),
     )
-        .prop_map(|(name, kind, points)| WorkloadMetric { name, kind, points })
+        .prop_map(|(name, unit, kind, points)| WorkloadMetric {
+            name,
+            unit,
+            kind,
+            points,
+        })
 }
 
 fn workload_strategy() -> impl Strategy<Value = Vec<WorkloadMetric>> {
@@ -223,6 +249,7 @@ fn build_otlp_request(workload: &[WorkloadMetric]) -> ExportMetricsServiceReques
             match &m.kind {
                 WorkloadKind::Gauge => Metric {
                     name: m.name.clone(),
+                    unit: m.unit.clone(),
                     data: Some(MetricData::Gauge(Gauge { data_points })),
                     ..Default::default()
                 },
@@ -231,6 +258,7 @@ fn build_otlp_request(workload: &[WorkloadMetric]) -> ExportMetricsServiceReques
                     is_monotonic,
                 } => Metric {
                     name: m.name.clone(),
+                    unit: m.unit.clone(),
                     data: Some(MetricData::Sum(Sum {
                         data_points,
                         aggregation_temporality: *temporality,
@@ -302,8 +330,9 @@ fn build_otap_batch(
             }
         })
         .collect();
+    let units: Vec<&str> = workload.iter().map(|m| m.unit.as_str()).collect();
     encoder
-        .encode_batch(batch_id, &metrics)
+        .encode_batch_units(batch_id, &metrics, &units)
         .expect("encode workload")
 }
 
@@ -384,6 +413,7 @@ fn future_skew_boundary_agrees() {
     };
     assert_paths_agree(&[WorkloadMetric {
         name: "widgets".to_string(),
+        unit: String::new(),
         kind: WorkloadKind::Gauge,
         points: vec![at_bound, past_bound],
     }]);
@@ -406,6 +436,7 @@ fn too_old_boundary_agrees() {
     };
     assert_paths_agree(&[WorkloadMetric {
         name: "widgets".to_string(),
+        unit: String::new(),
         kind: WorkloadKind::Gauge,
         points: vec![at_bound, past_bound],
     }]);
@@ -432,6 +463,7 @@ fn duplicate_label_names_after_sanitization_agree() {
     };
     assert_paths_agree(&[WorkloadMetric {
         name: "requests".to_string(),
+        unit: String::new(),
         kind: WorkloadKind::Gauge,
         points: vec![point],
     }]);
@@ -453,6 +485,7 @@ fn number_stale_marker_agrees() {
     };
     assert_paths_agree(&[WorkloadMetric {
         name: "requests".to_string(),
+        unit: String::new(),
         kind: WorkloadKind::Gauge,
         points: vec![point],
     }]);

--- a/crates/ravel-otlp/src/lib.rs
+++ b/crates/ravel-otlp/src/lib.rs
@@ -20,6 +20,7 @@
 pub mod limits;
 pub mod logs_limits;
 pub mod logs_normalize;
+pub mod metadata;
 pub mod normalize;
 pub mod promcompat;
 pub mod traces_limits;
@@ -28,9 +29,10 @@ pub mod traces_normalize;
 pub use limits::{IngestLimits, Rejection};
 pub use logs_limits::{LogIngestLimits, LogRejection};
 pub use logs_normalize::{LogNormalizeOutput, NormalizedLogRecord, normalize_logs};
+pub use metadata::{MetricKind, MetricMetadata};
 pub use normalize::{
     MetricsNormalizeResult, NormalizeOutput, NormalizedHistogramPoint, NormalizedPoint,
-    normalize_metrics, normalize_metrics_with_exemplars,
+    normalize_metrics, normalize_metrics_with_exemplars, normalize_metrics_with_metadata,
 };
 pub use traces_limits::{SpanIngestLimits, SpanRejection};
 pub use traces_normalize::{NormalizedSpan, SpanNormalizeOutput, normalize_traces};

--- a/crates/ravel-otlp/src/metadata.rs
+++ b/crates/ravel-otlp/src/metadata.rs
@@ -1,0 +1,45 @@
+//! Protocol-neutral per-metric metadata (ADR-0085 Decision 1).
+//!
+//! Every ingest surface (OTLP, OTAP, Remote Write v1/v2) already receives a
+//! metric's type, help text, and unit on the wire and, before this, discarded
+//! all three. This module defines the small, store-agnostic tuple each decoder
+//! now surfaces alongside its normalized points: one [`MetricMetadata`] per
+//! metric family. The decoders build it and hand it back; they never write it
+//! anywhere. The single metadata sink that persists it lives in `ravel-ingest`
+//! (ticket #235), off the ingest acknowledgement path.
+//!
+//! The `family_name` is defined per path so a lookup at query time matches
+//! what was stored (ADR-0085 Decision 1, "the map key is the family name"):
+//! for OTLP/OTAP it is the name after the Decision 2 suffix pass (unit and
+//! `_total` applied) but before the classic histogram/summary explosion that
+//! appends `_bucket`/`_sum`/`_count`; for RW1 it is `metric_family_name` as
+//! parsed; for RW2 it is the per-series `__name__` stripped of one structural
+//! `_bucket`/`_sum`/`_count`/`_total` suffix.
+
+/// A metric's Prometheus type. `Unknown` covers every wire type Ravel does not
+/// model as one of the four canonical kinds (RW's `GAUGEHISTOGRAM`, `INFO`,
+/// `STATESET`, and the unspecified/unknown discriminants), so a decoder never
+/// has to guess or drop a tuple it cannot classify precisely.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MetricKind {
+    Counter,
+    Gauge,
+    Histogram,
+    Summary,
+    Unknown,
+}
+
+/// One metric family's metadata, keyed by [`family_name`](Self::family_name).
+///
+/// `unit` is the mapped Prometheus word for the OTLP/OTAP surfaces (`bytes`,
+/// `seconds`; the same word an OpenMetrics `# UNIT` line carries, and the same
+/// word the name was suffixed with in Decision 2), or the raw sanitized unit
+/// when it maps to nothing, or empty. Remote Write payloads are already in the
+/// Prometheus model, so RW1/RW2 carry `unit` through verbatim as decoded.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MetricMetadata {
+    pub family_name: String,
+    pub kind: MetricKind,
+    pub help: String,
+    pub unit: String,
+}

--- a/crates/ravel-otlp/src/normalize.rs
+++ b/crates/ravel-otlp/src/normalize.rs
@@ -71,6 +71,7 @@ use ravel_types::{
 };
 
 use crate::limits::{IngestLimits, Rejection};
+use crate::metadata::{MetricKind, MetricMetadata};
 use crate::promcompat::format_float;
 
 /// Prometheus stale marker: a NaN with this exact bit pattern (upstream
@@ -208,6 +209,54 @@ pub fn normalize_metrics_with_exemplars(
     ingest_ts_ns: i64,
     exemplar_cap: &mut ExemplarCap,
 ) -> MetricsNormalizeResult {
+    normalize_impl(tenant, req, limits, ingest_ts_ns, exemplar_cap, None)
+}
+
+/// Decode and normalize gauge and sum data points exactly like
+/// [`normalize_metrics_with_exemplars`], and additionally surface one
+/// [`MetricMetadata`] per metric family that produced at least one point
+/// (ADR-0085 Decision 1). The returned [`MetricsNormalizeResult`] is
+/// byte-for-byte what [`normalize_metrics_with_exemplars`] returns for the same
+/// input, including the now-suffixed series names (Decision 2); the metadata is
+/// the only addition. `family_name` is the suffixed name before the classic
+/// histogram/summary explosion; metadata is deduplicated by `family_name`,
+/// first write wins.
+///
+/// The metric metadata store that consumes this is ticket #235; it has no
+/// production consumer yet. The suffix pass, in contrast, is reachable the
+/// moment this ships: every OTLP metric ingested through the existing
+/// `ravel-server` call sites gets its new Prometheus name.
+pub fn normalize_metrics_with_metadata(
+    tenant: &TenantId,
+    req: ExportMetricsServiceRequest,
+    limits: &IngestLimits,
+    ingest_ts_ns: i64,
+    exemplar_cap: &mut ExemplarCap,
+) -> (MetricsNormalizeResult, Vec<MetricMetadata>) {
+    let mut collector = MetadataCollector::default();
+    let result = normalize_impl(
+        tenant,
+        req,
+        limits,
+        ingest_ts_ns,
+        exemplar_cap,
+        Some(&mut collector),
+    );
+    (result, collector.entries)
+}
+
+/// Shared body of the two exemplar-carrying entry points. `metadata_out` is
+/// `Some` only for [`normalize_metrics_with_metadata`]; when `None`, the suffix
+/// pass still runs (names are unconditional) but no metadata is collected, so
+/// the older entry points stay behaviorally identical apart from the names.
+fn normalize_impl(
+    tenant: &TenantId,
+    req: ExportMetricsServiceRequest,
+    limits: &IngestLimits,
+    ingest_ts_ns: i64,
+    exemplar_cap: &mut ExemplarCap,
+    mut metadata_out: Option<&mut MetadataCollector>,
+) -> MetricsNormalizeResult {
     let total_points = count_data_points(&req);
     if total_points > limits.max_data_points_per_request {
         let mut rejected = vec![Rejection::TooManyDataPoints {
@@ -256,6 +305,7 @@ pub fn normalize_metrics_with_exemplars(
             &mut histogram_points,
             &mut exemplars,
             &mut rejected,
+            metadata_out.as_deref_mut(),
         );
     }
 
@@ -330,6 +380,7 @@ fn normalize_resource(
     histogram_points: &mut Vec<NormalizedHistogramPoint>,
     exemplars: &mut Vec<NormalizedExemplar>,
     rejected: &mut Vec<Rejection>,
+    mut metadata_out: Option<&mut MetadataCollector>,
 ) {
     let resource_point_count = resource_metrics_point_count(rm);
     if resource_point_count == 0 {
@@ -370,6 +421,7 @@ fn normalize_resource(
                 histogram_points,
                 exemplars,
                 rejected,
+                metadata_out.as_deref_mut(),
             );
         }
     }
@@ -387,6 +439,7 @@ fn normalize_metric(
     histogram_points: &mut Vec<NormalizedHistogramPoint>,
     exemplars: &mut Vec<NormalizedExemplar>,
     rejected: &mut Vec<Rejection>,
+    metadata_out: Option<&mut MetadataCollector>,
 ) {
     let point_count = metric_data_point_count(metric);
     if point_count == 0 {
@@ -407,6 +460,17 @@ fn normalize_metric(
         rejected.push(Rejection::EmptyMetricName { count: point_count });
         return;
     }
+
+    // Apply the ADR-0085 Decision 2 suffix pass to the sanitized base name
+    // before it reaches any `SeriesId::compute` call and before the classic
+    // histogram/summary explosion. `point_count > 0` guarantees `data` is set.
+    let Some(data) = metric.data.as_ref() else {
+        return;
+    };
+    let (kind, is_monotonic_sum) = metric_kind_of(data);
+    let name = prometheus_family_name(&name, &metric.unit, kind, is_monotonic_sum);
+    let points_before = points.len();
+    let hist_before = histogram_points.len();
 
     match &metric.data {
         Some(MetricData::Gauge(gauge)) => {
@@ -530,6 +594,21 @@ fn normalize_metric(
             }
         }
         None => {}
+    }
+
+    // One metadata tuple per metric family that produced at least one point.
+    // `family_name` is the suffixed name above, before the explosion that
+    // appends `_bucket`/`_sum`/`_count`, so it names the family the exploded
+    // series belong to (ADR-0085 Decision 1).
+    if let Some(collector) = metadata_out
+        && (points.len() > points_before || histogram_points.len() > hist_before)
+    {
+        collector.record(MetricMetadata {
+            family_name: name.clone(),
+            kind,
+            help: metric.description.clone(),
+            unit: metadata_unit_word(&metric.unit, kind),
+        });
     }
 }
 
@@ -1392,6 +1471,208 @@ fn any_value_to_label_value(value: Option<&AnyValue>) -> Result<String, Rejectio
         | Some(AnyValueVariant::KvlistValue(_))
         | Some(AnyValueVariant::BytesValue(_))
         | Some(AnyValueVariant::StringValueStrindex(_)) => Err(Rejection::ComplexAttributeValue),
+    }
+}
+
+/// Apply the OTLP-to-Prometheus name suffixes (ADR-0085 Decision 2) to a
+/// metric name that has already been through [`sanitize_metric_name`].
+///
+/// Order, matching the OpenTelemetry Collector's `prometheusexporter`
+/// translator: the mapped unit suffix (appended only when the name does not
+/// already end with it), then `_total` for a monotonic Sum (appended only when
+/// the name does not already end with it), then a final re-sanitize so any
+/// character the unit table introduced is still a valid metric-name character.
+///
+/// `kind` selects the dimensionless-ratio behavior (`unit == "1"` becomes
+/// `_ratio` on a `Gauge` only) and is redundant with `is_monotonic_sum` for
+/// the `_total` decision (`is_monotonic_sum` is `true` exactly when
+/// `kind == Counter`); both are taken so a caller need not derive one from the
+/// other. Pure and total: no allocation beyond the returned `String`, and it
+/// never fails.
+pub fn prometheus_family_name(
+    sanitized: &str,
+    unit: &str,
+    kind: MetricKind,
+    is_monotonic_sum: bool,
+) -> String {
+    let mut name = sanitized.to_string();
+    if let Some(suffix) = unit_suffix(unit, kind) {
+        let with_sep = format!("_{suffix}");
+        if !name.ends_with(&with_sep) {
+            name.push_str(&with_sep);
+        }
+    }
+    if is_monotonic_sum && !name.ends_with("_total") {
+        name.push_str("_total");
+    }
+    sanitize_metric_name(&name)
+}
+
+/// Map a whole (non-compound) UCUM unit through the OpenTelemetry Collector's
+/// `unitMapper` table (ADR-0085 Decision 2), returning the Prometheus word or
+/// `None` for an empty or unrecognized unit. The dimensionless `1` is not in
+/// this table: its `_ratio` mapping is gauge-specific and lives in
+/// [`unit_suffix`], since this mapper has no metric kind.
+pub fn map_unit(unit: &str) -> Option<String> {
+    let mapped = match unit {
+        // time
+        "d" => "days",
+        "h" => "hours",
+        "min" => "minutes",
+        "s" => "seconds",
+        "ms" => "milliseconds",
+        "us" => "microseconds",
+        "ns" => "nanoseconds",
+        // bytes
+        "By" => "bytes",
+        "KiBy" => "kibibytes",
+        "MiBy" => "mebibytes",
+        "GiBy" => "gibibytes",
+        "TiBy" => "tibibytes",
+        "KBy" => "kilobytes",
+        "MBy" => "megabytes",
+        "GBy" => "gigabytes",
+        "TBy" => "terabytes",
+        // SI
+        "m" => "meters",
+        "V" => "volts",
+        "A" => "amperes",
+        "J" => "joules",
+        "W" => "watts",
+        "g" => "grams",
+        // misc
+        "Cel" => "celsius",
+        "Hz" => "hertz",
+        "%" => "percent",
+        _ => return None,
+    };
+    Some(mapped.to_string())
+}
+
+/// Map a per-unit denominator through the Collector's `perUnitMapper` table
+/// (ADR-0085 Decision 2). Unlike [`map_unit`], `m` here is `minute`, not
+/// `meters`. An unrecognized denominator returns `None`; callers pass it
+/// through sanitized rather than dropping it.
+fn map_per_unit(unit: &str) -> Option<String> {
+    let mapped = match unit {
+        "s" => "second",
+        "m" => "minute",
+        "h" => "hour",
+        "d" => "day",
+        "w" => "week",
+        "mo" => "month",
+        "y" => "year",
+        _ => return None,
+    };
+    Some(mapped.to_string())
+}
+
+/// Strip every `{...}` annotation from a unit, anywhere it appears and at any
+/// nesting (ADR-0085 Decision 2: `{packet}/s` becomes `/s`). Unbalanced braces
+/// are tolerated rather than treated as an error, since a unit string is
+/// attacker-influenced input and must never panic here.
+fn strip_annotations(unit: &str) -> String {
+    let mut out = String::with_capacity(unit.len());
+    let mut depth: usize = 0;
+    for c in unit.chars() {
+        match c {
+            '{' => depth += 1,
+            '}' => depth = depth.saturating_sub(1),
+            _ if depth == 0 => out.push(c),
+            _ => {}
+        }
+    }
+    out
+}
+
+/// Compute the mapped unit suffix (without a leading `_`) for a unit string,
+/// or `None` when it should add no suffix (empty, an unrecognized simple unit,
+/// or `1` on a non-gauge). Handles the `a/b` compound form (each side mapped
+/// independently, joined as `<a>_per_<b>`) and the annotation-only-side
+/// collapse (`{packet}/s` yields `per_second`) from ADR-0085 Decision 2.
+fn unit_suffix(unit: &str, kind: MetricKind) -> Option<String> {
+    let stripped = strip_annotations(unit);
+    let trimmed = stripped.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    // Dimensionless ratio: `_ratio` on a gauge, nothing on any other kind.
+    if trimmed == "1" {
+        return match kind {
+            MetricKind::Gauge => Some("ratio".to_string()),
+            _ => None,
+        };
+    }
+    if let Some((num_raw, den_raw)) = trimmed.split_once('/') {
+        let num = num_raw.trim();
+        let den = den_raw.trim();
+        // An empty side (its content was entirely an annotation) contributes
+        // nothing; an unrecognized side passes through sanitized rather than
+        // being guessed or dropped.
+        let num_mapped =
+            (!num.is_empty()).then(|| map_unit(num).unwrap_or_else(|| num.to_string()));
+        let den_mapped =
+            (!den.is_empty()).then(|| map_per_unit(den).unwrap_or_else(|| den.to_string()));
+        match (num_mapped, den_mapped) {
+            (Some(n), Some(d)) => Some(format!("{n}_per_{d}")),
+            (Some(n), None) => Some(n),
+            (None, Some(d)) => Some(format!("per_{d}")),
+            (None, None) => None,
+        }
+    } else {
+        map_unit(trimmed)
+    }
+}
+
+/// The unit word stored in a metric's [`MetricMetadata`]: the mapped Prometheus
+/// word when the unit maps (agreeing with the name suffix), otherwise the raw
+/// unit sanitized as a metric name, otherwise empty (ADR-0085 Decision 1/2).
+fn metadata_unit_word(unit: &str, kind: MetricKind) -> String {
+    if let Some(word) = unit_suffix(unit, kind) {
+        return word;
+    }
+    let stripped = strip_annotations(unit);
+    let trimmed = stripped.trim();
+    if trimmed.is_empty() {
+        String::new()
+    } else {
+        sanitize_metric_name(trimmed)
+    }
+}
+
+/// The Prometheus [`MetricKind`] and monotonic-Sum flag a metric's `data`
+/// oneof implies (ADR-0085 Decision 1): a monotonic `Sum` is a `Counter`, a
+/// non-monotonic `Sum` and a `Gauge` are both `Gauge`, `Histogram` and
+/// `ExponentialHistogram` are `Histogram`, and `Summary` is `Summary`. `None`
+/// data carries no points and is handled before this is called.
+fn metric_kind_of(data: &MetricData) -> (MetricKind, bool) {
+    match data {
+        MetricData::Gauge(_) => (MetricKind::Gauge, false),
+        MetricData::Sum(s) if s.is_monotonic => (MetricKind::Counter, true),
+        MetricData::Sum(_) => (MetricKind::Gauge, false),
+        MetricData::Histogram(_) | MetricData::ExponentialHistogram(_) => {
+            (MetricKind::Histogram, false)
+        }
+        MetricData::Summary(_) => (MetricKind::Summary, false),
+    }
+}
+
+/// Accumulates one [`MetricMetadata`] per metric family that produced at least
+/// one point, deduplicated by `family_name` with the first write winning
+/// (ADR-0085 Decision 1). Threaded through normalization only by the
+/// [`normalize_metrics_with_metadata`] entry point; the exemplar-only entry
+/// points pass `None` and never allocate it.
+#[derive(Default)]
+struct MetadataCollector {
+    entries: Vec<MetricMetadata>,
+    seen: std::collections::HashSet<String>,
+}
+
+impl MetadataCollector {
+    fn record(&mut self, meta: MetricMetadata) {
+        if self.seen.insert(meta.family_name.clone()) {
+            self.entries.push(meta);
+        }
     }
 }
 
@@ -4070,5 +4351,262 @@ mod tests {
         );
         assert!(out.rejected.is_empty(), "{:?}", out.rejected);
         assert_eq!(out.points[0].sample.value, 5.0);
+    }
+
+    // --- ADR-0085 Decision 2: OTLP-to-Prometheus name suffixing, and
+    // Decision 1: per-metric metadata surfaced from normalize ---
+
+    fn cap() -> ExemplarCap {
+        ExemplarCap::new(IngestLimits::default().exemplar_cap_window_ns)
+    }
+
+    fn gauge_u(name: &str, unit: &str) -> Metric {
+        Metric {
+            name: name.to_string(),
+            unit: unit.to_string(),
+            data: Some(MetricData::Gauge(Gauge {
+                data_points: vec![number_point(vec![], 1_000_000, NumberValue::AsDouble(1.0))],
+            })),
+            ..Default::default()
+        }
+    }
+
+    fn mono_sum_u(name: &str, unit: &str) -> Metric {
+        Metric {
+            name: name.to_string(),
+            unit: unit.to_string(),
+            data: Some(MetricData::Sum(Sum {
+                data_points: vec![number_point(vec![], 1_000_000, NumberValue::AsDouble(1.0))],
+                aggregation_temporality: AggregationTemporality::Cumulative as i32,
+                is_monotonic: true,
+            })),
+            ..Default::default()
+        }
+    }
+
+    /// Normalize a one-metric request with metadata, returning the distinct
+    /// `__name__` values its points carry (sorted) and the metadata list.
+    fn suffixed(metric: Metric) -> (Vec<String>, Vec<MetricMetadata>) {
+        let rm = resource_metrics(vec![], vec![metric]);
+        let mut c = cap();
+        let (result, metadata) = normalize_metrics_with_metadata(
+            &tenant(),
+            request(vec![rm]),
+            &IngestLimits::default(),
+            1_000_000,
+            &mut c,
+        );
+        assert!(
+            result.output.rejected.is_empty(),
+            "{:?}",
+            result.output.rejected
+        );
+        let mut names: Vec<String> = result
+            .output
+            .points
+            .iter()
+            .map(|p| {
+                p.labels
+                    .get(METRIC_NAME_LABEL)
+                    .unwrap_or_default()
+                    .to_string()
+            })
+            .collect();
+        names.sort();
+        names.dedup();
+        (names, metadata)
+    }
+
+    #[test]
+    fn monotonic_sum_with_unit_gets_unit_then_total_suffix() {
+        let mut metric = mono_sum_u("foo", "By");
+        metric.description = "bytes processed".to_string();
+        let (names, metadata) = suffixed(metric);
+        assert_eq!(names, vec!["foo_bytes_total".to_string()]);
+        assert_eq!(
+            metadata,
+            vec![MetricMetadata {
+                family_name: "foo_bytes_total".to_string(),
+                kind: MetricKind::Counter,
+                help: "bytes processed".to_string(),
+                unit: "bytes".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn name_suffix_cases() {
+        use MetricKind::{Counter, Gauge};
+        assert_eq!(
+            prometheus_family_name("foo", "1", Gauge, false),
+            "foo_ratio"
+        );
+        assert_eq!(
+            prometheus_family_name("foo", "1", Counter, true),
+            "foo_total"
+        );
+        assert_eq!(
+            prometheus_family_name("foo", "By/s", Gauge, false),
+            "foo_bytes_per_second"
+        );
+        assert_eq!(
+            prometheus_family_name("foo", "{packet}/s", Gauge, false),
+            "foo_per_second"
+        );
+        assert_eq!(
+            prometheus_family_name("foo", "furlong", Gauge, false),
+            "foo"
+        );
+        assert_eq!(
+            prometheus_family_name("foo_total", "", Counter, true),
+            "foo_total"
+        );
+        assert_eq!(
+            prometheus_family_name("foo_bytes", "By", Gauge, false),
+            "foo_bytes"
+        );
+        assert_eq!(
+            prometheus_family_name("foo", "ms", Gauge, false),
+            "foo_milliseconds"
+        );
+        // A passthrough compound side with characters needing sanitizing
+        // survives the final re-sanitize: `a.b/c` -> `foo_a_b_per_c`.
+        assert_eq!(
+            prometheus_family_name("foo", "a.b/c", Gauge, false),
+            "foo_a_b_per_c"
+        );
+    }
+
+    #[test]
+    fn unit_table_is_complete() {
+        let table = [
+            ("d", "days"),
+            ("h", "hours"),
+            ("min", "minutes"),
+            ("s", "seconds"),
+            ("ms", "milliseconds"),
+            ("us", "microseconds"),
+            ("ns", "nanoseconds"),
+            ("By", "bytes"),
+            ("KiBy", "kibibytes"),
+            ("MiBy", "mebibytes"),
+            ("GiBy", "gibibytes"),
+            ("TiBy", "tibibytes"),
+            ("KBy", "kilobytes"),
+            ("MBy", "megabytes"),
+            ("GBy", "gigabytes"),
+            ("TBy", "terabytes"),
+            ("m", "meters"),
+            ("V", "volts"),
+            ("A", "amperes"),
+            ("J", "joules"),
+            ("W", "watts"),
+            ("g", "grams"),
+            ("Cel", "celsius"),
+            ("Hz", "hertz"),
+            ("%", "percent"),
+        ];
+        for (unit, word) in table {
+            assert_eq!(map_unit(unit).as_deref(), Some(word), "map_unit({unit})");
+            assert_eq!(
+                prometheus_family_name("foo", unit, MetricKind::Gauge, false),
+                format!("foo_{word}"),
+                "family({unit})"
+            );
+        }
+        assert_eq!(map_unit("furlong"), None);
+        assert_eq!(map_unit(""), None);
+    }
+
+    #[test]
+    fn gauge_ratio_end_to_end() {
+        let (names, metadata) = suffixed(gauge_u("cpu", "1"));
+        assert_eq!(names, vec!["cpu_ratio".to_string()]);
+        assert_eq!(metadata[0].unit, "ratio");
+        assert_eq!(metadata[0].kind, MetricKind::Gauge);
+    }
+
+    #[test]
+    fn metadata_unit_is_mapped_or_raw_sanitized_or_empty() {
+        let (_names, metadata) = suffixed(gauge_u("foo", "furlong"));
+        assert_eq!(metadata[0].unit, "furlong");
+        let (_names, metadata) = suffixed(gauge_u("bar", ""));
+        assert_eq!(metadata[0].unit, "");
+        let (_names, metadata) = suffixed(gauge_u("baz", "By"));
+        assert_eq!(metadata[0].unit, "bytes");
+    }
+
+    #[test]
+    fn classic_histogram_unit_suffix_before_structural() {
+        let hp = histogram_point(
+            vec![],
+            1_000_000,
+            3,
+            Some(6.0),
+            vec![1.0, 2.0],
+            vec![1, 1, 1],
+        );
+        let metric = Metric {
+            name: "foo".to_string(),
+            unit: "s".to_string(),
+            data: Some(MetricData::Histogram(Histogram {
+                data_points: vec![hp],
+                aggregation_temporality: AggregationTemporality::Cumulative as i32,
+            })),
+            ..Default::default()
+        };
+        let (names, metadata) = suffixed(metric);
+        assert!(
+            names.contains(&"foo_seconds_bucket".to_string()),
+            "{names:?}"
+        );
+        assert!(names.contains(&"foo_seconds_sum".to_string()), "{names:?}");
+        assert!(
+            names.contains(&"foo_seconds_count".to_string()),
+            "{names:?}"
+        );
+        assert_eq!(metadata.len(), 1);
+        assert_eq!(metadata[0].family_name, "foo_seconds");
+        assert_eq!(metadata[0].kind, MetricKind::Histogram);
+    }
+
+    #[test]
+    fn metadata_deduplicated_by_family_first_wins() {
+        let mut a = gauge_u("foo", "");
+        a.description = "first".to_string();
+        let mut b = gauge_u("foo", "");
+        b.description = "second".to_string();
+        let rm = resource_metrics(vec![], vec![a, b]);
+        let mut c = cap();
+        let (_r, metadata) = normalize_metrics_with_metadata(
+            &tenant(),
+            request(vec![rm]),
+            &IngestLimits::default(),
+            1_000_000,
+            &mut c,
+        );
+        assert_eq!(metadata.len(), 1);
+        assert_eq!(metadata[0].help, "first");
+    }
+
+    #[test]
+    fn metadata_absent_when_no_points_produced() {
+        let m = sum_metric(
+            "requests",
+            vec![number_point(vec![], 1_000_000, NumberValue::AsDouble(1.0))],
+            AggregationTemporality::Delta,
+            true,
+        );
+        let rm = resource_metrics(vec![], vec![m]);
+        let mut c = cap();
+        let (r, metadata) = normalize_metrics_with_metadata(
+            &tenant(),
+            request(vec![rm]),
+            &IngestLimits::default(),
+            1_000_000,
+            &mut c,
+        );
+        assert!(r.output.points.is_empty());
+        assert!(metadata.is_empty());
     }
 }

--- a/crates/ravel-otlp/src/normalize.rs
+++ b/crates/ravel-otlp/src/normalize.rs
@@ -1631,13 +1631,11 @@ fn metadata_unit_word(unit: &str, kind: MetricKind) -> String {
     if let Some(word) = unit_suffix(unit, kind) {
         return word;
     }
-    let stripped = strip_annotations(unit);
-    let trimmed = stripped.trim();
-    if trimmed.is_empty() {
-        String::new()
-    } else {
-        sanitize_metric_name(trimmed)
-    }
+    // Unmapped: carry the raw unit through as free text. This is a metadata
+    // field, not a metric name, so metric-name sanitizing rules do not apply
+    // (they would turn `1` into `_` and `2h` into `_h`, neither of which is
+    // the word an OpenMetrics `# UNIT` line would carry).
+    strip_annotations(unit).trim().to_string()
 }
 
 /// The Prometheus [`MetricKind`] and monotonic-Sum flag a metric's `data`
@@ -4527,13 +4525,25 @@ mod tests {
     }
 
     #[test]
-    fn metadata_unit_is_mapped_or_raw_sanitized_or_empty() {
+    fn metadata_unit_is_mapped_or_raw_or_empty_never_name_sanitized() {
         let (_names, metadata) = suffixed(gauge_u("foo", "furlong"));
         assert_eq!(metadata[0].unit, "furlong");
         let (_names, metadata) = suffixed(gauge_u("bar", ""));
         assert_eq!(metadata[0].unit, "");
         let (_names, metadata) = suffixed(gauge_u("baz", "By"));
         assert_eq!(metadata[0].unit, "bytes");
+        // A monotonic Sum with unit `1` gets no `_ratio` (Gauge-only), so the
+        // unit is unmapped for it; the metadata field must carry the raw `1`,
+        // not the metric-name-sanitized `_`. Same for a unit like `2h`: free
+        // text, not an identifier.
+        let (names, metadata) = suffixed(mono_sum_u("qux", "1"));
+        assert_eq!(names, vec!["qux_total".to_string()]);
+        assert_eq!(metadata[0].unit, "1");
+        let (_names, metadata) = suffixed(gauge_u("quux", "2h"));
+        assert_eq!(metadata[0].unit, "2h");
+        // Annotations are still stripped from the raw carry-through.
+        let (_names, metadata) = suffixed(gauge_u("corge", "{request}"));
+        assert_eq!(metadata[0].unit, "");
     }
 
     #[test]

--- a/crates/ravel-remote-write/src/normalize.rs
+++ b/crates/ravel-remote-write/src/normalize.rs
@@ -290,7 +290,7 @@ pub fn normalize_with_exemplars(
                 histograms_written: 0,
                 histograms_dropped: 0,
                 exemplars_dropped,
-                metadata_dropped: resolved.metadata_count,
+                metadata_dropped: resolved.metadata.len(),
                 created_timestamps_dropped: resolved.created_timestamps_count,
             },
             exemplars: Vec::new(),
@@ -330,7 +330,7 @@ pub fn normalize_with_exemplars(
             histograms_written: counts.written,
             histograms_dropped: counts.dropped,
             exemplars_dropped,
-            metadata_dropped: resolved.metadata_count,
+            metadata_dropped: resolved.metadata.len(),
             created_timestamps_dropped: resolved.created_timestamps_count,
         },
         exemplars,
@@ -1046,7 +1046,7 @@ mod tests {
     fn request(series: Vec<ResolvedSeries>) -> ResolvedRequest {
         ResolvedRequest {
             series,
-            metadata_count: 0,
+            metadata: vec![],
             created_timestamps_count: 0,
             exemplars_dropped: 0,
         }
@@ -2157,11 +2157,21 @@ mod tests {
 
     #[test]
     fn metadata_dropped_is_request_level_tally() {
+        use ravel_otlp::metadata::{MetricKind, MetricMetadata};
         let mut req = request(vec![series(
             vec![label("__name__", "up")],
             vec![sample(1_000, 1.0)],
         )]);
-        req.metadata_count = 5;
+        // `metadata_dropped` is the resolved metadata list length now that the
+        // tuple is surfaced rather than tallied (ADR-0085 Decision 1).
+        req.metadata = (0..5)
+            .map(|i| MetricMetadata {
+                family_name: format!("m{i}"),
+                kind: MetricKind::Unknown,
+                help: String::new(),
+                unit: String::new(),
+            })
+            .collect();
         let out = normalize_resolved(&tenant(), req, &IngestLimits::default(), 1_000_000);
         assert_eq!(out.metadata_dropped, 5);
     }

--- a/crates/ravel-remote-write/src/resolved.rs
+++ b/crates/ravel-remote-write/src/resolved.rs
@@ -8,6 +8,7 @@
 //! (length, uniqueness, presence of `__name__`) rather than mutating names,
 //! per ADR-0015's no-sanitization rule.
 
+use ravel_otlp::metadata::MetricMetadata;
 use ravel_types::Label;
 
 /// One sample as carried on the wire: milliseconds since epoch, not yet
@@ -112,10 +113,14 @@ pub struct ResolvedSeries {
 
 /// A resolved `WriteRequest`, version-blind.
 ///
-/// `metadata_count` is a whole-request tally: RW1's `MetricMetadata` list
-/// has no per-series correlation (unlike RW2's per-`TimeSeries` `metadata`
-/// field), so it is dropped with one request-level counter rather than
-/// distributed across series.
+/// `metadata` carries the per-metric-family `(family_name, type, help, unit)`
+/// tuples the request supplied (ADR-0085 Decision 1), surfaced rather than
+/// discarded. RW1 fills one entry per `MetricMetadata` (its list is
+/// request-level, `family_name` is `metric_family_name`); RW2 fills one entry
+/// per series carrying metadata, keyed by the series' `__name__` stripped of a
+/// structural `_bucket`/`_sum`/`_count`/`_total` suffix and deduplicated by
+/// family name (first write wins). A caller that only needs the old
+/// request-level count reads `metadata.len()`.
 ///
 /// `created_timestamps_count` tallies non-zero `start_timestamp` fields
 /// (RW2's `Sample.start_timestamp` and `Histogram.start_timestamp`; RW1's
@@ -133,7 +138,7 @@ pub struct ResolvedSeries {
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct ResolvedRequest {
     pub series: Vec<ResolvedSeries>,
-    pub metadata_count: usize,
+    pub metadata: Vec<MetricMetadata>,
     pub created_timestamps_count: usize,
     pub exemplars_dropped: usize,
 }

--- a/crates/ravel-remote-write/src/rw1.rs
+++ b/crates/ravel-remote-write/src/rw1.rs
@@ -6,6 +6,7 @@
 //! typed, non-retryable [`Rw1DecodeError`].
 
 use prost::Message;
+use ravel_otlp::metadata::{MetricKind, MetricMetadata};
 use ravel_types::Label;
 
 use crate::proto::prometheus::histogram::{Count, ZeroCount};
@@ -40,14 +41,39 @@ pub fn decode_write_request(
 }
 
 fn resolve(req: WriteRequest) -> ResolvedRequest {
+    // RW1's `MetricMetadata` list is request-level with no per-series
+    // correlation, so one resolved tuple per entry, in order (ADR-0085
+    // Decision 1). `family_name` is `metric_family_name`; help/unit are already
+    // in the Prometheus model, carried through verbatim.
+    let metadata = req.metadata.iter().map(rw1_metadata).collect();
     ResolvedRequest {
         series: req.timeseries.into_iter().map(resolve_series).collect(),
-        metadata_count: req.metadata.len(),
+        metadata,
         // prometheus.Sample carries no start_timestamp field on the wire.
         created_timestamps_count: 0,
         // RW1 resolves no symbol table and charges no resolved-label budget, so
         // no exemplar is ever dropped at decode time.
         exemplars_dropped: 0,
+    }
+}
+
+/// Map one RW1 `prometheus.MetricMetadata` to the protocol-neutral tuple.
+/// `GAUGEHISTOGRAM`, `INFO`, `STATESET`, and `UNKNOWN` have no canonical Ravel
+/// kind and map to [`MetricKind::Unknown`] rather than being guessed.
+fn rw1_metadata(m: &crate::proto::prometheus::MetricMetadata) -> MetricMetadata {
+    use crate::proto::prometheus::metric_metadata::MetricType;
+    let kind = match MetricType::try_from(m.r#type) {
+        Ok(MetricType::Counter) => MetricKind::Counter,
+        Ok(MetricType::Gauge) => MetricKind::Gauge,
+        Ok(MetricType::Histogram) => MetricKind::Histogram,
+        Ok(MetricType::Summary) => MetricKind::Summary,
+        _ => MetricKind::Unknown,
+    };
+    MetricMetadata {
+        family_name: m.metric_family_name.clone(),
+        kind,
+        help: m.help.clone(),
+        unit: m.unit.clone(),
     }
 }
 
@@ -299,15 +325,16 @@ mod tests {
     }
 
     #[test]
-    fn metadata_is_a_request_level_tally() {
+    fn metadata_list_surfaces_with_kinds_mapped() {
         use crate::proto::prometheus::metric_metadata::MetricType;
+        use ravel_otlp::metadata::MetricKind;
         let mut req = write_request(vec![]);
         req.metadata = vec![
             MetricMetadata {
                 r#type: MetricType::Counter as i32,
                 metric_family_name: "a".to_string(),
-                help: String::new(),
-                unit: String::new(),
+                help: "help a".to_string(),
+                unit: "bytes".to_string(),
             },
             MetricMetadata {
                 r#type: MetricType::Gauge as i32,
@@ -315,11 +342,24 @@ mod tests {
                 help: String::new(),
                 unit: String::new(),
             },
+            // GAUGEHISTOGRAM has no canonical Ravel kind: Unknown, not guessed.
+            MetricMetadata {
+                r#type: MetricType::Gaugehistogram as i32,
+                metric_family_name: "c".to_string(),
+                help: String::new(),
+                unit: String::new(),
+            },
         ];
         let body = compress(&req.encode_to_vec());
 
         let resolved = decode_write_request(&body, 1_000_000).expect("decode");
-        assert_eq!(resolved.metadata_count, 2);
+        assert_eq!(resolved.metadata.len(), 3);
+        assert_eq!(resolved.metadata[0].family_name, "a");
+        assert_eq!(resolved.metadata[0].kind, MetricKind::Counter);
+        assert_eq!(resolved.metadata[0].help, "help a");
+        assert_eq!(resolved.metadata[0].unit, "bytes");
+        assert_eq!(resolved.metadata[1].kind, MetricKind::Gauge);
+        assert_eq!(resolved.metadata[2].kind, MetricKind::Unknown);
     }
 
     #[test]
@@ -328,7 +368,7 @@ mod tests {
         let body = compress(&req.encode_to_vec());
         let resolved = decode_write_request(&body, 1_000_000).expect("decode");
         assert!(resolved.series.is_empty());
-        assert_eq!(resolved.metadata_count, 0);
+        assert!(resolved.metadata.is_empty());
     }
 
     #[test]

--- a/crates/ravel-remote-write/src/rw1.rs
+++ b/crates/ravel-remote-write/src/rw1.rs
@@ -45,7 +45,15 @@ fn resolve(req: WriteRequest) -> ResolvedRequest {
     // correlation, so one resolved tuple per entry, in order (ADR-0085
     // Decision 1). `family_name` is `metric_family_name`; help/unit are already
     // in the Prometheus model, carried through verbatim.
-    let metadata = req.metadata.iter().map(rw1_metadata).collect();
+    // An entry with an empty `metric_family_name` (legal on the wire) has no
+    // family to attach to and the catalog writer refuses empty names, so it is
+    // dropped here rather than poisoning a later flush.
+    let metadata = req
+        .metadata
+        .iter()
+        .filter(|m| !m.metric_family_name.is_empty())
+        .map(rw1_metadata)
+        .collect();
     ResolvedRequest {
         series: req.timeseries.into_iter().map(resolve_series).collect(),
         metadata,
@@ -360,6 +368,30 @@ mod tests {
         assert_eq!(resolved.metadata[0].unit, "bytes");
         assert_eq!(resolved.metadata[1].kind, MetricKind::Gauge);
         assert_eq!(resolved.metadata[2].kind, MetricKind::Unknown);
+    }
+
+    #[test]
+    fn metadata_with_empty_family_name_is_dropped_not_surfaced() {
+        use crate::proto::prometheus::metric_metadata::MetricType;
+        let mut req = write_request(vec![]);
+        req.metadata = vec![
+            MetricMetadata {
+                r#type: MetricType::Counter as i32,
+                metric_family_name: String::new(),
+                help: "orphan".to_string(),
+                unit: String::new(),
+            },
+            MetricMetadata {
+                r#type: MetricType::Gauge as i32,
+                metric_family_name: "kept".to_string(),
+                help: String::new(),
+                unit: String::new(),
+            },
+        ];
+        let body = compress(&req.encode_to_vec());
+        let resolved = decode_write_request(&body, 1_000_000).expect("decode");
+        assert_eq!(resolved.metadata.len(), 1);
+        assert_eq!(resolved.metadata[0].family_name, "kept");
     }
 
     #[test]

--- a/crates/ravel-remote-write/src/rw2.rs
+++ b/crates/ravel-remote-write/src/rw2.rs
@@ -15,8 +15,11 @@
 //! typed, non-retryable [`Rw2DecodeError`]; this module never panics on
 //! malformed input.
 
+use std::collections::HashSet;
+
 use prost::Message;
-use ravel_types::Label;
+use ravel_otlp::metadata::{MetricKind, MetricMetadata};
+use ravel_types::{Label, METRIC_NAME_LABEL};
 
 use crate::proto::write_v2::histogram::{Count, ZeroCount};
 use crate::proto::write_v2::{
@@ -136,7 +139,8 @@ pub fn decode_request(
 fn resolve(req: Request, resolved_label_budget: usize) -> Result<ResolvedRequest, Rw2DecodeError> {
     let symbols = req.symbols;
     let mut series = Vec::with_capacity(req.timeseries.len());
-    let mut metadata_count = 0usize;
+    let mut metadata: Vec<MetricMetadata> = Vec::new();
+    let mut metadata_seen: HashSet<String> = HashSet::new();
     let mut created_timestamps_count = 0usize;
     let mut exemplars_dropped = 0usize;
     let mut resolved_label_bytes = 0usize;
@@ -151,7 +155,8 @@ fn resolve(req: Request, resolved_label_budget: usize) -> Result<ResolvedRequest
             series_index,
             ts,
             &symbols,
-            &mut metadata_count,
+            &mut metadata,
+            &mut metadata_seen,
             &mut created_timestamps_count,
             &mut exemplars_dropped,
             &mut resolved_label_bytes,
@@ -161,10 +166,42 @@ fn resolve(req: Request, resolved_label_budget: usize) -> Result<ResolvedRequest
     }
     Ok(ResolvedRequest {
         series,
-        metadata_count,
+        metadata,
         created_timestamps_count,
         exemplars_dropped,
     })
+}
+
+/// Map one RW2 `io.prometheus.write.v2.Metadata` type to the protocol-neutral
+/// kind. Types with no canonical Ravel kind (`GAUGEHISTOGRAM`, `INFO`,
+/// `STATESET`, `UNSPECIFIED`) map to [`MetricKind::Unknown`].
+fn rw2_kind(ty: i32) -> MetricKind {
+    use crate::proto::write_v2::metadata::MetricType;
+    match MetricType::try_from(ty) {
+        Ok(MetricType::Counter) => MetricKind::Counter,
+        Ok(MetricType::Gauge) => MetricKind::Gauge,
+        Ok(MetricType::Histogram) => MetricKind::Histogram,
+        Ok(MetricType::Summary) => MetricKind::Summary,
+        _ => MetricKind::Unknown,
+    }
+}
+
+/// Strip one structural suffix from an RW2 series `__name__` to recover the
+/// metric family name (ADR-0085 Decision 1): `_bucket`/`_sum`/`_count` always,
+/// and `_total` only when the metric type is `Counter` (so a gauge legitimately
+/// named `foo_total` keeps its name). At most one suffix is removed.
+fn strip_structural_suffix(name: &str, kind: MetricKind) -> &str {
+    for suffix in ["_bucket", "_sum", "_count"] {
+        if let Some(stripped) = name.strip_suffix(suffix) {
+            return stripped;
+        }
+    }
+    if matches!(kind, MetricKind::Counter)
+        && let Some(stripped) = name.strip_suffix("_total")
+    {
+        return stripped;
+    }
+    name
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -172,7 +209,8 @@ fn resolve_series(
     series_index: usize,
     ts: ProtoTimeSeriesV2,
     symbols: &[String],
-    metadata_count: &mut usize,
+    metadata: &mut Vec<MetricMetadata>,
+    metadata_seen: &mut HashSet<String>,
     created_timestamps_count: &mut usize,
     exemplars_dropped: &mut usize,
     resolved_label_bytes: &mut usize,
@@ -226,7 +264,29 @@ fn resolve_series(
                 symbols_len: symbols.len(),
             });
         }
-        *metadata_count += 1;
+        // One tuple per metric family, keyed by the series `__name__` stripped
+        // of a structural suffix and deduplicated first-wins, so a classic
+        // histogram's `_bucket`/`_sum`/`_count` series collapse to one entry
+        // (ADR-0085 Decision 1). A series carrying metadata but no `__name__`
+        // has no family to key on and is skipped. help_ref/unit_ref are already
+        // range-checked above, so indexing `symbols` is in bounds.
+        let kind = rw2_kind(meta.r#type);
+        if let Some(name) = labels
+            .iter()
+            .find(|l| l.name == METRIC_NAME_LABEL)
+            .map(|l| l.value.as_str())
+            .filter(|v| !v.is_empty())
+        {
+            let family = strip_structural_suffix(name, kind).to_string();
+            if metadata_seen.insert(family.clone()) {
+                metadata.push(MetricMetadata {
+                    family_name: family,
+                    kind,
+                    help: symbols[meta.help_ref as usize].clone(),
+                    unit: symbols[meta.unit_ref as usize].clone(),
+                });
+            }
+        }
     }
 
     let mut samples = Vec::with_capacity(ts.samples.len());
@@ -633,7 +693,8 @@ mod tests {
     }
 
     #[test]
-    fn metadata_help_and_unit_refs_are_a_per_series_tally() {
+    fn metadata_surfaces_as_a_family_tuple() {
+        use ravel_otlp::metadata::MetricKind;
         let syms = symbols(&["__name__", "up", "help text", "seconds"]);
         let req = request(
             syms,
@@ -651,7 +712,76 @@ mod tests {
         );
 
         let resolved = decode(&req).expect("decode");
-        assert_eq!(resolved.metadata_count, 1);
+        assert_eq!(resolved.metadata.len(), 1);
+        assert_eq!(resolved.metadata[0].family_name, "up");
+        // Type 0 is METRIC_TYPE_UNSPECIFIED: no canonical kind, not guessed.
+        assert_eq!(resolved.metadata[0].kind, MetricKind::Unknown);
+        assert_eq!(resolved.metadata[0].help, "help text");
+        assert_eq!(resolved.metadata[0].unit, "seconds");
+    }
+
+    #[test]
+    fn metadata_tuples_use_family_name_stripped_of_structural_suffixes() {
+        use crate::proto::write_v2::metadata::MetricType;
+        use ravel_otlp::metadata::MetricKind;
+        // 0="",1="__name__",2..6=series names,7="help text",8="s"
+        let syms = symbols(&[
+            "__name__",
+            "foo_bucket",
+            "foo_sum",
+            "foo_count",
+            "bar_total",
+            "baz_total",
+            "help text",
+            "s",
+        ]);
+        let hist_meta = |name_ref: u32| ProtoTimeSeriesV2 {
+            labels_refs: vec![1, name_ref],
+            samples: vec![],
+            histograms: vec![],
+            exemplars: vec![],
+            metadata: Some(ProtoMetadataV2 {
+                r#type: MetricType::Histogram as i32,
+                help_ref: 7,
+                unit_ref: 8,
+            }),
+        };
+        let typed = |name_ref: u32, ty: MetricType| ProtoTimeSeriesV2 {
+            labels_refs: vec![1, name_ref],
+            samples: vec![],
+            histograms: vec![],
+            exemplars: vec![],
+            metadata: Some(ProtoMetadataV2 {
+                r#type: ty as i32,
+                help_ref: 7,
+                unit_ref: 8,
+            }),
+        };
+        let req = request(
+            syms,
+            vec![
+                hist_meta(2),                  // foo_bucket -> foo
+                hist_meta(3),                  // foo_sum    -> foo (deduped)
+                hist_meta(4),                  // foo_count  -> foo (deduped)
+                typed(5, MetricType::Counter), // bar_total -> bar
+                typed(6, MetricType::Gauge),   // baz_total stays (not a counter)
+            ],
+        );
+
+        let resolved = decode(&req).expect("decode");
+        let families: Vec<(&str, MetricKind)> = resolved
+            .metadata
+            .iter()
+            .map(|m| (m.family_name.as_str(), m.kind))
+            .collect();
+        assert_eq!(
+            families,
+            vec![
+                ("foo", MetricKind::Histogram),
+                ("bar", MetricKind::Counter),
+                ("baz_total", MetricKind::Gauge),
+            ]
+        );
     }
 
     #[test]
@@ -684,7 +814,7 @@ mod tests {
         let req = request(symbols(&[]), vec![]);
         let resolved = decode(&req).expect("decode");
         assert!(resolved.series.is_empty());
-        assert_eq!(resolved.metadata_count, 0);
+        assert!(resolved.metadata.is_empty());
         assert_eq!(resolved.created_timestamps_count, 0);
     }
 

--- a/crates/ravel-remote-write/src/rw2.rs
+++ b/crates/ravel-remote-write/src/rw2.rs
@@ -278,7 +278,10 @@ fn resolve_series(
             .filter(|v| !v.is_empty())
         {
             let family = strip_structural_suffix(name, kind).to_string();
-            if metadata_seen.insert(family.clone()) {
+            // A series literally named `_bucket`/`_sum`/`_count` (or `_total`
+            // on a Counter) strips to nothing; an empty family name is not a
+            // metadata entry (the catalog writer refuses it), so skip it.
+            if !family.is_empty() && metadata_seen.insert(family.clone()) {
                 metadata.push(MetricMetadata {
                     family_name: family,
                     kind,
@@ -781,6 +784,42 @@ mod tests {
                 ("bar", MetricKind::Counter),
                 ("baz_total", MetricKind::Gauge),
             ]
+        );
+    }
+
+    #[test]
+    fn series_that_strips_to_an_empty_family_name_yields_no_metadata_entry() {
+        use crate::proto::write_v2::metadata::MetricType;
+        // 0="",1="__name__",2="_bucket",3="_total",4="help",5="s"
+        let syms = symbols(&["__name__", "_bucket", "_total", "help", "s"]);
+        let typed = |name_ref: u32, ty: MetricType| ProtoTimeSeriesV2 {
+            labels_refs: vec![1, name_ref],
+            samples: vec![],
+            histograms: vec![],
+            exemplars: vec![],
+            metadata: Some(ProtoMetadataV2 {
+                r#type: ty as i32,
+                help_ref: 4,
+                unit_ref: 5,
+            }),
+        };
+        let req = request(
+            syms,
+            vec![
+                typed(2, MetricType::Histogram), // "_bucket" -> "" -> dropped
+                typed(3, MetricType::Counter),   // "_total"  -> "" -> dropped
+            ],
+        );
+        let resolved = decode(&req).expect("decode");
+        assert!(
+            resolved.metadata.is_empty(),
+            "an empty family name must not become a metadata entry: {:?}",
+            resolved.metadata
+        );
+        assert_eq!(
+            resolved.series.len(),
+            2,
+            "the series themselves still decode"
         );
     }
 


### PR DESCRIPTION
OTLP and OTAP metrics now get the OTLP-to-Prometheus name suffixes a
collector's Prometheus exporter would apply: the unit suffix from the
OTel unit table, then _total for a monotonic Sum, applied before the
name reaches SeriesId::compute and before the ADR-0016 structural
explosion. A counter foo with unit By ingests as foo_bytes_total, the
same series name it gets through a collector, so dashboards match
regardless of ingest path. This is the one-time compat break ADR-0085
calls out; historical data under old names is untouched.

Every decoder (OTLP, OTAP, RW1, RW2) now surfaces a protocol-neutral
(family_name, kind, help, unit) tuple. Additive only: existing entry
points and public types keep their signatures; a new
normalize_metrics_with_metadata entry point returns the tuples, and
ResolvedRequest.metadata replaces the RW metadata_count tally. The
tuples have no consumer yet; the ravel-ingest sink (#235) is next.

Fixes: #233
Fixes: #234
Refs: #119
