### PR TITLE
docs: add ADR-0101 declarable f64 typed attribute columns

### DIFF
--- a/docs/adrs/0100-wide-schema-load-and-sql-latency.md
+++ b/docs/adrs/0100-wide-schema-load-and-sql-latency.md
@@ -57,8 +57,9 @@ ClickBench is used here as an external dataset and query suite, the way the
 `parquet_baseline` bin already uses Parquet as an external comparison point:
 it is a fixed, public, wide-table analytical workload that exercises the SQL
 surface far past any fixture in the tree. Its `hits` schema is also a useful
-forcing function on decision 2 — it is all integers, strings, and date/time
-columns, so it lands squarely on the declared-column type gaps named there.
+forcing function on decision 2: it is all integers, strings, and date/time
+columns, so declaring it exercises the derivation at full width and settles
+what a time column costs when it is declared as `i64`.
 
 Relevant facts this decision leans on:
 
@@ -128,17 +129,27 @@ column and no `DeclaredType` extension — only a corpus rewrite pointing that
 column's references at `ts`. For ClickBench that is `EventTime`, which
 carries a large share of the suite's time filtering.
 
-What remains is a real gap, named here rather than discovered later.
-`DeclaredType` has no `F64`, so a float attribute cannot be declared at all;
-and it has no date or time variant, so every *secondary* time column stays
-untyped — `EventDate`, `ClientEventTime`, `LocalEventTime` in ClickBench's
-schema. Statements filtering or grouping on those pay a per-row string cast,
-which is the largest remaining latency cliff on this workload after the
-columnar and pushdown work. Both gaps get a follow-up issue filed at this
-epic's decomposition, not deferred to an unnamed later. This ADR does not
-extend `DeclaredType`: that is an ADR-0090 amendment with its own
-schema-append and projection consequences, and folding it in here would
-couple the measurement work to a format-adjacent change.
+A *secondary* time column — `EventDate`, `ClientEventTime`,
+`LocalEventTime` in ClickBench's schema — is declared as `i64` and gets the
+full typed treatment: the same NumStat pruning, the same typed comparison
+and pushdown, and exact-typed status for ADR-0094's parallel final
+aggregation. `DeclaredType` has no date or time variant, so what such a
+column does not get is ergonomic: a `DATE` or `TIMESTAMP` literal comparing
+directly rather than against an epoch integer, and `date_trunc`/`extract`
+applying without manual arithmetic. Corpus statements filtering on a
+secondary time column therefore compare against integers and carry the
+modified-query flag decision 3 requires. #432 records the ergonomic gap
+with the analysis.
+
+One gap is real rather than ergonomic: `DeclaredType` has no `F64`, and
+declaring a float key as `i64` yields NULL for every row (a declared type
+describes how a value is read, and the variants do not match), so a float
+attribute cannot be declared at all and every predicate over it pays a
+per-row string cast with no operator opt-out. ADR-0101 closes that; #431
+tracks it. Neither gap blocks this epic's measurements, and this ADR does
+not extend `DeclaredType` itself: that is a frozen-contract change to
+`TypedAttrColumnType` with its own rollout rule, and folding it in here
+would couple the measurement work to a format change.
 
 Derivation rules:
 
@@ -266,10 +277,9 @@ rather than building a second one.
 
 Competitive latency on this workload does not come from this ADR. It comes
 from ADR-0099's columnar decode, typed predicate and limit pushdown
