### PR TITLE
feat(logseg): observe the RLOG dynamic-column budget

### DIFF
--- a/crates/ravel-ingest/src/log_metrics.rs
+++ b/crates/ravel-ingest/src/log_metrics.rs
@@ -129,6 +129,20 @@ pub struct LogIngestMetrics {
     /// Indexed fields dropped from POSTINGS for exceeding the per-field
     /// distinct-value cap (ADR-0049 decision 4), summed over objects.
     postings_capped_fields_total: AtomicU64,
+    /// Distinct `(name, type)` pairs that received a real dynamic column,
+    /// summed over flushed objects (ADR-0100 decision 1).
+    dynamic_columns_used_total: AtomicU64,
+    /// Distinct `(name, type)` pairs that overflowed the `max_dynamic_columns`
+    /// budget and folded into `attrs_raw`, summed over flushed objects
+    /// (ADR-0100 decision 1). A sustained rise means loads are silently losing
+    /// columnar access to attributes past the budget.
+    dynamic_columns_overflowed_total: AtomicU64,
+    /// Largest `dynamic_columns_used` of any single flushed object seen so far
+    /// (a running maximum, not a sum). A total cannot show budget pressure
+    /// before the cap is crossed; this maximum can, so an operator sees a load
+    /// approaching `max_dynamic_columns` before any object overflows it
+    /// (ADR-0100 decision 1).
+    dynamic_columns_used_max: AtomicU64,
     /// Per-shard count of flushes whose flush task has been spawned but has
     /// not yet acked its waiters (ADR-0067 decisions 1-2, the log-pipeline
     /// counterpart of [`crate::IngestMetrics`]'s own gauge). Keyed by shard
@@ -170,6 +184,9 @@ pub struct LogIngestMetricsSnapshot {
     pub postings_indexed_fields_total: u64,
     pub postings_distinct_values_total: u64,
     pub postings_capped_fields_total: u64,
+    pub dynamic_columns_used_total: u64,
+    pub dynamic_columns_overflowed_total: u64,
+    pub dynamic_columns_used_max: u64,
 }
 
 impl LogIngestMetrics {
@@ -307,6 +324,19 @@ impl LogIngestMetrics {
             .fetch_add(stats.postings_distinct_total, Ordering::Relaxed);
         self.postings_capped_fields_total
             .fetch_add(u64::from(stats.postings_capped_fields), Ordering::Relaxed);
+        // Dynamic-column budget (ADR-0100 decision 1). Folded for every object,
+        // not only POSTINGS-carrying ones: an object with no indexed field
+        // still assigns dynamic columns and can overflow the budget. The used
+        // count also feeds a running maximum, which shows budget pressure
+        // before any object crosses the cap.
+        self.dynamic_columns_used_total
+            .fetch_add(u64::from(stats.dynamic_columns_used), Ordering::Relaxed);
+        self.dynamic_columns_overflowed_total.fetch_add(
+            u64::from(stats.dynamic_columns_overflowed),
+            Ordering::Relaxed,
+        );
+        self.dynamic_columns_used_max
+            .fetch_max(u64::from(stats.dynamic_columns_used), Ordering::Relaxed);
     }
 
     pub fn snapshot(&self) -> LogIngestMetricsSnapshot {
@@ -337,6 +367,11 @@ impl LogIngestMetrics {
                 .postings_distinct_values_total
                 .load(Ordering::Relaxed),
             postings_capped_fields_total: self.postings_capped_fields_total.load(Ordering::Relaxed),
+            dynamic_columns_used_total: self.dynamic_columns_used_total.load(Ordering::Relaxed),
+            dynamic_columns_overflowed_total: self
+                .dynamic_columns_overflowed_total
+                .load(Ordering::Relaxed),
+            dynamic_columns_used_max: self.dynamic_columns_used_max.load(Ordering::Relaxed),
         }
     }
 }
@@ -467,6 +502,8 @@ mod tests {
                     postings_indexed_fields: 3,
                     postings_distinct_total: 40,
                     postings_distinct_max: 25,
+                    dynamic_columns_used: 7,
+                    dynamic_columns_overflowed: 2,
                 })
             },
             LogIngestMetricsSnapshot {
@@ -475,6 +512,9 @@ mod tests {
                 postings_indexed_fields_total: 3,
                 postings_distinct_values_total: 40,
                 postings_capped_fields_total: 1,
+                dynamic_columns_used_total: 7,
+                dynamic_columns_overflowed_total: 2,
+                dynamic_columns_used_max: 7,
                 ..Default::default()
             },
         );
