### PR TITLE
docs: backfill the changelog, name all three images, amend ADR-0037 topology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,84 @@ All notable changes to Ravel are documented in this file. The format is based
 on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and Ravel aims to
 follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.3]
+
+### Added
+
+- `ravel-ingest-router`, a Ravel-native ingest router that steers OTLP over
+  HTTP and gRPC (HTTP/2) to a stable subset of ingest replicas, published as
+  its own container image.
+- gzip-compressed OTLP ingest over HTTP.
+- Exemplars carried end to end over the OTLP HTTP ingest path.
+- An optional `Authorization` credential on alert-sink delivery.
+- Operator support for Gateway API ingress exposure and a Ravel-native
+  ingest-affinity backend, per-tenant shard overrides, and an
+  operator-settable flush cadence.
+- Durable per-tenant indexed-field overrides applied at ingest, and a
+  per-tenant PUT attribution metric family.
+- Multi-architecture container images: `linux/amd64` and `linux/arm64` are
+  each built on a native runner and the merged index is signed.
+- A container-first quickstart whose marked README command blocks are
+  asserted against a live stack in CI.
+
+### Fixed
+
+- Bump `h2` to 0.4.16 for RUSTSEC-2026-0258.
+- `ravel-ingest-router` supervises its background tasks and redacts secrets
+  from `Debug` output.
+
+## [0.9.2]
+
+### Added
+
+- RSPAN v4 span segment format: per-key typed attribute columns replace the
+  single opaque per-row attribute blob, and span events, including the
+  exception stack traces they carry, are promoted into scan-queryable nested
+  columns.
+
+### Fixed
+
+- Set the workspace version to the real release version so the image-publish
+  version-tag gate passes; `0.9.0` and `0.9.1` had shipped from a `0.1.0`
+  placeholder.
+
+## [0.9.1]
+
+### Added
+
+- Selective subject erasure across metrics, logs, and traces: `ravel-cli
+  erase submit` and `erase status`, resolver-side exclusion of erased
+  subjects, and a segment-rewrite pass that removes their data from stored
+  objects.
+- A `spans` SQL table alongside `samples` and `logs`, over both HTTP and
+  Flight SQL, with service name, duration, and status-code predicate
+  pushdown.
+- OIDC and mTLS tenant resolvers, the latter served on a dedicated listener,
+  for authenticating tenants without static bearer tokens.
+- Per-tenant query cost governance: bytes-scanned and S3-request budgets
+  enforced during scans, with per-query cost accounting exported on
+  `/metrics`.
+- Online resharding through a generation-versioned shard count, with
+  maintenance work leased across workers.
+- Query-path OTLP trace export, enabled with `--otlp-trace-endpoint`.
+- A local read-cache tier over RAM and disk in front of object-store reads.
+- Signed and attested release images: every published index is cosign-signed
+  in keyless mode and carries an SBOM and build provenance, and a tag publish
+  is gated on a passing CI run for the tagged commit.
+
+### Changed
+
+- Cross-cluster federation defaults to TLS and warns on plaintext.
+- Ingest flushes are pipelined with an adaptive flush delay, and process-wide
+  ingest memory is bounded with idle-tenant eviction.
+
+### Security
+
+- Constant-time bearer-token lookup and a decode panic guard on the OTAP
+  ingest path.
+- Require an OIDC audience, and bump `jsonwebtoken` to 10.4 for
+  CVE-2026-25537.
+
 ## [0.9.0]
 
 First public release. Ravel is an OpenTelemetry-native observability database

--- a/README.md
+++ b/README.md
@@ -181,8 +181,9 @@ See the [Kubernetes guide](docs/guides/kubernetes.md).
 
 ## Container images
 
-`ravel-server` and `ravel-operator` publish to the GitHub Container Registry on
-every `vX.Y.Z` release tag, built from the root `Dockerfile`
+`ravel-server`, `ravel-operator`, and `ravel-ingest-router` publish to the
+GitHub Container Registry on every `vX.Y.Z` release tag, built from the root
+`Dockerfile`
 (see [ADR-0037](docs/adrs/0037-container-image-ci-registry.md)). Both
 `linux/amd64` and `linux/arm64` are published.
 Each published object is an OCI image index that carries an SBOM and full build
