### PR TITLE
chore(release): prepare 0.9.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to Ravel are documented in this file. The format is based
 on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and Ravel aims to
 follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.5]
+
+Documentation only. No code changed since 0.9.4, so the binaries and images
+this release publishes are rebuilt from the same source.
+
+### Added
+
+- An interactive architecture explorer in the documentation.
+- A release badge in README.md, pointing at the latest release.
+
+### Changed
+
+- ADR-0086 records that its required-checks decision has been applied:
+  `supply-chain`, `docker-build`, `fuzz`, `object-store-contract`,
+  `promql-difftest` and `actionlint` now gate merges to `main`.
+
 ## [0.9.4]
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4268,14 +4268,14 @@ dependencies = [
 
 [[package]]
 name = "ravel-affinity"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "blake3",
 ]
 
 [[package]]
 name = "ravel-alerting"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "blake3",
  "hex",
@@ -4287,14 +4287,14 @@ dependencies = [
 
 [[package]]
 name = "ravel-analytics"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "ravel-bench"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "arrow 59.1.0",
  "arrow-flight",
@@ -4335,7 +4335,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-cache"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "bytes",
  "crc32c",
@@ -4346,7 +4346,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-catalog"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "blake3",
@@ -4372,7 +4372,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-cli"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4403,7 +4403,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-codec"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "blake3",
  "crc32c",
@@ -4413,7 +4413,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-commit"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "blake3",
  "bytes",
@@ -4435,7 +4435,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-failure-tests"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "bytes",
  "futures",
@@ -4456,7 +4456,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-fleet"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "blake3",
  "futures",
@@ -4473,7 +4473,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-ingest"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "blake3",
@@ -4503,7 +4503,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-ingest-router"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "anyhow",
  "axum",
@@ -4530,7 +4530,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-logseg"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "blake3",
  "crc32c",
@@ -4546,7 +4546,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-maintain"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "blake3",
@@ -4574,7 +4574,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-object-store"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "axum",
@@ -4594,7 +4594,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-operator"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "clap",
  "futures",
@@ -4618,7 +4618,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-otap"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "arrow 59.1.0",
  "arrow-ipc 59.1.0",
@@ -4644,7 +4644,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-otlp"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "blake3",
  "hex",
@@ -4661,7 +4661,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-promql"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "blake3",
  "promql-parser",
@@ -4674,7 +4674,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-promql-difftest"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "axum",
  "bytes",
@@ -4702,7 +4702,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-proto"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "prost",
  "prost-build",
@@ -4711,7 +4711,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-query"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "axum",
@@ -4751,7 +4751,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-remote-write"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "bytes",
  "hex",
@@ -4769,7 +4769,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-rspan"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "crc32c",
  "proptest",
@@ -4783,7 +4783,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-segment"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "blake3",
  "bytes",
@@ -4801,7 +4801,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-server"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "anyhow",
  "arrow 59.1.0",
@@ -4865,7 +4865,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-sim"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4886,7 +4886,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-sql"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -4922,7 +4922,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-tenant-resolve"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "axum",
  "base64 0.23.0",
@@ -4937,7 +4937,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-tracing-export"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
@@ -4953,7 +4953,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-types"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "base64 0.23.0",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*", "services/*"]
 
 [workspace.package]
-version = "0.9.4"
+version = "0.9.5"
 edition = "2024"
 license = "Apache-2.0"
 rust-version = "1.97"
@@ -26,29 +26,29 @@ expect_used = "warn"
 # Version fields pin each path dependency so cargo-deny does not count them as
 # wildcards. allow-wildcard-paths is not usable here because these
 # crates are not marked publish = false, so it does not exempt them.
