### PR TITLE
feat(ravel-query): worker-side precision fixes for pushdown (ADR-0103)

### DIFF
--- a/crates/ravel-query/src/distrib/service.rs
+++ b/crates/ravel-query/src/distrib/service.rs
@@ -413,15 +413,45 @@ impl<R: SegmentResolver + 'static> SeriesFetchService<R> {
             // A native-histogram series has no scalar count/min/max shape:
             // `PartialAggregate` carries f64 bounds only. Silently omitting such
             // series would answer a pushdown query over an incomplete set, so
-            // fail closed to the coordinator's raw-fetch fallback instead.
+            // fail closed to the coordinator's raw-fetch fallback instead. This
+            // returns an `Unsupported` terminal summary carrying the accounting
+            // already spent on the fetches above, NOT an `Err` (which
+            // `run_slice`'s catch-all would rebuild from a default,
+            // zero-cost snapshot): a slice that paid real fetch cost before
+            // refusing must report that cost so the coordinator folds it, exactly
+            // as the byte-budget short-circuit above already does (ADR-0103
+            // amendment F1).
             if !histograms.is_empty() {
-                return Err((
+                return Ok(vec![summary_frame(
+                    &accounting.snapshot(),
+                    0,
+                    0,
                     pb::status::Code::Unsupported,
                     "aggregation pushdown is not defined for native-histogram series".to_string(),
-                ));
+                    &stats,
+                )]);
             }
+            // The reduction window (ADR-0103 amendment): `reduce_start_ns`
+            // exclusive, `reduce_end_ns` inclusive. Both fields are one window,
+            // so a caller must send both or neither. Both absent is today's only
+            // shape (no reduction restriction, byte-identical to pre-amendment
+            // behavior); exactly one present is a caller bug a lone bound cannot
+            // resolve into a window, so it is a typed `Internal` error rather than
+            // a silent one-sided filter.
+            let window = match (want.reduce_start_ns, want.reduce_end_ns) {
+                (None, None) => None,
+                (Some(start), Some(end)) => Some((start, end)),
+                (Some(_), None) | (None, Some(_)) => {
+                    return Err((
+                        pb::status::Code::Internal,
+                        "PartialAggregateRequest carries exactly one of \
+                         reduce_start_ns/reduce_end_ns; a caller must set both or neither"
+                            .to_string(),
+                    ));
+                }
+            };
             let (partials, samples_merged) =
