### PR TITLE
feat(ingest): add metric metadata sink and wire it from every ingest surface (ADR-0085)

### DIFF
--- a/crates/ravel-ingest/src/lib.rs
+++ b/crates/ravel-ingest/src/lib.rs
@@ -20,6 +20,7 @@ mod log_metrics;
 mod log_router;
 mod log_shard;
 mod metrics;
+mod metrics_meta_sink;
 mod reconcile;
 mod router;
 mod shard;
@@ -57,6 +58,10 @@ pub use log_error::LogWriteError;
 pub use log_metrics::{LogIngestMetrics, LogIngestMetricsSnapshot};
 pub use log_router::{LogIndexedFields, LogIngestRouter, LogWriteReceipt, NoIndexedFields};
 pub use metrics::{FlushTrigger, IngestMetrics, IngestMetricsSnapshot};
+pub use metrics_meta_sink::{
+    DEFAULT_MAX_CAS_RETRIES, DEFAULT_METADATA_FLUSH_WINDOW, FlushSummary, MetadataSink,
+    MetadataSinkConfig, catalog_metric_kind,
+};
 pub use reconcile::{DEFAULT_ADMISSION_RECONCILE_INTERVAL, reconcile_once, snapshot_key};
 pub use router::{IngestRouter, WriteMode, WriteReceipt};
 pub use span_error::SpanWriteError;

