### PR TITLE
fix(logseg): define and compute level-1 skip-index null_count

### DIFF
--- a/crates/ravel-logseg/src/block.rs
+++ b/crates/ravel-logseg/src/block.rs
@@ -1006,6 +1006,58 @@ mod tests {
         );
     }
 
+    /// A planned numeric column that no row resolves still gets a stat, and
+    /// that stat's `null_count` covers every row of the block. This is the
+    /// case docs/log-segment-format.md's `null_count` contract turns on: a
+    /// present stat is not evidence that any row resolves the column, and its
+    /// bounds are the degenerate 0/0 pair.
+    ///
+    /// Scope: this pins the emit half, taking the plan as given. That the
+    /// writer plans such a column at all, from a record-level occurrence whose
+    /// merged-view winner is of another type, is decided in `writer.rs` and is
+    /// not covered here.
+    #[test]
+    fn numstat_covers_every_row_when_none_resolves_the_column() {
+        let plans = vec![
+            ColumnPlan {
+                column_id: 10,
+                ty: FieldType::I64,
+            },
+            ColumnPlan {
+                column_id: 12,
+                ty: FieldType::Str,
+            },
+        ];
+
+        // Every row carries the name as both I64 and Str, and Str wins each
+        // time, so no row resolves an I64 value for a column that is planned
+        // because the I64 occurrence is present.
+        let rows: Vec<_> = (0..8i64)
+            .map(|i| {
+                let mut r = row(0, 1 + i);
+                r.columns.push((10, ColumnValue::I64(9999)));
+                r.columns.push((12, ColumnValue::Str(b"wins".to_vec())));
+                r.stat_winners
+                    .push((12, ColumnValue::Str(b"wins".to_vec())));
+                r
+            })
+            .collect();
+
+        let out = write_block(&rows, &plans, 3).expect("write");
+        let i64_stat = *out
+            .stats
+            .iter()
+            .find(|s| s.column_id == 10)
+            .expect("a planned column keeps its stat even when nothing resolves it");
+
+        assert_eq!(
+            i64_stat.null_count, 8,
+            "null_count must cover every row when no row resolves the column"
+        );
+        assert_eq!(i64_stat.min_bits, 0, "an all-null stat bounds nothing");
+        assert_eq!(i64_stat.max_bits, 0, "an all-null stat bounds nothing");
+    }
+
     /// A column filter decodes only the named columns' pages, leaves every
     /// other column absent, and reports how many pages it walked past. The
     /// values it does decode are identical to the all-columns decode's, so

--- a/crates/ravel-logseg/src/skip_index.rs
+++ b/crates/ravel-logseg/src/skip_index.rs
@@ -83,8 +83,23 @@ pub struct NumRangeArm {
     pub max_bits: Option<u64>,
 }
 
-/// Merges the stats of `children` by column id (type-aware min/max, summed
-/// null counts, OR-ed NaN flags).
+/// Merges the stats of `children` by column id: type-aware min/max and OR-ed NaN
+/// flags folded over the children that carry a stat for the column, and a
+/// `null_count` counting every row beneath the entry that resolves nothing of
+/// the column's type (docs/log-segment-format.md "null_count at both levels").
+///
+/// The bounds fold only stat-carrying children, which is sound because a child
+/// that resolves a value for the column always carries a stat (write-path
+/// completeness, this module's header). `null_count` cannot fold that way: a
+/// child with no stat for the column resolves nothing of that type in any of its
+/// rows, so all `record_count` of them are null and must be counted. Summing
+/// only the stat-carrying children's `null_count` would leave a level-1
+/// `null_count` that undercounts the group's null rows and, for a column resolved
+/// by only some children, has no well-defined meaning at all (issue #356).
+///
+/// `null_count` is a `u32` and the sum can exceed it (up to 64 children each with
+/// a `u32` `record_count`); `saturating_add` clamps at `u32::MAX`, which the doc
+/// defines as a saturated lower bound.
 fn merge_stats(children: &[Level0Entry]) -> Vec<NumStat> {
     let mut merged: Vec<NumStat> = Vec::new();
     for child in children {
@@ -96,6 +111,16 @@ fn merge_stats(children: &[Level0Entry]) -> Vec<NumStat> {
                 m.has_nan |= s.has_nan;
             } else {
                 merged.push(*s);
+            }
+        }
+    }
+    // Every row of a child that carries no stat for a merged column is null for
+    // it: fold those rows in so `null_count` counts all null rows beneath the
+    // entry, not just those in stat-carrying children.
+    for m in &mut merged {
+        for child in children {
+            if !child.stats.iter().any(|s| s.column_id == m.column_id) {
+                m.null_count = m.null_count.saturating_add(child.record_count);
             }
         }
     }