-                reduce_partial_aggregates(scalar, &want).map_err(map_merge_error)?;
+                reduce_partial_aggregates(scalar, &want, window).map_err(map_merge_error)?;
             let series_returned = partials.len() as u64;
             let mut frames = Vec::with_capacity(partials.len() + 1);
             for partial in &partials {
@@ -845,12 +875,35 @@ fn summary_frame(
 /// min/max UDAF uses (`crates/ravel-sql/src/minmax.rs`): a candidate replaces
 /// the incumbent only on a strict `Less`/`Greater`, so NaN payloads and the sign
 /// of zero behave exactly as they do in every other typed-aggregate path here,
-/// and never through `PartialOrd`. A series whose samples were all erased
-/// carries `count: Some(0)` with no bounds: there is no value to bound, and an
-/// absent bound stays distinct from a present `0.0`.
+/// and never through `PartialOrd`. A series whose samples were all erased (or
+/// all filtered out below) carries `count: Some(0)` with no bounds: there is no
+/// value to bound, and an absent bound stays distinct from a present `0.0`.
+///
+/// Two filters run over each series' merged samples, AFTER the merge and BEFORE
+/// the count/min/max fold, never before the merge:
+///
+/// - Staleness: a sample encoded as [`STALE_NAN_BITS`] is dropped
+///   unconditionally (independent of `window`), matching the evaluator, which
+///   drops staleness markers from every matrix selection before a range function
+///   sees them (`eval_matrix_selector`). A window whose only sample is a
+///   staleness marker must contribute 0 to the count, not 1.
+/// - Reduction window (`window = Some((start, end))`, ADR-0103 amendment): a
+///   sample survives iff `ts_ns > start && ts_ns <= end` -- exclusive start,
+///   inclusive end, the same convention `eval_matrix_selector` uses. `None`
+///   means no window restriction (today's only caller shape), reducing over
+///   every merged sample.
+///
+/// Both filters run after [`merge_soa_runs`] on purpose. The merge's own dedup
+/// tie-break (`is_greater`, a bit-pattern tuple comparison, unrelated to
+/// `total_cmp`) decides which candidate at a shared timestamp survives, exactly
+/// as it does on the raw path. Filtering staleness (or the window) before the
+/// merge could let a losing real sample win a slot the raw path resolves to the
+/// marker (or vice versa), diverging from the answer the same query gets on the
+/// local path.
 fn reduce_partial_aggregates(
     fetched: Vec<Vec<FetchedSeriesSoa>>,
     want: &pb::PartialAggregateRequest,
+    window: Option<(i64, i64)>,
 ) -> Result<(Vec<codec::PartialAggregate>, u64), QueryError> {
     // Insertion-ordered grouping (a positions map beside the runs), so the frame
     // order a worker emits is a deterministic function of its fetch order rather
@@ -877,17 +930,29 @@ fn reduce_partial_aggregates(
         let Some(series) = merged.into_iter().next() else {
             continue;
         };
-        let count = series.samples.len() as u64;
+        // Staleness filter (unconditional) and the optional reduction window,
+        // both applied here -- after the merge resolved each shared timestamp,
+        // before the fold. See this function's doc comment for why the order
+        // matters.
+        let values: Vec<f64> = series
+            .samples
+            .iter()
+            .filter(|s| s.value.to_bits() != STALE_NAN_BITS)
+            .filter(|s| match window {
+                Some((start, end)) => s.ts_ns > start && s.ts_ns <= end,
+                None => true,
+            })
+            .map(|s| s.value)
+            .collect();
+        let count = values.len() as u64;
         samples_merged += count;
-        let min = series
-            .samples
+        let min = values
             .iter()
-            .map(|s| s.value)
+            .copied()
             .reduce(|current, candidate| replaces(candidate, current, Ordering::Less));
-        let max = series
-            .samples
+        let max = values
             .iter()
-            .map(|s| s.value)
+            .copied()
             .reduce(|current, candidate| replaces(candidate, current, Ordering::Greater));
         partials.push(codec::PartialAggregate {
             series_id,
@@ -900,12 +965,22 @@ fn reduce_partial_aggregates(
     Ok((partials, samples_merged))
 }
 
-/// The min/max fold step: `candidate` replaces `current` only when
-/// `candidate.total_cmp(&current)` is the wanted strict ordering (`Less` for
+/// The PromQL staleness marker's bit pattern (a specific quiet-NaN payload),
+/// the same constant `ravel_promql`'s `eval_matrix_selector` filters on. A
+/// sample carrying it marks the series absent from that point forward and must
+/// not be counted; the reduction drops it after the merge, matching the
+/// evaluator's own pre-range-function filter.
+const STALE_NAN_BITS: u64 = 0x7ff0_0000_0000_0002;
+
+/// The worker's own local min/max fold step: `candidate` replaces `current` only
+/// when `candidate.total_cmp(&current)` is the wanted strict ordering (`Less` for
 /// min, `Greater` for max), so a tie keeps the incumbent. Mirrors
-/// `Extreme::replaces` in `crates/ravel-sql/src/minmax.rs` field for field, the
-/// ADR-0023 total order ADR-0103 decision 3 names for the coordinator's own
-/// combine.
+/// `Extreme::replaces` in `crates/ravel-sql/src/minmax.rs` field for field. This
+/// is only the worker's local reduction over the samples one worker holds; it
+/// makes no claim about any coordinator-side combine. No caller combines
+/// `min`/`max` across workers today: T3's `total_cmp` fold is not the IEEE fold
+/// PromQL's `min_over_time`/`max_over_time` compute, so min/max pushdown does not
+/// ship until a PromQL-semantics worker fold exists (ADR-0103 amendment).
 fn replaces(candidate: f64, current: f64, want: Ordering) -> f64 {
     if candidate.total_cmp(&current) == want {
         candidate

--- a/crates/ravel-query/src/distrib/tests.rs
+++ b/crates/ravel-query/src/distrib/tests.rs
@@ -4394,6 +4394,86 @@ fn worker_partial_aggregate_filters_staleness_before_counting() {
     });
 }
 
+/// ADR-0103 amendment: the staleness filter must run AFTER `merge_soa_runs`,
+/// not before. Two segments carry the same series at the same timestamp: one
+/// a real value (written first, lower priority), one a staleness marker
+/// (written later, higher priority, so it wins the merge's dedup tie-break).
+/// A pre-merge filter would drop the marker before the merge sees it, letting
+/// the losing real value take the slot the raw path resolves to the marker --
+/// diverging from what the same query gets on the local path. This test is
+/// the discriminator `worker_partial_aggregate_filters_staleness_before_counting`
+/// alone cannot be: that test's single-segment, single-sample corpus makes
+/// pre-merge and post-merge filtering produce the identical answer.
+#[test]
+fn staleness_filter_runs_after_the_merge() {
+    let rt = Runtime::new().expect("runtime");
+    rt.block_on(async {
+        const STALE_NAN_BITS: u64 = 0x7ff0_0000_0000_0002;
+        let store = Arc::new(MemoryStore::new());
+        // priority (0,1,0): the real sample, written first.
+        let real = write_segment_prov(
+            &store,
+            0,
+            0,
+            1,
+            0,
+            0,
+            100,
+            &[SeriesDesc {
+                metric: "d".to_string(),
+                samples: vec![(2 * NS, 5.0f64.to_bits())],
+            }],
+        )
+        .await;
+        // priority (0,1,1): the marker, written later, so it wins the merge at
+        // the shared timestamp 2*NS.
+        let marker = write_segment_prov(
+            &store,
+            1,
+            0,
+            1,
+            1,
+            0,
+            100,
+            &[SeriesDesc {
+                metric: "d".to_string(),
+                samples: vec![(2 * NS, STALE_NAN_BITS)],
+            }],
+        )
+        .await;
+        let segments = vec![real, marker];
+
+        let (fetcher, server) = spawn_worker(Arc::clone(&store), segments.clone()).await;
+        let response = SliceFetcher::fetch(
+            &fetcher,
+            pushdown_request(
+                &segments,
+                Some(pb::PartialAggregateRequest {
+                    want_count: true,
+                    want_min: false,
+                    want_max: false,
+                    reduce_start_ns: Some(NS),
+                    reduce_end_ns: Some(3 * NS),
+                }),
+            ),
+        )
+        .await
+        .expect("worker responds to a pushdown request");
+        server.abort();
+
+        assert_eq!(response.status, pb::status::Code::Ok);
+        let got = partials_by_metric(&response.partials);
+        let d = got.get("d").expect("a partial for the merged series");
+        assert_eq!(
+            d.count,
+            Some(0),
+            "the marker wins the merge at 2*NS, so the post-merge staleness \
+             filter must leave nothing to count; a pre-merge filter would let \
+             the losing real value (5.0) take the slot instead"
+        );
+    });
+}
+
 /// ADR-0103 amendment F1: a slice that spends real fetch cost before refusing a
 /// pushdown over native-histogram data must report that cost, not lose it. The
 /// native-histogram refusal now returns an `Unsupported` terminal summary

--- a/crates/ravel-query/src/distrib/tests.rs
+++ b/crates/ravel-query/src/distrib/tests.rs
@@ -3957,6 +3957,8 @@ fn worker_partial_aggregate_merges_before_reducing() {
                     want_count: true,
                     want_min: true,
                     want_max: true,
+                    reduce_start_ns: None,
+                    reduce_end_ns: None,
                 }),
             ),
         )
@@ -4041,6 +4043,8 @@ fn worker_group_only_partial_aggregate_enumerates_series() {
                     want_count: false,
                     want_min: false,
                     want_max: false,
+                    reduce_start_ns: None,
+                    reduce_end_ns: None,
                 }),
             ),
         )
