### PR TITLE
feat(logseg): expose a decoded block's columns as a borrowed view

### DIFF
--- a/crates/ravel-logseg/src/block.rs
+++ b/crates/ravel-logseg/src/block.rs
@@ -467,6 +467,10 @@ pub struct DecodedBlock {
     bool_cols: HashMap<u32, Vec<Option<bool>>>,
     str_cols: HashMap<u32, Vec<Option<Vec<u8>>>>,
     fixed_cols: HashMap<u32, Vec<Option<Vec<u8>>>>,
+    /// Whether any page descriptor in this block named [`COL_ATTRS_RAW`], read
+    /// off the header and independent of the column filter (see
+    /// [`DecodedBlock::has_attrs_raw_page`]).
+    attrs_raw_page: bool,
     pages_decoded: usize,
     pages_skipped: usize,
 }
@@ -487,6 +491,18 @@ impl DecodedBlock {
     /// projection reached the page level rather than being applied after decode.
     pub fn pages_skipped(&self) -> usize {
         self.pages_skipped
+    }
+
+    /// Whether this block carries any page for the `attrs_raw` overflow column.
+    ///
+    /// Read off the page descriptors in the block header, so it is true for a
+    /// block that has such a page even when the column filter excluded it and
+    /// nothing of it was decompressed. A block whose records all fit their
+    /// FIELD_DIR columns has no `attrs_raw` page at all
+    /// (`absent_column_occupies_no_page`), which is what makes this a metadata
+    /// read rather than a decode.
+    pub fn has_attrs_raw_page(&self) -> bool {
+        self.attrs_raw_page
     }
     pub fn i64_col(&self, column_id: u32) -> Option<&[Option<i64>]> {
         self.i64_cols.get(&column_id).map(Vec::as_slice)
@@ -712,6 +728,7 @@ pub fn read_block_columns(
         bool_cols: HashMap::new(),
         str_cols: HashMap::new(),
         fixed_cols: HashMap::new(),
+        attrs_raw_page: descs.iter().any(|d| d.column_id == COL_ATTRS_RAW),
         pages_decoded,
         pages_skipped,
     };

--- a/crates/ravel-logseg/src/columnar.rs
+++ b/crates/ravel-logseg/src/columnar.rs
@@ -1,0 +1,396 @@
+//! A borrowed columnar view over one decoded block (ADR-0099 decision 1).
+//!
+//! [`crate::BlockScan::next_block`] turns a decoded block into one
+//! [`LogRecord`](crate::LogRecord) per surviving row: an owned `String` for
+//! `body` and `severity_text`, a cloned STREAM_DIR blob, and a cloned key per
+//! present attribute. A caller that is about to build columnar output again
+//! (Arrow arrays, in `ravel-sql`) pays for that row form and then throws it
+//! away.
+//!
+//! [`ColumnarBlockView`] is the second exit: the same surviving rows, in the
+//! same order, read straight out of the decoded columns.
+//!
+//! # Accessors only, never the storage type
+//!
+//! Every method here returns a value or a borrowed slice of *one cell*. None
+//! returns the decoded block, and none returns a column's storage vector. That
+//! is deliberate and load-bearing: ADR-0099 decision 4 changes how string
+//! columns are stored (a dictionary plus ids instead of one `Vec<u8>` per row)
+//! without touching a caller, and a view handing out `&[Option<Vec<u8>>]` would
+//! either block that change or force it to materialize exactly the allocations
+//! it exists to delete.
+//!
+//! # Row addressing
+//!
+//! Every `_at`/per-row accessor takes an index into the *surviving* rows,
+//! `0..`[`surviving_count`](ColumnarBlockView::surviving_count) -- not a raw
+//! block row position. Surviving row `i` is the `i`-th row of this block that
+//! matched the scan's exact content predicate, which is the `i`-th
+//! [`LogRecord`](crate::LogRecord) `next_block` would have returned for the
+//! same block. An index at or past `surviving_count` reads `None`, as does a
+//! cell whose column is absent from the block or was projected away by the
+//! scan's [`ColumnSelection`](crate::ColumnSelection).
+
+use crate::block::DecodedBlock;
+use crate::field_dir::FieldDir;
+use crate::record::{
+    COL_BODY, COL_FLAGS, COL_OBSERVED_TS, COL_SEVERITY_NUM, COL_SEVERITY_TEXT, COL_SPAN_ID,
+    COL_STREAM_REF, COL_TRACE_ID, COL_TS, FieldType,
+};
+use crate::stream_dir::StreamDir;
+use ravel_types::logstream::LogStreamId;
+
+/// A dynamic attribute column resolved out of FIELD_DIR: the id to address it
+/// by and the stored type that says which accessor reads it.
+///
+/// Resolved once per block through
+/// [`ColumnarBlockView::resolve_attr`] or
+/// [`ColumnarBlockView::attr_columns`], instead of per row.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct AttrColumn {
+    pub column_id: u32,
+    pub ty: FieldType,
+}
+
+/// A borrowed columnar view of one decoded block, restricted to the rows that
+/// survived the scan's exact content predicate.
+///
+/// See the [module docs](self) for what this does and does not expose, and for
+/// how rows are addressed.
+pub struct ColumnarBlockView<'a> {
+    stream_dir: &'a StreamDir,
+    field_dir: &'a FieldDir,
+    block: &'a DecodedBlock,
+    /// Block row positions of the surviving rows, ascending.
+    rows: &'a [usize],
+}
+
+/// Shape only. Formatting a block's cells would defeat the point of a view that
+/// exists to avoid materializing them.
+impl std::fmt::Debug for ColumnarBlockView<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ColumnarBlockView")
+            .field("record_count", &self.record_count())
+            .field("surviving_count", &self.surviving_count())
+            .field("pages_decoded", &self.pages_decoded())
+            .field("pages_skipped", &self.pages_skipped())
+            .field("has_attrs_raw_page", &self.has_attrs_raw_page())
+            .finish()
+    }
+}
+
+impl<'a> ColumnarBlockView<'a> {
+    pub(crate) fn new(
+        stream_dir: &'a StreamDir,
+        field_dir: &'a FieldDir,
+        block: &'a DecodedBlock,
+        rows: &'a [usize],
+    ) -> Self {
+        ColumnarBlockView {
+            stream_dir,
+            field_dir,
+            block,
+            rows,
+        }
+    }
+
+    /// The block's total row count, before the content predicate.
+    pub fn record_count(&self) -> usize {
+        self.block.record_count()
+    }
+
+    /// Rows of this block that matched the content predicate: the length of
+    /// every column this view walks, and the number of records `next_block`
+    /// would have returned for the same block.
+    pub fn surviving_count(&self) -> usize {
+        self.rows.len()
+    }
+
+    /// Pages this block's decode decompressed and decoded.
+    pub fn pages_decoded(&self) -> usize {
+        self.block.pages_decoded()
+    }
+
+    /// Pages this block's decode skipped because the column filter excluded
+    /// them.
+    pub fn pages_skipped(&self) -> usize {
+        self.block.pages_skipped()
+    }
+
+    /// Whether this block carries any page for the `attrs_raw` overflow column.
+    ///
+    /// Answered from the block header's page descriptors: no `attrs_raw` page
+    /// is decoded to find out, and the answer holds even when the scan's column
+    /// selection excluded `attrs_raw` entirely. A caller whose fast path cannot
+    /// see attributes that spilled past the dynamic-column budget uses this as
+    /// an eligibility check (ADR-0099 decision 2), and decoding the column to
+    /// discover it is empty would cost exactly what the check avoids.
+    pub fn has_attrs_raw_page(&self) -> bool {
+        self.block.has_attrs_raw_page()
+    }
+
+    // --- fixed columns ------------------------------------------------------
+
+    /// Event timestamp of surviving row `i`.
+    pub fn ts(&self, i: usize) -> Option<i64> {
+        self.i64_at(COL_TS, i)
+    }
+
+    /// Observed (ingest) timestamp of surviving row `i`.
+    pub fn observed_ts(&self, i: usize) -> Option<i64> {
+        self.i64_at(COL_OBSERVED_TS, i)
+    }
+
+    /// Severity number of surviving row `i`, as stored. The row path narrows
+    /// this to the record's `u8`; the stored column is an i64 and this reports
+    /// it unnarrowed.
+    pub fn severity_num(&self, i: usize) -> Option<i64> {
+        self.i64_at(COL_SEVERITY_NUM, i)
+    }
+
+    /// Flags of surviving row `i`, as stored. The row path narrows this to the
+    /// record's `u32`.
+    pub fn flags(&self, i: usize) -> Option<i64> {
+        self.i64_at(COL_FLAGS, i)
+    }
+
+    /// The dense STREAM_DIR reference of surviving row `i`.
+    ///
+    /// `None` only when the row index is out of range or `stream_ref` was not
+    /// decoded; a stored value outside `u32` is rejected before this view is
+    /// handed out (see [`crate::BlockScan::next_block_columnar`]), so it cannot
+    /// surface here as a missing value.
+    pub fn stream_ref(&self, i: usize) -> Option<u32> {
+        u32::try_from(self.i64_at(COL_STREAM_REF, i)?).ok()
+    }
+
+    /// Severity text of surviving row `i`, as stored bytes. Not validated as
+    /// UTF-8: the row path validates when it builds a `String`, and a caller
+    /// building its own strings decides what to do about a violation.
+    pub fn severity_text(&self, i: usize) -> Option<&'a [u8]> {
+        self.bytes_at(COL_SEVERITY_TEXT, i)
+    }
+
+    /// Body of surviving row `i`, as stored bytes (see
+    /// [`severity_text`](Self::severity_text) on UTF-8).
+    pub fn body(&self, i: usize) -> Option<&'a [u8]> {
+        self.bytes_at(COL_BODY, i)
+    }
+
+    /// The 16-byte trace id of surviving row `i`, or `None` when the row
+    /// carries none.
+    pub fn trace_id(&self, i: usize) -> Option<&'a [u8]> {
+        self.bytes_at(COL_TRACE_ID, i)
+    }
+
+    /// The 8-byte span id of surviving row `i`, or `None` when the row carries
+    /// none.
+    pub fn span_id(&self, i: usize) -> Option<&'a [u8]> {
+        self.bytes_at(COL_SPAN_ID, i)
+    }
+
+    // --- stream identity ----------------------------------------------------
+
+    /// The stream identity of surviving row `i`, borrowed from STREAM_DIR.
+    pub fn stream_id(&self, i: usize) -> Option<&'a LogStreamId> {
+        self.stream_id_of(self.stream_ref(i)?)
+    }
+
+    /// The canonical resource+scope attribute blob of surviving row `i`,
+    /// borrowed from STREAM_DIR. This is the same bytes the row path clones
+    /// into every record's `stream_attrs`.
+    pub fn stream_attrs(&self, i: usize) -> Option<&'a [u8]> {
+        self.stream_attrs_of(self.stream_ref(i)?)
+    }
+
+    /// The stream identity behind a `stream_ref`, for a caller that groups rows
+    /// by reference and resolves each reference once.
+    pub fn stream_id_of(&self, stream_ref: u32) -> Option<&'a LogStreamId> {
+        self.stream_entry(stream_ref).map(|e| &e.stream_id)
+    }
+
+    /// The canonical resource+scope blob behind a `stream_ref`.
+    pub fn stream_attrs_of(&self, stream_ref: u32) -> Option<&'a [u8]> {
+        self.stream_entry(stream_ref).map(|e| e.blob.as_slice())
+    }
+
+    /// How many distinct `stream_ref` values this object's STREAM_DIR defines.
+    pub fn stream_count(&self) -> usize {
+        self.stream_dir.entries().len()
+    }
+
+    // --- dynamic attribute columns -----------------------------------------
+
+    /// The FIELD_DIR column for attribute `key` at stored type `ty`, resolved
+    /// once for the whole block.
+    ///
+    /// One key can have a column per type (a name written as both a string and
+    /// an integer splits into two columns), which is why the type is part of the
+    /// lookup. Use [`attr_columns_for`](Self::attr_columns_for) to find every
+    /// column a key has.
+    pub fn resolve_attr(&self, key: &str, ty: FieldType) -> Option<AttrColumn> {
+        self.field_dir.column(key, ty).map(|e| AttrColumn {
+            column_id: e.column_id,
+            ty: e.ty,
+        })
+    }
+
+    /// Every FIELD_DIR column carrying attribute `key`, one per stored type.
+    pub fn attr_columns_for<'k>(
+        &self,
+        key: &'k str,
+    ) -> impl Iterator<Item = AttrColumn> + use<'a, 'k> {
+        self.field_dir
+            .entries()
+            .iter()
+            .filter(move |e| e.name == key)
+            .map(|e| AttrColumn {
+                column_id: e.column_id,
+                ty: e.ty,
+            })
+    }
+
+    /// Every dynamic attribute column this object defines, as
+    /// `(attribute name, column)`, in FIELD_DIR order.
+    ///
+    /// A column here is not necessarily decoded: the scan's column selection
+    /// may have skipped it, in which case every cell of it reads `None`.
+    pub fn attr_columns(&self) -> impl Iterator<Item = (&'a str, AttrColumn)> + '_ {
+        self.field_dir.entries().iter().map(|e| {
+            (
+                e.name.as_str(),
+                AttrColumn {
+                    column_id: e.column_id,
+                    ty: e.ty,
+                },
+            )
+        })
+    }
+
+    // --- by column id -------------------------------------------------------
+
+    /// The i64 cell at surviving row `i` of column `column_id`.
+    pub fn i64_at(&self, column_id: u32, i: usize) -> Option<i64> {
+        let row = self.row(i)?;
+        self.block.i64_col(column_id)?.get(row).copied().flatten()
+    }
+
+    /// The f64 cell at surviving row `i` of column `column_id`, as its
+    /// `to_bits` pattern. Bits rather than an `f64` because NaN payloads and
+    /// `-0.0` are significant in this format and comparison here is bit-exact.
+    pub fn f64_bits_at(&self, column_id: u32, i: usize) -> Option<u64> {
+        let row = self.row(i)?;
+        self.block.f64_col(column_id)?.get(row).copied().flatten()
+    }
+
+    /// [`f64_bits_at`](Self::f64_bits_at) as an `f64`. Lossless
+    /// (`f64::from_bits`), but two distinct stored NaNs compare equal as
+    /// values; use the bits form to distinguish them.
+    pub fn f64_at(&self, column_id: u32, i: usize) -> Option<f64> {
+        self.f64_bits_at(column_id, i).map(f64::from_bits)
+    }
+
+    /// The bool cell at surviving row `i` of column `column_id`.
+    pub fn bool_at(&self, column_id: u32, i: usize) -> Option<bool> {
+        let row = self.row(i)?;
+        self.block.bool_col(column_id)?.get(row).copied().flatten()
+    }
+
+    /// The byte cell at surviving row `i` of column `column_id`: a string or
+    /// bytes attribute, `body`, `severity_text`, or a fixed-width id column.
+    ///
+    /// String-typed and fixed-width columns are deliberately one accessor. They
+    /// are stored differently and no column id is both, so a caller never needs
+    /// to know which of the two a column is; that is exactly the coupling this
+    /// view exists to avoid.
+    pub fn bytes_at(&self, column_id: u32, i: usize) -> Option<&'a [u8]> {
+        let row = self.row(i)?;
+        let block = self.block;
+        if let Some(col) = block.str_col(column_id) {
+            return col.get(row)?.as_deref();
+        }
+        block.fixed_col(column_id)?.get(row)?.as_deref()
+    }
+
+    // --- gather iterators ---------------------------------------------------
+
+    /// Walks column `column_id` over the surviving rows in order, as i64 cells.
+    pub fn iter_i64(&self, column_id: u32) -> impl Iterator<Item = Option<i64>> + '_ {
+        (0..self.rows.len()).map(move |i| self.i64_at(column_id, i))
+    }
+
+    /// Walks column `column_id` over the surviving rows in order, as f64 bit
+    /// patterns (see [`f64_bits_at`](Self::f64_bits_at)).
+    pub fn iter_f64_bits(&self, column_id: u32) -> impl Iterator<Item = Option<u64>> + '_ {
+        (0..self.rows.len()).map(move |i| self.f64_bits_at(column_id, i))
+    }
+
+    /// Walks column `column_id` over the surviving rows in order, as bool cells.
+    pub fn iter_bool(&self, column_id: u32) -> impl Iterator<Item = Option<bool>> + '_ {
+        (0..self.rows.len()).map(move |i| self.bool_at(column_id, i))
+    }
+
+    /// Walks column `column_id` over the surviving rows in order, as byte cells
+    /// (see [`bytes_at`](Self::bytes_at)).
+    pub fn iter_bytes(&self, column_id: u32) -> impl Iterator<Item = Option<&'a [u8]>> + '_ {
+        (0..self.rows.len()).map(move |i| self.bytes_at(column_id, i))
+    }
+
+    /// Walks `ts` over the surviving rows in order.
+    pub fn iter_ts(&self) -> impl Iterator<Item = Option<i64>> + '_ {
+        self.iter_i64(COL_TS)
+    }
+
+    /// Walks `observed_ts` over the surviving rows in order.
+    pub fn iter_observed_ts(&self) -> impl Iterator<Item = Option<i64>> + '_ {
+        self.iter_i64(COL_OBSERVED_TS)
+    }
+
+    /// Walks `severity_num` over the surviving rows in order.
+    pub fn iter_severity_num(&self) -> impl Iterator<Item = Option<i64>> + '_ {
+        self.iter_i64(COL_SEVERITY_NUM)
+    }
+
+    /// Walks `flags` over the surviving rows in order.
+    pub fn iter_flags(&self) -> impl Iterator<Item = Option<i64>> + '_ {
+        self.iter_i64(COL_FLAGS)
+    }
+
+    /// Walks `stream_ref` over the surviving rows in order.
+    pub fn iter_stream_ref(&self) -> impl Iterator<Item = Option<u32>> + '_ {
+        (0..self.rows.len()).map(move |i| self.stream_ref(i))
+    }
+
+    /// Walks `severity_text` over the surviving rows in order.
+    pub fn iter_severity_text(&self) -> impl Iterator<Item = Option<&'a [u8]>> + '_ {
+        self.iter_bytes(COL_SEVERITY_TEXT)
+    }
+
+    /// Walks `body` over the surviving rows in order.
+    pub fn iter_body(&self) -> impl Iterator<Item = Option<&'a [u8]>> + '_ {
+        self.iter_bytes(COL_BODY)
+    }
+
+    /// Walks `trace_id` over the surviving rows in order.
+    pub fn iter_trace_id(&self) -> impl Iterator<Item = Option<&'a [u8]>> + '_ {
+        self.iter_bytes(COL_TRACE_ID)
+    }
+
+    /// Walks `span_id` over the surviving rows in order.
+    pub fn iter_span_id(&self) -> impl Iterator<Item = Option<&'a [u8]>> + '_ {
+        self.iter_bytes(COL_SPAN_ID)
+    }
+
+    // --- internals ----------------------------------------------------------
+
+    /// The block row position of surviving row `i`. Every accessor goes through
+    /// this: reading `i` as a block row position would silently return another
+    /// row's data whenever the content predicate dropped anything.
+    fn row(&self, i: usize) -> Option<usize> {
+        self.rows.get(i).copied()
+    }
+
+    fn stream_entry(&self, stream_ref: u32) -> Option<&'a crate::stream_dir::StreamEntry> {
+        self.stream_dir.entries().get(stream_ref as usize)
+    }
+}

