### PR TITLE
feat(ravel-sql): intra-segment scan partitioning for logs, gated on the read cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4513,6 +4513,7 @@ dependencies = [
  "proptest",
  "prost",
  "rand 0.10.2",
+ "ravel-cache",
  "ravel-catalog",
  "ravel-codec",
  "ravel-commit",

--- a/crates/ravel-bench/Cargo.toml
+++ b/crates/ravel-bench/Cargo.toml
@@ -74,6 +74,12 @@ arrow-flight = { workspace = true, optional = true }
 # links datafusion 54 with the same version/features, so feature unification
 # resolves this to that same instance rather than a second copy.
 datafusion = { version = "54", default-features = false, features = ["sql"], optional = true }
+# Gated behind `sql-latency`. The logs scan-partitioning scaling bench
+# (`logs_scan_scaling`) wires ADR-0046's read cache into `LogSegmentFetcher` so
+# it can report the object-store request count with and without the cache's
+# single-flight coalescing. Reuses the workspace pin ravel-query/ravel-sql
+# already link; no new external crate enters the workspace.
+ravel-cache = { workspace = true, optional = true }
 # Gated behind `profiling` (off by default). CPU flamegraph lane for the
 # ingest and query bench bins (issue #365). pprof is a NEW external
 # dependency, NOT a workspace pin; its `flamegraph` feature pulls `inferno`
@@ -128,7 +134,7 @@ stage-timing = ["ravel-ingest/stage-timing"]
 # corpus gate reads `ravel_sql::conformance::registry()`, so it activates the
 # same optional `ravel-sql` entry `flight-egress` uses (no second entry, so no
 # second datafusion/arrow activation) and the plain gates never compile it.
-sql-latency = ["dep:ravel-sql", "dep:datafusion"]
+sql-latency = ["dep:ravel-sql", "dep:datafusion", "dep:ravel-cache", "dep:futures"]
 
 [dev-dependencies]
 criterion = { workspace = true }
@@ -240,6 +246,12 @@ required-features = ["sql-latency"]
 bench = false
 
 [[bin]]
+name = "logs_scan_scaling_bench"
+path = "src/bin/logs_scan_scaling_bench.rs"
+required-features = ["sql-latency"]
+bench = false
+
+[[bin]]
 name = "sql_latency_bench"
 path = "src/bin/sql_latency_bench.rs"
 required-features = ["sql-latency"]
@@ -324,6 +336,14 @@ bench = false
 [[test]]
 name = "groupby_scaling_smoke"
 path = "tests/groupby_scaling_smoke.rs"
+bench = false
+
+# The test body is gated on `sql-latency` (empty crate without it), so this
+# entry stays harmless under the default feature set and only exercises the
+# logs scan-partitioning scaling bench under `--features sql-latency`.
+[[test]]
+name = "logs_scan_scaling_smoke"
+path = "tests/logs_scan_scaling_smoke.rs"
 bench = false
 
 [[bench]]

--- a/crates/ravel-bench/src/bin/logs_scan_scaling_bench.rs
+++ b/crates/ravel-bench/src/bin/logs_scan_scaling_bench.rs
@@ -1,0 +1,151 @@
+//! Intra-segment scan-partitioning scaling benchmark (ADR-0102 decision 1,
+//! epic #361 item 1). Thin wrapper around
+//! `ravel_bench::logs_scan_scaling::run`: parses the sweep parameters and
+//! `--store memory|s3` via `ravel_bench::harness` (same convention as
+//! `groupby_scaling_bench`), then prints the report as JSON plus a human table.
+//!
+//! Sweeps DataFusion `target_partitions` (`--target-partitions 1,2,4,8,16`)
+//! over one fixed `logs` scan query and a FEW-segment / MANY-block dataset, so
+//! the undersubscribed case (segment count < target_partitions) this item fixes
+//! is what is measured. Each partition value is run with the read cache wired
+//! and un-wired, so the report shows both the scan fanning out past the segment
+//! count and the object-store GET count (flat with the cache, climbing without
+//! it).
+//!
+//! Report-only: a new standalone measurement tool, not wired into any
+//! production path. Gated on the `sql-latency` feature so the default build
+//! never compiles ravel-sql/datafusion or this bin.
+//!
+//! Run: `cargo run -p ravel-bench --release --features sql-latency \
+//!   --bin logs_scan_scaling_bench -- --store memory`
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::time::Duration;
+
+use clap::Parser;
+use ravel_bench::harness::{StoreKind, store_from_env};
+use ravel_bench::logs_scan_scaling::{LogsScanScalingConfig, Report, run};
+
+#[derive(Parser, Debug)]
+#[command(
+    about = "Intra-segment scan-partitioning scaling benchmark (target_partitions sweep, cache on/off)"
+)]
+struct Args {
+    #[arg(long, value_enum, default_value_t = StoreKind::Memory)]
+    store: StoreKind,
+    /// RLOG objects the tenant is split across. Deliberately small (and smaller
+    /// than the largest `--target-partitions`) so the undersubscribed case is
+    /// exercised.
+    #[arg(long, default_value_t = 2)]
+    segments: usize,
+    /// Records per object. With a small block target this sets the block count
+    /// the striping fans out across.
+    #[arg(long, default_value_t = 4_000)]
+    records_per_object: usize,
+    /// Writer block target. Small so each segment holds many blocks.
+    #[arg(long, default_value_t = 64)]
+    block_target_records: usize,
+    /// Comma-separated DataFusion `target_partitions` values to sweep.
+    #[arg(long, value_delimiter = ',', default_value = "1,2,4,8,16")]
+    target_partitions: Vec<usize>,
+    /// Timed repetitions per combination.
+    #[arg(long, default_value_t = 5)]
+    runs: usize,
+    /// Per-query wall deadline in seconds.
+    #[arg(long, default_value_t = 30)]
+    deadline_secs: u64,
+    /// Small dataset and few partition values for a fast CI-sized run.
+    #[arg(long, default_value_t = false)]
+    smoke: bool,
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() {
+    let args = Args::parse();
+    let config = if args.smoke {
+        LogsScanScalingConfig {
+            deadline: Duration::from_secs(args.deadline_secs),
+            ..LogsScanScalingConfig::smoke(store_from_env(args.store), &args.store.to_string())
+        }
+    } else {
+        LogsScanScalingConfig {
+            store: store_from_env(args.store),
+            store_label: args.store.to_string(),
+            segments: args.segments,
+            records_per_object: args.records_per_object,
+            block_target_records: args.block_target_records,
+            target_partitions: args.target_partitions,
+            runs: args.runs,
+            deadline: Duration::from_secs(args.deadline_secs),
+        }
+    };
+    let report = run(&config).await;
+
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&report).expect("serialize report")
+    );
+    print_human_table(&report);
+}
+
+fn print_human_table(report: &Report) {
+    println!();
+    println!("logs_scan_scaling_bench report");
+    println!("  store               : {}", report.config.store);
+    println!("  cores               : {}", report.config.cores);
+    println!("  profile             : {}", report.config.profile);
+    println!("  query               : {}", report.config.query);
+    println!("  segments            : {}", report.config.segments);
+    println!(
+        "  records_per_object  : {}",
+        report.config.records_per_object
+    );
+    println!(
+        "  block_target_records: {}",
+        report.config.block_target_records
+    );
+    println!("  total_records       : {}", report.config.total_records);
+    println!("  runs per combo      : {}", report.config.runs);
+    println!();
+    println!(
+        "{:>7} | {:>6} | {:>8} | {:>9} | {:>8} | {:>7} | {:>8} | {:>10} | {:>10} | {:>10} | {:>14}",
+        "target",
+        "cache",
+        "scanpart",
+        "nonempty",
+        "segments",
+        "s3_gets",
+        "cachehit",
+        "med (ms)",
+        "min (ms)",
+        "max (ms)",
+        "rows/sec",
+    );
+    println!(
+        "{:->7}-+-{:->6}-+-{:->8}-+-{:->9}-+-{:->8}-+-{:->7}-+-{:->8}-+-{:->10}-+-{:->10}-+-{:->10}-+-{:->14}",
+        "", "", "", "", "", "", "", "", "", "", ""
+    );
+    for c in &report.combos {
+        if let Some(err) = &c.error {
+            println!(
+                "{:>7} | {:>6} | FAILED: {}",
+                c.target_partitions, c.cache_wired, err,
+            );
+            continue;
+        }
+        println!(
+            "{:>7} | {:>6} | {:>8} | {:>9} | {:>8} | {:>7} | {:>8} | {:>10.3} | {:>10.3} | {:>10.3} | {:>14.0}",
+            c.target_partitions,
+            c.cache_wired,
+            c.scan_partitions,
+            c.non_empty_partitions,
+            c.segments_scanned,
+            c.object_store_get_requests,
+            c.cache_hits,
+            c.median_ms,
+            c.min_ms,
+            c.max_ms,
+            c.rows_per_sec,
+        );
+    }
+}

