### PR TITLE
docs(adrs): claim ADR-0101 for the declared-column type vocabulary

### DIFF
--- a/docs/adrs/0101-declared-column-type-vocabulary.md
+++ b/docs/adrs/0101-declared-column-type-vocabulary.md
@@ -1,0 +1,3 @@
+# ADR-0101: extend the declared-column type vocabulary (f64, date, timestamp)
+
+Status: claimed


### PR DESCRIPTION
Reserve ADR number 0101 on main so parallel epics cannot pick it. Stub only; the full decision text lands after the design approval gate.

Refs: #431 #432