### PR TITLE
feat(ravel-ingest): wire the metrics pipeline through the stage-timing seam

### DIFF
--- a/crates/ravel-ingest/src/lib.rs
+++ b/crates/ravel-ingest/src/lib.rs
@@ -69,5 +69,8 @@ pub use span_error::SpanWriteError;
 pub use span_metrics::{SpanIngestMetrics, SpanIngestMetricsSnapshot};
 pub use span_router::{SpanIngestRouter, SpanWriteReceipt, shard_for_span};
 #[cfg(feature = "stage-timing")]
-pub use stage_timing::{LogStage, LogStageSnapshot, LogStageTimings, StageTotals};
+pub use stage_timing::{
+    LogStage, LogStageSnapshot, LogStageTimings, MetricStage, MetricStageSnapshot,
+    MetricStageTimings, StageTotals,
+};
 pub use value::{IngestExemplar, IngestPoint, IngestValue};

--- a/crates/ravel-ingest/src/router.rs
+++ b/crates/ravel-ingest/src/router.rs
@@ -19,6 +19,8 @@ use crate::error::WriteError;
 use crate::generation::{DEFAULT_REFRESH_INTERVAL_NS, GenerationSwitch, Routed, load_generations};
 use crate::metrics::IngestMetrics;
 use crate::shard::{ShardActor, ShardMsg};
