### PR TITLE
ci(coderabbit): verify the environment is protected, in band

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-# Code owners for the trusted CodeRabbit control plane (ADR-0090).
+# Code owners for the trusted CodeRabbit control plane (ADR-0091).
 #
 # Everything listed here decides who can cause a CodeRabbit API call, what
 # policy that call runs under, and what CodeRabbit is allowed to do to this
@@ -12,13 +12,20 @@
 # docs/guides/coderabbit-runbook.md. Until that is applied, treat these paths as
 # unprotected.
 #
-# Listed individually because NOFireAI/ravel has no maintainer team yet. Every
-# login below holds `admin` on this repository. Replace the list with
-# `@NOFireAI/ravel-maintainers` once that team exists and carries `maintain` or
-# `admin`; a team is reconciled in one place, a list drifts.
+# @NOFireAI/ravel-maintainers holds `maintain` on this repository. It is
+# currently a one-person team, so every change to a path below needs that one
+# person. That is a deliberate narrow gate on the CodeRabbit control plane, not
+# an accident, but it is also a bus factor of one: add members as the set of
+# people who should own these paths grows.
+#
+# The team is NOT the required reviewer on the `coderabbit-oss` environment, and
+# should not become it while it has one member: `prevent_self_review` would then
+# leave nobody able to approve a review that person started. The environment
+# keeps a list of individual maintainers for that reason.
 
-/.github/workflows/coderabbit-maintainer-review.yml @ananos @spirosoik @pmoust @alextoulps @safts @stylianosrigas @asapranidis
-/.github/coderabbit/                                @ananos @spirosoik @pmoust @alextoulps @safts @stylianosrigas @asapranidis
-/.coderabbit.yaml                                   @ananos @spirosoik @pmoust @alextoulps @safts @stylianosrigas @asapranidis
-/scripts/coderabbit-maintainer-review.sh            @ananos @spirosoik @pmoust @alextoulps @safts @stylianosrigas @asapranidis
-/.github/CODEOWNERS                                 @ananos @spirosoik @pmoust @alextoulps @safts @stylianosrigas @asapranidis
+/.github/workflows/coderabbit-maintainer-review.yml @NOFireAI/ravel-maintainers
+/.github/coderabbit/                                @NOFireAI/ravel-maintainers
+/.coderabbit.yaml                                   @NOFireAI/ravel-maintainers
+/scripts/coderabbit-maintainer-review.sh            @NOFireAI/ravel-maintainers
+/scripts/coderabbit-acceptance-tests.sh             @NOFireAI/ravel-maintainers
+/.github/CODEOWNERS                                 @NOFireAI/ravel-maintainers

--- a/.github/workflows/coderabbit-maintainer-review.yml
+++ b/.github/workflows/coderabbit-maintainer-review.yml
@@ -294,10 +294,10 @@ jobs:
           fi
           policy_names=$(jq -r '[.branch_policies[] | select(.type == "branch") | .name] | sort | join(",")' policies.json)
           policy_count=$(jq -r '.branch_policies | length' policies.json)
-          [ "$policy_names" = "$TRUSTED_BASE_BRANCH" ] && [ "$policy_count" = "1" ] || {
+          if [ "$policy_names" != "$TRUSTED_BASE_BRANCH" ] || [ "$policy_count" != "1" ]; then
             echo "::error::coderabbit-oss deployment branches are '${policy_names}' (${policy_count} entries), expected only ${TRUSTED_BASE_BRANCH}"
             fail=1
-          }
+          fi
 
           [ "$fail" = "0" ] || exit 1
           echo "coderabbit-oss: ${reviewers} required reviewer(s), self-review prevented, ${TRUSTED_BASE_BRANCH} only" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/coderabbit-maintainer-review.yml
+++ b/.github/workflows/coderabbit-maintainer-review.yml
@@ -25,9 +25,12 @@
 # the job keeps drive-by comments from starting a runner at all; it is a noise
 # filter, and it is never the decision.
 #