--- a/crates/ravel-logseg/src/lib.rs
+++ b/crates/ravel-logseg/src/lib.rs
@@ -13,6 +13,7 @@
 //! panicking.
 
 pub mod block;
+pub mod columnar;
 pub mod columns;
 pub mod error;
 pub mod field_dir;
@@ -32,12 +33,17 @@ pub mod writer;
 // Cargo.toml need to change.
 pub use ravel_codec::{bloom, bloom_section, encoding, tokenizer};
 
+// The columnar block view (ADR-0099 decision 1). `block::DecodedBlock` is
+// deliberately NOT re-exported: the view is the whole public surface over a
+// decoded block, so decision 4 can change how columns are stored without
+// touching a caller.
+pub use columnar::{AttrColumn, ColumnarBlockView};
 pub use columns::ColumnSelection;
 pub use error::LogSegError;
 pub use footer::{SuffixOutcome, open_from_suffix};
 pub use ranged::{RlogRangeReader, StreamBlockLoc, StreamBlockSpan};
 pub use reader::{BlockScan, RlogReader, ScanStats, decode_section, read_section};
-pub use record::{FieldSel, LogRecord, Predicate, stream_attrs_bytes};
+pub use record::{FieldSel, FieldType, LogRecord, Predicate, stream_attrs_bytes};
 pub use writer::{ObjectIdentity, RlogConfig, RlogWriter};
 
 // Re-exported for callers building records; these are the ravel-types identity

