### PR TITLE
fix(clickbench): promote CounterID to a resource attribute

### DIFF
--- a/benchmarks/clickbench/hits.mapping.toml
+++ b/benchmarks/clickbench/hits.mapping.toml
@@ -42,10 +42,33 @@ ts_column = "EventTime"
 # the parquet only when EventTime is stored as an integer.
 ts_unit = "seconds"
 
-# All 104 non-EventTime columns, as record attributes (typed values in `attrs`, not
-# part of stream identity). No resource_attribute entries: the flat `hits` table has
-# no per-entity stream key, so every row shares one logstream. 104 attributes sit far
-# under the per-object dynamic-column budget of 1000 (RlogConfig::max_dynamic_columns).
+# CounterID (issue #519): the one column in `hits` that acts as a per-entity
+# key -- ClickBench's "counter" is the site/tag being measured, so CounterID
+# is the natural stream boundary. Declared as a resource_attribute rather than
+# an attribute so it becomes part of stream identity (ADR-0029 log_stream_id):
+# `shard_for_log` hashes resource attributes, so this is what actually spreads
+# ingest across `--shards`. In the pre-#519 mapping, CounterID was a record
+# attribute: every row's resource-attribute set was empty, so every row hashed
+# to the same stream and 100% of writes landed on one shard regardless of
+# --shards -- one core did all merge+encode work no matter how many shards
+# were provisioned.
+#
+# `ravel-cli load` runs with a fixed `target_bytes: 1` (one Strict flush per
+# batch), so raising --shards without raising --batch-rows to compensate
+# produces MORE, SMALLER objects: a batch's rows now split across shards by
+# CounterID hash, and each shard's slice flushes immediately as its own
+# object, before it can reach the `block_target_records` target (8192). See
+# docs/guides/clickbench.md step 2 for the --batch-rows this requires.
+#
+# The other 103 non-EventTime columns stay record attributes (typed values in
+# `attrs`, not part of stream identity). 104 declared columns total (103
+# attribute + 1 resource_attribute) sit far under the per-object dynamic-column
+# budget of 1000 (RlogConfig::max_dynamic_columns).
+
+[[resource_attribute]]
+key = "CounterID"
+column = "CounterID"
+type = "i64"
 
 [[attribute]]
 key = "WatchID"
@@ -70,11 +93,6 @@ type = "i64"
 [[attribute]]
 key = "EventDate"
 column = "EventDate"
-type = "i64"
-
-[[attribute]]
-key = "CounterID"
-column = "CounterID"
 type = "i64"
 
 [[attribute]]

--- a/docs/guides/clickbench.md
+++ b/docs/guides/clickbench.md
@@ -65,16 +65,31 @@ ravel-cli --store <your-store-flags> load \
   --tenant clickbench \
   --mapping benchmarks/clickbench/hits.mapping.toml \
   --shards 4 \
-  --batch-rows 10000
+  --batch-rows 40000
 ```
 
 `--batch-rows` is the object-count lever. One batch is one Strict flush, which is
-one RLOG object per involved shard, so ~100M rows at the default `10000` leaves
-on the order of 10,000 flushes' worth of objects behind. Per-object cost (LIST,
-footer read, decode setup) is then paid thousands of times per query and can
-dominate everything the columnar and pushdown work saves, so object count is a
+one RLOG object per shard the batch's rows land on. Per-object cost (LIST,
+footer read, decode setup) is paid thousands of times per query and can dominate
+everything the columnar and pushdown work saves, so object count is a
 first-class variable: raise `--batch-rows` for fewer, larger objects; lower it
 for the opposite. Measure both if you care where the time goes.
+
+`hits.mapping.toml` declares `CounterID` as a `resource_attribute` (issue
+#519), so it is part of stream identity and `shard_for_log` hashes it to pick
+a shard: rows spread across all `--shards` instead of every row landing on
+shard 0. That changes the batch-rows arithmetic. A batch's rows now split
+across up to `--shards` shards, and each shard's slice flushes as its own
+object *immediately* (the loader's `target_bytes` is fixed at `1`) — before it
+can reach the `block_target_records` block target (8192 rows). With the
+default `--batch-rows 10000` and `--shards 4`, a shard's slice averages ~2500
+rows, well under one full block, and object count would inflate well past
+`--shards`x rather than by a clean multiple. Raise `--batch-rows` to keep each
+shard's average slice at or above 8192: `40000` keeps that margin (`40000 / 4
+= 10000` rows/shard) while landing on roughly the same total object count as
+the pre-#519 single-shard `10000` batch size at ~100M rows. Lower `--shards`
+or raise `--batch-rows` further if a load still reports objects smaller than
+expected.
 
 The loader prints a completion summary to stdout — `rows processed`,
 `objects written`, and `elapsed` (the load wall-time ClickBench reports). It also
@@ -95,8 +110,9 @@ ravel-cli --store <your-store-flags> typed-attr-column set clickbench \
   --from-mapping benchmarks/clickbench/hits.mapping.toml
 ```
 
