### PR TITLE
feat(analytics): gate partial federated coverage behind allow_partial

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -220,6 +220,7 @@ endpoints):
 | `op` | object | The analytic to apply (tagged; see below). |
 | `timeout` | number, optional | Wall deadline in seconds; clamped to the server maximum, can only lower it. |
 | `min_commit_token` | array of string, optional | Read-your-write commit tokens. |
+| `allow_partial` | bool, optional | Consent to a partial federated answer; default `false`. See "Partial federated coverage" below. |
 
 `start`, `end`, and `step` accept the identical syntax `/api/v1/query_range`
 accepts. A JSON number is accepted wherever a bare-seconds string would be, so
@@ -256,7 +257,9 @@ the evaluated matrix:
        "result": { ... op result ... }}
     ]
   },
-  "stats": { "accounting": { ... }, "estimate": { ... } }
+  "stats": { "accounting": { ... }, "estimate": { ... } },
+  "partial": false,
+  "warnings": []
 }
 ```
 
@@ -268,6 +271,23 @@ serde). Fields are snake_case.
 on object storage, and the pre-execution upper envelope of that spend
 (ADR-0044). docs/guides/operations.md, section "Per-query cost accounting",
 gives the field list.
+
+`partial` and `warnings` sit beside `data` too, on every response, complete
+or not. `partial` is `true` only when the query federated across a remote
+that `skip_unavailable` let it skip; `warnings` names which one. See
+"Partial federated coverage" below.
+
+### Partial federated coverage
+
+A federated query (ADR-0071) can skip an unreachable remote when that
+remote's `skip_unavailable` opt-in is set. By default the analytics
+endpoint refuses to hand back an answer built on incomplete coverage: it
+fails with a `503`/`unavailable` naming the degraded cluster, and names
+`allow_partial` as the remedy in the message itself. Setting
+`allow_partial: true` in the request body opts in; the response is then a
+normal `200` with `partial: true` and `warnings` naming the skipped
+cluster(s). This mirrors the consent gate `/api/v1/query` and
+`/api/v1/query_range` apply to the same situation.
 
 `change_point` result:
 
@@ -349,6 +369,7 @@ mappings:
 | `AnalyticsError::EmptySeries` | 422 | `execution` |
 | Query deadline exceeded | 504 | `timeout` |
 | Transient storage fault, unsatisfiable commit token | 503 | `unavailable` |
+| Partial federated coverage without `allow_partial: true` | 503 | `unavailable` |
 | Permanent data corruption | 500 | `internal` |
 
 `AnalyticsError` messages carry only the caller's own parameters (a

--- a/services/ravel-server/src/analytics.rs
+++ b/services/ravel-server/src/analytics.rs
@@ -34,6 +34,14 @@
 //! raise it, and the optional `min_commit_token` array carries read-your-write
 //! tokens, both exactly as the range endpoint treats them.
 //!
+//! The optional `allow_partial` (bool, default `false`) is the consent gate for
+//! partial federated coverage (ADR-0071, "partial results are consent-gated and
+//! envelope-visible" amendment, section 2). Absent or `false`, a request whose
+//! evaluation skipped a federated remote is refused with a 503 rather than
+//! answered from an incomplete read; `true` accepts the partial answer, which
+//! the response envelope then states. It is a body field, not a query-string
+//! parameter, because this endpoint's whole request contract is the JSON body.
+//!
 //! `op` is a tagged object selecting one analytic:
 //!
 //! - `{"type": "change_point", "downsample": <bool, default false>}`
@@ -57,9 +65,17 @@
 //!                   "score": 42.1, "downsampled": false,
 //!                   "original_points": 120, "nan_excluded": 0}}
 //!     ]
-//!   }
+//!   },
+//!   "partial": false,
+//!   "warnings": []
 //! }
 //! ```
+//!
+//! `partial` and `warnings` are the ADR-0071 coverage surface: `partial` is
+//! always present and is `true` exactly when the evaluation skipped a federated
+//! remote (which requires `allow_partial: true`, see above), and `warnings`
+//! carries the fan-out's already-redacted per-cluster warnings, empty on a
+//! complete answer.
 //!
 //! The op result is serialized through the server-local serde structs at the
 //! bottom of this module; `ravel-analytics` carries no serde derive (ADR-0028
@@ -70,7 +86,9 @@
 //! Evaluator errors keep the exact status mapping `/api/v1/query_range` uses,
 //! including the redaction of storage-layer faults that would otherwise
 //! leak an object key or tenant hash. `ravel-analytics` errors and the
