### PR TITLE
docs(adrs): claim ADR-0098 for shared label string representation

### DIFF
--- a/docs/adrs/0098-shared-label-string-representation.md
+++ b/docs/adrs/0098-shared-label-string-representation.md
@@ -1,0 +1,3 @@
+# ADR-0098: Shared string representation for labels
+
+Status: claimed


### PR DESCRIPTION
Number reservation only. Lands a one-line stub so a parallel session cannot pick 0098; the decision content follows over this stub after review.

Refs: #367