### PR TITLE
docs(query-engine): document the SQL-lane distributed scan

### DIFF
--- a/docs/adrs/0071-distributed-read-fanout.md
+++ b/docs/adrs/0071-distributed-read-fanout.md
@@ -1433,14 +1433,27 @@ are that forward-looking work is now landed, not that any decision changed:
   redacted-partial under `skip_unavailable` and typed otherwise. Per-signal
   differential, erasure-property, skew, and federation tests are in place.
 
-**Not yet shipped: the SQL lane (T6).** Decision 7 puts both fan-out lanes in
-scope; only the queryfrag lane is built. The SQL-lane per-signal distributed
-scan (slice tickets, `DistributedScanExec`, per-signal merge execs for the
-`logs`/`alerts`/`audit`/`spans` tables) is unimplemented and still sequenced
-after ADR-0087 per Decision 8. Consequently the engine's own query flow only
-dispatches `Signal::Metrics` today
+**The SQL lane (T6) has landed, but is not yet wired into a running server.**
+Decision 7 puts both fan-out lanes in scope. T6 shipped in two halves — T6a
+(#326, the RLOG family: `logs`/`alerts`/`audit`) and T6b (#327, the `spans`
+table) — and both are built. The SQL-lane distributed scan reuses the same
+total-order/no-dedup merge rule as the queryfrag lane, reproduced at the SQL
+layer as a `SortPreservingMergeExec` under each table's total-order key with no
+dedup node above it (`crates/ravel-sql/src/distributed_rlog.rs`). The slice-
+ticket plumbing (`WorkerSlice`, `WorkerSliceClient`, `plan_distributed_slices`)
+is shared with the metrics SQL lane, not reimplemented.
+
+The scan is installed on a table provider via each provider's
+`with_distributed_scan` (`LogsTableProvider` and the alerts/audit/spans
+siblings) and is exercised end to end by the acceptance tests
+(`crates/ravel-sql/tests/flight_distributed.rs`) driving `provider.scan(..)`.
+It is **not yet wired into a running server's real query path**: the server-side
+coordinator that installs the distributed context from
+`get_flight_info_statement`, and the worker `do_get` slice-fragment branch that
+runs each provider's `worker_fragment`, are still later wiring. Consequently the
+engine's own query flow still dispatches `Signal::Metrics` only today
 (`fetch_samples_and_histograms_maybe_distributed` / `federate_scalar` in
 `crates/ravel-query/src/engine.rs`): the per-signal queryfrag fetch, merge, and
-federation machinery for Logs/Alerts/Audit/Spans is present and tested, but the
-coordinator caller that drives log and trace *search* over the wire is the SQL
-lane, which is where that fan-out becomes live.
+federation machinery for Logs/Alerts/Audit/Spans is present and tested, and the
+SQL lane that drives log and trace *search* over the wire now exists and is
+tested, but neither is reached from a live server binary yet.

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -411,8 +411,9 @@ skew, and federation tests. The coordinator caller that actually dispatches a
 Logs/Alerts/Audit/Spans distributed *search* is the SQL surface (log and trace
 search runs through the `logs`/`alerts`/`audit`/`spans` tables, not PromQL); the
 PromQL engine's own fetch/federation flow drives `Signal::Metrics` only today.
-The SQL-lane distributed scan is a separate, not-yet-landed step and is not
-described here.
+The SQL-lane distributed scan that drives that log and trace search is a
+separate step, now landed but not yet wired into a running server; see "The
+SQL-lane distributed scan" below.
 
 ### The log/span coordinator merge: order-independent, no dedup
 
@@ -460,6 +461,40 @@ Because each segment is self-contained, a resource-attribute-only exclusion
 evaluates identically wherever the segment is read, including when one stream's
 segments straddle two slices — proven by an erasure property test that diffs a
 distributed slice set against a local read of the same segments.
+
+### The SQL-lane distributed scan (logs, alerts, audit, spans)
+
+The two sections above describe the engine-level (queryfrag) machinery. The SQL
+surface has its own distributed scan that drives log and trace *search* over the
+`logs`, `alerts`, `audit`, and `spans` tables (ADR-0071 task T6, shipped as T6a
+#326 for the RLOG family and T6b #327 for spans;
+`crates/ravel-sql/src/distributed_rlog.rs`). It fans a table scan out to worker
+slices instead of scanning the local snapshot, then merges the per-slice streams
+at the coordinator.
+
+It reproduces the same total-order, no-dedup merge rule the queryfrag lane uses,
+one layer up in the DataFusion plan. Each worker returns its slice as one
+globally-sorted partition under the table's total-order key, and the coordinator
+runs a `SortPreservingMergeExec` under that key with **nothing above it** — no
+dedup node, no distinct. Logs, alerts, audit, and spans have no query-time dedup
+(`docs/consistency-model.md`, ADR-0051 section 5), so every row every slice
+returns stays visible, exactly as `merge_log_records`/`merge_spans` do in the
+queryfrag lane. The scan machinery (`DistributedSliceScanExec`, the merge
+assembly, byte accounting, schema validation) is signal-neutral and shared
+across all four tables; the only per-signal surface is each table's ordering-key
+column list. The slice-ticket plumbing (`WorkerSlice`, `WorkerSliceClient`,
+`plan_distributed_slices`) is reused unchanged from the metrics SQL lane, since
+a slice ticket pins a snapshot subset and carries no signal discriminator.
+
+Reachability: the distributed scan is installed on a table provider through each
+provider's `with_distributed_scan` (`LogsTableProvider` and the
+alerts/audit/spans siblings) and is exercised end to end by the acceptance tests
+(`crates/ravel-sql/tests/flight_distributed.rs`) driving `provider.scan(..)`. It
+is **not yet wired into a running server's coordinator and worker paths**: the
+server-side coordinator that installs the distributed context from
+`get_flight_info_statement`, and the worker `do_get` slice-fragment branch that
+runs each provider's `worker_fragment`, are still later wiring. The SQL lane
+exists and is tested, but no live server binary reaches it yet.
 
 ### Budgets and the fault matrix
 


### PR DESCRIPTION
T7 deferred SQL-lane fan-out documentation until T6 landed. T6 has
now landed (T6a #326, T6b #327): documents the SQL-lane distributed
scan for logs/alerts/audit/spans in docs/query-engine.md alongside the
existing queryfrag-lane sections, and updates the ADR-0071 amendment's
"Shipped status" section to reflect that T6 has landed. States plainly
that the SQL lane is not yet wired into a running server's coordinator
and worker paths.

Fixes: #343
Refs: #63
