### PR TITLE
docs(adrs): claim ADR-0097 for the SQL function surface

### DIFF
--- a/docs/adrs/0097-sql-scalar-function-surface.md
+++ b/docs/adrs/0097-sql-scalar-function-surface.md
@@ -1,0 +1,3 @@
+# ADR-0097: The SQL scalar and aggregate function surface
+
+Status: claimed


### PR DESCRIPTION
Reserve the ADR number on main before the full decision record is
written, so a parallel epic cannot pick 0097 at the same time. The full
Context, Decision, and Consequences land over this stub.

Refs: #359