-ravel-types = { path = "crates/ravel-types", version = "0.9.4" }
-ravel-tenant-resolve = { path = "crates/ravel-tenant-resolve", version = "0.9.4" }
-ravel-proto = { path = "crates/ravel-proto", version = "0.9.4" }
-ravel-codec = { path = "crates/ravel-codec", version = "0.9.4" }
-ravel-object-store = { path = "crates/ravel-object-store", version = "0.9.4" }
-ravel-segment = { path = "crates/ravel-segment", version = "0.9.4" }
-ravel-logseg = { path = "crates/ravel-logseg", version = "0.9.4" }
-ravel-rspan = { path = "crates/ravel-rspan", version = "0.9.4" }
-ravel-commit = { path = "crates/ravel-commit", version = "0.9.4" }
-ravel-catalog = { path = "crates/ravel-catalog", version = "0.9.4" }
-ravel-cache = { path = "crates/ravel-cache", version = "0.9.4" }
-ravel-maintain = { path = "crates/ravel-maintain", version = "0.9.4" }
-ravel-fleet = { path = "crates/ravel-fleet", version = "0.9.4" }
-ravel-otlp = { path = "crates/ravel-otlp", version = "0.9.4" }
-ravel-otap = { path = "crates/ravel-otap", version = "0.9.4" }
-ravel-remote-write = { path = "crates/ravel-remote-write", version = "0.9.4" }
-ravel-alerting = { path = "crates/ravel-alerting", version = "0.9.4" }
-ravel-ingest = { path = "crates/ravel-ingest", version = "0.9.4" }
-ravel-promql = { path = "crates/ravel-promql", version = "0.9.4" }
-ravel-query = { path = "crates/ravel-query", version = "0.9.4" }
-ravel-analytics = { path = "crates/ravel-analytics", version = "0.9.4" }
-ravel-tracing-export = { path = "crates/ravel-tracing-export", version = "0.9.4" }
-ravel-affinity = { path = "crates/ravel-affinity", version = "0.9.4" }
+ravel-types = { path = "crates/ravel-types", version = "0.9.5" }
+ravel-tenant-resolve = { path = "crates/ravel-tenant-resolve", version = "0.9.5" }
+ravel-proto = { path = "crates/ravel-proto", version = "0.9.5" }
+ravel-codec = { path = "crates/ravel-codec", version = "0.9.5" }
+ravel-object-store = { path = "crates/ravel-object-store", version = "0.9.5" }
+ravel-segment = { path = "crates/ravel-segment", version = "0.9.5" }
+ravel-logseg = { path = "crates/ravel-logseg", version = "0.9.5" }
+ravel-rspan = { path = "crates/ravel-rspan", version = "0.9.5" }
+ravel-commit = { path = "crates/ravel-commit", version = "0.9.5" }
+ravel-catalog = { path = "crates/ravel-catalog", version = "0.9.5" }
+ravel-cache = { path = "crates/ravel-cache", version = "0.9.5" }
+ravel-maintain = { path = "crates/ravel-maintain", version = "0.9.5" }
+ravel-fleet = { path = "crates/ravel-fleet", version = "0.9.5" }
+ravel-otlp = { path = "crates/ravel-otlp", version = "0.9.5" }
+ravel-otap = { path = "crates/ravel-otap", version = "0.9.5" }
+ravel-remote-write = { path = "crates/ravel-remote-write", version = "0.9.5" }
+ravel-alerting = { path = "crates/ravel-alerting", version = "0.9.5" }
+ravel-ingest = { path = "crates/ravel-ingest", version = "0.9.5" }
+ravel-promql = { path = "crates/ravel-promql", version = "0.9.5" }
+ravel-query = { path = "crates/ravel-query", version = "0.9.5" }
+ravel-analytics = { path = "crates/ravel-analytics", version = "0.9.5" }
+ravel-tracing-export = { path = "crates/ravel-tracing-export", version = "0.9.5" }
+ravel-affinity = { path = "crates/ravel-affinity", version = "0.9.5" }
 
 # async runtime / rpc / http
 tokio = { version = "1.53", features = ["rt-multi-thread", "macros", "sync", "time", "signal", "net", "io-util"] }

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ GitHub Container Registry on every `vX.Y.Z` release tag, built from the root
 (see [ADR-0037](docs/adrs/0037-container-image-ci-registry.md)). Both
 `linux/amd64` and `linux/arm64` are published.
 Each published object is an OCI image index that carries an SBOM and full build
