### PR TITLE
feat(ravel-sql): distributed SQL fan-out for logs/alerts/audit

### DIFF
--- a/crates/ravel-sql/src/alerts_provider.rs
+++ b/crates/ravel-sql/src/alerts_provider.rs
@@ -40,6 +40,14 @@ use ravel_types::accounting::QueryAccounting;
 use crate::alerts_pushdown::{AlertsPushdown, extract_alerts};
 use crate::alerts_scan::AlertsScanExec;
 use crate::alerts_schema::alerts_schema;
+#[cfg(feature = "flight-sql")]
+use crate::distributed::{WorkerSlice, WorkerSliceClient};
+#[cfg(feature = "flight-sql")]
+use crate::distributed_rlog::{
+    ALERTS_ORDER_COLS, DistributedRlogContext, distributed_alerts_plan, sort_slice_fragment,
+};
+#[cfg(feature = "flight-sql")]
+use ravel_query::ByteLimit;
 
 /// The `alerts` table provider for one tenant over one pinned `Signal::Alerts`
 /// snapshot.
@@ -55,6 +63,10 @@ pub struct AlertsTableProvider {
     /// `snapshot.pending_erasure` (ADR-0064 decision 2), cloned
     /// into every `AlertsScanExec` the provider builds.
     erasure: Arc<Vec<ErasurePredicate>>,
+    /// The coordinator-side distributed fan-out (ADR-0071; #326). `None` -- the
+    /// default, and every non-Flight build -- is the local scan path unchanged.
+    #[cfg(feature = "flight-sql")]
+    distributed: Option<DistributedRlogContext>,
 }
 
 impl AlertsTableProvider {
@@ -76,6 +88,57 @@ impl AlertsTableProvider {
             schema: alerts_schema(),
             accounting,
             erasure,
+            #[cfg(feature = "flight-sql")]
+            distributed: None,
+        }
+    }
+
+    /// Install a coordinator-side distributed scan context (ADR-0071; #326). The
+    /// alert-signal sibling of
+    /// [`LogsTableProvider::with_distributed_scan`](crate::LogsTableProvider):
+    /// [`TableProvider::scan`] fans the `alerts` scan out to the given worker
+    /// endpoints, feeding the no-dedup `SortPreservingMergeExec`, instead of
+    /// scanning locally. Only compiled with the Flight transport.
+    #[cfg(feature = "flight-sql")]
+    pub fn with_distributed_scan(
+        mut self,
+        endpoints: Vec<WorkerSlice>,
+        client: Arc<dyn WorkerSliceClient>,
+    ) -> Self {
+        self.distributed = Some(DistributedRlogContext { endpoints, client });
+        self
+    }
+
+    /// The worker-side fragment for a distributed `alerts` scan (ADR-0071; #326):
+    /// the whole-snapshot [`AlertsScanExec`] wrapped in a single globally-sorted
+    /// partition under the `alerts` total-order key, streamed to the coordinator's
+    /// no-dedup merge. There is NO dedup: alerts have no query-time dedup.
+    #[cfg(feature = "flight-sql")]
+    pub fn worker_fragment(&self, target_partitions: usize) -> DFResult<Arc<dyn ExecutionPlan>> {
+        let scan = self.build_scan(target_partitions, &AlertsPushdown::default())?;
+        sort_slice_fragment(scan, &self.schema, ALERTS_ORDER_COLS)
+    }
+
+    /// Apply projection pushdown (column selection only) above `plan` on the
+    /// distributed path, where the fan-out returns the full public schema.
+    #[cfg(feature = "flight-sql")]
+    fn apply_projection(
+        &self,
+        plan: Arc<dyn ExecutionPlan>,
+        projection: Option<&Vec<usize>>,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        match projection {
+            Some(proj) => {
+                let exprs = proj
+                    .iter()
+                    .map(|&i| {
+                        let name = self.schema.field(i).name();
+                        Ok((col(name, &self.schema)?, name.to_string()))
+                    })
+                    .collect::<DFResult<Vec<_>>>()?;
+                Ok(Arc::new(ProjectionExec::try_new(exprs, plan)?))
+            }
+            None => Ok(plan),
         }
     }
 
