### PR TITLE
docs(adrs): claim ADR-0095 (NumStat cross-type fix, RLOG v3)

### DIFF
--- a/docs/adrs/0095-numstat-crosstype-declared-column-agreement.md
+++ b/docs/adrs/0095-numstat-crosstype-declared-column-agreement.md
@@ -1,0 +1,3 @@
+# ADR-0095: NumStat write-path fix for cross-type duplicates, and RLOG trailer v3
+
+Status: claimed


### PR DESCRIPTION
Reserves the ADR number. Full draft follows in a separate commit after design review.

Refs: #331