### PR TITLE
fix(scripts): compare fleet result branches against origin/main

### DIFF
--- a/scripts/fleet-result-inspect.sh
+++ b/scripts/fleet-result-inspect.sh
@@ -3,35 +3,48 @@
 # it, so the caller can review scope before merging (never trust an
 # executor's own "gates green" claim; see the merge-fleet-result skill).
 #
-# Usage: fleet-result-inspect.sh <task-id>
+# Usage: fleet-result-inspect.sh <task-id> [base-ref]
 #
-# Prints: commits on the result branch not yet on main, and the diff stat
-# vs main. Exits nonzero (from `git fetch`/`git ls-remote`) if the result
-# ref does not exist: a `done` status with no result ref means the
+# base-ref defaults to origin/main. No session working in this repo checks
+# out or advances local `main`, so it sits wherever it was when the clone
+# or the session started; diffing against it silently mixes in every commit
+# another session has landed since, and presents a correctly-scoped result
+# as far larger than it is (or hides a real scope violation inside that
+# noise). This script always fetches origin/main itself before comparing,
+# so the base is never whatever local main happened to be.
+#
+# Prints: commits on the result branch not yet on the base, and the diff
+# stat vs the base. Exits nonzero (from `git fetch`/`git ls-remote`) if the
+# result ref does not exist: a `done` status with no result ref means the
 # executor never committed and the work is gone; re-dispatch instead of
 # retrying this script.
 set -euo pipefail
 
 if [[ $# -lt 1 ]]; then
-  echo "usage: $0 <task-id>" >&2
+  echo "usage: $0 <task-id> [base-ref]" >&2
   exit 64
 fi
 
 task_id="$1"
+base_ref="${2:-origin/main}"
 result_ref="refs/heads/task/${task_id}/result"
 
 echo "==> Verifying ${result_ref} exists on origin"
 git ls-remote --exit-code origin "${result_ref}" >/dev/null
 
+echo "==> Fetching origin/main"
+git fetch -q origin main
+
 echo "==> Fetching ${result_ref}"
 git fetch origin "${result_ref}"
+result_sha="$(git rev-parse FETCH_HEAD)"
 
-echo "==> Commits on the result branch not yet on main:"
-git log --oneline "main..FETCH_HEAD"
+echo "==> Commits on the result branch not yet on ${base_ref}:"
+git log --oneline "${base_ref}..${result_sha}"
 
 echo
-echo "==> Diff scope vs main:"
-git diff --stat "main...FETCH_HEAD"
+echo "==> Diff scope vs ${base_ref}:"
+git diff --stat "${base_ref}...${result_sha}"
 
 echo
 echo "Review the above. If scope matches what was dispatched, merge with:"


### PR DESCRIPTION
`fleet-result-inspect.sh` diffed a dispatched task's result branch against the local `main` ref. No session working in this repo checks out or advances local `main`, so it sits wherever it was when the clone or the session started, drifting further behind with every PR another session merges over the course of a run.

The script's whole job is to let a reviewer judge a result's scope before merging it, and a stale base breaks that judgment in both directions. A correctly scoped result gets padded with every commit landed elsewhere since the session began, reading exactly like a runaway-scope executor — the failure this step exists to catch. A real scope violation can sit hidden inside that same noise, indistinguishable from someone else's legitimate work.

Reported live: inspecting a correctly-scoped 4-file, +665-line result printed 21 files and 4096 insertions, because local `main` was 8 commits stale and six of those commits (from two other epics) got attributed to the wrong task.

Fetch `origin/main` explicitly and default the comparison base to it, with an optional second argument to override the base. Resolve the result ref to its own commit up front so later commands compare two fixed points rather than reusing `FETCH_HEAD` after a second fetch has overwritten it.

Checked the two related scripts for the same assumption: `epic-status.sh` does not reference `main` at all and is unaffected. `fleet-result-merge.sh` already fetches and diffs against `origin/main` — only this script had the bug.

**Verified against a scratch commit** pushed to a throwaway result ref, with local `main` genuinely 4 commits behind `origin/main` (this session's own worktree, no simulation needed). The unpatched script printed those 4 unrelated commits as part of the result; the fix printed exactly the one commit and one file that were actually on the branch.

No cargo build affected — shell script only, `shellcheck` clean.

Fixes: #439