### PR TITLE
feat(logseg): wire NumStat into reader-side range pruning, RLOG inspector v3

### DIFF
--- a/crates/ravel-logseg/src/ranged.rs
+++ b/crates/ravel-logseg/src/ranged.rs
@@ -171,7 +171,7 @@ impl RlogRangeReader {
         };
         let blocks = self
             .skip
-            .candidate_blocks(i64::MIN, i64::MAX, Some(&[stream_ref]));
+            .candidate_blocks(i64::MIN, i64::MAX, Some(&[stream_ref]), &[]);
         if blocks.is_empty() {
             return Ok(None);
         }
@@ -277,7 +277,7 @@ impl RlogRangeReader {
         };
         let blocks = self
             .skip
-            .candidate_blocks(i64::MIN, i64::MAX, Some(&[stream_ref]));
+            .candidate_blocks(i64::MIN, i64::MAX, Some(&[stream_ref]), &[]);
         if blocks.is_empty() {
             return Ok(None);
         }

--- a/crates/ravel-logseg/src/reader.rs
+++ b/crates/ravel-logseg/src/reader.rs
@@ -22,7 +22,7 @@ use crate::record::{
     COL_BODY, COL_FLAGS, COL_OBSERVED_TS, COL_SEVERITY_NUM, COL_SEVERITY_TEXT, COL_SPAN_ID,
     COL_STREAM_REF, COL_TRACE_ID, COL_TS, FieldSel, FieldType, LogRecord, Predicate, resolve_value,
 };
-use crate::skip_index::SkipIndex;
+use crate::skip_index::{NumRangeArm, SkipIndex};
 use crate::stream_dir::StreamDir;
 use crate::tokenizer::tokens;
 use crate::writer::RlogConfig;
@@ -233,10 +233,17 @@ impl<'a> RlogReader<'a> {
             return Ok(self.empty_scan(stats));
         }
 
+        // Numeric-range prune arms (ADR-0095 decision 6): resolved from the
+        // prune-only channel, they drive block pruning through the skip index
+        // and nothing else. An arm whose field does not resolve to a dynamic
+        // column of that exact type contributes zero pruning (the `Ok(None)`
+        // shape of the unindexed POSTINGS path), never an error.
+        let numeric = self.numeric_range_arms(&prune_arms);
+
         // Skip-index pruning.
-        let mut candidates = self
-            .skip
-            .candidate_blocks(ts_min, ts_max, stream_refs.as_deref());
+        let mut candidates =
+            self.skip
+                .candidate_blocks(ts_min, ts_max, stream_refs.as_deref(), &numeric);
         stats.blocks_after_skip = candidates.len() as u32;
 
         // Postings pruning. Exact (not probabilistic): a probed term's block
@@ -456,6 +463,39 @@ impl<'a> RlogReader<'a> {
                 if let Some(entry) = self.field_dir.column(name, ty) {
                     out.push((entry.column_id, term_key(&cv)));
                 }
+            }
+        }
+        out
+    }
+
+    /// Resolves the prune-only `NumRange` arms to [`NumRangeArm`] inputs for
+    /// [`SkipIndex::candidate_blocks`].
+    ///
+    /// Each arm names an attribute and its exact column type; it resolves to the
+    /// dynamic column [`FieldDir::column`] returns for that `(name, type)`. An
+    /// arm whose field does not resolve to such a column -- an unknown name, a
+    /// name stored only under other types, or a non-attribute selector -- yields
+    /// no [`NumRangeArm`] and so prunes nothing, matching the degrade-safe
+    /// fallthrough the unindexed POSTINGS field takes. The bounds pass straight
+    /// through as bit patterns; the range is prune-only, so the exact residual
+    /// stays the caller's (SQL layer's) job (ADR-0095 decision 6, ADR-0013).
+    fn numeric_range_arms(&self, arms: &[&Predicate]) -> Vec<NumRangeArm> {
+        let mut out = Vec::new();
+        for a in arms {
+            if let Predicate::NumRange {
+                field: FieldSel::Attr(name),
+                ty,
+                min,
+                max,
+            } = a
+                && let Some(entry) = self.field_dir.column(name, *ty)
+            {
+                out.push(NumRangeArm {
+                    column_id: entry.column_id,
+                    ty: *ty,
+                    min_bits: *min,
+                    max_bits: *max,
+                });
             }
         }
         out
@@ -699,6 +739,13 @@ fn eval(
             }
         }
         Predicate::Equals { field, value } => equals(field_dir, field, value, block, row)?,