@@ -498,5 +538,33 @@ mod tests {
         assert_eq!(snap.flushes_by_age, 2);
         assert_eq!(snap.buffered_bytes_total, 15);
         assert_eq!(snap.buffered_records_total, 3);
+    }
+
+    #[test]
+    fn dynamic_column_counters_and_used_max_fold_into_snapshot() {
+        // Two objects, the wider one first (used 8) then a narrower one (used
+        // 5). The used and overflowed counts sum; the used_max keeps the larger
+        // 8. A sum would report 13 and a store-latest would report 5, so the
+        // fixture forces the maximum fold to be the real thing that shows budget
+        // pressure a total cannot (ADR-0100 decision 1).
+        let metrics = LogIngestMetrics::default();
+        metrics.record_postings(ravel_logseg::writer::WriteStats {
+            dynamic_columns_used: 8,
+            dynamic_columns_overflowed: 3,
+            ..Default::default()
+        });
+        metrics.record_postings(ravel_logseg::writer::WriteStats {
+            dynamic_columns_used: 5,
+            dynamic_columns_overflowed: 0,
+            ..Default::default()
+        });
+
+        let snap = metrics.snapshot();
+        assert_eq!(snap.dynamic_columns_used_total, 13, "8 + 5");
+        assert_eq!(snap.dynamic_columns_overflowed_total, 3, "3 + 0");
+        assert_eq!(
+            snap.dynamic_columns_used_max, 8,
+            "running maximum keeps the wider object's used count"
+        );
     }
 }

--- a/crates/ravel-ingest/src/log_metrics.rs
+++ b/crates/ravel-ingest/src/log_metrics.rs
@@ -555,13 +555,16 @@ mod tests {
         });
         metrics.record_postings(ravel_logseg::writer::WriteStats {
             dynamic_columns_used: 5,
-            dynamic_columns_overflowed: 0,
+            dynamic_columns_overflowed: 2,
             ..Default::default()
         });
 
         let snap = metrics.snapshot();
         assert_eq!(snap.dynamic_columns_used_total, 13, "8 + 5");
-        assert_eq!(snap.dynamic_columns_overflowed_total, 3, "3 + 0");
+        // Both writes overflow, and by different amounts, so this sum
+        // distinguishes a `fetch_add` fold from a `fetch_max` one: a maximum
+        // would report 3 here.
+        assert_eq!(snap.dynamic_columns_overflowed_total, 5, "3 + 2");
         assert_eq!(
             snap.dynamic_columns_used_max, 8,
             "running maximum keeps the wider object's used count"

--- a/crates/ravel-logseg/src/writer.rs
+++ b/crates/ravel-logseg/src/writer.rs
@@ -111,6 +111,19 @@ pub struct WriteStats {
     /// Largest distinct-value count of any single non-capped indexed field in
     /// this object, or 0 when no field emitted a posting list.
     pub postings_distinct_max: u32,
+    /// Distinct `(name, type)` pairs that received a real dynamic column in
+    /// this object (docs/log-segment-format.md "FIELD_DIR"). Shaped like the
+    /// POSTINGS counters above: aggregate-only, no per-field label (the
+    /// ADR-0044 allowlist forbids one), so a `/metrics` renderer sees a used
+    /// count and, paired with `dynamic_columns_overflowed`, budget pressure
+    /// without a column name ever leaving this struct.
+    pub dynamic_columns_used: u32,
+    /// Distinct `(name, type)` pairs that found the `max_dynamic_columns`
+    /// budget full and folded into the `attrs_raw` overflow column instead of
+    /// getting their own column. Nonzero exactly when a load crossed the
+    /// budget, which is otherwise silent (ADR-0100 decision 1). Same
+    /// aggregate-only, no-per-field-label shaping as the fields above.
+    pub dynamic_columns_overflowed: u32,
 }
 
 /// The maximum byte length of a string value inserted into the bloom by exact
@@ -298,6 +311,12 @@ impl RlogWriter {
                 }
             }
         }
