### PR TITLE
feat(catalog): add typed_attr_columns to tenant config (ADR-0090)

### DIFF
--- a/crates/ravel-catalog/src/tenant_config.rs
+++ b/crates/ravel-catalog/src/tenant_config.rs
@@ -90,6 +90,148 @@ impl TenantLifecycleState {
     }
 }
 
+/// The logical type an operator declares for a promoted logs attribute column
+/// (ADR-0090 decision 1), decoded into a domain enum so consumers never touch
+/// the proto `i32`. Exactly the four declarable v1 types; `f64`, date, and
+/// timestamp are deferred by ADR-0090 and have no variant here. A record
+/// carrying the proto `UNSPECIFIED` sentinel is corrupt and refused on decode
+/// ([`TenantConfigError::InvalidTypedAttrColumnType`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeclaredColumnType {
+    /// UTF-8 string column.
+    Str,
+    /// Signed 64-bit integer column.
+    I64,
+    /// Boolean column.
+    Bool,
+    /// Opaque bytes column.
+    Bytes,
+}
+
+impl DeclaredColumnType {
+    /// Map to the persisted proto enum value.
+    fn to_proto(self) -> sysproto::TypedAttrColumnType {
+        match self {
+            DeclaredColumnType::Str => sysproto::TypedAttrColumnType::Str,
+            DeclaredColumnType::I64 => sysproto::TypedAttrColumnType::I64,
+            DeclaredColumnType::Bool => sysproto::TypedAttrColumnType::Bool,
+            DeclaredColumnType::Bytes => sysproto::TypedAttrColumnType::Bytes,
+        }
+    }
+
+    /// Map from the persisted proto `i32`. `UNSPECIFIED` (0) and any unknown
+    /// value are refused: a written column always names a real type, so an
+    /// absent or unknown one is corruption, not a default to guess at (matching
+    /// the `lifecycle_state` and commit-token version-prefix refuse-on-decode
+    /// discipline).
+    fn from_proto_i32(value: i32) -> Option<Self> {
+        match sysproto::TypedAttrColumnType::try_from(value).ok()? {
+            sysproto::TypedAttrColumnType::Unspecified => None,
+            sysproto::TypedAttrColumnType::Str => Some(DeclaredColumnType::Str),
+            sysproto::TypedAttrColumnType::I64 => Some(DeclaredColumnType::I64),
+            sysproto::TypedAttrColumnType::Bool => Some(DeclaredColumnType::Bool),
+            sysproto::TypedAttrColumnType::Bytes => Some(DeclaredColumnType::Bytes),
+        }
+    }
+}
+
+/// One operator-declared typed attribute column (ADR-0090 decision 1): an
+/// attribute key promoted to a native typed logs SQL column, paired with the
+/// logical type it is read as. The SQL column name is `key` verbatim.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeclaredTypedColumn {
+    /// The attribute key; the SQL column name, verbatim (never mangled).
+    pub key: String,
+    /// The declared logical type the column is read as.
+    pub ty: DeclaredColumnType,
+}
+
+/// The nine fixed logs SQL column names (ADR-0090 decision 1). A declared typed
+/// attribute column may not collide with any of these. Defined locally rather
+/// than imported from `ravel-sql`: `ravel-catalog` must not gain a dependency on
+/// `ravel-sql`, and these names are a small, stable list.
+pub const FIXED_LOGS_SQL_COLUMNS: [&str; 9] = [
+    "ts",
+    "observed_ts",
+    "severity_num",
+    "severity_text",
+    "body",
+    "trace_id",
+    "span_id",
+    "flags",
+    "attrs",
+];
+
+/// A typed-attribute-column declaration rejected at construction from operator
+/// input (ADR-0090 decision 1). Distinct from the durable [`TenantConfigError`]:
+/// these are operator-input validation failures, caught before any durable
+/// write, never a decode-time corruption signal.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum TypedAttrColumnError {
+    /// A declared column has an empty key.
+    #[error("a declared typed attribute column has an empty key")]
+    EmptyKey,
+    /// The same key appears more than once with the same declared type.
+    #[error("declared typed attribute column key {key:?} is declared more than once")]
+    DuplicateKey { key: String },
+    /// The same key appears more than once with conflicting declared types.
+    #[error(
+        "declared typed attribute column key {key:?} is declared with conflicting types \
+         (already {existing:?}, then {conflicting:?})"
+    )]
+    ConflictingType {
+        key: String,
+        existing: DeclaredColumnType,
+        conflicting: DeclaredColumnType,
+    },
+    /// A declared key collides with one of the nine fixed logs SQL column names.
+    #[error(
+        "declared typed attribute column key {key:?} collides with a fixed logs SQL column name"
+    )]
+    FixedColumnCollision { key: String },
+}
+
+/// Validate an operator-provided typed-attribute-column declaration (ADR-0090
+/// decision 1). Rejects an empty key, a duplicate key within the declaration,
+/// the same key declared with two different types, and a key colliding with any
+/// fixed logs SQL column name. This is the operator-input gate, called before a
+/// durable write, NOT at proto decode time (a durable record predating a rule
+/// is read, not re-validated).
+pub fn validate_typed_attr_columns(
+    columns: &[DeclaredTypedColumn],
+) -> Result<(), TypedAttrColumnError> {
+    let mut seen: std::collections::HashMap<&str, DeclaredColumnType> =
+        std::collections::HashMap::new();
+    for col in columns {
+        if col.key.is_empty() {
+            return Err(TypedAttrColumnError::EmptyKey);
+        }
+        if FIXED_LOGS_SQL_COLUMNS.contains(&col.key.as_str()) {
+            return Err(TypedAttrColumnError::FixedColumnCollision {
+                key: col.key.clone(),
+            });
+        }
+        match seen.get(col.key.as_str()) {
+            Some(&existing) if existing == col.ty => {
+                return Err(TypedAttrColumnError::DuplicateKey {
+                    key: col.key.clone(),
+                });
+            }
+            Some(&existing) => {
+                return Err(TypedAttrColumnError::ConflictingType {
+                    key: col.key.clone(),
+                    existing,
+                    conflicting: col.ty,
+                });
+            }
+            None => {
+                seen.insert(col.key.as_str(), col.ty);
+            }
+        }
+    }
+    Ok(())
+}
+
 /// A tenant's durable config, decoded into a plain struct so consumers (the
 /// refresh loop, the admission controller) never touch the proto type. An
 /// absent optional override means "use the deployment default"; a present one