@@ -777,6 +802,142 @@ mod tests {
         assert_eq!(i.max_bits as i64, 900);
         assert_eq!(i.null_count, 9);
         assert!(l1.iter().any(|s| s.column_id == 11 && s.has_nan));
+    }
+
+    /// A block resolving `record_count - null_count` rows of an i64 column over
+    /// `[min, max]` and `null_count` rows that resolve nothing of the type.
+    fn i64_stat_block(
+        idx: u64,
+        column_id: u32,
+        min: i64,
+        max: i64,
+        record_count: u32,
+        null_count: u32,
+    ) -> Level0Entry {
+        let mut e = entry(idx, 0, 1000, 0, 0);
+        e.record_count = record_count;
+        e.stats = vec![NumStat {
+            column_id,
+            ty: FieldType::I64,
+            min_bits: min as u64,
+            max_bits: max as u64,
+            null_count,
+            has_nan: false,
+        }];
+        e
+    }
+
+    /// A block that resolves nothing for the column under test: it carries no
+    /// stat for it, so every one of its `record_count` rows is null for it.
+    fn no_stat_block(idx: u64, record_count: u32) -> Level0Entry {
+        let mut e = entry(idx, 0, 1000, 0, 0);
+        e.record_count = record_count;
+        e.stats = Vec::new();
+        e
+    }
+
+    /// Issue #356's exact repro: two blocks in one level-1 group, block 0
+    /// resolving `dur=9999`, block 1 resolving no `dur` at all (no stat for the
+    /// column). Pre-fix `merge_stats` folded `null_count` only over the
+    /// stat-carrying children, yielding `null_count=0`; the corrected merge
+    /// counts block 1's row. min/max/record_count are asserted unchanged to pin
+    /// that the bounds are untouched.
+    #[test]
+    fn level1_null_count_counts_a_child_with_no_stat() {
+        const DUR: u32 = 20;
+        let l0 = vec![
+            i64_stat_block(0, DUR, 9999, 9999, 1, 0),
+            no_stat_block(1, 1),
+        ];
+        let idx = SkipIndex::build(l0);
+        assert_eq!(idx.l1.len(), 1);
+        let s = idx.l1[0]
+            .stats
+            .iter()
+            .find(|s| s.column_id == DUR)
+            .expect("dur stat");
+        assert_eq!(
+            s.null_count, 1,
+            "block 1's row resolves no dur and must count"
+        );
+        // Bounds and record_count unchanged.
+        assert_eq!(s.min_bits as i64, 9999);
+        assert_eq!(s.max_bits as i64, 9999);
+        assert_eq!(idx.l1[0].record_count, 2);
+    }
+
+    /// More than two children, mixing stat-carrying and non-stat-carrying
+    /// blocks, pins the "every row beneath the entry" claim beyond the
+    /// two-block shape.
+    #[test]
+    fn level1_null_count_sums_every_row_beneath_the_entry() {
+        const DUR: u32 = 20;
+        let l0 = vec![
+            i64_stat_block(0, DUR, 10, 10, 3, 1), // 2 resolved, 1 null within
+            no_stat_block(1, 5),                  // 5 null
+            i64_stat_block(2, DUR, 20, 20, 2, 0), // 2 resolved
+            no_stat_block(3, 4),                  // 4 null
+        ];
+        let idx = SkipIndex::build(l0);
+        assert_eq!(idx.l1.len(), 1);
+        let s = idx.l1[0]
+            .stats
+            .iter()
+            .find(|s| s.column_id == DUR)
+            .expect("dur stat");
+        // 1 (child0 nulls) + 5 (child1) + 0 (child2) + 4 (child3) = 10.
+        assert_eq!(s.null_count, 10);
+        assert_eq!(s.min_bits as i64, 10);
+        assert_eq!(s.max_bits as i64, 20);
+        assert_eq!(idx.l1[0].record_count, 14);
+    }
+
+    /// The corrected level-1 `null_count` is written as a varint and the fix
+    /// makes wider values reachable; a full encode/decode round-trip must
+    /// reproduce it.
+    #[test]
+    fn level1_null_count_survives_round_trip() {
+        const DUR: u32 = 20;
+        let l0 = vec![
+            i64_stat_block(0, DUR, 5, 5, 1, 0),
+            no_stat_block(1, 1_000_000),
+        ];
+        let idx = SkipIndex::build(l0);
+        let s = idx.l1[0]
+            .stats
+            .iter()
+            .find(|s| s.column_id == DUR)
+            .expect("dur stat");
+        assert_eq!(s.null_count, 1_000_000);
+        let got = SkipIndex::decode(&idx.encode(), 100).expect("decode");
+        assert_eq!(got, idx);
+        let ds = got.l1[0]
+            .stats
+            .iter()
+            .find(|s| s.column_id == DUR)
+            .expect("decoded dur stat");
+        assert_eq!(ds.null_count, 1_000_000);
+    }
+
+    /// The level-1 `null_count` sum can exceed `u32`; the merge saturates and
+    /// the doc defines `u32::MAX` as a saturated lower bound. Two no-stat
+    /// children each with `record_count == u32::MAX` drive the sum past the
+    /// ceiling.
+    #[test]
+    fn level1_null_count_saturates() {
+        const DUR: u32 = 20;
+        let l0 = vec![
+            i64_stat_block(0, DUR, 5, 5, 1, 0), // a stat must exist for the column
+            no_stat_block(1, u32::MAX),
+            no_stat_block(2, u32::MAX),
+        ];
+        let idx = SkipIndex::build(l0);
+        let s = idx.l1[0]
+            .stats
+            .iter()
+            .find(|s| s.column_id == DUR)
+            .expect("dur stat");
+        assert_eq!(s.null_count, u32::MAX, "null_count saturates at u32::MAX");
     }
 
     /// Truncating a stat-bearing SKIP_IDX at every prefix length is always a

