### PR TITLE
ci: lint workflow files, and guard workspace version drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,8 +173,78 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Check derived-doc drift (docs/query-engine.md)
         run: scripts/check-doc-drift.sh
+      - name: Check workspace version drift (ADR-0086 D8)
+        run: scripts/check-workspace-versions.sh
       - name: Python script unit tests
         run: make test-python
+
+  # Lint the workflow files themselves (ADR-0086 decision 7). actionlint is
+  # cheap and uses no cargo toolchain, so like doc-scripts it runs on every
+  # trigger rather than gating on `changes`.
+  #
+  # The whole point of this job is that shellcheck is GENUINELY available to
+  # actionlint. actionlint runs shellcheck over every `run:` script, but when
+  # the shellcheck binary is absent it silently skips those checks and still
+  # exits 0: a linter whose sub-checker is missing reports clean identically to
+  # one that ran everything. During epic #218 an executor hit exactly this,
+  # reporting a file clean that a shellcheck-enabled actionlint flagged twice
+  # (SC2046, SC2129). So this job installs a pinned shellcheck itself and then
+  # asserts it is on PATH before running actionlint; if that install or
+  # assertion fails, the job fails rather than linting less. Relying on the
+  # runner image's preinstalled shellcheck is exactly the silent-drift risk the
+  # ADR names, so both binaries are installed here at pinned, checksum-verified
+  # versions.
+  actionlint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      # Pinned versions and their published sha256 sums (exact-version pinning,
+      # the download equivalent of the commit-SHA pins the `uses:` steps carry).
+      ACTIONLINT_VERSION: 1.7.7
+      ACTIONLINT_SHA256: 023070a287cd8cccd71515fedc843f1985bf96c436b7effaecce67290e7e0757
+      SHELLCHECK_VERSION: v0.10.0
+      SHELLCHECK_SHA256: 6c881ab0698e4e6ea235245f22832860544f17ba386442fe7e9d629f8cbedf87
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - name: Install pinned shellcheck and actionlint
+        run: |
+          bin_dir="${RUNNER_TEMP}/lint-bin"
+          mkdir -p "$bin_dir"
+
+          # Verify the shellcheck archive's sha256 before extracting, then
+          # place the binary on PATH for the assert and lint steps below.
+          curl -fsSL -o shellcheck.tar.xz \
+            "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz"
+          echo "${SHELLCHECK_SHA256}  shellcheck.tar.xz" | sha256sum -c -
+          tar -xJf shellcheck.tar.xz
+          mv "shellcheck-${SHELLCHECK_VERSION}/shellcheck" "$bin_dir/shellcheck"
+
+          # actionlint: same verify-then-extract shape.
+          curl -fsSL -o actionlint.tar.gz \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          echo "${ACTIONLINT_SHA256}  actionlint.tar.gz" | sha256sum -c -
+          tar -xzf actionlint.tar.gz actionlint
+          mv actionlint "$bin_dir/actionlint"
+
+          echo "$bin_dir" >> "$GITHUB_PATH"
+      - name: Assert shellcheck is available
+        run: |
+          # actionlint exits 0 when shellcheck is missing, silently linting
+          # less (ADR-0086 D7). Fail the job here instead, so a missing
+          # sub-checker can never be mistaken for a clean run. This resolves
+          # on the same PATH actionlint uses in the next step.
+          if ! command -v shellcheck >/dev/null 2>&1; then
+            echo "::error::shellcheck not on PATH; actionlint would skip its shell checks and still pass (ADR-0086 D7)"
+            exit 1
+          fi
+          shellcheck --version
+      - name: Lint workflow files
+        run: |
+          # No path args: actionlint discovers every workflow under
+          # .github/workflows/ on its own, so a new workflow is covered
+          # automatically. -shellcheck=shellcheck names the binary asserted
+          # present above explicitly rather than relying on the default lookup.
+          actionlint -color -shellcheck=shellcheck
 
   # First-stage fail-fast gate (ADR-0053 D3). Runs fmt and the two clippy
   # configurations the workspace has (default features, plus ravel-server's
