### PR TITLE
feat(query): wire ADR-0103 pushdown eligibility gate into the fetch path

### DIFF
--- a/crates/ravel-promql/src/eval.rs
+++ b/crates/ravel-promql/src/eval.rs
@@ -376,7 +376,7 @@ const STALE_NAN_BITS: u64 = 0x7ff0_0000_0000_0002;
 /// the whole query's own parameters, fixed regardless of which grid step (if
 /// any) is currently being evaluated. For an instant query both fields equal
 /// the query's evaluation timestamp.
-pub(crate) struct QueryWindow {
+pub struct QueryWindow {
     start_ns: i64,
     end_ns: i64,
     /// Shared cross-level evaluation-grid-point budget, charged
@@ -405,6 +405,23 @@ pub(crate) struct QueryWindow {
 }
 
 impl QueryWindow {
+    /// A bare context for callers outside this crate that invoke a
+    /// window-resolution helper such as [`crate::functions::range_window`]
+    /// directly: the query's `[start_ns, end_ns]` parameters (consulted only to
+    /// resolve `@ start()`/`@ end()`), an effectively unbounded evaluation
+    /// budget, no deadline, and an empty annotation sink. Exposed so a
+    /// distributed-pushdown coordinator can assert its independently-derived
+    /// reduction bounds against the evaluator's own `range_window`.
+    pub fn bare(start_ns: i64, end_ns: i64) -> Self {
+        QueryWindow {
+            start_ns,
+            end_ns,
+            budget: Cell::new(u64::MAX),
+            deadline: None,
+            annotations: RefCell::new(Annotations::default()),
+        }
+    }
+
     /// Test-only bare context: instant window at time zero, effectively
     /// unbounded budget, no deadline, empty annotation sink. For unit tests
     /// that call an internal `eval_*`/annotation helper directly instead of

--- a/crates/ravel-promql/src/functions/mod.rs
+++ b/crates/ravel-promql/src/functions/mod.rs
@@ -131,11 +131,11 @@ pub(crate) type InstantFn = fn(
 /// which is the query's own instant, not the offset/`@`-shifted lookup
 /// time `end_ns` may be).
 #[derive(Clone, Copy)]
-pub(crate) struct RangeWindow {
-    pub(crate) start_ns: i64,
-    pub(crate) end_ns: i64,
-    pub(crate) range_ns: i64,
-    pub(crate) eval_ts_ns: i64,
+pub struct RangeWindow {
+    pub start_ns: i64,
+    pub end_ns: i64,
+    pub range_ns: i64,
+    pub eval_ts_ns: i64,
 }
 
 /// All registered function families, aggregated into one lookup table.
@@ -693,7 +693,7 @@ pub(crate) fn string_arg(
 /// [`Evaluator::eval_subquery_matrix`] produce the same [`RangeMatrix`]
 /// shape for a reducer to consume.
 #[derive(Clone, Copy)]
-pub(crate) enum MatrixArg<'a> {
+pub enum MatrixArg<'a> {
     Selector(&'a promql_parser::parser::MatrixSelector),
     Subquery(&'a promql_parser::parser::SubqueryExpr),
 }
@@ -707,7 +707,11 @@ pub(crate) enum MatrixArg<'a> {
 /// window a reducer like `rate` extrapolates against is the query's own
 /// declared range, matching Prometheus, which computes `rate`'s boundary
 /// extrapolation from the subquery's nominal range regardless of alignment.
-fn range_window(arg: MatrixArg, eval_ts_ns: i64, ctx: &QueryWindow) -> Result<RangeWindow, Error> {
+pub fn range_window(
+    arg: MatrixArg,
+    eval_ts_ns: i64,
+    ctx: &QueryWindow,
+) -> Result<RangeWindow, Error> {
     match arg {
         MatrixArg::Selector(ms) => {
             let sel_ts_ns = selector_eval_ts(&ms.vs, eval_ts_ns, ctx)?;
@@ -795,7 +799,7 @@ fn eval_matrix_arg(
 /// `MatrixSelector`, `Subquery`, or `Paren` wrapping either. Any other node
 /// is unreachable, since the parser rejects the query before this evaluator
 /// ever sees it otherwise.
-fn matrix_arg(expr: &promql_parser::parser::Expr) -> Result<MatrixArg<'_>, Error> {
+pub fn matrix_arg(expr: &promql_parser::parser::Expr) -> Result<MatrixArg<'_>, Error> {
     use promql_parser::parser::Expr;
     let mut cur = expr;
     loop {

--- a/crates/ravel-promql/src/lib.rs
+++ b/crates/ravel-promql/src/lib.rs
@@ -31,9 +31,14 @@ pub mod testsource;
 
 pub use eval::{
     Annotations, DEFAULT_LOOKBACK_NS, DEFAULT_MAX_RANGE_POINTS, DEFAULT_MAX_TOTAL_EVAL_POINTS,
-    DEFAULT_SUBQUERY_STEP_NS, Error, Evaluator, InstantSample, InstantVector, RangeMatrix, Value,
-    ms_to_ns, ns_to_ms_floor,
+    DEFAULT_SUBQUERY_STEP_NS, Error, Evaluator, InstantSample, InstantVector, QueryWindow,
+    RangeMatrix, Value, ms_to_ns, ns_to_ms_floor,
 };
+// ADR-0103 aggregation pushdown: the coordinator (`ravel-query`) derives a
+// count_over_time reduction window on the distributed path and asserts it
+// byte-for-byte against the evaluator's own `range_window`, so these are
+// public for that cross-crate check. Visibility only; behavior unchanged.
+pub use functions::{MatrixArg, RangeWindow, matrix_arg, range_window};
 pub use histogram::{FloatHistogram, ResetHint, Span};
 pub use matchers::{from_ast_matcher, from_ast_matchers, has_or_group, matches_series};
 pub use plan::{PlanAnchor, SelectorPlan, plan_selectors};

--- a/crates/ravel-promql/src/plan.rs
+++ b/crates/ravel-promql/src/plan.rs
@@ -36,6 +36,16 @@ pub struct SelectorPlan {
     pub offset_ns: i64,
     /// The resolved anchor for this selector's lookup instant.
     pub anchor: PlanAnchor,
+    /// ADR-0103 aggregation-pushdown tag: `true` only for the single
+    /// `SelectorPlan` produced by a `count_over_time` call whose matrix
+    /// argument, after unwrapping parentheses, is a literal matrix selector
+    /// (never a subquery). This is a purely structural, AST-shape-only marker
+    /// set by [`plan_walk`]'s `Expr::Call` arm; it records nothing about the
+    /// concrete reduction window (a `PlanAnchor::Window` selector has no
+    /// concrete timestamp until a query's evaluation window is known at fetch
+    /// time). Every other selector -- a different range function, a subquery
+    /// argument, or a bare selector with no wrapping call -- leaves it `false`.
+    pub count_over_time_pushdown_candidate: bool,
 }
 
 /// How a selector's lookup instant is anchored, after folding every `@`
@@ -202,6 +212,22 @@ fn plan_walk(
             )
         }
         Expr::Call(c) => {
+            // ADR-0103 pushdown candidate detection, computed BEFORE recursing
+            // so it reflects this call's own shape, not a nested one. A
+            // `count_over_time` over a literal matrix selector (never a
+            // subquery) is the only shape a coordinator may later push a
+            // precomputed count down for. `matrix_arg` is reused verbatim from
+            // `crate::functions` so the Paren-unwrap and the selector-vs-
+            // subquery distinction stay identical to the evaluator's own. A
+            // zero-arg call (`time()`, `pi()`) never reaches the index because
+            // the name check short-circuits first, and `count_over_time` always
+            // parses with exactly one matrix argument.
+            let is_candidate = c.func.name == "count_over_time"
+                && matches!(
+                    crate::functions::matrix_arg(&c.args.args[0]),
+                    Ok(crate::functions::MatrixArg::Selector(_))
+                );
+            let before = out.len();
             for arg in &c.args.args {
                 plan_walk(
                     arg,
@@ -212,6 +238,15 @@ fn plan_walk(
                     query_end_ns,
                     out,
                 )?;
+            }
+            // The literal-selector case pushes exactly one `SelectorPlan`; tag
+            // it. Any other count (a subquery argument recurses through
+            // `Expr::Subquery`'s own arm and never enters this branch's
+            // `is_candidate`, and a candidate whose recursion pushed a
+            // different number of plans is not the simple literal shape) leaves
+            // every plan `false`.
+            if is_candidate && out.len() == before + 1 {
+                out[before].count_over_time_pushdown_candidate = true;
             }
             Ok(())
         }
@@ -264,6 +299,10 @@ fn resolve_selector(
         range_ns,
         offset_ns,
         anchor,
+        // Structural pushdown tag, set by `plan_walk`'s `Expr::Call` arm once
+        // it knows this plan was pushed by a `count_over_time` over a literal
+        // selector; every selector is built here first with it `false`.
+        count_over_time_pushdown_candidate: false,
     })
 }
 
@@ -394,5 +433,50 @@ mod tests {
     fn no_selector_query_reports_nothing() {
         let plans = plan_selectors("42", 0, 0).expect("parses");
         assert!(plans.is_empty());
+    }
+
+    #[test]
+    fn count_over_time_over_literal_selector_is_a_pushdown_candidate() {
+        // The one shape ADR-0103's count pushdown targets: a `count_over_time`
+        // over a literal matrix selector. Exactly one plan, tagged.
+        let plans = plan_selectors("count_over_time(m[5m])", 0, 0).expect("parses");
+        assert_eq!(plans.len(), 1);
+        assert!(
+            plans[0].count_over_time_pushdown_candidate,
+            "count_over_time over a literal selector is a candidate"
+        );
+    }
+
+    #[test]
+    fn other_range_functions_and_bare_selectors_are_not_candidates() {
+        // A different `_over_time` function is not the count shape.
+        let plans = plan_selectors("sum_over_time(m[5m])", 0, 0).expect("parses");
+        assert_eq!(plans.len(), 1);
+        assert!(
+            !plans[0].count_over_time_pushdown_candidate,
+            "sum_over_time is not a count_over_time candidate"
+        );
+
+        // A bare matrix selector with no wrapping call never enters the Call
+        // arm, so it is never tagged.
+        let plans = plan_selectors("m[5m]", 0, 0).expect("parses");
+        assert_eq!(plans.len(), 1);
+        assert!(
+            !plans[0].count_over_time_pushdown_candidate,
+            "a bare selector is not a candidate"
+        );
+    }
+
+    #[test]
+    fn count_over_time_over_subquery_is_not_a_candidate() {
+        // `count_over_time(m[1h:5m])`: the argument is a subquery, whose inner
+        // selector is reached via `Expr::Subquery`'s own recursion, never
+        // through the `Call` arm's `is_candidate` branch. No plan is tagged.
+        let plans = plan_selectors("count_over_time(m[1h:5m])", 0, 0).expect("parses");
+        assert!(!plans.is_empty());
+        assert!(
+            plans.iter().all(|p| !p.count_over_time_pushdown_candidate),
+            "a subquery argument is structurally excluded"
+        );
     }
 }

--- a/crates/ravel-query/src/distrib/codec.rs
+++ b/crates/ravel-query/src/distrib/codec.rs
@@ -50,18 +50,17 @@ use crate::span_fetcher::SpanRow;
 /// worker is dropped at routing time (never a hard error), so a rolling deploy
 /// degrades to coordinator-local execution, never to a wrong answer.
 ///
-/// Bumped 3 -> 4 for ADR-0103 (epic #64): the coordinator now sets
-/// `FetchRequest.partial_aggregate` to `Some` on an eligible instant
-/// `count_over_time` query, asking the worker for a precomputed per-series
-/// count over an explicit reduction window instead of raw runs. The frame
-/// additions (`PartialAggregateRequest`, `PartialAggregate`) and their
-/// decode-side support landed under version 3 with no behavior change; this bump
-/// lands with the first commit that sets the field live on a real request, the
-/// same staging ADR-0096 used. A version-3 worker seeing a version-4 request
-/// returns `Unsupported` through [`check_protocol_version`], which the
-/// coordinator maps to a silent local fallback, so a version-skewed worker
-/// during a rolling deploy degrades to raw fetch, never a corrupt answer.
-pub const PROTOCOL_VERSION: u32 = 4;
+/// Still 3 as of ADR-0103 (epic #64): the `PartialAggregateRequest`/
+/// `PartialAggregate` frame additions and their decode-side support have
+/// landed with no behavior change (worker computes and returns a partial iff
+/// asked; nothing asks yet). The bump to 4 is deferred to the commit that
+/// sets `FetchRequest.partial_aggregate` live on a real request AND wires
+/// `MergedSource::query_precomputed_count` to consume the result -- the same
+/// staging ADR-0096 used, and load-bearing here: the worker's pushdown
+/// branch returns the partial INSTEAD OF raw runs, so a build that sends the
+/// request without a consumer for the reply would silently see zero raw
+/// series and no replacement for them.
+pub const PROTOCOL_VERSION: u32 = 3;
 
 /// The fragment-capability claim-set version (ADR-0071 amendment, decision 2).
 /// Distinct from [`PROTOCOL_VERSION`]: it versions the canonical claim encoding
@@ -1651,13 +1650,13 @@ mod tests {
         }
     }
 
-    /// ADR-0103 (epic #64): the protocol version is 4, bumped in the same
-    /// commit that first sets `FetchRequest.partial_aggregate` live on a real
-    /// request. A worker one version behind sees a mismatch and the coordinator
-    /// degrades to a silent local fallback, so this is a safe rolling bump.
+    /// ADR-0103 (epic #64): the protocol version stays 3 until the commit
+    /// that first sets `FetchRequest.partial_aggregate` live on a real
+    /// request AND wires its consumer -- see the doc comment on
+    /// `PROTOCOL_VERSION`.
     #[test]
-    fn protocol_version_is_four() {
-        assert_eq!(PROTOCOL_VERSION, 4);
+    fn protocol_version_is_still_three_pending_adr_0103_activation() {
+        assert_eq!(PROTOCOL_VERSION, 3);
     }
 
     #[test]

--- a/crates/ravel-query/src/distrib/codec.rs
+++ b/crates/ravel-query/src/distrib/codec.rs
@@ -50,7 +50,18 @@ use crate::span_fetcher::SpanRow;
 /// worker is dropped at routing time (never a hard error), so a rolling deploy
 /// degrades to coordinator-local execution, never to a wrong answer.
 ///
-pub const PROTOCOL_VERSION: u32 = 3;
+/// Bumped 3 -> 4 for ADR-0103 (epic #64): the coordinator now sets
+/// `FetchRequest.partial_aggregate` to `Some` on an eligible instant
+/// `count_over_time` query, asking the worker for a precomputed per-series
+/// count over an explicit reduction window instead of raw runs. The frame
+/// additions (`PartialAggregateRequest`, `PartialAggregate`) and their
+/// decode-side support landed under version 3 with no behavior change; this bump
+/// lands with the first commit that sets the field live on a real request, the
+/// same staging ADR-0096 used. A version-3 worker seeing a version-4 request
+/// returns `Unsupported` through [`check_protocol_version`], which the
+/// coordinator maps to a silent local fallback, so a version-skewed worker
+/// during a rolling deploy degrades to raw fetch, never a corrupt answer.
+pub const PROTOCOL_VERSION: u32 = 4;
 
 /// The fragment-capability claim-set version (ADR-0071 amendment, decision 2).
 /// Distinct from [`PROTOCOL_VERSION`]: it versions the canonical claim encoding
@@ -1638,6 +1649,15 @@ mod tests {
                 "special f64 corrupted on the wire"
             );
         }
+    }
+
+    /// ADR-0103 (epic #64): the protocol version is 4, bumped in the same
+    /// commit that first sets `FetchRequest.partial_aggregate` live on a real
+    /// request. A worker one version behind sees a mismatch and the coordinator
+    /// degrades to a silent local fallback, so this is a safe rolling bump.
+    #[test]
+    fn protocol_version_is_four() {
+        assert_eq!(PROTOCOL_VERSION, 4);
     }
 
     #[test]

--- a/crates/ravel-query/src/distrib/mod.rs
+++ b/crates/ravel-query/src/distrib/mod.rs
@@ -117,9 +117,17 @@ impl Distributed {
     /// results incrementally as each slice completes (so a budget trip or a
     /// hard error short-circuits without draining the rest).
     ///
+    /// `partial_aggregate` (ADR-0103) is `Some` only for an eligible instant
+    /// `count_over_time` query: the coordinator asks every slice for a
+    /// per-series precomputed partial over the request's reduction window
+    /// instead of raw runs, and the returned `Vec<codec::PartialAggregate>` is
+    /// the collected result (empty when the field is `None`, today's every real
+    /// query). `None` is byte-identical to the pre-ADR-0103 behavior.
+    ///
     /// Returns:
-    /// - `Ok(Some(triple))` when every slice succeeded: the coordinator merges
-    ///   it exactly as the local path merges its own fetch.
+    /// - `Ok(Some((triple, partials)))` when every slice succeeded: the
+    ///   coordinator merges `triple` exactly as the local path merges its own
+    ///   fetch, and `partials` carries any collected worker partials.
     /// - `Ok(None)` when the query must fall back to fully local execution: a
     ///   worker reported [`pb::status::Code::Unsupported`] (version skew or a
     ///   resolve-scope slice). ADR-0071's silent fallback, never an error to the
@@ -143,12 +151,16 @@ impl Distributed {
         accounting: &QueryAccounting,
         config: &EngineConfig,
         deadline_unix_ns: i64,
-    ) -> Result<Option<FetchedTriple>, QueryError> {
+        partial_aggregate: Option<pb::PartialAggregateRequest>,
+    ) -> Result<Option<(FetchedTriple, Vec<codec::PartialAggregate>)>, QueryError> {
         let slices = partition_snapshot(snapshot, self.thresholds.max_parallel_slices);
         if slices.is_empty() {
             // Nothing to fetch: an empty snapshot merges to an empty result
             // identically whether local or distributed.
-            return Ok(Some((Vec::new(), FetchStats::default(), Vec::new())));
+            return Ok(Some((
+                (Vec::new(), FetchStats::default(), Vec::new()),
+                Vec::new(),
+            )));
         }
 
         let encoded_matchers = codec::encode_matchers(matchers);
@@ -210,11 +222,17 @@ impl Distributed {
                     // builder leaves the bytes empty. A coordinator-local slice
                     // needs no capability.
                     fragment_capability: Vec::new(),
-                    // No aggregation pushdown from this builder: it always asks
-                    // for raw runs and merges them here (ADR-0103's eligibility
-                    // gate and the coordinator-side combine that would set this
-                    // field are not wired yet).
-                    partial_aggregate: None,
+                    // ADR-0103 aggregation pushdown: `Some` only for an eligible
+                    // instant `count_over_time` query (the coordinator's
+                    // per-matcher-set decision in `engine::prefetch`), in which
+                    // case every slice of this matcher set carries the identical
+                    // request so each worker computes a per-series count over
+                    // the same reduction window. `None` (every other query) asks
+                    // for raw runs, byte-identical to the pre-ADR-0103 builder.
+                    // The request is `Copy` (all-scalar fields), so each
+                    // per-slice build copies it rather than moving the shared
+                    // value out of this `FnMut`.
+                    partial_aggregate,
                 };
                 let fetcher = Arc::clone(&self.fetcher);
                 async move { fetcher.fetch(request).await }
@@ -234,6 +252,16 @@ impl Distributed {
         let mut distinct_hist: HashSet<SeriesId> = HashSet::new();
         let mut per_slice: Vec<Vec<FetchedSeriesSoa>> = Vec::new();
         let mut per_slice_hist: Vec<Vec<FetchedHistogramSeries>> = Vec::new();
+        // ADR-0103 collected worker partials, and a HashSet DEDICATED to
+        // detecting a duplicate series id across `.partials` entries (possibly
+        // from different slices/workers). This is a distinct mechanism from the
+        // `distinct`/`distinct_hist` cap-enforcement sets above: a legitimate
+        // cap truncation is not a duplicate-series bug, so the two must never
+        // share a set. Under decision 1's eligibility gate every series lives on
+        // exactly one worker, so a repeat means the gate was violated and the
+        // query must fail closed (below), never silently keep one of two values.
+        let mut collected_partials: Vec<codec::PartialAggregate> = Vec::new();
+        let mut partial_series: HashSet<SeriesId> = HashSet::new();
         // Running fold of the per-slice accounting snapshots (ADR-0071),
         // combined via the saturating merge so a worker near `u64::MAX` clamps
         // rather than wrapping past the bytes-scanned budget. This is the
@@ -294,6 +322,19 @@ impl Distributed {
                         bytes_scanned_exceeded(running.total_s3_bytes(), config.max_bytes_scanned)
                     {
                         return Err(err);
+                    }
+                    // ADR-0103: fold this slice's worker partials into the
+                    // per-fetch collection, hard-erroring on any repeated series
+                    // id (across this or any prior slice). Empty for a raw fetch
+                    // (`partial_aggregate` was `None`), so this is inert on every
+                    // query shape other than an eligible `count_over_time`.
+                    for pa in response.partials {
+                        if !partial_series.insert(pa.series_id) {
+                            return Err(QueryError::DuplicatePushdownSeries {
+                                series_id: pa.series_id.to_hex(),
+                            });
+                        }
+                        collected_partials.push(pa);
                     }
                     per_slice.push(response.scalar);
                     per_slice_hist.push(response.histogram);
@@ -370,7 +411,10 @@ impl Distributed {
             return Ok(None);
         }
 
-        Ok(Some((per_slice, stats, per_slice_hist)))
+        Ok(Some((
+            (per_slice, stats, per_slice_hist),
+            collected_partials,
+        )))
     }
 
     /// Partitions the snapshot, dispatches one RLOG-family (Logs, Alerts, Audit)

--- a/crates/ravel-query/src/distrib/pushdown.rs
+++ b/crates/ravel-query/src/distrib/pushdown.rs
@@ -101,10 +101,14 @@ where
 /// decision 1(b) forbids: a generation appended between the two reads would be
 /// invisible here while its segments are already in `segments`.
 ///
-/// This is the whole eligibility gate, and it is intentionally not called by
-/// any production query path yet (epic #64, T4 wires it into the planner). The
-/// expression-shape gate (ADR-0103 decision 4) is a separate, independent
-/// check; neither implies the other.
+/// This is the whole eligibility gate. `QueryEngine::prefetch` calls it on
+/// every real query (epic #64 T4c), but its result does not yet reach the
+/// wire: the coordinator computes and tests the pushdown target this gate
+/// feeds without ever setting `FetchRequest.partial_aggregate` live, because
+/// nothing yet consumes a worker's partial-only reply
+/// (`MergedSource::query_precomputed_count`, T4d). The expression-shape gate
+/// (ADR-0103 decision 4) is a separate, independent check; neither implies
+/// the other.
 pub fn is_pushdown_eligible(
     federation: Option<&Federation>,
     segments: &[SegmentRef],

--- a/crates/ravel-query/src/distrib/tests.rs
+++ b/crates/ravel-query/src/distrib/tests.rs
@@ -403,10 +403,12 @@ async fn assert_distributed_matches_local(
             &accounting,
             &config,
             i64::MAX,
+            None,
         )
         .await
         .expect("distributed fetch")
-        .expect("distributed produced a result (not a fallback)");
+        .expect("distributed produced a result (not a fallback)")
+        .0;
     let distributed_stats = triple.1;
     let distributed_merged = merge_soa_runs(triple.0, usize::MAX, usize::MAX).expect("dist merge");
 
@@ -682,13 +684,15 @@ fn run_merged_series_distributed_over_the_wire_not_refused() {
                 &accounting,
                 &EngineConfig::default(),
                 i64::MAX,
+                None,
             )
             .await
             .expect("distributed fetch")
             .expect(
                 "a run-merged series is now served over the wire (PROTOCOL_VERSION 3), \
                  not refused to local fallback",
-            );
+            )
+            .0;
         server.abort();
 
         let distributed_merged =
@@ -765,12 +769,15 @@ fn run_merged_series_distributed_equals_local_bitwise() {
                 &accounting,
                 &EngineConfig::default(),
                 i64::MAX,
+                None,
             )
             .await
             .expect("distributed fetch")
         {
             // #348: the frame carries the column; merge the real distributed runs.
-            Some(triple) => merge_soa_runs(triple.0, usize::MAX, usize::MAX).expect("dist merge"),
+            Some((triple, _partials)) => {
+                merge_soa_runs(triple.0, usize::MAX, usize::MAX).expect("dist merge")
+            }
             // Today: refusal -> the engine runs the query locally instead.
             None => {
                 let (runs, _a, _s) = local_scalar(Arc::clone(&store), &snapshot).await;
@@ -825,10 +832,12 @@ async fn distributed_metric_names(
             &accounting,
             &EngineConfig::default(),
             i64::MAX,
+            None,
         )
         .await
         .expect("distributed fetch")
-        .expect("distributed produced a result");
+        .expect("distributed produced a result")
+        .0;
     let merged = merge_soa_runs(triple.0, usize::MAX, usize::MAX).expect("merge");
     server.abort();
     let mut names: Vec<String> = merged
@@ -1029,6 +1038,7 @@ fn coordinator_reenforces_series_budget_over_honest_worker() {
                 &accounting,
                 &config,
                 i64::MAX,
+                None,
             )
             .await
             .expect_err("budget must trip");
@@ -1183,6 +1193,7 @@ fn coordinator_reenforces_bytes_budget_over_lying_worker() {
                 &accounting,
                 &config,
                 i64::MAX,
+                None,
             )
             .await
             .expect_err("coordinator must re-enforce the bytes budget");
@@ -1281,6 +1292,7 @@ fn many_invalidated_slices_map_to_one_retryable_error() {
                 &accounting,
                 &EngineConfig::default(),
                 i64::MAX,
+                None,
             )
             .await
             .expect_err("invalidation must surface as an error");
@@ -1630,6 +1642,7 @@ fn coordinator_fold_saturates_overflowing_worker_reports() {
                 &accounting,
                 &config,
                 i64::MAX,
+                None,
             )
             .await
             .expect_err("a wrapped fold would let the overflowing report through");
@@ -1766,13 +1779,15 @@ fn histogram_series_distributed_equals_local_bitwise() {
                 &accounting,
                 &EngineConfig::default(),
                 i64::MAX,
+                None,
             )
             .await
             .expect("distributed fetch")
             .expect(
                 "a histogram slice is now served over the wire (PROTOCOL_VERSION 3), \
                  not refused to local fallback",
-            );
+            )
+            .0;
         server.abort();
 
         // The distributed histogram runs (triple's third element) equal the local
@@ -1913,6 +1928,7 @@ fn erased_histogram_series_is_dropped_before_the_wire() {
                 &accounting,
                 &EngineConfig::default(),
                 i64::MAX,
+                None,
             )
             .await
             .expect("unsupported must not be an error");
@@ -1920,7 +1936,8 @@ fn erased_histogram_series_is_dropped_before_the_wire() {
             result.is_some(),
             "an erased histogram slice is served (empty), never a local fallback"
         );
-        let (per_slice, _stats, per_slice_hist) = result.expect("a real (non-fallback) result");
+        let ((per_slice, _stats, per_slice_hist), _partials) =
+            result.expect("a real (non-fallback) result");
         assert!(
             per_slice.iter().all(|series| series.is_empty()),
             "the erased histogram series must not surface as a scalar series"
@@ -4685,6 +4702,96 @@ fn count_only_no_window_request_is_byte_identical() {
             got, expected,
             "count-only, no-window partial frames must be byte-identical to the \
              pre-amendment encode"
+        );
+    });
+}
+
+/// A [`SliceFetcher`] double that returns two `PartialAggregate`s carrying the
+/// SAME series id in one slice response. ADR-0103's eligibility gate guarantees
+/// each series lives on exactly one worker, so the coordinator's collect step
+/// must never see a repeat; if it does, the query fails closed rather than
+/// silently keeping one of the two values.
+struct DuplicatePartialWorker;
+
+#[async_trait::async_trait]
+impl SliceFetcher for DuplicatePartialWorker {
+    async fn fetch(&self, _request: pb::FetchRequest) -> Result<SliceResponse, DistribError> {
+        let pa = crate::distrib::codec::PartialAggregate {
+            series_id: SeriesId([7u8; 16]),
+            labels: labels("m0"),
+            count: Some(3),
+            min: None,
+            max: None,
+        };
+        Ok(SliceResponse {
+            scalar: Vec::new(),
+            histogram: Vec::new(),
+            partials: vec![pa.clone(), pa],
+            accounting: QueryAccounting::new().snapshot(),
+            stats: crate::fetcher::FetchStats::default(),
+            series_returned: 0,
+            samples_returned: 0,
+            status: pb::status::Code::Ok,
+            status_message: String::new(),
+        })
+    }
+}
+
+/// ADR-0103 amendment: a duplicate series id across collected partials is a hard
+/// error (fail closed), never last-wins. Mutation proof: neutering the dedup
+/// insert in `Distributed::fetch`'s drain loop (mod.rs, the
+/// `if !partial_series.insert(pa.series_id)` guard) makes this `expect_err`
+/// fail, since the query would then succeed keeping one of the two values.
+#[test]
+fn duplicate_partial_series_id_is_a_hard_error() {
+    let rt = Runtime::new().expect("runtime");
+    rt.block_on(async {
+        let store = Arc::new(MemoryStore::new());
+        let descs = vec![SeriesDesc {
+            metric: "m0".to_string(),
+            samples: vec![(NS, 1.0f64.to_bits())],
+        }];
+        let seg = write_segment(&store, 0, 0, 100, &descs).await;
+        let snapshot = Snapshot {
+            segments: vec![seg],
+            segments_pruned: 0,
+            pending_erasure: Vec::new(),
+        };
+        let distributed = Distributed::new(
+            Arc::new(DuplicatePartialWorker),
+            DistribThresholds {
+                min_store_bytes: 0,
+                min_segments: 0,
+                max_parallel_slices: 1,
+            },
+        );
+        let accounting = QueryAccounting::new();
+        let err = distributed
+            .fetch(
+                TENANT,
+                Signal::Metrics,
+                &snapshot,
+                &[],
+                &[],
+                &accounting,
+                &EngineConfig::default(),
+                i64::MAX,
+                Some(pb::PartialAggregateRequest {
+                    want_count: true,
+                    want_min: false,
+                    want_max: false,
+                    reduce_start_ns: Some(0),
+                    reduce_end_ns: Some(NS),
+                }),
+            )
+            .await
+            .expect_err("a duplicate series id across partials must fail closed");
+        assert!(
+            matches!(
+                err,
+                crate::error::QueryError::DuplicatePushdownSeries { .. }
+            ),
+            "expected DuplicatePushdownSeries, got {err:?}"
         );
     });
 }

--- a/crates/ravel-query/src/engine.rs
+++ b/crates/ravel-query/src/engine.rs
@@ -927,18 +927,22 @@ impl QueryEngine {
                     let accounting = &accounting;
                     let pushdown_target = &pushdown_target;
                     async move {
-                        // This matcher set gets the pushdown request iff it is
-                        // the one eligible target; every other fetches raw with
-                        // `partial_aggregate: None`, byte-identical to today.
-                        let partial_req = pushdown_target.as_ref().and_then(|t| {
-                            (t.matchers == plan.matchers).then_some(pb::PartialAggregateRequest {
-                                want_count: true,
-                                want_min: false,
-                                want_max: false,
-                                reduce_start_ns: Some(t.reduce_start_ns),
-                                reduce_end_ns: Some(t.reduce_end_ns),
-                            })
-                        });
+                        // NOT YET LIVE (T4d): a worker that receives
+                        // `partial_aggregate: Some(..)` returns ONLY the
+                        // partial, no raw runs (`service.rs`'s
+                        // `run_slice_metrics` pushdown branch, pre-existing
+                        // T3/T4a behavior) -- there is no partial state
+                        // between "raw" and "pushed down". Sending this live
+                        // before `MergedSource::query_precomputed_count`
+                        // reads the partial back out (T4d, together with the
+                        // `PROTOCOL_VERSION` bump) would make every eligible
+                        // query silently see zero raw series and no
+                        // consumer of the partial that replaced them: a
+                        // real, empty answer instead of the real count.
+                        // `pushdown_target` above is still computed and
+                        // tested end to end; only sending it is deferred.
+                        let _ = pushdown_target.as_ref();
+                        let partial_req: Option<pb::PartialAggregateRequest> = None;
                         // A selector's segments carry scalar and/or
                         // native-histogram series; fetch both kinds (a series is
                         // one kind for its whole life, so the two sets never
@@ -4904,6 +4908,88 @@ mod prefetch_tests {
             2,
             "one slice dispatched on the initial attempt and once more after \
              exactly one re-resolve"
+        );
+    }
+
+    /// A slice fetcher double that records every `FetchRequest.partial_aggregate`
+    /// it receives and answers with a plain, empty, successful raw response.
+    struct CapturingPartialAggregate {
+        seen: Arc<std::sync::Mutex<Vec<Option<pb::PartialAggregateRequest>>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::distrib::client::SliceFetcher for CapturingPartialAggregate {
+        async fn fetch(
+            &self,
+            request: ravel_proto::queryfrag::v1::FetchRequest,
+        ) -> Result<crate::distrib::client::SliceResponse, crate::distrib::client::DistribError>
+        {
+            self.seen.lock().unwrap().push(request.partial_aggregate);
+            Ok(crate::distrib::client::SliceResponse {
+                scalar: Vec::new(),
+                histogram: Vec::new(),
+                partials: Vec::new(),
+                accounting: ravel_types::accounting::QueryAccountingSnapshot::default(),
+                stats: crate::fetcher::FetchStats::default(),
+                series_returned: 0,
+                samples_returned: 0,
+                status: ravel_proto::queryfrag::v1::status::Code::Ok,
+                status_message: String::new(),
+            })
+        }
+    }
+
+    /// ADR-0103 (epic #64) reachability guard, not just a mechanism test: an
+    /// otherwise fully eligible `count_over_time` query (single segment, no
+    /// federation, plan tagged `count_over_time_pushdown_candidate`) must
+    /// still dispatch `partial_aggregate: None` over the wire, because
+    /// nothing yet consumes a worker's partial-only reply
+    /// (`MergedSource::query_precomputed_count`, T4d). The worker's pushdown
+    /// branch returns the partial INSTEAD OF raw runs once asked -- landing
+    /// the request live without its consumer already produced one silent
+    /// empty-result bug (caught at checkpoint review, never merged). Flip
+    /// `partial_req` in `prefetch`'s per-plan closure back to `Some` without
+    /// wiring the consumer in the same change and this test fails; that is
+    /// the point.
+    #[tokio::test]
+    async fn eligible_count_over_time_does_not_send_partial_aggregate_yet() {
+        let store = Arc::new(MemoryStore::new());
+        let tenant_hash = TenantId::new("acme").hash();
+        publish_metric(
+            &store,
+            tenant_hash,
+            1,
+            "metric_a",
+            BASE_NS - NS_PER_MIN,
+            1.0,
+        )
+        .await;
+
+        let seen = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let distributed = Arc::new(crate::distrib::Distributed::new(
+            Arc::new(CapturingPartialAggregate {
+                seen: Arc::clone(&seen),
+            }),
+            crate::distrib::partition::DistribThresholds {
+                min_store_bytes: 0,
+                min_segments: 0,
+                max_parallel_slices: 1,
+            },
+        ));
+        let eng = engine(Arc::clone(&store)).with_distributed(distributed);
+
+        let mut plan = window_plan("metric_a");
+        plan.count_over_time_pushdown_candidate = true;
+        let eval_window = EvalWindow::Instant { t_ns: BASE_NS };
+        eng.prefetch(tenant_hash, &[plan], &eval_window, &[], BASE_NS)
+            .await
+            .expect("a fully eligible single-segment query must still succeed raw");
+
+        let dispatched = seen.lock().unwrap();
+        assert_eq!(dispatched.len(), 1, "exactly one slice dispatched");
+        assert_eq!(
+            dispatched[0], None,
+            "T4d not landed yet: partial_aggregate must stay None on the wire"
         );
     }
 

--- a/crates/ravel-query/src/engine.rs
+++ b/crates/ravel-query/src/engine.rs
@@ -10,13 +10,14 @@ use std::time::{Duration, Instant};
 
 use futures::stream::{self, StreamExt};
 use promql_parser::parser::{Expr, Offset};
-use ravel_catalog::{Catalog, SegmentRef, Snapshot};
+use ravel_catalog::{Catalog, SegmentRef, ShardGeneration, Snapshot};
 use ravel_object_store::{ObjectStoreBackend, StoreError};
 use ravel_promql::{
     Annotations, Evaluator, FloatHistogram, HistogramSeriesData, LabelMatcher, MatchOp, PlanAnchor,
     SelectorPlan, SeriesData, SeriesSource, SourceError, Span, Value, from_ast_matchers,
     has_or_group, matches_series, ms_to_ns, plan_selectors,
 };
+use ravel_proto::queryfrag::v1 as pb;
 use ravel_segment::ReaderLimits;
 use ravel_types::accounting::{CostEstimate, QueryAccounting, QueryAccountingSnapshot};
 use ravel_types::{
@@ -645,7 +646,11 @@ impl QueryEngine {
         now_ns: i64,
     ) -> Result<(Vec<(SeriesId, LabelSet)>, QueryStats), QueryError> {
         let name_filter = equality_name_filter(matchers);
-        let attempt = |snapshot: Snapshot, accounting: QueryAccounting| async move {
+        // Discovery does not push aggregation down (ADR-0103 is scalar-sample
+        // pushdown), so it ignores the resolve's generation history.
+        let attempt = |snapshot: Snapshot,
+                       _generations: Vec<ShardGeneration>,
+                       accounting: QueryAccounting| async move {
             // The bytes-scanned budget (ADR-0061 decision 1) is enforced
             // inside `fetch_all_series`, once per completed segment fetch, so a
             // labels/series query that matches zero series still evaluates the
@@ -818,6 +823,7 @@ impl QueryEngine {
                 MergedSource {
                     series: Vec::new(),
                     histogram_series: Vec::new(),
+                    precomputed_count: None,
                 },
                 QueryStats::default(),
             ));
@@ -856,7 +862,9 @@ impl QueryEngine {
         // the reference on each retry rather than moving the owned `Vec` out of
         // its environment. The per-plan futures below build owned pairs from it.
         let windows_ref = &windows;
-        let attempt = |snapshot: Snapshot, accounting: QueryAccounting| async move {
+        let attempt = |snapshot: Snapshot,
+                       generations: Vec<ShardGeneration>,
+                       accounting: QueryAccounting| async move {
             // Owned clones, not borrowed slice items: a closure capturing a
             // reference into `plans` through this combinator chain makes
             // rustc infer a fixed (non-higher-ranked) lifetime for the
@@ -867,11 +875,14 @@ impl QueryEngine {
             // Per-plan local result: this selector's raw scalar runs (kept
             // un-merged so cross-cluster federation runs can join the same
             // pool and merge once, below), the merged native-histogram series
-            // (federation contributes no histograms), and the page stats.
+            // (federation contributes no histograms), the page stats, and any
+            // honored ADR-0103 pushdown partials (`Some` only for the single
+            // eligible matcher set; `None` for every other plan).
             type PerPlan = (
                 Vec<Vec<FetchedSeriesSoa>>,
                 Vec<HistogramSeriesData>,
                 FetchStats,
+                Option<Vec<crate::distrib::codec::PartialAggregate>>,
             );
             // Two plans with equal `matchers` fetch byte-identical results
             // off the same snapshot: the fetch is matchers-only with no
@@ -893,11 +904,41 @@ impl QueryEngine {
                     distinct_plans.push(plan.clone());
                 }
             }
+            // ADR-0103 eligibility gate, evaluated ONCE per query over the whole
+            // resolved snapshot's segment set and the generation history THIS
+            // resolve produced (never a per-matcher-set subset, never a
+            // separately-read history). Passing `self.federation.as_deref()`
+            // (not a hardcoded `None`) is load-bearing: `None` here would make
+            // every federated query look eligible, the exact wrong-answer bug
+            // decision 1(a) exists to prevent.
+            let snapshot_eligible = crate::distrib::is_pushdown_eligible(
+                self.federation.as_deref(),
+                &snapshot.segments,
+                &generations,
+            );
+            // The single matcher set (if any) that gets a `count_over_time`
+            // partial-aggregate request, and the reduction window that request
+            // carries. `None` on every query today.
+            let pushdown_target =
+                count_over_time_pushdown_target(plans, eval_window, snapshot_eligible)?;
             let results: Vec<Result<PerPlan, QueryError>> = stream::iter(distinct_plans)
                 .map(|plan| {
                     let snapshot = &snapshot;
                     let accounting = &accounting;
+                    let pushdown_target = &pushdown_target;
                     async move {
+                        // This matcher set gets the pushdown request iff it is
+                        // the one eligible target; every other fetches raw with
+                        // `partial_aggregate: None`, byte-identical to today.
+                        let partial_req = pushdown_target.as_ref().and_then(|t| {
+                            (t.matchers == plan.matchers).then_some(pb::PartialAggregateRequest {
+                                want_count: true,
+                                want_min: false,
+                                want_max: false,
+                                reduce_start_ns: Some(t.reduce_start_ns),
+                                reduce_end_ns: Some(t.reduce_end_ns),
+                            })
+                        });
                         // A selector's segments carry scalar and/or
                         // native-histogram series; fetch both kinds (a series is
                         // one kind for its whole life, so the two sets never
@@ -911,7 +952,7 @@ impl QueryEngine {
                         // fetch charges into -- so the budget bounds the whole
                         // query's scan and cancels it mid-fetch, not after the
                         // merge has already paid for every byte.
-                        let (scalar_fetched, page_stats, hist_fetched) = self
+                        let (scalar_fetched, page_stats, hist_fetched, pushdown_partials) = self
                             .fetch_samples_and_histograms_maybe_distributed(
                                 tenant_hash,
                                 snapshot,
@@ -920,11 +961,17 @@ impl QueryEngine {
                                 max_bytes_scanned,
                                 max_s3_requests,
                                 deadline_unix_ns,
+                                partial_req,
                             )
                             .await?;
                         let histograms =
                             merge_histogram_soa_runs(hist_fetched, max_series, max_samples)?;
-                        Ok::<PerPlan, QueryError>((scalar_fetched, histograms, page_stats))
+                        Ok::<PerPlan, QueryError>((
+                            scalar_fetched,
+                            histograms,
+                            page_stats,
+                            pushdown_partials,
+                        ))
                     }
                 })
                 .buffer_unordered(concurrency)
@@ -959,8 +1006,11 @@ impl QueryEngine {
             let mut all_scalar_runs: Vec<Vec<FetchedSeriesSoa>> = Vec::new();
             let mut combined_histograms: HashMap<LabelSet, HistogramSeriesData> = HashMap::new();
             let mut page_stats = FetchStats::default();
+            // At most one plan (the eligible pushdown target) yields honored
+            // partials; every other yields `None`. Collect the one that did.
+            let mut collected_pushdown: Option<Vec<crate::distrib::codec::PartialAggregate>> = None;
             for r in results {
-                let (scalar_runs, histograms, per_plan_stats) = r?;
+                let (scalar_runs, histograms, per_plan_stats, pushdown_partials) = r?;
                 all_scalar_runs.extend(scalar_runs);
                 for series in histograms {
                     combined_histograms
@@ -969,6 +1019,9 @@ impl QueryEngine {
                 }
                 page_stats.raw_f64_pages += per_plan_stats.raw_f64_pages;
                 page_stats.raw_f64_bytes += per_plan_stats.raw_f64_bytes;
+                if let Some(partials) = pushdown_partials {
+                    collected_pushdown = Some(partials);
+                }
             }
 
             // Cross-cluster federation (ADR-0071): fan each
@@ -1042,11 +1095,34 @@ impl QueryEngine {
             let mut histogram_series: Vec<HistogramSeriesData> =
                 combined_histograms.into_values().collect();
             histogram_series.sort_by(|a, b| a.labels.iter().cmp(b.labels.iter()));
+            // Stash the collected pushdown count table iff a matcher set was
+            // eligible AND its workers honored the request (`collected_pushdown`
+            // is `Some`). An eligible query that fell back to raw fetch leaves
+            // this `None`, so the raw `series` above are used instead. A zero
+            // count maps to the absence of a series here already: only partials
+            // the worker actually returned (with a present count) become rows.
+            //
+            // This field is inert: `MergedSource` does not override
+            // `SeriesSource::query_precomputed_count`, so the T4b fast path
+            // never reads it. T4d adds that override and its reachability test.
+            let precomputed_count = match (&pushdown_target, collected_pushdown) {
+                (Some(target), Some(partials)) => Some(PrecomputedCount {
+                    matchers: target.matchers.clone(),
+                    start_ns: target.reduce_start_ns,
+                    end_ns: target.reduce_end_ns,
+                    counts: partials
+                        .into_iter()
+                        .filter_map(|p| p.count.map(|c| (p.labels, c)))
+                        .collect(),
+                }),
+                _ => None,
+            };
             Ok((
                 (
                     MergedSource {
                         series,
                         histogram_series,
+                        precomputed_count,
                     },
                     fed_warnings,
                     fed_partial,
@@ -1088,7 +1164,7 @@ impl QueryEngine {
         mut attempt: F,
     ) -> Result<(T, QueryStats), QueryError>
     where
-        F: FnMut(Snapshot, QueryAccounting) -> Fut,
+        F: FnMut(Snapshot, Vec<ShardGeneration>, QueryAccounting) -> Fut,
         Fut: std::future::Future<Output = Result<(T, FetchStats), QueryError>>,
     {
         // The catalog term (ADR-0044 decision 3) is the same for both
@@ -1103,7 +1179,7 @@ impl QueryEngine {
         // discarded first attempt's in-flight counts must not bleed into the
         // attempt that actually produced the result.
         let first_accounting = QueryAccounting::new();
-        let first = self
+        let (first, first_generations) = self
             .resolve_bounded(
                 tenant_hash,
                 window,
@@ -1116,13 +1192,13 @@ impl QueryEngine {
         let first_estimate = estimate_cost(&first, fetch_multiplier, catalog_requests);
         let first_segments = first.segments.len() as u64;
         let first_pruned = first.segments_pruned;
-        match attempt(first, first_accounting.clone()).await {
+        match attempt(first, first_generations, first_accounting.clone()).await {
             Err(QueryError::Fetch(FetchError::Store {
                 source: StoreError::NotFound,
                 ..
             })) => {
                 let second_accounting = QueryAccounting::new();
-                let second = self
+                let (second, second_generations) = self
                     .resolve_bounded(
                         tenant_hash,
                         window,
@@ -1135,7 +1211,7 @@ impl QueryEngine {
                 let second_estimate = estimate_cost(&second, fetch_multiplier, catalog_requests);
                 let second_segments = second.segments.len() as u64;
                 let second_pruned = second.segments_pruned;
-                match attempt(second, second_accounting.clone()).await {
+                match attempt(second, second_generations, second_accounting.clone()).await {
                     Err(QueryError::Fetch(FetchError::Store {
                         source: StoreError::NotFound,
                         ..
@@ -1181,10 +1257,15 @@ impl QueryEngine {
         now_ns: i64,
         name_filter: Option<&str>,
         accounting: &QueryAccounting,
-    ) -> Result<Snapshot, QueryError> {
-        let (snapshot, origins) = self
+    ) -> Result<(Snapshot, Vec<ShardGeneration>), QueryError> {
+        // `resolve_pruned_with_generations` returns the shard-generation history
+        // THIS resolve computed its scan set from (ADR-0103 decision 1(b)): the
+        // pushdown eligibility gate reads exactly this copy, never a separately
+        // re-read one, so a generation appended between two reads can never be
+        // visible in the resolved segments while invisible to the gate.
+        let (snapshot, origins, generations) = self
             .catalog
-            .resolve_pruned_with_admission(
+            .resolve_pruned_with_generations(
                 &tenant_hash,
                 Signal::Metrics,
                 window,
@@ -1199,7 +1280,7 @@ impl QueryEngine {
         // 2). Their cost is bounded separately by the request budget
         // checked incrementally during fetch, below.
         segment_admission::admit(&snapshot, &origins, &self.config)?;
-        Ok(snapshot)
+        Ok((snapshot, generations))
     }
 
     /// Fetches every matched series from each snapshot segment in a single
@@ -1303,6 +1384,7 @@ impl QueryEngine {
     /// fetch, which is why an engine that never opts in behaves precisely as
     /// it did before this seam existed.
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments)]
     async fn fetch_samples_and_histograms_maybe_distributed(
         &self,
         tenant_hash: TenantHash,
@@ -1312,14 +1394,24 @@ impl QueryEngine {
         max_bytes_scanned: ByteLimit,
         max_s3_requests: RequestLimit,
         deadline_unix_ns: i64,
+        partial_aggregate: Option<pb::PartialAggregateRequest>,
     ) -> Result<
         (
             Vec<Vec<FetchedSeriesSoa>>,
             FetchStats,
             Vec<Vec<FetchedHistogramSeries>>,
+            // `Some` only when a pushdown request was both sent AND honored by
+            // the distributed workers (an empty inner `Vec` then means a
+            // legitimate zero-series answer, not a fallback). `None` whenever
+            // the raw path ran -- no request, the cost gate declined to
+            // distribute, or a worker forced a local fallback -- so the caller
+            // never mistakes an eligible-but-fell-back query for a pushdown
+            // result and must use the raw samples it also returned.
+            Option<Vec<crate::distrib::codec::PartialAggregate>>,
         ),
         QueryError,
     > {
+        let want_pushdown = partial_aggregate.is_some();
         if let Some(distributed) = &self.distributed {
             // The cost gate reads the same estimate shape the engine already
             // computes (ADR-0044); a single per-segment pass (multiplier 1, no
@@ -1328,7 +1420,7 @@ impl QueryEngine {
             let cost = estimate_cost(snapshot, 1, 0);
             if crate::distrib::partition::should_distribute(distributed.thresholds(), &cost) {
                 let erasure = snapshot_erasure_predicates(snapshot);
-                if let Some(triple) = distributed
+                if let Some((triple, partials)) = distributed
                     .fetch(
                         tenant_hash,
                         Signal::Metrics,
@@ -1338,6 +1430,7 @@ impl QueryEngine {
                         accounting,
                         &self.config,
                         deadline_unix_ns,
+                        partial_aggregate,
                     )
                     .await?
                 {
@@ -1361,7 +1454,14 @@ impl QueryEngine {
                     ) {
                         return Err(err);
                     }
-                    return Ok(triple);
+                    let (scalar, stats, hist) = triple;
+                    // Distinguish "pushdown honored" (workers ran the partial
+                    // request; `scalar` is empty and `partials` is the answer,
+                    // possibly zero series) from "no pushdown asked" (raw runs
+                    // in `scalar`, `partials` empty): only the former yields a
+                    // pushdown result the caller may stash.
+                    let pushdown = want_pushdown.then_some(partials);
+                    return Ok((scalar, stats, hist, pushdown));
                 }
                 // `None`: a worker asked for local fallback (version skew, a
                 // histogram-bearing slice). Fall through to the local path.
@@ -1374,15 +1474,21 @@ impl QueryEngine {
                 // that is the true total cost, not a double-count.
             }
         }
-        self.fetch_all_samples_and_histograms(
-            tenant_hash,
-            snapshot,
-            matchers,
-            accounting,
-            max_bytes_scanned,
-            max_s3_requests,
-        )
-        .await
+        let (scalar, stats, hist) = self
+            .fetch_all_samples_and_histograms(
+                tenant_hash,
+                snapshot,
+                matchers,
+                accounting,
+                max_bytes_scanned,
+                max_s3_requests,
+            )
+            .await?;
+        // The local path has no worker to compute a partial: pushdown is a
+        // distributed-only optimization, so an eligible query that does not trip
+        // the cost gate (or a query with no distributed context at all) simply
+        // fetches raw and returns no pushdown result.
+        Ok((scalar, stats, hist, None))
     }
 
     /// Cross-cluster federation fan-out for the metrics path (ADR-0071, ADR-0096).
@@ -1700,6 +1806,83 @@ fn last_grid_ns(start_ns: i64, end_ns: i64, step_ns: i64) -> Result<i64, QueryEr
         .ok_or(QueryError::TimeOverflow)
 }
 
+/// The single matcher set the coordinator selected for ADR-0103
+/// `count_over_time` pushdown, and the reduction window its
+/// `PartialAggregateRequest` carries.
+#[derive(Debug, Clone, PartialEq)]
+struct PushdownTarget {
+    matchers: Vec<LabelMatcher>,
+    /// Exclusive lower bound of the reduction window (`sel_ts - range`).
+    reduce_start_ns: i64,
+    /// Inclusive upper bound of the reduction window (`sel_ts`).
+    reduce_end_ns: i64,
+}
+
+/// Decide whether ADR-0103 `count_over_time` pushdown applies to this query,
+/// and for which matcher set. Returns the single eligible matcher set's
+/// reduction window, or `None` when no matcher set qualifies. All four of the
+/// amendment's conditions are checked here:
+///
+/// - `EvalWindow::Instant`: a range window evaluates at N steps, each needing
+///   its own sub-window; one whole-fetch partial per series cannot serve more
+///   than one, so a `Range` window is excluded entirely (even a single
+///   effective step -- not special-cased).
+/// - Exactly one pushdown candidate in the whole query (the amendment's
+///   "count_over_time exactly once"): two `count_over_time` occurrences, even
+///   over disjoint matcher sets, disqualify the query, since the collected
+///   result stashes a single table.
+/// - That candidate's matcher set has exactly one consuming plan in the
+///   PRE-DEDUP `plans` slice (the selector-plan-dedup consumer-agreement rule):
+///   a second consumer -- a raw `a` in `count_over_time(a[5m]) + a`, or a
+///   different window in `count_over_time(a[5m]) + count_over_time(a[10m])` --
+///   forces the shared fetch to stay raw.
+/// - `snapshot_eligible`: the resolved-segment/generation gate
+///   ([`crate::distrib::is_pushdown_eligible`]), computed ONCE per query by the
+///   caller over the whole snapshot and passed in, never re-evaluated per plan.
+///
+/// The reduction window is the SAME resolution [`selector_fetch_window`]
+/// performs for the candidate plan against the instant: exclusive start
+/// `sel_ts - range_ns`, inclusive end `sel_ts`, with `sel_ts` the offset/`@`
+/// -resolved instant per the plan's `PlanAnchor`.
+fn count_over_time_pushdown_target(
+    plans: &[SelectorPlan],
+    eval_window: &EvalWindow,
+    snapshot_eligible: bool,
+) -> Result<Option<PushdownTarget>, QueryError> {
+    // Range queries are conservatively excluded in this task.
+    let EvalWindow::Instant { .. } = eval_window else {
+        return Ok(None);
+    };
+    if !snapshot_eligible {
+        return Ok(None);
+    }
+    // "count_over_time exactly once": exactly one candidate plan in the query.
+    let mut candidates = plans
+        .iter()
+        .filter(|p| p.count_over_time_pushdown_candidate);
+    let Some(candidate) = candidates.next() else {
+        return Ok(None);
+    };
+    if candidates.next().is_some() {
+        return Ok(None);
+    }
+    // Consumer agreement: the candidate's matcher set must have exactly one
+    // consuming plan (itself). Matcher equality only, matching `distinct_plans`.
+    let consumers = plans
+        .iter()
+        .filter(|p| p.matchers == candidate.matchers)
+        .count();
+    if consumers != 1 {
+        return Ok(None);
+    }
+    let window = selector_fetch_window(candidate, eval_window)?;
+    Ok(Some(PushdownTarget {
+        matchers: candidate.matchers.clone(),
+        reduce_start_ns: window.start_ns,
+        reduce_end_ns: window.end_ns,
+    }))
+}
+
 /// Translates one selector's plan (`range_ns`/`offset_ns`/`anchor`) into the
 /// concrete window to fetch for it, for either an instant or a range query.
 /// `PlanAnchor::Pinned` is already offset-adjusted and constant regardless
@@ -2001,6 +2184,7 @@ mod name_filter_tests {
             range_ns: 0,
             offset_ns: 0,
             anchor: PlanAnchor::Window,
+            count_over_time_pushdown_candidate: false,
         };
 
         // Same prefix across selectors: shared prefix key.
@@ -2715,9 +2899,42 @@ fn merge_histogram_soa_runs(
 /// native-histogram series), not a materialized per-timestamp window
 /// (docs/query-engine.md / `ravel_promql::source` module doc: by the time
 /// the evaluator runs, everything is plain, synchronous, in-memory data).
+/// The ADR-0103 pushdown result collected on the coordinator: the exact
+/// matcher set and reduction window this count table answers for, plus one
+/// `(labels, count)` per series a worker returned. Populated by
+/// [`QueryEngine::prefetch`] only when a query had an eligible instant
+/// `count_over_time` matcher set; `None` on every other query.
+///
+/// This is inert cargo for now: `MergedSource` does NOT override
+/// `SeriesSource::query_precomputed_count`, so the T4b fast path in
+/// `eval_call` still receives the defaulted `Ok(None)` from every real query
+/// and falls back to the raw path. T4d adds the override plus the reachability
+/// test that makes the fast path actually fire.
+///
+/// Every field is written by `prefetch` but read by nothing until T4d wires
+/// the `query_precomputed_count` override, hence `dead_code` is allowed here
+/// deliberately (removing it once T4d lands is part of that task).
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+struct PrecomputedCount {
+    /// The matcher set this table answers for (the one eligible
+    /// `count_over_time` selector's resolved matchers).
+    matchers: Vec<LabelMatcher>,
+    /// Exclusive lower bound of the reduction window the workers counted over.
+    start_ns: i64,
+    /// Inclusive upper bound of the reduction window.
+    end_ns: i64,
+    /// One per-series count, exactly as the workers reported it.
+    counts: Vec<(LabelSet, u64)>,
+}
+
 struct MergedSource {
     series: Vec<SeriesData>,
     histogram_series: Vec<HistogramSeriesData>,
+    /// ADR-0103 collected pushdown count table (T4d wires the read side).
+    /// Written by `prefetch`, read by nothing until then.
+    #[allow(dead_code)]
+    precomputed_count: Option<PrecomputedCount>,
 }
 
 impl SeriesSource for MergedSource {
@@ -4304,6 +4521,7 @@ mod histogram_source_tests {
         MergedSource {
             series: Vec::new(),
             histogram_series,
+            precomputed_count: None,
         }
     }
 
@@ -4442,6 +4660,7 @@ mod prefetch_tests {
             range_ns: DEFAULT_LOOKBACK_NS,
             offset_ns: 0,
             anchor: PlanAnchor::Window,
+            count_over_time_pushdown_candidate: false,
         }
     }
 
@@ -4897,6 +5116,125 @@ mod prefetch_tests {
         );
     }
 
+    /// ADR-0103 byte-exact reduction window: the `(reduce_start_ns,
+    /// reduce_end_ns)` this task derives for an eligible `count_over_time` must
+    /// equal, to the nanosecond, what the evaluator's own `range_window`
+    /// resolves for the SAME query text and instant. A silent drift here is a
+    /// permanent, gate-undetectable wrong-answer fallback, so this calls the
+    /// real `range_window` (not a hand-computed literal) and covers a nonzero
+    /// `offset`, which gives a different answer if computed from the eval
+    /// instant instead of the offset-resolved selector timestamp.
+    #[test]
+    fn pushdown_reduction_window_is_byte_exact_with_range_window() {
+        for query in [
+            "count_over_time(m[5m])",
+            "count_over_time(m[5m] offset 1h)",
+            "count_over_time(m[10m] offset 30m)",
+        ] {
+            let t_ns = BASE_NS;
+            let t_ms = t_ns / 1_000_000;
+            let plans = plan_selectors(query, t_ms, t_ms).expect("plan");
+            let target =
+                count_over_time_pushdown_target(&plans, &EvalWindow::Instant { t_ns }, true)
+                    .expect("no time overflow")
+                    .expect("an eligible single count_over_time is a target");
+
+            // The real evaluator resolution for the identical query and instant.
+            let expr = promql_parser::parser::parse(query).expect("parse");
+            let promql_parser::parser::Expr::Call(call) = &expr else {
+                panic!("count_over_time is a call");
+            };
+            let arg = ravel_promql::matrix_arg(&call.args.args[0]).expect("matrix arg");
+            let ctx = ravel_promql::QueryWindow::bare(t_ns, t_ns);
+            let rw = ravel_promql::range_window(arg, t_ns, &ctx).expect("range window");
+
+            assert_eq!(
+                target.reduce_start_ns, rw.start_ns,
+                "{query}: exclusive start must match range_window's"
+            );
+            assert_eq!(
+                target.reduce_end_ns, rw.end_ns,
+                "{query}: inclusive end must match range_window's"
+            );
+        }
+    }
+
+    /// ADR-0103 consumer-agreement rule: a matcher set consumed by both a
+    /// pushdown candidate and another plan (`count_over_time(a[5m]) + a`, two
+    /// `SelectorPlan`s sharing one matcher set, only one a candidate) is NOT a
+    /// pushdown target, so it fetches raw exactly as today.
+    #[test]
+    fn shared_matcher_set_with_a_raw_consumer_is_not_a_pushdown_target() {
+        let plans = plan_selectors("count_over_time(a[5m]) + a", 0, 0).expect("plan");
+        // Two plans, both matcher set {a}: one the count_over_time candidate,
+        // one the bare `a`.
+        assert_eq!(plans.len(), 2);
+        let target =
+            count_over_time_pushdown_target(&plans, &EvalWindow::Instant { t_ns: BASE_NS }, true)
+                .expect("no overflow");
+        assert!(
+            target.is_none(),
+            "a matcher set with a second raw consumer stays raw"
+        );
+    }
+
+    /// ADR-0103: a single eligible `count_over_time` over a literal selector IS
+    /// a target, and the four disqualifiers each independently defeat it.
+    #[test]
+    fn pushdown_target_gates() {
+        let single = plan_selectors("count_over_time(m[5m])", 0, 0).expect("plan");
+        let instant = EvalWindow::Instant { t_ns: BASE_NS };
+
+        // The happy path: eligible + instant + single candidate + sole consumer.
+        assert!(
+            count_over_time_pushdown_target(&single, &instant, true)
+                .expect("no overflow")
+                .is_some(),
+            "a lone eligible count_over_time is a target"
+        );
+
+        // Gate 1: the resolved-segment/generation eligibility is false.
+        assert!(
+            count_over_time_pushdown_target(&single, &instant, false)
+                .expect("no overflow")
+                .is_none(),
+            "an ineligible snapshot is never a target"
+        );
+
+        // Gate 2: a range window is excluded entirely.
+        let range = EvalWindow::Range {
+            start_ns: BASE_NS,
+            end_ns: BASE_NS + 60_000_000_000,
+            step_ns: 60_000_000_000,
+        };
+        assert!(
+            count_over_time_pushdown_target(&single, &range, true)
+                .expect("no overflow")
+                .is_none(),
+            "a range query is excluded"
+        );
+
+        // Gate 3: count_over_time appearing more than once (even over disjoint
+        // matcher sets) disqualifies the whole query.
+        let twice =
+            plan_selectors("count_over_time(a[5m]) + count_over_time(b[5m])", 0, 0).expect("plan");
+        assert!(
+            count_over_time_pushdown_target(&twice, &instant, true)
+                .expect("no overflow")
+                .is_none(),
+            "count_over_time must appear exactly once"
+        );
+
+        // Gate 4: a non-candidate call (different function) is never a target.
+        let other = plan_selectors("sum_over_time(m[5m])", 0, 0).expect("plan");
+        assert!(
+            count_over_time_pushdown_target(&other, &instant, true)
+                .expect("no overflow")
+                .is_none(),
+            "sum_over_time is not a candidate"
+        );
+    }
+
     /// ADR-0044: `estimate_cost`'s output must be a genuine upper envelope,
     /// never a prediction -- the actual accounting snapshot recorded by the
     /// same query attempt must never exceed it in any dimension. `divergence`
@@ -5061,6 +5399,7 @@ mod prefetch_tests {
             range_ns: 24 * 60 * NS_PER_MIN,
             offset_ns: 0,
             anchor: PlanAnchor::Window,
+            count_over_time_pushdown_candidate: false,
         }];
         let eval_window = EvalWindow::Instant { t_ns: BASE_NS };
         let (_source, stats) = eng

--- a/crates/ravel-query/src/error.rs
+++ b/crates/ravel-query/src/error.rs
@@ -53,4 +53,8 @@ pub enum QueryError {
         "run carries {priorities} per-sample dedup priorities but {samples} samples; the column must be parallel to the samples"
     )]
     PrioritySampleCountMismatch { priorities: usize, samples: usize },
+    #[error(
+        "aggregation pushdown collected series {series_id} from more than one slice; the ADR-0103 eligibility gate guarantees each series lives on exactly one worker, so a repeat means the gate was violated and the query must fail closed rather than keep one of two partials"
+    )]
+    DuplicatePushdownSeries { series_id: String },
 }

--- a/crates/ravel-query/src/http/error.rs
+++ b/crates/ravel-query/src/http/error.rs
@@ -134,7 +134,13 @@ impl From<QueryError> for ApiError {
             // object contradicts the format's invariants, so it is reported as
             // a server-side fault with a fixed message rather than echoing
             // internal column lengths.
-            | QueryError::PrioritySampleCountMismatch { .. } => {
+            | QueryError::PrioritySampleCountMismatch { .. }
+            // ADR-0103: the same series arrived from two slices under the
+            // pushdown eligibility gate, which guarantees each series lives on
+            // exactly one worker. A repeat is a server-side gate violation the
+            // query fails closed on rather than keeping one of two values; its
+            // message carries only a series id, redacted to the fixed message.
+            | QueryError::DuplicatePushdownSeries { .. } => {
                 ApiError::Unavailable(MSG_UNAVAILABLE.to_string())
             }
         }

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -456,10 +456,16 @@ slice, or on a slice holding native-histogram series (which have no scalar
 count/min/max shape), is refused with `Unsupported` (with the real accounting
 already spent, never dropped) and falls back to raw fetch.
 
-Reachable at the wire/worker layer, not yet from a query: no coordinator sets
-the request field today, so the eligibility gate, the coordinator-side combine,
-the PromQL plan-extraction wiring, and the `PROTOCOL_VERSION` bump ADR-0103
-stages with them are still to come.
+Reachable at the wire/worker layer, not yet from a query: `QueryEngine::prefetch`
+runs the eligibility gate and computes the pushdown target on every real query
+(epic #64 T4c), and the PromQL-side fast path (`SeriesSource::query_precomputed_count`)
+exists as a mechanism (T4b), but the coordinator does not set
+`FetchRequest.partial_aggregate` live yet, because nothing wires the two
+together: `MergedSource` does not yet override `query_precomputed_count` with
+the collected partials. The `PROTOCOL_VERSION` bump lands together with that
+wiring (T4d), not before — the worker's pushdown branch returns a partial
+INSTEAD OF raw runs, so sending the request live without a consumer already
+produced a silent empty-result bug once (caught before merge).
 
 This is the engine-level (queryfrag) fetch, merge, and federation machinery for
 all five signals — shipped and covered by the per-signal differential, erasure,


### PR DESCRIPTION
Runs the ADR-0103 count_over_time pushdown eligibility gate on every
real query, computes the reduction window and the single eligible
pushdown target, and threads a duplicate-series-id hard error through
the distributed fetch path. Adds a plan-time
count_over_time_pushdown_candidate tag in ravel-promql.

The wire opt-in itself stays deferred: prefetch always sends
partial_aggregate: None regardless of the computed target, because a
worker that receives it returns only the partial in place of raw
series, and nothing reads that partial back out until a follow-up
task wires MergedSource::query_precomputed_count. Sending the request
live without that consumer landing in the same commit was caught at
checkpoint review before merge (it silently empties a real, eligible
query's result) and is fixed here by keeping the field unconditionally
None, with an end-to-end test asserting it and PROTOCOL_VERSION left
at 3 until the consumer lands.

Refs: #502
