### PR TITLE
docs(adrs): claim ADR-0087, ADR-0088, ADR-0089

### DIFF
--- a/docs/adrs/0087-streaming-projected-logs-scan.md
+++ b/docs/adrs/0087-streaming-projected-logs-scan.md
@@ -1,0 +1,3 @@
+# ADR-0087: streaming, column-projecting logs SQL scan
+
+Status: claimed

--- a/docs/adrs/0088-operator-configurable-query-budgets.md
+++ b/docs/adrs/0088-operator-configurable-query-budgets.md
@@ -1,0 +1,3 @@
+# ADR-0088: operator-configurable query budgets
+
+Status: claimed

--- a/docs/adrs/0089-bulk-import-logs-signal.md
+++ b/docs/adrs/0089-bulk-import-logs-signal.md
@@ -1,0 +1,3 @@
+# ADR-0089: bulk import of structured event data into the logs signal
+
+Status: claimed


### PR DESCRIPTION
Reserves the next three ADR numbers for the streaming logs scan, query budgets, and bulk import epics ahead of the design work.

Refs: #279
Refs: #276
Refs: #275