### PR TITLE
fix(ingest-router): reject zero OIDC JWKS refresh interval

### DIFF
--- a/services/ravel-ingest-router/src/config.rs
+++ b/services/ravel-ingest-router/src/config.rs
@@ -421,6 +421,12 @@ impl Cli {
                 if self.oidc_audiences.iter().any(|a| a.is_empty()) {
                     anyhow::bail!("--oidc-audience must be non-empty");
                 }
+                if self.oidc_jwks_refresh_interval_secs == 0 {
+                    anyhow::bail!(
+                        "--oidc-jwks-refresh-interval-secs must be at least 1: a zero interval \
+                         cannot drive the JWKS refresh timer"
+                    );
+                }
                 Some(OidcSettings {
                     issuer: issuer.to_string(),
                     jwks_url: jwks_url.to_string(),
@@ -689,5 +695,53 @@ mod tests {
             .into_config()
             .expect_err("subset size 0 must fail");
         assert!(err.to_string().contains("--subset-size"));
+    }
+
+    #[test]
+    fn oidc_jwks_refresh_interval_zero_rejected() {
+        let err = cli(&[
+            "--key-source",
+            "canonical-tenant",
+            "--oidc-issuer",
+            "https://issuer.example.com",
+            "--oidc-jwks-url",
+            "https://issuer.example.com/jwks",
+            "--oidc-audience",
+            "ravel",
+            "--oidc-jwks-refresh-interval-secs",
+            "0",
+        ])
+        .into_config()
+        .expect_err("a zero JWKS refresh interval must fail");
+        assert!(
+            err.to_string()
+                .contains("--oidc-jwks-refresh-interval-secs"),
+            "error must name the flag, got: {err}"
+        );
+    }
+
+    #[test]
+    fn oidc_jwks_refresh_interval_one_accepted() {
+        let config = cli(&[
+            "--key-source",
+            "canonical-tenant",
+            "--oidc-issuer",
+            "https://issuer.example.com",
+            "--oidc-jwks-url",
+            "https://issuer.example.com/jwks",
+            "--oidc-audience",
+            "ravel",
+            "--oidc-jwks-refresh-interval-secs",
+            "1",
+        ])
+        .into_config()
+        .expect("the smallest positive refresh interval is valid");
+        match config.key {
+            KeyConfig::CanonicalTenant(settings) => {
+                let oidc = settings.oidc.expect("OIDC settings present");
+                assert_eq!(oidc.refresh_interval, Duration::from_secs(1));
+            }
+            other => panic!("expected canonical key config, got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
`--oidc-jwks-refresh-interval-secs 0` had no validation, and `auth.rs` feeds that value straight into `tokio::time::interval`, which panics on a zero period. Since #187 made a dead JWKS-refresh task fatal to the process, the outcome was correct but the diagnostics were not: an operator got a panic *after* the listeners bound, instead of being told which flag was wrong before startup.

Now rejected during `Cli::into_config()` → `canonical_auth_settings()`, which `main.rs` calls before anything binds, and surfaced as `invalid configuration: ...` with a failing exit code:

```
--oidc-jwks-refresh-interval-secs must be at least 1: a zero interval cannot drive the JWKS refresh timer
```

The check sits in the OIDC-enabled arm, where `refresh_interval` is actually built — the only path by which the value reaches `tokio::time::interval`.

No clamp. Silently turning 0 into 1 would hide the operator's mistake, and reporting a wrong value rather than repairing it is the point of the ticket.

Issue #223 asked whether other interval-shaped flags in the same config share the hazard. Each was checked:

- `--round-robin-idle-ttl` — already guarded, `into_config` rejects a zero duration.
- `--subset-size`, `--round-robin-max-entries` — not durations, already rejected at 0, and neither reaches a timer.

No other flag in this config flows into a `tokio::time::interval` or `sleep`.

Both boundaries are pinned: 0 rejected, 1 accepted. The zero-rejection test was demonstrated failing against the pre-change code — with the guard removed, `into_config()` returned `Ok` carrying a `0ns` refresh interval, so the test's `expect_err` panicked.

Verified locally, each command run unpiped with its own exit code captured: `cargo clippy -p ravel-ingest-router --all-targets` exit 0, `cargo test -p ravel-ingest-router` 49/49 pass, `cargo fmt --all --check` clean.

Fixes: #223