@@ -113,6 +255,11 @@ pub struct TenantConfig {
     /// `Some(vec![])` = override to no indexed fields; `Some(non-empty)` = the
     /// explicit indexed-field set.
     pub indexed_fields: Option<Vec<String>>,
+    /// Declared typed logs SQL columns override (ADR-0090 decision 1): `None` =
+    /// no override (deployment default); `Some(vec![])` = override to no declared
+    /// columns; `Some(non-empty)` = the explicit ordered declaration. Order is
+    /// stable and preserved verbatim through the round-trip, never re-sorted.
+    pub typed_attr_columns: Option<Vec<DeclaredTypedColumn>>,
 }
 
 impl TenantConfig {
@@ -128,6 +275,7 @@ impl TenantConfig {
             max_series_creation_rate: None,
             retention_ns: None,
             indexed_fields: None,
+            typed_attr_columns: None,
         }
     }
 }
@@ -182,6 +330,24 @@ pub enum TenantConfigError {
          failed): re-read and retry rather than overwrite the other write"
     )]
     CasConflict { key: String },
+    /// A stored typed-attribute column carries the `UNSPECIFIED` type sentinel or
+    /// an unknown value. A written column always names a real type; refusing
+    /// fail-closed rather than guessing keeps a corrupt record from silently
+    /// resolving a column to the wrong type (ADR-0090 decision 1).
+    #[error(
+        "config record {key:?} has a typed_attr_column with an invalid type {got}: a written \
+         column must name str, i64, bool, or bytes (ADR-0090 decision 1)"
+    )]
+    InvalidTypedAttrColumnType { key: String, got: i32 },
+    /// A [`set_tenant_config`] write carried a typed-attribute-column declaration
+    /// that failed operator-input validation (ADR-0090 decision 1). Caught before
+    /// the durable write, so an invalid declaration never persists.
+    #[error("config record {key:?} has an invalid typed_attr_columns declaration: {source}")]
+    InvalidTypedAttrColumns {
+        key: String,
+        #[source]
+        source: TypedAttrColumnError,
+    },
 }
 
 impl TenantConfigError {
@@ -223,6 +389,25 @@ fn decode_record(
             got: record.lifecycle_state,
         },
     )?;
