### PR TITLE
feat(queryfrag): add typed HistogramRecord, retire span_payload, wire histogram erasure

### DIFF
--- a/crates/ravel-query/src/distrib/codec.rs
+++ b/crates/ravel-query/src/distrib/codec.rs
@@ -27,6 +27,7 @@ use ravel_types::{Label, LabelSet, SeriesId, Signal};
 
 use ravel_logseg::LogRecord;
 use ravel_rspan::{SpanRecord, StatusCode};
+use ravel_segment::{HistogramCounts, HistogramSpan, HistogramValue, ResetHint};
 use ravel_types::logstream::{AttrValue, LogStreamId};
 
 use crate::erasure::ErasurePredicate;
@@ -220,6 +221,10 @@ pub enum CodecError {
     BadSpanParentId { got: usize },
     #[error("span status code {got} is not a known OTLP StatusCode (0 Unset, 1 Ok, 2 Error)")]
     UnknownSpanStatusCode { got: u32 },
+    #[error("histogram record carried no `counts` oneof variant")]
+    MissingHistogramCounts,
+    #[error("unknown histogram reset-hint discriminant {0}")]
+    UnknownResetHint(i32),
 }
 
 /// Rejects any protocol version this build does not speak. `Ok(())` only for
@@ -482,6 +487,194 @@ fn decode_sample_priorities(
         })
         .collect();
     Ok(Some(priorities))
