### PR TITLE
feat(bench): add runnable ClickBench hits workload for Ravel

### DIFF
--- a/benchmarks/clickbench/hits.corpus.json
+++ b/benchmarks/clickbench/hits.corpus.json
@@ -1,0 +1,973 @@
+{
+  "version": 1,
+  "entries": [
+    {
+      "id": "q01_count_all",
+      "sql": "SELECT COUNT(*) FROM logs",
+      "constructs": [
+        "logs -> Signal::Logs",
+        "count"
+      ],
+      "expected_rows": 1,
+      "upstream_id": "Q1"
+    },
+    {
+      "id": "q02_count_adv_engine",
+      "sql": "SELECT COUNT(*) FROM logs WHERE \"AdvEngineID\" <> 0",
+      "constructs": [
+        "logs -> Signal::Logs",
+        "Filter (WHERE)",
+        "count",
+        "declared i64 typed comparison"
+      ],
+      "expected_rows": 1,
+      "upstream_id": "Q2",
+      "required_declarations": [
+        {
+          "key": "AdvEngineID",
+          "ty": "i64"
+        }
+      ]
+    },
+    {
+      "id": "q03_sum_count_avg",
+      "sql": "SELECT SUM(\"AdvEngineID\"), COUNT(*), AVG(\"ResolutionWidth\") FROM logs",
+      "constructs": [
+        "logs -> Signal::Logs",
+        "sum",
+        "count",
+        "avg",
+        "declared i64 typed aggregate"
+      ],
+      "expected_rows": 1,
+      "upstream_id": "Q3",
+      "required_declarations": [
+        {
+          "key": "AdvEngineID",
+          "ty": "i64"
+        },
+        {
+          "key": "ResolutionWidth",
+          "ty": "i64"
+        }
+      ]
+    },
+    {
+      "id": "q04_avg_userid",
+      "sql": "SELECT AVG(\"UserID\") FROM logs",
+      "constructs": [
+        "logs -> Signal::Logs",
+        "avg",
+        "declared i64 typed aggregate"
+      ],
+      "expected_rows": 1,
+      "upstream_id": "Q4",
+      "required_declarations": [
+        {
+          "key": "UserID",
+          "ty": "i64"
+        }
+      ]
+    },
+    {
+      "id": "q05_distinct_userid",
+      "sql": "SELECT COUNT(DISTINCT \"UserID\") FROM logs",
+      "constructs": [
+        "logs -> Signal::Logs",
+        "count(DISTINCT)"
+      ],
+      "expected_rows": 1,
+      "upstream_id": "Q5",
+      "required_declarations": [
+        {
+          "key": "UserID",
+          "ty": "i64"
+        }
+      ]
+    },
+    {
+      "id": "q06_distinct_searchphrase",
+      "sql": "SELECT COUNT(DISTINCT \"SearchPhrase\") FROM logs",
+      "constructs": [
+        "logs -> Signal::Logs",
+        "count(DISTINCT)"
+      ],
+      "expected_rows": 1,
+      "upstream_id": "Q6",
+      "required_declarations": [
+        {
+          "key": "SearchPhrase",
+          "ty": "str"
+        }
+      ]
+    },
+    {
+      "id": "q07_min_max_eventdate",
+      "sql": "SELECT MIN(\"EventDate\"), MAX(\"EventDate\") FROM logs",
+      "constructs": [
+        "logs -> Signal::Logs",
+        "min",
+        "max",
+        "declared i64 typed aggregate"
+      ],
+      "expected_rows": 1,
+      "upstream_id": "Q7",
+      "modified": {
+        "modified": {
+          "reason": "EventDate is declared i64 in its native epoch-DAY unit (Date32 days), so MIN/MAX return epoch-day integers, not DATE values (ADR-0100 decision 2)."
+        }
+      },
+      "required_declarations": [
+        {
+          "key": "EventDate",
+          "ty": "i64"
+        }
+      ]
+    },
+    {
+      "id": "q08_adv_engine_breakdown",
+      "sql": "SELECT \"AdvEngineID\", COUNT(*) FROM logs WHERE \"AdvEngineID\" <> 0 GROUP BY \"AdvEngineID\" ORDER BY COUNT(*) DESC",
+      "constructs": [
+        "logs -> Signal::Logs",
+        "Filter (WHERE)",
+        "count",
+        "GROUP BY",
+        "ORDER BY",
+        "declared i64 typed comparison"
+      ],
+      "upstream_id": "Q8",
+      "required_declarations": [
+        {
+          "key": "AdvEngineID",
+          "ty": "i64"
+        }
+      ]
+    },
+    {
+      "id": "q09_region_distinct_users",
+      "sql": "SELECT \"RegionID\", COUNT(DISTINCT \"UserID\") AS u FROM logs GROUP BY \"RegionID\" ORDER BY u DESC LIMIT 10",
+      "constructs": [
+        "logs -> Signal::Logs",
+        "count(DISTINCT)",
+        "GROUP BY",
+        "ORDER BY",
+        "LIMIT"
+      ],
+      "upstream_id": "Q9",
+      "required_declarations": [
+        {
+          "key": "RegionID",
+          "ty": "i64"
+        },
+        {
+          "key": "UserID",
+          "ty": "i64"
+        }
+      ]
+    },
+    {
+      "id": "q10_region_aggregates",
+      "sql": "SELECT \"RegionID\", SUM(\"AdvEngineID\"), COUNT(*) AS c, AVG(\"ResolutionWidth\"), COUNT(DISTINCT \"UserID\") FROM logs GROUP BY \"RegionID\" ORDER BY c DESC LIMIT 10",
+      "constructs": [
+        "logs -> Signal::Logs",
+        "sum",
+        "count",
+        "avg",
+        "count(DISTINCT)",
+        "GROUP BY",
+        "ORDER BY",
+        "LIMIT",
+        "declared i64 typed aggregate"
+      ],
+      "upstream_id": "Q10",
+      "required_declarations": [
+        {
+          "key": "RegionID",
+          "ty": "i64"
+        },
+        {
+          "key": "AdvEngineID",
+          "ty": "i64"
+        },
+        {
+          "key": "ResolutionWidth",
+          "ty": "i64"
+        },
+        {
+          "key": "UserID",
+          "ty": "i64"
+        }
+      ]
+    },
+    {
+      "id": "q11_mobile_model_users",
+      "sql": "SELECT \"MobilePhoneModel\", COUNT(DISTINCT \"UserID\") AS u FROM logs WHERE \"MobilePhoneModel\" <> '' GROUP BY \"MobilePhoneModel\" ORDER BY u DESC LIMIT 10",
+      "constructs": [
+        "logs -> Signal::Logs",
+        "Filter (WHERE)",
+        "count(DISTINCT)",
+        "GROUP BY",
+        "ORDER BY",
+        "LIMIT"
+      ],
+      "upstream_id": "Q11",
+      "required_declarations": [
+        {
+          "key": "MobilePhoneModel",
+          "ty": "str"
+        },
+        {
+          "key": "UserID",
+          "ty": "i64"
+        }
+      ]
+    },
+    {
+      "id": "q12_mobile_phone_model_users",
+      "sql": "SELECT \"MobilePhone\", \"MobilePhoneModel\", COUNT(DISTINCT \"UserID\") AS u FROM logs WHERE \"MobilePhoneModel\" <> '' GROUP BY \"MobilePhone\", \"MobilePhoneModel\" ORDER BY u DESC LIMIT 10",
+      "constructs": [
+        "logs -> Signal::Logs",
+        "Filter (WHERE)",
+        "count(DISTINCT)",
+        "GROUP BY",
+        "ORDER BY",
+        "LIMIT"
+      ],
+      "upstream_id": "Q12",
+      "required_declarations": [
+        {
+          "key": "MobilePhone",
+          "ty": "i64"
+        },
+        {
+          "key": "MobilePhoneModel",
+          "ty": "str"
+        },
+        {
+          "key": "UserID",
+          "ty": "i64"
+        }
+      ]
+    },
+    {
+      "id": "q13_top_search_phrases",
+      "sql": "SELECT \"SearchPhrase\", COUNT(*) AS c FROM logs WHERE \"SearchPhrase\" <> '' GROUP BY \"SearchPhrase\" ORDER BY c DESC LIMIT 10",
+      "constructs": [
+        "logs -> Signal::Logs",
+        "Filter (WHERE)",
+        "count",
+        "GROUP BY",
+        "ORDER BY",
+        "LIMIT"
+      ],
+      "upstream_id": "Q13",
+      "required_declarations": [
+        {
+          "key": "SearchPhrase",
+          "ty": "str"
+        }
+      ]
+    },
+    {
+      "id": "q14_search_phrases_distinct_users",
+      "sql": "SELECT \"SearchPhrase\", COUNT(DISTINCT \"UserID\") AS u FROM logs WHERE \"SearchPhrase\" <> '' GROUP BY \"SearchPhrase\" ORDER BY u DESC LIMIT 10",
+      "constructs": [
+        "logs -> Signal::Logs",
+        "Filter (WHERE)",
+        "count(DISTINCT)",
+        "GROUP BY",
+        "ORDER BY",
+        "LIMIT"
+      ],
+      "upstream_id": "Q14",
+      "required_declarations": [
+        {
+          "key": "SearchPhrase",
+          "ty": "str"
+        },
+        {
+          "key": "UserID",
+          "ty": "i64"
+        }
+      ]
+    },
+    {
+      "id": "q15_engine_phrase_counts",
+      "sql": "SELECT \"SearchEngineID\", \"SearchPhrase\", COUNT(*) AS c FROM logs WHERE \"SearchPhrase\" <> '' GROUP BY \"SearchEngineID\", \"SearchPhrase\" ORDER BY c DESC LIMIT 10",
+      "constructs": [
+        "logs -> Signal::Logs",
+        "Filter (WHERE)",
+        "count",
+        "GROUP BY",
+        "ORDER BY",
+        "LIMIT"
+      ],
+      "upstream_id": "Q15",
+      "required_declarations": [
+        {
+          "key": "SearchEngineID",
+          "ty": "i64"
+        },
+        {
+          "key": "SearchPhrase",
+          "ty": "str"
+        }
+      ]
+    },
+    {
+      "id": "q16_top_users",
+      "sql": "SELECT \"UserID\", COUNT(*) FROM logs GROUP BY \"UserID\" ORDER BY COUNT(*) DESC LIMIT 10",
+      "constructs": [
+        "logs -> Signal::Logs",
+        "count",
+        "GROUP BY",
+        "ORDER BY",
+        "LIMIT"
+      ],
+      "upstream_id": "Q16",
+      "required_declarations": [
+        {
+          "key": "UserID",
+          "ty": "i64"
+        }
+      ]
+    },
+    {
+      "id": "q17_top_user_phrase",
+      "sql": "SELECT \"UserID\", \"SearchPhrase\", COUNT(*) FROM logs GROUP BY \"UserID\", \"SearchPhrase\" ORDER BY COUNT(*) DESC LIMIT 10",
+      "constructs": [
+        "logs -> Signal::Logs",
+        "count",
+        "GROUP BY",
+        "ORDER BY",
+        "LIMIT"
+      ],
+      "upstream_id": "Q17",
+      "required_declarations": [
+        {
+          "key": "UserID",
+          "ty": "i64"
+        },
+        {
+          "key": "SearchPhrase",
+          "ty": "str"
+        }
+      ]
+    },
+    {
+      "id": "q18_user_phrase_limit",
+      "sql": "SELECT \"UserID\", \"SearchPhrase\", COUNT(*) FROM logs GROUP BY \"UserID\", \"SearchPhrase\" LIMIT 10",
+      "constructs": [
+        "logs -> Signal::Logs",
+        "count",
+        "GROUP BY",
+        "LIMIT"
+      ],
+      "upstream_id": "Q18",
+      "required_declarations": [
+        {
+          "key": "UserID",
+          "ty": "i64"
+        },
+        {
+          "key": "SearchPhrase",
+          "ty": "str"
+        }
+      ]
+    },
+    {
+      "id": "q19_user_minute_phrase",
+      "sql": "SELECT \"UserID\", date_part('minute', ts) AS m, \"SearchPhrase\", COUNT(*) FROM logs GROUP BY \"UserID\", m, \"SearchPhrase\" ORDER BY COUNT(*) DESC LIMIT 10",
+      "constructs": [
+        "logs -> Signal::Logs",
+        "date_part(minute)",
+        "count",
+        "GROUP BY",
+        "ORDER BY",
+        "LIMIT"
+      ],
+      "upstream_id": "Q19",
+      "required_declarations": [
+        {
+          "key": "UserID",
+          "ty": "i64"
+        },
+        {
+          "key": "SearchPhrase",
+          "ty": "str"
+        }
+      ]
+    },
+    {
+      "id": "q20_userid_lookup",
+      "sql": "SELECT \"UserID\" FROM logs WHERE \"UserID\" = 435090932899640449",
+      "constructs": [
+        "logs -> Signal::Logs",
+        "Projection",
+        "Filter (WHERE)",
+        "declared i64 typed comparison"
+      ],
+      "upstream_id": "Q20",
+      "required_declarations": [
+        {
+          "key": "UserID",
+          "ty": "i64"
+        }
+      ]
+    },
+    {
+      "id": "q25_phrases_by_time",
+      "sql": "SELECT \"SearchPhrase\" FROM logs WHERE \"SearchPhrase\" <> '' ORDER BY ts LIMIT 10",
+      "constructs": [
+        "logs -> Signal::Logs",
+        "Projection",
+        "Filter (WHERE)",
+        "ORDER BY",
+        "LIMIT"
+      ],
+      "upstream_id": "Q25",
+      "required_declarations": [
+        {
+          "key": "SearchPhrase",
+          "ty": "str"
+        }
+      ]
+    },
+    {
+      "id": "q26_phrases_alpha",
+      "sql": "SELECT \"SearchPhrase\" FROM logs WHERE \"SearchPhrase\" <> '' ORDER BY \"SearchPhrase\" LIMIT 10",
+      "constructs": [
+        "logs -> Signal::Logs",
+        "Projection",
+        "Filter (WHERE)",
+        "ORDER BY",
+        "LIMIT"
+      ],
+      "upstream_id": "Q26",
+      "required_declarations": [
+        {
+          "key": "SearchPhrase",
+          "ty": "str"
+        }
+      ]
+    },
+    {
+      "id": "q27_phrases_time_then_phrase",
+      "sql": "SELECT \"SearchPhrase\" FROM logs WHERE \"SearchPhrase\" <> '' ORDER BY ts, \"SearchPhrase\" LIMIT 10",
+      "constructs": [
+        "logs -> Signal::Logs",
+        "Projection",
+        "Filter (WHERE)",
+        "ORDER BY",
+        "LIMIT"
+      ],
+      "upstream_id": "Q27",
+      "required_declarations": [
+        {
+          "key": "SearchPhrase",
+          "ty": "str"
+        }
+      ]
+    },
+    {
+      "id": "q30_resolution_running_sums",
+      "sql": "SELECT SUM(\"ResolutionWidth\"), SUM(\"ResolutionWidth\" + 1), SUM(\"ResolutionWidth\" + 2), SUM(\"ResolutionWidth\" + 3), SUM(\"ResolutionWidth\" + 4), SUM(\"ResolutionWidth\" + 5), SUM(\"ResolutionWidth\" + 6), SUM(\"ResolutionWidth\" + 7), SUM(\"ResolutionWidth\" + 8), SUM(\"ResolutionWidth\" + 9), SUM(\"ResolutionWidth\" + 10), SUM(\"ResolutionWidth\" + 11), SUM(\"ResolutionWidth\" + 12), SUM(\"ResolutionWidth\" + 13), SUM(\"ResolutionWidth\" + 14), SUM(\"ResolutionWidth\" + 15), SUM(\"ResolutionWidth\" + 16), SUM(\"ResolutionWidth\" + 17), SUM(\"ResolutionWidth\" + 18), SUM(\"ResolutionWidth\" + 19), SUM(\"ResolutionWidth\" + 20), SUM(\"ResolutionWidth\" + 21), SUM(\"ResolutionWidth\" + 22), SUM(\"ResolutionWidth\" + 23), SUM(\"ResolutionWidth\" + 24), SUM(\"ResolutionWidth\" + 25), SUM(\"ResolutionWidth\" + 26), SUM(\"ResolutionWidth\" + 27), SUM(\"ResolutionWidth\" + 28), SUM(\"ResolutionWidth\" + 29), SUM(\"ResolutionWidth\" + 30), SUM(\"ResolutionWidth\" + 31), SUM(\"ResolutionWidth\" + 32), SUM(\"ResolutionWidth\" + 33), SUM(\"ResolutionWidth\" + 34), SUM(\"ResolutionWidth\" + 35), SUM(\"ResolutionWidth\" + 36), SUM(\"ResolutionWidth\" + 37), SUM(\"ResolutionWidth\" + 38), SUM(\"ResolutionWidth\" + 39), SUM(\"ResolutionWidth\" + 40), SUM(\"ResolutionWidth\" + 41), SUM(\"ResolutionWidth\" + 42), SUM(\"ResolutionWidth\" + 43), SUM(\"ResolutionWidth\" + 44), SUM(\"ResolutionWidth\" + 45), SUM(\"ResolutionWidth\" + 46), SUM(\"ResolutionWidth\" + 47), SUM(\"ResolutionWidth\" + 48), SUM(\"ResolutionWidth\" + 49), SUM(\"ResolutionWidth\" + 50), SUM(\"ResolutionWidth\" + 51), SUM(\"ResolutionWidth\" + 52), SUM(\"ResolutionWidth\" + 53), SUM(\"ResolutionWidth\" + 54), SUM(\"ResolutionWidth\" + 55), SUM(\"ResolutionWidth\" + 56), SUM(\"ResolutionWidth\" + 57), SUM(\"ResolutionWidth\" + 58), SUM(\"ResolutionWidth\" + 59), SUM(\"ResolutionWidth\" + 60), SUM(\"ResolutionWidth\" + 61), SUM(\"ResolutionWidth\" + 62), SUM(\"ResolutionWidth\" + 63), SUM(\"ResolutionWidth\" + 64), SUM(\"ResolutionWidth\" + 65), SUM(\"ResolutionWidth\" + 66), SUM(\"ResolutionWidth\" + 67), SUM(\"ResolutionWidth\" + 68), SUM(\"ResolutionWidth\" + 69), SUM(\"ResolutionWidth\" + 70), SUM(\"ResolutionWidth\" + 71), SUM(\"ResolutionWidth\" + 72), SUM(\"ResolutionWidth\" + 73), SUM(\"ResolutionWidth\" + 74), SUM(\"ResolutionWidth\" + 75), SUM(\"ResolutionWidth\" + 76), SUM(\"ResolutionWidth\" + 77), SUM(\"ResolutionWidth\" + 78), SUM(\"ResolutionWidth\" + 79), SUM(\"ResolutionWidth\" + 80), SUM(\"ResolutionWidth\" + 81), SUM(\"ResolutionWidth\" + 82), SUM(\"ResolutionWidth\" + 83), SUM(\"ResolutionWidth\" + 84), SUM(\"ResolutionWidth\" + 85), SUM(\"ResolutionWidth\" + 86), SUM(\"ResolutionWidth\" + 87), SUM(\"ResolutionWidth\" + 88), SUM(\"ResolutionWidth\" + 89) FROM logs",
+      "constructs": [
+        "logs -> Signal::Logs",
+        "sum",
+        "declared i64 typed aggregate"
+      ],
+      "expected_rows": 1,
+      "upstream_id": "Q30",
+      "required_declarations": [
+        {
+          "key": "ResolutionWidth",
+          "ty": "i64"
+        }
+      ]
+    },
+    {
+      "id": "q31_engine_ip_aggregates",
+      "sql": "SELECT \"SearchEngineID\", \"ClientIP\", COUNT(*) AS c, SUM(\"IsRefresh\"), AVG(\"ResolutionWidth\") FROM logs WHERE \"SearchPhrase\" <> '' GROUP BY \"SearchEngineID\", \"ClientIP\" ORDER BY c DESC LIMIT 10",
+      "constructs": [
+        "logs -> Signal::Logs",
+        "Filter (WHERE)",
+        "count",
+        "sum",
+        "avg",
+        "GROUP BY",
+        "ORDER BY",
+        "LIMIT",
+        "declared i64 typed aggregate"
+      ],
+      "upstream_id": "Q31",
+      "required_declarations": [
+        {
+          "key": "SearchEngineID",
+          "ty": "i64"
+        },
+        {
+          "key": "ClientIP",
+          "ty": "i64"
+        },
+        {
+          "key": "IsRefresh",
+          "ty": "i64"
+        },
+        {
+          "key": "ResolutionWidth",
+          "ty": "i64"
+        },
+        {
+          "key": "SearchPhrase",
+          "ty": "str"
+        }
+      ]
+    },
+    {
+      "id": "q32_watch_ip_aggregates_filtered",
+      "sql": "SELECT \"WatchID\", \"ClientIP\", COUNT(*) AS c, SUM(\"IsRefresh\"), AVG(\"ResolutionWidth\") FROM logs WHERE \"SearchPhrase\" <> '' GROUP BY \"WatchID\", \"ClientIP\" ORDER BY c DESC LIMIT 10",
+      "constructs": [
+        "logs -> Signal::Logs",
+        "Filter (WHERE)",
+        "count",
+        "sum",
+        "avg",
+        "GROUP BY",
+        "ORDER BY",
+        "LIMIT",
+        "declared i64 typed aggregate"
+      ],
+      "upstream_id": "Q32",
+      "required_declarations": [
+        {
+          "key": "WatchID",
+          "ty": "i64"
+        },
+        {
+          "key": "ClientIP",
+          "ty": "i64"
+        },
+        {
+          "key": "IsRefresh",
+          "ty": "i64"
+        },
+        {
+          "key": "ResolutionWidth",
+          "ty": "i64"
+        },
+        {
+          "key": "SearchPhrase",
+          "ty": "str"
+        }
+      ]
+    },
+    {
+      "id": "q33_watch_ip_aggregates_all",
+      "sql": "SELECT \"WatchID\", \"ClientIP\", COUNT(*) AS c, SUM(\"IsRefresh\"), AVG(\"ResolutionWidth\") FROM logs GROUP BY \"WatchID\", \"ClientIP\" ORDER BY c DESC LIMIT 10",
+      "constructs": [
+        "logs -> Signal::Logs",
+        "count",
+        "sum",
+        "avg",
+        "GROUP BY",
+        "ORDER BY",
+        "LIMIT",
+        "declared i64 typed aggregate"
+      ],
+      "upstream_id": "Q33",
+      "required_declarations": [
+        {
+          "key": "WatchID",
+          "ty": "i64"
+        },
+        {
+          "key": "ClientIP",
+          "ty": "i64"
+        },
+        {
+          "key": "IsRefresh",
+          "ty": "i64"
+        },
+        {
+          "key": "ResolutionWidth",
+          "ty": "i64"
+        }
+      ]
+    },
+    {
+      "id": "q34_top_urls",
+      "sql": "SELECT \"URL\", COUNT(*) AS c FROM logs GROUP BY \"URL\" ORDER BY c DESC LIMIT 10",
+      "constructs": [
+        "logs -> Signal::Logs",
+        "count",
+        "GROUP BY",
+        "ORDER BY",
+        "LIMIT"
+      ],
+      "upstream_id": "Q34",
+      "required_declarations": [
+        {
+          "key": "URL",
+          "ty": "str"
+        }
+      ]
+    },
+    {
+      "id": "q35_top_urls_const_col",
+      "sql": "SELECT 1, \"URL\", COUNT(*) AS c FROM logs GROUP BY 1, \"URL\" ORDER BY c DESC LIMIT 10",
+      "constructs": [
+        "logs -> Signal::Logs",
+        "count",
+        "GROUP BY",
+        "GROUP BY ordinal",
+        "ORDER BY",
+        "LIMIT"
+      ],
+      "upstream_id": "Q35",
+      "required_declarations": [
+        {
+          "key": "URL",
+          "ty": "str"
+        }
+      ]
+    },
+    {
+      "id": "q36_clientip_offsets",
+      "sql": "SELECT \"ClientIP\", \"ClientIP\" - 1, \"ClientIP\" - 2, \"ClientIP\" - 3, COUNT(*) AS c FROM logs GROUP BY \"ClientIP\", \"ClientIP\" - 1, \"ClientIP\" - 2, \"ClientIP\" - 3 ORDER BY c DESC LIMIT 10",
+      "constructs": [
+        "logs -> Signal::Logs",
+        "count",
+        "GROUP BY",
+        "ORDER BY",
+        "LIMIT"
+      ],
+      "upstream_id": "Q36",
+      "required_declarations": [
+        {
+          "key": "ClientIP",
+          "ty": "i64"
+        }
+      ]
+    },
+    {
+      "id": "q37_july_pageviews_by_url",
+      "sql": "SELECT \"URL\", COUNT(*) AS PageViews FROM logs WHERE \"CounterID\" = 62 AND \"EventDate\" >= 15887 AND \"EventDate\" <= 15917 AND \"DontCountHits\" = 0 AND \"IsRefresh\" = 0 AND \"URL\" <> '' GROUP BY \"URL\" ORDER BY PageViews DESC LIMIT 10",
+      "constructs": [
+        "logs -> Signal::Logs",
+        "Filter (WHERE)",
+        "count",
+        "GROUP BY",
+        "ORDER BY",
+        "LIMIT",
+        "declared i64 typed comparison"
+      ],
+      "upstream_id": "Q37",
+      "modified": {
+        "modified": {
+          "reason": "EventDate is declared i64 epoch-days, so the DATE range '2013-07-01'..'2013-07-31' becomes the epoch-day integer range 15887..15917 (ADR-0100 decision 3)."
+        }
+      },
+      "required_declarations": [
+        {
+          "key": "URL",
+          "ty": "str"
+        },
+        {
+          "key": "CounterID",
+          "ty": "i64"
+        },
+        {
+          "key": "EventDate",
+          "ty": "i64"
+        },
+        {
+          "key": "DontCountHits",
+          "ty": "i64"
+        },
+        {
+          "key": "IsRefresh",
+          "ty": "i64"
+        }
+      ]
+    },
+    {
+      "id": "q38_july_pageviews_by_title",
+      "sql": "SELECT \"Title\", COUNT(*) AS PageViews FROM logs WHERE \"CounterID\" = 62 AND \"EventDate\" >= 15887 AND \"EventDate\" <= 15917 AND \"DontCountHits\" = 0 AND \"IsRefresh\" = 0 AND \"Title\" <> '' GROUP BY \"Title\" ORDER BY PageViews DESC LIMIT 10",
+      "constructs": [
+        "logs -> Signal::Logs",
+        "Filter (WHERE)",
+        "count",
+        "GROUP BY",
+        "ORDER BY",
+        "LIMIT",
+        "declared i64 typed comparison"
+      ],
+      "upstream_id": "Q38",
+      "modified": {
+        "modified": {
+          "reason": "EventDate is declared i64 epoch-days, so the DATE range '2013-07-01'..'2013-07-31' becomes the epoch-day integer range 15887..15917 (ADR-0100 decision 3)."
+        }
+      },
+      "required_declarations": [
+        {
+          "key": "Title",
+          "ty": "str"
+        },
+        {
+          "key": "CounterID",
+          "ty": "i64"
+        },
+        {
+          "key": "EventDate",
+          "ty": "i64"
+        },
+        {
+          "key": "DontCountHits",
+          "ty": "i64"
+        },
+        {
+          "key": "IsRefresh",
+          "ty": "i64"
+        }
+      ]
+    },
+    {
+      "id": "q39_july_pageviews_link_download",
+      "sql": "SELECT \"URL\", COUNT(*) AS PageViews FROM logs WHERE \"CounterID\" = 62 AND \"EventDate\" >= 15887 AND \"EventDate\" <= 15917 AND \"IsRefresh\" = 0 AND \"IsLink\" <> 0 AND \"IsDownload\" = 0 GROUP BY \"URL\" ORDER BY PageViews DESC LIMIT 10 OFFSET 1000",
+      "constructs": [
+        "logs -> Signal::Logs",
+        "Filter (WHERE)",
+        "count",
+        "GROUP BY",
+        "ORDER BY",
+        "LIMIT",
+        "OFFSET",
+        "declared i64 typed comparison"
+      ],
+      "upstream_id": "Q39",
+      "modified": {
+        "modified": {
+          "reason": "EventDate is declared i64 epoch-days, so the DATE range '2013-07-01'..'2013-07-31' becomes the epoch-day integer range 15887..15917 (ADR-0100 decision 3)."
+        }
+      },
+      "required_declarations": [
+        {
+          "key": "URL",
+          "ty": "str"
+        },
+        {
+          "key": "CounterID",
+          "ty": "i64"
+        },
+        {
+          "key": "EventDate",
+          "ty": "i64"
+        },
+        {
+          "key": "IsRefresh",
+          "ty": "i64"
+        },
+        {
+          "key": "IsLink",
+          "ty": "i64"
+        },
+        {
+          "key": "IsDownload",
+          "ty": "i64"
+        }
+      ]
+    },
+    {
+      "id": "q40_traffic_source_funnel",
+      "sql": "SELECT \"TraficSourceID\", \"SearchEngineID\", \"AdvEngineID\", CASE WHEN (\"SearchEngineID\" = 0 AND \"AdvEngineID\" = 0) THEN \"Referer\" ELSE '' END AS Src, \"URL\" AS Dst, COUNT(*) AS PageViews FROM logs WHERE \"CounterID\" = 62 AND \"EventDate\" >= 15887 AND \"EventDate\" <= 15917 AND \"IsRefresh\" = 0 GROUP BY \"TraficSourceID\", \"SearchEngineID\", \"AdvEngineID\", Src, Dst ORDER BY PageViews DESC LIMIT 10 OFFSET 1000",
+      "constructs": [
+        "logs -> Signal::Logs",
+        "Filter (WHERE)",
+        "CASE",
+        "count",
+        "GROUP BY",
+        "ORDER BY",
+        "LIMIT",
+        "OFFSET",
+        "declared i64 typed comparison"
+      ],
+      "upstream_id": "Q40",
+      "modified": {
+        "modified": {
+          "reason": "EventDate is declared i64 epoch-days, so the DATE range '2013-07-01'..'2013-07-31' becomes the epoch-day integer range 15887..15917 (ADR-0100 decision 3)."
+        }
+      },
+      "required_declarations": [
+        {
+          "key": "TraficSourceID",
+          "ty": "i64"
+        },
+        {
+          "key": "SearchEngineID",
+          "ty": "i64"
+        },
+        {
+          "key": "AdvEngineID",
+          "ty": "i64"
+        },
+        {
+          "key": "Referer",
+          "ty": "str"
+        },
+        {
+          "key": "URL",
+          "ty": "str"
+        },
+        {
+          "key": "CounterID",
+          "ty": "i64"
+        },
+        {
+          "key": "EventDate",
+          "ty": "i64"
+        },
+        {
+          "key": "IsRefresh",
+          "ty": "i64"
+        }
+      ]
+    },
+    {
+      "id": "q41_urlhash_date_pageviews",
+      "sql": "SELECT \"URLHash\", \"EventDate\", COUNT(*) AS PageViews FROM logs WHERE \"CounterID\" = 62 AND \"EventDate\" >= 15887 AND \"EventDate\" <= 15917 AND \"IsRefresh\" = 0 AND \"TraficSourceID\" IN (-1, 6) AND \"RefererHash\" = 3594120000172545465 GROUP BY \"URLHash\", \"EventDate\" ORDER BY PageViews DESC LIMIT 10 OFFSET 100",
+      "constructs": [
+        "logs -> Signal::Logs",
+        "Filter (WHERE)",
+        "IN list",
+        "count",
+        "GROUP BY",
+        "ORDER BY",
+        "LIMIT",
+        "OFFSET",
+        "declared i64 typed comparison"
+      ],
+      "upstream_id": "Q41",
+      "modified": {
+        "modified": {
+          "reason": "EventDate is declared i64 epoch-days: the DATE range '2013-07-01'..'2013-07-31' becomes epoch-day integers 15887..15917, and the projected EventDate returns epoch-day integers rather than DATE values (ADR-0100 decision 3)."
+        }
+      },
+      "required_declarations": [
+        {
+          "key": "URLHash",
+          "ty": "i64"
+        },
+        {
+          "key": "EventDate",
+          "ty": "i64"
+        },
+        {
+          "key": "CounterID",
+          "ty": "i64"
+        },
+        {
+          "key": "IsRefresh",
+          "ty": "i64"
+        },
+        {
+          "key": "TraficSourceID",
+          "ty": "i64"
+        },
+        {
+          "key": "RefererHash",
+          "ty": "i64"
+        }
+      ]
+    },
+    {
+      "id": "q42_window_dims_pageviews",
+      "sql": "SELECT \"WindowClientWidth\", \"WindowClientHeight\", COUNT(*) AS PageViews FROM logs WHERE \"CounterID\" = 62 AND \"EventDate\" >= 15887 AND \"EventDate\" <= 15917 AND \"IsRefresh\" = 0 AND \"DontCountHits\" = 0 AND \"URLHash\" = 2868770270353813622 GROUP BY \"WindowClientWidth\", \"WindowClientHeight\" ORDER BY PageViews DESC LIMIT 10 OFFSET 10000",
+      "constructs": [
+        "logs -> Signal::Logs",
+        "Filter (WHERE)",
+        "count",
+        "GROUP BY",
+        "ORDER BY",
+        "LIMIT",
+        "OFFSET",
+        "declared i64 typed comparison"
+      ],
+      "upstream_id": "Q42",
+      "modified": {
+        "modified": {
+          "reason": "EventDate is declared i64 epoch-days, so the DATE range '2013-07-01'..'2013-07-31' becomes the epoch-day integer range 15887..15917 (ADR-0100 decision 3)."
+        }
+      },
+      "required_declarations": [
+        {
+          "key": "WindowClientWidth",
+          "ty": "i64"
+        },
+        {
+          "key": "WindowClientHeight",
+          "ty": "i64"
+        },
+        {
+          "key": "CounterID",
+          "ty": "i64"
+        },
+        {
+          "key": "EventDate",
+          "ty": "i64"
+        },
+        {
+          "key": "IsRefresh",
+          "ty": "i64"
+        },
+        {
+          "key": "DontCountHits",
+          "ty": "i64"
+        },
+        {
+          "key": "URLHash",
+          "ty": "i64"
+        }
+      ]
+    },
+    {
+      "id": "q43_per_minute_pageviews",
+      "sql": "SELECT DATE_TRUNC('minute', ts) AS M, COUNT(*) AS PageViews FROM logs WHERE \"CounterID\" = 62 AND \"EventDate\" >= 15900 AND \"EventDate\" <= 15901 AND \"IsRefresh\" = 0 AND \"DontCountHits\" = 0 GROUP BY DATE_TRUNC('minute', ts) ORDER BY DATE_TRUNC('minute', ts) LIMIT 10 OFFSET 1000",
+      "constructs": [
+        "logs -> Signal::Logs",
+        "DATE_TRUNC",
+        "Filter (WHERE)",
+        "count",
+        "GROUP BY",
+        "ORDER BY",
+        "LIMIT",
+        "OFFSET",
+        "declared i64 typed comparison"
+      ],
+      "upstream_id": "Q43",
+      "modified": {
+        "modified": {
+          "reason": "EventDate is declared i64 epoch-days, so the DATE range '2013-07-14'..'2013-07-15' becomes the epoch-day integer range 15900..15901 (ADR-0100 decision 3)."
+        }
+      },
+      "required_declarations": [
+        {
+          "key": "CounterID",
+          "ty": "i64"
+        },
+        {
+          "key": "EventDate",
+          "ty": "i64"
+        },
+        {
+          "key": "IsRefresh",
+          "ty": "i64"
+        },
+        {
+          "key": "DontCountHits",
+          "ty": "i64"
+        }
+      ]
+    }
+  ]
+}

