### PR TITLE
feat(logs-sql): dictionary-encode declared Str columns end to end

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5120,6 +5120,7 @@ dependencies = [
  "ravel-alerting",
  "ravel-cache",
  "ravel-catalog",
+ "ravel-codec",
  "ravel-commit",
  "ravel-logseg",
  "ravel-maintain",

--- a/crates/ravel-sql/Cargo.toml
+++ b/crates/ravel-sql/Cargo.toml
@@ -193,6 +193,12 @@ stats_alloc = "0.1.10"
 # the writer's sections around ravel-logseg's own encoders, which means stamping
 # the section table's checksums. Same workspace pin ravel-logseg itself uses.
 crc32c = { workspace = true }
+# Dev-only: tests/logs_columnar.rs asserts a declared `Str` fixture's value set
+# actually encodes as `Enc::Dict`/`Enc::Plain` (the codec function the RLOG
+# writer stages a dynamic string column with), so a shift in the distinct-ratio
+# heuristic fails the dict-page tests loudly instead of silently. Already a
+# workspace pin (ravel-logseg depends on it); no new supply-chain surface.
+ravel-codec = { workspace = true }
 
 [[bench]]
 name = "samples_scan"

--- a/crates/ravel-sql/src/declared.rs
+++ b/crates/ravel-sql/src/declared.rs
@@ -6,7 +6,8 @@
 //! stringified value and no typed comparison is possible at all. ADR-0090 lets
 //! an operator *declare* a per-tenant set of attribute keys as native typed
 //! columns, appended after `attrs`, so the same value reads back as a real
-//! `Int64`/`Boolean`/`Utf8`/`Binary` Arrow column.
+//! `Int64`/`Boolean`/`Binary` Arrow column, or, for a `Str` column,
+//! `Dictionary(Int32, Utf8)` (ADR-0099 decision 5).
 //!
 //! This module owns the query-side contract only: the [`DeclaredColumnSource`]
 //! trait a plan resolves its declared columns from (ADR-0090 decision 2), the
@@ -38,7 +39,10 @@ use ravel_types::TenantHash;
 /// the module docs.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum DeclaredType {
-    /// A `Str`-typed attribute, projected as Arrow `Utf8`.
+    /// A `Str`-typed attribute, projected as Arrow `Dictionary(Int32, Utf8)`
+    /// (ADR-0099 decision 5): a dict-encoded page becomes the Arrow dictionary
+    /// and its ids with no per-row allocation, and a plain page a degenerate
+    /// identity dictionary, so both paths build the one schema DataFusion checks.
     Str,
     /// An `I64`-typed attribute, projected as Arrow `Int64`.
     I64,

--- a/crates/ravel-sql/src/flight/stream.rs
+++ b/crates/ravel-sql/src/flight/stream.rs
@@ -198,7 +198,15 @@ pub(super) async fn statement_stream(
         .map_err(|err| FlightError::Tonic(Box::new(status_from_sql(&err, tenant))))
     });
 
+    // Resend dictionaries rather than hydrating them (ADR-0099 decision 5). A
+    // declared `Str` column is `Dictionary(Int32, Utf8)`, and the encoder's
+    // default would hydrate it back to plain `Utf8` on the wire, stopping the
+    // win at the operator boundary; #479 (LIKE pushdown) depends on the
+    // dictionary surviving to the client operator so it can match once per
+    // distinct value. The internal worker path (`fragment_stream`) already sets
+    // this for the `labels` dictionary; the public statement path needs it too.
     let encoded = FlightDataEncoderBuilder::new()
