### PR TITLE
feat(ravel-catalog,ravel-query): pushdown eligibility gate (ADR-0103)

### DIFF
--- a/crates/ravel-catalog/src/catalog.rs
+++ b/crates/ravel-catalog/src/catalog.rs
@@ -25,6 +25,7 @@ use uuid::Uuid;
 use crate::cache::{CompactionRecordCache, HeadCache, PartCache, PostingsCache, RecordCache};
 use crate::config::CatalogConfig;
 use crate::error::CatalogError;
+use crate::provisioning::ShardGeneration;
 use crate::snapshot::{SegmentLevel, SegmentOrigin, SegmentOrigins, SegmentRef, Snapshot};
 
 const NS_PER_HOUR: i64 = 3_600_000_000_000;
@@ -664,7 +665,7 @@ impl Catalog {
     ) -> Result<Snapshot, CatalogError> {
         self.resolve_impl(tenant, signal, range, min_tokens, now_ns, None, accounting)
             .await
-            .map(|(snapshot, _origins)| snapshot)
+            .map(|(snapshot, _origins, _generations)| snapshot)
     }
 
     /// Like [`Catalog::resolve`], but applies postings-based segment pruning
@@ -729,7 +730,7 @@ impl Catalog {
             accounting,
         )
         .await
-        .map(|(snapshot, _origins)| snapshot)
+        .map(|(snapshot, _origins, _generations)| snapshot)
     }
 
     /// Like [`Catalog::resolve_pruned_with_accounting`], but also returns the
@@ -763,6 +764,55 @@ impl Catalog {
             accounting,
         )
         .await
+        .map(|(snapshot, origins, _generations)| (snapshot, origins))
+    }
+
+    /// Like [`Catalog::resolve_pruned_with_admission`], but also returns the
+    /// shard-generation history **this resolve itself** computed its scan set
+    /// from (ADR-0052 section 4), for the ADR-0103 pushdown eligibility gate.
+    ///
+    /// The gate (`ravel_query::distrib::pushdown::is_pushdown_eligible`) asks
+    /// whether every resolved segment's ingest hour sits inside one
+    /// generation's stable interval. ADR-0103 decision 1(b) requires it to read
+    /// the same history object the resolve used, never a second store read or a
+    /// separately-cached copy: a generation appended between the two reads would
+    /// otherwise be invisible to the gate while its segments are already
+    /// visible in the resolved set, and the gate would call a
+    /// generation-straddling query eligible. Returning the history the resolve
+    /// already read makes that skew structurally impossible, and costs no
+    /// additional request (`read_scan_generations` runs once per resolve
+    /// regardless).
+    ///
+    /// When head validation performed its one-shot record re-read, the returned
+    /// history is the *revalidated* one -- the same one the listing suffix
+    /// scanned under, and never staler than the one that validated the head.
+    ///
+    /// A separate method rather than a changed
+    /// `resolve_pruned_with_admission` signature, for the same reason each
+    /// `resolve*` variant above is separate: every existing call site
+    /// (`ravel-sql`'s executor, `ravel-query`'s admission seam) stays exactly
+    /// as it was.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn resolve_pruned_with_generations(
+        &self,
+        tenant: &TenantHash,
+        signal: Signal,
+        range: TimeRange,
+        min_tokens: &[CommitToken],
+        now_ns: i64,
+        name_filter: Option<&str>,
+        accounting: &QueryAccounting,
+    ) -> Result<(Snapshot, SegmentOrigins, Vec<ShardGeneration>), CatalogError> {
+        self.resolve_impl(
+            tenant,
+            signal,
+            range,
+            min_tokens,
+            now_ns,
+            name_filter,
+            accounting,
+        )
+        .await
     }
 
     /// Instruments the whole LIST/GET fan-out with the `catalog_resolve` span
