### PR TITLE
feat(ravel-sql): extend fail-closed function gate to all registries

### DIFF
--- a/crates/ravel-sql/Cargo.toml
+++ b/crates/ravel-sql/Cargo.toml
@@ -40,14 +40,30 @@ ravel-rspan = { workspace = true }
 # so this crate never depends on the workspace `arrow` pin directly. See the
 # module docs for the arrow 58 vs workspace-59 pinning note.
 #
-# `sql` is the only feature enabled on top of `default-features = false`: it is
-# what supplies `datafusion-sql` (the sqlparser front end and the SQL-to-
-# LogicalPlan planner) that the `/api/v1/sql` endpoint parses and plans with.
-# Everything the default feature set would otherwise add stays off, and that is
-# deliberate: no parquet/csv/avro/json file formats, no compression codecs, no
-# nested/regex/crypto expression packs. A file-format factory that is not linked
-# cannot be reached by a `CREATE EXTERNAL TABLE` that slipped a parse gate
-# (security invariant 1).
+# `sql` is the only feature enabled on top of `default-features = false`: it
+# supplies `datafusion-sql` (the sqlparser front end and the SQL-to-LogicalPlan
+# planner) that the `/api/v1/sql` endpoint parses and plans with. The flag does
+# keep the file-format factories off: no parquet/csv/avro/json readers, so a
+# `CREATE EXTERNAL TABLE` that slipped the parse gate has nothing to bind to
+# (security invariant 1), and crypto is off (no md5/sha256 in the live surface).
+#
+# `default-features = false` is NOT the control over the expression packs, and
+# must not be read as one. datafusion 54 declares `datafusion-functions`,
+# `-aggregate`, `-table`, and `-window` as MANDATORY dependencies with their own
+# default features on; a flag on this facade edge cannot subtract a mandatory
+# sub-crate's defaults. So the full string, unicode, datetime, math, regex, and
+# encoding scalar packs, all default aggregates and window functions, and the
+# `range`/`generate_series` table functions all resolve regardless of this flag.
+# `datafusion-functions-nested` is linked too (a mandatory dependency of
+# `datafusion-sql`) but its functions are never registered, gated off by the
+# `nested_expressions` feature this flag does leave off.
+#
+# The enforcement mechanism for the SQL function surface is therefore NOT this
+# manifest: it is the per-registry allowlist enumeration in
+# `crate::session::build_session` plus the drift test
+# (`admitted_and_excluded_cover_all_registries_for_every_table`), which
+# deregister every function outside the admitted set and fail closed when an
+# upgrade adds a new one (ADR-0097).
 datafusion = { version = "54", default-features = false, features = ["sql"] }
 
 # `url::Url` appears in the `ObjectStoreRegistry` trait signature, which

--- a/crates/ravel-sql/src/lib.rs
+++ b/crates/ravel-sql/src/lib.rs
@@ -139,8 +139,9 @@ pub use pushdown::Pushdown;
 pub use redact::{RedactError, redact};
 pub use schema::{internal_schema, public_schema};
 pub use session::{
-    EmptyObjectStoreRegistry, LOGS_TABLE, SAMPLES_TABLE, SPANS_TABLE, SessionTable, build_session,
-    session_config,
+    ADMITTED_SCALARS, ADMITTED_TABLE_FUNCTIONS, ADMITTED_WINDOWS, EXCLUDED_SCALARS,
+    EXCLUDED_TABLE_FUNCTIONS, EXCLUDED_WINDOWS, EmptyObjectStoreRegistry, LOGS_TABLE,
+    SAMPLES_TABLE, SPANS_TABLE, SessionTable, build_session, session_config,
 };
 pub use spans_fetcher::{SpanFetchError, SpanFetchOutput, SpanRow, SpanSegmentFetcher};
 pub use spans_provider::SpansTableProvider;

--- a/crates/ravel-sql/src/session.rs
+++ b/crates/ravel-sql/src/session.rs
@@ -31,24 +31,27 @@
 //!   replaced here, so a `CREATE EXTERNAL TABLE`/`COPY` that somehow slipped
 //!   the parse gate has nothing to bind to. `RsegScanExec` does its own I/O
 //!   through `SegmentFetcher` and never consults this registry.