+    let typed_attr_columns = match record.typed_attr_columns.as_ref() {
+        None => None,
+        Some(config) => {
+            let mut columns = Vec::with_capacity(config.columns.len());
+            for col in &config.columns {
+                let ty = DeclaredColumnType::from_proto_i32(col.r#type).ok_or(
+                    TenantConfigError::InvalidTypedAttrColumnType {
+                        key: key.to_string(),
+                        got: col.r#type,
+                    },
+                )?;
+                columns.push(DeclaredTypedColumn {
+                    key: col.key.clone(),
+                    ty,
+                });
+            }
+            Some(columns)
+        }
+    };
     Ok(TenantConfig {
         lifecycle_state,
         max_active_series: record.max_active_series,
@@ -231,6 +416,7 @@ fn decode_record(
         max_series_creation_rate: record.max_series_creation_rate,
         retention_ns: record.retention_ns,
         indexed_fields: record.indexed_fields.as_ref().map(|c| c.fields.clone()),
+        typed_attr_columns,
     })
 }
 
@@ -256,6 +442,17 @@ fn build_record(
             .map(|fields| sysproto::IndexedFieldConfig {
                 fields: fields.clone(),
             }),
+        typed_attr_columns: config.typed_attr_columns.as_ref().map(|columns| {
+            sysproto::TypedAttrColumnConfig {
+                columns: columns
+                    .iter()
+                    .map(|col| sysproto::TypedAttrColumn {
+                        key: col.key.clone(),
+                        r#type: col.ty.to_proto() as i32,
+                    })
+                    .collect(),
+            }
+        }),
         created_unix_ns,
         updated_unix_ns,
     }
