### PR TITLE
feat(ravel-sql): parallel final aggregation for exact-typed inputs

### DIFF
--- a/crates/ravel-sql/src/config.rs
+++ b/crates/ravel-sql/src/config.rs
@@ -38,6 +38,14 @@ pub struct SqlConfig {
     /// Ceiling, in bytes, on the query's DataFusion memory pool. Fed by
     /// measured `RecordBatch` sizes, never a sample count.
     pub max_query_bytes: usize,
+    /// Whether an exact-typed query is allowed to repartition its final
+    /// aggregation (ADR-0094 decision 4). Process-wide, default `false`: a
+    /// per-query classification (ADR-0094 decision 1) only ever flips
+    /// DataFusion's `repartition_aggregations` on when this is `true` *and*
+    /// every aggregate expression and GROUP BY key in the query is provably
+    /// order/partition-independent. Set once at server startup
+    /// (`services/ravel-server`); no live-reload, like every other field here.
+    pub parallel_final_aggregation: bool,
 }
 
 impl Default for SqlConfig {
@@ -45,6 +53,7 @@ impl Default for SqlConfig {
         SqlConfig {
             engine: EngineConfig::default(),
             max_query_bytes: DEFAULT_MAX_QUERY_BYTES,
+            parallel_final_aggregation: false,
         }
     }
 }

--- a/crates/ravel-sql/src/executor.rs
+++ b/crates/ravel-sql/src/executor.rs
@@ -75,10 +75,13 @@ use std::time::Duration;
 use datafusion::arrow::array::RecordBatch;
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::arrow::error::ArrowError;
+use datafusion::common::DFSchema;
+use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion};
 use datafusion::dataframe::DataFrame;
 use datafusion::error::DataFusionError;
 use datafusion::execution::SendableRecordBatchStream;
-use datafusion::logical_expr::{Expr, LogicalPlan};
+use datafusion::execution::memory_pool::{MemoryPool, UnboundedMemoryPool};
+use datafusion::logical_expr::{Aggregate, Distinct, Expr, ExprSchemable, LogicalPlan};
 use datafusion::physical_plan::{ExecutionPlan, execute_stream};
 use datafusion::prelude::SessionContext;
 use futures::{Stream, StreamExt};
@@ -610,6 +613,21 @@ impl SqlExecutor {
         let (pool, breach) = self
             .config
             .query_pool(self.tenant_budget(tenant_hash), accounting.clone());
+        // ADR-0094 decision 1/2: classify the query's aggregates and GROUP BY
+        // keys before the real session is built, right here at the one call site
+        // that funnels into `build_session`. The result flips
+        // `repartition_aggregations` on only for a query proven exact-typed.
+        // Skipped entirely when the process-wide flag is off (decision 2): an
+        // unclassified query already gets `false`, so the extra plan+analyze
+        // pass costs nothing when the feature is disabled. Classified against
+        // `extras.declared` (the same declared columns the real logs provider
+        // installs), before it is moved into the table below.
+        let exact_typed_aggregates = if self.config.parallel_final_aggregation {
+            self.classify_exact_typed(tenant_hash, sql, &extras.declared)
+                .await
+        } else {
+            false
+        };
         // Build the one table the query targets over the snapshot resolved for
         // its signal. `resolve` already resolved `snapshot` against exactly
         // this signal, so the provider and the snapshot always agree.
@@ -657,7 +675,8 @@ impl SqlExecutor {
             ))),
         };
 
