### PR TITLE
docs: add traces guide and spans SQL reference

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,0 +1,47 @@
+# Progress
+
+This file records delivered epics: what shipped and what was deliberately left
+out. It complements [CHANGELOG.md](CHANGELOG.md), which tracks releases; this
+file tracks the larger bodies of work behind them.
+
+## Epic #8: RSPAN v2/v3/v4 trace investigation
+
+Turned RSPAN from a correct span storage format into a span investigation
+format, and made the `spans` SQL table reachable. Design in
+[ADR-0041](docs/adrs/0041-rspan-v1-span-segment-format.md),
+[ADR-0045](docs/adrs/0045-rspan-v2-trace-investigation.md), and
+[ADR-0054](docs/adrs/0054-rspan-v3-bloom-and-service-name.md); on-disk layout in
+[docs/span-segment-format.md](docs/span-segment-format.md); the query surface in
+[docs/guides/traces.md](docs/guides/traces.md) and the `spans` section of
+[docs/query-engine.md](docs/query-engine.md).
+
+Shipped:
+
+- **RSPAN v2 skip-index fields.** Per block, `min/max_duration_ns` and a
+  one-byte `status_mask`. A `duration_ns` window or a `status_code` predicate
+  now prunes blocks.
+- **RSPAN v3 bloom and service name.** A per-block BLOOM section over
+  `service.name` and span `name` tokens, and a block-local `service_name`
+  column lifted out of the `attrs` map. `service_name = '...'` and `name =
+  '...'` now prune by bloom membership.
+- **RSPAN v4 attribute columns and span events.** Per-key typed attribute
+  columns with an overflow that stays scan-queryable, and span events as nested
+  columns (including exception stack traces) rather than an opaque blob.
+- **Ranged RSPAN reads.** A range reader so span compaction no longer decodes
+  every input object whole into memory.
+- **The `spans` SQL table.** Registered on `POST /api/v1/sql` alongside
+  `samples` and `logs`, under the same one-signal-per-query rule. Widen-only
+  pushdown for `trace_id`, time window, `duration_ns` (computed, not stored),
+  `status_code`, `service_name`, and `name`.
+
+Deliberately not shipped:
+
+- **Span links stay unstored.** A link to a span in another trace is out of
+  RSPAN scope. It will get its own design decision when a query needs it
+  (ADR-0045).
+- **Span postings.** Attribute-equality pruning over span attributes, analogous
+  to RLOG POSTINGS (ADR-0049), is a separate, undecided epic with its own cost
+  model. It follows the log postings work; its absence is not a gap in this
+  epic. Until then, an `attrs['k'] = 'v'` predicate on `spans` is evaluated
+  exactly as a residual and prunes no blocks.
+</content>

--- a/README.md
+++ b/README.md
@@ -170,7 +170,9 @@ All query endpoints live under `/api/v1` on the HTTP listener, which binds
 `127.0.0.1:4318` by default. They need `Authorization: Bearer <token>`, the same
 as ingest. The [query guide](docs/guides/query.md) and the
 [distributed query guide](docs/guides/distributed-query.md) cover PromQL, SQL,
-Flight SQL, exemplars, alerting, and analytics.
+Flight SQL, exemplars, alerting, and analytics. The
+[traces guide](docs/guides/traces.md) covers querying spans over the `spans`
+SQL table.
 
 ## Kubernetes
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,11 @@ Start here to run Ravel, ingest into it, or query it.
 - [guides/query.md](guides/query.md): the five `/api/v1` endpoints, the
   supported PromQL subset, query budgets, and HTTP status codes. Read this
   to read data back out.
+- [guides/traces.md](guides/traces.md): querying spans over the `spans` SQL
+  table (ADR-0045) -- how Ravel stores spans, why a trace-by-id lookup is a
+  bounded scan of one shard, the table schema, which predicates prune at the
+  skip-index and bloom levels, worked queries, and what an incomplete trace is.
+  Read this to investigate traces.
 - [guides/distributed-query.md](guides/distributed-query.md): distributed read
   fan-out and cross-cluster federation (ADR-0071) for operators -- the cost gate
   and its two thresholds, `--distributed-query` and the fragment token file, the

