### PR TITLE
Mechanize fleet watch, dispatch, and merge guardrails

### DIFF
--- a/.claude/skills/fleet-task-spec/SKILL.md
+++ b/.claude/skills/fleet-task-spec/SKILL.md
@@ -69,9 +69,36 @@ named crates plus every crate that depends on them). The commit that
 gets gated must already be formatted; never append a formatting-only
 fixup commit after a failed --check.
 Commit with trailer "Refs: #N".
+Self-check before the commit (see the checklist below): no tool-call
+artifacts in files, no debug_assert-only guards, generated docs
+regenerated, tests demonstrated failing, no stray files staged.
 Report: <what the orchestrator needs to merge: deviations, counts,
 ambiguities found>.
 ```
+
+## Self-check before the commit
+
+Adversarial checkpoint review runs on every result branch before merge,
+and the same defect classes keep coming back as extra review/fix rounds.
+Each item below has blocked a real result branch. Put the self-check line
+in every spec; the executor runs it against its own diff right before the
+commit:
+
+- **Tool-call artifacts in files**: a pasted tool result, a stray
+  transcript fragment, an editor conflict marker, or a placeholder left
+  in committed content. `git diff --staged` and read your own hunks.
+- **`debug_assert`-only guards**: a safety check that compiles out of
+  release builds is not a guard. If the condition matters in production,
+  it is a runtime check with a typed error.
+- **Generated docs**: if the change touches anything a doc generator
+  derives (counts, tables, indexes), regenerate against YOUR tree and
+  commit the output in the same commit. A hand-edit of generated output
+  is undone at the next regeneration.
+- **Vacuous tests**: the prove-the-test skill's rule applies to you -
+  demonstrate the new test failing against the pre-fix code and name the
+  flipped line in your report. A test that cannot fail proves nothing.
+- **Stray files**: nothing staged that the deliverables do not name
+  (scratch scripts, logs, `__pycache__/`, editor droppings).
 
 ## Executor test scope
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -440,6 +440,12 @@ file.
   heredocs run through Bash: heredoc writes bypass the post-edit hooks
   and leave no auditable diff in the session. Heredocs are fine for
   scratchpad files.
+- Code comments are for the next reader, not the reviewer. Write one
+  only when the code cannot show the constraint itself, keep it to a
+  sentence or two, and write none when the code is self-explanatory.
+  Do not narrate history ("this used to", "a session once", incident
+  stories): the why belongs in the comment only as the live constraint,
+  the story belongs in the commit message.
 - Parallel agents (fleet or local fan-out): derive every scratch path
   from your own task or agent id (`<scratchpad>/<agent-id>/...`), never a
   bare shared filename. Agents that share a name overwrite each other

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,7 +118,9 @@ script's pre-flight, a re-push) may skip the repeat run and let the PR's
 required checks enforce it; that is what `FLEET_MERGE_SKIP_GATES=1`
 (described under Scripts below) is for. The full list still runs at least
 once locally before the commit exists; protection makes the repeats
-redundant, not the first run.
+redundant, not the first run. This precondition is enforced, not
+remembered: `gates.sh` writes a receipt for every full clean-tree run,
+and the merge script refuses the skip without a matching receipt.
 
 ### Long commands and the Bash tool
 
@@ -134,6 +136,26 @@ polling can consume a large share of a session's turns.
 On an 8 GB host, default cargo parallelism gets ld killed with signal 9;
 `gates.sh` caps build jobs there automatically. If you invoke cargo
 directly on such a host, pass `--jobs 2`.
+
+### Waiting on fleet tasks and PRs
+
+Waiting is event-driven, never babysat. The harness kills background
+processes after about 10 minutes; an unbounded watcher dies unnoticed and
+the fallback becomes no-op status polls that burn turns and tokens.
+
+- Arm `scripts/fleet-watch-managed.sh` under a Monitor until-loop: each
+  bounded run exits 75 when its budget elapses and the Monitor relaunches
+  it; exit 0 prints the terminal event. Never nohup a watcher and never
+  poll one with `ps`.
+- Idle fallback wakeups: 15 minutes or longer. Embed the current ledger
+  state in every wakeup prompt so a compaction between wakeups costs
+  nothing.
+- If two consecutive polls on the same task return nothing new, stop
+  polling: fetch the fleet transcript and diagnose, or escalate.
+- "Where are we at?" has one answer: `scripts/epic-status.sh <epic>`.
+  Run it instead of repeated `gh issue view` reads, and post a one-line
+  status to the epic ledger at each state transition so the user can
+  self-serve.
 
 ### CI workflow changes
 
@@ -167,7 +189,28 @@ connection, a pushed-but-broken main).
   a loop. The SSE stream it wraps drops the connection almost immediately
   in this environment, so a single long-lived `curl -N` never sees the
   terminal event; this retries instead. Prints the terminal event and
-  exits 0 once one arrives.
+  exits 0 once one arrives. Prefer `fleet-watch-managed.sh` below when a
+  harness lifetime cap applies (it always does in Claude Code sessions).
+- `scripts/fleet-watch-managed.sh <watch-url> [budget-s] [poll-s]`: the
+  same polling, in bounded runs sized to survive the harness's 10-minute
+  background cap. Exit 0 = terminal event printed; exit 75 = budget
+  elapsed, relaunch (arm it under a Monitor until-loop that relaunches
+  on 75).
+- `scripts/epic-status.sh <epic-issue> [--fresh]`: one-call "where are we
+  at?": reads the epic ledger (cached 60 s) and reconciles every task id
+  in it against `refs/heads/task/*` on origin and the task-branch PRs.
+  This is the mandatory pre-dispatch ledger reconciliation as a single
+  command.
+- `scripts/fleet-dispatch-intent.sh intent|record|failed ...`: intent-first
+  dispatch bookkeeping on the epic ledger. `intent <epic> <ticket> <sha>`
+  refuses while a previous intent for the ticket is unresolved, runs the
+  fresh-ref guard, and posts a marker comment; `record`/`failed` close it
+  out after the `fleet_dispatch` call. A start push lost to a 5xx then
+  leaves a record instead of a ghost task, and a retry cannot
+  double-dispatch. Use it around every dispatch.
+- `scripts/ci-sweep-cancelled.sh [-y]`: finds cancelled ci runs on open PR
+  head SHAs and reruns them (dry run by default). A cancelled required
+  check blocks auto-merge the same as a red one, and nothing retries it.
 - `scripts/fleet-result-inspect.sh <task-id>`: fetches a dispatched
   task's result branch and prints its commits and diff scope vs `main`,
   for review before merging. Never trust an executor's own "gates green"
@@ -183,12 +226,15 @@ connection, a pushed-but-broken main).
   Run `fleet-result-inspect.sh` first: this script does not pause for
   review, it assumes you already decided the scope is correct.
   `FLEET_MERGE_SKIP_GATES=1` skips the local `gates.sh` run and lets the
-  PR's required checks be the gate. Use it only when the tree being
-  merged is byte-identical to one that already passed the full gates
-  this session (the common case: the orchestrator gated the result
-  branch minutes earlier); the cost is learning about a red PR from CI
-  instead of immediately. Never combine it with a conflict resolution
-  or any manual edit to the branch.
+  PR's required checks be the gate; the cost is learning about a red PR
+  from CI instead of immediately. The precondition is mechanical:
+  `gates.sh` writes a receipt keyed by tree hash on every full
+  clean-tree run, and the merge script refuses the skip unless the
+  history about to be pushed has a receipt younger than 24 h. An amend,
+  conflict resolution, or manual edit changes the tree and voids the
+  receipt: rerun the gates. The script also runs `assert-gh-auth.sh`
+  first and `assert-clean-authorship.sh` on the rewritten history before
+  it pushes.
 - `scripts/verify-dispatch-gates.sh <ref> <scratchpad-dir>`: the tier-1
   gate check behind the `verify-dispatch` skill: an isolated worktree
   outside the repo, a cold `CARGO_TARGET_DIR`, and the full workspace
@@ -231,6 +277,17 @@ as a precondition, not after the damage.
   SHA read earlier in the session goes stale the moment another PR merges,
   and dispatching it silently rebuilds on a superseded tree.
   `ALLOW_STALE_REF=1` to dispatch an intentionally older ref.
+- `scripts/guards/assert-gh-auth.sh [hostname]`: exits non-zero when gh
+  cannot complete an authenticated API call. Run it before any landing
+  sequence: tokens die mid-session, and a failure found at push time
+  strands committed work. `fleet-result-merge.sh` runs it first.
+- `scripts/guards/assert-clean-authorship.sh <ref> [email]`: exits
+  non-zero if any commit on `<ref>` not yet on origin/main has an author,
+  committer, or Signed-off-by other than the expected identity (default:
+  `git config user.email`), or carries an AI attribution trailer. The
+  merge script runs it after its rewrite; run it yourself after any
+  manual amend or script-bypassing merge. A wrong identity on protected
+  `main` cannot be fixed later.
 
 ### Writing gate and poll shell
 
@@ -302,6 +359,10 @@ processed as if it were done.
   the epic issue body), and regenerate any "Wave N landed" claim from a
   live `gh pr list --json number,state,mergedAt` query over that wave's PR
   numbers, never from memory of which MERGED notifications fired.
+- `scripts/epic-status.sh <epic>` performs this reconciliation as one
+  command; run it on every tick instead of hand-rolling the queries.
+- Wrap every dispatch in `scripts/fleet-dispatch-intent.sh`: `intent`
+  before the `fleet_dispatch` call, `record`/`failed` after.
 
 ## Commits
 
@@ -372,3 +433,17 @@ file.
 - Stay inside the crates your task names. The workspace root Cargo.toml,
   CI config, and other crates are out of scope unless the task says
   otherwise.
+
+## Editing and hygiene
+
+- Edit repo files with the Edit/Write tools, never `cat <<EOF` or python
+  heredocs run through Bash: heredoc writes bypass the post-edit hooks
+  and leave no auditable diff in the session. Heredocs are fine for
+  scratchpad files.
+- Parallel agents (fleet or local fan-out): derive every scratch path
+  from your own task or agent id (`<scratchpad>/<agent-id>/...`), never a
+  bare shared filename. Agents that share a name overwrite each other
+  mid-task.
+- Never paste live credentials into the conversation, and flag it in your
+  report if the user does: transcripts persist on disk and later agents
+  read them. Point at a keychain entry or environment variable instead.

--- a/scripts/ci-sweep-cancelled.sh
+++ b/scripts/ci-sweep-cancelled.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Find cancelled ci runs on the head SHA of open PRs and rerun them.
+# Dry run by default; -y applies.
+#
+# Cancelled is not failed, so nothing retries it, but a cancelled
+# required check blocks auto-merge the same as a red one. Most come from
+# the auto-merge/late-push concurrency race.
+#
+# Usage: ci-sweep-cancelled.sh [-y]
+set -euo pipefail
+
+apply=0
+if [[ "${1:-}" == "-y" ]]; then
+  apply=1
+fi
+
+open_prs=$(gh pr list --state open --json number,headRefName,headRefOid \
+  --jq '.[] | "\(.number) \(.headRefName) \(.headRefOid)"')
+
+if [[ -z "${open_prs}" ]]; then
+  echo "No open PRs; nothing to sweep."
+  exit 0
+fi
+
+found=0
+while IFS= read -r row; do
+  pr_num="${row%% *}"
+  rest="${row#* }"
+  head_branch="${rest%% *}"
+  head_sha="${rest##* }"
+
+  runs=$(gh run list --branch "${head_branch}" --limit 20 \
+    --json databaseId,conclusion,headSha,workflowName \
+    --jq ".[] | select(.conclusion == \"cancelled\" and .headSha == \"${head_sha}\") | \"\(.databaseId) \(.workflowName)\"" \
+    2>/dev/null || true)
+  [[ -z "${runs}" ]] && continue
+
+  while IFS= read -r run_row; do
+    run_id="${run_row%% *}"
+    wf_name="${run_row#* }"
+    found=1
+    if [[ ${apply} -eq 1 ]]; then
+      echo "PR #${pr_num}: rerunning cancelled '${wf_name}' run ${run_id}"
+      # Cancelled jobs do not count as failed, so rerun the whole run.
+      gh run rerun "${run_id}"
+    else
+      echo "PR #${pr_num}: cancelled '${wf_name}' run ${run_id} on ${head_sha:0:12} (dry run; -y to rerun)"
+    fi
+  done <<<"${runs}"
+done <<<"${open_prs}"
+
+if [[ ${found} -eq 0 ]]; then
+  echo "No cancelled runs on open PR heads."
+fi

--- a/scripts/epic-status.sh
+++ b/scripts/epic-status.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# One-call answer to "where are we at?" for a fleet-delivered epic.
+#
+# Reads the epic issue body (cached for 60 s), extracts every fleet task
+# UUID in it, and reconciles each against the task refs on origin and the
+# task-branch PRs. This is the pre-dispatch ledger reconciliation from
+# CLAUDE.md as one command.
+#
+# Usage: epic-status.sh <epic-issue-number> [--fresh]
+#   --fresh bypasses the cache.
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 <epic-issue-number> [--fresh]" >&2
+  exit 64
+fi
+
+issue="$1"
+fresh="${2:-}"
+
+cache_dir="${TMPDIR:-/tmp}/ravel-epic-status"
+mkdir -p "${cache_dir}"
+cache_file="${cache_dir}/issue-${issue}.json"
+
+now=$(date +%s)
+use_cache=0
+if [[ "${fresh}" != "--fresh" && -f "${cache_file}" ]]; then
+  if [[ "$(uname)" == "Darwin" ]]; then
+    mtime=$(stat -f %m "${cache_file}")
+  else
+    mtime=$(stat -c %Y "${cache_file}")
+  fi
+  if (( now - mtime < 60 )); then
+    use_cache=1
+  fi
+fi
+
+if [[ ${use_cache} -eq 0 ]]; then
+  gh issue view "${issue}" --json number,title,state,body >"${cache_file}.tmp"
+  mv "${cache_file}.tmp" "${cache_file}"
+fi
+
+title=$(jq -r .title "${cache_file}")
+issue_state=$(jq -r .state "${cache_file}")
+echo "== Epic #${issue}: ${title} [${issue_state}]"
+
+task_ids=$(jq -r .body "${cache_file}" \
+  | grep -oE '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' \
+  | sort -u || true)
+
+if [[ -z "${task_ids}" ]]; then
+  echo "No fleet task ids found in the issue body."
+else
+  # One remote round-trip for all task refs; one API call for all task PRs.
+  remote_refs=$(git ls-remote origin 'refs/heads/task/*' 2>/dev/null || true)
+  pr_rows=$(gh pr list --state all --limit 100 \
+    --json number,state,headRefName,mergedAt \
+    --jq '.[] | select(.headRefName | startswith("task/")) | "\(.headRefName) #\(.number) \(.state)"' \
+    2>/dev/null || true)
+
+  printf '%-38s %-6s %-7s %s\n' "task" "start" "result" "merge PR"
+  while IFS= read -r tid; do
+    have_start="no"
+    have_result="no"
+    grep -q "refs/heads/task/${tid}/start$" <<<"${remote_refs}" && have_start="yes"
+    grep -q "refs/heads/task/${tid}/result$" <<<"${remote_refs}" && have_result="yes"
+    pr_info=$(grep "^task/${tid}/merge " <<<"${pr_rows}" | head -1 || true)
+    pr_info="${pr_info#task/${tid}/merge }"
+    [[ -z "${pr_info}" ]] && pr_info="-"
+    printf '%-38s %-6s %-7s %s\n' "${tid}" "${have_start}" "${have_result}" "${pr_info}"
+  done <<<"${task_ids}"
+
+  echo
+  echo "Legend: start=yes result=no PR=-  -> in flight or dead (check fleet_status"
+  echo "        before a new dispatch); result=yes PR=-  -> ready to inspect/merge;"
+  echo "        PR OPEN  -> waiting on checks or a stuck auto-merge."
+fi
+
+open_task_prs=$(gh pr list --state open --json number,title,headRefName \
+  --jq '.[] | select(.headRefName | startswith("task/")) | "#\(.number) \(.headRefName) \(.title)"' \
+  2>/dev/null || true)
+if [[ -n "${open_task_prs}" ]]; then
+  echo
+  echo "== Open task PRs:"
+  printf '%s\n' "${open_task_prs}"
+fi

--- a/scripts/fleet-dispatch-intent.sh
+++ b/scripts/fleet-dispatch-intent.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Intent-first dispatch bookkeeping on the epic ledger.
+#
+# The dispatch itself goes through the fleet_dispatch MCP tool; this
+# script enforces the ordering around it. Record intent before the
+# dispatch, refuse a new intent while one for the same ticket is
+# unresolved, and record the outcome after. A start push that dies on a
+# control-plane 5xx then leaves a record instead of a ghost task, and a
+# retry cannot double-dispatch.
+#
+# Usage:
+#   fleet-dispatch-intent.sh intent <epic-issue> <ticket> <ref-sha>
+#       Refuses on a dangling intent (exit 65), runs the fresh-ref guard,
+#       posts a dispatch-intent comment, prints the nonce.
+#   fleet-dispatch-intent.sh record <epic-issue> <nonce> <task-id>
+#   fleet-dispatch-intent.sh failed <epic-issue> <nonce> [reason...]
+#
+# Flow in the orchestrator turn:
+#   1. sha=$(git fetch origin main -q && git rev-parse origin/main)
+#   2. nonce=$(scripts/fleet-dispatch-intent.sh intent <epic> <ticket> "$sha")
+#   3. call fleet_dispatch with ref=$sha
+#   4a. scripts/fleet-dispatch-intent.sh record <epic> "$nonce" <task-id>
+#   4b. on error: scripts/fleet-dispatch-intent.sh failed <epic> "$nonce" <why>
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ $# -lt 3 ]]; then
+  echo "usage: $0 intent <epic-issue> <ticket> <ref-sha>" >&2
+  echo "       $0 record <epic-issue> <nonce> <task-id>" >&2
+  echo "       $0 failed <epic-issue> <nonce> [reason...]" >&2
+  exit 64
+fi
+
+mode="$1"
+epic="$2"
+shift 2
+
+case "${mode}" in
+  intent)
+    if [[ $# -lt 2 ]]; then
+      echo "fleet-dispatch-intent.sh: intent needs <ticket> <ref-sha>" >&2
+      exit 64
+    fi
+    ticket="$1"
+    ref_sha="$2"
+
+    # A dangling intent = an intent comment for this ticket with no
+    # matching record/failed comment. Scan the most recent 100 comments.
+    comments=$(gh issue view "${epic}" --json comments \
+      --jq '.comments[-100:][].body' 2>/dev/null || true)
+    dangling=""
+    while IFS= read -r nonce_line; do
+      n="${nonce_line#dispatch-intent nonce=}"
+      n="${n%% *}"
+      [[ -z "${n}" ]] && continue
+      if ! grep -qE "^dispatch-(record|failed) nonce=${n}( |$)" <<<"${comments}"; then
+        dangling="${n}"
+      fi
+    done < <(grep -E "^dispatch-intent nonce=[a-z0-9-]+ ticket=${ticket}( |$)" <<<"${comments}" || true)
+
+    if [[ -n "${dangling}" ]]; then
+      echo "fleet-dispatch-intent.sh: dangling intent ${dangling} for ${ticket} on epic #${epic}." >&2
+      echo "  A previous dispatch of this ticket has no recorded outcome. Reconcile" >&2
+      echo "  first: check fleet_status / scripts/epic-status.sh ${epic}, then mark it" >&2
+      echo "  with 'record <task-id>' or 'failed' before dispatching again." >&2
+      exit 65
+    fi
+
+    "${script_dir}/guards/assert-fresh-dispatch-ref.sh" "${ref_sha}" >&2
+
+    nonce="$(date +%s)-$$"
+    gh issue comment "${epic}" --body \
+      "dispatch-intent nonce=${nonce} ticket=${ticket} ref=${ref_sha}" >/dev/null
+    echo "${nonce}"
+    ;;
+
+  record)
+    if [[ $# -lt 2 ]]; then
+      echo "fleet-dispatch-intent.sh: record needs <nonce> <task-id>" >&2
+      exit 64
+    fi
+    gh issue comment "${epic}" --body \
+      "dispatch-record nonce=$1 task=$2" >/dev/null
+    echo "recorded task $2 against intent $1 on epic #${epic}"
+    ;;
+
+  failed)
+    if [[ $# -lt 1 ]]; then
+      echo "fleet-dispatch-intent.sh: failed needs <nonce> [reason...]" >&2
+      exit 64
+    fi
+    nonce="$1"
+    shift
+    reason="${*:-unspecified}"
+    gh issue comment "${epic}" --body \
+      "dispatch-failed nonce=${nonce} reason: ${reason}" >/dev/null
+    echo "marked intent ${nonce} failed on epic #${epic}"
+    ;;
+
+  *)
+    echo "fleet-dispatch-intent.sh: unknown mode '${mode}' (intent|record|failed)" >&2
+    exit 64
+    ;;
+esac

--- a/scripts/fleet-result-merge.sh
+++ b/scripts/fleet-result-merge.sh
@@ -75,6 +75,10 @@ trap cleanup EXIT
 trap cleanup ERR
 
 # --- Pre-flight guard ----------------------------------------------------
+# Authenticate first: a dead token found at the push step, after the
+# rewrite and gates, strands finished work. Fail here while it is cheap.
+"${script_dir}/guards/assert-gh-auth.sh"
+
 # Compute the merge base against main, not against whatever HEAD happens to
 # be: a HEAD pointing at an old commit would yield a too-old base and replay
 # already-landed commits as duplicates. Require HEAD to be main (or a
@@ -308,6 +312,10 @@ git checkout -q "${start_checkout}"
 if [[ -n "${prev_rewrite_branch}" && "${prev_rewrite_branch}" != "${authorship_branch}" ]]; then
   git branch -D "${prev_rewrite_branch}" 2>/dev/null || true
 fi
+
+# Prove the rewrite worked before anything is pushed: a fleet-executor
+# identity that reaches protected main cannot be fixed later.
+"${script_dir}/guards/assert-clean-authorship.sh" "${clean_ref}" "${merge_email}"
 # --- end authorship rewrite ----------------------------------------------
 
 if [[ "${dry_run}" == "1" ]]; then
@@ -330,8 +338,35 @@ fi
 # the gate; the failure mode is discovering a red PR ~15 minutes later
 # instead of a red gate now. Never use it when the merged tree diverges
 # from what was already gated (a conflict resolution, a manual edit).
+#
+# The precondition is enforced, not remembered: gates.sh writes a receipt
+# (keyed by tree hash, which the rewrite above preserves) for every full
+# clean-tree run, and skip is honored only when the history about to be
+# pushed has a receipt younger than 24 h. An amend or manual edit changes
+# the tree and voids the receipt.
 if [[ "${FLEET_MERGE_SKIP_GATES:-0}" == "1" ]]; then
-  echo "==> Skipping local pre-flight gates (FLEET_MERGE_SKIP_GATES=1); PR required checks are the gate"
+  skip_tree="$(git rev-parse "${clean_ref}^{tree}")"
+  receipt_file="$(cd "$(git rev-parse --git-common-dir)" && pwd)/gates-pass/${skip_tree}"
+  receipt_ok=0
+  if [[ -f "${receipt_file}" ]]; then
+    if [[ "$(uname)" == "Darwin" ]]; then
+      receipt_mtime="$(stat -f %m "${receipt_file}")"
+    else
+      receipt_mtime="$(stat -c %Y "${receipt_file}")"
+    fi
+    if (( $(date +%s) - receipt_mtime < 86400 )); then
+      receipt_ok=1
+    fi
+  fi
+  if [[ ${receipt_ok} -ne 1 ]]; then
+    echo "fleet-result-merge.sh: FLEET_MERGE_SKIP_GATES=1 refused:" >&2
+    echo "  no gates-pass receipt (< 24 h) for tree ${skip_tree}." >&2
+    echo "  This tree was never taken through a full scripts/gates.sh run here" >&2
+    echo "  (or was amended since). Run the gates, or drop SKIP_GATES and let" >&2
+    echo "  this script run them." >&2
+    exit 65
+  fi
+  echo "==> Skipping local pre-flight gates (receipt found for tree ${skip_tree}); PR required checks re-verify"
 else
   echo "==> Running local pre-flight gates"
   git checkout -q --detach "${clean_ref}"

--- a/scripts/fleet-watch-managed.sh
+++ b/scripts/fleet-watch-managed.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Poll a fleet_dispatch watch endpoint in bounded runs.
+#
+# The harness kills background processes after about 10 minutes, so the
+# unbounded fleet-watch.sh dies unnoticed. This variant polls for at most
+# BUDGET seconds and then exits 75 so the caller relaunches it. Arm it
+# under a Monitor until-loop that relaunches on exit 75. Exit 0 prints
+# the terminal event. Any other exit code is an error; do not relaunch.
+#
+# Usage: fleet-watch-managed.sh <watch-url> [budget-seconds=480] [poll-seconds=20]
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 <watch-url> [budget-seconds] [poll-seconds]" >&2
+  exit 64
+fi
+
+watch_url="$1"
+budget="${2:-480}"
+poll="${3:-20}"
+
+deadline=$(( $(date +%s) + budget ))
+
+while (( $(date +%s) < deadline )); do
+  # The SSE stream drops almost immediately (see fleet-watch.sh). Take the
+  # first data: line of a short-lived connection if one arrives.
+  event_line="$(curl -s --max-time 25 "${watch_url}" 2>/dev/null | grep '^data:' | head -1 || true)"
+  if [[ -n "${event_line}" ]]; then
+    echo "${event_line}"
+    exit 0
+  fi
+  sleep "${poll}"
+done
+
+echo "fleet-watch-managed.sh: budget of ${budget}s elapsed, no terminal event; relaunch me." >&2
+exit 75

--- a/scripts/gates.sh
+++ b/scripts/gates.sh
@@ -133,4 +133,20 @@ if [[ ${want_features} -eq 1 ]]; then
   run_feature_lane flight-sql -p ravel-server -p ravel-sql
 fi
 
+# --- Gates-pass receipt ---------------------------------------------------
+# Record the tree this run passed. fleet-result-merge.sh honors
+# FLEET_MERGE_SKIP_GATES=1 only for a tree with a receipt here. Keyed by
+# TREE hash because the merge path's authorship/squash rewrite changes
+# commit ids but not content. Receipts live in the shared common dir (one
+# file per tree) so worktrees see each other's runs and concurrent
+# sessions never clobber each other. Written only for a full (unscoped)
+# run on a clean tree; a scoped or dirty run does not prove the tree.
+if [[ ${#crate_args[@]} -eq 0 && -z "$(git status --porcelain --untracked-files=no 2>/dev/null)" ]]; then
+  receipt_dir="$(cd "$(git rev-parse --git-common-dir)" && pwd)/gates-pass"
+  mkdir -p "${receipt_dir}"
+  gated_tree="$(git rev-parse 'HEAD^{tree}')"
+  date -u +%Y-%m-%dT%H:%M:%SZ >"${receipt_dir}/${gated_tree}"
+  echo "gates.sh: receipt written for tree ${gated_tree}"
+fi
+
 echo "All gates passed."

--- a/scripts/guards/assert-clean-authorship.sh
+++ b/scripts/guards/assert-clean-authorship.sh
@@ -1,0 +1,78 @@
+#!/bin/sh
+# assert-clean-authorship.sh <ref> [expected-email]
+# Make sure that every commit on <ref> that is not on origin/main has the
+# expected author, committer, and Signed-off-by, and no AI attribution
+# trailer. Exit 0 when clean; exit 1 with the offending commits listed.
+#
+# fleet-result-merge.sh runs this after its authorship rewrite. Run it
+# yourself on any branch you amended by hand, before you push: a wrong
+# identity on protected main cannot be fixed later. The default expected
+# email is `git config user.email`.
+set -u
+
+ref=${1:-}
+expected=${2:-}
+
+if [ -z "$ref" ]; then
+  echo "guard: usage: assert-clean-authorship.sh <ref> [expected-email]" >&2
+  exit 1
+fi
+
+if [ -z "$expected" ]; then
+  expected=$(git config user.email 2>/dev/null) || expected=''
+fi
+if [ -z "$expected" ]; then
+  echo "guard: no expected email: pass one or set git config user.email" >&2
+  exit 1
+fi
+
+base=''
+base=$(git merge-base origin/main "$ref" 2>/dev/null) || {
+  echo "guard: cannot compute merge-base of origin/main and $ref" >&2
+  exit 1
+}
+
+fail=0
+
+bad_ids=''
+bad_ids=$(git log --format='%h %ae %ce' "${base}..${ref}" \
+  | awk -v want="$expected" '$2 != want || $3 != want') || bad_ids=''
+if [ -n "$bad_ids" ]; then
+  echo "guard: commits with wrong author/committer (want $expected):" >&2
+  printf '%s\n' "$bad_ids" >&2
+  fail=1
+fi
+
+for c in $(git rev-list "${base}..${ref}"); do
+  body=$(git log -1 --format=%B "$c")
+  printf '%s\n' "$body" | grep -qi "^Signed-off-by:.*<${expected}>" || {
+    echo "guard: $c missing Signed-off-by <${expected}>" >&2
+    fail=1
+  }
+  wrong_signoff=''
+  wrong_signoff=$(printf '%s\n' "$body" \
+    | grep -i '^Signed-off-by:' | grep -v "<${expected}>") || wrong_signoff=''
+  if [ -n "$wrong_signoff" ]; then
+    echo "guard: $c carries a foreign sign-off:" >&2
+    printf '%s\n' "$wrong_signoff" >&2
+    fail=1
+  fi
+  ai_trailer=''
+  ai_trailer=$(printf '%s\n' "$body" \
+    | grep -iE '^Co-Authored-By:.*(claude|anthropic)|Generated with|Claude-Session:') || ai_trailer=''
+  if [ -n "$ai_trailer" ]; then
+    echo "guard: $c carries an AI attribution trailer:" >&2
+    printf '%s\n' "$ai_trailer" >&2
+    fail=1
+  fi
+done
+
+if [ "$fail" -ne 0 ]; then
+  echo "guard: authorship check FAILED for ${base}..${ref}." >&2
+  echo "guard: rewrite the branch with the correct identity before you push." >&2
+  exit 1
+fi
+
+count=$(git rev-list --count "${base}..${ref}")
+echo "guard: authorship clean on ${count} commit(s) (${base}..${ref})"
+exit 0

--- a/scripts/guards/assert-gh-auth.sh
+++ b/scripts/guards/assert-gh-auth.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# assert-gh-auth.sh [hostname]
+# Make sure that gh can complete an authenticated API call. Exit 0 on
+# success; exit 1 otherwise. Run it before a landing sequence: a dead
+# keychain token found at push time strands committed work. `gh auth
+# status` alone is not enough; it can report a token the API rejects.
+set -u
+
+host=${1:-github.com}
+
+gh auth status --hostname "$host" >/dev/null 2>&1 || {
+  echo "guard: gh has no stored credentials for $host." >&2
+  echo "guard: run 'gh auth login --hostname $host' and retry." >&2
+  exit 1
+}
+
+login=''
+login=$(gh api user -q .login 2>/dev/null) || {
+  echo "guard: gh has credentials for $host but the API rejects them." >&2
+  echo "guard: run 'gh auth refresh --hostname $host' and retry." >&2
+  exit 1
+}
+
+echo "guard: gh authenticated to $host as $login"
+exit 0


### PR DESCRIPTION
A review of a week of orchestrator sessions found five recurring failure classes that were held only by convention: harness-killed background watchers replaced by poll storms, dispatches lost or duplicated on control-plane 5xx, `FLEET_MERGE_SKIP_GATES=1` used on trees the gates never saw, executor authorship reaching PRs unverified, and gh auth failures discovered at push time after the work was done.

This turns each into a mechanical check:

- `gates.sh` writes a tree-hash receipt on every full clean-tree run; `fleet-result-merge.sh` refuses the skip-gates path without a fresh receipt. The authorship rewrite preserves the tree, so gating the result ref still covers the rewritten history.
- `fleet-result-merge.sh` runs `assert-gh-auth.sh` first and `assert-clean-authorship.sh` on the rewritten history before pushing.
- `fleet-watch-managed.sh`: bounded watcher runs (exit 75 = relaunch) for Monitor until-loops.
- `epic-status.sh`: one-call ledger reconciliation against origin task refs and task-branch PRs.
- `fleet-dispatch-intent.sh`: intent-first dispatch bookkeeping on the epic ledger; refuses while a prior intent is unresolved.
- `ci-sweep-cancelled.sh`: reruns cancelled ci runs on open PR heads (they block auto-merge like failures).
- CLAUDE.md and the fleet-task-spec skill document the scripts, the waiting cadence, editing hygiene, and an executor self-check list.

Guards were tested against fixture branches (wrong author, foreign sign-off, AI trailer, missing sign-off, clean) and the receipt logic against fresh/stale/amended trees; the tree-preservation property of the rewrite was verified with a cherry-pick simulation.
