### PR TITLE
docs(fleet-task-spec): require magnitude assertions, not non-zero

### DIFF
--- a/.claude/skills/fleet-task-spec/SKILL.md
+++ b/.claude/skills/fleet-task-spec/SKILL.md
@@ -169,6 +169,33 @@ be demonstrated failing, not merely written. The prove-the-test skill (in
 this repo, so executors have it too) lists the known vacuity shapes; point
 the spec's Tests section at it when the task is fix-shaped.
 
+## Numbers need magnitudes, not `> 0`
+
+When a task reports a count, a size, or any other measured quantity, the
+spec must forbid asserting only that it is non-zero or non-empty. A `> 0`
+assertion holds just as well when a figure is a fraction of the truth,
+which is how an accounting bug survives a green suite: a memory-pool charge
+shipped reporting roughly a quarter of its real resident footprint under a
+test that checked exactly that plus return-to-zero. Return-to-zero proves
+you released what you reserved, not that you reserved the right amount.
+
+- Pin an exact value where one exists. Generated 60 records, count 60.
+- Where the exact value moves with encoding or compression, bound it
+  **proportionally to something known** — per object, per row, per shard.
+  A flat floor is the trap: a floor low enough to be safe for one object is
+  also cleared by a figure that counts one object out of three. That exact
+  substitution passed a flat 1 KiB floor and failed a per-object band.
+- Require the magnitude assertion itself to be demonstrated failing, by
+  under-counting the source deliberately. An assertion nobody watched fail
+  is not evidence that it pins anything.
+
+This is also a REVIEWER's instruction, not only the executor's. The
+undercharge above survived its first adversarial review and was caught by a
+second one whose prompt asked, in as many words, whether each assertion
+actually pins a magnitude. Put that question in the review spec: for every
+number the change reports, does a test fail if the number is wrong, or only
+if it is missing?
+
 ## Sizing rules
 
 - One task must fit one context window: one crate, or one module cluster


### PR DESCRIPTION
A `> 0` or non-empty assertion holds just as well when a figure is a fraction of the truth, so a spec that accepts one lets an accounting bug pass a green suite.

Concrete case from this week: a memory-pool charge shipped reporting roughly a quarter of its real resident footprint, under a test that asserted exactly `> 0` plus return-to-zero. Return-to-zero proves you released what you reserved, not that you reserved the right amount.

Specs must now ask for an exact value where one exists, and a bound proportional to something known (per object, per row) where it does not. The flat-floor form is named as the trap: a floor low enough to be safe for one object is also cleared by a figure counting one object out of three — a substitution that really did pass a flat 1 KiB floor and fail a per-object band.

Also written as a **reviewer** instruction, which is the half that would otherwise be missed. The undercharge above survived its *first* adversarial review; the second caught it only because its prompt asked whether each assertion pins a magnitude. That question belongs in review specs: for every number a change reports, does a test fail if the number is wrong, or only if it is missing?

Complements #442, which put the unpiped-gate rule in the same skill for the same reason — specs are regenerated fresh each time, so a lesson living only in a session's memory never reaches an executor.

Refs: #428