### PR TITLE
refactor(distrib): address CodeRabbit follow-ups on span fan-out

### DIFF
--- a/crates/ravel-query/src/distrib/client.rs
+++ b/crates/ravel-query/src/distrib/client.rs
@@ -224,11 +224,19 @@ impl RemoteSliceFetcher {
     pub fn new(channel: Channel) -> Self {
         RemoteSliceFetcher { channel }
     }
-}
 
-#[async_trait::async_trait]
-impl SliceFetcher for RemoteSliceFetcher {
-    async fn fetch(&self, request: pb::FetchRequest) -> Result<SliceResponse, DistribError> {
+    /// Dispatches one slice request and drains the worker's response stream into
+    /// a flat `Vec` of frames. The signal-agnostic transport half shared by
+    /// [`fetch`](SliceFetcher::fetch),
+    /// [`fetch_logs`](SliceFetcher::fetch_logs), and
+    /// [`fetch_spans`](SliceFetcher::fetch_spans): each of those calls this, then
+    /// applies its own per-signal decode to the frames. Any transport failure (the
+    /// call itself or a mid-stream `message()`) is mapped to
+    /// [`DistribError::Transport`]; framing/decode is the caller's concern.
+    async fn collect_frames(
+        &self,
+        request: pb::FetchRequest,
+    ) -> Result<Vec<pb::FetchResponse>, DistribError> {
         let mut client = SeriesFetchClient::new(self.channel.clone());
         let response = client
             .fetch(request)
@@ -243,6 +251,14 @@ impl SliceFetcher for RemoteSliceFetcher {
         {
             frames.push(frame);
         }
+        Ok(frames)
+    }
+}
+
+#[async_trait::async_trait]
+impl SliceFetcher for RemoteSliceFetcher {
+    async fn fetch(&self, request: pb::FetchRequest) -> Result<SliceResponse, DistribError> {
+        let frames = self.collect_frames(request).await?;
         decode_slice_frames(frames)
     }
 
@@ -250,20 +266,7 @@ impl SliceFetcher for RemoteSliceFetcher {
         &self,
         request: pb::FetchRequest,
     ) -> Result<SliceLogResponse, DistribError> {
-        let mut client = SeriesFetchClient::new(self.channel.clone());
-        let response = client
-            .fetch(request)
-            .await
-            .map_err(|s| DistribError::Transport(s.to_string()))?;
-        let mut stream = response.into_inner();
-        let mut frames = Vec::new();
-        while let Some(frame) = stream
-            .message()
-            .await
-            .map_err(|s| DistribError::Transport(s.to_string()))?
-        {
-            frames.push(frame);
-        }
+        let frames = self.collect_frames(request).await?;
         decode_log_slice_frames(frames)
     }
 
@@ -271,20 +274,7 @@ impl SliceFetcher for RemoteSliceFetcher {
         &self,
         request: pb::FetchRequest,
     ) -> Result<SliceSpanResponse, DistribError> {
-        let mut client = SeriesFetchClient::new(self.channel.clone());
-        let response = client
-            .fetch(request)
-            .await
-            .map_err(|s| DistribError::Transport(s.to_string()))?;
-        let mut stream = response.into_inner();
-        let mut frames = Vec::new();
-        while let Some(frame) = stream
-            .message()
-            .await
-            .map_err(|s| DistribError::Transport(s.to_string()))?
-        {
-            frames.push(frame);
-        }
+        let frames = self.collect_frames(request).await?;
         decode_span_slice_frames(frames)
     }
 }
@@ -662,6 +652,175 @@ mod tests {
         assert!(matches!(
             decode_slice_frames(vec![bad_code]),
             Err(DistribError::Codec(CodecError::UnknownStatusCode(-1)))
+        ));
+    }
+
+    // --- decode_span_slice_frames (#307) -----------------------------------
+    //
+    // The span decoder mirrors `decode_slice_frames`' terminal paths (missing
+    // summary, duplicate summary, empty frame, missing status, unknown status)
+    // and adds its own: a series, histogram, or log-record frame in a span
+    // stream is rejected as `FrameSignalUnsupported`, never silently skipped.
+
+    /// A well-formed span frame (root span, `Unset` status, no attributes). Its
+    /// contents never reach a reject arm, so only the shape matters.
+    fn span_frame() -> pb::FetchResponse {
+        pb::FetchResponse {
+            frame: Some(pb::fetch_response::Frame::Span(pb::SpanFrame {
+                trace_id: vec![0xAAu8; 16],
+                span_id: vec![1u8; 8],
+                parent_span_id: Vec::new(),
+                name: "op".to_string(),
+                start_ts_ns: 10,
+                end_ts_ns: 11,
+                status_code: 0,
+                status_message: None,
+                attrs: Vec::new(),
+                service_name: None,
+            })),
+        }
+    }
+
+    /// The happy path: a span frame plus one terminal summary decodes to a
+    /// `SliceSpanResponse` carrying the decoded span and the summary fields.
+    #[test]
+    fn span_then_summary_decodes() {
+        let response =
+            decode_span_slice_frames(vec![span_frame(), summary_frame(pb::status::Code::Ok)])
+                .expect("valid span frame sequence decodes");
+        assert_eq!(response.spans.len(), 1);
+        assert_eq!(response.spans[0].record.trace_id, [0xAAu8; 16]);
+        assert_eq!(response.status, pb::status::Code::Ok);
+        // The summary's `series_returned` field is reused as the span count.
+        assert_eq!(response.spans_returned, 1);
+        assert_eq!(response.stats.raw_f64_pages, 5);
+        assert_eq!(response.accounting.s3_requests(AccountedOp::Get), 3);
+    }
+
+    /// A span stream that never sent its mandatory terminal summary is
+    /// `NoSummary`.
+    #[test]
+    fn span_missing_summary_is_typed_error() {
+        assert!(matches!(
+            decode_span_slice_frames(vec![span_frame()]),
+            Err(DistribError::NoSummary)
+        ));
+    }
+
+    /// Two summary frames violate the exactly-one-summary rule.
+    #[test]
+    fn span_duplicate_summary_is_typed_error() {
+        assert!(matches!(
+            decode_span_slice_frames(vec![
+                summary_frame(pb::status::Code::Ok),
+                summary_frame(pb::status::Code::Ok),
+            ]),
+            Err(DistribError::MultipleSummaries)
+        ));
+    }
+
+    /// A frame carrying no `frame` oneof variant is `EmptyFrame`.
+    #[test]
+    fn span_empty_frame_is_typed_error() {
+        assert!(matches!(
+            decode_span_slice_frames(vec![pb::FetchResponse { frame: None }]),
+            Err(DistribError::EmptyFrame)
+        ));
+    }
+
+    /// A summary that carries no status is a typed `MissingStatus` codec error.
+    #[test]
+    fn span_summary_without_status_is_typed_error() {
+        let no_status = pb::FetchResponse {
+            frame: Some(pb::fetch_response::Frame::Summary(pb::Summary {
+                accounting: None,
+                series_returned: 0,
+                samples_returned: 0,
+                status: None,
+                raw_f64_pages: 0,
+                raw_f64_bytes: 0,
+            })),
+        };
+        assert!(matches!(
+            decode_span_slice_frames(vec![no_status]),
+            Err(DistribError::Codec(CodecError::MissingStatus))
+        ));
+    }
+
+    /// A summary naming a status code discriminant this build does not model is a
+    /// typed error, never a silent success.
+    #[test]
+    fn span_unknown_status_code_is_typed_error() {
+        let bad_code = pb::FetchResponse {
+            frame: Some(pb::fetch_response::Frame::Summary(pb::Summary {
+                accounting: None,
+                series_returned: 0,
+                samples_returned: 0,
+                status: Some(pb::Status {
+                    code: -1,
+                    message: String::new(),
+                }),
+                raw_f64_pages: 0,
+                raw_f64_bytes: 0,
+            })),
+        };
+        assert!(matches!(
+            decode_span_slice_frames(vec![bad_code]),
+            Err(DistribError::Codec(CodecError::UnknownStatusCode(-1)))
+        ));
+    }
+
+    /// A series frame in a span stream is rejected as `FrameSignalUnsupported`,
+    /// never decoded as a span and never skipped. If the explicit
+    /// `Frame::Series(_)` reject arm in `decode_span_slice_frames` were relaxed
+    /// to a permissive wildcard (`_ => continue`), the frame would be dropped and
+    /// the trailing summary would decode to an empty `Ok` response, so this
+    /// `expect_err`-style match would fail.
+    #[test]
+    fn span_decoder_rejects_series_frame_as_unsupported() {
+        let soa = series_soa();
+        assert!(matches!(
+            decode_span_slice_frames(vec![
+                series_frame(&soa),
+                summary_frame(pb::status::Code::Ok),
+            ]),
+            Err(DistribError::FrameSignalUnsupported("series"))
+        ));
+    }
+
+    /// A native-histogram frame in a span stream is rejected as
+    /// `FrameSignalUnsupported`. As with the series case, relaxing the explicit
+    /// `Frame::Hist(_)` reject arm to a wildcard would drop the frame and decode
+    /// to an empty `Ok`, failing this assertion.
+    #[test]
+    fn span_decoder_rejects_histogram_frame_as_unsupported() {
+        let hist = pb::FetchResponse {
+            frame: Some(pb::fetch_response::Frame::Hist(pb::HistogramFrame {
+                series_id: vec![0u8; 16],
+                labels: Vec::new(),
+                runs: Vec::new(),
+            })),
+        };
+        assert!(matches!(
+            decode_span_slice_frames(vec![hist, summary_frame(pb::status::Code::Ok)]),
+            Err(DistribError::FrameSignalUnsupported("histogram"))
+        ));
+    }
+
+    /// A log-record frame in a span stream is rejected as
+    /// `FrameSignalUnsupported`. Relaxing the explicit `Frame::LogRecord(_)`
+    /// reject arm to a wildcard would drop the frame and decode to an empty `Ok`,
+    /// failing this assertion.
+    #[test]
+    fn span_decoder_rejects_log_record_frame_as_unsupported() {
+        let log = pb::FetchResponse {
+            frame: Some(pb::fetch_response::Frame::LogRecord(
+                pb::LogRecordFrame::default(),
+            )),
+        };
+        assert!(matches!(
+            decode_span_slice_frames(vec![log, summary_frame(pb::status::Code::Ok)]),
+            Err(DistribError::FrameSignalUnsupported("log-record"))
         ));
     }
 }

--- a/crates/ravel-query/src/distrib/mod.rs
+++ b/crates/ravel-query/src/distrib/mod.rs
@@ -853,19 +853,45 @@ pub(crate) fn log_record_order_key(record: &LogRecord) -> LogOrderKey {
 /// grouping (which differs from the local per-segment grouping) never changes
 /// the result -- exactly the property the differential test exercises.
 pub(crate) fn merge_spans(per_slice: Vec<Vec<SpanRow>>) -> Vec<SpanRow> {
-    let mut keyed: Vec<(SpanOrderKey, SpanRow)> = per_slice
-        .into_iter()
-        .flatten()
-        .map(|row| (span_order_key(&row), row))
-        .collect();
-    // A stable sort on the precomputed full-content key. Equal-key spans are
-    // byte-identical, but they are NOT collapsed: the consistency model
-    // (docs/consistency-model.md, "logs and spans") forbids query-time dedup for
-    // spans, because a retry after a lost ack produces byte-identical spans that
-    // are legitimately duplicate USER DATA and must stay visible. Every span in
-    // the pool is returned.
-    keyed.sort_by(|a, b| a.0.cmp(&b.0));
-    keyed.into_iter().map(|(_, row)| row).collect()
+    let mut spans: Vec<SpanRow> = per_slice.into_iter().flatten().collect();
+    // A stable sort under the full-content total-order comparator. Equal-key
+    // spans are byte-identical, but they are NOT collapsed: the consistency
+    // model (docs/consistency-model.md, "logs and spans") forbids query-time
+    // dedup for spans, because a retry after a lost ack produces byte-identical
+    // spans that are legitimately duplicate USER DATA and must stay visible.
+    // Every span in the pool is returned. `span_cmp` compares borrowed fields in
+    // place, so unlike an owned `SpanOrderKey` per span it clones nothing.
+    spans.sort_by(span_cmp);
+    spans
+}
+
+/// The total order over spans (see [`merge_spans`]): a `sort_by` comparator over
+/// borrowed fields, in the exact field sequence
+/// `(trace_id, span_id, start_ts_ns, end_ts_ns, parent_span_id, name,
+/// status_code, status_message, service_name, attrs)`. It compares the same
+/// fields, in the same order, as the [`span_order_key`] tuple (whose `Ord`
+/// derives structurally), but without allocating an owned key per span: no
+/// clones of `name`, `status_message`, `service_name`, or `attrs`. Span
+/// attribute values are plain strings, so `attrs` compares directly as a
+/// `Vec<(String, String)>` (no canonical byte encoding, unlike the typed log
+/// attribute values). `service_name` and `status_message` are `Option<String>`,
+/// so `None` orders before `Some`, keeping them distinct from an empty string.
+/// `span_cmp_agrees_with_span_order_key` pins the two definitions together so
+/// they cannot silently drift.
+pub(crate) fn span_cmp(a: &SpanRow, b: &SpanRow) -> std::cmp::Ordering {
+    let ra = &a.record;
+    let rb = &b.record;
+    ra.trace_id
+        .cmp(&rb.trace_id)
+        .then_with(|| ra.span_id.cmp(&rb.span_id))
+        .then_with(|| ra.start_ts_ns.cmp(&rb.start_ts_ns))
+        .then_with(|| ra.end_ts_ns.cmp(&rb.end_ts_ns))
+        .then_with(|| ra.parent_span_id.cmp(&rb.parent_span_id))
+        .then_with(|| ra.name.cmp(&rb.name))
+        .then_with(|| ra.status_code.to_u8().cmp(&rb.status_code.to_u8()))
+        .then_with(|| ra.status_message.cmp(&rb.status_message))
+        .then_with(|| a.service_name.cmp(&b.service_name))
+        .then_with(|| ra.attrs.cmp(&rb.attrs))
 }
 
 /// The total-order key for one span (see [`merge_spans`]). A tuple so `Ord`
@@ -874,6 +900,12 @@ pub(crate) fn merge_spans(per_slice: Vec<Vec<SpanRow>>) -> Vec<SpanRow> {
 /// byte encoding needed, unlike the typed log attribute values). `service_name`
 /// and `status_message` are `Option<String>`, so `None` orders before `Some`,
 /// keeping them distinct from an empty string.
+///
+/// The production merge no longer builds this owned key ([`merge_spans`] sorts
+/// with the allocation-free [`span_cmp`]); it stays as the reference definition
+/// of the span total order that the coordinator tests assert against directly,
+/// so it is compiled only under `cfg(test)`.
+#[cfg(test)]
 type SpanOrderKey = (
     [u8; 16],
     [u8; 8],
@@ -887,6 +919,7 @@ type SpanOrderKey = (
     Vec<(String, String)>,
 );
 
+#[cfg(test)]
 pub(crate) fn span_order_key(row: &SpanRow) -> SpanOrderKey {
     let record = &row.record;
     (

--- a/crates/ravel-query/src/distrib/tests.rs
+++ b/crates/ravel-query/src/distrib/tests.rs
@@ -45,7 +45,7 @@ use crate::distrib::Distributed;
 use crate::distrib::client::{DistribError, RemoteSliceFetcher, SliceFetcher, SliceResponse};
 use crate::distrib::partition::{DistribThresholds, partition_snapshot};
 use crate::distrib::{
-    log_record_order_key, service::SeriesFetchService, service::SnapshotSegmentResolver,
+    log_record_order_key, service::SeriesFetchService, service::SnapshotSegmentResolver, span_cmp,
     span_order_key,
 };
 use crate::engine::merge_soa_runs;
@@ -2887,4 +2887,67 @@ fn span_order_key_respects_field_precedence() {
             r.record.attrs = vec![("k".to_string(), "a".to_string())];
         },
     );
+}
+
+/// `merge_spans` sorts with the allocation-free [`span_cmp`] comparator rather
+/// than building an owned [`span_order_key`] tuple per span (#307). The two are
+/// separate definitions of the same total order and could silently drift, so
+/// this pins them together: over a matrix of rows built to differ in each key
+/// field (at least one differing pair per field, plus every cross pair),
+/// `span_cmp(a, b)` must equal `span_order_key(a).cmp(&span_order_key(b))` for
+/// every ordered pair -- including the reflexive `Equal` pairs. If a later edit
+/// reordered `span_cmp`'s `then_with` chain, dropped a field, or flipped a
+/// comparison relative to the key tuple, some pair would disagree and this fails.
+#[test]
+fn span_cmp_agrees_with_span_order_key() {
+    let base = SpanRow {
+        record: ravel_rspan::SpanRecord {
+            trace_id: TA,
+            span_id: S1,
+            parent_span_id: Some([3u8; 8]),
+            name: "op".to_string(),
+            start_ts_ns: 10,
+            end_ts_ns: 11,
+            status_code: ravel_rspan::StatusCode::Unset,
+            status_message: Some("msg".to_string()),
+            attrs: vec![("k".to_string(), "v".to_string())],
+        },
+        service_name: Some("alpha".to_string()),
+    };
+
+    let mutate = |m: &dyn Fn(&mut SpanRow)| {
+        let mut r = base.clone();
+        m(&mut r);
+        r
+    };
+    // The base plus one row differing in exactly each key field: every field
+    // therefore appears in at least one differing pair (base vs its mutant), and
+    // the full cartesian product below also exercises multi-field differences.
+    let rows = vec![
+        base.clone(),
+        mutate(&|r| r.record.trace_id = TB),
+        mutate(&|r| r.record.span_id = S2),
+        mutate(&|r| r.record.start_ts_ns = 20),
+        mutate(&|r| r.record.end_ts_ns = 99),
+        mutate(&|r| r.record.parent_span_id = Some([7u8; 8])),
+        mutate(&|r| r.record.parent_span_id = None),
+        mutate(&|r| r.record.name = "other".to_string()),
+        mutate(&|r| r.record.status_code = ravel_rspan::StatusCode::Error),
+        mutate(&|r| r.record.status_message = Some("boom".to_string())),
+        mutate(&|r| r.record.status_message = None),
+        mutate(&|r| r.service_name = Some("beta".to_string())),
+        mutate(&|r| r.service_name = None),
+        mutate(&|r| r.record.attrs = vec![("k".to_string(), "w".to_string())]),
+    ];
+
+    for (i, a) in rows.iter().enumerate() {
+        for (j, b) in rows.iter().enumerate() {
+            assert_eq!(
+                span_cmp(a, b),
+                span_order_key(a).cmp(&span_order_key(b)),
+                "span_cmp and span_order_key disagree on rows ({i}, {j}); \
+                 the comparator has drifted from the key tuple"
+            );
+        }
+    }
 }


### PR DESCRIPTION
Three non-blocking items CodeRabbit raised on PR #305 (epic #63, the
distributed span fan-out) that were deferred as follow-up rather than
scope-creeping that PR.

merge_spans built an owned SpanOrderKey (with cloned name,
status_message, service_name, and the whole attrs vector) for every
span before sorting, then held a second pool of clones until the sort
completed. Replaced with span_cmp, a comparator over borrowed fields
in the same documented field order, so the merge no longer clones
per-span state to sort it. span_order_key stays as the reference
definition under cfg(test); a new span_cmp_agrees_with_span_order_key
test pins the two together over a matrix of rows so they can't
silently drift. Verified by mutation: dropping the attrs comparison
from span_cmp makes that test fail.

RemoteSliceFetcher's three fetch methods each repeated the same
client-build/fetch/drain-stream/collect-frames sequence; extracted
into one collect_frames helper.

decode_span_slice_frames had no direct tests. Added the same terminal-
path coverage decode_slice_frames already has (missing/duplicate
summary, empty frame, missing/unknown status), plus its own case:
rejecting a series, histogram, or log-record frame as
FrameSignalUnsupported instead of silently dropping it.

Fixes: #307
