### PR TITLE
refactor(otlp,otap): share one OTel unit mapping table

### DIFF
--- a/crates/ravel-otap/src/normalize.rs
+++ b/crates/ravel-otap/src/normalize.rs
@@ -13,8 +13,10 @@
 //! identical rejection classes for the same logical input. Where
 //! `ravel_otlp::normalize` exposes a helper as `pub`, we call it directly;
 //! where a helper is private (sanitization, `push_checked`,
-//! `any_value_to_label_value`), we mirror it exactly below. See the crate
-//! report for a shared-helper refactor suggestion.
+//! `any_value_to_label_value`), we mirror it exactly below. The OTel unit
+//! mapping is one such shared helper: the metadata unit word is taken from the
+//! canonical `ravel_otlp::normalize::metadata_unit_word` rather than re-derived
+//! here, so a single edit to that table changes both ingest paths at once.
 //!
 //! Known scope gap (flagged, not silently worked around): the OTAP test
 //! encoder in `encode.rs` never emits `RESOURCE_ATTRS` or `SCOPE_ATTRS`
@@ -78,7 +80,7 @@ use arrow::array::{
 use arrow::datatypes::UInt8Type;
 use ravel_otlp::metadata::{MetricKind as PromMetricKind, MetricMetadata};
 use ravel_otlp::normalize::{
-    MetricsNormalizeResult, NormalizedExemplar, map_unit, prometheus_family_name,
+    MetricsNormalizeResult, NormalizedExemplar, metadata_unit_word, prometheus_family_name,
 };
 use ravel_otlp::promcompat::format_float;
 use ravel_otlp::{IngestLimits, NormalizeOutput, NormalizedPoint, Rejection};
@@ -941,93 +943,6 @@ fn metadata_kind(kind: &RootKind) -> PromMetricKind {
         RootKind::Summary => PromMetricKind::Summary,
         RootKind::Unsupported => PromMetricKind::Unknown,
     }
-}
-
-/// The unit word stored in a metadata tuple: the mapped Prometheus word when the
-/// unit maps (so it agrees with the suffix [`prometheus_family_name`] put on the
-/// name), otherwise the raw unit with annotations stripped, otherwise empty
-/// (ADR-0085 Decision 1/2).
-///
-/// This mirrors `ravel_otlp::normalize`'s private `metadata_unit_word` /
-/// `unit_suffix` pair, the same way this module already mirrors that crate's
-/// private sanitization helpers: the mapped-word table itself is reused through
-/// the pub `map_unit`, and only the compound (`a/b`) and annotation handling is
-/// restated. Exporting `metadata_unit_word` from `ravel-otlp` would let both
-/// paths share one function; that is a `ravel-otlp` change, outside this task's
-/// scope, and is flagged rather than made here.
-fn metadata_unit_word(unit: &str, kind: PromMetricKind) -> String {
-    match metadata_unit_suffix(unit, kind) {
-        Some(word) => word,
-        // Unmapped: carry the raw unit through as free text. This is a metadata
-        // field, not a metric name, so metric-name sanitizing does not apply.
-        None => strip_unit_annotations(unit).trim().to_string(),
-    }
-}
-
-/// The mapped unit suffix (without a leading `_`), or `None` when the unit adds
-/// no suffix (empty, unrecognized simple unit, or `1` on a non-gauge).
-fn metadata_unit_suffix(unit: &str, kind: PromMetricKind) -> Option<String> {
-    let stripped = strip_unit_annotations(unit);
-    let trimmed = stripped.trim();
-    if trimmed.is_empty() {
-        return None;
-    }
-    if trimmed == "1" {
-        return match kind {
-            PromMetricKind::Gauge => Some("ratio".to_string()),
-            _ => None,
-        };
-    }
-    if let Some((num_raw, den_raw)) = trimmed.split_once('/') {
-        let num = num_raw.trim();
-        let den = den_raw.trim();
-        let num_mapped =
-            (!num.is_empty()).then(|| map_unit(num).unwrap_or_else(|| num.to_string()));
-        let den_mapped =
-            (!den.is_empty()).then(|| map_per_unit(den).unwrap_or_else(|| den.to_string()));
-        match (num_mapped, den_mapped) {
-            (Some(n), Some(d)) => Some(format!("{n}_per_{d}")),
-            (Some(n), None) => Some(n),
-            (None, Some(d)) => Some(format!("per_{d}")),
-            (None, None) => None,
-        }
-    } else {
-        map_unit(trimmed)
-    }
-}
-
-/// Strip every `{...}` annotation from a unit, at any nesting, tolerating
-/// unbalanced braces (a unit string is attacker-influenced and must never
-/// panic). Mirrors `ravel_otlp::normalize`'s private `strip_annotations`.
-fn strip_unit_annotations(unit: &str) -> String {
-    let mut out = String::with_capacity(unit.len());
-    let mut depth: usize = 0;
-    for c in unit.chars() {
-        match c {
-            '{' => depth += 1,
-            '}' => depth = depth.saturating_sub(1),
-            _ if depth == 0 => out.push(c),
-            _ => {}
-        }
-    }
-    out
-}
-
-/// A per-unit denominator through the Collector's `perUnitMapper` table, where
-/// `m` is `minute` rather than `meters`. Mirrors `ravel_otlp::normalize`'s
-/// private `map_per_unit`.
-fn map_per_unit(unit: &str) -> Option<String> {
-    let mapped = match unit {
-        "s" => "second",
-        "m" => "minute",
-        "h" => "hour",
-        "d" => "day",
-        "w" => "week",
-        "mo" => "month",
-        "y" => "year",
-        _ => return None,
-    };
-    Some(mapped.to_string())
 }
 
 fn payloads_of(batch: &DecodedBatch, ty: ArrowPayloadType) -> Vec<&RecordBatch> {
@@ -2690,51 +2605,62 @@ fn explode_summary_point(
 mod tests {
     use super::*;
 
-    /// The unit word this module stores must be the same word
-    /// `ravel_otlp::normalize`'s private `metadata_unit_word` stores, since the
-    /// two surfaces write the same durable record. Pinned against the exact
-    /// table that crate's own tests pin (mapped word, dimensionless ratio,
-    /// unmapped raw passthrough, annotation-only collapse, compound form), so a
-    /// future divergence in either mirror fails here.
+    /// Run ravel-otap's real metadata path for a single gauge metric carrying
+    /// `unit` and return the unit word it stores. Drives [`build_metadata`], the
+    /// same function `normalize_impl` calls, so the word returned here is the
+    /// one an ingested OTAP metric would carry, not a re-derived value.
+    fn otap_stored_unit_word(unit: &str) -> String {
+        let root = vec![Some(RootEntry {
+            name: "m".to_string(),
+            kind: RootKind::Gauge,
+            unit: unit.to_string(),
+            description: String::new(),
+        })];
+        let decisions = vec![Some(MetricDecision {
+            name: "m".to_string(),
+            is_sum: false,
+            is_monotonic: false,
+        })];
+        let meta = build_metadata(&root, &decisions, &[None], &[None], &[true]);
+        meta.into_iter()
+            .next()
+            .expect("a produced metric yields one metadata tuple")
+            .unit
+    }
+
+    /// The unit word ravel-otap stores must be exactly the one ravel-otlp's
+    /// canonical `metadata_unit_word` produces: the two surfaces write the same
+    /// durable record, so they must agree on every shape the mapping handles.
+    ///
+    /// This compares ravel-otap's real-path output against ravel-otlp's function
+    /// directly (first assert), which catches a private mirror reappearing in
+    /// this crate and drifting, and pins ravel-otlp's canonical output to the
+    /// expected Prometheus word (second assert), so an edit to that single table
+    /// cannot silently change what ravel-otap stores. Covers the annotated,
+    /// per-unit, mapped-word, unmapped, and empty shapes.
     #[test]
-    fn metadata_unit_word_mirrors_the_otlp_mapping() {
-        assert_eq!(metadata_unit_word("By", PromMetricKind::Counter), "bytes");
-        assert_eq!(
-            metadata_unit_word("s", PromMetricKind::Histogram),
-            "seconds"
-        );
-        assert_eq!(metadata_unit_word("", PromMetricKind::Gauge), "");
-        // Dimensionless `1` is `ratio` on a gauge and nothing on any other kind,
-        // where "nothing" still carries the raw unit as free text.
-        assert_eq!(metadata_unit_word("1", PromMetricKind::Gauge), "ratio");
-        assert_eq!(metadata_unit_word("1", PromMetricKind::Counter), "1");
-        // Unmapped units pass through raw, never metric-name sanitized.
-        assert_eq!(
-            metadata_unit_word("furlong", PromMetricKind::Gauge),
-            "furlong"
-        );
-        assert_eq!(metadata_unit_word("2h", PromMetricKind::Gauge), "2h");
-        // Annotations are stripped; an annotation-only unit is empty.
-        assert_eq!(metadata_unit_word("{request}", PromMetricKind::Gauge), "");
-        assert_eq!(
-            metadata_unit_word("{packet}/s", PromMetricKind::Gauge),
-            "per_second"
-        );
-        // Compound form, each side mapped independently. `m` is `minute` in the
-        // denominator, not `meters`.
-        assert_eq!(
-            metadata_unit_word("By/s", PromMetricKind::Gauge),
-            "bytes_per_second"
-        );
-        assert_eq!(
-            metadata_unit_word("By/m", PromMetricKind::Gauge),
-            "bytes_per_minute"
-        );
-        // An unrecognized side passes through rather than being dropped.
-        assert_eq!(
-            metadata_unit_word("furlong/fortnight", PromMetricKind::Gauge),
-            "furlong_per_fortnight"
-        );
+    fn otap_metadata_unit_word_matches_ravel_otlp_canonical() {
+        // (raw unit, the word ravel-otlp's canonical table currently produces
+        // for a gauge).
+        let cases = [
+            ("{packets}", ""),            // annotation-only, stripped to empty
+            ("By/s", "bytes_per_second"), // per-unit compound
+            ("By", "bytes"),              // simple unit needing a metadata word
+            ("furlong", "furlong"),       // no mapping, raw passthrough
+            ("", ""),                     // empty
+        ];
+        for (unit, pinned) in cases {
+            let canonical = ravel_otlp::normalize::metadata_unit_word(unit, PromMetricKind::Gauge);
+            assert_eq!(
+                otap_stored_unit_word(unit),
+                canonical,
+                "ravel-otap must store ravel-otlp's canonical word for {unit:?}"
+            );
+            assert_eq!(
+                canonical, pinned,
+                "ravel-otlp unit table changed for {unit:?}"
+            );
+        }
     }
 
     /// The METRICS `metric_type`/`is_monotonic` pair maps to the same Prometheus

--- a/crates/ravel-otlp/src/normalize.rs
+++ b/crates/ravel-otlp/src/normalize.rs
@@ -1781,8 +1781,17 @@ fn unit_suffix(unit: &str, kind: MetricKind) -> Option<String> {
 
 /// The unit word stored in a metric's [`MetricMetadata`]: the mapped Prometheus
 /// word when the unit maps (agreeing with the name suffix), otherwise the raw
-/// unit sanitized as a metric name, otherwise empty (ADR-0085 Decision 1/2).
-fn metadata_unit_word(unit: &str, kind: MetricKind) -> String {
+/// unit with annotations stripped and trimmed, otherwise empty (ADR-0085
+/// Decision 1/2).
+///
+/// This is the canonical OTel-unit-to-metadata-word mapping. Other crates that
+/// store a [`MetricMetadata`] unit for an OTel metric (`ravel-otap`) must call
+/// this rather than re-derive the table: one edit here changes every ingest
+/// surface at once, and a private second copy silently drifts on the first
+/// edit to either. It shares the same compound (`a/b`) and annotation handling
+/// as the [`prometheus_family_name`] suffix, so the word stored in metadata and
+/// the word appended to the metric name always agree.
+pub fn metadata_unit_word(unit: &str, kind: MetricKind) -> String {
     if let Some(word) = unit_suffix(unit, kind) {
         return word;
     }
@@ -4752,6 +4761,34 @@ mod tests {
         }
         assert_eq!(map_unit("furlong"), None);
         assert_eq!(map_unit(""), None);
+    }
+
+    /// Direct contract test for the now-`pub` [`metadata_unit_word`], the
+    /// canonical mapping `ravel-otap` calls rather than re-derive. Other tests
+    /// exercise it only through the end-to-end `suffixed` metadata; this pins
+    /// each shape at the public boundary so a caller in another crate sees a
+    /// stable contract: mapped word, dimensionless ratio (gauge only), raw
+    /// passthrough for an unmapped or non-gauge `1`, annotation stripping, the
+    /// compound per-unit form, and empty.
+    #[test]
+    fn metadata_unit_word_contract() {
+        use MetricKind::{Counter, Gauge};
+        assert_eq!(metadata_unit_word("By", Counter), "bytes");
+        assert_eq!(metadata_unit_word("s", MetricKind::Histogram), "seconds");
+        assert_eq!(metadata_unit_word("", Gauge), "");
+        assert_eq!(metadata_unit_word("1", Gauge), "ratio");
+        // `1` maps to nothing off a gauge, so the raw `1` carries through.
+        assert_eq!(metadata_unit_word("1", Counter), "1");
+        assert_eq!(metadata_unit_word("furlong", Gauge), "furlong");
+        assert_eq!(metadata_unit_word("2h", Gauge), "2h");
+        assert_eq!(metadata_unit_word("{request}", Gauge), "");
+        assert_eq!(metadata_unit_word("{packet}/s", Gauge), "per_second");
+        assert_eq!(metadata_unit_word("By/s", Gauge), "bytes_per_second");
+        assert_eq!(metadata_unit_word("By/m", Gauge), "bytes_per_minute");
+        assert_eq!(
+            metadata_unit_word("furlong/fortnight", Gauge),
+            "furlong_per_fortnight"
+        );
     }
 
     #[test]


### PR DESCRIPTION
`ravel-otap` carried its own copy of ravel-otlp's OTel unit mapping — `unit_suffix`, `strip_annotations`, `map_per_unit`, `metadata_unit_word` — because those helpers were private and only `map_unit`/`prometheus_family_name` were public. Two copies of one table diverge on the first edit to either, and ravel-otap's parity test pinned hardcoded strings, so it could not have detected the divergence it existed to guard.

ravel-otlp is now the single source. Exactly one helper became public, `metadata_unit_word`, because it is the only one ravel-otap called across the boundary — the other three were used solely inside ravel-otap's own mirror of it, so they had no reason to be exported. The newly public item carries a doc comment saying it is the canonical mapping other crates must call rather than re-derive.

The old parity test is replaced by one that compares ravel-otap's real `build_metadata` output against ravel-otlp's function directly, over the shapes the mapping actually has to handle: an annotated unit, a per-unit, a unit needing a metadata word, a unit with no mapping, and the empty string. A new direct test in ravel-otlp pins the contract at the boundary that just became public.

**The two copies had not already diverged.** Byte-identical logic — same per-unit table, same annotation stripping, same compound and ratio handling, same raw passthrough. So this is behaviour-preserving: output is identical for every input, before and after. Worth stating explicitly, because a pre-existing divergence would have been a live bug on the OTAP ingest path rather than a cleanup detail.

No mirror survives: `map_per_unit`, `strip_unit_annotations`, `metadata_unit_suffix`, `strip_annotations`, `unit_suffix` and `fn metadata_unit_word` all grep clean in ravel-otap's `src` and `tests`, and `map_unit` went with them (it was only reachable from the deleted mirror). No new dependency edge — ravel-otap already depended on ravel-otlp.

Verified locally rather than taken on report: `cargo test -p ravel-otlp -p ravel-otap` passes 261 tests, `cargo fmt --all --check` clean. And the parity guard was proven by mutating the canonical table — changing `"By" => "bytes"` to `"octets"` in ravel-otlp fails **two** ravel-otap tests (`otap_metadata_unit_word_matches_ravel_otlp_canonical` on `"By/s"`, left `octets_per_second` vs right `bytes_per_second`, plus `build_metadata_dedups_by_family_and_skips_unproduced`), so a future edit on one side cannot pass unnoticed.

Reported and deliberately not fixed: ravel-otap still mirrors ravel-otlp's private sanitization helpers (`push_checked`, `any_value_to_label`, and friends). Same class of hazard, separate scope.

Fixes: #259
