### PR TITLE
feat(distrib): fan out RLOG logs/alerts/audit fetch and merge

### DIFF
--- a/crates/ravel-query/src/distrib/client.rs
+++ b/crates/ravel-query/src/distrib/client.rs
@@ -7,7 +7,9 @@
 //! [`SliceResponse`] shape, so the merge cannot tell a remote slice from a
 //! local one.
 
+use ravel_logseg::LogRecord;
 use ravel_proto::queryfrag::v1 as pb;
+use ravel_types::accounting::QueryAccountingSnapshot;
 use tonic::transport::Channel;
 
 use crate::distrib::codec::{self, CodecError};
@@ -86,12 +88,70 @@ pub struct SliceResponse {
     pub status_message: String,
 }
 
+/// One RLOG-family slice's fully-decoded response (Logs, Alerts, Audit). The
+/// log sibling of [`SliceResponse`]: `records` carries the worker's decoded
+/// per-segment merged view, post-erasure, in the worker's local scan order (the
+/// coordinator re-orders and dedups them, so this order is not load-bearing).
+/// Only meaningful when `status` is `Ok`.
+#[derive(Debug)]
+pub struct SliceLogResponse {
+    /// Decoded RLOG records, each carrying its full per-segment merged view.
+    pub records: Vec<LogRecord>,
+    /// The worker's per-slice cost accounting.
+    pub accounting: QueryAccountingSnapshot,
+    /// The worker's per-slice `FetchStats` page counters.
+    pub stats: FetchStats,
+    /// Records the worker reported returning (carried in the summary's
+    /// `series_returned` field, reused for the record count on this signal).
+    pub records_returned: u64,
+    /// The worker's terminal typed status.
+    pub status: pb::status::Code,
+    /// The status' human-readable detail (empty for `Ok`).
+    pub status_message: String,
+}
+
+impl SliceLogResponse {
+    /// A synthetic `Unsupported` response carrying no records, for a
+    /// [`SliceFetcher`] that has not wired the log path. The coordinator maps
+    /// `Unsupported` to whole-query local fallback (ADR-0071 failure
+    /// semantics), never a wrong or partial result.
+    pub fn unsupported(message: impl Into<String>) -> Self {
+        SliceLogResponse {
+            records: Vec::new(),
+            accounting: QueryAccountingSnapshot::default(),
+            stats: FetchStats::default(),
+            records_returned: 0,
+            status: pb::status::Code::Unsupported,
+            status_message: message.into(),
+        }
+    }
+}
+
 /// The seam between the coordinator merge and a slice worker. Object-safe (via
 /// `async_trait`) so the engine holds one `dyn SliceFetcher`.
 #[async_trait::async_trait]
 pub trait SliceFetcher: Send + Sync {
     /// Dispatches one slice request and collects its full response.
     async fn fetch(&self, request: pb::FetchRequest) -> Result<SliceResponse, DistribError>;
+
+    /// Dispatches one RLOG-family (Logs/Alerts/Audit) slice request and collects
+    /// its decoded records (#284).
+    ///
+    /// The default implementation reports [`pb::status::Code::Unsupported`], so
+    /// a `SliceFetcher` that has not wired the log fetch path degrades to
+    /// whole-query local execution rather than erroring. A real transport
+    /// (`RemoteSliceFetcher`) overrides it to drain the worker's stream and
+    /// decode its [`pb::LogRecordFrame`]s. This mirrors the base ADR's silent
+    /// version-skew fallback: an unimplemented log fetch is a coverage gap the
+    /// coordinator fills locally, never a hard failure.
+    async fn fetch_logs(
+        &self,
+        _request: pb::FetchRequest,
+    ) -> Result<SliceLogResponse, DistribError> {
+        Ok(SliceLogResponse::unsupported(
+            "distributed log fetch is not implemented by this slice fetcher",
+        ))
+    }
 }
 
 /// A [`SliceFetcher`] backed by a real gRPC worker over a `tonic` channel. The
@@ -124,6 +184,27 @@ impl SliceFetcher for RemoteSliceFetcher {
             frames.push(frame);
         }
         decode_slice_frames(frames)
+    }
+
+    async fn fetch_logs(
+        &self,
+        request: pb::FetchRequest,
+    ) -> Result<SliceLogResponse, DistribError> {
+        let mut client = SeriesFetchClient::new(self.channel.clone());
+        let response = client
+            .fetch(request)
+            .await
+            .map_err(|s| DistribError::Transport(s.to_string()))?;
+        let mut stream = response.into_inner();
+        let mut frames = Vec::new();
+        while let Some(frame) = stream
+            .message()
+            .await
+            .map_err(|s| DistribError::Transport(s.to_string()))?
+        {
+            frames.push(frame);
+        }
+        decode_log_slice_frames(frames)
     }
 }
 
@@ -192,6 +273,65 @@ pub fn decode_slice_frames(frames: Vec<pb::FetchResponse>) -> Result<SliceRespon
         },
         series_returned: summary.series_returned,
         samples_returned: summary.samples_returned,