+#[cfg(feature = "stage-timing")]
+use crate::stage_timing::{MetricStage, MetricStageTimings};
 use crate::value::{IngestExemplar, IngestPoint};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -67,6 +69,13 @@ pub struct IngestRouter {
     /// `services/ravel-server` installs the configured budget with
     /// [`IngestRouter::with_budget`].
     budget: Arc<IngestByteBudget>,
+    /// Per-stage timing accumulator (ADR-0104 decision 1), shared by `Arc` with
+    /// every shard actor and flush task so the seam records into one table the
+    /// bench reporter reads via [`IngestRouter::stage_timings`]. Present only
+    /// under the `stage-timing` feature; with it off this field, and every
+    /// timing site, is compiled out.
+    #[cfg(feature = "stage-timing")]
+    stage_timings: Arc<MetricStageTimings>,
 }
 
 impl IngestRouter {
@@ -94,6 +103,8 @@ impl IngestRouter {
         rng: Arc<dyn RngSource>,
     ) -> Self {
         let metrics = Arc::new(IngestMetrics::default());
+        #[cfg(feature = "stage-timing")]
+        let stage_timings = Arc::new(MetricStageTimings::new());
         // Each generation's shard-actor set gets a fresh writer identity, so
         // two sets never collide on a commit key for the same shard index.
         let factory = {
@@ -101,6 +112,8 @@ impl IngestRouter {
             let clock = Arc::clone(&clock);
             let rng = Arc::clone(&rng);
             let metrics = Arc::clone(&metrics);
+            #[cfg(feature = "stage-timing")]
+            let stage_timings = Arc::clone(&stage_timings);
             move |shard_count: u32| -> Vec<ShardHandle> {
                 let writer_id = rng.new_uuid();
                 let epoch =
@@ -119,6 +132,8 @@ impl IngestRouter {
                             config,
                             Arc::clone(&metrics),
                             rx,
+                            #[cfg(feature = "stage-timing")]
+                            Arc::clone(&stage_timings),
                         );
                         tokio::spawn(actor.run());
                         ShardHandle {
@@ -140,7 +155,17 @@ impl IngestRouter {
             metrics,
             config,
             budget: IngestByteBudget::shared(IngestByteBudgetLimit::Unlimited),
+            #[cfg(feature = "stage-timing")]
+            stage_timings,
         }
+    }
+
+    /// The per-stage timing accumulator (ADR-0104 decision 1), for the bench
+    /// reporter to read a snapshot after driving a write. Present only under the
+    /// `stage-timing` feature.
+    #[cfg(feature = "stage-timing")]
+    pub fn stage_timings(&self) -> Arc<MetricStageTimings> {
+        Arc::clone(&self.stage_timings)
     }
 
     /// Installs the process-wide ingest buffer byte budget (ADR-0069 decision
@@ -314,6 +339,8 @@ impl IngestRouter {
         // amount once the last clone is dropped. On any early return from here
         // on (a stale provisioning view, a dead shard) the clones not yet
         // handed to a live shard drop with this frame, so nothing leaks.
+        #[cfg(feature = "stage-timing")]
+        let admit_start = std::time::Instant::now();
         let estimate: u64 = points
             .iter()
             .map(IngestPoint::est_charge_bytes)
@@ -329,10 +356,15 @@ impl IngestRouter {
                 .try_charge(estimate)
                 .map_err(|_| WriteError::BufferBudgetExceeded)?,
         );
+        #[cfg(feature = "stage-timing")]
+        self.stage_timings
+            .record(MetricStage::Admit, admit_start.elapsed());
 
         // Route this write against the tenant's current generation view,
         // re-reading the provisioning record when the cache is older than `C`
         // and failing closed if that read cannot complete (ADR-0052 section 3).
+        #[cfg(feature = "stage-timing")]
+        let route_start = std::time::Instant::now();
         let set = self.active_set(tenant.hash(), self.clock.now_ns()).await?;
         let shard_count = set.len() as u32;
         let mut by_shard: HashMap<u32, Vec<IngestPoint>> = HashMap::new();
@@ -397,6 +429,11 @@ impl IngestRouter {
                 return Err(WriteError::ShardUnavailable);
             }
         }
+        // Routing ends at dispatch: the strict-mode ack wait below is downstream
+        // durability (merge/encode/PUT happen in the shard), not a router stage.
+        #[cfg(feature = "stage-timing")]
+        self.stage_timings
+            .record(MetricStage::Route, route_start.elapsed());
 
         if mode == WriteMode::Buffered {
             return Ok(WriteReceipt::default());

--- a/crates/ravel-ingest/src/shard.rs
+++ b/crates/ravel-ingest/src/shard.rs
@@ -44,6 +44,8 @@ use crate::clock::Clock;
 use crate::config::{IngestConfig, SEGMENT_FORMAT_VERSION, checked_ingest_hour_bucket};
 use crate::error::WriteError;
 use crate::metrics::{FlushTrigger, IngestMetrics};
+#[cfg(feature = "stage-timing")]
+use crate::stage_timing::{MetricStage, MetricStageTimings};
 use crate::value::{IngestExemplar, IngestPoint, IngestValue, ValueKind};
 
 pub(crate) type Ack = oneshot::Sender<Result<CommitToken, WriteError>>;
@@ -415,6 +417,12 @@ struct FlushCtx {
     config: IngestConfig,
     metrics: Arc<IngestMetrics>,
     rtt: Arc<RttTracker>,
+    /// Per-stage timing accumulator (ADR-0104 decision 1), shared by `Arc` with
+    /// the router and every shard. The flush task records `encode` here; the
+    /// actor reaches it through `self.ctx` to record `merge`. Present only under
+    /// the `stage-timing` feature.
+    #[cfg(feature = "stage-timing")]
+    stage_timings: Arc<MetricStageTimings>,
 }
 
 /// One flush's identity and payload, pinned by the actor before the flush
@@ -473,6 +481,11 @@ impl FlushCtx {
 
         let exemplar_inputs = self.admit_exemplars(exemplars, &series);
 
+        // Encode: the SeriesInputV3 build plus the RSEG serialization only,
+        // excluding the exemplar admission above and the object-store PUT below
+        // (decision 5 measures the PUT separately).
+        #[cfg(feature = "stage-timing")]
+        let encode_start = std::time::Instant::now();
         // ADR-0027: every flush emits v5, scalar and histogram batches alike.
         // The raw-sample adapter frames each series into a single run, so the
         // writer choice is no longer version- or content-driven; the buffer's
@@ -508,6 +521,9 @@ impl FlushCtx {
                 return;
             }
         };
+        #[cfg(feature = "stage-timing")]
+        self.stage_timings
+            .record(MetricStage::Encode, encode_start.elapsed());
 
         let data_key = match keys::data_key(
             &tenant_hash,
@@ -879,6 +895,7 @@ impl ShardActor {
         config: IngestConfig,
         metrics: Arc<IngestMetrics>,
         rx: mpsc::Receiver<ShardMsg>,
+        #[cfg(feature = "stage-timing")] stage_timings: Arc<MetricStageTimings>,
     ) -> Self {
         let rtt = Arc::new(RttTracker::new());
         let ctx = Arc::new(FlushCtx {
@@ -892,6 +909,8 @@ impl ShardActor {
             config,
             metrics: Arc::clone(&metrics),
             rtt: Arc::clone(&rtt),
+            #[cfg(feature = "stage-timing")]
+            stage_timings,
         });
         ShardActor {
             shard,
@@ -999,18 +1018,25 @@ impl ShardActor {
         let points_len = points.len() as u64;
         let target_bytes = self.config.target_bytes;
 
+        // Grab the timing handle before the mutable buffer borrow so recording
+        // `merge` does not clash with the `&mut self.tenants` borrow held below.
+        #[cfg(feature = "stage-timing")]
+        let merge_timings = Arc::clone(&self.ctx.stage_timings);
         let buf = self.tenants.entry(tenant.clone()).or_default();
         // Merge before enqueuing the waiter: a series-id collision rejects
         // the whole batch fail-loud (ADR-0005) and leaves the buffer
         // untouched, so its ack must carry the error rather than ride the
         // next flush of the surviving series.
+        #[cfg(feature = "stage-timing")]
+        let merge_start = std::time::Instant::now();
         let mut bytes_added = match buf.merge(points, arrival_ns) {
             Ok(bytes_added) => bytes_added,
             Err(err) => {
                 // Fail-loud rejection: the buffer is untouched, so this
-                // request's bytes were never held. Returning drops `charge`,
-                // refunding them (ADR-0069) rather than pinning the budget to a
-                // batch that was rejected.
+                // request's bytes were never held (no merge sample recorded:
+                // the batch was rejected before any append). Returning drops
+                // `charge`, refunding them (ADR-0069) rather than pinning the
+                // budget to a batch that was rejected.
                 self.metrics.record_series_id_collision();
                 if let Some(ack) = ack {
                     self.ctx.ack_waiters(vec![ack], Err(err));
@@ -1018,6 +1044,10 @@ impl ShardActor {
                 return;
             }
         };
+        // Merge times only the sample-buffer append, matching the logs merge;
+        // the exemplar absorb below is a separate ADR-0047 concern, excluded.
+        #[cfg(feature = "stage-timing")]
+        merge_timings.record(MetricStage::Merge, merge_start.elapsed());
         bytes_added += buf.absorb_exemplars(exemplars);
         // The batch is now in the buffer: keep its charge alive with the buffer
         // until it flushes (ADR-0069). It moves into the flush task in

--- a/crates/ravel-ingest/src/stage_timing.rs
+++ b/crates/ravel-ingest/src/stage_timing.rs
@@ -185,10 +185,166 @@ mod imp {
             self.entries.is_empty()
         }
     }
+
+    /// A wired stage of the metrics ingest pipeline (ADR-0104 decision 2,
+    /// metrics row). The four stages match the logs pipeline's by name, but each
+    /// is verified against the metrics code (`router.rs` / `shard.rs` /
+    /// `SegmentWriter`), not transplanted from [`LogStage`]: `merge` and `encode`
+    /// are `SegmentWriter` code here, not `RlogWriter`, and the router's
+    /// admission and routing steps differ from the log router's. Ordering fixes
+    /// the natural pipeline order used by [`MetricStageSnapshot`]'s `BTreeMap`.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    pub enum MetricStage {
+        /// Router-side admission gate: the ADR-0069 process-wide ingest byte
+        /// budget charge in [`crate::IngestRouter`]'s write path
+        /// (`est_charge_bytes` fold over the request's points and exemplars, then
+        /// `IngestByteBudget::try_charge`). On a budget shed the `?` returns
+        /// before the `record` call, so a shed request contributes no admit
+        /// sample: the stage measures the cost of admissions that succeeded.
+        ///
+        /// This is NOT the per-tenant [`crate::AdmissionController`] (ADR-0089):
+        /// that controller runs in the server, upstream of this router, and is
+        /// never invoked in the router's write path. The number is the router's
+        /// own byte-budget admission only.
+        Admit,
+        /// Router generation resolution + shard grouping + dispatch: the
+        /// `active_set` resolution, the `shard_for` grouping of points and
+        /// exemplars, and the per-shard channel sends in [`crate::IngestRouter`]'s
+        /// write path. It excludes the strict-mode ack wait, which is downstream
+        /// durability (merge/encode/PUT happen in the shard), not routing.
+        Route,
+        /// Shard-actor buffer append: `TenantBuf::merge` in the metrics shard
+        /// actor's write handler, the metrics analogue of the logs merge. A
+        /// series-id collision (ADR-0005) rejects the batch before mutating the
+        /// buffer, so a rejected batch records no merge sample; the exemplar
+        /// absorb that follows is excluded, exactly as the logs merge times only
+        /// the record append.
+        Merge,
+        /// Flush-task RSEG serialization: the `SeriesInputV3` build plus
+        /// `SegmentWriter::write_histograms_with_exemplars` in the spawned flush.
+        /// `SegmentWriter`, not `RlogWriter`; it excludes the flush-scoped
+        /// exemplar admission and the object-store PUT (decision 5 measures the
+        /// PUT separately).
+        Encode,
+    }
+
+    impl MetricStage {
+        /// Stable lowercase name for reporting.
+        pub fn name(self) -> &'static str {
+            match self {
+                MetricStage::Admit => "admit",
+                MetricStage::Route => "route",
+                MetricStage::Merge => "merge",
+                MetricStage::Encode => "encode",
+            }
+        }
+    }
+
+    /// Per-stage nanosecond accumulator for the metrics pipeline, shared by `Arc`
+    /// from [`crate::IngestRouter`] to every metrics shard actor and flush task.
+    /// The per-pipeline twin of [`LogStageTimings`] (ADR-0104 decision 2 keeps a
+    /// separate table per pipeline). Every method is lock-free; the atomics use
+    /// `Relaxed` because the only cross-task read (a caller taking a
+    /// [`Self::snapshot`] after a write's ack resolves) is ordered by the oneshot
+    /// ack channel, not by these atomics.
+    #[derive(Debug, Default)]
+    pub struct MetricStageTimings {
+        admit: StageCell,
+        route: StageCell,
+        merge: StageCell,
+        encode: StageCell,
+    }
+
+    impl MetricStageTimings {
+        pub fn new() -> Self {
+            Self::default()
+        }
+
+        fn cell(&self, stage: MetricStage) -> &StageCell {
+            match stage {
+                MetricStage::Admit => &self.admit,
+                MetricStage::Route => &self.route,
+                MetricStage::Merge => &self.merge,
+                MetricStage::Encode => &self.encode,
+            }
+        }
+
+        /// Adds one sample of `dur` to `stage`. Called at stage boundaries with a
+        /// duration measured by [`std::time::Instant`].
+        pub fn record(&self, stage: MetricStage, dur: Duration) {
+            let cell = self.cell(stage);
+            cell.samples.fetch_add(1, Ordering::Relaxed);
+            let ns = u64::try_from(dur.as_nanos()).unwrap_or(u64::MAX);
+            cell.total_ns.fetch_add(ns, Ordering::Relaxed);
+        }
+
+        /// A point-in-time view holding one entry per stage that recorded at
+        /// least one sample. A stage that was never wired (or never reached) is
+        /// absent, not present-with-zero: that is what lets a caller assert the
+        /// wired stage set exactly rather than only that the map is non-empty.
+        pub fn snapshot(&self) -> MetricStageSnapshot {
+            let mut entries = BTreeMap::new();
+            for stage in [
+                MetricStage::Admit,
+                MetricStage::Route,
+                MetricStage::Merge,
+                MetricStage::Encode,
+            ] {
+                let cell = self.cell(stage);
+                let samples = cell.samples.load(Ordering::Relaxed);
+                if samples > 0 {
+                    entries.insert(
+                        stage,
+                        StageTotals {
+                            samples,
+                            total_ns: cell.total_ns.load(Ordering::Relaxed),
+                        },
+                    );
+                }
+            }
+            MetricStageSnapshot { entries }
+        }
+    }
+
+    /// An immutable snapshot of the metrics per-stage totals, for the bench
+    /// reporter. The per-pipeline twin of [`LogStageSnapshot`].
+    #[derive(Debug, Clone, Default)]
+    pub struct MetricStageSnapshot {
+        entries: BTreeMap<MetricStage, StageTotals>,
+    }
+
+    impl MetricStageSnapshot {
+        /// Every stage that recorded at least one sample, in pipeline order.
+        pub fn stages(&self) -> impl Iterator<Item = MetricStage> + '_ {
+            self.entries.keys().copied()
+        }
+
+        /// Totals for `stage`, or `None` if it recorded nothing.
+        pub fn get(&self, stage: MetricStage) -> Option<StageTotals> {
+            self.entries.get(&stage).copied()
+        }
+
+        /// Accumulated nanoseconds for `stage`, or `None` if it recorded
+        /// nothing.
+        pub fn total_ns(&self, stage: MetricStage) -> Option<u64> {
+            self.entries.get(&stage).map(|t| t.total_ns)
+        }
+
+        pub fn len(&self) -> usize {
+            self.entries.len()
+        }
+
+        pub fn is_empty(&self) -> bool {
+            self.entries.is_empty()
+        }
+    }
 }
 
 #[cfg(feature = "stage-timing")]
-pub use imp::{LogStage, LogStageSnapshot, LogStageTimings, StageTotals};
+pub use imp::{
+    LogStage, LogStageSnapshot, LogStageTimings, MetricStage, MetricStageSnapshot,
+    MetricStageTimings, StageTotals,
+};
 
 #[cfg(test)]
 #[allow(clippy::expect_used, clippy::unwrap_used)]
@@ -342,6 +498,150 @@ mod tests {
             receipt.tokens.len(),
             1,
             "one shard, one flushed object, feature-off path intact"
+        );
+
+        router.shutdown().await;
+    }
+
+    /// A consistently-built metrics point: one series, one label set, a scalar
+    /// sample. Two points of the same series drive a single-object flush.
+    fn metric_points() -> Vec<crate::value::IngestPoint> {
+        use ravel_types::{Label, LabelSet, Sample, SeriesId};
+
+        use crate::value::{IngestPoint, IngestValue};
+
+        let labels = Arc::new(
+            LabelSet::new(vec![Label {
+                name: "__name__".to_string(),
+                value: "http_requests_total".to_string(),
+            }])
+            .expect("distinct label names"),
+        );
+        vec![
+            IngestPoint {
+                series_id: SeriesId([1u8; 16]),
+                labels: Arc::clone(&labels),
+                value: IngestValue::Scalar(Sample {
+                    ts_ns: 1_000,
+                    value: 1.0,
+                }),
+            },
+            IngestPoint {
+                series_id: SeriesId([1u8; 16]),
+                labels,
+                value: IngestValue::Scalar(Sample {
+                    ts_ns: 2_000,
+                    value: 2.0,
+                }),
+            },
+        ]
+    }
+
+    /// Drives a real metrics write through the router to a flush and asserts the
+    /// wired stage set is EXACTLY {admit, route, merge, encode} -- no missing
+    /// stage, no extra one -- and every stage recorded a nonzero duration.
+    ///
+    /// The set is pinned exactly on purpose: a "the map is non-empty" assertion
+    /// would still pass with three of the four stages silently unwired, which is
+    /// the failure this test exists to catch (ADR-0104 decision 2 wires four
+    /// metrics stages). The metrics analogue of
+    /// [`logs_pipeline_records_every_wired_stage`].
+    #[cfg(feature = "stage-timing")]
+    #[tokio::test]
+    async fn metrics_pipeline_records_every_wired_stage() {
+        use ravel_types::Signal;
+
+        use super::MetricStage;
+        use crate::router::IngestRouter;
+
+        let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+        let router = IngestRouter::new(
+            flush_on_first(),
+            Arc::clone(&store),
+            Signal::Metrics,
+            Arc::new(SystemClock),
+        );
+        let timings = router.stage_timings();
+
+        // A strict write blocks until the commit publishes, so on return every
+        // wired stage -- admit/route on the router, merge/encode in the shard --
+        // has already recorded.
+        let receipt = router
+            .write_values(
+                TenantId::new("acme"),
+                metric_points(),
+                WriteMode::Strict,
+                Duration::from_secs(30),
+            )
+            .await
+            .expect("a strict metrics write commits");
+        assert_eq!(receipt.tokens.len(), 1, "one shard, one flushed object");
+
+        let snap = timings.snapshot();
+
+        // The stage set is EXACTLY the wired set. Both directions: every wired
+        // stage present, and nothing else.
+        let wired = [
+            MetricStage::Admit,
+            MetricStage::Route,
+            MetricStage::Merge,
+            MetricStage::Encode,
+        ];
+        let recorded: Vec<MetricStage> = snap.stages().collect();
+        assert_eq!(
+            recorded,
+            wired.to_vec(),
+            "recorded stage set must be exactly the four wired metrics stages, got {:?}",
+            recorded.iter().map(|s| s.name()).collect::<Vec<_>>(),
+        );
+
+        // Every wired stage has a NONZERO duration.
+        for stage in wired {
+            let ns = snap
+                .total_ns(stage)
+                .unwrap_or_else(|| panic!("stage {} is unwired: no sample recorded", stage.name()));
+            assert!(
+                ns > 0,
+                "stage {} recorded a zero duration; it is not measuring real work",
+                stage.name()
+            );
+        }
+
+        router.shutdown().await;
+    }
+
+    /// With the feature off, the seam does not exist and the metrics write path
+    /// runs exactly as it does today: a strict write still drives a flush and
+    /// commits. Proves feature-off behavior is unchanged (the router exposes no
+    /// `stage_timings` accessor here, so this test cannot reference the seam).
+    #[cfg(not(feature = "stage-timing"))]
+    #[tokio::test]
+    async fn feature_off_metrics_write_still_commits() {
+        use ravel_types::Signal;
+
+        use crate::router::IngestRouter;
+
+        let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+        let router = IngestRouter::new(
+            flush_on_first(),
+            Arc::clone(&store),
+            Signal::Metrics,
+            Arc::new(SystemClock),
+        );
+
+        let receipt = router
+            .write_values(
+                TenantId::new("acme"),
+                metric_points(),
+                WriteMode::Strict,
+                Duration::from_secs(30),
+            )
+            .await
+            .expect("a strict metrics write commits with the feature off");
+        assert_eq!(
+            receipt.tokens.len(),
+            1,
+            "one shard, one flushed object, feature-off metrics path intact"
         );
 
         router.shutdown().await;


### PR DESCRIPTION
Wave 2 of epic #365, per ADR-0104 decisions 1 and 2. Wires the **metrics** pipeline through the `stage-timing` seam T1 (#509) landed for logs.

Placements were verified against the metrics code rather than transplanted from the logs side, which matters because `merge` and `encode` are different code here (`SegmentWriter`, not `RlogWriter`):

| Stage | Site | Boundary |
|---|---|---|
| admit | `router.rs:343-361` | before the `est_charge_bytes` fold over points **and exemplars**, recorded after `try_charge` succeeds |
| route | `router.rs:367-436` | before `active_set`, recorded after the per-shard send loop |
| merge | `shard.rs:1031-1050` | around `TenantBuf::merge`, `Ok` path only; `absorb_exemplars` excluded |
| encode | `shard.rs:488-526` | around the `SeriesInputV3` build and `write_histograms_with_exemplars`; `admit_exemplars` and the PUT excluded |

## The two boundary errors that would produce a misleading number rather than a failure

Both checked in the code, not taken on report:

**`route` excludes the strict-mode ack wait.** Recorded after the send loop and before `join_all`/`timeout`, and before the buffered early return. An ack wait folded in here would report object-store latency as routing cost. The shard-dead path (`ShardUnavailable`) returns before the record, so no route sample on that error.

**`encode` excludes the PUT.** Recorded before `keys::data_key`, `put_data_object_with_retry`, and `publish_with_retry`. A PUT retry loop sits entirely outside the window, so retries never inflate encode.

On double-counting: `admit` and `route` are recorded once per `write_points` call, so a multi-shard write records route once covering all sends. `merge` and `encode` are per shard-write and per flush, so a request fanning to N shards produces N merge samples and N encodes — one per distinct object, which is the intended per-object attribution.

Same shed property as the logs seam: on a budget shed the `?` returns before the record, so a shed request contributes no admit sample. The stage measures admissions that succeeded, not the cost of deciding.

## Verified locally

Both feature lanes exit 0; 169 lib tests with the feature on, and the logs and metrics acceptance tests both pass. `Instant::now()` only — the single `now_ns` occurrence in `stage_timing.rs` is a doc comment quoting the ADR's reasoning.

**Mutation, run independently of the executor's.** They misattributed `Route` as `Admit` in `router.rs`. I misattributed `Encode` as `Merge` in `shard.rs` — a different stage pair in the other file, leaving all four `record()` calls present and compiling:

```
assertion `left == right` failed: recorded stage set must be exactly the four wired metrics stages, got ["admit", "route", "merge"]
  left: [Admit, Route, Merge]
 right: [Admit, Route, Merge, Encode]
```

Fixes: #505
