### PR TITLE
test(bench): measure run fragmentation and bake off value/timestamp codecs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4312,6 +4312,7 @@ dependencies = [
  "prost",
  "rand 0.10.2",
  "ravel-catalog",
+ "ravel-codec",
  "ravel-commit",
  "ravel-ingest",
  "ravel-maintain",

--- a/crates/ravel-bench/Cargo.toml
+++ b/crates/ravel-bench/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 [dependencies]
 ravel-types = { workspace = true }
 ravel-proto = { workspace = true }
+ravel-codec = { workspace = true }
 ravel-segment = { workspace = true }
 ravel-otlp = { workspace = true }
 ravel-ingest = { workspace = true }
@@ -140,6 +141,16 @@ bench = false
 [[bin]]
 name = "histogram_size"
 path = "src/bin/histogram_size.rs"
+bench = false
+
+[[bin]]
+name = "codec_bakeoff"
+path = "src/bin/codec_bakeoff.rs"
+bench = false
+
+[[bin]]
+name = "ts_bakeoff"
+path = "src/bin/ts_bakeoff.rs"
 bench = false
 
 [[bin]]

--- a/crates/ravel-bench/src/bench_env.rs
+++ b/crates/ravel-bench/src/bench_env.rs
@@ -1,0 +1,104 @@
+//! Environment provenance header for the codec bake-off bins
+//! (`src/bin/codec_bakeoff.rs`, `src/bin/ts_bakeoff.rs`). A throughput number
+//! is meaningless without the machine that produced it, so both bins print
+//! this block first and the captured report in `bench/reports/` keeps it
+//! (ADR-0075 decision 3's "a number without provenance is not evidence",
+//! applied to a local measurement rather than a published S3 one).
+//!
+//! Best-effort: every field falls back to `"unknown"` rather than failing, so
+//! a bake-off still runs on a host missing `/proc` or `uname`. Subprocess and
+//! `/proc` reads live here, off the library's deterministic path, exactly as
+//! `bench_report`'s provenance helpers do.
+#![allow(clippy::expect_used)]
+
+use std::process::Command;
+
+/// Trimmed stdout of `program args`, or `None` on any failure.
+fn command_stdout(program: &str, args: &[&str]) -> Option<String> {
+    let output = Command::new(program).args(args).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let text = String::from_utf8(output.stdout).ok()?;
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+/// The commit these numbers describe. `GITHUB_SHA` (set by CI) wins so a report
+/// from a detached HEAD still names the branch tip; otherwise ask git.
+pub fn git_commit() -> String {
+    if let Ok(sha) = std::env::var("GITHUB_SHA")
+        && !sha.trim().is_empty()
+    {
+        return sha.trim().to_string();
+    }
+    command_stdout("git", &["rev-parse", "HEAD"]).unwrap_or_else(|| "unknown".to_string())
+}
+
+fn rustc_version() -> String {
+    command_stdout("rustc", &["--version"]).unwrap_or_else(|| "unknown".to_string())
+}
+
+/// First `model name` line of `/proc/cpuinfo`, the human CPU name.
+fn cpu_model() -> String {
+    let Ok(text) = std::fs::read_to_string("/proc/cpuinfo") else {
+        return "unknown".to_string();
+    };
+    for line in text.lines() {
+        if let Some((key, value)) = line.split_once(':')
+            && key.trim() == "model name"
+        {
+            return value.trim().to_string();
+        }
+    }
+    "unknown".to_string()
+}
+
+fn core_count() -> String {
+    std::thread::available_parallelism()
+        .map(|n| n.get().to_string())
+        .unwrap_or_else(|_| "unknown".to_string())
+}
+
+/// `MemTotal` from `/proc/meminfo`, rendered in GiB.
+fn total_memory() -> String {
+    let Ok(text) = std::fs::read_to_string("/proc/meminfo") else {
+        return "unknown".to_string();
+    };
+    for line in text.lines() {
+        if let Some(rest) = line.strip_prefix("MemTotal:") {
+            if let Some(kb_str) = rest.split_whitespace().next()
+                && let Ok(kb) = kb_str.parse::<f64>()
+            {
+                return format!("{:.1} GiB", kb / (1024.0 * 1024.0));
+            }
+            return "unknown".to_string();
+        }
+    }
+    "unknown".to_string()
+}
+
+fn os_string() -> String {
+    command_stdout("uname", &["-srm"]).unwrap_or_else(|| std::env::consts::OS.to_string())
+}
+
+/// The multi-line environment block printed at the top of each bake-off
+/// report. `title` names which bake-off produced the numbers that follow.
+pub fn env_header(title: &str) -> String {
+    let mut out = String::new();
+    out.push_str("========================================================================\n");
+    out.push_str(&format!("{title}\n"));
+    out.push_str("========================================================================\n");
+    out.push_str(&format!("cpu:     {}\n", cpu_model()));
+    out.push_str(&format!("cores:   {}\n", core_count()));
+    out.push_str(&format!("memory:  {}\n", total_memory()));
+    out.push_str(&format!("os:      {}\n", os_string()));
+    out.push_str(&format!("rustc:   {}\n", rustc_version()));
+    out.push_str(&format!("commit:  {}\n", git_commit()));
+    out.push_str("========================================================================\n");
+    out
+}

--- a/crates/ravel-bench/src/bin/codec_bakeoff.rs
+++ b/crates/ravel-bench/src/bin/codec_bakeoff.rs
@@ -1,0 +1,431 @@
+//! Value codec bake-off, round two (issue #312, ADR-0092 decision 6).
+//!
+//! Round one (2026-07-28) tested only XOR-family challengers and drove its
+//! counter workload with a random *float* increment, so it never exercised the
+//! integer-valued counters and gauges that dominate real metrics. This round
+//! adds two integer-transform challengers, [`Alp`] and [`GcdDeltaFor`], and
+//! measures every challenger against the production Gorilla path reached
+//! through the segment public API (`encode_run_v4` / `decode_run_pages_soa`,
+//! via `segment_support`) and against raw f64.
+//!
+//! Report-only: nothing here changes a production path. It produces the
+//! numbers issue #314 consumes to decide which value encoding, if any, enters
+//! the next RSEG version.
+//!
+//! ## What is measured, and the one asymmetry to know
+//!
+//! For every (dataset, page size) each codec reports bytes per sample and the
+//! median encode/decode throughput over repeated timed runs. Bytes per sample
+//! is the codec's *payload*: for the challengers that is `encode()`'s length;
+//! for production it is the VAL page minus its 6-byte enc/comp/crc header, so
+//! all rows compare header-less payloads (the 6-byte page header is common
+//! overhead paid on top of whichever codec wins).
+//!
+//! The throughput asymmetry: RSEG exposes no public value-only codec, so the
+//! production encode/decode timings go through `encode_run_v4` /
+//! `decode_run_pages_soa`, which frame and decode a whole run -- a TS page as
+//! well as the VAL page. That charges production a fixed TS-framing cost the
+//! payload-only challengers never pay, so these numbers *understate*
+//! production's value-only decode speed. A challenger that beats production
+//! decode here beats it by at least this much; a challenger that does not is
+//! ambiguous on throughput. The bytes-per-sample figures carry no such caveat.
+//!
+//! ## Adoption rule (ADR-0092 decision 6, applied in the summary)
+//!
+//! A challenger is adopted only if, bit-exact round trip confirmed, it uses at
+//! most 75% of production's bytes per sample *and* decodes at least as fast as
+//! production. A codec that cannot round-trip bit-exactly is disqualified
+//! outright.
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::hint::black_box;
+use std::time::Instant;
+
+use rand::rngs::StdRng;
+use rand::{RngExt, SeedableRng};
+use ravel_bench::bench_env::env_header;
+use ravel_bench::codecs::{Alp, ByteSplitZstd, Chimp128, GcdDeltaFor, RawF64, ValueCodec};
+use ravel_bench::segment_support::{decode_scalar_run, production_scalar_run, scalar_val_page};
+
+/// Page sizes measured: the small-run regime and a full L1-merged run.
+const PAGE_SIZES: [usize; 2] = [60, 500];
+/// Timed rounds per throughput cell; the median is reported.
+const MEASURE_ROUNDS: usize = 9;
+/// Inner repetitions per timed round, so each measurement spans many
+/// microseconds and swamps timer granularity.
+const INNER_REPS: usize = 4000;
+/// Adoption threshold: a challenger must use at most this fraction of
+/// production's bytes per sample.
+const BYTE_RATIO_MAX: f64 = 0.75;
+
+/// One synthetic value stream and its human name.
+struct Dataset {
+    name: &'static str,
+    values: Vec<f64>,
+}
+
+/// Round a float to `places` decimal places, the way a real decimal-valued
+/// gauge (a price, a ratio) arrives: the stored f64 is the nearest double to
+/// the rounded decimal.
+fn round_to(v: f64, places: i32) -> f64 {
+    let scale = 10f64.powi(places);
+    (v * scale).round() / scale
+}
+
+/// Builds one dataset of exactly `n` samples. Deterministic in `(kind, n)`: a
+/// fixed per-kind seed, no wall-clock time, so the byte figures reproduce.
+fn dataset(kind: &str, n: usize) -> Dataset {
+    let mut rng = StdRng::seed_from_u64(0x0C0D_EC00 ^ (n as u64) ^ seed_of(kind));
+    let values: Vec<f64> = match kind {
+        // Cumulative integer counter, small integer increments, ~2% reset to 0.
+        "counter_int_resets" => {
+            let mut acc = 0i64;
+            (0..n)
+                .map(|_| {
+                    if rng.random_bool(0.02) {
+                        acc = 0;
+                    } else {
+                        acc += rng.random_range(1..=10);
+                    }
+                    acc as f64
+                })
+                .collect()
+        }
+        // Integer gauge random walk, non-negative.
+        "gauge_int" => {
+            let mut acc = rng.random_range(0..1000) as i64;
+            (0..n)
+                .map(|_| {
+                    acc = (acc + rng.random_range(-5..=5)).max(0);
+                    acc as f64
+                })
+                .collect()
+        }
+        // 2-decimal gauge (e.g. a price) random walk.
+        "gauge_dec2" => {
+            let mut acc = round_to(rng.random_range(0.0..1000.0), 2);
+            (0..n)
+                .map(|_| {
+                    acc = round_to(acc + rng.random_range(-1.0..1.0), 2);
+                    acc
+                })
+                .collect()
+        }
+        // 3-decimal gauge random walk.
+        "gauge_dec3" => {
+            let mut acc = round_to(rng.random_range(0.0..1000.0), 3);
+            (0..n)
+                .map(|_| {
+                    acc = round_to(acc + rng.random_range(-1.0..1.0), 3);
+                    acc
+                })
+                .collect()
+        }
+        // Arbitrary noisy floats: no low decimal exponent reproduces them.
+        "noisy_float" => (0..n)
+            .map(|_| rng.random_range(-1_000_000.0..1_000_000.0))
+            .collect(),
+        // Constant series.
+        "constant" => vec![42.0; n],
+        // Sparse: mostly zero, ~10% integer spikes.
+        "sparse" => (0..n)
+            .map(|_| {
+                if rng.random_bool(0.1) {
+                    rng.random_range(1..=1000) as f64
+                } else {
+                    0.0
+                }
+            })
+            .collect(),
+        // The round-one control: a counter that increments by a random float.
+        "float_counter" => {
+            let mut acc = 0.0f64;
+            (0..n)
+                .map(|_| {
+                    acc += rng.random_range(0.0..5.0);
+                    acc
+                })
+                .collect()
+        }
+        other => panic!("unknown dataset {other}"),
+    };
+    Dataset {
+        name: dataset_label(kind),
+        values,
+    }
+}
+
+fn seed_of(kind: &str) -> u64 {
+    kind.bytes().fold(1469598103934665603u64, |h, b| {
+        (h ^ u64::from(b)).wrapping_mul(1099511628211)
+    })
+}
+
+fn dataset_label(kind: &str) -> &'static str {
+    match kind {
+        "counter_int_resets" => "counter_int_resets",
+        "gauge_int" => "gauge_int",
+        "gauge_dec2" => "gauge_dec2",
+        "gauge_dec3" => "gauge_dec3",
+        "noisy_float" => "noisy_float",
+        "constant" => "constant",
+        "sparse" => "sparse",
+        "float_counter" => "float_counter(ctrl)",
+        other => panic!("unknown dataset {other}"),
+    }
+}
+
+const DATASET_KINDS: [&str; 8] = [
+    "counter_int_resets",
+    "gauge_int",
+    "gauge_dec2",
+    "gauge_dec3",
+    "noisy_float",
+    "constant",
+    "sparse",
+    "float_counter",
+];
+
+fn bits_eq(a: &[f64], b: &[f64]) -> bool {
+    a.len() == b.len() && a.iter().zip(b).all(|(x, y)| x.to_bits() == y.to_bits())
+}
+
+fn median(mut xs: Vec<f64>) -> f64 {
+    xs.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    xs[xs.len() / 2]
+}
+
+/// Median Mval/s (millions of values per second) over [`MEASURE_ROUNDS`] timed
+/// rounds of [`INNER_REPS`] repetitions each.
+fn throughput_mvps<F: FnMut()>(mut f: F, n_values: usize) -> f64 {
+    for _ in 0..3 {
+        f();
+    }
+    let mut rounds = Vec::with_capacity(MEASURE_ROUNDS);
+    for _ in 0..MEASURE_ROUNDS {
+        let start = Instant::now();
+        for _ in 0..INNER_REPS {
+            f();
+        }
+        let elapsed = start.elapsed().as_secs_f64().max(1e-12);
+        rounds.push((n_values as f64 * INNER_REPS as f64) / elapsed / 1e6);
+    }
+    median(rounds)
+}
+
+/// One measured cell.
+struct Cell {
+    codec: &'static str,
+    bytes_per_sample: f64,
+    enc_mvps: f64,
+    dec_mvps: f64,
+    roundtrip_ok: bool,
+    /// Production enc tag (16 Gorilla, 17 raw) for the production row only.
+    prod_enc: Option<u8>,
+}
+
+/// One challenger's summary numbers, retained for the adoption pass.
+struct ChallengerSummary {
+    codec: &'static str,
+    bytes_per_sample: f64,
+    dec_mvps: f64,
+    roundtrip_ok: bool,
+}
+
+/// Per (page, dataset) summary: production baselines plus every challenger.
+struct DatasetSummary {
+    page: usize,
+    name: &'static str,
+    prod_bytes: f64,
+    prod_dec: f64,
+    challengers: Vec<ChallengerSummary>,
+}
+
+fn measure_challenger(codec: &dyn ValueCodec, values: &[f64]) -> Cell {
+    let n = values.len();
+    let encoded = codec.encode(values);
+    let roundtrip_ok = codec
+        .decode(&encoded, n)
+        .map(|d| bits_eq(&d, values))
+        .unwrap_or(false);
+    let enc_mvps = throughput_mvps(
+        || {
+            black_box(codec.encode(black_box(values)));
+        },
+        n,
+    );
+    let dec_mvps = throughput_mvps(
+        || {
+            black_box(codec.decode(black_box(&encoded), n)).ok();
+        },
+        n,
+    );
+    Cell {
+        codec: codec.name(),
+        bytes_per_sample: encoded.len() as f64 / n as f64,
+        enc_mvps,
+        dec_mvps,
+        roundtrip_ok,
+        prod_enc: None,
+    }
+}
+
+fn measure_production(values: &[f64]) -> Cell {
+    let n = values.len();
+    let run = production_scalar_run(values);
+    let page = scalar_val_page(&run);
+    // Payload only: drop the 6-byte enc/comp/crc header so the row compares to
+    // the header-less challenger payloads.
+    let payload = page.len().saturating_sub(6);
+    let prod_enc = page.first().copied();
+    let (_ts, decoded) = decode_scalar_run(&run);
+    let roundtrip_ok = bits_eq(&decoded, values);
+    let enc_mvps = throughput_mvps(
+        || {
+            black_box(production_scalar_run(black_box(values)));
+        },
+        n,
+    );
+    let dec_mvps = throughput_mvps(
+        || {
+            black_box(decode_scalar_run(black_box(&run)));
+        },
+        n,
+    );
+    Cell {
+        codec: "production",
+        bytes_per_sample: payload as f64 / n as f64,
+        enc_mvps,
+        dec_mvps,
+        roundtrip_ok,
+        prod_enc,
+    }
+}
+
+fn main() {
+    let mut out = String::new();
+    out.push_str(&env_header(
+        "Value codec bake-off (issue #312, ADR-0092 decision 6)",
+    ));
+    out.push_str(
+        "\nbytes/sample = codec payload (production excludes its 6-byte page header).\n\
+         throughput = median Mval/s over repeated runs; production timings frame a whole\n\
+         run (TS + VAL) through the public API, so they understate value-only speed.\n\
+         'ratio' = challenger bytes / production bytes; adoption needs <= 0.75 AND\n\
+         dec >= production dec AND a bit-exact round trip.\n",
+    );
+
+    // Retained for the adoption pass: per (page, dataset) the production
+    // baselines plus each challenger's summary numbers.
+    let mut summary: Vec<DatasetSummary> = Vec::new();
+
+    for &page in &PAGE_SIZES {
+        out.push_str(&format!(
+            "\n======================= {page} samples per page =======================\n"
+        ));
+        for kind in DATASET_KINDS {
+            let ds = dataset(kind, page);
+            let prod = measure_production(&ds.values);
+            let challengers: Vec<Cell> = [
+                &Alp as &dyn ValueCodec,
+                &GcdDeltaFor,
+                &Chimp128,
+                &ByteSplitZstd,
+                &RawF64,
+            ]
+            .iter()
+            .map(|c| measure_challenger(*c, &ds.values))
+            .collect();
+
+            let enc_tag = prod.prod_enc.map(enc_name).unwrap_or("?");
+            out.push_str(&format!(
+                "\n{}  (n={page}, production val enc={enc_tag})\n",
+                ds.name
+            ));
+            out.push_str(&format!(
+                "  {:<16} {:>10} {:>12} {:>12} {:>8}  {}\n",
+                "codec", "B/sample", "enc Mval/s", "dec Mval/s", "ratio", "roundtrip"
+            ));
+            let prod_bytes = prod.bytes_per_sample;
+            out.push_str(&format!(
+                "  {:<16} {:>10.4} {:>12.1} {:>12.1} {:>8}  {}\n",
+                prod.codec, prod.bytes_per_sample, prod.enc_mvps, prod.dec_mvps, "-", "ok"
+            ));
+            let mut summary_cells = Vec::new();
+            for c in &challengers {
+                let ratio = c.bytes_per_sample / prod_bytes.max(f64::MIN_POSITIVE);
+                out.push_str(&format!(
+                    "  {:<16} {:>10.4} {:>12.1} {:>12.1} {:>8.3}  {}\n",
+                    c.codec,
+                    c.bytes_per_sample,
+                    c.enc_mvps,
+                    c.dec_mvps,
+                    ratio,
+                    if c.roundtrip_ok { "ok" } else { "FAIL" },
+                ));
+                summary_cells.push(ChallengerSummary {
+                    codec: c.codec,
+                    bytes_per_sample: c.bytes_per_sample,
+                    dec_mvps: c.dec_mvps,
+                    roundtrip_ok: c.roundtrip_ok,
+                });
+            }
+            summary.push(DatasetSummary {
+                page,
+                name: ds.name,
+                prod_bytes,
+                prod_dec: prod.dec_mvps,
+                challengers: summary_cells,
+            });
+        }
+    }
+
+    // Adoption summary per (page, dataset).
+    out.push_str("\n======================= adoption summary =======================\n");
+    out.push_str(&format!(
+        "rule: bytes <= {:.0}% of production AND dec >= production dec AND bit-exact\n",
+        BYTE_RATIO_MAX * 100.0
+    ));
+    for row in &summary {
+        let winners: Vec<String> = row
+            .challengers
+            .iter()
+            .filter_map(|c| {
+                let clears = c.roundtrip_ok
+                    && c.bytes_per_sample <= row.prod_bytes * BYTE_RATIO_MAX
+                    && c.dec_mvps >= row.prod_dec;
+                clears.then(|| c.codec.to_string())
+            })
+            .collect();
+        let disq: Vec<&str> = row
+            .challengers
+            .iter()
+            .filter(|c| !c.roundtrip_ok)
+            .map(|c| c.codec)
+            .collect();
+        let (page, name) = (row.page, row.name);
+        out.push_str(&format!(
+            "  n={page:<4} {name:<20} adopt: {}{}\n",
+            if winners.is_empty() {
+                "none".to_string()
+            } else {
+                winners.join(", ")
+            },
+            if disq.is_empty() {
+                String::new()
+            } else {
+                format!("   disqualified(no round-trip): {}", disq.join(", "))
+            },
+        ));
+    }
+
+    print!("{out}");
+}
+
+fn enc_name(tag: u8) -> &'static str {
+    match tag {
+        16 => "16(gorilla)",
+        17 => "17(raw_f64)",
+        _ => "?",
+    }
+}

