### PR TITLE
feat(ravel-cli): wide-schema load signals, batch lever, mapping-derived declaration

### DIFF
--- a/docs/guides/ingest.md
+++ b/docs/guides/ingest.md
@@ -427,6 +427,15 @@ column = "status"
 type = "i64"                # str | i64 | f64 | bool | bytes
 ```
 
+**Date columns.** An Arrow `Date32` or `Date64` source column is mapped with
+`type = "i64"`, and its value is stored in its native unit, unchanged: a
+`Date32` stores **days since the Unix epoch**, a `Date64` stores **milliseconds
+since the Unix epoch**. Neither is rescaled to nanoseconds, and neither may be
+used as the `ts_column` (a date is not a valid event-time source; the loader
+rejects it there). So a query comparing against a mapped date column compares
+against that raw day or millisecond integer, not a timestamp -- e.g. a `Date32`
+for 2024-05-16 is the integer `19876`.
+
 ### Which admission rules this path keeps, relaxes, and bypasses
 
 - **Future skew: kept.** The loader enforces the same `max_future_skew_ns`
@@ -466,6 +475,48 @@ type = "i64"                # str | i64 | f64 | bool | bytes
   through it, and there is no equivalent concept for a single offline bulk load.
   Bulk-loaded volume is therefore not evidence the admission controller's limits
   were exercised. The CLI prints this warning before every run.
+
+### `--batch-rows`: the object-count lever
+
+`load` writes one Strict flush per batch, and one flush is one RLOG object per
+involved shard. `--batch-rows` sets the batch size (default 10000). It is
+therefore the lever that controls how many RLOG objects a load leaves behind:
+a 100M-row load at the default is on the order of 10000 flushes, each an RLOG
+object per shard. Object count is a first-order query-cost variable, because
+per-object cost (LIST, footer read, per-object decode setup) is paid on every
+later query over the affected range. A larger `--batch-rows` writes fewer,
+larger objects (less per-object overhead, more memory held per batch); a
+smaller one writes more, smaller objects.
+
+`--batch-rows 0` is rejected with an error rather than silently clamped: a zero
+would otherwise hide a misconfigured value that changes layout.
+
+### The dynamic-column budget and its warnings
+
+Each RLOG object gives a real typed column to the first
+`max_dynamic_columns` (default 1000) distinct `(attribute name, type)` pairs it
+holds, ordered lexicographically by name; anything past that budget folds into
+the object's `attrs_raw` overflow column. An overflowed attribute is **still
+queryable through `attrs['<key>']`**, but it gets **no typed column**, so a
+typed predicate or aggregate over it is unavailable and a SQL filter over it
+pays a per-row string cast.
+
+After a load, `load` reads the run's cumulative dynamic-column counters and
+prints one of two warnings to stderr when they apply:
+
+- an **overflow** warning when any object crossed the budget, naming the count
+  of overflowed `(name, type)` pairs;
+- a distinct **near-cap** warning when nothing overflowed but the widest object
+  reached **90% or more** of `max_dynamic_columns` -- pressure surfaced before
+  the cap, not only after it.
+
+Both name the same fix: reduce the number of distinct attribute columns per
+stream (map fewer columns, or split the load so each object stays under the
+budget), or accept `attrs`-only access for the overflow keys. To give an
+overflowed key a typed column at query time, declare it with
+`ravel-cli typed-attr-column set` (see [query.md](query.md#declaring-typed-attribute-columns));
+declaring does not change what the object already stored, so the two-step flow
+is load, then declare, then query.
 
 ### Failure, retention, and performance
 

--- a/docs/guides/query.md
+++ b/docs/guides/query.md
@@ -330,6 +330,43 @@ docs/query-engine.md for the full contract, including why an equality predicate
 moved onto a declared column is slower than the equivalent `attrs['k'] = 'v'`
 today.
 
+### Declaring typed attribute columns
+
+Loading a dataset and declaring its typed columns are **two separate steps**,
+in order:
+
+1. **Load** the data with `ravel-cli load --parquet ...` (see
+   [ingest.md](ingest.md#bulk-import-ravel-cli-load---parquet-adr-0089)). The
+   loader writes data objects only; it never touches tenant config.
+2. **Declare** the typed columns with `ravel-cli typed-attr-column set`. This is
+   a control-plane write, kept out of the loader on purpose (a durable
+   CAS whole-list replace does not belong in an append-only data-plane command,
+   where it could clobber a hand-declared column). You can pass the columns
+   explicitly as `KEY:TYPE` specs, or derive them from the same `--mapping` the
+   load used:
+
+   ```sh
+   ravel-cli typed-attr-column set acme --from-mapping map.toml
+   ```
+
+   `--from-mapping` turns every `[[attribute]]` and `[[resource_attribute]]`
+   entry into a declared column of the same-named type (`str`/`i64`/`bool`/
+   `bytes`). A resource (stream-level) key is legitimately declarable because a
+   declared column reads the merged resource+scope+record attribute view. An
+   `f64`-typed entry is **skipped with a per-key warning** (there is no `f64`
+   declared column type yet); the rest are still written. A key declared twice,
+   or a key colliding with a fixed logs column name, is rejected and nothing is
+   written.
+
+**A freshly written declaration is not instantly visible to queries.** A
+query-serving process resolves the durable declaration behind a **staleness
+horizon** (60s by default), so a `set` lands durably at once but a query may
+keep using the previous declaration until the server refreshes within that
+horizon. No restart is needed; wait out the horizon before asserting a newly
+declared column is typed. An attribute that overflowed the load's
+dynamic-column budget (see [ingest.md](ingest.md#the-dynamic-column-budget-and-its-warnings))
+stays queryable through `attrs['<key>']` regardless of whether it is declared.
+
 A `ts` range scan. `ts` is a timestamp, so the bounds are `TIMESTAMP` literals,
 not bare integers:
 

--- a/services/ravel-cli/src/load.rs
+++ b/services/ravel-cli/src/load.rs
@@ -251,7 +251,40 @@ pub async fn run(
     batch_rows: usize,
     now_ns: i64,
 ) -> anyhow::Result<()> {
-    eprintln!("{ADMISSION_BYPASS_WARNING}");
+    run_warning_to(
+        store,
+        parquet_path,
+        tenant,
+        mapping_path,
+        shards,
+        batch_rows,
+        now_ns,
+        &mut std::io::stderr(),
+    )
+    .await
+}
+
+/// [`run`] with its warning stream injected, so a test can prove the warnings
+/// actually reach a caller of the real entry point.
+///
+/// The seam exists because the alternative was untestable: the dynamic-column
+/// warnings are the whole operator-facing deliverable of ADR-0100 decision 1,
+/// and with `eprintln!` inlined here, deleting the emit loop left every test
+/// green. Only [`run`]'s one-line delegation above is now unproven by a test.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn run_warning_to(
+    store: Arc<dyn ObjectStoreBackend>,
+    parquet_path: &Path,
+    tenant: &str,
+    mapping_path: &Path,
+    shards: u32,
+    batch_rows: usize,
+    now_ns: i64,
+    warnings: &mut dyn std::io::Write,
+) -> anyhow::Result<()> {
+    // A diagnostic that cannot be written is not worth failing a durable load
+    // over, here or below.
+    let _ = writeln!(warnings, "{ADMISSION_BYPASS_WARNING}");
 
     let mapping_text = std::fs::read_to_string(mapping_path)
         .map_err(|e| anyhow::anyhow!("failed to read --mapping {}: {e}", mapping_path.display()))?;
@@ -275,7 +308,7 @@ pub async fn run(
             // its per-object dynamic-column budget is that default.
             let max_dynamic_columns = ravel_logseg::RlogConfig::default().max_dynamic_columns;
             for warning in dynamic_column_warnings(&report.metrics, max_dynamic_columns) {
-                eprintln!("{warning}");
+                let _ = writeln!(warnings, "{warning}");
             }
             Ok(())
         }
@@ -455,9 +488,6 @@ pub async fn load(
     now_ns: i64,
     clock: Arc<dyn Clock>,
 ) -> Result<LoadReport, LoadError> {
-    // Reject a zero batch size with a typed error rather than silently clamping
-    // it to 1: `batch_rows` is the operator-facing `--batch-rows` lever, and a
-    // silent clamp would hide a misconfigured value that changes object layout.
     // Reject a zero batch size with a typed error rather than silently clamping
     // it to 1: `batch_rows` is the operator-facing `--batch-rows` lever, and a
     // silent clamp would hide a misconfigured value that changes object layout.
@@ -1360,6 +1390,77 @@ type = "i64"
                 && warnings[0].contains("attrs_raw"),
             "the overflow warning states the count and the attrs_raw consequence: {}",
             warnings[0]
+        );
+    }
+
+    /// The overflow warning reaches a caller of the real entry point, not just
+    /// [`dynamic_column_warnings`].
+    ///
+    /// The sibling tests call that helper directly, so all of them stayed green
+    /// when the emit loop was deleted from the entry point: they prove the text,
+    /// not the wiring. This one drives [`run_warning_to`] end to end -- mapping
+    /// file on disk, Parquet fixture, real router, real write -- and asserts the
+    /// warning came out of the stream the CLI hands it.
+    #[tokio::test]
+    async fn the_entry_point_emits_the_overflow_warning() {
+        use parquet::arrow::ArrowWriter;
+        use ravel_object_store::memory::MemoryStore;
+
+        let n_attrs = 1001;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let pq = dir.path().join("wide.parquet");
+        let mapping_path = dir.path().join("mapping.toml");
+
+        let mut cols: Vec<(String, ArrayRef)> = vec![
+            ("ts".to_string(), i64_col(vec![NOW_NS])),
+            ("svc".to_string(), str_col(vec!["api"])),
+        ];
+        let mut attr_toml = String::new();
+        for i in 0..n_attrs {
+            let name = format!("a{i}");
+            cols.push((name.clone(), i64_col(vec![i as i64])));
+            attr_toml.push_str(&format!(
+                "\n[[attribute]]\nkey = \"{name}\"\ncolumn = \"{name}\"\ntype = \"i64\"\n"
+            ));
+        }
+        let batch = RecordBatch::try_from_iter(cols).expect("wide batch");
+        let file = std::fs::File::create(&pq).expect("create parquet");
+        let mut writer = ArrowWriter::try_new(file, batch.schema(), None).expect("arrow writer");
+        writer.write(&batch).expect("write batch");
+        writer.close().expect("close writer");
+
+        std::fs::write(
+            &mapping_path,
+            format!(
+                "ts_column = \"ts\"\nts_unit = \"nanos\"\n\n\
+                 [[resource_attribute]]\nkey = \"service.name\"\ncolumn = \"svc\"\ntype = \"str\"\n{attr_toml}"
+            ),
+        )
+        .expect("write mapping");
+
+        let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+        let mut sink: Vec<u8> = Vec::new();
+        run_warning_to(
+            store,
+            &pq,
+            "acme",
+            &mapping_path,
+            4,
+            10_000,
+            NOW_NS,
+            &mut sink,
+        )
+        .await
+        .expect("the load itself succeeds; overflow is a warning, not a failure");
+
+        let emitted = String::from_utf8(sink).expect("warnings are utf-8");
+        assert!(
+            emitted.contains("overflowed the per-object dynamic-column budget"),
+            "the entry point must emit the overflow warning it computed: {emitted}"
+        );
+        assert!(
+            emitted.contains(ADMISSION_BYPASS_WARNING),
+            "and the pre-existing admission warning still goes to the same stream: {emitted}"
         );
     }
 

--- a/services/ravel-cli/src/load.rs
+++ b/services/ravel-cli/src/load.rs
@@ -18,17 +18,19 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use arrow::array::{
-    Array, ArrayRef, BooleanArray, Float32Array, Float64Array, Int8Array, Int16Array, Int32Array,
-    Int64Array, LargeBinaryArray, LargeStringArray, StringArray, TimestampMicrosecondArray,
-    TimestampMillisecondArray, TimestampNanosecondArray, TimestampSecondArray, UInt8Array,
-    UInt16Array, UInt32Array, UInt64Array,
+    Array, ArrayRef, BooleanArray, Date32Array, Date64Array, Float32Array, Float64Array, Int8Array,
+    Int16Array, Int32Array, Int64Array, LargeBinaryArray, LargeStringArray, StringArray,
+    TimestampMicrosecondArray, TimestampMillisecondArray, TimestampNanosecondArray,
+    TimestampSecondArray, UInt8Array, UInt16Array, UInt32Array, UInt64Array,
 };
 use arrow::array::{BinaryArray, FixedSizeBinaryArray};
 use arrow::datatypes::{DataType, TimeUnit};
 use arrow::record_batch::RecordBatch;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use ravel_catalog::{AbsentPolicy, validate_or_adopt};
-use ravel_ingest::{Clock, IngestConfig, LogIngestRouter, SystemClock, WriteMode};
+use ravel_ingest::{
+    Clock, IngestConfig, LogIngestMetricsSnapshot, LogIngestRouter, SystemClock, WriteMode,
+};
 use ravel_object_store::ObjectStoreBackend;
 use ravel_otlp::NormalizedLogRecord;
 use ravel_otlp::logs_limits::LogIngestLimits;
@@ -170,9 +172,70 @@ pub const ADMISSION_BYPASS_WARNING: &str = "warning: bulk load writes directly t
      re-running after a failure re-ingests the whole file from the start. Retention is measured \
      from load time, not from the records' event times.";
 
+/// Near-cap warning threshold: the loader warns when the widest single object's
+/// `dynamic_columns_used` reaches this fraction of `max_dynamic_columns`,
+/// expressed as a percentage so the comparison is exact integer arithmetic
+/// (`used * 100 >= max * NEAR_CAP_PERCENT`) with no float rounding at the
+/// boundary. 90% is deliberate headroom: it fires before an object overflows,
+/// not only after.
+const NEAR_CAP_PERCENT: u64 = 90;
+
+/// Warnings to print to stderr after a load, derived from the router's
+/// cumulative dynamic-column counters (ADR-0100 decision 1). Returns at most one
+/// message:
+///
+/// - an overflow warning when any object crossed its dynamic-column budget
+///   (`dynamic_columns_overflowed_total > 0`), naming the count; or, when
+///   nothing overflowed,
+/// - a distinct near-cap warning when the widest object's `dynamic_columns_used`
+///   reached [`NEAR_CAP_PERCENT`]% of `max_dynamic_columns`.
+///
+/// Both state the same consequence an operator needs to act on: an overflowed
+/// attribute folds into the object's `attrs_raw` column, so it stays queryable
+/// through `attrs['<key>']` but gets no typed column (a typed predicate or
+/// aggregate over it is unavailable, and a SQL filter pays a per-row string
+/// cast). An empty vector means the load stayed comfortably under the budget and
+/// nothing is printed.
+pub fn dynamic_column_warnings(
+    metrics: &LogIngestMetricsSnapshot,
+    max_dynamic_columns: usize,
+) -> Vec<String> {
+    let max = max_dynamic_columns as u64;
+    if metrics.dynamic_columns_overflowed_total > 0 {
+        return vec![format!(
+            "warning: {overflowed} distinct (attribute name, type) pair(s) overflowed the \
+             per-object dynamic-column budget of {max} during this load. Each overflowed \
+             attribute was folded into the object's attrs_raw overflow column: it stays \
+             queryable through attrs['<key>'], but it gets NO typed column, so a typed predicate \
+             or aggregate over it is unavailable and a SQL filter pays a per-row string cast. To \
+             give an overflowed key a typed column, reduce the number of distinct attribute \
+             columns per stream (map fewer columns, or split the load so each object stays under \
+             {max} distinct (name, type) pairs).",
+            overflowed = metrics.dynamic_columns_overflowed_total,
+        )];
+    }
+    if max > 0 && metrics.dynamic_columns_used_max * 100 >= max * NEAR_CAP_PERCENT {
+        return vec![format!(
+            "warning: this load reached {used} distinct dynamic columns in a single object, at or \
+             above {pct}% of the per-object budget of {max}. No object overflowed, but a wider \
+             stream or one more attribute would push columns past the budget into the attrs_raw \
+             overflow column, where they stay queryable through attrs['<key>'] but get no typed \
+             column. Reduce the number of distinct attribute columns per stream, or split the \
+             load, to keep headroom under {max}.",
+            used = metrics.dynamic_columns_used_max,
+            pct = NEAR_CAP_PERCENT,
+        )];
+    }
+    Vec::new()
+}
+
 /// CLI entry point for `ravel-cli load --parquet`: read the mapping and Parquet
 /// file paths, run the load, and print a summary on success or the error plus
 /// the known-durable commit tokens on failure.
+///
+/// After a successful load, any dynamic-column overflow or near-cap pressure is
+/// reported to stderr from [`dynamic_column_warnings`] over the router's
+/// cumulative counters (ADR-0100 decision 1).
 ///
 /// Returns `Err` (nonzero exit) for any failure. On a flush failure or a
 /// rejected row, the durable commit tokens are printed rather than swallowed
@@ -185,6 +248,7 @@ pub async fn run(
     tenant: &str,
     mapping_path: &Path,
     shards: u32,
+    batch_rows: usize,
     now_ns: i64,
 ) -> anyhow::Result<()> {
     eprintln!("{ADMISSION_BYPASS_WARNING}");
@@ -199,7 +263,7 @@ pub async fn run(
         tenant,
         &mapping,
         shards,
-        DEFAULT_BATCH_ROWS,
+        batch_rows,
         now_ns,
         Arc::new(SystemClock),
     )
@@ -207,6 +271,12 @@ pub async fn run(
     {
         Ok(report) => {
             print_summary(&report);
+            // The loader's writer uses `RlogConfig::default()` (log_shard.rs), so
+            // its per-object dynamic-column budget is that default.
+            let max_dynamic_columns = ravel_logseg::RlogConfig::default().max_dynamic_columns;
+            for warning in dynamic_column_warnings(&report.metrics, max_dynamic_columns) {
+                eprintln!("{warning}");
+            }
             Ok(())
         }
         Err(err) => {
@@ -278,6 +348,12 @@ pub struct LoadReport {
     /// number of objects/segments written.
     pub tokens: Vec<CommitToken>,
     pub elapsed: Duration,
+    /// The router's cumulative write metrics, snapshotted once the load
+    /// finished. Carries the dynamic-column counters (ADR-0100 decision 1) the
+    /// caller reads to emit an overflow or near-cap warning; there is no other
+    /// return path for a per-load signal (`LogIngestRouter::metrics()` is only
+    /// reachable by whoever constructed the router, which is `load` itself).
+    pub metrics: LogIngestMetricsSnapshot,
 }
 
 impl LoadReport {
@@ -379,6 +455,20 @@ pub async fn load(
     now_ns: i64,
     clock: Arc<dyn Clock>,
 ) -> Result<LoadReport, LoadError> {
+    // Reject a zero batch size with a typed error rather than silently clamping
+    // it to 1: `batch_rows` is the operator-facing `--batch-rows` lever, and a
+    // silent clamp would hide a misconfigured value that changes object layout.
+    // Reject a zero batch size with a typed error rather than silently clamping
+    // it to 1: `batch_rows` is the operator-facing `--batch-rows` lever, and a
+    // silent clamp would hide a misconfigured value that changes object layout.
+    if batch_rows == 0 {
+        return Err(LoadError::Setup(
+            "--batch-rows must be at least 1 (each batch is one Strict flush per shard); 0 was \
+             given"
+                .to_string(),
+        ));
+    }
+
     let limits = LogIngestLimits::default();
     let tenant_id = TenantId::new(tenant);
 
@@ -422,7 +512,7 @@ pub async fn load(
     let builder = ParquetRecordBatchReaderBuilder::try_new(file)
         .map_err(|e| LoadError::Setup(format!("failed to open Parquet reader: {e}")))?;
     let reader = builder
-        .with_batch_size(batch_rows.max(1))
+        .with_batch_size(batch_rows)
         .build()
         .map_err(|e| LoadError::Setup(format!("failed to build Parquet reader: {e}")))?;
 
@@ -481,6 +571,10 @@ pub async fn load(
     // no-op here (nothing is buffered after a Strict write returns).
     router.flush_all().await;
 
+    // Snapshot the router's cumulative counters before it drops: the caller
+    // reads the dynamic-column figures to warn on overflow or near-cap pressure
+    // (ADR-0100 decision 1).
+    report.metrics = router.metrics().snapshot();
     report.elapsed = started.elapsed();
     Ok(report)
 }
@@ -715,7 +809,16 @@ fn read_attr(arr: &ArrayRef, row: usize, ty: ColType) -> Result<Option<AttrValue
     Ok(Some(value))
 }
 
-/// Read an integer cell as `i64`, accepting any Arrow integer width.
+/// Read an integer cell as `i64`, accepting any Arrow integer width and the two
+/// Arrow date types.
+///
+/// `Date32` (days since the Unix epoch) and `Date64` (milliseconds since the
+/// Unix epoch) land as their native-unit `i64`: a `Date32` day count and a
+/// `Date64` millisecond count, NOT converted to nanoseconds (ADR-0100). A wide
+/// analytical export routinely carries a date column mapped as an `i64`
+/// attribute; the stored number's unit is documented in `docs/guides/ingest.md`
+/// so a mapping author knows what a comparison against it means. Dates are
+/// deliberately not accepted by the `ts` path (see [`read_ts`]).
 fn read_i64(arr: &ArrayRef, row: usize) -> Result<Option<i64>, String> {
     if arr.is_null(row) {
         return Ok(None);
@@ -730,7 +833,15 @@ fn read_i64(arr: &ArrayRef, row: usize) -> Result<Option<i64>, String> {
         DataType::UInt32 => downcast::<UInt32Array>(arr)?.value(row) as i64,
         DataType::UInt64 => i64::try_from(downcast::<UInt64Array>(arr)?.value(row))
             .map_err(|_| "u64 value does not fit in i64".to_string())?,
-        other => return Err(format!("expected an integer column, found {other:?}")),
+        // Date32 is i32 days; Date64 is i64 milliseconds. Stored in their
+        // native unit, never rescaled to nanoseconds.
+        DataType::Date32 => downcast::<Date32Array>(arr)?.value(row) as i64,
+        DataType::Date64 => downcast::<Date64Array>(arr)?.value(row),
+        other => {
+            return Err(format!(
+                "expected an integer or date column, found {other:?}"
+            ));
+        }
     };
     Ok(Some(v))
 }
@@ -810,6 +921,19 @@ fn read_ts(arr: &ArrayRef, row: usize, declared: TsUnit) -> Result<Option<i64>, 
             };
             raw.checked_mul(factor)
                 .ok_or_else(|| "timestamp overflows i64 nanoseconds".to_string())?
+        }
+        // A date column is not a valid event-time source: it lands as a native-
+        // unit i64 attribute (read_i64), never rescaled to nanoseconds through
+        // the ts path (ADR-0100). Reject it here rather than let the read_i64
+        // fallback below silently multiply a day/millisecond count by the
+        // declared ts unit.
+        DataType::Date32 | DataType::Date64 => {
+            return Err(format!(
+                "ts column has date type {:?}; a date is not a valid ts source. Map it as an i64 \
+                 attribute instead (its value is days since the epoch for Date32, milliseconds \
+                 for Date64).",
+                arr.data_type()
+            ));
         }
         _ => {
             let raw =
@@ -1152,6 +1276,174 @@ type = "i64"
         assert_ne!(
             err.durable_tokens(),
             LoadError::Setup("x".into()).durable_tokens()
+        );
+    }
+
+    /// A clock pinned to `NOW_NS`, so the router buckets and routes against the
+    /// same instant the provisioning `now_ns` uses (as the loader integration
+    /// tests do).
+    struct FixedClock(i64);
+    impl Clock for FixedClock {
+        fn now_ns(&self) -> i64 {
+            self.0
+        }
+    }
+
+    /// Load a fixture of one record with `n_attrs` distinct i64 attribute
+    /// columns (plus one resource attribute) through the real `load`, and return
+    /// its report. `n_attrs` past the writer's 1000-column budget forces
+    /// overflow; below it exercises the near-cap path.
+    async fn run_wide_load(n_attrs: usize) -> LoadReport {
+        use parquet::arrow::ArrowWriter;
+        use ravel_object_store::memory::MemoryStore;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let pq = dir.path().join("wide.parquet");
+        let mut cols: Vec<(String, ArrayRef)> = vec![
+            ("ts".to_string(), i64_col(vec![NOW_NS])),
+            ("svc".to_string(), str_col(vec!["api"])),
+        ];
+        let mut attr_toml = String::new();
+        for i in 0..n_attrs {
+            let name = format!("a{i}");
+            cols.push((name.clone(), i64_col(vec![i as i64])));
+            attr_toml.push_str(&format!(
+                "\n[[attribute]]\nkey = \"{name}\"\ncolumn = \"{name}\"\ntype = \"i64\"\n"
+            ));
+        }
+        let batch = RecordBatch::try_from_iter(cols).expect("wide batch");
+        let file = std::fs::File::create(&pq).expect("create parquet");
+        let mut writer = ArrowWriter::try_new(file, batch.schema(), None).expect("arrow writer");
+        writer.write(&batch).expect("write batch");
+        writer.close().expect("close writer");
+
+        let m = parse_mapping(&format!(
+            "ts_column = \"ts\"\nts_unit = \"nanos\"\n\n\
+             [[resource_attribute]]\nkey = \"service.name\"\ncolumn = \"svc\"\ntype = \"str\"\n{attr_toml}"
+        ))
+        .expect("valid mapping");
+
+        let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+        load(
+            Arc::clone(&store),
+            &pq,
+            "acme",
+            &m,
+            4,
+            10_000,
+            NOW_NS,
+            Arc::new(FixedClock(NOW_NS)),
+        )
+        .await
+        .expect("load succeeds")
+    }
+
+    /// A load whose object crosses the 1000-column dynamic budget produces the
+    /// overflow warning, driven from real router metrics rather than a
+    /// hand-built snapshot. Flip the `dynamic_columns_overflowed_total > 0`
+    /// guard in `dynamic_column_warnings` to `false` and this fails: no warning
+    /// is emitted for a load that genuinely overflowed.
+    #[tokio::test]
+    async fn warns_when_dynamic_columns_overflow() {
+        let report = run_wide_load(1001).await;
+        assert!(
+            report.metrics.dynamic_columns_overflowed_total > 0,
+            "1001 distinct attribute columns overflow the 1000-column per-object budget"
+        );
+        let warnings = dynamic_column_warnings(
+            &report.metrics,
+            ravel_logseg::RlogConfig::default().max_dynamic_columns,
+        );
+        assert_eq!(warnings.len(), 1, "exactly the overflow warning fires");
+        assert!(
+            warnings[0].contains("overflowed the per-object dynamic-column budget")
+                && warnings[0].contains("attrs_raw"),
+            "the overflow warning states the count and the attrs_raw consequence: {}",
+            warnings[0]
+        );
+    }
+
+    /// A load that reaches >= 90% of the budget without overflowing produces the
+    /// distinct near-cap warning, again from real metrics.
+    #[tokio::test]
+    async fn warns_near_cap_without_overflow() {
+        let report = run_wide_load(950).await;
+        assert_eq!(
+            report.metrics.dynamic_columns_overflowed_total, 0,
+            "950 distinct columns stay under the 1000 budget, so nothing overflows"
+        );
+        assert!(
+            report.metrics.dynamic_columns_used_max >= 900,
+            "the widest object should sit near the cap: used_max = {}",
+            report.metrics.dynamic_columns_used_max
+        );
+        let warnings = dynamic_column_warnings(&report.metrics, 1000);
+        assert_eq!(warnings.len(), 1, "exactly the near-cap warning fires");
+        assert!(
+            warnings[0].contains("at or above") && warnings[0].contains("attrs_raw"),
+            "the near-cap warning states the pressure and the attrs_raw consequence: {}",
+            warnings[0]
+        );
+    }
+
+    /// The near-cap boundary is exact: 90% warns, 89% does not, and an overflow
+    /// takes precedence over the near-cap message. Flip the `>=` in
+    /// `dynamic_column_warnings` to `>` and the exactly-90% case fails.
+    #[test]
+    fn near_cap_threshold_is_at_ninety_percent() {
+        let snap = |used: u64, overflowed: u64| LogIngestMetricsSnapshot {
+            dynamic_columns_used_max: used,
+            dynamic_columns_overflowed_total: overflowed,
+            ..Default::default()
+        };
+        assert_eq!(
+            dynamic_column_warnings(&snap(900, 0), 1000).len(),
+            1,
+            "900 / 1000 = exactly 90% warns"
+        );
+        assert!(
+            dynamic_column_warnings(&snap(899, 0), 1000).is_empty(),
+            "899 / 1000 is just under 90% and does not warn"
+        );
+        assert!(
+            dynamic_column_warnings(&snap(890, 0), 1000).is_empty(),
+            "890 / 1000 = 89% does not warn"
+        );
+        let overflow = dynamic_column_warnings(&snap(900, 3), 1000);
+        assert_eq!(overflow.len(), 1, "overflow still yields one message");
+        assert!(
+            overflow[0].contains("overflowed the per-object dynamic-column budget"),
+            "overflow takes precedence over the near-cap message: {}",
+            overflow[0]
+        );
+    }
+
+    /// `--batch-rows 0` is rejected with a typed [`LoadError::Setup`] before any
+    /// work, rather than silently clamped to 1.
+    #[tokio::test]
+    async fn batch_rows_zero_is_rejected() {
+        use ravel_object_store::memory::MemoryStore;
+        let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+        let m = base_mapping();
+        let err = load(
+            store,
+            Path::new("/nonexistent.parquet"),
+            "acme",
+            &m,
+            4,
+            0,
+            NOW_NS,
+            Arc::new(FixedClock(NOW_NS)),
+        )
+        .await
+        .expect_err("batch_rows of 0 is rejected");
+        assert!(
+            matches!(err, LoadError::Setup(_)),
+            "a typed setup error, got: {err}"
+        );
+        assert!(
+            err.to_string().contains("--batch-rows must be at least 1"),
+            "the error names the lever: {err}"
         );
     }
 }

--- a/services/ravel-cli/src/main.rs
+++ b/services/ravel-cli/src/main.rs
@@ -227,6 +227,13 @@ enum Command {
         /// that record. Defaults to the server's default of 4.
         #[arg(long, default_value_t = 4)]
         shards: u32,
+        /// Rows per Strict flush. One flush is one RLOG object per involved
+        /// shard, so on a large load this is the lever that controls how many
+        /// RLOG objects the load leaves behind (a first-order query-cost
+        /// variable). Must be at least 1; 0 is rejected. Defaults to
+        /// `DEFAULT_BATCH_ROWS` (10000), leaving current behaviour unchanged.
+        #[arg(long, default_value_t = ravel_cli::load::DEFAULT_BATCH_ROWS)]
+        batch_rows: usize,
     },
 }
 
@@ -305,9 +312,19 @@ enum TypedAttrColumnCommand {
         tenant: String,
         /// The declaration, as `KEY:TYPE` specs in schema-append order, where
         /// TYPE is one of str/i64/bool/bytes (case-insensitive). A key may
-        /// contain `:`; the type is split off the right.
-        #[arg(value_name = "KEY:TYPE")]
+        /// contain `:`; the type is split off the right. Mutually exclusive
+        /// with `--from-mapping`.
+        #[arg(value_name = "KEY:TYPE", conflicts_with = "from_mapping")]
         columns: Vec<String>,
+        /// Derive the declaration from a `load --mapping` TOML instead of
+        /// positional `KEY:TYPE` specs: every `[[attribute]]` and
+        /// `[[resource_attribute]]` entry becomes a declared column of the
+        /// same-named type. `f64`-typed entries are skipped with a per-key
+        /// warning on stderr (there is no `f64` declared column type); the rest
+        /// are written through the same CAS whole-list replace. Mutually
+        /// exclusive with positional `KEY:TYPE` specs.
+        #[arg(long, value_name = "TOML")]
+        from_mapping: Option<std::path::PathBuf>,
     },
 }
 
@@ -1044,16 +1061,32 @@ async fn main() -> anyhow::Result<()> {
             command: TypedAttrColumnCommand::Show { tenant },
         } => ravel_cli::typed_attr_column::show(store::build_store(&cli.store)?, &tenant).await,
         Command::TypedAttrColumn {
-            command: TypedAttrColumnCommand::Set { tenant, columns },
-        } => {
-            ravel_cli::typed_attr_column::set(
-                store::build_store(&cli.store)?,
-                &tenant,
-                &columns,
-                now_ns()?,
-            )
-            .await
-        }
+            command:
+                TypedAttrColumnCommand::Set {
+                    tenant,
+                    columns,
+                    from_mapping,
+                },
+        } => match from_mapping {
+            Some(mapping_path) => {
+                ravel_cli::typed_attr_column::set_from_mapping(
+                    store::build_store(&cli.store)?,
+                    &tenant,
+                    &mapping_path,
+                    now_ns()?,
+                )
+                .await
+            }
+            None => {
+                ravel_cli::typed_attr_column::set(
+                    store::build_store(&cli.store)?,
+                    &tenant,
+                    &columns,
+                    now_ns()?,
+                )
+                .await
+            }
+        },
         Command::GcConfig {
             command: GcConfigCommand::Show {},
         } => ravel_cli::gc_config::show(store::build_store(&cli.store)?).await,
@@ -1137,6 +1170,7 @@ async fn main() -> anyhow::Result<()> {
             tenant,
             mapping,
             shards,
+            batch_rows,
         } => {
             ravel_cli::load::run(
                 store::build_store(&cli.store)?,
@@ -1144,6 +1178,7 @@ async fn main() -> anyhow::Result<()> {
                 &tenant,
                 &mapping,
                 shards,
+                batch_rows,
                 now_ns()?,
             )
             .await

--- a/services/ravel-cli/src/typed_attr_column.rs
+++ b/services/ravel-cli/src/typed_attr_column.rs
@@ -45,6 +45,7 @@
 //! `set_tenant_config` variant that takes the version the caller already read,
 //! which `ravel-catalog` does not expose today.
 
+use std::path::Path;
 use std::sync::Arc;
 
 use ravel_catalog::{
@@ -53,6 +54,8 @@ use ravel_catalog::{
 };
 use ravel_object_store::ObjectStoreBackend;
 use ravel_types::TenantId;
+
+use crate::load::{ColType, Mapping, parse_mapping};
 
 /// Parse one `KEY:TYPE` declaration spec, the same syntax `ravel-server`'s
 /// `--typed-attr-column` flag takes. Split on the LAST `:`, so an attribute key
@@ -157,11 +160,115 @@ pub async fn set(
     specs: &[String],
     now_ns: i64,
 ) -> anyhow::Result<()> {
-    let tenant_hash = TenantId::new(tenant).hash();
     let mut columns = Vec::with_capacity(specs.len());
     for spec in specs {
         columns.push(parse_spec(spec)?);
     }
+    set_columns(store, tenant, columns, now_ns).await
+}
+
+/// `typed-attr-column set <TENANT> --from-mapping <TOML>`: derive the
+/// declaration from a `load --mapping` document and write it through the same
+/// CAS whole-list replace [`set`] uses (ADR-0100 decision 2).
+///
+/// Every `[[attribute]]` and `[[resource_attribute]]` entry becomes a declared
+/// column of the same-named type. Resource attributes come first, in file
+/// order, then record attributes in file order (see
+/// [`derive_columns_from_mapping`]); that order is significant (it is the
+/// schema-append order) and is stable across invocations of the same mapping.
+/// `f64`-typed entries are skipped with a per-key warning on stderr, since
+/// `DeclaredColumnType` has no `f64` variant; the rest are written. Duplicate
+/// keys across the two lists, a key repeated with two types, or a key colliding
+/// with a fixed logs SQL column name are rejected by the shared
+/// `validate_typed_attr_columns` gate, writing nothing.
+///
+/// The loader never touches tenant config: this control-plane write stays in
+/// the control-plane subcommand (ADR-0100 decision 2, rejected alternative "the
+/// loader pushes the declaration itself").
+pub async fn set_from_mapping(
+    store: Arc<dyn ObjectStoreBackend>,
+    tenant: &str,
+    mapping_path: &Path,
+    now_ns: i64,
+) -> anyhow::Result<()> {
+    let text = std::fs::read_to_string(mapping_path).map_err(|e| {
+        anyhow::anyhow!(
+            "failed to read --from-mapping {}: {e}",
+            mapping_path.display()
+        )
+    })?;
+    let mapping = parse_mapping(&text)?;
+    let (columns, skipped) = derive_columns_from_mapping(&mapping);
+    for warning in &skipped {
+        eprintln!("{warning}");
+    }
+    set_columns(store, tenant, columns, now_ns).await
+}
+
+/// The `DeclaredColumnType` a mapping `ColType` maps to, or `None` for `F64`
+/// (which has no declared-column counterpart, ADR-0100 decision 2).
+fn declared_type(col_type: ColType) -> Option<DeclaredColumnType> {
+    match col_type {
+        ColType::Str => Some(DeclaredColumnType::Str),
+        ColType::I64 => Some(DeclaredColumnType::I64),
+        ColType::Bool => Some(DeclaredColumnType::Bool),
+        ColType::Bytes => Some(DeclaredColumnType::Bytes),
+        ColType::F64 => None,
+    }
+}
+
+/// Derive the declared-column list from a `--mapping` document (ADR-0100
+/// decision 2), returning the columns and one stderr warning per skipped `f64`
+/// key.
+///
+/// Order is `[[resource_attribute]]` entries first, in file order, then
+/// `[[attribute]]` entries in file order. Declared columns read the merged
+/// resource + scope + record attribute view (`ravel-sql/src/rlog_attrs.rs`), so
+/// a stream-level resource key is legitimately declarable. The order is
+/// significant (schema-append order) and deterministic, so re-running the same
+/// mapping yields byte-identical output; nothing is re-sorted. This is a single
+/// pass over the two lists (plus the O(n) `validate_typed_attr_columns` the
+/// caller runs), so it holds the ~105-column target with no quadratic step.
+///
+/// Duplicate or conflicting keys are NOT resolved here: the returned list may
+/// carry a key twice, and `validate_typed_attr_columns` (run by the caller) is
+/// the single authority that rejects that, so the rule is never reimplemented.
+fn derive_columns_from_mapping(mapping: &Mapping) -> (Vec<DeclaredTypedColumn>, Vec<String>) {
+    let mut columns =
+        Vec::with_capacity(mapping.resource_attributes.len() + mapping.attributes.len());
+    let mut skipped = Vec::new();
+    for attr in mapping
+        .resource_attributes
+        .iter()
+        .chain(mapping.attributes.iter())
+    {
+        match declared_type(attr.value_type) {
+            Some(ty) => columns.push(DeclaredTypedColumn {
+                key: attr.key.clone(),
+                ty,
+            }),
+            None => skipped.push(format!(
+                "warning: mapping key {:?} has type f64, which has no declared typed-column type \
+                 (ADR-0100); skipping it. It stays queryable through attrs['{}'] but gets no \
+                 typed column, so a SQL predicate over it pays a per-row string cast. The rest of \
+                 the mapping is still written.",
+                attr.key, attr.key
+            )),
+        }
+    }
+    (columns, skipped)
+}
+
+/// The shared write core behind [`set`] and [`set_from_mapping`]: validate the
+/// declaration, then perform the CAS whole-list replace (read-modify-write
+/// window documented in the module docs) and print the outcome.
+async fn set_columns(
+    store: Arc<dyn ObjectStoreBackend>,
+    tenant: &str,
+    columns: Vec<DeclaredTypedColumn>,
+    now_ns: i64,
+) -> anyhow::Result<()> {
+    let tenant_hash = TenantId::new(tenant).hash();
     // The same operator-input gate a durable write and the server's flags run.
     // Checked here first so the failure is reported before the read, and
     // reported as this command's own error rather than as a store-write error.
@@ -520,6 +627,181 @@ mod tests {
         fn capabilities(&self) -> Capabilities {
             self.inner.capabilities()
         }
+    }
+
+    /// Write `text` to a temp `.toml` and return the dir (kept alive) and path.
+    fn mapping_file(text: &str) -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("map.toml");
+        std::fs::write(&path, text).expect("write mapping");
+        (dir, path)
+    }
+
+    /// `set --from-mapping` derives a declared column from BOTH a
+    /// `[[resource_attribute]]` and an `[[attribute]]` entry, in resource-then-
+    /// record file order, and writes them through the CAS path.
+    #[tokio::test]
+    async fn from_mapping_derives_record_and_resource_attributes() {
+        let store = store();
+        let (_dir, path) = mapping_file(
+            r#"
+ts_column = "ts"
+ts_unit = "nanos"
+
+[[resource_attribute]]
+key = "service.name"
+column = "svc"
+type = "str"
+
+[[attribute]]
+key = "http.status_code"
+column = "status"
+type = "i64"
+"#,
+        );
+        set_from_mapping(store.clone(), "acme", &path, 1)
+            .await
+            .expect("a mapping-derived declaration is written");
+
+        assert_eq!(
+            durable(store.as_ref(), "acme")
+                .await
+                .expect("present")
+                .typed_attr_columns,
+            Some(vec![
+                DeclaredTypedColumn {
+                    key: "service.name".to_string(),
+                    ty: DeclaredColumnType::Str,
+                },
+                DeclaredTypedColumn {
+                    key: "http.status_code".to_string(),
+                    ty: DeclaredColumnType::I64,
+                },
+            ]),
+            "resource attributes derive first, then record attributes, both in file order"
+        );
+    }
+
+    /// An `f64` mapping entry has no `DeclaredColumnType`: it is skipped with a
+    /// per-key warning naming the key, and every other entry is still written.
+    /// Flip the `None =>` arm of `declared_type` to map `F64` onto some type
+    /// (or drop the `skipped.push`) and this fails: the f64 key would appear in
+    /// the durable list, or the warning would be absent.
+    #[tokio::test]
+    async fn from_mapping_skips_f64_with_warning_and_writes_the_rest() {
+        // Unit half: the derivation skips the f64 key with a warning and keeps
+        // the rest, in order.
+        let mapping = parse_mapping(
+            r#"
+ts_column = "ts"
+ts_unit = "nanos"
+
+[[attribute]]
+key = "http.status_code"
+column = "status"
+type = "i64"
+
+[[attribute]]
+key = "latency_ms"
+column = "latency"
+type = "f64"
+
+[[attribute]]
+key = "cache.hit"
+column = "hit"
+type = "bool"
+"#,
+        )
+        .expect("valid mapping");
+        let (columns, skipped) = derive_columns_from_mapping(&mapping);
+        assert_eq!(
+            columns,
+            vec![
+                DeclaredTypedColumn {
+                    key: "http.status_code".to_string(),
+                    ty: DeclaredColumnType::I64,
+                },
+                DeclaredTypedColumn {
+                    key: "cache.hit".to_string(),
+                    ty: DeclaredColumnType::Bool,
+                },
+            ],
+            "the f64 key is dropped from the list, the rest keep their order"
+        );
+        assert_eq!(skipped.len(), 1, "exactly the one f64 key is skipped");
+        assert!(
+            skipped[0].contains("latency_ms") && skipped[0].contains("f64"),
+            "the warning names the skipped key and its type: {}",
+            skipped[0]
+        );
+
+        // Integration half: the durable list written by the command excludes the
+        // f64 key and carries the rest.
+        let store = store();
+        let (_dir, path) = mapping_file(
+            r#"
+ts_column = "ts"
+ts_unit = "nanos"
+
+[[attribute]]
+key = "http.status_code"
+column = "status"
+type = "i64"
+
+[[attribute]]
+key = "latency_ms"
+column = "latency"
+type = "f64"
+"#,
+        );
+        set_from_mapping(store.clone(), "acme", &path, 1)
+            .await
+            .expect("the rest is still written after skipping the f64 key");
+        assert_eq!(
+            durable(store.as_ref(), "acme")
+                .await
+                .expect("present")
+                .typed_attr_columns,
+            Some(vec![DeclaredTypedColumn {
+                key: "http.status_code".to_string(),
+                ty: DeclaredColumnType::I64,
+            }]),
+            "the f64 key is not declared; the i64 key is"
+        );
+    }
+
+    /// A key appearing twice across the merged resource+record view is rejected
+    /// by the shared `validate_typed_attr_columns` gate, and nothing is written.
+    #[tokio::test]
+    async fn from_mapping_rejects_a_key_declared_twice() {
+        let store = store();
+        let (_dir, path) = mapping_file(
+            r#"
+ts_column = "ts"
+ts_unit = "nanos"
+
+[[resource_attribute]]
+key = "dur"
+column = "dur_res"
+type = "i64"
+
+[[attribute]]
+key = "dur"
+column = "dur_rec"
+type = "i64"
+"#,
+        );
+        let err = set_from_mapping(store.clone(), "acme", &path, 1)
+            .await
+            .expect_err("a key declared twice must be refused");
+        assert!(
+            err.to_string().contains("more than once"),
+            "the error names the duplicate-key rule: {err}"
+        );
+        assert!(
+            durable(store.as_ref(), "acme").await.is_none(),
+            "a refused derivation writes no record"
+        );
     }
 
     /// Sanity: the tenant hash the CLI writes under is the one a server reads,

--- a/services/ravel-cli/tests/load.rs
+++ b/services/ravel-cli/tests/load.rs
@@ -15,7 +15,7 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 
-use arrow::array::{ArrayRef, Int64Array, StringArray};
+use arrow::array::{ArrayRef, Date32Array, Date64Array, Int64Array, StringArray};
 use arrow::record_batch::RecordBatch;
 use parquet::arrow::ArrowWriter;
 
@@ -206,6 +206,114 @@ type = "i64"
         )
         .await,
         0
+    );
+}
+
+/// A `Date32` (days since the epoch) and a `Date64` (milliseconds since the
+/// epoch) column load end to end as i64 attributes in their native unit, read
+/// back exactly, without being rescaled to nanoseconds or routed through the ts
+/// path (ADR-0100). Before Date32/Date64 were added to `read_i64`, the loader
+/// rejected the batch with "expected an integer column, found Date32", so this
+/// could not load at all.
+#[tokio::test]
+async fn date32_and_date64_columns_load_and_read_back_exactly() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let pq = dir.path().join("dates.parquet");
+
+    // 19876 days since the epoch (2024-05-16); 1_700_000_000_000 ms since the
+    // epoch. Stored verbatim as i64 attribute values, not rescaled.
+    let d32: i32 = 19_876;
+    let d64: i64 = 1_700_000_000_000;
+    let batch = RecordBatch::try_from_iter(vec![
+        ("ts".to_string(), i64_col(vec![CLOCK_NS])),
+        ("svc".to_string(), str_col(vec!["api"])),
+        (
+            "event_date".to_string(),
+            Arc::new(Date32Array::from(vec![d32])) as ArrayRef,
+        ),
+        (
+            "event_ms".to_string(),
+            Arc::new(Date64Array::from(vec![d64])) as ArrayRef,
+        ),
+    ])
+    .expect("batch");
+    write_parquet(&pq, &batch);
+
+    let m = mapping(
+        r#"
+ts_column = "ts"
+ts_unit = "nanos"
+
+[[resource_attribute]]
+key = "service.name"
+column = "svc"
+type = "str"
+
+[[attribute]]
+key = "event_date"
+column = "event_date"
+type = "i64"
+
+[[attribute]]
+key = "event_ms"
+column = "event_ms"
+type = "i64"
+"#,
+    );
+
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+    let report = load::load(
+        Arc::clone(&store),
+        &pq,
+        "acme",
+        &m,
+        4,
+        10_000,
+        CLOCK_NS,
+        Arc::new(FixedClock(CLOCK_NS)),
+    )
+    .await
+    .expect("a date column loads as an i64 attribute");
+    assert_eq!(report.rows_processed, 1);
+
+    // The Date32 value reads back as its exact day count, the Date64 as its
+    // exact millisecond count (stringified in the attrs map).
+    assert_eq!(
+        logs_query_rows(
+            &store,
+            "acme",
+            &format!("SELECT ts FROM logs WHERE attrs['event_date'] = '{d32}'"),
+            &report.tokens,
+        )
+        .await,
+        1,
+        "the Date32 value is stored as its native day count ({d32}), not rescaled"
+    );
+    assert_eq!(
+        logs_query_rows(
+            &store,
+            "acme",
+            &format!("SELECT ts FROM logs WHERE attrs['event_ms'] = '{d64}'"),
+            &report.tokens,
+        )
+        .await,
+        1,
+        "the Date64 value is stored as its native millisecond count ({d64}), not rescaled"
+    );
+    // Not rescaled to nanoseconds: the ns-scaled value must NOT match.
+    assert_eq!(
+        logs_query_rows(
+            &store,
+            "acme",
+            &format!(
+                "SELECT ts FROM logs WHERE attrs['event_ms'] = '{}'",
+                d64 * 1_000_000
+            ),
+            &report.tokens,
+        )
+        .await,
+        0,
+        "the Date64 value is not multiplied to nanoseconds"
     );
 }
 


### PR DESCRIPTION
The operator-facing half of ADR-0100 decisions 1 and 2. Third task of #421.

Four things, all in `services/ravel-cli`, kept as one change because each touches `main.rs`'s clap surface and splitting them would produce divergent rewrites of the same file:

- **Overflow and near-cap warnings after a load.** Reads the router's own metrics and says what happened, in the terms the operator needs: how many `(name, type)` pairs overflowed the per-object dynamic-column budget, that each landed in `attrs_raw` so it stays queryable through `attrs['key']` but gets no typed column, and what to do about it. A separate near-cap warning fires at ≥90% of the budget with nothing yet overflowed, because pressure is worth knowing *before* the cliff. Nothing told an operator either thing before.
- **`load --batch-rows`.** The internal `load` already took the parameter; only the CLI hard-coded the default. One Strict flush happens per batch, so on a large load this is the lever that decides how many RLOG objects the load leaves behind — a first-order query-cost variable. Zero is a typed error, not a silent clamp.
- **`Date32`/`Date64` loading.** Previously unloadable: a wide analytical export routinely carries a date column and the type match rejected both. They land as `i64` attributes in their native units (days for `Date32`, milliseconds for `Date64`), documented where a mapping author will see it, and explicitly not routed through the `ts_column` timestamp path — a rescaled date is silent corruption, since every value stays a plausible date.
- **`typed-attr-column set --from-mapping`.** Derives the declared-column list from a `--mapping` document and writes it through the existing CAS whole-list replace, unchanged. Derives from both `[[attribute]]` and `[[resource_attribute]]` (declared columns read the merged resource+scope+record view, so a stream-level key is legitimately declarable). `ColType::F64` has no `DeclaredColumnType` counterpart, so those keys are skipped with a per-key warning and the rest are still written. Duplicate and conflicting keys are rejected by the existing `validate_typed_attr_columns` rather than a reimplementation. Derivation order is file order, single pass, no sorting and no `HashMap` iteration: the durable list's order is schema-append order, so a reordering between reads would change query results.

The loader still does not touch tenant config. The control-plane write stays in the control-plane subcommand.

Reviewed adversarially before this PR (opus, on the result ref): **PASS**. Two things it did that were worth the run:

It checked the warning's *denominator* rather than trusting the report — a wrong cap would make every near-cap warning fire at the wrong point. Traced independently: `log_shard.rs:320` constructs the writer as `RlogWriter::new(RlogConfig::default(), ...)` and `IngestConfig` carries no RLOG override, so the loader's `default()` matches the write budget exactly. Correct on this tree, with the latent coupling noted — if a future change plumbs `max_dynamic_columns` through `IngestConfig`, the loader's `default()` goes stale.

And it found that **no test exercised `load::run`**: every warning test called the helper directly, so all of them stayed green with the emit loop deleted. The second commit fixes that. `run` now delegates to `run_warning_to` with the warning stream injected, and the new test drives it with a Parquet fixture, a mapping file on disk, a real router and a real write, asserting both warnings came out of the passed-in stream. Demonstrated non-vacuous: with the emit loop disabled, 17 load tests pass and only the new one fails.

Boundaries the review confirmed by inspection and by mutation: 900/1000 warns, 899 and 890 do not, `max == 0` is guarded, `used == 0` produces nothing, and overflow and near-cap are mutually exclusive.

Verified locally, each command unpiped with its exit code captured: `cargo test -p ravel-cli` 90 tests across four binaries pass, `cargo clippy -p ravel-cli --all-targets` exit 0, `cargo fmt --all --check` clean.

Fixes: #426