@@ -174,6 +237,23 @@ impl TableProvider for AlertsTableProvider {
         filters: &[Expr],
         _limit: Option<usize>,
     ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        // Distributed coordinator path (ADR-0071; #326): fan out to worker slices
+        // instead of scanning locally, folding worker bytes into the query
+        // accounting under an `Unlimited` ceiling (no per-query byte budget on the
+        // alerts provider). See the `logs` provider for the full rationale.
+        #[cfg(feature = "flight-sql")]
+        if let Some(dist) = &self.distributed {
+            let plan = distributed_alerts_plan(
+                dist.endpoints.clone(),
+                Arc::clone(&dist.client),
+                Arc::clone(&self.schema),
+                _limit,
+                self.accounting.clone(),
+                ByteLimit::Unlimited,
+            )?;
+            return self.apply_projection(plan, projection);
+        }
+
         let target_partitions = state.config().target_partitions();
         let pushdown = extract_alerts(filters);
         let plan = self.build_scan(target_partitions, &pushdown)?;

--- a/crates/ravel-sql/src/audit_provider.rs
+++ b/crates/ravel-sql/src/audit_provider.rs
@@ -39,6 +39,14 @@ use ravel_types::accounting::QueryAccounting;
 use crate::audit_pushdown::{AuditPushdown, extract_audit};
 use crate::audit_scan::AuditScanExec;
 use crate::audit_schema::audit_schema;
+#[cfg(feature = "flight-sql")]
+use crate::distributed::{WorkerSlice, WorkerSliceClient};
+#[cfg(feature = "flight-sql")]
+use crate::distributed_rlog::{
+    AUDIT_ORDER_COLS, DistributedRlogContext, distributed_audit_plan, sort_slice_fragment,
+};
+#[cfg(feature = "flight-sql")]
+use ravel_query::ByteLimit;
 
 /// The `audit` table provider for one tenant over one pinned `Signal::Audit`
 /// snapshot.
@@ -54,6 +62,10 @@ pub struct AuditTableProvider {
     /// `snapshot.pending_erasure` (ADR-0064 decision 2), cloned
     /// into every `AuditScanExec` the provider builds.
     erasure: Arc<Vec<ErasurePredicate>>,
+    /// The coordinator-side distributed fan-out (ADR-0071; #326). `None` -- the
+    /// default, and every non-Flight build -- is the local scan path unchanged.
+    #[cfg(feature = "flight-sql")]
+    distributed: Option<DistributedRlogContext>,
 }
 
 impl AuditTableProvider {
@@ -75,6 +87,57 @@ impl AuditTableProvider {
             schema: audit_schema(),
             accounting,
             erasure,
+            #[cfg(feature = "flight-sql")]
+            distributed: None,
+        }
+    }
+
+    /// Install a coordinator-side distributed scan context (ADR-0071; #326). The
+    /// audit-signal sibling of
+    /// [`LogsTableProvider::with_distributed_scan`](crate::LogsTableProvider):
+    /// [`TableProvider::scan`] fans the `audit` scan out to the given worker
+    /// endpoints, feeding the no-dedup `SortPreservingMergeExec`, instead of
+    /// scanning locally. Only compiled with the Flight transport.
+    #[cfg(feature = "flight-sql")]
+    pub fn with_distributed_scan(
+        mut self,
+        endpoints: Vec<WorkerSlice>,
+        client: Arc<dyn WorkerSliceClient>,
+    ) -> Self {
+        self.distributed = Some(DistributedRlogContext { endpoints, client });
+        self
+    }
+
+    /// The worker-side fragment for a distributed `audit` scan (ADR-0071; #326):
+    /// the whole-snapshot [`AuditScanExec`] wrapped in a single globally-sorted
+    /// partition under the `audit` total-order key, streamed to the coordinator's
+    /// no-dedup merge. There is NO dedup: audit has no query-time dedup.
+    #[cfg(feature = "flight-sql")]
+    pub fn worker_fragment(&self, target_partitions: usize) -> DFResult<Arc<dyn ExecutionPlan>> {
+        let scan = self.build_scan(target_partitions, &AuditPushdown::default())?;
+        sort_slice_fragment(scan, &self.schema, AUDIT_ORDER_COLS)
+    }
+
+    /// Apply projection pushdown (column selection only) above `plan` on the
+    /// distributed path, where the fan-out returns the full public schema.
+    #[cfg(feature = "flight-sql")]
+    fn apply_projection(
+        &self,
+        plan: Arc<dyn ExecutionPlan>,
+        projection: Option<&Vec<usize>>,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        match projection {
+            Some(proj) => {
+                let exprs = proj
+                    .iter()
+                    .map(|&i| {
+                        let name = self.schema.field(i).name();
+                        Ok((col(name, &self.schema)?, name.to_string()))
+                    })
+                    .collect::<DFResult<Vec<_>>>()?;
+                Ok(Arc::new(ProjectionExec::try_new(exprs, plan)?))
+            }
+            None => Ok(plan),
         }
     }
 
@@ -171,6 +234,23 @@ impl TableProvider for AuditTableProvider {
         filters: &[Expr],
         _limit: Option<usize>,
     ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        // Distributed coordinator path (ADR-0071; #326): fan out to worker slices
+        // instead of scanning locally, folding worker bytes into the query
+        // accounting under an `Unlimited` ceiling. See the `logs` provider for the
+        // full rationale.
+        #[cfg(feature = "flight-sql")]
+        if let Some(dist) = &self.distributed {
+            let plan = distributed_audit_plan(
+                dist.endpoints.clone(),
+                Arc::clone(&dist.client),
+                Arc::clone(&self.schema),
+                _limit,
+                self.accounting.clone(),
+                ByteLimit::Unlimited,
+            )?;
+            return self.apply_projection(plan, projection);
+        }
+
         let target_partitions = state.config().target_partitions();
         let pushdown = extract_audit(filters);
         let plan = self.build_scan(target_partitions, &pushdown)?;

--- a/crates/ravel-sql/src/distributed_rlog.rs
+++ b/crates/ravel-sql/src/distributed_rlog.rs
@@ -1,0 +1,471 @@
+//! SQL-lane distributed read fan-out for the RLOG family: logs, alerts, and
+//! audit (ADR-0071; #326, the SQL half of #63's T6). The signal sibling of
+//! [`crate::distributed`], which owns the metrics lane.
+//!
+//! # What is signal-generic here, and what is not
+//!
+//! Everything in this module except the three per-signal total-order keys is
+//! signal-neutral. [`DistributedSliceScanExec`] takes a [`SchemaRef`] and an
+//! ordering column list and knows nothing about logs, alerts, or audit;
+//! [`distributed_slice_plan`] assembles the fan-out around any schema and key.
+//! A later task (#327, T6b) reuses both verbatim for the `spans` table by
+//! passing the spans schema and the span total-order key -- it does not
+//! reimplement the scan exec, the merge assembly, the byte accounting, or the
+//! schema validation. The only RLOG-specific surface is
+//! [`LOGS_ORDER_COLS`]/[`ALERTS_ORDER_COLS`]/[`AUDIT_ORDER_COLS`] and the three
+//! thin wrappers ([`distributed_logs_plan`] and siblings) that bind a signal's
+//! public schema to its key.
+//!
+//! The slice-ticket plumbing is not reimplemented here at all: the fan-out
+//! reuses [`crate::distributed`]'s [`WorkerSlice`], [`WorkerSliceClient`],
+//! [`WorkerEndpoints`], [`DistributedFlightConfig`], and
+//! [`plan_distributed_slices`](crate::distributed::plan_distributed_slices)
+//! unchanged. Those are already signal-agnostic: a slice ticket pins a subset
+//! of a resolved snapshot and carries no signal discriminator, so the same
+//! minting/redeeming path serves every table.
+//!
+//! # The merge rule this reproduces: total order, NO dedup
+//!
+//! This is where the correctness rule differs from the metrics lane, and it is
+//! the whole point of the split. The metrics coordinator runs
+//! `SortPreservingMergeExec -> RsegDedupExec`: a `(series_id, ts)` sample can be
+//! written through segments in different shards, and the greatest-wins winner
+//! is only decidable once every slice's candidates meet, so the coordinator's
+//! dedup is authoritative.
+//!
+//! Logs, alerts, and audit have **no query-time dedup**
+//! (`docs/consistency-model.md`, "logs and spans"; ADR-0051 section 5). A retry
+//! after a lost acknowledgement produces byte-identical rows that are
+//! legitimately duplicate user data and MUST stay visible. So the RLOG merge is
+//! a `SortPreservingMergeExec` under a total-order key and **nothing above it**:
+//! no dedup node, no `.dedup_by`, no distinct. Every row every slice returns is
+//! emitted. This mirrors [`ravel_query::distrib`]'s `merge_log_records`, which
+//! flattens the per-slice pool and stable-sorts under a total key without ever
+//! collapsing an equal-key pair.
+//!
+//! Because there is no dedup, the multiset of rows is preserved under *any*
+//! union of the slice partitions; the sort exists to reproduce a deterministic,
+//! local-equivalent ordering (and to make the reshard-straddle differential
+//! test non-vacuous: a slice-order concatenation is observably wrong once one
+//! stream's segments straddle two slices, an order the sorted merge never
+//! produces). The key is the orderable public columns in a fixed sequence; the
+//! `attrs` `Map` column is deliberately excluded because Arrow maps are not
+//! orderable, which is sound precisely because there is no dedup -- two rows
+//! that tie on every orderable column are indistinguishable to SQL, so their
+//! relative order never matters.
+//!
+//! # Reachability
+//!
+//! Like the metrics lane today, nothing in the shipping binary reaches this
+//! yet: an RLOG distributed scan is installed on a provider via
+//! [`LogsTableProvider::with_distributed_scan`](crate::LogsTableProvider) (and
+//! the alerts/audit siblings) and is exercised end to end by the acceptance
+//! tests (`tests/flight_distributed.rs`) driving `provider.scan(..)`. The
+//! server-side coordinator that installs the context from
+//! `get_flight_info_statement`, and the worker `do_get` slice-fragment branch
+//! that runs [`LogsTableProvider::worker_fragment`], are later wiring (see the
+//! task report).
+
+use std::fmt;
+use std::sync::Arc;
+
+use datafusion::arrow::compute::SortOptions;
+use datafusion::arrow::datatypes::{Schema, SchemaRef};
+use datafusion::error::{DataFusionError, Result as DFResult};
+use datafusion::execution::{SendableRecordBatchStream, TaskContext};
+use datafusion::physical_expr::expressions::col;
+use datafusion::physical_expr::{EquivalenceProperties, LexOrdering, PhysicalSortExpr};
+use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
+use datafusion::physical_plan::limit::GlobalLimitExec;
+use datafusion::physical_plan::sorts::sort::SortExec;
+use datafusion::physical_plan::sorts::sort_preserving_merge::SortPreservingMergeExec;
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties,
+};
+use futures::StreamExt;
+use ravel_query::ByteLimit;
+use ravel_types::accounting::{AccountedOp, QueryAccounting};
+
+use crate::distributed::{WorkerSlice, WorkerSliceClient};
+use crate::error::SqlError;
+
+/// The `logs` table's total-order key: the orderable fixed public columns in a
+/// fixed sequence (ADR-0033 schema order). `attrs` is excluded (Arrow maps are
+/// not orderable); declared typed columns are excluded because they are a
+/// per-tenant tail that need not participate for the order to be deterministic
+/// on the fixed columns. `ts` first mirrors the local read's natural order.
+pub const LOGS_ORDER_COLS: &[&str] = &[
+    "ts",
+    "observed_ts",
+    "severity_num",
+    "severity_text",
+    "body",
+    "trace_id",
+    "span_id",
+    "flags",
+];
+
+/// The `alerts` table's total-order key: the orderable public columns in schema
+/// order (ADR-0040). `attrs` excluded, as above.
+pub const ALERTS_ORDER_COLS: &[&str] = &["ts_ns", "alert_id", "rule_id", "state", "generation"];
+
+/// The `audit` table's total-order key: the orderable public columns in schema
+/// order (ADR-0040). `attrs` excluded, as above.
+pub const AUDIT_ORDER_COLS: &[&str] = &["ts_ns", "severity_text", "body"];
+
+/// A coordinator-side distributed RLOG scan context (ADR-0071): the worker
+/// endpoints one query fans out to, and the client that fetches each slice.
+/// Held in an `Option` on each RLOG provider; installed via that provider's
+/// `with_distributed_scan`, absent (the default) means the local scan path.
+///
+/// Signal-neutral by construction -- it carries no schema or key -- so the
+/// three RLOG providers (and, later, the spans provider) share it unchanged.
+pub(crate) struct DistributedRlogContext {
+    pub(crate) endpoints: Vec<WorkerSlice>,
+    pub(crate) client: Arc<dyn WorkerSliceClient>,
+}
+
+/// Build a lexicographic ascending ordering over `cols`, resolved against
+/// `schema`. `nulls_first: false` matches every RLOG scan's declared ordering
+/// and the metrics lane, so a nullable promoted column (an absent `alert_id`)
+/// sorts last rather than first.
+fn lex_ordering(schema: &SchemaRef, cols: &[&str]) -> DFResult<LexOrdering> {
+    let asc = SortOptions {
+        descending: false,
+        nulls_first: false,
+    };
+    let exprs = cols
+        .iter()
+        .map(|name| Ok(PhysicalSortExpr::new(col(name, schema)?, asc)))
+        .collect::<DFResult<Vec<_>>>()?;
+    LexOrdering::new(exprs)
+        .ok_or_else(|| DataFusionError::Internal("empty distributed RLOG ordering".into()))
+}
+
+/// Wrap a signal's local (multi-partition, unordered) scan in a single
+/// globally-sorted partition under `ordering_cols`: the shape a worker streams
+/// back for the coordinator's [`SortPreservingMergeExec`] to k-way merge.
+///
+/// `SortExec` with the default `preserve_partitioning = false` sorts and
+/// coalesces every input partition into one, so the result is one partition
+/// sorted by the signal's total-order key -- exactly what
+/// [`DistributedSliceScanExec`] declares each worker partition to be. This is
+/// the RLOG analog of the metrics worker fragment's
+/// `RsegScanExec -> SortPreservingMergeExec`, but a full `SortExec` rather than
+/// a merge because the RLOG scans declare no leaf ordering (ADR-0087) for the
+/// merge to preserve.
+pub fn sort_slice_fragment(
+    scan: Arc<dyn ExecutionPlan>,
+    schema: &SchemaRef,
+    ordering_cols: &[&str],
+) -> DFResult<Arc<dyn ExecutionPlan>> {
+    let ordering = lex_ordering(schema, ordering_cols)?;
+    Ok(Arc::new(SortExec::new(ordering, scan)))
+}
+
+/// The leaf of an RLOG family distributed pipeline: one DataFusion partition per
+/// worker endpoint, each partition the worker's public-schema slice stream,
+/// declared sorted by the signal's total-order key.
+///
+/// Signal-generic: it holds a [`SchemaRef`] and the ordering column names, so it
+/// is the same struct for logs, alerts, audit, and (later) spans. It mirrors the
+/// metrics [`crate::distributed::DistributedScanExec`] -- the same per-slice
+/// byte accounting, the same declared-ordering trick that keeps the optimizer
+/// from striking the merge above it -- but carries the public signal schema
+/// rather than the metrics internal provenance schema, and never feeds a dedup.
+pub struct DistributedSliceScanExec {
+    endpoints: Vec<WorkerSlice>,
+    client: Arc<dyn WorkerSliceClient>,
+    /// Best-effort fetch-stop hint threaded to each worker (ADR-0071). Any exact
+    /// limit is re-applied above the merge by [`distributed_slice_plan`], so this
+    /// may over-fetch but never causes under-fetch.
+    limit: Option<usize>,
+    /// The coordinator's byte-accounting handle (ADR-0044, ADR-0061 decision 1):
+    /// each worker batch is folded in by `get_array_memory_size`, exactly as the
+    /// metrics lane folds its worker batches.
+    accounting: QueryAccounting,
+    /// The per-tenant bytes-scanned budget. `Unlimited` (the RLOG default, since
+    /// these providers carry no per-query byte budget) never trips and still
+    /// folds the bytes.
+    max_bytes_scanned: ByteLimit,
+    /// The signal's public output schema, validated against every worker batch.
+    schema: SchemaRef,
+    properties: Arc<PlanProperties>,
+}
+
+impl DistributedSliceScanExec {
+    /// Build a scan over one worker endpoint per slice, declaring each partition
+    /// sorted by `ordering_cols` over `schema`. `endpoints` must be non-empty: a
+    /// distributed plan with no worker is a caller bug, not a silently-empty
+    /// result.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        endpoints: Vec<WorkerSlice>,
+        client: Arc<dyn WorkerSliceClient>,
+        schema: SchemaRef,
+        ordering_cols: &[&str],
+        limit: Option<usize>,
+        accounting: QueryAccounting,
+        max_bytes_scanned: ByteLimit,
+    ) -> DFResult<Self> {
+        if endpoints.is_empty() {
+            return Err(DataFusionError::Internal(
+                "DistributedSliceScanExec needs at least one worker endpoint".into(),
+            ));
+        }
+        let properties = Arc::new(Self::compute_properties(
+            &schema,
+            ordering_cols,
+            endpoints.len(),
+        )?);
+        Ok(DistributedSliceScanExec {
+            endpoints,
+            client,
+            limit,
+            accounting,
+            max_bytes_scanned,
+            schema,
+            properties,
+        })
+    }
+
+    /// Declare the signal's total-order ordering per partition. Declaring it is
+    /// what lets the [`SortPreservingMergeExec`] above merge on it rather than
+    /// re-sort, and (like the metrics dedup's required-ordering) keeps the
+    /// optimizer from striking the merge when the plan is optimized rather than
+    /// executed directly.
+    fn compute_properties(
+        schema: &SchemaRef,
+        ordering_cols: &[&str],
+        n: usize,
+    ) -> DFResult<PlanProperties> {
+        let ordering = lex_ordering(schema, ordering_cols)?;
+        let eq = EquivalenceProperties::new_with_orderings(Arc::clone(schema), vec![ordering]);
+        Ok(PlanProperties::new(
+            eq,
+            Partitioning::UnknownPartitioning(n),
+            EmissionType::Incremental,
+            Boundedness::Bounded,
+        ))
+    }
+}
+
+impl fmt::Debug for DistributedSliceScanExec {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "DistributedSliceScanExec {{ endpoints: {} }}",
+            self.endpoints.len()
+        )
+    }
+}
+
+impl DisplayAs for DistributedSliceScanExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "DistributedSliceScanExec: endpoints={}, limit={:?}",
+            self.endpoints.len(),
+            self.limit
+        )
+    }
+}
+
+impl ExecutionPlan for DistributedSliceScanExec {
+    fn name(&self) -> &str {
+        "DistributedSliceScanExec"
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        _children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        Ok(self)
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        _context: Arc<TaskContext>,
+    ) -> DFResult<SendableRecordBatchStream> {
+        let endpoint = self.endpoints.get(partition).ok_or_else(|| {
+            DataFusionError::Internal(format!(
+                "DistributedSliceScanExec: partition {partition} out of range"
+            ))
+        })?;
+        let inner = self
+            .client
+            .fetch_slice(&endpoint.location, &endpoint.ticket, self.limit)?;
+
+        // Validate every worker batch against this exec's declared schema, then
+        // fold its bytes into the coordinator's accounting and enforce the
+        // per-tenant budget, exactly as the metrics lane does. A version-skewed
+        // or buggy worker that streams a different layout must fail typed here,
+        // not feed mismatched columns into the merge's key resolution downstream.
+        let expected = Arc::clone(&self.schema);
+        let accounting = self.accounting.clone();
+        let max_bytes_scanned = self.max_bytes_scanned;
+        let folded = inner.map(move |item| {
+            let batch = item?;
+            validate_schema(batch.schema().as_ref(), expected.as_ref())?;
+            let bytes = batch.get_array_memory_size() as u64;
+            accounting.add_s3_bytes(AccountedOp::Get, bytes);
+            let scanned = accounting.snapshot().total_s3_bytes();
+            if max_bytes_scanned.is_exceeded_by(scanned) {
+                let max = match max_bytes_scanned {
+                    ByteLimit::Bounded(max) => max,
+                    ByteLimit::Unlimited => scanned,
+                };
+                return Err(DataFusionError::from(SqlError::TooManyBytesScanned {
+                    scanned,
+                    max,
+                }));
+            }
+            Ok(batch)
+        });
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            Arc::clone(&self.schema),
+            folded,
+        )))
+    }
+}
+
+/// Verify a worker's slice stream carries this scan's declared public schema
+/// (ADR-0071). Column count, names, data types, and nullability must match
+/// exactly; incidental schema-level metadata Flight encode/decode may carry is
+/// not compared. A mismatch is a typed error, never a panic or a wrong result
+/// downstream.
+fn validate_schema(actual: &Schema, expected: &Schema) -> DFResult<()> {
+    let same = actual.fields().len() == expected.fields().len()
+        && actual.fields().iter().zip(expected.fields()).all(|(a, e)| {
+            a.name() == e.name()
+                && a.data_type() == e.data_type()
+                && a.is_nullable() == e.is_nullable()
+        });
+    if same {
+        Ok(())
+    } else {
+        Err(DataFusionError::Internal(format!(
+            "worker slice stream schema does not match the expected RLOG scan schema: \
+             expected {expected:?}, got {actual:?}"
+        )))
+    }
+}
+
+/// Assemble the signal-generic RLOG distributed pipeline:
+///
+/// ```text
+/// DistributedSliceScanExec (one partition per worker slice, sorted by key)
+///   -> SortPreservingMergeExec (key)   [NO dedup]
+///   [-> GlobalLimitExec(limit)         when a fetch limit is present]
+/// ```
+///
+/// There is deliberately no dedup node above the merge: logs/alerts/audit have
+/// no query-time dedup, so every row every slice returns is emitted (see the
+/// module docs). The `SortPreservingMergeExec` reproduces the local read's
+/// deterministic total order over `ordering_cols`; when `limit` is `Some`, an
+/// exact [`GlobalLimitExec`] sits above the merge so the plan returns exactly
+/// `limit` rows without ever under-fetching (the per-worker hint may over-fetch).
+///
+/// Signal-neutral: pass any table's public schema and total-order key. The three
+/// RLOG wrappers below are the only signal-aware callers today; T6b calls it
+/// with the spans schema and key.
+pub fn distributed_slice_plan(
+    endpoints: Vec<WorkerSlice>,
+    client: Arc<dyn WorkerSliceClient>,
+    schema: SchemaRef,
+    ordering_cols: &[&str],
+    limit: Option<usize>,
+    accounting: QueryAccounting,
+    max_bytes_scanned: ByteLimit,
+) -> DFResult<Arc<dyn ExecutionPlan>> {
+    let scan: Arc<dyn ExecutionPlan> = Arc::new(DistributedSliceScanExec::new(
+        endpoints,
+        client,
+        Arc::clone(&schema),
+        ordering_cols,
+        limit,
+        accounting,
+        max_bytes_scanned,
+    )?);
+    let ordering = lex_ordering(&schema, ordering_cols)?;
+    let merge: Arc<dyn ExecutionPlan> = Arc::new(SortPreservingMergeExec::new(ordering, scan));
+    match limit {
+        Some(fetch) => Ok(Arc::new(GlobalLimitExec::new(merge, 0, Some(fetch)))),
+        None => Ok(merge),
+    }
+}
+
+/// The `logs` distributed plan: [`distributed_slice_plan`] bound to the `logs`
+/// public schema and [`LOGS_ORDER_COLS`]. `schema` is the provider's resolved
+/// schema (`logs_schema_with_declared`), so a query with declared columns still
+/// merges on the fixed key present in every row.
+pub fn distributed_logs_plan(
+    endpoints: Vec<WorkerSlice>,
+    client: Arc<dyn WorkerSliceClient>,
+    schema: SchemaRef,
+    limit: Option<usize>,
+    accounting: QueryAccounting,
+    max_bytes_scanned: ByteLimit,
+) -> DFResult<Arc<dyn ExecutionPlan>> {
+    distributed_slice_plan(
+        endpoints,
+        client,
+        schema,
+        LOGS_ORDER_COLS,
+        limit,
+        accounting,
+        max_bytes_scanned,
+    )
+}
+
+/// The `alerts` distributed plan: [`distributed_slice_plan`] bound to the
+/// `alerts` public schema and [`ALERTS_ORDER_COLS`].
+pub fn distributed_alerts_plan(
+    endpoints: Vec<WorkerSlice>,
+    client: Arc<dyn WorkerSliceClient>,
+    schema: SchemaRef,
+    limit: Option<usize>,
+    accounting: QueryAccounting,
+    max_bytes_scanned: ByteLimit,
+) -> DFResult<Arc<dyn ExecutionPlan>> {
+    distributed_slice_plan(
+        endpoints,
+        client,
+        schema,
+        ALERTS_ORDER_COLS,
+        limit,
+        accounting,
+        max_bytes_scanned,
+    )
+}
+
+/// The `audit` distributed plan: [`distributed_slice_plan`] bound to the `audit`
+/// public schema and [`AUDIT_ORDER_COLS`].
+pub fn distributed_audit_plan(
+    endpoints: Vec<WorkerSlice>,
+    client: Arc<dyn WorkerSliceClient>,
+    schema: SchemaRef,
+    limit: Option<usize>,
+    accounting: QueryAccounting,
+    max_bytes_scanned: ByteLimit,
+) -> DFResult<Arc<dyn ExecutionPlan>> {
+    distributed_slice_plan(
+        endpoints,
+        client,
+        schema,
+        AUDIT_ORDER_COLS,
+        limit,
+        accounting,
+        max_bytes_scanned,
+    )
+}

