### PR TITLE
test(ravel-otlp): pin OTLP normalize allocation scaling and label bytes

### DIFF
--- a/crates/ravel-otlp/src/normalize.rs
+++ b/crates/ravel-otlp/src/normalize.rs
@@ -2340,6 +2340,237 @@ mod tests {
         ));
     }
 
+    // --- #367 / ADR-0098: label bytes are unchanged by the per-scope hoist ---
+
+    /// The label pairs a `LabelSet` carries, in its stored (sorted-by-name)
+    /// order, as owned `(name, value)` tuples for byte-exact comparison.
+    fn label_pairs(ls: &LabelSet) -> Vec<(String, String)> {
+        ls.iter()
+            .map(|l| (l.name.clone(), l.value.clone()))
+            .collect()
+    }
+
+    fn pairs(items: &[(&str, &str)]) -> Vec<(String, String)> {
+        items
+            .iter()
+            .map(|(n, v)| (n.to_string(), v.to_string()))
+            .collect()
+    }
+
+    /// Differential test: for a batch that exercises every case where the
+    /// per-scope hoist (`SeriesIdMemo::series_id_for_attributes`, ADR-0098
+    /// decision 2) could silently re-identify a series, the emitted label sets
+    /// must be byte-identical to the values pinned here, and the
+    /// sanitization-collision rejections must be exactly as pinned. This is the
+    /// primary #367 deliverable: proof that hoisting the resource/metric prefix
+    /// out of the per-datapoint path changed no emitted byte.
+    ///
+    /// Cases covered in one batch: multiple resources; multiple metrics per
+    /// resource; multiple points per metric (memo hits, which must share one
+    /// `Arc` and yield the same id and bytes); attributes that need
+    /// sanitization; two distinct attributes that sanitize to the same name
+    /// (collision); an attribute that collides with `__name__`; an empty
+    /// attribute set; and a duplicate attribute key. The exponential-histogram
+    /// metric exercises the sibling native-histogram build path
+    /// (`build_native_histogram_point`), which duplicates the prefix logic and
+    /// must produce the identical resource-plus-attribute bytes.
+    #[test]
+    fn normalize_label_bytes_stable_across_hard_cases() {
+        // host.name is in the default resource-attribute allowlist.
+        let limits = IngestLimits::default();
+
+        // Resource 1: job=svc1 (from service.name), host_name=h1 (allowlist).
+        let rm1 = resource_metrics(
+            vec![
+                string_kv("service.name", "svc1"),
+                string_kv("host.name", "h1"),
+            ],
+            vec![
+                // Two identical points (memo hits) plus one empty-attribute
+                // point. Metric name carries a dot, sanitized to http_requests.
+                gauge_metric(
+                    "http.requests",
+                    vec![
+                        number_point(
+                            vec![string_kv("http.method", "GET"), int_kv("code", 200)],
+                            1_000,
+                            NumberValue::AsDouble(1.0),
+                        ),
+                        number_point(
+                            vec![string_kv("http.method", "GET"), int_kv("code", 200)],
+                            1_001,
+                            NumberValue::AsDouble(2.0),
+                        ),
+                        number_point(vec![], 1_002, NumberValue::AsDouble(3.0)),
+                    ],
+                ),
+                gauge_metric(
+                    "cpu",
+                    vec![number_point(
+                        vec![int_kv("core", 0)],
+                        1_003,
+                        NumberValue::AsDouble(4.0),
+                    )],
+                ),
+                // Native-histogram sibling of the prefix logic, same attrs as
+                // the http.requests points.
+                exponential_histogram_metric(
+                    "exp.latency",
+                    vec![ExponentialHistogramDataPoint {
+                        attributes: vec![string_kv("http.method", "GET"), int_kv("code", 200)],
+                        time_unix_nano: 1_004,
+                        ..Default::default()
+                    }],
+                    AggregationTemporality::Cumulative,
+                ),
+                // Two attributes sanitizing to the same name: collision.
+                gauge_metric(
+                    "collide_sanitize",
+                    vec![number_point(
+                        vec![string_kv("foo.bar", "1"), string_kv("foo-bar", "2")],
+                        1_005,
+                        NumberValue::AsDouble(5.0),
+                    )],
+                ),
+                // An attribute whose name collides with the injected __name__.
+                gauge_metric(
+                    "collide_name",
+                    vec![number_point(
+                        vec![string_kv("__name__", "oops")],
+                        1_006,
+                        NumberValue::AsDouble(6.0),
+                    )],
+                ),
+                // A duplicate attribute key.
+                gauge_metric(
+                    "collide_dupkey",
+                    vec![number_point(
+                        vec![string_kv("dup", "1"), string_kv("dup", "2")],
+                        1_007,
+                        NumberValue::AsDouble(7.0),
+                    )],
+                ),
+            ],
+        );
+
+        // Resource 2: same metric name and same attrs as resource 1's first
+        // point, but job=svc2 and no host_name. Must be a DIFFERENT series.
+        let rm2 = resource_metrics(
+            vec![string_kv("service.name", "svc2")],
+            vec![gauge_metric(
+                "http.requests",
+                vec![number_point(
+                    vec![string_kv("http.method", "GET"), int_kv("code", 200)],
+                    1_008,
+                    NumberValue::AsDouble(8.0),
+                )],
+            )],
+        );
+
+        let out = normalize_metrics(&tenant(), request(vec![rm1, rm2]), &limits, 1_000);
+
+        // Accepted scalar points, in emission order.
+        assert_eq!(out.points.len(), 5, "unexpected accepted points");
+        let a = pairs(&[
+            ("__name__", "http_requests"),
+            ("code", "200"),
+            ("host_name", "h1"),
+            ("http_method", "GET"),
+            ("job", "svc1"),
+        ]);
+        let c = pairs(&[
+            ("__name__", "http_requests"),
+            ("host_name", "h1"),
+            ("job", "svc1"),
+        ]);
+        let cpu = pairs(&[
+            ("__name__", "cpu"),
+            ("core", "0"),
+            ("host_name", "h1"),
+            ("job", "svc1"),
+        ]);
+        let r2 = pairs(&[
+            ("__name__", "http_requests"),
+            ("code", "200"),
+            ("http_method", "GET"),
+            ("job", "svc2"),
+        ]);
+        assert_eq!(label_pairs(&out.points[0].labels), a, "point A bytes");
+        assert_eq!(
+            label_pairs(&out.points[1].labels),
+            a,
+            "point B (memo hit) bytes"
+        );
+        assert_eq!(
+            label_pairs(&out.points[2].labels),
+            c,
+            "empty-attr point bytes"
+        );
+        assert_eq!(label_pairs(&out.points[3].labels), cpu, "cpu point bytes");
+        assert_eq!(
+            label_pairs(&out.points[4].labels),
+            r2,
+            "resource-2 point bytes"
+        );
+
+        // Memo hit shares one allocation and yields the same id.
+        assert_eq!(
+            out.points[0].series_id, out.points[1].series_id,
+            "two identical points must resolve to one series"
+        );
+        assert!(
+            Arc::ptr_eq(&out.points[0].labels, &out.points[1].labels),
+            "a memo hit must share the cached Arc<LabelSet>, not rebuild it"
+        );
+        // Distinct scopes are distinct series despite the shared metric name.
+        assert_ne!(
+            out.points[0].series_id, out.points[3].series_id,
+            "different metric must be a different series"
+        );
+        assert_ne!(
+            out.points[0].series_id, out.points[4].series_id,
+            "same metric+attrs under a different resource must be a different series"
+        );
+
+        // Native-histogram build path produces the identical prefix bytes.
+        assert_eq!(out.histogram_points.len(), 1, "one native-histogram point");
+        let exp = pairs(&[
+            ("__name__", "exp_latency"),
+            ("code", "200"),
+            ("host_name", "h1"),
+            ("http_method", "GET"),
+            ("job", "svc1"),
+        ]);
+        assert_eq!(
+            label_pairs(&out.histogram_points[0].labels),
+            exp,
+            "native-histogram label bytes"
+        );
+
+        // Sanitization collisions reject wholesale, with the pinned names, and
+        // the collision winner is stable (the injected __name__ is never
+        // displaced by a colliding attribute).
+        let dup_names: Vec<&str> = out
+            .rejected
+            .iter()
+            .filter_map(|r| match r {
+                Rejection::DuplicateLabelName(n) => Some(n.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            dup_names,
+            vec!["foo_bar", "__name__", "dup"],
+            "collision rejections must be exactly these names, in this order"
+        );
+        assert_eq!(
+            out.rejected.len(),
+            3,
+            "only the three collisions reject: {:?}",
+            out.rejected
+        );
+    }
+
     // --- int and double points ---
 
     #[test]

--- a/crates/ravel-otlp/tests/normalize_allocations.rs
+++ b/crates/ravel-otlp/tests/normalize_allocations.rs
@@ -1,0 +1,207 @@
+//! Allocation scaling acceptance test for the OTLP metrics normalize path
+//! (#367, ADR-0098).
+//!
+//! This file contains EXACTLY ONE test on purpose. The measurement wraps a
+//! `stats_alloc::Region` around the global allocator, so any other thread
+//! allocating while the region is open lands in the count; `cargo test` and
+//! nextest both run test functions in one binary concurrently, so a second
+//! test here would make the figures non-deterministic. This mirrors the
+//! established pattern in `ravel-sql/tests/scan_batch_allocations.rs`.
+//!
+//! The task (#367) named this acceptance test
+//! `ravel_otlp::normalize::tests::normalize_allocations_scale_per_scope_not_per_point`,
+//! i.e. a unit test in `src/normalize.rs`'s shared `mod tests`. It lives here
+//! as a single-test integration binary instead, for the reason above: a unit
+//! test would share the lib test binary with hundreds of other unit tests, and
+//! a global-`Region` measurement under concurrent execution is exactly what
+//! that neighbouring ravel-sql file documents as unusable. The test name is
+//! preserved; only the module path differs.
+//!
+//! What it pins (ADR-0098 decision 6): with the realistic OTLP shape (one
+//! series sampled over time, i.e. many points sharing one attribute set) the
+//! per-point resource-label clone and `__name__`/metric-name allocation are
+//! hoisted per scope by the `SeriesIdMemo`. So the allocation count must grow
+//! with the number of resource/metric SCOPES and stay FLAT in the number of
+//! points per scope. The assertions bound a per-point magnitude near zero and
+//! a per-scope magnitude near the full label-set build cost, so a regression to
+//! per-point rebuilding (the pre-ADR-0098 behaviour, ~`2R + A + 3` allocations
+//! per point) blows through the per-point bound by an order of magnitude.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::alloc::System;
+
+use opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest;
+use opentelemetry_proto::tonic::common::v1::any_value::Value as AnyValueVariant;
+use opentelemetry_proto::tonic::common::v1::{AnyValue, KeyValue};
+use opentelemetry_proto::tonic::metrics::v1::number_data_point::Value as NumberValue;
+use opentelemetry_proto::tonic::metrics::v1::{
+    Gauge, Metric, NumberDataPoint, ResourceMetrics, ScopeMetrics, metric::Data as MetricData,
+};
+use opentelemetry_proto::tonic::resource::v1::Resource;
+use ravel_otlp::{IngestLimits, normalize_metrics};
+use ravel_types::TenantId;
+use stats_alloc::{INSTRUMENTED_SYSTEM, Region, StatsAlloc};
+
+#[global_allocator]
+static GLOBAL: &StatsAlloc<System> = &INSTRUMENTED_SYSTEM;
+
+const INGEST_TS_NS: i64 = 1_700_000_000_000_000_000;
+
+/// Resource labels admitted per resource (`R`). Cloned into every point's
+/// label set on the pre-ADR-0098 path; hoisted per scope with the memo.
+const R: usize = 5;
+/// Attributes per datapoint (`A`).
+const A: usize = 5;
+
+fn string_kv(key: String, value: String) -> KeyValue {
+    KeyValue {
+        key,
+        value: Some(AnyValue {
+            value: Some(AnyValueVariant::StringValue(value)),
+        }),
+        ..Default::default()
+    }
+}
+
+/// Limits whose allowlist admits exactly `R` resource attributes.
+fn limits() -> IngestLimits {
+    IngestLimits {
+        resource_attribute_allowlist: (0..R).map(|i| format!("res.{i}")).collect(),
+        ..IngestLimits::default()
+    }
+}
+
+/// One request with `scopes` gauge metrics under a single resource, each metric
+/// carrying `points_per_scope` datapoints that all share ONE attribute set.
+/// Grouped shape: one series per metric, so `scopes` = distinct series =
+/// resource/metric scopes, and every point after the first in a metric is a
+/// memo hit. Attribute names carry a `.` so `sanitize_label_name` runs (the
+/// clean path still allocates its value string, which is the point under test).
+fn build_request(scopes: usize, points_per_scope: usize) -> (ExportMetricsServiceRequest, usize) {
+    let resource_attrs: Vec<KeyValue> = (0..R)
+        .map(|i| string_kv(format!("res.{i}"), format!("rv{i}")))
+        .collect();
+
+    let attrs: Vec<KeyValue> = (0..A)
+        .map(|a| string_kv(format!("attr.{a}"), format!("v{a}")))
+        .collect();
+
+    let metrics: Vec<Metric> = (0..scopes)
+        .map(|m| {
+            let data_points: Vec<NumberDataPoint> = (0..points_per_scope)
+                .map(|p| NumberDataPoint {
+                    attributes: attrs.clone(),
+                    time_unix_nano: (INGEST_TS_NS + p as i64 * 1_000_000) as u64,
+                    value: Some(NumberValue::AsDouble(p as f64 * 0.5)),
+                    ..Default::default()
+                })
+                .collect();
+            Metric {
+                name: format!("metric_{m}"),
+                data: Some(MetricData::Gauge(Gauge { data_points })),
+                ..Default::default()
+            }
+        })
+        .collect();
+
+    let req = ExportMetricsServiceRequest {
+        resource_metrics: vec![ResourceMetrics {
+            resource: Some(Resource {
+                attributes: resource_attrs,
+                ..Default::default()
+            }),
+            scope_metrics: vec![ScopeMetrics {
+                metrics,
+                ..Default::default()
+            }],
+            ..Default::default()
+        }],
+    };
+    (req, scopes * points_per_scope)
+}
+
+/// Allocations for one untimed `normalize_metrics` call, after a same-thread
+/// warmup on a freshly built (outside the region) fixture. The warmup grows
+/// `SeriesId::compute`'s thread-local scratch so its one-time growth is not
+/// charged to the measured region; the fixture the region measures is built
+/// before the region opens, and `normalize_metrics` consumes it by value.
+fn allocations(tenant: &TenantId, scopes: usize, points_per_scope: usize) -> usize {
+    let limits = limits();
+
+    let (warm, _) = build_request(scopes, points_per_scope);
+    let warm_out = normalize_metrics(tenant, warm, &limits, INGEST_TS_NS);
+    std::hint::black_box(&warm_out);
+    drop(warm_out);
+
+    let (req, total_points) = build_request(scopes, points_per_scope);
+    let region = Region::new(&INSTRUMENTED_SYSTEM);
+    let out = normalize_metrics(tenant, req, &limits, INGEST_TS_NS);
+    let change = region.change();
+    assert_eq!(out.points.len(), total_points, "unexpected point count");
+    assert!(
+        out.rejected.is_empty(),
+        "unexpected rejections: {:?}",
+        out.rejected
+    );
+    change.allocations
+}
+
+#[test]
+fn normalize_allocations_scale_per_scope_not_per_point() {
+    let tenant = TenantId::new("acme");
+
+    // Same scope count, few vs many points: isolates the per-point term.
+    let s = 8usize;
+    let few = allocations(&tenant, s, 1);
+    let many = allocations(&tenant, s, 100);
+
+    // Double the scopes at one point each: isolates the per-scope term.
+    let s2 = 16usize;
+    let few_2s = allocations(&tenant, s2, 1);
+
+    let extra_points = s * (100 - 1);
+    let per_point = (many.saturating_sub(few)) as f64 / extra_points as f64;
+    let per_scope = (few_2s.saturating_sub(few)) as f64 / (s2 - s) as f64;
+
+    eprintln!(
+        "normalize_allocations: few(S={s},P=1)={few} many(S={s},P=100)={many} \
+         few(S={s2},P=1)={few_2s} => per_point={per_point:.4} per_scope={per_scope:.2}"
+    );
+
+    // Flat in points. A memo hit is one `Arc::clone` (a refcount bump, no heap
+    // allocation), so every point after the first in a scope adds ~0
+    // allocations. Measured 0.0000 (few == many == 321 at 8 scopes). The bound
+    // is 1.0 rather than exact 0.0 to leave headroom for the output `Vec`'s
+    // O(log points) amortized growth without going brittle. A regression to
+    // per-point label rebuilding (pre-ADR-0098) costs ~`2R + A + 3` = 18
+    // allocations per point here, an order of magnitude over this bound.
+    assert!(
+        per_point < 1.0,
+        "allocations must be FLAT in points per scope: measured {per_point:.4} \
+         allocations per extra point ({few} at P=1, {many} at P=100 over {extra_points} \
+         extra points at {s} scopes). A per-point rebuild regression costs ~2R+A+3 \
+         allocations per point.",
+    );
+
+    // Grows with scopes. Each new scope is a new series whose first (and only,
+    // at P=1) point is a memo miss that builds one full `LabelSet`: the
+    // `Vec<Label>`, two strings per resource label, two for `__name__`, one per
+    // attribute value, plus the memo's attribute-key clone. Measured 38.00
+    // allocations per scope; the floor is 20 with headroom.
+    assert!(
+        per_scope >= 20.0,
+        "allocations must GROW with scope count: measured {per_scope:.2} allocations \
+         per scope ({few} at {s} scopes, {few_2s} at {s2} scopes). A scope that paid \
+         nothing would mean the per-scope build was itself elided.",
+    );
+
+    // The scaling is proportional to scope count, not a fixed cost: doubling the
+    // scopes adds at least `s * 20` allocations.
+    assert!(
+        few_2s >= few + s * 20,
+        "total allocations must grow proportionally to scope count: {few} at {s} \
+         scopes but only {few_2s} at {s2} scopes (expected at least {}).",
+        few + s * 20,
+    );
+}


### PR DESCRIPTION
Task 1 of epic #367. **The optimization it asked for was already landed; what was missing was the proof. This PR is the proof.**

#367 describes `build_point` allocating per datapoint — a fresh `Vec<Label>`, a deep clone of every resource label, two `to_string()` calls for the metric name — and asks for that work to be hoisted to per-resource/per-metric scope. **ADR-0098 already did it.** `NormalizedPoint`/`NormalizedHistogramPoint` carry `Arc<LabelSet>`, and both `build_point` and `build_native_histogram_point` route through `SeriesIdMemo::series_id_for_attributes`, which keys on the raw attribute slice and, on the grouped shape, returns an `Arc::clone` and rebuilds nothing.

So the epic's headline gap is closed on main. What had no coverage at all was whether it *stays* closed. A future edit that reintroduces a per-point rebuild is invisible: answers stay identical, only allocation count moves, and nothing asserted allocation count on this path.

## Two tests

**Allocation scaling**, `normalize_allocations_scale_per_scope_not_per_point`. Measured with the existing `stats_alloc` harness pattern: 8 scopes × 1 point = 321 allocations; 8 scopes × 100 points = **321**; 16 scopes × 1 point = 625. So per-point is 0.00 and per-scope is 38.0. It asserts the scaling *shape* — flat in points, growing in scopes — rather than a direction, so it cannot be satisfied by an optimization that is mostly undone.

**Label-byte differential**, `normalize_label_bytes_stable_across_hard_cases`. Canonical series identity is a frozen contract, so the label set for a given input must be byte-identical: same labels, values, order, sanitization, and collision winner. A faster normalize that shifts one byte silently re-identifies series and corrupts every downstream aggregation. The fixture pins multiple resources per batch, multiple metrics per resource, multiple points per metric, attributes needing sanitization, two distinct attributes colliding onto one sanitized name (`foo.bar` + `foo-bar` → `foo_bar`), an attribute colliding with the injected `__name__`, an empty attribute set, and a duplicate key — with the collision cases asserted to reject wholesale as `DuplicateLabelName` in exact order.

## Both mutations reproduced locally, not taken on report

Defeating the memo hit (`if false && let Some(entry) = &self.last` at `normalize.rs:730`) takes allocations 321 to **28041**:

```
allocations must be FLAT in points per scope: measured 35.0000 allocations per extra point
(321 at P=1, 28041 at P=100 over 792 extra points at 8 scopes).
A per-point rebuild regression costs ~2R+A+3 allocations per point.
```

The message states the expected regression cost, so the next reader knows what the number means rather than just that it moved. The differential test fails on a one-byte sanitizer change (`'_'` to `'x'`), reporting the exact differing label sets.

Tests only — no production change, since there was nothing left to optimize here.

Refs: #367
