### PR TITLE
ci(publish): split debug symbols and build the workspace once per platform

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -120,17 +120,26 @@ jobs:
           echo "::error::timed out after $((max_attempts * interval))s waiting for a successful ci.yml run for $SHA (decision 9, fail closed)"
           exit 1
 
-  # ADR-0037 multi-arch amendment, decisions 12-15 and 17. Each (target,
-  # platform) pair builds on its own NATIVE runner and pushes by digest with no
-  # tag. Decision 12: QEMU-emulated rustc SIGSEGVs on this workspace, so
+  # ADR-0037 multi-arch amendment, decisions 12-15 and 17, as amended by
+  # ADR-0086 decision 9. The matrix is now ONE dimension, platform: each
+  # platform job builds on its own NATIVE runner and runs the three target
+  # builds sequentially on that runner, pushing each by digest with no tag.
+  # Decision 12: QEMU-emulated rustc SIGSEGVs on this workspace, so
   # cross-building the arm64 half on an amd64 runner would reintroduce the exact
   # failure this whole ADR routes around. A native runner per platform is a
   # correctness requirement, not a speed preference; there is deliberately no
   # QEMU setup step and no multi-platform `platforms:` list that would make one
   # runner build both.
+  #
+  # ADR-0086 decision 9: the three per-target builds share one builder stage,
+  # so the second and third invocations hit the first's LOCAL layer cache and
+  # the workspace compiles once per platform instead of three times. That local
+  # reuse is the whole point of collapsing the matrix, and it is why the target
+  # builds run sequentially in one job rather than in three parallel jobs that
+  # could never share a layer cache.
   build:
     needs: gate
-    timeout-minutes: 60
+    timeout-minutes: 90
     # Decision 17: a build job no longer signs anything, so it holds
     # packages: write to push by digest and DROPS id-token entirely. A build
     # job carrying a signing-capable token is exactly the least-privilege drift
@@ -142,7 +151,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [server, operator, ingest-router]
         platform: [linux/amd64, linux/arm64]
         # Decision 12: pair each platform with its native runner label so
         # runs-on resolves from the matrix. The label carries its Ubuntu
@@ -181,55 +189,146 @@ jobs:
 
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
-      # No cache-from/cache-to: type=gha. The builder stage's single
-      # COPY-then-build layer changes on every commit (ADR-0037 decision 4),
-      # so a GHA cache export here could never hit and would only spend the
-      # 10 GB per-repo budget shared with sccache/rust-cache in ci.yml.
+      # The three target builds below share the builder stage. No
+      # cache-from/cache-to: type=gha on any of them: the builder stage's single
+      # COPY-then-build layer changes on every commit (ADR-0037 decision 4), so
+      # a GHA cache export could never hit and would only spend the 10 GB
+      # per-repo budget shared with sccache/rust-cache in ci.yml. The reuse that
+      # matters here is buildx's LOCAL layer cache on this one runner: the
+      # server build compiles the workspace, and the operator and ingest-router
+      # builds that follow reuse that builder layer instead of recompiling.
       #
       # Decision 13: push by digest and NO tag. `push-by-digest=true` publishes
       # the single-platform manifest under its content digest with no tag ref;
       # the tags decision 3 defines are applied later, by the merge job, onto
       # the assembled manifest list. `name` is the target's canonical image
       # reference so the digest is pushed into the right repository.
-      - name: Build and push by digest
-        id: build
+      #
+      # Decision 15: SBOM and max-mode provenance stay on each PLATFORM build
+      # (not the merge). They attach per platform here and the merge's
+      # imagetools create carries the attestation manifests into the assembled
+      # index.
+      - name: Build and push ravel-server by digest
+        id: build-server
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
-          target: ${{ matrix.target }}
+          target: server
           platforms: ${{ matrix.platform }}
-          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/ravel-${{ matrix.target }},push-by-digest=true,name-canonical=true,push=true
-          # Decision 15: SBOM and max-mode provenance stay on each PLATFORM
-          # build (not the merge). They attach per platform here and the merge's
-          # imagetools create carries the attestation manifests into the
-          # assembled index.
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/ravel-server,push-by-digest=true,name-canonical=true,push=true
           sbom: true
           provenance: mode=max
 
