### PR TITLE
feat(sql): unify session construction and pin the sliding-frame order

### DIFF
--- a/crates/ravel-sql/src/conformance.rs
+++ b/crates/ravel-sql/src/conformance.rs
@@ -107,6 +107,12 @@ pub enum Category {
     /// A window function used with an `OVER` clause (admitted or excluded)
     /// (ADR-0097 decisions 6, 8).
     Window,
+    /// An aggregate used over a moving window frame, whose semantics are
+    /// selected by the frame shape rather than by the function name (ADR-0097
+    /// decision 5). Kept separate from [`Category::Window`] because it enumerates
+    /// aggregate-over-frame positions, not the native window-function registry
+    /// the [`Category::Window`] drift check binds to.
+    WindowFrame,
 }
 
 impl Category {
@@ -117,8 +123,9 @@ impl Category {
             Category::Clause => 1,
             Category::Scalar => 2,
             Category::Window => 3,
-            Category::WriteStatement => 4,
-            Category::TableDispatch => 5,
+            Category::WindowFrame => 4,
+            Category::WriteStatement => 5,
+            Category::TableDispatch => 6,
         }
     }
 
@@ -129,6 +136,7 @@ impl Category {
             Category::Clause => "Clause / operator",
             Category::Scalar => "Scalar function",
             Category::Window => "Window function",
+            Category::WindowFrame => "Window frame",
             Category::WriteStatement => "Write / DDL statement",
             Category::TableDispatch => "Table dispatch",
         }
@@ -200,6 +208,13 @@ const E_EXCLUDED_WINDOW: &str = "ValidationError::ExcludedWindow";
 const E_NOT_READ_ONLY: &str = "ValidationError::NotReadOnly";
 const E_WRITE_IN_QUERY: &str = "ValidationError::WriteInQuery";
 const E_CROSS_SIGNAL: &str = "SqlError::CrossSignalQuery";
+/// The typed error a moving-frame `avg` surfaces (ADR-0097 decision 5): a
+/// DataFusion "retract_batch is not implemented" refusal, mapped to
+/// [`crate::error::SqlError::Execution`]. Unlike the other rejected constructs,
+/// this one is not refused by [`crate::validate`] (`avg` is admitted) and not by
+/// a registry gate; it fails closed inside DataFusion's sliding-window planner,
+/// so the conformance suite verifies it by executing the query.
+const E_SLIDING_AVG: &str = "SqlError::Execution";
 
 /// One admitted upstream scalar *family* (ADR-0097 decision 8), attested by a
 /// single representative row rather than one row per member. The family row is
@@ -596,6 +611,29 @@ pub fn registry() -> Vec<Construct> {
                         row (ADR-0097 decision 6)",
         });
     }
+
+    // --- Window frame (ADR-0097 decision 5) ------------------------------
+    // Moving-frame `avg` fails closed with a typed error rather than diverging:
+    // a frame whose start is not UNBOUNDED PRECEDING routes the aggregate through
+    // DataFusion's sliding accumulator, and `avg` (the sequential-fold UDAF,
+    // crate::avg) implements no `retract_batch`, so DataFusion refuses it. This
+    // records that refusal as a decision, so a future `supports_retract_batch`
+    // override cannot silently reverse it. Moving-frame `min`/`max`, by contrast,
+    // stay admitted and are pinned bit-for-bit against a total-order reference by
+    // tests/sliding_frame_total_order.rs (they run upstream's `total_cmp`-ordered
+    // sliding accumulator, the same order ADR-0023 mandates).
+    out.push(Construct {
+        category: Category::WindowFrame,
+        name: "avg (moving frame)".to_string(),
+        example: "SELECT avg(value) OVER (ORDER BY ts ROWS BETWEEN 2 PRECEDING AND CURRENT ROW) \
+                  FROM samples"
+            .to_string(),
+        classification: Classification::IntentionallyRejected {
+            typed_error: E_SLIDING_AVG,
+        },
+        rationale: "moving-frame avg has no retract_batch, so DataFusion refuses it \
+                    (ADR-0097 decision 5)",
+    });
 
     // --- Write / DDL statements ------------------------------------------
     // The read-only single-statement gate refuses every non-`SELECT` statement

