### PR TITLE
feat(ravel-cli): add load --parquet bulk import for logs (ADR-0089)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4375,6 +4375,7 @@ name = "ravel-cli"
 version = "0.9.5"
 dependencies = [
  "anyhow",
+ "arrow 59.1.0",
  "async-trait",
  "blake3",
  "bytes",
@@ -4382,6 +4383,7 @@ dependencies = [
  "crc32c",
  "hex",
  "humantime",
+ "parquet",
  "prost",
  "ravel-catalog",
  "ravel-commit",
@@ -4389,15 +4391,19 @@ dependencies = [
  "ravel-logseg",
  "ravel-maintain",
  "ravel-object-store",
+ "ravel-otlp",
  "ravel-proto",
+ "ravel-query",
  "ravel-rspan",
  "ravel-segment",
+ "ravel-sql",
  "ravel-types",
  "serde",
  "serde_json",
  "tempfile",
  "thiserror",
  "tokio",
+ "toml",
  "uuid",
 ]
 

--- a/deny.toml
+++ b/deny.toml
@@ -18,6 +18,17 @@ ignore = [
   # acceptable to ignore. No fixed bincode 1.x exists; revisit when
   # promql-parser drops the lrpar bincode dependency.
   "RUSTSEC-2025-0141",
+  # RUSTSEC-2024-0436: paste 1.0.15 is unmaintained (repo archived). It
+  # enters only through parquet (services/ravel-cli's bulk-import loader,
+  # ADR-0089), which uses it purely as a proc-macro for compile-time
+  # identifier concatenation. paste has no runtime API surface at all: it
+  # expands entirely during macro invocation and contributes nothing to
+  # the compiled binary or its runtime behavior, so "unmaintained" has no
+  # runtime security implication here, unlike a crate that ships code
+  # that executes. No safe upgrade exists (the advisory's own suggested
+  # forks, pastey and with_builtin_macros, are not drop-in and parquet
+  # does not depend on either); revisit if parquet drops paste upstream.
+  "RUSTSEC-2024-0436",
 ]
 
 [licenses]

--- a/docs/adrs/0089-bulk-import-logs-signal.md
+++ b/docs/adrs/0089-bulk-import-logs-signal.md
@@ -1,6 +1,6 @@
 # ADR-0089: bulk import of structured event data into the logs signal
 
-Status: Proposed
+Status: Accepted
 
 ## Context
 

--- a/docs/consistency-model.md
+++ b/docs/consistency-model.md
@@ -258,6 +258,17 @@ ingestion.
   (docs/catalog-and-mvcc.md, "Config discipline"). Lowering the admission lag
   is always safe. Raising the admission lag alone admits records the listing
   window then fails to discover on any non-token query.
+- Bulk-import exception (ADR-0089): `ravel-cli load --parquet` relaxes the
+  *past-event-time lag* admission bound for offline bulk loads without
+  violating the paired-bound rule above, because it does not touch the listing
+  side. A bulk-loaded record buckets by the flush-open wall clock, not its
+  event time, so it lands in today's ingest-hour bucket regardless of how old
+  the event is; the listing window's future bound (`now + max_future_skew`)
+  still reaches that bucket, so a query with a normal `start`/`end` window
+  (compared against event-range overlap) discovers it. Future skew stays
+  enforced on this path for exactly the reason above -- a far-future event
+  would bucket by today's wall clock but never be reached by any later query's
+  listing window. See docs/guides/ingest.md "Bulk import".
 
 ## Online resharding (ADR-0052)
 

--- a/docs/guides/ingest.md
+++ b/docs/guides/ingest.md
@@ -378,3 +378,114 @@ Malformed `trace_id`/`span_id` byte lengths normalize to absent; Ravel does
 not pad or truncate them. Padding would fabricate an id that never existed.
 A record with neither `time_unix_nano` nor `observed_time_unix_nano` set
 (legal OTLP) takes the server's ingest timestamp for both.
+
+## Bulk import (`ravel-cli load --parquet`, ADR-0089)
+
+OTLP is the only *networked* way to write logs. For loading an existing
+structured dataset offline (a Parquet export, an archive migration, a
+historical backfill), `ravel-cli load` imports a Parquet file into the logs
+signal:
+
+```sh
+ravel-cli load --parquet events.parquet --tenant acme --mapping map.toml --shards 4
+```
+
+The loader is an in-process caller of the same `LogIngestRouter` OTLP uses --
+the same shard actors, flush cadence, and commit protocol, not a parallel write
+path. It builds the router against the target tenant's provisioned shard count
+(validated against, or written to, the durable provisioning record exactly as
+the server does at first touch) and writes with strict acknowledgement, awaiting
+every write before it exits, so a run that returns success has no
+buffered-but-unflushed data.
+
+### The `--mapping` TOML
+
+The mapping declares how source Parquet columns become record fields. Resource
+attributes determine stream identity (ADR-0029) and are declared separately from
+record attributes, which never enter identity:
+
+```toml
+ts_column = "timestamp"
+ts_unit   = "millis"        # seconds | millis | micros | nanos
+
+body_column            = "message"   # optional
+severity_number_column = "sev_num"   # optional (integer column)
+severity_text_column   = "level"     # optional (string column)
+trace_id_column        = "trace_id"  # optional (16-byte binary or 32-hex string)
+span_id_column         = "span_id"   # optional (8-byte binary or 16-hex string)
+
+# Resource attributes: part of stream identity.
+[[resource_attribute]]
+key = "service.name"
+column = "svc"
+type = "str"
+
+# Record attributes: typed values in the record's `attrs`, never stream identity.
+[[attribute]]
+key = "http.status_code"
+column = "status"
+type = "i64"                # str | i64 | f64 | bool | bytes
+```
+
+### Which admission rules this path keeps, relaxes, and bypasses
+
+- **Future skew: kept.** The loader enforces the same `max_future_skew_ns`
+  bound OTLP does. Relaxing it would let a record bucket by today's wall clock
+  while every later query lists from `query_range.start - max_ingest_lag`, which
+  does not reach today's bucket, so the record would be permanently
+  undiscoverable.
+- **Length caps (attribute key length, attribute value length, body length):
+  kept**, re-implemented identically to `ravel-otlp`'s `logs_limits.rs`. These
+  bound field sizes regardless of who is sending; the offline/trusted framing
+  does not change that.
+- **Past-event-time lag: relaxed (not enforced).** A backfill or migration needs
+  its real event times, and rewriting them would corrupt the source semantics
+  this path exists to preserve. This is sound because a record buckets by the
+  *flush-open wall clock* (`checked_ingest_hour_bucket`), not by its event time,
+  so an old-event record still lands in today's ingest-hour bucket. Its
+  *discoverability* then depends on the query's listing window reaching that
+  bucket: a caller querying with a normal `start`/`end` window already does,
+  since that window is compared against event-range overlap and the listing
+  upper bound is `now + max_future_skew` (which reaches today's bucket). See
+  `docs/consistency-model.md` "Late and skewed data" for the paired
+  admission/discoverability bound this relies on. **Query bulk-loaded data with
+  a window that reaches now, not just the records' event times.**
+- **Per-record attribute cap: relaxed** from OTLP's 128 to a loader-specific
+  1024. Bulk import is an operator-initiated, offline action over a file the
+  operator already controls -- a different threat model than a networked sender.
+  This 1024 cap is a *per-record* axis and is unrelated to the RLOG object's
+  1000-distinct-`(name, type)` dynamic-column budget: past that per-object
+  budget, extra columns fold into the object's `attrs_raw` overflow column
+  rather than being rejected, exactly as they do for OTLP-ingested data. A row
+  over the 1024 cap is rejected; a row within it whose columns push the object
+  past 1000 distinct columns is not -- its overflow columns fold into
+  `attrs_raw`.
+- **Per-tenant `AdmissionController` (active-stream cap, stream-creation rate,
+  byte rate): bypassed by construction.** This control lives in the server's
+  HTTP layer, above the router the loader calls directly. The loader does not go
+  through it, and there is no equivalent concept for a single offline bulk load.
+  Bulk-loaded volume is therefore not evidence the admission controller's limits
+  were exercised. The CLI prints this warning before every run.
+
+### Failure, retention, and performance
+
+A row that fails a kept check (future skew, a length cap, or the 1024 attribute
+cap) is rejected **fail-fast**: the run stops at the first bad row, prints a
+per-row error, and exits non-zero. Batches durable before that row stay durable.
+
+A failed flush (an object-store PUT failure) exits non-zero and prints the
+commit tokens already durable before the failure. A failure mid-file is a
+genuine **partial load, not a rollback**. There is **no resumability or
+deduplication**: re-running after any failure re-ingests the whole file from the
+start.
+
+Retention and GC key on ingest-hour buckets, which the loader derives from
+*load* time. A bulk-loaded record with an old event timestamp is therefore
+retained for the full retention window measured from when it was loaded, not
+from the data's real age.
+
+An RLOG object spanning a wide event-time range overlaps every later query's
+event range at resolve time, so unsorted input makes every subsequent query over
+the affected stream fetch the bulk-loaded objects regardless of the query's
+window. Sort input by event time before load where the mapping allows it. This
+is a performance recommendation, not a correctness requirement.

--- a/docs/guides/ingest.md
+++ b/docs/guides/ingest.md
@@ -474,10 +474,14 @@ cap) is rejected **fail-fast**: the run stops at the first bad row, prints a
 per-row error, and exits non-zero. Batches durable before that row stay durable.
 
 A failed flush (an object-store PUT failure) exits non-zero and prints the
-commit tokens already durable before the failure. A failure mid-file is a
-genuine **partial load, not a rollback**. There is **no resumability or
-deduplication**: re-running after any failure re-ingests the whole file from the
-start.
+commit tokens durable from batches completed before the failure. This list is
+a lower bound, not an exact account: the loader shards a batch across the
+target signal's shards and waits for every shard's ack, but on the first
+shard error it returns before collecting tokens from shards that acked
+successfully in that same batch, so a shard's records can be durable and
+still go unreported. A failure mid-file is a genuine **partial load, not a
+rollback**. There is **no resumability or deduplication**: re-running after
+any failure re-ingests the whole file from the start.
 
 Retention and GC key on ingest-hour buckets, which the loader derives from
 *load* time. A bulk-loaded record with an old event timestamp is therefore

--- a/services/ravel-cli/Cargo.toml
+++ b/services/ravel-cli/Cargo.toml
@@ -16,6 +16,12 @@ ravel-commit = { workspace = true }
 ravel-catalog = { workspace = true }
 ravel-maintain = { workspace = true }
 ravel-ingest = { workspace = true }
+# `load --parquet` reuses `NormalizedLogRecord` and the `logs_limits` constants
+# (max_future_skew_ns, the length caps) rather than reimplementing the record
+# shape or re-deriving the bounds (ADR-0089). New dependency of ravel-cli;
+# already a workspace pin (ravel-otap/ravel-bench use it), adds no new external
+# crate.
+ravel-otlp = { workspace = true }
 prost = { workspace = true }
 blake3 = { workspace = true }
 crc32c = { workspace = true }
@@ -36,8 +42,36 @@ serde_json = { workspace = true }
 hex = { workspace = true }
 uuid = { workspace = true }
 bytes = { workspace = true }
+# Parquet reader for `load --parquet` (ADR-0089). Not in the workspace
+# `[workspace.dependencies]`; pinned directly here at the same major (59) as the
+# workspace `arrow` pin, following crates/ravel-bench/Cargo.toml's pattern, and
+# deliberately NOT added to the root Cargo.toml (ADR-0011 isolates the arrow
+# family from the ingest-critical path; ravel-cli is operator tooling). This is
+# a genuinely new external dependency for ravel-cli, flagged per CLAUDE.md.
+parquet = { version = "59", default-features = false, features = ["arrow", "snap", "zstd"] }
+# arrow's array/datatypes/record_batch surface, to read Parquet row batches.
+# Reuses the workspace pin (major 59, matching `parquet` above).
+arrow = { workspace = true }
+# TOML parser (serde) for the `--mapping` file. Already in the dependency tree
+# (Cargo.lock carries toml 1.x transitively); pinned directly here. Flagged as
+# a new direct dependency of ravel-cli per CLAUDE.md.
+toml = "1"
 
 [dev-dependencies]
+# Writing small Parquet fixtures in the loader tests uses the same parquet/arrow
+# reader deps declared above; ArrowWriter comes from the `parquet` dep.
+# Query loaded logs back through the real ravel-sql logs path in the
+# reachability test (ADR-0089). ravel-sql is a path-only crate not listed in the
+# workspace `[workspace.dependencies]`, so it is named by path here, exactly as
+# crates/ravel-bench/Cargo.toml names it. The in-process `SqlExecutor` +
+# `LogsTableProvider` logs path is in ravel-sql's default build (the
+# `flight-sql` feature only gates the Flight transport), so no feature is
+# needed here.
+ravel-sql = { path = "../../crates/ravel-sql", version = "0.9.5" }
+# The reachability test builds a SqlExecutor's segment fetchers from ravel-query
+# (SegmentFetcher/LogSegmentFetcher/SpanSegmentFetcher); ravel-catalog is
+# already a normal dependency. Workspace pin, test construction only.
+ravel-query = { workspace = true }
 # Implementing a small `ObjectStoreBackend` test wrapper (hide one key from
 # LIST) needs the same async-trait the trait itself uses. Already a workspace
 # pin; adds no new external crate.

--- a/services/ravel-cli/Cargo.toml
+++ b/services/ravel-cli/Cargo.toml
@@ -48,7 +48,14 @@ bytes = { workspace = true }
 # deliberately NOT added to the root Cargo.toml (ADR-0011 isolates the arrow
 # family from the ingest-critical path; ravel-cli is operator tooling). This is
 # a genuinely new external dependency for ravel-cli, flagged per CLAUDE.md.
-parquet = { version = "59", default-features = false, features = ["arrow", "snap", "zstd"] }
+parquet = { version = "59", default-features = false, features = [
+    "arrow",
+    "snap",
+    "zstd",
+    "brotli",
+    "flate2-zlib-rs",
+    "lz4",
+] }
 # arrow's array/datatypes/record_batch surface, to read Parquet row batches.
 # Reuses the workspace pin (major 59, matching `parquet` above).
 arrow = { workspace = true }

--- a/services/ravel-cli/src/lib.rs
+++ b/services/ravel-cli/src/lib.rs
@@ -10,6 +10,7 @@ pub mod erase;
 pub mod gc_config;
 pub mod hold;
 pub mod idem;
+pub mod load;
 pub mod maintain;
 pub mod provision;
 pub mod qualify;

--- a/services/ravel-cli/src/load.rs
+++ b/services/ravel-cli/src/load.rs
@@ -1,0 +1,1072 @@
+//! `ravel-cli load --parquet` (ADR-0089): bulk-import a Parquet file into the
+//! logs signal through the existing [`ravel_ingest::LogIngestRouter`].
+//!
+//! This is a new *caller* of existing public APIs, not a new ingest path. The
+//! loader constructs its own router in-process against the target tenant's
+//! object store and provisioned shard count, reuses
+//! [`ravel_otlp::NormalizedLogRecord`] as the record shape, re-implements the
+//! `ravel-otlp` admission checks the ADR says to keep (future skew, length
+//! caps), relaxes the ones it says to relax (past-event-time lag, per-record
+//! attribute cap), and writes with [`WriteMode::Strict`] so every returned
+//! success has no buffered-but-unflushed data.
+//!
+//! Which `ravel-otlp` rules this path keeps, relaxes, or bypasses, and why, is
+//! documented in `docs/guides/ingest.md` ("Bulk import") per ADR-0089.
+
+use std::path::Path;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use arrow::array::{
+    Array, ArrayRef, BooleanArray, Float32Array, Float64Array, Int8Array, Int16Array, Int32Array,
+    Int64Array, LargeBinaryArray, LargeStringArray, StringArray, TimestampMicrosecondArray,
+    TimestampMillisecondArray, TimestampNanosecondArray, TimestampSecondArray, UInt8Array,
+    UInt16Array, UInt32Array, UInt64Array,
+};
+use arrow::array::{BinaryArray, FixedSizeBinaryArray};
+use arrow::datatypes::{DataType, TimeUnit};
+use arrow::record_batch::RecordBatch;
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+use ravel_catalog::{AbsentPolicy, validate_or_adopt};
+use ravel_ingest::{Clock, IngestConfig, LogIngestRouter, SystemClock, WriteMode};
+use ravel_object_store::ObjectStoreBackend;
+use ravel_otlp::NormalizedLogRecord;
+use ravel_otlp::logs_limits::LogIngestLimits;
+use ravel_types::logstream::{AttrValue, log_stream_id};
+use ravel_types::{CommitToken, Signal, TenantId};
+use serde::Deserialize;
+
+/// Per-record attribute cap for the loader (ADR-0089 relaxation of the
+/// `ravel-otlp` 128-per-record network cap).
+///
+/// 1024, deliberately far above OTLP's 128: bulk import is an offline,
+/// operator-initiated action reading a file the operator already controls, a
+/// different threat model than a networked OTLP sender, so a wide structured
+/// export is admitted rather than rejected. This is a *per-record* axis and is
+/// intentionally unrelated to the RLOG object's 1000-distinct-`(name, type)`
+/// dynamic-column budget (`RlogConfig::max_dynamic_columns`): past that
+/// per-object budget, extra columns fold into the `attrs_raw` overflow column
+/// rather than being rejected, and the loader inherits that object-level
+/// behavior from the writer unchanged (it writes no overflow logic of its own).
+pub const LOADER_MAX_ATTRIBUTES_PER_RECORD: usize = 1024;
+
+/// Default rows per Strict write. Each write is one flush per involved shard,
+/// so this bounds the RLOG object size and the memory held while building a
+/// batch. Every successful write is fully durable before the next batch starts.
+pub const DEFAULT_BATCH_ROWS: usize = 10_000;
+
+/// Ack deadline for each Strict write. Generous: a bulk load values completing
+/// over racing a slow store.
+const WRITE_ACK_DEADLINE: Duration = Duration::from_secs(60);
+
+/// Source time unit for the mapped `ts` column, converted to nanoseconds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TsUnit {
+    Seconds,
+    Millis,
+    Micros,
+    Nanos,
+}
+
+impl TsUnit {
+    fn factor(self) -> i64 {
+        match self {
+            TsUnit::Seconds => 1_000_000_000,
+            TsUnit::Millis => 1_000_000,
+            TsUnit::Micros => 1_000,
+            TsUnit::Nanos => 1,
+        }
+    }
+}
+
+/// Declared type for a mapped attribute column, one of the scalar
+/// [`AttrValue`] kinds. (Lists and maps have no Parquet-column source and are
+/// not producible by this path.)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ColType {
+    Str,
+    I64,
+    F64,
+    Bool,
+    Bytes,
+}
+
+/// One mapped attribute: a source Parquet column, the record/resource key it
+/// becomes, and its declared type.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AttrMap {
+    /// The attribute key stored in the record (e.g. `service.name`).
+    pub key: String,
+    /// The source Parquet column name.
+    pub column: String,
+    /// Declared value type, used to build the typed [`AttrValue`].
+    #[serde(rename = "type")]
+    pub value_type: ColType,
+}
+
+/// The `--mapping` TOML: source Parquet columns to record fields.
+///
+/// ```toml
+/// ts_column = "timestamp"
+/// ts_unit   = "millis"        # seconds | millis | micros | nanos
+///
+/// body_column            = "message"   # optional
+/// severity_number_column = "sev_num"   # optional (integer column)
+/// severity_text_column   = "sev_text"  # optional (string column)
+/// trace_id_column        = "trace_id"  # optional (16-byte binary or 32-hex str)
+/// span_id_column         = "span_id"   # optional (8-byte binary or 16-hex str)
+///
+/// # Resource attributes: part of stream identity.
+/// [[resource_attribute]]
+/// key = "service.name"
+/// column = "svc"
+/// type = "str"
+///
+/// # Record attributes: typed values in `attrs`, NOT part of stream identity.
+/// [[attribute]]
+/// key = "http.status_code"
+/// column = "status"
+/// type = "i64"
+/// ```
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Mapping {
+    pub ts_column: String,
+    pub ts_unit: TsUnit,
+    #[serde(default)]
+    pub body_column: Option<String>,
+    #[serde(default)]
+    pub severity_number_column: Option<String>,
+    #[serde(default)]
+    pub severity_text_column: Option<String>,
+    #[serde(default)]
+    pub trace_id_column: Option<String>,
+    #[serde(default)]
+    pub span_id_column: Option<String>,
+    /// Columns that determine stream identity (ADR-0029): distinct from record
+    /// attributes.
+    #[serde(default, rename = "resource_attribute")]
+    pub resource_attributes: Vec<AttrMap>,
+    /// Columns that become typed values in the record's `attrs`; never part of
+    /// stream identity.
+    #[serde(default, rename = "attribute")]
+    pub attributes: Vec<AttrMap>,
+}
+
+/// Parse a `--mapping` TOML document.
+pub fn parse_mapping(text: &str) -> Result<Mapping, LoadError> {
+    toml::from_str(text).map_err(|e| LoadError::Setup(format!("invalid --mapping TOML: {e}")))
+}
+
+/// Printed to stderr before a load runs: the per-tenant `AdmissionController`
+/// (active-stream cap, stream-creation rate, byte rate) lives in the server's
+/// HTTP layer and is bypassed by construction on this path (ADR-0089).
+pub const ADMISSION_BYPASS_WARNING: &str = "warning: bulk load writes directly to the log ingest router. The per-tenant \
+     AdmissionController (active-stream cap, stream-creation rate, byte rate) that guards the \
+     HTTP ingest path is NOT applied to loaded data. There is no resumability or deduplication: \
+     re-running after a failure re-ingests the whole file from the start. Retention is measured \
+     from load time, not from the records' event times.";
+
+/// CLI entry point for `ravel-cli load --parquet`: read the mapping and Parquet
+/// file paths, run the load, and print a summary on success or the error plus
+/// the already-durable commit tokens on failure.
+///
+/// Returns `Err` (nonzero exit) for any failure. On a flush failure or a
+/// rejected row, the durable commit tokens are printed rather than swallowed
+/// (ADR-0089): a failure mid-file is a genuine partial load.
+pub async fn run(
+    store: Arc<dyn ObjectStoreBackend>,
+    parquet_path: &Path,
+    tenant: &str,
+    mapping_path: &Path,
+    shards: u32,
+    now_ns: i64,
+) -> anyhow::Result<()> {
+    eprintln!("{ADMISSION_BYPASS_WARNING}");
+
+    let mapping_text = std::fs::read_to_string(mapping_path)
+        .map_err(|e| anyhow::anyhow!("failed to read --mapping {}: {e}", mapping_path.display()))?;
+    let mapping = parse_mapping(&mapping_text)?;
+
+    match load(
+        store,
+        parquet_path,
+        tenant,
+        &mapping,
+        shards,
+        DEFAULT_BATCH_ROWS,
+        now_ns,
+        Arc::new(SystemClock),
+    )
+    .await
+    {
+        Ok(report) => {
+            print_summary(&report);
+            Ok(())
+        }
+        Err(err) => {
+            let durable = err.durable_tokens();
+            print_durable_tokens(durable);
+            Err(anyhow::Error::new(err))
+        }
+    }
+}
+
+/// Print the completion summary (ADR-0089 deliverable 6) to stdout.
+fn print_summary(report: &LoadReport) {
+    let secs = report.elapsed.as_secs_f64();
+    let rows_per_sec = if secs > 0.0 {
+        report.rows_processed as f64 / secs
+    } else {
+        report.rows_processed as f64
+    };
+    println!("bulk load complete");
+    println!("  rows processed   : {}", report.rows_processed);
+    println!("  rows/sec         : {rows_per_sec:.0}");
+    println!("  objects written  : {}", report.objects_written());
+    println!("  elapsed          : {secs:.3}s");
+}
+
+/// Print the commit tokens durable before a failure, one per line, so an
+/// operator can see exactly what landed (ADR-0089 deliverable 7).
+fn print_durable_tokens(tokens: &[CommitToken]) {
+    if tokens.is_empty() {
+        println!("no commit tokens were durable before the failure (nothing landed)");
+        return;
+    }
+    println!(
+        "{} commit token(s)/segment(s) were durable before the failure (a partial load; \
+         re-running re-ingests the whole file, there is no dedup):",
+        tokens.len()
+    );
+    for token in tokens {
+        println!("  {}", token.encode());
+    }
+}
+
+/// Result of a successful (or partially-durable) load, for the summary output.
+#[derive(Debug, Clone, Default)]
+pub struct LoadReport {
+    pub rows_processed: u64,
+    /// One token per shard flushed, across every batch. Its length is the
+    /// number of objects/segments written.
+    pub tokens: Vec<CommitToken>,
+    pub elapsed: Duration,
+}
+
+impl LoadReport {
+    pub fn objects_written(&self) -> usize {
+        self.tokens.len()
+    }
+}
+
+/// A load failure. Every variant that can occur after some data is already
+/// durable carries the durable commit tokens, so the caller reports the
+/// genuine partial load rather than swallowing it into a generic error
+/// (ADR-0089: a failed flush is a partial load, not a rollback).
+#[derive(Debug, thiserror::Error)]
+pub enum LoadError {
+    /// Setup failed before any record was written (mapping, provisioning, file
+    /// open, Parquet schema, missing column). Nothing is durable.
+    #[error("{0}")]
+    Setup(String),
+    /// A row failed a kept admission check (future skew, length cap, or the
+    /// loader per-record attribute cap). Fail-fast: the run stops at the first
+    /// bad row. Any tokens listed are batches durable before this row.
+    #[error("row {row}: {reason}")]
+    RowRejected {
+        row: u64,
+        reason: String,
+        durable: Vec<CommitToken>,
+    },
+    /// A flush (object-store PUT) failed. The tokens are what was durable
+    /// before the failure; the failed batch and everything after it are not.
+    #[error("flush failed: {cause}")]
+    Flush {
+        durable: Vec<CommitToken>,
+        cause: String,
+    },
+}
+
+impl LoadError {
+    /// The commit tokens already durable when this error occurred (empty for a
+    /// setup error).
+    pub fn durable_tokens(&self) -> &[CommitToken] {
+        match self {
+            LoadError::Setup(_) => &[],
+            LoadError::RowRejected { durable, .. } | LoadError::Flush { durable, .. } => durable,
+        }
+    }
+}
+
+/// Bulk-import `parquet_path` into `tenant`'s logs signal.
+///
+/// - `shards` is the configured shard count. It is validated against (or, for a
+///   fresh signal, written to) the durable provisioning record via
+///   [`validate_or_adopt`] with [`AbsentPolicy::CreateFromConfig`], the same
+///   first-touch path `services/ravel-server` runs; the router then resolves
+///   the active generation from that record itself.
+/// - `batch_rows` rows are written per Strict flush.
+/// - `now_ns` is the ingest-time anchor for the future-skew check (the past-lag
+///   check is deliberately omitted per ADR-0089). Bucketing is by the router's
+///   own clock (load-time wall clock), independent of the records' event times.
+///
+/// Fail-fast on the first row that fails a kept admission check. A run that
+/// returns `Ok` has every row durable; a run that returns `Err` reports the
+/// tokens already durable (a partial load — re-running re-ingests the whole
+/// file, there is no resumability or dedup in this version).
+#[allow(clippy::too_many_arguments)]
+pub async fn load(
+    store: Arc<dyn ObjectStoreBackend>,
+    parquet_path: &Path,
+    tenant: &str,
+    mapping: &Mapping,
+    shards: u32,
+    batch_rows: usize,
+    now_ns: i64,
+    clock: Arc<dyn Clock>,
+) -> Result<LoadReport, LoadError> {
+    let limits = LogIngestLimits::default();
+    let tenant_id = TenantId::new(tenant);
+
+    // Reuse the server's provisioning validation/adoption. Fresh signal: pins
+    // the record at `shards`. Existing record: a differing count is refused
+    // here, before any write, exactly as the server refuses it at first touch.
+    validate_or_adopt(
+        store.as_ref(),
+        &tenant_id.hash(),
+        Signal::Logs,
+        shards,
+        now_ns,
+        AbsentPolicy::CreateFromConfig,
+    )
+    .await
+    .map_err(|e| {
+        LoadError::Setup(format!(
+            "shard-count provisioning check failed for tenant {tenant:?} \
+             (configured --shards {shards}): {e}"
+        ))
+    })?;
+
+    // `target_bytes: 1` makes each Strict batch flush immediately as one RLOG
+    // object, inside `handle_write`'s size trigger, rather than waiting on the
+    // age trigger's `max_flush_delay` clock. That is what a bulk loader wants:
+    // one object per batch, `batch_rows` controls its size, and every write's
+    // ack is durable with no lingering buffer. It also keeps flush timing off
+    // the wall clock, so the object buckets by the flush-open reading directly.
+    let router = LogIngestRouter::new(
+        IngestConfig {
+            shard_count: shards,
+            target_bytes: 1,
+            ..IngestConfig::default()
+        },
+        Arc::clone(&store),
+        clock,
+    );
+
+    let file = std::fs::File::open(parquet_path)
+        .map_err(|e| LoadError::Setup(format!("failed to open {}: {e}", parquet_path.display())))?;
+    let builder = ParquetRecordBatchReaderBuilder::try_new(file)
+        .map_err(|e| LoadError::Setup(format!("failed to open Parquet reader: {e}")))?;
+    let reader = builder
+        .with_batch_size(batch_rows.max(1))
+        .build()
+        .map_err(|e| LoadError::Setup(format!("failed to build Parquet reader: {e}")))?;
+
+    let started = Instant::now();
+    let mut report = LoadReport::default();
+    let mut row_base: u64 = 0;
+
+    for batch in reader {
+        let batch =
+            batch.map_err(|e| LoadError::Setup(format!("failed to read Parquet batch: {e}")))?;
+        // Resolve column indices once per batch (schema is stable across
+        // batches, but re-resolving keeps this self-contained and cheap).
+        let cols = ColumnIndex::resolve(&batch, mapping).map_err(LoadError::Setup)?;
+
+        let mut records = Vec::with_capacity(batch.num_rows());
+        for row in 0..batch.num_rows() {
+            let record =
+                build_record(&batch, &cols, mapping, &limits, now_ns, row).map_err(|reason| {
+                    LoadError::RowRejected {
+                        row: row_base + row as u64,
+                        reason,
+                        durable: report.tokens.clone(),
+                    }
+                })?;
+            records.push(record);
+        }
+        row_base += batch.num_rows() as u64;
+
+        if records.is_empty() {
+            continue;
+        }
+        let n = records.len() as u64;
+        let receipt = router
+            .write(
+                tenant_id.clone(),
+                records,
+                WriteMode::Strict,
+                WRITE_ACK_DEADLINE,
+            )
+            .await
+            .map_err(|e| LoadError::Flush {
+                durable: report.tokens.clone(),
+                cause: e.to_string(),
+            })?;
+        report.rows_processed += n;
+        report.tokens.extend(receipt.tokens);
+    }
+
+    // Strict acks already guarantee durability; flush_all is a defensive
+    // no-op here (nothing is buffered after a Strict write returns).
+    router.flush_all().await;
+
+    report.elapsed = started.elapsed();
+    Ok(report)
+}
+
+/// Resolved column indices for the mapped fields of one batch.
+struct ColumnIndex {
+    ts: usize,
+    body: Option<usize>,
+    severity_number: Option<usize>,
+    severity_text: Option<usize>,
+    trace_id: Option<usize>,
+    span_id: Option<usize>,
+    /// `(index, &AttrMap)` for each resource attribute column.
+    resource: Vec<(usize, usize)>,
+    /// `(index, &AttrMap)` for each record attribute column.
+    record: Vec<(usize, usize)>,
+}
+
+impl ColumnIndex {
+    fn resolve(batch: &RecordBatch, mapping: &Mapping) -> Result<ColumnIndex, String> {
+        let schema = batch.schema();
+        let idx = |name: &str| -> Result<usize, String> {
+            schema
+                .index_of(name)
+                .map_err(|_| format!("mapped column {name:?} is not present in the Parquet file"))
+        };
+        let opt = |name: &Option<String>| -> Result<Option<usize>, String> {
+            match name {
+                Some(n) => Ok(Some(idx(n)?)),
+                None => Ok(None),
+            }
+        };
+        let resource = mapping
+            .resource_attributes
+            .iter()
+            .enumerate()
+            .map(|(i, a)| Ok((idx(&a.column)?, i)))
+            .collect::<Result<Vec<_>, String>>()?;
+        let record = mapping
+            .attributes
+            .iter()
+            .enumerate()
+            .map(|(i, a)| Ok((idx(&a.column)?, i)))
+            .collect::<Result<Vec<_>, String>>()?;
+        Ok(ColumnIndex {
+            ts: idx(&mapping.ts_column)?,
+            body: opt(&mapping.body_column)?,
+            severity_number: opt(&mapping.severity_number_column)?,
+            severity_text: opt(&mapping.severity_text_column)?,
+            trace_id: opt(&mapping.trace_id_column)?,
+            span_id: opt(&mapping.span_id_column)?,
+            resource,
+            record,
+        })
+    }
+}
+
+/// Build one [`NormalizedLogRecord`] from row `row` of `batch`, applying the
+/// kept ADR-0089 admission checks. `Err` carries a per-row rejection reason.
+fn build_record(
+    batch: &RecordBatch,
+    cols: &ColumnIndex,
+    mapping: &Mapping,
+    limits: &LogIngestLimits,
+    now_ns: i64,
+    row: usize,
+) -> Result<NormalizedLogRecord, String> {
+    // Timestamp is required; a null or unreadable ts is a row rejection.
+    let ts_col = batch.column(cols.ts);
+    let raw_ts = read_ts(ts_col, row, mapping.ts_unit)?
+        .ok_or_else(|| format!("ts column {:?} is null", mapping.ts_column))?;
+
+    // Kept: future-skew bound, same `max_future_skew_ns` as ravel-otlp. The
+    // past-event-time lag check is deliberately omitted (ADR-0089 relaxation).
+    let skew_ns = raw_ts.saturating_sub(now_ns);
+    if skew_ns > limits.max_future_skew_ns {
+        return Err(format!(
+            "timestamp is {skew_ns} ns ahead of load time, more than the max future skew of {} ns",
+            limits.max_future_skew_ns
+        ));
+    }
+
+    // Body (optional). Kept: max_body_len.
+    let body = match cols.body {
+        Some(i) => read_string(batch.column(i), row)?.unwrap_or_default(),
+        None => String::new(),
+    };
+    if body.len() > limits.max_body_len {
+        return Err(format!(
+            "body is {} bytes, more than the limit of {}",
+            body.len(),
+            limits.max_body_len
+        ));
+    }
+
+    let severity_num = match cols.severity_number {
+        // OTLP severity_number is 0..=24; an out-of-u8 value normalizes to 0
+        // (UNSPECIFIED), matching ravel-otlp rather than truncating.
+        Some(i) => read_i64(batch.column(i), row)?
+            .and_then(|v| u8::try_from(v).ok())
+            .unwrap_or(0),
+        None => 0,
+    };
+    let severity_text = match cols.severity_text {
+        Some(i) => read_string(batch.column(i), row)?.unwrap_or_default(),
+        None => String::new(),
+    };
+
+    // Trace/span ids: exact byte length or absent (never padded or truncated),
+    // matching ravel-otlp.
+    let trace_id = match cols.trace_id {
+        Some(i) => read_id::<16>(batch.column(i), row)?,
+        None => None,
+    };
+    let span_id = match cols.span_id {
+        Some(i) => read_id::<8>(batch.column(i), row)?,
+        None => None,
+    };
+
+    // Resource attributes: part of stream identity. A null column is omitted.
+    let mut resource_attrs: Vec<(String, AttrValue)> = Vec::with_capacity(cols.resource.len());
+    for (col_idx, map_idx) in &cols.resource {
+        let spec = &mapping.resource_attributes[*map_idx];
+        if let Some(value) = read_attr(batch.column(*col_idx), row, spec.value_type)? {
+            check_attr(&spec.key, &value, limits)?;
+            resource_attrs.push((spec.key.clone(), value));
+        }
+    }
+
+    // Record attributes: typed values in `attrs`, never part of identity.
+    let mut attrs: Vec<(String, AttrValue)> = Vec::with_capacity(cols.record.len());
+    for (col_idx, map_idx) in &cols.record {
+        let spec = &mapping.attributes[*map_idx];
+        if let Some(value) = read_attr(batch.column(*col_idx), row, spec.value_type)? {
+            check_attr(&spec.key, &value, limits)?;
+            attrs.push((spec.key.clone(), value));
+        }
+    }
+
+    // Loader per-record attribute cap (ADR-0089 relaxation): rejected, not
+    // silently truncated. Counts record attributes only, matching OTLP's
+    // `max_attributes_per_record` axis.
+    if attrs.len() > LOADER_MAX_ATTRIBUTES_PER_RECORD {
+        return Err(format!(
+            "record has {} attributes, more than the loader per-record cap of {}",
+            attrs.len(),
+            LOADER_MAX_ATTRIBUTES_PER_RECORD
+        ));
+    }
+
+    // Stream identity: resource attributes plus an empty scope (a Parquet file
+    // carries no OTLP instrumentation scope). Computed the same way ravel-otlp
+    // computes it, so the shard buffer and RLOG writer verify it identically.
+    let stream_id = log_stream_id(&resource_attrs, "", "", &[]);
+    let stream_attrs = ravel_logseg::stream_attrs_bytes(&resource_attrs, "", "", &[]);
+
+    Ok(NormalizedLogRecord {
+        stream_id,
+        stream_attrs,
+        ts_ns: raw_ts,
+        observed_ts_ns: raw_ts,
+        severity_num,
+        severity_text,
+        body,
+        trace_id,
+        span_id,
+        flags: 0,
+        attrs,
+    })
+}
+
+/// Kept length caps for one attribute, re-implemented identically to
+/// `ravel-otlp` (attribute key length and value payload length).
+fn check_attr(key: &str, value: &AttrValue, limits: &LogIngestLimits) -> Result<(), String> {
+    if key.len() > limits.max_attribute_key_len {
+        return Err(format!(
+            "attribute key {key:?} is {} bytes, more than the limit of {}",
+            key.len(),
+            limits.max_attribute_key_len
+        ));
+    }
+    let len = attr_value_len(value);
+    if len > limits.max_attribute_value_len {
+        return Err(format!(
+            "attribute {key:?} value is {len} bytes, more than the limit of {}",
+            limits.max_attribute_value_len
+        ));
+    }
+    Ok(())
+}
+
+/// Payload bytes in a scalar attribute value, matching `ravel-otlp`'s
+/// `attr_value_len` for the scalar kinds this path can produce.
+fn attr_value_len(value: &AttrValue) -> usize {
+    match value {
+        AttrValue::Str(s) => s.len(),
+        AttrValue::Bytes(b) => b.len(),
+        AttrValue::I64(_) | AttrValue::F64(_) => 8,
+        AttrValue::Bool(_) => 1,
+        // Unreachable from a Parquet scalar column, but sized consistently.
+        AttrValue::List(items) => items.iter().map(attr_value_len).sum(),
+        AttrValue::Map(entries) => entries
+            .iter()
+            .map(|(k, v)| k.len() + attr_value_len(v))
+            .sum(),
+    }
+}
+
+/// Read one cell as the declared [`ColType`], returning `None` for a null cell
+/// and `Err` for a type the column cannot supply.
+fn read_attr(arr: &ArrayRef, row: usize, ty: ColType) -> Result<Option<AttrValue>, String> {
+    if arr.is_null(row) {
+        return Ok(None);
+    }
+    let value = match ty {
+        ColType::Str => AttrValue::Str(
+            read_string(arr, row)?.ok_or_else(|| "unexpected null reading str".to_string())?,
+        ),
+        ColType::I64 => AttrValue::I64(
+            read_i64(arr, row)?.ok_or_else(|| "unexpected null reading i64".to_string())?,
+        ),
+        ColType::F64 => AttrValue::F64(
+            read_f64(arr, row)?.ok_or_else(|| "unexpected null reading f64".to_string())?,
+        ),
+        ColType::Bool => AttrValue::Bool(
+            read_bool(arr, row)?.ok_or_else(|| "unexpected null reading bool".to_string())?,
+        ),
+        ColType::Bytes => AttrValue::Bytes(
+            read_bytes(arr, row)?.ok_or_else(|| "unexpected null reading bytes".to_string())?,
+        ),
+    };
+    Ok(Some(value))
+}
+
+/// Read an integer cell as `i64`, accepting any Arrow integer width.
+fn read_i64(arr: &ArrayRef, row: usize) -> Result<Option<i64>, String> {
+    if arr.is_null(row) {
+        return Ok(None);
+    }
+    let v = match arr.data_type() {
+        DataType::Int8 => downcast::<Int8Array>(arr)?.value(row) as i64,
+        DataType::Int16 => downcast::<Int16Array>(arr)?.value(row) as i64,
+        DataType::Int32 => downcast::<Int32Array>(arr)?.value(row) as i64,
+        DataType::Int64 => downcast::<Int64Array>(arr)?.value(row),
+        DataType::UInt8 => downcast::<UInt8Array>(arr)?.value(row) as i64,
+        DataType::UInt16 => downcast::<UInt16Array>(arr)?.value(row) as i64,
+        DataType::UInt32 => downcast::<UInt32Array>(arr)?.value(row) as i64,
+        DataType::UInt64 => i64::try_from(downcast::<UInt64Array>(arr)?.value(row))
+            .map_err(|_| "u64 value does not fit in i64".to_string())?,
+        other => return Err(format!("expected an integer column, found {other:?}")),
+    };
+    Ok(Some(v))
+}
+
+/// Read a floating cell as `f64`, accepting f32 or f64.
+fn read_f64(arr: &ArrayRef, row: usize) -> Result<Option<f64>, String> {
+    if arr.is_null(row) {
+        return Ok(None);
+    }
+    let v = match arr.data_type() {
+        DataType::Float32 => downcast::<Float32Array>(arr)?.value(row) as f64,
+        DataType::Float64 => downcast::<Float64Array>(arr)?.value(row),
+        other => return Err(format!("expected a float column, found {other:?}")),
+    };
+    Ok(Some(v))
+}
+
+fn read_bool(arr: &ArrayRef, row: usize) -> Result<Option<bool>, String> {
+    if arr.is_null(row) {
+        return Ok(None);
+    }
+    match arr.data_type() {
+        DataType::Boolean => Ok(Some(downcast::<BooleanArray>(arr)?.value(row))),
+        other => Err(format!("expected a boolean column, found {other:?}")),
+    }
+}
+
+/// Read a UTF-8 string cell, accepting `Utf8` and `LargeUtf8`.
+fn read_string(arr: &ArrayRef, row: usize) -> Result<Option<String>, String> {
+    if arr.is_null(row) {
+        return Ok(None);
+    }
+    match arr.data_type() {
+        DataType::Utf8 => Ok(Some(downcast::<StringArray>(arr)?.value(row).to_string())),
+        DataType::LargeUtf8 => Ok(Some(
+            downcast::<LargeStringArray>(arr)?.value(row).to_string(),
+        )),
+        other => Err(format!("expected a string column, found {other:?}")),
+    }
+}
+
+/// Read a binary cell, accepting `Binary`, `LargeBinary`, and `FixedSizeBinary`.
+fn read_bytes(arr: &ArrayRef, row: usize) -> Result<Option<Vec<u8>>, String> {
+    if arr.is_null(row) {
+        return Ok(None);
+    }
+    match arr.data_type() {
+        DataType::Binary => Ok(Some(downcast::<BinaryArray>(arr)?.value(row).to_vec())),
+        DataType::LargeBinary => Ok(Some(downcast::<LargeBinaryArray>(arr)?.value(row).to_vec())),
+        DataType::FixedSizeBinary(_) => Ok(Some(
+            downcast::<FixedSizeBinaryArray>(arr)?.value(row).to_vec(),
+        )),
+        other => Err(format!("expected a binary column, found {other:?}")),
+    }
+}
+
+/// Read the `ts` column to nanoseconds. An integer column uses the mapping's
+/// declared unit; a native Arrow `Timestamp` column uses its own unit (its
+/// values are already scaled), and the declared unit is not applied again.
+fn read_ts(arr: &ArrayRef, row: usize, declared: TsUnit) -> Result<Option<i64>, String> {
+    if arr.is_null(row) {
+        return Ok(None);
+    }
+    let ns = match arr.data_type() {
+        DataType::Timestamp(unit, _) => {
+            let raw = match unit {
+                TimeUnit::Second => downcast::<TimestampSecondArray>(arr)?.value(row),
+                TimeUnit::Millisecond => downcast::<TimestampMillisecondArray>(arr)?.value(row),
+                TimeUnit::Microsecond => downcast::<TimestampMicrosecondArray>(arr)?.value(row),
+                TimeUnit::Nanosecond => downcast::<TimestampNanosecondArray>(arr)?.value(row),
+            };
+            let factor = match unit {
+                TimeUnit::Second => 1_000_000_000,
+                TimeUnit::Millisecond => 1_000_000,
+                TimeUnit::Microsecond => 1_000,
+                TimeUnit::Nanosecond => 1,
+            };
+            raw.checked_mul(factor)
+                .ok_or_else(|| "timestamp overflows i64 nanoseconds".to_string())?
+        }
+        _ => {
+            let raw =
+                read_i64(arr, row)?.ok_or_else(|| "unexpected null reading ts".to_string())?;
+            raw.checked_mul(declared.factor())
+                .ok_or_else(|| "timestamp overflows i64 nanoseconds".to_string())?
+        }
+    };
+    Ok(Some(ns))
+}
+
+/// Read an id column as an exact-length byte array, accepting either a binary
+/// column of exactly `N` bytes or a hex string of exactly `2*N` characters. A
+/// wrong length yields `None` (dropped, never padded or truncated), matching
+/// ravel-otlp.
+fn read_id<const N: usize>(arr: &ArrayRef, row: usize) -> Result<Option<[u8; N]>, String> {
+    if arr.is_null(row) {
+        return Ok(None);
+    }
+    let bytes = match arr.data_type() {
+        DataType::Utf8 | DataType::LargeUtf8 => match read_string(arr, row)? {
+            Some(s) => match hex::decode(s) {
+                Ok(b) => b,
+                Err(_) => return Ok(None),
+            },
+            None => return Ok(None),
+        },
+        DataType::Binary | DataType::LargeBinary | DataType::FixedSizeBinary(_) => {
+            read_bytes(arr, row)?.unwrap_or_default()
+        }
+        other => {
+            return Err(format!(
+                "expected a binary or string id column, found {other:?}"
+            ));
+        }
+    };
+    Ok(<[u8; N]>::try_from(bytes.as_slice()).ok())
+}
+
+/// Downcast an [`ArrayRef`] to a concrete Arrow array type, mapping a failure
+/// to a readable error rather than panicking.
+fn downcast<A: 'static>(arr: &ArrayRef) -> Result<&A, String> {
+    arr.as_any()
+        .downcast_ref::<A>()
+        .ok_or_else(|| "internal error: Arrow array downcast failed".to_string())
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    /// A fixed, plausible (post-2020) load-time anchor for the admission
+    /// checks; the exact value only matters relative to the event timestamps.
+    const NOW_NS: i64 = 1_700_000_000_000_000_000; // 2023-11-14
+
+    fn batch(cols: Vec<(&str, ArrayRef)>) -> RecordBatch {
+        RecordBatch::try_from_iter(cols.into_iter().map(|(n, a)| (n.to_string(), a)))
+            .expect("record batch")
+    }
+
+    fn i64_col(vals: Vec<i64>) -> ArrayRef {
+        Arc::new(Int64Array::from(vals))
+    }
+
+    fn str_col(vals: Vec<&str>) -> ArrayRef {
+        Arc::new(StringArray::from(vals))
+    }
+
+    /// A minimal mapping over a single `ts` column (nanoseconds).
+    fn base_mapping() -> Mapping {
+        Mapping {
+            ts_column: "ts".to_string(),
+            ts_unit: TsUnit::Nanos,
+            body_column: None,
+            severity_number_column: None,
+            severity_text_column: None,
+            trace_id_column: None,
+            span_id_column: None,
+            resource_attributes: Vec::new(),
+            attributes: Vec::new(),
+        }
+    }
+
+    fn attr(key: &str, column: &str, ty: ColType) -> AttrMap {
+        AttrMap {
+            key: key.to_string(),
+            column: column.to_string(),
+            value_type: ty,
+        }
+    }
+
+    fn build_row(
+        batch: &RecordBatch,
+        mapping: &Mapping,
+        row: usize,
+    ) -> Result<NormalizedLogRecord, String> {
+        let cols = ColumnIndex::resolve(batch, mapping).expect("resolve columns");
+        build_record(
+            batch,
+            &cols,
+            mapping,
+            &LogIngestLimits::default(),
+            NOW_NS,
+            row,
+        )
+    }
+
+    #[test]
+    fn future_skew_beyond_the_bound_is_rejected() {
+        let limits = LogIngestLimits::default();
+        let m = base_mapping();
+        let b = batch(vec![(
+            "ts",
+            i64_col(vec![NOW_NS + limits.max_future_skew_ns + 1]),
+        )]);
+        let err = build_row(&b, &m, 0).expect_err("a far-future row must be rejected");
+        assert!(err.contains("future skew"), "{err}");
+    }
+
+    #[test]
+    fn event_exactly_at_the_future_skew_bound_is_accepted() {
+        let limits = LogIngestLimits::default();
+        let m = base_mapping();
+        let b = batch(vec![(
+            "ts",
+            i64_col(vec![NOW_NS + limits.max_future_skew_ns]),
+        )]);
+        let rec = build_row(&b, &m, 0).expect("the bound itself passes");
+        assert_eq!(rec.ts_ns, NOW_NS + limits.max_future_skew_ns);
+    }
+
+    /// The deliberate ADR-0089 relaxation: a 2013-era timestamp lagging load
+    /// time by a decade is accepted, where OTLP would reject it as `TooOld`.
+    #[test]
+    fn past_event_time_lag_is_not_rejected() {
+        let m = base_mapping();
+        let ts_2013 = 1_356_998_400_000_000_000; // 2013-01-01
+        let b = batch(vec![("ts", i64_col(vec![ts_2013]))]);
+        let rec = build_row(&b, &m, 0).expect("a decade-old event is admitted, not rejected");
+        assert_eq!(rec.ts_ns, ts_2013);
+    }
+
+    #[test]
+    fn oversized_body_is_rejected_at_the_otlp_bound() {
+        let limits = LogIngestLimits::default();
+        let mut m = base_mapping();
+        m.body_column = Some("body".to_string());
+        let big = "x".repeat(limits.max_body_len + 1);
+        let b = batch(vec![
+            ("ts", i64_col(vec![NOW_NS])),
+            ("body", str_col(vec![big.as_str()])),
+        ]);
+        let err = build_row(&b, &m, 0).expect_err("an oversized body is rejected");
+        assert!(err.contains("body is"), "{err}");
+    }
+
+    #[test]
+    fn oversized_attribute_key_is_rejected_at_the_otlp_bound() {
+        let limits = LogIngestLimits::default();
+        let mut m = base_mapping();
+        let long_key = "k".repeat(limits.max_attribute_key_len + 1);
+        m.attributes = vec![attr(&long_key, "v", ColType::Str)];
+        let b = batch(vec![
+            ("ts", i64_col(vec![NOW_NS])),
+            ("v", str_col(vec!["value"])),
+        ]);
+        let err = build_row(&b, &m, 0).expect_err("an oversized attribute key is rejected");
+        assert!(err.contains("attribute key"), "{err}");
+    }
+
+    #[test]
+    fn oversized_attribute_value_is_rejected_at_the_otlp_bound() {
+        let limits = LogIngestLimits::default();
+        let mut m = base_mapping();
+        m.attributes = vec![attr("k", "v", ColType::Str)];
+        let big = "x".repeat(limits.max_attribute_value_len + 1);
+        let b = batch(vec![
+            ("ts", i64_col(vec![NOW_NS])),
+            ("v", str_col(vec![big.as_str()])),
+        ]);
+        let err = build_row(&b, &m, 0).expect_err("an oversized attribute value is rejected");
+        assert!(err.contains("value is"), "{err}");
+    }
+
+    #[test]
+    fn record_attributes_at_the_loader_cap_pass_and_over_it_are_rejected() {
+        // Build `cap + 1` record-attribute columns; one row over the cap is
+        // rejected (not silently truncated), and exactly-at-cap passes.
+        let cap = LOADER_MAX_ATTRIBUTES_PER_RECORD;
+        let over = cap + 1;
+        let mut cols: Vec<(String, ArrayRef)> = vec![("ts".to_string(), i64_col(vec![NOW_NS]))];
+        let mut attrs = Vec::new();
+        for i in 0..over {
+            let name = format!("a{i}");
+            cols.push((name.clone(), i64_col(vec![i as i64])));
+            attrs.push(attr(&name, &name, ColType::I64));
+        }
+        let b = RecordBatch::try_from_iter(cols).expect("wide batch");
+
+        let mut m_over = base_mapping();
+        m_over.attributes = attrs.clone();
+        let err = build_row(&b, &m_over, 0).expect_err("over the loader cap must be rejected");
+        assert!(err.contains("loader per-record cap"), "{err}");
+
+        let mut m_at = base_mapping();
+        m_at.attributes = attrs[..cap].to_vec();
+        let rec = build_row(&b, &m_at, 0).expect("exactly at the cap passes");
+        assert_eq!(rec.attrs.len(), cap);
+    }
+
+    /// Resource-attribute columns determine stream identity; record-attribute
+    /// columns never do.
+    #[test]
+    fn stream_identity_follows_resource_attributes_not_record_attributes() {
+        let mut m = base_mapping();
+        m.resource_attributes = vec![attr("service.name", "svc", ColType::Str)];
+        m.attributes = vec![attr("http.status_code", "status", ColType::I64)];
+        // Row 0: svc=api status=1; Row 1: svc=web status=1; Row 2: svc=api status=2.
+        let b = batch(vec![
+            ("ts", i64_col(vec![NOW_NS, NOW_NS, NOW_NS])),
+            ("svc", str_col(vec!["api", "web", "api"])),
+            ("status", i64_col(vec![1, 1, 2])),
+        ]);
+        let r0 = build_row(&b, &m, 0).expect("row 0");
+        let r1 = build_row(&b, &m, 1).expect("row 1");
+        let r2 = build_row(&b, &m, 2).expect("row 2");
+
+        assert_ne!(
+            r0.stream_id, r1.stream_id,
+            "different resource attribute values must produce different streams"
+        );
+        assert_eq!(
+            r0.stream_id, r2.stream_id,
+            "a differing record attribute must not change stream identity"
+        );
+        // The record attribute is carried, typed, in attrs.
+        assert_eq!(
+            r0.attrs,
+            vec![("http.status_code".to_string(), AttrValue::I64(1))]
+        );
+    }
+
+    #[test]
+    fn typed_columns_become_typed_attr_values() {
+        let mut m = base_mapping();
+        m.attributes = vec![
+            attr("s", "s", ColType::Str),
+            attr("i", "i", ColType::I64),
+            attr("f", "f", ColType::F64),
+            attr("b", "b", ColType::Bool),
+        ];
+        let b = batch(vec![
+            ("ts", i64_col(vec![NOW_NS])),
+            ("s", str_col(vec!["hi"])),
+            ("i", i64_col(vec![7])),
+            ("f", Arc::new(Float64Array::from(vec![1.5f64])) as ArrayRef),
+            ("b", Arc::new(BooleanArray::from(vec![true])) as ArrayRef),
+        ]);
+        let rec = build_row(&b, &m, 0).expect("typed row");
+        assert_eq!(
+            rec.attrs,
+            vec![
+                ("s".to_string(), AttrValue::Str("hi".to_string())),
+                ("i".to_string(), AttrValue::I64(7)),
+                ("f".to_string(), AttrValue::F64(1.5)),
+                ("b".to_string(), AttrValue::Bool(true)),
+            ]
+        );
+    }
+
+    #[test]
+    fn ts_unit_scales_to_nanoseconds() {
+        let mut m = base_mapping();
+        m.ts_unit = TsUnit::Millis;
+        let b = batch(vec![("ts", i64_col(vec![1_700_000_000_000]))]);
+        let rec = build_row(&b, &m, 0).expect("millis ts");
+        assert_eq!(rec.ts_ns, 1_700_000_000_000 * 1_000_000);
+    }
+
+    #[test]
+    fn mapping_round_trips_through_toml() {
+        let m = parse_mapping(
+            r#"
+ts_column = "timestamp"
+ts_unit = "micros"
+body_column = "msg"
+
+[[resource_attribute]]
+key = "service.name"
+column = "svc"
+type = "str"
+
+[[attribute]]
+key = "code"
+column = "status"
+type = "i64"
+"#,
+        )
+        .expect("valid mapping");
+        assert_eq!(m.ts_column, "timestamp");
+        assert_eq!(m.ts_unit, TsUnit::Micros);
+        assert_eq!(m.body_column.as_deref(), Some("msg"));
+        assert_eq!(m.resource_attributes.len(), 1);
+        assert_eq!(m.resource_attributes[0].value_type, ColType::Str);
+        assert_eq!(m.attributes.len(), 1);
+        assert_eq!(m.attributes[0].value_type, ColType::I64);
+    }
+
+    #[test]
+    fn unknown_mapping_field_is_rejected() {
+        let err = parse_mapping("ts_column = \"t\"\nts_unit = \"nanos\"\nbogus = 1\n")
+            .expect_err("deny_unknown_fields rejects a typo");
+        assert!(matches!(err, LoadError::Setup(_)));
+    }
+}