+        // Both budget numbers are known here without a second pass over the
+        // records: `distinct` holds every distinct `(name, type)` pair, and the
+        // loop below gives the first `max_dynamic_columns` of them a column. The
+        // used count is what `columns` ends with; the overflow is the rest, the
+        // pairs that fold into `attrs_raw` (docs/adrs/0100 decision 1).
+        let distinct_total = distinct.len();
         let mut column_of: HashMap<(String, u8), u32> = HashMap::new();
         let mut columns: Vec<(String, FieldType, u32)> = Vec::new();
         for (idx, (name, ty_byte)) in distinct.into_iter().enumerate() {
@@ -309,6 +328,8 @@ impl RlogWriter {
             column_of.insert((name.clone(), ty_byte), column_id);
             columns.push((name, ty, column_id));
         }
+        let dynamic_columns_used = columns.len() as u32;
+        let dynamic_columns_overflowed = distinct_total.saturating_sub(columns.len()) as u32;
         let ty_of_column: HashMap<u32, FieldType> =
             columns.iter().map(|(_, ty, id)| (*id, *ty)).collect();
 
@@ -687,6 +708,8 @@ impl RlogWriter {
                 postings_indexed_fields,
                 postings_distinct_total,
                 postings_distinct_max,
+                dynamic_columns_used,
+                dynamic_columns_overflowed,
             },
         ))
     }
@@ -1593,11 +1616,22 @@ mod tests {
     #[test]
     fn write_stats_report_no_postings_when_no_field_configured() {
         // No indexed fields: no POSTINGS section, so every write-side POSTINGS
-        // counter reports zero (absence is always legal, decision 5).
+        // counter reports zero (absence is always legal, decision 5). The
+        // dynamic-column counters are not POSTINGS counters: `base_record`'s
+        // stream blob carries `lib` as a scope-level i64, a numeric
+        // stream-level key, which draws one dynamic column even with no
+        // per-record attribute (docs/log-segment-format.md "FIELD_DIR"), so
+        // `dynamic_columns_used` is 1 and nothing overflows.
         let mut w = RlogWriter::new(RlogConfig::default(), identity());
         w.push(base_record(0, 0)).expect("push");
         let (_obj, stats) = w.finish_with_stats().expect("finish");
-        assert_eq!(stats, WriteStats::default());
+        assert_eq!(
+            stats,
+            WriteStats {
+                dynamic_columns_used: 1,
+                ..WriteStats::default()
+            }
+        );
     }
 
     #[test]
@@ -1653,5 +1687,146 @@ mod tests {
             })
             .expect("scan");
         assert_eq!(rows.len(), 1);
