### PR TITLE
docs(query): document shipped log/span queryfrag fan-out

### DIFF
--- a/docs/adrs/0071-distributed-read-fanout.md
+++ b/docs/adrs/0071-distributed-read-fanout.md
@@ -1092,9 +1092,14 @@ dedicated clones; only the merges serialize.
 
 ## Amendment: log and span distributed fan-out
 
-Status: Proposed. Amends the Decision, Architecture, and Failure semantics
-sections above to extend fan-out from Metrics to Logs and Spans. Tracked
-by #63.
+Status: Accepted; the queryfrag (engine-level) lane is shipped. Amends the
+Decision, Architecture, and Failure semantics sections above to extend fan-out
+from Metrics to Logs and Spans. Tracked by #63. The design below shipped as
+proposed for the queryfrag lane (tasks T1-T5); the SQL lane (task T6) has not
+landed. See "Shipped status" at the end of this amendment for where the
+as-built code differs from the proposal below (in short: it does not, except
+that the RLOG/span total orders T2 was to pin down are now concretely stated,
+and T6 remains outstanding).
 
 ### Context
 
@@ -1386,3 +1391,56 @@ frame variants are never on the wire toward one.
 | T5 | ravel-query | federation.rs (per-signal federation test, incl. old-remote Unsupported under skip_unavailable) | T2, T3 | low |
 | T6 | ravel-sql | SQL-lane per-signal distributed scan: slice tickets + DistributedScanExec for logs/alerts/audit/spans, per-signal merge execs (dedup for metrics only -- NOT for logs/alerts/audit/spans, see T2/T3), flight_distributed.rs coverage | T1, ADR-0087 landed | high (same merge-correctness class as T2/T3) |
 | T7 | docs | docs/query-engine.md, docs/adrs/0071-distributed-read-fanout.md currency | T4, T5, T6 | low |