+        // `NumRange` is prune-only (ADR-0095 decision 6): it drives block
+        // pruning through `scan_blocks`'s `prune` channel and is never an exact
+        // per-row filter. Reaching exact evaluation means the caller wired it
+        // into `content`; it matches every row (a no-op) rather than filtering,
+        // and the caller re-evaluates the real, exactly-typed range above the
+        // scan.
+        Predicate::NumRange { .. } => true,
     })
 }
 
@@ -2615,5 +2662,171 @@ mod tests {
         assert!(stats.postings_degraded);
         // No pruning applied, so every record survives.
         assert_eq!(rows.len(), 10);
+    }
+
+    /// A record carrying an i64 attribute `code`, in `stream`, at `ts`.
+    fn rec_code(stream: u8, ts: i64, code: i64) -> LogRecord {
+        let mut r = rec(stream, ts, "msg");
+        r.attrs.push(("code".into(), AttrValue::I64(code)));
+        r
+    }
+
+    /// Decodes an object's level-0 skip index.
+    fn skip_of(obj: &[u8]) -> SkipIndex {
+        let cfg = RlogConfig::default();
+        let footer = open(obj).expect("open");
+        let raw = read_section(obj, footer.section(kind::SKIP_IDX).expect("skip"), &cfg)
+            .expect("read skip");
+        SkipIndex::decode(&raw, MAX_BLOCKS).expect("decode skip")
+    }
+
+    /// Reachability (ADR-0095 decision 6): a `NumRange` prune arm, driven
+    /// through the real public `scan_pruned` entry point, excludes the block
+    /// whose merged-view winner for the column falls outside the range and keeps
+    /// the block whose winner falls inside it.
+    ///
+    /// Two single-record blocks: block 0 resolves `code = 200`, block 1 resolves
+    /// `code = 999`. A prune for `code IN [900, 1000]` must drop block 0 and keep
+    /// block 1. Asserted on `ScanStats` (the block actually left the candidate
+    /// set) and on the returned rows, not on either alone.
+    #[test]
+    fn num_range_prune_excludes_out_of_range_block_keeps_in_range() {
+        let cfg = RlogConfig {
+            block_target_records: 1,
+            ..RlogConfig::default()
+        };
+        let obj = build(cfg, vec![rec_code(0, 0, 200), rec_code(0, 1, 999)]);
+        let reader = RlogReader::new(&obj, &cfg).expect("open");
+
+        let prune = [Predicate::NumRange {
+            field: FieldSel::Attr("code".into()),
+            ty: FieldType::I64,
+            min: Some(900i64 as u64),
+            max: Some(1000i64 as u64),
+        }];
+        let (rows, stats) = reader
+            .scan_pruned(&Predicate::And(Vec::new()), &prune)
+            .expect("scan");
+
+        assert_eq!(stats.blocks_total, 2);
+        assert_eq!(
+            stats.blocks_after_skip, 1,
+            "the out-of-range block (code=200) is pruned by the numeric arm"
+        );
+        assert_eq!(rows.len(), 1, "only the in-range block's record survives");
+        assert_eq!(rows[0].ts_ns, 1);
+        assert_eq!(
+            rows[0]
+                .attrs
+                .iter()
+                .find(|(k, _)| k == "code")
+                .map(|(_, v)| v),
+            Some(&AttrValue::I64(999))
+        );
+    }
+
+    /// Soundness (ADR-0095 decision 6, ADR-0013): a block that resolves no value
+    /// for the arm's column carries no stat for it, and such a block is NEVER
+    /// pruned by the arm -- even though a naive "the block holds no matching
+    /// value" reading would drop it. Getting this backwards silently drops
+    /// correct results.
+    ///
+    /// Three single-record blocks: block 0 resolves `code = 15`, block 1 carries
+    /// no `code` at all (and its resource has none), block 2 resolves
+    /// `code = 999`. A prune for `code IN [10, 20]` keeps block 0 (in range),
+    /// prunes block 2 (out of range), and MUST keep block 1 (no stat). The test
+    /// first proves the premise off the decoded index -- block 1 genuinely has
+    /// no `code` stat -- so it is testing the absent-stat path, not a stat that
+    /// merely happens to overlap.
+    #[test]
+    fn num_range_prune_keeps_block_with_no_stat_for_the_column() {
+        let cfg = RlogConfig {
+            block_target_records: 1,
+            ..RlogConfig::default()
+        };
+        // Block 1 (ts 1) carries no `code`; `rec` gives it only a resource
+        // `service.name`, so no row of block 1 resolves the `code` column.
+        let obj = build(
+            cfg,
+            vec![
+                rec_code(0, 0, 15),
+                rec(0, 1, "no-code"),
+                rec_code(0, 2, 999),
+            ],
+        );
+
+        // Premise: the (code, i64) column exists object-wide, and block 1 has no
+        // stat for it. Blocks are one record each, sorted by ts, so l0[1] is the
+        // no-code block.
+        let fd = field_dir_of(&obj);
+        let cid = fd
+            .column("code", FieldType::I64)
+            .expect("(code, i64) column exists")
+            .column_id;
+        let skip = skip_of(&obj);
+        assert_eq!(skip.l0.len(), 3, "one record per block");
+        assert!(
+            !skip.l0[1].stats.iter().any(|s| s.column_id == cid),
+            "block 1 must genuinely carry no stat for the code column"
+        );
+        assert!(
+            skip.l0[0].stats.iter().any(|s| s.column_id == cid)
+                && skip.l0[2].stats.iter().any(|s| s.column_id == cid),
+            "blocks 0 and 2 do carry a code stat"
+        );
+
+        let reader = RlogReader::new(&obj, &cfg).expect("open");
+        let prune = [Predicate::NumRange {
+            field: FieldSel::Attr("code".into()),
+            ty: FieldType::I64,
+            min: Some(10i64 as u64),
+            max: Some(20i64 as u64),
+        }];
+        let (rows, stats) = reader
+            .scan_pruned(&Predicate::And(Vec::new()), &prune)
+            .expect("scan");
+
+        // Block 2 (code=999) pruned; blocks 0 and 1 survive.
+        assert_eq!(stats.blocks_total, 3);
+        assert_eq!(stats.blocks_after_skip, 2);
+        let by_ts: Vec<i64> = rows.iter().map(|r| r.ts_ns).collect();
+        assert!(
+            by_ts.contains(&1),
+            "the no-stat block must survive: absence is no information, never no match"
+        );
+        assert!(
+            !by_ts.contains(&2),
+            "the out-of-range block (code=999) is pruned"
+        );
+        assert!(by_ts.contains(&0), "the in-range block (code=15) survives");
+    }
+
+    /// A `NumRange` arm whose field does not resolve to a dynamic column of the
+    /// named type prunes nothing (degrade-safe fallthrough), the same way an
+    /// unindexed POSTINGS field does. Here `code` exists as i64 but the arm asks
+    /// for it as f64, which resolves to no column, so every block survives.
+    #[test]
+    fn num_range_prune_unresolved_column_prunes_nothing() {
+        let cfg = RlogConfig {
+            block_target_records: 1,
+            ..RlogConfig::default()
+        };
+        let obj = build(cfg, vec![rec_code(0, 0, 200), rec_code(0, 1, 999)]);
+        let reader = RlogReader::new(&obj, &cfg).expect("open");
+
+        let prune = [Predicate::NumRange {
+            field: FieldSel::Attr("code".into()),
+            ty: FieldType::F64,
+            min: Some(0.0f64.to_bits()),
+            max: Some(1.0f64.to_bits()),
+        }];
+        let (rows, stats) = reader
+            .scan_pruned(&Predicate::And(Vec::new()), &prune)
+            .expect("scan");
+        assert_eq!(
+            stats.blocks_after_skip, stats.blocks_total,
+            "a NumRange over an unresolved (name, type) must not prune"
+        );
+        assert_eq!(rows.len(), 2);
     }
 }