--- a/benchmarks/clickbench/hits.mapping.toml
+++ b/benchmarks/clickbench/hits.mapping.toml
@@ -1,0 +1,568 @@
+# ClickBench `hits` schema mapping for `ravel-cli load --parquet` (ADR-0100, issue #430).
+#
+# Source of truth for the column names and their upstream SQL types:
+# https://github.com/ClickHouse/ClickBench/blob/main/postgresql/create.sql
+# (105 columns). This mapping is checked in so a ClickBench load is repeatable;
+# it is consumed twice, with the SAME key/type information:
+#   1. `ravel-cli load --parquet --mapping hits.mapping.toml` writes the records.
+#   2. `ravel-cli typed-attr-column set --from-mapping hits.mapping.toml` declares
+#      the typed attribute columns the SQL layer accelerates (ADR-0100 decision 2).
+#
+# Type mapping (upstream SQL type -> loader ColType -> ravel-sql DeclaredType):
+#   BIGINT / INTEGER / SMALLINT -> i64  -> I64
+#   TEXT / VARCHAR(n) / CHAR    -> str  -> Str
+#   Date / TIMESTAMP            -> i64  -> I64   (see EventTime / secondary-time note)
+#
+# EventTime is the primary event-time column: it rides the native typed `ts`
+# path (ts_column below) and is NOT declared as an attribute. Every OTHER column
+# becomes a typed attribute with its ColType.
+#
+# F64 note (ADR-0101 / #431): ColType::F64 attributes CANNOT be declared as typed
+# columns -- ravel-sql `DeclaredType` has no F64 variant (Str/I64/Bool/Bytes only),
+# so `typed-attr-column set --from-mapping` skips an f64 entry with a stderr warning
+# and a float attribute stays queryable only through `attrs['<key>']`. This mapping
+# declares NO f64 column: the `hits` schema is entirely integer, string, and
+# date/time columns (77 integer/date/time, 28 text; 0 float), so the F64 gap affects
+# 0 of the 105 columns here. The note is kept because a different dataset would hit it.
+#
+# Secondary time columns EventDate, ClientEventTime, LocalEventTime are declared i64.
+# EventDate is a Date column: the loader stores it as its native unit, epoch DAYS
+# (Date32 = days since 1970-01-01), NOT nanoseconds (load.rs read_i64). A date-literal
+# comparison in a query therefore becomes an epoch-DAY integer comparison; the corpus
+# flags those statements `modified` (ADR-0100 decision 3). ClientEventTime and
+# LocalEventTime are TIMESTAMP in the schema: the loader `i64` path accepts integer
+# and Date32/Date64 columns but NOT a native Arrow Timestamp column, so these two load
+# only if the operator's hits.parquet encodes them as an integer/date column. None of
+# the 43 ClickBench statements reference them, so this does not affect the suite.
+
+ts_column = "EventTime"
+# EventTime in the original data is a Unix-seconds datetime. If the operator's
+# hits.parquet stores EventTime as a native Arrow Timestamp, the loader uses the
+# column's own unit and this ts_unit is ignored (load.rs read_ts); set it to match
+# the parquet only when EventTime is stored as an integer.
+ts_unit = "seconds"
+
+# All 104 non-EventTime columns, as record attributes (typed values in `attrs`, not
+# part of stream identity). No resource_attribute entries: the flat `hits` table has
+# no per-entity stream key, so every row shares one logstream. 104 attributes sit far
+# under the per-object dynamic-column budget of 1000 (RlogConfig::max_dynamic_columns).
+
+[[attribute]]
+key = "WatchID"
+column = "WatchID"
+type = "i64"
+
+[[attribute]]
+key = "JavaEnable"
+column = "JavaEnable"
+type = "i64"
+
+[[attribute]]
+key = "Title"
+column = "Title"
+type = "str"
+
+[[attribute]]
+key = "GoodEvent"
+column = "GoodEvent"
+type = "i64"
+
+[[attribute]]
+key = "EventDate"
+column = "EventDate"
+type = "i64"
+
+[[attribute]]
+key = "CounterID"
+column = "CounterID"
+type = "i64"
+
+[[attribute]]
+key = "ClientIP"
+column = "ClientIP"
+type = "i64"
+
+[[attribute]]
+key = "RegionID"
+column = "RegionID"
+type = "i64"
+
+[[attribute]]
+key = "UserID"
+column = "UserID"
+type = "i64"
+
+[[attribute]]
+key = "CounterClass"
+column = "CounterClass"
+type = "i64"
+
+[[attribute]]
+key = "OS"
+column = "OS"
+type = "i64"
+
+[[attribute]]
+key = "UserAgent"
+column = "UserAgent"
+type = "i64"
+
+[[attribute]]
+key = "URL"
+column = "URL"
+type = "str"
+
+[[attribute]]
+key = "Referer"
+column = "Referer"
+type = "str"
+
+[[attribute]]
+key = "IsRefresh"
+column = "IsRefresh"
+type = "i64"
+
+[[attribute]]
+key = "RefererCategoryID"
+column = "RefererCategoryID"
+type = "i64"
+
+[[attribute]]
+key = "RefererRegionID"
+column = "RefererRegionID"
+type = "i64"
+
+[[attribute]]
+key = "URLCategoryID"
+column = "URLCategoryID"
+type = "i64"
+
+[[attribute]]
+key = "URLRegionID"
+column = "URLRegionID"
+type = "i64"
+
+[[attribute]]
+key = "ResolutionWidth"
+column = "ResolutionWidth"
+type = "i64"
+
+[[attribute]]
+key = "ResolutionHeight"
+column = "ResolutionHeight"
+type = "i64"
+
+[[attribute]]
+key = "ResolutionDepth"
+column = "ResolutionDepth"
+type = "i64"
+
+[[attribute]]
+key = "FlashMajor"
+column = "FlashMajor"
+type = "i64"
+
+[[attribute]]
+key = "FlashMinor"
+column = "FlashMinor"
+type = "i64"
+
+[[attribute]]
+key = "FlashMinor2"
+column = "FlashMinor2"
+type = "str"
+
+[[attribute]]
+key = "NetMajor"
+column = "NetMajor"
+type = "i64"
+
+[[attribute]]
+key = "NetMinor"
+column = "NetMinor"
+type = "i64"
+
+[[attribute]]
+key = "UserAgentMajor"
+column = "UserAgentMajor"
+type = "i64"
+
+[[attribute]]
+key = "UserAgentMinor"
+column = "UserAgentMinor"
+type = "str"
+
+[[attribute]]
+key = "CookieEnable"
+column = "CookieEnable"
+type = "i64"
+
+[[attribute]]
+key = "JavascriptEnable"
+column = "JavascriptEnable"
+type = "i64"
+
+[[attribute]]
+key = "IsMobile"
+column = "IsMobile"
+type = "i64"
+
+[[attribute]]
+key = "MobilePhone"
+column = "MobilePhone"
+type = "i64"
+
+[[attribute]]
+key = "MobilePhoneModel"
+column = "MobilePhoneModel"
+type = "str"
+
+[[attribute]]
+key = "Params"
+column = "Params"
+type = "str"
+
+[[attribute]]
+key = "IPNetworkID"
+column = "IPNetworkID"
+type = "i64"
+
+[[attribute]]
+key = "TraficSourceID"
+column = "TraficSourceID"
+type = "i64"
+
+[[attribute]]
+key = "SearchEngineID"
+column = "SearchEngineID"
+type = "i64"
+
+[[attribute]]
+key = "SearchPhrase"
+column = "SearchPhrase"
+type = "str"
+
+[[attribute]]
+key = "AdvEngineID"
+column = "AdvEngineID"
+type = "i64"
+
+[[attribute]]
+key = "IsArtifical"
+column = "IsArtifical"
+type = "i64"
+
+[[attribute]]
+key = "WindowClientWidth"
+column = "WindowClientWidth"
+type = "i64"
+
+[[attribute]]
+key = "WindowClientHeight"
+column = "WindowClientHeight"
+type = "i64"
+
+[[attribute]]
+key = "ClientTimeZone"
+column = "ClientTimeZone"
+type = "i64"
+
+[[attribute]]
+key = "ClientEventTime"
+column = "ClientEventTime"
+type = "i64"
+
+[[attribute]]
+key = "SilverlightVersion1"
+column = "SilverlightVersion1"
+type = "i64"
+
+[[attribute]]
+key = "SilverlightVersion2"
+column = "SilverlightVersion2"
+type = "i64"
+
+[[attribute]]
+key = "SilverlightVersion3"
+column = "SilverlightVersion3"
+type = "i64"
+
+[[attribute]]
+key = "SilverlightVersion4"
+column = "SilverlightVersion4"
+type = "i64"
+
+[[attribute]]
+key = "PageCharset"
+column = "PageCharset"
+type = "str"
+
+[[attribute]]
+key = "CodeVersion"
+column = "CodeVersion"
+type = "i64"
+
+[[attribute]]
+key = "IsLink"
+column = "IsLink"
+type = "i64"
+
+[[attribute]]
+key = "IsDownload"
+column = "IsDownload"
+type = "i64"
+
+[[attribute]]
+key = "IsNotBounce"
+column = "IsNotBounce"
+type = "i64"
+
+[[attribute]]
+key = "FUniqID"
+column = "FUniqID"
+type = "i64"
+
+[[attribute]]
+key = "OriginalURL"
+column = "OriginalURL"
+type = "str"
+
+[[attribute]]
+key = "HID"
+column = "HID"
+type = "i64"
+
+[[attribute]]
+key = "IsOldCounter"
+column = "IsOldCounter"
+type = "i64"
+
+[[attribute]]
+key = "IsEvent"
+column = "IsEvent"
+type = "i64"
+
+[[attribute]]
+key = "IsParameter"
+column = "IsParameter"
+type = "i64"
+
+[[attribute]]
+key = "DontCountHits"
+column = "DontCountHits"
+type = "i64"
+
+[[attribute]]
+key = "WithHash"
+column = "WithHash"
+type = "i64"
+
+[[attribute]]
+key = "HitColor"
+column = "HitColor"
+type = "str"
+
+[[attribute]]
+key = "LocalEventTime"
+column = "LocalEventTime"
+type = "i64"
+
+[[attribute]]
+key = "Age"
+column = "Age"
+type = "i64"
+
+[[attribute]]
+key = "Sex"
+column = "Sex"
+type = "i64"
+
+[[attribute]]
+key = "Income"
+column = "Income"
+type = "i64"
+
+[[attribute]]
+key = "Interests"
+column = "Interests"
+type = "i64"
+
+[[attribute]]
+key = "Robotness"
+column = "Robotness"
+type = "i64"
+
+[[attribute]]
+key = "RemoteIP"
+column = "RemoteIP"
+type = "i64"
+
+[[attribute]]
+key = "WindowName"
+column = "WindowName"
+type = "i64"
+
+[[attribute]]
+key = "OpenerName"
+column = "OpenerName"
+type = "i64"
+
+[[attribute]]
+key = "HistoryLength"
+column = "HistoryLength"
+type = "i64"
+
+[[attribute]]
+key = "BrowserLanguage"
+column = "BrowserLanguage"
+type = "str"
+
+[[attribute]]
+key = "BrowserCountry"
+column = "BrowserCountry"
+type = "str"
+
+[[attribute]]
+key = "SocialNetwork"
+column = "SocialNetwork"
+type = "str"
+
+[[attribute]]
+key = "SocialAction"
+column = "SocialAction"
+type = "str"
+
+[[attribute]]
+key = "HTTPError"
+column = "HTTPError"
+type = "i64"
+
+[[attribute]]
+key = "SendTiming"
+column = "SendTiming"
+type = "i64"
+
+[[attribute]]
+key = "DNSTiming"
+column = "DNSTiming"
+type = "i64"
+
+[[attribute]]
+key = "ConnectTiming"
+column = "ConnectTiming"
+type = "i64"
+
+[[attribute]]
+key = "ResponseStartTiming"
+column = "ResponseStartTiming"
+type = "i64"
+
+[[attribute]]
+key = "ResponseEndTiming"
+column = "ResponseEndTiming"
+type = "i64"
+
+[[attribute]]
+key = "FetchTiming"
+column = "FetchTiming"
+type = "i64"
+
+[[attribute]]
+key = "SocialSourceNetworkID"
+column = "SocialSourceNetworkID"
+type = "i64"
+
+[[attribute]]
+key = "SocialSourcePage"
+column = "SocialSourcePage"
+type = "str"
+
+[[attribute]]
+key = "ParamPrice"
+column = "ParamPrice"
+type = "i64"
+
+[[attribute]]
+key = "ParamOrderID"
+column = "ParamOrderID"
+type = "str"
+
+[[attribute]]
+key = "ParamCurrency"
+column = "ParamCurrency"
+type = "str"
+
+[[attribute]]
+key = "ParamCurrencyID"
+column = "ParamCurrencyID"
+type = "i64"
+
+[[attribute]]
+key = "OpenstatServiceName"
+column = "OpenstatServiceName"
+type = "str"
+
+[[attribute]]
+key = "OpenstatCampaignID"
+column = "OpenstatCampaignID"
+type = "str"
+
+[[attribute]]
+key = "OpenstatAdID"
+column = "OpenstatAdID"
+type = "str"
+
+[[attribute]]
+key = "OpenstatSourceID"
+column = "OpenstatSourceID"
+type = "str"
+
+[[attribute]]
+key = "UTMSource"
+column = "UTMSource"
+type = "str"
+
+[[attribute]]
+key = "UTMMedium"
+column = "UTMMedium"
+type = "str"
+
+[[attribute]]
+key = "UTMCampaign"
+column = "UTMCampaign"
+type = "str"
+
+[[attribute]]
+key = "UTMContent"
+column = "UTMContent"
+type = "str"
+
+[[attribute]]
+key = "UTMTerm"
+column = "UTMTerm"
+type = "str"
+
+[[attribute]]
+key = "FromTag"
+column = "FromTag"
+type = "str"
+
+[[attribute]]
+key = "HasGCLID"
+column = "HasGCLID"
+type = "i64"
+
+[[attribute]]
+key = "RefererHash"
+column = "RefererHash"
+type = "i64"
+
+[[attribute]]
+key = "URLHash"
+column = "URLHash"
+type = "i64"
+
+[[attribute]]
+key = "CLID"
+column = "CLID"
+type = "i64"

