### PR TITLE
feat(server): wire the metric metadata read path and prove ADR-0085 end to end

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ delete the entire stateful tier. Ravel's job is to make that a good trade.
 Also live:
 
 - A Prometheus-compatible HTTP API, so existing Grafana dashboards work.
+  `/api/v1/metadata` returns real per-metric type, help, and unit for metrics
+  ingested after ADR-0085, and OTLP metric names get the standard
+  Prometheus-style unit and `_total` suffixes at ingest (a monotonic `foo` with
+  `unit: "By"` lands as `foo_bytes_total`), so the same metric matches whether
+  it arrives over OTLP or through a collector's Prometheus exporter.
 - Exemplars that link a metric sample to its trace.
 - Alerting that stores every rule transition as immutable, queryable data.
 - An analytics endpoint for change point detection and summary statistics.

--- a/docs/guides/ingest.md
+++ b/docs/guides/ingest.md
@@ -191,6 +191,27 @@ Two behaviors are worth knowing about, both intentional:
   one named `_foo` both sanitize to `_foo` and become the same series. This
   is a documented consequence of the sanitization rule, not a bug.
 
+## Metric metadata and OTLP name suffixing
+
+Ravel captures each metric's type, help, and unit at ingest time and serves it
+back through [`GET /api/v1/metadata`](query.md#get-apiv1statusbuildinfo-and-get-apiv1metadata).
+Every path supplies it: OTLP reads `Metric.description` (help) and `Metric.unit`
+alongside the name and infers the type from the data shape; Remote Write v1 and
+v2 stop discarding the `MetricMetadata`/per-series metadata they already parse.
+Capture is best-effort and off the acknowledgement path, so a point is acked on
+its data write and never waits on or fails from the metadata record.
+
+OTLP metric names also get the standard OpenTelemetry-to-Prometheus suffixes a
+Prometheus exporter would add, so the same metric ingested over OTLP or scraped
+through a collector lands under one series name. The unit is mapped and appended
+(`s` becomes `_seconds`, `By` becomes `_bytes`), then a monotonic `Sum` gets
+`_total`: a monotonic counter named `foo` with `unit: "By"` ingests as
+`foo_bytes_total`. This is an ingest-time transform on the name string only; it
+does not touch series identity or any stored format. It is a one-time,
+intentional naming change for dashboards built directly against pre-ADR-0085
+OTLP names. See [ADR-0085](../adrs/0085-metric-metadata-and-otlp-suffixing.md)
+for the full unit table and the metadata record format.
+
 ## Job and instance labels
 
 If the resource has `service.name`, its points get a `job` label. The value is

--- a/docs/guides/query.md
+++ b/docs/guides/query.md
@@ -132,9 +132,18 @@ save. They take no parameters.
 `version` is Ravel's own version, not a Prometheus one. `revision` is the
 build's git SHA when the build exported `RAVEL_GIT_SHA`, empty otherwise.
 
-`/api/v1/metadata` always returns `{"status": "success", "data": {}}`: Ravel
-captures no OTLP metric type, help, or unit metadata today, so there is
-nothing truthful to report.
+`/api/v1/metadata` returns real per-metric type, help, and unit for any metric
+ingested after ADR-0085 shipped, in Prometheus' documented shape (`data` maps
+each family name to a length-1 array of `{type, help, unit}`). It resolves the
+requesting tenant from the same bearer credential the other query routes use and
+serves that tenant's metadata from a per-process, per-tenant cache (one object
+read per tenant per refresh horizon, never a read per request). The optional
+`metric` and `limit` query parameters filter to one family and cap the number of
+names, matching Prometheus. Metadata is best-effort: a metric ingested before
+ADR-0085, or over a path that sent no type/help/unit, has no entry, and a request
+that carries no resolvable tenant still gets `{"status": "success", "data": {}}`
+(this endpoint never returns `401`). See [ADR-0085](../adrs/0085-metric-metadata-and-otlp-suffixing.md)
+for the record format and the OTLP name suffixing that decides the family names.
 
 ## PromQL support
 