--- a/crates/ravel-bench/src/bin/ts_bakeoff.rs
+++ b/crates/ravel-bench/src/bin/ts_bakeoff.rs
@@ -1,0 +1,197 @@
+//! Timestamp codec bake-off (issue #312, ADR-0092 decision 6).
+//!
+//! Compares three timestamp encoders on the same synthetic streams:
+//!
+//! 1. **production**: the RSEG TS page path -- `TS_DELTA_VARINT` plus the
+//!    writer's 64-byte-floor LZ4 rule -- reached by framing a real TS page
+//!    through `encode_run_v4` (`segment_support::production_ts_run`). Its byte
+//!    count therefore *includes the 6-byte page header* (enc, comp, crc);
+//!    the two comparators below are raw codec output with no such header, so a
+//!    production win of 6 bytes or less on a page is header, not codec.
+//! 2. **encode_i64**: `ravel_codec::encoding::encode_i64` applied to the raw
+//!    timestamps (the integer path RSEG v7 uses for its provenance columns).
+//! 3. **encode_i64/gcd**: the same, after dividing every timestamp by the
+//!    page's greatest common divisor. The divisor found is reported; it is
+//!    where a millisecond-resolution stream (every value a multiple of 1e6 ns)
+//!    can shed a constant factor before delta coding.
+//!
+//! Report-only, per ADR-0092 decision 6: the numbers feed issue #314, they
+//! adopt nothing. The decision rule to apply is that a timestamp stack must
+//! not regress the exactly-regular case, where production already reaches
+//! about 0.16 bytes per sample at large pages because LZ4 collapses the
+//! repeated varint.
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use rand::rngs::StdRng;
+use rand::{RngExt, SeedableRng};
+use ravel_bench::bench_env::env_header;
+use ravel_bench::segment_support::production_ts_run;
+use ravel_codec::encoding::{decode_i64, encode_i64};
+
+/// Page lengths measured, from the single-sample fragmentation floor to a
+/// full hour of 1 s data.
+const PAGE_LENS: [usize; 6] = [1, 2, 12, 60, 240, 3600];
+
+const START_NS: i64 = 1_700_000_000_000_000_000;
+const STEP_15S_NS: i64 = 15_000_000_000;
+const MS_NS: i64 = 1_000_000;
+
+fn gcd_i64(a: i64, b: i64) -> i64 {
+    let (mut a, mut b) = (a.unsigned_abs(), b.unsigned_abs());
+    while b != 0 {
+        (a, b) = (b, a % b);
+    }
+    a as i64
+}
+
+/// GCD of all timestamps in the page (0 only if every value is 0).
+fn page_gcd(ts: &[i64]) -> i64 {
+    ts.iter().fold(0i64, |acc, &v| gcd_i64(acc, v)).max(1)
+}
+
+/// Builds `n` timestamps for the named stream. Deterministic in `(kind, n)`:
+/// fixed per-kind seed, no wall-clock time.
+fn stream(kind: &str, n: usize) -> Vec<i64> {
+    let mut rng = StdRng::seed_from_u64(0x7357_0000 ^ (n as u64) ^ seed_of(kind));
+    match kind {
+        // Exactly regular 15 s, millisecond resolution (every value a
+        // multiple of 1e6 ns; all deltas identical).
+        "regular_ms" => (0..n).map(|i| START_NS + i as i64 * STEP_15S_NS).collect(),
+        // 15 s with +/-200 ms jitter, still millisecond resolution.
+        "jitter_ms" => (0..n)
+            .map(|i| {
+                let jitter = rng.random_range(-200..=200) * MS_NS;
+                START_NS + i as i64 * STEP_15S_NS + jitter
+            })
+            .collect(),
+        // True-nanosecond timestamps: 15 s nominal, +/-200 ms jitter at
+        // full nanosecond resolution (not ms-aligned), as OTLP delivers.
+        "nanos_jitter" => (0..n)
+            .map(|i| {
+                let jitter = rng.random_range(-200_000_000..=200_000_000);
+                START_NS + i as i64 * STEP_15S_NS + jitter
+            })
+            .collect(),
+        // Irregular intervals: 1 s..60 s gaps at nanosecond resolution.
+        "irregular" => {
+            let mut ts = START_NS;
+            (0..n)
+                .map(|_| {
+                    ts += rng.random_range(1..=60) * 1_000_000_000;
+                    ts
+                })
+                .collect()
+        }
+        // Regular millisecond cadence with ~15% of samples pushed two
+        // intervals back (out of order), as a bursty backfill produces.
+        "out_of_order" => (0..n)
+            .map(|i| {
+                let base = START_NS + i as i64 * STEP_15S_NS;
+                if rng.random_bool(0.15) {
+                    base - 2 * STEP_15S_NS
+                } else {
+                    base
+                }
+            })
+            .collect(),
+        other => panic!("unknown stream {other}"),
+    }
+}
+
+fn seed_of(kind: &str) -> u64 {
+    kind.bytes().fold(1469598103934665603u64, |h, b| {
+        (h ^ u64::from(b)).wrapping_mul(1099511628211)
+    })
+}
+
+/// Bytes the production TS page path spends (6-byte header included).
+fn production_bytes(ts: &[i64]) -> usize {
+    production_ts_run(ts).ts_page.len()
+}
+
+/// `encode_i64` bytes and a round-trip check.
+fn encode_i64_bytes(ts: &[i64]) -> (usize, bool) {
+    let (enc, bytes) = encode_i64(ts);
+    let ok = decode_i64(enc, &bytes, ts.len())
+        .map(|d| d == ts)
+        .unwrap_or(false);
+    (bytes.len(), ok)
+}
+
+/// `encode_i64` over timestamps divided by the page GCD; returns (bytes,
+/// divisor, round-trip ok). Round trip multiplies back by the divisor.
+fn encode_i64_gcd_bytes(ts: &[i64]) -> (usize, i64, bool) {
+    let g = page_gcd(ts);
+    let divided: Vec<i64> = ts.iter().map(|&v| v / g).collect();
+    let (enc, bytes) = encode_i64(&divided);
+    let ok = decode_i64(enc, &bytes, ts.len())
+        .map(|d| d.iter().map(|&v| v * g).eq(ts.iter().copied()))
+        .unwrap_or(false);
+    (bytes.len(), g, ok)
+}
+
+const MULTI_STREAMS: [&str; 5] = [
+    "regular_ms",
+    "jitter_ms",
+    "nanos_jitter",
+    "irregular",
+    "out_of_order",
+];
+
+fn main() {
+    let mut out = String::new();
+    out.push_str(&env_header(
+        "Timestamp codec bake-off (issue #312, ADR-0092 decision 6)",
+    ));
+    out.push_str(
+        "\nbytes/sample: production INCLUDES the 6-byte RSEG page header (enc/comp/crc);\n\
+         encode_i64 and encode_i64/gcd are raw codec output with no page header. A\n\
+         production lead of <= 6 bytes on a page is header overhead, not codec.\n\
+         gcd = divisor found for that page (encode_i64/gcd divides by it first).\n\
+         Rule: a timestamp stack must not regress the exactly-regular stream.\n",
+    );
+
+    for stream_kind in MULTI_STREAMS {
+        out.push_str(&format!("\n===== {stream_kind} =====\n"));
+        out.push_str(&format!(
+            "  {:>6} {:>14} {:>14} {:>16} {:>18}\n",
+            "n", "prod B/s", "enc_i64 B/s", "enc_i64/gcd B/s", "gcd"
+        ));
+        for &n in &PAGE_LENS {
+            let ts = stream(stream_kind, n);
+            let prod = production_bytes(&ts);
+            let (raw_bytes, raw_ok) = encode_i64_bytes(&ts);
+            let (gcd_bytes, gcd, gcd_ok) = encode_i64_gcd_bytes(&ts);
+            assert!(
+                raw_ok,
+                "encode_i64 round trip failed for {stream_kind} n={n}"
+            );
+            assert!(
+                gcd_ok,
+                "encode_i64/gcd round trip failed for {stream_kind} n={n}"
+            );
+            out.push_str(&format!(
+                "  {:>6} {:>14.4} {:>14.4} {:>16.4} {:>18}\n",
+                n,
+                prod as f64 / n as f64,
+                raw_bytes as f64 / n as f64,
+                gcd_bytes as f64 / n as f64,
+                gcd,
+            ));
+        }
+    }
+
+    // Single-sample runs: the fragmentation floor ADR-0092 cites (one absolute
+    // zigzag varint, ~9 bytes, plus production's 6-byte header, never reaching
+    // the LZ4 floor).
+    out.push_str("\n===== single_sample (one absolute timestamp) =====\n");
+    let ts = vec![START_NS];
+    let prod = production_bytes(&ts);
+    let (raw_bytes, _) = encode_i64_bytes(&ts);
+    let (gcd_bytes, gcd, _) = encode_i64_gcd_bytes(&ts);
+    out.push_str(&format!(
+        "  prod={prod} B  enc_i64={raw_bytes} B  enc_i64/gcd={gcd_bytes} B  gcd={gcd}\n"
+    ));
+
+    print!("{out}");
+}