+    }
+
+    /// Bit-pattern attribute equality (CLAUDE.md: float compares use
+    /// `f64::to_bits`, never `==`, so -0.0 and a NaN payload are significant).
+    fn attr_eq(a: &AttrValue, b: &AttrValue) -> bool {
+        match (a, b) {
+            (AttrValue::F64(x), AttrValue::F64(y)) => x.to_bits() == y.to_bits(),
+            _ => a == b,
+        }
+    }
+
+    /// The empty resource+scope blob: no stream-level key, so the dynamic-column
+    /// budget below is spent purely on per-record attributes and `lib`/
+    /// `service.name` from `attrs_blob` do not perturb the count.
+    fn empty_stream_blob() -> Vec<u8> {
+        stream_attrs_bytes(&[], "", "", &[])
+    }
+
+    #[test]
+    fn dynamic_column_budget_reports_used_and_overflowed() {
+        // Budget of 3 over 5 distinct (name, type) pairs. The records ARRIVE in
+        // reverse-lexicographic order (e, d, c, b, a), so an arrival-order
+        // selection would give columns to e, d, c; the writer selects
+        // lexicographically, so a, b, c win and d, e overflow. The counts alone
+        // (used 3, overflowed 2) hold under either rule -- the FIELD_DIR
+        // membership check below is what pins the order.
+        let cfg = RlogConfig {
+            max_dynamic_columns: 3,
+            ..RlogConfig::default()
+        };
+        let blob = empty_stream_blob();
+        let mut w = RlogWriter::new(cfg, identity());
+        for (i, name) in ["e", "d", "c", "b", "a"].iter().enumerate() {
+            let mut r = base_record(0, i as i64);
+            r.stream_attrs = blob.clone();
+            r.attrs = vec![((*name).to_string(), AttrValue::Str(format!("v_{name}")))];
+            w.push(r).expect("push");
+        }
+        let (obj, stats) = w.finish_with_stats().expect("finish");
+
+        assert_eq!(stats.dynamic_columns_used, 3, "first 3 pairs get a column");
+        assert_eq!(stats.dynamic_columns_overflowed, 2, "the other 2 overflow");
+
+        let footer = open(&obj).expect("open");
+        let fd = read_field_dir(&obj, &footer);
+        assert_eq!(fd.len(), 3, "exactly the budget of columns");
+        for name in ["a", "b", "c"] {
+            assert!(
+                fd.column(name, FieldType::Str).is_some(),
+                "lexicographic winner {name} must have a column, not the arrival-order pick"
+            );
+        }
+        for name in ["d", "e"] {
+            assert!(
+                fd.column(name, FieldType::Str).is_none(),
+                "overflow key {name} must have no column"
+            );
+        }
+    }
+
+    #[test]
+    fn budget_overflow_folds_to_attrs_raw_without_value_loss() {
+        // Budget of 4 over 6 distinct names, mixed types including f64(-0.0)
+        // (columnar) and f64(1.5)/f64(NaN payload) (overflow), so both the
+        // columnar and the attrs_raw paths carry a float whose bits must
+        // survive. Lexicographic order: a,b,c,d get columns; e,f overflow.
+        let cfg = RlogConfig {
+            max_dynamic_columns: 4,
+            ..RlogConfig::default()
+        };
+        let blob = empty_stream_blob();
+        // Three records, each carrying all six attributes with per-record
+        // values, so every column holds a real per-row value and every record
+        // has two overflow attributes.
+        let nan = f64::from_bits(0x7ff8_0000_0000_0abc);
+        let attrs_for = |rec: i64| -> Vec<(String, AttrValue)> {
+            vec![
+                ("a".into(), AttrValue::I64(rec)),
+                ("b".into(), AttrValue::Str(format!("s{rec}"))),
+                ("c".into(), AttrValue::Bool(rec % 2 == 0)),
+                (
+                    "d".into(),
+                    AttrValue::F64(if rec == 0 { -0.0 } else { rec as f64 }),
+                ),
+                (
+                    "e".into(),
+                    AttrValue::F64(if rec == 2 { nan } else { 1.5 * rec as f64 }),
+                ),
+                (
+                    "f".into(),
+                    AttrValue::Bytes(vec![rec as u8, 0xff, rec as u8]),
+                ),
+            ]
+        };
+
+        let mut w = RlogWriter::new(cfg, identity());
+        for rec in 0..3i64 {
+            let mut r = base_record(0, rec);
+            r.stream_attrs = blob.clone();
+            r.attrs = attrs_for(rec);
+            w.push(r).expect("push");
+        }
+        let (obj, stats) = w.finish_with_stats().expect("finish");
+        assert_eq!(stats.dynamic_columns_used, 4);
+        assert_eq!(stats.dynamic_columns_overflowed, 2, "e and f overflow");
+
+        // e and f are not columnar; they can only be read back through attrs_raw.
+        let footer = open(&obj).expect("open");
+        let fd = read_field_dir(&obj, &footer);
+        assert!(fd.column("e", FieldType::F64).is_none());
+        assert!(fd.column("f", FieldType::Bytes).is_none());
+
+        // Every attribute of every record reads back with its exact value and
+        // type, columnar and overflowed alike -- nothing dropped or corrupted
+        // at or across the budget boundary.
+        let reader = RlogReader::new(&obj, &RlogConfig::default()).expect("open reader");
+        let (rows, _) = reader.scan(&Predicate::And(Vec::new())).expect("scan");
+        assert_eq!(rows.len(), 3);
+        for rec in 0..3i64 {
+            let row = rows
+                .iter()
+                .find(|r| r.ts_ns == rec)
+                .unwrap_or_else(|| panic!("record ts {rec} present"));
+            let got: HashMap<&str, &AttrValue> =
+                row.attrs.iter().map(|(k, v)| (k.as_str(), v)).collect();
+            let want = attrs_for(rec);
+            assert_eq!(
+                got.len(),
+                want.len(),
+                "record {rec}: no attribute added or dropped"
+            );
+            for (name, value) in &want {
+                let read = got
+                    .get(name.as_str())
+                    .unwrap_or_else(|| panic!("record {rec} attribute {name} read back"));
+                assert!(
+                    attr_eq(read, value),
+                    "record {rec} attribute {name}: read {read:?} != written {value:?}"
+                );
+            }
+        }
     }
 }

