### PR TITLE
docs(adrs): claim ADR-0093

### DIFF
--- a/docs/adrs/0093-typed-column-pushdown-logs.md
+++ b/docs/adrs/0093-typed-column-pushdown-logs.md
@@ -1,0 +1,3 @@
+# ADR-0093: skip-index and postings pushdown for declared typed logs columns
+
+Status: claimed


### PR DESCRIPTION
Reserves ADR-0093 for the skip-index/postings typed-column pushdown design (epic #278). Full content follows after design approval.