### PR TITLE
feat(object-store): add S3 instance-role credential source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4798,6 +4798,7 @@ dependencies = [
  "object_store 0.14.1",
  "parking_lot",
  "rand 0.10.2",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/ravel-bench/src/bin/catalog_resolve_bench.rs
+++ b/crates/ravel-bench/src/bin/catalog_resolve_bench.rs
@@ -98,6 +98,8 @@ fn s3_config_from_env() -> S3Config {
         kms_key_id: None,
         session_token: None,
         credentials_file: None,
+        auth: Default::default(),
+        instance_metadata_endpoint: None,
     }
 }
 

--- a/crates/ravel-bench/src/bin/read_path_accounting.rs
+++ b/crates/ravel-bench/src/bin/read_path_accounting.rs
@@ -172,6 +172,8 @@ fn s3_config_from_env() -> Option<ravel_object_store::s3::S3Config> {
         kms_key_id: None,
         session_token: None,
         credentials_file: None,
+        auth: Default::default(),
+        instance_metadata_endpoint: None,
     })
 }
 

--- a/crates/ravel-bench/src/harness.rs
+++ b/crates/ravel-bench/src/harness.rs
@@ -49,6 +49,8 @@ pub fn s3_config_from_env() -> S3Config {
         kms_key_id: None,
         session_token: None,
         credentials_file: None,
+        auth: Default::default(),
+        instance_metadata_endpoint: None,
     }
 }
 

--- a/crates/ravel-bench/tests/concurrent_smoke.rs
+++ b/crates/ravel-bench/tests/concurrent_smoke.rs
@@ -127,6 +127,8 @@ async fn readers_writers_minio_smoke() {
         kms_key_id: None,
         session_token: None,
         credentials_file: None,
+        auth: Default::default(),
+        instance_metadata_endpoint: None,
     };
     let store = S3Store::new(s3_config).expect("S3Store::new must succeed with a valid config");
 

--- a/crates/ravel-bench/tests/query_latency_smoke.rs
+++ b/crates/ravel-bench/tests/query_latency_smoke.rs
@@ -107,6 +107,8 @@ async fn promql_instant_range_minio_smoke() {
         kms_key_id: None,
         session_token: None,
         credentials_file: None,
+        auth: Default::default(),
+        instance_metadata_endpoint: None,
     };
     let store = S3Store::new(config).expect("S3Store::new must succeed with a valid config");
 

--- a/crates/ravel-bench/tests/s3_e2e_smoke.rs
+++ b/crates/ravel-bench/tests/s3_e2e_smoke.rs
@@ -79,6 +79,8 @@ async fn minio_ingest_read_smoke() {
         kms_key_id: None,
         session_token: None,
         credentials_file: None,
+        auth: Default::default(),
+        instance_metadata_endpoint: None,
     };
     let store = S3Store::new(config).expect("S3Store::new must succeed with a valid config");
 

--- a/crates/ravel-object-store/Cargo.toml
+++ b/crates/ravel-object-store/Cargo.toml
@@ -26,6 +26,11 @@ serde = { workspace = true }
 # production dependency now, not just the dev-only JSON-shape regression test
 # serde_json was here for before.
 serde_json = { workspace = true }
+# HTTP client for the EC2 IMDSv2 instance-role credential provider (ADR-0106,
+# crates/ravel-object-store/src/s3/instance_role.rs): two plain-HTTP calls to
+# the link-local metadata endpoint. Version pinned once in the workspace so all
+# crates resolve the same reqwest.
+reqwest = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ravel-object-store/src/kms_routing.rs
+++ b/crates/ravel-object-store/src/kms_routing.rs
@@ -451,6 +451,8 @@ mod tests {
             kms_key_id: None,
             session_token: None,
             credentials_file: None,
+            auth: Default::default(),
+            instance_metadata_endpoint: None,
         }
     }
 

