### PR TITLE
feat(ravel-ingest): add feature-gated per-stage timing seam for logs

### DIFF
--- a/crates/ravel-ingest/Cargo.toml
+++ b/crates/ravel-ingest/Cargo.toml
@@ -5,6 +5,14 @@ edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
 
+[features]
+# Per-stage ingest timing seam (ADR-0104 decision 1). Off by default: with it
+# off the crate compiles and behaves exactly as today, so no shipping build
+# links the seam. On, it compiles in the `Instant`-based accumulator and wires
+# the logs pipeline's admit/route/merge/encode boundaries through it, read only
+# by the bench reporter. A CI lane must build and run this feature.
+stage-timing = []
+
 [dependencies]
 ravel-types = { workspace = true }
 ravel-segment = { workspace = true }

--- a/crates/ravel-ingest/src/clock.rs
+++ b/crates/ravel-ingest/src/clock.rs
@@ -3,6 +3,17 @@
 //! Actor logic must never read `SystemTime`/`Instant::now()` directly; every
 //! clock read goes through this trait so tests can pin, replay, and advance
 //! time across retries and hour boundaries.
+//!
+//! One bounded exception (ADR-0104 decision 1): the `stage-timing` cargo
+//! feature, off by default, compiles in a profiling seam (`crate::stage_timing`)
+//! that reads `Instant::now()` at stage boundaries to measure per-stage
+//! durations. It is sound only because it never ships (off by default, so every
+//! production and default-gate build is exactly as today), uses monotonic
+//! `Instant` rather than this wall-clock, and its accumulated timings feed no
+//! decision -- no control flow, flush trigger, flush identity, or backpressure
+//! choice reads a stage timing, only the bench reporter does. Extending the
+//! seam must preserve that no-decision-reads-a-timing property, or the
+//! exception stops being defensible.
 
 use std::future::Future;
 use std::pin::Pin;

--- a/crates/ravel-ingest/src/lib.rs
+++ b/crates/ravel-ingest/src/lib.rs
@@ -28,6 +28,7 @@ mod span_error;
 mod span_metrics;
 mod span_router;
 mod span_shard;
