### PR TITLE
fix(ingest): charge nested log attribute headers at every level

### DIFF
--- a/crates/ravel-ingest/src/log_router.rs
+++ b/crates/ravel-ingest/src/log_router.rs
@@ -541,6 +541,78 @@ mod tests {
         );
     }
 
+    /// Issue #389 regression, driven through the real charge path
+    /// (`LogIngestRouter::write` -> `try_charge` -> `IngestByteBudget`): a single
+    /// attribute whose value is a `Map` of 8192 `("", Bool)` entries. Under the
+    /// pre-fix `attr_value_len` the record charged only the 8192 one-byte Bool
+    /// payloads (~8.25 KB), so a 100 KB process budget admitted it; the fix also
+    /// charges each entry's `(String, AttrValue)` header, so the same record now
+    /// charges ~459 KB and the budget refuses it before any shard is touched.
+    ///
+    /// A helper-only assertion on `attr_value_len` would prove the estimate grew
+    /// but not that the budget's admission decision changed, so this asserts the
+    /// `write` call itself is shed.
+    #[tokio::test]
+    async fn wide_nested_map_attribute_is_shed_by_the_budget_after_the_nesting_fix() {
+        use ravel_otlp::logs_normalize::NormalizedLogRecord;
+        use ravel_types::TenantId;
+        use ravel_types::logstream::{AttrValue, LogStreamId};
+
+        let entries: Vec<(String, AttrValue)> = (0..8192)
+            .map(|_| (String::new(), AttrValue::Bool(false)))
+            .collect();
+        let rec = NormalizedLogRecord {
+            stream_id: LogStreamId([0u8; 16]),
+            stream_attrs: Vec::new(),
+            ts_ns: 1_000,
+            observed_ts_ns: 1_000,
+            severity_num: 9,
+            severity_text: String::new(),
+            body: String::new(),
+            trace_id: None,
+            span_id: None,
+            flags: 0,
+            attrs: vec![("m".to_string(), AttrValue::Map(entries))],
+        };
+
+        // Magnitude: the fixed estimate is on the order of 459 KB, far above the
+        // ~8.25 KB the old payload-only measure charged.
+        let est = est_record_bytes(&rec);
+        assert!(
+            (400_000..=600_000).contains(&est),
+            "nested-map estimate {est} is not on the ~459 KB order the fix charges"
+        );
+
+        // A budget bounded strictly between the old and new charge: admits the
+        // record under the old measure, sheds it under the fix.
+        let budget = IngestByteBudget::shared(IngestByteBudgetLimit::Bounded(100_000));
+        let router = test_router(Arc::new(MemoryStore::new())).with_budget(Arc::clone(&budget));
+
+        let err = router
+            .write(
+                TenantId::new("acme"),
+                vec![rec],
+                WriteMode::Buffered,
+                Duration::from_secs(1),
+            )
+            .await
+            .expect_err("the fixed nesting estimate pushes the record past the 100 KB ceiling");
+        assert!(
+            matches!(err, LogWriteError::BufferBudgetExceeded),
+            "the record must be shed at the byte budget, got {err:?}"
+        );
+        assert_eq!(
+            budget.shed_total(),
+            1,
+            "the shed counter fires exactly once"
+        );
+        assert_eq!(
+            budget.in_flight_bytes(),
+            0,
+            "a shed request charges nothing, so the gauge is untouched"
+        );
+    }
+
     /// A tenant whose cached view has genuinely changed `shard_count`
     /// (observed via a successful refresh, not grace-extension) routes at the
     /// new count immediately -- grace-extension is never on this router's path

--- a/crates/ravel-ingest/src/log_shard.rs
+++ b/crates/ravel-ingest/src/log_shard.rs
@@ -78,19 +78,30 @@ pub(crate) enum LogShardMsg {
     Shutdown { done: oneshot::Sender<()> },
 }
 