--- a/crates/ravel-object-store/src/s3.rs
+++ b/crates/ravel-object-store/src/s3.rs
@@ -90,6 +90,9 @@ use crate::{
 mod credentials;
 use credentials::FileCredentialProvider;
 
+mod instance_role;
+use instance_role::{DEFAULT_IMDS_ENDPOINT, InstanceRoleCredentialProvider};
+
 /// Default entries per `ListPage`, chosen to line up with S3's own
 /// `ListObjectsV2` page size. Overridable per instance via
 /// [`S3Store::with_page_size`].
@@ -129,6 +132,27 @@ const _: () = assert!(crate::MULTIPART_MAX_PARTS * MULTIPART_PART_SIZE >= 64 * 1
 /// compactor writing several objects at once must not open an unbounded
 /// number of connections per object.
 const MULTIPART_UPLOAD_CONCURRENCY: usize = 4;
+
+/// How [`S3Store`] sources AWS credentials (ADR-0106).
+///
+/// `Static` (the default) is every deployment today: inline keys, an optional
+/// `session_token`, or a rotating `credentials_file`. `InstanceRole` fetches
+/// short-lived credentials from the EC2 instance metadata service (IMDSv2) and
+/// forbids any inline credential field being set at the same time. Selecting
+/// the source is explicit, never inferred from the absence of keys, per
+/// `S3Config`'s "no credential-chain magic" contract. Future sources (EKS
+/// IRSA, ECS task roles) fit as additional variants.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum S3AuthMode {
+    /// Inline `access_key_id`/`secret_access_key`, optionally with
+    /// `session_token` or `credentials_file`. Behaves exactly as before
+    /// ADR-0106.
+    #[default]
+    Static,
+    /// Short-lived credentials from the EC2 IMDSv2 endpoint. Requires every
+    /// inline credential field to be absent.
+    InstanceRole,
+}
 
 /// Explicit configuration for the S3 / MinIO adapter. No environment or
 /// credential-chain magic: every value that changes behavior is a field
@@ -190,6 +214,17 @@ pub struct S3Config {
     /// `access_key_id`/`secret_access_key`/`session_token` are set, the file
     /// wins.
     pub credentials_file: Option<PathBuf>,
+    /// Which credential source [`S3Store`] uses (ADR-0106). `Static` (the
+    /// default) is every caller today and preserves byte-identical behavior.
+    /// `InstanceRole` fetches from EC2 IMDSv2 and requires `access_key_id`,
+    /// `secret_access_key`, `session_token`, and `credentials_file` all to be
+    /// absent; [`S3Store::new`] rejects the mix with a typed [`StoreError`].
+    pub auth: S3AuthMode,
+    /// Base URL of the EC2 instance metadata service, used only when
+    /// `auth` is [`S3AuthMode::InstanceRole`]. `None` uses the AWS link-local
+    /// address (`http://169.254.169.254`); a value redirects IMDS to a mock in
+    /// tests or an unusual deployment. Ignored under [`S3AuthMode::Static`].
+    pub instance_metadata_endpoint: Option<String>,
 }
 
 /// S3 / MinIO backend implementing [`ObjectStoreBackend`] over
@@ -202,11 +237,15 @@ pub struct S3Store {
     /// opaque `object_store::CredentialProvider` trait object) purely so
     /// [`S3Store::credential_rotation_failures`] has something to read.
     credential_provider: Option<Arc<FileCredentialProvider>>,
+    /// `Some` only under [`S3AuthMode::InstanceRole`]; kept for the same reason
+    /// as `credential_provider`, so [`S3Store::credential_refresh_failures`]
+    /// can read its counter (ADR-0106).
+    instance_role_provider: Option<Arc<InstanceRoleCredentialProvider>>,
 }
 
 impl S3Store {
     pub fn new(config: S3Config) -> Result<Self, StoreError> {
-        let (builder, credential_provider) = Self::builder(&config)?;
+        let (builder, credential_provider, instance_role_provider) = Self::builder(&config)?;
         let store = builder
             .build()
             .map_err(|e| StoreError::Permanent(format!("failed to build S3 client: {e}")))?;
@@ -214,6 +253,7 @@ impl S3Store {
             store,
             page_size: LIST_PAGE_SIZE,
             credential_provider,
+            instance_role_provider,
         })
     }
 
@@ -228,6 +268,19 @@ impl S3Store {
             .unwrap_or(0)
     }
 
+    /// Count of [`S3AuthMode::InstanceRole`] request-path refreshes that failed
+    /// while the cached credential was already expired, so the S3 request had
+    /// to fail (ADR-0106). A transient failure that still served an unexpired
+    /// last-good credential does not count. Always `0` under
+    /// [`S3AuthMode::Static`]. Mirrors [`S3Store::credential_rotation_failures`]
+    /// so #545 can wire both into ravel-server observability.
+    pub fn credential_refresh_failures(&self) -> u64 {
+        self.instance_role_provider
+            .as_deref()
+            .map(InstanceRoleCredentialProvider::refresh_failures)
+            .unwrap_or(0)
+    }
+
     /// Build the `AmazonS3Builder` from a [`S3Config`], with no network
     /// access (`build()` only validates local config shape). Split out from
     /// [`S3Store::new`] so a test can assert the fully-configured builder
@@ -238,17 +291,40 @@ impl S3Store {
     /// contract) only when `credentials_file` is `Some` and that file is
     /// unreadable or not valid JSON in the expected shape; every other
     /// config shape only sets local builder fields and cannot fail here.
-    /// Returns the [`FileCredentialProvider`] alongside the builder (rather
-    /// than only handing it to `with_credentials` as an opaque trait object)
-    /// so [`S3Store::new`] can keep its own handle for observability.
+    /// Returns the [`FileCredentialProvider`] and
+    /// [`InstanceRoleCredentialProvider`] alongside the builder (rather than
+    /// only handing whichever is active to `with_credentials` as an opaque
+    /// trait object) so [`S3Store::new`] can keep its own handle for
+    /// observability. At most one is ever `Some`.
+    ///
+    /// Under [`S3AuthMode::InstanceRole`] the inline key setters are skipped
+    /// entirely and the eager IMDS fetch runs here (so a misconfigured
+    /// instance fails at construction); mixing that mode with any inline
+    /// credential field is rejected with a typed [`StoreError`] before any
+    /// network call.
+    #[allow(clippy::type_complexity)]
     fn builder(
         config: &S3Config,
-    ) -> Result<(AmazonS3Builder, Option<Arc<FileCredentialProvider>>), StoreError> {
+    ) -> Result<
+        (
+            AmazonS3Builder,
+            Option<Arc<FileCredentialProvider>>,
+            Option<Arc<InstanceRoleCredentialProvider>>,
+        ),
+        StoreError,
+    > {
         let mut builder = AmazonS3Builder::new()
             .with_bucket_name(&config.bucket)
-            .with_region(&config.region)
-            .with_access_key_id(&config.access_key_id)
-            .with_secret_access_key(&config.secret_access_key)
+            .with_region(&config.region);
+        // The inline key setters exist only under Static: `InstanceRole` never
+        // signs with a static key, and setting one would be exactly the mix the
+        // check below forbids.
+        if matches!(config.auth, S3AuthMode::Static) {
+            builder = builder
+                .with_access_key_id(&config.access_key_id)
+                .with_secret_access_key(&config.secret_access_key);
+        }
+        builder = builder
             .with_allow_http(config.allow_http)
             .with_virtual_hosted_style_request(!config.force_path_style);
         if let Some(endpoint) = &config.endpoint {
@@ -258,23 +334,60 @@ impl S3Store {
         // inside S3 on every PUT, no crypto code here. Dual-layer DSSE is
         // reachable via `with_dsse_kms_encryption` on this same builder if a
         // future requirement needs it; single-layer is the sufficient default.
+        // Applies to both auth modes: an instance role needs
+        // kms:GenerateDataKey/kms:Decrypt on this key (docs/object-store-contract.md).
         if let Some(kms_key_id) = &config.kms_key_id {
             builder = builder.with_sse_kms_encryption(kms_key_id);
         }
-        // Rotating file credentials win over inline ones (ADR-0072 decision
-        // 1, S3Config::credentials_file doc comment): `with_credentials`
-        // overrides the access_key_id/secret_access_key/token set above.
-        // `FileCredentialProvider::load` does the fail-fast read+parse this
-        // function's Result exists for.
+
         let mut credential_provider = None;
-        if let Some(credentials_file) = &config.credentials_file {
-            let provider = Arc::new(FileCredentialProvider::load(credentials_file.clone())?);
-            builder = builder.with_credentials(Arc::clone(&provider) as AwsCredentialProvider);
-            credential_provider = Some(provider);
-        } else if let Some(session_token) = &config.session_token {
-            builder = builder.with_token(session_token.clone());
+        let mut instance_role_provider = None;
+        match config.auth {
+            S3AuthMode::Static => {
+                // Rotating file credentials win over inline ones (ADR-0072
+                // decision 1, S3Config::credentials_file doc comment):
+                // `with_credentials` overrides the
+                // access_key_id/secret_access_key/token set above.
+                // `FileCredentialProvider::load` does the fail-fast read+parse
+                // this function's Result exists for.
+                if let Some(credentials_file) = &config.credentials_file {
+                    let provider =
+                        Arc::new(FileCredentialProvider::load(credentials_file.clone())?);
+                    builder =
+                        builder.with_credentials(Arc::clone(&provider) as AwsCredentialProvider);
+                    credential_provider = Some(provider);
+                } else if let Some(session_token) = &config.session_token {
+                    builder = builder.with_token(session_token.clone());
+                }
+            }
+            S3AuthMode::InstanceRole => {
+                // Mixing an instance role with any inline credential is a
+                // configuration error, not a precedence question: refuse it
+                // outright (ADR-0106), before the eager IMDS fetch.
+                if !config.access_key_id.is_empty()
+                    || !config.secret_access_key.is_empty()
+                    || config.session_token.is_some()
+                    || config.credentials_file.is_some()
+                {
+                    return Err(StoreError::Permanent(
+                        "auth=InstanceRole must not be combined with access_key_id, \
+                         secret_access_key, session_token, or credentials_file"
+                            .to_string(),
+                    ));
+                }
+                let endpoint = config
+                    .instance_metadata_endpoint
+                    .clone()
+                    .unwrap_or_else(|| DEFAULT_IMDS_ENDPOINT.to_string());
+                // Eager fetch: a server misconfigured for EC2 fails here rather
+                // than on its first S3 request. `with_credentials` installs the
+                // provider as the client's credential source.
+                let provider = Arc::new(InstanceRoleCredentialProvider::load(endpoint)?);
+                builder = builder.with_credentials(Arc::clone(&provider) as AwsCredentialProvider);
+                instance_role_provider = Some(provider);
+            }
         }
-        Ok((builder, credential_provider))
+        Ok((builder, credential_provider, instance_role_provider))
     }
 
     /// Same backend, a smaller `list()` page size. Mirrors
@@ -1022,6 +1135,8 @@ mod tests {
             kms_key_id: None,
             session_token: None,
             credentials_file: None,
+            auth: S3AuthMode::Static,
+            instance_metadata_endpoint: None,
         }
     }
 
@@ -1113,6 +1228,146 @@ mod tests {
         );
     }
 
+    /// Stand up a minimal always-succeeding mock IMDS on an ephemeral loopback
+    /// port and return its `http://addr` base. Shared by the InstanceRole
+    /// builder tests, whose only need is a working eager fetch.
+    async fn spawn_ok_imds() -> String {
+        use axum::Router;
+        use axum::http::StatusCode;
+        use axum::routing::{get, put};
+
+        let app = Router::new()
+            .route("/latest/api/token", put(|| async { "mock-token" }))
+            .route(
+                "/latest/meta-data/iam/security-credentials/",
+                get(|| async { "ravel-role" }),
+            )
+            .route(
+                "/latest/meta-data/iam/security-credentials/{role}",
+                get(|| async {
+                    (
+                        StatusCode::OK,
+                        r#"{"Code":"Success","AccessKeyId":"AKIA_IMDS",
+                            "SecretAccessKey":"imds-secret","Token":"imds-token",
+                            "Expiration":"2033-11-14T22:13:20Z"}"#,
+                    )
+                }),
+            );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind loopback");
+        let endpoint = format!("http://{}", listener.local_addr().expect("addr"));
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        endpoint
+    }
+
+    /// `auth=InstanceRole` combined with any inline credential is a
+    /// construction-time typed error (ADR-0106). Non-vacuous by pointing at a
+    /// *working* mock IMDS: the all-absent config builds cleanly against it, so
+    /// each mixed config's failure can only be the mix guard, not a fetch
+    /// failure or a blanket InstanceRole refusal. Each inline field is
+    /// exercised on its own so a future field dropped from the guard is caught.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn builder_rejects_mixed_instance_role_and_inline_credentials() {
+        let endpoint = spawn_ok_imds().await;
+        let base = move || {
+            let mut config = test_config();
+            config.auth = S3AuthMode::InstanceRole;
+            config.instance_metadata_endpoint = Some(endpoint.clone());
+            config.access_key_id = String::new();
+            config.secret_access_key = String::new();
+            config
+        };
+
+        let mut with_key = base();
+        with_key.access_key_id = "AKIA_INLINE".to_string();
+
+        let mut with_secret = base();
+        with_secret.secret_access_key = "inline-secret".to_string();
+
+        let mut with_token = base();
+        with_token.session_token = Some("inline-token".to_string());
+
+        let mut with_file = base();
+        with_file.credentials_file = Some(PathBuf::from("/nonexistent/creds.json"));
+
+        let clean = base();
+
+        // spawn_blocking: builder() blocks on the eager fetch, which must be
+        // able to reach the mock task on this same runtime.
+        tokio::task::spawn_blocking(move || {
+            for (label, config) in [
+                ("access_key_id", with_key),
+                ("secret_access_key", with_secret),
+                ("session_token", with_token),
+                ("credentials_file", with_file),
+            ] {
+                let err = S3Store::builder(&config)
+                    .expect_err(&format!("InstanceRole + {label} must be rejected"));
+                assert!(
+                    matches!(err, StoreError::Permanent(_)),
+                    "{label}: got {err:?}"
+                );
+            }
+
+            // All-absent against the same working endpoint builds cleanly: the
+            // rejections above are the mix guard, not a blanket refusal.
+            S3Store::builder(&clean)
+                .expect("all-absent InstanceRole must build against a working IMDS");
+        })
+        .await
+        .expect("join");
+    }
+
+    /// The `InstanceRole` builder installs a credential provider that a Static
+    /// builder over the same non-credential config does not. Mirrors
+    /// [`none_kms_key_leaves_builder_unchanged`]'s manual-baseline shape so the
+    /// comparison isolates exactly the provider: the baseline reproduces every
+    /// non-credential setter and omits only `with_credentials`, so removing the
+    /// provider install would make the two Debug outputs equal and fail this.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn instance_role_builder_differs_from_static_baseline() {
+        let endpoint = spawn_ok_imds().await;
+
+        let mut instance_role = test_config();
+        instance_role.auth = S3AuthMode::InstanceRole;
+        instance_role.access_key_id = String::new();
+        instance_role.secret_access_key = String::new();
+        instance_role.instance_metadata_endpoint = Some(endpoint);
+
+        let baseline_config = instance_role.clone();
+
+        let (instance_debug, baseline_debug) = tokio::task::spawn_blocking(move || {
+            let instance_debug = format!(
+                "{:?}",
+                S3Store::builder(&instance_role)
+                    .expect("instance-role builder must construct against the mock")
+                    .0
+            );
+            // Every non-credential setter the InstanceRole path applies, with
+            // no key setters and no provider: the one difference must be the
+            // installed credential provider.
+            let mut baseline = AmazonS3Builder::new()
+                .with_bucket_name(&baseline_config.bucket)
+                .with_region(&baseline_config.region)
+                .with_allow_http(baseline_config.allow_http)
+                .with_virtual_hosted_style_request(!baseline_config.force_path_style);
+            if let Some(endpoint) = &baseline_config.endpoint {
+                baseline = baseline.with_endpoint(endpoint.clone());
+            }
+            (instance_debug, format!("{baseline:?}"))
+        })
+        .await
+        .expect("join");
+
+        assert_ne!(
+            instance_debug, baseline_debug,
+            "InstanceRole must install a credential provider the plain builder lacks"
+        );
+    }
+
     #[tokio::test]
     async fn credentials_file_wins_over_inline_credentials_and_token() {
         use object_store::CredentialProvider as _;
@@ -1128,7 +1383,7 @@ mod tests {
         let mut config = test_config();
         config.session_token = Some("inline-token".to_string());
         config.credentials_file = Some(path);
-        let (_, provider) = S3Store::builder(&config).expect("valid credentials file");
+        let (_, provider, _) = S3Store::builder(&config).expect("valid credentials file");
         let provider = provider.expect("a credentials file must produce a provider");
         let credential = provider.get_credential().await.expect("file credentials");
         assert_eq!(

--- a/crates/ravel-object-store/src/s3/instance_role.rs
+++ b/crates/ravel-object-store/src/s3/instance_role.rs
@@ -1,0 +1,828 @@
+//! EC2 IAM instance-role credential provider (ADR-0106,
+//! [`super::S3Config::auth`] = [`super::S3AuthMode::InstanceRole`]).
+//!
+//! [`InstanceRoleCredentialProvider`] implements `object_store`'s
+//! `CredentialProvider` trait, the same seam
+//! [`super::credentials::FileCredentialProvider`] installs through
+//! `with_credentials`, so `object_store`'s AWS client calls `get_credential`
+//! itself, once per signed S3 request. Credentials come from the EC2 instance
+//! metadata service over IMDSv2 on the link-local address (default
+//! `http://169.254.169.254`, overridable via
+//! [`super::S3Config::instance_metadata_endpoint`] so tests can point at a
+//! mock):
+//!
+//! 1. `PUT /latest/api/token` with `X-aws-ec2-metadata-token-ttl-seconds` to
+//!    mint a session token.
+//! 2. `GET /latest/meta-data/iam/security-credentials/` for the attached
+//!    role name.
+//! 3. `GET /latest/meta-data/iam/security-credentials/<role>` for the role
+//!    document (`AccessKeyId`, `SecretAccessKey`, `Token`, `Expiration`).
+//!
+//! IMDSv2 only: every call carries the token header, and any non-success
+//! (including a 403 from a hop-limited or disabled IMDS) is a typed error,
+//! never a downgrade to the token-less IMDSv1 flow.
+//!
+//! The first fetch happens eagerly at construction, so a process misconfigured
+//! for EC2 fails at startup with a typed [`StoreError`] rather than on its
+//! first S3 request. After that the credential is cached and refreshed on the
+//! request path when within [`REFRESH_MARGIN_NANOS`] of its `Expiration`. A
+//! transient refresh failure keeps serving the cached credential while it is
+//! still unexpired; once the cached credential has actually expired,
+//! `get_credential` fails typed, increments [`Self::refresh_failures`], and
+//! logs a warning rate-limited to one per [`WARNING_INTERVAL_NANOS`]. Serving
+//! an expired credential silently would turn one IMDS outage into a stream of
+//! confusing S3 403s. Credentials live only in memory: the manual `Debug` impl
+//! redacts them, and nothing here writes them to disk or logs.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use object_store::CredentialProvider;
+use object_store::aws::AwsCredential;
+use parking_lot::RwLock;
+
+use crate::StoreError;
+
+/// The AWS link-local IMDS address, used when
+/// [`super::S3Config::instance_metadata_endpoint`] is `None`.
+pub(crate) const DEFAULT_IMDS_ENDPOINT: &str = "http://169.254.169.254";
+
+/// TTL requested for the IMDSv2 session token, in seconds. AWS's maximum
+/// (6 hours); the token is minted fresh on every fetch, so a long TTL only
+/// avoids a token expiring mid-fetch and never outlives a process.
+const IMDS_TOKEN_TTL_SECONDS: u32 = 21_600;
+
+/// Connect timeout for every IMDS HTTP call. IMDS answers on the link-local
+/// address in well under a second on a healthy instance; a short bound keeps
+/// construction from hanging when the address is unreachable (not on EC2, or a
+/// blocked hop).
+const IMDS_CONNECT_TIMEOUT: Duration = Duration::from_secs(1);
+
+/// Total (connect + response) timeout for every IMDS HTTP call. Bounds each of
+/// the three calls independently, so construction can hang for at most a small
+/// multiple of this regardless of how IMDS misbehaves.
+const IMDS_REQUEST_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Refresh the cached credential once the wall clock comes within this many
+/// nanoseconds of its `Expiration`: 5 minutes. Wide enough that a transient
+/// IMDS blip inside the window still leaves the current credential valid while
+/// retries continue.
+const REFRESH_MARGIN_NANOS: i64 = 5 * 60 * 1_000_000_000;
+
+/// Minimum gap between expired-credential warnings, in wall-clock nanoseconds:
+/// 60s, so an IMDS outage after expiry logs about once a minute rather than
+/// once per S3 request.
+const WARNING_INTERVAL_NANOS: i64 = 60 * 1_000_000_000;
+
+/// Wall-clock time seam, in nanoseconds since the Unix epoch. Injected so the
+/// expiry math against the IMDS `Expiration` (an absolute timestamp) and the
+/// warning rate limit are deterministic in tests, mirroring how
+/// [`crate::instrument::MonotonicClock`] is injected into
+/// [`super::credentials::FileCredentialProvider`]. That sibling seam is
+/// monotonic-elapsed only and cannot interpret an absolute `Expiration`, which
+/// is why this one reports wall-clock time instead.
+pub(crate) trait WallClock: Send + Sync + 'static {
+    /// Nanoseconds since the Unix epoch. May be non-monotonic across a
+    /// wall-clock adjustment; a backward jump can only delay a refresh or a
+    /// warning, never serve an expired credential (the comparison is absolute).
+    fn now_unix_nanos(&self) -> i64;
+}
+
+/// Default clock: `SystemTime::now()`. This is the one sanctioned
+/// `SystemTime::now()` call for this provider, isolated behind the seam
+/// exactly as [`crate::instrument::InstantClock`] isolates `Instant::now()`.
+#[derive(Debug, Default)]
+pub(crate) struct SystemTimeClock;
+
+impl WallClock for SystemTimeClock {
+    fn now_unix_nanos(&self) -> i64 {
+        match SystemTime::now().duration_since(UNIX_EPOCH) {
+            Ok(d) => i64::try_from(d.as_nanos()).unwrap_or(i64::MAX),
+            // Before the epoch: only reachable with a wildly misset clock.
+            // Clamp rather than panic in a credential path.
+            Err(_) => 0,
+        }
+    }
+}
+
+/// A credential fetched from IMDS, with its `Expiration` resolved to Unix
+/// nanoseconds for the cache's expiry math.
+struct Fetched {
+    credential: AwsCredential,
+    expiration_unix_nanos: i64,
+}
+
+/// The cached credential plus the absolute instant it stops being valid.
+struct Cached {
+    credential: Arc<AwsCredential>,
+    expiration_unix_nanos: i64,
+}
+
+impl std::fmt::Debug for Cached {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Never print the credential itself; only its expiry is safe to show.
+        f.debug_struct("Cached")
+            .field("expiration_unix_nanos", &self.expiration_unix_nanos)
+            .finish_non_exhaustive()
+    }
+}
+
+/// See the [module docs](self) for the fetch, cache, and refresh contract.
+pub(crate) struct InstanceRoleCredentialProvider {
+    endpoint: String,
+    state: RwLock<Cached>,
+    /// Serializes refresh attempts so a burst of request-path calls inside the
+    /// refresh window issues one IMDS fetch, not one per call.
+    refresh_lock: tokio::sync::Mutex<()>,
+    clock: Arc<dyn WallClock>,
+    last_warned_nanos: AtomicI64,
+    refresh_failures: AtomicU64,
+}
+
+// Manual, not derived: `Arc<dyn WallClock>` has no `Debug` impl and the cached
+// credential must never be printed, but `object_store::CredentialProvider`
+// requires `Self: Debug`. This satisfies that supertrait while redacting the
+// secret material.
+impl std::fmt::Debug for InstanceRoleCredentialProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InstanceRoleCredentialProvider")
+            .field("endpoint", &self.endpoint)
+            .field("state", &self.state)
+            .field(
+                "refresh_failures",
+                &self.refresh_failures.load(Ordering::Relaxed),
+            )
+            .finish_non_exhaustive()
+    }
+}
+
+impl InstanceRoleCredentialProvider {
+    /// Fetch the role credential once, eagerly, with the default wall clock: a
+    /// misconfigured instance (IMDS unreachable, no role attached, a 403) fails
+    /// here, at construction, with a typed [`StoreError`] (fail fast at
+    /// startup, never a panic), per ADR-0106.
+    pub(crate) fn load(endpoint: String) -> Result<Self, StoreError> {
+        Self::with_clock(endpoint, Arc::new(SystemTimeClock))
+    }
+
+    /// [`Self::load`] with an injected [`WallClock`], for deterministic expiry
+    /// and rate-limit tests.
+    pub(crate) fn with_clock(
+        endpoint: String,
+        clock: Arc<dyn WallClock>,
+    ) -> Result<Self, StoreError> {
+        let fetched = fetch_blocking(&endpoint).map_err(|e| {
+            StoreError::Permanent(format!("IMDS instance-role credential fetch failed: {e}"))
+        })?;
+        Ok(InstanceRoleCredentialProvider {
+            endpoint,
+            state: RwLock::new(Cached {
+                credential: Arc::new(fetched.credential),
+                expiration_unix_nanos: fetched.expiration_unix_nanos,
+            }),
+            refresh_lock: tokio::sync::Mutex::new(()),
+            clock,
+            last_warned_nanos: AtomicI64::new(0),
+            refresh_failures: AtomicU64::new(0),
+        })
+    }
+
+    /// Count of request-path refreshes that failed *and* found the cached
+    /// credential already expired, so the S3 request had to fail. A transient
+    /// failure that still served an unexpired last-good credential does not
+    /// count. Exposed for observability (mirrors
+    /// [`super::credentials::FileCredentialProvider::rotation_failures`]); wired
+    /// through [`super::S3Store::credential_refresh_failures`].
+    pub(crate) fn refresh_failures(&self) -> u64 {
+        self.refresh_failures.load(Ordering::Relaxed)
+    }
+
+    /// Refresh the credential from IMDS and swap it into the cache. Serialized
+    /// by [`Self::refresh_lock`]; the caller re-checks the cache after
+    /// acquiring the lock so a credential another task already refreshed is not
+    /// fetched again.
+    async fn refresh(&self) -> Result<Arc<AwsCredential>, FetchError> {
+        let fetched = fetch_once(&self.endpoint).await?;
+        let credential = Arc::new(fetched.credential);
+        let mut guard = self.state.write();
+        guard.credential = Arc::clone(&credential);
+        guard.expiration_unix_nanos = fetched.expiration_unix_nanos;
+        Ok(credential)
+    }
+
+    fn warn_rate_limited(&self, message: &str) {
+        // Counted before the rate-limit gate: every expired-and-failed refresh
+        // increments the observability counter, even when its warning is
+        // suppressed as a duplicate.
+        self.refresh_failures.fetch_add(1, Ordering::Relaxed);
+        let now = self.clock.now_unix_nanos().max(1);
+        let last = self.last_warned_nanos.load(Ordering::Relaxed);
+        // `last == 0` is the never-warned sentinel so the very first expiry
+        // (the case an operator most needs) is never suppressed.
+        let due = last == 0 || now.saturating_sub(last) >= WARNING_INTERVAL_NANOS;
+        if due
+            && self
+                .last_warned_nanos
+                .compare_exchange(last, now, Ordering::Relaxed, Ordering::Relaxed)
+                .is_ok()
+        {
+            tracing::warn!(
+                endpoint = %self.endpoint,
+                error = message,
+                "IMDS instance-role credential expired and refresh failed"
+            );
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl CredentialProvider for InstanceRoleCredentialProvider {
+    type Credential = AwsCredential;
+
+    async fn get_credential(&self) -> object_store::Result<Arc<AwsCredential>> {
+        let now = self.clock.now_unix_nanos();
+        // Fast path: comfortably before the refresh margin, serve the cache
+        // with no network call. A parking_lot guard is never held across an
+        // await.
+        {
+            let guard = self.state.read();
+            if now < guard.expiration_unix_nanos - REFRESH_MARGIN_NANOS {
+                return Ok(Arc::clone(&guard.credential));
+            }
+        }
+
+        // Inside the margin (or already expired): refresh under the lock, but
+        // re-check first in case another task refreshed while we waited.
+        let _refresh_guard = self.refresh_lock.lock().await;
+        let now = self.clock.now_unix_nanos();
+        {
+            let guard = self.state.read();
+            if now < guard.expiration_unix_nanos - REFRESH_MARGIN_NANOS {
+                return Ok(Arc::clone(&guard.credential));
+            }
+        }
+
+        match self.refresh().await {
+            Ok(credential) => Ok(credential),
+            Err(e) => {
+                // A transient failure keeps serving the cached credential while
+                // it is still valid; only an actually-expired credential fails
+                // the request (and counts).
+                let (credential, expiration) = {
+                    let guard = self.state.read();
+                    (Arc::clone(&guard.credential), guard.expiration_unix_nanos)
+                };
+                if now < expiration {
+                    Ok(credential)
+                } else {
+                    self.warn_rate_limited(&e.to_string());
+                    Err(object_store::Error::Generic {
+                        store: "InstanceRoleCredentialProvider",
+                        source: format!(
+                            "instance-role credential expired and IMDS refresh failed: {e}"
+                        )
+                        .into(),
+                    })
+                }
+            }
+        }
+    }
+}
+
+/// Run the eager construction fetch to completion on a throwaway
+/// current-thread runtime on its own thread. `super::S3Store::builder` (and so
+/// `new`) is synchronous and may itself be called from inside an async
+/// runtime; owning the runtime on a separate thread keeps this fetch bounded
+/// and safe to call from either context without touching the caller's runtime.
+fn fetch_blocking(endpoint: &str) -> Result<Fetched, FetchError> {
+    std::thread::scope(|scope| {
+        scope
+            .spawn(|| {
+                let runtime = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .map_err(|e| FetchError::Client(e.to_string()))?;
+                runtime.block_on(fetch_once(endpoint))
+            })
+            .join()
+            .unwrap_or(Err(FetchError::Panicked))
+    })
+}
+
+/// The three IMDSv2 calls. Builds a fresh bounded client per fetch so the
+/// client always belongs to the runtime driving this call (the throwaway
+/// runtime at construction, the process runtime on the request path) and never
+/// outlives it. Fetches are rare (construction, then near expiry), so the
+/// per-fetch client cost is immaterial.
+async fn fetch_once(endpoint: &str) -> Result<Fetched, FetchError> {
+    let client = reqwest::Client::builder()
+        .connect_timeout(IMDS_CONNECT_TIMEOUT)
+        .timeout(IMDS_REQUEST_TIMEOUT)
+        .build()
+        .map_err(|e| FetchError::Client(e.to_string()))?;
+
+    let base = endpoint.trim_end_matches('/');
+
+    // 1. Mint the IMDSv2 session token. A non-success here (403 on a disabled
+    //    or hop-limited IMDS) is an error, never a fall-through to IMDSv1.
+    let token = client
+        .put(format!("{base}/latest/api/token"))
+        .header(
+            "X-aws-ec2-metadata-token-ttl-seconds",
+            IMDS_TOKEN_TTL_SECONDS.to_string(),
+        )
+        .send()
+        .await
+        .map_err(|e| FetchError::Http(e.to_string()))?
+        .error_for_status()
+        .map_err(|e| FetchError::Http(e.to_string()))?
+        .text()
+        .await
+        .map_err(|e| FetchError::Http(e.to_string()))?;
+
+    // 2. The attached role name.
+    let roles = client
+        .get(format!("{base}/latest/meta-data/iam/security-credentials/"))
+        .header("X-aws-ec2-metadata-token", &token)
+        .send()
+        .await
+        .map_err(|e| FetchError::Http(e.to_string()))?
+        .error_for_status()
+        .map_err(|e| FetchError::Http(e.to_string()))?
+        .text()
+        .await
+        .map_err(|e| FetchError::Http(e.to_string()))?;
+    let role = roles
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .ok_or(FetchError::NoRole)?;
+
+    // 3. The role credential document.
+    let body = client
+        .get(format!(
+            "{base}/latest/meta-data/iam/security-credentials/{role}"
+        ))
+        .header("X-aws-ec2-metadata-token", &token)
+        .send()
+        .await
+        .map_err(|e| FetchError::Http(e.to_string()))?
+        .error_for_status()
+        .map_err(|e| FetchError::Http(e.to_string()))?
+        .text()
+        .await
+        .map_err(|e| FetchError::Http(e.to_string()))?;
+
+    parse_role_document(&body)
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct RoleDocument {
+    access_key_id: String,
+    secret_access_key: String,
+    token: String,
+    expiration: String,
+}
+
+fn parse_role_document(body: &str) -> Result<Fetched, FetchError> {
+    let doc: RoleDocument =
+        serde_json::from_str(body).map_err(|e| FetchError::Parse(e.to_string()))?;
+    let expiration_unix_nanos = parse_imds_expiration(&doc.expiration)?;
+    Ok(Fetched {
+        credential: AwsCredential {
+            key_id: doc.access_key_id,
+            secret_key: doc.secret_access_key,
+            token: Some(doc.token),
+        },
+        expiration_unix_nanos,
+    })
+}
+
+/// Parse an IMDS `Expiration` (`YYYY-MM-DDTHH:MM:SSZ`, always UTC, an optional
+/// fractional-second part tolerated and truncated) to Unix nanoseconds.
+/// Returns a typed error, never a panic, on any malformation, so a corrupt
+/// document fails the fetch cleanly.
+fn parse_imds_expiration(value: &str) -> Result<i64, FetchError> {
+    let bad = || FetchError::BadExpiration(value.to_string());
+
+    let rest = value.strip_suffix('Z').ok_or_else(bad)?;
+    let (date, time) = rest.split_once('T').ok_or_else(bad)?;
+
+    let mut date_parts = date.split('-');
+    let year: i64 = date_parts
+        .next()
+        .ok_or_else(bad)?
+        .parse()
+        .map_err(|_| bad())?;
+    let month: i64 = date_parts
+        .next()
+        .ok_or_else(bad)?
+        .parse()
+        .map_err(|_| bad())?;
+    let day: i64 = date_parts
+        .next()
+        .ok_or_else(bad)?
+        .parse()
+        .map_err(|_| bad())?;
+    if date_parts.next().is_some() || !(1..=12).contains(&month) || !(1..=31).contains(&day) {
+        return Err(bad());
+    }
+
+    // Drop any fractional-second part before splitting the clock fields.
+    let clock = time.split('.').next().ok_or_else(bad)?;
+    let mut time_parts = clock.split(':');
+    let hour: i64 = time_parts
+        .next()
+        .ok_or_else(bad)?
+        .parse()
+        .map_err(|_| bad())?;
+    let minute: i64 = time_parts
+        .next()
+        .ok_or_else(bad)?
+        .parse()
+        .map_err(|_| bad())?;
+    let second: i64 = time_parts
+        .next()
+        .ok_or_else(bad)?
+        .parse()
+        .map_err(|_| bad())?;
+    if time_parts.next().is_some()
+        || !(0..24).contains(&hour)
+        || !(0..60).contains(&minute)
+        || !(0..=60).contains(&second)
+    {
+        return Err(bad());
+    }
+
+    let days = days_from_civil(year, month, day);
+    let secs = days
+        .checked_mul(86_400)
+        .and_then(|d| d.checked_add(hour * 3600 + minute * 60 + second))
+        .ok_or_else(bad)?;
+    secs.checked_mul(1_000_000_000).ok_or_else(bad)
+}
+
+/// Days since the Unix epoch (1970-01-01) for a proleptic-Gregorian civil date,
+/// Howard Hinnant's `days_from_civil` algorithm. Exact for all dates an IMDS
+/// `Expiration` can carry.
+fn days_from_civil(year: i64, month: i64, day: i64) -> i64 {
+    let y = if month <= 2 { year - 1 } else { year };
+    let era = if y >= 0 { y } else { y - 399 } / 400;
+    let yoe = y - era * 400;
+    let doy = (153 * (if month > 2 { month - 3 } else { month + 9 }) + 2) / 5 + day - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    era * 146_097 + doe - 719_468
+}
+
+/// Every way an IMDS fetch can fail. `String`-only payloads keep it
+/// `Send + Sync` (so it can source an `object_store::Error`) without holding a
+/// `reqwest::Error`.
+#[derive(Debug)]
+enum FetchError {
+    /// Building the HTTP client or its runtime failed.
+    Client(String),
+    /// A request failed, timed out, or returned a non-success status
+    /// (including 403 — never downgraded to IMDSv1).
+    Http(String),
+    /// The construction fetch thread panicked.
+    Panicked,
+    /// The role listing was empty (no role attached to the instance).
+    NoRole,
+    /// The role document was not the expected JSON shape.
+    Parse(String),
+    /// The `Expiration` field was not a parseable UTC timestamp.
+    BadExpiration(String),
+}
+
+impl std::fmt::Display for FetchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FetchError::Client(e) => write!(f, "building IMDS HTTP client: {e}"),
+            FetchError::Http(e) => write!(f, "IMDS request failed: {e}"),
+            FetchError::Panicked => write!(f, "IMDS fetch thread panicked"),
+            FetchError::NoRole => write!(f, "no IAM role attached to this instance"),
+            FetchError::Parse(e) => write!(f, "parsing IMDS credential document: {e}"),
+            FetchError::BadExpiration(v) => write!(f, "unparseable IMDS Expiration {v:?}"),
+        }
+    }
+}
+
+impl std::error::Error for FetchError {}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use std::net::SocketAddr;
+    use std::sync::atomic::{AtomicU16, AtomicUsize, Ordering as O};
+
+    use axum::Router;
+    use axum::extract::State;
+    use axum::http::StatusCode;
+    use axum::response::IntoResponse;
+    use axum::routing::{get, put};
+    use parking_lot::Mutex;
+
+    use super::*;
+
+    /// A settable wall clock for deterministic expiry/rate-limit tests.
+    struct FakeClock(AtomicI64);
+
+    impl FakeClock {
+        fn new(now: i64) -> Arc<Self> {
+            Arc::new(FakeClock(AtomicI64::new(now)))
+        }
+        fn set(&self, now: i64) {
+            self.0.store(now, O::Relaxed);
+        }
+    }
+
+    impl WallClock for FakeClock {
+        fn now_unix_nanos(&self) -> i64 {
+            self.0.load(O::Relaxed)
+        }
+    }
+
+    /// Mock IMDS state. Every knob a test flips lives here so one endpoint
+    /// covers the happy path, refresh, transient failure, 403, and hang.
+    struct ImdsState {
+        /// HTTP status the token PUT returns (200 by default).
+        token_status: AtomicU16,
+        /// HTTP status the credential-document GET returns (200 by default).
+        doc_status: AtomicU16,
+        /// The JSON credential document served, swappable to model rotation.
+        doc: Mutex<String>,
+        /// Count of credential-document GETs, so a test can prove a refresh
+        /// actually hit IMDS rather than serving the cache.
+        doc_requests: AtomicUsize,
+        /// When set, the token PUT blocks indefinitely (models a hung IMDS).
+        hang: std::sync::atomic::AtomicBool,
+    }
+
+    impl ImdsState {
+        fn new(doc: String) -> Arc<Self> {
+            Arc::new(ImdsState {
+                token_status: AtomicU16::new(200),
+                doc_status: AtomicU16::new(200),
+                doc: Mutex::new(doc),
+                doc_requests: AtomicUsize::new(0),
+                hang: std::sync::atomic::AtomicBool::new(false),
+            })
+        }
+    }
+
+    fn role_doc(key_id: &str, secret: &str, token: &str, expiration: &str) -> String {
+        format!(
+            r#"{{"Code":"Success","AccessKeyId":"{key_id}","SecretAccessKey":"{secret}",
+                "Token":"{token}","Expiration":"{expiration}"}}"#
+        )
+    }
+
+    async fn token_handler(State(state): State<Arc<ImdsState>>) -> impl IntoResponse {
+        if state.hang.load(O::Relaxed) {
+            // Longer than any test's own timeout; the client's request timeout
+            // is what must fire, proving the bound is client-side.
+            tokio::time::sleep(Duration::from_secs(3600)).await;
+        }
+        let status = StatusCode::from_u16(state.token_status.load(O::Relaxed)).expect("status");
+        (status, "AQAE-mock-imds-token")
+    }
+
+    async fn role_handler() -> impl IntoResponse {
+        (StatusCode::OK, "ravel-instance-role")
+    }
+
+    async fn doc_handler(State(state): State<Arc<ImdsState>>) -> impl IntoResponse {
+        state.doc_requests.fetch_add(1, O::Relaxed);
+        let status = StatusCode::from_u16(state.doc_status.load(O::Relaxed)).expect("status");
+        (status, state.doc.lock().clone())
+    }
+
+    /// Bind an ephemeral loopback port and serve the mock IMDS until the test
+    /// runtime shuts down. Returns the `http://addr` base for
+    /// `instance_metadata_endpoint`.
+    async fn spawn_imds(state: Arc<ImdsState>) -> String {
+        let app = Router::new()
+            .route("/latest/api/token", put(token_handler))
+            .route(
+                "/latest/meta-data/iam/security-credentials/",
+                get(role_handler),
+            )
+            .route(
+                "/latest/meta-data/iam/security-credentials/{role}",
+                get(doc_handler),
+            )
+            .with_state(state);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind loopback");
+        let addr: SocketAddr = listener.local_addr().expect("local addr");
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        format!("http://{addr}")
+    }
+
+    /// Construct the provider off the runtime's worker threads: `with_clock` is
+    /// synchronous and blocks on its own runtime, so running it inline on a
+    /// current-thread test runtime would starve the mock server task.
+    async fn build_provider(
+        endpoint: String,
+        clock: Arc<FakeClock>,
+    ) -> Result<InstanceRoleCredentialProvider, StoreError> {
+        tokio::task::spawn_blocking(move || {
+            InstanceRoleCredentialProvider::with_clock(endpoint, clock)
+        })
+        .await
+        .expect("join")
+    }
+
+    // A fixed absolute expiry, parsed through the crate's own parser so the
+    // FakeClock and the served `Expiration` stay consistent without an inverse
+    // formatter.
+    const EXP_A: &str = "2033-11-14T22:13:20Z";
+    const EXP_B: &str = "2033-11-14T23:13:20Z";
+    const ONE_HOUR_NANOS: i64 = 3600 * 1_000_000_000;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn fetch_serves_imdsv2_role_document() {
+        let state = ImdsState::new(role_doc("AKIA_ROLE", "role-secret", "role-token", EXP_A));
+        let endpoint = spawn_imds(Arc::clone(&state)).await;
+        let exp_a = parse_imds_expiration(EXP_A).expect("exp");
+
+        // Well before the refresh margin so get_credential serves the cache.
+        let clock = FakeClock::new(exp_a - ONE_HOUR_NANOS);
+        let provider = build_provider(endpoint, Arc::clone(&clock))
+            .await
+            .expect("eager fetch must succeed");
+
+        let credential = provider.get_credential().await.expect("cached credential");
+        assert_eq!(credential.key_id, "AKIA_ROLE");
+        assert_eq!(credential.secret_key, "role-secret");
+        assert_eq!(credential.token.as_deref(), Some("role-token"));
+        // One document GET at construction; the cache read did not hit IMDS.
+        assert_eq!(state.doc_requests.load(O::Relaxed), 1);
+        assert_eq!(provider.refresh_failures(), 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn refreshes_before_expiry_via_injected_clock() {
+        let state = ImdsState::new(role_doc("AKIA_A", "secret-a", "token-a", EXP_A));
+        let endpoint = spawn_imds(Arc::clone(&state)).await;
+        let exp_a = parse_imds_expiration(EXP_A).expect("exp");
+
+        let clock = FakeClock::new(exp_a - ONE_HOUR_NANOS);
+        let provider = build_provider(endpoint, Arc::clone(&clock))
+            .await
+            .expect("eager fetch");
+
+        // Fast path: cached A, no new document GET beyond construction's one.
+        let a = provider.get_credential().await.expect("cached A");
+        assert_eq!(a.key_id, "AKIA_A");
+        assert_eq!(state.doc_requests.load(O::Relaxed), 1);
+
+        // Rotate the served document, then move the clock into the 5-minute
+        // margin (but before expiry): the next call must refresh.
+        *state.doc.lock() = role_doc("AKIA_B", "secret-b", "token-b", EXP_B);
+        clock.set(exp_a - 60 * 1_000_000_000); // 1 min before expiry -> in margin
+
+        let b = provider.get_credential().await.expect("refreshed B");
+        assert_eq!(b.key_id, "AKIA_B", "must serve the refreshed credential");
+        assert_eq!(b.token.as_deref(), Some("token-b"));
+        assert_eq!(
+            state.doc_requests.load(O::Relaxed),
+            2,
+            "the in-margin call must have hit IMDS exactly once more"
+        );
+        assert_eq!(provider.refresh_failures(), 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn last_good_served_within_validity_on_transient_failure() {
+        let state = ImdsState::new(role_doc("AKIA_GOOD", "good-secret", "good-token", EXP_A));
+        let endpoint = spawn_imds(Arc::clone(&state)).await;
+        let exp_a = parse_imds_expiration(EXP_A).expect("exp");
+
+        let clock = FakeClock::new(exp_a - ONE_HOUR_NANOS);
+        let provider = build_provider(endpoint, Arc::clone(&clock))
+            .await
+            .expect("eager fetch");
+
+        // Enter the refresh margin, but make refresh fail: still unexpired, so
+        // the cached credential must be served and nothing counted.
+        state.doc_status.store(500, O::Relaxed);
+        clock.set(exp_a - 60 * 1_000_000_000);
+
+        let served = provider
+            .get_credential()
+            .await
+            .expect("last-good must be served while still valid");
+        assert_eq!(served.key_id, "AKIA_GOOD");
+        assert!(
+            state.doc_requests.load(O::Relaxed) >= 2,
+            "a refresh was attempted"
+        );
+        assert_eq!(
+            provider.refresh_failures(),
+            0,
+            "a transient failure with a still-valid credential must not count"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn expired_credential_fails_typed_and_counts_failure() {
+        let state = ImdsState::new(role_doc("AKIA_OLD", "old-secret", "old-token", EXP_A));
+        let endpoint = spawn_imds(Arc::clone(&state)).await;
+        let exp_a = parse_imds_expiration(EXP_A).expect("exp");
+
+        let clock = FakeClock::new(exp_a - ONE_HOUR_NANOS);
+        let provider = build_provider(endpoint, Arc::clone(&clock))
+            .await
+            .expect("eager fetch");
+
+        // Past expiry and refresh broken: the request must fail typed, count
+        // exactly one failure, and log (rate-limited).
+        state.doc_status.store(500, O::Relaxed);
+        clock.set(exp_a + 1);
+
+        let err = provider
+            .get_credential()
+            .await
+            .expect_err("an expired credential with a broken refresh must fail");
+        assert!(
+            matches!(err, object_store::Error::Generic { .. }),
+            "{err:?}"
+        );
+        assert_eq!(provider.refresh_failures(), 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn metadata_403_is_error_not_v1_fallback() {
+        let state = ImdsState::new(role_doc("AKIA_X", "x", "x", EXP_A));
+        state.token_status.store(403, O::Relaxed);
+        let endpoint = spawn_imds(Arc::clone(&state)).await;
+
+        let clock = FakeClock::new(parse_imds_expiration(EXP_A).expect("exp") - ONE_HOUR_NANOS);
+        let err = build_provider(endpoint, clock)
+            .await
+            .expect_err("a 403 from IMDS must fail construction, not downgrade to IMDSv1");
+        assert!(matches!(err, StoreError::Permanent(_)), "{err:?}");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn construction_bounded_by_timeout_when_imds_hangs() {
+        let state = ImdsState::new(role_doc("AKIA_X", "x", "x", EXP_A));
+        state.hang.store(true, O::Relaxed);
+        let endpoint = spawn_imds(Arc::clone(&state)).await;
+
+        let clock = FakeClock::new(parse_imds_expiration(EXP_A).expect("exp") - ONE_HOUR_NANOS);
+        // The client request timeout is 2s; a generous 20s ceiling proves the
+        // bound holds without depending on its exact value. Without a bounded
+        // client, this future would never resolve and the test would hang.
+        let built = tokio::time::timeout(Duration::from_secs(20), build_provider(endpoint, clock))
+            .await
+            .expect("construction must return within the bound, never hang");
+        assert!(
+            matches!(built, Err(StoreError::Permanent(_))),
+            "a hung IMDS must fail construction typed, got {built:?}"
+        );
+    }
+
+    #[test]
+    fn parse_imds_expiration_matches_known_epoch() {
+        // 2033-11-14T22:13:20Z is 2_015_619_200 s since the epoch
+        // (`date -u -d 2033-11-14T22:13:20Z +%s`).
+        assert_eq!(
+            parse_imds_expiration("2033-11-14T22:13:20Z").expect("parse"),
+            2_015_619_200 * 1_000_000_000
+        );
+        // The Unix epoch itself.
+        assert_eq!(
+            parse_imds_expiration("1970-01-01T00:00:00Z").expect("epoch"),
+            0
+        );
+        // A fractional second is tolerated and truncated.
+        assert_eq!(
+            parse_imds_expiration("1970-01-01T00:00:01.500Z").expect("frac"),
+            1_000_000_000
+        );
+    }
+
+    #[test]
+    fn parse_imds_expiration_rejects_malformed() {
+        for bad in [
+            "",
+            "not-a-date",
+            "2033-11-14T22:13:20",  // no Z
+            "2033-13-01T00:00:00Z", // month 13
+            "2033-11-14T24:00:00Z", // hour 24
+            "2033/11/14T22:13:20Z", // wrong separators
+        ] {
+            assert!(
+                parse_imds_expiration(bad).is_err(),
+                "{bad:?} must be rejected, not parsed or panic"
+            );
+        }
+    }
+}

--- a/crates/ravel-object-store/tests/contract.rs
+++ b/crates/ravel-object-store/tests/contract.rs
@@ -1030,6 +1030,8 @@ fn test_s3_config() -> S3Config {
         kms_key_id: None,
         session_token: None,
         credentials_file: None,
+        auth: Default::default(),
+        instance_metadata_endpoint: None,
     }
 }
 
@@ -1107,6 +1109,8 @@ fn s3_store_reports_upload_checksum_unsupported() {
         kms_key_id: None,
         session_token: None,
         credentials_file: None,
+        auth: Default::default(),
+        instance_metadata_endpoint: None,
     };
     let store = S3Store::new(config).expect("dummy config must build without network access");
     assert!(
@@ -1142,6 +1146,8 @@ fn s3_store_satisfies_maintain_mode_capabilities() {
         kms_key_id: None,
         session_token: None,
         credentials_file: None,
+        auth: Default::default(),
+        instance_metadata_endpoint: None,
     })
     .expect("dummy config must build without network access");
     let maintain_required = Capabilities {
@@ -1196,6 +1202,8 @@ async fn minio_contract() {
         kms_key_id: None,
         session_token: None,
         credentials_file: None,
+        auth: Default::default(),
+        instance_metadata_endpoint: None,
     };
     // A small page size, like `memory_store_paged_contract`, so the
     // pagination assertion exercises `list_with_offset` continuation
@@ -1276,6 +1284,8 @@ async fn floci_contract() {
         kms_key_id: None,
         session_token: None,
         credentials_file: None,
+        auth: Default::default(),
+        instance_metadata_endpoint: None,
     };
     // A small page size, as in `minio_contract`, so the pagination assertion
     // exercises `list_with_offset` continuation against the real bucket.

--- a/crates/ravel-object-store/tests/s3_http_faults.rs
+++ b/crates/ravel-object-store/tests/s3_http_faults.rs
@@ -220,6 +220,8 @@ impl FakeS3 {
             kms_key_id: None,
             session_token: None,
             credentials_file: None,
+            auth: Default::default(),
+            instance_metadata_endpoint: None,
         })
         .expect("a fake-endpoint S3Store must build")
     }

--- a/docs/object-store-contract.md
+++ b/docs/object-store-contract.md
@@ -267,7 +267,12 @@ client, which is why `S3Store` reports `upload_checksum: false` for both.
 
 ### Credentials
 
-`S3Config` (ADR-0072 decision 1) takes long-lived `access_key_id` /
+`S3Config` selects a credential source explicitly through `auth`
+(`S3AuthMode`), never by inferring one from the absence of keys. The default
+is `S3AuthMode::Static`, which is every deployment today and behaves exactly
+as before ADR-0106.
+
+**Static mode (ADR-0072 decision 1).** Takes long-lived `access_key_id` /
 `secret_access_key`, an optional temporary `session_token` for STS-issued or
 IRSA-style credentials, and an optional `credentials_file` for credentials
 an external process rotates on disk (a Kubernetes secret mount, an STS
@@ -282,6 +287,41 @@ credential atomically, so a request already in flight finishes on whatever
 credential it already obtained. A read or parse failure while rotating
 never fails the request: the last-good credential is kept and a
 rate-limited warning is logged, never a panic.
+
+**Instance-role mode (ADR-0106).** `auth = S3AuthMode::InstanceRole` fetches
+short-lived credentials from the EC2 instance metadata service (IMDSv2) on
+the link-local address, so an EC2 deployment stores no static key at all.
+`access_key_id`, `secret_access_key`, `session_token`, and `credentials_file`
+must all be absent; setting `auth = InstanceRole` together with any of them is
+a configuration error, and `S3Store::new` rejects it with a typed `StoreError`
+at construction (there is no precedence question, because the mix is refused
+outright). `instance_metadata_endpoint` overrides the IMDS base URL (default
+`http://169.254.169.254`); it is an operator-facing knob on the same trust
+boundary as every other `--s3-*` setting and exists so tests and unusual
+deployments can redirect IMDS.
+
+The provider is IMDSv2 only: it `PUT`s for a session token, then `GET`s the
+role document (`AccessKeyId`, `SecretAccessKey`, `Token`, `Expiration`). Any
+non-success from the metadata endpoint, including a `403` from a disabled or
+hop-limited IMDS, is a typed error, never a downgrade to the token-less
+IMDSv1 flow. The first fetch runs eagerly at `S3Store::new` under a bounded
+timeout, so an instance misconfigured for a role fails at startup rather than
+on its first S3 request, and construction never hangs indefinitely. The
+credential is cached and refreshed on the request path once the clock comes
+within 5 minutes of its `Expiration`. A transient refresh failure keeps
+serving the cached credential while it is still unexpired; once the cached
+credential has actually expired, the request fails with a typed error, a
+failure counter (`S3Store::credential_refresh_failures`, mirroring
+`credential_rotation_failures`) increments, and a warning is logged
+rate-limited to once per 60s. Credentials live only in memory: never written
+to disk, and redacted from the provider's `Debug`.
+
+**SSE-KMS under an instance role.** `kms_key_id` works unchanged in either
+mode, because S3 performs the KMS call server-side on every PUT. When
+`kms_key_id` is set with `auth = InstanceRole`, the instance role's IAM
+policy must grant `kms:GenerateDataKey` and `kms:Decrypt` on that key, since
+the role is the identity S3 evaluates for the encryption and decryption
+calls.
 
 ## Runtime qualification (executable contract)
 

--- a/services/ravel-cli/src/store.rs
+++ b/services/ravel-cli/src/store.rs
@@ -88,6 +88,8 @@ pub fn build_store(args: &StoreArgs) -> anyhow::Result<Arc<dyn ObjectStoreBacken
                 kms_key_id: None,
                 session_token: None,
                 credentials_file: None,
+                auth: Default::default(),
+                instance_metadata_endpoint: None,
             };
             let store = S3Store::new(config)
                 .map_err(|err| anyhow::anyhow!("failed to build S3 store: {err}"))?;

--- a/services/ravel-operator/src/controller.rs
+++ b/services/ravel-operator/src/controller.rs
@@ -430,6 +430,8 @@ async fn build_auth_store(
         kms_key_id: None,
         session_token: None,
         credentials_file: None,
+        auth: Default::default(),
+        instance_metadata_endpoint: None,
     };
     S3Store::new(config).map_err(Error::Store)
 }

--- a/services/ravel-server/src/store.rs
+++ b/services/ravel-server/src/store.rs
@@ -308,6 +308,8 @@ pub fn build_store(cli: &Cli) -> anyhow::Result<BuiltStore> {
                 kms_key_id: cli.s3_kms_key.clone(),
                 session_token: None,
                 credentials_file: None,
+                auth: Default::default(),
+                instance_metadata_endpoint: None,
             };
             let store = S3Store::new(config.clone())
                 .map_err(|err| anyhow::anyhow!("failed to build S3 store: {err}"))?;
@@ -524,6 +526,8 @@ mod tests {
             kms_key_id: None,
             session_token: None,
             credentials_file: None,
+            auth: Default::default(),
+            instance_metadata_endpoint: None,
         })
         .expect("dummy S3 config must build without network access");
         assert!(

--- a/services/ravel-server/tests/flight_sql_e2e.rs
+++ b/services/ravel-server/tests/flight_sql_e2e.rs
@@ -180,6 +180,8 @@ impl Minio {
             kms_key_id: None,
             session_token: None,
             credentials_file: None,
+            auth: Default::default(),
+            instance_metadata_endpoint: None,
         }
     }
 }


### PR DESCRIPTION
EC2 deployments currently need a static S3 key pair baked into the
environment. This adds an explicit S3AuthMode to S3Config selecting
between static keys and an IMDSv2 instance-role credential provider,
per ADR-0106. The provider fetches eagerly at construction so a
misconfigured server fails at startup, refreshes five minutes before
expiry, serves the last-good credential while it is still valid, and
fails typed after expiry with a counted, rate-limited warning. Mixing
instance-role mode with inline credentials is rejected at construction.
Static mode behavior is unchanged.

No production caller selects InstanceRole yet; #545 wires
ravel-server/ravel-cli flags and #546 wires ravel-bench.

Fixes: #544
Refs: #537
