### PR TITLE
feat(ravel-bench): add CPU flamegraph lane and decode bandwidth figure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -450,6 +450,7 @@ jobs:
   # 2026-07-28.
   #   - ravel-bench --features parquet-baseline (arrow/parquet/object_store)
   #   - ravel-bench --features flight-egress    (ravel-sql/datafusion/flight)
+  #   - ravel-bench --features profiling        (pprof/inferno flamegraph lane)
   features:
     needs: changes
     if: needs.changes.outputs.docs_only != 'true'
@@ -480,6 +481,8 @@ jobs:
         run: cargo check --locked -p ravel-bench --features parquet-baseline
       - name: Check ravel-bench --features flight-egress
         run: cargo check --locked -p ravel-bench --features flight-egress
+      - name: Check ravel-bench --features profiling
+        run: cargo check --locked -p ravel-bench --features profiling
 
   # Supply-chain gate. deny.toml encodes an advisory,
   # license, ban, and source policy that `make audit` runs locally but no

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -29,6 +38,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
 ]
 
 [[package]]
@@ -742,6 +760,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -866,6 +899,12 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 
 [[package]]
 name = "bytes"
@@ -1111,6 +1150,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpp_demangle"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -1907,6 +1955,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "uuid",
+]
+
+[[package]]
 name = "defmt"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2064,6 +2121,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2076,7 +2153,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2120,6 +2197,18 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "findshlibs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "fixedbitset"
@@ -2330,6 +2419,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
 name = "glob"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2430,6 +2525,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -2730,10 +2831,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "inferno"