--- a/crates/ravel-logseg/src/reader.rs
+++ b/crates/ravel-logseg/src/reader.rs
@@ -12,6 +12,7 @@ use ravel_types::logstream::AttrValue;
 
 use crate::block::{ColumnPlan, DecodedBlock, read_block_columns};
 use crate::bloom_section::BloomSection;
+use crate::columnar::ColumnarBlockView;
 use crate::columns::ColumnSelection;
 use crate::error::LogSegError;
 use crate::field_dir::FieldDir;
@@ -355,6 +356,8 @@ impl<'a> RlogReader<'a> {
             blocks,
             next: 0,
             stats,
+            current: None,
+            surviving: Vec::new(),
         })
     }
 
@@ -371,6 +374,8 @@ impl<'a> RlogReader<'a> {
             blocks: Vec::new(),
             next: 0,
             stats,
+            current: None,
+            surviving: Vec::new(),
         }
     }
 
@@ -618,6 +623,14 @@ pub struct BlockScan {
     blocks: Vec<BlockLoc>,
     next: usize,
     stats: ScanStats,
+    /// The block [`Self::decode_block`] most recently decoded, held only for as
+    /// long as one of the two exits is reading it. Dropped at the start of the
+    /// next decode, and dropped by [`Self::next_block`] before it returns, so
+    /// the row path holds exactly one block's decoded columns at a time as it
+    /// did before the columnar exit existed (ADR-0087 decision 2).
+    current: Option<DecodedBlock>,
+    /// Row positions of [`Self::current`] that matched `content`, ascending.
+    surviving: Vec<usize>,
 }
 
 impl BlockScan {
@@ -649,8 +662,95 @@ impl BlockScan {
         &mut self,
         object_bytes: &[u8],
     ) -> Result<Option<Vec<LogRecord>>, LogSegError> {
-        let Some(loc) = self.blocks.get(self.next).copied() else {
+        if !self.decode_block(object_bytes)? {
             return Ok(None);
+        }
+        let Some(decoded) = self.current.take() else {
+            return Err(LogSegError::Corrupted("block not decoded".into()));
+        };
+        let strict = self.columns.is_none();
+        let mut out = Vec::with_capacity(self.surviving.len());
+        for &row in &self.surviving {
+            out.push(rebuild_record_projected(
+                &self.stream_dir,
+                &self.field_dir,
+                &decoded,
+                row,
+                strict,
+            )?);
+        }
+        self.surviving.clear();
+        Ok(Some(out))
+    }
+
+    /// Decode the next surviving block and return a borrowed columnar view of
+    /// the rows of it that match the exact filter, or `None` once every
+    /// surviving block has been decoded (ADR-0099 decision 1).
+    ///
+    /// This is the second exit next to [`Self::next_block`], over the same
+    /// decode primitive: the view's surviving rows are exactly the rows
+    /// `next_block` would have returned records for, in the same order. What
+    /// differs is that nothing is rebuilt -- no `String`, no cloned STREAM_DIR
+    /// blob, no per-attribute key clone -- so a caller that is about to build
+    /// columnar output does not pay for a row form first.
+    ///
+    /// `object_bytes` has the same contract as [`Self::next_block`]'s, and the
+    /// same malformed-block cases are the same typed `Corrupted` errors, never
+    /// panics. Two of them are checked here rather than while rebuilding a
+    /// record: every surviving row must have a `ts` and a `stream_ref` that
+    /// resolves to a STREAM_DIR entry. The row path rejects both while building
+    /// each record; this exit builds nothing, so it checks them up front rather
+    /// than handing out a view whose `ts` and stream identity read as absent.
+    ///
+    /// The returned view borrows this cursor, so it must be dropped before the
+    /// next call. The decoded block is released on the next call to either
+    /// exit.
+    pub fn next_block_columnar(
+        &mut self,
+        object_bytes: &[u8],
+    ) -> Result<Option<ColumnarBlockView<'_>>, LogSegError> {
+        if !self.decode_block(object_bytes)? {
+            return Ok(None);
+        }
+        let Some(decoded) = self.current.as_ref() else {
+            return Err(LogSegError::Corrupted("block not decoded".into()));
+        };
+        for &row in &self.surviving {
+            let sref = u32::try_from(i64_at(decoded, COL_STREAM_REF, row)?)
+                .map_err(|_| LogSegError::Corrupted("stream_ref range".into()))?;
+            if self.stream_dir.entries().get(sref as usize).is_none() {
+                return Err(LogSegError::Corrupted("stream_ref out of range".into()));
+            }
+            i64_at(decoded, COL_TS, row)?;
+        }
+        Ok(Some(ColumnarBlockView::new(
+            &self.stream_dir,
+            &self.field_dir,
+            decoded,
+            &self.surviving,
+        )))
+    }
+
+    /// The decode primitive both exits run on: locate the next surviving block,
+    /// decode its selected columns, account for its pages, and evaluate the
+    /// exact content predicate into [`Self::surviving`].
+    ///
+    /// `Ok(false)` means the cursor is exhausted and nothing was decoded.
+    /// `Ok(true)` leaves the decoded block in [`Self::current`] and its
+    /// surviving row positions, ascending, in [`Self::surviving`].
+    ///
+    /// Having one primitive is what keeps the two exits from drifting: the
+    /// surviving row set is computed once, by one predicate evaluation, so a
+    /// columnar view cannot disagree with the records `next_block` would have
+    /// produced for the same block.
+    fn decode_block(&mut self, object_bytes: &[u8]) -> Result<bool, LogSegError> {
+        // Release the previous block before decoding the next, so peak resident
+        // decoded memory stays one block rather than two.
+        self.current = None;
+        self.surviving.clear();
+
+        let Some(loc) = self.blocks.get(self.next).copied() else {
+            return Ok(false);
         };
         self.next += 1;
         let start = usize::try_from(loc.start)
@@ -674,8 +774,6 @@ impl BlockScan {
         self.stats.pages_decoded += decoded.pages_decoded() as u64;
         self.stats.pages_skipped += decoded.pages_skipped() as u64;
 
-        let strict = self.columns.is_none();
-        let mut out = Vec::new();
         for row in 0..decoded.record_count() {
             if eval(
                 &self.stream_dir,
@@ -684,16 +782,11 @@ impl BlockScan {
                 &decoded,
                 row,
             )? {
-                out.push(rebuild_record_projected(
-                    &self.stream_dir,
-                    &self.field_dir,
-                    &decoded,
-                    row,
-                    strict,
-                )?);
+                self.surviving.push(row);
             }
         }
-        Ok(Some(out))
+        self.current = Some(decoded);
+        Ok(true)
     }
 }
 
@@ -2828,5 +2921,519 @@ mod tests {
             "a NumRange over an unresolved (name, type) must not prune"
         );
         assert_eq!(rows.len(), 2);
+    }
+
+    // --- columnar block view (ADR-0099 decision 1) ---------------------------
+
+    /// The attribute key that overflows the dynamic-column budget in
+    /// [`columnar_corpus`] and therefore lands in `attrs_raw`.
+    const OVERFLOW_KEY: &str = "z_over";
+
+    /// The dynamic-column budget [`columnar_corpus`] is built against: exactly
+    /// enough for its five columned attribute names, so the sixth
+    /// ([`OVERFLOW_KEY`], last in the writer's `(name, type)` order) spills into
+    /// `attrs_raw`.
+    const COLUMNAR_MAX_COLUMNS: usize = 5;
+
+    fn rec_attrs(stream: u8, ts: i64, body: &str, attrs: Vec<(String, AttrValue)>) -> LogRecord {
+        let mut r = rec(stream, ts, body);
+        r.attrs = attrs;
+        r
+    }
+
+    fn attr(k: &str, v: AttrValue) -> (String, AttrValue) {
+        (k.to_string(), v)
+    }
+
+    /// A corpus for the columnar view, deliberately awkward: two streams, five
+    /// columned attribute types plus one that overflows into `attrs_raw`, rows
+    /// with no attributes at all (so every dynamic column is partially present),
+    /// an empty `body`, an empty string attribute, a negative and an extreme
+    /// integer, a negative zero, and rows with and without trace/span ids.
+    ///
+    /// Bodies are worded so `HasWord(body, "keep")` keeps a non-contiguous
+    /// subset of every block's rows: an accessor that read a surviving-row index
+    /// as a raw block row position would return another row's data.
+    fn columnar_corpus() -> Vec<LogRecord> {
+        vec![
+            rec_attrs(
+                0,
+                100,
+                "keep alpha",
+                vec![
+                    attr("a_str", AttrValue::Str("x".into())),
+                    attr("b_int", AttrValue::I64(7)),
+                    attr("c_f64", AttrValue::F64(1.5)),
+                    attr("d_bool", AttrValue::Bool(true)),
+                    attr("e_bytes", AttrValue::Bytes(vec![1, 2])),
+                    attr(OVERFLOW_KEY, AttrValue::Str("ov".into())),
+                ],
+            ),
+            rec_attrs(0, 101, "drop beta", Vec::new()),
+            rec_attrs(
+                0,
+                102,
+                "keep gamma",
+                vec![attr("a_str", AttrValue::Str("y".into()))],
+            ),
+            rec_attrs(
+                0,
+                103,
+                "",
+                vec![
+                    attr("b_int", AttrValue::I64(-3)),
+                    attr("c_f64", AttrValue::F64(2.5)),
+                ],
+            ),
+            rec_attrs(
+                0,
+                104,
+                "keep delta",
+                vec![
+                    attr("a_str", AttrValue::Str(String::new())),
+                    attr("d_bool", AttrValue::Bool(false)),
+                ],
+            ),
+            rec_attrs(
+                1,
+                105,
+                "drop epsilon",
+                vec![attr("e_bytes", AttrValue::Bytes(vec![9]))],
+            ),
+            rec_attrs(
+                1,
+                106,
+                "keep zeta",
+                vec![attr(OVERFLOW_KEY, AttrValue::Str("ov2".into()))],
+            ),
+            rec_attrs(1, 107, "drop eta", Vec::new()),
+            rec_attrs(
+                1,
+                108,
+                "keep theta",
+                vec![attr("b_int", AttrValue::I64(i64::MIN))],
+            ),
+            {
+                let mut r = rec_attrs(1, 109, "", Vec::new());
+                r.trace_id = Some([3u8; 16]);
+                r.span_id = Some([4u8; 8]);
+                r
+            },
+            rec_attrs(
+                1,
+                110,
+                "keep iota",
+                vec![attr("c_f64", AttrValue::F64(-0.0))],
+            ),
+            {
+                let mut r = rec_attrs(
+                    1,
+                    111,
+                    "drop kappa",
+                    vec![
+                        attr("a_str", AttrValue::Str("z".into())),
+                        attr("d_bool", AttrValue::Bool(true)),
+                    ],
+                );
+                r.trace_id = Some([5u8; 16]);
+                r
+            },
+        ]
+    }
+
+    /// Which columns a [`ColumnSelection`] under test keeps, so the comparison
+    /// knows when a `None` from the view is the projection working rather than a
+    /// disagreement with the row path.
+    struct Kept {
+        observed_ts: bool,
+        severity_num: bool,
+        flags: bool,
+    }
+
+    /// Reads every field of surviving row `i` through the view and asserts it
+    /// equals the corresponding field of `r`, the record the row exit produced
+    /// for the same block at the same position.
+    fn assert_row_matches(view: &ColumnarBlockView<'_>, i: usize, r: &LogRecord, kept: &Kept) {
+        assert_eq!(view.ts(i), Some(r.ts_ns), "ts at surviving row {i}");
+        assert_eq!(
+            view.stream_id(i),
+            Some(&r.stream_id),
+            "stream_id at surviving row {i}"
+        );
+        assert_eq!(
+            view.stream_attrs(i),
+            Some(r.stream_attrs.as_slice()),
+            "stream_attrs at surviving row {i}"
+        );
+        // The blob is borrowed from STREAM_DIR, so two rows of the same stream
+        // read the identical slice rather than two clones.
+        assert_eq!(
+            view.stream_attrs(i),
+            view.stream_ref(i).and_then(|s| view.stream_attrs_of(s)),
+            "row and stream_ref forms of the blob must agree"
+        );
+
+        assert_eq!(
+            view.observed_ts(i),
+            kept.observed_ts.then_some(r.observed_ts_ns),
+            "observed_ts at surviving row {i}"
+        );
+        assert_eq!(
+            view.severity_num(i),
+            kept.severity_num.then_some(i64::from(r.severity_num)),
+            "severity_num at surviving row {i}"
+        );
+        assert_eq!(
+            view.flags(i),
+            kept.flags.then_some(i64::from(r.flags)),
+            "flags at surviving row {i}"
+        );
+
+        // `severity_text` and `body` are always-present columns whose value can
+        // be empty; the row path reads an absent one as `""` and so does this.
+        assert_eq!(
+            view.severity_text(i).unwrap_or(b""),
+            r.severity_text.as_bytes(),
+            "severity_text at surviving row {i}"
+        );
+        assert_eq!(
+            view.body(i).unwrap_or(b""),
+            r.body.as_bytes(),
+            "body at surviving row {i}"
+        );
+        assert_eq!(
+            view.trace_id(i).map(<[u8]>::to_vec),
+            r.trace_id.map(|t| t.to_vec()),
+            "trace_id at surviving row {i}"
+        );
+        assert_eq!(
+            view.span_id(i).map(<[u8]>::to_vec),
+            r.span_id.map(|s| s.to_vec()),
+            "span_id at surviving row {i}"
+        );
+
+        // Attributes reachable through FIELD_DIR columns, resolved once for the
+        // block and read per row. The row path pushes these in FIELD_DIR order
+        // and then appends whatever `attrs_raw` decoded, so the view-derived
+        // list must be a prefix of the record's and the remainder must be
+        // overflow keys only.
+        let mut got: Vec<(String, AttrValue)> = Vec::new();
+        for (name, col) in view.attr_columns() {
+            let v = match col.ty {
+                FieldType::Str => view
+                    .bytes_at(col.column_id, i)
+                    .and_then(|b| String::from_utf8(b.to_vec()).ok())
+                    .map(AttrValue::Str),
+                FieldType::Bytes => view
+                    .bytes_at(col.column_id, i)
+                    .map(|b| AttrValue::Bytes(b.to_vec())),
+                FieldType::I64 => view.i64_at(col.column_id, i).map(AttrValue::I64),
+                FieldType::F64 => view
+                    .f64_bits_at(col.column_id, i)
+                    .map(|bits| AttrValue::F64(f64::from_bits(bits))),
+                FieldType::Bool => view.bool_at(col.column_id, i).map(AttrValue::Bool),
+            };
+            if let Some(v) = v {
+                // Resolution by key must land on the same column.
+                assert_eq!(
+                    view.resolve_attr(name, col.ty),
+                    Some(col),
+                    "resolve_attr({name}) must match the enumerated column"
+                );
+                got.push((name.to_string(), v));
+            }
+        }
+        assert!(
+            got.len() <= r.attrs.len(),
+            "view produced {} attrs for surviving row {i}, record has {}",
+            got.len(),
+            r.attrs.len()
+        );
+        let (prefix, tail) = r.attrs.split_at(got.len());
+        for (g, w) in got.iter().zip(prefix) {
+            assert_eq!(g.0, w.0, "attr key at surviving row {i}");
+            assert!(
+                attr_value_eq(&g.1, &w.1),
+                "attr {} at surviving row {i}: view {:?} vs record {:?}",
+                g.0,
+                g.1,
+                w.1
+            );
+        }
+        for (k, _) in tail {
+            assert_eq!(
+                k, OVERFLOW_KEY,
+                "record attr {k} at surviving row {i} is not reachable through a \
+                 FIELD_DIR column and is not the known overflow key"
+            );
+        }
+        assert!(
+            view.resolve_attr(OVERFLOW_KEY, FieldType::Str).is_none(),
+            "the overflow key must have no FIELD_DIR column, or the corpus no \
+             longer exercises attrs_raw"
+        );
+    }
+
+    /// Drives the row exit and the columnar exit over the same object with the
+    /// same predicate and column selection, block for block, and asserts they
+    /// agree on every field of every surviving row. Returns each block's
+    /// `attrs_raw` page flag paired with whether that block's records actually
+    /// carried an overflow attribute.
+    fn compare_exits(
+        reader: &RlogReader<'_>,
+        obj: &[u8],
+        pred: &Predicate,
+        columns: &ColumnSelection,
+        kept: &Kept,
+        case: &str,
+    ) -> Vec<(bool, bool)> {
+        let mut rows_cursor = reader
+            .scan_blocks(pred, &[], columns)
+            .expect("open row cursor");
+        let mut col_cursor = reader
+            .scan_blocks(pred, &[], columns)
+            .expect("open columnar cursor");
+        let mut flags = Vec::new();
+        loop {
+            let records = rows_cursor.next_block(obj).expect("row exit");
+            let view = col_cursor.next_block_columnar(obj).expect("columnar exit");
+            match (records, view) {
+                (None, None) => break,
+                (Some(records), Some(view)) => {
+                    assert_eq!(
+                        view.surviving_count(),
+                        records.len(),
+                        "{case}: surviving row count must equal the row exit's record count"
+                    );
+                    assert!(
+                        view.record_count() >= view.surviving_count(),
+                        "{case}: surviving rows cannot outnumber the block's rows"
+                    );
+                    for (i, r) in records.iter().enumerate() {
+                        assert_row_matches(&view, i, r, kept);
+                    }
+                    // Out-of-range reads are `None`, never another row's data.
+                    assert_eq!(view.ts(view.surviving_count()), None, "{case}");
+
+                    // The gather iterators walk the same cells in the same order
+                    // as the per-row readers.
+                    let ts_iter: Vec<Option<i64>> = view.iter_ts().collect();
+                    let ts_rows: Vec<Option<i64>> =
+                        (0..view.surviving_count()).map(|i| view.ts(i)).collect();
+                    assert_eq!(ts_iter, ts_rows, "{case}: iter_ts");
+                    let body_iter: Vec<Option<&[u8]>> = view.iter_body().collect();
+                    let body_rows: Vec<Option<&[u8]>> =
+                        (0..view.surviving_count()).map(|i| view.body(i)).collect();
+                    assert_eq!(body_iter, body_rows, "{case}: iter_body");
+                    assert_eq!(
+                        view.iter_stream_ref().collect::<Vec<_>>(),
+                        (0..view.surviving_count())
+                            .map(|i| view.stream_ref(i))
+                            .collect::<Vec<_>>(),
+                        "{case}: iter_stream_ref"
+                    );
+
+                    if columns.is_all() {
+                        assert_eq!(
+                            view.pages_skipped(),
+                            0,
+                            "{case}: an all-columns decode skips no page"
+                        );
+                    }
+                    assert!(
+                        view.pages_decoded() > 0,
+                        "{case}: a surviving block decodes at least one page"
+                    );
+
+                    let record_has_overflow = records
+                        .iter()
+                        .any(|r| r.attrs.iter().any(|(k, _)| k == OVERFLOW_KEY));
+                    flags.push((view.has_attrs_raw_page(), record_has_overflow));
+                }
+                (records, view) => panic!(
+                    "{case}: exits disagree on exhaustion (row exit {}, columnar exit {})",
+                    records.is_some(),
+                    view.is_some()
+                ),
+            }
+        }
+        assert_eq!(
+            rows_cursor.stats(),
+            col_cursor.stats(),
+            "{case}: both exits must account for the same blocks and pages"
+        );
+        flags
+    }
+
+    /// Acceptance test for the columnar block view (issue #413): every field of
+    /// every surviving row, read through the view, equals the corresponding
+    /// field of the `LogRecord` the row exit produces for the same block at the
+    /// same position -- across an all-columns and a projected decode, and a
+    /// match-everything and a selective predicate.
+    ///
+    /// The selective predicate is the load-bearing half: it keeps a
+    /// non-contiguous subset of each block's rows, so an accessor that read its
+    /// index as a raw block row position would disagree here.
+    #[test]
+    fn columnar_view_matches_rebuilt_records() {
+        let cfg = RlogConfig {
+            block_target_records: 3,
+            max_dynamic_columns: COLUMNAR_MAX_COLUMNS,
+            ..RlogConfig::default()
+        };
+        let obj = build(cfg, columnar_corpus());
+        let reader = RlogReader::new(&obj, &cfg).expect("open object");
+
+        let all_rows = Predicate::And(Vec::new());
+        let selective = Predicate::HasWord {
+            field: FieldSel::Body,
+            word: "keep".into(),
+        };
+        // Projected: no observed_ts, severity_num, flags, trace_id or span_id,
+        // and only one of the five dynamic columns.
+        let projected = ColumnSelection::fixed_only()
+            .with_body()
+            .with_severity_text()
+            .with_attr("a_str");
+        let all_kept = Kept {
+            observed_ts: true,
+            severity_num: true,
+            flags: true,
+        };
+        let projected_kept = Kept {
+            observed_ts: false,
+            severity_num: false,
+            flags: false,
+        };
+
+        let flags = compare_exits(
+            &reader,
+            &obj,
+            &all_rows,
+            &ColumnSelection::all(),
+            &all_kept,
+            "match-all / all-columns",
+        );
+        // With a match-everything predicate every row survives, so the row
+        // exit's records cover the whole block and the `attrs_raw` page flag is
+        // exactly "some record here spilled".
+        assert!(flags.len() > 1, "corpus must produce several blocks");
+        for (has_page, record_has_overflow) in &flags {
+            assert_eq!(
+                has_page, record_has_overflow,
+                "attrs_raw page presence must match the block's spilled records"
+            );
+        }
+        assert!(
+            flags.iter().any(|(p, _)| *p),
+            "corpus must include a block whose records spill to attrs_raw"
+        );
+        assert!(
+            flags.iter().any(|(p, _)| !*p),
+            "corpus must include a block with no attrs_raw spill"
+        );
+
+        compare_exits(
+            &reader,
+            &obj,
+            &selective,
+            &ColumnSelection::all(),
+            &all_kept,
+            "selective / all-columns",
+        );
+        compare_exits(
+            &reader,
+            &obj,
+            &all_rows,
+            &projected,
+            &projected_kept,
+            "match-all / projected",
+        );
+        let selective_projected = compare_exits(
+            &reader,
+            &obj,
+            &selective,
+            &projected,
+            &projected_kept,
+            "selective / projected",
+        );
+        // The projected decode leaves `attrs_raw` decodable (naming an attribute
+        // key keeps it, since the key may have spilled), so the page flag is
+        // still answered from descriptors and still varies across blocks.
+        assert!(selective_projected.iter().any(|(p, _)| *p));
+        assert!(selective_projected.iter().any(|(p, _)| !*p));
+
+        // A projected decode really did skip pages, so the comparison above was
+        // over a partial decode rather than a silently-full one.
+        let mut cursor = reader
+            .scan_blocks(&all_rows, &[], &projected)
+            .expect("open cursor");
+        while cursor
+            .next_block_columnar(&obj)
+            .expect("columnar exit")
+            .is_some()
+        {}
+        assert!(
+            cursor.stats().pages_skipped > 0,
+            "the projected selection must leave pages undecoded"
+        );
+    }
+
+    /// Both exits reject a corrupt block with the same typed error, and neither
+    /// panics. The flipped byte is inside block 0's stored extent, so its
+    /// crc32c no longer matches its SKIP_IDX entry.
+    #[test]
+    fn corrupt_block_is_a_typed_error_through_both_exits() {
+        let cfg = RlogConfig {
+            block_target_records: 3,
+            ..RlogConfig::default()
+        };
+        let good = build(cfg, columnar_corpus());
+        let blocks_offset = open(&good)
+            .expect("open footer")
+            .section(kind::BLOCKS)
+            .expect("BLOCKS section")
+            .offset;
+        let skip = skip_of(&good);
+        let entry = skip.l0.first().expect("a first block");
+        let at = usize::try_from(blocks_offset + entry.block_offset).expect("offset fits")
+            + usize::try_from(entry.block_len).expect("len fits") / 2;
+        let mut obj = good.clone();
+        obj[at] ^= 0xff;
+
+        let pred = Predicate::And(Vec::new());
+        let reader = RlogReader::new(&obj, &cfg).expect("footer and sections are intact");
+        let err = reader
+            .scan_blocks(&pred, &[], &ColumnSelection::all())
+            .expect("open cursor")
+            .next_block(&obj)
+            .expect_err("row exit rejects the corrupt block");
+        assert!(matches!(err, LogSegError::Corrupted(_)), "{err:?}");
+        let err = reader
+            .scan_blocks(&pred, &[], &ColumnSelection::all())
+            .expect("open cursor")
+            .next_block_columnar(&obj)
+            .expect_err("columnar exit rejects the corrupt block");
+        assert!(matches!(err, LogSegError::Corrupted(_)), "{err:?}");
+
+        // Same object, uncorrupted: both exits succeed, so the assertions above
+        // are about the flipped byte and not about the fixture.
+        let reader = RlogReader::new(&good, &cfg).expect("open");
+        assert!(
+            reader
+                .scan_blocks(&pred, &[], &ColumnSelection::all())
+                .expect("open cursor")
+                .next_block(&good)
+                .expect("row exit")
+                .is_some()
+        );
+        assert!(
+            reader
+                .scan_blocks(&pred, &[], &ColumnSelection::all())
+                .expect("open cursor")
+                .next_block_columnar(&good)
+                .expect("columnar exit")
+                .is_some()
+        );
     }
 }