@@ -4159,6 +4163,8 @@ fn partial_aggregate_on_a_log_slice_is_unsupported() {
                 want_count: true,
                 want_min: false,
                 want_max: false,
+                reduce_start_ns: None,
+                reduce_end_ns: None,
             }),
         );
         request.signal = crate::distrib::codec::signal_to_u32(Signal::Logs);
@@ -4171,6 +4177,434 @@ fn partial_aggregate_on_a_log_slice_is_unsupported() {
             response.status_message.contains("pushdown"),
             "expected the pushdown-not-defined refusal, got {:?}",
             response.status_message
+        );
+    });
+}
+
+/// ADR-0103 amendment: the reduction-window fields are load-bearing. A worker
+/// given `reduce_start_ns`/`reduce_end_ns` counts and folds only the samples in
+/// `(reduce_start_ns, reduce_end_ns]` -- exclusive start, inclusive end, matching
+/// `eval_matrix_selector`.
+///
+/// The corpus is one series with four samples at `1..=4` NS. The window
+/// `(2*NS, 4*NS]` keeps exactly `{3*NS, 4*NS}`. Two boundary cases are the point,
+/// not just somewhere-inside vs somewhere-outside:
+///   - `2*NS` sits exactly AT the exclusive start and must be EXCLUDED (an
+///     inclusive start would count it, giving `count = 3` and `min = 5.0`).
+///   - `4*NS` sits exactly AT the inclusive end and must be INCLUDED (an
+///     exclusive end would drop it, giving `count = 1`).
+///
+/// The `1*NS` sample sits outside the window entirely; its `100.0` value would
+/// become the `max` if the window were ignored, so `max = 7.0` proves the window
+/// gates the fold, not just the count.
+#[test]
+fn worker_partial_aggregate_reduction_window_is_load_bearing() {
+    let rt = Runtime::new().expect("runtime");
+    rt.block_on(async {
+        let store = Arc::new(MemoryStore::new());
+        let segments = vec![
+            write_segment(
+                &store,
+                0,
+                0,
+                100,
+                &[SeriesDesc {
+                    metric: "m".to_string(),
+                    samples: vec![
+                        (NS, 100.0f64.to_bits()),
+                        (2 * NS, 5.0f64.to_bits()),
+                        (3 * NS, 7.0f64.to_bits()),
+                        (4 * NS, 3.0f64.to_bits()),
+                    ],
+                }],
+            )
+            .await,
+        ];
+
+        let (fetcher, server) = spawn_worker(Arc::clone(&store), segments.clone()).await;
+        let response = SliceFetcher::fetch(
+            &fetcher,
+            pushdown_request(
+                &segments,
+                Some(pb::PartialAggregateRequest {
+                    want_count: true,
+                    want_min: true,
+                    want_max: true,
+                    reduce_start_ns: Some(2 * NS),
+                    reduce_end_ns: Some(4 * NS),
+                }),
+            ),
+        )
+        .await
+        .expect("worker responds to a windowed pushdown request");
+        server.abort();
+
+        assert_eq!(response.status, pb::status::Code::Ok);
+        let got = partials_by_metric(&response.partials);
+        let m = got.get("m").expect("m partial");
+        assert_eq!(
+            m.count,
+            Some(2),
+            "only the two in-window samples (3*NS, 4*NS) are counted; \
+             the AT-start (2*NS) and out-of-window (1*NS) samples are excluded"
+        );
+        assert_eq!(
+            m.min.map(f64::to_bits),
+            Some(3.0f64.to_bits()),
+            "min folds only in-window values (3.0 at 4*NS)"
+        );
+        assert_eq!(
+            m.max.map(f64::to_bits),
+            Some(7.0f64.to_bits()),
+            "max folds only in-window values (7.0 at 3*NS), never the \
+             out-of-window 100.0 at 1*NS"
+        );
+        // The summary's reduced-sample count also reflects the window, not the
+        // fetched total.
+        assert_eq!(response.samples_returned, 2);
+    });
+}
+
+/// ADR-0103 amendment: the two reduction-window fields are one window, so a lone
+/// bound is a caller bug. The worker rejects a request carrying exactly one of
+/// `reduce_start_ns`/`reduce_end_ns` with a typed `Internal` status (never a
+/// silent one-sided filter), in either order.
+#[test]
+fn worker_partial_aggregate_lone_window_bound_is_internal_error() {
+    let rt = Runtime::new().expect("runtime");
+    rt.block_on(async {
+        let store = Arc::new(MemoryStore::new());
+        let segments = partial_pushdown_corpus(&store).await;
+        let (fetcher, server) = spawn_worker(Arc::clone(&store), segments.clone()).await;
+
+        // Only the start bound set.
+        let start_only = SliceFetcher::fetch(
+            &fetcher,
+            pushdown_request(
+                &segments,
+                Some(pb::PartialAggregateRequest {
+                    want_count: true,
+                    want_min: false,
+                    want_max: false,
+                    reduce_start_ns: Some(NS),
+                    reduce_end_ns: None,
+                }),
+            ),
+        )
+        .await
+        .expect("worker responds");
+        assert_eq!(start_only.status, pb::status::Code::Internal);
+        assert!(
+            start_only.status_message.contains("reduce_start_ns")
+                && start_only.status_message.contains("both or neither"),
+            "expected the lone-bound refusal, got {:?}",
+            start_only.status_message
+        );
+
+        // Only the end bound set: the mirror-image caller bug is rejected the
+        // same way.
+        let end_only = SliceFetcher::fetch(
+            &fetcher,
+            pushdown_request(
+                &segments,
+                Some(pb::PartialAggregateRequest {
+                    want_count: true,
+                    want_min: false,
+                    want_max: false,
+                    reduce_start_ns: None,
+                    reduce_end_ns: Some(4 * NS),
+                }),
+            ),
+        )
+        .await
+        .expect("worker responds");
+        server.abort();
+        assert_eq!(end_only.status, pb::status::Code::Internal);
+        assert!(
+            end_only.status_message.contains("reduce_end_ns")
+                && end_only.status_message.contains("both or neither"),
+            "expected the lone-bound refusal, got {:?}",
+            end_only.status_message
+        );
+    });
+}
+
+/// ADR-0103 amendment: staleness filtering is load-bearing. A series whose only
+/// merged sample in the reduction window is a `STALE_NAN_BITS` marker must
+/// contribute `count: Some(0)`, not `Some(1)` -- the evaluator drops the marker
+/// before any range function sees it, and the worker's pushed-down count must
+/// match.
+///
+/// Mutation proof: this test is RED against a worker missing the staleness
+/// filter. Removing the `.filter(|s| s.value.to_bits() != STALE_NAN_BITS)` line
+/// in `reduce_partial_aggregates` (`service.rs`) makes the marker count as a
+/// real sample, so `count` comes back `Some(1)` and the assertion below fails.
+/// The window here covers the marker's timestamp, so it is the staleness filter,
+/// not the window, that removes it.
+#[test]
+fn worker_partial_aggregate_filters_staleness_before_counting() {
+    let rt = Runtime::new().expect("runtime");
+    rt.block_on(async {
+        const STALE_NAN_BITS: u64 = 0x7ff0_0000_0000_0002;
+        let store = Arc::new(MemoryStore::new());
+        let segments = vec![
+            write_segment(
+                &store,
+                0,
+                0,
+                100,
+                &[SeriesDesc {
+                    metric: "s".to_string(),
+                    // The series' only sample is a staleness marker, inside the
+                    // window below.
+                    samples: vec![(2 * NS, STALE_NAN_BITS)],
+                }],
+            )
+            .await,
+        ];
+
+        let (fetcher, server) = spawn_worker(Arc::clone(&store), segments.clone()).await;
+        let response = SliceFetcher::fetch(
+            &fetcher,
+            pushdown_request(
+                &segments,
+                Some(pb::PartialAggregateRequest {
+                    want_count: true,
+                    want_min: false,
+                    want_max: false,
+                    reduce_start_ns: Some(NS),
+                    reduce_end_ns: Some(3 * NS),
+                }),
+            ),
+        )
+        .await
+        .expect("worker responds to a pushdown request");
+        server.abort();
+
+        assert_eq!(response.status, pb::status::Code::Ok);
+        let got = partials_by_metric(&response.partials);
+        let s = got.get("s").expect("a partial for the stale-only series");
+        assert_eq!(
+            s.count,
+            Some(0),
+            "a staleness marker must not inflate the pushed-down count"
+        );
+        // The reduced-sample tally the summary reports also excludes the marker.
+        assert_eq!(response.samples_returned, 0);
+    });
+}
+
+/// ADR-0103 amendment F1: a slice that spends real fetch cost before refusing a
+/// pushdown over native-histogram data must report that cost, not lose it. The
+/// native-histogram refusal now returns an `Unsupported` terminal summary
+/// carrying the accounting the segment fetches already paid for, instead of an
+/// `Err` that `run_slice` rebuilds from a zero-cost default snapshot.
+///
+/// Mutation proof: this test is RED against the pre-fix code on `main`. Restoring
+/// the refusal to `return Err((pb::status::Code::Unsupported, ...))` sends the
+/// outcome through `run_slice`'s catch-all, whose summary carries
+/// `QueryAccountingSnapshot::default()` (all zeros), so the nonzero-spend
+/// assertion below fails while the `Unsupported` status still passes.
+#[test]
+fn native_histogram_pushdown_refusal_reports_real_accounting() {
+    let rt = Runtime::new().expect("runtime");
+    rt.block_on(async {
+        use ravel_segment::{
+            HistogramCounts, HistogramSample, HistogramValue, ResetHint, SeriesInputV3,
+            SeriesValues,
+        };
+
+        let store = Arc::new(MemoryStore::new());
+        let metric = "h0";
+        let label_set = labels(metric);
+        let series_id = SeriesId::compute(&tenant_id(), metric, &label_set).expect("series id");
+        let hist = HistogramValue {
+            scale: 0,
+            zero_threshold: 0.0,
+            sum: Some(2.5),
+            custom_values: None,
+            positive_spans: vec![ravel_segment::HistogramSpan {
+                offset: 0,
+                length: 1,
+            }],
+            negative_spans: Vec::new(),
+            counts: HistogramCounts::Int {
+                zero_count: 0,
+                count: 1,
+                positive: vec![1],
+                negative: Vec::new(),
+            },
+            reset_hint: ResetHint::Unknown,
+        };
+        let identity = SegmentIdentity {
+            tenant_hash: TENANT.0,
+            shard: 0,
+            writer_id: Uuid::from_u128(1).to_string(),
+            writer_epoch: 1,
+            writer_seq: 0,
+        };
+        let written = SegmentWriter::write_histograms(
+            vec![SeriesInputV3 {
+                series_id,
+                labels: label_set,
+                values: SeriesValues::Histogram(vec![HistogramSample {
+                    ts_ns: NS,
+                    value: hist,
+                }]),
+            }],
+            identity,
+            IngestBounds {
+                min_ingest_ts_ns: 0,
+                max_ingest_ts_ns: 0,
+            },
+        )
+        .expect("write histogram segment");
+        let object_key = "seg/f1_hist.rseg".to_string();
+        store
+            .put(&object_key, written.bytes.clone(), PutOptions::default())
+            .await
+            .expect("put segment");
+        let seg = SegmentRef {
+            data_object_key: object_key,
+            object_size: written.bytes.len() as u64,
+            min_event_ts_ns: written.summary.min_event_ts_ns,
+            max_event_ts_ns: written.summary.max_event_ts_ns,
+            ingest_hour_bucket: 100,
+            sample_count: written.summary.sample_count,
+            series_count: written.summary.series_count,
+            shard: 0,
+            content_hash: written.summary.blake3,
+            writer_id: Uuid::from_u128(1),
+            writer_epoch: 1,
+            writer_seq: 0,
+            created_unix_ns: 0,
+            level: SegmentLevel::L0,
+        };
+        let segments = vec![seg];
+
+        let (fetcher, server) = spawn_worker(Arc::clone(&store), segments.clone()).await;
+        let response = SliceFetcher::fetch(
+            &fetcher,
+            pushdown_request(
+                &segments,
+                Some(pb::PartialAggregateRequest {
+                    want_count: true,
+                    want_min: false,
+                    want_max: false,
+                    reduce_start_ns: None,
+                    reduce_end_ns: None,
+                }),
+            ),
+        )
+        .await
+        .expect("worker responds to the histogram pushdown request");
+        server.abort();
+
+        assert_eq!(
+            response.status,
+            pb::status::Code::Unsupported,
+            "a native-histogram pushdown is refused so the coordinator falls back"
+        );
+        assert!(
+            response.status_message.contains("native-histogram"),
+            "expected the native-histogram refusal, got {:?}",
+            response.status_message
+        );
+        assert!(
+            response.accounting.total_s3_bytes() > 0,
+            "the refusal summary must carry the real fetch cost already spent, \
+             not a zero-cost default"
+        );
+    });
+}
+
+/// Regression guard for the "completely unchanged when no window is set" contract
+/// (ADR-0103 amendment, deliverable 1): a `want_count`-only request with NEITHER
+/// reduction-window field set (T3's exact shape) produces the byte-identical
+/// `PartialAggregate` frames the pre-amendment worker produced. The staleness
+/// filter this task adds is unconditional but a no-op over this non-stale corpus,
+/// and with no window the fold runs over every merged sample, so the wire output
+/// must not move.
+///
+/// The expected bytes are built independently from the corpus' hand-known merged
+/// counts (`m0` dedups six fetched samples to four; `m1` keeps two), encoded
+/// through the same `encode_partial_aggregate` path, then compared as a sorted
+/// set so the assertion turns on frame content, not on fetch/group order.
+#[test]
+fn count_only_no_window_request_is_byte_identical() {
+    let rt = Runtime::new().expect("runtime");
+    rt.block_on(async {
+        use prost::Message;
+
+        let store = Arc::new(MemoryStore::new());
+        let segments = partial_pushdown_corpus(&store).await;
+
+        let encode = |p: &crate::distrib::codec::PartialAggregate| {
+            pb::FetchResponse {
+                frame: Some(pb::fetch_response::Frame::PartialAggregate(
+                    crate::distrib::codec::encode_partial_aggregate(p),
+                )),
+            }
+            .encode_to_vec()
+        };
+        let expected_partial = |metric: &str, count: u64| crate::distrib::codec::PartialAggregate {
+            series_id: SeriesId::compute(&tenant_id(), metric, &labels(metric)).expect("series id"),
+            labels: labels(metric),
+            count: Some(count),
+            min: None,
+            max: None,
+        };
+        let mut expected: Vec<Vec<u8>> = vec![
+            encode(&expected_partial("m0", 4)),
+            encode(&expected_partial("m1", 2)),
+        ];
+        expected.sort();
+
+        // Drive the service directly so the partial frames are observable on the
+        // wire before any decode collapses them.
+        let metrics_store: Arc<dyn ObjectStoreBackend> =
+            Arc::clone(&store) as Arc<dyn ObjectStoreBackend>;
+        let service = SeriesFetchService::new(
+            SegmentFetcher::new(metrics_store),
+            Arc::new(SnapshotSegmentResolver::new(segments.clone())),
+        );
+        let response = SeriesFetch::fetch(
+            &service,
+            tonic::Request::new(pushdown_request(
+                &segments,
+                Some(pb::PartialAggregateRequest {
+                    want_count: true,
+                    want_min: false,
+                    want_max: false,
+                    reduce_start_ns: None,
+                    reduce_end_ns: None,
+                }),
+            )),
+        )
+        .await
+        .expect("worker serves the count-only request");
+        let frames: Vec<pb::FetchResponse> =
+            futures::StreamExt::collect::<Vec<_>>(response.into_inner())
+                .await
+                .into_iter()
+                .map(|f| f.expect("frame"))
+                .collect();
+
+        let mut got: Vec<Vec<u8>> = frames
+            .iter()
+            .filter(|f| {
+                matches!(
+                    f.frame,
+                    Some(pb::fetch_response::Frame::PartialAggregate(_))
+                )
+            })
+            .map(|f| f.encode_to_vec())
+            .collect();
+        got.sort();
+        assert_eq!(
+            got, expected,
+            "count-only, no-window partial frames must be byte-identical to the \
+             pre-amendment encode"
         );
     });
 }

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -415,14 +415,27 @@ it fails closed rather than under-filter).
 ### Worker-side aggregation pushdown
 
 A Metrics `FetchRequest` may carry a `PartialAggregateRequest`