--- a/crates/ravel-logseg/src/record.rs
+++ b/crates/ravel-logseg/src/record.rs
@@ -264,6 +264,37 @@ pub enum Predicate {
         field: FieldSel,
         value: AttrValue,
     },
+    /// Prune-only inclusive numeric range on a dynamic numeric column
+    /// (I64/F64/Bool), selected by attribute name and exact column type.
+    ///
+    /// `min`/`max` are inclusive bounds in the same bit-pattern encoding
+    /// [`crate::block::NumStat`] stores: an `i64` as its two's-complement `u64`,
+    /// an `f64` as `to_bits`, a `bool` as `0`/`1`. `None` is an open end.
+    ///
+    /// This arm may drive block pruning ONLY, through
+    /// [`crate::RlogReader::scan_blocks`]'s `prune` channel (exactly like the
+    /// POSTINGS `Equals` prune channel). It is never an exact per-row filter:
+    /// the caller (the SQL layer, not this crate) re-evaluates the real,
+    /// exactly-typed and exactly-bounded range above the scan. Placing it in the
+    /// `content` channel matches every row rather than filtering (ADR-0095
+    /// decision 6, ADR-0013).
+    ///
+    /// An `f64` bound is ordered by [`crate::block::NumStat`]'s own
+    /// `total_cmp`-based comparison, under which `-0.0 < +0.0` and NaN sorts to
+    /// an extreme -- both disagree with SQL's float equality. A caller building
+    /// a range that should include zero MUST widen it to cover both zero bit
+    /// patterns explicitly, and MUST NOT construct a NaN bound (this pruning
+    /// layer has no way to detect or reject one; a NaN bound silently prunes
+    /// either everything or nothing depending on its sign bit). Neither case is
+    /// reachable through any caller in this crate today; this is a contract
+    /// note for the first caller that builds one (ADR-0095 decision 6's
+    /// planner-side consumer, tracked separately).
+    NumRange {
+        field: FieldSel,
+        ty: FieldType,
+        min: Option<u64>,
+        max: Option<u64>,
+    },
 }
 
 #[cfg(test)]