--- a/services/ravel-server/src/erasure_e2e.rs
+++ b/services/ravel-server/src/erasure_e2e.rs
@@ -385,6 +385,7 @@ fn build_metrics_app(
         ),
         None,
         None,
+        None,
     );
     ravel_query::http::router(state)
 }

--- a/services/ravel-server/src/lib.rs
+++ b/services/ravel-server/src/lib.rs
@@ -410,6 +410,14 @@ pub struct Running {
     fragment_shutdown: Option<oneshot::Sender<()>>,
     fragment_task: Option<JoinHandle<anyhow::Result<()>>>,
     ingest_router: Option<Arc<IngestRouter>>,
+    /// The process's one metric metadata sink (ADR-0085 decision 1), `Some`
+    /// exactly in the ingest-serving modes that built it. Public by design as a
+    /// test seam: an end-to-end test drives the durable flush deterministically
+    /// with `metadata_sink.flush_once(now_ns)` rather than waiting on the real
+    /// debounce window, following the repo's time-injection testing pattern.
+    /// The supervised background flush loop still owns the production cadence
+    /// (`metadata_sink_task`); this handle shares the same `Arc`.
+    pub metadata_sink: Option<Arc<ravel_ingest::MetadataSink>>,
     log_ingest_router: Option<Arc<LogIngestRouter>>,
     span_ingest_router: Option<Arc<SpanIngestRouter>>,
     fold_tasks: fold::FoldTasks,
@@ -672,6 +680,28 @@ pub async fn start(
             router.metrics_handle(),
         ))
     });
+
+    // The read side of the same record (ADR-0085 decision 1 read path): one
+    // per-process, per-tenant, on-demand cache over `t/<tenant_hash>/m/meta`,
+    // reading through the same `store` handle. Unlike `metadata_sink` (an
+    // ingest-only concern) this is a query-side concern, so it is built in
+    // exactly the modes that mount the Prometheus-shaped query routes below
+    // (`Mode::All`/`Mode::Query`) and threaded into `build_app_state`; a
+    // gateway- or maintain-only process serves no `/api/v1/metadata` and builds
+    // none. Defaults throughout (60 s refresh horizon, 256 tenants, LRU); no CLI
+    // knob is added. `SystemClock` here matches the injected-clock rule the
+    // cache follows for its horizon and idle-eviction decisions.
+    let metadata_cache = if matches!(config.mode, Mode::All | Mode::Query) {
+        Some(Arc::new(ravel_query::http::MetadataCache::new(
+            store.clone(),
+            ravel_query::http::MetadataCacheConfig::default(),
+            // The cache's horizon/idle clock is `ravel_cache::Clock`, not the
+            // ingest `Clock` this file's `SystemClock` implements.
+            Arc::new(ravel_cache::SystemClock),
+        )))
+    } else {
+        None
+    };
 
     // The log pipeline is a parallel router, not a mode of the metrics one:
     // same shard count, same store, same clock, but RLOG objects under the
@@ -1168,6 +1198,7 @@ pub async fn start(
             query_admission.clone(),
             distributed.clone(),
             federation,
+            metadata_cache.clone(),
         );
         // Bound without an initializer and assigned exactly once inside the
         // block below, which always runs under this feature: a `None` default
@@ -1277,10 +1308,16 @@ pub async fn start(
         )?;
 
         if let Some(mtls) = &config.mtls_listener {
-            let mtls_app_state =
+            let mut mtls_app_state =
                 ravel_query::http::AppState::new(app_state.engine.clone(), mtls.resolver.clone())
                     .with_cost_recorder(query_accounting.clone())
                     .with_query_admission(query_admission.clone());
+            // Same read-side metadata cache the primary listener serves from
+            // (ADR-0085 decision 1): the mTLS `/api/v1/metadata` must serve the
+            // same per-tenant record, not fall back to the empty object.
+            if let Some(cache) = &metadata_cache {
+                mtls_app_state = mtls_app_state.with_metadata_cache(cache.clone());
+            }
             mtls_router = mtls_router.merge(ravel_query::http::router(mtls_app_state));
         }
         http_router = http_router.merge(ravel_query::http::router(app_state));