-(`want_count`/`want_min`/`want_max`, ADR-0103 decision 2). The worker then
-returns one `PartialAggregate` frame per series — series identity, labels, and
-whichever of count/min/max was asked for, the bounds as raw f64 bit patterns —
-in place of every `SeriesFrame`, under the same slice atomicity. All three flags
+(`want_count`/`want_min`/`want_max`, plus `reduce_start_ns`/`reduce_end_ns`,
+ADR-0103 decision 2 and its Amendment). The worker then returns one
+`PartialAggregate` frame per series — series identity, labels, and whichever of
+count/min/max was asked for, the bounds as raw f64 bit patterns — in place of
+every `SeriesFrame`, under the same slice atomicity. All three value flags
 false is the group-only request: identity frames with no value fields, the
 distinct-group enumeration. The branch is per request, so a slice returns all
 partials or all raw frames, never a mix, and a request with no
 `partial_aggregate` is the unchanged raw-frame path.
+
+`reduce_start_ns`/`reduce_end_ns` restrict the reduction to an exact
+`(start, end]` window, matching the evaluator's own matrix-selector convention
+(`crates/ravel-promql/src/eval.rs`'s `eval_matrix_selector`) rather than
+whatever the fetched segments happen to span — the two bounds must both be
+present or both absent, or the worker refuses with a typed `Internal` error.
+The worker also unconditionally filters `STALE_NAN_BITS` samples out of its
+merged set before counting, *after* `merge_soa_runs` runs, never before: the
+merge's own dedup tie-break decides which candidate survives a shared
+timestamp exactly as it does on the raw path, and filtering staleness first
+could let a different candidate win that slot than the raw path resolves for
+the same query.
 
 The worker merges its own runs through the same total-order per-series merge the
 coordinator runs (`merge_soa_runs`) *before* reducing, so a sample two of its
@@ -431,16 +444,22 @@ exact, given ADR-0103 decision 1's eligibility gate (not federated, every
 resolved segment inside one shard generation's stable interval): under that gate
 no other worker and no remote cluster holds runs of the same series, so nothing
 is left for the coordinator's cross-worker dedup belt to reconcile. `min`/`max`
-fold under `f64::total_cmp`, the ADR-0023 total order, never `PartialOrd`. The
-terminal summary still reports the slice's real merged sample count, so the
-coordinator's sample-budget re-check works even though no sample crosses the
-wire. Pushdown is metrics-only: an aggregate request on a log or span slice, or
-on a slice holding native-histogram series (which have no scalar count/min/max
-shape), is refused with `Unsupported` and falls back to raw fetch.
+fold under `f64::total_cmp`, the ADR-0023 total order, never `PartialOrd` — but
+per the Amendment, no caller combines min/max yet: `total_cmp` disagrees with
+PromQL's own `min_over_time`/`max_over_time` (plain IEEE, NaN-overwrite) on NaN
+and `-0.0` windows, so only `count` pushdown is wired to a caller. The terminal
+summary reports the slice's real, POST-staleness-filter merged sample count
+(lower than main's pre-amendment count whenever the window held a marker), so
+the coordinator's sample-budget re-check works even though no sample crosses
+the wire. Pushdown is metrics-only: an aggregate request on a log or span
+slice, or on a slice holding native-histogram series (which have no scalar
+count/min/max shape), is refused with `Unsupported` (with the real accounting
+already spent, never dropped) and falls back to raw fetch.
 
 Reachable at the wire/worker layer, not yet from a query: no coordinator sets
 the request field today, so the eligibility gate, the coordinator-side combine,
-and the `PROTOCOL_VERSION` bump ADR-0103 stages with them are still to come.
+the PromQL plan-extraction wiring, and the `PROTOCOL_VERSION` bump ADR-0103
+stages with them are still to come.
 
 This is the engine-level (queryfrag) fetch, merge, and federation machinery for
 all five signals — shipped and covered by the per-signal differential, erasure,

--- a/proto/ravel/queryfrag.proto
+++ b/proto/ravel/queryfrag.proto
@@ -89,6 +89,27 @@ message PartialAggregateRequest {
   bool want_count = 1;  // populate PartialAggregate.count
   bool want_min = 2;    // populate PartialAggregate.min_bits
   bool want_max = 3;    // populate PartialAggregate.max_bits
+
+  // The reduction window the worker filters merged samples to before it counts
+  // or folds them (ADR-0103 amendment). Matches `eval_matrix_selector`'s range
+  // convention exactly: `reduce_start_ns` is EXCLUSIVE and `reduce_end_ns` is
+  // INCLUSIVE, so a merged sample survives iff
+  // `ts_ns > reduce_start_ns && ts_ns <= reduce_end_ns`. These carry the
+  // offset/@-resolved `(start, end]` of the `_over_time` selector, NOT the
+  // coordinator's fetch window: the fetch window is deliberately left-padded
+  // for PromQL lookback and is a strict superset of this range, so the worker
+  // must never reduce over it directly.
+  //
+  // A caller MUST send BOTH or NEITHER; these two fields are one window, not two
+  // independent knobs. Both absent is the only shape any caller sends today
+  // (T1-T3, and this task adds no caller): the worker then reduces over every
+  // merged sample with no window restriction, byte-identical to the
+  // pre-amendment behavior. Both present: the worker filters to the range above
+  // before the count/min/max fold. Exactly one present is a caller bug -- a lone
+  // bound cannot define a window -- which the worker rejects with
+  // `Status.Code.INTERNAL`, never a silent one-sided filter.
+  optional sint64 reduce_start_ns = 4;  // exclusive lower bound of the reduction window
+  optional sint64 reduce_end_ns = 5;    // inclusive upper bound of the reduction window
 }
 
 // Intra-cluster scope: the explicit segment set for this slice, reconstructed
@@ -177,8 +198,14 @@ message FetchResponse {
 // One worker-computed partial aggregate for a single group (ADR-0103 decision
 // 2): the group's series identity plus whichever of count/min/max the query
 // actually asked for. A worker sends these instead of raw sample runs when the
-// coordinator opted the query into aggregation pushdown; the coordinator sums
-// the counts and folds the bounds under the ADR-0023 `total_cmp` total order.
+// coordinator opted the query into aggregation pushdown. Decision 1's
+// eligibility gate guarantees every series in scope lives on exactly one worker,
+// so the coordinator COLLECTS one partial per series (one worker contributes
+// each series' whole partial) rather than summing counts across workers. Min/max
+// combine does not ship yet (ADR-0103 amendment: T3's `total_cmp` fold is not
+// the IEEE fold `min_over_time`/`max_over_time` compute), so no caller combines
+// `min_bits`/`max_bits` today; only `count`, from `count_over_time` pushdown, is
+// consumed.
 //
 // No dedup-key metadata rides here. ADR-0103 decision 1's eligibility gate
 // (not federated, every resolved segment inside one shard generation's stable


### PR DESCRIPTION
Epic #64 T4a. Adds the precision requirements ADR-0103's amendment
specifies before a real caller can safely use count_over_time pushdown:
an exact reduction-window field on PartialAggregateRequest
(reduce_start_ns exclusive, reduce_end_ns inclusive, matching the
evaluator's own matrix-selector convention), unconditional
staleness-marker filtering placed after the merge-before-reduce step
(not before, or a stale sample can win the merge's dedup tie-break
differently than the raw path resolves), and a fix for a pre-existing
bug where the native-histogram refusal path dropped the real S3 cost a
slice already spent instead of reporting it.

No caller sets the new fields yet -- a request with both absent is
unchanged from before this commit, and pushdown remains unreachable
from any real query, same as T1-T3. That's the next task.

Checkpoint review (opus, worktree-isolated) found the shipped staleness
test couldn't distinguish correct post-merge filtering from a buggy
pre-merge version, since its corpus made both orderings agree; added
the discriminating test (two segments, a real value and a later,
higher-priority staleness marker sharing one timestamp) and proved it
red under the pre-merge mutation before restoring. Also updated
docs/query-engine.md's pushdown section, stale after this and the prior
task's changes.

Refs: #64
Fixes: #495