--- a/crates/ravel-bench/Cargo.toml
+++ b/crates/ravel-bench/Cargo.toml
@@ -279,6 +279,14 @@ path = "tests/sql_latency_smoke.rs"
 required-features = ["sql-latency"]
 bench = false
 
+# Gate test for the checked-in ClickBench corpus (issue #430). It reads
+# `ravel_bench::sql_corpus`, so it lives behind the same `sql-latency` feature.
+[[test]]
+name = "clickbench_corpus"
+path = "tests/clickbench_corpus.rs"
+required-features = ["sql-latency"]
+bench = false
+
 [[test]]
 name = "distrib_crossover_smoke"
 path = "tests/distrib_crossover_smoke.rs"

--- a/crates/ravel-bench/tests/clickbench_corpus.rs
+++ b/crates/ravel-bench/tests/clickbench_corpus.rs
@@ -1,0 +1,124 @@
+//! Gate test for the checked-in ClickBench `hits` corpus (issue #430,
+//! ADR-0100 decision 3), at `benchmarks/clickbench/hits.corpus.json`.
+//!
+//! It asserts two things that together stop the corpus rotting:
+//!
+//! 1. The corpus FILE parses and passes the construct gate. `load_external_corpus`
+//!    parses the document and runs the same gate the harness runs before the
+//!    first query, so an unsupported construct, a duplicate id, an empty
+//!    modification reason, or a malformed document is a loud typed error naming
+//!    the fault -- not a silently skipped entry.
+//! 2. Every one of ClickBench's 43 upstream statements (queries.sql, Q1..Q43) is
+//!    accounted for: present in the corpus, or listed in [`KNOWN_GAPS`] with the
+//!    single unsupported construct that keeps it out. A statement dropped without
+//!    a gap entry fails the accounting; a gap claimed for a construct that is
+//!    actually supported fails the last test.
+//!
+//! The gap list here mirrors the runbook (`docs/guides/clickbench.md`) and the
+//! capability issues it references; this test is what keeps the two honest.
+#![cfg(feature = "sql-latency")]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+
+use ravel_bench::sql_corpus::{load_external_corpus, supported_construct_names};
+
+/// The checked-in corpus, relative to this crate's manifest dir
+/// (`crates/ravel-bench`) up to the repo root.
+fn corpus_path() -> PathBuf {
+    PathBuf::from(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../benchmarks/clickbench/hits.corpus.json"
+    ))
+}
+
+/// ClickBench maintains 43 statements upstream (queries.sql, Q1..Q43).
+const UPSTREAM_COUNT: usize = 43;
+
+/// The ClickBench statements the corpus construct-gate cannot admit, each paired
+/// with the single construct that blocks it. One row per rejected statement; the
+/// distinct missing capabilities are two (`LIKE` pattern matching, and `length`
+/// not being enumerated as a named construct in the conformance registry) -- see
+/// the runbook's gap list and the issues it references.
+///
+/// Each named construct MUST be absent from [`supported_construct_names`]
+/// (asserted by [`each_known_gap_names_a_genuinely_unsupported_construct`]): a
+/// gap cannot be claimed for a construct that is actually supported, and if a
+/// construct here later becomes supported this test fails, which is the signal to
+/// move that statement into the corpus file.
+const KNOWN_GAPS: &[(&str, &str)] = &[
+    ("Q21", "LIKE pattern match"),
+    ("Q22", "LIKE pattern match"),
+    ("Q23", "LIKE pattern match"),
+    ("Q24", "LIKE pattern match"),
+    ("Q28", "length"),
+    ("Q29", "length"),
+];
+
+#[test]
+fn checked_in_clickbench_corpus_parses_and_passes_the_construct_gate() {
+    let entries = load_external_corpus(corpus_path())
+        .expect("checked-in ClickBench corpus parses and passes the construct gate");
+    assert!(!entries.is_empty(), "corpus is empty");
+    for e in &entries {
+        assert!(
+            e.upstream_id.is_some(),
+            "corpus entry `{}` has no upstream_id; every ClickBench statement must carry \
+             the id it is diffed against",
+            e.id
+        );
+        // A modified statement without a reason is already refused by the gate;
+        // this makes the disclosure obligation explicit at the corpus boundary.
+        if e.modified.is_modified() {
+            assert!(
+                e.modified.reason().is_some_and(|r| !r.trim().is_empty()),
+                "corpus entry `{}` is modified but states no reason",
+                e.id
+            );
+        }
+    }
+}
+
+#[test]
+fn every_clickbench_statement_is_run_or_a_named_gap() {
+    let entries = load_external_corpus(corpus_path()).expect("corpus loads");
+
+    let mut accounted: BTreeSet<String> = BTreeSet::new();
+    for e in &entries {
+        let up = e
+            .upstream_id
+            .clone()
+            .expect("every entry carries an upstream_id");
+        assert!(
+            accounted.insert(up.clone()),
+            "upstream id `{up}` appears twice across the corpus"
+        );
+    }
+    for (up, _) in KNOWN_GAPS {
+        assert!(
+            accounted.insert((*up).to_string()),
+            "upstream id `{up}` is both in the corpus and listed as a known gap"
+        );
+    }
+
+    let expected: BTreeSet<String> = (1..=UPSTREAM_COUNT).map(|i| format!("Q{i}")).collect();
+    assert_eq!(
+        accounted, expected,
+        "every ClickBench statement Q1..Q{UPSTREAM_COUNT} must be either in the corpus or a \
+         named gap: neither silently absent nor invented"
+    );
+}
+
+#[test]
+fn each_known_gap_names_a_genuinely_unsupported_construct() {
+    let supported = supported_construct_names();
+    for (up, construct) in KNOWN_GAPS {
+        assert!(
+            !supported.contains(*construct),
+            "known gap {up} names construct `{construct}`, but the conformance registry \
+             classifies it as supported; if it is now supported, move {up} into the corpus \
+             file instead of listing it as a gap"
+        );
+    }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -87,6 +87,11 @@ Start here to run Ravel, ingest into it, or query it.
   loop (`cargo check` while you edit, the full gate list before you commit) and
   how CI shares build work across jobs with sccache and nextest. Read this
   to change Ravel's code.
+- [guides/clickbench.md](guides/clickbench.md): running the public ClickBench
+  `hits` workload against Ravel -- fetching the dataset, loading it, declaring
+  the typed columns from the checked-in mapping, and measuring with
+  `sql_latency_bench`, plus the gap list of statements the construct gate
+  rejects. Read this to reproduce or extend the ClickBench numbers.
 - [guides/coderabbit-runbook.md](guides/coderabbit-runbook.md): enabling,
   verifying, operating, rotating, and removing the maintainer-gated CodeRabbit
   integration (ADR-0091), including the controls that live in GitHub and

--- a/docs/guides/clickbench.md
+++ b/docs/guides/clickbench.md
@@ -1,0 +1,232 @@
+# Running ClickBench against Ravel
+
+ClickBench is an external, public analytical benchmark: a flat 105-column,
+~100M-row `hits` table and a fixed suite of 43 statements, reported as the
+minimum / median / maximum of three consecutive runs per query alongside the
+load time and the stored size (ADR-0100). This guide makes that workload
+runnable and repeatable against Ravel. It never fetches the dataset for you and
+never reports a number: it is the procedure, not a measurement.
+
+The checked-in artifacts live under `benchmarks/clickbench/`:
+
+| File | What it is |
+|---|---|
+| `hits.mapping.toml` | the `--mapping` for `ravel-cli load` and `typed-attr-column set` |
+| `hits.corpus.json` | the ClickBench suite rewritten for Ravel's `logs` table, in `sql_corpus.rs`'s external-file format |
+
+The upstream suite is maintained at
+<https://github.com/ClickHouse/ClickBench>; `queries.sql` (Q1..Q43) and
+`postgresql/create.sql` are the sources the corpus and mapping were built from.
+Each corpus entry carries its upstream `Q<n>` id so it can be diffed against the
+original.
+
+## What this measures, and what it does not
+
+The millisecond figures the harness prints **do not reproduce across hosts**:
+they depend on CPU, memory, and — by an order of magnitude — on the object-store
+backend (local filesystem vs MinIO vs S3). Only **ratios within one run** are
+comparable: query A versus query B, cold versus warm, pre- versus
+post-compaction, one `--batch-rows` layout versus another. That is why every
+report carries its own provenance (backend, region/endpoint, host logical cores,
+dataset id, runs). A latency table without its backend named will mislead the
+first person who compares two runs.
+
+## 0. Prerequisites
+
+- An object store both `ravel-cli` and `sql_latency_bench` can reach. The bench
+  reads the `RAVEL_S3_*` env vars (`RAVEL_S3_BUCKET`, `RAVEL_S3_REGION`,
+  `RAVEL_S3_ENDPOINT`, `RAVEL_S3_ACCESS_KEY_ID`, `RAVEL_S3_SECRET_ACCESS_KEY`,
+  `RAVEL_S3_ALLOW_HTTP`, `RAVEL_S3_FORCE_PATH_STYLE`); point `ravel-cli` at the
+  same store with its global `--store` flag. A ~100M-row load needs durable
+  storage, so this is the `s3` backend (real S3 or MinIO), not `memory`.
+- The `sql-latency` cargo feature builds the harness; it is off by default.
+
+## 1. Fetch the dataset (you run this, not this guide)
+
+`hits.parquet` is on the order of tens of gigabytes. Do not fetch it on a small
+host. From the ClickBench repository:
+
+```sh
+# One partitioned file (recommended for loading in bounded memory):
+#   https://github.com/ClickHouse/ClickBench#data-loading
+# Single-file Parquet export:
+wget 'https://datasets.clickhouse.com/hits_compatible/hits.parquet'
+```
+
+Confirm how your copy encodes the datetime columns before loading. `EventTime`
+(the primary event-time column) is handled either way; the mapping's caveats for
+the secondary time columns are in `hits.mapping.toml` and in step 3 below.
+
+## 2. Load it
+
+```sh
+ravel-cli --store <your-store-flags> load \
+  --parquet /path/to/hits.parquet \
+  --tenant clickbench \
+  --mapping benchmarks/clickbench/hits.mapping.toml \
+  --shards 4 \
+  --batch-rows 10000
+```
+
+`--batch-rows` is the object-count lever. One batch is one Strict flush, which is
+one RLOG object per involved shard, so ~100M rows at the default `10000` leaves
+on the order of 10,000 flushes' worth of objects behind. Per-object cost (LIST,
+footer read, decode setup) is then paid thousands of times per query and can
+dominate everything the columnar and pushdown work saves, so object count is a
+first-class variable: raise `--batch-rows` for fewer, larger objects; lower it
+for the opposite. Measure both if you care where the time goes.
+
+The loader prints a completion summary to stdout — `rows processed`,
+`objects written`, and `elapsed` (the load wall-time ClickBench reports). It also
+prints a stderr warning if any object crossed, or came within 90% of, the
+per-object dynamic-column budget of 1000. The `hits` schema is 104 attribute
+columns (see step 3), far under that budget, so a clean load prints no such
+warning; one appearing means a per-object attribute set is wider than the schema
+suggests (stray per-record keys), which is worth investigating before trusting
+the numbers.
+
+## 3. Declare the typed columns
+
+The load writes the data; it does not tell the SQL layer which attributes to
+treat as typed columns. Derive that declaration from the same mapping:
+
+```sh
+ravel-cli --store <your-store-flags> typed-attr-column set clickbench \
+  --from-mapping benchmarks/clickbench/hits.mapping.toml
+```
+
+This writes ~104 declared columns (every `[[attribute]]` entry) through the
+config CAS path. Notes specific to `hits`:
+
+- **`EventTime` is not declared.** It is the mapping's `ts_column`, so it rides
+  the native typed `ts` path; range predicates over it need no declared column.
+  Corpus statements point `EventTime` references at `ts`.
+- **Secondary time columns are declared `i64`.** `EventDate`, `ClientEventTime`,
+  `LocalEventTime` get the full typed treatment (NumStat pruning, typed
+  comparison and pushdown), but as integers: `DeclaredType` has no date/time
+  variant. `EventDate` is stored in its native epoch-DAY unit, so a query filters
+  it against an epoch-day integer, not a `DATE` literal. The corpus flags those
+  statements `modified` with the conversion stated (see the gap/modification
+  notes below). `#432` tracks the date/time ergonomic gap.
+- **No column is skipped for `f64`.** `ColType::F64` attributes cannot be
+  declared (`DeclaredType` has no F64 variant; ADR-0101 / `#431`), so a float
+  column would be skipped here with a stderr warning and stay queryable only
+  through `attrs['<key>']`. The `hits` schema has **zero** float columns (77
+  integer/date/time, 28 text), so this affects nothing here.
+
+## 4. Wait out the declaration staleness horizon
+
+A declaration written by the CLI becomes visible to queries only after the
+server's declared-column cache staleness horizon. Do not query immediately after
+step 3, or the first queries will run against the old (empty) declaration and
+project NULL for every declared column. Wait past the horizon before measuring.
+(The `sql_latency_bench --tenant` lane reads the tenant's durable declaration
+directly, so it sees a freshly written declaration without the server cache in
+the path; the horizon still applies to anything querying through
+`ravel-server`.)
+
+## 5. Run the harness
+
+```sh
+cargo run -p ravel-bench --features sql-latency --bin sql_latency_bench -- \
+  --tenant clickbench \
+  --store s3 \
+  --corpus benchmarks/clickbench/hits.corpus.json \
+  --runs 3 \
+  --compaction pre \
+  --window-hours 200000
+```
+
+- `--tenant clickbench` measures the loaded tenant (not an in-process generated
+  dataset). It resolves the tenant's real durable declaration and **skips** any
+  statement whose required declared column is absent or the wrong type, rather
+  than running it and reporting a plausible-but-wrong latency.
+- `--corpus benchmarks/clickbench/hits.corpus.json` runs the checked-in
+  ClickBench suite instead of the default Ravel corpus. It is parse- and
+  construct-gated before the first query, exactly like the checked-in set.
+- `--runs 3` is ClickBench's convention: three runs, first flagged cold.
+- `--compaction pre|post` labels which layout you measured (freshly loaded, or
+  after the maintenance machinery compacted it). Both are legitimate; the delta
+  between them is itself a finding, so the report states which one it is.
+- `--window-hours` must reach back far enough to cover the data's event-time
+  span. ClickBench's `EventTime` values are from 2013, so widen the window well
+  past the default 24 hours (relative to `--now-secs`, default the wall clock),
+  or the catalog resolve will not see the segments.
+
+### How to read the report
+
+The bench prints the full report as JSON, then a human table. Per statement:
+
+- **min / median / max ms** over the `--runs` executions, and **cold ms** (the
+  first run, against a fresh `Catalog` + `SqlExecutor` per statement so it is
+  genuinely cold). Ratios only — see the reproducibility note above.
+- **rows returned.**
+- **scan diagnostics**, which say *where* the time went rather than only that it
+  was slow: `segments`, `blocks_total`, `blocks_scanned`,
+  `blocks_pruned_by_postings` (POSTINGS pruning selectivity), plus the cold run's
+  object-store GET/LIST request counts, bytes transferred, and fetch-cache
+  hits/misses/bytes.
+
+Dataset-level, independent of any one query:
+
+- **load wall-time**: `0` in the `--tenant` lane (the load ran out of process;
+  read its time from the `ravel-cli load` summary's `elapsed`), measured in the
+  `--generate` lane.
+- **stored bytes** and **object count**: summed over the resolved snapshot's
+  segments. Object count is the `--batch-rows` consequence from step 2 made
+  visible.
+- **rows** and the **pre-/post-compaction layout label**.
+
+Provenance (backend, region, endpoint, host logical cores, source, dataset id,
+runs) is recorded beside the numbers so two runs are comparable or provably not.
+
+## Gap list: ClickBench statements the construct gate rejects
+
+Running a 43-query suite against a supported-construct gate means some queries
+fail the gate rather than return a number. That is the intended outcome: an
+unsupported construct becomes a **named capability gap with a failing query
+attached**, not an omission from a results table. The checked-in corpus holds
+the **37** statements that pass the gate; the **6** below are recorded as known
+gaps (enforced by `crates/ravel-bench/tests/clickbench_corpus.rs`, which fails if
+any of the 43 is neither in the corpus nor listed as a gap).
+
+| Upstream | Blocking construct | Why | Issue |
+|---|---|---|---|
+| Q21 | `LIKE` pattern match | `WHERE URL LIKE '%google%'` | substring/pattern search |
+| Q22 | `LIKE` pattern match | `WHERE URL LIKE '%google%'` | substring/pattern search |
+| Q23 | `LIKE` pattern match | `LIKE '%Google%'` and `NOT LIKE '%.google.%'` | substring/pattern search |
+| Q24 | `LIKE` pattern match | `WHERE URL LIKE '%google%'` (also `SELECT *`) | substring/pattern search |
+| Q28 | `length` | `AVG(length(URL))` | scalar not enumerated in the conformance registry |
+| Q29 | `length` | `AVG(length(Referer))` | scalar not enumerated in the conformance registry |
+
+Two distinct capability gaps sit behind these six statements:
+
+1. **`LIKE` / SQL pattern matching** is not in Ravel's supported construct set.
+   Ravel offers token search (`has_word`) and `regexp_replace`, but no `LIKE`
+   with `%`/`_` wildcards, which four ClickBench statements depend on. This is a
+   genuine engine capability gap.
+2. **`length` is admitted by the SQL engine but not enumerated as a named
+   construct** in `ravel_sql::conformance::registry()`. The registry attests
+   scalar functions by family representative (`upper`, `regexp_replace`, ...),
+   not one row per function, so `length` — though it executes — cannot be named
+   by a corpus entry without failing the construct gate. This is an
+   attestation-coverage gap, not an executability gap: the fix is to enumerate
+   `length` (and peers) in the registry, after which Q28/Q29 move into the
+   corpus. See the "corpus format" note in the ADR-0100 epic.
+
+The issue bodies for both are filed with the epic (they could not be filed from
+the executor environment; see the task report).
+
+## Modified statements
+
+Any rewrite that changes what a statement *computes* is flagged `modified` in the
+corpus with a stated reason; pure renames (`hits`→`logs`, identifier quoting for
+`hits`'s CamelCase column names, `EventTime`→`ts`, and the `extract(minute FROM
+EventTime)`→`date_part('minute', ts)` spelling swap, which computes the same
+minute) are not. The flagged statements are exactly those touching the
+secondary time column `EventDate`: because it is declared `i64` in epoch-days,
+`DATE` range literals become epoch-day integers (e.g. `'2013-07-01'` → `15887`,
+`'2013-07-31'` → `15917`, `'2013-07-14'` → `15900`, `'2013-07-15'` → `15901`),
+and `MIN`/`MAX` over it return epoch-day integers rather than `DATE` values. This
+is the epoch-integer-comparison consequence ADR-0100 decision 3 requires be
+flagged. The affected statements are Q7 and Q37–Q43.


### PR DESCRIPTION
The last task of epic #421 (ADR-0100). Makes the ClickBench `hits` workload runnable against Ravel, checked in and repeatable. No crate code — a mapping, a corpus, a runbook, and a gate test.

- `benchmarks/clickbench/hits.mapping.toml` — the `--mapping` for the 105-column `hits` schema. `EventTime` is `ts_column`, so the primary event-time column rides the native typed `ts` path and needs no declared column.
- `benchmarks/clickbench/hits.corpus.json` — 37 statements in `sql_corpus`'s external-file format, each carrying its upstream query id.
- `docs/guides/clickbench.md` — the runbook, indexed in `docs/README.md`.
- `crates/ravel-bench/tests/clickbench_corpus.rs` — the gate test.

**All 43 statements are authentic, obtained from the upstream source rather than reproduced from memory.** The executor fetched `clickhouse/queries.sql` and `postgresql/create.sql` from the ClickBench repository directly. Nothing is invented. This mattered enough to be a hard constraint in the task: a corpus of plausible-looking SQL that is not actually ClickBench's would produce numbers we could not defend.

**37 of 43 run; 6 are recorded as known gaps across 2 distinct capabilities:**

| Upstream | Blocking construct |
|---|---|
| Q21, Q22, Q23, Q24 | `LIKE` / `NOT LIKE` pattern matching |
| Q28, Q29 | `length` — an admitted scalar, but not enumerated in the conformance registry |

Neither is an omission from a results table. Each is a named capability gap with a failing query attached, and each gets its own issue.

`f64` columns in `hits`: **zero**. The schema is 77 integer/date/time and 28 text columns, so ADR-0101's undeclarable-float gap (#431) does not touch this benchmark at all. The mapping keeps the note and states it affects 0 of 105 columns, because a future schema might.

**Epoch-integer date comparisons are flagged as modified queries**, consistently: Q7 (whose `MIN`/`MAX` now return epoch-day integers rather than dates) and Q37–Q43 (whose `DATE` range literals become epoch-day integers, e.g. `'2013-07-01'` → `15887`). That follows ADR-0100 decision 3's own rule, which anticipated exactly this case for secondary time columns declared `i64`. Pure renames are not modifications and stay verbatim: `hits` → `logs`, CamelCase identifier quoting, `EventTime` → `ts`.

The gate test enforces the property that keeps this honest: **all 43 = corpus ∪ gaps**. A statement cannot go silently missing, and a gap cannot be recorded for a construct that is actually supported. Three tests — the corpus parses and passes the construct gate, every statement is either run or a named gap, and each named gap really is unsupported.

Verified locally: all 3 gate tests pass, `cargo fmt --all --check` clean.

No performance numbers appear anywhere in this change, and none were produced. There is no dataset on a build host to measure, and the runbook says explicitly that millisecond figures do not reproduce across hosts — only within-run ratios are comparable, which is why the harness reports provenance.

Fixes: #430