-/// Estimated encoded length of one attribute value, for the `est_bytes`
-/// flush-trigger heuristic. Nested `List`/`Map` values recurse. This is a
-/// sizing estimate only, not the RLOG encoder's exact output.
+/// Estimated buffered byte cost of one attribute value, for the `est_bytes`
+/// flush-trigger heuristic and the process-wide ingest byte budget it feeds
+/// (ADR-0069). Every container charges its per-element struct header at its own
+/// nesting level, not only at the top: a `Map` charges
+/// `size_of::<(String, AttrValue)>()` per entry and a `List` charges
+/// `size_of::<AttrValue>()` per item, each in addition to the recursive cost of
+/// the contained value. The buffer holds those structs whatever the leaf bytes
+/// contain, so counting leaf bytes alone would undercharge a nested value
+/// against the shared ceiling by the header width at every level below the top
+/// (up to ~56x for a wide `Map` of one-byte values). This is a sizing estimate
+/// only, not the RLOG encoder's exact output.
 fn attr_value_len(value: &AttrValue) -> usize {
     match value {
         AttrValue::Str(s) => s.len(),
         AttrValue::Bytes(b) => b.len(),
         AttrValue::I64(_) | AttrValue::F64(_) => 8,
         AttrValue::Bool(_) => 1,
-        AttrValue::List(items) => items.iter().map(attr_value_len).sum(),
+        AttrValue::List(items) => items
+            .iter()
+            .map(|v| size_of::<AttrValue>() + attr_value_len(v))
+            .sum(),
         AttrValue::Map(entries) => entries
             .iter()
-            .map(|(k, v)| k.len() + attr_value_len(v))
+            .map(|(k, v)| size_of::<(String, AttrValue)>() + k.len() + attr_value_len(v))
             .sum(),
     }
 }
@@ -1937,5 +1948,56 @@ mod tests {
     /// constant. Kept in sync with `IndexedFieldsOverlay::new`'s horizon.
     fn ravel_ingest_default_lifecycle_horizon_ns() -> i64 {
         crate::DEFAULT_LIFECYCLE_REFRESH_INTERVAL_NS
+    }
+
+    /// A `List` charges the `size_of::<AttrValue>()` slot header for each item,
+    /// on top of the item's own recursive cost. Pre-fix the `List` arm summed
+    /// the item costs alone, so three `Bool`s charged 3 bytes; the fix charges
+    /// the per-item header at this level too.
+    #[test]
+    fn list_charges_the_per_item_slot_header() {
+        let item = size_of::<AttrValue>();
+        let v = AttrValue::List(vec![
+            AttrValue::Bool(true),
+            AttrValue::Bool(false),
+            AttrValue::Bool(true),
+        ]);
+        assert_eq!(
+            attr_value_len(&v),
+            3 * (item + 1),
+            "each of the three Bool items must charge its AttrValue slot header \
+             plus its one payload byte"
+        );
+    }
+
+    /// The "every level" claim: a `Map` containing a `List` containing a `Map`
+    /// charges a per-element struct header at all three nesting levels, not only
+    /// the top. Pre-fix, `attr_value_len` counted no struct header at any level,
+    /// so this value measured 3 bytes (two one-char keys plus one Bool payload);
+    /// the fix charges a `(String, AttrValue)` header per map entry and a
+    /// `size_of::<AttrValue>()` header per list item at their own levels.
+    #[test]
+    fn nested_map_list_map_charges_headers_at_every_level() {
+        let pair = size_of::<(String, AttrValue)>();
+        let item = size_of::<AttrValue>();
+
+        // Map{ "a": List[ Map{ "b": Bool } ] }
+        let inner_map = AttrValue::Map(vec![("b".to_string(), AttrValue::Bool(false))]);
+        let list = AttrValue::List(vec![inner_map]);
+        let top = AttrValue::Map(vec![("a".to_string(), list)]);
+
+        // Hand-computed bottom-up, a header at each level:
+        //   inner Map entry: pair header + key "b" (1) + Bool payload (1)
+        //   List item:       item header + inner-map cost
+        //   top Map entry:   pair header + key "a" (1) + list cost
+        let inner_cost = pair + 1 + 1;
+        let list_cost = item + inner_cost;
+        let expected = pair + 1 + list_cost;
+
+        assert_eq!(
+            attr_value_len(&top),
+            expected,
+            "a header must be charged at the top Map, the List, and the inner Map"
+        );
     }
 }

