### PR TITLE
feat(ravel-bench): add sql_latency_bench per-query SQL latency harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4517,6 +4517,7 @@ dependencies = [
  "ravel-codec",
  "ravel-commit",
  "ravel-ingest",
+ "ravel-logseg",
  "ravel-maintain",
  "ravel-object-store",
  "ravel-otlp",

--- a/crates/ravel-bench/Cargo.toml
+++ b/crates/ravel-bench/Cargo.toml
@@ -11,6 +11,7 @@ ravel-types = { workspace = true }
 ravel-proto = { workspace = true }
 ravel-codec = { workspace = true }
 ravel-segment = { workspace = true }
+ravel-logseg = { workspace = true }
 ravel-otlp = { workspace = true }
 ravel-ingest = { workspace = true }
 ravel-object-store = { workspace = true }
@@ -226,6 +227,12 @@ path = "src/bin/groupby_scaling_bench.rs"
 required-features = ["sql-latency"]
 bench = false
 
+[[bin]]
+name = "sql_latency_bench"
+path = "src/bin/sql_latency_bench.rs"
+required-features = ["sql-latency"]
+bench = false
+
 [[test]]
 name = "read_accounting"
 path = "tests/read_accounting.rs"
@@ -264,6 +271,12 @@ bench = false
 [[test]]
 name = "query_latency_smoke"
 path = "tests/query_latency_smoke.rs"
+bench = false
+
+[[test]]
+name = "sql_latency_smoke"
+path = "tests/sql_latency_smoke.rs"
+required-features = ["sql-latency"]
 bench = false
 
 [[test]]

--- a/crates/ravel-bench/src/bin/sql_latency_bench.rs
+++ b/crates/ravel-bench/src/bin/sql_latency_bench.rs
@@ -1,0 +1,237 @@
+//! Per-query SQL latency benchmark over the ADR-0100 corpus (decision 4).
+//!
+//! Thin wrapper around `ravel_bench::sql_latency`: it parses the dataset source
+//! (`--generate` or `--tenant <id>`) and the store flag, classifies the backend
+//! for the report's provenance, drives the measurement core, and prints the
+//! report as JSON plus a human table.
+//!
+//! Gated behind the `sql-latency` feature so the default build never compiles
+//! ravel-sql/datafusion/arrow or this bin.
+//!
+//! Generated lane:
+//! `cargo run -p ravel-bench --features sql-latency --bin sql_latency_bench -- --generate`
+//!
+//! Loaded-tenant lane (needs a tenant already loaded by `ravel-cli load`):
+//! `... --bin sql_latency_bench -- --tenant <id> --store s3`
+#![allow(clippy::expect_used)]
+
+use std::process::ExitCode;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use clap::Parser;
+use ravel_bench::harness::{StoreKind, store_from_env};
+use ravel_bench::sql_corpus::{checked_default_corpus, load_external_corpus};
+use ravel_bench::sql_latency::{
+    Compaction, GenerateConfig, SqlLatencyReport, TenantConfigInput, run_generated, run_tenant,
+};
+use ravel_types::TimeRange;
+
+#[derive(Parser, Debug)]
+#[command(about = "Per-query SQL latency over the ADR-0100 corpus (cold/warm, min/median/max)")]
+struct Args {
+    /// Build a wide-schema dataset in process and measure against it.
+    #[arg(long, conflicts_with = "tenant")]
+    generate: bool,
+    /// Measure against a tenant already loaded in the configured object store.
+    #[arg(long)]
+    tenant: Option<String>,
+    /// Object-store backend. The generated lane defaults to `memory`; the
+    /// tenant lane usually needs `s3` (a loaded tenant lives in durable
+    /// storage).
+    #[arg(long, value_enum, default_value_t = StoreKind::Memory)]
+    store: StoreKind,
+    /// Executions per statement; the first is the cold run.
+    #[arg(long, default_value_t = 3)]
+    runs: usize,
+    /// An external corpus file (same format as the checked-in set), run instead
+    /// of the checked-in corpus.
+    #[arg(long)]
+    corpus: Option<String>,
+
+    // --- generated lane knobs ---------------------------------------------
+    /// Distinct log records to generate.
+    #[arg(long, default_value_t = 2_000)]
+    records: usize,
+    /// Records per RLOG object; the lever that sets the dataset's object count.
+    #[arg(long, default_value_t = 500)]
+    records_per_object: usize,
+    /// Filler attribute keys per record, widening the schema past the one
+    /// declared `duration_ms` column.
+    #[arg(long, default_value_t = 16)]
+    extra_attrs: usize,
+
+    // --- tenant lane knobs ------------------------------------------------
+    /// Which layout the tenant is in. ADR-0100 decision 4 requires the report
+    /// to state this rather than guess.
+    #[arg(long, value_enum, default_value_t = CompactionArg::Pre)]
+    compaction: CompactionArg,
+    /// Upper bound (unix seconds) of the resolve window and the injected query
+    /// clock. Defaults to the wall clock at startup.
+    #[arg(long)]
+    now_secs: Option<u64>,
+    /// How many hours before `--now-secs` the resolve window opens. Bounds the
+    /// catalog LIST fan-out; widen it for a tenant whose data is older.
+    #[arg(long, default_value_t = 24)]
+    window_hours: u64,
+}
+
+#[derive(Copy, Clone, Debug, clap::ValueEnum)]
+enum CompactionArg {
+    Pre,
+    Post,
+}
+
+impl From<CompactionArg> for Compaction {
+    fn from(a: CompactionArg) -> Self {
+        match a {
+            CompactionArg::Pre => Compaction::Pre,
+            CompactionArg::Post => Compaction::Post,
+        }
+    }
+}
+
+/// Classify the store for the report: backend name, region, and endpoint. A
+/// custom S3 endpoint is MinIO; a bare S3 config is S3; `MemoryStore` has
+/// neither region nor endpoint, so both carry the `"n/a"` sentinel.
+fn provenance_strings(store: StoreKind) -> (String, String, String) {
+    match store {
+        StoreKind::Memory => ("memory".to_string(), "n/a".to_string(), "n/a".to_string()),
+        StoreKind::S3 => {
+            let region = std::env::var("RAVEL_S3_REGION")
+                .ok()
+                .filter(|r| !r.is_empty())
+                .unwrap_or_else(|| "n/a".to_string());
+            match std::env::var("RAVEL_S3_ENDPOINT")
+                .ok()
+                .filter(|e| !e.is_empty())
+            {
+                Some(endpoint) => ("minio".to_string(), region, endpoint),
+                None => ("s3".to_string(), region, "n/a".to_string()),
+            }
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    let args = Args::parse();
+    match run(&args).await {
+        Ok(report) => {
+            match serde_json::to_string_pretty(&report) {
+                Ok(json) => println!("{json}"),
+                Err(err) => {
+                    eprintln!("sql_latency_bench: failed to serialize report: {err}");
+                    return ExitCode::FAILURE;
+                }
+            }
+            print_human_table(&report);
+            ExitCode::SUCCESS
+        }
+        Err(err) => {
+            eprintln!("sql_latency_bench: {err}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn run(args: &Args) -> Result<SqlLatencyReport, ravel_bench::sql_latency::Error> {
+    let entries = match &args.corpus {
+        Some(path) => load_external_corpus(path)?,
+        None => checked_default_corpus()?,
+    };
+    let (store_backend, region, endpoint) = provenance_strings(args.store);
+    let store = store_from_env(args.store);
+
+    match &args.tenant {
+        Some(tenant) => {
+            let now_secs = args.now_secs.unwrap_or_else(|| {
+                SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .map(|d| d.as_secs())
+                    .unwrap_or(0)
+            });
+            let now_ns = (now_secs as i64).saturating_mul(1_000_000_000);
+            let start_ns =
+                now_ns.saturating_sub((args.window_hours as i64).saturating_mul(3_600_000_000_000));
+            let cfg = TenantConfigInput {
+                store,
+                store_backend,
+                region,
+                endpoint,
+                tenant: tenant.clone(),
+                entries,
+                runs: args.runs,
+                window: TimeRange {
+                    start_ns,
+                    end_ns: now_ns,
+                },
+                now_ns,
+                compaction: args.compaction.into(),
+            };
+            run_tenant(&cfg).await
+        }
+        None => {
+            if !args.generate {
+                return Err("choose a dataset source: --generate or --tenant <id>".into());
+            }
+            let cfg = GenerateConfig {
+                store,
+                store_backend,
+                region,
+                endpoint,
+                entries,
+                runs: args.runs,
+                records: args.records,
+                records_per_object: args.records_per_object,
+                extra_attrs: args.extra_attrs,
+            };
+            run_generated(&cfg).await
+        }
+    }
+}
+
+fn print_human_table(report: &SqlLatencyReport) {
+    let p = &report.provenance;
+    let d = &report.dataset;
+    println!("\nsql_latency_bench report");
+    println!(
+        "  backend    : {} (region={}, endpoint={})",
+        p.store_backend, p.region, p.endpoint
+    );
+    println!("  host       : {} logical cores", p.host_logical_cores);
+    println!("  source     : {}  dataset={}", p.source, p.dataset_id);
+    println!(
+        "  dataset    : {} objects, {} bytes, {} rows, layout={}, load={:.1}ms",
+        d.object_count, d.stored_bytes, d.rows, d.layout, d.load_wall_ms
+    );
+    println!("  runs/query : {}", p.runs);
+    println!();
+    println!(
+        "  {:<32} | {:>9} | {:>9} | {:>9} | {:>9} | {:>7} | {:>7} | {:>7} | {:>7}",
+        "id", "min ms", "med ms", "max ms", "cold ms", "rows", "blk_tot", "blk_scn", "get"
+    );
+    println!(
+        "  {:-<32}-+-{:-<9}-+-{:-<9}-+-{:-<9}-+-{:-<9}-+-{:-<7}-+-{:-<7}-+-{:-<7}-+-{:-<7}",
+        "", "", "", "", "", "", "", "", ""
+    );
+    for e in &report.entries {
+        println!(
+            "  {:<32} | {:>9.3} | {:>9.3} | {:>9.3} | {:>9.3} | {:>7} | {:>7} | {:>7} | {:>7}",
+            e.id,
+            e.min_ms,
+            e.median_ms,
+            e.max_ms,
+            e.cold_ms,
+            e.rows_returned,
+            e.scan.blocks_total,
+            e.scan.blocks_scanned,
+            e.scan.object_store_get_requests,
+        );
+    }
+    if !report.skipped.is_empty() {
+        println!("\n  skipped (unsatisfied declared column):");
+        for s in &report.skipped {
+            println!("    {:<32} missing `{}`: {}", s.id, s.missing_key, s.reason);
+        }
+    }
+}

--- a/crates/ravel-bench/src/lib.rs
+++ b/crates/ravel-bench/src/lib.rs
@@ -20,4 +20,6 @@ pub mod section_accounting;
 pub mod segment_support;
 #[cfg(feature = "sql-latency")]
 pub mod sql_corpus;
+#[cfg(feature = "sql-latency")]
+pub mod sql_latency;
 pub mod value_shapes;

--- a/crates/ravel-bench/src/sql_corpus.rs
+++ b/crates/ravel-bench/src/sql_corpus.rs
@@ -88,6 +88,63 @@ impl Modification {
     }
 }
 
+/// One of the four declared logical types an attribute column can take
+/// (ADR-0090 decision 1), mirrored here as a serializable field so a corpus
+/// entry can state the declared column it depends on. Kept in this crate rather
+/// than reusing [`ravel_sql::DeclaredType`] because that type is deliberately
+/// not `Serialize`/`Deserialize`; [`Self::as_declared_type`] bridges the two.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RequiredDeclaredType {
+    /// A `Str`-typed declared column (Arrow `Utf8`).
+    Str,
+    /// An `I64`-typed declared column (Arrow `Int64`).
+    I64,
+    /// A `Bool`-typed declared column (Arrow `Boolean`).
+    Bool,
+    /// A `Bytes`-typed declared column (Arrow `Binary`).
+    Bytes,
+}
+
+impl RequiredDeclaredType {
+    /// The matching [`ravel_sql::DeclaredType`], so the harness can compare a
+    /// required declaration against a resolved [`ravel_sql::DeclaredColumn`].
+    pub fn as_declared_type(self) -> ravel_sql::DeclaredType {
+        match self {
+            RequiredDeclaredType::Str => ravel_sql::DeclaredType::Str,
+            RequiredDeclaredType::I64 => ravel_sql::DeclaredType::I64,
+            RequiredDeclaredType::Bool => ravel_sql::DeclaredType::Bool,
+            RequiredDeclaredType::Bytes => ravel_sql::DeclaredType::Bytes,
+        }
+    }
+}
+
+/// A declared typed attribute column a statement depends on: the attribute key
+/// plus the type it must be declared as (ADR-0100 decision 4).
+///
+/// This is data, not a doc comment: a statement that filters or aggregates a
+/// declared column returns wrong numbers (every row NULL) rather than an error
+/// when that column is absent from the tenant under measurement, so the
+/// requirement travels with the statement and the `sql_latency_bench` `--tenant`
+/// lane skips any entry the tenant does not satisfy.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RequiredDeclaration {
+    /// The attribute key the statement reads as a declared typed column.
+    pub key: String,
+    /// The declared type that key must carry.
+    pub ty: RequiredDeclaredType,
+}
+
+impl RequiredDeclaration {
+    /// A declared-column requirement for `key` at type `ty`.
+    pub fn new(key: impl Into<String>, ty: RequiredDeclaredType) -> Self {
+        RequiredDeclaration {
+            key: key.into(),
+            ty,
+        }
+    }
+}
+
 /// One corpus statement and everything a reader needs to judge it.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CorpusEntry {
@@ -111,6 +168,20 @@ pub struct CorpusEntry {
     /// computes.
     #[serde(default)]
     pub modified: Modification,
+    /// The declared typed attribute columns this statement depends on. Additive
+    /// under corpus `version = 1`: an older corpus file that predates this field
+    /// parses with an empty list (`#[serde(default)]`), and an entry with no
+    /// declared-column dependency carries an empty list too.
+    #[serde(default)]
+    pub required_declarations: Vec<RequiredDeclaration>,
+}
+
+impl CorpusEntry {
+    /// Attach the declared typed attribute columns this statement needs.
+    fn requiring(mut self, declarations: Vec<RequiredDeclaration>) -> Self {
+        self.required_declarations = declarations;
+        self
+    }
 }
 
 /// A parsed corpus document: a format version plus its entries.
@@ -291,6 +362,10 @@ fn entry(id: &str, sql: &str, constructs: &[&str], expected_rows: Option<usize>)
         // so there is no upstream id to diff against and nothing to disclose.
         upstream_id: None,
         modified: Modification::Verbatim,
+        // Most statements read only the fixed `logs` columns and depend on no
+        // declaration; the two that query `duration_ms` state that in
+        // `default_corpus` via `CorpusEntry::requiring`.
+        required_declarations: Vec::new(),
     }
 }
 
@@ -332,13 +407,21 @@ pub fn default_corpus() -> Vec<CorpusEntry> {
             "SELECT count(*) FROM logs WHERE duration_ms >= 1000",
             &["declared i64 typed comparison", "Filter (WHERE)", "count"],
             Some(1),
-        ),
+        )
+        .requiring(vec![RequiredDeclaration::new(
+            "duration_ms",
+            RequiredDeclaredType::I64,
+        )]),
         entry(
             "typed_duration_sum",
             "SELECT sum(duration_ms) FROM logs WHERE severity_num >= 9",
             &["declared i64 typed aggregate", "Filter (WHERE)", "sum"],
             Some(1),
-        ),
+        )
+        .requiring(vec![RequiredDeclaration::new(
+            "duration_ms",
+            RequiredDeclaredType::I64,
+        )]),
         // --- String search ------------------------------------------------
         entry(
             "body_word_search",
@@ -450,6 +533,88 @@ mod tests {
         // The same check through the shipped gate, so the gate itself is what a
         // caller relies on rather than this test's open-coded loop.
         checked_default_corpus().expect("checked-in corpus passes its own gate");
+    }
+
+    #[test]
+    fn the_two_duration_entries_declare_their_dependency_in_data() {
+        let corpus = default_corpus();
+        // The declared-column dependency now lives in the entry data, not in a
+        // doc comment: exactly the two `duration_ms` statements carry it, at
+        // type i64, and every other entry carries an empty list.
+        for e in &corpus {
+            let needs_duration =
+                e.id == "typed_duration_threshold_count" || e.id == "typed_duration_sum";
+            if needs_duration {
+                assert_eq!(
+                    e.required_declarations,
+                    vec![RequiredDeclaration::new(
+                        "duration_ms",
+                        RequiredDeclaredType::I64
+                    )],
+                    "entry `{}` must declare duration_ms:i64 in data",
+                    e.id
+                );
+            } else {
+                assert!(
+                    e.required_declarations.is_empty(),
+                    "entry `{}` reads only fixed columns and must declare nothing",
+                    e.id
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn required_declarations_is_additive_over_version_1() {
+        // A corpus file written before this field existed omits it entirely and
+        // must still parse under `version = 1`, its entries carrying an empty
+        // requirement list. Proves the field is additive, not a format break.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = write_corpus(
+            &dir,
+            "old.json",
+            r#"{
+              "version": 1,
+              "entries": [
+                {
+                  "id": "old_entry",
+                  "sql": "SELECT count(*) FROM logs",
+                  "constructs": ["count"]
+                }
+              ]
+            }"#,
+        );
+        let entries = load_external_corpus(&path).expect("pre-field corpus still parses");
+        assert_eq!(entries.len(), 1);
+        assert!(
+            entries[0].required_declarations.is_empty(),
+            "an absent required_declarations field defaults to empty"
+        );
+
+        // And a corpus that does carry the field round-trips through serde.
+        let path2 = write_corpus(
+            &dir,
+            "new.json",
+            r#"{
+              "version": 1,
+              "entries": [
+                {
+                  "id": "new_entry",
+                  "sql": "SELECT count(*) FROM logs WHERE duration_ms >= 1000",
+                  "constructs": ["declared i64 typed comparison", "count"],
+                  "required_declarations": [{"key": "duration_ms", "ty": "i64"}]
+                }
+              ]
+            }"#,
+        );
+        let entries2 = load_external_corpus(&path2).expect("corpus with the field parses");
+        assert_eq!(
+            entries2[0].required_declarations,
+            vec![RequiredDeclaration::new(
+                "duration_ms",
+                RequiredDeclaredType::I64
+            )]
+        );
     }
 
     #[test]
@@ -632,6 +797,7 @@ mod tests {
             modified: Modification::Modified {
                 reason: "   ".to_string(),
             },
+            required_declarations: Vec::new(),
         }];
         let err = gate_corpus(&entries).expect_err("an empty reason must fail");
         assert!(

--- a/crates/ravel-bench/src/sql_latency.rs
+++ b/crates/ravel-bench/src/sql_latency.rs
@@ -1,0 +1,706 @@
+//! Per-query SQL latency harness over the ADR-0100 corpus (decision 4).
+//!
+//! Where `query_latency` times the PromQL evaluator, this module times the SQL
+//! executor one corpus statement at a time and reports, per statement, the
+//! minimum / median / maximum of `--runs` executions with the first flagged
+//! cold, the rows it returned, and the scan diagnostics the executor already
+//! computes (`SqlStats` block counters plus the query's `QueryAccounting`
+//! object-store request/byte and cache counters). A stopwatch says a query is
+//! slow; those counters say where the time went.
+//!
+//! Two dataset sources feed the same measurement core ([`measure_corpus`]):
+//!
+//! - [`run_generated`] builds a wide-schema logs dataset in process (the way
+//!   `flight_sql_egress` publishes its dataset: write RLOG objects and their
+//!   commit records straight to the store) and installs the union of the
+//!   corpus's `required_declarations` through [`StaticDeclaredColumns`], which
+//!   sidesteps the server cache's staleness horizon. This is the lane the smoke
+//!   test exercises.
+//! - [`run_tenant`] runs against a tenant already loaded in the configured
+//!   object store (by `ravel-cli load --parquet`). It does *not* install
+//!   declarations; it resolves the tenant's real durable declaration
+//!   ([`ravel_catalog::read_config_values`]), because that is the configuration
+//!   under measurement, and it *verifies* every entry's `required_declarations`
+//!   against what resolved, skipping (never running) any entry whose declared
+//!   column is absent: a missing declared column projects NULL for every row,
+//!   so the query would return wrong numbers with a plausible latency instead
+//!   of an error.
+//!
+//! Report-only: like the rest of `ravel-bench`, this never changes library
+//! behavior, it only measures it.
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use ravel_catalog::{Catalog, CatalogConfig, DeclaredColumnType, read_config_values};
+use ravel_commit::publish::RetryPolicy;
+use ravel_commit::record::NewCommitRecord;
+use ravel_commit::{keys, publish, record};
+use ravel_logseg::{
+    AttrValue, LogRecord, ObjectIdentity, RlogConfig, RlogWriter, stream_attrs_bytes,
+};
+use ravel_object_store::{ObjectStoreBackend, PutOptions};
+use ravel_query::{LogSegmentFetcher, SegmentFetcher};
+use ravel_sql::{
+    DeclaredColumn, DeclaredType, SpanSegmentFetcher, SqlConfig, SqlExecutor, SqlRequest,
+    StaticDeclaredColumns,
+};
+use ravel_types::accounting::AccountedOp;
+use ravel_types::logstream::log_stream_id;
+use ravel_types::{Signal, TenantHash, TenantId, TimeRange};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::sql_corpus::CorpusEntry;
+
+/// A frozen query clock, bounding the catalog resolve's ingest-hour fan-out.
+/// The generated data lands in ingest-hour bucket 0 with event timestamps a few
+/// microseconds after the epoch, so a resolve over `[0, NOW_NS]` lists a handful
+/// of buckets per shard rather than a wall-clock number of them (the same
+/// technique `flight_sql_egress` uses).
+const NS_PER_HOUR: i64 = 3_600_000_000_000;
+const NOW_NS: i64 = 4 * NS_PER_HOUR;
+
+/// Anything the harness can fail on. Boxed so `?` composes over the executor,
+/// catalog, writer, publish, and tenant-config error types without a bespoke
+/// enum; a bench never needs to match on the variant.
+pub type Error = Box<dyn std::error::Error + Send + Sync>;
+
+/// Whether the measured object layout is a freshly loaded tenant (many small
+/// objects) or one the maintenance machinery has compacted (fewer, larger).
+/// ADR-0100 decision 4 requires the report to *state* this rather than guess,
+/// so the `--tenant` lane takes it as an operator-supplied flag; the generated
+/// lane is always freshly written and never compacted.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Compaction {
+    /// A freshly loaded (or freshly generated) layout, never compacted.
+    Pre,
+    /// A layout the maintenance machinery has compacted.
+    Post,
+}
+
+impl Compaction {
+    fn label(self) -> &'static str {
+        match self {
+            Compaction::Pre => "pre-compaction",
+            Compaction::Post => "post-compaction",
+        }
+    }
+}
+
+/// Run provenance: without it two latency tables are not comparable (the same
+/// corpus against local memory and against S3 differs by an order of
+/// magnitude), so the backend, host shape, and dataset identity are recorded
+/// beside the numbers.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Provenance {
+    /// Object-store backend that actually ran: `"memory"`, `"minio"`, or
+    /// `"s3"`. The caller classifies it (a custom S3 endpoint is MinIO), since
+    /// the store is handed in already constructed.
+    pub store_backend: String,
+    /// Backend region, or the sentinel `"n/a"` for a backend with none
+    /// (`MemoryStore`), keeping the no-null contract.
+    pub region: String,
+    /// Backend endpoint, or `"n/a"` when the backend has none.
+    pub endpoint: String,
+    /// Logical cores on the measuring host.
+    pub host_logical_cores: usize,
+    /// Which lane produced the run: `"generate"` or `"tenant"`.
+    pub source: String,
+    /// The tenant the numbers describe (a generated run mints a unique id).
+    pub dataset_id: String,
+    /// Executions per statement behind the min/median/max.
+    pub runs: usize,
+}
+
+/// The dataset as it sits in the object store, independent of any one query.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DatasetInfo {
+    /// Wall time to build and publish the dataset. Measured for the generated
+    /// lane; `0.0` for the `--tenant` lane, whose load happened out of process
+    /// through `ravel-cli` and is not this harness's to time.
+    pub load_wall_ms: f64,
+    /// Bytes stored across the dataset's data objects (summed over the resolved
+    /// snapshot's segments).
+    pub stored_bytes: u64,
+    /// Data objects the dataset comprises: the count of segments a full-window
+    /// resolve returns. Per-object cost (LIST, footer read, decode setup) is
+    /// paid once per object per query, so this is a first-class figure, not
+    /// decoration.
+    pub object_count: usize,
+    /// Durable rows across the dataset (summed segment sample counts).
+    pub rows: u64,
+    /// `"pre-compaction"` or `"post-compaction"`: which layout was measured.
+    pub layout: String,
+}
+
+/// The scan diagnostics for one statement, read off the executor's own
+/// counters: block pruning selectivity plus the object-store traffic and cache
+/// behavior of the cold run.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ScanDiagnostics {
+    /// Segments in the snapshot the successful attempt used.
+    pub segments: usize,
+    /// Blocks the logs scan saw.
+    pub blocks_total: u64,
+    /// Blocks the logs scan actually read.
+    pub blocks_scanned: u64,
+    /// Blocks pruned by POSTINGS before any read (ADR-0049).
+    pub blocks_pruned_by_postings: u64,
+    /// Object-store GET requests the cold run issued.
+    pub object_store_get_requests: u64,
+    /// Object-store LIST requests the cold run issued.
+    pub object_store_list_requests: u64,
+    /// Bytes transferred from the object store across every operation kind.
+    pub object_store_bytes: u64,
+    /// Fetch-cache hits on the cold run.
+    pub cache_hits: u64,
+    /// Fetch-cache misses on the cold run.
+    pub cache_misses: u64,
+    /// Bytes served from the fetch cache on the cold run.
+    pub cache_bytes: u64,
+}
+
+/// One measured statement.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct EntryReport {
+    /// The corpus entry id.
+    pub id: String,
+    /// Fastest of the `runs` executions, in milliseconds.
+    pub min_ms: f64,
+    /// Median of the `runs` executions (nearest-rank), in milliseconds.
+    pub median_ms: f64,
+    /// Slowest of the `runs` executions, in milliseconds.
+    pub max_ms: f64,
+    /// The first (cold) execution against a fresh catalog and executor, in
+    /// milliseconds.
+    pub cold_ms: f64,
+    /// Rows the statement returned.
+    pub rows_returned: usize,
+    /// Where the time went.
+    pub scan: ScanDiagnostics,
+}
+
+/// One statement that was not run because the dataset does not satisfy its
+/// declared-column dependency. Distinct from a zero-latency measurement: a skip
+/// carries no timing at all.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SkippedEntry {
+    /// The corpus entry id.
+    pub id: String,
+    /// The declared attribute key that was missing (or present at the wrong
+    /// type).
+    pub missing_key: String,
+    /// A human-readable reason naming the key and the type it needed.
+    pub reason: String,
+}
+
+/// The full report: provenance, dataset shape, measured statements, and the
+/// statements skipped for an unsatisfied declared-column dependency.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SqlLatencyReport {
+    pub provenance: Provenance,
+    pub dataset: DatasetInfo,
+    pub entries: Vec<EntryReport>,
+    pub skipped: Vec<SkippedEntry>,
+}
+
+/// Inputs for the generated lane.
+pub struct GenerateConfig {
+    pub store: Arc<dyn ObjectStoreBackend>,
+    pub store_backend: String,
+    pub region: String,
+    pub endpoint: String,
+    /// Statements to measure (the checked-in corpus, or an external file).
+    pub entries: Vec<CorpusEntry>,
+    /// Executions per statement.
+    pub runs: usize,
+    /// Distinct log records to generate.
+    pub records: usize,
+    /// Records per RLOG object; the record set is split into
+    /// `ceil(records / records_per_object)` objects, so this is the lever that
+    /// makes object count a measurable variable in process.
+    pub records_per_object: usize,
+    /// Extra distinct filler attribute keys per record, on top of the fixed
+    /// `duration_ms` declared column, to widen the schema.
+    pub extra_attrs: usize,
+}
+
+/// Inputs for the loaded-tenant lane.
+pub struct TenantConfigInput {
+    pub store: Arc<dyn ObjectStoreBackend>,
+    pub store_backend: String,
+    pub region: String,
+    pub endpoint: String,
+    /// The tenant already loaded in `store`.
+    pub tenant: String,
+    /// Statements to measure.
+    pub entries: Vec<CorpusEntry>,
+    /// Executions per statement.
+    pub runs: usize,
+    /// Event-time window handed to the catalog resolve.
+    pub window: TimeRange,
+    /// Injected clock reading bounding that window.
+    pub now_ns: i64,
+    /// Which layout the operator is measuring.
+    pub compaction: Compaction,
+}
+
+fn percentile(sorted_ns: &[u64], pct: f64) -> u64 {
+    if sorted_ns.is_empty() {
+        return 0;
+    }
+    let rank = ((sorted_ns.len() - 1) as f64 * pct).round() as usize;
+    sorted_ns[rank.min(sorted_ns.len() - 1)]
+}
+
+fn host_logical_cores() -> usize {
+    std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1)
+}
+
+/// The first `required_declaration` of `entry` that `declared` does not satisfy
+/// (absent key, or present at the wrong type), or `None` if every requirement
+/// is met. Shared by both lanes: the generated lane installs the union so this
+/// returns `None`, the tenant lane resolves the durable set so it may not.
+fn first_unsatisfied(
+    entry: &CorpusEntry,
+    declared: &[DeclaredColumn],
+) -> Option<(String, DeclaredType)> {
+    for req in &entry.required_declarations {
+        let want = req.ty.as_declared_type();
+        let satisfied = declared.iter().any(|d| d.key == req.key && d.ty == want);
+        if !satisfied {
+            return Some((req.key.clone(), want));
+        }
+    }
+    None
+}
+
+/// The union of every entry's `required_declarations`, as a declared-column
+/// set to install for the generated lane. A key required at two types by two
+/// entries keeps its first-seen type; the corpus never does that (the gate
+/// would still run, but the second entry would then be skipped, which the smoke
+/// test would catch).
+fn declaration_union(entries: &[CorpusEntry]) -> Vec<DeclaredColumn> {
+    let mut out: Vec<DeclaredColumn> = Vec::new();
+    for entry in entries {
+        for req in &entry.required_declarations {
+            let ty = req.ty.as_declared_type();
+            if !out.iter().any(|d| d.key == req.key) {
+                out.push(DeclaredColumn::new(req.key.clone(), ty));
+            }
+        }
+    }
+    out
+}
+
+/// Build a fresh executor over `store` with `declared` installed. Fresh per
+/// corpus entry so the first run is genuinely cold: a shared executor would let
+/// one statement warm the next through the catalog and fetch caches.
+fn cold_executor(
+    store: &Arc<dyn ObjectStoreBackend>,
+    declared: &[DeclaredColumn],
+) -> Result<SqlExecutor, Error> {
+    let catalog = Arc::new(Catalog::new(Arc::clone(store), CatalogConfig::default())?);
+    Ok(SqlExecutor::new(
+        catalog,
+        SegmentFetcher::new(Arc::clone(store)),
+        LogSegmentFetcher::new(Arc::clone(store)),
+        SpanSegmentFetcher::new(Arc::clone(store)),
+        SqlConfig::default(),
+        1 << 30,
+    )
+    .with_declared_column_source(Arc::new(StaticDeclaredColumns::new(declared.to_vec()))))
+}
+
+/// Measure `entries` against a dataset already durable in `store`, using
+/// `declared` as the tenant's declared-column configuration. This is the shared
+/// core both lanes drive; they differ only in how the dataset was written and
+/// how `declared` was obtained.
+///
+/// Each entry gets a fresh [`cold_executor`] and is executed `runs` times; the
+/// first run is the cold number. An entry whose `required_declarations` are not
+/// all satisfied by `declared` is skipped with its missing key named and never
+/// executed.
+pub async fn measure_corpus(
+    store: &Arc<dyn ObjectStoreBackend>,
+    tenant_hash: TenantHash,
+    entries: &[CorpusEntry],
+    declared: &[DeclaredColumn],
+    runs: usize,
+    window: TimeRange,
+    now_ns: i64,
+) -> Result<(Vec<EntryReport>, Vec<SkippedEntry>), Error> {
+    let runs = runs.max(1);
+    let mut measured = Vec::new();
+    let mut skipped = Vec::new();
+
+    for entry in entries {
+        // Verify the declared-column dependency before running anything. A
+        // missing declared column reads NULL for every row, so an unsatisfied
+        // entry must be skipped, not run: removing this guard lets the entry
+        // execute and report a plausible-but-wrong latency.
+        if let Some((missing_key, want)) = first_unsatisfied(entry, declared) {
+            skipped.push(SkippedEntry {
+                id: entry.id.clone(),
+                missing_key: missing_key.clone(),
+                reason: format!(
+                    "required declared column `{missing_key}` ({want:?}) is not satisfied by the \
+                     dataset under measurement"
+                ),
+            });
+            continue;
+        }
+
+        let executor = cold_executor(store, declared)?;
+        let req = SqlRequest {
+            sql: entry.sql.clone(),
+            window,
+            min_tokens: Vec::new(),
+            now_ns,
+            deadline: Duration::from_secs(30),
+        };
+
+        let mut latencies_ns = Vec::with_capacity(runs);
+        let mut cold_ns = 0u64;
+        let mut rows_returned = 0usize;
+        let mut scan = ScanDiagnostics {
+            segments: 0,
+            blocks_total: 0,
+            blocks_scanned: 0,
+            blocks_pruned_by_postings: 0,
+            object_store_get_requests: 0,
+            object_store_list_requests: 0,
+            object_store_bytes: 0,
+            cache_hits: 0,
+            cache_misses: 0,
+            cache_bytes: 0,
+        };
+
+        for run in 0..runs {
+            let start = Instant::now();
+            let outcome = executor
+                .execute(tenant_hash, &req)
+                .await
+                .map_err(|e| Error::from(format!("entry `{}` failed to execute: {e}", entry.id)))?;
+            let elapsed_ns = start.elapsed().as_nanos() as u64;
+            latencies_ns.push(elapsed_ns);
+            if run == 0 {
+                // The cold run's counters are the informative ones: it pays the
+                // object-store traffic and cache misses a warm repeat elides.
+                // Block counters are deterministic across runs regardless.
+                cold_ns = elapsed_ns;
+                rows_returned = outcome.output.num_rows();
+                let acc = &outcome.accounting;
+                scan = ScanDiagnostics {
+                    segments: outcome.stats.segments,
+                    blocks_total: outcome.stats.blocks_total,
+                    blocks_scanned: outcome.stats.blocks_scanned,
+                    blocks_pruned_by_postings: outcome.stats.blocks_pruned_by_postings,
+                    object_store_get_requests: acc.s3_requests(AccountedOp::Get),
+                    object_store_list_requests: acc.s3_requests(AccountedOp::List),
+                    object_store_bytes: acc.total_s3_bytes(),
+                    cache_hits: acc.cache_hits,
+                    cache_misses: acc.cache_misses,
+                    cache_bytes: acc.cache_bytes,
+                };
+            }
+        }
+
+        let mut sorted = latencies_ns.clone();
+        sorted.sort_unstable();
+        let to_ms = |ns: u64| ns as f64 / 1e6;
+        measured.push(EntryReport {
+            id: entry.id.clone(),
+            min_ms: to_ms(*sorted.first().unwrap()),
+            median_ms: to_ms(percentile(&sorted, 0.50)),
+            max_ms: to_ms(*sorted.last().unwrap()),
+            cold_ms: to_ms(cold_ns),
+            rows_returned,
+            scan,
+        });
+    }
+
+    Ok((measured, skipped))
+}
+
+/// Resolve the dataset-level figures (bytes, object count, rows) from a
+/// full-window catalog resolve over the logs signal. Shared by both lanes so
+/// object count is defined identically however the dataset was written.
+async fn dataset_info(
+    store: &Arc<dyn ObjectStoreBackend>,
+    tenant_hash: TenantHash,
+    window: TimeRange,
+    now_ns: i64,
+    load_wall_ms: f64,
+    compaction: Compaction,
+) -> Result<DatasetInfo, Error> {
+    let catalog = Arc::new(Catalog::new(Arc::clone(store), CatalogConfig::default())?);
+    let snapshot = catalog
+        .resolve(&tenant_hash, Signal::Logs, window, &[], now_ns)
+        .await?;
+    let stored_bytes = snapshot.segments.iter().map(|s| s.object_size).sum();
+    let rows = snapshot.segments.iter().map(|s| s.sample_count).sum();
+    Ok(DatasetInfo {
+        load_wall_ms,
+        stored_bytes,
+        object_count: snapshot.segments.len(),
+        rows,
+        layout: compaction.label().to_string(),
+    })
+}
+
+/// Run the generated lane: build a wide-schema logs dataset in process, install
+/// the corpus's declared-column union, and measure every statement.
+pub async fn run_generated(cfg: &GenerateConfig) -> Result<SqlLatencyReport, Error> {
+    // Unique tenant per run so repeated runs against one shared bucket never
+    // read each other's objects (mirrors the other bench cores).
+    let tenant = TenantId::new(format!("sql-latency-gen-{}", Uuid::new_v4()));
+    let tenant_hash = tenant.hash();
+
+    let load_start = Instant::now();
+    generate_dataset(&cfg.store, &tenant, cfg).await?;
+    let load_wall_ms = load_start.elapsed().as_secs_f64() * 1e3;
+
+    let window = TimeRange {
+        start_ns: 0,
+        end_ns: NOW_NS,
+    };
+    let declared = declaration_union(&cfg.entries);
+    let dataset = dataset_info(
+        &cfg.store,
+        tenant_hash,
+        window,
+        NOW_NS,
+        load_wall_ms,
+        Compaction::Pre,
+    )
+    .await?;
+    let (entries, skipped) = measure_corpus(
+        &cfg.store,
+        tenant_hash,
+        &cfg.entries,
+        &declared,
+        cfg.runs,
+        window,
+        NOW_NS,
+    )
+    .await?;
+
+    Ok(SqlLatencyReport {
+        provenance: Provenance {
+            store_backend: cfg.store_backend.clone(),
+            region: cfg.region.clone(),
+            endpoint: cfg.endpoint.clone(),
+            host_logical_cores: host_logical_cores(),
+            source: "generate".to_string(),
+            dataset_id: tenant.as_str().to_string(),
+            runs: cfg.runs.max(1),
+        },
+        dataset,
+        entries,
+        skipped,
+    })
+}
+
+/// Run the loaded-tenant lane: resolve the tenant's real durable declaration,
+/// verify each entry against it, and measure the statements it satisfies.
+///
+/// Kept deliberately thin over [`measure_corpus`]/[`dataset_info`]: the only
+/// lane-specific step is resolving the durable declaration, so the generated
+/// lane (which the smoke test drives) exercises the rest of this path too.
+pub async fn run_tenant(cfg: &TenantConfigInput) -> Result<SqlLatencyReport, Error> {
+    let tenant = TenantId::new(cfg.tenant.clone());
+    let tenant_hash = tenant.hash();
+
+    // The configuration under measurement: the tenant's real durable declared
+    // columns, not a set this harness installs. An absent config, or a config
+    // with no typed columns, means the tenant declared nothing.
+    let declared = resolve_durable_declarations(&cfg.store, &tenant_hash).await?;
+
+    let dataset = dataset_info(
+        &cfg.store,
+        tenant_hash,
+        cfg.window,
+        cfg.now_ns,
+        0.0,
+        cfg.compaction,
+    )
+    .await?;
+    let (entries, skipped) = measure_corpus(
+        &cfg.store,
+        tenant_hash,
+        &cfg.entries,
+        &declared,
+        cfg.runs,
+        cfg.window,
+        cfg.now_ns,
+    )
+    .await?;
+
+    Ok(SqlLatencyReport {
+        provenance: Provenance {
+            store_backend: cfg.store_backend.clone(),
+            region: cfg.region.clone(),
+            endpoint: cfg.endpoint.clone(),
+            host_logical_cores: host_logical_cores(),
+            source: "tenant".to_string(),
+            dataset_id: cfg.tenant.clone(),
+            runs: cfg.runs.max(1),
+        },
+        dataset,
+        entries,
+        skipped,
+    })
+}
+
+/// Read the tenant's durable declared typed attribute columns from its
+/// `TenantConfig` and map them to `ravel-sql`'s [`DeclaredColumn`]. This is the
+/// same durable record `ravel-cli typed-attr-column set` writes; reading it
+/// directly (rather than through the server's cache-aside overlay) is a
+/// point-in-time resolution of exactly that configuration.
+async fn resolve_durable_declarations(
+    store: &Arc<dyn ObjectStoreBackend>,
+    tenant_hash: &TenantHash,
+) -> Result<Vec<DeclaredColumn>, Error> {
+    let config = read_config_values(store.as_ref(), tenant_hash).await?;
+    let columns = config
+        .and_then(|c| c.typed_attr_columns)
+        .unwrap_or_default()
+        .into_iter()
+        .map(|col| {
+            let ty = match col.ty {
+                DeclaredColumnType::Str => DeclaredType::Str,
+                DeclaredColumnType::I64 => DeclaredType::I64,
+                DeclaredColumnType::Bool => DeclaredType::Bool,
+                DeclaredColumnType::Bytes => DeclaredType::Bytes,
+            };
+            DeclaredColumn::new(col.key, ty)
+        })
+        .collect();
+    Ok(columns)
+}
+
+/// The one resource+scope every generated record shares.
+fn resource() -> Vec<(String, AttrValue)> {
+    vec![(
+        "service.name".to_string(),
+        AttrValue::Str("api".to_string()),
+    )]
+}
+
+const SCOPE_NAME: &str = "sql-latency-bench";
+const SCOPE_VERSION: &str = "1.0";
+
+/// Build the wide-schema dataset: `cfg.records` log records split into RLOG
+/// objects of `cfg.records_per_object`, each published with its own commit
+/// record so a real `Catalog::resolve` finds it. Every record carries a
+/// `duration_ms` i64 attribute (the corpus's declared column) plus
+/// `cfg.extra_attrs` filler keys.
+async fn generate_dataset(
+    store: &Arc<dyn ObjectStoreBackend>,
+    tenant: &TenantId,
+    cfg: &GenerateConfig,
+) -> Result<(), Error> {
+    let records = build_records(cfg.records.max(1), cfg.extra_attrs);
+    let per_object = cfg.records_per_object.max(1);
+    let writer_id = Uuid::from_u128(0x5100_0100);
+
+    for (obj_idx, chunk) in records.chunks(per_object).enumerate() {
+        let writer_seq = (obj_idx + 1) as u64;
+        let identity = ObjectIdentity {
+            tenant_hash: tenant.hash().0,
+            shard: 0,
+            writer_id: *writer_id.as_bytes(),
+            writer_epoch: 1,
+            writer_seq,
+        };
+        let mut writer = RlogWriter::new(RlogConfig::default(), identity);
+        for rec in chunk {
+            writer.push(rec.clone())?;
+        }
+        let bytes = writer.finish()?;
+
+        let min = chunk.iter().map(|r| r.ts_ns).min().unwrap_or(0);
+        let max = chunk.iter().map(|r| r.ts_ns).max().unwrap_or(0);
+        let new_record = NewCommitRecord {
+            tenant_hash: tenant.hash(),
+            signal: Signal::Logs,
+            shard: 0,
+            writer_id,
+            writer_epoch: 1,
+            writer_seq,
+            object_size: bytes.len() as u64,
+            content_hash: [0u8; 32],
+            sample_count: chunk.len() as u64,
+            series_count: 1,
+            min_event_ts_ns: min,
+            max_event_ts_ns: max,
+            min_ingest_ts_ns: min,
+            max_ingest_ts_ns: max,
+            segment_format_version: 1,
+            created_unix_ns: 10,
+            ingest_hour_bucket: 0,
+        };
+        let rec = record::build(new_record)?;
+        let data_key = keys::reconstruct_data_key(&rec)?;
+        store
+            .put(&data_key, bytes::Bytes::from(bytes), PutOptions::default())
+            .await?;
+        publish::publish(store.as_ref(), &rec, &RetryPolicy::default()).await?;
+    }
+    Ok(())
+}
+
+/// The four severities the corpus filters on, as `(severity_num, text)`.
+const SEVERITIES: [(u8, &str); 4] = [(9, "INFO"), (13, "WARN"), (17, "ERROR"), (21, "FATAL")];
+
+/// Generate `count` records on one stream. The values are chosen so every
+/// corpus statement returns something non-trivial: severities cycle through all
+/// four the corpus names, some bodies carry the word `timeout`, and
+/// `duration_ms` spans below and above the corpus's `1000` threshold.
+fn build_records(count: usize, extra_attrs: usize) -> Vec<LogRecord> {
+    let res = resource();
+    let stream_id = log_stream_id(&res, SCOPE_NAME, SCOPE_VERSION, &[]);
+    let stream_attrs = stream_attrs_bytes(&res, SCOPE_NAME, SCOPE_VERSION, &[]);
+
+    (0..count)
+        .map(|i| {
+            let (severity_num, severity_text) = SEVERITIES[i % SEVERITIES.len()];
+            // Some bodies contain `timeout` (for has_word), and a few digits so
+            // regexp_replace has something to fold.
+            let body = if i % 3 == 0 {
+                format!("request {i} timeout after 30s")
+            } else {
+                format!("request {i} ok in {}ms", (i % 900) as i64)
+            };
+            let duration_ms = ((i % 5) as i64) * 400; // 0,400,800,1200,1600
+
+            let mut attrs: Vec<(String, AttrValue)> =
+                vec![("duration_ms".to_string(), AttrValue::I64(duration_ms))];
+            for k in 0..extra_attrs {
+                attrs.push((
+                    format!("attr_{k}"),
+                    AttrValue::Str(format!("v{}", (i + k) % 7)),
+                ));
+            }
+
+            LogRecord {
+                stream_id,
+                stream_attrs: stream_attrs.clone(),
+                ts_ns: 1_000 + (i as i64) * 1_000,
+                observed_ts_ns: 1_000 + (i as i64) * 1_000,
+                severity_num,
+                severity_text: severity_text.to_string(),
+                body,
+                trace_id: None,
+                span_id: None,
+                flags: 0,
+                attrs,
+            }
+        })
+        .collect()
+}