-        let ctx = build_session(&self.config, pool, table).map_err(plan_error)?;
+        let ctx =
+            build_session(&self.config, pool, table, exact_typed_aggregates).map_err(plan_error)?;
         let frame = ctx.sql(sql).await.map_err(plan_error)?;
         let schema = frame.schema().inner().clone();
         Ok(PinnedQuery {
@@ -736,10 +755,14 @@ impl SqlExecutor {
         let plan = provider
             .worker_fragment(target_partitions, &segments)
             .map_err(plan_error)?;
+        // ADR-0094 decision 2: the worker fragment plans no new SQL and runs no
+        // aggregation of its own, so it never repartitions -- always `false`,
+        // never through the classification check.
         let ctx = build_session(
             &self.config,
             pool,
             SessionTable::Metrics(Arc::clone(&provider)),
+            false,
         )
         .map_err(plan_error)?;
         let schema = plan.schema();
@@ -860,6 +883,115 @@ impl SqlExecutor {
         equality_name_filter(&extract(&predicates).matchers)
     }
 
+    /// ADR-0094 decision 1: whether every aggregate expression and GROUP BY key
+    /// in `sql`, once fully type-coerced, is provably order/partition-independent
+    /// -- the precondition for fanning the final aggregation across partitions.
+    ///
+    /// Reuses `pushed_down_name_filter`'s throwaway-session shape (an empty
+    /// snapshot, no I/O) but with one deliberate difference: the plan is run
+    /// through DataFusion's `Analyzer` (type coercion) before classification, so
+    /// a `sum`/`min`/`max` argument or a group key is classified by its
+    /// *resolved* Arrow type, not its syntactic operands (ADR-0094 decision 1;
+    /// `create_logical_plan` alone does not coerce). The throwaway session
+    /// registers everything a real query needs to plan -- the table's scalar
+    /// UDFs, the map-field `ExprPlanner`, and the tenant's ADR-0090 declared
+    /// columns -- via `build_session`, so a legitimate query does not silently
+    /// lose the optimization by failing to plan here.
+    ///
+    /// Fail-closed, the opposite polarity from `pushed_down_name_filter`'s
+    /// fail-open `None`: any error building or analyzing the throwaway plan
+    /// classifies the query as NOT exact, because wrongly admitting an
+    /// unclassifiable query could repartition an aggregate this check never
+    /// verified.
+    async fn classify_exact_typed(
+        &self,
+        tenant_hash: TenantHash,
+        sql: &str,
+        declared: &[DeclaredColumn],
+    ) -> bool {
+        match self
+            .analyzed_classification_plan(tenant_hash, sql, declared)
+            .await
+        {
+            Some(plan) => plan_is_exact_typed(&plan),
+            None => false,
+        }
+    }
+
+    /// Build the throwaway empty-snapshot session for `sql`'s target signal,
+    /// logical-plan `sql`, and run DataFusion's analyzer (type coercion) over
+    /// the result. `None` on any error (the fail-closed source for
+    /// [`Self::classify_exact_typed`]).
+    ///
+    /// The analyzer step is the `execute_and_check` pass DataFusion's own
+    /// physical planning applies before optimization; running it here is what
+    /// resolves, for example, `avg`'s argument to `Float64` and an integer
+    /// `sum`'s argument to `Int64` before the walk inspects their types.
+    async fn analyzed_classification_plan(
+        &self,
+        tenant_hash: TenantHash,
+        sql: &str,
+        declared: &[DeclaredColumn],
+    ) -> Option<LogicalPlan> {
+        let target = Self::target_signal(sql).ok()?;
+        let table = self.empty_snapshot_table(target, tenant_hash, declared);
+        // A private, unbounded pool: this session never executes, so nothing is
+        // ever reserved against it and it never touches the tenant accountant.
+        let pool: Arc<dyn MemoryPool> = Arc::new(UnboundedMemoryPool::default());
+        // `exact_typed_aggregates` is irrelevant to a plan we only inspect; the
+        // classification decides the real session's value, not this throwaway.
+        let ctx = build_session(&self.config, pool, table, false).ok()?;
+        let state = ctx.state();
+        let plan = state.create_logical_plan(sql).await.ok()?;
+        let config_options = Arc::clone(state.config_options());
+        state
+            .analyzer()
+            .execute_and_check(plan, &config_options, |_, _| {})
+            .ok()
+    }
+
+    /// A throwaway [`SessionTable`] over an empty snapshot for `target`,
+    /// carrying the same table-specific surface a real query of that signal
+    /// would (the logs provider's ADR-0090 declared columns included), so the
+    /// classification plan resolves identically to the real one. Issues no I/O:
+    /// the snapshot has no segments and the session is discarded unexecuted.
+    fn empty_snapshot_table(
+        &self,
+        target: TargetSignal,
+        tenant_hash: TenantHash,
+        declared: &[DeclaredColumn],
+    ) -> SessionTable {
+        let empty_snapshot = || Snapshot {
+            segments: Vec::new(),
+            segments_pruned: 0,
+            pending_erasure: Vec::new(),
+        };
+        match target {
+            TargetSignal::Metrics => SessionTable::Metrics(Arc::new(RavelTableProvider::new(
+                empty_snapshot(),
+                tenant_hash,
+                self.fetcher.clone(),
+                self.config,
+                QueryAccounting::new(),
+            ))),
+            TargetSignal::Logs => SessionTable::Logs(Arc::new(
+                LogsTableProvider::new(
+                    empty_snapshot(),
+                    tenant_hash,
+                    self.log_fetcher.clone(),
+                    QueryAccounting::new(),
+                )
+                .with_declared_columns(declared.to_vec()),
+            )),
+            TargetSignal::Spans => SessionTable::Spans(Arc::new(SpansTableProvider::new(
+                empty_snapshot(),
+                tenant_hash,
+                self.span_fetcher.clone(),
+                QueryAccounting::new(),
+            ))),
+        }
+    }
+
     /// The table (and thus the signal) a query resolves against, decided from
     /// its `FROM` clause before any planning (ADR-0033 "one SQL endpoint, two
     /// tables").
@@ -972,6 +1104,19 @@ impl PinnedQuery {
     /// The planned result schema.
     pub fn schema(&self) -> SchemaRef {
         Arc::clone(&self.schema)
+    }
+
+    /// Build the physical plan for this query without consuming it or starting
+    /// a stream, for plan-shape inspection (ADR-0094 decision 5's EXPLAIN-shape
+    /// tests assert whether a `RepartitionExec` fans the `Final` `AggregateExec`
+    /// out). This is the same first step [`Self::execute`] takes, run over the
+    /// frame's logical plan by reference so it can be called on a borrow.
+    pub async fn create_physical_plan(&self) -> Result<Arc<dyn ExecutionPlan>, SqlError> {
+        self.ctx
+            .state()
+            .create_physical_plan(self.frame.logical_plan())
+            .await
+            .map_err(plan_error)
     }
 
     /// Start the plan's stream. The session stays alive inside the returned
@@ -1263,6 +1408,159 @@ fn collect_filter_predicates(plan: &LogicalPlan, out: &mut Vec<Expr>) {
     }
     for input in plan.inputs() {
         collect_filter_predicates(input, out);
+    }
+}
+
+/// Collect every grouping node reachable in `plan` for ADR-0094 decision 1's
+/// exact-typed classification: [`LogicalPlan::Aggregate`] nodes into
+/// `aggregates`, and [`LogicalPlan::Distinct`] nodes into `distincts`. A
+/// `SELECT DISTINCT` lowers to a `GROUP BY` on its distinct keys only in the
+/// optimizer; the analyzer this walk runs over leaves it as a `Distinct` node,
+/// so it is captured here and classified for its keys (the
+/// `SELECT DISTINCT float_col` case). Sibling to [`collect_filter_predicates`],
+/// with two reach rules:
+///
+/// - `plan.inputs()` recursion, for grouping nodes in the direct operator tree.
+/// - a scan of every visited node's own `expressions()` for an embedded
+///   subquery plan (`Expr::ScalarSubquery`/`InSubquery`/`Exists`), each of
+///   which wraps a `LogicalPlan` that `plan.inputs()` never descends into. Every
+///   embedded plan is walked with this same recursion, so a disqualifying
+///   aggregate hidden inside a scalar subquery is found the same as one at the
+///   top level.
+///
+/// Nodes are cloned out (both variants hold an `Arc`-backed input and their own
+/// expression vectors, so a clone is cheap) rather than borrowed, because the
+/// subquery plans live inside the owned `Vec<Expr>` that `expressions()` returns
+/// and would not outlive the walk.
+fn collect_aggregate_exprs(
+    plan: &LogicalPlan,
+    aggregates: &mut Vec<Aggregate>,
+    distincts: &mut Vec<Distinct>,
+) {
+    match plan {
+        LogicalPlan::Aggregate(aggregate) => aggregates.push(aggregate.clone()),
+        LogicalPlan::Distinct(distinct) => distincts.push(distinct.clone()),
+        _ => {}
+    }
+    for input in plan.inputs() {
+        collect_aggregate_exprs(input, aggregates, distincts);
+    }
+    for expr in plan.expressions() {
+        // Never errors: the closure only recurses and returns `Continue`.
+        let _ = expr.apply(|node| {
+            match node {
+                Expr::ScalarSubquery(subquery) => {
+                    collect_aggregate_exprs(&subquery.subquery, aggregates, distincts);
+                }
+                Expr::InSubquery(in_subquery) => {
+                    collect_aggregate_exprs(&in_subquery.subquery.subquery, aggregates, distincts);
+                }
+                Expr::Exists(exists) => {
+                    collect_aggregate_exprs(&exists.subquery.subquery, aggregates, distincts);
+                }
+                _ => {}
+            }
+            Ok(TreeNodeRecursion::Continue)
+        });
+    }
+}
+
+/// Whether every grouping node in `plan` (analyzed/type-coerced) is
+/// order/partition-independent (ADR-0094 decision 1). A single disqualifying
+/// aggregate, GROUP BY key, or DISTINCT key anywhere, including inside a
+/// subquery, makes the whole query not exact -- `repartition_aggregations` is
+/// one session-wide knob, not a per-node choice.
+fn plan_is_exact_typed(plan: &LogicalPlan) -> bool {
+    let mut aggregates = Vec::new();
+    let mut distincts = Vec::new();
+    collect_aggregate_exprs(plan, &mut aggregates, &mut distincts);
+    aggregates.iter().all(aggregate_node_is_exact) && distincts.iter().all(distinct_node_is_exact)
+}
+
+/// Classify a DISTINCT node's implicit group keys (ADR-0094 decision 1): a
+/// float key disqualifies exactly as a float `GROUP BY` key does, since a
+/// DISTINCT lowers to a `GROUP BY` on these keys. Plain `DISTINCT` keys on
+/// every output column; `DISTINCT ON` keys on its `on_expr` list.
+fn distinct_node_is_exact(distinct: &Distinct) -> bool {
+    match distinct {
+        Distinct::All(input) => input
+            .schema()
+            .fields()
+            .iter()
+            .all(|field| !crate::minmax::is_float(field.data_type())),
+        Distinct::On(distinct_on) => {
+            let schema = distinct_on.input.schema().as_ref();
+            distinct_on
+                .on_expr
+                .iter()
+                .all(|key| match key.get_type(schema) {
+                    Ok(ty) => !crate::minmax::is_float(&ty),
+                    Err(_) => false,
+                })
+        }
+    }
+}
+
+/// Classify one [`Aggregate`] node (ADR-0094 decision 1): every GROUP BY key
+/// must be non-float, and every aggregate expression must be exact-eligible.
+/// Types are resolved against the node's *input* schema, over which both group
+/// and aggregate-argument expressions are evaluated.
+fn aggregate_node_is_exact(aggregate: &Aggregate) -> bool {
+    let schema = aggregate.input.schema().as_ref();
+    // A float GROUP BY key disqualifies the query even when every aggregate is
+    // exact (`-0.0`/NaN bit-significance, ADR-0013): this ADR has no proof
+    // DataFusion picks a merge-order-stable representative bit pattern for a
+    // float group key. This also covers `SELECT DISTINCT float_col`, a
+    // zero-aggregate `Aggregate` whose group key is the DISTINCT column.
+    for key in &aggregate.group_expr {
+        match key.get_type(schema) {
+            Ok(ty) if crate::minmax::is_float(&ty) => return false,
+            Ok(_) => {}
+            // Fail closed: a key whose type will not resolve is not admitted.
+            Err(_) => return false,
+        }
+    }
+    aggregate
+        .aggr_expr
+        .iter()
+        .all(|expr| aggregate_expr_is_exact(expr, schema))
+}
+
+/// Whether one aggregate expression is exact-eligible (ADR-0094 decision 1):
+///
+/// - `count(...)`/`count(DISTINCT ...)`: always exact, any input type.
+/// - `sum`/`min`/`max` over a resolved non-float input: exact.
+/// - `avg`/`mean` over any input, `sum`/`min`/`max` over a float input, and
+///   anything unexpected: never exact (fail closed).
+fn aggregate_expr_is_exact(expr: &Expr, schema: &DFSchema) -> bool {
+    // `aggr_expr` entries are either an `AggregateFunction` or an `Alias`
+    // wrapping one; unwrap a single alias layer.
+    let inner = match expr {
+        Expr::Alias(alias) => alias.expr.as_ref(),
+        other => other,
+    };
+    let Expr::AggregateFunction(aggregate_function) = inner else {
+        // Not an aggregate function where one is required: fail closed.
+        return false;
+    };
+    match aggregate_function.func.name().to_ascii_lowercase().as_str() {
+        // Counting presence is order-independent regardless of the counted
+        // value's type; a partial-count merge is exact integer addition, and
+        // distinctness is a per-row property merge order cannot change.
+        "count" => true,
+        // Exact only over a resolved non-float input.
+        "sum" | "min" | "max" => match aggregate_function.params.args.first() {
+            Some(arg) => match arg.get_type(schema) {
+                Ok(ty) => !crate::minmax::is_float(&ty),
+                Err(_) => false,
+            },
+            // A sum/min/max with no argument should not occur; fail closed.
+            None => false,
+        },
+        // `avg`/`mean` always run plain IEEE f64 addition (crate::avg), so they
+        // are never exact regardless of input type; any other name is outside
+        // the admitted aggregate set and fails closed.
+        _ => false,
     }
 }
 
@@ -1699,6 +1997,126 @@ mod tests {
         let err = execution_error(df);
         assert!(matches!(err, SqlError::ResourcesExhausted(_)));
         assert!(err.client_message().contains("limit 8"));
+    }
+
+    /// ADR-0094 report sanity check: the analyzer step
+    /// ([`SqlExecutor::analyzed_classification_plan`]) actually resolves `avg`'s
+    /// argument to `Float64` for an integer input -- the whole reason
+    /// classification runs DataFusion's analyzer and not `create_logical_plan`
+    /// alone. Proven by inspecting the coerced argument's type, not just that the
+    /// code compiles.
+    #[tokio::test]
+    async fn analyzer_coerces_avg_argument_to_float64() {
+        use datafusion::arrow::datatypes::DataType;
+
+        let exec = eviction_test_executor();
+        let plan = exec
+            .analyzed_classification_plan(
+                TenantHash([9u8; 16]),
+                "SELECT avg(CAST(value AS BIGINT)) AS a FROM samples",
+                &[],
+            )
+            .await
+            .expect("throwaway avg plan analyzes");
+
+        let mut aggregates = Vec::new();
+        let mut distincts = Vec::new();
+        collect_aggregate_exprs(&plan, &mut aggregates, &mut distincts);
+        let aggregate = aggregates.first().expect("one aggregate node");
+        let schema = aggregate.input.schema().as_ref();
+        let expr = aggregate.aggr_expr.first().expect("one aggregate expr");
+        let inner = match expr {
+            Expr::Alias(alias) => alias.expr.as_ref(),
+            other => other,
+        };
+        let Expr::AggregateFunction(af) = inner else {
+            panic!("aggregate expression is not an AggregateFunction: {inner:?}");
+        };
+        assert_eq!(af.func.name().to_ascii_lowercase(), "avg");
+        let arg_type = af
+            .params
+            .args
+            .first()
+            .expect("avg has an argument")
+            .get_type(schema)
+            .expect("argument type resolves");
+        assert_eq!(
+            arg_type,
+            DataType::Float64,
+            "the analyzer must coerce avg(int) to a Float64 argument"
+        );
+        // And avg is never exact regardless of that resolved type.
+        assert!(
+            !aggregate_expr_is_exact(expr, schema),
+            "avg is never exact-eligible (ADR-0094 decision 1)"
+        );
+    }
+
+    /// ADR-0094 decision 1: the classifier admits exactly the exact-typed
+    /// shapes and rejects the rest, exercised through the real throwaway-session
+    /// plan+analyze path (not the pure helpers in isolation).
+    #[tokio::test]
+    async fn classify_exact_typed_admits_and_rejects_per_adr_0094() {
+        let exec = eviction_test_executor();
+        let t = TenantHash([3u8; 16]);
+
+        // Integer sum + string group key + count: exact.
+        assert!(
+            exec.classify_exact_typed(
+                t,
+                "SELECT label(labels,'__name__') AS m, \
+                 sum(CAST(value AS BIGINT)) AS s, count(*) AS c FROM samples GROUP BY m",
+                &[],
+            )
+            .await
+        );
+        // count(DISTINCT float): count is always exact.
+        assert!(
+            exec.classify_exact_typed(t, "SELECT count(DISTINCT value) FROM samples", &[])
+                .await
+        );
+        // No aggregate at all: trivially exact.
+        assert!(
+            exec.classify_exact_typed(t, "SELECT ts, value FROM samples", &[])
+                .await
+        );
+        // Float sum: not exact.
+        assert!(
+            !exec
+                .classify_exact_typed(t, "SELECT sum(value) FROM samples", &[])
+                .await
+        );
+        // Float GROUP BY key (aggregate itself exact): not exact.
+        assert!(
+            !exec
+                .classify_exact_typed(t, "SELECT value, count(*) FROM samples GROUP BY value", &[])
+                .await
+        );
+        // SELECT DISTINCT on a float column (zero-aggregate float group key):
+        // not exact.
+        assert!(
+            !exec
+                .classify_exact_typed(t, "SELECT DISTINCT value FROM samples", &[])
+                .await
+        );
+        // avg over integer input: not exact.
+        assert!(
+            !exec
+                .classify_exact_typed(t, "SELECT avg(CAST(value AS BIGINT)) FROM samples", &[])
+                .await
+        );
+        // A disqualifying float avg hidden inside a scalar subquery: not exact,
+        // proving the expression-embedded subquery walk (decision 1).
+        assert!(
+            !exec
+                .classify_exact_typed(
+                    t,
+                    "SELECT count(*) FROM samples \
+                     WHERE value > (SELECT avg(value) FROM samples)",
+                    &[],
+                )
+                .await
+        );
     }
 
     /// An executor over an empty store, for the idle-accountant eviction tests.

--- a/crates/ravel-sql/src/logs_provider.rs
+++ b/crates/ravel-sql/src/logs_provider.rs
@@ -439,7 +439,7 @@ mod tests {
         let config = SqlConfig::default();
         let tenant = TenantMemoryAccountant::new(1 << 30);
         let (pool, _breach) = config.query_pool(tenant, QueryAccounting::new());
-        build_session(&config, pool, SessionTable::Logs(Arc::new(provider)))
+        build_session(&config, pool, SessionTable::Logs(Arc::new(provider)), false)
     }
 
     /// Every test here selects exactly `SELECT ts, body FROM logs WHERE ...`,

--- a/crates/ravel-sql/src/minmax.rs
+++ b/crates/ravel-sql/src/minmax.rs
@@ -123,7 +123,12 @@ impl std::hash::Hash for TotalOrderMinMax {
 /// Whether `data_type` gets the total-order accumulator. Only floating-point
 /// types can disagree between the total order and `partial_cmp`; every other
 /// type delegates.
-fn is_float(data_type: &DataType) -> bool {
+///
+/// `pub(crate)` so `executor.rs`'s ADR-0094 exact-typed classification reuses
+/// the exact float predicate that drives this UDAF's accumulator choice: the
+/// same resolved-type test decides both "needs the total-order accumulator"
+/// and "must not repartition its final aggregation".
+pub(crate) fn is_float(data_type: &DataType) -> bool {
     matches!(
         data_type,
         DataType::Float16 | DataType::Float32 | DataType::Float64

--- a/crates/ravel-sql/src/session.rs
+++ b/crates/ravel-sql/src/session.rs
@@ -51,14 +51,26 @@
 //!   planner as a second, ungoverned data source alongside `samples`.
 //!
 //! Determinism:
-//! every `repartition_*` knob is turned off. Float aggregation is
-//! order-dependent, so v1 requires aggregations to execute
+//! every `repartition_*` knob except aggregation is turned off unconditionally.
+//! Float aggregation is order-dependent, so v1 requires it to execute
 //! single-partitioned above the merged, deduplicated stream. Left on,
 //! `EnforceDistribution` would insert a `RepartitionExec` above
 //! `RsegDedupExec` and fan an aggregate out across partitions, reordering
 //! summation and breaking bit-exactness against the differential gate's
-//! reference. Parallel aggregation is banned until an ADR defines a
-//! tolerance policy or a compensated-summation scheme.
+//! reference.
+//!
+//! `repartition_aggregations` is the one exception (ADR-0094): it reads the
+//! `exact_typed_aggregates` argument [`session_config`] receives, rather than a
+//! hardcoded `false`. That argument is `true` only when a per-query
+//! classification (`executor::SqlExecutor`) has proven every aggregate and
+//! GROUP BY key in the query is order/partition-independent -- `count`, and
+//! `sum`/`min`/`max` over a resolved non-float input, with no float group key;
+//! `avg`/`mean` (always plain IEEE f64 addition) and any float input or key are
+//! never eligible. It is `false` for every other query and behind a default-off
+//! `SqlConfig` flag, so this is byte-identical to the old single-partition plan
+//! unless an operator opts in. The join/sort/window/file-scan knobs stay
+//! unconditionally `false`: their determinism requirements are out of ADR-0094's
+//! scope.
 
 use std::sync::Arc;
 
@@ -153,12 +165,19 @@ impl ObjectStoreRegistry for EmptyObjectStoreRegistry {
 
 /// Build the per-query `SessionConfig`. Separated from [`build_session`] so
 /// the invariants above can be asserted without constructing a provider.
-pub fn session_config(config: &SqlConfig) -> SessionConfig {
+///
+/// `exact_typed_aggregates` (ADR-0094 decision 2) is the one per-query input:
+/// `true` only when the caller's classification proved the query's aggregates
+/// and GROUP BY keys are order/partition-independent, allowing DataFusion to
+/// fan the final aggregation across partitions. `false` for every other query,
+/// which reproduces the old single-partition plan exactly.
+pub fn session_config(config: &SqlConfig, exact_typed_aggregates: bool) -> SessionConfig {
     SessionConfig::new()
         .with_information_schema(false)
         .with_target_partitions(config.engine.fetch_concurrency.max(1))
-        // See the module docs: v1 aggregates must stay single-partitioned.
-        .with_repartition_aggregations(false)
+        // ADR-0094: the only knob that is ever true, and only for a query whose
+        // aggregates and group keys are all exact-typed. See the module docs.
+        .with_repartition_aggregations(exact_typed_aggregates)
         .with_repartition_joins(false)
         .with_repartition_sorts(false)
         .with_repartition_windows(false)
@@ -185,13 +204,15 @@ pub fn build_session(
     config: &SqlConfig,
     pool: Arc<dyn MemoryPool>,
     table: SessionTable,
+    exact_typed_aggregates: bool,
 ) -> DFResult<SessionContext> {
     let runtime = RuntimeEnvBuilder::new()
         .with_memory_pool(pool)
         .with_object_store_registry(Arc::new(EmptyObjectStoreRegistry))
         .build_arc()?;
 
-    let mut ctx = SessionContext::new_with_config_rt(session_config(config), runtime);
+    let mut ctx =
+        SessionContext::new_with_config_rt(session_config(config, exact_typed_aggregates), runtime);
 
     // Register a hand-written `ExprPlanner` so `col['key']`
     // (`logs.attrs`, `samples.labels`) plans instead of failing with
@@ -329,6 +350,7 @@ mod tests {
             &SqlConfig::default(),
             test_pool(),
             SessionTable::Spans(Arc::new(provider)),
+            false,
         )
         .expect("spans session builds");
 
@@ -364,13 +386,31 @@ mod tests {
 
     #[test]
     fn information_schema_is_disabled_and_repartitioning_is_off() {
-        let config = session_config(&SqlConfig::default());
+        let config = session_config(&SqlConfig::default(), false);
         let options = config.options();
         assert!(
             !options.catalog.information_schema,
             "information_schema must stay disabled (security invariant 1)"
         );
         assert!(!options.optimizer.repartition_aggregations);
+        assert!(!options.optimizer.repartition_joins);
+        assert!(!options.optimizer.repartition_sorts);
+        assert!(!options.optimizer.repartition_windows);
+        assert!(!options.optimizer.repartition_file_scans);
+    }
+
+    /// ADR-0094 decision 2: `exact_typed_aggregates = true` flips ONLY
+    /// `repartition_aggregations` on; every other `repartition_*` knob stays
+    /// unconditionally off, and `information_schema` stays disabled.
+    #[test]
+    fn exact_typed_aggregates_flips_only_repartition_aggregations() {
+        let config = session_config(&SqlConfig::default(), true);
+        let options = config.options();
+        assert!(!options.catalog.information_schema);
+        assert!(
+            options.optimizer.repartition_aggregations,
+            "exact-typed queries repartition their final aggregation (ADR-0094)"
+        );
         assert!(!options.optimizer.repartition_joins);
         assert!(!options.optimizer.repartition_sorts);
         assert!(!options.optimizer.repartition_windows);

--- a/crates/ravel-sql/src/spans_scan.rs
+++ b/crates/ravel-sql/src/spans_scan.rs
@@ -681,6 +681,7 @@ mod tests {
             &SqlConfig::default(),
             pool,
             SessionTable::Spans(Arc::new(provider)),
+            false,
         )
         .expect("spans session builds");
 

--- a/crates/ravel-sql/tests/ceiling_breach.rs
+++ b/crates/ravel-sql/tests/ceiling_breach.rs
@@ -61,6 +61,7 @@ async fn a_join_that_overruns_the_query_ceiling_aborts_and_frees_the_tenant_budg
     let config = SqlConfig {
         engine: util::engine_config(),
         max_query_bytes: 768 * 1024,
+        parallel_final_aggregation: false,
     };
     let fixture = Fixture::build(
         Arc::new(MemoryStore::new()),

--- a/crates/ravel-sql/tests/logs_provider.rs
+++ b/crates/ravel-sql/tests/logs_provider.rs
@@ -596,6 +596,7 @@ fn logs_session(
         &config,
         pool,
         ravel_sql::SessionTable::Logs(Arc::new(provider)),
+        false,
     )
 }
 

--- a/crates/ravel-sql/tests/memory_accounting.rs
+++ b/crates/ravel-sql/tests/memory_accounting.rs
@@ -70,6 +70,7 @@ async fn drain(
         &SqlConfig::default(),
         Arc::clone(&pool),
         SessionTable::Metrics(provider),
+        false,
     )
     .expect("session");
 
@@ -249,6 +250,7 @@ async fn a_query_that_outgrows_its_pool_still_releases_tenant_bytes() {
     let config = SqlConfig {
         engine: util::engine_config(),
         max_query_bytes: 1_400_000,
+        parallel_final_aggregation: false,
     };
     let accountant = TenantMemoryAccountant::new(1 << 30);
     let (pool, _breach) = config.query_pool(Arc::clone(&accountant), QueryAccounting::new());
@@ -261,8 +263,13 @@ async fn a_query_that_outgrows_its_pool_still_releases_tenant_bytes() {
         config,
         QueryAccounting::new(),
     ));
-    let ctx = build_session(&config, Arc::clone(&pool), SessionTable::Metrics(provider))
-        .expect("session");
+    let ctx = build_session(
+        &config,
+        Arc::clone(&pool),
+        SessionTable::Metrics(provider),
+        false,
+    )
+    .expect("session");
     let mut stream = ctx
         .sql("SELECT ts, value FROM samples")
         .await

--- a/crates/ravel-sql/tests/memory_ceiling_and_budget_errors.rs
+++ b/crates/ravel-sql/tests/memory_ceiling_and_budget_errors.rs
@@ -94,6 +94,7 @@ async fn a_sort_or_aggregate_budget_error_keeps_its_type() {
     let config = SqlConfig {
         engine: util::engine_config(),
         max_query_bytes: 1024 * 1024,
+        parallel_final_aggregation: false,
     };
     let fixture = Fixture::build(
         Arc::new(MemoryStore::new()),

--- a/crates/ravel-sql/tests/parallel_final_aggregation.rs
+++ b/crates/ravel-sql/tests/parallel_final_aggregation.rs
@@ -1,0 +1,350 @@
+//! ADR-0094 decision 5: end-to-end tests for parallel final aggregation on
+//! exact-typed queries.
+//!
+//! Every test drives the real `execute` / `plan_pinned` path (not the
+//! classification helper in isolation), so it proves the whole chain: the
+//! per-query classification (decision 1), the `repartition_aggregations` config
+//! flip (decision 2), and the `SqlConfig::parallel_final_aggregation` gate
+//! (decision 4).
+//!
+//! The four tests mirror decision 5:
+//!
+//! - `exact_typed_group_by_is_bit_identical_across_partition_counts`: the
+//!   differential. The same exact-typed `GROUP BY` query and data at
+//!   `fetch_concurrency` 1/4/8/16 (each repartitioned count run several times to
+//!   surface a merge-order race), sorted by the group-by key, must equal the
+//!   shipped single-partition baseline bit-for-bit -- including an integer sum
+//!   that crosses 2^53 within one group (the case that would have caught the
+//!   `avg`-exactness mistake this ADR records). The `fetch_concurrency=1` +
+//!   flag-on run is compared against flag-off both by result and by physical
+//!   plan shape (they must converge).
+//! - `disqualified_queries_stay_single_partition`: a float aggregate, a float
+//!   GROUP BY key, and `SELECT DISTINCT float_col` each keep the
+//!   single-partition plan shape (no `RepartitionExec`) regardless of the flag.
+//! - `subquery_hidden_disqualifier_stays_single_partition`: a disqualifying
+//!   aggregate hidden inside a scalar subquery forces the single-partition plan.
+//! - `count_distinct_float_is_bit_identical_across_partition_counts`: the
+//!   post-merge fable-review case -- `count(DISTINCT float_col)` over -0.0/0.0
+//!   pairs and mixed-payload NaNs split across partitions, bit-identical across
+//!   partition counts.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+mod util;
+
+use datafusion::physical_plan::displayable;
+use ravel_object_store::ObjectStoreBackend;
+use ravel_object_store::memory::MemoryStore;
+use ravel_query::EngineConfig;
+use ravel_sql::SqlConfig;
+use ravel_types::TenantId;
+use ravel_types::accounting::QueryAccounting;
+use std::sync::Arc;
+
+use util::gate::{self, Cell, Row};
+use util::{Fixture, SegSpec, SeriesSpec, request};
+
+/// The one tenant every test in this file uses.
+fn tenant() -> TenantId {
+    util::tenant_id("adr94-parallel-final-agg")
+}
+
+/// A value that casts to a large integer (`4e15`, exactly representable as
+/// `f64`): three of them in one group sum to `1.2e16`, past 2^53, so an integer
+/// accumulator and a float accumulator would disagree if the classifier ever
+/// misrouted an exact integer sum through a float path.
+const BIG: f64 = 4_000_000_000_000_000.0;
+
+/// The exact integer sum of the `big` group: `3 * 4e15`.
+const BIG_SUM: i64 = 12_000_000_000_000_000;
+
+/// Two distinct NaN bit payloads: this repo treats a NaN's payload as
+/// significant, so `count(DISTINCT)` must keep them apart, and a third sample
+/// reusing `NAN_A` (on a different ts, in a different segment) must collapse
+/// back into it.
+fn nan_a() -> f64 {
+    f64::from_bits(0x7ff8_0000_0000_0001)
+}
+
+fn nan_b() -> f64 {
+    f64::from_bits(0x7ff8_0000_0000_0002)
+}
+
+/// The shared dataset: several string-keyed metric groups over three segments
+/// with distinct provenance, so the dedup total order and multi-partition scan
+/// both have something real to act on. Every sample in a series carries a
+/// distinct `ts`, so nothing is deduplicated away and each contributes to its
+/// group's aggregate. Includes:
+///
+/// - `big`: three `4e15` samples, one per segment, for the 2^53-crossing sum.
+/// - `floats`: `-0.0`/`0.0` and mixed-payload NaNs split across partitions, for
+///   `count(DISTINCT float_col)`.
+fn dataset() -> Vec<SegSpec> {
+    let seg1 = SegSpec::new(
+        10,
+        1,
+        1,
+        vec![
+            SeriesSpec::new("m0", vec![(100, 1.0), (101, 2.0)]),
+            SeriesSpec::new("m1", vec![(100, 3.0)]),
+            SeriesSpec::new("m2", vec![(100, 5.0), (101, 6.0)]),
+            SeriesSpec::new("big", vec![(200, BIG)]),
+            SeriesSpec::new("floats", vec![(300, -0.0), (301, nan_a())]),
+        ],
+    );
+    let seg2 = SegSpec::new(
+        20,
+        1,
+        2,
+        vec![
+            SeriesSpec::new("m0", vec![(110, 4.0)]),
+            SeriesSpec::new("m3", vec![(100, 7.0), (101, 8.0)]),
+            SeriesSpec::new("m4", vec![(100, 9.0)]),
+            SeriesSpec::new("big", vec![(201, BIG)]),
+            SeriesSpec::new("floats", vec![(310, 0.0), (311, nan_b())]),
+        ],
+    );
+    let seg3 = SegSpec::new(
+        30,
+        1,
+        3,
+        vec![
+            SeriesSpec::new("m5", vec![(100, 10.0), (101, 11.0)]),
+            SeriesSpec::new("m1", vec![(110, 12.0)]),
+            SeriesSpec::new("big", vec![(202, BIG)]),
+            // A third NaN reusing NAN_A's payload, distinct ts, distinct
+            // segment: DISTINCT must collapse it back into the single NAN_A.
+            SeriesSpec::new("floats", vec![(320, nan_a())]),
+        ],
+    );
+    vec![seg1, seg2, seg3]
+}
+
+/// A fixture over a fresh store carrying [`dataset`], with the given scan
+/// `fetch_concurrency` (the SQL `target_partitions`) and the ADR-0094 flag.
+async fn fixture_with(fetch_concurrency: usize, parallel_final_aggregation: bool) -> Fixture {
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+    let config = SqlConfig {
+        engine: EngineConfig {
+            fetch_concurrency,
+            ..EngineConfig::default()
+        },
+        parallel_final_aggregation,
+        ..SqlConfig::default()
+    };
+    let t = tenant();
+    let specs = dataset();
+    Fixture::build(store, &[(&t, &specs[..])], config, 1 << 30).await
+}
+
+/// The result rows of `sql`, sorted by the group-by key (column 0), reduced to
+/// bit-exact comparable cells. `GROUP BY` has no row-order guarantee (unchanged
+/// by ADR-0094), and repartitioned merge order is completion-order-dependent, so
+/// content is compared under a canonical order, never arrival order.
+async fn sorted_rows(fixture: &Fixture, sql: &str) -> Vec<Row> {
+    let outcome = fixture
+        .executor
+        .execute(tenant().hash(), &request(sql))
+        .await
+        .expect("query executes");
+    let mut rows = gate::actual_rows(&outcome.output);
+    rows.sort_by_key(group_key);
+    rows
+}
+
+/// The group-by key of a row (column 0) as a sortable string. Group-by keys are
+/// unique per row, so this is a total order over the result.
+fn group_key(row: &Row) -> String {
+    match &row[0] {
+        Cell::Text(s) => s.clone(),
+        other => format!("{other:?}"),
+    }
+}
+
+/// Whether `plan` fans its final aggregation across partitions. The marker is a
+/// hash-partitioning `RepartitionExec` (`partitioning=Hash(...)`), which
+/// `EnforceDistribution` inserts above the scan to feed a fanned-out `Final`
+/// `AggregateExec` only when `repartition_aggregations` is on and the aggregate
+/// has group keys. This is distinct from the `RoundRobinBatch` repartition
+/// DataFusion always inserts to parallelize the scan, which is present under both
+/// plans and is not the ADR-0094 behavior.
+fn fans_out_final_aggregation(plan: &str) -> bool {
+    plan.contains("partitioning=Hash(")
+}
+
+/// The indented physical-plan text for `sql`, planned through the real
+/// `plan_pinned` path (so the classification ran) over the fixture's snapshot.
+async fn physical_plan_text(fixture: &Fixture, sql: &str) -> String {
+    let t = tenant();
+    let snapshot = fixture.snapshot(&t).await;
+    let accounting = QueryAccounting::new();
+    let planned = fixture
+        .executor
+        .plan_pinned(t.hash(), snapshot, sql, &accounting, &[])
+        .await
+        .expect("plan_pinned");
+    let plan = planned
+        .create_physical_plan()
+        .await
+        .expect("physical plan builds");
+    format!("{}", displayable(plan.as_ref()).indent(true))
+}
+
+/// The exact-typed query under differential test: a string group key, an
+/// integer sum (via `CAST`), and a count. All three are exact-eligible, so with
+/// the flag on this repartitions its final aggregation.
+// Excludes the `floats` group: it carries NaN values, and `CAST(NaN AS BIGINT)`
+// is a hard cast error (unrelated to this ADR). Its float distinctness is
+// covered by `count_distinct_float_is_bit_identical_across_partition_counts`. The
+// residual string filter does not change the exact-typed classification.
+const EXACT_SQL: &str = "SELECT label(labels,'__name__') AS metric, \
+     sum(CAST(value AS BIGINT)) AS s, count(*) AS c \
+     FROM samples WHERE label(labels,'__name__') <> 'floats' GROUP BY metric";
+
+#[tokio::test]
+async fn exact_typed_group_by_is_bit_identical_across_partition_counts() {
+    // The shipped baseline: single partition, flag off.
+    let baseline_fixture = fixture_with(1, false).await;
+    let baseline = sorted_rows(&baseline_fixture, EXACT_SQL).await;
+
+    // Sanity: the dataset actually exercises the 2^53-crossing integer sum, and
+    // its exact integer value is present (a float accumulator would not reach
+    // this bit pattern for this multiset).
+    let big_row = baseline
+        .iter()
+        .find(|row| group_key(row) == "big")
+        .expect("the big group is present");
+    assert_eq!(
+        big_row[1],
+        Cell::Int(BIG_SUM),
+        "the integer sum crossing 2^53 must be exact"
+    );
+    assert!(baseline.len() >= 6, "the dataset has several group keys");
+
+    // Flag on at fetch_concurrency 1 must converge with the baseline both in
+    // result and in physical plan shape: target_partitions=1 already satisfies
+    // EnforceDistribution, so no RepartitionExec is expected even though the
+    // classification and the config flip both ran.
+    let one_partition_on = fixture_with(1, true).await;
+    assert_eq!(
+        sorted_rows(&one_partition_on, EXACT_SQL).await,
+        baseline,
+        "flag-on at fetch_concurrency=1 must equal the single-partition baseline"
+    );
+    let baseline_plan = physical_plan_text(&baseline_fixture, EXACT_SQL).await;
+    let one_partition_on_plan = physical_plan_text(&one_partition_on, EXACT_SQL).await;
+    assert!(
+        !fans_out_final_aggregation(&one_partition_on_plan),
+        "at target_partitions=1 the final aggregation is not fanned out even with the flag on:\n{one_partition_on_plan}"
+    );
+    assert_eq!(
+        baseline_plan, one_partition_on_plan,
+        "flag-on at fetch_concurrency=1 must produce the same plan shape as flag-off"
+    );
+
+    // Repartitioned counts: each run several times to surface a merge-order race
+    // that a single run could miss by chance.
+    for fetch_concurrency in [4usize, 8, 16] {
+        let fixture = fixture_with(fetch_concurrency, true).await;
+        // Prove the flag actually repartitioned (otherwise the differential
+        // would vacuously compare single-partition plans).
+        let plan = physical_plan_text(&fixture, EXACT_SQL).await;
+        assert!(
+            fans_out_final_aggregation(&plan),
+            "an exact-typed GROUP BY at fetch_concurrency={fetch_concurrency} with the flag on \
+             must fan its final aggregation across partitions:\n{plan}"
+        );
+        for run in 0..5 {
+            let rows = sorted_rows(&fixture, EXACT_SQL).await;
+            assert_eq!(
+                rows, baseline,
+                "repartitioned result at fetch_concurrency={fetch_concurrency} \
+                 (run {run}) must equal the single-partition baseline"
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn disqualified_queries_stay_single_partition() {
+    // Each query has a disqualifier: a float aggregate, a float GROUP BY key,
+    // and SELECT DISTINCT on a float column. None may repartition, flag or not.
+    let disqualified = [
+        "SELECT label(labels,'__name__') AS metric, sum(value) AS s \
+         FROM samples GROUP BY metric",
+        "SELECT value, count(*) AS c FROM samples GROUP BY value",
+        "SELECT DISTINCT value FROM samples",
+    ];
+
+    for parallel in [false, true] {
+        let fixture = fixture_with(8, parallel).await;
+        for sql in disqualified {
+            let plan = physical_plan_text(&fixture, sql).await;
+            assert!(
+                !fans_out_final_aggregation(&plan),
+                "a disqualified query must stay single-partition \
+                 (parallel_final_aggregation={parallel}); got:\n{plan}\nfor: {sql}"
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn subquery_hidden_disqualifier_stays_single_partition() {
+    // The outer aggregate (count) is exact, but a disqualifying float avg hides
+    // inside a scalar subquery. Decision 1's subquery walk must find it, forcing
+    // the whole query single-partition.
+    let sql = "SELECT count(*) AS c FROM samples \
+               WHERE value > (SELECT avg(value) FROM samples)";
+    let fixture = fixture_with(8, true).await;
+    let plan = physical_plan_text(&fixture, sql).await;
+    assert!(
+        !fans_out_final_aggregation(&plan),
+        "a disqualifying aggregate hidden in a scalar subquery must keep the \
+         single-partition plan; got:\n{plan}"
+    );
+}
+
+#[tokio::test]
+async fn count_distinct_float_is_bit_identical_across_partition_counts() {
+    // count(DISTINCT float_col) is exact (count is always exact), so it
+    // repartitions. The `floats` group holds -0.0/0.0 and mixed-payload NaNs
+    // split across segments: the distinct count must be stable across partition
+    // counts. This is insurance against a future DataFusion upgrade breaking the
+    // bit-pattern hash/eq consistency this relies on.
+    let sql = "SELECT label(labels,'__name__') AS metric, \
+               count(DISTINCT value) AS d FROM samples GROUP BY metric";
+
+    let baseline = sorted_rows(&fixture_with(1, false).await, sql).await;
+
+    // The `floats` group's four distinct bit patterns (-0.0, 0.0, NAN_A, NAN_B),
+    // with the second NAN_A collapsing back into the first.
+    let floats_row = baseline
+        .iter()
+        .find(|row| group_key(row) == "floats")
+        .expect("the floats group is present");
+    assert_eq!(
+        floats_row[1],
+        Cell::Int(4),
+        "-0.0, 0.0, and two NaN payloads are four distinct values; a repeated \
+         payload collapses"
+    );
+
+    for fetch_concurrency in [4usize, 8, 16] {
+        let fixture = fixture_with(fetch_concurrency, true).await;
+        let plan = physical_plan_text(&fixture, sql).await;
+        assert!(
+            fans_out_final_aggregation(&plan),
+            "count(DISTINCT float) is exact and must repartition at \
+             fetch_concurrency={fetch_concurrency}:\n{plan}"
+        );
+        for run in 0..5 {
+            let rows = sorted_rows(&fixture, sql).await;
+            assert_eq!(
+                rows, baseline,
+                "count(DISTINCT float) at fetch_concurrency={fetch_concurrency} \
+                 (run {run}) must equal the single-partition baseline"
+            );
+        }
+    }
+}

--- a/crates/ravel-sql/tests/pushdown_memory.rs
+++ b/crates/ravel-sql/tests/pushdown_memory.rs
@@ -814,6 +814,7 @@ async fn byte_budget_exceeded_returns_typed_error() {
     let config = SqlConfig {
         engine: EngineConfig::default(),
         max_query_bytes: 8,
+        parallel_final_aggregation: false,
     };
     let tenant = TenantMemoryAccountant::new(1 << 30);
     let task_ctx = task_ctx_with_pool(&config, Arc::clone(&tenant));
@@ -899,6 +900,7 @@ async fn high_cardinality_trips_query_pool_before_tenant() {
     let config = SqlConfig {
         engine: EngineConfig::default(),
         max_query_bytes: 16 * 1024,
+        parallel_final_aggregation: false,
     };
     let tenant = TenantMemoryAccountant::new(1 << 30);
     let task_ctx = task_ctx_with_pool(&config, Arc::clone(&tenant));
@@ -952,6 +954,7 @@ async fn tenant_budget_trips_and_rolls_back_the_query_reservation() {
     let config = SqlConfig {
         engine: EngineConfig::default(),
         max_query_bytes: 1 << 30,
+        parallel_final_aggregation: false,
     };
     let tenant = TenantMemoryAccountant::new(8);
     let (pool, _breach) = config.query_pool(Arc::clone(&tenant), QueryAccounting::new());
@@ -1007,6 +1010,7 @@ async fn query_budget_reported_first_when_both_ceilings_are_equally_reachable() 
     let config = SqlConfig {
         engine: EngineConfig::default(),
         max_query_bytes: 8,
+        parallel_final_aggregation: false,
     };
     let tenant = TenantMemoryAccountant::new(8);
     let task_ctx = task_ctx_with_pool(&config, Arc::clone(&tenant));

--- a/crates/ravel-sql/tests/scan_budgets.rs
+++ b/crates/ravel-sql/tests/scan_budgets.rs
@@ -480,6 +480,7 @@ fn task_ctx_with_query_bytes(max_query_bytes: usize) -> Arc<TaskContext> {
     let config = SqlConfig {
         engine: EngineConfig::default(),
         max_query_bytes,
+        parallel_final_aggregation: false,
     };
     let tenant = TenantMemoryAccountant::new(1 << 30);
     let (pool, _breach) = config.query_pool(tenant, QueryAccounting::new());

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -1360,6 +1360,48 @@ of its disjuncts; a **cross-axis** disjunction (`status_code = 2 OR duration_ns
 > 5e8`) is refused. `trace_id` is a single-point lookup with no range primitive
 to union, so a `trace_id` disjunction is refused too.
 
+## Parallel final aggregation for exact-typed queries (ADR-0094)
+
+Every SQL query plans its aggregation single-partitioned by default: DataFusion's
+`repartition_aggregations` knob is off, so a `Partial` `AggregateExec` runs per
+scan partition, a `CoalescePartitionsExec` collapses them into one stream, and a
+single serial `Final` `AggregateExec` produces the result. This keeps float
+aggregation bit-exact against the differential gate (ADR-0013), whose reference
+depends on a deterministic fold order.
+
+`--sql-parallel-final-aggregation` (the process-wide `SqlConfig`
+`parallel_final_aggregation`, default off; no live-reload, flipping it needs a
+restart) lets a query whose aggregation is provably order- and
+partition-independent instead fan its `Final` stage across partitions behind a
+hash-partitioning `RepartitionExec`. Admission is per-query and decided from the
+query's fully type-coerced (analyzed) plan:
+
+- **Eligible:** `count(...)` and `count(DISTINCT ...)` over any type; `sum`,
+  `min`, `max` over a resolved **non-float** input.
+- **Never eligible:** `avg`/`mean` over **any** input type (their UDAF always
+  runs plain IEEE f64 addition, which is not associative once a running sum
+  exceeds 2^53, so it depends on the single-partition fold order); any `sum`,
+  `min`, `max` over a `Float16`/`Float32`/`Float64` input; and any **float
+  GROUP BY key** (including a bare `SELECT DISTINCT float_col`), because
+  `-0.0`/NaN payloads are bit-significant here and no merge-order-stable
+  representative bit pattern for a float group key is proven.
+
+A single disqualifying aggregate or key anywhere in the query -- including inside
+a scalar/`IN`/`EXISTS` subquery -- forces the whole query onto the
+single-partition plan: `repartition_aggregations` is one session-wide switch, not
+a per-node choice. Any error building or analyzing the classification plan
+fails closed to the single-partition plan (a missed optimization, never a wrong
+result). With the flag off, no classification runs and every query is
+single-partition, byte-identical to before this feature existed.
+
+Row order is unaffected. A `GROUP BY` without an explicit `ORDER BY` has **no
+row-order guarantee** in this engine -- single-partition or repartitioned, and
+unchanged by ADR-0094. Under repartitioned final aggregation the physical merge
+order is completion-order-dependent (nondeterministic even at a fixed partition
+count), so a client that needs a stable order must add `ORDER BY`. The result
+*content* is identical across partition counts for an admitted query; only
+arrival order varies.
+
 ## Caching note
 
 ADR-0046 added a content-addressed RAM read-cache tier (`ravel-cache`,

--- a/services/ravel-cli/tests/typed_attr_column_reachability_e2e.rs
+++ b/services/ravel-cli/tests/typed_attr_column_reachability_e2e.rs
@@ -190,6 +190,7 @@ fn build_app(store: Arc<dyn ObjectStoreBackend>, clock: Arc<AtomicI64>) -> Route
         ravel_query::EngineConfig::default(),
         ravel_server::query::DEFAULT_MAX_QUERY_BYTES,
         ravel_server::query::DEFAULT_MAX_TENANT_BYTES,
+        false,
         Arc::new(ravel_server::metrics::QueryAccountingMetrics::new(
             std::collections::HashSet::new(),
         )),
@@ -396,6 +397,7 @@ async fn an_explicitly_empty_declaration_overrides_the_cli_default() {
         ravel_query::EngineConfig::default(),
         ravel_server::query::DEFAULT_MAX_QUERY_BYTES,
         ravel_server::query::DEFAULT_MAX_TENANT_BYTES,
+        false,
         Arc::new(ravel_server::metrics::QueryAccountingMetrics::new(
             std::collections::HashSet::new(),
         )),

--- a/services/ravel-server/src/config.rs
+++ b/services/ravel-server/src/config.rs
@@ -430,6 +430,20 @@ pub struct Cli {
     #[arg(long = "sql-tenant-max-bytes", value_name = "BYTES", default_value_t = DEFAULT_SQL_TENANT_MAX_BYTES)]
     pub sql_tenant_max_bytes: usize,
 
+    /// Allow an exact-typed SQL query to repartition its final aggregation
+    /// (ADR-0094), threaded into `ravel_sql::SqlConfig::parallel_final_aggregation`.
+    /// Off by default: a process with this unset plans every aggregation
+    /// single-partitioned, byte-identical to before this flag existed. When set,
+    /// a per-query classification flips DataFusion's `repartition_aggregations`
+    /// on only for a query whose aggregates and GROUP BY keys are all provably
+    /// order/partition-independent (`count`, and `sum`/`min`/`max` over non-float
+    /// input, no float group key); `avg`/`mean` and any float input or key are
+    /// never eligible and stay single-partitioned. Process-wide, not per-tenant;
+    /// flipping it needs a restart, like every other SQL budget. Meaningful only
+    /// in a build with the `sql` feature; inert otherwise.
+    #[arg(long = "sql-parallel-final-aggregation")]
+    pub sql_parallel_final_aggregation: bool,
+
     /// Bound on concurrent in-flight segment fetches per query (ADR-0088),
     /// threaded into `ravel_query::EngineConfig::fetch_concurrency`. This is a
     /// single knob with three coupled effects, NOT decoupled by this change: it
@@ -920,6 +934,10 @@ pub struct QueryBudgets {
     /// Per-tenant SQL memory ceiling. Reaches the `SqlExecutor`'s per-tenant
     /// accountant (`max_tenant_bytes`).
     pub sql_tenant_max_bytes: usize,
+    /// Whether an exact-typed SQL query may repartition its final aggregation
+    /// (ADR-0094). Reaches `SqlConfig::parallel_final_aggregation`. Default
+    /// `false`, so a server built without the flag is byte-identical to before.
+    pub sql_parallel_final_aggregation: bool,
 }
 
 impl Default for QueryBudgets {
@@ -929,6 +947,7 @@ impl Default for QueryBudgets {
             max_segments: ravel_query::DEFAULT_MAX_SEGMENTS,
             sql_max_query_bytes: DEFAULT_SQL_MAX_QUERY_BYTES,
             sql_tenant_max_bytes: DEFAULT_SQL_TENANT_MAX_BYTES,
+            sql_parallel_final_aggregation: false,
         }
     }
 }
@@ -1614,6 +1633,7 @@ impl Cli {
             max_segments: self.max_segments,
             sql_max_query_bytes: self.sql_max_query_bytes,
             sql_tenant_max_bytes: self.sql_tenant_max_bytes,
+            sql_parallel_final_aggregation: self.sql_parallel_final_aggregation,
         }
     }
 
@@ -3667,6 +3687,10 @@ mod tests {
         assert_eq!(budgets.max_segments, EngineConfig::default().max_segments);
         assert_eq!(budgets.sql_max_query_bytes, DEFAULT_SQL_MAX_QUERY_BYTES);
         assert_eq!(budgets.sql_tenant_max_bytes, DEFAULT_SQL_TENANT_MAX_BYTES);
+        assert!(
+            !budgets.sql_parallel_final_aggregation,
+            "ADR-0094: exact-typed final-aggregation repartitioning defaults off"
+        );
         // The two EngineConfig-bound defaults leave a base config untouched.
         assert_eq!(
             budgets.apply_to_engine(EngineConfig::default()),

--- a/services/ravel-server/src/erasure_e2e.rs
+++ b/services/ravel-server/src/erasure_e2e.rs
@@ -755,6 +755,7 @@ mod logs {
             ravel_query::EngineConfig::default(),
             ravel_sql::DEFAULT_MAX_QUERY_BYTES,
             crate::query::DEFAULT_MAX_TENANT_BYTES,
+            false,
             Arc::new(crate::metrics::QueryAccountingMetrics::new(
                 std::collections::HashSet::new(),
             )),

--- a/services/ravel-server/src/lib.rs
+++ b/services/ravel-server/src/lib.rs
@@ -1286,6 +1286,10 @@ pub async fn start(
                 // 256 MiB and the compiled-in 1 GiB tenant ceiling.
                 config.query_budgets.sql_max_query_bytes,
                 config.query_budgets.sql_tenant_max_bytes,
+                // ADR-0094: the exact-typed final-aggregation repartition switch,
+                // from `--sql-parallel-final-aggregation`. Default-off, so an
+                // unset flag leaves every SQL query single-partitioned.
+                config.query_budgets.sql_parallel_final_aggregation,
                 query_accounting.clone(),
                 query_admission.clone(),
                 Some(declared_columns),

--- a/services/ravel-server/src/query.rs
+++ b/services/ravel-server/src/query.rs
@@ -213,6 +213,12 @@ pub const DEFAULT_MAX_QUERY_BYTES: usize = ravel_sql::DEFAULT_MAX_QUERY_BYTES;
 /// operator's override the value the executor's pool and per-tenant accountant
 /// actually enforce.
 ///
+/// `parallel_final_aggregation` (ADR-0094 decision 4) is the process-wide
+/// switch, from `--sql-parallel-final-aggregation`, that lets an exact-typed
+/// query repartition its final aggregation. Default `false`; threaded here so an
+/// operator's opt-in is the value the executor's classification gate actually
+/// reads rather than `SqlConfig::default()`'s off.
+///
 /// `declared_columns` is the source of each tenant's declared typed attribute
 /// columns (ADR-0090 decision 2), installed on the executor with
 /// `SqlExecutor::with_declared_column_source`. `None` leaves the executor's
@@ -233,6 +239,7 @@ pub fn build_sql_state(
     engine_config: EngineConfig,
     max_query_bytes: usize,
     max_tenant_bytes: usize,
+    parallel_final_aggregation: bool,
     query_accounting: Arc<crate::metrics::QueryAccountingMetrics>,
     query_admission: Arc<QueryAdmissionController>,
     declared_columns: Option<Arc<dyn ravel_sql::DeclaredColumnSource>>,
@@ -243,6 +250,10 @@ pub fn build_sql_state(
     let config = SqlConfig {
         engine: engine_config,
         max_query_bytes,
+        // ADR-0094: the process-wide exact-typed repartition switch, from
+        // `--sql-parallel-final-aggregation`. Default-off leaves every query
+        // single-partitioned exactly as before.
+        parallel_final_aggregation,
     };
     let max_deadline = config.engine.deadline;
     let mut metrics_fetcher = SegmentFetcher::new(store.clone());
@@ -467,6 +478,7 @@ mod tests {
             non_default,
             ravel_sql::DEFAULT_MAX_QUERY_BYTES,
             DEFAULT_MAX_TENANT_BYTES,
+            false,
             Arc::new(crate::metrics::QueryAccountingMetrics::new(
                 std::collections::HashSet::new(),
             )),
@@ -511,6 +523,7 @@ mod tests {
             engine_config,
             ravel_sql::DEFAULT_MAX_QUERY_BYTES,
             DEFAULT_MAX_TENANT_BYTES,
+            false,
             Arc::new(crate::metrics::QueryAccountingMetrics::new(
                 std::collections::HashSet::new(),
             )),
@@ -551,6 +564,7 @@ mod tests {
             EngineConfig::default(),
             budgets.sql_max_query_bytes,
             budgets.sql_tenant_max_bytes,
+            budgets.sql_parallel_final_aggregation,
             Arc::new(crate::metrics::QueryAccountingMetrics::new(
                 std::collections::HashSet::new(),
             )),
@@ -585,6 +599,27 @@ mod tests {
         assert_eq!(
             state.executor.config().max_query_bytes,
             ravel_sql::DEFAULT_MAX_QUERY_BYTES,
+        );
+    }
+
+    /// ADR-0094 reachability: `--sql-parallel-final-aggregation` must reach the
+    /// `SqlConfig::parallel_final_aggregation` the executor's classification
+    /// gate reads, not stop at a parsed field. Traced from the CLI through
+    /// `query_budgets()` and `build_sql_state` to `executor.config()`. Default
+    /// unset stays `false`, so the shipped posture is single-partition.
+    #[test]
+    fn sql_parallel_final_aggregation_is_reachable_from_cli() {
+        let state = sql_state_from_cli(&["ravel-server", "--sql-parallel-final-aggregation"]);
+        assert!(
+            state.executor.config().parallel_final_aggregation,
+            "the SQL executor must carry the configured flag, not the default false"
+        );
+
+        // Unset: the default-off posture, single-partition for every query.
+        let state = sql_state_from_cli(&["ravel-server"]);
+        assert!(
+            !state.executor.config().parallel_final_aggregation,
+            "default must stay off (ADR-0094 decision 4)"
         );
     }
 

--- a/services/ravel-server/tests/cache_attachment_logs.rs
+++ b/services/ravel-server/tests/cache_attachment_logs.rs
@@ -207,6 +207,7 @@ async fn cache_enabled_config_attaches_cache_to_the_log_path() {
         ravel_query::EngineConfig::default(),
         ravel_server::query::DEFAULT_MAX_QUERY_BYTES,
         ravel_server::query::DEFAULT_MAX_TENANT_BYTES,
+        false,
         Arc::new(ravel_server::metrics::QueryAccountingMetrics::new(
             std::collections::HashSet::new(),
         )),

--- a/services/ravel-server/tests/recent_hours_reachability_e2e.rs
+++ b/services/ravel-server/tests/recent_hours_reachability_e2e.rs
@@ -219,6 +219,7 @@ fn sql_app(
         engine_config,
         ravel_server::query::DEFAULT_MAX_QUERY_BYTES,
         ravel_server::query::DEFAULT_MAX_TENANT_BYTES,
+        false,
         Arc::new(ravel_server::metrics::QueryAccountingMetrics::new(
             std::collections::HashSet::new(),
         )),


### PR DESCRIPTION
Implements ADR-0094 (docs/adrs/0094-parallel-final-aggregation-exact-typed.md), fleet task #335, epic #277.

Rebased over 4329ebcd (distributed SQL fan-out for logs/alerts/audit, landed on main while this ran) as a single clean commit, not a merge commit. The interaction between the two features was separately reviewed and found safe: repartitioning only affects plan structure above the scan, and the distributed RLOG lane has no dedup node to protect. The combination isn't reachable in production yet (RLOG coordinator wiring is still pending), so a combined test is tracked as #339 for when it lands.

Refs: #335
Refs: #277