@@ -328,6 +525,19 @@ pub async fn set_tenant_config(
     now_ns: i64,
 ) -> Result<SetOutcome, TenantConfigError> {
     let key = config_key(tenant_hash);
+
+    // Validate the operator-provided declared-column list before any durable
+    // write (ADR-0090 decision 1: "any durable write" rejects an empty key, a
+    // duplicate, a conflicting type, or a fixed-column collision). Decode never
+    // re-runs this; it is the write-time operator-input gate.
+    if let Some(columns) = config.typed_attr_columns.as_ref() {
+        validate_typed_attr_columns(columns).map_err(|source| {
+            TenantConfigError::InvalidTypedAttrColumns {
+                key: key.clone(),
+                source,
+            }
+        })?;
+    }
 
     match store.get(&key, GetRange::Full).await {
         Ok(outcome) => {
@@ -410,6 +620,20 @@ mod tests {
             max_series_creation_rate: Some(100),
             retention_ns: Some(72 * 3_600_000_000_000),
             indexed_fields: Some(vec!["service.name".into(), "http.route".into()]),
+            typed_attr_columns: Some(vec![
+                DeclaredTypedColumn {
+                    key: "http.status_code".into(),
+                    ty: DeclaredColumnType::I64,
+                },
+                DeclaredTypedColumn {
+                    key: "k8s.namespace.name".into(),
+                    ty: DeclaredColumnType::Str,
+                },
+                DeclaredTypedColumn {
+                    key: "error".into(),
+                    ty: DeclaredColumnType::Bool,
+                },
+            ]),
         }
     }
 
@@ -714,6 +938,256 @@ mod tests {
         assert!(
             matches!(err, TenantConfigError::Decode { .. }),
             "got: {err}"
+        );
+    }
+
+    /// `TENANT_CONFIG_FORMAT_VERSION` is unchanged by the additive
+    /// `typed_attr_columns` field (ADR-0090: no bump for an additive field).
+    /// Pinned so a future accidental bump on this field's account fails loudly.
+    #[test]
+    fn tenant_config_format_version_is_unchanged() {
+        assert_eq!(
+            TENANT_CONFIG_FORMAT_VERSION, 1,
+            "typed_attr_columns is additive; ADR-0090 forbids a format-version bump"
+        );
+    }
+
+    /// A non-trivial declared-column list (three entries, three distinct types)
+    /// round-trips through the real `set_tenant_config`/`read_config` path
+    /// against a real store, matching exactly and in declaration order.
+    #[tokio::test]
+    async fn typed_attr_columns_round_trip_in_order() {
+        let store = mem();
+        let columns = vec![
+            DeclaredTypedColumn {
+                key: "http.status_code".into(),
+                ty: DeclaredColumnType::I64,
+            },
+            DeclaredTypedColumn {
+                key: "k8s.namespace.name".into(),
+                ty: DeclaredColumnType::Str,
+            },
+            DeclaredTypedColumn {
+                key: "error".into(),
+                ty: DeclaredColumnType::Bool,
+            },
+            DeclaredTypedColumn {
+                key: "payload".into(),
+                ty: DeclaredColumnType::Bytes,
+            },
+        ];
+        let cfg = TenantConfig {
+            typed_attr_columns: Some(columns.clone()),
+            ..TenantConfig::new(TenantLifecycleState::Active)
+        };
+        set_tenant_config(store.as_ref(), &tenant(), &cfg, 1_000)
+            .await
+            .expect("create");
+        let (read, _v) = read_config(store.as_ref(), &tenant())
+            .await
+            .expect("read")
+            .expect("present");
+        assert_eq!(
+            read.typed_attr_columns,
+            Some(columns),
+            "the declared list round-trips exactly, in order"
+        );
+    }
+
+    /// A present-but-empty declared-column override is distinct from absent and
+    /// round-trips as `Some(vec![])`, not `None` (mirrors the indexed-field
+    /// present-empty-vs-absent distinction).
+    #[tokio::test]
+    async fn empty_typed_attr_columns_override_is_distinct_from_absent() {
+        let store = mem();
+        let cfg = TenantConfig {
+            typed_attr_columns: Some(vec![]),
+            ..TenantConfig::new(TenantLifecycleState::Active)
+        };
+        set_tenant_config(store.as_ref(), &tenant(), &cfg, 1)
+            .await
+            .expect("create");
+        let (read, _v) = read_config(store.as_ref(), &tenant())
+            .await
+            .expect("read")
+            .expect("present");
+        assert_eq!(
+            read.typed_attr_columns,
+            Some(vec![]),
+            "present-empty, not absent"
+        );
+    }
+
+    /// Forward-compat: a record with every other field set but field 12 absent
+    /// (an older-format record) decodes with `typed_attr_columns == None` — no
+    /// error, no panic. This is the property behind ADR-0090's "no dual-reader
+    /// window" claim; proven, not assumed.
+    #[tokio::test]
+    async fn record_without_field_12_decodes_as_none() {
+        let store = mem();
+        // Build a full record, then strip field 12 to simulate an older writer.
+        let mut record = build_record(&tenant(), &full_config(), 5, 7);
+        record.typed_attr_columns = None;
+        assert!(
+            record.indexed_fields.is_some(),
+            "every other field is set; only field 12 is absent"
+        );
+        store
+            .put(
+                &config_key(&tenant()),
+                record.encode_to_vec().into(),
+                PutOptions::default(),
+            )
+            .await
+            .expect("put older-format record");
+        let (read, _v) = read_config(store.as_ref(), &tenant())
+            .await
+            .expect("an absent field 12 must decode cleanly")
+            .expect("present");
+        assert!(
+            read.typed_attr_columns.is_none(),
+            "field 12 absent reads as None, not empty, and never errors"
+        );
+    }
+
+    /// A stored column carrying the `UNSPECIFIED` type sentinel is corrupt and
+    /// refused on decode, never guessed at.
+    #[tokio::test]
+    async fn read_rejects_unspecified_typed_attr_column_type() {
+        let store = mem();
+        let mut record = build_record(
+            &tenant(),
+            &TenantConfig::new(TenantLifecycleState::Active),
+            0,
+            0,
+        );
+        record.typed_attr_columns = Some(sysproto::TypedAttrColumnConfig {
+            columns: vec![sysproto::TypedAttrColumn {
+                key: "http.status_code".into(),
+                r#type: sysproto::TypedAttrColumnType::Unspecified as i32,
+            }],
+        });
+        store
+            .put(
+                &config_key(&tenant()),
+                record.encode_to_vec().into(),
+                PutOptions::default(),
+            )
+            .await
+            .expect("put record with unspecified column type");
+        let err = read_config(store.as_ref(), &tenant())
+            .await
+            .expect_err("an unspecified declared-column type must be refused");
+        assert!(
+            matches!(
+                err,
+                TenantConfigError::InvalidTypedAttrColumnType { got: 0, .. }
+            ),
+            "got: {err}"
+        );
+    }
+
+    /// Validation rejects an empty key.
+    #[test]
+    fn validation_rejects_empty_key() {
+        let err = validate_typed_attr_columns(&[DeclaredTypedColumn {
+            key: String::new(),
+            ty: DeclaredColumnType::Str,
+        }])
+        .expect_err("empty key must be rejected");
+        assert_eq!(err, TypedAttrColumnError::EmptyKey);
+    }
+
+    /// Validation rejects the same key declared twice with the same type.
+    #[test]
+    fn validation_rejects_duplicate_key() {
+        let err = validate_typed_attr_columns(&[
+            DeclaredTypedColumn {
+                key: "k".into(),
+                ty: DeclaredColumnType::I64,
+            },
+            DeclaredTypedColumn {
+                key: "k".into(),
+                ty: DeclaredColumnType::I64,
+            },
+        ])
+        .expect_err("a duplicate key must be rejected");
+        assert_eq!(err, TypedAttrColumnError::DuplicateKey { key: "k".into() });
+    }
+
+    /// Validation rejects the same key declared twice with different types.
+    #[test]
+    fn validation_rejects_conflicting_type() {
+        let err = validate_typed_attr_columns(&[
+            DeclaredTypedColumn {
+                key: "k".into(),
+                ty: DeclaredColumnType::I64,
+            },
+            DeclaredTypedColumn {
+                key: "k".into(),
+                ty: DeclaredColumnType::Str,
+            },
+        ])
+        .expect_err("a key declared with two types must be rejected");
+        assert_eq!(
+            err,
+            TypedAttrColumnError::ConflictingType {
+                key: "k".into(),
+                existing: DeclaredColumnType::I64,
+                conflicting: DeclaredColumnType::Str,
+            }
+        );
+    }
+
+    /// Validation rejects a key colliding with each fixed logs SQL column name.
+    #[test]
+    fn validation_rejects_fixed_column_collision() {
+        for fixed in FIXED_LOGS_SQL_COLUMNS {
+            let err = validate_typed_attr_columns(&[DeclaredTypedColumn {
+                key: fixed.into(),
+                ty: DeclaredColumnType::Str,
+            }])
+            .expect_err("a collision with a fixed column name must be rejected");
+            assert_eq!(
+                err,
+                TypedAttrColumnError::FixedColumnCollision { key: fixed.into() },
+                "collision with {fixed:?} must report FixedColumnCollision"
+            );
+        }
+    }
+
+    /// A durable write carrying an invalid declaration is refused before it
+    /// persists (validation is the `set_tenant_config` write-time gate).
+    #[tokio::test]
+    async fn set_tenant_config_rejects_invalid_declaration() {
+        let store = mem();
+        let cfg = TenantConfig {
+            typed_attr_columns: Some(vec![DeclaredTypedColumn {
+                key: "ts".into(),
+                ty: DeclaredColumnType::I64,
+            }]),
+            ..TenantConfig::new(TenantLifecycleState::Active)
+        };
+        let err = set_tenant_config(store.as_ref(), &tenant(), &cfg, 1)
+            .await
+            .expect_err("a fixed-column collision must fail the durable write");
+        assert!(
+            matches!(
+                err,
+                TenantConfigError::InvalidTypedAttrColumns {
+                    source: TypedAttrColumnError::FixedColumnCollision { .. },
+                    ..
+                }
+            ),
+            "got: {err}"
+        );
+        // Nothing was written: the record must not exist.
+        assert!(
+            read_config(store.as_ref(), &tenant())
+                .await
+                .expect("read")
+                .is_none(),
+            "an invalid declaration must not persist"
         );
     }
 }

--- a/docs/adrs/0090-typed-attribute-columns-logs-sql.md
+++ b/docs/adrs/0090-typed-attribute-columns-logs-sql.md
@@ -1,6 +1,6 @@
 # ADR-0090: typed attribute columns for the logs SQL table
 
-Status: Proposed
+Status: Accepted
 
 ## Context
 

--- a/docs/catalog-and-mvcc.md
+++ b/docs/catalog-and-mvcc.md
@@ -177,8 +177,10 @@ retention, and indexed-field config off process flags and into durable state.
 A tenant-scoped object (not per-signal, since these apply across every signal)
 holding `tenant_hash`, a `format_version` floor, a `lifecycle_state`
 (`active` / `suspended` / `offboarding`), optional admission-limit and
-retention overrides, an optional indexed-field set, and `created`/`updated`
-timestamps (proto/ravel/sys.proto `TenantConfigRecord`). Defaults still come
+retention overrides, an optional indexed-field set, an optional declared
+typed-attribute-column set (ADR-0090; `str`/`i64`/`bool`/`bytes` only in v1),
+and `created`/`updated` timestamps (proto/ravel/sys.proto
+`TenantConfigRecord`). Defaults still come
 from flags/limits-file at startup; a field present here overrides the default
 for this tenant, an absent one leaves the default in place. Unlike the
 append-only `prov`/`enc` histories, it is mutated by **whole-record

--- a/proto/ravel/sys.proto
+++ b/proto/ravel/sys.proto
@@ -358,6 +358,43 @@ message IndexedFieldConfig {
   repeated string fields = 1;  // attribute keys promoted to indexed columns
 }
 
+// The logical type an operator declares for a promoted logs attribute column
+// (ADR-0090 decision 1). Exactly four declarable types in v1: str/i64/bool/
+// bytes. f64, date, and timestamp are deliberately deferred by ADR-0090
+// (f64 gated on #277's fold-order decision; date/timestamp on a lifting rule),
+// so they are absent here on purpose, not by omission. UNSPECIFIED is the
+// proto3 zero default that is never written; a stored column carrying it is
+// corrupt and refused on decode (fail closed), the same discipline
+// TenantLifecycleState/Signal apply to their own enums.
+enum TypedAttrColumnType {
+  TYPED_ATTR_COLUMN_TYPE_UNSPECIFIED = 0;  // never written; a column carrying it is corrupt
+  TYPED_ATTR_COLUMN_TYPE_STR = 1;
+  TYPED_ATTR_COLUMN_TYPE_I64 = 2;
+  TYPED_ATTR_COLUMN_TYPE_BOOL = 3;
+  TYPED_ATTR_COLUMN_TYPE_BYTES = 4;
+}
+
+// One operator-declared typed attribute column (ADR-0090 decision 1): an
+// attribute key promoted to a native typed logs SQL column, paired with the
+// logical type it is read as. The SQL column name is the key verbatim, never
+// mangled.
+message TypedAttrColumn {
+  string key = 1;                 // the attribute key; the SQL column name, verbatim
+  TypedAttrColumnType type = 2;   // the declared logical type
+}
+
+// The set of attribute keys promoted to native typed logs SQL columns for one
+// tenant (ADR-0090 decision 1), carried as an optional sub-message of
+// TenantConfigRecord so its three states are distinct, exactly like
+// IndexedFieldConfig: absent sub-message means "no override, use the deployment
+// default"; a present sub-message with an empty `columns` list means "override
+// to no declared columns"; a present non-empty list is the explicit ordered
+// declaration. Declaration order is stable and never re-sorted (ADR-0090
+// decision 3).
+message TypedAttrColumnConfig {
+  repeated TypedAttrColumn columns = 1;
+}
+
 // The durable, per-tenant configuration record at `t/<tenant_hash>/config`
 // (ADR-0066 decision 6, epic EM). Moves per-tenant lifecycle state, admission
 // limits, retention, and indexed-field config off process flags and into a
@@ -405,6 +442,14 @@ message TenantConfigRecord {
   IndexedFieldConfig indexed_fields = 9;
   sfixed64 created_unix_ns = 10;      // informational; when the record was first written
   sfixed64 updated_unix_ns = 11;      // informational; when it was last swapped
+  // Per-tenant declared typed logs SQL columns (ADR-0090 decision 1); absent
+  // leaves the deployment default (see TypedAttrColumnConfig for the
+  // present-but-empty vs absent distinction). Additive field: a reader that
+  // skips this unknown field reads every earlier field exactly as before, and a
+  // reader that understands it sees an absent sub-message on every pre-ADR-0090
+  // record, identical to "no override". No format_version bump (ADR-0090
+  // Consequences).
+  TypedAttrColumnConfig typed_attr_columns = 12;
 }
 
 // One entry of the durable `sys/auth` token map (ADR-0066 decision 6, epic EM):


### PR DESCRIPTION
Adds a durable, per-tenant declared schema for logs attribute columns:
a new additive field 12 on TenantConfigRecord (proto/ravel/sys.proto)
and its Rust mirror on TenantConfig, carrying a list of {key, type}
pairs restricted to four types (str/i64/bool/bytes). Round-trips
through the existing set_tenant_config/read_config path with no
format version bump, since it's a purely additive proto field.

This lands ADR-0090 (typed attribute columns for the logs SQL table)
and the ravel-catalog half of the change. Includes validation
(duplicate keys, empty keys, collisions with fixed column names),
a forward-compat test proving an older record with field 12 absent
still decodes cleanly, and docs/catalog-and-mvcc.md's field list
updated to match.

Fixes: #300