+}
+
+// ---- HistogramRecord <-> ravel_segment::HistogramValue --------------------
+
+/// Encodes decoded native-histogram samples as typed [`pb::HistogramRecord`]s
+/// (ADR-0096 decision 2), mirroring [`HistogramValue`] field for field. Every
+/// `f64` crosses as its [`f64::to_bits`] pattern (proto `fixed64`), never a
+/// proto double, so NaN payloads, signalling NaNs, and `-0.0` survive the wire
+/// byte-for-byte, the same discipline [`encode_series_frame`] applies to scalar
+/// sample values.
+///
+/// `sum: None` stays distinct from a present value (proto3 `optional`).
+/// `custom_values: None` maps to an empty repeated field, which proto3 omits;
+/// on decode an empty field is read back as `None`. For a well-formed
+/// histogram this is lossless: a `Some` custom-values set is never empty (it is
+/// present iff `scale == -53`, with ascending boundaries), so the only value
+/// that maps to the empty wire form is `None`.
+///
+/// No live caller wires this encoder into the distributed fetch path yet: the
+/// worker still refuses any histogram-bearing slice (see
+/// [`crate::distrib::service`]), and flipping the protocol version to enable
+/// the encoder is a later step of the same epic (ADR-0096 decision 3 step 4,
+/// #379). It is proven structurally by this module's round-trip property test
+/// against [`HistogramValue`].
+pub fn encode_histogram_records(values: &[HistogramValue]) -> Vec<pb::HistogramRecord> {
+    values.iter().map(encode_histogram_record).collect()
+}
+
+fn encode_histogram_record(value: &HistogramValue) -> pb::HistogramRecord {
+    pb::HistogramRecord {
+        scale: value.scale,
+        zero_threshold_bits: value.zero_threshold.to_bits(),
+        sum_bits: value.sum.map(f64::to_bits),
+        custom_values_bits: value
+            .custom_values
+            .as_ref()
+            .map(|bounds| bounds.iter().map(|b| b.to_bits()).collect())
+            .unwrap_or_default(),
+        positive_spans: value
+            .positive_spans
+            .iter()
+            .map(encode_histogram_span)
+            .collect(),
+        negative_spans: value
+            .negative_spans
+            .iter()
+            .map(encode_histogram_span)
+            .collect(),
+        counts: Some(encode_histogram_counts(&value.counts)),
+        reset_hint: encode_reset_hint(value.reset_hint) as i32,
+    }
+}
+
+/// Inverse of [`encode_histogram_records`]. Every malformation is a typed
+/// [`CodecError`], never a panic or a silently defaulted field: a record with
+/// no `counts` oneof member is [`CodecError::MissingHistogramCounts`], and an
+/// unknown reset-hint discriminant is [`CodecError::UnknownResetHint`].
+pub fn decode_histogram_records(
+    records: &[pb::HistogramRecord],
+) -> Result<Vec<HistogramValue>, CodecError> {
+    records.iter().map(decode_histogram_record).collect()
+}
+
+fn decode_histogram_record(record: &pb::HistogramRecord) -> Result<HistogramValue, CodecError> {
+    let counts = record
+        .counts
+        .as_ref()
+        .ok_or(CodecError::MissingHistogramCounts)?;
+    // An empty repeated field is absent on the wire (proto3), so it decodes to
+    // `None`; a non-empty one to `Some`. See `encode_histogram_records` on why
+    // this is lossless for a well-formed histogram.
+    let custom_values = if record.custom_values_bits.is_empty() {
+        None
+    } else {
+        Some(
+            record
+                .custom_values_bits
+                .iter()
+                .map(|b| f64::from_bits(*b))
+                .collect(),
+        )
+    };
+    Ok(HistogramValue {
+        scale: record.scale,
+        zero_threshold: f64::from_bits(record.zero_threshold_bits),
+        sum: record.sum_bits.map(f64::from_bits),
+        custom_values,
+        positive_spans: record
+            .positive_spans
+            .iter()
+            .map(decode_histogram_span)
+            .collect(),
+        negative_spans: record
+            .negative_spans
+            .iter()
+            .map(decode_histogram_span)
+            .collect(),
+        counts: decode_histogram_counts(counts),
+        reset_hint: decode_reset_hint(record.reset_hint)?,
+    })
+}
+
+fn encode_histogram_span(span: &HistogramSpan) -> pb::HistogramSpan {
+    pb::HistogramSpan {
+        offset: span.offset,
+        length: span.length,
+    }
+}
+
+fn decode_histogram_span(span: &pb::HistogramSpan) -> HistogramSpan {
+    HistogramSpan {
+        offset: span.offset,
+        length: span.length,
+    }
+}
+
+/// Encodes the counts variant, carrying every float as its [`f64::to_bits`]
+/// pattern so `-0.0` and NaN bucket counts survive exactly (the float variant
+/// really does hold arbitrary `f64` counts after exponential-histogram scaling).
+fn encode_histogram_counts(counts: &HistogramCounts) -> pb::histogram_record::Counts {
+    use pb::histogram_record::Counts;
+    match counts {
+        HistogramCounts::Int {
+            zero_count,
+            count,
+            positive,
+            negative,
+        } => Counts::IntCounts(pb::HistogramCountsInt {
+            zero_count: *zero_count,
+            count: *count,
+            positive: positive.clone(),
+            negative: negative.clone(),
+        }),
+        HistogramCounts::Float {
+            zero_count,
+            count,
+            positive,
+            negative,
+        } => Counts::FloatCounts(pb::HistogramCountsFloat {
+            zero_count_bits: zero_count.to_bits(),
+            count_bits: count.to_bits(),
+            positive_bits: positive.iter().map(|v| v.to_bits()).collect(),
+            negative_bits: negative.iter().map(|v| v.to_bits()).collect(),
+        }),
+    }
+}
+
+fn decode_histogram_counts(counts: &pb::histogram_record::Counts) -> HistogramCounts {
+    use pb::histogram_record::Counts;
+    match counts {
+        Counts::IntCounts(c) => HistogramCounts::Int {
+            zero_count: c.zero_count,
+            count: c.count,
+            positive: c.positive.clone(),
+            negative: c.negative.clone(),
+        },
+        Counts::FloatCounts(c) => HistogramCounts::Float {
+            zero_count: f64::from_bits(c.zero_count_bits),
+            count: f64::from_bits(c.count_bits),
+            positive: c.positive_bits.iter().map(|b| f64::from_bits(*b)).collect(),
+            negative: c.negative_bits.iter().map(|b| f64::from_bits(*b)).collect(),
+        },
+    }
+}
+
+/// Maps a [`ResetHint`] to its wire enum. Explicit, not `as i32`: mirrors
+/// [`signal_to_u32`]'s discipline so the wire contract does not shift if a
+/// variant is ever inserted into either enum.
+fn encode_reset_hint(hint: ResetHint) -> pb::histogram_record::ResetHint {
+    use pb::histogram_record::ResetHint as Pb;
+    match hint {
+        ResetHint::Unknown => Pb::Unknown,
+        ResetHint::Yes => Pb::Yes,
+        ResetHint::No => Pb::No,
+        ResetHint::Gauge => Pb::Gauge,
+    }
+}
+
+/// Inverse of [`encode_reset_hint`]; an unrecognized discriminant is a typed
+/// error, never a silent default to `Unknown`.
+fn decode_reset_hint(raw: i32) -> Result<ResetHint, CodecError> {
+    use pb::histogram_record::ResetHint as Pb;
+    match Pb::try_from(raw).map_err(|_| CodecError::UnknownResetHint(raw))? {
+        Pb::Unknown => Ok(ResetHint::Unknown),
+        Pb::Yes => Ok(ResetHint::Yes),
+        Pb::No => Ok(ResetHint::No),
+        Pb::Gauge => Ok(ResetHint::Gauge),
+    }
 }
 
 fn decode_series_id(bytes: &[u8]) -> Result<SeriesId, CodecError> {
@@ -1289,10 +1482,11 @@ mod tests {
     }
 
     /// The `HistogramRun` provenance columns share `Run`'s codec, so they
-    /// round-trip identically through the real wire. `HistogramRun`'s value
-    /// payload (`span_payload`) is untouched by this step (a later ticket
-    /// retires it), so this proves only that the provenance columns survive and
-    /// that `span_payload` is carried through unchanged alongside them.
+    /// round-trip identically through the real wire. `span_payload` (field 5)
+    /// is now retired (`reserved`, ADR-0096 decision 2) and the typed
+    /// `records` field carries the value payload; this test still isolates the
+    /// provenance columns, driving them alongside one typed record to prove the
+    /// two coexist on `HistogramRun` without interfering.
     #[test]
     fn histogram_run_carries_per_sample_provenance_round_trip() {
         use prost::Message;
@@ -1313,25 +1507,25 @@ mod tests {
         ];
         let (prov_created_delta, prov_epoch_delta, prov_seq_delta, prov_in_page_index) =
             encode_sample_priorities(&Some(priorities.clone()));
+        let records = encode_histogram_records(&[sample_histogram_int(), sample_histogram_int()]);
         let run = pb::HistogramRun {
             created_unix_ns: 7,
             writer_epoch: 2,
             writer_seq: 100,
             ts_delta: encode_ts_deltas(&[1_000, 900]),
-            // Opaque, out of this step's scope; must survive unchanged.
-            span_payload: vec![0xDE, 0xAD, 0xBE, 0xEF],
             prov_created_delta,
             prov_epoch_delta,
             prov_seq_delta,
             prov_in_page_index,
+            records,
         };
 
         let bytes = run.encode_to_vec();
         let back = pb::HistogramRun::decode(bytes.as_slice()).expect("prost decode");
         assert_eq!(
-            back.span_payload,
-            vec![0xDE, 0xAD, 0xBE, 0xEF],
-            "the opaque histogram payload is carried through untouched"
+            decode_histogram_records(&back.records).expect("decode records"),
+            vec![sample_histogram_int(), sample_histogram_int()],
+            "the typed histogram records are carried through alongside provenance"
         );
         let decoded = decode_sample_priorities(
             &back.prov_created_delta,
@@ -1345,6 +1539,410 @@ mod tests {
             decoded,
             Some(priorities),
             "the histogram run's per-sample provenance key round-trips"
+        );
+    }
+
+    // ---- HistogramRecord round-trip -----------------------------------------
+
+    /// A small consistent integer-count histogram, used where the surrounding
+    /// test compares whole `HistogramValue`s with `==` (so it must carry no NaN
+    /// or `-0.0`, which `==` would mis-handle).
+    fn sample_histogram_int() -> HistogramValue {
+        HistogramValue {
+            scale: 2,
+            zero_threshold: 0.5,
+            sum: Some(3.0),
+            custom_values: None,
+            positive_spans: vec![HistogramSpan {
+                offset: 1,
+                length: 2,
+            }],
+            negative_spans: vec![],
+            counts: HistogramCounts::Int {
+                zero_count: 1,
+                count: 6,
+                positive: vec![2, 3],
+                negative: vec![],
+            },
+            reset_hint: ResetHint::Yes,
+        }
+    }
+
+    /// f64 generator weighted toward the bit patterns a naive `double`-based
+    /// codec would corrupt: quiet/signalling/payload NaNs, both zeros, both
+    /// infinities, and the finite extremes, plus uniform arbitrary bit patterns.
+    fn arb_hist_float() -> impl Strategy<Value = f64> {
+        prop_oneof![
+            2 => any::<u64>().prop_map(f64::from_bits),
+            1 => prop::sample::select(vec![
+                0.0_f64,
+                -0.0_f64,
+                f64::NAN,
+                -f64::NAN,
+                f64::from_bits(0x7ff0_0000_0000_0001), // signalling NaN
+                f64::from_bits(0x7ff8_0000_dead_beef), // NaN with payload
+                f64::INFINITY,
+                f64::NEG_INFINITY,
+                f64::MAX,
+                f64::MIN,
+                f64::MIN_POSITIVE,
+            ]),
+        ]
+    }
+
+    fn arb_hist_span() -> impl Strategy<Value = HistogramSpan> {
+        (any::<i32>(), any::<u32>()).prop_map(|(offset, length)| HistogramSpan { offset, length })
+    }
+
+    fn arb_hist_counts() -> impl Strategy<Value = HistogramCounts> {
+        prop_oneof![
+            (
+                any::<u64>(),
+                any::<u64>(),
+                prop::collection::vec(any::<u64>(), 0..6),
+                prop::collection::vec(any::<u64>(), 0..6),
+            )
+                .prop_map(|(zero_count, count, positive, negative)| {
+                    HistogramCounts::Int {
+                        zero_count,
+                        count,
+                        positive,
+                        negative,
+                    }
+                }),
+            (
+                arb_hist_float(),
+                arb_hist_float(),
+                prop::collection::vec(arb_hist_float(), 0..6),
+                prop::collection::vec(arb_hist_float(), 0..6),
+            )
+                .prop_map(|(zero_count, count, positive, negative)| {
+                    HistogramCounts::Float {
+                        zero_count,
+                        count,
+                        positive,
+                        negative,
+                    }
+                }),
+        ]
+    }
+
+    fn arb_reset_hint() -> impl Strategy<Value = ResetHint> {
+        prop_oneof![
+            Just(ResetHint::Unknown),
+            Just(ResetHint::Yes),
+            Just(ResetHint::No),
+            Just(ResetHint::Gauge),
+        ]
+    }
+
+    /// Generates a [`HistogramValue`] spanning both `HistogramCounts` variants,
+    /// `sum` present and absent, `custom_values` present (scale `-53`) and
+    /// absent, every `ResetHint`, and float payloads including NaN/`-0.0`/finite
+    /// extremes. The two arms keep `custom_values: Some` bound to `scale == -53`
+    /// and `custom_values: None` bound to any other scale, mirroring the storage
+    /// invariant (custom boundaries iff the custom scale).
+    fn arb_histogram_value() -> impl Strategy<Value = HistogramValue> {
+        let with_custom = (
+            prop::collection::vec(arb_hist_float(), 1..5),
+            arb_hist_float(),
+            prop::option::of(arb_hist_float()),
+            prop::collection::vec(arb_hist_span(), 0..4),
+            prop::collection::vec(arb_hist_span(), 0..4),
+            arb_hist_counts(),
+            arb_reset_hint(),
+        )
+            .prop_map(
+                |(
+                    custom,
+                    zero_threshold,
+                    sum,
+                    positive_spans,
+                    negative_spans,
+                    counts,
+                    reset_hint,
+                )| {
+                    HistogramValue {
+                        scale: -53,
+                        zero_threshold,
+                        sum,
+                        custom_values: Some(custom),
+                        positive_spans,
+                        negative_spans,
+                        counts,
+                        reset_hint,
+                    }
+                },
+            );
+        let without_custom = (
+            any::<i32>(),
+            arb_hist_float(),
+            prop::option::of(arb_hist_float()),
+            prop::collection::vec(arb_hist_span(), 0..4),
+            prop::collection::vec(arb_hist_span(), 0..4),
+            arb_hist_counts(),
+            arb_reset_hint(),
+        )
+            .prop_map(
+                |(
+                    scale,
+                    zero_threshold,
+                    sum,
+                    positive_spans,
+                    negative_spans,
+                    counts,
+                    reset_hint,
+                )| {
+                    HistogramValue {
+                        // Keep this arm off the custom scale so `None`
+                        // custom_values never implies the custom-scale shape.
+                        scale: if scale == -53 { -52 } else { scale },
+                        zero_threshold,
+                        sum,
+                        custom_values: None,
+                        positive_spans,
+                        negative_spans,
+                        counts,
+                        reset_hint,
+                    }
+                },
+            );
+        prop_oneof![with_custom, without_custom]
+    }
+
+    fn opt_f64_bits_eq(a: Option<f64>, b: Option<f64>) -> bool {
+        match (a, b) {
+            (Some(x), Some(y)) => x.to_bits() == y.to_bits(),
+            (None, None) => true,
+            _ => false,
+        }
+    }
+
+    fn vec_f64_bits_eq(a: &[f64], b: &[f64]) -> bool {
+        a.len() == b.len() && a.iter().zip(b).all(|(x, y)| x.to_bits() == y.to_bits())
+    }
+
+    fn opt_vec_f64_bits_eq(a: &Option<Vec<f64>>, b: &Option<Vec<f64>>) -> bool {
+        match (a, b) {
+            (Some(x), Some(y)) => vec_f64_bits_eq(x, y),
+            (None, None) => true,
+            _ => false,
+        }
+    }
+
+    fn counts_bits_eq(a: &HistogramCounts, b: &HistogramCounts) -> bool {
+        match (a, b) {
+            (
+                HistogramCounts::Int {
+                    zero_count: za,
+                    count: ca,
+                    positive: pa,
+                    negative: na,
+                },
+                HistogramCounts::Int {
+                    zero_count: zb,
+                    count: cb,
+                    positive: p2,
+                    negative: n2,
+                },
+            ) => za == zb && ca == cb && pa == p2 && na == n2,
+            (
+                HistogramCounts::Float {
+                    zero_count: za,
+                    count: ca,
+                    positive: pa,
+                    negative: na,
+                },
+                HistogramCounts::Float {
+                    zero_count: zb,
+                    count: cb,
+                    positive: p2,
+                    negative: n2,
+                },
+            ) => {
+                za.to_bits() == zb.to_bits()
+                    && ca.to_bits() == cb.to_bits()
+                    && vec_f64_bits_eq(pa, p2)
+                    && vec_f64_bits_eq(na, n2)
+            }
+            _ => false,
+        }
+    }
+
+    /// Whole-`HistogramValue` equality by bit pattern for every `f64`, so
+    /// `-0.0` and NaN (including payloads) compare by pattern, never `==`.
+    fn histogram_bits_eq(a: &HistogramValue, b: &HistogramValue) -> bool {
+        a.scale == b.scale
+            && a.zero_threshold.to_bits() == b.zero_threshold.to_bits()
+            && opt_f64_bits_eq(a.sum, b.sum)
+            && opt_vec_f64_bits_eq(&a.custom_values, &b.custom_values)
+            && a.positive_spans == b.positive_spans
+            && a.negative_spans == b.negative_spans
+            && counts_bits_eq(&a.counts, &b.counts)
+            && a.reset_hint == b.reset_hint
+    }
+
+    proptest! {
+        /// Typed histogram records survive the real prost wire (encode ->
+        /// prost bytes -> prost decode -> codec decode) field for field, every
+        /// `f64` bit-exact. Covers both count variants, `sum`/`custom_values`
+        /// present and absent, every `ResetHint`, and NaN/`-0.0`/extreme float
+        /// payloads (compared by `to_bits`, never `==`).
+        #[test]
+        fn histogram_records_round_trip_bit_for_bit(
+            values in prop::collection::vec(arb_histogram_value(), 0..6)
+        ) {
+            use prost::Message;
+            let run = pb::HistogramRun {
+                records: encode_histogram_records(&values),
+                ..Default::default()
+            };
+            let bytes = run.encode_to_vec();
+            let back = pb::HistogramRun::decode(bytes.as_slice()).expect("prost decode");
+            let decoded = decode_histogram_records(&back.records).expect("codec decode");
+            prop_assert_eq!(decoded.len(), values.len());
+            for (got, want) in decoded.iter().zip(values.iter()) {
+                prop_assert!(
+                    histogram_bits_eq(got, want),
+                    "histogram record corrupted on the wire: {:?} vs {:?}",
+                    got,
+                    want
+                );
+            }
+        }
+    }
+
+    /// The float payloads a naive `double`/`==` codec corrupts, driven through
+    /// every `f64`-bearing field of both count variants and the scalar fields,
+    /// plus the `sum: None`/`Some` and `custom_values: None`/`Some` distinctions
+    /// and all four reset hints, across the real prost wire.
+    #[test]
+    fn histogram_record_special_values_and_optionals_round_trip() {
+        use prost::Message;
+
+        let payload_nan = f64::from_bits(0x7ff8_0000_dead_beef);
+        let specials = [
+            f64::NAN,
+            payload_nan,
+            -0.0_f64,
+            0.0_f64,
+            f64::INFINITY,
+            f64::MAX,
+        ];
+
+        // A float-count histogram at the custom scale, carrying specials in
+        // every f64 field and `sum: None`.
+        let float_custom = HistogramValue {
+            scale: -53,
+            zero_threshold: payload_nan,
+            sum: None,
+            custom_values: Some(specials.to_vec()),
+            positive_spans: vec![HistogramSpan {
+                offset: -2,
+                length: 3,
+            }],
+            negative_spans: vec![HistogramSpan {
+                offset: 5,
+                length: 1,
+            }],
+            counts: HistogramCounts::Float {
+                zero_count: -0.0,
+                count: f64::INFINITY,
+                positive: vec![f64::NAN, -0.0, f64::MAX],
+                negative: vec![payload_nan],
+            },
+            reset_hint: ResetHint::Gauge,
+        };
+
+        // An int-count histogram with `sum: Some`, `custom_values: None`, and a
+        // distinct reset hint, so both optional distinctions and another enum
+        // value are exercised in one pass.
+        let int_plain = HistogramValue {
+            scale: 4,
+            zero_threshold: 0.0,
+            sum: Some(-0.0),
+            custom_values: None,
+            positive_spans: vec![],
+            negative_spans: vec![],
+            counts: HistogramCounts::Int {
+                zero_count: u64::MAX,
+                count: 0,
+                positive: vec![],
+                negative: vec![7],
+            },
+            reset_hint: ResetHint::No,
+        };
+
+        let values = vec![float_custom, int_plain];
+        let run = pb::HistogramRun {
+            records: encode_histogram_records(&values),
+            ..Default::default()
+        };
+        let back = pb::HistogramRun::decode(run.encode_to_vec().as_slice()).expect("prost decode");
+        let decoded = decode_histogram_records(&back.records).expect("codec decode");
+        assert_eq!(decoded.len(), values.len());
+        for (got, want) in decoded.iter().zip(values.iter()) {
+            assert!(
+                histogram_bits_eq(got, want),
+                "special histogram value corrupted: {got:?} vs {want:?}"
+            );
+        }
+        // `sum: None` must stay distinct from a present zero.
+        assert_eq!(decoded[0].sum, None);
+        assert_eq!(decoded[1].sum.map(f64::to_bits), Some((-0.0_f64).to_bits()));
+    }
+
+    /// Every `ResetHint` variant round-trips to itself across the wire.
+    #[test]
+    fn histogram_record_every_reset_hint_round_trips() {
+        use prost::Message;
+        for hint in [
+            ResetHint::Unknown,
+            ResetHint::Yes,
+            ResetHint::No,
+            ResetHint::Gauge,
+        ] {
+            let mut value = sample_histogram_int();
+            value.reset_hint = hint;
+            let run = pb::HistogramRun {
+                records: encode_histogram_records(&[value]),
+                ..Default::default()
+            };
+            let back =
+                pb::HistogramRun::decode(run.encode_to_vec().as_slice()).expect("prost decode");
+            let decoded = decode_histogram_records(&back.records).expect("codec decode");
+            assert_eq!(decoded[0].reset_hint, hint, "reset hint {hint:?} changed");
+        }
+    }
+
+    /// A record with no `counts` oneof member is a typed error, never a panic
+    /// or a silently defaulted count set.
+    #[test]
+    fn histogram_record_missing_counts_is_typed_error() {
+        let record = pb::HistogramRecord {
+            counts: None,
+            ..Default::default()
+        };
+        assert_eq!(
+            decode_histogram_records(std::slice::from_ref(&record)),
+            Err(CodecError::MissingHistogramCounts)
+        );
+    }
+
+    /// An unknown reset-hint discriminant is a typed error, never a silent
+    /// default to `Unknown`.
+    #[test]
+    fn histogram_record_unknown_reset_hint_is_typed_error() {
+        let record = pb::HistogramRecord {
+            reset_hint: 99,
+            counts: Some(pb::histogram_record::Counts::IntCounts(
+                pb::HistogramCountsInt::default(),
+            )),
+            ..Default::default()
+        };
+        assert_eq!(
+            decode_histogram_records(std::slice::from_ref(&record)),
+            Err(CodecError::UnknownResetHint(99))
         );
     }
 

--- a/crates/ravel-query/src/distrib/service.rs
+++ b/crates/ravel-query/src/distrib/service.rs
@@ -10,12 +10,15 @@
 //!
 //! # Scalar-only, for now
 //!
-//! Distribution carries scalar series only. The histogram span payload grammar
-//! is future work (`proto/ravel/queryfrag.proto`'s `HistogramRun`), so a
-//! slice whose segments decode any native-histogram series returns
-//! [`pb::status::Code::Unsupported`]; the coordinator then silently falls back
-//! to fully local execution for the whole query (ADR-0071 failure semantics),
-//! never a partial or wrong result.
+//! Distribution carries scalar series only. The typed `HistogramRecord` wire
+//! shape now exists (`proto/ravel/queryfrag.proto`, ADR-0096 decision 2) and
+//! its codec is in place, but no encoder writes it onto a frame yet (the
+//! version flip that enables it is ADR-0096 decision 3 step 4, #379). So a
+//! slice whose segments still decode any native-histogram series -- after
+//! erasure filtering (ADR-0096 decision 3 step 3) removes any fully-erased
+//! ones -- returns [`pb::status::Code::Unsupported`]; the coordinator then
+//! silently falls back to fully local execution for the whole query (ADR-0071
+//! failure semantics), never a partial or wrong result.
 //!
 //! # Segment identity resolution
 //!
@@ -44,7 +47,7 @@ use crate::distrib::codec;
 use crate::distrib::proto::series_fetch_server::{SeriesFetch, SeriesFetchServer};
 use crate::engine::bytes_scanned_exceeded;
 use crate::erasure::is_erased_span;
-use crate::fetcher::{FetchError, FetchStats, SegmentFetcher};
+use crate::fetcher::{FetchError, FetchStats, FetchedHistogramSeries, SegmentFetcher};
 use crate::log_fetcher::{LogFetchError, LogQuery, LogSegmentFetcher};
 use crate::span_fetcher::{SpanFetchError, SpanSegmentFetcher};
 
@@ -312,7 +315,7 @@ impl<R: SegmentResolver + 'static> SeriesFetchService<R> {
         // returned snapshot into the query's aggregate (ADR-0071).
         let accounting = QueryAccounting::new();
         let mut scalar = Vec::new();
-        let mut any_histograms = false;
+        let mut histograms: Vec<FetchedHistogramSeries> = Vec::new();
         let mut stats = FetchStats::default();
         for seg in &segments {
             let (seg_scalar, seg_stats, seg_hist) = self
@@ -320,9 +323,7 @@ impl<R: SegmentResolver + 'static> SeriesFetchService<R> {
                 .fetch_soa_and_histograms_accounted(tenant_hash, seg, &matchers, &accounting)
                 .await
                 .map_err(map_fetch_error)?;
-            if !seg_hist.is_empty() {
-                any_histograms = true;
-            }
+            histograms.extend(seg_hist);
             stats.raw_f64_pages += seg_stats.raw_f64_pages;
             stats.raw_f64_bytes += seg_stats.raw_f64_bytes;
             scalar.push(seg_scalar);
@@ -346,13 +347,26 @@ impl<R: SegmentResolver + 'static> SeriesFetchService<R> {
             }
         }
 
+        // Selective-erasure exclusion on the histogram series, applied
+        // post-decode exactly as the local path applies it (ADR-0064, ADR-0071,
+        // ADR-0096 decision 3 step 3). Run BEFORE the histogram-refusal check so
+        // the refusal keys on the series that actually survive erasure, not on
+        // the raw per-segment fetch: an erasure predicate that erases every
+        // sample of every histogram series present leaves nothing to refuse.
+        // Filtering is observable here even though no encoder writes
+        // HistogramRecord onto the wire yet (that is #379): the Unsupported
+        // refusal below no longer fires when erasure emptied the histogram set.
+        if !erasure.is_empty() {
+            crate::erasure::retain_histogram_series(&mut histograms, &erasure);
+        }
+
         // Scalar-only distribution: hand a histogram-bearing slice back to the
         // coordinator's local fallback rather than return partial results. The
         // summary still carries this slice's accounting/stats so the
         // coordinator folds its spend before falling back to local (ADR-0071);
         // otherwise the histogram query would pay for this fetch twice and
         // report it once.
-        if any_histograms {
+        if !histograms.is_empty() {
             return Ok(vec![summary_frame(
                 &accounting.snapshot(),
                 0,

--- a/crates/ravel-query/src/distrib/tests.rs
+++ b/crates/ravel-query/src/distrib/tests.rs
@@ -1681,6 +1681,145 @@ fn histogram_slice_falls_back_with_spend_folded() {
     });
 }
 
+/// The worker-side histogram erasure wiring (ADR-0096 decision 3 step 3) is
+/// real, not latent. An erasure predicate that erases every sample of the only
+/// histogram series present leaves nothing to refuse, so the
+/// `Unsupported`/"histogram series are not distributed yet" refusal does NOT
+/// fire: the slice returns an ordinary (empty) result and the coordinator does
+/// not fall back to local (`Ok(Some(..))`, not `Ok(None)`).
+///
+/// This is the counterpart to `histogram_slice_falls_back_with_spend_folded`,
+/// which drives the identical segment with NO erasure and asserts the refusal
+/// DOES fire (`Ok(None)`). The single line that makes this test pass is the
+/// `crate::erasure::retain_histogram_series(&mut histograms, &erasure)` call in
+/// `service.rs::run_slice_metrics`, placed before the refusal check which now
+/// keys on the post-filter `!histograms.is_empty()`. Deleting that call, or
+/// reverting the refusal to the pre-filter per-segment `seg_hist.is_empty()`
+/// check, leaves the histogram set non-empty and flips this back to `Ok(None)`.
+#[test]
+fn erased_histogram_series_no_longer_triggers_the_unsupported_refusal() {
+    let rt = Runtime::new().expect("runtime");
+    rt.block_on(async {
+        use ravel_segment::{
+            HistogramCounts, HistogramSample, HistogramValue, ResetHint, SeriesInputV3,
+            SeriesValues,
+        };
+
+        let store = Arc::new(MemoryStore::new());
+        let metric = "h0";
+        let label_set = labels(metric);
+        let series_id = SeriesId::compute(&tenant_id(), metric, &label_set).expect("series id");
+        let hist = HistogramValue {
+            scale: 0,
+            zero_threshold: 0.0,
+            sum: Some(1.0),
+            custom_values: None,
+            positive_spans: vec![ravel_segment::HistogramSpan {
+                offset: 0,
+                length: 1,
+            }],
+            negative_spans: Vec::new(),
+            counts: HistogramCounts::Int {
+                zero_count: 0,
+                count: 1,
+                positive: vec![1],
+                negative: Vec::new(),
+            },
+            reset_hint: ResetHint::Unknown,
+        };
+        let identity = SegmentIdentity {
+            tenant_hash: TENANT.0,
+            shard: 0,
+            writer_id: Uuid::from_u128(1).to_string(),
+            writer_epoch: 1,
+            writer_seq: 0,
+        };
+        let written = SegmentWriter::write_histograms(
+            vec![SeriesInputV3 {
+                series_id,
+                labels: label_set,
+                values: SeriesValues::Histogram(vec![HistogramSample {
+                    ts_ns: NS,
+                    value: hist,
+                }]),
+            }],
+            identity,
+            IngestBounds {
+                min_ingest_ts_ns: 0,
+                max_ingest_ts_ns: 0,
+            },
+        )
+        .expect("write histogram segment");
+        let object_key = "seg/hist_erase0.rseg".to_string();
+        store
+            .put(&object_key, written.bytes.clone(), PutOptions::default())
+            .await
+            .expect("put segment");
+        let seg = SegmentRef {
+            data_object_key: object_key,
+            object_size: written.bytes.len() as u64,
+            min_event_ts_ns: written.summary.min_event_ts_ns,
+            max_event_ts_ns: written.summary.max_event_ts_ns,
+            ingest_hour_bucket: 100,
+            sample_count: written.summary.sample_count,
+            series_count: written.summary.series_count,
+            shard: 0,
+            content_hash: written.summary.blake3,
+            writer_id: Uuid::from_u128(1),
+            writer_epoch: 1,
+            writer_seq: 0,
+            created_unix_ns: 0,
+            level: SegmentLevel::L0,
+        };
+        let snapshot = Snapshot {
+            segments: vec![seg.clone()],
+            segments_pruned: 0,
+            pending_erasure: Vec::new(),
+        };
+
+        let (fetcher, server) = spawn_worker(Arc::clone(&store), vec![seg]).await;
+        let distributed = Distributed::new(
+            Arc::new(fetcher),
+            DistribThresholds {
+                min_store_bytes: 0,
+                min_segments: 0,
+                max_parallel_slices: 1,
+            },
+        );
+        // A windowless predicate on the series' own label erases the whole
+        // series (`retain_histogram_series` drops it entirely).
+        let erasure = vec![ErasurePredicate::windowless(vec![(
+            "__name__".to_string(),
+            metric.to_string(),
+        )])];
+        let accounting = QueryAccounting::new();
+        let result = distributed
+            .fetch(
+                TENANT,
+                Signal::Metrics,
+                &snapshot,
+                &[],
+                &erasure,
+                &accounting,
+                &EngineConfig::default(),
+                i64::MAX,
+            )
+            .await
+            .expect("unsupported must not be an error");
+        assert!(
+            result.is_some(),
+            "an erasure that empties the only histogram series leaves nothing to \
+             refuse, so no Unsupported local fallback fires"
+        );
+        let (per_slice, _stats, _hist) = result.expect("a real (non-fallback) result");
+        assert!(
+            per_slice.iter().all(|series| series.is_empty()),
+            "the erased histogram series must not surface as a scalar series either"
+        );
+        server.abort();
+    });
+}
+
 // --- RLOG-family distributed fan-out (#284) --------------------------------
 //
 // The centerpiece is `run_log_differential`: over a real loopback worker, a

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -383,9 +383,12 @@ Alerts, Audit, and Spans. The worker's `run_slice_inner` decodes the request's
 (`crates/ravel-query/src/distrib/service.rs`):
 
 - **Metrics** resolves the pinned scope and fetches scalar series through the
-  metric `SegmentFetcher`. Native-histogram series are not distributed yet: a
-  slice that decodes any histogram series answers `Unsupported` (with its spend
-  folded first) and the whole query falls back to local.
+  metric `SegmentFetcher`. Native-histogram series are not distributed yet:
+  erasure predicates are applied to decoded histogram series before the
+  refusal check (ADR-0096 decision 2), so a slice whose histograms are fully
+  erased is not refused; a slice with any histogram series still standing
+  after erasure answers `Unsupported` (with its spend folded first) and the
+  whole query falls back to local.
 - **Logs, Alerts, Audit** are one RLOG object family and share a single fetch
   path over `LogSegmentFetcher`, distinguished only by the object-key prefix the
   coordinator already resolved (the worker never re-derives it, it fetches the

--- a/proto/ravel/queryfrag.proto
+++ b/proto/ravel/queryfrag.proto
@@ -185,10 +185,8 @@ message Run {
   repeated uint32 prov_in_page_index = 9 [packed = true];
 }
 
-// One histogram series. Mirrors SeriesFrame, but each run carries an opaque
-// encoded span payload instead of scalar value bits. The payload grammar is a
-// later ticket; the field is reserved here as opaque bytes with its number
-// frozen, so adding the grammar is a decode-side change, not a wire change.
+// One histogram series. Mirrors SeriesFrame, but each run carries one typed
+// HistogramRecord per sample instead of scalar value bits.
 message HistogramFrame {
   bytes series_id = 1;
   repeated Label labels = 2;
@@ -200,9 +198,7 @@ message HistogramRun {
   uint64 writer_epoch = 2;
   uint64 writer_seq = 3;
   repeated sint64 ts_delta = 4 [packed = true];
-  // Opaque encoded histogram span payload for this run. Grammar deferred to a
-  // later ticket; treated as an opaque blob by this contract.
-  bytes span_payload = 5;
+  reserved 5;  // was `bytes span_payload`, the deferred opaque histogram payload (ADR-0096 decision 2)
 
   // Per-sample dedup key columns, identical in shape and semantics to
   // `Run`'s fields 6-9 (ADR-0096 decision 1): either all four present with
@@ -213,6 +209,71 @@ message HistogramRun {
   repeated sint64 prov_epoch_delta = 7 [packed = true];
   repeated sint64 prov_seq_delta = 8 [packed = true];
   repeated uint32 prov_in_page_index = 9 [packed = true];
+
+  // One typed HistogramRecord per sample, parallel to ts_delta (ADR-0096
+  // decision 2, retiring the opaque span_payload above). Mirrors
+  // ravel_segment::HistogramValue field for field; every f64 crosses as its
+  // to_bits fixed64, never a proto double, so NaN payloads and -0.0 survive the
+  // wire byte-for-byte, the same discipline Run.value_bits uses for scalars.
+  repeated HistogramRecord records = 10;
+}
+
+// One native-histogram sample value, mirroring ravel_segment::HistogramValue
+// field for field (ADR-0096 decision 2). Every f64 crosses as its to_bits
+// fixed64, never a proto double, so NaN payloads, signalling NaNs, and -0.0
+// survive the round trip exactly, matching the scalar Run.value_bits path.
+message HistogramRecord {
+  sint32 scale = 1;
+  fixed64 zero_threshold_bits = 2;   // f64::to_bits
+  // Absent (None) stays distinct from a present value: proto3 `optional`, not a
+  // bare field, so a histogram with no sum is distinct from one whose sum is a
+  // present zero.
+  optional fixed64 sum_bits = 3;     // f64::to_bits when present
+  // Present iff scale == -53 (custom bucket boundaries), ascending. Empty means
+  // absent (None), non-empty means present, exactly as proto3 handles a
+  // repeated field. Each boundary crosses as its to_bits fixed64.
+  repeated fixed64 custom_values_bits = 4 [packed = true];
+  repeated HistogramSpan positive_spans = 5;
+  repeated HistogramSpan negative_spans = 6;
+  // All-integer or all-float counts, never mixed within one sample, mirroring
+  // ravel_segment::HistogramCounts. Exactly one member is set for a well-formed
+  // record; a record with neither is a typed decode error.
+  oneof counts {
+    HistogramCountsInt int_counts = 7;
+    HistogramCountsFloat float_counts = 8;
+  }
+  // Reset-hint states, mirroring ravel_segment::ResetHint (the default, 0, is
+  // Unknown, matching that enum's own zero value).
+  enum ResetHint {
+    UNKNOWN = 0;
+    YES = 1;
+    NO = 2;
+    GAUGE = 3;
+  }
+  ResetHint reset_hint = 9;
+}
+
+// One populated run on a histogram side, mirroring ravel_segment::HistogramSpan.
+message HistogramSpan {
+  sint32 offset = 1;
+  uint32 length = 2;
+}
+
+// All-integer bucket/zero/total counts (ravel_segment::HistogramCounts::Int).
+message HistogramCountsInt {
+  uint64 zero_count = 1;
+  uint64 count = 2;
+  repeated uint64 positive = 3 [packed = true];
+  repeated uint64 negative = 4 [packed = true];
+}
+
+// All-float bucket/zero/total counts (ravel_segment::HistogramCounts::Float),
+// every f64 as its to_bits fixed64 so NaN payloads and -0.0 survive the wire.
+message HistogramCountsFloat {
+  fixed64 zero_count_bits = 1;       // f64::to_bits
+  fixed64 count_bits = 2;            // f64::to_bits
+  repeated fixed64 positive_bits = 3 [packed = true];
+  repeated fixed64 negative_bits = 4 [packed = true];
 }
 
 // One log-record frame for a slice of the RLOG family (Logs, Alerts, Audit),


### PR DESCRIPTION
feat(queryfrag): add typed HistogramRecord, retire span_payload, wire histogram erasure

Second staged commit toward ADR-0096's PROTOCOL_VERSION flip (decision 3
step 3). Adds a typed HistogramRecord message (field 10 on HistogramRun),
mirroring ravel_segment::HistogramValue field for field with every f64
crossing as a to_bits bit pattern. Retires the never-defined
span_payload opaque blob (reserved 5, following the LogRecordFrame/
SpanFrame precedent).

Wires crate::erasure::retain_histogram_series into the worker-side
distributed histogram fetch path so erasure filtering on histogram
series is real rather than latent: a slice whose histograms are fully
erased no longer trips the Unsupported refusal, matching what a local
query with the same predicates would do.

PROTOCOL_VERSION stays 2. No encoder is wired into the live fetch path
(that's the version-flip commit, #379); the codec round-trip pair is
proven structurally by property tests only.

Includes a doc fix to docs/query-engine.md's histogram distribution
note, which still described the pre-erasure-aware always-refuse
behavior (checkpoint review finding).

Fixes: #378
Refs: #348
