### PR TITLE
feat(ingest): share one label set per series run (ADR-0098)

### DIFF
--- a/crates/ravel-bench/src/generator.rs
+++ b/crates/ravel-bench/src/generator.rs
@@ -8,6 +8,8 @@ use ravel_segment::{
     HistogramCounts, HistogramSample, HistogramSpan, HistogramValue, ResetHint, SeriesInputV3,
     SeriesValues,
 };
+use std::sync::Arc;
+
 use ravel_types::{Label, LabelSet, METRIC_NAME_LABEL, Sample, SeriesId, TenantId, TypeError};
 
 /// Gauge or cumulative counter.
@@ -336,7 +338,7 @@ fn interleave(series: Vec<GeneratedSeries>) -> Vec<NormalizedPoint> {
             if let Some(sample) = s.samples.get(i) {
                 out.push(NormalizedPoint {
                     series_id: s.series_id,
-                    labels: s.labels.clone(),
+                    labels: Arc::new(s.labels.clone()),
                     sample: *sample,
                     is_monotonic_sum: matches!(s.kind, MetricKind::Counter),
                 });

--- a/crates/ravel-failure-tests/tests/common/mod.rs
+++ b/crates/ravel-failure-tests/tests/common/mod.rs
@@ -83,7 +83,7 @@ pub fn make_point(
     let series_id = SeriesId::compute(tenant, metric, &labels).expect("series id");
     NormalizedPoint {
         series_id,
-        labels,
+        labels: Arc::new(labels),
         sample: Sample { ts_ns, value },
         is_monotonic_sum: false,
     }

--- a/crates/ravel-ingest/src/shard.rs
+++ b/crates/ravel-ingest/src/shard.rs
@@ -134,7 +134,12 @@ impl SeriesAccumValues {
 }
 
 struct SeriesAccum {
-    labels: LabelSet,
+    /// The series' shared label set (ADR-0098). Moved in from the first
+    /// point of the run that opened this accumulator; the points that
+    /// followed cloned the same `Arc` and dropped their clones as they
+    /// merged, so by flush time the accumulator holds the last reference and
+    /// [`Arc::try_unwrap`] hands `SeriesInputV3` the allocation by move.
+    labels: Arc<LabelSet>,
     values: SeriesAccumValues,
 }
 
@@ -218,7 +223,7 @@ impl TenantBuf {
     /// losing series' samples under the winning label set (the id-keyed
     /// `HashMap` below cannot tell them apart), which ADR-0005 forbids.
     fn merge(&mut self, points: Vec<IngestPoint>, arrival_ns: i64) -> Result<usize, WriteError> {
-        let mut batch_claims: HashMap<SeriesId, (&LabelSet, ValueKind)> = HashMap::new();
+        let mut batch_claims: HashMap<SeriesId, (&Arc<LabelSet>, ValueKind)> = HashMap::new();
         for point in &points {
             let point_kind = point.value.kind();
             let claimed = self
@@ -227,7 +232,14 @@ impl TenantBuf {
                 .map(|accum| (&accum.labels, accum.values.kind()))
                 .or_else(|| batch_claims.get(&point.series_id).copied());
             match claimed {
-                Some((labels, _)) if *labels != point.labels => {
+                // ADR-0098 decision 3: two points sharing the cached label set
+                // settle in one pointer comparison. The structural comparison
+                // is the fallback for genuinely distinct `Arc`s, so the
+                // collision check keeps exactly the strength it had before:
+                // ptr_eq is a fast path only, never the whole check.
+                Some((labels, _))
+                    if !Arc::ptr_eq(labels, &point.labels) && **labels != *point.labels =>
+                {
                     return Err(WriteError::SeriesIdCollision(format!(
                         "series_id {:?} maps to two distinct label sets in one shard buffer",
                         point.series_id
@@ -471,7 +483,13 @@ impl FlushCtx {
             .into_iter()
             .map(|(series_id, accum)| SeriesInputV3 {
                 series_id,
-                labels: accum.labels,
+                // ADR-0098: the accumulator holds the last reference to the
+                // run's shared label set by flush time (the points that shared
+                // it were consumed into `values`), so this unwraps the `Arc`
+                // by move on the common path; a surviving clone (none today,
+                // but a future cross-request memo could keep one) degrades to a
+                // deep copy rather than aliasing.
+                labels: Arc::try_unwrap(accum.labels).unwrap_or_else(|arc| (*arc).clone()),
                 values: accum.values.into_series_values(),
             })
             .collect();
@@ -1399,7 +1417,7 @@ mod buffer_accounting_tests {
         id[0] = series;
         IngestPoint {
             series_id: SeriesId(id),
-            labels,
+            labels: Arc::new(labels),
             value: IngestValue::Scalar(Sample {
                 ts_ns: 1_000,
                 value: 1.0,
@@ -1438,6 +1456,90 @@ mod buffer_accounting_tests {
             );
             assert_eq!(buf.est_bytes as u64, charged);
         }
+    }
+
+    /// ADR-0098 test 3. Two points with the same `series_id` and genuinely
+    /// different label sets, not sharing an `Arc`, still produce
+    /// `SeriesIdCollision`: the `Arc::ptr_eq` fast path does not fire on
+    /// distinct pointers, so the structural comparison runs and catches the
+    /// collision. If ptr_eq were the whole check this would be missed.
+    #[test]
+    fn distinct_arcs_with_different_labels_still_collide() {
+        let mut buf = TenantBuf::default();
+        let a = point(1, labels_of(3));
+        let b = point(1, {
+            let mut v: Vec<Label> = labels_of(3).iter().cloned().collect();
+            v.push(Label {
+                name: "extra".to_string(),
+                value: "x".to_string(),
+            });
+            LabelSet::new(v).expect("distinct label names")
+        });
+        assert!(
+            !Arc::ptr_eq(&a.labels, &b.labels),
+            "test setup: the two points must hold distinct Arcs"
+        );
+        let err = buf
+            .merge(vec![a, b], 1_000)
+            .expect_err("same id, different labels is a collision");
+        assert!(matches!(err, WriteError::SeriesIdCollision(_)), "{err:?}");
+    }
+
+    /// The complement pinning that `Arc::ptr_eq` is a fast path ONLY: two
+    /// points with the same `series_id` and structurally EQUAL labels but
+    /// distinct `Arc`s must be accepted, not rejected. The structural
+    /// comparison, not pointer identity, decides.
+    #[test]
+    fn distinct_arcs_with_equal_labels_do_not_collide() {
+        let mut buf = TenantBuf::default();
+        let a = point(1, labels_of(3));
+        let b = point(1, labels_of(3));
+        assert!(
+            !Arc::ptr_eq(&a.labels, &b.labels),
+            "test setup: the two points must hold distinct Arcs"
+        );
+        buf.merge(vec![a, b], 1_000)
+            .expect("equal labels under one id are not a collision");
+        assert_eq!(buf.series.len(), 1, "both points merged into one series");
+    }
+
+    /// ADR-0098 consequence: after a run of points that shared one
+    /// `Arc<LabelSet>` merges into the accumulator, the accumulator holds the
+    /// LAST reference to that set (strong_count == 1). This is what lets the
+    /// flush `Arc::try_unwrap` move the allocation into `SeriesInputV3` rather
+    /// than deep-copy it on the common path. The points that shared the set are
+    /// consumed by `merge` and their `Arc` clones dropped; nothing outside the
+    /// buffer keeps one, because the request-scoped memo does not outlive the
+    /// normalize call.
+    #[test]
+    fn accumulator_holds_the_last_reference_after_a_shared_run() {
+        // Five points of one series run sharing a single Arc, as the normalizer
+        // produces them. The original binding is dropped when this block ends,
+        // so only the point clones (about to be consumed by merge) reference it.
+        let pts: Vec<IngestPoint> = {
+            let shared = Arc::new(labels_of(3));
+            (0..5)
+                .map(|i| IngestPoint {
+                    series_id: SeriesId([1u8; 16]),
+                    labels: Arc::clone(&shared),
+                    value: IngestValue::Scalar(Sample {
+                        ts_ns: 1_000 + i,
+                        value: i as f64,
+                    }),
+                })
+                .collect()
+        };
+        let mut buf = TenantBuf::default();
+        buf.merge(pts, 1_000).expect("one series, one value kind");
+        let accum = buf
+            .series
+            .get(&SeriesId([1u8; 16]))
+            .expect("series present");
+        assert_eq!(
+            Arc::strong_count(&accum.labels),
+            1,
+            "the accumulator must hold the last reference so flush unwraps by move"
+        );
     }
 
     /// A second point for a series already in the buffer costs only its sample:

--- a/crates/ravel-ingest/src/value.rs
+++ b/crates/ravel-ingest/src/value.rs
@@ -6,6 +6,8 @@
 //! reach the same RSEG v5 writer regardless of which wire path decoded the
 //! point.
 
+use std::sync::Arc;
+
 use ravel_segment::{ExemplarInput, HistogramSample};
 use ravel_types::{Exemplar, Label, LabelSet, Sample, SeriesId};
 
@@ -22,7 +24,11 @@ pub enum IngestValue {
 #[derive(Debug, Clone)]
 pub struct IngestPoint {
     pub series_id: SeriesId,
-    pub labels: LabelSet,
+    /// One label set shared across the points of a series run (ADR-0098).
+    /// The points of one run clone the same `Arc` rather than each owning a
+    /// copy, so the shard buffer's collision pre-pass can short-circuit on
+    /// [`Arc::ptr_eq`] and the flush moves a single allocation.
+    pub labels: Arc<LabelSet>,
     pub value: IngestValue,
 }
 
@@ -185,7 +191,7 @@ mod tests {
     fn point_with(labels: LabelSet) -> IngestPoint {
         IngestPoint {
             series_id: SeriesId([0u8; 16]),
-            labels,
+            labels: Arc::new(labels),
             value: IngestValue::Scalar(Sample {
                 ts_ns: 1_000,
                 value: 1.0,

--- a/crates/ravel-ingest/tests/common/mod.rs
+++ b/crates/ravel-ingest/tests/common/mod.rs
@@ -212,7 +212,7 @@ pub fn make_point(
     let series_id = SeriesId::compute(tenant, metric, &labels).expect("series id");
     NormalizedPoint {
         series_id,
-        labels,
+        labels: Arc::new(labels),
         sample: Sample { ts_ns, value },
         is_monotonic_sum: false,
     }

--- a/crates/ravel-ingest/tests/exemplar_flush.rs
+++ b/crates/ravel-ingest/tests/exemplar_flush.rs
@@ -47,7 +47,7 @@ fn scalar_point(tenant_id: &TenantId, metric: &str, ts_ns: i64, value: f64) -> I
     let labels = build_labels(&[(METRIC_NAME_LABEL, metric)]);
     IngestPoint {
         series_id: series_id_of(tenant_id, metric),
-        labels,
+        labels: Arc::new(labels),
         value: IngestValue::Scalar(Sample { ts_ns, value }),
     }
 }

--- a/crates/ravel-ingest/tests/histogram_ingest_read_back.rs
+++ b/crates/ravel-ingest/tests/histogram_ingest_read_back.rs
@@ -45,7 +45,7 @@ fn histogram_point(tenant_id: &ravel_types::TenantId, metric: &str, ts_ns: i64) 
     let series_id = SeriesId::compute(tenant_id, metric, &labels).expect("series id");
     IngestPoint {
         series_id,
-        labels,
+        labels: Arc::new(labels),
         value: IngestValue::Histogram(HistogramSample {
             ts_ns,
             value: HistogramValue {
@@ -80,7 +80,7 @@ fn scalar_point(
     let series_id = SeriesId::compute(tenant_id, metric, &labels).expect("series id");
     IngestPoint {
         series_id,
-        labels,
+        labels: Arc::new(labels),
         value: IngestValue::Scalar(Sample { ts_ns, value }),
     }
 }

--- a/crates/ravel-otap/src/normalize.rs
+++ b/crates/ravel-otap/src/normalize.rs
@@ -732,7 +732,10 @@ fn normalize_impl(
                 let series_id = *series_id;
                 points.push(NormalizedPoint {
                     series_id,
-                    labels: label_set.clone(),
+                    // ADR-0098: ravel-otap keeps its own built-set memo and
+                    // shares nothing across points; it wraps each built set in
+                    // a fresh Arc. Rekeying it is a follow-up.
+                    labels: Arc::new(label_set.clone()),
                     sample: Sample {
                         ts_ns: dp.ts_ns,
                         value,
@@ -2290,7 +2293,8 @@ fn finish_exploded_point(
 
     Ok(NormalizedPoint {
         series_id,
-        labels: label_set,
+        // ADR-0098: fresh Arc per exploded series, no sharing (see above).
+        labels: Arc::new(label_set),
         sample: Sample { ts_ns, value },
         is_monotonic_sum: false,
     })

--- a/crates/ravel-otlp/src/normalize.rs
+++ b/crates/ravel-otlp/src/normalize.rs
@@ -52,6 +52,8 @@
 //! intentional, not an oversight; callers who need collision-free names
 //! for adversarial input should pre-validate before calling in.
 
+use std::sync::Arc;
+
 use opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest;
 use opentelemetry_proto::tonic::common::v1::any_value::Value as AnyValueVariant;
 use opentelemetry_proto::tonic::common::v1::{AnyValue, KeyValue};
@@ -99,7 +101,10 @@ fn has_no_recorded_value(flags: u32) -> bool {
 #[derive(Debug, Clone, PartialEq)]
 pub struct NormalizedPoint {
     pub series_id: SeriesId,
-    pub labels: LabelSet,
+    /// One label set shared across the points of a series run (ADR-0098). A
+    /// run of points with identical attributes clone the same `Arc` rather
+    /// than each building and owning a copy.
+    pub labels: Arc<LabelSet>,
     pub sample: Sample,
     /// `true` only for points from a `Sum` metric with `is_monotonic` set;
     /// always `false` for `Gauge` points.
@@ -115,7 +120,8 @@ pub struct NormalizedPoint {
 #[derive(Debug, Clone, PartialEq)]
 pub struct NormalizedHistogramPoint {
     pub series_id: SeriesId,
-    pub labels: LabelSet,
+    /// Shared per series run, as on [`NormalizedPoint`] (ADR-0098).
+    pub labels: Arc<LabelSet>,
     pub sample: HistogramSample,
 }
 
@@ -645,30 +651,59 @@ struct NativeHistogramContext<'a> {
     ingest_ts_ns: i64,
 }
 
-/// Last-seen memo for `SeriesId::compute`, scoped to one `Metric`.
+/// Last-seen memo scoped to one `Metric`, keyed on the normalizer's input and
+/// caching the built `Arc<LabelSet>` alongside the `SeriesId` (ADR-0098
+/// decision 2). A hit clones an `Arc` and rebuilds nothing; the realistic OTLP
+/// shape is one series sampled over time, so on a run of points with identical
+/// attributes every point after the first pays one refcount bump instead of
+/// rebuilding the label set and recomputing the id.
 ///
-/// Within a metric `tenant` and `metric_name` are constant, and the built
-/// `LabelSet` (which carries `__name__`) fully determines the canonical
-/// series identity (ADR-0005), so an equal `LabelSet` always yields a
-/// bit-identical `SeriesId`. The realistic OTLP shape is a single series
-/// sampled over time: one metric holding many data points with identical
-/// attributes, emitted consecutively. A one-entry last-seen memo skips the
-/// per-point BLAKE3 hash across such a run while staying correct for
-/// interleaved or single-point metrics (a mismatch just recomputes).
+/// Two keying modes, one per producer shape, chosen by which method the caller
+/// uses:
 ///
-/// A hit is a full structural comparison of the label set, not a pointer
-/// compare: `LabelSet` compares as a `Vec<Label>` of `String` pairs, so it
-/// costs O(L) string comparisons, and it saves no allocation, because
-/// `SeriesId::compute` hashes through a thread-local scratch buffer that
-/// allocates nothing once warm. A miss adds a deep clone of the label set on
-/// top. `benches/normalize_alloc.rs` measures 46.05 allocations per point on
-/// interleaved series against 23.27 grouped, so this memo pays off only while
-/// points arrive in runs.
+/// - [`series_id_for_attributes`](Self::series_id_for_attributes), for gauge,
+///   sum, and native-histogram points. Within a metric `tenant`, `metric_name`
+///   and the resource labels are constant, so the raw attribute slice alone
+///   determines the label set. The key is that slice, compared by borrowed
+///   equality against the previous point's, which allocates nothing;
+///   determinism makes the sound direction hold (byte-equal raw input under a
+///   fixed scope always builds the same label set), and the comparison is
+///   order-sensitive on purpose (a reordered slice misses and rebuilds, which
+///   is correct and merely unsaved). Sanitisation is many-to-one, so distinct
+///   raw slices can build equal label sets; that direction only ever causes a
+///   miss.
 ///
-/// Fixed capacity of one entry; dropped when the metric's loop ends, so
-/// memory is bounded to a single label set.
+/// - [`series_id_for_built`](Self::series_id_for_built), for the classic
+///   histogram and summary explosion. The exploded series of one data point
+///   share a single raw attribute slice and differ only in the exploded name
+///   and the synthesized `le`/`quantile` label, so a raw-attributes-only key
+///   would hand every bucket the first bucket's id and labels -- silent data
+///   corruption the merge collision check cannot detect, because the wrong id
+///   and wrong labels travel as a consistent pair (ADR-0098). This path keeps
+///   the built-set comparison instead: it is correct, and with a one-entry
+///   memo the exploded series never repeat consecutively anyway, so it shares
+///   nothing and merely computes each id once.
+///
+/// A hit records only after `LabelSet::new` and `SeriesId::compute` both
+/// succeeded, and skips only label construction; every other admission check
+/// runs unconditionally in the caller, so the set of rejected points is
+/// identical with and without the memo.
+///
+/// Fixed capacity of one entry; dropped when the metric's loop ends, so memory
+/// is bounded to a single label set plus, on the attribute-keyed path, one
+/// copy of the raw attribute slice that keyed it.
 struct SeriesIdMemo {
-    last: Option<(LabelSet, SeriesId)>,
+    last: Option<MemoEntry>,
+}
+
+/// One cached series identity and the input that produced it.
+struct MemoEntry {
+    /// The raw attribute slice of the point that built this entry, for the
+    /// attribute-keyed path; `None` on the explode paths, which compare the
+    /// built label set held in `labels` instead.
+    attr_key: Option<Vec<KeyValue>>,
+    labels: Arc<LabelSet>,
+    series_id: SeriesId,
 }
 
 impl SeriesIdMemo {
@@ -676,27 +711,73 @@ impl SeriesIdMemo {
         SeriesIdMemo { last: None }
     }
 
-    /// Return the id for `labels`, reusing the last computation when the
-    /// label set is unchanged and otherwise computing and caching it. The
-    /// returned id is identical to calling `SeriesId::compute` directly.
-    fn series_id(
+    /// Resolve the id and shared label set for a gauge/sum/native-histogram
+    /// point keyed on its raw `attributes`. On a hit the cached `Arc` is
+    /// cloned and `build_labels` is never called; on a miss `build_labels`
+    /// consumes `attributes` to build the set (moving attribute-name strings,
+    /// the #367 optimisation), the id is computed, and both are cached along
+    /// with a copy of `attributes` as the key.
+    fn series_id_for_attributes<F>(
         &mut self,
         tenant: &TenantId,
         metric_name: &str,
-        labels: &LabelSet,
-    ) -> Result<SeriesId, TypeError> {
-        if let Some((last_labels, last_id)) = &self.last
-            && last_labels == labels
+        attributes: Vec<KeyValue>,
+        build_labels: F,
+    ) -> Result<(SeriesId, Arc<LabelSet>), Rejection>
+    where
+        F: FnOnce(Vec<KeyValue>) -> Result<LabelSet, Rejection>,
+    {
+        if let Some(entry) = &self.last
+            && entry.attr_key.as_deref() == Some(attributes.as_slice())
         {
             #[cfg(any(test, feature = "memo-stats"))]
             memo_stats::record_hit();
-            return Ok(*last_id);
+            return Ok((entry.series_id, Arc::clone(&entry.labels)));
         }
         #[cfg(any(test, feature = "memo-stats"))]
         memo_stats::record_miss();
-        let id = SeriesId::compute(tenant, metric_name, labels)?;
-        self.last = Some((labels.clone(), id));
-        Ok(id)
+        let key = attributes.clone();
+        let label_set = build_labels(attributes)?;
+        let series_id = SeriesId::compute(tenant, metric_name, &label_set)
+            .map_err(|_| Rejection::OversizedSeriesComponent)?;
+        let labels = Arc::new(label_set);
+        self.last = Some(MemoEntry {
+            attr_key: Some(key),
+            labels: Arc::clone(&labels),
+            series_id,
+        });
+        Ok((series_id, labels))
+    }
+
+    /// Resolve the id and shared label set for an already-built `label_set`,
+    /// keyed on the built set itself. Used by the explode paths, where the raw
+    /// attribute slice does not distinguish the exploded series (see the type
+    /// doc). The returned id is identical to calling `SeriesId::compute`
+    /// directly.
+    fn series_id_for_built(
+        &mut self,
+        tenant: &TenantId,
+        metric_name: &str,
+        label_set: LabelSet,
+    ) -> Result<(SeriesId, Arc<LabelSet>), TypeError> {
+        if let Some(entry) = &self.last
+            && entry.attr_key.is_none()
+            && *entry.labels == label_set
+        {
+            #[cfg(any(test, feature = "memo-stats"))]
+            memo_stats::record_hit();
+            return Ok((entry.series_id, Arc::clone(&entry.labels)));
+        }
+        #[cfg(any(test, feature = "memo-stats"))]
+        memo_stats::record_miss();
+        let series_id = SeriesId::compute(tenant, metric_name, &label_set)?;
+        let labels = Arc::new(label_set);
+        self.last = Some(MemoEntry {
+            attr_key: None,
+            labels: Arc::clone(&labels),
+            series_id,
+        });
+        Ok((series_id, labels))
     }
 }
 
@@ -906,25 +987,32 @@ fn build_point(
         }
     };
 
-    let mut labels = Vec::with_capacity(ctx.resource_labels.len() + dp.attributes.len() + 1);
-    labels.extend_from_slice(ctx.resource_labels);
-    labels.push(Label {
-        name: METRIC_NAME_LABEL.to_string(),
-        value: ctx.metric_name.to_string(),
-    });
-    push_attribute_labels(&mut labels, std::mem::take(&mut dp.attributes), ctx.limits)?;
-
-    let label_set = LabelSet::new(labels).map_err(|err| match err {
-        TypeError::DuplicateLabelName(name) => Rejection::DuplicateLabelName(name),
-        // LabelSet::new only ever returns DuplicateLabelName; this arm
-        // exists so a future TypeError variant can't silently pass through
-        // as an accepted point.
-        _ => Rejection::DuplicateLabelName(String::new()),
-    })?;
-
-    let series_id = memo
-        .series_id(ctx.tenant, ctx.metric_name, &label_set)
-        .map_err(|_| Rejection::OversizedSeriesComponent)?;
+    // ADR-0098: key the memo on the raw attribute slice, not on a built set.
+    // On a hit `build_labels` never runs and the cached `Arc` is cloned; on a
+    // miss it builds the set once (resource-label prefix, `__name__`, then the
+    // sanitised attributes with their names moved in). Every check above ran
+    // regardless, so a hit changes only whether labels are rebuilt.
+    let (series_id, label_set) = memo.series_id_for_attributes(
+        ctx.tenant,
+        ctx.metric_name,
+        std::mem::take(&mut dp.attributes),
+        |attributes| {
+            let mut labels = Vec::with_capacity(ctx.resource_labels.len() + attributes.len() + 1);
+            labels.extend_from_slice(ctx.resource_labels);
+            labels.push(Label {
+                name: METRIC_NAME_LABEL.to_string(),
+                value: ctx.metric_name.to_string(),
+            });
+            push_attribute_labels(&mut labels, attributes, ctx.limits)?;
+            LabelSet::new(labels).map_err(|err| match err {
+                TypeError::DuplicateLabelName(name) => Rejection::DuplicateLabelName(name),
+                // LabelSet::new only ever returns DuplicateLabelName; this arm
+                // exists so a future TypeError variant can't silently pass
+                // through as an accepted point.
+                _ => Rejection::DuplicateLabelName(String::new()),
+            })
+        },
+    )?;
 
     let mut informational: Vec<Rejection> = precision_loss.into_iter().collect();
     admit_exemplars(
@@ -974,22 +1062,26 @@ fn build_native_histogram_point(
     let event_ts_ns = checked_event_ts(dp.time_unix_nano, ctx.ingest_ts_ns, ctx.limits)?;
     let value = build_histogram_value(dp)?;
 
-    let mut labels = Vec::with_capacity(ctx.resource_labels.len() + dp.attributes.len() + 1);
-    labels.extend_from_slice(ctx.resource_labels);
-    labels.push(Label {
-        name: METRIC_NAME_LABEL.to_string(),
-        value: ctx.metric_name.to_string(),
-    });
-    push_attribute_labels(&mut labels, std::mem::take(&mut dp.attributes), ctx.limits)?;
-
-    let label_set = LabelSet::new(labels).map_err(|err| match err {
-        TypeError::DuplicateLabelName(name) => Rejection::DuplicateLabelName(name),
-        _ => Rejection::DuplicateLabelName(String::new()),
-    })?;
-
-    let series_id = memo
-        .series_id(ctx.tenant, ctx.metric_name, &label_set)
-        .map_err(|_| Rejection::OversizedSeriesComponent)?;
+    // ADR-0098: a native histogram is one series per data point, keyed on the
+    // raw attribute slice like gauge/sum (see [`build_point`]).
+    let (series_id, label_set) = memo.series_id_for_attributes(
+        ctx.tenant,
+        ctx.metric_name,
+        std::mem::take(&mut dp.attributes),
+        |attributes| {
+            let mut labels = Vec::with_capacity(ctx.resource_labels.len() + attributes.len() + 1);
+            labels.extend_from_slice(ctx.resource_labels);
+            labels.push(Label {
+                name: METRIC_NAME_LABEL.to_string(),
+                value: ctx.metric_name.to_string(),
+            });
+            push_attribute_labels(&mut labels, attributes, ctx.limits)?;
+            LabelSet::new(labels).map_err(|err| match err {
+                TypeError::DuplicateLabelName(name) => Rejection::DuplicateLabelName(name),
+                _ => Rejection::DuplicateLabelName(String::new()),
+            })
+        },
+    )?;
 
     let mut informational = Vec::new();
     if dp.min.is_some() || dp.max.is_some() {
@@ -1212,8 +1304,13 @@ fn finish_point(
         _ => Rejection::DuplicateLabelName(String::new()),
     })?;
 
-    let series_id = memo
-        .series_id(ctx.tenant, metric_name, &label_set)
+    // ADR-0098: the explode paths keep the built-set comparison. The exploded
+    // series of one data point share a raw attribute slice and differ only in
+    // `__name__` and the synthesized `le`/`quantile` label, so keying on that
+    // slice would false-hit every bucket after the first onto the first
+    // bucket's id and labels; comparing the built set cannot.
+    let (series_id, label_set) = memo
+        .series_id_for_built(ctx.tenant, metric_name, label_set)
         .map_err(|_| Rejection::OversizedSeriesComponent)?;
 
     Ok(NormalizedPoint {
@@ -3476,7 +3573,7 @@ mod tests {
         assert!(out.rejected.is_empty(), "{:?}", out.rejected);
         assert_eq!(out.points.len(), SERIES * POINTS_PER_SERIES);
 
-        let label_sets: Vec<LabelSet> = out.points.iter().map(|p| p.labels.clone()).collect();
+        let label_sets: Vec<Arc<LabelSet>> = out.points.iter().map(|p| p.labels.clone()).collect();
         let name = "http_requests_total";
 
         // before: recompute the id for every point (pre-memo behavior).
@@ -3487,12 +3584,16 @@ mod tests {
         }
         let before = t0.elapsed();
 
-        // after: last-seen memo over the same order.
+        // after: last-seen memo over the same order (built-set comparison).
         let t1 = std::time::Instant::now();
         let mut memo = SeriesIdMemo::new();
         let mut after_ids = Vec::with_capacity(label_sets.len());
         for ls in &label_sets {
-            after_ids.push(memo.series_id(&tenant(), name, ls).expect("compute id"));
+            after_ids.push(
+                memo.series_id_for_built(&tenant(), name, (**ls).clone())
+                    .expect("compute id")
+                    .0,
+            );
         }
         let after = t1.elapsed();
 
@@ -4840,5 +4941,165 @@ mod tests {
         // with bytes identical to the oracle's.
         let out = sanitize_label_name(String::from("http.status.code"));
         assert_eq!(out, "http_status_code");
+    }
+
+    // --- ADR-0098: shared label set per series run ---
+
+    const MEMO_TS: i64 = 1_700_000_000_000_000_000;
+
+    /// ADR-0098 test 1 (the trap). One classic histogram data point with
+    /// several bounds explodes into `{name}_bucket{le=..}` per bound, `+Inf`,
+    /// `_sum`, and `_count`. Every exploded series must get a DISTINCT series
+    /// id, each equal to computing that id directly with no memo. A memo keyed
+    /// on the raw attribute slice alone would hand every bucket after the first
+    /// the first bucket's id and labels (they share one attribute slice and
+    /// differ only in `__name__` and `le`), which this distinctness check
+    /// catches; the explode path keeps the built-set comparison instead.
+    #[test]
+    fn histogram_explode_yields_distinct_ids_through_the_memo() {
+        let dp = histogram_point(
+            vec![string_kv("host", "a")],
+            MEMO_TS,
+            10,
+            Some(5.0),
+            vec![1.0, 2.5, 5.0],
+            vec![2, 3, 4, 1],
+        );
+        let out = normalize_metrics(
+            &tenant(),
+            request(vec![resource_metrics(
+                Vec::new(),
+                vec![histogram_metric(
+                    "lat",
+                    vec![dp],
+                    AggregationTemporality::Cumulative,
+                )],
+            )]),
+            &IngestLimits::default(),
+            MEMO_TS,
+        );
+        assert!(out.rejected.is_empty(), "{:?}", out.rejected);
+        // 3 explicit bounds -> 3 bucket series + `+Inf` bucket + `_sum` +
+        // `_count` = 6 exploded series.
+        assert_eq!(out.points.len(), 6);
+
+        let distinct: HashSet<SeriesId> = out.points.iter().map(|p| p.series_id).collect();
+        assert_eq!(
+            distinct.len(),
+            out.points.len(),
+            "every exploded series must have a distinct id; a raw-attributes-only \
+             key would collapse the buckets onto the first bucket's id"
+        );
+
+        // Each id equals computing it directly, with the exploded name (the
+        // point's own `__name__`) and its full label set.
+        for p in &out.points {
+            let name = p.labels.get(METRIC_NAME_LABEL).expect("__name__");
+            let direct = SeriesId::compute(&tenant(), name, &p.labels).expect("compute id");
+            assert_eq!(
+                p.series_id, direct,
+                "memoised id diverged from direct compute"
+            );
+        }
+    }
+
+    /// ADR-0098 test 4. A run of points with identical attributes shares ONE
+    /// `Arc<LabelSet>`: every produced point clones the same allocation, pinned
+    /// with `Arc::ptr_eq` rather than assumed.
+    #[test]
+    fn identical_attribute_run_shares_one_arc() {
+        let points: Vec<NumberDataPoint> = (0..5)
+            .map(|i| {
+                number_point(
+                    vec![string_kv("host", "a")],
+                    MEMO_TS + i,
+                    NumberValue::AsDouble(i as f64),
+                )
+            })
+            .collect();
+        let out = normalize_metrics(
+            &tenant(),
+            request(vec![resource_metrics(
+                Vec::new(),
+                vec![gauge_metric("cpu", points)],
+            )]),
+            &IngestLimits::default(),
+            MEMO_TS,
+        );
+        assert!(out.rejected.is_empty(), "{:?}", out.rejected);
+        assert_eq!(out.points.len(), 5);
+        let first = &out.points[0].labels;
+        for p in &out.points[1..] {
+            assert!(
+                Arc::ptr_eq(first, &p.labels),
+                "points of one run must share one Arc<LabelSet>"
+            );
+        }
+    }
+
+    /// ADR-0098 test 2. Memoised output is bit-identical to unmemoised output
+    /// over arbitrary requests, rejections included. The unmemoised oracle is
+    /// the same points split into one-data-point metrics of the same name: each
+    /// gets its own single-entry memo, so the memo never hits, while the
+    /// per-point results (id and full label set) are unchanged. `SeriesId`
+    /// bytes and full `LabelSet` contents are compared via the derived
+    /// `PartialEq` on `NormalizeOutput`.
+    ///
+    /// This exercises the attribute-keyed path (gauge points, where the memo
+    /// does hit on repeats); the intra-data-point explosion trap is pinned
+    /// separately by [`histogram_explode_yields_distinct_ids_through_the_memo`],
+    /// which the split oracle cannot see (one data point explodes through one
+    /// memo in both the grouped and split shapes).
+    fn attrs_of(spec: &[(u8, u8)]) -> Vec<KeyValue> {
+        spec.iter()
+            .enumerate()
+            .map(|(i, (_, v))| string_kv(&format!("k{i}"), &format!("v{v}")))
+            .collect()
+    }
+
+    proptest::proptest! {
+        #[test]
+        fn memoised_output_matches_unmemoised(
+            specs in proptest::collection::vec(
+                proptest::collection::vec((0u8..3, 0u8..3), 0usize..4),
+                1usize..12,
+            )
+        ) {
+            let tenant = tenant();
+            let limits = IngestLimits::default();
+
+            // Grouped: all data points in one metric -> the memo hits on
+            // repeated attribute slices.
+            let grouped_points: Vec<NumberDataPoint> = specs
+                .iter()
+                .enumerate()
+                .map(|(i, spec)| number_point(
+                    attrs_of(spec),
+                    MEMO_TS + i as i64,
+                    NumberValue::AsDouble(i as f64),
+                ))
+                .collect();
+            let grouped = request(vec![resource_metrics(
+                Vec::new(),
+                vec![gauge_metric("m", grouped_points)],
+            )]);
+
+            // Unmemoised oracle: each data point alone in its own metric of the
+            // same name, so every SeriesIdMemo sees exactly one point.
+            let split_metrics: Vec<Metric> = specs
+                .iter()
+                .enumerate()
+                .map(|(i, spec)| gauge_metric("m", vec![number_point(
+                    attrs_of(spec),
+                    MEMO_TS + i as i64,
+                    NumberValue::AsDouble(i as f64),
+                )]))
+                .collect();
+            let split = request(vec![resource_metrics(Vec::new(), split_metrics)]);
+
+            let memoised = normalize_metrics(&tenant, grouped, &limits, MEMO_TS);
+            let unmemoised = normalize_metrics(&tenant, split, &limits, MEMO_TS);
+            proptest::prop_assert_eq!(memoised, unmemoised);
+        }
     }
 }

--- a/crates/ravel-promql-difftest/src/ravel_stack.rs
+++ b/crates/ravel-promql-difftest/src/ravel_stack.rs
@@ -123,7 +123,7 @@ fn to_points(tenant: &TenantId, dataset: &Dataset) -> Result<Vec<IngestPoint>, R
     // against the pinned Prometheus side.
     let mut points = Vec::new();
     for series in &dataset.series {
-        let labels = build_label_set(&series.labels)?;
+        let labels = Arc::new(build_label_set(&series.labels)?);
         let series_id = SeriesId::compute(tenant, series.metric_name(), &labels)
             .map_err(RavelStackError::SeriesId)?;
         for (ts_ms, value) in &series.samples {
@@ -166,7 +166,7 @@ fn histogram_series_to_points(
     tenant: &TenantId,
     series: &GeneratedHistogramSeries,
 ) -> Result<Vec<IngestPoint>, RavelStackError> {
-    let labels = build_label_set(&series.labels)?;
+    let labels = Arc::new(build_label_set(&series.labels)?);
     let series_id = SeriesId::compute(tenant, series.metric_name(), &labels)
         .map_err(RavelStackError::SeriesId)?;
     Ok(series

--- a/crates/ravel-remote-write/src/normalize.rs
+++ b/crates/ravel-remote-write/src/normalize.rs
@@ -32,6 +32,8 @@
 //! re-checked here so an accepted point can never fail either (see
 //! [`build_histogram_value`]).
 
+use std::sync::Arc;
+
 use ravel_otlp::normalize::{NormalizedExemplar, NormalizedHistogramPoint, NormalizedPoint};
 use ravel_otlp::{IngestLimits, Rejection};
 use ravel_segment::{
@@ -380,6 +382,10 @@ fn normalize_series(
             return;
         }
     };
+
+    // ADR-0098: one label set shared across this series' samples and
+    // histograms. All points built below clone the same `Arc`.
+    let label_set = Arc::new(label_set);
 
     admit_exemplars(
         series,

--- a/crates/ravel-sim/src/driver.rs
+++ b/crates/ravel-sim/src/driver.rs
@@ -653,7 +653,7 @@ fn ingest_point_at(
                 sample.ts_ns,
                 IngestPoint {
                     series_id: series.series_id,
-                    labels: series.labels.clone(),
+                    labels: Arc::new(series.labels.clone()),
                     value: IngestValue::Scalar(*sample),
                 },
             )
@@ -663,7 +663,7 @@ fn ingest_point_at(
                 sample.ts_ns,
                 IngestPoint {
                     series_id: series.series_id,
-                    labels: series.labels.clone(),
+                    labels: Arc::new(series.labels.clone()),
                     value: IngestValue::Histogram(sample.clone()),
                 },
             )

--- a/crates/ravel-sim/tests/fold_makes_resolve_list_free.rs
+++ b/crates/ravel-sim/tests/fold_makes_resolve_list_free.rs
@@ -165,17 +165,19 @@ fn fold_makes_resolve_list_free() {
 
         let tenant = TenantId::new("fold-load-bearing-tenant");
         let tenant_hash = tenant.hash();
-        let labels = LabelSet::new(vec![
-            Label {
-                name: "__name__".to_string(),
-                value: "sim_probe".to_string(),
-            },
-            Label {
-                name: "shape".to_string(),
-                value: "f1".to_string(),
-            },
-        ])
-        .expect("valid label set");
+        let labels = Arc::new(
+            LabelSet::new(vec![
+                Label {
+                    name: "__name__".to_string(),
+                    value: "sim_probe".to_string(),
+                },
+                Label {
+                    name: "shape".to_string(),
+                    value: "f1".to_string(),
+                },
+            ])
+            .expect("valid label set"),
+        );
         let series_id = SeriesId::compute(&tenant, "sim_probe", &labels).expect("series id");
 
         let ingest_config = IngestConfig {

--- a/services/ravel-server/tests/recent_hours_reachability_e2e.rs
+++ b/services/ravel-server/tests/recent_hours_reachability_e2e.rs
@@ -142,7 +142,7 @@ async fn ingest_hot_segments(
         let ts_ns = base_ns + (i as i64) * 2 * NS_PER_SEC;
         let point = NormalizedPoint {
             series_id,
-            labels: label_set(),
+            labels: Arc::new(label_set()),
             sample: Sample {
                 ts_ns,
                 value: sample_value(i),

--- a/services/ravel-server/tests/reshard_e2e.rs
+++ b/services/ravel-server/tests/reshard_e2e.rs
@@ -137,7 +137,7 @@ fn point(metric: &str, ts_ns: i64, value: f64) -> NormalizedPoint {
     let series_id = SeriesId::compute(&tenant(), metric, &labels).expect("series id");
     NormalizedPoint {
         series_id,
-        labels,
+        labels: Arc::new(labels),
         sample: Sample { ts_ns, value },
         is_monotonic_sum: false,
     }


### PR DESCRIPTION
Today a series carrying 100 points in one batch builds 100 `LabelSet`s: `TenantBuf::merge` compares 99 of them against the claimed set field by field and drops them, keeping one. The allocation and the O(L) string comparison are both pure waste on the 99, and the realistic OTLP shape is exactly this: one series sampled over time, many points with identical attributes, emitted consecutively.

`NormalizedPoint`, `NormalizedHistogramPoint`, and `IngestPoint` now carry `Arc<LabelSet>` instead of an owned `LabelSet`, and `SeriesIdMemo` is rekeyed on the normalizer's input rather than on a constructed `LabelSet`, so a hit clones an `Arc` instead of rebuilding the set and recomputing the id. `ravel-types` is untouched.

**Two keying modes, one per producer shape.** Gauge, sum, and native-histogram points key on the raw attribute slice: within one metric, tenant/name/resource-labels are constant, so the slice alone determines the label set, and comparing it by borrowed equality allocates nothing.

**The classic histogram and summary explosion paths deliberately keep the built-set comparison instead.** This is the one thing this change could get wrong in a way nothing downstream would catch. The exploded series of one data point (bucket, +Inf, `_sum`, `_count`, or the quantiles) share a single raw attribute slice and differ only in the exploded name and the synthesized `le`/`quantile` label. A raw-attributes-only key would hand every exploded series after the first the first one's id and labels, and because the wrong id and wrong labels travel as a consistent pair, the merge collision check cannot see it — buckets would merge silently. This is exactly the failure an architecture review found in ADR-0098's first draft, before any code existed.

`TenantBuf::merge`'s collision pre-pass gains an `Arc::ptr_eq` fast path; genuinely distinct `Arc`s still compare structurally, so a real `SeriesIdCollision` is caught exactly as before. Flush unwraps the shared `Arc` by move when the accumulator holds the last reference, which it does on the common path — measured with a test that shares one `Arc` across five points and confirms `strong_count == 1` after merge, not assumed. `ravel-otap` keeps its own separate memo and built-set comparison, sharing nothing; rekeying it is a follow-up.

**Measured** (100 points/metric): grouped, 5 attributes, 5 resource labels, dirty names, falls from 23.27 to 0.40 allocations per datapoint. The interleaved (all-miss) shape does not regress — it improves, 41.05 to 30.05, because even a memo miss's raw-attribute-slice copy is cheaper than the old deep `LabelSet` clone.

**Adversarial review verified the explode-path decision independently**, not from this description. It built its own adversarial histogram (5 bounds plus sum, 8 exploded series) and additionally asserted the resulting `Arc<LabelSet>` pointers are pairwise distinct, a check this branch's own test omits. Against the real code both checks pass. Against a deliberately weakened comparison simulating a raw-attributes-only key, both fail with all 8 series collapsing to one id — confirming the test catches the exact failure the ADR was amended to prevent. The review also reproduced the benchmark numbers above exactly and confirmed no test's expected VALUE changed anywhere in the diff, only the `LabelSet` → `Arc<LabelSet>` rewrap.

No behaviour change: the bytes fed to `SeriesId::compute`, their order, the sorted-unique `LabelSet` invariant, the collision error, and every query result are unchanged.

Refs: #367