--- a/crates/ravel-ingest/src/value.rs
+++ b/crates/ravel-ingest/src/value.rs
@@ -228,6 +228,19 @@ mod tests {
         }
     }
 
+    /// A log record whose single top-level attribute is a `Map` of `entry_count`
+    /// identical `("", Bool)` entries, isolating the nested-level per-entry
+    /// header. The top-level attribute is present at every `entry_count`, so
+    /// differencing two counts cancels it and leaves only the nested cost.
+    fn log_record_with_nested_map(entry_count: usize) -> NormalizedLogRecord {
+        let entries = (0..entry_count)
+            .map(|_| (String::new(), AttrValue::Bool(false)))
+            .collect();
+        let mut rec = log_record_with(0);
+        rec.attrs = vec![("m".to_string(), AttrValue::Map(entries))];
+        rec
+    }
+
     /// A span carrying `attr_count` attributes, each the identical
     /// `("attr", "v")` pair, everything else empty/zero. Same differencing
     /// trick as [`log_record_with`].
@@ -256,11 +269,12 @@ mod tests {
     /// while the others charge honestly -- exactly the skew this pin exists to
     /// catch.
     ///
-    /// Scope, so this doc does not read as more than it proves: the pin covers
-    /// depth 0 only, with `AttrValue::Str` values. A log attribute whose value
-    /// is a nested `Map` is measured by `attr_value_len`, which still counts
-    /// string bytes alone at every level below the top, and this test does not
-    /// catch that.
+    /// Scope: the four-way top-level check below uses `AttrValue::Str` values at
+    /// depth 0. The final block extends the log estimator one level deeper, to a
+    /// nested `Map` value, pinning that `attr_value_len` charges the
+    /// `(String, AttrValue)` header for every nested entry, not only for the
+    /// top-level attribute. It does not exercise the metrics/span estimators
+    /// below depth 0, which have no nested attribute values to charge.
     ///
     /// Each estimator's header term is isolated by differencing two attribute
     /// widths with identical per-attribute content, which cancels every fixed
@@ -344,6 +358,22 @@ mod tests {
             "point and exemplar headers must agree"
         );
         assert_eq!(point_hdr, span_hdr, "point and span headers must agree");
+
+        // Nested level: a log attribute whose value is a `Map` charges the
+        // `(String, AttrValue)` header for each of its entries too, not only for
+        // the top-level attribute. Differencing a W-entry nested `Map` against an
+        // empty one cancels the (identical) top-level attribute and isolates the
+        // nested-entry cost, W * (`(String, AttrValue)` header + one Bool byte).
+        let nested_delta = (est_record_bytes(&log_record_with_nested_map(W as usize))
+            - est_record_bytes(&log_record_with_nested_map(0))) as u64;
+        let nested_hdr = nested_delta - W; // subtract each entry's Bool payload byte
+        assert_eq!(
+            nested_hdr,
+            W * log_pair,
+            "attr_value_len dropped the per-entry header inside a nested Map: \
+             {nested_hdr} != {}",
+            W * log_pair
+        );
     }
 
     /// The two buffered-byte estimators must charge one label the same way, or

--- a/docs/ingest.md
+++ b/docs/ingest.md
@@ -560,12 +560,17 @@ terms:
    for the ceiling itself.
 
    That two-times figure is a metrics measurement and does not transfer to