--- a/docs/guides/traces.md
+++ b/docs/guides/traces.md
@@ -1,0 +1,193 @@
+# Querying traces
+
+Ravel stores every span in RSPAN objects and serves them through the `spans`
+SQL table. This guide explains how spans are stored, why a single trace is a
+bounded read, how to query the `spans` table, and what "incomplete trace"
+means. Read the [query guide](query.md) first for the shared `POST /api/v1/sql`
+mechanics; this guide covers only what is specific to spans.
+
+## How Ravel stores spans
+
+A span is one record in an RSPAN segment object. Object storage is the only
+durable copy. Records in a segment sort by `(trace_id, start_ts)`, so all spans
+of one trace occupy a contiguous run of blocks. Each object carries a skip
+index that holds, per block, the block's `trace_id` range, its time interval
+(`start_ts` minimum and `end_ts` maximum), its `duration_ns` range, and a
+one-byte `status_mask`. RSPAN v3 objects also carry a BLOOM section with a
+per-block bloom filter over the tokens of `service.name` and span `name`, plus a
+block-local `service_name` column. The reader uses these structures to skip
+blocks that cannot match a query.
+
+This guide does not repeat the on-disk layout. The full, normative spec is
+[docs/span-segment-format.md](../span-segment-format.md). Read it to change the
+format; read this guide to query it.
+
+## Why one trace is a bounded read
+
+Ingest routes each span to a shard by its `trace_id`. The router hashes the
+`trace_id` with BLAKE3 and picks the shard from the hash. A `trace_id` alone
+picks the shard, so all spans of one trace land on the same shard, and within
+that shard's objects they sort together into a contiguous block run. A lookup by
+`trace_id` is therefore a bounded scan of one shard, not a fan-out across every
+shard. The skip index prunes it further: it drops every block whose `trace_id`
+range excludes the target, so the reader decodes only the blocks that can hold
+the trace.
+
+One caveat applies. ADR-0052 online resharding can move a tenant to a new shard
+count while spans are still arriving. A trace whose spans straddle a reshard
+activation can split across two shards. This is rare and is covered in depth in
+the resharding documentation; a trace-by-id query still returns every stored
+span, it just reads two shards instead of one.
+
+## The `spans` table
+
+`POST /api/v1/sql` serves three tables from one endpoint: `samples`
+(metrics), `logs`, and `spans`. Each query targets exactly one table. Ravel
+decides the target from the query's `FROM` clause before planning and rejects a
+query that names two real tables. This matches the one-signal-per-query rule the
+`samples` and `logs` tables already follow.
+
+The `spans` table has these columns:
+
+| column           | type                          | notes                                        |
+|------------------|-------------------------------|----------------------------------------------|
+| `trace_id`       | `FixedSizeBinary(16)`         | trace identity, never null                   |
+| `span_id`        | `FixedSizeBinary(8)`          | span identity, never null                    |
+| `parent_span_id` | `FixedSizeBinary(8)`          | null on a root span                          |
+| `name`           | `Utf8`                        | span (operation) name                        |
+| `start_ts`       | `Timestamp(ns)`               | span start                                   |
+| `end_ts`         | `Timestamp(ns)`               | span end                                     |
+| `status_code`    | `UInt8`                       | `0` Unset, `1` Ok, `2` Error                 |
+| `status_message` | `Utf8`                        | null when the span set no message            |
+| `attrs`          | `Map(Utf8, Utf8)`             | merged resource, scope, and span attributes  |
+| `service_name`   | `Utf8`                        | from `attrs["service.name"]`, null when absent |
+| `duration_ns`    | `Int64`                       | computed `end_ts - start_ts`, never stored   |
+
+`status_code` is the stored OTLP byte. To read it as text, map the three values
+in SQL, for example `CASE status_code WHEN 0 THEN 'Unset' WHEN 1 THEN 'Ok' WHEN
+2 THEN 'Error' END`.
+
+`duration_ns` is a computed column, not a stored one. It is exactly `end_ts -
+start_ts`, and both endpoints are already stored, so Ravel exposes the
+difference as a column rather than writing it to every row. You query it like
+any other column (`WHERE duration_ns > 5e8`); the reader answers it from each
+block's stored duration range.
+
+### Which predicates prune
+
+All pruning is widen-only. DataFusion always re-applies the original `WHERE`
+predicate above the scan, so a query never returns a wrong row. Pruning only
+decides which blocks the reader decodes; it never decides which rows the query
+returns. A predicate the reader cannot prune with is still evaluated exactly, it
+just reads more blocks.
+
+These predicates prune at the skip-index level:
+
+- `trace_id = <literal>` selects the trace fast path. The literal is a 16-byte
+  binary or a 32-character hex string. The reader drops every block whose
+  `trace_id` range excludes the target.
+- `start_ts` and `end_ts` range comparisons (`>=`, `>`, `<`, `<=`, `=`, and
+  `BETWEEN`) fold into one time window. The reader drops every block whose time
+  interval does not overlap it.
+- `duration_ns` range comparisons fold into a duration window. The reader drops
+  every block whose stored `duration_ns` range does not overlap it.
+- `status_code = <literal>` (and `status_code IN (...)`, and a same-axis `OR`
+  of `status_code` equalities) maps to status bits. The reader drops every
+  block whose `status_mask` clears every requested bit. A `status_code = 2`
+  query skips every block with no Error span.
+
+These predicates prune at the bloom level (RSPAN v3):
+
+- `service_name = <literal>` probes the block's `service.name` bloom. The
+  reader skips a block whose bloom proves the token absent. A bloom never proves
+  presence, so a positive probe still reads the block.
+- `name = <literal>` probes the block's span-name bloom the same way.
+
+Every other predicate is evaluated as a DataFusion residual only. It prunes no
+blocks but still filters rows exactly. Notes on the shapes above:
+
+- The pruning predicates must be top-level `AND` conjuncts. A disjunction (`OR`)
+  inside a conjunct drops that conjunct from pruning, except a same-axis `OR` or
+  `IN` list on `status_code` or `duration_ns`, which prunes as the union of its
+  parts.
+- `service_name` and `name` equality push down but are also always re-checked
+  as a residual, because a bloom is a false-positive filter.
+- Attribute equality on the `attrs` map (`attrs['k'] = 'v'`) does not prune. It
+  is evaluated exactly over the merged map. Span attribute pruning is a later,
+  undecided epic, not a current capability.
+
+### Worked queries
+
+Find one trace by id and order its spans by start time:
+
+```sql
+SELECT span_id, parent_span_id, name, service_name, start_ts, duration_ns,
+       status_code
+FROM spans
+WHERE trace_id = '00112233445566778899aabbccddeeff'
+ORDER BY start_ts;
+```
+
+All error spans in a one-hour window:
+
+```sql
+SELECT trace_id, span_id, service_name, name, duration_ns
+FROM spans
+WHERE status_code = 2
+  AND start_ts >= TIMESTAMP '2026-08-19T00:00:00'
+  AND start_ts <  TIMESTAMP '2026-08-19T01:00:00'
+ORDER BY start_ts;
+```
+
+The slowest spans for one service:
+
+```sql
+SELECT trace_id, span_id, name, duration_ns
+FROM spans
+WHERE service_name = 'checkout'
+  AND start_ts >= TIMESTAMP '2026-08-19T00:00:00'
+ORDER BY duration_ns DESC
+LIMIT 20;
+```
+
+Every span of one operation, slower than 500 ms:
+
+```sql
+SELECT trace_id, span_id, service_name, duration_ns, status_code
+FROM spans
+WHERE name = 'GET /cart'
+  AND duration_ns > 500000000
+  AND start_ts >= TIMESTAMP '2026-08-19T00:00:00'
+ORDER BY duration_ns DESC;
+```
+
+The first query uses the `trace_id` fast path. The others combine a time window
+with a status, service, name, or duration prune. Each `WHERE` clause is also
+re-applied exactly above the scan, so every result is correct whether or not a
+block was pruned.
+
+## Incomplete traces
+
+A trace is incomplete when the query does not see all of its spans. This happens
+in two ways:
+
+- Some of the trace's spans have not landed yet. Ravel acknowledges each span
+  batch as it is durable and never buffers a whole trace to wait for its
+  siblings. A tail-sampling or completeness buffer belongs at the collector, not
+  in Ravel.
+- The trace's parent or root span falls outside the queried time window. A child
+  span can start and end inside a window whose parent started before it. A
+  window query returns the spans in the window, not the whole trace.
+
+To read a whole trace regardless of window, query by `trace_id` and widen or
+drop the time bounds. A trace missing its root span is reported as incomplete on
+the result; Ravel never waits for it.
+
+## What Ravel does not store
+
+Span links are not stored. A link points from one span to another span in a
+different trace. Ravel deliberately keeps links out of RSPAN; they will get
+their own design decision when a query needs them. A query over the `spans`
+table cannot filter or return links.
+</content>
+</invoke>