-# The workflow is inert until an administrator creates the `coderabbit-oss`
-# environment and its `CODERABBIT_API_KEY` secret. Without them the review job
-# cannot start. See docs/guides/coderabbit-runbook.md.
+# The `coderabbit-oss` environment must exist AND be protected before this can
+# spend anything. Note that referencing an environment that does not exist makes
+# GitHub create it, with no protection rules and no secrets, so the environment
+# existing proves nothing on its own. The `authorize` job therefore checks its
+# protection rules in band and fails closed, rather than trusting that setup
+# happened. See docs/guides/coderabbit-runbook.md.
 
 name: coderabbit-maintainer-review
 
@@ -249,6 +252,55 @@ jobs:
           fi
           echo "role_name=$actor_role" >> "$GITHUB_OUTPUT"
           echo "$ACTOR is $actor_role; triggered by $TRIGGERING_ACTOR" >> "$GITHUB_STEP_SUMMARY"
+
+      # GitHub creates an environment the first time a workflow names one, with
+      # no protection rules and no secrets. So "the environment exists" is not
+      # evidence that anyone configured it, and an administrator who later adds
+      # the key to that auto-created environment gets no reviewer gate and no
+      # branch restriction while everything looks set up. This asserts the rules
+      # are really there, every run, before the environment is requested.
+      #
+      # Verified on 2026-08-19 that the default GITHUB_TOKEN with
+      # `contents: read` can read both endpoints on this repository.
+      - name: Verify the protected environment is actually protected
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -Eeuo pipefail
+          umask 077
+          code=0
+          gh api "repos/${TRUSTED_REPOSITORY}/environments/coderabbit-oss" > env.json || code=$?
+          if [ "$code" != "0" ]; then
+            echo "::error::the coderabbit-oss environment could not be read; create and protect it per docs/guides/coderabbit-runbook.md"
+            exit 1
+          fi
+
+          fail=0
+          reviewers=$(jq '[.protection_rules[] | select(.type == "required_reviewers") | .reviewers // []] | flatten | length' env.json)
+          [ "$reviewers" -gt 0 ] || { echo "::error::coderabbit-oss has no required reviewers"; fail=1; }
+
+          self_review=$(jq -r '[.protection_rules[] | select(.type == "required_reviewers") | .prevent_self_review] | first // false' env.json)
+          [ "$self_review" = "true" ] || { echo "::error::coderabbit-oss does not prevent self-review"; fail=1; }
+
+          custom=$(jq -r '.deployment_branch_policy.custom_branch_policies // false' env.json)
+          protected_only=$(jq -r '.deployment_branch_policy.protected_branches // false' env.json)
+          [ "$custom" = "true" ] || { echo "::error::coderabbit-oss has no custom deployment branch policy"; fail=1; }
+          [ "$protected_only" = "false" ] || { echo "::error::coderabbit-oss admits every protected branch, not only ${TRUSTED_BASE_BRANCH}"; fail=1; }
+
+          gh api "repos/${TRUSTED_REPOSITORY}/environments/coderabbit-oss/deployment-branch-policies" > policies.json || code=$?
+          if [ "$code" != "0" ]; then
+            echo "::error::the coderabbit-oss deployment branch policies could not be read; failing closed"
+            exit 1
+          fi
+          policy_names=$(jq -r '[.branch_policies[] | select(.type == "branch") | .name] | sort | join(",")' policies.json)
+          policy_count=$(jq -r '.branch_policies | length' policies.json)
+          [ "$policy_names" = "$TRUSTED_BASE_BRANCH" ] && [ "$policy_count" = "1" ] || {
+            echo "::error::coderabbit-oss deployment branches are '${policy_names}' (${policy_count} entries), expected only ${TRUSTED_BASE_BRANCH}"
+            fail=1
+          }
+
+          [ "$fail" = "0" ] || exit 1
+          echo "coderabbit-oss: ${reviewers} required reviewer(s), self-review prevented, ${TRUSTED_BASE_BRANCH} only" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Check out trusted policy from main
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0

