### PR TITLE
fix(tracing-export): stop span-export test stalling in CI

### DIFF
--- a/crates/ravel-tracing-export/src/tests.rs
+++ b/crates/ravel-tracing-export/src/tests.rs
@@ -161,7 +161,18 @@ fn wait_until(mut f: impl FnMut() -> bool, timeout: Duration) -> bool {
 /// Decision 2/5: with `otlp: Some(_)`, a span emitted through the installed
 /// subscriber reaches the collector, carrying the span name and the
 /// `service.name` / `ravel.mode` resource attributes.
-#[tokio::test]
+///
+/// Runs on a multi-thread runtime, the same shape the service binaries install,
+/// not the single-thread default `#[tokio::test]` gives. `guard.flush()` drives
+/// `SdkTracerProvider::shutdown`, a synchronous call that internally waits on
+/// the batch processor's async export (with its own bounded timeout) to drain.
+/// On a single-thread runtime that async work cannot make progress while the
+/// blocking shutdown holds the runtime, so a collector that accepts the
+/// connection but is slow to answer leaves the flush waiting forever (issue
+/// #454: a 28-minute CI stall until the workflow timeout). A second worker lets
+/// the export's own timeout fire, so the flush returns in about ten seconds
+/// even against a collector that never responds.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn some_exports_the_emitted_span_to_the_collector() {
     let mock = start_mock_collector();
     let (dispatch, guard, degraded) =
@@ -180,10 +191,22 @@ async fn some_exports_the_emitted_span_to_the_collector() {
     }
 
     // Force the batch processor to flush on this call, off the mock's thread.
-    let flushed = tokio::task::spawn_blocking(move || {
-        guard.flush();
-    })
-    .await;
+    // The multi-thread runtime above is the fix for the #454 stall; this bound
+    // is the safety net. If the flush ever blocks past 20s anyway, fail with an
+    // attributable message rather than hang to the workflow timeout. A healthy
+    // flush against the live mock returns in milliseconds and even a
+    // never-responding collector returns in about ten seconds, so 20s never
+    // fires on a healthy run yet sits far below the workflow timeout. Nested
+    // results: `timeout`'s outer Ok means it returned, the inner `JoinHandle`'s
+    // Ok means `flush()` did not panic.
+    let flushed = tokio::time::timeout(
+        Duration::from_secs(20),
+        tokio::task::spawn_blocking(move || {
+            guard.flush();
+        }),
+    )
+    .await
+    .expect("flush against the live mock collector must return within 20s, not hang");
     flushed.expect("flush join");
 
     assert!(
@@ -405,10 +428,18 @@ async fn a_refused_collector_logs_a_runtime_export_failure_warning() {
     // Force an export attempt off the test's runtime. The export dials the
     // refused endpoint, fails, and the wrapper logs its one-shot warning on the
     // background thread, which reaches the global default installed above.
-    tokio::task::spawn_blocking(move || {
-        let _ = provider.shutdown();
-    })
+    // Bound the shutdown for the same reason the flush above is bounded (issue
+    // #454): a provider shutdown that drives the batch processor to talk to a
+    // network peer must never hang the test to the workflow timeout. A refused
+    // port fails fast, so 20s is generous.
+    tokio::time::timeout(
+        Duration::from_secs(20),
+        tokio::task::spawn_blocking(move || {
+            let _ = provider.shutdown();
+        }),
+    )
     .await
+    .expect("shutdown against the refused collector must return within 20s, not hang")
     .expect("shutdown join");
 
     let matched = |w: &str| {


### PR DESCRIPTION
`some_exports_the_emitted_span_to_the_collector` hung the `check` job for 28 minutes on PR #450 before the workflow timeout killed the run. `check` is a required check, so this intermittently blocks unrelated pull requests from every session working in this repo, and each occurrence costs a 25-minute rerun.

**Root cause: a test-runtime mismatch, not a product bug.** The test ran on the single-thread default `#[tokio::test]` runtime. `guard.flush()` drives `SdkTracerProvider::shutdown`, a *synchronous* call that internally waits for the batch processor's *async* export to drain. On a one-thread runtime the blocking shutdown holds the only worker, so the export can make no progress and its own internal timeout can never fire — against a collector that accepts the connection but answers slowly, the flush waits forever. The service binaries run a multi-thread runtime, where this cannot happen.

The fix is `#[tokio::test(flavor = "multi_thread", worker_threads = 2)]`. With a mock that records the span then sleeps 600s before responding, the flush returns in about ten seconds (the export's own timeout fires) and the test passes, versus hanging past 90s on current-thread.

A 20-second bound around the flush is added as a safety net, plus one on a previously unbounded provider shutdown in a sibling test. A healthy flush returns in milliseconds and even a never-responding collector returns in about ten seconds, so 20s never fires on a healthy machine yet sits far below the workflow timeout.

**The bound alone would have been a false green, and that is the important part of this change.** On the current-thread runtime the timer cannot advance while the blocking flush pegs the runtime, so `tokio::time::timeout` never fires — it hangs exactly as before. I verified this rather than taking it on report: reverting only the runtime flavor while keeping the 20s bound, with a 45-second blocking sleep before the flush, produces no panic at all. The run logs `test ... has been running for over 60 seconds` and was still hanging when I killed it at 130 seconds. Zero panics, zero failures — a mitigation that looks present and does nothing.

So the ordering matters: the multi-thread switch is the fix, and the timeout only becomes meaningful because of it.

Deliberate-stall proof of the bound in its shipped form: a 25-second sleep before the flush fails at 20.0s with `flush against the live mock collector must return within 20s, not hang: Elapsed(())`, exiting 101 at about 27 seconds — an attributable test failure in `check` rather than a workflow-timeout kill.

Every other wait in the crate was audited. `none_constructs_no_exporter_and_sends_nothing`'s flush is a no-op with no peer (`provider` is `None`, asserted) and is left unbounded; `an_unreachable_collector`'s flush was already bounded; the refused-collector shutdown was unbounded and is now bounded.

Verified locally: `cargo test -p ravel-tracing-export` 4 tests pass in 0.53s, `cargo fmt --all --check` clean.

Fixes: #454
