### PR TITLE
fix(ingest): count Label struct overhead in byte estimators

### DIFF
--- a/crates/ravel-ingest/src/shard.rs
+++ b/crates/ravel-ingest/src/shard.rs
@@ -32,7 +32,7 @@ use ravel_segment::{
     SeriesValues,
 };
 use ravel_types::{
-    CommitToken, ExemplarCap, LabelSet, Sample, SeriesId, Signal, TenantHash, TenantId,
+    CommitToken, ExemplarCap, Label, LabelSet, Sample, SeriesId, Signal, TenantHash, TenantId,
 };
 use tokio::sync::{Semaphore, mpsc, oneshot};
 use tokio::task::JoinSet;
@@ -196,8 +196,13 @@ impl TenantBuf {
     }
 
     /// Merges `points` into this buffer, returning the estimated byte cost
-    /// added (samples * 16 plus label bytes the first time a series is
-    /// seen), per docs/ingest.md's `est_bytes` rule.
+    /// added (samples * 16, plus each label's `Label` struct header and its
+    /// name/value bytes the first time a series is seen), per
+    /// docs/ingest.md's `est_bytes` rule. The header term is the same one
+    /// [`IngestPoint::est_charge_bytes`] and [`IngestExemplar::est_bytes`]
+    /// apply: a `Label` is two `String` headers whatever the strings hold, so
+    /// leaving it out understates a label-heavy buffer by roughly an order of
+    /// magnitude and both flush triggers fire late.
     ///
     /// Fails loud on a series-id collision (ADR-0005) or a value-kind
     /// mismatch (a series is scalar or