--- a/docs/adrs/0091-maintainer-gated-coderabbit-reviews.md
+++ b/docs/adrs/0091-maintainer-gated-coderabbit-reviews.md
@@ -509,10 +509,22 @@ Reviews stop being automatic. A maintainer dispatches the workflow, approves the
 environment, and gets one review of one revision. That is slower than the App,
 and it is the cost of the property.
 
-The workflow is inert until an administrator creates the `coderabbit-oss`
-environment and its secret. A dispatch before then fails at the environment
-gate. This is the intended shipping state: nothing can spend the allowance until
-someone with the authority to decide that has acted.
+The workflow cannot spend anything until an administrator creates the
+`coderabbit-oss` environment, protects it, and adds its secret. It is worth
+being precise about which of those is load-bearing, because an earlier draft of
+this ADR got it wrong: GitHub creates an environment the first time a workflow
+names one, with no protection rules and no secrets. So a dispatch before setup
+does not fail at a missing environment, it silently creates an unprotected one,
+and the run then fails on the missing key. The failure mode that leaves behind
+is an administrator adding the key to that auto-created environment and getting
+no reviewer gate and no branch restriction, with everything looking configured.
+
+The `authorize` job therefore verifies the environment's protection rules in
+band, on every run, and fails closed: required reviewers present, self-review
+prevented, a custom deployment branch policy naming exactly `main` and nothing
+else. Setup is asserted rather than assumed. Verified on 2026-08-19 that the
+default `GITHUB_TOKEN` with `contents: read` can read both the environments and
+the deployment-branch-policies endpoints on this repository.
 
 Three questions cannot be answered from a terminal and are named as runbook
 preconditions rather than assumed: whether the CodeRabbit organization backing

--- a/docs/guides/coderabbit-runbook.md
+++ b/docs/guides/coderabbit-runbook.md
@@ -48,6 +48,23 @@ The seven `admin` holders on `NOFireAI/ravel` today are `ananos`,
 `gh api repos/NOFireAI/ravel/collaborators --jq '.[] | select(.role_name == "admin" or .role_name == "maintain") | .login'`
 whenever CODEOWNERS or the environment reviewer list is touched.
 
+`@NOFireAI/ravel-maintainers` was created on 2026-08-19, holds `maintain` on
+this repository, and owns the trusted paths in `.github/CODEOWNERS`. It has one
+member, `pmoust`. Two consequences follow, and both are deliberate.
+
+Every change to the CodeRabbit control plane needs that one person's approval
+once step 5 is applied. That is a narrow gate on exactly the right paths, and a
+bus factor of one. Add members when the set of people who should own these paths
+grows; that is a one-line change and needs no code.
+
+The team is **not** a required reviewer on the `coderabbit-oss` environment, and
+must not become the only one while it has a single member. `prevent_self_review`
+would then leave nobody able to approve a review that person started, and every
+run would hang at the environment gate. The environment keeps individual
+reviewers for that reason. If the team grows past two members, moving the
+environment to the team is the better shape: it makes the six-reviewer cap stop
+binding and reconciles the list in one place.
+
 ---
 
 ## Step 1: verify the plan, before anything else
@@ -171,10 +188,11 @@ integration's primary operator and `prevent_self_review` already excludes them
 from approving their own dispatches, which makes their reviewer slot the one
 least often usable. Swap it with one API call if that is wrong.
 
-The cap is why a `@NOFireAI/ravel-maintainers` team is the better end state: a
-team counts as one reviewer entry, so the cap stops binding, and it also
-replaces the seven hardcoded logins in `.github/CODEOWNERS`. Reconcile the list
-against roles whenever they change.
+The cap is why a team is the better end state for the reviewer list: a team
+counts as one entry, so the cap stops binding. `@NOFireAI/ravel-maintainers`
+now exists and has replaced the hardcoded logins in `.github/CODEOWNERS`, but it
+has one member, so it is deliberately not the environment's reviewer yet. See
+"Who can change what" for why that ordering matters.
 
 To recreate this from scratch:
 

--- a/docs/guides/coderabbit-runbook.md
+++ b/docs/guides/coderabbit-runbook.md
@@ -10,10 +10,22 @@ Everything here was verified against CodeRabbit's and GitHub's documentation,
 the GitHub API for `NOFireAI/ravel`, and the CodeRabbit CLI binary, on
 **2026-08-19**.
 
