### PR TITLE
feat(maintain): merge runs at L1 and store dedup provenance per sample

### DIFF
--- a/crates/ravel-bench/tests/catalog_byte_gates.rs
+++ b/crates/ravel-bench/tests/catalog_byte_gates.rs
@@ -21,8 +21,8 @@ use ravel_bench::segment_support::{
     bench_bounds, bench_identity, bench_meta, build_segment_v5,
 };
 use ravel_segment::{
-    ReaderLimits, RunInputV4, SegmentWriter, SeriesInputV4, SeriesValues, WrittenSegment,
-    encode_run_v4, open_from_full,
+    ReaderLimits, RunInputV4, RunInputV7, SampleProvenance, SegmentWriter, SeriesInputV4,
+    SeriesInputV7, SeriesValues, WrittenSegment, encode_run_v4, open_from_full,
 };
 use ravel_types::{LabelSet, Sample, SeriesId};
 
@@ -207,6 +207,56 @@ fn build_fragmented(raw: &[(SeriesId, LabelSet, Vec<Sample>)]) -> WrittenSegment
         .expect("write fragmented v5")
 }
 
+/// The run-merged L1 layout the SHIPPING compactor actually produces (ADR-0092
+/// decision 1, issue #315): one run of N samples per series, carrying the
+/// per-sample dedup provenance column that a merge of N distinct L0 flushes
+/// requires. Each sample keeps the flush it came from: `created_unix_ns` and
+/// `writer_seq` vary per flush, `in_page_index` is 0 (each fragmented flush held
+/// one sample). This is `build_merged` plus the real provenance cost, so its
+/// bytes-per-sample is the epic's actual result, not the no-provenance floor.
+fn build_merged_with_provenance(raw: &[(SeriesId, LabelSet, Vec<Sample>)]) -> WrittenSegment {
+    let base = 1_700_000_000_000_000_000i64;
+    let inputs: Vec<SeriesInputV7> = raw
+        .iter()
+        .map(|(series_id, labels, samples)| {
+            let run = encode_run_v4(
+                series_id,
+                base,
+                0,
+                0,
+                &SeriesValues::Scalar(samples.clone()),
+            )
+            .expect("encode merged run");
+            let column: Vec<SampleProvenance> = samples
+                .iter()
+                .enumerate()
+                .map(|(k, _)| SampleProvenance {
+                    created_unix_ns: base + k as i64 * FRAG_FLUSH_SPACING_NS,
+                    writer_epoch: 0,
+                    writer_seq: k as u64,
+                    in_page_index: 0,
+                })
+                .collect();
+            SeriesInputV7 {
+                series_id: *series_id,
+                labels: labels.clone(),
+                runs: vec![RunInputV7 {
+                    run,
+                    provenance: Some(column),
+                }],
+            }
+        })
+        .collect();
+    SegmentWriter::write_v7_with_provenance(
+        inputs,
+        bench_identity(),
+        bench_bounds(),
+        bench_meta(),
+        Vec::new(),
+    )
+    .expect("write merged v7 with provenance")
+}
+
 /// The five per-section byte-per-sample figures ADR-0092 reports, plus the
 /// object total.
 struct SectionSplit {
@@ -290,6 +340,73 @@ fn fragmented_multi_run_shape_costs_more_than_merged() {
         "fragmented layout ({:.2} B/sample) must exceed merged ({:.2} B/sample) by >= {FRAG_RATIO_MIN}x, got {ratio:.3}x",
         fragmented_split.total,
         merged_split.total,
+    );
+}
+
+/// Pinned lower bound on `fragmented_total / merged_with_provenance_total`,
+/// the epic's headline result: a run-merged L1 object carrying the per-sample
+/// provenance columns still costs materially less per sample than the fragmented
+/// inputs it replaces. Measured on this tree the merged-with-provenance shape is
+/// 8.88 B/sample against the fragmented 26.52, a ratio of 2.986. The per-sample
+/// provenance cost is negligible here: 320 bytes over 120,000 samples (~0.003
+/// B/sample), because the four columns are constant/arithmetic sequences that
+/// `encode_i64` and zstd flatten almost to nothing on a regular flush cadence.
+/// That is far below ADR-0092's ~5 B/sample estimate, which assumed the
+/// columns did not compress. The gate is pinned ~20% below the measured ratio,
+/// matching the `FRAG_RATIO_MIN` margin policy, so it flags a real regression in
+/// the merge win without wobbling on codec-level byte drift.
+const MERGED_WITH_PROV_RATIO_MIN: f64 = 2.4;
+
+#[test]
+fn run_merged_l1_with_provenance_costs_materially_less_than_inputs() {
+    let raw = fragmentation_workload();
+    let total_samples: usize = raw.iter().map(|(_, _, s)| s.len()).sum();
+    assert_eq!(total_samples, FRAG_SERIES * FRAG_SAMPLES_PER_SERIES);
+
+    let fragmented = build_fragmented(&raw);
+    let merged_no_prov = build_merged(&raw);
+    let merged_with_prov = build_merged_with_provenance(&raw);
+
+    let fragmented_split = section_split(&fragmented, total_samples);
+    let merged_no_prov_split = section_split(&merged_no_prov, total_samples);
+    let merged_with_prov_split = section_split(&merged_with_prov, total_samples);
+
+    print_split("fragmented (inputs)", &fragmented_split);
+    print_split("merged (no provenance)", &merged_no_prov_split);
+    print_split(
+        "merged + per-sample provenance (shipping L1)",
+        &merged_with_prov_split,
+    );
+
+    let provenance_cost = merged_with_prov_split.total - merged_no_prov_split.total;
+    println!(
+        "[fragmentation] exact object bytes: merged_no_prov={} merged_with_prov={} delta={} \
+         over {total_samples} samples",
+        merged_no_prov.bytes.len(),
+        merged_with_prov.bytes.len(),
+        merged_with_prov.bytes.len() as i64 - merged_no_prov.bytes.len() as i64,
+    );
+    // The provenance-carrying object must actually differ from the no-provenance
+    // one: the columns are present, just highly compressible (constant/arithmetic
+    // sequences under encode_i64 inside zstd), so their per-sample cost is small,
+    // not zero-because-dropped.
+    assert!(
+        merged_with_prov.bytes.len() > merged_no_prov.bytes.len(),
+        "the provenance columns must add bytes; equal size means they were dropped"
+    );
+    let ratio = fragmented_split.total / merged_with_prov_split.total;
+    println!(
+        "[fragmentation] merged+provenance = {:.2} B/sample (per-sample provenance cost = {:.2} \
+         B/sample); fragmented/merged+prov ratio = {ratio:.3} (gate >= {MERGED_WITH_PROV_RATIO_MIN})",
+        merged_with_prov_split.total, provenance_cost,
+    );
+
+    assert!(
+        ratio >= MERGED_WITH_PROV_RATIO_MIN,
+        "run-merged L1 with provenance ({:.2} B/sample) must cost materially less than the \
+         fragmented inputs ({:.2} B/sample): ratio {ratio:.3} < {MERGED_WITH_PROV_RATIO_MIN}",
+        merged_with_prov_split.total,
+        fragmented_split.total,
     );
 }
 

--- a/crates/ravel-maintain/src/build.rs
+++ b/crates/ravel-maintain/src/build.rs
@@ -1,51 +1,55 @@
-//! Whole-bucket catalog group-by and verbatim-page copy into RSEG v5 parts
-//! (with the ADR-0026/0027
-//! v5 writer substitution). Every input catalog's series is grouped into one
-//! `BTreeMap` keyed by series id (all inputs' per-series metadata resident at
-//! once), then iterated in id order; this is a group-by-then-iterate, not a
-//! bounded-window k-way merge. Only the page bytes stream: every run of a
-//! series is gathered from every input that carries it, its TS and VAL-or-HIST
-//! pages are fetched by range and copied verbatim (never decoded), and parts
-//! are split on series boundaries once accumulated page bytes reach
-//! `max_l1_part_bytes`, so a series' runs never straddle a part and part
-//! id-ranges are disjoint. Each finished part is a whole object written with a
-//! single `CreateIfAbsent` PUT (no multipart), and its encoded
-//! bytes are retained in the returned `Vec` until publish so the
-//! convergence-repair path can re-PUT a part a racing winner is missing.
+//! Whole-bucket catalog group-by and run-merged rewrite into RSEG v7 parts.
+//! Every input catalog's series is grouped into one `BTreeMap` keyed by series
+//! id (all inputs' per-series metadata resident at once), then iterated in id
+//! order; this is a group-by-then-iterate, not a bounded-window k-way merge.
 //!
-//! Format-migration exception (ADR-0066 decision 5): an input recorded *below*
-//! the current output version (its commit record's `segment_format_version` is
-//! older than [`OUTPUT_FORMAT_VERSION`]) cannot be copied verbatim -- copying an
-//! older layout's pages under a current-version trailer would be a mislabeled
-//! object, not a migration. Its object key is passed in `migrate_keys`, and
-//! every one of its runs is instead fully decoded
-//! ([`ravel_segment::decode_run_pages_soa`] /
-//! [`ravel_segment::decode_run_histogram_pages`]) and re-encoded at the current
-//! version ([`ravel_segment::encode_run_v4`]) at the page-materialization step,
-//! the exact point a current-version run is copied. Everything else -- the
-//! series group-by, the size-capped part split, exemplar assignment, and the
-//! record-count conservation gate -- is the one shared merge, unchanged. When
-//! `migrate_keys` is empty (every input at the current version, the normal
-//! compaction case) the fast verbatim path runs exactly as before. RLOG and
-//! RSPAN already decode and re-encode on every merge, so this
-//! decode-and-re-encode primitive is RSEG-specific.
+//! Since ADR-0092 decision 1, L1 compaction is a rewrite, not a re-layout. Per
+//! series, every contributing run's pages are decoded, the samples are merged in
+//! timestamp order, and the whole series is re-encoded into a SINGLE run
+//! (`RunInputV7`) carrying each sample's dedup key (`created_unix_ns`,
+//! `writer_epoch`, `writer_seq`, original in-page index) in the run-major
+//! per-sample provenance columns, so a query over the merged part answers every
+//! request identically to a query over the pre-compaction inputs
+//! (`crates/ravel-query/tests/differential_compaction.rs`). A series that
+//! appears in only one input already is one run: it is copied verbatim with no
+//! provenance column (byte-identical to the L0 shape), which costs nothing.
 //!
-//! Page fetch mechanics: the pages for one part are
-//! fetched as a batch, not one blocking GET per page. First the per-run TS and
-//! VAL-or-HIST byte ranges of every series in the batch are grouped by input
-//! object and coalesced (adjacent/near ranges merged into one GET, mirroring
-//! `ravel-query`'s `SegmentFetcher::coalesce_ranges`), collapsing the ~2R
-//! sequential GETs the naive path issued toward a couple of GETs per input.
-//! The coalesced GETs then run concurrently under a bounded semaphore + a
-//! `buffer_unordered` window, so a bucket's page fetch collapses from k RTT
-//! toward ceil(k/parallelism) RTT on real object storage. Emission stays
-//! deterministic: results are collected before any page is materialized, then
-//! sliced (zero-copy `Bytes::slice`, no per-page `to_vec` off the wire) into
-//! `RunInputV4` in the exact series-then-run order the sequential path used,
-//! so the built part bytes are identical. Fetch buffering is bounded to one
-//! part's worth of page bytes because a batch is exactly the series that fit
-//! under `max_l1_part_bytes`; the encoded parts held until publish still
-//! dominate peak memory.
+//! Parts are split on ENCODED OUTPUT page bytes (ADR-0092 decision 3), not on
+//! input catalog byte ranges: after run merging the output size is a function of
+//! the data's shape through per-page codec selection, so the input-byte figure
+//! no longer predicts it. Input page bytes are retained only as a fetch-buffer
+//! bound (the window below). A series' runs never straddle a part and part
+//! id-ranges are disjoint, since series are emitted in ascending id order and a
+//! part is a contiguous id range. Each finished part is a whole object written
+//! with a single `CreateIfAbsent` PUT (no multipart), and its encoded bytes are
+//! retained in the returned `Vec` until publish so the convergence-repair path
+//! can re-PUT a part a racing winner is missing.
+//!
+//! Format-migration note (ADR-0066 decision 5): an input recorded *below* the
+//! current output version (its commit record's `segment_format_version` is older
+//! than [`OUTPUT_FORMAT_VERSION`]) cannot be copied verbatim, so its object key
+//! is passed in `migrate_keys`. Under the run-merged rewrite this is largely
+//! moot: a multi-run series is decoded and re-encoded regardless of version, and
+//! a single-run series whose input is a migrate key takes the
+//! decode-and-re-encode path ([`reencode_run_to_current_version`]) instead of
+//! the verbatim copy. Under RSEG v7's single-version window `migrate_keys` is
+//! empty in practice (a below-v7 input is unreadable), so the distinction only
+//! affects the single-run verbatim fast path.
+//!
+//! Page fetch mechanics: pages are fetched in windows, not one blocking GET per
+//! page. A fetch window is a run of consecutive series whose INPUT page bytes
+//! stay under `max_l1_part_bytes` (the fetch-buffer bound). For each window the
+//! per-run TS and VAL-or-HIST byte ranges are grouped by input object and
+//! coalesced (adjacent/near ranges merged into one GET, mirroring
+//! `ravel-query`'s `SegmentFetcher::coalesce_ranges`), then the coalesced GETs
+//! run concurrently under a bounded semaphore + a `buffer_unordered` window, so
+//! a bucket's page fetch collapses from k RTT toward ceil(k/parallelism) RTT on
+//! real object storage. Each window's series are materialized (decoded, merged,
+//! re-encoded) in ascending id order and the window's fetched buffers are then
+//! dropped, so peak fetch buffering is one window's worth. A part accumulates
+//! re-encoded series across windows until its OUTPUT page bytes reach
+//! `max_l1_part_bytes`; the encoded parts held until publish, plus one series'
+//! decoded samples at a time, dominate peak memory.
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::future::Future;
@@ -57,9 +61,9 @@ use ravel_commit::keys;
 use ravel_object_store::{GetRange, ObjectStoreBackend};
 use ravel_proto::commit::v1::CompactionPart;
 use ravel_segment::{
-    CompactionMetaV4, ExemplarInput, IngestBounds, ReaderLimits, RunEntry, RunInputV4,
-    RunValuePageV4, SegmentIdentity, SegmentWriter, SeriesInputV4, SeriesValues, ValueKind,
-    decode_run_histogram_pages, decode_run_pages_soa, encode_run_v4,
+    CompactionMetaV4, ExemplarInput, IngestBounds, ReaderLimits, RunEntry, RunInputV4, RunInputV7,
+    RunValuePageV4, SampleProvenance, SegmentIdentity, SegmentWriter, SeriesInputV7, SeriesValues,
+    ValueKind, decode_run_histogram_pages, decode_run_pages_soa, encode_run_v4,
 };
 use ravel_types::{LabelSet, Sample, SeriesId};
 use tokio::sync::Semaphore;
