### PR TITLE
docs(adr-0094): accept after S3-backed final-aggregation measurement

### DIFF
--- a/crates/ravel-sql/src/config.rs
+++ b/crates/ravel-sql/src/config.rs
@@ -99,3 +99,19 @@ impl SqlConfig {
         (pool, breach)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// ADR-0094: a proper S3-backed production-scale measurement (issue #458)
+    /// found parallel final aggregation not robustly faster than serial at
+    /// any measured partition count, so the flag's default stays `false`.
+    /// This pins that decision -- a future measurement that finds a real win
+    /// and flips the default should update this assertion in the same
+    /// change, not discover it broken in an unrelated PR.
+    #[test]
+    fn parallel_final_aggregation_defaults_to_false() {
+        assert!(!SqlConfig::default().parallel_final_aggregation);
+    }
+}

--- a/docs/adrs/0094-parallel-final-aggregation-exact-typed.md
+++ b/docs/adrs/0094-parallel-final-aggregation-exact-typed.md
@@ -1,6 +1,6 @@
 # ADR-0094: parallel final aggregation for exact-typed inputs
 
-Status: Proposed
+Status: Accepted
 
 ## Context
 
@@ -57,7 +57,11 @@ multi-tenant server. It is enough to justify drafting this design; it
 is explicitly **not** enough to justify shipping the resulting feature
 without a release-build, production-scale (S3-backed, multi-GB,
 realistic cardinality distribution) validation pass — Consequences
