### PR TITLE
fix(ingest): report a surviving shard's token on a partial log write

### DIFF
--- a/crates/ravel-ingest/src/log_error.rs
+++ b/crates/ravel-ingest/src/log_error.rs
@@ -1,6 +1,8 @@
 //! Errors returned to strict-mode waiters of the log pipeline, the log-side
 //! counterpart of [`crate::WriteError`].
 
+use ravel_types::CommitToken;
+
 /// Failure classification for a single log shard's contribution to a write.
 ///
 /// Variants carry only owned strings (not the underlying store/publish
@@ -53,21 +55,63 @@ pub enum LogWriteError {
     /// The gateway maps it to HTTP 429 / gRPC `RESOURCE_EXHAUSTED`.
     #[error("ingest buffer byte budget reached")]
     BufferBudgetExceeded,
+    /// A multi-shard Strict write in which at least one shard failed *after*
+    /// one or more sibling shards had already acked their commit durably in
+    /// the same [`LogIngestRouter::write`](crate::LogIngestRouter::write) call
+    /// (issue #296). `inner` is the underlying single-shard classification the
+    /// write would otherwise have surfaced; `durable` carries the commit
+    /// tokens the successful siblings actually acked, so that durable data is
+    /// reportable instead of being silently discarded by the error return.
+    ///
+    /// The router constructs this only when `durable` is non-empty: a failure
+    /// that touched no durably-committed sibling still surfaces as the bare
+    /// underlying variant, so an existing single-shard caller sees no change.
+    /// `durable` never includes a shard whose ack failed to resolve (a
+    /// panicked actor): an unresolved ack is not a durable write and reporting
+    /// it as one would be worse than the bug this closes.
+    ///
+    /// This is an information-carrying wrapper, not a new failure mode: it is
+    /// exactly as retryable as its `inner` cause ([`Self::is_retryable`]), and
+    /// a caller that ignores [`Self::durable_tokens`] behaves exactly as it did
+    /// before (the write is still reported as a failure).
+    #[error("{inner}")]
+    PartialWrite {
+        inner: Box<LogWriteError>,
+        durable: Vec<CommitToken>,
+    },
 }
 
 impl LogWriteError {
     /// Whether a client may reasonably retry the whole write after this
     /// error. `SegmentBuild` and `StreamIdCollision` are excluded: both
     /// reflect a problem with the input itself, not a transient condition.
+    /// A [`Self::PartialWrite`] is exactly as retryable as its underlying
+    /// cause: it is the same failure, carrying recovered sibling tokens.
     pub fn is_retryable(&self) -> bool {
-        matches!(
-            self,
+        match self {
             LogWriteError::ShardUnavailable
-                | LogWriteError::AckTimeout
-                | LogWriteError::Abandoned(_)
-                | LogWriteError::StaleProvisioningView
-                | LogWriteError::BufferBudgetExceeded
-        )
+            | LogWriteError::AckTimeout
+            | LogWriteError::Abandoned(_)
+            | LogWriteError::StaleProvisioningView
+            | LogWriteError::BufferBudgetExceeded => true,
+            LogWriteError::SegmentBuild(_) | LogWriteError::StreamIdCollision(_) => false,
+            LogWriteError::PartialWrite { inner, .. } => inner.is_retryable(),
+        }
+    }
+
+    /// The commit tokens for sibling shards that acked durable in the same
+    /// multi-shard `write()` call as this failure (issue #296). Empty for
+    /// every variant except [`Self::PartialWrite`]: a failure that committed
+    /// no sibling durably carries no tokens, and neither does a failure whose
+    /// ack round never resolved (an [`Self::AckTimeout`], or a
+    /// [`Self::ShardUnavailable`] raised at send time before any ack was
+    /// awaited). A caller that ignores this loses only information, never
+    /// correctness -- the write is still an error.
+    pub fn durable_tokens(&self) -> &[CommitToken] {
+        match self {
+            LogWriteError::PartialWrite { durable, .. } => durable,
+            _ => &[],
+        }
     }
 }
 