--- a/docs/log-segment-format.md
+++ b/docs/log-segment-format.md
@@ -454,16 +454,19 @@ count0 level-0 entries:
     has_nan:   u8   (0 or 1)
 count1: u32
 count1 level-1 entries: same fields as a level-0 entry with the byte
-  range and crc omitted, mins/maxes merged over the entry's <= 64
-  children
+  range and crc omitted, merged over the entry's <= 64 children:
+  mins/maxes by the per-type order, has_nan OR-ed, null_count as
+  defined in "null_count at both levels" below
 ```
 
-A level-1 stat merges only the children that carry a stat for that column, so
-its bounds are the group's bounds only because every child that resolves a
-value for the column carries one (see "What a numeric stat bounds" below). A
-child block that resolved values but carried no stat would read as "no
-information" here and be dropped from the merge silently, leaving a level-1
-entry that looks complete and bounds a subset of its group.
+A level-1 stat merges the min/max bounds of only the children that carry a stat
+for that column, so its bounds are the group's bounds only because every child
+that resolves a value for the column carries one (see "What a numeric stat
+bounds" below). A child block that resolved values but carried no stat would
+read as "no information" for the bounds and be dropped from the merge silently,
+leaving a level-1 entry that looks complete and bounds a subset of its group.
+`null_count`, unlike the bounds, does account for the children that carry no
+stat: see "null_count at both levels" below.
 
 Fanout is 64: one level-1 entry per 64 level-0 blocks. A numeric stat
 stores i64 as its two's-complement `u64` bit pattern (`v as u64`), and
@@ -538,6 +541,66 @@ stat range cannot overlap a queried range holds no matching row. Under version
 2 the stats bounded the raw columnar occurrences instead, which could exclude
 the block holding the record a range query wanted; that is the defect version 3
 fixes, and it is why a v2 object cannot be read as a v3 one.
+
+### null_count at both levels (trailer version 3, normative)
+
+A stat's `null_count` counts rows that resolve nothing the stat's `[min, max]`
+bounds. It never contributes to pruning (`candidate_blocks` reads only min/max,
+and null rows never satisfy a range); it is a per-column cardinality hint for a
+future reader, and this section is its only contract.
+
+- **Level-0** (per block). `null_count` is the number of rows of the block whose
+  resolved merged-view value for the column's name is absent or of a type other
+  than the column's type, i.e. the block's `record_count` minus the count of
+  rows that resolve a value of the column's type (the rows the bounds fold in).
+  A block carries a stat for every column it plans, and it plans a numeric
+  column when some row carries a record-level occurrence of that column, or
+  some row's merged-view winner is of its type. The first condition does not
+  require the second, so a present level-0 stat may have
+  `null_count == record_count`: rows carried an occurrence of the column, but
+  every merged-view winner for the name was of another type. That is the
+  cross-type duplicate case (ADR-0095), and such a stat carries
+  `min_bits == max_bits == 0`, bounds that bound nothing. A stat is absent only
+  when neither condition holds, and then no row of the block resolves the
+  column either (see "What a numeric stat bounds").
+
+- **Level-1** (per <= 64 children). `null_count` is the number of rows *beneath
+  the entry* -- summed across all children -- that resolve nothing of the
+  column's type. This counts, for each child, the rows that child's own stat
+  reports null, PLUS every row of any child that carries no stat for the column
+  at all: by the level-0 rule a child with no stat for a column resolves nothing
+  of that type in any of its rows, so all `record_count` of them are null. The
+  writer computes it as `sum(child.stat.null_count for children with the stat) +
+  sum(child.record_count for children without it)`. A level-1 stat exists iff
+  some child carries one, and a child's stat may itself be all-null, so a
+  level-1 stat may also have `null_count == record_count`. An all-null child
+  stat folds its degenerate `0`/`0` bounds into the merged min/max as well,
+  widening them; pruning stays sound, because a wider range only keeps more
+  blocks, but it is less precise.
+
+The rule a reader must honor at both levels: **neither the presence of a stat
+nor its bounds is evidence that any row resolves the column.** A column no row
+resolves has two encodings, and they carry different information even though
+they state the same fact. The stat is absent when no row carries an occurrence
+of the column and no row's winner is of its type. It is present with
+`null_count == record_count` when rows carry an occurrence but every winner is
+of another type. They differ in whether bounds accompany the fact: an absent
+stat carries none and prunes nothing, exactly like an absent posting list,
+while a present stat always carries bounds, which in this case are the
+degenerate `0`/`0` pair. A reader must not read a present stat as "at least one
+row resolves this column", must not read an absent stat as
+`null_count == record_count`, and must not use `null_count` to prune.
+
+`null_count` is a `u32` written as a varint, and the level-1 sum above can in
+principle exceed `u32::MAX` (up to 64 children, each with a `u32` `record_count`).
+The merge saturates: a level-1 `null_count` of `u32::MAX` means "at least
+`u32::MAX` null rows beneath this entry", an exact value lost to saturation. A
+reader that consumes the field must treat `u32::MAX` as a saturated lower bound,
+not an exact count. Saturation is the only approximation in the field and is
+confined to this case; every non-saturated value is exact. (The current writer's
+block sizing keeps real `record_count` values far below `u32::MAX / 64`, so
+saturation is unreachable in practice; it is documented because the format
+contract, not the current writer, bounds `record_count`.)
 
 `candidate_blocks(ts_min, ts_max, stream_refs, numeric)` returns the level-0
 block indices whose entries survive the coarse predicate. Alongside the ts and


### PR DESCRIPTION
The RLOG skip index's level-1 `null_count` had no well-defined meaning. `merge_stats` summed it only over children carrying a stat for a column, so a child that resolves nothing for a column (and therefore emits no stat for it at all) contributed neither its rows nor its nulls. Two blocks in one group where only the first resolves `dur` reported `record_count=2, null_count=0`.

Defines `null_count` normatively for both levels in `docs/log-segment-format.md` and computes the level-1 value to match: each child's own `null_count`, plus the full `record_count` of every child carrying no stat for the column. The byte layout, varints, field order, and trailer version are unchanged; only the value written into the existing level-1 varint changes, and only where the doc previously defined nothing.

**A present stat may have `null_count == record_count`, and the doc now says so.** The first draft of this section asserted the opposite. An adversarial review falsified it through the real writer: 8 records carrying a key as both `I64` and `Bytes`, where `Bytes` wins the merge, decode out of the object's SKIP_IDX as `record_count=8 null_count=8 min=0 max=0`. A block plans a numeric column when some row carries a record-level occurrence of it, which does not require any row's merged-view winner to be of that type, so a cross-type duplicate key (ADR-0095, #333 — a real OTLP payload shape) produces a stat covering every row with degenerate 0/0 bounds. The contract is now that neither a stat's presence nor its bounds is evidence that any row resolves the column, and that an all-null column has two encodings differing only in whether bounds accompany the fact. A test pins the emit half; the planning half lives in `writer.rs` and the test comment says so rather than claiming coverage it does not have.

Bounds are untouched, so no pruning decision changes. Pruning reads only min/max — not even `has_nan`.

`null_count` stays a `u32` varint. The level-1 sum can exceed `u32` by the format contract (up to 64 children each with a `u32` `record_count`), so the merge keeps `saturating_add` and the doc defines `u32::MAX` as a saturated lower bound a reader must treat as such. It is unreachable with the current writer's block sizing, but the contract bounds `record_count`, not the writer, so it is documented rather than assumed away.

No live consumer reads `null_count` today. The value delivered is a defined field where the format had an undefined one; the beneficiary is the next NumStat reader, which would otherwise have been misled. No observable behaviour change.

No ADR or version bump: this assigns a value to a field the format left undefined rather than altering a frozen contract. The reviewer independently reached the same conclusion.

Fixes: #356