### PR TITLE
docs(otlp): correct SeriesIdMemo hit-cost comment

### DIFF
--- a/crates/ravel-otlp/src/normalize.rs
+++ b/crates/ravel-otlp/src/normalize.rs
@@ -652,11 +652,21 @@ struct NativeHistogramContext<'a> {
 /// series identity (ADR-0005), so an equal `LabelSet` always yields a
 /// bit-identical `SeriesId`. The realistic OTLP shape is a single series
 /// sampled over time: one metric holding many data points with identical
-/// attributes, emitted consecutively. A one-entry last-seen memo turns the
-/// per-point BLAKE3 hash into one pointer compare across such a run while
-/// staying correct for interleaved or single-point metrics (a mismatch just
-/// recomputes). Fixed capacity of one entry; dropped when the metric's loop
-/// ends, so memory is bounded to a single label set.
+/// attributes, emitted consecutively. A one-entry last-seen memo skips the
+/// per-point BLAKE3 hash across such a run while staying correct for
+/// interleaved or single-point metrics (a mismatch just recomputes).
+///
+/// A hit is a full structural comparison of the label set, not a pointer
+/// compare: `LabelSet` compares as a `Vec<Label>` of `String` pairs, so it
+/// costs O(L) string comparisons, and it saves no allocation, because
+/// `SeriesId::compute` hashes through a thread-local scratch buffer that
+/// allocates nothing once warm. A miss adds a deep clone of the label set on
+/// top. `benches/normalize_alloc.rs` measures 46.05 allocations per point on
+/// interleaved series against 23.27 grouped, so this memo pays off only while
+/// points arrive in runs.
+///
+/// Fixed capacity of one entry; dropped when the metric's loop ends, so
+/// memory is bounded to a single label set.
 struct SeriesIdMemo {
     last: Option<(LabelSet, SeriesId)>,
 }


### PR DESCRIPTION
The `SeriesIdMemo` doc comment described the memo as turning the per-point BLAKE3 hash into "one pointer compare". Nothing is compared by pointer: `LabelSet` derives `PartialEq` over `Vec<Label>` and `Label` derives it over two `String`s, so a hit is a full structural comparison costing O(L) string compares.

The claim mattered because it was the stated reason the memo exists, and the allocation benchmark added in #367 measured that reason to be wrong on both sides. A hit saves no allocation, because `SeriesId::compute` hashes through a thread-local scratch buffer and allocates nothing once warm. A miss costs more than having no memo at all, because it deep-clones the label set to store it. On interleaved series, where the one-entry memo never hits, that is 46.05 allocations per point against 23.27 grouped.

This records what a hit and a miss actually cost and points at the benchmark, so the next reader does not assume the memo is free.

Whether to keep, redesign, or drop it is deliberately not decided here. That is a design question, it should not ride in on a comment correction, and #367 ranks it third behind hoisting the per-point resource-label clone and returning `Cow` from `sanitize_label_name`.

Comment-only change. Found by the #367 checkpoint review; pre-existing, not introduced by that branch.

Fixes: #392