-Read this first: **the integration is inert until step 3 is done.** No
-`coderabbit-oss` environment exists, so the review job cannot start and no
-credential exists to spend. That is deliberate. Do not create the environment
-until steps 1 and 2 pass.
+Read this first: **the integration cannot spend anything until the
+`coderabbit-oss` environment is protected and carries a secret.**
+
+Be precise about why, because the obvious reading is wrong. GitHub creates an
+environment the first time a workflow names one, with no protection rules and no
+secrets: "Running a workflow that references an environment that does not exist
+will create an environment with the referenced name." So a run before setup does
+not stop at a missing environment. It creates an unprotected one and then fails
+on the missing key.
+
+The trap that leaves is an administrator finding `coderabbit-oss` already there
+and simply adding the secret to it, which yields no reviewer gate and no branch
+restriction while looking configured. The `authorize` job closes it by checking
+the protection rules on every run and failing closed. **If you ever see
+`coderabbit-oss` with no required reviewers, it was auto-created. Protect it
+before adding anything to it.**
 
 ---
 
@@ -136,23 +148,51 @@ residual risk, or remove it. CodeRabbit's finest-grained chat control is
 13 `write` collaborators who are not maintainers, so that boundary is not a
 maintainer-only boundary here.
 
-## Step 3: create the protected environment
+## Step 3: create and protect the environment
 
 Only after step 1 passes.
 
-1. Repository settings, Environments, **New environment**, named exactly
-   `coderabbit-oss`.
-2. **Required reviewers**: add only current `maintain` or `admin` holders. Use
-   the reconciliation command in "Who can change what".
-3. **Prevent self-review**: on. A maintainer who dispatches the workflow must
-   not be able to approve their own deployment.
-4. **Deployment branches and tags**: *Selected branches and tags*, one rule,
-   exactly `main`. No wildcard, no tag rule.
-5. **Custom deployment protection rules**: none. Do not enable a third-party
-   protection app here.
-6. Add the secret **`CODERABBIT_API_KEY`** as an *environment* secret of
-   `coderabbit-oss`. Not a repository secret, not an organization secret, not a
-   variable.
+**Done on 2026-08-19**, with this state, which the `authorize` job now asserts
+on every run:
+
+- Required reviewers: `ananos`, `spirosoik`, `alextoulps`, `safts`,
+  `stylianosrigas`, `asapranidis`
+- Prevent self-review: on
+- Deployment branches: *Selected*, one rule, exactly `main`
+- Custom deployment protection rules: none
+- Secret: **not set**. Adding `CODERABBIT_API_KEY` is the remaining step, and it
+  waits on step 1.
+
+Two things to know about that reviewer list.
+
+GitHub caps required reviewers at **six**, and this repository has seven admins,
+so one had to be left out. It is `pmoust`, on the reasoning that they are the
+integration's primary operator and `prevent_self_review` already excludes them
+from approving their own dispatches, which makes their reviewer slot the one
+least often usable. Swap it with one API call if that is wrong.
+
+The cap is why a `@NOFireAI/ravel-maintainers` team is the better end state: a
+team counts as one reviewer entry, so the cap stops binding, and it also
+replaces the seven hardcoded logins in `.github/CODEOWNERS`. Reconcile the list
+against roles whenever they change.
+
+To recreate this from scratch:
+
+```sh
+gh api --method PUT repos/NOFireAI/ravel/environments/coderabbit-oss --input - <<'JSON'
+{"wait_timer":0,"prevent_self_review":true,
+ "reviewers":[{"type":"User","id":678645},{"type":"User","id":812075},
+              {"type":"User","id":4415924},{"type":"User","id":14074326},
+              {"type":"User","id":14320113},{"type":"User","id":149146140}],
+ "deployment_branch_policy":{"protected_branches":false,"custom_branch_policies":true}}
+JSON
+gh api --method POST repos/NOFireAI/ravel/environments/coderabbit-oss/deployment-branch-policies \
+  -f name=main -f type=branch
+```
+
+Then add the secret **`CODERABBIT_API_KEY`** as an *environment* secret of
+`coderabbit-oss`. Not a repository secret, not an organization secret, not a
+variable.
 
 Verify:
 