@@ -102,9 +106,10 @@ pub struct BuiltPart {
     pub part: CompactionPart,
 }
 
-/// Merge all inputs into size-capped v5 parts. `catalogs` MUST be
-/// aligned with `inputs` (both in canonical input order): the alignment is
-/// what makes run tie-breaking by canonical input position deterministic.
+/// Merge all inputs into size-capped run-merged RSEG v7 parts. `catalogs` MUST
+/// be aligned with `inputs` (both in canonical input order): the alignment is
+/// what makes run tie-breaking by canonical input position deterministic, which
+/// in turn fixes each merged sample's provenance in-page index.
 ///
 /// `catalogs` is taken by value, and this call is their last use, so the
 /// exemplar records are moved out of them (`std::mem::take` below) rather than
@@ -116,9 +121,9 @@ pub struct BuiltPart {
 /// `migrate_keys` holds the object keys of any input recorded below the current
 /// output version (ADR-0066 decision 5): a run whose input key is in this set is
 /// decoded and re-encoded at the current version rather than page-copied
-/// verbatim (see the module doc and [`materialize_batch`]). It is empty for
+/// verbatim (see the module doc and [`materialize_series`]). It is empty for
 /// ordinary compaction, where every input is already at the current version, and
-/// the verbatim path then runs unchanged.
+/// the single-run verbatim fast path then runs unchanged.
 pub async fn build_parts(
     store: &dyn ObjectStoreBackend,
     config: &CompactorConfig,
@@ -217,66 +222,89 @@ pub async fn build_parts(
         });
     }
 
-    // One shared cap for every batch's fetches (batches run sequentially, so
+    // One shared cap for every window's fetches (windows run sequentially, so
     // this bounds total in-flight GETs at `FETCH_CONCURRENCY`).
     let semaphore = Semaphore::new(FETCH_CONCURRENCY);
+    let limits = ReaderLimits::default();
 
     let mut parts = Vec::new();
     let mut part_index: u32 = 0;
-    let mut batch_start = 0usize;
-    let mut batch_bytes: u64 = 0;
 
-    // Accumulate series into a batch until its predicted page bytes reach the
-    // cap, exactly as the sequential path did (the last series pushes a batch
-    // over the cap; a single series larger than the cap is its own part). Then
-    // fetch that batch's pages (coalesced + concurrent), materialize them in
-    // order, and flush the part.
+    // The rolling output part: series already decoded, merged, and re-encoded
+    // whose accumulated ENCODED page bytes have not yet reached
+    // `max_l1_part_bytes`. Part boundaries are chosen on output bytes (ADR-0092
+    // decision 3), which after run merging no longer track input bytes, so a
+    // part may span several fetch windows and a window may finish several parts.
+    let mut pending: Vec<SeriesInputV7> = Vec::new();
+    let mut pending_exemplars: Vec<ExemplarInput> = Vec::new();
+    let mut pending_output_bytes: u64 = 0;
     let mut exemplars_assigned = 0usize;