+
+### Shipped status
+
+The queryfrag lane shipped as proposed above. The as-built code matches the
+Decision points with no design divergence; the differences from the proposal
+are that forward-looking work is now landed, not that any decision changed:
+
+- **Per-signal dispatch (T1, T2, T3).** `run_slice_inner`
+  (`crates/ravel-query/src/distrib/service.rs`) decodes the signal and
+  dispatches: Metrics keeps its exact prior path; Logs, Alerts, and Audit share
+  one `LogSegmentFetcher` path (`run_slice_logs`); Spans fetch through
+  `SpanSegmentFetcher`, promoted into ravel-query as planned (`run_slice_spans`);
+  Profiles stays `Unsupported`. The log and span fetchers are opt-in builder
+  extras (`with_log_fetcher`/`with_span_fetcher`); an unwired fetcher, and a
+  log/span slice carrying matchers (no pushdown mapping in this lane yet), both
+  answer `Unsupported` and fall back to local — a fail-closed choice inside the
+  proposal's "correct without atomicity" envelope.
+- **Frames (T1).** `FetchResponse` gained `LogRecordFrame` and `SpanFrame`
+  additively, no `protocol_version` bump, exactly as decided; skew is governed
+  by the signal gate.
+- **The total orders T2 was to "pin down" are now stated** and load-bearing, in
+  the doc comments and code of `merge_log_records` and `merge_spans`
+  (`crates/ravel-query/src/distrib/mod.rs`). RLOG records sort under
+  `(ts_ns, stream_id, stream_attrs, observed_ts_ns, severity_num,
+  severity_text, body, trace_id, span_id, flags, attrs)` (attrs by frozen
+  `canonical_attr_bytes`, so f64 compares by bit pattern); spans under
+  `(trace_id, span_id, start_ts_ns, end_ts_ns, parent_span_id, name,
+  status_code, status_message, service_name, attrs)`. Both are stable sorts of
+  the flattened multiset with **no dedup** (docs/consistency-model.md "logs and
+  spans", ADR-0051 section 5), so the shard-major slice grouping — and a
+  reshard-straddling stream or trace — never changes the result. The
+  coordinator only orders; workers ship the per-segment merged view (segment
+  self-containment), never a coordinator-side attribute re-merge.
+- **Erasure (T2, T3).** Applied worker-side per segment through the same funnel
+  the local path uses, never re-applied at the coordinator.
+- **Skew and federation (T4, T5).** The new-coordinator/old-worker direction
+  degrades to whole-query silent local fallback via `Unsupported`; under
+  federation, an old remote's `Unsupported` for a new fan-out signal is a
+  skippable coverage gap (`crates/ravel-query/src/distrib/federation.rs`),
+  redacted-partial under `skip_unavailable` and typed otherwise. Per-signal
+  differential, erasure-property, skew, and federation tests are in place.
+
+**Not yet shipped: the SQL lane (T6).** Decision 7 puts both fan-out lanes in
+scope; only the queryfrag lane is built. The SQL-lane per-signal distributed
+scan (slice tickets, `DistributedScanExec`, per-signal merge execs for the
+`logs`/`alerts`/`audit`/`spans` tables) is unimplemented and still sequenced
+after ADR-0087 per Decision 8. Consequently the engine's own query flow only
+dispatches `Signal::Metrics` today
+(`fetch_samples_and_histograms_maybe_distributed` / `federate_scalar` in
+`crates/ravel-query/src/engine.rs`): the per-signal queryfrag fetch, merge, and
+federation machinery for Logs/Alerts/Audit/Spans is present and tested, but the
+coordinator caller that drives log and trace *search* over the wire is the SQL
+lane, which is where that fan-out becomes live.

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -375,6 +375,92 @@ leader, no assignment object, no new durable state — and the per-process
 content-addressed read caches behave as one aggregate cache because segments
 are immutable.
 
+### Signals that fan out
+
+The queryfrag lane distributes all five queryable signals: Metrics, Logs,
+Alerts, Audit, and Spans. The worker's `run_slice_inner` decodes the request's
+`signal` discriminant and dispatches to a per-signal fetch path
+(`crates/ravel-query/src/distrib/service.rs`):
+
+- **Metrics** resolves the pinned scope and fetches scalar series through the
+  metric `SegmentFetcher`. Native-histogram series are not distributed yet: a
+  slice that decodes any histogram series answers `Unsupported` (with its spend
+  folded first) and the whole query falls back to local.
+- **Logs, Alerts, Audit** are one RLOG object family and share a single fetch
+  path over `LogSegmentFetcher`, distinguished only by the object-key prefix the
+  coordinator already resolved (the worker never re-derives it, it fetches the
+  pinned segments the resolver maps). Each yields one `LogRecordFrame` per
+  decoded record.
+- **Spans** fetch through `SpanSegmentFetcher` (promoted into ravel-query from
+  the SQL crate for this lane), the same funnel a local `spans` read uses, and
+  yield one `SpanFrame` per surviving span.
+- **Profiles** has no distributed path and stays single-process: the worker
+  answers `Unsupported` exactly as every non-Metrics signal did before this
+  amendment.
+
+Two per-signal preconditions on the worker also degrade to local fallback
+(`Unsupported`), never a wrong or partial result: a Logs/Alerts/Audit or Spans
+slice on a worker with no log/span fetcher wired (both are opt-in builder
+extras, `with_log_fetcher`/`with_span_fetcher`), and a log/span slice carrying
+matchers (matcher pushdown for those signals has no mapping in this lane yet, so
+it fails closed rather than under-filter).
+
+This is the engine-level (queryfrag) fetch, merge, and federation machinery for
+all five signals — shipped and covered by the per-signal differential, erasure,
+skew, and federation tests. The coordinator caller that actually dispatches a
+Logs/Alerts/Audit/Spans distributed *search* is the SQL surface (log and trace
+search runs through the `logs`/`alerts`/`audit`/`spans` tables, not PromQL); the
+PromQL engine's own fetch/federation flow drives `Signal::Metrics` only today.
+The SQL-lane distributed scan is a separate, not-yet-landed step and is not
+described here.
+
+### The log/span coordinator merge: order-independent, no dedup
+
+The metrics coordinator merge is the order-insensitive k-way merge keyed on
+`(series_id, ts)` with the provenance tie-break already described under Flow;
+duplicates there are harmless and collapse. The RLOG-family and span merges
+(`merge_log_records`, `merge_spans` in `distrib/mod.rs`) differ in one decisive
+way: **they never dedup.** `docs/consistency-model.md` ("logs and spans") and
+ADR-0051 section 5 are explicit that logs, alerts, audit, and spans carry no
+query-time dedup — a retry after a lost ack produces byte-identical rows that
+are legitimately duplicate user data and must stay visible. Every record in the
+pool is returned.
+
+Correctness rests on two facts, neither of which is slice or shard atomicity
+(ADR-0052 online resharding routes one stream's or one trace's segments to
+different shard indices across generations, so a query window spanning a reshard
+activation can land one stream's or one trace's segments in two different
+slices):
+
+- **Segment self-containment.** Every RLOG segment embeds the resource+scope
+  `stream_attrs` blob for the streams it carries, and RSPAN rebuilds a span's
+  whole merged `attrs` from one segment alone, so a worker reading only its
+  slice's segments produces the exact per-record/per-span merged view a local
+  read produces. The coordinator never re-derives attribute merging; it only
+  orders.
+- **Order defined on record identity, not arrival order.** The coordinator
+  stable-sorts the flat pool under a stated total order over the whole record
+  content (for logs: `(ts_ns, stream_id, stream_attrs, observed_ts_ns,
+  severity_num, severity_text, body, trace_id, span_id, flags, attrs)`, with
+  `attrs` compared by the frozen `canonical_attr_bytes` encoding so f64 values
+  compare by bit pattern; for spans: `(trace_id, span_id, start_ts_ns,
+  end_ts_ns, parent_span_id, name, status_code, status_message, service_name,
+  attrs)`). Sorting the flattened multiset is a pure function of that multiset,
+  so the shard-major slice grouping — which differs from the local per-segment
+  grouping, and which a reshard-straddling stream or trace makes differ further
+  — never changes the result. The output is bit-identical to a local
+  multi-segment read merged under the same order, which the differential test
+  exercises with at least one generated case placing one stream's or trace's
+  segments in two slices.
+
+Erasure is applied worker-side, per segment, through the same funnel the local
+path uses (`retain_series_soa` for metrics, `LogQuery` erasure for the RLOG
+family, `is_erased_span` for spans); the coordinator never re-applies it.
+Because each segment is self-contained, a resource-attribute-only exclusion
+evaluates identically wherever the segment is read, including when one stream's
+segments straddle two slices — proven by an erasure property test that diffs a
+distributed slice set against a local read of the same segments.
+
 ### Budgets and the fault matrix
 
 The coordinator re-enforces the query's budgets over the folded per-slice
@@ -406,11 +492,17 @@ Failures map to the same typed outcomes the local path produces:
   `max_query_duration` that keeps workers inside the GC protection horizon)
   cancels the fan-out; stream teardown reaches workers and drop-based
   cancellation frees their GETs and permits.
