### PR TITLE
docs(adrs): claim ADR-0105 for substring pruning on indexed log fields

### DIFF
--- a/docs/adrs/0105-substring-pruning-for-like.md
+++ b/docs/adrs/0105-substring-pruning-for-like.md
@@ -1,0 +1,3 @@
+# ADR-0105: substring pruning for LIKE on indexed log fields
+
+Status: claimed


### PR DESCRIPTION
Reserve ADR number 0105 on main so parallel epics cannot pick it. Stub only; the full decision text lands after the design approval gate.

Refs: #514