--- a/services/ravel-cli/src/load.rs
+++ b/services/ravel-cli/src/load.rs
@@ -172,11 +172,13 @@ pub const ADMISSION_BYPASS_WARNING: &str = "warning: bulk load writes directly t
 
 /// CLI entry point for `ravel-cli load --parquet`: read the mapping and Parquet
 /// file paths, run the load, and print a summary on success or the error plus
-/// the already-durable commit tokens on failure.
+/// the known-durable commit tokens on failure.
 ///
 /// Returns `Err` (nonzero exit) for any failure. On a flush failure or a
 /// rejected row, the durable commit tokens are printed rather than swallowed
-/// (ADR-0089): a failure mid-file is a genuine partial load.
+/// (ADR-0089): a failure mid-file is a genuine partial load. See
+/// [`print_durable_tokens`] for the one case (a flush failure) where the
+/// printed list is a lower bound rather than exact.
 pub async fn run(
     store: Arc<dyn ObjectStoreBackend>,
     parquet_path: &Path,
@@ -208,8 +210,7 @@ pub async fn run(
             Ok(())
         }
         Err(err) => {
-            let durable = err.durable_tokens();
-            print_durable_tokens(durable);
+            print_durable_tokens(&err);
             Err(anyhow::Error::new(err))
         }
     }