@@ -1855,6 +1892,7 @@ pub async fn start(
         fragment_shutdown,
         fragment_task,
         ingest_router,
+        metadata_sink,
         log_ingest_router,
         span_ingest_router,
         fold_tasks,

--- a/services/ravel-server/src/query.rs
+++ b/services/ravel-server/src/query.rs
@@ -136,6 +136,7 @@ pub fn build_app_state(
     query_admission: Arc<QueryAdmissionController>,
     distributed: Option<Arc<ravel_query::distrib::Distributed>>,
     federation: Option<Arc<ravel_query::distrib::Federation>>,
+    metadata_cache: Option<Arc<ravel_query::http::MetadataCache>>,
 ) -> AppState {
     let mut engine = QueryEngine::new(catalog, store, engine_config);
     if let Some(cache) = cache {
@@ -158,9 +159,17 @@ pub fn build_app_state(
     // `/metrics` covers PromQL read traffic too. The shared query
     // concurrency controller (ADR-0061 decision 2) gates every handler before
     // it resolves or fetches.
-    AppState::new(Arc::new(engine), tenant_resolver)
+    // ADR-0085 decision 1 read path: attach the per-process metric metadata
+    // cache that backs `/api/v1/metadata`. `None` in a mode that serves no
+    // Prometheus-shaped query routes; when absent the endpoint keeps its
+    // pre-ADR behavior byte-for-byte (a `200` with an empty `data` object).
+    let state = AppState::new(Arc::new(engine), tenant_resolver)
         .with_cost_recorder(query_accounting)
-        .with_query_admission(query_admission)
+        .with_query_admission(query_admission);
+    match metadata_cache {
+        Some(cache) => state.with_metadata_cache(cache),
+        None => state,
+    }
 }
 
 /// Default per-tenant SQL memory ceiling: 1 GiB across a tenant's concurrent
@@ -281,6 +290,7 @@ mod catalog_cache_tests {
                 std::collections::HashSet::new(),
             )),
             QueryAdmissionController::shared(ravel_query::QueryConcurrencyLimit::Unlimited),
+            None,
             None,
             None,
         );

--- a/services/ravel-server/tests/cache_attachment_metrics.rs
+++ b/services/ravel-server/tests/cache_attachment_metrics.rs
@@ -188,6 +188,7 @@ async fn cache_enabled_config_attaches_cache_to_the_metric_path() {
         ),
         None,
         None,
+        None,
     );
     let app: Router = router(state);
 

--- a/services/ravel-server/tests/federation_handler_warnings.rs
+++ b/services/ravel-server/tests/federation_handler_warnings.rs
@@ -178,6 +178,7 @@ async fn promql_with_federation(store: Arc<dyn ObjectStoreBackend>, tenant: &Ten
         ),
         None,
         Some(federation),
+        None,
     );
     promql_router(app_state)
 }