--- a/crates/ravel-ingest/src/metrics.rs
+++ b/crates/ravel-ingest/src/metrics.rs
@@ -151,6 +151,30 @@ pub struct IngestMetrics {
     /// struct (see the module docs' "no per-shard dimension" note); read it
     /// via [`IngestMetrics::in_flight_flushes_by_shard`].
     in_flight_flushes: Mutex<HashMap<u32, i64>>,
+    /// Metadata-record GETs issued by the metric metadata sink's flush window
+    /// (ADR-0085 decision 1). The ADR budgets one GET per tenant per window
+    /// with a non-empty pending set, so this is the counter an operator checks
+    /// that budget against. Exported as
+    /// `ingest_metadata_flush_gets_total`.
+    metadata_flush_gets: AtomicU64,
+    /// Metadata-record CAS PUTs *attempted* by the sink's flush window
+    /// (ADR-0085 decision 1), including an attempt that lost its CAS and was
+    /// retried, so `puts - conflicts` is the number that landed. The ADR
+    /// budgets at most one PUT per tenant per window in the conflict-free
+    /// case. Exported as `ingest_metadata_flush_puts_total`.
+    metadata_flush_puts: AtomicU64,
+    /// Flush windows whose metadata update was dropped: a CAS that still
+    /// conflicted after `max_cas_retries`, or any other read/write failure
+    /// against the record. Never fatal to an ingest request (the flush is off
+    /// the acknowledgement path entirely) and never silent, which is what this
+    /// counter is for. Exported as `ingest_metadata_flush_dropped_total`.
+    metadata_flush_dropped: AtomicU64,
+    /// Metric family names not added to a tenant's metadata record because it
+    /// was already at the per-tenant entry cap (ADR-0085 decision 1). The
+    /// points themselves are still ingested and queryable; only the metadata
+    /// entry is dropped. Exported as
+    /// `ingest_metadata_entries_dropped_total`.
+    metadata_entries_dropped: AtomicU64,
     /// Bounded-cardinality per-tenant PUT attribution (ADR-0076 decision 2).
     /// Unlike every flat counter above it carries a per-tenant dimension, so
     /// it is kept bounded by a top-K cap rather than exposed as an unbounded
@@ -181,6 +205,15 @@ pub struct IngestMetricsSnapshot {
     pub exemplars_dropped_total: u64,
     pub stale_provisioning_flushes: u64,
     pub grace_extended_stale_flushes: u64,
+    /// `ingest_metadata_flush_gets_total` (ADR-0085 decision 1).
+    pub metadata_flush_gets_total: u64,
+    /// `ingest_metadata_flush_puts_total` (ADR-0085 decision 1). Counts PUT
+    /// attempts, so a CAS-conflicted attempt is included.
+    pub metadata_flush_puts_total: u64,
+    /// `ingest_metadata_flush_dropped_total` (ADR-0085 decision 1).
+    pub metadata_flush_dropped_total: u64,
+    /// `ingest_metadata_entries_dropped_total` (ADR-0085 decision 1).
+    pub metadata_entries_dropped_total: u64,
     /// Sum across shards of [`IngestMetrics::in_flight_flushes_by_shard`] at
     /// snapshot time. The per-shard breakdown does not fit this struct's flat
     /// Copy shape; call `in_flight_flushes_by_shard` directly for that.
@@ -308,6 +341,30 @@ impl IngestMetrics {
             .fetch_add(1, Ordering::Relaxed);
     }
 
+    /// One metadata-record GET issued by a flush window (ADR-0085 decision 1).
+    pub(crate) fn record_metadata_flush_get(&self) {
+        self.metadata_flush_gets.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// One metadata-record CAS PUT attempted by a flush window. Counted per
+    /// attempt, so a conflicted-and-retried write counts more than once.
+    pub(crate) fn record_metadata_flush_put(&self) {
+        self.metadata_flush_puts.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// One flush window's metadata update dropped (CAS retries exhausted, or a
+    /// read/write failure against the record). Visible, never fatal.
+    pub(crate) fn record_metadata_flush_dropped(&self) {
+        self.metadata_flush_dropped.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// `count` new family names not stored because the tenant's record was
+    /// already at the per-tenant entry cap. The points stay ingested.
+    pub(crate) fn record_metadata_entries_dropped(&self, count: u64) {
+        self.metadata_entries_dropped
+            .fetch_add(count, Ordering::Relaxed);
+    }
+
     pub fn snapshot(&self) -> IngestMetricsSnapshot {
         IngestMetricsSnapshot {
             flushes_by_size: self.flushes_by_size.load(Ordering::Relaxed),
@@ -327,6 +384,10 @@ impl IngestMetrics {
             exemplars_dropped_total: self.exemplars_dropped_total.load(Ordering::Relaxed),
             stale_provisioning_flushes: self.stale_provisioning_flushes.load(Ordering::Relaxed),
             grace_extended_stale_flushes: self.grace_extended_stale_flushes.load(Ordering::Relaxed),
+            metadata_flush_gets_total: self.metadata_flush_gets.load(Ordering::Relaxed),
+            metadata_flush_puts_total: self.metadata_flush_puts.load(Ordering::Relaxed),
+            metadata_flush_dropped_total: self.metadata_flush_dropped.load(Ordering::Relaxed),
+            metadata_entries_dropped_total: self.metadata_entries_dropped.load(Ordering::Relaxed),
             in_flight_flushes_total: self
                 .in_flight_flushes_by_shard()
                 .into_iter()

--- a/crates/ravel-ingest/src/metrics_meta_sink.rs
+++ b/crates/ravel-ingest/src/metrics_meta_sink.rs
@@ -1,0 +1,1127 @@
+//! The one-per-process metric metadata sink (ADR-0085 decision 1, write side).
+//!
+//! Every ingest surface (OTLP, OTAP, RW1, RW2) decodes a metric's
+//! `(family_name, type, help, unit)` tuple and hands it to [`MetadataSink`]
+//! through [`MetadataSink::observe`]. This crate owns the sink because it
+//! already owns the object-store client and the per-process ingest pipeline all
+//! four surfaces funnel through; `ravel-server` constructs exactly one and
+//! spawns its flush loop next to the lifecycle refresh loop. One sink per
+//! process, not one per protocol, so a single process never races itself on
+//! `t/<tenant_hash>/m/meta`.
+//!
+//! # The two halves, and why they are split
+//!
+//! [`observe`](MetadataSink::observe) runs on the ingest request path. It is
+//! synchronous, does no I/O, awaits nothing, and cannot fail: it fingerprints
+//! each tuple, compares the fingerprint against the last-flushed one, and
+//! pushes only new-or-changed tuples into a per-tenant pending set under a
+//! short mutex hold. Nothing an ingest client sends can make a request fail,
+//! slow down, or block on the metadata record.
+//!
+//! [`flush_once`](MetadataSink::flush_once) runs on the background flush loop,
+//! once per debounce window ([`MetadataSinkConfig::window`], default 30 s). Per
+//! tenant with a non-empty pending set it does exactly **one GET** of the
+//! record and **at most one CAS PUT**, whatever number of names arrived. The
+//! merge is [`ravel_catalog::merge_entries`] (field-wise, so RW1
+//! supplying help without unit and OTLP later supplying unit without help
+//! compose instead of clobbering); a merge that changes nothing skips the PUT
+//! and only updates the local fingerprints, which is the common case right
+//! after a restart when every name looks new locally but the durable record
+//! already reflects it.
+//!
+//! # The local fingerprint map is a skip, never a source of truth
+//!
+//! The map holds a hash of the last-flushed `(kind, help, unit)` per (tenant,
+//! family), keyed on content rather than on name alone, so a help or unit
+//! change mid-process is detected locally instead of being masked by "we have
+//! seen this name before". It is never trusted on its own: the durable record
+//! is always read and merged before any write, so a fresh process with an empty
+//! map converges to zero PUTs rather than rewriting what is already stored.
+//!
+//! Its memory grows with the number of distinct metric family names a process
+//! sees over its lifetime, per tenant. That growth is the same vector the
+//! record-side per-tenant entry cap
+//! ([`MetadataSinkConfig::entry_cap`]) bounds durably; ADR-0085 puts the cap on
+//! the record, and a family whose entry was dropped over cap is not re-armed
+//! every window (its fingerprint is committed like any other), so a hostile
+//! name-minting client costs one bounded local map and no extra requests.
+//!
+//! # Failure handling
+//!
+//! Nothing here propagates an error to a caller. A CAS conflict re-reads,
+//! re-merges onto the winner's body, and retries with jittered backoff up to
+//! [`MetadataSinkConfig::max_cas_retries`]; on exhaustion the window's update is
+//! dropped, `ingest_metadata_flush_dropped_total` is incremented and a warning
+//! logged. Nothing is re-queued: the next `observe` of a still-changed tuple
+//! re-arms it naturally, because its fingerprint was never committed. Any other
+//! store or record error is treated the same way. A contended or degraded
+//! metadata key can therefore never become an ingest availability regression.
+
+use std::collections::{BTreeMap, HashMap};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use ravel_catalog::{
+    DEFAULT_METRICS_META_ENTRY_CAP, MetricKind as CatalogMetricKind, MetricMetadataEntry,
+    MetricsMetaError, merge_entries, read_metrics_meta, write_metrics_meta,
+};
+use ravel_commit::rng::{RngSource, SystemRng};
+use ravel_object_store::ObjectStoreBackend;
+use ravel_otlp::metadata::{MetricKind as WireMetricKind, MetricMetadata};
+use ravel_types::{TenantHash, TenantId};
+use tokio::sync::oneshot;
+
+use crate::clock::{Clock, SystemClock};
+use crate::metrics::IngestMetrics;
+
+/// Default debounce window: 30 s (ADR-0085 decision 1). One GET and at most one
+/// PUT per tenant per window, however many names arrived in it.
+pub const DEFAULT_METADATA_FLUSH_WINDOW: Duration = Duration::from_secs(30);
+
+/// Default bounded CAS retry count (ADR-0085 decision 1). Exceeding it drops the
+/// window's update and counts it rather than looping against a hot key.
+pub const DEFAULT_MAX_CAS_RETRIES: u32 = 5;
+
+/// Base CAS backoff step. Attempt `n` sleeps `BASE * 2^(n-1)` plus up to 10%
+/// jitter, so two replicas that collided do not re-collide in lockstep. Small
+/// on purpose: this is a background flush whose whole retry budget must stay far
+/// inside one debounce window.
+const CAS_BACKOFF_BASE: Duration = Duration::from_millis(50);
+
+/// Tuning for [`MetadataSink`]. Every default is the ADR-0085 decision 1 value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MetadataSinkConfig {
+    /// Debounce window between flushes. One GET and at most one CAS PUT per
+    /// tenant with pending metadata per window.
+    pub window: Duration,
+    /// Per-tenant durable entry cap. A *new* family name arriving when the
+    /// record is already at the cap is dropped and counted
+    /// (`ingest_metadata_entries_dropped_total`); its points are still ingested
+    /// and queryable.
+    pub entry_cap: usize,
+    /// How many times a CAS PUT is retried against a freshly read body after a
+    /// conflict. The initial attempt is not a retry, so a window issues at most
+    /// `max_cas_retries + 1` PUTs.
+    pub max_cas_retries: u32,
+    /// Turns the sink into a no-op: `observe` returns immediately without
+    /// touching any map and `flush_once` does no I/O. For an operator who needs
+    /// to switch metadata capture off without redeploying a different binary.
+    pub disabled: bool,
+}
+
+impl Default for MetadataSinkConfig {
+    fn default() -> Self {
+        MetadataSinkConfig {
+            window: DEFAULT_METADATA_FLUSH_WINDOW,
+            entry_cap: DEFAULT_METRICS_META_ENTRY_CAP,
+            max_cas_retries: DEFAULT_MAX_CAS_RETRIES,
+            disabled: false,
+        }
+    }
+}
+
+/// What one [`MetadataSink::flush_once`] call did, for tests and for the flush
+/// loop's log line. Every field is a per-call count, never cumulative; the
+/// cumulative view is [`IngestMetrics`].
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct FlushSummary {
+    /// Tenants that had a non-empty pending set and were processed.
+    pub tenants_flushed: usize,
+    /// Metadata-record GETs issued. One per tenant per attempt (a CAS retry
+    /// re-reads, so it adds one).
+    pub gets: usize,
+    /// CAS PUTs *attempted*. A conflicted attempt counts here too, so
+    /// `puts - cas_conflicts` is what landed.
+    pub puts: usize,
+    /// PUTs refused because another writer moved the record first.
+    pub cas_conflicts: usize,
+    /// Tenants whose window update was dropped (retries exhausted, or a
+    /// read/write failure).
+    pub dropped_flushes: usize,
+    /// New family names not stored because the record was at `entry_cap`.
+    pub dropped_over_cap: usize,
+}
+
+/// Map a decoder-side metric kind onto the durable record's kind.
+///
+/// The two enums have identical variants and live in two crates that must not
+/// depend on each other (`ravel-otlp` is a store-agnostic decoder,
+/// `ravel-catalog` owns the durable record), so the mapping lives here, in the
+/// one crate that depends on both. It is a function rather than the
+/// `impl From<..> for ..` a reader would expect: both types are foreign to this
+/// crate, so that impl is forbidden by the orphan rule (E0117) and would have
+/// to be written inside `ravel-otlp` or `ravel-catalog`, coupling one decoder
+/// crate to the catalog or vice versa.
+pub fn catalog_metric_kind(kind: WireMetricKind) -> CatalogMetricKind {
+    match kind {
+        WireMetricKind::Counter => CatalogMetricKind::Counter,
+        WireMetricKind::Gauge => CatalogMetricKind::Gauge,
+        WireMetricKind::Histogram => CatalogMetricKind::Histogram,
+        WireMetricKind::Summary => CatalogMetricKind::Summary,
+        WireMetricKind::Unknown => CatalogMetricKind::Unknown,
+    }
+}
+
+/// One pending metadata tuple: the wire tuple plus the fingerprint that will be
+/// committed to the local map once the flush that carried it succeeds (or
+/// proved to be a no-op against the durable record).
+#[derive(Debug, Clone)]
+struct PendingEntry {
+    kind: WireMetricKind,
+    help: String,
+    unit: String,
+    fingerprint: u64,
+}
+
+/// One tenant's pending set. `tenant` is kept for log context only: the record's
+/// key is derived from the hash, which the caller already resolved.
+#[derive(Debug)]
+struct PendingTenant {
+    tenant: TenantId,
+    entries: BTreeMap<String, PendingEntry>,
+}
+
+#[derive(Debug, Default)]
+struct SinkState {
+    /// Last-flushed fingerprint per (tenant, family name). Nested rather than
+    /// keyed by a `(TenantHash, String)` tuple so the request-path lookup in
+    /// `observe` borrows the name instead of cloning it into a key.
+    fingerprints: HashMap<TenantHash, HashMap<String, u64>>,
+    /// Names whose fingerprint differs from `fingerprints`, awaiting the next
+    /// flush window. Ordered so a flush is deterministic.
+    pending: BTreeMap<TenantHash, PendingTenant>,
+}
+
+/// The one-per-process metric metadata sink. Share it by `Arc`: every ingest
+/// surface calls [`observe`](Self::observe) on the same instance, and
+/// [`run`](Self::run) drives the single flush loop.
+pub struct MetadataSink {
+    store: Arc<dyn ObjectStoreBackend>,
+    config: MetadataSinkConfig,
+    metrics: Arc<IngestMetrics>,
+    /// Injected clock: the flush cadence and the CAS backoff sleep both go
+    /// through it, so tests drive both without a wall-clock sleep (CLAUDE.md
+    /// time injection).
+    clock: Arc<dyn Clock>,
+    /// Injected jitter source for the CAS backoff and the flush cadence.
+    rng: Arc<dyn RngSource>,
+    state: Mutex<SinkState>,
+}
+
+impl std::fmt::Debug for MetadataSink {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MetadataSink")
+            .field("config", &self.config)
+            .finish_non_exhaustive()
+    }
+}
+
+impl MetadataSink {
+    /// Build the process's sink. `store` is the same foreground handle the
+    /// ingest router writes data objects through, and `metrics` is the router's
+    /// own counter registry (`IngestRouter::metrics_handle`) so the flush
+    /// counters land in the snapshot an operator already scrapes.
+    pub fn new(
+        store: Arc<dyn ObjectStoreBackend>,
+        config: MetadataSinkConfig,
+        metrics: Arc<IngestMetrics>,
+    ) -> Self {
+        MetadataSink {
+            store,
+            config,
+            metrics,
+            clock: Arc::new(SystemClock),
+            rng: Arc::new(SystemRng),
+            state: Mutex::new(SinkState::default()),
+        }
+    }
+
+    /// Replace the injected clock (the flush cadence and the CAS backoff).
+    #[must_use]
+    pub fn with_clock(mut self, clock: Arc<dyn Clock>) -> Self {
+        self.clock = clock;
+        self
+    }
+
+    /// Replace the injected jitter source.
+    #[must_use]
+    pub fn with_rng(mut self, rng: Arc<dyn RngSource>) -> Self {
+        self.rng = rng;
+        self
+    }
+
+    pub fn config(&self) -> &MetadataSinkConfig {
+        &self.config
+    }
+
+    /// Record what one request's normalization decoded, on the ingest request
+    /// path.
+    ///
+    /// Synchronous, allocation-light, and infallible by construction: it takes
+    /// one short mutex, compares each tuple's fingerprint against the
+    /// last-flushed one, and stores only the changed ones. It never touches the
+    /// object store, never awaits, and returns nothing a caller could be
+    /// tempted to fail a request on. Ingest acknowledgement therefore never
+    /// depends on the metadata record (ADR-0085 decision 1).
+    ///
+    /// Within one window the last tuple for a family wins. A tuple with an
+    /// empty `family_name` is dropped defensively: it names no family, and the
+    /// record writer refuses it anyway.
+    pub fn observe(
+        &self,
+        tenant: &TenantId,
+        tenant_hash: TenantHash,
+        metadata: impl IntoIterator<Item = MetricMetadata>,
+    ) {
+        if self.config.disabled {
+            return;
+        }
+        let mut metadata = metadata.into_iter().peekable();
+        if metadata.peek().is_none() {
+            return;
+        }
+        let Ok(mut state) = self.state.lock() else {
+            // A poisoned mutex means a previous holder panicked. Metadata
+            // capture is best-effort and off the ack path, so this must not
+            // propagate into an ingest request; the flush loop logs the
+            // degradation on its next tick.
+            return;
+        };
+        for meta in metadata {
+            if meta.family_name.is_empty() {
+                continue;
+            }
+            let fingerprint = fingerprint_of(&meta);
+            let unchanged = state
+                .fingerprints
+                .get(&tenant_hash)
+                .and_then(|names| names.get(meta.family_name.as_str()))
+                .is_some_and(|stored| *stored == fingerprint);
+            if unchanged {
+                continue;
+            }
+            let pending = state
+                .pending
+                .entry(tenant_hash)
+                .or_insert_with(|| PendingTenant {
+                    tenant: tenant.clone(),
+                    entries: BTreeMap::new(),
+                });
+            pending.entries.insert(
+                meta.family_name,
+                PendingEntry {
+                    kind: meta.kind,
+                    help: meta.help,
+                    unit: meta.unit,
+                    fingerprint,
+                },
+            );
+        }
+    }
+
+    /// Flush every tenant with a non-empty pending set: one GET and at most one
+    /// CAS PUT each (ADR-0085 decision 1). `now_ns` is the merge's
+    /// `updated_unix_ns` for entries that actually changed, injected rather than
+    /// read so a flush is deterministic.
+    ///
+    /// Never returns an error: every failure is logged, counted, and dropped.
+    pub async fn flush_once(&self, now_ns: i64) -> FlushSummary {
+        let mut summary = FlushSummary::default();
+        if self.config.disabled {
+            return summary;
+        }
+        let pending = self.take_pending();
+        for (tenant_hash, pending) in pending {
+            summary.tenants_flushed += 1;
+            self.flush_tenant(tenant_hash, pending, now_ns, &mut summary)
+                .await;
+        }
+        summary
+    }
+
+    /// The flush loop: one [`flush_once`](Self::flush_once) per debounce window
+    /// until `shutdown` fires, then one final flush so a graceful stop does not
+    /// discard the window in progress.
+    ///
+    /// The window sleep is jittered so replicas that started together do not
+    /// contend on the same key on the same tick.
+    pub async fn run(self: Arc<Self>, mut shutdown: oneshot::Receiver<()>) {
+        if self.config.disabled {
+            // Still wait for shutdown rather than returning: the task handle's
+            // join then behaves the same in both configurations.
+            let _ = shutdown.await;
+            return;
+        }
+        loop {
+            let window = jittered(self.config.window, self.rng.as_ref());
+            tokio::select! {
+                _ = self.clock.sleep(window) => {
+                    let summary = self.flush_once(self.clock.now_ns()).await;
+                    log_summary("metric metadata flush window complete", &summary);
+                }
+                _ = &mut shutdown => break,
+            }
+        }
+        let summary = self.flush_once(self.clock.now_ns()).await;
+        log_summary("metric metadata final flush on shutdown complete", &summary);
+    }
+
+    /// Take (not clone) every tenant's pending set. Anything `observe` adds
+    /// while the flush runs lands in a fresh pending set and is flushed next
+    /// window; because fingerprints are committed only after this flush
+    /// concludes, such a tuple is at worst re-sent and merged as a no-op, never
+    /// lost.
+    fn take_pending(&self) -> BTreeMap<TenantHash, PendingTenant> {
+        match self.state.lock() {
+            Ok(mut state) => std::mem::take(&mut state.pending),
+            Err(_) => {
+                tracing::warn!(
+                    "metric metadata sink state mutex poisoned; skipping this flush window \
+                     (metadata capture degraded, ingest unaffected)"
+                );
+                BTreeMap::new()
+            }
+        }
+    }
+
+    async fn flush_tenant(
+        &self,
+        tenant_hash: TenantHash,
+        pending: PendingTenant,
+        now_ns: i64,
+        summary: &mut FlushSummary,
+    ) {
+        let incoming: Vec<MetricMetadataEntry> = pending
+            .entries
+            .iter()
+            .map(|(family_name, entry)| MetricMetadataEntry {
+                family_name: family_name.clone(),
+                kind: catalog_metric_kind(entry.kind),
+                help: entry.help.clone(),
+                unit: entry.unit.clone(),
+                updated_unix_ns: now_ns,
+            })
+            .collect();
+
+        let mut retries: u32 = 0;
+        loop {
+            summary.gets += 1;
+            self.metrics.record_metadata_flush_get();
+            let record = match read_metrics_meta(self.store.as_ref(), &tenant_hash).await {
+                Ok(record) => record,
+                Err(err) => {
+                    self.record_dropped_flush(&pending.tenant, &tenant_hash, summary, &err);
+                    return;
+                }
+            };
+            let (existing, expected) = match record {
+                Some((entries, version)) => (entries, Some(version)),
+                // No record yet: the first write bootstraps with
+                // `CreateIfAbsent` rather than CAS against a version that does
+                // not exist (ADR-0085 decision 1).
+                None => (Vec::new(), None),
+            };
+
+            let outcome = merge_entries(&existing, &incoming, now_ns, self.config.entry_cap);
+            if !outcome.changed {
+                // The durable record already says everything this window
+                // carried: skip the PUT and just remember it locally. The
+                // common case for a freshly started process.
+                self.commit_fingerprints(tenant_hash, &pending);
+                self.record_over_cap(&pending.tenant, outcome.dropped_over_cap, summary);
+                return;
+            }
+
+            summary.puts += 1;
+            self.metrics.record_metadata_flush_put();
+            match write_metrics_meta(self.store.as_ref(), &tenant_hash, &outcome.merged, expected)
+                .await
+            {
+                Ok(_) => {
+                    self.commit_fingerprints(tenant_hash, &pending);
+                    self.record_over_cap(&pending.tenant, outcome.dropped_over_cap, summary);
+                    return;
+                }
+                Err(MetricsMetaError::CasConflict { .. }) => {
+                    summary.cas_conflicts += 1;
+                    if retries >= self.config.max_cas_retries {
+                        // Drop this window's update and count it. Nothing is
+                        // re-queued and no fingerprint is committed, so the next
+                        // `observe` of a still-changed tuple re-arms it.
+                        summary.dropped_flushes += 1;
+                        self.metrics.record_metadata_flush_dropped();
+                        tracing::warn!(
+                            tenant = %pending.tenant.as_str(),
+                            tenant_hash = %tenant_hash.to_hex(),
+                            names = pending.entries.len(),
+                            retries = self.config.max_cas_retries,
+                            "metric metadata CAS lost every retry; dropping this window's \
+                             metadata update (ingest unaffected, re-armed on the next changed \
+                             tuple)"
+                        );
+                        return;
+                    }
+                    retries += 1;
+                    self.clock.sleep(self.cas_backoff(retries)).await;
+                }
+                Err(err) => {
+                    self.record_dropped_flush(&pending.tenant, &tenant_hash, summary, &err);
+                    return;
+                }
+            }
+        }
+    }
+
+    /// `CAS_BACKOFF_BASE * 2^(retry - 1)`, jittered. Saturates rather than
+    /// overflowing on an absurd configured retry count.
+    fn cas_backoff(&self, retry: u32) -> Duration {
+        let factor = 1u32
+            .checked_shl(retry.saturating_sub(1))
+            .unwrap_or(u32::MAX);
+        jittered(CAS_BACKOFF_BASE.saturating_mul(factor), self.rng.as_ref())
+    }
+
+    /// Remember every tuple this flush carried, so a later identical `observe`
+    /// is skipped locally. Called after a successful PUT and after a no-op
+    /// merge, never after a drop.
+    fn commit_fingerprints(&self, tenant_hash: TenantHash, pending: &PendingTenant) {
+        let Ok(mut state) = self.state.lock() else {
+            return;
+        };
+        let names = state.fingerprints.entry(tenant_hash).or_default();
+        for (family_name, entry) in &pending.entries {
+            names.insert(family_name.clone(), entry.fingerprint);
+        }
+    }
+
+    fn record_over_cap(&self, tenant: &TenantId, dropped: usize, summary: &mut FlushSummary) {
+        if dropped == 0 {
+            return;
+        }
+        summary.dropped_over_cap += dropped;
+        self.metrics.record_metadata_entries_dropped(dropped as u64);
+        tracing::warn!(
+            tenant = %tenant.as_str(),
+            dropped,
+            cap = self.config.entry_cap,
+            "metric metadata record at the per-tenant entry cap; new family names not stored \
+             (their points are still ingested and queryable)"
+        );
+    }
+
+    fn record_dropped_flush(
+        &self,
+        tenant: &TenantId,
+        tenant_hash: &TenantHash,
+        summary: &mut FlushSummary,
+        err: &MetricsMetaError,
+    ) {
+        summary.dropped_flushes += 1;
+        self.metrics.record_metadata_flush_dropped();
+        tracing::warn!(
+            tenant = %tenant.as_str(),
+            tenant_hash = %tenant_hash.to_hex(),
+            error = %err,
+            "metric metadata flush failed; dropping this window's metadata update (ingest \
+             unaffected, re-armed on the next changed tuple)"
+        );
+    }
+}
+
+fn log_summary(message: &'static str, summary: &FlushSummary) {
+    if summary.tenants_flushed == 0 {
+        return;
+    }
+    tracing::debug!(
+        tenants = summary.tenants_flushed,
+        gets = summary.gets,
+        puts = summary.puts,
+        cas_conflicts = summary.cas_conflicts,
+        dropped_flushes = summary.dropped_flushes,
+        dropped_over_cap = summary.dropped_over_cap,
+        "{message}"
+    );
+}
+
+/// `base` plus up to 10% jitter, the same shape every other jittered background
+/// cadence in the codebase uses.
+fn jittered(base: Duration, rng: &dyn RngSource) -> Duration {
+    let bound_ms = u64::try_from(base.as_millis() / 10).unwrap_or(u64::MAX);
+    if bound_ms == 0 {
+        return base;
+    }
+    base + Duration::from_millis(rng.jitter_ms(bound_ms))
+}
+
+/// Hash of the fields that make a metadata tuple current: kind, help, unit.
+/// Deliberately *not* the family name (it is the map key) and not any timestamp
+/// (a timestamp-only difference is not a change; see
+/// [`ravel_catalog::MergeOutcome::changed`]). blake3 rather than a
+/// `DefaultHasher` so the value is stable across processes and builds, which is
+/// what makes a fingerprint comparable to one a restart would compute.
+fn fingerprint_of(meta: &MetricMetadata) -> u64 {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(&[kind_tag(meta.kind)]);
+    // Length-prefixed so ("ab", "c") and ("a", "bc") cannot collide.
+    hasher.update(&(meta.help.len() as u64).to_le_bytes());
+    hasher.update(meta.help.as_bytes());
+    hasher.update(&(meta.unit.len() as u64).to_le_bytes());
+    hasher.update(meta.unit.as_bytes());
+    let digest = hasher.finalize();
+    let mut head = [0u8; 8];
+    head.copy_from_slice(&digest.as_bytes()[..8]);
+    u64::from_le_bytes(head)
+}
+
+fn kind_tag(kind: WireMetricKind) -> u8 {
+    match kind {
+        WireMetricKind::Counter => 1,
+        WireMetricKind::Gauge => 2,
+        WireMetricKind::Histogram => 3,
+        WireMetricKind::Summary => 4,
+        WireMetricKind::Unknown => 5,
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+    use ravel_object_store::fault::{FaultKind, FaultPlan, FaultStore, Op, Rule, ScriptedFault};
+    use ravel_object_store::instrument::{InstrumentedStore, StoreOp};
+    use ravel_object_store::memory::MemoryStore;
+    use ravel_object_store::{
+        Capabilities, DelimitedList, GetOutcome, GetRange, ListPage, ObjectMeta, PageToken,
+        PutOptions, PutOutcome, StoreError,
+    };
+
+    const NOW: i64 = 1_700_000_000_000_000_000;
+
+    /// A clock whose `sleep` completes immediately, so a CAS backoff costs no
+    /// wall-clock time, and whose `now_ns` is fixed.
+    #[derive(Debug)]
+    struct InstantClock;
+
+    impl Clock for InstantClock {
+        fn now_ns(&self) -> i64 {
+            NOW
+        }
+
+        fn sleep(
+            &self,
+            _dur: Duration,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + '_>> {
+            Box::pin(std::future::ready(()))
+        }
+    }
+
+    /// A clock whose `sleep` never completes, so the flush loop's window arm can
+    /// never fire and only the shutdown arm can.
+    #[derive(Debug)]
+    struct NeverClock;
+
+    impl Clock for NeverClock {
+        fn now_ns(&self) -> i64 {
+            NOW
+        }
+
+        fn sleep(
+            &self,
+            _dur: Duration,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + '_>> {
+            Box::pin(std::future::pending())
+        }
+    }
+
+    /// Deterministic jitter: none.
+    #[derive(Debug)]
+    struct NoJitter;
+
+    impl RngSource for NoJitter {
+        fn jitter_ms(&self, _max_ms: u64) -> u64 {
+            0
+        }
+
+        fn new_uuid(&self) -> uuid::Uuid {
+            uuid::Uuid::nil()
+        }
+    }
+
+    /// A backend that panics on every access. `observe` must never reach it.
+    struct PanicStore;
+
+    #[async_trait::async_trait]
+    impl ObjectStoreBackend for PanicStore {
+        async fn put(
+            &self,
+            _key: &str,
+            _data: Bytes,
+            _opts: PutOptions,
+        ) -> Result<PutOutcome, StoreError> {
+            panic!("observe must not touch the object store");
+        }
+
+        async fn get(&self, _key: &str, _range: GetRange) -> Result<GetOutcome, StoreError> {
+            panic!("observe must not touch the object store");
+        }
+
+        async fn head(&self, _key: &str) -> Result<ObjectMeta, StoreError> {
+            panic!("observe must not touch the object store");
+        }
+
+        async fn list(
+            &self,
+            _prefix: &str,
+            _page: Option<PageToken>,
+        ) -> Result<ListPage, StoreError> {
+            panic!("observe must not touch the object store");
+        }
+
+        async fn list_delimited(&self, _prefix: &str) -> Result<DelimitedList, StoreError> {
+            panic!("observe must not touch the object store");
+        }
+
+        async fn delete(&self, _key: &str) -> Result<(), StoreError> {
+            panic!("observe must not touch the object store");
+        }
+
+        fn capabilities(&self) -> Capabilities {
+            panic!("observe must not touch the object store");
+        }
+    }
+
+    type Counting = Arc<InstrumentedStore<MemoryStore>>;
+    type CountingFaulty = Arc<InstrumentedStore<FaultStore<MemoryStore>>>;
+
+    fn counting_store() -> Counting {
+        Arc::new(InstrumentedStore::new(MemoryStore::new()))
+    }
+
+    fn faulty_store(plan: FaultPlan) -> CountingFaulty {
+        Arc::new(InstrumentedStore::new(FaultStore::new(
+            MemoryStore::new(),
+            plan,
+        )))
+    }
+
+    fn gets(store: &InstrumentedStore<impl ObjectStoreBackend>) -> u64 {
+        store.metrics().snapshot().op(StoreOp::Get).calls
+    }
+
+    fn puts(store: &InstrumentedStore<impl ObjectStoreBackend>) -> u64 {
+        store.metrics().snapshot().op(StoreOp::Put).calls
+    }
+
+    fn sink(store: Arc<dyn ObjectStoreBackend>, config: MetadataSinkConfig) -> Arc<MetadataSink> {
+        Arc::new(
+            MetadataSink::new(store, config, Arc::new(IngestMetrics::default()))
+                .with_clock(Arc::new(InstantClock))
+                .with_rng(Arc::new(NoJitter)),
+        )
+    }
+
+    fn meta(name: &str, help: &str, unit: &str) -> MetricMetadata {
+        MetricMetadata {
+            family_name: name.to_string(),
+            kind: WireMetricKind::Counter,
+            help: help.to_string(),
+            unit: unit.to_string(),
+        }
+    }
+
+    fn families(prefix: &str, count: usize) -> Vec<MetricMetadata> {
+        (0..count)
+            .map(|i| meta(&format!("{prefix}_{i}_total"), "help text", "bytes"))
+            .collect()
+    }
+
+    async fn stored(store: &dyn ObjectStoreBackend, tenant: &TenantId) -> Vec<MetricMetadataEntry> {
+        read_metrics_meta(store, &tenant.hash())
+            .await
+            .expect("read record")
+            .map(|(entries, _)| entries)
+            .unwrap_or_default()
+    }
+
+    /// Acceptance test for ADR-0085 decision 1's request budget: however many
+    /// names arrive in a window, a tenant costs exactly one GET and at most one
+    /// PUT. Asserted on the store's own call counters, not on the summary, so a
+    /// summary that lied would not pass.
+    #[tokio::test]
+    async fn window_flush_does_one_get_and_at_most_one_put_per_tenant() {
+        let store = counting_store();
+        let sink = sink(store.clone(), MetadataSinkConfig::default());
+        let a = TenantId::new("tenant-a");
+        let b = TenantId::new("tenant-b");
+
+        for chunk in families("alpha", 250).chunks(25) {
+            sink.observe(&a, a.hash(), chunk.to_vec());
+        }
+        for chunk in families("beta", 250).chunks(25) {
+            sink.observe(&b, b.hash(), chunk.to_vec());
+        }
+
+        let summary = sink.flush_once(NOW).await;
+
+        assert_eq!(gets(store.as_ref()), 2, "one GET per tenant, per window");
+        assert_eq!(puts(store.as_ref()), 2, "one PUT per tenant, per window");
+        assert_eq!(summary.tenants_flushed, 2);
+        assert_eq!(summary.cas_conflicts, 0);
+        assert_eq!(summary.dropped_flushes, 0);
+        assert_eq!(summary.dropped_over_cap, 0);
+
+        assert_eq!(stored(store.as_ref(), &a).await.len(), 250);
+        assert_eq!(stored(store.as_ref(), &b).await.len(), 250);
+    }
+
+    /// A restarted replica's local map is empty, so every name looks new. The
+    /// durable record already reflects them, so the merge is a no-op and the
+    /// window must cost its GET and nothing else.
+    #[tokio::test]
+    async fn restart_against_populated_record_does_zero_puts() {
+        let store = counting_store();
+        let a = TenantId::new("tenant-a");
+        let b = TenantId::new("tenant-b");
+        let first = sink(store.clone(), MetadataSinkConfig::default());
+        first.observe(&a, a.hash(), families("alpha", 250));
+        first.observe(&b, b.hash(), families("beta", 250));
+        first.flush_once(NOW).await;
+        let gets_before = gets(store.as_ref());
+        let puts_before = puts(store.as_ref());
+
+        // A fresh process: same store, same tuples, empty fingerprint map.
+        let restarted = sink(store.clone(), MetadataSinkConfig::default());
+        restarted.observe(&a, a.hash(), families("alpha", 250));
+        restarted.observe(&b, b.hash(), families("beta", 250));
+        let summary = restarted.flush_once(NOW + 1_000_000_000).await;
+
+        assert_eq!(gets(store.as_ref()) - gets_before, 2);
+        assert_eq!(puts(store.as_ref()) - puts_before, 0);
+        assert_eq!(summary.puts, 0);
+        assert_eq!(summary.tenants_flushed, 2);
+    }
+
+    /// A help change during the process's lifetime is detected locally (the
+    /// fingerprint is keyed on content, not just on the name) and flushed; an
+    /// identical re-observation is not.
+    #[tokio::test]
+    async fn changed_help_mid_lifetime_is_flushed() {
+        let store = counting_store();
+        let sink = sink(store.clone(), MetadataSinkConfig::default());
+        let tenant = TenantId::new("tenant-a");
+        sink.observe(
+            &tenant,
+            tenant.hash(),
+            [meta("http_requests_total", "old", "")],
+        );
+        sink.flush_once(NOW).await;
+        let gets_before = gets(store.as_ref());
+        let puts_before = puts(store.as_ref());
+
+        sink.observe(
+            &tenant,
+            tenant.hash(),
+            [meta("http_requests_total", "new", "")],
+        );
+        let summary = sink.flush_once(NOW + 1).await;
+        assert_eq!(gets(store.as_ref()) - gets_before, 1);
+        assert_eq!(puts(store.as_ref()) - puts_before, 1);
+        assert_eq!(summary.puts, 1);
+        let entries = stored(store.as_ref(), &tenant).await;
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].help, "new");
+
+        // The identical tuple again: nothing pending, so the next window does
+        // not even read the record. Re-baselined here because the `stored`
+        // assertion above is itself a GET through the same counting store.
+        let gets_settled = gets(store.as_ref());
+        sink.observe(
+            &tenant,
+            tenant.hash(),
+            [meta("http_requests_total", "new", "")],
+        );
+        let summary = sink.flush_once(NOW + 2).await;
+        assert_eq!(
+            gets(store.as_ref()) - gets_settled,
+            0,
+            "no GET without pending work"
+        );
+        assert_eq!(summary.tenants_flushed, 0);
+        assert_eq!(summary.gets, 0);
+    }
+
+    /// RW1 supplies help without unit and OTLP supplies unit without help; the
+    /// two must compose, never clobber (the field-wise merge rule).
+    #[tokio::test]
+    async fn empty_incoming_unit_does_not_clobber_populated() {
+        let store = counting_store();
+        let sink = sink(store.clone(), MetadataSinkConfig::default());
+        let tenant = TenantId::new("tenant-a");
+        sink.observe(
+            &tenant,
+            tenant.hash(),
+            [meta("bytes_sent_total", "", "bytes")],
+        );
+        sink.flush_once(NOW).await;
+
+        sink.observe(
+            &tenant,
+            tenant.hash(),
+            [meta("bytes_sent_total", "bytes sent", "")],
+        );
+        sink.flush_once(NOW + 1).await;
+
+        let entries = stored(store.as_ref(), &tenant).await;
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].help, "bytes sent");
+        assert_eq!(
+            entries[0].unit, "bytes",
+            "an empty incoming unit must not clobber"
+        );
+    }
+
+    /// A lost CAS re-reads the winner's body, re-merges onto it, and converges.
+    #[tokio::test]
+    async fn cas_conflict_rereads_and_converges() {
+        let store = faulty_store(
+            FaultPlan::empty().with_rule(
+                Rule::new(Op::Put, ScriptedFault::FailedConditionalWrite)
+                    .with_key_contains("/m/meta")
+                    .with_occurrence(ravel_object_store::fault::Occurrence::Nth(1)),
+            ),
+        );
+        let sink = sink(store.clone(), MetadataSinkConfig::default());
+        let tenant = TenantId::new("tenant-a");
+        sink.observe(&tenant, tenant.hash(), families("alpha", 3));
+
+        let summary = sink.flush_once(NOW).await;
+
+        assert_eq!(
+            store
+                .inner()
+                .fault_count(Op::Put, FaultKind::FailedConditionalWrite),
+            1,
+            "the scripted conflict must actually have fired"
+        );
+        assert_eq!(summary.cas_conflicts, 1);
+        assert_eq!(summary.dropped_flushes, 0);
+        assert_eq!(summary.gets, 2, "the retry re-reads before re-merging");
+        assert_eq!(summary.puts, 2);
+        assert_eq!(stored(store.as_ref(), &tenant).await.len(), 3);
+    }
+
+    /// More conflicts than the retry budget: the window's update is dropped and
+    /// counted, and the ingest path never learns about it.
+    #[tokio::test]
+    async fn cas_retries_exhausted_drops_and_counts() {
+        let store = faulty_store(FaultPlan::empty().with_rule(
+            Rule::new(Op::Put, ScriptedFault::FailedConditionalWrite).with_key_contains("/m/meta"),
+        ));
+        let metrics = Arc::new(IngestMetrics::default());
+        let config = MetadataSinkConfig {
+            max_cas_retries: 2,
+            ..MetadataSinkConfig::default()
+        };
+        let sink = Arc::new(
+            MetadataSink::new(store.clone(), config, metrics.clone())
+                .with_clock(Arc::new(InstantClock))
+                .with_rng(Arc::new(NoJitter)),
+        );
+        let tenant = TenantId::new("tenant-a");
+
+        // `observe` is infallible and returns nothing: the ingest path cannot
+        // see the failure that follows.
+        sink.observe(&tenant, tenant.hash(), families("alpha", 2));
+        let summary = sink.flush_once(NOW).await;
+
+        assert_eq!(summary.dropped_flushes, 1);
+        assert_eq!(summary.cas_conflicts, 3, "initial attempt plus two retries");
+        assert_eq!(summary.puts, 3);
+        assert_eq!(metrics.snapshot().metadata_flush_dropped_total, 1);
+        assert!(stored(store.as_ref(), &tenant).await.is_empty());
+
+        // Nothing was re-queued, and no fingerprint was committed, so the next
+        // observation of the same tuple re-arms the write.
+        assert_eq!(sink.flush_once(NOW + 1).await.tenants_flushed, 0);
+        sink.observe(&tenant, tenant.hash(), families("alpha", 2));
+        assert_eq!(sink.flush_once(NOW + 2).await.tenants_flushed, 1);
+    }
+
+    /// The per-tenant entry cap drops *new* names, visibly, and never blocks an
+    /// update to a name already stored.
+    #[tokio::test]
+    async fn over_cap_new_names_are_dropped_and_counted() {
+        let store = counting_store();
+        let metrics = Arc::new(IngestMetrics::default());
+        let config = MetadataSinkConfig {
+            entry_cap: 3,
+            ..MetadataSinkConfig::default()
+        };
+        let sink = Arc::new(
+            MetadataSink::new(store.clone(), config, metrics.clone())
+                .with_clock(Arc::new(InstantClock))
+                .with_rng(Arc::new(NoJitter)),
+        );
+        let tenant = TenantId::new("tenant-a");
+
+        sink.observe(&tenant, tenant.hash(), families("alpha", 5));
+        let summary = sink.flush_once(NOW).await;
+
+        let entries = stored(store.as_ref(), &tenant).await;
+        assert_eq!(entries.len(), 3);
+        assert_eq!(summary.dropped_over_cap, 2);
+        assert_eq!(metrics.snapshot().metadata_entries_dropped_total, 2);
+
+        // An existing name's help still updates at the cap: shrinking or
+        // refusing a stored entry is a pruning decision, not a side effect of
+        // one more name arriving.
+        let existing = entries[0].family_name.clone();
+        sink.observe(
+            &tenant,
+            tenant.hash(),
+            [meta(&existing, "revised help", "bytes")],
+        );
+        sink.flush_once(NOW + 1).await;
+        let entries = stored(store.as_ref(), &tenant).await;
+        assert_eq!(entries.len(), 3);
+        let updated = entries
+            .iter()
+            .find(|e| e.family_name == existing)
+            .expect("existing family still stored");
+        assert_eq!(updated.help, "revised help");
+    }
+
+    /// `observe` is synchronous (this test is not `async` and never awaits it)
+    /// and does no I/O: a store that panics on every access is untouched.
+    #[test]
+    fn observe_never_awaits() {
+        let sink = MetadataSink::new(
+            Arc::new(PanicStore),
+            MetadataSinkConfig::default(),
+            Arc::new(IngestMetrics::default()),
+        );
+        let tenant = TenantId::new("tenant-a");
+        for _ in 0..100 {
+            sink.observe(&tenant, tenant.hash(), families("alpha", 20));
+        }
+        // Pending work accumulated without a single store call; only a flush
+        // (which this test never runs) would touch the store.
+        let state = sink.state.lock().expect("state lock");
+        assert_eq!(state.pending.len(), 1);
+        assert_eq!(
+            state
+                .pending
+                .values()
+                .next()
+                .expect("one tenant pending")
+                .entries
+                .len(),
+            20
+        );
+    }
+
+    /// An empty family name is dropped rather than sent to a writer that would
+    /// refuse the whole record.
+    #[tokio::test]
+    async fn empty_family_name_is_dropped_defensively() {
+        let store = counting_store();
+        let sink = sink(store.clone(), MetadataSinkConfig::default());
+        let tenant = TenantId::new("tenant-a");
+        sink.observe(&tenant, tenant.hash(), [meta("", "help", "bytes")]);
+        let summary = sink.flush_once(NOW).await;
+        assert_eq!(summary.tenants_flushed, 0);
+        assert_eq!(puts(store.as_ref()), 0);
+    }
+
+    /// A disabled sink is a no-op on both halves.
+    #[tokio::test]
+    async fn disabled_sink_never_reads_or_writes() {
+        let config = MetadataSinkConfig {
+            disabled: true,
+            ..MetadataSinkConfig::default()
+        };
+        let sink = sink(Arc::new(PanicStore), config);
+        let tenant = TenantId::new("tenant-a");
+        sink.observe(&tenant, tenant.hash(), families("alpha", 5));
+        assert_eq!(sink.flush_once(NOW).await, FlushSummary::default());
+    }
+
+    /// Shutdown flushes the window in progress rather than discarding it. The
+    /// clock's window sleep never completes, so only the shutdown arm can fire:
+    /// whatever is written came from the final flush.
+    #[tokio::test]
+    async fn shutdown_does_a_final_flush() {
+        let store = counting_store();
+        let sink = Arc::new(
+            MetadataSink::new(
+                store.clone(),
+                MetadataSinkConfig::default(),
+                Arc::new(IngestMetrics::default()),
+            )
+            .with_clock(Arc::new(NeverClock))
+            .with_rng(Arc::new(NoJitter)),
+        );
+        let tenant = TenantId::new("tenant-a");
+        sink.observe(&tenant, tenant.hash(), families("alpha", 4));
+
+        let (tx, rx) = oneshot::channel();
+        let task = tokio::spawn(sink.clone().run(rx));
+        tx.send(()).expect("shutdown receiver alive");
+        task.await.expect("flush loop joined");
+
+        assert_eq!(stored(store.as_ref(), &tenant).await.len(), 4);
+    }
+
+    #[test]
+    fn fingerprint_covers_kind_help_and_unit_and_nothing_else() {
+        let base = meta("m", "help", "bytes");
+        assert_eq!(
+            fingerprint_of(&base),
+            fingerprint_of(&meta("other", "help", "bytes"))
+        );
+        assert_ne!(
+            fingerprint_of(&base),
+            fingerprint_of(&meta("m", "help2", "bytes"))
+        );
+        assert_ne!(
+            fingerprint_of(&base),
+            fingerprint_of(&meta("m", "help", "seconds"))
+        );
+        let gauge = MetricMetadata {
+            kind: WireMetricKind::Gauge,
+            ..base.clone()
+        };
+        assert_ne!(fingerprint_of(&base), fingerprint_of(&gauge));
+        // Length-prefixed field encoding: a boundary shift is a different
+        // fingerprint, not a collision.
+        assert_ne!(
+            fingerprint_of(&meta("m", "ab", "c")),
+            fingerprint_of(&meta("m", "a", "bc"))
+        );
+    }
+
+    #[test]
+    fn every_wire_kind_maps_to_its_catalog_twin() {
+        assert_eq!(
+            catalog_metric_kind(WireMetricKind::Counter),
+            CatalogMetricKind::Counter
+        );
+        assert_eq!(
+            catalog_metric_kind(WireMetricKind::Gauge),
+            CatalogMetricKind::Gauge
+        );
+        assert_eq!(
+            catalog_metric_kind(WireMetricKind::Histogram),
+            CatalogMetricKind::Histogram
+        );
+        assert_eq!(
+            catalog_metric_kind(WireMetricKind::Summary),
+            CatalogMetricKind::Summary
+        );
+        assert_eq!(
+            catalog_metric_kind(WireMetricKind::Unknown),
+            CatalogMetricKind::Unknown
+        );
+    }
+}

--- a/crates/ravel-ingest/src/metrics_meta_sink.rs
+++ b/crates/ravel-ingest/src/metrics_meta_sink.rs
@@ -38,13 +38,16 @@
 //! is always read and merged before any write, so a fresh process with an empty
 //! map converges to zero PUTs rather than rewriting what is already stored.
 //!
-//! Its memory grows with the number of distinct metric family names a process
-//! sees over its lifetime, per tenant. That growth is the same vector the
-//! record-side per-tenant entry cap
-//! ([`MetadataSinkConfig::entry_cap`]) bounds durably; ADR-0085 puts the cap on
-//! the record, and a family whose entry was dropped over cap is not re-armed
-//! every window (its fingerprint is committed like any other), so a hostile
-//! name-minting client costs one bounded local map and no extra requests.
+//! Both maps are bounded, not just the durable record: a family name that
+//! would grow one tenant's tracked set past `MetadataSinkConfig::entry_cap`
+//! (the same cap the durable record enforces) is never fingerprinted or
+//! queued, and a tenant beyond `MetadataSinkConfig::max_tracked_tenants` has
+//! its least-recently-touched, no-pending-work sibling evicted to make room.
+//! A hostile client minting unbounded distinct family names or tenant
+//! identities therefore cannot grow this process's memory without bound; the
+//! cost is at most one extra GET per window for the tenant whose local state
+//! was capped or evicted, never lost data (the durable record is unaffected,
+//! and it enforces its own cap independently via `merge_entries`).
 //!
 //! # Failure handling
 //!
@@ -88,6 +91,15 @@ pub const DEFAULT_MAX_CAS_RETRIES: u32 = 5;
 /// inside one debounce window.
 const CAS_BACKOFF_BASE: Duration = Duration::from_millis(50);
 
+/// Default cap on the number of distinct tenants [`MetadataSink`]'s local
+/// fingerprint map tracks at once. Chosen generously above any deployment's
+/// real tenant count (this is a memory-safety backstop, not an operational
+/// limit); a tenant beyond the cap is not refused, its least-recently-touched
+/// sibling with no pending flush is evicted from the local map instead, which
+/// only costs that sibling one extra GET on its next observed metric (the
+/// durable record already has what the local map forgot).
+pub const DEFAULT_MAX_TRACKED_TENANTS: usize = 4096;
+
 /// Tuning for [`MetadataSink`]. Every default is the ADR-0085 decision 1 value.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MetadataSinkConfig {
@@ -97,8 +109,17 @@ pub struct MetadataSinkConfig {
     /// Per-tenant durable entry cap. A *new* family name arriving when the
     /// record is already at the cap is dropped and counted
     /// (`ingest_metadata_entries_dropped_total`); its points are still ingested
-    /// and queryable.
+    /// and queryable. Also the bound on the local fingerprint/pending maps'
+    /// per-tenant size (see [`SinkState::fingerprints`]): a client cannot make
+    /// this process track more distinct families for one tenant, in memory,
+    /// than could ever be durably stored for it.
     pub entry_cap: usize,
+    /// Cap on the number of distinct tenants tracked in the local fingerprint
+    /// map at once (see [`DEFAULT_MAX_TRACKED_TENANTS`]). Bounds this
+    /// process's total metadata-sink memory to roughly
+    /// `max_tracked_tenants * entry_cap` entries regardless of how many
+    /// distinct tenants or metric names a client mints.
+    pub max_tracked_tenants: usize,
     /// How many times a CAS PUT is retried against a freshly read body after a
     /// conflict. The initial attempt is not a retry, so a window issues at most
     /// `max_cas_retries + 1` PUTs.
@@ -114,6 +135,7 @@ impl Default for MetadataSinkConfig {
         MetadataSinkConfig {
             window: DEFAULT_METADATA_FLUSH_WINDOW,
             entry_cap: DEFAULT_METRICS_META_ENTRY_CAP,
+            max_tracked_tenants: DEFAULT_MAX_TRACKED_TENANTS,
             max_cas_retries: DEFAULT_MAX_CAS_RETRIES,
             disabled: false,
         }
@@ -186,10 +208,27 @@ struct SinkState {
     /// Last-flushed fingerprint per (tenant, family name). Nested rather than
     /// keyed by a `(TenantHash, String)` tuple so the request-path lookup in
     /// `observe` borrows the name instead of cloning it into a key.
+    ///
+    /// Bounded per tenant at `MetadataSinkConfig::entry_cap`: a family name
+    /// that would grow a tenant's tracked set past the cap is never
+    /// fingerprinted or queued (see `observe`), so this map cannot grow past
+    /// `entry_cap` distinct families per known tenant regardless of how many
+    /// distinct names a client sends. Bounded in tenant count at
+    /// `MetadataSinkConfig::max_tracked_tenants` (see `evict_tenant_if_full`):
+    /// a hostile or misconfigured client cannot make this process's memory
+    /// grow without bound just by minting metric names or tenants.
     fingerprints: HashMap<TenantHash, HashMap<String, u64>>,
     /// Names whose fingerprint differs from `fingerprints`, awaiting the next
-    /// flush window. Ordered so a flush is deterministic.
+    /// flush window. Ordered so a flush is deterministic. Same per-tenant cap
+    /// as `fingerprints` (the two together, not each separately, bound one
+    /// tenant's tracked family count).
     pending: BTreeMap<TenantHash, PendingTenant>,
+    /// Last `touch_seq` a tenant was observed at, for `evict_tenant_if_full`'s
+    /// least-recently-touched eviction when `max_tracked_tenants` is reached.
+    /// A logical clock (not wall time) so eviction order is deterministic
+    /// under test without a clock dependency.
+    tenant_touch: HashMap<TenantHash, u64>,
+    touch_seq: u64,
 }
 
 /// The one-per-process metric metadata sink. Share it by `Arc`: every ingest
@@ -287,18 +326,52 @@ impl MetadataSink {
             // degradation on its next tick.
             return;
         };
+        // Touch this tenant (for LRU eviction below) and, if it is one this
+        // process has never tracked, make room under `max_tracked_tenants`
+        // before adding anything for it. A tenant with pending work is never
+        // evicted, so this can never evict the tenant it is about to serve.
+        state.touch_seq = state.touch_seq.wrapping_add(1);
+        let seq = state.touch_seq;
+        state.tenant_touch.insert(tenant_hash, seq);
+        if !state.fingerprints.contains_key(&tenant_hash)
+            && !state.pending.contains_key(&tenant_hash)
+        {
+            evict_tenant_if_full(&mut state, tenant_hash, self.config.max_tracked_tenants);
+        }
         for meta in metadata {
             if meta.family_name.is_empty() {
                 continue;
             }
             let fingerprint = fingerprint_of(&meta);
-            let unchanged = state
+            let existing_fingerprint = state
                 .fingerprints
                 .get(&tenant_hash)
                 .and_then(|names| names.get(meta.family_name.as_str()))
-                .is_some_and(|stored| *stored == fingerprint);
-            if unchanged {
+                .copied();
+            if existing_fingerprint == Some(fingerprint) {
                 continue;
+            }
+            let already_pending = state
+                .pending
+                .get(&tenant_hash)
+                .is_some_and(|p| p.entries.contains_key(meta.family_name.as_str()));
+            // A name absent from both maps would grow this tenant's tracked
+            // set by one slot. Refuse it past `entry_cap` so the local maps
+            // cannot outgrow what the durable record could ever hold for this
+            // tenant, however many distinct names a client sends -- the same
+            // counter the flush-time durable-record cap uses, since both are
+            // "this family name did not get a metadata entry because the
+            // tenant is already at its cap."
+            if existing_fingerprint.is_none() && !already_pending {
+                let known = state.fingerprints.get(&tenant_hash).map_or(0, HashMap::len)
+                    + state
+                        .pending
+                        .get(&tenant_hash)
+                        .map_or(0, |p| p.entries.len());
+                if known >= self.config.entry_cap {
+                    self.metrics.record_metadata_entries_dropped(1);
+                    continue;
+                }
             }
             let pending = state
                 .pending
@@ -525,6 +598,41 @@ impl MetadataSink {
             "metric metadata flush failed; dropping this window's metadata update (ingest \
              unaffected, re-armed on the next changed tuple)"
         );
+    }
+}
+
+/// If `state.fingerprints` already tracks `max_tracked_tenants` distinct
+/// tenants, evict the least-recently-touched one that has no pending flush,
+/// to make room for `incoming` (never itself a candidate). A tenant with
+/// pending data is never evicted, so an evicted tenant's local state is
+/// simply forgotten -- exactly what a process restart already does to every
+/// tenant, and self-healing the same way: its next observed metric costs one
+/// extra GET, not lost data (the durable record is unaffected).
+///
+/// A linear scan, same as `MetadataCache::evict_if_full` in `ravel-query`:
+/// this only runs when a genuinely new tenant is seen with the map already
+/// at capacity, not on every `observe` call, and `max_tracked_tenants` is a
+/// memory-safety backstop sized in the low thousands, not a per-request cost.
+fn evict_tenant_if_full(state: &mut SinkState, incoming: TenantHash, max_tracked_tenants: usize) {
+    let max = max_tracked_tenants.max(1);
+    while state.fingerprints.len() >= max {
+        let victim = state
+            .fingerprints
+            .keys()
+            .filter(|hash| **hash != incoming && !state.pending.contains_key(*hash))
+            .min_by_key(|hash| state.tenant_touch.get(*hash).copied().unwrap_or(0))
+            .copied();
+        match victim {
+            Some(hash) => {
+                state.fingerprints.remove(&hash);
+                state.tenant_touch.remove(&hash);
+            }
+            // Every tracked tenant has pending work: nothing is safe to
+            // evict this call. The map temporarily exceeds
+            // `max_tracked_tenants`; the next flush drains pending sets and
+            // the next `observe` after that will find room.
+            None => break,
+        }
     }
 }
 
@@ -970,7 +1078,14 @@ mod tests {
 
         let entries = stored(store.as_ref(), &tenant).await;
         assert_eq!(entries.len(), 3);
-        assert_eq!(summary.dropped_over_cap, 2);
+        // `observe` itself refuses a name that would grow this tenant's
+        // tracked set past `entry_cap` (the local-map memory bound), so the
+        // two over-cap names never reach `pending` and `merge_entries` never
+        // sees them at flush time: `dropped_over_cap` is the *merge's* own
+        // count, and it is 0 here. The counter still fires from `observe`'s
+        // own drop path, which is what the durable outcome (3 stored, 2
+        // dropped) actually depends on.
+        assert_eq!(summary.dropped_over_cap, 0);
         assert_eq!(metrics.snapshot().metadata_entries_dropped_total, 2);
 
         // An existing name's help still updates at the cap: shrinking or
@@ -990,6 +1105,108 @@ mod tests {
             .find(|e| e.family_name == existing)
             .expect("existing family still stored");
         assert_eq!(updated.help, "revised help");
+    }
+
+    /// The memory-safety regression this exists to prevent: a single burst of
+    /// far more distinct family names than `entry_cap` must not make the
+    /// local maps grow past it before a flush ever runs. Proven indirectly
+    /// (the fields are private): if `observe` queued every name instead of
+    /// capping locally, `flush_once` would still do one GET/PUT (the flush
+    /// loop is always one-per-tenant), but `merge_entries` would report a
+    /// dropped_over_cap of `10_000 - cap`, not 0, because the flush-time
+    /// cap would be doing all the work `observe` should have already done.
+    #[tokio::test]
+    async fn observe_bounds_a_huge_burst_before_any_flush_runs() {
+        let store = counting_store();
+        let metrics = Arc::new(IngestMetrics::default());
+        let config = MetadataSinkConfig {
+            entry_cap: 5,
+            ..MetadataSinkConfig::default()
+        };
+        let sink = Arc::new(
+            MetadataSink::new(store.clone(), config, metrics.clone())
+                .with_clock(Arc::new(InstantClock))
+                .with_rng(Arc::new(NoJitter)),
+        );
+        let tenant = TenantId::new("tenant-a");
+
+        sink.observe(&tenant, tenant.hash(), families("burst", 10_000));
+        let summary = sink.flush_once(NOW).await;
+
+        assert_eq!(summary.gets, 1);
+        assert_eq!(summary.puts, 1);
+        assert_eq!(
+            summary.dropped_over_cap, 0,
+            "observe already refused the over-cap names; merge_entries never saw them"
+        );
+        assert_eq!(stored(store.as_ref(), &tenant).await.len(), 5);
+        assert_eq!(metrics.snapshot().metadata_entries_dropped_total, 9_995);
+    }
+
+    /// `max_tracked_tenants` bounds the number of distinct tenants the local
+    /// fingerprint map holds. A tenant evicted to make room is not lost data:
+    /// its durable record is untouched, and re-observing an unchanged metric
+    /// for it costs one extra GET (the map "forgot" it, exactly what a
+    /// process restart already does), never an extra PUT.
+    #[tokio::test]
+    async fn max_tracked_tenants_evicts_the_idle_tenant_and_self_heals() {
+        let store = counting_store();
+        let metrics = Arc::new(IngestMetrics::default());
+        let config = MetadataSinkConfig {
+            max_tracked_tenants: 2,
+            ..MetadataSinkConfig::default()
+        };
+        let sink = Arc::new(
+            MetadataSink::new(store.clone(), config, metrics.clone())
+                .with_clock(Arc::new(InstantClock))
+                .with_rng(Arc::new(NoJitter)),
+        );
+        let tenant_a = TenantId::new("tenant-a");
+        let tenant_b = TenantId::new("tenant-b");
+        let tenant_c = TenantId::new("tenant-c");
+
+        // A and B each get one metric, and are flushed (so neither has
+        // pending work and both are eviction-eligible). A is touched first,
+        // so it is the least-recently-touched of the two once C arrives.
+        sink.observe(&tenant_a, tenant_a.hash(), [meta("m", "help", "bytes")]);
+        sink.flush_once(NOW).await;
+        sink.observe(&tenant_b, tenant_b.hash(), [meta("m", "help", "bytes")]);
+        sink.flush_once(NOW).await;
+
+        // A third tenant, with the map already at max_tracked_tenants,
+        // evicts A (not B, which was touched more recently).
+        sink.observe(&tenant_c, tenant_c.hash(), [meta("m", "help", "bytes")]);
+        let summary = sink.flush_once(NOW).await;
+        assert_eq!(summary.tenants_flushed, 1, "only C had pending work");
+
+        // B, never evicted, is still a pure local hit: no GET, no PUT.
+        let gets_before = gets(store.as_ref());
+        let puts_before = puts(store.as_ref());
+        sink.observe(&tenant_b, tenant_b.hash(), [meta("m", "help", "bytes")]);
+        let summary = sink.flush_once(NOW).await;
+        assert_eq!(summary.tenants_flushed, 0, "B is still tracked locally");
+        assert_eq!(gets(store.as_ref()), gets_before);
+        assert_eq!(puts(store.as_ref()), puts_before);
+
+        // Re-observing A's already-durable, unchanged metric looks "new"
+        // locally (A was evicted), so it flushes: one more GET, but the merge
+        // is a no-op against the durable record, so zero more PUTs. This
+        // insert itself evicts whichever of {B, C} is now least-recently
+        // touched (B, touched before C arrived) -- LRU eviction keeps
+        // running exactly the same way once the map is back at capacity;
+        // this call only asserts A's own self-healing GET-not-PUT, not B's
+        // fate afterward.
+        let gets_before = gets(store.as_ref());
+        let puts_before = puts(store.as_ref());
+        sink.observe(&tenant_a, tenant_a.hash(), [meta("m", "help", "bytes")]);
+        let summary = sink.flush_once(NOW).await;
+        assert_eq!(summary.tenants_flushed, 1);
+        assert_eq!(gets(store.as_ref()), gets_before + 1);
+        assert_eq!(
+            puts(store.as_ref()),
+            puts_before,
+            "the durable record already had A's unchanged entry; eviction cost a GET, not a PUT"
+        );
     }
 
     /// `observe` is synchronous (this test is not `async` and never awaits it)

--- a/crates/ravel-ingest/src/router.rs
+++ b/crates/ravel-ingest/src/router.rs
@@ -158,6 +158,15 @@ impl IngestRouter {
         &self.metrics
     }
 
+    /// The counter registry as a shared handle, for a process-level component
+    /// that outlives a borrow and must count into the same registry the
+    /// `/metrics` snapshot reads: the metric metadata sink
+    /// ([`crate::MetadataSink`], ADR-0085 decision 1) is spawned as its own task
+    /// and holds this rather than a second, invisible `IngestMetrics`.
+    pub fn metrics_handle(&self) -> Arc<IngestMetrics> {
+        self.metrics.clone()
+    }
+
     /// Resolve the tenant's active shard-actor set for a write at `now_ns`,
     /// re-reading the provisioning record when the cached view is older than the
     /// refresh interval `C` (ADR-0052 section 3). When the re-read cannot

--- a/crates/ravel-otap/src/normalize.rs
+++ b/crates/ravel-otap/src/normalize.rs
@@ -67,7 +67,7 @@
 //! counted as dropped by [`push_exp_histogram_exemplar_drops`], which also
 //! records the attachment rule waiting for them.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use arrow::array::{
@@ -76,8 +76,10 @@ use arrow::array::{
     UInt8Array, UInt16Array, UInt32Array, UInt64Array,
 };
 use arrow::datatypes::UInt8Type;
-use ravel_otlp::metadata::MetricKind as PromMetricKind;
-use ravel_otlp::normalize::{MetricsNormalizeResult, NormalizedExemplar, prometheus_family_name};
+use ravel_otlp::metadata::{MetricKind as PromMetricKind, MetricMetadata};
+use ravel_otlp::normalize::{
+    MetricsNormalizeResult, NormalizedExemplar, map_unit, prometheus_family_name,
+};
 use ravel_otlp::promcompat::format_float;
 use ravel_otlp::{IngestLimits, NormalizeOutput, NormalizedPoint, Rejection};
 use ravel_types::{
@@ -477,6 +479,57 @@ pub fn normalize_decoded_with_exemplars(
     ingest_ts_ns: i64,
     exemplar_cap: &mut ExemplarCap,
 ) -> MetricsNormalizeResult {
+    normalize_impl(tenant, batch, limits, ingest_ts_ns, exemplar_cap, false).0
+}
+
+/// Normalize exactly like [`normalize_decoded_with_exemplars`], and additionally
+/// surface one [`MetricMetadata`] per metric family that produced at least one
+/// point (ADR-0085 Decision 1). The returned [`MetricsNormalizeResult`] is what
+/// [`normalize_decoded_with_exemplars`] returns for the same input, unchanged;
+/// the metadata is the only addition.
+///
+/// This mirrors `ravel_otlp::normalize::normalize_metrics_with_metadata` field
+/// for field, since the two surfaces must store the same tuple for the same
+/// logical metric:
+///
+/// - `family_name` is the Decision 2 suffixed name (unit word and `_total`
+///   applied) *before* the classic histogram/summary explosion appends
+///   `_bucket`/`_sum`/`_count`, i.e. exactly the decision name the exploded
+///   series are derived from.
+/// - `kind` comes from the METRICS `metric_type` column and the `is_monotonic`
+///   flag, the OTAP equivalent of OTLP's `data` oneof: a monotonic Sum is a
+///   Counter, a non-monotonic Sum and a Gauge are both Gauge.
+/// - `help` is the METRICS `description` column, empty when the producer omits
+///   it (OTLP's `Metric.description`).
+/// - `unit` is the mapped Prometheus word (`bytes`, `seconds`), the raw unit
+///   when it maps to nothing, or empty, matching the word the name was suffixed
+///   with.
+///
+/// Metadata is deduplicated by `family_name`, first write wins. A metric whose
+/// every point was rejected contributes nothing: metadata describes families
+/// Ravel actually stored points for.
+pub fn normalize_decoded_with_metadata(
+    tenant: &TenantId,
+    batch: &DecodedBatch,
+    limits: &IngestLimits,
+    ingest_ts_ns: i64,
+    exemplar_cap: &mut ExemplarCap,
+) -> (MetricsNormalizeResult, Vec<MetricMetadata>) {
+    normalize_impl(tenant, batch, limits, ingest_ts_ns, exemplar_cap, true)
+}
+
+/// Shared body of the two exemplar-carrying entry points. `collect_metadata` is
+/// true only for [`normalize_decoded_with_metadata`]; the points, exemplars, and
+/// rejections it produces do not depend on it, so the older entry points are
+/// behaviorally unchanged.
+fn normalize_impl(
+    tenant: &TenantId,
+    batch: &DecodedBatch,
+    limits: &IngestLimits,
+    ingest_ts_ns: i64,
+    exemplar_cap: &mut ExemplarCap,
+    collect_metadata: bool,
+) -> (MetricsNormalizeResult, Vec<MetricMetadata>) {
     let total_points = count_total_points(batch);
     if total_points > limits.max_data_points_per_request {
         // No payload past the count is decoded, so no exemplar is even read
@@ -489,21 +542,27 @@ pub fn normalize_decoded_with_exemplars(
         // The difference is structural, not an oversight, and the differential
         // gate compares rejection classes at the shared admission layer rather
         // than at this return for exactly that reason.
-        return MetricsNormalizeResult {
-            output: NormalizeOutput {
-                points: Vec::new(),
-                // OTAP carries only scalar metric points; native-histogram
-                // admission is the OTLP/Remote Write surface's concern, so this
-                // vector is always empty here (ravel_otlp::NormalizeOutput
-                // gained it for those surfaces).
-                histogram_points: Vec::new(),
-                rejected: vec![Rejection::TooManyDataPoints {
-                    count: total_points,
-                    max: limits.max_data_points_per_request,
-                }],
+        return (
+            MetricsNormalizeResult {
+                output: NormalizeOutput {
+                    points: Vec::new(),
+                    // OTAP carries only scalar metric points; native-histogram
+                    // admission is the OTLP/Remote Write surface's concern, so
+                    // this vector is always empty here
+                    // (ravel_otlp::NormalizeOutput gained it for those
+                    // surfaces).
+                    histogram_points: Vec::new(),
+                    rejected: vec![Rejection::TooManyDataPoints {
+                        count: total_points,
+                        max: limits.max_data_points_per_request,
+                    }],
+                },
+                exemplars: Vec::new(),
             },
-            exemplars: Vec::new(),
-        };
+            // A whole-request rejection stored no point, so it describes no
+            // family: no metadata, exactly as OTLP's own early return.
+            Vec::new(),
+        );
     }
 
     let mut rejected = Vec::new();
@@ -565,6 +624,12 @@ pub fn normalize_decoded_with_exemplars(
             count: unknown_metric_count,
         });
     }
+
+    // Which metric ids actually contributed a point. Read only by the metadata
+    // build below (a family whose every point was rejected describes nothing),
+    // and one bool write per admitted point regardless, so the metadata-free
+    // entry points pay nothing measurable for it.
+    let mut produced = vec![false; dense_size];
 
     let attr_order = sort_attrs_by_parent(&flat_attrs);
     let mut points = Vec::with_capacity(flat_dp.len());
@@ -674,6 +739,9 @@ pub fn normalize_decoded_with_exemplars(
                     },
                     is_monotonic_sum: decision.is_sum && decision.is_monotonic,
                 });
+                if let Some(slot) = produced.get_mut(dp.parent_id as usize) {
+                    *slot = true;
+                }
                 // A number data point has no buckets, so its exemplars attach
                 // to the point's own series: there is no `le` bound to resolve
                 // This is the same rule `ravel_otlp::build_point`
@@ -722,6 +790,11 @@ pub fn normalize_decoded_with_exemplars(
             memo,
         ) {
             Ok((mut new_points, informational)) => {
+                if !new_points.is_empty()
+                    && let Some(slot) = produced.get_mut(dp.parent_id as usize)
+                {
+                    *slot = true;
+                }
                 points.append(&mut new_points);
                 rejected.extend(informational);
             }
@@ -753,21 +826,205 @@ pub fn normalize_decoded_with_exemplars(
             ingest_ts_ns,
             memo,
         ) {
-            Ok(mut new_points) => points.append(&mut new_points),
+            Ok(mut new_points) => {
+                if !new_points.is_empty()
+                    && let Some(slot) = produced.get_mut(dp.parent_id as usize)
+                {
+                    *slot = true;
+                }
+                points.append(&mut new_points);
+            }
             Err(rejection) => rejected.push(rejection),
         }
     }
 
-    MetricsNormalizeResult {
-        output: NormalizeOutput {
-            points,
-            // Always empty: OTAP admits only scalar points (see the early
-            // return above).
-            histogram_points: Vec::new(),
-            rejected,
+    let metadata = if collect_metadata {
+        build_metadata(
+            &root,
+            &metric_decision,
+            &hist_decision,
+            &summary_decision,
+            &produced,
+        )
+    } else {
+        Vec::new()
+    };
+
+    (
+        MetricsNormalizeResult {
+            output: NormalizeOutput {
+                points,
+                // Always empty: OTAP admits only scalar points (see the early
+                // return above).
+                histogram_points: Vec::new(),
+                rejected,
+            },
+            exemplars,
         },
-        exemplars,
+        metadata,
+    )
+}
+
+/// One [`MetricMetadata`] per metric id that contributed a point, in metric-id
+/// order, deduplicated by `family_name` with the first occurrence winning
+/// (`ravel_otlp`'s `MetadataCollector` rule). The family name is the decision's
+/// already-suffixed name, so it agrees with the series the points carry.
+fn build_metadata(
+    root: &[Option<RootEntry>],
+    metric_decision: &[Option<MetricDecision>],
+    hist_decision: &[Option<HistogramDecision>],
+    summary_decision: &[Option<SummaryDecision>],
+    produced: &[bool],
+) -> Vec<MetricMetadata> {
+    let mut out: Vec<MetricMetadata> = Vec::new();
+    let mut seen: HashSet<&str> = HashSet::new();
+    for (id, contributed) in produced.iter().enumerate() {
+        if !contributed {
+            continue;
+        }
+        let Some(entry) = root.get(id).and_then(|e| e.as_ref()) else {
+            continue;
+        };
+        // Exactly one of the three decision tables holds this id: the tables
+        // are built from the same `metric_type` column, and a row whose type
+        // disagrees with its data-point table was classed unknown and produced
+        // no point.
+        let family_name = metric_decision
+            .get(id)
+            .and_then(|d| d.as_ref())
+            .map(|d| d.name.as_str())
+            .or_else(|| {
+                hist_decision
+                    .get(id)
+                    .and_then(|d| d.as_ref())
+                    .map(|d| d.name.as_str())
+            })
+            .or_else(|| {
+                summary_decision
+                    .get(id)
+                    .and_then(|d| d.as_ref())
+                    .map(|d| d.name.as_str())
+            });
+        let Some(family_name) = family_name else {
+            continue;
+        };
+        if !seen.insert(family_name) {
+            continue;
+        }
+        let kind = metadata_kind(&entry.kind);
+        out.push(MetricMetadata {
+            family_name: family_name.to_string(),
+            kind,
+            help: entry.description.clone(),
+            unit: metadata_unit_word(&entry.unit, kind),
+        });
     }
+    out
+}
+
+/// The Prometheus kind a METRICS root row implies, the OTAP twin of
+/// `ravel_otlp`'s `metric_kind_of` over the `data` oneof: a monotonic Sum is a
+/// Counter, a non-monotonic Sum and a Gauge are both Gauge. An `Unsupported`
+/// row never reaches here (it produces no point and so no metadata), and
+/// [`PromMetricKind::Unknown`] is the honest answer if one ever did.
+fn metadata_kind(kind: &RootKind) -> PromMetricKind {
+    match kind {
+        RootKind::Gauge => PromMetricKind::Gauge,
+        RootKind::Sum {
+            is_monotonic: true, ..
+        } => PromMetricKind::Counter,
+        RootKind::Sum { .. } => PromMetricKind::Gauge,
+        RootKind::Histogram { .. } => PromMetricKind::Histogram,
+        RootKind::Summary => PromMetricKind::Summary,
+        RootKind::Unsupported => PromMetricKind::Unknown,
+    }
+}
+
+/// The unit word stored in a metadata tuple: the mapped Prometheus word when the
+/// unit maps (so it agrees with the suffix [`prometheus_family_name`] put on the
+/// name), otherwise the raw unit with annotations stripped, otherwise empty
+/// (ADR-0085 Decision 1/2).
+///
+/// This mirrors `ravel_otlp::normalize`'s private `metadata_unit_word` /
+/// `unit_suffix` pair, the same way this module already mirrors that crate's
+/// private sanitization helpers: the mapped-word table itself is reused through
+/// the pub `map_unit`, and only the compound (`a/b`) and annotation handling is
+/// restated. Exporting `metadata_unit_word` from `ravel-otlp` would let both
+/// paths share one function; that is a `ravel-otlp` change, outside this task's
+/// scope, and is flagged rather than made here.
+fn metadata_unit_word(unit: &str, kind: PromMetricKind) -> String {
+    match metadata_unit_suffix(unit, kind) {
+        Some(word) => word,
+        // Unmapped: carry the raw unit through as free text. This is a metadata
+        // field, not a metric name, so metric-name sanitizing does not apply.
+        None => strip_unit_annotations(unit).trim().to_string(),
+    }
+}
+
+/// The mapped unit suffix (without a leading `_`), or `None` when the unit adds
+/// no suffix (empty, unrecognized simple unit, or `1` on a non-gauge).
+fn metadata_unit_suffix(unit: &str, kind: PromMetricKind) -> Option<String> {
+    let stripped = strip_unit_annotations(unit);
+    let trimmed = stripped.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if trimmed == "1" {
+        return match kind {
+            PromMetricKind::Gauge => Some("ratio".to_string()),
+            _ => None,
+        };
+    }
+    if let Some((num_raw, den_raw)) = trimmed.split_once('/') {
+        let num = num_raw.trim();
+        let den = den_raw.trim();
+        let num_mapped =
+            (!num.is_empty()).then(|| map_unit(num).unwrap_or_else(|| num.to_string()));
+        let den_mapped =
+            (!den.is_empty()).then(|| map_per_unit(den).unwrap_or_else(|| den.to_string()));
+        match (num_mapped, den_mapped) {
+            (Some(n), Some(d)) => Some(format!("{n}_per_{d}")),
+            (Some(n), None) => Some(n),
+            (None, Some(d)) => Some(format!("per_{d}")),
+            (None, None) => None,
+        }
+    } else {
+        map_unit(trimmed)
+    }
+}
+
+/// Strip every `{...}` annotation from a unit, at any nesting, tolerating
+/// unbalanced braces (a unit string is attacker-influenced and must never
+/// panic). Mirrors `ravel_otlp::normalize`'s private `strip_annotations`.
+fn strip_unit_annotations(unit: &str) -> String {
+    let mut out = String::with_capacity(unit.len());
+    let mut depth: usize = 0;
+    for c in unit.chars() {
+        match c {
+            '{' => depth += 1,
+            '}' => depth = depth.saturating_sub(1),
+            _ if depth == 0 => out.push(c),
+            _ => {}
+        }
+    }
+    out
+}
+
+/// A per-unit denominator through the Collector's `perUnitMapper` table, where
+/// `m` is `minute` rather than `meters`. Mirrors `ravel_otlp::normalize`'s
+/// private `map_per_unit`.
+fn map_per_unit(unit: &str) -> Option<String> {
+    let mapped = match unit {
+        "s" => "second",
+        "m" => "minute",
+        "h" => "hour",
+        "d" => "day",
+        "w" => "week",
+        "mo" => "month",
+        "y" => "year",
+        _ => return None,
+    };
+    Some(mapped.to_string())
 }
 
 fn payloads_of(batch: &DecodedBatch, ty: ArrowPayloadType) -> Vec<&RecordBatch> {
@@ -861,6 +1118,13 @@ struct RootEntry {
     /// [`prometheus_family_name`] when building each decision's suffixed name
     /// (ADR-0085 Decision 2), mirroring `ravel_otlp::normalize_metric`.
     unit: String,
+    /// The metric's help text (METRICS.description column), empty when the
+    /// column is absent or null. OTAP's counterpart to OTLP's
+    /// `Metric.description`, and the `help` field of the metadata tuple
+    /// [`normalize_decoded_with_metadata`] surfaces (ADR-0085 Decision 1). It
+    /// has no effect on points, names, or rejections, so a producer that omits
+    /// the column normalizes exactly as before with an empty help.
+    description: String,
 }
 
 enum RootKind {
@@ -1094,12 +1358,19 @@ fn build_root_table(
         let temporality_col = column_as::<Int32Array>(rb, "aggregation_temporality");
         let monotonic_col = column_as::<BooleanArray>(rb, "is_monotonic");
         let unit_col = rb.column_by_name("unit");
+        // Optional like `unit`: a producer that omits the column (this crate's
+        // own test encoder among them) yields an empty help rather than a
+        // decode failure.
+        let description_col = rb.column_by_name("description");
 
         for (i, &id) in ids.iter().enumerate() {
             let Some(name) = name_at(name_col, i) else {
                 continue;
             };
             let unit = unit_col.and_then(|c| name_at(c, i)).unwrap_or_default();
+            let description = description_col
+                .and_then(|c| name_at(c, i))
+                .unwrap_or_default();
             let kind = match types.value(i) {
                 METRIC_TYPE_GAUGE => RootKind::Gauge,
                 METRIC_TYPE_SUM => {
@@ -1120,7 +1391,12 @@ fn build_root_table(
                 _ => RootKind::Unsupported,
             };
             if (id as usize) < entries.len() {
-                entries[id as usize] = Some(RootEntry { name, kind, unit });
+                entries[id as usize] = Some(RootEntry {
+                    name,
+                    kind,
+                    unit,
+                    description,
+                });
             }
         }
     }
@@ -2403,4 +2679,159 @@ fn explode_summary_point(
     )?);
 
     Ok(series)
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    /// The unit word this module stores must be the same word
+    /// `ravel_otlp::normalize`'s private `metadata_unit_word` stores, since the
+    /// two surfaces write the same durable record. Pinned against the exact
+    /// table that crate's own tests pin (mapped word, dimensionless ratio,
+    /// unmapped raw passthrough, annotation-only collapse, compound form), so a
+    /// future divergence in either mirror fails here.
+    #[test]
+    fn metadata_unit_word_mirrors_the_otlp_mapping() {
+        assert_eq!(metadata_unit_word("By", PromMetricKind::Counter), "bytes");
+        assert_eq!(
+            metadata_unit_word("s", PromMetricKind::Histogram),
+            "seconds"
+        );
+        assert_eq!(metadata_unit_word("", PromMetricKind::Gauge), "");
+        // Dimensionless `1` is `ratio` on a gauge and nothing on any other kind,
+        // where "nothing" still carries the raw unit as free text.
+        assert_eq!(metadata_unit_word("1", PromMetricKind::Gauge), "ratio");
+        assert_eq!(metadata_unit_word("1", PromMetricKind::Counter), "1");
+        // Unmapped units pass through raw, never metric-name sanitized.
+        assert_eq!(
+            metadata_unit_word("furlong", PromMetricKind::Gauge),
+            "furlong"
+        );
+        assert_eq!(metadata_unit_word("2h", PromMetricKind::Gauge), "2h");
+        // Annotations are stripped; an annotation-only unit is empty.
+        assert_eq!(metadata_unit_word("{request}", PromMetricKind::Gauge), "");
+        assert_eq!(
+            metadata_unit_word("{packet}/s", PromMetricKind::Gauge),
+            "per_second"
+        );
+        // Compound form, each side mapped independently. `m` is `minute` in the
+        // denominator, not `meters`.
+        assert_eq!(
+            metadata_unit_word("By/s", PromMetricKind::Gauge),
+            "bytes_per_second"
+        );
+        assert_eq!(
+            metadata_unit_word("By/m", PromMetricKind::Gauge),
+            "bytes_per_minute"
+        );
+        // An unrecognized side passes through rather than being dropped.
+        assert_eq!(
+            metadata_unit_word("furlong/fortnight", PromMetricKind::Gauge),
+            "furlong_per_fortnight"
+        );
+    }
+
+    /// The METRICS `metric_type`/`is_monotonic` pair maps to the same Prometheus
+    /// kind OTLP's `data` oneof does.
+    #[test]
+    fn metadata_kind_follows_the_otlp_oneof_rule() {
+        assert_eq!(metadata_kind(&RootKind::Gauge), PromMetricKind::Gauge);
+        assert_eq!(
+            metadata_kind(&RootKind::Sum {
+                temporality: AGGREGATION_TEMPORALITY_CUMULATIVE,
+                is_monotonic: true,
+            }),
+            PromMetricKind::Counter
+        );
+        assert_eq!(
+            metadata_kind(&RootKind::Sum {
+                temporality: AGGREGATION_TEMPORALITY_CUMULATIVE,
+                is_monotonic: false,
+            }),
+            PromMetricKind::Gauge
+        );
+        assert_eq!(
+            metadata_kind(&RootKind::Histogram {
+                temporality: AGGREGATION_TEMPORALITY_CUMULATIVE,
+            }),
+            PromMetricKind::Histogram
+        );
+        assert_eq!(metadata_kind(&RootKind::Summary), PromMetricKind::Summary);
+        assert_eq!(
+            metadata_kind(&RootKind::Unsupported),
+            PromMetricKind::Unknown
+        );
+    }
+
+    /// Deduplication by family name, first occurrence winning, and "no point, no
+    /// metadata".
+    #[test]
+    fn build_metadata_dedups_by_family_and_skips_unproduced() {
+        let root = vec![
+            Some(RootEntry {
+                name: "requests".to_string(),
+                kind: RootKind::Sum {
+                    temporality: AGGREGATION_TEMPORALITY_CUMULATIVE,
+                    is_monotonic: true,
+                },
+                unit: "By".to_string(),
+                description: "first help".to_string(),
+            }),
+            Some(RootEntry {
+                name: "requests".to_string(),
+                kind: RootKind::Sum {
+                    temporality: AGGREGATION_TEMPORALITY_CUMULATIVE,
+                    is_monotonic: true,
+                },
+                unit: "By".to_string(),
+                description: "second help".to_string(),
+            }),
+            Some(RootEntry {
+                name: "silent".to_string(),
+                kind: RootKind::Gauge,
+                unit: String::new(),
+                description: "never stored".to_string(),
+            }),
+        ];
+        let decisions = vec![
+            Some(MetricDecision {
+                name: "requests_bytes_total".to_string(),
+                is_sum: true,
+                is_monotonic: true,
+            }),
+            Some(MetricDecision {
+                name: "requests_bytes_total".to_string(),
+                is_sum: true,
+                is_monotonic: true,
+            }),
+            Some(MetricDecision {
+                name: "silent".to_string(),
+                is_sum: false,
+                is_monotonic: false,
+            }),
+        ];
+        let empty_hist: Vec<Option<HistogramDecision>> = vec![None, None, None];
+        let empty_summary: Vec<Option<SummaryDecision>> = vec![None, None, None];
+
+        let metadata = build_metadata(
+            &root,
+            &decisions,
+            &empty_hist,
+            &empty_summary,
+            // The third metric produced no admitted point.
+            &[true, true, false],
+        );
+
+        assert_eq!(
+            metadata,
+            vec![MetricMetadata {
+                family_name: "requests_bytes_total".to_string(),
+                kind: PromMetricKind::Counter,
+                help: "first help".to_string(),
+                unit: "bytes".to_string(),
+            }]
+        );
+    }
 }

--- a/services/ravel-server/src/exemplars.rs
+++ b/services/ravel-server/src/exemplars.rs
@@ -2038,6 +2038,7 @@ mod tests {
             )),
             recovery: None,
             provisioning: None,
+            metadata_sink: None,
         };
 
         // A classic histogram data point (le bounds [0.5]) carrying one

--- a/services/ravel-server/src/ingest.rs
+++ b/services/ravel-server/src/ingest.rs
@@ -9,10 +9,11 @@ use opentelemetry_proto::tonic::collector::metrics::v1::{
     ExportMetricsPartialSuccess, ExportMetricsServiceRequest, ExportMetricsServiceResponse,
 };
 use ravel_ingest::{
-    AdmissionController, IngestExemplar, IngestPoint, IngestRouter, RequestRejection, WriteError,
-    WriteMode, plausible_ingest_clock,
+    AdmissionController, IngestExemplar, IngestPoint, IngestRouter, MetadataSink, RequestRejection,
+    WriteError, WriteMode, plausible_ingest_clock,
 };
-use ravel_otlp::{IngestLimits, Rejection, normalize_metrics_with_exemplars};
+use ravel_otlp::normalize::normalize_metrics_with_metadata;
+use ravel_otlp::{IngestLimits, Rejection};
 use ravel_types::{CommitToken, ExemplarCap, SeriesId, TenantId};
 
 pub struct IngestState {
@@ -33,6 +34,11 @@ pub struct IngestState {
     /// write and fails the request on a `shard_count` mismatch. `Some` in the
     /// ingest modes; `None` (e.g. a unit test) is a no-op.
     pub provisioning: Option<Arc<crate::provisioning::ProvisioningRecordWriter>>,
+    /// The one-per-process metric metadata sink (ADR-0085 decision 1). Every
+    /// ingest surface shares this one `Arc`; `handle_export` hands it what
+    /// normalization decoded, synchronously and off the acknowledgement path.
+    /// `None` in a unit test or a mode that captures no metadata.
+    pub metadata_sink: Option<Arc<MetadataSink>>,
 }
 
 pub struct IngestOutcome {
@@ -151,8 +157,17 @@ pub async fn handle_export(
     // `shard.rs`'s per-flush cap comment already rejected building one layer
     // lower).
     let mut cap = ExemplarCap::new(state.limits.exemplar_cap_window_ns);
-    let result =
-        normalize_metrics_with_exemplars(&tenant, request, &state.limits, ingest_ts_ns, &mut cap);
+    let (result, metadata) =
+        normalize_metrics_with_metadata(&tenant, request, &state.limits, ingest_ts_ns, &mut cap);
+    // Capture this request's `(family, type, help, unit)` tuples (ADR-0085
+    // decision 1). Synchronous, no I/O, infallible: it only compares
+    // fingerprints and stores the changed ones for the background flush window,
+    // so it is deliberately called here, right after normalization, rather than
+    // anywhere near the write's await. A point is acked on its data write and is
+    // never blocked on or failed by the metadata record.
+    if let Some(sink) = &state.metadata_sink {
+        sink.observe(&tenant, tenant.hash(), metadata);
+    }
     let exemplars: Vec<IngestExemplar> = result
         .exemplars
         .into_iter()
@@ -316,7 +331,39 @@ mod tests {
             )),
             recovery: None,
             provisioning: None,
+            metadata_sink: None,
         }
+    }
+
+    /// An ingest state whose metric metadata sink writes to the same store the
+    /// router does, plus that store and sink, so a test can drive the real
+    /// `handle_export` and then flush the window it armed.
+    fn state_with_metadata_sink() -> (IngestState, Arc<dyn ObjectStoreBackend>, Arc<MetadataSink>) {
+        let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+        let router = Arc::new(IngestRouter::new(
+            IngestConfig::default(),
+            store.clone(),
+            Signal::Metrics,
+            Arc::new(SystemClock),
+        ));
+        let sink = Arc::new(MetadataSink::new(
+            store.clone(),
+            ravel_ingest::MetadataSinkConfig::default(),
+            router.metrics_handle(),
+        ));
+        let state = IngestState {
+            router,
+            limits: IngestLimits::default(),
+            ack_deadline: Duration::from_secs(5),
+            admission: Arc::new(AdmissionController::new(
+                Arc::new(SystemClock),
+                AdmissionLimits::default(),
+            )),
+            recovery: None,
+            provisioning: None,
+            metadata_sink: Some(sink.clone()),
+        };
+        (state, store, sink)
     }
 
     fn empty_request() -> ExportMetricsServiceRequest {
@@ -428,6 +475,74 @@ mod tests {
         );
     }
 
+    /// The OTLP surface must hand every ingested family's `(type, help, unit)`
+    /// to the process metadata sink (ADR-0085 decision 1), keyed by the family
+    /// name after the Decision 2 suffix pass. Drives the real `handle_export`,
+    /// then flushes the window it armed and reads the durable record back: this
+    /// is the wiring, not the sink's own behavior (unit-tested in
+    /// `ravel-ingest`), that it proves.
+    #[tokio::test]
+    async fn handle_export_observes_metric_metadata_for_the_flush_window() {
+        use opentelemetry_proto::tonic::metrics::v1::number_data_point::Value as NumberValue;
+        use opentelemetry_proto::tonic::metrics::v1::{
+            Metric, NumberDataPoint, ResourceMetrics, ScopeMetrics, Sum, metric::Data as MetricData,
+        };
+
+        let (state, store, sink) = state_with_metadata_sink();
+        let tenant = TenantId::new("acme");
+        let request = ExportMetricsServiceRequest {
+            resource_metrics: vec![ResourceMetrics {
+                scope_metrics: vec![ScopeMetrics {
+                    metrics: vec![Metric {
+                        name: "http_request_size".to_string(),
+                        description: "size of each request".to_string(),
+                        unit: "By".to_string(),
+                        data: Some(MetricData::Sum(Sum {
+                            data_points: vec![NumberDataPoint {
+                                time_unix_nano: BASE_TS_NS as u64,
+                                value: Some(NumberValue::AsDouble(1.0)),
+                                ..Default::default()
+                            }],
+                            aggregation_temporality: 2,
+                            is_monotonic: true,
+                        })),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+        };
+
+        handle_export(
+            &state,
+            tenant.clone(),
+            WriteMode::Buffered,
+            request,
+            BASE_TS_NS,
+        )
+        .await
+        .expect("buffered write succeeds");
+
+        let summary = sink.flush_once(BASE_TS_NS).await;
+        assert_eq!(summary.tenants_flushed, 1);
+        assert_eq!(summary.gets, 1);
+        assert_eq!(summary.puts, 1);
+
+        let entries = ravel_catalog::read_metrics_meta(store.as_ref(), &tenant.hash())
+            .await
+            .expect("read metadata record")
+            .expect("record written by the flush")
+            .0;
+        assert_eq!(entries.len(), 1);
+        // Suffixed name (unit word, then `_total` for a monotonic Sum), the
+        // mapped unit word, and the OTLP description as help.
+        assert_eq!(entries[0].family_name, "http_request_size_bytes_total");
+        assert_eq!(entries[0].kind, ravel_catalog::MetricKind::Counter);
+        assert_eq!(entries[0].help, "size of each request");
+        assert_eq!(entries[0].unit, "bytes");
+    }
+
     #[tokio::test]
     async fn handle_export_reports_no_partial_success_when_nothing_rejected() {
         let state = state();
@@ -476,6 +591,7 @@ mod tests {
             )),
             recovery: Some(writer),
             provisioning: None,
+            metadata_sink: None,
         };
 
         let tenant = TenantId::new("acme");

--- a/services/ravel-server/src/lib.rs
+++ b/services/ravel-server/src/lib.rs
@@ -27,6 +27,7 @@ pub mod ingest_concurrency;
 pub mod lifecycle_refresh;
 pub mod logs_ingest;
 pub mod maintain;
+pub mod metadata_sink_task;
 pub mod metrics;
 #[cfg(feature = "otap")]
 pub mod otap_grpc;
@@ -421,6 +422,7 @@ pub struct Running {
     scrub_task: scrub::ScrubTask,
     lifecycle_refresh_task: lifecycle_refresh::LifecycleRefreshTask,
     idle_tenant_state_task: idle_tenant_state::IdleTenantStateTask,
+    metadata_sink_task: metadata_sink_task::MetadataSinkTask,
 }
 
 impl Running {
@@ -497,6 +499,9 @@ impl Running {
         self.scrub_task.shutdown().await;
         self.lifecycle_refresh_task.shutdown().await;
         self.idle_tenant_state_task.shutdown().await;
+        // Last: its final flush writes whatever the in-progress window
+        // observed, and it must not race the ingest surfaces that feed it.
+        self.metadata_sink_task.shutdown().await;
 
         Ok(())
     }
@@ -514,6 +519,7 @@ fn gateway_state(
     provisioning: &Option<Arc<provisioning::ProvisioningRecordWriter>>,
     ingest_concurrency: &Arc<ingest_concurrency::IngestConcurrencyController>,
     ingest_byte_metrics: &Arc<ingest_byte_metrics::IngestByteMetrics>,
+    metadata_sink: &Option<Arc<ravel_ingest::MetadataSink>>,
 ) -> Arc<otlp_http::GatewayState> {
     Arc::new(otlp_http::GatewayState {
         tenant_resolver,
@@ -524,6 +530,7 @@ fn gateway_state(
             admission: admission.clone(),
             recovery: recovery.clone(),
             provisioning: provisioning.clone(),
+            metadata_sink: metadata_sink.clone(),
         },
         logs_ingest: logs_ingest::LogIngestState {
             router: log_ingest_router.clone(),
@@ -549,6 +556,7 @@ fn gateway_state(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 fn remote_write_state(
     ingest_router: &Arc<IngestRouter>,
     tenant_resolver: Arc<dyn TenantResolver>,
@@ -556,6 +564,7 @@ fn remote_write_state(
     recovery: &Option<Arc<tenancy::RecoveryManifestWriter>>,
     provisioning: &Option<Arc<provisioning::ProvisioningRecordWriter>>,
     ingest_concurrency: &Arc<ingest_concurrency::IngestConcurrencyController>,
+    metadata_sink: &Option<Arc<ravel_ingest::MetadataSink>>,
 ) -> Arc<remote_write::RemoteWriteState> {
     Arc::new(remote_write::RemoteWriteState {
         tenant_resolver,
@@ -568,6 +577,7 @@ fn remote_write_state(
         provisioning: provisioning.clone(),
         ingest_concurrency: ingest_concurrency.clone(),
         clock: Arc::new(SystemClock),
+        metadata_sink: metadata_sink.clone(),
     })
 }
 
@@ -644,6 +654,24 @@ pub async fn start(
     } else {
         None
     };
+
+    // The one metric metadata sink for this process (ADR-0085 decision 1). One
+    // sink, not one per protocol, so the OTLP, OTAP, RW1, and RW2 surfaces
+    // sharing this `Arc` can never race each other on `t/<tenant_hash>/m/meta`.
+    // It counts into the metrics router's own `IngestMetrics`, so its GET/PUT/
+    // drop counters land in the snapshot an operator already scrapes, and it
+    // writes through the foreground store handle the router writes data objects
+    // through. Built only in the ingest-serving modes: a query-only process
+    // captures no metadata and spawns no flush loop. Defaults are used
+    // throughout (30 s window, 20k entries per tenant, 5 CAS retries); no CLI
+    // knob is added, so retuning it is a code change for now.
+    let metadata_sink = ingest_router.as_ref().map(|router| {
+        Arc::new(ravel_ingest::MetadataSink::new(
+            store.clone(),
+            ravel_ingest::MetadataSinkConfig::default(),
+            router.metrics_handle(),
+        ))
+    });
 
     // The log pipeline is a parallel router, not a mode of the metrics one:
     // same shard count, same store, same clock, but RLOG objects under the
@@ -864,6 +892,7 @@ pub async fn start(
             &provisioning_writer,
             &ingest_concurrency,
             &ingest_byte_metrics,
+            &metadata_sink,
         );
         http_router = http_router.merge(otlp_http::router(state));
         let rw_state = remote_write_state(
@@ -873,6 +902,7 @@ pub async fn start(
             &recovery,
             &provisioning_writer,
             &ingest_concurrency,
+            &metadata_sink,
         );
         http_router = http_router.merge(remote_write::router(rw_state));
 
@@ -888,6 +918,7 @@ pub async fn start(
                 &provisioning_writer,
                 &ingest_concurrency,
                 &ingest_byte_metrics,
+                &metadata_sink,
             );
             let mtls_rw_state = remote_write_state(
                 router,
@@ -896,6 +927,7 @@ pub async fn start(
                 &recovery,
                 &provisioning_writer,
                 &ingest_concurrency,
+                &metadata_sink,
             );
             mtls_router = mtls_router
                 .merge(otlp_http::router(mtls_state))
@@ -1371,6 +1403,7 @@ pub async fn start(
             &provisioning_writer,
             &ingest_concurrency,
             &ingest_byte_metrics,
+            &metadata_sink,
         )),
         _ => None,
     };
@@ -1774,6 +1807,12 @@ pub async fn start(
         lifecycle_refresh::spawn(durable_auth.clone(), store.clone(), limits, interval)
     };
 
+    // The metric metadata flush loop (ADR-0085 decision 1), supervised exactly
+    // like the lifecycle refresh loop above: one task per process, joined on
+    // shutdown after a final flush, and never able to fail an ingest request
+    // (every metadata failure is counted and logged inside the sink).
+    let metadata_sink_task = metadata_sink_task::spawn(metadata_sink.clone());
+
     // Idle-tenant state eviction sweep (ADR-0069 decision 2): one
     // task per process that evicts re-derivable per-tenant state idle past
     // `--idle-tenant-state-ttl`. The evictor set is built from whatever
@@ -1828,5 +1867,6 @@ pub async fn start(
         scrub_task,
         lifecycle_refresh_task,
         idle_tenant_state_task,
+        metadata_sink_task,
     })
 }

--- a/services/ravel-server/src/metadata_sink_task.rs
+++ b/services/ravel-server/src/metadata_sink_task.rs
@@ -1,0 +1,128 @@
+//! Supervision for the process's metric metadata flush loop (ADR-0085 decision
+//! 1, write side).
+//!
+//! The *mechanism* lives in `ravel-ingest` ([`ravel_ingest::MetadataSink`]): the
+//! fingerprint map, the debounce window's one-GET-and-at-most-one-CAS-PUT per
+//! tenant, the field-wise merge, the bounded CAS retry. This module owns only
+//! the process lifecycle half, exactly the way [`crate::lifecycle_refresh`] and
+//! [`crate::admission_reconcile`] split over their `ravel-ingest` mechanisms:
+//! one background task, spawned when the process serves ingest, joined on
+//! shutdown after a final flush.
+//!
+//! The sink itself is constructed once in [`crate::start`] next to the ingest
+//! router (one per process, not one per protocol, so the process never races
+//! itself on `t/<tenant_hash>/m/meta`) and shared by `Arc` with every ingest
+//! surface, which calls [`ravel_ingest::MetadataSink::observe`] on the request
+//! path. `observe` is synchronous and does no I/O, so no ingest acknowledgement
+//! ever waits on this loop.
+
+use std::sync::Arc;
+
+use ravel_ingest::MetadataSink;
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
+
+/// Handle to the spawned flush loop. Dropping it leaves the loop running;
+/// [`shutdown`](Self::shutdown) stops it and waits for its final flush.
+pub struct MetadataSinkTask {
+    shutdown: Option<oneshot::Sender<()>>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl MetadataSinkTask {
+    /// A task handle for a mode that spawned no flush loop (a query-only
+    /// process, or a disabled sink). Shutting it down is a no-op.
+    pub fn none() -> Self {
+        MetadataSinkTask {
+            shutdown: None,
+            handle: None,
+        }
+    }
+
+    /// Signal the loop to stop and wait for it to finish, including the final
+    /// flush of whatever window was in progress.
+    pub async fn shutdown(self) {
+        if let Some(tx) = self.shutdown {
+            let _ = tx.send(());
+        }
+        if let Some(handle) = self.handle {
+            let _ = handle.await;
+        }
+    }
+}
+
+/// Spawn the metadata flush loop. Returns immediately; the loop runs until
+/// [`MetadataSinkTask::shutdown`], flushing once per debounce window
+/// ([`ravel_ingest::MetadataSinkConfig::window`]) and once more on the way out.
+///
+/// Same supervision shape as [`crate::lifecycle_refresh::spawn`]: this module
+/// owns the oneshot, the loop never returns an error (every metadata failure is
+/// counted and logged inside the sink, never fatal to ingest), and a `None` sink
+/// (a process that serves no ingest) spawns nothing.
+pub fn spawn(sink: Option<Arc<MetadataSink>>) -> MetadataSinkTask {
+    let Some(sink) = sink else {
+        return MetadataSinkTask::none();
+    };
+    let (tx, rx) = oneshot::channel();
+    let window = sink.config().window;
+    let handle = tokio::spawn(async move { sink.run(rx).await });
+    tracing::debug!(
+        window_secs = window.as_secs(),
+        "metric metadata flush loop started (ADR-0085 decision 1)"
+    );
+    MetadataSinkTask {
+        shutdown: Some(tx),
+        handle: Some(handle),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+    use ravel_ingest::{IngestMetrics, MetadataSinkConfig};
+    use ravel_object_store::memory::MemoryStore;
+    use ravel_types::TenantId;
+
+    /// The spawned loop flushes what was observed before shutdown, so a graceful
+    /// stop does not discard the window in progress. Uses a short window so the
+    /// final-flush path is what the assertion depends on, not the cadence.
+    #[tokio::test]
+    async fn shutdown_joins_the_loop_after_a_final_flush() {
+        let store = Arc::new(MemoryStore::new());
+        let sink = Arc::new(MetadataSink::new(
+            store.clone(),
+            MetadataSinkConfig::default(),
+            Arc::new(IngestMetrics::default()),
+        ));
+        let tenant = TenantId::new("tenant-a");
+        sink.observe(
+            &tenant,
+            tenant.hash(),
+            [ravel_otlp::metadata::MetricMetadata {
+                family_name: "http_requests_total".to_string(),
+                kind: ravel_otlp::metadata::MetricKind::Counter,
+                help: "requests".to_string(),
+                unit: String::new(),
+            }],
+        );
+
+        let task = spawn(Some(sink));
+        task.shutdown().await;
+
+        let entries = ravel_catalog::read_metrics_meta(store.as_ref(), &tenant.hash())
+            .await
+            .expect("read metadata record")
+            .expect("record written by the final flush")
+            .0;
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].family_name, "http_requests_total");
+    }
+
+    /// No sink (a process that serves no ingest) spawns nothing and shuts down
+    /// cleanly.
+    #[tokio::test]
+    async fn no_sink_spawns_no_task() {
+        spawn(None).shutdown().await;
+    }
+}

--- a/services/ravel-server/src/metrics.rs
+++ b/services/ravel-server/src/metrics.rs
@@ -567,6 +567,25 @@ pub struct IngestPipelineSnapshot {
     /// log pipeline; `None` for metrics and spans, which build no POSTINGS
     /// section, so the postings family renders no sample for them.
     pub postings: Option<PostingsCounters>,
+    /// Metric metadata sink counters (ADR-0085 decision 1). `Some` only for
+    /// the metrics pipeline: the sink and its record are metrics-only
+    /// concepts, so logs and spans render no sample for this family, the
+    /// same structural-absence convention `collisions` and `postings` use.
+    pub metadata_sink: Option<MetadataSinkCounters>,
+}
+
+/// Metric metadata sink counters (ADR-0085 decision 1), mirroring
+/// [`ravel_ingest::IngestMetricsSnapshot`]'s four `metadata_*` fields. A
+/// separate struct rather than four more flat fields on
+/// [`IngestPipelineSnapshot`] because they are always present or always
+/// absent together (one sink, one set of counters), which `Option<Self>`
+/// says once instead of four times.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct MetadataSinkCounters {
+    pub flush_gets_total: u64,
+    pub flush_puts_total: u64,
+    pub flush_dropped_total: u64,
+    pub entries_dropped_total: u64,
 }
 
 /// The log pipeline's write-side POSTINGS counters, cumulative over flushed
@@ -601,6 +620,12 @@ impl IngestPipelineSnapshot {
             shard_deaths: snapshot.shard_deaths,
             stale_provisioning_flushes: snapshot.stale_provisioning_flushes,
             postings: None,
+            metadata_sink: Some(MetadataSinkCounters {
+                flush_gets_total: snapshot.metadata_flush_gets_total,
+                flush_puts_total: snapshot.metadata_flush_puts_total,
+                flush_dropped_total: snapshot.metadata_flush_dropped_total,
+                entries_dropped_total: snapshot.metadata_entries_dropped_total,
+            }),
         }
     }
 
@@ -627,6 +652,7 @@ impl IngestPipelineSnapshot {
                 distinct_values_total: snapshot.postings_distinct_values_total,
                 capped_fields_total: snapshot.postings_capped_fields_total,
             }),
+            metadata_sink: None,
         }
     }
 
@@ -647,6 +673,7 @@ impl IngestPipelineSnapshot {
             shard_deaths: snapshot.shard_deaths,
             stale_provisioning_flushes: snapshot.stale_provisioning_flushes,
             postings: None,
+            metadata_sink: None,
         }
     }
 }
@@ -856,6 +883,83 @@ fn render_ingest_family(out: &mut String, mode: Mode, pipelines: &[IngestPipelin
             &labels(mode, pipeline.signal),
             pipeline.stale_provisioning_flushes,
         );
+    }
+
+    // Metric metadata sink counters (ADR-0085 decision 1): only the metrics
+    // pipeline builds this record, so `metadata_sink` is `Some` only there
+    // (same structural-absence convention as `collisions` above), and the
+    // family is empty in a logs- or spans-only process.
+    let with_metadata_sink: Vec<_> = pipelines
+        .iter()
+        .filter_map(|pipeline| pipeline.metadata_sink.map(|counters| (pipeline, counters)))
+        .collect();
+    if !with_metadata_sink.is_empty() {
+        write_header(
+            out,
+            "ravel_ingest_metadata_flush_gets_total",
+            "Metric metadata record GETs issued by the flush window (ADR-0085 decision 1), by \
+             signal.",
+            "counter",
+        );
+        for (pipeline, counters) in &with_metadata_sink {
+            write_sample(
+                out,
+                "ravel_ingest_metadata_flush_gets_total",
+                &labels(mode, pipeline.signal),
+                counters.flush_gets_total,
+            );
+        }
+
+        write_header(
+            out,
+            "ravel_ingest_metadata_flush_puts_total",
+            "Metric metadata record CAS PUTs attempted by the flush window (ADR-0085 decision \
+             1), by signal. Counts attempts, so a conflicted-and-retried write counts more than \
+             once.",
+            "counter",
+        );
+        for (pipeline, counters) in &with_metadata_sink {
+            write_sample(
+                out,
+                "ravel_ingest_metadata_flush_puts_total",
+                &labels(mode, pipeline.signal),
+                counters.flush_puts_total,
+            );
+        }
+
+        write_header(
+            out,
+            "ravel_ingest_metadata_flush_dropped_total",
+            "Flush windows whose metric metadata update was dropped: CAS retries exhausted, or \
+             a read/write failure against the record (ADR-0085 decision 1), by signal. Never \
+             fatal to an ingest request.",
+            "counter",
+        );
+        for (pipeline, counters) in &with_metadata_sink {
+            write_sample(
+                out,
+                "ravel_ingest_metadata_flush_dropped_total",
+                &labels(mode, pipeline.signal),
+                counters.flush_dropped_total,
+            );
+        }
+
+        write_header(
+            out,
+            "ravel_ingest_metadata_entries_dropped_total",
+            "Metric family names not stored in a tenant's metadata record because it was \
+             already at the per-tenant entry cap (ADR-0085 decision 1), by signal. The points \
+             themselves are still ingested and queryable.",
+            "counter",
+        );
+        for (pipeline, counters) in &with_metadata_sink {
+            write_sample(
+                out,
+                "ravel_ingest_metadata_entries_dropped_total",
+                &labels(mode, pipeline.signal),
+                counters.entries_dropped_total,
+            );
+        }
     }
 }
 
@@ -3489,6 +3593,74 @@ mod tests {
                 "+Inf bucket must equal _count for series {series}"
             );
         }
+    }
+
+    /// The four metric metadata sink counters (ADR-0085 decision 1) render
+    /// for the metrics pipeline, carrying the driven values, and render
+    /// nothing for logs/spans pipelines -- `metadata_sink` is a
+    /// metrics-only concept, the same structural-absence convention
+    /// `collisions` and `postings` use, checked here so a future edit
+    /// cannot silently stop exporting them the way this family started out
+    /// (ADR-0085's own doc comments claimed "Exported as ..." for a build
+    /// that rendered nothing).
+    #[test]
+    fn metadata_sink_counters_render_for_metrics_only() {
+        let ingest = vec![
+            IngestPipelineSnapshot::from_metrics(IngestMetricsSnapshot {
+                metadata_flush_gets_total: 7,
+                metadata_flush_puts_total: 3,
+                metadata_flush_dropped_total: 1,
+                metadata_entries_dropped_total: 42,
+                ..Default::default()
+            }),
+            IngestPipelineSnapshot::from_log_metrics(LogIngestMetricsSnapshot::default()),
+            IngestPipelineSnapshot::from_span_metrics(SpanIngestMetricsSnapshot::default()),
+        ];
+        let body = render(
+            Mode::Gateway,
+            &StoreMetricsSnapshot::default(),
+            &ingest,
+            &CatalogCountersSnapshot::default(),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            &AdmissionCountersSnapshot::default(),
+            &[],
+            0,
+            IngestBufferBudgetSnapshot::default(),
+            None,
+            None,
+            &[],
+        );
+
+        assert!(body.contains(
+            "ravel_ingest_metadata_flush_gets_total{mode=\"gateway\",signal=\"metrics\"} 7"
+        ));
+        assert!(body.contains(
+            "ravel_ingest_metadata_flush_puts_total{mode=\"gateway\",signal=\"metrics\"} 3"
+        ));
+        assert!(body.contains(
+            "ravel_ingest_metadata_flush_dropped_total{mode=\"gateway\",signal=\"metrics\"} 1"
+        ));
+        assert!(body.contains(
+            "ravel_ingest_metadata_entries_dropped_total{mode=\"gateway\",signal=\"metrics\"} 42"
+        ));
+        assert!(
+            !body.contains(
+                "ravel_ingest_metadata_flush_gets_total{mode=\"gateway\",signal=\"logs\""
+            ),
+            "logs pipeline must render no metadata_sink sample"
+        );
+        assert!(
+            !body.contains(
+                "ravel_ingest_metadata_flush_gets_total{mode=\"gateway\",signal=\"spans\""
+            ),
+            "spans pipeline must render no metadata_sink sample"
+        );
     }
 
     #[test]

--- a/services/ravel-server/src/otap_grpc.rs
+++ b/services/ravel-server/src/otap_grpc.rs
@@ -25,11 +25,11 @@ use std::sync::Arc;
 
 use futures::Stream;
 use ravel_ingest::{IngestPoint, WriteMode, plausible_ingest_clock};
-use ravel_otap::normalize::normalize_decoded;
+use ravel_otap::normalize::normalize_decoded_with_metadata;
 use ravel_otap::proto::experimental::arrow::v1::arrow_metrics_service_server::ArrowMetricsService;
 use ravel_otap::proto::experimental::arrow::v1::{BatchArrowRecords, BatchStatus, StatusCode};
 use ravel_otap::stream::{DecodeError, DecodedBatch, StreamConfig, StreamState};
-use ravel_types::{CommitToken, SeriesId, Signal, TenantId};
+use ravel_types::{CommitToken, ExemplarCap, SeriesId, Signal, TenantId};
 use tonic::{Request, Response, Status, Streaming};
 
 use crate::ingest::{IngestRequestError, IngestState};
@@ -335,7 +335,28 @@ async fn write_batch(
     .await
     .map_err(|e| IngestRequestError::Provisioning(e.to_string()))?;
 
-    let normalized = normalize_decoded(tenant, decoded, &ingest.limits, ingest_ts_ns);
+    // OTAP mirrors OTLP's normalize point-for-point, metadata included: the same
+    // `(family, type, help, unit)` tuple, from the METRICS table's
+    // `metric_type`/`description`/`unit` columns (ADR-0085 decision 1). The
+    // exemplar-carrying inner call is unchanged, so this stays the
+    // `normalize_decoded` wrapper's behavior plus the metadata.
+    //
+    // The request-scoped `ExemplarCap` and the discarded `result.exemplars` are
+    // what the `normalize_decoded` wrapper this call site used to call built
+    // internally: nothing on this path stores exemplars (it writes through
+    // `write_values`, not `write_values_with_exemplars`), and the wrapper's
+    // drop-count rejection went into a `rejected` vector this function does not
+    // read either. So points, series, and the ack are byte-for-byte what they
+    // were; the metadata tuple is the only addition.
+    let mut cap = ExemplarCap::new(ingest.limits.exemplar_cap_window_ns);
+    let (result, metadata) =
+        normalize_decoded_with_metadata(tenant, decoded, &ingest.limits, ingest_ts_ns, &mut cap);
+    let normalized = result.output;
+    // Synchronous, no I/O, off the acknowledgement path: see the twin call in
+    // `crate::ingest::handle_export`.
+    if let Some(sink) = &ingest.metadata_sink {
+        sink.observe(tenant, tenant.hash(), metadata);
+    }
     let mut points: Vec<IngestPoint> =
         Vec::with_capacity(normalized.points.len() + normalized.histogram_points.len());
     points.extend(normalized.points.into_iter().map(IngestPoint::from));
@@ -449,6 +470,7 @@ mod tests {
             )),
             recovery: None,
             provisioning: None,
+            metadata_sink: None,
         }
     }
 

--- a/services/ravel-server/src/otlp_http.rs
+++ b/services/ravel-server/src/otlp_http.rs
@@ -732,6 +732,7 @@ mod tests {
                 admission: admission.clone(),
                 recovery: None,
                 provisioning: None,
+                metadata_sink: None,
             },
             logs_ingest: crate::logs_ingest::LogIngestState {
                 router: log_router,

--- a/services/ravel-server/src/remote_write.rs
+++ b/services/ravel-server/src/remote_write.rs
@@ -145,6 +145,11 @@ pub struct RemoteWriteState {
     /// `SystemTime::now()`; tests supply a fixed sub-floor clock to exercise
     /// the receiver-clock plausibility floor deterministically.
     pub clock: Arc<dyn Clock>,
+    /// The one-per-process metric metadata sink (ADR-0085 decision 1), the same
+    /// `Arc` the OTLP and OTAP surfaces hold. RW1 and RW2 both decode
+    /// `(family, type, help, unit)` already; this is where the decoded tuples
+    /// stop being discarded. `None` captures nothing.
+    pub metadata_sink: Option<Arc<ravel_ingest::MetadataSink>>,
 }
 
 pub fn router(state: Arc<RemoteWriteState>) -> Router {
@@ -354,6 +359,17 @@ async fn remote_write(
             return (StatusCode::BAD_REQUEST, message).into_response();
         }
     };
+
+    // Metric metadata (ADR-0085 decision 1), captured before `resolved` is
+    // consumed by normalization. Cloned rather than moved out: the decoded
+    // metadata is part of the request `normalize_resolved` accounts for
+    // (`metadata_dropped` below), so taking it would change what this surface
+    // reports. `observe` is synchronous, does no I/O, and cannot fail, so the
+    // 2xx this handler eventually returns depends only on the data write.
+    let metadata = resolved.metadata.clone();
+    if let Some(sink) = &state.metadata_sink {
+        sink.observe(&tenant, tenant.hash(), metadata);
+    }
 
     // Strict mode only: a Remote Write 2xx must mean durable, so the
     // buffered-mode header override is never consulted on this surface.
@@ -565,6 +581,7 @@ mod tests {
                 IngestConcurrencyLimit::Unlimited,
             ),
             clock,
+            metadata_sink: None,
         })
     }
 

--- a/services/ravel-server/tests/admission_reconcile_e2e.rs
+++ b/services/ravel-server/tests/admission_reconcile_e2e.rs
@@ -150,6 +150,7 @@ fn build_process(store: Arc<dyn ObjectStoreBackend>) -> (Arc<AdmissionController
         admission: admission.clone(),
         recovery: None,
         provisioning: None,
+        metadata_sink: None,
     };
     (admission, state)
 }


### PR DESCRIPTION
feat(ingest): add metric metadata sink and wire it from every ingest surface (ADR-0085)

Adds the one-per-process metric metadata sink ADR-0085 Decision 1
describes: observe() runs on the ingest request path, synchronous
and off the acknowledgement path, tracking new-or-changed
(family_name, type, help, unit) tuples per tenant. flush_once() does
exactly one GET and at most one CAS PUT per tenant per debounce
window, merging through the catalog's field-wise merge_entries.
Wired into services/ravel-server from all three ingest surfaces
(OTLP, OTAP, RW1/RW2), with a supervised background flush loop next
to lifecycle_refresh.

Includes a fix from the wave's checkpoint review: the sink's local
maps are now bounded (a per-tenant entry cap and a max-tracked-tenant
LRU) so a client cannot grow this process's memory without bound by
minting distinct metric names or tenants, and the sink's four
counters are wired into the Prometheus text exporter, which
previously claimed to export them but did not.

No production caller reads this record yet by design; the
ravel-query read path (#236) and the end-to-end reachability test
(#237) land next.

Fixes: #235
Refs: #119