--- a/crates/ravel-sql/src/lib.rs
+++ b/crates/ravel-sql/src/lib.rs
@@ -52,6 +52,8 @@ mod declared;
 mod dedup;
 #[cfg(feature = "flight-sql")]
 pub mod distributed;
+#[cfg(feature = "flight-sql")]
+pub mod distributed_rlog;
 mod error;
 mod executor;
 #[cfg(feature = "flight-sql")]
@@ -101,6 +103,12 @@ pub use distributed::{
     DistributedFlightConfig, DistributedScanExec, FlightWorkerSliceClient, StaticWorkerEndpoints,
     WorkerEndpoints, WorkerSlice, WorkerSliceClient, distributed_samples_plan,
     plan_distributed_slices,
+};
+#[cfg(feature = "flight-sql")]
+pub use distributed_rlog::{
+    ALERTS_ORDER_COLS, AUDIT_ORDER_COLS, DistributedSliceScanExec, LOGS_ORDER_COLS,
+    distributed_alerts_plan, distributed_audit_plan, distributed_logs_plan, distributed_slice_plan,
+    sort_slice_fragment,
 };
 pub use error::{
     ErrorClass, MSG_CORRUPT, MSG_EXECUTION, MSG_INTERNAL, MSG_PLAN, MSG_UNAVAILABLE,

--- a/crates/ravel-sql/src/logs_provider.rs
+++ b/crates/ravel-sql/src/logs_provider.rs
@@ -28,14 +28,26 @@ use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::catalog::{Session, TableProvider};
 use datafusion::error::Result as DFResult;
 use datafusion::logical_expr::{Expr, TableProviderFilterPushDown, TableType};
+#[cfg(feature = "flight-sql")]
+use datafusion::physical_expr::expressions::col;
 use datafusion::physical_plan::ExecutionPlan;
+#[cfg(feature = "flight-sql")]
+use datafusion::physical_plan::projection::ProjectionExec;
 use ravel_catalog::{SegmentRef, Snapshot};
+#[cfg(feature = "flight-sql")]
+use ravel_query::ByteLimit;
 use ravel_query::LogSegmentFetcher;
 use ravel_query::erasure::{ErasurePredicate, snapshot_pending_erasure_predicates};
 use ravel_types::TenantHash;
 use ravel_types::accounting::QueryAccounting;
 
 use crate::declared::DeclaredColumn;
+#[cfg(feature = "flight-sql")]
+use crate::distributed::{WorkerSlice, WorkerSliceClient};
+#[cfg(feature = "flight-sql")]
+use crate::distributed_rlog::{
+    DistributedRlogContext, LOGS_ORDER_COLS, distributed_logs_plan, sort_slice_fragment,
+};
 use crate::logs_pushdown::{LogsPushdown, extract_logs};
 use crate::logs_scan::LogsScanExec;
 use crate::logs_schema::{logs_schema, logs_schema_with_declared};
@@ -62,6 +74,11 @@ pub struct LogsTableProvider {
     /// exactly. The provider's advertised [`Self::schema`] and every
     /// `LogsScanExec` it builds are derived from this list.
     declared: Arc<Vec<DeclaredColumn>>,
+    /// The coordinator-side distributed fan-out (ADR-0071; #326), if this
+    /// provider is acting as a distributed coordinator. `None` -- the default,
+    /// and every non-Flight build -- is the local scan path unchanged.
+    #[cfg(feature = "flight-sql")]
+    distributed: Option<DistributedRlogContext>,
 }
 
 impl LogsTableProvider {
@@ -84,6 +101,64 @@ impl LogsTableProvider {
             accounting,
             erasure,
             declared: Arc::new(Vec::new()),
+            #[cfg(feature = "flight-sql")]
+            distributed: None,
+        }
+    }
+
+    /// Install a coordinator-side distributed scan context (ADR-0071; #326). With
+    /// it, [`TableProvider::scan`] fans the `logs` scan out to the given worker
+    /// endpoints -- one [`crate::distributed_rlog::DistributedSliceScanExec`]
+    /// partition per slice, feeding the no-dedup `SortPreservingMergeExec` --
+    /// instead of scanning the local snapshot. Without it, the provider is
+    /// unchanged. Only compiled with the Flight transport, which is the only
+    /// thing that can carry a slice ticket.
+    #[cfg(feature = "flight-sql")]
+    pub fn with_distributed_scan(
+        mut self,
+        endpoints: Vec<WorkerSlice>,
+        client: Arc<dyn WorkerSliceClient>,
+    ) -> Self {
+        self.distributed = Some(DistributedRlogContext { endpoints, client });
+        self
+    }
+
+    /// The worker-side fragment for a distributed `logs` scan (ADR-0071; #326):
+    /// the whole-snapshot [`LogsScanExec`] (all columns, no pushdown) wrapped in a
+    /// single globally-sorted partition under the `logs` total-order key. A worker
+    /// executes this over its slice and streams the result to the coordinator,
+    /// whose `DistributedSliceScanExec` exposes each worker stream as one sorted
+    /// partition feeding the SAME no-dedup merge. There is NO dedup, in the worker
+    /// or the coordinator: logs have no query-time dedup, so every fetched record
+    /// is returned.
+    #[cfg(feature = "flight-sql")]
+    pub fn worker_fragment(&self, target_partitions: usize) -> DFResult<Arc<dyn ExecutionPlan>> {
+        let scan = self.build_scan(target_partitions, &LogsPushdown::default(), None)?;
+        sort_slice_fragment(scan, &self.schema, LOGS_ORDER_COLS)
+    }
+
+    /// Apply projection pushdown (column selection only) above `plan`, used only
+    /// on the distributed path where the fan-out returns the full public schema
+    /// and DataFusion asked for a subset. The local path pushes projection into
+    /// the scan instead (see [`Self::build_scan`]).
+    #[cfg(feature = "flight-sql")]
+    fn apply_projection(
+        &self,
+        plan: Arc<dyn ExecutionPlan>,
+        projection: Option<&Vec<usize>>,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        match projection {
+            Some(proj) => {
+                let exprs = proj
+                    .iter()
+                    .map(|&i| {
+                        let name = self.schema.field(i).name();
+                        Ok((col(name, &self.schema)?, name.to_string()))
+                    })
+                    .collect::<DFResult<Vec<_>>>()?;
+                Ok(Arc::new(ProjectionExec::try_new(exprs, plan)?))
+            }
+            None => Ok(plan),
         }
     }
 
@@ -203,6 +278,29 @@ impl TableProvider for LogsTableProvider {
         filters: &[Expr],
         _limit: Option<usize>,
     ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        // Distributed coordinator path (ADR-0071; #326): fan out to worker slices
+        // instead of scanning locally. The scan's `_limit` is honored as a
+        // fetch-stop hint across the distributed partitions, with the exact limit
+        // re-applied above the merge (over-fetch is safe, under-fetch is not).
+        // Filters are re-applied above the returned plan by DataFusion (the
+        // provider reports `Inexact`), so not pushing them to workers only widens
+        // each worker's read, never changes a row. The `logs` provider carries no
+        // per-query byte budget (admission is decided at resolve time), so the
+        // fan-out folds bytes into the query accounting under an `Unlimited`
+        // ceiling, matching the local path.
+        #[cfg(feature = "flight-sql")]
+        if let Some(dist) = &self.distributed {
+            let plan = distributed_logs_plan(
+                dist.endpoints.clone(),
+                Arc::clone(&dist.client),
+                Arc::clone(&self.schema),
+                _limit,
+                self.accounting.clone(),
+                ByteLimit::Unlimited,
+            )?;
+            return self.apply_projection(plan, projection);
+        }
+
         let target_partitions = state.config().target_partitions();
         let pushdown = extract_logs(filters);
         // Projection pushdown reaches the reader (ADR-0087 decision 3): the

--- a/crates/ravel-sql/tests/flight_distributed.rs
+++ b/crates/ravel-sql/tests/flight_distributed.rs
@@ -1340,3 +1340,720 @@ async fn distributed_scan_folds_bytes_into_coordinator_accounting() {
         "the byte ceiling surfaces as a scanned-too-many-bytes error: {err}"
     );
 }
+
+// ===========================================================================
+// RLOG family (logs / alerts / audit) SQL-lane distributed fan-out (#326, T6a)
+// ===========================================================================
+//
+// These reproduce, at the SQL layer, the queryfrag-layer merge-correctness
+// invariant #284 established (`ravel_query::distrib::merge_log_records`):
+// logs/alerts/audit merge under a total order with NO dedup. Two shapes, per
+// signal, both from T2:
+//
+// - *reshard-straddle*: one stream's records live in TWO shards (two slices),
+//   with `ts` interleaving across the shards. The distributed output must be
+//   the total-order merge of both slices, which differs from any slice-order
+//   concatenation. The specific line a naive concat breaks: the coordinator
+//   `SortPreservingMergeExec` in `distributed_slice_plan` (equivalently the
+//   worker `SortExec` in `sort_slice_fragment`). Replace either with an
+//   unordered coalesce and the ordered assertion below fails, because the
+//   fixture's `ts` values interleave [10,20,30,40] across the two shards, an
+//   order neither slice-concat produces ([10,30,20,40] or [20,40,10,30]).
+//
+// - *duplicate-preservation*: two byte-identical records, one per shard (a
+//   retry after a lost ack). Both must survive: logs/alerts/audit have no
+//   query-time dedup (docs/consistency-model.md, "logs and spans"). The
+//   specific line a reintroduced dedup breaks: the absence of any dedup node
+//   above the merge. Add a `.dedup`/distinct and the row count drops from 2 to
+//   1 and the assertion below fails.
+//
+// prove-the-test discipline (the second #284 trap): the "local" reference on
+// every differential is the plain single-process provider scan (`plan(..)`)
+// collected and sorted IN-TEST by a hand-written comparator -- it never calls
+// the distributed merge exec under test on the reference side, so a regression
+// in that exec cannot hide by appearing on both sides.
+
+use bytes::Bytes;
+use datafusion::arrow::array::StringArray;
+use datafusion::physical_plan::ExecutionPlan;
+use ravel_logseg::writer::ObjectIdentity;
+use ravel_logseg::{AttrValue, LogRecord, RlogConfig, RlogWriter, stream_attrs_bytes};
+use ravel_sql::{AlertsTableProvider, AuditTableProvider, LogsTableProvider};
+use ravel_types::logstream::log_stream_id;
+
+/// A generic RLOG record on the stream identified by `resource`, carrying
+/// per-record dynamic `attrs`. Structurally shared by all three signals (an
+/// alert/audit record rides RLOG verbatim, ADR-0040).
+fn log_record(
+    resource: &[(String, AttrValue)],
+    attrs: &[(String, AttrValue)],
+    ts: i64,
+    body: &str,
+) -> LogRecord {
+    LogRecord {
+        stream_id: log_stream_id(resource, "scope", "1.0", &[]),
+        stream_attrs: stream_attrs_bytes(resource, "scope", "1.0", &[]),
+        ts_ns: ts,
+        observed_ts_ns: ts,
+        severity_num: 9,
+        severity_text: "INFO".into(),
+        body: body.into(),
+        trace_id: None,
+        span_id: None,
+        flags: 0,
+        attrs: attrs.to_vec(),
+    }
+}
+
+/// An alert record: the four promoted scalar fields carried as attributes
+/// (ADR-0040 decision 2), `alert_id` the differentiator this test reads back.
+fn alert_record(resource: &[(String, AttrValue)], ts: i64, alert_id: &str) -> LogRecord {
+    log_record(
+        resource,
+        &[
+            ("alert_id".to_string(), AttrValue::Str(alert_id.into())),
+            ("rule_id".to_string(), AttrValue::Str("rule-1".into())),
+            ("state".to_string(), AttrValue::Str("firing".into())),
+            ("generation".to_string(), AttrValue::I64(1)),
+        ],
+        ts,
+        "",
+    )
+}
+
+/// Write one RLOG object from `records` on `shard`, put it at `key`, and return a
+/// matching L0 `SegmentRef` carrying the object's true ts span and `shard` (so
+/// `partition_snapshot` groups it shard-major into its own slice). The identity's
+/// `tenant_hash` must match [`TENANT`], which the RLOG read path enforces.
+async fn write_rlog_segment(
+    store: &dyn ObjectStoreBackend,
+    key: &str,
+    shard: u32,
+    writer_seq: u64,
+    created_unix_ns: i64,
+    records: &[LogRecord],
+) -> SegmentRef {
+    let identity = ObjectIdentity {
+        tenant_hash: TENANT.0,
+        shard,
+        writer_id: [2u8; 16],
+        writer_epoch: 1,
+        writer_seq,
+    };
+    let mut w = RlogWriter::new(RlogConfig::default(), identity);
+    for r in records {
+        w.push(r.clone()).expect("push record");
+    }
+    let bytes = w.finish().expect("finish object");
+    let size = bytes.len() as u64;
+    store
+        .put(key, Bytes::from(bytes), PutOptions::default())
+        .await
+        .expect("put object");
+
+    let min = records.iter().map(|r| r.ts_ns).min().expect("nonempty");
+    let max = records.iter().map(|r| r.ts_ns).max().expect("nonempty");
+    SegmentRef {
+        data_object_key: key.to_string(),
+        object_size: size,
+        min_event_ts_ns: min,
+        max_event_ts_ns: max,
+        ingest_hour_bucket: 0,
+        sample_count: records.len() as u64,
+        series_count: 0,
+        shard,
+        content_hash: [0u8; 32],
+        writer_id: Uuid::from_u128(shard as u128 + 1),
+        writer_epoch: 1,
+        writer_seq,
+        created_unix_ns,
+        level: SegmentLevel::L0,
+    }
+}
+
+fn rlog_snapshot(segments: Vec<SegmentRef>) -> Snapshot {
+    Snapshot {
+        segments,
+        segments_pruned: 0,
+        pending_erasure: Vec::new(),
+    }
+}
+
+/// One worker endpoint per shard-major slice, minting a slice ticket for each.
+/// Reuses the signal-agnostic slice-ticket plumbing (`partition_snapshot`,
+/// `FlightTicket`, `SegmentPin`) unchanged -- it carries no signal discriminator.
+fn rlog_endpoints_for(snapshot: &Snapshot) -> Vec<WorkerSlice> {
+    let slices = partition_snapshot(snapshot, 8);
+    let count = slices.len() as u32;
+    slices
+        .iter()
+        .enumerate()
+        .map(|(k, slice)| WorkerSlice {
+            location: format!("grpc://rlog-worker-{k}"),
+            ticket: FlightTicket {
+                tenant: TENANT,
+                statement: String::new(),
+                segments: slice
+                    .segments
+                    .iter()
+                    .map(SegmentPin::from_segment_ref)
+                    .collect(),
+                min_commit_tokens: Vec::new(),
+                now_ns: NOW_NS,
+                deadline_ns: NOW_NS + 1_000_000_000,
+                slice_index: k as u32,
+                slice_count: count,
+                pending_erasure: Vec::new(),
+                declared_columns: Vec::new(),
+            },
+        })
+        .collect()
+}
+
+/// The in-process RLOG worker: rebuilds the slice's snapshot from the ticket and
+/// runs that signal's worker fragment (`<signal>ScanExec -> SortExec`, public
+/// schema, one sorted partition, NO dedup), streaming the result back. The
+/// signal is selected by the `build` fn pointer, so one worker type serves all
+/// three signals (and, later, spans).
+struct RlogWorker {
+    fetcher: LogSegmentFetcher,
+    build: fn(Snapshot, LogSegmentFetcher, usize) -> DFResult<Arc<dyn ExecutionPlan>>,
+}
+
+impl std::fmt::Debug for RlogWorker {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("RlogWorker")
+    }
+}
+
+impl WorkerSliceClient for RlogWorker {
+    fn fetch_slice(
+        &self,
+        _location: &str,
+        ticket: &FlightTicket,
+        _limit: Option<usize>,
+    ) -> DFResult<SendableRecordBatchStream> {
+        let snapshot = ticket.snapshot();
+        let target_partitions = snapshot.segments.len().max(1);
+        let plan = (self.build)(snapshot, self.fetcher.clone(), target_partitions)?;
+        execute_stream(plan, Arc::new(TaskContext::default()))
+    }
+}
+
+fn logs_fragment(
+    snapshot: Snapshot,
+    fetcher: LogSegmentFetcher,
+    target_partitions: usize,
+) -> DFResult<Arc<dyn ExecutionPlan>> {
+    LogsTableProvider::new(snapshot, TENANT, fetcher, QueryAccounting::new())
+        .worker_fragment(target_partitions)
+}
+
+fn alerts_fragment(
+    snapshot: Snapshot,
+    fetcher: LogSegmentFetcher,
+    target_partitions: usize,
+) -> DFResult<Arc<dyn ExecutionPlan>> {
+    AlertsTableProvider::new(snapshot, TENANT, fetcher, QueryAccounting::new())
+        .worker_fragment(target_partitions)
+}
+
+fn audit_fragment(
+    snapshot: Snapshot,
+    fetcher: LogSegmentFetcher,
+    target_partitions: usize,
+) -> DFResult<Arc<dyn ExecutionPlan>> {
+    AuditTableProvider::new(snapshot, TENANT, fetcher, QueryAccounting::new())
+        .worker_fragment(target_partitions)
+}
+
+/// Extract `(ts, discriminator)` rows in emission order. `ts_col` is the
+/// signal's timestamp column (`ts` for logs, `ts_ns` for alerts/audit);
+/// `other_col` a nullable/non-null Utf8 differentiator. A NULL differentiator
+/// renders as the empty string.
+fn ts_and(batches: &[RecordBatch], ts_col: &str, other_col: &str) -> Vec<(i64, String)> {
+    let mut out = Vec::new();
+    for b in batches {
+        let ts = b
+            .column_by_name(ts_col)
+            .unwrap_or_else(|| panic!("column {ts_col}"))
+            .as_any()
+            .downcast_ref::<TimestampNanosecondArray>()
+            .expect("ts column type");
+        let other = b
+            .column_by_name(other_col)
+            .unwrap_or_else(|| panic!("column {other_col}"))
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("discriminator column type");
+        for i in 0..b.num_rows() {
+            let s = if other.is_null(i) {
+                String::new()
+            } else {
+                other.value(i).to_string()
+            };
+            out.push((ts.value(i), s));
+        }
+    }
+    out
+}
+
+async fn collect_plan(plan: Arc<dyn ExecutionPlan>) -> Vec<RecordBatch> {
+    collect(plan, Arc::new(TaskContext::default()))
+        .await
+        .expect("collect plan")
+}
+
+async fn collect_distributed(provider: Arc<dyn TableProvider>) -> Vec<RecordBatch> {
+    let ctx = SessionContext::new();
+    let plan = provider
+        .scan(&ctx.state(), None, &[], None)
+        .await
+        .expect("distributed scan");
+    collect(plan, Arc::new(TaskContext::default()))
+        .await
+        .expect("collect distributed")
+}
+
+// --- logs -----------------------------------------------------------------
+
+#[tokio::test]
+async fn distributed_logs_reshard_straddle_equals_sorted_local() {
+    let store = Arc::new(MemoryStore::new());
+    let backend: Arc<dyn ObjectStoreBackend> = store;
+    // One stream (`service.name = api`) straddles two shards, ts interleaving.
+    let res = vec![("service.name".to_string(), AttrValue::Str("api".into()))];
+    let s0 = write_rlog_segment(
+        backend.as_ref(),
+        "logs/reshard-0.rlog",
+        0,
+        1,
+        10,
+        &[
+            log_record(&res, &[], 10, "b10"),
+            log_record(&res, &[], 30, "b30"),
+        ],
+    )
+    .await;
+    let s1 = write_rlog_segment(
+        backend.as_ref(),
+        "logs/reshard-1.rlog",
+        1,
+        1,
+        20,
+        &[
+            log_record(&res, &[], 20, "b20"),
+            log_record(&res, &[], 40, "b40"),
+        ],
+    )
+    .await;
+    let snapshot = rlog_snapshot(vec![s0, s1]);
+    let fetcher = LogSegmentFetcher::new(Arc::clone(&backend));
+
+    assert!(
+        rlog_endpoints_for(&snapshot).len() >= 2,
+        "fixture must genuinely partition into more than one slice"
+    );
+
+    // Independent local reference: plain scan, sorted in-test (never the merge
+    // exec under test).
+    let local = collect_plan(
+        LogsTableProvider::new(
+            snapshot.clone(),
+            TENANT,
+            fetcher.clone(),
+            QueryAccounting::new(),
+        )
+        .plan(4)
+        .expect("local plan"),
+    )
+    .await;
+    let mut want = ts_and(&local, "ts", "body");
+    want.sort();
+
+    let client: Arc<dyn WorkerSliceClient> = Arc::new(RlogWorker {
+        fetcher: fetcher.clone(),
+        build: logs_fragment,
+    });
+    let dist: Arc<dyn TableProvider> = Arc::new(
+        LogsTableProvider::new(snapshot.clone(), TENANT, fetcher, QueryAccounting::new())
+            .with_distributed_scan(rlog_endpoints_for(&snapshot), client),
+    );
+    let got = ts_and(&collect_distributed(dist).await, "ts", "body");
+
+    assert_eq!(
+        got, want,
+        "the distributed output is the total-order merge of both slices; a slice-order concat would differ"
+    );
+    assert_eq!(
+        got.iter().map(|(t, _)| *t).collect::<Vec<_>>(),
+        vec![10, 20, 30, 40],
+        "the straddling stream's ts are globally sorted across slices, not slice-concatenated"
+    );
+}
+
+#[tokio::test]
+async fn distributed_logs_preserves_duplicate_rows() {
+    let store = Arc::new(MemoryStore::new());
+    let backend: Arc<dyn ObjectStoreBackend> = store;
+    let res = vec![("service.name".to_string(), AttrValue::Str("api".into()))];
+    // Two byte-identical records, one per shard: a retry after a lost ack.
+    let s0 = write_rlog_segment(
+        backend.as_ref(),
+        "logs/dup-0.rlog",
+        0,
+        1,
+        10,
+        &[log_record(&res, &[], 50, "dup")],
+    )
+    .await;
+    let s1 = write_rlog_segment(
+        backend.as_ref(),
+        "logs/dup-1.rlog",
+        1,
+        1,
+        20,
+        &[log_record(&res, &[], 50, "dup")],
+    )
+    .await;
+    let snapshot = rlog_snapshot(vec![s0, s1]);
+    let fetcher = LogSegmentFetcher::new(Arc::clone(&backend));
+
+    let local = collect_plan(
+        LogsTableProvider::new(
+            snapshot.clone(),
+            TENANT,
+            fetcher.clone(),
+            QueryAccounting::new(),
+        )
+        .plan(4)
+        .expect("local plan"),
+    )
+    .await;
+    let mut want = ts_and(&local, "ts", "body");
+    want.sort();
+
+    let client: Arc<dyn WorkerSliceClient> = Arc::new(RlogWorker {
+        fetcher: fetcher.clone(),
+        build: logs_fragment,
+    });
+    let dist: Arc<dyn TableProvider> = Arc::new(
+        LogsTableProvider::new(snapshot.clone(), TENANT, fetcher, QueryAccounting::new())
+            .with_distributed_scan(rlog_endpoints_for(&snapshot), client),
+    );
+    let mut got = ts_and(&collect_distributed(dist).await, "ts", "body");
+    got.sort();
+
+    assert_eq!(got, want, "distributed multiset equals local multiset");
+    assert_eq!(
+        got,
+        vec![(50, "dup".to_string()), (50, "dup".to_string())],
+        "both byte-identical rows survive; a reintroduced dedup would collapse them to one"
+    );
+}
+
+#[tokio::test]
+async fn distributed_logs_plan_merges_without_dedup() {
+    let store = Arc::new(MemoryStore::new());
+    let backend: Arc<dyn ObjectStoreBackend> = store;
+    let res = vec![("service.name".to_string(), AttrValue::Str("api".into()))];
+    let s0 = write_rlog_segment(
+        backend.as_ref(),
+        "logs/shape-0.rlog",
+        0,
+        1,
+        10,
+        &[log_record(&res, &[], 10, "b10")],
+    )
+    .await;
+    let s1 = write_rlog_segment(
+        backend.as_ref(),
+        "logs/shape-1.rlog",
+        1,
+        1,
+        20,
+        &[log_record(&res, &[], 20, "b20")],
+    )
+    .await;
+    let snapshot = rlog_snapshot(vec![s0, s1]);
+    let fetcher = LogSegmentFetcher::new(Arc::clone(&backend));
+
+    let client: Arc<dyn WorkerSliceClient> = Arc::new(RlogWorker {
+        fetcher: fetcher.clone(),
+        build: logs_fragment,
+    });
+    let dist = LogsTableProvider::new(snapshot.clone(), TENANT, fetcher, QueryAccounting::new())
+        .with_distributed_scan(rlog_endpoints_for(&snapshot), client);
+    let ctx = SessionContext::new();
+    let plan = dist
+        .scan(&ctx.state(), None, &[], None)
+        .await
+        .expect("distributed scan");
+    let text = displayable(plan.as_ref()).indent(true).to_string();
+
+    assert!(
+        text.contains("SortPreservingMergeExec"),
+        "the RLOG merge is a SortPreservingMergeExec:\n{text}"
+    );
+    assert!(
+        text.contains("DistributedSliceScanExec"),
+        "over the fan-out slice scan:\n{text}"
+    );
+    // The load-bearing negative: logs/alerts/audit have NO query-time dedup, so
+    // the plan must never grow an RsegDedupExec (or any dedup node) above the
+    // merge. This is trap #1 from the task, guarded directly.
+    assert!(
+        !text.to_lowercase().contains("dedup"),
+        "logs/alerts/audit have no query-time dedup; the merge must not introduce one:\n{text}"
+    );
+}
+
+// --- alerts ----------------------------------------------------------------
+
+#[tokio::test]
+async fn distributed_alerts_reshard_straddle_equals_sorted_local() {
+    let store = Arc::new(MemoryStore::new());
+    let backend: Arc<dyn ObjectStoreBackend> = store;
+    let res = vec![("service.name".to_string(), AttrValue::Str("alerts".into()))];
+    let s0 = write_rlog_segment(
+        backend.as_ref(),
+        "alerts/reshard-0.rlog",
+        0,
+        1,
+        10,
+        &[alert_record(&res, 10, "a10"), alert_record(&res, 30, "a30")],
+    )
+    .await;
+    let s1 = write_rlog_segment(
+        backend.as_ref(),
+        "alerts/reshard-1.rlog",
+        1,
+        1,
+        20,
+        &[alert_record(&res, 20, "a20"), alert_record(&res, 40, "a40")],
+    )
+    .await;
+    let snapshot = rlog_snapshot(vec![s0, s1]);
+    let fetcher = LogSegmentFetcher::new(Arc::clone(&backend));
+
+    let local = collect_plan(
+        AlertsTableProvider::new(
+            snapshot.clone(),
+            TENANT,
+            fetcher.clone(),
+            QueryAccounting::new(),
+        )
+        .plan(4)
+        .expect("local plan"),
+    )
+    .await;
+    let mut want = ts_and(&local, "ts_ns", "alert_id");
+    want.sort();
+
+    let client: Arc<dyn WorkerSliceClient> = Arc::new(RlogWorker {
+        fetcher: fetcher.clone(),
+        build: alerts_fragment,
+    });
+    let dist: Arc<dyn TableProvider> = Arc::new(
+        AlertsTableProvider::new(snapshot.clone(), TENANT, fetcher, QueryAccounting::new())
+            .with_distributed_scan(rlog_endpoints_for(&snapshot), client),
+    );
+    let got = ts_and(&collect_distributed(dist).await, "ts_ns", "alert_id");
+
+    assert_eq!(got, want, "alerts distributed merge equals sorted local");
+    assert_eq!(
+        got.iter().map(|(t, _)| *t).collect::<Vec<_>>(),
+        vec![10, 20, 30, 40],
+        "the straddling stream's ts are globally sorted across slices"
+    );
+}
+
+#[tokio::test]
+async fn distributed_alerts_preserves_duplicate_rows() {
+    let store = Arc::new(MemoryStore::new());
+    let backend: Arc<dyn ObjectStoreBackend> = store;
+    let res = vec![("service.name".to_string(), AttrValue::Str("alerts".into()))];
+    let s0 = write_rlog_segment(
+        backend.as_ref(),
+        "alerts/dup-0.rlog",
+        0,
+        1,
+        10,
+        &[alert_record(&res, 50, "adup")],
+    )
+    .await;
+    let s1 = write_rlog_segment(
+        backend.as_ref(),
+        "alerts/dup-1.rlog",
+        1,
+        1,
+        20,
+        &[alert_record(&res, 50, "adup")],
+    )
+    .await;
+    let snapshot = rlog_snapshot(vec![s0, s1]);
+    let fetcher = LogSegmentFetcher::new(Arc::clone(&backend));
+
+    let local = collect_plan(
+        AlertsTableProvider::new(
+            snapshot.clone(),
+            TENANT,
+            fetcher.clone(),
+            QueryAccounting::new(),
+        )
+        .plan(4)
+        .expect("local plan"),
+    )
+    .await;
+    let mut want = ts_and(&local, "ts_ns", "alert_id");
+    want.sort();
+
+    let client: Arc<dyn WorkerSliceClient> = Arc::new(RlogWorker {
+        fetcher: fetcher.clone(),
+        build: alerts_fragment,
+    });
+    let dist: Arc<dyn TableProvider> = Arc::new(
+        AlertsTableProvider::new(snapshot.clone(), TENANT, fetcher, QueryAccounting::new())
+            .with_distributed_scan(rlog_endpoints_for(&snapshot), client),
+    );
+    let mut got = ts_and(&collect_distributed(dist).await, "ts_ns", "alert_id");
+    got.sort();
+
+    assert_eq!(
+        got, want,
+        "alerts distributed multiset equals local multiset"
+    );
+    assert_eq!(
+        got,
+        vec![(50, "adup".to_string()), (50, "adup".to_string())],
+        "both duplicate alert rows survive; a reintroduced dedup would drop one"
+    );
+}
+
+// --- audit -----------------------------------------------------------------
+
+#[tokio::test]
+async fn distributed_audit_reshard_straddle_equals_sorted_local() {
+    let store = Arc::new(MemoryStore::new());
+    let backend: Arc<dyn ObjectStoreBackend> = store;
+    let res = vec![("service.name".to_string(), AttrValue::Str("audit".into()))];
+    let s0 = write_rlog_segment(
+        backend.as_ref(),
+        "audit/reshard-0.rlog",
+        0,
+        1,
+        10,
+        &[
+            log_record(&res, &[], 10, "e10"),
+            log_record(&res, &[], 30, "e30"),
+        ],
+    )
+    .await;
+    let s1 = write_rlog_segment(
+        backend.as_ref(),
+        "audit/reshard-1.rlog",
+        1,
+        1,
+        20,
+        &[
+            log_record(&res, &[], 20, "e20"),
+            log_record(&res, &[], 40, "e40"),
+        ],
+    )
+    .await;
+    let snapshot = rlog_snapshot(vec![s0, s1]);
+    let fetcher = LogSegmentFetcher::new(Arc::clone(&backend));
+
+    let local = collect_plan(
+        AuditTableProvider::new(
+            snapshot.clone(),
+            TENANT,
+            fetcher.clone(),
+            QueryAccounting::new(),
+        )
+        .plan(4)
+        .expect("local plan"),
+    )
+    .await;
+    let mut want = ts_and(&local, "ts_ns", "body");
+    want.sort();
+
+    let client: Arc<dyn WorkerSliceClient> = Arc::new(RlogWorker {
+        fetcher: fetcher.clone(),
+        build: audit_fragment,
+    });
+    let dist: Arc<dyn TableProvider> = Arc::new(
+        AuditTableProvider::new(snapshot.clone(), TENANT, fetcher, QueryAccounting::new())
+            .with_distributed_scan(rlog_endpoints_for(&snapshot), client),
+    );
+    let got = ts_and(&collect_distributed(dist).await, "ts_ns", "body");
+
+    assert_eq!(got, want, "audit distributed merge equals sorted local");
+    assert_eq!(
+        got.iter().map(|(t, _)| *t).collect::<Vec<_>>(),
+        vec![10, 20, 30, 40],
+        "the straddling stream's ts are globally sorted across slices"
+    );
+}
+
+#[tokio::test]
+async fn distributed_audit_preserves_duplicate_rows() {
+    let store = Arc::new(MemoryStore::new());
+    let backend: Arc<dyn ObjectStoreBackend> = store;
+    let res = vec![("service.name".to_string(), AttrValue::Str("audit".into()))];
+    let s0 = write_rlog_segment(
+        backend.as_ref(),
+        "audit/dup-0.rlog",
+        0,
+        1,
+        10,
+        &[log_record(&res, &[], 50, "edup")],
+    )
+    .await;
+    let s1 = write_rlog_segment(
+        backend.as_ref(),
+        "audit/dup-1.rlog",
+        1,
+        1,
+        20,
+        &[log_record(&res, &[], 50, "edup")],
+    )
+    .await;
+    let snapshot = rlog_snapshot(vec![s0, s1]);
+    let fetcher = LogSegmentFetcher::new(Arc::clone(&backend));
+
+    let local = collect_plan(
+        AuditTableProvider::new(
+            snapshot.clone(),
+            TENANT,
+            fetcher.clone(),
+            QueryAccounting::new(),
+        )
+        .plan(4)
+        .expect("local plan"),
+    )
+    .await;
+    let mut want = ts_and(&local, "ts_ns", "body");
+    want.sort();
+
+    let client: Arc<dyn WorkerSliceClient> = Arc::new(RlogWorker {
+        fetcher: fetcher.clone(),
+        build: audit_fragment,
+    });
+    let dist: Arc<dyn TableProvider> = Arc::new(
+        AuditTableProvider::new(snapshot.clone(), TENANT, fetcher, QueryAccounting::new())
+            .with_distributed_scan(rlog_endpoints_for(&snapshot), client),
+    );
+    let mut got = ts_and(&collect_distributed(dist).await, "ts_ns", "body");
+    got.sort();
+
+    assert_eq!(
+        got, want,
+        "audit distributed multiset equals local multiset"
+    );
+    assert_eq!(
+        got,
+        vec![(50, "edup".to_string()), (50, "edup".to_string())],
+        "both duplicate audit rows survive; a reintroduced dedup would drop one"
+    );
+}