--- a/crates/ravel-sql/src/executor.rs
+++ b/crates/ravel-sql/src/executor.rs
@@ -103,7 +103,6 @@ use crate::pushdown::extract;
 use crate::session::{LOGS_TABLE, SAMPLES_TABLE, SPANS_TABLE, SessionTable, build_session};
 use crate::spans_fetcher::SpanSegmentFetcher;
 use crate::spans_provider::SpansTableProvider;
-use crate::udf::{label_match_udf, label_udf};
 use crate::validate::{referenced_base_tables, validate};
 
 /// Which of the three v1 tables (and thus which `Signal`) a query targets.
@@ -859,24 +858,21 @@ impl SqlExecutor {
     /// `None` (no prune); the real plan surfaces such errors later through
     /// [`Self::plan_pinned`].
     async fn pushed_down_name_filter(&self, tenant_hash: TenantHash, sql: &str) -> Option<String> {
-        let ctx = SessionContext::new();
-        ctx.register_udf(label_udf());
-        ctx.register_udf(label_match_udf());
-        let provider = RavelTableProvider::new(
-            Snapshot {
-                segments: Vec::new(),
-                segments_pruned: 0,
-                pending_erasure: Vec::new(),
-            },
-            tenant_hash,
-            self.fetcher.clone(),
-            self.config,
-            // Throwaway handle: this plans over an empty snapshot purely to
-            // recover predicates, so no store fetch is ever issued through
-            // it and nothing would ever be recorded here.
-            QueryAccounting::new(),
-        );
-        ctx.register_table(SAMPLES_TABLE, Arc::new(provider)).ok()?;
+        // Route through `build_session`, the same construction
+        // `analyzed_classification_plan` uses, rather than a bare
+        // `SessionContext::new()` (ADR-0097 decision 7). This carries the
+        // `EmptyObjectStoreRegistry` (ADR-0013 security invariant 1) and the
+        // per-registry allowlist deregistrations plus the UDAF replacements,
+        // so the two throwaway-session sites converge on one path. The
+        // per-table `label`/`label_match` UDFs a metrics session needs are
+        // registered by `build_session` itself. This is a metrics-only site
+        // (its sole caller resolves the `__name__` postings filter).
+        let table = self.empty_snapshot_table(TargetSignal::Metrics, tenant_hash, &[]);
+        // A private, unbounded pool: this session only logical-plans and never
+        // executes, so nothing is reserved against it and it never touches the
+        // tenant accountant.
+        let pool: Arc<dyn MemoryPool> = Arc::new(UnboundedMemoryPool::default());
+        let ctx = build_session(&self.config, pool, table, false).ok()?;
         let plan = ctx.state().create_logical_plan(sql).await.ok()?;
         let mut predicates = Vec::new();
         collect_filter_predicates(&plan, &mut predicates);

--- a/crates/ravel-sql/src/minmax.rs
+++ b/crates/ravel-sql/src/minmax.rs
@@ -161,6 +161,8 @@ impl AggregateUDFImpl for TotalOrderMinMax {
     }
 
     fn accumulator(&self, acc_args: AccumulatorArgs) -> DFResult<Box<dyn Accumulator>> {
+        #[cfg(test)]
+        routing_probe::note_accumulator();
         let return_type = acc_args.return_field.data_type();
         if is_float(return_type) {
             Ok(Box::new(TotalOrderAccumulator::new(
@@ -192,7 +194,15 @@ impl AggregateUDFImpl for TotalOrderMinMax {
         self.inner.create_groups_accumulator(args)
     }
 
+    // Delegate the moving-window (sliding) accumulator to the wrapped built-in
+    // with no float guard, unlike `accumulator` above. Upstream's
+    // `MovingMin`/`MovingMax` order candidates through `ScalarValue`'s
+    // `PartialOrd`, which is `f64::total_cmp` for float types -- the same total
+    // order ADR-0023 mandates -- so the sliding path is total-order by
+    // construction for float input and needs no replacement here.
     fn create_sliding_accumulator(&self, args: AccumulatorArgs) -> DFResult<Box<dyn Accumulator>> {
+        #[cfg(test)]
+        routing_probe::note_sliding();
         self.inner.create_sliding_accumulator(args)
     }
 
@@ -309,5 +319,138 @@ impl Accumulator for TotalOrderAccumulator {
 
     fn size(&self) -> usize {
         std::mem::size_of_val(self)
+    }
+}
+
+/// Test-only instrumentation that records which accumulator constructor
+/// DataFusion calls for a given window frame shape, so the sliding-path
+/// float-safety guarantee rests on a measured routing fact rather than an
+/// assumption about DataFusion internals. Counters are thread-local: the
+/// routing test drives its plan on a current-thread runtime, so every
+/// constructor call lands on the test thread and parallel tests on other
+/// threads cannot pollute the counts.
+#[cfg(test)]
+mod routing_probe {
+    use std::cell::Cell;
+
+    thread_local! {
+        static ACCUMULATOR_CALLS: Cell<usize> = const { Cell::new(0) };
+        static SLIDING_CALLS: Cell<usize> = const { Cell::new(0) };
+    }
+
+    pub(super) fn note_accumulator() {
+        ACCUMULATOR_CALLS.with(|c| c.set(c.get() + 1));
+    }
+
+    pub(super) fn note_sliding() {
+        SLIDING_CALLS.with(|c| c.set(c.get() + 1));
+    }
+
+    pub(super) fn reset() {
+        ACCUMULATOR_CALLS.with(|c| c.set(0));
+        SLIDING_CALLS.with(|c| c.set(0));
+    }
+
+    pub(super) fn accumulator_calls() -> usize {
+        ACCUMULATOR_CALLS.with(Cell::get)
+    }
+
+    pub(super) fn sliding_calls() -> usize {
+        SLIDING_CALLS.with(Cell::get)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use datafusion::arrow::array::{Float64Array, Int64Array};
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::arrow::record_batch::RecordBatch;
+    use datafusion::datasource::MemTable;
+    use datafusion::prelude::{SessionConfig, SessionContext};
+
+    use super::*;
+
+    /// Establish, rather than assume, which window frame shapes DataFusion
+    /// routes to `create_sliding_accumulator` versus `accumulator`. This is the
+    /// premise the acceptance test
+    /// (`tests/sliding_frame_total_order.rs`) rests on: a *moving* frame runs
+    /// the sliding accumulator (upstream `MovingMin`/`MovingMax`), while an
+    /// UNBOUNDED PRECEDING frame runs Ravel's own `TotalOrderAccumulator`, so a
+    /// test over only the unbounded shape would never exercise the delegation
+    /// under test.
+    ///
+    /// The routing is observed directly by counting each constructor call on the
+    /// registered total-order `min` UDAF (`routing_probe`), on a current-thread
+    /// runtime so the counts are deterministic.
+    #[test]
+    fn moving_frame_routes_to_the_sliding_accumulator() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("t", DataType::Int64, false),
+            Field::new("v", DataType::Float64, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(Int64Array::from(vec![1, 2, 3, 4])),
+                Arc::new(Float64Array::from(vec![1.0, 2.0, 3.0, 4.0])),
+            ],
+        )
+        .expect("batch");
+
+        // A current-thread runtime keeps all plan execution -- and thus every
+        // accumulator construction -- on this thread, where the thread-local
+        // probe counters live.
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("current-thread runtime");
+
+        let drain = |sql: &str| {
+            let ctx =
+                SessionContext::new_with_config(SessionConfig::new().with_target_partitions(1));
+            // Displace the built-in `min` with the total-order UDAF under test,
+            // exactly as `build_session` does.
+            ctx.register_udaf(total_order_min_udaf());
+            let table = MemTable::try_new(Arc::clone(&schema), vec![vec![batch.clone()]])
+                .expect("memtable");
+            ctx.register_table("x", Arc::new(table)).expect("register");
+            let batches = rt.block_on(async {
+                ctx.sql(sql)
+                    .await
+                    .expect("plan window query")
+                    .collect()
+                    .await
+                    .expect("execute window query")
+            });
+            // Force full execution.
+            assert!(batches.iter().map(|b| b.num_rows()).sum::<usize>() > 0);
+        };
+
+        // An UNBOUNDED PRECEDING frame runs Ravel's own accumulator, never the
+        // sliding one.
+        routing_probe::reset();
+        drain("SELECT min(v) OVER (ORDER BY t) AS m FROM x");
+        assert!(
+            routing_probe::accumulator_calls() > 0,
+            "the unbounded frame must construct Ravel's own accumulator"
+        );
+        assert_eq!(
+            routing_probe::sliding_calls(),
+            0,
+            "the unbounded frame must NOT construct the sliding accumulator"
+        );
+
+        // A moving `ROWS BETWEEN n PRECEDING AND CURRENT ROW` frame routes to
+        // the sliding accumulator (upstream `MovingMin`), the path the
+        // acceptance test's float-safety guarantee depends on.
+        routing_probe::reset();
+        drain(
+            "SELECT min(v) OVER (ORDER BY t ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS m FROM x",
+        );
+        assert!(
+            routing_probe::sliding_calls() > 0,
+            "a moving frame must construct the sliding accumulator"
+        );
     }
 }

--- a/crates/ravel-sql/tests/conformance.rs
+++ b/crates/ravel-sql/tests/conformance.rs
@@ -464,6 +464,27 @@ async fn verify(construct: &Construct, fixture: &Fixture) -> Verdict {
                         observed: "cross-signal query was accepted".to_string(),
                     },
                 }
+            } else if construct.category == Category::WindowFrame {
+                // Moving-frame `avg` is not refused by `validate` (`avg` is
+                // admitted) nor by a registry gate: it fails closed inside
+                // DataFusion's sliding-window planner, so it must be executed to
+                // see the typed error, and only over a fixture with rows (an
+                // empty frame short-circuits before the accumulator is built).
+                match fixture
+                    .executor
+                    .execute(tenant.hash(), &request(&construct.example))
+                    .await
+                {
+                    Err(SqlError::Execution(msg)) if msg.contains("sliding accumulator") => {
+                        Verdict::Confirmed
+                    }
+                    Err(e) => Verdict::Broken {
+                        observed: format!("wrong error: {e}"),
+                    },
+                    Ok(_) => Verdict::Broken {
+                        observed: "moving-frame avg was accepted".to_string(),
+                    },
+                }
             } else {
                 // Every other rejected construct is refused by the read-only
                 // single-statement gate before any planning, so the typed
@@ -565,8 +586,11 @@ async fn supported_constructs_execute() {
 /// fail cleanly").
 #[tokio::test]
 async fn every_intentionally_rejected_construct_returns_a_typed_error() {
-    let tenant = tenant_id("conformance");
-    let fixture = Fixture::memory(&[(&tenant, &[])]).await;
+    // A data-bearing fixture: most rejected constructs are refused before any
+    // planning and would pass over an empty store, but moving-frame `avg`
+    // (ADR-0097 decision 5) is refused inside DataFusion's sliding-window planner
+    // and only when the frame actually has rows, so it needs real samples.
+    let fixture = conformance_fixture().await;
 
     let mut rejected = 0usize;
     for construct in registry() {

--- a/crates/ravel-sql/tests/sliding_frame_total_order.rs
+++ b/crates/ravel-sql/tests/sliding_frame_total_order.rs
@@ -1,0 +1,179 @@
+//! Moving-frame `min`/`max` float-safety (ADR-0097 decision 5).
+//!
+//! A moving window frame (any frame whose start is not UNBOUNDED PRECEDING)
+//! routes an aggregate-over-window through DataFusion's *sliding* accumulator,
+//! not Ravel's `TotalOrderAccumulator`: `min(value) OVER (ORDER BY ts ROWS
+//! BETWEEN 2 PRECEDING AND CURRENT ROW)` runs upstream's `MovingMin`/`MovingMax`
+//! (`crate::minmax::create_sliding_accumulator` delegates to the built-in with
+//! no float guard). That is safe only because `ScalarValue`'s `PartialOrd` is
+//! `f64::total_cmp` for float types, the same total order ADR-0023 mandates.
+//! Nothing else in this workspace enters that path, so this test pins the
+//! guarantee against an upstream comparator change.
+//!
+//! The routing fact -- that a moving frame constructs the sliding accumulator
+//! while an UNBOUNDED PRECEDING frame constructs Ravel's own -- is established
+//! directly by `crate::minmax`'s `moving_frame_routes_to_the_sliding_accumulator`
+//! unit test, which counts each constructor call. This suite exercises that
+//! established path end to end through `SqlExecutor::execute` over a real RSEG
+//! fixture and asserts every moving frame's result is bit-identical to a total-
+//! order reference computed over that frame's own rows.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+mod util;
+
+use std::sync::Arc;
+
+use ravel_object_store::ObjectStoreBackend;
+use ravel_object_store::memory::MemoryStore;
+use util::gate::{Cell, actual_rows, max_total_order, min_total_order};
+use util::{Fixture, SegSpec, SeriesSpec, request, tenant_id};
+
+/// A quiet NaN carrying a non-default payload (ADR-0022 decision 1's adversarial
+/// pool). A `==` comparison can never see this survive a fold; only a
+/// bit-pattern comparison can, and only a total order keeps it as the extreme.
+const NAN_PAYLOAD: f64 = f64::from_bits(0x7ff8_0000_dead_beef);
+
+/// The adversarial value pool, in `ts` order (the sliding frame's own order).
+///
+/// Laid out so a width-3 moving frame slides across every hazard ADR-0022
+/// decision 1 names: `+0.0` ordered before `-0.0` (indices 1, 2), a NaN with a
+/// non-default payload that a later frame must *retract* without poisoning the
+/// deque (index 3, gone by index 6), an all-`+inf` frame (indices 5-7), an
+/// all-`-inf` frame (indices 8-10), and ordinary finite values throughout.
+fn pool() -> Vec<f64> {
+    vec![
+        5.0,               // 0
+        0.0,               // 1  (+0.0, ordered before the -0.0 below)
+        -0.0,              // 2
+        NAN_PAYLOAD,       // 3
+        2.0,               // 4
+        f64::INFINITY,     // 5
+        f64::INFINITY,     // 6
+        f64::INFINITY,     // 7  frame {5,6,7} is all +inf
+        f64::NEG_INFINITY, // 8
+        f64::NEG_INFINITY, // 9
+        f64::NEG_INFINITY, // 10 frame {8,9,10} is all -inf
+        -7.5,              // 11
+        3.0,               // 12
+    ]
+}
+
+/// Build a single-series, single-segment metrics fixture whose one series
+/// carries [`pool`] at `ts = 1..=n`, so the row order the SQL window sees
+/// (sorted by `ts`) is exactly the pool order.
+async fn pool_fixture() -> Fixture {
+    let tenant = tenant_id("sliding-frame");
+    let samples: Vec<(i64, f64)> = pool()
+        .into_iter()
+        .enumerate()
+        .map(|(i, v)| (i as i64 + 1, v))
+        .collect();
+    let spec = SegSpec::new(10, 1, 1, vec![SeriesSpec::new("m", samples)]);
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+    Fixture::build(
+        store,
+        &[(&tenant, &[spec])],
+        ravel_sql::SqlConfig::default(),
+        1 << 30,
+    )
+    .await
+}
+
+/// The row indices the frame `[i - start_off, i - end_off]` covers for output
+/// row `i`, clamped to the rows that exist at or before `i`. Empty when the
+/// whole range is before row 0.
+fn frame_indices(i: usize, start_off: usize, end_off: usize) -> Vec<usize> {
+    // `hi` is `i - end_off`; if `end_off > i` the whole frame is before row 0.
+    let Some(hi) = i.checked_sub(end_off) else {
+        return Vec::new();
+    };
+    let lo = i.saturating_sub(start_off);
+    (lo..=hi).collect()
+}
+
+/// The reference cell for one frame: the total-order `min`/`max` over the
+/// frame's own values as a bit-compared [`Cell`], or `Cell::Null` for an empty
+/// frame (SQL `min`/`max` over no rows is NULL).
+fn reference_cell(values: &[f64], indices: &[usize], want_max: bool) -> Cell {
+    if indices.is_empty() {
+        return Cell::Null;
+    }
+    let frame: Vec<f64> = indices.iter().map(|&j| values[j]).collect();
+    let extreme = if want_max {
+        max_total_order(&frame)
+    } else {
+        min_total_order(&frame)
+    };
+    match extreme {
+        Some(v) => Cell::float(v),
+        None => Cell::Null,
+    }
+}
+
+/// The acceptance test (ADR-0097 decision 5): moving-frame `min`/`max` over the
+/// adversarial pool, run through the real pipeline, matches a total-order
+/// reference computed over each frame's own rows, bit for bit.
+///
+/// Two frame specifications are checked, both of which route to the sliding
+/// accumulator (frame start is not UNBOUNDED PRECEDING; see the module-level
+/// note and `crate::minmax`'s routing unit test):
+///
+/// - `ROWS BETWEEN 2 PRECEDING AND CURRENT ROW`: a width-3 moving frame that
+///   slides across the pool, so every value enters and later *retracts* --
+///   across the NaN (indices 3 -> gone by 6) and across `+0.0` (index 1 ->
+///   gone by 4). A retract that poisoned the deque, or one that lost the sign
+///   of zero or the NaN payload, diverges here.
+/// - `ROWS BETWEEN 3 PRECEDING AND 2 PRECEDING`: a frame that is empty for the
+///   first two rows (SQL NULL) and holds two historical rows thereafter.
+///
+/// Every comparison is by `f64::to_bits` (via [`Cell`]), never `==`: `-0.0 ==
+/// +0.0` is true and `NaN != NaN`, so an `==` comparison would pass on exactly
+/// the inputs this test exists to catch.
+#[tokio::test]
+async fn moving_frame_minmax_matches_total_order_reference() {
+    let fixture = pool_fixture().await;
+    let tenant = tenant_id("sliding-frame");
+    let values = pool();
+    let n = values.len();
+
+    // (frame SQL, start offset, end offset) for the moving and empty frames.
+    let frames = [
+        ("ROWS BETWEEN 2 PRECEDING AND CURRENT ROW", 2usize, 0usize),
+        ("ROWS BETWEEN 3 PRECEDING AND 2 PRECEDING", 3usize, 2usize),
+    ];
+
+    for (frame_sql, start_off, end_off) in frames {
+        let sql = format!(
+            "SELECT CAST(ts AS BIGINT) AS t, \
+             min(value) OVER (ORDER BY ts {frame_sql}) AS mn, \
+             max(value) OVER (ORDER BY ts {frame_sql}) AS mx \
+             FROM samples ORDER BY t"
+        );
+        let outcome = fixture
+            .executor
+            .execute(tenant.hash(), &request(&sql))
+            .await
+            .unwrap_or_else(|e| panic!("moving-frame query must execute ({frame_sql}): {e}"));
+        let rows = actual_rows(&outcome.output);
+        assert_eq!(
+            rows.len(),
+            n,
+            "one output row per input row for frame {frame_sql}"
+        );
+
+        for (i, row) in rows.iter().enumerate() {
+            let indices = frame_indices(i, start_off, end_off);
+            let want_mn = reference_cell(&values, &indices, false);
+            let want_mx = reference_cell(&values, &indices, true);
+            let expected = vec![Cell::Int(i as i64 + 1), want_mn, want_mx];
+            assert_eq!(
+                row,
+                &expected,
+                "frame {frame_sql} row {i} (ts {}) diverged from the total-order reference \
+                 over frame rows {indices:?}",
+                i + 1
+            );
+        }
+    }
+}

--- a/docs/sql-conformance.md
+++ b/docs/sql-conformance.md
@@ -55,9 +55,9 @@ and stays conformant.
 ## Score
 
 - Supported and covered: 41
-- Intentionally rejected: 67
+- Intentionally rejected: 68
 - Unclassified / broken: 0
-- **Conformance: 108 / 108 = 100.0%**
+- **Conformance: 109 / 109 = 100.0%**
 
 ## Conformance table
 
@@ -153,6 +153,7 @@ and stays conformant.
 | Window function | `percent_rank` | `SELECT max(pr) FROM (SELECT percent_rank() OVER (ORDER BY value) AS pr FROM samples)` | Supported and covered | `tests/conformance.rs::supported_constructs_execute` | admitted native window function (ADR-0097 decision 6) |
 | Window function | `rank` | `SELECT max(r) FROM (SELECT rank() OVER (ORDER BY value) AS r FROM samples)` | Supported and covered | `tests/conformance.rs::supported_constructs_execute` | admitted native window function (ADR-0097 decision 6) |
 | Window function | `row_number` | `SELECT max(rn) FROM (SELECT row_number() OVER (ORDER BY value) AS rn FROM samples)` | Supported and covered | `tests/conformance.rs::supported_constructs_execute` | admitted native window function (ADR-0097 decision 6) |
+| Window frame | `avg (moving frame)` | `SELECT avg(value) OVER (ORDER BY ts ROWS BETWEEN 2 PRECEDING AND CURRENT ROW) FROM samples` | Intentionally rejected | `SqlError::Execution` | moving-frame avg has no retract_batch, so DataFusion refuses it (ADR-0097 decision 5) |
 | Write / DDL statement | `ALTER TABLE` | `ALTER TABLE samples ADD COLUMN x INT` | Intentionally rejected | `ValidationError::NotReadOnly` | read-only endpoint; refused before planning (crate::validate) |
 | Write / DDL statement | `COPY` | `COPY (SELECT 1) TO 's3://evil/out.parquet'` | Intentionally rejected | `ValidationError::NotReadOnly` | read-only endpoint; refused before planning (crate::validate) |
 | Write / DDL statement | `CREATE EXTERNAL TABLE` | `CREATE EXTERNAL TABLE t (a INT) STORED AS PARQUET LOCATION '/tmp/x'` | Intentionally rejected | `ValidationError::NotReadOnly` | read-only endpoint; refused before planning (crate::validate) |


### PR DESCRIPTION
ADR-0097 decisions 5 and 7. The last task of epic #359.

## Decision 7 — unify the second session construction

`pushed_down_name_filter` built a bare `SessionContext::new()`, skipping the `EmptyObjectStoreRegistry` that ADR-0013 security invariant 1 relies on, plus the whole aggregate/scalar/window/table-function deregistration set — while its sibling `analyzed_classification_plan` built correctly through `build_session`. It now routes through `build_session` too.

**No query result changes**, and the reason is structural rather than incidental. The name filter comes from the same `label`/`label_match` UDF forms as before: `extract` mints a `__name__` matcher only from those, and the map-field `ExprPlanner` that `build_session` adds lowers `labels['__name__']` to `get_field`, which `extract` ignores. `walk_conjunct` descends only top-level `AND`, so an `OR` or `NOT` is one opaque leaf that prunes nothing, and `equality_name_filter` refuses `Ne`, non-prefix regex, and a second `__name__` matcher.

Verified adversarially rather than argued: on a two-segment fixture, `NOT(label(...)='aaa')` and `label(...)='aaa' OR label(...)='bbb'` both fire **no** prune and return complete results, and map-index comparisons fail at `type_coercion` end-to-end. Existing tests could not have covered this, since they were written when this site never planned map-index syntax at all.

Consistency fix, not an exploit fix. The site is reached only after `validate`, plans without executing, and discards the session — though it does sit behind `resolve()`, which both the HTTP and Flight SQL surfaces funnel through.

## Decision 5 — pin the sliding-frame assumption

`create_sliding_accumulator` delegates unconditionally with no float guard, unlike `accumulator`. DataFusion routes an aggregate-over-window through it whenever the frame start is not UNBOUNDED PRECEDING, so moving-frame `min`/`max` run upstream's code rather than Ravel's `TotalOrderAccumulator`.

**That is correct and deliberately unchanged.** Upstream's `MovingMin`/`MovingMax` are generic over `PartialOrd`, and `ScalarValue`'s `PartialOrd` uses `f64::total_cmp` — the total order ADR-0023 mandates. What was missing is that nothing tested it, in a path no test entered. So this pins the assumption rather than "fixing" the delegation; an earlier draft proposed excluding aggregate-shaped `OVER` here and a probe disproved its premise, recorded as ADR-0097 rejected alternative F.

The differential test drives moving-frame `min`/`max` through `SqlExecutor::execute` over a real RSEG fixture, comparing bit patterns against a total-order reference over each frame's own rows, across ADR-0022's adversarial pool: NaN with a non-default payload, `+0.0` before `-0.0`, all-infinite frames, finite values, retract transitions across the NaN and across `+0.0`, and an empty frame. Comparison is `f64::to_bits` throughout — `-0.0 == +0.0` is true and `NaN != NaN`, so an equality comparison would pass on precisely these inputs.

Routing is measured, not assumed: `cfg(test)` probe counters in both constructors show `ROWS BETWEEN n PRECEDING` builds the sliding accumulator and `OVER (ORDER BY ts)` builds Ravel's own.

Two mutations confirm the test is not vacuous. Swapping the reference to `partial_cmp` fails on the `-0.0` case; reordering NaN as smallest fails on the `{+0.0, -0.0, NaN}` frame with the payload compared bit-for-bit.

Moving-frame `avg` gets a recorded rejected position. It fails closed today only because `SequentialAvg` overrides neither `create_sliding_accumulator` nor `supports_retract_batch` — a trait default, not a decision. The conformance row makes it one: the test fails if a future override lets it succeed, and fails if it errors differently.

Fixes: #375
Refs: #359