### PR TITLE
perf(sql): build logs scan batches from the columnar block view

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5110,6 +5110,7 @@ dependencies = [
  "async-trait",
  "blake3",
  "bytes",
+ "crc32c",
  "criterion",
  "datafusion",
  "futures",

--- a/crates/ravel-logseg/src/block.rs
+++ b/crates/ravel-logseg/src/block.rs
@@ -504,6 +504,43 @@ impl DecodedBlock {
     pub fn has_attrs_raw_page(&self) -> bool {
         self.attrs_raw_page
     }
+
+    /// The heap bytes this decoded block holds resident: every column vector's
+    /// allocation plus every present string and fixed-width cell's own buffer.
+    ///
+    /// A caller that keeps a block alive while it drains the block (the SQL
+    /// logs scan's columnar path, which holds a borrowed view) has to charge
+    /// its memory pool for this. The per-cell term is the reason the figure is
+    /// computed here rather than estimated from `record_count`: a byte-valued
+    /// column of `n` rows is `n` separate allocations plus the vector spine, so
+    /// counting spines alone understates a body or string-attribute column
+    /// several-fold.
+    ///
+    /// Capacity, not length, because capacity is what is allocated. The
+    /// per-kind `HashMap` spines are not counted: they hold one entry per
+    /// decoded column, bounded by the scan's column selection and negligible
+    /// against the cells.
+    pub fn decoded_heap_bytes(&self) -> usize {
+        let mut total = 0usize;
+        for v in self.i64_cols.values() {
+            total += v.capacity() * std::mem::size_of::<Option<i64>>();
+        }
+        for v in self.f64_cols.values() {
+            total += v.capacity() * std::mem::size_of::<Option<u64>>();
+        }
+        for v in self.bool_cols.values() {
+            total += v.capacity() * std::mem::size_of::<Option<bool>>();
+        }
+        for cols in [&self.str_cols, &self.fixed_cols] {
+            for v in cols.values() {
+                total += v.capacity() * std::mem::size_of::<Option<Vec<u8>>>();
+                for cell in v.iter().flatten() {
+                    total += cell.capacity();
+                }
+            }
+        }
+        total
+    }
     pub fn i64_col(&self, column_id: u32) -> Option<&[Option<i64>]> {
         self.i64_cols.get(&column_id).map(Vec::as_slice)
     }

--- a/crates/ravel-logseg/src/columnar.rs
+++ b/crates/ravel-logseg/src/columnar.rs
@@ -129,6 +129,25 @@ impl<'a> ColumnarBlockView<'a> {
         self.block.has_attrs_raw_page()
     }
 
+    /// The heap bytes the decoded block behind this view holds resident: every
+    /// decoded column vector plus every present string and fixed-width cell's
+    /// own allocation.
+    ///
+    /// This view borrows the block, and the block stays resident for as long as
+    /// the view (and anything built from it while the cursor has not moved on)
+    /// is alive. A caller charging a memory pool for what it concurrently holds
+    /// therefore has to charge this in addition to whatever it builds
+    /// (ADR-0087 decision 2). It is an accessor like every other method here:
+    /// it reports a size, and exposes neither the block nor any column's
+    /// storage type, so ADR-0099 decision 4 can change how string columns are
+    /// stored without touching a caller.
+    ///
+    /// The figure covers the whole block, not only the surviving rows: a
+    /// content predicate that drops rows does not shrink the decoded columns.
+    pub fn decoded_bytes(&self) -> usize {
+        self.block.decoded_heap_bytes()
+    }
+
     // --- fixed columns ------------------------------------------------------
 
     /// Event timestamp of surviving row `i`.

--- a/crates/ravel-logseg/src/reader.rs
+++ b/crates/ravel-logseg/src/reader.rs
@@ -3442,4 +3442,59 @@ mod tests {
                 .is_some()
         );
     }
+
+    /// `ColumnarBlockView::decoded_bytes` reports the block's real resident
+    /// footprint: it counts every string cell's own allocation, not just the
+    /// column spines, and it tracks what the column selection actually decoded.
+    ///
+    /// The bodies are 4 KiB each, so the per-cell term (8 x 4096 = 32768 bytes)
+    /// dwarfs the spines a `record_count`-based estimate would see. A figure
+    /// that counted spines only would land under the cell total and fail the
+    /// first assertion; a figure that ignored the column filter would fail the
+    /// last two.
+    #[test]
+    fn decoded_bytes_counts_cells_and_follows_the_column_selection() {
+        const ROWS: i64 = 8;
+        const BODY: usize = 4096;
+        let cfg = RlogConfig {
+            block_target_records: 64,
+            ..RlogConfig::default()
+        };
+        let body = "b".repeat(BODY);
+        let recs: Vec<LogRecord> = (0..ROWS)
+            .map(|i| rec_attrs(0, i, &body, Vec::new()))
+            .collect();
+        let obj = build(cfg.clone(), recs);
+        let pred = Predicate::And(Vec::new());
+        let reader = RlogReader::new(&obj, &cfg).expect("open");
+
+        let bytes_with = |sel: &ColumnSelection| -> usize {
+            let mut cursor = reader.scan_blocks(&pred, &[], sel).expect("open cursor");
+            let view = cursor
+                .next_block_columnar(&obj)
+                .expect("columnar exit")
+                .expect("one block");
+            assert_eq!(view.surviving_count(), ROWS as usize);
+            view.decoded_bytes()
+        };
+
+        let with_body = bytes_with(&ColumnSelection::fixed_only().with_body());
+        let cells = ROWS as usize * BODY;
+        assert!(
+            with_body > cells,
+            "the body column's cells alone are {cells} bytes; got {with_body}"
+        );
+
+        let fixed_only = bytes_with(&ColumnSelection::fixed_only());
+        assert!(
+            fixed_only < cells,
+            "a decode that skipped the body column must not carry its \
+             {cells} bytes of cells; got {fixed_only}"
+        );
+        assert!(
+            with_body - fixed_only >= cells,
+            "adding the body column must add at least its cells \
+             ({cells}); with_body={with_body}, fixed_only={fixed_only}"
+        );
+    }
 }

