### PR TITLE
fix(fleet): let callers pin a WorkerSet process id

### DIFF
--- a/crates/ravel-fleet/src/worker_set.rs
+++ b/crates/ravel-fleet/src/worker_set.rs
@@ -208,6 +208,25 @@ impl WorkerSet {
         }
     }
 
+    /// The same worker under a caller-supplied `process_id` instead of the
+    /// freshly generated one.
+    ///
+    /// Rendezvous ownership is a function of the `process_id`, so a test that
+    /// needs a specific owner for a specific unit must be able to pin the id
+    /// the same way this crate's clocks are injected: a random draw inside the
+    /// constructor is the identity equivalent of `SystemTime::now()` in library
+    /// logic, and a test that searches for a peer id which outweighs a random
+    /// own id fails whenever that draw lands near the top of the weight range.
+    ///
+    /// Production callers never use this: they take [`WorkerSet::new`]'s fresh
+    /// UUID, so every process keeps a distinct membership identity. Two live
+    /// processes sharing one `process_id` would share one heartbeat key and one
+    /// rendezvous weight, which is exactly the collision decision 1 rules out.
+    pub fn with_process_id(mut self, process_id: Uuid) -> Self {
+        self.process_id = process_id;
+        self
+    }
+
     /// A worker with the ADR-0065 defaults (`H = 60s`, `3 * H` liveness window,
     /// 4 units in flight), started at `started_unix_ns`.
     pub fn with_defaults(started_unix_ns: i64) -> Self {
@@ -372,6 +391,33 @@ mod tests {
         for _ in 0..16 {
             assert_eq!(owner(&key, &live), Some(first), "owner must not vary");
         }
+    }
+
+    /// Two workers constructed without an explicit id get DIFFERENT ids. The
+    /// `with_process_id` seam must stay an override, never a shared default: two
+    /// live processes on one id would write one heartbeat key and carry one
+    /// rendezvous weight, colliding on ownership of every unit.
+    #[test]
+    fn default_process_ids_are_distinct() {
+        let a = worker(0);
+        let b = worker(0);
+        assert_ne!(a.process_id(), b.process_id());
+        assert_ne!(
+            WorkerSet::with_defaults(0).process_id(),
+            WorkerSet::with_defaults(0).process_id()
+        );
+    }
+
+    /// `with_process_id` pins the identity the rendezvous hash resolves against,
+    /// leaving the rest of the configuration alone.
+    #[test]
+    fn with_process_id_pins_the_identity() {
+        let pinned = Uuid::from_u128(0xABCD);
+        let w = worker(0).with_process_id(pinned);
+        assert_eq!(w.process_id(), pinned);
+        assert_eq!(w.solo_live_set(), vec![pinned]);
+        assert_eq!(w.unit_concurrency(), DEFAULT_UNIT_CONCURRENCY);
+        assert_eq!(w.heartbeat_interval(), H);
     }
 
     /// Ownership is independent of the order the live set is presented in: the

--- a/services/ravel-server/src/maintain.rs
+++ b/services/ravel-server/src/maintain.rs
@@ -2143,6 +2143,27 @@ mod tests {
         WorkerSet::with_defaults(0)
     }
 
+    /// The pinned membership identity the rendezvous-repartition tests below
+    /// resolve ownership against, plus a peer id that outweighs it for
+    /// `(TenantId::new("acme"), Signal::Metrics, shard 0)`.
+    ///
+    /// Rendezvous weight is a function of the process id, so a test that needs
+    /// a peer to take a specific unit must pin both ids. Searching a candidate
+    /// range for a peer that outweighs a randomly drawn own id fails outright
+    /// whenever that draw lands near the top of the weight range: with an own
+    /// id of `Uuid::from_u128(7282)`, no peer in the old `1..10_000` candidate
+    /// range flips this unit at all. The flip is asserted at each use, so a
+    /// change to `unit_key` or the weight function fails loudly here instead of
+    /// silently leaving the peer without ownership.
+    const PINNED_WORKER_ID: Uuid = Uuid::from_u128(1);
+    const PINNED_PEER_ID: Uuid = Uuid::from_u128(2);
+
+    /// A solo worker on [`PINNED_WORKER_ID`], otherwise identical to
+    /// [`solo_worker`].
+    fn pinned_worker() -> WorkerSet {
+        solo_worker().with_process_id(PINNED_WORKER_ID)
+    }
+
     /// The acceptance test for shared-store ownership (ADR-0065
     /// decisions 1 and 2): two maintain replicas sharing one store partition the
     /// unit set rather than both paying for it.
@@ -4815,21 +4836,23 @@ mod tests {
         let discovery_metrics = TenantDiscoveryMetrics::default();
         let safety = MaintenanceSafetyMetrics::default();
         let ownership = MaintenanceOwnershipMetrics::new(THRESHOLD);
-        let worker = solo_worker();
+        let worker = pinned_worker();
         let live_solo = worker.solo_live_set();
 
-        // A deterministic peer id whose presence in the live set flips shard
-        // 0's rendezvous owner away from `worker` (the argmax is a function
-        // of both ids, so some peer id must exist that outweighs `worker`'s
-        // own weight for this specific unit key).
-        let peer_id = (1u128..10_000)
-            .map(Uuid::from_u128)
-            .find(|candidate| {
-                let live = vec![worker.process_id(), *candidate];
-                !worker.owns_unit(&live, &tenant, Signal::Metrics, 0)
-            })
-            .expect("some peer id flips shard 0's rendezvous owner away from the solo worker");
-        let live_ab = vec![worker.process_id(), peer_id];
+        // Both ids are pinned, so the repartition this test needs is a fact
+        // about fixed inputs rather than a property of a random draw. Asserted,
+        // not assumed: shard 0 is owned here under the solo live set, and the
+        // peer's presence takes it away.
+        let live_ab = vec![worker.process_id(), PINNED_PEER_ID];
+        assert!(
+            worker.owns_unit(&live_solo, &tenant, Signal::Metrics, 0),
+            "the solo worker must own shard 0 under rendezvous hashing"
+        );
+        assert!(
+            !worker.owns_unit(&live_ab, &tenant, Signal::Metrics, 0),
+            "the pinned peer id must flip shard 0's rendezvous owner away from \
+             the solo worker"
+        );
 
         let inner = MemoryStore::new();
         publish_terminal_bucket(&inner, &tenant_id).await;
@@ -4958,7 +4981,7 @@ mod tests {
         let discovery_metrics = TenantDiscoveryMetrics::default();
         let safety = MaintenanceSafetyMetrics::default();
         let ownership = MaintenanceOwnershipMetrics::new(THRESHOLD);
-        let worker = solo_worker();
+        let worker = pinned_worker();
         let live_solo = worker.solo_live_set();
         let mut memo = MaintainMemo::with_default_interval();
 
@@ -5083,14 +5106,16 @@ mod tests {
         // The unit is now genuinely unowned, so its entry must be pruned --
         // the behavior the evaluated-keyed prune was written for, which
         // keying on ownership must preserve.
-        let peer_id = (1u128..10_000)
-            .map(Uuid::from_u128)
-            .find(|candidate| {
-                let live = vec![worker.process_id(), *candidate];
-                !worker.owns_unit(&live, &tenant, Signal::Metrics, 0)
-            })
-            .expect("some peer id flips shard 0's rendezvous owner away from the solo worker");
-        let live_ab = vec![worker.process_id(), peer_id];
+        let live_ab = vec![worker.process_id(), PINNED_PEER_ID];
+        assert!(
+            worker.owns_unit(&live_solo, &tenant, Signal::Metrics, 0),
+            "the solo worker must own shard 0 under rendezvous hashing"
+        );
+        assert!(
+            !worker.owns_unit(&live_ab, &tenant, Signal::Metrics, 0),
+            "the pinned peer id must flip shard 0's rendezvous owner away from \
+             the solo worker"
+        );
         let clean = store_with_tenant_data(&tenant_id).await;
         let _report = run_discovery_cycle(
             &clean,


### PR DESCRIPTION
`WorkerSet::new` hard-coded `Uuid::new_v4` for the process id, so a test that needed a peer to take rendezvous ownership of shard 0 had to search a candidate range and hope the random draw cooperated. It failed once in CI on an unrelated PR with `some peer id flips shard 0's rendezvous owner away from the solo worker`.

`WorkerSet::with_process_id(self, Uuid) -> Self` is a consuming builder, matching the repo's existing override idiom (`Catalog::with_provisioning_enforcement`, `FaultPlan::then_passthrough`). It adds a seam without touching `new`/`with_defaults`, so every existing caller compiles and behaves identically. A `new` parameter was rejected because it would churn roughly thirty call sites for a value two tests care about.

**The production path is unchanged and cannot share an id.** The only production construction is the maintain-role process, still `WorkerSet::new` with a fresh UUID; every other call site is inside a `#[cfg(test)]` module, and no production path calls `with_process_id`. That matters more than the flake: two live workers sharing one process id would share one heartbeat key and one rendezvous weight, colliding on ownership of every unit — far worse than an occasional red test. `default_process_ids_are_distinct` pins that guarantee, asserting two `WorkerSet`s built without an explicit id differ.

The flake's actual probability was measured rather than assumed: with process id `Uuid::from_u128(7282)`, *no* peer in the old `1..10_000` candidate range flips the unit. A 200,000-trial probe over random ids found 66 such cases, about 3.3e-4, matching the analytic ~1/10,000.

Nothing was weakened to gain determinism. The tests now **assert** what they previously assumed — that the solo worker owns shard 0 and that the pinned peer takes it away — so a change to `unit_key` or the weight function fails loudly here instead of silently leaving the peer without ownership.

Verified locally rather than taken on report:

- `cargo test -p ravel-fleet` 18 tests pass; the three `units_stalled` tests pass.
- The ownership assertion is load-bearing: setting `PINNED_PEER_ID` to an id that does not flip ownership fails two of the three tests (`units_stalled_drops_a_unit_that_leaves_the_owned_set` and `units_stalled_survives_a_transient_error_that_skips_a_still_owned_tick`).
- The executor separately showed the *product* property intact by making `UnitStallTracker::retain_owned`'s retain a no-op, which still fails both pinned tests.
- 20 consecutive runs of the previously flaking test, 20/20 green.
- `cargo fmt --all --check` clean.

Fixes: #198