--- a/crates/ravel-query/src/lib.rs
+++ b/crates/ravel-query/src/lib.rs
@@ -27,7 +27,8 @@ pub use fetcher::{
     SegmentFetcher,
 };
 pub use log_fetcher::{
-    LogFetchError, LogFetchOutput, LogQuery, LogSegmentFetcher, LogSegmentScan, StreamAttrEquals,
+    ColumnarBlockOutcome, LogFetchError, LogFetchOutput, LogQuery, LogSegmentFetcher,
+    LogSegmentScan, StreamAttrEquals,
 };
 pub use query_admission::{
     QueryAdmissionController, QueryConcurrencyLimit, QueryPermit, QueryRejected,

--- a/crates/ravel-query/src/log_fetcher.rs
+++ b/crates/ravel-query/src/log_fetcher.rs
@@ -40,8 +40,8 @@ use ravel_catalog::SegmentRef;
 use ravel_logseg::footer::{self, kind};
 use ravel_logseg::stream_dir::StreamDir;
 use ravel_logseg::{
-    AttrValue, BlockScan, ColumnSelection, LogRecord, LogSegError, LogStreamId, Predicate,
-    RlogConfig, RlogReader, ScanStats, read_section,
+    AttrValue, BlockScan, ColumnSelection, ColumnarBlockView, LogRecord, LogSegError, LogStreamId,
+    Predicate, RlogConfig, RlogReader, ScanStats, read_section,
 };
 use ravel_object_store::{GetRange, ObjectStoreBackend, StoreError};
 use ravel_types::TenantHash;
@@ -246,12 +246,7 @@ impl LogSegmentScan {
             .in_scope(|| self.scan.next_block(&self.bytes))
             .map_err(|source| corrupt(&self.key, source))?;
         let Some(mut records) = decoded else {
-            if !self.finished {
-                self.finished = true;
-                let stats = self.scan.stats();
-                self.span.record("blocks_scanned", stats.blocks_scanned);
-                self.span.record("blocks_total", stats.blocks_total);
-            }
+            self.finish();
             return Ok(None);
         };
         // Selective-erasure exclusion (ADR-0064 decision 2), per block rather
@@ -261,6 +256,101 @@ impl LogSegmentScan {
         crate::erasure::retain_log_records(&mut records, &self.erasure);
         Ok(Some(records))
     }
+
+    /// Whether a pending erasure predicate applies to this scan, which is what
+    /// makes [`next_block_columnar`](Self::next_block_columnar) refuse.
+    pub fn erasure_pending(&self) -> bool {
+        !self.erasure.is_empty()
+    }
+
+    /// Columnar counterpart of [`next_block`](Self::next_block) (ADR-0099
+    /// decision 1): the same block, the same surviving rows in the same order,
+    /// handed out as a borrowed [`ColumnarBlockView`] instead of rebuilt
+    /// records. Same object bytes, same pruning, same `decode` span and the same
+    /// block counters recorded on exhaustion.
+    ///
+    /// The returned view borrows this scan, so it must be dropped before the
+    /// next call to either exit.
+    ///
+    /// # This exit refuses when erasure is pending
+    ///
+    /// [`next_block`](Self::next_block) excludes rows matching a pending
+    /// erasure predicate ([`crate::erasure::retain_log_records`], ADR-0064
+    /// decision 2). That exclusion is record-level and there is no columnar
+    /// form of it yet, so a view cannot honour it and this method hands one out
+    /// only when the scan carries no erasure predicate; otherwise it returns
+    /// [`ColumnarBlockOutcome::ErasurePending`] without decoding anything or
+    /// advancing the cursor, and the caller must drain the row exit instead.
+    ///
+    /// Failing closed here is deliberate: the failure mode of getting erasure
+    /// wrong is an erased record served to a client, not a slow query
+    /// (ADR-0099 decision 2).
+    pub fn next_block_columnar(&mut self) -> Result<ColumnarBlockOutcome<'_>, LogFetchError> {
+        if !self.erasure.is_empty() {
+            return Ok(ColumnarBlockOutcome::ErasurePending);
+        }
+        // Exhaustion is reported from the block count rather than from a `None`
+        // out of the cursor. The returned view borrows the cursor for as long as
+        // the caller holds it, which is longer than the counter-recording read
+        // of `scan.stats()` could borrow it for, so the two cannot share one
+        // call site.
+        if self.scan.remaining_blocks() == 0 {
+            self.finish();
+            return Ok(ColumnarBlockOutcome::Exhausted);
+        }
+        // Destructured so entering the span borrows only `span` and the view's
+        // borrow of the cursor is not held by a closure.
+        let Self {
+            bytes,
+            scan,
+            span,
+            key,
+            ..
+        } = self;
+        let entered = span.enter();
+        let decoded = scan.next_block_columnar(bytes);
+        drop(entered);
+        match decoded.map_err(|source| corrupt(key, source))? {
+            Some(view) => Ok(ColumnarBlockOutcome::Block(view)),
+            // Unreachable: a cursor with blocks remaining yields one. Reported
+            // as exhaustion rather than unwrapped, and `finished` is left unset
+            // so a following call still records the counters.
+            None => Ok(ColumnarBlockOutcome::Exhausted),
+        }
+    }
+
+    /// Records the scan's block counters on the `decode` span, exactly once,
+    /// when an exit reports exhaustion.
+    fn finish(&mut self) {
+        if self.finished {
+            return;
+        }
+        self.finished = true;
+        let stats = self.scan.stats();
+        self.span.record("blocks_scanned", stats.blocks_scanned);
+        self.span.record("blocks_total", stats.blocks_total);
+    }
+}
+
+/// What [`LogSegmentScan::next_block_columnar`] produced.
+///
+/// Three outcomes rather than an `Option` because "no view" has two distinct
+/// causes that a caller must not conflate: the scan ran out of blocks, or it
+/// carries a pending erasure predicate the columnar path cannot evaluate. An
+/// `Option` would make the second look like the first and silently truncate a
+/// query's results.
+#[derive(Debug)]
+pub enum ColumnarBlockOutcome<'a> {
+    /// The next surviving block, as a borrowed columnar view.
+    Block(ColumnarBlockView<'a>),
+    /// Every surviving block has been decoded. `Block(view)` with a zero
+    /// surviving-row count is different: that block survived pruning and simply
+    /// held no matching row.
+    Exhausted,
+    /// A pending erasure predicate applies to this scan, so no view is handed
+    /// out. Nothing was decoded and the cursor did not advance; drain
+    /// [`LogSegmentScan::next_block`] instead.
+    ErasurePending,
 }
 
 /// Errors fetching and decoding one RLOG segment. Every variant is a hard

