### PR TITLE
docs(adrs): claim ADR-0099 for the columnar decode-to-Arrow path

### DIFF
--- a/docs/adrs/0099-columnar-decode-to-arrow.md
+++ b/docs/adrs/0099-columnar-decode-to-arrow.md
@@ -1,0 +1,3 @@
+# ADR-0099: columnar decode-to-Arrow path for SQL scans
+
+Status: claimed


### PR DESCRIPTION
Reserves ADR-0099 for epic #360 so a parallel epic cannot pick the same number. Stub only; the decision text lands after design approval.

Refs: #360