### PR TITLE
docs(adrs): write ADR-0087, ADR-0088, ADR-0089

### DIFF
--- a/docs/adrs/0087-streaming-projected-logs-scan.md
+++ b/docs/adrs/0087-streaming-projected-logs-scan.md
@@ -1,3 +1,166 @@
 # ADR-0087: streaming, column-projecting logs SQL scan
 
-Status: claimed
+Status: Proposed
+
+## Context
+
+The logs SQL scan (`crates/ravel-sql/src/logs_scan.rs`) reads a query
+partition by decoding every RLOG block in full, rebuilding each record in
+row form (`Vec<(String, AttrValue)>` per record), collecting the whole
+partition into one `Vec<LogRecord>`, sorting it by `ts`, then emitting it
+in fixed 8192-row batches (`BATCH_ROWS`). `crates/ravel-logseg/src/block.rs`
+`read_block` decodes every page of every column in a block regardless of
+which columns the query references; there is no column-set parameter on
+the read path. The per-query memory reservation (`try_grow` on each
+emitted batch, `logs_scan.rs`) only grows over the life of the query and
+is freed once on drop: it tracks cumulative Arrow bytes emitted, not
+bytes currently resident, so it bounds throughput, not memory pressure.
+The row-form `Vec<LogRecord>` collected before emission is never charged
+against this reservation at all — it is invisible to the DataFusion
+memory pool regardless of which bound is used.
+
+At roughly 100 dynamic attributes per record this is several KB of
+row-form memory per record before any Arrow array exists. Because
+projection is applied *above* the scan today (a `ProjectionExec` that
+drops unwanted columns after the scan has already produced them,
+`crates/ravel-sql/src/logs_provider.rs`), even `COUNT(*)` receives every
+column from the scan; at ~100 attributes per row the emitted `attrs` Map
+arrays alone cross the default 256 MiB SQL pool well under 100,000 rows,
+long before any aggregate state is built. Raising the pool ceiling does
+not fix this: the collect-then-emit design keeps growing the *emitted*
+charge without bound as more rows are scanned, and the row-form
+collection stage that precedes it is not charged at all, so no pool
+setting makes a full-table scan of a large logs table complete.
+
+A second, load-bearing fact this ADR must not lose: the scan declares a
+per-partition `ts` ascending ordering through `PlanProperties`
+(`logs_scan.rs`, doc comment: "Declaring `ts` ascending is therefore
+truthful for the stream this stage produces"), and earns that truth by
+sorting the *entire collected partition* before emitting it — `RlogReader`
+itself only emits a segment's records grouped by `(stream_ref, ts)`, not
+globally by `ts`, and a partition spans several segments. Any change that
+streams blocks out one at a time without also buffering across the whole
+partition breaks that sort silently: DataFusion trusts the declared
+ordering downstream (`ORDER BY ts`, a sort-preserving merge) and would
+produce wrong results with no error, not a slower correct one.
+
+## Decision
+
+Three changes, delivered together because a correct fix to one requires
+the other two:
+
+1. **Drop the per-partition global `ts` ordering guarantee from
+   `PlanProperties`.** A block-streaming scan can only guarantee the order
+   `RlogReader` already produces — grouped by `(stream_ref, ts)` within
+   each block, not globally ascending across a partition. `ORDER BY ts`
+   queries get their ordering from an explicit sort operator above the
+   scan instead of a leaf-level guarantee. This is the correctness
+   prerequisite for streaming at all; everything below assumes it.
+2. **Live memory reservation.** The reservation is grown when a block's
+   decoded columns and the row-form records built from them are held, and
+   shrunk when that block's data is no longer needed (its rows have been
+   emitted downstream or discarded by predicate evaluation). It charges
+   what streaming decode actually holds at a point in time — one block's
+   worth of buffered data plus the batch under construction — not
+   cumulative output. The pool (256 MiB, or operator-configured per
+   ADR-0088) now bounds concurrently-held scan memory, which is what an
+   operator sizing a host needs it to bound.
+3. **Column projection into the reader.** The projected column set is
+   defined as: the fixed columns always needed (`stream_ref`, `ts`), the
+   schema columns DataFusion's `ProjectionExec` requests, every field
+   named by a pushed content predicate (`LogQuery.content`, evaluated
+   exactly per row in `RlogReader::eval`), and every attribute key named
+   by a pending erasure predicate (record-level in the fetcher, merged
+   resource/scope/record level at the scan's `retain_unerased`, ADR-0064
+   — both must see the columns they filter on). Because the SQL schema
+   exposes attributes as a single `attrs` Map column (ADR-0033), any
+   query that references `attrs` at all — including `SELECT *` — is
+   treated as referencing every dynamic column plus the `attrs_raw`
+   overflow column; per-key projection through `attrs['k']` expressions
+   is out of scope for this ADR and left for the typed-attribute-columns
+   epic. `read_block` decompresses and decodes only pages for the
+   resolved column set; skip-index and bloom evaluation, which already
+   operate on stored statistics rather than decoded pages, are unchanged.
+   Whole-object GET is retained; `RlogRangeReader` (`ravel-logseg::ranged`)
+   already exists for per-stream block-range reads and is the natural
+   target for a later range-read change, out of scope here.
+
+This touches three crates, not one file: `ravel-logseg` (`read_block`'s
+signature, and its other callers — `RlogReader::scan_pruned` and the
+ranged reader used by `ravel-maintain` compaction, both of which must stay
+byte-identical when no column filter is supplied), `ravel-query`
+(`LogSegmentFetcher`, which returns the collected `Vec<LogRecord>` today
+and must support a streaming/callback mode), and `ravel-sql` (the scan
+executor itself).
+
+```mermaid
+flowchart LR
+    subgraph before["today"]
+        B1[RLOG block] --> D1[decode ALL column pages]
+        D1 --> R1[rebuild full LogRecord per row]
+        R1 --> C1[collect + sort WHOLE partition into Vec]
+        C1 --> E1[emit 8192-row batches]
+        E1 -.pool charged per batch, never shrunk.-> P1[(memory pool)]
+        C1 -.never charged.-> Unch[(row-form Vec: invisible to pool)]
+    end
+    subgraph after["this ADR"]
+        B2[RLOG block] --> D2[decode ONLY resolved column pages]
+        D2 --> Chg[reservation grows: block held]
+        Chg --> R2[build partial records: resolved columns]
+        R2 --> E2[emit batch]
+        E2 --> Rel[block's rows emitted: reservation shrinks]
+        Rel --> B2
+        Note[per-partition ts ordering NOT declared;<br/>ORDER BY ts sorts explicitly above the scan]
+    end
+```
+
+## Rejected alternatives
+
+- **Raise the pool ceiling instead of changing the reservation model.**
+  Rejected: the row-form collection stage is never charged against any
+  pool setting, so no ceiling fixes the failure mode; it only postpones
+  it to a larger table while leaving the actual resident memory
+  unaccounted for.
+- **Column projection only, reservation semantics unchanged.** Rejected:
+  a cumulative-emitted reservation still charges for the whole table's
+  worth of output on a full scan regardless of how narrow each batch is,
+  so a `COUNT(*)` at large row counts still exhausts the pool for a
+  reason unrelated to what memory is actually held at any instant.
+- **Keep the per-partition `ts` ordering by buffering the whole partition
+  before emitting (stream only the block-decode step).** Rejected: this
+  keeps peak memory proportional to partition size rather than block
+  size, which is the exact problem this ADR exists to remove; a partition
+  spanning a large `logs` table is no better bounded than today.
+- **Larger fixed batch size / fewer batches.** Does not change the
+  underlying charge-what-you-emit-forever model; only shifts where the
+  ceiling is hit.
+
+## Consequences
+
+- Dropping the leaf-level `ts` ordering guarantee is a plan-shape change:
+  any downstream operator relying on a sort-preserving merge over logs
+  scan partitions now needs an explicit sort. A test must assert
+  `ORDER BY ts` still returns correctly sorted results (via the added
+  sort, not the removed leaf guarantee) — this is the must-not-regress
+  case for this ADR.
+- `docs/query-engine.md` and `docs/guides/query.md` ("Query budgets"
+  section) gain the corrected description of what the SQL pool bounds:
+  concurrently-held scan memory, not cumulative query output. (Not
+  `docs/guides/caching.md` — that page's 256 MiB figure is
+  `--cache-max-bytes`, the unrelated read cache.)
+- A new bounded-memory test: a fixture large enough that the *cumulative*
+  emitted-bytes charge would exceed a small pool (e.g. 8 MiB) by an order
+  of magnitude, with a full-table `COUNT(*)` and a `GROUP BY` completing
+  within that pool — proving peak memory tracks live block/batch state,
+  not total rows scanned.
+- No format change: RLOG's on-disk layout, FIELD_DIR, and page structure
+  are untouched. This is a read-path change only, but it is not confined
+  to `ravel-sql`; `ravel-logseg` and `ravel-query` callers listed above
+  must be updated in the same change and their existing differential
+  tests (including `ravel-maintain` compaction, which uses the ranged
+  reader) must still pass unmodified when no column filter is supplied.
+- Scan fan-out (`target_partitions`) versus S3 GET concurrency
+  (`fetch_concurrency`) are the same knob today
+  (`crates/ravel-sql/src/session.rs`); this ADR does not decouple them.
+  ADR-0088 exposes `--fetch-concurrency` as the single flag governing
+  both; a future decoupling is a separate decision, not implied here.