-//! per-call series cap map to 422. The full table is in docs/analytics.md.
+//! per-call series cap map to 422. Partial coverage without `allow_partial`
+//! maps to 503 `unavailable`, the same typed shape the HTTP query endpoints
+//! use. The full table is in docs/analytics.md.
 
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -89,7 +107,7 @@ use ravel_ingest::Clock;
 use ravel_maintain::{QueryAuditSink, QueryStatus, query_audit_event};
 use ravel_promql::Value;
 use ravel_query::http::{QueryErrorResponse, TenantResolver};
-use ravel_query::{QueryEngine, QueryError};
+use ravel_query::{Coverage, QueryEngine, QueryError};
 use ravel_types::{CommitToken, LabelSet, Sample, TenantHash};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -163,6 +181,14 @@ struct AnalyticsBody {
     /// them.
     #[serde(default)]
     min_commit_token: Vec<String>,
+    /// Consent to a partial federated answer (ADR-0071 amendment, section 2).
+    /// `serde(default)`, so an absent field means `false`: a client that never
+    /// asked for partial coverage gets a 503 refusal instead of an incomplete
+    /// answer that looks complete. Mirrors the `allow_partial` query-string
+    /// parameter the HTTP query endpoints take, carried in the body because
+    /// this endpoint's request contract is the body.
+    #[serde(default)]
+    allow_partial: bool,
 }
 
 /// The tagged analytic selector. `rename_all = "snake_case"` makes the tag
@@ -288,6 +314,16 @@ async fn run(state: &AnalyticsState, req: Request<Body>) -> Result<Response, Api
     .await?;
     let (value, stats) = eval.map_err(ApiError::from_query)?;
 
+    // Consent gate (ADR-0071 "partial results are consent-gated and
+    // envelope-visible" amendment, section 2): the evaluation ran and was
+    // audited, but a partial answer the client did not opt into is refused with
+    // the typed 503 the HTTP query endpoints use, before any op runs and before
+    // any body is built. Coverage is knowable only now, and it is derived from
+    // the stats the engine already produced rather than newly tracked
+    // (amendment decision 4).
+    let coverage = Coverage::from_stats(&stats);
+    gate_partial(&coverage, body.allow_partial)?;
+
     // Fold this query's actual cost and its pre-execution estimate into the
     // process-global aggregator for `/metrics` (ADR-0044 section 4) and record
     // the final counts on the span.
@@ -345,9 +381,32 @@ async fn run(state: &AnalyticsState, req: Request<Body>) -> Result<Response, Api
             // Beside `data`, the "stats object beside data" shape
             // `/api/v1/query_exemplars` uses (ADR-0044).
             "stats": stats_json,
+            // The coverage of the answer, stated on the envelope where a naive
+            // consumer cannot miss it (ADR-0071 amendment, section 2): `partial`
+            // is always present, and `warnings` carries the federation
+            // fan-out's already-redacted per-cluster warnings (empty on a
+            // complete answer). Reaching here with `partial: true` means the
+            // request opted in through `allow_partial`.
+            "partial": coverage.is_partial(),
+            "warnings": stats.warnings,
         })),
     )
         .into_response())
+}
+
+/// The consent gate, the analytics mirror of `gate_partial` in
+/// `crates/ravel-query/src/http/handlers.rs` (ADR-0071 amendment, section 2).
+/// Partial coverage the client did not opt into fails with the same typed shape
+/// the HTTP query endpoints use, HTTP 503 with `errorType: "unavailable"`, so a
+/// consumer that never asked for a partial answer fails safe instead of
+/// silently accepting one. Complete coverage, or partial coverage with
+/// `allow_partial: true`, passes and the response is a 200 whose top-level
+/// `partial` field states the coverage.
+fn gate_partial(coverage: &Coverage, allow_partial: bool) -> Result<(), ApiError> {
+    if coverage.is_partial() && !allow_partial {
+        return Err(ApiError::partial_refusal(coverage.skipped()));
+    }
+    Ok(())
 }
 
 /// Apply the selected op to every series, converting each crate result into