--- a/crates/ravel-query/tests/log_fetcher.rs
+++ b/crates/ravel-query/tests/log_fetcher.rs
@@ -20,8 +20,8 @@ use ravel_cache::{Cache, CacheLimits};
 use ravel_catalog::{SegmentLevel, SegmentRef};
 use ravel_logseg::writer::ObjectIdentity;
 use ravel_logseg::{
-    AttrValue, FieldSel, LogRecord, LogStreamId, Predicate, RlogConfig, RlogWriter,
-    stream_attrs_bytes,
+    AttrValue, ColumnSelection, FieldSel, FieldType, LogRecord, LogStreamId, Predicate, RlogConfig,
+    RlogWriter, stream_attrs_bytes,
 };
 use ravel_object_store::memory::MemoryStore;
 use ravel_object_store::{
@@ -29,7 +29,10 @@ use ravel_object_store::{
     PageToken, PutOptions, PutOutcome, StoreError,
 };
 use ravel_query::erasure::ErasurePredicate;
-use ravel_query::{CacheFetchError, LogQuery, LogSegmentFetcher, StreamAttrEquals};
+use ravel_query::{
+    CacheFetchError, ColumnarBlockOutcome, LogFetchError, LogQuery, LogSegmentFetcher,
+    StreamAttrEquals,
+};
 use ravel_types::TenantHash;
 use ravel_types::accounting::{AccountedOp, QueryAccounting};
 use uuid::Uuid;
@@ -950,4 +953,302 @@ async fn erasure_runs_after_cache_hit() {
             .all(|(k, v)| !(k == "user_id" && *v == AttrValue::Str("u1".into())))),
         "cache-served bytes of the erased subject must not leak"
     );
