### PR TITLE
feat(distrib): dispatch fragment fetch per signal, not blanket reject

### DIFF
--- a/crates/ravel-query/src/distrib/client.rs
+++ b/crates/ravel-query/src/distrib/client.rs
@@ -46,6 +46,18 @@ pub enum DistribError {
         "remote returned native-histogram data this build cannot decode across the slice boundary"
     )]
     HistogramUnsupported,
+    /// The remote streamed a per-signal record frame (a log record or a span)
+    /// for a signal this coordinator's metrics fetch path cannot consume.
+    /// Unreachable from a real query today: the metrics coordinator only ever
+    /// dispatches `Signal::Metrics`, and the log/span coordinators that would
+    /// receive these frames are built by #284/#285. The `frame` oneof is
+    /// exhaustive, so the metrics decoder must still name the variants; like
+    /// [`HistogramUnsupported`](Self::HistogramUnsupported) this is a
+    /// well-formed frame this build does not consume, not corruption.
+    #[error(
+        "remote returned a {0} frame this metrics coordinator cannot decode across the slice boundary"
+    )]
+    FrameSignalUnsupported(&'static str),
 }
 
 /// One slice's fully-decoded response, in the same in-memory shapes the local
@@ -145,6 +157,12 @@ pub fn decode_slice_frames(frames: Vec<pb::FetchResponse>) -> Result<SliceRespon
             }
             Some(pb::fetch_response::Frame::Hist(_)) => {
                 return Err(DistribError::HistogramUnsupported);
+            }
+            Some(pb::fetch_response::Frame::LogRecord(_)) => {
+                return Err(DistribError::FrameSignalUnsupported("log-record"));
+            }
+            Some(pb::fetch_response::Frame::Span(_)) => {
+                return Err(DistribError::FrameSignalUnsupported("span"));
             }
             Some(pb::fetch_response::Frame::Summary(s)) => {
                 if summary.is_some() {

--- a/crates/ravel-query/src/distrib/service.rs
+++ b/crates/ravel-query/src/distrib/service.rs
@@ -133,19 +133,16 @@ impl<R: SegmentResolver + 'static> SeriesFetchService<R> {
         codec::check_protocol_version(request.protocol_version)
             .map_err(|e| (pb::status::Code::Unsupported, e.to_string()))?;
 
-        // Signal validation. An unknown discriminant is malformed (BadData); a
-        // known non-metrics signal is simply not distributed yet, so hand it to
-        // the coordinator's local fallback (Unsupported) rather than return a
-        // wrong or partial result. `signal_from_u32` is otherwise only exercised
-        // by codec round-trip tests; this is its production caller.
+        // Decode the signal discriminant, then the signal-agnostic request
+        // shape (tenant, matchers, erasure), and only then dispatch on the
+        // signal. An unknown discriminant is malformed (BadData);
+        // `signal_from_u32` is otherwise only exercised by codec round-trip
+        // tests, this is its production caller. The per-signal dispatch is a
+        // real match arm reached AFTER this decode (not the former pre-decode
+        // blanket rejection), so a signal's own fetch path can build on the
+        // decoded request rather than re-parsing it (#283).
         let signal = codec::signal_from_u32(request.signal)
             .map_err(|e| (pb::status::Code::BadData, e.to_string()))?;
-        if signal != Signal::Metrics {
-            return Err((
-                pb::status::Code::Unsupported,
-                format!("signal {signal:?} is not distributed yet; only Metrics"),
-            ));
-        }
 
         let tenant_hash =
             decode_tenant_hash(&request.tenant_hash).map_err(|m| (pb::status::Code::BadData, m))?;
@@ -154,7 +151,57 @@ impl<R: SegmentResolver + 'static> SeriesFetchService<R> {
             .map_err(|e| (pb::status::Code::BadData, e.to_string()))?;
         let erasure = codec::decode_erasure(request.erasure);
 
-        let identities = match request.scope {
+        match signal {
+            // Metrics keeps its exact path: resolve the pinned scope, fetch,
+            // and encode scalar series. Unchanged from before #283.
+            Signal::Metrics => {
+                self.run_slice_metrics(
+                    request.scope,
+                    request.budgets,
+                    tenant_hash,
+                    matchers,
+                    erasure,
+                )
+                .await
+            }
+            // The RLOG family (Logs, Alerts, Audit) and Spans now reach a real
+            // per-signal branch after decoding, proving the signal check is a
+            // dispatch and not a pre-decode reject. Their fetch-and-encode
+            // paths land in #284 (logs) and #285 (spans); until then the branch
+            // returns a distinct "not yet implemented" Unsupported, so the
+            // coordinator still silently falls back to fully local execution
+            // (ADR-0071 failure semantics). This is deliberately NOT reachable
+            // from a real query yet: no caller dispatches a non-Metrics
+            // distributed fetch until #284/#285 build the coordinators.
+            Signal::Logs | Signal::Alerts | Signal::Audit | Signal::Spans => Err((
+                pb::status::Code::Unsupported,
+                format!("distributed fetch for signal {signal:?} is not yet implemented"),
+            )),
+            // Profiles has no distributed fetch path planned in this lane, so it
+            // stays rejected exactly as every non-Metrics signal was before
+            // #283: Unsupported, whole-query local fallback.
+            Signal::Profiles => Err((
+                pb::status::Code::Unsupported,
+                format!("signal {signal:?} is not distributed"),
+            )),
+        }
+    }
+
+    /// The Metrics slice path: resolve the pinned scope to refs, fetch each
+    /// segment's scalar (and histogram) series, enforce the per-slice
+    /// bytes-scanned budget, apply erasure, and stream scalar frames ending in
+    /// a terminal summary. Extracted from `run_slice_inner` unchanged so the
+    /// per-signal dispatch there can call it as one arm; Metrics behavior is
+    /// bit-for-bit what it was before #283.
+    async fn run_slice_metrics(
+        &self,
+        scope: Option<pb::fetch_request::Scope>,
+        budgets: Option<pb::Budgets>,
+        tenant_hash: TenantHash,
+        matchers: Vec<ravel_promql::LabelMatcher>,
+        erasure: Vec<crate::erasure::ErasurePredicate>,
+    ) -> Result<Vec<pb::FetchResponse>, (pb::status::Code, String)> {
+        let identities = match scope {
             Some(pb::fetch_request::Scope::Pinned(pinned)) => pinned.segments,
             // Cross-cluster resolve scope is future work; fall back to local.
             Some(pb::fetch_request::Scope::Resolve(_)) | None => {
@@ -184,7 +231,7 @@ impl<R: SegmentResolver + 'static> SeriesFetchService<R> {
         // Per-slice bytes-scanned budget, enforced per completed segment
         // exactly as the local path does (ADR-0061 decision 1): `0` is the wire
         // sentinel for "no cap" (a real fetch never scans zero bytes).
-        let byte_limit = match request.budgets.as_ref().map(|b| b.max_bytes_scanned) {
+        let byte_limit = match budgets.as_ref().map(|b| b.max_bytes_scanned) {
             Some(0) | None => ByteLimit::Unlimited,
             Some(max) => ByteLimit::Bounded(max),
         };

--- a/crates/ravel-query/src/distrib/tests.rs
+++ b/crates/ravel-query/src/distrib/tests.rs
@@ -985,6 +985,125 @@ fn worker_rejects_non_metrics_and_unknown_signals() {
     });
 }
 
+/// #283: `run_slice_inner` dispatches on the signal via a real per-signal match
+/// arm reached AFTER decoding tenant/matchers/erasure, not the former
+/// pre-decode blanket rejection. Logs and Spans route to their own branch (a
+/// stub returning a distinct "not yet implemented" Unsupported until #284/#285
+/// fill it in); Profiles stays rejected exactly as every non-Metrics signal was
+/// before #283.
+///
+/// Two facts here would each FAIL against the old blanket-rejection code:
+///  1. Logs/Spans now carry the distinct "not yet implemented" message; the old
+///     code produced "not distributed yet; only Metrics" for every non-Metrics
+///     signal, so it never distinguished the stubbed family from Profiles.
+///  2. A Logs request with a malformed `tenant_hash` now returns `BadData`
+///     (tenant decode runs before the signal dispatch); the old code returned
+///     `Unsupported` because the signal check preceded any decode.
+#[test]
+fn run_slice_inner_dispatches_on_signal_not_blanket_rejects() {
+    let rt = Runtime::new().expect("runtime");
+    rt.block_on(async {
+        let store = Arc::new(MemoryStore::new());
+        let seg = write_segment(
+            &store,
+            0,
+            0,
+            100,
+            &[SeriesDesc {
+                metric: "m0".to_string(),
+                samples: vec![(NS, 1.0f64.to_bits())],
+            }],
+        )
+        .await;
+        let (fetcher, server) = spawn_worker(Arc::clone(&store), vec![seg.clone()]).await;
+
+        let request = |signal: u32, tenant: Vec<u8>| pb::FetchRequest {
+            protocol_version: crate::distrib::codec::PROTOCOL_VERSION,
+            query_id: Vec::new(),
+            tenant_hash: tenant,
+            signal,
+            scope: Some(pb::fetch_request::Scope::Pinned(pb::PinnedScope {
+                segments: vec![crate::distrib::codec::encode_segment_identity(&seg)],
+            })),
+            matchers: Vec::new(),
+            window_start_ns: 0,
+            window_end_ns: 0,
+            budgets: None,
+            deadline_unix_ns: 0,
+            erasure: Vec::new(),
+            trace_context: String::new(),
+            fragment_capability: Vec::new(),
+        };
+
+        // Logs and Spans reach the new stub branch: Unsupported, but with the
+        // distinct "not yet implemented" message the old code never produced.
+        for signal in [Signal::Logs, Signal::Spans] {
+            let resp = SliceFetcher::fetch(
+                &fetcher,
+                request(
+                    crate::distrib::codec::signal_to_u32(signal),
+                    TENANT.0.to_vec(),
+                ),
+            )
+            .await
+            .unwrap_or_else(|e| panic!("worker responds to a {signal:?} request: {e:?}"));
+            assert_eq!(
+                resp.status,
+                pb::status::Code::Unsupported,
+                "{signal:?} stub is still Unsupported so the coordinator falls back to local"
+            );
+            assert!(
+                resp.status_message.contains("not yet implemented"),
+                "{signal:?} must reach the new per-signal stub branch (distinct message), \
+                 got {:?}",
+                resp.status_message
+            );
+        }
+
+        // Structural proof the signal check now runs AFTER decoding: a Logs
+        // request with a malformed tenant hash is BadData (decode failed), not
+        // the Unsupported the pre-decode blanket check would have returned.
+        let bad_tenant = SliceFetcher::fetch(
+            &fetcher,
+            request(
+                crate::distrib::codec::signal_to_u32(Signal::Logs),
+                vec![0u8; 3],
+            ),
+        )
+        .await
+        .expect("worker responds to a malformed-tenant logs request");
+        assert_eq!(
+            bad_tenant.status,
+            pb::status::Code::BadData,
+            "tenant decode runs before the signal dispatch, so a bad tenant is BadData"
+        );
+
+        // Profiles stays on the reject arm, exactly as before #283: Unsupported,
+        // and specifically NOT the stubbed-family "not yet implemented" message.
+        let profiles = SliceFetcher::fetch(
+            &fetcher,
+            request(
+                crate::distrib::codec::signal_to_u32(Signal::Profiles),
+                TENANT.0.to_vec(),
+            ),
+        )
+        .await
+        .expect("worker responds to a profiles request");
+        assert_eq!(
+            profiles.status,
+            pb::status::Code::Unsupported,
+            "Profiles keeps returning Unsupported like every non-Metrics signal did"
+        );
+        assert!(
+            !profiles.status_message.contains("not yet implemented"),
+            "Profiles must take the reject arm, not the stubbed-family branch, got {:?}",
+            profiles.status_message
+        );
+
+        server.abort();
+    });
+}
+
 /// A [`SliceFetcher`] double whose reported spend is keyed on the slice's
 /// shard, with the overflow-sized report delayed so it always completes (and
 /// folds) second -- the one completion order a wrapping fold is blind to.

--- a/proto/ravel/queryfrag.proto
+++ b/proto/ravel/queryfrag.proto
@@ -135,6 +135,8 @@ message FetchResponse {
     SeriesFrame series = 1;
     HistogramFrame hist = 2;
     Summary summary = 3;
+    LogRecordFrame log_record = 4;
+    SpanFrame span = 5;
   }
 }
 
@@ -180,6 +182,36 @@ message HistogramRun {
   // Opaque encoded histogram span payload for this run. Grammar deferred to a
   // later ticket; treated as an opaque blob by this contract.
   bytes span_payload = 5;
+}
+
+// One log-record frame for a slice of the RLOG family (Logs, Alerts, Audit),
+// carrying the worker's per-record merged attribute view so the coordinator
+// orders and dedups records without re-deriving attribute merging (ADR-0071
+// "log and span distributed fan-out" amendment). Additive oneof member: no
+// protocol_version bump, because skew is governed by the signal gate, not the
+// version field (an old worker returns Unsupported for signal=Logs, which the
+// coordinator maps to whole-query local fallback, so this frame can never
+// reach an old coordinator). The record payload grammar is deferred to the log
+// distribution ticket (#284); the field is reserved here as opaque bytes with
+// its number frozen, so adding the grammar is a decode-side change, not a wire
+// change, exactly as HistogramRun.span_payload reserves the histogram grammar.
+message LogRecordFrame {
+  // Opaque encoded per-record merged view for this slice. Grammar deferred to
+  // #284; treated as an opaque blob by this contract.
+  bytes record_payload = 1;
+}
+
+// One span frame for a slice of the Spans signal, carrying the worker's
+// per-span merged view so the coordinator orders and dedups spans keyed on
+// (trace_id, span_id) without re-deriving attribute merging (ADR-0071 "log and
+// span distributed fan-out" amendment). Additive oneof member with the same
+// no-version-bump rationale as LogRecordFrame. The span payload grammar is
+// deferred to the span distribution ticket (#285); the field is reserved here
+// as opaque bytes with its number frozen.
+message SpanFrame {
+  // Opaque encoded per-span merged view for this slice. Grammar deferred to
+  // #285; treated as an opaque blob by this contract.
+  bytes span_payload = 1;
 }
 
 // The terminal frame of a slice: the worker's accounting snapshot, the counts


### PR DESCRIPTION
The fragment fan-out worker rejected every non-Metrics signal before
decoding the request. Replace that pre-decode blanket rejection with a
per-signal dispatch reached after decoding tenant, matchers, and erasure.

run_slice_inner now decodes the signal-agnostic request shape first, then
matches on the signal. Metrics keeps its exact prior path, extracted
unchanged into run_slice_metrics. Logs, Alerts, Audit, and Spans route to
a new per-signal branch that stubs a distinct "not yet implemented"
Unsupported until the log and span fetch paths land (#284/#285). Profiles
stays rejected exactly as every non-Metrics signal was before.

Add LogRecordFrame and SpanFrame to FetchResponse's frame oneof. Both are
additive members with opaque payloads and frozen field numbers, following
the HistogramRun.span_payload precedent; the grammars are deferred to
#284/#285. No protocol_version bump: skew stays governed by the signal
gate, not the version field, so these frames can never reach an old
coordinator that never dispatches these signals. The queryfrag proto is a
transient wire contract, not a persistent frozen format, so this is not a
format-change event.

The coordinator's frame decoder gains arms for the two new variants, each
a typed FrameSignalUnsupported error. These are unreachable from a real
query today: no caller dispatches a non-Metrics distributed fetch until
#284/#285 build the log and span coordinators. This task only proves the
signal check is a real post-decode dispatch, not that logs or spans are
distributed yet.

Refs: #63
Fixes: #283