-   logs. `est_record_bytes` counts the pair header for a record's own
-   attributes but `attr_value_len` still measures a nested `Map` value by its
-   string bytes alone, so a record whose attributes nest can under-charge by
-   far more than two times. Until that is fixed, treat the ceiling as a lower
-   bound on log resident memory rather than a proportional estimate, and size
-   a log-heavy host from measurement rather than from this multiplier.
+   logs. The nesting-accounting gap it once warned about is closed:
+   `attr_value_len` now charges the per-element struct header at every nesting
+   level (a `(String, AttrValue)` per `Map` entry and a `size_of::<AttrValue>()`
+   per `List` item), not only for a record's own top-level attributes, so a
+   record whose attributes nest is charged for the structs the buffer actually
+   holds rather than for leaf bytes alone. What is still unestablished is the
+   ratio itself: no one has measured the charged-to-resident ratio on a log
+   workload the way the 38.4 MB / 69.3 MB metrics figure above was measured, and
+   closing the accounting gap does not by itself make the metrics "roughly twice"
+   ratio hold for logs. Until a log workload is measured, size a log-heavy host
+   from measurement rather than from this multiplier.
 2. **In-flight decode overhead**: each admitted in-flight request transiently
    holds one decoded/normalized request body during normalization, before its
    points reach a buffer. This is bounded by


### PR DESCRIPTION
`attr_value_len` charged the per-element struct header only at the top nesting level, so a record whose single attribute was a wide `Map` of small values was measured by its leaf bytes alone. A `Map` of 8192 one-byte entries charged ~8.25 KB against a buffer holding ~459 KB of `(String, AttrValue)` structs. That estimate feeds `try_charge` on the process-wide ingest byte budget (ADR-0069), so the shared ceiling admitted records it should have shed — the process passed a limit it believed it was under.

The `Map` arm now charges `size_of::<(String, AttrValue)>()` per entry and the `List` arm `size_of::<AttrValue>()` per item, at every level, mirroring the per-label header term the metrics and span estimators already apply.

**The exposure was worse than the ~56x the ticket claimed.** The 8192-byte attribute value cap lives in `ravel-otlp` and is enforced at normalize time on its own payload-only measure, before a record reaches this estimator, so it never gated this path. A `List` of empty `List`s measures zero under that cap, so the cap bounds no element count at all, while the buffer holds 32 bytes per item. Pre-fix that shape undercharged without bound. Both shapes now charge what they hold.

Arithmetic verified by hand against the code rather than assumed. For `Map{"a": List[Map{"b": Bool}]}`: 56 + 1 + (32 + 56 + 1 + 1) = 147; the code returns 147 against ~146 actually held. The one byte is an inline scalar leaf and is pre-existing. The estimate still under-reads true RSS, since it ignores `Vec` spare capacity and allocator rounding — it has not flipped to over-counting, which would make ingest shed load it could accept.

**No recursion depth bound, deliberately.** This change alters neither the recursion depth nor the frame, adding only compile-time `size_of` constants inside the existing folds, so any stack property is identical on both sides. On the charge path a nested `AttrValue` is built only by `ravel_otlp::logs_normalize::convert_value` from a prost-decoded `AnyValue` tree, and by ravel-cli's Parquet loader, each recursing to full depth with a per-level frame heavier than this function's, before `est_record_bytes` sees the value. A depth-matched measurement put `convert_value`'s overflow depth at roughly half `attr_value_len`'s across 128/256/512 KiB stacks, and tokio workers run the 2 MiB default. A value deep enough to overflow this function could not have been constructed.

Tests drive the adversarial input through the real charge path (`write` → `try_charge` → `IngestByteBudget`) and assert the record is shed, with the budget set between the old and new charge so a top-level-only fix still fails. `List` and multi-level `Map`/`List`/`Map` cases pin the every-level rule. Each was demonstrated failing against the pre-fix code.

`docs/ingest.md`'s sizing caveat is narrowed rather than removed: the nesting-accounting gap is closed, but the charged-to-resident ratio is still unmeasured for logs, so a log-heavy host is sized from measurement.

Fixes: #389