### PR TITLE
docs: close out epic #360's doc currency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -279,6 +279,14 @@ as a precondition, not after the damage.
   its OWN `cargo`/`rustc` below a floor of about 8 GB. Killing your build
   costs a retry; letting the volume reach zero stops every Bash command
   in every session on the host, including the ones that would clean up.
+- This host is itself a fleet executor. `~/.fleet/executor` holds the
+  cargo target of whatever task it has claimed from the queue, which no
+  session here chose and which grows without warning; it has been observed
+  at 46 GB. So "no other session is building" does not mean the volume is
+  idle, and a gate failure is not evidence about the crates you scoped.
+  Measure before concluding: a `-p ravel-sql -p ravel-server` gate with
+  both feature lanes, the largest in the workspace, completes in 56 GB on
+  a quiet volume. Earlier failures of that same lane were contention.
 - A cold gate needs 54-70 GB of `target/` per worktree, so this machine
   runs ONE at a time regardless of how many sessions are otherwise idle.
   Two sessions gating concurrently is the expected failure, not bad luck:

--- a/README.md
+++ b/README.md
@@ -60,8 +60,12 @@ Also live:
 - Per-tenant typed attribute columns on the `logs` SQL table: an operator
   declares an attribute key (`ravel-cli typed-attr-column set acme
   http.duration_ms:i64`, or the `--typed-attr-column` server flags) and it
-  becomes a native `Int64`/`Boolean`/`Utf8`/`Binary` column, so typed
-  comparisons and aggregates need no `CAST` over the stringified `attrs` map.
+  becomes a native `Int64`/`Boolean`/`Binary` column, or
+  `Dictionary(Int32, Utf8)` for a declared string, so typed comparisons and
+  aggregates need no `CAST` over the stringified `attrs` map. A declared
+  string column keeps its dictionary encoding through Flight SQL and Arrow
+  IPC rather than being expanded per row; JSON row values are unchanged, but
+  the JSON envelope reports the dictionary type.
 
 Not there yet:
 


### PR DESCRIPTION
Two doc corrections from epic #360 (columnar decode-to-Arrow), both facts learned during the epic rather than planned work.

README's capability list still described a declared string attribute column as a plain `Utf8` column. It projects as `Dictionary(Int32, Utf8)` and keeps that encoding through Flight SQL and Arrow IPC.

CLAUDE.md gains the fact that this host claims fleet tasks itself, so a gate that dies on disk here is not evidence about the crates it scoped. Two failures were attributed to `ravel-sql` on that reasoning; measured on a quiet volume the largest lane in the workspace completes in 56 GB, so those were contention from a source no session could see.

Refs: #360