-//! - Aggregate registration is an allowlist (ADR-0022 decision 2): every
-//!   aggregate UDAF the default session registers is enumerated and every name
-//!   outside the admitted set ([`ADMITTED_AGGREGATES`]: `count`, `sum`, `min`,
-//!   `max`, `avg`, `mean`) is deregistered. This backstops the subset check in
+//! - Function registration is an allowlist across every registry (ADR-0022
+//!   decision 2 for aggregates, ADR-0097 decisions 2/4/6 for the rest):
+//!   [`build_session`] enumerates each of `aggregate_functions()`,
+//!   `scalar_functions()`, `window_functions()`, and `table_functions()` and
+//!   deregisters every name outside that registry's admitted set
+//!   ([`ADMITTED_AGGREGATES`], [`ADMITTED_SCALARS`], [`ADMITTED_WINDOWS`],
+//!   [`ADMITTED_TABLE_FUNCTIONS`]). This backstops the subset check in
 //!   crate::validate and fails closed under DataFusion upgrades -- a newly added
-//!   default aggregate is excluded by default rather than silently reachable.
-//!   `avg`/`mean` are admitted (ADR-0022 decisions 3, 4): they stay
-//!   in the admitted set so the deregistration loop keeps them, and their
-//!   built-in accumulator is then replaced by the sequential-fold UDAF
+//!   default function in any registry is excluded by default rather than
+//!   silently reachable. `avg`/`mean` are admitted (ADR-0022 decisions 3, 4):
+//!   they stay in the admitted set so the deregistration loop keeps them, and
+//!   their built-in accumulator is then replaced by the sequential-fold UDAF
 //!   (crate::avg), the same registry-replacement pattern min/max use.
-//! - The `range`/`generate_series` table functions are deregistered
-//!   (checkpoint review finding, not in the original design):
-//!   `SessionContext::new_with_config_rt` calls DataFusion's
-//!   `with_default_features()`, which registers these unconditionally --
-//!   `EmptyObjectStoreRegistry` blocks reading anything, but a table
-//!   function generates rows in memory and needs no store, so
-//!   `SELECT count(*) FROM range(0, 1e18)` would otherwise reach the
-//!   planner as a second, ungoverned data source alongside `samples`.
+//! - The table-function admitted set is empty, so `range`/`generate_series`
+//!   (registered unconditionally by DataFusion's `with_default_features()`
+//!   inside `SessionContext::new_with_config_rt`) are deregistered like any
+//!   other non-admitted name. `EmptyObjectStoreRegistry` blocks reading
+//!   anything, but a table function generates rows in memory and needs no
+//!   store, so `SELECT count(*) FROM range(0, 1e18)` would otherwise reach the
+//!   planner as a second, ungoverned data source alongside the one registered
+//!   table.
 //!
 //! Determinism:
 //! every `repartition_*` knob except aggregation is turned off unconditionally.