--- a/crates/ravel-logseg/src/reader.rs
+++ b/crates/ravel-logseg/src/reader.rs
@@ -3464,7 +3464,7 @@ mod tests {
         let recs: Vec<LogRecord> = (0..ROWS)
             .map(|i| rec_attrs(0, i, &body, Vec::new()))
             .collect();
-        let obj = build(cfg.clone(), recs);
+        let obj = build(cfg, recs);
         let pred = Predicate::And(Vec::new());
         let reader = RlogReader::new(&obj, &cfg).expect("open");
 

--- a/crates/ravel-sql/Cargo.toml
+++ b/crates/ravel-sql/Cargo.toml
@@ -188,6 +188,11 @@ criterion = { workspace = true }
 # dependency that owns the `unsafe impl GlobalAlloc` itself; this is the same
 # version and pattern crates/ravel-otap/benches/decode.rs uses.
 stats_alloc = "0.1.10"
+# Dev-only: tests/logs_columnar.rs assembles one RLOG object the writer cannot
+# produce (a declared `Str` column cell that is not UTF-8) by rebuilding two of
+# the writer's sections around ravel-logseg's own encoders, which means stamping
+# the section table's checksums. Same workspace pin ravel-logseg itself uses.
+crc32c = { workspace = true }
 
 [[bench]]
 name = "samples_scan"

--- a/crates/ravel-sql/Cargo.toml
+++ b/crates/ravel-sql/Cargo.toml
@@ -178,8 +178,8 @@ ravel-proto = { workspace = true }
 # Already a workspace pin used elsewhere (ravel-query depends on it);
 # ravel-sql's non-test code has no need for it.
 ravel-cache = { workspace = true }
-# Dev-only: the metrics-scan batch-building bench (benches/samples_scan.rs,
-# ADR-0099 decision 7).
+# Dev-only: the batch-building benches (benches/samples_scan.rs and
+# benches/logs_scan.rs, ADR-0099 decision 7).
 criterion = { workspace = true }
 # Dev-only: the allocation upper bound for batch building
 # (tests/scan_batch_allocations.rs) installs stats_alloc's instrumented global
@@ -191,4 +191,8 @@ stats_alloc = "0.1.10"
 
 [[bench]]
 name = "samples_scan"
+harness = false
+
+[[bench]]
+name = "logs_scan"
 harness = false

--- a/crates/ravel-sql/benches/logs_scan.rs
+++ b/crates/ravel-sql/benches/logs_scan.rs
@@ -1,0 +1,193 @@
+//! Logs SQL scan batch-building throughput (ADR-0099 decision 7, issue #415).
+//!
+//! Both benchmarks drain [`ravel_sql::LogsScanExec`] itself over one RLOG object
+//! held in a `MemoryStore`, so what they time is fetch/decode plus the
+//! per-block batch construction this ADR added, with no object-store latency in
+//! the way. The two fixtures are the *same corpus*; they differ only in the
+//! projection, which is what decides the batch-building path:
+//!
+//! - `fast_path_fixed_columns` projects only fixed columns (`ts`, `body`), so
+//!   the scan is columnar-eligible and every spill-free block is turned into an
+//!   Arrow batch straight from the `ColumnarBlockView`, with no `LogRecord` and
+//!   no `merged_attrs`;
+//! - `row_path_attrs_map` projects the merged `attrs` map, which makes the query
+//!   ineligible ([`columnar_static_eligible`] rejects any `attrs` reference), so
+//!   the unchanged row path rebuilds a `LogRecord` per row and merges its
+//!   attributes.
+//!
+//! Reporting both over one corpus makes the comparison like-for-like: the only
+//! variable is the path, so the throughput gap is the path's, not the fixture's.
+//! Throughput is reported in records per second (`Throughput::Elements`).
+//! Allocation counting lives in `tests/logs_scan_allocations.rs`, which needs a
+//! one-test binary to keep the count deterministic.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::sync::Arc;
+
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use datafusion::execution::TaskContext;
+use datafusion::physical_plan::ExecutionPlan;
+use futures::StreamExt;
+use ravel_catalog::{SegmentLevel, SegmentRef};
+use ravel_logseg::writer::ObjectIdentity;
+use ravel_logseg::{AttrValue, LogRecord, RlogConfig, RlogWriter, stream_attrs_bytes};
+use ravel_object_store::memory::MemoryStore;
+use ravel_object_store::{ObjectStoreBackend, PutOptions};
+use ravel_query::LogSegmentFetcher;
+use ravel_sql::{LOG_COL_ATTRS, LogsScanExec, logs_schema_with_declared};
+use ravel_types::TenantHash;
+use ravel_types::accounting::QueryAccounting;
+use ravel_types::logstream::log_stream_id;
+use uuid::Uuid;
+
+const TENANT: TenantHash = TenantHash([7u8; 16]);
+/// Records written into the one RLOG object. With the default block target
+/// (8192 records) this is several full blocks, so both paths run their per-block
+/// loop rather than a single block.
+const RECORDS: usize = 40_000;
+
+const WORD_VOCAB: &[&str] = &["timeout", "connection", "error", "ok", "retry"];
+
+fn identity() -> ObjectIdentity {
+    ObjectIdentity {
+        tenant_hash: TENANT.0,
+        shard: 0,
+        writer_id: [2u8; 16],
+        writer_epoch: 1,
+        writer_seq: 1,
+    }
+}
+
+/// One record. Carries a resource attribute and one dynamic attribute so the
+/// row path's `merged_attrs` has real work to do, matching a realistic `attrs`
+/// projection; the fast path never touches either.
+fn record(i: usize) -> LogRecord {
+    let resource = vec![(
+        "service.name".to_string(),
+        AttrValue::Str(format!("svc-{}", i % 8)),
+    )];
+    LogRecord {
+        stream_id: log_stream_id(&resource, "scope", "1.0", &[]),
+        stream_attrs: stream_attrs_bytes(&resource, "scope", "1.0", &[]),
+        ts_ns: i as i64,
+        observed_ts_ns: i as i64,
+        severity_num: (i % 24) as u8,
+        severity_text: "INFO".to_string(),
+        body: format!(
+            "{} {}",
+            WORD_VOCAB[i % WORD_VOCAB.len()],
+            WORD_VOCAB[(i + 2) % WORD_VOCAB.len()]
+        ),
+        trace_id: Some([(i % 251) as u8; 16]),
+        span_id: Some([(i % 251) as u8; 8]),
+        flags: i as u32,
+        attrs: vec![("user_id".to_string(), AttrValue::Str(format!("u{i}")))],
+    }
+}
+
+/// Write `RECORDS` records into one RLOG object and return its `SegmentRef`.
+async fn build() -> (Arc<dyn ObjectStoreBackend>, Vec<SegmentRef>) {
+    let store = MemoryStore::new();
+    let mut w = RlogWriter::new(RlogConfig::default(), identity());
+    let mut min = i64::MAX;
+    let mut max = i64::MIN;
+    for i in 0..RECORDS {
+        let r = record(i);
+        min = min.min(r.ts_ns);
+        max = max.max(r.ts_ns);
+        w.push(r).expect("push");
+    }
+    let bytes = w.finish().expect("finish");
+    let size = bytes.len() as u64;
+    let key = "logs/bench.rlog";
+    store
+        .put(key, bytes::Bytes::from(bytes), PutOptions::default())
+        .await
+        .expect("put");
+    let seg = SegmentRef {
+        data_object_key: key.to_string(),
+        object_size: size,
+        min_event_ts_ns: min,
+        max_event_ts_ns: max,
+        ingest_hour_bucket: 0,
+        sample_count: RECORDS as u64,
+        series_count: 0,
+        shard: 0,
+        content_hash: [0u8; 32],
+        writer_id: Uuid::from_u128(1),
+        writer_epoch: 1,
+        writer_seq: 1,
+        created_unix_ns: 0,
+        level: SegmentLevel::L0,
+    };
+    (Arc::new(store), vec![seg])
+}
+
+/// Drain a `LogsScanExec` over `segments` with `projection`, returning the rows
+/// it emitted.
+async fn drain(
+    store: Arc<dyn ObjectStoreBackend>,
+    segments: &[SegmentRef],
+    projection: Vec<usize>,
+) -> usize {
+    let scan = LogsScanExec::new(
+        TENANT,
+        LogSegmentFetcher::new(store),
+        segments,
+        1,
+        i64::MIN,
+        i64::MAX,
+        Arc::new(Vec::new()),
+        Arc::new(Vec::new()),
+        Arc::new(Vec::new()),
+        Some(&projection),
+        QueryAccounting::new(),
+        logs_schema_with_declared(&[]),
+        Arc::new(Vec::new()),
+    )
+    .expect("build scan");
+    let mut stream = scan
+        .execute(0, Arc::new(TaskContext::default()))
+        .expect("execute scan");
+    let mut rows = 0;
+    while let Some(next) = stream.next().await {
+        rows += next.expect("batch").num_rows();
+    }
+    rows
+}
+
+fn bench_scan(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+
+    let (store, segments) = rt.block_on(build());
+
+    // ts, body: fixed columns only, so the scan takes the columnar fast path.
+    let fast = vec![0usize, 4];
+    // ts, body, attrs: the merged map makes the query columnar-ineligible, so
+    // the same corpus drains the row path.
+    let row = vec![0usize, 4, LOG_COL_ATTRS];
+
+    for (name, projection) in [
+        ("fast_path_fixed_columns", fast),
+        ("row_path_attrs_map", row),
+    ] {
+        let rows = rt.block_on(drain(Arc::clone(&store), &segments, projection.clone()));
+
+        let mut group = c.benchmark_group("logs_scan");
+        group.throughput(Throughput::Elements(rows as u64));
+        group.bench_function(name, |b| {
+            b.iter(|| {
+                let emitted = rt.block_on(drain(Arc::clone(&store), &segments, projection.clone()));
+                std::hint::black_box(emitted);
+            });
+        });
+        group.finish();
+    }
+}
+
+criterion_group!(benches, bench_scan);
+criterion_main!(benches);

--- a/crates/ravel-sql/benches/logs_scan.rs
+++ b/crates/ravel-sql/benches/logs_scan.rs
@@ -1,22 +1,30 @@
 //! Logs SQL scan batch-building throughput (ADR-0099 decision 7, issue #415).
 //!
-//! Both benchmarks drain [`ravel_sql::LogsScanExec`] itself over one RLOG object
-//! held in a `MemoryStore`, so what they time is fetch/decode plus the
+//! All three benchmarks drain [`ravel_sql::LogsScanExec`] itself over one RLOG
+//! object held in a `MemoryStore`, so what they time is fetch/decode plus the
 //! per-block batch construction this ADR added, with no object-store latency in
-//! the way. The two fixtures are the *same corpus*; they differ only in the
-//! projection, which is what decides the batch-building path:
+//! the way. They run over the *same corpus*:
 //!
-//! - `fast_path_fixed_columns` projects only fixed columns (`ts`, `body`), so
-//!   the scan is columnar-eligible and every spill-free block is turned into an
-//!   Arrow batch straight from the `ColumnarBlockView`, with no `LogRecord` and
-//!   no `merged_attrs`;
-//! - `row_path_attrs_map` projects the merged `attrs` map, which makes the query
-//!   ineligible ([`columnar_static_eligible`] rejects any `attrs` reference), so
-//!   the unchanged row path rebuilds a `LogRecord` per row and merges its
-//!   attributes.
+//! - `fast_path_fixed_columns` projects `ts, body`, so the scan is
+//!   columnar-eligible and every spill-free block is turned into an Arrow batch
+//!   straight from the `ColumnarBlockView`, with no `LogRecord` and no
+//!   `merged_attrs`;
+//! - `row_path_same_projection` projects **the identical `ts, body`** and is
+//!   forced onto the row path by a pending erasure predicate that matches no
+//!   record (any pending erasure makes a scan ineligible, ADR-0099 decision 2).
+//!   This is the like-for-like pair: same corpus, same output columns, so the
+//!   gap is the batch-building path's. Its one caveat is the forcing mechanism
+//!   itself: an erasure-carrying scan also runs the fetcher's record filter and
+//!   `retain_unerased`, a `merged_attrs` pass per record, which no eligible query
+//!   pays. The gap this arm reports is therefore an upper bound on the path's own
+//!   share, not a pure measure of it.
+//! - `row_path_attrs_map` projects `ts, body, attrs`: the merged map makes the
+//!   query ineligible without any erasure, so this arm carries no filter cost but
+//!   does build a whole `Map(Utf8, Utf8)` column the other two do not. Reported
+//!   alongside so the two confounders stay separable instead of being conflated
+//!   into one "path" number: this arm minus the previous one is roughly what the
+//!   `attrs` column costs to materialize.
 //!
-//! Reporting both over one corpus makes the comparison like-for-like: the only
-//! variable is the path, so the throughput gap is the path's, not the fixture's.
 //! Throughput is reported in records per second (`Throughput::Elements`).
 //! Allocation counting lives in `tests/logs_scan_allocations.rs`, which needs a
 //! one-test binary to keep the count deterministic.
@@ -29,12 +37,13 @@ use criterion::{Criterion, Throughput, criterion_group, criterion_main};
 use datafusion::execution::TaskContext;
 use datafusion::physical_plan::ExecutionPlan;
 use futures::StreamExt;
-use ravel_catalog::{SegmentLevel, SegmentRef};
+use ravel_catalog::{SegmentLevel, SegmentRef, Snapshot};
 use ravel_logseg::writer::ObjectIdentity;
 use ravel_logseg::{AttrValue, LogRecord, RlogConfig, RlogWriter, stream_attrs_bytes};
 use ravel_object_store::memory::MemoryStore;
 use ravel_object_store::{ObjectStoreBackend, PutOptions};
 use ravel_query::LogSegmentFetcher;
+use ravel_query::erasure::{ErasurePredicate, snapshot_pending_erasure_predicates};
 use ravel_sql::{LOG_COL_ATTRS, LogsScanExec, logs_schema_with_declared};
 use ravel_types::TenantHash;
 use ravel_types::accounting::QueryAccounting;
@@ -124,12 +133,31 @@ async fn build() -> (Arc<dyn ObjectStoreBackend>, Vec<SegmentRef>) {
     (Arc::new(store), vec![seg])
 }
 
-/// Drain a `LogsScanExec` over `segments` with `projection`, returning the rows
-/// it emitted.
+/// A pending erasure whose key exists in no record of the corpus: it forces the
+/// row path (any pending erasure makes a scan columnar-ineligible) while erasing
+/// nothing, so the forced arm emits exactly what the fast arm does. Same
+/// technique as `tests/logs_columnar.rs`.
+fn no_match_erasure(segments: &[SegmentRef]) -> Vec<ErasurePredicate> {
+    snapshot_pending_erasure_predicates(&Snapshot {
+        segments: segments.to_vec(),
+        segments_pruned: 0,
+        pending_erasure: vec![ravel_proto::commit::v1::ErasureRequest {
+            predicate: vec![ravel_proto::commit::v1::ErasurePredicateMatcher {
+                key: "__does_not_exist__".to_string(),
+                value: "__nope__".to_string(),
+            }],
+            ..Default::default()
+        }],
+    })
+}
+
+/// Drain a `LogsScanExec` over `segments` with `projection` and `erasure`,
+/// returning the rows it emitted.
 async fn drain(
     store: Arc<dyn ObjectStoreBackend>,
     segments: &[SegmentRef],
     projection: Vec<usize>,
+    erasure: Vec<ErasurePredicate>,
 ) -> usize {
     let scan = LogsScanExec::new(
         TENANT,
@@ -140,7 +168,7 @@ async fn drain(
         i64::MAX,
         Arc::new(Vec::new()),
         Arc::new(Vec::new()),
-        Arc::new(Vec::new()),
+        Arc::new(erasure),
         Some(&projection),
         QueryAccounting::new(),
         logs_schema_with_declared(&[]),
@@ -166,22 +194,34 @@ fn bench_scan(c: &mut Criterion) {
     let (store, segments) = rt.block_on(build());
 
     // ts, body: fixed columns only, so the scan takes the columnar fast path.
-    let fast = vec![0usize, 4];
-    // ts, body, attrs: the merged map makes the query columnar-ineligible, so
-    // the same corpus drains the row path.
-    let row = vec![0usize, 4, LOG_COL_ATTRS];
+    let fixed = vec![0usize, 4];
+    // ts, body, attrs: the merged map makes the query columnar-ineligible
+    // without an erasure, at the price of one extra output column.
+    let with_attrs = vec![0usize, 4, LOG_COL_ATTRS];
+    let forced = no_match_erasure(&segments);
 
-    for (name, projection) in [
-        ("fast_path_fixed_columns", fast),
-        ("row_path_attrs_map", row),
+    for (name, projection, erasure) in [
+        ("fast_path_fixed_columns", fixed.clone(), Vec::new()),
+        ("row_path_same_projection", fixed, forced),
+        ("row_path_attrs_map", with_attrs, Vec::new()),
     ] {
-        let rows = rt.block_on(drain(Arc::clone(&store), &segments, projection.clone()));
+        let rows = rt.block_on(drain(
+            Arc::clone(&store),
+            &segments,
+            projection.clone(),
+            erasure.clone(),
+        ));
 
         let mut group = c.benchmark_group("logs_scan");
         group.throughput(Throughput::Elements(rows as u64));
         group.bench_function(name, |b| {
             b.iter(|| {
-                let emitted = rt.block_on(drain(Arc::clone(&store), &segments, projection.clone()));
+                let emitted = rt.block_on(drain(
+                    Arc::clone(&store),
+                    &segments,
+                    projection.clone(),
+                    erasure.clone(),
+                ));
                 std::hint::black_box(emitted);
             });
         });

--- a/crates/ravel-sql/src/lib.rs
+++ b/crates/ravel-sql/src/lib.rs
@@ -128,8 +128,9 @@ pub use logs_provider::LogsTableProvider;
 pub use logs_pushdown::{LogsPushdown, extract_logs};
 pub use logs_scan::LogsScanExec;
 pub use logs_schema::{
-    LOG_COL_ATTRS, LOG_COL_BODY, LOG_COL_FLAGS, LOG_COL_OBSERVED_TS, LOG_COL_SEVERITY_NUM,
-    LOG_COL_SEVERITY_TEXT, LOG_COL_SPAN_ID, LOG_COL_TRACE_ID, LOG_COL_TS, logs_schema,
+    FIRST_DECLARED_COL, LOG_COL_ATTRS, LOG_COL_BODY, LOG_COL_FLAGS, LOG_COL_OBSERVED_TS,
+    LOG_COL_SEVERITY_NUM, LOG_COL_SEVERITY_TEXT, LOG_COL_SPAN_ID, LOG_COL_TRACE_ID, LOG_COL_TS,
+    logs_schema, logs_schema_with_declared,
 };
 pub use logs_udf::{HAS_WORD_UDF, has_word_udf};
 pub use memory::{CeilingBreach, TenantDelegatingPool, TenantMemoryAccountant};

--- a/crates/ravel-sql/src/logs_scan.rs
+++ b/crates/ravel-sql/src/logs_scan.rs
@@ -1006,10 +1006,10 @@ impl Stream for LogScanStream {
                             // a later `attrs_raw` fallback skips exactly the
                             // blocks the columnar cursor advanced past.
                             this.seg_columnar_blocks += 1;
-                            if !batches.is_empty() {
-                                if let Err(e) = this.hold_batches(batches) {
-                                    return this.fail(e);
-                                }
+                            if !batches.is_empty()
+                                && let Err(e) = this.hold_batches(batches)
+                            {
+                                return this.fail(e);
                             }
                         }
                     }
@@ -1316,18 +1316,18 @@ fn resource_attrs<'c>(
     cache: &'c mut HashMap<u32, Arc<Vec<(String, AttrValue)>>>,
     stream_ref: u32,
 ) -> DFResult<&'c Arc<Vec<(String, AttrValue)>>> {
-    if !cache.contains_key(&stream_ref) {
-        let blob = view.stream_attrs_of(stream_ref).ok_or_else(|| {
-            DataFusionError::from(SqlError::CorruptStreamAttrs(
-                "columnar fast path: stream_ref has no STREAM_DIR entry".to_string(),
-            ))
-        })?;
-        let decoded = Arc::new(decode_stream_attrs(blob)?);
-        cache.insert(stream_ref, decoded);
+    match cache.entry(stream_ref) {
+        std::collections::hash_map::Entry::Occupied(e) => Ok(e.into_mut()),
+        std::collections::hash_map::Entry::Vacant(e) => {
+            let blob = view.stream_attrs_of(stream_ref).ok_or_else(|| {
+                DataFusionError::from(SqlError::CorruptStreamAttrs(
+                    "columnar fast path: stream_ref has no STREAM_DIR entry".to_string(),
+                ))
+            })?;
+            let decoded = Arc::new(decode_stream_attrs(blob)?);
+            Ok(e.insert(decoded))
+        }
     }
-    Ok(cache
-        .get(&stream_ref)
-        .expect("just inserted the stream_ref entry"))
 }
 
 /// The merged value of a declared key at surviving row `i`, under the same

--- a/crates/ravel-sql/src/logs_scan.rs
+++ b/crates/ravel-sql/src/logs_scan.rs
@@ -87,7 +87,7 @@
 //! the key to the record's value, which wins). The merged column and the
 //! residual are the whole correctness story.
 
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
@@ -114,9 +114,12 @@ use datafusion::physical_plan::{
 };
 use futures::Stream;
 use ravel_catalog::SegmentRef;
-use ravel_logseg::{ColumnSelection, FieldSel, LogRecord, Predicate, ScanStats};
+use ravel_logseg::{
+    AttrColumn, ColumnSelection, ColumnarBlockView, FieldSel, FieldType, LogRecord, Predicate,
+    ScanStats,
+};
 use ravel_query::erasure::ErasurePredicate;
-use ravel_query::{LogQuery, LogSegmentFetcher, LogSegmentScan};
+use ravel_query::{ColumnarBlockOutcome, LogQuery, LogSegmentFetcher, LogSegmentScan};
 use ravel_types::TenantHash;
 use ravel_types::accounting::QueryAccounting;
 use ravel_types::logstream::AttrValue;
@@ -128,7 +131,9 @@ use crate::logs_schema::{
     LOG_COL_SEVERITY_NUM, LOG_COL_SEVERITY_TEXT, LOG_COL_SPAN_ID, LOG_COL_TRACE_ID, LOG_COL_TS,
     SPAN_ID_WIDTH, TRACE_ID_WIDTH,
 };
-use crate::rlog_attrs::{attr_value_to_string, find_attr, merged_attrs, retain_unerased};
+use crate::rlog_attrs::{
+    attr_value_to_string, decode_stream_attrs, find_attr, merged_attrs, retain_unerased,
+};
 use ravel_logseg::record::canonical_value_bytes;
 
 /// Rows accumulated into one output batch before it is emitted.
@@ -275,6 +280,33 @@ fn content_columns(pred: &Predicate, sel: ColumnSelection) -> ColumnSelection {
     }
 }
 
+/// The query-shape half of the columnar fast-path eligibility rule (ADR-0099
+/// decision 2), decided once at plan time. The fast path is taken only when
+/// this AND the per-block `has_attrs_raw_page() == false` check both hold;
+/// otherwise the row path runs unchanged.
+///
+/// Two clauses live here because they do not vary per block:
+///
+/// - **(a) the projection touches only fixed and declared typed columns.** A
+///   reference to the merged `attrs` map ([`LOG_COL_ATTRS`]) makes the query
+///   ineligible: the map needs the stream-blob overlay the fast path exists to
+///   avoid. A declared typed column (index `>= FIRST_DECLARED_COL`) is fine --
+///   it resolves to a FIELD_DIR column the view reads directly.
+/// - **(c) no pending erasure predicate applies.** Erasure exclusion is
+///   record-level and has no columnar form yet, so a scan carrying one drains
+///   the row path. This clause fails closed on purpose: the failure mode of
+///   getting erasure wrong is an erased record served to a client, not a slow
+///   query. In practice this also falls out of handling
+///   [`ColumnarBlockOutcome::ErasurePending`], but it is asserted here as its
+///   own condition so the fast path is never even attempted under erasure.
+///
+/// Content predicates are deliberately absent: the reader evaluates them into
+/// the surviving-row set before the view is handed out, so the fast path never
+/// re-evaluates them and their shape cannot make it unsound.
+fn columnar_static_eligible(projection: &[usize], erasure: &[ErasurePredicate]) -> bool {
+    erasure.is_empty() && projection.iter().all(|&i| i != LOG_COL_ATTRS)
+}
+
 /// Log segment scan producing block-at-a-time batches over a projection of the
 /// public `logs` schema. Declares no ordering (ADR-0087 decision 1).
 pub struct LogsScanExec {
@@ -315,6 +347,12 @@ pub struct LogsScanExec {
     /// This scan's output schema: the resolved full schema
     /// (`logs_schema_with_declared(&declared)`) projected by `projection`.
     schema: SchemaRef,
+    /// Whether this scan may take the columnar fast path (ADR-0099 decision 2),
+    /// decided once from the query shape: the projection touches only fixed and
+    /// declared columns (no `attrs` map), and no pending erasure predicate
+    /// applies. The remaining per-block clause (no `attrs_raw` overflow page) is
+    /// checked as each block is decoded; see [`columnar_static_eligible`].
+    columnar_eligible: bool,
     properties: Arc<PlanProperties>,
     /// This query's accounting handle (ADR-0044), threaded into every
     /// per-partition fetch so log fetches are recorded like every other
@@ -344,6 +382,16 @@ struct BlockMetrics {
     /// post-decode filter: a query that touches two of a hundred attributes
     /// leaves this large and `pages_decoded` small.
     pages_skipped: Count,
+    /// Output batches this partition built through the columnar fast path
+    /// (ADR-0099 decisions 2-3), straight from a [`ColumnarBlockView`] with no
+    /// `LogRecord` and no `merged_attrs`. The output of the two paths is
+    /// identical by construction, so this and [`Self::rowpath_batches`] are the
+    /// only externally visible proof of which path a query took.
+    columnar_batches: Count,
+    /// Output batches this partition built through the row path: an ineligible
+    /// query (an `attrs` projection, a pending erasure predicate) or an
+    /// eligible one that hit a block carrying an `attrs_raw` overflow page.
+    rowpath_batches: Count,
 }
 
 impl BlockMetrics {
@@ -355,6 +403,8 @@ impl BlockMetrics {
                 .counter("blocks_pruned_by_postings", partition),
             pages_decoded: MetricBuilder::new(metrics).counter("pages_decoded", partition),
             pages_skipped: MetricBuilder::new(metrics).counter("pages_skipped", partition),
+            columnar_batches: MetricBuilder::new(metrics).counter("columnar_batches", partition),
+            rowpath_batches: MetricBuilder::new(metrics).counter("rowpath_batches", partition),
         }
     }
 
@@ -436,6 +486,7 @@ impl LogsScanExec {
         }
         let columns = resolve_columns(&projection, &content, &erasure, &declared);
         let schema: SchemaRef = Arc::new(full.project(&projection)?);
+        let columnar_eligible = columnar_static_eligible(&projection, &erasure);
         let properties = Arc::new(Self::compute_properties(&schema, n));
         Ok(LogsScanExec {
             tenant_hash,
@@ -450,6 +501,7 @@ impl LogsScanExec {
             columns,
             declared,
             schema,
+            columnar_eligible,
             properties,
             accounting,
             metrics: ExecutionPlanMetricsSet::new(),
@@ -563,13 +615,15 @@ impl ExecutionPlan for LogsScanExec {
                 accounting: self.accounting.clone(),
             }),
             erasure: Arc::clone(&self.erasure),
+            columnar_eligible: self.columnar_eligible,
             blocks: BlockMetrics::new(&self.metrics, partition),
             segments,
             reservation,
             held: 0,
             emitted: 0,
-            pending: Vec::new(),
-            pos: 0,
+            pending: Pending::None,
+            current_seg: None,
+            seg_columnar_blocks: 0,
             state: LogScanState::NextSegment,
         }))
     }
@@ -612,9 +666,45 @@ enum LogScanState {
     NextSegment,
     /// Awaiting one segment's GET and prune.
     Opening(OpenFuture),
-    /// Draining one segment's surviving blocks, one at a time.
-    Draining(Box<LogSegmentScan>),
+    /// Draining one segment's surviving blocks through the columnar fast path
+    /// (ADR-0099 decision 2). Entered only when the scan is statically eligible;
+    /// a block carrying an `attrs_raw` overflow page falls this segment back to
+    /// the row path via [`LogScanState::ReopenRows`].
+    Columnar(Box<LogSegmentScan>),
+    /// Draining one segment's surviving blocks through the row path
+    /// ([`LogSegmentScan::next_block`]), rebuilding a [`LogRecord`] per row: the
+    /// unchanged pre-ADR-0099 path, taken by an ineligible scan or by the
+    /// `attrs_raw` fallback. `skip` blocks are drained and discarded first, to
+    /// step past the blocks a fallback already emitted columnar before it hit
+    /// the overflow page (0 for an ineligible scan that never ran the fast path).
+    Rows {
+        scan: Box<LogSegmentScan>,
+        skip: usize,
+    },
+    /// Re-opening the current segment to restart it on the row path after a
+    /// block turned out to carry an `attrs_raw` overflow page. `skip` is the
+    /// number of blocks already emitted columnar for this segment, which the
+    /// re-opened row scan drains and discards so no row is emitted twice.
+    ReopenRows {
+        fut: OpenFuture,
+        skip: usize,
+    },
     Done,
+}
+
+/// The block currently being drained into output batches, and the form it is
+/// held in. The reservation charge tracked by [`LogScanStream::held`] covers
+/// whichever variant is live.
+enum Pending {
+    /// Nothing held.
+    None,
+    /// Row path: the block's surviving records, drained `BATCH_ROWS` at a time
+    /// from `pos`.
+    Rows { records: Vec<LogRecord>, pos: usize },
+    /// Columnar fast path: the block's already-built output batches, emitted one
+    /// per poll. Built whole from the [`ColumnarBlockView`] so the view (which
+    /// borrows the scan) is dropped before the next block is decoded.
+    Batches(VecDeque<RecordBatch>),
 }
 
 /// Per-partition record-batch stream (ADR-0087 decisions 1 and 2).
@@ -634,10 +724,15 @@ struct LogScanStream {
     /// Indices into the resolved full schema to emit, in output order.
     projection: Arc<Vec<usize>>,
     /// The tenant's declared typed attribute columns (ADR-0090), consulted by
-    /// [`build_batch`] for a projected declared index.
+    /// [`build_batch`] and [`build_columnar_batches`] for a projected declared
+    /// index.
     declared: Arc<Vec<DeclaredColumn>>,
     ctx: Arc<PartitionCtx>,
     erasure: Arc<Vec<ErasurePredicate>>,
+    /// Whether this scan may attempt the columnar fast path (the query-shape
+    /// clauses of [`columnar_static_eligible`]). When false, every segment
+    /// drains the row path.
+    columnar_eligible: bool,
     blocks: BlockMetrics,
     segments: VecDeque<SegmentRef>,
     reservation: MemoryReservation,
@@ -645,49 +740,105 @@ struct LogScanStream {
     held: usize,
     /// Reservation bytes currently covering the batch emitted last poll.
     emitted: usize,
-    /// The block being drained into batches.
-    pending: Vec<LogRecord>,
-    pos: usize,
+    /// The block being drained into batches, in row or columnar form.
+    pending: Pending,
+    /// The segment currently being drained, kept so the `attrs_raw` fallback can
+    /// re-open it on the row path. Set when a segment's open resolves.
+    current_seg: Option<SegmentRef>,
+    /// How many blocks of the current segment the columnar fast path has already
+    /// emitted. The `attrs_raw` fallback re-opens the segment and skips this many
+    /// blocks so none is emitted twice. Reset when a new segment starts draining.
+    seg_columnar_blocks: usize,
     state: LogScanState,
 }
 
 impl LogScanStream {
-    /// Build the next batch out of `pending`, moving the reservation with it:
-    /// the previous batch's charge is released (it is downstream's now), the new
-    /// batch's charge is taken before it is handed over.
-    fn emit_next_batch(&mut self) -> DFResult<RecordBatch> {
+    /// Emit the next row-path batch out of `pending`, moving the reservation
+    /// with it: the previous batch's charge is released (it is downstream's
+    /// now), the new batch's charge is taken before it is handed over.
+    fn emit_next_row_batch(&mut self) -> DFResult<RecordBatch> {
         self.reservation.shrink(std::mem::take(&mut self.emitted));
-        let end = (self.pos + BATCH_ROWS).min(self.pending.len());
+        let Pending::Rows { records, pos } = &mut self.pending else {
+            return Err(DataFusionError::Internal(
+                "emit_next_row_batch called without a row block held".into(),
+            ));
+        };
+        let end = (*pos + BATCH_ROWS).min(records.len());
         let batch = build_batch(
-            &self.pending[self.pos..end],
+            &records[*pos..end],
             Arc::clone(&self.schema),
             &self.projection,
             &self.declared,
         )?;
-        self.pos = end;
+        *pos = end;
         let bytes = batch.get_array_memory_size();
         self.reservation.try_grow(bytes)?;
         self.emitted = bytes;
+        self.blocks.rowpath_batches.add(1);
         Ok(batch)
     }
 
-    /// Take ownership of one decoded block, charging the pool for it before it
-    /// is held. An empty block (every row filtered out) charges nothing and
-    /// leaves the stream to ask for the next one.
+    /// Emit the next columnar-path batch: pop the front pre-built batch, relabel
+    /// its already-reserved bytes from `held` to `emitted`, and release the
+    /// batch handed out on the previous poll. No new reservation is taken -- the
+    /// whole block's batches were charged once in [`Self::hold_batches`].
+    fn emit_next_columnar_batch(&mut self) -> DFResult<RecordBatch> {
+        self.reservation.shrink(std::mem::take(&mut self.emitted));
+        let Pending::Batches(queue) = &mut self.pending else {
+            return Err(DataFusionError::Internal(
+                "emit_next_columnar_batch called without columnar batches held".into(),
+            ));
+        };
+        let Some(batch) = queue.pop_front() else {
+            return Err(DataFusionError::Internal(
+                "emit_next_columnar_batch called on an empty queue".into(),
+            ));
+        };
+        let bytes = batch.get_array_memory_size();
+        // The batch's bytes were reserved as part of `held`; moving it
+        // downstream relabels that charge rather than growing or releasing it.
+        self.held = self.held.saturating_sub(bytes);
+        self.emitted = bytes;
+        self.blocks.columnar_batches.add(1);
+        Ok(batch)
+    }
+
+    /// Take ownership of one decoded block's records (row path), charging the
+    /// pool for `records_memory` before it is held. An empty block (every row
+    /// filtered out) charges nothing and leaves the stream to ask for the next.
     fn hold_block(&mut self, records: Vec<LogRecord>) -> DFResult<()> {
         let bytes = records_memory(&records);
         self.reservation.try_grow(bytes)?;
         self.held = bytes;
-        self.pending = records;
-        self.pos = 0;
+        self.pending = Pending::Rows { records, pos: 0 };
         Ok(())
+    }
+
+    /// Take ownership of one block's pre-built columnar batches, charging the
+    /// pool for their total Arrow footprint before they are held. This is the
+    /// fast path's live-bytes unit (ADR-0099 decision 2): the scan holds the
+    /// batches it built straight from the view rather than a `Vec<LogRecord>`.
+    fn hold_batches(&mut self, batches: Vec<RecordBatch>) -> DFResult<()> {
+        let bytes: usize = batches.iter().map(|b| b.get_array_memory_size()).sum();
+        self.reservation.try_grow(bytes)?;
+        self.held = bytes;
+        self.pending = Pending::Batches(batches.into());
+        Ok(())
+    }
+
+    /// True when the current block still has a batch to emit.
+    fn has_pending(&self) -> bool {
+        match &self.pending {
+            Pending::None => false,
+            Pending::Rows { records, pos } => *pos < records.len(),
+            Pending::Batches(queue) => !queue.is_empty(),
+        }
     }
 
     /// Drop the drained block and release its charge.
     fn release_block(&mut self) {
         self.reservation.shrink(std::mem::take(&mut self.held));
-        self.pending = Vec::new();
-        self.pos = 0;
+        self.pending = Pending::None;
     }
 
     /// Abandon the stream on error, releasing everything the scan still holds.
@@ -696,6 +847,20 @@ impl LogScanStream {
         self.release_block();
         self.reservation.shrink(std::mem::take(&mut self.emitted));
         Poll::Ready(Some(Err(e)))
+    }
+
+    /// Take one decoded block's surviving records through the row path: apply
+    /// scan-layer selective-erasure exclusion (ADR-0064) and hold the records.
+    ///
+    /// The exclusion here is authoritative because it sees the same merged
+    /// `attrs` view the surface returns (resource + scope + record), so a
+    /// subject named only in a resource/scope attribute is dropped; the
+    /// fetcher-level filter matches per-record attributes alone and cannot see
+    /// it. An empty `records` is normal, not end-of-segment: a block can survive
+    /// pruning and hold no matching row, or have every matching row erased.
+    fn take_row_block(&mut self, mut records: Vec<LogRecord>) -> DFResult<()> {
+        retain_unerased(&mut records, &self.erasure)?;
+        self.hold_block(records)
     }
 }
 
@@ -706,21 +871,28 @@ impl Stream for LogScanStream {
         let this = self.get_mut();
         loop {
             // Anything buffered from the current block goes out first.
-            if this.pos < this.pending.len() {
-                return match this.emit_next_batch() {
+            if this.has_pending() {
+                let emitted = match &this.pending {
+                    Pending::Rows { .. } => this.emit_next_row_batch(),
+                    Pending::Batches(_) => this.emit_next_columnar_batch(),
+                    Pending::None => unreachable!("has_pending() ruled this out"),
+                };
+                return match emitted {
                     Ok(batch) => Poll::Ready(Some(Ok(batch))),
                     Err(e) => this.fail(e),
                 };
             }
             // The block is drained: release it before decoding another, so the
             // reservation never covers two blocks at once.
-            if this.held > 0 {
+            if this.held > 0 || !matches!(this.pending, Pending::None) {
                 this.release_block();
             }
 
             match &mut this.state {
                 LogScanState::NextSegment => match this.segments.pop_front() {
                     Some(seg) => {
+                        this.current_seg = Some(seg.clone());
+                        this.seg_columnar_blocks = 0;
                         this.state =
                             LogScanState::Opening(open_segment(Arc::clone(&this.ctx), seg));
                     }
@@ -730,7 +902,14 @@ impl Stream for LogScanStream {
                 },
                 LogScanState::Opening(fut) => match fut.as_mut().poll(cx) {
                     Poll::Ready(Ok(Some(scan))) => {
-                        this.state = LogScanState::Draining(Box::new(scan));
+                        this.state = if this.columnar_eligible {
+                            LogScanState::Columnar(Box::new(scan))
+                        } else {
+                            LogScanState::Rows {
+                                scan: Box::new(scan),
+                                skip: 0,
+                            }
+                        };
                     }
                     // The segment's ts span could not satisfy the query: no GET
                     // was issued and there is nothing to drain.
@@ -738,32 +917,121 @@ impl Stream for LogScanStream {
                     Poll::Ready(Err(e)) => return this.fail(e),
                     Poll::Pending => return Poll::Pending,
                 },
-                LogScanState::Draining(scan) => {
-                    let decoded = scan.next_block().map_err(SqlError::from);
-                    match decoded {
-                        Ok(Some(mut records)) => {
-                            // Scan-layer selective-erasure exclusion (ADR-0064).
-                            // This is the authoritative exclusion because it
-                            // sees the same merged `attrs` view the surface
-                            // returns (resource + scope + record), so a subject
-                            // named only in a resource/scope attribute is
-                            // dropped; the fetcher-level filter matches
-                            // per-record attributes alone and cannot see it.
-                            if let Err(e) = retain_unerased(&mut records, &this.erasure) {
-                                return this.fail(e);
+                LogScanState::ReopenRows { fut, skip } => match fut.as_mut().poll(cx) {
+                    Poll::Ready(Ok(Some(scan))) => {
+                        let skip = *skip;
+                        this.state = LogScanState::Rows {
+                            scan: Box::new(scan),
+                            skip,
+                        };
+                    }
+                    // Cannot happen for a segment already opened once this scan;
+                    // treat a vanished segment as end-of-segment rather than
+                    // panicking.
+                    Poll::Ready(Ok(None)) => this.state = LogScanState::NextSegment,
+                    Poll::Ready(Err(e)) => return this.fail(e),
+                    Poll::Pending => return Poll::Pending,
+                },
+                LogScanState::Columnar(scan) => {
+                    // One of three outcomes, folded into an owned step so the
+                    // view (which borrows `scan`) is dropped before `this.state`
+                    // or the reservation is touched.
+                    enum Step {
+                        Exhausted(ScanStats),
+                        // A block carrying an `attrs_raw` overflow page (or, only
+                        // defensively, an unexpected pending erasure): fall the
+                        // rest of this segment back to the row path.
+                        Fallback,
+                        // A clean block's built batches (possibly empty for a
+                        // block with no surviving row).
+                        Held(Vec<RecordBatch>),
+                        // A decode or build error, carried out of the view's
+                        // borrow so it can be handled once the borrow ends.
+                        Failed(DataFusionError),
+                    }
+                    // The view borrows `scan`, so every outcome is folded into an
+                    // owned `Step` here; `this.fail`/`this.state` are only touched
+                    // after the match, once that borrow has ended.
+                    let step = match scan.next_block_columnar() {
+                        Ok(ColumnarBlockOutcome::Exhausted) => Step::Exhausted(scan.stats()),
+                        // The fast path is only entered with no erasure, so this
+                        // is unreachable in practice; fall back rather than
+                        // risk serving an erased record columnar.
+                        Ok(ColumnarBlockOutcome::ErasurePending) => Step::Fallback,
+                        Ok(ColumnarBlockOutcome::Block(view)) => {
+                            if view.has_attrs_raw_page() {
+                                Step::Fallback
+                            } else {
+                                match build_columnar_batches(
+                                    &view,
+                                    &this.schema,
+                                    &this.projection,
+                                    &this.declared,
+                                ) {
+                                    Ok(batches) => Step::Held(batches),
+                                    Err(e) => Step::Failed(e),
+                                }
                             }
-                            // Every surviving record is emitted:
-                            // stream-attribute equalities are not pushed (a
-                            // stream-level prune is unsound against the merged
-                            // `attrs` column), so nothing here narrows below
-                            // what DataFusion's residual keeps.
-                            //
-                            // An empty `records` here is normal, not the end of
-                            // the segment: a block can survive pruning and hold
-                            // no row matching the exact filter, or have every
-                            // matching row erased. The loop just asks for the
-                            // next block.
-                            if let Err(e) = this.hold_block(records) {
+                        }
+                        Err(e) => Step::Failed(SqlError::from(e).into()),
+                    };
+                    match step {
+                        Step::Failed(e) => return this.fail(e),
+                        Step::Exhausted(stats) => {
+                            this.blocks.record(&stats);
+                            this.state = LogScanState::NextSegment;
+                        }
+                        Step::Fallback => {
+                            // Re-open the segment and restart it on the row path,
+                            // skipping the blocks already emitted columnar so no
+                            // row is emitted twice. The abandoned columnar scan's
+                            // partial counters are dropped; the row scan re-counts
+                            // the whole segment.
+                            let seg = match this.current_seg.clone() {
+                                Some(seg) => seg,
+                                None => {
+                                    return this.fail(DataFusionError::Internal(
+                                        "attrs_raw fallback with no current segment".into(),
+                                    ));
+                                }
+                            };
+                            let fut = open_segment(Arc::clone(&this.ctx), seg);
+                            this.state = LogScanState::ReopenRows {
+                                fut,
+                                skip: this.seg_columnar_blocks,
+                            };
+                        }
+                        Step::Held(batches) => {
+                            // Count every consumed clean block, empty or not, so
+                            // a later `attrs_raw` fallback skips exactly the
+                            // blocks the columnar cursor advanced past.
+                            this.seg_columnar_blocks += 1;
+                            if !batches.is_empty() {
+                                if let Err(e) = this.hold_batches(batches) {
+                                    return this.fail(e);
+                                }
+                            }
+                        }
+                    }
+                }
+                LogScanState::Rows { scan, skip } => {
+                    // Drain and discard the blocks a columnar fallback already
+                    // emitted, then hold the next block's records.
+                    if *skip > 0 {
+                        match scan.next_block() {
+                            Ok(Some(_)) => *skip -= 1,
+                            Ok(None) => {
+                                let stats = scan.stats();
+                                this.blocks.record(&stats);
+                                this.state = LogScanState::NextSegment;
+                            }
+                            Err(e) => return this.fail(SqlError::from(e).into()),
+                        }
+                        continue;
+                    }
+                    match scan.next_block() {
+                        Ok(Some(records)) => {
+                            if let Err(e) = this.take_row_block(records) {
                                 return this.fail(e);
                             }
                         }
@@ -774,7 +1042,7 @@ impl Stream for LogScanStream {
                             this.blocks.record(&stats);
                             this.state = LogScanState::NextSegment;
                         }
-                        Err(e) => return this.fail(e.into()),
+                        Err(e) => return this.fail(SqlError::from(e).into()),
                     }
                 }
                 LogScanState::Done => return Poll::Ready(None),
@@ -993,4 +1261,346 @@ fn declared_column_array(dc: &DeclaredColumn, merged: &[Vec<(String, AttrValue)>
             Arc::new(b.finish())
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// Columnar fast path (ADR-0099 decision 2)
+// ---------------------------------------------------------------------------
+
+/// One declared column's FIELD_DIR resolution for a block, done once via
+/// [`ColumnarBlockView::resolve_attr`] rather than per row via
+/// [`find_attr`] (ADR-0099 decision 2).
+struct DeclaredPlan<'d> {
+    dc: &'d DeclaredColumn,
+    /// The FIELD_DIR column carrying this key at the declared type, if any. A
+    /// record row whose value lives here reads that value; a row whose value
+    /// lives in a different-typed column of the same key reads NULL (record
+    /// wins, wrong variant), matching the row path exactly.
+    matching: Option<AttrColumn>,
+    /// Every FIELD_DIR column for this key, across all stored types. Used only
+    /// to answer "does this record set the key at all" so record-wins precedence
+    /// matches the merged view: if the record sets the key (any type), the
+    /// resource/scope fallback is not consulted.
+    all_cols: Vec<AttrColumn>,
+}
+
+/// The [`FieldType`] a declared column resolves its FIELD_DIR column at. A
+/// `match` (not a two-arm `if`) so a future declared `f64` (ADR-0090, deferred)
+/// slots in as one more arm rather than silently falling through.
+fn declared_field_type(ty: DeclaredType) -> FieldType {
+    match ty {
+        DeclaredType::Str => FieldType::Str,
+        DeclaredType::I64 => FieldType::I64,
+        DeclaredType::Bool => FieldType::Bool,
+        DeclaredType::Bytes => FieldType::Bytes,
+    }
+}
+
+/// Whether a FIELD_DIR column carries a value at surviving row `i`.
+fn attr_present(view: &ColumnarBlockView<'_>, col: AttrColumn, i: usize) -> bool {
+    match col.ty {
+        FieldType::Str | FieldType::Bytes => view.bytes_at(col.column_id, i).is_some(),
+        FieldType::I64 => view.i64_at(col.column_id, i).is_some(),
+        FieldType::F64 => view.f64_bits_at(col.column_id, i).is_some(),
+        FieldType::Bool => view.bool_at(col.column_id, i).is_some(),
+    }
+}
+
+/// The block's per-`stream_ref` decoded resource/scope scalar attributes, cached
+/// so a block's streams are each decoded once even though the fallback is a
+/// per-row lookup. This is the fast path's only stream-blob decode, reached only
+/// for a declared key a record row does not set in a FIELD_DIR column; a query
+/// whose declared keys are all record attributes never enters it.
+fn resource_attrs<'c>(
+    view: &ColumnarBlockView<'_>,
+    cache: &'c mut HashMap<u32, Arc<Vec<(String, AttrValue)>>>,
+    stream_ref: u32,
+) -> DFResult<&'c Arc<Vec<(String, AttrValue)>>> {
+    if !cache.contains_key(&stream_ref) {
+        let blob = view.stream_attrs_of(stream_ref).ok_or_else(|| {
+            DataFusionError::from(SqlError::CorruptStreamAttrs(
+                "columnar fast path: stream_ref has no STREAM_DIR entry".to_string(),
+            ))
+        })?;
+        let decoded = Arc::new(decode_stream_attrs(blob)?);
+        cache.insert(stream_ref, decoded);
+    }
+    Ok(cache
+        .get(&stream_ref)
+        .expect("just inserted the stream_ref entry"))
+}
+
+/// The merged value of a declared key at surviving row `i`, under the same
+/// record-wins-over-resource precedence the row path's [`merged_attrs`] +
+/// [`find_attr`] produce: the record's own value if it sets the key (in any
+/// FIELD_DIR column), otherwise the resource/scope scalar.
+///
+/// Returns the record-column value directly when the record sets the key at the
+/// declared type; `None` when the record sets it at a different type (wrong
+/// variant, NULL by ADR-0090 decision 7). Only when the record does not set the
+/// key at all is the resource/scope fallback consulted, returning a cloned
+/// [`AttrValue`] whose variant the caller checks against the declared type.
+fn declared_merged_value(
+    view: &ColumnarBlockView<'_>,
+    plan: &DeclaredPlan<'_>,
+    i: usize,
+    cache: &mut HashMap<u32, Arc<Vec<(String, AttrValue)>>>,
+) -> DFResult<Option<AttrValue>> {
+    let record_sets_key = plan.all_cols.iter().any(|&c| attr_present(view, c, i));
+    if record_sets_key {
+        let Some(mc) = plan.matching else {
+            return Ok(None);
+        };
+        return Ok(read_typed_cell(view, mc, i));
+    }
+    let Some(stream_ref) = view.stream_ref(i) else {
+        return Ok(None);
+    };
+    let resource = resource_attrs(view, cache, stream_ref)?;
+    Ok(find_attr(resource, &plan.dc.key).cloned())
+}
+
+/// Read the value of a FIELD_DIR column at surviving row `i` as an
+/// [`AttrValue`], or `None` when the cell is NULL.
+fn read_typed_cell(view: &ColumnarBlockView<'_>, col: AttrColumn, i: usize) -> Option<AttrValue> {
+    match col.ty {
+        FieldType::Str => view
+            .bytes_at(col.column_id, i)
+            .map(|b| AttrValue::Str(String::from_utf8_lossy(b).into_owned())),
+        FieldType::I64 => view.i64_at(col.column_id, i).map(AttrValue::I64),
+        FieldType::F64 => view
+            .f64_bits_at(col.column_id, i)
+            .map(|bits| AttrValue::F64(f64::from_bits(bits))),
+        FieldType::Bool => view.bool_at(col.column_id, i).map(AttrValue::Bool),
+        FieldType::Bytes => view
+            .bytes_at(col.column_id, i)
+            .map(|b| AttrValue::Bytes(b.to_vec())),
+    }
+}
+
+/// Build one declared typed attribute column for surviving rows `start..end`
+/// straight from the view (ADR-0099 decision 2). Byte-identical to
+/// [`declared_column_array`] over the same input: a value whose variant matches
+/// the declared type is appended natively, and every other case -- absent key,
+/// or a value of a different variant -- appends NULL, never a cast (ADR-0090
+/// decision 7). The `Bytes` arm applies the same `List`/`Map` canonicalization.
+///
+/// The `match` on the declared type mirrors [`declared_column_array`], so a
+/// future declared `f64` slots in as one arm on both paths.
+fn build_declared_columnar_array(
+    view: &ColumnarBlockView<'_>,
+    plan: &DeclaredPlan<'_>,
+    start: usize,
+    end: usize,
+    cache: &mut HashMap<u32, Arc<Vec<(String, AttrValue)>>>,
+) -> DFResult<ArrayRef> {
+    Ok(match plan.dc.ty {
+        DeclaredType::Str => {
+            let mut b = StringBuilder::new();
+            for i in start..end {
+                match declared_merged_value(view, plan, i, cache)? {
+                    Some(AttrValue::Str(s)) => b.append_value(s),
+                    _ => b.append_null(),
+                }
+            }
+            Arc::new(b.finish())
+        }
+        DeclaredType::I64 => {
+            let mut b = Int64Builder::new();
+            for i in start..end {
+                match declared_merged_value(view, plan, i, cache)? {
+                    Some(AttrValue::I64(v)) => b.append_value(v),
+                    _ => b.append_null(),
+                }
+            }
+            Arc::new(b.finish())
+        }
+        DeclaredType::Bool => {
+            let mut b = BooleanBuilder::new();
+            for i in start..end {
+                match declared_merged_value(view, plan, i, cache)? {
+                    Some(AttrValue::Bool(v)) => b.append_value(v),
+                    _ => b.append_null(),
+                }
+            }
+            Arc::new(b.finish())
+        }
+        DeclaredType::Bytes => {
+            let mut b = BinaryBuilder::new();
+            for i in start..end {
+                match declared_merged_value(view, plan, i, cache)? {
+                    Some(AttrValue::Bytes(bytes)) => b.append_value(bytes),
+                    // Parity with the row path: a resource/scope `List`/`Map`
+                    // value is canonicalized. In the eligible (no `attrs_raw`)
+                    // case a record's `List`/`Map` is already stored as a
+                    // canonicalized `Bytes` column, and `decode_stream_attrs`
+                    // omits nested resource values, so this arm is effectively
+                    // dead here; it is kept identical to `declared_column_array`.
+                    Some(v @ (AttrValue::List(_) | AttrValue::Map(_))) => {
+                        b.append_value(canonical_value_bytes(&v))
+                    }
+                    _ => b.append_null(),
+                }
+            }
+            Arc::new(b.finish())
+        }
+    })
+}
+
+/// A UTF-8 log field (`body`, `severity_text`) read from the view; a violation
+/// is the same client-visible corruption class the row path's `string_from_bytes`
+/// produces, never a panic or silently-wrong data.
+fn view_str(bytes: &[u8]) -> DFResult<&str> {
+    std::str::from_utf8(bytes)
+        .map_err(|_| SqlError::CorruptStreamAttrs("log text field not utf-8".to_string()).into())
+}
+
+/// Build all of one block's output batches straight from its columnar view
+/// (ADR-0099 decision 2), chunked at [`BATCH_ROWS`] exactly as the row path
+/// chunks its records, so the two paths' batches are byte-identical. Returns an
+/// empty vec for a block with no surviving row. The view borrows the scan, so
+/// the whole block is built here and the batches handed back owned, letting the
+/// caller drop the view before decoding the next block.
+fn build_columnar_batches(
+    view: &ColumnarBlockView<'_>,
+    schema: &SchemaRef,
+    projection: &[usize],
+    declared: &[DeclaredColumn],
+) -> DFResult<Vec<RecordBatch>> {
+    let n = view.surviving_count();
+    // Resolve each projected declared column's FIELD_DIR column once for the
+    // whole block (ADR-0099 decision 2), not per row and not per chunk.
+    let mut plans: HashMap<usize, DeclaredPlan> = HashMap::new();
+    for &idx in projection {
+        if idx >= FIRST_DECLARED_COL
+            && let Some(dc) = declared.get(idx - FIRST_DECLARED_COL)
+        {
+            plans.insert(
+                idx,
+                DeclaredPlan {
+                    dc,
+                    matching: view.resolve_attr(&dc.key, declared_field_type(dc.ty)),
+                    all_cols: view.attr_columns_for(&dc.key).collect(),
+                },
+            );
+        }
+    }
+    let mut cache: HashMap<u32, Arc<Vec<(String, AttrValue)>>> = HashMap::new();
+    let mut out = Vec::new();
+    let mut start = 0;
+    while start < n {
+        let end = (start + BATCH_ROWS).min(n);
+        out.push(build_columnar_batch(
+            view, schema, projection, &plans, &mut cache, start, end,
+        )?);
+        start = end;
+    }
+    Ok(out)
+}
+
+/// Build one output batch for surviving rows `start..end` from the view, one
+/// array per projected column. The column set is the same eligible set
+/// [`columnar_static_eligible`] admits: fixed columns and declared typed
+/// columns, never the `attrs` map.
+#[allow(clippy::too_many_arguments)]
+fn build_columnar_batch(
+    view: &ColumnarBlockView<'_>,
+    schema: &SchemaRef,
+    projection: &[usize],
+    plans: &HashMap<usize, DeclaredPlan<'_>>,
+    cache: &mut HashMap<u32, Arc<Vec<(String, AttrValue)>>>,
+    start: usize,
+    end: usize,
+) -> DFResult<RecordBatch> {
+    let mut columns: Vec<ArrayRef> = Vec::with_capacity(projection.len());
+    for &idx in projection {
+        let array: ArrayRef = match idx {
+            LOG_COL_TS => Arc::new(TimestampNanosecondArray::from(
+                (start..end)
+                    .map(|i| view.ts(i).unwrap_or_default())
+                    .collect::<Vec<_>>(),
+            )),
+            LOG_COL_OBSERVED_TS => Arc::new(TimestampNanosecondArray::from(
+                (start..end)
+                    .map(|i| view.observed_ts(i).unwrap_or_default())
+                    .collect::<Vec<_>>(),
+            )),
+            LOG_COL_SEVERITY_NUM => Arc::new(UInt8Array::from(
+                (start..end)
+                    .map(|i| view.severity_num(i).unwrap_or_default() as u8)
+                    .collect::<Vec<_>>(),
+            )),
+            LOG_COL_SEVERITY_TEXT => {
+                let mut b = StringBuilder::new();
+                for i in start..end {
+                    match view.severity_text(i) {
+                        Some(bytes) => b.append_value(view_str(bytes)?),
+                        None => b.append_value(""),
+                    }
+                }
+                Arc::new(b.finish())
+            }
+            LOG_COL_BODY => {
+                let mut b = StringBuilder::new();
+                for i in start..end {
+                    match view.body(i) {
+                        Some(bytes) => b.append_value(view_str(bytes)?),
+                        None => b.append_value(""),
+                    }
+                }
+                Arc::new(b.finish())
+            }
+            LOG_COL_TRACE_ID => {
+                let mut b = FixedSizeBinaryBuilder::with_capacity(end - start, TRACE_ID_WIDTH);
+                for i in start..end {
+                    match view.trace_id(i) {
+                        Some(id) => b
+                            .append_value(id)
+                            .map_err(|e| SqlError::Internal(format!("trace_id array build: {e}")))?,
+                        None => b.append_null(),
+                    }
+                }
+                Arc::new(b.finish())
+            }
+            LOG_COL_SPAN_ID => {
+                let mut b = FixedSizeBinaryBuilder::with_capacity(end - start, SPAN_ID_WIDTH);
+                for i in start..end {
+                    match view.span_id(i) {
+                        Some(id) => b
+                            .append_value(id)
+                            .map_err(|e| SqlError::Internal(format!("span_id array build: {e}")))?,
+                        None => b.append_null(),
+                    }
+                }
+                Arc::new(b.finish())
+            }
+            LOG_COL_FLAGS => Arc::new(UInt32Array::from(
+                (start..end)
+                    .map(|i| view.flags(i).unwrap_or_default() as u32)
+                    .collect::<Vec<_>>(),
+            )),
+            // Ruled out by `columnar_static_eligible`; a projection reaching the
+            // fast path never carries the `attrs` map.
+            LOG_COL_ATTRS => {
+                return Err(DataFusionError::Internal(
+                    "columnar fast path reached with an attrs map projection".into(),
+                ));
+            }
+            other => match plans.get(&other) {
+                Some(plan) => build_declared_columnar_array(view, plan, start, end, cache)?,
+                None => {
+                    return Err(DataFusionError::Internal(format!(
+                        "logs columnar scan projection index {other} out of range"
+                    )));
+                }
+            },
+        };
+        columns.push(array);
+    }
+    debug_assert_eq!(schema.fields().len(), columns.len());
+    // Carry the row count explicitly so an empty projection (a bare `COUNT(*)`)
+    // still reports its rows, exactly as the row path does.
+    let options = RecordBatchOptions::new().with_row_count(Some(end - start));
+    RecordBatch::try_new_with_options(Arc::clone(schema), columns, &options)
+        .map_err(DataFusionError::from)
 }

--- a/crates/ravel-sql/src/logs_scan.rs
+++ b/crates/ravel-sql/src/logs_scan.rs
@@ -32,6 +32,17 @@
 //! handed downstream -- and released as each goes away, so the pool bounds
 //! concurrently-held scan memory rather than cumulative bytes emitted.
 //!
+//! The two batch-building paths hold different things, and each charges what it
+//! actually holds. The row path's [`ravel_logseg::BlockScan::next_block`] drops
+//! the decoded block before it returns, so what remains resident is the
+//! `Vec<LogRecord>` it built ([`records_memory`]) plus the batch handed
+//! downstream. The columnar path's `next_block_columnar` hands out a view
+//! *borrowing* the decoded block, which the reader releases only when the next
+//! block is decoded, so the block stays resident alongside the Arrow batches
+//! built from it: both terms are charged together
+//! ([`LogScanStream::hold_batches`]) and released together. Charging the
+//! batches alone would admit a query at a fraction of its resident footprint.
+//!
 //! # Column projection
 //!
 //! The scan's output schema *is* the projection DataFusion asked for; there is
@@ -703,7 +714,10 @@ enum Pending {
     Rows { records: Vec<LogRecord>, pos: usize },
     /// Columnar fast path: the block's already-built output batches, emitted one
     /// per poll. Built whole from the [`ColumnarBlockView`] so the view (which
-    /// borrows the scan) is dropped before the next block is decoded.
+    /// borrows the scan) is dropped before the next block is decoded. The
+    /// decoded block itself is still resident behind the reader until then, so
+    /// the charge covering this variant includes it (see
+    /// [`LogScanStream::hold_batches`]).
     Batches(VecDeque<RecordBatch>),
 }
 
@@ -781,7 +795,9 @@ impl LogScanStream {
     /// Emit the next columnar-path batch: pop the front pre-built batch, relabel
     /// its already-reserved bytes from `held` to `emitted`, and release the
     /// batch handed out on the previous poll. No new reservation is taken -- the
-    /// whole block's batches were charged once in [`Self::hold_batches`].
+    /// decoded block and all of its batches were charged once in
+    /// [`Self::hold_batches`], and the block's share stays in `held` until the
+    /// block is released.
     fn emit_next_columnar_batch(&mut self) -> DFResult<RecordBatch> {
         self.reservation.shrink(std::mem::take(&mut self.emitted));
         let Pending::Batches(queue) = &mut self.pending else {
@@ -815,11 +831,24 @@ impl LogScanStream {
     }
 
     /// Take ownership of one block's pre-built columnar batches, charging the
-    /// pool for their total Arrow footprint before they are held. This is the
-    /// fast path's live-bytes unit (ADR-0099 decision 2): the scan holds the
-    /// batches it built straight from the view rather than a `Vec<LogRecord>`.
-    fn hold_batches(&mut self, batches: Vec<RecordBatch>) -> DFResult<()> {
-        let bytes: usize = batches.iter().map(|b| b.get_array_memory_size()).sum();
+    /// pool for everything the fast path holds while they drain: their total
+    /// Arrow footprint **plus** `block_bytes`, the decoded block's own heap
+    /// footprint ([`ColumnarBlockView::decoded_bytes`]).
+    ///
+    /// Both terms are live at the same time, which is why both are charged. The
+    /// batches were built from a view borrowing the decoded block, and
+    /// `BlockScan` releases that block only when the next one is decoded -- so
+    /// for as long as this stream is emitting these batches, the block is
+    /// resident too. The batch term alone would report a fraction of the true
+    /// footprint and break ADR-0087 decision 2's contract that the pool bounds
+    /// concurrently-held scan memory.
+    ///
+    /// The block's share of the charge stays in [`Self::held`] until
+    /// [`Self::release_block`]: [`Self::emit_next_columnar_batch`] moves only
+    /// the emitted batch's bytes from `held` to `emitted`.
+    fn hold_batches(&mut self, batches: Vec<RecordBatch>, block_bytes: usize) -> DFResult<()> {
+        let batch_bytes: usize = batches.iter().map(|b| b.get_array_memory_size()).sum();
+        let bytes = batch_bytes.saturating_add(block_bytes);
         self.reservation.try_grow(bytes)?;
         self.held = bytes;
         self.pending = Pending::Batches(batches.into());
@@ -943,8 +972,14 @@ impl Stream for LogScanStream {
                         // rest of this segment back to the row path.
                         Fallback,
                         // A clean block's built batches (possibly empty for a
-                        // block with no surviving row).
-                        Held(Vec<RecordBatch>),
+                        // block with no surviving row), and the decoded block's
+                        // own heap footprint, read off the view before its
+                        // borrow ends because the block stays resident behind
+                        // the reader while those batches drain.
+                        Held {
+                            batches: Vec<RecordBatch>,
+                            block_bytes: usize,
+                        },
                         // A decode or build error, carried out of the view's
                         // borrow so it can be handled once the borrow ends.
                         Failed(DataFusionError),
@@ -968,7 +1003,10 @@ impl Stream for LogScanStream {
                                     &this.projection,
                                     &this.declared,
                                 ) {
-                                    Ok(batches) => Step::Held(batches),
+                                    Ok(batches) => Step::Held {
+                                        batches,
+                                        block_bytes: view.decoded_bytes(),
+                                    },
                                     Err(e) => Step::Failed(e),
                                 }
                             }
@@ -1001,13 +1039,21 @@ impl Stream for LogScanStream {
                                 skip: this.seg_columnar_blocks,
                             };
                         }
-                        Step::Held(batches) => {
+                        Step::Held {
+                            batches,
+                            block_bytes,
+                        } => {
                             // Count every consumed clean block, empty or not, so
                             // a later `attrs_raw` fallback skips exactly the
                             // blocks the columnar cursor advanced past.
                             this.seg_columnar_blocks += 1;
+                            // A block with no surviving row is not held at all:
+                            // the loop asks for the next block immediately,
+                            // which releases it inside this same poll, so there
+                            // is no interval during which it is resident and
+                            // uncharged.
                             if !batches.is_empty()
-                                && let Err(e) = this.hold_batches(batches)
+                                && let Err(e) = this.hold_batches(batches, block_bytes)
                             {
                                 return this.fail(e);
                             }
@@ -1296,10 +1342,17 @@ fn declared_field_type(ty: DeclaredType) -> FieldType {
     }
 }
 
-/// Whether a FIELD_DIR column carries a value at surviving row `i`.
+/// Whether a FIELD_DIR column carries a *readable* value at surviving row `i`.
+///
+/// "Readable" is what makes this agree with the row path: a `Str` cell holding
+/// bytes that are not UTF-8 is not a value there
+/// (`get_attr_value`/`read_typed_cell`), so it must not count as the record
+/// setting the key either -- otherwise it would suppress the resource/scope
+/// fallback the row path applies.
 fn attr_present(view: &ColumnarBlockView<'_>, col: AttrColumn, i: usize) -> bool {
     match col.ty {
-        FieldType::Str | FieldType::Bytes => view.bytes_at(col.column_id, i).is_some(),
+        FieldType::Str => read_str_cell(view, col.column_id, i).is_some(),
+        FieldType::Bytes => view.bytes_at(col.column_id, i).is_some(),
         FieldType::I64 => view.i64_at(col.column_id, i).is_some(),
         FieldType::F64 => view.f64_bits_at(col.column_id, i).is_some(),
         FieldType::Bool => view.bool_at(col.column_id, i).is_some(),
@@ -1360,13 +1413,27 @@ fn declared_merged_value(
     Ok(find_attr(resource, &plan.dc.key).cloned())
 }
 
+/// A `Str`-typed FIELD_DIR cell at surviving row `i`, as `&str`: `None` when the
+/// cell is NULL **or** when its bytes are not UTF-8.
+///
+/// Treating invalid UTF-8 as no value is what the row path does
+/// (`get_attr_value`'s `String::from_utf8(b).ok()`, `ravel-logseg`'s
+/// `reader.rs`), which makes the attribute absent for that record and lets the
+/// resource/scope value show through. Substituting U+FFFD instead would both
+/// invent a value and suppress that fallback, and this crate's rule is exact
+/// semantics by default.
+fn read_str_cell<'v>(view: &ColumnarBlockView<'v>, column_id: u32, i: usize) -> Option<&'v str> {
+    std::str::from_utf8(view.bytes_at(column_id, i)?).ok()
+}
+
 /// Read the value of a FIELD_DIR column at surviving row `i` as an
-/// [`AttrValue`], or `None` when the cell is NULL.
+/// [`AttrValue`], or `None` when the cell is NULL (or, for `Str`, not UTF-8;
+/// see [`read_str_cell`]).
 fn read_typed_cell(view: &ColumnarBlockView<'_>, col: AttrColumn, i: usize) -> Option<AttrValue> {
     match col.ty {
-        FieldType::Str => view
-            .bytes_at(col.column_id, i)
-            .map(|b| AttrValue::Str(String::from_utf8_lossy(b).into_owned())),
+        FieldType::Str => {
+            read_str_cell(view, col.column_id, i).map(|s| AttrValue::Str(s.to_string()))
+        }
         FieldType::I64 => view.i64_at(col.column_id, i).map(AttrValue::I64),
         FieldType::F64 => view
             .f64_bits_at(col.column_id, i)

--- a/crates/ravel-sql/src/logs_scan.rs
+++ b/crates/ravel-sql/src/logs_scan.rs
@@ -1554,9 +1554,9 @@ fn build_columnar_batch(
                 let mut b = FixedSizeBinaryBuilder::with_capacity(end - start, TRACE_ID_WIDTH);
                 for i in start..end {
                     match view.trace_id(i) {
-                        Some(id) => b
-                            .append_value(id)
-                            .map_err(|e| SqlError::Internal(format!("trace_id array build: {e}")))?,
+                        Some(id) => b.append_value(id).map_err(|e| {
+                            SqlError::Internal(format!("trace_id array build: {e}"))
+                        })?,
                         None => b.append_null(),
                     }
                 }

--- a/crates/ravel-sql/src/rlog_attrs.rs
+++ b/crates/ravel-sql/src/rlog_attrs.rs
@@ -138,7 +138,7 @@ fn hex_lower(bytes: &[u8]) -> String {
 /// refinement). Per-record dynamic attributes with nested values are unaffected
 /// -- they are merged in verbatim by [`merged_attrs`] and rendered by
 /// [`attr_value_to_string`].
-fn decode_stream_attrs(blob: &[u8]) -> DFResult<Vec<(String, AttrValue)>> {
+pub(crate) fn decode_stream_attrs(blob: &[u8]) -> DFResult<Vec<(String, AttrValue)>> {
     let mut pos = 0usize;
     let mut out = Vec::new();
     // Resource attribute set.

--- a/crates/ravel-sql/tests/logs_columnar.proptest-regressions
+++ b/crates/ravel-sql/tests/logs_columnar.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc cfa01d3c894ba8b795db502860fd344432776c0c3e70260a93c791994d7fc5b1 # shrinks to scenario = Scenario { records: [RecordSpec { ts: 0, obs_extra: 0, severity_num: 0, severity_text: "INFO", body: "timeout", trace_id: None, span_id: None, flags: 0, resource: [("name", Str("api"))], attrs: [("name", I64(7))] }], projection: [10], word: None }

--- a/crates/ravel-sql/tests/logs_columnar.rs
+++ b/crates/ravel-sql/tests/logs_columnar.rs
@@ -1,0 +1,668 @@
+//! Acceptance gate for the columnar fast path of the `logs` SQL scan
+//! (ADR-0099 decisions 2-3, issue #415).
+//!
+//! The fast path builds Arrow arrays straight from `ravel_logseg`'s
+//! `ColumnarBlockView` over the surviving rows, with no `LogRecord` and no
+//! `merged_attrs`, and is taken only when the query is eligible: the projection
+//! touches only fixed and declared typed columns (no `attrs` map), no pending
+//! erasure predicate applies, and the block carries no `attrs_raw` overflow
+//! page. Otherwise the unchanged row path runs. Because the two paths' output is
+//! identical by construction, the `columnar_batches`/`rowpath_batches` partition
+//! metrics are the only way to prove which one ran.
+//!
+//! The tests drive [`ravel_sql::LogsScanExec`] directly rather than a full
+//! `SessionContext`, so a projection is chosen exactly (no planner folding) and
+//! the same input can be run through both paths for a byte-for-byte comparison:
+//!
+//! - the fast path is a scan with no pending erasure over a corpus with no
+//!   `attrs_raw` spill;
+//! - the row path is the *same* projection over the *same* corpus, forced
+//!   ineligible by a pending erasure predicate that matches no record (so it
+//!   drains the row path yet erases nothing, leaving the output identical).
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::sync::Arc;
+
+use datafusion::arrow::array::{
+    Array, BinaryArray, BooleanArray, FixedSizeBinaryArray, Int64Array, RecordBatch, StringArray,
+    TimestampNanosecondArray, UInt8Array, UInt32Array,
+};
+use datafusion::execution::TaskContext;
+use datafusion::physical_plan::ExecutionPlan;
+use futures::StreamExt;
+use proptest::prelude::*;
+use ravel_catalog::{SegmentLevel, SegmentRef, Snapshot};
+use ravel_logseg::writer::ObjectIdentity;
+use ravel_logseg::{
+    AttrValue, FieldSel, LogRecord, Predicate, RlogConfig, RlogWriter, stream_attrs_bytes,
+};
+use ravel_object_store::memory::MemoryStore;
+use ravel_object_store::{ObjectStoreBackend, PutOptions};
+use ravel_query::LogSegmentFetcher;
+use ravel_query::erasure::snapshot_pending_erasure_predicates;
+use ravel_sql::{
+    DeclaredColumn, DeclaredType, FIRST_DECLARED_COL, LOG_COL_ATTRS, LogsScanExec,
+    logs_schema_with_declared,
+};
+use ravel_types::TenantHash;
+use ravel_types::accounting::QueryAccounting;
+use ravel_types::logstream::log_stream_id;
+use uuid::Uuid;
+
+const TENANT: TenantHash = TenantHash([7u8; 16]);
+const CASES: u32 = 48;
+
+// --- vocabularies ----------------------------------------------------------
+
+/// Resource attribute keys, disjoint from the declared keys so the declared
+/// columns are genuinely record-sourced (the common case) without an accidental
+/// resource/record collision confusing the comparison.
+const RESOURCE_KEYS: &[&str] = &["service.name", "host"];
+const VALUE_VOCAB: &[&str] = &["api", "worker", "db", "edge"];
+const WORD_VOCAB: &[&str] = &["timeout", "connection", "error", "ok", "retry"];
+const SEVERITY_TEXT: &[&str] = &["INFO", "WARN", "ERROR"];
+
+/// The tenant's four declared typed attribute columns, one per declared type.
+fn declared_columns() -> Vec<DeclaredColumn> {
+    vec![
+        DeclaredColumn::new("dur", DeclaredType::I64),
+        DeclaredColumn::new("name", DeclaredType::Str),
+        DeclaredColumn::new("ok", DeclaredType::Bool),
+        DeclaredColumn::new("blob", DeclaredType::Bytes),
+    ]
+}
+
+/// Every schema index the fast path may project: the fixed columns (0..=7) and
+/// the four declared columns (9..=12), never the `attrs` map (index 8).
+fn eligible_indices() -> Vec<usize> {
+    let mut v: Vec<usize> = (0..LOG_COL_ATTRS).collect();
+    v.extend(FIRST_DECLARED_COL..FIRST_DECLARED_COL + declared_columns().len());
+    v
+}
+
+// --- corpus ----------------------------------------------------------------
+
+#[derive(Clone, Debug)]
+struct RecordSpec {
+    ts: i64,
+    obs_extra: i64,
+    severity_num: u8,
+    severity_text: String,
+    body: String,
+    trace_id: Option<[u8; 16]>,
+    span_id: Option<[u8; 8]>,
+    flags: u32,
+    resource: Vec<(String, AttrValue)>,
+    attrs: Vec<(String, AttrValue)>,
+}
+
+#[derive(Clone, Debug)]
+struct Scenario {
+    records: Vec<RecordSpec>,
+    /// Which eligible schema indices to project (a subsequence, at least `ts`).
+    projection: Vec<usize>,
+    /// Optional `has_word(body, _)` content predicate.
+    word: Option<String>,
+}
+
+fn arb_value() -> impl Strategy<Value = AttrValue> {
+    prop::sample::select(VALUE_VOCAB).prop_map(|s| AttrValue::Str(s.to_string()))
+}
+
+fn arb_resource() -> impl Strategy<Value = Vec<(String, AttrValue)>> {
+    proptest::sample::subsequence(RESOURCE_KEYS.to_vec(), 0..=RESOURCE_KEYS.len())
+        .prop_flat_map(|sel| {
+            let n = sel.len();
+            (Just(sel), prop::collection::vec(arb_value(), n))
+        })
+        .prop_map(|(sel, vals)| {
+            sel.into_iter()
+                .zip(vals)
+                .map(|(k, v)| (k.to_string(), v))
+                .collect()
+        })
+}
+
+/// A declared key is independently absent, present with the matching variant, or
+/// present with a deliberately wrong variant (which must read NULL, never a
+/// cast). This is what exercises ADR-0090 decision 7 through the fast path.
+fn arb_declared_attrs() -> impl Strategy<Value = Vec<(String, AttrValue)>> {
+    let dur = prop_oneof![
+        Just(None),
+        any::<i32>().prop_map(|v| Some(AttrValue::I64(i64::from(v)))),
+        Just(Some(AttrValue::Str("not-an-int".into()))), // wrong variant
+    ];
+    let name = prop_oneof![
+        Just(None),
+        prop::sample::select(VALUE_VOCAB).prop_map(|s| Some(AttrValue::Str(s.to_string()))),
+        Just(Some(AttrValue::I64(7))), // wrong variant
+    ];
+    let ok = prop_oneof![
+        Just(None),
+        any::<bool>().prop_map(|b| Some(AttrValue::Bool(b))),
+        Just(Some(AttrValue::Str("not-a-bool".into()))), // wrong variant
+    ];
+    let blob = prop_oneof![
+        Just(None),
+        prop::collection::vec(any::<u8>(), 0..4).prop_map(|b| Some(AttrValue::Bytes(b))),
+        Just(Some(AttrValue::I64(9))), // wrong variant
+    ];
+    (dur, name, ok, blob).prop_map(|(dur, name, ok, blob)| {
+        let mut out = Vec::new();
+        if let Some(v) = dur {
+            out.push(("dur".to_string(), v));
+        }
+        if let Some(v) = name {
+            out.push(("name".to_string(), v));
+        }
+        if let Some(v) = ok {
+            out.push(("ok".to_string(), v));
+        }
+        if let Some(v) = blob {
+            out.push(("blob".to_string(), v));
+        }
+        out
+    })
+}
+
+fn arb_body() -> impl Strategy<Value = String> {
+    prop::collection::vec(prop::sample::select(WORD_VOCAB), 1..4).prop_map(|w| w.join(" "))
+}
+
+fn arb_record() -> impl Strategy<Value = RecordSpec> {
+    (
+        0i64..50,
+        0i64..3,
+        0u8..=24,
+        prop::sample::select(SEVERITY_TEXT),
+        arb_body(),
+        prop::option::of(any::<u8>().prop_map(|b| [b; 16])),
+        prop::option::of(any::<u8>().prop_map(|b| [b; 8])),
+        any::<u32>(),
+        arb_resource(),
+        arb_declared_attrs(),
+    )
+        .prop_map(
+            |(
+                ts,
+                obs_extra,
+                severity_num,
+                severity_text,
+                body,
+                trace_id,
+                span_id,
+                flags,
+                resource,
+                attrs,
+            )| RecordSpec {
+                ts,
+                obs_extra,
+                severity_num,
+                severity_text: severity_text.to_string(),
+                body,
+                trace_id,
+                span_id,
+                flags,
+                resource,
+                attrs,
+            },
+        )
+}
+
+fn arb_projection() -> impl Strategy<Value = Vec<usize>> {
+    let all = eligible_indices();
+    proptest::sample::subsequence(all.clone(), 0..=all.len()).prop_map(|mut sel| {
+        if sel.is_empty() {
+            sel.push(0);
+        }
+        sel
+    })
+}
+
+fn arb_scenario() -> impl Strategy<Value = Scenario> {
+    (
+        prop::collection::vec(arb_record(), 1..12),
+        arb_projection(),
+        prop::option::of(prop::sample::select(WORD_VOCAB).prop_map(|s| s.to_string())),
+    )
+        .prop_map(|(records, projection, word)| Scenario {
+            records,
+            projection,
+            word,
+        })
+}
+
+// --- materialize -----------------------------------------------------------
+
+fn identity() -> ObjectIdentity {
+    ObjectIdentity {
+        tenant_hash: TENANT.0,
+        shard: 0,
+        writer_id: [2u8; 16],
+        writer_epoch: 1,
+        writer_seq: 1,
+    }
+}
+
+fn build_record(spec: &RecordSpec) -> LogRecord {
+    LogRecord {
+        stream_id: log_stream_id(&spec.resource, "scope", "1.0", &[]),
+        stream_attrs: stream_attrs_bytes(&spec.resource, "scope", "1.0", &[]),
+        ts_ns: spec.ts,
+        observed_ts_ns: spec.ts + spec.obs_extra,
+        severity_num: spec.severity_num,
+        severity_text: spec.severity_text.clone(),
+        body: spec.body.clone(),
+        trace_id: spec.trace_id,
+        span_id: spec.span_id,
+        flags: spec.flags,
+        attrs: spec.attrs.clone(),
+    }
+}
+
+/// Write `records` into one RLOG object with `cfg` and return its `SegmentRef`.
+async fn write_object(
+    store: &MemoryStore,
+    key: &str,
+    records: &[LogRecord],
+    cfg: RlogConfig,
+) -> SegmentRef {
+    let mut w = RlogWriter::new(cfg, identity());
+    for r in records {
+        w.push(r.clone()).expect("push");
+    }
+    let bytes = w.finish().expect("finish");
+    let size = bytes.len() as u64;
+    store
+        .put(key, bytes::Bytes::from(bytes), PutOptions::default())
+        .await
+        .expect("put");
+    let min = records.iter().map(|r| r.ts_ns).min().expect("nonempty");
+    let max = records.iter().map(|r| r.ts_ns).max().expect("nonempty");
+    SegmentRef {
+        data_object_key: key.to_string(),
+        object_size: size,
+        min_event_ts_ns: min,
+        max_event_ts_ns: max,
+        ingest_hour_bucket: 0,
+        sample_count: records.len() as u64,
+        series_count: 0,
+        shard: 0,
+        content_hash: [0u8; 32],
+        writer_id: Uuid::from_u128(1),
+        writer_epoch: 1,
+        writer_seq: 1,
+        created_unix_ns: 0,
+        level: SegmentLevel::L0,
+    }
+}
+
+/// Small blocks so a corpus of a dozen records still spans several blocks,
+/// exercising the per-block loop and the block-release accounting.
+fn small_blocks() -> RlogConfig {
+    RlogConfig {
+        block_target_records: 3,
+        ..RlogConfig::default()
+    }
+}
+
+// --- run the scan ----------------------------------------------------------
+
+struct ScanRun {
+    batches: Vec<RecordBatch>,
+    columnar_batches: usize,
+    rowpath_batches: usize,
+}
+
+/// Execute a `LogsScanExec` directly over `segments` with the given projection,
+/// content predicate, and pending-erasure requests, returning its batches and
+/// the two path metrics.
+async fn run_scan(
+    store: Arc<dyn ObjectStoreBackend>,
+    segments: Vec<SegmentRef>,
+    declared: Vec<DeclaredColumn>,
+    projection: Option<Vec<usize>>,
+    content: Vec<Predicate>,
+    erasure_reqs: Vec<ravel_proto::commit::v1::ErasureRequest>,
+) -> ScanRun {
+    let full_schema = logs_schema_with_declared(&declared);
+    let erasure = snapshot_pending_erasure_predicates(&Snapshot {
+        segments: segments.clone(),
+        segments_pruned: 0,
+        pending_erasure: erasure_reqs,
+    });
+    let scan = LogsScanExec::new(
+        TENANT,
+        LogSegmentFetcher::new(store),
+        &segments,
+        1,
+        i64::MIN,
+        i64::MAX,
+        Arc::new(content),
+        Arc::new(Vec::new()),
+        Arc::new(erasure),
+        projection.as_ref(),
+        QueryAccounting::new(),
+        full_schema,
+        Arc::new(declared),
+    )
+    .expect("build scan");
+
+    let mut stream = scan
+        .execute(0, Arc::new(TaskContext::default()))
+        .expect("execute");
+    let mut batches = Vec::new();
+    while let Some(next) = stream.next().await {
+        batches.push(next.expect("batch"));
+    }
+    drop(stream);
+
+    let metrics = scan.metrics().expect("metrics");
+    let count = |name: &str| metrics.sum_by_name(name).map(|v| v.as_usize()).unwrap_or(0);
+    ScanRun {
+        columnar_batches: count("columnar_batches"),
+        rowpath_batches: count("rowpath_batches"),
+        batches,
+    }
+}
+
+/// A dummy pending erasure whose key exists in no record, so it forces the row
+/// path (any erasure makes a scan ineligible) yet erases nothing, leaving the
+/// output identical to the fast path over the same input.
+fn no_match_erasure() -> Vec<ravel_proto::commit::v1::ErasureRequest> {
+    vec![ravel_proto::commit::v1::ErasureRequest {
+        predicate: vec![ravel_proto::commit::v1::ErasurePredicateMatcher {
+            key: "__does_not_exist__".to_string(),
+            value: "__nope__".to_string(),
+        }],
+        ..Default::default()
+    }]
+}
+
+// --- comparable rows -------------------------------------------------------
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+enum Cell {
+    Ts(i64),
+    U8(u8),
+    Str(String),
+    Bin(Option<Vec<u8>>),
+    U32(u32),
+    OptI64(Option<i64>),
+    OptStr(Option<String>),
+    OptBool(Option<bool>),
+}
+
+fn a<T: Array + 'static>(batch: &RecordBatch, col: usize) -> &T {
+    batch
+        .column(col)
+        .as_any()
+        .downcast_ref::<T>()
+        .expect("column type")
+}
+
+/// Extract every row of `batches` as a `Vec<Cell>`, one cell per projected
+/// column, so two scans over the same input compare as sorted multisets.
+fn rows(
+    batches: &[RecordBatch],
+    projection: &[usize],
+    declared: &[DeclaredColumn],
+) -> Vec<Vec<Cell>> {
+    let mut out = Vec::new();
+    for batch in batches {
+        for i in 0..batch.num_rows() {
+            let mut row = Vec::with_capacity(projection.len());
+            for (col, &idx) in projection.iter().enumerate() {
+                row.push(cell(batch, col, idx, declared, i));
+            }
+            out.push(row);
+        }
+    }
+    out.sort();
+    out
+}
+
+fn cell(
+    batch: &RecordBatch,
+    col: usize,
+    idx: usize,
+    declared: &[DeclaredColumn],
+    i: usize,
+) -> Cell {
+    match idx {
+        0 | 1 => Cell::Ts(a::<TimestampNanosecondArray>(batch, col).value(i)),
+        2 => Cell::U8(a::<UInt8Array>(batch, col).value(i)),
+        3 | 4 => Cell::Str(a::<StringArray>(batch, col).value(i).to_string()),
+        5 | 6 => {
+            let arr = a::<FixedSizeBinaryArray>(batch, col);
+            Cell::Bin((!arr.is_null(i)).then(|| arr.value(i).to_vec()))
+        }
+        7 => Cell::U32(a::<UInt32Array>(batch, col).value(i)),
+        _ => {
+            let dc = &declared[idx - FIRST_DECLARED_COL];
+            match dc.ty {
+                DeclaredType::I64 => {
+                    let arr = a::<Int64Array>(batch, col);
+                    Cell::OptI64((!arr.is_null(i)).then(|| arr.value(i)))
+                }
+                DeclaredType::Str => {
+                    let arr = a::<StringArray>(batch, col);
+                    Cell::OptStr((!arr.is_null(i)).then(|| arr.value(i).to_string()))
+                }
+                DeclaredType::Bool => {
+                    let arr = a::<BooleanArray>(batch, col);
+                    Cell::OptBool((!arr.is_null(i)).then(|| arr.value(i)))
+                }
+                DeclaredType::Bytes => {
+                    let arr = a::<BinaryArray>(batch, col);
+                    Cell::Bin((!arr.is_null(i)).then(|| arr.value(i).to_vec()))
+                }
+            }
+        }
+    }
+}
+
+fn total_rows(batches: &[RecordBatch]) -> usize {
+    batches.iter().map(|b| b.num_rows()).sum()
+}
+
+// --- the gate --------------------------------------------------------------
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(CASES))]
+
+    /// The acceptance test (issue #415): over random corpora, projections, and
+    /// content predicates, the columnar fast path's batches equal the row
+    /// path's exactly, and the `columnar_batches` metric proves the fast path
+    /// actually ran for the eligible cases.
+    #[test]
+    fn columnar_fast_path_matches_row_path_over_random_corpora(scenario in arb_scenario()) {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async move {
+            let declared = declared_columns();
+            let records: Vec<LogRecord> = scenario.records.iter().map(build_record).collect();
+            let store = MemoryStore::new();
+            let seg = write_object(&store, "logs/case.rlog", &records, small_blocks()).await;
+            let store: Arc<dyn ObjectStoreBackend> = Arc::new(store);
+            let segments = vec![seg];
+
+            let content: Vec<Predicate> = scenario
+                .word
+                .clone()
+                .map(|w| Predicate::HasWord { field: FieldSel::Body, word: w })
+                .into_iter()
+                .collect();
+
+            // Fast path: eligible (no erasure), no attrs_raw spill in this corpus.
+            let fast = run_scan(
+                Arc::clone(&store),
+                segments.clone(),
+                declared.clone(),
+                Some(scenario.projection.clone()),
+                content.clone(),
+                Vec::new(),
+            )
+            .await;
+
+            // Row path: same projection, forced ineligible by a no-match erasure
+            // that changes no row.
+            let row = run_scan(
+                Arc::clone(&store),
+                segments.clone(),
+                declared.clone(),
+                Some(scenario.projection.clone()),
+                content.clone(),
+                no_match_erasure(),
+            )
+            .await;
+
+            let n = total_rows(&fast.batches);
+            prop_assert_eq!(n, total_rows(&row.batches), "row counts must match");
+
+            // The fast path never fell back on this spill-free corpus, and it
+            // ran (emitted a columnar batch) whenever there was output.
+            prop_assert_eq!(fast.rowpath_batches, 0, "fast scan must not fall back");
+            if n > 0 {
+                prop_assert!(fast.columnar_batches > 0, "fast path must have run");
+            }
+            // The forced row path never touched the fast path.
+            prop_assert_eq!(row.columnar_batches, 0, "row scan must not run columnar");
+            if n > 0 {
+                prop_assert!(row.rowpath_batches > 0, "row path must have run");
+            }
+
+            let want = rows(&row.batches, &scenario.projection, &declared);
+            let got = rows(&fast.batches, &scenario.projection, &declared);
+            prop_assert_eq!(got, want, "fast path output must equal the row path exactly");
+            Ok(())
+        })?;
+    }
+}
+
+/// The data-protection case (issue #415): with a pending erasure predicate
+/// active, the scan takes the row path (`columnar_batches == 0`,
+/// `rowpath_batches > 0`) and the erased record is absent from the output. This
+/// is the clause that fails closed on purpose (ADR-0099 decision 2): erasure
+/// decides whether an erased record reaches a client.
+#[tokio::test]
+async fn pending_erasure_forces_the_row_path() {
+    let declared = declared_columns();
+    let resource = vec![("service.name".to_string(), AttrValue::Str("worker".into()))];
+    let mk = |ts: i64, user: &str, body: &str| LogRecord {
+        stream_id: log_stream_id(&resource, "scope", "1.0", &[]),
+        stream_attrs: stream_attrs_bytes(&resource, "scope", "1.0", &[]),
+        ts_ns: ts,
+        observed_ts_ns: ts,
+        severity_num: 9,
+        severity_text: "INFO".into(),
+        body: body.into(),
+        trace_id: None,
+        span_id: None,
+        flags: 0,
+        attrs: vec![("user_id".to_string(), AttrValue::Str(user.into()))],
+    };
+    let records = vec![mk(1, "u1", "erase me"), mk(2, "u2", "keep me")];
+
+    let store = MemoryStore::new();
+    let seg = write_object(&store, "logs/erasure.rlog", &records, RlogConfig::default()).await;
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(store);
+
+    let erasure = vec![ravel_proto::commit::v1::ErasureRequest {
+        predicate: vec![ravel_proto::commit::v1::ErasurePredicateMatcher {
+            key: "user_id".to_string(),
+            value: "u1".to_string(),
+        }],
+        ..Default::default()
+    }];
+
+    // Project only fixed columns, which would be eligible but for the erasure.
+    let run = run_scan(
+        store,
+        vec![seg],
+        declared.clone(),
+        Some(vec![0, 4]), // ts, body
+        Vec::new(),
+        erasure,
+    )
+    .await;
+
+    assert_eq!(run.columnar_batches, 0, "erasure must forbid the fast path");
+    assert!(run.rowpath_batches > 0, "the row path must have run");
+
+    let projection = vec![0usize, 4];
+    let got = rows(&run.batches, &projection, &declared);
+    // Only ts=2 "keep me" survives; the erased ts=1 "u1" row is absent.
+    assert_eq!(got.len(), 1, "the erased record must be dropped");
+    assert_eq!(got[0][0], Cell::Ts(2));
+    assert_eq!(got[0][1], Cell::Str("keep me".to_string()));
+}
+
+/// A block WITH an `attrs_raw` spill and a query projecting a declared column
+/// falls back to the row path and still returns the spilled attribute's value
+/// (issue #415). A false-negative `has_attrs_raw_page` would silently drop the
+/// spilled value, so this asserts the value itself, not only the path taken.
+///
+/// The spill is forced with `max_dynamic_columns = 1`: the alphabetically
+/// earlier `filler` key consumes the single dynamic column, so the declared
+/// `tags` key overflows into `attrs_raw` and is only visible after canonical
+/// decode, which the fast path does not do.
+#[tokio::test]
+async fn attrs_raw_spill_falls_back_to_row_path_and_keeps_the_value() {
+    let declared = vec![DeclaredColumn::new("tags", DeclaredType::Str)];
+    let resource = vec![("service.name".to_string(), AttrValue::Str("api".into()))];
+    let record = LogRecord {
+        stream_id: log_stream_id(&resource, "scope", "1.0", &[]),
+        stream_attrs: stream_attrs_bytes(&resource, "scope", "1.0", &[]),
+        ts_ns: 1,
+        observed_ts_ns: 1,
+        severity_num: 9,
+        severity_text: "INFO".into(),
+        body: "row".into(),
+        trace_id: None,
+        span_id: None,
+        flags: 0,
+        attrs: vec![
+            ("filler".to_string(), AttrValue::Str("f".into())),
+            ("tags".to_string(), AttrValue::Str("spilled".into())),
+        ],
+    };
+    let cfg = RlogConfig {
+        max_dynamic_columns: 1,
+        ..RlogConfig::default()
+    };
+
+    let store = MemoryStore::new();
+    let seg = write_object(&store, "logs/spill.rlog", &[record], cfg).await;
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(store);
+
+    // Project ts and the declared `tags` column (schema index FIRST_DECLARED_COL).
+    let projection = vec![0usize, FIRST_DECLARED_COL];
+    let run = run_scan(
+        store,
+        vec![seg],
+        declared.clone(),
+        Some(projection.clone()),
+        Vec::new(),
+        Vec::new(),
+    )
+    .await;
+
+    assert_eq!(
+        run.columnar_batches, 0,
+        "an attrs_raw block must fall back to the row path"
+    );
+    assert!(run.rowpath_batches > 0, "the row path must have run");
+
+    let got = rows(&run.batches, &projection, &declared);
+    assert_eq!(got.len(), 1);
+    assert_eq!(got[0][0], Cell::Ts(1));
+    assert_eq!(
+        got[0][1],
+        Cell::OptStr(Some("spilled".to_string())),
+        "the spilled declared value must survive the fallback"
+    );
+}

--- a/crates/ravel-sql/tests/logs_columnar.rs
+++ b/crates/ravel-sql/tests/logs_columnar.rs
@@ -55,10 +55,12 @@ const CASES: u32 = 48;
 
 // --- vocabularies ----------------------------------------------------------
 
-/// Resource attribute keys, disjoint from the declared keys so the declared
-/// columns are genuinely record-sourced (the common case) without an accidental
-/// resource/record collision confusing the comparison.
-const RESOURCE_KEYS: &[&str] = &["service.name", "host"];
+/// Resource attribute keys. `name` is deliberately also a *declared* key, so a
+/// generated record can set the same key at both resource and record level and
+/// the differential exercises the record-wins-over-resource merge rather than
+/// only the resource-absent case. With a disjoint vocabulary an implementation
+/// that inverted the precedence passed the whole suite.
+const RESOURCE_KEYS: &[&str] = &["service.name", "host", "name"];
 const VALUE_VOCAB: &[&str] = &["api", "worker", "db", "edge"];
 const WORD_VOCAB: &[&str] = &["timeout", "connection", "error", "ok", "retry"];
 const SEVERITY_TEXT: &[&str] = &["INFO", "WARN", "ERROR"];
@@ -268,34 +270,19 @@ async fn write_object(
     records: &[LogRecord],
     cfg: RlogConfig,
 ) -> SegmentRef {
+    let bytes = encode_object(records, cfg);
+    let min = records.iter().map(|r| r.ts_ns).min().expect("nonempty");
+    let max = records.iter().map(|r| r.ts_ns).max().expect("nonempty");
+    put_object(store, key, bytes, min, max, records.len()).await
+}
+
+/// Encode `records` into one RLOG object's bytes.
+fn encode_object(records: &[LogRecord], cfg: RlogConfig) -> Vec<u8> {
     let mut w = RlogWriter::new(cfg, identity());
     for r in records {
         w.push(r.clone()).expect("push");
     }
-    let bytes = w.finish().expect("finish");
-    let size = bytes.len() as u64;
-    store
-        .put(key, bytes::Bytes::from(bytes), PutOptions::default())
-        .await
-        .expect("put");
-    let min = records.iter().map(|r| r.ts_ns).min().expect("nonempty");
-    let max = records.iter().map(|r| r.ts_ns).max().expect("nonempty");
-    SegmentRef {
-        data_object_key: key.to_string(),
-        object_size: size,
-        min_event_ts_ns: min,
-        max_event_ts_ns: max,
-        ingest_hour_bucket: 0,
-        sample_count: records.len() as u64,
-        series_count: 0,
-        shard: 0,
-        content_hash: [0u8; 32],
-        writer_id: Uuid::from_u128(1),
-        writer_epoch: 1,
-        writer_seq: 1,
-        created_unix_ns: 0,
-        level: SegmentLevel::L0,
-    }
+    w.finish().expect("finish")
 }
 
 /// Small blocks so a corpus of a dozen records still spans several blocks,
@@ -304,6 +291,40 @@ fn small_blocks() -> RlogConfig {
     RlogConfig {
         block_target_records: 3,
         ..RlogConfig::default()
+    }
+}
+
+/// Put already-encoded RLOG bytes into `store` and describe them as a
+/// `SegmentRef`. Split out of [`write_object`] because one fixture needs an
+/// object the writer cannot produce (see `rewrite_single_block`).
+async fn put_object(
+    store: &MemoryStore,
+    key: &str,
+    bytes: Vec<u8>,
+    min: i64,
+    max: i64,
+    records: usize,
+) -> SegmentRef {
+    let size = bytes.len() as u64;
+    store
+        .put(key, bytes::Bytes::from(bytes), PutOptions::default())
+        .await
+        .expect("put");
+    SegmentRef {
+        data_object_key: key.to_string(),
+        object_size: size,
+        min_event_ts_ns: min,
+        max_event_ts_ns: max,
+        ingest_hour_bucket: 0,
+        sample_count: records as u64,
+        series_count: 0,
+        shard: 0,
+        content_hash: [0u8; 32],
+        writer_id: Uuid::from_u128(1),
+        writer_epoch: 1,
+        writer_seq: 1,
+        created_unix_ns: 0,
+        level: SegmentLevel::L0,
     }
 }
 
@@ -664,5 +685,181 @@ async fn attrs_raw_spill_falls_back_to_row_path_and_keeps_the_value() {
         got[0][1],
         Cell::OptStr(Some("spilled".to_string())),
         "the spilled declared value must survive the fallback"
+    );
+}
+
+/// A declared key set at BOTH resource and record level, which is where the
+/// merge's precedence is decided (ADR-0033: the record wins) and where a wrong
+/// variant must read NULL rather than falling through to the resource value
+/// (ADR-0090 decision 7).
+///
+/// Three rows, one per case, asserted on both paths:
+///
+/// - ts 0: resource sets `name`, the record sets it too -> the record's value;
+/// - ts 1: resource sets `name`, the record does not -> the resource's value;
+/// - ts 2: resource sets `name`, the record sets it as an `I64` -> NULL, not the
+///   resource value: the record does set the key, so the fallback is not
+///   consulted, and the value's variant does not match the declared type.
+///
+/// An implementation that inverted the precedence, or that fell through to the
+/// resource layer on a wrong-variant record value, produces a different answer
+/// for ts 0 and ts 2 respectively.
+#[tokio::test]
+async fn a_declared_key_set_at_both_levels_resolves_record_over_resource() {
+    let declared = declared_columns();
+    // Index 1 of `declared_columns()` is the `Str`-typed `name`.
+    let name_col = FIRST_DECLARED_COL + 1;
+    let projection = vec![0usize, name_col];
+
+    let resource = vec![("name".to_string(), AttrValue::Str("from-resource".into()))];
+    let mk = |ts: i64, attrs: Vec<(String, AttrValue)>| LogRecord {
+        stream_id: log_stream_id(&resource, "scope", "1.0", &[]),
+        stream_attrs: stream_attrs_bytes(&resource, "scope", "1.0", &[]),
+        ts_ns: ts,
+        observed_ts_ns: ts,
+        severity_num: 9,
+        severity_text: "INFO".into(),
+        body: "b".into(),
+        trace_id: None,
+        span_id: None,
+        flags: 0,
+        attrs,
+    };
+    let records = vec![
+        mk(
+            0,
+            vec![("name".to_string(), AttrValue::Str("from-record".into()))],
+        ),
+        mk(1, Vec::new()),
+        mk(2, vec![("name".to_string(), AttrValue::I64(7))]),
+    ];
+
+    let store = MemoryStore::new();
+    let seg = write_object(&store, "logs/collide.rlog", &records, RlogConfig::default()).await;
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(store);
+    let segments = vec![seg];
+
+    let want = vec![
+        vec![Cell::Ts(0), Cell::OptStr(Some("from-record".to_string()))],
+        vec![Cell::Ts(1), Cell::OptStr(Some("from-resource".to_string()))],
+        vec![Cell::Ts(2), Cell::OptStr(None)],
+    ];
+
+    let fast = run_scan(
+        Arc::clone(&store),
+        segments.clone(),
+        declared.clone(),
+        Some(projection.clone()),
+        Vec::new(),
+        Vec::new(),
+    )
+    .await;
+    assert!(fast.columnar_batches > 0, "the fast path must have run");
+    assert_eq!(fast.rowpath_batches, 0, "the fast path must not fall back");
+    assert_eq!(rows(&fast.batches, &projection, &declared), want);
+
+    let row = run_scan(
+        Arc::clone(&store),
+        segments,
+        declared.clone(),
+        Some(projection.clone()),
+        Vec::new(),
+        no_match_erasure(),
+    )
+    .await;
+    assert_eq!(
+        row.columnar_batches, 0,
+        "the forced run must take the row path"
+    );
+    assert!(row.rowpath_batches > 0, "the row path must have run");
+    assert_eq!(rows(&row.batches, &projection, &declared), want);
+}
+
+/// The `attrs_raw` fallback *mid-segment*: an earlier block is clean and a later
+/// one carries an overflow page, so the fast path emits block 0, then re-opens
+/// the segment on the row path and discards the blocks it already emitted.
+///
+/// That discard loop (`LogScanState::Rows`'s `skip`) is the one place in the
+/// columnar change where a row can be emitted twice or dropped, and a fixture of
+/// one block can never reach it: the fallback there fires on block 0 with
+/// `skip == 0`. Here `columnar_batches == 1` and `rowpath_batches == 1` prove
+/// both halves ran, and the `ts` multiset proves every row was emitted exactly
+/// once across the switch.
+///
+/// The spill is forced with `max_dynamic_columns = 1`: `filler` (earlier in the
+/// writer's `(name, type)` order) takes the single dynamic column, so `tags`
+/// overflows into `attrs_raw` -- but only in the block holding the two records
+/// that carry it, because a block whose records all fit their columns has no
+/// `attrs_raw` page at all.
+#[tokio::test]
+async fn a_later_block_with_attrs_raw_falls_back_without_losing_or_repeating_rows() {
+    let declared = vec![DeclaredColumn::new("tags", DeclaredType::Str)];
+    let resource = vec![("service.name".to_string(), AttrValue::Str("api".into()))];
+    let mk = |ts: i64, spilled: bool| LogRecord {
+        stream_id: log_stream_id(&resource, "scope", "1.0", &[]),
+        stream_attrs: stream_attrs_bytes(&resource, "scope", "1.0", &[]),
+        ts_ns: ts,
+        observed_ts_ns: ts,
+        severity_num: 9,
+        severity_text: "INFO".into(),
+        body: "b".into(),
+        trace_id: None,
+        span_id: None,
+        flags: 0,
+        attrs: {
+            let mut attrs = vec![("filler".to_string(), AttrValue::Str("f".into()))];
+            if spilled {
+                attrs.push(("tags".to_string(), AttrValue::Str(format!("spilled-{ts}"))));
+            }
+            attrs
+        },
+    };
+    // Blocks of two records: block 0 (ts 0, 1) is clean, block 1 (ts 2, 3)
+    // carries the `attrs_raw` page.
+    let records = vec![mk(0, false), mk(1, false), mk(2, true), mk(3, true)];
+    let cfg = RlogConfig {
+        block_target_records: 2,
+        max_dynamic_columns: 1,
+        ..RlogConfig::default()
+    };
+
+    let store = MemoryStore::new();
+    let seg = write_object(&store, "logs/midspill.rlog", &records, cfg).await;
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(store);
+
+    let projection = vec![0usize, FIRST_DECLARED_COL];
+    let run = run_scan(
+        store,
+        vec![seg],
+        declared.clone(),
+        Some(projection.clone()),
+        Vec::new(),
+        Vec::new(),
+    )
+    .await;
+
+    assert_eq!(
+        run.columnar_batches, 1,
+        "the clean first block must be emitted columnar; columnar={}, rowpath={}",
+        run.columnar_batches, run.rowpath_batches
+    );
+    assert_eq!(
+        run.rowpath_batches, 1,
+        "the spilled second block must be emitted by the re-opened row path; \
+         columnar={}, rowpath={}",
+        run.columnar_batches, run.rowpath_batches
+    );
+
+    let got = rows(&run.batches, &projection, &declared);
+    let want = vec![
+        vec![Cell::Ts(0), Cell::OptStr(None)],
+        vec![Cell::Ts(1), Cell::OptStr(None)],
+        vec![Cell::Ts(2), Cell::OptStr(Some("spilled-2".to_string()))],
+        vec![Cell::Ts(3), Cell::OptStr(Some("spilled-3".to_string()))],
+    ];
+    assert_eq!(
+        got, want,
+        "every row exactly once across the columnar/row switch, spilled values \
+         included"
     );
 }

--- a/crates/ravel-sql/tests/logs_columnar.rs
+++ b/crates/ravel-sql/tests/logs_columnar.rs
@@ -33,9 +33,18 @@ use datafusion::physical_plan::ExecutionPlan;
 use futures::StreamExt;
 use proptest::prelude::*;
 use ravel_catalog::{SegmentLevel, SegmentRef, Snapshot};
+use ravel_logseg::block::{ColumnPlan, write_block};
+use ravel_logseg::field_dir::FieldDir;
+use ravel_logseg::footer::{
+    COMP_NONE, LogFooter, SectionDesc, kind, open as open_footer, write_footer_and_trailer,
+};
+use ravel_logseg::reader::read_section;
+use ravel_logseg::record::{ColumnValue, ResolvedRow};
+use ravel_logseg::skip_index::{Level0Entry, SkipIndex};
 use ravel_logseg::writer::ObjectIdentity;
 use ravel_logseg::{
-    AttrValue, FieldSel, LogRecord, Predicate, RlogConfig, RlogWriter, stream_attrs_bytes,
+    AttrValue, FieldSel, FieldType, LogRecord, Predicate, RlogConfig, RlogWriter,
+    stream_attrs_bytes,
 };
 use ravel_object_store::memory::MemoryStore;
 use ravel_object_store::{ObjectStoreBackend, PutOptions};
@@ -861,5 +870,206 @@ async fn a_later_block_with_attrs_raw_falls_back_without_losing_or_repeating_row
         got, want,
         "every row exactly once across the columnar/row switch, spilled values \
          included"
+    );
+}
+
+// --- a declared `Str` cell that is not UTF-8 --------------------------------
+
+/// Rewrite one writer-produced RLOG object, replacing its single block with one
+/// whose dynamic column `column_id` holds `cells[i]` verbatim at row `i`.
+///
+/// `RlogWriter` cannot produce the fixture this exists for: a `Str` column cell
+/// that is not UTF-8. Its input is `AttrValue::Str(String)` and `resolve_value`
+/// carries those bytes through unchanged, so every `Str` cell it writes is valid
+/// by construction -- while a reader still has to decide what such a cell means,
+/// and the two batch-building paths must decide it the same way.
+///
+/// Everything except the block is the writer's own output: STREAM_DIR, FIELD_DIR
+/// and BLOOM are copied verbatim (bytes, `comp` and `uncomp_len` alike) and the
+/// footer keeps its identity and counters, because `rows` mirrors the object's
+/// records one for one. Only BLOCKS and the SKIP_IDX entry describing it are
+/// rebuilt, through `write_block` and `SkipIndex` themselves, so this carries no
+/// independent knowledge of any section's encoding. The stale BLOOM is harmless
+/// here: it is consulted only to prune on a content predicate, and this fixture
+/// pushes none.
+fn rewrite_str_column_cells(
+    obj: &[u8],
+    cfg: RlogConfig,
+    records: &[LogRecord],
+    column_id: u32,
+    cells: &[Vec<u8>],
+) -> Vec<u8> {
+    assert_eq!(records.len(), cells.len(), "one cell per record");
+    let footer = open_footer(obj).expect("open the writer's footer");
+
+    let rows: Vec<ResolvedRow> = records
+        .iter()
+        .zip(cells)
+        .map(|(r, cell)| ResolvedRow {
+            stream_ref: 0,
+            ts_ns: r.ts_ns,
+            observed_ts_ns: r.observed_ts_ns,
+            severity_num: r.severity_num,
+            severity_text: r.severity_text.clone(),
+            body: r.body.clone(),
+            trace_id: r.trace_id,
+            span_id: r.span_id,
+            flags: r.flags,
+            attrs_raw: None,
+            columns: vec![(column_id, ColumnValue::Str(cell.clone()))],
+            indexed_terms: Vec::new(),
+            stat_winners: Vec::new(),
+        })
+        .collect();
+    let plans = vec![ColumnPlan {
+        column_id,
+        ty: FieldType::Str,
+    }];
+    let block = write_block(&rows, &plans, cfg.zstd_level).expect("write one block");
+    let skip = SkipIndex::build(vec![Level0Entry {
+        block_offset: 0,
+        block_len: block.bytes.len() as u64,
+        block_crc32c: block.crc32c,
+        record_count: block.record_count,
+        min_ts: block.min_ts,
+        max_ts: block.max_ts,
+        min_stream_ref: block.min_stream_ref,
+        max_stream_ref: block.max_stream_ref,
+        stats: block.stats.clone(),
+    }])
+    .encode();
+
+    let mut out: Vec<u8> = Vec::new();
+    let mut sections: Vec<SectionDesc> = Vec::new();
+    for d in &footer.sections {
+        let (bytes, comp, uncomp_len) = match d.kind {
+            kind::BLOCKS => (block.bytes.clone(), COMP_NONE, block.bytes.len() as u64),
+            kind::SKIP_IDX => (skip.clone(), COMP_NONE, skip.len() as u64),
+            _ => {
+                let start = usize::try_from(d.offset).expect("offset fits");
+                let end = start + usize::try_from(d.len).expect("len fits");
+                (obj[start..end].to_vec(), d.comp, d.uncomp_len)
+            }
+        };
+        sections.push(SectionDesc {
+            kind: d.kind,
+            offset: out.len() as u64,
+            len: bytes.len() as u64,
+            crc32c: crc32c::crc32c(&bytes),
+            comp,
+            uncomp_len,
+        });
+        out.extend_from_slice(&bytes);
+    }
+    let patched = LogFooter { sections, ..footer };
+    write_footer_and_trailer(&mut out, &patched);
+    out
+}
+
+/// The `Str`-typed FIELD_DIR column id for `key` in `obj`.
+fn str_column_id(obj: &[u8], cfg: RlogConfig, key: &str) -> u32 {
+    let footer = open_footer(obj).expect("open footer");
+    let desc = *footer
+        .section(kind::FIELD_DIR)
+        .expect("a FIELD_DIR section");
+    let bytes = read_section(obj, &desc, &cfg).expect("read FIELD_DIR");
+    let dir = FieldDir::decode(&bytes, u64::MAX).expect("decode FIELD_DIR");
+    dir.column(key, FieldType::Str)
+        .expect("a Str column for the key")
+        .column_id
+}
+
+/// A declared `Str` cell whose bytes are not UTF-8 means the record does not set
+/// the key, so the resource value shows through -- on both paths.
+///
+/// The row path decides this in `ravel_logseg`'s `get_attr_value`
+/// (`String::from_utf8(b).ok()`): the attribute never enters the record, so the
+/// merged view resolves the key to the resource's value. The fast path used
+/// `String::from_utf8_lossy`, which reported the cell present (suppressing that
+/// fallback) and substituted U+FFFD -- two divergences and a silent
+/// approximation on a read path, from one line.
+///
+/// Row 0 holds `[0xff]` in the declared column while the resource sets the same
+/// key; row 1 holds a valid record value, so the fixture also shows the cell is
+/// still read when it is readable.
+#[tokio::test]
+async fn a_declared_str_cell_that_is_not_utf8_reads_as_absent_on_both_paths() {
+    let cfg = RlogConfig::default();
+    let declared = vec![DeclaredColumn::new("name", DeclaredType::Str)];
+    let resource = vec![("name".to_string(), AttrValue::Str("from-resource".into()))];
+    let mk = |ts: i64, name: &str| LogRecord {
+        stream_id: log_stream_id(&resource, "scope", "1.0", &[]),
+        stream_attrs: stream_attrs_bytes(&resource, "scope", "1.0", &[]),
+        ts_ns: ts,
+        observed_ts_ns: ts,
+        severity_num: 9,
+        severity_text: "INFO".into(),
+        body: "b".into(),
+        trace_id: None,
+        span_id: None,
+        flags: 0,
+        attrs: vec![("name".to_string(), AttrValue::Str(name.to_string()))],
+    };
+    // The placeholder at row 0 is replaced by `[0xff]` below; row 1 keeps its
+    // value, so both the readable and the unreadable case are in one block.
+    let records = vec![mk(0, "placeholder"), mk(1, "from-record")];
+
+    let clean = encode_object(&records, cfg);
+    let column_id = str_column_id(&clean, cfg, "name");
+    let patched = rewrite_str_column_cells(
+        &clean,
+        cfg,
+        &records,
+        column_id,
+        &[vec![0xff], b"from-record".to_vec()],
+    );
+
+    let store = MemoryStore::new();
+    let seg = put_object(&store, "logs/badutf8.rlog", patched, 0, 1, records.len()).await;
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(store);
+    let segments = vec![seg];
+
+    let projection = vec![0usize, FIRST_DECLARED_COL];
+    let want = vec![
+        vec![Cell::Ts(0), Cell::OptStr(Some("from-resource".to_string()))],
+        vec![Cell::Ts(1), Cell::OptStr(Some("from-record".to_string()))],
+    ];
+
+    let fast = run_scan(
+        Arc::clone(&store),
+        segments.clone(),
+        declared.clone(),
+        Some(projection.clone()),
+        Vec::new(),
+        Vec::new(),
+    )
+    .await;
+    assert!(fast.columnar_batches > 0, "the fast path must have run");
+    assert_eq!(fast.rowpath_batches, 0, "the fast path must not fall back");
+    let got = rows(&fast.batches, &projection, &declared);
+    assert_eq!(
+        got, want,
+        "invalid UTF-8 in a declared Str cell must read as absent, letting the \
+         resource value through, not as U+FFFD"
+    );
+
+    let row = run_scan(
+        Arc::clone(&store),
+        segments,
+        declared.clone(),
+        Some(projection.clone()),
+        Vec::new(),
+        no_match_erasure(),
+    )
+    .await;
+    assert_eq!(
+        row.columnar_batches, 0,
+        "the forced run must be the row path"
+    );
+    assert!(row.rowpath_batches > 0, "the row path must have run");
+    assert_eq!(
+        rows(&row.batches, &projection, &declared),
+        want,
+        "the row path's answer is the reference the fast path must match"
     );
 }

--- a/crates/ravel-sql/tests/logs_differential.rs
+++ b/crates/ravel-sql/tests/logs_differential.rs
@@ -941,6 +941,161 @@ async fn scan_rows(
     rows_from_batches(&batches)
 }
 
+/// A row of the fixed-column projection (no `attrs`), so the columnar fast path
+/// and the reference can be compared over the columns the fast path builds.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct ProjRow {
+    ts: i64,
+    observed_ts: i64,
+    severity_num: u8,
+    severity_text: String,
+    body: String,
+    trace_id: Option<Vec<u8>>,
+    span_id: Option<Vec<u8>>,
+    flags: u32,
+}
+
+impl From<&Row> for ProjRow {
+    fn from(r: &Row) -> Self {
+        ProjRow {
+            ts: r.ts,
+            observed_ts: r.observed_ts,
+            severity_num: r.severity_num,
+            severity_text: r.severity_text.clone(),
+            body: r.body.clone(),
+            trace_id: r.trace_id.clone(),
+            span_id: r.span_id.clone(),
+            flags: r.flags,
+        }
+    }
+}
+
+/// The block counters a scan published, and its rows over the fixed-column
+/// projection.
+struct ProjRun {
+    rows: Vec<ProjRow>,
+    columnar_batches: usize,
+    rowpath_batches: usize,
+}
+
+/// The `LogsScanExec` leaf of a physical plan, found by walking rather than by
+/// shape (the optimizer inserts a residual `FilterExec` and possibly a
+/// repartition above it).
+fn find_logs_scan(
+    plan: &Arc<dyn datafusion::physical_plan::ExecutionPlan>,
+) -> Option<Arc<dyn datafusion::physical_plan::ExecutionPlan>> {
+    if plan.name() == "LogsScanExec" {
+        return Some(Arc::clone(plan));
+    }
+    plan.children().iter().find_map(|c| find_logs_scan(c))
+}
+
+/// Run the same query with a fixed-column projection (no `attrs`), so a query
+/// with no attribute predicate takes the columnar fast path and one with an
+/// attribute predicate (which folds `attrs` into the scan projection) takes the
+/// row path. Returns the projected rows and both path metrics, so the gate can
+/// assert which path ran as well as that the output is correct.
+async fn scan_projected(
+    store: Arc<dyn ObjectStoreBackend>,
+    snapshot: Snapshot,
+    query: &QuerySpec,
+) -> ProjRun {
+    let fetcher = LogSegmentFetcher::new(store);
+    let provider = LogsTableProvider::new(
+        snapshot,
+        TenantHash([7u8; 16]),
+        fetcher,
+        QueryAccounting::new(),
+    );
+
+    let ctx = SessionContext::new();
+    let get_field = ScalarUDF::from(GetField::new());
+    let has_word = has_word_udf();
+    ctx.register_udf(get_field.clone());
+    ctx.register_udf(has_word.clone());
+    ctx.register_table("logs", Arc::new(provider))
+        .expect("register table");
+
+    let df = ctx.table("logs").await.expect("table");
+    let df = match query.to_filter(&get_field, &has_word) {
+        Some(filter) => df.filter(filter).expect("filter"),
+        None => df,
+    };
+    let df = df
+        .select_columns(&[
+            "ts",
+            "observed_ts",
+            "severity_num",
+            "severity_text",
+            "body",
+            "trace_id",
+            "span_id",
+            "flags",
+        ])
+        .expect("project fixed columns");
+    let plan = df.create_physical_plan().await.expect("physical plan");
+    let scan = find_logs_scan(&plan).expect("a LogsScanExec leaf");
+    let batches = collect(Arc::clone(&plan), Arc::new(TaskContext::default()))
+        .await
+        .expect("collect");
+
+    let metrics = scan.metrics().expect("scan metrics");
+    let count = |name: &str| metrics.sum_by_name(name).map(|v| v.as_usize()).unwrap_or(0);
+
+    let mut rows = Vec::new();
+    for batch in &batches {
+        let ts = col_ts(batch, 0);
+        let observed_ts = col_ts(batch, 1);
+        let severity_num = batch
+            .column(2)
+            .as_any()
+            .downcast_ref::<UInt8Array>()
+            .expect("severity_num");
+        let severity_text = batch
+            .column(3)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("severity_text");
+        let body = batch
+            .column(4)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("body");
+        let trace = batch
+            .column(5)
+            .as_any()
+            .downcast_ref::<FixedSizeBinaryArray>()
+            .expect("trace_id");
+        let span = batch
+            .column(6)
+            .as_any()
+            .downcast_ref::<FixedSizeBinaryArray>()
+            .expect("span_id");
+        let flags = batch
+            .column(7)
+            .as_any()
+            .downcast_ref::<UInt32Array>()
+            .expect("flags");
+        for i in 0..batch.num_rows() {
+            rows.push(ProjRow {
+                ts: ts.value(i),
+                observed_ts: observed_ts.value(i),
+                severity_num: severity_num.value(i),
+                severity_text: severity_text.value(i).to_string(),
+                body: body.value(i).to_string(),
+                trace_id: (!trace.is_null(i)).then(|| trace.value(i).to_vec()),
+                span_id: (!span.is_null(i)).then(|| span.value(i).to_vec()),
+                flags: flags.value(i),
+            });
+        }
+    }
+    ProjRun {
+        rows,
+        columnar_batches: count("columnar_batches"),
+        rowpath_batches: count("rowpath_batches"),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // The gate
 // ---------------------------------------------------------------------------
@@ -952,6 +1107,13 @@ proptest! {
     /// random ts-range / stream-attribute / has_word predicate combinations, the
     /// `logs` scan's output equals an independent record-by-record reference by
     /// exact multiset equality, every field byte-for-byte.
+    ///
+    /// Both scan paths are exercised (ADR-0099). The full-schema query projects
+    /// the `attrs` map, so it always takes the row path. A second run projects
+    /// only the fixed columns: with no attribute predicate it takes the columnar
+    /// fast path; with one, `attrs` folds back into the scan projection and it
+    /// takes the row path. Either way its output must match the reference's fixed
+    /// columns, and its published metric must name the path it took.
     #[test]
     fn scan_output_exactly_matches_reference_over_random_corpora_and_predicates(
         scenario in arb_scenario(),
@@ -980,6 +1142,40 @@ proptest! {
                 want.len()
             );
             prop_assert_eq!(&got, &want, "scan output must equal the reference exactly for query {:?}", query);
+
+            // The fixed-column projection, exercising the columnar fast path
+            // (and the row-path fallback when the query names an attribute).
+            let proj = scan_projected(Arc::clone(&backend), snapshot.clone(), &query).await;
+            let mut proj_got = proj.rows;
+            let mut proj_want: Vec<ProjRow> = want.iter().map(ProjRow::from).collect();
+            proj_got.sort();
+            proj_want.sort();
+            prop_assert_eq!(
+                &proj_got,
+                &proj_want,
+                "projected scan output must equal the reference for query {:?}",
+                query
+            );
+
+            // The projection carries no `attrs`, so the path is decided by
+            // whether the query names an attribute (which folds `attrs` back into
+            // the scan projection). An attribute predicate here is a stream-attr
+            // equality, evaluated through the `get_field` UDF residual.
+            if query.stream_attr.is_some() {
+                prop_assert_eq!(
+                    proj.columnar_batches, 0,
+                    "an attribute predicate must fold attrs in and take the row path"
+                );
+            } else if !proj_got.is_empty() {
+                prop_assert!(
+                    proj.columnar_batches > 0,
+                    "a fixed-only projection with no attribute predicate must take the fast path"
+                );
+                prop_assert_eq!(
+                    proj.rowpath_batches, 0,
+                    "the fast path must not fall back on this spill-free corpus"
+                );
+            }
             Ok(())
         })?;
     }

--- a/crates/ravel-sql/tests/logs_scan_allocations.rs
+++ b/crates/ravel-sql/tests/logs_scan_allocations.rs
@@ -1,0 +1,231 @@
+//! Allocation upper bound for the logs scan's columnar batch building (ADR-0099
+//! decision 2, issue #415).
+//!
+//! This file contains EXACTLY ONE test on purpose. The measurement is a
+//! `stats_alloc::Region` around the global allocator, so any other thread
+//! allocating while it is open would land in the count; `cargo test` and
+//! nextest both run test functions concurrently, so a second test in this
+//! binary would make the figure non-deterministic. The scan itself is driven on
+//! a current-thread tokio runtime for the same reason. This mirrors
+//! `tests/scan_batch_allocations.rs`, which bounds the metrics scan.
+//!
+//! The assertion is an upper bound per emitted 8192-row batch, not an equality:
+//! an unrelated small change must not fail it, but a return to per-record work
+//! on this path (rebuilding a `LogRecord` and calling `merged_attrs`, i.e. the
+//! row path this fast path exists to skip) blows through it by orders of
+//! magnitude.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::alloc::System;
+use std::sync::Arc;
+
+use datafusion::execution::TaskContext;
+use datafusion::physical_plan::ExecutionPlan;
+use futures::StreamExt;
+use ravel_catalog::{SegmentLevel, SegmentRef};
+use ravel_logseg::writer::ObjectIdentity;
+use ravel_logseg::{AttrValue, LogRecord, RlogConfig, RlogWriter, stream_attrs_bytes};
+use ravel_object_store::memory::MemoryStore;
+use ravel_object_store::{ObjectStoreBackend, PutOptions};
+use ravel_query::LogSegmentFetcher;
+use ravel_sql::{LogsScanExec, logs_schema_with_declared};
+use ravel_types::TenantHash;
+use ravel_types::accounting::QueryAccounting;
+use ravel_types::logstream::log_stream_id;
+use stats_alloc::{INSTRUMENTED_SYSTEM, Region, StatsAlloc};
+use uuid::Uuid;
+
+#[global_allocator]
+static GLOBAL: &StatsAlloc<System> = &INSTRUMENTED_SYSTEM;
+
+const TENANT: TenantHash = TenantHash([7u8; 16]);
+
+/// `LogsScanExec::BATCH_ROWS`, which is also the default RLOG block target, so
+/// each written block decodes to exactly one full output batch.
+const BATCH_ROWS: usize = 8192;
+/// 30 full batches: 30 blocks of one full batch each, at the default block
+/// target.
+const RECORDS: usize = BATCH_ROWS * 30;
+
+/// Allocations one 8192-row batch may cost on the columnar fast path, over a
+/// numeric fixed-column projection (`ts`, `observed_ts`, `severity_num`,
+/// `flags`). Each is an i64-backed column the block decodes into one contiguous
+/// buffer, so the fast path builds each output batch from a bounded number of
+/// Arrow buffers (one `Vec` gather plus the arrow array per column) and does no
+/// per-record work at all: allocations per batch are O(columns), not O(rows).
+///
+/// The projection is numeric on purpose. `body` and `severity_text` are stored
+/// as `Vec<Option<Vec<u8>>>` in `ravel_logseg`'s `DecodedBlock`, one owned
+/// allocation per cell, so decoding either costs ~1 allocation per row *before*
+/// any batch is built -- a property of the block decode both scan paths share,
+/// not of the fast path this bound exists to characterize. Projecting them would
+/// swamp the batch-building figure with decode allocations and measure the wrong
+/// thing; the metrics scan's allocation test bounds only numeric columns for the
+/// same reason.
+///
+/// A regression that reintroduced per-record work on this path (rebuilding a
+/// `LogRecord` and calling `merged_attrs` per row, i.e. the row path) would be
+/// three orders of magnitude above this bound. Measured at 51 on this fixture;
+/// the bound is set with headroom over that.
+const MAX_ALLOCS_PER_BATCH: usize = 80;
+
+fn identity() -> ObjectIdentity {
+    ObjectIdentity {
+        tenant_hash: TENANT.0,
+        shard: 0,
+        writer_id: [2u8; 16],
+        writer_epoch: 1,
+        writer_seq: 1,
+    }
+}
+
+/// One record with a resource attribute and one dynamic attribute. The fast
+/// path touches neither; they are present so a regression to the row path pays
+/// their full `merged_attrs` cost and trips the bound.
+fn record(i: usize) -> LogRecord {
+    let resource = vec![(
+        "service.name".to_string(),
+        AttrValue::Str(format!("svc-{}", i % 8)),
+    )];
+    LogRecord {
+        stream_id: log_stream_id(&resource, "scope", "1.0", &[]),
+        stream_attrs: stream_attrs_bytes(&resource, "scope", "1.0", &[]),
+        ts_ns: i as i64,
+        observed_ts_ns: i as i64,
+        severity_num: (i % 24) as u8,
+        severity_text: "INFO".to_string(),
+        body: format!("request {} completed", i % 997),
+        trace_id: Some([(i % 251) as u8; 16]),
+        span_id: Some([(i % 251) as u8; 8]),
+        flags: i as u32,
+        attrs: vec![("user_id".to_string(), AttrValue::Str(format!("u{i}")))],
+    }
+}
+
+/// One RLOG object, `RECORDS` records, default block target: `RECORDS /
+/// BATCH_ROWS` full blocks, each a single spill-free block the fast path
+/// consumes.
+async fn fixture() -> (Arc<dyn ObjectStoreBackend>, Vec<SegmentRef>) {
+    let store = MemoryStore::new();
+    let mut w = RlogWriter::new(RlogConfig::default(), identity());
+    for i in 0..RECORDS {
+        w.push(record(i)).expect("push");
+    }
+    let bytes = w.finish().expect("finish");
+    let size = bytes.len() as u64;
+    let key = "logs/alloc.rlog";
+    store
+        .put(key, bytes::Bytes::from(bytes), PutOptions::default())
+        .await
+        .expect("put");
+    let seg = SegmentRef {
+        data_object_key: key.to_string(),
+        object_size: size,
+        min_event_ts_ns: 0,
+        max_event_ts_ns: (RECORDS - 1) as i64,
+        ingest_hour_bucket: 0,
+        sample_count: RECORDS as u64,
+        series_count: 0,
+        shard: 0,
+        content_hash: [0u8; 32],
+        writer_id: Uuid::from_u128(1),
+        writer_epoch: 1,
+        writer_seq: 1,
+        created_unix_ns: 0,
+        level: SegmentLevel::L0,
+    };
+    (Arc::new(store), vec![seg])
+}
+
+/// Drain the columnar fast path (fixed-column projection, no erasure), returning
+/// (batches, rows, columnar_batches, rowpath_batches).
+async fn drain(
+    store: Arc<dyn ObjectStoreBackend>,
+    segments: &[SegmentRef],
+) -> (usize, usize, usize, usize) {
+    let scan = LogsScanExec::new(
+        TENANT,
+        LogSegmentFetcher::new(store),
+        segments,
+        1,
+        i64::MIN,
+        i64::MAX,
+        Arc::new(Vec::new()),
+        Arc::new(Vec::new()),
+        Arc::new(Vec::new()),
+        // ts, observed_ts, severity_num, flags: numeric fixed columns, so the
+        // query is columnar-eligible and no per-cell string decode is charged.
+        Some(&vec![0usize, 1, 2, 7]),
+        QueryAccounting::new(),
+        logs_schema_with_declared(&[]),
+        Arc::new(Vec::new()),
+    )
+    .expect("build scan");
+    let mut stream = scan
+        .execute(0, Arc::new(TaskContext::default()))
+        .expect("execute scan");
+    let mut batches = 0;
+    let mut rows = 0;
+    while let Some(next) = stream.next().await {
+        let batch = next.expect("batch");
+        batches += 1;
+        rows += batch.num_rows();
+    }
+    let metrics = scan.metrics().expect("metrics");
+    let count = |name: &str| metrics.sum_by_name(name).map(|v| v.as_usize()).unwrap_or(0);
+    (
+        batches,
+        rows,
+        count("columnar_batches"),
+        count("rowpath_batches"),
+    )
+}
+
+#[test]
+fn logs_scan_allocations_per_batch_stay_bounded() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+    let (store, segments) = rt.block_on(fixture());
+
+    // One untimed warm run outside the region: the first scan of a process
+    // initializes DataFusion's lazily-built state, and those allocations belong
+    // to no batch.
+    let warm = rt.block_on(drain(Arc::clone(&store), &segments));
+    assert_eq!(warm.1, RECORDS, "the warm run must emit every record");
+    assert_eq!(warm.3, 0, "the warm run must take the columnar fast path");
+    assert!(warm.2 > 0, "the warm run must build columnar batches");
+
+    let region = Region::new(&INSTRUMENTED_SYSTEM);
+    let (batches, rows, columnar, rowpath) = rt.block_on(drain(store, &segments));
+    let stats = region.change();
+
+    assert_eq!(rows, RECORDS, "every written record must be emitted");
+    assert_eq!(batches, 30, "the fixture must emit 30 full batches");
+    assert_eq!(
+        rowpath, 0,
+        "the measured run must not fall back to the row path"
+    );
+    assert_eq!(
+        columnar, batches,
+        "every measured batch must come from the columnar fast path"
+    );
+
+    let per_batch = stats.allocations / batches;
+    let bytes_per_batch = stats.bytes_allocated / batches;
+    eprintln!(
+        "logs_scan_allocations: {rows} rows in {batches} batches, \
+         {} allocations ({} bytes) total, {per_batch} allocations/batch, \
+         {bytes_per_batch} bytes/batch",
+        stats.allocations, stats.bytes_allocated,
+    );
+    assert!(
+        per_batch <= MAX_ALLOCS_PER_BATCH,
+        "batch building must stay columnar: {per_batch} allocations per \
+         {BATCH_ROWS}-row batch exceeds the {MAX_ALLOCS_PER_BATCH} bound \
+         ({} allocations over {batches} batches)",
+        stats.allocations,
+    );
+}

--- a/crates/ravel-sql/tests/memory_accounting.rs
+++ b/crates/ravel-sql/tests/memory_accounting.rs
@@ -330,10 +330,14 @@ async fn a_query_that_outgrows_its_pool_still_releases_tenant_bytes() {
 // The tests above all drive the `samples` (metrics) scan, whose reservation
 // holds decoded SoA plus one row-built batch. They never touch the `logs` scan,
 // so before this section the return-to-zero property was unproven for what the
-// columnar fast path holds instead: a block's *pre-built* `RecordBatch`es
+// columnar fast path holds instead: the decoded block still resident behind the
+// view plus that block's *pre-built* `RecordBatch`es
 // (`hold_batches`/`emit_next_columnar_batch`), charged once and relabelled from
 // `held` to `emitted` rather than regrown. That release path is arithmetically
 // different from the row path's, and a leak in it would have shown nowhere.
+// Balance alone is not enough, though: the second test here pins the magnitude,
+// which is what catches a charge that balances but covers a fraction of what is
+// held.
 //
 // This test drives it end to end: a fixed-column `logs` query is columnar-
 // eligible, and asserting `columnar_batches > 0` proves the fast path actually
@@ -369,9 +373,32 @@ fn log_record(i: usize) -> LogRecord {
     }
 }
 
-/// Write one RLOG object of `LOG_RECORDS` records into `store` and return a
-/// snapshot over it.
-async fn write_logs(store: &Arc<dyn ObjectStoreBackend>) -> Snapshot {
+/// Records for the two-path magnitude fixture: exactly one block at RLOG's
+/// default 8192-record block target, so one block's charge *is* the peak and
+/// the two paths' peaks are directly comparable.
+const ONE_BLOCK_RECORDS: usize = 8192;
+
+/// A pending erasure whose key exists in no record of this fixture. Any pending
+/// erasure makes a scan columnar-ineligible (ADR-0099 decision 2), so this
+/// drains the row path over the identical projection while erasing nothing --
+/// same data, same rows, same output, only the path differs.
+fn no_match_erasure() -> Vec<ravel_proto::commit::v1::ErasureRequest> {
+    vec![ravel_proto::commit::v1::ErasureRequest {
+        predicate: vec![ravel_proto::commit::v1::ErasurePredicateMatcher {
+            key: "__does_not_exist__".to_string(),
+            value: "__nope__".to_string(),
+        }],
+        ..Default::default()
+    }]
+}
+
+/// Write one RLOG object of `records` records into `store` and return a
+/// snapshot over it, carrying `erasure` as the snapshot's pending erasure.
+async fn write_logs(
+    store: &Arc<dyn ObjectStoreBackend>,
+    records: usize,
+    erasure: Vec<ravel_proto::commit::v1::ErasureRequest>,
+) -> Snapshot {
     let identity = ObjectIdentity {
         tenant_hash: [7u8; 16],
         shard: 0,
@@ -380,7 +407,7 @@ async fn write_logs(store: &Arc<dyn ObjectStoreBackend>) -> Snapshot {
         writer_seq: 1,
     };
     let mut w = RlogWriter::new(RlogConfig::default(), identity);
-    for i in 0..LOG_RECORDS {
+    for i in 0..records {
         w.push(log_record(i)).expect("push");
     }
     let bytes = w.finish().expect("finish");
@@ -395,9 +422,9 @@ async fn write_logs(store: &Arc<dyn ObjectStoreBackend>) -> Snapshot {
             data_object_key: key.to_string(),
             object_size: size,
             min_event_ts_ns: 0,
-            max_event_ts_ns: (LOG_RECORDS - 1) as i64,
+            max_event_ts_ns: records.saturating_sub(1) as i64,
             ingest_hour_bucket: 0,
-            sample_count: LOG_RECORDS as u64,
+            sample_count: records as u64,
             series_count: 0,
             shard: 0,
             content_hash: [0u8; 32],
@@ -408,7 +435,7 @@ async fn write_logs(store: &Arc<dyn ObjectStoreBackend>) -> Snapshot {
             level: SegmentLevel::L0,
         }],
         segments_pruned: 0,
-        pending_erasure: Vec::new(),
+        pending_erasure: erasure,
     }
 }
 
@@ -426,19 +453,24 @@ fn find_logs_scan(plan: &Arc<dyn ExecutionPlan>) -> Option<Arc<dyn ExecutionPlan
 /// `LogsScanExec` leaf that prove which batch-building path ran.
 struct LogsDrain {
     batches: usize,
+    rows: usize,
     peak: usize,
     columnar: usize,
     rowpath: usize,
 }
 
-/// Drain one `logs` query through a pool the test owns.
+/// Drain one `logs` query over a fixture of `records` records through a pool the
+/// test owns, with `erasure` as the snapshot's pending erasure (empty leaves the
+/// query columnar-eligible).
 async fn drain_logs(
     store: Arc<dyn ObjectStoreBackend>,
     tenant: &TenantId,
     pool: Arc<dyn MemoryPool>,
     sql: &str,
+    records: usize,
+    erasure: Vec<ravel_proto::commit::v1::ErasureRequest>,
 ) -> LogsDrain {
-    let snapshot = write_logs(&store).await;
+    let snapshot = write_logs(&store, records, erasure).await;
     let provider = Arc::new(LogsTableProvider::new(
         snapshot,
         tenant.hash(),
@@ -464,10 +496,12 @@ async fn drain_logs(
     let mut stream = execute_stream(Arc::clone(&plan), ctx.task_ctx()).expect("execute");
 
     let mut batches = 0usize;
+    let mut rows = 0usize;
     let mut peak = 0usize;
     while let Some(next) = stream.next().await {
-        let _batch = next.expect("batch");
+        let batch = next.expect("batch");
         batches += 1;
+        rows += batch.num_rows();
         peak = peak.max(pool.reserved());
     }
     drop(stream);
@@ -476,6 +510,7 @@ async fn drain_logs(
     let count = |name: &str| metrics.sum_by_name(name).map(|v| v.as_usize()).unwrap_or(0);
     LogsDrain {
         batches,
+        rows,
         peak,
         columnar: count("columnar_batches"),
         rowpath: count("rowpath_batches"),
@@ -489,11 +524,13 @@ async fn drain_logs(
 /// `repeated_multi_batch_queries_do_not_accumulate_tenant_bytes` uses for the
 /// metrics scan).
 ///
-/// This is the return-to-zero property for what the fast path holds: a block's
-/// pre-built `RecordBatch`es (`hold_batches`/`emit_next_columnar_batch`), charged
-/// once and relabelled from `held` to `emitted`, not a `Vec<LogRecord>`. The
-/// metrics-scan tests above never touch the logs scan, so before this case that
-/// release path was unexercised here.
+/// This is the return-to-zero property for what the fast path holds: the decoded
+/// block plus its pre-built `RecordBatch`es
+/// (`hold_batches`/`emit_next_columnar_batch`), charged once together and
+/// relabelled from `held` to `emitted` batch by batch, not a `Vec<LogRecord>`.
+/// The metrics-scan tests above never touch the logs scan, so before this case
+/// that release path was unexercised here. The magnitude of that charge is the
+/// next test's job.
 ///
 /// There is deliberately no "reserved bytes grew across batches" assertion like
 /// the metrics scan's: the logs scan is block-at-a-time (ADR-0087) and releases
@@ -521,6 +558,8 @@ async fn repeated_logs_columnar_queries_return_every_reserved_byte() {
             &tenant,
             Arc::clone(&pool),
             "SELECT ts, body FROM logs",
+            LOG_RECORDS,
+            Vec::new(),
         )
         .await;
 
@@ -559,4 +598,104 @@ async fn repeated_logs_columnar_queries_return_every_reserved_byte() {
              one query's blocks would accumulate across rounds"
         );
     }
+}
+
+/// How far below the row path's peak the columnar path's peak may sit for the
+/// same data before this test calls it an undercharge.
+///
+/// The two paths hold different things, so their peaks are not equal and pinning
+/// a ratio exactly would be a change detector: the row path holds a
+/// `Vec<LogRecord>` (a per-record struct, a cloned STREAM_DIR blob and an owned
+/// `String` per record), the columnar path holds the decoded block plus the
+/// Arrow batches built from it. On this fixture the columnar peak is a little
+/// under half the row path's, so a factor of 3 leaves room in both directions
+/// while still failing the defect it exists to catch: charging the batches
+/// alone put the columnar peak at under a quarter of the row path's.
+const MAX_COLUMNAR_UNDERCHARGE: usize = 3;
+
+/// The columnar path's pool charge must be the same order of magnitude as the
+/// row path's for the same data, because it holds the same data.
+///
+/// This is the magnitude half of the fast path's accounting, which return-to-zero
+/// cannot see: a charge of one byte per block balances perfectly. The fixture is
+/// one 8192-record block and the identical projection (`ts, body`) on both runs,
+/// with the row path forced by a pending erasure that matches no record, so the
+/// two runs differ in nothing but the batch-building path. `rows` proves that.
+///
+/// The defect this catches: the columnar path holds a view *borrowing*
+/// `BlockScan`'s decoded block, which the reader releases only when the next
+/// block is decoded, so the block is resident for as long as its batches drain.
+/// Charging only the batches admitted a tenant at 24% of the row path's figure
+/// for identical data, which is what a `peak > 0` assertion cannot distinguish
+/// from a correct charge.
+#[tokio::test]
+async fn the_columnar_path_charges_the_same_order_of_bytes_as_the_row_path() {
+    let tenant = tenant_id("acme");
+    let sql = "SELECT ts, body FROM logs";
+
+    let accountant = TenantMemoryAccountant::new(1 << 30);
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+    let (pool, _breach) =
+        SqlConfig::default().query_pool(Arc::clone(&accountant), QueryAccounting::new());
+    let fast = drain_logs(
+        Arc::clone(&store),
+        &tenant,
+        Arc::clone(&pool),
+        sql,
+        ONE_BLOCK_RECORDS,
+        Vec::new(),
+    )
+    .await;
+    assert_eq!(
+        pool.reserved(),
+        0,
+        "the columnar run must release its bytes"
+    );
+
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+    let (pool, _breach) =
+        SqlConfig::default().query_pool(Arc::clone(&accountant), QueryAccounting::new());
+    let row = drain_logs(
+        Arc::clone(&store),
+        &tenant,
+        Arc::clone(&pool),
+        sql,
+        ONE_BLOCK_RECORDS,
+        no_match_erasure(),
+    )
+    .await;
+    assert_eq!(pool.reserved(), 0, "the row run must release its bytes");
+
+    // Both runs must have taken the path this comparison names them for,
+    // otherwise the ratio below compares one path against itself.
+    assert!(
+        fast.columnar > 0 && fast.rowpath == 0,
+        "the eligible run must be columnar: columnar={}, rowpath={}",
+        fast.columnar,
+        fast.rowpath
+    );
+    assert!(
+        row.rowpath > 0 && row.columnar == 0,
+        "the erasure-forced run must be the row path: columnar={}, rowpath={}",
+        row.columnar,
+        row.rowpath
+    );
+    // Same data through both, so the peaks are comparable.
+    assert_eq!(
+        fast.rows, row.rows,
+        "the two paths must emit the same rows for the ratio to mean anything"
+    );
+    assert_eq!(fast.rows, ONE_BLOCK_RECORDS);
+    assert!(fast.peak > 0 && row.peak > 0);
+
+    assert!(
+        fast.peak * MAX_COLUMNAR_UNDERCHARGE >= row.peak,
+        "the columnar path's peak charge ({} bytes) is more than \
+         {MAX_COLUMNAR_UNDERCHARGE}x below the row path's ({} bytes) for the \
+         identical block and projection, so the pool is not bounding what the \
+         scan actually holds (ADR-0087 decision 2). The decoded block stays \
+         resident behind the view while its batches drain; charge it.",
+        fast.peak,
+        row.peak
+    );
 }

--- a/crates/ravel-sql/tests/memory_accounting.rs
+++ b/crates/ravel-sql/tests/memory_accounting.rs
@@ -25,14 +25,23 @@ mod util;
 use std::sync::Arc;
 
 use datafusion::execution::memory_pool::MemoryPool;
+use datafusion::physical_plan::{ExecutionPlan, execute_stream};
 use futures::StreamExt;
-use ravel_query::SegmentFetcher;
+use ravel_catalog::{SegmentLevel, SegmentRef, Snapshot};
+use ravel_logseg::writer::ObjectIdentity;
+use ravel_logseg::{AttrValue, LogRecord, RlogConfig, RlogWriter, stream_attrs_bytes};
+use ravel_object_store::memory::MemoryStore;
+use ravel_object_store::{ObjectStoreBackend, PutOptions};
+use ravel_query::{LogSegmentFetcher, SegmentFetcher};
 use ravel_sql::{
-    RavelTableProvider, SessionTable, SqlConfig, TenantMemoryAccountant, build_session,
+    LogsTableProvider, RavelTableProvider, SessionTable, SqlConfig, TenantMemoryAccountant,
+    build_session,
 };
 use ravel_types::TenantId;
 use ravel_types::accounting::QueryAccounting;
+use ravel_types::logstream::log_stream_id;
 use util::{Fixture, SegSpec, SeriesSpec, request, tenant_id};
+use uuid::Uuid;
 
 /// Comfortably more than `RsegScanExec`'s 8192-row batch size, so the scan
 /// emits several batches from one partition.
@@ -312,4 +321,242 @@ async fn a_query_that_outgrows_its_pool_still_releases_tenant_bytes() {
         0,
         "a query that failed on its own budget must not leak tenant bytes"
     );
+}
+
+// ---------------------------------------------------------------------------
+// The `logs` columnar fast path (ADR-0099 decision 2, issue #415)
+// ---------------------------------------------------------------------------
+//
+// The tests above all drive the `samples` (metrics) scan, whose reservation
+// holds decoded SoA plus one row-built batch. They never touch the `logs` scan,
+// so before this section the return-to-zero property was unproven for what the
+// columnar fast path holds instead: a block's *pre-built* `RecordBatch`es
+// (`hold_batches`/`emit_next_columnar_batch`), charged once and relabelled from
+// `held` to `emitted` rather than regrown. That release path is arithmetically
+// different from the row path's, and a leak in it would have shown nowhere.
+//
+// This test drives it end to end: a fixed-column `logs` query is columnar-
+// eligible, and asserting `columnar_batches > 0` proves the fast path actually
+// ran (so the test is not silently reduced to the row path), while the peak /
+// return-to-zero assertions prove the columnar release path balances.
+
+/// Records for the logs fixture. Several full blocks at RLOG's default 8192-row
+/// block target, so the columnar path holds and releases more than one block and
+/// the reserved figure accumulates across them.
+const LOG_RECORDS: usize = 40_000;
+
+/// One log record with a resource attribute and a dynamic attribute. The
+/// fixed-column fast path touches neither, but they are present so the corpus is
+/// realistic and a regression that folded `attrs` into the projection would
+/// change the reserved figures.
+fn log_record(i: usize) -> LogRecord {
+    let resource = vec![(
+        "service.name".to_string(),
+        AttrValue::Str(format!("svc-{}", i % 8)),
+    )];
+    LogRecord {
+        stream_id: log_stream_id(&resource, "scope", "1.0", &[]),
+        stream_attrs: stream_attrs_bytes(&resource, "scope", "1.0", &[]),
+        ts_ns: i as i64,
+        observed_ts_ns: i as i64,
+        severity_num: (i % 24) as u8,
+        severity_text: "INFO".to_string(),
+        body: format!("request {} completed", i % 997),
+        trace_id: None,
+        span_id: None,
+        flags: i as u32,
+        attrs: vec![("user_id".to_string(), AttrValue::Str(format!("u{i}")))],
+    }
+}
+
+/// Write one RLOG object of `LOG_RECORDS` records into `store` and return a
+/// snapshot over it.
+async fn write_logs(store: &Arc<dyn ObjectStoreBackend>) -> Snapshot {
+    let identity = ObjectIdentity {
+        tenant_hash: [7u8; 16],
+        shard: 0,
+        writer_id: [2u8; 16],
+        writer_epoch: 1,
+        writer_seq: 1,
+    };
+    let mut w = RlogWriter::new(RlogConfig::default(), identity);
+    for i in 0..LOG_RECORDS {
+        w.push(log_record(i)).expect("push");
+    }
+    let bytes = w.finish().expect("finish");
+    let size = bytes.len() as u64;
+    let key = "logs/accounting.rlog";
+    store
+        .put(key, bytes::Bytes::from(bytes), PutOptions::default())
+        .await
+        .expect("put");
+    Snapshot {
+        segments: vec![SegmentRef {
+            data_object_key: key.to_string(),
+            object_size: size,
+            min_event_ts_ns: 0,
+            max_event_ts_ns: (LOG_RECORDS - 1) as i64,
+            ingest_hour_bucket: 0,
+            sample_count: LOG_RECORDS as u64,
+            series_count: 0,
+            shard: 0,
+            content_hash: [0u8; 32],
+            writer_id: Uuid::from_u128(1),
+            writer_epoch: 1,
+            writer_seq: 1,
+            created_unix_ns: 0,
+            level: SegmentLevel::L0,
+        }],
+        segments_pruned: 0,
+        pending_erasure: Vec::new(),
+    }
+}
+
+/// The `LogsScanExec` leaf of a physical plan, found by walking rather than by
+/// shape: the optimizer inserts operators above it.
+fn find_logs_scan(plan: &Arc<dyn ExecutionPlan>) -> Option<Arc<dyn ExecutionPlan>> {
+    if plan.name() == "LogsScanExec" {
+        return Some(Arc::clone(plan));
+    }
+    plan.children().iter().find_map(|c| find_logs_scan(c))
+}
+
+/// The outcome of one columnar `logs` drain: how many batches it emitted, the
+/// peak bytes the pool held mid-stream, and the two path metrics from the
+/// `LogsScanExec` leaf that prove which batch-building path ran.
+struct LogsDrain {
+    batches: usize,
+    peak: usize,
+    columnar: usize,
+    rowpath: usize,
+}
+
+/// Drain one `logs` query through a pool the test owns.
+async fn drain_logs(
+    store: Arc<dyn ObjectStoreBackend>,
+    tenant: &TenantId,
+    pool: Arc<dyn MemoryPool>,
+    sql: &str,
+) -> LogsDrain {
+    let snapshot = write_logs(&store).await;
+    let provider = Arc::new(LogsTableProvider::new(
+        snapshot,
+        tenant.hash(),
+        LogSegmentFetcher::new(store),
+        QueryAccounting::new(),
+    ));
+    let ctx = build_session(
+        &SqlConfig::default(),
+        Arc::clone(&pool),
+        SessionTable::Logs(provider),
+        false,
+    )
+    .expect("session");
+
+    let plan = ctx
+        .sql(sql)
+        .await
+        .expect("plan")
+        .create_physical_plan()
+        .await
+        .expect("physical plan");
+    let scan = find_logs_scan(&plan).expect("a LogsScanExec leaf");
+    let mut stream = execute_stream(Arc::clone(&plan), ctx.task_ctx()).expect("execute");
+
+    let mut batches = 0usize;
+    let mut peak = 0usize;
+    while let Some(next) = stream.next().await {
+        let _batch = next.expect("batch");
+        batches += 1;
+        peak = peak.max(pool.reserved());
+    }
+    drop(stream);
+
+    let metrics = scan.metrics().expect("scan metrics");
+    let count = |name: &str| metrics.sum_by_name(name).map(|v| v.as_usize()).unwrap_or(0);
+    LogsDrain {
+        batches,
+        peak,
+        columnar: count("columnar_batches"),
+        rowpath: count("rowpath_batches"),
+    }
+}
+
+/// A fixed-column `logs` query takes the columnar fast path, holds real bytes
+/// while streaming, and returns every one of them once the stream drops -- three
+/// times over against one tenant accountant, so a leak of even one block's
+/// batches per query would accumulate and show (the pattern
+/// `repeated_multi_batch_queries_do_not_accumulate_tenant_bytes` uses for the
+/// metrics scan).
+///
+/// This is the return-to-zero property for what the fast path holds: a block's
+/// pre-built `RecordBatch`es (`hold_batches`/`emit_next_columnar_batch`), charged
+/// once and relabelled from `held` to `emitted`, not a `Vec<LogRecord>`. The
+/// metrics-scan tests above never touch the logs scan, so before this case that
+/// release path was unexercised here.
+///
+/// There is deliberately no "reserved bytes grew across batches" assertion like
+/// the metrics scan's: the logs scan is block-at-a-time (ADR-0087) and releases
+/// each block before decoding the next, so its reserved figure is bounded by one
+/// block, not cumulative. Non-vacuity comes from `columnar > 0` (the fast path
+/// actually ran), `peak > 0` (it reserved real bytes), and the cross-round
+/// accountant check (a surviving leak accumulates), not from growth.
+#[tokio::test]
+async fn repeated_logs_columnar_queries_return_every_reserved_byte() {
+    let tenant = tenant_id("acme");
+
+    let accountant = TenantMemoryAccountant::new(1 << 30);
+    for round in 0..3 {
+        let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+        let (pool, _breach) =
+            SqlConfig::default().query_pool(Arc::clone(&accountant), QueryAccounting::new());
+        assert_eq!(
+            pool.reserved(),
+            0,
+            "round {round}: a fresh pool starts empty"
+        );
+
+        let run = drain_logs(
+            Arc::clone(&store),
+            &tenant,
+            Arc::clone(&pool),
+            "SELECT ts, body FROM logs",
+        )
+        .await;
+
+        assert!(
+            run.batches > 1,
+            "round {round}: the test is meaningless with one batch; got {}",
+            run.batches
+        );
+        assert!(
+            run.columnar > 0,
+            "round {round}: the query must take the columnar fast path, else this \
+             case asserts nothing about it; columnar={}, rowpath={}",
+            run.columnar,
+            run.rowpath
+        );
+        assert_eq!(
+            run.rowpath, 0,
+            "round {round}: a fixed-column, spill-free query must not fall back \
+             to the row path"
+        );
+        assert!(
+            run.peak > 0,
+            "round {round}: the fast path must reserve real bytes for its held \
+             block's batches"
+        );
+        assert_eq!(
+            pool.reserved(),
+            0,
+            "round {round}: the query pool must return to zero once the columnar \
+             stream drops"
+        );
+        assert_eq!(
+            accountant.reserved(),
+            0,
+            "round {round}: the tenant accountant must be back to zero; a leak of \
+             one query's blocks would accumulate across rounds"
+        );
+    }
 }


### PR DESCRIPTION
The logs SQL scan decoded each RLOG block into columnar form, rebuilt
every surviving row as a LogRecord, merged its attributes against the
stream blob once per record, and only then copied each cell into an Arrow
builder. A string cell crossed four allocations on the way.

For projections that touch only fixed and declared typed columns, the
scan now gathers Arrow arrays straight from the columnar block view added
by #413. Declared columns resolve to their FIELD_DIR column id once per
block rather than through a per-row attribute search.

The fast path is taken only when the projection excludes the attrs map,
the block carries no attrs_raw overflow page, and no erasure predicate is
pending. The erasure clause fails closed on purpose: erasure decides
whether an erased record reaches a client, and columnar erasure
evaluation is a separate change. Two partition metrics, columnar_batches
and rowpath_batches, make the chosen path visible in EXPLAIN ANALYZE and
assertable in tests, since the two paths produce identical output by
construction.

The reservation charges the built batches plus the decoded block the view
borrows, because that block stays resident until the next one is decoded.
Charging only the batches would admit a query at a fraction of its real
footprint and break what ADR-0087 says the pool bounds.

Measured at an identical ts, body projection over 40,000 records, with
the row path forced by a no-match erasure predicate: 3.21 ms against
9.46 ms, so about 3x, and that is an upper bound because the
erasure-forced arm also pays a merged_attrs pass no eligible query pays.
A fast-path batch allocates 51 times per 8192 rows.

Fixes: #415
Refs: #360

---

Gate provenance, stated plainly: the full local gate list did NOT complete
on this tree. A scoped `gates.sh -p ravel-sql -p ravel-logseg` ran twice on
this host and was killed both times by disk exhaustion; the second run got
through `cargo fmt --all --check`, workspace `clippy --all-targets`, and
the `ravel-sql` and `ravel-logseg` test suites green, then died partway
into the `flight-sql` feature lane when a watchdog killed it to keep the
volume from reaching zero. A cold gate needs 54-70 GB of `target/` per
worktree and this volume did not have it. So the required checks on this
PR are the first complete gate this tree has seen, not a repeat of a local
run.

What it does have instead: two independent adversarial reviews of the
result ref. The first returned BLOCK on six findings, including a pool
undercharge that admitted a query at roughly a quarter of its resident
bytes. The second verified each fix, mutation-proved the new coverage by
inverting the merge precedence and zeroing the fallback discard count, and
passed. Follow-up #474 records an observability-only counter under-report
found during that review and deliberately left out of this PR.
