### PR TITLE
feat(logseg): keep dictionary form for decoded string columns

### DIFF
--- a/crates/ravel-codec/src/encoding.rs
+++ b/crates/ravel-codec/src/encoding.rs
@@ -491,8 +491,45 @@ pub fn encode_strings(values: &[&[u8]]) -> (Enc, Vec<u8>) {
     }
 }
 
-/// Decodes `count` byte-string values encoded with `enc`.
-pub fn decode_strings(enc: Enc, bytes: &[u8], count: usize) -> Result<Vec<Vec<u8>>, CodecError> {
+/// The non-fusing decode of a string column: either the plain per-value form,
+/// or the dictionary form kept intact (the distinct values plus one id per
+/// value). A dictionary page decoded this way keeps its structure instead of
+/// materializing one owned `Vec<u8>` per row, which a columnar consumer
+/// (ADR-0099 decision 4) turns straight into an Arrow dictionary array.
+///
+/// The `ids` are per value in row order, before any presence bitmap is applied:
+/// each indexes `dict`, and every id is validated `< dict.len()` at decode.
+pub enum DecodedStrings {
+    Plain(Vec<Vec<u8>>),
+    Dict { dict: Vec<Vec<u8>>, ids: Vec<u32> },
+}
+
+impl DecodedStrings {
+    /// Fuses the dictionary form back to one owned value per row; the plain form
+    /// is returned as-is. This is exactly what [`decode_strings`] returns, and
+    /// it is the reason `decode_strings` can be a thin wrapper: the fused output
+    /// is byte-for-byte the pre-ADR-0099 result, repeated entries and all.
+    pub fn fuse(self) -> Vec<Vec<u8>> {
+        match self {
+            DecodedStrings::Plain(v) => v,
+            DecodedStrings::Dict { dict, ids } => ids
+                .into_iter()
+                .map(|id| dict[id as usize].clone())
+                .collect(),
+        }
+    }
+}
+
+/// Decodes `count` byte-string values encoded with `enc` without fusing a
+/// dictionary page: a [`Enc::Dict`] page returns its distinct values and ids
+/// intact ([`DecodedStrings::Dict`]), a [`Enc::Plain`] page the per-value form
+/// ([`DecodedStrings::Plain`]). Every corruption guard [`decode_strings`]
+/// applies fires here too; both entry points share this body.
+pub fn decode_strings_columnar(
+    enc: Enc,
+    bytes: &[u8],
+    count: usize,
+) -> Result<DecodedStrings, CodecError> {
     let mut pos = 0usize;
     let out = match enc {
         Enc::Plain => {
@@ -520,7 +557,7 @@ pub fn decode_strings(enc: Enc, bytes: &[u8], count: usize) -> Result<Vec<Vec<u8
                 off += len;
             }
             pos = bytes.len();
-            out
+            DecodedStrings::Plain(out)
         }
         Enc::Dict => {
             let dict_count = get_uvarint(bytes, &mut pos)? as usize;
@@ -536,10 +573,12 @@ pub fn decode_strings(enc: Enc, bytes: &[u8], count: usize) -> Result<Vec<Vec<u8
                 dict.push(entry.to_vec());
                 pos += len;
             }
+            // `decode_dict_ids` validates every id is `< dict_count`, and
+            // `dict_count` is bounded by `cap` (<= 1 << 16), so each id fits a
+            // u32 losslessly.
             let ids = decode_dict_ids(bytes, &mut pos, count, dict_count)?;
-            ids.into_iter()
-                .map(|id| dict[id as usize].clone())
-                .collect()
+            let ids: Vec<u32> = ids.into_iter().map(|id| id as u32).collect();
+            DecodedStrings::Dict { dict, ids }
         }
         other => {
             return Err(CodecError::Corrupted(format!(
@@ -549,6 +588,14 @@ pub fn decode_strings(enc: Enc, bytes: &[u8], count: usize) -> Result<Vec<Vec<u8
     };
     expect_consumed(pos, bytes.len())?;
     Ok(out)
+}
+
+/// Decodes `count` byte-string values encoded with `enc`, fusing a dictionary
+/// page to one owned value per row. A thin wrapper over
+/// [`decode_strings_columnar`] kept byte-for-byte identical in signature and
+/// output so every existing caller is untouched.
+pub fn decode_strings(enc: Enc, bytes: &[u8], count: usize) -> Result<Vec<Vec<u8>>, CodecError> {
+    Ok(decode_strings_columnar(enc, bytes, count)?.fuse())
 }
 
 // ---------------------------------------------------------------------------
@@ -932,6 +979,107 @@ mod string_dict_tests {
         assert_eq!(got, vals);
     }
 
+    /// Acceptance test (issue #416): over a corpus that triggers `Enc::Dict`,
+    /// the non-fusing decode returns a dictionary and ids whose fusion equals
+    /// `decode_strings`' output exactly -- repeated entries, an empty value, and
+    /// a single-distinct-value column included -- and a plain page returns the
+    /// plain form.
+    #[test]
+    fn dict_decode_preserves_dictionary_and_ids() {
+        // Low cardinality (2 distinct of many) forces Enc::Dict, and the corpus
+        // carries a repeated entry and an empty value.
+        let corpus: Vec<&[u8]> = vec![b"get", b"", b"get", b"", b"get", b""];
+        let (enc, bytes) = encode_strings(&corpus);
+        assert_eq!(enc, Enc::Dict, "low-cardinality corpus must be a dict page");
+
+        let decoded = decode_strings_columnar(enc, &bytes, corpus.len()).expect("columnar decode");
+        match &decoded {
+            DecodedStrings::Dict { dict, ids } => {
+                // The distinct set survives, sorted (the encoder sorts): "", "get".
+                assert_eq!(dict.len(), 2, "the distinct set is kept, not fused away");
+                assert_eq!(dict[0], b"");
+                assert_eq!(dict[1], b"get");
+                assert_eq!(ids.len(), corpus.len(), "one id per value");
+                // Every id indexes the dictionary in range.
+                for &id in ids {
+                    assert!((id as usize) < dict.len());
+                }
+            }
+            DecodedStrings::Plain(_) => panic!("a dict page must not decode as plain"),
+        }
+
+        // Fusing the non-fusing form equals the fused entry point byte-for-byte.
+        let fused_direct = decode_strings(enc, &bytes, corpus.len()).expect("fused decode");
+        assert_eq!(decoded.fuse(), fused_direct);
+        assert_eq!(fused_direct.len(), corpus.len());
+        for (got, want) in fused_direct.iter().zip(&corpus) {
+            assert_eq!(got.as_slice(), *want);
+        }
+
+        // A single-distinct-value column: still a dict page (1 distinct of 5).
+        let single: Vec<&[u8]> = vec![b"only", b"only", b"only", b"only", b"only"];
+        let (enc, bytes) = encode_strings(&single);
+        assert_eq!(enc, Enc::Dict);
+        match decode_strings_columnar(enc, &bytes, single.len()).expect("decode") {
+            DecodedStrings::Dict { dict, ids } => {
+                assert_eq!(dict, vec![b"only".to_vec()]);
+                assert_eq!(ids, vec![0u32; single.len()]);
+            }
+            DecodedStrings::Plain(_) => panic!("single-distinct must be a dict page"),
+        }
+
+        // A plain page decodes to the plain form (all distinct -> Enc::Plain).
+        let distinct: Vec<&[u8]> = vec![b"a", b"b", b"c", b"d"];
+        let (enc, bytes) = encode_strings(&distinct);
+        assert_eq!(enc, Enc::Plain);
+        match decode_strings_columnar(enc, &bytes, distinct.len()).expect("decode") {
+            DecodedStrings::Plain(v) => {
+                let got: Vec<&[u8]> = v.iter().map(|x| x.as_slice()).collect();
+                assert_eq!(got, distinct);
+            }
+            DecodedStrings::Dict { .. } => panic!("a plain page must not decode as dict"),
+        }
+    }
+
+    /// Every corruption guard still fires through the non-fusing entry point,
+    /// as a typed `CodecError`, never a panic and never wrong data.
+    #[test]
+    fn columnar_decode_rejects_corruption() {
+        // Out-of-range id: dict_count 2, entries "a","b", one id = 3.
+        let out_of_range = vec![0x02, 0x01, 0x61, 0x01, 0x62, 0x02, 0x03];
+        assert!(matches!(
+            decode_strings_columnar(Enc::Dict, &out_of_range, 1),
+            Err(CodecError::Corrupted(_))
+        ));
+        // dict_count larger than the buffer.
+        let lying_count = vec![0x05, 0x01, 0x61];
+        assert!(matches!(
+            decode_strings_columnar(Enc::Dict, &lying_count, 1),
+            Err(CodecError::Corrupted(_))
+        ));
+        // Truncated dict entry: length says 4 but no bytes follow.
+        let truncated = vec![0x01, 0x04];
+        assert!(matches!(
+            decode_strings_columnar(Enc::Dict, &truncated, 1),
+            Err(CodecError::Corrupted(_))
+        ));
+        // Plain page with a length longer than its blob.
+        let short_blob = vec![0x05, 0x61, 0x62];
+        assert!(matches!(
+            decode_strings_columnar(Enc::Plain, &short_blob, 1),
+            Err(CodecError::Corrupted(_))
+        ));
+        // Trailing unconsumed bytes after a valid single-distinct dict page.
+        let single: Vec<&[u8]> = vec![b"x", b"x"];
+        let (enc, mut bytes) = encode_strings(&single);
+        assert_eq!(enc, Enc::Dict);
+        bytes.push(0x00);
+        assert!(matches!(
+            decode_strings_columnar(Enc::Dict, &bytes, single.len()),
+            Err(CodecError::Corrupted(_))
+        ));
+    }
+
     #[test]
     fn f64_constant_and_nan_and_neg_zero() {
         // Constant.
@@ -1067,6 +1215,40 @@ mod string_dict_proptests {
                 let _ = decode_strings(e, &bytes, count);
                 let _ = decode_f64(e, &bytes, count);
                 let _ = decode_fixed(e, &bytes, count, 8);
+            }
+        }
+
+        /// The non-fusing decode fused equals the fusing decode, and every id it
+        /// returns indexes its dictionary in range. A low-cardinality generator
+        /// (values drawn from a small alphabet) makes `Enc::Dict` the common
+        /// case rather than a rarity.
+        #[test]
+        fn columnar_decode_fuses_to_decode_strings(
+            idxs in proptest::collection::vec(0usize..6, 0..400)
+        ) {
+            let alphabet: [&[u8]; 6] = [b"", b"a", b"get", b"post", b"timeout", b"xyz"];
+            let vals: Vec<&[u8]> = idxs.iter().map(|&i| alphabet[i]).collect();
+            let (enc, bytes) = encode_strings(&vals);
+            let columnar = decode_strings_columnar(enc, &bytes, vals.len()).expect("columnar");
+            if let DecodedStrings::Dict { dict, ids } = &columnar {
+                prop_assert_eq!(ids.len(), vals.len());
+                for &id in ids {
+                    prop_assert!((id as usize) < dict.len());
+                }
+            }
+            let fused = decode_strings(enc, &bytes, vals.len()).expect("fused");
+            prop_assert_eq!(columnar.fuse(), fused);
+        }
+
+        /// The non-fusing entry point never panics on arbitrary bytes.
+        #[test]
+        fn columnar_string_decode_never_panics(
+            tag in 1u8..=9,
+            bytes in proptest::collection::vec(any::<u8>(), 0..256),
+            count in 0usize..500,
+        ) {
+            if let Ok(e) = Enc::from_u8(tag) {
+                let _ = decode_strings_columnar(e, &bytes, count);
             }
         }
     }

--- a/crates/ravel-logseg/src/block.rs
+++ b/crates/ravel-logseg/src/block.rs
@@ -11,8 +11,8 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::encoding::{
-    Enc, decode_bitmap, decode_f64, decode_fixed, decode_i64, decode_strings, encode_bitmap,
-    encode_f64, encode_fixed, encode_i64, encode_strings,
+    DecodedStrings, Enc, decode_bitmap, decode_f64, decode_fixed, decode_i64,
+    decode_strings_columnar, encode_bitmap, encode_f64, encode_fixed, encode_i64, encode_strings,
 };
 use crate::error::LogSegError;
 use crate::page::{PageDesc, read_page, write_page};
@@ -451,6 +451,45 @@ fn winner_value(row: &ResolvedRow, column_id: u32) -> Option<&ColumnValue> {
         .map(|(_, v)| v)
 }
 
+/// A decoded string column, kept in whichever shape its page carried
+/// (ADR-0099 decision 4). A dictionary page keeps its distinct set and per-row
+/// ids instead of materializing one owned `Vec<u8>` per row; a plain page keeps
+/// the per-row values. Both are addressed by block row position and carry
+/// presence separately: an absent row reads `None` either way.
+enum StrColumn {
+    /// Per-row values, `None` for an absent row. What a plain page decodes to.
+    Plain(Vec<Option<Vec<u8>>>),
+    /// The distinct values plus one id per block row: `Some(id)` indexes `dict`,
+    /// `None` marks an absent row (the presence bitmap, kept out of the id
+    /// vector rather than folded in as a sentinel). Every `Some(id)` is
+    /// `< dict.len()`, validated at decode.
+    Dict {
+        dict: Vec<Vec<u8>>,
+        ids: Vec<Option<u32>>,
+    },
+}
+
+/// The borrowed dictionary form of a string column: the distinct values and
+/// one id per block row (`None` for an absent row). Returned by
+/// [`DecodedBlock::str_dict`] for the columnar view to build an Arrow
+/// dictionary array from.
+type StrDictRef<'a> = (&'a [Vec<u8>], &'a [Option<u32>]);
+
+impl StrColumn {
+    /// The bytes at block row `row`, or `None` when the row is absent (or out of
+    /// range). Both shapes read identically here, which is what lets the storage
+    /// shape stay invisible above [`DecodedBlock`].
+    fn cell(&self, row: usize) -> Option<&[u8]> {
+        match self {
+            StrColumn::Plain(v) => v.get(row)?.as_deref(),
+            StrColumn::Dict { dict, ids } => {
+                let id = (*ids.get(row)?)? as usize;
+                dict.get(id).map(Vec::as_slice)
+            }
+        }
+    }
+}
+
 /// A decoded block: per-column, per-row values. Every column vector has length
 /// `record_count`; `None` marks a row where the column has no value.
 ///
@@ -465,7 +504,7 @@ pub struct DecodedBlock {
     i64_cols: HashMap<u32, Vec<Option<i64>>>,
     f64_cols: HashMap<u32, Vec<Option<u64>>>,
     bool_cols: HashMap<u32, Vec<Option<bool>>>,
-    str_cols: HashMap<u32, Vec<Option<Vec<u8>>>>,
+    str_cols: HashMap<u32, StrColumn>,
     fixed_cols: HashMap<u32, Vec<Option<Vec<u8>>>>,
     /// Whether any page descriptor in this block named [`COL_ATTRS_RAW`], read
     /// off the header and independent of the column filter (see
@@ -531,12 +570,32 @@ impl DecodedBlock {
         for v in self.bool_cols.values() {
             total += v.capacity() * std::mem::size_of::<Option<bool>>();
         }
-        for cols in [&self.str_cols, &self.fixed_cols] {
-            for v in cols.values() {
-                total += v.capacity() * std::mem::size_of::<Option<Vec<u8>>>();
-                for cell in v.iter().flatten() {
-                    total += cell.capacity();
+        // A dictionary-form string column holds its distinct values once plus a
+        // narrow id per row, not one owned buffer per row: charging it as though
+        // every row still owned a `Vec<u8>` would over-report by the
+        // deduplication factor and make `ravel-sql` charge its pool for memory
+        // that no longer exists (ADR-0099 decision 4).
+        for col in self.str_cols.values() {
+            match col {
+                StrColumn::Plain(v) => {
+                    total += v.capacity() * std::mem::size_of::<Option<Vec<u8>>>();
+                    for cell in v.iter().flatten() {
+                        total += cell.capacity();
+                    }
                 }
+                StrColumn::Dict { dict, ids } => {
+                    total += ids.capacity() * std::mem::size_of::<Option<u32>>();
+                    total += dict.capacity() * std::mem::size_of::<Vec<u8>>();
+                    for entry in dict {
+                        total += entry.capacity();
+                    }
+                }
+            }
+        }
+        for v in self.fixed_cols.values() {
+            total += v.capacity() * std::mem::size_of::<Option<Vec<u8>>>();
+            for cell in v.iter().flatten() {
+                total += cell.capacity();
             }
         }
         total
@@ -550,11 +609,41 @@ impl DecodedBlock {
     pub fn bool_col(&self, column_id: u32) -> Option<&[Option<bool>]> {
         self.bool_cols.get(&column_id).map(Vec::as_slice)
     }
-    pub fn str_col(&self, column_id: u32) -> Option<&[Option<Vec<u8>>]> {
-        self.str_cols.get(&column_id).map(Vec::as_slice)
+
+    /// The bytes of string column `column_id` at block row `row`, or `None` when
+    /// the column is absent (or projected away) or the row has no value. Both
+    /// the plain and dictionary storage shapes read through here, so a caller
+    /// never learns which one the column is (ADR-0099 decision 4).
+    pub(crate) fn str_at(&self, column_id: u32, row: usize) -> Option<&[u8]> {
+        self.str_cols.get(&column_id)?.cell(row)
     }
+
+    /// The dictionary form of string column `column_id`: its distinct values and
+    /// one id per block row (`None` for an absent row). `None` when the column is
+    /// absent, projected away, or stored in plain form -- a plain page is read
+    /// through [`Self::str_at`], never forced into a dictionary here.
+    pub(crate) fn str_dict(&self, column_id: u32) -> Option<StrDictRef<'_>> {
+        match self.str_cols.get(&column_id)? {
+            StrColumn::Dict { dict, ids } => Some((dict, ids)),
+            StrColumn::Plain(_) => None,
+        }
+    }
+
     pub fn fixed_col(&self, column_id: u32) -> Option<&[Option<Vec<u8>>]> {
         self.fixed_cols.get(&column_id).map(Vec::as_slice)
+    }
+
+    /// Test-only fused view of a string column, `None` when the column is absent.
+    /// Rebuilds the pre-ADR-0099 `Vec<Option<Vec<u8>>>` shape so existing
+    /// assertions read unchanged regardless of the storage shape.
+    #[cfg(test)]
+    fn str_col_fused(&self, column_id: u32) -> Option<Vec<Option<Vec<u8>>>> {
+        let _ = self.str_cols.get(&column_id)?;
+        Some(
+            (0..self.record_count)
+                .map(|row| self.str_at(column_id, row).map(<[u8]>::to_vec))
+                .collect(),
+        )
     }
 }
 
@@ -809,8 +898,18 @@ pub fn read_block_columns(
                 out.bool_cols.insert(column_id, scatter(&present, vals)?);
             }
             ColKind::Str => {
-                let vals = decode_strings(enc, encoded, present_count)?;
-                out.str_cols.insert(column_id, scatter(&present, vals)?);
+                // Presence is applied by scattering against the block's presence
+                // bitmap; the page's ids are per present row, so an absent row
+                // gets a `None` slot rather than a sentinel id (ADR-0099
+                // decision 4). A dict page keeps its distinct set intact.
+                let col = match decode_strings_columnar(enc, encoded, present_count)? {
+                    DecodedStrings::Plain(vals) => StrColumn::Plain(scatter(&present, vals)?),
+                    DecodedStrings::Dict { dict, ids } => StrColumn::Dict {
+                        dict,
+                        ids: scatter(&present, ids)?,
+                    },
+                };
+                out.str_cols.insert(column_id, col);
             }
             ColKind::Fixed(width) => {
                 let vals = decode_fixed(enc, encoded, present_count, width)?;
@@ -894,7 +993,7 @@ mod tests {
         for (i, v) in ts.iter().enumerate() {
             assert_eq!(*v, Some(1000 + i as i64));
         }
-        let body = dec.str_col(COL_BODY).expect("body");
+        let body = dec.str_col_fused(COL_BODY).expect("body");
         assert_eq!(body[7], Some(b"body 1007".to_vec()));
 
         // Dynamic presence.
@@ -906,7 +1005,7 @@ mod tests {
                 assert_eq!(*v, None);
             }
         }
-        let c11 = dec.str_col(11).expect("c11");
+        let c11 = dec.str_col_fused(11).expect("c11");
         assert_eq!(c11[10], Some(b"s10".to_vec()));
         assert_eq!(c11[60], None);
 
@@ -1161,12 +1260,12 @@ mod tests {
 
         // Kept columns decode identically to the unfiltered decode.
         assert_eq!(projected.i64_col(COL_TS), all.i64_col(COL_TS));
-        assert_eq!(projected.str_col(11), all.str_col(11));
-        assert_eq!(projected.str_col(17), all.str_col(17));
+        assert_eq!(projected.str_col_fused(11), all.str_col_fused(11));
+        assert_eq!(projected.str_col_fused(17), all.str_col_fused(17));
         // Excluded columns are absent, including fixed ones.
-        assert!(projected.str_col(12).is_none());
-        assert!(projected.str_col(COL_BODY).is_none());
-        assert!(all.str_col(COL_BODY).is_some());
+        assert!(projected.str_col_fused(12).is_none());
+        assert!(projected.str_col_fused(COL_BODY).is_none());
+        assert!(all.str_col_fused(COL_BODY).is_some());
     }
 
     /// A filter never weakens the integrity checks: the block crc still covers
@@ -1192,6 +1291,62 @@ mod tests {
             read_block_columns(&bad, out.crc32c, &plans, 1 << 30, Some(&keep)),
             Err(LogSegError::Corrupted(_))
         ));
+    }
+
+    /// `decoded_heap_bytes` charges a dictionary-form string column its true
+    /// footprint -- the distinct set once plus a narrow id per row -- not one
+    /// owned `Vec<u8>` per row (ADR-0099 decision 4, deliverable 4). Pinned
+    /// against a column of known distinct count so a regression to the fused
+    /// figure (which would over-report by the deduplication factor) fails here.
+    #[test]
+    fn dict_decoded_heap_bytes_reports_dictionary_footprint() {
+        const N: usize = 100;
+        const DISTINCT: usize = 4;
+        const LEN: usize = 5;
+        let dict_vals: [&[u8]; DISTINCT] = [b"aaaaa", b"bbbbb", b"ccccc", b"ddddd"];
+
+        let plans = vec![ColumnPlan {
+            column_id: 10,
+            ty: FieldType::Str,
+        }];
+        let mut rows = Vec::new();
+        for i in 0..N {
+            let mut r = row(0, i as i64);
+            r.columns
+                .push((10, ColumnValue::Str(dict_vals[i % DISTINCT].to_vec())));
+            rows.push(r);
+        }
+        let out = write_block(&rows, &plans, 3).expect("write");
+
+        // Decode only column 10 so the figure is exactly that one column's.
+        let keep: HashSet<u32> = HashSet::from([10]);
+        let dec =
+            read_block_columns(&out.bytes, out.crc32c, &plans, 1 << 30, Some(&keep)).expect("read");
+
+        // The column dictionary-encoded (4 distinct of 100) and is kept intact.
+        let (dict, ids) = dec.str_dict(10).expect("column 10 is a dictionary page");
+        assert_eq!(dict.len(), DISTINCT);
+        assert_eq!(ids.len(), N);
+
+        let opt_u32 = std::mem::size_of::<Option<u32>>();
+        let vec_spine = std::mem::size_of::<Vec<u8>>();
+        let opt_vec = std::mem::size_of::<Option<Vec<u8>>>();
+
+        // New (dict) footprint: one id per row + the distinct set once.
+        let dict_figure = N * opt_u32 + DISTINCT * vec_spine + DISTINCT * LEN;
+        assert_eq!(
+            dec.decoded_heap_bytes(),
+            dict_figure,
+            "decoded_heap_bytes must report the dictionary footprint"
+        );
+
+        // Old (fused) footprint the code must no longer report: one owned buffer
+        // per row. On this 64-bit host dict_figure=916, fused_figure=2900.
+        let fused_figure = N * opt_vec + N * LEN;
+        assert!(
+            dict_figure < fused_figure,
+            "the dictionary form must be smaller: dict={dict_figure}, fused={fused_figure}"
+        );
     }
 
     #[test]

--- a/crates/ravel-logseg/src/columnar.rs
+++ b/crates/ravel-logseg/src/columnar.rs
@@ -52,6 +52,64 @@ pub struct AttrColumn {
     pub ty: FieldType,
 }
 
+/// The dictionary form of a string column, restricted to a view's surviving
+/// rows (ADR-0099 decision 4).
+///
+/// Handed out only for a column whose page was dictionary-encoded, by
+/// [`ColumnarBlockView::str_dict`]. It exposes the distinct values and one id
+/// per surviving row, indexed by surviving row position exactly as every other
+/// per-row accessor is -- never the block's storage vectors.
+pub struct StrDictColumn<'a> {
+    dict: &'a [Vec<u8>],
+    /// One entry per block row, `Some(id)` indexing `dict`, `None` for an absent
+    /// row. Addressed through `rows` so callers see surviving-row indices only.
+    ids: &'a [Option<u32>],
+    /// Block row positions of the surviving rows, ascending (the view's `rows`).
+    rows: &'a [usize],
+}
+
+impl<'a> StrDictColumn<'a> {
+    /// The distinct values, in the page's dictionary order. Id `k` from
+    /// [`id_at`](Self::id_at) addresses `dict()[k as usize]`.
+    pub fn dict(&self) -> &'a [Vec<u8>] {
+        self.dict
+    }
+
+    /// The number of surviving rows: the length [`id_at`](Self::id_at) and
+    /// [`iter_ids`](Self::iter_ids) range over.
+    pub fn len(&self) -> usize {
+        self.rows.len()
+    }
+
+    /// Whether no row survives.
+    pub fn is_empty(&self) -> bool {
+        self.rows.is_empty()
+    }
+
+    /// The dictionary id of surviving row `i`, or `None` when that row has no
+    /// value for the column (absent per the presence bitmap) or `i` is out of
+    /// range. `Some(id)` always indexes [`dict`](Self::dict) in bounds.
+    pub fn id_at(&self, i: usize) -> Option<u32> {
+        let row = *self.rows.get(i)?;
+        self.ids.get(row).copied().flatten()
+    }
+
+    /// The dictionary ids of the surviving rows in order (see
+    /// [`id_at`](Self::id_at)).
+    pub fn iter_ids(&self) -> impl Iterator<Item = Option<u32>> + '_ {
+        (0..self.rows.len()).map(move |i| self.id_at(i))
+    }
+
+    /// The bytes of surviving row `i`, resolved through the dictionary. This is
+    /// the same value [`ColumnarBlockView::bytes_at`] returns for the same
+    /// surviving row; it exists so a test can prove the dictionary form fuses
+    /// back to the per-row form.
+    pub fn value_at(&self, i: usize) -> Option<&'a [u8]> {
+        let id = self.id_at(i)? as usize;
+        self.dict.get(id).map(Vec::as_slice)
+    }
+}
+
 /// A borrowed columnar view of one decoded block, restricted to the rows that
 /// survived the scan's exact content predicate.
 ///
@@ -325,10 +383,31 @@ impl<'a> ColumnarBlockView<'a> {
     pub fn bytes_at(&self, column_id: u32, i: usize) -> Option<&'a [u8]> {
         let row = self.row(i)?;
         let block = self.block;
-        if let Some(col) = block.str_col(column_id) {
-            return col.get(row)?.as_deref();
+        if let Some(bytes) = block.str_at(column_id, row) {
+            return Some(bytes);
         }
         block.fixed_col(column_id)?.get(row)?.as_deref()
+    }
+
+    /// The dictionary form of string column `column_id`, restricted to the
+    /// surviving rows (ADR-0099 decision 4): the distinct values plus one id per
+    /// surviving row. `Some` only for a column whose page was dictionary-encoded;
+    /// `None` for a plain page, an absent column, or one projected away -- a
+    /// plain page stays readable through [`bytes_at`](Self::bytes_at) and is
+    /// never forced into a dictionary here.
+    ///
+    /// Issue #417 consumes this to build an Arrow `Dictionary(Int32, Utf8)`
+    /// array without rebuilding a dictionary row by row. Like every accessor
+    /// here it returns values, never the block's storage type: `dict()` borrows
+    /// the distinct byte values and the ids address them, so the caller learns
+    /// nothing of how the column is stored beyond that it deduplicates.
+    pub fn str_dict(&self, column_id: u32) -> Option<StrDictColumn<'a>> {
+        let (dict, ids) = self.block.str_dict(column_id)?;
+        Some(StrDictColumn {
+            dict,
+            ids,
+            rows: self.rows,
+        })
     }
 
     // --- gather iterators ---------------------------------------------------

--- a/crates/ravel-logseg/src/lib.rs
+++ b/crates/ravel-logseg/src/lib.rs
@@ -37,7 +37,7 @@ pub use ravel_codec::{bloom, bloom_section, encoding, tokenizer};
 // deliberately NOT re-exported: the view is the whole public surface over a
 // decoded block, so decision 4 can change how columns are stored without
 // touching a caller.
-pub use columnar::{AttrColumn, ColumnarBlockView};
+pub use columnar::{AttrColumn, ColumnarBlockView, StrDictColumn};
 pub use columns::ColumnSelection;
 pub use error::LogSegError;
 pub use footer::{SuffixOutcome, open_from_suffix};

--- a/crates/ravel-logseg/src/reader.rs
+++ b/crates/ravel-logseg/src/reader.rs
@@ -905,14 +905,11 @@ fn overflow_attr(
     row: usize,
     name: &str,
 ) -> Result<Option<AttrValue>, LogSegError> {
-    let raw = match block.str_col(crate::record::COL_ATTRS_RAW) {
-        Some(col) => match col.get(row).and_then(|v| v.as_ref()) {
-            Some(bytes) => bytes.clone(),
-            None => return Ok(None),
-        },
+    let raw = match block.str_at(crate::record::COL_ATTRS_RAW, row) {
+        Some(bytes) => bytes,
         None => return Ok(None),
     };
-    let attrs = decode_canonical_attrs(&raw)?;
+    let attrs = decode_canonical_attrs(raw)?;
     Ok(attrs.into_iter().find(|(k, _)| k == name).map(|(_, v)| v))
 }
 
@@ -999,9 +996,7 @@ pub(crate) fn rebuild_record_projected(
             attrs.push((e.name.clone(), v));
         }
     }
-    if let Some(col) = block.str_col(crate::record::COL_ATTRS_RAW)
-        && let Some(Some(raw)) = col.get(row)
-    {
+    if let Some(raw) = block.str_at(crate::record::COL_ATTRS_RAW, row) {
         attrs.extend(decode_canonical_attrs(raw)?);
     }
 
@@ -1137,10 +1132,7 @@ pub(crate) fn i64_at(block: &DecodedBlock, col: u32, row: usize) -> Result<i64, 
 }
 
 fn str_at(block: &DecodedBlock, col: u32, row: usize) -> Option<Vec<u8>> {
-    block
-        .str_col(col)
-        .and_then(|c| c.get(row).cloned())
-        .flatten()
+    block.str_at(col, row).map(<[u8]>::to_vec)
 }
 
 fn fixed_at(block: &DecodedBlock, col: u32, row: usize) -> Option<Vec<u8>> {
@@ -3385,6 +3377,136 @@ mod tests {
         );
     }
 
+    /// `ColumnarBlockView::str_dict` hands out a dictionary-encoded string
+    /// column intact, and fusing it back through the dictionary yields exactly
+    /// the per-row bytes the byte accessor returns for the same surviving rows
+    /// (ADR-0099 decision 4, deliverable 5). Presence is carried by the id
+    /// vector, so a surviving row whose column value is absent reads `None`
+    /// through both, an empty-string value survives as an empty dictionary
+    /// entry, and a plain-page column exposes no dictionary at all.
+    ///
+    /// The selective predicate drops a middle row, so the surviving rows are
+    /// non-contiguous: a dictionary that addressed ids by raw block row rather
+    /// than by surviving-row index would disagree here.
+    #[test]
+    fn columnar_str_dict_fuses_to_byte_accessor() {
+        let cfg = RlogConfig {
+            block_target_records: 8,
+            max_dynamic_columns: COLUMNAR_MAX_COLUMNS,
+            ..RlogConfig::default()
+        };
+        // "svc" is low cardinality (3 distinct across 6 present of 8 rows -> a
+        // dictionary page), carries an empty-string value, and is absent from
+        // two rows. Bodies are all distinct -> a plain page, and worded so
+        // `keep` drops one row to make the survivors non-contiguous.
+        let recs = vec![
+            rec_attrs(
+                0,
+                100,
+                "keep a",
+                vec![attr("svc", AttrValue::Str("api".into()))],
+            ),
+            rec_attrs(
+                0,
+                101,
+                "keep b",
+                vec![attr("svc", AttrValue::Str("".into()))],
+            ),
+            rec_attrs(0, 102, "drop c", Vec::new()),
+            rec_attrs(
+                0,
+                103,
+                "keep d",
+                vec![attr("svc", AttrValue::Str("api".into()))],
+            ),
+            rec_attrs(
+                0,
+                104,
+                "keep e",
+                vec![attr("svc", AttrValue::Str("db".into()))],
+            ),
+            rec_attrs(0, 105, "keep f", Vec::new()),
+            rec_attrs(
+                0,
+                106,
+                "keep g",
+                vec![attr("svc", AttrValue::Str("db".into()))],
+            ),
+            rec_attrs(
+                0,
+                107,
+                "keep h",
+                vec![attr("svc", AttrValue::Str("api".into()))],
+            ),
+        ];
+        let obj = build(cfg, recs);
+        let reader = RlogReader::new(&obj, &cfg).expect("open object");
+        let pred = Predicate::HasWord {
+            field: FieldSel::Body,
+            word: "keep".into(),
+        };
+
+        let mut cursor = reader
+            .scan_blocks(&pred, &[], &ColumnSelection::all())
+            .expect("open cursor");
+        let mut saw_dict = false;
+        let mut saw_absent = false;
+        let mut saw_empty = false;
+        while let Some(view) = cursor.next_block_columnar(&obj).expect("columnar exit") {
+            // A plain-page column (all-distinct bodies) exposes no dictionary.
+            assert!(
+                view.str_dict(COL_BODY).is_none(),
+                "a plain page must not be forced into a dictionary"
+            );
+
+            let svc = view
+                .resolve_attr("svc", FieldType::Str)
+                .expect("svc has a FIELD_DIR column");
+            let dict = view
+                .str_dict(svc.column_id)
+                .expect("the svc column is a dictionary page");
+            saw_dict = true;
+            assert_eq!(
+                dict.len(),
+                view.surviving_count(),
+                "the dictionary column spans exactly the surviving rows"
+            );
+
+            for i in 0..view.surviving_count() {
+                let via_bytes = view.bytes_at(svc.column_id, i);
+                // Fusing the dictionary form equals the byte accessor cell.
+                assert_eq!(dict.value_at(i), via_bytes, "surviving row {i}");
+                match dict.id_at(i) {
+                    Some(id) => {
+                        let entry = dict.dict()[id as usize].as_slice();
+                        assert_eq!(Some(entry), via_bytes, "id maps through dict() at {i}");
+                        if entry.is_empty() {
+                            saw_empty = true;
+                        }
+                    }
+                    None => {
+                        saw_absent = true;
+                        assert_eq!(via_bytes, None, "an absent id must read absent bytes");
+                    }
+                }
+            }
+            // The gather form agrees with the per-row form.
+            let ids_iter: Vec<Option<u32>> = dict.iter_ids().collect();
+            let ids_rows: Vec<Option<u32>> =
+                (0..view.surviving_count()).map(|i| dict.id_at(i)).collect();
+            assert_eq!(ids_iter, ids_rows, "iter_ids");
+        }
+        assert!(
+            saw_dict,
+            "the corpus must produce a dictionary-encoded svc page"
+        );
+        assert!(saw_absent, "a surviving row must carry an absent svc value");
+        assert!(
+            saw_empty,
+            "a surviving row must carry an empty-string svc value"
+        );
+    }
+
     /// Both exits reject a corrupt block with the same typed error, and neither
     /// panics. The flipped byte is inside block 0's stored extent, so its
     /// crc32c no longer matches its SKIP_IDX entry.
@@ -3447,11 +3569,15 @@ mod tests {
     /// footprint: it counts every string cell's own allocation, not just the
     /// column spines, and it tracks what the column selection actually decoded.
     ///
-    /// The bodies are 4 KiB each, so the per-cell term (8 x 4096 = 32768 bytes)
-    /// dwarfs the spines a `record_count`-based estimate would see. A figure
-    /// that counted spines only would land under the cell total and fail the
-    /// first assertion; a figure that ignored the column filter would fail the
-    /// last two.
+    /// The bodies are 4 KiB each and all distinct, so the body column is a plain
+    /// page and its per-cell term (8 x 4096 = 32768 bytes) dwarfs the spines a
+    /// `record_count`-based estimate would see. Distinct is deliberate: an
+    /// identical-body column would dictionary-encode to one 4 KiB entry plus
+    /// eight narrow ids (ADR-0099 decision 4), which is the case
+    /// `dict_decoded_bytes_reports_dictionary_footprint` pins. A figure that
+    /// counted spines only would land under the cell total and fail the first
+    /// assertion; a figure that ignored the column filter would fail the last
+    /// two.
     #[test]
     fn decoded_bytes_counts_cells_and_follows_the_column_selection() {
         const ROWS: i64 = 8;
@@ -3460,9 +3586,14 @@ mod tests {
             block_target_records: 64,
             ..RlogConfig::default()
         };
-        let body = "b".repeat(BODY);
+        // Distinct bodies (a per-row suffix) keep the column a plain page, so the
+        // per-cell accounting under test is exercised rather than dictionary
+        // deduplication.
         let recs: Vec<LogRecord> = (0..ROWS)
-            .map(|i| rec_attrs(0, i, &body, Vec::new()))
+            .map(|i| {
+                let body = format!("{}{i:08}", "b".repeat(BODY - 8));
+                rec_attrs(0, i, &body, Vec::new())
+            })
             .collect();
         let obj = build(cfg, recs);
         let pred = Predicate::And(Vec::new());


### PR DESCRIPTION
A dictionary-encoded string page stores distinct values once and a
bit-packed id per row, but the decoder threw that structure away
immediately: it materialized the dictionary, decoded the ids, and
returned one cloned Vec per row. A column with a thousand distinct
values across a million rows was fully materialized per row, and
nothing downstream could tell a dictionary page from a plain one.

ravel-codec gains a non-fusing string decode that returns either the
plain per-value form or the dictionary and its ids. decode_strings is
now a thin wrapper that fuses, so every existing caller is unchanged.
A decoded block keeps the dictionary form internally, with presence
carried in the id vector rather than a sentinel id, so an absent value,
an empty string, and a projected-away column stay three distinguishable
results.

The columnar block view gains an accessor handing out the distinct
values plus the ids of the surviving rows, which is what the logs scan
needs to build an Arrow dictionary array without rebuilding one row by
row. A page that was not dictionary-encoded returns nothing from it and
stays readable through the existing byte accessors.

decoded_heap_bytes now reports the dictionary's real footprint. That
figure is what the logs scan charges to the query memory pool, so
leaving it computing per-row buffers would have charged for memory that
no longer exists and rejected queries that fit. On a 100-row column with
four distinct five-byte values it reports 916 bytes rather than 2900.

No persistent format change: Enc tags, page layout, and the encoder are
untouched, and the row rebuild path is byte-identical.

Fixes: #416
Refs: #360
