### PR TITLE
fix(scripts): reap worktrees whose PR merged, not just ancestors

### DIFF
--- a/scripts/disk-reap.sh
+++ b/scripts/disk-reap.sh
@@ -48,6 +48,11 @@ main_sha="$(git -C "${repo_root}" rev-parse origin/main)"
 # The primary checkout is never a candidate, whatever its state. (git
 # refuses to remove a main working tree, but do not rely on that.)
 main_wt="$(dirname "$(git -C "${repo_root}" rev-parse --path-format=absolute --git-common-dir)")"
+# owner/name for the PR-state fallback below, derived from the remote rather
+# than hardcoded. Empty is fine: the fallback treats an unresolvable repo the
+# same as an absent gh and keeps the conservative skip.
+gh_repo="$(git -C "${repo_root}" remote get-url origin 2>/dev/null |
+  sed -E 's#^(https://[^/]+/|git@[^:]+:)##; s#\.git$##')"
 
 echo "==> merged, clean worktrees"
 # Parse `worktree list --porcelain` blocks; macOS ships bash 3.2, so no
@@ -79,9 +84,53 @@ git -C "${repo_root}" worktree list --porcelain | awk '
   fi
   if git -C "${repo_root}" merge-base --is-ancestor "${head_sha}" "${main_sha}"; then
     act git -C "${repo_root}" worktree remove --force "${wt}"
-  else
-    echo "skip (unmerged): ${wt}"
+    continue
   fi
+  # Ancestry is necessary but not sufficient on this repo: `main` is
+  # protected and merges are REBASE-only, so a merged branch's commits are
+  # rewritten and its HEAD is never an ancestor of main. Ancestry alone
+  # therefore refuses every merged worktree forever -- six were sitting in
+  # that state, all with merged PRs, and this script would never have
+  # touched any of them.
+  #
+  # So fall back to the PR state, which is the authoritative signal for
+  # "has this landed". Two conditions, both required, because a merged PR
+  # does not by itself mean the worktree is disposable:
+  #   - a PR whose head is this branch is MERGED, and
+  #   - the worktree's HEAD is still exactly that PR's head commit, so any
+  #     commit added after the merge blocks the reap rather than being
+  #     silently discarded.
+  # Any uncertainty (no gh, not authenticated, no PR, a mismatched sha)
+  # keeps the old conservative skip: this script must never be the reason
+  # work disappears.
+  branch="$(git -C "${wt}" symbolic-ref --quiet --short HEAD 2>/dev/null || true)"
+  if [[ -z "${branch}" ]]; then
+    echo "skip (detached, not an ancestor of main): ${wt}"
+    continue
+  fi
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "skip (not an ancestor of main; gh absent, cannot check PR state): ${wt}"
+    continue
+  fi
+  pr_head=""
+  pr_num=""
+  pr_line="$(gh pr list --repo "${gh_repo}" --head "${branch}" --state merged \
+    --limit 1 --json number,headRefOid \
+    --jq '.[0] | select(.number) | "\(.number)\t\(.headRefOid)"' 2>/dev/null || true)"
+  if [[ -n "${pr_line}" ]]; then
+    pr_num="${pr_line%%$'\t'*}"
+    pr_head="${pr_line##*$'\t'}"
+  fi
+  if [[ -z "${pr_num}" ]]; then
+    echo "skip (not an ancestor of main, no merged PR for ${branch}): ${wt}"
+    continue
+  fi
+  if [[ "${pr_head}" != "${head_sha}" ]]; then
+    echo "skip (PR #${pr_num} merged but ${wt} has moved past its head): ${wt}"
+    continue
+  fi
+  echo "reap (PR #${pr_num} merged, rebase-merged so not an ancestor): ${wt}"
+  act git -C "${repo_root}" worktree remove --force "${wt}"
 done
 
 echo "==> orphaned cargo target dirs"


### PR DESCRIPTION
`disk-reap.sh` decided "has this landed" with `merge-base --is-ancestor HEAD origin/main`. But `main` is protected and merges are **rebase-only**, so a merged branch's commits are rewritten and its HEAD is never an ancestor. The check therefore refuses every merged worktree, permanently.

Six were sitting in that state when this was found — all six with merged PRs, all six clean, and the script would never have touched any of them. On a volume that has hit **zero bytes free** more than once this week (at which point the Bash tool cannot create its own output file and every session on the host is hard-blocked, including whichever one has to do the recovery), a reaper that structurally cannot reap is worth fixing.

Ancestry stays as the cheap first test — no network, and it still holds for a fast-forwarded branch. When it fails, PR state decides, because that is the authoritative signal. Two conditions, both required:

- a PR whose head is this branch is **MERGED**, and
- the worktree's HEAD is still **exactly that PR's head commit**.

The second condition is what makes this safe rather than merely useful: a commit added after the merge blocks the reap instead of being silently discarded.

Every uncertainty keeps the old conservative skip, and says which one it hit: `gh` absent, repo unresolvable, no merged PR for the branch, detached HEAD, or a sha mismatch. This script must never be the reason work disappears.

**Verified both directions against a real worktree, not by reading the diff.** At PR #465's exact head:

```
reap (PR #465 merged, rebase-merged so not an ancestor): /private/tmp/reap-probe
```

With one commit added on top:

```
skip (PR #465 merged but /private/tmp/reap-probe has moved past its head)
```

Found while reclaiming disk during a multi-session day: I removed those six by hand after checking PR state, having first been told by `git branch --merged` to keep all of them. Credit to the session that pointed out the script has the same blind spot rather than letting it stay a private workaround.

Refs: #475