+
+    // Accumulate consecutive series into a fetch window until their INPUT page
+    // bytes reach the cap (the fetch-buffer bound; the last series closes the
+    // final window). Fetch that window's pages (coalesced + concurrent),
+    // materialize each series in ascending id order into a run-merged
+    // `SeriesInputV7`, and flush a part whenever the pending output reaches the
+    // cap. A single series whose output alone exceeds the cap becomes its own
+    // part. Series stay in ascending id order throughout, so every part is a
+    // contiguous, disjoint id range.
+    let mut window_start = 0usize;
+    let mut window_input_bytes: u64 = 0;
     for i in 0..builds.len() {
-        batch_bytes = batch_bytes.saturating_add(builds[i].page_bytes);
-        if batch_bytes >= config.max_l1_part_bytes {
-            let batch = &builds[batch_start..=i];
-            let batch_exemplars = take_batch_exemplars(&mut exemplars_by_series, batch);
-            exemplars_assigned += batch_exemplars.len();
-            let part = build_part_from_batch(
-                store,
-                &semaphore,
-                bucket,
-                config,
-                &ingest_bounds,
-                input_set_hash,
-                &input_set_hash16,
-                part_index,
-                batch,
-                batch_exemplars,
-                migrate_keys,
-            )
-            .await?;
-            parts.push(part);
-            part_index += 1;
-            batch_start = i + 1;
-            batch_bytes = 0;
+        window_input_bytes = window_input_bytes.saturating_add(builds[i].page_bytes);
+        let last = i + 1 == builds.len();
+        if window_input_bytes < config.max_l1_part_bytes && !last {
+            continue;
         }
+        let window = &builds[window_start..=i];
+        let regions = fetch_batch_pages(store, &semaphore, window).await?;
+        for build in window {
+            let (series_v7, output_bytes) =
+                materialize_series(build, &regions, migrate_keys, limits)?;
+            pending.push(series_v7);
+            pending_output_bytes = pending_output_bytes.saturating_add(output_bytes);
+            if let Some(mut records) = exemplars_by_series.remove(&build.series_id.0) {
+                exemplars_assigned += records.len();
+                pending_exemplars.append(&mut records);
+            }
+            if pending_output_bytes >= config.max_l1_part_bytes {
+                let part = flush_part(
+                    bucket,
+                    config,
+                    &ingest_bounds,
+                    input_set_hash,
+                    &input_set_hash16,
+                    part_index,
+                    std::mem::take(&mut pending),
+                    std::mem::take(&mut pending_exemplars),
+                )?;
+                if !config.dry_run {
+                    put_part(store, &part).await?;
+                }
+                parts.push(part);
+                part_index += 1;
+                pending_output_bytes = 0;
+            }
+        }
+        window_start = i + 1;
+        window_input_bytes = 0;
     }
 
-    if batch_start < builds.len() {
-        let batch = &builds[batch_start..];
-        let batch_exemplars = take_batch_exemplars(&mut exemplars_by_series, batch);
-        exemplars_assigned += batch_exemplars.len();
-        let part = build_part_from_batch(
-            store,
-            &semaphore,
+    // The tail part: whatever series remain below the cap.
+    if !pending.is_empty() {
+        let part = flush_part(
             bucket,
             config,
             &ingest_bounds,
             input_set_hash,
             &input_set_hash16,
             part_index,
-            batch,
-            batch_exemplars,
-            migrate_keys,
-        )
-        .await?;
+            pending,
+            pending_exemplars,
+        )?;
+        if !config.dry_run {
+            put_part(store, &part).await?;
+        }
         parts.push(part);
     }
 
@@ -303,75 +331,15 @@ pub async fn build_parts(
     Ok(parts)
 }
 
-/// Take the exemplars belonging to one batch's series out of the by-series map,
-/// in the batch's own series order (ascending series id, the same order the
-/// output's SERIES_IDS takes) and, within a series, in the order the inputs
-/// carried them.
-///
-/// Removing rather than copying is what lets [`build_parts`] prove conservation:
-/// a series is in exactly one batch, so after the last batch the map must be
-/// empty. The output writer re-resolves each record's `series_index` against
-/// its own SERIES_IDS and stable-sorts by `(series_index, ts_ns)`, so this
-/// ordering is what breaks ties between two records sharing a key, and the
-/// encoded section stays a function of the canonical input order alone.
-fn take_batch_exemplars(
-    by_series: &mut BTreeMap<[u8; 16], Vec<ExemplarInput>>,
-    batch: &[SeriesBuild<'_>],
-) -> Vec<ExemplarInput> {
-    let mut out = Vec::new();
-    for build in batch {
-        if let Some(mut records) = by_series.remove(&build.series_id.0) {
-            out.append(&mut records);
-        }
-    }
-    out
-}
-
 /// One output series' merge plan without its page bytes: identity, borrowed
 /// labels, and its ordered runs (each tagged with the input object to fetch
-/// from), plus the total page bytes those runs will contribute to a part.
+/// from), plus the total INPUT page bytes those runs contribute to a fetch
+/// window (the fetch-buffer bound; part sizing is on output bytes).
 struct SeriesBuild<'a> {
     series_id: SeriesId,
     labels: &'a LabelSet,
     runs: Vec<(&'a str, &'a RunPlan)>,
     page_bytes: u64,
-}
-
-/// Fetch every page of one batch of series (coalesced per object, concurrent
-/// under `semaphore`), materialize the runs in deterministic order, and build
-/// the part. The fetch/materialize split keeps the buffered page bytes bounded
-/// to this one part's worth and makes emission independent of GET completion
-/// order.
-#[allow(clippy::too_many_arguments)]
-async fn build_part_from_batch(
-    store: &dyn ObjectStoreBackend,
-    semaphore: &Semaphore,
-    bucket: &Bucket,
-    config: &CompactorConfig,
-    ingest_bounds: &IngestBounds,
-    input_set_hash: &[u8; 32],
-    input_set_hash16: &str,
-    part_index: u32,
-    builds: &[SeriesBuild<'_>],
-    exemplars: Vec<ExemplarInput>,
-    migrate_keys: &HashSet<String>,
-) -> Result<BuiltPart> {
-    let regions = fetch_batch_pages(store, semaphore, builds).await?;
-    let batch = materialize_batch(builds, &regions, migrate_keys)?;
-    let part = flush_part(
-        bucket,
-        config,
-        ingest_bounds,
-        input_set_hash,
-        input_set_hash16,
-        part_index,
-        batch,
-        exemplars,
-    )?;
-    if !config.dry_run {
-        put_part(store, &part).await?;
-    }
-    Ok(part)
 }
 
 /// The fetched, coalesced byte regions of one batch, keyed by input object
@@ -458,53 +426,65 @@ async fn fetch_one_range<'a>(
     Ok((key, start, got.data))
 }
 
-/// Slice each run's TS and VAL-or-HIST page out of the fetched regions in the
-/// batch's series-then-run order and pack them into [`SeriesInputV4`], stamping
-/// each run's provenance from its commit record. The page
-/// bytes are sliced zero-copy from the coalesced GET buffers; the single
-/// `to_vec` per page here is the copy `RunInputV4`'s owned `Vec<u8>` fields
-/// require, not a redundant copy off the wire.
-fn materialize_batch(
-    builds: &[SeriesBuild<'_>],
+/// Decode, merge, and re-encode one series into a single run-merged
+/// [`SeriesInputV7`], returning it with its encoded output page-byte size (the
+/// figure `build_parts` splits parts on, ADR-0092 decision 3).
+///
+/// A series with exactly one contributing run is already one run: it is copied
+/// verbatim (no per-sample provenance column, so the merged object stays
+/// byte-identical to the L0 shape for that series), unless its input is a
+/// migrate key, in which case it is decoded and re-encoded at the current
+/// version. A series with two or more runs is fully decoded across every input,
+/// its samples merged in timestamp order, and re-encoded into one run carrying
+/// each sample's dedup key -- `(created_unix_ns, writer_epoch, writer_seq,
+/// original in-page index)` -- in the per-sample provenance column, so a query
+/// over the merged run reproduces the same candidate multiset with the same
+/// priorities the unmerged runs produced (ADR-0092 decision 2).
+fn materialize_series(
+    build: &SeriesBuild<'_>,
     regions: &BatchRegions<'_>,
     migrate_keys: &HashSet<String>,
-) -> Result<Vec<SeriesInputV4>> {
-    let limits = ReaderLimits::default();
-    let mut batch = Vec::with_capacity(builds.len());
-    for build in builds {
-        let mut runs = Vec::with_capacity(build.runs.len());
-        for (key, run) in &build.runs {
-            let object = regions.get(key).ok_or_else(|| {
-                MaintainError::Invariant(format!("no fetched region for object {key}"))
-            })?;
-            let ts_page = slice_region(object, run.ts_abs).ok_or_else(|| {
-                MaintainError::Invariant("coalesced fetch missing a TS page range".into())
-            })?;
-            let page = slice_region(object, run.page_abs).ok_or_else(|| {
-                MaintainError::Invariant("coalesced fetch missing a value page range".into())
-            })?;
-            if migrate_keys.contains(*key) {
-                // Format-migration path (ADR-0066 decision 5): this run's input
-                // is recorded below the current output version, so its pages are
-                // decoded to samples and re-encoded at the current version
-                // rather than copied verbatim. Run provenance
-                // (`created_unix_ns`/`writer_epoch`/`writer_seq`) and the sample
-                // multiset are preserved -- a migration changes the byte format,
-                // never the run's dedup-priority identity or its samples.
-                runs.push(reencode_run_to_current_version(
-                    &build.series_id,
-                    run,
-                    ts_page.as_ref(),
-                    page.as_ref(),
-                    limits,
-                )?);
-                continue;
-            }
+    limits: ReaderLimits,
+) -> Result<(SeriesInputV7, u64)> {
+    let series_id = build.series_id;
+    let kind = match build.runs.first() {
+        Some((_, run)) => run.kind,
+        // A series with no runs cannot reach here: `build_parts` only builds a
+        // `SeriesBuild` from a non-empty contribution list.
+        None => {
+            return Err(MaintainError::Invariant(format!(
+                "series {} has no runs to materialize",
+                series_id.to_hex()
+            )));
+        }
+    };
+
+    // Single-run fast path: no decode/merge, no provenance column.
+    if build.runs.len() == 1 {
+        let (key, run) = build.runs[0];
+        let object = regions.get(key).ok_or_else(|| {
+            MaintainError::Invariant(format!("no fetched region for object {key}"))
+        })?;
+        let ts_page = slice_region(object, run.ts_abs).ok_or_else(|| {
+            MaintainError::Invariant("coalesced fetch missing a TS page range".into())
+        })?;
+        let page = slice_region(object, run.page_abs).ok_or_else(|| {
+            MaintainError::Invariant("coalesced fetch missing a value page range".into())
+        })?;
+        let run_v4 = if migrate_keys.contains(key) {
+            reencode_run_to_current_version(
+                &series_id,
+                run,
+                ts_page.as_ref(),
+                page.as_ref(),
+                limits,
+            )?
+        } else {
             let value_page = match run.kind {
                 ValueKind::Scalar => RunValuePageV4::Scalar(page.to_vec()),
                 ValueKind::Histogram => RunValuePageV4::Histogram(page.to_vec()),
             };
-            runs.push(RunInputV4 {
+            RunInputV4 {
                 created_unix_ns: run.created_unix_ns,
                 writer_epoch: run.writer_epoch,
                 writer_seq: run.writer_seq,
@@ -513,15 +493,239 @@ fn materialize_batch(
                 sample_count: run.sample_count,
                 ts_page: ts_page.to_vec(),
                 value_page,
-            });
-        }
-        batch.push(SeriesInputV4 {
-            series_id: build.series_id,
-            labels: build.labels.clone(),
-            runs,
-        });
+            }
+        };
+        let output_bytes = run_output_bytes(&run_v4);
+        return Ok((
+            SeriesInputV7 {
+                series_id,
+                labels: build.labels.clone(),
+                runs: vec![RunInputV7 {
+                    run: run_v4,
+                    provenance: None,
+                }],
+            },
+            output_bytes,
+        ));
     }
-    Ok(batch)
+
+    // Multi-run merge: decode every run, tagging each sample with its run's
+    // dedup key and its original in-page index, merge in timestamp order (stable
+    // by insertion order for equal timestamps, which is canonical input order
+    // then run order then in-page order -- deterministic), and re-encode into
+    // one run carrying the per-sample provenance column.
+    let (run_v4, provenance) = match kind {
+        ValueKind::Scalar => merge_scalar_runs(&series_id, build, regions, limits)?,
+        ValueKind::Histogram => merge_histogram_runs(&series_id, build, regions, limits)?,
+    };
+    let output_bytes = run_output_bytes(&run_v4);
+    Ok((
+        SeriesInputV7 {
+            series_id,
+            labels: build.labels.clone(),
+            runs: vec![RunInputV7 {
+                run: run_v4,
+                provenance: Some(provenance),
+            }],
+        },
+        output_bytes,
+    ))
+}
+
+/// The encoded output page bytes one run contributes to a part, the counterpart
+/// of the input `page_bytes` figure a fetch window is bounded by. Provenance
+/// columns live in the zstd-compressed SERIES_META, not the page sections, so
+/// they are not counted here; part sizing tracks the TS/VAL/HIST page sections,
+/// which dominate object size, exactly as the pre-merge input figure did.
+fn run_output_bytes(run: &RunInputV4) -> u64 {
+    let value_len = match &run.value_page {
+        RunValuePageV4::Scalar(p) => p.len(),
+        RunValuePageV4::Histogram(p) => p.len(),
+    };
+    run.ts_page.len() as u64 + value_len as u64
+}
+
+/// A sample's full ADR-0010 §5 dedup key, the ordering key within one
+/// timestamp: `(created_unix_ns, writer_epoch, writer_seq, in_page_index)`.
+fn provenance_key(p: &SampleProvenance) -> (i64, u64, u64, u32) {
+    (
+        p.created_unix_ns,
+        p.writer_epoch,
+        p.writer_seq,
+        p.in_page_index,
+    )
+}
+
+/// Order a merged run's scalar samples by `(ts_ns, dedup key, value bits)`
+/// ascending. The primary key keeps the run ascending-by-ts, as every RSEG page
+/// must be. The secondary keys matter because a query over a run-merged run may
+/// fall back to run-wide-plus-position provenance (the fourth dedup element from
+/// on-disk position) as well as read the explicit per-sample column: ordering
+/// same-timestamp samples by ascending dedup priority makes on-disk position a
+/// monotone proxy for that priority, so the two representations pick the same
+/// winner at a duplicate timestamp. The tie-break on value bits keeps equal-key
+/// duplicates (a re-sent identical sample) deterministic.
+fn sort_merged_scalar(merged: &mut [(Sample, SampleProvenance)]) {
+    merged.sort_by(|(sa, pa), (sb, pb)| {
+        sa.ts_ns
+            .cmp(&sb.ts_ns)
+            .then_with(|| provenance_key(pa).cmp(&provenance_key(pb)))
+            .then_with(|| sa.value.to_bits().cmp(&sb.value.to_bits()))
+    });
+}
+
+/// The run-wide `(created_unix_ns, writer_epoch, writer_seq)` a merged run
+/// carries: the lexicographic minimum over its samples' dedup keys. A merged
+/// run's dedup source is its per-sample provenance column, not this triple, so
+/// the value is not query-observable; the minimum keeps the SERIES_META
+/// `created_delta` column (relative to the footer base) compact and makes the
+/// choice a deterministic function of the samples.
+fn merged_run_prefix(provenance: &[SampleProvenance]) -> (i64, u64, u64) {
+    provenance
+        .iter()
+        .map(|p| (p.created_unix_ns, p.writer_epoch, p.writer_seq))
+        .min()
+        .unwrap_or((0, 0, 0))
+}
+
+/// Decode and merge every scalar run of one multi-run series into a single
+/// re-encoded run plus its per-sample provenance column.
+fn merge_scalar_runs(
+    series_id: &SeriesId,
+    build: &SeriesBuild<'_>,
+    regions: &BatchRegions<'_>,
+    limits: ReaderLimits,
+) -> Result<(RunInputV4, Vec<SampleProvenance>)> {
+    let mut merged: Vec<(Sample, SampleProvenance)> = Vec::new();
+    let mut scratch = Vec::new();
+    let mut timestamps = Vec::new();
+    let mut values = Vec::new();
+    for (key, run) in &build.runs {
+        let (ts_page, page) = slice_run_pages(regions, key, run)?;
+        let entry = run_entry_for_decode(run);
+        timestamps.clear();
+        values.clear();
+        decode_run_pages_soa(
+            series_id,
+            &entry,
+            ts_page.as_ref(),
+            page.as_ref(),
+            limits,
+            &mut scratch,
+            &mut timestamps,
+            &mut values,
+        )?;
+        for (in_page_index, (&ts_ns, &value)) in timestamps.iter().zip(&values).enumerate() {
+            merged.push((
+                Sample { ts_ns, value },
+                sample_provenance(run, in_page_index)?,
+            ));
+        }
+    }
+    sort_merged_scalar(&mut merged);
+
+    let (samples, provenance): (Vec<Sample>, Vec<SampleProvenance>) = merged.into_iter().unzip();
+    let (created, epoch, seq) = merged_run_prefix(&provenance);
+    let run_v4 = encode_run_v4(
+        series_id,
+        created,
+        epoch,
+        seq,
+        &SeriesValues::Scalar(samples),
+    )?;
+    Ok((run_v4, provenance))
+}
+
+/// Histogram counterpart of [`merge_scalar_runs`].
+fn merge_histogram_runs(
+    series_id: &SeriesId,
+    build: &SeriesBuild<'_>,
+    regions: &BatchRegions<'_>,
+    limits: ReaderLimits,
+) -> Result<(RunInputV4, Vec<SampleProvenance>)> {
+    let mut merged: Vec<(ravel_segment::HistogramSample, SampleProvenance)> = Vec::new();
+    for (key, run) in &build.runs {
+        let (ts_page, page) = slice_run_pages(regions, key, run)?;
+        let entry = run_entry_for_decode(run);
+        let samples =
+            decode_run_histogram_pages(series_id, &entry, ts_page.as_ref(), page.as_ref(), limits)?;
+        for (in_page_index, sample) in samples.into_iter().enumerate() {
+            merged.push((sample, sample_provenance(run, in_page_index)?));
+        }
+    }
+    // Order by `(ts_ns, dedup key)` ascending, the histogram counterpart of the
+    // scalar sort: primary ts keeps the run ascending, and ordering same-ts
+    // samples by ascending dedup priority keeps on-disk position a monotone
+    // proxy for priority (there is no bit-pattern value tie-break for a
+    // histogram; the structural order is decided by the priority column).
+    merged.sort_by(|(sa, pa), (sb, pb)| {
+        sa.ts_ns
+            .cmp(&sb.ts_ns)
+            .then_with(|| provenance_key(pa).cmp(&provenance_key(pb)))
+    });
+
+    let (samples, provenance): (Vec<ravel_segment::HistogramSample>, Vec<SampleProvenance>) =
+        merged.into_iter().unzip();
+    let (created, epoch, seq) = merged_run_prefix(&provenance);
+    let run_v4 = encode_run_v4(
+        series_id,
+        created,
+        epoch,
+        seq,
+        &SeriesValues::Histogram(samples),
+    )?;
+    Ok((run_v4, provenance))
+}
+
+/// This sample's dedup key: its run's `(created_unix_ns, writer_epoch,
+/// writer_seq)` plus the sample's original position in that run's page. The
+/// fourth element is what the query engine reconstructs from array position for
+/// an unmerged run (ADR-0018), made explicit here because merging destroys that
+/// position.
+fn sample_provenance(run: &RunPlan, in_page_index: usize) -> Result<SampleProvenance> {
+    Ok(SampleProvenance {
+        created_unix_ns: run.created_unix_ns,
+        writer_epoch: run.writer_epoch,
+        writer_seq: run.writer_seq,
+        in_page_index: u32::try_from(in_page_index)
+            .map_err(|_| MaintainError::Invariant("run sample index exceeds u32".into()))?,
+    })
+}
+
+/// A [`RunEntry`] carrying only the fields the decode primitives read (run
+/// provenance, sample count, event-time bounds); the page byte ranges are
+/// supplied directly, so the `(0, 0)` section-range sentinels are correct
+/// (mirrors the erasure-rewrite decode path).
+fn run_entry_for_decode(run: &RunPlan) -> RunEntry {
+    RunEntry {
+        created_unix_ns: run.created_unix_ns,
+        writer_epoch: run.writer_epoch,
+        writer_seq: run.writer_seq,
+        sample_count: run.sample_count,
+        min_ts_ns: run.min_ts_ns,
+        max_ts_ns: run.max_ts_ns,
+        ts_page: (0, 0),
+        val_page: (0, 0),
+        hist_page: (0, 0),
+    }
+}
+
+/// Slice one run's TS and VAL-or-HIST pages out of the fetched regions.
+fn slice_run_pages<'a>(
+    regions: &BatchRegions<'a>,
+    key: &str,
+    run: &RunPlan,
+) -> Result<(Bytes, Bytes)> {
+    let object = regions
+        .get(key)
+        .ok_or_else(|| MaintainError::Invariant(format!("no fetched region for object {key}")))?;
+    let ts_page = slice_region(object, run.ts_abs).ok_or_else(|| {
+        MaintainError::Invariant("coalesced fetch missing a TS page range".into())
+    })?;
+    let page = slice_region(object, run.page_abs).ok_or_else(|| {
+        MaintainError::Invariant("coalesced fetch missing a value page range".into())
+    })?;
+    Ok((ts_page, page))
 }
 
 /// Decode one run's TS and VAL-or-HIST pages to samples and re-encode them at
@@ -656,7 +860,7 @@ fn flush_part(
     input_set_hash: &[u8; 32],
     input_set_hash16: &str,
     part_index: u32,
-    batch: Vec<SeriesInputV4>,
+    batch: Vec<SeriesInputV7>,
     exemplars: Vec<ExemplarInput>,
 ) -> Result<BuiltPart> {
     let run_count: u64 = batch.iter().map(|s| s.runs.len() as u64).sum();
@@ -685,7 +889,8 @@ fn flush_part(
     // only field the copy changes (ADR-0047 decision 3). An exemplar naming a
     // series this part does not carry is a writer error, not a silent drop, so
     // a mis-assignment above fails the run instead of shrinking the output.
-    let written = SegmentWriter::write_v5_with_exemplars(batch, identity, ingest, meta, exemplars)?;
+    let written =
+        SegmentWriter::write_v7_with_provenance(batch, identity, ingest, meta, exemplars)?;
     let content_hash = written.summary.blake3;
     let hash16 = hex::encode(&content_hash[..8]);
     let key = keys::l1_part_key(

--- a/crates/ravel-maintain/src/compact.rs
+++ b/crates/ravel-maintain/src/compact.rs
@@ -616,10 +616,13 @@ mod tests {
 
     /// Exemplars on the sparse-catalog decode path.
     ///
-    /// `read.rs` routes an input with `series_count >= V5_SPARSE_THRESHOLD`
-    /// (4096) to the whole-object `decode_catalog_v5`, and every other test
-    /// here (and `ravel-ingest`'s `exemplar_flush.rs`) stays far below that, so
-    /// the chunked decoder is the only one exercised for exemplars. Exemplar
+    /// `read.rs` routes an input whose object carries the sparse sections
+    /// (SERIES_IDX + SERIES_META_CHUNKS) to the whole-object `decode_catalog_v5`
+    /// via `catalog_is_sparse` -- presence-signalled since #311, not the old
+    /// `series_count >= V5_SPARSE_THRESHOLD` test. A 4096+-series object takes
+    /// the sparse form, and every other test here (and `ravel-ingest`'s
+    /// `exemplar_flush.rs`) stays far below that, so the chunked decoder is the
+    /// only one exercised for exemplars. Exemplar
     /// `series_index` resolution depends on the decoder returning entries in
     /// SERIES_IDS order; if a future change to the sparse decoder broke that,
     /// every exemplar here would resolve to the wrong series while the smaller

--- a/crates/ravel-maintain/tests/common/mod.rs
+++ b/crates/ravel-maintain/tests/common/mod.rs
@@ -724,6 +724,27 @@ pub async fn fetch_compaction_record(
 
 /// Read every part of a compaction record back down to per-series samples,
 /// merged across parts.
+/// Total number of runs each series holds across every L1 part of `record`,
+/// decoded through the real catalog reader. Under run-merged L1 compaction
+/// (ADR-0092 decision 1) every series must resolve to exactly one run.
+pub async fn record_run_counts(
+    store: &dyn ObjectStoreBackend,
+    record: &ravel_proto::commit::v1::CompactionRecord,
+) -> BTreeMap<[u8; 16], usize> {
+    let limits = ReaderLimits::default();
+    let mut out: BTreeMap<[u8; 16], usize> = BTreeMap::new();
+    for part in &record.parts {
+        let key = keys::reconstruct_l1_part_key(record, part).expect("part key");
+        let bytes = get_full(store, &key).await;
+        let loc = open_from_full(&bytes, limits).expect("open part");
+        let entries = decode_catalog_v5(&loc.footer, &bytes, limits).expect("decode part catalog");
+        for entry in &entries {
+            *out.entry(entry.entry.series_id.0).or_default() += entry.runs.len();
+        }
+    }
+    out
+}
+
 pub async fn read_record_samples(
     store: &dyn ObjectStoreBackend,
     record: &ravel_proto::commit::v1::CompactionRecord,

--- a/crates/ravel-maintain/tests/end_to_end.rs
+++ b/crates/ravel-maintain/tests/end_to_end.rs
@@ -105,6 +105,66 @@ async fn compacts_bucket_and_preserves_all_samples() {
     assert_eq!(got, expected);
 }
 
+/// The epic's reachability test (ADR-0092, issue #315): drive a real bucket
+/// through the SHIPPING compaction path, prove the L1 object holds exactly one
+/// run per series (the whole point of run-merged L1), and confirm the samples
+/// read back through the real segment decode path match the inputs bit-for-bit.
+///
+/// The input set has a series (`http_requests{job=a}`) present in two L0 flushes
+/// with an overlapping timestamp, so it takes the multi-run merge path and its
+/// two runs must collapse to one carrying per-sample provenance. The engine-level
+/// dedup equivalence (that a query over the merged L1 picks the same winners as a
+/// query over the inputs) is proven separately and rigorously by
+/// `crates/ravel-query/tests/differential_compaction.rs`.
+#[tokio::test]
+async fn compacted_bucket_holds_one_run_per_series_and_query_matches_inputs() {
+    let store = MemoryStore::new();
+    let specs = three_inputs();
+    for s in &specs {
+        seed_input(&store, s).await;
+    }
+    let clock = FixedClock::new(sealed_now_ns());
+    let bucket = bucket();
+
+    let outcome = compact_bucket(&store, &clock, &cfg(), &bucket)
+        .await
+        .expect("compact");
+    assert!(
+        matches!(outcome, CompactionOutcome::Compacted { .. }),
+        "expected Compacted, got {outcome:?}"
+    );
+
+    let record = fetch_compaction_record(&store, &bucket).await;
+    for p in &record.parts {
+        assert_eq!(p.segment_format_version, u32::from(VERSION_V7));
+    }
+
+    // Exactly one run per series after merging: the run-merged L1 invariant.
+    let run_counts = record_run_counts(&store, &record).await;
+    assert!(
+        !run_counts.is_empty(),
+        "the compacted bucket must carry series"
+    );
+    for (id, count) in &run_counts {
+        assert_eq!(
+            *count,
+            1,
+            "series {:02x?} must hold exactly one merged run, got {count}",
+            &id[..8]
+        );
+    }
+
+    // Query the L1 through the real decode path and compare to the union of the
+    // inputs, bit-for-bit (compaction preserves every input sample; dedup is a
+    // query-time concern, exercised by the differential test).
+    let got = read_record_samples(&store, &record).await;
+    let expected = expected_samples(&specs);
+    assert_eq!(
+        got, expected,
+        "L1 samples must match the inputs bit-for-bit"
+    );
+}
+
 #[tokio::test]
 async fn dry_run_reports_the_plan_but_writes_nothing() {
     // Dry-run: config.dry_run computes the identical eligible set and part plan a

--- a/crates/ravel-maintain/tests/memory.rs
+++ b/crates/ravel-maintain/tests/memory.rs
@@ -42,9 +42,13 @@ async fn peak_memory_on_3600_input_bucket() {
     const HOT_SERIES: usize = 10;
 
     let store = MemoryStore::new();
-    // Each input is one flush of the same HOT_SERIES series with 2 samples,
-    // so the merge produces HOT_SERIES output series each with 3,600 runs
-    // (the §9 hot-series shape).
+    // Each input is one flush of the same HOT_SERIES series with 2 samples. Under
+    // run-merged L1 compaction (ADR-0092 decision 1) every series' 3,600
+    // contributing runs are decoded, merged in timestamp order, and re-encoded
+    // into ONE run, so the output holds exactly HOT_SERIES runs. Decoding those
+    // 3,600 runs' samples one series at a time is the memory shape this test
+    // pins: it must stay under the ceiling even though the decoded samples now
+    // live alongside the fetch buffer.
     let mut input_bytes: u64 = 0;
     for i in 0..INPUTS {
         let series: Vec<RawSeries> = (0..HOT_SERIES)
@@ -81,7 +85,8 @@ async fn peak_memory_on_3600_input_bucket() {
     let total_runs: u64 = record.parts.iter().map(|p| p.run_count).sum();
     assert!(matches!(outcome, CompactionOutcome::Compacted { .. }));
     assert_eq!(record.inputs.len(), INPUTS);
-    assert_eq!(total_runs, (INPUTS * HOT_SERIES) as u64);
+    // One run per series after merging, not one per (input, series).
+    assert_eq!(total_runs, HOT_SERIES as u64);
 
     match (after_seed, after_compact) {
         (Some((rss_seed, hwm_seed)), Some((rss_c, hwm_c))) => {

--- a/crates/ravel-query/src/distrib/codec.rs
+++ b/crates/ravel-query/src/distrib/codec.rs
@@ -269,17 +269,25 @@ pub fn signal_from_u32(raw: u32) -> Result<Signal, CodecError> {
 /// are not in the frozen `ravel.queryfrag.v1` `Run` message, and silently
 /// dropping them would make a distributed fetch pick a different winner at an
 /// overlapping timestamp than a local fetch. Since issue #315 the run-merged
-/// L1 producer exists, so this path REFUSES the merged shape rather than
-/// degrading it: the `debug_assert` trips in test the moment such a run reaches
-/// the wire encoder. Carrying it means extending the `Run` message (next field
-/// number 6) and bumping [`PROTOCOL_VERSION`] with it; until then the merged
-/// shape must not be sent over the distributed path.
+/// L1 producer exists, so such a run must never reach this encoder.
+///
+/// This function does NOT itself enforce that. The enforcing guard is at the
+/// service level ([`crate::distrib::service`]): a slice whose fetched scalar
+/// series carry a `per_sample_priorities` column is refused with
+/// [`pb::status::Code::Unsupported`] before the encode loop, handing the slice
+/// to the coordinator's local fallback (which is exact). The `debug_assert`
+/// below is a second line of defence that trips in test builds only; it
+/// compiles to nothing under `debug_assertions = off`, so it is not the guard.
+/// Carrying the merged shape over the wire means extending the `Run` message
+/// and bumping [`PROTOCOL_VERSION`] with it, tracked as issue #348 (bundled
+/// with the identical `HistogramRun` change); until then the merged shape must
+/// not be sent over the distributed path.
 pub fn encode_series_frame(series: &FetchedSeriesSoa) -> pb::SeriesFrame {
     debug_assert!(
         series.per_sample_priorities.is_none(),
         "distributed frame cannot carry a per-sample provenance column; \
-         extend the ravel.queryfrag.v1 Run message and bump PROTOCOL_VERSION \
-         before sending a run-merged series over the distributed path (#315)"
+         the service-level guard must refuse a run-merged series before it \
+         reaches this encoder (#348)"
     );
     pb::SeriesFrame {
         series_id: series.series_id.0.to_vec(),

--- a/crates/ravel-query/src/distrib/codec.rs
+++ b/crates/ravel-query/src/distrib/codec.rs
@@ -263,15 +263,24 @@ pub fn signal_from_u32(raw: u32) -> Result<Signal, CodecError> {
 /// become zig-zag deltas (delta-from-zero for the first), values become raw
 /// bit patterns.
 ///
-/// `pb::Run` carries run-wide provenance only, which is exactly what every
-/// object in existence holds, so this mapping is total for every run the
-/// fetcher emits today. It cannot express a run-merged run's per-sample dedup
-/// priority column ([`FetchedSeriesSoa::per_sample_priorities`]): adding four
-/// per-sample columns to the frozen `ravel.queryfrag.v1` messages is a wire
-/// contract change, so whatever makes a worker able to produce such a run
-/// (issue #315) must extend this frame and bump [`PROTOCOL_VERSION`] with it.
-/// Nothing constructs that column yet.
+/// `pb::Run` carries run-wide provenance only. It CANNOT express a run-merged
+/// run's per-sample dedup priority column
+/// ([`FetchedSeriesSoa::per_sample_priorities`]): the four per-sample columns
+/// are not in the frozen `ravel.queryfrag.v1` `Run` message, and silently
+/// dropping them would make a distributed fetch pick a different winner at an
+/// overlapping timestamp than a local fetch. Since issue #315 the run-merged
+/// L1 producer exists, so this path REFUSES the merged shape rather than
+/// degrading it: the `debug_assert` trips in test the moment such a run reaches
+/// the wire encoder. Carrying it means extending the `Run` message (next field
+/// number 6) and bumping [`PROTOCOL_VERSION`] with it; until then the merged
+/// shape must not be sent over the distributed path.
 pub fn encode_series_frame(series: &FetchedSeriesSoa) -> pb::SeriesFrame {
+    debug_assert!(
+        series.per_sample_priorities.is_none(),
+        "distributed frame cannot carry a per-sample provenance column; \
+         extend the ravel.queryfrag.v1 Run message and bump PROTOCOL_VERSION \
+         before sending a run-merged series over the distributed path (#315)"
+    );
     pb::SeriesFrame {
         series_id: series.series_id.0.to_vec(),
         labels: encode_labels(&series.labels),

--- a/crates/ravel-query/src/distrib/service.rs
+++ b/crates/ravel-query/src/distrib/service.rs
@@ -363,6 +363,37 @@ impl<R: SegmentResolver + 'static> SeriesFetchService<R> {
             )]);
         }
 
+        // Run-merged provenance is not representable on the wire: `pb::Run`
+        // carries the run-wide triple only, so a series with an explicit
+        // per-sample provenance column (a merged L1 v7 run, produced since
+        // issue #315) cannot cross the distributed path without silently
+        // dropping the column and letting the coordinator pick a different
+        // dedup winner than the local path at an overlapping timestamp. Refuse
+        // the whole slice back to the coordinator's local fallback rather than
+        // return a degraded frame, exactly as the histogram arm above does. The
+        // summary carries this slice's accounting/stats so the coordinator
+        // folds its spend once before falling back (ADR-0071); otherwise the
+        // query would pay for this fetch twice and report it once. The wire
+        // format extension that would let this fan out is issue #348, bundled
+        // with the identical `HistogramRun` change so `PROTOCOL_VERSION` bumps
+        // once rather than twice.
+        if scalar
+            .iter()
+            .flatten()
+            .any(|fs| fs.per_sample_priorities.is_some())
+        {
+            return Ok(vec![summary_frame(
+                &accounting.snapshot(),
+                0,
+                0,
+                pb::status::Code::Unsupported,
+                "run-merged series (per-sample provenance column) are not \
+                 distributed yet (#348)"
+                    .to_string(),
+                &stats,
+            )]);
+        }
+
         // Selective-erasure exclusion, applied post-decode exactly as the local
         // path applies it (ADR-0064, ADR-0071): the coordinator does not
         // re-apply, so worker-side application must match the local rule.

--- a/crates/ravel-query/src/distrib/tests.rs
+++ b/crates/ravel-query/src/distrib/tests.rs
@@ -27,7 +27,10 @@ use ravel_object_store::memory::MemoryStore;
 use ravel_object_store::{ObjectStoreBackend, PutOptions};
 use ravel_promql::SeriesData;
 use ravel_proto::queryfrag::v1 as pb;
-use ravel_segment::{IngestBounds, SegmentIdentity, SegmentWriter, SeriesInput};
+use ravel_segment::{
+    CompactionMetaV4, IngestBounds, RunInputV7, SampleProvenance, SegmentIdentity, SegmentWriter,
+    SeriesInput, SeriesInputV7, SeriesValues, encode_run_v4,
+};
 use ravel_types::accounting::{QueryAccounting, QueryAccountingSnapshot};
 use ravel_types::{Label, LabelSet, Sample, SeriesId, Signal, TenantHash, TenantId};
 use tokio::runtime::Runtime;
@@ -447,6 +450,268 @@ fn reshard_activation_hour_series_spans_two_slices() {
         ];
         // cap 2 => the two shards land in two distinct slices.
         run_acceptance(corpus, 2).await;
+    });
+}
+
+// --- run-merged (per-sample provenance) refusal (#315/#348) -----------------
+
+/// Writes one L1 merged RSEG segment for series `m0` whose single run carries a
+/// per-sample provenance column (the shape an L1 compaction produces since
+/// issue #315), and returns a matching L1 `SegmentRef`.
+///
+/// The layout is the reviewed hazard: the merged run's run-wide minimum-prefix
+/// `(created_unix_ns, ...)` picks a DIFFERENT dedup winner at a duplicate
+/// timestamp than the explicit per-sample column does. At ts=10 the column gives
+/// the `created=200` sample (value 1.0) the win, while the run-wide prefix
+/// `created=100` applied by array position would instead pick the `created=100`
+/// sample (value 9.0). So a distributed path that dropped the column (degrading
+/// the frame rather than refusing it) returns 9.0 where the local path returns
+/// 1.0 -- the silent wrong result this fix closes.
+async fn write_l1_merged_provenance(store: &MemoryStore) -> SegmentRef {
+    let label_set = labels("m0");
+    let series_id = SeriesId::compute(&tenant_id(), "m0", &label_set).expect("series id");
+    let identity = SegmentIdentity {
+        tenant_hash: TENANT.0,
+        shard: 0,
+        writer_id: Uuid::nil().to_string(),
+        writer_epoch: 0,
+        writer_seq: 0,
+    };
+    let bounds = IngestBounds {
+        min_ingest_ts_ns: 0,
+        max_ingest_ts_ns: 0,
+    };
+    let input_set_hash = [0x33u8; 32];
+    let meta = CompactionMetaV4 {
+        ingest_hour_bucket: 100,
+        input_set_hash,
+        part_index: 0,
+        level: 1,
+    };
+    // Merged run, samples in on-disk order (ascending ts, dup ts kept):
+    //   idx0: ts=10 val=1.0  from write A (created 200)
+    //   idx1: ts=10 val=9.0  from write B (created 100)
+    //   idx2: ts=20 val=2.0  from write A (created 200)
+    let samples = SeriesValues::Scalar(vec![
+        Sample {
+            ts_ns: 10,
+            value: 1.0,
+        },
+        Sample {
+            ts_ns: 10,
+            value: 9.0,
+        },
+        Sample {
+            ts_ns: 20,
+            value: 2.0,
+        },
+    ]);
+    // Run-wide created deliberately 100 (the min-prefix): a reader that ignored
+    // the columns would let idx1 (9.0) win ts=10 by array position.
+    let run = encode_run_v4(&series_id, 100, 0, 0, &samples).expect("frame merged run");
+    let provenance = Some(vec![
+        SampleProvenance {
+            created_unix_ns: 200,
+            writer_epoch: 1,
+            writer_seq: 1,
+            in_page_index: 0,
+        },
+        SampleProvenance {
+            created_unix_ns: 100,
+            writer_epoch: 1,
+            writer_seq: 1,
+            in_page_index: 0,
+        },
+        SampleProvenance {
+            created_unix_ns: 200,
+            writer_epoch: 1,
+            writer_seq: 1,
+            in_page_index: 1,
+        },
+    ]);
+    let series = vec![SeriesInputV7 {
+        series_id,
+        labels: label_set,
+        runs: vec![RunInputV7 { run, provenance }],
+    }];
+    let written =
+        SegmentWriter::write_v7_with_provenance(series, identity, bounds, meta, Vec::new())
+            .expect("write L1 with provenance");
+    let key = "seg/l1-merged-provenance.rseg";
+    store
+        .put(key, written.bytes.clone(), PutOptions::default())
+        .await
+        .expect("put L1 object");
+    SegmentRef {
+        data_object_key: key.to_string(),
+        object_size: written.bytes.len() as u64,
+        min_event_ts_ns: written.summary.min_event_ts_ns,
+        max_event_ts_ns: written.summary.max_event_ts_ns,
+        ingest_hour_bucket: 100,
+        sample_count: written.summary.sample_count,
+        series_count: written.summary.series_count,
+        shard: 0,
+        content_hash: written.summary.blake3,
+        writer_id: Uuid::nil(),
+        writer_epoch: 0,
+        writer_seq: 0,
+        created_unix_ns: 100,
+        level: SegmentLevel::L1 {
+            input_set_hash,
+            part_index: 0,
+        },
+    }
+}
+
+/// A fetched scalar series carrying a per-sample provenance column must be
+/// REFUSED at the service level in every build profile, handing the slice to the
+/// coordinator's local fallback rather than being encoded as a degraded run-wide
+/// frame. `Distributed::fetch` returning `Ok(None)` is that refusal-driven
+/// fallback.
+///
+/// This guards the release-build hazard directly. The old `debug_assert`-only
+/// guard in `encode_series_frame` compiles to nothing under
+/// `debug_assertions = off`, so before the service-level refusal this same fetch
+/// encoded the degraded frame and `fetch` returned `Ok(Some(..))`. Asserting
+/// `None` here therefore FAILS against the unfixed code compiled in release --
+/// the exact profile the defect shipped in -- and it does not merely trip the
+/// `debug_assert`: it drives the full loopback worker and coordinator, and the
+/// pass condition is the coordinator's fallback decision, not a panic.
+#[test]
+fn run_merged_series_refuses_over_the_wire_not_degrades() {
+    let rt = Runtime::new().expect("runtime");
+    rt.block_on(async {
+        let store = Arc::new(MemoryStore::new());
+        let seg = write_l1_merged_provenance(&store).await;
+        let snapshot = Snapshot {
+            segments: vec![seg.clone()],
+            segments_pruned: 0,
+            pending_erasure: Vec::new(),
+        };
+
+        // Ground-truth cost of fetching this one slice's segment once, to prove
+        // the refusal folds the slice's spend exactly once (not zero, not twice):
+        // the worker returns its accounting in the terminal summary before the
+        // Unsupported status, exactly as the histogram arm does.
+        let (_local_runs, local_acct, _local_stats) =
+            local_scalar(Arc::clone(&store), &snapshot).await;
+
+        let (fetcher, server) = spawn_worker(Arc::clone(&store), vec![seg]).await;
+        let distributed = Distributed::new(
+            Arc::new(fetcher),
+            DistribThresholds {
+                min_store_bytes: 0,
+                min_segments: 0,
+                max_parallel_slices: 1,
+            },
+        );
+        let accounting = QueryAccounting::new();
+        let result = distributed
+            .fetch(
+                TENANT,
+                Signal::Metrics,
+                &snapshot,
+                &[],
+                &[],
+                &accounting,
+                &EngineConfig::default(),
+                i64::MAX,
+            )
+            .await
+            .expect("distributed fetch");
+        server.abort();
+
+        assert!(
+            result.is_none(),
+            "a run-merged series (per-sample provenance column) must trigger the \
+             Unsupported local fallback (Ok(None)), never a degraded run-wide \
+             frame; got a distributed result"
+        );
+        // The refusal folded the slice's real S3 spend exactly once: equal to a
+        // single local fetch of the segment, not zero and not doubled.
+        assert_eq!(
+            accounting.snapshot(),
+            local_acct,
+            "the refusal path must fold the slice's spend exactly once \
+             (histogram-arm accounting behaviour)"
+        );
+    });
+}
+
+/// Closes the reviewed coverage gap: drive a run-merged series (per-sample
+/// provenance column) through the distributed query path and assert the result
+/// is bit-identical to the same query run purely locally, compared by
+/// `f64::to_bits`.
+///
+/// Today the slice is refused and the coordinator falls back to local, so the
+/// distributed-with-fallback result IS the local result. The winner pin proves
+/// the corpus is the discriminating one (the column winner 1.0 at ts=10, never
+/// the degraded run-wide 9.0). When #348 lands and the frame carries the column,
+/// `fetch` returns the real distributed result and this same assertion proves the
+/// wire preserved the column's winners. The test survives that change because it
+/// compares the coordinator's answer -- however produced -- to local, mirroring
+/// the engine's own `None`-means-local-fallback rule (engine.rs).
+#[test]
+fn run_merged_series_distributed_equals_local_bitwise() {
+    let rt = Runtime::new().expect("runtime");
+    rt.block_on(async {
+        let store = Arc::new(MemoryStore::new());
+        let seg = write_l1_merged_provenance(&store).await;
+        let snapshot = Snapshot {
+            segments: vec![seg.clone()],
+            segments_pruned: 0,
+            pending_erasure: Vec::new(),
+        };
+
+        // Pure-local reference.
+        let (local_runs, _acct, _stats) = local_scalar(Arc::clone(&store), &snapshot).await;
+        let local_merged = merge_soa_runs(local_runs, usize::MAX, usize::MAX).expect("local merge");
+
+        let (fetcher, server) = spawn_worker(Arc::clone(&store), vec![seg]).await;
+        let distributed = Distributed::new(
+            Arc::new(fetcher),
+            DistribThresholds {
+                min_store_bytes: 0,
+                min_segments: 0,
+                max_parallel_slices: 1,
+            },
+        );
+        let accounting = QueryAccounting::new();
+        let distributed_merged = match distributed
+            .fetch(
+                TENANT,
+                Signal::Metrics,
+                &snapshot,
+                &[],
+                &[],
+                &accounting,
+                &EngineConfig::default(),
+                i64::MAX,
+            )
+            .await
+            .expect("distributed fetch")
+        {
+            // #348: the frame carries the column; merge the real distributed runs.
+            Some(triple) => merge_soa_runs(triple.0, usize::MAX, usize::MAX).expect("dist merge"),
+            // Today: refusal -> the engine runs the query locally instead.
+            None => {
+                let (runs, _a, _s) = local_scalar(Arc::clone(&store), &snapshot).await;
+                merge_soa_runs(runs, usize::MAX, usize::MAX).expect("fallback merge")
+            }
+        };
+        server.abort();
+
+        assert_series_bit_identical(&local_merged, &distributed_merged);
+        // Pin the column-dictated winners so this is not "two equal empties": the
+        // merge keeps 1.0 at ts=10 (created=200 beats created=100's 9.0) and 2.0
+        // at ts=20. A degraded run-wide path would put 9.0 at ts=10.
+        assert_eq!(local_merged.len(), 1);
+        let samples = &local_merged[0].samples;
+        assert_eq!(samples.len(), 2);
+        assert_eq!(samples[0].ts_ns, 10);
+        assert_eq!(samples[0].value.to_bits(), 1.0f64.to_bits());
+        assert_eq!(samples[1].ts_ns, 20);
+        assert_eq!(samples[1].value.to_bits(), 2.0f64.to_bits());
     });
 }
 

--- a/crates/ravel-query/tests/differential_compaction.proptest-regressions
+++ b/crates/ravel-query/tests/differential_compaction.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 0de44b3b3b9c11492915150965bd4fada9f3256f18be3b9551ae777f40e165e0 # shrinks to specs = [WriterSpec { created_offset_ns: 0, seq: 1, samples: [(1, 0, 4611686018427387904)] }, WriterSpec { created_offset_ns: 60000000000, seq: 1, samples: [(1, 0, 18446744073709551615), (1, 2, 13832806255468478464)] }]

--- a/crates/ravel-segment/src/reader.rs
+++ b/crates/ravel-segment/src/reader.rs
@@ -1741,7 +1741,7 @@ fn parse_series_meta_tail_v4(
 /// first byte is the [`ravel_codec::encoding::Enc`] tag and whose remainder is
 /// the codec payload for exactly `count` values. Every codec/tag/length
 /// violation is a typed `ProvenanceColumnCodec`, never a panic.
-fn take_encoded_i64_block(
+pub(crate) fn take_encoded_i64_block(
     bytes: &[u8],
     pos: &mut usize,
     count: usize,

--- a/crates/ravel-segment/src/sparse.rs
+++ b/crates/ravel-segment/src/sparse.rs
@@ -1420,7 +1420,7 @@ fn build_meta_chunks(cols: &MetaColumns) -> Result<(Vec<u8>, Vec<ChunkDirEntry>)
         // are the sample-major slice covering this chunk's flagged samples.
         if !cols.prov_presence.is_empty() {
             let presence = &cols.prov_presence[r0..r1];
-            if presence.iter().any(|&p| p == 1) {
+            if presence.contains(&1) {
                 let sc0 = cols.prov_sample_offsets[r0];
                 let sc1 = cols.prov_sample_offsets[r1];
                 push_encoded_i64_block(&mut frame, presence);

--- a/crates/ravel-segment/src/sparse.rs
+++ b/crates/ravel-segment/src/sparse.rs
@@ -37,10 +37,11 @@ use crate::format::{
     section_kind,
 };
 use crate::reader::{
-    DictResolver, RUN_LIVE_BYTES_CHUNK, RunEntry, SeriesEntry, SeriesEntryV4, ValueKind,
-    check_run_total_live_budget, check_series_counts_v2, decode_section_bytes, find_section,
-    index_label_dict, parse_schema_list_v2, parse_schema_ref_block_v2, parse_series_ids_v2,
-    parse_value_ord_block_all_v2, take_block, take_u32_le,
+    DictResolver, RUN_LIVE_BYTES_CHUNK, RunEntry, SampleProvenance, SeriesEntry, SeriesEntryV4,
+    ValueKind, check_run_total_live_budget, check_series_counts_v2, decode_section_bytes,
+    find_section, index_label_dict, parse_schema_list_v2, parse_schema_ref_block_v2,
+    parse_series_ids_v2, parse_value_ord_block_all_v2, take_block, take_encoded_i64_block,
+    take_u32_le,
 };
 use crate::varint::{read_uvarint, write_uvarint};
 use crate::writer::WrittenSegment;
@@ -492,6 +493,11 @@ struct ChunkFrame {
     /// Per-run reconstructed entries (`frame_run_total` entries, in series
     /// then run order), with absolute page offsets and provenance.
     runs: Vec<RunEntry>,
+    /// Optional per-sample dedup provenance (ADR-0092 decision 1), parallel to
+    /// `runs`: empty when this chunk frame carries no provenance extension, else
+    /// `frame_run_total` long with `None` for a run that keeps its run-wide
+    /// provenance and `Some(column)` for a flagged run.
+    provenance: Vec<Option<Vec<SampleProvenance>>>,
 }
 
 /// Decodes one meta-chunk frame's full run-major column set, reconstructing
@@ -571,6 +577,19 @@ fn decode_chunk_frame(
     let val_len = read_uvarint_block(frame_raw, &mut pos, frame_run_total)?;
     let hist_gap = read_uvarint_block(frame_raw, &mut pos, frame_run_total)?;
     let hist_len = read_uvarint_block(frame_raw, &mut pos, frame_run_total)?;
+
+    // Optional per-chunk per-sample provenance extension (ADR-0092 decision 1),
+    // the frame-local counterpart of the whole-section reader's blocks 17-21:
+    // a run-major presence column then four sample-major `encode_i64` columns
+    // over the flagged runs' samples, deltas relative to
+    // `footer.base_created_unix_ns`. Absent for a provenance-free frame, in
+    // which case the trailing-bytes check below still fires on real garbage.
+    let provenance = if pos < frame_raw.len() {
+        parse_chunk_provenance(frame_raw, &mut pos, footer, &sample_count, limits)?
+    } else {
+        Vec::new()
+    };
+
     if pos != frame_raw.len() {
         return Err(SegmentError::TrailingBytes);
     }
@@ -636,7 +655,97 @@ fn decode_chunk_frame(
         schema_ref,
         value_ord: value_ord_block_to_flat(&value_ord_block)?,
         runs,
+        provenance,
     })
+}
+
+/// Parses one chunk frame's per-sample provenance extension into a
+/// `frame_run_total`-long vector parallel to the frame's runs: `None` for a run
+/// that keeps its run-wide provenance, `Some(column)` with one
+/// [`SampleProvenance`] per sample for a flagged run. The frame-local
+/// counterpart of the reader's `parse_provenance_extension`, reading the same
+/// block shape (presence, then `created_unix_ns` delta / `writer_epoch` /
+/// `writer_seq` / in-page index, deltas relative to `footer.base_created_unix_ns`)
+/// and enforcing the same invariants (a present-but-empty extension, an invalid
+/// presence flag, and an over-budget live decode are typed errors, never panics
+/// or wrong keys).
+fn parse_chunk_provenance(
+    frame_raw: &[u8],
+    pos: &mut usize,
+    footer: &Footer,
+    sample_count: &[u64],
+    limits: ReaderLimits,
+) -> Result<Vec<Option<Vec<SampleProvenance>>>, SegmentError> {
+    let run_total = sample_count.len();
+    let presence = take_encoded_i64_block(frame_raw, pos, run_total)?;
+
+    let mut prov_sample_total: u64 = 0;
+    let mut any_present = false;
+    for (&flag, &sc) in presence.iter().zip(sample_count) {
+        match flag {
+            0 => {}
+            1 => {
+                any_present = true;
+                prov_sample_total = prov_sample_total
+                    .checked_add(sc)
+                    .ok_or(SegmentError::FieldOverflow)?;
+            }
+            _ => {
+                return Err(SegmentError::InvalidProvenancePresence(
+                    u64::try_from(flag).unwrap_or(u64::MAX),
+                ));
+            }
+        }
+    }
+    if !any_present {
+        return Err(SegmentError::EmptyProvenanceExtension);
+    }
+
+    // Bound the live decode as the whole-section reader does: four i64 columns
+    // plus one `SampleProvenance` per flagged sample.
+    let live_bytes = prov_sample_total
+        .checked_mul(4 * 8 + std::mem::size_of::<SampleProvenance>() as u64)
+        .ok_or(SegmentError::FieldOverflow)?;
+    if live_bytes > limits.max_section_uncompressed_bytes {
+        return Err(SegmentError::ProvenanceLiveBudgetExceeded {
+            live_bytes,
+            cap: limits.max_section_uncompressed_bytes,
+        });
+    }
+    let prov_total = usize::try_from(prov_sample_total).map_err(|_| SegmentError::FieldOverflow)?;
+
+    let created_delta = take_encoded_i64_block(frame_raw, pos, prov_total)?;
+    let epoch = take_encoded_i64_block(frame_raw, pos, prov_total)?;
+    let seq = take_encoded_i64_block(frame_raw, pos, prov_total)?;
+    let in_page_index = take_encoded_i64_block(frame_raw, pos, prov_total)?;
+
+    let mut out: Vec<Option<Vec<SampleProvenance>>> = Vec::with_capacity(run_total);
+    let mut cursor = 0usize;
+    for (&flag, &sc) in presence.iter().zip(sample_count) {
+        if flag == 0 {
+            out.push(None);
+            continue;
+        }
+        let n = usize::try_from(sc).map_err(|_| SegmentError::FieldOverflow)?;
+        let mut column = Vec::with_capacity(n.min(prov_total));
+        for _ in 0..n {
+            let created = i64::try_from(
+                i128::from(footer.base_created_unix_ns) + i128::from(created_delta[cursor]),
+            )
+            .map_err(|_| SegmentError::ProvenanceBoundsOverflow)?;
+            let ipi =
+                u32::try_from(in_page_index[cursor]).map_err(|_| SegmentError::FieldOverflow)?;
+            column.push(SampleProvenance {
+                created_unix_ns: created,
+                writer_epoch: epoch[cursor] as u64,
+                writer_seq: seq[cursor] as u64,
+                in_page_index: ipi,
+            });
+            cursor += 1;
+        }
+        out.push(Some(column));
+    }
+    Ok(out)
 }
 
 /// The value_ord block is series-major but its per-series lengths need the
@@ -878,6 +987,15 @@ pub fn decode_catalog_v5_chunked(
 
             let rc = frame.run_count[i] as usize;
             let runs: Vec<RunEntry> = frame.runs[roff..roff + rc].to_vec();
+            // Per-sample provenance for this series' runs (ADR-0092 decision 1).
+            // Empty when the frame carried no extension, else the run slice
+            // parallel to `runs`, exactly as the whole-section decode produces.
+            let per_sample_provenance: Vec<Option<Vec<SampleProvenance>>> =
+                if frame.provenance.is_empty() {
+                    Vec::new()
+                } else {
+                    frame.provenance[roff..roff + rc].to_vec()
+                };
             roff += rc;
 
             let mut sample_count: u32 = 0;
@@ -906,12 +1024,7 @@ pub fn decode_catalog_v5_chunked(
                     hist_page: (0, 0),
                 },
                 runs,
-                // The sparse (chunked) SERIES_META form does not carry the
-                // per-sample provenance extension: the writer fails closed
-                // (`PerSampleProvenanceInSparse`) rather than emit a large
-                // object with provenance, so a decoded sparse object never has
-                // per-sample columns (ADR-0092 decision 1, this task's scope).
-                per_sample_provenance: Vec::new(),
+                per_sample_provenance,
             });
         }
         if voff != frame.value_ord.len() {
@@ -1023,6 +1136,22 @@ struct MetaColumns {
     ts_end: Vec<u64>,
     val_end: Vec<u64>,
     hist_end: Vec<u64>,
+    /// Optional per-sample provenance (ADR-0092 decision 1), carried verbatim as
+    /// the whole-section extension's raw columns so the chunk rebuild re-slices
+    /// them without reconstruction. Empty when the SERIES_META has no extension.
+    /// `presence` is one 0/1 per run (`run_total` long); the four value columns
+    /// are sample-major over the flagged runs in run order, exactly as the
+    /// whole-section form stores them (deltas relative to the same
+    /// `footer.base_created_unix_ns`, so they transfer bit-for-bit).
+    prov_presence: Vec<i64>,
+    prov_created_delta: Vec<i64>,
+    prov_epoch: Vec<i64>,
+    prov_seq: Vec<i64>,
+    prov_in_page_index: Vec<i64>,
+    /// Prefix sample offset into the four value columns, per run (length
+    /// `run_total + 1`): `prov_sample_offsets[r]` is the count of provenance
+    /// samples in runs `[0, r)`. Empty when there is no extension.
+    prov_sample_offsets: Vec<usize>,
 }
 
 fn read_raw_uvarint_block(
@@ -1104,6 +1233,54 @@ fn parse_v4_meta_columns(
     let val_len = read_raw_uvarint_block(meta, &mut pos, run_total)?;
     let hist_gap = read_raw_uvarint_block(meta, &mut pos, run_total)?;
     let hist_len = read_raw_uvarint_block(meta, &mut pos, run_total)?;
+
+    // Optional per-sample provenance extension (blocks 17-21, ADR-0092
+    // decision 1): a run-major presence column then four sample-major columns
+    // over the flagged runs' samples, matching the whole-section reader. Absent
+    // (`pos == meta.len()`) for every object without provenance, so the columns
+    // stay empty and the chunk rebuild appends nothing.
+    let mut prov_presence: Vec<i64> = Vec::new();
+    let mut prov_created_delta: Vec<i64> = Vec::new();
+    let mut prov_epoch: Vec<i64> = Vec::new();
+    let mut prov_seq: Vec<i64> = Vec::new();
+    let mut prov_in_page_index: Vec<i64> = Vec::new();
+    let mut prov_sample_offsets: Vec<usize> = Vec::new();
+    if pos < meta.len() {
+        let presence = take_encoded_i64_block(meta, &mut pos, run_total)?;
+        // Sample offset per run, and the total flagged-sample count the four
+        // columns hold. A run flagged present contributes its `sample_count`
+        // samples; a run not flagged contributes none.
+        prov_sample_offsets = Vec::with_capacity(run_total + 1);
+        prov_sample_offsets.push(0usize);
+        let mut acc = 0usize;
+        let mut any_present = false;
+        for (&flag, &sc) in presence.iter().zip(&sample_count) {
+            match flag {
+                0 => {}
+                1 => {
+                    any_present = true;
+                    acc = acc
+                        .checked_add(usize::try_from(sc).map_err(|_| SegmentError::FieldOverflow)?)
+                        .ok_or(SegmentError::FieldOverflow)?;
+                }
+                _ => {
+                    return Err(SegmentError::InvalidProvenancePresence(
+                        u64::try_from(flag).unwrap_or(u64::MAX),
+                    ));
+                }
+            }
+            prov_sample_offsets.push(acc);
+        }
+        if !any_present {
+            return Err(SegmentError::EmptyProvenanceExtension);
+        }
+        prov_created_delta = take_encoded_i64_block(meta, &mut pos, acc)?;
+        prov_epoch = take_encoded_i64_block(meta, &mut pos, acc)?;
+        prov_seq = take_encoded_i64_block(meta, &mut pos, acc)?;
+        prov_in_page_index = take_encoded_i64_block(meta, &mut pos, acc)?;
+        prov_presence = presence;
+    }
+
     if pos != meta.len() {
         return Err(SegmentError::TrailingBytes);
     }
@@ -1136,6 +1313,12 @@ fn parse_v4_meta_columns(
         ts_end,
         val_end,
         hist_end,
+        prov_presence,
+        prov_created_delta,
+        prov_epoch,
+        prov_seq,
+        prov_in_page_index,
+        prov_sample_offsets,
     })
 }
 
@@ -1174,6 +1357,17 @@ fn push_u32_uvarint_block(buf: &mut Vec<u8>, values: &[u32]) {
 fn push_bytes_block(buf: &mut Vec<u8>, bytes: &[u8]) {
     write_uvarint(buf, bytes.len() as u64);
     buf.extend_from_slice(bytes);
+}
+
+/// Appends one `encode_i64` column as a `block_len`-prefixed body whose first
+/// byte is the chosen [`ravel_codec::encoding::Enc`] tag, the exact shape the
+/// whole-section provenance extension uses (writer's `push_encoded_i64_block`)
+/// and the inverse of [`take_encoded_i64_block`].
+fn push_encoded_i64_block(buf: &mut Vec<u8>, values: &[i64]) {
+    let (enc, bytes) = ravel_codec::encoding::encode_i64(values);
+    write_uvarint(buf, (1 + bytes.len()) as u64);
+    buf.push(enc.to_u8());
+    buf.extend_from_slice(&bytes);
 }
 
 /// Builds the SERIES_META_CHUNKS section (header + per-chunk zstd frames) and
@@ -1217,6 +1411,25 @@ fn build_meta_chunks(cols: &MetaColumns) -> Result<(Vec<u8>, Vec<ChunkDirEntry>)
         push_uvarint_block(&mut frame, &cols.val_len[r0..r1]);
         push_uvarint_block(&mut frame, &cols.hist_gap[r0..r1]);
         push_uvarint_block(&mut frame, &cols.hist_len[r0..r1]);
+
+        // Optional per-sample provenance for this chunk (ADR-0092 decision 1).
+        // Emitted iff the object carries the extension AND at least one run in
+        // this chunk is flagged present, so a chunk with no flagged run appends
+        // nothing and decodes exactly as a provenance-free frame. Presence spans
+        // every run in the chunk (0 for the unflagged); the four value columns
+        // are the sample-major slice covering this chunk's flagged samples.
+        if !cols.prov_presence.is_empty() {
+            let presence = &cols.prov_presence[r0..r1];
+            if presence.iter().any(|&p| p == 1) {
+                let sc0 = cols.prov_sample_offsets[r0];
+                let sc1 = cols.prov_sample_offsets[r1];
+                push_encoded_i64_block(&mut frame, presence);
+                push_encoded_i64_block(&mut frame, &cols.prov_created_delta[sc0..sc1]);
+                push_encoded_i64_block(&mut frame, &cols.prov_epoch[sc0..sc1]);
+                push_encoded_i64_block(&mut frame, &cols.prov_seq[sc0..sc1]);
+                push_encoded_i64_block(&mut frame, &cols.prov_in_page_index[sc0..sc1]);
+            }
+        }
 
         let stored = zstd::bulk::compress(&frame, ZSTD_LEVEL)
             .map_err(|e| WriteError::Zstd(e.to_string()))?;

--- a/crates/ravel-segment/src/writer.rs
+++ b/crates/ravel-segment/src/writer.rs
@@ -511,17 +511,11 @@ fn assemble_v4_body_impl(
             return Err(WriteError::MixedValueKindInSeries);
         }
     }
-
-    // Per-sample provenance is not yet supported in the sparse (chunked)
-    // SERIES_META form. Fail closed here rather than silently drop the columns
-    // during the sparse rebuild (which would re-parse the whole SERIES_META and
-    // reject its extension as trailing bytes anyway).
-    if !prov_by_series.is_empty()
-        && series.len() as u64 >= V5_SPARSE_THRESHOLD
-        && prov_by_series.iter().any(|s| s.iter().any(|r| r.is_some()))
-    {
-        return Err(WriteError::PerSampleProvenanceInSparse);
-    }
+    // Per-sample provenance is carried by both SERIES_META forms: the
+    // whole-section extension below the sparse threshold (blocks 17-21, built by
+    // `build_series_meta_v4`), and the per-chunk extension at or above it (the
+    // sparse rebuild in `crate::sparse` re-lays those columns frame by frame,
+    // ADR-0092 decision 1). Nothing to gate here.
 
     let series_count = u64::try_from(series.len()).map_err(|_| WriteError::TooManySeries)?;
 
@@ -856,12 +850,12 @@ impl SegmentWriter {
     /// SERIES_META gains the extension only when at least one run carries them
     /// (absent columns cost zero bytes).
     ///
-    /// The read path for these columns is complete (reader plus query wiring);
-    /// no production caller emits them yet (issue #315 wires the compactor).
-    /// The columns are supported only in the whole-section SERIES_META form:
-    /// an object large enough to take the sparse (chunked) form fails closed
-    /// with `WriteError::PerSampleProvenanceInSparse` rather than silently
-    /// dropping the columns.
+    /// The read path for these columns is complete (reader plus query wiring),
+    /// in both SERIES_META forms. The columns are carried by the whole-section
+    /// form below the sparse threshold and by the per-chunk form at or above it
+    /// (`crate::sparse` re-lays the extension frame by frame), so a merged L1
+    /// object over a large tenant stores them rather than failing closed
+    /// (ADR-0092 decision 1, issue #315).
     pub fn write_v7_with_provenance(
         series: Vec<SeriesInputV7>,
         identity: SegmentIdentity,
@@ -908,10 +902,10 @@ impl SegmentWriter {
         if body.series_count < V5_SPARSE_THRESHOLD {
             return Ok(finalize_v4_trailer(body, VERSION_V7));
         }
-        // The sparse (chunked) SERIES_META form does not carry the provenance
-        // extension yet. `assemble_v4_body_impl` already rejected a
-        // provenance-carrying object here, so reaching this point means no run
-        // carried columns and the sparse rebuild is safe.
+        // At or above the sparse threshold the base's whole-section SERIES_META
+        // (including any provenance extension) is re-laid into per-chunk frames
+        // by the sparse rebuild, which carries the provenance columns per chunk
+        // (ADR-0092 decision 1).
         let base = finalize_v4_trailer(body, VERSION_V4);
         crate::sparse::build_sparse_object(&base)
     }

--- a/crates/ravel-segment/tests/provenance_columns.rs
+++ b/crates/ravel-segment/tests/provenance_columns.rs
@@ -15,8 +15,8 @@
 use proptest::prelude::*;
 use ravel_segment::{
     CompactionMetaV4, IngestBounds, ReaderLimits, RunInputV7, SampleProvenance, SegmentIdentity,
-    SegmentWriter, SeriesInputV4, SeriesInputV7, SeriesValues, decode_catalog_v5, encode_run_v4,
-    open_from_full,
+    SegmentWriter, SeriesInputV4, SeriesInputV7, SeriesValues, V5_SPARSE_THRESHOLD,
+    decode_catalog_v5, encode_run_v4, open_from_full,
 };
 use ravel_types::{Label, LabelSet, METRIC_NAME_LABEL, Sample, SeriesId};
 
@@ -169,6 +169,107 @@ fn run_strategy() -> impl Strategy<Value = (Vec<(i64, f64)>, Option<Vec<SamplePr
             samples.sort_by_key(|(ts, _)| *ts);
             (samples, prov)
         })
+}
+
+/// A merged L1 object over a large tenant is the sparse case (>= 4096 series,
+/// chunked SERIES_META). This proves the per-sample provenance columns survive
+/// a write-then-read round trip through that form too, not just the whole-
+/// section form: without the sparse-form support (ADR-0092 decision 1, issue
+/// #315) `write_v7_with_provenance` failed closed here, so L1 compaction broke
+/// for every tenant above the threshold.
+#[test]
+fn provenance_round_trips_through_sparse_chunked_form() {
+    const N: usize = V5_SPARSE_THRESHOLD as usize + 37;
+
+    // A handful of series carry a merged (multi-sample) run with a per-sample
+    // provenance column; the rest are single-sample runs with no column. The
+    // flagged indices are spread across several 512-wide chunks (and include the
+    // last series) so the chunked rebuild is exercised end to end.
+    let flagged: [usize; 5] = [3, 511, 512, 2000, N - 1];
+    let column = vec![
+        SampleProvenance {
+            created_unix_ns: 40,
+            writer_epoch: 7,
+            writer_seq: 11,
+            in_page_index: 0,
+        },
+        SampleProvenance {
+            created_unix_ns: 55,
+            writer_epoch: 7,
+            writer_seq: 12,
+            in_page_index: 2,
+        },
+        SampleProvenance {
+            created_unix_ns: 55,
+            writer_epoch: 8,
+            writer_seq: 1,
+            in_page_index: 1,
+        },
+    ];
+
+    let mut series_v7 = Vec::with_capacity(N);
+    for i in 0..N {
+        // Big-endian index ids so the writer's ascending-id sort matches input
+        // order, keeping the flagged indices' chunk placement predictable.
+        let mut raw = [0u8; 16];
+        raw[8..].copy_from_slice(&(i as u64).to_be_bytes());
+        let id = SeriesId(raw);
+        let name = format!("m{i:05}");
+        if flagged.contains(&i) {
+            series_v7.push(SeriesInputV7 {
+                series_id: id,
+                labels: labels(&name),
+                runs: vec![run_with_prov(
+                    &id,
+                    40,
+                    1,
+                    1,
+                    &[(100, 1.0), (200, 2.0), (300, 3.0)],
+                    Some(column.clone()),
+                )],
+            });
+        } else {
+            series_v7.push(SeriesInputV7 {
+                series_id: id,
+                labels: labels(&name),
+                runs: vec![run_with_prov(&id, 40, 1, 1, &[(100 + i as i64, 1.0)], None)],
+            });
+        }
+    }
+
+    let written =
+        SegmentWriter::write_v7_with_provenance(series_v7, identity(), bounds(), meta(), Vec::new())
+            .expect("write_v7_with_provenance over a sparse tenant");
+
+    let loc = open_from_full(&written.bytes, ReaderLimits::default()).expect("open");
+    // Sanity: this really is the sparse (chunked) form, not the whole-section
+    // one, so the assertion below exercises the chunk rebuild.
+    assert!(loc.footer.series_count >= V5_SPARSE_THRESHOLD);
+    let entries = decode_catalog_v5(&loc.footer, &written.bytes, ReaderLimits::default())
+        .expect("decode sparse catalog");
+    assert_eq!(entries.len(), N);
+
+    for i in 0..N {
+        let mut raw = [0u8; 16];
+        raw[8..].copy_from_slice(&(i as u64).to_be_bytes());
+        let entry = entries
+            .iter()
+            .find(|e| e.entry.series_id.0 == raw)
+            .expect("series present");
+        assert_eq!(entry.runs.len(), 1, "one run per series");
+        if flagged.contains(&i) {
+            assert_eq!(entry.per_sample_provenance.len(), 1);
+            let got = entry.per_sample_provenance[0]
+                .as_ref()
+                .expect("flagged run keeps its per-sample column");
+            assert_eq!(got, &column, "sparse-form provenance must round-trip exact");
+        } else {
+            // An unflagged run reads back as run-wide: either no column in its
+            // chunk (empty vector) or an explicit `None` when its chunk also
+            // carried a flagged run. Both mean the same dedup key.
+            assert!(entry.per_sample_provenance.iter().all(|p| p.is_none()));
+        }
+    }
 }
 
 proptest! {

--- a/crates/ravel-segment/tests/provenance_columns.rs
+++ b/crates/ravel-segment/tests/provenance_columns.rs
@@ -237,9 +237,14 @@ fn provenance_round_trips_through_sparse_chunked_form() {
         }
     }
 
-    let written =
-        SegmentWriter::write_v7_with_provenance(series_v7, identity(), bounds(), meta(), Vec::new())
-            .expect("write_v7_with_provenance over a sparse tenant");
+    let written = SegmentWriter::write_v7_with_provenance(
+        series_v7,
+        identity(),
+        bounds(),
+        meta(),
+        Vec::new(),
+    )
+    .expect("write_v7_with_provenance over a sparse tenant");
 
     let loc = open_from_full(&written.bytes, ReaderLimits::default()).expect("open");
     // Sanity: this really is the sparse (chunked) form, not the whole-section
@@ -270,6 +275,62 @@ fn provenance_round_trips_through_sparse_chunked_form() {
             assert!(entry.per_sample_provenance.iter().all(|p| p.is_none()));
         }
     }
+}
+
+/// Two samples at the SAME timestamp in one run, with distinct provenance --
+/// the shape run merging produces that no L0 run ever has. The column must stay
+/// aligned to the value page through the round trip, so the higher-priority
+/// sample keeps its own value.
+#[test]
+fn provenance_round_trips_with_duplicate_timestamps_in_one_run() {
+    let id = SeriesId([9u8; 16]);
+    let column = vec![
+        SampleProvenance {
+            created_unix_ns: 100,
+            writer_epoch: 1,
+            writer_seq: 2,
+            in_page_index: 0,
+        },
+        SampleProvenance {
+            created_unix_ns: 50,
+            writer_epoch: 1,
+            writer_seq: 1,
+            in_page_index: 0,
+        },
+    ];
+    let series_v7 = vec![SeriesInputV7 {
+        series_id: id,
+        labels: labels("dup"),
+        runs: vec![run_with_prov(
+            &id,
+            50,
+            1,
+            1,
+            &[(10, f64::from_bits(0x7FF8_0000_0000_0000)), (10, 2.0)],
+            Some(column.clone()),
+        )],
+    }];
+    let written = SegmentWriter::write_v7_with_provenance(
+        series_v7,
+        identity(),
+        bounds(),
+        meta(),
+        Vec::new(),
+    )
+    .expect("write");
+    let loc = open_from_full(&written.bytes, ReaderLimits::default()).expect("open");
+    let entries =
+        decode_catalog_v5(&loc.footer, &written.bytes, ReaderLimits::default()).expect("decode");
+    let e = entries
+        .iter()
+        .find(|e| e.entry.series_id == id)
+        .expect("series present");
+    assert_eq!(e.per_sample_provenance.len(), 1);
+    let got = e.per_sample_provenance[0].as_ref().expect("column present");
+    assert_eq!(
+        got, &column,
+        "column must round-trip aligned with the duplicate-ts value page"
+    );
 }
 
 proptest! {

--- a/docs/adrs/0018-l0-l1-compaction.md
+++ b/docs/adrs/0018-l0-l1-compaction.md
@@ -9,6 +9,22 @@ docs/catalog-and-mvcc.md, and docs/segment-format.md remain authoritative
 as written until their amendments land. Nothing in this ADR changes any
 stored byte today.
 
+**Amended by ADR-0092 (run-merged L1, RSEG v7).** This ADR's verbatim
+run-preservation decision -- an L1 object holds one run per input segment per
+series, page bytes copied unchanged -- is reversed for the metrics path.
+Since ADR-0092 (issue #315) L1 compaction decodes every contributing run,
+merges the samples in timestamp order, and re-encodes one run per series,
+carrying each sample's dedup key in the RSEG v7 per-sample provenance columns.
+The exactness property this ADR relies on (a snapshot with an L1 part plus any
+subset of its inputs answers identically to the pre-compaction snapshot) is
+preserved: the merged run reproduces the same candidate multiset with the same
+priorities, proven by
+`crates/ravel-query/tests/differential_compaction.rs`. Part splitting also
+moves from predicted input bytes to encoded output bytes (ADR-0092 decision 3),
+since re-encoding decouples output size from input size. The overlap-harmlessness
+and non-atomic-swap reasoning below still holds; only the "page bytes copied
+verbatim" mechanism is superseded.
+
 ## Context
 
 Phase 1 never deletes or rewrites anything. Every flush leaves one L0

--- a/docs/segment-format.md
+++ b/docs/segment-format.md
@@ -325,10 +325,12 @@ the decoded live footprint is bounded by the same section byte cap the run-major
 columns use. The columns live inside SERIES_META, under its existing section
 `crc32c`; no page CRC or checksum boundary changes.
 
-The columns exist only in the whole-section SERIES_META (kind 6) form. The
-sparse (chunked) SERIES_META_CHUNKS form does not carry them yet; a writer asked
-to emit provenance on an object large enough to take the sparse form fails
-closed rather than dropping the columns.
+Both SERIES_META forms carry the columns. In the whole-section form (kind 6)
+they are the trailing blocks 17-21 above. In the sparse (chunked)
+SERIES_META_CHUNKS form (kind 9) the same columns are re-laid per chunk, scoped
+to each frame's runs; see SERIES_META_CHUNKS below. A merged L1 object over a
+large tenant is exactly the sparse case, so the sparse form must carry them
+(ADR-0092 decision 1); it is no longer a fail-closed gap.
 
 ## Sparse catalog
 
@@ -405,6 +407,10 @@ hist_base: varint   (running HIST_PAGES end before this frame's first run)
 then the same block_len-prefixed columns as SERIES_META blocks 1-16, scoped
 to this frame (schema_ref/value_ord over n series, the run columns over
 frame_run_total runs)
+then, iff at least one run in this frame carries per-sample provenance,
+the five provenance blocks 17-21 scoped to this frame: presence over
+frame_run_total runs, then the four value columns over this frame's flagged
+samples (same Enc-tagged encode_i64 blocks, same base-relative deltas)
 ```
 
 The column meanings and reconstruction arithmetic are SERIES_META's, verbatim,
@@ -420,7 +426,13 @@ needed for a by-id fetch) via their `block_len` prefixes.
 The chunked form re-lays the identical raw delta/gap/len columns plus per-frame
 bases, so the whole-catalog decode of a sparse object is bit-identical to the
 whole-catalog decode of the same batch below the threshold, and a sparse
-point-probe of any series is bit-identical to that series' slice of it.
+point-probe of any series is bit-identical to that series' slice of it. The
+per-sample provenance columns re-lay the same way: a frame emits blocks 17-21
+only when one of its runs is flagged, so a provenance-free frame is byte-
+identical to one written without the capability, and the deltas (relative to
+the same `footer.base_created_unix_ns`) transfer verbatim from the whole-section
+form. A frame with no flagged run omits the extension, and its series decode as
+run-wide, exactly as below the threshold.
 
 ## EXEMPLARS (kind 10, uncompressed body)
 

--- a/docs/segment-format.md
+++ b/docs/segment-format.md
@@ -39,9 +39,10 @@ protobuf-style LEB128; signed values use zigzag.
 > the union of those layouts. v7 is v6 plus three additive changes from
 > ADR-0092, none of which alter how a v6-shaped object is laid out:
 >
-> - an optional per-sample dedup provenance extension appended to the
->   whole-section SERIES_META, present only when a run merged several writes'
->   samples (decision 1);
+> - an optional per-sample dedup provenance extension carried by both
+>   SERIES_META forms (appended to the whole-section form, re-laid per chunk in
+>   the sparse form), present only when a run merged several writes' samples
+>   (decision 1);
 > - two value page encodings, VAL_ALP (18) and VAL_GCD_DELTA_FOR (19), and one
 >   timestamp encoding, TS_GCD_I64 (2), each selected per page against the prior
 >   encoding and kept only when smaller (decision 6);


### PR DESCRIPTION
ADR-0018 chose to preserve runs verbatim through compaction, so an L1
object carried one run per input object per series. Strict mode is the
default on every ingest surface and the flush delay is 2 seconds, so a
15-second scraped series produced roughly 240 single-sample runs per
hour. Measured over 500 series, that shape cost 26.52 bytes per sample
against 8.88 for the same samples in one merged run per series.

The compactor now decodes every contributing run, merges in timestamp
order, and re-encodes one run per series, carrying each sample's dedup
key in the per-sample provenance columns RSEG v7 added. A series with a
single contributing run keeps its bytes and carries no column, so an L0
flush is unchanged.

Merged samples are ordered by timestamp, then dedup key, then value bits.
That ordering matters for more than determinism: the differential oracle
keys on run-wide provenance plus array position, while the engine keys on
the explicit column, and ordering this way makes on-disk position a
monotone proxy for priority so both representations pick the same winner.
A timestamp-only sort makes them disagree at duplicate timestamps.

Part splitting now accumulates encoded output bytes rather than predicted
input bytes. The prediction was exact only while bytes were copied
verbatim, and page-level codec selection means output size is a function
of the data's shape rather than its sample count.

The sparse form carries the provenance columns too, re-laid per chunk in
SERIES_META_CHUNKS. Without that, compaction would fail for every tenant
above the 4096-series sparse threshold, which is exactly where merged L1
objects matter most.

A run-merged series cannot be sent over the distributed query path.
ravel.queryfrag.v1's Run message carries run-wide provenance only, and
the run-wide triple a merged run would report is the lexicographic
minimum over its samples, so a distributed fetch would pick a different
winner at an overlapping timestamp than the same query run locally. The
worker now refuses the merged shape with an Unsupported status and the
coordinator falls back to local execution, the same way it already
handles histograms. Extending the frame is issue #348, which also covers
histogram fan-out because both messages need the same columns and should
bump the protocol version once rather than twice.

Measured on the byte-gate harness: 26.52 bytes per sample fragmented
against 8.88 merged, a 2.99x reduction. Peak compaction memory is
unchanged at roughly 29 MiB against a 512 MiB bound, with decoded samples
now living alongside the fetch buffer.

Fixes: #315
Refs: #309
