### PR TITLE
fix(ravel-sql): register length as a named conformance construct

### DIFF
--- a/benchmarks/clickbench/hits.corpus.json
+++ b/benchmarks/clickbench/hits.corpus.json
@@ -470,6 +470,57 @@
       ]
     },
     {
+      "id": "q28_url_length_by_counter",
+      "sql": "SELECT \"CounterID\", AVG(length(\"URL\")) AS l, COUNT(*) AS c FROM logs WHERE \"URL\" <> '' GROUP BY \"CounterID\" HAVING COUNT(*) > 100000 ORDER BY l DESC LIMIT 25",
+      "constructs": [
+        "logs -> Signal::Logs",
+        "Filter (WHERE)",
+        "GROUP BY",
+        "HAVING",
+        "ORDER BY",
+        "LIMIT",
+        "avg",
+        "count",
+        "length",
+        "declared i64 typed comparison"
+      ],
+      "upstream_id": "Q28",
+      "required_declarations": [
+        {
+          "key": "CounterID",
+          "ty": "i64"
+        },
+        {
+          "key": "URL",
+          "ty": "str"
+        }
+      ]
+    },
+    {
+      "id": "q29_referer_length_by_host",
+      "sql": "SELECT regexp_replace(\"Referer\", '^https?://(?:www\\.)?([^/]+)/.*$', '\\1') AS k, AVG(length(\"Referer\")) AS l, COUNT(*) AS c, MIN(\"Referer\") FROM logs WHERE \"Referer\" <> '' GROUP BY k HAVING COUNT(*) > 100000 ORDER BY l DESC LIMIT 25",
+      "constructs": [
+        "logs -> Signal::Logs",
+        "Filter (WHERE)",
+        "GROUP BY",
+        "HAVING",
+        "ORDER BY",
+        "LIMIT",
+        "avg",
+        "count",
+        "min",
+        "length",
+        "regexp_replace"
+      ],
+      "upstream_id": "Q29",
+      "required_declarations": [
+        {
+          "key": "Referer",
+          "ty": "str"
+        }
+      ]
+    },
+    {
       "id": "q30_resolution_running_sums",
       "sql": "SELECT SUM(\"ResolutionWidth\"), SUM(\"ResolutionWidth\" + 1), SUM(\"ResolutionWidth\" + 2), SUM(\"ResolutionWidth\" + 3), SUM(\"ResolutionWidth\" + 4), SUM(\"ResolutionWidth\" + 5), SUM(\"ResolutionWidth\" + 6), SUM(\"ResolutionWidth\" + 7), SUM(\"ResolutionWidth\" + 8), SUM(\"ResolutionWidth\" + 9), SUM(\"ResolutionWidth\" + 10), SUM(\"ResolutionWidth\" + 11), SUM(\"ResolutionWidth\" + 12), SUM(\"ResolutionWidth\" + 13), SUM(\"ResolutionWidth\" + 14), SUM(\"ResolutionWidth\" + 15), SUM(\"ResolutionWidth\" + 16), SUM(\"ResolutionWidth\" + 17), SUM(\"ResolutionWidth\" + 18), SUM(\"ResolutionWidth\" + 19), SUM(\"ResolutionWidth\" + 20), SUM(\"ResolutionWidth\" + 21), SUM(\"ResolutionWidth\" + 22), SUM(\"ResolutionWidth\" + 23), SUM(\"ResolutionWidth\" + 24), SUM(\"ResolutionWidth\" + 25), SUM(\"ResolutionWidth\" + 26), SUM(\"ResolutionWidth\" + 27), SUM(\"ResolutionWidth\" + 28), SUM(\"ResolutionWidth\" + 29), SUM(\"ResolutionWidth\" + 30), SUM(\"ResolutionWidth\" + 31), SUM(\"ResolutionWidth\" + 32), SUM(\"ResolutionWidth\" + 33), SUM(\"ResolutionWidth\" + 34), SUM(\"ResolutionWidth\" + 35), SUM(\"ResolutionWidth\" + 36), SUM(\"ResolutionWidth\" + 37), SUM(\"ResolutionWidth\" + 38), SUM(\"ResolutionWidth\" + 39), SUM(\"ResolutionWidth\" + 40), SUM(\"ResolutionWidth\" + 41), SUM(\"ResolutionWidth\" + 42), SUM(\"ResolutionWidth\" + 43), SUM(\"ResolutionWidth\" + 44), SUM(\"ResolutionWidth\" + 45), SUM(\"ResolutionWidth\" + 46), SUM(\"ResolutionWidth\" + 47), SUM(\"ResolutionWidth\" + 48), SUM(\"ResolutionWidth\" + 49), SUM(\"ResolutionWidth\" + 50), SUM(\"ResolutionWidth\" + 51), SUM(\"ResolutionWidth\" + 52), SUM(\"ResolutionWidth\" + 53), SUM(\"ResolutionWidth\" + 54), SUM(\"ResolutionWidth\" + 55), SUM(\"ResolutionWidth\" + 56), SUM(\"ResolutionWidth\" + 57), SUM(\"ResolutionWidth\" + 58), SUM(\"ResolutionWidth\" + 59), SUM(\"ResolutionWidth\" + 60), SUM(\"ResolutionWidth\" + 61), SUM(\"ResolutionWidth\" + 62), SUM(\"ResolutionWidth\" + 63), SUM(\"ResolutionWidth\" + 64), SUM(\"ResolutionWidth\" + 65), SUM(\"ResolutionWidth\" + 66), SUM(\"ResolutionWidth\" + 67), SUM(\"ResolutionWidth\" + 68), SUM(\"ResolutionWidth\" + 69), SUM(\"ResolutionWidth\" + 70), SUM(\"ResolutionWidth\" + 71), SUM(\"ResolutionWidth\" + 72), SUM(\"ResolutionWidth\" + 73), SUM(\"ResolutionWidth\" + 74), SUM(\"ResolutionWidth\" + 75), SUM(\"ResolutionWidth\" + 76), SUM(\"ResolutionWidth\" + 77), SUM(\"ResolutionWidth\" + 78), SUM(\"ResolutionWidth\" + 79), SUM(\"ResolutionWidth\" + 80), SUM(\"ResolutionWidth\" + 81), SUM(\"ResolutionWidth\" + 82), SUM(\"ResolutionWidth\" + 83), SUM(\"ResolutionWidth\" + 84), SUM(\"ResolutionWidth\" + 85), SUM(\"ResolutionWidth\" + 86), SUM(\"ResolutionWidth\" + 87), SUM(\"ResolutionWidth\" + 88), SUM(\"ResolutionWidth\" + 89) FROM logs",
       "constructs": [

--- a/crates/ravel-bench/tests/clickbench_corpus.rs
+++ b/crates/ravel-bench/tests/clickbench_corpus.rs
@@ -38,9 +38,10 @@ const UPSTREAM_COUNT: usize = 43;
 
 /// The ClickBench statements the corpus construct-gate cannot admit, each paired
 /// with the single construct that blocks it. One row per rejected statement; the
-/// distinct missing capabilities are two (`LIKE` pattern matching, and `length`
-/// not being enumerated as a named construct in the conformance registry) -- see
-/// the runbook's gap list and the issues it references.
+/// distinct missing capability is `LIKE` pattern matching (issue #479) -- see
+/// the runbook's gap list and the issue it references. Q28/Q29 (`length`, issue
+/// #480) moved into the corpus file once `length` was registered as a named
+/// construct.
 ///
 /// Each named construct MUST be absent from [`supported_construct_names`]
 /// (asserted by [`each_known_gap_names_a_genuinely_unsupported_construct`]): a
@@ -52,8 +53,6 @@ const KNOWN_GAPS: &[(&str, &str)] = &[
     ("Q22", "LIKE pattern match"),
     ("Q23", "LIKE pattern match"),
     ("Q24", "LIKE pattern match"),
-    ("Q28", "length"),
-    ("Q29", "length"),
 ];
 
 #[test]

--- a/crates/ravel-sql/src/conformance.rs
+++ b/crates/ravel-sql/src/conformance.rs
@@ -276,6 +276,22 @@ const ADMITTED_SCALAR_FAMILIES: [ScalarFamily; 6] = [
     },
 ];
 
+/// Individually-named upstream admitted scalars (ADR-0097 decision 8: "every
+/// function this repository already names as claimed or relied upon"),
+/// distinct from [`ADMITTED_SCALAR_FAMILIES`]'s one-row-per-family bound.
+/// `length`'s family (unicode) already has a representative row (`reverse`),
+/// but the corpus construct gate (`ravel_bench::sql_corpus`) matches by exact
+/// function name, so a caller who names `length` specifically -- as
+/// ClickBench's Q28/Q29 do (issue #480) -- needs its own row, not coverage
+/// borrowed from a same-family sibling. Every name here is a member of
+/// [`ADMITTED_SCALARS`]; the drift test asserts that.
+const NAMED_ADMITTED_SCALARS: [ScalarFamily; 1] = [ScalarFamily {
+    name: "length",
+    example: "SELECT length('résumé') FROM samples LIMIT 1",
+    note: "character count, not byte count: 'résumé' is 6 characters but 7 bytes \
+           (the 'é's are two-byte UTF-8)",
+}];
+
 /// Ravel's own scalar UDFs (ADR-0097 decision 8), each individually attested
 /// because each is Ravel code rather than upstream DataFusion. Every name is a
 /// member of [`ADMITTED_SCALARS`]; the drift test asserts that. Each carries a
@@ -298,15 +314,16 @@ const RAVEL_SCALAR_UDFS: [(&str, &str); 3] = [
 ];
 
 /// The number of admitted-scalar conformance rows the registry is expected to
-/// emit: one per admitted family plus each Ravel UDF. Recorded as a hard
-/// literal, independent of the array lengths, so a row silently deleted from
-/// [`ADMITTED_SCALAR_FAMILIES`] or [`RAVEL_SCALAR_UDFS`] fails the drift test
+/// emit: one per admitted family, plus each individually-named admitted
+/// scalar, plus each Ravel UDF. Recorded as a hard literal, independent of the
+/// array lengths, so a row silently deleted from [`ADMITTED_SCALAR_FAMILIES`],
+/// [`NAMED_ADMITTED_SCALARS`], or [`RAVEL_SCALAR_UDFS`] fails the drift test
 /// (`registry_reads_the_live_allowlist_sets`) instead of shrinking the score's
 /// denominator along with its numerator and holding the reported score at 100%
 /// (#408). A deliberate change to the family/UDF set updates this literal in the
 /// same edit.
 #[cfg(test)]
-const EXPECTED_ADMITTED_SCALAR_ROW_COUNT: usize = 9;
+const EXPECTED_ADMITTED_SCALAR_ROW_COUNT: usize = 10;
 
 /// The eight admitted native window functions (ADR-0097 decision 6), each with
 /// an `OVER` example whose aggregated result is re-derived from the four
@@ -566,6 +583,19 @@ pub fn registry() -> Vec<Construct> {
             example: fam.example.to_string(),
             classification: Classification::SupportedAndCovered { test: T_SUPPORTED },
             rationale: fam.note,
+        });
+    }
+    // Individually-named upstream admitted scalars: a family member with its
+    // own row because a caller (e.g. the ClickBench corpus, issue #480) names
+    // it by exact function name rather than being covered by the family
+    // representative's row.
+    for named in &NAMED_ADMITTED_SCALARS {
+        out.push(Construct {
+            category: Category::Scalar,
+            name: named.name.to_string(),
+            example: named.example.to_string(),
+            classification: Classification::SupportedAndCovered { test: T_SUPPORTED },
+            rationale: named.note,
         });
     }
     // Ravel's own scalar UDFs, individually attested: each is Ravel code, not
