### PR TITLE
feat(ravel-bench): report the per-stage ingest breakdown from ingest_bench

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -445,6 +445,10 @@ jobs:
   #   - ravel-bench --features profiling        (pprof/inferno flamegraph lane)
   #   - ravel-bench --features sql-latency      (ravel-sql; the SQL corpus and
   #                                              its construct gate, ADR-0100)
+  #   - ravel-bench --features stage-timing     (ravel-ingest/stage-timing;
+  #                                              per-stage ingest breakdown,
+  #                                              ADR-0104. RUNS its test, does
+  #                                              not merely compile it)
   #
   # `flight-sql` used to be probed here too. It moved to the `flight-sql` job
   # above, which lints and RUNS it: a compile-only probe let every test behind
@@ -497,6 +501,18 @@ jobs:
         # the step above (same feature set, same target dir).
       - name: Test ravel-bench --features sql-latency
         run: cargo test --locked -p ravel-bench --features sql-latency
+      - name: Check ravel-bench --features stage-timing
+        run: cargo check --locked -p ravel-bench --features stage-timing --all-targets
+        # RUN the stage-timing acceptance test, not merely compile it (ADR-0104
+        # decision 2b). The test drives the default-built `ingest_bench` binary
+        # as a subprocess and asserts it emits the per-stage breakdown, so this
+        # lane proves the shipping binary is reachable, not only that
+        # ravel-ingest compiles the seam. `cargo test` also builds every
+        # consumer bin with the feature on, which is where a cfg-gated
+        # constructor param would break: it proves the CALLERS link, not just
+        # the crate that declares the feature.
+      - name: Test ravel-bench --features stage-timing
+        run: cargo test --locked -p ravel-bench --features stage-timing
 
   # Supply-chain gate. deny.toml encodes an advisory,
   # license, ban, and source policy that `make audit` runs locally but no

--- a/crates/ravel-bench/Cargo.toml
+++ b/crates/ravel-bench/Cargo.toml
@@ -116,6 +116,13 @@ flight-egress = [
 # bench bins wrap their measured region in a sampler when
 # `RAVEL_BENCH_PROFILE_SVG` names an output path (see `src/profiling.rs`).
 profiling = ["dep:pprof"]
+# Per-stage ingest timing (ADR-0104 decision 2b). Off by default: the shipping
+# `ingest_bench` bin compiles and runs in BOTH modes and only emits the
+# stage-breakdown field with this on, so no default gate stops covering the bin
+# and the default build never fails on a cfg-gated seam. Forwards to
+# `ravel-ingest/stage-timing`, which compiles the monotonic `Instant` seam into
+# the metrics/logs actors. Adds no new external dependency.
+stage-timing = ["ravel-ingest/stage-timing"]
 # The ADR-0100 decision 3 SQL corpus (`src/sql_corpus.rs`) and, once #428
 # lands, the `sql_latency_bench` harness that runs it. Off by default: the
 # corpus gate reads `ravel_sql::conformance::registry()`, so it activates the

--- a/crates/ravel-bench/src/bin/ingest_bench.rs
+++ b/crates/ravel-bench/src/bin/ingest_bench.rs
@@ -93,4 +93,19 @@ fn print_human_table(report: &Report) {
         report.visibility_lag_ms.resolved_count,
         report.visibility_lag_ms.unresolved_count
     );
+    #[cfg(feature = "stage-timing")]
+    {
+        let b = &report.stage_breakdown;
+        println!(
+            "  stage harness ns  : decode={} normalize={}",
+            b.harness_stages.decode.total_ns, b.harness_stages.normalize.total_ns
+        );
+        println!(
+            "  stage seam ns     : admit={} route={} merge={} encode={}",
+            b.seam_stages.admit.total_ns,
+            b.seam_stages.route.total_ns,
+            b.seam_stages.merge.total_ns,
+            b.seam_stages.encode.total_ns
+        );
+    }
 }

--- a/crates/ravel-bench/src/generator.rs
+++ b/crates/ravel-bench/src/generator.rs
@@ -216,6 +216,37 @@ pub fn generate_batches(config: &WorkloadConfig) -> Result<Vec<Vec<NormalizedPoi
     Ok(batches)
 }
 