-below makes that a required follow-up, not optional polish.
+below makes that a required follow-up, not optional polish. **That
+validation pass has since been run** (ADR-0102 decision 2, issue #458);
+its S3-backed release-build numbers, and the decision they drive (the
+flag's default stays `false`), are recorded in Consequences below and
+are why this ADR is now Accepted rather than Proposed.
 
 The type-exactness half of the epic's premise needs more care than "int
 vs float." Two aggregates behave very differently once repartitioning is
@@ -433,15 +437,150 @@ explained there.
   field — no live-reload.
 - No format change: this is pure query-execution-plan behavior, no
   proto, no `TenantConfig`, no RSEG/RLOG change.
-- Required before `parallel_final_aggregation` defaults to `true` in any
-  deployment (not required to merge this ADR's code, gated by the flag
-  itself per decision 4): a release-build, S3-backed, production-scale
-  (multi-GB objects, realistic group-key cardinality distribution)
-  re-run of the Context section's benchmark, plus decision 3's
-  peak-memory measurement — specifically isolating the new
-  redistribution-buffer cost — across the same shapes. Track as a
-  follow-up issue at decompose time, not silently assumed done by this
-  ADR's landing.
+- **S3-backed validation measurement (ADR-0102 decision 2, issue #458).**
+  The Context section's preliminary `MemoryStore` benchmark has now been
+  re-run at release build against a real S3-compatible store, replacing
+  that preliminary framing as the evidence of record. Tool:
+  `crates/ravel-bench/src/bin/groupby_scaling_bench.rs` (issue #457),
+  `--store s3`. Backend: a loopback MinIO reached over `RAVEL_S3_*`
+  (`minio/minio:latest`, HTTP, `127.0.0.1`) — **not** a real AWS S3
+  endpoint. Host: 8 logical cores, release profile. Query: the bin's
+  fixed exact-typed group-by, `SELECT series_id, count(*), min(ts),
+  max(ts) FROM samples GROUP BY series_id` (non-float group key,
+  `count`/`min`/`max` over non-float inputs — provably exact-typed, so
+  the flag genuinely engages: the `fanned_out` column below is read back
+  from the real physical plan). Dataset: 2000 distinct series (= 2000
+  result groups) across 8 RSEG parts, 1000 samples/series (2,000,000
+  scanned rows). 30 timed runs per combination after one warm-up.
+
+  | target_partitions | parallel | fanned_out | median_ms | stddev_ms | runs |
+  |---|---|---|---|---|---|
+  | 1 | false | no  | 6403.8 | 116.7 | 30 |
+  | 1 | true  | no  | 6392.1 | 117.6 | 30 |
+  | 2 | false | yes | 8210.9 | 678.8 | 30 |
+  | 2 | true  | yes | 7742.7 | 185.9 | 30 |
+  | 4 | false | yes | 9834.0 | 464.5 | 30 |
+  | 4 | true  | yes | 9467.5 | 546.4 | 30 |
+  | 8 | false | yes | 18590.1 | 2754.1 | 30 |
+  | 8 | true  | yes | 18552.6 | 2521.8 | 30 |
+
+  (At `target_partitions=1` a single partition already satisfies
+  `EnforceDistribution`, so no `RepartitionExec` is inserted and
+  `fanned_out` is `no` even with the flag on — the expected convergence
+  decision 5 predicts. At 2/4/8 the flag really did fan the `Final`
+  stage out.)
+
+  **Reading, per-partition-count (on median vs off median at the same
+  `target_partitions`, run-to-run stddev from a per-run spread on a
+  contended host, not a standard error of the median -- runs within a
+  combination were not interleaved, so this is a coarser check than a
+  proper significance test):** `tp=1` −0.18% (11.7 ms, well inside the
+  ~117 ms stddev); `tp=2` −5.7% (468 ms — the largest apparent gain, but
+  the off row's 679 ms stddev comes from a high-variance tail and the two
+  distributions overlap heavily); `tp=4` −3.7% (367 ms, inside one
+  combined per-run stddev); `tp=8` −0.20% (37.5 ms, dwarfed by the
+  ~2500 ms stddev). Parallel final aggregation is **within one combined
+  per-run stddev of serial at every measured partition count**: the only
+  apparent gains (tp=2, tp=4) are small and inside that band, and vanish
+  again at tp=8; no partition count shows parallel robustly faster by
+  this check, and none shows it slower.
+
+  **A second, structural finding, on the PARTITION-COUNT axis (not the
+  flag axis above):** holding the flag fixed, median latency *rises*
+  monotonically with `target_partitions` (6.4 s → 18.6 s from tp=1 to
+  tp=8, roughly +190%) -- the opposite of core-count speed-up, and a far
+  larger effect, in the same direction, as the preliminary `MemoryStore`
+  measurement's own partition-count sweep (which found parallelizing the
+  scan ~14% slower at 8 partitions and low cardinality). The two
+  measurements are not directly comparable -- the preliminary run had no
+  `parallel_final_aggregation` flag to test, only scan partition count
+  with a serial final merge -- but both point the same way: fanning the
+  scan out costs more than it saves at this cardinality, on both a
+  `MemoryStore` and a real-S3 backend. The likely mechanism on real S3:
+  the dataset's segment count (`parts=8`) is fixed across the whole
+  sweep, so GET count and size per segment are invariant as
+  `target_partitions` increases from 1 to 8 -- only *concurrency*
+  changes, either more simultaneous object-store round trips contending
+  for the same loopback MinIO, or CPU oversubscription from running more
+  concurrent scan/decode threads than the host's 8 logical cores. This
+  measurement cannot distinguish the two; either way, the epic's founding
+  premise (the serial final merge is the bottleneck) holds only when this
+  concurrency cost is absent, as the preliminary `MemoryStore` run's
+  much smaller regression suggests it was; with real S3 (and its
+  concurrency contention) in the loop, the final merge is not where the
+  time goes, so parallelizing it buys nothing net.
+
+  **Decision, per ADR-0102 decision 2's default-follows-measurement
+  rule:** parallel is not robustly faster than serial at any measured
+  partition count, so the flag's default **stays `false`**
+  (`SqlConfig::default().parallel_final_aggregation`,
+  `crates/ravel-sql/src/config.rs`; unchanged by this measurement, pinned
+  by a new test -- see Tests below) and this ADR moves to Accepted on the
+  strength of a proper S3-backed measurement — a validated "do not
+  default this on" is a real, evidenced decision, not an open question.
+  This measurement did not reach a cardinality large enough to test
+  ADR-0102 decision 2's other branch (a partition-count-dependent
+  crossover) -- see the cardinality caveat below.
+
+  **Caveats, stated plainly:**
+  - *Loopback MinIO, not real AWS S3, and the I/O-vs-CPU-oversubscription
+    ambiguity above.* A `127.0.0.1` MinIO has far lower and more uniform
+    latency than a real remote S3 endpoint. If the structural finding
+    above is genuinely object-store-latency-bound, a real S3 endpoint
+    would make the scan dominate the wall clock *more*, not less, which
+    would make this measurement a **lower bound** on how thoroughly the
+    scan out-weighs the final merge in production and would strengthen
+    the "default off" conclusion. But if the finding is actually
+    CPU/thread oversubscription on this specific 8-core host rather than
+    object-store latency, that lower-bound argument does not hold, and a
+    differently-shaped host or a real S3 endpoint could shift the balance
+    either way. This measurement cannot tell the two apart; whoever picks
+    up ADR-0102 decision 1's redesign (which independently flagged the
+    same real-S3 request-amplification risk from scan fan-out) should
+    re-derive this rather than assume the lower-bound framing holds.
+  - *Cardinality is 2000 groups / 2M rows (`groupby_scaling_bench`'s
+    `--series` default left as-is, `--samples-per-series` raised
+    500→1000), below the 20000-group / ClickBench-class target
+    ADR-0102 framed.* The final-merge cost this ADR parallelizes grows
+    with group cardinality, so a much larger cardinality could in
+    principle shift the balance toward parallel. That regime was not
+    reachable for a 30-run sweep on this real-S3 path: scan cost scales
+    with series count (≈25 s per scan at 20000 series, and higher
+    `target_partitions` made it slower, not faster, for the same
+    concurrency-cost reason above), and a single aggregation over
+    ≈10M+ rows exceeds the shipped 256 MiB per-query pool
+    (`DEFAULT_MAX_QUERY_BYTES`) and fails closed with a typed
+    `ResourcesExhausted` (ADR-0013 no-spill) — which the bench exposes no
+    flag to raise (`--max-tenant-bytes` sets the per-tenant ceiling, not
+    the per-query pool; confirmed no other flag reaches it). So the
+    measured point is the largest that both fits the real shipped
+    per-query budget and admits a 30-run sweep within the validation
+    host's time budget. A future task that wants the high-cardinality
+    crossover point specifically would need the bin extended to raise
+    `max_query_bytes`; that is not this decision's blocker, because the
+    scan-dominated real-S3 result is itself the
+    answer for representative execution.
+  - Decision 3's isolated peak-memory (redistribution-buffer)
+    measurement is not reproduced numerically here; the sweep did
+    surface its qualitative shape during scoping (a parallel-plan
+    combination hit `Memory Exhausted while SpillPool (DiskManager is
+    disabled)` where the serial plan reported the plain pool-exhausted
+    error for the same data, i.e. the new redistribution buffer does move
+    the memory ceiling), consistent with decision 3's caveat. A precise
+    peak-memory isolation remains the follow-up decision 3 named.
+  - **Cross-reference for ADR-0102 decision 1 (intra-segment scan
+    partitioning, currently Deferred pending redesign):** this
+    measurement's structural finding -- scan fan-out costing more than it
+    saves at this cardinality on real S3 -- empirically corroborates
+    decision 1's own deferral rationale, which independently predicted
+    real S3 request/egress amplification from splitting one segment's
+    blocks across partitions. Whoever redesigns decision 1 should read
+    this measurement's caveats above (particularly the
+    I/O-vs-CPU-oversubscription ambiguity on this specific 8-core host)
+    before assuming the amplification is purely an object-store-request
+    cost that a byte-range `GetRange` fetch or the ADR-0046 single-flight
+    cache would fully absorb -- it may be a concurrency/scheduling cost
+    that persists even with the request count fixed.
 - `docs/query-engine.md` gains a short note on `parallel_final_aggregation`,
   the exact-typed admission rule (including that `avg`/`mean` and any
   float group-by key are never eligible), and that a `GROUP BY` without


