### PR TITLE
feat(ravel-bench): wire the flamegraph lane into sql_latency_bench

### DIFF
--- a/crates/ravel-bench/src/sql_latency.rs
+++ b/crates/ravel-bench/src/sql_latency.rs
@@ -338,6 +338,12 @@ pub async fn measure_corpus(
     let mut measured = Vec::new();
     let mut skipped = Vec::new();
 
+    // CPU flamegraph lane (issue #365's pattern; see crate::profiling). Covers
+    // every entry's execution, both lanes (run_generated/run_tenant funnel
+    // through this one function), so a query-side profile always reflects the
+    // full corpus rather than one statement in isolation.
+    let profile = crate::profiling::ProfileSession::from_env("sql_latency_bench");
+
     for entry in entries {
         // Verify the declared-column dependency before running anything. A
         // missing declared column reads NULL for every row, so an unsatisfied
@@ -423,6 +429,8 @@ pub async fn measure_corpus(
             scan,
         });
     }
+
+    profile.finish();
 
     Ok((measured, skipped))
 }


### PR DESCRIPTION
## Summary
- `ravel-bench`'s pprof-based CPU flamegraph lane (`crates/ravel-bench/src/profiling.rs`, issue #365) is already wired into `ingest_bench`/`query_latency_bench`, but not `sql_latency_bench` - the bin that runs the ADR-0100 ClickBench corpus.
- Brackets `measure_corpus`'s per-entry execution loop with `ProfileSession::from_env`. Both `run_generated` and `run_tenant` funnel through this one function, so a query-side flamegraph covers the whole corpus regardless of lane.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p ravel-bench --all-targets --features sql-latency -- -D warnings`
- [x] `cargo clippy -p ravel-bench --all-targets --features sql-latency,profiling -- -D warnings`
- [x] `cargo test -p ravel-bench --features sql-latency` (full suite, real output verified after an initial name-filter false negative)
- [x] `cargo test -p ravel-bench --features sql-latency,profiling` (full suite)

Fixes: #551