### PR TITLE
fix(ingest): count attribute overhead in log and span estimators

### DIFF
--- a/crates/ravel-ingest/src/log_shard.rs
+++ b/crates/ravel-ingest/src/log_shard.rs
@@ -101,11 +101,19 @@ fn attr_value_len(value: &AttrValue) -> usize {
 /// encoded length, plus a fixed 32 covering the two i64 timestamps,
 /// severity_num, flags, and the optional trace/span ids. A `target_bytes`
 /// flush-trigger estimate, not a byte-exact accounting of the RLOG output.
+///
+/// Each attribute also costs its `(String, AttrValue)` pair header, the log
+/// analogue of the `size_of::<Label>()` term [`crate::shard::TenantBuf::merge`]
+/// and [`crate::value::IngestPoint::est_charge_bytes`] apply per label: the
+/// buffer holds that struct whatever the key and value bytes contain, and all
+/// three signals charge the one process-wide byte budget (ADR-0069), so leaving
+/// the header term out here would undercharge the shared ceiling on exactly the
+/// attribute-heavy records it exists to bound while metrics charge it honestly.
 pub(crate) fn est_record_bytes(rec: &NormalizedLogRecord) -> usize {
     let attr_bytes: usize = rec
         .attrs
         .iter()
-        .map(|(k, v)| k.len() + attr_value_len(v))
+        .map(|(k, v)| size_of::<(String, AttrValue)>() + k.len() + attr_value_len(v))
         .sum();
     rec.body.len() + rec.severity_text.len() + rec.stream_attrs.len() + attr_bytes + 32
 }

--- a/crates/ravel-ingest/src/span_shard.rs
+++ b/crates/ravel-ingest/src/span_shard.rs
@@ -82,8 +82,21 @@ pub(crate) enum SpanShardMsg {
 /// covering the two i64 timestamps, the 16-byte trace id, the two 8-byte span
 /// ids, and the status code. A `target_bytes` flush-trigger estimate, not a
 /// byte-exact accounting of the RSPAN output.
+///
+/// Each attribute also costs its `(String, String)` pair header, the span
+/// analogue of the `size_of::<Label>()` term [`crate::shard::TenantBuf::merge`]
+/// and [`crate::value::IngestPoint::est_charge_bytes`] apply per label (and
+/// byte-identical to it, since a span attribute pair is two `String` headers
+/// just as `Label` is): the buffer holds that struct whatever the key and value
+/// bytes contain, and all three signals charge the one process-wide byte budget
+/// (ADR-0069), so leaving the header term out here would undercharge the shared
+/// ceiling on attribute-heavy spans while metrics charge it honestly.
 pub(crate) fn est_span_bytes(span: &NormalizedSpan) -> usize {
-    let attr_bytes: usize = span.attrs.iter().map(|(k, v)| k.len() + v.len()).sum();
+    let attr_bytes: usize = span
+        .attrs
+        .iter()
+        .map(|(k, v)| size_of::<(String, String)>() + k.len() + v.len())
+        .sum();
     span.name.len() + span.status_message.as_ref().map(String::len).unwrap_or(0) + attr_bytes + 64
 }
 

--- a/crates/ravel-ingest/src/value.rs
+++ b/crates/ravel-ingest/src/value.rs
@@ -165,6 +165,13 @@ mod tests {
     use super::*;
     use ravel_types::Exemplar;
 
+    use crate::log_shard::est_record_bytes;
+    use crate::span_shard::est_span_bytes;
+    use ravel_otlp::logs_normalize::NormalizedLogRecord;
+    use ravel_otlp::traces_normalize::NormalizedSpan;
+    use ravel_rspan::StatusCode;
+    use ravel_types::logstream::{AttrValue, LogStreamId};
+
     fn labels_of(count: usize) -> LabelSet {
         let labels = (0..count)
             .map(|i| Label {
@@ -197,6 +204,146 @@ mod tests {
                 filtered_attributes: labels.iter().cloned().collect(),
             },
         }
+    }
+
+    /// A log record carrying `attr_count` attributes, each the identical
+    /// `("attr", "v")` pair, and every other field empty/zero so that
+    /// differencing two attribute widths cancels every fixed term and isolates
+    /// the per-attribute charge.
+    fn log_record_with(attr_count: usize) -> NormalizedLogRecord {
+        NormalizedLogRecord {
+            stream_id: LogStreamId([0u8; 16]),
+            stream_attrs: Vec::new(),
+            ts_ns: 1_000,
+            observed_ts_ns: 1_000,
+            severity_num: 9,
+            severity_text: String::new(),
+            body: String::new(),
+            trace_id: None,
+            span_id: None,
+            flags: 0,
+            attrs: (0..attr_count)
+                .map(|_| ("attr".to_string(), AttrValue::Str("v".to_string())))
+                .collect(),
+        }
+    }
+
+    /// A span carrying `attr_count` attributes, each the identical
+    /// `("attr", "v")` pair, everything else empty/zero. Same differencing
+    /// trick as [`log_record_with`].
+    fn span_with(attr_count: usize) -> NormalizedSpan {
+        NormalizedSpan {
+            trace_id: [0u8; 16],
+            span_id: [0u8; 8],
+            parent_span_id: None,
+            name: String::new(),
+            start_ts_ns: 1_000,
+            end_ts_ns: 1_100,
+            status_code: StatusCode::Unset,
+            status_message: None,
+            attrs: (0..attr_count)
+                .map(|_| ("attr".to_string(), "v".to_string()))
+                .collect(),
+        }
+    }
+
+    /// Every buffered-byte estimator feeding the one process-wide ingest byte
+    /// budget (ADR-0069) must charge a per-attribute struct header for its
+    /// TOP-LEVEL attributes, not only the attribute's string bytes. Metrics
+    /// points and exemplars, log records, and spans all charge that single
+    /// shared ceiling by `Arc` (docs/ingest.md), so if any one estimator drops
+    /// the header term it silently undercharges the ceiling on its own signal
+    /// while the others charge honestly -- exactly the skew this pin exists to
+    /// catch.
+    ///
+    /// Scope, so this doc does not read as more than it proves: the pin covers
+    /// depth 0 only, with `AttrValue::Str` values. A log attribute whose value
+    /// is a nested `Map` is measured by `attr_value_len`, which still counts
+    /// string bytes alone at every level below the top, and this test does not
+    /// catch that.
+    ///
+    /// Each estimator's header term is isolated by differencing two attribute
+    /// widths with identical per-attribute content, which cancels every fixed
+    /// term (sample bytes, timestamps, body/name). The isolated term must equal
+    /// that estimator's own attribute-pair `size_of`: `Label` for metrics,
+    /// `(String, String)` for spans (byte-identical to `Label`), and the wider
+    /// `(String, AttrValue)` for logs. This is the pin that stops the four rules
+    /// drifting apart again.
+    #[test]
+    fn every_estimator_charges_a_per_attribute_header() {
+        const W: u64 = 8;
+        let label_sz = size_of::<Label>() as u64;
+
+        // Metrics point: header per label is `size_of::<Label>()`.
+        let labels = labels_of(W as usize);
+        let label_content: u64 = labels
+            .iter()
+            .map(|l| (l.name.len() + l.value.len()) as u64)
+            .sum();
+        let point = point_with(labels.clone());
+        let point_hdr = point.est_charge_bytes() - 16 - label_content;
+        assert_eq!(
+            point_hdr,
+            W * label_sz,
+            "IngestPoint::est_charge_bytes dropped the per-label header: \
+             {point_hdr} != {}",
+            W * label_sz
+        );
+
+        // Metrics exemplar: same `Label` header per filtered attribute.
+        let exemplar = exemplar_with(labels);
+        let exemplar_hdr =
+            (exemplar.est_bytes() - size_of::<IngestExemplar>()) as u64 - label_content;
+        assert_eq!(
+            exemplar_hdr,
+            W * label_sz,
+            "IngestExemplar::est_bytes dropped the per-attribute header: \
+             {exemplar_hdr} != {}",
+            W * label_sz
+        );
+
+        // Log record: pair is `(String, AttrValue)`, wider than a `Label`.
+        let log_pair = size_of::<(String, AttrValue)>() as u64;
+        let attr_content = W * ("attr".len() + "v".len()) as u64;
+        let log_hdr = (est_record_bytes(&log_record_with(W as usize))
+            - est_record_bytes(&log_record_with(0))) as u64
+            - attr_content;
+        assert_eq!(
+            log_hdr,
+            W * log_pair,
+            "est_record_bytes dropped the per-attribute header: {log_hdr} != {}",
+            W * log_pair
+        );
+
+        // Span: pair is `(String, String)`, byte-identical to a `Label`.
+        let span_pair = size_of::<(String, String)>() as u64;
+        let span_hdr = (est_span_bytes(&span_with(W as usize)) - est_span_bytes(&span_with(0)))
+            as u64
+            - attr_content;
+        assert_eq!(
+            span_hdr,
+            W * span_pair,
+            "est_span_bytes dropped the per-attribute header: {span_hdr} != {}",
+            W * span_pair
+        );
+
+        // Consistency across all four: the two-`String`-pair signals (point,
+        // exemplar, span) charge the identical per-attribute header, and the
+        // log record's `(String, AttrValue)` header is never smaller (a smaller
+        // one would undercharge the shared ceiling on logs against the rest).
+        assert_eq!(
+            span_pair, label_sz,
+            "span attr pair must match `Label` width"
+        );
+        assert!(
+            log_pair >= label_sz,
+            "log attr pair must be at least `Label` width"
+        );
+        assert_eq!(
+            point_hdr, exemplar_hdr,
+            "point and exemplar headers must agree"
+        );
+        assert_eq!(point_hdr, span_hdr, "point and span headers must agree");
     }
 
     /// The two buffered-byte estimators must charge one label the same way, or

--- a/docs/ingest.md
+++ b/docs/ingest.md
@@ -521,7 +521,13 @@ Each ingest write charges its estimated buffered bytes into the gauge in the
 router's write path, after decode/normalize/admission and before any shard
 buffer is touched (`IngestPoint::est_charge_bytes`: 16 bytes per sample plus,
 per label, the `Label` struct header and the name/value bytes, plus each
-exemplar's buffered width). If the charge would push the gauge past the ceiling
+exemplar's buffered width). The log and span routers charge the same gauge with
+`est_record_bytes`/`est_span_bytes`, and those apply the identical per-attribute
+rule: each attribute costs its pair struct header (`(String, AttrValue)` for a
+log attribute, `(String, String)` for a span attribute, the latter byte-for-byte
+the same as a `Label`) plus its key/value bytes. Counting only the string bytes
+on any one signal would undercharge this shared ceiling on that signal while the
+others charge honestly. If the charge would push the gauge past the ceiling
 (`--max-ingest-buffer-bytes`, default 512 MiB, `0` = unlimited) the request
 is shed *before* buffering: no shard is touched, no commit token is minted,
 the shed counter increments, and the caller gets HTTP 429 with `Retry-After`
@@ -545,13 +551,21 @@ terms:
    This ceiling covers the estimated bytes of every shard buffer *and* every
    in-flight pipelined flush across all tenants and signals at once, since a
    flush's buffer stays charged until its PUTs complete. The charge is an
-   estimate (`est_charge_bytes`). It counts a series' label bytes on every
-   point rather than only on first sight, which over-counts, and it counts
-   neither `HashMap` overhead nor allocator slack, which under-counts by
-   more. The second effect dominates: measured on a 50k-series, 11-label
+   estimate. For metrics (`est_charge_bytes`) it counts a series' label bytes
+   on every point rather than only on first sight, which over-counts, and it
+   counts neither `HashMap` overhead nor allocator slack, which under-counts
+   by more. The second effect dominates: measured on a 50k-series, 11-label
    buffered workload, the charged figure was 38.4 MB against a 69.3 MB
-   resident delta. Size a host for roughly twice this ceiling, not for the
-   ceiling itself.
+   resident delta. Size a metrics host for roughly twice this ceiling, not
+   for the ceiling itself.
+
+   That two-times figure is a metrics measurement and does not transfer to
+   logs. `est_record_bytes` counts the pair header for a record's own
+   attributes but `attr_value_len` still measures a nested `Map` value by its
+   string bytes alone, so a record whose attributes nest can under-charge by
+   far more than two times. Until that is fixed, treat the ceiling as a lower
+   bound on log resident memory rather than a proportional estimate, and size
+   a log-heavy host from measurement rather than from this multiplier.
 2. **In-flight decode overhead**: each admitted in-flight request transiently
    holds one decoded/normalized request body during normalization, before its
    points reach a buffer. This is bounded by


### PR DESCRIPTION
Issue #369 corrected the metrics buffered-byte estimators to count the
per-label `Label` struct header but named only the metrics path. The log and
span estimators carried the same defect: `est_record_bytes` and
`est_span_bytes` summed only attribute string lengths.

All signals charge one process-wide ingest byte budget (ADR-0069), shared by
`Arc` across the metrics, log and span routers. With only metrics counting the
header, that single ceiling was fed by two different accounting rules, so it
silently favoured whichever signal was undercounted when it bound.

The attribute types differ, so this is not a copy of the metrics rule: a log
attribute is `(String, AttrValue)` at 56 bytes of header, a span attribute is
`(String, String)` at 48, byte-identical to a `Label`. Both use `size_of`
rather than literals, so a new `AttrValue` variant cannot silently rot the
figure.

The cross-estimator pin now covers all four estimators feeding the shared
budget. Review verified each arm independently by reverting one estimator at a
time; each produced a distinct failure naming its own estimator, so no arm is
decorative.

Defaults in `config.rs` are deliberately untouched. Request cost is linear in
flush count, so that trade gets decided once every signal's input number is
honest.

Two scoping corrections were made on review. The worst-case-memory section's
"size a host for roughly twice this ceiling" was measured on metrics, and this
change extends that section to logs and spans where it does not hold, so it is
now scoped with the log caveat stated. The pinning test's doc comment claimed
every estimator charges a per-attribute header, which reads as universal when
it covers depth 0 with `Str` values.

Known gap, filed separately rather than fixed here: `attr_value_len` still
measures nested `Map` attribute values by string bytes alone, so a log record
with nested attributes can under-charge by a large factor. Pre-existing, and
strictly improved by this change at depth 0.

Fixes: #385