@@ -1062,13 +1092,15 @@ mod tests {
             "rejected scalar rows must be exactly EXCLUDED_SCALARS"
         );
 
-        // Admitted scalar: family-based. One row per family plus each Ravel
-        // UDF, each naming a live admitted scalar.
+        // Admitted scalar: family-based. One row per family, plus each
+        // individually-named admitted scalar, plus each Ravel UDF, each
+        // naming a live admitted scalar.
         let admitted_scalar_rows = names(Category::Scalar, false);
         assert_eq!(
             admitted_scalar_rows.len(),
-            ADMITTED_SCALAR_FAMILIES.len() + RAVEL_SCALAR_UDFS.len(),
-            "admitted scalar rows must be one per family plus each Ravel UDF"
+            ADMITTED_SCALAR_FAMILIES.len() + NAMED_ADMITTED_SCALARS.len() + RAVEL_SCALAR_UDFS.len(),
+            "admitted scalar rows must be one per family, plus each individually-named \
+             admitted scalar, plus each Ravel UDF"
         );
         // Bind the source arrays to a hard-recorded count, not just to each
         // other. The check above compares the registry's rows against the same
@@ -1078,10 +1110,11 @@ mod tests {
         // array length must equal the recorded count, which a deliberate change
         // updates in the same edit.
         assert_eq!(
-            ADMITTED_SCALAR_FAMILIES.len() + RAVEL_SCALAR_UDFS.len(),
+            ADMITTED_SCALAR_FAMILIES.len() + NAMED_ADMITTED_SCALARS.len() + RAVEL_SCALAR_UDFS.len(),
             EXPECTED_ADMITTED_SCALAR_ROW_COUNT,
             "admitted-scalar row count changed: update EXPECTED_ADMITTED_SCALAR_ROW_COUNT \
-             deliberately if a family or Ravel UDF was intentionally added or removed"
+             deliberately if a family, named scalar, or Ravel UDF was intentionally added \
+             or removed"
         );
         for name in &admitted_scalar_rows {
             assert!(
@@ -1094,6 +1127,13 @@ mod tests {
                 admitted_scalar_rows.contains(fam.name),
                 "scalar family representative `{}` has no row",
                 fam.name
+            );
+        }
+        for named in &NAMED_ADMITTED_SCALARS {
+            assert!(
+                admitted_scalar_rows.contains(named.name),
+                "individually-named admitted scalar `{}` has no row",
+                named.name
             );
         }
         for (udf, _) in RAVEL_SCALAR_UDFS {

--- a/crates/ravel-sql/tests/conformance.rs
+++ b/crates/ravel-sql/tests/conformance.rs
@@ -151,6 +151,10 @@ fn expectation(construct: &Construct) -> Option<Expect> {
         (Category::Scalar, "regexp_replace") => Some(Expect::Str("fooXbar")),
         // hex of the single byte 0x61 ('a').
         (Category::Scalar, "encode") => Some(Expect::Str("61")),
+        // Character count, not byte count: 'résumé' is 6 characters (r-é-s-u-
+        // m-é) but 7 bytes, since each 'é' is a two-byte UTF-8 sequence. A
+        // byte-counting length would answer 7, so this is load-bearing.
+        (Category::Scalar, "length") => Some(Expect::Scalar(6.0)),
         // Ravel UDFs over the fixture. The sample with value 3.0 belongs to
         // series "b", whose only label is `__name__ = "b"`.
         (Category::Scalar, "label") => Some(Expect::Str("b")),
@@ -260,7 +264,7 @@ fn single_str(output: &QueryOutput) -> Result<String, String> {
 /// The single numeric cell of a one-row, one-column result, as an `f64`.
 /// `count` comes back as an integer column, so both cases are read.
 fn single_f64(output: &QueryOutput) -> Result<f64, String> {
-    use datafusion::arrow::array::{Float64Array, Int64Array, UInt64Array};
+    use datafusion::arrow::array::{Float64Array, Int32Array, Int64Array, UInt64Array};
 
     let batch = output
         .batches()
@@ -278,6 +282,12 @@ fn single_f64(output: &QueryOutput) -> Result<f64, String> {
         return Ok(ints.value(0) as f64);
     }
     if let Some(ints) = column.as_any().downcast_ref::<UInt64Array>() {
+        return Ok(ints.value(0) as f64);
+    }
+    // `length`/`character_length` return Int32 (DataFusion's
+    // `utf8_to_int_type`, narrower than the Int64 the other admitted scalars
+    // and aggregates use).
+    if let Some(ints) = column.as_any().downcast_ref::<Int32Array>() {
         return Ok(ints.value(0) as f64);
     }
     Err(format!(

--- a/docs/guides/clickbench.md
+++ b/docs/guides/clickbench.md
@@ -186,7 +186,7 @@ Running a 43-query suite against a supported-construct gate means some queries
 fail the gate rather than return a number. That is the intended outcome: an
 unsupported construct becomes a **named capability gap with a failing query
 attached**, not an omission from a results table. The checked-in corpus holds
-the **37** statements that pass the gate; the **6** below are recorded as known
+the **39** statements that pass the gate; the **4** below are recorded as known
 gaps (enforced by `crates/ravel-bench/tests/clickbench_corpus.rs`, which fails if
 any of the 43 is neither in the corpus nor listed as a gap).
 
@@ -196,26 +196,18 @@ any of the 43 is neither in the corpus nor listed as a gap).
 | Q22 | `LIKE` pattern match | `WHERE URL LIKE '%google%'` | substring/pattern search |
 | Q23 | `LIKE` pattern match | `LIKE '%Google%'` and `NOT LIKE '%.google.%'` | substring/pattern search |
 | Q24 | `LIKE` pattern match | `WHERE URL LIKE '%google%'` (also `SELECT *`) | substring/pattern search |
-| Q28 | `length` | `AVG(length(URL))` | scalar not enumerated in the conformance registry |
-| Q29 | `length` | `AVG(length(Referer))` | scalar not enumerated in the conformance registry |
 
-Two distinct capability gaps sit behind these six statements:
+**`LIKE` / SQL pattern matching** is not in Ravel's supported construct set.
+Ravel offers token search (`has_word`) and `regexp_replace`, but no `LIKE`
+with `%`/`_` wildcards, which four ClickBench statements depend on. This is a
+genuine engine capability gap, tracked as issue #479.
 
-1. **`LIKE` / SQL pattern matching** is not in Ravel's supported construct set.
-   Ravel offers token search (`has_word`) and `regexp_replace`, but no `LIKE`
-   with `%`/`_` wildcards, which four ClickBench statements depend on. This is a
-   genuine engine capability gap.
-2. **`length` is admitted by the SQL engine but not enumerated as a named
-   construct** in `ravel_sql::conformance::registry()`. The registry attests
-   scalar functions by family representative (`upper`, `regexp_replace`, ...),
-   not one row per function, so `length` — though it executes — cannot be named
-   by a corpus entry without failing the construct gate. This is an
-   attestation-coverage gap, not an executability gap: the fix is to enumerate
-   `length` (and peers) in the registry, after which Q28/Q29 move into the
-   corpus. See the "corpus format" note in the ADR-0100 epic.
-
-The issue bodies for both are filed with the epic (they could not be filed from
-the executor environment; see the task report).
+Q28/Q29 (`AVG(length(...))`) were also blocked, but that gap was bookkeeping,
+not capability: `length` was already admitted by the SQL engine, just not
+enumerated as a named construct in `ravel_sql::conformance::registry()` (the
+registry attests scalar functions by family representative and did not yet
+have an individual row for `length`). Issue #480 added that row; Q28 and Q29
+now run as ordinary corpus entries.
 
 ## Modified statements
 

--- a/docs/sql-conformance-examples.txt
+++ b/docs/sql-conformance-examples.txt
@@ -79,6 +79,7 @@ Scalar function	encode	SELECT encode('a', 'hex') FROM samples LIMIT 1
 Scalar function	has_word	SELECT count(*) FROM logs WHERE has_word(body, '1')
 Scalar function	label	SELECT label(labels, '__name__') FROM samples WHERE value = 3.0
 Scalar function	label_match	SELECT count(*) FROM samples WHERE label_match(labels, '__name__', 'b')
+Scalar function	length	SELECT length('résumé') FROM samples LIMIT 1
 Scalar function	now	SELECT now() FROM samples
 Scalar function	rand	SELECT rand() FROM samples
 Scalar function	random	SELECT random() FROM samples

--- a/docs/sql-conformance.md
+++ b/docs/sql-conformance.md
@@ -54,10 +54,10 @@ and stays conformant.
 
 ## Score
 
-- Supported and covered: 41
+- Supported and covered: 42
 - Intentionally rejected: 68
 - Unclassified / broken: 0
-- **Conformance: 109 / 109 = 100.0%**
+- **Conformance: 110 / 110 = 100.0%**
 
 ## Conformance table
 
@@ -132,6 +132,7 @@ and stays conformant.
 | Scalar function | `has_word` | `SELECT count(*) FROM logs WHERE has_word(body, '1')` | Supported and covered | `tests/conformance.rs::supported_constructs_execute` | Ravel per-table scalar UDF, individually attested (ADR-0097 decision 8) |
 | Scalar function | `label` | `SELECT label(labels, '__name__') FROM samples WHERE value = 3.0` | Supported and covered | `tests/conformance.rs::supported_constructs_execute` | Ravel per-table scalar UDF, individually attested (ADR-0097 decision 8) |
 | Scalar function | `label_match` | `SELECT count(*) FROM samples WHERE label_match(labels, '__name__', 'b')` | Supported and covered | `tests/conformance.rs::supported_constructs_execute` | Ravel per-table scalar UDF, individually attested (ADR-0097 decision 8) |
+| Scalar function | `length` | `SELECT length('résumé') FROM samples LIMIT 1` | Supported and covered | `tests/conformance.rs::supported_constructs_execute` | character count, not byte count: 'résumé' is 6 characters but 7 bytes (the 'é's are two-byte UTF-8) |
 | Scalar function | `now` | `SELECT now() FROM samples` | Intentionally rejected | `ValidationError::ExcludedScalar` | nondeterministic or environment-reading; unattestable by the differential oracle (ADR-0097 decision 4) |
 | Scalar function | `rand` | `SELECT rand() FROM samples` | Intentionally rejected | `ValidationError::ExcludedScalar` | nondeterministic or environment-reading; unattestable by the differential oracle (ADR-0097 decision 4) |
 | Scalar function | `random` | `SELECT random() FROM samples` | Intentionally rejected | `ValidationError::ExcludedScalar` | nondeterministic or environment-reading; unattestable by the differential oracle (ADR-0097 decision 4) |


### PR DESCRIPTION
## What

Registers `length` as a named construct in `ravel_sql::conformance::registry()`
and moves ClickBench Q28/Q29 (`AVG(length(URL))`, `AVG(length(Referer))`) from
the corpus's known-gaps list into `benchmarks/clickbench/hits.corpus.json`.

## Why

The corpus construct gate is fail-closed: a construct absent from the registry
is rejected regardless of whether the engine can evaluate it. `length` was
already admitted (`ADMITTED_SCALARS`) and executes correctly, just not
enumerated. It sits in the `unicode` family, whose representative row is
`reverse` — that covers the family for the drift test, but the corpus gate
matches by exact function name, so a caller naming `length` directly still
needed its own row. Added `NAMED_ADMITTED_SCALARS`, a bucket distinct from the
family bound, for exactly this shape (ADR-0097 decision 8: "every function
this repository already names as claimed or relied upon").

## Verification before writing the fix

Two throwaway probe tests, run and removed before touching the corpus file:

- `length`'s actual return type/value (`Int32`, character count not byte
  count — `résumé` is 6 characters but 7 bytes). `tests/conformance.rs`'s
  `single_f64` only handled `Float64`/`Int64`/`UInt64`, so extended it.
- Q29's exact shape (`GROUP BY` on a `REGEXP_REPLACE` alias, `HAVING`,
  `AVG(length(...))`, `MIN(...)`) executes end to end — a different capability
  than the plain-column `GROUP BY` already proven elsewhere in the corpus, so
  worth confirming rather than assuming it falls out of existing coverage.

Q28/Q29's SQL text is the real upstream ClickBench queries (fetched from
`ClickHouse/ClickBench`'s `queries.sql`), not reconstructed from the runbook's
paraphrase.

## Testing

Mutation-proofed: removed the `NAMED_ADMITTED_SCALARS` registration and
confirmed the corpus gate test fails on `q28`'s construct (`UnsupportedConstruct`),
then restored it and confirmed both `ravel-sql`'s conformance suite and
`ravel-bench`'s `clickbench_corpus` gate test pass.

Runbook (`docs/guides/clickbench.md`) updated: 39 statements now pass the gate,
not 37; the `length` gap is described as bookkeeping (unregistered, not
unsupported), distinct from the genuine `LIKE` capability gap (#479).

`scripts/gates.sh -p ravel-sql -p ravel-bench` green.

Fixes: #480