--- a/crates/ravel-bench/tests/sql_latency_smoke.rs
+++ b/crates/ravel-bench/tests/sql_latency_smoke.rs
@@ -1,0 +1,227 @@
+//! Smoke tests for the `sql_latency_bench` harness (ADR-0100 decision 4),
+//! behind the `sql-latency` feature. They drive the `--generate` lane end to
+//! end against a `MemoryStore` and pin the three properties the report
+//! contract rests on:
+//!
+//! - the generated lane reports per-statement min/median/max, a cold number,
+//!   non-zero scan block counters, and the dataset object count;
+//! - an entry whose `required_declarations` are not satisfied is *skipped*
+//!   (never run) with the missing key named, and is absent from the measured
+//!   set;
+//! - `--runs 1` still reports a cold number, with min == median == max.
+//!
+//! The `--tenant` lane cannot be exercised here: it needs a tenant already
+//! loaded into durable storage by `ravel-cli load --parquet`, which CI does not
+//! provide. Its code path is deliberately thin over `measure_corpus`/
+//! `dataset_info`, both of which the generated lane exercises fully.
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::sync::Arc;
+
+use ravel_bench::sql_corpus::{
+    CorpusEntry, Modification, RequiredDeclaration, RequiredDeclaredType, checked_default_corpus,
+};
+use ravel_bench::sql_latency::{GenerateConfig, measure_corpus, run_generated};
+use ravel_object_store::ObjectStoreBackend;
+use ravel_object_store::memory::MemoryStore;
+use ravel_types::{TenantId, TimeRange};
+
+/// The frozen query clock the generated lane uses (`4h` in ns); the generated
+/// data lands in ingest-hour bucket 0 near the epoch, so a resolve over
+/// `[0, NOW_NS]` stays bounded.
+const NOW_NS: i64 = 4 * 3_600_000_000_000;
+
+fn small_generate_config(store: Arc<dyn ObjectStoreBackend>, runs: usize) -> GenerateConfig {
+    GenerateConfig {
+        store,
+        store_backend: "memory".to_string(),
+        region: "n/a".to_string(),
+        endpoint: "n/a".to_string(),
+        entries: checked_default_corpus().expect("checked-in corpus gates"),
+        runs,
+        // Small enough for CI, but split across several objects so the object
+        // count and the block counters are meaningfully non-trivial.
+        records: 60,
+        records_per_object: 20,
+        extra_attrs: 4,
+    }
+}
+
+#[tokio::test]
+async fn generated_lane_reports_per_query_min_median_max_and_scan_diagnostics() {
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+    let report = run_generated(&small_generate_config(Arc::clone(&store), 3))
+        .await
+        .expect("generated lane runs");
+
+    // Dataset-level: the object count is a first-class figure and must be
+    // populated. 60 records at 20 per object is 3 objects.
+    assert!(
+        report.dataset.object_count > 0,
+        "dataset object count must be reported and non-zero"
+    );
+    assert_eq!(report.dataset.object_count, 3, "60 records / 20 per object");
+    assert!(
+        report.dataset.rows > 0,
+        "dataset row count must be non-zero"
+    );
+    assert!(
+        report.dataset.stored_bytes > 0,
+        "dataset stored bytes must be non-zero"
+    );
+    assert_eq!(report.dataset.layout, "pre-compaction");
+    assert_eq!(report.provenance.runs, 3);
+
+    // Every checked-in entry is satisfied by the installed declaration union,
+    // so nothing is skipped and every entry is measured.
+    assert!(
+        report.skipped.is_empty(),
+        "generated lane installs the union of required declarations: {:?}",
+        report.skipped
+    );
+    let corpus_len = checked_default_corpus().expect("corpus").len();
+    assert_eq!(
+        report.entries.len(),
+        corpus_len,
+        "every corpus entry is measured"
+    );
+
+    // Per-entry: min <= median <= max, a positive cold number, and the two
+    // typed-duration entries carry their declared dependency (so they ran, not
+    // skipped).
+    for e in &report.entries {
+        assert!(
+            e.min_ms <= e.median_ms && e.median_ms <= e.max_ms,
+            "entry `{}` violates min<=median<=max: {} {} {}",
+            e.id,
+            e.min_ms,
+            e.median_ms,
+            e.max_ms
+        );
+        assert!(e.cold_ms > 0.0, "entry `{}` cold time must be > 0", e.id);
+    }
+    for id in ["typed_duration_threshold_count", "typed_duration_sum"] {
+        assert!(
+            report.entries.iter().any(|e| e.id == id),
+            "typed entry `{id}` must be measured, not skipped"
+        );
+    }
+
+    // Scan diagnostics: at least one statement scans blocks over the durable
+    // objects, proving the block counters are wired rather than always zero.
+    assert!(
+        report.entries.iter().any(|e| e.scan.blocks_total > 0),
+        "at least one entry must report a non-zero blocks_total"
+    );
+    assert!(
+        report
+            .entries
+            .iter()
+            .any(|e| e.scan.segments == report.dataset.object_count),
+        "a full-window statement sees every dataset segment"
+    );
+
+    // The report serializes to JSON (the machine-readable half of the
+    // contract).
+    serde_json::to_string(&report).expect("report serializes");
+}
+
+#[tokio::test]
+async fn an_entry_with_an_unsatisfied_required_declaration_is_skipped_with_the_key_named() {
+    // Publish a real dataset so the statement below is genuinely executable.
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+    let report = run_generated(&small_generate_config(Arc::clone(&store), 1))
+        .await
+        .expect("generated lane runs");
+    let tenant = TenantId::new(report.provenance.dataset_id.clone());
+
+    // The statement reads only fixed columns, so it runs fine against the base
+    // schema -- but it *requires* the `duration_ms` declared column. Measure it
+    // with an EMPTY declared set, the way the tenant lane would against a tenant
+    // that never declared duration_ms.
+    let entry = CorpusEntry {
+        id: "needs_duration".to_string(),
+        sql: "SELECT count(*) FROM logs".to_string(),
+        constructs: vec!["count".to_string()],
+        expected_rows: Some(1),
+        upstream_id: None,
+        modified: Modification::Verbatim,
+        required_declarations: vec![RequiredDeclaration::new(
+            "duration_ms",
+            RequiredDeclaredType::I64,
+        )],
+    };
+    let window = TimeRange {
+        start_ns: 0,
+        end_ns: NOW_NS,
+    };
+    let (measured, skipped) = measure_corpus(
+        &store,
+        tenant.hash(),
+        std::slice::from_ref(&entry),
+        &[], // no declared columns: duration_ms is unsatisfied
+        1,
+        window,
+        NOW_NS,
+    )
+    .await
+    .expect("measure_corpus runs");
+
+    // The entry is skipped, with the missing key named, and is absent from the
+    // measurement set.
+    //
+    // Prove-the-test: this assertion is what fires when the skip is defeated.
+    // Deleting the `continue;` at the end of the `if let Some(..) =
+    // first_unsatisfied(..)` block in `measure_corpus` (src/sql_latency.rs) lets
+    // the entry run -- `SELECT count(*) FROM logs` executes against the base
+    // schema and produces a latency number -- so `measured` becomes length 1
+    // and `skipped` empty, failing both assertions below.
+    assert!(
+        measured.is_empty(),
+        "an unsatisfied entry must not be measured: {measured:?}"
+    );
+    assert_eq!(skipped.len(), 1, "the entry must be skipped");
+    assert_eq!(skipped[0].id, "needs_duration");
+    assert_eq!(
+        skipped[0].missing_key, "duration_ms",
+        "the skip reason must name the missing declared column"
+    );
+    assert!(
+        skipped[0].reason.contains("duration_ms"),
+        "the human reason names the key: {}",
+        skipped[0].reason
+    );
+}
+
+#[tokio::test]
+async fn runs_1_reports_a_cold_number_and_equal_min_median_max() {
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+    let report = run_generated(&small_generate_config(Arc::clone(&store), 1))
+        .await
+        .expect("generated lane runs");
+
+    assert_eq!(report.provenance.runs, 1);
+    assert!(!report.entries.is_empty());
+    for e in &report.entries {
+        assert!(
+            e.cold_ms > 0.0,
+            "entry `{}` still reports a cold number",
+            e.id
+        );
+        assert_eq!(
+            e.min_ms, e.cold_ms,
+            "with one run the min is the cold run for `{}`",
+            e.id
+        );
+        assert_eq!(
+            e.min_ms, e.median_ms,
+            "one run: min == median for `{}`",
+            e.id
+        );
+        assert_eq!(
+            e.median_ms, e.max_ms,
+            "one run: median == max for `{}`",
+            e.id
+        );
+    }
+}

