### PR TITLE
docs(adrs): claim ADR-0096

### DIFF
--- a/docs/adrs/0096-queryfrag-per-sample-provenance-and-histograms.md
+++ b/docs/adrs/0096-queryfrag-per-sample-provenance-and-histograms.md
@@ -1,0 +1,3 @@
+# ADR-0096: Query fan-out frame carries per-sample provenance and histograms
+
+Status: claimed


### PR DESCRIPTION
Reserves ADR-0096 for issue #348, extending `ravel.queryfrag.v1` so the distributed fan-out can carry a run-merged series and a histogram.

Stub only, no decision content. Two parallel sessions are working this repo and both pick "next free number" locally, which is how a collision happens: nothing hits main until after a design gate, so both sessions can choose the same number independently. Landing the stub takes it off the free list now.

The decision content is written by whoever starts #348.

Refs: #348