@@ -90,5 +134,44 @@ mod tests {
         assert!(LogWriteError::Abandoned("x".into()).is_retryable());
         assert!(LogWriteError::AckTimeout.is_retryable());
         assert!(LogWriteError::ShardUnavailable.is_retryable());
+    }
+
+    #[test]
+    fn non_partial_variants_carry_no_durable_tokens() {
+        assert!(LogWriteError::AckTimeout.durable_tokens().is_empty());
+        assert!(
+            LogWriteError::Abandoned("x".into())
+                .durable_tokens()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn partial_write_carries_tokens_and_delegates_retryability_and_display() {
+        use ravel_types::CommitToken;
+
+        let token = CommitToken {
+            shard: 3,
+            writer_id: uuid::Uuid::nil(),
+            epoch: 0,
+            seq: 7,
+            ingest_hour_bucket: 0,
+        };
+        // A retryable cause: the wrapper is retryable and surfaces the cause's
+        // own Display, not a new string.
+        let retryable = LogWriteError::PartialWrite {
+            inner: Box::new(LogWriteError::Abandoned("data put exhausted".into())),
+            durable: vec![token.clone()],
+        };
+        assert!(retryable.is_retryable());
+        assert_eq!(retryable.durable_tokens(), std::slice::from_ref(&token));
+        assert_eq!(retryable.to_string(), "flush abandoned: data put exhausted");
+
+        // A non-retryable cause makes the wrapper non-retryable too.
+        let not_retryable = LogWriteError::PartialWrite {
+            inner: Box::new(LogWriteError::StreamIdCollision("clash".into())),
+            durable: vec![token],
+        };
+        assert!(!not_retryable.is_retryable());
     }
 }

--- a/crates/ravel-ingest/src/log_router.rs
+++ b/crates/ravel-ingest/src/log_router.rs
@@ -346,24 +346,62 @@ impl LogIngestRouter {
         }
 
         // `join_all` preserves input order, so `joined[i]` is `ack_shards[i]`.
+        // On a deadline elapse the whole `join_all` future is dropped, so no
+        // per-shard ack is observed: `AckTimeout` carries no recovered tokens
+        // (a sibling that committed inside the elapsed window is unknowable
+        // here, and reporting an unresolved ack as durable would be wrong).
         let joined = tokio::time::timeout(ack_deadline, futures::future::join_all(ack_rxs))
             .await
             .map_err(|_| LogWriteError::AckTimeout)?;
-        let mut tokens = Vec::with_capacity(joined.len());
+
+        // Every ack resolved. Scan them all: collect every shard that acked a
+        // durable commit (issue #296), and record the first failure in shard
+        // order so the returned classification and `mark_shard_dead` side
+        // effect are exactly what the pre-fix early-return produced. A shard
+        // whose ack failed to resolve (`RecvError`: the actor panicked
+        // mid-flush) is NOT a durable write and contributes no token.
+        let mut durable = Vec::with_capacity(joined.len());
+        let mut first_error: Option<LogWriteError> = None;
+        let mut dead_shard: Option<u32> = None;
         for (shard, result) in ack_shards.into_iter().zip(joined) {
-            // A `RecvError` here means the actor dropped the ack sender without
-            // sending: it panicked mid-flush (a healthy actor always acks, even
-            // on abandonment). Count the death and report it as unavailable.
-            let inner = match result {
-                Ok(inner) => inner,
+            match result {
+                Ok(Ok(token)) => durable.push(token),
+                Ok(Err(shard_error)) => {
+                    if first_error.is_none() {
+                        first_error = Some(shard_error);
+                    }
+                }
                 Err(_) => {
-                    self.mark_shard_dead(&set[shard as usize]);
-                    return Err(LogWriteError::ShardUnavailable);
+                    if first_error.is_none() {
+                        first_error = Some(LogWriteError::ShardUnavailable);
+                        dead_shard = Some(shard);
+                    }
+                }
+            }
+        }
+
+        if let Some(inner) = first_error {
+            // Preserve the exact failure semantics: the death is counted once,
+            // only when the first failure in shard order is a dropped ack, and
+            // only then (a resolved shard-level error never marked a death).
+            if let Some(shard) = dead_shard {
+                self.mark_shard_dead(&set[shard as usize]);
+            }
+            // Carry the durably-acked sibling tokens only when there are any;
+            // a failure with no partial success surfaces as the bare variant,
+            // unchanged from before this fix.
+            let error = if durable.is_empty() {
+                inner
+            } else {
+                LogWriteError::PartialWrite {
+                    inner: Box::new(inner),
+                    durable,
                 }
             };
-            tokens.push(inner?);
+            return Err(error);
         }
-        Ok(LogWriteReceipt { tokens })
+
+        Ok(LogWriteReceipt { tokens: durable })
     }
 
     /// Records the first observation of a shard actor's death, deduped so a

--- a/crates/ravel-ingest/tests/log_router.rs
+++ b/crates/ravel-ingest/tests/log_router.rs
@@ -20,6 +20,9 @@ use ravel_commit::keys;
 use ravel_commit::record::{self, NewCommitRecord};
 use ravel_ingest::{IngestConfig, LogIngestRouter, LogWriteError, WriteMode};
 use ravel_logseg::{Predicate, RlogConfig, RlogReader, stream_attrs_bytes};
+use ravel_object_store::fault::{
+    FaultKind, FaultPlan, FaultStore, Occurrence, Op, Rule, ScriptedFault,
+};
 use ravel_object_store::memory::MemoryStore;
 use ravel_object_store::{
     Capabilities, DelimitedList, GetOutcome, GetRange, ListPage, ObjectMeta, ObjectStoreBackend,
@@ -369,6 +372,230 @@ async fn dead_shard_is_observable_and_counted_once() {
         1,
         "a permanently dead shard is counted once, not once per routed write"
     );
+
+    router.shutdown().await;
+}
+
+/// Issue #296: a multi-shard Strict write where one shard's flush is abandoned
+/// (its data-object PUT fails permanently) while a sibling shard commits
+/// durably in the same `write()` call. The failure must still surface as an
+/// error, and the sibling's commit token must be recoverable from that error
+/// via `LogWriteError::durable_tokens` rather than being silently discarded.
+///
+/// Non-vacuity (prove-the-test): the failing shard (shard 0) sorts *first* in
+/// the router's ack-collection loop, so before the fix the loop's `inner?`
+/// returned at shard 0 and never looked at shard 1's successful ack. Against
+/// that unfixed loop this test fails at the `durable_tokens().len() == 1`
+/// assertion (the recovered list is empty). The injected fault is asserted via
+/// the `FaultStore` counter so the test proves the abandonment actually fired.
+#[tokio::test]
+async fn partial_failure_recovers_the_surviving_shards_token() {
+    let shard_count = 4;
+    // Fail every data-object PUT for shard 0 (`/l0/0000/`) permanently: a
+    // non-retryable store error abandons that flush on the first attempt with
+    // no backoff, so the outcome is deterministic and needs no clock advance.
+    let plan = FaultPlan::empty().with_rule(
+        Rule::new(
+            Op::Put,
+            ScriptedFault::Permanent("simulated permanent data-object PUT failure".into()),
+        )
+        .with_key_contains("/l0/0000/")
+        .with_occurrence(Occurrence::Always),
+    );
+    let store = Arc::new(FaultStore::new(MemoryStore::new(), plan));
+    let clock = TestClock::new(BASE_NS);
+    let router = LogIngestRouter::new(
+        flush_on_first(shard_count),
+        store.clone() as Arc<dyn ObjectStoreBackend>,
+        clock.clone(),
+    );
+
+    let tenant = tenant("acme");
+    let victim = record_on_shard(0, shard_count, 1_000, "victim");
+    let survivor = record_on_shard(1, shard_count, 2_000, "survivor");
+    assert_ne!(
+        shard_for_log(&victim.stream_id, shard_count),
+        shard_for_log(&survivor.stream_id, shard_count),
+        "the fixture must span two shards"
+    );
+
+    let err = router
+        .write(
+            tenant.clone(),
+            vec![victim, survivor],
+            WriteMode::Strict,
+            Duration::from_secs(5),
+        )
+        .await
+        .expect_err("one shard's flush was abandoned, so the write is a failure");
+
+    // The failure is still a failure, and still classifies as its underlying
+    // (retryable) abandonment cause.
+    assert!(
+        err.is_retryable(),
+        "an abandoned-flush partial write stays retryable, got {err}"
+    );
+
+    // The surviving shard's durable token is recoverable from the error.
+    let recovered = err.durable_tokens();
+    assert_eq!(
+        recovered.len(),
+        1,
+        "exactly the surviving shard's token is recoverable, got {recovered:?}"
+    );
+    let records = read_back(store.as_ref(), &tenant.hash(), &recovered[0]).await;
+    assert_eq!(records.len(), 1);
+    assert_eq!(
+        records[0].body, "survivor",
+        "the recovered token points at the shard that actually committed"
+    );
+
+    // Prove the injected fault fired: the victim shard's data PUT was rejected.
+    assert_eq!(
+        store.fault_count(Op::Put, FaultKind::Permanent),
+        1,
+        "the permanent data-object PUT fault fired exactly once (shard 0, no retry)"
+    );
+
+    router.shutdown().await;
+}
+
+/// Lands a conflicting commit record at shard 0's commit key and reports
+/// `AlreadyExists`, driving the pinned-identity split-brain panic in *that
+/// specific* shard actor. Unlike `SplitBrainOnFirstCommit`, it targets shard 0
+/// only (`/c/0000/`), so a sibling shard's commit is untouched and the panic is
+/// deterministic regardless of inter-actor flush ordering.
+struct SplitBrainOnShardZeroCommit {
+    inner: MemoryStore,
+    poisoned: AtomicBool,
+}
+
+impl SplitBrainOnShardZeroCommit {
+    fn new() -> Self {
+        SplitBrainOnShardZeroCommit {
+            inner: MemoryStore::new(),
+            poisoned: AtomicBool::new(false),
+        }
+    }
+
+    fn conflicting_record(&self) -> Bytes {
+        let rec = record::build(NewCommitRecord {
+            tenant_hash: tenant("acme").hash(),
+            signal: Signal::Logs,
+            shard: 0,
+            writer_id: Uuid::nil(),
+            writer_epoch: 1,
+            writer_seq: 0,
+            object_size: 1,
+            content_hash: [0xAA; 32],
+            sample_count: 1,
+            series_count: 1,
+            min_event_ts_ns: 0,
+            max_event_ts_ns: 0,
+            min_ingest_ts_ns: 0,
+            max_ingest_ts_ns: 0,
+            segment_format_version: 1,
+            created_unix_ns: 0,
+            ingest_hour_bucket: 0,
+        })
+        .expect("valid conflicting record");
+        record::encode(&rec)
+    }
+}
+
+#[async_trait]
+impl ObjectStoreBackend for SplitBrainOnShardZeroCommit {
+    async fn put(
+        &self,
+        key: &str,
+        data: Bytes,
+        opts: PutOptions,
+    ) -> Result<PutOutcome, StoreError> {
+        if key.contains("/c/0000/") && !self.poisoned.swap(true, Ordering::SeqCst) {
+            self.inner
+                .put(key, self.conflicting_record(), PutOptions::default())
+                .await?;
+            return Err(StoreError::AlreadyExists);
+        }
+        self.inner.put(key, data, opts).await
+    }
+
+    async fn get(&self, key: &str, range: GetRange) -> Result<GetOutcome, StoreError> {
+        self.inner.get(key, range).await
+    }
+
+    async fn head(&self, key: &str) -> Result<ObjectMeta, StoreError> {
+        self.inner.head(key).await
+    }
+
+    async fn list(&self, prefix: &str, page: Option<PageToken>) -> Result<ListPage, StoreError> {
+        self.inner.list(prefix, page).await
+    }
+
+    async fn list_delimited(&self, prefix: &str) -> Result<DelimitedList, StoreError> {
+        self.inner.list_delimited(prefix).await
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), StoreError> {
+        self.inner.delete(key).await
+    }
+
+    fn capabilities(&self) -> Capabilities {
+        Capabilities {
+            multipart: false,
+            ..self.inner.capabilities()
+        }
+    }
+}
+
+/// Issue #296: a shard whose ack never resolves (its actor panics mid-flush,
+/// so the ack sender is dropped) must contribute NO token to the recovered
+/// partial-success list, while a sibling that did commit durably is still
+/// recovered. Reporting the panicked shard's records as durable would be worse
+/// than the original bug, since nothing was acked.
+#[tokio::test]
+async fn an_unresolved_ack_contributes_no_token() {
+    let shard_count = 4;
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(SplitBrainOnShardZeroCommit::new());
+    let clock = TestClock::new(BASE_NS);
+    let router = LogIngestRouter::new(
+        flush_on_first(shard_count),
+        Arc::clone(&store),
+        clock.clone(),
+    );
+
+    let tenant = tenant("acme");
+    let victim = record_on_shard(0, shard_count, 1_000, "victim");
+    let survivor = record_on_shard(1, shard_count, 2_000, "survivor");
+
+    let err = router
+        .write(
+            tenant.clone(),
+            vec![victim, survivor],
+            WriteMode::Strict,
+            Duration::from_secs(5),
+        )
+        .await
+        .expect_err("the split-brain panic takes shard 0's actor down mid-flush");
+
+    // The write still fails as ShardUnavailable, and the death is counted once.
+    assert!(
+        err.is_retryable(),
+        "ShardUnavailable is retryable, got {err}"
+    );
+    assert_eq!(router.metrics().snapshot().shard_deaths, 1);
+
+    // Only the surviving shard's token is recovered; the panicked shard, whose
+    // ack never resolved, contributes none.
+    let recovered = err.durable_tokens();
+    assert_eq!(
+        recovered.len(),
+        1,
+        "only the committed sibling's token is recovered, not the panicked shard's, got {recovered:?}"
+    );
+    let records = read_back(store.as_ref(), &tenant.hash(), &recovered[0]).await;
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].body, "survivor");
 
     router.shutdown().await;
 }