--- a/docs/guides/traces.md
+++ b/docs/guides/traces.md
@@ -13,7 +13,7 @@ durable copy. Records in a segment sort by `(trace_id, start_ts)`, so all spans
 of one trace occupy a contiguous run of blocks. Each object carries a skip
 index that holds, per block, the block's `trace_id` range, its time interval
 (`start_ts` minimum and `end_ts` maximum), its `duration_ns` range, and a
-one-byte `status_mask`. RSPAN v3 objects also carry a BLOOM section with a
+one-byte `status_mask`. RSPAN v4 objects also carry a BLOOM section with a
 per-block bloom filter over the tokens of `service.name` and span `name`, plus a
 block-local `service_name` column. The reader uses these structures to skip
 blocks that cannot match a query.
@@ -25,19 +25,22 @@ format; read this guide to query it.
 ## Why one trace is a bounded read
 
 Ingest routes each span to a shard by its `trace_id`. The router hashes the
-`trace_id` with BLAKE3 and picks the shard from the hash. A `trace_id` alone
-picks the shard, so all spans of one trace land on the same shard, and within
-that shard's objects they sort together into a contiguous block run. A lookup by
-`trace_id` is therefore a bounded scan of one shard, not a fan-out across every
-shard. The skip index prunes it further: it drops every block whose `trace_id`
-range excludes the target, so the reader decodes only the blocks that can hold
-the trace.
+`trace_id` with BLAKE3 and picks the shard from the hash, so all spans of one
+trace land on the same shard, and within that shard's objects they sort
+together into a contiguous block run.
 