--- a/crates/ravel-logseg/src/skip_index.rs
+++ b/crates/ravel-logseg/src/skip_index.rs
@@ -64,6 +64,25 @@ pub struct SkipIndex {
     pub l1: Vec<Level1Entry>,
 }
 
+/// A resolved numeric-range prune arm for [`SkipIndex::candidate_blocks`]: the
+/// dynamic column to probe and the inclusive bounds a query wants to keep.
+///
+/// `min_bits`/`max_bits` are in the same bit-pattern encoding
+/// [`NumStat::min_bits`]/[`NumStat::max_bits`] store -- an `i64` as its
+/// two's-complement `u64`, an `f64` as `to_bits`, a `bool` as `0`/`1` -- so the
+/// overlap test reuses the exact type-aware order [`merge_stats`] folds under
+/// (nothing re-implements per-type comparison). `None` is an open end. The
+/// bounds are treated as inclusive, which is always the widen-only choice: a
+/// strict SQL bound resolves to an inclusive arm here, so pruning can only ever
+/// keep a block the exact residual would drop, never the reverse (ADR-0013).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct NumRangeArm {
+    pub column_id: u32,
+    pub ty: FieldType,
+    pub min_bits: Option<u64>,
+    pub max_bits: Option<u64>,
+}
+
 /// Merges the stats of `children` by column id (type-aware min/max, summed
 /// null counts, OR-ed NaN flags).
 fn merge_stats(children: &[Level0Entry]) -> Vec<NumStat> {
@@ -123,6 +142,56 @@ fn max_bits(ty: FieldType, a: u64, b: u64) -> u64 {
     }
 }
 