@@ -192,6 +193,7 @@ it with `RAVEL_IMAGE`.
 ```sh
 docker pull ghcr.io/nofireai/ravel-server:latest
 docker pull ghcr.io/nofireai/ravel-operator:latest
+docker pull ghcr.io/nofireai/ravel-ingest-router:latest
 ```
 
 `X.Y.Z` is write-once. A bad release is superseded by a new patch release, never
@@ -204,8 +206,8 @@ an immutable reference.
 Every published index digest is signed with
 [cosign](https://github.com/sigstore/cosign) in keyless mode. The signing
 certificate binds the signature to the release workflow's identity, so you can
-verify a pull without a pre-shared key. Releases are cut from the public mirror
-`NOFireAI/ravel`, so that is the identity in the certificate:
+verify a pull without a pre-shared key. Releases are cut from this repository,
+so that is the identity in the certificate:
 
 ```sh
 cosign verify \

--- a/docs/adrs/0037-container-image-ci-registry.md
+++ b/docs/adrs/0037-container-image-ci-registry.md
@@ -570,3 +570,34 @@ set out to avoid.
   only which digest is signed.
 - No frozen format changes, no crate changes, no runtime behavior change.
   This amendment is CI configuration, a compose file, and documentation.
+
+## Amendment: repository topology
+
+The two amendments above reason throughout about releases publishing from a
+public mirror. Decision 7 grounds keyless signing in "the mirror is the
+repository strangers can actually read", decision 9 rejects the implicit CI
+gate because the tagged commit "lives on the mirror's rewritten history", and
+several of the supporting facts describe `v0.9.0` existing only on the mirror.
+That reasoning was written when this repository was the private `store` and a
+separate public mirror, `NOFireAI/ravel`, carried the releases.
+
+That topology no longer holds. `origin` is now `NOFireAI/ravel` directly: this
+repository is the public one, and there is no separate mirror. There is no
+rewritten downstream history, and release tags live here rather than only on a
+mirror.
+
+Read the mirror-era passages in the sections above historically. They record
+why the decisions were made and remain load-bearing for that: the
+keyless-signing rationale and the explicit-gate rationale both turn on the
+mirror having been the only public, CI-running copy at the time. Collapsing the
+mirror into this repository does not weaken either decision. Keyless signing is
+still the right fit for a public repository that keeps no long-lived
+credentials, and an explicit CI gate on the publishing side is still stronger
+than trusting temporal ordering between independently triggered workflows.
+
+The `cosign verify` identity is unaffected. Decision 7 binds the signature to
+the mirror's workflow path,
+`https://github.com/NOFireAI/ravel/.github/workflows/publish-images.yml`, which
+is now this repository's own. The identity string does not change, so the
+invocation documented in README.md stays correct as written and consumers
+verifying released images need do nothing.


### PR DESCRIPTION
ADR-0086 decisions 5, 6 and 10.

CHANGELOG.md documented 0.9.0 and nothing since, while three releases had
shipped. Sections for 0.9.1, 0.9.2 and 0.9.3 are reconstructed from what
actually landed in each tag range, written as a delta over the 0.9.0 umbrella
rather than a fresh enumeration, because v0.9.0 was tagged early and its
section already describes the full feature set. Docs-only work with no
implementing commit is deliberately not described as shipped behaviour.

These entries will not appear in any automated release's notes: the release job
reads CHANGELOG.md from the tagged tree and these tags already exist. They are
for readers of the file.

README named two of the three images that publish. ravel-ingest-router has
published since 0.9.3, so it joins the prose and the pull block. The same
section's claim that releases are cut from a public mirror is also stale and is
corrected: origin is this repository and there is no mirror. The cosign verify
invocation and the certificate identity it names are unchanged, because the
identity already resolves to this repository's own workflow path.

ADR-0037 gains a dated topology amendment rather than an edit. Its mirror-era
reasoning is load-bearing history: decision 7 argues keyless signing is right
partly because the mirror is the repository strangers can actually read, and
decision 9 rejects the implicit CI gate specifically because the mirror rewrote
history. Editing the topology out from under those arguments would leave them
reading as non sequiturs and hide that the topology ever changed. The
amendment is append-only, verified as zero deletions in that file.

Fixes: #246
Refs: #243