--- a/services/ravel-server/tests/metadata_e2e.rs
+++ b/services/ravel-server/tests/metadata_e2e.rs
@@ -1,0 +1,376 @@
+//! End-to-end coverage for ADR-0085 through the real HTTP server: OTLP and
+//! Remote-Write v1 ingest capture per-metric type/help/unit, the OTLP name gets
+//! its Prometheus-style unit and counter suffixes, and `/api/v1/metadata` serves
+//! the captured record back over the same running binary. This is the epic's
+//! closing loop: nothing here is a crate-only capability, every assertion is
+//! made against a real `MemoryStore`-backed `ravel_server::start` process.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest;
+use opentelemetry_proto::tonic::common::v1::any_value::Value as AnyValueVariant;
+use opentelemetry_proto::tonic::common::v1::{AnyValue, KeyValue};
+use opentelemetry_proto::tonic::metrics::v1::metric::Data as MetricData;
+use opentelemetry_proto::tonic::metrics::v1::number_data_point::Value as NumberValue;
+use opentelemetry_proto::tonic::metrics::v1::{
+    AggregationTemporality, Metric, NumberDataPoint, ResourceMetrics, ScopeMetrics, Sum,
+};
+use opentelemetry_proto::tonic::resource::v1::Resource;
+use prost::Message;
+use ravel_object_store::memory::MemoryStore;
+use ravel_remote_write::proto::prometheus::metric_metadata::MetricType;
+use ravel_remote_write::proto::prometheus::{
+    Label as ProtoLabelV1, MetricMetadata as ProtoMetricMetadataV1, Sample as ProtoSampleV1,
+    TimeSeries as ProtoTimeSeriesV1, WriteRequest as ProtoWriteRequestV1,
+};
+use ravel_server::{FoldTaskConfig, Mode, ServerConfig};
+use ravel_types::TenantId;
+
+const TOKEN: &str = "testtoken";
+
+fn now_ns() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before epoch")
+        .as_nanos() as i64
+}
+
+fn now_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before epoch")
+        .as_millis() as i64
+}
+
+fn string_kv(key: &str, value: &str) -> KeyValue {
+    KeyValue {
+        key: key.to_string(),
+        value: Some(AnyValue {
+            value: Some(AnyValueVariant::StringValue(value.to_string())),
+        }),
+        ..Default::default()
+    }
+}
+
+/// A monotonic cumulative `Sum` metric named `metric_name`, with `unit` and
+/// `description` set so the metadata capture and the OTLP suffix pass both have
+/// something to read. A monotonic Sum with `unit: "By"` named `foo` ingests as
+/// the family `foo_bytes_total` (ADR-0085 decision 2).
+fn export_counter_request(
+    metric_name: &str,
+    job: &str,
+    unit: &str,
+    description: &str,
+    value: f64,
+    ts_ns: i64,
+) -> ExportMetricsServiceRequest {
+    ExportMetricsServiceRequest {
+        resource_metrics: vec![ResourceMetrics {
+            resource: Some(Resource {
+                attributes: vec![string_kv("service.name", job)],
+                ..Default::default()
+            }),
+            scope_metrics: vec![ScopeMetrics {
+                metrics: vec![Metric {
+                    name: metric_name.to_string(),
+                    description: description.to_string(),
+                    unit: unit.to_string(),
+                    data: Some(MetricData::Sum(Sum {
+                        data_points: vec![NumberDataPoint {
+                            time_unix_nano: ts_ns as u64,
+                            value: Some(NumberValue::AsDouble(value)),
+                            ..Default::default()
+                        }],
+                        aggregation_temporality: AggregationTemporality::Cumulative as i32,
+                        is_monotonic: true,
+                    })),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+            ..Default::default()
+        }],
+    }
+}
+
+fn compress(bytes: &[u8]) -> Vec<u8> {
+    snap::raw::Encoder::new()
+        .compress_vec(bytes)
+        .expect("compress")
+}
+
+/// An RW1 body for one series named `metric`, carrying one
+/// `prometheus.MetricMetadata` entry describing that family (ADR-0085 decision
+/// 1: RW1's family key is `metric_family_name` as parsed).
+fn rw1_body_with_metadata(
+    metric: &str,
+    job: &str,
+    value: f64,
+    ts_ms: i64,
+    meta_type: MetricType,
+    help: &str,
+    unit: &str,
+) -> Vec<u8> {
+    let req = ProtoWriteRequestV1 {
+        timeseries: vec![ProtoTimeSeriesV1 {
+            labels: vec![
+                ProtoLabelV1 {
+                    name: "__name__".to_string(),
+                    value: metric.to_string(),
+                },
+                ProtoLabelV1 {
+                    name: "job".to_string(),
+                    value: job.to_string(),
+                },
+            ],
+            samples: vec![ProtoSampleV1 {
+                value,
+                timestamp: ts_ms,
+            }],
+            exemplars: vec![],
+            histograms: vec![],
+        }],
+        metadata: vec![ProtoMetricMetadataV1 {
+            r#type: meta_type as i32,
+            metric_family_name: metric.to_string(),
+            help: help.to_string(),
+            unit: unit.to_string(),
+        }],
+    };
+    compress(&req.encode_to_vec())
+}
+
+async fn start_test_server() -> ravel_server::Running {
+    let mut tokens = HashMap::new();
+    tokens.insert(TOKEN.to_string(), TenantId::new("acme"));
+    let tenant_resolver = ravel_server::tenant::build_resolver(tokens, false);
+    let store = Arc::new(MemoryStore::new());
+    let config = ServerConfig {
+        max_inflight_flushes: 1,
+        adaptive_flush_delay: false,
+        max_flush_delay: std::time::Duration::from_secs(2),
+        max_flush_delay_idle: std::time::Duration::from_secs(40),
+        min_flush_bytes: 256 * 1024,
+        mode: Mode::All,
+        listen_http: "127.0.0.1:0".parse().expect("valid loopback addr"),
+        listen_grpc: "127.0.0.1:0".parse().expect("valid loopback addr"),
+        shard_count: 1,
+        tenant_resolver,
+        mtls_listener: None,
+        fold_tenants: Vec::new(),
+        fold: FoldTaskConfig {
+            enabled: false,
+            ..FoldTaskConfig::default()
+        },
+        maintain: ravel_server::MaintenanceTaskConfig::default(),
+        alerting: ravel_server::AlertEvalConfig::default(),
+        oidc_refresh: None,
+        otap: false,
+        metrics_tenant_labels: false,
+        limits: ravel_server::LimitsConfig::default(),
+        deployment_key: None,
+        gc: ravel_maintain::GcConfigValues::maintain_defaults(),
+        query_deadline: ravel_query::EngineConfig::default().deadline,
+        store_probe_interval: ravel_server::store_probe::DEFAULT_STORE_PROBE_INTERVAL,
+        admission_reconcile_interval: ravel_ingest::DEFAULT_ADMISSION_RECONCILE_INTERVAL,
+        query_concurrency_limit: ravel_query::QueryConcurrencyLimit::Unlimited,
+        max_s3_requests: ravel_query::EngineConfig::default().max_s3_requests,
+        scrub_period: std::time::Duration::from_secs(7 * 86_400),
+        indexed_fields: Default::default(),
+        disable_cache: false,
+        cache_max_bytes: 256 * 1024 * 1024,
+        ingest_buffer_budget_limit: ravel_server::IngestByteBudgetLimit::Unlimited,
+        idle_tenant_state_ttl: std::time::Duration::from_secs(3600),
+        distrib: None,
+        remote_clusters: Vec::new(),
+        ingest_concurrency_limit: ravel_server::ingest_concurrency::IngestConcurrencyLimit::Bounded(
+            1024,
+        ),
+    };
+    ravel_server::start(
+        config,
+        store.clone(),
+        store.clone(),
+        Arc::new(ravel_object_store::StoreMetrics::default()),
+        None,
+    )
+    .await
+    .expect("server starts")
+}
+
+/// Assert the query for `metric` (constrained to `commit_token`'s visibility)
+/// returns exactly one series with that `__name__`.
+async fn assert_query_one(base: &str, client: &reqwest::Client, metric: &str, commit_token: &str) {
+    let query_response = client
+        .get(format!("{base}/api/v1/query"))
+        .header("authorization", format!("Bearer {TOKEN}"))
+        .query(&[("query", metric), ("min_commit_token", commit_token)])
+        .send()
+        .await
+        .expect("query request succeeds");
+
+    assert_eq!(query_response.status(), 200, "query should succeed");
+    let body: serde_json::Value = query_response.json().await.expect("query response is JSON");
+    assert_eq!(body["status"], "success");
+    let result = body["data"]["result"]
+        .as_array()
+        .expect("result is an array");
+    assert_eq!(result.len(), 1, "expected exactly one series: {body}");
+    assert_eq!(result[0]["metric"]["__name__"], metric);
+}
+
+/// The acceptance test: a unit-suffixed OTLP counter and an RW1 series with
+/// metadata are ingested over the real HTTP surfaces, their metadata is flushed
+/// durably, and `/api/v1/metadata` serves both back with the OTLP name suffixed;
+/// `/api/v1/query` resolves the suffixed name, proving it is what the query path
+/// actually stores. The anonymous probe still gets a `200` with an empty object.
+///
+/// prove-the-test: dropping the `flush_once` call below (so the durable record is
+/// never written before the metadata GET) makes the `data["foo_bytes_total"]`
+/// assertion fail with the response's `data` observed as `{}` (an empty object
+/// where the suffixed entry was expected). Independently, omitting
+/// `.with_metadata_cache` from `build_app_state` makes the same GET serve the
+/// pre-ADR empty object even after the flush, failing identically.
+#[tokio::test]
+async fn otlp_counter_is_suffixed_and_metadata_visible_over_http() {
+    let running = start_test_server().await;
+    let base = format!("http://{}", running.http_addr);
+    let client = reqwest::Client::new();
+
+    // 1. OTLP: a monotonic Sum named `foo`, unit `By`, description `bytes sent`.
+    //    It ingests as the family `foo_bytes_total` (unit suffix `_bytes`, then
+    //    `_total` for the monotonic counter).
+    let otlp = export_counter_request("foo", "demo", "By", "bytes sent", 42.0, now_ns());
+    let otlp_response = client
+        .post(format!("{base}/v1/metrics"))
+        .header("authorization", format!("Bearer {TOKEN}"))
+        .header("content-type", "application/x-protobuf")
+        .body(otlp.encode_to_vec())
+        .send()
+        .await
+        .expect("OTLP export succeeds");
+    assert_eq!(otlp_response.status(), 200, "OTLP export should succeed");
+    let otlp_commit_token = otlp_response
+        .headers()
+        .get("x-ravel-commit-token")
+        .expect("commit token header present")
+        .to_str()
+        .expect("commit token header is ascii")
+        .to_string();
+
+    // 2. RW1: a series named `bar` carrying a Gauge metadata entry.
+    let rw1 = rw1_body_with_metadata(
+        "bar",
+        "demo",
+        7.0,
+        now_ms(),
+        MetricType::Gauge,
+        "a gauge",
+        "seconds",
+    );
+    let rw1_response = client
+        .post(format!("{base}/api/v1/write"))
+        .header("authorization", format!("Bearer {TOKEN}"))
+        .header(
+            "content-type",
+            "application/x-protobuf;proto=prometheus.WriteRequest",
+        )
+        .body(rw1)
+        .send()
+        .await
+        .expect("RW1 write succeeds");
+    assert_eq!(rw1_response.status(), 204, "RW1 write should succeed");
+
+    // 3. Flush the metadata sink deterministically (no real 30 s window wait):
+    //    this writes the durable `t/<tenant_hash>/m/meta` record both surfaces'
+    //    `observe` calls populated. The time-injection testing pattern applied
+    //    end to end, exactly as it is for a unit test.
+    running
+        .metadata_sink
+        .as_ref()
+        .expect("metadata sink present in Mode::All")
+        .flush_once(now_ns())
+        .await;
+
+    // 4. GET /api/v1/metadata with the bearer: both families are visible, with
+    //    the OTLP name suffixed and its unit mapped to the Prometheus word.
+    let meta_response = client
+        .get(format!("{base}/api/v1/metadata"))
+        .header("authorization", format!("Bearer {TOKEN}"))
+        .send()
+        .await
+        .expect("metadata request succeeds");
+    assert_eq!(meta_response.status(), 200, "metadata GET should succeed");
+    let meta: serde_json::Value = meta_response.json().await.expect("metadata JSON");
+    assert_eq!(meta["status"], "success");
+    let data = meta["data"].as_object().expect("data is an object");
+
+    let foo = &data["foo_bytes_total"];
+    assert!(
+        foo.is_array(),
+        "the OTLP counter is visible under its suffixed family name: {meta}"
+    );
+    assert_eq!(foo[0]["type"], "counter", "monotonic Sum -> counter");
+    assert_eq!(foo[0]["help"], "bytes sent", "OTLP description is the help");
+    assert_eq!(
+        foo[0]["unit"], "bytes",
+        "By -> bytes (mapped, not raw UCUM)"
+    );
+
+    let bar = &data["bar"];
+    assert!(bar.is_array(), "the RW1 series is visible: {meta}");
+    assert_eq!(bar[0]["type"], "gauge");
+    assert_eq!(bar[0]["help"], "a gauge");
+    assert_eq!(bar[0]["unit"], "seconds");
+
+    // 5. The OTLP-suffixed name is what the query path resolves, not just what
+    //    the metadata record claims.
+    assert_query_one(&base, &client, "foo_bytes_total", &otlp_commit_token).await;
+
+    // 6. The anonymous probe never becomes a 401: no bearer -> 200 with an empty
+    //    object, through the real router (ADR-0085 read path contract).
+    let anon = client
+        .get(format!("{base}/api/v1/metadata"))
+        .send()
+        .await
+        .expect("anonymous metadata request completes");
+    assert_eq!(anon.status(), 200, "metadata is never a 401");
+    let anon_body: serde_json::Value = anon.json().await.expect("anonymous metadata JSON");
+    assert_eq!(
+        anon_body["data"],
+        serde_json::json!({}),
+        "an unresolved tenant gets the empty object"
+    );
+
+    running.shutdown().await.expect("graceful shutdown");
+}
+
+/// The read side degrades gracefully with no metadata yet: a tenant that has
+/// ingested nothing gets a `200` with an empty `data` object, not an error.
+#[tokio::test]
+async fn metadata_for_tenant_with_no_ingest_is_empty_not_an_error() {
+    let running = start_test_server().await;
+    let base = format!("http://{}", running.http_addr);
+    let client = reqwest::Client::new();
+
+    let response = client
+        .get(format!("{base}/api/v1/metadata"))
+        .header("authorization", format!("Bearer {TOKEN}"))
+        .send()
+        .await
+        .expect("metadata request succeeds");
+    assert_eq!(response.status(), 200, "an empty tenant is still a 200");
+    let body: serde_json::Value = response.json().await.expect("metadata JSON");
+    assert_eq!(body["status"], "success");
+    assert_eq!(
+        body["data"],
+        serde_json::json!({}),
+        "no metadata ingested yet -> empty data object, no error"
+    );
+
+    running.shutdown().await.expect("graceful shutdown");
+}

--- a/services/ravel-server/tests/query_cost_surfaces.rs
+++ b/services/ravel-server/tests/query_cost_surfaces.rs
@@ -172,6 +172,7 @@ fn surfaces(store: Arc<dyn ObjectStoreBackend>, tenant: &TenantId) -> Surfaces {
         ),
         None,
         None,
+        None,
     );
     let promql = promql_router(app_state);
 

--- a/services/ravel-server/tests/recent_hours_reachability_e2e.rs
+++ b/services/ravel-server/tests/recent_hours_reachability_e2e.rs
@@ -198,6 +198,7 @@ fn promql_app(
         QueryAdmissionController::shared(QueryConcurrencyLimit::Unlimited),
         None,
         None,
+        None,
     );
     ravel_query::http::router(state)
 }


### PR DESCRIPTION
feat(server): wire the metric metadata read path and prove ADR-0085 end to end

Wires ravel-query's metric metadata cache (Wave 2) into services/ravel-server,
so /api/v1/metadata serves real data on the shipping binary instead of the
placeholder empty object. Closes the epic: a metric ingested through the real
OTLP or Remote-Write HTTP surface now has its metadata durably captured and
visible through /api/v1/metadata, and its Prometheus-suffixed name (foo ->
foo_bytes_total) is what /api/v1/query actually resolves, proven by a new
end-to-end test driving the real HTTP server rather than a crate-level
shortcut.

Adds a public Running.metadata_sink field so tests can trigger a
deterministic flush instead of waiting on the real 30s window, matching the
project's time-injection testing convention.

Updates README and the query/ingest guides for the real /api/v1/metadata
behavior and OTLP name suffixing.

Fixes: #237
Refs: #119
