### PR TITLE
feat(query): pair the bare engine wrappers with their coverage

### DIFF
--- a/crates/ravel-bench/src/bin/catalog_resolve_bench.rs
+++ b/crates/ravel-bench/src/bin/catalog_resolve_bench.rs
@@ -499,7 +499,7 @@ async fn run_gate_scenario(raw_store: Arc<dyn ObjectStoreBackend>, args: &Args) 
         EngineConfig::default(),
     );
     let query_start = Instant::now();
-    let value = engine
+    let (value, _coverage) = engine
         .instant(
             tenant_hash,
             query,

--- a/crates/ravel-bench/src/bin/compaction_bench.rs
+++ b/crates/ravel-bench/src/bin/compaction_bench.rs
@@ -491,8 +491,10 @@ async fn measure_query(
     let query_wall = query_start.elapsed();
     let (qg, ql, _) = q_counters.snapshot();
     let query_status = match result {
-        Ok(ravel_promql::Value::Vector(v)) => format!("OK ({} series matched)", v.len()),
-        Ok(other) => format!("OK (non-vector: {other:?})"),
+        Ok((ravel_promql::Value::Vector(v), _coverage)) => {
+            format!("OK ({} series matched)", v.len())
+        }
+        Ok((other, _coverage)) => format!("OK (non-vector: {other:?})"),
         Err(e) => format!("FAILS: {e}"),
     };
     QueryMeasure {
@@ -652,10 +654,11 @@ async fn query_value(
 ) -> ravel_promql::Value {
     let catalog = Arc::new(build_catalog(Arc::clone(&raw), 1));
     let engine = QueryEngine::new(catalog, raw, EngineConfig::default());
-    engine
+    let (value, _coverage) = engine
         .instant(tenant_hash, query, t_ms, &[], now, Duration::from_secs(30))
         .await
-        .expect("query")
+        .expect("query");
+    value
 }
 
 /// Bit-exact comparison of two instant-vector results (value bits and labels),

--- a/crates/ravel-bench/src/concurrent.rs
+++ b/crates/ravel-bench/src/concurrent.rs
@@ -300,7 +300,7 @@ async fn run_reader(
         latencies_ns.push(start.elapsed().as_nanos() as u64);
         queries_run += 1;
         match result {
-            Ok(Value::Vector(v)) if !v.is_empty() => non_empty_results += 1,
+            Ok((Value::Vector(v), _coverage)) if !v.is_empty() => non_empty_results += 1,
             Ok(_) => {}
             Err(err) => eprintln!("reader {reader_id}: query error: {err}"),
         }
@@ -325,7 +325,7 @@ async fn run_reader(
     latencies_ns.push(start.elapsed().as_nanos() as u64);
     queries_run += 1;
     match result {
-        Ok(Value::Vector(v)) if !v.is_empty() => non_empty_results += 1,
+        Ok((Value::Vector(v), _coverage)) if !v.is_empty() => non_empty_results += 1,
         Ok(_) => {}
         Err(err) => eprintln!("reader {reader_id}: final query error: {err}"),
     }
@@ -458,7 +458,7 @@ pub async fn run(config: &ConcurrentConfig) -> Report {
     let query_now_ns = clock.now_ns();
 
     let cold_start = Instant::now();
-    let cold_value = cold_engine
+    let (cold_value, _cold_coverage) = cold_engine
         .instant(
             tenant_hash,
             &config.query,
@@ -476,7 +476,7 @@ pub async fn run(config: &ConcurrentConfig) -> Report {
     };
 
     let warm_start = Instant::now();
-    let warm_value = cold_engine
+    let (warm_value, _warm_coverage) = cold_engine
         .instant(
             tenant_hash,
             &config.query,

--- a/crates/ravel-bench/src/e2e.rs
+++ b/crates/ravel-bench/src/e2e.rs
@@ -472,7 +472,7 @@ pub async fn run(config: &E2eConfig) -> Report {
     let mut query_matched_series = 0usize;
     for i in 0..config.query_count {
         let start = std::time::Instant::now();
-        let value = engine
+        let (value, _coverage) = engine
             .instant(
                 tenant_hash,
                 &config.query,

--- a/crates/ravel-bench/src/query_latency.rs
+++ b/crates/ravel-bench/src/query_latency.rs
@@ -239,7 +239,7 @@ pub async fn run(config: &QueryLatencyConfig) -> Report {
     let mut instant_matched_series = 0usize;
     for i in 0..config.instant_query_count {
         let start = Instant::now();
-        let value = engine
+        let (value, _coverage) = engine
             .instant(
                 tenant_hash,
                 &config.query,
@@ -263,7 +263,7 @@ pub async fn run(config: &QueryLatencyConfig) -> Report {
     let mut range_matched_series = 0usize;
     for i in 0..config.range_query_count {
         let start = Instant::now();
-        let value = engine
+        let (value, _coverage) = engine
             .range(
                 tenant_hash,
                 &config.query,

--- a/crates/ravel-bench/src/report.rs
+++ b/crates/ravel-bench/src/report.rs
@@ -476,7 +476,7 @@ pub async fn run(config: &ReportRunConfig) -> BenchReport {
 
     let run_query = || async {
         let start = std::time::Instant::now();
-        let value = engine
+        let (value, _coverage) = engine
             .instant(
                 tenant_hash,
                 &w.query,

--- a/crates/ravel-failure-tests/tests/common/mod.rs
+++ b/crates/ravel-failure-tests/tests/common/mod.rs
@@ -194,7 +194,15 @@ pub fn engine(store: Arc<dyn ObjectStoreBackend>, catalog: Catalog) -> QueryEngi
 /// Unwraps an instant-query result this suite expects to be a plain
 /// instant vector (every query here is a bare selector, never a
 /// scalar/string literal), panicking with the actual variant otherwise.
-pub fn expect_vector(value: ravel_promql::Value) -> ravel_promql::InstantVector {
+///
+/// Takes the `(Value, Coverage)` pair `QueryEngine::instant` returns
+/// (ADR-0071 amendment decision 4) and drops the coverage here, in one
+/// place, rather than at each of this suite's call sites: every query in
+/// this suite is single-cluster, so its coverage is always
+/// `Coverage::Complete`.
+pub fn expect_vector(
+    (value, _coverage): (ravel_promql::Value, ravel_query::Coverage),
+) -> ravel_promql::InstantVector {
     match value {
         ravel_promql::Value::Vector(v) => v,
         other => panic!("expected instant vector, got {other:?}"),
@@ -202,8 +210,11 @@ pub fn expect_vector(value: ravel_promql::Value) -> ravel_promql::InstantVector 
 }
 
 /// Unwraps a range-query result this suite expects to be a plain range
-/// matrix, panicking with the actual variant otherwise.
-pub fn expect_matrix(value: ravel_promql::Value) -> ravel_promql::RangeMatrix {
+/// matrix, panicking with the actual variant otherwise. Drops the coverage
+/// for the same reason [`expect_vector`] does.
+pub fn expect_matrix(
+    (value, _coverage): (ravel_promql::Value, ravel_query::Coverage),
+) -> ravel_promql::RangeMatrix {
     match value {
         ravel_promql::Value::Matrix(m) => m,
         other => panic!("expected range matrix, got {other:?}"),

--- a/crates/ravel-query/src/engine.rs
+++ b/crates/ravel-query/src/engine.rs
@@ -367,6 +367,17 @@ impl QueryEngine {
         &self.config
     }
 
+    /// Evaluates `query` as an instant query, returning its value paired with
+    /// the [`Coverage`] that value was computed over.
+    ///
+    /// The `Coverage` is not optional: ADR-0071's "partial results are
+    /// consent-gated and envelope-visible" amendment (decision 4) requires that
+    /// no public entry point hand a caller a result which compiles away its
+    /// coverage. A caller that does not care must bind the coverage to a name,
+    /// so that ignoring it is a decision review can see. The coverage is
+    /// derived by [`Coverage::from_stats`] from the same [`QueryStats`]
+    /// [`Self::instant_with_stats`] returns, so this wrapper computes nothing
+    /// new; it only refuses to drop what the fan-out already recorded.
     pub async fn instant(
         &self,
         tenant_hash: TenantHash,
@@ -375,17 +386,17 @@ impl QueryEngine {
         min_tokens: &[CommitToken],
         now_ns: i64,
         deadline: Duration,
-    ) -> Result<Value, QueryError> {
-        let (value, _stats) = self
+    ) -> Result<(Value, Coverage), QueryError> {
+        let (value, stats) = self
             .instant_with_stats(tenant_hash, query, t_ms, min_tokens, now_ns, deadline)
             .await?;
-        Ok(value)
+        Ok((value, Coverage::from_stats(&stats)))
     }
 
-    /// Same as [`Self::instant`], additionally returning this query's
-    /// segment counters. Additive: `instant`
-    /// keeps its original signature and behavior unchanged, mirroring the
-    /// `Catalog::resolve`/`resolve_pruned` split.
+    /// Same as [`Self::instant`], returning this query's full segment counters
+    /// instead of just the [`Coverage`] derived from them. This is the source
+    /// for the wire rendering, and its signature is unchanged by the ADR-0071
+    /// amendment.
     pub async fn instant_with_stats(
         &self,
         tenant_hash: TenantHash,
@@ -405,7 +416,7 @@ impl QueryEngine {
     /// evaluation [`Annotations`] (Prometheus' separate `warnings` and
     /// `infos`). The HTTP query handlers use this so both fields reach the
     /// response envelope; the stats-only and value-only wrappers discard the
-    /// annotations, keeping their original signatures.
+    /// annotations.
     pub async fn instant_with_stats_annotated(
         &self,
         tenant_hash: TenantHash,
@@ -447,6 +458,11 @@ impl QueryEngine {
         Ok((value, annotations, stats))
     }
 
+    /// Evaluates `query` as a range query, returning its value paired with the
+    /// [`Coverage`] that value was computed over. Same contract as
+    /// [`Self::instant`]: the coverage cannot be dropped silently (ADR-0071
+    /// amendment decision 4), and it is derived by [`Coverage::from_stats`] from
+    /// the [`QueryStats`] [`Self::range_with_stats`] already produces.
     #[allow(clippy::too_many_arguments)]
     pub async fn range(
         &self,
@@ -458,8 +474,8 @@ impl QueryEngine {
         min_tokens: &[CommitToken],
         now_ns: i64,
         deadline: Duration,
-    ) -> Result<Value, QueryError> {
-        let (value, _stats) = self
+    ) -> Result<(Value, Coverage), QueryError> {
+        let (value, stats) = self
             .range_with_stats(
                 tenant_hash,
                 query,
@@ -471,13 +487,13 @@ impl QueryEngine {
                 deadline,
             )
             .await?;
-        Ok(value)
+        Ok((value, Coverage::from_stats(&stats)))
     }
 
-    /// Same as [`Self::range`], additionally returning this query's segment
-    /// counters. Additive: `range` keeps its
-    /// original signature and behavior unchanged, mirroring the
-    /// `Catalog::resolve`/`resolve_pruned` split.
+    /// Same as [`Self::range`], returning this query's full segment counters
+    /// instead of just the [`Coverage`] derived from them. This is the source
+    /// for the wire rendering, and its signature is unchanged by the ADR-0071
+    /// amendment.
     #[allow(clippy::too_many_arguments)]
     pub async fn range_with_stats(
         &self,
@@ -579,7 +595,11 @@ impl QueryEngine {
     }
 
     /// Resolves the series (labels only, no samples) matching `matchers` in
-    /// `window`, for the labels/label-values/series HTTP endpoints.
+    /// `window`, for the labels/label-values/series HTTP endpoints, returning
+    /// them paired with the [`Coverage`] they were resolved over. Same contract
+    /// as [`Self::instant`]: the coverage cannot be dropped silently (ADR-0071
+    /// amendment decision 4), and it is derived by [`Coverage::from_stats`] from
+    /// the [`QueryStats`] [`Self::resolve_series_with_stats`] already produces.
     pub async fn resolve_series(
         &self,
         tenant_hash: TenantHash,
@@ -588,17 +608,17 @@ impl QueryEngine {
         min_tokens: &[CommitToken],
         now_ns: i64,
         deadline: Duration,
-    ) -> Result<Vec<(SeriesId, LabelSet)>, QueryError> {
-        let (series, _stats) = self
+    ) -> Result<(Vec<(SeriesId, LabelSet)>, Coverage), QueryError> {
+        let (series, stats) = self
             .resolve_series_with_stats(tenant_hash, matchers, window, min_tokens, now_ns, deadline)
             .await?;
-        Ok(series)
+        Ok((series, Coverage::from_stats(&stats)))
     }
 
-    /// Same as [`Self::resolve_series`], additionally returning this query's
-    /// segment counters. Additive:
-    /// `resolve_series` keeps its original signature and behavior unchanged,
-    /// mirroring the `Catalog::resolve`/`resolve_pruned` split.
+    /// Same as [`Self::resolve_series`], returning this query's full segment
+    /// counters instead of just the [`Coverage`] derived from them. This is the
+    /// source for the wire rendering, and its signature is unchanged by the
+    /// ADR-0071 amendment.
     pub async fn resolve_series_with_stats(
         &self,
         tenant_hash: TenantHash,
@@ -4531,5 +4551,214 @@ mod prefetch_tests {
              not trip a budget set at that exact real cost: {:?}",
             result.err()
         );
+    }
+}
+
+/// The bare convenience wrappers ([`QueryEngine::instant`],
+/// [`QueryEngine::range`], [`QueryEngine::resolve_series`]) hand back the same
+/// [`Coverage`] their `_with_stats` sibling's [`QueryStats`] yields, for the
+/// identical inputs (ADR-0071 "partial results are consent-gated and
+/// envelope-visible" amendment, decision 4).
+///
+/// Flip-line proof: replace any wrapper's `Coverage::from_stats(&stats)` with a
+/// hardcoded `Coverage::Complete` and the partial case below fails; drop the
+/// pairing entirely and the module does not compile.
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod coverage_wrapper_tests {
+    use std::sync::Arc;
+
+    use async_trait::async_trait;
+    use ravel_catalog::{Catalog, CatalogConfig};
+    use ravel_object_store::memory::MemoryStore;
+    use ravel_promql::MatchOp;
+    use ravel_proto::queryfrag::v1 as pb;
+    use ravel_types::TenantId;
+    use ravel_types::accounting::QueryAccountingSnapshot;
+
+    use super::*;
+    use crate::distrib::client::{DistribError, SliceFetcher, SliceResponse};
+    use crate::distrib::{Federation, RemoteCluster};
+
+    const REMOTE: &str = "eu-west";
+    const WINDOW_END_NS: i64 = 1_000_000_000_000;
+    const DEADLINE: Duration = Duration::from_secs(30);
+
+    /// A remote whose every fetch fails at the transport. With
+    /// `skip_unavailable = true` the coordinator skips it, so the query
+    /// succeeds with `stats.partial = true` and one redacted warning.
+    struct UnavailableFetcher;
+
+    #[async_trait]
+    impl SliceFetcher for UnavailableFetcher {
+        async fn fetch(&self, _request: pb::FetchRequest) -> Result<SliceResponse, DistribError> {
+            Err(DistribError::Transport("connection refused".to_string()))
+        }
+    }
+
+    /// A healthy remote that contributes nothing: the query stays complete.
+    struct EmptyFetcher;
+
+    #[async_trait]
+    impl SliceFetcher for EmptyFetcher {
+        async fn fetch(&self, _request: pb::FetchRequest) -> Result<SliceResponse, DistribError> {
+            Ok(SliceResponse {
+                scalar: Vec::new(),
+                accounting: QueryAccountingSnapshot::default(),
+                stats: FetchStats::default(),
+                series_returned: 0,
+                samples_returned: 0,
+                status: pb::status::Code::Ok,
+                status_message: String::new(),
+            })
+        }
+    }
+
+    /// An engine over an empty local tenant plus one `skip_unavailable` remote,
+    /// either healthy (`available = true`, coverage complete) or dead
+    /// (`available = false`, coverage partial). The local side carries no data,
+    /// so the coverage under test comes only from the federation fan-out.
+    fn engine(available: bool) -> QueryEngine {
+        let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+        let catalog =
+            Arc::new(Catalog::new(store.clone(), CatalogConfig::default()).expect("catalog"));
+        let fetcher: Arc<dyn SliceFetcher> = if available {
+            Arc::new(EmptyFetcher)
+        } else {
+            Arc::new(UnavailableFetcher)
+        };
+        let federation = Federation::new(vec![RemoteCluster {
+            name: REMOTE.to_string(),
+            fetcher,
+            skip_unavailable: true,
+            soft_timeout: Duration::from_secs(5),
+        }]);
+        QueryEngine::new(catalog, store, EngineConfig::default())
+            .with_federation(Arc::new(federation))
+    }
+
+    fn tenant() -> TenantHash {
+        TenantId::new("tenant-260".to_string()).hash()
+    }
+
+    fn matchers() -> Vec<LabelMatcher> {
+        vec![LabelMatcher {
+            name: METRIC_NAME_LABEL.to_string(),
+            op: MatchOp::Eq,
+            value: "m".to_string(),
+        }]
+    }
+
+    /// Coverage the fan-out reports for `available`, read off the stats-carrying
+    /// wrapper. The bare wrappers are asserted equal to this, so the assertion
+    /// is a parity check against the existing source of truth rather than a
+    /// restatement of `Coverage::from_stats`.
+    fn expected(available: bool) -> Coverage {
+        if available {
+            Coverage::Complete
+        } else {
+            Coverage::Partial {
+                skipped: vec![format!(
+                    "remote cluster {REMOTE} unavailable; results are partial"
+                )],
+            }
+        }
+    }
+
+    async fn assert_instant_parity(available: bool) {
+        let engine = engine(available);
+        let t_ms = WINDOW_END_NS / 1_000_000;
+        let (_value, stats) = engine
+            .instant_with_stats(tenant(), "m", t_ms, &[], WINDOW_END_NS, DEADLINE)
+            .await
+            .expect("instant_with_stats");
+        let (_value, coverage) = engine
+            .instant(tenant(), "m", t_ms, &[], WINDOW_END_NS, DEADLINE)
+            .await
+            .expect("instant");
+        assert_eq!(coverage, Coverage::from_stats(&stats));
+        assert_eq!(coverage, expected(available));
+    }
+
+    async fn assert_range_parity(available: bool) {
+        let engine = engine(available);
+        let end_ms = WINDOW_END_NS / 1_000_000;
+        let start_ms = end_ms - 60_000;
+        let (_value, stats) = engine
+            .range_with_stats(
+                tenant(),
+                "m",
+                start_ms,
+                end_ms,
+                15_000,
+                &[],
+                WINDOW_END_NS,
+                DEADLINE,
+            )
+            .await
+            .expect("range_with_stats");
+        let (_value, coverage) = engine
+            .range(
+                tenant(),
+                "m",
+                start_ms,
+                end_ms,
+                15_000,
+                &[],
+                WINDOW_END_NS,
+                DEADLINE,
+            )
+            .await
+            .expect("range");
+        assert_eq!(coverage, Coverage::from_stats(&stats));
+        assert_eq!(coverage, expected(available));
+    }
+
+    async fn assert_resolve_series_parity(available: bool) {
+        let engine = engine(available);
+        let window = TimeRange {
+            start_ns: 0,
+            end_ns: WINDOW_END_NS,
+        };
+        let (_series, stats) = engine
+            .resolve_series_with_stats(tenant(), &matchers(), window, &[], WINDOW_END_NS, DEADLINE)
+            .await
+            .expect("resolve_series_with_stats");
+        let (_series, coverage) = engine
+            .resolve_series(tenant(), &matchers(), window, &[], WINDOW_END_NS, DEADLINE)
+            .await
+            .expect("resolve_series");
+        assert_eq!(coverage, Coverage::from_stats(&stats));
+        assert_eq!(coverage, expected(available));
+    }
+
+    #[tokio::test]
+    async fn instant_reports_complete_coverage_matching_its_stats() {
+        assert_instant_parity(true).await;
+    }
+
+    #[tokio::test]
+    async fn instant_reports_partial_coverage_matching_its_stats() {
+        assert_instant_parity(false).await;
+    }
+
+    #[tokio::test]
+    async fn range_reports_complete_coverage_matching_its_stats() {
+        assert_range_parity(true).await;
+    }
+
+    #[tokio::test]
+    async fn range_reports_partial_coverage_matching_its_stats() {
+        assert_range_parity(false).await;
+    }
+
+    #[tokio::test]
+    async fn resolve_series_reports_complete_coverage_matching_its_stats() {
+        assert_resolve_series_parity(true).await;
+    }
+
+    #[tokio::test]
+    async fn resolve_series_reports_partial_coverage_matching_its_stats() {
+        assert_resolve_series_parity(false).await;
     }
 }

--- a/crates/ravel-query/tests/bytes_scanned_budget.rs
+++ b/crates/ravel-query/tests/bytes_scanned_budget.rs
@@ -324,7 +324,7 @@ async fn empty_matching_labels_query_still_trips_budget() {
 
     // Unlimited: proves the query really does match zero series.
     let (engine, gets, tokens, tenant_hash) = setup(ByteLimit::Unlimited).await;
-    let series = engine
+    let (series, _coverage) = engine
         .resolve_series(
             tenant_hash,
             &matchers,

--- a/crates/ravel-query/tests/erasure_cross_surface.rs
+++ b/crates/ravel-query/tests/erasure_cross_surface.rs
@@ -290,7 +290,7 @@ async fn instant_user_ids(
     tokens: &[CommitToken],
     ts_ns: i64,
 ) -> Vec<String> {
-    let value = engine
+    let (value, _coverage) = engine
         .instant(
             tenant_hash,
             METRIC,
@@ -322,7 +322,7 @@ async fn range_user_ids(
     tenant_hash: TenantHash,
     token: &CommitToken,
 ) -> Vec<String> {
-    let value = engine
+    let (value, _coverage) = engine
         .range(
             tenant_hash,
             METRIC,
@@ -357,7 +357,7 @@ async fn enumerated_user_ids(
     tenant_hash: TenantHash,
     token: &CommitToken,
 ) -> Vec<String> {
-    let series = engine
+    let (series, _coverage) = engine
         .resolve_series(
             tenant_hash,
             &[LabelMatcher::equal(METRIC_NAME_LABEL, METRIC)],

--- a/crates/ravel-query/tests/erasure_e2e.rs
+++ b/crates/ravel-query/tests/erasure_e2e.rs
@@ -295,7 +295,7 @@ async fn queried_user_ids(
     token: &CommitToken,
     ts_ns: i64,
 ) -> Vec<String> {
-    let value = engine
+    let (value, _coverage) = engine
         .instant(
             tenant_hash,
             METRIC,
@@ -333,7 +333,7 @@ async fn range_user_ids(
     tenant_hash: TenantHash,
     token: &CommitToken,
 ) -> Vec<String> {
-    let value = engine
+    let (value, _coverage) = engine
         .range(
             tenant_hash,
             METRIC,
@@ -372,7 +372,7 @@ async fn enumerated_user_ids(
     tenant_hash: TenantHash,
     token: &CommitToken,
 ) -> Vec<String> {
-    let series = engine
+    let (series, _coverage) = engine
         .resolve_series(
             tenant_hash,
             &[LabelMatcher::equal(METRIC_NAME_LABEL, METRIC)],

--- a/crates/ravel-query/tests/federated_request_budget.rs
+++ b/crates/ravel-query/tests/federated_request_budget.rs
@@ -167,8 +167,9 @@ async fn federated_series_under_request_budget_succeeds() {
         result.is_ok(),
         "an under-budget federated query must not be rejected: {result:?}"
     );
+    let (series, _coverage) = result.expect("checked is_ok above");
     assert!(
-        result.expect("checked is_ok above").is_empty(),
+        series.is_empty(),
         "the remote and the empty local tenant both report zero series"
     );
 }

--- a/crates/ravel-sim/src/driver.rs
+++ b/crates/ravel-sim/src/driver.rs
@@ -1386,7 +1386,7 @@ async fn probe_all_series(
     let mut record_count = 0usize;
     for series in series_list {
         let selector = series_selector(series);
-        let value = engine
+        let (value, _coverage) = engine
             .range(
                 tenant_hash,
                 &selector,
@@ -1475,7 +1475,7 @@ async fn check_visible(
         let Some(expected) = expected_sample(series) else {
             continue;
         };
-        let value = engine
+        let (value, _coverage) = engine
             .instant(
                 *tenant_hash,
                 &expected.query,
@@ -1547,9 +1547,10 @@ async fn run_query(
 ) -> Result<Value, QueryError> {
     match query {
         QuerySpec::Instant { query, t_ms } => {
-            engine
+            let (value, _coverage) = engine
                 .instant(tenant_hash, query, *t_ms, &[], now_ns, deadline)
-                .await
+                .await?;
+            Ok(value)
         }
         QuerySpec::Range {
             query,
@@ -1557,7 +1558,7 @@ async fn run_query(
             end_ms,
             step_ms,
         } => {
-            engine
+            let (value, _coverage) = engine
                 .range(
                     tenant_hash,
                     query,
@@ -1568,7 +1569,8 @@ async fn run_query(
                     now_ns,
                     deadline,
                 )
-                .await
+                .await?;
+            Ok(value)
         }
     }
 }

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -489,6 +489,30 @@ warning (the remote returned a data kind this build cannot federate yet),
 and without `skip_unavailable` it fails with that same typed reason rather
 than a generic transport error.
 
+#### The engine API cannot hand a caller a value without its coverage
+
+Warnings in a response envelope only help a caller that reads an envelope,
+so the engine API carries the same signal in its types (ADR-0071 "partial
+results are consent-gated and envelope-visible" amendment, decision 4). The
+bare convenience wrappers `QueryEngine::{instant, range, resolve_series}`
+return their value paired with a `#[must_use] Coverage`
+(`Complete | Partial { skipped }`), derived by `Coverage::from_stats` from
+the same `QueryStats` their `_with_stats` sibling returns. Nothing new is
+tracked; the wrappers simply cannot drop what the fan-out already recorded.
+A caller that does not care must bind the coverage to a name, which puts the
+decision to ignore it where review can see it. The `_with_stats` and
+`_with_stats_annotated` variants are unchanged and remain the source for the
+wire rendering.
+
+The alert evaluator (`services/ravel-server/src/alerting.rs`, `run_query`)
+is the caller this matters most for, and it treats `Coverage::Partial` as a
+failed evaluation (amendment decision 5): the rule is logged, counted in the
+tick's `rules_failed`, its prior alert state is left untouched, no transition
+record is written, and the next tick retries. A rule can therefore never fire
+or resolve on data a skipped cluster never returned. There is deliberately no
+per-rule opt-in to evaluate on partial coverage; that policy belongs with the
+alerting surface's own work.
+
 ### Cross-cluster duplicate tie-break limitation
 
 The merge resolves a duplicate `(series_id, ts)` under the total order in

--- a/services/ravel-server/src/alerting.rs
+++ b/services/ravel-server/src/alerting.rs
@@ -68,7 +68,7 @@ use ravel_ingest::{Clock, LOG_SEGMENT_FORMAT_VERSION};
 use ravel_logseg::{ObjectIdentity, Predicate, RlogConfig, RlogReader};
 use ravel_object_store::{GetRange, ObjectStoreBackend, PutMode, PutOptions, StoreError, list_all};
 use ravel_promql::Value as PromqlValue;
-use ravel_query::QueryEngine;
+use ravel_query::{Coverage, QueryEngine};
 use ravel_types::{Signal, TenantHash, TenantId};
 use serde::{Deserialize, Serialize};
 use tokio::sync::oneshot;
@@ -835,10 +835,21 @@ impl AlertEvaluator {
 
     /// Run a rule's query and summarize the result into the shape its condition
     /// tests.
+    ///
+    /// Partial federated coverage is a failed evaluation, not a usable answer
+    /// (ADR-0071 "partial results are consent-gated and envelope-visible"
+    /// amendment, decision 5). A rule evaluated over a result that omits a
+    /// skipped remote's data can fire, or worse resolve, on data that was never
+    /// read. Returning an error here puts the rule on the existing per-rule
+    /// failure path in [`Self::run_tick`]: it is logged, counted in
+    /// `rules_failed`, the prior alert state is left exactly as it was, no
+    /// transition record is written, and the next tick retries. A per-rule
+    /// opt-in to evaluate on partial coverage is deliberately not offered here;
+    /// the amendment leaves that to the alerting surface's own work.
     async fn run_query(&self, rule: &Rule, now_ns: i64) -> anyhow::Result<QueryResultSummary> {
         match &rule.query {
             RuleQuery::Promql(text) => {
-                let value = self
+                let (value, coverage) = self
                     .engines
                     .promql
                     .instant(
@@ -850,6 +861,13 @@ impl AlertEvaluator {
                         self.query_deadline,
                     )
                     .await?;
+                if let Coverage::Partial { skipped } = coverage {
+                    anyhow::bail!(
+                        "alert rule query ran over partial federated coverage (degraded \
+                         clusters: {}); refusing to evaluate the rule on an incomplete result",
+                        skipped.join(", ")
+                    );
+                }
                 promql_summary(value)
             }
             RuleQuery::Sql(text) => self.run_sql(text, now_ns).await,

--- a/services/ravel-server/tests/alerting_e2e.rs
+++ b/services/ravel-server/tests/alerting_e2e.rs
@@ -28,12 +28,14 @@ use ravel_ingest::Clock;
 use ravel_logseg::{Predicate, RlogConfig, RlogReader};
 use ravel_object_store::memory::MemoryStore;
 use ravel_object_store::{GetRange, ObjectStoreBackend, PutOptions, list_all};
+use ravel_query::distrib::{Federation, RemoteCluster};
 use ravel_query::{EngineConfig, QueryEngine};
 use ravel_segment::{IngestBounds, SegmentIdentity, SegmentWriter, SeriesInput};
 use ravel_server::alert_sink::{AlertSink, Credential};
 use ravel_server::alerting::{
     ALERT_SHARD, AlertEvalConfig, AlertEvaluator, AlertQueryEngines, parse_rules,
 };
+use ravel_server::config::RemoteClusterConfig;
 use ravel_types::{Label, LabelSet, Sample, SeriesId, Signal, TenantHash, TenantId};
 use serde_json::Value as Json;
 use tokio::sync::oneshot;
@@ -1387,4 +1389,251 @@ async fn a_rule_removed_from_config_never_repeats() {
     );
 
     server.stop().await;
+}
+
+// --- Partial federated coverage freezes a rule (ADR-0071 amendment) --------
+
+/// An address that was bound then immediately released: a connection to it is
+/// refused, so a remote pointed here is unavailable at evaluation time. Same
+/// device `federation_e2e.rs` uses for its dead-cluster cases.
+async fn dead_endpoint() -> String {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind dead");
+    let addr = listener.local_addr().expect("dead local addr");
+    drop(listener);
+    addr.to_string()
+}
+
+/// An evaluator whose PromQL engine federates to one `skip_unavailable = true`
+/// remote that is down, dialed by the production `FederationSliceFetcher`. Every
+/// rule query it runs therefore completes with partial coverage: the fan-out
+/// skips the dead cluster, warns, and marks the stats partial.
+///
+/// Identical to [`evaluator`] in every other respect, and over the same store,
+/// so a test can seed durable alert state with a healthy evaluator and then
+/// evaluate the next tick under partial coverage.
+async fn evaluator_with_dead_remote(
+    store: Arc<dyn ObjectStoreBackend>,
+    clock: TestClock,
+    rules: Vec<Rule>,
+) -> AlertEvaluator {
+    let endpoint = dead_endpoint().await;
+    let cluster_config = RemoteClusterConfig {
+        name: "west".to_string(),
+        endpoint: endpoint.clone(),
+        credential: "operator-cred".to_string(),
+        tls: false,
+        tls_ca_file: None,
+        skip_unavailable: true,
+        soft_timeout: Duration::from_secs(2),
+    };
+    let fetcher = ravel_server::distrib::FederationSliceFetcher::connect(&cluster_config)
+        .expect("federation client connects lazily");
+    let federation = Federation::new(vec![RemoteCluster {
+        name: "west".to_string(),
+        fetcher: Arc::new(fetcher),
+        skip_unavailable: true,
+        soft_timeout: Duration::from_secs(2),
+    }]);
+
+    let catalog =
+        Arc::new(Catalog::new(Arc::clone(&store), CatalogConfig::default()).expect("catalog"));
+    let engine = QueryEngine::new(catalog, Arc::clone(&store), EngineConfig::default())
+        .with_federation(Arc::new(federation));
+    let config = AlertEvalConfig {
+        enabled: true,
+        ..AlertEvalConfig::default()
+    };
+    AlertEvaluator::new(
+        store,
+        AlertQueryEngines {
+            promql: Arc::new(engine),
+            #[cfg(feature = "sql")]
+            sql: None,
+        },
+        Arc::new(clock),
+        TenantId::new(TENANT).hash(),
+        rules,
+        &config,
+    )
+    .expect("build evaluator")
+}
+
+/// ADR-0071 "partial results are consent-gated and envelope-visible" amendment,
+/// decision 5: a rule whose query federates across a down `skip_unavailable`
+/// remote is a FAILED evaluation, not a decided one. The tick must count
+/// `rules_failed`, write no transition record, and leave the prior alert state
+/// exactly as it was, so the next tick retries against (hopefully) full
+/// coverage.
+///
+/// Both prior states are seeded, and in each the local-only answer is the
+/// OPPOSITE of the prior state, so an evaluator that ignores coverage really
+/// does transition:
+///
+/// - prior `Firing`, local data stale at the partial tick: ignoring coverage
+///   resolves the alert on data that was never read.
+/// - prior `Resolved`, local data fresh and above threshold at the partial
+///   tick: ignoring coverage fires it.
+///
+/// Flip-line proof (prove-the-test): in
+/// `services/ravel-server/src/alerting.rs::run_query`, delete the
+/// `if let Coverage::Partial { skipped } = coverage { anyhow::bail!(...) }`
+/// block (equivalently, bind the wrapper's second element to `_coverage` and
+/// carry on, which is exactly the pre-change behavior). Both halves then fail
+/// on `records_written`/`rules_failed`, and the read-back history grows a
+/// transition record decided from an incomplete answer.
+#[tokio::test]
+async fn partial_coverage_freezes_rule_state() {
+    let tenant = TenantId::new(TENANT).hash();
+
+    // --- Prior state Firing -------------------------------------------------
+    {
+        let store = seeded_store().await;
+        let clock = TestClock::at(NOW_NS);
+        {
+            let mut healthy = evaluator(
+                Arc::clone(&store),
+                clock.clone(),
+                vec![threshold_rule(None)],
+                Vec::new(),
+            );
+            assert_eq!(healthy.run_tick().await.records_written, 1, "fires");
+        }
+        let before = read_alert_records(store.as_ref(), tenant).await;
+        assert_eq!(before.len(), 1);
+        assert_eq!(before[0].state, AlertState::Firing);
+
+        // Ten minutes on, the only local sample is outside PromQL's 5-minute
+        // lookback, so the local-only instant vector is empty and the threshold
+        // can no longer be met: an evaluator that ignored coverage would write a
+        // Resolved record here.
+        clock.advance(Duration::from_secs(600));
+        let mut degraded = evaluator_with_dead_remote(
+            Arc::clone(&store),
+            clock.clone(),
+            vec![threshold_rule(None)],
+        )
+        .await;
+        let report = degraded.run_tick().await;
+
+        assert!(
+            !report.lease_not_held && !report.lease_unavailable,
+            "the degraded evaluator must actually reach rule evaluation, or every \
+             assertion below is vacuous: {report:?}"
+        );
+        assert_eq!(
+            report.rules_failed, 1,
+            "partial coverage must take the per-rule failure path"
+        );
+        assert_eq!(
+            report.rules_evaluated, 0,
+            "a rule that could not be evaluated is not counted as evaluated"
+        );
+        assert_eq!(
+            report.records_written, 0,
+            "no transition record may be written from partial data"
+        );
+        assert!(!report.history_unavailable, "history read fine");
+
+        let after = read_alert_records(store.as_ref(), tenant).await;
+        assert_eq!(
+            after.len(),
+            1,
+            "the alerts keyspace must be byte-for-byte unchanged: {after:?}"
+        );
+        assert_eq!(
+            after[0].state,
+            AlertState::Firing,
+            "prior Firing state must survive the partial tick untouched"
+        );
+        assert_eq!(after[0].ts_ns, before[0].ts_ns);
+        assert_eq!(after[0].alert_id, before[0].alert_id);
+        assert_eq!(
+            alert_object_count(store.as_ref(), tenant).await,
+            1,
+            "not even an uncommitted orphan object may be written"
+        );
+    }
+
+    // --- Prior state Resolved -----------------------------------------------
+    {
+        // Two samples in one segment: the first fires the first tick, the second
+        // is above threshold again once the clock reaches it. Between them the
+        // series goes stale, which is what resolves the alert.
+        let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+        let tenant_id = TenantId::new(TENANT);
+        publish_metric(
+            store.as_ref(),
+            &tenant_id,
+            &[
+                (NOW_NS - 30 * NS_PER_SEC, 1.0),
+                (NOW_NS + 870 * NS_PER_SEC, 1.0),
+            ],
+        )
+        .await;
+
+        let clock = TestClock::at(NOW_NS);
+        {
+            let mut healthy = evaluator(
+                Arc::clone(&store),
+                clock.clone(),
+                vec![threshold_rule(None)],
+                Vec::new(),
+            );
+            assert_eq!(healthy.run_tick().await.records_written, 1, "fires");
+            // Ten minutes on: the first sample is outside the lookback window and
+            // the second is still in the future, so the alert resolves.
+            clock.advance(Duration::from_secs(600));
+            assert_eq!(healthy.run_tick().await.records_written, 1, "resolves");
+        }
+        let before = read_alert_records(store.as_ref(), tenant).await;
+        assert_eq!(before.len(), 2);
+        assert_eq!(before[1].state, AlertState::Resolved);
+
+        // Five minutes more brings the second sample inside the lookback window,
+        // so the local-only answer is above threshold: an evaluator that ignored
+        // coverage would fire the alert again here. Five and not one, because the
+        // healthy evaluator above holds the tenant alert lease for three
+        // evaluation intervals (180s at the default): a shorter gap would leave
+        // the degraded evaluator locked out and skipping rules for a reason that
+        // has nothing to do with coverage, making every assertion below vacuous.
+        clock.advance(Duration::from_secs(300));
+        let mut degraded = evaluator_with_dead_remote(
+            Arc::clone(&store),
+            clock.clone(),
+            vec![threshold_rule(None)],
+        )
+        .await;
+        let report = degraded.run_tick().await;
+
+        assert!(
+            !report.lease_not_held && !report.lease_unavailable,
+            "the degraded evaluator must actually reach rule evaluation, or every \
+             assertion below is vacuous: {report:?}"
+        );
+        assert_eq!(
+            report.rules_failed, 1,
+            "partial coverage must take the per-rule failure path"
+        );
+        assert_eq!(report.rules_evaluated, 0);
+        assert_eq!(
+            report.records_written, 0,
+            "no transition record may be written from partial data"
+        );
+
+        let after = read_alert_records(store.as_ref(), tenant).await;
+        assert_eq!(
+            after.len(),
+            2,
+            "the alerts keyspace must be unchanged: {after:?}"
+        );
+        assert_eq!(
+            after[1].state,
+            AlertState::Resolved,
+            "prior Resolved state must survive the partial tick untouched"
+        );
+        assert_eq!(after[1].ts_ns, before[1].ts_ns);
+        assert_eq!(alert_object_count(store.as_ref(), tenant).await, 2);
+    }
 }

--- a/services/ravel-server/tests/reshard_e2e.rs
+++ b/services/ravel-server/tests/reshard_e2e.rs
@@ -273,10 +273,11 @@ async fn instant(
     min_tokens: &[CommitToken],
     now_ns: i64,
 ) -> Value {
-    engine
+    let (value, _coverage) = engine
         .instant(tenant_hash(), query, t_ms, min_tokens, now_ns, ACK)
         .await
-        .expect("instant query succeeds")
+        .expect("instant query succeeds");
+    value
 }
 
 /// A range query over `[start_ms, end_ms]` at `step_ms`. Used for the
@@ -292,7 +293,7 @@ async fn range(
     step_ms: i64,
     now_ns: i64,
 ) -> Value {
-    engine
+    let (value, _coverage) = engine
         .range(
             tenant_hash(),
             query,
@@ -304,7 +305,8 @@ async fn range(
             ACK,
         )
         .await
-        .expect("range query succeeds")
+        .expect("range query succeeds");
+    value
 }
 
 /// `(metric_name, value)` pairs of an instant vector; exact `f64` values.


### PR DESCRIPTION
The query engine's instant/range/resolve_series wrappers discarded
whether a federated result was partial. The only production caller
that bypasses the HTTP consent gate, the alert evaluator, had no way
to see that a rule's query ran over incomplete data. A rule could
observe no data for a series that only lived on an unreachable remote
and fire a false resolve, which is confident silence during an
outage.

instant/range/resolve_series now return their value paired with
Coverage, derived the same way their _with_stats siblings already do.
The alert evaluator refuses to evaluate a rule over Coverage::Partial:
it logs, counts the failure, keeps the rule's prior state, and writes
no transition record, so a firing alert keeps paging and a resolved
one stays resolved until coverage is complete again.

Refs: #260