--- a/crates/ravel-bench/tests/sql_latency_smoke.rs
+++ b/crates/ravel-bench/tests/sql_latency_smoke.rs
@@ -61,13 +61,30 @@ async fn generated_lane_reports_per_query_min_median_max_and_scan_diagnostics() 
         "dataset object count must be reported and non-zero"
     );
     assert_eq!(report.dataset.object_count, 3, "60 records / 20 per object");
-    assert!(
-        report.dataset.rows > 0,
-        "dataset row count must be non-zero"
+    // Pinned to the exact count, not `> 0`. A harness whose whole job is to
+    // report magnitudes has to be checked against magnitudes: `> 0` holds just
+    // as well when a figure is a fraction of the truth, which is how an
+    // accounting bug survives a green suite. Every record generated must be
+    // counted once.
+    assert_eq!(
+        report.dataset.rows, 60,
+        "every generated record is counted exactly once"
     );
+    // Bytes cannot be pinned exactly (encoding and compression move with the
+    // format), so bound them PER OBJECT rather than in absolute terms. An
+    // absolute floor is the trap: this fixture stores about 1300 bytes per
+    // object, so any floor low enough to be safe for one object is also passed
+    // by a figure that counts only one object out of three. Verified by
+    // mutation -- summing `.take(1)` of the segments passed a flat 1 KiB floor
+    // and fails this. The per-object band is what makes an under-count visible.
+    let per_object = report.dataset.stored_bytes / report.dataset.object_count as u64;
     assert!(
-        report.dataset.stored_bytes > 0,
-        "dataset stored bytes must be non-zero"
+        (512..1024 * 1024).contains(&per_object),
+        "stored bytes {} over {} objects is {} per object, outside the \
+         plausible band: the figure is being under- or over-counted",
+        report.dataset.stored_bytes,
+        report.dataset.object_count,
+        per_object
     );
     assert_eq!(report.dataset.layout, "pre-compaction");
     assert_eq!(report.provenance.runs, 3);
@@ -119,6 +136,35 @@ async fn generated_lane_reports_per_query_min_median_max_and_scan_diagnostics() 
             .iter()
             .any(|e| e.scan.segments == report.dataset.object_count),
         "a full-window statement sees every dataset segment"
+    );
+
+    // A scanning statement must charge object-store reads proportional to the
+    // dataset, not merely non-zero ones. `> 0` cannot distinguish a counter
+    // wired to one object from a counter wired to all three, and this harness
+    // exists to attribute per-object cost -- a systematically low figure here
+    // would point other epics at the wrong bottleneck. Each of the three
+    // objects needs at least one GET, and its bytes must reach the same
+    // plausible floor the dataset does.
+    let scanning = report
+        .entries
+        .iter()
+        .filter(|e| e.scan.blocks_total > 0)
+        .max_by_key(|e| e.scan.object_store_get_requests)
+        .expect("at least one entry scans blocks");
+    assert!(
+        scanning.scan.object_store_get_requests >= report.dataset.object_count as u64,
+        "entry `{}` charged {} GETs for a {}-object dataset: fewer GETs than \
+         objects means the accounting is under-counting reads",
+        scanning.id,
+        scanning.scan.object_store_get_requests,
+        report.dataset.object_count
+    );
+    assert!(
+        scanning.scan.object_store_bytes >= 1_024,
+        "entry `{}` charged only {} object-store bytes across {} objects",
+        scanning.id,
+        scanning.scan.object_store_bytes,
+        report.dataset.object_count
     );
 
     // The report serializes to JSON (the machine-readable half of the


