### PR TITLE
chore(segment): clear three loose ends from the RSEG v7 train

### DIFF
--- a/crates/ravel-query/src/fetcher.rs
+++ b/crates/ravel-query/src/fetcher.rs
@@ -2394,6 +2394,125 @@ mod tests {
         );
     }
 
+    /// Writes a single-series RSEG object whose lone sample is an incompressible
+    /// double (`0x4008_9abc_def0_1234`, a normal value with a random mantissa).
+    /// Gorilla and both integer-model codecs (ALP, GCD-delta-FOR) lose to a raw
+    /// copy on it, so the writer selects VAL_RAW_F64 -- the positive case the
+    /// `raw_f64_pages` counter must count.
+    async fn write_incompressible_segment() -> (Arc<MemoryStore>, TenantHash, SegmentRef) {
+        let tenant_hash = TenantHash([11u8; 16]);
+        let writer_id = Uuid::from_u128(2);
+        let identity = SegmentIdentity {
+            tenant_hash: tenant_hash.0,
+            shard: 0,
+            writer_id: writer_id.to_string(),
+            writer_epoch: 1,
+            writer_seq: 1,
+        };
+        let bounds = IngestBounds {
+            min_ingest_ts_ns: 0,
+            max_ingest_ts_ns: 0,
+        };
+        const NS: i64 = 1_000_000_000;
+        let incompressible = f64::from_bits(0x4008_9abc_def0_1234);
+        let only = series("incompressible_metric", &[(1_000 * NS, incompressible)]);
+        let written = SegmentWriter::write(vec![only], identity, bounds).expect("write segment");
+
+        let store = Arc::new(MemoryStore::new());
+        let key = "test/incompressible.rseg";
+        store
+            .put(key, written.bytes.clone(), PutOptions::default())
+            .await
+            .expect("put segment object");
+
+        let seg_ref = SegmentRef {
+            data_object_key: key.to_string(),
+            object_size: written.bytes.len() as u64,
+            min_event_ts_ns: written.summary.min_event_ts_ns,
+            max_event_ts_ns: written.summary.max_event_ts_ns,
+            ingest_hour_bucket: 0,
+            sample_count: written.summary.sample_count,
+            series_count: written.summary.series_count,
+            shard: 0,
+            content_hash: written.summary.blake3,
+            writer_id,
+            writer_epoch: 1,
+            writer_seq: 1,
+            created_unix_ns: 42,
+            level: ravel_catalog::SegmentLevel::L0,
+        };
+        (store, tenant_hash, seg_ref)
+    }
+
+    /// Positive case for the `raw_f64_pages` counter. Its predecessor,
+    /// `fetch_soa_matches_fetch_and_counts_raw_f64_pages`, only asserts the
+    /// counter stays zero now that every fixture selects ALP / GCD-delta-FOR;
+    /// nothing there proves the counter increments when a raw page IS present.
+    /// This publishes an incompressible value that genuinely stores as
+    /// VAL_RAW_F64 and asserts both the counter and the decoded page kind.
+    #[tokio::test]
+    async fn fetch_soa_counts_raw_f64_page_for_incompressible_value() {
+        let (store, tenant_hash, seg_ref) = write_incompressible_segment().await;
+        let backend: Arc<dyn ObjectStoreBackend> = store.clone();
+        let fetcher = SegmentFetcher::new(backend);
+
+        let (soa, stats) = fetcher
+            .fetch_soa(tenant_hash, &seg_ref, &[])
+            .await
+            .expect("fetch_soa");
+
+        assert_eq!(soa.len(), 1);
+        assert_eq!(
+            stats.raw_f64_pages, 1,
+            "the incompressible value must select and count one raw f64 page"
+        );
+        assert!(
+            stats.raw_f64_bytes > 0,
+            "a counted raw f64 page must contribute nonzero bytes"
+        );
+
+        // Prove the page really is raw f64, not merely that the counter moved.
+        let object = store
+            .get(&seg_ref.data_object_key, GetRange::Full)
+            .await
+            .expect("get object")
+            .data;
+        let loc = ravel_segment::open_from_full(&object, ReaderLimits::default()).expect("open");
+        let entries = decode_catalog_v5(&loc.footer, &object, ReaderLimits::default())
+            .expect("decode catalog");
+        let selected: Vec<&SeriesEntryV4> = entries.iter().collect();
+        let ranges = plan_ranges_v4(&loc.footer, &selected).expect("plan ranges");
+        let mut kinds = Vec::new();
+        for entry in &entries {
+            for (run_index, run) in entry.runs.iter().enumerate() {
+                let range = ranges
+                    .iter()
+                    .find(|r| r.series_id == entry.entry.series_id && r.run_index == run_index)
+                    .expect("range for run");
+                let ts = &object
+                    [range.ts_range.0 as usize..(range.ts_range.0 + range.ts_range.1) as usize];
+                let val = &object
+                    [range.val_range.0 as usize..(range.val_range.0 + range.val_range.1) as usize];
+                let mut scratch = Vec::new();
+                let mut tss = Vec::new();
+                let mut vals = Vec::new();
+                let kind = decode_run_pages_soa(
+                    &entry.entry.series_id,
+                    run,
+                    ts,
+                    val,
+                    ReaderLimits::default(),
+                    &mut scratch,
+                    &mut tss,
+                    &mut vals,
+                )
+                .expect("decode run");
+                kinds.push(kind);
+            }
+        }
+        assert_eq!(kinds, vec![ValPageKind::RawF64]);
+    }
+
     fn e2e_series_id() -> SeriesId {
         SeriesId::compute(&TenantId::new("t".to_string()), "m", &labels("m")).expect("series id")
     }