--- a/crates/ravel-bench/src/bin/logs_scan_scaling_bench.rs
+++ b/crates/ravel-bench/src/bin/logs_scan_scaling_bench.rs
@@ -33,10 +33,11 @@ use ravel_bench::logs_scan_scaling::{LogsScanScalingConfig, Report, run};
 struct Args {
     #[arg(long, value_enum, default_value_t = StoreKind::Memory)]
     store: StoreKind,
-    /// RLOG objects the tenant is split across. Deliberately small (and smaller
-    /// than the largest `--target-partitions`) so the undersubscribed case is
-    /// exercised.
-    #[arg(long, default_value_t = 2)]
+    /// RLOG objects the tenant is split across. Smaller than the largest
+    /// `--target-partitions` so the undersubscribed case is exercised, but large
+    /// enough that the planning prune's per-segment serialized await is
+    /// measurable.
+    #[arg(long, default_value_t = 32)]
     segments: usize,
     /// Records per object. With a small block target this sets the block count
     /// the striping fans out across.
@@ -45,8 +46,10 @@ struct Args {
     /// Writer block target. Small so each segment holds many blocks.
     #[arg(long, default_value_t = 64)]
     block_target_records: usize,
-    /// Comma-separated DataFusion `target_partitions` values to sweep.
-    #[arg(long, value_delimiter = ',', default_value = "1,2,4,8,16")]
+    /// Comma-separated DataFusion `target_partitions` values to sweep. Straddle
+    /// `--segments` so the report shows both the un-cached cap binding and the
+    /// cache-wired fan-out continuing past it.
+    #[arg(long, value_delimiter = ',', default_value = "1,8,32,64,128")]
     target_partitions: Vec<usize>,
     /// Timed repetitions per combination.
     #[arg(long, default_value_t = 5)]
@@ -106,6 +109,15 @@ fn print_human_table(report: &Report) {
     );
     println!("  total_records       : {}", report.config.total_records);
     println!("  runs per combo      : {}", report.config.runs);
+    println!();
+    println!(
+        "  planning prune ({} segments, {} blocks): {:.3} ms serial (what \
+         compute_plan_counts pays), {:.3} ms concurrent",
+        report.planning.segments,
+        report.planning.total_blocks,
+        report.planning.serial_ms,
+        report.planning.concurrent_ms,
+    );
     println!();
     println!(
         "{:>7} | {:>6} | {:>8} | {:>9} | {:>8} | {:>7} | {:>8} | {:>10} | {:>10} | {:>10} | {:>14}",

--- a/crates/ravel-bench/src/lib.rs
+++ b/crates/ravel-bench/src/lib.rs
@@ -11,6 +11,8 @@ pub mod generator;
 pub mod groupby_scaling;
 pub mod harness;
 pub mod ingest;
+#[cfg(feature = "sql-latency")]
+pub mod logs_scan_scaling;
 pub mod profiling;
 pub mod pushdown_crossover;
 pub mod query_latency;

--- a/crates/ravel-bench/src/logs_scan_scaling.rs
+++ b/crates/ravel-bench/src/logs_scan_scaling.rs
@@ -1,0 +1,605 @@
+//! Intra-segment scan-partitioning core-count scaling benchmark (ADR-0102
+//! decision 1, epic #361 item 1).
+//!
+//! The sibling of [`crate::groupby_scaling`], aimed at the specific capability
+//! item 1 adds: a `logs` query touching FEWER segments than `target_partitions`
+//! used to pin to at most `segment_count` scan partitions
+//! (`min(target_partitions, segment_count)`), so raising `target_partitions`
+//! past the segment count bought nothing. Block-level striping lets such a query
+//! fan out to `target_partitions`. This bench holds one `logs` query and a fixed
+//! FEW-segment / MANY-block dataset, and sweeps `target_partitions` to show the
+//! scan fanning out past the segment count and the wall time responding.
+//!
+//! It also reports the object-store request count the striping issues, read from
+//! the executed query's `QueryAccounting` (the same source
+//! [`crate::sql_latency`] and [`crate::pushdown_crossover`] use), on both a
+//! cache-wired fetcher and an un-cached one. Striping one segment's blocks
+//! across N partitions turns one sequential whole-object read into N whole-object
+//! reads at the same key; ADR-0046's read cache keys the whole object, so with
+//! the cache wired those N reads coalesce (single-flight) onto ONE GET and the
+//! request count is flat across the sweep, while without it the raw GET count
+//! climbs with the partition count. Both numbers are reported so the checkpoint
+//! review can see the effect and confirm the cache neutralizes it (there is no
+//! ranged block reader here; ADR-0087 decision 3).
+//!
+//! Report-only: it never changes library behavior. Gated on the `sql-latency`
+//! feature, like the other SQL scaling benches.
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use datafusion::physical_plan::{ExecutionPlan, ExecutionPlanProperties};
+use ravel_cache::{Cache, CacheLimits};
+use ravel_catalog::{Catalog, CatalogConfig};
+use ravel_commit::publish::RetryPolicy;
+use ravel_commit::record::NewCommitRecord;
+use ravel_commit::{keys, publish, record};
+use ravel_logseg::{
+    AttrValue, LogRecord, ObjectIdentity, RlogConfig, RlogWriter, stream_attrs_bytes,
+};
+use ravel_object_store::{ObjectStoreBackend, PutOptions};
+use ravel_query::{
+    ByteLimit, CacheFetchError, EngineConfig, LogSegmentFetcher, RequestLimit, SegmentFetcher,
+};
+use ravel_sql::{SpanSegmentFetcher, SqlConfig, SqlExecutor, SqlRequest};
+use ravel_types::accounting::{AccountedOp, QueryAccounting};
+use ravel_types::logstream::log_stream_id;
+use ravel_types::{Signal, TenantHash, TenantId, TimeRange};
+use serde::Serialize;
+use uuid::Uuid;
+
+const NS_PER_HOUR: i64 = 3_600_000_000_000;
+/// Frozen query clock, like [`crate::groupby_scaling`]: every record lands a few
+/// microseconds after the epoch, inside `[0, NOW_NS]` and ingest-hour bucket 0,
+/// so `Catalog::resolve` issues a bounded number of LISTs.
+const NOW_NS: i64 = 4 * NS_PER_HOUR;
+
+/// The one query the sweep measures: a bare projection scan (no aggregation), so
+/// the scan node's partition fan-out drives the parallelism directly rather than
+/// being masked by a downstream aggregate.
+pub const QUERY: &str = "SELECT ts, body FROM logs";
+
+const SCOPE_NAME: &str = "logs-scan-scaling-bench";
+const SCOPE_VERSION: &str = "1.0";
+
+/// Inputs for one scaling run.
+pub struct LogsScanScalingConfig {
+    pub store: Arc<dyn ObjectStoreBackend>,
+    pub store_label: String,
+    /// RLOG objects the tenant is split across. Deliberately SMALL (and smaller
+    /// than the largest swept `target_partitions`) so the run exercises the
+    /// undersubscribed case this item fixes.
+    pub segments: usize,
+    /// Records per object. With [`block_target_records`](Self::block_target_records)
+    /// small, this sets how many blocks each segment carries, which is the pool
+    /// the striping fans out across.
+    pub records_per_object: usize,
+    /// Writer block target. Small so each segment holds many blocks.
+    pub block_target_records: usize,
+    /// Swept `target_partitions` values (fed through `fetch_concurrency`).
+    pub target_partitions: Vec<usize>,
+    /// Timed repetitions per combination; the first is the cold run whose
+    /// accounting counters are reported.
+    pub runs: usize,
+    pub deadline: Duration,
+}
+
+impl LogsScanScalingConfig {
+    /// A cheap fixture for the acceptance test and CI.
+    pub fn smoke(store: Arc<dyn ObjectStoreBackend>, store_label: &str) -> Self {
+        LogsScanScalingConfig {
+            store,
+            store_label: store_label.to_string(),
+            segments: 2,
+            records_per_object: 300,
+            block_target_records: 16,
+            target_partitions: vec![1, 4, 8],
+            runs: 2,
+            deadline: Duration::from_secs(30),
+        }
+    }
+}
+
+#[derive(Serialize)]
+pub struct ReportConfig {
+    pub store: String,
+    pub query: String,
+    pub segments: usize,
+    pub records_per_object: usize,
+    pub block_target_records: usize,
+    pub total_records: usize,
+    pub target_partitions: Vec<usize>,
+    pub runs: usize,
+    pub cores: usize,
+    pub profile: String,
+}
+
+/// One `(target_partitions x cache)` measurement. Every non-axis field is read
+/// from the real plan or the executed query, never echoed from the request.
+#[derive(Serialize)]
+pub struct ComboResult {
+    pub target_partitions: usize,
+    /// Whether ADR-0046's read cache was wired into the logs fetcher.
+    pub cache_wired: bool,
+    /// Observed: the `LogsScanExec` node's declared output partition count in the
+    /// real physical plan. Under block-level striping (ADR-0102) this is
+    /// `target_partitions` even when the segment count is smaller -- the whole
+    /// point of the item, read from the plan rather than recomputed.
+    pub scan_partitions: usize,
+    /// Observed: partitions of the scan that actually decoded blocks, from
+    /// `SqlStats`/metrics via a drained execution -- see `non_empty_partitions`.
+    /// The capability check: this exceeds the segment count in the
+    /// undersubscribed case.
+    pub non_empty_partitions: usize,
+    /// Segments the resolved snapshot scanned.
+    pub segments_scanned: usize,
+    pub blocks_total: u64,
+    pub blocks_scanned: u64,
+    /// Object-store GET requests the cold run issued (`QueryAccounting`). The
+    /// number this deliverable exists to report: with the cache wired it is flat
+    /// across the sweep (whole-object reads coalesce on one key); un-cached it
+    /// climbs with the partition count.
+    pub object_store_get_requests: u64,
+    /// Cache hits/misses the cold run recorded (zero when un-cached).
+    pub cache_hits: u64,
+    pub cache_misses: u64,
+    pub object_store_bytes: u64,
+    pub result_rows: usize,
+    pub runs_taken: usize,
+    pub min_ms: f64,
+    pub median_ms: f64,
+    pub max_ms: f64,
+    pub stddev_ms: f64,
+    pub samples_ms: Vec<f64>,
+    /// Scanned records per second, from `total_records` and the median latency.
+    pub rows_per_sec: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+impl ComboResult {
+    fn failed(
+        target_partitions: usize,
+        cache_wired: bool,
+        scan_partitions: usize,
+        error: String,
+    ) -> Self {
+        ComboResult {
+            target_partitions,
+            cache_wired,
+            scan_partitions,
+            non_empty_partitions: 0,
+            segments_scanned: 0,
+            blocks_total: 0,
+            blocks_scanned: 0,
+            object_store_get_requests: 0,
+            cache_hits: 0,
+            cache_misses: 0,
+            object_store_bytes: 0,
+            result_rows: 0,
+            runs_taken: 0,
+            min_ms: 0.0,
+            median_ms: 0.0,
+            max_ms: 0.0,
+            stddev_ms: 0.0,
+            samples_ms: Vec::new(),
+            rows_per_sec: 0.0,
+            error: Some(error),
+        }
+    }
+}
+
+#[derive(Serialize)]
+pub struct Report {
+    pub config: ReportConfig,
+    pub combos: Vec<ComboResult>,
+}
+
+fn percentile(sorted_ns: &[u64], pct: f64) -> u64 {
+    if sorted_ns.is_empty() {
+        return 0;
+    }
+    let rank = ((sorted_ns.len() - 1) as f64 * pct).round() as usize;
+    sorted_ns[rank.min(sorted_ns.len() - 1)]
+}
+
+fn stddev_ns(samples_ns: &[u64]) -> f64 {
+    if samples_ns.len() < 2 {
+        return 0.0;
+    }
+    let n = samples_ns.len() as f64;
+    let mean = samples_ns.iter().map(|&v| v as f64).sum::<f64>() / n;
+    let variance = samples_ns
+        .iter()
+        .map(|&v| {
+            let d = v as f64 - mean;
+            d * d
+        })
+        .sum::<f64>()
+        / (n - 1.0);
+    variance.sqrt()
+}
+
+/// The `LogsScanExec` node's declared output partition count in `plan`, read
+/// from the real plan, so the recorded value proves the requested
+/// `target_partitions` reached the scan. 0 if no `LogsScanExec` is present.
+fn scan_partition_count(plan: &Arc<dyn ExecutionPlan>) -> usize {
+    if plan.name() == "LogsScanExec" {
+        return plan.output_partitioning().partition_count();
+    }
+    plan.children()
+        .into_iter()
+        .map(scan_partition_count)
+        .max()
+        .unwrap_or(0)
+}
+
+/// The `LogsScanExec` node in `plan`, if any.
+fn find_logs_scan(plan: &Arc<dyn ExecutionPlan>) -> Option<Arc<dyn ExecutionPlan>> {
+    if plan.name() == "LogsScanExec" {
+        return Some(Arc::clone(plan));
+    }
+    plan.children().into_iter().find_map(find_logs_scan)
+}
+
+fn build_profile() -> &'static str {
+    if cfg!(debug_assertions) {
+        "debug"
+    } else {
+        "release"
+    }
+}
+
+fn available_cores() -> usize {
+    std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1)
+}
+
+/// Build the few-segment / many-block dataset, then sweep every
+/// `(target_partitions x cache)` combination, returning the full report.
+pub async fn run(config: &LogsScanScalingConfig) -> Report {
+    let store = Arc::clone(&config.store);
+    let tenant = TenantId::new(format!("bench-tenant-{}", Uuid::new_v4()));
+    let tenant_hash = tenant.hash();
+
+    let total_records = publish_dataset(store.as_ref(), &tenant, config).await;
+
+    let mut combos = Vec::with_capacity(config.target_partitions.len() * 2);
+    for &tp in &config.target_partitions {
+        for cache_wired in [false, true] {
+            let result = run_combo(
+                Arc::clone(&store),
+                tenant_hash,
+                tp,
+                cache_wired,
+                config.runs,
+                config.deadline,
+                total_records,
+            )
+            .await;
+            combos.push(result);
+        }
+    }
+
+    Report {
+        config: ReportConfig {
+            store: config.store_label.clone(),
+            query: QUERY.to_string(),
+            segments: config.segments,
+            records_per_object: config.records_per_object,
+            block_target_records: config.block_target_records,
+            total_records,
+            target_partitions: config.target_partitions.clone(),
+            runs: config.runs,
+            cores: available_cores(),
+            profile: build_profile().to_string(),
+        },
+        combos,
+    }
+}
+
+/// One `(target_partitions, cache_wired)` measurement.
+#[allow(clippy::too_many_arguments)]
+async fn run_combo(
+    store: Arc<dyn ObjectStoreBackend>,
+    tenant_hash: TenantHash,
+    target_partitions: usize,
+    cache_wired: bool,
+    runs: usize,
+    deadline: Duration,
+    total_records: usize,
+) -> ComboResult {
+    let engine = EngineConfig {
+        max_series: usize::MAX,
+        max_samples: usize::MAX,
+        max_bytes_scanned: ByteLimit::Unlimited,
+        max_s3_requests: RequestLimit::Unlimited,
+        fetch_concurrency: target_partitions.max(1),
+        ..EngineConfig::default()
+    };
+    let sql_config = SqlConfig {
+        engine,
+        ..SqlConfig::default()
+    };
+
+    // A fresh catalog and a fresh (optionally cache-wired) logs fetcher per
+    // combination, so the cold run genuinely pays the object-store traffic and
+    // cache misses a warm repeat would elide.
+    let catalog = match Catalog::new(Arc::clone(&store), CatalogConfig::default()) {
+        Ok(c) => Arc::new(c),
+        Err(e) => return ComboResult::failed(target_partitions, cache_wired, 0, e.to_string()),
+    };
+    let mut logs_fetcher = LogSegmentFetcher::new(Arc::clone(&store));
+    if cache_wired {
+        // Big enough to hold every object with room to spare, so the striping's
+        // repeated whole-object reads coalesce onto cache hits.
+        let cache: Cache<CacheFetchError> = Cache::new(CacheLimits::new(1 << 30, 1 << 20, 1 << 30));
+        logs_fetcher = logs_fetcher.with_cache(Arc::new(cache));
+    }
+    let executor = SqlExecutor::new(
+        Arc::clone(&catalog),
+        SegmentFetcher::new(Arc::clone(&store)),
+        logs_fetcher,
+        SpanSegmentFetcher::new(Arc::clone(&store)),
+        sql_config,
+        1 << 30,
+    );
+
+    let window = TimeRange {
+        start_ns: 0,
+        end_ns: NOW_NS,
+    };
+    let request = || SqlRequest {
+        sql: QUERY.to_string(),
+        window,
+        min_tokens: Vec::new(),
+        now_ns: NOW_NS,
+        deadline,
+    };
+
+    // Observe the physical plan's scan fan-out before the timed runs. Planning
+    // does not execute, so it is always available even if execution later fails.
+    let accounting = QueryAccounting::new();
+    let snapshot = match catalog
+        .resolve(&tenant_hash, Signal::Logs, window, &[], NOW_NS)
+        .await
+    {
+        Ok(s) => s,
+        Err(e) => return ComboResult::failed(target_partitions, cache_wired, 0, e.to_string()),
+    };
+    let planned = match executor
+        .plan_pinned(tenant_hash, snapshot, QUERY, &accounting, &[])
+        .await
+    {
+        Ok(p) => p,
+        Err(e) => return ComboResult::failed(target_partitions, cache_wired, 0, e.to_string()),
+    };
+    let plan = match planned.create_physical_plan().await {
+        Ok(p) => p,
+        Err(e) => return ComboResult::failed(target_partitions, cache_wired, 0, e.to_string()),
+    };
+    let scan_partitions = scan_partition_count(&plan);
+
+    // Cold run: its accounting is the informative one (it pays the GETs and
+    // cache misses a warm repeat elides), and its metrics give the non-empty
+    // partition count. Any execution error fails only this combination.
+    let cold = match executor.execute(tenant_hash, &request()).await {
+        Ok(outcome) => outcome,
+        Err(e) => {
+            return ComboResult::failed(
+                target_partitions,
+                cache_wired,
+                scan_partitions,
+                e.to_string(),
+            );
+        }
+    };
+    let result_rows = cold.output.num_rows();
+    let segments_scanned = cold.stats.segments;
+    let blocks_total = cold.stats.blocks_total;
+    let blocks_scanned = cold.stats.blocks_scanned;
+    let acc = &cold.accounting;
+    let object_store_get_requests = acc.s3_requests(AccountedOp::Get);
+    let cache_hits = acc.cache_hits;
+    let cache_misses = acc.cache_misses;
+    let object_store_bytes = acc.total_s3_bytes();
+
+    // Drive the LogsScanExec node's own partitions to count how many actually
+    // emit rows -- the capability check (exceeds the segment count when
+    // undersubscribed). Driven directly on the scan node so plan-level
+    // repartition/coalesce above it cannot mask the scan's real fan-out.
+    let non_empty_partitions = match count_non_empty_scan_partitions(&plan).await {
+        Ok(n) => n,
+        Err(e) => {
+            return ComboResult::failed(target_partitions, cache_wired, scan_partitions, e);
+        }
+    };
+
+    let mut latencies_ns = Vec::with_capacity(runs.max(1));
+    for _ in 0..runs.max(1) {
+        let start = Instant::now();
+        let outcome = match executor.execute(tenant_hash, &request()).await {
+            Ok(outcome) => outcome,
+            Err(e) => {
+                return ComboResult::failed(
+                    target_partitions,
+                    cache_wired,
+                    scan_partitions,
+                    e.to_string(),
+                );
+            }
+        };
+        latencies_ns.push(start.elapsed().as_nanos() as u64);
+        assert_eq!(
+            outcome.output.num_rows(),
+            result_rows,
+            "logs scan result row count is deterministic across runs"
+        );
+    }
+    let runs_taken = latencies_ns.len();
+    latencies_ns.sort_unstable();
+
+    let median_ns = percentile(&latencies_ns, 0.50);
+    let min_ns = latencies_ns.first().copied().unwrap_or(0);
+    let max_ns = latencies_ns.last().copied().unwrap_or(0);
+    let stddev = stddev_ns(&latencies_ns);
+    let samples_ms = latencies_ns.iter().map(|&ns| ns as f64 / 1e6).collect();
+    let rows_per_sec = if median_ns == 0 {
+        0.0
+    } else {
+        total_records as f64 / (median_ns as f64 / 1e9)
+    };
+
+    ComboResult {
+        target_partitions,
+        cache_wired,
+        scan_partitions,
+        non_empty_partitions,
+        segments_scanned,
+        blocks_total,
+        blocks_scanned,
+        object_store_get_requests,
+        cache_hits,
+        cache_misses,
+        object_store_bytes,
+        result_rows,
+        runs_taken,
+        min_ms: min_ns as f64 / 1e6,
+        median_ms: median_ns as f64 / 1e6,
+        max_ms: max_ns as f64 / 1e6,
+        stddev_ms: stddev / 1e6,
+        samples_ms,
+        rows_per_sec,
+        error: None,
+    }
+}
+
+/// Drive the `LogsScanExec` node's own partitions to exhaustion and count how
+/// many emitted at least one row. Executed directly on the scan node so a
+/// repartition/coalesce above it in the plan cannot mask the scan's fan-out.
+/// Returns 0 if the plan carries no `LogsScanExec`.
+async fn count_non_empty_scan_partitions(plan: &Arc<dyn ExecutionPlan>) -> Result<usize, String> {
+    use datafusion::execution::TaskContext;
+    use futures::StreamExt;
+
+    let Some(scan) = find_logs_scan(plan) else {
+        return Ok(0);
+    };
+    let ctx = Arc::new(TaskContext::default());
+    let partitions = scan.output_partitioning().partition_count();
+    let mut non_empty = 0;
+    for p in 0..partitions {
+        let mut stream = scan
+            .execute(p, Arc::clone(&ctx))
+            .map_err(|e| format!("execute scan partition {p}: {e}"))?;
+        let mut rows = 0usize;
+        while let Some(next) = stream.next().await {
+            rows += next
+                .map_err(|e| format!("drain scan partition {p}: {e}"))?
+                .num_rows();
+        }
+        if rows > 0 {
+            non_empty += 1;
+        }
+    }
+    Ok(non_empty)
+}
+
+/// The single stream this dataset uses; small on purpose so every record shares
+/// one `LogStreamId` and the fan-out is purely block-level, not stream-level.
+fn resource() -> Vec<(String, AttrValue)> {
+    vec![(
+        "service.name".to_string(),
+        AttrValue::Str("api".to_string()),
+    )]
+}
+
+/// Write `config.segments` RLOG objects, each carrying `records_per_object`
+/// records under `config.block_target_records`-record blocks, and publish each
+/// one's commit record so a real `Catalog::resolve` finds it. Returns the total
+/// record count the query scans.
+async fn publish_dataset(
+    store: &dyn ObjectStoreBackend,
+    tenant: &TenantId,
+    config: &LogsScanScalingConfig,
+) -> usize {
+    let segments = config.segments.max(1);
+    let per_object = config.records_per_object.max(1);
+    let tenant_hash = tenant.hash();
+    let cfg = RlogConfig {
+        block_target_records: config.block_target_records.max(1),
+        ..RlogConfig::default()
+    };
+    let mut total = 0usize;
+    let mut ts = 1_000i64;
+    for obj_idx in 0..segments {
+        let writer_seq = (obj_idx + 1) as u64;
+        let writer_id = Uuid::from_u128(0x5200_0100 + obj_idx as u128);
+        let identity = ObjectIdentity {
+            tenant_hash: tenant_hash.0,
+            shard: 0,
+            writer_id: *writer_id.as_bytes(),
+            writer_epoch: 1,
+            writer_seq,
+        };
+        let mut writer = RlogWriter::new(cfg, identity);
+        let res = resource();
+        let stream_id = log_stream_id(&res, SCOPE_NAME, SCOPE_VERSION, &[]);
+        let stream_attrs = stream_attrs_bytes(&res, SCOPE_NAME, SCOPE_VERSION, &[]);
+        let mut min = i64::MAX;
+        let mut max = i64::MIN;
+        for _ in 0..per_object {
+            min = min.min(ts);
+            max = max.max(ts);
+            writer
+                .push(LogRecord {
+                    stream_id,
+                    stream_attrs: stream_attrs.clone(),
+                    ts_ns: ts,
+                    observed_ts_ns: ts,
+                    severity_num: 9,
+                    severity_text: "INFO".to_string(),
+                    body: format!("request {ts} ok"),
+                    trace_id: None,
+                    span_id: None,
+                    flags: 0,
+                    attrs: Vec::new(),
+                })
+                .expect("push record");
+            ts += 1_000;
+            total += 1;
+        }
+        let bytes = writer.finish().expect("finish object");
+        let new_record = NewCommitRecord {
+            tenant_hash,
+            signal: Signal::Logs,
+            shard: 0,
+            writer_id,
+            writer_epoch: 1,
+            writer_seq,
+            object_size: bytes.len() as u64,
+            content_hash: [0u8; 32],
+            sample_count: per_object as u64,
+            series_count: 1,
+            min_event_ts_ns: min,
+            max_event_ts_ns: max,
+            min_ingest_ts_ns: min,
+            max_ingest_ts_ns: max,
+            segment_format_version: 1,
+            created_unix_ns: 10,
+            ingest_hour_bucket: 0,
+        };
+        let rec = record::build(new_record).expect("valid commit record");
+        let data_key = keys::reconstruct_data_key(&rec).expect("data key");
+        store
+            .put(&data_key, bytes::Bytes::from(bytes), PutOptions::default())
+            .await
+            .expect("put data object");
+        publish::publish(store, &rec, &RetryPolicy::default())
+            .await
+            .expect("publish");
+    }
+    total
+}

--- a/crates/ravel-bench/src/logs_scan_scaling.rs
+++ b/crates/ravel-bench/src/logs_scan_scaling.rs
@@ -10,17 +10,37 @@
 //! FEW-segment / MANY-block dataset, and sweeps `target_partitions` to show the
 //! scan fanning out past the segment count and the wall time responding.
 //!
-//! It also reports the object-store request count the striping issues, read from
-//! the executed query's `QueryAccounting` (the same source
-//! [`crate::sql_latency`] and [`crate::pushdown_crossover`] use), on both a
-//! cache-wired fetcher and an un-cached one. Striping one segment's blocks
-//! across N partitions turns one sequential whole-object read into N whole-object
-//! reads at the same key; ADR-0046's read cache keys the whole object, so with
-//! the cache wired those N reads coalesce (single-flight) onto ONE GET and the
-//! request count is flat across the sweep, while without it the raw GET count
-//! climbs with the partition count. Both numbers are reported so the checkpoint
-//! review can see the effect and confirm the cache neutralizes it (there is no
-//! ranged block reader here; ADR-0087 decision 3).
+//! The fan-out is gated on ADR-0046's read cache
+//! (`LogSegmentFetcher::has_cache`, the precondition ADR-0102 decision 1 names):
+//! a cache-wired fetcher gets `target_partitions` partitions, an un-cached one
+//! keeps the old `min(target_partitions, segment_count)` bound. So this bench
+//! sweeps every `target_partitions` value on BOTH a cache-wired and an un-cached
+//! fetcher, and the two sides answer different questions: the cached side shows
+//! how far the scan fans out past the segment count and what the wall time does,
+//! the un-cached side shows the request count staying put once the cap binds.
+//!
+//! It also reports the object-store request count each combination issues, read
+//! from the executed query's `QueryAccounting` (the same source
+//! [`crate::sql_latency`] and [`crate::pushdown_crossover`] use). The fetch unit
+//! is the whole object (ADR-0087 decision 3: no ranged block reader), so every
+//! partition owning blocks in a segment issues its own whole-object read at that
+//! segment's key. Un-cached, the partition count is capped at the segment count,
+//! so raising `target_partitions` past that changes nothing. Cache-wired, the
+//! partition count keeps climbing and those repeated reads are what ADR-0046's
+//! single-flight cache absorbs.
+//!
+//! Every request-count figure in this report is a measurement of THIS fixture --
+//! a `MemoryStore`, this segment/block/partition shape, a cache sized to hold the
+//! whole dataset with no eviction -- and not a general "no amplification" result
+//! about striping. Cache size, eviction, object size, and store latency all move
+//! it.
+//!
+//! Finally it reports the cost of the planning prune itself
+//! ([`PlanningLatency`]): `ravel_sql`'s `compute_plan_counts` awaits
+//! [`LogSegmentFetcher::plan_segment`] once per segment, sequentially, before any
+//! partition drains a block. That serialization is invisible at two or three
+//! segments, so this measures it over the fixture's full segment set and reports
+//! the serial wall time next to the same prunes issued concurrently.
 //!
 //! Report-only: it never changes library behavior. Gated on the `sql-latency`
 //! feature, like the other SQL scaling benches.
@@ -40,7 +60,8 @@ use ravel_logseg::{
 };
 use ravel_object_store::{ObjectStoreBackend, PutOptions};
 use ravel_query::{
-    ByteLimit, CacheFetchError, EngineConfig, LogSegmentFetcher, RequestLimit, SegmentFetcher,
+    ByteLimit, CacheFetchError, EngineConfig, LogQuery, LogSegmentFetcher, RequestLimit,
+    SegmentFetcher,
 };
 use ravel_sql::{SpanSegmentFetcher, SqlConfig, SqlExecutor, SqlRequest};
 use ravel_types::accounting::{AccountedOp, QueryAccounting};
@@ -67,9 +88,11 @@ const SCOPE_VERSION: &str = "1.0";
 pub struct LogsScanScalingConfig {
     pub store: Arc<dyn ObjectStoreBackend>,
     pub store_label: String,
-    /// RLOG objects the tenant is split across. Deliberately SMALL (and smaller
-    /// than the largest swept `target_partitions`) so the run exercises the
-    /// undersubscribed case this item fixes.
+    /// RLOG objects the tenant is split across. Smaller than the largest swept
+    /// `target_partitions` so the run exercises the undersubscribed case this
+    /// item fixes, but large enough that the planning prune's per-segment
+    /// serialized await ([`PlanningLatency`]) is measurable rather than lost in
+    /// noise.
     pub segments: usize,
     /// Records per object. With [`block_target_records`](Self::block_target_records)
     /// small, this sets how many blocks each segment carries, which is the pool
@@ -87,16 +110,24 @@ pub struct LogsScanScalingConfig {
 
 impl LogsScanScalingConfig {
     /// A cheap fixture for the acceptance test and CI.
+    ///
+    /// 32 segments, not the 2 this started at: at two segments the planning
+    /// prune's per-segment serialized await is a rounding error, so the
+    /// [`PlanningLatency`] figure said nothing. The swept partition counts
+    /// straddle the segment count on both sides (1 below it, 32 at it, 64 above
+    /// it) so the report shows the un-cached cap binding and the cached fan-out
+    /// continuing past it. Objects stay small (96 records, 6 blocks each) to keep
+    /// the run cheap despite the segment count.
     pub fn smoke(store: Arc<dyn ObjectStoreBackend>, store_label: &str) -> Self {
         LogsScanScalingConfig {
             store,
             store_label: store_label.to_string(),
-            segments: 2,
-            records_per_object: 300,
+            segments: 32,
+            records_per_object: 96,
             block_target_records: 16,
-            target_partitions: vec![1, 4, 8],
+            target_partitions: vec![1, 32, 64],
             runs: 2,
-            deadline: Duration::from_secs(30),
+            deadline: Duration::from_secs(60),
         }
     }
 }
@@ -124,8 +155,10 @@ pub struct ComboResult {
     pub cache_wired: bool,
     /// Observed: the `LogsScanExec` node's declared output partition count in the
     /// real physical plan. Under block-level striping (ADR-0102) this is
-    /// `target_partitions` even when the segment count is smaller -- the whole
-    /// point of the item, read from the plan rather than recomputed.
+    /// `target_partitions` when the cache is wired, even where the segment count
+    /// is smaller -- the whole point of the item -- and
+    /// `min(target_partitions, segment_count)` when it is not. Read from the plan
+    /// rather than recomputed.
     pub scan_partitions: usize,
     /// Observed: partitions of the scan that actually decoded blocks, from
     /// `SqlStats`/metrics via a drained execution -- see `non_empty_partitions`.
@@ -137,9 +170,12 @@ pub struct ComboResult {
     pub blocks_total: u64,
     pub blocks_scanned: u64,
     /// Object-store GET requests the cold run issued (`QueryAccounting`). The
-    /// number this deliverable exists to report: with the cache wired it is flat
-    /// across the sweep (whole-object reads coalesce on one key); un-cached it
-    /// climbs with the partition count.
+    /// number this deliverable exists to report. Un-cached, the partition count
+    /// is capped at the segment count, so this stops moving once
+    /// `target_partitions` reaches that cap. Cache-wired, the partition count
+    /// keeps climbing and the repeated whole-object reads at one key are what
+    /// single-flight absorbs. A figure for THIS fixture only, not a general
+    /// result (see the module doc).
     pub object_store_get_requests: u64,
     /// Cache hits/misses the cold run recorded (zero when un-cached).
     pub cache_hits: u64,
@@ -190,9 +226,32 @@ impl ComboResult {
     }
 }
 
+/// The planning prune's cost, measured directly against the same call
+/// `ravel_sql`'s `compute_plan_counts` makes
+/// ([`LogSegmentFetcher::plan_segment`], one per segment).
+///
+/// `compute_plan_counts` awaits those prunes SEQUENTIALLY, once per query,
+/// before any partition drains its first block, so this latency sits on the
+/// critical path of every partition. `serial_ms` is that loop; `concurrent_ms`
+/// is the same prunes issued together, i.e. what the serialization costs. Both
+/// use a fresh un-cached fetcher, so neither is served warm by the other.
+#[derive(Serialize)]
+pub struct PlanningLatency {
+    /// Segments pruned, i.e. how many serialized awaits the figure covers.
+    pub segments: usize,
+    /// Surviving blocks the prunes counted, summed over segments.
+    pub total_blocks: usize,
+    /// Wall time of the per-segment sequential loop `compute_plan_counts` runs.
+    pub serial_ms: f64,
+    /// Wall time of the same prunes awaited concurrently.
+    pub concurrent_ms: f64,
+}
+
 #[derive(Serialize)]
 pub struct Report {
     pub config: ReportConfig,
+    /// What the per-segment serialized planning prune costs on this fixture.
+    pub planning: PlanningLatency,
     pub combos: Vec<ComboResult>,
 }
 
@@ -266,6 +325,8 @@ pub async fn run(config: &LogsScanScalingConfig) -> Report {
 
     let total_records = publish_dataset(store.as_ref(), &tenant, config).await;
 
+    let planning = measure_planning_latency(Arc::clone(&store), tenant_hash).await;
+
     let mut combos = Vec::with_capacity(config.target_partitions.len() * 2);
     for &tp in &config.target_partitions {
         for cache_wired in [false, true] {
@@ -296,7 +357,76 @@ pub async fn run(config: &LogsScanScalingConfig) -> Report {
             cores: available_cores(),
             profile: build_profile().to_string(),
         },
+        planning,
         combos,
+    }
+}
+
+/// Time the planning prune both ways: the per-segment sequential loop
+/// `ravel_sql`'s `compute_plan_counts` runs, and the same prunes awaited
+/// concurrently. Each uses its own un-cached fetcher so neither reads bytes the
+/// other warmed.
+async fn measure_planning_latency(
+    store: Arc<dyn ObjectStoreBackend>,
+    tenant_hash: TenantHash,
+) -> PlanningLatency {
+    let window = TimeRange {
+        start_ns: 0,
+        end_ns: NOW_NS,
+    };
+    let catalog = Catalog::new(Arc::clone(&store), CatalogConfig::default()).expect("catalog");
+    let snapshot = catalog
+        .resolve(&tenant_hash, Signal::Logs, window, &[], NOW_NS)
+        .await
+        .expect("resolve snapshot");
+    let segments = snapshot.segments;
+    let query = LogQuery::new(0, NOW_NS);
+
+    let serial_fetcher = LogSegmentFetcher::new(Arc::clone(&store));
+    let accounting = QueryAccounting::new();
+    let start = Instant::now();
+    let mut total_blocks = 0usize;
+    for seg in &segments {
+        let planned = serial_fetcher
+            .plan_segment(seg, tenant_hash, &query, &accounting)
+            .await
+            .expect("plan segment");
+        if let Some((survivors, _)) = planned {
+            total_blocks += survivors;
+        }
+    }
+    let serial = start.elapsed();
+
+    let concurrent_fetcher = LogSegmentFetcher::new(store);
+    let accounting = QueryAccounting::new();
+    let start = Instant::now();
+    let planned = futures::future::join_all(segments.iter().map(|seg| {
+        let fetcher = concurrent_fetcher.clone();
+        let query = query.clone();
+        let accounting = accounting.clone();
+        async move {
+            fetcher
+                .plan_segment(seg, tenant_hash, &query, &accounting)
+                .await
+                .expect("plan segment")
+        }
+    }))
+    .await;
+    let concurrent = start.elapsed();
+    assert_eq!(
+        planned
+            .iter()
+            .filter_map(|p| p.as_ref().map(|(s, _)| *s))
+            .sum::<usize>(),
+        total_blocks,
+        "both planning passes must prune to the same surviving-block count"
+    );
+
+    PlanningLatency {
+        segments: segments.len(),
+        total_blocks,
+        serial_ms: serial.as_secs_f64() * 1e3,
+        concurrent_ms: concurrent.as_secs_f64() * 1e3,
     }
 }
 
@@ -580,7 +710,13 @@ async fn publish_dataset(
             writer_epoch: 1,
             writer_seq,
             object_size: bytes.len() as u64,
-            content_hash: [0u8; 32],
+            // The real BLAKE3 of the bytes, not a zero placeholder: ADR-0046's
+            // cache key is `(tenant, content_hash, offset, object_size)`, so
+            // objects sharing a zero hash collide with each other whenever their
+            // sizes also match, and the cached side of this sweep would report
+            // cross-segment collisions as if they were single-flight
+            // coalescing.
+            content_hash: *blake3::hash(&bytes).as_bytes(),
             sample_count: per_object as u64,
             series_count: 1,
             min_event_ts_ns: min,

--- a/crates/ravel-bench/tests/logs_scan_scaling_smoke.rs
+++ b/crates/ravel-bench/tests/logs_scan_scaling_smoke.rs
@@ -2,11 +2,12 @@
 //! epic #361 item 1).
 //!
 //! Drives `logs_scan_scaling::run` in its smoke configuration end to end against
-//! an in-process `MemoryStore` and asserts the report proves the two facts this
-//! item exists to demonstrate: the undersubscribed `logs` scan fans out to
-//! `target_partitions` (more than the segment count) block-level partitions, and
-//! ADR-0046's read cache keeps the object-store GET count flat across the sweep
-//! while the un-cached path's climbs.
+//! an in-process `MemoryStore` and asserts the report proves what this item
+//! actually ships: with ADR-0046's read cache wired, an undersubscribed `logs`
+//! scan fans out to `target_partitions` block-level partitions (more than the
+//! segment count); without it the partition count is capped at the segment count
+//! and the object-store GET count therefore stops responding to
+//! `target_partitions` once the cap binds.
 //!
 //! Gated on `sql-latency` (the module and bin's gate), so a default
 //! `cargo test -p ravel-bench` sees an empty crate rather than a link error. Run
@@ -21,7 +22,7 @@ use ravel_bench::logs_scan_scaling::{LogsScanScalingConfig, run};
 use ravel_object_store::memory::MemoryStore;
 
 #[tokio::test(flavor = "multi_thread")]
-async fn logs_scan_scaling_smoke_proves_fanout_and_flat_request_count() {
+async fn logs_scan_scaling_smoke_proves_cache_gated_fanout_and_request_count() {
     let config = LogsScanScalingConfig::smoke(Arc::new(MemoryStore::new()), "memory");
     let segments = config.segments;
     let expected_partitions = config.target_partitions.clone();
@@ -35,6 +36,25 @@ async fn logs_scan_scaling_smoke_proves_fanout_and_flat_request_count() {
         report.combos.len(),
         expected_partitions.len() * 2,
         "one entry per (target_partitions x cache) combination"
+    );
+
+    // The planning prune's per-segment serialized await is only visible with
+    // enough segments to serialize; two made it a rounding error. The report
+    // carries the real figure rather than prose about it.
+    assert_eq!(
+        report.planning.segments, segments,
+        "the planning measurement must cover every segment in the fixture"
+    );
+    assert!(
+        segments >= 32,
+        "the fixture needs enough segments for `compute_plan_counts`'s \
+         per-segment serialized await to be measurable; got {segments}"
+    );
+    assert!(
+        report.planning.serial_ms > 0.0 && report.planning.total_blocks > 0,
+        "planning measurement must report real work: {} ms over {} blocks",
+        report.planning.serial_ms,
+        report.planning.total_blocks
     );
 
     let mut get_by_combo: HashMap<(usize, bool), u64> = HashMap::new();
@@ -57,35 +77,39 @@ async fn logs_scan_scaling_smoke_proves_fanout_and_flat_request_count() {
             "a bare `SELECT ts, body FROM logs` returns every record"
         );
 
-        // The declared scan fan-out is target_partitions regardless of the
-        // segment count -- the capability block-level striping adds. Under the
-        // old segment-granular rule this would have been min(tp, segments).
+        // The declared fan-out is `target_partitions` only when the read cache is
+        // wired (ADR-0102 decision 1's precondition: the fetch unit is the whole
+        // object, so the extra partitions' repeated reads need the cache to
+        // coalesce). Un-cached it falls back to the pre-item-1 bound.
+        let expected = if c.cache_wired {
+            c.target_partitions
+        } else {
+            c.target_partitions.min(segments)
+        };
         assert_eq!(
-            c.scan_partitions, c.target_partitions,
-            "block-level striping declares target_partitions scan partitions, not \
-             min(tp, segments): tp={}, observed {}",
-            c.target_partitions, c.scan_partitions
+            c.scan_partitions, expected,
+            "tp={} cache={}: expected {expected} scan partitions, got {}",
+            c.target_partitions, c.cache_wired, c.scan_partitions
         );
 
-        // The undersubscribed capability: more non-empty partitions than
-        // segments once the partition count exceeds the segment count. The
-        // dataset has many blocks per segment, so every partition up to tp gets
-        // at least one block.
-        if c.target_partitions > segments {
+        // Every declared partition owns blocks on this fixture (192 blocks across
+        // at most 64 partitions), so the non-empty count matches the declared
+        // one -- and in the cached, undersubscribed case that exceeds the segment
+        // count, which is the capability this item adds.
+        assert_eq!(
+            c.non_empty_partitions, expected,
+            "tp={} cache={}: every declared partition should decode blocks; got {}",
+            c.target_partitions, c.cache_wired, c.non_empty_partitions
+        );
+        if c.cache_wired && c.target_partitions > segments {
             assert!(
                 c.non_empty_partitions > segments,
-                "tp={} (> {segments} segments) must fan out to more than {segments} \
-                 non-empty partitions; got {}",
+                "cached tp={} (> {segments} segments) must fan out past the \
+                 segment count; got {}",
                 c.target_partitions,
                 c.non_empty_partitions
             );
         }
-        assert_eq!(
-            c.non_empty_partitions, c.target_partitions,
-            "with many blocks per segment every partition up to tp={} decodes \
-             blocks; got {}",
-            c.target_partitions, c.non_empty_partitions
-        );
 
         get_by_combo.insert(
             (c.target_partitions, c.cache_wired),
@@ -93,39 +117,69 @@ async fn logs_scan_scaling_smoke_proves_fanout_and_flat_request_count() {
         );
     }
 
-    // Request-count story (ADR-0046): with the cache wired, the whole-object
-    // reads the striping issues coalesce (single-flight) so the GET count is
-    // FLAT across the whole sweep -- one whole-object GET per segment plus the
-    // constant catalog-resolve traffic, independent of the partition count.
-    // Without the cache each partition issues its own whole-object GET, so the
-    // raw count is at least the cached count and climbs with the partition
-    // count. (`segments` is unused directly here because the absolute count
-    // includes constant catalog GETs; the invariant is flatness, not a literal.)
-    let _ = segments;
-    let cached_at_1 = get_by_combo[&(1, true)];
-    for &tp in &expected_partitions {
-        let cached = get_by_combo[&(tp, true)];
-        let uncached = get_by_combo[&(tp, false)];
+    // Request count, un-cached: once `target_partitions` reaches the segment
+    // count the partition count stops growing, so the GET count stops growing
+    // with it. This is the property the has_cache gate buys -- without it, every
+    // partition past the segment count added whole-object reads that nothing
+    // absorbed.
+    let at_cap = expected_partitions
+        .iter()
+        .copied()
+        .filter(|&tp| tp >= segments)
+        .collect::<Vec<_>>();
+    assert!(
+        at_cap.len() >= 2,
+        "the sweep must contain at least two `target_partitions` values at or \
+         above the segment count to show the un-cached count going flat; got {at_cap:?}"
+    );
+    let baseline = get_by_combo[&(at_cap[0], false)];
+    for &tp in &at_cap[1..] {
         assert_eq!(
-            cached, cached_at_1,
-            "cache-wired GET count must be flat across the sweep: tp={tp} issued \
-             {cached}, tp=1 issued {cached_at_1}"
-        );
-        assert!(
-            uncached >= cached,
-            "un-cached tp={tp} GET count ({uncached}) must be at least the cached count ({cached})"
+            get_by_combo[&(tp, false)],
+            baseline,
+            "un-cached GET count must be flat once the segment-count cap binds: \
+             tp={tp} issued {}, tp={} issued {baseline}",
+            get_by_combo[&(tp, false)],
+            at_cap[0]
         );
     }
 
-    // The un-cached raw GET count actually grows with the partition count: the
-    // largest swept tp issues strictly more GETs than tp=1. This is the
-    // regression the cache neutralizes, measured directly.
+    // Request count, cache-wired: this is the side that keeps adding partitions
+    // past the segment count, so it is the side where repeated whole-object reads
+    // at one key actually happen. On this fixture -- a cache sized to hold every
+    // object, no eviction -- they coalesce completely and the GET count is flat
+    // across the sweep, and below the un-cached count at every partition value.
+    // "Flat" is a property of THIS fixture, not of striping: a cache too small to
+    // hold the working set would evict between partitions and issue GETs again.
+    let &min_tp = expected_partitions.iter().min().unwrap();
+    let cached_baseline = get_by_combo[&(min_tp, true)];
+    for &tp in &expected_partitions {
+        assert_eq!(
+            get_by_combo[&(tp, true)],
+            cached_baseline,
+            "cache-wired GET count is flat across the sweep on this fixture: \
+             tp={tp} issued {}, tp={min_tp} issued {cached_baseline}",
+            get_by_combo[&(tp, true)]
+        );
+        assert!(
+            get_by_combo[&(tp, true)] <= get_by_combo[&(tp, false)],
+            "cache-wired tp={tp} GET count ({}) must not exceed the un-cached \
+             count ({})",
+            get_by_combo[&(tp, true)],
+            get_by_combo[&(tp, false)]
+        );
+    }
+
+    // The multiplier the segment-count cap bounds but does not remove: below the
+    // cap, raising `target_partitions` still adds whole-object reads, because
+    // every partition owning blocks in a segment opens that segment itself. Only
+    // a single-partition plan matches the pre-item-1 whole-segment request count.
     let &max_tp = expected_partitions.iter().max().unwrap();
-    if max_tp > 1 {
+    if min_tp == 1 && max_tp > 1 {
         assert!(
             get_by_combo[&(max_tp, false)] > get_by_combo[&(1, false)],
-            "un-cached GET count must climb with target_partitions: tp={max_tp} \
-             issued {}, tp=1 issued {}",
+            "un-cached GET count still climbs from a single partition to the cap: \
+             tp={max_tp} issued {}, tp=1 issued {}",
             get_by_combo[&(max_tp, false)],
             get_by_combo[&(1, false)]
         );

--- a/crates/ravel-bench/tests/logs_scan_scaling_smoke.rs
+++ b/crates/ravel-bench/tests/logs_scan_scaling_smoke.rs
@@ -1,0 +1,133 @@
+//! Acceptance test for the `logs_scan_scaling_bench` path (ADR-0102 decision 1,
+//! epic #361 item 1).
+//!
+//! Drives `logs_scan_scaling::run` in its smoke configuration end to end against
+//! an in-process `MemoryStore` and asserts the report proves the two facts this
+//! item exists to demonstrate: the undersubscribed `logs` scan fans out to
+//! `target_partitions` (more than the segment count) block-level partitions, and
+//! ADR-0046's read cache keeps the object-store GET count flat across the sweep
+//! while the un-cached path's climbs.
+//!
+//! Gated on `sql-latency` (the module and bin's gate), so a default
+//! `cargo test -p ravel-bench` sees an empty crate rather than a link error. Run
+//! with `cargo test -p ravel-bench --features sql-latency`.
+#![cfg(feature = "sql-latency")]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use ravel_bench::logs_scan_scaling::{LogsScanScalingConfig, run};
+use ravel_object_store::memory::MemoryStore;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn logs_scan_scaling_smoke_proves_fanout_and_flat_request_count() {
+    let config = LogsScanScalingConfig::smoke(Arc::new(MemoryStore::new()), "memory");
+    let segments = config.segments;
+    let expected_partitions = config.target_partitions.clone();
+    let report = run(&config).await;
+
+    assert!(
+        report.config.total_records > 0,
+        "smoke run must ingest a non-zero record count"
+    );
+    assert_eq!(
+        report.combos.len(),
+        expected_partitions.len() * 2,
+        "one entry per (target_partitions x cache) combination"
+    );
+
+    let mut get_by_combo: HashMap<(usize, bool), u64> = HashMap::new();
+    for c in &report.combos {
+        assert!(
+            c.error.is_none(),
+            "combo tp={} cache={} unexpectedly failed: {:?}",
+            c.target_partitions,
+            c.cache_wired,
+            c.error
+        );
+        assert!(
+            c.median_ms > 0.0,
+            "combo tp={} cache={} must report non-zero timing",
+            c.target_partitions,
+            c.cache_wired
+        );
+        assert_eq!(
+            c.result_rows, report.config.total_records,
+            "a bare `SELECT ts, body FROM logs` returns every record"
+        );
+
+        // The declared scan fan-out is target_partitions regardless of the
+        // segment count -- the capability block-level striping adds. Under the
+        // old segment-granular rule this would have been min(tp, segments).
+        assert_eq!(
+            c.scan_partitions, c.target_partitions,
+            "block-level striping declares target_partitions scan partitions, not \
+             min(tp, segments): tp={}, observed {}",
+            c.target_partitions, c.scan_partitions
+        );
+
+        // The undersubscribed capability: more non-empty partitions than
+        // segments once the partition count exceeds the segment count. The
+        // dataset has many blocks per segment, so every partition up to tp gets
+        // at least one block.
+        if c.target_partitions > segments {
+            assert!(
+                c.non_empty_partitions > segments,
+                "tp={} (> {segments} segments) must fan out to more than {segments} \
+                 non-empty partitions; got {}",
+                c.target_partitions,
+                c.non_empty_partitions
+            );
+        }
+        assert_eq!(
+            c.non_empty_partitions, c.target_partitions,
+            "with many blocks per segment every partition up to tp={} decodes \
+             blocks; got {}",
+            c.target_partitions, c.non_empty_partitions
+        );
+
+        get_by_combo.insert(
+            (c.target_partitions, c.cache_wired),
+            c.object_store_get_requests,
+        );
+    }
+
+    // Request-count story (ADR-0046): with the cache wired, the whole-object
+    // reads the striping issues coalesce (single-flight) so the GET count is
+    // FLAT across the whole sweep -- one whole-object GET per segment plus the
+    // constant catalog-resolve traffic, independent of the partition count.
+    // Without the cache each partition issues its own whole-object GET, so the
+    // raw count is at least the cached count and climbs with the partition
+    // count. (`segments` is unused directly here because the absolute count
+    // includes constant catalog GETs; the invariant is flatness, not a literal.)
+    let _ = segments;
+    let cached_at_1 = get_by_combo[&(1, true)];
+    for &tp in &expected_partitions {
+        let cached = get_by_combo[&(tp, true)];
+        let uncached = get_by_combo[&(tp, false)];
+        assert_eq!(
+            cached, cached_at_1,
+            "cache-wired GET count must be flat across the sweep: tp={tp} issued \
+             {cached}, tp=1 issued {cached_at_1}"
+        );
+        assert!(
+            uncached >= cached,
+            "un-cached tp={tp} GET count ({uncached}) must be at least the cached count ({cached})"
+        );
+    }
+
+    // The un-cached raw GET count actually grows with the partition count: the
+    // largest swept tp issues strictly more GETs than tp=1. This is the
+    // regression the cache neutralizes, measured directly.
+    let &max_tp = expected_partitions.iter().max().unwrap();
+    if max_tp > 1 {
+        assert!(
+            get_by_combo[&(max_tp, false)] > get_by_combo[&(1, false)],
+            "un-cached GET count must climb with target_partitions: tp={max_tp} \
+             issued {}, tp=1 issued {}",
+            get_by_combo[&(max_tp, false)],
+            get_by_combo[&(1, false)]
+        );
+    }
+}

--- a/crates/ravel-logseg/src/reader.rs
+++ b/crates/ravel-logseg/src/reader.rs
@@ -361,6 +361,58 @@ impl<'a> RlogReader<'a> {
         })
     }
 
+    /// Like [`RlogReader::scan_blocks`], but the returned cursor drains only the
+    /// surviving blocks at the positions named in `indices`, in the order given,
+    /// rather than every surviving block (intra-segment scan partitioning,
+    /// ADR-0102).
+    ///
+    /// `indices` are positions into the full surviving-block list
+    /// [`scan_blocks`](Self::scan_blocks) would produce for the same
+    /// `content`/`prune`: the same skip-index, POSTINGS, and bloom pruning runs
+    /// here, once, and produces the same ordered survivor list; this then keeps
+    /// only the entries the caller named. Callers derive `indices` from a prior
+    /// `scan_blocks` (or an equivalent count) over the SAME immutable object, so
+    /// the two survivor lists are identical by construction and an index at or
+    /// past the survivor count can only mean corruption -- it is a typed
+    /// `Corrupted` error, never a panic.
+    ///
+    /// It is deliberately an explicit index list, not a contiguous range: the
+    /// SQL logs scan hands one segment's blocks to several partitions on a
+    /// `pos % n` stride, so a partition owns a non-contiguous subset (0, n, 2n,
+    /// ...) that a range cannot express.
+    ///
+    /// The returned cursor's [`ScanStats`] totals (`blocks_total`,
+    /// `blocks_after_skip`/`_postings`/`_bloom`) describe the WHOLE segment's
+    /// pruning, exactly as `scan_blocks` reports them, because the same pruning
+    /// ran; only `blocks_scanned`/`pages_*` grow as this subset drains. A caller
+    /// striping one segment across partitions must therefore attribute the
+    /// whole-segment totals to a single partition to avoid counting them once
+    /// per partition (see `ravel_sql::logs_scan`).
+    ///
+    /// [`scan_blocks`](Self::scan_blocks) itself, and every other caller, is
+    /// unchanged: this adds a way to restrict which of the already-pruned blocks
+    /// a cursor drains, and changes nothing about what is read from the object.
+    pub fn scan_blocks_subset(
+        &self,
+        content: &Predicate,
+        prune: &[Predicate],
+        columns: &ColumnSelection,
+        indices: &[usize],
+    ) -> Result<BlockScan, LogSegError> {
+        let mut scan = self.scan_blocks(content, prune, columns)?;
+        let mut subset = Vec::with_capacity(indices.len());
+        for &i in indices {
+            let loc =
+                scan.blocks.get(i).copied().ok_or_else(|| {
+                    LogSegError::Corrupted("subset block index out of range".into())
+                })?;
+            subset.push(loc);
+        }
+        scan.blocks = subset;
+        scan.next = 0;
+        Ok(scan)
+    }
+
     /// A cursor over zero surviving blocks, for the two pre-decode short
     /// circuits (an empty ts range, an empty resolved stream set). Draining it
     /// yields nothing, which is what those paths returned before.

--- a/crates/ravel-query/src/log_fetcher.rs
+++ b/crates/ravel-query/src/log_fetcher.rs
@@ -411,6 +411,17 @@ impl LogSegmentFetcher {
         self
     }
 
+    /// Whether ADR-0046's read cache is wired ([`with_cache`](Self::with_cache)
+    /// was called). A caller that would issue several whole-object GETs at the
+    /// same key needs this: with a cache those coalesce onto one fetch through
+    /// single-flight, without one each is a real object-store request. ADR-0102
+    /// decision 1 names the cache as the precondition for that fan-out, and
+    /// `LogsScanExec::new` gates its partition count on this.
+    #[must_use]
+    pub fn has_cache(&self) -> bool {
+        self.cache.is_some()
+    }
+
     /// Per-object relevance from the catalog summary alone, with no object
     /// read: true iff the segment's event-ts span (`SegmentRef`'s
     /// `min_event_ts_ns..=max_event_ts_ns`, the same bounds the footer carries)

--- a/crates/ravel-query/src/log_fetcher.rs
+++ b/crates/ravel-query/src/log_fetcher.rs
@@ -668,6 +668,86 @@ impl LogSegmentFetcher {
         }))
     }
 
+    /// Prune one segment for intra-segment scan partitioning (ADR-0102) WITHOUT
+    /// decoding any block: returns how many of its blocks survive this query's
+    /// pruning, plus the whole-segment [`ScanStats`] the prune produced, or
+    /// `Ok(None)` when the catalog summary proved the segment irrelevant (no
+    /// GET, exactly like [`scan_accounted_with_tenant`](Self::
+    /// scan_accounted_with_tenant)).
+    ///
+    /// The survivor count is column-independent -- pruning never consults the
+    /// [`ColumnSelection`], which only narrows which pages a decoded block
+    /// reads -- so this opens the scan with [`ColumnSelection::all`] and decodes
+    /// nothing (`blocks_scanned`/`pages_*` in the returned stats are therefore
+    /// zero; the totals describe the whole segment). The byte read goes through
+    /// the same cache-aware funnel [`scan_accounted_with_tenant`](Self::
+    /// scan_accounted_with_tenant) uses, so in production it is single-flight
+    /// coalesced with the per-partition subset scans that follow rather than
+    /// issuing an extra distinct GET.
+    ///
+    /// [`scan_accounted_with_tenant`]: Self::scan_accounted_with_tenant
+    pub async fn plan_segment(
+        &self,
+        seg_ref: &SegmentRef,
+        tenant_hash: TenantHash,
+        query: &LogQuery,
+        accounting: &QueryAccounting,
+    ) -> Result<Option<(usize, ScanStats)>, LogFetchError> {
+        let Some(bytes) = self
+            .tenant_bytes(seg_ref, tenant_hash, query, accounting)
+            .await?
+        else {
+            return Ok(None);
+        };
+        let key = &seg_ref.data_object_key;
+        let span = decode_span();
+        let scan = span.in_scope(|| self.open_scan(key, &bytes, query, &ColumnSelection::all()))?;
+        Ok(Some((scan.remaining_blocks(), scan.stats())))
+    }
+
+    /// [`scan_accounted_with_tenant`](Self::scan_accounted_with_tenant),
+    /// restricted to the surviving blocks at the positions in `indices`
+    /// (intra-segment scan partitioning, ADR-0102). Same GET, same cache, same
+    /// pruning; the returned [`LogSegmentScan`] drains only the named subset of
+    /// the segment's surviving blocks, in the order given.
+    ///
+    /// `indices` index into the ordered survivor list this query's pruning
+    /// produces over this (immutable) object, the same list a prior
+    /// [`plan_segment`](Self::plan_segment) counted, so a partition hands the
+    /// exact positions it was assigned. The returned scan's whole-segment stats
+    /// totals are reported by [`plan_segment`] instead, to keep one segment's
+    /// totals from being counted once per partition (see `ravel_sql::
+    /// logs_scan`).
+    ///
+    /// [`scan_accounted_with_tenant`]: Self::scan_accounted_with_tenant
+    pub async fn scan_accounted_with_tenant_subset(
+        &self,
+        seg_ref: &SegmentRef,
+        tenant_hash: TenantHash,
+        query: &LogQuery,
+        columns: &ColumnSelection,
+        indices: &[usize],
+        accounting: &QueryAccounting,
+    ) -> Result<Option<LogSegmentScan>, LogFetchError> {
+        let Some(bytes) = self
+            .tenant_bytes(seg_ref, tenant_hash, query, accounting)
+            .await?
+        else {
+            return Ok(None);
+        };
+        let key = &seg_ref.data_object_key;
+        let span = decode_span();
+        let scan = span.in_scope(|| self.open_scan_subset(key, &bytes, query, columns, indices))?;
+        Ok(Some(LogSegmentScan {
+            bytes,
+            scan,
+            erasure: query.erasure.clone(),
+            span,
+            key: key.to_string(),
+            finished: false,
+        }))
+    }
+
     /// The byte-fetch half of the tenant-aware funnel: the ts-range pre-check,
     /// then the object's bytes from the read cache or a whole-object GET, with
     /// the `page_fetch` span and the accounting both entry points share.
@@ -863,6 +943,51 @@ impl LogSegmentFetcher {
         query: &LogQuery,
         columns: &ColumnSelection,
     ) -> Result<BlockScan, LogFetchError> {
+        let pred = self.combined_predicate(key, bytes, query)?;
+        let reader = RlogReader::new(bytes, &self.cfg).map_err(|source| corrupt(key, source))?;
+        // `prune` is passed as the reader's prune-only channel, never folded
+        // into `pred`: an arm there would become an exact per-row filter and
+        // drop resource/scope-only matches (docs/adrs/0049-rlog-postings.md
+        // amendment 2026-08-03). An empty channel makes this identical to
+        // `scan`.
+        reader
+            .scan_blocks(&pred, &query.prune, columns)
+            .map_err(|source| corrupt(key, source))
+    }
+
+    /// [`open_scan`](Self::open_scan), restricted to the surviving blocks at the
+    /// positions in `indices` (intra-segment scan partitioning, ADR-0102). The
+    /// predicate, prune channel, and pruning are identical to `open_scan`; only
+    /// the set of blocks the returned cursor will drain differs. `indices`
+    /// index into the same ordered survivor list `open_scan` would produce over
+    /// this (immutable) object, so they line up with a prior
+    /// [`plan_segment`](Self::plan_segment) count.
+    fn open_scan_subset(
+        &self,
+        key: &str,
+        bytes: &Bytes,
+        query: &LogQuery,
+        columns: &ColumnSelection,
+        indices: &[usize],
+    ) -> Result<BlockScan, LogFetchError> {
+        let pred = self.combined_predicate(key, bytes, query)?;
+        let reader = RlogReader::new(bytes, &self.cfg).map_err(|source| corrupt(key, source))?;
+        reader
+            .scan_blocks_subset(&pred, &query.prune, columns, indices)
+            .map_err(|source| corrupt(key, source))
+    }
+
+    /// The combined exact predicate (`ts range AND resolved streams AND
+    /// content`) both scan-opening paths hand to the reader. Stream-attribute
+    /// equalities are resolved against STREAM_DIR here (over-approximating, see
+    /// [`matching_streams`](Self::matching_streams)); the prune-only channel is
+    /// passed separately by the caller.
+    fn combined_predicate(
+        &self,
+        key: &str,
+        bytes: &Bytes,
+        query: &LogQuery,
+    ) -> Result<Predicate, LogFetchError> {
         let stream_ids = if query.stream_attrs.is_empty() {
             None
         } else {
@@ -884,17 +1009,7 @@ impl LogSegmentFetcher {
             arms.push(Predicate::StreamIn(ids));
         }
         arms.extend(query.content.iter().cloned());
-        let pred = Predicate::And(arms);
-
-        let reader = RlogReader::new(bytes, &self.cfg).map_err(|source| corrupt(key, source))?;
-        // `prune` is passed as the reader's prune-only channel, never folded
-        // into `pred`: an arm there would become an exact per-row filter and
-        // drop resource/scope-only matches (docs/adrs/0049-rlog-postings.md
-        // amendment 2026-08-03). An empty channel makes this identical to
-        // `scan`.
-        reader
-            .scan_blocks(&pred, &query.prune, columns)
-            .map_err(|source| corrupt(key, source))
+        Ok(Predicate::And(arms))
     }
 
     /// Decodes the STREAM_DIR section of an object from its own public section

--- a/crates/ravel-sql/src/logs_scan.rs
+++ b/crates/ravel-sql/src/logs_scan.rs
@@ -11,6 +11,11 @@
 //! the old segment-granular rule (`min(target_partitions, segment_count)`)
 //! pinned such a query to at most `segment_count` partitions.
 //!
+//! That fan-out is gated on the fetcher carrying ADR-0046's read cache
+//! ([`LogSegmentFetcher::has_cache`]); an un-cached fetcher keeps the old
+//! `min(target_partitions, segment_count)` bound. See
+//! [`LogsScanExec::new`] and the request-count paragraph below for why.
+//!
 //! The per-segment surviving-block counts the assignment needs are determined
 //! once, before draining, by [`LogSegmentFetcher::plan_segment`] (a prune with
 //! no block decode), shared across partitions through a
@@ -21,12 +26,45 @@
 //! at a time**, and turns each block's [`ravel_logseg::LogRecord`]s into Arrow
 //! arrays matching this scan's projection of [`crate::logs_schema::logs_schema`].
 //!
-//! Because the whole object is still fetched with one whole-object GET
-//! (ADR-0087 decision 3: no ranged block reader here) and the read cache keys
-//! the whole object, the several partitions that stripe one segment's blocks
-//! coalesce onto one cached GET via single-flight rather than issuing one GET
-//! each; the object-store request count is unchanged from the whole-segment
-//! path. A future ranged reader would change that.
+//! # Object-store request count, and the cache gate
+//!
+//! The whole object is still fetched with one whole-object GET (ADR-0087
+//! decision 3: no ranged block reader here), so every partition that owns
+//! blocks in a segment issues its own whole-object read at that segment's key.
+//! What those reads cost depends on the cache, and so does how many partitions
+//! are planned:
+//!
+//! - **Un-cached fetcher.** The partition count is capped at the segment count,
+//!   so the request count stops responding to `target_partitions` once that cap
+//!   binds. It is the pre-ADR-0102 whole-segment count only when the plan
+//!   collapses to a single partition; with `n > 1` partitions, every segment
+//!   holding at least `n` surviving blocks is opened by all `n` of them, so the
+//!   scan costs up to `n` whole-object reads per segment, and planning's prune
+//!   (`compute_plan_counts`) adds one more per relevant segment. The cap
+//!   bounds that multiplier by the segment count instead of letting
+//!   `target_partitions` set it; it does not remove it. `ravel-bench`'s
+//!   `logs_scan_scaling` report measures both.
+//! - **Cache-wired fetcher.** The partition count is `target_partitions`, so
+//!   several partitions can stripe one segment's blocks. The read cache keys the
+//!   whole object, so those reads coalesce onto one GET via single-flight, and
+//!   on the bench fixture the request count is flat across the whole
+//!   `target_partitions` sweep (planning's prune coalesces with them too).
+//!   Coalescing is not free of request count in general, though: a read that
+//!   misses the in-flight window, or finds its key already evicted, issues its
+//!   own GET. So striding past the segment count *can* raise the GET count above
+//!   the whole-segment path's, and that is the cost ADR-0102 accepts in exchange
+//!   for the cache absorbing the repeat reads and for the extra scan
+//!   parallelism.
+//!
+//! A future ranged (per-block) reader would remove the trade entirely by making
+//! each partition's fetch cover only its own blocks.
+//!
+//! Any "no amplification" or "flat request count" figure reported for this path
+//! (here, in `ravel-bench`'s `logs_scan_scaling` report, or in that bench's
+//! smoke test) is a measurement of one fixture -- a `MemoryStore`, a specific
+//! segment/block/partition shape, a cache sized to hold the whole dataset -- and
+//! not a general result about striping. Cache size, eviction, object size, and
+//! store latency all move it.
 //!
 //! # Streaming, and why no ordering is declared (ADR-0087)
 //!
@@ -488,8 +526,10 @@ impl BlockMetrics {
 }
 
 impl LogsScanExec {
-    /// Build a scan over `segments`, split round-robin into
-    /// `min(target_partitions, segments.len())` partitions, with the given ts
+    /// Build a scan over `segments`, striping their blocks round-robin across
+    /// `target_partitions` partitions when `fetcher` carries ADR-0046's read
+    /// cache and across `min(target_partitions, segments.len())` when it does
+    /// not (see the `declared_partitions` comment below), with the given ts
     /// bounds, content predicates, and prune-only predicates. Stream-attribute
     /// equalities are deliberately not accepted: they are not pushed into the
     /// fetch, because a stream-level prune is unsound against the merged `attrs`
@@ -528,13 +568,29 @@ impl LogsScanExec {
         // Blocks, not segments, are what get striped (ADR-0102), but the
         // per-segment block counts are not known until a prune runs, which is
         // async and cannot happen in this synchronous constructor. So the
-        // declared partition count is `target_partitions.max(1)` and the
-        // block-level assignment (with the stride `n` capped by the real block
-        // count) happens lazily on first poll, shared through `counts`. When
-        // there are fewer blocks than partitions the surplus partitions run
+        // declared partition count is a function of `target_partitions` alone
+        // and the block-level assignment (with the stride `n` capped by the real
+        // block count) happens lazily on first poll, shared through `counts`.
+        // When there are fewer blocks than partitions the surplus partitions run
         // empty, which is equivalent to capping `n` here and DataFusion handles
         // empty partitions.
-        let declared_partitions = target_partitions.max(1);
+        //
+        // Striping past the segment count is gated on the fetcher carrying
+        // ADR-0046's read cache, which is the precondition ADR-0102 decision 1
+        // names for it: the fetch unit here is the whole object
+        // (`GetRange::Full`, no ranged block reader -- ADR-0087 decision 3), so K
+        // partitions sharing one segment issue K whole-object reads at the same
+        // key. With the cache those coalesce onto one GET through single-flight;
+        // without it each is a real request, and requesting more partitions than
+        // there are segments would multiply object-store GETs for no reason. So
+        // an un-cached fetcher falls back to the pre-ADR-0102 bound,
+        // `min(target_partitions, segment_count)`, and never plans a partition
+        // whose extra GETs nothing absorbs.
+        let declared_partitions = if fetcher.has_cache() {
+            target_partitions.max(1)
+        } else {
+            target_partitions.max(1).min(segments.len().max(1))
+        };
         let full = full_schema;
         // A `None` projection means every column, in schema order. Resolving it
         // here rather than carrying an `Option` keeps one code path for the

--- a/crates/ravel-sql/src/logs_scan.rs
+++ b/crates/ravel-sql/src/logs_scan.rs
@@ -1,14 +1,32 @@
 //! `LogsScanExec`: the leaf of the `logs` pipeline, the log-signal sibling of
 //! [`crate::scan::RsegScanExec`] (ADR-0033).
 //!
-//! Partitions the snapshot's segments round-robin into
-//! `N = min(target_partitions, segment_count)` partitions. Each partition
-//! opens its segments one at a time through
-//! [`LogSegmentFetcher::scan_accounted_with_tenant`] (one [`LogQuery`] per
-//! segment: the extracted ts range, stream-attribute equalities, and content
-//! predicates), decodes **one block at a time**, and turns each block's
-//! [`ravel_logseg::LogRecord`]s into Arrow arrays matching this scan's
-//! projection of [`crate::logs_schema::logs_schema`].
+//! Partitions the snapshot's segments' *blocks* round-robin across
+//! `target_partitions` partitions (intra-segment scan partitioning, ADR-0102).
+//! Every `(segment, surviving-block)` unit across all segments is flattened
+//! into one ordered list (segment order, then block order) and unit `i` is
+//! assigned to partition `i % n`, where `n = target_partitions.max(1).
+//! min(total_block_count.max(1))`. This lets a query touching fewer segments
+//! than `target_partitions` still fan out to `target_partitions` partitions:
+//! the old segment-granular rule (`min(target_partitions, segment_count)`)
+//! pinned such a query to at most `segment_count` partitions.
+//!
+//! The per-segment surviving-block counts the assignment needs are determined
+//! once, before draining, by [`LogSegmentFetcher::plan_segment`] (a prune with
+//! no block decode), shared across partitions through a
+//! [`tokio::sync::OnceCell`]. Each partition then opens each segment it owns
+//! blocks in through [`LogSegmentFetcher::scan_accounted_with_tenant_subset`]
+//! (the same [`LogQuery`] and cache-aware GET as the whole-segment path,
+//! restricted to that partition's own block-index list), decodes **one block
+//! at a time**, and turns each block's [`ravel_logseg::LogRecord`]s into Arrow
+//! arrays matching this scan's projection of [`crate::logs_schema::logs_schema`].
+//!
+//! Because the whole object is still fetched with one whole-object GET
+//! (ADR-0087 decision 3: no ranged block reader here) and the read cache keys
+//! the whole object, the several partitions that stripe one segment's blocks
+//! coalesce onto one cached GET via single-flight rather than issuing one GET
+//! each; the object-store request count is unchanged from the whole-segment
+//! path. A future ranged reader would change that.
 //!
 //! # Streaming, and why no ordering is declared (ADR-0087)
 //!
@@ -135,6 +153,7 @@ use ravel_query::{ColumnarBlockOutcome, LogQuery, LogSegmentFetcher, LogSegmentS
 use ravel_types::TenantHash;
 use ravel_types::accounting::QueryAccounting;
 use ravel_types::logstream::AttrValue;
+use tokio::sync::OnceCell;
 
 use crate::declared::{DeclaredColumn, DeclaredType};
 use crate::error::SqlError;
@@ -324,9 +343,23 @@ fn columnar_static_eligible(projection: &[usize], erasure: &[ErasurePredicate]) 
 pub struct LogsScanExec {
     tenant_hash: TenantHash,
     fetcher: LogSegmentFetcher,
-    /// Round-robin segment assignment; `partitions[k]` runs as DataFusion
-    /// partition `k`.
-    partitions: Vec<Vec<SegmentRef>>,
+    /// Every segment in the snapshot, in snapshot order. Blocks are flattened
+    /// across these (segment order, then block order) and striped across
+    /// partitions; the per-segment block counts the striping needs are
+    /// resolved lazily into [`Self::counts`].
+    segments: Arc<Vec<SegmentRef>>,
+    /// DataFusion partition count this scan declares. Equal to
+    /// `target_partitions.max(1)`; the assignment stride `n` is
+    /// `target_partitions.max(1).min(total_block_count.max(1))`, which only
+    /// differs when there are fewer blocks than partitions, and then the
+    /// partitions past `n` simply run empty streams (DataFusion tolerates
+    /// them), so the observed non-empty partition count is identical either way.
+    target_partitions: usize,
+    /// The shared per-segment block plan (surviving-block counts and
+    /// whole-segment prune stats), computed once by the first partition to
+    /// poll and reused by the rest (ADR-0102). `None` entries are ts-irrelevant
+    /// segments that issue no GET.
+    counts: Arc<OnceCell<Arc<PlanCounts>>>,
     /// Inclusive ts bounds for the fetch's [`LogQuery`].
     ts_min: i64,
     ts_max: i64,
@@ -420,19 +453,35 @@ impl BlockMetrics {
         }
     }
 
-    /// Accumulates one segment's [`ScanStats`]. `blocks_pruned_by_postings` is
-    /// the drop across the postings step alone (`blocks_after_skip` minus
-    /// `blocks_after_postings`), so it credits POSTINGS with nothing the skip
-    /// index or the bloom did. `saturating_sub` because a degraded postings
-    /// section leaves the two counts equal rather than ordered by construction.
-    fn record(&self, stats: &ScanStats) {
+    /// Accumulates one segment's *whole-segment* prune totals: `blocks_total`
+    /// and `blocks_pruned_by_postings` (the drop across the postings step
+    /// alone, `blocks_after_skip` minus `blocks_after_postings`, so it credits
+    /// POSTINGS with nothing the skip index or the bloom did; `saturating_sub`
+    /// because a degraded postings section leaves the two counts equal rather
+    /// than ordered by construction).
+    ///
+    /// Recorded once per relevant segment by partition 0 during planning
+    /// (ADR-0102), never per partition: several partitions stripe one segment's
+    /// blocks, and each re-prunes the whole segment to open its own subset, so
+    /// attributing the whole-segment totals per partition would multiply them.
+    /// The per-partition decode counts come from [`Self::record_scan`] instead.
+    fn record_segment_totals(&self, stats: &ScanStats) {
         self.total.add(stats.blocks_total as usize);
-        self.scanned.add(stats.blocks_scanned as usize);
         self.pruned_by_postings.add(
             stats
                 .blocks_after_skip
                 .saturating_sub(stats.blocks_after_postings) as usize,
         );
+    }
+
+    /// Accumulates what one partition's cursor actually decoded: the blocks it
+    /// scanned and the column pages it decoded or skipped. Per partition, unlike
+    /// [`Self::record_segment_totals`], because each partition decodes only its
+    /// own striped subset of a segment's blocks. Summed across every partition
+    /// this equals what a single whole-segment scan would have reported for
+    /// `blocks_scanned`/`pages_*`.
+    fn record_scan(&self, stats: &ScanStats) {
+        self.scanned.add(stats.blocks_scanned as usize);
         self.pages_decoded.add(stats.pages_decoded as usize);
         self.pages_skipped.add(stats.pages_skipped as usize);
     }
@@ -476,11 +525,16 @@ impl LogsScanExec {
         full_schema: SchemaRef,
         declared: Arc<Vec<DeclaredColumn>>,
     ) -> DFResult<Self> {
-        let n = target_partitions.max(1).min(segments.len().max(1));
-        let mut partitions: Vec<Vec<SegmentRef>> = vec![Vec::new(); n];
-        for (i, seg) in segments.iter().enumerate() {
-            partitions[i % n].push(seg.clone());
-        }
+        // Blocks, not segments, are what get striped (ADR-0102), but the
+        // per-segment block counts are not known until a prune runs, which is
+        // async and cannot happen in this synchronous constructor. So the
+        // declared partition count is `target_partitions.max(1)` and the
+        // block-level assignment (with the stride `n` capped by the real block
+        // count) happens lazily on first poll, shared through `counts`. When
+        // there are fewer blocks than partitions the surplus partitions run
+        // empty, which is equivalent to capping `n` here and DataFusion handles
+        // empty partitions.
+        let declared_partitions = target_partitions.max(1);
         let full = full_schema;
         // A `None` projection means every column, in schema order. Resolving it
         // here rather than carrying an `Option` keeps one code path for the
@@ -499,11 +553,13 @@ impl LogsScanExec {
         let columns = resolve_columns(&projection, &content, &erasure, &declared);
         let schema: SchemaRef = Arc::new(full.project(&projection)?);
         let columnar_eligible = columnar_static_eligible(&projection, &erasure);
-        let properties = Arc::new(Self::compute_properties(&schema, n));
+        let properties = Arc::new(Self::compute_properties(&schema, declared_partitions));
         Ok(LogsScanExec {
             tenant_hash,
             fetcher,
-            partitions,
+            segments: Arc::new(segments.to_vec()),
+            target_partitions: declared_partitions,
+            counts: Arc::new(OnceCell::new()),
             ts_min,
             ts_max,
             content,
@@ -522,8 +578,11 @@ impl LogsScanExec {
 
     /// No output ordering (ADR-0087 decision 1). A block-streaming scan emits a
     /// partition's blocks in stored order, which is `(stream_ref, ts)` within a
-    /// block and segment order across a partition, so no `ts` ordering holds.
-    /// Downstream operators that need one get an explicit sort.
+    /// block and, across a partition, whatever striped subset of segments'
+    /// blocks it was assigned, so no `ts` ordering holds. Striping blocks rather
+    /// than whole segments (ADR-0102) removes even the per-segment grouping a
+    /// partition used to have, which only reinforces that no ordering can be
+    /// declared. Downstream operators that need one get an explicit sort.
     fn compute_properties(schema: &SchemaRef, n: usize) -> PlanProperties {
         let eq = EquivalenceProperties::new(Arc::clone(schema));
         PlanProperties::new(
@@ -539,8 +598,9 @@ impl fmt::Debug for LogsScanExec {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "LogsScanExec {{ partitions: {} }}",
-            self.partitions.len()
+            "LogsScanExec {{ partitions: {}, segments: {} }}",
+            self.target_partitions,
+            self.segments.len()
         )
     }
 }
@@ -550,7 +610,7 @@ impl DisplayAs for LogsScanExec {
         write!(
             f,
             "LogsScanExec: partitions={}, content={}, prune={}, projection=[{}]",
-            self.partitions.len(),
+            self.target_partitions,
             self.content.len(),
             self.prune.len(),
             self.schema
@@ -592,13 +652,6 @@ impl ExecutionPlan for LogsScanExec {
         partition: usize,
         context: Arc<TaskContext>,
     ) -> DFResult<SendableRecordBatchStream> {
-        let segments: VecDeque<SegmentRef> = self
-            .partitions
-            .get(partition)
-            .cloned()
-            .unwrap_or_default()
-            .into();
-
         let mut query =
             LogQuery::new(self.ts_min, self.ts_max).with_erasure((*self.erasure).clone());
         for c in self.content.iter() {
@@ -615,30 +668,153 @@ impl ExecutionPlan for LogsScanExec {
         let reservation = MemoryConsumer::new(format!("LogsScanExec[{partition}]"))
             .register(context.memory_pool());
 
+        let ctx = Arc::new(PartitionCtx {
+            fetcher: self.fetcher.clone(),
+            tenant_hash: self.tenant_hash,
+            query,
+            columns: self.columns.clone(),
+            accounting: self.accounting.clone(),
+        });
+
+        // The block-level assignment needs each segment's surviving-block count,
+        // which a prune must produce (async). The first partition to poll runs
+        // that prune for every segment through the shared `counts` cell; the
+        // rest await its result. Building the future here (not awaiting it)
+        // keeps `execute` synchronous, as DataFusion requires.
+        let counts_fut = plan_counts_future(
+            Arc::clone(&self.counts),
+            Arc::clone(&ctx),
+            Arc::clone(&self.segments),
+        );
+
         Ok(Box::pin(LogScanStream {
             schema: Arc::clone(&self.schema),
             projection: Arc::clone(&self.projection),
             declared: Arc::clone(&self.declared),
-            ctx: Arc::new(PartitionCtx {
-                fetcher: self.fetcher.clone(),
-                tenant_hash: self.tenant_hash,
-                query,
-                columns: self.columns.clone(),
-                accounting: self.accounting.clone(),
-            }),
+            ctx,
             erasure: Arc::clone(&self.erasure),
             columnar_eligible: self.columnar_eligible,
             blocks: BlockMetrics::new(&self.metrics, partition),
-            segments,
+            partition,
+            target_partitions: self.target_partitions,
+            segments: Arc::clone(&self.segments),
+            work: VecDeque::new(),
             reservation,
             held: 0,
             emitted: 0,
             pending: Pending::None,
             current_seg: None,
+            current_indices: Vec::new(),
             seg_columnar_blocks: 0,
-            state: LogScanState::NextSegment,
+            state: LogScanState::Planning(counts_fut),
         }))
     }
+}
+
+/// The shared per-segment block plan (ADR-0102): for each segment, in snapshot
+/// order, the count of blocks that survive this query's pruning and the
+/// whole-segment [`ScanStats`] the prune produced, or `None` for a
+/// ts-irrelevant segment (no GET, no blocks). Computed once and reused by every
+/// partition.
+struct PlanCounts {
+    segs: Vec<Option<SegPlan>>,
+    total_blocks: usize,
+}
+
+/// One relevant segment's contribution to [`PlanCounts`].
+struct SegPlan {
+    /// Blocks surviving this query's pruning; the count the block-index stripe
+    /// is computed over.
+    survivors: usize,
+    /// The whole-segment prune stats ([`BlockMetrics::record_segment_totals`]
+    /// consumes `blocks_total` and the postings drop). `blocks_scanned`/`pages`
+    /// are zero here -- planning decodes nothing.
+    stats: ScanStats,
+}
+
+type CountsFuture = Pin<Box<dyn Future<Output = DFResult<Arc<PlanCounts>>> + Send>>;
+
+/// A future resolving the shared [`PlanCounts`] through `cell`: the first
+/// partition to poll computes it (pruning every segment once), the rest await
+/// that one computation. Errors are not cached, so a transient fetch failure
+/// can be retried by a later poll.
+fn plan_counts_future(
+    cell: Arc<OnceCell<Arc<PlanCounts>>>,
+    ctx: Arc<PartitionCtx>,
+    segments: Arc<Vec<SegmentRef>>,
+) -> CountsFuture {
+    Box::pin(async move {
+        let counts = cell
+            .get_or_try_init(|| compute_plan_counts(&ctx, &segments))
+            .await?;
+        Ok(Arc::clone(counts))
+    })
+}
+
+/// Prune every segment once (no block decode) to build the shared block plan.
+/// Sequential on purpose: the reads are single-flight coalesced with the
+/// per-partition scans that follow, and this runs once per query, not per
+/// partition.
+async fn compute_plan_counts(
+    ctx: &PartitionCtx,
+    segments: &[SegmentRef],
+) -> DFResult<Arc<PlanCounts>> {
+    let mut segs = Vec::with_capacity(segments.len());
+    let mut total_blocks = 0usize;
+    for seg in segments {
+        let planned = ctx
+            .fetcher
+            .plan_segment(seg, ctx.tenant_hash, &ctx.query, &ctx.accounting)
+            .await
+            .map_err(SqlError::from)?;
+        match planned {
+            Some((survivors, stats)) => {
+                total_blocks += survivors;
+                segs.push(Some(SegPlan { survivors, stats }));
+            }
+            None => segs.push(None),
+        }
+    }
+    Ok(Arc::new(PlanCounts { segs, total_blocks }))
+}
+
+/// One segment this partition owns blocks in, and the block-index list (into
+/// the segment's surviving-block list) it must drain.
+struct OwnedSeg {
+    seg: SegmentRef,
+    indices: Vec<usize>,
+}
+
+/// This partition's share of the flattened block assignment (ADR-0102): unit
+/// `i` in the segment-then-block order over all surviving blocks goes to
+/// partition `i % n`, with `n = target_partitions.max(1).min(total.max(1))`.
+/// Returns, per owned segment, the surviving-block indices this partition
+/// drains, in ascending order.
+fn owned_work(
+    counts: &PlanCounts,
+    segments: &[SegmentRef],
+    partition: usize,
+    n: usize,
+) -> VecDeque<OwnedSeg> {
+    let mut work = VecDeque::new();
+    let mut global = 0usize;
+    for (seg_idx, plan) in counts.segs.iter().enumerate() {
+        let Some(plan) = plan else { continue };
+        let mut indices = Vec::new();
+        for local in 0..plan.survivors {
+            if (global + local) % n == partition {
+                indices.push(local);
+            }
+        }
+        global += plan.survivors;
+        if !indices.is_empty() {
+            work.push_back(OwnedSeg {
+                seg: segments[seg_idx].clone(),
+                indices,
+            });
+        }
+    }
+    work
 }
 
 /// Everything one partition's fetches need, shared by every per-segment open
@@ -653,18 +829,21 @@ struct PartitionCtx {
 
 type OpenFuture = Pin<Box<dyn Future<Output = DFResult<Option<LogSegmentScan>>> + Send>>;
 
-/// Fetch one segment's bytes and open its pruned, column-projected scan.
+/// Fetch one segment's bytes and open its pruned, column-projected scan
+/// restricted to the surviving-block positions in `indices` (ADR-0102).
 /// `Ok(None)` means the catalog summary proved the segment irrelevant, with no
-/// GET issued.
-fn open_segment(ctx: Arc<PartitionCtx>, seg: SegmentRef) -> OpenFuture {
+/// GET issued -- which cannot happen for a segment that was already counted
+/// with survivors, but is handled as end-of-segment rather than panicking.
+fn open_segment_subset(ctx: Arc<PartitionCtx>, seg: SegmentRef, indices: Vec<usize>) -> OpenFuture {
     Box::pin(async move {
         let scan = ctx
             .fetcher
-            .scan_accounted_with_tenant(
+            .scan_accounted_with_tenant_subset(
                 &seg,
                 ctx.tenant_hash,
                 &ctx.query,
                 &ctx.columns,
+                &indices,
                 &ctx.accounting,
             )
             .await
@@ -674,9 +853,14 @@ fn open_segment(ctx: Arc<PartitionCtx>, seg: SegmentRef) -> OpenFuture {
 }
 
 enum LogScanState {
-    /// Advance to the next segment of this partition, or finish.
+    /// Awaiting the shared per-segment block plan (ADR-0102). Once it resolves,
+    /// this partition's owned `(segment, block-index-list)` work is computed and
+    /// the stream advances to draining.
+    Planning(CountsFuture),
+    /// Advance to the next owned segment of this partition, or finish.
     NextSegment,
-    /// Awaiting one segment's GET and prune.
+    /// Awaiting one owned segment's GET and prune (restricted to this
+    /// partition's block-index list).
     Opening(OpenFuture),
     /// Draining one segment's surviving blocks through the columnar fast path
     /// (ADR-0099 decision 2). Entered only when the scan is statically eligible;
@@ -694,9 +878,14 @@ enum LogScanState {
         skip: usize,
     },
     /// Re-opening the current segment to restart it on the row path after a
-    /// block turned out to carry an `attrs_raw` overflow page. `skip` is the
-    /// number of blocks already emitted columnar for this segment, which the
-    /// re-opened row scan drains and discards so no row is emitted twice.
+    /// block turned out to carry an `attrs_raw` overflow page. The re-opened
+    /// scan is given the SAME block-index list this partition owns for the
+    /// segment (ADR-0102), so `skip` is a position within that list: the number
+    /// of this partition's blocks already emitted columnar. The re-opened row
+    /// scan drains and discards exactly those, then resumes, so no row this
+    /// partition owns is emitted twice or dropped -- and because the list is
+    /// this partition's own, a fallback another partition independently triggers
+    /// for the same segment concerns a disjoint list and cannot interfere.
     ReopenRows {
         fut: OpenFuture,
         skip: usize,
@@ -749,7 +938,17 @@ struct LogScanStream {
     /// drains the row path.
     columnar_eligible: bool,
     blocks: BlockMetrics,
-    segments: VecDeque<SegmentRef>,
+    /// This stream's DataFusion partition index, and the total declared count.
+    /// Together with the shared [`PlanCounts`] they determine which
+    /// `(segment, block-index-list)` units this partition owns (ADR-0102).
+    partition: usize,
+    target_partitions: usize,
+    /// Every segment in the snapshot, snapshot order, shared with the exec. The
+    /// owned-work computation indexes this by segment position.
+    segments: Arc<Vec<SegmentRef>>,
+    /// This partition's owned segments and their block-index lists, filled once
+    /// [`LogScanState::Planning`] resolves. Drained front to back.
+    work: VecDeque<OwnedSeg>,
     reservation: MemoryReservation,
     /// Reservation bytes currently covering `pending`.
     held: usize,
@@ -760,9 +959,14 @@ struct LogScanStream {
     /// The segment currently being drained, kept so the `attrs_raw` fallback can
     /// re-open it on the row path. Set when a segment's open resolves.
     current_seg: Option<SegmentRef>,
-    /// How many blocks of the current segment the columnar fast path has already
-    /// emitted. The `attrs_raw` fallback re-opens the segment and skips this many
-    /// blocks so none is emitted twice. Reset when a new segment starts draining.
+    /// The surviving-block index list this partition owns for [`Self::
+    /// current_seg`], kept so the `attrs_raw` fallback re-opens the row path
+    /// over the SAME list (ADR-0102). Set alongside `current_seg`.
+    current_indices: Vec<usize>,
+    /// How many of this partition's blocks in the current segment the columnar
+    /// fast path has already emitted. The `attrs_raw` fallback re-opens the
+    /// segment over `current_indices` and skips this many positions so none is
+    /// emitted twice. Reset when a new segment starts draining.
     seg_columnar_blocks: usize,
     state: LogScanState,
 }
@@ -919,12 +1123,40 @@ impl Stream for LogScanStream {
             }
 
             match &mut this.state {
-                LogScanState::NextSegment => match this.segments.pop_front() {
-                    Some(seg) => {
+                LogScanState::Planning(fut) => match fut.as_mut().poll(cx) {
+                    Poll::Ready(Ok(counts)) => {
+                        // Cap the stride by the real block count (ADR-0102): with
+                        // fewer blocks than partitions this collapses the extra
+                        // partitions to empty work, exactly what the declared
+                        // `min(target_partitions, total_blocks)` would give.
+                        let n = this
+                            .target_partitions
+                            .max(1)
+                            .min(counts.total_blocks.max(1));
+                        // Partition 0 publishes every relevant segment's
+                        // whole-segment prune totals, once, so striping a segment
+                        // across partitions does not multiply them.
+                        if this.partition == 0 {
+                            for plan in counts.segs.iter().flatten() {
+                                this.blocks.record_segment_totals(&plan.stats);
+                            }
+                        }
+                        this.work = owned_work(&counts, &this.segments, this.partition, n);
+                        this.state = LogScanState::NextSegment;
+                    }
+                    Poll::Ready(Err(e)) => return this.fail(e),
+                    Poll::Pending => return Poll::Pending,
+                },
+                LogScanState::NextSegment => match this.work.pop_front() {
+                    Some(OwnedSeg { seg, indices }) => {
                         this.current_seg = Some(seg.clone());
+                        this.current_indices = indices.clone();
                         this.seg_columnar_blocks = 0;
-                        this.state =
-                            LogScanState::Opening(open_segment(Arc::clone(&this.ctx), seg));
+                        this.state = LogScanState::Opening(open_segment_subset(
+                            Arc::clone(&this.ctx),
+                            seg,
+                            indices,
+                        ));
                     }
                     None => {
                         this.state = LogScanState::Done;
@@ -1017,15 +1249,19 @@ impl Stream for LogScanStream {
                     match step {
                         Step::Failed(e) => return this.fail(e),
                         Step::Exhausted(stats) => {
-                            this.blocks.record(&stats);
+                            this.blocks.record_scan(&stats);
                             this.state = LogScanState::NextSegment;
                         }
                         Step::Fallback => {
-                            // Re-open the segment and restart it on the row path,
+                            // Re-open the segment on the row path over the SAME
+                            // block-index list this partition owns (ADR-0102),
                             // skipping the blocks already emitted columnar so no
-                            // row is emitted twice. The abandoned columnar scan's
-                            // partial counters are dropped; the row scan re-counts
-                            // the whole segment.
+                            // row is emitted twice. `skip` is a position within
+                            // this partition's own list, so the count and the list
+                            // line up even when the segment's blocks are striped
+                            // across several partitions. The abandoned columnar
+                            // scan's partial counters are dropped; the row scan
+                            // re-scans this partition's whole list.
                             let seg = match this.current_seg.clone() {
                                 Some(seg) => seg,
                                 None => {
@@ -1034,7 +1270,11 @@ impl Stream for LogScanStream {
                                     ));
                                 }
                             };
-                            let fut = open_segment(Arc::clone(&this.ctx), seg);
+                            let fut = open_segment_subset(
+                                Arc::clone(&this.ctx),
+                                seg,
+                                this.current_indices.clone(),
+                            );
                             this.state = LogScanState::ReopenRows {
                                 fut,
                                 skip: this.seg_columnar_blocks,
@@ -1069,7 +1309,7 @@ impl Stream for LogScanStream {
                             Ok(Some(_)) => *skip -= 1,
                             Ok(None) => {
                                 let stats = scan.stats();
-                                this.blocks.record(&stats);
+                                this.blocks.record_scan(&stats);
                                 this.state = LogScanState::NextSegment;
                             }
                             Err(e) => return this.fail(SqlError::from(e).into()),
@@ -1086,7 +1326,7 @@ impl Stream for LogScanStream {
                         // now, so publish them before moving on.
                         Ok(None) => {
                             let stats = scan.stats();
-                            this.blocks.record(&stats);
+                            this.blocks.record_scan(&stats);
                             this.state = LogScanState::NextSegment;
                         }
                         Err(e) => return this.fail(SqlError::from(e).into()),

--- a/crates/ravel-sql/tests/logs_columnar.rs
+++ b/crates/ravel-sql/tests/logs_columnar.rs
@@ -399,6 +399,89 @@ async fn run_scan(
     }
 }
 
+/// The result of executing a `LogsScanExec` across ALL of its declared
+/// partitions (intra-segment scan partitioning, ADR-0102), for the tests that
+/// need block striping to actually fan out.
+struct MultiRun {
+    /// Every partition's batches, concatenated. Row order across partitions is
+    /// meaningless (no ordering is declared), so callers compare as a multiset.
+    batches: Vec<RecordBatch>,
+    columnar_batches: usize,
+    rowpath_batches: usize,
+    blocks_total: usize,
+    blocks_scanned: usize,
+    /// Partitions that emitted at least one row. The capability this item adds
+    /// is that this can exceed the segment count.
+    non_empty_partitions: usize,
+    /// The DataFusion partition count the scan declared (`target_partitions`).
+    declared_partitions: usize,
+}
+
+/// Execute `LogsScanExec` over `segments` at `target_partitions`, draining every
+/// declared partition and summing the path/block metrics across all of them.
+#[allow(clippy::too_many_arguments)]
+async fn run_scan_tp(
+    store: Arc<dyn ObjectStoreBackend>,
+    segments: Vec<SegmentRef>,
+    declared: Vec<DeclaredColumn>,
+    projection: Option<Vec<usize>>,
+    content: Vec<Predicate>,
+    erasure_reqs: Vec<ravel_proto::commit::v1::ErasureRequest>,
+    target_partitions: usize,
+) -> MultiRun {
+    let full_schema = logs_schema_with_declared(&declared);
+    let erasure = snapshot_pending_erasure_predicates(&Snapshot {
+        segments: segments.clone(),
+        segments_pruned: 0,
+        pending_erasure: erasure_reqs,
+    });
+    let scan = LogsScanExec::new(
+        TENANT,
+        LogSegmentFetcher::new(store),
+        &segments,
+        target_partitions,
+        i64::MIN,
+        i64::MAX,
+        Arc::new(content),
+        Arc::new(Vec::new()),
+        Arc::new(erasure),
+        projection.as_ref(),
+        QueryAccounting::new(),
+        full_schema,
+        Arc::new(declared),
+    )
+    .expect("build scan");
+
+    let declared_partitions = scan.properties().output_partitioning().partition_count();
+    let ctx = Arc::new(TaskContext::default());
+    let mut batches = Vec::new();
+    let mut non_empty_partitions = 0;
+    for p in 0..declared_partitions {
+        let mut stream = scan.execute(p, Arc::clone(&ctx)).expect("execute");
+        let mut rows_here = 0usize;
+        while let Some(next) = stream.next().await {
+            let batch = next.expect("batch");
+            rows_here += batch.num_rows();
+            batches.push(batch);
+        }
+        if rows_here > 0 {
+            non_empty_partitions += 1;
+        }
+    }
+
+    let metrics = scan.metrics().expect("metrics");
+    let count = |name: &str| metrics.sum_by_name(name).map(|v| v.as_usize()).unwrap_or(0);
+    MultiRun {
+        batches,
+        columnar_batches: count("columnar_batches"),
+        rowpath_batches: count("rowpath_batches"),
+        blocks_total: count("blocks_total"),
+        blocks_scanned: count("blocks_scanned"),
+        non_empty_partitions,
+        declared_partitions,
+    }
+}
+
 /// A dummy pending erasure whose key exists in no record, so it forces the row
 /// path (any erasure makes a scan ineligible) yet erases nothing, leaving the
 /// output identical to the fast path over the same input.
@@ -887,6 +970,367 @@ async fn a_later_block_with_attrs_raw_falls_back_without_losing_or_repeating_row
         got, want,
         "every row exactly once across the columnar/row switch, spilled values \
          included"
+    );
+}
+
+/// The strided sibling of the test above, for intra-segment scan partitioning
+/// (ADR-0102, deliverable 4): the single most important test in this item,
+/// because a wrong `ReopenRows` fallback drops or duplicates rows *silently* --
+/// no crash, just a wrong answer.
+///
+/// One segment of four two-record blocks is striped across `target_partitions =
+/// 2`. Blocks flatten to surviving positions 0..3 and unit `i` goes to partition
+/// `i % 2`, so partition 0 owns positions {0, 2} and partition 1 owns {1, 3}.
+/// The `attrs_raw` overflow is placed on positions 2 and 3 (the LATER block each
+/// partition owns), so on each partition the fallback fires on a block it does
+/// NOT own contiguously from the start of the segment: it has already emitted
+/// its position-0/1 block columnar (`seg_columnar_blocks == 1`) and must skip
+/// exactly ONE position of its OWN index list, not one block of the whole
+/// segment.
+///
+/// The fix (ADR-0102) is that the reopened row scan is handed the SAME
+/// `current_indices` this partition owns, so `skip` is a position within that
+/// list. Proven by mutation: temporarily change the `LogScanState::Fallback`
+/// arm in `crates/ravel-sql/src/logs_scan.rs` to reopen a contiguous
+/// whole-segment range instead of `this.current_indices.clone()` -- e.g.
+/// `open_segment_subset(ctx, seg, (0..=this.current_indices.iter().copied()
+/// .max().unwrap_or(0)).collect())` -- and this test goes RED with duplicated
+/// rows (each partition's whole-segment skip-by-count re-emits blocks the other
+/// partition owns). Restoring `this.current_indices.clone()` makes it pass.
+#[tokio::test]
+async fn a_strided_fallback_across_partitions_neither_drops_nor_repeats_rows() {
+    let declared = vec![DeclaredColumn::new("tags", DeclaredType::Str)];
+    let resource = vec![("service.name".to_string(), AttrValue::Str("api".into()))];
+    let mk = |ts: i64, spilled: bool| LogRecord {
+        stream_id: log_stream_id(&resource, "scope", "1.0", &[]),
+        stream_attrs: stream_attrs_bytes(&resource, "scope", "1.0", &[]),
+        ts_ns: ts,
+        observed_ts_ns: ts,
+        severity_num: 9,
+        severity_text: "INFO".into(),
+        body: "b".into(),
+        trace_id: None,
+        span_id: None,
+        flags: 0,
+        attrs: {
+            let mut attrs = vec![("filler".to_string(), AttrValue::Str("f".into()))];
+            if spilled {
+                attrs.push(("tags".to_string(), AttrValue::Str(format!("spilled-{ts}"))));
+            }
+            attrs
+        },
+    };
+    // Four blocks of two records: positions 0 (ts 0,1) and 1 (ts 2,3) are clean,
+    // positions 2 (ts 4,5) and 3 (ts 6,7) carry the `attrs_raw` page. Under the
+    // 2-way stride, partition 0 gets {clean pos 0, spilled pos 2} and partition 1
+    // gets {clean pos 1, spilled pos 3}: each falls back on its SECOND owned
+    // block, so `skip == 1` against its own two-element index list.
+    let records = vec![
+        mk(0, false),
+        mk(1, false),
+        mk(2, false),
+        mk(3, false),
+        mk(4, true),
+        mk(5, true),
+        mk(6, true),
+        mk(7, true),
+    ];
+    let cfg = RlogConfig {
+        block_target_records: 2,
+        max_dynamic_columns: 1,
+        ..RlogConfig::default()
+    };
+
+    let store = MemoryStore::new();
+    let seg = write_object(&store, "logs/strided-midspill.rlog", &records, cfg).await;
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(store);
+
+    let projection = vec![0usize, FIRST_DECLARED_COL];
+    let run = run_scan_tp(
+        store,
+        vec![seg],
+        declared.clone(),
+        Some(projection.clone()),
+        Vec::new(),
+        Vec::new(),
+        2,
+    )
+    .await;
+
+    // Both partitions ran, each emitting one clean block columnar and one
+    // spilled block through the re-opened row path.
+    assert_eq!(run.declared_partitions, 2, "target_partitions=2 declared");
+    assert_eq!(
+        run.non_empty_partitions, 2,
+        "both partitions own blocks and emit rows"
+    );
+    assert_eq!(
+        run.columnar_batches, 2,
+        "each partition emits its clean block columnar; columnar={}, rowpath={}",
+        run.columnar_batches, run.rowpath_batches
+    );
+    assert_eq!(
+        run.rowpath_batches, 2,
+        "each partition emits its spilled block via the re-opened row path; \
+         columnar={}, rowpath={}",
+        run.columnar_batches, run.rowpath_batches
+    );
+
+    let got = rows(&run.batches, &projection, &declared);
+    let want = vec![
+        vec![Cell::Ts(0), Cell::OptStr(None)],
+        vec![Cell::Ts(1), Cell::OptStr(None)],
+        vec![Cell::Ts(2), Cell::OptStr(None)],
+        vec![Cell::Ts(3), Cell::OptStr(None)],
+        vec![Cell::Ts(4), Cell::OptStr(Some("spilled-4".to_string()))],
+        vec![Cell::Ts(5), Cell::OptStr(Some("spilled-5".to_string()))],
+        vec![Cell::Ts(6), Cell::OptStr(Some("spilled-6".to_string()))],
+        vec![Cell::Ts(7), Cell::OptStr(Some("spilled-7".to_string()))],
+    ];
+    assert_eq!(
+        got, want,
+        "every row exactly once across the strided columnar/row switch, no drops \
+         and no duplicates"
+    );
+}
+
+/// Differential correctness (ADR-0102): the SAME query over the SAME segments
+/// yields the SAME row multiset under a single partition (blocks drained in
+/// order, the closest analogue of the old whole-segment partitioning) and under
+/// block-level striping across many partitions. Covers BOTH the
+/// already-adequately-partitioned case (segment count >= target_partitions) and
+/// the undersubscribed case (segment count < target_partitions), the latter
+/// being the one this item exists to fix.
+#[tokio::test]
+async fn block_striping_is_row_identical_to_single_partition() {
+    let declared = declared_columns();
+    // Vary block counts per segment so the stride crosses segment boundaries at
+    // non-trivial offsets (block_target_records = 3, see `small_blocks`).
+    let seg_sizes = [7usize, 4, 11, 5];
+    let mut all_records: Vec<Vec<LogRecord>> = Vec::new();
+    let mut ts = 0i64;
+    for &size in &seg_sizes {
+        let mut recs = Vec::with_capacity(size);
+        for _ in 0..size {
+            let spilled = ts % 3 == 0;
+            recs.push(LogRecord {
+                stream_id: log_stream_id(
+                    &[("service.name".to_string(), AttrValue::Str("api".into()))],
+                    "scope",
+                    "1.0",
+                    &[],
+                ),
+                stream_attrs: stream_attrs_bytes(
+                    &[("service.name".to_string(), AttrValue::Str("api".into()))],
+                    "scope",
+                    "1.0",
+                    &[],
+                ),
+                ts_ns: ts,
+                observed_ts_ns: ts,
+                severity_num: (ts % 5) as u8,
+                severity_text: "INFO".into(),
+                body: format!("body-{ts}"),
+                trace_id: None,
+                span_id: None,
+                flags: ts as u32,
+                attrs: {
+                    let mut a = vec![("filler".to_string(), AttrValue::Str("f".into()))];
+                    if spilled {
+                        // Overflow into attrs_raw for some blocks so the run also
+                        // exercises the fallback path under striping.
+                        a.push(("tags".to_string(), AttrValue::Str(format!("t-{ts}"))));
+                    }
+                    a
+                },
+            });
+            ts += 1;
+        }
+        all_records.push(recs);
+    }
+
+    // max_dynamic_columns = 1 so `tags` overflows into attrs_raw wherever it is
+    // set, forcing the columnar->row fallback on those blocks.
+    let cfg = RlogConfig {
+        block_target_records: 3,
+        max_dynamic_columns: 1,
+        ..RlogConfig::default()
+    };
+
+    let store = MemoryStore::new();
+    let mut segments = Vec::new();
+    for (i, recs) in all_records.iter().enumerate() {
+        segments.push(write_object(&store, &format!("logs/diff-{i}.rlog"), recs, cfg).await);
+    }
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(store);
+
+    let projection = vec![0usize, 4usize, FIRST_DECLARED_COL + 1];
+
+    let baseline = run_scan_tp(
+        Arc::clone(&store),
+        segments.clone(),
+        declared.clone(),
+        Some(projection.clone()),
+        Vec::new(),
+        Vec::new(),
+        1,
+    )
+    .await;
+    let baseline_rows = rows(&baseline.batches, &projection, &declared);
+
+    // Adequately partitioned: 4 segments, target_partitions = 4.
+    let adequate = run_scan_tp(
+        Arc::clone(&store),
+        segments.clone(),
+        declared.clone(),
+        Some(projection.clone()),
+        Vec::new(),
+        Vec::new(),
+        4,
+    )
+    .await;
+    assert_eq!(
+        rows(&adequate.batches, &projection, &declared),
+        baseline_rows,
+        "block striping at target_partitions=4 (>= segment count) must be \
+         row-identical to a single partition"
+    );
+
+    // Undersubscribed: 4 segments, target_partitions = 12 (the case this fixes).
+    let under = run_scan_tp(
+        Arc::clone(&store),
+        segments.clone(),
+        declared.clone(),
+        Some(projection.clone()),
+        Vec::new(),
+        Vec::new(),
+        12,
+    )
+    .await;
+    assert_eq!(
+        rows(&under.batches, &projection, &declared),
+        baseline_rows,
+        "block striping at target_partitions=12 (< nothing; > segment count) \
+         must be row-identical to a single partition"
+    );
+
+    // The whole-segment prune totals are counted once regardless of how many
+    // partitions stripe a segment: blocks_total is stable across the sweep.
+    assert_eq!(
+        baseline.blocks_total, adequate.blocks_total,
+        "blocks_total is a whole-object figure, counted once, not per partition"
+    );
+    assert_eq!(
+        baseline.blocks_total, under.blocks_total,
+        "blocks_total stays stable under heavy striping"
+    );
+    // Every surviving block is decoded exactly once across all partitions.
+    assert_eq!(
+        baseline.blocks_scanned, under.blocks_scanned,
+        "each surviving block is decoded exactly once whatever the partitioning"
+    );
+}
+
+/// The capability this item adds (ADR-0102): in the undersubscribed case
+/// (segment count < target_partitions) the scan now uses MORE than
+/// `segment_count` non-empty partitions when the block count allows it. Asserts
+/// the non-empty partition count directly, not just row correctness.
+#[tokio::test]
+async fn undersubscribed_uses_more_partitions_than_segments() {
+    let declared = declared_columns();
+    // Two segments, but 18 and 21 records at 3 records/block => 6 and 7 blocks,
+    // 13 surviving blocks total. With target_partitions = 8 the stride is
+    // min(8, 13) = 8, so 8 partitions each own at least one block -- four times
+    // the segment count.
+    let store = MemoryStore::new();
+    let cfg = small_blocks();
+    let mut segments = Vec::new();
+    let mut ts = 0i64;
+    for (i, &size) in [18usize, 21].iter().enumerate() {
+        let mut recs = Vec::with_capacity(size);
+        for _ in 0..size {
+            recs.push(LogRecord {
+                stream_id: log_stream_id(
+                    &[("service.name".to_string(), AttrValue::Str("api".into()))],
+                    "scope",
+                    "1.0",
+                    &[],
+                ),
+                stream_attrs: stream_attrs_bytes(
+                    &[("service.name".to_string(), AttrValue::Str("api".into()))],
+                    "scope",
+                    "1.0",
+                    &[],
+                ),
+                ts_ns: ts,
+                observed_ts_ns: ts,
+                severity_num: 1,
+                severity_text: "INFO".into(),
+                body: format!("b-{ts}"),
+                trace_id: None,
+                span_id: None,
+                flags: 0,
+                attrs: vec![],
+            });
+            ts += 1;
+        }
+        segments.push(write_object(&store, &format!("logs/under-{i}.rlog"), &recs, cfg).await);
+    }
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(store);
+
+    let projection = vec![0usize];
+    let run = run_scan_tp(
+        store,
+        segments,
+        declared,
+        Some(projection),
+        Vec::new(),
+        Vec::new(),
+        8,
+    )
+    .await;
+
+    assert_eq!(run.declared_partitions, 8, "target_partitions=8 declared");
+    assert!(
+        run.non_empty_partitions > 2,
+        "undersubscribed (2 segments) must fan out to more than 2 non-empty \
+         partitions; got {}",
+        run.non_empty_partitions
+    );
+    assert_eq!(
+        total_rows(&run.batches),
+        39,
+        "all 18+21 records are emitted once"
+    );
+}
+
+/// `LogsScanExec` still declares NO output ordering after the change to
+/// block-level striping (ADR-0087 decision 1, ADR-0102): striping blocks rather
+/// than segments only weakens any per-partition order, so declaring one would
+/// be unsound. Nothing downstream in this crate depends on scan order; an
+/// `ORDER BY` gets an explicit `SortExec` above this leaf.
+#[tokio::test]
+async fn logs_scan_declares_no_output_ordering() {
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+    let scan = LogsScanExec::new(
+        TENANT,
+        LogSegmentFetcher::new(store),
+        &[],
+        8,
+        i64::MIN,
+        i64::MAX,
+        Arc::new(Vec::new()),
+        Arc::new(Vec::new()),
+        Arc::new(Vec::new()),
+        None,
+        QueryAccounting::new(),
+        logs_schema_with_declared(&[]),
+        Arc::new(Vec::new()),
+    )
+    .expect("build scan");
+    assert!(
+        scan.properties().output_ordering().is_none(),
+        "LogsScanExec must declare no output ordering"
     );
 }
 

--- a/crates/ravel-sql/tests/logs_columnar.rs
+++ b/crates/ravel-sql/tests/logs_columnar.rs
@@ -33,6 +33,7 @@ use datafusion::execution::TaskContext;
 use datafusion::physical_plan::ExecutionPlan;
 use futures::StreamExt;
 use proptest::prelude::*;
+use ravel_cache::{Cache, CacheLimits};
 use ravel_catalog::{SegmentLevel, SegmentRef, Snapshot};
 use ravel_codec::encoding::{Enc, encode_strings};
 use ravel_logseg::block::{ColumnPlan, write_block};
@@ -50,8 +51,8 @@ use ravel_logseg::{
 };
 use ravel_object_store::memory::MemoryStore;
 use ravel_object_store::{ObjectStoreBackend, PutOptions};
-use ravel_query::LogSegmentFetcher;
 use ravel_query::erasure::snapshot_pending_erasure_predicates;
+use ravel_query::{CacheFetchError, LogSegmentFetcher};
 use ravel_sql::{
     DeclaredColumn, DeclaredType, FIRST_DECLARED_COL, LOG_COL_ATTRS, LogsScanExec,
     logs_schema_with_declared,
@@ -399,6 +400,14 @@ async fn run_scan(
     }
 }
 
+/// A logs fetcher with ADR-0046's read cache wired, sized to hold any fixture
+/// in this file with room to spare so the striping's repeated whole-object reads
+/// coalesce rather than evict each other.
+fn cached_fetcher(store: Arc<dyn ObjectStoreBackend>) -> LogSegmentFetcher {
+    let cache: Cache<CacheFetchError> = Cache::new(CacheLimits::new(1 << 26, 1 << 20, 1 << 26));
+    LogSegmentFetcher::new(store).with_cache(Arc::new(cache))
+}
+
 /// The result of executing a `LogsScanExec` across ALL of its declared
 /// partitions (intra-segment scan partitioning, ADR-0102), for the tests that
 /// need block striping to actually fan out.
@@ -419,6 +428,13 @@ struct MultiRun {
 
 /// Execute `LogsScanExec` over `segments` at `target_partitions`, draining every
 /// declared partition and summing the path/block metrics across all of them.
+///
+/// The fetcher is wired with ADR-0046's read cache, because that is the
+/// precondition `LogsScanExec::new` requires before it declares more partitions
+/// than there are segments (ADR-0102 decision 1): an un-cached fetcher is capped
+/// at the segment count, which is what
+/// `an_uncached_fetcher_caps_partitions_at_the_segment_count` pins. These tests
+/// exercise the striping itself, so they take the cached side of that gate.
 #[allow(clippy::too_many_arguments)]
 async fn run_scan_tp(
     store: Arc<dyn ObjectStoreBackend>,
@@ -437,7 +453,7 @@ async fn run_scan_tp(
     });
     let scan = LogsScanExec::new(
         TENANT,
-        LogSegmentFetcher::new(store),
+        cached_fetcher(store),
         &segments,
         target_partitions,
         i64::MIN,
@@ -1301,6 +1317,123 @@ async fn undersubscribed_uses_more_partitions_than_segments() {
         total_rows(&run.batches),
         39,
         "all 18+21 records are emitted once"
+    );
+}
+
+/// The cache gate on the fan-out (ADR-0102 decision 1): striping one segment's
+/// blocks across K partitions means K whole-object GETs at that segment's key,
+/// because the fetch unit is the whole object (ADR-0087 decision 3, no ranged
+/// block reader). ADR-0046's read cache is what makes those coalesce, so the
+/// planner only declares more partitions than segments when the fetcher carries
+/// one. Un-cached, the partition count falls back to the pre-ADR-0102 bound,
+/// `min(target_partitions, segment_count)`.
+///
+/// Both halves are asserted over the SAME fixture and the SAME
+/// `target_partitions`, so the only difference is the cache.
+#[tokio::test]
+async fn an_uncached_fetcher_caps_partitions_at_the_segment_count() {
+    let declared = declared_columns();
+    let resource = vec![("service.name".to_string(), AttrValue::Str("api".into()))];
+    let mk = |ts: i64| LogRecord {
+        stream_id: log_stream_id(&resource, "scope", "1.0", &[]),
+        stream_attrs: stream_attrs_bytes(&resource, "scope", "1.0", &[]),
+        ts_ns: ts,
+        observed_ts_ns: ts,
+        severity_num: 9,
+        severity_text: "INFO".into(),
+        body: format!("b-{ts}"),
+        trace_id: None,
+        span_id: None,
+        flags: 0,
+        attrs: Vec::new(),
+    };
+
+    // Two segments, 12 records each at 3 records/block: 4 blocks per segment, 8
+    // surviving blocks total, so the block count is NOT what limits the fan-out
+    // at target_partitions = 6. Only the cache gate is.
+    const SEGMENTS: usize = 2;
+    const TARGET_PARTITIONS: usize = 6;
+    let store = MemoryStore::new();
+    let mut segments = Vec::new();
+    let mut ts = 0i64;
+    for i in 0..SEGMENTS {
+        let recs: Vec<LogRecord> = (0..12)
+            .map(|_| {
+                let r = mk(ts);
+                ts += 1;
+                r
+            })
+            .collect();
+        segments.push(
+            write_object(
+                &store,
+                &format!("logs/gate-{i}.rlog"),
+                &recs,
+                small_blocks(),
+            )
+            .await,
+        );
+    }
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(store);
+    let full_schema = logs_schema_with_declared(&declared);
+    let projection = vec![0usize];
+
+    let build = |fetcher: LogSegmentFetcher| {
+        LogsScanExec::new(
+            TENANT,
+            fetcher,
+            &segments,
+            TARGET_PARTITIONS,
+            i64::MIN,
+            i64::MAX,
+            Arc::new(Vec::new()),
+            Arc::new(Vec::new()),
+            Arc::new(Vec::new()),
+            Some(&projection),
+            QueryAccounting::new(),
+            Arc::clone(&full_schema),
+            Arc::new(declared.clone()),
+        )
+        .expect("build scan")
+    };
+
+    let uncached = build(LogSegmentFetcher::new(Arc::clone(&store)));
+    assert_eq!(
+        uncached
+            .properties()
+            .output_partitioning()
+            .partition_count(),
+        SEGMENTS,
+        "an un-cached fetcher caps the partition count at the segment count \
+         ({SEGMENTS}), not target_partitions ({TARGET_PARTITIONS}): nothing \
+         absorbs the extra whole-object GETs"
+    );
+
+    let cached = build(cached_fetcher(Arc::clone(&store)));
+    assert_eq!(
+        cached.properties().output_partitioning().partition_count(),
+        TARGET_PARTITIONS,
+        "a cache-wired fetcher declares target_partitions ({TARGET_PARTITIONS}) \
+         even though only {SEGMENTS} segments are scanned"
+    );
+
+    // The clamp must not lose rows: the capped plan still emits every record.
+    let ctx = Arc::new(TaskContext::default());
+    let mut rows_seen = 0usize;
+    for p in 0..uncached
+        .properties()
+        .output_partitioning()
+        .partition_count()
+    {
+        let mut stream = uncached.execute(p, Arc::clone(&ctx)).expect("execute");
+        while let Some(next) = stream.next().await {
+            rows_seen += next.expect("batch").num_rows();
+        }
+    }
+    assert_eq!(
+        rows_seen,
+        SEGMENTS * 12,
+        "the un-cached, segment-capped plan still emits every record"
     );
 }
 

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -1290,6 +1290,46 @@ partition count, not of table size. Before ADR-0087 the scan collected a whole
 partition's records in row form, sorted them, and only then emitted batches, so
 a full-table scan's peak memory grew with the table.
 
+#### How many partitions, and the read-cache precondition (ADR-0102)
+
+What a partition owns is *blocks*, not whole segments: every
+`(segment, surviving-block)` pair is flattened into one list and unit `i` goes to
+partition `i % n`. So a query touching fewer segments than `target_partitions`
+can still fan out past the segment count, which the old segment-granular rule
+(`min(target_partitions, segment_count)`) made impossible.
+
+That fan-out is gated on the logs fetcher carrying ADR-0046's read cache, which
+is the precondition ADR-0102 decision 1 names for it:
+
+- **Cache wired** (`ravel-server` built a read cache and called
+  `LogSegmentFetcher::with_cache`, i.e. `--disable-cache` is off): the scan
+  declares `target_partitions` partitions, even where the snapshot has fewer
+  segments than that.
+- **No cache** (`--disable-cache`, or any embedding that never calls
+  `with_cache`): the scan declares `min(target_partitions, segment_count)`, the
+  pre-ADR-0102 bound.
+
+The reason is the fetch unit. There is no ranged block reader on the SQL read
+path, so each partition that owns blocks in a segment fetches that segment's
+whole object. With the cache, those reads coalesce through single-flight on one
+key; without it, each is a real object-store GET, and partitions beyond the
+segment count would multiply GETs with nothing absorbing them. Note what the cap
+does and does not buy: it stops `target_partitions` from setting the multiplier,
+but below the cap a plan with `n` partitions still opens each sufficiently-blocky
+segment `n` times, and the planning prune that counts surviving blocks adds one
+more read per segment. `ravel-bench`'s `logs_scan_scaling` report measures the
+cached and un-cached request counts side by side; its figures describe that
+fixture (a `MemoryStore`, a cache sized to hold the whole dataset), not striping
+in general.
+
+The peak-memory consequence follows the same gate. Concurrently-held scan memory
+is bounded by block size times the number of partitions decoding at once, so
+only the cached configuration raises that bound above the old
+`min(target_partitions, segment_count)` one — an un-cached deployment's bound is
+unchanged by ADR-0102. The per-query DataFusion pool enforces it either way:
+a partition count that would exceed the budget fails the query rather than
+spilling (ADR-0013).
+
 Two consequences an operator and a plan reader both see:
 
 - **The scan declares no output ordering.** It used to declare `ts` ascending


### PR DESCRIPTION
Logs queries were pinned to at most one partition per segment
(min(target_partitions, segment_count)), so a query touching few
segments could not use the parallelism a query touching many did.
ADR-0102 decision 1 splits striping to block granularity: blocks,
not segments, get assigned round-robin across target_partitions
partitions, with the per-segment surviving-block count and the
striped assignment resolved lazily on first poll since the prune
that determines it is async.

That fan-out only pays off when the extra whole-object GETs it
causes are absorbed by ADR-0046's single-flight read cache: without
one, striping more partitions than there are segments multiplies
real object-store requests for no reason. This ships the fan-out
gated on LogSegmentFetcher::has_cache() -- a cached fetcher keeps
target_partitions.max(1) partitions, an uncached one falls back to
the pre-existing min(target_partitions, segment_count) bound. This
makes ADR-0102 decision 1's named precondition (the cache) real in
code instead of assumed; the ADR itself is unchanged.

Includes a BlockScan reader API for the explicit per-partition block
list, a fix to the ReopenRows segment-reopen path (it now reopens
against the partition's own block-index list instead of a positional
whole-segment skip, which previously duplicated rows on a striped
partition), and a ravel-bench logs_scan_scaling benchmark measuring
both request-count shapes and the per-segment planning latency.

Fixes: #503
Refs: #361