@@ -536,7 +606,7 @@ jobs:
             minio/minio:latest server /data
       - name: Wait for MinIO to be live
         run: |
-          for i in $(seq 1 30); do
+          for _ in $(seq 1 30); do
             if curl -fsS http://localhost:9000/minio/health/live; then
               echo "MinIO is live"
               exit 0
@@ -604,7 +674,7 @@ jobs:
           # floci reports per-service readiness, so wait on S3 specifically
           # rather than on the process being up: the container answers on
           # 4566 before every handler is running.
-          for i in $(seq 1 60); do
+          for _ in $(seq 1 60); do
             if curl -fsS http://localhost:4566/_floci/health | grep -q '"s3":"running"'; then
               echo "floci S3 is live"
               exit 0
@@ -709,7 +779,7 @@ jobs:
             minio/minio:latest server /data
       - name: Wait for MinIO to be live
         run: |
-          for i in $(seq 1 30); do
+          for _ in $(seq 1 30); do
             if curl -fsS http://localhost:9000/minio/health/live; then
               echo "MinIO is live"
               exit 0
@@ -1374,7 +1444,7 @@ jobs:
       - name: Wait for ravel-server readiness
         if: steps.filter.outputs.run == 'true'
         run: |
-          for i in $(seq 1 60); do
+          for _ in $(seq 1 60); do
             if curl -fsS "${RAVEL_HTTP_BASE}/readyz" >/dev/null 2>&1; then
               echo "ravel-server ready"
               exit 0

--- a/.github/workflows/quickstart-published.yml
+++ b/.github/workflows/quickstart-published.yml
@@ -131,7 +131,7 @@ jobs:
       # comes up. A fixed sleep would race image-pull and startup time.
       - name: Wait for ravel-server readiness
         run: |
-          for i in $(seq 1 60); do
+          for _ in $(seq 1 60); do
             if curl -fsS "${RAVEL_HTTP_BASE}/readyz" >/dev/null 2>&1; then
               echo "ravel-server ready"
               exit 0

