### PR TITLE
fix(ravel-logseg): make POSTINGS terms match the merged-view winner

### DIFF
--- a/crates/ravel-logseg/src/reader.rs
+++ b/crates/ravel-logseg/src/reader.rs
@@ -131,11 +131,12 @@ impl<'a> RlogReader<'a> {
     /// to hold no record carrying the term; it is widen-only by construction
     /// (docs/adrs/0013, docs/adrs/0049 decision 7).
     ///
-    /// For a version 1 object one more arm is declined: a key that also appears
-    /// at resource or scope level anywhere in this object. A v1 POSTINGS list
-    /// indexes the per-record layer only, so an exact index over one layer
-    /// cannot prune a merged-view query that spans two. A version 2 object
-    /// indexes the merged view directly, so no arm is declined. See
+    /// A version 1 object declines POSTINGS pruning outright: its lists index
+    /// the per-record column layer only, and a record-level duplicate key (which
+    /// the v1 format records nothing about) can put the merged-view winner in a
+    /// value no posting indexes, so an exact index over one layer cannot prune a
+    /// merged-view query. A version 2 object indexes the merged view directly and
+    /// prunes normally. See [`RlogReader::scan_blocks`] and
     /// [`RlogReader::prune_postings_arms`].
     ///
     /// The separation is deliberate and load-bearing. A `prune` `Equals` on
@@ -249,37 +250,45 @@ impl<'a> RlogReader<'a> {
             // postings pruning; an unindexed or capped field on either falls
             // through to bloom + exact scan via the `Ok(None)` path below.
             //
-            // The prune-only arms need the object's POSTINGS version to know
-            // whether the stream-attribute exclusion applies (version 1) or not
-            // (version 2, whose lists already index the merged view). Building
-            // the version-2 arm set (no exclusion, hence a superset of the
-            // version-1 set) first tells us whether any postings work exists at
-            // all, so a query with no eligible arm still skips the section
-            // exactly as before.
+            // Both channels resolve to equality arms; building them first tells
+            // us whether any postings work exists at all, so a query with no
+            // eligible arm still skips the section exactly as before.
             let content_arms = self.postings_arms(&arms);
-            let prune_arms_no_exclusion = self.prune_postings_arms(&prune_arms, false);
-            if !content_arms.is_empty() || !prune_arms_no_exclusion.is_empty() {
+            let prune_arms = self.prune_postings_arms(&prune_arms);
+            if !content_arms.is_empty() || !prune_arms.is_empty() {
                 match self
                     .postings_section_verified(desc)
                     .and_then(PostingsSection::parse)
                 {
                     Ok(section) => {
-                        let prune_arms = if section.version() == POSTINGS_VERSION_V1 {
-                            self.prune_postings_arms(&prune_arms, true)
-                        } else {
-                            prune_arms_no_exclusion
-                        };
-                        let mut postings_arms = content_arms;
-                        postings_arms.extend(prune_arms);
-                        for (cid, term) in &postings_arms {
-                            match section.probe(*cid, term) {
-                                Ok(Some(blocks)) => {
-                                    let allowed: std::collections::HashSet<usize> =
-                                        blocks.iter().map(|&b| b as usize).collect();
-                                    candidates.retain(|b| allowed.contains(b));
+                        // A version 1 POSTINGS list indexes the per-record
+                        // column layer's first occurrence per type only. A
+                        // record that carries one indexed key more than once
+                        // (any type) has a merged-view winner the list can omit
+                        // -- a same-type duplicate's later value lands in
+                        // `attrs_raw`, which no posting indexes -- and a v1
+                        // object records nothing that distinguishes "had such a
+                        // duplicate" from "did not". So a v1 object declines ALL
+                        // equality pruning, on both channels, widen-only
+                        // (ADR-0013): it costs the optimization on legacy
+                        // objects, never correctness (docs/adrs/0049 amendment
+                        // 2026-08-20, issue #333). A v2 list indexes the merged
+                        // view and prunes both channels. This subsumes the old
+                        // version-1 resource/scope exclusion, which only covered
+                        // the stream-level hazard.
+                        if section.version() != POSTINGS_VERSION_V1 {
+                            let mut postings_arms = content_arms;
+                            postings_arms.extend(prune_arms);
+                            for (cid, term) in &postings_arms {
+                                match section.probe(*cid, term) {
+                                    Ok(Some(blocks)) => {
+                                        let allowed: std::collections::HashSet<usize> =
+                                            blocks.iter().map(|&b| b as usize).collect();
+                                        candidates.retain(|b| allowed.contains(b));
+                                    }
+                                    Ok(None) => {}
+                                    Err(_) => stats.postings_degraded = true,
                                 }
-                                Ok(None) => {}
-                                Err(_) => stats.postings_degraded = true,
                             }
                         }
                     }
@@ -414,34 +423,25 @@ impl<'a> RlogReader<'a> {
 
     /// Prune-only postings arms for a merged-view query.
     ///
-    /// The soundness question is whether an exact posting list can prune a
-    /// query over the merged attribute view (`ravel_sql::rlog_attrs`: the union
-    /// of a record's resource, scope, and per-record attributes, the record
-    /// winning on a key collision). The answer depends on what the object's
-    /// POSTINGS lists index, which its grammar version records:
+    /// A `prune` arm is the SQL merged-view equality pushed down over the `attrs`
+    /// column, which DataFusion re-applies exactly above the scan, so this may
+    /// only ever widen the fetch (ADR-0013). It answers, per arm, "which blocks
+    /// can hold a record whose merged `attrs[name]` equals this value", by
+    /// probing the `(name, type)` column the literal resolves to. Version
+    /// handling (a version 1 object declines pruning entirely) lives in
+    /// [`RlogReader::scan_blocks`], which knows the grammar version after parse.
     ///
-    /// - `apply_stream_exclusion == false` (a version 2 object): the lists
-    ///   index the merged view already, so probing a term is sound for every
-    ///   arm. No arm is dropped.
-    /// - `apply_stream_exclusion == true` (a version 1 object): the lists index
-    ///   the per-record layer only. `field_dir` is object-wide, so one record
-    ///   carrying a key per-record makes it an indexed column for the whole
-    ///   object, including records whose value for that key lives in their
-    ///   resource blob; those records are in no posting list, so probing the
-    ///   term would prune their block away. An exact index over one layer
-    ///   cannot prune a union over two, so when the key appears at stream level
-    ///   anywhere in this object this declines to prune it. Declining is
-    ///   widen-only (ADR-0013), which pruning wrongly is not.
-    ///
-    /// Only the prune channel needs the exclusion. A `content` arm is the
-    /// caller's own exact per-record predicate ([`RlogReader::postings_arms`]),
-    /// so pruning it to the records that carry the term per-record is precisely
-    /// right regardless of version.
-    fn prune_postings_arms(
-        &self,
-        arms: &[&Predicate],
-        apply_stream_exclusion: bool,
-    ) -> Vec<(u32, Vec<u8>)> {
+    /// One arm is declined here regardless of version: a `Str` literal on a name
+    /// that also has a non-`Str` column. SQL's `attrs` is `Map(Utf8, Utf8)`, so
+    /// `attrs['k'] = 'v'` arrives as a `Str` literal, but a value of another
+    /// type that stringifies to the same text is a merged-view match too and
+    /// lives in a different column's postings. POSTINGS terms are bit-exact per
+    /// type, never stringified, so probing only the `(name, Str)` column would
+    /// prune away a block whose match is, say, an `I64` value with that text.
+    /// Declining is widen-only; the exact SQL residual still filters. This is a
+    /// distinct hazard from the duplicate-occurrence fold order (issue #333):
+    /// the term written is right, the column probed is wrong.
+    fn prune_postings_arms(&self, arms: &[&Predicate]) -> Vec<(u32, Vec<u8>)> {
         let mut out = Vec::new();
         for a in arms {
             if let Predicate::Equals {
@@ -449,10 +449,10 @@ impl<'a> RlogReader<'a> {
                 value,
             } = a
             {
-                if apply_stream_exclusion && self.name_in_stream_attrs(name) {
+                let (ty, cv) = resolve_value(value);
+                if ty == FieldType::Str && self.name_has_non_str_column(name) {
                     continue;
                 }
-                let (ty, cv) = resolve_value(value);
                 if let Some(entry) = self.field_dir.column(name, ty) {
                     out.push((entry.column_id, term_key(&cv)));
                 }
@@ -461,18 +461,15 @@ impl<'a> RlogReader<'a> {
         out
     }
 
-    /// Whether `name` appears as a resource or scope attribute of any stream in
-    /// this object. A blob that fails to decode counts as "present", so a
-    /// corrupt STREAM_DIR declines to prune rather than pruning on a partial
-    /// read.
-    fn name_in_stream_attrs(&self, name: &str) -> bool {
-        self.stream_dir
+    /// Whether `name` has any dynamic column of a type other than `Str` in this
+    /// object. A `Str`-literal merged-view prune on such a name is unsound
+    /// (a non-`Str` value can stringify to the same text yet sit in a different
+    /// column's postings), so [`RlogReader::prune_postings_arms`] declines it.
+    fn name_has_non_str_column(&self, name: &str) -> bool {
+        self.field_dir
             .entries()
             .iter()
-            .any(|e| match stream_attr_names(&e.blob) {
-                Ok(names) => names.iter().any(|n| n == name),
-                Err(_) => true,
-            })
+            .any(|e| e.name == name && e.ty != FieldType::Str)
     }
 
     /// The bloom column id for a string field selector, if one exists.
@@ -1100,9 +1097,8 @@ fn phrase_match(value: &[u8], word: &str) -> bool {
 /// [`crate::record::stream_attrs_bytes`]); the two length-prefixed scope
 /// strings are positional, not key-value entries, so they are skipped over.
 ///
-/// Shared by [`stream_attr_names`] (which drops the values) and the writer's
-/// merged-view POSTINGS accumulation (which keeps them, to index the union of
-/// a record's stream and per-record attributes). Kept in this crate so the
+/// Used by the writer's merged-view POSTINGS accumulation (to index the union
+/// of a record's stream and per-record attributes). Kept in this crate so the
 /// merge does not depend on `ravel-sql`
 /// (docs/adrs/0049-rlog-postings.md amendment 2026-08-03).
 pub(crate) fn stream_attr_pairs(blob: &[u8]) -> Result<Vec<(String, AttrValue)>, LogSegError> {
@@ -1120,14 +1116,6 @@ pub(crate) fn stream_attr_pairs(blob: &[u8]) -> Result<Vec<(String, AttrValue)>,
     }
     pairs.extend(decode_attr_set(blob, &mut pos, 0)?);
     Ok(pairs)
-}
-
-/// The attribute names a STREAM_DIR blob carries, at resource and scope level.
-fn stream_attr_names(blob: &[u8]) -> Result<Vec<String>, LogSegError> {
-    Ok(stream_attr_pairs(blob)?
-        .into_iter()
-        .map(|(k, _)| k)
-        .collect())
 }
 
 fn decode_canonical_attrs(bytes: &[u8]) -> Result<Vec<(String, AttrValue)>, LogSegError> {
@@ -2029,48 +2017,336 @@ mod tests {
         assert!(!stats.postings_degraded);
     }
 
-    /// A version 1 object still reads and still prunes: for a key that is NOT at
-    /// stream level, the conservative rule does not fire, so the per-record
-    /// index prunes exactly as it did before the amendment. Built by pinning the
-    /// version byte in a fixture.
+    /// A version 1 object declines POSTINGS pruning outright, even for a key
+    /// that is NOT at stream level and carries no duplicates: the v1 grammar
+    /// records nothing that could prove a record-level duplicate was absent, so
+    /// the reader cannot know its per-record-layer index is complete, and
+    /// declines rather than risk dropping a merged-view match (widen-only,
+    /// ADR-0013; docs/adrs/0049 amendment 2026-08-20). It still reads back every
+    /// record; the identical v2 object below prunes, proving the decline is a
+    /// version choice, not a missing index. Built by pinning the version byte in
+    /// a fixture.
     #[test]
-    fn version_1_object_prunes_key_not_at_stream_level() {
+    fn version_1_object_declines_all_equality_pruning() {
         let cfg = RlogConfig {
             block_target_records: 5,
             ..RlogConfig::default()
         };
-        // `svc` is per-record only (never a resource/scope attribute), 12 blocks
-        // cycling 3 values, so a probe for one value prunes to 4 blocks. For
-        // this key the v1 and v2 posting lists are identical, so downgrading the
-        // version byte faithfully models a real v1 object.
+        // `svc` is per-record only, 12 blocks cycling 3 values.
         let mut recs = Vec::new();
         for i in 0..60i64 {
             let block = i / 5;
             recs.push(rec_with_svc(i, &format!("s{}", block % 3)));
         }
-        let obj = downgrade_postings_to_v1(&build_indexed(cfg, recs, &["svc"]));
-        let reader = RlogReader::new(&obj, &cfg).expect("open");
-
+        let v2 = build_indexed(cfg, recs, &["svc"]);
         let prune = [Predicate::Equals {
             field: FieldSel::Attr("svc".into()),
             value: AttrValue::Str("s0".into()),
         }];
+
+        // v2 prunes to the 4 blocks that carry "s0".
+        let reader = RlogReader::new(&v2, &cfg).expect("open v2");
+        let (_rows, stats) = reader
+            .scan_pruned(&Predicate::And(Vec::new()), &prune)
+            .expect("scan");
+        assert_eq!(stats.blocks_after_postings, 4, "v2 prunes");
+
+        // The same object read as v1 declines: no block is pruned, and every
+        // record still reads back (content is match-all here).
+        let v1 = downgrade_postings_to_v1(&v2);
+        let reader = RlogReader::new(&v1, &cfg).expect("open v1");
         let (rows, stats) = reader
             .scan_pruned(&Predicate::And(Vec::new()), &prune)
             .expect("scan");
         assert_eq!(stats.blocks_total, 12);
-        assert_eq!(stats.blocks_after_postings, 4);
-        assert_eq!(stats.blocks_scanned, 4);
+        assert_eq!(
+            stats.blocks_after_postings, stats.blocks_after_skip,
+            "v1 declines to prune"
+        );
+        assert_eq!(rows.len(), 60, "every record survives");
         assert!(!stats.postings_degraded);
-        // Reads back the pruned rows correctly.
-        assert!(rows.iter().all(|r| (r.ts_ns / 5) % 3 == 0));
     }
 
-    /// A version 1 object declines to prune a key that appears at stream level:
-    /// its posting list indexes the per-record layer only, so an exact index
-    /// over one layer cannot prune a merged-view query over two. Every record
-    /// the merged view matches is returned, and no block is pruned. This is the
-    /// conservative behaviour version 2 replaces
+    /// Step-4 regression for issue #333: a v1-grammar object carrying a
+    /// cross-type duplicate-key record must decline to prune, returning the row
+    /// a wrong v1 prune would drop. The record has `dur = I64(5)` and
+    /// `dur = Str("x")`; its merged-view winner is the reconstruction-order last
+    /// occurrence, `I64(5)` (`Str` type byte < `I64`, so the `(dur, Str)` column
+    /// sorts first and `(dur, I64)` last). A v2 posting therefore lists this
+    /// block only under `(dur, I64) = 5`. Downgrading the version byte models a
+    /// v1 object; under v1 the reader declines all equality pruning, so a prune
+    /// on `Str("x")` -- which resolves to the `(dur, Str)` column whose posting
+    /// is empty and would otherwise drop the block -- keeps it.
+    #[test]
+    fn version_1_object_with_cross_type_duplicate_declines_to_prune() {
+        let cfg = RlogConfig {
+            block_target_records: 1,
+            ..RlogConfig::default()
+        };
+        let mut r = rec(0, 0, "msg");
+        r.attrs.push(("dur".into(), AttrValue::I64(5)));
+        r.attrs.push(("dur".into(), AttrValue::Str("x".into())));
+        let obj = downgrade_postings_to_v1(&build_indexed(cfg, vec![r], &["dur"]));
+        let reader = RlogReader::new(&obj, &cfg).expect("open");
+
+        // A prune whose literal resolves to the empty (dur, Str) posting would
+        // drop the only block if v1 pruned; declining keeps it.
+        let prune = [Predicate::Equals {
+            field: FieldSel::Attr("dur".into()),
+            value: AttrValue::Str("x".into()),
+        }];
+        let (rows, stats) = reader
+            .scan_pruned(&Predicate::And(Vec::new()), &prune)
+            .expect("scan");
+        assert_eq!(rows.len(), 1, "v1 declines: the row survives");
+        assert_eq!(stats.blocks_after_postings, stats.blocks_after_skip);
+        assert!(!stats.postings_degraded);
+    }
+
+    /// The `attrs` merged view a query sees for one record, duplicating
+    /// `ravel_sql::rlog_attrs::merged_attrs` inline (a test dependency on
+    /// ravel-sql would be a dependency cycle): its decoded stream (resource +
+    /// scope) attributes, then its own attributes folded last-wins by name.
+    /// Operates on a record already reconstructed by `rebuild_record` (i.e. one
+    /// returned by `scan`), so its `attrs` are in on-disk reconstruction order.
+    fn merged_attrs_local(r: &LogRecord) -> Vec<(String, AttrValue)> {
+        let mut merged = stream_attr_pairs(&r.stream_attrs).expect("decode stream_attrs");
+        for (k, v) in &r.attrs {
+            if let Some(slot) = merged.iter_mut().find(|(mk, _)| mk == k) {
+                slot.1 = v.clone();
+            } else {
+                merged.push((k.clone(), v.clone()));
+            }
+        }
+        merged
+    }
+
+    /// Decodes an object's FIELD_DIR.
+    fn field_dir_of(obj: &[u8]) -> FieldDir {
+        let cfg = RlogConfig::default();
+        let footer = open(obj).expect("open");
+        let desc = footer.section(kind::FIELD_DIR).expect("field_dir");
+        let raw = read_section(obj, desc, &cfg).expect("read field_dir");
+        FieldDir::decode(&raw, 1 << 20).expect("decode field_dir")
+    }
+
+    /// The POSTINGS section bytes of an object, for a `PostingsSection::parse`.
+    fn postings_bytes_of(obj: &[u8]) -> Vec<u8> {
+        let footer = open(obj).expect("open");
+        let desc = footer.section(kind::POSTINGS).expect("postings");
+        obj[desc.offset as usize..(desc.offset + desc.len) as usize].to_vec()
+    }
+
+    /// Issue #333 repro 1 (cross-type duplicate). A record carrying `dur = I64(5)`
+    /// then `dur = Str("x")`, with `dur` indexed. The read-side merged view is
+    /// the reconstruction-order last occurrence: `Str` type byte (1) sorts before
+    /// `I64` (2), so `rebuild_record` lays out `(dur, Str) = "x"` then
+    /// `(dur, I64) = 5`, and `merged_attrs` folds to `I64(5)`. Before the fix the
+    /// writer folded over write-time order and chose `Str("x")`, leaving the
+    /// `(dur, I64)` posting empty, so a prune on `I64(5)` dropped the block. It
+    /// must now keep it.
+    #[test]
+    fn issue_333_cross_type_duplicate_prune_keeps_row() {
+        let cfg = RlogConfig {
+            block_target_records: 1,
+            ..RlogConfig::default()
+        };
+        let mut r = rec(0, 0, "msg");
+        r.attrs.push(("dur".into(), AttrValue::I64(5)));
+        r.attrs.push(("dur".into(), AttrValue::Str("x".into())));
+        let obj = build_indexed(cfg, vec![r], &["dur"]);
+        let reader = RlogReader::new(&obj, &cfg).expect("open");
+
+        let prune = [Predicate::Equals {
+            field: FieldSel::Attr("dur".into()),
+            value: AttrValue::I64(5),
+        }];
+        let (rows, stats) = reader
+            .scan_pruned(&Predicate::And(Vec::new()), &prune)
+            .expect("scan");
+        assert_eq!(
+            rows.len(),
+            1,
+            "the merged view returns dur=I64(5); the prune must not drop its block"
+        );
+        assert!(!stats.postings_degraded);
+
+        // Directly: the (dur, I64) posting lists this block for term 5.
+        let fd = field_dir_of(&obj);
+        let cid = fd
+            .column("dur", FieldType::I64)
+            .expect("(dur, I64) column")
+            .column_id;
+        let pd = postings_bytes_of(&obj);
+        let section = PostingsSection::parse(&pd).expect("parse postings");
+        assert_eq!(
+            section
+                .probe(cid, &term_key(&resolve_value(&AttrValue::I64(5)).1))
+                .expect("probe"),
+            Some(vec![0]),
+            "the winning I64(5) value must be the indexed term"
+        );
+    }
+
+    /// Issue #333 repro 2 (cross-type stringification). Two single-record blocks,
+    /// `dur = I64(5)` and `dur = Str("q")`, `dur` indexed. This is not about
+    /// duplicates: it is the reader resolving a `Str` prune literal only against
+    /// the `(dur, Str)` column. A prune on the I64 value keeps the I64 block; a
+    /// prune on `Str("5")` must NOT drop the I64 block, because `I64(5)`
+    /// stringifies to `"5"` in the merged view and would match. The fix declines
+    /// a `Str`-literal prune on a name that also has a non-`Str` column.
+    #[test]
+    fn issue_333_cross_type_stringification_prune_does_not_overprune() {
+        let cfg = RlogConfig {
+            block_target_records: 1,
+            ..RlogConfig::default()
+        };
+        let mut r0 = rec(0, 0, "msg");
+        r0.attrs.push(("dur".into(), AttrValue::I64(5)));
+        let mut r1 = rec(0, 1, "msg");
+        r1.attrs.push(("dur".into(), AttrValue::Str("q".into())));
+        let obj = build_indexed(cfg, vec![r0, r1], &["dur"]);
+        let reader = RlogReader::new(&obj, &cfg).expect("open");
+
+        // A prune on the I64 value keeps the I64 record's block.
+        let prune = [Predicate::Equals {
+            field: FieldSel::Attr("dur".into()),
+            value: AttrValue::I64(5),
+        }];
+        let (rows, _stats) = reader
+            .scan_pruned(&Predicate::And(Vec::new()), &prune)
+            .expect("scan");
+        assert!(
+            rows.iter().any(|r| r.ts_ns == 0),
+            "an I64 prune must keep the I64 record's block"
+        );
+
+        // A Str("5") prune must not drop the I64 block: I64(5) stringifies to
+        // "5" and is a merged-view match. The reader declines the arm.
+        let prune = [Predicate::Equals {
+            field: FieldSel::Attr("dur".into()),
+            value: AttrValue::Str("5".into()),
+        }];
+        let (rows, stats) = reader
+            .scan_pruned(&Predicate::And(Vec::new()), &prune)
+            .expect("scan");
+        assert!(
+            rows.iter().any(|r| r.ts_ns == 0),
+            "a Str('5') prune must not drop the block holding I64(5), which stringifies to '5'"
+        );
+        assert_eq!(
+            stats.blocks_after_postings, stats.blocks_after_skip,
+            "the cross-type Str arm is declined, not pruned on"
+        );
+        assert!(!stats.postings_degraded);
+    }
+
+    /// The general differential test for issue #333: for varied duplicate-key
+    /// shapes, the POSTINGS term the writer chose for an indexed name must equal
+    /// what a full write-then-read round trip through `rebuild_record` (via
+    /// `scan`) and `merged_attrs` (via [`merged_attrs_local`]) reports. Each
+    /// shape is written as its own one-record object, so the block index is
+    /// trivially 0 and the probe assertion is exact. This proves the fix in
+    /// general, not just for the two known repros, and checks write against an
+    /// independent read path rather than against the writer's own algorithm.
+    #[test]
+    fn issue_333_write_side_winner_matches_read_side_merged_view() {
+        // Each shape: the record's per-record attrs (dur duplicated variously),
+        // plus an optional resource-level dur to exercise layer precedence.
+        struct Shape {
+            name: &'static str,
+            record_attrs: Vec<AttrValue>,
+            resource_dur: Option<AttrValue>,
+        }
+        let shapes = vec![
+            Shape {
+                name: "two same type",
+                record_attrs: vec![AttrValue::I64(5), AttrValue::I64(6)],
+                resource_dur: None,
+            },
+            Shape {
+                name: "three same type, encoded order != write order",
+                record_attrs: vec![AttrValue::I64(3), AttrValue::I64(10), AttrValue::I64(7)],
+                resource_dur: None,
+            },
+            Shape {
+                name: "two different types",
+                record_attrs: vec![AttrValue::I64(5), AttrValue::Str("x".into())],
+                resource_dur: None,
+            },
+            Shape {
+                name: "three different types",
+                record_attrs: vec![
+                    AttrValue::Str("s".into()),
+                    AttrValue::Bool(true),
+                    AttrValue::I64(42),
+                ],
+                resource_dur: None,
+            },
+            Shape {
+                name: "duplicate plus resource-level same name",
+                record_attrs: vec![AttrValue::I64(5), AttrValue::I64(9)],
+                resource_dur: Some(AttrValue::Str("R".into())),
+            },
+        ];
+
+        let cfg = RlogConfig {
+            block_target_records: 1,
+            ..RlogConfig::default()
+        };
+        for shape in &shapes {
+            let mut r = rec(0, 0, "msg");
+            if let Some(rd) = &shape.resource_dur {
+                r.stream_attrs = crate::record::stream_attrs_bytes(
+                    &[
+                        ("service.name".into(), AttrValue::Str("svc0".into())),
+                        ("dur".into(), rd.clone()),
+                    ],
+                    "scope",
+                    "1",
+                    &[],
+                );
+            }
+            for v in &shape.record_attrs {
+                r.attrs.push(("dur".into(), v.clone()));
+            }
+            let obj = build_indexed(cfg, vec![r], &["dur"]);
+            let reader = RlogReader::new(&obj, &cfg).expect("open");
+
+            // Read side: reconstruct the record and compute the merged value.
+            let (rows, _) = reader.scan(&Predicate::And(Vec::new())).expect("scan");
+            assert_eq!(rows.len(), 1, "{}", shape.name);
+            let merged = merged_attrs_local(&rows[0]);
+            let value = merged
+                .iter()
+                .find(|(k, _)| k == "dur")
+                .map(|(_, v)| v.clone())
+                .unwrap_or_else(|| panic!("{}: merged view has dur", shape.name));
+            let (ty, cv) = resolve_value(&value);
+
+            // Write side: the POSTINGS term for dur must be exactly that value.
+            let fd = field_dir_of(&obj);
+            let cid = fd
+                .column("dur", ty)
+                .unwrap_or_else(|| panic!("{}: (dur, {ty:?}) column exists", shape.name))
+                .column_id;
+            let pd = postings_bytes_of(&obj);
+            let section = PostingsSection::parse(&pd).expect("parse postings");
+            assert_eq!(
+                section.probe(cid, &term_key(&cv)).expect("probe"),
+                Some(vec![0]),
+                "{}: write-side POSTINGS term must equal the read-side merged winner {value:?}",
+                shape.name
+            );
+        }
+    }
+
+    /// A version 1 object declines to prune (here for a key that also appears at
+    /// stream level, one of the hazards): a v1 posting list indexes the
+    /// per-record layer only, so an exact index over one layer cannot prune a
+    /// merged-view query over two. Every record the merged view matches is
+    /// returned, and no block is pruned. This is the conservative behaviour
+    /// version 2 replaces
     /// (see [`prune_must_not_drop_a_resource_only_match_when_the_key_is_also_a_column`]).
     #[test]
     fn version_1_object_declines_to_prune_key_at_stream_level() {

--- a/crates/ravel-logseg/src/writer.rs
+++ b/crates/ravel-logseg/src/writer.rs
@@ -23,7 +23,7 @@ use crate::postings::{DEFAULT_STRIDE, FieldTerms, encode_postings_section, term_
 use crate::reader::stream_attr_pairs;
 use crate::record::{
     COL_BODY, COL_SEVERITY_TEXT, ColumnValue, FIRST_DYNAMIC_COL, FieldType, LogRecord, ResolvedRow,
-    resolve_value,
+    canonical_value_bytes, resolve_value,
 };
 use crate::skip_index::{Level0Entry, SkipIndex};
 use crate::stream_dir::{StreamDir, StreamEntry};
@@ -612,15 +612,37 @@ fn resolve_row(
     let stream_ref = ref_of.get(&r.stream_id).copied().unwrap_or(0);
     let mut cols: BTreeMap<u32, ColumnValue> = BTreeMap::new();
     let mut overflow: Vec<(String, ravel_types::logstream::AttrValue)> = Vec::new();
+    // For each indexed name this record carries, its own occurrences split the
+    // same way the read side reconstructs them: the columnar ones (those that
+    // took a fresh dynamic-column slot, one per distinct type, each with its
+    // type byte kept alongside its value) and the overflow ones (any type,
+    // duplicates and budget overflow alike). `merged_indexed_terms` reduces
+    // these to the single occurrence `rebuild_record` + `merged_attrs` report
+    // for the name (docs/adrs/0049-rlog-postings.md amendment 2026-08-20).
+    let mut idx_cols: BTreeMap<String, Vec<(u8, ColumnValue)>> = BTreeMap::new();
+    let mut idx_overflow: BTreeMap<String, Vec<ravel_types::logstream::AttrValue>> =
+        BTreeMap::new();
     for (k, v) in &r.attrs {
         let (ty, cv) = resolve_value(v);
+        let indexed = indexed_names.contains(k.as_str());
         match column_of.get(&(k.clone(), ty.to_u8())) {
             Some(cid) if !cols.contains_key(cid) => {
+                if indexed {
+                    idx_cols
+                        .entry(k.clone())
+                        .or_default()
+                        .push((ty.to_u8(), cv.clone()));
+                }
                 cols.insert(*cid, cv);
             }
             // Overflow column, or a duplicate (name,type) already columnar this
             // row: fold into attrs_raw so no value is lost.
-            _ => overflow.push((k.clone(), v.clone())),
+            _ => {
+                if indexed {
+                    idx_overflow.entry(k.clone()).or_default().push(v.clone());
+                }
+                overflow.push((k.clone(), v.clone()));
+            }
         }
     }
     let attrs_raw = if overflow.is_empty() {
@@ -628,7 +650,8 @@ fn resolve_row(
     } else {
         Some(canonical_attr_bytes(&overflow))
     };
-    let indexed_terms = merged_indexed_terms(r, indexed_names, column_of)?;
+    let indexed_terms =
+        merged_indexed_terms(r, indexed_names, column_of, &idx_cols, &idx_overflow)?;
     Ok(ResolvedRow {
         stream_ref,
         ts_ns: r.ts_ns,
@@ -655,6 +678,13 @@ fn resolve_row(
 /// reproduced here so the writer does not depend on ravel-sql
 /// (docs/adrs/0049-rlog-postings.md amendment 2026-08-03).
 ///
+/// When a record carries one indexed key more than once (any type mix), the
+/// winning occurrence is the one `rebuild_record` + `merged_attrs` will report,
+/// not a re-derived guess: see [`record_level_winners`] for the exact two-tier
+/// order (docs/adrs/0049-rlog-postings.md amendment 2026-08-20, closing issue
+/// #333). The record layer then wins over the stream (resource/scope) layer as
+/// before.
+///
 /// A field with no matching dynamic column contributes nothing. The writer
 /// gives an indexed field a column even when it appears only at stream
 /// level, so a resource-only indexed key normally does have a column to
@@ -668,37 +698,96 @@ fn merged_indexed_terms(
     r: &LogRecord,
     indexed_names: &std::collections::HashSet<&str>,
     column_of: &HashMap<(String, u8), u32>,
+    idx_cols: &BTreeMap<String, Vec<(u8, ColumnValue)>>,
+    idx_overflow: &BTreeMap<String, Vec<ravel_types::logstream::AttrValue>>,
 ) -> Result<Vec<(u32, ColumnValue)>, LogSegError> {
     if indexed_names.is_empty() {
         return Ok(Vec::new());
     }
     // Merge, restricted to indexed keys, record-wins: resource/scope pairs
-    // first, then each per-record attribute overrides in place or appends. This
-    // mirrors `merged_attrs` (resource/scope, then record attrs win).
-    let mut merged: Vec<(String, ravel_types::logstream::AttrValue)> = Vec::new();
+    // first, then each indexed key's record-level winner overrides in place or
+    // appends. This mirrors `merged_attrs` (resource/scope, then record attrs
+    // win). Each entry carries the type byte its value resolves to, so a
+    // record-level winner of a different type than the stream value keys its
+    // posting by the right column.
+    let mut merged: Vec<(String, (u8, ColumnValue))> = Vec::new();
     for (k, v) in stream_attr_pairs(&r.stream_attrs)? {
         if indexed_names.contains(k.as_str()) {
-            merged.push((k, v));
+            let (ty, cv) = resolve_value(&v);
+            merged.push((k, (ty.to_u8(), cv)));
         }
     }
-    for (k, v) in &r.attrs {
-        if !indexed_names.contains(k.as_str()) {
-            continue;
-        }
-        if let Some(slot) = merged.iter_mut().find(|(mk, _)| mk == k) {
-            slot.1 = v.clone();
+    for (name, winner) in record_level_winners(idx_cols, idx_overflow) {
+        if let Some(slot) = merged.iter_mut().find(|(mk, _)| *mk == name) {
+            slot.1 = winner;
         } else {
-            merged.push((k.clone(), v.clone()));
+            merged.push((name, winner));
         }
     }
     let mut out = Vec::with_capacity(merged.len());
-    for (name, value) in merged {
-        let (ty, cv) = resolve_value(&value);
-        if let Some(&cid) = column_of.get(&(name, ty.to_u8())) {
+    for (name, (ty_byte, cv)) in merged {
+        if let Some(&cid) = column_of.get(&(name, ty_byte)) {
             out.push((cid, cv));
         }
     }
     Ok(out)
+}
+
+/// The record-level winning occurrence of each indexed key this record carries,
+/// keyed by name and carrying the winner's `(type byte, value)`.
+///
+/// The winner is defined as whatever the read side already, deterministically
+/// produces: `rebuild_record` lays a record's own attributes out as its
+/// columnar entries in FIELD_DIR `(name bytes, type)`-ascending order, followed
+/// by its `attrs_raw` overflow entries in `encode_attrs`'s canonical
+/// `(key bytes, encoded value bytes)`-ascending order, and
+/// `rlog_attrs::merged_attrs` then folds that list last-wins by name. Restricted
+/// to one name, that combined order is: the columnar occurrences ascending by
+/// [`FieldType::to_u8`], then the overflow occurrences ascending by the frozen
+/// canonical encoding of the value ([`canonical_value_bytes`], which shares the
+/// exact comparator `encode_attrs` uses so the two cannot drift). The last entry
+/// of that order wins. Making the write side predict this, rather than
+/// independently pick a winner over the original write-time occurrence order the
+/// on-disk format does not preserve, is the issue #333 fix
+/// (docs/adrs/0049-rlog-postings.md amendment 2026-08-20).
+fn record_level_winners(
+    idx_cols: &BTreeMap<String, Vec<(u8, ColumnValue)>>,
+    idx_overflow: &BTreeMap<String, Vec<ravel_types::logstream::AttrValue>>,
+) -> BTreeMap<String, (u8, ColumnValue)> {
+    let mut names: BTreeSet<&String> = BTreeSet::new();
+    names.extend(idx_cols.keys());
+    names.extend(idx_overflow.keys());
+
+    let mut out: BTreeMap<String, (u8, ColumnValue)> = BTreeMap::new();
+    for name in names {
+        let mut combined: Vec<(u8, ColumnValue)> = Vec::new();
+        // Columnar occurrences first, ascending by type byte (FIELD_DIR's
+        // (name, type) sort key restricted to this one name).
+        if let Some(cols) = idx_cols.get(name) {
+            let mut cols = cols.clone();
+            cols.sort_by_key(|(ty_byte, _)| *ty_byte);
+            combined.extend(cols);
+        }
+        // Overflow occurrences next, ascending by the canonical encoding of a
+        // one-entry value set. They all share this name, so this orders by
+        // encoded value bytes exactly as `attrs_raw` stores (and the reader
+        // decodes) them.
+        if let Some(over) = idx_overflow.get(name) {
+            let mut keyed: Vec<(Vec<u8>, (u8, ColumnValue))> = over
+                .iter()
+                .map(|v| {
+                    let (ty, cv) = resolve_value(v);
+                    (canonical_value_bytes(v), (ty.to_u8(), cv))
+                })
+                .collect();
+            keyed.sort_by(|a, b| a.0.cmp(&b.0));
+            combined.extend(keyed.into_iter().map(|(_, entry)| entry));
+        }
+        if let Some(winner) = combined.pop() {
+            out.insert(name.clone(), winner);
+        }
+    }
+    out
 }
 
 /// Splits row indices into block spans by record target and an estimated

--- a/docs/adrs/0049-rlog-postings.md
+++ b/docs/adrs/0049-rlog-postings.md
@@ -291,3 +291,92 @@ measures the prune ratio and finds it is 1.0.
 would decode `stream_attrs` per block to decide whether a prune is safe. It
 moves per-record work onto the path whose whole point is to avoid reading
 records, and it still cannot recover a record the index never listed.
+
+## Amendment 2026-08-20: precedence among a record's own duplicate occurrences
+
+The 2026-08-03 amendment said POSTINGS indexes "the union of a record's
+resource, scope, and own attributes, with its own winning on a key collision,
+which is exactly what `ravel_sql::rlog_attrs::merged_attrs` computes". That
+defined precedence *between* layers (record over resource/scope) but left
+precedence *among* a single record's own multiple occurrences of one key
+undefined. `LogRecord::attrs` is an ordered list that has always permitted
+duplicate keys of any type mix (`encode_attrs` in `ravel-types` is written to
+keep both), so this gap was reachable.
+
+### What was wrong
+
+Two functions folded a record's own duplicates in two different orders, and
+nothing said which was authoritative:
+
+- `writer.rs::merged_indexed_terms` (write side) folded a record's attributes
+  last-wins over their **original write-time occurrence order**.
+- `reader.rs::rebuild_record` reconstructs a record's attributes in a fixed
+  order the on-disk format dictates -- its FIELD_DIR columnar entries in
+  `(name bytes, type)`-ascending order, then its `attrs_raw` overflow entries
+  in the canonical `(key bytes, encoded value bytes)`-ascending order -- and
+  `rlog_attrs::merged_attrs` (read side) then folds *that* list last-wins.
+
+Write-time order and reconstruction order can disagree, so the POSTINGS term
+for a key could be built from a value the query-time merged view does not
+return, and an equality prune on the value the query truly needs could drop the
+block that has it. This shipped and is reachable through the `attrs['k'] = 'v'`
+pushdown; it has nothing to do with declared columns.
+
+The on-disk format does not preserve write-time occurrence order, and inventing
+a way to preserve it would break ADR-0029's frozen `attrs_raw` canonical
+encoding. It is also unnecessary: no consumer needs write-time order, only a
+single deterministic answer that write and read agree on.
+
+### Decision
+
+The winner among a record's own occurrences of one key is defined as **the last
+entry in the read side's reconstruction order**, which is:
+
+1. the record's columnar occurrences of that key, ascending by `FieldType`
+   type byte (FIELD_DIR's `(name, type)` sort key restricted to one name);
+   then
+2. the record's overflow (`attrs_raw`) occurrences of that key, ascending by
+   the frozen canonical `(key, encoded value)` order of `encode_attrs`
+   (`ravel-types`); with the name fixed, this is the encoded-value-byte order.
+
+The last entry of that combined order wins, then the record layer wins over the
+stream (resource/scope) layer as before. This is exactly what `rebuild_record`
+followed by `merged_attrs` already, incidentally, produces.
+
+This amendment is what makes that incidental read-side behavior an intentional,
+documented contract. It now governs both sides: `merged_indexed_terms` computes
+this same winner (its job is to *predict* what `rebuild_record` + `merged_attrs`
+will report for an indexed key, not to independently pick one), and the read
+side is its authoritative definition. No on-disk format changes: `ResolvedRow`'s
+shape, `attrs_raw`'s encoding, and FIELD_DIR's layout are untouched, and the
+`POSTINGS_VERSION` byte stays 2 (the change fixes which value a v2 list records,
+not what a v2 list means).
+
+### Version 1 objects
+
+A version 1 POSTINGS list indexes the per-record column layer's first
+occurrence per type only. A record-level duplicate key therefore can put the
+merged-view winner in a value no v1 posting indexes: a same-type duplicate's
+later occurrence lands in `attrs_raw`, which no posting covers, and a v1 object
+records nothing that distinguishes "carried such a duplicate" from "did not".
+Since that cannot be told apart per object without bookkeeping the v1 format
+never wrote, a v1-grammar object now declines POSTINGS pruning for its equality
+arms unconditionally, on both the content and prune channels. This is
+widen-only (ADR-0013): it costs the pruning optimization on legacy objects,
+never correctness, and it subsumes the narrower version-1 resource/scope
+exclusion the 2026-08-03 amendment introduced (which covered only the
+stream-level hazard, not the duplicate one).
+
+### A distinct, adjacent hazard: cross-type stringification
+
+Separately from the fold order, the reader resolved a merged-view prune
+literal against a single `(name, type)` column: a pushed-down `attrs['k'] = 'v'`
+is a `Str` literal (SQL's `attrs` is `Map(Utf8, Utf8)`), and a value of another
+type that stringifies to the same text is a merged-view match that lives in a
+different column's postings, which POSTINGS stores bit-exact per type, never
+stringified. Probing only the `(name, Str)` column would prune away a block
+whose match is, for example, an `I64` value with that text. The reader now
+declines a `Str`-literal prune arm on a name that also has a non-`Str` column
+(widen-only, ADR-0013). This is a different mechanism than the duplicate fold
+order -- the term written is right, the column probed is wrong -- and is fixed
+here because it sits in the same prune path.


### PR DESCRIPTION
Fixes #333: a live correctness bug where POSTINGS could index the wrong value for a record carrying a duplicate attribute key, causing equality pruning to silently drop the block with the matching row. Reachable today via `attrs['k'] = 'v'`, independent of any declared-column work.

Rebased over the RSEG v6->v7 flip that landed on main mid-flight as a single clean commit, not a merge commit (verified zero overlap: that change is scoped to `ravel-segment`/metrics, unrelated to `ravel-logseg`). Gates green plus the full 15-crate transitive-dependent test suite.

See commit message for the fix details and the v1-grammar decision.

Fixes: #333