--- a/docs/guides/operations.md
+++ b/docs/guides/operations.md
@@ -430,6 +430,25 @@ section:
   flushed object for exceeding the per-field distinct-value cap (ADR-0049
   decision 4).
 
+### Dynamic-column budget metrics (ADR-0100)
+
+Each RLOG object gives the first `max_dynamic_columns` (default 1000) distinct
+`(name, type)` attribute pairs a real typed column, ordered lexicographically
+by name bytes then type byte; the rest fold into the `attrs_raw` overflow
+column and lose columnar access. These `ravel_logs_dynamic_columns_*` metrics
+render at `GET /metrics` for the log ingest pipeline with `mode` and `signal`
+labels, so an operator can see a load approaching or crossing the budget
+instead of it being silent (ADR-0100 decision 1).
+
+- `ravel_logs_dynamic_columns_used_total` (counter): distinct `(name, type)`
+  pairs that received a real dynamic column, summed across flushed objects.
+- `ravel_logs_dynamic_columns_overflowed_total` (counter): distinct
+  `(name, type)` pairs that overflowed the budget and folded into `attrs_raw`,
+  summed across flushed objects. Nonzero means some loads crossed the budget.
+- `ravel_logs_dynamic_columns_used_max` (gauge): the largest per-object used
+  count seen so far. It rises toward `max_dynamic_columns` before any object
+  overflows, so it signals budget pressure a total cannot show.
+
 ### Query-side prune-selectivity metrics
 
 `ravel_logs_prune_*` renders at `GET /metrics` for the logs query path.

--- a/services/ravel-server/src/metrics.rs
+++ b/services/ravel-server/src/metrics.rs
@@ -3445,6 +3445,82 @@ mod tests {
         }
     }
 
+    /// The dynamic-column budget family (ADR-0100 decision 1) renders its three
+    /// samples, each labelled with exactly `{mode, signal="logs"}`.
+    ///
+    /// A sibling of `postings_family_carries_only_allowlisted_labels` rather
+    /// than an addition to it: that test filters the `ravel_logs_postings_`
+    /// prefix and asserts an exact sample count, so these three names fall
+    /// outside its net entirely. Without this, a stray per-attribute-name label
+    /// on the budget family would violate the ADR-0044 allowlist with no test
+    /// failing.
+    #[test]
+    fn dynamic_columns_family_carries_only_allowlisted_labels() {
+        let ingest = vec![
+            IngestPipelineSnapshot::from_log_metrics(LogIngestMetricsSnapshot {
+                dynamic_columns_used_total: 13,
+                dynamic_columns_overflowed_total: 5,
+                dynamic_columns_used_max: 8,
+                ..Default::default()
+            }),
+            IngestPipelineSnapshot::from_metrics(IngestMetricsSnapshot::default()),
+            IngestPipelineSnapshot::from_span_metrics(SpanIngestMetricsSnapshot::default()),
+        ];
+        let body = render(
+            Mode::Gateway,
+            &populated_store_snapshot(),
+            &ingest,
+            &CatalogCountersSnapshot::default(),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            &AdmissionCountersSnapshot::default(),
+            &[],
+            0,
+            IngestBufferBudgetSnapshot::default(),
+            None,
+            None,
+            &[],
+        );
+
+        let lines: Vec<&str> = body
+            .lines()
+            .filter(|l| l.starts_with("ravel_logs_dynamic_columns_"))
+            .collect();
+        // Three metrics, one sample each: only the log pipeline carries them.
+        assert_eq!(
+            lines.len(),
+            3,
+            "one sample per dynamic-column metric, log pipeline only:\n{body}"
+        );
+
+        for line in &lines {
+            let labels = line
+                .split_once('{')
+                .and_then(|(_, rest)| rest.split_once('}'))
+                .map(|(inner, _)| inner)
+                .expect("sample carries a label block");
+            let keys: HashSet<&str> = labels
+                .split(',')
+                .map(|kv| kv.split_once('=').expect("label is key=value").0)
+                .collect();
+            assert_eq!(
+                keys,
+                HashSet::from(["mode", "signal"]),
+                "a dynamic-column sample must carry only {{mode, signal}}, never an \
+                 attribute key (ADR-0044): {line}"
+            );
+            assert!(
+                line.contains("signal=\"logs\""),
+                "the dynamic-column budget is a log-only family: {line}"
+            );
+        }
+    }
+
     /// The prune-selectivity family renders its three counters,
     /// each labelled with exactly `{mode, signal="logs"}` and nothing more.
     /// Rendered directly rather than through the process-global so the values

