### PR TITLE
ci(coderabbit): grant pull-requests write for the ack reaction

### DIFF
--- a/.github/workflows/coderabbit-maintainer-review.yml
+++ b/.github/workflows/coderabbit-maintainer-review.yml
@@ -418,8 +418,17 @@ jobs:
   # Tells the maintainer the command was heard, without giving anyone else a
   # way to make this workflow speak. It runs only after authorization succeeded,
   # so an unauthorised comment gets no reaction and no reply: silence, and a
-  # failed run that only maintainers can see. `issues: write` lives here and
-  # nowhere else, and this job never touches pull-request content.
+  # failed run that only maintainers can see. Both permissions below live here
+  # and nowhere else, and this job never touches pull-request content.
+  #
+  # `pull-requests: write` is required alongside `issues: write` because the
+  # triggering comment always belongs to a pull request (the `authorize` job's
+  # `if` only admits comments where `github.event.issue.pull_request != null`).
+  # The REST docs list reaction endpoints under the "Issues" permission
+  # category, but GitHub's real enforcement for a reaction on a PR-linked
+  # comment also checks `pull-requests`; without it the API returns 403
+  # "Resource not accessible by integration" even though `issues: write` is
+  # present. Confirmed against run 32361349210 on 2026-08-20.
   ack:
     name: acknowledge the command
     needs: authorize
@@ -428,6 +437,7 @@ jobs:
     timeout-minutes: 5
     permissions:
       issues: write
+      pull-requests: write
     steps:
       - name: React to the triggering comment
         env:


### PR DESCRIPTION
## Summary
- The `ack` job's reaction to the `/coderabbit review` trigger comment 403'd with "Resource not accessible by integration" despite holding `issues: write`
- The comment always belongs to a pull request, and GitHub's real enforcement for reacting to a PR-linked comment also checks `pull-requests`, not just `issues` (the REST docs list it under Issues, but that's not what's enforced)
- Adds `pull-requests: write` to the `ack` job's permissions

## Evidence
Run https://github.com/NOFireAI/ravel/actions/runs/32361349210/job/96401445682 failed on `gh api ... issues/comments/${COMMENT_ID}/reactions` with 403, even though the job log shows `Issues: write` granted. This was the workflow's first real trigger (every prior run skipped past the `authorize` gate), so the reaction step had never run against live GitHub behavior before.

The `review` job doesn't depend on `ack`, so the actual CodeRabbit review was unaffected; only the acknowledgment reaction failed.

## Test plan
- [ ] Comment `/coderabbit review` on an open PR as a maintainer and confirm the `ack` job succeeds and posts a reaction