### PR DESCRIPTION
Adds the SQL-lane distributed read fan-out for the RLOG family
(logs, alerts, audit), the signal sibling of the metrics lane's
distributed scan (ADR-0071). This is where log/alert/audit search
actually runs distributed in SQL, as opposed to the queryfrag
engine-level fetch T1-T5 already cover.

The new distributed_rlog module is signal-generic except for the
three per-signal total-order keys, so a later task (T6b) can extend
it for spans without rewriting it. The merge is a
SortPreservingMergeExec under a total-order key with no dedup node
above it, reproducing at the SQL layer what merge_log_records
reproduces at the queryfrag layer: logs/alerts/audit have no
query-time dedup, so every row is returned, duplicates included.

Reachability: the distributed RLOG scan is reachable through each
provider's scan() once a distributed context is installed, exercised
end to end by the acceptance tests. The server-side coordinator
install and the worker do_get slice-fragment branch are later wiring,
not yet connected to a running server.

Adversarially reviewed (opus, isolated fleet checkout): PASS, no
dedup reintroduction, correct total-order keys, non-vacuous
reshard-straddle and duplicate-preservation tests, accurate
reachability claim, no invariant violations, correct per-segment
erasure. Gated: full workspace tier-1, plus the sql and flight-sql
feature lanes (this code sits behind flight-sql).

Fixes: #326
Refs: #63