@@ -546,6 +605,31 @@ impl ApiError {
             error_type: "execution",
             message: format!(
                 "analytics call matched {count} series, exceeding the limit of {MAX_SERIES}"
+            ),
+        }
+    }
+
+    /// Partial coverage without `allow_partial` (ADR-0071 amendment, section
+    /// 2). The status, the `errorType` tag, and the message shape are the ones
+    /// `ApiError::Unavailable` and `partial_refusal_message` produce on the HTTP
+    /// query endpoints (`crates/ravel-query/src/http/error.rs`,
+    /// `handlers.rs`), reproduced here because both are private to that crate;
+    /// the wording is kept identical so one refusal contract covers every read
+    /// surface. `skipped` names the degraded clusters, already redacted at the
+    /// federation seam to operator-facing cluster names, and the remedy
+    /// (`allow_partial`) is named in the failure itself.
+    fn partial_refusal(skipped: &[String]) -> Self {
+        let clusters = if skipped.is_empty() {
+            "one or more federated clusters were skipped".to_string()
+        } else {
+            skipped.join("; ")
+        };
+        ApiError {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            error_type: "unavailable",
+            message: format!(
+                "partial results: coverage is incomplete ({clusters}); \
+                 set allow_partial=true to receive partial results"
             ),
         }
     }
@@ -847,5 +931,33 @@ mod tests {
         let unavailable = ApiError::from_query(QueryError::SnapshotInvalidated);
         assert_eq!(unavailable.status, StatusCode::SERVICE_UNAVAILABLE);
         assert_eq!(unavailable.message, ravel_query::http::MSG_UNAVAILABLE);
+    }
+
+    /// The consent gate's decision table (ADR-0071 amendment, section 2). The
+    /// end-to-end behavior is pinned through the real handler in
+    /// `tests/analytics_endpoint.rs`; this pins the branch table itself,
+    /// including the empty-`skipped` fallback a partial flag with no per-cluster
+    /// warning would take.
+    #[test]
+    fn the_consent_gate_refuses_only_unconsented_partial_coverage() {
+        let partial = Coverage::Partial {
+            skipped: vec!["remote cluster west unavailable".to_string()],
+        };
+        gate_partial(&Coverage::Complete, false).expect("complete coverage passes");
+        gate_partial(&Coverage::Complete, true).expect("complete coverage passes opted in");
+        gate_partial(&partial, true).expect("opted-in partial coverage passes");
+
+        let err = gate_partial(&partial, false).expect_err("unconsented partial is refused");
+        assert_eq!(err.status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(err.error_type, "unavailable");
+        assert!(err.message.contains("west"), "{}", err.message);
+        assert!(err.message.contains("allow_partial"), "{}", err.message);
+
+        let bare = ApiError::partial_refusal(&[]);
+        assert!(
+            bare.message.contains("one or more federated clusters"),
+            "{}",
+            bare.message
+        );
     }
 }

--- a/services/ravel-server/tests/analytics_endpoint.rs
+++ b/services/ravel-server/tests/analytics_endpoint.rs
@@ -11,6 +11,7 @@
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use async_trait::async_trait;
 use axum::Router;
@@ -791,4 +792,262 @@ async fn analytics_submits_one_audit_event_per_executed_query() {
         audit_attr(event, "query.tenant"),
         Some(tenant.hash().to_hex().as_str())
     );