### PR DESCRIPTION
The measurement instrument ADR-0100 decision 4 specifies, and the last code task of #421. Nothing in the tree reported SQL query latency before this: `query_latency_bench` is PromQL-only and `flight_sql_egress` measures result-egress encoding for a single query.

`sql_latency_bench` runs the checked-in corpus (or an external `--corpus` file) and reports, per statement, min/median/max over `--runs N` with the first run flagged cold. Cold is **per query**: a fresh `Catalog`, fetchers and `SqlExecutor` are built for each entry, with `cache: None`, so nothing survives between entries. A corpus-level cold pass would let entry N warm entry N+1 and report one cold number for the whole corpus.

Two dataset lanes: `--generate` builds in process through ravel-ingest, and `--tenant <id>` runs against data already loaded by the real `ravel-cli load --parquet`. The generated lane installs the union of the corpus's `required_declarations` via `StaticDeclaredColumns`; the tenant lane instead resolves the tenant's real durable declaration, since that is the configuration under measurement.

`required_declarations` is new on `CorpusEntry` (additive under `version = 1`, so corpus files written before this still parse), and it closes the gap #427's review flagged. An entry whose declarations are unsatisfied is **skipped with the missing key named**, never executed — a declared column absent from the tenant projects NULL for every row, so running it would attach a plausible latency to wrong output, the worst possible failure for a benchmark. Skipped entries are reported separately and never counted as measurements.

