### PR TITLE
docs(adrs): claim ADR-0100 for wide-schema load and SQL latency

### DIFF
--- a/docs/adrs/0100-wide-schema-load-and-sql-latency.md
+++ b/docs/adrs/0100-wide-schema-load-and-sql-latency.md
@@ -1,0 +1,3 @@
+# ADR-0100: wide-schema load validation and SQL query latency measurement
+
+Status: claimed


### PR DESCRIPTION
Reserve ADR number 0100 on main so parallel epics cannot pick it. Stub only; the full decision text lands after the design approval gate.

Refs: #421