+/// Strict less-than over two bit patterns in the same per-type order
+/// [`min_bits`]/[`max_bits`] fold under, so a range-overlap test and the stat
+/// merge can never disagree on ordering. `a < b` iff `a` is the pair's minimum
+/// and the two are not equal.
+fn bits_lt(ty: FieldType, a: u64, b: u64) -> bool {
+    a != b && min_bits(ty, a, b) == a
+}
+
+/// True when `arm`'s inclusive bounds cannot overlap `stat`'s recorded
+/// `[min_bits, max_bits]` range -- the only case in which the arm proves the
+/// entry holds no row it can match.
+///
+/// Null rows and NaN rows never satisfy a numeric range, so a stat's min/max
+/// (which bound exactly the non-NaN resolved values, ADR-0095) is the whole
+/// test; `null_count`/`has_nan` are irrelevant to it. A stat whose type does
+/// not match the arm's proves nothing (the reader resolves an arm to one exact
+/// `(name, type)` column, so this is defensive, not expected).
+fn stat_disjoint(stat: &NumStat, arm: &NumRangeArm) -> bool {
+    if stat.ty != arm.ty {
+        return false;
+    }
+    // Query entirely below the block: its top is strictly under the stat's min.
+    if let Some(qmax) = arm.max_bits
+        && bits_lt(stat.ty, qmax, stat.min_bits)
+    {
+        return true;
+    }
+    // Query entirely above the block: its bottom is strictly over the stat's max.
+    if let Some(qmin) = arm.min_bits
+        && bits_lt(stat.ty, stat.max_bits, qmin)
+    {
+        return true;
+    }
+    false
+}
+
+/// True if some numeric arm proves `stats` holds no matching row. An arm whose
+/// column has no stat in `stats` proves nothing and is skipped: absence is "no
+/// information", never "no match" (ADR-0013, and the completeness contract in
+/// this module's header). Pruning on an absent stat would silently drop correct
+/// results, so this degrade-safe fallthrough is unconditional.
+fn numeric_prunes(stats: &[NumStat], numeric: &[NumRangeArm]) -> bool {
+    numeric.iter().any(|arm| {
+        stats
+            .iter()
+            .find(|s| s.column_id == arm.column_id)
+            .is_some_and(|stat| stat_disjoint(stat, arm))
+    })
+}
+
 impl SkipIndex {
     /// Builds the index from level-0 entries, deriving level 1 at fanout 64.
     pub fn build(l0: Vec<Level0Entry>) -> Self {
@@ -152,16 +221,31 @@ impl SkipIndex {
         SkipIndex { l0, l1 }
     }
 
-    /// Block indices whose level-0 entries survive the coarse ts/stream
-    /// predicate. Sound: a block is included unless its bounds prove no record
-    /// matches. `stream_refs`, when given, is the set of stream refs of
-    /// interest; a block survives only if its `[min, max]` ref range contains
-    /// at least one.
+    /// Block indices whose level-0 entries survive the coarse ts/stream and
+    /// numeric-range predicates. Sound: a block is included unless its bounds
+    /// prove no record matches. `stream_refs`, when given, is the set of stream
+    /// refs of interest; a block survives only if its `[min, max]` ref range
+    /// contains at least one.
+    ///
+    /// `numeric` carries the prune-only numeric-range arms (ADR-0095 decision
+    /// 6). Each probes one NumStat-eligible column at both tiers this method
+    /// already prunes at: a whole level-1 group is skipped when its merged stat
+    /// for the column proves no overlap, then a surviving group's individual
+    /// level-0 blocks are skipped the same way. An arm whose column has no stat
+    /// in the entry being tested prunes nothing there -- absence is "no
+    /// information" (ADR-0013), which is why a level-1 group carrying no stat
+    /// for the column is descended into rather than dropped, and a level-0 block
+    /// with none survives. A group *does* carry a merged stat whenever any of
+    /// its children resolve the column; a child that resolves none holds only
+    /// nulls for it (write-path completeness, this module's header), and nulls
+    /// never satisfy a range, so pruning such a group on its merged stat still
+    /// drops no matching row.
     pub fn candidate_blocks(
         &self,
         ts_min: i64,
         ts_max: i64,
         stream_refs: Option<&[u32]>,
+        numeric: &[NumRangeArm],
     ) -> Vec<usize> {
         let mut out = Vec::new();
         for (g, group) in self.l1.iter().enumerate() {
@@ -174,6 +258,9 @@ impl SkipIndex {
             }) {
                 continue;
             }
+            if numeric_prunes(&group.stats, numeric) {
+                continue;
+            }
             let start = g * FANOUT;
             let end = (start + FANOUT).min(self.l0.len());
             for (j, e) in self.l0[start..end].iter().enumerate() {
@@ -183,6 +270,9 @@ impl SkipIndex {
                 if stream_refs
                     .is_some_and(|refs| !refs_intersect(refs, e.min_stream_ref, e.max_stream_ref))
                 {
+                    continue;
+                }
+                if numeric_prunes(&e.stats, numeric) {
                     continue;
                 }
                 out.push(start + j);
@@ -403,7 +493,7 @@ mod tests {
             l0.push(entry(i, t, t + 9, 0, 0));
         }
         let idx = SkipIndex::build(l0);
-        let got = idx.candidate_blocks(30, 55, None);
+        let got = idx.candidate_blocks(30, 55, None, &[]);
         assert_eq!(got, vec![3, 4, 5]);
     }
 
@@ -416,8 +506,194 @@ mod tests {
         }
         let idx = SkipIndex::build(l0);
         let refs = [7u32, 42u32];
-        let got = idx.candidate_blocks(0, 1000, Some(&refs));
+        let got = idx.candidate_blocks(0, 1000, Some(&refs), &[]);
         assert_eq!(got, vec![7, 42]);
+    }
+
+    /// A level-0 entry spanning all ts/streams, carrying one i64 stat for
+    /// `column_id` over `[min, max]`.
+    fn i64_entry(idx: u64, column_id: u32, min: i64, max: i64) -> Level0Entry {
+        let mut e = entry(idx, 0, 1000, 0, 0);
+        e.record_count = 1;
+        e.stats = vec![NumStat {
+            column_id,
+            ty: FieldType::I64,
+            min_bits: min as u64,
+            max_bits: max as u64,
+            null_count: 0,
+            has_nan: false,
+        }];
+        e
+    }
+
+    fn i64_arm(column_id: u32, min: Option<i64>, max: Option<i64>) -> NumRangeArm {
+        NumRangeArm {
+            column_id,
+            ty: FieldType::I64,
+            min_bits: min.map(|v| v as u64),
+            max_bits: max.map(|v| v as u64),
+        }
+    }
+
+    /// A numeric arm drops exactly the level-0 blocks whose stat range is
+    /// disjoint from the query, at both an inclusive lower and upper bound, and
+    /// keeps a block whose range overlaps.
+    #[test]
+    fn candidate_blocks_numeric_range_prunes_disjoint_blocks() {
+        // Block 0: [0,10], block 1: [50,60], block 2: [100,110].
+        let l0 = vec![
+            i64_entry(0, 10, 0, 10),
+            i64_entry(1, 10, 50, 60),
+            i64_entry(2, 10, 100, 110),
+        ];
+        let idx = SkipIndex::build(l0);
+
+        // Range [45, 65] overlaps only block 1.
+        let arm = [i64_arm(10, Some(45), Some(65))];
+        assert_eq!(
+            idx.candidate_blocks(i64::MIN, i64::MAX, None, &arm),
+            vec![1]
+        );
+
+        // Open upper bound: >= 55 keeps blocks 1 and 2, drops block 0.
+        let arm = [i64_arm(10, Some(55), None)];
+        assert_eq!(
+            idx.candidate_blocks(i64::MIN, i64::MAX, None, &arm),
+            vec![1, 2]
+        );
+
+        // Open lower bound: <= 5 keeps only block 0.
+        let arm = [i64_arm(10, None, Some(5))];
+        assert_eq!(
+            idx.candidate_blocks(i64::MIN, i64::MAX, None, &arm),
+            vec![0]
+        );
+    }
+
+    /// The soundness rule of ADR-0095 decision 6: a block with NO stat for the
+    /// arm's column is never pruned by that arm, even though a naive "the block
+    /// holds no value in range" reading would drop it. Block 1 carries no stat
+    /// for column 10; a range that excludes block 0's value must still keep
+    /// block 1.
+    #[test]
+    fn candidate_blocks_numeric_range_never_prunes_a_block_missing_the_stat() {
+        // Block 0 has a stat [0,10]; block 1 has NO stat for column 10. They are
+        // in different level-1 groups (block 1 is the 65th block) so the group
+        // summary cannot prune block 1 either: block 1's own group carries no
+        // stat for the column and is descended into.
+        let mut l0 = vec![i64_entry(0, 10, 0, 10)];
+        for i in 1..FANOUT as u64 {
+            // Filler blocks in group 0, also without the stat, ts-disjoint from
+            // the query below so they never appear in the candidate set.
+            l0.push(entry(i, 5000, 5000, 0, 0));
+        }
+        // Block 64: the no-stat block under test, in level-1 group 1.
+        let mut no_stat = entry(FANOUT as u64, 0, 1000, 0, 0);
+        no_stat.record_count = 1;
+        no_stat.stats = Vec::new();
+        l0.push(no_stat);
+        let idx = SkipIndex::build(l0);
+        assert_eq!(idx.l1.len(), 2, "block 64 forces a second level-1 group");
+
+        // A range far above block 0's [0,10]. Block 0 is pruned; the no-stat
+        // block (index 64) survives -- absence is no information.
+        let arm = [i64_arm(10, Some(1_000_000), None)];
+        let got = idx.candidate_blocks(0, 1000, None, &arm);
+        assert!(
+            !got.contains(&0),
+            "block 0's stat is disjoint, so it prunes"
+        );
+        assert!(
+            got.contains(&(FANOUT)),
+            "a block with no stat for the column must never be pruned by the arm"
+        );
+    }
+
+    /// The level-1 coarse tier prunes too: a whole group whose merged stat is
+    /// disjoint from the query is skipped without descending. 128 blocks (two
+    /// groups): group 0's values are all low, group 1's all high, so a
+    /// high range drops every block of group 0 at the group tier.
+    #[test]
+    fn candidate_blocks_numeric_range_prunes_at_level1_group() {
+        let mut l0 = Vec::new();
+        for i in 0..FANOUT as u64 {
+            l0.push(i64_entry(i, 10, 0, 100));
+        }
+        for i in FANOUT as u64..(2 * FANOUT) as u64 {
+            l0.push(i64_entry(i, 10, 1000, 1100));
+        }
+        let idx = SkipIndex::build(l0);
+        assert_eq!(idx.l1.len(), 2);
+
+        // Range [1050, 1200] overlaps only group 1's blocks.
+        let arm = [i64_arm(10, Some(1050), Some(1200))];
+        let got = idx.candidate_blocks(i64::MIN, i64::MAX, None, &arm);
+        assert_eq!(got.len(), FANOUT, "only the 64 blocks of group 1 survive");
+        assert!(got.iter().all(|&b| b >= FANOUT));
+    }
+
+    /// f64 arms compare by `total_cmp` order (via the shared `min_bits` helper),
+    /// and bool arms by their 0/1 bit, so both prune the same way i64 does.
+    #[test]
+    fn candidate_blocks_numeric_range_f64_and_bool() {
+        let f = |bits_min: f64, bits_max: f64| {
+            let mut e = entry(0, 0, 1000, 0, 0);
+            e.record_count = 1;
+            e.stats = vec![NumStat {
+                column_id: 11,
+                ty: FieldType::F64,
+                min_bits: bits_min.to_bits(),
+                max_bits: bits_max.to_bits(),
+                null_count: 0,
+                has_nan: false,
+            }];
+            e
+        };
+        let idx = SkipIndex::build(vec![f(1.0, 2.0)]);
+        let arm = [NumRangeArm {
+            column_id: 11,
+            ty: FieldType::F64,
+            min_bits: Some(3.0f64.to_bits()),
+            max_bits: Some(4.0f64.to_bits()),
+        }];
+        assert!(
+            idx.candidate_blocks(i64::MIN, i64::MAX, None, &arm)
+                .is_empty(),
+            "f64 [1,2] is disjoint from [3,4]"
+        );
+        let arm = [NumRangeArm {
+            column_id: 11,
+            ty: FieldType::F64,
+            min_bits: Some(1.5f64.to_bits()),
+            max_bits: None,
+        }];
+        assert_eq!(
+            idx.candidate_blocks(i64::MIN, i64::MAX, None, &arm),
+            vec![0]
+        );
+
+        // Bool block carrying only `false` (0), queried for `true` (1): pruned.
+        let mut b = entry(0, 0, 1000, 0, 0);
+        b.record_count = 1;
+        b.stats = vec![NumStat {
+            column_id: 12,
+            ty: FieldType::Bool,
+            min_bits: 0,
+            max_bits: 0,
+            null_count: 0,
+            has_nan: false,
+        }];
+        let idx = SkipIndex::build(vec![b]);
+        let arm = [NumRangeArm {
+            column_id: 12,
+            ty: FieldType::Bool,
+            min_bits: Some(1),
+            max_bits: Some(1),
+        }];
+        assert!(
+            idx.candidate_blocks(i64::MIN, i64::MAX, None, &arm)
+                .is_empty()
+        );
     }
 
     #[test]
@@ -438,7 +714,7 @@ mod tests {
             let idx = SkipIndex::build(l0.clone());
             let qmax = qmin.saturating_add(qspan);
             let refs = [qref];
-            let cands = idx.candidate_blocks(qmin, qmax, Some(&refs));
+            let cands = idx.candidate_blocks(qmin, qmax, Some(&refs), &[]);
             // Soundness: any block that actually contains a matching (ts,ref)
             // pair must be a candidate.
             for (i, e) in l0.iter().enumerate() {

--- a/crates/ravel-logseg/tests/differential.rs
+++ b/crates/ravel-logseg/tests/differential.rs
@@ -184,6 +184,10 @@ fn eval(rec: &LogRecord, pred: &Predicate) -> bool {
                 .iter()
                 .any(|(k, v)| k == name && value_eq(v, value)),
         },
+        // Prune-only (ADR-0095 decision 6): never an exact per-row filter, and
+        // `arb_predicate` never generates it. Mirror the reader's exact channel
+        // (match every row) so the differential stays correct if one appears.
+        Predicate::NumRange { .. } => true,
     }
 }
 

--- a/crates/ravel-sql/src/logs_scan.rs
+++ b/crates/ravel-sql/src/logs_scan.rs
@@ -263,7 +263,10 @@ fn resolve_columns(
 fn content_columns(pred: &Predicate, sel: ColumnSelection) -> ColumnSelection {
     match pred {
         Predicate::And(arms) => arms.iter().fold(sel, |acc, a| content_columns(a, acc)),
-        Predicate::TsRange { .. } | Predicate::StreamIn(_) => sel,
+        // `NumRange` is prune-only (ADR-0095 decision 6): it never reaches the
+        // exact content channel, so it reads no columns, same as ts/stream. The
+        // planner-side pushdown that would emit it is #278's job.
+        Predicate::TsRange { .. } | Predicate::StreamIn(_) | Predicate::NumRange { .. } => sel,
         Predicate::HasWord { field, .. } | Predicate::Equals { field, .. } => match field {
             FieldSel::Body => sel.with_body(),
             FieldSel::SeverityText => sel.with_severity_text(),

--- a/docs/log-segment-format.md
+++ b/docs/log-segment-format.md
@@ -539,11 +539,20 @@ stat range cannot overlap a queried range holds no matching row. Under version
 the block holding the record a range query wanted; that is the defect version 3
 fixes, and it is why a v2 object cannot be read as a v3 one.
 
-`candidate_blocks(ts_min, ts_max, stream_refs)` returns the level-0 block
-indices whose entries survive the coarse predicate. The pruning is sound
-(ADR-0013): a block is dropped only when its min/max bounds prove no
-record in it can match. Precision is not guaranteed; survivors are
-scanned and re-evaluated exactly.
+`candidate_blocks(ts_min, ts_max, stream_refs, numeric)` returns the level-0
+block indices whose entries survive the coarse predicate. Alongside the ts and
+stream-ref bounds, `numeric` carries prune-only inclusive range arms, one per
+NumStat-eligible column: a block is dropped when its stat's min/max for that
+column proves no overlap with the queried range, and a whole level-1 group is
+dropped the same way before its blocks are examined. A column with no stat in
+the entry under test prunes nothing there (absence is "no information"), so a
+level-1 group carrying no stat for the column is descended into and a level-0
+block with none survives. These arms drive block pruning only, through
+`RlogReader::scan_blocks`'s prune channel (ADR-0095 decision 6); the exact,
+exactly-typed range is re-evaluated above the scan by the caller. The pruning is
+sound (ADR-0013): a block is dropped only when its bounds prove no record in it
+can match. Precision is not guaranteed; survivors are scanned and re-evaluated
+exactly.
 
 ## BLOOM
 

--- a/services/ravel-cli/src/main.rs
+++ b/services/ravel-cli/src/main.rs
@@ -1543,14 +1543,33 @@ fn rlog_field_type_name(ty: FieldType) -> &'static str {
 fn rlog_print_stats(stats: &[NumStat]) {
     for st in stats {
         println!(
-            "    stat column_id={} type={} min_bits={} max_bits={} null_count={} has_nan={}",
+            "    stat column_id={} type={} min_bits={} max_bits={} null_count={} has_nan={} \
+             resolved_min={} resolved_max={}",
             st.column_id,
             rlog_field_type_name(st.ty),
             st.min_bits,
             st.max_bits,
             st.null_count,
             st.has_nan,
+            rlog_stat_value(st.ty, st.min_bits),
+            rlog_stat_value(st.ty, st.max_bits),
         );
+    }
+}
+
+/// Decodes a NumStat `min_bits`/`max_bits` bit pattern to its typed value for
+/// display. Under RLOG v3 (ADR-0095) this is the resolved merged-view bound an
+/// operator reasons about when a range prune keeps or drops a block, so the
+/// inspector prints it decoded next to the raw bits rather than leaving an
+/// operator to reinterpret an `i64`-as-`u64` or an `f64::to_bits` pattern by
+/// hand. A NumStat only ever carries a numeric type; the string arms are
+/// defensive and never reached.
+fn rlog_stat_value(ty: FieldType, bits: u64) -> String {
+    match ty {
+        FieldType::I64 => (bits as i64).to_string(),
+        FieldType::F64 => f64::from_bits(bits).to_string(),
+        FieldType::Bool => (bits != 0).to_string(),
+        FieldType::Str | FieldType::Bytes => format!("{bits}"),
     }
 }
 

--- a/services/ravel-cli/tests/fixtures/rlog_inspect.txt
+++ b/services/ravel-cli/tests/fixtures/rlog_inspect.txt
@@ -25,9 +25,9 @@ sections:
   kind=6 name=POSTINGS offset=547 len=66 comp=none uncompressed_len=66
 skip_index level 0 (2 block(s)):
   block[0] offset=0 len=105 crc32c=e97c8ea6 record_count=2 ts_range=[100, 200] stream_ref_range=[0, 0]
-    stat column_id=10 type=i64 min_bits=200 max_bits=504 null_count=0 has_nan=false
+    stat column_id=10 type=i64 min_bits=200 max_bits=504 null_count=0 has_nan=false resolved_min=200 resolved_max=504
   block[1] offset=105 len=109 crc32c=c009cac7 record_count=2 ts_range=[150, 250] stream_ref_range=[1, 1]
-    stat column_id=10 type=i64 min_bits=200 max_bits=401 null_count=0 has_nan=false
+    stat column_id=10 type=i64 min_bits=200 max_bits=401 null_count=0 has_nan=false resolved_min=200 resolved_max=401
 stream_dir (2 entry(ies)):
   stream_ref=0 stream_id=01000000000000000000000000000000 blob_len=27 blocks=[0, 0]
   stream_ref=1 stream_id=02000000000000000000000000000000 blob_len=27 blocks=[1, 1]


### PR DESCRIPTION
Wave 2 of #331, ADR-0095 decision 6. SkipIndex::candidate_blocks now consumes a numeric-range predicate at both the L1 group and L0 block level, using the NumStat bounds Wave 1 made sound. Absence of a stat for a column is never treated as a non-match -- proven by mutation testing in both directions (opus checkpoint review, PASS).

New Predicate::NumRange, prune-only exactly like the existing POSTINGS Equals channel -- never reaches the exact per-row content evaluation. Bound representation reuses NumStat's own bit-pattern comparison rather than a second implementation.

Includes one doc-only addition from the checkpoint review: a contract note on Predicate::NumRange about f64 -0.0/+0.0 and NaN bound handling, for #278's future planner-side consumer (not reachable through any caller in this crate today).

This closes epic #331. Reader-side wiring only -- extracting a NumRange predicate from a SQL declared-column comparison is #278's job, unblocked by this landing.

Fixes: #331