-One caveat applies. ADR-0052 online resharding can move a tenant to a new shard
-count while spans are still arriving. A trace whose spans straddle a reshard
-activation can split across two shards. This is rare and is covered in depth in
-the resharding documentation; a trace-by-id query still returns every stored
-span, it just reads two shards instead of one.
+The query-time catalog listing does not yet exploit this routing: a
+`trace_id =` query still lists and opens every shard's segments in the
+matched time window, the same as any other query. What is bounded is the
+per-object decode: the skip index drops every block whose `trace_id` range
+excludes the target, so the reader decodes only the blocks that can hold the
+trace, on whichever shard(s) it lists. Shard-level pruning by `trace_id` is a
+later capability, not a current one.
+
+One caveat applies regardless. ADR-0052 online resharding can move a tenant
+to a new shard count while spans are still arriving. A trace whose spans
+straddle a reshard activation can split across two shards; a trace-by-id
+query still returns every stored span from wherever it landed.
 
 ## The `spans` table
 
@@ -96,7 +99,7 @@ These predicates prune at the skip-index level:
   block whose `status_mask` clears every requested bit. A `status_code = 2`
   query skips every block with no Error span.
 
-These predicates prune at the bloom level (RSPAN v3):
+These predicates prune at the bloom level (RSPAN v4):
 
 - `service_name = <literal>` probes the block's `service.name` bloom. The
   reader skips a block whose bloom proves the token absent. A bloom never proves
@@ -180,8 +183,8 @@ in two ways:
   window query returns the spans in the window, not the whole trace.
 
 To read a whole trace regardless of window, query by `trace_id` and widen or