@@ -124,16 +127,232 @@ pub enum SessionTable {
 /// enumerates the aggregate UDAFs the default session registers and
 /// deregisters every name outside this set, so exclusion is the default state
 /// and a DataFusion upgrade that adds a default aggregate fails closed.
-/// `avg`/`mean` are admitted (ADR-0022 decision 7) and stay excluded here until their custom UDAF lands.
+/// `avg`/`mean` are admitted (ADR-0022 decisions 3, 4): they are kept in this
+/// set so the deregistration loop preserves the built-in entries, which
+/// [`build_session`] then replaces with the sequential-fold UDAF (crate::avg).
 ///
 /// The complement within the default registrations lives in
 /// [`crate::validate::EXCLUDED_AGGREGATES`]; the two are kept exhaustive by
 /// `admitted_and_excluded_aggregates_cover_the_default_registrations` below.
-///
-/// `avg`/`mean` are admitted (ADR-0022 decisions 3, 4): kept here so
-/// the deregistration loop does not drop them, then their built-in accumulator
-/// is displaced by the sequential-fold UDAF (crate::avg).
 pub const ADMITTED_AGGREGATES: [&str; 6] = ["count", "sum", "min", "max", "avg", "mean"];
+
+/// The v1 SQL scalar allowlist (ADR-0097 decisions 2, 4). [`build_session`]
+/// enumerates the scalar UDFs the default session registers and deregisters
+/// every name outside this set, the same fail-closed pattern
+/// [`ADMITTED_AGGREGATES`] uses. Scalars are pure per-row transforms, so
+/// ADR-0022's sequential-accumulation concern does not apply and the whole
+/// registered surface stays admitted except the eight in [`EXCLUDED_SCALARS`].
+///
+/// Ravel's own per-table scalar UDFs (`label` and `label_match` for Metrics,
+/// `has_word` for Logs) are part of this set: they are registered *after* the
+/// deregistration loop, per table, so they are never enumerated by it, but the
+/// drift test counts them here. No single session registers all three; each
+/// table's session registers the upstream admitted scalars plus that table's
+/// own UDFs (ADR-0097 decision 2: "one upstream set plus a per-table
+/// addendum").
+///
+/// The complement within the upstream default registrations lives in
+/// [`EXCLUDED_SCALARS`]; the two are kept exhaustive by
+/// `admitted_and_excluded_cover_all_registries_for_every_table` below.
+pub const ADMITTED_SCALARS: [&str; 127] = [
+    // Ravel's own per-table scalar UDFs (registered after the loop, per table).
+    "label",
+    "label_match",
+    "has_word",
+    // The upstream datafusion-functions scalar packs (string, unicode,
+    // datetime, math, regex, encoding), minus the eight in EXCLUDED_SCALARS.
+    "abs",
+    "acos",
+    "acosh",
+    "arrow_cast",
+    "arrow_field",
+    "arrow_metadata",
+    "arrow_try_cast",
+    "arrow_typeof",
+    "ascii",
+    "asin",
+    "asinh",
+    "atan",
+    "atan2",
+    "atanh",
+    "bit_length",
+    "btrim",
+    "cast_to_type",
+    "cbrt",
+    "ceil",
+    "char_length",
+    "character_length",
+    "chr",
+    "coalesce",
+    "concat",
+    "concat_ws",
+    "contains",
+    "cos",
+    "cosh",
+    "cot",
+    "date_bin",
+    "date_format",
+    "date_part",
+    "date_trunc",
+    "datepart",
+    "datetrunc",
+    "decode",
+    "degrees",
+    "encode",
+    "ends_with",
+    "exp",
+    "factorial",
+    "find_in_set",
+    "floor",
+    "from_unixtime",
+    "gcd",
+    "get_field",
+    "greatest",
+    "ifnull",
+    "initcap",
+    "instr",
+    "isnan",
+    "iszero",
+    "lcm",
+    "least",
+    "left",
+    "length",
+    "levenshtein",
+    "ln",
+    "log",
+    "log10",
+    "log2",
+    "lower",
+    "lpad",
+    "ltrim",
+    "make_date",
+    "make_time",
+    "named_struct",
+    "nanvl",
+    "nullif",
+    "nvl",
+    "nvl2",
+    "octet_length",
+    "overlay",
+    "pi",
+    "position",
+    "pow",
+    "power",
+    "radians",
+    "regexp_count",
+    "regexp_instr",
+    "regexp_like",
+    "regexp_match",
+    "regexp_replace",
+    "repeat",
+    "replace",
+    "reverse",
+    "right",
+    "round",
+    "row",
+    "rpad",
+    "rtrim",
+    "signum",
+    "sin",
+    "sinh",
+    "split_part",
+    "sqrt",
+    "starts_with",
+    "strpos",
+    "struct",
+    "substr",
+    "substr_index",
+    "substring",
+    "substring_index",
+    "tan",
+    "tanh",
+    "to_char",
+    "to_date",
+    "to_hex",
+    "to_local_time",
+    "to_time",
+    "to_timestamp",
+    "to_timestamp_micros",
+    "to_timestamp_millis",
+    "to_timestamp_nanos",
+    "to_timestamp_seconds",
+    "to_unixtime",
+    "translate",
+    "trim",
+    "trunc",
+    "try_cast_to_type",
+    "union_extract",
+    "union_tag",
+    "upper",
+    "with_metadata",
+];
+
+/// The scalar UDFs the default DataFusion session registers that are **not**
+/// admitted (ADR-0097 decision 4): nondeterministic or environment-reading, so
+/// unattestable by the differential conformance oracle. `uuid`/`random`/`rand`
+/// return a different answer for identical input; `now`/`current_timestamp`/
+/// `current_date`/`current_time` read the wall clock (query-time is available
+/// through the request's own time range); `version` reports the DataFusion
+/// build to any caller. [`build_session`] deregisters these, and the drift test
+/// keeps this list exhaustive against the upstream registrations.
+///
+/// `today` is here even though ADR-0097 decision 4 names only eight: it is a
+/// DataFusion alias of `current_date` (datafusion-functions 54's
+/// `current_date.rs` registers `aliases: vec!["today"]`), so it reads the same
+/// wall clock and is caught by the same rationale. It also cannot be admitted
+/// independently: deregistering `current_date` removes the shared UDF, dropping
+/// the `today` key too, so admitting it would make the drift test fail closed.
+pub const EXCLUDED_SCALARS: [&str; 9] = [
+    "uuid",
+    "random",
+    "rand",
+    "now",
+    "current_timestamp",
+    "current_date",
+    "current_time",
+    "version",
+    "today",
+];
+
+/// The v1 SQL window allowlist (ADR-0097 decision 6). The rank/offset families
+/// carry no floating-point accumulation and are deterministic under the
+/// single-partition rule; `cume_dist`/`percent_rank` return one correctly
+/// rounded IEEE division of two exact integer counts, deterministic and
+/// bit-reproducible. [`build_session`] enumerates `window_functions()` and
+/// deregisters every name outside this set.
+pub const ADMITTED_WINDOWS: [&str; 8] = [
+    "row_number",
+    "rank",
+    "dense_rank",
+    "ntile",
+    "lag",
+    "lead",
+    "cume_dist",
+    "percent_rank",
+];
+
+/// The window UDWFs the default session registers that are **not** admitted
+/// (ADR-0097 decision 6). Until this enumeration existed these three were
+/// refused only incidentally, because their names collide with
+/// [`crate::validate::EXCLUDED_AGGREGATES`], a list written about aggregates.
+/// Deregistering them here makes the refusal explicit and window-aware; whether
+/// they are ever readmitted is a conformance-row decision, not a default.
+pub const EXCLUDED_WINDOWS: [&str; 3] = ["first_value", "last_value", "nth_value"];
+
+/// The v1 SQL table-function allowlist (ADR-0097 decision 2): empty. No table
+/// function is reachable today and none should become reachable by an upstream
+/// addition. [`build_session`] enumerates `table_functions()` and deregisters
+/// every name, replacing the earlier two hardcoded `deregister_udtf` calls so a
+/// DataFusion release adding a third table function cannot ship it into the
+/// surface.
+pub const ADMITTED_TABLE_FUNCTIONS: [&str; 0] = [];
+
+/// The table functions the default session registers, all excluded (ADR-0097
+/// decision 2). `range`/`generate_series` generate rows in memory, so
+/// [`EmptyObjectStoreRegistry`] does not block them; they reach the planner as
+/// a second, ungoverned data source unless deregistered. Kept exhaustive
+/// against the upstream registrations by the drift test.
+pub const EXCLUDED_TABLE_FUNCTIONS: [&str; 2] = ["generate_series", "range"];
 
 /// An `ObjectStoreRegistry` that holds nothing and registers nothing.
 ///
@@ -188,11 +407,11 @@ pub fn session_config(config: &SqlConfig, exact_typed_aggregates: bool) -> Sessi
 /// installed as the query's memory pool.
 ///
 /// `table` selects which single table the session exposes (ADR-0033 decision
-/// C: one signal per query). The aggregate allowlist, the total-order/
-/// sequential-fold UDAF replacements, and the `range`/`generate_series`
-/// deregistration run for both, because those are the hard registration
-/// boundaries behind the parse gate and must not depend on which table is
-/// registered. The table-specific scalar UDFs are registered per table: the
+/// C: one signal per query). The per-registry allowlists (aggregate, scalar,
+/// window, table function), the total-order/sequential-fold UDAF replacements,
+/// and the table-function deregistration run for every table, because those
+/// are the hard registration boundaries behind the parse gate and must not
+/// depend on which table is registered. The table-specific scalar UDFs are registered per table: the
 /// metric `label`/`label_match` UDFs only alongside `samples`, and `has_word`
 /// only alongside `logs`, so the session exposes exactly the surface the one
 /// query needs and no more.
@@ -238,6 +457,40 @@ pub fn build_session(
     for name in &excluded {
         ctx.deregister_udaf(name);
     }
+
+    // The same fail-closed boundary for the scalar registry (ADR-0097
+    // decisions 2, 4). Running before the per-table UDF registration below
+    // keeps this enumeration over upstream defaults only. That order is
+    // defensive, not load-bearing: `label`, `label_match`, and `has_word` are
+    // in ADMITTED_SCALARS, so the filter spares them from either position. It
+    // becomes load-bearing if a Ravel UDF ever leaves that list, which is the
+    // membership `per_table_scalar_udfs_survive_the_scalar_gate` asserts.
+    let excluded_scalars: Vec<String> = ctx
+        .state()
+        .scalar_functions()
+        .keys()
+        .filter(|name| !ADMITTED_SCALARS.contains(&name.to_ascii_lowercase().as_str()))
+        .cloned()
+        .collect();
+    for name in &excluded_scalars {
+        ctx.deregister_udf(name);
+    }
+
+    // And the window registry (ADR-0097 decision 6). Before this enumeration
+    // existed, `first_value`/`last_value`/`nth_value` were refused only because
+    // their names collide with the aggregate deny-list in crate::validate; the
+    // other eight window functions executed with no gate at all.
+    let excluded_windows: Vec<String> = ctx
+        .state()
+        .window_functions()
+        .keys()
+        .filter(|name| !ADMITTED_WINDOWS.contains(&name.to_ascii_lowercase().as_str()))
+        .cloned()
+        .collect();
+    for name in &excluded_windows {
+        ctx.deregister_udwf(name);
+    }
+
     // Replace the built-in min/max with the total-order UDAF (ADR-0023):
     // `register_udaf` inserts by name and displaces the built-in entry, so
     // grouped and ungrouped MIN/MAX over floating point both use the
@@ -255,12 +508,24 @@ pub fn build_session(
     // this line replaces it. This is independent of the public `sum` UDAF,
     // which is untouched (ADR-0024).
     ctx.register_udaf(sequential_avg_udaf());
-    // `with_default_features()` (inside `new_with_config_rt` above)
-    // registers these unconditionally; they generate rows in memory and so
-    // are not blocked by `EmptyObjectStoreRegistry`. `samples` must be the
-    // only table this session can query.
-    ctx.deregister_udtf("range");
-    ctx.deregister_udtf("generate_series");
+    // The table-function registry (ADR-0097 decision 2), enumerated like the
+    // others rather than removed by hardcoded name. `with_default_features()`
+    // (inside `new_with_config_rt` above) registers `range`/`generate_series`
+    // unconditionally; they generate rows in memory and so are not blocked by
+    // `EmptyObjectStoreRegistry`. The admitted set is empty: the one table this
+    // session can query is the one registered below, and a DataFusion release
+    // adding a third table function is deregistered by default instead of
+    // shipping into the surface.
+    let excluded_udtfs: Vec<String> = ctx
+        .state()
+        .table_functions()
+        .keys()
+        .filter(|name| !ADMITTED_TABLE_FUNCTIONS.contains(&name.to_ascii_lowercase().as_str()))
+        .cloned()
+        .collect();
+    for name in &excluded_udtfs {
+        ctx.deregister_udtf(name);
+    }
 
     // Register exactly the one table this query needs, plus that table's own
     // scalar UDFs. A metrics query never sees `has_word` and a logs query
@@ -460,6 +725,253 @@ mod tests {
              registered but unclassified (surface silently widened; add to the admitted set \
              or crate::validate::EXCLUDED_AGGREGATES): {unclassified:?}\n  \
              classified but not registered (stale entry to remove): {stale:?}"
+        );
+    }
+
+    fn empty_snapshot() -> Snapshot {
+        Snapshot {
+            segments: Vec::new(),
+            segments_pruned: 0,
+            pending_erasure: Vec::new(),
+        }
+    }
+
+    fn metrics_table(store: &Arc<dyn ravel_object_store::ObjectStoreBackend>) -> SessionTable {
+        SessionTable::Metrics(Arc::new(crate::provider::RavelTableProvider::new(
+            empty_snapshot(),
+            ravel_types::TenantHash([0u8; 16]),
+            ravel_query::SegmentFetcher::new(store.clone()),
+            SqlConfig::default(),
+            QueryAccounting::new(),
+        )))
+    }
+
+    fn logs_table(store: &Arc<dyn ravel_object_store::ObjectStoreBackend>) -> SessionTable {
+        SessionTable::Logs(Arc::new(crate::logs_provider::LogsTableProvider::new(
+            empty_snapshot(),
+            ravel_types::TenantHash([0u8; 16]),
+            ravel_query::LogSegmentFetcher::new(store.clone()),
+            QueryAccounting::new(),
+        )))
+    }
+
+    fn spans_table(store: &Arc<dyn ravel_object_store::ObjectStoreBackend>) -> SessionTable {
+        SessionTable::Spans(Arc::new(crate::spans_provider::SpansTableProvider::new(
+            empty_snapshot(),
+            ravel_types::TenantHash([0u8; 16]),
+            SpanSegmentFetcher::new(store.clone()),
+            QueryAccounting::new(),
+        )))
+    }
+
+    /// ADR-0097 decisions 2, 3, 4, 6: the fail-closed boundary now covers all
+    /// four registries, not aggregates alone. For every table variant and every
+    /// registry, the admitted and excluded name sets must be disjoint, must
+    /// together cover exactly the upstream default registrations (so a
+    /// DataFusion upgrade that adds any function to any registry fails this test
+    /// naming it), and a session built by [`build_session`] must register
+    /// exactly the upstream admitted names plus that table's own Ravel UDFs (so
+    /// a per-table UDF that goes missing or lands on the wrong table also fails
+    /// it). All comparisons are lowercased.
+    #[test]
+    fn admitted_and_excluded_cover_all_registries_for_every_table() {
+        use std::collections::BTreeSet;
+
+        fn set<'a>(names: impl IntoIterator<Item = &'a &'a str>) -> BTreeSet<String> {
+            names.into_iter().map(|n| n.to_ascii_lowercase()).collect()
+        }
+        fn keys(names: impl Iterator<Item = String>) -> BTreeSet<String> {
+            names.map(|n| n.to_ascii_lowercase()).collect()
+        }
+
+        /// Assert one registry for one table. `admitted`/`excluded` are the
+        /// full per-registry constants (scalar admits include Ravel's own
+        /// UDFs); `all_ravel` is every Ravel-added name in this registry across
+        /// all tables (empty except for scalars); `ravel_for_table` is the
+        /// subset registered for THIS table; `default_upstream` is what a plain
+        /// `SessionContext::new()` registers; `registered` is what
+        /// `build_session` left after the gate.
+        #[allow(clippy::too_many_arguments)]
+        fn check(
+            table: &str,
+            registry: &str,
+            admitted: &BTreeSet<String>,
+            excluded: &BTreeSet<String>,
+            all_ravel: &BTreeSet<String>,
+            ravel_for_table: &BTreeSet<String>,
+            default_upstream: &BTreeSet<String>,
+            registered: &BTreeSet<String>,
+        ) {
+            let overlap: Vec<&String> = admitted.intersection(excluded).collect();
+            assert!(
+                overlap.is_empty(),
+                "{table}/{registry}: names in both admitted and excluded: {overlap:?}"
+            );
+
+            // The upstream slice of the admitted set (Ravel's own UDFs are not
+            // upstream defaults) plus the excluded set must exactly cover the
+            // default registrations. This is the drift guard.
+            let admitted_upstream: BTreeSet<String> =
+                admitted.difference(all_ravel).cloned().collect();
+            let classified: BTreeSet<String> = admitted_upstream.union(excluded).cloned().collect();
+            let unclassified: Vec<&String> = default_upstream.difference(&classified).collect();
+            let stale: Vec<&String> = classified.difference(default_upstream).collect();
+            assert!(
+                unclassified.is_empty() && stale.is_empty(),
+                "{table}/{registry}: allowlist/excluded drifted from the default registrations.\n  \
+                 registered but unclassified (surface widened; admit it or add to the excluded list): {unclassified:?}\n  \
+                 classified but not registered (stale entry to remove): {stale:?}"
+            );
+
+            // build_session must leave exactly the upstream admitted names plus
+            // this table's own Ravel UDFs: nothing excluded survives, and the
+            // per-table UDFs land on the right table.
+            let expected: BTreeSet<String> =
+                admitted_upstream.union(ravel_for_table).cloned().collect();
+            let missing: Vec<&String> = expected.difference(registered).collect();
+            let extra: Vec<&String> = registered.difference(&expected).collect();
+            assert!(
+                missing.is_empty() && extra.is_empty(),
+                "{table}/{registry}: build_session registrations differ from the admitted set.\n  \
+                 admitted but not registered (per-table UDF missing, or gate dropped it): {missing:?}\n  \
+                 registered but not admitted (gate failed to remove it, or wrong table): {extra:?}"
+            );
+        }
+
+        // Upstream default registrations, the reference every registry covers.
+        let default = SessionContext::new();
+        let dstate = default.state();
+        let default_scalars = keys(dstate.scalar_functions().keys().cloned());
+        let default_windows = keys(dstate.window_functions().keys().cloned());
+        let default_aggregates = keys(dstate.aggregate_functions().keys().cloned());
+        let default_tables = keys(dstate.table_functions().keys().cloned());
+
+        let admitted_scalars = set(ADMITTED_SCALARS.iter());
+        let excluded_scalars = set(EXCLUDED_SCALARS.iter());
+        let admitted_windows = set(ADMITTED_WINDOWS.iter());
+        let excluded_windows = set(EXCLUDED_WINDOWS.iter());
+        let admitted_aggregates = set(ADMITTED_AGGREGATES.iter());
+        let excluded_aggregates = set(crate::validate::EXCLUDED_AGGREGATES.iter());
+        let admitted_tables = set(ADMITTED_TABLE_FUNCTIONS.iter());
+        let excluded_tables = set(EXCLUDED_TABLE_FUNCTIONS.iter());
+
+        // Every Ravel-added scalar UDF across all tables, and the per-table
+        // subset. Non-scalar registries have no per-table addendum.
+        let all_ravel_scalars = set(["label", "label_match", "has_word"].iter());
+        let empty: BTreeSet<String> = BTreeSet::new();
+
+        let store: Arc<dyn ravel_object_store::ObjectStoreBackend> = Arc::new(MemoryStore::new());
+
+        for (table_label, table, ravel_scalars) in [
+            (
+                "metrics",
+                metrics_table(&store),
+                set(["label", "label_match"].iter()),
+            ),
+            ("logs", logs_table(&store), set(["has_word"].iter())),
+            ("spans", spans_table(&store), empty.clone()),
+        ] {
+            let ctx = build_session(&SqlConfig::default(), test_pool(), table, false)
+                .expect("session builds");
+            let state = ctx.state();
+            let reg_scalars = keys(state.scalar_functions().keys().cloned());
+            let reg_windows = keys(state.window_functions().keys().cloned());
+            let reg_aggregates = keys(state.aggregate_functions().keys().cloned());
+            let reg_tables = keys(state.table_functions().keys().cloned());
+
+            check(
+                table_label,
+                "scalar",
+                &admitted_scalars,
+                &excluded_scalars,
+                &all_ravel_scalars,
+                &ravel_scalars,
+                &default_scalars,
+                &reg_scalars,
+            );
+            check(
+                table_label,
+                "window",
+                &admitted_windows,
+                &excluded_windows,
+                &empty,
+                &empty,
+                &default_windows,
+                &reg_windows,
+            );
+            check(
+                table_label,
+                "aggregate",
+                &admitted_aggregates,
+                &excluded_aggregates,
+                &empty,
+                &empty,
+                &default_aggregates,
+                &reg_aggregates,
+            );
+            check(
+                table_label,
+                "table",
+                &admitted_tables,
+                &excluded_tables,
+                &empty,
+                &empty,
+                &default_tables,
+                &reg_tables,
+            );
+        }
+    }
+
+    /// Ravel's per-table UDFs survive the scalar gate: a logs session keeps
+    /// `has_word`, a metrics session keeps `label`/`label_match`.
+    ///
+    /// They survive by membership in [`ADMITTED_SCALARS`], not by the
+    /// deregistration loop running before registration, so this test does not
+    /// pin that ordering: inverting the two leaves every assertion here
+    /// passing. What it pins is the membership that makes the ordering safe to
+    /// get wrong, which is why the membership is asserted directly below.
+    #[test]
+    fn per_table_scalar_udfs_survive_the_scalar_gate() {
+        for name in ["label", "label_match", "has_word"] {
+            assert!(
+                ADMITTED_SCALARS.contains(&name),
+                "{name} must stay in ADMITTED_SCALARS: the scalar gate spares \
+                 Ravel's own UDFs by admitting them, and dropping one here \
+                 makes the loop's position relative to per-table registration \
+                 load-bearing"
+            );
+        }
+
+        let store: Arc<dyn ravel_object_store::ObjectStoreBackend> = Arc::new(MemoryStore::new());
+
+        let logs = build_session(
+            &SqlConfig::default(),
+            test_pool(),
+            logs_table(&store),
+            false,
+        )
+        .expect("logs session builds");
+        assert!(
+            logs.state().scalar_functions().contains_key("has_word"),
+            "a logs session must keep has_word after the scalar gate"
+        );
+
+        let metrics = build_session(
+            &SqlConfig::default(),
+            test_pool(),
+            metrics_table(&store),
+            false,
+        )
+        .expect("metrics session builds");
+        let metrics_state = metrics.state();
+        let metrics_scalars = metrics_state.scalar_functions();
+        assert!(
+            metrics_scalars.contains_key("label"),
+            "a metrics session must keep label after the scalar gate"
+        );
+        assert!(
+            metrics_scalars.contains_key("label_match"),
+            "a metrics session must keep label_match after the scalar gate"
         );
     }
 

--- a/docs/adrs/0033-sql-query-over-logs.md
+++ b/docs/adrs/0033-sql-query-over-logs.md
@@ -219,6 +219,15 @@ registers a hand-written `ExprPlanner` covering only the map-field case, so
 this ADR weighed therefore survives intact: the subscript is supported and
 the dependency surface did not grow.
 
+**Amended 2026-08-20 (ADR-0097):** "the dependency surface did not grow" is
+true of the *registration* but not the *dependency* under DataFusion 54. The
+registration did not grow — `map_field_planner.rs`'s hand-written `ExprPlanner`
+still does that work and `nested_expressions` stays off — but
+`datafusion-functions-nested` is compiled in, arriving as a mandatory
+dependency of `datafusion-sql`. It is linked but never registered, so no array
+function reaches the surface; the distinction is between what is compiled and
+what is reachable. See ADR-0097 and the `crates/ravel-sql/Cargo.toml` comment.
+
 The paragraph above is left as written because an ADR records what was
 decided and why, and the reasoning that made fail-loud acceptable for v1 is
 still the reasoning that governs any construct outside the subset. Only the


### PR DESCRIPTION
Extends the fail-closed function-registry gate in `build_session` from
aggregates alone to the scalar, window, and table registries, each against an
explicit admitted list, per ADR-0097 decisions 2, 3, 4 and 6.

Before this, `build_session` enumerated `aggregate_functions()` and nothing
else. A live session registered 134 scalar and 11 window functions with no
allowlist and no drift test, so `uuid()` was callable inside a query and eight
window functions executed end to end. ADR-0022's promise that the surface
fails closed on a DataFusion upgrade held for one registry of three.

Table functions were removed by two hardcoded names, which an upstream
addition would have walked straight past; that is now an enumeration against
an empty admitted set, which is strictly stronger.

The drift test is generalised across all three `SessionTable` variants and all
four registries. It was verified falsifiable three ways during review: removing
`abs` from the scalar allowlist, removing `lag` from the window allowlist, and
simulating an upstream addition by skipping a deregistration each produce a
failure naming the function.

Two review findings were fixed before this PR. A comment claimed a test proved
the scalar loop must run before per-table UDF registration; inverting the two
left every test passing, because `label`, `label_match` and `has_word` are in
`ADMITTED_SCALARS` and survive from either position. The comment now states
that honestly and an assertion pins the membership the ordering safety rests
on, so removing one of those names fails and points at the coupling. The
commit message carried the same false claim and was corrected.

Also corrects three stale statements found alongside: the `Cargo.toml`
rationale comment (`default-features = false` never disabled the mandatory
sub-crate expression packs), the `ADMITTED_AGGREGATES` comment about avg/mean,
and ADR-0033's "the dependency surface did not grow" note.

Fixes: #372
