### PR TITLE
fix(ravel-sql,ravel-logseg): unify has_word's phrase_match with the reader

### DIFF
--- a/crates/ravel-logseg/src/reader.rs
+++ b/crates/ravel-logseg/src/reader.rs
@@ -1214,7 +1214,13 @@ fn attr_value_eq(a: &AttrValue, b: &AttrValue) -> bool {
 /// Phrase/word match: `word` tokenizes to one or more query tokens; a single
 /// token requires containment, multiple tokens require an in-order contiguous
 /// run in the tokenized value (docs/log-segment-format.md "Tokenizer").
-fn phrase_match(value: &[u8], word: &str) -> bool {
+///
+/// `pub` so `ravel-sql`'s `has_word` UDF calls this directly instead of
+/// keeping its own copy: the pushed `Predicate::HasWord` filter here and the
+/// UDF re-applied above the scan must agree on every row for the pushdown to
+/// stay sound, and two independently maintained implementations can drift
+/// without either crate's own tests noticing.
+pub fn phrase_match(value: &[u8], word: &str) -> bool {
     let query = tokens(word);
     if query.is_empty() {
         return true;

--- a/crates/ravel-sql/src/logs_udf.rs
+++ b/crates/ravel-sql/src/logs_udf.rs
@@ -21,7 +21,8 @@
 //! rows the residual `has_word` above the scan would remove, so no row the
 //! query needs is ever dropped. This is the same agreement that makes the
 //! metrics `label_match` regex pushdown sound (crate::udf): the pushed arm and
-//! the re-applied UDF are the identical predicate.
+//! the re-applied UDF call the identical [`ravel_logseg::reader::phrase_match`],
+//! not two implementations kept in sync by hand.
 
 use std::sync::Arc;
 
@@ -30,7 +31,6 @@ use datafusion::arrow::datatypes::DataType;
 use datafusion::error::{DataFusionError, Result as DFResult};
 use datafusion::logical_expr::{ColumnarValue, ScalarUDF, Volatility, create_udf};
 use datafusion::scalar::ScalarValue;
-use ravel_logseg::tokenizer::tokens;
 
 /// The name of the `has_word(text, 'word') -> Boolean` UDF.
 pub const HAS_WORD_UDF: &str = "has_word";
@@ -46,18 +46,13 @@ pub fn has_word_udf() -> ScalarUDF {
     )
 }
 
-/// True iff `word` tokenizes to an in-order contiguous run of tokens present in
-/// the tokenized `text`. Mirrors `RlogReader`'s own `phrase_match` exactly so
-/// the pushed [`ravel_logseg::Predicate::HasWord`] and this UDF agree on every
-/// row (docs/log-segment-format.md "Tokenizer"). An empty query (a `word` with
-/// no tokens) matches every row, matching the reader.
+/// Forwards to `ravel_logseg::reader::phrase_match`, the same function
+/// `RlogReader::scan` applies as the pushed [`ravel_logseg::Predicate::HasWord`]
+/// filter, so the two can no longer drift into disagreement (there is only one
+/// implementation). `text` is always valid UTF-8 here (it comes from an Arrow
+/// `StringArray`), so the byte conversion cannot itself change the result.
 fn phrase_match(text: &str, word: &str) -> bool {
-    let query = tokens(word);
-    if query.is_empty() {
-        return true;
-    }
-    let toks = tokens(text);
-    toks.windows(query.len()).any(|w| w == query.as_slice())
+    ravel_logseg::reader::phrase_match(text.as_bytes(), word)
 }
 
 pub(crate) fn has_word_impl(args: &[ColumnarValue]) -> DFResult<ColumnarValue> {
@@ -115,6 +110,15 @@ mod tests {
         assert!(!phrase_match("connection timeout", "time"));
         // Case-insensitive, split on non-alphanumerics.
         assert!(phrase_match("GET /api/v1 TIMEOUT", "timeout"));
+    }
+
+    #[test]
+    fn empty_word_matches_every_row() {
+        // ravel_logseg::reader::phrase_match checks query.is_empty() before the
+        // UTF-8 conversion, so this is the one input where the shim's control
+        // flow order actually matters, not just its output.
+        assert!(phrase_match("connection timeout", ""));
+        assert!(phrase_match("", ""));
     }
 
     #[test]


### PR DESCRIPTION
## What

`has_word`'s UDF and `RlogReader::scan`'s pushed `HasWord` predicate each
kept their own copy of phrase/word matching. `ravel_logseg::reader::phrase_match`
is now `pub`, and `ravel-sql`'s `logs_udf::phrase_match` forwards to it
instead of reimplementing tokenize-and-match.

## Why

A #409 adversarial review found the double-implementation could drift
silently: the pushed predicate filters rows before the UDF ever sees
them, so a divergence between the two copies only shows up when a
query is specifically shaped to force the UDF to re-check rows the
pushdown already let through. The SQL conformance test for `has_word`
couldn't catch that shape by construction (#434).

With one implementation, that gap is closed structurally rather than
by adding a test for it: there's nothing left to drift, so the class
of bug is no longer expressible, not just harder to trigger.

`phrase_match` is a pure function of the frozen tokenizer with no
coupling to the RSEG format, so exporting it from `ravel-logseg`
doesn't need an ADR.

## Testing

- Mutation-proofed: broke the forwarding call, confirmed all three
  `logs_udf` tests fail, restored it.
- Added a test for the empty-word case, the one input where the
  reader's early `query.is_empty()` check and the old duplicate's
  tokenize-then-match order could in principle disagree even though
  both return `true`.
- `scripts/gates.sh -p ravel-logseg -p ravel-sql` green.

Fixes: #434