+        .with_dictionary_handling(DictionaryHandling::Resend)
         .with_schema(schema)
         .build(batches)
         .map(move |item| {
@@ -316,9 +324,9 @@ pub(super) async fn fragment_stream(
     // that schema. `internal_schema()` dictionary-encodes the `labels` column
     // (`Dictionary(Int32, Map)`, crate::schema), so hydrating it to a plain
     // `Map` on the wire would make every decoded batch fail the coordinator's
-    // schema check. The public statement path (`statement_stream`) can keep the
-    // hydrating default because its consumer is an external client with no
-    // downstream plan to satisfy; this internal fan-out cannot.
+    // schema check. The public statement path (`statement_stream`) sets the same
+    // handling for its own reason (ADR-0099 decision 5: keep declared `Str`
+    // dictionaries intact to the client rather than hydrating them on the wire).
     let encoded = FlightDataEncoderBuilder::new()
         .with_dictionary_handling(DictionaryHandling::Resend)
         .with_schema(schema)

--- a/crates/ravel-sql/src/logs_scan.rs
+++ b/crates/ravel-sql/src/logs_scan.rs
@@ -106,10 +106,11 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use datafusion::arrow::array::{
-    ArrayRef, BinaryBuilder, BooleanBuilder, FixedSizeBinaryBuilder, Int64Builder, MapBuilder,
-    StringArray, StringBuilder, TimestampNanosecondArray, UInt8Array, UInt32Array,
+    ArrayRef, BinaryBuilder, BooleanBuilder, DictionaryArray, FixedSizeBinaryBuilder, Int32Array,
+    Int64Builder, MapBuilder, StringArray, StringBuilder, StringDictionaryBuilder,
+    TimestampNanosecondArray, UInt8Array, UInt32Array,
 };
-use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::arrow::datatypes::{Int32Type, SchemaRef};
 use datafusion::arrow::record_batch::{RecordBatch, RecordBatchOptions};
 use datafusion::error::{DataFusionError, Result as DFResult};
 use datafusion::execution::TaskContext;
@@ -1258,8 +1259,14 @@ fn build_batch(
 /// `attrs_raw` and decoded back as `List`/`Map`.
 fn declared_column_array(dc: &DeclaredColumn, merged: &[Vec<(String, AttrValue)>]) -> ArrayRef {
     match dc.ty {
+        // Dictionary-typed to match the fast path's schema (ADR-0099 decision
+        // 5): every batch DataFusion validates carries one type per column, so
+        // the row path must produce `Dictionary(Int32, Utf8)` too or every
+        // fallback batch (erasure pending, `attrs` projected, an `attrs_raw`
+        // page) would fail schema validation at runtime. The builder dedups; a
+        // wrong variant or absent key is a NULL cell, never a cast (decision 7).
         DeclaredType::Str => {
-            let mut b = StringBuilder::new();
+            let mut b = StringDictionaryBuilder::<Int32Type>::new();
             for row in merged {
                 match find_attr(row, &dc.key) {
                     Some(AttrValue::Str(s)) => b.append_value(s),
@@ -1462,16 +1469,7 @@ fn build_declared_columnar_array(
     cache: &mut HashMap<u32, Arc<Vec<(String, AttrValue)>>>,
 ) -> DFResult<ArrayRef> {
     Ok(match plan.dc.ty {
-        DeclaredType::Str => {
-            let mut b = StringBuilder::new();
-            for i in start..end {
-                match declared_merged_value(view, plan, i, cache)? {
-                    Some(AttrValue::Str(s)) => b.append_value(s),
-                    _ => b.append_null(),
-                }
-            }
-            Arc::new(b.finish())
-        }
+        DeclaredType::Str => build_declared_str_columnar(view, plan, start, end, cache)?,
         DeclaredType::I64 => {
             let mut b = Int64Builder::new();
             for i in start..end {
@@ -1512,6 +1510,117 @@ fn build_declared_columnar_array(
             Arc::new(b.finish())
         }
     })
+}
+
+/// Build a declared `Str` column as an Arrow `Dictionary(Int32, Utf8)` for
+/// surviving rows `start..end` (ADR-0099 decision 5).
+///
+/// Two cases, both producing the same logical values [`declared_column_array`]'s
+/// `Str` arm produces on the row path, so a fast-path batch and a fallback batch
+/// validate against the one schema DataFusion checks:
+///
+/// - **Dict-encoded page** ([`ColumnarBlockView::str_dict`] returns `Some`): the
+///   page's distinct values become the Arrow dictionary and the record rows
+///   reuse the page's ids directly, with no per-row string allocation. A page
+///   dict entry that is not UTF-8 becomes a NULL dictionary value, so a row
+///   keyed to it reads NULL; that only happens for a row the record sets in a
+///   *different*-typed column of the same key (record wins, wrong variant is
+///   NULL by ADR-0090 decision 7). A row the record does not set at all reads
+///   through to the resource/scope fallback, whose value is appended to the
+///   dictionary (the one per-row copy, unavoidable because that value is not in
+///   the page).
+/// - **Plain page** (`str_dict` returns `None`, or the key has no `Str`
+///   FIELD_DIR column at all): a degenerate identity dictionary, one entry per
+///   non-null surviving row with keys `0..`, built from [`declared_merged_value`]
+///   exactly as the pre-dictionary code did. No hashing and no dedup pass, so
+///   this case stays exactly as expensive as it was.
+fn build_declared_str_columnar(
+    view: &ColumnarBlockView<'_>,
+    plan: &DeclaredPlan<'_>,
+    start: usize,
+    end: usize,
+    cache: &mut HashMap<u32, Arc<Vec<(String, AttrValue)>>>,
+) -> DFResult<ArrayRef> {
+    let n = end - start;
+    Ok(
+        match plan.matching.and_then(|mc| view.str_dict(mc.column_id)) {
+            Some(col) => {
+                // Dictionary values start as the page's distinct byte values,
+                // decoded to UTF-8; a non-UTF-8 entry becomes a NULL value. Ids
+                // address these in the page's order, so a record row's page id maps
+                // straight to a dictionary index. Resource/scope fallback values are
+                // appended past the page dict.
+                let mut values = StringBuilder::new();
+                for v in col.dict() {
+                    match std::str::from_utf8(v) {
+                        Ok(s) => values.append_value(s),
+                        Err(_) => values.append_null(),
+                    }
+                }
+                let mut next_extra = i32::try_from(col.dict().len()).map_err(|_| {
+                    DataFusionError::Internal("declared Str dictionary exceeds i32 keys".into())
+                })?;
+                let mut keys: Vec<Option<i32>> = Vec::with_capacity(n);
+                for i in start..end {
+                    if plan.all_cols.iter().any(|&c| attr_present(view, c, i)) {
+                        // Record wins. `id_at` is `Some` only when the record's
+                        // `Str` column has a value at this row; `None` (record set
+                        // the key in another-typed column) is a NULL cell. An `id`
+                        // pointing at a non-UTF-8 (NULL) dictionary value also reads
+                        // NULL, matching `read_str_cell`.
+                        match col.id_at(i) {
+                            Some(id) => keys.push(Some(i32::try_from(id).map_err(|_| {
+                                DataFusionError::Internal(
+                                    "declared Str dictionary id exceeds i32".into(),
+                                )
+                            })?)),
+                            None => keys.push(None),
+                        }
+                    } else if let Some(stream_ref) = view.stream_ref(i) {
+                        let resource = resource_attrs(view, cache, stream_ref)?;
+                        match find_attr(resource, &plan.dc.key) {
+                            Some(AttrValue::Str(s)) => {
+                                values.append_value(s);
+                                keys.push(Some(next_extra));
+                                next_extra += 1;
+                            }
+                            _ => keys.push(None),
+                        }
+                    } else {
+                        keys.push(None);
+                    }
+                }
+                let dict = DictionaryArray::<Int32Type>::try_new(
+                    Int32Array::from(keys),
+                    Arc::new(values.finish()),
+                )
+                .map_err(DataFusionError::from)?;
+                Arc::new(dict)
+            }
+            None => {
+                // Identity dictionary: one entry per non-null row, no dedup.
+                let mut values = StringBuilder::new();
+                let mut keys: Vec<Option<i32>> = Vec::with_capacity(n);
+                let mut next = 0i32;
+                for i in start..end {
+                    match declared_merged_value(view, plan, i, cache)? {
+                        Some(AttrValue::Str(s)) => {
+                            values.append_value(&s);
+                            keys.push(Some(next));
+                            next += 1;
+                        }
+                        _ => keys.push(None),
+                    }
+                }
+                let dict = DictionaryArray::<Int32Type>::try_new(
+                    Int32Array::from(keys),
+                    Arc::new(values.finish()),
+                )
+                .map_err(DataFusionError::from)?;
+                Arc::new(dict)
+            }
+        },
+    )
 }
 
 /// A UTF-8 log field (`body`, `severity_text`) read from the view; a violation

--- a/crates/ravel-sql/src/logs_schema.rs
+++ b/crates/ravel-sql/src/logs_schema.rs
@@ -91,7 +91,13 @@ pub fn logs_schema() -> SchemaRef {
 /// a cast (ADR-0090 decision 7).
 fn declared_arrow_type(ty: DeclaredType) -> DataType {
     match ty {
-        DeclaredType::Str => DataType::Utf8,
+        // `Str` is dictionary-encoded end to end (ADR-0099 decision 5): a
+        // dict-encoded page reaches Arrow as its dictionary and ids with no
+        // per-row allocation, and the client receives it as
+        // `Dictionary(Int32, Utf8)` over the public Flight statement path.
+        DeclaredType::Str => {
+            DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8))
+        }
         DeclaredType::I64 => DataType::Int64,
         DeclaredType::Bool => DataType::Boolean,
         DeclaredType::Bytes => DataType::Binary,
@@ -180,7 +186,10 @@ mod tests {
         assert_eq!(s.field(LOG_COL_ATTRS).name(), "attrs");
         // Declared columns follow, in list order, each nullable.
         assert_eq!(s.field(FIRST_DECLARED_COL).name(), "z.last");
-        assert_eq!(s.field(FIRST_DECLARED_COL).data_type(), &DataType::Utf8);
+        assert_eq!(
+            s.field(FIRST_DECLARED_COL).data_type(),
+            &DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8))
+        );
         assert_eq!(s.field(FIRST_DECLARED_COL + 1).name(), "duration_ms");
         assert_eq!(
             s.field(FIRST_DECLARED_COL + 1).data_type(),

--- a/crates/ravel-sql/src/logs_udf.rs
+++ b/crates/ravel-sql/src/logs_udf.rs
@@ -26,24 +26,96 @@
 
 use std::sync::Arc;
 
-use datafusion::arrow::array::{Array, BooleanArray, StringArray};
-use datafusion::arrow::datatypes::DataType;
+use datafusion::arrow::array::{Array, BooleanArray, DictionaryArray, StringArray};
+use datafusion::arrow::datatypes::{DataType, Int32Type};
 use datafusion::error::{DataFusionError, Result as DFResult};
-use datafusion::logical_expr::{ColumnarValue, ScalarUDF, Volatility, create_udf};
+use datafusion::logical_expr::{
+    ColumnarValue, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature, Volatility,
+};
 use datafusion::scalar::ScalarValue;
 
 /// The name of the `has_word(text, 'word') -> Boolean` UDF.
 pub const HAS_WORD_UDF: &str = "has_word";
 
+/// The `has_word` scalar UDF implementation.
+///
+/// The text argument is either a fixed `Utf8` column (`body`, `severity_text`)
+/// or a declared `Str` column, which arrives `Dictionary(Int32, Utf8)`
+/// (ADR-0099 decision 5). An exact `create_udf([Utf8, Utf8])` signature would
+/// make DataFusion coerce a dictionary argument to `Utf8`, inserting
+/// `CAST(col AS Utf8)` ahead of the call: the dictionary would be hydrated back
+/// to one value per row before the UDF ran, the dictionary arm of
+/// [`has_word_impl`] would be unreachable, and `has_word` over a declared column
+/// would be *slower* than the plain `Utf8` column it replaced. A user-defined
+/// signature that passes a `Dictionary(Int32, Utf8)` first argument through
+/// unchanged (see [`Self::coerce_types`]) keeps the dictionary intact into the
+/// evaluator, so it is matched once per distinct value; #479's LIKE pushdown
+/// builds on exactly this shape. Every other first-argument type still coerces
+/// to `Utf8`, so the UDF accepts exactly what the old exact signature did.
+#[derive(Debug, PartialEq, Eq, Hash)]
+struct HasWordUdf {
+    signature: Signature,
+}
+
+impl HasWordUdf {
+    fn new() -> Self {
+        HasWordUdf {
+            signature: Signature::user_defined(Volatility::Immutable),
+        }
+    }
+}
+
+impl ScalarUDFImpl for HasWordUdf {
+    fn name(&self) -> &str {
+        HAS_WORD_UDF
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> DFResult<DataType> {
+        Ok(DataType::Boolean)
+    }
+
+    /// Coerce the arguments to what the evaluator consumes while leaving a
+    /// declared `Str` column's `Dictionary(Int32, Utf8)` first argument
+    /// **unchanged**, so no coercing `CAST` hydrates the dictionary away (the
+    /// whole point of the user-defined signature; see the type doc).
+    ///
+    /// Every other first-argument type is coerced to `Utf8`, exactly what the
+    /// original `create_udf([Utf8, Utf8])` exact signature accepted: `Utf8`,
+    /// `LargeUtf8`, `Utf8View` (DataFusion types SQL `VARCHAR` as `Utf8View`
+    /// via `map_varchar_to_utf8view`), a `Dictionary` over any other key/value
+    /// pair, a NULL literal, and any type DataFusion can cast to `Utf8` all plan
+    /// and answer as they did before. The second argument coerces to `Utf8`, so
+    /// a wrong type there is a typed planning error rather than an execution
+    /// failure, consistent with the first. An input DataFusion cannot cast to
+    /// `Utf8` fails with its standard typed planning error at cast insertion.
+    fn coerce_types(&self, arg_types: &[DataType]) -> DFResult<Vec<DataType>> {
+        if arg_types.len() != 2 {
+            return Err(DataFusionError::Plan(format!(
+                "has_word() expects 2 arguments, got {}",
+                arg_types.len()
+            )));
+        }
+        let first = match &arg_types[0] {
+            DataType::Dictionary(k, v) if **k == DataType::Int32 && **v == DataType::Utf8 => {
+                arg_types[0].clone()
+            }
+            _ => DataType::Utf8,
+        };
+        Ok(vec![first, DataType::Utf8])
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> DFResult<ColumnarValue> {
+        has_word_impl(&args.args)
+    }
+}
+
 /// Build the `has_word` scalar UDF: `has_word(text, word) -> Boolean`.
 pub fn has_word_udf() -> ScalarUDF {
-    create_udf(
-        HAS_WORD_UDF,
-        vec![DataType::Utf8, DataType::Utf8],
-        DataType::Boolean,
-        Volatility::Immutable,
-        Arc::new(has_word_impl),
-    )
+    ScalarUDF::new_from_impl(HasWordUdf::new())
 }
 
 /// Forwards to `ravel_logseg::reader::phrase_match`, the same function
@@ -67,21 +139,67 @@ pub(crate) fn has_word_impl(args: &[ColumnarValue]) -> DFResult<ColumnarValue> {
         ColumnarValue::Array(a) => Arc::clone(a),
         ColumnarValue::Scalar(s) => s.to_array()?,
     };
-    let strings = text.as_any().downcast_ref::<StringArray>().ok_or_else(|| {
-        DataFusionError::Execution("has_word() first argument must be a Utf8 column".into())
-    })?;
-    let out: BooleanArray = (0..strings.len())
-        .map(|i| {
-            if strings.is_null(i) {
-                // A NULL cell contains no word; matches the reader treating an
-                // absent/undecodable text field as "no match".
-                Some(false)
-            } else {
-                Some(phrase_match(strings.value(i), &word))
+    // Fixed Utf8 columns (`body`, `severity_text`) arrive as a `StringArray`.
+    if let Some(strings) = text.as_any().downcast_ref::<StringArray>() {
+        let out: BooleanArray = (0..strings.len())
+            .map(|i| {
+                if strings.is_null(i) {
+                    // A NULL cell contains no word; matches the reader treating
+                    // an absent/undecodable text field as "no match".
+                    Some(false)
+                } else {
+                    Some(phrase_match(strings.value(i), &word))
+                }
+            })
+            .collect();
+        return Ok(ColumnarValue::Array(Arc::new(out)));
+    }
+    // Declared `Str` columns arrive dictionary-encoded (ADR-0099 decision 5).
+    // Evaluate `phrase_match` once per distinct dictionary value, then gather
+    // by key, so a column with few distinct values costs far less than one
+    // match per row (the shape #479's LIKE pushdown builds on).
+    if let Some(dict) = text.as_any().downcast_ref::<DictionaryArray<Int32Type>>() {
+        let values = dict
+            .values()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .ok_or_else(|| {
+                DataFusionError::Execution(
+                    "has_word() dictionary column must have Utf8 values".into(),
+                )
+            })?;
+        let per_value: Vec<bool> = (0..values.len())
+            .map(|k| !values.is_null(k) && phrase_match(values.value(k), &word))
+            .collect();
+        let keys = dict.keys();
+        let mut out: Vec<Option<bool>> = Vec::with_capacity(dict.len());
+        for i in 0..dict.len() {
+            if dict.is_null(i) {
+                out.push(Some(false));
+                continue;
             }
-        })
-        .collect();
-    Ok(ColumnarValue::Array(Arc::new(out)))
+            // A key that does not resolve to a distinct value is a corrupt
+            // column, not a non-match: default `false` would serve a
+            // silently-wrong answer on a read path (this crate's rule is exact
+            // semantics by default). Mirror `output.rs`'s `resolve_key`, which
+            // errors on the identical shape.
+            let key = keys.value(i);
+            let idx = usize::try_from(key).map_err(|_| {
+                DataFusionError::Execution(format!("has_word() negative dictionary key {key}"))
+            })?;
+            let matched = *per_value.get(idx).ok_or_else(|| {
+                DataFusionError::Execution(format!(
+                    "has_word() dictionary key {idx} out of range for {} values",
+                    per_value.len()
+                ))
+            })?;
+            out.push(Some(matched));
+        }
+        return Ok(ColumnarValue::Array(Arc::new(BooleanArray::from(out))));
+    }
+    Err(DataFusionError::Execution(
+        "has_word() first argument must be a Utf8 or Dictionary(Int32, Utf8) column".into(),
+    ))
 }
 
 /// Extract a non-null Utf8 scalar argument, mirroring `crate::udf`'s helper.
@@ -149,5 +267,34 @@ mod tests {
         assert!(b.value(0));
         assert!(!b.value(1));
         assert!(!b.value(2));
+    }
+
+    /// A declared `Str` column reaches `has_word` as a `Dictionary(Int32, Utf8)`
+    /// (ADR-0099 decision 5), not a `StringArray`. Without the dictionary arm the
+    /// downcast fails at runtime; this proves the arm evaluates the same rows the
+    /// plain-column path would, including a NULL key and a repeated value.
+    #[test]
+    fn impl_evaluates_over_a_declared_str_dictionary_column() {
+        use datafusion::arrow::array::{DictionaryArray, Int32Array};
+
+        // Distinct values 0="connection timeout", 1="ok"; keys reuse them and a
+        // NULL key stands in for an absent/undecodable cell.
+        let values = StringArray::from(vec![Some("connection timeout"), Some("ok")]);
+        let keys = Int32Array::from(vec![Some(0), Some(1), None, Some(0)]);
+        let dict = DictionaryArray::<Int32Type>::try_new(keys, Arc::new(values)).expect("dict");
+        let args = vec![
+            ColumnarValue::Array(Arc::new(dict)),
+            ColumnarValue::Scalar(ScalarValue::Utf8(Some("timeout".into()))),
+        ];
+        let out = has_word_impl(&args).expect("eval");
+        let arr = match out {
+            ColumnarValue::Array(a) => a,
+            ColumnarValue::Scalar(_) => panic!("expected array"),
+        };
+        let b = arr.as_any().downcast_ref::<BooleanArray>().unwrap();
+        assert!(b.value(0), "row 0 = 'connection timeout' matches 'timeout'");
+        assert!(!b.value(1), "row 1 = 'ok' does not match");
+        assert!(!b.value(2), "row 2 = NULL key is no match");
+        assert!(b.value(3), "row 3 reuses value 0 and matches");
     }
 }

--- a/crates/ravel-sql/src/output.rs
+++ b/crates/ravel-sql/src/output.rs
@@ -377,4 +377,121 @@ mod tests {
             .expect("json");
         assert_eq!(json["rows"][0][0], json!("deadbeef"));
     }
+
+    /// A declared `Str` column arrives as `Dictionary(Int32, Utf8)` after
+    /// ADR-0099 decision 5, but the HTTP JSON output must be byte-for-byte what
+    /// the pre-dictionary plain `Utf8` column produced: a string per row, JSON
+    /// `null` for a NULL key, and JSON `null` for a key addressing a NULL
+    /// (non-UTF-8) dictionary value. This asserts the existing
+    /// `Dictionary(Int32, _)` arm already covers the new column type.
+    #[test]
+    fn json_encodes_declared_str_dictionary_like_a_plain_string_column() {
+        use datafusion::arrow::array::{Int32Array, StringArray};
+
+        // Values 0="api", 1=<null>. Keys: "api", reuse "api", NULL key,
+        // key->null value.
+        let values = StringArray::from(vec![Some("api"), None]);
+        let keys = Int32Array::from(vec![Some(0), Some(0), None, Some(1)]);
+        let dict = DictionaryArray::<Int32Type>::try_new(keys, Arc::new(values)).expect("dict");
+        let schema: SchemaRef = Arc::new(Schema::new(vec![Field::new(
+            "name",
+            DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
+            true,
+        )]));
+        let batch = RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(dict) as ArrayRef])
+            .expect("batch");
+        let json = QueryOutput::new(schema, vec![batch])
+            .to_json()
+            .expect("json");
+        let rows = json["rows"].as_array().expect("rows");
+        assert_eq!(rows[0][0], json!("api"));
+        assert_eq!(rows[1][0], json!("api"));
+        assert_eq!(rows[2][0], Json::Null, "a NULL key is JSON null");
+        assert_eq!(
+            rows[3][0],
+            Json::Null,
+            "a key pointing at a NULL dictionary value is JSON null"
+        );
+    }
+
+    /// The JSON row *values* of a declared `Str` column are plain strings, but
+    /// the response envelope's declared `columns[].type` is the dictionary type,
+    /// not `Utf8`: `to_json` reports `f.data_type().to_string()`, so a client
+    /// reading the column type sees the ADR-0099 decision 5 change. The docs must
+    /// not claim JSON renders "exactly as a plain string column".
+    #[test]
+    fn json_envelope_reports_declared_str_column_as_dictionary_type() {
+        use datafusion::arrow::array::{Int32Array, StringArray};
+
+        let values = StringArray::from(vec![Some("api"), Some("worker")]);
+        let keys = Int32Array::from(vec![Some(0), Some(1)]);
+        let dict = DictionaryArray::<Int32Type>::try_new(keys, Arc::new(values)).expect("dict");
+        let schema: SchemaRef = Arc::new(Schema::new(vec![Field::new(
+            "name",
+            DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
+            true,
+        )]));
+        let batch = RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(dict) as ArrayRef])
+            .expect("batch");
+        let json = QueryOutput::new(schema, vec![batch])
+            .to_json()
+            .expect("json");
+
+        let rows = json["rows"].as_array().expect("rows");
+        assert_eq!(rows[0][0], json!("api"), "values are plain strings");
+        assert_eq!(rows[1][0], json!("worker"));
+
+        let cols = json["columns"].as_array().expect("columns");
+        assert_eq!(cols[0]["name"], json!("name"));
+        assert_eq!(
+            cols[0]["type"],
+            json!("Dictionary(Int32, Utf8)"),
+            "the envelope declares the dictionary type, not Utf8"
+        );
+    }
+
+    /// The Arrow IPC surface (`to_arrow_ipc`, served by ravel-server's SQL
+    /// endpoint for an `Accept: application/vnd.apache.arrow.stream` request)
+    /// hands the schema and batches to `StreamWriter` unchanged, so a declared
+    /// `Str` column's `Dictionary(Int32, Utf8)` type crosses the wire verbatim:
+    /// both the IPC schema and the batch column are a dictionary, not `Utf8`.
+    /// The docs must not claim Arrow IPC renders it as a plain string column.
+    #[test]
+    fn arrow_ipc_carries_the_declared_str_dictionary_type() {
+        use datafusion::arrow::array::{Int32Array, StringArray};
+        use datafusion::arrow::ipc::reader::StreamReader;
+
+        let values = StringArray::from(vec![Some("api"), Some("worker")]);
+        let keys = Int32Array::from(vec![Some(0), Some(1), Some(0)]);
+        let dict = DictionaryArray::<Int32Type>::try_new(keys, Arc::new(values)).expect("dict");
+        let dict_ty = DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8));
+        let schema: SchemaRef =
+            Arc::new(Schema::new(vec![Field::new("name", dict_ty.clone(), true)]));
+        let batch = RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(dict) as ArrayRef])
+            .expect("batch");
+        let bytes = QueryOutput::new(schema, vec![batch])
+            .to_arrow_ipc()
+            .expect("ipc");
+
+        let reader = StreamReader::try_new(bytes.as_slice(), None).expect("reader");
+        let batches: Vec<RecordBatch> = reader.map(|b| b.expect("batch")).collect();
+        assert_eq!(batches.len(), 1);
+        assert_eq!(
+            batches[0].schema().field(0).data_type(),
+            &dict_ty,
+            "the IPC schema carries the dictionary type verbatim, not Utf8"
+        );
+        let col = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<DictionaryArray<Int32Type>>()
+            .expect("the IPC batch column is a real dictionary");
+        let vals = col
+            .values()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("utf8 dictionary values");
+        assert_eq!(vals.value(col.keys().value(0) as usize), "api");
+        assert_eq!(vals.value(col.keys().value(2) as usize), "api");
+    }
 }

--- a/crates/ravel-sql/tests/logs_columnar.rs
+++ b/crates/ravel-sql/tests/logs_columnar.rs
@@ -25,14 +25,16 @@
 use std::sync::Arc;
 
 use datafusion::arrow::array::{
-    Array, BinaryArray, BooleanArray, FixedSizeBinaryArray, Int64Array, RecordBatch, StringArray,
-    TimestampNanosecondArray, UInt8Array, UInt32Array,
+    Array, BinaryArray, BooleanArray, DictionaryArray, FixedSizeBinaryArray, Int64Array,
+    RecordBatch, StringArray, TimestampNanosecondArray, UInt8Array, UInt32Array,
 };
+use datafusion::arrow::datatypes::{DataType, Int32Type};
 use datafusion::execution::TaskContext;
 use datafusion::physical_plan::ExecutionPlan;
 use futures::StreamExt;
 use proptest::prelude::*;
 use ravel_catalog::{SegmentLevel, SegmentRef, Snapshot};
+use ravel_codec::encoding::{Enc, encode_strings};
 use ravel_logseg::block::{ColumnPlan, write_block};
 use ravel_logseg::field_dir::FieldDir;
 use ravel_logseg::footer::{
@@ -432,6 +434,24 @@ fn a<T: Array + 'static>(batch: &RecordBatch, col: usize) -> &T {
         .expect("column type")
 }
 
+/// The logical `Str` value of a declared `Dictionary(Int32, Utf8)` column at row
+/// `i`: `None` for a NULL key or a key addressing a NULL (non-UTF-8) dictionary
+/// value, `Some(s)` otherwise. Declared `Str` columns are dictionary-encoded
+/// (ADR-0099 decision 5), so a plain `StringArray` downcast no longer applies.
+fn dict_str(batch: &RecordBatch, col: usize, i: usize) -> Option<String> {
+    let dict = a::<DictionaryArray<Int32Type>>(batch, col);
+    if dict.is_null(i) {
+        return None;
+    }
+    let values = dict
+        .values()
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .expect("dictionary values are Utf8");
+    let k = usize::try_from(dict.keys().value(i)).expect("non-negative key");
+    (!values.is_null(k)).then(|| values.value(k).to_string())
+}
+
 /// Extract every row of `batches` as a `Vec<Cell>`, one cell per projected
 /// column, so two scans over the same input compare as sorted multisets.
 fn rows(
@@ -476,10 +496,7 @@ fn cell(
                     let arr = a::<Int64Array>(batch, col);
                     Cell::OptI64((!arr.is_null(i)).then(|| arr.value(i)))
                 }
-                DeclaredType::Str => {
-                    let arr = a::<StringArray>(batch, col);
-                    Cell::OptStr((!arr.is_null(i)).then(|| arr.value(i).to_string()))
-                }
+                DeclaredType::Str => Cell::OptStr(dict_str(batch, col, i)),
                 DeclaredType::Bool => {
                     let arr = a::<BooleanArray>(batch, col);
                     Cell::OptBool((!arr.is_null(i)).then(|| arr.value(i)))
@@ -897,7 +914,7 @@ fn rewrite_str_column_cells(
     cfg: RlogConfig,
     records: &[LogRecord],
     column_id: u32,
-    cells: &[Vec<u8>],
+    cells: &[Option<Vec<u8>>],
 ) -> Vec<u8> {
     assert_eq!(records.len(), cells.len(), "one cell per record");
     let footer = open_footer(obj).expect("open the writer's footer");
@@ -916,7 +933,14 @@ fn rewrite_str_column_cells(
             span_id: r.span_id,
             flags: r.flags,
             attrs_raw: None,
-            columns: vec![(column_id, ColumnValue::Str(cell.clone()))],
+            // `None` leaves the declared column absent at this row, so a
+            // resource-level value shows through the merge (the fallback-append
+            // branch); `Some` writes the record cell verbatim, including bytes
+            // the writer would reject (a non-UTF-8 `Str`).
+            columns: match cell {
+                Some(bytes) => vec![(column_id, ColumnValue::Str(bytes.clone()))],
+                None => Vec::new(),
+            },
             indexed_terms: Vec::new(),
             stat_winners: Vec::new(),
         })
@@ -1021,7 +1045,7 @@ async fn a_declared_str_cell_that_is_not_utf8_reads_as_absent_on_both_paths() {
         cfg,
         &records,
         column_id,
-        &[vec![0xff], b"from-record".to_vec()],
+        &[Some(vec![0xff]), Some(b"from-record".to_vec())],
     );
 
     let store = MemoryStore::new();
@@ -1070,6 +1094,340 @@ async fn a_declared_str_cell_that_is_not_utf8_reads_as_absent_on_both_paths() {
     assert_eq!(
         rows(&row.batches, &projection, &declared),
         want,
+        "the row path's answer is the reference the fast path must match"
+    );
+}
+
+/// The two-paths-one-schema invariant (ADR-0099 decision 5). An erasure-pending
+/// query over a declared `Str` column takes the row path, and its batches must
+/// carry the SAME `Dictionary(Int32, Utf8)` column type the fast path produces:
+/// DataFusion validates every batch against one schema, so a row-path batch that
+/// built a plain `Utf8` array would be rejected by `RecordBatch::try_new` at
+/// runtime. This asserts the type on the returned batch and that the two paths'
+/// batch schemas are identical, not merely that the scan did not error.
+///
+/// Reverting `declared_column_array`'s `Str` arm to a `StringBuilder`
+/// (crates/ravel-sql/src/logs_scan.rs, the `DeclaredType::Str` arm) makes the
+/// row-path scan fail to produce batches at all, failing this test.
+#[tokio::test]
+async fn fallback_batches_match_the_dictionary_schema() {
+    let declared = declared_columns();
+    let name_col = FIRST_DECLARED_COL + 1; // the Str-typed `name`
+    let projection = vec![0usize, name_col];
+
+    let resource = vec![("service.name".to_string(), AttrValue::Str("api".into()))];
+    let mk = |ts: i64, name: &str| LogRecord {
+        stream_id: log_stream_id(&resource, "scope", "1.0", &[]),
+        stream_attrs: stream_attrs_bytes(&resource, "scope", "1.0", &[]),
+        ts_ns: ts,
+        observed_ts_ns: ts,
+        severity_num: 9,
+        severity_text: "INFO".into(),
+        body: "b".into(),
+        trace_id: None,
+        span_id: None,
+        flags: 0,
+        attrs: vec![("name".to_string(), AttrValue::Str(name.to_string()))],
+    };
+    let records = vec![mk(0, "a"), mk(1, "b"), mk(2, "a")];
+
+    let store = MemoryStore::new();
+    let seg = write_object(&store, "logs/schema.rlog", &records, RlogConfig::default()).await;
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(store);
+    let segments = vec![seg];
+
+    let row = run_scan(
+        Arc::clone(&store),
+        segments.clone(),
+        declared.clone(),
+        Some(projection.clone()),
+        Vec::new(),
+        no_match_erasure(),
+    )
+    .await;
+    assert_eq!(row.columnar_batches, 0, "erasure must force the row path");
+    assert!(row.rowpath_batches > 0, "the row path must have run");
+
+    let fast = run_scan(
+        Arc::clone(&store),
+        segments,
+        declared.clone(),
+        Some(projection.clone()),
+        Vec::new(),
+        Vec::new(),
+    )
+    .await;
+    assert!(fast.columnar_batches > 0, "the fast path must have run");
+
+    let dict_ty = DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8));
+    for b in &row.batches {
+        assert_eq!(
+            b.schema().field(1).data_type(),
+            &dict_ty,
+            "row-path declared Str column must be dictionary-typed"
+        );
+    }
+    assert_eq!(
+        row.batches[0].schema(),
+        fast.batches[0].schema(),
+        "the row path and fast path must agree on the batch schema"
+    );
+    assert_eq!(
+        rows(&row.batches, &projection, &declared),
+        rows(&fast.batches, &projection, &declared),
+        "both paths must read the same values"
+    );
+}
+
+/// A dict-encoded page and a plain page both read back correct declared `Str`
+/// values through the fast path (ADR-0099 decision 5). A page whose distinct
+/// values are at most half its rows is dictionary-encoded (the writer's
+/// distinct-ratio heuristic) and reaches Arrow as its dictionary plus ids; an
+/// all-distinct page stays plain and takes the degenerate identity-dictionary
+/// branch (`str_dict` returns `None`). Both must yield the exact strings.
+#[tokio::test]
+async fn dict_page_and_plain_page_both_read_correct_values() {
+    let declared = declared_columns();
+    let name_col = FIRST_DECLARED_COL + 1;
+    let projection = vec![0usize, name_col];
+    let resource = vec![("service.name".to_string(), AttrValue::Str("api".into()))];
+    let mk = |ts: i64, name: &str| LogRecord {
+        stream_id: log_stream_id(&resource, "scope", "1.0", &[]),
+        stream_attrs: stream_attrs_bytes(&resource, "scope", "1.0", &[]),
+        ts_ns: ts,
+        observed_ts_ns: ts,
+        severity_num: 9,
+        severity_text: "INFO".into(),
+        body: "b".into(),
+        trace_id: None,
+        span_id: None,
+        flags: 0,
+        attrs: vec![("name".to_string(), AttrValue::Str(name.to_string()))],
+    };
+
+    // One block per object so the encoding decision is per whole corpus.
+    let cfg = RlogConfig {
+        block_target_records: 64,
+        ..RlogConfig::default()
+    };
+
+    // Dict page: 6 rows, 2 distinct values (2*2 <= 6).
+    let dict_records: Vec<LogRecord> = (0..6)
+        .map(|i| mk(i, if i % 2 == 0 { "api" } else { "worker" }))
+        .collect();
+    // Plain page: 6 rows, all distinct (6*2 > 6).
+    let plain_records: Vec<LogRecord> = (0..6).map(|i| mk(i, &format!("n{i}"))).collect();
+
+    for (key, recs) in [
+        ("logs/dictpage.rlog", &dict_records),
+        ("logs/plainpage.rlog", &plain_records),
+    ] {
+        // Assert each fixture's declared `name` value set actually produces the
+        // encoding its name claims. `encode_strings` is the exact codec the
+        // writer stages a dynamic string column with, so this ties the fixture
+        // to the live `dict_is_worth_it` heuristic: move that heuristic and the
+        // "dict page" fixture becomes a plain page, failing here rather than
+        // silently exercising the identity branch twice.
+        let name_vals: Vec<&[u8]> = recs
+            .iter()
+            .map(|r| match &r.attrs[0].1 {
+                AttrValue::Str(s) => s.as_bytes(),
+                _ => unreachable!(),
+            })
+            .collect();
+        let want_enc = if key == "logs/dictpage.rlog" {
+            Enc::Dict
+        } else {
+            Enc::Plain
+        };
+        assert_eq!(
+            encode_strings(&name_vals).0,
+            want_enc,
+            "fixture {key} must actually produce {want_enc:?}"
+        );
+
+        let store = MemoryStore::new();
+        let seg = write_object(&store, key, recs, cfg).await;
+        let store: Arc<dyn ObjectStoreBackend> = Arc::new(store);
+        let fast = run_scan(
+            store,
+            vec![seg],
+            declared.clone(),
+            Some(projection.clone()),
+            Vec::new(),
+            Vec::new(),
+        )
+        .await;
+        assert!(
+            fast.columnar_batches > 0,
+            "fast path must have run for {key}"
+        );
+        assert_eq!(
+            fast.rowpath_batches, 0,
+            "fast path must not fall back for {key}"
+        );
+
+        let mut want: Vec<Vec<Cell>> = recs
+            .iter()
+            .map(|r| {
+                let name = match &r.attrs[0].1 {
+                    AttrValue::Str(s) => s.clone(),
+                    _ => unreachable!(),
+                };
+                vec![Cell::Ts(r.ts_ns), Cell::OptStr(Some(name))]
+            })
+            .collect();
+        want.sort();
+        assert_eq!(
+            rows(&fast.batches, &projection, &declared),
+            want,
+            "declared Str values must be correct for {key}"
+        );
+    }
+}
+
+/// The dict-page fast path with BOTH a resource/scope fallback append and a
+/// non-UTF-8 page-dictionary entry in the same block (logs_scan.rs's
+/// `next_extra` append and the `str::from_utf8` NULL arm). Neither is reached by
+/// the existing coverage: `a_declared_str_cell_that_is_not_utf8_reads_as_absent`
+/// uses 2 rows / 2 distinct, so `dict_is_worth_it(2, 2)` is false and it takes
+/// the identity (plain-page) branch, and the differential proptest's
+/// `small_blocks()` admits only a single-entry page dictionary.
+///
+/// The block: rows 0..=3 set the declared `name` to "api", row 4 to "worker",
+/// row 5 to raw `[b'b', 0xff]` (a non-UTF-8 record cell, sorting between "api"
+/// and "worker" in the page dictionary so a dropped-not-nulled entry would
+/// misnumber a value that is actually used), rows 6..=7 do not set it at all. The record `name` column is present on rows 0..=5 (six values, three
+/// distinct), so `dict_is_worth_it(3, 6)` holds and the page is `Enc::Dict` with
+/// a non-UTF-8 entry. A non-UTF-8 record cell reads as absent (matching the row
+/// path's `String::from_utf8().ok()`), so row 5 and the truly-absent rows 6..=7
+/// all fall through to the resource value appended past the page dictionary.
+#[tokio::test]
+async fn dict_page_with_non_utf8_entry_and_resource_fallback_append() {
+    let cfg = RlogConfig {
+        block_target_records: 64,
+        ..RlogConfig::default()
+    };
+    let declared = vec![DeclaredColumn::new("name", DeclaredType::Str)];
+    let resource = vec![("name".to_string(), AttrValue::Str("from-resource".into()))];
+    let mk = |ts: i64| LogRecord {
+        stream_id: log_stream_id(&resource, "scope", "1.0", &[]),
+        stream_attrs: stream_attrs_bytes(&resource, "scope", "1.0", &[]),
+        ts_ns: ts,
+        observed_ts_ns: ts,
+        severity_num: 9,
+        severity_text: "INFO".into(),
+        body: "b".into(),
+        trace_id: None,
+        span_id: None,
+        flags: 0,
+        // A record-level `name` on every record so the FIELD_DIR (copied verbatim
+        // by the rewrite) carries the `Str` column; per-row presence is decided
+        // by the rewrite's cell list below, not here.
+        attrs: vec![("name".to_string(), AttrValue::Str("seed".to_string()))],
+    };
+    let records: Vec<LogRecord> = (0..8).map(mk).collect();
+
+    let clean = encode_object(&records, cfg);
+    let column_id = str_column_id(&clean, cfg, "name");
+
+    // Present rows carry the page dictionary; `None` rows leave the column absent
+    // so the resource value shows through the fallback append.
+    let cells: Vec<Option<Vec<u8>>> = vec![
+        Some(b"api".to_vec()),
+        Some(b"api".to_vec()),
+        Some(b"api".to_vec()),
+        Some(b"api".to_vec()),
+        Some(b"worker".to_vec()),
+        // A non-UTF-8 cell whose bytes sort BETWEEN "api" and "worker" in the
+        // page dictionary. The `Err(_) => append_null()` arm in logs_scan.rs
+        // exists to keep Arrow dictionary indices aligned with the page's ids:
+        // a non-UTF-8 entry must become a NULL SLOT, not be dropped. A value
+        // that sorts last (e.g. `[0xff]`) shifts no in-use id when dropped, so
+        // the test could not tell "null slot" from "dropped"; `[b'b', 0xff]`
+        // sorts mid-dictionary, so skipping it would renumber "worker".
+        Some(vec![b'b', 0xff]),
+        None,
+        None,
+    ];
+    // The page holds only the present cells; assert it truly encodes as a dict
+    // page (three distinct of six present), with the non-UTF-8 byte string among
+    // its entries.
+    let present: Vec<&[u8]> = cells.iter().filter_map(|c| c.as_deref()).collect();
+    assert_eq!(
+        encode_strings(&present).0,
+        Enc::Dict,
+        "the present cells must encode as a dict page"
+    );
+
+    let patched = rewrite_str_column_cells(&clean, cfg, &records, column_id, &cells);
+
+    let store = MemoryStore::new();
+    let seg = put_object(
+        &store,
+        "logs/dictfallback.rlog",
+        patched,
+        0,
+        7,
+        records.len(),
+    )
+    .await;
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(store);
+    let segments = vec![seg];
+
+    let projection = vec![0usize, FIRST_DECLARED_COL];
+    let want = vec![
+        vec![Cell::Ts(0), Cell::OptStr(Some("api".to_string()))],
+        vec![Cell::Ts(1), Cell::OptStr(Some("api".to_string()))],
+        vec![Cell::Ts(2), Cell::OptStr(Some("api".to_string()))],
+        vec![Cell::Ts(3), Cell::OptStr(Some("api".to_string()))],
+        vec![Cell::Ts(4), Cell::OptStr(Some("worker".to_string()))],
+        // Row 5's [0xff] cell reads as absent -> resource shows through.
+        vec![Cell::Ts(5), Cell::OptStr(Some("from-resource".to_string()))],
+        vec![Cell::Ts(6), Cell::OptStr(Some("from-resource".to_string()))],
+        vec![Cell::Ts(7), Cell::OptStr(Some("from-resource".to_string()))],
+    ];
+
+    let fast = run_scan(
+        Arc::clone(&store),
+        segments.clone(),
+        declared.clone(),
+        Some(projection.clone()),
+        Vec::new(),
+        Vec::new(),
+    )
+    .await;
+    assert!(fast.columnar_batches > 0, "the fast path must have run");
+    assert_eq!(fast.rowpath_batches, 0, "the fast path must not fall back");
+    let mut got = rows(&fast.batches, &projection, &declared);
+    got.sort();
+    let mut want_sorted = want.clone();
+    want_sorted.sort();
+    assert_eq!(
+        got, want_sorted,
+        "dict-id rows, the non-UTF-8 cell, and the fallback-append rows must all \
+         read correctly on the fast path"
+    );
+
+    // The row path over the same object is the reference: it must agree.
+    let row = run_scan(
+        Arc::clone(&store),
+        segments,
+        declared.clone(),
+        Some(projection.clone()),
+        Vec::new(),
+        no_match_erasure(),
+    )
+    .await;
+    assert_eq!(
+        row.columnar_batches, 0,
+        "the forced run must be the row path"
+    );
+    assert!(row.rowpath_batches > 0, "the row path must have run");
+    let mut row_got = rows(&row.batches, &projection, &declared);
+    row_got.sort();
+    assert_eq!(
+        row_got, want_sorted,
         "the row path's answer is the reference the fast path must match"
     );
 }

--- a/crates/ravel-sql/tests/logs_declared_columns.rs
+++ b/crates/ravel-sql/tests/logs_declared_columns.rs
@@ -27,8 +27,10 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use datafusion::arrow::array::{
-    Array, BinaryArray, BooleanArray, Int64Array, MapArray, StringArray, StructArray,
+    Array, BinaryArray, BooleanArray, DictionaryArray, Int64Array, MapArray, StringArray,
+    StructArray,
 };
+use datafusion::arrow::datatypes::Int32Type;
 use ravel_catalog::{Catalog, CatalogConfig};
 use ravel_commit::publish::RetryPolicy;
 use ravel_commit::record::NewCommitRecord;
@@ -223,11 +225,28 @@ async fn declared_columns_project_as_native_typed_arrays_null_on_mismatch() {
         .as_any()
         .downcast_ref::<Int64Array>()
         .expect("dur is a native Int64 column, not a string");
-    let name = batch
+    // A declared Str column is dictionary-encoded (ADR-0099 decision 5), so it
+    // downcasts to `Dictionary(Int32, Utf8)`, not a plain `StringArray`.
+    let name_dict = batch
         .column(2)
         .as_any()
+        .downcast_ref::<DictionaryArray<Int32Type>>()
+        .expect("name is a native Dictionary(Int32, Utf8) column");
+    let name_values = name_dict
+        .values()
+        .as_any()
         .downcast_ref::<StringArray>()
-        .expect("name is a native Utf8 column");
+        .expect("name dictionary values are Utf8");
+    let name: Vec<Option<String>> = (0..name_dict.len())
+        .map(|i| {
+            if name_dict.is_null(i) {
+                None
+            } else {
+                let k = name_dict.keys().value(i) as usize;
+                (!name_values.is_null(k)).then(|| name_values.value(k).to_string())
+            }
+        })
+        .collect();
     let ok = batch
         .column(3)
         .as_any()
@@ -241,13 +260,16 @@ async fn declared_columns_project_as_native_typed_arrays_null_on_mismatch() {
 
     // Row 0 (ts=1): matching values, native and non-null.
     assert!(!dur.is_null(0) && dur.value(0) == 42);
-    assert!(!name.is_null(0) && name.value(0) == "checkout");
+    assert!(name[0].as_deref() == Some("checkout"));
     assert!(!ok.is_null(0) && ok.value(0));
     assert!(!blob.is_null(0) && blob.value(0) == [1u8, 2, 3]);
 
     // Row 1 (ts=2): every value is the wrong variant -> NULL, never a cast.
     assert!(dur.is_null(1), "a Str under an i64 column must read NULL");
-    assert!(name.is_null(1), "an I64 under a str column must read NULL");
+    assert!(
+        name[1].is_none(),
+        "an I64 under a str column must read NULL"
+    );
     assert!(ok.is_null(1), "a Str under a bool column must read NULL");
     assert!(
         blob.is_null(1),
@@ -255,7 +277,7 @@ async fn declared_columns_project_as_native_typed_arrays_null_on_mismatch() {
     );
 
     // Row 2 (ts=3): keys absent -> NULL.
-    assert!(dur.is_null(2) && name.is_null(2) && ok.is_null(2) && blob.is_null(2));
+    assert!(dur.is_null(2) && name[2].is_none() && ok.is_null(2) && blob.is_null(2));
 
     // Decision 6: declared keys still appear in the `attrs` map exactly as they
     // would undeclared. Row 0 carries dur/name/ok/blob plus the resource key.

--- a/crates/ravel-sql/tests/logs_provider.rs
+++ b/crates/ravel-sql/tests/logs_provider.rs
@@ -32,7 +32,7 @@ use datafusion::execution::TaskContext;
 use datafusion::logical_expr::{
     ColumnarValue, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature, Volatility,
 };
-use datafusion::physical_plan::collect;
+use datafusion::physical_plan::{collect, displayable};
 use datafusion::prelude::{SessionContext, col, lit};
 use datafusion::scalar::ScalarValue;
 use ravel_catalog::{SegmentLevel, SegmentRef, Snapshot};
@@ -42,7 +42,7 @@ use ravel_logseg::{AttrValue, LogRecord, RlogConfig, RlogWriter, stream_attrs_by
 use ravel_object_store::memory::MemoryStore;
 use ravel_object_store::{ObjectStoreBackend, PutOptions};
 use ravel_query::LogSegmentFetcher;
-use ravel_sql::{LogsTableProvider, has_word_udf};
+use ravel_sql::{DeclaredColumn, DeclaredType, LogsTableProvider, has_word_udf};
 use ravel_types::TenantHash;
 use ravel_types::accounting::QueryAccounting;
 use uuid::Uuid;
@@ -941,5 +941,229 @@ async fn referencing_attrs_decodes_every_dynamic_column() {
         skipped,
         5 * blocks,
         "referencing attrs must skip only the unprojected fixed columns"
+    );
+}
+
+/// ADR-0099 decision 5 types a declared `Str` column `Dictionary(Int32, Utf8)`.
+/// `has_word` must reach that dictionary column with NO materializing cast: an
+/// exact `create_udf([Utf8, Utf8])` signature makes DataFusion insert
+/// `CAST(name AS Utf8)` over the dictionary argument, which both hydrates the
+/// column back to one value per row (defeating the per-distinct-value shape
+/// #479 builds on) and leaves the dictionary arm of `has_word_impl` unreachable
+/// by any plan. This asserts the optimized physical plan carries no `CAST`, and
+/// that the query still returns exactly the matching rows -- so the dictionary
+/// arm actually executes end to end, which a direct `has_word_impl` unit call
+/// cannot prove.
+#[tokio::test]
+async fn has_word_over_declared_str_column_has_no_cast_and_returns_exact_rows() {
+    let store = MemoryStore::new();
+    // Low-cardinality declared `name` values so the page is a dict page, the
+    // shape decision 5 targets. `name` matches "timeout" on the even rows.
+    let resource = vec![("service.name".to_string(), AttrValue::Str("svc".into()))];
+    let records: Vec<LogRecord> = (0..6)
+        .map(|i| {
+            let name = if i % 2 == 0 {
+                "connection timeout"
+            } else {
+                "ok"
+            };
+            record_with_resource_and_attrs(
+                &resource,
+                i,
+                "b",
+                &[("name".to_string(), AttrValue::Str(name.to_string()))],
+            )
+        })
+        .collect();
+    let seg = write_object(&store, "logs/declared.rlog", &records).await;
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(store);
+    let fetcher = LogSegmentFetcher::new(store);
+    let snapshot = Snapshot {
+        segments: vec![seg],
+        segments_pruned: 0,
+        pending_erasure: Vec::new(),
+    };
+    let provider = LogsTableProvider::new(
+        snapshot,
+        TenantHash([7u8; 16]),
+        fetcher,
+        QueryAccounting::new(),
+    )
+    .with_declared_columns(vec![DeclaredColumn::new("name", DeclaredType::Str)]);
+
+    let ctx = SessionContext::new();
+    ctx.register_udf(has_word_udf());
+    ctx.register_table("logs", Arc::new(provider))
+        .expect("register table");
+    let df = ctx
+        .table("logs")
+        .await
+        .expect("table")
+        .filter(has_word_udf().call(vec![col("name"), lit("timeout")]))
+        .expect("filter");
+    let plan = df.create_physical_plan().await.expect("physical plan");
+
+    // The only expression in the plan is the `has_word` residual over the
+    // declared column; a `CAST` anywhere is the coercion the exact signature
+    // would have inserted over the dictionary argument.
+    let text = displayable(plan.as_ref()).indent(true).to_string();
+    assert!(
+        !text.contains("CAST"),
+        "has_word must take the dictionary column with no coercing CAST; plan was:\n{text}"
+    );
+    assert!(
+        text.contains("has_word(name@"),
+        "has_word's first argument must be the bare declared column, not a CAST; \
+         plan was:\n{text}"
+    );
+
+    // End to end: the dictionary arm evaluates and returns exactly the even
+    // rows, whose declared `name` token-contains "timeout".
+    let batches = collect_plan(plan).await;
+    let mut got = BTreeSet::new();
+    for batch in &batches {
+        let ts = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<TimestampNanosecondArray>()
+            .expect("ts col");
+        for i in 0..batch.num_rows() {
+            got.insert(ts.value(i));
+        }
+    }
+    assert_eq!(
+        got,
+        BTreeSet::from([0i64, 2, 4]),
+        "has_word over the declared dictionary column must match exactly the \
+         'connection timeout' rows"
+    );
+}
+
+/// Probe matrix for `has_word`'s first-argument coercion. The user-defined
+/// signature must leave a declared `Str` column's `Dictionary(Int32, Utf8)`
+/// intact (no coercing CAST, so the per-distinct-value dictionary arm stays
+/// reachable) while still accepting every first-argument type the original
+/// `create_udf([Utf8, Utf8])` exact signature accepted. A prior fix over-narrowed
+/// the signature to reject anything but `Utf8`/`Dictionary(Int32, Utf8)`, turning
+/// ordinary queries -- notably `CAST(body AS VARCHAR)`, which DataFusion types as
+/// `Utf8View` -- into planning errors. This pins each type end to end: it must
+/// plan AND return the expected rows.
+#[tokio::test]
+async fn has_word_first_argument_coercion_matrix() {
+    let store = MemoryStore::new();
+    let resource = vec![("service.name".to_string(), AttrValue::Str("svc".into()))];
+    // `body` and the declared `name` carry the same low-cardinality text, so
+    // `name` encodes as a dict page (the shape decision 5 targets) and both
+    // columns token-contain "timeout" on the same two rows (ts 0 and 2).
+    let rows_spec = [
+        (0i64, "connection timeout"),
+        (1, "ok"),
+        (2, "request timeout"),
+        (3, "fine"),
+    ];
+    let records: Vec<LogRecord> = rows_spec
+        .iter()
+        .map(|(ts, text)| {
+            record_with_resource_and_attrs(
+                &resource,
+                *ts,
+                text,
+                &[("name".to_string(), AttrValue::Str((*text).to_string()))],
+            )
+        })
+        .collect();
+    let seg = write_object(&store, "logs/matrix.rlog", &records).await;
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(store);
+    let fetcher = LogSegmentFetcher::new(store);
+    let snapshot = Snapshot {
+        segments: vec![seg],
+        segments_pruned: 0,
+        pending_erasure: Vec::new(),
+    };
+    let provider = LogsTableProvider::new(
+        snapshot,
+        TenantHash([7u8; 16]),
+        fetcher,
+        QueryAccounting::new(),
+    )
+    .with_declared_columns(vec![DeclaredColumn::new("name", DeclaredType::Str)]);
+
+    let ctx = SessionContext::new();
+    ctx.register_udf(has_word_udf());
+    ctx.register_table("logs", Arc::new(provider))
+        .expect("register table");
+
+    // (label, first-argument SQL expression, expected surviving ts values in
+    // order). Each planned and answered under the old exact signature; the fix
+    // must keep them planning and answering identically.
+    let cases: &[(&str, &str, &[i64])] = &[
+        ("Utf8 body", "body", &[0, 2]),
+        ("declared Str dictionary", "name", &[0, 2]),
+        (
+            "SQL CAST(body AS VARCHAR) -> Utf8View",
+            "CAST(body AS VARCHAR)",
+            &[0, 2],
+        ),
+        ("LargeUtf8", "arrow_cast(body, 'LargeUtf8')", &[0, 2]),
+        ("Utf8View", "arrow_cast(body, 'Utf8View')", &[0, 2]),
+        (
+            "Dictionary(Int8, Utf8)",
+            "arrow_cast(name, 'Dictionary(Int8, Utf8)')",
+            &[0, 2],
+        ),
+        // Int64 casts to its decimal text, which token-contains no "timeout".
+        ("Int64", "arrow_cast(ts, 'Int64')", &[]),
+        // A NULL first argument is never a match.
+        ("NULL literal", "NULL", &[]),
+        // A constant-true string literal matches every row.
+        ("string literal", "'connection timeout'", &[0, 1, 2, 3]),
+    ];
+
+    for (label, first_arg, expected) in cases {
+        let sql = format!("SELECT ts FROM logs WHERE has_word({first_arg}, 'timeout') ORDER BY ts");
+        let df = ctx
+            .sql(&sql)
+            .await
+            .unwrap_or_else(|e| panic!("[{label}] planning failed: {e}"));
+        let batches = df
+            .collect()
+            .await
+            .unwrap_or_else(|e| panic!("[{label}] execution failed: {e}"));
+        let mut got = Vec::new();
+        for batch in &batches {
+            let ts = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<TimestampNanosecondArray>()
+                .expect("ts col");
+            for i in 0..batch.num_rows() {
+                got.push(ts.value(i));
+            }
+        }
+        assert_eq!(
+            got, *expected,
+            "[{label}] has_word({first_arg}, 'timeout') returned unexpected rows"
+        );
+    }
+
+    // The dictionary case must additionally carry NO CAST in the optimized
+    // physical plan: leaving `Dictionary(Int32, Utf8)` intact is the whole point
+    // of the user-defined signature (kept from the earlier dedicated test).
+    let dict_plan = ctx
+        .sql("SELECT ts FROM logs WHERE has_word(name, 'timeout')")
+        .await
+        .expect("plan dict case")
+        .create_physical_plan()
+        .await
+        .expect("physical plan");
+    let text = displayable(dict_plan.as_ref()).indent(true).to_string();
+    assert!(
+        !text.contains("CAST"),
+        "has_word over the declared dictionary column must carry no coercing CAST; \
+         plan was:\n{text}"
+    );
+    assert!(
+        text.contains("has_word(name@"),
+        "has_word's first argument must be the bare dictionary column; plan was:\n{text}"
     );
 }

--- a/docs/guides/operations.md
+++ b/docs/guides/operations.md
@@ -474,8 +474,15 @@ The `logs` SQL table exposes every attribute through one merged
 attribute is a `CAST(attrs['k'] AS ...)` over a stringified value. An operator
 *declares* a per-tenant set of attribute keys as native typed columns, appended
 after `attrs` in declaration order, and the same value then reads back as a
-real `Int64`/`Boolean`/`Utf8`/`Binary` Arrow column. A declared key still
-appears in `attrs` as well, so no existing query breaks.
+real `Int64`/`Boolean`/`Dictionary(Int32, Utf8)` (for a `str` column)/`Binary`
+Arrow column. A declared `str` column is dictionary-encoded and stays a
+dictionary over the Flight SQL wire. HTTP JSON row values are unchanged (a
+string per row), but the JSON envelope's declared `columns[].type` reads
+`Dictionary(Int32, Utf8)` rather than `Utf8`, and the Arrow IPC schema and
+batch columns carry the dictionary type verbatim -- both client-visible changes
+from the plain `Utf8` column a consumer must expect. A declared key still
+appears in `attrs` as well, so a `SELECT attrs` or `SELECT *` query keeps
+working.
 
 Two ways to declare, one resolution:
 

--- a/docs/guides/query.md
+++ b/docs/guides/query.md
@@ -318,9 +318,16 @@ semantics).
 
 Beyond those fixed columns, an operator can declare per-tenant *typed
 attribute columns*: an attribute key promoted to a native `Int64`, `Boolean`,
-`Utf8`, or `Binary` column named exactly after the key, so a typed comparison
-or aggregate over it needs no `CAST` over the stringified map. Declared keys
-still appear in `attrs`. A declaration comes from the server's
+`Dictionary(Int32, Utf8)` (for a `str` column), or `Binary` column named
+exactly after the key, so a typed comparison or aggregate over it needs no
+`CAST` over the stringified map. A declared `str` column is dictionary-encoded,
+and stays a dictionary over the Flight SQL wire (it is not hydrated back to
+plain `Utf8`). Over HTTP JSON the row *values* are unchanged (a string per row,
+`null` for an absent or type-mismatched cell), but the response envelope's
+declared `columns[].type` reports `Dictionary(Int32, Utf8)` instead of `Utf8`;
+over Arrow IPC the schema and every batch column carry the dictionary type
+verbatim. Both are client-visible changes from the pre-declaration plain `Utf8`
+column. Declared keys still appear in `attrs`. A declaration comes from the server's
 `--typed-attr-column` flags or from the durable per-tenant override written by
 `ravel-cli typed-attr-column set`, and a query process picks a durable change
 up within 60s. Querying an undeclared column is an unknown-column error, and a

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -1208,8 +1208,23 @@ An operator can declare a per-tenant set of attribute keys as native typed
 columns, appended after `attrs` (schema index 9 onward) in declaration order.
 The column name is the attribute key verbatim, never mangled, so a key
 containing `.` or uppercase characters needs double-quoting in SQL. Four
-declarable types: `str` (`Utf8`), `i64` (`Int64`), `bool` (`Boolean`), and
-`bytes` (`Binary`). `f64` is deferred (a declared float aggregate is
+declarable types: `str` (`Dictionary(Int32, Utf8)`), `i64` (`Int64`), `bool`
+(`Boolean`), and `bytes` (`Binary`). A declared `str` column is
+dictionary-encoded end to end (ADR-0099 decision 5): a dict-encoded RLOG page
+becomes the Arrow dictionary and its ids with no per-row allocation, a plain
+page becomes a degenerate identity dictionary, and the row fallback path builds
+the same dictionary type so every batch validates against the one schema
+DataFusion checks. The public Flight statement stream sets
+`DictionaryHandling::Resend`, so the column stays a dictionary on the wire
+rather than being hydrated back to plain `Utf8`. Over HTTP JSON the row *values*
+are identical to the pre-dictionary form (`output.rs` unwraps the
+`Dictionary(Int32, _)` cell and recurses to a string per row), but the JSON
+envelope's declared `columns[].type` changes from `Utf8` to
+`Dictionary(Int32, Utf8)`, and the Arrow IPC schema and batch columns carry the
+dictionary type verbatim (`to_arrow_ipc` hands the schema and batches to the
+writer unchanged). Both are client-visible: a consumer reading the reported
+column type or the IPC schema must expect the dictionary type. `f64` is deferred
+(a declared float aggregate is
 order-sensitive under ADR-0013/ADR-0022, which #277 decides), and so are date
 and timestamp (they need a lifting rule from `i64` storage plus a declared
 unit); the four shipped types all aggregate exactly under any partitioning.
@@ -1247,6 +1262,19 @@ pages it needs. The practical consequence: moving an equality predicate from
 `attrs['k'] = 'v'` (which prunes blocks through POSTINGS) to a declared
 `k = 'v'` makes it slower until #278 lands. Declare for typed comparisons and
 aggregates, which the map cannot express at all.
+
+There is also a wire-size trade for a *high-cardinality* `str` column. ADR-0099
+decision 5's "leaves that case exactly as expensive as it is today" is a
+statement about CPU, not egress: a plain (all-distinct) page becomes a
+degenerate identity `Dictionary(Int32, Utf8)`, and with `DictionaryHandling::Resend`
+that dictionary is sent as its values *plus* a 4-byte `Int32` key per row, and
+re-emitted for every batch a block larger than the batch size splits into. For a
+column whose values barely repeat, that is larger on the wire than the old plain
+`Utf8` column, which sent each value once with no key. Declaring a
+high-cardinality attribute (a URL, a request id) as `str` is therefore a
+CPU-neutral but egress-heavier choice; it is the low-cardinality case (a status,
+a region) where the dictionary both saves allocation and shrinks the wire. This
+is a known trade, not a regression to fix here.
 
 ### Scan execution: streaming and column projection (ADR-0087)
 

--- a/services/ravel-server/tests/sql_endpoint.rs
+++ b/services/ravel-server/tests/sql_endpoint.rs
@@ -1457,3 +1457,251 @@ async fn an_audit_write_failure_fails_the_query_closed_in_required_mode() {
         "the audit PUT fault must have fired"
     );
 }
+
+/// Reachability for the last task of epic #360: a tenant's declared `Str`
+/// column must arrive as Arrow `Dictionary(Int32, Utf8)` when queried through
+/// the shipping server's real Flight SQL surface, not merely inside ravel-sql.
+///
+/// The assertion is on the WIRE `DataType`, not just the values, on purpose.
+/// Downstream #479 (LIKE pushdown) depends on the dictionary SURVIVING to the
+/// operator so it can match once per distinct value; if the Flight encoder
+/// hydrated the dictionary back to plain `Utf8` in transit (the encoder's
+/// default, which the public statement path overrides with
+/// `DictionaryHandling::Resend`), every value assertion would still pass while
+/// the optimisation silently had nothing to key on.
+///
+/// arrow-flight carries arrow 58 and this crate's `arrow` dev-dependency is the
+/// workspace 59 pin, so the decoded batch's `DataType` is compared by its
+/// `Debug` form rather than a cross-major `==`. The plain-form values are
+/// asserted over the HTTP JSON surface, which renders the same dictionary column
+/// as plain strings.
+#[cfg(feature = "flight-sql")]
+mod flight_wire {
+    use std::net::SocketAddr;
+
+    use arrow_flight::flight_service_client::FlightServiceClient;
+    use arrow_flight::sql::{CommandStatementQuery, ProstMessageExt};
+    use arrow_flight::{FlightData, FlightDescriptor};
+    use futures::TryStreamExt;
+    use prost::Message;
+    use ravel_sql::{DeclaredColumn, DeclaredColumnSource, DeclaredType, StaticDeclaredColumns};
+    use tokio::sync::oneshot;
+    use tonic::Request;
+
+    use super::*;
+
+    /// The tenant's one declared column: a `Str`-typed `name`.
+    fn declared_source() -> Arc<dyn DeclaredColumnSource> {
+        Arc::new(StaticDeclaredColumns::new(vec![DeclaredColumn::new(
+            "name",
+            DeclaredType::Str,
+        )]))
+    }
+
+    /// A `LogRecord` on `service` carrying a record-level `name` attribute, so
+    /// the declared `name` column resolves from the record.
+    fn log_record_named(service: &str, ts: i64, name: &str) -> LogRecord {
+        let mut record = log_record(service, ts, "b");
+        record.attrs = vec![("name".to_string(), AttrValue::Str(name.to_string()))];
+        record
+    }
+
+    /// A [`SqlState`] whose executor resolves the declared `name` column for
+    /// every tenant.
+    fn sql_state_with_declared(
+        store: Arc<dyn ObjectStoreBackend>,
+        tokens: HashMap<String, TenantId>,
+    ) -> SqlState {
+        let catalog =
+            Arc::new(Catalog::new(Arc::clone(&store), CatalogConfig::default()).expect("catalog"));
+        let executor = SqlExecutor::new(
+            catalog,
+            SegmentFetcher::new(store.clone()),
+            LogSegmentFetcher::new(store.clone()),
+            ravel_sql::SpanSegmentFetcher::new(store.clone()),
+            SqlConfig::default(),
+            1 << 30,
+        )
+        .with_declared_column_source(declared_source());
+        SqlState {
+            executor: Arc::new(executor),
+            tenant_resolver: Arc::new(StaticBearerTokenResolver::new(tokens)),
+            store,
+            clock: Arc::new(FixedClock),
+            max_deadline: Duration::from_secs(30),
+            query_accounting: Arc::new(ravel_server::metrics::QueryAccountingMetrics::new(
+                std::collections::HashSet::new(),
+            )),
+            query_admission: ravel_query::QueryAdmissionController::shared(
+                ravel_query::QueryConcurrencyLimit::Unlimited,
+            ),
+            audit_sink: Arc::new(ravel_maintain::NoopQueryAuditSink),
+        }
+    }
+
+    /// A running tonic server carrying only the Flight SQL service, mirroring the
+    /// in-process harness in `flight_sql.rs`.
+    struct FlightServer {
+        addr: SocketAddr,
+        shutdown: oneshot::Sender<()>,
+        task: tokio::task::JoinHandle<()>,
+    }
+
+    impl FlightServer {
+        async fn start(state: &SqlState) -> Self {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+                .await
+                .expect("bind");
+            let addr = listener.local_addr().expect("addr");
+            let (tx, rx) = oneshot::channel::<()>();
+            let ceiling = ravel_server::gc_config::flight_ceiling(
+                &ravel_maintain::GcConfigValues::maintain_defaults(),
+            );
+            let service = ravel_server::flight::service(state, ceiling, None);
+            let task = tokio::spawn(async move {
+                tonic::transport::Server::builder()
+                    .add_service(service)
+                    .serve_with_incoming_shutdown(
+                        tonic::transport::server::TcpIncoming::from(listener),
+                        async {
+                            let _ = rx.await;
+                        },
+                    )
+                    .await
+                    .expect("serve");
+            });
+            FlightServer {
+                addr,
+                shutdown: tx,
+                task,
+            }
+        }
+
+        async fn client(&self) -> FlightServiceClient<tonic::transport::Channel> {
+            let channel = tonic::transport::Channel::from_shared(format!("http://{}", self.addr))
+                .expect("valid endpoint uri")
+                .connect()
+                .await
+                .expect("connect");
+            FlightServiceClient::new(channel)
+        }
+
+        async fn stop(self) {
+            let _ = self.shutdown.send(());
+            let _ = self.task.await;
+        }
+    }
+
+    fn descriptor(command: &impl ProstMessageExt) -> FlightDescriptor {
+        FlightDescriptor::new_cmd(command.as_any().encode_to_vec())
+    }
+
+    fn authed<T>(message: T, token: &str) -> Request<T> {
+        let mut request = Request::new(message);
+        let metadata = request.metadata_mut();
+        metadata.insert(
+            "authorization",
+            format!("Bearer {token}").parse().expect("ascii"),
+        );
+        metadata.insert("x-ravel-start", "0".parse().expect("ascii"));
+        metadata.insert(
+            "x-ravel-end",
+            format!("{}", NOW_NS as f64 / 1e9).parse().expect("ascii"),
+        );
+        request
+    }
+
+    /// Decode a `DoGet` response into its total row count and, per column, the
+    /// name and the `Debug` form of the wire `DataType`.
+    async fn decode_schema(stream: tonic::Streaming<FlightData>) -> (usize, Vec<(String, String)>) {
+        let batches = arrow_flight::decode::FlightRecordBatchStream::new_from_flight_data(
+            stream.map_err(|status| arrow_flight::error::FlightError::Tonic(Box::new(status))),
+        )
+        .try_collect::<Vec<_>>()
+        .await
+        .expect("decode flight data");
+        let rows = batches.iter().map(|batch| batch.num_rows()).sum();
+        let columns = batches
+            .first()
+            .map(|batch| {
+                batch
+                    .schema()
+                    .fields()
+                    .iter()
+                    .map(|field| (field.name().clone(), format!("{:?}", field.data_type())))
+                    .collect()
+            })
+            .unwrap_or_default();
+        (rows, columns)
+    }
+
+    #[tokio::test]
+    async fn a_declared_str_column_arrives_dictionary_encoded_over_flight() {
+        let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+        let tenant = TenantId::new("acme".to_string());
+        let records = vec![
+            log_record_named("api", 100, "alpha"),
+            log_record_named("worker", 150, "beta"),
+            log_record_named("api", 200, "alpha"),
+        ];
+        publish_log_segment(store.as_ref(), &tenant, 0, &records).await;
+
+        // Flight SQL surface: the declared `name` column must arrive as a
+        // dictionary on the wire, proving the public statement path's
+        // DictionaryHandling::Resend keeps it from being hydrated in transit.
+        let state = sql_state_with_declared(Arc::clone(&store), tokens(&[("acme-token", "acme")]));
+        let server = FlightServer::start(&state).await;
+        let mut client = server.client().await;
+        let command = CommandStatementQuery {
+            query: "SELECT \"name\" FROM logs ORDER BY ts".to_string(),
+            transaction_id: None,
+        };
+        let info = client
+            .get_flight_info(authed(descriptor(&command), "acme-token"))
+            .await
+            .expect("flight info")
+            .into_inner();
+        let ticket = info
+            .endpoint
+            .first()
+            .expect("one endpoint")
+            .ticket
+            .clone()
+            .expect("a ticket");
+        let stream = client
+            .do_get(authed(ticket, "acme-token"))
+            .await
+            .expect("do get")
+            .into_inner();
+        let (rows, columns) = decode_schema(stream).await;
+        server.stop().await;
+
+        assert_eq!(rows, records.len(), "every published row comes back");
+        assert_eq!(columns.len(), 1, "one projected column: name");
+        assert_eq!(columns[0].0, "name");
+        assert_eq!(
+            columns[0].1, "Dictionary(Int32, Utf8)",
+            "a declared Str column must survive the Flight wire as a dictionary, \
+             not be hydrated back to plain Utf8"
+        );
+
+        // The same column over HTTP JSON renders the plain-form string values,
+        // so the dictionary wire type carries exactly the plain values.
+        let http_state = sql_state_with_declared(store, tokens(&[("acme-token", "acme")]));
+        let app = router(http_state);
+        let (status, value) =
+            post_json(&app, "acme-token", "SELECT \"name\" FROM logs ORDER BY ts").await;
+        assert_eq!(status, StatusCode::OK, "{value}");
+        let json_rows = value["data"]["rows"].as_array().expect("rows");
+        let got: Vec<Value> = json_rows.iter().map(|r| r[0].clone()).collect();
+        assert_eq!(
+            got,
+            vec![
+                serde_json::json!("alpha"),
+                serde_json::json!("beta"),
+                serde_json::json!("alpha"),
+            ],
+            "the dictionary column's values equal the plain string form"
+        );
+    }
+}


### PR DESCRIPTION
A declared Str attribute column was projected as a plain Utf8 array, so a
low-cardinality column with a thousand distinct values across millions of
rows was materialized per row and re-hashed by every downstream group-by,
even though the RLOG page underneath already stored it as a dictionary
plus a bit-packed id per row.

Declared Str columns are now Dictionary(Int32, Utf8). A dictionary-encoded
page contributes its distinct values and reuses its ids as Arrow keys with
no per-row allocation; a plain page gets a degenerate identity dictionary,
which costs no hashing and no dedup pass and leaves that case exactly as
expensive as it was.

Both scan paths build dictionary arrays, not just the columnar one.
DataFusion validates every batch against one schema, so a row-path
fallback batch emitting a plain Utf8 array would fail at runtime rather
than in a test. Fallbacks happen whenever erasure is pending, attrs is
projected, or a block carries an attrs_raw page.

The public Flight statement path now resends dictionaries instead of
hydrating them, matching what the internal worker path already did.
Without that the encoder expands the dictionary back to per-row values on
the wire and the win stops at the operator boundary. The reachability test
drives the real server's Flight SQL surface and asserts the received Arrow
type, not just the values, because a hydrating encoder passes every value
comparison while leaving a consumer nothing to key on.

has_word gained a dictionary arm: it matches once per distinct dictionary
value and gathers by key, rather than once per row. body and severity_text
are fixed columns, stay Utf8, and keep the original path.

Declared-column semantics are unchanged. A wrong attribute variant or an
absent key still yields NULL and never a cast, invalid UTF-8 still means
the attribute is absent so a resource or scope value shows through, and
declared keys remain stringified inside the attrs map. HTTP JSON output is
unchanged, including for a null key and a null dictionary value.

The declared-type mapping stays a match on the declared type, so ADR-0101's
f64 lands as one new arm projecting Float64 rather than forcing a redesign.

Fixes: #417
Refs: #360

---

Gates: the full list ran locally and clean on this exact tree, including
both feature lanes (`sql` and `flight-sql`), which are the ones that
compile the affected call sites.

Three adversarial review passes ran against this work before it was
proposed. The first found the Flight wire form correct but `has_word`'s
dictionary arm unreachable behind an exact UDF signature, plus a false
client-facing doc claim. The second found the signature fix had
over-corrected and turned `has_word(CAST(x AS VARCHAR), ...)` into a
planning error, and that the new non-UTF-8 dictionary test could not
fail. The third rebuilt the probe matrix independently, proved it
non-vacuous by running it against the broken intermediate commit (15 of
24 cases regressed there), and confirmed all 24 behave identically before
and after.