+}
+
+// ---------------------------------------------------------------------------
+// ADR-0071 partial-coverage consent gate ("partial results are consent-gated
+// and envelope-visible" amendment, section 2: the analytics endpoint bypasses
+// the HTTP query endpoints' gate, so it carries its own).
+// ---------------------------------------------------------------------------
+
+/// The degraded cluster the gate tests federate to. It must appear in both the
+/// refusal message and the opted-in response's `warnings`.
+const DEAD_CLUSTER: &str = "west";
+const GATE_OPERATOR_CRED: &str = "operator-west-credential";
+
+/// An address bound then immediately released: a connection to it is refused,
+/// so a remote pointed here is unavailable at query time (the same technique
+/// `federation_handler_warnings.rs` uses).
+async fn dead_endpoint() -> String {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind dead");
+    let addr = listener.local_addr().expect("dead local addr");
+    drop(listener);
+    addr.to_string()
+}
+
+/// A `Federation` over one unavailable remote cluster that opted into
+/// `skip_unavailable`, dialed by the production `FederationSliceFetcher`
+/// exactly as `--remote-cluster` wires it. The fan-out skips it and records a
+/// partial-coverage warning naming the cluster, which is the only way this
+/// endpoint can observe partial coverage at all (intra-cluster execution never
+/// returns partial results).
+fn dead_federation(name: &str, endpoint: &str) -> ravel_query::distrib::Federation {
+    use ravel_query::distrib::{Federation, RemoteCluster};
+    use ravel_server::config::RemoteClusterConfig;
+
+    let config = RemoteClusterConfig {
+        name: name.to_string(),
+        endpoint: endpoint.to_string(),
+        credential: GATE_OPERATOR_CRED.to_string(),
+        tls: false,
+        tls_ca_file: None,
+        skip_unavailable: true,
+        soft_timeout: Duration::from_secs(3),
+    };
+    let fetcher = ravel_server::distrib::FederationSliceFetcher::connect(&config)
+        .expect("federation client connects lazily");
+    Federation::new(vec![RemoteCluster {
+        name: name.to_string(),
+        fetcher: Arc::new(fetcher),
+        skip_unavailable: true,
+        soft_timeout: Duration::from_secs(3),
+    }])
+}
+
+/// The analytics router over a local store holding `samples`, with a federation
+/// attached over one dead, skippable remote, so every evaluation this router
+/// runs has partial coverage.
+async fn federated_app(metric: &str, samples: &[(i64, f64)]) -> Router {
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+    let tenant = TenantId::new("acme".to_string());
+    publish(
+        store.as_ref(),
+        &tenant,
+        0,
+        vec![one_series(&tenant, metric, samples)],
+    )
+    .await;
+    let catalog =
+        Arc::new(Catalog::new(Arc::clone(&store), CatalogConfig::default()).expect("catalog"));
+    let federation = Arc::new(dead_federation(DEAD_CLUSTER, &dead_endpoint().await));
+    let engine =
+        QueryEngine::new(catalog, store, EngineConfig::default()).with_federation(federation);
+    router(AnalyticsState {
+        engine: Arc::new(engine),
+        tenant_resolver: Arc::new(StaticBearerTokenResolver::new(tokens(&[(
+            "acme-token",
+            "acme",
+        )]))),
+        clock: Arc::new(FixedClock),
+        query_accounting: Arc::new(ravel_server::metrics::QueryAccountingMetrics::new(
+            std::collections::HashSet::new(),
+        )),
+        audit_sink: Arc::new(ravel_maintain::NoopQueryAuditSink),
+    })
+}
+
+/// A `summary` request over the whole ingested window. `allow_partial` is
+/// omitted entirely when `allow_partial` is `None`, which is the "client never
+/// asked" case the gate must refuse.
+fn gate_body(metric: &str, end_sec: f64, allow_partial: Option<bool>) -> String {
+    let mut body = serde_json::json!({
+        "query": metric,
+        "start": 0.0,
+        "end": end_sec,
+        "step": "10s",
+        "op": {"type": "summary", "percentiles": [0.5]},
+    });
+    if let Some(allow) = allow_partial {
+        body["allow_partial"] = serde_json::json!(allow);
+    }
+    body.to_string()
+}
+
+/// Samples for the gate tests: a plain 10-second grid, enough points for
+/// `summary` to be meaningful and few enough to keep the run cheap.
+fn gate_samples() -> (Vec<(i64, f64)>, f64) {
+    let values: Vec<f64> = (0..12).map(|i| 10.0 + i as f64).collect();
+    grid_samples(10 * NS_PER_SEC, &values)
+}
+
+/// Acceptance 1: partial coverage with no `allow_partial` in the body is
+/// refused with the typed 503 the HTTP query endpoints use, and the refusal
+/// names both the degraded cluster and the remedy.
+///
+/// Flip-line proof (prove-the-test evidence): delete the
+/// `gate_partial(&coverage, body.allow_partial)?;` line in
+/// `services/ravel-server/src/analytics.rs::run` (the line right after
+/// `let coverage = Coverage::from_stats(&stats);`). Without it the request is a
+/// 200 carrying an answer that silently omits the skipped cluster's data, and
+/// the `SERVICE_UNAVAILABLE` assertion below fails. Verified failing against
+/// the pre-change handler, which had no gate at all.
+#[tokio::test]
+async fn partial_coverage_without_consent_is_refused() {
+    let (samples, end_sec) = gate_samples();
+    let app = federated_app("gate_metric", &samples).await;
+
+    let (status, value) =
+        post_json(&app, "acme-token", gate_body("gate_metric", end_sec, None)).await;
+
+    assert_eq!(
+        status,
+        StatusCode::SERVICE_UNAVAILABLE,
+        "partial coverage the client did not opt into must be refused: {value}"
+    );
+    assert_eq!(value["status"], "error", "{value}");
+    assert_eq!(value["errorType"], "unavailable", "{value}");
+    let message = value["error"]
+        .as_str()
+        .unwrap_or_else(|| panic!("the refusal must carry an error message: {value}"));
+    assert!(
+        message.contains(DEAD_CLUSTER),
+        "the refusal must name the degraded cluster: {message:?}"
+    );
+    assert!(
+        message.contains("allow_partial"),
+        "the refusal must name the remedy: {message:?}"
+    );
+}
+
+/// Acceptance 2: the same partial evaluation with `allow_partial: true` is a
+/// 200 whose envelope states the coverage: top-level `partial` is `true` and
+/// top-level `warnings` names the skipped cluster.
+///
+/// Flip-line proof: delete the `"partial": coverage.is_partial(),` and
+/// `"warnings": stats.warnings,` entries from the `json!` response envelope in
+/// `services/ravel-server/src/analytics.rs::run`. Both assertions below then
+/// fail (the fields read as JSON null), while the request still returns 200 --
+/// exactly the "a partial answer is indistinguishable from a complete one"
+/// defect this pins. Verified failing against the pre-change handler, whose
+/// envelope carried only `status`/`data`/`stats`.
+#[tokio::test]
+async fn partial_coverage_with_consent_is_reported_on_the_envelope() {
+    let (samples, end_sec) = gate_samples();
+    let app = federated_app("gate_metric", &samples).await;
+
+    let (status, value) = post_json(
+        &app,
+        "acme-token",
+        gate_body("gate_metric", end_sec, Some(true)),
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "opted-in partial must succeed: {value}"
+    );
+    assert_eq!(
+        value["partial"],
+        serde_json::json!(true),
+        "the envelope's top-level partial field must state the coverage: {value}"
+    );
+    let warnings = value["warnings"]
+        .as_array()
+        .unwrap_or_else(|| panic!("the envelope must carry a warnings array: {value}"));
+    assert!(
+        !warnings.is_empty(),
+        "a skipped remote must produce at least one warning: {value}"
+    );
+    assert!(
+        warnings.iter().any(|w| w
+            .as_str()
+            .map(|s| s.contains(DEAD_CLUSTER))
+            .unwrap_or(false)),
+        "the skipped cluster must be named in the warnings: {warnings:?}"
+    );
+    // The op still ran over the coverage that was available.
+    assert_eq!(value["data"]["resultType"], "analytics", "{value}");
+    assert!(
+        value["data"]["result"].as_array().is_some(),
+        "the partial answer still carries its result array: {value}"
+    );
+}
+
+/// Acceptance 3: complete coverage is a 200 with `partial: false` and no
+/// warnings, with or without the opt-in, and the rest of the envelope is
+/// unchanged (`data` and `stats` still present and shaped as before).
+#[tokio::test]
+async fn complete_coverage_reports_not_partial_either_way() {
+    let (samples, end_sec) = gate_samples();
+
+    for allow_partial in [None, Some(false), Some(true)] {
+        let app = single_series_app("gate_metric", &samples).await;
+        let (status, value) = post_json(
+            &app,
+            "acme-token",
+            gate_body("gate_metric", end_sec, allow_partial),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK, "{allow_partial:?}: {value}");
+        assert_eq!(
+            value["partial"],
+            serde_json::json!(false),
+            "complete coverage must report partial=false ({allow_partial:?}): {value}"
+        );
+        assert_eq!(
+            value["warnings"],
+            serde_json::json!([]),
+            "complete coverage carries no warnings ({allow_partial:?}): {value}"
+        );
+
+        // The pre-existing envelope, unchanged: status, the analytics data
+        // block with one entry per series, and the accounting stats block.
+        assert_eq!(value["status"], "success", "{value}");
+        assert_eq!(value["data"]["resultType"], "analytics", "{value}");
+        let result = value["data"]["result"]
+            .as_array()
+            .unwrap_or_else(|| panic!("data.result must be an array: {value}"));
+        assert_eq!(
+            result.len(),
+            1,
+            "one entry for the one ingested series: {value}"
+        );
+        assert_eq!(result[0]["metric"]["__name__"], "gate_metric", "{value}");
+        assert!(
+            result[0]["result"]["median"].is_f64(),
+            "the summary op result is unchanged: {value}"
+        );
+        assert!(
+            value["stats"]["accounting"].is_object(),
+            "the stats block still carries accounting: {value}"
+        );
+        assert!(
+            value["stats"]["estimate"].is_object(),
+            "the stats block still carries the estimate: {value}"
+        );
+    }
 }


### PR DESCRIPTION
The analytics endpoint reaches the query engine directly, bypassing the
HTTP query surface's partial-coverage consent gate. A federated answer
that skipped an unavailable remote returned 200 with no way for a caller
to tell it apart from a complete one.

AnalyticsBody gains allow_partial (default false). Partial coverage
without it fails with the same typed 503 the query endpoints use,
naming the degraded cluster and the allow_partial remedy. An opted-in
partial response, and every complete response, now carries top-level
partial and warnings fields the envelope previously dropped.

Refs: #261