@@ -328,7 +368,8 @@ identities available for the `write` cases.
 | 19 | Rate limit does not fall through to paid usage | Exhaust the hourly CLI allowance, then dispatch | Job summary: "CodeRabbit declined this review". No retry, no credit, exit success. Confirm the CodeRabbit usage page shows no credit spend | I + M |
 | 20 | Oversized PR does not trigger on-demand billing or partitioned reviews | Dispatch against a PR exceeding the plan's per-review file limit | One call, one declining message, no split, no matrix, no credit spend. Confirm on the CodeRabbit usage page | I + M |
 | 21 | Key absent from logs, outputs, caches, artifacts | Read the full run log; check `gh run view <id> --log` for the key; confirm no `upload-artifact` and no cache step exists | The key appears nowhere. It is referenced by exactly one step, passed as an argument to one process, and the runner state is scrubbed afterwards | I |
-| 22 | Non-`main` ref cannot reach the environment | Push a branch carrying a modified copy of the workflow and dispatch it on that ref | Rejected twice over: the "Assert trusted control plane" step fails on the ref, and the environment's deployment branch policy admits only `main` | I + M |
+| 22 | Non-`main` ref cannot reach the environment | Push a branch carrying a modified copy of the workflow and dispatch it on that ref | Rejected three times over: "Assert trusted control plane" fails on the ref, the in-band guard requires the deployment branch policy to name exactly `main`, and GitHub itself refuses the deployment | I |
+| 24 | An unprotected environment is refused | Remove the required reviewers from `coderabbit-oss` (or let a run auto-create a fresh one), then dispatch | "Verify the protected environment is actually protected" fails before the environment is requested. Covered offline by `scripts/coderabbit-acceptance-tests.sh` section E3, which exercises the shipped guard against a rules-less environment, self-review left on, an any-protected-branch policy, a wildcard branch, an extra branch, and an unreadable environment | I |
 | 23 | Disabling stops all activity without touching Ravel CI | Follow [Rollback](#rollback) on a scratch schedule and observe | No CodeRabbit review can be produced. `ci`, `publish-images`, `bench-s3`, `k8s-nightly`, `sim-nightly`, and `quickstart-published` are untouched: no file of theirs changes and no required check is removed | I |
 
 Cases 1 to 5, 7, 8, 12, 16, and 18, and the policy and cost-control assertions
@@ -537,6 +578,14 @@ never the decision: MEMBER and COLLABORATOR are both far wider than maintainer.
 A determined abuser is answered by revoking their access; there is no
 workflow-level fix, because GitHub does not expose the trigger permission this
 design would want.
+
+**Every comment in the repository now produces a workflow run record.**
+`issue_comment` has no body or path filter at the trigger level, so GitHub
+queues a run for each comment on every issue and pull request, and the
+pre-filter skips the jobs. A skipped job allocates no runner and consumes no
+minutes, so the cost is Actions-tab noise rather than money. Filter with
+`gh run list --workflow coderabbit-maintainer-review.yml --json conclusion` and
+ignore the `skipped` ones.
 
 **The acknowledgement job holds `issues: write`.** That scope can comment on
 issues, not only react to them. It is confined to a job that runs after

--- a/env.json
+++ b/env.json
@@ -1,0 +1,3 @@
+{"protection_rules":[{"type":"required_reviewers","prevent_self_review":true,
+ "reviewers":[{"reviewer":{"login":"a"}},{"reviewer":{"login":"b"}}]},{"type":"branch_policy"}],
+ "deployment_branch_policy":{"protected_branches":false,"custom_branch_policies":true}}

--- a/policies.json
+++ b/policies.json
@@ -1,0 +1,1 @@
+{"total_count":0,"branch_policies":[]}

--- a/scripts/coderabbit-acceptance-tests.sh
+++ b/scripts/coderabbit-acceptance-tests.sh
@@ -258,6 +258,71 @@ rc=0; grep -q "if: success() && github.event_name == 'issue_comment'" "$WORKFLOW
 check "$rc" "acknowledgement happens only after authorization succeeds"
 
 # ---------------------------------------------------------------------------
+section "E3. The environment-protection guard, running the shipped shell"
+# ---------------------------------------------------------------------------
+# GitHub creates an environment the first time a workflow names one, with no
+# protection rules and no secrets, so the guard has to assert the rules rather
+# than assume setup happened.
+python3 "${POLICY_DIR}/extract-run-block.py" "$WORKFLOW" \
+  "Verify the protected environment is actually protected" > "${tmp_root}/envguard.sh"
+
+env_bin="${tmp_root}/envbin"
+mkdir -p "$env_bin"
+cat > "${env_bin}/gh" <<'MOCK'
+#!/usr/bin/env bash
+target=""
+for a in "$@"; do case "$a" in repos/*) target="$a";; esac; done
+case "$target" in
+  */deployment-branch-policies) cat "${MOCK_POLICIES:?}" ;;
+  */environments/coderabbit-oss) if [ "${MOCK_ENV_MISSING:-0}" = "1" ]; then exit 1; fi; cat "${MOCK_ENV:?}" ;;
+esac
+MOCK
+chmod +x "${env_bin}/gh"
+
+good_env="${tmp_root}/env-good.json"
+cat > "$good_env" <<'JSON'
+{"protection_rules":[{"type":"required_reviewers","prevent_self_review":true,
+ "reviewers":[{"reviewer":{"login":"a"}},{"reviewer":{"login":"b"}}]},{"type":"branch_policy"}],
+ "deployment_branch_policy":{"protected_branches":false,"custom_branch_policies":true}}
+JSON
+good_pol="${tmp_root}/pol-good.json"
+echo '{"total_count":1,"branch_policies":[{"name":"main","type":"branch"}]}' > "$good_pol"
+
+env_case() {
+  local label="$1" expected="$2" envfile="$3" polfile="$4" missing="${5:-0}" rc=0
+  MOCK_ENV="$envfile" MOCK_POLICIES="$polfile" MOCK_ENV_MISSING="$missing" \
+    PATH="${env_bin}:${PATH}" TRUSTED_REPOSITORY="NOFireAI/ravel" \
+    TRUSTED_BASE_BRANCH="main" GITHUB_STEP_SUMMARY="${tmp_root}/sum.txt" \
+    bash "${tmp_root}/envguard.sh" > /dev/null 2>&1 || rc=$?
+  if [ "$expected" = "accept" ]; then
+    check "$([ "$rc" = "0" ] && echo 0 || echo 1)" "$label"
+  else
+    check "$([ "$rc" != "0" ] && echo 0 || echo 1)" "$label"
+  fi
+}
+
+env_case "a fully protected environment passes" accept "$good_env" "$good_pol"
+env_case "a missing or unreadable environment fails closed" deny "$good_env" "$good_pol" 1
+
+printf '%s' '{"protection_rules":[{"type":"branch_policy"}],"deployment_branch_policy":{"protected_branches":false,"custom_branch_policies":true}}' > "${tmp_root}/env-noreviewers.json"
+env_case "an auto-created environment with no rules is rejected" deny "${tmp_root}/env-noreviewers.json" "$good_pol"
+
+printf '%s' '{"protection_rules":[{"type":"required_reviewers","prevent_self_review":false,"reviewers":[{"reviewer":{"login":"a"}}]},{"type":"branch_policy"}],"deployment_branch_policy":{"protected_branches":false,"custom_branch_policies":true}}' > "${tmp_root}/env-selfreview.json"
+env_case "self-review left enabled is rejected" deny "${tmp_root}/env-selfreview.json" "$good_pol"
+
+printf '%s' '{"protection_rules":[{"type":"required_reviewers","prevent_self_review":true,"reviewers":[{"reviewer":{"login":"a"}}]}],"deployment_branch_policy":{"protected_branches":true,"custom_branch_policies":false}}' > "${tmp_root}/env-anyprotected.json"
+env_case "any-protected-branch policy is rejected" deny "${tmp_root}/env-anyprotected.json" "$good_pol"
+
+echo '{"total_count":2,"branch_policies":[{"name":"main","type":"branch"},{"name":"release/*","type":"branch"}]}' > "${tmp_root}/pol-extra.json"
+env_case "an extra deployment branch is rejected" deny "$good_env" "${tmp_root}/pol-extra.json"
+
+echo '{"total_count":1,"branch_policies":[{"name":"*","type":"branch"}]}' > "${tmp_root}/pol-wildcard.json"
+env_case "a wildcard deployment branch is rejected" deny "$good_env" "${tmp_root}/pol-wildcard.json"
+
+echo '{"total_count":0,"branch_policies":[]}' > "${tmp_root}/pol-empty.json"
+env_case "no deployment branch policy is rejected" deny "$good_env" "${tmp_root}/pol-empty.json"
+
+# ---------------------------------------------------------------------------
 section "F. Output handling (case 18)"
 # ---------------------------------------------------------------------------
 hostile="${tmp_root}/hostile.jsonl"