@@ -785,7 +835,7 @@ impl Catalog {
         now_ns: i64,
         name_filter: Option<&str>,
         accounting: &QueryAccounting,
-    ) -> Result<(Snapshot, SegmentOrigins), CatalogError> {
+    ) -> Result<(Snapshot, SegmentOrigins, Vec<ShardGeneration>), CatalogError> {
         // Idle-tenant eviction last-touch (ADR-0069 decision 2):
         // stamp this tenant's activity with the caller's injected `now_ns`
         // before the fan-out. Every resolve entry point funnels through here,
@@ -831,7 +881,7 @@ impl Catalog {
                 .total_s3_bytes()
                 .saturating_sub(before.total_s3_bytes()),
         );
-        if let Ok((snapshot, _origins)) = &result {
+        if let Ok((snapshot, _origins, _generations)) = &result {
             span.record("segments_pruned", snapshot.segments_pruned);
         }
         result
@@ -847,7 +897,7 @@ impl Catalog {
         now_ns: i64,
         name_filter: Option<&str>,
         accounting: &QueryAccounting,
-    ) -> Result<(Snapshot, SegmentOrigins), CatalogError> {
+    ) -> Result<(Snapshot, SegmentOrigins, Vec<ShardGeneration>), CatalogError> {
         // Durable shard_count enforcement on the read path (ADR-0050 section 5): fail before the `0..shard_count` listing loop below if this
         // catalog's configured shard_count disagrees with the (tenant, signal)'s
         // provisioning record, so a lower value never silently drops the shards
@@ -871,7 +921,14 @@ impl Catalog {
         // knowable -- routed to the prefix path when the per-bucket estimate
         // would be expensive, and capped at runtime by real LIST count if the
         // prefix scan itself turns out to be too large.
-        let generations = self.read_scan_generations(tenant, signal).await?;
+        //
+        // Mutable, and returned to the caller at the end of this function: the
+        // head-revalidation path below can replace it with a fresher read, and
+        // ADR-0103's pushdown eligibility gate must see the very history this
+        // resolve computed its scan set from, not a later independent read (a
+        // generation appended between the two reads would be invisible to the
+        // gate while already visible in the resolved segments).
+        let mut generations = self.read_scan_generations(tenant, signal).await?;
 
         let mut segments: HashMap<String, SegmentRef> = HashMap::new();
         let mut segments_pruned = 0u64;
@@ -914,7 +971,9 @@ impl Catalog {
             // computation below too. Otherwise the listing suffix would scan
             // the stale, narrower range the re-read exists to correct, silently
             // omitting data that landed in a wider generation's shards.
-            let generations = revalidated_generations.unwrap_or(generations);
+            if let Some(revalidated) = revalidated_generations {
+                generations = revalidated;
+            }
             let listing_start_hour = match &window {
                 Some(window) if window.watermark_hour >= window_start_hour => {
                     let snapshot_end_hour = window_end_hour.min(window.watermark_hour);
@@ -1100,6 +1159,7 @@ impl Catalog {
                 pending_erasure,
             },
             origins,
+            generations,
         ))
     }
 

--- a/crates/ravel-catalog/src/lib.rs
+++ b/crates/ravel-catalog/src/lib.rs
@@ -58,7 +58,7 @@ pub use provisioning::{
     append_generation, current_floor, current_floor_from_store, max_scan_count_over_range,
     provisioning_key, raise_format_floor, read_floors, read_floors_checked, read_floors_from_store,
     read_generations, read_generations_checked, read_generations_from_store, scan_count,
-    shard_ceiling, validate_or_adopt,
+    shard_ceiling, stable_generation_for_hour, validate_or_adopt,
 };
 pub use seal_divergence::{
     EntryIdentity, SealDivergenceError, SealDivergenceReport, verify_seal_divergence,

--- a/crates/ravel-catalog/src/provisioning.rs
+++ b/crates/ravel-catalog/src/provisioning.rs
@@ -571,6 +571,82 @@ pub fn max_scan_count_over_range(
     }
 }
 
+/// The generation that *unambiguously* owns ingest-hour bucket `hour`, or
+/// `None` when more than one generation's shards can hold that hour's data
+/// (ADR-0103 decision 1(b)). The generation-identity sibling of [`scan_count`]:
+/// same history, same interval math, but it answers "is exactly one generation
+/// in the scan set for this hour, and which one" instead of "how wide is the
+/// scan set".
+///
+/// A generation `g` owns `hour` iff `hour` falls in `g`'s **stable** interval
+///
+/// ```text
+/// [ activation_hour(g) + S , activation_hour(g+1) )
+/// ```
+///
+/// where `S` is `slack_hours` ([`DEFAULT_SCAN_SLACK_HOURS`]) and a nonexistent
+/// successor activates at infinity. The two ends close the two ways a second
+/// generation can reach into the hour:
+///
+/// - The `+ S` on the lower end excludes `g`'s own activation boundary and the
+///   slack margin above it, where a straggler routed under the retiring
+///   predecessor `g-1` is still in [`scan_count`]'s set (ADR-0052 section 4).
+/// - The exclusive `activation_hour(g+1)` upper end excludes every hour the
+///   successor has already activated for.
+///
+/// The **first** generation carries no lower margin (`activation_hour(0)`, not
+/// `activation_hour(0) + S`): the margin exists only to exclude a predecessor's
+/// stragglers, and generation 0 has no predecessor. For a validated history
+/// generation 0 activates at hour 0, so the first `S` hours of the tenant's
+/// history resolve to `Some(0)` and a single-generation history resolves every
+/// hour to `Some(0)` -- the "never resharded" case, which must stay eligible.
+///
+/// This makes the function exactly equivalent to "the scan set for `hour` is
+/// the single generation `g`": `Some(g)` iff `g` is the only generation
+/// [`scan_count`]'s interval test admits for `hour`, `None` iff two or more are
+/// admitted. `shard_for(series, shard_count)` is therefore provably constant
+/// for every hour this returns `Some` for, which is what ADR-0103's pushdown
+/// eligibility gate needs: no series can be split across two shard values, so
+/// no series can be split across two slice workers.
+///
+/// `None` for an hour that predates the first generation's activation (no
+/// generation owns it) and for an empty slice. Neither happens for the
+/// normalized, validated history [`read_generations`] returns (non-empty,
+/// dense, activation-increasing, generation 0 at `activation_hour` 0); both are
+/// handled defensively rather than assumed away, because the fail-closed answer
+/// here is "ineligible", never "assume generation 0".
+///
+/// A pure function with no I/O, like [`scan_count`] and
+/// [`max_scan_count_over_range`] beside it.
+pub fn stable_generation_for_hour(
+    generations: &[ShardGeneration],
+    hour: u32,
+    slack_hours: u32,
+) -> Option<u32> {
+    for (idx, g) in generations.iter().enumerate() {
+        // `u64` keeps `activation + slack` from overflowing `u32`, matching
+        // `scan_count`.
+        let stable_start = if idx == 0 {
+            // No predecessor, so no straggler margin to clear.
+            u64::from(g.activation_hour)
+        } else {
+            u64::from(g.activation_hour).saturating_add(u64::from(slack_hours))
+        };
+        if u64::from(hour) < stable_start {
+            // `hour` is below this generation's stable interval, and
+            // activations increase, so it is below every later one's too.
+            return None;
+        }
+        let successor_activation = generations
+            .get(idx + 1)
+            .map_or(u64::MAX, |s| u64::from(s.activation_hour));
+        if u64::from(hour) < successor_activation {
+            return Some(g.generation);
+        }
+    }
+    None
+}
+
 /// The fold-time fan-out ceiling (ADR-0052 section 5): `max { count(g) :
 /// activation_hour(g) <= watermark_hour }`, with **no** slack-window upper
 /// bound. This is the value a fold stamps into `SnapshotHead.shard_count` /
@@ -1494,6 +1570,7 @@ pub async fn raise_format_floor(
 #[allow(clippy::expect_used)]
 mod tests {
     use super::*;
+    use proptest::prelude::*;
     use ravel_object_store::fault::{FaultPlan, FaultStore, Occurrence, Op, Rule, ScriptedFault};
     use ravel_object_store::memory::MemoryStore;
     use ravel_object_store::{ObjectStoreBackend, PutMode, PutOptions};
@@ -2005,6 +2082,296 @@ mod tests {
         );
         assert_eq!(scan_count(&gens, 201, 2), 8, "still inside gen1's slack");
         assert_eq!(scan_count(&gens, 202, 2), 2, "slack closed: gen2's count");
+    }
+
+    /// The generation ids [`scan_count`]'s documented interval math admits for
+    /// `hour`: `activation_hour(g) <= hour` and
+    /// `hour < successor_activation(g) + S`, with a nonexistent successor
+    /// activating at infinity. Written out independently here (rather than
+    /// reusing `stable_generation_for_hour`'s own loop) so the property tests
+    /// below compare `stable_generation_for_hour` against the scan rule
+    /// itself, not against its own implementation.
+    fn scan_set_generations(gens: &[ShardGeneration], hour: u32, slack_hours: u32) -> Vec<u32> {
+        let mut ids = Vec::new();
+        for (idx, g) in gens.iter().enumerate() {
+            if g.activation_hour > hour {
+                continue;
+            }
+            let successor_activation = gens
+                .get(idx + 1)
+                .map_or(u64::MAX, |s| u64::from(s.activation_hour));
+            if u64::from(hour) < successor_activation.saturating_add(u64::from(slack_hours)) {
+                ids.push(g.generation);
+            }
+        }
+        ids
+    }
+
+    /// A valid history: generation 0 at `activation_hour` 0, dense generation
+    /// numbers, strictly increasing activations spaced `min_gap..=max_gap`
+    /// apart, adjacent counts always differing.
+    fn history_strategy(
+        min_gap: u32,
+        max_gap: u32,
+        max_extra_gens: usize,
+    ) -> impl Strategy<Value = Vec<ShardGeneration>> {
+        proptest::collection::vec((min_gap..=max_gap, 1u32..=64u32), 0..max_extra_gens).prop_map(
+            |tail| {
+                let mut gens = vec![sg(0, 4, 0)];
+                for (gap, count) in tail {
+                    let prev = gens[gens.len() - 1];
+                    let count = if count == prev.shard_count {
+                        prev.shard_count + 1
+                    } else {
+                        count
+                    };
+                    gens.push(sg(
+                        prev.generation + 1,
+                        count,
+                        prev.activation_hour + gap.max(1),
+                    ));
+                }
+                gens
+            },
+        )
+    }
+
+    /// `stable_generation_for_hour`: a single generation (the never-resharded
+    /// tenant) owns every hour, including the first `S` hours -- generation 0
+    /// has no predecessor, so it carries no straggler margin. This is the case
+    /// pushdown eligibility must never lose (ADR-0103 decision 1(b)).
+    #[test]
+    fn stable_generation_for_hour_single_generation() {
+        let gens = [sg(0, 4, 0)];
+        for hour in [0, 1, 2, 3, 99, 1_000, u32::MAX] {
+            assert_eq!(
+                stable_generation_for_hour(&gens, hour, DEFAULT_SCAN_SLACK_HOURS),
+                Some(0),
+                "hour {hour}"
+            );
+        }
+    }
+
+    /// `stable_generation_for_hour` across a shard-count INCREASE: the last
+    /// hour before the activation belongs to the retiring generation, the
+    /// activation hour and its slack margin belong to neither, and the first
+    /// hour past the margin belongs to the new generation.
+    #[test]
+    fn stable_generation_for_hour_increase_boundary() {
+        // gen0 count 4 @0; gen1 count 8 @100. S = 3.
+        let gens = [sg(0, 4, 0), sg(1, 8, 100)];
+        let s = DEFAULT_SCAN_SLACK_HOURS;
+        assert_eq!(stable_generation_for_hour(&gens, 99, s), Some(0));
+        assert_eq!(
+            stable_generation_for_hour(&gens, 100, s),
+            None,
+            "activation hour: a straggler routed under gen0 can still land here"
+        );
+        assert_eq!(stable_generation_for_hour(&gens, 101, s), None);
+        assert_eq!(
+            stable_generation_for_hour(&gens, 102, s),
+            None,
+            "last hour inside the slack margin"
+        );
+        assert_eq!(
+            stable_generation_for_hour(&gens, 103, s),
+            Some(1),
+            "first stable hour of gen1"
+        );
+        assert_eq!(stable_generation_for_hour(&gens, 10_000, s), Some(1));
+    }
+
+    /// `stable_generation_for_hour` across a shard-count DECREASE: identical
+    /// interval math (the function reads activation hours only, never counts),
+    /// so the retiring larger generation's slack margin is ambiguous the same
+    /// way an increase's is.
+    #[test]
+    fn stable_generation_for_hour_decrease_boundary() {
+        // gen0 count 8 @0; gen1 count 4 @100. S = 3.
+        let gens = [sg(0, 8, 0), sg(1, 4, 100)];
+        let s = DEFAULT_SCAN_SLACK_HOURS;
+        assert_eq!(stable_generation_for_hour(&gens, 99, s), Some(0));
+        assert_eq!(stable_generation_for_hour(&gens, 100, s), None);
+        assert_eq!(stable_generation_for_hour(&gens, 102, s), None);
+        assert_eq!(stable_generation_for_hour(&gens, 103, s), Some(1));
+    }
+
+    /// Three generations: a middle generation whose stable interval is bounded
+    /// on both sides, plus the ambiguous margins around each boundary.
+    #[test]
+    fn stable_generation_for_hour_three_generations() {
+        // gen0 count 4 @0; gen1 count 8 @100; gen2 count 2 @200. S = 3.
+        let gens = [sg(0, 4, 0), sg(1, 8, 100), sg(2, 2, 200)];
+        let s = DEFAULT_SCAN_SLACK_HOURS;
+        assert_eq!(stable_generation_for_hour(&gens, 50, s), Some(0));
+        assert_eq!(stable_generation_for_hour(&gens, 100, s), None);
+        assert_eq!(stable_generation_for_hour(&gens, 103, s), Some(1));
+        assert_eq!(stable_generation_for_hour(&gens, 199, s), Some(1));
+        assert_eq!(stable_generation_for_hour(&gens, 200, s), None);
+        assert_eq!(stable_generation_for_hour(&gens, 202, s), None);
+        assert_eq!(stable_generation_for_hour(&gens, 203, s), Some(2));
+    }
+
+    /// A generation whose successor activates inside its own slack margin has
+    /// NO stable interval at all: every one of its hours is ambiguous. Two
+    /// reshards within `S` hours of each other therefore disable pushdown for
+    /// the whole span, which is the conservative direction.
+    #[test]
+    fn stable_generation_for_hour_gap_narrower_than_slack_has_no_stable_hour() {
+        // gen1 @100, gen2 @102, with S = 3: gen1's stable interval would be
+        // [103, 102), empty.
+        let gens = [sg(0, 4, 0), sg(1, 8, 100), sg(2, 2, 102)];
+        let s = DEFAULT_SCAN_SLACK_HOURS;
+        assert_eq!(stable_generation_for_hour(&gens, 99, s), Some(0));
+        for hour in 100..=104 {
+            assert_eq!(
+                stable_generation_for_hour(&gens, hour, s),
+                None,
+                "hour {hour}"
+            );
+        }
+        assert_eq!(stable_generation_for_hour(&gens, 105, s), Some(2));
+    }
+
+    /// An hour that predates the first generation's activation is owned by no
+    /// generation: `None`, never "assume generation 0". Unreachable for a
+    /// validated history (generation 0 activates at hour 0); the defensive
+    /// branch is pinned so it cannot drift to a fail-open answer.
+    #[test]
+    fn stable_generation_for_hour_before_first_activation_is_none() {
+        let gens = [sg(0, 4, 50)];
+        assert_eq!(
+            stable_generation_for_hour(&gens, 49, DEFAULT_SCAN_SLACK_HOURS),
+            None
+        );
+        assert_eq!(
+            stable_generation_for_hour(&gens, 50, DEFAULT_SCAN_SLACK_HOURS),
+            Some(0),
+            "the first generation carries no lower margin"
+        );
+        assert_eq!(
+            stable_generation_for_hour(&[], 0, DEFAULT_SCAN_SLACK_HOURS),
+            None,
+            "empty (never-validated) history owns nothing"
+        );
+    }
+
+    /// The load-bearing slack-margin test (ADR-0103 decision 1(b)): skipping
+    /// the margin and using `next_activation_hour` directly is unsound, because
+    /// ADR-0052's scan rule keeps the retiring generation's shard indices in
+    /// the scan set for `DEFAULT_SCAN_SLACK_HOURS` past the successor's
+    /// activation. A query resolving a segment from that margin can hold the
+    /// same series under two shard values (two slice workers), and a pushed-down
+    /// count/min/max over it would be silently wrong.
+    ///
+    /// Delete the `+ slack_hours` from `stable_generation_for_hour`'s
+    /// `stable_start` and hour 100 starts returning `Some(1)`: this test fails.
+    #[test]
+    fn nf_stable_generation_for_hour_slack_margin_is_load_bearing() {
+        // Count 4 then 8, activation at hour 100.
+        let gens = [sg(0, 4, 0), sg(1, 8, 100)];
+        assert_eq!(
+            stable_generation_for_hour(&gens, 100, DEFAULT_SCAN_SLACK_HOURS),
+            None,
+            "hour 100 is inside gen1's slack margin: ADR-0052's scan rule still \
+             scans gen0's 4 shards for it, so the hour is ambiguous"
+        );
+        // The scan rule itself is what makes it ambiguous: both generations are
+        // in the scan set for hour 100.
+        assert_eq!(
+            scan_set_generations(&gens, 100, DEFAULT_SCAN_SLACK_HOURS),
+            vec![0, 1]
+        );
+        assert_eq!(
+            stable_generation_for_hour(
+                &gens,
+                100 + DEFAULT_SCAN_SLACK_HOURS,
+                DEFAULT_SCAN_SLACK_HOURS
+            ),
+            Some(1),
+            "one slack window past the activation, gen1 owns the hour alone"
+        );
+        assert_eq!(
+            scan_set_generations(
+                &gens,
+                100 + DEFAULT_SCAN_SLACK_HOURS,
+                DEFAULT_SCAN_SLACK_HOURS
+            ),
+            vec![1]
+        );
+    }
+
+    proptest! {
+        /// `stable_generation_for_hour` is exactly "the scan set for this hour
+        /// holds one generation, and this is it", over arbitrary valid
+        /// histories (one to four generations, increases and decreases, gaps
+        /// both wider and narrower than the slack window), arbitrary hours, and
+        /// arbitrary slack windows. The oracle is `scan_count`'s own documented
+        /// interval math, restated at generation-id level.
+        #[test]
+        fn stable_generation_for_hour_matches_scan_set(
+            gens in history_strategy(1, 120, 4),
+            hour in 0u32..500,
+            slack in 0u32..6,
+        ) {
+            let set = scan_set_generations(&gens, hour, slack);
+            let expected = if set.len() == 1 { Some(set[0]) } else { None };
+            prop_assert_eq!(stable_generation_for_hour(&gens, hour, slack), expected);
+        }
+
+        /// When an hour is stable, the scan set is that one generation, so
+        /// `scan_count` for the hour is exactly that generation's own
+        /// `shard_count`: the shard-index domain is provably a single
+        /// generation's, which is what makes `shard_for` constant over the
+        /// hour (ADR-0103 decision 1(b)).
+        #[test]
+        fn stable_hour_scan_count_is_that_generations_count(
+            gens in history_strategy(1, 120, 4),
+            hour in 0u32..500,
+        ) {
+            let s = DEFAULT_SCAN_SLACK_HOURS;
+            if let Some(id) = stable_generation_for_hour(&gens, hour, s) {
+                let owner = gens
+                    .iter()
+                    .find(|g| g.generation == id)
+                    .expect("returned id is one of the history's generations");
+                prop_assert_eq!(scan_count(&gens, hour, s), owner.shard_count);
+            }
+        }
+
+        /// Both edges of every reshard boundary's slack window, for histories
+        /// whose generations are spaced wider than the window: the activation
+        /// hour and `activation_hour + S - 1` are ambiguous, and
+        /// `activation_hour + S` is the first hour the new generation owns
+        /// alone.
+        #[test]
+        fn stable_generation_for_hour_slack_window_edges(
+            gens in history_strategy(DEFAULT_SCAN_SLACK_HOURS + 1, 200, 4),
+        ) {
+            let s = DEFAULT_SCAN_SLACK_HOURS;
+            for (idx, g) in gens.iter().enumerate().skip(1) {
+                prop_assert_eq!(
+                    stable_generation_for_hour(&gens, g.activation_hour, s),
+                    None,
+                    "activation hour of generation {}", idx
+                );
+                prop_assert_eq!(
+                    stable_generation_for_hour(&gens, g.activation_hour + s - 1, s),
+                    None,
+                    "last hour of generation {}'s slack margin", idx
+                );
+                prop_assert_eq!(
+                    stable_generation_for_hour(&gens, g.activation_hour + s, s),
+                    Some(g.generation),
+                    "first stable hour of generation {}", idx
+                );
+                prop_assert_eq!(
+                    stable_generation_for_hour(&gens, g.activation_hour - 1, s),
+                    Some(gens[idx - 1].generation),
+                    "last stable hour before generation {}", idx
+                );
+            }
+        }
     }
 
     /// `DEFAULT_SCAN_SLACK_HOURS` is the sum of

--- a/crates/ravel-query/src/distrib/mod.rs
+++ b/crates/ravel-query/src/distrib/mod.rs
@@ -18,9 +18,11 @@ pub mod client;
 pub mod codec;
 pub mod federation;
 pub mod partition;
+pub mod pushdown;
 pub mod service;
 
 pub use federation::{DEFAULT_REMOTE_SOFT_TIMEOUT, Federation, FederationOutcome, RemoteCluster};
+pub use pushdown::{all_hours_in_one_stable_generation, is_pushdown_eligible};
 
 #[cfg(test)]
 mod tests;

--- a/crates/ravel-query/src/distrib/pushdown.rs
+++ b/crates/ravel-query/src/distrib/pushdown.rs
@@ -1,0 +1,321 @@
+//! The ADR-0103 order-insensitive aggregation pushdown eligibility gate
+//! (decision 1).
+//!
+//! Pushdown lets a slice worker compute a `count`/`min`/`max`/distinct-group
+//! partial instead of shipping raw samples back. That is exact only when no
+//! series can be held by two workers (or by a worker and a remote cluster) at
+//! once: a worker merging only the runs IT holds cannot know whether a sample
+//! it counted is about to lose to an overlapping duplicate elsewhere, so
+//! combining such partials would be a silent wrong answer, not an
+//! approximation. Two independent mechanisms can duplicate one series across
+//! sources, and this module closes both:
+//!
+//! 1. **Online resharding (ADR-0052).** `shard_for(series_id, shard_count)` is
+//!    a modulus over a per-generation `shard_count`, and existing data is never
+//!    re-keyed when that count changes. A series written under two generations
+//!    therefore carries two different shard values, and `partition_snapshot`
+//!    cuts slices by shard, so the same series lands on two workers.
+//! 2. **Federation.** `Federation` folds remote clusters' decoded series into
+//!    the coordinator's merge pool under a shared `SeriesId`, with no relation
+//!    to shard generations at all. A local partial is never complete for a
+//!    series a remote may also hold.
+//!
+//! The gate is deliberately coarse: one boolean per query, computed from the
+//! *resolved* segment set (not the query's stated event-time window --
+//! `Catalog::window_hour_bounds` extends the ingest-hour scan range past the
+//! event window's end so late-arriving writes are still found, so an
+//! event-time check can pass while the resolve still straddles a reshard).
+//! Ineligible means "falls back to today's raw-fetch-and-merge path", never
+//! "wrong": the visible signal is "not accelerated".
+//!
+//! Nothing in the production query path calls this module yet. It is the
+//! primitive ADR-0103's planner-integration task (epic #64, T4) wires into the
+//! planner; the aggregate-expression-shape gate (ADR-0103 decision 4), which is
+//! independent of this one, is separate work.
+
+use ravel_catalog::{
+    DEFAULT_SCAN_SLACK_HOURS, SegmentRef, ShardGeneration, stable_generation_for_hour,
+};
+
+use crate::distrib::federation::Federation;
+
+/// Whether every ingest hour in `hours` is owned by the *same single* shard
+/// generation (ADR-0103 decision 1(b)): the reshard half of the eligibility
+/// gate.
+///
+/// `true` only when [`stable_generation_for_hour`] returns `Some` for every
+/// hour and every one of those answers is the same generation id. Any hour that
+/// is ambiguous (inside a generation boundary's slack margin, where ADR-0052's
+/// scan rule still scans the retiring generation's shards) makes the whole set
+/// ineligible, as does any pair of hours owned by two different generations.
+///
+/// An **empty** `hours` is `false`. A query that resolved no segments has no
+/// data to push down, so eligibility is moot; answering "ineligible" keeps this
+/// function's contract a single unambiguous rule ("exactly one generation owns
+/// every hour") instead of a vacuous `true` a caller could mistake for a
+/// positive verdict.
+///
+/// `generations` must be the normalized, validated history
+/// `Catalog::resolve_pruned_with_generations` returns *for this same resolve*,
+/// never a second, independently-read copy: see that method for why.
+pub fn all_hours_in_one_stable_generation<I>(
+    generations: &[ShardGeneration],
+    hours: I,
+    slack_hours: u32,
+) -> bool
+where
+    I: IntoIterator<Item = u32>,
+{
+    let mut owner: Option<u32> = None;
+    for hour in hours {
+        match stable_generation_for_hour(generations, hour, slack_hours) {
+            // Ambiguous hour: the scan set for it holds more than one
+            // generation, so a series in it can carry two shard values.
+            None => return false,
+            Some(id) => match owner {
+                None => owner = Some(id),
+                Some(seen) if seen == id => {}
+                Some(_) => return false,
+            },
+        }
+    }
+    owner.is_some()
+}
+
+/// Both halves of ADR-0103 decision 1: whether this query may attempt
+/// order-insensitive aggregation pushdown.
+///
+/// - `false` immediately when `federation` is `Some` (decision 1(a)): any
+///   configured remote means a local partial can be incomplete for a series the
+///   remote also holds. Unconditional, regardless of how many remotes are
+///   configured or whether they would actually contribute.
+/// - Otherwise, `true` iff every resolved segment's `ingest_hour_bucket` is
+///   owned by one and the same shard generation's stable interval (decision
+///   1(b)), evaluated with [`DEFAULT_SCAN_SLACK_HOURS`].
+///
+/// `segments` are the segments the query actually resolved (post-resolve, one
+/// pass over an already-materialized list), and `generations` is the history
+/// that same resolve read
+/// (`Catalog::resolve_pruned_with_generations`). Passing a freshly-read or
+/// separately-cached history instead would reintroduce exactly the skew
+/// decision 1(b) forbids: a generation appended between the two reads would be
+/// invisible here while its segments are already in `segments`.
+///
+/// This is the whole eligibility gate, and it is intentionally not called by
+/// any production query path yet (epic #64, T4 wires it into the planner). The
+/// expression-shape gate (ADR-0103 decision 4) is a separate, independent
+/// check; neither implies the other.
+pub fn is_pushdown_eligible(
+    federation: Option<&Federation>,
+    segments: &[SegmentRef],
+    generations: &[ShardGeneration],
+) -> bool {
+    if federation.is_some() {
+        return false;
+    }
+    all_hours_in_one_stable_generation(
+        generations,
+        segments.iter().map(|seg| seg.ingest_hour_bucket),
+        DEFAULT_SCAN_SLACK_HOURS,
+    )
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use async_trait::async_trait;
+    use ravel_catalog::SegmentLevel;
+    use ravel_proto::queryfrag::v1 as pb;
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::distrib::client::{DistribError, SliceFetcher, SliceResponse};
+    use crate::distrib::federation::RemoteCluster;
+
+    fn sg(generation: u32, shard_count: u32, activation_hour: u32) -> ShardGeneration {
+        ShardGeneration {
+            generation,
+            shard_count,
+            activation_hour,
+            appended_unix_ns: 0,
+        }
+    }
+
+    /// A `SegmentRef` carrying only the fields this gate reads
+    /// (`ingest_hour_bucket`, and `shard` for realism); nothing here fetches
+    /// the object, so the identity fields are placeholders.
+    fn seg(ingest_hour_bucket: u32, shard: u32) -> SegmentRef {
+        SegmentRef {
+            data_object_key: format!("t/aa/m/l0/{shard:04}/w.0.{ingest_hour_bucket:020}.x.rseg"),
+            object_size: 1,
+            min_event_ts_ns: 0,
+            max_event_ts_ns: 1,
+            ingest_hour_bucket,
+            sample_count: 1,
+            series_count: 1,
+            shard,
+            content_hash: [0u8; 32],
+            writer_id: Uuid::nil(),
+            writer_epoch: 0,
+            writer_seq: 0,
+            created_unix_ns: 0,
+            level: SegmentLevel::L0,
+        }
+    }
+
+    /// A remote that is never dispatched to: the federation exclusion is
+    /// decided by the presence of a `Federation`, not by any remote's behavior.
+    struct NeverCalledFetcher;
+
+    #[async_trait]
+    impl SliceFetcher for NeverCalledFetcher {
+        async fn fetch(&self, _r: pb::FetchRequest) -> Result<SliceResponse, DistribError> {
+            unreachable!("the eligibility gate never dispatches a fetch")
+        }
+    }
+
+    fn federation() -> Federation {
+        Federation::new(vec![RemoteCluster {
+            name: "eu-west".to_string(),
+            fetcher: Arc::new(NeverCalledFetcher),
+            skip_unavailable: false,
+            soft_timeout: Duration::from_secs(1),
+        }])
+    }
+
+    /// Decision 1(a): a federated query is ineligible unconditionally, even
+    /// when its segments and generation history would otherwise pass on their
+    /// own (proved by the `None` federation case on the same inputs).
+    #[test]
+    fn federated_query_is_never_eligible() {
+        let gens = [sg(0, 4, 0)];
+        let segments = [seg(10, 0), seg(11, 1)];
+        assert!(
+            is_pushdown_eligible(None, &segments, &gens),
+            "these inputs are eligible when not federated"
+        );
+        assert!(!is_pushdown_eligible(Some(&federation()), &segments, &gens));
+        // Also ineligible for input shapes that would fail 1(b) anyway, and for
+        // an empty snapshot: 1(a) short-circuits before either is consulted.
+        let split = [seg(10, 0), seg(500, 1)];
+        let two_gens = [sg(0, 4, 0), sg(1, 8, 100)];
+        assert!(!is_pushdown_eligible(
+            Some(&federation()),
+            &split,
+            &two_gens
+        ));
+        assert!(!is_pushdown_eligible(Some(&federation()), &[], &gens));
+    }
+
+    /// Decision 1(b), the trivial case that must stay fast: a tenant that never
+    /// resharded has one generation, so every resolved hour is owned by it and
+    /// every query is eligible.
+    #[test]
+    fn single_generation_is_eligible() {
+        let gens = [sg(0, 4, 0)];
+        let segments = [seg(0, 0), seg(1, 3), seg(9_999, 2), seg(u32::MAX, 1)];
+        assert!(is_pushdown_eligible(None, &segments, &gens));
+    }
+
+    /// Decision 1(b): resolved segments spanning two generations' stable
+    /// intervals are ineligible. `shard_for` is not constant across them, so
+    /// one series can carry two shard values and land on two workers.
+    #[test]
+    fn segments_spanning_two_generations_are_ineligible() {
+        // gen0 count 4 @0, gen1 count 8 @100, S = 3: gen0's stable interval is
+        // [0, 100), gen1's is [103, inf).
+        let gens = [sg(0, 4, 0), sg(1, 8, 100)];
+        let same_generation = [seg(50, 0), seg(99, 1)];
+        assert!(
+            is_pushdown_eligible(None, &same_generation, &gens),
+            "both hours inside gen0's stable interval"
+        );
+        let spanning = [seg(99, 1), seg(200, 5)];
+        assert!(
+            !is_pushdown_eligible(None, &spanning, &gens),
+            "hour 99 is gen0's, hour 200 is gen1's"
+        );
+        // Order is irrelevant: the gate is a set property.
+        let spanning_reversed = [seg(200, 5), seg(99, 1)];
+        assert!(!is_pushdown_eligible(None, &spanning_reversed, &gens));
+    }
+
+    /// Decision 1(b): every resolved hour inside ONE generation's stable
+    /// interval is eligible, including the post-reshard generation (a tenant
+    /// that resharded long ago is not disqualified forever, only for the
+    /// queries whose scan set touches the boundary).
+    #[test]
+    fn all_segments_in_one_stable_interval_are_eligible() {
+        let gens = [sg(0, 4, 0), sg(1, 8, 100)];
+        let after = [seg(103, 0), seg(150, 7), seg(9_000, 3)];
+        assert!(is_pushdown_eligible(None, &after, &gens));
+        let before = [seg(0, 0), seg(99, 3)];
+        assert!(is_pushdown_eligible(None, &before, &gens));
+    }
+
+    /// Decision 1(b): a single segment from inside a boundary's slack margin
+    /// disqualifies the query on its own, even though every resolved hour maps
+    /// to the same *shard count*. ADR-0052's scan rule still scans the retiring
+    /// generation's shards for that hour, so the hour is genuinely ambiguous.
+    #[test]
+    fn one_segment_inside_the_slack_margin_is_ineligible() {
+        let gens = [sg(0, 4, 0), sg(1, 8, 100)];
+        for hour in 100..100 + DEFAULT_SCAN_SLACK_HOURS {
+            assert!(
+                !is_pushdown_eligible(None, &[seg(hour, 0)], &gens),
+                "hour {hour} is inside gen1's slack margin"
+            );
+            assert!(
+                !is_pushdown_eligible(None, &[seg(150, 0), seg(hour, 1)], &gens),
+                "one ambiguous hour {hour} disqualifies an otherwise-stable set"
+            );
+        }
+        assert!(
+            is_pushdown_eligible(None, &[seg(100 + DEFAULT_SCAN_SLACK_HOURS, 0)], &gens),
+            "the first hour past the margin is gen1's alone"
+        );
+    }
+
+    /// An empty resolved segment set is ineligible: there is nothing to push
+    /// down, and the raw-fetch path handles an empty snapshot identically.
+    #[test]
+    fn empty_segment_set_is_ineligible() {
+        let gens = [sg(0, 4, 0)];
+        assert!(!is_pushdown_eligible(None, &[], &gens));
+        assert!(!all_hours_in_one_stable_generation(
+            &gens,
+            std::iter::empty(),
+            DEFAULT_SCAN_SLACK_HOURS
+        ));
+    }
+
+    /// An empty (never-validated) generation history owns no hour, so it is
+    /// ineligible rather than treated as "assume generation 0".
+    #[test]
+    fn empty_generation_history_is_ineligible() {
+        assert!(!is_pushdown_eligible(None, &[seg(10, 0)], &[]));
+    }
+
+    /// `all_hours_in_one_stable_generation` is the reshard half on its own,
+    /// including duplicate hours (many segments per hour, the common case) and
+    /// an explicit slack argument.
+    #[test]
+    fn hours_check_is_independent_of_multiplicity_and_slack() {
+        let gens = [sg(0, 4, 0), sg(1, 8, 100)];
+        let s = DEFAULT_SCAN_SLACK_HOURS;
+        assert!(all_hours_in_one_stable_generation(
+            &gens,
+            [50, 50, 50, 99],
+            s
+        ));
+        assert!(!all_hours_in_one_stable_generation(&gens, [50, 50, 100], s));
+        // With no slack the margin vanishes, so the activation hour itself is
+        // gen1's alone. Pins that the slack window is the argument's, not a
+        // hard-coded constant inside the check.
+        assert!(all_hours_in_one_stable_generation(&gens, [100, 150], 0));
+        assert!(!all_hours_in_one_stable_generation(&gens, [99, 100], 0));
+    }
+}


### PR DESCRIPTION
Epic #64 T1. Adds the standalone eligibility primitive ADR-0103 decision
1 specifies for order-insensitive aggregation pushdown: a shard-generation
stable-interval check plus a federation exclusion.

stable_generation_for_hour in ravel-catalog/provisioning.rs returns the
owning generation for an ingest hour only when that hour sits outside
every reshard boundary's slack margin; is_pushdown_eligible in
ravel-query/distrib/pushdown.rs combines that with an unconditional
federation exclusion. Not wired into any query path yet; a later task
in this epic does that once the wire protocol and coordinator combine
land.

Reviewed by an opus checkpoint pass in an isolated worktree, which
mutated the slack-margin comparisons and the federation short-circuit
directly to confirm the tests actually go red without them, and traced
the resolve path to confirm the gate reads the same generation history
the snapshot resolve already fetched rather than a second, possibly
staler read.

Refs: #64
Fixes: #473