--- a/crates/ravel-segment/src/writer.rs
+++ b/crates/ravel-segment/src/writer.rs
@@ -1119,9 +1119,7 @@ fn frame_val_page(series_id: &SeriesId, values: &[f64], payload: &mut Vec<u8>) -
     let gdf = crate::value_codecs::encode_gcd_delta_for(values);
     if gdf.len() < best_len {
         best_enc = page_enc::VAL_GCD_DELTA_FOR;
-        best_len = gdf.len();
     }
-    let _ = best_len;
 
     match best_enc {
         page_enc::VAL_GORILLA => frame_page(&series_id.0, best_enc, page_comp::NONE, payload),

--- a/crates/ravel-segment/tests/structural_validator_negatives.rs
+++ b/crates/ravel-segment/tests/structural_validator_negatives.rs
@@ -1,8 +1,8 @@
 //! Negative-path coverage for the RSEG structural footer/section validator.
 //! A byte-flip test cannot reach these branches: a flip in a length/offset/
 //! count field also invalidates the covering crc and is caught earlier. Each
-//! test below violates exactly one structural rule of `validate_sections_v6`
-//! (the only version ADR-0047 keeps, superseding ADR-0027's v5) and asserts
+//! test below violates exactly one structural rule of `validate_sections_v7`
+//! (the only version ADR-0092 keeps, superseding ADR-0047's v6) and asserts
 //! the exact typed corruption error, never a panic and never wrong data. The
 //! test name names the precise rule pinned, so an editor who weakens that
 //! branch sees one red test.
@@ -52,7 +52,7 @@ fn bounds() -> IngestBounds {
     }
 }
 
-/// A minimal real, valid v6 object (one series, one sample) -- below the
+/// A minimal real, valid v7 object (one series, one sample) -- below the
 /// sparse threshold, so LABEL_DICT/SERIES_IDS/SERIES_META/TS_PAGES/VAL_PAGES.
 fn one_sample_object() -> bytes::Bytes {
     let series = vec![SeriesInput {
@@ -68,7 +68,7 @@ fn one_sample_object() -> bytes::Bytes {
         .bytes
 }
 
-/// A real, valid v6 footer plus its `page_region_end` (the footer offset,
+/// A real, valid v7 footer plus its `page_region_end` (the footer offset,
 /// exactly what `open_from_full` passes to `validate_sections`).
 fn valid_footer() -> (Footer, u64) {
     let object = one_sample_object();
@@ -76,9 +76,9 @@ fn valid_footer() -> (Footer, u64) {
     (loc.footer, loc.footer_offset)
 }
 
-/// Control: a real, unmutated v6 footer validates.
+/// Control: a real, unmutated v7 footer validates.
 #[test]
-fn valid_v6_footer_accepted() {
+fn valid_v7_footer_accepted() {
     let (footer, region) = valid_footer();
     assert_eq!(
         validate_sections(&footer, VERSION_V7, region, ReaderLimits::default()),
@@ -86,7 +86,7 @@ fn valid_v6_footer_accepted() {
     );
 }
 
-/// Pins: every mandatory v6 kind must be present. SERIES_IDS is a kind that
+/// Pins: every mandatory v7 kind must be present. SERIES_IDS is a kind that
 /// did not exist in the retired v1 layout; dropping it is rejected.
 #[test]
 fn missing_mandatory_section_rejected() {
@@ -233,13 +233,13 @@ fn incomplete_sparse_catalog_rejected() {
     );
 }
 
-/// Pins: `validate_sections` rejects any trailer version other than 6
-/// (ADR-0047), matching `parse_footer`'s accepted set.
+/// Pins: `validate_sections` rejects any trailer version other than 7
+/// (ADR-0092), matching `parse_footer`'s accepted set.
 #[test]
 fn unsupported_version_rejected() {
     let (footer, region) = valid_footer();
-    // v5 (ADR-0026) is retired by the v6 EXEMPLARS bump; rejected the same
-    // way as any other non-6 version.
+    // v5 (ADR-0026) is retired; rejected the same way as any other
+    // non-7 version.
     assert_eq!(
         validate_sections(&footer, 5, region, ReaderLimits::default()),
         Err(SegmentError::UnsupportedVersion(5))


### PR DESCRIPTION
All three follow from one fact: after v7 a value page can be encoded four
ways rather than two. Each was found by a checkpoint review and left out
of scope at the time, because each sits in a crate the task that caused
it was not scoped to.

The page-count test in ravel-query asserted that a chaotic fixture
produced one raw f64 page. After v7 that fixture selects ALP, so the
assertion became `raw_f64_pages == 0` and nothing proved the counter
still increments when a raw page does exist. A new case publishes an
incompressible value, asserts the counter reaches one, and decodes the
page kind to confirm it is raw. The zero-case assertion stays: the point
is that both directions are now covered, since the previous test went
silently vacuous when the encodings changed.

`frame_val_page` carried a dead store of `best_len` after its last
candidate comparison, plus a `let _ = best_len;` to silence the resulting
warning. The value is still read by each candidate comparison; only the
final store was dead, because the match below selects on `best_enc`.
Both lines are gone and the comparison is unchanged.

`valid_v6_footer_accepted` validates a v7 footer since the flip, and its
file still referred to `validate_sections_v6`, a symbol that no longer
exists, and cited ADR-0047 for a version ADR-0092 retired. Names, doc
comments and the ADR reference now match the code.

Fixes: #338
Refs: #309