### PR DESCRIPTION
Two follow-ups to #298, one of them a correction.

## The environment guard

ADR-0091 claimed the workflow was inert until an administrator created the
`coderabbit-oss` environment. That was wrong, and the way it was wrong matters.

GitHub creates an environment the first time a workflow names one, with no
protection rules and no secrets: "Running a workflow that references an
environment that does not exist will create an environment with the referenced
name." So a run before setup does not stop at a missing environment. It creates
an unprotected one and then fails on the missing key.

The failure that leaves behind is an administrator finding `coderabbit-oss`
already there, adding the key to it, and ending up with no reviewer gate and no
branch restriction while everything looks configured.

The `authorize` job now reads the environment on every run and fails closed
unless it has required reviewers, prevents self-review, and carries a custom
deployment branch policy naming exactly `main` and nothing else. Setup is
asserted rather than assumed.

Whether the default `GITHUB_TOKEN` could read those endpoints was verified on
this repository before the guard was written, not assumed: with only
`contents: read`, both `environments/{name}` and its
`deployment-branch-policies` return 200. Had they not, this guard would have
bricked the feature on every run.

## The maintainers team

`.github/CODEOWNERS` listed seven logins because no maintainer team existed.
`@NOFireAI/ravel-maintainers` now does, holds `maintain` on this repository, and
owns the trusted CodeRabbit paths, including the acceptance-test script that the
original list missed. A team is reconciled in one place; a list of logins drifts
as roles change.