The report carries the scan diagnostics that already existed but were never surfaced — `SqlStats` block counters and `QueryAccounting` object-store and cache counters — plus dataset load time, stored bytes, object count, a pre/post-compaction label taken from an operator flag rather than guessed, and provenance (backend, region, host cores, dataset id). A stopwatch says a query is slow; these say where the time went, which is what makes this an instrument for ADR-0099, #331, #278 and #361 rather than a scoreboard.

Reviewed adversarially before this PR (opus, on the result ref): **PASS**. It confirmed by reading the catalog that a `Snapshot` segment is 1:1 with a stored data object, so `object_count` is named correctly, and verified per-object cost scaling by running the lane at 4 and 20 objects with constant rows — GET requests moved 9→41 and bytes 10021→26564.

**The second commit tightens the smoke test's assertions, and it is the part worth reading.** The test pinned `stored_bytes > 0`, `rows > 0`, `blocks_total > 0`. Those hold just as well when a figure is a fraction of the truth — which is precisely how an accounting bug survives a green suite. A peer session hit exactly this on another epic hours ago: a memory-pool charge reporting about a quarter of its real footprint, under a test that asserted only non-zero and return-to-zero.

So: `rows` is now pinned exactly, and a scanning statement must charge at least one object-store GET per dataset object, making a counter wired to one object instead of three visible.

Bytes are bounded **per object**, and the absolute form was tried first and rejected on evidence. This fixture stores about 1300 bytes per object, so any absolute floor low enough to be safe for one object is also cleared by a figure counting one object out of three — I confirmed that by mutating `stored_bytes` to sum `.take(1)` of the segments and watching a flat 1 KiB floor pass it. The per-object band fails that same mutation with `stored bytes 1292 over 3 objects is 430 per object`.

Verified locally, unpiped with exit codes captured: `cargo test -p ravel-bench --features sql-latency` 3 smoke tests plus the corpus suite pass, `cargo clippy -p ravel-bench --features sql-latency --all-targets` exit 0, `cargo fmt --all --check` clean. CI's `features` job compiles and runs this feature, so it is gated rather than rotting.

One merge note: `crates/ravel-bench/Cargo.toml` conflicted with `groupby_scaling_bench` (#361 item 4), which landed while this was in flight. Both bins are kept; they measure different axes — this one per-query latency across a diverse corpus, that one a scaling curve against core count.

The `--tenant` lane is not exercised by CI, which has no pre-loaded tenant. Its path is deliberately thin over the same `measure_corpus`/`dataset_info` helpers the generated lane drives fully.

Fixes: #428