-drop the time bounds. A trace missing its root span is reported as incomplete on
-the result; Ravel never waits for it.
+drop the time bounds. Ravel does not flag a result as incomplete; it returns
+exactly the spans in view and never waits for a missing root or sibling.
 
 ## What Ravel does not store
 

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -1147,7 +1147,7 @@ Schema (fixed columns plus one map, `crates/ravel-sql/src/spans_schema.rs`):
   span attributes. RSPAN stores that merged map directly, so unlike `logs`
   there is no separate stream-identity blob to fold in at scan time.
 - `service_name` — `Utf8`, nullable: populated from `attrs["service.name"]`
-  (NULL when the span has no such attribute). RSPAN v3 stores it as a
+  (NULL when the span has no such attribute). RSPAN v4 stores it as a
   block-local dictionary column (ADR-0054); the scan exposes it as a plain
   column so `WHERE service_name = '...'` is pushdown-eligible.
 - `duration_ns` — `Int64`, non-null: **computed** `end_ts - start_ts`, never a

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -1116,6 +1116,95 @@ oversights.
    `blocks_pruned_by_postings=0` and reads everything, which is the widen-only
    fallback, not a failure.
 
+## SQL over spans (the `spans` table, ADR-0045)
+
+`POST /api/v1/sql` serves a third table alongside `samples` and `logs`:
+`spans` (`Signal::Spans`). It follows the same one-signal-per-query rule the
+logs table established. `SqlExecutor` decides the target table from the `FROM`
+clause before planning, resolves a snapshot for that one signal, and registers
+exactly the one table in the per-query `SessionContext`. A query naming two real
+tables is rejected before any catalog listing (HTTP 400). A CTE named `spans` is
+a query-local name, not a base-table reference.
+
+The operator-facing walkthrough, with worked queries, is
+[docs/guides/traces.md](guides/traces.md). This section is the reference: the
+exact schema, the exact pushdown, and which predicate prunes where.
+
+Schema (fixed columns plus one map, `crates/ravel-sql/src/spans_schema.rs`):
+
+- `trace_id` — `FixedSizeBinary(16)`, non-null; `span_id` —
+  `FixedSizeBinary(8)`, non-null.
+- `parent_span_id` — `FixedSizeBinary(8)`, nullable (NULL on a root span, never
+  zero-filled).
+- `name` — `Utf8`, non-null (the span/operation name).
+- `start_ts`, `end_ts` — `Timestamp(Nanosecond, None)`, non-null.
+- `status_code` — `UInt8`, non-null: the stored OTLP byte, `0=Unset`, `1=Ok`,
+  `2=Error`. A `UInt8` for the same reason `logs.severity_num` is one: a tiny
+  fixed enum a plain integer round-trips exactly. Map it to text in SQL when a
+  caller wants the string.
+- `status_message` — `Utf8`, nullable.
+- `attrs` — `Map(Utf8, Utf8)`: the span's already-merged resource, scope, and
+  span attributes. RSPAN stores that merged map directly, so unlike `logs`
+  there is no separate stream-identity blob to fold in at scan time.
+- `service_name` — `Utf8`, nullable: populated from `attrs["service.name"]`
+  (NULL when the span has no such attribute). RSPAN v3 stores it as a
+  block-local dictionary column (ADR-0054); the scan exposes it as a plain
+  column so `WHERE service_name = '...'` is pushdown-eligible.
+- `duration_ns` — `Int64`, non-null: **computed** `end_ts - start_ts`, never a
+  stored column (ADR-0045 decision 5, rejected alternative 3). Both endpoints
+  are already stored, so materializing the difference per row would add bytes to
+  answer a question the block bounds answer for free. It is exposed as a SQL
+  column so `WHERE duration_ns > 5e8` is expressible, and the pushdown maps it
+  onto each block's stored duration bounds.
+
+Supported predicates (all pushdown is widen-only; `supports_filters_pushdown`
+returns `Inexact` for every filter, so DataFusion always re-applies the original
+predicate above the scan, and pruning can only ever widen the fetch, never drop
+a true result). Six shapes are recognized; every other predicate contributes no
+prune and is evaluated as a residual only:
+
+- `trace_id = <literal>` — the RSPAN fast path (ADR-0041). The literal is a
+  16-byte binary or a 32-character hex string. It compiles to a
+  `SpanQuery::trace` lookup, and the skip index drops every block whose
+  `[min_trace_id, max_trace_id]` range excludes the target: a bounded
+  single-trace scan instead of a full window scan.
+- `start_ts` / `end_ts` range comparisons (`>=`, `>`, `<`, `<=`, `=`, and
+  `BETWEEN`) — both columns fold into one inclusive `[ts_min, ts_max]` window
+  the reader prunes blocks against by time-interval overlap. Folding both
+  endpoints into one window is a widen, never a narrow, because `end_ts >=
+  start_ts` on every record.
+- `duration_ns` range comparisons — fold into a `[lo, hi]` window exactly as
+  the ts window folds, pruned against each block's `min/max_duration_ns` (RSPAN
+  v2 skip-index fields). Strict `>`/`<` use `checked_add`/`checked_sub`.
+- `status_code = <literal>`, `status_code IN (...)`, and a same-axis `OR` of
+  `status_code` equalities — map to the skip index's status bits and prune
+  against each block's one-byte `status_mask` (RSPAN v2). `status_code = 2`
+  skips every block with no Error span. Multiple sibling equalities
+  AND-intersect; a same-axis `OR`/`IN` unions.
+- `service_name = <literal>` — a per-block `service.name` bloom probe (RSPAN
+  v3, ADR-0054). A block whose bloom proves the token absent is skipped before
+  decode.
+- `name = <literal>` — the span-name sibling of `service_name`, the other field
+  the v3 per-block bloom is built over.
+
+Prune site by predicate: `trace_id`, `start_ts`/`end_ts`, `duration_ns`, and
+`status_code` prune at the **skip index** (exact min/max ranges and the status
+mask). `service_name` and `name` prune at the **bloom** (a false-positive-only
+membership test, so a negative excludes a block and a positive changes nothing,
+under the widen-only rule ADR-0013 established). Everything else, including
+`attrs['k'] = 'v'` and any predicate on `span_id`, `parent_span_id`, or
+`status_message`, prunes nothing and is evaluated exactly as a DataFusion
+residual. Span attribute pruning (postings, analogous to RLOG's) is a later,
+undecided epic, not a current capability.
+
+Conjunctive shape: the pruning predicates must be top-level `AND` conjuncts. A
+disjunction inside a conjunct's subtree drops that whole conjunct from pruning
+(refusing is always widen-safe: the residual re-applies it). The exception is a
+**same-axis** `OR`/`IN` on `status_code` or `duration_ns`, pushed as the union
+of its disjuncts; a **cross-axis** disjunction (`status_code = 2 OR duration_ns
+> 5e8`) is refused. `trace_id` is a single-point lookup with no range primitive
+to union, so a `trace_id` disjunction is refused too.
+
 ## Caching note
 
 ADR-0046 added a content-addressed RAM read-cache tier (`ravel-cache`,


### PR DESCRIPTION
Epic #8 (RSPAN v2/v3/v4 investigation) reconciled to reality: T1-T7
were already implemented and tested on main under different names than
the epic's stale task list used. This is the one genuinely missing
piece, T8: operator-facing docs for querying spans.

Adds docs/guides/traces.md (storage model, why a trace lookup is
bounded, the spans table schema, worked queries, incomplete-trace
semantics) and a matching "SQL over spans" reference section in
docs/query-engine.md, following the existing logs-table doc structure.
README.md, docs/README.md, and PROGRESS.md updated to link and count
it.

A follow-up review checked every factual claim (schema, pushdown
shapes, ADR citations, shard routing) against the real code. Two
claims didn't hold up and are corrected in the second commit: a
trace-by-id query does not yet get shard-level pruning (only
per-object skip-index pruning is real today), and there is no
result-level "incomplete trace" flag. Both are now described
accurately instead of aspirationally.

Fixes: #11
Refs: #8