@@ -253,7 +258,7 @@ impl TenantBuf {
                     let label_bytes: usize = point
                         .labels
                         .iter()
-                        .map(|l| l.name.len() + l.value.len())
+                        .map(|l| size_of::<Label>() + l.name.len() + l.value.len())
                         .sum();
                     bytes_added += label_bytes;
                     vac.insert(SeriesAccum {
@@ -1371,5 +1376,85 @@ mod adaptive_delay_tests {
                  unconditionally"
             );
         }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod buffer_accounting_tests {
+    use super::*;
+
+    fn labels_of(count: usize) -> LabelSet {
+        let labels = (0..count)
+            .map(|i| Label {
+                name: format!("k{i}"),
+                value: "v".to_string(),
+            })
+            .collect();
+        LabelSet::new(labels).expect("distinct label names")
+    }
+
+    fn point(series: u8, labels: LabelSet) -> IngestPoint {
+        let mut id = [0u8; 16];
+        id[0] = series;
+        IngestPoint {
+            series_id: SeriesId(id),
+            labels,
+            value: IngestValue::Scalar(Sample {
+                ts_ns: 1_000,
+                value: 1.0,
+            }),
+        }
+    }
+
+    /// The flush triggers read `TenantBuf::est_bytes`; the process-wide ceiling
+    /// reads `IngestPoint::est_charge_bytes`. On a batch of first-sighting
+    /// series the two must produce the same number, or one of them is lying
+    /// about the same bytes -- which is exactly how the label-header term went
+    /// missing from the budget side while the exemplar side kept it.
+    #[test]
+    fn merge_accounting_matches_the_budget_charge() {
+        for width in [1usize, 10, 64] {
+            let points: Vec<IngestPoint> = (0..3u8)
+                .map(|i| {
+                    let mut labels: Vec<Label> = labels_of(width).iter().cloned().collect();
+                    labels.push(Label {
+                        name: "series".to_string(),
+                        value: i.to_string(),
+                    });
+                    point(i, LabelSet::new(labels).expect("distinct label names"))
+                })
+                .collect();
+            let charged: u64 = points.iter().map(IngestPoint::est_charge_bytes).sum();
+
+            let mut buf = TenantBuf::default();
+            let added = buf
+                .merge(points, 1_000)
+                .expect("distinct series ids, one value kind") as u64;
+
+            assert_eq!(
+                added, charged,
+                "{width} labels: buffer counted {added} bytes, budget charged {charged}"
+            );
+            assert_eq!(buf.est_bytes as u64, charged);
+        }
+    }
+
+    /// A second point for a series already in the buffer costs only its sample:
+    /// the label bytes (headers included) are already counted. This is the
+    /// deliberate asymmetry with `est_charge_bytes`, which cannot see buffer
+    /// state and so over-counts in the safe direction.
+    #[test]
+    fn repeat_series_adds_only_the_sample() {
+        let labels = labels_of(10);
+        let mut buf = TenantBuf::default();
+        let first = buf
+            .merge(vec![point(1, labels.clone())], 1_000)
+            .expect("first sighting");
+        let repeat = buf
+            .merge(vec![point(1, labels)], 2_000)
+            .expect("same series again");
+        assert_eq!(repeat, 16, "a repeat sighting charges the sample only");
+        assert_eq!(first, 16 + 10 * (size_of::<Label>() + 3));
     }
 }

--- a/crates/ravel-ingest/src/value.rs
+++ b/crates/ravel-ingest/src/value.rs
@@ -134,19 +134,116 @@ impl IngestPoint {
     /// ingest byte budget's admission charge (ADR-0069, [`crate::IngestByteBudget`]).
     ///
     /// Mirrors `TenantBuf::merge`'s `est_bytes` rule -- 16 bytes per sample plus
-    /// the label name/value bytes -- but counts label bytes for *every* point,
-    /// not only the first sighting of a series in a buffer: the charge happens
-    /// before routing, without the shard's buffer state, so it cannot know
-    /// which series are already present. That makes the charge a deliberate
-    /// slight over-estimate of what finally lands in the buffer, which is the
-    /// safe direction for a memory ceiling (it sheds a touch early rather than
-    /// a touch late).
+    /// each label's `Label` struct header and its name/value bytes, the same
+    /// per-label rule [`IngestExemplar::est_bytes`] applies -- but counts label
+    /// bytes for *every* point, not only the first sighting of a series in a
+    /// buffer: the charge happens before routing, without the shard's buffer
+    /// state, so it cannot know which series are already present. That makes
+    /// the charge a deliberate slight over-estimate of what finally lands in
+    /// the buffer, which is the safe direction for a memory ceiling (it sheds a
+    /// touch early rather than a touch late).
+    ///
+    /// The header term is what the buffer actually holds: a `Label` is two
+    /// `String` headers (24 bytes each) whatever the strings contain, so
+    /// counting only `name.len() + value.len()` undercharges a ten-label series
+    /// with short values by about 480 bytes against the roughly 200 it counts,
+    /// and the error grows with label count. Undercharging the ceiling is the
+    /// unsafe direction: the process passes a limit it believes it is under.
     pub(crate) fn est_charge_bytes(&self) -> u64 {
         let label_bytes: u64 = self
             .labels
             .iter()
-            .map(|l| (l.name.len() + l.value.len()) as u64)
+            .map(|l| (size_of::<Label>() + l.name.len() + l.value.len()) as u64)
             .sum();
         16 + label_bytes
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+    use ravel_types::Exemplar;
+
+    fn labels_of(count: usize) -> LabelSet {
+        let labels = (0..count)
+            .map(|i| Label {
+                name: format!("k{i}"),
+                value: "v".to_string(),
+            })
+            .collect();
+        LabelSet::new(labels).expect("distinct label names")
+    }
+
+    fn point_with(labels: LabelSet) -> IngestPoint {
+        IngestPoint {
+            series_id: SeriesId([0u8; 16]),
+            labels,
+            value: IngestValue::Scalar(Sample {
+                ts_ns: 1_000,
+                value: 1.0,
+            }),
+        }
+    }
+
+    fn exemplar_with(labels: LabelSet) -> IngestExemplar {
+        IngestExemplar {
+            series_id: SeriesId([0u8; 16]),
+            exemplar: Exemplar {
+                ts_ns: 1_000,
+                value_bits: 1.0f64.to_bits(),
+                trace_id: [0u8; 16],
+                span_id: [0u8; 8],
+                filtered_attributes: labels.iter().cloned().collect(),
+            },
+        }
+    }
+
+    /// The two buffered-byte estimators must charge one label the same way, or
+    /// the process-wide ceiling and the exemplar accounting drift apart again.
+    ///
+    /// Two bounds, both stated here so a future edit has to break one of them:
+    /// the per-label part of each estimate is byte-identical at every width,
+    /// and once labels dominate the fixed struct overheads (10 labels and up)
+    /// the totals stay within 25% of each other. At one label the fixed
+    /// overheads still dominate -- an `IngestExemplar` carries a trace id, a
+    /// span id, and a `Vec` header where a point carries 16 bytes of sample --
+    /// so only the per-label bound is meaningful there.
+    #[test]
+    fn both_estimators_charge_a_label_the_same_way() {
+        for width in [1usize, 10, 64] {
+            let labels = labels_of(width);
+            let point = point_with(labels.clone());
+            let exemplar = exemplar_with(labels);
+
+            let point_labels = point.est_charge_bytes() - 16;
+            let exemplar_attrs = (exemplar.est_bytes() - size_of::<IngestExemplar>()) as u64;
+            assert_eq!(
+                point_labels, exemplar_attrs,
+                "{width} labels: point charges {point_labels} label bytes, \
+                 exemplar charges {exemplar_attrs}"
+            );
+
+            // Every label costs at least a `Label` header, whatever its strings
+            // hold. This is the specific undercount the pin exists to catch:
+            // dropping the header term leaves 3 to 4 bytes per label here.
+            assert!(
+                point_labels >= (width * size_of::<Label>()) as u64,
+                "{width} labels: {point_labels} bytes charged is below the \
+                 {} bytes of `Label` headers the buffer holds",
+                width * size_of::<Label>()
+            );
+
+            if width >= 10 {
+                let ratio = point.est_charge_bytes() as f64 / exemplar.est_bytes() as f64;
+                assert!(
+                    (0.75..=1.25).contains(&ratio),
+                    "{width} labels: estimator ratio {ratio} outside [0.75, 1.25] \
+                     (point {}, exemplar {})",
+                    point.est_charge_bytes(),
+                    exemplar.est_bytes()
+                );
+            }
+        }
     }
 }

--- a/crates/ravel-ingest/tests/byte_budget.rs
+++ b/crates/ravel-ingest/tests/byte_budget.rs
@@ -23,12 +23,13 @@ use ravel_object_store::memory::MemoryStore;
 use ravel_types::Signal;
 
 /// A single-point write's charge, per [`IngestPoint::est_charge_bytes`]: 16
-/// bytes for the sample plus the label name/value bytes. `make_point(_, "m",
+/// bytes for the sample plus, per label, the `Label` struct header (two
+/// `String` headers, 48 bytes) and the name/value bytes. `make_point(_, "m",
 /// &[], ..)` carries exactly one label, `__name__="m"` (8 + 1 bytes), so the
-/// charge is 16 + 9 = 25. Hard-coded here on purpose: a change to the estimate
-/// formula must break this test, not silently shift the ceiling arithmetic
-/// below.
-const PER_POINT_CHARGE: u64 = 25;
+/// charge is 16 + 48 + 9 = 73. Hard-coded here on purpose: a change to the
+/// estimate formula must break this test, not silently shift the ceiling
+/// arithmetic below.
+const PER_POINT_CHARGE: u64 = 73;
 
 fn budgeted_router(
     store: Arc<dyn ObjectStoreBackend>,
@@ -60,9 +61,9 @@ async fn ceiling_shed_before_buffering() {
     let store: Arc<dyn ObjectStoreBackend> = fault_store.clone();
     let clock = TestClock::new(1_700_000_000_000_000_000);
 
-    // Ceiling admits two single-point writes (2 * 25 = 50) but not a third
-    // (50 + 25 = 75 > 60).
-    let budget = IngestByteBudget::shared(IngestByteBudgetLimit::Bounded(60));
+    // Ceiling admits two single-point writes (2 * 73 = 146) but not a third
+    // (146 + 73 = 219 > 180).
+    let budget = IngestByteBudget::shared(IngestByteBudgetLimit::Bounded(180));
     let router = budgeted_router(store, clock.clone(), budget.clone(), 2);
 
     // Hold every data-object PUT so the two fill flushes stay in flight,
@@ -71,7 +72,7 @@ async fn ceiling_shed_before_buffering() {
     let gate = fault_store.hold(Op::Put, Some("/l0/".to_string()), Occurrence::Always);
 
     // Two tenants, each one point, each flushing immediately (target_bytes 8 <
-    // the 25-byte point) and parking at the held data PUT.
+    // the 73-byte point) and parking at the held data PUT.
     let mut fills = Vec::new();
     for name in ["acme", "globex"] {
         let router = Arc::clone(&router);
@@ -96,7 +97,7 @@ async fn ceiling_shed_before_buffering() {
         "both fills' charges are held on the gauge while their flushes are in flight"
     );
 
-    // A third write would charge 25 more (75 > 60): it must shed before
+    // A third write would charge 73 more (219 > 180): it must shed before
     // routing. Buffered mode so the assertion does not depend on ack timing;
     // the shed happens in `write_points` before any shard is touched
     // regardless of mode.

--- a/docs/ingest.md
+++ b/docs/ingest.md
@@ -162,7 +162,13 @@ Single task per shard. No locks on the hot path; all state actor-local:
 - `exemplars: Vec<IngestExemplar>` in arrival order, one per exemplar the wire
   admitted for a series routed to this shard (ADR-0047)
 - `est_bytes`: running estimate (samples * 16 + label bytes on first sight,
-  plus ~40 bytes and its attribute strings per buffered exemplar)
+  plus the `IngestExemplar` struct width and its attribute bytes per buffered
+  exemplar). "Label bytes" means what the buffer holds, not what the object
+  will hold: each label costs `size_of::<Label>()` (two `String` headers, 48
+  bytes) plus its name and value bytes. Leaving the header term out
+  understates a ten-label series by roughly 480 bytes against the 200 it
+  counts, so both flush triggers and the process-wide budget below fire late
+  on exactly the label-heavy workloads they exist to bound.
 - `oldest_ns`: ingest-arrival time of the oldest buffered point
 - `waiters: Vec<oneshot::Sender<...>>` for strict-mode acks in this flush window
 - writer identity: (writer_id uuid, epoch, next_seq) owned by the process
@@ -513,9 +519,9 @@ covers every signal.
 
 Each ingest write charges its estimated buffered bytes into the gauge in the
 router's write path, after decode/normalize/admission and before any shard
-buffer is touched (`IngestPoint::est_charge_bytes`: 16 bytes per sample plus
-the point's label name/value bytes, plus each exemplar's buffered width). If
-the charge would push the gauge past the ceiling
+buffer is touched (`IngestPoint::est_charge_bytes`: 16 bytes per sample plus,
+per label, the `Label` struct header and the name/value bytes, plus each
+exemplar's buffered width). If the charge would push the gauge past the ceiling
 (`--max-ingest-buffer-bytes`, default 512 MiB, `0` = unlimited) the request
 is shed *before* buffering: no shard is touched, no commit token is minted,
 the shed counter increments, and the caller gets HTTP 429 with `Retry-After`
@@ -539,9 +545,13 @@ terms:
    This ceiling covers the estimated bytes of every shard buffer *and* every
    in-flight pipelined flush across all tenants and signals at once, since a
    flush's buffer stays charged until its PUTs complete. The charge is an
-   estimate (`est_charge_bytes`), a deliberate slight over-count of the live
-   buffer (it counts a series' label bytes on every point, not only first
-   sight), so the true buffered RSS is at or below this term.
+   estimate (`est_charge_bytes`). It counts a series' label bytes on every
+   point rather than only on first sight, which over-counts, and it counts
+   neither `HashMap` overhead nor allocator slack, which under-counts by
+   more. The second effect dominates: measured on a 50k-series, 11-label
+   buffered workload, the charged figure was 38.4 MB against a 69.3 MB
+   resident delta. Size a host for roughly twice this ceiling, not for the
+   ceiling itself.
 2. **In-flight decode overhead**: each admitted in-flight request transiently
    holds one decoded/normalized request body during normalization, before its
    points reach a buffer. This is bounded by


### PR DESCRIPTION
`IngestPoint::est_charge_bytes` and `TenantBuf::merge` counted only
`name.len() + value.len()` per label, while `IngestExemplar::est_bytes` in the
same file already counted the `Label` struct header for the same data and
documented why. A `Label` is two `String` headers, 48 bytes, whatever the
strings hold, so a ten-label series with short values had roughly 480 bytes
uncounted against the 200 bytes counted, and the error grows with label count.

Both numbers are load-bearing. `est_charge_bytes` feeds the process-wide
memory ceiling from ADR-0069, so the process could pass a limit it believed it
was under and meet the OOM killer instead of backpressure.
`TenantBuf::est_bytes` drives the `target_bytes` size trigger and the
`min_flush_bytes` priority-age selection, so both fired late on exactly the
label-heavy workloads they exist to bound.

Measured on a 50k-series, 11-label buffered workload: the gauge tracked 12.0 MB
against a 69.3 MB resident delta before, and 38.4 MB after. The remainder is
HashMap and allocator overhead that neither estimator claims to cover.

Three tests pin the estimators against each other so they cannot drift apart
again, and each was verified to fail when its own estimator is reverted.

Flush cadence changes as a consequence, and this is the part worth attention
at review: with 11 labels a buffer reaches `target_bytes` after 11.5k series
instead of 41.3k, so size-triggered PUT rate rises by roughly 3.6x on
label-heavy tenants. Request cost is linear in flush count, so this partially
spends the reduction epic #84 measured. The `target_bytes` and
`min_flush_bytes` defaults are deliberately left alone; re-tuning them is a
separate decision now that the input number is honest.

Review also caught that the worst-case-memory section of `docs/ingest.md`
described the charge as a slight over-count bounding true RSS. That was
already wrong and is more wrong after this change, so it is corrected with the
measured ratio and a sizing note.

Fixes: #369