-      # Decision 13: the per-platform digest reaches the merge job as an
+      - name: Build and push ravel-operator by digest
+        id: build-operator
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: .
+          target: operator
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/ravel-operator,push-by-digest=true,name-canonical=true,push=true
+          sbom: true
+          provenance: mode=max
+
+      - name: Build and push ravel-ingest-router by digest
+        id: build-ingest-router
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: .
+          target: ingest-router
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/ravel-ingest-router,push-by-digest=true,name-canonical=true,push=true
+          sbom: true
+          provenance: mode=max
+
+      # Decision 13: each per-platform digest reaches the merge job as an
       # uploaded artifact, NOT as a job output. A matrix's job outputs collapse
-      # to a single last-writer-wins value, so a two-platform matrix routed
-      # through outputs would silently publish an index containing whichever
-      # build finished last. The digest travels as the artifact's filename (an
-      # empty marker file named by the digest's hex), so the merge job can
-      # reconstruct `<image>@sha256:<digest>` for each platform.
-      - name: Export digest
+      # to a single last-writer-wins value, so routing them through outputs
+      # would silently publish an index containing whichever build finished
+      # last. The digest travels as the artifact's filename (an empty marker
+      # file named by the digest's hex), one per-target directory so the three
+      # globs below never collide, so the merge job can reconstruct
+      # `<image>@sha256:<digest>` for each platform.
+      - name: Export digests
+        env:
+          SERVER_DIGEST: ${{ steps.build-server.outputs.digest }}
+          OPERATOR_DIGEST: ${{ steps.build-operator.outputs.digest }}
+          INGEST_ROUTER_DIGEST: ${{ steps.build-ingest-router.outputs.digest }}
         run: |
           set -euo pipefail
-          mkdir -p "${{ runner.temp }}/digests"
-          digest="${{ steps.build.outputs.digest }}"
-          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+          for pair in "server:$SERVER_DIGEST" "operator:$OPERATOR_DIGEST" \
+                      "ingest-router:$INGEST_ROUTER_DIGEST"; do
+            target="${pair%%:*}"
+            digest="${pair#*:}"
+            mkdir -p "${{ runner.temp }}/digests/$target"
+            touch "${{ runner.temp }}/digests/$target/${digest#sha256:}"
+          done
 
       # Decision 14: the artifact name is scoped per target AND per platform
-      # (digest-server-linux-amd64). upload-artifact v4 rejects a duplicate
+      # (digest-server-linux-amd64), byte-identical to what the per-target merge
+      # jobs' `pattern: digest-<target>-*` expects, so collapsing the build
+      # matrix needs no change there. upload-artifact v4 rejects a duplicate
       # name, so a cross-target or cross-platform mix-up fails the run instead
       # of silently overwriting a digest and yielding a wrong index that still
       # passes the digest-equality check downstream.
