### PR TITLE
feat(ravel-query): compute partial aggregates on the slice worker

### DIFF
--- a/crates/ravel-query/src/distrib/client.rs
+++ b/crates/ravel-query/src/distrib/client.rs
@@ -42,8 +42,9 @@ pub enum DistribError {
     /// The remote streamed a frame kind this decoder's call site cannot
     /// consume: a per-signal record frame (a log record or a span) for a signal
     /// this coordinator's metrics fetch path does not handle, or a
-    /// `PartialAggregate` (ADR-0103 decision 2), which no coordinator consumes
-    /// yet because no encoder call site sends one.
+    /// `PartialAggregate` (ADR-0103 decision 2) on a log or span slice, where a
+    /// worker-computed scalar aggregate is never expected (the metrics decoder
+    /// does consume it).
     /// Unreachable from a real query today: the metrics coordinator only ever
     /// dispatches `Signal::Metrics`, and the log/span coordinators that would
     /// receive these frames are built by #284/#285. The `frame` oneof is
@@ -69,6 +70,14 @@ pub struct SliceResponse {
     /// (ADR-0096 decision 3 step 4). Post-erasure (the worker applied the
     /// request's predicates). Only meaningful when `status` is `Ok`.
     pub histogram: Vec<FetchedHistogramSeries>,
+    /// Decoded worker-computed partial aggregates, one per series the worker
+    /// held (ADR-0103 decision 2). Non-empty only for a slice whose request
+    /// carried a `partial_aggregate`, and mutually exclusive with `scalar` on
+    /// such a slice: a worker returns all partials or all raw frames, never a
+    /// mix. Nothing combines these into a query result yet -- the
+    /// coordinator-side combine and the planner integration are the next task,
+    /// so today's callers of [`decode_slice_frames`] ignore this field.
+    pub partials: Vec<codec::PartialAggregate>,
     /// The worker's per-slice cost accounting.
     pub accounting: ravel_types::accounting::QueryAccountingSnapshot,
     /// The worker's per-slice `FetchStats` page counters, folded (summed) by
@@ -289,15 +298,23 @@ impl SliceFetcher for RemoteSliceFetcher {
 /// frame that fails to decode ([`DistribError::Codec`], the same as a malformed
 /// scalar frame -- as of `PROTOCOL_VERSION` 3 a `Hist` frame is real data this
 /// build consumes, so a decode failure is corruption, never a coverage gap), a
-/// `PartialAggregate` frame, which this build never consumes because no encoder
-/// sends one yet ([`DistribError::FrameSignalUnsupported`]), a
+/// malformed `PartialAggregate` frame ([`DistribError::Codec`], for the same
+/// reason: a worker only sends one when the coordinator asked for it, so a frame
+/// that fails to decode is corruption), a
 /// frame carrying no oneof variant ([`DistribError::EmptyFrame`]), a second
 /// summary ([`DistribError::MultipleSummaries`]), a stream that ended with no
 /// summary ([`DistribError::NoSummary`]), a summary with no status, or an
 /// unknown status code.
+///
+/// `PartialAggregate` frames (ADR-0103 decision 2) decode into
+/// [`SliceResponse::partials`]. This is the decode side only: no caller acts on
+/// them yet, so a slice that returns partials contributes nothing to a query
+/// result today. The coordinator-side combine and the planner integration that
+/// make a pushdown-computed answer reachable from a real query are the next task.
 pub fn decode_slice_frames(frames: Vec<pb::FetchResponse>) -> Result<SliceResponse, DistribError> {
     let mut scalar = Vec::new();
     let mut histogram = Vec::new();
+    let mut partials = Vec::new();
     let mut summary: Option<pb::Summary> = None;
     for frame in frames {
         match frame.frame {
@@ -313,8 +330,8 @@ pub fn decode_slice_frames(frames: Vec<pb::FetchResponse>) -> Result<SliceRespon
             Some(pb::fetch_response::Frame::Span(_)) => {
                 return Err(DistribError::FrameSignalUnsupported("span"));
             }
-            Some(pb::fetch_response::Frame::PartialAggregate(_)) => {
-                return Err(DistribError::FrameSignalUnsupported("partial-aggregate"));
+            Some(pb::fetch_response::Frame::PartialAggregate(pa)) => {
+                partials.push(codec::decode_partial_aggregate(pa)?);
             }
             Some(pb::fetch_response::Frame::Summary(s)) => {
                 if summary.is_some() {
@@ -338,6 +355,7 @@ pub fn decode_slice_frames(frames: Vec<pb::FetchResponse>) -> Result<SliceRespon
     Ok(SliceResponse {
         scalar,
         histogram,
+        partials,
         accounting,
         stats: FetchStats {
             raw_f64_pages: summary.raw_f64_pages,
@@ -889,35 +907,82 @@ mod tests {
         ));
     }
 
-    /// A `PartialAggregate` frame (ADR-0103 decision 2) is rejected as
-    /// `FrameSignalUnsupported` by every decoder: the frame and its codec land
-    /// before any sender exists, so no coordinator consumes one yet. Relaxing
-    /// any of the three explicit `Frame::PartialAggregate(_)` reject arms to a
-    /// wildcard would drop the frame and decode to an empty `Ok`, failing these
-    /// assertions.
-    #[test]
-    fn every_decoder_rejects_partial_aggregate_as_unsupported() {
-        let partial = || pb::FetchResponse {
+    /// A well-formed `PartialAggregate` frame (ADR-0103 decision 2). Its bounds
+    /// are `-0.0` and a NaN payload so a decode that round-tripped them through
+    /// a proto double instead of the bit pattern would be visible.
+    fn partial_frame() -> pb::FetchResponse {
+        pb::FetchResponse {
             frame: Some(pb::fetch_response::Frame::PartialAggregate(
                 pb::PartialAggregate {
-                    series_id: vec![0u8; 16],
-                    labels: Vec::new(),
+                    series_id: vec![4u8; 16],
+                    labels: vec![pb::Label {
+                        name: "__name__".to_string(),
+                        value: "m".to_string(),
+                    }],
                     count: Some(3),
+                    min_bits: Some((-0.0f64).to_bits()),
+                    max_bits: Some(0x7ff8_0000_0000_0abc),
+                },
+            )),
+        }
+    }
+
+    /// The metrics decoder consumes a `PartialAggregate` frame as real data
+    /// (ADR-0103 decision 2): it lands in `SliceResponse::partials`, bit-exact,
+    /// and does not disturb the raw `scalar`/`histogram` collections. Restoring
+    /// the former `FrameSignalUnsupported` reject arm at this one call site fails
+    /// the `expect` below.
+    #[test]
+    fn metrics_decoder_collects_partial_aggregates() {
+        let response =
+            decode_slice_frames(vec![partial_frame(), summary_frame(pb::status::Code::Ok)])
+                .expect("a well-formed partial aggregate decodes");
+        assert!(response.scalar.is_empty());
+        assert!(response.histogram.is_empty());
+        assert_eq!(response.partials.len(), 1);
+        let got = &response.partials[0];
+        assert_eq!(got.series_id, SeriesId([4u8; 16]));
+        assert_eq!(got.count, Some(3));
+        // Bit patterns, never `==`: -0.0 and a NaN payload must survive exactly.
+        assert_eq!(got.min.map(f64::to_bits), Some((-0.0f64).to_bits()));
+        assert_eq!(got.max.map(f64::to_bits), Some(0x7ff8_0000_0000_0abc));
+    }
+
+    /// A malformed `PartialAggregate` (a 15-byte series id) on the metrics path
+    /// is a typed `Codec` error, never a panic and never a silently dropped
+    /// group.
+    #[test]
+    fn malformed_partial_aggregate_is_typed_codec_error() {
+        let bad = pb::FetchResponse {
+            frame: Some(pb::fetch_response::Frame::PartialAggregate(
+                pb::PartialAggregate {
+                    series_id: vec![0u8; 15],
+                    labels: Vec::new(),
+                    count: Some(1),
                     min_bits: None,
                     max_bits: None,
                 },
             )),
         };
         assert!(matches!(
-            decode_slice_frames(vec![partial(), summary_frame(pb::status::Code::Ok)]),
+            decode_slice_frames(vec![bad, summary_frame(pb::status::Code::Ok)]),
+            Err(DistribError::Codec(CodecError::BadSeriesId { got: 15 }))
+        ));
+    }
+
+    /// The log and span decoders keep rejecting a `PartialAggregate` as
+    /// `FrameSignalUnsupported`: a worker-computed scalar aggregate is never
+    /// expected on those slices (ADR-0103 is metrics-only). Relaxing either
+    /// explicit reject arm to a wildcard would drop the frame and decode to an
+    /// empty `Ok`, failing these assertions.
+    #[test]
+    fn log_and_span_decoders_reject_partial_aggregate_as_unsupported() {
+        assert!(matches!(
+            decode_log_slice_frames(vec![partial_frame(), summary_frame(pb::status::Code::Ok)]),
             Err(DistribError::FrameSignalUnsupported("partial-aggregate"))
         ));
         assert!(matches!(
-            decode_log_slice_frames(vec![partial(), summary_frame(pb::status::Code::Ok)]),
-            Err(DistribError::FrameSignalUnsupported("partial-aggregate"))
-        ));
-        assert!(matches!(
-            decode_span_slice_frames(vec![partial(), summary_frame(pb::status::Code::Ok)]),
+            decode_span_slice_frames(vec![partial_frame(), summary_frame(pb::status::Code::Ok)]),
             Err(DistribError::FrameSignalUnsupported("partial-aggregate"))
         ));
     }

--- a/crates/ravel-query/src/distrib/codec.rs
+++ b/crates/ravel-query/src/distrib/codec.rs
@@ -935,9 +935,11 @@ pub struct PartialAggregate {
 /// [`f64::to_bits`] pattern. An absent field stays absent on the wire (proto3
 /// `optional`), never a zero sentinel.
 ///
-/// Not reachable from a query today: no encoder call site sends this frame yet
-/// (the worker-side sender lands with the pushdown execution path). This is the
-/// wire format and its codec only.
+/// The worker's slice path is this encoder's call site (ADR-0103 decision 2,
+/// `service.rs`): a Metrics slice whose request carries a
+/// [`pb::PartialAggregateRequest`] emits one of these per series instead of its
+/// raw series frames. Not yet reachable from a real query, though: no
+/// coordinator sets that request field until the planner integration lands.
 pub fn encode_partial_aggregate(partial: &PartialAggregate) -> pb::PartialAggregate {
     pb::PartialAggregate {
         series_id: partial.series_id.0.to_vec(),

--- a/crates/ravel-query/src/distrib/federation.rs
+++ b/crates/ravel-query/src/distrib/federation.rs
@@ -262,6 +262,11 @@ impl Federation {
                 // (ADR-0071 amendment, decision 2): it authenticates through an
                 // ordinary tenant credential on the remote, never a capability.
                 fragment_capability: Vec::new(),
+                // A federated query is unconditionally ineligible for
+                // aggregation pushdown (ADR-0103 decision 1(a)): a remote's
+                // local partial cannot be complete for a series the local
+                // cluster may also hold runs of.
+                partial_aggregate: None,
             };
             let handle =
                 tokio::spawn(
@@ -552,6 +557,7 @@ mod tests {
             Ok(SliceResponse {
                 scalar: Vec::new(),
                 histogram: Vec::new(),
+                partials: Vec::new(),
                 accounting: QueryAccountingSnapshot::default(),
                 stats: FetchStats::default(),
                 series_returned: 0,

--- a/crates/ravel-query/src/distrib/mod.rs
+++ b/crates/ravel-query/src/distrib/mod.rs
@@ -210,6 +210,11 @@ impl Distributed {
                     // builder leaves the bytes empty. A coordinator-local slice
                     // needs no capability.
                     fragment_capability: Vec::new(),
+                    // No aggregation pushdown from this builder: it always asks
+                    // for raw runs and merges them here (ADR-0103's eligibility
+                    // gate and the coordinator-side combine that would set this
+                    // field are not wired yet).
+                    partial_aggregate: None,
                 };
                 let fetcher = Arc::clone(&self.fetcher);
                 async move { fetcher.fetch(request).await }
@@ -439,6 +444,9 @@ impl Distributed {
                     erasure: encoded_erasure.clone(),
                     trace_context: String::new(),
                     fragment_capability: Vec::new(),
+                    // Pushdown is metrics-only (ADR-0103); a log slice never
+                    // carries an aggregate request.
+                    partial_aggregate: None,
                 };
                 let fetcher = Arc::clone(&self.fetcher);
                 async move { fetcher.fetch_logs(request).await }
@@ -592,6 +600,9 @@ impl Distributed {
                     erasure: encoded_erasure.clone(),
                     trace_context: String::new(),
                     fragment_capability: Vec::new(),
+                    // Pushdown is metrics-only (ADR-0103); a span slice never
+                    // carries an aggregate request.
+                    partial_aggregate: None,
                 };
                 let fetcher = Arc::clone(&self.fetcher);
                 async move { fetcher.fetch_spans(request).await }

--- a/crates/ravel-query/src/distrib/service.rs
+++ b/crates/ravel-query/src/distrib/service.rs
@@ -21,6 +21,21 @@
 //! version ever receives these frames, so the new columns and records are never
 //! silently dropped by an older decoder.
 //!
+//! # Aggregation pushdown
+//!
+//! A Metrics slice whose request carries a [`pb::PartialAggregateRequest`]
+//! (ADR-0103 decision 2) returns one [`pb::PartialAggregate`] frame per series
+//! instead of its raw series frames. The worker merges its own runs first
+//! ([`merge_soa_runs`], the same total-order per-series dedup the coordinator
+//! runs on the raw-fetch path) and reduces each series' deduped samples, so a
+//! sample that two of this worker's segments both carry is counted once, never
+//! twice. That local merge is what makes the partial exact: under ADR-0103
+//! decision 1's eligibility gate the coordinator only asks for a partial when
+//! no other worker and no remote cluster can hold runs of the same series, so
+//! there is nothing left for the coordinator's cross-worker dedup belt to
+//! reconcile. A request with no `partial_aggregate` takes the raw-frame path
+//! unchanged.
+//!
 //! # Segment identity resolution
 //!
 //! A worker receives durable [`pb::SegmentIdentity`] values, not object keys or
@@ -31,6 +46,7 @@
 //! is the interim implementation, resolving against the same pinned snapshot
 //! the coordinator dispatched from.
 
+use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -39,16 +55,19 @@ use futures::Stream;
 use ravel_catalog::SegmentRef;
 use ravel_proto::queryfrag::v1 as pb;
 use ravel_types::accounting::{QueryAccounting, QueryAccountingSnapshot};
-use ravel_types::{Signal, TenantHash};
+use ravel_types::{SeriesId, Signal, TenantHash};
 
 use ravel_rspan::SpanQuery;
 
 use crate::config::ByteLimit;
 use crate::distrib::codec;
 use crate::distrib::proto::series_fetch_server::{SeriesFetch, SeriesFetchServer};
-use crate::engine::bytes_scanned_exceeded;
+use crate::engine::{bytes_scanned_exceeded, merge_soa_runs};
 use crate::erasure::is_erased_span;
-use crate::fetcher::{FetchError, FetchStats, FetchedHistogramSeries, SegmentFetcher};
+use crate::error::QueryError;
+use crate::fetcher::{
+    FetchError, FetchStats, FetchedHistogramSeries, FetchedSeriesSoa, SegmentFetcher,
+};
 use crate::log_fetcher::{LogFetchError, LogQuery, LogSegmentFetcher};
 use crate::span_fetcher::{SpanFetchError, SpanSegmentFetcher};
 
@@ -202,6 +221,18 @@ impl<R: SegmentResolver + 'static> SeriesFetchService<R> {
             .map_err(|e| (pb::status::Code::BadData, e.to_string()))?;
         let erasure = codec::decode_erasure(request.erasure);
 
+        // Aggregation pushdown (ADR-0103) is defined for the scalar Metrics
+        // lane only: `PartialAggregate` carries f64 bounds over scalar samples,
+        // and no log or span shape maps onto it. Fail closed so the coordinator
+        // falls back to raw fetch, rather than silently ignoring the request and
+        // streaming frames a pushdown-expecting caller did not ask for.
+        if request.partial_aggregate.is_some() && !matches!(signal, Signal::Metrics) {
+            return Err((
+                pb::status::Code::Unsupported,
+                format!("aggregation pushdown is not defined for signal {signal:?}"),
+            ));
+        }
+
         match signal {
             // Metrics keeps its exact path: resolve the pinned scope, fetch,
             // and encode scalar series. Unchanged from before #283.
@@ -212,6 +243,7 @@ impl<R: SegmentResolver + 'static> SeriesFetchService<R> {
                     tenant_hash,
                     matchers,
                     erasure,
+                    request.partial_aggregate,
                 )
                 .await
             }
@@ -269,6 +301,12 @@ impl<R: SegmentResolver + 'static> SeriesFetchService<R> {
     /// scalar series and one `HistogramFrame` per native-histogram series,
     /// ending in a terminal summary (ADR-0096 decision 3 step 4). Extracted from
     /// `run_slice_inner` so the per-signal dispatch there can call it as one arm.
+    ///
+    /// When `partial_aggregate` is `Some`, the fetch loop and the erasure pass
+    /// are unchanged but the encode step is replaced: the worker merges its own
+    /// runs and streams one [`pb::PartialAggregate`] per series instead of every
+    /// series frame (ADR-0103 decision 2). The branch is per request, not per
+    /// series, so one slice returns all partials or all raw frames, never a mix.
     async fn run_slice_metrics(
         &self,
         scope: Option<pb::fetch_request::Scope>,
@@ -276,6 +314,7 @@ impl<R: SegmentResolver + 'static> SeriesFetchService<R> {
         tenant_hash: TenantHash,
         matchers: Vec<ravel_promql::LabelMatcher>,
         erasure: Vec<crate::erasure::ErasurePredicate>,
+        partial_aggregate: Option<pb::PartialAggregateRequest>,
     ) -> Result<Vec<pb::FetchResponse>, (pb::status::Code, String)> {
         let identities = match scope {
             Some(pb::fetch_request::Scope::Pinned(pinned)) => pinned.segments,
@@ -364,6 +403,47 @@ impl<R: SegmentResolver + 'static> SeriesFetchService<R> {
             for series in &mut scalar {
                 crate::erasure::retain_series_soa(series, &erasure);
             }
+        }
+
+        // Aggregation pushdown (ADR-0103 decision 2): this slice returns one
+        // partial per series instead of its raw runs. Everything above (fetch,
+        // budget, erasure) already ran exactly as it does on the raw path; only
+        // the encode step below differs.
+        if let Some(want) = partial_aggregate {
+            // A native-histogram series has no scalar count/min/max shape:
+            // `PartialAggregate` carries f64 bounds only. Silently omitting such
+            // series would answer a pushdown query over an incomplete set, so
+            // fail closed to the coordinator's raw-fetch fallback instead.
+            if !histograms.is_empty() {
+                return Err((
+                    pb::status::Code::Unsupported,
+                    "aggregation pushdown is not defined for native-histogram series".to_string(),
+                ));
+            }
+            let (partials, samples_merged) =
+                reduce_partial_aggregates(scalar, &want).map_err(map_merge_error)?;
+            let series_returned = partials.len() as u64;
+            let mut frames = Vec::with_capacity(partials.len() + 1);
+            for partial in &partials {
+                frames.push(pb::FetchResponse {
+                    frame: Some(pb::fetch_response::Frame::PartialAggregate(
+                        codec::encode_partial_aggregate(partial),
+                    )),
+                });
+            }
+            // `samples_returned` stays the count of samples this slice actually
+            // reduced, not the number of frames, so the coordinator's own
+            // sample-budget re-check still sees a slice's real yield even though
+            // the samples themselves never cross the wire.
+            frames.push(summary_frame(
+                &accounting.snapshot(),
+                series_returned,
+                samples_merged,
+                pb::status::Code::Ok,
+                String::new(),
+                &stats,
+            ));
+            return Ok(frames);
         }
 
         // Run-merged scalar runs and native-histogram runs now cross the wire
@@ -732,6 +812,123 @@ fn summary_frame(
             raw_f64_pages: stats.raw_f64_pages,
             raw_f64_bytes: stats.raw_f64_bytes,
         })),
+    }
+}
+
+/// Reduces this worker's fetched scalar runs into one exact partial aggregate
+/// per series (ADR-0103 decisions 1 and 3), plus the total number of deduped
+/// samples the reduction consumed (for the terminal summary's
+/// `samples_returned`).
+///
+/// The merge comes first and is not optional. `fetched` is per-segment, so two
+/// segments of this slice can both carry the same `(series_id, ts)` -- a
+/// duplicate write, or a run-merged L1 segment overlapping its L0 inputs.
+/// Reducing each `FetchedSeriesSoa` on its own would count such a sample twice
+/// and could report a bound from the sample the dedup order drops.
+/// [`merge_soa_runs`] resolves each timestamp under the full ADR-0010 total
+/// order first, so the reduction below runs over exactly one winning sample per
+/// timestamp -- the same samples the coordinator's raw-fetch path would have
+/// merged out of these runs.
+///
+/// Grouping by series id here, then merging one series at a time, is what
+/// preserves the identity the frame must carry: [`merge_soa_runs`] returns
+/// `SeriesData` (labels plus deduped samples) and drops the series id, and a
+/// worker cannot recompute it (`SeriesId::compute` hashes the `TenantId`, and a
+/// worker holds only a [`TenantHash`]). One call per series id is otherwise
+/// identical to one call over everything: `merge_soa_runs` already merges each
+/// series id's runs independently of every other series, and the caps are
+/// unbounded here because the worker's own budget is bytes-scanned only (the
+/// coordinator enforces the series and sample caps, over the summary this
+/// returns).
+///
+/// `min`/`max` fold under [`f64::total_cmp`], the same total order ADR-0023's
+/// min/max UDAF uses (`crates/ravel-sql/src/minmax.rs`): a candidate replaces
+/// the incumbent only on a strict `Less`/`Greater`, so NaN payloads and the sign
+/// of zero behave exactly as they do in every other typed-aggregate path here,
+/// and never through `PartialOrd`. A series whose samples were all erased
+/// carries `count: Some(0)` with no bounds: there is no value to bound, and an
+/// absent bound stays distinct from a present `0.0`.
+fn reduce_partial_aggregates(
+    fetched: Vec<Vec<FetchedSeriesSoa>>,
+    want: &pb::PartialAggregateRequest,
+) -> Result<(Vec<codec::PartialAggregate>, u64), QueryError> {
+    // Insertion-ordered grouping (a positions map beside the runs), so the frame
+    // order a worker emits is a deterministic function of its fetch order rather
+    // than of hash iteration order.
+    let mut positions: HashMap<SeriesId, usize> = HashMap::new();
+    let mut grouped: Vec<(SeriesId, Vec<FetchedSeriesSoa>)> = Vec::new();
+    for segment_series in fetched {
+        for fs in segment_series {
+            match positions.get(&fs.series_id) {
+                Some(&idx) => grouped[idx].1.push(fs),
+                None => {
+                    positions.insert(fs.series_id, grouped.len());
+                    grouped.push((fs.series_id, vec![fs]));
+                }
+            }
+        }
+    }
+
+    let mut partials = Vec::with_capacity(grouped.len());
+    let mut samples_merged = 0u64;
+    for (series_id, runs) in grouped {
+        // One series id in, so at most one `SeriesData` out.
+        let merged = merge_soa_runs(vec![runs], usize::MAX, usize::MAX)?;
+        let Some(series) = merged.into_iter().next() else {
+            continue;
+        };
+        let count = series.samples.len() as u64;
+        samples_merged += count;
+        let min = series
+            .samples
+            .iter()
+            .map(|s| s.value)
+            .reduce(|current, candidate| replaces(candidate, current, Ordering::Less));
+        let max = series
+            .samples
+            .iter()
+            .map(|s| s.value)
+            .reduce(|current, candidate| replaces(candidate, current, Ordering::Greater));
+        partials.push(codec::PartialAggregate {
+            series_id,
+            labels: series.labels,
+            count: want.want_count.then_some(count),
+            min: if want.want_min { min } else { None },
+            max: if want.want_max { max } else { None },
+        });
+    }
+    Ok((partials, samples_merged))
+}
+
+/// The min/max fold step: `candidate` replaces `current` only when
+/// `candidate.total_cmp(&current)` is the wanted strict ordering (`Less` for
+/// min, `Greater` for max), so a tie keeps the incumbent. Mirrors
+/// `Extreme::replaces` in `crates/ravel-sql/src/minmax.rs` field for field, the
+/// ADR-0023 total order ADR-0103 decision 3 names for the coordinator's own
+/// combine.
+fn replaces(candidate: f64, current: f64, want: Ordering) -> f64 {
+    if candidate.total_cmp(&current) == want {
+        candidate
+    } else {
+        current
+    }
+}
+
+/// Maps a worker-side merge failure to the slice's typed status. A run that is
+/// not ascending, or a per-sample dedup column that is not parallel to its run,
+/// is corruption in a decoded segment, not a budget or capability problem. The
+/// caps are unbounded on this path, so the two budget variants cannot fire; they
+/// map to `BudgetExceeded` rather than being collapsed into a catch-all, so a
+/// future capped call site gets the right status instead of `Internal`.
+fn map_merge_error(err: QueryError) -> (pb::status::Code, String) {
+    match err {
+        QueryError::TooManySeries { .. } | QueryError::TooManySamples { .. } => {
+            (pb::status::Code::BudgetExceeded, err.to_string())
+        }
+        QueryError::NonMonotonicSamples { .. } | QueryError::PrioritySampleCountMismatch { .. } => {
+            (pb::status::Code::Corrupt, err.to_string())
+        }
+        other => (pb::status::Code::Internal, other.to_string()),
     }
 }
 

--- a/crates/ravel-query/src/distrib/tests.rs
+++ b/crates/ravel-query/src/distrib/tests.rs
@@ -1085,6 +1085,7 @@ fn worker_trips_bytes_budget_per_segment() {
             erasure: Vec::new(),
             trace_context: String::new(),
             fragment_capability: Vec::new(),
+            partial_aggregate: None,
         };
         let response = SliceFetcher::fetch(&fetcher, request)
             .await
@@ -1118,6 +1119,7 @@ impl SliceFetcher for LyingBudgetWorker {
         Ok(SliceResponse {
             scalar: Vec::new(),
             histogram: Vec::new(),
+            partials: Vec::new(),
             accounting: acct.snapshot(),
             stats: crate::fetcher::FetchStats::default(),
             series_returned: 0,
@@ -1214,6 +1216,7 @@ impl SliceFetcher for AlwaysInvalidated {
         Ok(SliceResponse {
             scalar: Vec::new(),
             histogram: Vec::new(),
+            partials: Vec::new(),
             accounting: ravel_types::accounting::QueryAccountingSnapshot::default(),
             stats: crate::fetcher::FetchStats::default(),
             series_returned: 0,
@@ -1339,6 +1342,7 @@ fn worker_rejects_non_metrics_and_unknown_signals() {
             erasure: Vec::new(),
             trace_context: String::new(),
             fragment_capability: Vec::new(),
+            partial_aggregate: None,
         };
 
         // Spans is now served (#285): the request reaches the real span path.
@@ -1434,6 +1438,7 @@ fn run_slice_inner_dispatches_on_signal_not_blanket_rejects() {
             erasure: Vec::new(),
             trace_context: String::new(),
             fragment_capability: Vec::new(),
+            partial_aggregate: None,
         };
 
         // Spans now dispatches to the real span path (#285), no longer a stub.
@@ -1555,6 +1560,7 @@ impl SliceFetcher for OverflowingLyingWorker {
         Ok(SliceResponse {
             scalar: Vec::new(),
             histogram: Vec::new(),
+            partials: Vec::new(),
             accounting: acct.snapshot(),
             stats: crate::fetcher::FetchStats::default(),
             series_returned: 0,
@@ -3574,6 +3580,7 @@ fn raw_slice_request(signal: Signal, tenant: Vec<u8>) -> pb::FetchRequest {
         erasure: Vec::new(),
         trace_context: String::new(),
         fragment_capability: Vec::new(),
+        partial_aggregate: None,
     }
 }
 
@@ -3763,5 +3770,407 @@ fn old_worker_rejecting_nonmetrics_signals_yields_silent_local_fallback() {
              Ok(None), never a wrong or partial result"
         );
         server.abort();
+    });
+}
+
+// --- ADR-0103 aggregation pushdown (worker side) ---------------------------
+//
+// A slice whose request carries a `PartialAggregateRequest` returns one
+// `PartialAggregate` per series instead of its raw runs. The property that makes
+// such a partial exact is the worker's OWN local merge: it must dedup its runs
+// before reducing, or a sample two of its segments both carry is counted twice.
+// The tests below drive the real worker service (no doubles) and compare against
+// a local fetch-merge-reduce over the identical data.
+
+/// The corpus the pushdown tests share: two segments in the SAME shard and hour
+/// (so a coordinator would put them in ONE slice, i.e. on one worker) whose runs
+/// of series `m0` overlap at two timestamps, plus a second series `m1` carrying
+/// `0.0` and `-0.0` so the min/max fold's total order is observable.
+///
+/// `m0` merged (the later `writer_seq` wins each duplicate timestamp):
+/// `1.0, -0.0, 42.0, 7.5` -- four samples, from six fetched.
+async fn partial_pushdown_corpus(store: &MemoryStore) -> Vec<SegmentRef> {
+    let first = write_segment(
+        store,
+        0,
+        0,
+        100,
+        &[
+            SeriesDesc {
+                metric: "m0".to_string(),
+                samples: vec![
+                    (NS, 1.0f64.to_bits()),
+                    (2 * NS, 2.0f64.to_bits()),
+                    (3 * NS, 3.0f64.to_bits()),
+                ],
+            },
+            SeriesDesc {
+                metric: "m1".to_string(),
+                samples: vec![(NS, 0.0f64.to_bits()), (2 * NS, (-0.0f64).to_bits())],
+            },
+        ],
+    )
+    .await;
+    let second = write_segment(
+        store,
+        1,
+        0,
+        100,
+        &[SeriesDesc {
+            metric: "m0".to_string(),
+            // ts 2 and ts 3 duplicate the first segment's samples with different
+            // values; this segment's higher `writer_seq` wins both.
+            samples: vec![
+                (2 * NS, (-0.0f64).to_bits()),
+                (3 * NS, 42.0f64.to_bits()),
+                (4 * NS, 7.5f64.to_bits()),
+            ],
+        }],
+    )
+    .await;
+    vec![first, second]
+}
+
+/// A `FetchRequest` for the whole pinned set, with `partial_aggregate` set to
+/// `want`.
+fn pushdown_request(
+    segments: &[SegmentRef],
+    want: Option<pb::PartialAggregateRequest>,
+) -> pb::FetchRequest {
+    pb::FetchRequest {
+        protocol_version: crate::distrib::codec::PROTOCOL_VERSION,
+        query_id: Vec::new(),
+        tenant_hash: TENANT.0.to_vec(),
+        signal: crate::distrib::codec::signal_to_u32(Signal::Metrics),
+        scope: Some(pb::fetch_request::Scope::Pinned(pb::PinnedScope {
+            segments: segments
+                .iter()
+                .map(crate::distrib::codec::encode_segment_identity)
+                .collect(),
+        })),
+        matchers: Vec::new(),
+        window_start_ns: 0,
+        window_end_ns: 0,
+        budgets: None,
+        deadline_unix_ns: 0,
+        erasure: Vec::new(),
+        trace_context: String::new(),
+        fragment_capability: Vec::new(),
+        partial_aggregate: want,
+    }
+}
+
+/// The local reference reduction: `count`, `min` bits, and `max` bits over one
+/// coordinator-merged series, folded under `f64::total_cmp` exactly as ADR-0023's
+/// min/max UDAF does. This is the answer the worker must reproduce.
+fn reference_reduction(series: &SeriesData) -> (u64, Option<u64>, Option<u64>) {
+    let fold = |want: std::cmp::Ordering| {
+        series
+            .samples
+            .iter()
+            .map(|s| s.value)
+            .reduce(|current, candidate| {
+                if candidate.total_cmp(&current) == want {
+                    candidate
+                } else {
+                    current
+                }
+            })
+            .map(f64::to_bits)
+    };
+    (
+        series.samples.len() as u64,
+        fold(std::cmp::Ordering::Less),
+        fold(std::cmp::Ordering::Greater),
+    )
+}
+
+/// Indexes decoded partials by their metric name, which is this corpus' whole
+/// label set.
+fn partials_by_metric(
+    partials: &[crate::distrib::codec::PartialAggregate],
+) -> std::collections::HashMap<String, &crate::distrib::codec::PartialAggregate> {
+    partials
+        .iter()
+        .map(|p| {
+            let metric = p
+                .labels
+                .iter()
+                .find(|l| l.name == "__name__")
+                .map(|l| l.value.clone())
+                .expect("corpus labels carry __name__");
+            (metric, p)
+        })
+        .collect()
+}
+
+/// ADR-0103 acceptance (worker side): a slice asked for `count`/`min`/`max`
+/// merges its own runs FIRST and returns exactly what a local
+/// fetch-merge-reduce over the identical data produces, over a real loopback
+/// worker and a real decoder.
+///
+/// The corpus is the case that separates a correct implementation from a naive
+/// one: series `m0` has six fetched samples across two segments of one slice,
+/// two of which are duplicate timestamps, so the exact answer is `count = 4`.
+/// Replacing the `merge_soa_runs` call in `reduce_partial_aggregates`
+/// (`service.rs`) with a per-run concatenation reports `count = 6` -- the
+/// duplicates double-counted -- and the `count` assertion below fails. The
+/// `-0.0` min on `m0` and the `0.0`/`-0.0` pair on `m1` pin the fold's total
+/// order: under `PartialOrd` (where `-0.0 == 0.0`) `m1`'s min comes back as
+/// `0.0`, whose bit pattern differs from the asserted `-0.0`.
+#[test]
+fn worker_partial_aggregate_merges_before_reducing() {
+    let rt = Runtime::new().expect("runtime");
+    rt.block_on(async {
+        let store = Arc::new(MemoryStore::new());
+        let segments = partial_pushdown_corpus(&store).await;
+        let snapshot = Snapshot {
+            segments: segments.clone(),
+            segments_pruned: 0,
+            pending_erasure: Vec::new(),
+        };
+
+        // Local reference: the same fetch, the same coordinator-side merge, then
+        // the reduction the worker is supposed to have done.
+        let (local_runs, _acct, _stats) = local_scalar(Arc::clone(&store), &snapshot).await;
+        let fetched_samples: usize = local_runs
+            .iter()
+            .flatten()
+            .map(|s| s.timestamps.len())
+            .sum();
+        let local_merged = merge_soa_runs(local_runs, usize::MAX, usize::MAX).expect("local merge");
+        let merged_samples: usize = local_merged.iter().map(|s| s.samples.len()).sum();
+        // The corpus must actually exercise dedup, or the merge-first property is
+        // untested: fewer samples survive the merge than were fetched.
+        assert!(
+            merged_samples < fetched_samples,
+            "corpus must carry cross-segment duplicates: fetched {fetched_samples}, \
+             merged {merged_samples}"
+        );
+
+        let (fetcher, server) = spawn_worker(Arc::clone(&store), segments.clone()).await;
+        let response = SliceFetcher::fetch(
+            &fetcher,
+            pushdown_request(
+                &segments,
+                Some(pb::PartialAggregateRequest {
+                    want_count: true,
+                    want_min: true,
+                    want_max: true,
+                }),
+            ),
+        )
+        .await
+        .expect("worker responds to a pushdown request");
+        server.abort();
+
+        assert_eq!(response.status, pb::status::Code::Ok);
+        // All partials, no raw frames: the branch is per request, not per series.
+        assert!(
+            response.scalar.is_empty(),
+            "a pushdown slice must not also stream raw series frames"
+        );
+        assert!(response.histogram.is_empty());
+        assert_eq!(
+            response.partials.len(),
+            local_merged.len(),
+            "one partial per merged series, not one per segment run"
+        );
+
+        let got = partials_by_metric(&response.partials);
+        for series in &local_merged {
+            let metric = series
+                .labels
+                .iter()
+                .find(|l| l.name == "__name__")
+                .map(|l| l.value.clone())
+                .expect("corpus labels carry __name__");
+            let partial = got.get(&metric).expect("a partial for every merged series");
+            let (count, min_bits, max_bits) = reference_reduction(series);
+            assert_eq!(
+                partial.count,
+                Some(count),
+                "{metric}: count must be the deduped sample count"
+            );
+            assert_eq!(
+                partial.min.map(f64::to_bits),
+                min_bits,
+                "{metric}: min bit pattern differs from the local reduction"
+            );
+            assert_eq!(
+                partial.max.map(f64::to_bits),
+                max_bits,
+                "{metric}: max bit pattern differs from the local reduction"
+            );
+        }
+
+        // Hand-computed, independent of the reference fold above: `m0` dedups to
+        // four samples with `-0.0` as its minimum, and `m1`'s `0.0`/`-0.0` pair
+        // separates `total_cmp` from `PartialOrd`.
+        let m0 = got.get("m0").expect("m0 partial");
+        assert_eq!(m0.count, Some(4));
+        assert_eq!(m0.min.map(f64::to_bits), Some((-0.0f64).to_bits()));
+        assert_eq!(m0.max.map(f64::to_bits), Some(42.0f64.to_bits()));
+        let m1 = got.get("m1").expect("m1 partial");
+        assert_eq!(m1.count, Some(2));
+        assert_eq!(m1.min.map(f64::to_bits), Some((-0.0f64).to_bits()));
+        assert_eq!(m1.max.map(f64::to_bits), Some(0.0f64.to_bits()));
+
+        // The summary still reports this slice's real yield, so the coordinator's
+        // own sample-budget re-check works even though no sample crossed the wire.
+        assert_eq!(response.series_returned, local_merged.len() as u64);
+        assert_eq!(response.samples_returned, merged_samples as u64);
+    });
+}
+
+/// A group-only request (no aggregate flag set, ADR-0103 decision 3's set-union
+/// case) enumerates the worker's distinct series: one frame per merged series,
+/// identity only, with every value field absent rather than a zero.
+#[test]
+fn worker_group_only_partial_aggregate_enumerates_series() {
+    let rt = Runtime::new().expect("runtime");
+    rt.block_on(async {
+        let store = Arc::new(MemoryStore::new());
+        let segments = partial_pushdown_corpus(&store).await;
+        let (fetcher, server) = spawn_worker(Arc::clone(&store), segments.clone()).await;
+        let response = SliceFetcher::fetch(
+            &fetcher,
+            pushdown_request(
+                &segments,
+                Some(pb::PartialAggregateRequest {
+                    want_count: false,
+                    want_min: false,
+                    want_max: false,
+                }),
+            ),
+        )
+        .await
+        .expect("worker responds to a group-only request");
+        server.abort();
+
+        assert_eq!(response.status, pb::status::Code::Ok);
+        assert!(response.scalar.is_empty());
+        // Two distinct series in the corpus, each held once even though `m0`'s
+        // runs came from two segments.
+        assert_eq!(response.partials.len(), 2);
+        let got = partials_by_metric(&response.partials);
+        for metric in ["m0", "m1"] {
+            let partial = got.get(metric).expect("a partial per distinct series");
+            assert_eq!(partial.count, None, "{metric}: count was not requested");
+            assert_eq!(partial.min, None, "{metric}: min was not requested");
+            assert_eq!(partial.max, None, "{metric}: max was not requested");
+        }
+        // The identity a group enumeration exists to carry is present.
+        let expected_id = SeriesId::compute(&tenant_id(), "m0", &labels("m0")).expect("series id");
+        assert_eq!(got.get("m0").expect("m0 partial").series_id, expected_id);
+    });
+}
+
+/// Regression guard for the "completely unchanged" half of the request-level
+/// branch: a request with NO `partial_aggregate` produces exactly the raw-frame
+/// sequence the pre-pushdown worker produced -- one `SeriesFrame` per fetched
+/// per-segment run, in fetch order, byte-identical on the wire, and no
+/// `PartialAggregate` frame anywhere.
+///
+/// The expected bytes are built from an independent local fetch through
+/// `encode_series_frame`, which is exactly what the raw path's encode loop does,
+/// so this compares the worker's output against the encoding rather than against
+/// itself.
+#[test]
+fn request_without_partial_aggregate_streams_unchanged_raw_frames() {
+    let rt = Runtime::new().expect("runtime");
+    rt.block_on(async {
+        use prost::Message;
+
+        let store = Arc::new(MemoryStore::new());
+        let segments = partial_pushdown_corpus(&store).await;
+        let snapshot = Snapshot {
+            segments: segments.clone(),
+            segments_pruned: 0,
+            pending_erasure: Vec::new(),
+        };
+        let (local_runs, _acct, _stats) = local_scalar(Arc::clone(&store), &snapshot).await;
+        let expected: Vec<Vec<u8>> = local_runs
+            .iter()
+            .flatten()
+            .map(|soa| {
+                pb::FetchResponse {
+                    frame: Some(pb::fetch_response::Frame::Series(
+                        crate::distrib::codec::encode_series_frame(soa),
+                    )),
+                }
+                .encode_to_vec()
+            })
+            .collect();
+
+        // Drive the service directly so the raw frames are observable before any
+        // decode collapses them.
+        let metrics_store: Arc<dyn ObjectStoreBackend> =
+            Arc::clone(&store) as Arc<dyn ObjectStoreBackend>;
+        let service = SeriesFetchService::new(
+            SegmentFetcher::new(metrics_store),
+            Arc::new(SnapshotSegmentResolver::new(segments.clone())),
+        );
+        let response = SeriesFetch::fetch(
+            &service,
+            tonic::Request::new(pushdown_request(&segments, None)),
+        )
+        .await
+        .expect("worker serves the raw request");
+        let frames: Vec<pb::FetchResponse> =
+            futures::StreamExt::collect::<Vec<_>>(response.into_inner())
+                .await
+                .into_iter()
+                .map(|f| f.expect("frame"))
+                .collect();
+
+        let (summary, series): (Vec<_>, Vec<_>) = frames
+            .iter()
+            .partition(|f| matches!(f.frame, Some(pb::fetch_response::Frame::Summary(_))));
+        assert_eq!(summary.len(), 1, "exactly one terminal summary");
+        assert!(
+            !frames.iter().any(|f| matches!(
+                f.frame,
+                Some(pb::fetch_response::Frame::PartialAggregate(_))
+            )),
+            "a request with no partial_aggregate must never yield a partial frame"
+        );
+        let got: Vec<Vec<u8>> = series.iter().map(|f| f.encode_to_vec()).collect();
+        assert_eq!(
+            got, expected,
+            "raw series frames must be byte-identical to the unchanged encode path"
+        );
+    });
+}
+
+/// Pushdown is metrics-only (ADR-0103): a Logs slice carrying an aggregate
+/// request is refused with `Unsupported` so the coordinator falls back, rather
+/// than being served raw log frames a pushdown-expecting caller never asked for.
+#[test]
+fn partial_aggregate_on_a_log_slice_is_unsupported() {
+    let rt = Runtime::new().expect("runtime");
+    rt.block_on(async {
+        let store = Arc::new(MemoryStore::new());
+        let segments = partial_pushdown_corpus(&store).await;
+        let (fetcher, server) = spawn_worker(Arc::clone(&store), segments.clone()).await;
+        let mut request = pushdown_request(
+            &segments,
+            Some(pb::PartialAggregateRequest {
+                want_count: true,
+                want_min: false,
+                want_max: false,
+            }),
+        );
+        request.signal = crate::distrib::codec::signal_to_u32(Signal::Logs);
+        let response = SliceFetcher::fetch_logs(&fetcher, request)
+            .await
+            .expect("worker responds");
+        server.abort();
+        assert_eq!(response.status, pb::status::Code::Unsupported);
+        assert!(
+            response.status_message.contains("pushdown"),
+            "expected the pushdown-not-defined refusal, got {:?}",
+            response.status_message
+        );
     });
 }

--- a/crates/ravel-query/src/engine.rs
+++ b/crates/ravel-query/src/engine.rs
@@ -4621,6 +4621,7 @@ mod prefetch_tests {
             Ok(crate::distrib::client::SliceResponse {
                 scalar: Vec::new(),
                 histogram: Vec::new(),
+                partials: Vec::new(),
                 accounting: ravel_types::accounting::QueryAccountingSnapshot::default(),
                 stats: crate::fetcher::FetchStats::default(),
                 series_returned: 0,
@@ -5262,6 +5263,7 @@ mod coverage_wrapper_tests {
             Ok(SliceResponse {
                 scalar: Vec::new(),
                 histogram: Vec::new(),
+                partials: Vec::new(),
                 accounting: QueryAccountingSnapshot::default(),
                 stats: FetchStats::default(),
                 series_returned: 0,

--- a/crates/ravel-query/tests/erasure_cross_surface.rs
+++ b/crates/ravel-query/tests/erasure_cross_surface.rs
@@ -639,6 +639,7 @@ fn ok_response(scalar: Vec<FetchedSeriesSoa>) -> SliceResponse {
     SliceResponse {
         scalar,
         histogram: Vec::new(),
+        partials: Vec::new(),
         accounting: QueryAccountingSnapshot::default(),
         stats: FetchStats::default(),
         series_returned,

--- a/crates/ravel-query/tests/federated_request_budget.rs
+++ b/crates/ravel-query/tests/federated_request_budget.rs
@@ -51,6 +51,7 @@ impl SliceFetcher for FixedCostFetcher {
         Ok(SliceResponse {
             scalar: Vec::new(),
             histogram: Vec::new(),
+            partials: Vec::new(),
             accounting,
             stats: Default::default(),
             series_returned: 0,

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -412,6 +412,36 @@ extras, `with_log_fetcher`/`with_span_fetcher`), and a log/span slice carrying
 matchers (matcher pushdown for those signals has no mapping in this lane yet, so
 it fails closed rather than under-filter).
 
+### Worker-side aggregation pushdown
+
+A Metrics `FetchRequest` may carry a `PartialAggregateRequest`
+(`want_count`/`want_min`/`want_max`, ADR-0103 decision 2). The worker then
+returns one `PartialAggregate` frame per series — series identity, labels, and
+whichever of count/min/max was asked for, the bounds as raw f64 bit patterns —
+in place of every `SeriesFrame`, under the same slice atomicity. All three flags
+false is the group-only request: identity frames with no value fields, the
+distinct-group enumeration. The branch is per request, so a slice returns all
+partials or all raw frames, never a mix, and a request with no
+`partial_aggregate` is the unchanged raw-frame path.
+
+The worker merges its own runs through the same total-order per-series merge the
+coordinator runs (`merge_soa_runs`) *before* reducing, so a sample two of its
+segments both carry is counted once. That local merge is what makes the partial
+exact, given ADR-0103 decision 1's eligibility gate (not federated, every
+resolved segment inside one shard generation's stable interval): under that gate
+no other worker and no remote cluster holds runs of the same series, so nothing
+is left for the coordinator's cross-worker dedup belt to reconcile. `min`/`max`
+fold under `f64::total_cmp`, the ADR-0023 total order, never `PartialOrd`. The
+terminal summary still reports the slice's real merged sample count, so the
+coordinator's sample-budget re-check works even though no sample crosses the
+wire. Pushdown is metrics-only: an aggregate request on a log or span slice, or
+on a slice holding native-histogram series (which have no scalar count/min/max
+shape), is refused with `Unsupported` and falls back to raw fetch.
+
+Reachable at the wire/worker layer, not yet from a query: no coordinator sets
+the request field today, so the eligibility gate, the coordinator-side combine,
+and the `PROTOCOL_VERSION` bump ADR-0103 stages with them are still to come.
+
 This is the engine-level (queryfrag) fetch, merge, and federation machinery for
 all five signals — shipped and covered by the per-signal differential, erasure,
 skew, and federation tests. The coordinator caller that actually dispatches a

--- a/proto/ravel/queryfrag.proto
+++ b/proto/ravel/queryfrag.proto
@@ -58,6 +58,37 @@ message FetchRequest {
   // ordinary tenant credential instead. Additive field on this transient wire
   // contract, exactly the evolution this file's header sanctions.
   bytes fragment_capability = 14;
+
+  // The aggregation the coordinator wants this slice to compute itself instead
+  // of streaming raw samples (ADR-0103 decision 2). Absent means today's
+  // behavior, unchanged: the worker streams raw `SeriesFrame`s and the
+  // coordinator merges and aggregates them. Present means the worker merges its
+  // own runs locally (its exact per-series answer under decision 1's
+  // eligibility gate) and streams one `PartialAggregate` per series in place of
+  // every series frame -- all partials or all raw frames for one slice, never a
+  // mix. Additive field on this transient wire contract, exactly the evolution
+  // this file's header sanctions, and the same precedent
+  // `fragment_capability` above set.
+  //
+  // A singular message field carries explicit presence in proto3, so no
+  // `optional` keyword is needed for absent to stay distinct from a
+  // default-valued request (an all-false `PartialAggregateRequest` is the
+  // group-only enumeration, NOT "no pushdown").
+  PartialAggregateRequest partial_aggregate = 15;
+}
+
+// Which aggregates a pushdown-eligible slice must compute (ADR-0103 decision
+// 2/3). Each flag selects one field of the `PartialAggregate` frames the worker
+// returns; a flag left false leaves that field absent on the wire.
+//
+// All three false is the group-only request (distinct group enumeration, ADR-0103
+// decision 3's set-union case): the worker still returns one frame per series it
+// holds, carrying identity only. That is why no separate "group only" flag
+// exists -- the absence of all three IS the request.
+message PartialAggregateRequest {
+  bool want_count = 1;  // populate PartialAggregate.count
+  bool want_min = 2;    // populate PartialAggregate.min_bits
+  bool want_max = 3;    // populate PartialAggregate.max_bits
 }
 
 // Intra-cluster scope: the explicit segment set for this slice, reconstructed


### PR DESCRIPTION
Epic #64 T3. A new additive FetchRequest field asks a slice worker for
count/min/max instead of raw samples. The worker merges its own
overlapping runs across every segment it holds for a series
(merge_soa_runs, the same function the coordinator uses) before
reducing, so a per-worker partial is exact even when the worker holds
more than one segment for the same series -- reducing each segment
independently would double-count an overlapping sample.

min/max use the same total-order float comparison (f64::total_cmp) as
every other typed-aggregate path in this codebase, never PartialOrd.
A request with no partial_aggregate field is byte-identical to today's
raw-frame behavior; the metrics decode site on the coordinator now
decodes PartialAggregate frames but nothing yet consumes them -- the
combine and planner integration are a later task, and this is unreachable
from any real query today (every slice builder hard-codes the field to
None).

Reviewed by an opus checkpoint pass in an isolated worktree, which
mutated the merge-before-reduce step and the total_cmp comparison
directly to confirm both are load-bearing (naive per-segment reduction
inflates the count; PartialOrd corrupts -0.0/+0.0 handling).

Two preconditions carried into the next task's spec, not fixed here
(unreachable in this diff, but both live in code this task touched):
the native-histogram refusal path drops real spent S3 cost from its
summary instead of reporting it (service.rs, an existing pattern this
branch's new pushdown branch sits near but doesn't itself trigger), and
no test yet pins that the pushdown branch runs strictly after erasure
filtering (currently correct by code order, but unguarded).

Refs: #64
Fixes: #491