+/// The harness's synthetic "decode" stage (ADR-0104 decision 2, the "harness,
+/// no seam" rows): materialize the structured per-series samples the seed
+/// expands to. This is the bench analogue of decoding a wire request into
+/// structured points; [`normalize_into_batches`] is the normalize half.
+/// `generate_batches` is exactly
+/// `normalize_into_batches(config, generate_decoded(config)?)`, so timing the
+/// two halves separately measures the same fixture work the ingest bench
+/// already does, split at the decode/normalize boundary.
+pub fn generate_decoded(config: &WorkloadConfig) -> Result<Vec<GeneratedSeries>, TypeError> {
+    generate_series(config)
+}
+
+/// The harness's synthetic "normalize" stage (ADR-0104 decision 2): flatten
+/// decoded series into arrival-order [`NormalizedPoint`]s (building each point's
+/// shared `Arc<LabelSet>`) and chunk them into per-request batches with the same
+/// size distribution [`generate_batches`] uses. The normalize half of
+/// [`generate_decoded`].
+pub fn normalize_into_batches(
+    config: &WorkloadConfig,
+    series: Vec<GeneratedSeries>,
+) -> Vec<Vec<NormalizedPoint>> {
+    let mut rng = StdRng::seed_from_u64(config.seed ^ 0xBA7C_BA7C_BA7C_BA7C);
+    let mut rest = interleave(series);
+    let mut batches = Vec::new();
+    while !rest.is_empty() {
+        let take = config.batch_size.sample(&mut rng).min(rest.len());
+        batches.push(rest.drain(..take).collect());
+    }
+    batches
+}
+
 /// Populated buckets per side in the representative native-histogram shape:
 /// 30 per side, 60 total, a mid-range latency-style population.
 pub const HIST_BUCKETS_PER_SIDE: usize = 30;

--- a/crates/ravel-bench/src/ingest.rs
+++ b/crates/ravel-bench/src/ingest.rs
@@ -24,7 +24,7 @@ use ravel_object_store::{ObjectStoreBackend, list_all};
 use ravel_types::{Signal, TenantId, TimeRange};
 use serde::Serialize;
 
-use crate::generator::{BatchSizeDistribution, WorkloadConfig, generate_batches};
+use crate::generator::{BatchSizeDistribution, WorkloadConfig};
 use crate::harness::{StoreKind, store_from_env};
 
 /// Bytes on the wire per logical sample: `ts_ns: i64` + `value: f64`. Used as
@@ -234,6 +234,98 @@ pub struct Report {
     pub logical_bytes: u64,
     pub write_amplification: f64,
     pub visibility_lag_ms: VisibilityReport,
+    /// Per-stage ingest timing (ADR-0104 decision 2b). Present only when the bin
+    /// is built with the `stage-timing` feature; the field is compiled out
+    /// otherwise, so a feature-off run emits valid JSON simply lacking it and
+    /// every consumer (epic #51's `bench_compare`) must treat it as optional.
+    #[cfg(feature = "stage-timing")]
+    pub stage_breakdown: StageBreakdown,
+}
+
+/// Per-stage ingest timing breakdown (ADR-0104 decision 2). Two groups kept
+/// deliberately apart so a `decode`/`normalize` figure the harness timed itself
+/// can never be misread as a seam-reported router/shard stage: `harness_stages`
+/// are the bench's own synthetic decode/normalize (measured before the router,
+/// no seam), `seam_stages` are the four stages the `ravel-ingest/stage-timing`
+/// seam reports (`admit`/`route` in the router, `merge`/`encode` in the shard).
+#[cfg(feature = "stage-timing")]
+#[derive(Serialize)]
+pub struct StageBreakdown {
+    pub harness_stages: HarnessStages,
+    pub seam_stages: SeamStages,
+}
+
+/// The two stages the harness times directly (ADR-0104 decision 2, "harness, no
+/// seam"). Named fields, not a map, so the stage set is exactly these two.
+#[cfg(feature = "stage-timing")]
+#[derive(Serialize)]
+pub struct HarnessStages {
+    pub decode: StageTiming,
+    pub normalize: StageTiming,
+}
+
+/// The four stages the `ravel-ingest` stage-timing seam reports for the metrics
+/// pipeline (`ingest_bench` drives `IngestRouter`). Named fields, not a map, so
+/// the stage set is exactly these four: no missing stage, no extra one.
+#[cfg(feature = "stage-timing")]
+#[derive(Serialize)]
+pub struct SeamStages {
+    pub admit: StageTiming,
+    pub route: StageTiming,
+    pub merge: StageTiming,
+    pub encode: StageTiming,
+}
+
+/// One stage's accumulated nanoseconds and the number of measurements folded
+/// into them.
+#[cfg(feature = "stage-timing")]
+#[derive(Serialize)]
+pub struct StageTiming {
+    pub total_ns: u64,
+    pub samples: u64,
+}
+
+#[cfg(feature = "stage-timing")]
+impl StageBreakdown {
+    /// Assembles the breakdown from the two harness-measured durations and a
+    /// snapshot of the seam accumulator. A seam stage that recorded nothing maps
+    /// to a zero timing rather than being dropped, so a never-wired stage shows
+    /// up as a zero the acceptance test names instead of a silently absent key.
+    fn collect(
+        decode: std::time::Duration,
+        normalize: std::time::Duration,
+        snap: &ravel_ingest::MetricStageSnapshot,
+    ) -> Self {
+        use ravel_ingest::MetricStage;
+        let seam = |stage: MetricStage| match snap.get(stage) {
+            Some(t) => StageTiming {
+                total_ns: t.total_ns,
+                samples: t.samples,
+            },
+            None => StageTiming {
+                total_ns: 0,
+                samples: 0,
+            },
+        };
+        StageBreakdown {
+            harness_stages: HarnessStages {
+                decode: StageTiming {
+                    total_ns: decode.as_nanos() as u64,
+                    samples: 1,
+                },
+                normalize: StageTiming {
+                    total_ns: normalize.as_nanos() as u64,
+                    samples: 1,
+                },
+            },
+            seam_stages: SeamStages {
+                admit: seam(MetricStage::Admit),
+                route: seam(MetricStage::Route),
+                merge: seam(MetricStage::Merge),
+                encode: seam(MetricStage::Encode),
+            },
+        }
+    }
 }
 
 #[derive(Serialize)]
