### PR TITLE
docs(adrs): claim ADR-0090

### DIFF
--- a/docs/adrs/0090-typed-attribute-columns-logs-sql.md
+++ b/docs/adrs/0090-typed-attribute-columns-logs-sql.md
@@ -1,0 +1,3 @@
+# ADR-0090: typed attribute columns for the logs SQL table
+
+Status: claimed


### PR DESCRIPTION
Reserves ADR-0090 for the typed attribute columns epic (#274) ahead of the design work.

Refs: #274