--- a/docs/adrs/0088-operator-configurable-query-budgets.md
+++ b/docs/adrs/0088-operator-configurable-query-budgets.md
@@ -1,3 +1,129 @@
 # ADR-0088: operator-configurable query budgets
 
-Status: claimed
+Status: Proposed
+
+## Context
+
+Several budgets that decide whether a large analytical query completes
+are compiled in with no flag: the SQL per-query memory pool (256 MiB,
+`crates/ravel-sql/src/config.rs`, its own comment calls it "a placeholder
+pending measurement"), the per-tenant SQL ceiling (1 GiB,
+`services/ravel-server/src/query.rs`), `fetch_concurrency` (8,
+`crates/ravel-query/src/config.rs`), and `max_segments` (1024). Flags
+already exist for the engine deadline (`--gc-max-query-duration`) and
+`--max-s3-requests`; `max_bytes_scanned` is not a flag today — it comes
+from the `--limits-file` TOML's `query_defaults.max_bytes_scanned`
+(default Unlimited). Nothing threads the compiled-in values into
+`EngineConfig`/`SqlConfig` except the ones the server already overrides.
+
+`max_segments` needs correcting from an earlier draft of this ADR: it is
+not exempt for "fresh or lightly-compacted tables" in general.
+`SegmentOrigin::Recent` is a narrow exemption — segments the fold-below-
+watermark listing path resolves directly, roughly the most recent couple
+of hours. Everything older counts as `SealedBelowWatermark` toward the
+1024 cap regardless of whether it has been compacted. A wide scan over a
+tenant with many sealed L0 or L1 objects — the exact shape of workload
+this ADR is meant to unblock — hits the cap directly, so it belongs in
+the flag set, not left compiled in.
+
+An operator sizing a specific host — more or less memory, more or fewer
+cores, a workload with wider scans than the defaults were chosen for —
+cannot express any of this today without a rebuild.
+
+## Decision
+
+Add server flags for `max_query_bytes` (SQL per-query pool), the
+per-tenant SQL ceiling, `fetch_concurrency`, and `max_segments`. Document
+`fetch_concurrency`'s relation to scan partition count: it is, today, the
+single knob governing both SQL scan fan-out and S3 GET concurrency
+(ADR-0087 does not decouple them). Document the existing
+`--max-s3-requests` flag and the limits-file `max_bytes_scanned` default,
+and how to size both for wide scans. Verify `--gc-max-query-duration` at
+multi-minute values passes validation against the tenant's durable
+`sys/gc.max_query_duration` (default 1 h) — a deadline set above that
+value requires raising `sys/gc` first, and this ADR documents that
+ordering rather than silently accepting a flag value the engine can never
+honor.
+
+The new per-query and per-tenant SQL budgets are server flags, not
+limits-file entries, even though the limits-file is this repo's existing
+precedent for a per-tenant override (ADR-0061). The limits-file's
+per-tenant query overrides are process-wide today with no per-tenant
+`EngineConfig` lookup at query time (`services/ravel-server/src/main.rs`
+warns exactly this: a per-tenant override there is currently inert).
+Adding new per-tenant knobs to a mechanism already known not to enforce
+per-tenant scoping would ship a second budget an operator could
+reasonably expect to be tenant-scoped and would not be. A server flag is
+honest about being process-wide; per-tenant SQL budgets are future work
+once the limits-file's per-tenant enforcement gap is closed.
+
+**Defaults are unchanged at ship time.** The 256 MiB and 1 GiB figures
+stay exactly as they are; only the ability to override them is new. The
+"placeholder pending measurement" comments are replaced with the actual
+default rationale (today's compiled-in value, adjustable via flag) rather
+than with a new guessed number. Changing the default is a separate,
+measurement-backed follow-up once real workload data exists — this ADR is
+about giving operators a lever, not about deciding where the lever should
+default to for workloads nobody has measured yet.
+
+```mermaid
+flowchart TD
+    subgraph today
+        F1[--gc-max-query-duration] --> EC1[EngineConfig]
+        F3[--max-s3-requests] --> EC1
+        LF[limits-file: max_bytes_scanned, default Unlimited] --> EC1
+        X1[max_query_bytes: compiled in] -.no flag.-> SC1[SqlConfig]
+        X2[tenant ceiling: compiled in] -.no flag.-> SC1
+        X3[fetch_concurrency: compiled in] -.no flag.-> EC1
+        X4[max_segments: compiled in] -.no flag.-> EC1
+    end
+    subgraph after
+        G1[--gc-max-query-duration] --> EC2[EngineConfig]
+        G3[--max-s3-requests] --> EC2
+        LF2[limits-file: max_bytes_scanned] --> EC2
+        G4[--sql-max-query-bytes] --> SC2[SqlConfig]
+        G5[--sql-tenant-max-bytes] --> SC2
+        G6[--fetch-concurrency] --> EC2
+        G7[--max-segments] --> EC2
+    end
+```
+
+## Rejected alternatives
+
+- **Choose new default values now, based on estimated workloads.**
+  Rejected: there is no measurement behind any candidate number, so a new
+  default would just be a different placeholder with more confidence
+  behind it than it has earned. This ADR ships the lever; the follow-up
+  ships the number, backed by data.
+- **A single global budget instead of per-query and per-tenant.**
+  Rejected: the per-tenant ceiling exists specifically for multi-tenant
+  isolation (one tenant's wide scan should not starve another's query
+  pool). Collapsing to one budget removes that isolation property.
+- **Auto-tune budgets from host resources at startup.** Rejected as scope
+  creep beyond what this ADR decides: the goal is operator control that
+  is explicit and auditable in server flags/config, not inference from
+  detected host capacity, which hides the actual bound in play from
+  whoever is reading the startup flags.
+- **Put the new SQL budgets in the limits-file instead of server flags.**
+  Rejected: the limits-file's per-tenant override path has no per-tenant
+  `EngineConfig` lookup at query time today (a known gap noted in
+  `main.rs`), so a per-tenant entry there would silently not do what its
+  location implies. A process-wide server flag is honest about its own
+  scope; per-tenant SQL budgets wait on that gap closing.
+
+## Consequences
+
+- Every new flag needs a reachability test in the shape of the existing
+  `max_s3_requests_budget_is_reachable_from_cli` test
+  (`services/ravel-server/src/config.rs`): the flag's value proven to
+  arrive at the `EngineConfig`/`SqlConfig` the engine actually uses,
+  driven through real server startup — not a unit test on the flag parser
+  alone. This project has shipped features that parsed correctly and
+  never reached their consumer before (a registered-but-unreachable table
+  provider, an unreachable erasure filter); this ADR's acceptance
+  criterion is explicitly the reachability shape, not just "flag parses."
+- `docs/guides/operations.md`, `docs/guides/query.md`, and
+  `docs/guides/admission-limits.md` gain the new flags and the
+  `--max-s3-requests` sizing guidance.
+- No behavior change at default flag values: every default matches
+  today's compiled-in constant exactly.

--- a/docs/adrs/0089-bulk-import-logs-signal.md
+++ b/docs/adrs/0089-bulk-import-logs-signal.md
@@ -1,3 +1,183 @@
 # ADR-0089: bulk import of structured event data into the logs signal
 
-Status: claimed
+Status: Proposed
+
+## Context
+
+The only way to write log records into Ravel is OTLP: `crates/ravel-otlp`
+enforces a two-hour past-event-time lag, a matching future-skew bound, a
+128-attribute-per-record cap, and several length caps, on top of a
+per-tenant `AdmissionController` (active-stream cap, stream-creation rate,
+byte rate) that lives in `services/ravel-server/src/logs_ingest.rs`, one
+layer above the router. There is no bulk import path. Loading an existing
+structured dataset — a Parquet export, an archive migration, a historical
+backfill — requires writing code against internal crates.
+
+The event-time lag exists to protect a specific hazard, documented in
+`docs/guides/ingest.md`: a point admitted with too old an event time could
+land in a bucket a query has already stopped looking at. The record's
+ingest-hour bucket is derived from the *flush-open wall clock*
+(`crates/ravel-ingest/src/config.rs`, `checked_ingest_hour_bucket`), not
+from the record's event timestamp — so an old-event record still lands in
+today's bucket. But that alone does not prove the record stays
+discoverable: what a query can find is governed separately by the catalog
+listing window, `crates/ravel-catalog/src/catalog.rs::window_hour_bounds`,
+which lists `[query_range.start - max_ingest_lag, now + max_future_skew]`,
+and the folded-snapshot resolve path prunes by those same hour bounds
+before checking event-range overlap. A record's *bucket* is safe from the
+lag limit's stated hazard because it buckets by wall clock; a record's
+*discoverability* still depends on the query's listing window reaching
+that bucket. `docs/consistency-model.md` states this as a paired
+invariant: "the bound on what is admitted and the bound on what is
+discoverable must be the same value... raising the admission lag alone
+admits records the listing window then fails to discover." This ADR
+relaxes the *admission* lag for this path without violating that
+invariant, by keeping the *listing* side's future bound intact (see
+Decision) and by requiring bulk-loaded queries to use a query window wide
+enough to reach the ingest-hour bucket the loader actually wrote to
+(`now`, not the event time) — which a caller querying through the normal
+`start`/`end` window already does, since that window is compared against
+event-range overlap, not used to compute the bucket.
+
+The future-skew bound has no equivalent argument for relaxation: a record
+admitted with an event time far in the *future* still buckets by today's
+wall clock, but a later query for that time range lists from
+`query_range.start - lag`, which does not reach today's bucket — such a
+record becomes permanently undiscoverable. Future skew must stay
+enforced.
+
+## Decision
+
+Add `services/ravel-cli load --parquet <file> --tenant <t> --mapping
+<toml>`. The loader is an in-process caller of `LogIngestRouter` — the
+same shard actors, flush cadence, and commit protocol OTLP calls, not a
+parallel implementation — built by the CLI process itself against the
+target tenant's provisioned shard count (ADR-0052/ADR-0082) and configured
+indexed fields, using `WriteMode::Strict` and awaiting every write's
+acknowledgment before the process exits, so a run that returns success has
+no buffered-but-unflushed data.
+
+Two `ravel-otlp`-layer admission rules are explicitly relaxed for this
+path; everything else stays enforced, either by the loader re-implementing
+the same check or by construction:
+
+- **Past event-time lag: relaxed.** Per the discoverability argument
+  above, this is sound as long as bulk-loaded data is queried with a
+  window that reaches the ingest-hour bucket the loader wrote to. The
+  loader's `--mapping` maps a source column to the record's `ts`
+  independent of when the load ran; documentation must state this
+  explicitly, and `docs/consistency-model.md`'s paired-bound statement
+  gets a clause noting this path's exception and why it does not violate
+  the invariant.
+- **Future skew: kept.** Not relaxed — the argument above shows relaxing
+  it would create permanently undiscoverable records. The loader enforces
+  the same `max_future_skew_ns` bound OTLP does.
+- **128-attribute-per-record cap: relaxed to a loader-specific explicit
+  cap**, chosen independent of the RLOG per-object dynamic-column ceiling
+  (1000 distinct name+type pairs *per object*, which is a different
+  budget — past it, further keys silently fold into the `attrs_raw`
+  overflow column rather than being rejected, and that overflow behavior
+  applies to this path exactly as it does to OTLP and must be documented,
+  not treated as a cap). The relaxation is justified the same way the
+  original ADR framing argued: this is an operator-initiated, offline,
+  locally-invoked action reading a file the operator already controls, a
+  different threat model than a networked OTLP sender.
+- **Length caps (attribute key/value length, body length): kept**,
+  re-implemented by the loader identically to `ravel-otlp`'s limits —
+  these protect against unbounded field sizes regardless of who is
+  sending, and nothing about the offline/trusted framing changes that.
+- **Per-tenant `AdmissionController` (active-stream cap, stream-creation
+  rate, byte rate): not applicable.** This sits in `ravel-server`'s HTTP
+  layer, above the router the loader calls directly; the loader does not
+  go through it and there is no equivalent concept for a single bulk
+  load. This is a bypass by construction, not a relaxation decision, and
+  must be stated as such in the README so nobody mistakes bulk-loaded
+  volume for evidence the admission controller's limits were exercised.
+
+The `--mapping` TOML declares, at minimum: which source columns are
+resource attributes (they determine stream identity via
+`stream_attrs_bytes`, so must be distinguished from record attributes),
+which is the record's `ts` column and its unit, the `severity`/`body`
+source columns if present, and a type for every other mapped column
+(str/i64/f64/bool/bytes) used to build typed `AttrValue`s. Trace/span ID
+mapping is optional and defaults to absent.
+
+```mermaid
+flowchart TB
+    subgraph "OTLP path (existing)"
+        OTLP[OTLP HTTP/gRPC] --> AC[AdmissionController: rate, stream cap]
+        AC --> NORM[ravel-otlp normalize:<br/>lag, future skew, attr cap, length caps]
+        NORM --> NLR1[NormalizedLogRecord]
+    end
+    subgraph "bulk import path (this ADR)"
+        PQ[Parquet file] --> MAP[declared TOML mapping]
+        MAP --> LOAD[loader: enforces future skew,<br/>length caps, loader attr cap;<br/>lag check OMITTED]
+        LOAD --> NLR2[NormalizedLogRecord]
+    end
+    NLR1 --> LIR[LogIngestRouter, Strict mode]
+    NLR2 --> LIR
+    LIR --> SH[shard actor: flush + commit]
+    SH --> OBJ[(RLOG object, object store)]
+```
+
+## Rejected alternatives
+
+- **A new ingest path outside `LogIngestRouter`.** Rejected: duplicates
+  shard, flush, and commit logic that already exists and is tested; a
+  second implementation of the durability-critical write path doubles the
+  surface for a divergent bug, for no benefit over calling the existing
+  router directly.
+- **Keep the past-event-time lag limit and require callers to rewrite
+  timestamps before import.** Rejected: this corrupts the source data's
+  semantics for exactly the use case bulk import exists for (a backfill
+  or migration needs its real event times), and the discoverability
+  argument above shows the limit can be relaxed on the admission side
+  without reintroducing the hazard, as long as the listing side keeps its
+  own bound — which this ADR does not touch.
+- **Relax future skew too, for symmetry with the lag limit.** Rejected:
+  the two are not symmetric. The lag limit's hazard is about admission
+  reaching a bucket the *listing window's past bound* excludes; the skew
+  limit's hazard is about the *listing window's future bound* (`now +
+  skew`) never reaching a bucket at all once time moves on. Relaxing it
+  produces silently unrecoverable data.
+- **Raise the attribute cap in `ravel-otlp` itself instead of relaxing it
+  per-path.** Rejected: the cap's job is bounding what an untrusted or
+  semi-trusted network sender can push into one record. Raising it
+  globally weakens that protection for live ingest to accommodate a
+  different, offline, operator-trusted caller; a per-path limit keeps
+  each admission rule matched to the threat model it actually faces.
+
+## Consequences
+
+- `docs/guides/ingest.md` gains a bulk-import section stating which
+  `ravel-otlp` rules this path relaxes (past lag, attribute cap), which it
+  keeps (future skew, length caps), and which it bypasses by construction
+  (the per-tenant `AdmissionController`) — with the discoverability
+  argument for the lag relaxation spelled out, not just asserted.
+  `docs/consistency-model.md` gets a clause on its paired admission/
+  discoverability bound noting this path's documented exception.
+- Retention and GC are keyed on ingest-hour buckets
+  (`docs/catalog-and-mvcc.md`), so a bulk-loaded record with an old event
+  timestamp is retained for the full retention window measured from the
+  *load* time, not the event time — worth a line in the doc section so an
+  operator doesn't expect retention to follow the data's real age.
+- An RLOG object spanning a wide event-time range overlaps every later
+  query's event range at resolve time; unsorted input makes every
+  subsequent query over the affected stream fetch the bulk-loaded objects
+  regardless of the query's actual window. The loader documentation
+  recommends sorting input by event time before load where the mapping
+  allows it; this is a performance note, not a correctness requirement.
+- `parquet` is a new external dependency for the workspace (today's
+  `[workspace.dependencies]` carries `arrow`/`arrow-ipc`/`arrow-flight`
+  but not `parquet`), and this is the first `arrow`-family dependency in
+  `ravel-cli`, which sits outside the ingest-critical path ADR-0011
+  otherwise isolates `arrow` from. Flagged per the dependency-addition
+  rule; not itself a reason to reject, since `ravel-cli` is inspection/
+  operator tooling, not a durability-path crate.
+- An end-to-end test (Parquet fixture in, SQL logs query out, against
+  `MemoryStore`) and a fault test (`FaultStore` injecting a PUT failure)
+  proving a failed flush surfaces as a non-zero CLI exit that reports the
+  commit tokens already durable before the failure — a failure mid-file
+  is a genuine partial load, not a rollback, and re-running the loader
+  re-ingests the whole file with no deduplication; the CLI's output and
+  the docs must say so plainly so an operator doesn't assume otherwise.


### PR DESCRIPTION
Full design content for the three ADR numbers claimed in the prior stub PR. Reviewed and amended (streamed-scan ordering correctness, max_segments accuracy, budget scoping, bulk-import discoverability argument) before landing.

Refs: #279
Refs: #276
Refs: #275