+        status: code,
+        status_message: status.message,
+    })
+}
+
+/// Decode an RLOG-family slice's full frame sequence into a [`SliceLogResponse`]
+/// (#284). The log sibling of [`decode_slice_frames`]: it accepts
+/// [`pb::LogRecordFrame`]s and exactly one terminal [`pb::Summary`], and rejects
+/// any metric/histogram/span frame as [`DistribError::FrameSignalUnsupported`]
+/// (a log slice must not carry them). Every malformation is a typed error, never
+/// a panic: a malformed record ([`DistribError::Codec`]), a mixed-signal frame,
+/// an empty frame, a second summary, a missing summary, a summary with no
+/// status, or an unknown status code.
+pub fn decode_log_slice_frames(
+    frames: Vec<pb::FetchResponse>,
+) -> Result<SliceLogResponse, DistribError> {
+    let mut records = Vec::new();
+    let mut summary: Option<pb::Summary> = None;
+    for frame in frames {
+        match frame.frame {
+            Some(pb::fetch_response::Frame::LogRecord(lr)) => {
+                records.push(codec::decode_log_record(lr)?);
+            }
+            Some(pb::fetch_response::Frame::Series(_)) => {
+                return Err(DistribError::FrameSignalUnsupported("series"));
+            }
+            Some(pb::fetch_response::Frame::Hist(_)) => {
+                return Err(DistribError::FrameSignalUnsupported("histogram"));
+            }
+            Some(pb::fetch_response::Frame::Span(_)) => {
+                return Err(DistribError::FrameSignalUnsupported("span"));
+            }
+            Some(pb::fetch_response::Frame::Summary(s)) => {
+                if summary.is_some() {
+                    return Err(DistribError::MultipleSummaries);
+                }
+                summary = Some(s);
+            }
+            None => return Err(DistribError::EmptyFrame),
+        }
+    }
+
+    let summary = summary.ok_or(DistribError::NoSummary)?;
+    let status = summary
+        .status
+        .ok_or(DistribError::Codec(CodecError::MissingStatus))?;
+    let code = codec::decode_status_code(status.code)?;
+    let accounting = summary
+        .accounting
+        .map(codec::decode_accounting)
+        .unwrap_or_default();
+    Ok(SliceLogResponse {
+        records,
+        accounting,
+        stats: FetchStats {
+            raw_f64_pages: summary.raw_f64_pages,
+            raw_f64_bytes: summary.raw_f64_bytes,
+        },
+        records_returned: summary.series_returned,
         status: code,
         status_message: status.message,
     })

--- a/crates/ravel-query/src/distrib/client.rs
+++ b/crates/ravel-query/src/distrib/client.rs
@@ -91,7 +91,8 @@ pub struct SliceResponse {
 /// One RLOG-family slice's fully-decoded response (Logs, Alerts, Audit). The
 /// log sibling of [`SliceResponse`]: `records` carries the worker's decoded
 /// per-segment merged view, post-erasure, in the worker's local scan order (the
-/// coordinator re-orders and dedups them, so this order is not load-bearing).
+/// coordinator re-orders them under the stated total order and does not dedup,
+/// so this arrival order is not load-bearing).
 /// Only meaningful when `status` is `Ok`.
 #[derive(Debug)]
 pub struct SliceLogResponse {

--- a/crates/ravel-query/src/distrib/codec.rs
+++ b/crates/ravel-query/src/distrib/codec.rs
@@ -25,6 +25,9 @@ use ravel_proto::queryfrag::v1 as pb;
 use ravel_types::accounting::{AccountedOp, QueryAccountingSnapshot};
 use ravel_types::{Label, LabelSet, SeriesId, Signal};
 
+use ravel_logseg::LogRecord;
+use ravel_types::logstream::{AttrValue, LogStreamId};
+
 use crate::erasure::ErasurePredicate;
 use crate::fetcher::FetchedSeriesSoa;
 
@@ -185,6 +188,16 @@ pub enum CodecError {
     UnknownSegmentLevel(u32),
     #[error("fragment capability is {got} bytes, expected {CAPABILITY_LEN}")]
     BadCapabilityLength { got: usize },
+    #[error("log stream id is {got} bytes, expected 16")]
+    BadStreamId { got: usize },
+    #[error("log trace id is {got} bytes, expected 16 (or 0 for absent)")]
+    BadTraceId { got: usize },
+    #[error("log span id is {got} bytes, expected 8 (or 0 for absent)")]
+    BadSpanId { got: usize },
+    #[error("log severity number {got} does not fit in a u8")]
+    SeverityOutOfRange { got: u32 },
+    #[error("log attribute carried no value")]
+    MissingAttrValue,
 }
 
 /// Rejects any protocol version this build does not speak. `Ok(())` only for
@@ -333,6 +346,156 @@ fn decode_labels(labels: Vec<pb::Label>) -> Result<LabelSet, CodecError> {
         })
         .collect();
     LabelSet::new(pairs).map_err(|e| CodecError::InvalidLabels(e.to_string()))
+}
+
+// ---- LogRecordFrame <-> ravel_logseg::LogRecord ---------------------------
+
+/// Encodes one decoded RLOG record as a `LogRecordFrame`, field for field. The
+/// worker produces the record through the same `LogSegmentFetcher`/`RlogReader`
+/// funnel the local path uses, so the shipped per-segment merged view (the
+/// verbatim `stream_attrs` resource+scope blob plus the per-record `attrs`) is
+/// byte-identical to what a local read produces; the coordinator never
+/// re-derives attribute merging. `f64` attribute values cross as raw bit
+/// patterns, never proto doubles, so NaN payloads and `-0.0` survive the wire,
+/// the same discipline the scalar path applies to sample values.
+pub fn encode_log_record(record: &LogRecord) -> pb::LogRecordFrame {
+    pb::LogRecordFrame {
+        stream_id: record.stream_id.0.to_vec(),
+        stream_attrs: record.stream_attrs.clone(),
+        ts_ns: record.ts_ns,
+        observed_ts_ns: record.observed_ts_ns,
+        severity_num: u32::from(record.severity_num),
+        severity_text: record.severity_text.clone(),
+        body: record.body.clone(),
+        // An absent id is the empty byte string; a present one is its fixed
+        // width. A real all-zero id is still its full 16/8 bytes, so it is
+        // distinguishable from absent (which is zero bytes).
+        trace_id: record.trace_id.map(|t| t.to_vec()).unwrap_or_default(),
+        span_id: record.span_id.map(|s| s.to_vec()).unwrap_or_default(),
+        flags: record.flags,
+        attrs: record.attrs.iter().map(encode_log_attr).collect(),
+    }
+}
+
+/// Inverse of [`encode_log_record`]. Every malformation (a mis-sized stream,
+/// trace, or span id, a severity past `u8`, or an attribute with no value) is a
+/// typed [`CodecError`], never a panic or a silently truncated record.
+pub fn decode_log_record(frame: pb::LogRecordFrame) -> Result<LogRecord, CodecError> {
+    let stream_id = decode_log_stream_id(&frame.stream_id)?;
+    let trace_id = decode_trace_id(&frame.trace_id)?;
+    let span_id = decode_span_id(&frame.span_id)?;
+    let severity_num =
+        u8::try_from(frame.severity_num).map_err(|_| CodecError::SeverityOutOfRange {
+            got: frame.severity_num,
+        })?;
+    let attrs = frame
+        .attrs
+        .into_iter()
+        .map(decode_log_attr)
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(LogRecord {
+        stream_id,
+        stream_attrs: frame.stream_attrs,
+        ts_ns: frame.ts_ns,
+        observed_ts_ns: frame.observed_ts_ns,
+        severity_num,
+        severity_text: frame.severity_text,
+        body: frame.body,
+        trace_id,
+        span_id,
+        flags: frame.flags,
+        attrs,
+    })
+}
+
+fn encode_log_attr(attr: &(String, AttrValue)) -> pb::LogAttr {
+    pb::LogAttr {
+        key: attr.0.clone(),
+        value: Some(encode_attr_value(&attr.1)),
+    }
+}
+
+fn decode_log_attr(attr: pb::LogAttr) -> Result<(String, AttrValue), CodecError> {
+    let value = attr.value.ok_or(CodecError::MissingAttrValue)?;
+    Ok((attr.key, decode_attr_value(value)?))
+}
+
+/// Encodes one attribute value, recursing through lists and maps. `f64` is
+/// carried as `to_bits` (proto `fixed64`), never a double, so every bit
+/// pattern (NaN payloads, `-0.0`) round-trips exactly.
+fn encode_attr_value(value: &AttrValue) -> pb::LogAttrValue {
+    use pb::log_attr_value::Value;
+    let inner = match value {
+        AttrValue::Str(s) => Value::Str(s.clone()),
+        AttrValue::I64(v) => Value::Int(*v),
+        AttrValue::F64(f) => Value::DoubleBits(f.to_bits()),
+        AttrValue::Bool(b) => Value::Boolean(*b),
+        AttrValue::Bytes(b) => Value::BytesVal(b.clone()),
+        AttrValue::List(items) => Value::List(pb::LogAttrList {
+            items: items.iter().map(encode_attr_value).collect(),
+        }),
+        AttrValue::Map(entries) => Value::Map(pb::LogAttrMap {
+            entries: entries.iter().map(encode_log_attr).collect(),
+        }),
+    };
+    pb::LogAttrValue { value: Some(inner) }
+}
+
+/// Inverse of [`encode_attr_value`]. An attribute value with no oneof variant
+/// set is [`CodecError::MissingAttrValue`], never a silent default.
+fn decode_attr_value(value: pb::LogAttrValue) -> Result<AttrValue, CodecError> {
+    use pb::log_attr_value::Value;
+    let inner = value.value.ok_or(CodecError::MissingAttrValue)?;
+    Ok(match inner {
+        Value::Str(s) => AttrValue::Str(s),
+        Value::Int(v) => AttrValue::I64(v),
+        Value::DoubleBits(b) => AttrValue::F64(f64::from_bits(b)),
+        Value::Boolean(b) => AttrValue::Bool(b),
+        Value::BytesVal(b) => AttrValue::Bytes(b),
+        Value::List(l) => AttrValue::List(
+            l.items
+                .into_iter()
+                .map(decode_attr_value)
+                .collect::<Result<Vec<_>, _>>()?,
+        ),
+        Value::Map(m) => AttrValue::Map(
+            m.entries
+                .into_iter()
+                .map(decode_log_attr)
+                .collect::<Result<Vec<_>, _>>()?,
+        ),
+    })
+}
+
+fn decode_log_stream_id(bytes: &[u8]) -> Result<LogStreamId, CodecError> {
+    let arr: [u8; 16] = bytes
+        .try_into()
+        .map_err(|_| CodecError::BadStreamId { got: bytes.len() })?;
+    Ok(LogStreamId(arr))
+}
+
+/// Decodes an optional trace id: an empty byte string is `None`, a 16-byte
+/// string is `Some`, and any other length is a typed error.
+fn decode_trace_id(bytes: &[u8]) -> Result<Option<[u8; 16]>, CodecError> {
+    if bytes.is_empty() {
+        return Ok(None);
+    }
+    let arr: [u8; 16] = bytes
+        .try_into()
+        .map_err(|_| CodecError::BadTraceId { got: bytes.len() })?;
+    Ok(Some(arr))
+}
+
+/// Decodes an optional span id: an empty byte string is `None`, an 8-byte
+/// string is `Some`, and any other length is a typed error.
+fn decode_span_id(bytes: &[u8]) -> Result<Option<[u8; 8]>, CodecError> {
+    if bytes.is_empty() {
+        return Ok(None);
+    }
+    let arr: [u8; 8] = bytes
+        .try_into()
+        .map_err(|_| CodecError::BadSpanId { got: bytes.len() })?;
+    Ok(Some(arr))
 }
 
 // ---- LabelMatcher <-> pb::LabelMatcher ------------------------------------
@@ -915,6 +1078,176 @@ mod tests {
             decode_status_code(-1),
             Err(CodecError::UnknownStatusCode(-1))
         );
+    }
+
+    /// A full RLOG record with every attribute-value kind (including a nested
+    /// list and map), a NaN-payload `f64` attribute, and present trace/span ids
+    /// round-trips byte-for-byte. The `f64` crosses as its bit pattern, so the
+    /// NaN payload survives -- the same discipline the scalar path applies.
+    #[test]
+    fn log_record_round_trips_including_nested_and_nan_attrs() {
+        let nan = f64::from_bits(0x7ff8_0000_dead_beef);
+        let record = LogRecord {
+            stream_id: LogStreamId([3u8; 16]),
+            stream_attrs: vec![1, 2, 3, 4, 5],
+            ts_ns: -42,
+            observed_ts_ns: i64::MAX,
+            severity_num: 17,
+            severity_text: "WARN".to_string(),
+            body: "something happened".to_string(),
+            trace_id: Some([9u8; 16]),
+            span_id: Some([7u8; 8]),
+            flags: 0xdead_beef,
+            attrs: vec![
+                ("s".to_string(), AttrValue::Str("v".to_string())),
+                ("i".to_string(), AttrValue::I64(-7)),
+                ("f".to_string(), AttrValue::F64(nan)),
+                ("b".to_string(), AttrValue::Bool(true)),
+                ("raw".to_string(), AttrValue::Bytes(vec![0, 255, 1])),
+                (
+                    "list".to_string(),
+                    AttrValue::List(vec![AttrValue::I64(1), AttrValue::Str("x".to_string())]),
+                ),
+                (
+                    "map".to_string(),
+                    AttrValue::Map(vec![("k".to_string(), AttrValue::F64(-0.0))]),
+                ),
+            ],
+        };
+        let decoded = decode_log_record(encode_log_record(&record)).expect("decode");
+        assert_eq!(decoded.stream_id, record.stream_id);
+        assert_eq!(decoded.stream_attrs, record.stream_attrs);
+        assert_eq!(decoded.ts_ns, record.ts_ns);
+        assert_eq!(decoded.observed_ts_ns, record.observed_ts_ns);
+        assert_eq!(decoded.severity_num, record.severity_num);
+        assert_eq!(decoded.severity_text, record.severity_text);
+        assert_eq!(decoded.body, record.body);
+        assert_eq!(decoded.trace_id, record.trace_id);
+        assert_eq!(decoded.span_id, record.span_id);
+        assert_eq!(decoded.flags, record.flags);
+        // Structural equality would treat NaN != NaN, so check the f64 attr by
+        // bit pattern explicitly, then the rest structurally.
+        let got_f = decoded
+            .attrs
+            .iter()
+            .find(|(k, _)| k == "f")
+            .expect("f attr");
+        let want_f = record.attrs.iter().find(|(k, _)| k == "f").expect("f attr");
+        match (&got_f.1, &want_f.1) {
+            (AttrValue::F64(a), AttrValue::F64(b)) => assert_eq!(a.to_bits(), b.to_bits()),
+            _ => panic!("f attr is not F64"),
+        }
+        // The map's -0.0 likewise survives by bit pattern.
+        match &decoded
+            .attrs
+            .iter()
+            .find(|(k, _)| k == "map")
+            .expect("map")
+            .1
+        {
+            AttrValue::Map(entries) => match &entries[0].1 {
+                AttrValue::F64(v) => assert_eq!(v.to_bits(), (-0.0f64).to_bits()),
+                _ => panic!("map value not F64"),
+            },
+            _ => panic!("map attr not a Map"),
+        }
+    }
+
+    /// An absent trace/span id is the empty byte string; a present one is its
+    /// fixed width. A record with neither round-trips to `None`, and a present
+    /// all-zero id (16/8 bytes) round-trips to `Some`, distinct from absent.
+    #[test]
+    fn log_record_optional_ids_round_trip() {
+        let none = LogRecord {
+            stream_id: LogStreamId([0u8; 16]),
+            stream_attrs: Vec::new(),
+            ts_ns: 0,
+            observed_ts_ns: 0,
+            severity_num: 0,
+            severity_text: String::new(),
+            body: String::new(),
+            trace_id: None,
+            span_id: None,
+            flags: 0,
+            attrs: Vec::new(),
+        };
+        let decoded = decode_log_record(encode_log_record(&none)).expect("decode");
+        assert_eq!(decoded.trace_id, None);
+        assert_eq!(decoded.span_id, None);
+
+        let zero_ids = LogRecord {
+            trace_id: Some([0u8; 16]),
+            span_id: Some([0u8; 8]),
+            ..none
+        };
+        let decoded = decode_log_record(encode_log_record(&zero_ids)).expect("decode");
+        assert_eq!(decoded.trace_id, Some([0u8; 16]));
+        assert_eq!(decoded.span_id, Some([0u8; 8]));
+    }
+
+    #[test]
+    fn log_record_bad_lengths_and_missing_value_are_typed_errors() {
+        let base = pb::LogRecordFrame {
+            stream_id: vec![0u8; 16],
+            stream_attrs: Vec::new(),
+            ts_ns: 0,
+            observed_ts_ns: 0,
+            severity_num: 0,
+            severity_text: String::new(),
+            body: String::new(),
+            trace_id: Vec::new(),
+            span_id: Vec::new(),
+            flags: 0,
+            attrs: Vec::new(),
+        };
+
+        let bad_stream = pb::LogRecordFrame {
+            stream_id: vec![0u8; 15],
+            ..base.clone()
+        };
+        assert!(matches!(
+            decode_log_record(bad_stream),
+            Err(CodecError::BadStreamId { got: 15 })
+        ));
+
+        let bad_trace = pb::LogRecordFrame {
+            trace_id: vec![0u8; 8],
+            ..base.clone()
+        };
+        assert!(matches!(
+            decode_log_record(bad_trace),
+            Err(CodecError::BadTraceId { got: 8 })
+        ));
+
+        let bad_span = pb::LogRecordFrame {
+            span_id: vec![0u8; 7],
+            ..base.clone()
+        };
+        assert!(matches!(
+            decode_log_record(bad_span),
+            Err(CodecError::BadSpanId { got: 7 })
+        ));
+
+        let bad_sev = pb::LogRecordFrame {
+            severity_num: 256,
+            ..base.clone()
+        };
+        assert!(matches!(
+            decode_log_record(bad_sev),
+            Err(CodecError::SeverityOutOfRange { got: 256 })
+        ));
+
+        let missing_value = pb::LogRecordFrame {
+            attrs: vec![pb::LogAttr {
+                key: "k".to_string(),
+                value: None,
+            }],
+            ..base
+        };
+        assert!(matches!(
+            decode_log_record(missing_value),
+            Err(CodecError::MissingAttrValue)
+        ));
     }
 
     #[test]

--- a/crates/ravel-query/src/distrib/mod.rs
+++ b/crates/ravel-query/src/distrib/mod.rs
@@ -37,13 +37,15 @@ use std::sync::Arc;
 
 use futures::{StreamExt, stream};
 use ravel_catalog::{SegmentRef, Snapshot};
+use ravel_logseg::LogRecord;
 use ravel_promql::LabelMatcher;
 use ravel_proto::queryfrag::v1 as pb;
 use ravel_types::accounting::{QueryAccounting, QueryAccountingSnapshot};
+use ravel_types::logstream::canonical_attr_bytes;
 use ravel_types::{SeriesId, Signal, TenantHash};
 
 use crate::config::{ByteLimit, EngineConfig};
-use crate::distrib::client::{DistribError, SliceFetcher};
+use crate::distrib::client::{DistribError, SliceFetcher, SliceLogResponse};
 use crate::distrib::partition::{DistribThresholds, partition_snapshot};
 use crate::engine::bytes_scanned_exceeded;
 use crate::erasure::ErasurePredicate;
@@ -337,6 +339,158 @@ impl Distributed {
 
         Ok(Some((per_slice, stats, Vec::new())))
     }
