### PR TITLE
chore(deps): drop the arrayref yank exception, the yank was an attack

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -29,19 +29,6 @@ ignore = [
   # forks, pastey and with_builtin_macros, are not drop-in and parquet
   # does not depend on either); revisit if parquet drops paste upstream.
   "RUSTSEC-2024-0436",
-  # arrayref: every published version satisfying blake3's `^0.3.5`
-  # requirement (0.3.5 through 0.3.9, the crates.io max as of 2026-08-20)
-  # is yanked. No RUSTSEC advisory exists for this yank; it is a plain
-  # crates.io yank with no stated reason, not a known vulnerability.
-  # blake3 1.8.6 (latest) still depends on the same `^0.3.5` range, so no
-  # dependency bump avoids it, and downgrading to the last non-yanked
-  # 0.3.4 fails blake3's requirement. arrayref is a small, stable
-  # array-reference macro crate with no history of security advisories;
-  # accepting the currently-locked 0.3.9 (last version published before
-  # the yank) carries no known additional risk. Revisit when blake3 or
-  # arrayref publish a release that resolves this without a yanked
-  # dependency.
-  "arrayref",
 ]
 
 [licenses]


### PR DESCRIPTION
The `arrayref` yank that `deny.toml` works around was part of the crates.io supply-chain attack disclosed by the Rust Security Response Team on 2026-08-20. An attacker with access to the author's account published a malicious `arrayref@0.3.10` depending on a malicious `proc-macro1` whose build script downloaded a payload, and yanked every legitimate version so resolution would move to theirs.

**Ravel was not exposed.** `Cargo.lock` pins `arrayref 0.3.9` (published 2024-09-14), and a locked build never resolves to 0.3.10. The official indicator scan over `~/.cargo/registry/cache` finds none of the malicious crates. The malicious version was live for 86 minutes (07:15–08:41 UTC); the commit adding this exception landed at 09:13 UTC, after it was already deleted, so this repo only ever saw the yank.

**Why remove it now.** The Rust team has unyanked the maliciously-yanked versions, confirmed against the crates.io API: 0.3.5 through 0.3.9 all read `yanked=false`. The exception no longer suppresses anything real, and left in place it would silently accept a future *legitimate* yank of arrayref — a hole in a required check.

`cargo deny check` passes without it, once the local crates.io index is refreshed. A stale index still reports the reverted yank, which is worth knowing if CI disagrees.

The original exception's reasoning was sound on the information available, and its conclusion that the locked 0.3.9 carried no added risk was right.

Refs: https://blog.rust-lang.org/2026/08/20/arrayref-supply-chain-attack/