+mod stage_timing;
 mod value;
 
 pub use admission::{
@@ -67,4 +68,6 @@ pub use router::{IngestRouter, WriteMode, WriteReceipt};
 pub use span_error::SpanWriteError;
 pub use span_metrics::{SpanIngestMetrics, SpanIngestMetricsSnapshot};
 pub use span_router::{SpanIngestRouter, SpanWriteReceipt, shard_for_span};
+#[cfg(feature = "stage-timing")]
+pub use stage_timing::{LogStage, LogStageSnapshot, LogStageTimings, StageTotals};
 pub use value::{IngestExemplar, IngestPoint, IngestValue};

--- a/crates/ravel-ingest/src/log_router.rs
+++ b/crates/ravel-ingest/src/log_router.rs
@@ -26,6 +26,8 @@ use crate::log_error::LogWriteError;
 use crate::log_metrics::LogIngestMetrics;
 use crate::log_shard::{LogShardActor, LogShardMsg, est_record_bytes};
 use crate::router::WriteMode;
+#[cfg(feature = "stage-timing")]
+use crate::stage_timing::{LogStage, LogStageTimings};
 
 /// Resolves the POSTINGS indexed-field list for a tenant at flush time
 /// (ADR-0049 decision 3). The shard actor calls this once per
@@ -92,6 +94,13 @@ pub struct LogIngestRouter {
     /// `services/ravel-server` installs the configured budget via
     /// [`LogIngestRouter::with_budget`].
     budget: Arc<IngestByteBudget>,
+    /// Per-stage timing accumulator (ADR-0104 decision 1), shared by `Arc` with
+    /// every shard actor and flush task so the seam records into one table the
+    /// bench reporter reads via [`LogIngestRouter::stage_timings`]. Present only
+    /// under the `stage-timing` feature; with it off this field, and every
+    /// timing site, is compiled out.
+    #[cfg(feature = "stage-timing")]
+    stage_timings: Arc<LogStageTimings>,
 }
 
 impl LogIngestRouter {
@@ -130,12 +139,16 @@ impl LogIngestRouter {
         // routing every draw through the seam still keeps `rand::rng()` and
         // `Uuid::new_v4()` off this production path.
         let rng: Arc<dyn RngSource> = Arc::new(SystemRng);
+        #[cfg(feature = "stage-timing")]
+        let stage_timings = Arc::new(LogStageTimings::new());
         let factory = {
             let store = Arc::clone(&store);
             let clock = Arc::clone(&clock);
             let rng = Arc::clone(&rng);
             let metrics = Arc::clone(&metrics);
             let indexed_fields = Arc::clone(&indexed_fields);
+            #[cfg(feature = "stage-timing")]
+            let stage_timings = Arc::clone(&stage_timings);
             move |shard_count: u32| -> Vec<LogShardHandle> {
                 let writer_id = rng.new_uuid();
                 let epoch =
@@ -154,6 +167,8 @@ impl LogIngestRouter {
                             Arc::clone(&metrics),
                             rx,
                             Arc::clone(&indexed_fields),
+                            #[cfg(feature = "stage-timing")]
+                            Arc::clone(&stage_timings),
                         );
                         tokio::spawn(actor.run());
                         LogShardHandle {
@@ -175,7 +190,17 @@ impl LogIngestRouter {
             indexed_fields,
             config,
             budget: IngestByteBudget::shared(IngestByteBudgetLimit::Unlimited),
+            #[cfg(feature = "stage-timing")]
+            stage_timings,
         }
+    }
+
+    /// The per-stage timing accumulator (ADR-0104 decision 1), for the bench
+    /// reporter to read a snapshot after driving a write. Present only under the
+    /// `stage-timing` feature.
+    #[cfg(feature = "stage-timing")]
+    pub fn stage_timings(&self) -> Arc<LogStageTimings> {
+        Arc::clone(&self.stage_timings)
     }
 
     /// Installs the shared process-wide ingest buffer byte budget (ADR-0069).
@@ -282,6 +307,8 @@ impl LogIngestRouter {
         // cloned into every shard message below and refunded when the flush(es)
         // holding these bytes complete or fail; any early return from here on
         // drops the not-yet-handed-off clones, so nothing leaks.
+        #[cfg(feature = "stage-timing")]
+        let admit_start = std::time::Instant::now();
         let estimate: u64 = records
             .iter()
             .map(|r| est_record_bytes(r) as u64)
@@ -291,10 +318,15 @@ impl LogIngestRouter {
                 .try_charge(estimate)
                 .map_err(|_| LogWriteError::BufferBudgetExceeded)?,
         );
+        #[cfg(feature = "stage-timing")]
+        self.stage_timings
+            .record(LogStage::Admit, admit_start.elapsed());
 
         // Route against the tenant's current generation view, re-reading the
         // provisioning record when the cache is older than `C` and failing
         // closed if that read cannot complete (ADR-0052 section 3).
+        #[cfg(feature = "stage-timing")]
+        let route_start = std::time::Instant::now();
         let set = self.active_set(tenant.hash(), self.clock.now_ns()).await?;
         let shard_count = set.len() as u32;
         let mut by_shard: HashMap<u32, Vec<NormalizedLogRecord>> = HashMap::new();
@@ -340,6 +372,11 @@ impl LogIngestRouter {
                 return Err(LogWriteError::ShardUnavailable);
             }
         }
+        // Routing ends at dispatch: the strict-mode ack wait below is downstream
+        // durability (merge/encode/PUT happen in the shard), not a router stage.
+        #[cfg(feature = "stage-timing")]
+        self.stage_timings
+            .record(LogStage::Route, route_start.elapsed());
 
         if mode == WriteMode::Buffered {
             return Ok(LogWriteReceipt::default());

--- a/crates/ravel-ingest/src/log_shard.rs
+++ b/crates/ravel-ingest/src/log_shard.rs
@@ -57,6 +57,8 @@ use crate::config::{IngestConfig, LOG_SEGMENT_FORMAT_VERSION, checked_ingest_hou
 use crate::log_error::LogWriteError;
 use crate::log_metrics::LogIngestMetrics;
 use crate::metrics::FlushTrigger;
+#[cfg(feature = "stage-timing")]
+use crate::stage_timing::{LogStage, LogStageTimings};
 
 pub(crate) type LogAck = oneshot::Sender<Result<CommitToken, LogWriteError>>;
 
@@ -213,6 +215,12 @@ struct LogFlushCtx {
     /// (ADR-0079). Shared across shards by `Arc`; its per-tenant cache is the
     /// one place a tenant's `TenantConfig.indexed_fields` override is read.
     indexed_fields: Arc<IndexedFieldsOverlay>,
+    /// Per-stage timing accumulator (ADR-0104 decision 1), shared by `Arc` with
+    /// the router and every shard. The flush task records `encode` here; the
+    /// actor reaches it through `self.ctx` to record `merge`. Present only under
+    /// the `stage-timing` feature.
+    #[cfg(feature = "stage-timing")]
+    stage_timings: Arc<LogStageTimings>,
 }
 
 /// One log flush's identity and payload, pinned by the actor before the flush
@@ -316,6 +324,10 @@ impl LogFlushCtx {
                 outcome.into_fields()
             }
         };
+        // Encode: RLOG serialization only (RlogWriter push + finish), excluding
+        // the indexed-field resolution above and the object-store PUT below.
+        #[cfg(feature = "stage-timing")]
+        let encode_start = std::time::Instant::now();
         let mut writer =
             RlogWriter::new(RlogConfig::default(), identity).with_indexed_fields(indexed_fields);
         for rec in records {
@@ -343,6 +355,9 @@ impl LogFlushCtx {
                 return;
             }
         };
+        #[cfg(feature = "stage-timing")]
+        self.stage_timings
+            .record(LogStage::Encode, encode_start.elapsed());
 
         let content_hash: [u8; 32] = *blake3::hash(&bytes).as_bytes();
         let data = Bytes::from(bytes);
@@ -621,6 +636,7 @@ impl LogShardActor {
         metrics: Arc<LogIngestMetrics>,
         rx: mpsc::Receiver<LogShardMsg>,
         indexed_fields: Arc<IndexedFieldsOverlay>,
+        #[cfg(feature = "stage-timing")] stage_timings: Arc<LogStageTimings>,
     ) -> Self {
         let ctx = Arc::new(LogFlushCtx {
             shard,
@@ -632,6 +648,8 @@ impl LogShardActor {
             config,
             metrics: Arc::clone(&metrics),
             indexed_fields,
+            #[cfg(feature = "stage-timing")]
+            stage_timings,
         });
         LogShardActor {
             shard,
@@ -724,8 +742,16 @@ impl LogShardActor {
         let records_len = records.len() as u64;
         let target_bytes = self.config.target_bytes;
 
+        // Grab the timing handle before the mutable buffer borrow so recording
+        // `merge` does not clash with the `&mut self.tenants` borrow held below.
+        #[cfg(feature = "stage-timing")]
+        let merge_timings = Arc::clone(&self.ctx.stage_timings);
         let buf = self.tenants.entry(tenant.clone()).or_default();
+        #[cfg(feature = "stage-timing")]
+        let merge_start = std::time::Instant::now();
         let bytes_added = buf.merge(records, arrival_ns);
+        #[cfg(feature = "stage-timing")]
+        merge_timings.record(LogStage::Merge, merge_start.elapsed());
         // The records are now buffered: hold their budget charge with the buffer
         // until it flushes (ADR-0069).
         if let Some(charge) = charge {
@@ -1048,6 +1074,8 @@ mod tests {
                 Arc::new(IndexedFieldsOverlay::new(Arc::new(
                     crate::log_router::NoIndexedFields,
                 ))),
+                #[cfg(feature = "stage-timing")]
+                Arc::new(LogStageTimings::new()),
             );
             let task = tokio::spawn(actor.run());
             Harness {
@@ -1697,6 +1725,8 @@ mod tests {
             Arc::new(IndexedFieldsOverlay::new(Arc::new(
                 crate::log_router::NoIndexedFields,
             ))),
+            #[cfg(feature = "stage-timing")]
+            Arc::new(LogStageTimings::new()),
         );
         let task = tokio::spawn(actor.run());
 

--- a/crates/ravel-ingest/src/stage_timing.rs
+++ b/crates/ravel-ingest/src/stage_timing.rs
@@ -1,0 +1,349 @@
+//! Feature-gated per-stage timing seam for the logs ingest pipeline (ADR-0104
+//! decision 1). Compiled only under the `stage-timing` cargo feature, which is
+//! off by default, so the shipping actor is byte-for-byte what it is today and
+//! the `clock.rs` prohibition on reading time outside the injected `Clock` is
+//! not weakened for any build that ships.
+//!
+//! Stage boundaries read `Instant::now()`, never the injected [`crate::Clock`].
+//! ADR-0104 decision 1 rejects the `Clock` explicitly: `Clock::now_ns()` is
+//! wall-clock, so a clock step could make a stage duration negative or jumped;
+//! and a deterministic test clock returns pinned values, so every stage
+//! duration measured through it would be zero under exactly the tests that
+//! verify the instrumentation. `Instant` is monotonic and independent of the
+//! injected clock, so a pinned test clock does not zero these measurements.
+//!
+//! The accumulated values are read ONLY by the bench reporter (next wave). No
+//! control-flow, flush trigger, flush identity, or backpressure choice reads a
+//! stage timing. That property is what keeps ADR-0104's `clock.rs` exception
+//! sound; if it ever breaks, the exception stops being defensible.
+//!
+//! The stages here are verified against `log_router.rs` / `log_shard.rs` and
+//! the RLOG flush, not transplanted from the metrics pipeline: merge and encode
+//! are `RlogWriter` code in this pipeline, not `SegmentWriter`.
+
+#[cfg(feature = "stage-timing")]
+mod imp {
+    use std::collections::BTreeMap;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::Duration;
+
+    /// A wired stage of the logs ingest pipeline (ADR-0104 decision 2, logs
+    /// row). Ordering here fixes the natural pipeline order used by
+    /// [`LogStageSnapshot`]'s `BTreeMap`.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    pub enum LogStage {
+        /// Router-side admission gate: the ADR-0069 process-wide ingest byte
+        /// budget charge in [`crate::LogIngestRouter::write`]
+        /// (`est_record_bytes` + `IngestByteBudget::try_charge`).
+        ///
+        /// This is NOT the per-tenant [`crate::AdmissionController`] (ADR-0089):
+        /// that controller runs in the server, upstream of this router, and the
+        /// bulk-load path bypasses it by construction (surfaced to operators as
+        /// `ADMISSION_BYPASS_WARNING`). It is never invoked inside `write`, so
+        /// no `AdmissionController` cost is folded into this figure for either
+        /// OTLP ingest or `load --parquet`. The number is the router's own
+        /// byte-budget admission only, which runs for both paths.
+        Admit,
+        /// Router generation resolution + shard grouping + dispatch: the
+        /// `active_set` re-read, the `shard_for_log` grouping, and the
+        /// per-shard channel sends in [`crate::LogIngestRouter::write`]. It does
+        /// not include the strict-mode ack wait, which is downstream durability,
+        /// not routing.
+        Route,
+        /// Shard-actor buffer append: `LogTenantBuf::merge` in the log shard
+        /// actor's write handler. The log analogue of the metrics merge, but a
+        /// plain append here (the stream-identity collision check is deferred to
+        /// `RlogWriter::finish`), so it is genuinely different code.
+        Merge,
+        /// Flush-task RLOG serialization: the `RlogWriter::push` loop plus
+        /// `finish_with_stats` in the spawned flush. `RlogWriter`, not
+        /// `SegmentWriter`; it excludes the object-store PUT, which decision 5
+        /// measures separately.
+        Encode,
+    }
+
+    impl LogStage {
+        /// Stable lowercase name for reporting.
+        pub fn name(self) -> &'static str {
+            match self {
+                LogStage::Admit => "admit",
+                LogStage::Route => "route",
+                LogStage::Merge => "merge",
+                LogStage::Encode => "encode",
+            }
+        }
+    }
+
+    /// Accumulated samples and nanoseconds for one stage.
+    #[derive(Debug, Default)]
+    struct StageCell {
+        samples: AtomicU64,
+        total_ns: AtomicU64,
+    }
+
+    /// A read-only view of one stage's accumulated totals at snapshot time.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct StageTotals {
+        /// How many times the stage recorded a duration.
+        pub samples: u64,
+        /// Sum of every recorded duration, in nanoseconds.
+        pub total_ns: u64,
+    }
+
+    /// Per-stage nanosecond accumulator for the logs pipeline, shared by `Arc`
+    /// from [`crate::LogIngestRouter`] to every log shard actor and flush task.
+    /// Every method is lock-free; the atomics use `Relaxed` because the only
+    /// cross-task read (a caller taking a [`Self::snapshot`] after a write's ack
+    /// resolves) is ordered by the oneshot ack channel, not by these atomics.
+    #[derive(Debug, Default)]
+    pub struct LogStageTimings {
+        admit: StageCell,
+        route: StageCell,
+        merge: StageCell,
+        encode: StageCell,
+    }
+
+    impl LogStageTimings {
+        pub fn new() -> Self {
+            Self::default()
+        }
+
+        fn cell(&self, stage: LogStage) -> &StageCell {
+            match stage {
+                LogStage::Admit => &self.admit,
+                LogStage::Route => &self.route,
+                LogStage::Merge => &self.merge,
+                LogStage::Encode => &self.encode,
+            }
+        }
+
+        /// Adds one sample of `dur` to `stage`. Called at stage boundaries with a
+        /// duration measured by [`std::time::Instant`].
+        pub fn record(&self, stage: LogStage, dur: Duration) {
+            let cell = self.cell(stage);
+            cell.samples.fetch_add(1, Ordering::Relaxed);
+            let ns = u64::try_from(dur.as_nanos()).unwrap_or(u64::MAX);
+            cell.total_ns.fetch_add(ns, Ordering::Relaxed);
+        }
+
+        /// A point-in-time view holding one entry per stage that recorded at
+        /// least one sample. A stage that was never wired (or never reached) is
+        /// absent, not present-with-zero: that is what lets a caller assert the
+        /// wired stage set exactly rather than only that the map is non-empty.
+        pub fn snapshot(&self) -> LogStageSnapshot {
+            let mut entries = BTreeMap::new();
+            for stage in [
+                LogStage::Admit,
+                LogStage::Route,
+                LogStage::Merge,
+                LogStage::Encode,
+            ] {
+                let cell = self.cell(stage);
+                let samples = cell.samples.load(Ordering::Relaxed);
+                if samples > 0 {
+                    entries.insert(
+                        stage,
+                        StageTotals {
+                            samples,
+                            total_ns: cell.total_ns.load(Ordering::Relaxed),
+                        },
+                    );
+                }
+            }
+            LogStageSnapshot { entries }
+        }
+    }
+
+    /// An immutable snapshot of the per-stage totals, for the bench reporter.
+    #[derive(Debug, Clone, Default)]
+    pub struct LogStageSnapshot {
+        entries: BTreeMap<LogStage, StageTotals>,
+    }
+
+    impl LogStageSnapshot {
+        /// Every stage that recorded at least one sample, in pipeline order.
+        pub fn stages(&self) -> impl Iterator<Item = LogStage> + '_ {
+            self.entries.keys().copied()
+        }
+
+        /// Totals for `stage`, or `None` if it recorded nothing.
+        pub fn get(&self, stage: LogStage) -> Option<StageTotals> {
+            self.entries.get(&stage).copied()
+        }
+
+        /// Accumulated nanoseconds for `stage`, or `None` if it recorded
+        /// nothing.
+        pub fn total_ns(&self, stage: LogStage) -> Option<u64> {
+            self.entries.get(&stage).map(|t| t.total_ns)
+        }
+
+        pub fn len(&self) -> usize {
+            self.entries.len()
+        }
+
+        pub fn is_empty(&self) -> bool {
+            self.entries.is_empty()
+        }
+    }
+}
+
+#[cfg(feature = "stage-timing")]
+pub use imp::{LogStage, LogStageSnapshot, LogStageTimings, StageTotals};
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use ravel_logseg::stream_attrs_bytes;
+    use ravel_object_store::ObjectStoreBackend;
+    use ravel_object_store::memory::MemoryStore;
+    use ravel_otlp::logs_normalize::NormalizedLogRecord;
+    use ravel_types::TenantId;
+    use ravel_types::logstream::{AttrValue, log_stream_id};
+
+    use crate::clock::SystemClock;
+    use crate::config::IngestConfig;
+    use crate::log_router::LogIngestRouter;
+    use crate::router::WriteMode;
+
+    /// Flushes on the first record (`target_bytes: 1`) and never on age, so a
+    /// single strict write drives one complete flush inline and the strict ack
+    /// only resolves once the commit publishes (after encode).
+    fn flush_on_first() -> IngestConfig {
+        IngestConfig {
+            shard_count: 1,
+            target_bytes: 1,
+            max_flush_delay: Duration::from_secs(3600),
+            flush_tick: Duration::from_millis(10),
+            put_retry_base_delay: Duration::from_millis(1),
+            put_retry_max_delay: Duration::from_millis(5),
+            ..IngestConfig::default()
+        }
+    }
+
+    /// A consistently-built record: `stream_id` and `stream_attrs` derived from
+    /// the same inputs, so `RlogWriter::finish`'s collision check passes.
+    fn norm_record(service: &str, ts_ns: i64, body: &str) -> NormalizedLogRecord {
+        let res: Vec<(String, AttrValue)> = vec![(
+            "service.name".to_string(),
+            AttrValue::Str(service.to_string()),
+        )];
+        let scope_attrs: Vec<(String, AttrValue)> = Vec::new();
+        let stream_id = log_stream_id(&res, "scope", "", &scope_attrs);
+        let stream_attrs = stream_attrs_bytes(&res, "scope", "", &scope_attrs);
+        NormalizedLogRecord {
+            stream_id,
+            stream_attrs,
+            ts_ns,
+            observed_ts_ns: ts_ns,
+            severity_num: 9,
+            severity_text: "INFO".to_string(),
+            body: body.to_string(),
+            trace_id: None,
+            span_id: None,
+            flags: 0,
+            attrs: Vec::new(),
+        }
+    }
+
+    fn test_router(store: Arc<dyn ObjectStoreBackend>) -> LogIngestRouter {
+        LogIngestRouter::new(flush_on_first(), store, Arc::new(SystemClock))
+    }
+
+    /// Drives a real logs write through the router to a flush and asserts the
+    /// wired stage set is EXACTLY {admit, route, merge, encode} -- no missing
+    /// stage, no extra one -- and every stage recorded a nonzero duration.
+    ///
+    /// The set is pinned exactly on purpose: a "the map is non-empty" assertion
+    /// would still pass with three of the four stages silently unwired, which is
+    /// the failure this test exists to catch (ADR-0104 decision 2 wires four
+    /// logs stages).
+    #[cfg(feature = "stage-timing")]
+    #[tokio::test]
+    async fn logs_pipeline_records_every_wired_stage() {
+        use super::LogStage;
+
+        let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+        let router = test_router(Arc::clone(&store));
+        let timings = router.stage_timings();
+
+        // A strict write blocks until the commit publishes, so on return every
+        // wired stage -- admit/route on the router, merge/encode in the shard --
+        // has already recorded.
+        let receipt = router
+            .write(
+                TenantId::new("acme"),
+                vec![
+                    norm_record("api", 1_000, "first"),
+                    norm_record("api", 2_000, "second"),
+                ],
+                WriteMode::Strict,
+                Duration::from_secs(30),
+            )
+            .await
+            .expect("a strict logs write commits");
+        assert_eq!(receipt.tokens.len(), 1, "one shard, one flushed object");
+
+        let snap = timings.snapshot();
+
+        // The stage set is EXACTLY the wired set. Both directions: every wired
+        // stage present, and nothing else.
+        let wired = [
+            LogStage::Admit,
+            LogStage::Route,
+            LogStage::Merge,
+            LogStage::Encode,
+        ];
+        let recorded: Vec<LogStage> = snap.stages().collect();
+        assert_eq!(
+            recorded,
+            wired.to_vec(),
+            "recorded stage set must be exactly the four wired logs stages, got {:?}",
+            recorded.iter().map(|s| s.name()).collect::<Vec<_>>(),
+        );
+
+        // Every wired stage has a NONZERO duration.
+        for stage in wired {
+            let ns = snap
+                .total_ns(stage)
+                .unwrap_or_else(|| panic!("stage {} is unwired: no sample recorded", stage.name()));
+            assert!(
+                ns > 0,
+                "stage {} recorded a zero duration; it is not measuring real work",
+                stage.name()
+            );
+        }
+
+        router.shutdown().await;
+    }
+
+    /// With the feature off, the seam does not exist and the logs write path
+    /// runs exactly as it does today: a strict write still drives a flush and
+    /// commits. Proves feature-off behavior is unchanged (the router exposes no
+    /// `stage_timings` accessor here, so this test cannot reference the seam).
+    #[cfg(not(feature = "stage-timing"))]
+    #[tokio::test]
+    async fn feature_off_logs_write_still_commits() {
+        let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+        let router = test_router(Arc::clone(&store));
+
+        let receipt = router
+            .write(
+                TenantId::new("acme"),
+                vec![norm_record("api", 1_000, "only")],
+                WriteMode::Strict,
+                Duration::from_secs(30),
+            )
+            .await
+            .expect("a strict logs write commits with the feature off");
+        assert_eq!(
+            receipt.tokens.len(),
+            1,
+            "one shard, one flushed object, feature-off path intact"
+        );
+
+        router.shutdown().await;
+    }
+}

--- a/docs/adrs/0104-ingest-profiling-and-baselines.md
+++ b/docs/adrs/0104-ingest-profiling-and-baselines.md
@@ -126,12 +126,28 @@ Decode and normalize need no seam: the bench drives them and can time them
 directly. Only `admit`, `route`, `merge` and `encode` need instrumentation,
 which keeps the seam's surface small.
 
-**Caveat on `admit`, and it matters for the load-time question
-specifically:** the bulk-load path bypasses the per-tenant
-`AdmissionController` by construction (ADR-0089, surfaced to operators as
-`ADMISSION_BYPASS_WARNING`). So an `admit` figure describes OTLP ingest, not
-`load --parquet`. A stage breakdown that reported a nonzero admit cost for a
-bulk load would be measuring something that does not happen.
+**Caveat on `admit` — CORRECTED after T1 (#504) measured it.** The original
+text here said the bulk-load path bypasses the per-tenant
+`AdmissionController` (ADR-0089, `ADMISSION_BYPASS_WARNING`), and therefore
+that an `admit` figure describes OTLP ingest but not `load --parquet`. That
+was wrong, and the error was in the premise rather than the conclusion.
+
+`AdmissionController` is never invoked inside `LogIngestRouter::write` at
+all. It is constructed and applied in the server, upstream of
+`crates/ravel-ingest` — `services/ravel-server/src/otap_grpc.rs:467` and
+`services/ravel-server/src/exemplars.rs:2035`. `log_router.rs` references it
+only in a test comment.
+
+So the `admit` stage measures the router's own ADR-0069 byte-budget
+admission (`est_record_bytes` folded, then `IngestByteBudget::try_charge`),
+which runs for **both** OTLP and `load --parquet`. The figure is comparable
+across both paths, which is more useful than the ADR originally claimed, and
+no `AdmissionController` cost is folded into it on either path.
+
+One real property of the boundary, worth stating because it shapes how the
+number reads: on a budget shed the `?` returns before the `record` call, so a
+shed request contributes **no** admit sample. The stage therefore measures
+the cost of admissions that succeeded, not the cost of deciding.
 
 `encode` deserves its own number rather than being folded into the flush,
 because #368 hypothesises that segment encoding on the tokio worker pool is


### PR DESCRIPTION
Wave 1 of epic #365, per ADR-0104 decisions 1 and 2. Adds a `stage-timing` feature to `crates/ravel-ingest` (off by default) and wires the **logs** pipeline's admit, route, merge and encode boundaries through it.

Logs first because ClickBench load time goes through `LogIngestRouter`. Every citation in #365 is metrics-side; those land next wave (#505), and this change deliberately does not touch `router.rs`, `shard.rs`, or `SegmentWriter`.

**Stage timing does not use the injected `Clock`.** ADR-0104 rejects it: `Clock::now_ns()` is wall-clock, so durations are exposed to clock steps — and decisively, a pinned test clock returns pinned values, making every measured stage *zero* under exactly the tests that would verify the instrumentation. `Instant::now()` instead, at five sites. `clock.rs` records the bounded exception.

The property that keeps that exception sound: **no decision reads a stage timing.** `record()` is write-only; the accumulator is read only through `snapshot()`, exposed via `LogIngestRouter::stage_timings()` for next wave's reporter. No control flow, flush trigger, flush identity, or backpressure choice touches it.

## Verified, not taken on report

Both feature lanes exit 0 with 168 lib tests either way; every seam line is symmetrically cfg-gated, so the shipping path is main plus one `cfg(not)`-gated test.

**Mutation proof.** Rather than re-running the executor's (a commented-out `record()` call), I misattributed one — relabelled `LogStage::Route` as `Admit`, leaving all four calls present and compiling. The acceptance test still failed and named the gap:

```
recorded stage set must be exactly the four wired logs stages, got ["admit", "merge", "encode"]
  left: [Admit, Merge, Encode]
 right: [Admit, Route, Merge, Encode]
```

A weaker test passes that, since the map is still written four times.

Adversarial checkpoint review: **PASS, zero findings.** It independently confirmed the boundaries bracket the work their names imply — `route` excludes the strict-mode ack wait, `encode` excludes the PUT, and on a budget shed the early return precedes the record. Accumulator is `AtomicU64`/`fetch_add` with no lock and no await inside a timed region. `record()` saturates via `try_from(...).unwrap_or(u64::MAX)` rather than panicking.

## Second commit corrects the ADR

The review question I could not settle myself turned out to invalidate my own caveat. ADR-0104 claimed the bulk-load path bypasses the per-tenant `AdmissionController`, so an `admit` figure would describe OTLP only. The premise is false: that controller is never invoked inside `LogIngestRouter::write` — it lives in the server, upstream (`otap_grpc.rs:467`, `exemplars.rs:2035`), and `log_router.rs` mentions it only in a test comment.

So `admit` measures the router's own ADR-0069 byte-budget admission, which runs for **both** OTLP and `load --parquet`. The figure is comparable across both paths — more useful than the ADR originally claimed.

Fixes: #504