--- a/services/ravel-server/src/metrics.rs
+++ b/services/ravel-server/src/metrics.rs
@@ -600,6 +600,13 @@ pub struct PostingsCounters {
     pub indexed_fields_total: u64,
     pub distinct_values_total: u64,
     pub capped_fields_total: u64,
+    /// Dynamic-column budget counters (ADR-0100 decision 1). `used_total` and
+    /// `overflowed_total` are cumulative over flushed objects;
+    /// `used_max` is a running maximum of one object's used count, so an
+    /// operator sees budget pressure before any object crosses the cap.
+    pub dynamic_columns_used_total: u64,
+    pub dynamic_columns_overflowed_total: u64,
+    pub dynamic_columns_used_max: u64,
 }
 
 impl IngestPipelineSnapshot {
@@ -651,6 +658,9 @@ impl IngestPipelineSnapshot {
                 indexed_fields_total: snapshot.postings_indexed_fields_total,
                 distinct_values_total: snapshot.postings_distinct_values_total,
                 capped_fields_total: snapshot.postings_capped_fields_total,
+                dynamic_columns_used_total: snapshot.dynamic_columns_used_total,
+                dynamic_columns_overflowed_total: snapshot.dynamic_columns_overflowed_total,
+                dynamic_columns_used_max: snapshot.dynamic_columns_used_max,
             }),
             metadata_sink: None,
         }
