### PR TITLE
test(ravel-bench): honest per-shape bytes-per-sample byte gate

### DIFF
--- a/crates/ravel-bench/src/bin/codec_bakeoff.rs
+++ b/crates/ravel-bench/src/bin/codec_bakeoff.rs
@@ -41,11 +41,10 @@
 use std::hint::black_box;
 use std::time::Instant;
 
-use rand::rngs::StdRng;
-use rand::{RngExt, SeedableRng};
 use ravel_bench::bench_env::env_header;
 use ravel_bench::codecs::{Alp, ByteSplitZstd, Chimp128, GcdDeltaFor, RawF64, ValueCodec};
 use ravel_bench::segment_support::{decode_scalar_run, production_scalar_run, scalar_val_page};
+use ravel_bench::value_shapes::{ALL_SHAPES, ValueShape, value_stream};
 
 /// Page sizes measured: the small-run regime and a full L1-merged run.
 const PAGE_SIZES: [usize; 2] = [60, 500];
@@ -64,127 +63,15 @@ struct Dataset {
     values: Vec<f64>,
 }
 
-/// Round a float to `places` decimal places, the way a real decimal-valued
-/// gauge (a price, a ratio) arrives: the stored f64 is the nearest double to
-/// the rounded decimal.
-fn round_to(v: f64, places: i32) -> f64 {
-    let scale = 10f64.powi(places);
-    (v * scale).round() / scale
-}
-
-/// Builds one dataset of exactly `n` samples. Deterministic in `(kind, n)`: a
-/// fixed per-kind seed, no wall-clock time, so the byte figures reproduce.
-fn dataset(kind: &str, n: usize) -> Dataset {
-    let mut rng = StdRng::seed_from_u64(0x0C0D_EC00 ^ (n as u64) ^ seed_of(kind));
-    let values: Vec<f64> = match kind {
-        // Cumulative integer counter, small integer increments, ~2% reset to 0.
-        "counter_int_resets" => {
-            let mut acc = 0i64;
-            (0..n)
-                .map(|_| {
-                    if rng.random_bool(0.02) {
-                        acc = 0;
-                    } else {
-                        acc += rng.random_range(1..=10);
-                    }
-                    acc as f64
-                })
-                .collect()
-        }
-        // Integer gauge random walk, non-negative.
-        "gauge_int" => {
-            let mut acc = rng.random_range(0..1000) as i64;
-            (0..n)
-                .map(|_| {
-                    acc = (acc + rng.random_range(-5..=5)).max(0);
-                    acc as f64
-                })
-                .collect()
-        }
-        // 2-decimal gauge (e.g. a price) random walk.
-        "gauge_dec2" => {
-            let mut acc = round_to(rng.random_range(0.0..1000.0), 2);
-            (0..n)
-                .map(|_| {
-                    acc = round_to(acc + rng.random_range(-1.0..1.0), 2);
-                    acc
-                })
-                .collect()
-        }
-        // 3-decimal gauge random walk.
-        "gauge_dec3" => {
-            let mut acc = round_to(rng.random_range(0.0..1000.0), 3);
-            (0..n)
-                .map(|_| {
-                    acc = round_to(acc + rng.random_range(-1.0..1.0), 3);
-                    acc
-                })
-                .collect()
-        }
-        // Arbitrary noisy floats: no low decimal exponent reproduces them.
-        "noisy_float" => (0..n)
-            .map(|_| rng.random_range(-1_000_000.0..1_000_000.0))
-            .collect(),
-        // Constant series.
-        "constant" => vec![42.0; n],
-        // Sparse: mostly zero, ~10% integer spikes.
-        "sparse" => (0..n)
-            .map(|_| {
-                if rng.random_bool(0.1) {
-                    rng.random_range(1..=1000) as f64
-                } else {
-                    0.0
-                }
-            })
-            .collect(),
-        // The round-one control: a counter that increments by a random float.
-        "float_counter" => {
-            let mut acc = 0.0f64;
-            (0..n)
-                .map(|_| {
-                    acc += rng.random_range(0.0..5.0);
-                    acc
-                })
-                .collect()
-        }
-        other => panic!("unknown dataset {other}"),
-    };
+/// Builds one dataset of exactly `n` samples from the shared shape
+/// definitions ([`value_stream`]). Deterministic in `(shape, n)`: the bake-off
+/// uses `salt = 0`, one stream per dataset.
+fn dataset(shape: ValueShape, n: usize) -> Dataset {
     Dataset {
-        name: dataset_label(kind),
-        values,
+        name: shape.label(),
+        values: value_stream(shape, n, 0),
     }
 }
-
-fn seed_of(kind: &str) -> u64 {
-    kind.bytes().fold(1469598103934665603u64, |h, b| {
-        (h ^ u64::from(b)).wrapping_mul(1099511628211)
-    })
-}
-
-fn dataset_label(kind: &str) -> &'static str {
-    match kind {
-        "counter_int_resets" => "counter_int_resets",
-        "gauge_int" => "gauge_int",
-        "gauge_dec2" => "gauge_dec2",
-        "gauge_dec3" => "gauge_dec3",
-        "noisy_float" => "noisy_float",
-        "constant" => "constant",
-        "sparse" => "sparse",
-        "float_counter" => "float_counter(ctrl)",
-        other => panic!("unknown dataset {other}"),
-    }
-}
-
-const DATASET_KINDS: [&str; 8] = [
-    "counter_int_resets",
-    "gauge_int",
-    "gauge_dec2",
-    "gauge_dec3",
-    "noisy_float",
-    "constant",
-    "sparse",
-    "float_counter",
-];
 
 fn bits_eq(a: &[f64], b: &[f64]) -> bool {
     a.len() == b.len() && a.iter().zip(b).all(|(x, y)| x.to_bits() == y.to_bits())
@@ -323,8 +210,8 @@ fn main() {
         out.push_str(&format!(
             "\n======================= {page} samples per page =======================\n"
         ));
-        for kind in DATASET_KINDS {
-            let ds = dataset(kind, page);
+        for shape in ALL_SHAPES {
+            let ds = dataset(shape, page);
             let prod = measure_production(&ds.values);
             let challengers: Vec<Cell> = [
                 &Alp as &dyn ValueCodec,

--- a/crates/ravel-bench/src/lib.rs
+++ b/crates/ravel-bench/src/lib.rs
@@ -15,3 +15,4 @@ pub mod read_accounting;
 pub mod report;
 pub mod section_accounting;
 pub mod segment_support;
+pub mod value_shapes;

--- a/crates/ravel-bench/src/value_shapes.rs
+++ b/crates/ravel-bench/src/value_shapes.rs
@@ -1,0 +1,167 @@
+//! Deterministic value-stream shapes shared by the value codec bake-off
+//! (`src/bin/codec_bakeoff.rs`) and the catalog byte gate
+//! (`tests/catalog_byte_gates.rs`).
+//!
+//! The bake-off (ADR-0092 decision 6, round two) added realistic integer and
+//! decimal metric shapes so the codec measurement stopped being driven by a
+//! full-mantissa random float that no integer-model codec can compress. The
+//! byte gate historically measured that same uncompressible float and quoted
+//! the result as the format's cost (issue #370). Both now draw their values
+//! from one place, so a shape is defined once and measured identically by the
+//! codec bench and by the gate.
+//!
+//! Each stream is deterministic in `(shape, n, salt)`: a fixed seed derived
+//! from those three, no wall-clock time, so the byte figures reproduce. The
+//! bake-off passes `salt = 0` (one stream per dataset); the gate passes the
+//! series index as salt, so its 500 series each get a distinct walk and the
+//! zstd-compressed VAL section cannot collapse identical streams into an
+//! unrealistically small figure.
+use rand::rngs::StdRng;
+use rand::{RngExt, SeedableRng};
+
+/// One synthetic value-stream shape. Names match the `kind` strings the
+/// round-two bake-off used, so its seeds (and therefore its committed report
+/// numbers) are unchanged when `salt == 0`.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum ValueShape {
+    /// Cumulative integer counter, small integer increments, ~2% reset to 0.
+    CounterIntResets,
+    /// Integer gauge random walk, non-negative.
+    GaugeInt,
+    /// 2-decimal gauge (e.g. a price) random walk.
+    GaugeDec2,
+    /// 3-decimal gauge random walk.
+    GaugeDec3,
+    /// Arbitrary noisy floats: no low decimal exponent reproduces them.
+    NoisyFloat,
+    /// Constant series.
+    Constant,
+    /// Sparse: mostly zero, ~10% integer spikes.
+    Sparse,
+    /// The round-one control: a counter that increments by a random float.
+    FloatCounter,
+}
+
+/// Every shape, in the bake-off's report order.
+pub const ALL_SHAPES: [ValueShape; 8] = [
+    ValueShape::CounterIntResets,
+    ValueShape::GaugeInt,
+    ValueShape::GaugeDec2,
+    ValueShape::GaugeDec3,
+    ValueShape::NoisyFloat,
+    ValueShape::Constant,
+    ValueShape::Sparse,
+    ValueShape::FloatCounter,
+];
+
+impl ValueShape {
+    /// The seed key: the exact `kind` string the round-two bake-off hashed, so
+    /// `value_stream(shape, n, 0)` reproduces the bake-off's committed values.
+    pub fn key(self) -> &'static str {
+        match self {
+            ValueShape::CounterIntResets => "counter_int_resets",
+            ValueShape::GaugeInt => "gauge_int",
+            ValueShape::GaugeDec2 => "gauge_dec2",
+            ValueShape::GaugeDec3 => "gauge_dec3",
+            ValueShape::NoisyFloat => "noisy_float",
+            ValueShape::Constant => "constant",
+            ValueShape::Sparse => "sparse",
+            ValueShape::FloatCounter => "float_counter",
+        }
+    }
+
+    /// Human-facing label; the float control is tagged so a reader cannot
+    /// mistake it for a realistic shape.
+    pub fn label(self) -> &'static str {
+        match self {
+            ValueShape::FloatCounter => "float_counter(ctrl)",
+            other => other.key(),
+        }
+    }
+}
+
+/// Round a float to `places` decimal places, the way a real decimal-valued
+/// gauge (a price, a ratio) arrives: the stored f64 is the nearest double to
+/// the rounded decimal.
+fn round_to(v: f64, places: i32) -> f64 {
+    let scale = 10f64.powi(places);
+    (v * scale).round() / scale
+}
+
+/// FNV-1a over the shape key, so distinct shapes get well-separated seeds.
+fn seed_of(key: &str) -> u64 {
+    key.bytes().fold(1469598103934665603u64, |h, b| {
+        (h ^ u64::from(b)).wrapping_mul(1099511628211)
+    })
+}
+
+/// One value stream of exactly `n` samples for `shape`, deterministic in
+/// `(shape, n, salt)`. `salt` separates otherwise-identical streams (e.g. one
+/// per series); pass `0` to reproduce the bake-off's single-stream values.
+pub fn value_stream(shape: ValueShape, n: usize, salt: u64) -> Vec<f64> {
+    let mut rng = StdRng::seed_from_u64(0x0C0D_EC00 ^ (n as u64) ^ seed_of(shape.key()) ^ salt);
+    match shape {
+        ValueShape::CounterIntResets => {
+            let mut acc = 0i64;
+            (0..n)
+                .map(|_| {
+                    if rng.random_bool(0.02) {
+                        acc = 0;
+                    } else {
+                        acc += rng.random_range(1..=10);
+                    }
+                    acc as f64
+                })
+                .collect()
+        }
+        ValueShape::GaugeInt => {
+            let mut acc = rng.random_range(0..1000) as i64;
+            (0..n)
+                .map(|_| {
+                    acc = (acc + rng.random_range(-5..=5)).max(0);
+                    acc as f64
+                })
+                .collect()
+        }
+        ValueShape::GaugeDec2 => {
+            let mut acc = round_to(rng.random_range(0.0..1000.0), 2);
+            (0..n)
+                .map(|_| {
+                    acc = round_to(acc + rng.random_range(-1.0..1.0), 2);
+                    acc
+                })
+                .collect()
+        }
+        ValueShape::GaugeDec3 => {
+            let mut acc = round_to(rng.random_range(0.0..1000.0), 3);
+            (0..n)
+                .map(|_| {
+                    acc = round_to(acc + rng.random_range(-1.0..1.0), 3);
+                    acc
+                })
+                .collect()
+        }
+        ValueShape::NoisyFloat => (0..n)
+            .map(|_| rng.random_range(-1_000_000.0..1_000_000.0))
+            .collect(),
+        ValueShape::Constant => vec![42.0; n],
+        ValueShape::Sparse => (0..n)
+            .map(|_| {
+                if rng.random_bool(0.1) {
+                    rng.random_range(1..=1000) as f64
+                } else {
+                    0.0
+                }
+            })
+            .collect(),
+        ValueShape::FloatCounter => {
+            let mut acc = 0.0f64;
+            (0..n)
+                .map(|_| {
+                    acc += rng.random_range(0.0..5.0);
+                    acc
+                })
+                .collect()
+        }
+    }
+}

--- a/crates/ravel-bench/tests/catalog_byte_gates.rs
+++ b/crates/ravel-bench/tests/catalog_byte_gates.rs
@@ -10,19 +10,37 @@
 //! Fixture: the 10k `many_small` shape (5 label pairs/series, 20k total
 //! samples), at or above the 4096-series sparse-emission threshold. The
 //! generator seed is fixed (the [`WorkloadConfig`] default, 0), so the whole
-//! fixture is deterministic. Measured values are printed on success too, so
-//! `cargo test -- --nocapture` output can be diffed across runs.
+//! fixture is deterministic. The per-shape numbers are pinned by the
+//! committed golden rather than printed; regenerate it with
+//! `REGEN_CATALOG_BYTE_GATES=1`.
+//!
+//! This file also carries the run-fragmentation gate (issue #312, ADR-0092)
+//! and, on top of it, the honest per-shape byte gate (issue #370). The
+//! fragmentation gate historically measured only the generator's default
+//! full-mantissa float, which no integer-model value codec can compress, then
+//! quoted the result as the format's cost. The #370 gate re-points the same
+//! 500x240 fixture at realistic value shapes (integer counter with resets,
+//! integer gauge, two-decimal gauge, shared with the codec bake-off) and
+//! commits the exact per-section split, the value encoding each shape lands
+//! on, and a second scrape interval as a regenerable golden
+//! (`catalog_byte_gates_golden.txt`); the full-entropy float stays as an
+//! explicitly labelled control.
 #![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
+use std::path::PathBuf;
 
 use ravel_bench::generator::{CardinalityProfile, WorkloadConfig, generate_raw};
 use ravel_bench::section_accounting::shape_many_small;
 use ravel_bench::segment_support::{
-    LABEL_DICT, SERIES_IDS, SERIES_IDX, SERIES_META, SERIES_META_CHUNKS, TS_PAGES, VAL_PAGES,
-    bench_bounds, bench_identity, bench_meta, build_segment_v5,
+    SERIES_IDX, SERIES_META, SERIES_META_CHUNKS, VAL_PAGES, bench_bounds, bench_identity,
+    bench_meta, build_segment_v5,
 };
+use ravel_bench::value_shapes::{ValueShape, value_stream};
 use ravel_segment::{
     ReaderLimits, RunInputV4, RunInputV7, SampleProvenance, SegmentWriter, SeriesInputV4,
-    SeriesInputV7, SeriesValues, WrittenSegment, encode_run_v4, open_from_full,
+    SeriesInputV7, SeriesValues, WrittenSegment, decode_catalog_v5, encode_run_v4, open_from_full,
 };
 use ravel_types::{LabelSet, Sample, SeriesId};
 
@@ -128,12 +146,23 @@ const FRAG_FLUSH_SPACING_NS: i64 = 2_000_000_000;
 /// One deterministic workload: 500 series x 240 samples, timestamps snapped to
 /// millisecond resolution and sorted ascending. Fixed seed, no wall-clock
 /// time. Both layouts consume this identical data, so the comparison is
-/// apples-to-apples.
+/// apples-to-apples. Values keep the generator's default full-entropy
+/// counter/gauge floats: this is the historical control fixture (issue #370),
+/// the one that produces 8.88 B/sample merged because no integer-model codec
+/// can compress a full-mantissa f64.
 fn fragmentation_workload() -> Vec<(SeriesId, LabelSet, Vec<Sample>)> {
+    fragmentation_workload_at(FRAG_INTERVAL_NS)
+}
+
+/// [`fragmentation_workload`] at an arbitrary scrape interval, so the same
+/// fixture can be measured at 15 s and at a second cadence (issue #370
+/// deliverable 5). Only `interval_ns` moves; series count, sample count,
+/// jitter, resolution, and seed are fixed.
+fn fragmentation_workload_at(interval_ns: i64) -> Vec<(SeriesId, LabelSet, Vec<Sample>)> {
     let config = WorkloadConfig {
         series_count: FRAG_SERIES,
         samples_per_series: FRAG_SAMPLES_PER_SERIES,
-        interval_ns: FRAG_INTERVAL_NS,
+        interval_ns,
         jitter_ns: FRAG_JITTER_NS,
         cardinality: CardinalityProfile::many_small(FRAG_SERIES),
         ..Default::default()
@@ -145,6 +174,23 @@ fn fragmentation_workload() -> Vec<(SeriesId, LabelSet, Vec<Sample>)> {
             s.ts_ns = (s.ts_ns / MS_NS) * MS_NS;
         }
         samples.sort_by_key(|s| s.ts_ns);
+    }
+    raw
+}
+
+/// The control fixture's timestamp shape with the value column replaced by a
+/// realistic metric shape ([`ValueShape`], shared with the codec bake-off).
+/// Timestamps are untouched, so a shape's TS_PAGES cost matches the control's
+/// and only VAL_PAGES (and its dependent codec choice) moves. Each series gets
+/// its own value walk (salt = series index), so the zstd-compressed VAL
+/// section cannot collapse 500 identical streams into an unrealistic figure.
+fn shaped_workload(shape: ValueShape, interval_ns: i64) -> Vec<(SeriesId, LabelSet, Vec<Sample>)> {
+    let mut raw = fragmentation_workload_at(interval_ns);
+    for (idx, (_, _, samples)) in raw.iter_mut().enumerate() {
+        let values = value_stream(shape, samples.len(), idx as u64);
+        for (s, v) in samples.iter_mut().zip(values) {
+            s.value = v;
+        }
     }
     raw
 }
@@ -257,89 +303,187 @@ fn build_merged_with_provenance(raw: &[(SeriesId, LabelSet, Vec<Sample>)]) -> Wr
     .expect("write merged v7 with provenance")
 }
 
-/// The five per-section byte-per-sample figures ADR-0092 reports, plus the
-/// object total.
-struct SectionSplit {
-    label_dict: f64,
-    series_ids: f64,
-    series_meta: f64,
-    ts_pages: f64,
-    val_pages: f64,
-    total: f64,
+/// Total samples in the fragmentation fixture, the denominator of every
+/// bytes-per-sample figure below.
+const FRAG_TOTAL_SAMPLES: usize = FRAG_SERIES * FRAG_SAMPLES_PER_SERIES;
+
+/// A full byte breakdown of one written object: every footer section by kind,
+/// plus the residual. Sections + residual sum exactly to the object.
+///
+/// The old five-part `section_split` did not sum: it divided the whole object
+/// length for the total but summed only five named sections for the parts, so
+/// the footer, the 16-byte trailer, and inter-section alignment padding were an
+/// unaccounted remainder (issue #370 deliverable 4). This view names that
+/// remainder as `residual`, and [`Breakdown::assert_sums`] pins the identity.
+struct Breakdown {
+    object_bytes: u64,
+    total_samples: usize,
+    /// (kind, len) for every section the footer lists, sorted by kind.
+    sections: Vec<(u32, u64)>,
+    /// `object_bytes - sum(section lens)`: footer + 16-byte trailer +
+    /// inter-section alignment padding.
+    residual: u64,
 }
 
-fn section_split(seg: &WrittenSegment, total_samples: usize) -> SectionSplit {
-    let n = total_samples as f64;
-    let per = |kind: u32| section_len(&seg.bytes, kind) as f64 / n;
-    // At 500 series the layout is non-sparse: SERIES_META (kind 6) carries the
-    // run-major columns; SERIES_META_CHUNKS (kind 9) is absent (len 0).
-    let series_meta = per(SERIES_META) + per(SERIES_META_CHUNKS);
-    SectionSplit {
-        label_dict: per(LABEL_DICT),
-        series_ids: per(SERIES_IDS),
-        series_meta,
-        ts_pages: per(TS_PAGES),
-        val_pages: per(VAL_PAGES),
-        total: seg.bytes.len() as f64 / n,
+impl Breakdown {
+    fn of(seg: &WrittenSegment, total_samples: usize) -> Self {
+        let loc = open_from_full(&seg.bytes, ReaderLimits::default()).expect("open");
+        let mut sections: Vec<(u32, u64)> = loc
+            .footer
+            .sections
+            .iter()
+            .map(|s| (s.kind, s.len))
+            .collect();
+        sections.sort_by_key(|(k, _)| *k);
+        let object_bytes = seg.bytes.len() as u64;
+        let section_sum: u64 = sections.iter().map(|(_, l)| *l).sum();
+        let residual = object_bytes
+            .checked_sub(section_sum)
+            .expect("section bytes cannot exceed the object");
+        Breakdown {
+            object_bytes,
+            total_samples,
+            sections,
+            residual,
+        }
+    }
+
+    fn per_sample(&self, bytes: u64) -> f64 {
+        bytes as f64 / self.total_samples as f64
+    }
+
+    fn total_per_sample(&self) -> f64 {
+        self.per_sample(self.object_bytes)
+    }
+
+    fn section_bytes(&self, kind: u32) -> u64 {
+        self.sections
+            .iter()
+            .find(|(k, _)| *k == kind)
+            .map(|(_, l)| *l)
+            .unwrap_or(0)
+    }
+
+    /// The named sections account for all but a small fixed remainder of the
+    /// object.
+    ///
+    /// Sections-plus-residual equalling the object is not asserted here
+    /// because `residual` is defined as that difference, so the equality is an
+    /// identity for any input. The golden is what pins it: it emits every
+    /// section line and the residual, and an exact match proves they close.
+    ///
+    /// What is falsifiable, and what this checks, is that the remainder stays
+    /// small. The residual is meant to be footer plus the 16-byte trailer plus
+    /// inter-section alignment padding, a few hundred bytes. A new section
+    /// that nobody added to `SECTION_KINDS` would land here instead and blow
+    /// the bound.
+    fn assert_sums(&self) {
+        const MAX_RESIDUAL_BYTES: u64 = 4096;
+        assert!(
+            self.residual <= MAX_RESIDUAL_BYTES,
+            "residual {} exceeds {MAX_RESIDUAL_BYTES} bytes for a {}-byte object: \
+             a section is likely missing from the breakdown's section list",
+            self.residual,
+            self.object_bytes,
+        );
     }
 }
 
-fn print_split(name: &str, s: &SectionSplit) {
-    println!(
-        "[fragmentation {name}] total={:.2} B/sample  \
-         LABEL_DICT={:.2} SERIES_IDS={:.2} SERIES_META={:.2} TS_PAGES={:.2} VAL_PAGES={:.2}",
-        s.total, s.label_dict, s.series_ids, s.series_meta, s.ts_pages, s.val_pages,
-    );
+fn section_name(kind: u32) -> &'static str {
+    match kind {
+        1 => "LABEL_DICT",
+        2 => "SERIES_TABLE",
+        3 => "TS_PAGES",
+        4 => "VAL_PAGES",
+        5 => "SERIES_IDS",
+        6 => "SERIES_META",
+        7 => "HIST_PAGES",
+        8 => "SERIES_IDX",
+        9 => "SERIES_META_CHUNKS",
+        10 => "EXEMPLARS",
+        _ => "UNKNOWN",
+    }
+}
+
+/// Value page encoding tag names (docs/segment-format.md, `page_enc`). The
+/// point of the honest fixture is to make these fire: on the random-float
+/// control every page is VAL_RAW_F64, and the integer-model codecs
+/// (VAL_ALP, VAL_GCD_DELTA_FOR) cannot engage by construction.
+fn val_enc_name(tag: u8) -> &'static str {
+    match tag {
+        16 => "VAL_GORILLA",
+        17 => "VAL_RAW_F64",
+        18 => "VAL_ALP",
+        19 => "VAL_GCD_DELTA_FOR",
+        _ => "VAL_UNKNOWN",
+    }
+}
+
+/// Histogram of the value-page encoding tag over every run's VAL page. One
+/// entry per run (fragmented: 240 per series; merged: 1 per series). This is
+/// what confirms or refutes "the integer-model codecs never fire on the
+/// fixture".
+fn val_enc_histogram(seg: &WrittenSegment) -> BTreeMap<u8, usize> {
+    let limits = ReaderLimits::default();
+    let loc = open_from_full(&seg.bytes, limits).expect("open");
+    let entries = decode_catalog_v5(&loc.footer, &seg.bytes, limits).expect("decode catalog");
+    let val_sec = loc
+        .footer
+        .sections
+        .iter()
+        .find(|s| s.kind == VAL_PAGES)
+        .expect("VAL_PAGES present");
+    let mut hist = BTreeMap::new();
+    for e in &entries {
+        for run in &e.runs {
+            let (off, len) = run.val_page;
+            if len == 0 {
+                continue;
+            }
+            let tag = seg.bytes[(val_sec.offset + off) as usize];
+            *hist.entry(tag).or_insert(0) += 1;
+        }
+    }
+    hist
 }
 
 /// Pinned lower bound on `fragmented_total / merged_total`. Measured on this
-/// tree (RSEG v7, #314) the ratio is 2.987: fragmented 26.52 B/sample against
-/// merged 8.88 (see the printed splits). That is down from the 3.126 #312
-/// measured and the 3.68 ADR-0092's table reports, because the page-codec wins
-/// in this train (ALP, GCD-delta-FOR, GCD timestamps, first-ts-as-delta, the
-/// single-sample no-pad rule) shrank the fragmented regime's per-run pages more
-/// than the merged one. Re-derived here from the 2.987 measured value using the
+/// tree (RSEG v7, #314) the ratio is 2.987 on the random-float control:
+/// fragmented 26.52 B/sample against merged 8.88. That is down from the 3.126
+/// #312 measured and the 3.68 ADR-0092's table reports, because the page-codec
+/// wins in this train (ALP, GCD-delta-FOR, GCD timestamps, first-ts-as-delta,
+/// the single-sample no-pad rule) shrank the fragmented regime's per-run pages
+/// more than the merged one. Re-derived from the 2.987 measured value using the
 /// same ~20%-below-measured margin policy #312 used to pin 2.5 against its then
 /// 3.126, which lands at 2.4. The gate flags a regression in the fragmentation
-/// penalty without being brittle to codec-level byte wobble; it is not a no-op,
-/// and a superseded pin (2.5 was pinned against a measurement two page-codec
-/// generations old) is exactly the drift this epic keeps finding.
+/// penalty without being brittle to codec-level byte wobble.
 const FRAG_RATIO_MIN: f64 = 2.4;
 
 #[test]
 fn fragmented_multi_run_shape_costs_more_than_merged() {
     let raw = fragmentation_workload();
     let total_samples: usize = raw.iter().map(|(_, _, s)| s.len()).sum();
-    assert_eq!(total_samples, FRAG_SERIES * FRAG_SAMPLES_PER_SERIES);
+    assert_eq!(total_samples, FRAG_TOTAL_SAMPLES);
 
-    let merged = build_merged(&raw);
-    let fragmented = build_fragmented(&raw);
-
-    let merged_split = section_split(&merged, total_samples);
-    let fragmented_split = section_split(&fragmented, total_samples);
-
-    // Both splits printed on success so the numbers can be diffed across runs.
-    print_split("merged", &merged_split);
-    print_split("fragmented", &fragmented_split);
+    let merged = Breakdown::of(&build_merged(&raw), total_samples);
+    let fragmented = Breakdown::of(&build_fragmented(&raw), total_samples);
+    merged.assert_sums();
+    fragmented.assert_sums();
 
     // Sanity: at 500 series both layouts are non-sparse (plain SERIES_META,
     // no chunked catalog).
     assert_eq!(
-        section_len(&merged.bytes, SERIES_META_CHUNKS),
+        merged.section_bytes(SERIES_META_CHUNKS),
         0,
         "500 series is below the sparse threshold: no SERIES_META_CHUNKS"
     );
 
-    let ratio = fragmented_split.total / merged_split.total;
-    println!(
-        "[fragmentation] fragmented/merged total ratio = {ratio:.3} (gate >= {FRAG_RATIO_MIN})"
-    );
-
+    let ratio = fragmented.total_per_sample() / merged.total_per_sample();
     assert!(
         ratio >= FRAG_RATIO_MIN,
         "fragmented layout ({:.2} B/sample) must exceed merged ({:.2} B/sample) by >= {FRAG_RATIO_MIN}x, got {ratio:.3}x",
-        fragmented_split.total,
-        merged_split.total,
+        fragmented.total_per_sample(),
+        merged.total_per_sample(),
     );
 }
 
@@ -353,39 +497,22 @@ fn fragmented_multi_run_shape_costs_more_than_merged() {
 /// `encode_i64` and zstd flatten almost to nothing on a regular flush cadence.
 /// That is far below ADR-0092's ~5 B/sample estimate, which assumed the
 /// columns did not compress. The gate is pinned ~20% below the measured ratio,
-/// matching the `FRAG_RATIO_MIN` margin policy, so it flags a real regression in
-/// the merge win without wobbling on codec-level byte drift.
+/// matching the `FRAG_RATIO_MIN` margin policy.
 const MERGED_WITH_PROV_RATIO_MIN: f64 = 2.4;
 
 #[test]
 fn run_merged_l1_with_provenance_costs_materially_less_than_inputs() {
     let raw = fragmentation_workload();
     let total_samples: usize = raw.iter().map(|(_, _, s)| s.len()).sum();
-    assert_eq!(total_samples, FRAG_SERIES * FRAG_SAMPLES_PER_SERIES);
+    assert_eq!(total_samples, FRAG_TOTAL_SAMPLES);
 
     let fragmented = build_fragmented(&raw);
     let merged_no_prov = build_merged(&raw);
     let merged_with_prov = build_merged_with_provenance(&raw);
 
-    let fragmented_split = section_split(&fragmented, total_samples);
-    let merged_no_prov_split = section_split(&merged_no_prov, total_samples);
-    let merged_with_prov_split = section_split(&merged_with_prov, total_samples);
+    let fragmented_b = Breakdown::of(&fragmented, total_samples);
+    let merged_with_prov_b = Breakdown::of(&merged_with_prov, total_samples);
 
-    print_split("fragmented (inputs)", &fragmented_split);
-    print_split("merged (no provenance)", &merged_no_prov_split);
-    print_split(
-        "merged + per-sample provenance (shipping L1)",
-        &merged_with_prov_split,
-    );
-
-    let provenance_cost = merged_with_prov_split.total - merged_no_prov_split.total;
-    println!(
-        "[fragmentation] exact object bytes: merged_no_prov={} merged_with_prov={} delta={} \
-         over {total_samples} samples",
-        merged_no_prov.bytes.len(),
-        merged_with_prov.bytes.len(),
-        merged_with_prov.bytes.len() as i64 - merged_no_prov.bytes.len() as i64,
-    );
     // The provenance-carrying object must actually differ from the no-provenance
     // one: the columns are present, just highly compressible (constant/arithmetic
     // sequences under encode_i64 inside zstd), so their per-sample cost is small,
@@ -394,24 +521,18 @@ fn run_merged_l1_with_provenance_costs_materially_less_than_inputs() {
         merged_with_prov.bytes.len() > merged_no_prov.bytes.len(),
         "the provenance columns must add bytes; equal size means they were dropped"
     );
-    let ratio = fragmented_split.total / merged_with_prov_split.total;
-    println!(
-        "[fragmentation] merged+provenance = {:.2} B/sample (per-sample provenance cost = {:.2} \
-         B/sample); fragmented/merged+prov ratio = {ratio:.3} (gate >= {MERGED_WITH_PROV_RATIO_MIN})",
-        merged_with_prov_split.total, provenance_cost,
-    );
-
+    let ratio = fragmented_b.total_per_sample() / merged_with_prov_b.total_per_sample();
     assert!(
         ratio >= MERGED_WITH_PROV_RATIO_MIN,
         "run-merged L1 with provenance ({:.2} B/sample) must cost materially less than the \
          fragmented inputs ({:.2} B/sample): ratio {ratio:.3} < {MERGED_WITH_PROV_RATIO_MIN}",
-        merged_with_prov_split.total,
-        fragmented_split.total,
+        merged_with_prov_b.total_per_sample(),
+        fragmented_b.total_per_sample(),
     );
 }
 
 /// Determinism: the fixed-seed workload -> both writers yields byte-identical
-/// object sizes on a second run, so the pinned ratio never wobbles.
+/// object sizes on a second run, so the pinned numbers never wobble.
 #[test]
 fn fragmentation_measurements_are_deterministic() {
     let measure = || {
@@ -422,4 +543,274 @@ fn fragmentation_measurements_are_deterministic() {
         )
     };
     assert_eq!(measure(), measure());
+}
+
+// --- honest per-shape byte gate + committed golden (issue #370) ---------
+//
+// The gate above measures only the random-float control: the generator's
+// default full-mantissa counter/gauge floats, which no integer-model value
+// codec can compress. Real metrics are integer counters, integer gauges, and
+// low-precision decimals. This section measures those realistic shapes on the
+// SAME 500x240 fixture (only the value column changes) and commits the exact
+// per-section split, the value encoding each shape lands on, and a second
+// scrape interval, as a regenerable golden.
+
+/// One value shape the golden measures. The control is the historical fixture
+/// (generator-default floats, the 8.88 anchor); the realistic shapes overwrite
+/// only the value column of that same fixture.
+#[derive(Clone, Copy)]
+enum GateShape {
+    RandomFloatControl,
+    Realistic(ValueShape),
+}
+
+impl GateShape {
+    fn label(self) -> &'static str {
+        match self {
+            GateShape::RandomFloatControl => "random_float(ctrl)",
+            GateShape::Realistic(s) => s.label(),
+        }
+    }
+
+    fn workload(self, interval_ns: i64) -> Vec<(SeriesId, LabelSet, Vec<Sample>)> {
+        match self {
+            GateShape::RandomFloatControl => fragmentation_workload_at(interval_ns),
+            GateShape::Realistic(s) => shaped_workload(s, interval_ns),
+        }
+    }
+}
+
+/// The shapes measured: an integer counter with resets, an integer gauge, a
+/// two-decimal gauge, and the full-entropy random float kept as an explicitly
+/// labelled control (issue #370 deliverable 1).
+const GATE_SHAPES: [GateShape; 4] = [
+    GateShape::Realistic(ValueShape::CounterIntResets),
+    GateShape::Realistic(ValueShape::GaugeInt),
+    GateShape::Realistic(ValueShape::GaugeDec2),
+    GateShape::RandomFloatControl,
+];
+
+/// The layouts measured per shape: the fragmented inputs, the merged object
+/// without provenance, and the shipping merged object with per-sample
+/// provenance.
+#[derive(Clone, Copy)]
+enum Layout {
+    Fragmented,
+    MergedNoProv,
+    MergedWithProv,
+}
+
+impl Layout {
+    fn tag(self) -> &'static str {
+        match self {
+            Layout::Fragmented => "fragmented",
+            Layout::MergedNoProv => "merged_no_prov",
+            Layout::MergedWithProv => "merged_with_prov",
+        }
+    }
+
+    fn build(self, raw: &[(SeriesId, LabelSet, Vec<Sample>)]) -> WrittenSegment {
+        match self {
+            Layout::Fragmented => build_fragmented(raw),
+            Layout::MergedNoProv => build_merged(raw),
+            Layout::MergedWithProv => build_merged_with_provenance(raw),
+        }
+    }
+}
+
+const GATE_LAYOUTS: [Layout; 3] = [
+    Layout::Fragmented,
+    Layout::MergedNoProv,
+    Layout::MergedWithProv,
+];
+
+/// The two scrape intervals: the fixture's 15 s and a 60 s second point
+/// (issue #370 deliverable 5). No measurement at any interval other than 15 s
+/// existed before.
+const GATE_INTERVALS: [(&str, i64); 2] = [("15s", FRAG_INTERVAL_NS), ("60s", 60_000_000_000)];
+
+/// One measured cell, retained so rendering and the assertions run over a
+/// single build pass.
+struct GateMeasurement {
+    interval: &'static str,
+    shape: &'static str,
+    layout: &'static str,
+    breakdown: Breakdown,
+    val_enc: BTreeMap<u8, usize>,
+}
+
+/// Build every (interval, shape, layout) cell once.
+fn measure_gate() -> Vec<GateMeasurement> {
+    let mut out = Vec::new();
+    for (interval, interval_ns) in GATE_INTERVALS {
+        for shape in GATE_SHAPES {
+            let raw = shape.workload(interval_ns);
+            let total_samples: usize = raw.iter().map(|(_, _, s)| s.len()).sum();
+            assert_eq!(total_samples, FRAG_TOTAL_SAMPLES);
+            for layout in GATE_LAYOUTS {
+                let seg = layout.build(&raw);
+                let breakdown = Breakdown::of(&seg, total_samples);
+                breakdown.assert_sums();
+                out.push(GateMeasurement {
+                    interval,
+                    shape: shape.label(),
+                    layout: layout.tag(),
+                    val_enc: val_enc_histogram(&seg),
+                    breakdown,
+                });
+            }
+        }
+    }
+    out
+}
+
+/// Render one measurement as fully-qualified lines, so a golden mismatch on any
+/// single line names the interval, shape, layout, and section it belongs to.
+/// bytes are exact; B/sample = bytes / total_samples.
+fn render_measurement(m: &GateMeasurement, out: &mut String) {
+    let q = format!("{} {} {}", m.interval, m.shape, m.layout);
+    let b = &m.breakdown;
+    let _ = writeln!(out, "{q} object_bytes {}", b.object_bytes);
+    let _ = writeln!(out, "{q} total_per_sample {:.4}", b.total_per_sample());
+    for (kind, len) in &b.sections {
+        let _ = writeln!(
+            out,
+            "{q} section {} {} {:.4}",
+            section_name(*kind),
+            len,
+            b.per_sample(*len),
+        );
+    }
+    let _ = writeln!(
+        out,
+        "{q} residual {} {:.4}",
+        b.residual,
+        b.per_sample(b.residual),
+    );
+    for (tag, count) in &m.val_enc {
+        let _ = writeln!(out, "{q} valenc {} {}", val_enc_name(*tag), count);
+    }
+}
+
+fn render_golden(measurements: &[GateMeasurement]) -> String {
+    let mut out = String::new();
+    out.push_str(GOLDEN_HEADER);
+    for m in measurements {
+        render_measurement(m, &mut out);
+    }
+    out
+}
+
+const GOLDEN_HEADER: &str = "\
+# Catalog byte-gate golden (issue #370). Committed, exact, deterministic.
+#
+# Regenerate after any INTENDED codec or format change:
+#   REGEN_CATALOG_BYTE_GATES=1 cargo test -p ravel-bench --test catalog_byte_gates
+#
+# Fixture: 500 series x 240 samples, 15s/60s spacing, ms resolution, 200ms
+# jitter, seed 0. Only the value column changes across shapes; timestamps are
+# identical, so a shape moves VAL_PAGES (and its codec choice) and nothing else
+# on the value side. bytes are exact and deterministic; timing is not, so only
+# bytes are asserted (see the file header).
+#
+# Each line is fully qualified: <interval> <shape> <layout> <metric...>.
+# 'section <NAME> <bytes> <B/sample>' lines plus the 'residual' line sum
+# exactly to 'object_bytes' (residual = footer + 16-byte trailer + inter-section
+# alignment padding). 'valenc <ENC> <count>' is the value-page encoding tag over
+# every run's VAL page (one per run): it shows which codec actually fired.
+";
+
+fn golden_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("catalog_byte_gates_golden.txt")
+}
+
+/// The committed golden: the exact per-section split (with residual), the value
+/// encoding each shape lands on, and a second scrape interval, for four value
+/// shapes. This is the honest bytes-per-sample record issue #370 asks for; the
+/// random-float control is the only shape that stays on VAL_RAW_F64 and near
+/// 8.88 merged, and the realistic shapes land well below it.
+#[test]
+fn catalog_byte_gates_golden() {
+    let measurements = measure_gate();
+    let rendered = render_golden(&measurements);
+    let path = golden_path();
+
+    // An empty value must not regenerate: `REGEN_CATALOG_BYTE_GATES= cargo test`
+    // would otherwise rewrite the golden instead of asserting against it, and
+    // report a pass.
+    if std::env::var("REGEN_CATALOG_BYTE_GATES").is_ok_and(|v| !v.is_empty()) {
+        std::fs::write(&path, &rendered).expect("write golden");
+        return;
+    }
+
+    let committed = std::fs::read_to_string(&path).unwrap_or_else(|e| {
+        panic!(
+            "cannot read {}: {e}. Regenerate with \
+             REGEN_CATALOG_BYTE_GATES=1 cargo test -p ravel-bench --test catalog_byte_gates",
+            path.display()
+        )
+    });
+
+    if committed != rendered {
+        for (i, (c, r)) in committed.lines().zip(rendered.lines()).enumerate() {
+            assert_eq!(
+                c,
+                r,
+                "catalog byte-gate golden mismatch at line {}. Regenerate INTENDED \
+                 changes with REGEN_CATALOG_BYTE_GATES=1 cargo test -p ravel-bench \
+                 --test catalog_byte_gates",
+                i + 1,
+            );
+        }
+        assert_eq!(
+            committed.lines().count(),
+            rendered.lines().count(),
+            "catalog byte-gate golden line count differs. Regenerate with \
+             REGEN_CATALOG_BYTE_GATES=1 cargo test -p ravel-bench --test catalog_byte_gates",
+        );
+        // Reaching here means the two differ as strings but match line for line
+        // and in line count, so the difference is trailing-newline or
+        // line-ending only. Fail rather than fall out of the branch reporting a
+        // pass on a golden that did not match.
+        panic!(
+            "catalog byte-gate golden differs only in trailing whitespace or line \
+             endings. Regenerate with REGEN_CATALOG_BYTE_GATES=1 cargo test \
+             -p ravel-bench --test catalog_byte_gates"
+        );
+    }
+}
+
+/// Per-shape honesty gate (issue #370 deliverable 2): every realistic shape's
+/// merged-with-provenance cost lands materially below the random-float
+/// control's, because the integer-model codecs fire on realistic values and
+/// cannot on a full-mantissa float. This is the claim the golden's numbers
+/// back, asserted directly so a regression that makes the realistic shapes
+/// stop compressing fails a named gate, not only the golden diff.
+#[test]
+fn realistic_shapes_beat_the_random_float_control() {
+    let total_samples = FRAG_TOTAL_SAMPLES;
+    let control = Breakdown::of(
+        &build_merged_with_provenance(&GateShape::RandomFloatControl.workload(FRAG_INTERVAL_NS)),
+        total_samples,
+    )
+    .total_per_sample();
+
+    for shape in [
+        ValueShape::CounterIntResets,
+        ValueShape::GaugeInt,
+        ValueShape::GaugeDec2,
+    ] {
+        let raw = shaped_workload(shape, FRAG_INTERVAL_NS);
+        let merged = Breakdown::of(&build_merged_with_provenance(&raw), total_samples);
+        assert!(
+            merged.total_per_sample() < control,
+            "realistic shape {} merged cost {:.2} B/sample must be below the random-float \
+             control {:.2} B/sample; if it is not, the integer-model value codecs stopped firing",
+            shape.label(),
+            merged.total_per_sample(),
+            control,
+        );
+    }
 }

--- a/crates/ravel-bench/tests/catalog_byte_gates_golden.txt
+++ b/crates/ravel-bench/tests/catalog_byte_gates_golden.txt
@@ -1,0 +1,248 @@
+# Catalog byte-gate golden (issue #370). Committed, exact, deterministic.
+#
+# Regenerate after any INTENDED codec or format change:
+#   REGEN_CATALOG_BYTE_GATES=1 cargo test -p ravel-bench --test catalog_byte_gates
+#
+# Fixture: 500 series x 240 samples, 15s/60s spacing, ms resolution, 200ms
+# jitter, seed 0. Only the value column changes across shapes; timestamps are
+# identical, so a shape moves VAL_PAGES (and its codec choice) and nothing else
+# on the value side. bytes are exact and deterministic; timing is not, so only
+# bytes are asserted (see the file header).
+#
+# Each line is fully qualified: <interval> <shape> <layout> <metric...>.
+# 'section <NAME> <bytes> <B/sample>' lines plus the 'residual' line sum
+# exactly to 'object_bytes' (residual = footer + 16-byte trailer + inter-section
+# alignment padding). 'valenc <ENC> <count>' is the value-page encoding tag over
+# every run's VAL page (one per run): it shows which codec actually fired.
+15s counter_int_resets fragmented object_bytes 2920046
+15s counter_int_resets fragmented total_per_sample 24.3337
+15s counter_int_resets fragmented section LABEL_DICT 2209 0.0184
+15s counter_int_resets fragmented section TS_PAGES 840000 7.0000
+15s counter_int_resets fragmented section VAL_PAGES 1409387 11.7449
+15s counter_int_resets fragmented section SERIES_IDS 8004 0.0667
+15s counter_int_resets fragmented section SERIES_META 660226 5.5019
+15s counter_int_resets fragmented residual 220 0.0018
+15s counter_int_resets fragmented valenc VAL_ALP 120000
+15s counter_int_resets merged_no_prov object_bytes 360140
+15s counter_int_resets merged_no_prov total_per_sample 3.0012
+15s counter_int_resets merged_no_prov section LABEL_DICT 2209 0.0184
+15s counter_int_resets merged_no_prov section TS_PAGES 212719 1.7727
+15s counter_int_resets merged_no_prov section VAL_PAGES 126659 1.0555
+15s counter_int_resets merged_no_prov section SERIES_IDS 8004 0.0667
+15s counter_int_resets merged_no_prov section SERIES_META 10328 0.0861
+15s counter_int_resets merged_no_prov residual 221 0.0018
+15s counter_int_resets merged_no_prov valenc VAL_ALP 478
+15s counter_int_resets merged_no_prov valenc VAL_GCD_DELTA_FOR 22
+15s counter_int_resets merged_with_prov object_bytes 360460
+15s counter_int_resets merged_with_prov total_per_sample 3.0038
+15s counter_int_resets merged_with_prov section LABEL_DICT 2209 0.0184
+15s counter_int_resets merged_with_prov section TS_PAGES 212719 1.7727
+15s counter_int_resets merged_with_prov section VAL_PAGES 126659 1.0555
+15s counter_int_resets merged_with_prov section SERIES_IDS 8004 0.0667
+15s counter_int_resets merged_with_prov section SERIES_META 10648 0.0887
+15s counter_int_resets merged_with_prov residual 221 0.0018
+15s counter_int_resets merged_with_prov valenc VAL_ALP 478
+15s counter_int_resets merged_with_prov valenc VAL_GCD_DELTA_FOR 22
+15s gauge_int fragmented object_bytes 2935566
+15s gauge_int fragmented total_per_sample 24.4630
+15s gauge_int fragmented section LABEL_DICT 2209 0.0184
+15s gauge_int fragmented section TS_PAGES 840000 7.0000
+15s gauge_int fragmented section VAL_PAGES 1432779 11.9398
+15s gauge_int fragmented section SERIES_IDS 8004 0.0667
+15s gauge_int fragmented section SERIES_META 652348 5.4362
+15s gauge_int fragmented residual 226 0.0019
+15s gauge_int fragmented valenc VAL_ALP 120000
+15s gauge_int merged_no_prov object_bytes 299663
+15s gauge_int merged_no_prov total_per_sample 2.4972
+15s gauge_int merged_no_prov section LABEL_DICT 2209 0.0184
+15s gauge_int merged_no_prov section TS_PAGES 212719 1.7727
+15s gauge_int merged_no_prov section VAL_PAGES 66470 0.5539
+15s gauge_int merged_no_prov section SERIES_IDS 8004 0.0667
+15s gauge_int merged_no_prov section SERIES_META 10043 0.0837
+15s gauge_int merged_no_prov residual 218 0.0018
+15s gauge_int merged_no_prov valenc VAL_GCD_DELTA_FOR 500
+15s gauge_int merged_with_prov object_bytes 299983
+15s gauge_int merged_with_prov total_per_sample 2.4999
+15s gauge_int merged_with_prov section LABEL_DICT 2209 0.0184
+15s gauge_int merged_with_prov section TS_PAGES 212719 1.7727
+15s gauge_int merged_with_prov section VAL_PAGES 66470 0.5539
+15s gauge_int merged_with_prov section SERIES_IDS 8004 0.0667
+15s gauge_int merged_with_prov section SERIES_META 10363 0.0864
+15s gauge_int merged_with_prov residual 218 0.0018
+15s gauge_int merged_with_prov valenc VAL_GCD_DELTA_FOR 500
+15s gauge_dec2 fragmented object_bytes 3053748
+15s gauge_dec2 fragmented total_per_sample 25.4479
+15s gauge_dec2 fragmented section LABEL_DICT 2209 0.0184
+15s gauge_dec2 fragmented section TS_PAGES 840000 7.0000
+15s gauge_dec2 fragmented section VAL_PAGES 1539609 12.8301
+15s gauge_dec2 fragmented section SERIES_IDS 8004 0.0667
+15s gauge_dec2 fragmented section SERIES_META 663704 5.5309
+15s gauge_dec2 fragmented residual 222 0.0019
+15s gauge_dec2 fragmented valenc VAL_ALP 120000
+15s gauge_dec2 merged_no_prov object_bytes 360185
+15s gauge_dec2 merged_no_prov total_per_sample 3.0015
+15s gauge_dec2 merged_no_prov section LABEL_DICT 2209 0.0184
+15s gauge_dec2 merged_no_prov section TS_PAGES 212719 1.7727
+15s gauge_dec2 merged_no_prov section VAL_PAGES 126952 1.0579
+15s gauge_dec2 merged_no_prov section SERIES_IDS 8004 0.0667
+15s gauge_dec2 merged_no_prov section SERIES_META 10084 0.0840
+15s gauge_dec2 merged_no_prov residual 217 0.0018
+15s gauge_dec2 merged_no_prov valenc VAL_GCD_DELTA_FOR 500
+15s gauge_dec2 merged_with_prov object_bytes 360513
+15s gauge_dec2 merged_with_prov total_per_sample 3.0043
+15s gauge_dec2 merged_with_prov section LABEL_DICT 2209 0.0184
+15s gauge_dec2 merged_with_prov section TS_PAGES 212719 1.7727
+15s gauge_dec2 merged_with_prov section VAL_PAGES 126952 1.0579
+15s gauge_dec2 merged_with_prov section SERIES_IDS 8004 0.0667
+15s gauge_dec2 merged_with_prov section SERIES_META 10406 0.0867
+15s gauge_dec2 merged_with_prov residual 223 0.0019
+15s gauge_dec2 merged_with_prov valenc VAL_GCD_DELTA_FOR 500
+15s random_float(ctrl) fragmented object_bytes 3182003
+15s random_float(ctrl) fragmented total_per_sample 26.5167
+15s random_float(ctrl) fragmented section LABEL_DICT 2209 0.0184
+15s random_float(ctrl) fragmented section TS_PAGES 840000 7.0000
+15s random_float(ctrl) fragmented section VAL_PAGES 1680000 14.0000
+15s random_float(ctrl) fragmented section SERIES_IDS 8004 0.0667
+15s random_float(ctrl) fragmented section SERIES_META 651569 5.4297
+15s random_float(ctrl) fragmented residual 221 0.0018
+15s random_float(ctrl) fragmented valenc VAL_RAW_F64 120000
+15s random_float(ctrl) merged_no_prov object_bytes 1065208
+15s random_float(ctrl) merged_no_prov total_per_sample 8.8767
+15s random_float(ctrl) merged_no_prov section LABEL_DICT 2209 0.0184
+15s random_float(ctrl) merged_no_prov section TS_PAGES 212719 1.7727
+15s random_float(ctrl) merged_no_prov section VAL_PAGES 831175 6.9265
+15s random_float(ctrl) merged_no_prov section SERIES_IDS 8004 0.0667
+15s random_float(ctrl) merged_no_prov section SERIES_META 10880 0.0907
+15s random_float(ctrl) merged_no_prov residual 221 0.0018
+15s random_float(ctrl) merged_no_prov valenc VAL_GORILLA 362
+15s random_float(ctrl) merged_no_prov valenc VAL_RAW_F64 35
+15s random_float(ctrl) merged_no_prov valenc VAL_ALP 3
+15s random_float(ctrl) merged_no_prov valenc VAL_GCD_DELTA_FOR 100
+15s random_float(ctrl) merged_with_prov object_bytes 1065528
+15s random_float(ctrl) merged_with_prov total_per_sample 8.8794
+15s random_float(ctrl) merged_with_prov section LABEL_DICT 2209 0.0184
+15s random_float(ctrl) merged_with_prov section TS_PAGES 212719 1.7727
+15s random_float(ctrl) merged_with_prov section VAL_PAGES 831175 6.9265
+15s random_float(ctrl) merged_with_prov section SERIES_IDS 8004 0.0667
+15s random_float(ctrl) merged_with_prov section SERIES_META 11199 0.0933
+15s random_float(ctrl) merged_with_prov residual 222 0.0019
+15s random_float(ctrl) merged_with_prov valenc VAL_GORILLA 362
+15s random_float(ctrl) merged_with_prov valenc VAL_RAW_F64 35
+15s random_float(ctrl) merged_with_prov valenc VAL_ALP 3
+15s random_float(ctrl) merged_with_prov valenc VAL_GCD_DELTA_FOR 100
+60s counter_int_resets fragmented object_bytes 2940838
+60s counter_int_resets fragmented total_per_sample 24.5070
+60s counter_int_resets fragmented section LABEL_DICT 2209 0.0184
+60s counter_int_resets fragmented section TS_PAGES 840000 7.0000
+60s counter_int_resets fragmented section VAL_PAGES 1409387 11.7449
+60s counter_int_resets fragmented section SERIES_IDS 8004 0.0667
+60s counter_int_resets fragmented section SERIES_META 681019 5.6752
+60s counter_int_resets fragmented residual 219 0.0018
+60s counter_int_resets fragmented valenc VAL_ALP 120000
+60s counter_int_resets merged_no_prov object_bytes 360284
+60s counter_int_resets merged_no_prov total_per_sample 3.0024
+60s counter_int_resets merged_no_prov section LABEL_DICT 2209 0.0184
+60s counter_int_resets merged_no_prov section TS_PAGES 212719 1.7727
+60s counter_int_resets merged_no_prov section VAL_PAGES 126659 1.0555
+60s counter_int_resets merged_no_prov section SERIES_IDS 8004 0.0667
+60s counter_int_resets merged_no_prov section SERIES_META 10474 0.0873
+60s counter_int_resets merged_no_prov residual 219 0.0018
+60s counter_int_resets merged_no_prov valenc VAL_ALP 478
+60s counter_int_resets merged_no_prov valenc VAL_GCD_DELTA_FOR 22
+60s counter_int_resets merged_with_prov object_bytes 360604
+60s counter_int_resets merged_with_prov total_per_sample 3.0050
+60s counter_int_resets merged_with_prov section LABEL_DICT 2209 0.0184
+60s counter_int_resets merged_with_prov section TS_PAGES 212719 1.7727
+60s counter_int_resets merged_with_prov section VAL_PAGES 126659 1.0555
+60s counter_int_resets merged_with_prov section SERIES_IDS 8004 0.0667
+60s counter_int_resets merged_with_prov section SERIES_META 10795 0.0900
+60s counter_int_resets merged_with_prov residual 218 0.0018
+60s counter_int_resets merged_with_prov valenc VAL_ALP 478
+60s counter_int_resets merged_with_prov valenc VAL_GCD_DELTA_FOR 22
+60s gauge_int fragmented object_bytes 2956606
+60s gauge_int fragmented total_per_sample 24.6384
+60s gauge_int fragmented section LABEL_DICT 2209 0.0184
+60s gauge_int fragmented section TS_PAGES 840000 7.0000
+60s gauge_int fragmented section VAL_PAGES 1432779 11.9398
+60s gauge_int fragmented section SERIES_IDS 8004 0.0667
+60s gauge_int fragmented section SERIES_META 673394 5.6116
+60s gauge_int fragmented residual 220 0.0018
+60s gauge_int fragmented valenc VAL_ALP 120000
+60s gauge_int merged_no_prov object_bytes 299807
+60s gauge_int merged_no_prov total_per_sample 2.4984
+60s gauge_int merged_no_prov section LABEL_DICT 2209 0.0184
+60s gauge_int merged_no_prov section TS_PAGES 212719 1.7727
+60s gauge_int merged_no_prov section VAL_PAGES 66470 0.5539
+60s gauge_int merged_no_prov section SERIES_IDS 8004 0.0667
+60s gauge_int merged_no_prov section SERIES_META 10186 0.0849
+60s gauge_int merged_no_prov residual 219 0.0018
+60s gauge_int merged_no_prov valenc VAL_GCD_DELTA_FOR 500
+60s gauge_int merged_with_prov object_bytes 300127
+60s gauge_int merged_with_prov total_per_sample 2.5011
+60s gauge_int merged_with_prov section LABEL_DICT 2209 0.0184
+60s gauge_int merged_with_prov section TS_PAGES 212719 1.7727
+60s gauge_int merged_with_prov section VAL_PAGES 66470 0.5539
+60s gauge_int merged_with_prov section SERIES_IDS 8004 0.0667
+60s gauge_int merged_with_prov section SERIES_META 10505 0.0875
+60s gauge_int merged_with_prov residual 220 0.0018
+60s gauge_int merged_with_prov valenc VAL_GCD_DELTA_FOR 500
+60s gauge_dec2 fragmented object_bytes 3074740
+60s gauge_dec2 fragmented total_per_sample 25.6228
+60s gauge_dec2 fragmented section LABEL_DICT 2209 0.0184
+60s gauge_dec2 fragmented section TS_PAGES 840000 7.0000
+60s gauge_dec2 fragmented section VAL_PAGES 1539609 12.8301
+60s gauge_dec2 fragmented section SERIES_IDS 8004 0.0667
+60s gauge_dec2 fragmented section SERIES_META 684695 5.7058
+60s gauge_dec2 fragmented residual 223 0.0019
+60s gauge_dec2 fragmented valenc VAL_ALP 120000
+60s gauge_dec2 merged_no_prov object_bytes 360329
+60s gauge_dec2 merged_no_prov total_per_sample 3.0027
+60s gauge_dec2 merged_no_prov section LABEL_DICT 2209 0.0184
+60s gauge_dec2 merged_no_prov section TS_PAGES 212719 1.7727
+60s gauge_dec2 merged_no_prov section VAL_PAGES 126952 1.0579
+60s gauge_dec2 merged_no_prov section SERIES_IDS 8004 0.0667
+60s gauge_dec2 merged_no_prov section SERIES_META 10225 0.0852
+60s gauge_dec2 merged_no_prov residual 220 0.0018
+60s gauge_dec2 merged_no_prov valenc VAL_GCD_DELTA_FOR 500
+60s gauge_dec2 merged_with_prov object_bytes 360649
+60s gauge_dec2 merged_with_prov total_per_sample 3.0054
+60s gauge_dec2 merged_with_prov section LABEL_DICT 2209 0.0184
+60s gauge_dec2 merged_with_prov section TS_PAGES 212719 1.7727
+60s gauge_dec2 merged_with_prov section VAL_PAGES 126952 1.0579
+60s gauge_dec2 merged_with_prov section SERIES_IDS 8004 0.0667
+60s gauge_dec2 merged_with_prov section SERIES_META 10545 0.0879
+60s gauge_dec2 merged_with_prov residual 220 0.0018
+60s gauge_dec2 merged_with_prov valenc VAL_GCD_DELTA_FOR 500
+60s random_float(ctrl) fragmented object_bytes 3203059
+60s random_float(ctrl) fragmented total_per_sample 26.6922
+60s random_float(ctrl) fragmented section LABEL_DICT 2209 0.0184
+60s random_float(ctrl) fragmented section TS_PAGES 840000 7.0000
+60s random_float(ctrl) fragmented section VAL_PAGES 1680000 14.0000
+60s random_float(ctrl) fragmented section SERIES_IDS 8004 0.0667
+60s random_float(ctrl) fragmented section SERIES_META 672621 5.6052
+60s random_float(ctrl) fragmented residual 225 0.0019
+60s random_float(ctrl) fragmented valenc VAL_RAW_F64 120000
+60s random_float(ctrl) merged_no_prov object_bytes 1065360
+60s random_float(ctrl) merged_no_prov total_per_sample 8.8780
+60s random_float(ctrl) merged_no_prov section LABEL_DICT 2209 0.0184
+60s random_float(ctrl) merged_no_prov section TS_PAGES 212719 1.7727
+60s random_float(ctrl) merged_no_prov section VAL_PAGES 831175 6.9265
+60s random_float(ctrl) merged_no_prov section SERIES_IDS 8004 0.0667
+60s random_float(ctrl) merged_no_prov section SERIES_META 11034 0.0920
+60s random_float(ctrl) merged_no_prov residual 219 0.0018
+60s random_float(ctrl) merged_no_prov valenc VAL_GORILLA 362
+60s random_float(ctrl) merged_no_prov valenc VAL_RAW_F64 35
+60s random_float(ctrl) merged_no_prov valenc VAL_ALP 3
+60s random_float(ctrl) merged_no_prov valenc VAL_GCD_DELTA_FOR 100
+60s random_float(ctrl) merged_with_prov object_bytes 1065680
+60s random_float(ctrl) merged_with_prov total_per_sample 8.8807
+60s random_float(ctrl) merged_with_prov section LABEL_DICT 2209 0.0184
+60s random_float(ctrl) merged_with_prov section TS_PAGES 212719 1.7727
+60s random_float(ctrl) merged_with_prov section VAL_PAGES 831175 6.9265
+60s random_float(ctrl) merged_with_prov section SERIES_IDS 8004 0.0667
+60s random_float(ctrl) merged_with_prov section SERIES_META 11356 0.0946
+60s random_float(ctrl) merged_with_prov residual 217 0.0018
+60s random_float(ctrl) merged_with_prov valenc VAL_GORILLA 362
+60s random_float(ctrl) merged_with_prov valenc VAL_RAW_F64 35
+60s random_float(ctrl) merged_with_prov valenc VAL_ALP 3
+60s random_float(ctrl) merged_with_prov valenc VAL_GCD_DELTA_FOR 100


### PR DESCRIPTION
The catalog byte gate measured RSEG against the generator's default
full-mantissa float. The integer-model value codecs cannot fire on a 53-bit
random mantissa by construction, so the gate exercised the raw-f64 fallback
and the resulting 8.88 B/sample was quoted as the format's cost. ADR-0092
identified this exact generator line as the flaw in its round-one bake-off and
round two added realistic value shapes, but the byte gate was never re-pointed
at them.

Re-points the same 500x240 fixture at realistic value distributions, changing
only the value column, and commits the result as an exact golden.

| shape | merged B/sample | value codec that fired |
|---|---|---|
| `gauge_int` | 2.50 | VAL_GCD_DELTA_FOR (500/500 runs) |
| `counter_int_resets` | 3.00 | VAL_ALP (478), VAL_GCD_DELTA_FOR (22) |
| `gauge_dec2` | 3.00 | VAL_GCD_DELTA_FOR (500/500) |
| `random_float` (control) | 8.88 | VAL_GORILLA (362), VAL_RAW_F64 (35) |

The integer-model codecs fire on every realistic shape and never on the
control, which is the mechanism the re-pointing predicted.

The per-section split matters as much as the total. On realistic shapes
TS_PAGES is 1.77 B/sample against VAL_PAGES at 0.55 to 1.06, so timestamps are
59 to 71 percent of a merged object; on the control that ratio inverts to 20
percent. Work aimed at value-page compression was scoped against the control's
profile and should be reconsidered against these numbers.

TS_PAGES is byte-identical at 15s and 60s. Review confirmed this is a real
codec result rather than a stuck knob: the timestamps genuinely differ between
the two fixtures and SERIES_META differs accordingly, but the generator draws
jitter from the same RNG sequence either way, so every 60s delta is a constant
offset from the 15s one and lands on the same encoded width.

Also fixes the split accounting so the parts sum: the old view divided the
whole object for the total but summed only five named sections, leaving the
footer, the 16-byte trailer and alignment padding as an unaccounted remainder.

Three hardening fixes from review, all in the gate itself: the
sections-plus-residual assertion was an identity that could not fail and now
bounds the residual instead; the golden comparison could exit its mismatch
branch without asserting when files differed only in trailing whitespace and
now fails; and `REGEN_CATALOG_BYTE_GATES` was gated on presence, so an empty
value silently regenerated instead of asserting.

Note for follow-up, not addressed here: ADR-0092 still quotes 8.88 as the
shipped merged cost in several places.

Fixes: #370