-This writes ~104 declared columns (every `[[attribute]]` entry) through the
-config CAS path. Notes specific to `hits`:
+This writes ~104 declared columns (every `[[attribute]]` and
+`[[resource_attribute]]` entry) through the config CAS path. Notes specific to
+`hits`:
 
 - **`EventTime` is not declared.** It is the mapping's `ts_column`, so it rides
   the native typed `ts` path; range predicates over it need no declared column.

--- a/services/ravel-cli/tests/clickbench_mapping.rs
+++ b/services/ravel-cli/tests/clickbench_mapping.rs
@@ -1,0 +1,57 @@
+//! Gate test for the checked-in ClickBench mapping (issue #519), at
+//! `benchmarks/clickbench/hits.mapping.toml`.
+//!
+//! `CounterID` is the one column in the flat `hits` table that acts as a
+//! per-entity key. It must stay a `[[resource_attribute]]`, not a
+//! `[[attribute]]`: only resource attributes are hashed into stream identity
+//! (ADR-0029 `log_stream_id`), and `shard_for_log` uses that hash to pick a
+//! shard. Left as a record attribute, every row's resource-attribute set is
+//! empty, every row hashes to the same stream, and every write lands on one
+//! shard regardless of `--shards` -- the single-shard, single-core load this
+//! issue diagnosed. A future edit that moves `CounterID` back to
+//! `[[attribute]]` (or drops it) reintroduces that bottleneck silently; this
+//! test catches it the same way `clickbench_corpus.rs` keeps the corpus file
+//! honest against the runbook.
+#![allow(clippy::expect_used)]
+
+use std::path::PathBuf;
+
+use ravel_cli::load::{ColType, parse_mapping};
+
+fn mapping_path() -> PathBuf {
+    PathBuf::from(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../benchmarks/clickbench/hits.mapping.toml"
+    ))
+}
+
+#[test]
+fn counter_id_is_the_sole_resource_attribute() {
+    let text = std::fs::read_to_string(mapping_path()).expect("hits.mapping.toml is checked in");
+    let mapping = parse_mapping(&text).expect("hits.mapping.toml parses");
+
+    assert_eq!(
+        mapping.resource_attributes.len(),
+        1,
+        "expected exactly one resource_attribute (CounterID); found {:?}",
+        mapping
+            .resource_attributes
+            .iter()
+            .map(|a| &a.key)
+            .collect::<Vec<_>>()
+    );
+    let counter_id = &mapping.resource_attributes[0];
+    assert_eq!(counter_id.key, "CounterID");
+    assert_eq!(counter_id.column, "CounterID");
+    assert_eq!(counter_id.value_type, ColType::I64);
+
+    assert!(
+        mapping.attributes.iter().all(|a| a.key != "CounterID"),
+        "CounterID must not also appear as a record attribute"
+    );
+    assert_eq!(
+        mapping.attributes.len(),
+        103,
+        "expected 103 record attributes now that CounterID moved to resource_attribute"
+    );
+}


### PR DESCRIPTION
## Summary

- `ravel-cli load --parquet` was routing every row of the ClickBench
  `hits` dataset to the same shard regardless of `--shards`, because
  `hits.mapping.toml` declared zero `[[resource_attribute]]` entries.
  `log_stream_id` (ADR-0029) hashes only resource attributes into
  stream identity, so an empty resource-attribute set means every row
  hashes to one stream and `shard_for_log` sends 100% of writes to
  shard 0 -- one core does all merge/encode work no matter how many
  shards are provisioned. Confirmed live: one busy core on a 16-core
  box for the whole duration of a 100M-row load.
- `CounterID` is the natural per-entity key in the flat `hits` table
  (the site/tag a hit belongs to), so it moves from `[[attribute]]` to
  `[[resource_attribute]]`. It stays a declared typed column either
  way -- `typed-attr-column set --from-mapping` declares
  `resource_attribute` entries the same as `attribute` entries.
- Updates the guide's `--batch-rows` recommendation (10000 -> 40000).
  `ravel-cli load` runs with a fixed `target_bytes: 1`, so once a
  batch's rows split across shards, each shard's slice flushes
  immediately as its own object -- before it can reach the
  `block_target_records` target (8192). Without raising batch size to
  compensate, promoting a resource attribute inflates object count
  well past a clean `--shards`x multiple.
- Adds a gate test (`services/ravel-cli/tests/clickbench_mapping.rs`)
  parsing the checked-in mapping and asserting `CounterID` is the sole
  resource attribute, mirroring the existing `clickbench_corpus.rs`
  gate for the corpus file.

## Test plan

- [x] `cargo fmt --all --check` (ravel-cli)
- [x] `cargo clippy -p ravel-cli --all-targets -- -D warnings`
- [x] `cargo test -p ravel-cli` (all green, including the new gate test)
- [x] Mutation check: reverted the mapping change locally, confirmed
      `counter_id_is_the_sole_resource_attribute` fails
      (`left: 0, right: 1`), then restored the fix
- [ ] Live multi-shard load measurement against the real dataset
      (tracked as a follow-up comment on #519, not blocking this PR --
      the mechanism is already covered by `load.rs`'s existing
      `stream_identity_follows_resource_attributes_not_record_attributes`
      test; this PR applies it to the checked-in benchmark config)

Refs: #519
