### PR TITLE
feat(ravel-sql): distributed SQL fan-out for the spans table

### DIFF
--- a/crates/ravel-sql/src/distributed_rlog.rs
+++ b/crates/ravel-sql/src/distributed_rlog.rs
@@ -8,13 +8,13 @@
 //! signal-neutral. [`DistributedSliceScanExec`] takes a [`SchemaRef`] and an
 //! ordering column list and knows nothing about logs, alerts, or audit;
 //! [`distributed_slice_plan`] assembles the fan-out around any schema and key.
-//! A later task (#327, T6b) reuses both verbatim for the `spans` table by
-//! passing the spans schema and the span total-order key -- it does not
-//! reimplement the scan exec, the merge assembly, the byte accounting, or the
-//! schema validation. The only RLOG-specific surface is
-//! [`LOGS_ORDER_COLS`]/[`ALERTS_ORDER_COLS`]/[`AUDIT_ORDER_COLS`] and the three
-//! thin wrappers ([`distributed_logs_plan`] and siblings) that bind a signal's
-//! public schema to its key.
+//! The `spans` table (#327, T6b) reuses both verbatim by passing the spans
+//! schema and the span total-order key -- it does not reimplement the scan exec,
+//! the merge assembly, the byte accounting, or the schema validation. The only
+//! signal-specific surface is
+//! [`LOGS_ORDER_COLS`]/[`ALERTS_ORDER_COLS`]/[`AUDIT_ORDER_COLS`]/[`SPAN_ORDER_COLS`]
+//! and the thin wrappers ([`distributed_logs_plan`] and siblings, plus
+//! [`distributed_spans_plan`]) that bind a signal's public schema to its key.
 //!
 //! The slice-ticket plumbing is not reimplemented here at all: the fan-out
 //! reuses [`crate::distributed`]'s [`WorkerSlice`], [`WorkerSliceClient`],
@@ -33,10 +33,10 @@
 //! is only decidable once every slice's candidates meet, so the coordinator's
 //! dedup is authoritative.
 //!
-//! Logs, alerts, and audit have **no query-time dedup**
+//! Logs, alerts, audit, and spans have **no query-time dedup**
 //! (`docs/consistency-model.md`, "logs and spans"; ADR-0051 section 5). A retry
 //! after a lost acknowledgement produces byte-identical rows that are
-//! legitimately duplicate user data and MUST stay visible. So the RLOG merge is
+//! legitimately duplicate user data and MUST stay visible. So the merge is
 //! a `SortPreservingMergeExec` under a total-order key and **nothing above it**:
 //! no dedup node, no `.dedup_by`, no distinct. Every row every slice returns is
 //! emitted. This mirrors [`ravel_query::distrib`]'s `merge_log_records`, which
