### PR TITLE
docs(adrs): claim ADR-0092 for run-merged L1 and RSEG v7

### DIFF
--- a/docs/adrs/0092-run-merged-l1-and-rseg-v7.md
+++ b/docs/adrs/0092-run-merged-l1-and-rseg-v7.md
@@ -1,0 +1,3 @@
+# ADR-0092: Run-merged L1 compaction and RSEG v7
+
+Status: claimed


### PR DESCRIPTION
Reserve ADR number 0092 with a stub so a parallel epic cannot pick the same number.

The full decision, on run-merged L1 compaction and the RSEG v7 bump it needs, overwrites this stub after the epic's design review.