-provenance. The quickstart pins `ghcr.io/nofireai/ravel-server:0.9.4`. Override
+provenance. The quickstart pins `ghcr.io/nofireai/ravel-server:0.9.5`. Override
 it with `RAVEL_IMAGE`.
 
 ```sh

--- a/crates/ravel-bench/Cargo.toml
+++ b/crates/ravel-bench/Cargo.toml
@@ -63,7 +63,7 @@ futures = { workspace = true, optional = true }
 # ravel-sql is an internal path crate not yet listed in the workspace
 # `[workspace.dependencies]`, so it is named by path here; every other dep
 # below reuses a workspace pin.
-ravel-sql = { path = "../ravel-sql", version = "0.9.4", optional = true, features = ["flight-sql"] }
+ravel-sql = { path = "../ravel-sql", version = "0.9.5", optional = true, features = ["flight-sql"] }
 arrow-flight = { workspace = true, optional = true }
 
 [features]

--- a/crates/ravel-ingest/Cargo.toml
+++ b/crates/ravel-ingest/Cargo.toml
@@ -22,7 +22,7 @@ ravel-catalog = { workspace = true }
 # [workspace.dependencies]; the root Cargo.toml is out of this task's scope, so
 # this is a version-pinned path dependency (the pin keeps cargo-deny from
 # counting it as a wildcard, matching the workspace's path-dep convention).
-ravel-rspan = { path = "../ravel-rspan", version = "0.9.4" }
+ravel-rspan = { path = "../ravel-rspan", version = "0.9.5" }
 # The router live switch (ADR-0052) decodes the provisioning record read for a
 # generation refresh; prost's Message trait provides `decode`.
 prost = { workspace = true }

--- a/crates/ravel-otlp/Cargo.toml
+++ b/crates/ravel-otlp/Cargo.toml
@@ -16,7 +16,7 @@ ravel-logseg = { workspace = true }
 # Used for the span record's StatusCode and the frozen resource+scope+span
 # attribute merge rule, so trace normalization and the RSPAN writer cannot
 # drift apart on either.
-ravel-rspan = { path = "../ravel-rspan", version = "0.9.4" }
+ravel-rspan = { path = "../ravel-rspan", version = "0.9.5" }
 opentelemetry-proto = { workspace = true }
 # Span events and links are stored as an opaque serialized blob in RSPAN v1
 # (ADR-0041 decision 4), which needs prost's own length-delimited encoding.

--- a/crates/ravel-query/Cargo.toml
+++ b/crates/ravel-query/Cargo.toml
@@ -81,7 +81,7 @@ ravel-cache = { workspace = true }
 # proof (tests/differential_compaction.rs) drives P4's real compactor to
 # produce write_v4 L1 parts. ravel-maintain does not depend on ravel-query,
 # so this is acyclic.
-ravel-maintain = { path = "../ravel-maintain", version = "0.9.4" }
+ravel-maintain = { path = "../ravel-maintain", version = "0.9.5" }
 proptest = { workspace = true }
 tokio = { workspace = true }
 tower = { workspace = true, features = ["util"] }

--- a/deploy/docker-compose/ravel.yml
+++ b/deploy/docker-compose/ravel.yml
@@ -50,7 +50,7 @@ services:
   # already-qualified bucket it reports the existing record and exits 0, so this
   # tolerates a populated `minio-data/` across runs.
   qualify:
-    image: ${RAVEL_IMAGE:-ghcr.io/nofireai/ravel-server:0.9.4}
+    image: ${RAVEL_IMAGE:-ghcr.io/nofireai/ravel-server:0.9.5}
     depends_on:
       createbucket:
         condition: service_completed_successfully
@@ -72,7 +72,7 @@ services:
   # container boundary forbids, so the demo authenticates with a real bearer
   # token against a real tenant map, exactly as a deployment does.
   ravel-server:
-    image: ${RAVEL_IMAGE:-ghcr.io/nofireai/ravel-server:0.9.4}
+    image: ${RAVEL_IMAGE:-ghcr.io/nofireai/ravel-server:0.9.5}
     depends_on:
       qualify:
         condition: service_completed_successfully

--- a/services/ravel-server/Cargo.toml
+++ b/services/ravel-server/Cargo.toml
@@ -154,14 +154,14 @@ reqwest = { version = "0.13", features = ["json"] }
 # ravel-rspan below are: the workspace root Cargo.toml is outside this task's
 # scope. The pin keeps cargo-deny from counting it as a wildcard path
 # dependency.
-ravel-alerting = { path = "../../crates/ravel-alerting", version = "0.9.4" }
+ravel-alerting = { path = "../../crates/ravel-alerting", version = "0.9.5" }
 
 # ravel-sql is declared here as a path dependency rather than through
 # `[workspace.dependencies]` because the workspace root Cargo.toml is outside
 # this task's scope. The version is pinned so cargo-deny does not count it as
 # a wildcard path dependency, matching how every other
 # internal crate is pinned.
-ravel-sql = { path = "../../crates/ravel-sql", version = "0.9.4", optional = true }
+ravel-sql = { path = "../../crates/ravel-sql", version = "0.9.5", optional = true }
 
 # Flight service codegen for the `flight-sql` feature. This is arrow 58's
 # arrow-flight, a different arrow major than the `arrow` dev-dependency below;
@@ -208,7 +208,7 @@ tokio = { workspace = true, features = ["test-util"] }
 # listed in the workspace [workspace.dependencies]; the root Cargo.toml is out
 # of this task's scope, so this is a version-pinned path dependency (the pin
 # keeps cargo-deny from counting it as a wildcard).
-ravel-rspan = { path = "../../crates/ravel-rspan", version = "0.9.4" }
+ravel-rspan = { path = "../../crates/ravel-rspan", version = "0.9.5" }
 uuid = { workspace = true }
 # Real-authn end-to-end test (tests/real_authn_e2e.rs): mint a JWT and build a
 # local oct (HMAC) JWKS so the OIDC resolver runs through a real HTTP request


### PR DESCRIPTION
Release prep for v0.9.5.

Bumps the workspace version and every path dependency to 0.9.5, points the quickstart compose default and README pin at it, and adds the changelog section.

Both have to land before the tag: decision 11's gate refuses a tag whose version does not match `[workspace.package] version`, and the release job reads `CHANGELOG.md` from the tagged tree.

Only documentation changed since 0.9.4 (the release badge and decision-11 record, and the architecture explorer), so this release rebuilds the same source. The changelog section states that rather than implying new behaviour.