### PR TITLE
test(otlp): measure normalize per-datapoint allocations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4657,6 +4657,7 @@ name = "ravel-otlp"
 version = "0.10.0"
 dependencies = [
  "blake3",
+ "criterion",
  "hex",
  "opentelemetry-proto",
  "proptest",
@@ -4665,6 +4666,7 @@ dependencies = [
  "ravel-rspan",
  "ravel-segment",
  "ravel-types",
+ "stats_alloc",
  "thiserror",
  "tokio",
 ]

--- a/crates/ravel-otlp/Cargo.toml
+++ b/crates/ravel-otlp/Cargo.toml
@@ -28,6 +28,21 @@ hex = { workspace = true }
 tokio = { workspace = true }
 blake3 = { workspace = true }
 proptest = { workspace = true }
+criterion = { workspace = true }
+# Same version already vendored by ravel-otap and ravel-bench; not a
+# workspace.dependencies entry, so it is pinned here to match theirs.
+stats_alloc = "0.1.10"
+
+[features]
+# Compiles the SeriesIdMemo hit/miss counters (normalize::memo_stats) into the
+# build. Off by default: the counters are otherwise present only under
+# `cfg(test)`, so the production normalize path carries none of them. The
+# normalize_alloc bench enables this to report the memo hit rate.
+memo-stats = []
+
+[[bench]]
+name = "normalize_alloc"
+harness = false
 
 [lints]
 workspace = true

--- a/crates/ravel-otlp/benches/normalize_alloc.rs
+++ b/crates/ravel-otlp/benches/normalize_alloc.rs
@@ -1,0 +1,379 @@
+//! Allocation accounting for the OTLP metrics normalize path (#367).
+//!
+//! This benchmark MEASURES a claim; it changes nothing. The claim, read from
+//! `normalize.rs` and not yet verified, is that `build_point` allocates on the
+//! order of `2 * (labels per point) + 4` times per datapoint, and that the
+//! per-metric `SeriesIdMemo` is at best neutral and at worst net-negative.
+//! Every number here is produced so that claim can be confirmed or refuted.
+//!
+//! What is measured, and what is deliberately kept out of the measured region
+//! (the earlier profiling task in this epic reported numbers dominated by its
+//! own harness and had to withdraw them; this does not repeat that):
+//!
+//! - The `ExportMetricsServiceRequest` fixture is built ONCE per configuration,
+//!   entirely outside the `stats_alloc::Region`. `normalize_metrics` consumes
+//!   its request by value, so the measured call receives an owned request that
+//!   was constructed before the region opened; no fixture clone, no `Vec`
+//!   growth for collecting results, and no formatting happens inside the region.
+//! - `SeriesId::compute` keeps a thread-local scratch buffer that grows on
+//!   first use. A warmup `normalize_metrics` call runs on the same thread
+//!   before every measured region so that one-time growth is not counted as a
+//!   per-point cost.
+//! - The only allocations left inside the region are `normalize_metrics`'s own:
+//!   per-point label building plus the output point `Vec`. The output `Vec`
+//!   grows O(log points) times and washes out of the per-point figure.
+//!
+//! Reachability: this is measurement infrastructure. Its only callers are
+//! `cargo bench` and a human reading the output; there is no production caller.
+//!
+//! The memo hit-rate half (deliverable 3) needs the `memo-stats` cargo feature:
+//!
+//! ```sh
+//! cargo bench -p ravel-otlp --features memo-stats --bench normalize_alloc
+//! ```
+//!
+//! Without the feature the bench still builds and runs (so it compiles under
+//! `--all-targets`); it just prints a note where the hit rate would be.
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::alloc::System;
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest;
+use opentelemetry_proto::tonic::common::v1::any_value::Value as AnyValueVariant;
+use opentelemetry_proto::tonic::common::v1::{AnyValue, KeyValue};
+use opentelemetry_proto::tonic::metrics::v1::number_data_point::Value as NumberValue;
+use opentelemetry_proto::tonic::metrics::v1::{
+    Gauge, Metric, NumberDataPoint, ResourceMetrics, ScopeMetrics, metric::Data as MetricData,
+};
+use opentelemetry_proto::tonic::resource::v1::Resource;
+use ravel_otlp::{IngestLimits, normalize_metrics};
+use ravel_types::TenantId;
+use stats_alloc::{INSTRUMENTED_SYSTEM, Region, StatsAlloc};
+
+#[global_allocator]
+static GLOBAL: &StatsAlloc<System> = &INSTRUMENTED_SYSTEM;
+
+const INGEST_TS_NS: i64 = 1_700_000_000_000_000_000;
+/// Metrics per request in the sweep. Allocation counts are exact and
+/// deterministic, so this only needs to be large enough that the per-request
+/// fixed cost (the output `Vec`) is negligible against the per-point figure.
+const METRICS: usize = 8;
+
+/// How the datapoints within one metric map to series.
+#[derive(Clone, Copy, PartialEq)]
+enum Shape {
+    /// Every datapoint of a metric carries an identical attribute set: one
+    /// series per metric. The memo hits on every point after the first.
+    Grouped,
+    /// Each datapoint of a metric carries a distinct attribute value, so no two
+    /// consecutive points share a series. The one-entry memo never hits.
+    Interleaved,
+}
+
+#[derive(Clone, Copy)]
+struct Cfg {
+    /// Resource labels per resource (`R`); paid per POINT if the claim holds.
+    resource_labels: usize,
+    /// Attributes per datapoint (`A`).
+    attrs_per_point: usize,
+    /// Datapoints per metric; the term that separates per-resource from
+    /// per-point costs.
+    points_per_metric: usize,
+    /// When true, attribute names carry a `.` that `sanitize_label_name` must
+    /// rewrite; when false, names are already valid label names.
+    needs_sanitise: bool,
+    shape: Shape,
+}
+
+impl Cfg {
+    /// `L` in the `2L + 4` model: labels contributed per point excluding the
+    /// synthesized `__name__`.
+    fn labels_per_point(&self) -> usize {
+        self.resource_labels + self.attrs_per_point
+    }
+}
+
+/// One attribute key. A dirty key holds a `.`, which sanitisation rewrites to
+/// `_`; a clean key is already a valid label name (sanitisation still runs and
+/// still allocates, which is the point under test).
+fn attr_key(i: usize, needs_sanitise: bool) -> String {
+    if needs_sanitise {
+        format!("attr.{i}")
+    } else {
+        format!("attr_{i}")
+    }
+}
+
+fn string_kv(key: String, value: String) -> KeyValue {
+    KeyValue {
+        key,
+        value: Some(AnyValue {
+            value: Some(AnyValueVariant::StringValue(value)),
+        }),
+        ..Default::default()
+    }
+}
+
+/// Limits whose allowlist admits exactly `resource_labels` resource attributes,
+/// so each configured resource attribute becomes one resource label.
+fn limits_for(cfg: &Cfg) -> IngestLimits {
+    IngestLimits {
+        resource_attribute_allowlist: (0..cfg.resource_labels)
+            .map(|i| format!("res_{i}"))
+            .collect(),
+        ..IngestLimits::default()
+    }
+}
+
+/// The attribute set for point `idx` of a metric under `cfg`.
+fn attrs_for_point(cfg: &Cfg, idx: usize) -> Vec<KeyValue> {
+    (0..cfg.attrs_per_point)
+        .map(|a| {
+            let key = attr_key(a, cfg.needs_sanitise);
+            let value = match cfg.shape {
+                // Vary attribute 0 by point index so every point is its own
+                // series; the rest are constant.
+                Shape::Interleaved if a == 0 => format!("v{idx}"),
+                _ => format!("v{a}"),
+            };
+            string_kv(key, value)
+        })
+        .collect()
+}
+
+/// Build the request fixture for `cfg`, entirely outside any measured region.
+/// Returns the request and its total datapoint count.
+fn build_request(cfg: &Cfg) -> (ExportMetricsServiceRequest, usize) {
+    let resource_attrs: Vec<KeyValue> = (0..cfg.resource_labels)
+        .map(|i| string_kv(format!("res_{i}"), format!("rv{i}")))
+        .collect();
+
+    let metrics: Vec<Metric> = (0..METRICS)
+        .map(|m| {
+            let data_points: Vec<NumberDataPoint> = (0..cfg.points_per_metric)
+                .map(|p| NumberDataPoint {
+                    attributes: attrs_for_point(cfg, p),
+                    time_unix_nano: (INGEST_TS_NS + p as i64 * 1_000_000) as u64,
+                    value: Some(NumberValue::AsDouble(p as f64 * 0.5)),
+                    ..Default::default()
+                })
+                .collect();
+            Metric {
+                name: format!("metric_{m}"),
+                data: Some(MetricData::Gauge(Gauge { data_points })),
+                ..Default::default()
+            }
+        })
+        .collect();
+
+    let req = ExportMetricsServiceRequest {
+        resource_metrics: vec![ResourceMetrics {
+            resource: Some(Resource {
+                attributes: resource_attrs,
+                ..Default::default()
+            }),
+            scope_metrics: vec![ScopeMetrics {
+                metrics,
+                ..Default::default()
+            }],
+            ..Default::default()
+        }],
+    };
+    let total_points = METRICS * cfg.points_per_metric;
+    (req, total_points)
+}
+
+/// Allocations and bytes for one untimed `normalize_metrics` call on a freshly
+/// built (outside the region) fixture, after a same-thread warmup that grows
+/// `SeriesId::compute`'s thread-local scratch.
+fn measure_alloc(cfg: &Cfg, tenant: &TenantId) -> (usize, usize, usize) {
+    let limits = limits_for(cfg);
+
+    // Warmup on a separate fixture, same thread: grows the compute scratch so
+    // its one-time growth is not charged to the measured region.
+    let (warm, _) = build_request(cfg);
+    let warm_out = normalize_metrics(tenant, warm, &limits, INGEST_TS_NS);
+    std::hint::black_box(&warm_out);
+    drop(warm_out);
+
+    let (req, total_points) = build_request(cfg);
+    let region = Region::new(&INSTRUMENTED_SYSTEM);
+    let out = normalize_metrics(tenant, req, &limits, INGEST_TS_NS);
+    let change = region.change();
+    assert_eq!(out.points.len(), total_points, "unexpected point count");
+    (total_points, change.allocations, change.bytes_allocated)
+}
+
+fn sweep_configs() -> Vec<(String, Cfg)> {
+    let resource_labels = [0usize, 5, 15];
+    let attrs = [0usize, 5, 15];
+    let points = [1usize, 100];
+    let mut out = Vec::new();
+    for &r in &resource_labels {
+        for &a in &attrs {
+            for &pmm in &points {
+                for &sanitise in &[false, true] {
+                    // The sanitise variant only differs when there are
+                    // attributes to sanitise.
+                    if sanitise && a == 0 {
+                        continue;
+                    }
+                    let tag = if sanitise { "dirty" } else { "clean" };
+                    let label = format!("R{r}_A{a}_P{pmm}_{tag}");
+                    out.push((
+                        label,
+                        Cfg {
+                            resource_labels: r,
+                            attrs_per_point: a,
+                            points_per_metric: pmm,
+                            needs_sanitise: sanitise,
+                            shape: Shape::Grouped,
+                        },
+                    ));
+                }
+            }
+        }
+    }
+    out
+}
+
+fn report_sweep(tenant: &TenantId) {
+    eprintln!("\n=== #367 OTLP normalize allocation sweep (grouped: 1 series/metric) ===");
+    eprintln!(
+        "{:<22} {:>8} {:>10} {:>12} {:>10} {:>10}",
+        "config", "points", "allocs/pt", "bytes/pt", "2L+4", "measured-2L+4"
+    );
+    for (label, cfg) in sweep_configs() {
+        let (points, allocs, bytes) = measure_alloc(&cfg, tenant);
+        let per_pt = allocs as f64 / points as f64;
+        let bytes_pt = bytes as f64 / points as f64;
+        let predicted = 2.0 * cfg.labels_per_point() as f64 + 4.0;
+        eprintln!(
+            "{label:<22} {points:>8} {per_pt:>10.2} {bytes_pt:>12.1} {predicted:>10.1} {:>+10.2}",
+            per_pt - predicted
+        );
+    }
+}
+
+fn report_memo(tenant: &TenantId) {
+    eprintln!("\n=== #367 SeriesIdMemo hit rate and per-point cost ===");
+    // Two shapes at 100 points/metric, R=5, A=5, clean names, so only the
+    // series layout differs.
+    let base = Cfg {
+        resource_labels: 5,
+        attrs_per_point: 5,
+        points_per_metric: 100,
+        needs_sanitise: false,
+        shape: Shape::Grouped,
+    };
+    let grouped = base;
+    let interleaved = Cfg {
+        shape: Shape::Interleaved,
+        ..base
+    };
+
+    let (g_points, g_allocs, _) = measure_alloc(&grouped, tenant);
+    let (i_points, i_allocs, _) = measure_alloc(&interleaved, tenant);
+    let g_per = g_allocs as f64 / g_points as f64;
+    let i_per = i_allocs as f64 / i_points as f64;
+
+    eprintln!("R=5 A=5, 100 points/metric, {METRICS} metrics:");
+    eprintln!("  grouped     allocs/pt = {g_per:.2}");
+    eprintln!("  interleaved allocs/pt = {i_per:.2}");
+    eprintln!(
+        "  interleaved - grouped = {:+.2} allocs/pt (the memo's store-clone paid on every miss)",
+        i_per - g_per
+    );
+
+    report_memo_stats(tenant, &grouped, "grouped");
+    report_memo_stats(tenant, &interleaved, "interleaved");
+}
+
+#[cfg(feature = "memo-stats")]
+fn report_memo_stats(tenant: &TenantId, cfg: &Cfg, name: &str) {
+    use ravel_otlp::normalize::memo_stats;
+    let limits = limits_for(cfg);
+    let (req, _) = build_request(cfg);
+    memo_stats::reset();
+    let out = normalize_metrics(tenant, req, &limits, INGEST_TS_NS);
+    std::hint::black_box(&out);
+    let (hits, misses) = memo_stats::snapshot();
+    let total = hits + misses;
+    let rate = if total == 0 {
+        0.0
+    } else {
+        hits as f64 / total as f64 * 100.0
+    };
+    eprintln!("  {name:<12} hits={hits} misses={misses} hit_rate={rate:.1}%");
+}
+
+#[cfg(not(feature = "memo-stats"))]
+fn report_memo_stats(_tenant: &TenantId, _cfg: &Cfg, name: &str) {
+    eprintln!("  {name:<12} hit rate: rerun with --features memo-stats");
+}
+
+fn bench_normalize(c: &mut Criterion) {
+    let tenant = TenantId::new("acme");
+
+    // Allocation reporting (the deliverable), printed outside criterion's
+    // measured region so its bookkeeping never enters the counts.
+    report_sweep(&tenant);
+    report_memo(&tenant);
+
+    // A representative timing slice. iter_batched keeps the fixture clone in
+    // the untimed setup closure, so only normalize_metrics is timed.
+    let timing: [(&str, Cfg); 3] = [
+        (
+            "R0_A5_P100",
+            Cfg {
+                resource_labels: 0,
+                attrs_per_point: 5,
+                points_per_metric: 100,
+                needs_sanitise: false,
+                shape: Shape::Grouped,
+            },
+        ),
+        (
+            "R15_A5_P100",
+            Cfg {
+                resource_labels: 15,
+                attrs_per_point: 5,
+                points_per_metric: 100,
+                needs_sanitise: false,
+                shape: Shape::Grouped,
+            },
+        ),
+        (
+            "R5_A5_P100_interleaved",
+            Cfg {
+                resource_labels: 5,
+                attrs_per_point: 5,
+                points_per_metric: 100,
+                needs_sanitise: false,
+                shape: Shape::Interleaved,
+            },
+        ),
+    ];
+
+    let mut group = c.benchmark_group("normalize");
+    for (label, cfg) in timing {
+        let limits = limits_for(&cfg);
+        let (req, total_points) = build_request(&cfg);
+        group.throughput(Throughput::Elements(total_points as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(label), &req, |b, req| {
+            b.iter_batched(
+                || req.clone(),
+                |owned| {
+                    let out = normalize_metrics(&tenant, owned, &limits, INGEST_TS_NS);
+                    std::hint::black_box(out.points.len())
+                },
+                criterion::BatchSize::SmallInput,
+            );
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_normalize);
+criterion_main!(benches);

--- a/crates/ravel-otlp/src/normalize.rs
+++ b/crates/ravel-otlp/src/normalize.rs
@@ -678,11 +678,52 @@ impl SeriesIdMemo {
         if let Some((last_labels, last_id)) = &self.last
             && last_labels == labels
         {
+            #[cfg(any(test, feature = "memo-stats"))]
+            memo_stats::record_hit();
             return Ok(*last_id);
         }
+        #[cfg(any(test, feature = "memo-stats"))]
+        memo_stats::record_miss();
         let id = SeriesId::compute(tenant, metric_name, labels)?;
         self.last = Some((labels.clone(), id));
         Ok(id)
+    }
+}
+
+/// Hit/miss counters for [`SeriesIdMemo`], compiled only under `cfg(test)` or
+/// the `memo-stats` cargo feature; the production normalize path (neither cfg
+/// active) carries none of this. Counts are thread-local and process-global
+/// across every `SeriesIdMemo` on the thread, so a caller measures the memo's
+/// aggregate behaviour over a whole `normalize_metrics` call by resetting
+/// before it and reading the snapshot after. Used by the `normalize_alloc`
+/// bench and pinned by a unit test; there is no production reader.
+#[cfg(any(test, feature = "memo-stats"))]
+pub mod memo_stats {
+    use std::cell::Cell;
+
+    thread_local! {
+        static HITS: Cell<u64> = const { Cell::new(0) };
+        static MISSES: Cell<u64> = const { Cell::new(0) };
+    }
+
+    pub(super) fn record_hit() {
+        HITS.with(|h| h.set(h.get() + 1));
+    }
+
+    pub(super) fn record_miss() {
+        MISSES.with(|m| m.set(m.get() + 1));
+    }
+
+    /// Zero both counters on the current thread.
+    pub fn reset() {
+        HITS.with(|h| h.set(0));
+        MISSES.with(|m| m.set(0));
+    }
+
+    /// `(hits, misses)` recorded on the current thread since the last
+    /// [`reset`].
+    pub fn snapshot() -> (u64, u64) {
+        (HITS.with(Cell::get), MISSES.with(Cell::get))
     }
 }
 
@@ -1907,6 +1948,67 @@ mod tests {
         );
         assert!(out.points.is_empty());
         assert!(out.rejected.is_empty());
+    }
+
+    // --- SeriesIdMemo hit rate (pins the memo_stats counter, deliverable 3
+    //     of #367) ---
+
+    #[test]
+    fn memo_hit_rate_grouped_vs_interleaved() {
+        let tenant = tenant();
+        let limits = IngestLimits::default();
+        const P: usize = 100;
+
+        // Grouped: one metric, P points all carrying the same attribute set, so
+        // every point after the first is one series the memo already holds.
+        let grouped = request(vec![resource_metrics(
+            vec![],
+            vec![gauge_metric(
+                "grouped",
+                (0..P)
+                    .map(|i| {
+                        number_point(
+                            vec![string_kv("k", "v")],
+                            1_000 + i as i64,
+                            NumberValue::AsDouble(i as f64),
+                        )
+                    })
+                    .collect(),
+            )],
+        )]);
+        memo_stats::reset();
+        let out = normalize_metrics(&tenant, grouped, &limits, 1_000_000);
+        assert_eq!(out.points.len(), P);
+        let (hits, misses) = memo_stats::snapshot();
+        // One miss to seed the single series, then a hit for every later point.
+        assert_eq!(misses, 1, "grouped: expected one seeding miss");
+        assert_eq!(hits, (P - 1) as u64, "grouped: expected P-1 hits");
+
+        // Interleaved: one metric, P points alternating between two distinct
+        // attribute sets, so no point ever matches the one before it. The
+        // one-entry memo never hits.
+        let interleaved = request(vec![resource_metrics(
+            vec![],
+            vec![gauge_metric(
+                "interleaved",
+                (0..P)
+                    .map(|i| {
+                        let v = if i % 2 == 0 { "a" } else { "b" };
+                        number_point(
+                            vec![string_kv("k", v)],
+                            1_000 + i as i64,
+                            NumberValue::AsDouble(i as f64),
+                        )
+                    })
+                    .collect(),
+            )],
+        )]);
+        memo_stats::reset();
+        let out = normalize_metrics(&tenant, interleaved, &limits, 1_000_000);
+        assert_eq!(out.points.len(), P);
+        let (hits, misses) = memo_stats::snapshot();
+        assert_eq!(hits, 0, "interleaved: one-entry memo must never hit");
+        assert_eq!(misses, P as u64, "interleaved: every point is a miss");
     }
 
     // --- mapping table: job/instance synthesis ---


### PR DESCRIPTION
Adds an allocation-counting benchmark for the OTLP metrics normalize path,
so the cost of a datapoint is a measured number rather than a figure read
off the source.

The benchmark sweeps resource labels (0, 5, 15), attributes per point
(0, 5, 15), points per metric (1, 100), and sanitising against
non-sanitising attribute names. Varying resource labels separately from
per-point attributes is what makes it visible whether resource labels are
re-cloned per point, and varying points per metric is what separates
per-resource cost from per-point cost.

Three results change what we believed about this path.

Allocations per datapoint track 2L + 4 (L = resource labels plus point
attributes) in steady state, but only while the SeriesIdMemo is hitting.
On an all-miss shape the real cost is about 4L + 6, roughly double,
because a miss deep-clones the whole LabelSet in order to store it.

Resource labels are re-cloned on every point, not once per resource. At
100 points per series with the memo hitting, each added resource label
still costs about 2.0 allocations per point: 13.16, 23.27 and 43.50
allocations per point across 0, 5 and 15 resource labels at 5 attributes
and 100 points. The clone is at normalize.rs, where the per-point label
vector extends from the resource label slice.

sanitize_label_name allocates whether or not the name needs rewriting.
Clean and dirty attribute-name rows measure byte-identical, so it builds a
fresh String even when it has nothing to change.

The memo measures net-negative on interleaved series: 46.05 allocations
per point against 23.27 grouped. SeriesId::compute reuses a thread-local
scratch buffer and does not allocate once warm, so a point with no memo at
all costs what a memo hit costs. The memo therefore never removes an
allocation, and on series that alternate it adds a full LabelSet clone per
point for nothing.

The counting region holds normalize_metrics and its output vector alone.
The fixture is built before the region opens, the compute scratch is warmed
on the same thread first, and the criterion timing loop is a disjoint code
path that never runs inside a counted region. That separation is the point:
the ingest profiling in #365 produced numbers that had to be withdrawn
because the harness's own work sat inside the measured bracket.

SeriesIdMemo gains hit and miss counters behind
cfg(any(test, feature = "memo-stats")). The production build carries none
of them, no workspace crate enables the feature, and criterion and
stats_alloc are dev-dependencies.

This is measurement infrastructure. It has no production caller and does
not change ingest behaviour. The optimisations it points at are follow-up
work.

Fixes: #367