### PR DESCRIPTION

Epic #361 (ADR-0102 decision 2). Runs #457's group-by scaling benchmark
against a real S3-compatible store (loopback MinIO, release build, 30
runs per combination) to measure ADR-0094's parallel_final_aggregation
flag, replacing the earlier rejected MemoryStore-only preliminary
measurement.

Result: parallel is within one combined per-run stddev of serial at
every measured target_partitions value (1, 2, 4, 8) -- no partition
count shows a robust win. A second finding, on the partition-count axis
holding the flag fixed: median latency rises monotonically with
target_partitions (6.4s to 18.6s, roughly +190%), the opposite of
core-count speedup, in the same direction as the preliminary
MemoryStore run's own partition sweep (though at nowhere near the same
magnitude, and not directly comparable since that run had no flag to
test). The likely cause is scan concurrency cost, not the final merge
-- either object-store contention or CPU oversubscription on the
8-core host, which this measurement can't distinguish.

Per ADR-0102 decision 2's default-follows-measurement rule: the flag's
default stays false (unchanged; pinned by a new test in
crates/ravel-sql/src/config.rs), and ADR-0094 moves from Proposed to
Accepted -- a validated "don't default this on" is a real, evidenced
decision.

Cross-references ADR-0102 decision 1 (intra-segment scan partitioning,
currently deferred): this measurement's structural finding empirically
corroborates that decision's own deferral rationale (real S3
request/egress amplification from scan fan-out), and flags that the
amplification may be a concurrency cost rather than a pure request-count
cost, which matters for whichever redesign direction gets picked later.

States plainly what this measurement did not reach: a cardinality large
enough to test decision 2's other branch (a partition-count-dependent
crossover), blocked by the shipped 256 MiB per-query pool and the
benchmark having no flag to raise it -- named as a real follow-up, not
silently dropped.

Refs: #361
Fixes: #458