-(#331, #278), multi-core execution and spill behavior (#361), the
-post-load object layout this harness now measures, and the declared-column
-type gaps named in decision 2. What this ADR delivers is the only thing that
-can tell those apart.
+(#331, #278), multi-core execution and spill behavior (#361), and the
+post-load object layout this harness now measures. What this ADR delivers is
+the only thing that can tell those apart.
 
 ### 5. Reachability through the shipping surfaces
 

--- a/docs/adrs/0101-declared-column-type-vocabulary.md
+++ b/docs/adrs/0101-declared-column-type-vocabulary.md
@@ -1,3 +1,209 @@
-# ADR-0101: extend the declared-column type vocabulary (f64, date, timestamp)
+# ADR-0101: declarable f64 typed attribute columns
 
-Status: claimed
+Status: Accepted
+
+## Context
+
+ADR-0090 shipped declared typed attribute columns with exactly four types —
+`str`, `i64`, `bool`, `bytes` — and deferred three more on the record
+(ADR-0090 decision 1): `f64` "gated on #277 landing", and date/timestamp
+needing "a lifting rule from `i64` storage plus a declared unit".
+`proto/ravel/sys.proto:360-375` repeats both deferrals in the
+`TypedAttrColumnType` comment, so the absence is deliberate.
+
+**The `f64` gate is now closed.** #277 landed as ADR-0094: a per-query
+exact-typed check gates parallel final aggregation, and float input keeps
+the serial, total-order path (`crates/ravel-sql/src/minmax.rs`'s
+`is_float`, ADR-0094 decision 1). Float aggregation is order-dependent, so
+the fold-order question ADR-0090 was waiting on has a settled answer:
+floats are excluded from repartitioning rather than silently reordered. A
+declared `f64` column therefore cannot corrupt an aggregate result; it can
+only decline the parallel path.
+
+**A float attribute is undeclarable today, with no workaround.** The other
+four types each cover their storage variant, but `AttrValue::F64` has no
+declarable type, and declaring such a key as `i64` yields NULL for every row
+(`logs_scan.rs::declared_column_array` NULLs a value whose variant does not
+match the declared type). So a float attribute stays in the merged `attrs`
+map, and every predicate or aggregate over it is a
+`CAST(attrs['k'] AS ...)` over a materialized string — exactly the cost
+ADR-0090 exists to remove, with no way for an operator to opt out of it.
+
+### Date and timestamp are not part of this ADR
+
+They were in an earlier draft and are cut deliberately, because `i64`
+already covers the semantics.
+
+`ts` is natively `Timestamp(Nanosecond, None)` (`logs_schema.rs:60`) and a
+`--mapping` requires `ts_column`, so a dataset's primary event-time column
+is fully typed already. For a *secondary* time column declared as `i64`,
+NumStat pruning uses the same stat, typed comparison and pushdown work
+identically, and ADR-0094 treats it as exact-typed so it keeps parallel
+final aggregation. What a declared time type would add is ergonomic: a
+`DATE`/`TIMESTAMP` literal comparing directly (rather than against an epoch
+integer), and `date_trunc`/`extract` applying without manual arithmetic.
+
+That is a real ergonomic gap and #432 records it, with the analysis, as an
+ergonomics ticket. It is not a latency gap, and this ADR does not spend a
+frozen-contract change on it.
+
+### The blast radius of an unknown type is the whole tenant record
+
+This is the fact that shapes the rollout, and it applies to any new enum
+value however small. `DeclaredColumnType::from_proto_i32` refuses an
+unrecognized value (`crates/ravel-catalog/src/tenant_config.rs:122-135`, by
+design: "an absent or unknown one is corruption, not a default to guess
+at"), and its caller propagates that refusal with `?` at
+`tenant_config.rs:397`, inside the decode of the whole
+`TenantConfigRecord`.
+
+So an old binary reading a declaration that names `f64` does not lose one
+column, and does not lose only the declared-column list: **the entire tenant
+config record fails to decode**, taking lifecycle state and every admission
+override with it. On the query path that surfaces as
+`TenantConfigDeclaredColumns` serving a fallback and counting
+`ravel_typed_attr_columns_stale_fallback_total`
+(`services/ravel-server/src/declared_columns.rs`) — the "permanently
+unreadable override" case that metric exists to expose.
+
+Fail-closed decode is correct and this ADR does not change it. It does mean
+the new value is only safe to *write* once every reader can decode it.
+
+## Decision
+
+### 1. One new `TypedAttrColumnType` value, additive
+
+`proto/ravel/sys.proto` gains one enum value, keeping 0-4 untouched:
+
+```
+TYPED_ATTR_COLUMN_TYPE_F64 = 5;
+```
+
+Additive, no renumbering, no field-number change, per the frozen-contract
+rule. `DeclaredColumnType`, `DeclaredType`, the CLI column-spec vocabulary
+(`f64`), and `--from-mapping`'s derivation (#426, which currently skips
+`ColType::F64` with a warning) gain the matching variant. The proto comment
+that names the deferral is updated in the same change: `f64` is no longer
+deferred, and the date/timestamp deferral note stays with a pointer to #432.
+
+Migration class: the tenant config record is a mutable, CAS-versioned
+control-plane record, not a bulk data object — Class C in ADR-0066 decision
+4's sense (additive-only metadata). Nothing needs converging: existing
+records stay byte-valid and decode unchanged.
+
+### 2. Projection semantics
+
+A declared `f64` column projects as Arrow `Float64` from an
+`AttrValue::F64`. A value of any other variant yields NULL for that row,
+exactly as the four existing types already do. No coercion from `I64` and no
+parse from `Str`: a declared type describes how a value is *read*, and
+silently widening an integer into a float column would make a query's
+result depend on which variant a writer happened to store.
+
+Float comparison in this path, and in every test asserting it, uses bit
+patterns (`f64::to_bits`), never `==`. NaN payloads and `-0.0` stay
+significant, per the repo invariant.
+
+### 3. NumStat pruning, with the NaN rule stated
+
+The RLOG writer already computes NumStats for `I64`, `F64`, and `Bool`
+(`crates/ravel-logseg/src/writer.rs`), so a declared `f64` column has real
+bounds to prune on and needs no new stat.
+
+The NaN rule is explicit: a page whose values include NaN has no usable
+ordered bound, so its stat must not be used to prune a range predicate. An
+absent or unusable stat prunes nothing, which is always legal (ADR-0095
+decision 5's discipline). A test must prove that a NaN-carrying page
+survives a range predicate which would exclude it on min/max alone —
+demonstrated failing against an implementation that prunes on the bounds
+regardless.
+
+Cross-type agreement follows ADR-0095 unchanged: a name carrying both `I64`
+and `F64` occurrences resolves by that ADR's rules, and this ADR adds no new
+resolution.
+
+### 4. Aggregation: float declines the parallel path, per ADR-0094
+
+A query aggregating a declared `f64` column fails ADR-0094's exact-typed
+check and runs its final aggregation serially. That is the existing rule for
+float input, applied to a new way of producing float input; nothing here
+weakens it. This is a latency consequence, not a correctness one, and it is
+the reason ADR-0090 waited for #277 rather than shipping `f64` in v1.
+
+### 5. Rollout: readers before writers
+
+Because an unknown value fails the whole tenant record decode (see Context),
+the change lands in two ordered releases:
+
+1. **Reader release.** Decode, projection, and pruning recognize `f64`.
+   Nothing writes it: the CLI does not offer it, and `--from-mapping` still
+   skips a float mapping entry with the warning it prints today.
+2. **Writer release**, once the fleet is on the reader release. The CLI
+   column-spec vocabulary and `--from-mapping` gain `f64` and can write it
+   durably.
+
+The gap is a deployment property, not a code flag: a mixed-version fleet
+where a writer runs ahead of a reader can strand a tenant's whole config
+behind a fallback until the reader catches up. The release notes and
+`docs/guides/query.md` state the ordering requirement, and the writer
+release's ticket names the reader release as its dependency.
+
+## Diagram
+
+```mermaid
+flowchart TD
+    M["CLI column spec / --mapping"] -->|"writer release only"| CAS[typed-attr-column set CAS replace]
+    CAS --> TCR[(TenantConfigRecord)]
+    TCR -->|from_proto_i32| DEC{f64 recognized?}
+    DEC -->|"no: WHOLE record fails"| FB["fallback + stale_fallback metric<br/>tenant pinned to base config"]
+    DEC -->|yes| DCS[DeclaredColumnSource]
+    DCS --> SCH[logs_schema_with_declared]
+    SCH --> PROJ[declared_column_array]
+    A["AttrValue::F64"] --> PROJ
+    B["any other variant"] -->|NULL| PROJ
+    PROJ --> F64["Arrow Float64"]
+    ST["RLOG NumStat (I64/F64/Bool)"] -->|"prune; NaN page never pruned on bounds"| PROJ
+    F64 -->|"fails exact-typed check"| SER["serial final aggregation (ADR-0094)"]
+```
+
+## Rejected alternatives
+
+- **Include date and timestamp types.** Cut after checking what they buy:
+  `ts` is already natively `Timestamp(Nanosecond, None)`, and a secondary
+  time column declared as `i64` gets identical pruning, pushdown, and
+  aggregation treatment. The remaining difference is literal and function
+  ergonomics, which is not worth a frozen-contract change on its own. #432
+  carries the analysis.
+- **Coerce `I64` values into a declared `f64` column.** Makes a query's
+  answer depend on which variant a writer stored, and hides a schema
+  mismatch that NULL surfaces.
+- **Per-entry skip on an unknown type at decode**, removing the
+  deployment-order requirement. Wrong trade: it converts a loud, metered
+  failure into a silently narrower schema, so a query would return rows
+  computed against a schema the operator never declared. ADR-0090's
+  fail-closed decode is deliberate and stays.
+- **Leave `f64` undeclarable.** Defensible while #277 was open; not after
+  ADR-0094 settled the fold order. The status quo makes every float
+  predicate a per-row string cast with no operator opt-out.
+
+## Consequences
+
+- One additive proto enum value. Existing records decode unchanged; no
+  version bump, no migration, no dual reader for the record itself.
+- A mixed-version fleet must upgrade readers before any tenant writes an
+  `f64` declaration, or that tenant's whole config falls back until it does.
+  Stated in the guide, enforced by shipping the writer one release later.
+- A declared `f64` column costs its queries ADR-0094's parallel final
+  aggregation.
+- The Arrow-side arms (`logs_schema.rs`, `logs_scan.rs::declared_column_array`,
+  `flight_ticket.rs`) each gain one case. `flight_ticket.rs` pins a resolved
+  declaration into its ticket, so a plan-then-`DoGet` across a mixed-version
+  pair is bounded by the same rollout rule as the durable record.
+- ADR-0099 types every declared `Str` column as `Dictionary(Int32, Utf8)`;
+  an `f64` column is not dictionary-encoded, so both the fast path and the
+  row-path fallback must build the right array kind or DataFusion's schema
+  validation fails at runtime. That work overlaps #360's ownership of those
+  files and is sequenced with it, not raced.
+- This is a completeness fix, not benchmark work. ADR-0100's workload has
+  no float columns to declare (verified against the real schema in #430), so
+  none of #421's measurements depend on this landing.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -102,3 +102,4 @@ One decision per document. Status: Proposed | Accepted | Superseded.
 | [0097](0097-sql-scalar-function-surface.md) | The SQL scalar and window function surface: extend the fail-closed registry gate beyond aggregates | Proposed |
 | [0099](0099-columnar-decode-to-arrow.md) | Columnar decode-to-Arrow path for SQL scans: a block view out of ravel-logseg, dictionary pages preserved end to end, and SoA buffer adoption on the metrics scan | Accepted |
 | [0100](0100-wide-schema-load-and-sql-latency.md) | Wide-schema load validation and SQL query latency measurement: dynamic-column budget counters, declared columns derived from a load mapping, a versioned analytical query corpus, and a cold/warm per-query latency harness | Accepted |
+| [0101](0101-declared-column-type-vocabulary.md) | Declarable f64 typed attribute columns: one additive TypedAttrColumnType value, Float64 projection, the NaN pruning rule, and a readers-before-writers rollout | Accepted |


### PR DESCRIPTION
Fills in ADR-0101 over the number stub reserved in #433, and corrects one claim in ADR-0100.

ADR-0090 deferred `f64` declared columns pending #277's fold-order decision. #277 landed as ADR-0094: float input keeps the serial total-order aggregation path, so a declared `f64` column can only decline the parallel path, never reorder a float fold. The gate is closed.

Today a float attribute is undeclarable with no workaround — declaring the key as `i64` NULLs every row, because a declared type describes how a value is read and the variants do not match. Every predicate over a float attribute pays a per-row string cast and an operator cannot opt out.

The decision: one additive `TypedAttrColumnType` value, Arrow `Float64` projection, NumStat pruning with an explicit rule that a NaN-carrying page is never pruned on its bounds, and a readers-before-writers rollout. That last part is not ceremony: an unrecognized enum value fails the whole `TenantConfigRecord` decode (`tenant_config.rs:397`), not just the offending column, so an old binary reading an `f64` declaration drops the tenant's lifecycle state and admission overrides too. Nothing may write `f64` until every reader recognizes it.

Date and timestamp types were in an earlier draft and are cut. `ts` is already natively `Timestamp(Nanosecond, None)`, and a secondary time column declared as `i64` gets the same pruning, pushdown, and exact-typed aggregation treatment; what a declared time type adds is literal and function ergonomics, which is #432, not latency.

This also corrects ADR-0100, which called untyped secondary time columns the largest remaining latency cliff on a wide analytical workload. They are declarable as `i64`; the cast is only paid by an attribute nobody declared.

Refs: #431