@@ -113,6 +113,28 @@ pub const ALERTS_ORDER_COLS: &[&str] = &["ts_ns", "alert_id", "rule_id", "state"
 /// The `audit` table's total-order key: the orderable public columns in schema
 /// order (ADR-0040). `attrs` excluded, as above.
 pub const AUDIT_ORDER_COLS: &[&str] = &["ts_ns", "severity_text", "body"];
+
+/// The `spans` table's total-order key (ADR-0041): the orderable public columns
+/// in the exact field sequence `ravel_query::distrib`'s `span_cmp`/
+/// `span_order_key` use -- `(trace_id, span_id, start_ts_ns, end_ts_ns,
+/// parent_span_id, name, status_code, status_message, service_name)` -- mapped
+/// to the public `spans` schema column names (`start_ts`/`end_ts` for the two
+/// timestamp columns). The trailing `attrs` `Map` column is excluded because
+/// Arrow maps are not orderable; this is sound because spans have no query-time
+/// dedup, so two rows tying on every orderable column are indistinguishable to
+/// SQL and their relative order never matters (the same rationale that excludes
+/// `attrs` from the RLOG keys above and from the queryfrag-layer span key).
+pub const SPAN_ORDER_COLS: &[&str] = &[
+    "trace_id",
+    "span_id",
+    "start_ts",
+    "end_ts",
+    "parent_span_id",
+    "name",
+    "status_code",
+    "status_message",
+    "service_name",
+];
 
 /// A coordinator-side distributed RLOG scan context (ADR-0071): the worker
 /// endpoints one query fans out to, and the client that fetches each slice.
@@ -464,6 +486,29 @@ pub fn distributed_audit_plan(
         client,
         schema,
         AUDIT_ORDER_COLS,
+        limit,
+        accounting,
+        max_bytes_scanned,
+    )
+}
+
+/// The `spans` distributed plan (#327, T6b): [`distributed_slice_plan`] bound to
+/// the `spans` public schema and [`SPAN_ORDER_COLS`]. Like the RLOG wrappers it
+/// merges under the total-order key with NO dedup above it, because spans have
+/// no query-time dedup (see the module docs).
+pub fn distributed_spans_plan(
+    endpoints: Vec<WorkerSlice>,
+    client: Arc<dyn WorkerSliceClient>,
+    schema: SchemaRef,
+    limit: Option<usize>,
+    accounting: QueryAccounting,
+    max_bytes_scanned: ByteLimit,
+) -> DFResult<Arc<dyn ExecutionPlan>> {
+    distributed_slice_plan(
+        endpoints,
+        client,
+        schema,
+        SPAN_ORDER_COLS,
         limit,
         accounting,
         max_bytes_scanned,

--- a/crates/ravel-sql/src/spans_provider.rs
+++ b/crates/ravel-sql/src/spans_provider.rs
@@ -29,10 +29,18 @@ use datafusion::physical_expr::expressions::col;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::physical_plan::projection::ProjectionExec;
 use ravel_catalog::{SegmentRef, Snapshot};
+#[cfg(feature = "flight-sql")]
+use ravel_query::ByteLimit;
 use ravel_query::erasure::{ErasurePredicate, snapshot_pending_erasure_predicates};
 use ravel_types::TenantHash;
 use ravel_types::accounting::QueryAccounting;
 
+#[cfg(feature = "flight-sql")]
+use crate::distributed::{WorkerSlice, WorkerSliceClient};
+#[cfg(feature = "flight-sql")]
+use crate::distributed_rlog::{
+    DistributedRlogContext, SPAN_ORDER_COLS, distributed_spans_plan, sort_slice_fragment,
+};
 use crate::spans_fetcher::SpanSegmentFetcher;
 use crate::spans_pushdown::{SpansPushdown, extract_spans};
 use crate::spans_scan::SpansScanExec;
@@ -54,6 +62,12 @@ pub struct SpansTableProvider {
     /// `snapshot.pending_erasure` (ADR-0064 decision 2), cloned
     /// into every `SpansScanExec` the provider builds.
     erasure: Arc<Vec<ErasurePredicate>>,
+    /// The coordinator-side distributed fan-out (ADR-0071; #327, T6b). `None` --
+    /// the default, and every non-Flight build -- is the local scan path
+    /// unchanged. Reuses the signal-neutral [`DistributedRlogContext`], which
+    /// carries no schema or key, exactly as the RLOG providers do.
+    #[cfg(feature = "flight-sql")]
+    distributed: Option<DistributedRlogContext>,
 }
 
 impl SpansTableProvider {
@@ -75,6 +89,72 @@ impl SpansTableProvider {
             schema: spans_schema(),
             accounting,
             erasure,
+            #[cfg(feature = "flight-sql")]
+            distributed: None,
+        }
+    }
+
+    /// Install a coordinator-side distributed scan context (ADR-0071; #327, T6b).
+    /// The span-signal sibling of
+    /// [`LogsTableProvider::with_distributed_scan`](crate::LogsTableProvider):
+    /// [`TableProvider::scan`] fans the `spans` scan out to the given worker
+    /// endpoints -- one [`crate::distributed_rlog::DistributedSliceScanExec`]
+    /// partition per slice, feeding the no-dedup `SortPreservingMergeExec` --
+    /// instead of scanning the local snapshot. Without it, the provider is
+    /// unchanged. Only compiled with the Flight transport, which is the only
+    /// thing that can carry a slice ticket.
+    #[cfg(feature = "flight-sql")]
+    pub fn with_distributed_scan(
+        mut self,
+        endpoints: Vec<WorkerSlice>,
+        client: Arc<dyn WorkerSliceClient>,
+    ) -> Self {
+        self.distributed = Some(DistributedRlogContext { endpoints, client });
+        self
+    }
+
+    /// The worker-side fragment for a distributed `spans` scan (ADR-0071; #327,
+    /// T6b): the whole-snapshot [`SpansScanExec`] (no pushdown) wrapped in a
+    /// single globally-sorted partition under the `spans` total-order key
+    /// ([`SPAN_ORDER_COLS`]), streamed to the coordinator's no-dedup merge. A
+    /// worker executes this over its slice; the coordinator's
+    /// `DistributedSliceScanExec` exposes each worker stream as one sorted
+    /// partition feeding the SAME no-dedup merge. There is NO dedup, in the
+    /// worker or the coordinator: spans have no query-time dedup, so every
+    /// fetched span is returned.
+    ///
+    /// Note the local `SpansScanExec` already declares a `(trace_id, start_ts)`
+    /// ordering, but the distributed total order is the full [`SPAN_ORDER_COLS`]
+    /// key, so this is a full [`sort_slice_fragment`] `SortExec` (not a
+    /// preserving merge over the leaf's weaker order).
+    #[cfg(feature = "flight-sql")]
+    pub fn worker_fragment(&self, target_partitions: usize) -> DFResult<Arc<dyn ExecutionPlan>> {
+        let scan = self.build_scan(target_partitions, &SpansPushdown::default())?;
+        sort_slice_fragment(scan, &self.schema, SPAN_ORDER_COLS)
+    }
+
+    /// Apply projection pushdown (column selection only) above `plan` on the
+    /// distributed path, where the fan-out returns the full public schema and
+    /// DataFusion asked for a subset. The local path applies the same
+    /// `ProjectionExec` inline in [`TableProvider::scan`].
+    #[cfg(feature = "flight-sql")]
+    fn apply_projection(
+        &self,
+        plan: Arc<dyn ExecutionPlan>,
+        projection: Option<&Vec<usize>>,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        match projection {
+            Some(proj) => {
+                let exprs = proj
+                    .iter()
+                    .map(|&i| {
+                        let name = self.schema.field(i).name();
+                        Ok((col(name, &self.schema)?, name.to_string()))
+                    })
+                    .collect::<DFResult<Vec<_>>>()?;
+                Ok(Arc::new(ProjectionExec::try_new(exprs, plan)?))
+            }
+            None => Ok(plan),
         }
     }
 
@@ -182,6 +262,26 @@ impl TableProvider for SpansTableProvider {
         filters: &[Expr],
         _limit: Option<usize>,
     ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        // Distributed coordinator path (ADR-0071; #327, T6b): fan out to worker
+        // slices instead of scanning locally, folding worker bytes into the query
+        // accounting under an `Unlimited` ceiling (no per-query byte budget on the
+        // spans provider). See the `logs` provider for the full rationale: the
+        // scan's `_limit` is a fetch-stop hint across partitions with the exact
+        // limit re-applied above the merge, and filters are re-applied above the
+        // returned plan by DataFusion (the provider reports `Inexact`).
+        #[cfg(feature = "flight-sql")]
+        if let Some(dist) = &self.distributed {
+            let plan = distributed_spans_plan(
+                dist.endpoints.clone(),
+                Arc::clone(&dist.client),
+                Arc::clone(&self.schema),
+                _limit,
+                self.accounting.clone(),
+                ByteLimit::Unlimited,
+            )?;
+            return self.apply_projection(plan, projection);
+        }
+
         let target_partitions = state.config().target_partitions();
         let pushdown = extract_spans(filters);
         let plan = self.build_scan(target_partitions, &pushdown)?;

--- a/crates/ravel-sql/tests/flight_distributed.rs
+++ b/crates/ravel-sql/tests/flight_distributed.rs
@@ -2057,3 +2057,337 @@ async fn distributed_audit_preserves_duplicate_rows() {
         "both duplicate audit rows survive; a reintroduced dedup would drop one"
     );
 }
+
+// ===========================================================================
+// spans SQL-lane distributed fan-out (#327, T6b)
+// ===========================================================================
+//
+// The span sibling of the RLOG family above. Spans also have NO query-time
+// dedup (docs/consistency-model.md, "logs and spans"; ADR-0051 section 5), so
+// the coordinator merges under the span total order (`SPAN_ORDER_COLS`) with
+// nothing above it. The two shapes mirror the RLOG ones exactly:
+//
+// - *reshard-straddle*: one trace's spans live in TWO shards (two slices), with
+//   `start_ts` interleaving across the shards. The span total-order key is
+//   primary on `(trace_id, span_id, start_ts, ...)`, so the fixture gives every
+//   span the SAME trace_id and makes span_id order agree with start_ts order;
+//   the total-order merge then emits start_ts [10, 20, 30, 40], an order NO
+//   slice-order concatenation produces ([10,30,20,40] or [20,40,10,30]). The
+//   specific line a naive concat breaks: the coordinator `SortPreservingMergeExec`
+//   in `distributed_slice_plan` (equivalently the worker `SortExec` in
+//   `sort_slice_fragment`). Replace either with an unordered coalesce and the
+//   ordered assertion below fails.
+//
+// - *duplicate-preservation*: two byte-identical spans, one per shard (a retry
+//   after a lost ack). Both must survive. The specific line a reintroduced dedup
+//   breaks: the absence of any dedup node above the merge. Add a dedup/distinct
+//   and the row count drops from 2 to 1 and the assertion below fails.
+//
+// prove-the-test discipline: the "local" reference on every differential is the
+// plain single-process `SpansTableProvider::plan(..)` scan, collected and sorted
+// IN-TEST -- it never calls the distributed merge exec under test, so a
+// regression in that exec cannot hide by appearing on both sides.
+
+use ravel_rspan::{
+    ObjectIdentity as RspanObjectIdentity, RspanConfig, RspanWriter, SpanRecord, StatusCode,
+};
+use ravel_sql::{SpanSegmentFetcher, SpansTableProvider};
+
+/// A span on trace `trace` with the given `span_id`, `start_ts`, and `name`
+/// (the differential's read-back discriminator). `end_ts = start_ts + 1`, root
+/// span, `Ok` status, one attribute -- the fields the span total-order key does
+/// not otherwise pin are held constant so a test controls the order through
+/// `span_id`/`start_ts` alone.
+fn span(trace: [u8; 16], span_id: [u8; 8], start: i64, name: &str) -> SpanRecord {
+    SpanRecord {
+        trace_id: trace,
+        span_id,
+        parent_span_id: None,
+        name: name.to_string(),
+        start_ts_ns: start,
+        end_ts_ns: start + 1,
+        status_code: StatusCode::Ok,
+        status_message: None,
+        attrs: vec![("service.name".to_string(), "svc".to_string())],
+    }
+}
+
+/// Write one RSPAN object from `records` on `shard`, put it at `key`, and return
+/// a matching L0 `SegmentRef` carrying `shard` (so `partition_snapshot` groups
+/// it shard-major into its own slice). The identity's `tenant_hash` must match
+/// [`TENANT`], which the span read path enforces in `fetch_accounted`.
+async fn write_rspan_segment(
+    store: &dyn ObjectStoreBackend,
+    key: &str,
+    shard: u32,
+    writer_seq: u64,
+    created_unix_ns: i64,
+    records: &[SpanRecord],
+) -> SegmentRef {
+    let identity = RspanObjectIdentity {
+        tenant_hash: TENANT.0,
+        shard,
+        writer_id: [2u8; 16],
+        writer_epoch: 1,
+        writer_seq,
+    };
+    let mut w = RspanWriter::new(RspanConfig::default(), identity);
+    for r in records {
+        w.push(r.clone());
+    }
+    let bytes = w.finish().expect("finish object");
+    let size = bytes.len() as u64;
+    store
+        .put(key, Bytes::from(bytes), PutOptions::default())
+        .await
+        .expect("put object");
+
+    let min = records
+        .iter()
+        .map(|r| r.start_ts_ns)
+        .min()
+        .expect("nonempty");
+    let max = records.iter().map(|r| r.end_ts_ns).max().expect("nonempty");
+    SegmentRef {
+        data_object_key: key.to_string(),
+        object_size: size,
+        min_event_ts_ns: min,
+        max_event_ts_ns: max,
+        ingest_hour_bucket: 0,
+        sample_count: records.len() as u64,
+        series_count: 0,
+        shard,
+        content_hash: [0u8; 32],
+        writer_id: Uuid::from_u128(shard as u128 + 1),
+        writer_epoch: 1,
+        writer_seq,
+        created_unix_ns,
+        level: SegmentLevel::L0,
+    }
+}
+
+/// The in-process spans worker: rebuilds the slice's snapshot from the ticket and
+/// runs `SpansTableProvider::worker_fragment` (`SpansScanExec -> SortExec`, public
+/// spans schema, one sorted partition, NO dedup), streaming the result back. The
+/// span analog of `RlogWorker`, using the `SpanSegmentFetcher` the spans path
+/// reads through.
+struct SpanWorker {
+    fetcher: SpanSegmentFetcher,
+}
+
+impl std::fmt::Debug for SpanWorker {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("SpanWorker")
+    }
+}
+
+impl WorkerSliceClient for SpanWorker {
+    fn fetch_slice(
+        &self,
+        _location: &str,
+        ticket: &FlightTicket,
+        _limit: Option<usize>,
+    ) -> DFResult<SendableRecordBatchStream> {
+        let snapshot = ticket.snapshot();
+        let target_partitions = snapshot.segments.len().max(1);
+        let plan = SpansTableProvider::new(
+            snapshot,
+            TENANT,
+            self.fetcher.clone(),
+            QueryAccounting::new(),
+        )
+        .worker_fragment(target_partitions)?;
+        execute_stream(plan, Arc::new(TaskContext::default()))
+    }
+}
+
+#[tokio::test]
+async fn distributed_spans_reshard_straddle_equals_sorted_local() {
+    let store = Arc::new(MemoryStore::new());
+    let backend: Arc<dyn ObjectStoreBackend> = store;
+    // One trace straddles two shards; span_id order agrees with start_ts order,
+    // and the two shards interleave ts [10, 20, 30, 40].
+    let trace = [1u8; 16];
+    let s0 = write_rspan_segment(
+        backend.as_ref(),
+        "spans/reshard-0.rspan",
+        0,
+        1,
+        10,
+        &[
+            span(trace, [1u8; 8], 10, "s10"),
+            span(trace, [3u8; 8], 30, "s30"),
+        ],
+    )
+    .await;
+    let s1 = write_rspan_segment(
+        backend.as_ref(),
+        "spans/reshard-1.rspan",
+        1,
+        1,
+        20,
+        &[
+            span(trace, [2u8; 8], 20, "s20"),
+            span(trace, [4u8; 8], 40, "s40"),
+        ],
+    )
+    .await;
+    let snapshot = rlog_snapshot(vec![s0, s1]);
+    let fetcher = SpanSegmentFetcher::new(Arc::clone(&backend));
+
+    assert!(
+        rlog_endpoints_for(&snapshot).len() >= 2,
+        "fixture must genuinely partition into more than one slice"
+    );
+
+    // Independent local reference: plain scan, sorted in-test (never the merge
+    // exec under test).
+    let local = collect_plan(
+        SpansTableProvider::new(
+            snapshot.clone(),
+            TENANT,
+            fetcher.clone(),
+            QueryAccounting::new(),
+        )
+        .plan(4)
+        .expect("local plan"),
+    )
+    .await;
+    let mut want = ts_and(&local, "start_ts", "name");
+    want.sort();
+
+    let client: Arc<dyn WorkerSliceClient> = Arc::new(SpanWorker {
+        fetcher: fetcher.clone(),
+    });
+    let dist: Arc<dyn TableProvider> = Arc::new(
+        SpansTableProvider::new(snapshot.clone(), TENANT, fetcher, QueryAccounting::new())
+            .with_distributed_scan(rlog_endpoints_for(&snapshot), client),
+    );
+    let got = ts_and(&collect_distributed(dist).await, "start_ts", "name");
+
+    assert_eq!(
+        got, want,
+        "the distributed output is the total-order merge of both slices; a slice-order concat would differ"
+    );
+    assert_eq!(
+        got.iter().map(|(t, _)| *t).collect::<Vec<_>>(),
+        vec![10, 20, 30, 40],
+        "the straddling trace's start_ts are globally sorted across slices, not slice-concatenated"
+    );
+}
+
+#[tokio::test]
+async fn distributed_spans_preserves_duplicate_rows() {
+    let store = Arc::new(MemoryStore::new());
+    let backend: Arc<dyn ObjectStoreBackend> = store;
+    // Two byte-identical spans, one per shard: a retry after a lost ack.
+    let dup = span([9u8; 16], [9u8; 8], 50, "dup");
+    let s0 = write_rspan_segment(
+        backend.as_ref(),
+        "spans/dup-0.rspan",
+        0,
+        1,
+        10,
+        std::slice::from_ref(&dup),
+    )
+    .await;
+    let s1 = write_rspan_segment(
+        backend.as_ref(),
+        "spans/dup-1.rspan",
+        1,
+        1,
+        20,
+        std::slice::from_ref(&dup),
+    )
+    .await;
+    let snapshot = rlog_snapshot(vec![s0, s1]);
+    let fetcher = SpanSegmentFetcher::new(Arc::clone(&backend));
+
+    let local = collect_plan(
+        SpansTableProvider::new(
+            snapshot.clone(),
+            TENANT,
+            fetcher.clone(),
+            QueryAccounting::new(),
+        )
+        .plan(4)
+        .expect("local plan"),
+    )
+    .await;
+    let mut want = ts_and(&local, "start_ts", "name");
+    want.sort();
+
+    let client: Arc<dyn WorkerSliceClient> = Arc::new(SpanWorker {
+        fetcher: fetcher.clone(),
+    });
+    let dist: Arc<dyn TableProvider> = Arc::new(
+        SpansTableProvider::new(snapshot.clone(), TENANT, fetcher, QueryAccounting::new())
+            .with_distributed_scan(rlog_endpoints_for(&snapshot), client),
+    );
+    let mut got = ts_and(&collect_distributed(dist).await, "start_ts", "name");
+    got.sort();
+
+    assert_eq!(
+        got, want,
+        "spans distributed multiset equals local multiset"
+    );
+    assert_eq!(
+        got,
+        vec![(50, "dup".to_string()), (50, "dup".to_string())],
+        "both byte-identical spans survive; a reintroduced dedup would collapse them to one"
+    );
+}
+
+#[tokio::test]
+async fn distributed_spans_plan_merges_without_dedup() {
+    let store = Arc::new(MemoryStore::new());
+    let backend: Arc<dyn ObjectStoreBackend> = store;
+    let s0 = write_rspan_segment(
+        backend.as_ref(),
+        "spans/shape-0.rspan",
+        0,
+        1,
+        10,
+        &[span([1u8; 16], [1u8; 8], 10, "s10")],
+    )
+    .await;
+    let s1 = write_rspan_segment(
+        backend.as_ref(),
+        "spans/shape-1.rspan",
+        1,
+        1,
+        20,
+        &[span([2u8; 16], [2u8; 8], 20, "s20")],
+    )
+    .await;
+    let snapshot = rlog_snapshot(vec![s0, s1]);
+    let fetcher = SpanSegmentFetcher::new(Arc::clone(&backend));
+
+    let client: Arc<dyn WorkerSliceClient> = Arc::new(SpanWorker {
+        fetcher: fetcher.clone(),
+    });
+    let dist = SpansTableProvider::new(snapshot.clone(), TENANT, fetcher, QueryAccounting::new())
+        .with_distributed_scan(rlog_endpoints_for(&snapshot), client);
+    let ctx = SessionContext::new();
+    let plan = dist
+        .scan(&ctx.state(), None, &[], None)
+        .await
+        .expect("distributed scan");
+    let text = displayable(plan.as_ref()).indent(true).to_string();
+
+    assert!(
+        text.contains("SortPreservingMergeExec"),
+        "the spans merge is a SortPreservingMergeExec:\n{text}"
+    );
+    assert!(
+        text.contains("DistributedSliceScanExec"),
+        "over the fan-out slice scan:\n{text}"
+    );
+    // The load-bearing negative: spans have NO query-time dedup, so the plan must
+    // never grow an RsegDedupExec (or any dedup node) above the merge. This is
+    // trap #1 from the task, guarded directly.
+    assert!(
+        !text.to_lowercase().contains("dedup"),
+        "spans have no query-time dedup; the merge must not introduce one:\n{text}"
+    );
+}


### PR DESCRIPTION
Extends T6a's SQL-lane distributed scan to the spans table, reusing
DistributedSliceScanExec, distributed_slice_plan, and the slice-ticket
plumbing verbatim rather than reimplementing them. The span total-order
key (SPAN_ORDER_COLS) matches the queryfrag layer's span_cmp/
span_order_key field sequence exactly, attrs excluded for the same
reason the RLOG keys exclude it. Spans have no query-time dedup, so the
merge is SortPreservingMergeExec with nothing above it, same as T6a.

Reachability: reachable through spans_provider's scan() once a
distributed context is installed, exercised end to end by the
acceptance tests. The server-side coordinator install and worker do_get
slice-fragment branch remain later wiring, not yet connected to a
running server.

Adversarially reviewed (opus, isolated fleet checkout): PASS, reused
not reimplemented, no dedup reintroduction, correct key mapping
(verified start_ts/end_ts aren't swapped), non-vacuous tests, accurate
reachability, no invariant violations. Gated: full workspace tier-1
plus the sql and flight-sql feature lanes.

Fixes: #327
Refs: #63