--- a/crates/ravel-bench/src/codecs.rs
+++ b/crates/ravel-bench/src/codecs.rs
@@ -5,8 +5,22 @@
 //! is measured through its public segment API in the bin, not reimplemented
 //! here.
 //!
-//! Two challengers plus a raw baseline:
+//! Four challengers plus a raw baseline:
 //!
+//! - [`Alp`]: Adaptive Lossless floating-Point compression (Afroozeh,
+//!   Kuffo, Boncz, "ALP: Adaptive Lossless floating-Point Compression",
+//!   SIGMOD 2024). Recover a decimal exponent `e` so each value becomes the
+//!   integer `round(v * 10^e)`, compress those integers through
+//!   `encode_i64` (the same integer path RSEG v7 uses for its
+//!   provenance columns, ADR-0092), and store any value the model does not
+//!   reproduce bit-exactly as a raw `f64` exception. Clean fallback: a value
+//!   that overflows the integer domain, is non-finite, or is `-0.0` becomes an
+//!   exception rather than corrupting the stream.
+//! - [`GcdDeltaFor`]: recover the same decimal exponent (all values must fit,
+//!   else a whole-page raw fallback), delta the resulting integers, divide the
+//!   deltas by their greatest common divisor, then frame-of-reference
+//!   bit-pack the reduced deltas. Targets integer-valued counters and
+//!   fixed-precision decimal gauges, where the deltas share a large GCD.
 //! - [`Chimp128`]: the 128-previous-values variant of the Chimp codec
 //!   (Liakos, Papakonstantinopoulou, Kotidis, "Chimp: Efficient Lossless
 //!   Floating Point Compression for Time Series Databases", VLDB 2022). Each