-- **Protocol version mismatch** (rolling deploy) or a **non-metrics signal**
-  or a **histogram-bearing slice:** the worker answers `Unsupported`, and the
+- **Protocol version mismatch** (rolling deploy), a **`Profiles` signal**, a
+  **histogram-bearing metrics slice**, an **unwired log/span fetcher**, or a
+  **matcher-bearing log/span slice:** the worker answers `Unsupported`, and the
   coordinator silently falls back to fully local execution for the whole
-  query — never an error, never a partial result. Intra-cluster execution is
-  all-or-nothing; only cross-cluster federation (below) ever returns partial.
+  query — never an error, never a partial result. This is the load-bearing skew
+  direction: a *new* coordinator against an *old* worker that predates the
+  log/span fan-out sees `Unsupported` for Logs/Alerts/Audit/Spans and degrades
+  to local execution, so the new `LogRecordFrame`/`SpanFrame` variants never
+  reach a coordinator that cannot decode them (an *old* coordinator never
+  dispatches these signals). Intra-cluster execution is all-or-nothing; only
+  cross-cluster federation (below) ever returns partial.
 
 Fragment admission runs under a separate internal workload class with its own
 cap, so a coordinator holding a client-query permit can never deadlock
@@ -488,6 +580,23 @@ under `skip_unavailable` it degrades to partial coverage with a truthful
 warning (the remote returned a data kind this build cannot federate yet),
 and without `skip_unavailable` it fails with that same typed reason rather
 than a generic transport error.
+
+A remote that answers `Unsupported` for the whole query is handled the same
+way, and this is the federation analog of the intra-cluster skew fallback: a
+remote resolves its own snapshot, so `Unsupported` can only mean "this cluster
+does not serve this query kind yet" — an availability/coverage property, not a
+wrong-data one. The concrete case is a remote running code that predates the
+log/span fan-out: it rejects a Logs/Alerts/Audit/Spans query with `Unsupported`
+(its `run_slice_inner` rejects every non-Metrics signal). Federation routes that
+through the same `skip_unavailable` path an unavailable or histogram-bearing
+remote takes: under `skip_unavailable=true` the cluster is skipped, coverage is
+marked partial, and the warning names only the operator-facing cluster (the
+remote's internal status text is redacted out); under `=false` it fails with a
+typed `Federation` error naming the cluster. Treating it as a non-skippable hard
+fault would defeat exactly the availability `skip_unavailable` exists to provide
+during a mixed-version fan-out rollout. Federation composes over all five fan-out
+signals with no code beyond the per-signal `SliceFetcher`, and a per-signal
+federation test proves it rather than assuming it.
 
 #### The engine API cannot hand a caller a value without its coverage
 


### PR DESCRIPTION
Updates docs/query-engine.md and the ADR-0071 amendment from describing
the proposed design to the shipped one: which signals distribute
(Metrics, Logs, Alerts, Audit, Spans), the total-order/no-dedup merge
rule and why it holds without slice/shard atomicity, worker-side
erasure, and the skew/federation fallback behavior. States plainly that
the SQL lane (T6) has not landed and isn't described here.

Fixes: #289
Refs: #63