+
+    /// Partitions the snapshot, dispatches one RLOG-family (Logs, Alerts, Audit)
+    /// slice request per slice, and merges the decoded records into the single
+    /// cross-segment total order a local multi-segment read produces (#284). The
+    /// log sibling of [`fetch`](Self::fetch).
+    ///
+    /// Returns:
+    /// - `Ok(Some(records))` when every slice succeeded: the coordinator-ordered,
+    ///   deduped record set, bit-identical to a local `LogSegmentFetcher` read
+    ///   over the same segments merged under the same rule (see
+    ///   [`merge_log_records`]).
+    /// - `Ok(None)` for whole-query local fallback: a worker reported
+    ///   `Unsupported` (version skew, a worker with no log fetcher wired, matcher
+    ///   pushdown, or a resolve-scope slice).
+    /// - `Err(QueryError::Fetch(Store { NotFound }))` for a `SnapshotInvalidated`
+    ///   slice, so the engine re-resolves and re-dispatches once.
+    /// - `Err(..)` for a terminal slice failure or a re-enforced budget overrun.
+    ///
+    /// This machinery is correct and tested, but no caller in the engine or SQL
+    /// layer dispatches a non-Metrics distributed fetch yet
+    /// (`fetch_samples_and_histograms_maybe_distributed` only ever passes
+    /// `Signal::Metrics`); wiring a real log caller is out of #284's scope.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn fetch_logs(
+        &self,
+        tenant_hash: TenantHash,
+        signal: Signal,
+        snapshot: &Snapshot,
+        matchers: &[LabelMatcher],
+        erasure: &[ErasurePredicate],
+        accounting: &QueryAccounting,
+        config: &EngineConfig,
+        deadline_unix_ns: i64,
+    ) -> Result<Option<Vec<LogRecord>>, QueryError> {
+        let slices = partition_snapshot(snapshot, self.thresholds.max_parallel_slices);
+        if slices.is_empty() {
+            // An empty snapshot merges to an empty record set identically whether
+            // local or distributed.
+            return Ok(Some(Vec::new()));
+        }
+
+        let encoded_matchers = codec::encode_matchers(matchers);
+        let encoded_erasure = codec::encode_erasure(erasure);
+        let budgets = encode_budgets(config);
+        let tenant_bytes = tenant_hash.0.to_vec();
+        let signal_disc = codec::signal_to_u32(signal);
+        let query_id = query_id_bytes(&tenant_bytes, signal_disc, deadline_unix_ns, snapshot);
+
+        let concurrency = self.thresholds.max_parallel_slices.max(1);
+        let mut stream = stream::iter(slices)
+            .map(|slice| {
+                let (window_start_ns, window_end_ns) = slice_event_window(&slice.segments);
+                let request = pb::FetchRequest {
+                    protocol_version: codec::PROTOCOL_VERSION,
+                    query_id: query_id.to_vec(),
+                    tenant_hash: tenant_bytes.clone(),
+                    signal: signal_disc,
+                    scope: Some(pb::fetch_request::Scope::Pinned(pb::PinnedScope {
+                        segments: slice
+                            .segments
+                            .iter()
+                            .map(codec::encode_segment_identity)
+                            .collect(),
+                    })),
+                    matchers: encoded_matchers.clone(),
+                    window_start_ns,
+                    window_end_ns,
+                    budgets: Some(budgets),
+                    deadline_unix_ns,
+                    erasure: encoded_erasure.clone(),
+                    trace_context: String::new(),
+                    fragment_capability: Vec::new(),
+                };
+                let fetcher = Arc::clone(&self.fetcher);
+                async move { fetcher.fetch_logs(request).await }
+            })
+            .buffer_unordered(concurrency);
+
+        // Collect each slice's records into a flat per-slice pool, folding its
+        // accounting into the query's aggregate and re-enforcing the
+        // bytes-scanned budget over the running total, exactly as the metrics
+        // path does. Precedence on soft outcomes matches `fetch`: a later hard
+        // error dominates an invalidation, which dominates an Unsupported
+        // fallback.
+        let mut per_slice: Vec<Vec<LogRecord>> = Vec::new();
+        let mut running = QueryAccountingSnapshot::default();
+        let mut invalidated = false;
+        let mut unsupported = false;
+
+        while let Some(result) = stream.next().await {
+            let response = result.map_err(distrib_error)?;
+            match response.status {
+                pb::status::Code::Ok => {
+                    fold_log_slice(accounting, &mut running, &response);
+                    if let Some(err) =
+                        bytes_scanned_exceeded(running.total_s3_bytes(), config.max_bytes_scanned)
+                    {
+                        return Err(err);
+                    }
+                    per_slice.push(response.records);
+                }
+                pb::status::Code::SnapshotInvalidated => invalidated = true,
+                pb::status::Code::Unsupported => {
+                    fold_log_slice(accounting, &mut running, &response);
+                    unsupported = true;
+                }
+                pb::status::Code::BudgetExceeded => {
+                    fold_log_slice(accounting, &mut running, &response);
+                    return Err(bytes_scanned_exceeded(
+                        running.total_s3_bytes(),
+                        config.max_bytes_scanned,
+                    )
+                    .unwrap_or_else(|| QueryError::Distrib {
+                        reason: format!("slice tripped its budget: {}", response.status_message),
+                    }));
+                }
+                pb::status::Code::Corrupt => {
+                    return Err(QueryError::Distrib {
+                        reason: format!(
+                            "slice reported a corrupt segment: {}",
+                            response.status_message
+                        ),
+                    });
+                }
+                pb::status::Code::Unavailable => {
+                    return Err(QueryError::Distrib {
+                        reason: format!(
+                            "slice unavailable after re-dispatch and local execution: {}",
+                            response.status_message
+                        ),
+                    });
+                }
+                other => {
+                    return Err(QueryError::Distrib {
+                        reason: format!("slice returned {other:?}: {}", response.status_message),
+                    });
+                }
+            }
+        }
+
+        if invalidated {
+            return Err(QueryError::Fetch(FetchError::Store {
+                key: "distributed-slice".to_string(),
+                source: ravel_object_store::StoreError::NotFound,
+            }));
+        }
+        if unsupported {
+            return Ok(None);
+        }
+
+        Ok(Some(merge_log_records(per_slice)))
+    }
 }
 
 /// Folds one OK/Unsupported slice's reported cost into both the query's live
@@ -358,6 +512,121 @@ fn fold_slice(
     stats.raw_f64_bytes = stats
         .raw_f64_bytes
         .saturating_add(response.stats.raw_f64_bytes);
+}
+
+/// Folds one RLOG-family slice's accounting into the query's live handle and the
+/// coordinator's running snapshot (the basis for the incremental bytes-scanned
+/// check). The log sibling of [`fold_slice`]; a log slice carries no `FetchStats`
+/// page counters (a metric-path concept), so there is none to sum.
+fn fold_log_slice(
+    live: &QueryAccounting,
+    running: &mut QueryAccountingSnapshot,
+    response: &SliceLogResponse,
+) {
+    live.merge_snapshot(&response.accounting);
+    *running = running.saturating_merge(&response.accounting);
+}
+
+/// The stated cross-segment total order and dedup rule for RLOG records, and the
+/// coordinator merge that reproduces it (#284, ADR-0071 amendment decision 4).
+///
+/// # The invariant this reproduces
+///
+/// A distributed Logs/Alerts/Audit fetch must be bit-identical to reading every
+/// pinned segment locally with `LogSegmentFetcher` and combining the records
+/// under one defined total order. Because ADR-0052 online resharding routes a
+/// single stream to different shard indices across generations, a stream's
+/// segments can land in different slices; the merge is therefore defined purely
+/// on record identity and this total order, never on slice or shard arrival
+/// order (mirroring the metrics lane's `merge_soa_runs`, which is order-
+/// independent over the flat run pool).
+///
+/// The **total order** over records is ascending, lexicographic, over the whole
+/// record content in a fixed field sequence:
+///
+/// `(ts_ns, stream_id, stream_attrs, observed_ts_ns, severity_num,
+///   severity_text, body, trace_id, span_id, flags, attrs)`
+///
+/// where `attrs` is compared by the concatenation of each `(key, value)` pair's
+/// frozen `canonical_attr_bytes` encoding **in the record's own attribute
+/// order** (so `f64` values compare by bit pattern, preserving NaN/-0.0, and two
+/// records differing only in attribute order are ordered, not conflated). Every
+/// field participates, so the key is a total order: two records with an equal
+/// key are byte-identical.
+///
+/// The **dedup / tie-break rule**: records with an equal key are exact
+/// duplicates (identical in every field, e.g. one record copied verbatim into
+/// two overlapping segments), and the merge keeps one. This is the log analog of
+/// the metrics `(series_id, ts)` dedup: the identity is the full record because
+/// an RLOG record carries no separate id, and the tie-break is total because the
+/// key already orders every field. Distinct records never share a key, so dedup
+/// can never drop a genuine record.
+///
+/// The naive alternative -- concatenating each slice's records in slice arrival
+/// order -- is wrong precisely when one stream's segments straddle two slices:
+/// it emits one slice's records (some with large `ts`) before another slice's
+/// (some with small `ts`), an order the local read never produces. The
+/// `sort_by` below is the line that fixes it; replacing this merge with a
+/// slice-order concatenation fails the reshard-straddling differential test.
+///
+/// The merge is order-independent over the flat pool: sorting the flattened
+/// multiset of records is a pure function of that multiset, so the per-slice
+/// grouping (which differs from the local per-segment grouping) never changes
+/// the result -- exactly the property the differential test exercises.
+pub(crate) fn merge_log_records(per_slice: Vec<Vec<LogRecord>>) -> Vec<LogRecord> {
+    let mut keyed: Vec<(LogOrderKey, LogRecord)> = per_slice
+        .into_iter()
+        .flatten()
+        .map(|record| (log_record_order_key(&record), record))
+        .collect();
+    // A stable sort on the precomputed full-content key; equal-key records are
+    // byte-identical, so which of a duplicate run survives `dedup_by` is
+    // immaterial.
+    keyed.sort_by(|a, b| a.0.cmp(&b.0));
+    keyed.dedup_by(|a, b| a.0 == b.0);
+    keyed.into_iter().map(|(_, record)| record).collect()
+}
+
+/// The total-order key for one RLOG record (see [`merge_log_records`]). A tuple
+/// so `Ord` derives structurally; the trailing `Vec<u8>` is the order-preserving
+/// canonical encoding of the record's attributes.
+type LogOrderKey = (
+    i64,
+    [u8; 16],
+    Vec<u8>,
+    i64,
+    u8,
+    String,
+    String,
+    Option<[u8; 16]>,
+    Option<[u8; 8]>,
+    u32,
+    Vec<u8>,
+);
+
+fn log_record_order_key(record: &LogRecord) -> LogOrderKey {
+    // Encode each attribute pair with the frozen canonical grammar and
+    // concatenate in the record's own order. Each single-entry encoding is
+    // self-delimiting (leading count 1, then `len(key) key encode_value`), so
+    // the concatenation is injective and order-preserving, and `f64` values are
+    // compared by `to_bits` (NaN payloads and -0.0 significant).
+    let mut attrs_key = Vec::new();
+    for pair in &record.attrs {
+        attrs_key.extend_from_slice(&canonical_attr_bytes(std::slice::from_ref(pair)));
+    }
+    (
+        record.ts_ns,
+        record.stream_id.0,
+        record.stream_attrs.clone(),
+        record.observed_ts_ns,
+        record.severity_num,
+        record.severity_text.clone(),
+        record.body.clone(),
+        record.trace_id,
+        record.span_id,
+        record.flags,
+        attrs_key,
+    )
 }
 
 /// Maps a per-slice `Budgets` share from the engine config. `Unlimited` bytes