@@ -23,6 +37,8 @@
 //! denormals survive exactly (asserted by `tests/codec_roundtrip.rs`).
 //! Decoders treat their input as untrusted: corrupt or truncated bytes return
 //! a typed [`CodecError`], never a panic.
+
+use ravel_codec::encoding::{Enc, decode_i64, encode_i64};
 
 /// Typed decode failure. Encoding never fails, so only decoders return this.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
@@ -451,6 +467,398 @@ impl ValueCodec for RawF64 {
     }
 }
 
+// --- shared integer-model helpers (ALP, GCD-FOR) ------------------------
+
+/// Largest decimal exponent either integer-model codec will try. `10^18`
+/// still fits an `i64` (max `~9.22e18`), and larger exponents only lose
+/// precision, so a decimal that needs more than 18 places is not modelled and
+/// falls back (per value for ALP, per page for GCD-FOR).
+const MAX_DECIMAL_EXP: usize = 18;
+
+/// `10^0 ..= 10^18` as exact `f64` (every one is representable: `10^22` is the
+/// last exactly-representable power of ten in `f64`).
+const POW10: [f64; MAX_DECIMAL_EXP + 1] = [
+    1e0, 1e1, 1e2, 1e3, 1e4, 1e5, 1e6, 1e7, 1e8, 1e9, 1e10, 1e11, 1e12, 1e13, 1e14, 1e15, 1e16,
+    1e17, 1e18,
+];
+
+/// The i64 digit `v` maps to under exponent `e`, or `None` when the model does
+/// not reproduce `v` bit-exactly: non-finite, out of the i64 domain after
+/// scaling, or a round-trip that changes any bit (notably `-0.0`, whose sign
+/// the integer path drops).
+fn digit_for(v: f64, e: usize) -> Option<i64> {
+    let scaled = v * POW10[e];
+    // 2^63 as f64; `as i64` saturates but we reject the whole range to stay
+    // inside the exactly-invertible domain.
+    if !scaled.is_finite() || scaled.abs() >= 9_223_372_036_854_775_808.0 {
+        return None;
+    }
+    let digit = scaled.round() as i64;
+    // The decoder computes exactly this; accept only when it is bit-identical.
+    if ((digit as f64) / POW10[e]).to_bits() == v.to_bits() {
+        Some(digit)
+    } else {
+        None
+    }
+}
+
+/// Exponent in `0..=MAX_DECIMAL_EXP` that fits the most values bit-exactly,
+/// ties broken toward the smaller exponent (fewer significant digits, smaller
+/// integers). Returns the exponent and how many values it fits.
+fn best_exponent(values: &[f64]) -> (usize, usize) {
+    let mut best = (0usize, 0usize);
+    for e in 0..=MAX_DECIMAL_EXP {
+        let fits = values
+            .iter()
+            .filter(|&&v| digit_for(v, e).is_some())
+            .count();
+        if fits > best.1 {
+            best = (e, fits);
+            if fits == values.len() {
+                break;
+            }
+        }
+    }
+    best
+}
+
+fn gcd_u64(a: u64, b: u64) -> u64 {
+    let (mut a, mut b) = (a, b);
+    while b != 0 {
+        (a, b) = (b, a % b);
+    }
+    a
+}
+
+// --- self-contained LEB128 varints + zigzag (no dependency on ravel_codec's
+// crate-private varint module) -------------------------------------------
+
+fn put_uvarint(out: &mut Vec<u8>, mut v: u64) {
+    loop {
+        let byte = (v & 0x7f) as u8;
+        v >>= 7;
+        if v == 0 {
+            out.push(byte);
+            break;
+        }
+        out.push(byte | 0x80);
+    }
+}
+
+fn put_ivarint(out: &mut Vec<u8>, v: i64) {
+    put_uvarint(out, ((v << 1) ^ (v >> 63)) as u64);
+}
+
+fn get_uvarint(bytes: &[u8], pos: &mut usize) -> Result<u64, CodecError> {
+    let mut result = 0u64;
+    let mut shift = 0u32;
+    loop {
+        let byte = *bytes.get(*pos).ok_or(CodecError::Truncated)?;
+        *pos += 1;
+        if shift >= 64 {
+            return Err(CodecError::Corrupt);
+        }
+        result |= u64::from(byte & 0x7f) << shift;
+        if byte & 0x80 == 0 {
+            return Ok(result);
+        }
+        shift += 7;
+    }
+}
+
+fn get_ivarint(bytes: &[u8], pos: &mut usize) -> Result<i64, CodecError> {
+    let u = get_uvarint(bytes, pos)?;
+    Ok(((u >> 1) as i64) ^ -((u & 1) as i64))
+}
+
+// --- frame-of-reference bit-packing over i64 (LSB-first) ----------------
+
+/// FOR-packs `values`: zigzag-varint min, then a `bit_width` byte, then each
+/// `(value - min)` LSB-packed at that width. Width 0 (all equal) writes no
+/// packed bytes.
+fn for_pack(out: &mut Vec<u8>, values: &[i64]) {
+    let min = values.iter().copied().min().unwrap_or(0);
+    let max_offset = values
+        .iter()
+        .map(|&v| (v as u64).wrapping_sub(min as u64))
+        .max()
+        .unwrap_or(0);
+    let bit_width = if max_offset == 0 {
+        0
+    } else {
+        64 - max_offset.leading_zeros()
+    };
+    put_ivarint(out, min);
+    out.push(bit_width as u8);
+    if bit_width == 0 {
+        return;
+    }
+    let mask = if bit_width == 64 {
+        u64::MAX
+    } else {
+        (1u64 << bit_width) - 1
+    };
+    let mut acc: u128 = 0;
+    let mut nbits: u32 = 0;
+    for &v in values {
+        let off = (v as u64).wrapping_sub(min as u64);
+        acc |= u128::from(off & mask) << nbits;
+        nbits += bit_width;
+        while nbits >= 8 {
+            out.push((acc & 0xff) as u8);
+            acc >>= 8;
+            nbits -= 8;
+        }
+    }
+    if nbits > 0 {
+        out.push((acc & 0xff) as u8);
+    }
+}
+
+/// Inverse of [`for_pack`] for exactly `count` values, reading from `bytes` at
+/// `pos`. A `bit_width > 64` or a packed region shorter than `count * width`
+/// bits is a typed error, never a panic.
+fn for_unpack(bytes: &[u8], pos: &mut usize, count: usize) -> Result<Vec<i64>, CodecError> {
+    let min = get_ivarint(bytes, pos)?;
+    let bit_width = u32::from(*bytes.get(*pos).ok_or(CodecError::Truncated)?);
+    *pos += 1;
+    if bit_width > 64 {
+        return Err(CodecError::Corrupt);
+    }
+    if bit_width == 0 {
+        return Ok(vec![min; count]);
+    }
+    let need_bits = (count as u64)
+        .checked_mul(u64::from(bit_width))
+        .ok_or(CodecError::Overflow)?;
+    let need = usize::try_from(need_bits.div_ceil(8)).map_err(|_| CodecError::Overflow)?;
+    let region = bytes.get(*pos..*pos + need).ok_or(CodecError::Truncated)?;
+    *pos += need;
+    let mask = if bit_width == 64 {
+        u64::MAX
+    } else {
+        (1u64 << bit_width) - 1
+    };
+    let mut out = Vec::with_capacity(count.min(1 << 16));
+    let mut acc: u128 = 0;
+    let mut nbits: u32 = 0;
+    let mut byte_idx = 0usize;
+    for _ in 0..count {
+        while nbits < bit_width {
+            acc |= u128::from(region[byte_idx]) << nbits;
+            byte_idx += 1;
+            nbits += 8;
+        }
+        let off = (acc as u64) & mask;
+        acc >>= bit_width;
+        nbits -= bit_width;
+        out.push((min as u64).wrapping_add(off) as i64);
+    }
+    Ok(out)
+}
+
+// --- ALP -----------------------------------------------------------------
+
+/// ALP codec (see module docs). Stateless handle.
+pub struct Alp;
+
+impl ValueCodec for Alp {
+    fn name(&self) -> &'static str {
+        "alp"
+    }
+
+    fn encode(&self, values: &[f64]) -> Vec<u8> {
+        if values.is_empty() {
+            return Vec::new();
+        }
+        let (e, _fits) = best_exponent(values);
+        // Digits for fit positions; a placeholder 0 for exceptions, so the
+        // integer stream stays length `count` and the exceptions overwrite it.
+        let mut digits = Vec::with_capacity(values.len());
+        let mut exceptions: Vec<(usize, u64)> = Vec::new();
+        for (i, &v) in values.iter().enumerate() {
+            match digit_for(v, e) {
+                Some(d) => digits.push(d),
+                None => {
+                    digits.push(0);
+                    exceptions.push((i, v.to_bits()));
+                }
+            }
+        }
+        let (enc, int_bytes) = encode_i64(&digits);
+        let mut out = Vec::new();
+        out.push(e as u8);
+        out.push(enc.to_u8());
+        put_uvarint(&mut out, int_bytes.len() as u64);
+        out.extend_from_slice(&int_bytes);
+        put_uvarint(&mut out, exceptions.len() as u64);
+        for (idx, bits) in &exceptions {
+            put_uvarint(&mut out, *idx as u64);
+            out.extend_from_slice(&bits.to_le_bytes());
+        }
+        out
+    }
+
+    fn decode(&self, bytes: &[u8], count: usize) -> Result<Vec<f64>, CodecError> {
+        if count == 0 {
+            return Ok(Vec::new());
+        }
+        let mut pos = 0usize;
+        let e = usize::from(*bytes.get(pos).ok_or(CodecError::Truncated)?);
+        pos += 1;
+        if e > MAX_DECIMAL_EXP {
+            return Err(CodecError::Corrupt);
+        }
+        let enc_tag = *bytes.get(pos).ok_or(CodecError::Truncated)?;
+        pos += 1;
+        let enc = Enc::from_u8(enc_tag).map_err(|_| CodecError::Corrupt)?;
+        let int_len =
+            usize::try_from(get_uvarint(bytes, &mut pos)?).map_err(|_| CodecError::Overflow)?;
+        let int_end = pos.checked_add(int_len).ok_or(CodecError::Truncated)?;
+        let int_bytes = bytes.get(pos..int_end).ok_or(CodecError::Truncated)?;
+        pos += int_len;
+        let digits = decode_i64(enc, int_bytes, count).map_err(|_| CodecError::Corrupt)?;
+        if digits.len() != count {
+            return Err(CodecError::Corrupt);
+        }
+        let mut out: Vec<f64> = digits.iter().map(|&d| (d as f64) / POW10[e]).collect();
+        let n_exc =
+            usize::try_from(get_uvarint(bytes, &mut pos)?).map_err(|_| CodecError::Overflow)?;
+        for _ in 0..n_exc {
+            let idx =
+                usize::try_from(get_uvarint(bytes, &mut pos)?).map_err(|_| CodecError::Overflow)?;
+            let raw_end = pos.checked_add(8).ok_or(CodecError::Truncated)?;
+            let raw = bytes.get(pos..raw_end).ok_or(CodecError::Truncated)?;
+            pos += 8;
+            let arr: [u8; 8] = raw.try_into().map_err(|_| CodecError::Truncated)?;
+            *out.get_mut(idx).ok_or(CodecError::Corrupt)? = f64::from_bits(u64::from_le_bytes(arr));
+        }
+        Ok(out)
+    }
+}
+
+// --- GCD-of-deltas + frame-of-reference ---------------------------------
+
+/// GCD-of-deltas then FOR bit-packing (see module docs). Stateless handle.
+pub struct GcdDeltaFor;
+
+/// Model marker byte written first: whole-page raw fallback vs the integer
+/// model.
+const GDF_RAW: u8 = 0;
+const GDF_MODEL: u8 = 1;
+
+impl GcdDeltaFor {
+    /// Digits under the smallest exponent that fits *every* value, or `None`
+    /// when no exponent does (then the page falls back to raw f64).
+    fn model_digits(values: &[f64]) -> Option<(usize, Vec<i64>)> {
+        for e in 0..=MAX_DECIMAL_EXP {
+            let mut digits = Vec::with_capacity(values.len());
+            let mut all = true;
+            for &v in values {
+                match digit_for(v, e) {
+                    Some(d) => digits.push(d),
+                    None => {
+                        all = false;
+                        break;
+                    }
+                }
+            }
+            if all {
+                return Some((e, digits));
+            }
+        }
+        None
+    }
+}
+
+impl ValueCodec for GcdDeltaFor {
+    fn name(&self) -> &'static str {
+        "gcd_delta_for"
+    }
+
+    fn encode(&self, values: &[f64]) -> Vec<u8> {
+        if values.is_empty() {
+            return Vec::new();
+        }
+        let modelled = GcdDeltaFor::model_digits(values).and_then(|(e, digits)| {
+            // Deltas of the digit stream; a checked_sub failure (astronomical
+            // spread) drops to raw.
+            let mut deltas = Vec::with_capacity(digits.len().saturating_sub(1));
+            for w in digits.windows(2) {
+                deltas.push(w[1].checked_sub(w[0])?);
+            }
+            let g = deltas
+                .iter()
+                .fold(0u64, |acc, &d| gcd_u64(acc, d.unsigned_abs()));
+            let g = g.max(1);
+            let reduced: Vec<i64> = deltas.iter().map(|&d| d / g as i64).collect();
+            let mut out = vec![GDF_MODEL, e as u8];
+            put_ivarint(&mut out, digits[0]);
+            put_uvarint(&mut out, g);
+            for_pack(&mut out, &reduced);
+            Some(out)
+        });
+        modelled.unwrap_or_else(|| {
+            let mut out = Vec::with_capacity(values.len() * 8 + 1);
+            out.push(GDF_RAW);
+            for v in values {
+                out.extend_from_slice(&v.to_bits().to_le_bytes());
+            }
+            out
+        })
+    }
+
+    fn decode(&self, bytes: &[u8], count: usize) -> Result<Vec<f64>, CodecError> {
+        if count == 0 {
+            return Ok(Vec::new());
+        }
+        let (&marker, body) = bytes.split_first().ok_or(CodecError::Truncated)?;
+        match marker {
+            GDF_RAW => {
+                let expected = count.checked_mul(8).ok_or(CodecError::Overflow)?;
+                if body.len() != expected {
+                    return Err(CodecError::LengthMismatch {
+                        expected,
+                        actual: body.len(),
+                        count,
+                    });
+                }
+                let mut out = Vec::with_capacity(count);
+                for chunk in body.chunks_exact(8) {
+                    let arr: [u8; 8] = chunk.try_into().map_err(|_| CodecError::Truncated)?;
+                    out.push(f64::from_bits(u64::from_le_bytes(arr)));
+                }
+                Ok(out)
+            }
+            GDF_MODEL => {
+                let mut pos = 0usize;
+                let e = usize::from(*body.get(pos).ok_or(CodecError::Truncated)?);
+                pos += 1;
+                if e > MAX_DECIMAL_EXP {
+                    return Err(CodecError::Corrupt);
+                }
+                let first = get_ivarint(body, &mut pos)?;
+                let g = get_uvarint(body, &mut pos)?;
+                if g == 0 {
+                    return Err(CodecError::Corrupt);
+                }
+                let reduced = for_unpack(body, &mut pos, count - 1)?;
+                let g = g as i64;
+                let mut digits = Vec::with_capacity(count);
+                digits.push(first);
+                let mut acc = first;
+                for r in reduced {
+                    let step = r.checked_mul(g).ok_or(CodecError::Corrupt)?;
+                    acc = acc.checked_add(step).ok_or(CodecError::Corrupt)?;
+                    digits.push(acc);
+                }
+                Ok(digits.iter().map(|&d| (d as f64) / POW10[e]).collect())
+            }
+            _ => Err(CodecError::Corrupt),
+        }
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
@@ -492,6 +900,8 @@ mod tests {
     #[test]
     fn all_codecs_roundtrip_special_values() {
         let values = special_values();
+        roundtrip(&Alp, &values);
+        roundtrip(&GcdDeltaFor, &values);
         roundtrip(&Chimp128, &values);
         roundtrip(&ByteSplitZstd, &values);
         roundtrip(&RawF64, &values);
@@ -500,10 +910,50 @@ mod tests {
     #[test]
     fn empty_and_single_roundtrip() {
         for values in [vec![], vec![7.25], vec![f64::NAN]] {
+            roundtrip(&Alp, &values);
+            roundtrip(&GcdDeltaFor, &values);
             roundtrip(&Chimp128, &values);
             roundtrip(&ByteSplitZstd, &values);
             roundtrip(&RawF64, &values);
         }
+    }
+
+    #[test]
+    fn integer_and_decimal_streams_roundtrip() {
+        // Integer counter, 2-dp and 3-dp decimals: the paths the two integer
+        // codecs model rather than fall back on.
+        let counter: Vec<f64> = (0..200).map(|i| (i * 3) as f64).collect();
+        let dec2: Vec<f64> = (0..200).map(|i| (i as f64) * 0.01 + 3.57).collect();
+        let dec3: Vec<f64> = (0..200).map(|i| (i as f64) * 0.001 - 2.501).collect();
+        for values in [&counter, &dec2, &dec3] {
+            roundtrip(&Alp, values);
+            roundtrip(&GcdDeltaFor, values);
+        }
+    }
+
+    #[test]
+    fn alp_negative_zero_is_an_exception() {
+        // -0.0 * 10^e rounds to integer 0, which decodes to +0.0; ALP must
+        // route it through the exception list to preserve the sign bit.
+        let values = vec![1.0, -0.0, 2.0, -0.0, 3.0];
+        let encoded = Alp.encode(&values);
+        let decoded = Alp.decode(&encoded, values.len()).expect("decode");
+        assert_eq!(bits(&decoded), bits(&values));
+        assert!(decoded[1].is_sign_negative());
+    }
+
+    #[test]
+    fn gcd_delta_for_reduces_regular_counter() {
+        // A counter stepping by a constant 250 has all deltas == 250; the GCD
+        // is 250, reduced deltas are all 1, and the model beats raw f64.
+        let values: Vec<f64> = (0..240).map(|i| (i * 250) as f64).collect();
+        let encoded = GcdDeltaFor.encode(&values);
+        assert!(
+            encoded.len() < values.len() * 8,
+            "gcd_delta_for must beat raw on a constant-stride counter"
+        );
+        let decoded = GcdDeltaFor.decode(&encoded, values.len()).expect("decode");
+        assert_eq!(bits(&decoded), bits(&values));
     }
 
     #[test]
@@ -526,6 +976,8 @@ mod tests {
             Chimp128.encode(&values),
             ByteSplitZstd.encode(&values),
             RawF64.encode(&values),
+            Alp.encode(&values),
+            GcdDeltaFor.encode(&values),
         ]
         .into_iter()
         .enumerate()
@@ -536,7 +988,9 @@ mod tests {
                 let _ = match which {
                     0 => Chimp128.decode(truncated, values.len()),
                     1 => ByteSplitZstd.decode(truncated, values.len()),
-                    _ => RawF64.decode(truncated, values.len()),
+                    2 => RawF64.decode(truncated, values.len()),
+                    3 => Alp.decode(truncated, values.len()),
+                    _ => GcdDeltaFor.decode(truncated, values.len()),
                 };
                 // No panic is the assertion; result may be Ok or Err.
             }

--- a/crates/ravel-bench/src/lib.rs
+++ b/crates/ravel-bench/src/lib.rs
@@ -1,6 +1,7 @@
 //! Benchmark harness for Ravel. Report-only: this crate never changes library
 //! behavior, it only measures it.
 
+pub mod bench_env;
 pub mod codecs;
 pub mod concurrent;
 pub mod distrib_crossover;

--- a/crates/ravel-bench/src/segment_support.rs
+++ b/crates/ravel-bench/src/segment_support.rs
@@ -15,9 +15,10 @@
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
 use ravel_segment::{
-    CompactionMetaV4, Footer, IngestBounds, ReaderLimits, RunInputV4, RunValuePageV4,
+    CompactionMetaV4, Footer, IngestBounds, ReaderLimits, RunEntry, RunInputV4, RunValuePageV4,
     SegmentIdentity, SegmentWriter, SeriesEntry, SeriesEntryV4, SeriesInputV3, SeriesInputV4,
-    SeriesValues, WrittenSegment, decode_catalog_v5, open_from_full,
+    SeriesValues, WrittenSegment, decode_catalog_v5, decode_run_pages_soa, encode_run_v4,
+    open_from_full,
 };
 use ravel_types::{LabelSet, Sample, SeriesId};
 
@@ -196,6 +197,117 @@ pub fn decode_matching_entries(
         .map(fold_entry)
         .collect();
     (loc.footer, folded)
+}
+
+// --- production single-run page access for the codec bake-offs ----------
+//
+// The value and timestamp bake-offs (`src/bin/codec_bakeoff.rs`,
+// `src/bin/ts_bakeoff.rs`) need the *production* encoding of one page, reached
+// through the public API rather than reimplemented. `encode_run_v4` is the only
+// public entry that frames a real RSEG run (a 6-byte-header TS page under the
+// TS_DELTA_VARINT + 64-byte-floor-LZ4 rule, and a VAL page under the
+// Gorilla/raw-fallback rule), and `decode_run_pages_soa` is its inverse. Both
+// frame a whole run, so a value measurement carries a fixed TS-framing cost the
+// payload-only challengers do not; the bins state this in their output.
+
+/// Fixed synthetic timestamp base and 15 s step for a value-codec run. A value
+/// codec only cares about the value payload, but the production writer frames a
+/// whole run, so it is handed regular millisecond-epoch timestamps.
+const BAKEOFF_TS_START_NS: i64 = 1_700_000_000_000_000_000;
+const BAKEOFF_TS_STEP_NS: i64 = 15_000_000_000;
+
+/// A fixed series id for bake-off runs. Any value works: the page crc binds
+/// `series_id || enc || comp || payload`, and encode and decode here use the
+/// same id, so verification passes.
+fn bakeoff_series_id() -> SeriesId {
+    SeriesId([7u8; 16])
+}
+
+/// One scalar run framed through the production writer ([`encode_run_v4`]) over
+/// `values` with synthetic regular timestamps. The value bake-off reads
+/// [`scalar_val_page`] off the result; the timestamps exist only because the
+/// run frames a TS page too.
+pub fn production_scalar_run(values: &[f64]) -> RunInputV4 {
+    let samples: Vec<Sample> = values
+        .iter()
+        .enumerate()
+        .map(|(i, &value)| Sample {
+            ts_ns: BAKEOFF_TS_START_NS + i as i64 * BAKEOFF_TS_STEP_NS,
+            value,
+        })
+        .collect();
+    encode_run_v4(
+        &bakeoff_series_id(),
+        0,
+        0,
+        0,
+        &SeriesValues::Scalar(samples),
+    )
+    .expect("encode scalar run through production writer")
+}
+
+/// The framed VAL page of a scalar run: byte 0 is the enc tag (16 Gorilla,
+/// 17 raw f64), byte 1 the comp tag, bytes 2..6 the crc, bytes 6.. the payload.
+pub fn scalar_val_page(run: &RunInputV4) -> &[u8] {
+    let RunValuePageV4::Scalar(bytes) = &run.value_page else {
+        panic!("production_scalar_run always frames a scalar value page");
+    };
+    bytes
+}
+
+/// One scalar run framed through the production writer over `ts_ns` (values are
+/// irrelevant to the TS page, so they are all zero). The timestamp bake-off
+/// reads `ts_page` off the result: a real 6-byte-header TS_DELTA_VARINT page,
+/// LZ4-compressed exactly when the writer's 64-byte floor rule fires.
+pub fn production_ts_run(ts_ns: &[i64]) -> RunInputV4 {
+    let samples: Vec<Sample> = ts_ns
+        .iter()
+        .map(|&ts_ns| Sample { ts_ns, value: 0.0 })
+        .collect();
+    encode_run_v4(
+        &bakeoff_series_id(),
+        0,
+        0,
+        0,
+        &SeriesValues::Scalar(samples),
+    )
+    .expect("encode scalar run through production writer")
+}
+
+/// Decodes a production scalar run's TS and VAL pages back to `(timestamps,
+/// values)` through [`decode_run_pages_soa`], the inverse of
+/// [`production_scalar_run`]. Used to time the production decode path and to
+/// assert the production round trip is bit-exact.
+pub fn decode_scalar_run(run: &RunInputV4) -> (Vec<i64>, Vec<f64>) {
+    let entry = RunEntry {
+        created_unix_ns: run.created_unix_ns,
+        writer_epoch: run.writer_epoch,
+        writer_seq: run.writer_seq,
+        sample_count: run.sample_count,
+        min_ts_ns: run.min_ts_ns,
+        max_ts_ns: run.max_ts_ns,
+        ts_page: (0, 0),
+        val_page: (0, 0),
+        hist_page: (0, 0),
+    };
+    let RunValuePageV4::Scalar(val_bytes) = &run.value_page else {
+        panic!("production_scalar_run always frames a scalar value page");
+    };
+    let mut scratch = Vec::new();
+    let mut timestamps = Vec::new();
+    let mut values = Vec::new();
+    decode_run_pages_soa(
+        &bakeoff_series_id(),
+        &entry,
+        &run.ts_page,
+        val_bytes,
+        ReaderLimits::default(),
+        &mut scratch,
+        &mut timestamps,
+        &mut values,
+    )
+    .expect("decode scalar run");
+    (timestamps, values)
 }
 
 /// Raw VAL page bytes for one series entry (header + payload, undecoded):

--- a/crates/ravel-bench/tests/catalog_byte_gates.rs
+++ b/crates/ravel-bench/tests/catalog_byte_gates.rs
@@ -14,9 +14,17 @@
 //! `cargo test -- --nocapture` output can be diffed across runs.
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
+use ravel_bench::generator::{CardinalityProfile, WorkloadConfig, generate_raw};
 use ravel_bench::section_accounting::shape_many_small;
-use ravel_bench::segment_support::{SERIES_IDX, SERIES_META, SERIES_META_CHUNKS, build_segment_v5};
-use ravel_segment::{ReaderLimits, open_from_full};
+use ravel_bench::segment_support::{
+    LABEL_DICT, SERIES_IDS, SERIES_IDX, SERIES_META, SERIES_META_CHUNKS, TS_PAGES, VAL_PAGES,
+    bench_bounds, bench_identity, bench_meta, build_segment_v5,
+};
+use ravel_segment::{
+    ReaderLimits, RunInputV4, SegmentWriter, SeriesInputV4, SeriesValues, WrittenSegment,
+    encode_run_v4, open_from_full,
+};
+use ravel_types::{LabelSet, Sample, SeriesId};
 
 /// 10k `many_small` series, 20k total samples: >= the 4096 sparse-emission
 /// threshold, a fraction of the 100k report's runtime.
@@ -89,6 +97,205 @@ fn v5_measurements_are_deterministic() {
             v5.bytes.len() as u64,
             section_len(&v5.bytes, SERIES_IDX),
             section_len(&v5.bytes, SERIES_META_CHUNKS),
+        )
+    };
+    assert_eq!(measure(), measure());
+}
+
+// --- run-fragmentation byte gate (issue #312, ADR-0092) -----------------
+//
+// The gate above builds one run of two samples per series, so it measures the
+// per-series identity floor and cannot see run fragmentation. This gate builds
+// the SAME sample data two ways through `SegmentWriter::write_v5` and pins that
+// the fragmented layout costs materially more per sample than the merged one,
+// which is the whole premise of ADR-0092's run-merging L1.
+
+/// Fragmentation fixture: 500 series, 240 samples each, 15 s spacing,
+/// millisecond-resolution timestamps with +/-200 ms jitter. 500 series is
+/// below the 4096 sparse-emission threshold, so both layouts emit a plain
+/// SERIES_META (not SERIES_META_CHUNKS), matching ADR-0092's measured table.
+const FRAG_SERIES: usize = 500;
+const FRAG_SAMPLES_PER_SERIES: usize = 240;
+const FRAG_INTERVAL_NS: i64 = 15_000_000_000;
+const FRAG_JITTER_NS: i64 = 200_000_000;
+const MS_NS: i64 = 1_000_000;
+
+/// A flush is modelled 2 s apart (ADR-0076 `max_flush_delay`), so the
+/// fragmented layout's per-run provenance columns carry realistic distinct
+/// values rather than an all-zero column that would understate its cost.
+const FRAG_FLUSH_SPACING_NS: i64 = 2_000_000_000;
+
+/// One deterministic workload: 500 series x 240 samples, timestamps snapped to
+/// millisecond resolution and sorted ascending. Fixed seed, no wall-clock
+/// time. Both layouts consume this identical data, so the comparison is
+/// apples-to-apples.
+fn fragmentation_workload() -> Vec<(SeriesId, LabelSet, Vec<Sample>)> {
+    let config = WorkloadConfig {
+        series_count: FRAG_SERIES,
+        samples_per_series: FRAG_SAMPLES_PER_SERIES,
+        interval_ns: FRAG_INTERVAL_NS,
+        jitter_ns: FRAG_JITTER_NS,
+        cardinality: CardinalityProfile::many_small(FRAG_SERIES),
+        ..Default::default()
+    };
+    let mut raw = generate_raw(&config).expect("generate fragmentation workload");
+    for (_, _, samples) in &mut raw {
+        for s in samples.iter_mut() {
+            // Snap to millisecond resolution.
+            s.ts_ns = (s.ts_ns / MS_NS) * MS_NS;
+        }
+        samples.sort_by_key(|s| s.ts_ns);
+    }
+    raw
+}
+
+/// Merged layout: one run of N samples per series (one L0 flush's worth,
+/// carrying one provenance triple).
+fn build_merged(raw: &[(SeriesId, LabelSet, Vec<Sample>)]) -> WrittenSegment {
+    let inputs: Vec<SeriesInputV4> = raw
+        .iter()
+        .map(|(series_id, labels, samples)| {
+            let run = encode_run_v4(
+                series_id,
+                1_700_000_000_000_000_000,
+                0,
+                0,
+                &SeriesValues::Scalar(samples.clone()),
+            )
+            .expect("encode merged run");
+            SeriesInputV4 {
+                series_id: *series_id,
+                labels: labels.clone(),
+                runs: vec![run],
+            }
+        })
+        .collect();
+    SegmentWriter::write_v5(inputs, bench_identity(), bench_bounds(), bench_meta())
+        .expect("write merged v5")
+}
+
+/// Fragmented layout: N runs of one sample per series, each modelling a
+/// separate L0 flush with its own provenance. Every one-sample value page
+/// falls back to raw f64 and every one-sample timestamp page is an absolute
+/// varint, exactly the regime ADR-0092 measures.
+fn build_fragmented(raw: &[(SeriesId, LabelSet, Vec<Sample>)]) -> WrittenSegment {
+    let inputs: Vec<SeriesInputV4> = raw
+        .iter()
+        .map(|(series_id, labels, samples)| {
+            let runs: Vec<RunInputV4> = samples
+                .iter()
+                .enumerate()
+                .map(|(k, sample)| {
+                    encode_run_v4(
+                        series_id,
+                        1_700_000_000_000_000_000 + k as i64 * FRAG_FLUSH_SPACING_NS,
+                        0,
+                        k as u64,
+                        &SeriesValues::Scalar(vec![*sample]),
+                    )
+                    .expect("encode fragmented run")
+                })
+                .collect();
+            SeriesInputV4 {
+                series_id: *series_id,
+                labels: labels.clone(),
+                runs,
+            }
+        })
+        .collect();
+    SegmentWriter::write_v5(inputs, bench_identity(), bench_bounds(), bench_meta())
+        .expect("write fragmented v5")
+}
+
+/// The five per-section byte-per-sample figures ADR-0092 reports, plus the
+/// object total.
+struct SectionSplit {
+    label_dict: f64,
+    series_ids: f64,
+    series_meta: f64,
+    ts_pages: f64,
+    val_pages: f64,
+    total: f64,
+}
+
+fn section_split(seg: &WrittenSegment, total_samples: usize) -> SectionSplit {
+    let n = total_samples as f64;
+    let per = |kind: u32| section_len(&seg.bytes, kind) as f64 / n;
+    // At 500 series the layout is non-sparse: SERIES_META (kind 6) carries the
+    // run-major columns; SERIES_META_CHUNKS (kind 9) is absent (len 0).
+    let series_meta = per(SERIES_META) + per(SERIES_META_CHUNKS);
+    SectionSplit {
+        label_dict: per(LABEL_DICT),
+        series_ids: per(SERIES_IDS),
+        series_meta,
+        ts_pages: per(TS_PAGES),
+        val_pages: per(VAL_PAGES),
+        total: seg.bytes.len() as f64 / n,
+    }
+}
+
+fn print_split(name: &str, s: &SectionSplit) {
+    println!(
+        "[fragmentation {name}] total={:.2} B/sample  \
+         LABEL_DICT={:.2} SERIES_IDS={:.2} SERIES_META={:.2} TS_PAGES={:.2} VAL_PAGES={:.2}",
+        s.total, s.label_dict, s.series_ids, s.series_meta, s.ts_pages, s.val_pages,
+    );
+}
+
+/// Pinned lower bound on `fragmented_total / merged_total`. Measured on this
+/// tree the ratio is about 3.0 (see the printed splits); ADR-0092's own table
+/// reports 3.68 for the same workload built through the full production writer
+/// with real per-run provenance. This gate pins a conservative 2.5x with
+/// margin so it flags a regression in the fragmentation penalty without being
+/// brittle to codec-level byte wobble.
+const FRAG_RATIO_MIN: f64 = 2.5;
+
+#[test]
+fn fragmented_multi_run_shape_costs_more_than_merged() {
+    let raw = fragmentation_workload();
+    let total_samples: usize = raw.iter().map(|(_, _, s)| s.len()).sum();
+    assert_eq!(total_samples, FRAG_SERIES * FRAG_SAMPLES_PER_SERIES);
+
+    let merged = build_merged(&raw);
+    let fragmented = build_fragmented(&raw);
+
+    let merged_split = section_split(&merged, total_samples);
+    let fragmented_split = section_split(&fragmented, total_samples);
+
+    // Both splits printed on success so the numbers can be diffed across runs.
+    print_split("merged", &merged_split);
+    print_split("fragmented", &fragmented_split);
+
+    // Sanity: at 500 series both layouts are non-sparse (plain SERIES_META,
+    // no chunked catalog).
+    assert_eq!(
+        section_len(&merged.bytes, SERIES_META_CHUNKS),
+        0,
+        "500 series is below the sparse threshold: no SERIES_META_CHUNKS"
+    );
+
+    let ratio = fragmented_split.total / merged_split.total;
+    println!(
+        "[fragmentation] fragmented/merged total ratio = {ratio:.3} (gate >= {FRAG_RATIO_MIN})"
+    );
+
+    assert!(
+        ratio >= FRAG_RATIO_MIN,
+        "fragmented layout ({:.2} B/sample) must exceed merged ({:.2} B/sample) by >= {FRAG_RATIO_MIN}x, got {ratio:.3}x",
+        fragmented_split.total,
+        merged_split.total,
+    );
+}
+
+/// Determinism: the fixed-seed workload -> both writers yields byte-identical
+/// object sizes on a second run, so the pinned ratio never wobbles.
+#[test]
+fn fragmentation_measurements_are_deterministic() {
+    let measure = || {
+        let raw = fragmentation_workload();
+        (
+            build_merged(&raw).bytes.len(),
+            build_fragmented(&raw).bytes.len(),
         )
     };
     assert_eq!(measure(), measure());

--- a/crates/ravel-bench/tests/codec_roundtrip.rs
+++ b/crates/ravel-bench/tests/codec_roundtrip.rs
@@ -11,7 +11,7 @@
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
 use proptest::prelude::*;
-use ravel_bench::codecs::{ByteSplitZstd, Chimp128, RawF64, ValueCodec};
+use ravel_bench::codecs::{Alp, ByteSplitZstd, Chimp128, GcdDeltaFor, RawF64, ValueCodec};
 
 fn bits(values: &[f64]) -> Vec<u64> {
     values.iter().map(|v| v.to_bits()).collect()
@@ -32,6 +32,8 @@ fn assert_roundtrip<C: ValueCodec>(codec: &C, values: &[f64]) {
 }
 
 fn assert_roundtrip_all(values: &[f64]) {
+    assert_roundtrip(&Alp, values);
+    assert_roundtrip(&GcdDeltaFor, values);
     assert_roundtrip(&Chimp128, values);
     assert_roundtrip(&ByteSplitZstd, values);
     assert_roundtrip(&RawF64, values);
@@ -88,9 +90,55 @@ proptest! {
 
     #[test]
     fn arbitrary_bitpatterns_roundtrip(values in proptest::collection::vec(any_f64(), 0..600)) {
+        assert_roundtrip(&Alp, &values);
+        assert_roundtrip(&GcdDeltaFor, &values);
         assert_roundtrip(&Chimp128, &values);
         assert_roundtrip(&ByteSplitZstd, &values);
         assert_roundtrip(&RawF64, &values);
+    }
+
+    // Integer- and fixed-decimal streams are the paths ALP and GCD-FOR model
+    // (rather than fall back on), so they exercise the exponent-recovery,
+    // exception, and GCD-reduction logic that random bit patterns skip. All
+    // must still round-trip bit-exactly.
+    #[test]
+    fn decimal_streams_roundtrip(
+        ints in proptest::collection::vec(-1_000_000i64..1_000_000, 1..300),
+        places in 0i32..4,
+    ) {
+        let scale = 10f64.powi(places);
+        let values: Vec<f64> = ints.iter().map(|&i| (i as f64) / scale).collect();
+        assert_roundtrip(&Alp, &values);
+        assert_roundtrip(&GcdDeltaFor, &values);
+        assert_roundtrip(&Chimp128, &values);
+        assert_roundtrip(&ByteSplitZstd, &values);
+        assert_roundtrip(&RawF64, &values);
+    }
+
+    // A decimal stream salted with occasional special values (NaN, -0.0, inf):
+    // the model fits most, and the special values must survive as ALP
+    // exceptions / GCD-FOR raw-fallback, bit-for-bit.
+    #[test]
+    fn decimal_with_exceptions_roundtrip(
+        ints in proptest::collection::vec(-100_000i64..100_000, 2..200),
+        specials in proptest::collection::vec(
+            prop_oneof![
+                Just(f64::NAN),
+                Just(-0.0f64),
+                Just(f64::INFINITY),
+                Just(f64::NEG_INFINITY),
+                Just(f64::from_bits(1)),
+            ],
+            0..8,
+        ),
+    ) {
+        let mut values: Vec<f64> = ints.iter().map(|&i| (i as f64) / 100.0).collect();
+        for (k, s) in specials.into_iter().enumerate() {
+            let idx = k % values.len();
+            values[idx] = s;
+        }
+        assert_roundtrip(&Alp, &values);
+        assert_roundtrip(&GcdDeltaFor, &values);
     }
 
     // Streams built from a tiny alphabet of close values exercise Chimp's
@@ -104,6 +152,8 @@ proptest! {
             .iter()
             .map(|&s| f64::from_bits(base ^ u64::from(s)))
             .collect();
+        assert_roundtrip(&Alp, &values);
+        assert_roundtrip(&GcdDeltaFor, &values);
         assert_roundtrip(&Chimp128, &values);
         assert_roundtrip(&ByteSplitZstd, &values);
         assert_roundtrip(&RawF64, &values);
@@ -116,6 +166,8 @@ proptest! {
         bytes in proptest::collection::vec(any::<u8>(), 0..2048),
         count in 0usize..800,
     ) {
+        let _ = Alp.decode(&bytes, count);
+        let _ = GcdDeltaFor.decode(&bytes, count);
         let _ = Chimp128.decode(&bytes, count);
         let _ = ByteSplitZstd.decode(&bytes, count);
         let _ = RawF64.decode(&bytes, count);
@@ -129,11 +181,13 @@ proptest! {
         values in proptest::collection::vec(any_f64(), 2..200),
         cut in 1usize..40,
     ) {
-        for codec_kind in 0..3u8 {
+        for codec_kind in 0..5u8 {
             let encoded = match codec_kind {
                 0 => Chimp128.encode(&values),
                 1 => ByteSplitZstd.encode(&values),
-                _ => RawF64.encode(&values),
+                2 => RawF64.encode(&values),
+                3 => Alp.encode(&values),
+                _ => GcdDeltaFor.encode(&values),
             };
             if cut >= encoded.len() {
                 continue;
@@ -142,7 +196,9 @@ proptest! {
             let decoded = match codec_kind {
                 0 => Chimp128.decode(truncated, values.len()),
                 1 => ByteSplitZstd.decode(truncated, values.len()),
-                _ => RawF64.decode(truncated, values.len()),
+                2 => RawF64.decode(truncated, values.len()),
+                3 => Alp.decode(truncated, values.len()),
+                _ => GcdDeltaFor.decode(truncated, values.len()),
             };
             // RawF64 loses exactly `cut` bytes so the length can never match.
             if codec_kind == 2 {


### PR DESCRIPTION
Produces the numbers that ADR-0092 decision 6 defers to, so the next segment format's encodings are chosen from measurement rather than reasoning. All work is confined to `crates/ravel-bench`; no production crate or path is touched.

**Fragmentation.** A new byte gate builds one identical 500-series, 240-sample workload two ways through `SegmentWriter::write_v5`: 240 runs of one sample per series, and one run of 240 samples. Measured 36.52 vs 11.68 bytes per sample, ratio 3.126x, gate pinned at 2.5x for margin. It builds both shapes directly through the writer and never invokes the compactor, so it pins the format-level fragmentation penalty, not a compaction regression.

**Value codecs.** ALP and GCD-of-deltas-plus-frame-of-reference, measured against the production Gorilla path. Both clear the 75% rule decisively on integer counters (0.415 / 0.511), integer gauges (0.446 for GCD), decimal gauges (0.226 / 0.165) and constant series (0.070 / 0.085), and fall back to about 1.0 on noisy floats rather than expanding. Nothing failed bit-exactness.

**Timestamps.** Nothing beats the production path on exactly-regular streams, where LZ4 already reaches 0.16 bytes per sample. GCD plus `encode_i64` wins on jittered millisecond streams (4.66 to 1.82) and irregular ones (3.60 to 1.02), and gives nothing on true nanoseconds.

Two changes on top of the dispatched result: the raw report is not committed, since the root `.gitignore` excludes `/bench/` and the measurements live in the epic issue instead; and `Alp::decode` computed two slice bounds with unchecked addition, so a corrupt length varint could panic rather than return the typed error the module documents. Both now use `checked_add`.

Fixes: #312