### PR TITLE
feat(ravel-sql): support LIKE and NOT LIKE on the logs table

### DIFF
--- a/benchmarks/clickbench/hits.corpus.json
+++ b/benchmarks/clickbench/hits.corpus.json
@@ -416,6 +416,102 @@
       ]
     },
     {
+      "id": "q21_count_google_urls",
+      "sql": "SELECT COUNT(*) FROM logs WHERE \"URL\" LIKE '%google%'",
+      "constructs": [
+        "logs -> Signal::Logs",
+        "Filter (WHERE)",
+        "count",
+        "LIKE"
+      ],
+      "expected_rows": 1,
+      "upstream_id": "Q21",
+      "required_declarations": [
+        {
+          "key": "URL",
+          "ty": "str"
+        }
+      ]
+    },
+    {
+      "id": "q22_google_phrase_breakdown",
+      "sql": "SELECT \"SearchPhrase\", MIN(\"URL\"), COUNT(*) AS c FROM logs WHERE \"URL\" LIKE '%google%' AND \"SearchPhrase\" <> '' GROUP BY \"SearchPhrase\" ORDER BY c DESC LIMIT 10",
+      "constructs": [
+        "logs -> Signal::Logs",
+        "Filter (WHERE)",
+        "min",
+        "count",
+        "LIKE",
+        "GROUP BY",
+        "ORDER BY",
+        "LIMIT"
+      ],
+      "upstream_id": "Q22",
+      "required_declarations": [
+        {
+          "key": "URL",
+          "ty": "str"
+        },
+        {
+          "key": "SearchPhrase",
+          "ty": "str"
+        }
+      ]
+    },
+    {
+      "id": "q23_google_title_not_google_url",
+      "sql": "SELECT \"SearchPhrase\", MIN(\"URL\"), MIN(\"Title\"), COUNT(*) AS c, COUNT(DISTINCT \"UserID\") FROM logs WHERE \"Title\" LIKE '%Google%' AND \"URL\" NOT LIKE '%.google.%' AND \"SearchPhrase\" <> '' GROUP BY \"SearchPhrase\" ORDER BY c DESC LIMIT 10",
+      "constructs": [
+        "logs -> Signal::Logs",
+        "Filter (WHERE)",
+        "min",
+        "count",
+        "count(DISTINCT)",
+        "LIKE",
+        "GROUP BY",
+        "ORDER BY",
+        "LIMIT"
+      ],
+      "upstream_id": "Q23",
+      "required_declarations": [
+        {
+          "key": "Title",
+          "ty": "str"
+        },
+        {
+          "key": "URL",
+          "ty": "str"
+        },
+        {
+          "key": "SearchPhrase",
+          "ty": "str"
+        },
+        {
+          "key": "UserID",
+          "ty": "i64"
+        }
+      ]
+    },
+    {
+      "id": "q24_google_urls_by_time",
+      "sql": "SELECT * FROM logs WHERE \"URL\" LIKE '%google%' ORDER BY ts LIMIT 10",
+      "constructs": [
+        "logs -> Signal::Logs",
+        "Projection",
+        "Filter (WHERE)",
+        "LIKE",
+        "ORDER BY",
+        "LIMIT"
+      ],
+      "upstream_id": "Q24",
+      "required_declarations": [
+        {
+          "key": "URL",
+          "ty": "str"
+        }
+      ]
+    },
+    {
       "id": "q25_phrases_by_time",
       "sql": "SELECT \"SearchPhrase\" FROM logs WHERE \"SearchPhrase\" <> '' ORDER BY ts LIMIT 10",
       "constructs": [

--- a/crates/ravel-bench/tests/clickbench_corpus.rs
+++ b/crates/ravel-bench/tests/clickbench_corpus.rs
@@ -37,23 +37,19 @@ fn corpus_path() -> PathBuf {
 const UPSTREAM_COUNT: usize = 43;
 
 /// The ClickBench statements the corpus construct-gate cannot admit, each paired
-/// with the single construct that blocks it. One row per rejected statement; the
-/// distinct missing capability is `LIKE` pattern matching (issue #479) -- see
-/// the runbook's gap list and the issue it references. Q28/Q29 (`length`, issue
-/// #480) moved into the corpus file once `length` was registered as a named
-/// construct.
+/// with the single construct that blocks it. One row per rejected statement.
+///
+/// Now empty: every ClickBench statement Q1..Q43 is in the corpus file. Q21-Q24
+/// (`LIKE` pattern matching, issue #479) moved into the corpus once `LIKE` was
+/// registered as a named construct; Q28/Q29 (`length`, issue #480) moved earlier
+/// once `length` was registered.
 ///
 /// Each named construct MUST be absent from [`supported_construct_names`]
 /// (asserted by [`each_known_gap_names_a_genuinely_unsupported_construct`]): a
 /// gap cannot be claimed for a construct that is actually supported, and if a
 /// construct here later becomes supported this test fails, which is the signal to
 /// move that statement into the corpus file.
-const KNOWN_GAPS: &[(&str, &str)] = &[
-    ("Q21", "LIKE pattern match"),
-    ("Q22", "LIKE pattern match"),
-    ("Q23", "LIKE pattern match"),
-    ("Q24", "LIKE pattern match"),
-];
+const KNOWN_GAPS: &[(&str, &str)] = &[];
 
 #[test]
 fn checked_in_clickbench_corpus_parses_and_passes_the_construct_gate() {

--- a/crates/ravel-sql/src/conformance.rs
+++ b/crates/ravel-sql/src/conformance.rs
@@ -569,6 +569,20 @@ pub fn registry() -> Vec<Construct> {
         });
     }
 
+    // `col LIKE 'pattern'` / `NOT LIKE` substring matching on the `logs` table
+    // (#479), evaluated by the Ravel `like` UDF (crate::like_udf) so a declared
+    // `Str` column's dictionary is matched once per distinct value. Only `body`
+    // is exercised here (a fixed `Utf8` column); the dictionary path is proven in
+    // `tests/logs_provider.rs`. Not pushed down: substring `LIKE` is not a sound
+    // superset of the reader's exact `HasWord`/`Equals` predicates.
+    out.push(Construct {
+        category: Category::Clause,
+        name: "LIKE".to_string(),
+        example: "SELECT count(*) FROM logs WHERE body LIKE '%record 1%'".to_string(),
+        classification: Classification::SupportedAndCovered { test: T_SUPPORTED },
+        rationale: "substring pattern match via the Ravel like UDF (#479)",
+    });
+
     // --- Scalar functions (ADR-0097 decisions 4, 8) ----------------------
     // One representative row per admitted upstream family. The other members
     // of each family stay admitted (they survive build_session's scalar gate,

--- a/crates/ravel-sql/src/lib.rs
+++ b/crates/ravel-sql/src/lib.rs
@@ -61,6 +61,7 @@ pub mod flight;
 #[cfg(feature = "flight-sql")]
 mod flight_ticket;
 mod labels;
+mod like_udf;
 mod logs_provider;
 mod logs_pushdown;
 mod logs_scan;

--- a/crates/ravel-sql/src/like_udf.rs
+++ b/crates/ravel-sql/src/like_udf.rs
@@ -1,0 +1,526 @@
+//! The SQL `col LIKE 'pattern'` / `col NOT LIKE 'pattern'` predicate for the
+//! `logs` table (#479), evaluated by a Ravel-owned scalar UDF instead of
+//! DataFusion's built-in `LIKE`.
+//!
+//! # Why a UDF and a rewrite, not the built-in operator
+//!
+//! A declared `Str` column reaches the query as `Dictionary(Int32, Utf8)`
+//! (ADR-0099 decision 5). DataFusion's built-in `LIKE` coercion casts a
+//! dictionary operand back to one value per row before matching, so a `LIKE`
+//! over a low-cardinality declared column pays a match per row rather than a
+//! match per distinct value, and the dictionary is gone by the time any Ravel
+//! code runs. This is the same wall the `has_word` UDF hit ([`crate::logs_udf`]):
+//! an exact signature makes DataFusion hydrate the dictionary away.
+//!
+//! The fix is the same shape as `has_word`: a [`ScalarUDFImpl`] whose
+//! [`LikeUdf::coerce_types`] leaves a `Dictionary(Int32, Utf8)` first argument
+//! **unchanged** (so no coercing `CAST` hydrates it) while coercing every other
+//! first-argument type, and the second argument, to `Utf8` exactly as the
+//! built-in accepted. A [`FunctionRewrite`] ([`LikeToUdf`]) rewrites every
+//! case-sensitive `Expr::Like` into a call to this UDF. It is registered as a
+//! *function rewrite*, not an analyzer rule, so it runs BEFORE type coercion:
+//! the rewrite sees the original operands (a dictionary still a dictionary), and
+//! coercion then applies [`LikeUdf::coerce_types`] to the UDF call it produced.
+//!
+//! `ILIKE` (`case_insensitive`) is left to the built-in: Ravel's matcher folds
+//! case with ASCII rules only, which would silently diverge from the built-in's
+//! full-Unicode `ILIKE` on non-ASCII input, and ClickBench needs only
+//! case-sensitive `LIKE`. Leaving `ILIKE` native keeps its existing (correct, if
+//! dictionary-hydrating) behavior rather than replacing it with a subtly wrong
+//! one.
+//!
+//! # Two evaluation paths
+//!
+//! - **Dictionary path** for a declared `Str` column's `Dictionary(Int32, Utf8)`
+//!   first argument with a constant pattern: the pattern is matched once per
+//!   DISTINCT dictionary value, then results are gathered by key. A dictionary
+//!   may retain values no surviving row references; matching them is redundant
+//!   but correct, so there is no compaction pass.
+//! - **Row-wise path** for a plain `Utf8` first argument (`body` is a fixed
+//!   `Utf8` column and stays plain), and for the rare non-constant pattern.
+//!
+//! Neither path is a fallback for the other; the array type of the first
+//! argument selects the path.
+//!
+//! # Pushdown
+//!
+//! None. `LIKE` is a substring predicate and the RLOG reader offers only exact
+//! `HasWord` (token/phrase) and `Equals` predicates ([`ravel_logseg::Predicate`]),
+//! neither of which is a sound superset of SQL substring `LIKE`: `LIKE '%foo%'`
+//! matches `"foobar"`, whose only token is `"foobar"`, so a `HasWord{word:"foo"}`
+//! prune (even block-level, widen-only) would drop that block and lose the row.
+//! `LIKE` is therefore evaluated exactly by DataFusion's mandatory `Inexact`
+//! residual over the scanned rows and pushes nothing; [`crate::logs_pushdown`]
+//! recognizes neither `Expr::Like` nor this UDF.
+
+use std::sync::Arc;
+
+use datafusion::arrow::array::{Array, ArrayRef, BooleanArray, DictionaryArray, StringArray};
+use datafusion::arrow::compute::cast;
+use datafusion::arrow::datatypes::{DataType, Int32Type};
+use datafusion::common::DFSchema;
+use datafusion::common::tree_node::Transformed;
+use datafusion::config::ConfigOptions;
+use datafusion::error::{DataFusionError, Result as DFResult};
+use datafusion::logical_expr::expr::ScalarFunction;
+use datafusion::logical_expr::expr_rewriter::FunctionRewrite;
+use datafusion::logical_expr::{
+    ColumnarValue, Expr, Like, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature, Volatility,
+};
+use datafusion::scalar::ScalarValue;
+
+/// The name of the `like` scalar UDF the `LIKE` rewrite produces.
+pub const LIKE_UDF: &str = "like";
+
+/// The default `LIKE` escape character when a statement gives no `ESCAPE`
+/// clause, matching DataFusion's built-in `LIKE` (and Postgres): a backslash
+/// escapes the next character, so `\%` and `\_` are literal `%`/`_`.
+const DEFAULT_ESCAPE: char = '\\';
+
+/// The `col LIKE 'pattern' -> Boolean` (or `NOT LIKE`) scalar UDF.
+///
+/// One instance is built per `Expr::Like` by [`LikeToUdf`], carrying that
+/// predicate's `negated` flag and `ESCAPE` character. The UDF is embedded in the
+/// expression tree directly (never registered by name), so the per-predicate
+/// configuration travels with the call and the session's scalar allowlist
+/// (which gates the *registry*, [`crate::session`]) is unaffected.
+#[derive(Debug, PartialEq, Eq, Hash)]
+struct LikeUdf {
+    signature: Signature,
+    /// `true` for `NOT LIKE`: the per-row match is inverted (a NULL stays NULL).
+    negated: bool,
+    /// The escape character; `None` means [`DEFAULT_ESCAPE`].
+    escape_char: Option<char>,
+}
+
+impl LikeUdf {
+    fn new(negated: bool, escape_char: Option<char>) -> Self {
+        LikeUdf {
+            signature: Signature::user_defined(Volatility::Immutable),
+            negated,
+            escape_char,
+        }
+    }
+}
+
+impl ScalarUDFImpl for LikeUdf {
+    fn name(&self) -> &str {
+        LIKE_UDF
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> DFResult<DataType> {
+        Ok(DataType::Boolean)
+    }
+
+    /// Leave a declared `Str` column's `Dictionary(Int32, Utf8)` first argument
+    /// unchanged so no coercing `CAST` hydrates the dictionary away (the whole
+    /// point; see the module doc). Every other first-argument type, and the
+    /// pattern, coerce to `Utf8` -- exactly what DataFusion's built-in `LIKE`
+    /// accepted, so `LargeUtf8`, `Utf8View` (SQL `VARCHAR`), a NULL literal, a
+    /// dictionary over any other key/value pair, and any other castable type all
+    /// still plan. Coercing the second argument (rather than leaving it verbatim
+    /// and failing at execution) keeps a wrong pattern type a typed *planning*
+    /// error.
+    fn coerce_types(&self, arg_types: &[DataType]) -> DFResult<Vec<DataType>> {
+        if arg_types.len() != 2 {
+            return Err(DataFusionError::Plan(format!(
+                "like() expects 2 arguments, got {}",
+                arg_types.len()
+            )));
+        }
+        let first = match &arg_types[0] {
+            DataType::Dictionary(k, v) if **k == DataType::Int32 && **v == DataType::Utf8 => {
+                arg_types[0].clone()
+            }
+            _ => DataType::Utf8,
+        };
+        Ok(vec![first, DataType::Utf8])
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> DFResult<ColumnarValue> {
+        like_impl(&args.args, self.negated, self.escape_char)
+    }
+}
+
+/// A [`FunctionRewrite`] that turns every case-sensitive `Expr::Like` into a
+/// call to [`LikeUdf`], so the Ravel evaluator (and its dictionary fast path)
+/// runs instead of DataFusion's built-in `LIKE`. Registered per `logs` session
+/// ([`crate::session::build_session`]); it runs before type coercion, so it sees
+/// the original (un-hydrated) operands. `ILIKE` is left untouched (see the
+/// module doc).
+#[derive(Debug)]
+pub(crate) struct LikeToUdf;
+
+impl FunctionRewrite for LikeToUdf {
+    fn name(&self) -> &str {
+        "ravel_logs_like_to_udf"
+    }
+
+    fn rewrite(
+        &self,
+        expr: Expr,
+        _schema: &DFSchema,
+        _config: &ConfigOptions,
+    ) -> DFResult<Transformed<Expr>> {
+        if let Expr::Like(Like {
+            negated,
+            expr: inner,
+            pattern,
+            escape_char,
+            case_insensitive: false,
+        }) = &expr
+        {
+            let udf = Arc::new(ScalarUDF::new_from_impl(LikeUdf::new(
+                *negated,
+                *escape_char,
+            )));
+            let call = Expr::ScalarFunction(ScalarFunction::new_udf(
+                udf,
+                vec![(**inner).clone(), (**pattern).clone()],
+            ));
+            return Ok(Transformed::yes(call));
+        }
+        Ok(Transformed::no(expr))
+    }
+}
+
+/// Evaluate `text LIKE pattern` (or `NOT LIKE`) over `args`. After coercion the
+/// text is `Utf8` (a `StringArray`) or `Dictionary(Int32, Utf8)`, and the
+/// pattern is `Utf8` (scalar or, rarely, an array).
+pub(crate) fn like_impl(
+    args: &[ColumnarValue],
+    negated: bool,
+    escape_char: Option<char>,
+) -> DFResult<ColumnarValue> {
+    if args.len() != 2 {
+        return Err(DataFusionError::Execution(format!(
+            "like() expects 2 arguments, got {}",
+            args.len()
+        )));
+    }
+    let escape = escape_char.unwrap_or(DEFAULT_ESCAPE);
+    let text: ArrayRef = match &args[0] {
+        ColumnarValue::Array(a) => Arc::clone(a),
+        ColumnarValue::Scalar(s) => s.to_array()?,
+    };
+
+    match &args[1] {
+        // The common case: a constant pattern, compiled once. This is where the
+        // dictionary fast path lives.
+        ColumnarValue::Scalar(sv) => {
+            let pattern = scalar_utf8_opt(sv, "like() pattern")?;
+            let matcher = pattern.as_deref().map(|p| LikeMatcher::compile(p, escape));
+            eval_constant_pattern(&text, matcher.as_ref(), negated)
+        }
+        // A per-row (non-constant) pattern: rare, and never a dictionary fast
+        // path. Hydrate the text to plain `Utf8` and match row by row.
+        ColumnarValue::Array(patterns) => {
+            let patterns = patterns
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .ok_or_else(|| {
+                    DataFusionError::Execution("like() pattern column must be Utf8".into())
+                })?;
+            eval_array_pattern(&text, patterns, escape, negated)
+        }
+    }
+}
+
+/// Apply `negated` to a per-row match, preserving SQL NULL (`NOT NULL` is NULL).
+#[inline]
+fn apply_negation(matched: Option<bool>, negated: bool) -> Option<bool> {
+    matched.map(|m| m != negated)
+}
+
+/// Match a constant `matcher` (or a NULL pattern, `None`) against every cell of
+/// `text`. `text` is either a `StringArray` (row-wise path) or a
+/// `Dictionary(Int32, Utf8)` (dictionary path: match once per distinct value).
+fn eval_constant_pattern(
+    text: &ArrayRef,
+    matcher: Option<&LikeMatcher>,
+    negated: bool,
+) -> DFResult<ColumnarValue> {
+    // A NULL pattern makes every comparison NULL (`x LIKE NULL` is NULL), which
+    // NOT LIKE does not flip.
+    let Some(matcher) = matcher else {
+        let out = BooleanArray::from(vec![None; text.len()]);
+        return Ok(ColumnarValue::Array(Arc::new(out)));
+    };
+
+    if let Some(strings) = text.as_any().downcast_ref::<StringArray>() {
+        let out: BooleanArray = (0..strings.len())
+            .map(|i| {
+                let m = if strings.is_null(i) {
+                    None
+                } else {
+                    Some(matcher.matches(strings.value(i)))
+                };
+                apply_negation(m, negated)
+            })
+            .collect();
+        return Ok(ColumnarValue::Array(Arc::new(out)));
+    }
+
+    if let Some(dict) = text.as_any().downcast_ref::<DictionaryArray<Int32Type>>() {
+        let values = dict
+            .values()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .ok_or_else(|| {
+                DataFusionError::Execution("like() dictionary column must have Utf8 values".into())
+            })?;
+        // Match once per distinct value; a NULL value stays NULL.
+        let per_value: Vec<Option<bool>> = (0..values.len())
+            .map(|k| {
+                if values.is_null(k) {
+                    None
+                } else {
+                    Some(matcher.matches(values.value(k)))
+                }
+            })
+            .collect();
+        let keys = dict.keys();
+        let mut out: Vec<Option<bool>> = Vec::with_capacity(dict.len());
+        for i in 0..dict.len() {
+            if dict.is_null(i) {
+                out.push(None);
+                continue;
+            }
+            // A key that resolves to no value is a corrupt column, not a
+            // non-match; error rather than serve a wrong answer on a read path
+            // (mirrors `has_word_impl` and `output.rs`'s `resolve_key`).
+            let key = keys.value(i);
+            let idx = usize::try_from(key).map_err(|_| {
+                DataFusionError::Execution(format!("like() negative dictionary key {key}"))
+            })?;
+            let matched = *per_value.get(idx).ok_or_else(|| {
+                DataFusionError::Execution(format!(
+                    "like() dictionary key {idx} out of range for {} values",
+                    per_value.len()
+                ))
+            })?;
+            out.push(apply_negation(matched, negated));
+        }
+        return Ok(ColumnarValue::Array(Arc::new(BooleanArray::from(out))));
+    }
+
+    Err(DataFusionError::Execution(
+        "like() first argument must be a Utf8 or Dictionary(Int32, Utf8) column".into(),
+    ))
+}
+
+/// Match a per-row `patterns` array against `text`, compiling the matcher for
+/// each row. The text is hydrated to plain `Utf8` first: a per-row pattern is
+/// rare and never worth a dictionary fast path.
+fn eval_array_pattern(
+    text: &ArrayRef,
+    patterns: &StringArray,
+    escape: char,
+    negated: bool,
+) -> DFResult<ColumnarValue> {
+    let hydrated: ArrayRef = if text.data_type() == &DataType::Utf8 {
+        Arc::clone(text)
+    } else {
+        cast(text, &DataType::Utf8)?
+    };
+    let strings = hydrated
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .ok_or_else(|| {
+            DataFusionError::Execution("like() first argument must be castable to Utf8".into())
+        })?;
+    let rows = strings.len();
+    let out: BooleanArray = (0..rows)
+        .map(|i| {
+            let m = if strings.is_null(i) || patterns.is_null(i) {
+                None
+            } else {
+                let matcher = LikeMatcher::compile(patterns.value(i), escape);
+                Some(matcher.matches(strings.value(i)))
+            };
+            apply_negation(m, negated)
+        })
+        .collect();
+    Ok(ColumnarValue::Array(Arc::new(out)))
+}
+
+/// A non-null `Utf8`/`LargeUtf8`/`Utf8View` scalar as an owned string, or `None`
+/// for the corresponding NULL scalar. After coercion the pattern is `Utf8`; the
+/// other string types are accepted defensively.
+fn scalar_utf8_opt(sv: &ScalarValue, what: &str) -> DFResult<Option<String>> {
+    match sv {
+        ScalarValue::Utf8(v) | ScalarValue::LargeUtf8(v) | ScalarValue::Utf8View(v) => {
+            Ok(v.clone())
+        }
+        _ => Err(DataFusionError::Execution(format!(
+            "{what} must be a Utf8 literal"
+        ))),
+    }
+}
+
+/// One element of a compiled `LIKE` pattern.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Elem {
+    /// `%`: matches any sequence of zero or more characters.
+    Any,
+    /// `_`: matches exactly one character.
+    Single,
+    /// A literal character (an escaped `%`/`_`/escape, or an ordinary char).
+    Lit(char),
+}
+
+/// A `LIKE` pattern compiled into a sequence of [`Elem`]s, matched
+/// character-wise (Unicode scalar values, not bytes) and case-sensitively.
+#[derive(Debug)]
+struct LikeMatcher {
+    elems: Vec<Elem>,
+}
+
+impl LikeMatcher {
+    /// Compile `pattern` with `escape` as the escape character. An escape
+    /// followed by any character makes that character a literal; a trailing
+    /// escape with nothing after it is itself literal.
+    fn compile(pattern: &str, escape: char) -> Self {
+        let mut elems = Vec::new();
+        let mut chars = pattern.chars();
+        while let Some(c) = chars.next() {
+            if c == escape {
+                match chars.next() {
+                    Some(n) => elems.push(Elem::Lit(n)),
+                    None => elems.push(Elem::Lit(escape)),
+                }
+            } else if c == '%' {
+                elems.push(Elem::Any);
+            } else if c == '_' {
+                elems.push(Elem::Single);
+            } else {
+                elems.push(Elem::Lit(c));
+            }
+        }
+        LikeMatcher { elems }
+    }
+
+    /// Whether `text` matches the whole pattern. Classic two-pointer wildcard
+    /// match with backtracking to the last `%`, over character slices so
+    /// multi-byte characters count as one for `_`.
+    fn matches(&self, text: &str) -> bool {
+        let text: Vec<char> = text.chars().collect();
+        let elems = &self.elems;
+        let (n, m) = (text.len(), elems.len());
+        let mut i = 0usize; // index into text
+        let mut j = 0usize; // index into elems
+        let mut star_j: Option<usize> = None;
+        let mut star_i = 0usize;
+
+        while i < n {
+            if j < m {
+                match elems[j] {
+                    Elem::Single => {
+                        i += 1;
+                        j += 1;
+                        continue;
+                    }
+                    Elem::Lit(c) => {
+                        if text[i] == c {
+                            i += 1;
+                            j += 1;
+                            continue;
+                        }
+                    }
+                    Elem::Any => {
+                        star_j = Some(j);
+                        star_i = i;
+                        j += 1;
+                        continue;
+                    }
+                }
+            }
+            // A mismatch (or the pattern ran out before the text did): stretch
+            // the most recent `%` by one more character, if there was one.
+            match star_j {
+                Some(sj) => {
+                    j = sj + 1;
+                    star_i += 1;
+                    i = star_i;
+                }
+                None => return false,
+            }
+        }
+        // The text is consumed; the match succeeds iff every remaining pattern
+        // element is a `%` (which can match the empty tail).
+        while j < m && elems[j] == Elem::Any {
+            j += 1;
+        }
+        j == m
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn matches(pattern: &str, text: &str) -> bool {
+        LikeMatcher::compile(pattern, DEFAULT_ESCAPE).matches(text)
+    }
+
+    #[test]
+    fn literal_and_substring_patterns() {
+        assert!(matches("abc", "abc"));
+        assert!(!matches("abc", "abcd"));
+        assert!(matches("%abc%", "xxabcyy"));
+        assert!(matches("%google%", "http://google.com/"));
+        assert!(!matches("%google%", "http://example.com/"));
+        // Bare `%` matches anything, including the empty string.
+        assert!(matches("%", ""));
+        assert!(matches("%", "anything"));
+        // Empty pattern matches only the empty string.
+        assert!(matches("", ""));
+        assert!(!matches("", "x"));
+    }
+
+    #[test]
+    fn like_is_case_sensitive() {
+        // The load-bearing property for ClickBench Q23, which pairs
+        // `Title LIKE '%Google%'` with `URL NOT LIKE '%.google.%'`.
+        assert!(matches("%Google%", "The Google Homepage"));
+        assert!(!matches("%Google%", "the google homepage"));
+        assert!(matches("%.google.%", "www.google.com"));
+        assert!(!matches("%.Google.%", "www.google.com"));
+    }
+
+    #[test]
+    fn underscore_matches_exactly_one_character() {
+        assert!(matches("a_c", "abc"));
+        assert!(!matches("a_c", "ac"));
+        assert!(!matches("a_c", "abbc"));
+        // One multi-byte character is one `_`, not one per byte.
+        assert!(matches("a_c", "aéc"));
+    }
+
+    #[test]
+    fn escaped_wildcards_are_literal() {
+        // `\%` is a literal percent, so this matches only a real `%`.
+        assert!(matches("100\\%", "100%"));
+        assert!(!matches("100\\%", "1000"));
+        // `%\%foo\%%` looks for the literal substring `%foo%`.
+        assert!(matches("%\\%foo\\%%", "bar %foo% baz"));
+        assert!(!matches("%\\%foo\\%%", "bar foo baz"));
+        // `\_` is a literal underscore.
+        assert!(matches("a\\_c", "a_c"));
+        assert!(!matches("a\\_c", "abc"));
+    }
+
+    #[test]
+    fn adjacent_and_trailing_wildcards() {
+        assert!(matches("%%abc%%", "zzabczz"));
+        assert!(matches("abc%", "abcdef"));
+        assert!(matches("%abc", "defabc"));
+        assert!(matches("a%b%c", "axxbyyc"));
+        assert!(!matches("a%b%c", "axxbyy"));
+    }
+}

--- a/crates/ravel-sql/src/session.rs
+++ b/crates/ravel-sql/src/session.rs
@@ -550,6 +550,12 @@ pub fn build_session(
         }
         SessionTable::Logs(provider) => {
             ctx.register_udf(has_word_udf());
+            // Rewrite `col LIKE 'pattern'` into the Ravel `like` UDF (#479) so a
+            // declared `Str` column's dictionary reaches the matcher intact,
+            // matched once per distinct value. Registered as a function rewrite
+            // (runs before type coercion) so it sees the un-hydrated operands;
+            // see `crate::like_udf`.
+            ctx.register_function_rewrite(Arc::new(crate::like_udf::LikeToUdf))?;
             ctx.register_table(LOGS_TABLE, provider)?;
         }
         SessionTable::Spans(provider) => {

--- a/crates/ravel-sql/tests/conformance.rs
+++ b/crates/ravel-sql/tests/conformance.rs
@@ -137,6 +137,9 @@ fn expectation(construct: &Construct) -> Option<Expect> {
         // `dur >= 20`; the sum is 60.
         (Category::Clause, "declared i64 typed comparison") => Some(Expect::Rows(2)),
         (Category::Clause, "declared i64 typed aggregate") => Some(Expect::Scalar(60.0)),
+        // Of the three log bodies ("conformance record 0/1/2"), only the second
+        // contains the substring "record 1".
+        (Category::Clause, "LIKE") => Some(Expect::Scalar(1.0)),
 
         // ADR-0097 decision 8: one representative scalar per admitted family,
         // each result re-derived from its literal inputs.

--- a/crates/ravel-sql/tests/logs_provider.rs
+++ b/crates/ravel-sql/tests/logs_provider.rs
@@ -1167,3 +1167,158 @@ async fn has_word_first_argument_coercion_matrix() {
         "has_word's first argument must be the bare dictionary column; plan was:\n{text}"
     );
 }
+
+/// The #479 acceptance test: `col LIKE 'pattern'` over the `logs` table plans
+/// with NO coercing CAST on a declared `Str` column (its `Dictionary(Int32,
+/// Utf8)` reaches the Ravel `like` UDF intact, matched once per distinct value),
+/// while still planning and answering correctly for every other first-argument
+/// type DataFusion's built-in `LIKE` accepted. The second argument (the pattern)
+/// is coerced to `Utf8` too, so a `LargeUtf8`/`Utf8View` pattern plans rather
+/// than failing at execution.
+///
+/// This runs through the real `logs` session (`build_session`, via
+/// [`logs_session`]), which is where the `LIKE` -> `like` function rewrite is
+/// registered: a bare `SessionContext` would not rewrite `Expr::Like` at all, so
+/// the dictionary fast path and its no-CAST plan would never be exercised. A
+/// unit call into `like_impl` cannot catch the CAST class either -- it is handed
+/// whatever array type the test picks, which is exactly what DataFusion's
+/// coercion was silently changing.
+#[tokio::test]
+async fn like_matrix_plans_without_cast_and_matches_rows() {
+    let store = MemoryStore::new();
+    let resource = vec![("service.name".to_string(), AttrValue::Str("svc".into()))];
+    // `body` (fixed Utf8) and the declared `name` (dictionary) carry the same
+    // low-cardinality text; both substring-contain "timeout" on ts 0 and 2.
+    let rows_spec = [
+        (0i64, "connection timeout"),
+        (1, "ok"),
+        (2, "request timeout"),
+        (3, "fine"),
+    ];
+    let records: Vec<LogRecord> = rows_spec
+        .iter()
+        .map(|(ts, text)| {
+            record_with_resource_and_attrs(
+                &resource,
+                *ts,
+                text,
+                &[("name".to_string(), AttrValue::Str((*text).to_string()))],
+            )
+        })
+        .collect();
+    let seg = write_object(&store, "logs/like-matrix.rlog", &records).await;
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(store);
+    let fetcher = LogSegmentFetcher::new(store);
+    let snapshot = Snapshot {
+        segments: vec![seg],
+        segments_pruned: 0,
+        pending_erasure: Vec::new(),
+    };
+    let provider = LogsTableProvider::new(
+        snapshot,
+        TenantHash([7u8; 16]),
+        fetcher,
+        QueryAccounting::new(),
+    )
+    .with_declared_columns(vec![DeclaredColumn::new("name", DeclaredType::Str)]);
+
+    // The real production `logs` session: this is what registers the LIKE
+    // rewrite. `arrow_cast` is an admitted scalar, so the cast probes plan.
+    let ctx = logs_session(provider).expect("session");
+
+    // (label, WHERE predicate, expected surviving ts values in order).
+    let cases: &[(&str, &str, &[i64])] = &[
+        // --- first-argument (matched column) coercion ---
+        ("Utf8 body", "body LIKE '%timeout%'", &[0, 2]),
+        ("declared Str dictionary", "name LIKE '%timeout%'", &[0, 2]),
+        (
+            "SQL CAST(body AS VARCHAR) -> Utf8View",
+            "CAST(body AS VARCHAR) LIKE '%timeout%'",
+            &[0, 2],
+        ),
+        (
+            "LargeUtf8",
+            "arrow_cast(body, 'LargeUtf8') LIKE '%timeout%'",
+            &[0, 2],
+        ),
+        (
+            "Utf8View",
+            "arrow_cast(body, 'Utf8View') LIKE '%timeout%'",
+            &[0, 2],
+        ),
+        (
+            "Dictionary(Int8, Utf8)",
+            "arrow_cast(name, 'Dictionary(Int8, Utf8)') LIKE '%timeout%'",
+            &[0, 2],
+        ),
+        // Int64 casts to its decimal text ("0".."3"), which contains no
+        // "timeout" substring.
+        ("Int64", "arrow_cast(ts, 'Int64') LIKE '%timeout%'", &[]),
+        // A NULL first argument is never a match (NULL LIKE x is NULL).
+        ("NULL literal", "NULL LIKE '%timeout%'", &[]),
+        // A constant-matching string literal matches every row.
+        (
+            "string literal",
+            "'connection timeout' LIKE '%timeout%'",
+            &[0, 1, 2, 3],
+        ),
+        // --- second-argument (pattern) coercion, which the impl must survive ---
+        (
+            "LargeUtf8 pattern",
+            "body LIKE arrow_cast('%timeout%', 'LargeUtf8')",
+            &[0, 2],
+        ),
+        (
+            "Utf8View pattern",
+            "body LIKE arrow_cast('%timeout%', 'Utf8View')",
+            &[0, 2],
+        ),
+        // A NULL pattern makes every comparison NULL: no surviving rows.
+        ("NULL pattern", "body LIKE NULL", &[]),
+        // NOT LIKE inverts the match (and keeps NULL NULL): the two non-matching
+        // rows survive.
+        ("NOT LIKE", "body NOT LIKE '%timeout%'", &[1, 3]),
+        // Case sensitivity is load-bearing (ClickBench Q23): lowercase pattern
+        // over capitalized text matches nothing.
+        ("case sensitive", "body LIKE '%TIMEOUT%'", &[]),
+    ];
+
+    for (label, predicate, expected) in cases {
+        let sql = format!("SELECT ts FROM logs WHERE {predicate} ORDER BY ts");
+        let df = ctx
+            .sql(&sql)
+            .await
+            .unwrap_or_else(|e| panic!("[{label}] planning failed: {e}"));
+        let batches = df
+            .collect()
+            .await
+            .unwrap_or_else(|e| panic!("[{label}] execution failed: {e}"));
+        let got = ts_sequence(&batches);
+        assert_eq!(
+            got, *expected,
+            "[{label}] `{predicate}` returned unexpected rows"
+        );
+    }
+
+    // The dictionary case must carry NO CAST in the optimized physical plan:
+    // leaving `Dictionary(Int32, Utf8)` intact into the `like` UDF is the whole
+    // point. A `CAST` here is the coercion DataFusion's built-in LIKE would have
+    // inserted over the dictionary argument, defeating the per-distinct-value arm
+    // and hydrating the column to one value per row.
+    let dict_plan = ctx
+        .sql("SELECT ts FROM logs WHERE name LIKE '%timeout%'")
+        .await
+        .expect("plan dict case")
+        .create_physical_plan()
+        .await
+        .expect("physical plan");
+    let text = displayable(dict_plan.as_ref()).indent(true).to_string();
+    assert!(
+        !text.contains("CAST"),
+        "LIKE over the declared dictionary column must carry no coercing CAST; plan was:\n{text}"
+    );
+    assert!(
+        text.contains("like(name@"),
+        "LIKE's matched argument must be the bare dictionary column, not a CAST; plan was:\n{text}"
+    );
+}

--- a/docs/guides/clickbench.md
+++ b/docs/guides/clickbench.md
@@ -185,22 +185,21 @@ runs) is recorded beside the numbers so two runs are comparable or provably not.
 Running a 43-query suite against a supported-construct gate means some queries
 fail the gate rather than return a number. That is the intended outcome: an
 unsupported construct becomes a **named capability gap with a failing query
-attached**, not an omission from a results table. The checked-in corpus holds
-the **39** statements that pass the gate; the **4** below are recorded as known
-gaps (enforced by `crates/ravel-bench/tests/clickbench_corpus.rs`, which fails if
-any of the 43 is neither in the corpus nor listed as a gap).
+attached**, not an omission from a results table. The checked-in corpus now
+holds **all 43** statements; the gap list is empty (enforced by
+`crates/ravel-bench/tests/clickbench_corpus.rs`, which fails if any of the 43 is
+neither in the corpus nor listed as a gap).
 
-| Upstream | Blocking construct | Why | Issue |
-|---|---|---|---|
-| Q21 | `LIKE` pattern match | `WHERE URL LIKE '%google%'` | substring/pattern search |
-| Q22 | `LIKE` pattern match | `WHERE URL LIKE '%google%'` | substring/pattern search |
-| Q23 | `LIKE` pattern match | `LIKE '%Google%'` and `NOT LIKE '%.google.%'` | substring/pattern search |
-| Q24 | `LIKE` pattern match | `WHERE URL LIKE '%google%'` (also `SELECT *`) | substring/pattern search |
+There are currently no known gaps.
 
-**`LIKE` / SQL pattern matching** is not in Ravel's supported construct set.
-Ravel offers token search (`has_word`) and `regexp_replace`, but no `LIKE`
-with `%`/`_` wildcards, which four ClickBench statements depend on. This is a
-genuine engine capability gap, tracked as issue #479.
+**`LIKE` / SQL pattern matching** used to block Q21-Q24 and is now supported
+(issue #479): `col LIKE 'pattern'` / `NOT LIKE` with `%`/`_` wildcards is
+evaluated by the Ravel `like` UDF (`crates/ravel-sql/src/like_udf.rs`), which
+matches a declared `Str` column's dictionary once per distinct value and leaves
+`body` (plain `Utf8`) on a row-wise path. It is case-sensitive and pushes down
+nothing: substring `LIKE` is not a sound superset of the RLOG reader's exact
+`HasWord`/`Equals` predicates, so it is evaluated exactly over the scanned rows.
+Ravel also offers token search (`has_word`) and `regexp_replace`.
 
 Q28/Q29 (`AVG(length(...))`) were also blocked, but that gap was bookkeeping,
 not capability: `length` was already admitted by the SQL engine, just not

--- a/docs/sql-conformance-examples.txt
+++ b/docs/sql-conformance-examples.txt
@@ -62,6 +62,7 @@ Clause / operator	GROUP BY	SELECT series_id, count(value) FROM samples GROUP BY 
 Clause / operator	GROUP BY ordinal	SELECT series_id, count(value) FROM samples GROUP BY 1 ORDER BY series_id
 Clause / operator	HAVING	SELECT series_id, count(value) FROM samples GROUP BY series_id HAVING count(value) > 2
 Clause / operator	IN list	SELECT value FROM samples WHERE value IN (1, 2)
+Clause / operator	LIKE	SELECT count(*) FROM logs WHERE body LIKE '%record 1%'
 Clause / operator	LIMIT	SELECT ts, value FROM samples ORDER BY series_id, ts LIMIT 1
 Clause / operator	OFFSET	SELECT value FROM samples ORDER BY value OFFSET 1
 Clause / operator	ORDER BY	SELECT ts, value FROM samples ORDER BY ts

--- a/docs/sql-conformance.md
+++ b/docs/sql-conformance.md
@@ -54,10 +54,10 @@ and stays conformant.
 
 ## Score
 
-- Supported and covered: 42
+- Supported and covered: 43
 - Intentionally rejected: 68
 - Unclassified / broken: 0
-- **Conformance: 110 / 110 = 100.0%**
+- **Conformance: 111 / 111 = 100.0%**
 
 ## Conformance table
 
@@ -115,6 +115,7 @@ and stays conformant.
 | Clause / operator | `GROUP BY ordinal` | `SELECT series_id, count(value) FROM samples GROUP BY 1 ORDER BY series_id` | Supported and covered | `tests/conformance.rs::supported_constructs_execute` | analytical clause/operator over typed columns (ADR-0090 decision 8) |
 | Clause / operator | `HAVING` | `SELECT series_id, count(value) FROM samples GROUP BY series_id HAVING count(value) > 2` | Supported and covered | `tests/conformance.rs::supported_constructs_execute` | analytical clause/operator over typed columns (ADR-0090 decision 8) |
 | Clause / operator | `IN list` | `SELECT value FROM samples WHERE value IN (1, 2)` | Supported and covered | `tests/conformance.rs::supported_constructs_execute` | analytical clause/operator over typed columns (ADR-0090 decision 8) |
+| Clause / operator | `LIKE` | `SELECT count(*) FROM logs WHERE body LIKE '%record 1%'` | Supported and covered | `tests/conformance.rs::supported_constructs_execute` | substring pattern match via the Ravel like UDF (#479) |
 | Clause / operator | `LIMIT` | `SELECT ts, value FROM samples ORDER BY series_id, ts LIMIT 1` | Supported and covered | `tests/conformance.rs::supported_constructs_execute` | covered by the two-layer differential gate (tests/differential.rs) |
 | Clause / operator | `OFFSET` | `SELECT value FROM samples ORDER BY value OFFSET 1` | Supported and covered | `tests/conformance.rs::supported_constructs_execute` | analytical clause/operator over typed columns (ADR-0090 decision 8) |
 | Clause / operator | `ORDER BY` | `SELECT ts, value FROM samples ORDER BY ts` | Supported and covered | `tests/conformance.rs::supported_constructs_execute` | covered by the two-layer differential gate (tests/differential.rs) |


### PR DESCRIPTION
Closes the last ClickBench gap. **`KNOWN_GAPS` is now `&[]` and all 43 statements are in the corpus** — Q21-Q24 move in, and the gate test that asserts `all 43 = corpus ∪ gaps` passes with an empty gap list.

`col LIKE 'pattern'` and `NOT LIKE` on the `logs` table, via a Ravel-owned `like` scalar UDF (`crates/ravel-sql/src/like_udf.rs`). A `FunctionRewrite` registered per logs session runs **before** type coercion and turns each case-sensitive `Expr::Like` into a UDF call, so it sees the un-hydrated dictionary and the UDF's own `coerce_types` then applies. ILIKE is deliberately left native — ASCII-only case folding would diverge from the built-in's Unicode ILIKE, and ClickBench needs only case-sensitive LIKE.

## No pushdown, deliberately

`ravel_logseg::Predicate` offers only exact `HasWord` (token/phrase) and `Equals`, and neither is a sound superset of a substring match. `LIKE '%foo%'` matches `"foobar"`, whose only token is `"foobar"` — so a `HasWord { word: "foo" }` prune drops that block and loses the row, even block-level and widen-only.

So this ships a correct scan-everything LIKE. Q21-Q24 return correct answers and are simply not pruned. A refused extraction costs a full scan; a wrong one is silent data loss, and those are not comparable risks. Follow-up filed as #514 for a substring-capable predicate in ravel-logseg, with the extraction constraints and the differential-test shape it needs.

## Both coercion walls handled, and verified at the plan

These are the two failure modes that cost epic #360's T5 three review cycles, so the tests target them directly rather than the values.

`coerce_types` leaves a `Dictionary(Int32, Utf8)` first argument verbatim and coerces every other first-argument type **and the pattern** to `Utf8`. That is the narrow path between the two walls: an exact `create_udf` signature would make DataFusion cast the dictionary away before the implementation runs (dead fast path, correct answers), while over-narrowing `coerce_types` to prevent that turns working queries into planning errors.

**Verified locally by mutation, not taken on report.** Forcing the passthrough arm to hydrate (`arg_types[0].clone()` → `DataType::Utf8`) makes the acceptance test fail with the plan printed:

```
LIKE over the declared dictionary column must carry no coercing CAST; plan was:
FilterExec: like(CAST(name@1 AS Utf8), %timeout%), projection=[ts@0]
```

A values-only test passes that mutation — answers are unchanged, only the dictionary path is dead. This is why the assertion is on the optimized plan.

The probe matrix runs each argument type end to end on plan **and** rows: `Utf8`, declared `Dictionary(Int32, Utf8)`, `CAST(body AS VARCHAR)` → `Utf8View` (the case that broke `has_word`), `LargeUtf8`, `Utf8View`, `Dictionary(Int8, Utf8)`, `Int64`, a NULL literal, and a bare string literal. Then second-argument coercion — `LargeUtf8`, `Utf8View`, NULL pattern, `NOT LIKE`, and a case-sensitivity check — which the equivalent `has_word` fix had dropped entirely with no test catching it.

## Gate provenance, stated plainly

Verified locally: the ClickBench corpus gate (3 tests), `logs_provider` (9 tests, both the LIKE and `has_word` matrices), `cargo fmt --all --check`, and the mutation above.

**The full `cargo test -p ravel-server -p ravel-sql --features flight-sql` lane timed out at 10 minutes locally**, so the required checks are its first complete run. That is a moved gate, not a skipped one.

Fixes: #479