--- a/docs/guides/ingest.md
+++ b/docs/guides/ingest.md
@@ -525,14 +525,18 @@ cap) is rejected **fail-fast**: the run stops at the first bad row, prints a
 per-row error, and exits non-zero. Batches durable before that row stay durable.
 
 A failed flush (an object-store PUT failure) exits non-zero and prints the
-commit tokens durable from batches completed before the failure. This list is
-a lower bound, not an exact account: the loader shards a batch across the
-target signal's shards and waits for every shard's ack, but on the first
-shard error it returns before collecting tokens from shards that acked
-successfully in that same batch, so a shard's records can be durable and
-still go unreported. A failure mid-file is a genuine **partial load, not a
-rollback**. There is **no resumability or deduplication**: re-running after
-any failure re-ingests the whole file from the start.
+commit tokens durable from batches completed before the failure, plus any shard
+of the failing batch itself that acked its commit durably before a sibling
+shard failed. The loader shards a batch across the target signal's shards and
+waits for every shard's ack; when one shard fails while a sibling committed,
+the sibling's token is recovered from the write error and reported, so the
+printed list is **exact** for that partial-flush case. It remains a lower bound
+only when the failing batch's ack round did not resolve at all -- an
+ack-deadline timeout, or a shard's channel dying at send time -- because no
+per-shard ack is observed then, and a commit can land without an observable
+ack. A failure mid-file is a genuine **partial load, not a rollback**. There is
+**no resumability or deduplication**: re-running after any failure re-ingests
+the whole file from the start.
 
 Retention and GC key on ingest-hour buckets, which the loader derives from
 *load* time. A bulk-loaded record with an old event timestamp is therefore