It has one member today, so every change to the control plane needs that one
approval once `protect-main` requires a code-owner review. That is the intended
gate on these paths and also a bus factor of one.

The team is deliberately **not** the required reviewer on the `coderabbit-oss`
environment. With one member, `prevent_self_review` would leave nobody able to
approve a review that person started, and every run would hang at the
environment gate. The environment keeps individual reviewers until the team is
large enough for its members to approve each other. Both the runbook and the
CODEOWNERS header record that, so it does not get "tidied" later.

## Verification

- `scripts/coderabbit-acceptance-tests.sh`: 135 checks pass, up from 127. The
  eight new ones run the shipped guard against a rules-less environment,
  self-review left enabled, an any-protected-branch policy, a wildcard branch,
  an extra branch, and an unreadable environment.
- `actionlint`, `shellcheck`, and `scripts/check-doc-drift.sh` clean.

## Repository state this depends on

Already applied: the `coderabbit-oss` environment exists with six required
reviewers, self-review prevented, and `main` as its only deployment branch. It
holds no secret.

Still outstanding, and the security property does not hold without the first
one:

1. `protect-main` needs `require_code_owner_review: true` and at least one
   required approval. Until then CODEOWNERS only requests review of the trusted
   paths, and a `write` user can still merge a change to them.
2. Runbook step 1, the CodeRabbit plan checks, which decide whether the
   Actions path is used at all or whether the local fallback is the whole
   integration.
3. `CODERABBIT_API_KEY` on the environment.

Refs: #298