--- a/scripts/check-workspace-versions.sh
+++ b/scripts/check-workspace-versions.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# Workspace version-drift guard (ADR-0086 decision 8).
+#
+# Failure class this prevents: a version bump that updates
+# `[workspace.package] version` in the root Cargo.toml but leaves one or more
+# path dependencies pinned to the old version. Epic #218 shipped a 0.9.3 bump
+# that left seven per-crate path dependencies requiring 0.9.2. That compiles,
+# because a caret requirement on 0.9.2 is satisfied by a 0.9.3 path crate, so
+# the drift stays invisible until a MINOR bump makes those requirements fail to
+# resolve, landing the failure on whoever cuts 0.10.0, far from the change that
+# caused it.
+#
+# This asserts the invariant directly: every `version = "..."` attached to a
+# path dependency, in every workspace manifest, must equal the root
+# `[workspace.package] version`. It reads Cargo.toml text only; no cargo build,
+# no toolchain.
+#
+# Exit 0 when every path-dependency version matches, 1 on drift (each mismatch
+# named as file:line), 2 when the workspace version cannot be read at all.
+#
+# Portability: must run on bash 3.2 (macOS system bash) as well as bash 5, so
+# no `mapfile` and no associative arrays (issue #193). The line-by-line parsing
+# is done in awk for the same reason.
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+root_manifest=$repo_root/Cargo.toml
+
+fail_setup() {
+  echo "check-workspace-versions: $1" >&2
+  exit 2
+}
+
+[[ -r $root_manifest ]] || fail_setup "cannot read $root_manifest"
+
+# The authoritative version: the `version` key inside the [workspace.package]
+# table, not [workspace.dependencies] or any other section. awk tracks the
+# current table header so a `version` line elsewhere can never be mistaken for
+# it.
+ws_version=$(awk '
+  /^\[/ { in_pkg = ($0 == "[workspace.package]"); next }
+  in_pkg && match($0, /^[[:space:]]*version[[:space:]]*=[[:space:]]*"[^"]*"/) {
+    v = substr($0, RSTART, RLENGTH)
+    match(v, /"[^"]*"/)
+    print substr(v, RSTART + 1, RLENGTH - 2)
+    exit
+  }
+' "$root_manifest")
+[[ -n $ws_version ]] ||
+  fail_setup "no [workspace.package] version in $root_manifest"
+
+# Every tracked Cargo.toml in the workspace. `git ls-files` keeps vendored,
+# target/, and node_modules manifests out of scope without a prune list.
+manifests=$(git -C "$repo_root" ls-files '*Cargo.toml' 'Cargo.toml')
+[[ -n $manifests ]] || fail_setup "no Cargo.toml files tracked in $repo_root"
+
+# Scan one manifest, printing "<file>:<line>: ..." for each path dependency
+# whose version differs from the workspace version. Handles both dependency
+# spellings this repo could use:
+#   - inline table:  foo = { path = "../foo", version = "0.9.3" }
+#   - table header:  [dependencies.foo] / [dev-dependencies.foo] with `path`
+#     and `version` on separate lines.
+# A path KEY is matched only when preceded by `{`, `,`, or line start, so a
+# crate whose NAME ends in "path" (fastpath = { version = "1" }) is not a false
+# positive, and a `[[bin]]` `path = "src/..."` target carries no version so it
+# is never checked. Exit status: 1 if any drift was printed, else 0.
+scan_manifest() {
+  awk -v ws="$ws_version" -v file="$1" '
+    function verval(s,   v) {
+      # Return the quoted value of the first `version = "..."` on the line.
+      # Both TOML string forms are accepted: basic (double-quoted) and literal
+      # (single-quoted). Cargo writes double quotes, but a hand-edited manifest
+      # using literal strings is legal TOML and must not slip past the guard.
+      if (match(s, /version[[:space:]]*=[[:space:]]*"[^"]*"/)) {
+        v = substr(s, RSTART, RLENGTH)
+        match(v, /"[^"]*"/)
+        return substr(v, RSTART + 1, RLENGTH - 2)
+      }
+      if (match(s, /version[[:space:]]*=[[:space:]]*'"'"'[^'"'"']*'"'"'/)) {
+        v = substr(s, RSTART, RLENGTH)
+        match(v, /'"'"'[^'"'"']*'"'"'/)
+        return substr(v, RSTART + 1, RLENGTH - 2)
+      }
+      return ""
+    }
+
+    function bare(v) {
+      # Strip a leading comparator so an explicitly caret- or tilde-pinned
+      # path dependency is compared on its version, not on its operator:
+      # `version = "^0.9.3"` against workspace 0.9.3 is a match, not drift.
+      # A comparator on a DIFFERENT version (`"^0.9.2"`) still fails, which is
+      # the case that matters.
+      sub(/^[[:space:]]*(\^|~|>=|<=|=|>|<)[[:space:]]*/, "", v)
+      return v
+    }
+    function report(ver) {
+      printf "%s:%d: path dependency version \"%s\" != workspace version \"%s\"\n", \
+        file, FNR, ver, ws
+      bad = 1
+    }
+    # Flush a pending multiline dependency table before moving on.
+    function flush(   v) {
+      if (tbl_is_dep && tbl_path && tbl_ver != "") {
+        if (bare(tbl_ver) != ws) {
+          printf "%s:%d: path dependency version \"%s\" != workspace version \"%s\"\n", \
+            file, tbl_ver_line, tbl_ver, ws
+          bad = 1
+        }
+      }
+      tbl_is_dep = 0; tbl_path = 0; tbl_ver = ""; tbl_ver_line = 0
+    }
+    # A commented-out line is not a dependency. Without this a stale dep left
+    # behind a `#` fails the build, which teaches people to delete the comment
+    # rather than fix the version.
+    /^[[:space:]]*#/ { next }
+    /^\[/ {
+      flush()
+      # A single-dependency table: [dependencies.NAME], [dev-dependencies.NAME],
+      # [build-dependencies.NAME], or a target-scoped variant of any of them.
+      tbl_is_dep = ($0 ~ /^\[([^]]*\.)?(dependencies|dev-dependencies|build-dependencies)\.[^]]+\][[:space:]]*$/)
+      next
+    }
+    # Inline-table path dependency: a `path` key inside `{ ... }` on this line,
+    # plus a `version` key on the same line.
+    /[{,[:space:]]path[[:space:]]*=/ && /version[[:space:]]*=/ {
+      ver = verval($0)
+      if (ver != "" && bare(ver) != ws) report(ver)
+      next
+    }
+    # Multiline dependency-table body: accumulate path/version until the table
+    # ends (next header or EOF), then compare in flush().
+    tbl_is_dep && /^[[:space:]]*path[[:space:]]*=/ { tbl_path = 1; next }
+    tbl_is_dep && /^[[:space:]]*version[[:space:]]*=/ {
+      tbl_ver = verval($0); tbl_ver_line = FNR; next
+    }
+    END { flush(); exit bad }
+  ' "$1"
+}
+
+drift=0
+while IFS= read -r manifest; do
+  [[ -n $manifest ]] || continue
+  scan_manifest "$repo_root/$manifest" || drift=1
+done <<EOF
+$manifests
+EOF
+
+if ((drift)); then
+  echo "check-workspace-versions: path dependency versions drifted from [workspace.package] version \"$ws_version\"; update the versions listed above (ADR-0086 decision 8)" >&2
+  exit 1
+fi
+
+echo "check-workspace-versions: all path dependency versions match [workspace.package] version \"$ws_version\""


### PR DESCRIPTION
ADR-0086 decisions 7 and 8.

actionlint exits 0 when shellcheck is absent, silently skipping every shell
check. That is not theoretical: during epic #218 an executor ran actionlint on
a 300-line workflow rework, got exit 0, and reported it clean, while a
shellcheck-enabled actionlint on the same file reported SC2046 and SC2129. A
linter whose sub-checker is missing reports clean identically to one that ran
everything, and nothing downstream can tell the difference. Reproduced here
before building on it: `actionlint -shellcheck=<missing>` and `-shellcheck=`
both exit 0 on this repository's ci.yml.

The new job makes that state impossible three ways: it installs shellcheck
itself at a pinned, checksum-verified version so a failed download or checksum
fails the job rather than falling back; it asserts `command -v shellcheck` and
runs `shellcheck --version` on the same PATH the lint step uses, so a
present-but-unrunnable binary also fails; and it passes `-shellcheck=shellcheck`
explicitly rather than relying on default lookup. It does not trust the runner
image's preinstalled copy, which is the silent drift the ADR names.

The version guard fails when any path dependency's version differs from
`[workspace.package] version`. Epic #218 shipped a 0.9.3 bump that left seven
per-crate path dependencies requiring 0.9.2. That compiles, because a caret
requirement on 0.9.2 is satisfied by a 0.9.3 path crate, so it stays invisible
until a minor bump makes those requirements fail to resolve, landing the
failure on whoever cuts 0.10.0. It runs in doc-scripts, which is unconditional
and is one of main's required checks.

The guard was verified against constructed manifests rather than assumed:
inline and table-style declarations, dev- and build-dependencies,
target-scoped tables, comparator versions, single-quoted TOML strings,
commented-out lines, and external crates that carry a version but no path. A
caret pin on the matching version is not drift; a caret pin on a different one
is. It parses with awk and uses no bash 4 features, so it runs on macOS
(issue #193).

Five pre-existing SC2034 findings are fixed, all unused loop variables in
health-check wait loops renamed to `_`. No loop body referenced them.

Fixes: #245
Refs: #243
