### PR TITLE
ci: raise check job timeout from 25 to 35 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,7 +304,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 35
     env:
       # Share compiled objects across the six workspace-compiling jobs via the
       # GitHub Actions cache backend. rust-cache only restores the dependency


### PR DESCRIPTION
The check job's Test step ran ~24 minutes on a cold cache and got killed by the 25-minute job timeout, surfacing as a cancelled required check that blocks auto-merge with no code defect behind it (seen on PR #393). 35 minutes gives headroom above the observed cold-cache duration.