@@ -976,6 +986,12 @@ fn render_ingest_family(out: &mut String, mode: Mode, pipelines: &[IngestPipelin
 /// distinct-per-field without any field-name label, which the ADR-0044 label
 /// allowlist forbids. The prune-selectivity metric is rendered separately, off
 /// the query path's DataFusion counters.
+///
+/// The same family also carries the dynamic-column budget counters (ADR-0100
+/// decision 1): `ravel_logs_dynamic_columns_used_total` and
+/// `_overflowed_total` are cumulative, and `ravel_logs_dynamic_columns_used_max`
+/// is a gauge (a running per-object maximum), all under the same `{mode, signal}`
+/// labels with no per-field dimension.
 fn render_logs_postings_family(out: &mut String, mode: Mode, pipelines: &[IngestPipelineSnapshot]) {
     fn labels(mode: Mode, signal: Signal) -> [Label; 2] {
         [Label::Mode(mode), Label::Signal(signal)]
@@ -987,7 +1003,7 @@ fn render_logs_postings_family(out: &mut String, mode: Mode, pipelines: &[Ingest
     // Each metric is one header then one sample per pipeline that builds
     // postings, keeping the zero-is-not-absence discipline the other families
     // keep for a configured-but-idle pipeline.
-    let metrics: [PostingsMetric; 5] = [
+    let metrics: [PostingsMetric; 7] = [
         (
             "ravel_logs_postings_objects_total",
             "Flushed log objects that carried a POSTINGS section, by signal (the denominator for average section bytes per indexed object).",
@@ -1013,6 +1029,16 @@ fn render_logs_postings_family(out: &mut String, mode: Mode, pipelines: &[Ingest
             "Indexed fields dropped from POSTINGS for exceeding the per-field distinct-value cap (ADR-0049 decision 4), summed over objects, by signal.",
             |p| p.capped_fields_total,
         ),
+        (
+            "ravel_logs_dynamic_columns_used_total",
+            "Distinct (name, type) attribute pairs that received a real dynamic column, summed over flushed log objects, by signal (ADR-0100 decision 1).",
+            |p| p.dynamic_columns_used_total,
+        ),
+        (
+            "ravel_logs_dynamic_columns_overflowed_total",
+            "Distinct (name, type) attribute pairs that overflowed the max_dynamic_columns budget and folded into attrs_raw, summed over flushed log objects, by signal (ADR-0100 decision 1).",
+            |p| p.dynamic_columns_overflowed_total,
+        ),
     ];
 
     for (name, help, get) in metrics {
@@ -1021,6 +1047,27 @@ fn render_logs_postings_family(out: &mut String, mode: Mode, pipelines: &[Ingest
             if let Some(postings) = &pipeline.postings {
                 write_sample(out, name, &labels(mode, pipeline.signal), get(postings));
             }
+        }
+    }
+
+    // The per-object maximum of dynamic_columns_used. A running maximum, not a
+    // cumulative sum, so it is a gauge and its name carries no `_total` suffix
+    // (ADR-0100 decision 1: it shows budget pressure before the cap is crossed,
+    // which a total cannot).
+    write_header(
+        out,
+        "ravel_logs_dynamic_columns_used_max",
+        "Largest per-object dynamic-column count seen so far, by signal: the budget-pressure gauge that rises before any object overflows max_dynamic_columns (ADR-0100 decision 1).",
+        "gauge",
+    );
+    for pipeline in pipelines {
+        if let Some(postings) = &pipeline.postings {
+            write_sample(
+                out,
+                "ravel_logs_dynamic_columns_used_max",
+                &labels(mode, pipeline.signal),
+                postings.dynamic_columns_used_max,
+            );
         }
     }
 }

--- a/services/ravel-server/src/postings_config.rs
+++ b/services/ravel-server/src/postings_config.rs
@@ -351,10 +351,16 @@ mod tests {
         let (obj, stats) = writer.finish_with_stats().expect("finish");
 
         // Every POSTINGS counter is zero: no section, no fields, no distinct
-        // values, no capped fields, no bytes.
+        // values, no capped fields, no bytes. The dynamic-column counters are
+        // not POSTINGS counters (ADR-0100): the per-record `http.status_code`
+        // draws one dynamic column, so `dynamic_columns_used` is 1 and nothing
+        // overflows.
         assert_eq!(
             stats,
-            WriteStats::default(),
+            WriteStats {
+                dynamic_columns_used: 1,
+                ..WriteStats::default()
+            },
             "an absent field list must leave every POSTINGS counter at its default"
         );
         // And the object still scans: probing an unindexed field prunes nothing


### PR DESCRIPTION
Makes the RLOG per-object dynamic-column budget observable, so a load that crosses it stops being silent. First task of #421 (ADR-0100 decision 1).

`RlogConfig::max_dynamic_columns` gives a real typed column to the first N distinct `(name, type)` pairs of an object, lexicographically by name bytes then type byte. Everything past the cap folds into `attrs_raw`, and nothing told the caller it happened: `WriteStats` counted POSTINGS caps and carried no dynamic-column counter at all.

- `WriteStats` gains `dynamic_columns_used` and `dynamic_columns_overflowed`, shaped like the ADR-0049 POSTINGS counters: aggregate-only, no per-field label, so no attribute name can reach `/metrics` (ADR-0044).
- `LogIngestMetrics` folds both into cumulative totals plus a per-object maximum of used, which is what shows budget pressure *before* the cap is crossed.
- Three metrics render: `ravel_logs_dynamic_columns_used_total`, `_overflowed_total`, and `ravel_logs_dynamic_columns_used_max` as a gauge (a running maximum, not a cumulative sum, so no `_total` suffix).
- The budget behaviour itself is asserted, not changed. Non-test code is a pure addition: six executable lines, zero deletions outside tests, so the selection order, the cap boundary, and the `attrs_raw` fold are untouched by construction. The golden fixture test confirms no persisted RLOG byte moved.

Tests pin the parts that were previously unproven: selection is lexicographic and not arrival-ordered (records arrive reverse-lexicographically, so an arrival-order implementation fails), every overflowed attribute reads back through `attrs_raw` bit-exact including `-0.0` and a NaN payload, and the ingest fold is a real sum plus a real maximum.

The second commit closes two coverage gaps an adversarial review found in the first, both demonstrated failing before being fixed.

Fixes: #425