--- a/crates/ravel-query/src/distrib/mod.rs
+++ b/crates/ravel-query/src/distrib/mod.rs
@@ -346,10 +346,10 @@ impl Distributed {
     /// log sibling of [`fetch`](Self::fetch).
     ///
     /// Returns:
-    /// - `Ok(Some(records))` when every slice succeeded: the coordinator-ordered,
-    ///   deduped record set, bit-identical to a local `LogSegmentFetcher` read
-    ///   over the same segments merged under the same rule (see
-    ///   [`merge_log_records`]).
+    /// - `Ok(Some(records))` when every slice succeeded: the coordinator-ordered
+    ///   record set (no dedup -- see [`merge_log_records`]), bit-identical to a
+    ///   local `LogSegmentFetcher` read over the same segments merged under the
+    ///   same rule.
     /// - `Ok(None)` for whole-query local fallback: a worker reported
     ///   `Unsupported` (version skew, a worker with no log fetcher wired, matcher
     ///   pushdown, or a resolve-scope slice).
@@ -527,8 +527,9 @@ fn fold_log_slice(
     *running = running.saturating_merge(&response.accounting);
 }
 
-/// The stated cross-segment total order and dedup rule for RLOG records, and the
-/// coordinator merge that reproduces it (#284, ADR-0071 amendment decision 4).
+/// The stated cross-segment total order for RLOG records (no dedup: see below),
+/// and the coordinator merge that reproduces it (#284, ADR-0071 amendment
+/// decision 4).
 ///
 /// # The invariant this reproduces
 ///
@@ -554,13 +555,14 @@ fn fold_log_slice(
 /// field participates, so the key is a total order: two records with an equal
 /// key are byte-identical.
 ///
-/// The **dedup / tie-break rule**: records with an equal key are exact
-/// duplicates (identical in every field, e.g. one record copied verbatim into
-/// two overlapping segments), and the merge keeps one. This is the log analog of
-/// the metrics `(series_id, ts)` dedup: the identity is the full record because
-/// an RLOG record carries no separate id, and the tie-break is total because the
-/// key already orders every field. Distinct records never share a key, so dedup
-/// can never drop a genuine record.
+/// **No dedup.** Unlike the metrics `(series_id, ts)` dedup, an equal key here
+/// (two byte-identical records) is NOT collapsed. `docs/consistency-model.md`
+/// ("logs and spans") and ADR-0051 section 5 are explicit that logs/alerts/audit
+/// have no query-time dedup: a retry after a lost ack produces byte-identical
+/// rows that are legitimately duplicate user data and must stay visible, not
+/// silently dropped. The total order above still matters for merge determinism
+/// (a stable sort under a total key gives the same output regardless of slice
+/// arrival order), it just never doubles as an identity for collapsing records.
 ///
 /// The naive alternative -- concatenating each slice's records in slice arrival
 /// order -- is wrong precisely when one stream's segments straddle two slices:

--- a/crates/ravel-query/src/distrib/mod.rs
+++ b/crates/ravel-query/src/distrib/mod.rs
@@ -579,11 +579,14 @@ pub(crate) fn merge_log_records(per_slice: Vec<Vec<LogRecord>>) -> Vec<LogRecord
         .flatten()
         .map(|record| (log_record_order_key(&record), record))
         .collect();
-    // A stable sort on the precomputed full-content key; equal-key records are
-    // byte-identical, so which of a duplicate run survives `dedup_by` is
-    // immaterial.
+    // A stable sort on the precomputed full-content key. Equal-key records are
+    // byte-identical, but they are NOT collapsed: the consistency model
+    // (docs/consistency-model.md, "logs and spans") forbids query-time dedup
+    // for logs/alerts/audit, because a retry after a lost ack produces
+    // byte-identical rows that are legitimately duplicate USER DATA and must
+    // stay visible. Every record in the pool is returned; only the metric path
+    // (dedup by (series_id, ts), where duplicates are harmless) dedups.
     keyed.sort_by(|a, b| a.0.cmp(&b.0));
-    keyed.dedup_by(|a, b| a.0 == b.0);
     keyed.into_iter().map(|(_, record)| record).collect()
 }
 
@@ -604,7 +607,7 @@ type LogOrderKey = (
     Vec<u8>,
 );
 
-fn log_record_order_key(record: &LogRecord) -> LogOrderKey {
+pub(crate) fn log_record_order_key(record: &LogRecord) -> LogOrderKey {
     // Encode each attribute pair with the frozen canonical grammar and
     // concatenate in the record's own order. Each single-entry encoding is
     // self-delimiting (leading count 1, then `len(key) key encode_value`), so

--- a/crates/ravel-query/src/distrib/service.rs
+++ b/crates/ravel-query/src/distrib/service.rs
@@ -200,6 +200,7 @@ impl<R: SegmentResolver + 'static> SeriesFetchService<R> {
                 self.run_slice_logs(
                     request.scope,
                     request.budgets,
+                    tenant_hash,
                     matchers,
                     erasure,
                     request.window_start_ns,
@@ -377,12 +378,15 @@ impl<R: SegmentResolver + 'static> SeriesFetchService<R> {
     /// this slice's segments produces the exact per-record view `RlogReader`
     /// produces locally, and applies erasure identically per segment, whether or
     /// not a stream's segments straddle two slices. The coordinator (see
-    /// [`crate::distrib::merge_log_records`]) re-orders and dedups; this path
-    /// never assumes a stream maps to one slice.
+    /// [`crate::distrib::merge_log_records`]) re-orders under a total order but
+    /// never dedups (logs have no query-time dedup); this path never assumes a
+    /// stream maps to one slice.
+    #[allow(clippy::too_many_arguments)]
     async fn run_slice_logs(
         &self,
         scope: Option<pb::fetch_request::Scope>,
         budgets: Option<pb::Budgets>,
+        tenant_hash: TenantHash,
         matchers: Vec<ravel_promql::LabelMatcher>,
         erasure: Vec<crate::erasure::ErasurePredicate>,
         window_start_ns: i64,
@@ -448,7 +452,7 @@ impl<R: SegmentResolver + 'static> SeriesFetchService<R> {
         let stats = FetchStats::default();
         for seg in &segments {
             let out = log_fetcher
-                .fetch_accounted(seg, &query, &accounting)
+                .fetch_accounted_with_tenant(seg, tenant_hash, &query, &accounting)
                 .await
                 .map_err(map_log_fetch_error)?;
             if let Some(output) = out {

--- a/crates/ravel-query/src/distrib/service.rs
+++ b/crates/ravel-query/src/distrib/service.rs
@@ -42,6 +42,7 @@ use crate::distrib::codec;
 use crate::distrib::proto::series_fetch_server::{SeriesFetch, SeriesFetchServer};
 use crate::engine::bytes_scanned_exceeded;
 use crate::fetcher::{FetchError, FetchStats, SegmentFetcher};
+use crate::log_fetcher::{LogFetchError, LogQuery, LogSegmentFetcher};
 
 /// Resolves a shipped [`pb::SegmentIdentity`] back to the [`SegmentRef`] a
 /// worker fetches. The production resolver reconstructs the
@@ -86,12 +87,35 @@ impl SegmentResolver for SnapshotSegmentResolver {
 /// turn shipped identities into refs.
 pub struct SeriesFetchService<R: SegmentResolver + 'static> {
     fetcher: SegmentFetcher,
+    /// The RLOG-family fetcher (Logs, Alerts, Audit), wired via
+    /// [`with_log_fetcher`](Self::with_log_fetcher). `None` (the default) means
+    /// this worker cannot serve a distributed log fetch: a Logs/Alerts/Audit
+    /// slice returns `Unsupported` so the coordinator falls back to local
+    /// execution. Kept optional so the crate-internal `new` constructor (and the
+    /// out-of-crate coordinator wiring that calls it) is unchanged; a worker that
+    /// wants to serve logs opts in with the builder.
+    log_fetcher: Option<LogSegmentFetcher>,
     resolver: Arc<R>,
 }
 
 impl<R: SegmentResolver + 'static> SeriesFetchService<R> {
     pub fn new(fetcher: SegmentFetcher, resolver: Arc<R>) -> Self {
-        SeriesFetchService { fetcher, resolver }
+        SeriesFetchService {
+            fetcher,
+            log_fetcher: None,
+            resolver,
+        }
+    }
+
+    /// Wires the RLOG-family fetch path (#284) onto this worker. Built over the
+    /// same object store the metrics [`SegmentFetcher`] reads, so a Logs,
+    /// Alerts, or Audit slice fetches the same pinned segments the resolver
+    /// maps. Without this, those signals return `Unsupported` and the
+    /// coordinator runs the query locally.
+    #[must_use]
+    pub fn with_log_fetcher(mut self, log_fetcher: LogSegmentFetcher) -> Self {
+        self.log_fetcher = Some(log_fetcher);
+        self
     }
 
     /// Wraps this service in the generated gRPC server, ready to add to a
@@ -164,16 +188,31 @@ impl<R: SegmentResolver + 'static> SeriesFetchService<R> {
                 )
                 .await
             }
-            // The RLOG family (Logs, Alerts, Audit) and Spans now reach a real
-            // per-signal branch after decoding, proving the signal check is a
-            // dispatch and not a pre-decode reject. Their fetch-and-encode
-            // paths land in #284 (logs) and #285 (spans); until then the branch
-            // returns a distinct "not yet implemented" Unsupported, so the
-            // coordinator still silently falls back to fully local execution
-            // (ADR-0071 failure semantics). This is deliberately NOT reachable
-            // from a real query yet: no caller dispatches a non-Metrics
-            // distributed fetch until #284/#285 build the coordinators.
-            Signal::Logs | Signal::Alerts | Signal::Audit | Signal::Spans => Err((
+            // The RLOG family (Logs, Alerts, Audit) fetches through the same
+            // `LogSegmentFetcher`/`RlogReader` funnel the local logs/alerts/audit
+            // paths use (#284). All three signals share one fetch path: they are
+            // the same RLOG object family, distinguished only by the object-key
+            // prefix the coordinator resolved, which the worker never re-derives
+            // (it fetches the pinned segments the resolver maps). A worker with
+            // no log fetcher wired returns Unsupported inside `run_slice_logs`,
+            // so the coordinator falls back to local.
+            Signal::Logs | Signal::Alerts | Signal::Audit => {
+                self.run_slice_logs(
+                    request.scope,
+                    request.budgets,
+                    matchers,
+                    erasure,
+                    request.window_start_ns,
+                    request.window_end_ns,
+                )
+                .await
+            }
+            // Spans reach a real per-signal branch after decoding but their
+            // fetch-and-encode path lands in #285; until then the branch returns
+            // a distinct "not yet implemented" Unsupported, so the coordinator
+            // still silently falls back to fully local execution (ADR-0071
+            // failure semantics).
+            Signal::Spans => Err((
                 pb::status::Code::Unsupported,
                 format!("distributed fetch for signal {signal:?} is not yet implemented"),
             )),
@@ -324,6 +363,137 @@ impl<R: SegmentResolver + 'static> SeriesFetchService<R> {
         ));
         Ok(frames)
     }
+
+    /// The RLOG-family slice path (Logs, Alerts, Audit): resolve the pinned
+    /// scope to refs, fetch each segment through the production
+    /// [`LogSegmentFetcher`] funnel (so the per-segment merged attribute view
+    /// and the erasure exclusion are byte-identical to a local read), enforce
+    /// the per-slice bytes-scanned budget, and stream one `LogRecordFrame` per
+    /// decoded record ending in a terminal summary.
+    ///
+    /// Correctness under ADR-0052 resharding rests on segment self-containment,
+    /// not slice atomicity: every RLOG segment embeds the resource+scope
+    /// `stream_attrs` blob for the streams it carries, so a worker reading only
+    /// this slice's segments produces the exact per-record view `RlogReader`
+    /// produces locally, and applies erasure identically per segment, whether or
+    /// not a stream's segments straddle two slices. The coordinator (see
+    /// [`crate::distrib::merge_log_records`]) re-orders and dedups; this path
+    /// never assumes a stream maps to one slice.
+    async fn run_slice_logs(
+        &self,
+        scope: Option<pb::fetch_request::Scope>,
+        budgets: Option<pb::Budgets>,
+        matchers: Vec<ravel_promql::LabelMatcher>,
+        erasure: Vec<crate::erasure::ErasurePredicate>,
+        window_start_ns: i64,
+        window_end_ns: i64,
+    ) -> Result<Vec<pb::FetchResponse>, (pb::status::Code, String)> {
+        let Some(log_fetcher) = self.log_fetcher.as_ref() else {
+            return Err((
+                pb::status::Code::Unsupported,
+                "distributed log fetch is not configured on this worker".to_string(),
+            ));
+        };
+
+        // Matcher pushdown for logs has no defined `LogQuery` mapping in this
+        // lane yet (that is the SQL lane / engine log-fetch wiring, out of
+        // #284's scope). Ignoring matchers would under-filter, so fail closed to
+        // the coordinator's local fallback rather than return a wrong result.
+        if !matchers.is_empty() {
+            return Err((
+                pb::status::Code::Unsupported,
+                "distributed log fetch does not support matcher pushdown yet".to_string(),
+            ));
+        }
+
+        let identities = match scope {
+            Some(pb::fetch_request::Scope::Pinned(pinned)) => pinned.segments,
+            Some(pb::fetch_request::Scope::Resolve(_)) | None => {
+                return Err((
+                    pb::status::Code::Unsupported,
+                    "resolve-scope slices are not supported yet".to_string(),
+                ));
+            }
+        };
+
+        let mut segments = Vec::with_capacity(identities.len());
+        for identity in &identities {
+            match self.resolver.resolve(identity) {
+                Some(seg) => segments.push(seg),
+                None => {
+                    return Err((
+                        pb::status::Code::SnapshotInvalidated,
+                        "pinned segment not found on worker".to_string(),
+                    ));
+                }
+            }
+        }
+
+        let byte_limit = match budgets.as_ref().map(|b| b.max_bytes_scanned) {
+            Some(0) | None => ByteLimit::Unlimited,
+            Some(max) => ByteLimit::Bounded(max),
+        };
+
+        // The slice's event-time window is the ts range for the fetch. The
+        // coordinator sets it to the envelope of this slice's pinned segments, a
+        // superset of every one of them, so the `TsRange` filter drops no record
+        // a local read (over the whole-snapshot window) would keep. Erasure is
+        // threaded through the same funnel, applied per segment after decode.
+        let query = LogQuery::new(window_start_ns, window_end_ns).with_erasure(erasure);
+
+        let accounting = QueryAccounting::new();
+        let mut records: Vec<ravel_logseg::LogRecord> = Vec::new();
+        // Logs carry no raw-f64 page counters (a metric-path concept), so
+        // `FetchStats` stays zero, exactly what a local log read reports.
+        let stats = FetchStats::default();
+        for seg in &segments {
+            let out = log_fetcher
+                .fetch_accounted(seg, &query, &accounting)
+                .await
+                .map_err(map_log_fetch_error)?;
+            if let Some(output) = out {
+                records.extend(output.records);
+            }
+            // Per-segment bytes-scanned short-circuit, matching the metric path
+            // and the local per-segment check. The terminal summary carries the
+            // spend so far so the coordinator folds this slice's real cost
+            // before failing the query.
+            if let Some(err) =
+                bytes_scanned_exceeded(accounting.snapshot().total_s3_bytes(), byte_limit)
+            {
+                return Ok(vec![summary_frame(
+                    &accounting.snapshot(),
+                    0,
+                    0,
+                    pb::status::Code::BudgetExceeded,
+                    err.to_string(),
+                    &stats,
+                )]);
+            }
+        }
+
+        let records_returned = records.len() as u64;
+        let mut frames = Vec::with_capacity(records.len() + 1);
+        for record in &records {
+            frames.push(pb::FetchResponse {
+                frame: Some(pb::fetch_response::Frame::LogRecord(
+                    codec::encode_log_record(record),
+                )),
+            });
+        }
+        // The record count rides the summary's `series_returned` field (reused
+        // per signal); `decode_log_slice_frames` reads it back as
+        // `records_returned`.
+        frames.push(summary_frame(
+            &accounting.snapshot(),
+            records_returned,
+            0,
+            pb::status::Code::Ok,
+            String::new(),
+            &stats,
+        ));
+        Ok(frames)
+    }
 }
 
 /// The stream type the generated trait requires: a boxed stream of already-
@@ -388,5 +558,20 @@ fn map_fetch_error(err: FetchError) -> (pb::status::Code, String) {
         FetchError::Store { .. } => (pb::status::Code::Unavailable, err.to_string()),
         FetchError::Corrupt { .. } => (pb::status::Code::Corrupt, err.to_string()),
         FetchError::EtagChanged { .. } => (pb::status::Code::Corrupt, err.to_string()),
+    }
+}
+
+/// Maps an RLOG fetch-path error to the worker's typed status, mirroring
+/// [`map_fetch_error`]: a vanished object is a snapshot invalidation
+/// (retryable), a transient store error is unavailable, and a corrupt object is
+/// terminal.
+fn map_log_fetch_error(err: LogFetchError) -> (pb::status::Code, String) {
+    match err {
+        LogFetchError::Store {
+            source: ravel_object_store::StoreError::NotFound,
+            ..
+        } => (pb::status::Code::SnapshotInvalidated, err.to_string()),
+        LogFetchError::Store { .. } => (pb::status::Code::Unavailable, err.to_string()),
+        LogFetchError::Corrupt { .. } => (pb::status::Code::Corrupt, err.to_string()),
     }
 }

--- a/crates/ravel-query/src/distrib/tests.rs
+++ b/crates/ravel-query/src/distrib/tests.rs
@@ -32,14 +32,21 @@ use tonic::transport::server::TcpIncoming;
 use tonic::transport::{Channel, Server};
 use uuid::Uuid;
 
+use ravel_logseg::writer::ObjectIdentity;
+use ravel_logseg::{AttrValue, LogRecord, RlogConfig, RlogWriter, stream_attrs_bytes};
+use ravel_types::logstream::{LogStreamId, log_stream_id};
+
 use crate::config::EngineConfig;
 use crate::distrib::Distributed;
 use crate::distrib::client::{DistribError, RemoteSliceFetcher, SliceFetcher, SliceResponse};
-use crate::distrib::partition::DistribThresholds;
-use crate::distrib::service::{SeriesFetchService, SnapshotSegmentResolver};
+use crate::distrib::partition::{DistribThresholds, partition_snapshot};
+use crate::distrib::{
+    merge_log_records, service::SeriesFetchService, service::SnapshotSegmentResolver,
+};
 use crate::engine::merge_soa_runs;
 use crate::erasure::ErasurePredicate;
 use crate::fetcher::SegmentFetcher;
+use crate::log_fetcher::{LogQuery, LogSegmentFetcher};
 
 const NS: i64 = 1_000_000;
 const TENANT: TenantHash = TenantHash([7u8; 16]);
@@ -165,9 +172,15 @@ async fn spawn_worker(
     store: Arc<MemoryStore>,
     segments: Vec<SegmentRef>,
 ) -> (RemoteSliceFetcher, JoinHandle<()>) {
+    // Wire both the metric and the RLOG-family fetch path over the same store,
+    // so one worker serves Metrics and Logs/Alerts/Audit slices.
+    let log_store: Arc<dyn ObjectStoreBackend> = Arc::clone(&store) as Arc<dyn ObjectStoreBackend>;
+    let log_fetcher = LogSegmentFetcher::new(log_store);
     let fetcher = SegmentFetcher::new(store);
     let resolver = Arc::new(SnapshotSegmentResolver::new(segments));
-    let service = SeriesFetchService::new(fetcher, resolver).into_server();
+    let service = SeriesFetchService::new(fetcher, resolver)
+        .with_log_fetcher(log_fetcher)
+        .into_server();
 
     let incoming = TcpIncoming::bind("127.0.0.1:0".parse().expect("addr")).expect("bind");
     let addr = incoming.local_addr().expect("local addr");
@@ -918,13 +931,12 @@ fn many_invalidated_slices_map_to_one_retryable_error() {
     });
 }
 
-/// ADR-0071 protocol: the worker validates `request.signal` before touching
-/// storage. A known non-metrics signal (logs, spans, ...) is answered with an
-/// `Unsupported` summary so the coordinator falls back to the local path, and
+/// ADR-0071 protocol: the worker dispatches on `request.signal` after decoding.
+/// A still-unimplemented distributed signal (Spans, until #285) is answered with
+/// an `Unsupported` summary so the coordinator falls back to the local path, and
 /// an unknown discriminant is `BadData` (a broken or newer peer, not a
-/// capability gap). Deleting the signal-validation block in `run_slice_inner`
-/// (`service.rs`) makes both requests fetch and return `Ok` scalar frames, and
-/// the status assertions below fail.
+/// capability gap). The RLOG family (Logs/Alerts/Audit) is now served (#284), so
+/// a Logs request reaches the real log path rather than a blanket rejection.
 #[test]
 fn worker_rejects_non_metrics_and_unknown_signals() {
     let rt = Runtime::new().expect("runtime");
@@ -961,6 +973,24 @@ fn worker_rejects_non_metrics_and_unknown_signals() {
             fragment_capability: Vec::new(),
         };
 
+        // Spans is still unimplemented (#285), so it must be Unsupported, not
+        // silently answered with metrics.
+        let spans = SliceFetcher::fetch(
+            &fetcher,
+            request(crate::distrib::codec::signal_to_u32(Signal::Spans)),
+        )
+        .await
+        .expect("worker responds to a spans request");
+        assert_eq!(
+            spans.status,
+            pb::status::Code::Unsupported,
+            "an unimplemented distributed signal must be Unsupported, not silently answered with metrics"
+        );
+
+        // Logs is now served (#284): the request reaches the real RLOG path.
+        // This RSEG-only corpus has no records in the [0,0] window, so the log
+        // fetcher skips it and the slice returns an empty Ok summary -- proving
+        // Logs is dispatched to a real path, not the former blanket rejection.
         let logs = SliceFetcher::fetch(
             &fetcher,
             request(crate::distrib::codec::signal_to_u32(Signal::Logs)),
@@ -969,8 +999,8 @@ fn worker_rejects_non_metrics_and_unknown_signals() {
         .expect("worker responds to a logs request");
         assert_eq!(
             logs.status,
-            pb::status::Code::Unsupported,
-            "a known non-metrics signal must be Unsupported, not silently answered with metrics"
+            pb::status::Code::Ok,
+            "the RLOG family is now served, not rejected"
         );
 
         let unknown = SliceFetcher::fetch(&fetcher, request(u32::MAX))
@@ -1035,9 +1065,11 @@ fn run_slice_inner_dispatches_on_signal_not_blanket_rejects() {
             fragment_capability: Vec::new(),
         };
 
-        // Logs and Spans reach the new stub branch: Unsupported, but with the
-        // distinct "not yet implemented" message the old code never produced.
-        for signal in [Signal::Logs, Signal::Spans] {
+        // Spans reaches the per-signal stub branch: Unsupported, but with the
+        // distinct "not yet implemented" message the old blanket code never
+        // produced. (Logs/Alerts/Audit are now served by #284, so they no longer
+        // take a stub branch; see the Logs assertion below.)
+        for signal in [Signal::Spans] {
             let resp = SliceFetcher::fetch(
                 &fetcher,
                 request(
@@ -1059,6 +1091,30 @@ fn run_slice_inner_dispatches_on_signal_not_blanket_rejects() {
                 resp.status_message
             );
         }
+
+        // Logs now dispatches to the real RLOG path (#284), no longer a stub. The
+        // RSEG-only corpus has no records in the [0,0] window, so the log fetcher
+        // skips it and the slice returns an empty Ok summary. The key point is
+        // that the status is not the "not yet implemented" stub.
+        let logs = SliceFetcher::fetch(
+            &fetcher,
+            request(
+                crate::distrib::codec::signal_to_u32(Signal::Logs),
+                TENANT.0.to_vec(),
+            ),
+        )
+        .await
+        .expect("worker responds to a logs request");
+        assert_eq!(
+            logs.status,
+            pb::status::Code::Ok,
+            "Logs is served by the real path, not the stub"
+        );
+        assert!(
+            !logs.status_message.contains("not yet implemented"),
+            "Logs must not take a stub branch, got {:?}",
+            logs.status_message
+        );
 
         // Structural proof the signal check now runs AFTER decoding: a Logs
         // request with a malformed tenant hash is BadData (decode failed), not
@@ -1330,6 +1386,561 @@ fn histogram_slice_falls_back_with_spend_folded() {
         assert!(
             accounting.snapshot().total_s3_bytes() > 0,
             "the worker's real spend must be folded into the query accounting before fallback"
+        );
+        server.abort();
+    });
+}
+
+// --- RLOG-family distributed fan-out (#284) --------------------------------
+//
+// The centerpiece is `assert_log_distributed_matches_local`: over a real
+// loopback worker, a distributed Logs/Alerts/Audit fetch merged by the
+// coordinator is bit-identical to a local `LogSegmentFetcher` read over the same
+// segments, merged under the same stated total order (`merge_log_records`),
+// including a corpus where one stream's segments straddle two slices (a
+// reshard-activation window). Both paths feed the same order-independent merge,
+// so the test proves the codec preserves every record and the partition is total
+// -- and, on the split corpus, that the coordinator ORDERS rather than
+// concatenates in slice order.
+
+/// Resource attributes and the derived stream identity/blob for a named
+/// service. Records sharing a service name share one `LogStreamId`, so a corpus
+/// can place one stream's records in segments under different shards (the
+/// reshard-straddle case).
+fn log_stream(service: &str) -> (LogStreamId, Vec<u8>) {
+    let resource = vec![(
+        "service.name".to_string(),
+        AttrValue::Str(service.to_string()),
+    )];
+    let id = log_stream_id(&resource, "scope", "1.0", &[]);
+    let blob = stream_attrs_bytes(&resource, "scope", "1.0", &[]);
+    (id, blob)
+}
+
+/// One log record on `service`'s stream at event time `ts`, with `body` and the
+/// given per-record string attributes.
+fn log_record(service: &str, ts: i64, body: &str, attrs: &[(&str, &str)]) -> LogRecord {
+    let (stream_id, stream_attrs) = log_stream(service);
+    LogRecord {
+        stream_id,
+        stream_attrs,
+        ts_ns: ts,
+        observed_ts_ns: ts,
+        severity_num: 9,
+        severity_text: "INFO".to_string(),
+        body: body.to_string(),
+        trace_id: None,
+        span_id: None,
+        flags: 0,
+        attrs: attrs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), AttrValue::Str((*v).to_string())))
+            .collect(),
+    }
+}
+
+/// Writes one RLOG object holding `records` under `shard`/`hour`, returning an
+/// L0 `SegmentRef` with a distinct content hash (blake3 of the bytes) so the
+/// worker's content-hash resolver keys each segment uniquely.
+async fn write_log_segment(
+    store: &MemoryStore,
+    key: u64,
+    shard: u32,
+    hour: u32,
+    records: &[LogRecord],
+) -> SegmentRef {
+    // Small blocks so a multi-block object is exercised; this never changes the
+    // record set returned.
+    let cfg = RlogConfig {
+        block_target_records: 3,
+        ..RlogConfig::default()
+    };
+    let identity = ObjectIdentity {
+        tenant_hash: TENANT.0,
+        shard,
+        writer_id: [2u8; 16],
+        writer_epoch: 1,
+        writer_seq: key,
+    };
+    let mut writer = RlogWriter::new(cfg, identity);
+    for r in records {
+        writer.push(r.clone()).expect("push record");
+    }
+    let bytes = writer.finish().expect("finish object");
+    let content_hash: [u8; 32] = *blake3::hash(&bytes).as_bytes();
+    let size = bytes.len() as u64;
+    let object_key = format!("logs/{key}.rlog");
+    store
+        .put(
+            &object_key,
+            bytes::Bytes::from(bytes),
+            PutOptions::default(),
+        )
+        .await
+        .expect("put log object");
+    let min = records.iter().map(|r| r.ts_ns).min().expect("nonempty");
+    let max = records.iter().map(|r| r.ts_ns).max().expect("nonempty");
+    SegmentRef {
+        data_object_key: object_key,
+        object_size: size,
+        min_event_ts_ns: min,
+        max_event_ts_ns: max,
+        ingest_hour_bucket: hour,
+        sample_count: records.len() as u64,
+        series_count: 0,
+        shard,
+        content_hash,
+        writer_id: Uuid::from_u128(u128::from(key) + 1),
+        writer_epoch: 1,
+        writer_seq: key,
+        created_unix_ns: 0,
+        level: SegmentLevel::L0,
+    }
+}
+
+/// The whole-snapshot event window: `[min over all segments, max over all]`, a
+/// superset of every segment's own span, so a local read over it prunes nothing.
+fn whole_window(segments: &[SegmentRef]) -> (i64, i64) {
+    let min = segments
+        .iter()
+        .map(|s| s.min_event_ts_ns)
+        .min()
+        .unwrap_or(i64::MIN);
+    let max = segments
+        .iter()
+        .map(|s| s.max_event_ts_ns)
+        .max()
+        .unwrap_or(i64::MAX);
+    (min, max)
+}
+
+/// The local reference for logs: read every segment with `LogSegmentFetcher`
+/// over the whole-snapshot window (a superset of each segment), then merge under
+/// the stated total order. This is exactly what a local multi-segment read
+/// produces.
+async fn local_log_records(
+    store: Arc<MemoryStore>,
+    segments: &[SegmentRef],
+    erasure: &[ErasurePredicate],
+) -> Vec<LogRecord> {
+    let fetcher = LogSegmentFetcher::new(store);
+    let (min, max) = whole_window(segments);
+    let query = LogQuery::new(min, max).with_erasure(erasure.to_vec());
+    let mut per_segment = Vec::with_capacity(segments.len());
+    for seg in segments {
+        let out = fetcher.fetch(seg, &query).await.expect("local log fetch");
+        per_segment.push(out.map(|o| o.records).unwrap_or_default());
+    }
+    merge_log_records(per_segment)
+}
+
+/// The distributed reference for logs: dispatch `signal` over a real loopback
+/// worker at width `cap`, merged by the coordinator's `fetch_logs`.
+async fn distributed_log_records(
+    store: Arc<MemoryStore>,
+    segments: Vec<SegmentRef>,
+    snapshot: &Snapshot,
+    signal: Signal,
+    erasure: &[ErasurePredicate],
+    cap: usize,
+) -> Vec<LogRecord> {
+    let (fetcher, server) = spawn_worker(store, segments).await;
+    let distributed = Distributed::new(
+        Arc::new(fetcher),
+        DistribThresholds {
+            min_store_bytes: 0,
+            min_segments: 0,
+            max_parallel_slices: cap,
+        },
+    );
+    let accounting = QueryAccounting::new();
+    let records = distributed
+        .fetch_logs(
+            TENANT,
+            signal,
+            snapshot,
+            &[],
+            erasure,
+            &accounting,
+            &EngineConfig::default(),
+            i64::MAX,
+        )
+        .await
+        .expect("distributed log fetch")
+        .expect("distributed produced a result (not a fallback)");
+    server.abort();
+    records
+}
+
+/// The split corpus: two segments under two DIFFERENT shards (a reshard-
+/// activation window), each carrying records of BOTH the `alpha` and `beta`
+/// streams. Because the corpus has exactly two shards, `cap = 2` puts each
+/// segment in its own slice (shard-major partitioning), so both streams straddle
+/// the two slices: `alpha`'s and `beta`'s records live on both sides. Their
+/// timestamps interleave across the two segments, so a coordinator that
+/// concatenated slice results in arrival order would misorder them.
+///
+/// Per-record `user_id`: u1 at ts {10, 15, 20}, u2 at ts {25, 30, 40}. Erasing
+/// u1 therefore leaves {25, 30, 40}, and the erased rows straddle the two slices.
+async fn split_stream_corpus(store: &MemoryStore) -> Vec<SegmentRef> {
+    // seg_a shard 0: alpha ts 10 (u1), 40 (u2); beta ts 15 (u1).
+    // seg_b shard 1: alpha ts 20 (u1), 30 (u2); beta ts 25 (u2).
+    // Global ts order 10,15,20,25,30,40 interleaves the two shards, so slice-order
+    // concatenation (all of seg_a's ts before all of seg_b's) is NOT sorted.
+    let seg_a = write_log_segment(
+        store,
+        0,
+        0,
+        100,
+        &[
+            log_record("alpha", 10, "a-early", &[("user_id", "u1")]),
+            log_record("alpha", 40, "a-late", &[("user_id", "u2")]),
+            log_record("beta", 15, "b-early", &[("user_id", "u1")]),
+        ],
+    )
+    .await;
+    let seg_b = write_log_segment(
+        store,
+        1,
+        1,
+        101,
+        &[
+            log_record("alpha", 20, "a-mid1", &[("user_id", "u1")]),
+            log_record("alpha", 30, "a-mid2", &[("user_id", "u2")]),
+            log_record("beta", 25, "b-mid", &[("user_id", "u2")]),
+        ],
+    )
+    .await;
+    vec![seg_a, seg_b]
+}
+
+/// Drives the per-signal differential: distributed == local, over both a
+/// single-slice (`cap = 1`) and a stream-straddling two-slice (`cap = 2`)
+/// partition of the same split corpus. On the two-slice case it also proves the
+/// corpus is discriminating: a naive concatenate-in-slice-order coordinator
+/// would emit an order the local read never produces, so the `sort_by` line in
+/// `merge_log_records` is the line under test.
+async fn run_log_differential(signal: Signal) {
+    let store = Arc::new(MemoryStore::new());
+    let segments = split_stream_corpus(&store).await;
+    let snapshot = Snapshot {
+        segments: segments.clone(),
+        segments_pruned: 0,
+        pending_erasure: Vec::new(),
+    };
+
+    // Single-slice: every segment in one slice. Distributed == local.
+    let local = local_log_records(Arc::clone(&store), &segments, &[]).await;
+    let one_slice = distributed_log_records(
+        Arc::clone(&store),
+        segments.clone(),
+        &snapshot,
+        signal,
+        &[],
+        1,
+    )
+    .await;
+    assert_eq!(
+        one_slice, local,
+        "{signal:?}: single-slice distributed must equal local"
+    );
+
+    // Two-slice straddle: confirm the partition genuinely places each segment in
+    // its own slice, so both streams' segments straddle two slices (not the easy
+    // single-slice case). One segment per slice, two slices, and each segment
+    // carries alpha and beta records, so both streams are split across slices.
+    let slices = partition_snapshot(&snapshot, 2);
+    assert_eq!(
+        slices.len(),
+        2,
+        "{signal:?}: the reshard-straddle corpus must produce two slices"
+    );
+    assert_eq!(
+        slices[0].segments.len(),
+        1,
+        "{signal:?}: slice 0 must hold exactly one segment, so the streams straddle"
+    );
+    assert_eq!(
+        slices[1].segments.len(),
+        1,
+        "{signal:?}: slice 1 must hold exactly one segment, so the streams straddle"
+    );
+
+    let two_slice = distributed_log_records(
+        Arc::clone(&store),
+        segments.clone(),
+        &snapshot,
+        signal,
+        &[],
+        2,
+    )
+    .await;
+    assert_eq!(
+        two_slice, local,
+        "{signal:?}: two-slice distributed must equal local even when a stream straddles slices"
+    );
+
+    // Prove-the-test: the naive wrong coordinator concatenates each slice's local
+    // read in slice order. On this corpus that order is observably NOT the global
+    // total order the correct merge produces, so the differential is not vacuous.
+    let ref_store: Arc<dyn ObjectStoreBackend> = Arc::clone(&store) as Arc<dyn ObjectStoreBackend>;
+    let ref_fetcher = LogSegmentFetcher::new(ref_store);
+    let (min, max) = whole_window(&segments);
+    let full = LogQuery::new(min, max);
+    let mut naive_ts = Vec::new();
+    for slice in &slices {
+        for seg in &slice.segments {
+            let out = ref_fetcher
+                .fetch(seg, &full)
+                .await
+                .expect("fetch")
+                .expect("in range");
+            naive_ts.extend(out.records.iter().map(|r| r.ts_ns));
+        }
+    }
+    let correct_ts: Vec<i64> = two_slice.iter().map(|r| r.ts_ns).collect();
+    assert_ne!(
+        naive_ts, correct_ts,
+        "{signal:?}: slice-order concatenation must differ from the correct merge, else the test is vacuous"
+    );
+    // The correct order is the globally sorted timestamps: 10,15,20,25,30,40.
+    assert_eq!(
+        correct_ts,
+        vec![10, 15, 20, 25, 30, 40],
+        "{signal:?}: the merge must emit the global cross-segment ts order"
+    );
+}
+
+#[test]
+fn logs_distributed_matches_local_including_reshard_straddle() {
+    let rt = Runtime::new().expect("runtime");
+    rt.block_on(run_log_differential(Signal::Logs));
+}
+
+#[test]
+fn alerts_distributed_matches_local_including_reshard_straddle() {
+    let rt = Runtime::new().expect("runtime");
+    rt.block_on(run_log_differential(Signal::Alerts));
+}
+
+#[test]
+fn audit_distributed_matches_local_including_reshard_straddle() {
+    let rt = Runtime::new().expect("runtime");
+    rt.block_on(run_log_differential(Signal::Audit));
+}
+
+/// A record present verbatim in two overlapping segments that land in two
+/// different slices is collapsed to one by the coordinator's record-identity
+/// dedup, matching a local read merged under the same rule. Pins the dedup /
+/// tie-break half of the stated invariant (the ordering half is pinned by
+/// `run_log_differential`).
+#[test]
+fn logs_coordinator_dedups_identical_record_across_slices() {
+    let rt = Runtime::new().expect("runtime");
+    rt.block_on(async {
+        let store = Arc::new(MemoryStore::new());
+        // The SAME record (same stream, ts, body, attrs) written into two
+        // segments under two shards -> two slices at cap 2.
+        let dup = log_record("gamma", 50, "dup", &[("k", "v")]);
+        let seg_a = write_log_segment(&store, 0, 0, 100, std::slice::from_ref(&dup)).await;
+        let seg_b = write_log_segment(&store, 1, 1, 100, std::slice::from_ref(&dup)).await;
+        let segments = vec![seg_a, seg_b];
+        let snapshot = Snapshot {
+            segments: segments.clone(),
+            segments_pruned: 0,
+            pending_erasure: Vec::new(),
+        };
+
+        let local = local_log_records(Arc::clone(&store), &segments, &[]).await;
+        assert_eq!(local.len(), 1, "local merge collapses the identical record");
+
+        let distributed = distributed_log_records(
+            Arc::clone(&store),
+            segments,
+            &snapshot,
+            Signal::Logs,
+            &[],
+            2,
+        )
+        .await;
+        assert_eq!(
+            distributed, local,
+            "the coordinator dedups the cross-slice duplicate to one record"
+        );
+        assert_eq!(distributed.len(), 1);
+    });
+}
+
+/// Worker-side erasure property: erasing rows by a per-record attribute against
+/// a distributed slice set equals a local read of the same segments erased the
+/// same way, including when the affected stream's segments straddle two slices.
+/// The worker applies erasure per segment through the same `LogSegmentFetcher`
+/// funnel the local path uses; correctness rests on segment self-containment,
+/// not slice atomicity (ADR-0071 amendment decision 5).
+///
+/// Note on "resource-only key": `ravel-query`'s erasure funnel
+/// (`retain_log_records`) evaluates PER-RECORD attributes only; merged-view
+/// (resource-attribute) exclusion is the SQL lane's residual (ADR-0064,
+/// `logs_provider`), out of #284's scope. So the row-removing case uses a
+/// per-record key (`user_id`), and a resource-only key is separately shown to be
+/// a consistent no-op through this funnel.
+#[test]
+fn logs_worker_applies_erasure_across_straddling_slices() {
+    let rt = Runtime::new().expect("runtime");
+    rt.block_on(async {
+        for cap in [1usize, 2] {
+            let store = Arc::new(MemoryStore::new());
+            let segments = split_stream_corpus(&store).await;
+            let snapshot = Snapshot {
+                segments: segments.clone(),
+                segments_pruned: 0,
+                pending_erasure: Vec::new(),
+            };
+
+            // Erase every row carrying user_id=u1. alpha's u1 rows are ts 10
+            // (slice 0) and ts 20 (slice 1), so the erased stream straddles
+            // slices at cap 2.
+            let erasure = vec![ErasurePredicate::windowless(vec![(
+                "user_id".to_string(),
+                "u1".to_string(),
+            )])];
+
+            let local = local_log_records(Arc::clone(&store), &segments, &erasure).await;
+            let distributed = distributed_log_records(
+                Arc::clone(&store),
+                segments.clone(),
+                &snapshot,
+                Signal::Logs,
+                &erasure,
+                cap,
+            )
+            .await;
+            assert_eq!(
+                distributed, local,
+                "cap {cap}: distributed erasure must equal local erasure over the same segments"
+            );
+            // The erasure genuinely removed the u1 rows (not a vacuous no-op),
+            // and did so across the straddling slices.
+            assert!(
+                distributed.iter().all(|r| !r
+                    .attrs
+                    .iter()
+                    .any(|(k, v)| k == "user_id" && *v == AttrValue::Str("u1".to_string()))),
+                "cap {cap}: no surviving row carries the erased user_id=u1"
+            );
+            let kept_ts: Vec<i64> = distributed.iter().map(|r| r.ts_ns).collect();
+            assert_eq!(
+                kept_ts,
+                vec![25, 30, 40],
+                "cap {cap}: exactly the u2 rows survive, in global ts order"
+            );
+        }
+    });
+}
+
+/// A resource-only attribute key erases nothing through this funnel (per-record
+/// attributes only), consistently in both paths -- the "resource-only" wording
+/// of the ADR's acceptance test, made a consistent no-op here. The row-removing
+/// straddle case above carries the real erasure property.
+#[test]
+fn logs_resource_only_erasure_key_is_a_consistent_no_op() {
+    let rt = Runtime::new().expect("runtime");
+    rt.block_on(async {
+        let store = Arc::new(MemoryStore::new());
+        let segments = split_stream_corpus(&store).await;
+        let snapshot = Snapshot {
+            segments: segments.clone(),
+            segments_pruned: 0,
+            pending_erasure: Vec::new(),
+        };
+        // `service.name` is a resource attribute (in `stream_attrs`), never a
+        // per-record attribute, so this funnel matches no row.
+        let erasure = vec![ErasurePredicate::windowless(vec![(
+            "service.name".to_string(),
+            "alpha".to_string(),
+        )])];
+
+        let baseline = local_log_records(Arc::clone(&store), &segments, &[]).await;
+        let local = local_log_records(Arc::clone(&store), &segments, &erasure).await;
+        assert_eq!(local, baseline, "resource-only key erases nothing locally");
+
+        let distributed = distributed_log_records(
+            Arc::clone(&store),
+            segments,
+            &snapshot,
+            Signal::Logs,
+            &erasure,
+            2,
+        )
+        .await;
+        assert_eq!(
+            distributed, baseline,
+            "resource-only key erases nothing distributed either (consistent no-op)"
+        );
+    });
+}
+
+/// A worker with no log fetcher wired returns `Unsupported` for a Logs slice, so
+/// the coordinator falls back to whole-query local execution (`Ok(None)`), never
+/// an error. This is the load-bearing skew direction (a not-yet-upgraded worker)
+/// exercised over the real wire.
+#[test]
+fn logs_worker_without_log_fetcher_signals_local_fallback() {
+    let rt = Runtime::new().expect("runtime");
+    rt.block_on(async {
+        let store = Arc::new(MemoryStore::new());
+        let segments = split_stream_corpus(&store).await;
+        let snapshot = Snapshot {
+            segments: segments.clone(),
+            segments_pruned: 0,
+            pending_erasure: Vec::new(),
+        };
+
+        // A worker WITHOUT `.with_log_fetcher(..)`: the metric path only.
+        let metric_store: Arc<dyn ObjectStoreBackend> =
+            Arc::clone(&store) as Arc<dyn ObjectStoreBackend>;
+        let metric_fetcher = SegmentFetcher::new(metric_store);
+        let resolver = Arc::new(SnapshotSegmentResolver::new(segments.clone()));
+        let service = SeriesFetchService::new(metric_fetcher, resolver).into_server();
+        let incoming = TcpIncoming::bind("127.0.0.1:0".parse().expect("addr")).expect("bind");
+        let addr = incoming.local_addr().expect("local addr");
+        let server = tokio::spawn(async move {
+            Server::builder()
+                .add_service(service)
+                .serve_with_incoming(incoming)
+                .await
+                .expect("serve");
+        });
+        let channel = Channel::from_shared(format!("http://{addr}"))
+            .expect("endpoint")
+            .connect_lazy();
+        let fetcher = RemoteSliceFetcher::new(channel);
+
+        let distributed = Distributed::new(
+            Arc::new(fetcher),
+            DistribThresholds {
+                min_store_bytes: 0,
+                min_segments: 0,
+                max_parallel_slices: 2,
+            },
+        );
+        let accounting = QueryAccounting::new();
+        let result = distributed
+            .fetch_logs(
+                TENANT,
+                Signal::Logs,
+                &snapshot,
+                &[],
+                &[],
+                &accounting,
+                &EngineConfig::default(),
+                i64::MAX,
+            )
+            .await
+            .expect("unsupported must not be an error");
+        assert!(
+            result.is_none(),
+            "a worker with no log fetcher signals whole-query local fallback (Ok(None))"
         );
         server.abort();
     });

--- a/crates/ravel-query/src/distrib/tests.rs
+++ b/crates/ravel-query/src/distrib/tests.rs
@@ -18,7 +18,11 @@
 use std::sync::Arc;
 
 use proptest::prelude::*;
+use ravel_cache::{Cache, CacheLimits};
 use ravel_catalog::{SegmentLevel, SegmentRef, Snapshot};
+use ravel_object_store::fault::{
+    FaultKind, FaultPlan, FaultStore, Occurrence, Op, Rule, ScriptedFault,
+};
 use ravel_object_store::memory::MemoryStore;
 use ravel_object_store::{ObjectStoreBackend, PutOptions};
 use ravel_promql::SeriesData;
@@ -41,7 +45,7 @@ use crate::distrib::Distributed;
 use crate::distrib::client::{DistribError, RemoteSliceFetcher, SliceFetcher, SliceResponse};
 use crate::distrib::partition::{DistribThresholds, partition_snapshot};
 use crate::distrib::{
-    merge_log_records, service::SeriesFetchService, service::SnapshotSegmentResolver,
+    log_record_order_key, service::SeriesFetchService, service::SnapshotSegmentResolver,
 };
 use crate::engine::merge_soa_runs;
 use crate::erasure::ErasurePredicate;
@@ -176,7 +180,18 @@ async fn spawn_worker(
     // so one worker serves Metrics and Logs/Alerts/Audit slices.
     let log_store: Arc<dyn ObjectStoreBackend> = Arc::clone(&store) as Arc<dyn ObjectStoreBackend>;
     let log_fetcher = LogSegmentFetcher::new(log_store);
-    let fetcher = SegmentFetcher::new(store);
+    let metrics_store: Arc<dyn ObjectStoreBackend> = store as Arc<dyn ObjectStoreBackend>;
+    spawn_worker_with_log_fetcher(metrics_store, log_fetcher, segments).await
+}
+
+/// `spawn_worker` with an explicitly built (possibly cache-wired) log fetcher, so
+/// a test can prove the worker's log path is cache-aware.
+async fn spawn_worker_with_log_fetcher(
+    metrics_store: Arc<dyn ObjectStoreBackend>,
+    log_fetcher: LogSegmentFetcher,
+    segments: Vec<SegmentRef>,
+) -> (RemoteSliceFetcher, JoinHandle<()>) {
+    let fetcher = SegmentFetcher::new(metrics_store);
     let resolver = Arc::new(SnapshotSegmentResolver::new(segments));
     let service = SeriesFetchService::new(fetcher, resolver)
         .with_log_fetcher(log_fetcher)
@@ -1393,15 +1408,18 @@ fn histogram_slice_falls_back_with_spend_folded() {
 
 // --- RLOG-family distributed fan-out (#284) --------------------------------
 //
-// The centerpiece is `assert_log_distributed_matches_local`: over a real
-// loopback worker, a distributed Logs/Alerts/Audit fetch merged by the
-// coordinator is bit-identical to a local `LogSegmentFetcher` read over the same
-// segments, merged under the same stated total order (`merge_log_records`),
-// including a corpus where one stream's segments straddle two slices (a
-// reshard-activation window). Both paths feed the same order-independent merge,
-// so the test proves the codec preserves every record and the partition is total
-// -- and, on the split corpus, that the coordinator ORDERS rather than
-// concatenates in slice order.
+// The centerpiece is `run_log_differential`: over a real loopback worker, a
+// distributed Logs/Alerts/Audit fetch merged by the coordinator equals, as a
+// multiset under the stated total order, a raw local `LogSegmentFetcher` read
+// over the same segments -- concatenated directly, NOT through
+// `merge_log_records`, so the reference is independent of the function under
+// test and the differential can actually catch a merge regression. This
+// includes a corpus where one stream's segments straddle two slices (a
+// reshard-activation window). The test proves the codec preserves every record
+// and the partition is total -- and, on the split corpus, that the coordinator
+// ORDERS rather than concatenates in slice order. Duplicate-record preservation
+// (no query-time dedup for logs) is pinned separately by
+// `logs_coordinator_preserves_duplicate_records_across_slices`.
 
 /// Resource attributes and the derived stream identity/blob for a named
 /// service. Records sharing a service name share one `LogStreamId`, so a corpus
@@ -1515,9 +1533,13 @@ fn whole_window(segments: &[SegmentRef]) -> (i64, i64) {
 }
 
 /// The local reference for logs: read every segment with `LogSegmentFetcher`
-/// over the whole-snapshot window (a superset of each segment), then merge under
-/// the stated total order. This is exactly what a local multi-segment read
-/// produces.
+/// over the whole-snapshot window (a superset of each segment) and concatenate
+/// the per-segment records directly, with NO merge or dedup. This is exactly the
+/// multiset of records a local multi-segment read observes, and it is
+/// deliberately independent of `merge_log_records` (the function under test) so
+/// the differential compares distributed output against a reference the function
+/// cannot influence. Callers compare via [`sorted_by_order_key`] as a multiset
+/// (duplicates preserved on both sides).
 async fn local_log_records(
     store: Arc<MemoryStore>,
     segments: &[SegmentRef],
@@ -1526,12 +1548,21 @@ async fn local_log_records(
     let fetcher = LogSegmentFetcher::new(store);
     let (min, max) = whole_window(segments);
     let query = LogQuery::new(min, max).with_erasure(erasure.to_vec());
-    let mut per_segment = Vec::with_capacity(segments.len());
+    let mut all = Vec::new();
     for seg in segments {
         let out = fetcher.fetch(seg, &query).await.expect("local log fetch");
-        per_segment.push(out.map(|o| o.records).unwrap_or_default());
+        all.extend(out.map(|o| o.records).unwrap_or_default());
     }
-    merge_log_records(per_segment)
+    all
+}
+
+/// Stable-sort a record multiset under the production total-order key, preserving
+/// duplicates. Applying this to both sides of a differential turns an
+/// order-sensitive `Vec` equality into a multiset equality under the stated
+/// order, without ever calling `merge_log_records`.
+fn sorted_by_order_key(mut records: Vec<LogRecord>) -> Vec<LogRecord> {
+    records.sort_by_key(log_record_order_key);
+    records
 }
 
 /// The distributed reference for logs: dispatch `signal` over a real loopback
@@ -1641,7 +1672,8 @@ async fn run_log_differential(signal: Signal) {
     )
     .await;
     assert_eq!(
-        one_slice, local,
+        sorted_by_order_key(one_slice),
+        sorted_by_order_key(local.clone()),
         "{signal:?}: single-slice distributed must equal local"
     );
 
@@ -1676,7 +1708,8 @@ async fn run_log_differential(signal: Signal) {
     )
     .await;
     assert_eq!(
-        two_slice, local,
+        sorted_by_order_key(two_slice.clone()),
+        sorted_by_order_key(local),
         "{signal:?}: two-slice distributed must equal local even when a stream straddles slices"
     );
 
@@ -1729,18 +1762,21 @@ fn audit_distributed_matches_local_including_reshard_straddle() {
     rt.block_on(run_log_differential(Signal::Audit));
 }
 
-/// A record present verbatim in two overlapping segments that land in two
-/// different slices is collapsed to one by the coordinator's record-identity
-/// dedup, matching a local read merged under the same rule. Pins the dedup /
-/// tie-break half of the stated invariant (the ordering half is pinned by
-/// `run_log_differential`).
+/// Two byte-identical records split across two segments/slices must BOTH survive
+/// the coordinator's merge. Per docs/consistency-model.md ("logs and spans"),
+/// logs/alerts/audit have NO query-time dedup: a retry after a lost ack produces
+/// byte-identical rows that are legitimately duplicate user data and must stay
+/// visible, so collapsing them is silent data loss. This is the focused
+/// minimal-repro for the dedup bug that shipped in #284 (`merge_log_records`
+/// applied the metric-path `(series_id, ts)` dedup where it is forbidden).
 #[test]
-fn logs_coordinator_dedups_identical_record_across_slices() {
+fn logs_coordinator_preserves_duplicate_records_across_slices() {
     let rt = Runtime::new().expect("runtime");
     rt.block_on(async {
         let store = Arc::new(MemoryStore::new());
         // The SAME record (same stream, ts, body, attrs) written into two
-        // segments under two shards -> two slices at cap 2.
+        // segments under two shards -> two slices at cap 2. A raw local read of
+        // the two segments returns TWO records; the distributed merge must too.
         let dup = log_record("gamma", 50, "dup", &[("k", "v")]);
         let seg_a = write_log_segment(&store, 0, 0, 100, std::slice::from_ref(&dup)).await;
         let seg_b = write_log_segment(&store, 1, 1, 100, std::slice::from_ref(&dup)).await;
@@ -1751,8 +1787,13 @@ fn logs_coordinator_dedups_identical_record_across_slices() {
             pending_erasure: Vec::new(),
         };
 
+        // Reference: a raw local read of both segments, independent of the merge.
         let local = local_log_records(Arc::clone(&store), &segments, &[]).await;
-        assert_eq!(local.len(), 1, "local merge collapses the identical record");
+        assert_eq!(
+            local.len(),
+            2,
+            "a raw local read of the two segments returns both duplicate records"
+        );
 
         let distributed = distributed_log_records(
             Arc::clone(&store),
@@ -1764,10 +1805,112 @@ fn logs_coordinator_dedups_identical_record_across_slices() {
         )
         .await;
         assert_eq!(
-            distributed, local,
-            "the coordinator dedups the cross-slice duplicate to one record"
+            distributed.len(),
+            2,
+            "the coordinator must preserve both cross-slice duplicate records, not collapse them"
         );
-        assert_eq!(distributed.len(), 1);
+        assert_eq!(
+            sorted_by_order_key(distributed),
+            sorted_by_order_key(local),
+            "the distributed result is the same multiset as the raw local read"
+        );
+    });
+}
+
+/// The worker's log fetch path is cache-aware: it goes through
+/// [`LogSegmentFetcher::fetch_accounted_with_tenant`] (ADR-0046's read cache),
+/// not the cache-blind `fetch_accounted`. Proven by wiring a cache into the
+/// worker's fetcher over a `FaultStore` that fails the SECOND store GET of the
+/// segment object. The first distributed fetch is a cache miss (one real GET,
+/// which populates the cache); the second must be served from the cache with no
+/// further GET, so the scripted second-GET fault never fires. With the
+/// cache-blind funnel the second fetch would GET again, trip the fault, and the
+/// coordinator would silently fall back to local -- exactly the wiring gap this
+/// fixes.
+#[test]
+fn logs_worker_serves_repeat_reads_from_the_read_cache() {
+    let rt = Runtime::new().expect("runtime");
+    rt.block_on(async {
+        // Write the segment, then wrap a snapshot of that store in a FaultStore.
+        let seed = MemoryStore::new();
+        let records = [
+            log_record("gamma", 10, "one", &[("k", "v")]),
+            log_record("gamma", 20, "two", &[("k", "v")]),
+        ];
+        let seg = write_log_segment(&seed, 0, 0, 100, &records).await;
+        let segments = vec![seg];
+        let snapshot = Snapshot {
+            segments: segments.clone(),
+            segments_pruned: 0,
+            pending_erasure: Vec::new(),
+        };
+
+        // Fail the SECOND GET of any object; the first (cache-miss) GET passes
+        // through and populates the cache.
+        let plan = FaultPlan::empty().with_rule(
+            Rule::new(
+                Op::Get,
+                ScriptedFault::Permanent(
+                    "second GET must not happen: cache should serve it".into(),
+                ),
+            )
+            .with_occurrence(Occurrence::Nth(2)),
+        );
+        let fault_store = Arc::new(FaultStore::new(seed, plan));
+        let cache: Arc<Cache<crate::fetcher::CacheFetchError>> = Arc::new(Cache::new(
+            CacheLimits::new(16 * 1024 * 1024, 100, 16 * 1024 * 1024),
+        ));
+        let log_store: Arc<dyn ObjectStoreBackend> =
+            Arc::clone(&fault_store) as Arc<dyn ObjectStoreBackend>;
+        let log_fetcher = LogSegmentFetcher::new(log_store).with_cache(cache);
+
+        // Metrics path is unused for a Logs signal; give it an empty store.
+        let metrics_store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+        let (fetcher, server) =
+            spawn_worker_with_log_fetcher(metrics_store, log_fetcher, segments).await;
+        let distributed = Distributed::new(
+            Arc::new(fetcher),
+            DistribThresholds {
+                min_store_bytes: 0,
+                min_segments: 0,
+                max_parallel_slices: 1,
+            },
+        );
+
+        let fetch = || async {
+            distributed
+                .fetch_logs(
+                    TENANT,
+                    Signal::Logs,
+                    &snapshot,
+                    &[],
+                    &[],
+                    &QueryAccounting::new(),
+                    &EngineConfig::default(),
+                    i64::MAX,
+                )
+                .await
+                .expect("distributed log fetch")
+                .expect("distributed produced a result (not a fallback)")
+        };
+
+        // Miss: one real GET populates the cache.
+        let first = fetch().await;
+        assert_eq!(first.len(), 2, "cache-miss fetch returns both records");
+
+        // Hit: served from the cache, so the scripted second GET never happens.
+        let second = fetch().await;
+        server.abort();
+        assert_eq!(
+            sorted_by_order_key(second),
+            sorted_by_order_key(first),
+            "cache-hit fetch returns the same records as the miss"
+        );
+        assert_eq!(
+            fault_store.fault_count(Op::Get, FaultKind::Permanent),
+            0,
+            "the second fetch must be served from the read cache, issuing no store GET"
+        );
     });
 }
 
@@ -1816,7 +1959,8 @@ fn logs_worker_applies_erasure_across_straddling_slices() {
             )
             .await;
             assert_eq!(
-                distributed, local,
+                sorted_by_order_key(distributed.clone()),
+                sorted_by_order_key(local),
                 "cap {cap}: distributed erasure must equal local erasure over the same segments"
             );
             // The erasure genuinely removed the u1 rows (not a vacuous no-op),
@@ -1862,7 +2006,11 @@ fn logs_resource_only_erasure_key_is_a_consistent_no_op() {
 
         let baseline = local_log_records(Arc::clone(&store), &segments, &[]).await;
         let local = local_log_records(Arc::clone(&store), &segments, &erasure).await;
-        assert_eq!(local, baseline, "resource-only key erases nothing locally");
+        assert_eq!(
+            sorted_by_order_key(local),
+            sorted_by_order_key(baseline.clone()),
+            "resource-only key erases nothing locally"
+        );
 
         let distributed = distributed_log_records(
             Arc::clone(&store),
@@ -1874,7 +2022,8 @@ fn logs_resource_only_erasure_key_is_a_consistent_no_op() {
         )
         .await;
         assert_eq!(
-            distributed, baseline,
+            sorted_by_order_key(distributed),
+            sorted_by_order_key(baseline),
             "resource-only key erases nothing distributed either (consistent no-op)"
         );
     });

--- a/crates/ravel-query/src/distrib/tests.rs
+++ b/crates/ravel-query/src/distrib/tests.rs
@@ -1787,6 +1787,17 @@ fn logs_coordinator_preserves_duplicate_records_across_slices() {
             pending_erasure: Vec::new(),
         };
 
+        // Confirm the two duplicate records genuinely land in two different
+        // slices, not the easy single-slice case where any merge would trivially
+        // preserve both.
+        let slices = partition_snapshot(&snapshot, 2);
+        assert_eq!(
+            slices.len(),
+            2,
+            "the two segments must partition into two slices for this to be a
+             cross-slice duplicate, not a within-slice one"
+        );
+
         // Reference: a raw local read of both segments, independent of the merge.
         let local = local_log_records(Arc::clone(&store), &segments, &[]).await;
         assert_eq!(
@@ -1824,9 +1835,10 @@ fn logs_coordinator_preserves_duplicate_records_across_slices() {
 /// segment object. The first distributed fetch is a cache miss (one real GET,
 /// which populates the cache); the second must be served from the cache with no
 /// further GET, so the scripted second-GET fault never fires. With the
-/// cache-blind funnel the second fetch would GET again, trip the fault, and the
-/// coordinator would silently fall back to local -- exactly the wiring gap this
-/// fixes.
+/// cache-blind funnel the second fetch would GET again and trip the fault; the
+/// worker then returns a hard error for that slice rather than silently
+/// substituting stale or partial data, and the coordinator surfaces it as a
+/// `QueryError::Distrib` -- exactly the wiring gap this fixes.
 #[test]
 fn logs_worker_serves_repeat_reads_from_the_read_cache() {
     let rt = Runtime::new().expect("runtime");

--- a/proto/ravel/queryfrag.proto
+++ b/proto/ravel/queryfrag.proto
@@ -191,14 +191,68 @@ message HistogramRun {
 // protocol_version bump, because skew is governed by the signal gate, not the
 // version field (an old worker returns Unsupported for signal=Logs, which the
 // coordinator maps to whole-query local fallback, so this frame can never
-// reach an old coordinator). The record payload grammar is deferred to the log
-// distribution ticket (#284); the field is reserved here as opaque bytes with
-// its number frozen, so adding the grammar is a decode-side change, not a wire
-// change, exactly as HistogramRun.span_payload reserves the histogram grammar.
+// reach an old coordinator).
+//
+// #284 defines the concrete grammar below. It carries one decoded
+// `ravel_logseg::LogRecord` field-for-field: the stream identity plus its
+// verbatim canonical resource+scope blob (`stream_attrs`, the STREAM_DIR bytes
+// every segment carrying the stream embeds -- this is what makes the
+// per-segment merged attribute view self-contained, so a worker ships exactly
+// what `RlogReader` produces locally and the coordinator never re-derives
+// attribute merging), the record's timestamps and content columns, and its
+// per-record attributes. That whole content is also the record's identity for
+// coordinator-side dedup: two frames are the same logical record iff every
+// field matches. Field 1 was a deferred opaque `bytes record_payload`
+// placeholder in #283; its number is retired (reserved) rather than reused
+// with a new type, per this file's frozen-field-number discipline. Every
+// field below is additive.
 message LogRecordFrame {
-  // Opaque encoded per-record merged view for this slice. Grammar deferred to
-  // #284; treated as an opaque blob by this contract.
-  bytes record_payload = 1;
+  reserved 1;                   // was the deferred opaque `bytes record_payload`
+
+  bytes stream_id = 2;          // 16 bytes; ravel_types LogStreamId
+  bytes stream_attrs = 3;       // canonical resource+scope blob, verbatim
+  sint64 ts_ns = 4;             // event time
+  sint64 observed_ts_ns = 5;    // observed (ingest) time
+  uint32 severity_num = 6;      // 0..=255 (u8 widened; a larger value is BadData)
+  string severity_text = 7;
+  string body = 8;
+  bytes trace_id = 9;           // 16 bytes when present, empty = absent
+  bytes span_id = 10;           // 8 bytes when present, empty = absent
+  uint32 flags = 11;
+  repeated LogAttr attrs = 12;  // per-record attributes, order preserved
+}
+
+// One per-record attribute: a key and its typed value. Mirrors one entry of
+// `ravel_logseg::LogRecord::attrs` (a `(String, AttrValue)` pair).
+message LogAttr {
+  string key = 1;
+  LogAttrValue value = 2;
+}
+
+// One OTLP attribute value, mirroring `ravel_types::logstream::AttrValue`
+// variant for variant. `f64` crosses as its raw `to_bits` pattern (fixed64),
+// never a proto double, so NaN payloads and -0.0 survive byte-for-byte, the
+// same bit-exactness the scalar `Run.value_bits` path guarantees.
+message LogAttrValue {
+  oneof value {
+    string str = 1;
+    sint64 int = 2;
+    fixed64 double_bits = 3;    // f64::to_bits
+    bool boolean = 4;
+    bytes bytes_val = 5;
+    LogAttrList list = 6;
+    LogAttrMap map = 7;
+  }
+}
+
+// A list attribute value (`AttrValue::List`).
+message LogAttrList {
+  repeated LogAttrValue items = 1;
+}
+
+// A map attribute value (`AttrValue::Map`): an ordered set of nested entries.
+message LogAttrMap {
+  repeated LogAttr entries = 1;
 }
 
 // One span frame for a slice of the Spans signal, carrying the worker's


### PR DESCRIPTION
Wire Logs, Alerts, and Audit through the fragment fan-out dispatch #283
added. The worker fetches pinned segments through LogSegmentFetcher and
ships each segment's already-merged resource/scope/record attribute
view verbatim, so the coordinator never re-derives attribute merging.

Add a structured LogRecordFrame to FetchResponse's oneof (field 4,
additive), carrying a decoded LogRecord field for field: stream id and
attrs, timestamps, severity, body, trace/span ids, flags, and a repeated
attribute list mirroring AttrValue's variants (f64 by bit pattern, so
NaN and -0.0 survive the wire).

The coordinator merge is defined on record identity and a stated total
order over every field, never on slice or shard arrival order: ADR-0052
online resharding can route the same log stream to different shard
indices across generations, so a stream's segments can straddle two
slices, and the merge has to be correct without assuming otherwise. It
does not dedup: logs, alerts, and audit have no query-time dedup per
docs/consistency-model.md, since a retry after a lost ack produces
legitimately duplicate rows that must stay visible.

Erasure runs worker-side, per segment, through the same funnel the
local path uses (LogSegmentFetcher's per-record erasure). Resource-view
(merged-attribute) erasure exclusion stays where it already lives, the
SQL lane, and is unaffected by this change; the worker ships the
merged attribute view faithfully so that lane's exclusion still applies
correctly to a distributed record.

SliceFetcher gains a defaulted fetch_logs method so no existing
implementor needs a matching change.

This wires the worker+coordinator machinery only. Nothing calls it with
a non-Metrics signal yet; the engine and SQL-lane callers are separate,
later tasks.

Refs: #63
Fixes: #284