@@ -344,7 +436,24 @@ pub async fn run(config: &IngestBenchConfig) -> Report {
         batch_size: BatchSizeDistribution::fixed(config.batch_size),
         ..WorkloadConfig::default()
     };
-    let batches = generate_batches(&workload).expect("generate workload");
+    // Fixture generation. With `stage-timing` on, split it at the
+    // decode/normalize boundary and time each half directly: these are the
+    // harness's own synthetic decode/normalize (ADR-0104 decision 2, "harness,
+    // no seam"), measured here before the router so they are excluded from the
+    // seam and from the flamegraph below. The batches produced are identical to
+    // `generate_batches`, so the measured ingest path is unchanged either way.
+    #[cfg(not(feature = "stage-timing"))]
+    let batches = crate::generator::generate_batches(&workload).expect("generate workload");
+    #[cfg(feature = "stage-timing")]
+    let (batches, decode_elapsed, normalize_elapsed) = {
+        let decode_start = std::time::Instant::now();
+        let series = crate::generator::generate_decoded(&workload).expect("generate workload");
+        let decode_elapsed = decode_start.elapsed();
+        let normalize_start = std::time::Instant::now();
+        let batches = crate::generator::normalize_into_batches(&workload, series);
+        let normalize_elapsed = normalize_start.elapsed();
+        (batches, decode_elapsed, normalize_elapsed)
+    };
 
     // Start the CPU profiler here, immediately after fixture generation, so the
     // measured region brackets the ingest write path and excludes workload
@@ -558,6 +667,16 @@ pub async fn run(config: &IngestBenchConfig) -> Report {
         depth_report(samples.clone())
     };
 
+    // Snapshot the seam after every strict write has acked and the trailing
+    // flush drained, so admit/route (router) and merge/encode (shard flush)
+    // have all recorded.
+    #[cfg(feature = "stage-timing")]
+    let stage_breakdown = StageBreakdown::collect(
+        decode_elapsed,
+        normalize_elapsed,
+        &router.stage_timings().snapshot(),
+    );
+
     let metrics = router.metrics().snapshot();
     let objects = list_all(store.as_ref(), "")
         .await
@@ -604,6 +723,8 @@ pub async fn run(config: &IngestBenchConfig) -> Report {
         logical_bytes,
         write_amplification,
         visibility_lag_ms: visibility,
+        #[cfg(feature = "stage-timing")]
+        stage_breakdown,
     }
 }
 