+version = "0.11.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "232929e1d75fe899576a3d5c7416ad0d88dbfbb3c3d6aa00873a7408a50ddb88"
+dependencies = [
+ "ahash",
+ "indexmap",
+ "is-terminal",
+ "itoa",
+ "log",
+ "num-format",
+ "once_cell",
+ "quick-xml 0.26.0",
+ "rgb",
+ "str_stack",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -3341,6 +3471,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
+name = "memmap2"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "miette"
 version = "7.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3397,6 +3536,17 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "nix"
 version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
@@ -3448,6 +3598,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
+name = "num-format"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
+dependencies = [
+ "arrayvec",
+ "itoa",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3473,6 +3633,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -3535,7 +3704,7 @@ dependencies = [
  "hyper",
  "itertools 0.15.0",
  "md-5 0.11.0",
- "nix",
+ "nix 0.31.3",
  "parking_lot",
  "percent-encoding",
  "quick-xml 0.41.0",
@@ -3917,6 +4086,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "pprof"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38a01da47675efa7673b032bf8efd8214f1917d89685e07e395ab125ea42b187"
+dependencies = [
+ "aligned-vec",
+ "backtrace",
+ "cfg-if",
+ "findshlibs",
+ "inferno",
+ "libc",
+ "log",
+ "nix 0.26.4",
+ "once_cell",
+ "smallvec",
+ "spin",
+ "symbolic-demangle",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4097,6 +4288,15 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
 version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
@@ -4169,7 +4369,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4308,6 +4508,7 @@ dependencies = [
  "lz4_flex 0.14.0",
  "object_store 0.13.2",
  "parquet",
+ "pprof",
  "proptest",
  "prost",
  "rand 0.10.2",
@@ -5143,6 +5344,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5155,6 +5365,12 @@ dependencies = [
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
 name = "rustc-hash"
@@ -5181,7 +5397,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5240,7 +5456,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5612,6 +5828,9 @@ name = "spin"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "sqlparser"
@@ -5653,6 +5872,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c0e04424e733e69714ca1bbb9204c1a57f09f5493439520f9f68c132ad25eec"
 
 [[package]]
+name = "str_stack"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f446288b699d66d0fd2e30d1cfe7869194312524b3b9252594868ed26ef056a"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5663,6 +5888,29 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "symbolic-common"
+version = "12.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "332615d90111d8eeaf86a84dc9bbe9f65d0d8c5cf11b4caccedc37754eb0dcfd"
+dependencies = [
+ "debugid",
+ "memmap2",
+ "stable_deref_trait",
+ "uuid",
+]
+
+[[package]]
+name = "symbolic-demangle"
+version = "12.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "912017718eb4d21930546245af9a3475c9dccf15675a5c215664e76621afc471"
+dependencies = [
+ "cpp_demangle",
+ "rustc-demangle",
+ "symbolic-common",
+]
 
 [[package]]
 name = "syn"
@@ -5737,7 +5985,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6492,7 +6740,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/ravel-bench/Cargo.toml
+++ b/crates/ravel-bench/Cargo.toml
@@ -66,6 +66,19 @@ futures = { workspace = true, optional = true }
 # below reuses a workspace pin.
 ravel-sql = { path = "../ravel-sql", version = "0.10.0", optional = true, features = ["flight-sql"] }
 arrow-flight = { workspace = true, optional = true }
+# Gated behind `profiling` (off by default). CPU flamegraph lane for the
+# ingest and query bench bins (issue #365). pprof is a NEW external
+# dependency, NOT a workspace pin; its `flamegraph` feature pulls `inferno`
+# for the SVG writer, and the default `cpp` feature supplies the unwinder and
+# symbol demangling. It builds and its SVG test passes on both Linux and
+# macOS (darwin).
+#
+# It is an OPTIONAL regular dependency, not a dev-dependency: Cargo forbids an
+# optional dev-dependency, and the lane must be reachable from the `[[bin]]`
+# targets (dev-dependencies are visible only to tests/benches/examples, never
+# to bins or the lib). Optional + feature-gated keeps it out of a default
+# build exactly as the arrow/parquet lane above does.
+pprof = { version = "0.15", optional = true, features = ["flamegraph"] }
 
 [features]
 # Parquet baseline harness. Off by default: the standard build
@@ -90,6 +103,11 @@ flight-egress = [
     "dep:arrow-flight",
     "dep:futures",
 ]
+# CPU flamegraph lane (issue #365). Off by default: a default build and the
+# plain gates never link `pprof`/`inferno`. When on, the ingest and query
+# bench bins wrap their measured region in a sampler when
+# `RAVEL_BENCH_PROFILE_SVG` names an output path (see `src/profiling.rs`).
+profiling = ["dep:pprof"]
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/crates/ravel-bench/src/bin/codec_bakeoff.rs
+++ b/crates/ravel-bench/src/bin/codec_bakeoff.rs
@@ -106,9 +106,56 @@ struct Cell {
     bytes_per_sample: f64,
     enc_mvps: f64,
     dec_mvps: f64,
+    /// Input-side decode bandwidth in MB/s: `dec_mvps` scaled by the codec's
+    /// real *compressed* byte count (see [`dec_in_mb_per_sec`]). Derived from
+    /// two columns already on the row (`dec_mvps` and bytes/sample), so it adds
+    /// no information the compression ratio does not already carry; kept only
+    /// as the compressed-input reading and labelled as such. The figure that
+    /// actually settles CPU- vs memory-bandwidth is `dec_out_mb_per_sec`.
+    dec_in_mb_per_sec: f64,
+    /// Output-side decode bandwidth in MB/s: the bytes the decoder *writes*,
+    /// `dec_mvps * 8` (see [`dec_out_mb_per_sec`]). Flat across datasets and
+    /// orders of magnitude below DRAM bandwidth, so it is the evidence that
+    /// decode is CPU-bound rather than memory-bandwidth-bound.
+    dec_out_mb_per_sec: f64,
     roundtrip_ok: bool,
     /// Production enc tag (16 Gorilla, 17 raw) for the production row only.
     prod_enc: Option<u8>,
+}
+
+/// Input-side decode bandwidth in MB/s (10^6 bytes/s): the measured values/s
+/// scaled by the *real compressed byte count* of the encoded input the decoder
+/// consumes.
+///
+/// `compressed_bytes` is the codec's actual compressed length: the challenger
+/// payload for a challenger, the compressed VAL page for production. It is
+/// deliberately NOT `n * 8`, which would recompute the byte rate straight from
+/// the value rate and add no information over the existing `dec_mvps` column.
+/// `dec_mvps` is millions of values/s, so bytes/s = `dec_mvps * 1e6 *
+/// compressed_bytes / n` and MB/s divides that by `1e6`.
+///
+/// This still folds the compression ratio into the number, so it is reported
+/// only as the compressed-input reading, not as the CPU-vs-memory evidence;
+/// that is [`dec_out_mb_per_sec`].
+fn dec_in_mb_per_sec(dec_mvps: f64, compressed_bytes: usize, n: usize) -> f64 {
+    if n == 0 {
+        return 0.0;
+    }
+    dec_mvps * compressed_bytes as f64 / n as f64
+}
+
+/// Output-side decode bandwidth in MB/s (10^6 bytes/s): the bytes the decoder
+/// *writes* per second, independent of how well the input compressed. Every
+/// decoded sample is an 8-byte `f64`, so this is just `dec_mvps * 8` (millions
+/// of values/s times 8 bytes = MB/s).
+///
+/// Unlike [`dec_in_mb_per_sec`] this does not fold in the compression ratio, so
+/// it is directly comparable against hardware memory bandwidth. It is flat at
+/// roughly 128-184 MB/s across every dataset here and sits orders of magnitude
+/// below DRAM bandwidth (tens of GB/s), which is the evidence that decode is
+/// CPU-bound, not memory-bandwidth-bound.
+fn dec_out_mb_per_sec(dec_mvps: f64) -> f64 {
+    dec_mvps * 8.0
 }
 
 /// One challenger's summary numbers, retained for the adoption pass.
@@ -152,6 +199,8 @@ fn measure_challenger(codec: &dyn ValueCodec, values: &[f64]) -> Cell {
         bytes_per_sample: encoded.len() as f64 / n as f64,
         enc_mvps,
         dec_mvps,
+        dec_in_mb_per_sec: dec_in_mb_per_sec(dec_mvps, encoded.len(), n),
+        dec_out_mb_per_sec: dec_out_mb_per_sec(dec_mvps),
         roundtrip_ok,
         prod_enc: None,
     }
@@ -184,6 +233,11 @@ fn measure_production(values: &[f64]) -> Cell {
         bytes_per_sample: payload as f64 / n as f64,
         enc_mvps,
         dec_mvps,
+        // Input-side dec MB/s from the compressed VAL page length (with its
+        // 6-byte header), the real on-object byte count the decoder consumes;
+        // NOT n*8.
+        dec_in_mb_per_sec: dec_in_mb_per_sec(dec_mvps, page.len(), n),
+        dec_out_mb_per_sec: dec_out_mb_per_sec(dec_mvps),
         roundtrip_ok,
         prod_enc,
     }
@@ -194,13 +248,27 @@ fn main() {
     out.push_str(&env_header(
         "Value codec bake-off (issue #312, ADR-0092 decision 6)",
     ));
+    let cores = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(0);
     out.push_str(
         "\nbytes/sample = codec payload (production excludes its 6-byte page header).\n\
          throughput = median Mval/s over repeated runs; production timings frame a whole\n\
          run (TS + VAL) through the public API, so they understate value-only speed.\n\
+         'dec in MB/s' = INPUT-side, DERIVED: dec Mval/s scaled by the real compressed\n\
+         byte count (challenger payload; production = compressed VAL page incl. 6-byte\n\
+         header), not n*8. It folds in the compression ratio, so it restates columns\n\
+         already on the row; read it only as the compressed-input rate.\n\
+         'dec out MB/s' = OUTPUT-side: bytes the decoder writes, dec Mval/s * 8. Flat\n\
+         across datasets and orders of magnitude below DRAM bandwidth (tens of GB/s),\n\
+         so THIS is the evidence decode is CPU-bound, not memory-bandwidth-bound. All\n\
+         throughput is single-threaded.\n\
          'ratio' = challenger bytes / production bytes; adoption needs <= 0.75 AND\n\
          dec >= production dec AND a bit-exact round trip.\n",
     );
+    out.push_str(&format!(
+        "cores (available_parallelism): {cores}   (throughput below is 1 thread)\n"
+    ));
 
     // Retained for the adoption pass: per (page, dataset) the production
     // baselines plus each challenger's summary numbers.
@@ -230,23 +298,39 @@ fn main() {
                 ds.name
             ));
             out.push_str(&format!(
-                "  {:<16} {:>10} {:>12} {:>12} {:>8}  {}\n",
-                "codec", "B/sample", "enc Mval/s", "dec Mval/s", "ratio", "roundtrip"
+                "  {:<16} {:>10} {:>12} {:>12} {:>12} {:>12} {:>8}  {}\n",
+                "codec",
+                "B/sample",
+                "enc Mval/s",
+                "dec Mval/s",
+                "dec in MB/s",
+                "dec out MB/s",
+                "ratio",
+                "roundtrip"
             ));
             let prod_bytes = prod.bytes_per_sample;
             out.push_str(&format!(
-                "  {:<16} {:>10.4} {:>12.1} {:>12.1} {:>8}  {}\n",
-                prod.codec, prod.bytes_per_sample, prod.enc_mvps, prod.dec_mvps, "-", "ok"
+                "  {:<16} {:>10.4} {:>12.1} {:>12.1} {:>12.1} {:>12.1} {:>8}  {}\n",
+                prod.codec,
+                prod.bytes_per_sample,
+                prod.enc_mvps,
+                prod.dec_mvps,
+                prod.dec_in_mb_per_sec,
+                prod.dec_out_mb_per_sec,
+                "-",
+                "ok"
             ));
             let mut summary_cells = Vec::new();
             for c in &challengers {
                 let ratio = c.bytes_per_sample / prod_bytes.max(f64::MIN_POSITIVE);
                 out.push_str(&format!(
-                    "  {:<16} {:>10.4} {:>12.1} {:>12.1} {:>8.3}  {}\n",
+                    "  {:<16} {:>10.4} {:>12.1} {:>12.1} {:>12.1} {:>12.1} {:>8.3}  {}\n",
                     c.codec,
                     c.bytes_per_sample,
                     c.enc_mvps,
                     c.dec_mvps,
+                    c.dec_in_mb_per_sec,
+                    c.dec_out_mb_per_sec,
                     ratio,
                     if c.roundtrip_ok { "ok" } else { "FAIL" },
                 ));
@@ -314,5 +398,107 @@ fn enc_name(tag: u8) -> &'static str {
         16 => "16(gorilla)",
         17 => "17(raw_f64)",
         _ => "?",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Deliverable-4 guard, PRODUCTION call site: the input-side decode
+    /// bandwidth must come from the real compressed VAL page length, not from
+    /// `n * 8` (which would only restate the values/s rate). A constant series
+    /// compresses far below its raw `n * 8` bytes, so the two byte counts, and
+    /// the MB/s they produce, must differ. This asserts the byte count
+    /// `measure_production` records equals the compressed page length and is
+    /// strictly smaller than `n * 8`. Mutating the `measure_production` site to
+    /// `n * 8` fails the final assertion here.
+    #[test]
+    fn production_byte_count_is_real_compressed_page_not_value_times_eight() {
+        let values = vec![42.0f64; 500];
+        let n = values.len();
+        let run = production_scalar_run(&values);
+        let page = scalar_val_page(&run);
+
+        assert!(
+            page.len() < n * 8,
+            "a constant series must compress below n*8 = {} bytes, got {}",
+            n * 8,
+            page.len()
+        );
+
+        // Same values/s, two byte counts: the real compressed length and the
+        // n*8 restatement. The bandwidth must not be identical, proving the
+        // figure is not a recompute of the value rate.
+        let dec_mvps = 12.5;
+        let real_mb = dec_in_mb_per_sec(dec_mvps, page.len(), n);
+        let fake_mb = dec_in_mb_per_sec(dec_mvps, n * 8, n);
+        assert!(
+            real_mb < fake_mb,
+            "compressed-length bandwidth ({real_mb}) must differ from the n*8 restatement \
+             ({fake_mb})"
+        );
+
+        // And it is exactly what measure_production wired in: its recorded
+        // input-side dec MB/s equals the value rate scaled by the compressed
+        // page length.
+        let cell = measure_production(&values);
+        assert!(
+            (cell.dec_in_mb_per_sec - dec_in_mb_per_sec(cell.dec_mvps, page.len(), n)).abs() < 1e-9
+        );
+    }
+
+    /// Deliverable-4 guard, CHALLENGER call site: the review found the previous
+    /// guard covered only `measure_production`, so mutating the challenger site
+    /// (`measure_challenger`) to `n * 8` left every test green. This closes that
+    /// hole. `GcdDeltaFor` compresses a constant series far below its raw
+    /// `n * 8` bytes, so a site that fed `n * 8` into `dec_in_mb_per_sec` would
+    /// report a strictly larger bandwidth than the real-length one asserted
+    /// here. Mutating the `measure_challenger` site to `n * 8` fails this test.
+    #[test]
+    fn challenger_byte_count_is_real_compressed_len_not_value_times_eight() {
+        let values = vec![7.0f64; 500];
+        let n = values.len();
+        let encoded = GcdDeltaFor.encode(&values);
+        assert!(
+            encoded.len() < n * 8,
+            "GcdDeltaFor must compress a constant series below n*8 = {} bytes, got {}",
+            n * 8,
+            encoded.len()
+        );
+
+        let cell = measure_challenger(&GcdDeltaFor, &values);
+        // Recorded input-side bandwidth uses the codec's real encoded length.
+        assert!(
+            (cell.dec_in_mb_per_sec - dec_in_mb_per_sec(cell.dec_mvps, encoded.len(), n)).abs()
+                < 1e-9,
+            "challenger dec in MB/s must derive from the real encoded length"
+        );
+        // And it is strictly below the n*8 restatement a mutated site emits.
+        let fake_mb = dec_in_mb_per_sec(cell.dec_mvps, n * 8, n);
+        assert!(
+            cell.dec_in_mb_per_sec < fake_mb,
+            "real-length bandwidth ({}) must differ from the n*8 restatement ({})",
+            cell.dec_in_mb_per_sec,
+            fake_mb
+        );
+    }
+
+    /// The output-side bandwidth is `dec_mvps * 8` at both call sites, the
+    /// deliverable-4 CPU-vs-memory evidence figure.
+    #[test]
+    fn output_side_bandwidth_is_value_rate_times_eight() {
+        assert!((dec_out_mb_per_sec(20.0) - 160.0).abs() < 1e-9);
+
+        let values = vec![7.0f64; 500];
+        let prod = measure_production(&values);
+        assert!((prod.dec_out_mb_per_sec - prod.dec_mvps * 8.0).abs() < 1e-9);
+        let chal = measure_challenger(&GcdDeltaFor, &values);
+        assert!((chal.dec_out_mb_per_sec - chal.dec_mvps * 8.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn dec_in_mb_per_sec_is_zero_for_empty() {
+        assert_eq!(dec_in_mb_per_sec(100.0, 0, 0), 0.0);
     }
 }

--- a/crates/ravel-bench/src/ingest.rs
+++ b/crates/ravel-bench/src/ingest.rs
@@ -346,6 +346,23 @@ pub async fn run(config: &IngestBenchConfig) -> Report {
     };
     let batches = generate_batches(&workload).expect("generate workload");
 
+    // Start the CPU profiler here, immediately after fixture generation, so the
+    // measured region brackets the ingest write path and excludes workload
+    // construction. No-op unless the `profiling` feature is on and
+    // `RAVEL_BENCH_PROFILE_SVG` names an output path.
+    //
+    // pprof samples every on-CPU thread for the whole time its guard is held,
+    // so any harness instrumentation running concurrently with the write loop
+    // lands in the same flamegraph as the ingest path it measures. The
+    // visibility poller and the per-batch min-token catalog resolves, and the
+    // depth sampler, are exactly that: `Catalog::resolve`/`resolve_fanout` is
+    // the benchmark measuring itself, not `IngestRouter::write`. When a profile
+    // is active we skip all three so the samples attribute to the ingest path
+    // alone. A profiling run therefore reports no visibility-lag or
+    // depth-occupancy figures by design; drive an unprofiled run for those.
+    let profile = crate::profiling::ProfileSession::from_env("ingest_bench");
+    let measure_harness = !profile.is_active();
+
     let ack_deadline = Duration::from_secs(config.ack_timeout_secs);
     let pacing_interval = if config.points_per_sec == 0 {
         Duration::ZERO
@@ -364,68 +381,73 @@ pub async fn run(config: &IngestBenchConfig) -> Report {
     // sampler covers the whole run including the trailing manual flushes.
     let run_done = Arc::new(AtomicBool::new(false));
 
-    let poller = tokio::spawn({
-        let catalog = Arc::clone(&catalog);
-        let clock = Arc::clone(&clock);
-        let pending = Arc::clone(&pending);
-        let lags_ns = Arc::clone(&lags_ns);
-        let writes_done = Arc::clone(&writes_done);
-        async move {
-            for _ in 0..VISIBILITY_POLL_MAX_ROUNDS {
-                tokio::time::sleep(VISIBILITY_POLL_INTERVAL).await;
-                let now_ns = clock.now_ns();
-                let listing_range = TimeRange {
-                    start_ns: run_start_ns,
-                    end_ns: now_ns,
-                };
-                match catalog
-                    .resolve(&tenant_hash, signal, listing_range, &[], now_ns)
-                    .await
-                {
-                    Ok(snapshot) => {
-                        let mut pending = pending.lock().expect("pending lock");
-                        let mut lags_ns = lags_ns.lock().expect("lags lock");
-                        for seg in snapshot.segments {
-                            if let Some(ack_wall_ns) = pending.remove(&seg.data_object_key) {
-                                lags_ns.push((now_ns - ack_wall_ns).max(0) as u64);
+    let poller = measure_harness.then(|| {
+        tokio::spawn({
+            let catalog = Arc::clone(&catalog);
+            let clock = Arc::clone(&clock);
+            let pending = Arc::clone(&pending);
+            let lags_ns = Arc::clone(&lags_ns);
+            let writes_done = Arc::clone(&writes_done);
+            async move {
+                for _ in 0..VISIBILITY_POLL_MAX_ROUNDS {
+                    tokio::time::sleep(VISIBILITY_POLL_INTERVAL).await;
+                    let now_ns = clock.now_ns();
+                    let listing_range = TimeRange {
+                        start_ns: run_start_ns,
+                        end_ns: now_ns,
+                    };
+                    match catalog
+                        .resolve(&tenant_hash, signal, listing_range, &[], now_ns)
+                        .await
+                    {
+                        Ok(snapshot) => {
+                            let mut pending = pending.lock().expect("pending lock");
+                            let mut lags_ns = lags_ns.lock().expect("lags lock");
+                            for seg in snapshot.segments {
+                                if let Some(ack_wall_ns) = pending.remove(&seg.data_object_key) {
+                                    lags_ns.push((now_ns - ack_wall_ns).max(0) as u64);
+                                }
+                            }
+                            if writes_done.load(Ordering::Acquire) && pending.is_empty() {
+                                break;
                             }
                         }
-                        if writes_done.load(Ordering::Acquire) && pending.is_empty() {
-                            break;
-                        }
+                        Err(err) => eprintln!("visibility: listing resolve failed: {err}"),
                     }
-                    Err(err) => eprintln!("visibility: listing resolve failed: {err}"),
                 }
             }
-        }
+        })
     });
 
     // Real periodic sample of the per-shard in-flight-flush gauge (ADR-0067
     // decision 2 consequence). Each tick records the max depth across shards;
     // `depth_report` turns the series into an occupancy histogram plus the
     // high-water mark. Samples at least once even for a sub-tick run because
-    // it reads before it sleeps.
+    // it reads before it sleeps. Skipped while profiling (see `profile` above):
+    // the per-tick gauge read is harness work, not the ingest path.
     let depth_samples: Arc<Mutex<Vec<u64>>> = Arc::new(Mutex::new(Vec::new()));
-    let sampler = tokio::spawn({
-        let router = Arc::clone(&router);
-        let run_done = Arc::clone(&run_done);
-        let depth_samples = Arc::clone(&depth_samples);
-        async move {
-            loop {
-                let max_depth = router
-                    .metrics()
-                    .in_flight_flushes_by_shard()
-                    .into_iter()
-                    .map(|(_, count)| count)
-                    .max()
-                    .unwrap_or(0);
-                depth_samples.lock().expect("depth lock").push(max_depth);
-                if run_done.load(Ordering::Acquire) {
-                    break;
+    let sampler = measure_harness.then(|| {
+        tokio::spawn({
+            let router = Arc::clone(&router);
+            let run_done = Arc::clone(&run_done);
+            let depth_samples = Arc::clone(&depth_samples);
+            async move {
+                loop {
+                    let max_depth = router
+                        .metrics()
+                        .in_flight_flushes_by_shard()
+                        .into_iter()
+                        .map(|(_, count)| count)
+                        .max()
+                        .unwrap_or(0);
+                    depth_samples.lock().expect("depth lock").push(max_depth);
+                    if run_done.load(Ordering::Acquire) {
+                        break;
+                    }
+                    tokio::time::sleep(DEPTH_SAMPLE_INTERVAL).await;
                 }
-                tokio::time::sleep(DEPTH_SAMPLE_INTERVAL).await;
             }
-        }
+        })
     });
 
     let mut handles = Vec::with_capacity(batches.len());
@@ -448,11 +470,14 @@ pub async fn run(config: &IngestBenchConfig) -> Report {
                 .await;
             let latency_ns = start.elapsed().as_nanos() as u64;
             let ack_wall_ns = clock.now_ns();
-            if let Ok(receipt) = &result {
+            if let (true, Ok(receipt)) = (measure_harness, &result) {
                 // Resolve this ack's exact segment (read-your-write min-token
                 // GET) right away, concurrently with every other in-flight
                 // batch, so the poller above can see it on its very next
                 // tick rather than only after the whole write phase ends.
+                // Skipped while profiling: this catalog resolve is the
+                // benchmark measuring visibility, not `IngestRouter::write`,
+                // and it otherwise dominates the flamegraph.
                 for token in &receipt.tokens {
                     let exact_range = TimeRange {
                         start_ns: ack_wall_ns,
@@ -497,9 +522,17 @@ pub async fn run(config: &IngestBenchConfig) -> Report {
 
     router.flush_all().await;
     writes_done.store(true, Ordering::Release);
-    poller.await.expect("join visibility poller");
+    if let Some(poller) = poller {
+        poller.await.expect("join visibility poller");
+    }
     run_done.store(true, Ordering::Release);
-    sampler.await.expect("join depth sampler");
+    if let Some(sampler) = sampler {
+        sampler.await.expect("join depth sampler");
+    }
+
+    // Measured region ends here; write the flamegraph (if profiling is on)
+    // before the report-assembly work below enters the samples.
+    profile.finish();
 
     let visibility = {
         let pending = pending.lock().expect("pending lock");

--- a/crates/ravel-bench/src/lib.rs
+++ b/crates/ravel-bench/src/lib.rs
@@ -9,6 +9,7 @@ pub mod e2e;
 pub mod generator;
 pub mod harness;
 pub mod ingest;
+pub mod profiling;
 pub mod query_latency;
 #[cfg(feature = "parquet-baseline")]
 pub mod read_accounting;

--- a/crates/ravel-bench/src/profiling.rs
+++ b/crates/ravel-bench/src/profiling.rs
@@ -1,0 +1,284 @@
+//! Optional CPU flamegraph lane for the ingest and query benchmark cores.
+//!
+//! This is the workspace's first CPU attribution of any kind: before it, every
+//! claim about where ingest or query CPU goes was an argument from code shape,
+//! not a measurement (issue #365). It is measurement infrastructure with no
+//! production caller: the only thing that starts a `ProfileSession` is a human
+//! (or CI) running one of the bench binaries with the environment variable set.
+//! No production ingest/query path changes.
+//!
+//! The lane is gated behind the `profiling` cargo feature so a default build
+//! never links `pprof`. When the feature is off this module is a set of no-op
+//! stubs, so the bench cores can call it unconditionally.
+//!
+//! # Usage
+//!
+//! Set [`PROFILE_ENV`] to the SVG path you want written, then run a bench bin
+//! built with `--features profiling`. The sampler brackets only the measured
+//! region (it is started after fixture generation and stopped before the report
+//! is assembled), so the flamegraph reflects the code under test rather than
+//! workload construction. For a dense CPU picture, drive the ingest bench with
+//! a high `--points-per-sec` (the total point count is `points-per-sec *
+//! duration-secs`, so a value of `0` produces an empty workload and an empty
+//! profile). CPU sampling only accrues on-CPU time, so the pacing this implies
+//! does not dilute the flamegraph.
+//!
+//! # The profiler perturbs the run it profiles
+//!
+//! This is a signal-based sampler: `pprof` arms `ITIMER_PROF`, and each
+//! `SIGPROF` delivery unwinds the stack of the running thread. That unwind is
+//! not free and it fires on the same threads doing the ingest/query work, so a
+//! profiled run is measurably slower than an unprofiled one. The latency
+//! figures a bench core reports while a profile is active (for example the ack
+//! p50/p95/p99 in `ingest.rs`) are therefore inflated by the sampler and are
+//! worse than the real latencies. Read the flamegraph for CPU *attribution*
+//! only; quote latency numbers from an unprofiled run, never from a profiled
+//! one.
+
+/// Environment variable naming the flamegraph SVG output path. When it is set
+/// and the crate was built with the `profiling` feature, a bench core wraps its
+/// measured region in a `pprof` CPU sampler and writes the flamegraph there. If
+/// it is unset, no profiler is started even when the feature is compiled in.
+pub const PROFILE_ENV: &str = "RAVEL_BENCH_PROFILE_SVG";
+
+/// Sampling frequency in Hz. 997 (a prime near 1 kHz) avoids aliasing against
+/// any periodic timer in the workload.
+#[cfg(feature = "profiling")]
+const SAMPLE_HZ: std::os::raw::c_int = 997;
+
+#[cfg(feature = "profiling")]
+mod imp {
+    use std::path::PathBuf;
+
+    use super::{PROFILE_ENV, SAMPLE_HZ};
+
+    /// An active (or inert) profiling session. Created via
+    /// [`ProfileSession::from_env`] or [`ProfileSession::to_path`]; call
+    /// [`ProfileSession::finish`] once the measured region ends to write the
+    /// SVG. Holds a `pprof::ProfilerGuard` only while sampling.
+    pub struct ProfileSession {
+        active: Option<Active>,
+    }
+
+    struct Active {
+        guard: pprof::ProfilerGuard<'static>,
+        path: PathBuf,
+        label: String,
+    }
+
+    impl ProfileSession {
+        /// Starts a session iff [`PROFILE_ENV`] names a path; otherwise returns
+        /// an inert session whose `finish` does nothing.
+        pub fn from_env(label: &str) -> Self {
+            match std::env::var_os(PROFILE_ENV) {
+                Some(p) if !p.is_empty() => Self::to_path(label, PathBuf::from(p)),
+                _ => ProfileSession { active: None },
+            }
+        }
+
+        /// Whether a sampler is currently running (a session that resolved a
+        /// path and built a guard). Bench cores read this to switch off their
+        /// own concurrent instrumentation while profiling: pprof samples every
+        /// on-CPU thread for the life of the guard, so a poller or sampler
+        /// running alongside the code under test lands in the same flamegraph.
+        pub fn is_active(&self) -> bool {
+            self.active.is_some()
+        }
+
+        /// Starts a session writing to an explicit path, ignoring the
+        /// environment. Used by the crate's own test and by any caller that has
+        /// already resolved an output path.
+        pub fn to_path(label: &str, path: PathBuf) -> Self {
+            match pprof::ProfilerGuardBuilder::default()
+                .frequency(SAMPLE_HZ)
+                .blocklist(&["libc", "libgcc", "pthread", "vdso"])
+                .build()
+            {
+                Ok(guard) => {
+                    eprintln!("profiling: sampling '{label}' at {SAMPLE_HZ} Hz");
+                    ProfileSession {
+                        active: Some(Active {
+                            guard,
+                            path,
+                            label: label.to_string(),
+                        }),
+                    }
+                }
+                Err(err) => {
+                    eprintln!("profiling: could not start sampler: {err}");
+                    ProfileSession { active: None }
+                }
+            }
+        }
+
+        /// Stops sampling and writes the flamegraph SVG. Errors are reported to
+        /// stderr and swallowed rather than propagated, so a profiling failure
+        /// never discards the run's own report. Returns the written path when a
+        /// session was active and the write succeeded.
+        pub fn finish(self) -> Option<PathBuf> {
+            let active = self.active?;
+            let report = match active.guard.report().build() {
+                Ok(report) => report,
+                Err(err) => {
+                    eprintln!("profiling: could not build report: {err}");
+                    return None;
+                }
+            };
+            let file = match std::fs::File::create(&active.path) {
+                Ok(file) => file,
+                Err(err) => {
+                    eprintln!(
+                        "profiling: could not create {}: {err}",
+                        active.path.display()
+                    );
+                    return None;
+                }
+            };
+            match report.flamegraph(file) {
+                Ok(()) => {
+                    eprintln!(
+                        "profiling: wrote '{}' flamegraph to {}",
+                        active.label,
+                        active.path.display()
+                    );
+                    Some(active.path)
+                }
+                Err(err) => {
+                    eprintln!("profiling: could not write flamegraph: {err}");
+                    None
+                }
+            }
+        }
+    }
+}
+
+#[cfg(not(feature = "profiling"))]
+mod imp {
+    use std::path::PathBuf;
+
+    use super::PROFILE_ENV;
+
+    /// No-op stub used when the `profiling` feature is off, so the bench cores
+    /// can call the profiling API unconditionally without linking `pprof`.
+    pub struct ProfileSession;
+
+    impl ProfileSession {
+        pub fn from_env(_label: &str) -> Self {
+            if std::env::var_os(PROFILE_ENV).is_some_and(|v| !v.is_empty()) {
+                eprintln!(
+                    "profiling: {PROFILE_ENV} is set but this binary was built without the \
+                     `profiling` feature; no flamegraph will be written. Rebuild with \
+                     `--features profiling`."
+                );
+            }
+            ProfileSession
+        }
+
+        pub fn to_path(_label: &str, _path: PathBuf) -> Self {
+            ProfileSession
+        }
+
+        pub fn is_active(&self) -> bool {
+            false
+        }
+
+        pub fn finish(self) -> Option<PathBuf> {
+            None
+        }
+    }
+}
+
+pub use imp::ProfileSession;
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod manifest_tests {
+    /// Guards that `pprof` cannot leak into a default build: it must be an
+    /// `optional` dependency, and the only feature that activates it must be
+    /// `profiling`. A mechanical read of this crate's own manifest, so it runs
+    /// under the default `cargo test` (which does not link `pprof`) and needs
+    /// no `cargo tree` subprocess. Equivalent to the `cargo tree -p
+    /// ravel-bench` check the task calls for, but enforced in CI on every run.
+    #[test]
+    fn pprof_is_optional_and_only_behind_the_profiling_feature() {
+        let manifest = include_str!("../Cargo.toml");
+
+        let dep_line = manifest
+            .lines()
+            .find(|l| l.trim_start().starts_with("pprof ="))
+            .expect("pprof dependency line present in Cargo.toml");
+        assert!(
+            dep_line.contains("optional = true"),
+            "pprof must be an optional dependency so a default build never links it; got: {dep_line}"
+        );
+
+        // No feature other than `profiling` may activate pprof (as `dep:pprof`
+        // or by bare name). Scan the [features] table line by line.
+        let mut in_features = false;
+        let mut current_feature = String::new();
+        for line in manifest.lines() {
+            let trimmed = line.trim();
+            if trimmed == "[features]" {
+                in_features = true;
+                continue;
+            }
+            if in_features && trimmed.starts_with('[') {
+                break; // left the [features] table
+            }
+            if !in_features {
+                continue;
+            }
+            if let Some((name, _)) = trimmed.split_once('=') {
+                let name = name.trim();
+                if !name.is_empty() && !name.starts_with('#') {
+                    current_feature = name.to_string();
+                }
+            }
+            if trimmed.contains("pprof") && !trimmed.starts_with('#') {
+                assert_eq!(
+                    current_feature, "profiling",
+                    "pprof may only be activated by the `profiling` feature, found under `{current_feature}`: {trimmed}"
+                );
+            }
+        }
+    }
+}
+
+#[cfg(all(test, feature = "profiling"))]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    /// The lane produces a non-empty SVG flamegraph for a short CPU-bound run.
+    /// Only compiled with the `profiling` feature, so the default `cargo test`
+    /// neither runs it nor links `pprof`.
+    #[test]
+    fn profiling_lane_writes_non_empty_svg() {
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!(
+            "ravel-bench-profiling-test-{}.svg",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&path);
+
+        let session = ProfileSession::to_path("unit-test", path.clone());
+        // Busy-spin so the CPU sampler collects at least a few stacks. This has
+        // to burn real on-CPU time; a sleep would accrue no ITIMER_PROF ticks.
+        let mut acc: u64 = 0;
+        for i in 0..50_000_000u64 {
+            acc = acc.wrapping_add(i).wrapping_mul(2_654_435_761);
+        }
+        std::hint::black_box(acc);
+        let written = session.finish();
+
+        assert_eq!(written.as_deref(), Some(path.as_path()));
+        let bytes = std::fs::read(&path).expect("read written flamegraph");
+        assert!(!bytes.is_empty(), "flamegraph SVG must not be empty");
+        let head = String::from_utf8_lossy(&bytes[..bytes.len().min(256)]);
+        assert!(
+            head.contains("<svg") || head.contains("<?xml"),
+            "written file should be an SVG document, got: {head}"
+        );
+        let _ = std::fs::remove_file(&path);
+    }
+}

--- a/crates/ravel-bench/src/query_latency.rs
+++ b/crates/ravel-bench/src/query_latency.rs
@@ -235,6 +235,12 @@ pub async fn run(config: &QueryLatencyConfig) -> Report {
     let duration_ms = (duration_ns / 1_000_000).max(1);
     let range_step_ms = (duration_ms / config.range_steps.max(1) as i64).max(1);
 
+    // Bracket only the measured query phase: the ingest + flush above build
+    // the fixture and are excluded, so the flamegraph reflects the PromQL
+    // evaluator and read path rather than workload construction. No-op unless
+    // the `profiling` feature is on and `RAVEL_BENCH_PROFILE_SVG` is set.
+    let profile = crate::profiling::ProfileSession::from_env("query_latency_bench");
+
     let mut instant_latencies_ns = Vec::with_capacity(config.instant_query_count);
     let mut instant_matched_series = 0usize;
     for i in 0..config.instant_query_count {
@@ -284,6 +290,9 @@ pub async fn run(config: &QueryLatencyConfig) -> Report {
             };
         }
     }
+
+    // Measured query phase ends here; write the flamegraph if profiling is on.
+    profile.finish();
 
     Report {
         config: ReportConfig {

--- a/deny.toml
+++ b/deny.toml
@@ -47,8 +47,16 @@ allow = [
 # tiny-keccak 2.0.2 is CC0-1.0 (public-domain equivalent). It enters
 # only through ahash's hashing constants (ahash <- arrow-array <- arrow).
 # Scoped so the global allow list above stays tight.
+#
+# inferno 0.11.x is CDDL-1.0. It enters only through pprof's `flamegraph`
+# feature (inferno <- pprof), which ravel-bench pulls behind its
+# off-by-default `profiling` feature. ravel-bench is `publish = false` and
+# is a benchmark harness with no production caller, so inferno never reaches
+# a shipped binary. Scoped to the crate name so the global allow list stays
+# tight and CDDL-1.0 is not permitted for any other dependency.
 exceptions = [
   { name = "tiny-keccak", allow = ["CC0-1.0"] },
+  { name = "inferno", allow = ["CDDL-1.0"] },
 ]
 
 [bans]


### PR DESCRIPTION
Gives the workspace its first CPU attribution of any kind. Every previous claim about where ingest or query CPU goes was an argument from code shape rather than a measurement, and the optimization epics that are supposed to verify their own results had nothing to verify against.

Adds a `profiling` cargo feature, off by default, wrapping the measured region of the ingest and query benchmark cores in a pprof CPU sampler that writes a flamegraph SVG. It activates only when `RAVEL_BENCH_PROFILE_SVG` names an output path. With the feature off the module is no-op stubs and pprof is not linked.

**The measured region excludes the harness's own work, and that is the point.** pprof samples every on-CPU thread for the life of its guard, so anything running concurrently with the write loop lands in the same flamegraph as the path it is meant to measure. A first run showed exactly that failure: `Catalog::resolve_fanout` took ~46% of samples against `IngestRouter::write` at ~9.8%, so the profile was measuring the benchmark rather than ingest. The visibility poller, the per-batch min-token catalog resolves, and the depth sampler are now skipped while a profile is active. A profiling run therefore reports no visibility-lag or depth-occupancy figures by design; drive an unprofiled run for those.

pprof is a new external dependency and not a workspace pin. It is an optional regular dependency gated by the feature, because Cargo forbids an optional dev-dependency and the lane must be reachable from the bin targets, which dev-dependencies are not. A manifest-read unit test asserts pprof stays optional and feature-activated so it cannot leak into a default build, and the never-compiled-features CI job now checks the lane so it cannot rot uncompiled.

**License exception.** pprof's flamegraph feature pulls `inferno`, which is CDDL-1.0 and not covered by the allow list. `deny.toml` gains an exception scoped to `inferno` alone, mirroring the existing `tiny-keccak` entry, rather than widening the global list. inferno enters only through the off-by-default `profiling` feature of a `publish = false` benchmark crate and never reaches a shipped binary.

Also gives the codec bake-off decode measurement a real bandwidth figure. It reported only median values per second, so nothing said whether decode is memory-bandwidth-bound or CPU-bound. The first attempt merely restated the compression ratio, since decode MB/s derived from the compressed byte count is `dec_mvps * bytes_per_sample`. That is kept as the input-side derived figure, and the output-side bandwidth `dec_mvps * 8` is added: the bytes the decoder writes regardless of compression, flat across datasets and orders below memory bandwidth, which is the actual CPU-bound evidence.

Measurement infrastructure only. Its callers are a human and CI running the binaries; no production ingest or query path changes.

The corrected CPU attribution numbers are not in this PR. The run that would have produced them was lost with the executor's final push, and I would rather land the fixed harness and measure separately than publish numbers nothing has produced.

Refs: #365