### PR TITLE
docs(adrs): claim ADR-0104 for ingest profiling and baselines

### DIFF
--- a/docs/adrs/0104-ingest-profiling-and-baselines.md
+++ b/docs/adrs/0104-ingest-profiling-and-baselines.md
@@ -1,0 +1,3 @@
+# ADR-0104: per-stage ingest profiling and regression baselines
+
+Status: claimed


### PR DESCRIPTION
Reserve ADR number 0104 on main so parallel epics cannot pick it. Stub only; the full decision text lands after the design approval gate.

Refs: #365