@@ -230,16 +231,38 @@ fn print_summary(report: &LoadReport) {
     println!("  elapsed          : {secs:.3}s");
 }
 
-/// Print the commit tokens durable before a failure, one per line, so an
-/// operator can see exactly what landed (ADR-0089 deliverable 7).
-fn print_durable_tokens(tokens: &[CommitToken]) {
+/// Print the commit tokens known durable before a failure, one per line, so
+/// an operator can see what landed (ADR-0089 deliverable 7). On
+/// [`LoadError::Flush`] this is a lower bound, not an exact account: the
+/// listed tokens are batches completed *before* the failing one, and do not
+/// include a shard that may have committed within the failing batch itself
+/// while a sibling shard's ack failed (see that variant's doc). Every other
+/// variant's tokens are exact -- the failing row or batch never reached
+/// `LogIngestRouter::write`.
+fn print_durable_tokens(err: &LoadError) {
+    let tokens = err.durable_tokens();
+    let is_flush = matches!(err, LoadError::Flush { .. });
     if tokens.is_empty() {
-        println!("no commit tokens were durable before the failure (nothing landed)");
+        if is_flush {
+            println!(
+                "no commit tokens were durable from a completed batch before the failure \
+                 (earlier batches, if any, all landed; the failing batch's own shards may or \
+                 may not have -- ravel-ingest does not report partial-shard success on error)"
+            );
+        } else {
+            println!("no commit tokens were durable before the failure (nothing landed)");
+        }
         return;
     }
+    let suffix = if is_flush {
+        " (this list may undercount: a shard within the failing batch itself may also have \
+          committed, but ravel-ingest does not report that on error)"
+    } else {
+        ""
+    };
     println!(
         "{} commit token(s)/segment(s) were durable before the failure (a partial load; \
-         re-running re-ingests the whole file, there is no dedup):",
+         re-running re-ingests the whole file, there is no dedup){suffix}:",
         tokens.len()
     );
     for token in tokens {
@@ -296,7 +319,14 @@ pub enum LoadError {
         durable: Vec<CommitToken>,
     },
     /// A flush (object-store PUT) failed. The tokens are what was durable
-    /// before the failure; the failed batch and everything after it are not.
+    /// from *earlier* batches. `LogIngestRouter::write` shards the failing
+    /// batch and waits for every shard's ack, but on the first shard error it
+    /// returns before collecting tokens from shards that acked successfully
+    /// in that same call (`LogWriteError` carries no partial-success data),
+    /// so a shard's records from the failing batch can be durable and still
+    /// go unreported here. Narrowing that gap needs `ravel-ingest` to return
+    /// per-shard outcomes on error; tracked as a follow-up, not fixed by this
+    /// type.
     #[error("flush failed: {cause}")]
     Flush {
         durable: Vec<CommitToken>,
@@ -332,8 +362,12 @@ impl LoadError {
 ///
 /// Fail-fast on the first row that fails a kept admission check. A run that
 /// returns `Ok` has every row durable; a run that returns `Err` reports the
-/// tokens already durable (a partial load — re-running re-ingests the whole
-/// file, there is no resumability or dedup in this version).
+/// tokens durable from batches that completed before the failure (a partial
+/// load — re-running re-ingests the whole file, there is no resumability or
+/// dedup in this version). On a [`LoadError::Flush`], the reported tokens can
+/// undercount: a shard within the failing batch may have committed while a
+/// sibling shard's ack failed, and that shard's token is not recoverable from
+/// the current `LogIngestRouter::write` error (see the variant's doc).
 #[allow(clippy::too_many_arguments)]
 pub async fn load(
     store: Arc<dyn ObjectStoreBackend>,

--- a/services/ravel-cli/src/load.rs
+++ b/services/ravel-cli/src/load.rs
@@ -270,9 +270,22 @@ impl LoadReport {
 #[derive(Debug, thiserror::Error)]
 pub enum LoadError {
     /// Setup failed before any record was written (mapping, provisioning, file
-    /// open, Parquet schema, missing column). Nothing is durable.
+    /// open, Parquet reader construction). Nothing is durable. Not used once
+    /// the batch loop starts — a failure there uses `BatchFailed` instead,
+    /// since earlier batches in the same run may already be durable.
     #[error("{0}")]
     Setup(String),
+    /// A batch failed to decode, or its columns failed to resolve against the
+    /// mapping, once the loop has already started (a later Parquet batch may
+    /// have a schema/type Parquet itself allows but the mapping cannot
+    /// handle). Distinct from `Setup`: earlier batches in the same run may
+    /// already be durable, and this variant reports them rather than
+    /// silently losing them.
+    #[error("{reason}")]
+    BatchFailed {
+        reason: String,
+        durable: Vec<CommitToken>,
+    },
     /// A row failed a kept admission check (future skew, length cap, or the
     /// loader per-record attribute cap). Fail-fast: the run stops at the first
     /// bad row. Any tokens listed are batches durable before this row.
@@ -293,11 +306,14 @@ pub enum LoadError {
 
 impl LoadError {
     /// The commit tokens already durable when this error occurred (empty for a
-    /// setup error).
+    /// setup error, since `Setup` never occurs once any batch could have
+    /// flushed).
     pub fn durable_tokens(&self) -> &[CommitToken] {
         match self {
             LoadError::Setup(_) => &[],
-            LoadError::RowRejected { durable, .. } | LoadError::Flush { durable, .. } => durable,
+            LoadError::BatchFailed { durable, .. }
+            | LoadError::RowRejected { durable, .. }
+            | LoadError::Flush { durable, .. } => durable,
         }
     }
 }
@@ -381,11 +397,17 @@ pub async fn load(
     let mut row_base: u64 = 0;
 
     for batch in reader {
-        let batch =
-            batch.map_err(|e| LoadError::Setup(format!("failed to read Parquet batch: {e}")))?;
+        let batch = batch.map_err(|e| LoadError::BatchFailed {
+            reason: format!("failed to read Parquet batch: {e}"),
+            durable: report.tokens.clone(),
+        })?;
         // Resolve column indices once per batch (schema is stable across
         // batches, but re-resolving keeps this self-contained and cheap).
-        let cols = ColumnIndex::resolve(&batch, mapping).map_err(LoadError::Setup)?;
+        let cols =
+            ColumnIndex::resolve(&batch, mapping).map_err(|reason| LoadError::BatchFailed {
+                reason,
+                durable: report.tokens.clone(),
+            })?;
 
         let mut records = Vec::with_capacity(batch.num_rows());
         for row in 0..batch.num_rows() {
@@ -1068,5 +1090,34 @@ type = "i64"
         let err = parse_mapping("ts_column = \"t\"\nts_unit = \"nanos\"\nbogus = 1\n")
             .expect_err("deny_unknown_fields rejects a typo");
         assert!(matches!(err, LoadError::Setup(_)));
+    }
+
+    // A batch that fails mid-loop (a later Parquet batch fails to decode, or
+    // its columns fail to resolve against the mapping) must report whatever
+    // was durable before it, not the empty slice `Setup` reports. Before this
+    // fix, both in-loop failure sites used `LoadError::Setup`, so a load that
+    // durably flushed earlier batches and then hit this error told the
+    // operator "nothing landed" while `report.tokens` already held commit
+    // tokens for those earlier batches -- confirmed by temporarily reverting
+    // this test's expectation to `&[]` and observing it match `Setup`'s
+    // behavior, which is the exact silent-loss shape the fix removes.
+    #[test]
+    fn batch_failed_reports_durable_tokens_not_empty() {
+        let durable = vec![CommitToken {
+            shard: 0,
+            writer_id: uuid::Uuid::nil(),
+            epoch: 0,
+            seq: 1,
+            ingest_hour_bucket: 0,
+        }];
+        let err = LoadError::BatchFailed {
+            reason: "failed to read Parquet batch: corrupt page".into(),
+            durable: durable.clone(),
+        };
+        assert_eq!(err.durable_tokens(), durable.as_slice());
+        assert_ne!(
+            err.durable_tokens(),
+            LoadError::Setup("x".into()).durable_tokens()
+        );
     }
 }

--- a/services/ravel-cli/src/main.rs
+++ b/services/ravel-cli/src/main.rs
@@ -86,7 +86,8 @@ fn command_hashes_tenant(command: &Command) -> bool {
         | Command::Maintain { .. }
         | Command::Hold { .. }
         | Command::Erase { .. }
-        | Command::Provision { .. } => true,
+        | Command::Provision { .. }
+        | Command::Load { .. } => true,
         // `commit reconstruct` computes a `t/<tenant_hash>/` prefix from its
         // `--tenant`, so it needs the bucket's scheme resolved first; the
         // other `commit` variants take an explicit key/path and do not.
@@ -182,6 +183,37 @@ enum Command {
     Tenant {
         #[command(subcommand)]
         command: TenantCommand,
+    },
+    /// Bulk-import a Parquet file into the logs signal (ADR-0089).
+    ///
+    /// Writes directly to the log ingest router in-process. NOTE: the
+    /// per-tenant AdmissionController (active-stream cap, stream-creation rate,
+    /// byte rate) that guards the HTTP ingest path is BYPASSED by construction
+    /// on this path. The future-skew and length caps are enforced identically
+    /// to OTLP; the past-event-time lag check is deliberately NOT enforced, so
+    /// historical timestamps are admitted (they bucket by load time, so query
+    /// with a window that reaches now). A per-record attribute cap of 1024
+    /// applies (relaxed from OTLP's 128). A row that fails a kept check is
+    /// rejected fail-fast: the run stops at the first bad row and exits
+    /// nonzero. There is NO resumability or deduplication: re-running after a
+    /// failure re-ingests the whole file from the start, and retention is
+    /// measured from load time, not the records' event times.
+    Load {
+        /// Path to the source Parquet file.
+        #[arg(long, value_name = "FILE")]
+        parquet: std::path::PathBuf,
+        /// Target tenant id (hashed under the bucket's pinned scheme).
+        #[arg(long)]
+        tenant: String,
+        /// Path to the `--mapping` TOML (source columns to record fields).
+        #[arg(long, value_name = "TOML")]
+        mapping: std::path::PathBuf,
+        /// Configured shard count. Validated against (or, for a fresh signal,
+        /// written to) the durable provisioning record, exactly as the server
+        /// does at first touch; the router resolves the active generation from
+        /// that record. Defaults to the server's default of 4.
+        #[arg(long, default_value_t = 4)]
+        shards: u32,
     },
 }
 
@@ -1046,6 +1078,22 @@ async fn main() -> anyhow::Result<()> {
                 tenant_token::list(store::build_store(&cli.store)?, &deployment_key_file).await?;
             print!("{report}");
             Ok(())
+        }
+        Command::Load {
+            parquet,
+            tenant,
+            mapping,
+            shards,
+        } => {
+            ravel_cli::load::run(
+                store::build_store(&cli.store)?,
+                &parquet,
+                &tenant,
+                &mapping,
+                shards,
+                now_ns()?,
+            )
+            .await
         }
     }
 }

--- a/services/ravel-cli/tests/load.rs
+++ b/services/ravel-cli/tests/load.rs
@@ -1,0 +1,391 @@
+//! End-to-end coverage for `ravel-cli load --parquet` (ADR-0089, issue #275).
+//!
+//! These drive the loader's real command-dispatch entry point
+//! (`ravel_cli::load::load`, what `main.rs` calls) in-process against a shared
+//! `MemoryStore`, then query the loaded data back through the real `ravel-sql`
+//! logs path. A subprocess against `--store memory` cannot be used for the
+//! round-trip: each process gets its own empty in-memory store, so a second
+//! process could never see the first's writes (the same reason
+//! `tests/catalog.rs` drives the library entry points in-process). The library
+//! entry point is the exact function the compiled binary dispatches to.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use arrow::array::{ArrayRef, Int64Array, StringArray};
+use arrow::record_batch::RecordBatch;
+use parquet::arrow::ArrowWriter;
+
+use ravel_catalog::{Catalog, CatalogConfig};
+use ravel_cli::load::{self, LoadError, Mapping};
+use ravel_ingest::Clock;
+use ravel_object_store::ObjectStoreBackend;
+use ravel_object_store::fault::{FaultPlan, Op, ScriptedFault, Sequence};
+use ravel_object_store::memory::MemoryStore;
+use ravel_query::{LogSegmentFetcher, SegmentFetcher};
+use ravel_sql::{SpanSegmentFetcher, SqlConfig, SqlExecutor, SqlRequest};
+use ravel_types::{CommitToken, TenantId, TimeRange};
+
+const NS_PER_HOUR: i64 = 3_600_000_000_000;
+
+/// A fixed, plausible (post-2020) load-time clock. The RLOG flush buckets by
+/// this reading, so the query window below reaches a known hour and
+/// `Catalog::resolve` fans out only a couple of LISTs (a realistic wall-clock
+/// value with a window from 0 would fan out to hundreds of thousands).
+const CLOCK_NS: i64 = 1_700_000_000_000_000_000; // 2023-11-14T22:13:20Z
+
+/// A clock pinned to `CLOCK_NS`; the shard actor's flush-open reading and the
+/// router's generation lookups both use it. The default real-timer `sleep` is
+/// fine (the flush-age tick never needs to advance in these tests).
+struct FixedClock(i64);
+impl Clock for FixedClock {
+    fn now_ns(&self) -> i64 {
+        self.0
+    }
+}
+
+fn write_parquet(path: &Path, batch: &RecordBatch) {
+    let file = std::fs::File::create(path).expect("create parquet");
+    let mut writer = ArrowWriter::try_new(file, batch.schema(), None).expect("arrow writer");
+    writer.write(batch).expect("write batch");
+    writer.close().expect("close writer");
+}
+
+fn i64_col(vals: Vec<i64>) -> ArrayRef {
+    Arc::new(Int64Array::from(vals))
+}
+
+fn str_col(vals: Vec<&str>) -> ArrayRef {
+    Arc::new(StringArray::from(vals))
+}
+
+fn mapping(text: &str) -> Mapping {
+    load::parse_mapping(text).expect("valid mapping")
+}
+
+/// Run a logs SQL query in-process through a real `SqlExecutor`, over a narrow
+/// window around `CLOCK_NS`, with `min_tokens` for read-your-write. Returns the
+/// matched row count.
+async fn logs_query_rows(
+    store: &Arc<dyn ObjectStoreBackend>,
+    tenant: &str,
+    sql: &str,
+    min_tokens: &[CommitToken],
+) -> usize {
+    let catalog =
+        Arc::new(Catalog::new(Arc::clone(store), CatalogConfig::default()).expect("catalog"));
+    let executor = SqlExecutor::new(
+        catalog,
+        SegmentFetcher::new(Arc::clone(store)),
+        LogSegmentFetcher::new(Arc::clone(store)),
+        SpanSegmentFetcher::new(Arc::clone(store)),
+        SqlConfig::default(),
+        1 << 30,
+    );
+    let req = SqlRequest {
+        sql: sql.to_string(),
+        window: TimeRange {
+            start_ns: CLOCK_NS - NS_PER_HOUR,
+            end_ns: CLOCK_NS + NS_PER_HOUR,
+        },
+        min_tokens: min_tokens.to_vec(),
+        now_ns: CLOCK_NS + 1_000,
+        deadline: Duration::from_secs(30),
+    };
+    let outcome = executor
+        .execute(TenantId::new(tenant).hash(), &req)
+        .await
+        .expect("logs query executes");
+    outcome.output.num_rows()
+}
+
+/// Reachability: a Parquet fixture loaded through the compiled loader's
+/// command-dispatch entry point is queryable through the real ravel-sql logs
+/// path, and typed attributes survive through `attrs['k']`.
+#[tokio::test]
+async fn loaded_parquet_round_trips_through_the_logs_sql_path() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let pq = dir.path().join("logs.parquet");
+    // Two records, same resource (service.name=api) so they share one stream,
+    // distinct typed record attributes.
+    let batch = RecordBatch::try_from_iter(vec![
+        ("ts".to_string(), i64_col(vec![CLOCK_NS, CLOCK_NS])),
+        ("body".to_string(), str_col(vec!["hello", "world"])),
+        ("svc".to_string(), str_col(vec!["api", "api"])),
+        ("status".to_string(), i64_col(vec![200, 500])),
+    ])
+    .expect("batch");
+    write_parquet(&pq, &batch);
+
+    let m = mapping(
+        r#"
+ts_column = "ts"
+ts_unit = "nanos"
+body_column = "body"
+
+[[resource_attribute]]
+key = "service.name"
+column = "svc"
+type = "str"
+
+[[attribute]]
+key = "http.status_code"
+column = "status"
+type = "i64"
+"#,
+    );
+
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+    let report = load::load(
+        Arc::clone(&store),
+        &pq,
+        "acme",
+        &m,
+        4,
+        10_000,
+        CLOCK_NS,
+        Arc::new(FixedClock(CLOCK_NS)),
+    )
+    .await
+    .expect("load succeeds");
+    assert_eq!(report.rows_processed, 2);
+    assert_eq!(
+        report.objects_written(),
+        1,
+        "both records share one stream, so one shard flushed"
+    );
+
+    // Both records are visible.
+    assert_eq!(
+        logs_query_rows(&store, "acme", "SELECT ts, body FROM logs", &report.tokens).await,
+        2
+    );
+    // The typed i64 record attribute survives through attrs['k'] (stringified
+    // in the Map(Utf8,Utf8) attrs column): each value matches exactly its row.
+    assert_eq!(
+        logs_query_rows(
+            &store,
+            "acme",
+            "SELECT ts FROM logs WHERE attrs['http.status_code'] = '200'",
+            &report.tokens,
+        )
+        .await,
+        1
+    );
+    assert_eq!(
+        logs_query_rows(
+            &store,
+            "acme",
+            "SELECT ts FROM logs WHERE attrs['http.status_code'] = '500'",
+            &report.tokens,
+        )
+        .await,
+        1
+    );
+    // The resource attribute is also queryable via attrs and matches both rows.
+    assert_eq!(
+        logs_query_rows(
+            &store,
+            "acme",
+            "SELECT ts FROM logs WHERE attrs['service.name'] = 'api'",
+            &report.tokens,
+        )
+        .await,
+        2
+    );
+    // A non-matching predicate returns nothing (not an error).
+    assert_eq!(
+        logs_query_rows(
+            &store,
+            "acme",
+            "SELECT ts FROM logs WHERE attrs['http.status_code'] = '999'",
+            &report.tokens,
+        )
+        .await,
+        0
+    );
+}
+
+/// A PUT failure partway through a multi-batch load exits non-zero and reports
+/// the commit tokens already durable before the failure. This fails against a
+/// naive loader that swallows the error or exits 0.
+#[tokio::test]
+async fn put_failure_midway_reports_already_durable_tokens() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let pq = dir.path().join("logs.parquet");
+    // Three rows, each a distinct stream (distinct service.name) so each lands
+    // in its own single-record batch flush under batch_rows = 1.
+    let batch = RecordBatch::try_from_iter(vec![
+        (
+            "ts".to_string(),
+            i64_col(vec![CLOCK_NS, CLOCK_NS, CLOCK_NS]),
+        ),
+        ("svc".to_string(), str_col(vec!["a", "b", "c"])),
+    ])
+    .expect("batch");
+    write_parquet(&pq, &batch);
+
+    let m = mapping(
+        r#"
+ts_column = "ts"
+ts_unit = "nanos"
+
+[[resource_attribute]]
+key = "service.name"
+column = "svc"
+type = "str"
+"#,
+    );
+
+    // Fail the SECOND log data-object PUT and every retry of it, so the first
+    // batch is durable and the second batch's flush is abandoned. The key
+    // filter `/l/l0/` matches only log data objects (not the provisioning
+    // record or commit records), so the first data PUT passes through.
+    let fault = ScriptedFault::Transient("injected PUT failure".into());
+    let mut seq = Sequence::new(Op::Put)
+        .with_key_contains("/l/l0/")
+        .then_passthrough();
+    for _ in 0..8 {
+        seq = seq.then_fault(fault.clone());
+    }
+    let plan = FaultPlan::empty().with_sequence(seq);
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(ravel_object_store::fault::FaultStore::new(
+        MemoryStore::new(),
+        plan,
+    ));
+
+    let err = load::load(
+        Arc::clone(&store),
+        &pq,
+        "acme",
+        &m,
+        4,
+        1, // one row per Strict flush
+        CLOCK_NS,
+        Arc::new(FixedClock(CLOCK_NS)),
+    )
+    .await
+    .expect_err("a PUT failure must surface as an error, not exit 0");
+
+    assert!(
+        matches!(err, LoadError::Flush { .. }),
+        "expected a flush failure, got: {err}"
+    );
+    assert_eq!(
+        err.durable_tokens().len(),
+        1,
+        "exactly the first batch was durable before the failure: {err}"
+    );
+}
+
+/// The deliberate ADR-0089 relaxation, end to end: a 2013-era event is
+/// accepted (not rejected as `TooOld`) and its RLOG object buckets by *load*
+/// time, not the event time. The commit token carries the pinned ingest-hour
+/// bucket, so this asserts the bucketing behavior the discoverability argument
+/// depends on.
+#[tokio::test]
+async fn past_dated_event_is_accepted_and_buckets_by_load_time() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let pq = dir.path().join("old.parquet");
+    let ts_2013 = 1_356_998_400_000_000_000; // 2013-01-01
+    let batch = RecordBatch::try_from_iter(vec![
+        ("ts".to_string(), i64_col(vec![ts_2013])),
+        ("svc".to_string(), str_col(vec!["api"])),
+    ])
+    .expect("batch");
+    write_parquet(&pq, &batch);
+
+    let m = mapping(
+        r#"
+ts_column = "ts"
+ts_unit = "nanos"
+
+[[resource_attribute]]
+key = "service.name"
+column = "svc"
+type = "str"
+"#,
+    );
+
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+    let report = load::load(
+        Arc::clone(&store),
+        &pq,
+        "acme",
+        &m,
+        4,
+        10_000,
+        CLOCK_NS,
+        Arc::new(FixedClock(CLOCK_NS)),
+    )
+    .await
+    .expect("a decade-old event is admitted");
+    assert_eq!(report.rows_processed, 1);
+    assert_eq!(report.tokens.len(), 1);
+
+    let load_hour = u32::try_from(CLOCK_NS.div_euclid(NS_PER_HOUR)).expect("hour fits u32");
+    assert_eq!(
+        report.tokens[0].ingest_hour_bucket, load_hour,
+        "the object must bucket by load time, not by the 2013 event time"
+    );
+}
+
+/// Attribute-count overflow at the RLOG object's dynamic-column budget: a load
+/// whose mapping has more distinct attribute columns than the 1000-per-object
+/// budget, but each row within the loader's per-record cap, succeeds. The
+/// overflow columns fold into the writer's `attrs_raw` overflow column rather
+/// than being rejected. This requires no loader code (the writer's existing
+/// behavior is reached), only that the loader does not itself reject.
+#[tokio::test]
+async fn attribute_columns_over_the_object_budget_fold_into_overflow_not_rejected() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let pq = dir.path().join("wide.parquet");
+
+    // 1001 distinct attribute columns: within the loader per-record cap (1024),
+    // over the RLOG object's 1000-distinct-column budget.
+    let n_attrs = 1001usize;
+    let mut cols: Vec<(String, ArrayRef)> = vec![
+        ("ts".to_string(), i64_col(vec![CLOCK_NS])),
+        ("svc".to_string(), str_col(vec!["api"])),
+    ];
+    let mut attr_toml = String::new();
+    for i in 0..n_attrs {
+        let name = format!("a{i}");
+        cols.push((name.clone(), i64_col(vec![i as i64])));
+        attr_toml.push_str(&format!(
+            "\n[[attribute]]\nkey = \"{name}\"\ncolumn = \"{name}\"\ntype = \"i64\"\n"
+        ));
+    }
+    let batch = RecordBatch::try_from_iter(cols).expect("wide batch");
+    write_parquet(&pq, &batch);
+
+    let m = mapping(&format!(
+        "ts_column = \"ts\"\nts_unit = \"nanos\"\n\n\
+         [[resource_attribute]]\nkey = \"service.name\"\ncolumn = \"svc\"\ntype = \"str\"\n{attr_toml}"
+    ));
+
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+    let report = load::load(
+        Arc::clone(&store),
+        &pq,
+        "acme",
+        &m,
+        4,
+        10_000,
+        CLOCK_NS,
+        Arc::new(FixedClock(CLOCK_NS)),
+    )
+    .await
+    .expect("over-budget attribute columns fold into attrs_raw, they are not rejected");
+    assert_eq!(report.rows_processed, 1);
+    assert_eq!(report.tokens.len(), 1);
+
+    // And the record is still queryable, confirming the object was written.
+    assert_eq!(
+        logs_query_rows(&store, "acme", "SELECT ts FROM logs", &report.tokens).await,
+        1
+    );
+}


### PR DESCRIPTION
There was no way to bulk-import structured event data into the logs
signal. The only ingest path, OTLP, enforces a two-hour past-event-time
lag and a 128-attribute cap sized for live telemetry, so a historical
backfill or a Parquet migration could not be loaded through it.

Adds ravel-cli load --parquet, a caller of the existing
LogIngestRouter that maps Parquet columns to record fields via a TOML
mapping. Past-event-time lag is deliberately not enforced (the
ingest-hour bucket is derived from load time, not event time, so this
does not reintroduce the discoverability hazard the OTLP limit
protects against); future skew and length caps are re-enforced at the
same bounds ravel-otlp uses; the per-record attribute cap is raised to
1024 for this offline, operator-initiated path, independent of the
RLOG object's 1000-column overflow budget. Writes use WriteMode::Strict
so a successful exit has no buffered-but-unflushed data, and a failed
flush reports the commit tokens already durable rather than swallowing
the partial load.

Checkpoint review found a batch-loop failure (a corrupt Parquet batch,
or a column-resolve failure on a later batch) used LoadError::Setup,
whose durable_tokens() always returns empty, even when earlier batches
in the same run had already flushed. Fixed before landing: a new
LoadError::BatchFailed variant carries the actual durable tokens at
both in-loop failure sites.

Fixes: #275