--- a/crates/ravel-bench/src/lib.rs
+++ b/crates/ravel-bench/src/lib.rs
@@ -23,3 +23,186 @@ pub mod sql_corpus;
 #[cfg(feature = "sql-latency")]
 pub mod sql_latency;
 pub mod value_shapes;
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use std::path::PathBuf;
+    use std::process::Command;
+
+    /// Locates the shipping `ingest_bench` binary. An integration test would get
+    /// `CARGO_BIN_EXE_ingest_bench`, but this is a lib unit test (its path must
+    /// be `ravel_bench::tests::...`), which does not, so it falls back to
+    /// deriving the path from the test executable's own directory:
+    /// `target/<profile>/deps/<test>` sits one level below the bins in
+    /// `target/<profile>/`. Both the test and the bin are built with the same
+    /// feature set in the same invocation, so this resolves to a binary whose
+    /// `stage-timing` state matches this test's.
+    fn ingest_bench_bin() -> PathBuf {
+        if let Some(p) = option_env!("CARGO_BIN_EXE_ingest_bench") {
+            return PathBuf::from(p);
+        }
+        let mut path = std::env::current_exe().expect("test current_exe");
+        path.pop();
+        if path.ends_with("deps") {
+            path.pop();
+        }
+        path.push("ingest_bench");
+        path
+    }
+
+    /// Runs the real `ingest_bench` binary against an in-process `MemoryStore`
+    /// and returns the JSON report it prints. The bin prints the pretty JSON
+    /// document first and a human table after it, so this reads the first JSON
+    /// value off stdout and ignores the trailing text.
+    fn run_ingest_bench() -> serde_json::Value {
+        let output = Command::new(ingest_bench_bin())
+            .args([
+                "--store",
+                "memory",
+                "--shards",
+                "2",
+                "--target-series",
+                "40",
+                "--points-per-sec",
+                "4000",
+                "--duration-secs",
+                "1",
+                "--batch-size",
+                "40",
+                "--ack-timeout-secs",
+                "20",
+            ])
+            .output()
+            .expect("spawn ingest_bench");
+        assert!(
+            output.status.success(),
+            "ingest_bench exited non-zero: status={:?} stderr={}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        );
+        serde_json::Deserializer::from_slice(&output.stdout)
+            .into_iter::<serde_json::Value>()
+            .next()
+            .expect("some JSON on stdout")
+            .expect("valid JSON report")
+    }
+
+    #[cfg(feature = "stage-timing")]
+    fn total_ns(group: &serde_json::Value, stage: &str) -> u64 {
+        group
+            .get(stage)
+            .and_then(|s| s.get("total_ns"))
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or_else(|| panic!("stage {stage} missing total_ns"))
+    }
+
+    /// Acceptance test (ADR-0104 decision 2b, epic #365 T3): the SHIPPING
+    /// `ingest_bench` binary emits the per-stage breakdown end to end when built
+    /// with the `stage-timing` feature, and emits valid JSON lacking the field
+    /// when built without it. Drives the real binary as a subprocess, not an
+    /// in-process stand-in, so it proves the breakdown is reachable from the
+    /// binary a feature-lane build actually ships, not merely from library code.
+    #[test]
+    fn ingest_bench_emits_stage_breakdown_in_feature_lane() {
+        let report = run_ingest_bench();
+        assert!(report.is_object(), "report must be a JSON object");
+        // Base fields are present regardless of the feature: the breakdown is
+        // additive, it does not replace the report.
+        assert!(
+            report.get("accepted_points").is_some(),
+            "base report field accepted_points must be present"
+        );
+        assert!(
+            report.get("config").is_some(),
+            "base report field config must be present"
+        );
+
+        #[cfg(feature = "stage-timing")]
+        {
+            use std::collections::BTreeSet;
+
+            let breakdown = report
+                .get("stage_breakdown")
+                .expect("stage_breakdown present in the feature build");
+
+            // Harness-timed stages: the key set is EXACTLY {decode, normalize}.
+            // A distinct group from the seam stages, so a harness measurement
+            // can never be misread as a seam-reported one.
+            let harness = breakdown
+                .get("harness_stages")
+                .expect("harness_stages present")
+                .as_object()
+                .expect("harness_stages is an object");
+            let harness_keys: BTreeSet<&str> = harness.keys().map(String::as_str).collect();
+            assert_eq!(
+                harness_keys,
+                BTreeSet::from(["decode", "normalize"]),
+                "harness stage set must be exactly {{decode, normalize}}"
+            );
+
+            // Seam-reported stages: the key set is EXACTLY {admit, route, merge,
+            // encode}. Pinned both ways: every wired stage present, nothing
+            // extra.
+            let seam = breakdown
+                .get("seam_stages")
+                .expect("seam_stages present")
+                .as_object()
+                .expect("seam_stages is an object");
+            let seam_keys: BTreeSet<&str> = seam.keys().map(String::as_str).collect();
+            assert_eq!(
+                seam_keys,
+                BTreeSet::from(["admit", "route", "merge", "encode"]),
+                "seam stage set must be exactly {{admit, route, merge, encode}}"
+            );
+
+            // Every stage recorded a nonzero duration. A missing or unreached
+            // stage shows as a zero here and this names it, unlike a
+            // non-empty-map check that passes with most stages silently
+            // unreported.
+            let harness_val = breakdown.get("harness_stages").expect("harness_stages");
+            for stage in ["decode", "normalize"] {
+                assert!(
+                    total_ns(harness_val, stage) > 0,
+                    "harness stage {stage} recorded a zero duration"
+                );
+            }
+            let seam_val = breakdown.get("seam_stages").expect("seam_stages");
+            let seam_ns: Vec<(&str, u64)> = ["admit", "route", "merge", "encode"]
+                .into_iter()
+                .map(|s| (s, total_ns(seam_val, s)))
+                .collect();
+            for (stage, ns) in &seam_ns {
+                assert!(
+                    *ns > 0,
+                    "seam stage {stage} recorded a zero duration; it is unwired or unreached"
+                );
+            }
+
+            // Each seam stage is measured independently over its own boundary,
+            // so the four nanosecond totals are pairwise distinct. Misattributing
+            // one stage as another (emitting route's duration under the admit
+            // key) leaves the key set and count valid but makes two totals
+            // identical; this catches exactly that, which an exact-key-set check
+            // alone cannot.
+            for i in 0..seam_ns.len() {
+                for j in (i + 1)..seam_ns.len() {
+                    assert_ne!(
+                        seam_ns[i].1, seam_ns[j].1,
+                        "seam stages {} and {} report identical total_ns ({}); a stage is misattributed",
+                        seam_ns[i].0, seam_ns[j].0, seam_ns[i].1
+                    );
+                }
+            }
+        }
+
+        #[cfg(not(feature = "stage-timing"))]
+        {
+            assert!(
+                report.get("stage_breakdown").is_none(),
+                "feature-off build must not emit stage_breakdown; the field is optional for \
+                 consumers and absent without the feature"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Wave 2 of epic #365, ADR-0104 decisions 2b and 5b. The epic's **end-to-end reachability task**: it proves the stage breakdown is emitted by the shipping binary in a real feature lane, not that the pieces work in isolation.

`ingest_bench` gains a `stage_breakdown` field when built with `ravel-bench/stage-timing`, which forwards to `ravel-ingest/stage-timing` (landed in #509 and #511):

```json
"stage_breakdown": {
  "harness_stages": {
    "decode":    { "total_ns": 3385450, "samples": 1 },
    "normalize": { "total_ns": 4321209, "samples": 1 }
  },
  "seam_stages": {
    "admit":  { "total_ns": 1511098,  "samples": 100 },
    "route":  { "total_ns": 11684698, "samples": 100 },
    "merge":  { "total_ns": 12395065, "samples": 200 },
    "encode": { "total_ns": 17065438, "samples": 2 }
  }
}
```

The two groups are structurally separate so a harness-timed stage cannot be mistaken for a seam-reported one. `decode` and `normalize` are the bench's own synthetic work timed before the router, which is why ADR-0104 gives them no seam.

**The bin stays default-built.** With the feature off the field is compiled out entirely and the binary emits valid JSON without it, so consumers, including epic #51's `bench_compare`, must tolerate its absence. Had the breakdown required the feature, either the bin moves behind a flag and every existing default gate stops covering it, or the default build breaks on cfg-gated params.

**The acceptance test drives the real binary.** `ingest_bench_emits_stage_breakdown_in_feature_lane` spawns the shipping `ingest_bench` through `std::process::Command`, locating it via `option_env!("CARGO_BIN_EXE_ingest_bench")` with a `current_exe` fallback since lib tests get no `CARGO_BIN_EXE`, and reads the first JSON value off stdout. Not an in-process stand-in — a crate-level test passes against code no production path builds.

The CI `features` job gains a check step and a **test** step that runs it. `cargo test` builds every consumer bin with the feature on, so it proves the callers link rather than only that `ravel-ingest` compiles.

## The mutation found a hole in the spec

I asked for two things in tension without noticing: pin the exact stage set, and prove failure by *misattributing* a stage rather than deleting a field. **Misattribution leaves the key set intact, so an exact-key-set assertion is blind to it.**

The test carries a pairwise-distinct check on reported `total_ns` instead. Rerouting `admit` to emit route's totals fails with:

```
seam stages admit and route report identical total_ns (10474836); a stage is misattributed
```

General form worth keeping: when a spec names both an assertion and the mutation that must break it, check the assertion can actually observe that mutation.

## Verified locally

Both lanes exit 0. Feature-on asserts the field present with the exact stage set; feature-off asserts it absent — checked that the `cfg` split makes the test non-vacuous in each lane rather than asserting absence in both. `cargo fmt --all --check` clean, `affected-tests.sh -p ravel-bench -p ravel-ingest` 2186 tests green.

Fixes: #506