+}
+
+// --- columnar pass-through (ADR-0099 decision 1) ----------------------------
+
+/// Records with attributes and mixed trace ids, so the columnar comparison
+/// below has something to disagree about beyond `ts`.
+fn columnar_records() -> Vec<LogRecord> {
+    (100..=111)
+        .map(|ts| {
+            let mut r = record_with_attrs(
+                if ts % 3 == 0 { "api" } else { "worker" },
+                ts,
+                if ts % 2 == 0 {
+                    "keep this"
+                } else {
+                    "drop that"
+                },
+                &[
+                    ("user_id".to_string(), AttrValue::Str(format!("u{ts}"))),
+                    ("code".to_string(), AttrValue::I64(ts)),
+                ],
+            );
+            if ts % 4 == 0 {
+                r.trace_id = Some([u8::try_from(ts % 251).unwrap(); 16]);
+            }
+            r
+        })
+        .collect()
+}
+
+/// The columnar pass-through yields the same rows the row API yields for the
+/// same segment: same blocks, same surviving rows in the same order, same field
+/// values, and the same scan counters.
+#[tokio::test]
+async fn columnar_pass_through_yields_the_same_rows_as_the_row_api() {
+    let tenant = TenantHash([9u8; 16]);
+    let mem = MemoryStore::new();
+    let records = columnar_records();
+    let seg_ref = write_object(&mem, "logs/columnar.rlog", &records).await;
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(mem);
+    let fetcher = LogSegmentFetcher::new(store);
+
+    // A selective predicate, so each block's surviving rows are a proper,
+    // non-contiguous subset and a view that ignored them would disagree.
+    let query = LogQuery::new(0, 5000).with_content(Predicate::HasWord {
+        field: FieldSel::Body,
+        word: "keep".into(),
+    });
+
+    let mut rows_scan = fetcher
+        .scan_accounted_with_tenant(
+            &seg_ref,
+            tenant,
+            &query,
+            &ColumnSelection::all(),
+            &QueryAccounting::new(),
+        )
+        .await
+        .expect("open row scan")
+        .expect("in range");
+    let mut col_scan = fetcher
+        .scan_accounted_with_tenant(
+            &seg_ref,
+            tenant,
+            &query,
+            &ColumnSelection::all(),
+            &QueryAccounting::new(),
+        )
+        .await
+        .expect("open columnar scan")
+        .expect("in range");
+
+    let mut blocks = 0usize;
+    let mut rows = 0usize;
+    loop {
+        let want = rows_scan.next_block().expect("row exit");
+        let got = col_scan.next_block_columnar().expect("columnar exit");
+        match (want, got) {
+            (None, ColumnarBlockOutcome::Exhausted) => break,
+            (Some(want), ColumnarBlockOutcome::Block(view)) => {
+                blocks += 1;
+                assert_eq!(
+                    view.surviving_count(),
+                    want.len(),
+                    "block {blocks}: surviving row count"
+                );
+                for (i, r) in want.iter().enumerate() {
+                    assert_eq!(view.ts(i), Some(r.ts_ns), "block {blocks} row {i}: ts");
+                    assert_eq!(
+                        view.observed_ts(i),
+                        Some(r.observed_ts_ns),
+                        "block {blocks} row {i}: observed_ts"
+                    );
+                    assert_eq!(
+                        view.body(i).unwrap_or(b""),
+                        r.body.as_bytes(),
+                        "block {blocks} row {i}: body"
+                    );
+                    assert_eq!(
+                        view.severity_text(i).unwrap_or(b""),
+                        r.severity_text.as_bytes(),
+                        "block {blocks} row {i}: severity_text"
+                    );
+                    assert_eq!(
+                        view.trace_id(i).map(<[u8]>::to_vec),
+                        r.trace_id.map(|t| t.to_vec()),
+                        "block {blocks} row {i}: trace_id"
+                    );
+                    assert_eq!(
+                        view.stream_id(i),
+                        Some(&r.stream_id),
+                        "block {blocks} row {i}: stream identity"
+                    );
+                    assert_eq!(
+                        view.stream_attrs(i),
+                        Some(r.stream_attrs.as_slice()),
+                        "block {blocks} row {i}: resource+scope blob"
+                    );
+                    // The declared keys resolve to a column once per block and
+                    // read the same values the record carries.
+                    let code = view
+                        .resolve_attr("code", FieldType::I64)
+                        .expect("code column");
+                    assert_eq!(
+                        view.i64_at(code.column_id, i).map(AttrValue::I64),
+                        r.attrs
+                            .iter()
+                            .find(|(k, _)| k == "code")
+                            .map(|(_, v)| v.clone()),
+                        "block {blocks} row {i}: code attribute"
+                    );
+                    let uid = view
+                        .resolve_attr("user_id", FieldType::Str)
+                        .expect("user_id column");
+                    assert_eq!(
+                        view.bytes_at(uid.column_id, i),
+                        r.attrs
+                            .iter()
+                            .find(|(k, _)| k == "user_id")
+                            .and_then(|(_, v)| match v {
+                                AttrValue::Str(s) => Some(s.as_bytes()),
+                                _ => None,
+                            }),
+                        "block {blocks} row {i}: user_id attribute"
+                    );
+                    rows += 1;
+                }
+                assert!(
+                    !view.has_attrs_raw_page(),
+                    "block {blocks}: two attributes fit the column budget, no spill"
+                );
+            }
+            (want, got) => panic!(
+                "block {blocks}: exits disagree (row exit {:?}, columnar exit {got:?})",
+                want.map(|w| w.len())
+            ),
+        }
+    }
+    assert!(blocks > 1, "the fixture must span several blocks");
+    assert_eq!(rows, 6, "six of the twelve records carry the word 'keep'");
+    assert_eq!(
+        rows_scan.stats(),
+        col_scan.stats(),
+        "both exits must account for the same blocks and pages"
+    );
+}
+
+/// The row path's accounting and erasure behaviour is unchanged by the new
+/// exit: one GET recorded, erased rows still dropped -- and the columnar exit
+/// refuses outright while an erasure predicate is pending rather than handing
+/// out a view it cannot filter.
+#[tokio::test]
+async fn columnar_pass_through_refuses_while_erasure_is_pending() {
+    let tenant = TenantHash([11u8; 16]);
+    let mem = Arc::new(MemoryStore::new());
+    let records = erasure_records();
+    let seg_ref = write_object(&mem, "logs/columnar_erase.rlog", &records).await;
+    let counting = Arc::new(CountingStore::new(mem));
+    let fetcher = LogSegmentFetcher::new(counting.clone() as Arc<dyn ObjectStoreBackend>);
+
+    let query = LogQuery::new(0, 5000).with_erasure(vec![erase("user_id", "u1")]);
+    let accounting = QueryAccounting::new();
+    let mut scan = fetcher
+        .scan_accounted_with_tenant(
+            &seg_ref,
+            tenant,
+            &query,
+            &ColumnSelection::all(),
+            &accounting,
+        )
+        .await
+        .expect("open scan")
+        .expect("in range");
+
+    assert!(scan.erasure_pending());
+    assert!(
+        matches!(
+            scan.next_block_columnar().expect("columnar exit"),
+            ColumnarBlockOutcome::ErasurePending
+        ),
+        "a pending erasure predicate must not yield a columnar view"
+    );
+    // The refusal decoded nothing and did not advance the cursor, so the row
+    // path still sees every block.
+    let before = scan.remaining_blocks();
+    assert!(before > 0);
+    assert_eq!(scan.stats().blocks_scanned, 0);
+
+    let mut kept = Vec::new();
+    while let Some(rows) = scan.next_block().expect("row exit") {
+        kept.extend(rows);
+    }
+    assert_eq!(kept.len(), 6, "erasure still drops the matching rows");
+    assert!(
+        kept.iter().all(|r| r
+            .attrs
+            .iter()
+            .all(|(k, v)| !(k == "user_id" && *v == AttrValue::Str("u1".into())))),
+        "no erased subject may survive the row path"
+    );
+    assert_eq!(counting.get_count(), 1, "one whole-object GET");
+    let snapshot = accounting.snapshot();
+    assert_eq!(
+        snapshot.s3_requests(AccountedOp::Get),
+        1,
+        "the row path's accounting is unchanged"
+    );
+    assert!(snapshot.s3_bytes(AccountedOp::Get) > 0);
+}
+
+/// A corrupt block is a typed `LogFetchError::Corrupt` through the columnar
+/// exit exactly as through the row exit, never a panic.
+#[tokio::test]
+async fn corrupt_block_is_a_typed_error_through_the_columnar_pass_through() {
+    let tenant = TenantHash([13u8; 16]);
+    let mem = MemoryStore::new();
+    let records = columnar_records();
+    let seg_ref = write_object(&mem, "logs/columnar_corrupt.rlog", &records).await;
+    // Flip a byte inside the BLOCKS region, so the footer and every section
+    // still parse and the failure is the block's own crc mismatch, reached
+    // through whichever exit decodes the block.
+    let good = mem
+        .get(&seg_ref.data_object_key, GetRange::Full)
+        .await
+        .expect("get")
+        .data
+        .to_vec();
+    let blocks = ravel_logseg::footer::open(&good)
+        .expect("footer")
+        .section(ravel_logseg::footer::kind::BLOCKS)
+        .expect("BLOCKS section")
+        .offset;
+    let mut bad = good.clone();
+    let at = usize::try_from(blocks).expect("offset fits") + 1;
+    bad[at] ^= 0xff;
+    mem.put(
+        &seg_ref.data_object_key,
+        bytes::Bytes::from(bad),
+        PutOptions::default(),
+    )
+    .await
+    .expect("overwrite with corrupt bytes");
+
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(mem);
+    let fetcher = LogSegmentFetcher::new(store);
+    let query = LogQuery::new(0, 5000);
+
+    let mut scan = fetcher
+        .scan_accounted_with_tenant(
+            &seg_ref,
+            tenant,
+            &query,
+            &ColumnSelection::all(),
+            &QueryAccounting::new(),
+        )
+        .await
+        .expect("open scan")
+        .expect("in range");
+    let err = scan
+        .next_block_columnar()
+        .expect_err("the columnar exit must reject the corrupt block");
+    assert!(matches!(err, LogFetchError::Corrupt { .. }), "{err:?}");
+
+    let mut scan = fetcher
+        .scan_accounted_with_tenant(
+            &seg_ref,
+            tenant,
+            &query,
+            &ColumnSelection::all(),
+            &QueryAccounting::new(),
+        )
+        .await
+        .expect("open scan")
+        .expect("in range");
+    let err = scan
+        .next_block()
+        .expect_err("the row exit must reject the corrupt block");
+    assert!(matches!(err, LogFetchError::Corrupt { .. }), "{err:?}");
 }


### PR DESCRIPTION
BlockScan decoded every RLOG block into columnar form and then threw that
form away, rebuilding each surviving row as a LogRecord before anything
outside the crate could see it. The SQL scan then rebuilt columns again
for Arrow, so a string cell crossed several allocations for no reason.

BlockScan gains a second exit that hands out what it already decoded: a
borrowed view over the block, the stream and field directories, and the
surviving row indices. The view exposes accessors only, never a column's
storage type, so a later change can store string columns in dictionary
form without touching a caller. DecodedBlock stays internal.

The view also reports whether the block carries an attrs_raw page, read
from page descriptors without decoding, which is the eligibility signal
the logs scan needs to know a fast path may skip canonical-attr decode.

next_block, scan, scan_pruned, and the ranged reader are reimplemented
over the same primitive and keep byte-identical behaviour, so compaction
and its differential tests are unaffected. LogSegmentScan gains the
matching pass-through with the same accounting and erasure hooks.

No Arrow types enter either crate and no persistent format changes: page
layout, Enc tags, and on-disk bytes are untouched.

Nothing consumes the view yet. #415 is the caller and lands next.

Fixes: #413
Refs: #360
