### PR TITLE
perf(sql): stream and column-project the logs scan

### DIFF
--- a/crates/ravel-logseg/src/block.rs
+++ b/crates/ravel-logseg/src/block.rs
@@ -8,7 +8,7 @@
 //! SKIP_IDX level-0 entry, not inline; [`read_block`] verifies it before
 //! decoding anything.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::encoding::{
     Enc, decode_bitmap, decode_f64, decode_fixed, decode_i64, decode_strings, encode_bitmap,
@@ -386,6 +386,13 @@ fn row_column(row: &ResolvedRow, column_id: u32) -> Option<&ColumnValue> {
 
 /// A decoded block: per-column, per-row values. Every column vector has length
 /// `record_count`; `None` marks a row where the column has no value.
+///
+/// A block decoded through [`read_block_columns`] with a column filter holds
+/// only the filtered columns. A column the filter excluded is indistinguishable
+/// from a column the block never carried: its accessor returns `None`. Callers
+/// that project must therefore know which columns they asked for; nothing here
+/// can tell them apart, by design (an absent page and a skipped page decode to
+/// the same nothing).
 pub struct DecodedBlock {
     record_count: usize,
     i64_cols: HashMap<u32, Vec<Option<i64>>>,
@@ -393,11 +400,26 @@ pub struct DecodedBlock {
     bool_cols: HashMap<u32, Vec<Option<bool>>>,
     str_cols: HashMap<u32, Vec<Option<Vec<u8>>>>,
     fixed_cols: HashMap<u32, Vec<Option<Vec<u8>>>>,
+    pages_decoded: usize,
+    pages_skipped: usize,
 }
 
 impl DecodedBlock {
     pub fn record_count(&self) -> usize {
         self.record_count
+    }
+
+    /// Pages this decode decompressed and decoded (value pages and presence
+    /// bitmaps alike).
+    pub fn pages_decoded(&self) -> usize {
+        self.pages_decoded
+    }
+
+    /// Pages this decode skipped because the column filter excluded them. Zero
+    /// for an all-columns decode. This is the observable proof that column
+    /// projection reached the page level rather than being applied after decode.
+    pub fn pages_skipped(&self) -> usize {
+        self.pages_skipped
     }
     pub fn i64_col(&self, column_id: u32) -> Option<&[Option<i64>]> {
         self.i64_cols.get(&column_id).map(Vec::as_slice)
@@ -446,6 +468,17 @@ fn column_kind(column_id: u32, plans: &[ColumnPlan]) -> Result<ColKind, LogSegEr
     })
 }
 
+/// The decoded bytes of a page that the column filter kept. Only ever called
+/// for a page whose column was grouped, i.e. one the filter kept, so a `None`
+/// here would be an internal inconsistency rather than bad input; it is still
+/// reported as a typed error rather than unwrapped.
+fn page(pages: &[Option<Vec<u8>>], idx: usize) -> Result<&[u8], LogSegError> {
+    pages
+        .get(idx)
+        .and_then(|p| p.as_deref())
+        .ok_or_else(|| LogSegError::Corrupted("page not decoded".into()))
+}
+
 /// Scatters `present`-length-`record_count` values into a per-row vector.
 /// `values` holds only the present entries, in row order.
 fn scatter<T: Clone>(present: &[bool], values: Vec<T>) -> Result<Vec<Option<T>>, LogSegError> {
@@ -469,12 +502,42 @@ fn scatter<T: Clone>(present: &[bool], values: Vec<T>) -> Result<Vec<Option<T>>,
     Ok(out)
 }
 
-/// Decodes a block, verifying its crc32c first.
+/// Decodes every column of a block, verifying its crc32c first.
+///
+/// This is the all-columns case, and it is what
+/// [`crate::ranged::RlogRangeReader`] (the compaction merge's reader) and
+/// [`crate::RlogReader::scan_pruned`] use: identical decoded output to before
+/// column projection existed. Use [`read_block_columns`] to decode a subset.
 pub fn read_block(
     bytes: &[u8],
     expected_crc: u32,
     plans: &[ColumnPlan],
     max_uncomp: u64,
+) -> Result<DecodedBlock, LogSegError> {
+    read_block_columns(bytes, expected_crc, plans, max_uncomp, None)
+}
+
+/// Decodes a block, verifying its crc32c first, decompressing and decoding only
+/// the pages of the columns `columns` names (ADR-0087 decision 3).
+///
+/// `columns == None` is the all-columns case ([`read_block`]). Otherwise every
+/// page whose `column_id` is not in the set is walked past without a
+/// `read_page` call, so its stored bytes are never decompressed and its values
+/// are never materialized; the resulting [`DecodedBlock`] reports that column as
+/// absent. Both a column's presence bitmap page and its value page are governed
+/// by the same decision, so a projected column is never left half-decoded.
+///
+/// The block's crc32c covers the whole block and is verified in full regardless
+/// of the filter: projection changes what is decoded, never what is checked.
+/// Every page descriptor is still parsed and every page's stored extent is still
+/// walked, so a truncated or over-long block is rejected exactly as it is
+/// without a filter.
+pub fn read_block_columns(
+    bytes: &[u8],
+    expected_crc: u32,
+    plans: &[ColumnPlan],
+    max_uncomp: u64,
+    columns: Option<&HashSet<u32>>,
 ) -> Result<DecodedBlock, LogSegError> {
     if crc32c::crc32c(bytes) != expected_crc {
         return Err(LogSegError::Corrupted("block crc mismatch".into()));
@@ -521,8 +584,19 @@ pub fn read_block(
         });
     }
 
-    // Slice each page's stored bytes and decompress to encoded bytes.
-    let mut page_bytes: Vec<Vec<u8>> = Vec::with_capacity(descs.len());
+    // Whether a column's pages are decoded at all. `None` selects everything.
+    let wanted = |cid: u32| match columns {
+        None => true,
+        Some(set) => set.contains(&cid),
+    };
+
+    // Slice each page's stored bytes and decompress to encoded bytes. A page
+    // belonging to an unwanted column is walked past: its extent is still
+    // validated (so truncation is still caught) but `read_page` is not called,
+    // so its bytes are never decompressed.
+    let mut page_bytes: Vec<Option<Vec<u8>>> = Vec::with_capacity(descs.len());
+    let mut pages_decoded = 0usize;
+    let mut pages_skipped = 0usize;
     for d in &descs {
         let len = usize::try_from(d.len)
             .map_err(|_| LogSegError::Corrupted("page len out of range".into()))?;
@@ -532,7 +606,13 @@ pub fn read_block(
         let stored = bytes
             .get(pos..end)
             .ok_or_else(|| LogSegError::Corrupted("page range out of bounds".into()))?;
-        page_bytes.push(read_page(stored, d, max_uncomp)?);
+        if wanted(d.column_id) {
+            page_bytes.push(Some(read_page(stored, d, max_uncomp)?));
+            pages_decoded += 1;
+        } else {
+            page_bytes.push(None);
+            pages_skipped += 1;
+        }
         pos = end;
     }
     if pos != bytes.len() {
@@ -541,10 +621,14 @@ pub fn read_block(
         ));
     }
 
-    // Group descriptor indices by column id, preserving order.
+    // Group descriptor indices by column id, preserving order. Unwanted columns
+    // are not grouped at all, so nothing below ever looks at their pages.
     let mut order: Vec<u32> = Vec::new();
     let mut groups: HashMap<u32, Vec<usize>> = HashMap::new();
     for (i, d) in descs.iter().enumerate() {
+        if !wanted(d.column_id) {
+            continue;
+        }
         groups.entry(d.column_id).or_insert_with(|| {
             order.push(d.column_id);
             Vec::new()
@@ -561,6 +645,8 @@ pub fn read_block(
         bool_cols: HashMap::new(),
         str_cols: HashMap::new(),
         fixed_cols: HashMap::new(),
+        pages_decoded,
+        pages_skipped,
     };
 
     for column_id in order {
@@ -571,7 +657,7 @@ pub fn read_block(
                 if descs[*p].enc != Enc::Bitmap {
                     return Err(LogSegError::Corrupted("presence page not a bitmap".into()));
                 }
-                (decode_bitmap(&page_bytes[*p], record_count)?, *v)
+                (decode_bitmap(page(&page_bytes, *p)?, record_count)?, *v)
             }
             _ => {
                 return Err(LogSegError::Corrupted(format!(
@@ -582,7 +668,7 @@ pub fn read_block(
         };
         let present_count = present.iter().filter(|&&b| b).count();
         let enc = descs[value_idx].enc;
-        let encoded = &page_bytes[value_idx];
+        let encoded = page(&page_bytes, value_idx)?;
         match column_kind(column_id, plans)? {
             ColKind::I64 => {
                 let vals = decode_i64(enc, encoded, present_count)?;
@@ -753,6 +839,88 @@ mod tests {
         assert_eq!(f64::from_bits(s11.min_bits), -3.0);
         assert_eq!(f64::from_bits(s11.max_bits), 1.5);
         assert_eq!(s11.null_count, 7);
+    }
+
+    /// A column filter decodes only the named columns' pages, leaves every
+    /// other column absent, and reports how many pages it walked past. The
+    /// values it does decode are identical to the all-columns decode's, so
+    /// projection changes cost, never content.
+    #[test]
+    fn column_filter_decodes_only_the_named_columns() {
+        let plans: Vec<ColumnPlan> = (10..30)
+            .map(|column_id| ColumnPlan {
+                column_id,
+                ty: FieldType::Str,
+            })
+            .collect();
+        let mut rows = Vec::new();
+        for i in 0..64i64 {
+            let mut r = row(0, 1000 + i);
+            for p in &plans {
+                r.columns.push((
+                    p.column_id,
+                    ColumnValue::Str(format!("c{}r{i}", p.column_id).into_bytes()),
+                ));
+            }
+            rows.push(r);
+        }
+        let out = write_block(&rows, &plans, 3).expect("write");
+
+        let all = read_block(&out.bytes, out.crc32c, &plans, 1 << 30).expect("read all");
+        assert_eq!(all.pages_skipped(), 0, "no filter skips nothing");
+
+        let keep: HashSet<u32> = HashSet::from([COL_TS, COL_STREAM_REF, 11, 17]);
+        let projected =
+            read_block_columns(&out.bytes, out.crc32c, &plans, 1 << 30, Some(&keep)).expect("read");
+
+        assert_eq!(projected.record_count(), 64);
+        // Exactly the four requested columns decoded, one page each (every
+        // column here is present in every row, so no presence bitmaps).
+        assert_eq!(projected.pages_decoded(), 4);
+        assert_eq!(
+            projected.pages_decoded() + projected.pages_skipped(),
+            all.pages_decoded(),
+            "every page is either decoded or skipped, none invented"
+        );
+        assert!(
+            projected.pages_skipped() >= 18,
+            "the 18 unreferenced dynamic columns must be skipped, got {}",
+            projected.pages_skipped()
+        );
+
+        // Kept columns decode identically to the unfiltered decode.
+        assert_eq!(projected.i64_col(COL_TS), all.i64_col(COL_TS));
+        assert_eq!(projected.str_col(11), all.str_col(11));
+        assert_eq!(projected.str_col(17), all.str_col(17));
+        // Excluded columns are absent, including fixed ones.
+        assert!(projected.str_col(12).is_none());
+        assert!(projected.str_col(COL_BODY).is_none());
+        assert!(all.str_col(COL_BODY).is_some());
+    }
+
+    /// A filter never weakens the integrity checks: the block crc still covers
+    /// the whole block, so a corrupted byte inside a *skipped* column's page is
+    /// still caught.
+    #[test]
+    fn column_filter_still_verifies_the_whole_block_crc() {
+        let plans = vec![ColumnPlan {
+            column_id: 10,
+            ty: FieldType::Str,
+        }];
+        let mut rows = vec![row(0, 1), row(0, 2)];
+        for r in &mut rows {
+            r.columns.push((10, ColumnValue::Str(b"payload".to_vec())));
+        }
+        let out = write_block(&rows, &plans, 3).expect("write");
+        let keep: HashSet<u32> = HashSet::from([COL_TS, COL_STREAM_REF]);
+        // Corrupt the tail, which belongs to a column the filter skips.
+        let mut bad = out.bytes.clone();
+        let last = bad.len() - 1;
+        bad[last] ^= 0xff;
+        assert!(matches!(
+            read_block_columns(&bad, out.crc32c, &plans, 1 << 30, Some(&keep)),
+            Err(LogSegError::Corrupted(_))
+        ));
     }
 
     #[test]

--- a/crates/ravel-logseg/src/columns.rs
+++ b/crates/ravel-logseg/src/columns.rs
@@ -1,0 +1,306 @@
+//! The column set a scan needs decoded (ADR-0087 decision 3).
+//!
+//! [`crate::block::read_block_columns`] takes raw column ids, but a caller
+//! outside this crate cannot know a dynamic attribute's column id: ids are
+//! assigned per object by its FIELD_DIR. [`ColumnSelection`] is the caller-facing
+//! form -- fixed columns by name, dynamic columns by *attribute* name -- which
+//! [`RlogReader`](crate::RlogReader) resolves against the object it opened.
+//!
+//! Two columns are always decoded, whatever the selection says: `ts` and
+//! `stream_ref`. Every predicate evaluation path and every rebuilt record needs
+//! them (`ts` for the exact ts-range re-check, `stream_ref` to resolve a record
+//! back to its stream identity and its resource/scope attributes), so naming
+//! them would be noise and forgetting them would be a bug.
+//!
+//! A record's resource and scope attributes are *not* a block column at all:
+//! they live in STREAM_DIR and are reached through `stream_ref`. They therefore
+//! cost nothing to keep and are always present in a rebuilt record, however
+//! narrow the selection.
+
+use std::collections::{BTreeSet, HashSet};
+
+use crate::field_dir::FieldDir;
+use crate::record::{
+    COL_ATTRS_RAW, COL_BODY, COL_FLAGS, COL_OBSERVED_TS, COL_SEVERITY_NUM, COL_SEVERITY_TEXT,
+    COL_SPAN_ID, COL_STREAM_REF, COL_TRACE_ID, COL_TS,
+};
+
+/// Which columns a scan needs decoded from each block.
+///
+/// Build one with [`ColumnSelection::all`] (today's behavior: decode
+/// everything) or [`ColumnSelection::fixed_only`] plus the `with_*` builders.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ColumnSelection {
+    /// Decode every column in the block, ignoring every other field here.
+    all: bool,
+    /// Decode every dynamic attribute column plus the `attrs_raw` overflow.
+    all_attrs: bool,
+    /// Explicitly requested fixed column ids (`ts`/`stream_ref` are implicit).
+    fixed: BTreeSet<u32>,
+    /// Requested dynamic attribute names, resolved per object against FIELD_DIR.
+    attrs: BTreeSet<String>,
+}
+
+impl ColumnSelection {
+    /// Decode every column, exactly as the reader did before column projection
+    /// existed. This is what compaction's ranged reader and
+    /// [`RlogReader::scan_pruned`](crate::RlogReader::scan_pruned) use.
+    #[must_use]
+    pub fn all() -> Self {
+        ColumnSelection {
+            all: true,
+            all_attrs: false,
+            fixed: BTreeSet::new(),
+            attrs: BTreeSet::new(),
+        }
+    }
+
+    /// The narrowest selection: `ts` and `stream_ref` only. Add what the query
+    /// needs with the `with_*` builders.
+    #[must_use]
+    pub fn fixed_only() -> Self {
+        ColumnSelection {
+            all: false,
+            all_attrs: false,
+            fixed: BTreeSet::new(),
+            attrs: BTreeSet::new(),
+        }
+    }
+
+    /// True when this selection decodes every column.
+    #[must_use]
+    pub fn is_all(&self) -> bool {
+        self.all
+    }
+
+    /// True when this selection decodes every dynamic attribute column (either
+    /// because it decodes everything, or because a query referenced the merged
+    /// `attrs` view).
+    #[must_use]
+    pub fn wants_all_attrs(&self) -> bool {
+        self.all || self.all_attrs
+    }
+
+    /// Decode `observed_ts`.
+    #[must_use]
+    pub fn with_observed_ts(self) -> Self {
+        self.with_fixed(COL_OBSERVED_TS)
+    }
+
+    /// Decode `severity_num`.
+    #[must_use]
+    pub fn with_severity_num(self) -> Self {
+        self.with_fixed(COL_SEVERITY_NUM)
+    }
+
+    /// Decode `severity_text`.
+    #[must_use]
+    pub fn with_severity_text(self) -> Self {
+        self.with_fixed(COL_SEVERITY_TEXT)
+    }
+
+    /// Decode `body`.
+    #[must_use]
+    pub fn with_body(self) -> Self {
+        self.with_fixed(COL_BODY)
+    }
+
+    /// Decode `trace_id`.
+    #[must_use]
+    pub fn with_trace_id(self) -> Self {
+        self.with_fixed(COL_TRACE_ID)
+    }
+
+    /// Decode `span_id`.
+    #[must_use]
+    pub fn with_span_id(self) -> Self {
+        self.with_fixed(COL_SPAN_ID)
+    }
+
+    /// Decode `flags`.
+    #[must_use]
+    pub fn with_flags(self) -> Self {
+        self.with_fixed(COL_FLAGS)
+    }
+
+    /// Decode the dynamic column(s) carrying attribute `name`, plus the
+    /// `attrs_raw` overflow column (a record can carry the attribute there
+    /// instead of in a column, and the two are indistinguishable to a caller
+    /// naming a key).
+    ///
+    /// A name can map to more than one column id: FIELD_DIR keys a column by
+    /// `(name, type)`, so the same key seen with a string value and an integer
+    /// value in one object occupies two columns. All of them are decoded.
+    #[must_use]
+    pub fn with_attr(mut self, name: impl Into<String>) -> Self {
+        self.attrs.insert(name.into());
+        self
+    }
+
+    /// Decode every dynamic attribute column plus `attrs_raw`. This is what a
+    /// query referencing the SQL `attrs` map column at all resolves to,
+    /// including `SELECT *` (ADR-0087: per-key `attrs['k']` projection is out
+    /// of scope, and the merged map's contract is that every key is present).
+    #[must_use]
+    pub fn with_all_attrs(mut self) -> Self {
+        self.all_attrs = true;
+        self
+    }
+
+    fn with_fixed(mut self, column_id: u32) -> Self {
+        self.fixed.insert(column_id);
+        self
+    }
+
+    /// Resolve to the concrete block column ids for one object, or `None` when
+    /// every column is wanted (which [`crate::block::read_block_columns`] takes
+    /// as "no filter").
+    pub(crate) fn resolve(&self, field_dir: &FieldDir) -> Option<HashSet<u32>> {
+        if self.all {
+            return None;
+        }
+        let mut out: HashSet<u32> = HashSet::new();
+        // Always needed: the exact ts re-check and the stream-identity lookup.
+        out.insert(COL_TS);
+        out.insert(COL_STREAM_REF);
+        out.extend(self.fixed.iter().copied());
+        if self.all_attrs {
+            out.insert(COL_ATTRS_RAW);
+            out.extend(field_dir.entries().iter().map(|e| e.column_id));
+        } else if !self.attrs.is_empty() {
+            // An attribute named here may live in a dynamic column or have
+            // overflowed into `attrs_raw`; both must be readable.
+            out.insert(COL_ATTRS_RAW);
+            for e in field_dir.entries() {
+                if self.attrs.contains(&e.name) {
+                    out.insert(e.column_id);
+                }
+            }
+        }
+        Some(out)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::record::FieldType;
+    use crate::writer::{ObjectIdentity, RlogConfig, RlogWriter};
+    use crate::{LogRecord, RlogReader};
+    use ravel_types::logstream::AttrValue;
+
+    fn dir() -> FieldDir {
+        // Build a real object so the FIELD_DIR is the writer's, not a fixture.
+        let identity = ObjectIdentity {
+            tenant_hash: [0u8; 16],
+            shard: 0,
+            writer_id: [0u8; 16],
+            writer_epoch: 0,
+            writer_seq: 0,
+        };
+        let cfg = RlogConfig::default();
+        let mut w = RlogWriter::new(cfg, identity);
+        let resource = [("service.name".to_string(), AttrValue::Str("api".into()))];
+        let mut rec = LogRecord {
+            stream_id: ravel_types::logstream::log_stream_id(&resource, "s", "1", &[]),
+            stream_attrs: crate::record::stream_attrs_bytes(&resource, "s", "1", &[]),
+            ts_ns: 1,
+            observed_ts_ns: 1,
+            severity_num: 9,
+            severity_text: "INFO".into(),
+            body: "b".into(),
+            trace_id: None,
+            span_id: None,
+            flags: 0,
+            attrs: vec![
+                ("k".to_string(), AttrValue::Str("v".into())),
+                ("n".to_string(), AttrValue::I64(1)),
+            ],
+        };
+        w.push(rec.clone()).expect("push");
+        // Same key with a different value type: two FIELD_DIR columns for "k".
+        rec.ts_ns = 2;
+        rec.attrs = vec![("k".to_string(), AttrValue::I64(7))];
+        w.push(rec).expect("push");
+        let bytes = w.finish().expect("finish");
+        let reader = RlogReader::new(&bytes, &cfg).expect("open");
+        reader.field_dir().clone()
+    }
+
+    #[test]
+    fn all_resolves_to_no_filter() {
+        assert!(ColumnSelection::all().resolve(&dir()).is_none());
+        assert!(ColumnSelection::all().is_all());
+    }
+
+    #[test]
+    fn fixed_only_still_keeps_ts_and_stream_ref() {
+        let got = ColumnSelection::fixed_only()
+            .resolve(&dir())
+            .expect("a filter");
+        assert_eq!(got, HashSet::from([COL_TS, COL_STREAM_REF]));
+    }
+
+    #[test]
+    fn named_fixed_columns_are_added() {
+        let got = ColumnSelection::fixed_only()
+            .with_body()
+            .with_flags()
+            .resolve(&dir())
+            .expect("a filter");
+        assert_eq!(
+            got,
+            HashSet::from([COL_TS, COL_STREAM_REF, COL_BODY, COL_FLAGS])
+        );
+    }
+
+    #[test]
+    fn one_attr_name_resolves_to_every_column_id_for_that_name_plus_overflow() {
+        let field_dir = dir();
+        let want: HashSet<u32> = field_dir
+            .entries()
+            .iter()
+            .filter(|e| e.name == "k")
+            .map(|e| e.column_id)
+            .collect();
+        // The fixture writes `k` as both Str and I64, so this is the
+        // multi-column case, not a single-column one.
+        assert_eq!(
+            want.len(),
+            2,
+            "fixture must exercise two columns for one key"
+        );
+        assert!(field_dir.column("k", FieldType::Str).is_some());
+        assert!(field_dir.column("k", FieldType::I64).is_some());
+
+        let got = ColumnSelection::fixed_only()
+            .with_attr("k")
+            .resolve(&field_dir)
+            .expect("a filter");
+        let mut expect = want;
+        expect.extend([COL_TS, COL_STREAM_REF, COL_ATTRS_RAW]);
+        assert_eq!(got, expect);
+        // `n` is a different key and is not decoded.
+        let n = field_dir.column("n", FieldType::I64).expect("n column");
+        assert!(!got.contains(&n.column_id));
+    }
+
+    #[test]
+    fn all_attrs_resolves_to_every_dynamic_column_plus_overflow() {
+        let field_dir = dir();
+        let got = ColumnSelection::fixed_only()
+            .with_all_attrs()
+            .resolve(&field_dir)
+            .expect("a filter");
+        assert!(got.contains(&COL_ATTRS_RAW));
+        for e in field_dir.entries() {
+            assert!(got.contains(&e.column_id), "missing column {}", e.column_id);
+        }
+        assert!(
+            ColumnSelection::fixed_only()
+                .with_all_attrs()
+                .wants_all_attrs()
+        );
+    }
+}

--- a/crates/ravel-logseg/src/lib.rs
+++ b/crates/ravel-logseg/src/lib.rs
@@ -13,6 +13,7 @@
 //! panicking.
 
 pub mod block;
+pub mod columns;
 pub mod error;
 pub mod field_dir;
 pub mod footer;
@@ -31,10 +32,11 @@ pub mod writer;
 // Cargo.toml need to change.
 pub use ravel_codec::{bloom, bloom_section, encoding, tokenizer};
 
+pub use columns::ColumnSelection;
 pub use error::LogSegError;
 pub use footer::{SuffixOutcome, open_from_suffix};
 pub use ranged::{RlogRangeReader, StreamBlockLoc, StreamBlockSpan};
-pub use reader::{RlogReader, ScanStats, decode_section, read_section};
+pub use reader::{BlockScan, RlogReader, ScanStats, decode_section, read_section};
 pub use record::{FieldSel, LogRecord, Predicate, stream_attrs_bytes};
 pub use writer::{ObjectIdentity, RlogConfig, RlogWriter};
 

--- a/crates/ravel-logseg/src/reader.rs
+++ b/crates/ravel-logseg/src/reader.rs
@@ -10,8 +10,9 @@
 
 use ravel_types::logstream::AttrValue;
 
-use crate::block::{ColumnPlan, DecodedBlock, read_block};
+use crate::block::{ColumnPlan, DecodedBlock, read_block_columns};
 use crate::bloom_section::BloomSection;
+use crate::columns::ColumnSelection;
 use crate::error::LogSegError;
 use crate::field_dir::FieldDir;
 use crate::footer::{COMP_ZSTD, LogFooter, SectionDesc, kind, open};
@@ -45,6 +46,14 @@ pub struct ScanStats {
     /// be parsed and postings pruning was skipped for that arm (the scan
     /// still returns correct results via bloom + exact scan).
     pub postings_degraded: bool,
+    /// Block pages this scan decompressed and decoded. Grows as blocks are
+    /// decoded, so a partially-drained [`BlockScan`] reports what it has read
+    /// so far, not what it will read.
+    pub pages_decoded: u64,
+    /// Block pages this scan skipped because the [`ColumnSelection`] excluded
+    /// their column. Zero for an all-columns scan; the observable proof that
+    /// column projection reached the page level (ADR-0087 decision 3).
+    pub pages_skipped: u64,
 }
 
 /// An opened RLOG object ready to scan.
@@ -92,6 +101,15 @@ impl<'a> RlogReader<'a> {
         column_plans(&self.field_dir)
     }
 
+    /// This object's FIELD_DIR. Test-only: production resolution of a
+    /// [`ColumnSelection`] happens inside [`RlogReader::scan_blocks`], which
+    /// reaches the directory directly; `columns.rs`'s unit tests need a real
+    /// writer-produced FIELD_DIR to resolve against.
+    #[cfg(test)]
+    pub(crate) fn field_dir(&self) -> &FieldDir {
+        &self.field_dir
+    }
+
     /// Scans the object for records matching `pred`, evaluated exactly per row.
     ///
     /// Equivalent to [`RlogReader::scan_pruned`] with an empty prune channel.
@@ -133,6 +151,38 @@ impl<'a> RlogReader<'a> {
         content: &Predicate,
         prune: &[Predicate],
     ) -> Result<(Vec<LogRecord>, ScanStats), LogSegError> {
+        let mut cursor = self.scan_blocks(content, prune, &ColumnSelection::all())?;
+        let mut out = Vec::new();
+        while let Some(rows) = cursor.next_block(self.bytes)? {
+            out.extend(rows);
+        }
+        Ok((out, cursor.stats()))
+    }
+
+    /// The block-at-a-time form of [`RlogReader::scan_pruned`], plus column
+    /// projection (ADR-0087).
+    ///
+    /// Pruning is identical: the same skip-index, POSTINGS, and bloom steps run
+    /// here, once, and the returned [`BlockScan`] names exactly the surviving
+    /// blocks. What differs is that nothing is decoded yet. The caller drives
+    /// [`BlockScan::next_block`] one block at a time and can release each
+    /// block's records before asking for the next, so peak resident decoded
+    /// memory is one block rather than one object.
+    ///
+    /// `columns` narrows what each block decodes.
+    /// [`ColumnSelection::all`] reproduces `scan_pruned` exactly, which is how
+    /// `scan_pruned` itself is implemented; a narrower selection leaves the
+    /// unselected columns undecoded, so the rebuilt records carry a *partial*
+    /// view (an unselected fixed column reads as its zero value, an unselected
+    /// attribute is simply absent from `attrs`). A caller that narrows the
+    /// selection is responsible for having included every column it, or
+    /// anything downstream of it, reads.
+    pub fn scan_blocks(
+        &self,
+        content: &Predicate,
+        prune: &[Predicate],
+        columns: &ColumnSelection,
+    ) -> Result<BlockScan, LogSegError> {
         let mut stats = ScanStats {
             blocks_total: self.skip.l0.len() as u32,
             ..ScanStats::default()
@@ -159,7 +209,7 @@ impl<'a> RlogReader<'a> {
             }
         }
         if ts_min > ts_max {
-            return Ok((Vec::new(), stats));
+            return Ok(self.empty_scan(stats));
         }
 
         // Stream filter: intersect every StreamIn arm's resolved refs.
@@ -179,7 +229,7 @@ impl<'a> RlogReader<'a> {
             }
         }
         if stream_refs.as_ref().is_some_and(|r| r.is_empty()) {
-            return Ok((Vec::new(), stats));
+            return Ok(self.empty_scan(stats));
         }
 
         // Skip-index pruning.
@@ -261,21 +311,51 @@ impl<'a> RlogReader<'a> {
         }
         stats.blocks_after_bloom = survivors.len() as u32;
 
-        // Read, verify, decode, and re-evaluate the survivors exactly.
-        let plans = self.plans();
-        let mut out = Vec::new();
+        // Locate the survivors. Nothing is read or decoded here: the caller
+        // drives the decode one block at a time through `BlockScan::next_block`.
+        let mut blocks = Vec::with_capacity(survivors.len());
         for &b in &survivors {
-            let entry = &self.skip.l0[b];
-            let block_bytes = self.block_bytes(entry.block_offset, entry.block_len)?;
-            let decoded = read_block(block_bytes, entry.block_crc32c, &plans, DEFAULT_MAX_UNCOMP)?;
-            for row in 0..decoded.record_count() {
-                if self.eval(content, &decoded, row)? {
-                    out.push(self.rebuild_record(&decoded, row)?);
-                }
-            }
+            let entry =
+                self.skip.l0.get(b).ok_or_else(|| {
+                    LogSegError::Corrupted("skip block index out of range".into())
+                })?;
+            let start = self
+                .blocks_offset
+                .checked_add(entry.block_offset)
+                .ok_or_else(|| LogSegError::Corrupted("block offset overflow".into()))?;
+            blocks.push(BlockLoc {
+                start,
+                len: entry.block_len,
+                crc32c: entry.block_crc32c,
+            });
         }
-        stats.blocks_scanned = survivors.len() as u32;
-        Ok((out, stats))
+
+        Ok(BlockScan {
+            stream_dir: self.stream_dir.clone(),
+            field_dir: self.field_dir.clone(),
+            plans: self.plans(),
+            columns: columns.resolve(&self.field_dir),
+            content: content.clone(),
+            blocks,
+            next: 0,
+            stats,
+        })
+    }
+
+    /// A cursor over zero surviving blocks, for the two pre-decode short
+    /// circuits (an empty ts range, an empty resolved stream set). Draining it
+    /// yields nothing, which is what those paths returned before.
+    fn empty_scan(&self, stats: ScanStats) -> BlockScan {
+        BlockScan {
+            stream_dir: self.stream_dir.clone(),
+            field_dir: self.field_dir.clone(),
+            plans: Vec::new(),
+            columns: None,
+            content: Predicate::And(Vec::new()),
+            blocks: Vec::new(),
+            next: 0,
+            stats,
+        }
     }
 
     /// The bloom-eligible arms: HasWord on any field, and Equals on a short
@@ -467,145 +547,236 @@ impl<'a> RlogReader<'a> {
             .get(start..end)
             .ok_or_else(|| LogSegError::Corrupted("section out of bounds".into()))
     }
+}
 
-    /// Slice of one block's stored bytes (offset is relative to BLOCKS).
-    fn block_bytes(&self, block_offset: u64, block_len: u64) -> Result<&'a [u8], LogSegError> {
-        let abs = self
-            .blocks_offset
-            .checked_add(block_offset)
-            .ok_or_else(|| LogSegError::Corrupted("block offset overflow".into()))?;
-        let start = usize::try_from(abs)
+/// The absolute extent and checksum of one surviving block, copied out of the
+/// skip index so a [`BlockScan`] can locate it without borrowing the reader.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct BlockLoc {
+    start: u64,
+    len: u64,
+    crc32c: u32,
+}
+
+/// A pruned scan that has not decoded anything yet: the surviving block list,
+/// the directories needed to rebuild records, and the resolved column filter.
+///
+/// [`RlogReader::scan_pruned`] is this type drained in a loop. The point of
+/// exposing it is that a caller can drain it *incrementally* and drop each
+/// block's records before asking for the next, which is what bounds the SQL
+/// logs scan's peak memory to one block rather than one partition (ADR-0087).
+///
+/// It owns everything it needs (the two directories are cloned out of the
+/// reader), so it does not borrow the object bytes. The bytes are supplied per
+/// call instead, which lets the caller hold them however it likes -- an owned
+/// `Bytes` from a cache hit, say -- without a self-referential struct.
+pub struct BlockScan {
+    stream_dir: StreamDir,
+    field_dir: FieldDir,
+    plans: Vec<ColumnPlan>,
+    /// `None` decodes every column (see [`ColumnSelection::resolve`]).
+    columns: Option<std::collections::HashSet<u32>>,
+    /// The exact per-row filter, re-evaluated against every decoded row.
+    content: Predicate,
+    blocks: Vec<BlockLoc>,
+    next: usize,
+    stats: ScanStats,
+}
+
+impl BlockScan {
+    /// Pruning counters. `blocks_total`/`blocks_after_*` are final from
+    /// construction; `blocks_scanned`, `pages_decoded`, and `pages_skipped`
+    /// grow as blocks are drained, so read this after the last
+    /// [`Self::next_block`] to get the whole scan's figures.
+    pub fn stats(&self) -> ScanStats {
+        self.stats
+    }
+
+    /// Surviving blocks not yet decoded.
+    pub fn remaining_blocks(&self) -> usize {
+        self.blocks.len().saturating_sub(self.next)
+    }
+
+    /// Decode the next surviving block and return the rows of it that match the
+    /// exact filter, or `None` once every surviving block has been decoded.
+    ///
+    /// `object_bytes` MUST be the whole RLOG object the [`RlogReader`] this
+    /// cursor came from was opened on: block extents are absolute offsets into
+    /// it. A block whose extent falls outside the buffer is a typed
+    /// `Corrupted` error, never a panic.
+    ///
+    /// Returning `Some(vec![])` is normal and distinct from `None`: a block can
+    /// survive pruning and still have no row matching the exact filter. Only
+    /// `None` means the scan is finished.
+    pub fn next_block(
+        &mut self,
+        object_bytes: &[u8],
+    ) -> Result<Option<Vec<LogRecord>>, LogSegError> {
+        let Some(loc) = self.blocks.get(self.next).copied() else {
+            return Ok(None);
+        };
+        self.next += 1;
+        let start = usize::try_from(loc.start)
             .map_err(|_| LogSegError::Corrupted("block offset range".into()))?;
-        let len = usize::try_from(block_len)
+        let len = usize::try_from(loc.len)
             .map_err(|_| LogSegError::Corrupted("block len range".into()))?;
         let end = start
             .checked_add(len)
             .ok_or_else(|| LogSegError::Corrupted("block range overflow".into()))?;
-        self.bytes
+        let block_bytes = object_bytes
             .get(start..end)
-            .ok_or_else(|| LogSegError::Corrupted("block out of bounds".into()))
+            .ok_or_else(|| LogSegError::Corrupted("block out of bounds".into()))?;
+        let decoded = read_block_columns(
+            block_bytes,
+            loc.crc32c,
+            &self.plans,
+            DEFAULT_MAX_UNCOMP,
+            self.columns.as_ref(),
+        )?;
+        self.stats.blocks_scanned += 1;
+        self.stats.pages_decoded += decoded.pages_decoded() as u64;
+        self.stats.pages_skipped += decoded.pages_skipped() as u64;
+
+        let strict = self.columns.is_none();
+        let mut out = Vec::new();
+        for row in 0..decoded.record_count() {
+            if eval(
+                &self.stream_dir,
+                &self.field_dir,
+                &self.content,
+                &decoded,
+                row,
+            )? {
+                out.push(rebuild_record_projected(
+                    &self.stream_dir,
+                    &self.field_dir,
+                    &decoded,
+                    row,
+                    strict,
+                )?);
+            }
+        }
+        Ok(Some(out))
     }
+}
 
-    // --- exact evaluation ---------------------------------------------------
+// --- exact evaluation -------------------------------------------------------
 
-    fn eval(
-        &self,
-        pred: &Predicate,
-        block: &DecodedBlock,
-        row: usize,
-    ) -> Result<bool, LogSegError> {
-        Ok(match pred {
-            Predicate::And(v) => {
-                for p in v {
-                    if !self.eval(p, block, row)? {
-                        return Ok(false);
-                    }
-                }
-                true
-            }
-            Predicate::TsRange { min_ns, max_ns } => {
-                let ts = i64_at(block, COL_TS, row)?;
-                ts >= *min_ns && ts <= *max_ns
-            }
-            Predicate::StreamIn(ids) => {
-                let r = u32::try_from(i64_at(block, COL_STREAM_REF, row)?)
-                    .map_err(|_| LogSegError::Corrupted("stream_ref range".into()))?;
-                match self.stream_dir.stream_id(r) {
-                    Some(sid) => ids.contains(sid),
-                    None => false,
+/// Evaluate the exact filter against one decoded row.
+///
+/// Free rather than a [`RlogReader`] method because [`BlockScan`] evaluates the
+/// same predicate without holding a reader: both need only the two directories.
+fn eval(
+    stream_dir: &StreamDir,
+    field_dir: &FieldDir,
+    pred: &Predicate,
+    block: &DecodedBlock,
+    row: usize,
+) -> Result<bool, LogSegError> {
+    Ok(match pred {
+        Predicate::And(v) => {
+            for p in v {
+                if !eval(stream_dir, field_dir, p, block, row)? {
+                    return Ok(false);
                 }
             }
-            Predicate::HasWord { field, word } => {
-                let value = self.field_text(field, block, row)?;
-                match value {
-                    Some(bytes) => phrase_match(&bytes, word),
-                    None => false,
-                }
+            true
+        }
+        Predicate::TsRange { min_ns, max_ns } => {
+            let ts = i64_at(block, COL_TS, row)?;
+            ts >= *min_ns && ts <= *max_ns
+        }
+        Predicate::StreamIn(ids) => {
+            let r = u32::try_from(i64_at(block, COL_STREAM_REF, row)?)
+                .map_err(|_| LogSegError::Corrupted("stream_ref range".into()))?;
+            match stream_dir.stream_id(r) {
+                Some(sid) => ids.contains(sid),
+                None => false,
             }
-            Predicate::Equals { field, value } => self.equals(field, value, block, row)?,
-        })
-    }
+        }
+        Predicate::HasWord { field, word } => {
+            let value = field_text(field_dir, field, block, row)?;
+            match value {
+                Some(bytes) => phrase_match(&bytes, word),
+                None => false,
+            }
+        }
+        Predicate::Equals { field, value } => equals(field_dir, field, value, block, row)?,
+    })
+}
 
-    /// The tokenizable text of a field for a row, if present.
-    fn field_text(
-        &self,
-        field: &FieldSel,
-        block: &DecodedBlock,
-        row: usize,
-    ) -> Result<Option<Vec<u8>>, LogSegError> {
-        Ok(match field {
-            FieldSel::Body => str_at(block, COL_BODY, row),
-            FieldSel::SeverityText => str_at(block, COL_SEVERITY_TEXT, row),
-            FieldSel::Attr(name) => {
-                match self.field_dir.column(name, FieldType::Str) {
-                    Some(e) => str_at(block, e.column_id, row),
-                    // Fall back to an overflow attr of type Str.
-                    None => self.overflow_attr(block, row, name)?.and_then(|v| match v {
-                        AttrValue::Str(s) => Some(s.into_bytes()),
-                        _ => None,
-                    }),
-                }
+/// The tokenizable text of a field for a row, if present.
+fn field_text(
+    field_dir: &FieldDir,
+    field: &FieldSel,
+    block: &DecodedBlock,
+    row: usize,
+) -> Result<Option<Vec<u8>>, LogSegError> {
+    Ok(match field {
+        FieldSel::Body => str_at(block, COL_BODY, row),
+        FieldSel::SeverityText => str_at(block, COL_SEVERITY_TEXT, row),
+        FieldSel::Attr(name) => {
+            match field_dir.column(name, FieldType::Str) {
+                Some(e) => str_at(block, e.column_id, row),
+                // Fall back to an overflow attr of type Str.
+                None => overflow_attr(block, row, name)?.and_then(|v| match v {
+                    AttrValue::Str(s) => Some(s.into_bytes()),
+                    _ => None,
+                }),
             }
-        })
-    }
+        }
+    })
+}
 
-    fn equals(
-        &self,
-        field: &FieldSel,
-        value: &AttrValue,
-        block: &DecodedBlock,
-        row: usize,
-    ) -> Result<bool, LogSegError> {
-        match field {
-            FieldSel::Body | FieldSel::SeverityText => {
-                let col = if matches!(field, FieldSel::Body) {
-                    COL_BODY
-                } else {
-                    COL_SEVERITY_TEXT
-                };
-                let stored = str_at(block, col, row);
-                Ok(match (value, stored) {
-                    (AttrValue::Str(s), Some(b)) => s.as_bytes() == b.as_slice(),
-                    _ => false,
-                })
-            }
-            FieldSel::Attr(name) => {
-                let (ty, _) = resolve_value(value);
-                if let Some(entry) = self.field_dir.column(name, ty) {
-                    Ok(attr_equals(block, entry.column_id, ty, value, row))
-                } else {
-                    // Overflow: compare against the decoded attrs_raw value.
-                    Ok(self
-                        .overflow_attr(block, row, name)?
-                        .as_ref()
-                        .is_some_and(|v| attr_value_eq(v, value)))
-                }
+fn equals(
+    field_dir: &FieldDir,
+    field: &FieldSel,
+    value: &AttrValue,
+    block: &DecodedBlock,
+    row: usize,
+) -> Result<bool, LogSegError> {
+    match field {
+        FieldSel::Body | FieldSel::SeverityText => {
+            let col = if matches!(field, FieldSel::Body) {
+                COL_BODY
+            } else {
+                COL_SEVERITY_TEXT
+            };
+            let stored = str_at(block, col, row);
+            Ok(match (value, stored) {
+                (AttrValue::Str(s), Some(b)) => s.as_bytes() == b.as_slice(),
+                _ => false,
+            })
+        }
+        FieldSel::Attr(name) => {
+            let (ty, _) = resolve_value(value);
+            if let Some(entry) = field_dir.column(name, ty) {
+                Ok(attr_equals(block, entry.column_id, ty, value, row))
+            } else {
+                // Overflow: compare against the decoded attrs_raw value.
+                Ok(overflow_attr(block, row, name)?
+                    .as_ref()
+                    .is_some_and(|v| attr_value_eq(v, value)))
             }
         }
     }
+}
 
-    /// Looks up an attribute by name in a row's decoded `attrs_raw`, if any.
-    fn overflow_attr(
-        &self,
-        block: &DecodedBlock,
-        row: usize,
-        name: &str,
-    ) -> Result<Option<AttrValue>, LogSegError> {
-        let raw = match block.str_col(crate::record::COL_ATTRS_RAW) {
-            Some(col) => match col.get(row).and_then(|v| v.as_ref()) {
-                Some(bytes) => bytes.clone(),
-                None => return Ok(None),
-            },
+/// Looks up an attribute by name in a row's decoded `attrs_raw`, if any.
+fn overflow_attr(
+    block: &DecodedBlock,
+    row: usize,
+    name: &str,
+) -> Result<Option<AttrValue>, LogSegError> {
+    let raw = match block.str_col(crate::record::COL_ATTRS_RAW) {
+        Some(col) => match col.get(row).and_then(|v| v.as_ref()) {
+            Some(bytes) => bytes.clone(),
             None => return Ok(None),
-        };
-        let attrs = decode_canonical_attrs(&raw)?;
-        Ok(attrs.into_iter().find(|(k, _)| k == name).map(|(_, v)| v))
-    }
-
-    /// Rebuilds a full [`LogRecord`] from a decoded row.
-    fn rebuild_record(&self, block: &DecodedBlock, row: usize) -> Result<LogRecord, LogSegError> {
-        rebuild_record(&self.stream_dir, &self.field_dir, block, row)
-    }
+        },
+        None => return Ok(None),
+    };
+    let attrs = decode_canonical_attrs(&raw)?;
+    Ok(attrs.into_iter().find(|(k, _)| k == name).map(|(_, v)| v))
 }
 
 /// The column plans for every dynamic column, for block decode. Shared by the
@@ -632,6 +803,30 @@ pub(crate) fn rebuild_record(
     field_dir: &FieldDir,
     block: &DecodedBlock,
     row: usize,
+) -> Result<LogRecord, LogSegError> {
+    rebuild_record_projected(stream_dir, field_dir, block, row, true)
+}
+
+/// [`rebuild_record`] over a possibly column-projected block.
+///
+/// `strict` is the all-columns contract: every fixed numeric column must be
+/// present, and its absence is a `Corrupted` error, because for an unprojected
+/// decode absence really does mean the block is malformed. Under a projection
+/// (`strict == false`) an undecoded fixed numeric column is expected, so it
+/// reads as `0` rather than erroring -- the caller asked not to decode it and
+/// must not read the field. `ts` and `stream_ref` are exempt: a
+/// [`ColumnSelection`](crate::ColumnSelection) always keeps them, so their
+/// absence is a real corruption under either mode and still errors.
+///
+/// String and fixed-width columns need no mode: they are `Option` at the block
+/// level already, so an undecoded one reads as empty/`None` exactly as an
+/// absent one does.
+pub(crate) fn rebuild_record_projected(
+    stream_dir: &StreamDir,
+    field_dir: &FieldDir,
+    block: &DecodedBlock,
+    row: usize,
+    strict: bool,
 ) -> Result<LogRecord, LogSegError> {
     let sref = u32::try_from(i64_at(block, COL_STREAM_REF, row)?)
         .map_err(|_| LogSegError::Corrupted("stream_ref range".into()))?;
@@ -677,15 +872,31 @@ pub(crate) fn rebuild_record(
         stream_id,
         stream_attrs,
         ts_ns: i64_at(block, COL_TS, row)?,
-        observed_ts_ns: i64_at(block, COL_OBSERVED_TS, row)?,
-        severity_num: i64_at(block, COL_SEVERITY_NUM, row)? as u8,
+        observed_ts_ns: i64_projected(block, COL_OBSERVED_TS, row, strict)?,
+        severity_num: i64_projected(block, COL_SEVERITY_NUM, row, strict)? as u8,
         severity_text,
         body,
         trace_id,
         span_id,
-        flags: i64_at(block, COL_FLAGS, row)? as u32,
+        flags: i64_projected(block, COL_FLAGS, row, strict)? as u32,
         attrs,
     })
+}
+
+/// A fixed numeric column's value, or `0` when the column was projected away.
+/// Under `strict` (an all-columns decode) an absent column is corruption and
+/// errors, exactly as before column projection existed.
+fn i64_projected(
+    block: &DecodedBlock,
+    col: u32,
+    row: usize,
+    strict: bool,
+) -> Result<i64, LogSegError> {
+    match block.i64_col(col) {
+        Some(_) => i64_at(block, col, row),
+        None if strict => i64_at(block, col, row),
+        None => Ok(0),
+    }
 }
 
 fn section(footer: &LogFooter, k: u32) -> Result<&SectionDesc, LogSegError> {

--- a/crates/ravel-query/src/lib.rs
+++ b/crates/ravel-query/src/lib.rs
@@ -25,7 +25,7 @@ pub use fetcher::{
     CacheFetchError, FetchError, FetchStats, FetchedSeries, FetchedSeriesSoa, SegmentFetcher,
 };
 pub use log_fetcher::{
-    LogFetchError, LogFetchOutput, LogQuery, LogSegmentFetcher, StreamAttrEquals,
+    LogFetchError, LogFetchOutput, LogQuery, LogSegmentFetcher, LogSegmentScan, StreamAttrEquals,
 };
 pub use query_admission::{
     QueryAdmissionController, QueryConcurrencyLimit, QueryPermit, QueryRejected,

--- a/crates/ravel-query/src/log_fetcher.rs
+++ b/crates/ravel-query/src/log_fetcher.rs
@@ -40,8 +40,8 @@ use ravel_catalog::SegmentRef;
 use ravel_logseg::footer::{self, kind};
 use ravel_logseg::stream_dir::StreamDir;
 use ravel_logseg::{
-    AttrValue, LogRecord, LogSegError, LogStreamId, Predicate, RlogConfig, RlogReader, ScanStats,
-    read_section,
+    AttrValue, BlockScan, ColumnSelection, LogRecord, LogSegError, LogStreamId, Predicate,
+    RlogConfig, RlogReader, ScanStats, read_section,
 };
 use ravel_object_store::{GetRange, ObjectStoreBackend, StoreError};
 use ravel_types::TenantHash;
@@ -189,6 +189,78 @@ impl LogQuery {
 pub struct LogFetchOutput {
     pub records: Vec<LogRecord>,
     pub stats: ScanStats,
+}
+
+/// A fetched, pruned, not-yet-decoded scan over one segment (ADR-0087).
+///
+/// This is the streaming counterpart of [`LogFetchOutput`]: the object's bytes
+/// are resident and its blocks are pruned, but no block has been decoded. The
+/// caller pulls one block at a time with [`next_block`](Self::next_block) and
+/// can drop each block's records before asking for the next, so peak decoded
+/// memory is one block rather than one segment.
+///
+/// Everything else is identical to [`LogSegmentFetcher::fetch`]: the same
+/// combined predicate is the exact per-row filter, the same prune channel drives
+/// POSTINGS, and the same selective-erasure exclusion
+/// ([`crate::erasure::retain_log_records`]) is applied to each block's rows
+/// after fetch and after cache. Draining this to exhaustion yields exactly the
+/// records `fetch` would return, in the same order, which is how `fetch` is
+/// implemented.
+pub struct LogSegmentScan {
+    /// The whole object. Block extents are absolute offsets into it.
+    bytes: Bytes,
+    scan: BlockScan,
+    erasure: Vec<ErasurePredicate>,
+    /// The log path's `decode` span, entered around each block decode and
+    /// completed with the block counters when the scan runs out.
+    span: tracing::Span,
+    /// The object key, for error attribution.
+    key: String,
+    /// Set once [`next_block`](Self::next_block) has reported exhaustion, so
+    /// the span's counters are recorded exactly once.
+    finished: bool,
+}
+
+impl LogSegmentScan {
+    /// The reader's pruning counters. `blocks_scanned`, `pages_decoded`, and
+    /// `pages_skipped` grow as blocks are drained; read this after the last
+    /// [`next_block`](Self::next_block) for the whole segment's figures.
+    pub fn stats(&self) -> ScanStats {
+        self.scan.stats()
+    }
+
+    /// Surviving blocks not yet decoded.
+    pub fn remaining_blocks(&self) -> usize {
+        self.scan.remaining_blocks()
+    }
+
+    /// Decode the next surviving block and return its matching, unerased rows,
+    /// or `None` once every surviving block has been decoded.
+    ///
+    /// `Some(vec![])` is normal and distinct from `None`: a block can survive
+    /// pruning and hold no row that matches the exact filter, or have every
+    /// matching row erased. Only `None` ends the scan.
+    pub fn next_block(&mut self) -> Result<Option<Vec<LogRecord>>, LogFetchError> {
+        let span = self.span.clone();
+        let decoded = span
+            .in_scope(|| self.scan.next_block(&self.bytes))
+            .map_err(|source| corrupt(&self.key, source))?;
+        let Some(mut records) = decoded else {
+            if !self.finished {
+                self.finished = true;
+                let stats = self.scan.stats();
+                self.span.record("blocks_scanned", stats.blocks_scanned);
+                self.span.record("blocks_total", stats.blocks_total);
+            }
+            return Ok(None);
+        };
+        // Selective-erasure exclusion (ADR-0064 decision 2), per block rather
+        // than per segment. Filtering a block's rows and filtering the
+        // concatenation of every block's rows give the same survivors: the
+        // predicate is per record and carries no cross-record state.
+        crate::erasure::retain_log_records(&mut records, &self.erasure);
+        Ok(Some(records))
+    }
 }
 
 /// Errors fetching and decoding one RLOG segment. Every variant is a hard
@@ -452,17 +524,84 @@ impl LogSegmentFetcher {
         query: &LogQuery,
         accounting: &QueryAccounting,
     ) -> Result<Option<LogFetchOutput>, LogFetchError> {
+        let Some(bytes) = self
+            .tenant_bytes(seg_ref, tenant_hash, query, accounting)
+            .await?
+        else {
+            return Ok(None);
+        };
+        self.decode_spanned(&seg_ref.data_object_key, &bytes, query)
+    }
+
+    /// Streaming counterpart of
+    /// [`fetch_accounted_with_tenant`](Self::fetch_accounted_with_tenant)
+    /// (ADR-0087 decisions 2 and 3): the same GET, the same cache, the same
+    /// pruning, but the object's blocks are returned as a [`LogSegmentScan`]
+    /// the caller drains one block at a time instead of one
+    /// already-fully-decoded `Vec<LogRecord>`.
+    ///
+    /// `columns` narrows what each block decodes. `ColumnSelection::all()`
+    /// makes this exactly `fetch_accounted_with_tenant` in slow motion; a
+    /// narrower selection leaves unselected columns undecoded, so the yielded
+    /// records carry a partial view and the caller must have included every
+    /// column it (or anything downstream of it, including its selective-erasure
+    /// exclusion) reads.
+    ///
+    /// The whole object is still fetched with one [`GetRange::Full`] GET: this
+    /// bounds *decoded* memory, not raw bytes. A ranged block read is
+    /// [`ravel_logseg::RlogRangeReader`]'s territory and out of scope here
+    /// (ADR-0087 decision 3).
+    pub async fn scan_accounted_with_tenant(
+        &self,
+        seg_ref: &SegmentRef,
+        tenant_hash: TenantHash,
+        query: &LogQuery,
+        columns: &ColumnSelection,
+        accounting: &QueryAccounting,
+    ) -> Result<Option<LogSegmentScan>, LogFetchError> {
+        let Some(bytes) = self
+            .tenant_bytes(seg_ref, tenant_hash, query, accounting)
+            .await?
+        else {
+            return Ok(None);
+        };
+        let key = &seg_ref.data_object_key;
+        let span = decode_span();
+        let scan = span.in_scope(|| self.open_scan(key, &bytes, query, columns))?;
+        Ok(Some(LogSegmentScan {
+            bytes,
+            scan,
+            erasure: query.erasure.clone(),
+            span,
+            key: key.to_string(),
+            finished: false,
+        }))
+    }
+
+    /// The byte-fetch half of the tenant-aware funnel: the ts-range pre-check,
+    /// then the object's bytes from the read cache or a whole-object GET, with
+    /// the `page_fetch` span and the accounting both entry points share.
+    /// `Ok(None)` means the catalog summary proved the object irrelevant and no
+    /// GET was issued.
+    async fn tenant_bytes(
+        &self,
+        seg_ref: &SegmentRef,
+        tenant_hash: TenantHash,
+        query: &LogQuery,
+        accounting: &QueryAccounting,
+    ) -> Result<Option<Bytes>, LogFetchError> {
         if !Self::ts_range_relevant(seg_ref, query.ts_min_ns, query.ts_max_ns) {
             return Ok(None);
         }
         let key = &seg_ref.data_object_key;
 
         // Same two phases as `fetch_accounted`, spanned on the path production
-        // log/alerts/audit traffic actually takes (ADR-0044 decision 5): the whole-object GET (`page_fetch`), then the STREAM_DIR
-        // resolve + `RlogReader` scan in `scan_bytes` (`decode`). Duplicated
-        // rather than shared with `fetch_accounted` because the byte-fetch
-        // differs -- this one is cache-aware and may serve a hit with no store
-        // GET at all -- while only the `scan_bytes` tail is common. The
+        // log/alerts/audit traffic actually takes (ADR-0044 decision 5): the
+        // whole-object GET (`page_fetch`) here, then the STREAM_DIR resolve +
+        // `RlogReader` prune and decode (`decode`) in whichever of the two
+        // callers this feeds. Duplicated rather than shared with
+        // `fetch_accounted` because the byte-fetch differs -- this one is
+        // cache-aware and may serve a hit with no store GET at all. The
         // recorded `s3_requests`/`s3_bytes` reflect this call's own store GETs:
         // one on the uncached or cache-miss path, zero on a cache hit (the
         // served bytes are cache, not S3).
@@ -489,7 +628,7 @@ impl LogSegmentFetcher {
             accounting.add_s3_bytes(AccountedOp::Get, got.data.len() as u64);
             fetch_span.record("s3_requests", 1u64);
             fetch_span.record("s3_bytes", got.data.len() as u64);
-            return self.decode_spanned(key, &got.data, query);
+            return Ok(Some(got.data));
         };
 
         let cache_key = CacheKey::new(tenant_hash.0, seg_ref.content_hash, 0, seg_ref.object_size);
@@ -546,7 +685,7 @@ impl LogSegmentFetcher {
             fetch_span.record("s3_bytes", bytes.len() as u64);
             bytes
         };
-        self.decode_spanned(key, &bytes, query)
+        Ok(Some(bytes))
     }
 
     /// Runs [`scan_bytes`](Self::scan_bytes) inside the log path's `decode`
@@ -562,7 +701,7 @@ impl LogSegmentFetcher {
     /// bytes, and decompression happens per block inside
     /// [`RlogReader::scan_pruned`] (`read_block`) where the total is never
     /// summed. Surfacing one would need a new `ScanStats` field and a structural
-    /// change to `ravel-logseg`, out of scope for a fix confined to this crate.
+    /// change to `ravel-logseg`, out of scope for that fix.
     ///
     /// `blocks_scanned`/`blocks_total` are instead a real, already-computed
     /// pruning-effectiveness signal -- how much of the object's block index the
@@ -577,12 +716,7 @@ impl LogSegmentFetcher {
         bytes: &Bytes,
         query: &LogQuery,
     ) -> Result<Option<LogFetchOutput>, LogFetchError> {
-        let span = tracing::debug_span!(
-            "decode",
-            signal = "logs",
-            blocks_scanned = tracing::field::Empty,
-            blocks_total = tracing::field::Empty,
-        );
+        let span = decode_span();
         let out = span.in_scope(|| self.scan_bytes(key, bytes, query))?;
         if let Some(output) = &out {
             span.record("blocks_scanned", output.stats.blocks_scanned);
@@ -591,20 +725,54 @@ impl LogSegmentFetcher {
         Ok(out)
     }
 
-    /// Shared tail of both fetch entry points: resolve stream-attribute
-    /// equalities against STREAM_DIR (over-approximating, see
-    /// [`matching_streams`](Self::matching_streams)), build the combined exact
-    /// predicate, and scan it with `query.prune` as the prune-only channel.
-    /// Identical regardless of whether `bytes` came from the store or the cache
-    /// -- `RlogReader::scan_pruned`'s block-level skip-index and bloom
-    /// verification run unconditionally either way, so a corrupt cache entry
-    /// fails exactly like a corrupt store read.
+    /// Shared tail of both fetch entry points: open the pruned scan and drain
+    /// every block of it. This is [`LogSegmentScan`] collected eagerly, so the
+    /// two paths cannot drift: same predicate, same prune channel, same
+    /// per-record erasure exclusion, same order.
     fn scan_bytes(
         &self,
         key: &str,
         bytes: &Bytes,
         query: &LogQuery,
     ) -> Result<Option<LogFetchOutput>, LogFetchError> {
+        let mut scan = self.open_scan(key, bytes, query, &ColumnSelection::all())?;
+        let mut records = Vec::new();
+        loop {
+            let block = scan.next_block(bytes).map_err(|s| corrupt(key, s))?;
+            let Some(mut rows) = block else { break };
+            // Selective-erasure exclusion (ADR-0064 decision 2): drop every
+            // row a pending erasure predicate matches. Applied here, on the
+            // decoded records, so it excludes rows identically whether `bytes`
+            // came from the store or from a cache hit -- the whole point of
+            // filtering after fetch and after cache. A no-op when
+            // `query.erasure` is empty.
+            crate::erasure::retain_log_records(&mut rows, &query.erasure);
+            records.extend(rows);
+        }
+        Ok(Some(LogFetchOutput {
+            records,
+            stats: scan.stats(),
+        }))
+    }
+
+    /// Resolve stream-attribute equalities against STREAM_DIR
+    /// (over-approximating, see [`matching_streams`](Self::matching_streams)),
+    /// build the combined exact predicate, and open the pruned scan with
+    /// `query.prune` as the prune-only channel.
+    ///
+    /// Identical regardless of whether `bytes` came from the store or the cache
+    /// -- the reader's block-level skip-index and bloom verification run
+    /// unconditionally either way, so a corrupt cache entry fails exactly like
+    /// a corrupt store read.
+    ///
+    /// [`matching_streams`]: Self::matching_streams
+    fn open_scan(
+        &self,
+        key: &str,
+        bytes: &Bytes,
+        query: &LogQuery,
+        columns: &ColumnSelection,
+    ) -> Result<BlockScan, LogFetchError> {
         let stream_ids = if query.stream_attrs.is_empty() {
             None
         } else {
@@ -634,16 +802,9 @@ impl LogSegmentFetcher {
         // drop resource/scope-only matches (docs/adrs/0049-rlog-postings.md
         // amendment 2026-08-03). An empty channel makes this identical to
         // `scan`.
-        let (mut records, stats) = reader
-            .scan_pruned(&pred, &query.prune)
-            .map_err(|source| corrupt(key, source))?;
-        // Selective-erasure exclusion (ADR-0064 decision 2): drop every
-        // row a pending erasure predicate matches. Applied here, on the decoded
-        // records, so it excludes rows identically whether `bytes` came from
-        // the store or from a cache hit -- the whole point of filtering after
-        // fetch and after cache. A no-op when `query.erasure` is empty.
-        crate::erasure::retain_log_records(&mut records, &query.erasure);
-        Ok(Some(LogFetchOutput { records, stats }))
+        reader
+            .scan_blocks(&pred, &query.prune, columns)
+            .map_err(|source| corrupt(key, source))
     }
 
     /// Decodes the STREAM_DIR section of an object from its own public section
@@ -688,6 +849,17 @@ fn blob_contains(blob: &[u8], needle: &[u8]) -> bool {
         return false;
     }
     blob.windows(needle.len()).any(|w| w == needle)
+}
+
+/// The log path's `decode` phase span, shared by the collecting and the
+/// streaming funnel so both report the same fields (docs/guides/tracing.md).
+fn decode_span() -> tracing::Span {
+    tracing::debug_span!(
+        "decode",
+        signal = "logs",
+        blocks_scanned = tracing::field::Empty,
+        blocks_total = tracing::field::Empty,
+    )
 }
 
 fn corrupt(key: &str, source: LogSegError) -> LogFetchError {

--- a/crates/ravel-sql/src/logs_provider.rs
+++ b/crates/ravel-sql/src/logs_provider.rs
@@ -28,9 +28,7 @@ use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::catalog::{Session, TableProvider};
 use datafusion::error::Result as DFResult;
 use datafusion::logical_expr::{Expr, TableProviderFilterPushDown, TableType};
-use datafusion::physical_expr::expressions::col;
 use datafusion::physical_plan::ExecutionPlan;
-use datafusion::physical_plan::projection::ProjectionExec;
 use ravel_catalog::{SegmentRef, Snapshot};
 use ravel_query::LogSegmentFetcher;
 use ravel_query::erasure::{ErasurePredicate, snapshot_pending_erasure_predicates};
@@ -80,11 +78,11 @@ impl LogsTableProvider {
         }
     }
 
-    /// Build the scan over every segment in the snapshot with no pushdown.
-    /// Exposed (like the metrics provider's `plan`) so tests can execute the
-    /// scan without a SQL front-end.
+    /// Build the scan over every segment in the snapshot with no pushdown and
+    /// no projection (every column). Exposed (like the metrics provider's
+    /// `plan`) so tests can execute the scan without a SQL front-end.
     pub fn plan(&self, target_partitions: usize) -> DFResult<Arc<dyn ExecutionPlan>> {
-        self.build_scan(target_partitions, &LogsPushdown::default())
+        self.build_scan(target_partitions, &LogsPushdown::default(), None)
     }
 
     /// Build the scan for a set of filters, extracting the pushdown from them.
@@ -94,7 +92,7 @@ impl LogsTableProvider {
         target_partitions: usize,
         filters: &[Expr],
     ) -> DFResult<Arc<dyn ExecutionPlan>> {
-        self.build_scan(target_partitions, &extract_logs(filters))
+        self.build_scan(target_partitions, &extract_logs(filters), None)
     }
 
     /// Admission (the sealed-segment cap) is decided exactly once, at
@@ -109,6 +107,7 @@ impl LogsTableProvider {
         &self,
         target_partitions: usize,
         pushdown: &LogsPushdown,
+        projection: Option<&Vec<usize>>,
     ) -> DFResult<Arc<dyn ExecutionPlan>> {
         let segments = self.pruned_segments(pushdown);
         let scan = LogsScanExec::new(
@@ -121,6 +120,7 @@ impl LogsTableProvider {
             Arc::new(pushdown.content.clone()),
             Arc::new(pushdown.prune.clone()),
             Arc::clone(&self.erasure),
+            projection,
             self.accounting.clone(),
         )?;
         Ok(Arc::new(scan))
@@ -179,26 +179,19 @@ impl TableProvider for LogsTableProvider {
     ) -> DFResult<Arc<dyn ExecutionPlan>> {
         let target_partitions = state.config().target_partitions();
         let pushdown = extract_logs(filters);
-        let plan = self.build_scan(target_partitions, &pushdown)?;
-
-        // Projection pushdown: column selection only. When a column is not
-        // projected DataFusion still receives every column from the scan and
-        // this ProjectionExec drops the rest; the fetch reads the whole object
-        // regardless (RLOG's reader has no per-column page toggle at this
-        // layer), matching the metrics provider's stance.
-        match projection {
-            Some(proj) => {
-                let exprs = proj
-                    .iter()
-                    .map(|&i| {
-                        let name = self.schema.field(i).name();
-                        Ok((col(name, &self.schema)?, name.to_string()))
-                    })
-                    .collect::<DFResult<Vec<_>>>()?;
-                Ok(Arc::new(ProjectionExec::try_new(exprs, plan)?))
-            }
-            None => Ok(plan),
-        }
+        // Projection pushdown reaches the reader (ADR-0087 decision 3): the
+        // scan's output schema *is* the projection, and the resolved column set
+        // stops the RLOG reader decoding the pages of columns nothing reads.
+        // There is no `ProjectionExec` above the scan any more; one would have
+        // dropped columns the scan had already paid to decode and materialize.
+        //
+        // The projection DataFusion hands us already contains every column its
+        // residual `FilterExec` above this scan will read: pushdown is
+        // `Inexact`, so the optimizer keeps the filters' columns in the scan's
+        // projection. `LogsScanExec` separately adds the columns its own pushed
+        // content predicates and pending erasure predicates need, which are not
+        // visible in the projection at all.
+        self.build_scan(target_partitions, &pushdown, projection)
     }
 }
 

--- a/crates/ravel-sql/src/logs_scan.rs
+++ b/crates/ravel-sql/src/logs_scan.rs
@@ -3,21 +3,46 @@
 //!
 //! Partitions the snapshot's segments round-robin into
 //! `N = min(target_partitions, segment_count)` partitions. Each partition
-//! fetches its segments through [`LogSegmentFetcher::fetch`] (one
-//! [`LogQuery`] per segment: the extracted ts range, stream-attribute
-//! equalities, and content predicates), decodes the returned
-//! [`ravel_logseg::LogRecord`]s into Arrow arrays matching
-//! [`crate::logs_schema::logs_schema`], and emits them sorted by `ts`
-//! ascending. That per-partition ordering is declared through
-//! `PlanProperties` so a later merge stage can honor it with a
-//! `SortPreservingMergeExec`.
+//! opens its segments one at a time through
+//! [`LogSegmentFetcher::scan_accounted_with_tenant`] (one [`LogQuery`] per
+//! segment: the extracted ts range, stream-attribute equalities, and content
+//! predicates), decodes **one block at a time**, and turns each block's
+//! [`ravel_logseg::LogRecord`]s into Arrow arrays matching this scan's
+//! projection of [`crate::logs_schema::logs_schema`].
 //!
-//! `RlogReader::scan` (inside `fetch`) already emits a segment's records
-//! grouped by `(stream_ref, ts)`, not globally by `ts`, and a partition draws
-//! from several segments, so this stage sorts each partition's collected
-//! records by `ts` before emitting. Declaring `ts` ascending is therefore
-//! truthful for the stream this stage produces; nothing declares a global
-//! cross-partition order (that is a merge's job, not the leaf's).
+//! # Streaming, and why no ordering is declared (ADR-0087)
+//!
+//! This stage declares **no** output ordering. It used to declare `ts`
+//! ascending per partition, and earned that by collecting the whole partition
+//! and sorting it before emitting anything -- which made peak memory
+//! proportional to the partition, i.e. to the table. `RlogReader` itself only
+//! emits a segment's records grouped by `(stream_ref, ts)`, not globally by
+//! `ts`, and a partition draws from several segments, so a block-at-a-time
+//! scan cannot truthfully claim a global per-partition `ts` order.
+//!
+//! Declaring one anyway would be silently wrong, not merely optimistic:
+//! DataFusion trusts a leaf's declared ordering and would skip the sort an
+//! `ORDER BY ts` needs. So the guarantee is gone, and an `ORDER BY ts` gets an
+//! explicit `SortExec` that DataFusion inserts above this leaf. Nothing here
+//! sorts, buffers a partition, or otherwise reintroduces the bound this
+//! removes.
+//!
+//! Memory is reserved against the query's DataFusion pool for what the scan
+//! *currently holds* -- the decoded block being drained plus the batch just
+//! handed downstream -- and released as each goes away, so the pool bounds
+//! concurrently-held scan memory rather than cumulative bytes emitted.
+//!
+//! # Column projection
+//!
+//! The scan's output schema *is* the projection DataFusion asked for; there is
+//! no `ProjectionExec` above it dropping columns the scan already paid to
+//! produce. The projected columns, plus every field a pushed content predicate
+//! names, plus every attribute key a pending erasure predicate names, are
+//! resolved into a [`ColumnSelection`] that the reader uses to decode only
+//! those columns' pages ([`resolve_columns`]). Any reference to the SQL `attrs`
+//! map column resolves to every dynamic column plus `attrs_raw`, because the
+//! map's contract is that every key is present; per-key `attrs['k']`
+//! projection is out of scope (ADR-0087 decision 3).
 //!
 //! # Correctness: the merged `attrs` column plus DataFusion's residual
 //!
@@ -62,6 +87,7 @@
 //! the key to the record's value, which wins). The merged column and the
 //! residual are the whole correctness story.
 
+use std::collections::VecDeque;
 use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
@@ -72,14 +98,12 @@ use datafusion::arrow::array::{
     ArrayRef, FixedSizeBinaryBuilder, MapBuilder, StringArray, StringBuilder,
     TimestampNanosecondArray, UInt8Array, UInt32Array,
 };
-use datafusion::arrow::compute::SortOptions;
 use datafusion::arrow::datatypes::SchemaRef;
-use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::arrow::record_batch::{RecordBatch, RecordBatchOptions};
 use datafusion::error::{DataFusionError, Result as DFResult};
 use datafusion::execution::TaskContext;
 use datafusion::execution::memory_pool::{MemoryConsumer, MemoryReservation};
-use datafusion::physical_expr::expressions::col;
-use datafusion::physical_expr::{EquivalenceProperties, LexOrdering, PhysicalSortExpr};
+use datafusion::physical_expr::EquivalenceProperties;
 use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
 use datafusion::physical_plan::metrics::{
     Count, ExecutionPlanMetricsSet, MetricBuilder, MetricsSet,
@@ -90,21 +114,144 @@ use datafusion::physical_plan::{
 };
 use futures::Stream;
 use ravel_catalog::SegmentRef;
-use ravel_logseg::{LogRecord, Predicate, ScanStats};
+use ravel_logseg::{ColumnSelection, FieldSel, LogRecord, Predicate, ScanStats};
 use ravel_query::erasure::ErasurePredicate;
-use ravel_query::{LogQuery, LogSegmentFetcher};
+use ravel_query::{LogQuery, LogSegmentFetcher, LogSegmentScan};
 use ravel_types::TenantHash;
 use ravel_types::accounting::QueryAccounting;
+use ravel_types::logstream::AttrValue;
 
 use crate::error::SqlError;
-use crate::logs_schema::{SPAN_ID_WIDTH, TRACE_ID_WIDTH, logs_schema};
+use crate::logs_schema::{
+    LOG_COL_ATTRS, LOG_COL_BODY, LOG_COL_FLAGS, LOG_COL_OBSERVED_TS, LOG_COL_SEVERITY_NUM,
+    LOG_COL_SEVERITY_TEXT, LOG_COL_SPAN_ID, LOG_COL_TRACE_ID, LOG_COL_TS, SPAN_ID_WIDTH,
+    TRACE_ID_WIDTH, logs_schema,
+};
 use crate::rlog_attrs::{attr_value_to_string, merged_attrs, retain_unerased};
 
 /// Rows accumulated into one output batch before it is emitted.
+///
+/// A block usually decodes to fewer rows than this (RLOG's default block target
+/// is 8192 records, and predicate evaluation only removes rows), so one block
+/// normally becomes one batch. This bounds the other direction: a block written
+/// with a larger target is still emitted in pieces of at most this many rows, so
+/// one batch's Arrow footprint stays bounded whatever the writer chose.
 const BATCH_ROWS: usize = 8192;
 
-/// Log segment scan producing per-partition ts-ascending batches over the
-/// public `logs` schema.
+/// Rough resident size of a decoded record in row form, for the memory
+/// reservation.
+///
+/// Deliberately an estimate, not an exact figure: the point is that the pool
+/// sees a charge proportional to what the scan actually holds, which nothing
+/// charged at all before (ADR-0087 context). It counts the struct itself, the
+/// owned string and blob payloads, and the attribute vector's spine and
+/// contents. It does not chase `AttrValue::List`/`Map` recursively past their
+/// direct children, so a deeply nested attribute is undercounted; the fixed
+/// per-record and per-attribute terms dominate at the cardinalities this
+/// bound exists for.
+fn records_memory(records: &[LogRecord]) -> usize {
+    let mut total = std::mem::size_of_val(records);
+    for r in records {
+        total += r.stream_attrs.len() + r.severity_text.len() + r.body.len();
+        total += r.attrs.len() * std::mem::size_of::<(String, AttrValue)>();
+        for (k, v) in &r.attrs {
+            total += k.len() + attr_value_memory(v);
+        }
+    }
+    total
+}
+
+fn attr_value_memory(v: &AttrValue) -> usize {
+    match v {
+        AttrValue::Str(s) => s.len(),
+        AttrValue::Bytes(b) => b.len(),
+        AttrValue::I64(_) | AttrValue::F64(_) | AttrValue::Bool(_) => 0,
+        AttrValue::List(items) => items.len() * std::mem::size_of::<AttrValue>(),
+        AttrValue::Map(entries) => entries.len() * std::mem::size_of::<(String, AttrValue)>(),
+    }
+}
+
+/// The block columns one query needs decoded (ADR-0087 decision 3).
+///
+/// Four contributors, and every one of them is load-bearing:
+///
+/// - the **projected schema columns**, which are what the query's output and
+///   DataFusion's residual `FilterExec` above this leaf read (the projection
+///   DataFusion hands `TableProvider::scan` already includes the columns its
+///   residual filters need, which is why the residual is safe over a projected
+///   scan);
+/// - the **`ts`/`stream_ref` fixed columns**, added unconditionally by
+///   [`ColumnSelection`] because every rebuilt record and every exact
+///   ts re-check needs them;
+/// - every field a **pushed content predicate** names, because
+///   `RlogReader` evaluates those exactly per row and a column it cannot see
+///   reads as absent, i.e. as not matching, i.e. as dropped rows;
+/// - every attribute key a **pending erasure predicate** names, at record level
+///   for the fetcher's own filter and at merged resource/scope/record level for
+///   [`retain_unerased`] here (ADR-0064). A key the selection omits makes an
+///   erased row reappear.
+///
+/// The prune-only channel contributes nothing: its arms drive POSTINGS block
+/// pruning and are never evaluated per row, so no page has to be decoded for
+/// them.
+///
+/// Resource and scope attributes cost nothing to keep: they live in STREAM_DIR,
+/// reached through `stream_ref`, not in a block column. So an erasure subject
+/// named only at resource level is matched under any selection.
+fn resolve_columns(
+    projection: &[usize],
+    content: &[Predicate],
+    erasure: &[ErasurePredicate],
+) -> ColumnSelection {
+    let mut sel = ColumnSelection::fixed_only();
+    for &i in projection {
+        sel = match i {
+            // `ts` is always decoded; naming it changes nothing.
+            LOG_COL_TS => sel,
+            LOG_COL_OBSERVED_TS => sel.with_observed_ts(),
+            LOG_COL_SEVERITY_NUM => sel.with_severity_num(),
+            LOG_COL_SEVERITY_TEXT => sel.with_severity_text(),
+            LOG_COL_BODY => sel.with_body(),
+            LOG_COL_TRACE_ID => sel.with_trace_id(),
+            LOG_COL_SPAN_ID => sel.with_span_id(),
+            LOG_COL_FLAGS => sel.with_flags(),
+            // The merged `attrs` map exposes every key, so referencing it at
+            // all means every dynamic column plus the overflow.
+            LOG_COL_ATTRS => sel.with_all_attrs(),
+            // Not reachable: `LogsScanExec::new` validates every index against
+            // the schema before building the projected schema. Fail open (decode
+            // everything) rather than silently under-decode if that ever
+            // changes.
+            _ => ColumnSelection::all(),
+        };
+    }
+    for p in content {
+        sel = content_columns(p, sel);
+    }
+    for p in erasure {
+        for (key, _) in p.matchers() {
+            sel = sel.with_attr(key);
+        }
+    }
+    sel
+}
+
+/// Add every column an exact content predicate reads. `TsRange` and `StreamIn`
+/// need only the two always-decoded fixed columns.
+fn content_columns(pred: &Predicate, sel: ColumnSelection) -> ColumnSelection {
+    match pred {
+        Predicate::And(arms) => arms.iter().fold(sel, |acc, a| content_columns(a, acc)),
+        Predicate::TsRange { .. } | Predicate::StreamIn(_) => sel,
+        Predicate::HasWord { field, .. } | Predicate::Equals { field, .. } => match field {
+            FieldSel::Body => sel.with_body(),
+            FieldSel::SeverityText => sel.with_severity_text(),
+            FieldSel::Attr(name) => sel.with_attr(name.clone()),
+        },
+    }
+}
+
+/// Log segment scan producing block-at-a-time batches over a projection of the
+/// public `logs` schema. Declares no ordering (ADR-0087 decision 1).
 pub struct LogsScanExec {
     tenant_hash: TenantHash,
     fetcher: LogSegmentFetcher,
@@ -128,6 +275,13 @@ pub struct LogsScanExec {
     /// (`retain_log_records`) engages; empty when the snapshot has no pending
     /// erasure, which is a no-op there.
     erasure: Arc<Vec<ErasurePredicate>>,
+    /// Indices into [`logs_schema`] this scan emits, in output order. Always
+    /// concrete: a `None` projection from DataFusion becomes every index.
+    projection: Arc<Vec<usize>>,
+    /// The block columns the reader must decode, resolved once from
+    /// `projection`, `content`, and `erasure` (see [`resolve_columns`]).
+    columns: ColumnSelection,
+    /// This scan's output schema: `logs_schema()` projected by `projection`.
     schema: SchemaRef,
     properties: Arc<PlanProperties>,
     /// This query's accounting handle (ADR-0044), threaded into every
@@ -150,6 +304,14 @@ struct BlockMetrics {
     total: Count,
     scanned: Count,
     pruned_by_postings: Count,
+    /// Column pages this partition decompressed and decoded.
+    pages_decoded: Count,
+    /// Column pages this partition walked past because the resolved
+    /// [`ColumnSelection`] excluded them. This is the externally visible proof
+    /// that column projection reached the page level rather than being a
+    /// post-decode filter: a query that touches two of a hundred attributes
+    /// leaves this large and `pages_decoded` small.
+    pages_skipped: Count,
 }
 
 impl BlockMetrics {
@@ -159,6 +321,8 @@ impl BlockMetrics {
             scanned: MetricBuilder::new(metrics).counter("blocks_scanned", partition),
             pruned_by_postings: MetricBuilder::new(metrics)
                 .counter("blocks_pruned_by_postings", partition),
+            pages_decoded: MetricBuilder::new(metrics).counter("pages_decoded", partition),
+            pages_skipped: MetricBuilder::new(metrics).counter("pages_skipped", partition),
         }
     }
 
@@ -175,6 +339,8 @@ impl BlockMetrics {
                 .blocks_after_skip
                 .saturating_sub(stats.blocks_after_postings) as usize,
         );
+        self.pages_decoded.add(stats.pages_decoded as usize);
+        self.pages_skipped.add(stats.pages_skipped as usize);
     }
 }
 
@@ -202,6 +368,7 @@ impl LogsScanExec {
         content: Arc<Vec<Predicate>>,
         prune: Arc<Vec<Predicate>>,
         erasure: Arc<Vec<ErasurePredicate>>,
+        projection: Option<&Vec<usize>>,
         accounting: QueryAccounting,
     ) -> DFResult<Self> {
         let n = target_partitions.max(1).min(segments.len().max(1));
@@ -209,8 +376,24 @@ impl LogsScanExec {
         for (i, seg) in segments.iter().enumerate() {
             partitions[i % n].push(seg.clone());
         }
-        let schema = logs_schema();
-        let properties = Arc::new(Self::compute_properties(&schema, n)?);
+        let full = logs_schema();
+        // A `None` projection means every column, in schema order. Resolving it
+        // here rather than carrying an `Option` keeps one code path for the
+        // schema, the batch builder, and the column-set resolution.
+        let projection: Vec<usize> = match projection {
+            Some(p) => p.clone(),
+            None => (0..full.fields().len()).collect(),
+        };
+        for &i in &projection {
+            if i >= full.fields().len() {
+                return Err(DataFusionError::Internal(format!(
+                    "logs scan projection index {i} out of range"
+                )));
+            }
+        }
+        let columns = resolve_columns(&projection, &content, &erasure);
+        let schema: SchemaRef = Arc::new(full.project(&projection)?);
+        let properties = Arc::new(Self::compute_properties(&schema, n));
         Ok(LogsScanExec {
             tenant_hash,
             fetcher,
@@ -220,6 +403,8 @@ impl LogsScanExec {
             content,
             prune,
             erasure,
+            projection: Arc::new(projection),
+            columns,
             schema,
             properties,
             accounting,
@@ -227,21 +412,18 @@ impl LogsScanExec {
         })
     }
 
-    fn compute_properties(schema: &SchemaRef, n: usize) -> DFResult<PlanProperties> {
-        let asc = SortOptions {
-            descending: false,
-            nulls_first: false,
-        };
-        let sort_expr = PhysicalSortExpr::new(col("ts", schema)?, asc);
-        let ordering = LexOrdering::new(vec![sort_expr])
-            .ok_or_else(|| DataFusionError::Internal("empty logs scan ordering".into()))?;
-        let eq = EquivalenceProperties::new_with_orderings(Arc::clone(schema), vec![ordering]);
-        Ok(PlanProperties::new(
+    /// No output ordering (ADR-0087 decision 1). A block-streaming scan emits a
+    /// partition's blocks in stored order, which is `(stream_ref, ts)` within a
+    /// block and segment order across a partition, so no `ts` ordering holds.
+    /// Downstream operators that need one get an explicit sort.
+    fn compute_properties(schema: &SchemaRef, n: usize) -> PlanProperties {
+        let eq = EquivalenceProperties::new(Arc::clone(schema));
+        PlanProperties::new(
             eq,
             Partitioning::UnknownPartitioning(n),
             EmissionType::Incremental,
             Boundedness::Bounded,
-        ))
+        )
     }
 }
 
@@ -259,10 +441,16 @@ impl DisplayAs for LogsScanExec {
     fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "LogsScanExec: partitions={}, content={}, prune={}",
+            "LogsScanExec: partitions={}, content={}, prune={}, projection=[{}]",
             self.partitions.len(),
             self.content.len(),
-            self.prune.len()
+            self.prune.len(),
+            self.schema
+                .fields()
+                .iter()
+                .map(|field| field.name().as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
         )
     }
 }
@@ -296,111 +484,170 @@ impl ExecutionPlan for LogsScanExec {
         partition: usize,
         context: Arc<TaskContext>,
     ) -> DFResult<SendableRecordBatchStream> {
-        let segs = self.partitions.get(partition).cloned().unwrap_or_default();
-        let fetcher = self.fetcher.clone();
-        let tenant_hash = self.tenant_hash;
-        let content = Arc::clone(&self.content);
-        let prune = Arc::clone(&self.prune);
-        let erasure = Arc::clone(&self.erasure);
-        let schema = Arc::clone(&self.schema);
-        let blocks = BlockMetrics::new(&self.metrics, partition);
+        let segments: VecDeque<SegmentRef> = self
+            .partitions
+            .get(partition)
+            .cloned()
+            .unwrap_or_default()
+            .into();
+
+        let mut query =
+            LogQuery::new(self.ts_min, self.ts_max).with_erasure((*self.erasure).clone());
+        for c in self.content.iter() {
+            query = query.with_content(c.clone());
+        }
+        // The prune channel, kept out of `content` on purpose: the reader
+        // evaluates a content arm exactly per row against per-record attributes
+        // only, which would drop a resource/scope-only match the merged
+        // residual must keep.
+        for p in self.prune.iter() {
+            query = query.with_prune(p.clone());
+        }
 
         let reservation = MemoryConsumer::new(format!("LogsScanExec[{partition}]"))
             .register(context.memory_pool());
 
-        let fut = Box::pin(prepare_partition(
-            fetcher,
-            tenant_hash,
-            segs,
-            self.ts_min,
-            self.ts_max,
-            content,
-            prune,
-            erasure,
-            self.accounting.clone(),
-            blocks,
-        ));
         Ok(Box::pin(LogScanStream {
-            schema,
+            schema: Arc::clone(&self.schema),
+            projection: Arc::clone(&self.projection),
+            ctx: Arc::new(PartitionCtx {
+                fetcher: self.fetcher.clone(),
+                tenant_hash: self.tenant_hash,
+                query,
+                columns: self.columns.clone(),
+                accounting: self.accounting.clone(),
+            }),
+            erasure: Arc::clone(&self.erasure),
+            blocks: BlockMetrics::new(&self.metrics, partition),
+            segments,
             reservation,
-            state: LogScanState::Fetching(fut),
+            held: 0,
+            emitted: 0,
+            pending: Vec::new(),
+            pos: 0,
+            state: LogScanState::NextSegment,
         }))
     }
 }
 
-/// Fetch every segment in this partition and return its records sorted by `ts`
-/// ascending. The ts range and content predicates prune the fetch and the
-/// attribute equalities in `prune` drive POSTINGS block pruning inside the
-/// reader; neither filters attributes, which is DataFusion's residual over
-/// [`build_batch`]'s merged `attrs` column (see the module doc). Every fetched
-/// record is emitted.
-#[allow(clippy::too_many_arguments)]
-async fn prepare_partition(
+/// Everything one partition's fetches need, shared by every per-segment open
+/// future so each can be `'static` without cloning the query per segment.
+struct PartitionCtx {
     fetcher: LogSegmentFetcher,
     tenant_hash: TenantHash,
-    segs: Vec<SegmentRef>,
-    ts_min: i64,
-    ts_max: i64,
-    content: Arc<Vec<Predicate>>,
-    prune: Arc<Vec<Predicate>>,
-    erasure: Arc<Vec<ErasurePredicate>>,
+    query: LogQuery,
+    columns: ColumnSelection,
     accounting: QueryAccounting,
-    blocks: BlockMetrics,
-) -> DFResult<Vec<LogRecord>> {
-    let mut query = LogQuery::new(ts_min, ts_max).with_erasure((*erasure).clone());
-    for c in content.iter() {
-        query = query.with_content(c.clone());
-    }
-    // The prune channel, kept out of `content` on purpose: the reader evaluates
-    // a content arm exactly per row against per-record attributes only, which
-    // would drop a resource/scope-only match the merged residual must keep.
-    for p in prune.iter() {
-        query = query.with_prune(p.clone());
-    }
-
-    let mut out: Vec<LogRecord> = Vec::new();
-    for seg in &segs {
-        let Some(output) = fetcher
-            .fetch_accounted_with_tenant(seg, tenant_hash, &query, &accounting)
-            .await
-            .map_err(SqlError::from)?
-        else {
-            continue;
-        };
-        blocks.record(&output.stats);
-        // Emit every fetched record: stream-attribute equalities are not pushed
-        // (a stream-level prune is unsound against the merged `attrs` column),
-        // so nothing here narrows below what DataFusion's residual keeps.
-        out.extend(output.records);
-    }
-    // Scan-layer selective-erasure exclusion (ADR-0064). This is the
-    // authoritative exclusion because it sees the same merged `attrs` view the
-    // surface returns (resource + scope + record), so a subject named only in a
-    // resource/scope attribute is dropped; the fetcher-level filter matches
-    // per-record attributes alone and cannot see it.
-    retain_unerased(&mut out, &erasure)?;
-    // Stable sort so records with equal ts keep the reader's emission order.
-    out.sort_by_key(|r| r.ts_ns);
-    Ok(out)
 }
 
-type PrepareFuture = Pin<Box<dyn Future<Output = DFResult<Vec<LogRecord>>> + Send>>;
+type OpenFuture = Pin<Box<dyn Future<Output = DFResult<Option<LogSegmentScan>>> + Send>>;
+
+/// Fetch one segment's bytes and open its pruned, column-projected scan.
+/// `Ok(None)` means the catalog summary proved the segment irrelevant, with no
+/// GET issued.
+fn open_segment(ctx: Arc<PartitionCtx>, seg: SegmentRef) -> OpenFuture {
+    Box::pin(async move {
+        let scan = ctx
+            .fetcher
+            .scan_accounted_with_tenant(
+                &seg,
+                ctx.tenant_hash,
+                &ctx.query,
+                &ctx.columns,
+                &ctx.accounting,
+            )
+            .await
+            .map_err(SqlError::from)?;
+        Ok(scan)
+    })
+}
 
 enum LogScanState {
-    Fetching(PrepareFuture),
-    Emitting { records: Vec<LogRecord>, pos: usize },
+    /// Advance to the next segment of this partition, or finish.
+    NextSegment,
+    /// Awaiting one segment's GET and prune.
+    Opening(OpenFuture),
+    /// Draining one segment's surviving blocks, one at a time.
+    Draining(Box<LogSegmentScan>),
     Done,
 }
 
-/// Per-partition record-batch stream: awaits the fetch, then emits ts-ascending
-/// bounded batches, growing the memory reservation by each batch's measured
-/// size so a byte-budget overrun surfaces as the pool's `ResourcesExhausted`.
-/// The reservation lives on the stream (not the state) so it is the same one
+/// Per-partition record-batch stream (ADR-0087 decisions 1 and 2).
+///
+/// Holds at most one segment's decoded block plus the batch built from it, and
+/// charges the query's memory pool for exactly that: `held` is the reservation
+/// covering `pending`, `emitted` the reservation covering the batch handed
+/// downstream on the previous poll. Both are released as their data goes away,
+/// so the reservation tracks live resident memory rather than cumulative output
+/// and a pool overrun surfaces as `ResourcesExhausted` at the moment the scan
+/// genuinely holds too much.
+///
+/// The reservation lives on the stream (not on the state) so it is the same one
 /// for the partition's lifetime and frees exactly once on drop.
 struct LogScanStream {
     schema: SchemaRef,
+    /// Indices into [`logs_schema`] to emit, in output order.
+    projection: Arc<Vec<usize>>,
+    ctx: Arc<PartitionCtx>,
+    erasure: Arc<Vec<ErasurePredicate>>,
+    blocks: BlockMetrics,
+    segments: VecDeque<SegmentRef>,
     reservation: MemoryReservation,
+    /// Reservation bytes currently covering `pending`.
+    held: usize,
+    /// Reservation bytes currently covering the batch emitted last poll.
+    emitted: usize,
+    /// The block being drained into batches.
+    pending: Vec<LogRecord>,
+    pos: usize,
     state: LogScanState,
+}
+
+impl LogScanStream {
+    /// Build the next batch out of `pending`, moving the reservation with it:
+    /// the previous batch's charge is released (it is downstream's now), the new
+    /// batch's charge is taken before it is handed over.
+    fn emit_next_batch(&mut self) -> DFResult<RecordBatch> {
+        self.reservation.shrink(std::mem::take(&mut self.emitted));
+        let end = (self.pos + BATCH_ROWS).min(self.pending.len());
+        let batch = build_batch(
+            &self.pending[self.pos..end],
+            Arc::clone(&self.schema),
+            &self.projection,
+        )?;
+        self.pos = end;
+        let bytes = batch.get_array_memory_size();
+        self.reservation.try_grow(bytes)?;
+        self.emitted = bytes;
+        Ok(batch)
+    }
+
+    /// Take ownership of one decoded block, charging the pool for it before it
+    /// is held. An empty block (every row filtered out) charges nothing and
+    /// leaves the stream to ask for the next one.
+    fn hold_block(&mut self, records: Vec<LogRecord>) -> DFResult<()> {
+        let bytes = records_memory(&records);
+        self.reservation.try_grow(bytes)?;
+        self.held = bytes;
+        self.pending = records;
+        self.pos = 0;
+        Ok(())
+    }
+
+    /// Drop the drained block and release its charge.
+    fn release_block(&mut self) {
+        self.reservation.shrink(std::mem::take(&mut self.held));
+        self.pending = Vec::new();
+        self.pos = 0;
+    }
+
+    /// Abandon the stream on error, releasing everything the scan still holds.
+    fn fail(&mut self, e: DataFusionError) -> Poll<Option<DFResult<RecordBatch>>> {
+        self.state = LogScanState::Done;
+        self.release_block();
+        self.reservation.shrink(std::mem::take(&mut self.emitted));
+        Poll::Ready(Some(Err(e)))
+    }
 }
 
 impl Stream for LogScanStream {
@@ -409,36 +656,77 @@ impl Stream for LogScanStream {
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
         loop {
+            // Anything buffered from the current block goes out first.
+            if this.pos < this.pending.len() {
+                return match this.emit_next_batch() {
+                    Ok(batch) => Poll::Ready(Some(Ok(batch))),
+                    Err(e) => this.fail(e),
+                };
+            }
+            // The block is drained: release it before decoding another, so the
+            // reservation never covers two blocks at once.
+            if this.held > 0 {
+                this.release_block();
+            }
+
             match &mut this.state {
-                LogScanState::Fetching(fut) => match fut.as_mut().poll(cx) {
-                    Poll::Ready(Ok(records)) => {
-                        this.state = LogScanState::Emitting { records, pos: 0 };
+                LogScanState::NextSegment => match this.segments.pop_front() {
+                    Some(seg) => {
+                        this.state =
+                            LogScanState::Opening(open_segment(Arc::clone(&this.ctx), seg));
                     }
-                    Poll::Ready(Err(e)) => {
+                    None => {
                         this.state = LogScanState::Done;
-                        return Poll::Ready(Some(Err(e)));
                     }
+                },
+                LogScanState::Opening(fut) => match fut.as_mut().poll(cx) {
+                    Poll::Ready(Ok(Some(scan))) => {
+                        this.state = LogScanState::Draining(Box::new(scan));
+                    }
+                    // The segment's ts span could not satisfy the query: no GET
+                    // was issued and there is nothing to drain.
+                    Poll::Ready(Ok(None)) => this.state = LogScanState::NextSegment,
+                    Poll::Ready(Err(e)) => return this.fail(e),
                     Poll::Pending => return Poll::Pending,
                 },
-                LogScanState::Emitting { records, pos } => {
-                    if *pos >= records.len() {
-                        this.state = LogScanState::Done;
-                        return Poll::Ready(None);
-                    }
-                    let end = (*pos + BATCH_ROWS).min(records.len());
-                    let batch = match build_batch(&records[*pos..end], Arc::clone(&this.schema)) {
-                        Ok(b) => b,
-                        Err(e) => {
-                            this.state = LogScanState::Done;
-                            return Poll::Ready(Some(Err(e)));
+                LogScanState::Draining(scan) => {
+                    let decoded = scan.next_block().map_err(SqlError::from);
+                    match decoded {
+                        Ok(Some(mut records)) => {
+                            // Scan-layer selective-erasure exclusion (ADR-0064).
+                            // This is the authoritative exclusion because it
+                            // sees the same merged `attrs` view the surface
+                            // returns (resource + scope + record), so a subject
+                            // named only in a resource/scope attribute is
+                            // dropped; the fetcher-level filter matches
+                            // per-record attributes alone and cannot see it.
+                            if let Err(e) = retain_unerased(&mut records, &this.erasure) {
+                                return this.fail(e);
+                            }
+                            // Every surviving record is emitted:
+                            // stream-attribute equalities are not pushed (a
+                            // stream-level prune is unsound against the merged
+                            // `attrs` column), so nothing here narrows below
+                            // what DataFusion's residual keeps.
+                            //
+                            // An empty `records` here is normal, not the end of
+                            // the segment: a block can survive pruning and hold
+                            // no row matching the exact filter, or have every
+                            // matching row erased. The loop just asks for the
+                            // next block.
+                            if let Err(e) = this.hold_block(records) {
+                                return this.fail(e);
+                            }
                         }
-                    };
-                    *pos = end;
-                    if let Err(e) = this.reservation.try_grow(batch.get_array_memory_size()) {
-                        this.state = LogScanState::Done;
-                        return Poll::Ready(Some(Err(e)));
+                        // Only `None` ends the segment. Its counters are final
+                        // now, so publish them before moving on.
+                        Ok(None) => {
+                            let stats = scan.stats();
+                            this.blocks.record(&stats);
+                            this.state = LogScanState::NextSegment;
+                        }
+                        Err(e) => return this.fail(e.into()),
                     }
-                    return Poll::Ready(Some(Ok(batch)));
                 }
                 LogScanState::Done => return Poll::Ready(None),
             }
@@ -452,75 +740,103 @@ impl RecordBatchStream for LogScanStream {
     }
 }
 
-/// Decode a slice of records into one `logs`-schema [`RecordBatch`].
-fn build_batch(records: &[LogRecord], schema: SchemaRef) -> DFResult<RecordBatch> {
-    let ts = TimestampNanosecondArray::from(records.iter().map(|r| r.ts_ns).collect::<Vec<_>>());
-    let observed_ts = TimestampNanosecondArray::from(
-        records.iter().map(|r| r.observed_ts_ns).collect::<Vec<_>>(),
-    );
-    let severity_num = UInt8Array::from(records.iter().map(|r| r.severity_num).collect::<Vec<_>>());
-    let severity_text = StringArray::from(
-        records
-            .iter()
-            .map(|r| r.severity_text.as_str())
-            .collect::<Vec<_>>(),
-    );
-    let body = StringArray::from(records.iter().map(|r| r.body.as_str()).collect::<Vec<_>>());
-
-    let mut trace = FixedSizeBinaryBuilder::with_capacity(records.len(), TRACE_ID_WIDTH);
-    for r in records {
-        match &r.trace_id {
-            Some(id) => trace
-                .append_value(id)
-                .map_err(|e| SqlError::Internal(format!("trace_id array build: {e}")))?,
-            None => trace.append_null(),
-        }
+/// Decode a slice of records into one [`RecordBatch`] over `schema`, which is
+/// `logs_schema()` projected by `projection`.
+///
+/// Only the projected columns are built. A column the query did not ask for is
+/// never materialized here, which is the second half of the projection story:
+/// the reader does not decode its pages ([`resolve_columns`]) and this does not
+/// allocate an Arrow array for it. `attrs` is the expensive one to skip -- at a
+/// hundred attributes a row it dominated the batch's footprint even for
+/// `COUNT(*)`, which projects nothing at all.
+fn build_batch(
+    records: &[LogRecord],
+    schema: SchemaRef,
+    projection: &[usize],
+) -> DFResult<RecordBatch> {
+    let mut columns: Vec<ArrayRef> = Vec::with_capacity(projection.len());
+    for &i in projection {
+        let array: ArrayRef = match i {
+            LOG_COL_TS => Arc::new(TimestampNanosecondArray::from(
+                records.iter().map(|r| r.ts_ns).collect::<Vec<_>>(),
+            )),
+            LOG_COL_OBSERVED_TS => Arc::new(TimestampNanosecondArray::from(
+                records.iter().map(|r| r.observed_ts_ns).collect::<Vec<_>>(),
+            )),
+            LOG_COL_SEVERITY_NUM => Arc::new(UInt8Array::from(
+                records.iter().map(|r| r.severity_num).collect::<Vec<_>>(),
+            )),
+            LOG_COL_SEVERITY_TEXT => Arc::new(StringArray::from(
+                records
+                    .iter()
+                    .map(|r| r.severity_text.as_str())
+                    .collect::<Vec<_>>(),
+            )),
+            LOG_COL_BODY => Arc::new(StringArray::from(
+                records.iter().map(|r| r.body.as_str()).collect::<Vec<_>>(),
+            )),
+            LOG_COL_TRACE_ID => {
+                let mut trace =
+                    FixedSizeBinaryBuilder::with_capacity(records.len(), TRACE_ID_WIDTH);
+                for r in records {
+                    match &r.trace_id {
+                        Some(id) => trace.append_value(id).map_err(|e| {
+                            SqlError::Internal(format!("trace_id array build: {e}"))
+                        })?,
+                        None => trace.append_null(),
+                    }
+                }
+                Arc::new(trace.finish())
+            }
+            LOG_COL_SPAN_ID => {
+                let mut span = FixedSizeBinaryBuilder::with_capacity(records.len(), SPAN_ID_WIDTH);
+                for r in records {
+                    match &r.span_id {
+                        Some(id) => span
+                            .append_value(id)
+                            .map_err(|e| SqlError::Internal(format!("span_id array build: {e}")))?,
+                        None => span.append_null(),
+                    }
+                }
+                Arc::new(span.finish())
+            }
+            LOG_COL_FLAGS => Arc::new(UInt32Array::from(
+                records.iter().map(|r| r.flags).collect::<Vec<_>>(),
+            )),
+            // `attrs` map: each record's stream-identity (resource + scope)
+            // attributes merged with its dynamic per-record attributes, values
+            // rendered to text. DataFusion's mandatory `Inexact` residual
+            // re-applies `attrs['k'] = 'v'` against this column, and that
+            // residual is the sole exactness mechanism, so the column must carry
+            // the fully merged view. Populating it from `r.attrs` alone silently
+            // dropped every record whose matched attribute was a genuine
+            // resource attribute (ADR-0033 amendment). See `merged_attrs`.
+            LOG_COL_ATTRS => {
+                let mut attrs = MapBuilder::new(None, StringBuilder::new(), StringBuilder::new());
+                for r in records {
+                    for (k, v) in merged_attrs(r)? {
+                        attrs.keys().append_value(&k);
+                        attrs.values().append_value(attr_value_to_string(&v));
+                    }
+                    attrs
+                        .append(true)
+                        .map_err(|e| SqlError::Internal(format!("attrs map build: {e}")))?;
+                }
+                Arc::new(attrs.finish())
+            }
+            other => {
+                return Err(DataFusionError::Internal(format!(
+                    "logs scan projection index {other} out of range"
+                )));
+            }
+        };
+        columns.push(array);
     }
-    let trace = trace.finish();
-
-    let mut span = FixedSizeBinaryBuilder::with_capacity(records.len(), SPAN_ID_WIDTH);
-    for r in records {
-        match &r.span_id {
-            Some(id) => span
-                .append_value(id)
-                .map_err(|e| SqlError::Internal(format!("span_id array build: {e}")))?,
-            None => span.append_null(),
-        }
-    }
-    let span = span.finish();
-
-    let flags = UInt32Array::from(records.iter().map(|r| r.flags).collect::<Vec<_>>());
-
-    // `attrs` map: each record's stream-identity (resource + scope) attributes
-    // merged with its dynamic per-record attributes, values rendered to text.
-    // DataFusion's mandatory `Inexact` residual re-applies `attrs['k'] = 'v'`
-    // against this column, and that residual is the sole exactness mechanism, so
-    // the column must carry the fully merged view. Populating it from `r.attrs`
-    // alone silently dropped every record whose matched attribute was a genuine
-    // resource attribute (ADR-0033 amendment). See `merged_attrs`.
-    let mut attrs = MapBuilder::new(None, StringBuilder::new(), StringBuilder::new());
-    for r in records {
-        for (k, v) in merged_attrs(r)? {
-            attrs.keys().append_value(&k);
-            attrs.values().append_value(attr_value_to_string(&v));
-        }
-        attrs
-            .append(true)
-            .map_err(|e| SqlError::Internal(format!("attrs map build: {e}")))?;
-    }
-    let attrs = attrs.finish();
-
-    let columns: Vec<ArrayRef> = vec![
-        Arc::new(ts),
-        Arc::new(observed_ts),
-        Arc::new(severity_num),
-        Arc::new(severity_text),
-        Arc::new(body),
-        Arc::new(trace),
-        Arc::new(span),
-        Arc::new(flags),
-        Arc::new(attrs),
-    ];
     debug_assert_eq!(schema.fields().len(), columns.len());
-    RecordBatch::try_new(schema, columns).map_err(DataFusionError::from)
+    // The row count is carried explicitly: an empty projection (what a bare
+    // `COUNT(*)` asks for, and the cheapest case this change exists to make
+    // work) has no column to infer it from, and inferring zero rows there would
+    // silently lose every row.
+    let options = RecordBatchOptions::new().with_row_count(Some(records.len()));
+    RecordBatch::try_new_with_options(schema, columns, &options).map_err(DataFusionError::from)
 }

--- a/crates/ravel-sql/tests/logs_provider.rs
+++ b/crates/ravel-sql/tests/logs_provider.rs
@@ -578,3 +578,367 @@ async fn residual_recheck_keeps_resource_only_stream_attr_match() {
          and exclude ts=2 (non-matching stream); got {got:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// ADR-0087: streaming, column-projecting scan
+// ---------------------------------------------------------------------------
+
+/// A `SessionContext` built through the real production path
+/// (`ravel_sql::build_session`), the same one `/api/v1/sql` and Flight SQL use,
+/// with `provider` registered as `logs`.
+fn logs_session(
+    provider: LogsTableProvider,
+) -> datafusion::error::Result<datafusion::prelude::SessionContext> {
+    let config = ravel_sql::SqlConfig::default();
+    let tenant = ravel_sql::TenantMemoryAccountant::new(1 << 30);
+    let (pool, _breach) = config.query_pool(tenant, QueryAccounting::new());
+    ravel_sql::build_session(
+        &config,
+        pool,
+        ravel_sql::SessionTable::Logs(Arc::new(provider)),
+    )
+}
+
+/// The `LogsScanExec` leaf of a physical plan. The plan above it is whatever
+/// the optimizer built, so the leaf is found by walking rather than by shape.
+fn find_by_name(
+    plan: &Arc<dyn datafusion::physical_plan::ExecutionPlan>,
+    name: &str,
+) -> Option<Arc<dyn datafusion::physical_plan::ExecutionPlan>> {
+    if plan.name() == name {
+        return Some(Arc::clone(plan));
+    }
+    plan.children().iter().find_map(|c| find_by_name(c, name))
+}
+
+/// Two streams whose records interleave in time, written to two objects, so
+/// neither the reader's `(stream_ref, ts)` grouping within an object nor the
+/// segment order across the partition is `ts` ascending. This is what makes the
+/// `ORDER BY ts` assertion below non-vacuous.
+fn interleaved_objects() -> (Vec<LogRecord>, Vec<LogRecord>) {
+    // Object A: "api" at even ts 0..40, "worker" at odd ts 1..41. The writer
+    // sorts by (stream_ref, ts), so A emits all of one stream then all of the
+    // other: not ts ascending.
+    let a: Vec<LogRecord> = (0..20)
+        .flat_map(|i| {
+            [
+                record("api", i * 2, &format!("api {}", i * 2)),
+                record("worker", i * 2 + 1, &format!("worker {}", i * 2 + 1)),
+            ]
+        })
+        .collect();
+    // Object B covers a ts band that *precedes* part of A, so concatenating the
+    // partition's segments in order is not ts ascending either.
+    let b: Vec<LogRecord> = (0..20)
+        .map(|i| record("db", i * 2 + 100, &format!("db {}", i * 2 + 100)))
+        .collect();
+    (a, b)
+}
+
+/// ADR-0087 decision 1's must-not-regress case: the leaf declares no ordering,
+/// and `ORDER BY ts` is nonetheless exactly sorted because DataFusion inserts a
+/// sort above it.
+///
+/// Three things are asserted together, and all three are needed. The rows are
+/// exactly the reference multiset (nothing lost or duplicated); the emitted
+/// sequence is `ts` ascending (the ordering itself); and the plan contains a
+/// `SortExec` above the `LogsScanExec` while the leaf's own
+/// `PlanProperties` declare no output ordering (the ordering comes from the
+/// inserted sort, not from a leaf claim).
+///
+/// Against a naive streaming implementation that keeps the old
+/// `EquivalenceProperties::new_with_orderings(... ts asc ...)` in
+/// `LogsScanExec::compute_properties` and simply drops the partition sort,
+/// DataFusion trusts the leaf, inserts no `SortExec`, and the ts-ascending
+/// assertion fails on the very first out-of-order pair.
+#[tokio::test]
+async fn order_by_ts_is_sorted_by_an_inserted_sort_not_by_a_leaf_claim() {
+    let store = MemoryStore::new();
+    let (obj_a, obj_b) = interleaved_objects();
+    let ref_a = write_object(&store, "logs/order-a.rlog", &obj_a).await;
+    let ref_b = write_object(&store, "logs/order-b.rlog", &obj_b).await;
+    let snapshot = Snapshot {
+        segments: vec![ref_a, ref_b],
+        segments_pruned: 0,
+        pending_erasure: Vec::new(),
+    };
+    let backend: Arc<dyn ObjectStoreBackend> = Arc::new(store);
+    let provider = LogsTableProvider::new(
+        snapshot,
+        TenantHash([7u8; 16]),
+        LogSegmentFetcher::new(backend),
+        QueryAccounting::new(),
+    );
+
+    // The leaf itself declares nothing. Read it off the unsorted plan so this
+    // is a statement about `LogsScanExec`, not about whatever the optimizer
+    // wrapped it in.
+    let bare = provider.plan(4).expect("plan");
+    assert!(
+        bare.properties().output_ordering().is_none(),
+        "the logs scan must declare no output ordering (ADR-0087 decision 1)"
+    );
+
+    let ctx = logs_session(provider).expect("session");
+
+    // Unordered: prove the scan really does emit out of ts order, so the
+    // ordered assertion below is not satisfied by accident.
+    let unordered = ctx
+        .sql("SELECT ts, body FROM logs")
+        .await
+        .expect("plan")
+        .collect()
+        .await
+        .expect("collect");
+    let emitted = ts_sequence(&unordered);
+    assert!(
+        emitted.windows(2).any(|w| w[0] > w[1]),
+        "fixture must not already be ts-ascending out of the scan, else the \
+         ORDER BY assertion proves nothing"
+    );
+
+    let plan = ctx
+        .sql("SELECT ts, body FROM logs ORDER BY ts")
+        .await
+        .expect("plan")
+        .create_physical_plan()
+        .await
+        .expect("physical plan");
+    assert!(
+        find_by_name(&plan, "SortExec").is_some(),
+        "ORDER BY ts must be answered by a sort operator above the scan"
+    );
+    assert!(
+        find_by_name(&plan, "LogsScanExec").is_some(),
+        "the plan must still be over the logs scan"
+    );
+
+    let ordered = collect_plan(plan).await;
+    let got = ts_sequence(&ordered);
+    let mut want = emitted;
+    want.sort_unstable();
+    assert_eq!(
+        got, want,
+        "ORDER BY ts must return every scanned row exactly once, ts ascending"
+    );
+    assert!(
+        got.windows(2).all(|w| w[0] <= w[1]),
+        "ORDER BY ts output must be ascending"
+    );
+}
+
+/// The `ts` values of `batches`, in emission order (column 0 of `SELECT ts, ...`).
+fn ts_sequence(batches: &[RecordBatch]) -> Vec<i64> {
+    let mut out = Vec::new();
+    for batch in batches {
+        let ts = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<TimestampNanosecondArray>()
+            .expect("ts col");
+        for i in 0..batch.num_rows() {
+            out.push(ts.value(i));
+        }
+    }
+    out
+}
+
+/// Number of dynamic attribute columns each record in the projection fixture
+/// carries. Comfortably over the "100+ attributes" the ADR's motivating case
+/// describes.
+const WIDE_ATTRS: usize = 120;
+
+/// One record carrying `WIDE_ATTRS` dynamic attributes. `a007` and `a042` vary
+/// per record (so an erasure predicate can name one specific row); the rest are
+/// constant, which changes nothing about how many *columns* exist.
+fn wide_record(ts: i64) -> LogRecord {
+    let resource = vec![("service.name".to_string(), AttrValue::Str("api".into()))];
+    let attrs: Vec<(String, AttrValue)> = (0..WIDE_ATTRS)
+        .map(|i| {
+            let key = format!("a{i:03}");
+            let value = match i {
+                7 => format!("r{ts}"),
+                42 => format!("s{ts}"),
+                _ => format!("v{i}"),
+            };
+            (key, AttrValue::Str(value))
+        })
+        .collect();
+    record_with_resource_and_attrs(&resource, ts, &format!("body {ts}"), &attrs)
+}
+
+/// Sum a named `LogsScanExec` metric over the executed plan.
+fn scan_metric(plan: &Arc<dyn datafusion::physical_plan::ExecutionPlan>, name: &str) -> usize {
+    find_by_name(plan, "LogsScanExec")
+        .expect("a LogsScanExec leaf")
+        .metrics()
+        .expect("the scan publishes metrics")
+        .sum_by_name(name)
+        .map(|v| v.as_usize())
+        .unwrap_or_else(|| panic!("metric {name} missing"))
+}
+
+/// ADR-0087 decision 3: a query that references two of a hundred-and-twenty
+/// attributes decodes exactly those two columns' pages and walks past the rest.
+///
+/// The two referenced attributes here are named by *pending erasure
+/// predicates*, not by the projection. That is deliberate and it is the only
+/// shape the ADR leaves room for: the SQL surface exposes attributes as one
+/// merged `attrs` Map column, so any query naming `attrs` at all resolves to
+/// every dynamic column (per-key `attrs['k']` projection is explicitly out of
+/// scope). Erasure predicates name individual attribute keys, so they exercise
+/// the per-key resolution path that does exist -- and they are the case where
+/// getting the column set wrong is a correctness bug, not just a performance
+/// one: an erasure key the reader never decodes makes the erased row reappear.
+///
+/// Both halves are asserted: the page counts (projection reached the page
+/// level) and the rows (the two erasures still bite, so the columns that *were*
+/// decoded are the right ones).
+#[tokio::test]
+async fn column_projection_decodes_only_the_referenced_attribute_pages() {
+    let store = MemoryStore::new();
+    let records: Vec<LogRecord> = (0..12).map(wide_record).collect();
+    let seg = write_object(&store, "logs/wide.rlog", &records).await;
+    let backend: Arc<dyn ObjectStoreBackend> = Arc::new(store);
+
+    // Two pending erasure requests, each naming one attribute key: `a007` on
+    // the ts=3 row and `a042` on the ts=5 row.
+    let erasure = |key: &str, value: &str| ravel_proto::commit::v1::ErasureRequest {
+        predicate: vec![ravel_proto::commit::v1::ErasurePredicateMatcher {
+            key: key.to_string(),
+            value: value.to_string(),
+        }],
+        ..Default::default()
+    };
+    let snapshot = Snapshot {
+        segments: vec![seg],
+        segments_pruned: 0,
+        pending_erasure: vec![erasure("a007", "r3"), erasure("a042", "s5")],
+    };
+    let provider = LogsTableProvider::new(
+        snapshot,
+        TenantHash([7u8; 16]),
+        LogSegmentFetcher::new(backend),
+        QueryAccounting::new(),
+    );
+    let ctx = logs_session(provider).expect("session");
+
+    let plan = ctx
+        .sql("SELECT ts, body FROM logs")
+        .await
+        .expect("plan")
+        .create_physical_plan()
+        .await
+        .expect("physical plan");
+    let batches = collect_plan(Arc::clone(&plan)).await;
+
+    // Rows: everything except the two erased ones. This proves the two decoded
+    // attribute columns are genuinely the erasure keys' columns -- had the
+    // projection dropped them, the erasure would have found nothing to match
+    // and both rows would be back.
+    let got: BTreeSet<i64> = ts_sequence(&batches).into_iter().collect();
+    let want: BTreeSet<i64> = (0..12).filter(|ts| *ts != 3 && *ts != 5).collect();
+    assert_eq!(
+        got, want,
+        "the two erasure predicates must still exclude their rows"
+    );
+
+    let blocks = scan_metric(&plan, "blocks_scanned");
+    let decoded = scan_metric(&plan, "pages_decoded");
+    let skipped = scan_metric(&plan, "pages_skipped");
+    assert!(blocks > 0, "the fixture must actually decode blocks");
+
+    // Per block: `ts`, `stream_ref` (always), `body` (projected), and the two
+    // erasure-named attribute columns. Nothing else. `attrs_raw` is in the
+    // resolved set but occupies no page here (no record overflowed), and an
+    // absent column costs no page either way.
+    assert_eq!(
+        decoded,
+        5 * blocks,
+        "expected 5 pages per block (ts, stream_ref, body, a007, a042), got \
+         {decoded} over {blocks} blocks"
+    );
+    // Everything else in the block: the remaining 118 dynamic columns plus the
+    // four unprojected always-present fixed columns (observed_ts, severity_num,
+    // flags, severity_text).
+    assert_eq!(
+        skipped,
+        (WIDE_ATTRS - 2 + 4) * blocks,
+        "every unreferenced column's pages must be skipped, got {skipped} over \
+         {blocks} blocks"
+    );
+    assert!(
+        skipped > 20 * decoded,
+        "the whole point: {skipped} pages skipped vs {decoded} decoded"
+    );
+}
+
+/// The counterpart to the test above: a query that *does* reference `attrs`
+/// gets every dynamic column, because the merged map's contract is that every
+/// key is present (ADR-0087 decision 3, per-key projection out of scope).
+/// Without this, "we skipped pages" could be true while `SELECT *` silently
+/// returned a truncated map.
+#[tokio::test]
+async fn referencing_attrs_decodes_every_dynamic_column() {
+    let store = MemoryStore::new();
+    let records: Vec<LogRecord> = (0..6).map(wide_record).collect();
+    let seg = write_object(&store, "logs/wide-attrs.rlog", &records).await;
+    let backend: Arc<dyn ObjectStoreBackend> = Arc::new(store);
+    let snapshot = Snapshot {
+        segments: vec![seg],
+        segments_pruned: 0,
+        pending_erasure: Vec::new(),
+    };
+    let provider = LogsTableProvider::new(
+        snapshot,
+        TenantHash([7u8; 16]),
+        LogSegmentFetcher::new(backend),
+        QueryAccounting::new(),
+    );
+    let ctx = logs_session(provider).expect("session");
+
+    let plan = ctx
+        .sql("SELECT ts, attrs FROM logs")
+        .await
+        .expect("plan")
+        .create_physical_plan()
+        .await
+        .expect("physical plan");
+    let batches = collect_plan(Arc::clone(&plan)).await;
+
+    // Every record's map carries all WIDE_ATTRS dynamic keys plus the one
+    // resource attribute.
+    let mut rows = 0usize;
+    for batch in &batches {
+        let map = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<MapArray>()
+            .expect("attrs map col");
+        for i in 0..batch.num_rows() {
+            let entries = map.value(i);
+            let entries = entries
+                .as_any()
+                .downcast_ref::<StructArray>()
+                .expect("map entries");
+            assert_eq!(
+                entries.len(),
+                WIDE_ATTRS + 1,
+                "a query referencing attrs must see every dynamic key plus the \
+                 resource attribute"
+            );
+            rows += 1;
+        }
+    }
+    assert_eq!(rows, 6);
+
+    let blocks = scan_metric(&plan, "blocks_scanned");
+    let skipped = scan_metric(&plan, "pages_skipped");
+    // Only the five unprojected fixed columns (observed_ts, severity_num,
+    // flags, severity_text, body) are skipped; every dynamic column is decoded.
+    assert_eq!(
+        skipped,
+        5 * blocks,
+        "referencing attrs must skip only the unprojected fixed columns"
+    );
+}

--- a/docs/adrs/0087-streaming-projected-logs-scan.md
+++ b/docs/adrs/0087-streaming-projected-logs-scan.md
@@ -1,6 +1,6 @@
 # ADR-0087: streaming, column-projecting logs SQL scan
 
-Status: Proposed
+Status: Accepted
 
 ## Context
 

--- a/docs/guides/query.md
+++ b/docs/guides/query.md
@@ -226,6 +226,18 @@ truncation ([crates/ravel-query/src/config.rs](../../crates/ravel-query/src/conf
 seconds) lowers the deadline per request. It cannot raise it above the
 server's configured default.
 
+SQL queries carry one more bound, a per-query byte ceiling on the DataFusion
+memory pool (256 MiB by default). It bounds the memory the query *holds at one
+instant* -- what a scan currently has decoded, plus the batch it is handing
+downstream, plus whatever aggregate state the operators above it accumulate --
+not the number of bytes the query has produced over its lifetime. A full-table
+scan over `logs` therefore does not exhaust it merely by being large: the logs
+scan streams one block at a time and releases each block before decoding the
+next (ADR-0087), so its own contribution tracks block size and partition count.
+An `ORDER BY` or a high-cardinality `GROUP BY` over a large result is what
+genuinely accumulates. Exceeding the ceiling is an HTTP 422 `execution` error
+naming the pool, never a truncated result.
+
 The catalog-list budget is checked before any object-store request is made,
 not after. The catalog lists one prefix per (shard, ingest hour) from the
 window's start to the current hour, so a query whose `start` reaches far back

--- a/docs/log-segment-format.md
+++ b/docs/log-segment-format.md
@@ -265,6 +265,17 @@ its SKIP_IDX level-0 entry, not inline) covers the complete block bytes
 (header and all pages); the reader verifies it before decoding anything
 in the block.
 
+A reader may decode a *subset* of a block's columns. The page header names each
+page's `column_id` and stored length, so a reader walks past a page it does not
+want without decompressing it (`read_block_columns`, ADR-0087); the SQL logs
+scan uses this to decode only the columns a query references. This is a read
+choice, not a format variant: the crc32c is still verified over the complete
+block bytes, every page descriptor is still parsed, and every page's stored
+extent is still walked, so a truncated or over-long block is rejected exactly
+as it is under a whole-block decode. A skipped column is indistinguishable from
+an absent one in the decoded result, so a reader that projects is responsible
+for having asked for every column it goes on to read.
+
 ```
    one row block, columnar:
 

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -996,6 +996,52 @@ never drop a true result):
   `attrs['k'] IN (...)` stays unextracted, because an `IN` list is a
   disjunction the intersecting prune channel cannot represent soundly.
 
+### Scan execution: streaming and column projection (ADR-0087)
+
+`LogsScanExec` streams. A partition opens its segments one at a time, decodes
+one RLOG block, emits that block's rows as a batch, and releases the block
+before decoding the next. Peak memory is therefore a function of block size and
+partition count, not of table size. Before ADR-0087 the scan collected a whole
+partition's records in row form, sorted them, and only then emitted batches, so
+a full-table scan's peak memory grew with the table.
+
+Two consequences an operator and a plan reader both see:
+
+- **The scan declares no output ordering.** It used to declare `ts` ascending
+  per partition, which it earned by sorting the collected partition.
+  `RlogReader` emits a segment's records grouped by `(stream_ref, ts)`, not
+  globally by `ts`, and a partition spans several segments, so a
+  block-at-a-time scan cannot truthfully claim that order. `ORDER BY ts` still
+  returns correctly sorted results; the ordering now comes from a `SortExec`
+  DataFusion inserts above the scan, visible in `EXPLAIN`. Any downstream
+  operator that relied on a sort-preserving merge over logs-scan partitions
+  gets that explicit sort instead.
+- **Projection reaches the reader.** The scan's output schema *is* DataFusion's
+  requested projection; there is no `ProjectionExec` above it discarding
+  columns the scan already decoded. The decoded column set is the projected
+  columns, plus `ts`/`stream_ref` (always), plus every field a pushed content
+  predicate names, plus every attribute key a pending erasure predicate names
+  (ADR-0064). `read_block` decompresses and decodes only those columns' pages.
+  Because `attrs` is one merged map column, a query referencing `attrs` at all
+  -- `SELECT *` included -- resolves to every dynamic column plus the
+  `attrs_raw` overflow; per-key `attrs['k']` projection is not implemented.
+  Skip-index, POSTINGS, and bloom pruning are unchanged: they read stored
+  statistics, not decoded pages.
+
+`LogsScanExec` publishes `pages_decoded` and `pages_skipped` per partition
+alongside its block counters, so `EXPLAIN ANALYZE` shows how much of each block
+the projection avoided touching.
+
+The per-query DataFusion memory pool now bounds concurrently-held scan memory:
+the reservation grows when a decoded block and the batch built from it are held
+and shrinks as each is released. It is not a cumulative-output budget, and
+raising it does not change how much a full-table scan holds at one instant.
+
+Whole-object GET is unchanged: this bounds decoded memory, not the raw bytes an
+object fetch brings into RAM. Per-block ranged reads are
+`RlogRangeReader`'s territory (used by compaction) and are not on the SQL read
+path.
+
 Both gaps ADR-0033 recorded are now closed. Both were deliberate, not
 oversights.
 

--- a/services/ravel-server/tests/sql_logs_streaming_e2e.rs
+++ b/services/ravel-server/tests/sql_logs_streaming_e2e.rs
@@ -1,0 +1,406 @@
+//! ADR-0087 reachability gate: a full-table analytical query over a wide,
+//! large `logs` table completes inside a small SQL memory pool, driven through
+//! the real `POST /api/v1/sql` handler.
+//!
+//! This is the test that fails against the pre-ADR-0087 scan, and it has to
+//! live here rather than in `ravel-sql` because the failure it pins is a
+//! property of the whole request path: the endpoint installs the per-query
+//! `TenantDelegatingPool` (`SqlConfig::query_pool`), the executor drains the
+//! plan's stream into a response, and only that combination shows a scan's
+//! memory behaviour as a client-visible success or failure.
+//!
+//! The fixture is deliberately hostile in exactly the way the ADR describes:
+//! [`ATTRS_PER_RECORD`] dynamic attributes on every one of [`TOTAL_RECORDS`]
+//! records. Against the old collect-then-emit scan both queries fail: every
+//! column was decoded regardless of projection, the whole partition was
+//! collected in row form before any batch was emitted (a stage that was never
+//! charged against the pool at all), and the per-batch `try_grow` only ever
+//! grew, so the cumulative charge crossed an 8 MiB pool within the first few
+//! thousand rows. Against the streaming, column-projecting scan neither query
+//! decodes an attribute column at all, and the reservation tracks one block
+//! plus one batch.
+//!
+//! Both a `COUNT(*)` (no projected column at all) and a `GROUP BY` over a
+//! projected fixed column are exercised: the first is the degenerate case the
+//! ADR's context paragraph names, the second proves a real aggregate over a
+//! projected column still works under the same ceiling.
+
+#![cfg(feature = "sql")]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::Router;
+use axum::body::Body;
+use axum::http::{Request, StatusCode, header};
+use ravel_catalog::{Catalog, CatalogConfig};
+use ravel_commit::publish::RetryPolicy;
+use ravel_commit::record::NewCommitRecord;
+use ravel_commit::{keys, publish, record};
+use ravel_ingest::Clock;
+use ravel_logseg::writer::ObjectIdentity;
+use ravel_logseg::{AttrValue, LogRecord, RlogConfig, RlogWriter, stream_attrs_bytes};
+use ravel_object_store::memory::MemoryStore;
+use ravel_object_store::{ObjectStoreBackend, PutOptions};
+use ravel_query::http::StaticBearerTokenResolver;
+use ravel_query::{LogSegmentFetcher, SegmentFetcher};
+use ravel_server::sql::{SqlState, router};
+use ravel_sql::{SqlConfig, SqlExecutor};
+use ravel_types::logstream::log_stream_id;
+use ravel_types::{Signal, TenantId};
+use serde_json::Value;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+const NS_PER_HOUR: i64 = 3_600_000_000_000;
+/// Small on purpose: `Catalog::resolve` issues one LIST per (shard,
+/// ingest-hour) pair across the window.
+const NOW_NS: i64 = 4 * NS_PER_HOUR;
+
+/// Dynamic attribute columns on every record. The ADR's motivating figure is
+/// "roughly 100 dynamic attributes per record"; this sits just above it.
+const ATTRS_PER_RECORD: usize = 100;
+/// RLOG objects in the fixture.
+const OBJECTS: usize = 30;
+/// Records per object. Kept modest because `RlogWriter` buffers a whole
+/// object's records before `finish()`, so this, not `TOTAL_RECORDS`, bounds the
+/// fixture builder's own peak memory.
+const RECORDS_PER_OBJECT: usize = 10_000;
+/// Total records in the `logs` table under test.
+const TOTAL_RECORDS: usize = OBJECTS * RECORDS_PER_OBJECT;
+
+/// Severity texts cycled across records, so the `GROUP BY` has several real
+/// groups with known counts rather than one.
+const SEVERITIES: &[&str] = &["INFO", "WARN", "ERROR", "DEBUG"];
+
+/// The per-query DataFusion memory-pool ceiling for this test: 8 MiB, a
+/// thirty-second of the 256 MiB default. The fixture's cumulative emitted
+/// bytes are orders of magnitude past this, so a scan whose reservation tracks
+/// cumulative output cannot pass however many batches it splits into.
+const SMALL_POOL_BYTES: usize = 8 * 1024 * 1024;
+/// The tenant-wide ceiling behind the per-query pool. Above the per-query
+/// ceiling (it is shared across a tenant's concurrent queries) but still small,
+/// so it cannot silently become the thing under test.
+const SMALL_TENANT_BYTES: usize = 32 * 1024 * 1024;
+
+/// A clock frozen at [`NOW_NS`].
+struct FixedClock;
+
+impl Clock for FixedClock {
+    fn now_ns(&self) -> i64 {
+        NOW_NS
+    }
+}
+
+fn identity(index: usize, tenant_hash: [u8; 16], writer_id: Uuid) -> ObjectIdentity {
+    ObjectIdentity {
+        tenant_hash,
+        shard: 0,
+        writer_id: writer_id.into_bytes(),
+        writer_epoch: 1,
+        writer_seq: index as u64 + 1,
+    }
+}
+
+/// The [`ATTRS_PER_RECORD`] dynamic attributes every fixture record carries,
+/// built once and cloned per record.
+///
+/// The attribute *values* are shared across records on purpose (they compress
+/// away, keeping the objects small); what matters to this test is the number of
+/// distinct attribute *columns*, since that is what an unprojected decode has
+/// to materialize per row. Building the vector once is purely a fixture-cost
+/// choice: at 100 attributes over 300,000 records, formatting the keys and
+/// values per record dominates the whole test's wall clock.
+fn wide_attrs() -> Vec<(String, AttrValue)> {
+    (0..ATTRS_PER_RECORD)
+        .map(|i| {
+            (
+                format!("attr.{i:03}"),
+                AttrValue::Str(format!("value-{i:03}")),
+            )
+        })
+        .collect()
+}
+
+/// One record of the wide fixture: a fixed stream, a cycling severity, and
+/// `attrs` (see [`wide_attrs`]).
+fn wide_record(
+    ts: i64,
+    stream_id: ravel_types::logstream::LogStreamId,
+    stream_attrs: &[u8],
+    attrs: &[(String, AttrValue)],
+) -> LogRecord {
+    LogRecord {
+        stream_id,
+        stream_attrs: stream_attrs.to_vec(),
+        ts_ns: ts,
+        observed_ts_ns: ts,
+        severity_num: 9,
+        severity_text: SEVERITIES[(ts as usize) % SEVERITIES.len()].to_string(),
+        body: format!("request {ts} completed"),
+        trace_id: None,
+        span_id: None,
+        flags: 0,
+        attrs: attrs.to_vec(),
+    }
+}
+
+/// Publish one RLOG object of `count` wide records starting at `first_ts`, plus
+/// its `Signal::Logs` commit record, exactly as `ravel-ingest`'s log shard
+/// actor does. Records are generated and pushed one at a time so the fixture
+/// never holds the whole table in row form.
+async fn publish_wide_object(
+    store: &dyn ObjectStoreBackend,
+    tenant: &TenantId,
+    index: usize,
+    first_ts: i64,
+    count: usize,
+) {
+    let tenant_hash = tenant.hash();
+    let writer_id = Uuid::from_u128(9_000 + index as u128);
+    let mut writer = RlogWriter::new(
+        RlogConfig::default(),
+        identity(index, tenant_hash.0, writer_id),
+    );
+    let resource = vec![(
+        "service.name".to_string(),
+        AttrValue::Str("api".to_string()),
+    )];
+    let stream_id = log_stream_id(&resource, "scope", "1.0", &[]);
+    let stream_attrs = stream_attrs_bytes(&resource, "scope", "1.0", &[]);
+    let attrs = wide_attrs();
+    for i in 0..count {
+        let rec = wide_record(first_ts + i as i64, stream_id, &stream_attrs, &attrs);
+        writer.push(rec).expect("push log record");
+    }
+    let bytes = writer.finish().expect("finish rlog object");
+    let content_hash: [u8; 32] = *blake3::hash(&bytes).as_bytes();
+    let min_event_ts_ns = first_ts;
+    let max_event_ts_ns = first_ts + count as i64 - 1;
+
+    let rec = record::build(NewCommitRecord {
+        tenant_hash,
+        signal: Signal::Logs,
+        shard: 0,
+        writer_id,
+        writer_epoch: 1,
+        writer_seq: index as u64 + 1,
+        object_size: bytes.len() as u64,
+        content_hash,
+        sample_count: count as u64,
+        // One stream: every fixture record shares the same resource attributes.
+        series_count: 1,
+        min_event_ts_ns,
+        max_event_ts_ns,
+        min_ingest_ts_ns: min_event_ts_ns,
+        max_ingest_ts_ns: max_event_ts_ns,
+        segment_format_version: 1,
+        created_unix_ns: 10 + index as i64,
+        ingest_hour_bucket: 0,
+    })
+    .expect("valid log commit record");
+
+    let data_key = keys::reconstruct_data_key(&rec).expect("data key");
+    store
+        .put(&data_key, bytes::Bytes::from(bytes), PutOptions::default())
+        .await
+        .expect("put log data object");
+    publish::publish(store, &rec, &RetryPolicy::default())
+        .await
+        .expect("publish log commit");
+}
+
+/// The real `/api/v1/sql` router, with the per-query memory pool capped at
+/// [`SMALL_POOL_BYTES`]. This is the whole point of driving the test through
+/// the endpoint: `SqlConfig::max_query_bytes` is consumed where the endpoint
+/// builds the query's `RuntimeEnv`, so the ceiling under test is the one
+/// production installs.
+fn build_router(store: Arc<dyn ObjectStoreBackend>, tokens: HashMap<String, TenantId>) -> Router {
+    let catalog =
+        Arc::new(Catalog::new(Arc::clone(&store), CatalogConfig::default()).expect("catalog"));
+    let config = SqlConfig {
+        max_query_bytes: SMALL_POOL_BYTES,
+        ..SqlConfig::default()
+    };
+    let executor = SqlExecutor::new(
+        catalog,
+        SegmentFetcher::new(store.clone()),
+        LogSegmentFetcher::new(store.clone()),
+        ravel_sql::SpanSegmentFetcher::new(store.clone()),
+        config,
+        SMALL_TENANT_BYTES,
+    );
+    router(SqlState {
+        executor: Arc::new(executor),
+        tenant_resolver: Arc::new(StaticBearerTokenResolver::new(tokens)),
+        store,
+        clock: Arc::new(FixedClock),
+        // Generous: this test is about memory, and a debug-build scan over
+        // 300k records must not be failed by a wall clock instead.
+        max_deadline: Duration::from_secs(600),
+        query_accounting: Arc::new(ravel_server::metrics::QueryAccountingMetrics::new(
+            std::collections::HashSet::new(),
+        )),
+        query_admission: ravel_query::QueryAdmissionController::shared(
+            ravel_query::QueryConcurrencyLimit::Unlimited,
+        ),
+        audit_sink: Arc::new(ravel_maintain::NoopQueryAuditSink),
+    })
+}
+
+async fn post_json(app: &Router, token: &str, query: &str) -> (StatusCode, Value) {
+    let payload = serde_json::json!({
+        "query": query,
+        "start": 0.0,
+        "end": NOW_NS as f64 / 1_000_000_000.0,
+        "timeout": 540.0,
+    })
+    .to_string();
+    let request = Request::builder()
+        .method("POST")
+        .uri("/api/v1/sql")
+        .header(header::CONTENT_TYPE, "application/json")
+        .header(header::AUTHORIZATION, format!("Bearer {token}"))
+        .body(Body::from(payload))
+        .expect("build request");
+    let response = app
+        .clone()
+        .oneshot(request)
+        .await
+        .expect("oneshot is infallible");
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read body")
+        .to_vec();
+    let value = serde_json::from_slice(&bytes).unwrap_or_else(|e| {
+        panic!(
+            "body is not JSON ({e}): {}",
+            String::from_utf8_lossy(&bytes)
+        )
+    });
+    (status, value)
+}
+
+/// The index of `name` in the response's column list.
+fn column_index(value: &Value, name: &str) -> usize {
+    value["data"]["columns"]
+        .as_array()
+        .unwrap_or_else(|| panic!("no columns in {value}"))
+        .iter()
+        .position(|c| c["name"].as_str() == Some(name))
+        .unwrap_or_else(|| panic!("no column {name} in {value}"))
+}
+
+/// The rows of a successful response, as positional JSON arrays.
+fn rows(value: &Value) -> &Vec<Value> {
+    value["data"]["rows"]
+        .as_array()
+        .unwrap_or_else(|| panic!("no rows in {value}"))
+}
+
+/// The query's own reported peak reserved bytes (ADR-0044
+/// `peak_intermediate_bytes`), the high-water mark of the per-query pool.
+fn peak_intermediate_bytes(value: &Value) -> u64 {
+    value["stats"]["accounting"]["peakIntermediateBytes"]
+        .as_u64()
+        .unwrap_or_else(|| panic!("no peakIntermediateBytes in {value}"))
+}
+
+/// The acceptance test (ADR-0087): a full-table `COUNT(*)` and a full-table
+/// `GROUP BY` over 300,000 records carrying 100 dynamic attributes each both
+/// return correct results through `POST /api/v1/sql` under an 8 MiB per-query
+/// memory pool.
+///
+/// Failing this means the scan is holding, or charging for, memory proportional
+/// to the table rather than to a block.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn wide_full_table_aggregates_complete_within_a_small_memory_pool() {
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+    let tenant = TenantId::new("acme".to_string());
+    for index in 0..OBJECTS {
+        let first_ts = (index * RECORDS_PER_OBJECT) as i64 + 1;
+        publish_wide_object(store.as_ref(), &tenant, index, first_ts, RECORDS_PER_OBJECT).await;
+    }
+    let app = build_router(
+        store,
+        HashMap::from([("acme-token".to_string(), tenant.clone())]),
+    );
+
+    // 1. `COUNT(*)`: no column projected at all. The pre-change scan still
+    //    received (and materialized) every column including the 100-attribute
+    //    `attrs` map, which is precisely the case the ADR's context paragraph
+    //    describes as crossing the pool "well under 100,000 rows".
+    let (status, value) = post_json(&app, "acme-token", "SELECT COUNT(*) FROM logs").await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "COUNT(*) must complete inside the {SMALL_POOL_BYTES}-byte pool: {value}"
+    );
+    assert_eq!(value["status"], "success", "{value}");
+    let count_rows = rows(&value);
+    assert_eq!(count_rows.len(), 1, "COUNT(*) returns one row: {value}");
+    assert_eq!(
+        count_rows[0][0].as_i64(),
+        Some(TOTAL_RECORDS as i64),
+        "every record must be counted: {value}"
+    );
+    // The query's own high-water mark, not just "it did not fail": a scan that
+    // charged cumulative output would have reported far more than the pool.
+    let peak = peak_intermediate_bytes(&value);
+    assert!(
+        peak < SMALL_POOL_BYTES as u64,
+        "peak reserved bytes {peak} must stay under the {SMALL_POOL_BYTES}-byte          pool, not merely avoid tripping it: {value}"
+    );
+
+    // 2. A real aggregate over a projected fixed column. Four groups of known
+    //    size, so a partially-drained scan shows up as wrong counts rather than
+    //    merely as a different error.
+    let (status, value) = post_json(
+        &app,
+        "acme-token",
+        "SELECT severity_text, COUNT(*) AS n FROM logs GROUP BY severity_text",
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "GROUP BY must complete inside the {SMALL_POOL_BYTES}-byte pool: {value}"
+    );
+    assert_eq!(value["status"], "success", "{value}");
+
+    let severity_col = column_index(&value, "severity_text");
+    let n_col = column_index(&value, "n");
+    let group_rows = rows(&value);
+    assert_eq!(
+        group_rows.len(),
+        SEVERITIES.len(),
+        "one row per severity: {value}"
+    );
+    let mut total = 0i64;
+    let mut seen: Vec<String> = Vec::new();
+    for row in group_rows {
+        let severity = row[severity_col].as_str().expect("severity_text");
+        let n = row[n_col].as_i64().expect("count");
+        assert!(
+            SEVERITIES.contains(&severity),
+            "unexpected severity {severity} in {value}"
+        );
+        seen.push(severity.to_string());
+        total += n;
+    }
+    seen.sort();
+    seen.dedup();
+    assert_eq!(seen.len(), SEVERITIES.len(), "duplicate groups in {value}");
+    assert_eq!(
+        total, TOTAL_RECORDS as i64,
+        "the groups must account for every record: {value}"
+    );
+    let peak = peak_intermediate_bytes(&value);
+    assert!(
+        peak < SMALL_POOL_BYTES as u64,
+        "peak reserved bytes {peak} must stay under the {SMALL_POOL_BYTES}-byte          pool: {value}"
+    );
+}


### PR DESCRIPTION
The logs SQL scan collected an entire query partition into row-form
records before emitting any Arrow, and the RLOG reader decoded every
column of every block regardless of which columns the query used. The
per-query memory reservation only grew, tracking cumulative bytes
emitted rather than what was actually resident, so a wide analytical
query over the logs table exhausted the pool or the host long before
its real cost was reached.

The scan now decodes and emits one block at a time, releasing each
block's memory before the next, and threads a resolved column set down
to the RLOG reader so only referenced columns decode. The reservation
tracks live held memory instead of cumulative output.

This required dropping the scan's leaf-level ts-ascending ordering
guarantee: it was only truthful because the old scan sorted an entire
collected partition before emitting, which a block-streaming scan
cannot do. ORDER BY ts now sorts via an explicit operator DataFusion
inserts above the scan; a test proves the unordered scan really does
emit out of order before proving the compensated plan sorts correctly.

Fixes: #279
