### PR TITLE
docs: claim ADR-0086 github-releases-and-release-hygiene

### DIFF
--- a/docs/adrs/0086-github-releases-and-release-hygiene.md
+++ b/docs/adrs/0086-github-releases-and-release-hygiene.md
@@ -1,0 +1,3 @@
+# ADR-0086: GitHub Releases, downloadable binaries, and release hygiene
+
+Status: claimed


### PR DESCRIPTION
Reserve ADR number 0086 on main before writing the full ADR, so a parallel epic cannot pick the same number.

Stub only: a title line and `Status: claimed`. The full ADR overwrites it after the approval gate.