--- a/services/ravel-cli/src/load.rs
+++ b/services/ravel-cli/src/load.rs
@@ -240,8 +240,9 @@ pub fn dynamic_column_warnings(
 /// Returns `Err` (nonzero exit) for any failure. On a flush failure or a
 /// rejected row, the durable commit tokens are printed rather than swallowed
 /// (ADR-0089): a failure mid-file is a genuine partial load. See
-/// [`print_durable_tokens`] for the one case (a flush failure) where the
-/// printed list is a lower bound rather than exact.
+/// [`print_durable_tokens`] for the residual cases (a flush that timed out or
+/// lost a shard at send time) where the printed list can still be a lower
+/// bound rather than exact.
 pub async fn run(
     store: Arc<dyn ObjectStoreBackend>,
     parquet_path: &Path,
@@ -336,21 +337,24 @@ fn print_summary(report: &LoadReport) {
 
 /// Print the commit tokens known durable before a failure, one per line, so
 /// an operator can see what landed (ADR-0089 deliverable 7). On
-/// [`LoadError::Flush`] this is a lower bound, not an exact account: the
-/// listed tokens are batches completed *before* the failing one, and do not
-/// include a shard that may have committed within the failing batch itself
-/// while a sibling shard's ack failed (see that variant's doc). Every other
-/// variant's tokens are exact -- the failing row or batch never reached
-/// `LogIngestRouter::write`.
+/// [`LoadError::Flush`] the list now includes the failing batch's own shards
+/// that acked durable before a sibling shard failed, recovered from the
+/// router error via `LogWriteError::durable_tokens` (issue #296), so it is
+/// exact for the common partial-flush case. It remains a lower bound only when
+/// the failing batch's ack round did not resolve at all -- an ack-deadline
+/// timeout, or a shard channel dying at send time -- because no per-shard ack
+/// is observed then. Every non-flush variant's tokens are exact: the failing
+/// row or batch never reached `LogIngestRouter::write`.
 fn print_durable_tokens(err: &LoadError) {
     let tokens = err.durable_tokens();
     let is_flush = matches!(err, LoadError::Flush { .. });
     if tokens.is_empty() {
         if is_flush {
             println!(
-                "no commit tokens were durable from a completed batch before the failure \
-                 (earlier batches, if any, all landed; the failing batch's own shards may or \
-                 may not have -- ravel-ingest does not report partial-shard success on error)"
+                "no commit tokens were durable before the failure (any earlier batches, and any \
+                 shard of the failing batch that acked durable, are listed here; none did -- if \
+                 the failing batch timed out or a shard died at send time, a shard may still have \
+                 committed without an observable ack)"
             );
         } else {
             println!("no commit tokens were durable before the failure (nothing landed)");
@@ -358,8 +362,9 @@ fn print_durable_tokens(err: &LoadError) {
         return;
     }
     let suffix = if is_flush {
-        " (this list may undercount: a shard within the failing batch itself may also have \
-          committed, but ravel-ingest does not report that on error)"
+        " (exact for a partial flush where a sibling shard committed; still a lower bound if the \
+          failing batch timed out or a shard died at send time, where a commit can land with no \
+          observable ack)"
     } else {
         ""
     };
@@ -427,15 +432,18 @@ pub enum LoadError {
         reason: String,
         durable: Vec<CommitToken>,
     },
-    /// A flush (object-store PUT) failed. The tokens are what was durable
-    /// from *earlier* batches. `LogIngestRouter::write` shards the failing
-    /// batch and waits for every shard's ack, but on the first shard error it
-    /// returns before collecting tokens from shards that acked successfully
-    /// in that same call (`LogWriteError` carries no partial-success data),
-    /// so a shard's records from the failing batch can be durable and still
-    /// go unreported here. Narrowing that gap needs `ravel-ingest` to return
-    /// per-shard outcomes on error; tracked as a follow-up, not fixed by this
-    /// type.
+    /// A flush (object-store PUT) failed. The tokens are what was durable from
+    /// *earlier* batches, plus any shard of the failing batch itself that acked
+    /// its commit durably before a sibling shard failed:
+    /// `LogIngestRouter::write` returns those recovered tokens on the error via
+    /// `LogWriteError::durable_tokens` (issue #296), and this variant appends
+    /// them. This list is therefore exact for the common partial-flush case (a
+    /// shard's flush abandoned or rejected while a sibling committed, all
+    /// within a completed ack round). It remains a lower bound only when the
+    /// ack round itself did not resolve: an ack-deadline timeout, or a shard's
+    /// channel dying at send time, returns before any per-shard ack is
+    /// observed, so no sibling token can be attributed even though one may have
+    /// landed. See [`print_durable_tokens`].
     #[error("flush failed: {cause}")]
     Flush {
         durable: Vec<CommitToken>,
@@ -471,12 +479,15 @@ impl LoadError {
 ///
 /// Fail-fast on the first row that fails a kept admission check. A run that
 /// returns `Ok` has every row durable; a run that returns `Err` reports the
-/// tokens durable from batches that completed before the failure (a partial
-/// load — re-running re-ingests the whole file, there is no resumability or
-/// dedup in this version). On a [`LoadError::Flush`], the reported tokens can
-/// undercount: a shard within the failing batch may have committed while a
-/// sibling shard's ack failed, and that shard's token is not recoverable from
-/// the current `LogIngestRouter::write` error (see the variant's doc).
+/// tokens durable from batches that completed before the failure, plus any
+/// shard of the failing batch that acked durable before a sibling shard failed
+/// (recovered from the router error, issue #296) — a partial load, re-running
+/// re-ingests the whole file, there is no resumability or dedup in this
+/// version. On a [`LoadError::Flush`], the reported tokens are exact for a
+/// partial flush where a sibling committed; they can still undercount only when
+/// the failing batch's ack round did not resolve (a timeout, or a shard dying
+/// at send time), where a commit can land with no observable ack (see the
+/// variant's doc).
 #[allow(clippy::too_many_arguments)]
 pub async fn load(
     store: Arc<dyn ObjectStoreBackend>,
@@ -589,9 +600,16 @@ pub async fn load(
                 WRITE_ACK_DEADLINE,
             )
             .await
-            .map_err(|e| LoadError::Flush {
-                durable: report.tokens.clone(),
-                cause: e.to_string(),
+            .map_err(|e| {
+                // Earlier batches are already durable; append this batch's own
+                // durably-acked shards, which `LogWriteError::durable_tokens`
+                // recovers from a multi-shard partial failure (issue #296).
+                let mut durable = report.tokens.clone();
+                durable.extend_from_slice(e.durable_tokens());
+                LoadError::Flush {
+                    durable,
+                    cause: e.to_string(),
+                }
             })?;
         report.rows_processed += n;
         report.tokens.extend(receipt.tokens);
@@ -1545,6 +1563,133 @@ type = "i64"
         assert!(
             err.to_string().contains("--batch-rows must be at least 1"),
             "the error names the lever: {err}"
+        );
+    }
+
+    /// The first host value (by an incrementing suffix) whose loader stream
+    /// identity routes to `target` under `shards`. Uses the loader's own
+    /// identity inputs -- resource attributes in mapping order, empty scope --
+    /// so it matches how `build_record` computes `stream_id`.
+    fn host_for_shard(target: u32, shards: u32) -> String {
+        use ravel_types::shard_for_log;
+        for i in 0..1_000_000u32 {
+            let host = format!("h{i}");
+            let resource = vec![
+                (
+                    "service.name".to_string(),
+                    AttrValue::Str("api".to_string()),
+                ),
+                ("host".to_string(), AttrValue::Str(host.clone())),
+            ];
+            let stream_id = log_stream_id(&resource, "", "", &[]);
+            if shard_for_log(&stream_id, shards) == target {
+                return host;
+            }
+        }
+        panic!("no host routes to shard {target} of {shards}");
+    }
+
+    /// Issue #296 reachability, end to end through the loader: a multi-shard
+    /// batch where one shard's data-object PUT fails permanently while a
+    /// sibling shard commits durably. `load` must return `LoadError::Flush`
+    /// whose durable-token list -- the exact list `print_durable_tokens` prints
+    /// -- includes the surviving shard's token, where before the fix that token
+    /// was structurally unreportable and the list undercounted.
+    ///
+    /// Non-vacuity (prove-the-test): the failing shard (shard 0) sorts first in
+    /// the router's ack loop, so the pre-fix early return dropped shard 1's
+    /// token; against that code this fails at `durable.len() == 1` (the list is
+    /// empty). The `FaultStore` counter is asserted so the abandonment is
+    /// proven to have fired.
+    #[tokio::test]
+    async fn flush_failure_reports_the_surviving_shards_durable_token() {
+        use parquet::arrow::ArrowWriter;
+        use ravel_object_store::fault::{
+            FaultKind, FaultPlan, FaultStore, Occurrence, Op, Rule, ScriptedFault,
+        };
+        use ravel_object_store::memory::MemoryStore;
+
+        let shards = 4;
+        let h_victim = host_for_shard(0, shards);
+        let h_survivor = host_for_shard(1, shards);
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let pq = dir.path().join("two_shards.parquet");
+        let cols: Vec<(String, ArrayRef)> = vec![
+            ("ts".to_string(), i64_col(vec![NOW_NS, NOW_NS])),
+            ("svc".to_string(), str_col(vec!["api", "api"])),
+            (
+                "host".to_string(),
+                str_col(vec![h_victim.as_str(), h_survivor.as_str()]),
+            ),
+        ];
+        let batch = RecordBatch::try_from_iter(cols).expect("two-row batch");
+        let file = std::fs::File::create(&pq).expect("create parquet");
+        let mut writer = ArrowWriter::try_new(file, batch.schema(), None).expect("arrow writer");
+        writer.write(&batch).expect("write batch");
+        writer.close().expect("close writer");
+
+        let m = parse_mapping(
+            "ts_column = \"ts\"\nts_unit = \"nanos\"\n\n\
+             [[resource_attribute]]\nkey = \"service.name\"\ncolumn = \"svc\"\ntype = \"str\"\n\n\
+             [[resource_attribute]]\nkey = \"host\"\ncolumn = \"host\"\ntype = \"str\"\n",
+        )
+        .expect("valid mapping");
+
+        // Fail every data-object PUT for shard 0 (`/l0/0000/`) permanently: a
+        // non-retryable error abandons that flush at once, deterministically,
+        // while shard 1 commits normally in the same Strict write.
+        let plan = FaultPlan::empty().with_rule(
+            Rule::new(
+                Op::Put,
+                ScriptedFault::Permanent("simulated permanent data-object PUT failure".into()),
+            )
+            .with_key_contains("/l0/0000/")
+            .with_occurrence(Occurrence::Always),
+        );
+        let store = Arc::new(FaultStore::new(MemoryStore::new(), plan));
+
+        let err = load(
+            store.clone() as Arc<dyn ObjectStoreBackend>,
+            &pq,
+            "acme",
+            &m,
+            shards,
+            // Both rows in one batch, so one Strict write spans both shards.
+            10,
+            NOW_NS,
+            Arc::new(FixedClock(NOW_NS)),
+        )
+        .await
+        .expect_err("one shard's flush was abandoned, so the load fails");
+
+        let durable = match &err {
+            LoadError::Flush { durable, cause } => {
+                assert!(
+                    cause.contains("flush abandoned"),
+                    "the flush failure classifies as the underlying abandonment: {cause}"
+                );
+                durable.clone()
+            }
+            other => panic!("expected LoadError::Flush, got {other:?}"),
+        };
+
+        // The exact list `print_durable_tokens` iterates: the surviving shard's
+        // token, recovered from the write error (issue #296).
+        assert_eq!(
+            err.durable_tokens().len(),
+            1,
+            "the surviving shard's token reaches the printed durable list, got {durable:?}"
+        );
+        assert_eq!(
+            durable[0].shard, 1,
+            "the recovered token is the surviving shard's (shard 1), not the abandoned shard 0"
+        );
+
+        assert_eq!(
+            store.fault_count(Op::Put, FaultKind::Permanent),
+            1,
+            "the permanent data-object PUT fault fired exactly once (shard 0, no retry)"
         );
     }
 }


### PR DESCRIPTION
When a multi-shard Strict write partly failed, `LogIngestRouter::write` discarded the commit tokens of shards that had already succeeded. The ack-collection loop did `tokens.push(inner?)`, so the first shard error returned early and every token collected before it was lost — the data was durable in object storage and the caller had no way to learn it. `LogWriteError` carried no partial-success data at all, which is why `ravel-cli load --parquet` documents its durable-token list as a *lower bound* rather than an account.

`LogWriteError::PartialWrite { inner, durable }` now carries the surviving tokens, with a `durable_tokens()` accessor, and the loader folds them into `LoadError::Flush`.

A variant rather than a paired return type, because `write()`'s error is consumed by `ravel-server`'s `logs_ingest.rs` and the two OTLP status maps, which are outside this change's scope: keeping the signature means those keep compiling, `is_retryable()` delegates through the wrapper, and their catch-all arms preserve the existing HTTP 503 / gRPC unavailable-vs-internal mapping exactly.

**A token is only reported for a write that is genuinely durable.** That is the property that matters here, since fabricating durability would be worse than the bug being fixed. A token enters `durable` on exactly one match arm, `Ok(Ok(token))` — the ack both resolved *and* resolved to success — and it is pushed inside the same arm that inspects that shard's own ack, over `zip`ped input-ordered results, so there is no collect-first-inspect-later window. At the source, `log_shard.rs` sends `Ok(token)` only after both the data-object and commit-record PUTs land.

**`LoadError::Flush` is now exact for the common partial-flush case, and still a lower bound in exactly two modes**, both because no per-shard ack is ever observed: an `AckTimeout` (the whole `join_all` is dropped) and a `ShardUnavailable` raised at send time. `BufferBudgetExceeded` and `StaleProvisioningView` return before routing, so nothing is durable and they are exact. The `LoadError::Flush` doc comment, `print_durable_tokens`, and `docs/guides/ingest.md` all say so — updated in this commit, because those three previously documented the gap this closes and leaving them stale would make the docs wrong in the opposite direction.

Failure semantics are unchanged: a partial failure is still an error, `mark_shard_dead` still fires, and `ShardUnavailable` behaves as before. This carries information; it does not change outcomes.

Tests use `FaultStore` with counter assertions proving the fault actually fired (`fault_count(Op::Put, FaultKind::Permanent) == 1`; the unresolved-ack case asserts `shard_deaths == 1`), and the loader test drives a real two-shard Parquet load end to end, asserting the surviving shard's token is recoverable from the error. Both new router tests were demonstrated failing pre-fix with `got []`.

Reviewed adversarially before this PR (opus, on the result ref): **PASS** on all five items. The reviewer traced every shard-failure path individually rather than reasoning from the diff, and proved the guard load-bearing by fabricating a token push into the dead-shard arm — `an_unresolved_ack_contributes_no_token` then failed with two tokens where it expects none. It also confirmed independently that the two remaining lower-bound modes are the only ones, by enumerating every error return that can occur after a sibling could have committed.

Verified locally, unpiped with exit codes captured: `cargo test -p ravel-ingest` 167+ tests pass, `cargo test -p ravel-cli` 79 lib plus integration pass, `cargo fmt --all --check` clean.

Reported by the review and deliberately not fixed here: on the OTLP path, a `PartialWrite` still discards the recovered sibling tokens and writes no idempotency marker for durably-committed siblings (`logs_ingest.rs`). Unchanged from before this commit and not a regression — the recovery this adds is simply unused there. Follow-up filed separately.

Fixes: #296