-      - name: Upload digest
+      - name: Upload ravel-server digest
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: digest-${{ matrix.target }}-${{ env.PLATFORM_PAIR }}
-          path: ${{ runner.temp }}/digests/*
+          name: digest-server-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/server/*
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Upload ravel-operator digest
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: digest-operator-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/operator/*
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Upload ravel-ingest-router digest
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: digest-ingest-router-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/ingest-router/*
+          if-no-files-found: error
+          retention-days: 1
+
+      # ADR-0086 decision 3: export the non-runtime debug-symbols stage and
+      # upload the separated .debug files for task #248's release job to attach
+      # next to the stripped binaries. This build reuses the same builder layer
+      # the three image builds already compiled on this runner, so it recompiles
+      # nothing; type=local writes the stage's files to a directory.
+      #
+      # One builder stage produces all four binaries, so the debug-symbols stage
+      # carries all four .debug files and there is exactly ONE export per
+      # platform, not one per target. The artifact name is therefore
+      # debug-symbols-<platform> (per-platform-unique, so upload-artifact v4's
+      # duplicate-name guard still fails a cross-platform mix-up); a per-target
+      # name cannot fit a single export that holds four files across three
+      # targets (server alone carries ravel-server.debug and ravel-cli.debug).
+      - name: Export debug symbols
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: .
+          target: debug-symbols
+          platforms: ${{ matrix.platform }}
+          outputs: type=local,dest=${{ runner.temp }}/debug
+          # Explicit, not inherited. BuildKit rejects attestations on the local
+          # exporter, so if the action ever attached its defaults here the step
+          # would hard-fail, and a failed build job skips every merge job and
+          # blocks the whole release. The action is believed to disable them for
+          # non-image exporters already; stating it costs two lines and removes
+          # the dependency on that behaviour.
+          provenance: false
+          sbom: false
+
+      - name: Upload debug symbols
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: debug-symbols-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/debug/*.debug
           if-no-files-found: error
           retention-days: 1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,24 @@ RUN cargo build --release --locked -p ravel-server --features sql \
     && cargo build --release --locked -p ravel-operator \
     && cargo build --release --locked -p ravel-ingest-router
 
+# Split debug info out of each binary (ADR-0086 decision 3). The four cargo
+# invocations above stay four and stay separate: this workspace is
+# resolver = "3", so collapsing them into one -p ... -p ... --features
+# ravel-server/sql would unify the DataFusion feature tree into the other three
+# binaries and silently change what ships. [profile.release] debug = 1 also
+# stays (ADR-0036 depends on it for line-level profiling); rather than dropping
+# symbols to shrink the artifact, we separate them here and strip the shipped
+# copy. Order matters: extract the .debug copy FIRST, then strip and link, or
+# --add-gnu-debuglink would point at contents already discarded.
+# --add-gnu-debuglink is required, not decoration: it lets gdb resolve symbols
+# from a downloaded .debug file by name, with no manual symbol-file step.
+RUN set -eux; \
+    cd target/release; \
+    for bin in ravel-server ravel-cli ravel-operator ravel-ingest-router; do \
+        objcopy --only-keep-debug "$bin" "$bin.debug"; \
+        objcopy --strip-debug --add-gnu-debuglink="$bin.debug" "$bin"; \
+    done
+
 # ---- Runtime: server image --------------------------------------------------
 # distroless/cc: glibc (no untested musl), ships ca-certificates for
 # object_store's TLS path against real AWS S3, and carries no shell or package
@@ -103,3 +121,17 @@ COPY --from=builder /app/target/release/ravel-ingest-router /usr/local/bin/ravel
 # to gateway pods; every listen address and flag is supplied by the operator
 # from the CRD, so no default CMD is baked in.
 ENTRYPOINT ["/usr/local/bin/ravel-ingest-router"]
+
+# ---- Debug symbols (non-runtime) --------------------------------------------
+# ADR-0086 decision 3. A scratch stage carrying ONLY the four separated .debug
+# files produced by the objcopy step in the builder, nothing runnable. The
+# publish workflow exports this stage with `--output type=local` and uploads
+# the result as workflow artifacts; task #248's release job attaches them next
+# to the stripped binaries so downloaded symbols resolve by name. This is never
+# a runtime target and no image is published from it.
+FROM scratch AS debug-symbols
+
+COPY --from=builder /app/target/release/ravel-server.debug /
+COPY --from=builder /app/target/release/ravel-cli.debug /
+COPY --from=builder /app/target/release/ravel-operator.debug /
+COPY --from=builder /app/target/release/ravel-ingest-router.debug /

--- a/docs/adrs/0086-github-releases-and-release-hygiene.md
+++ b/docs/adrs/0086-github-releases-and-release-hygiene.md
@@ -24,8 +24,15 @@ Facts this ADR is built on, measured against the live registry and current
   profiling"*. Removing it would silently revoke that ADR's premise.
 - The cost of that setting on the shipped artifact is large and unmeasured
   until now. Extracted from `ghcr.io/nofireai/ravel-server:0.9.3` (arm64):
-  `ravel-server` is **659 MB**; stripped it is **81.5 MB**; stripped and
-  gzipped, **30.7 MB**. The published image is **923 MB**.
+  `ravel-server` is **659 MB**, and the published image is **923 MB**. A full
+  `strip` takes the binary to 81.5 MB, and 30.7 MB gzipped.
+
+  What this ADR actually does is `--strip-debug`, not a full `strip`, which
+  keeps `.symtab`. Measured on a real build of the resulting Dockerfile:
+  `ravel-server` is **107 MB** and the server image is **208 MB**. The extra
+  25 MB over a full strip is the symbol table, and it is deliberate: a
+  backtrace from a deployed binary still resolves function names with no
+  `.debug` file present at all, and the separated file adds line numbers on top.
 - The Dockerfile has three runtime targets (`server`, `operator`,
   `ingest-router`) and a single builder stage that produces all four binaries;
   every runtime target already copies from that one stage. The six full
@@ -138,9 +145,28 @@ images receive the stripped binaries, which carry a `.gnu_debuglink` section. A
 dedicated non-runtime stage (`FROM scratch AS debug-symbols`) receives the
 `.debug` files; each per-platform build job exports that stage with
 `--output type=local` and uploads the result as a workflow artifact named
-`debug-<target>-<platform>`, following the same per-target-and-per-platform
-naming rule ADR-0037 decision 14 requires of the digest artifacts. The release
-job downloads those and uploads each as `<name>-<os>-<arch>.debug`.
+`debug-symbols-<platform>`.
+
+Two details of that naming were wrong in this ADR's first draft and are
+corrected here, because each would have shipped something that looks right and
+is useless:
+
+- The artifact is scoped **per platform, not per target**. One builder stage
+  produces all four binaries, so there is exactly one export per platform
+  carrying all four `.debug` files, and the `server` target alone owns two of
+  them (`ravel-server.debug` and `ravel-cli.debug`). A per-target name cannot
+  describe that. Nothing is lost: the per-target scoping ADR-0037 decision 14
+  requires exists so a `server` merge can never ingest an `operator` digest,
+  and debug symbols never reach the merge job. Per-platform naming still gives
+  `upload-artifact` v4's duplicate-name guard its cross-platform protection.
+- The release job publishes **one archive per platform**
+  (`ravel-debug-symbols-<os>-<arch>.tar.gz`), not individually renamed `.debug`
+  files. `--add-gnu-debuglink` records a *basename*: the binary points at
+  `ravel-server.debug`, so an asset renamed to `ravel-server-linux-amd64.debug`
+  would never auto-resolve, and the "no manual `symbol-file` step" property
+  this decision exists to provide would be silently gone while every step still
+  exited 0. Archiving preserves the basename through extraction, and keeps one
+  asset per platform, matching the single-export reality above.
 
 Doing the split here rather than in the release job is forced by two things,
 either of which alone would decide it:
@@ -181,9 +207,9 @@ for 81.5 MB of actual code is a hostile default. Stripping without publishing
 symbols was also rejected: it would revoke exactly what ADR-0036 set the
 profile flag to buy.
 
-This decision is also what shrinks the published images, from 923 MB toward the
-size their stripped contents occupy. That is a direct consequence of the same
-`objcopy` step, not a separate change.
+This decision is also what shrinks the published images: measured on a real
+build, the server image goes from 923 MB to 208 MB. That is a direct
+consequence of the same `objcopy` step, not a separate change.
 
 ## Decision 4: assets carry checksums, and the checksum file is signed
 


### PR DESCRIPTION
ADR-0086 decisions 3 (builder half) and 9.

The builder now separates debug info before anything is copied into a runtime
image: objcopy --only-keep-debug, then objcopy --strip-debug with
--add-gnu-debuglink. The order matters, since linking first would point at
contents already discarded. A scratch debug-symbols stage carries the four
.debug files out for the release job in #248 to attach.

[profile.release] debug = 1 is unchanged. ADR-0036 depends on it for
line-level profiling, so the flag stays and the shipped copy is stripped
instead. --strip-debug rather than a full strip keeps .symtab, so a backtrace
from a deployed binary still resolves function names with no .debug file at
all, and the separated file adds line numbers on top.

Measured on a real build of this Dockerfile, not predicted: the server image
drops from 923 MB to 208 MB, and ravel-server from 659 MB to 107 MB. The
stripped binary carries a .gnu_debuglink section naming ravel-server.debug,
carries no .debug_info, keeps .symtab, and runs.

The six full workspace compiles per release were never coming from the
Dockerfile: the builder is one stage producing all four binaries and all three
runtime targets already copy from it. They came from this workflow's
target x platform matrix, six jobs on six runners with type=gha caching
deliberately off, so no job could reuse another's builder layer. The matrix
collapses to platform only, and the three target builds run sequentially on one
runner where they share that runner's local layer cache. Two compiles per
release instead of six.

The builder's four cargo invocations stay four. Collapsing them would unify
shared-dependency features across the selection under resolver = "3", pulling
the DataFusion feature tree into the other three binaries and silently changing
what ships, to save nothing the shared target directory does not already save.

Everything downstream is untouched: digest artifacts keep the exact
digest-<target>-<platform> names the per-target merge jobs filter on, now
written to per-target subdirectories so the globs cannot collide; SBOM and
max-mode provenance stay on every image build; build jobs still hold no
id-token. The debug export sets provenance and sbom to false explicitly,
because BuildKit rejects attestations on the local exporter and a failure there
would skip every merge job and block the release.

The debug artifact is debug-symbols-<platform>, not the
debug-<target>-<platform> the ADR first specified. One builder stage produces
all four binaries, so there is one export per platform and the server target
alone owns two of the four files. ADR-0086 decision 3 is corrected here, along
with its release-asset shape: symbols ship as one tar.gz per platform, because
--add-gnu-debuglink records a basename and a renamed per-arch .debug file would
never auto-resolve.

Fixes: #247
Refs: #243
