### PR TITLE
feat(ravel-bench): honor RAVEL_S3_AUTH=instance-role in the bench harness

### DIFF
--- a/crates/ravel-bench/src/harness.rs
+++ b/crates/ravel-bench/src/harness.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use clap::ValueEnum;
 use ravel_object_store::ObjectStoreBackend;
 use ravel_object_store::memory::MemoryStore;
-use ravel_object_store::s3::{S3Config, S3Store};
+use ravel_object_store::s3::{S3AuthMode, S3Config, S3Store};
 
 #[derive(Copy, Clone, Debug, ValueEnum)]
 pub enum StoreKind {
@@ -36,21 +36,43 @@ impl std::fmt::Display for StoreKind {
 /// `ingest_bench`'s `--store s3`; not the `RAVEL_MINIO_*` convention used by
 /// `ravel-object-store`'s contract suite, which gates a fixed local MinIO
 /// rather than configuring an arbitrary S3-compatible endpoint.
+///
+/// `RAVEL_S3_AUTH=instance-role` (ADR-0106) selects
+/// [`ravel_object_store::s3::S3AuthMode::InstanceRole`]: any value other than
+/// exactly `instance-role` (including unset) keeps the default `Static`
+/// mode, so the access/secret key env vars stay required exactly as before
+/// for every caller that does not opt in. `RAVEL_S3_INSTANCE_METADATA_ENDPOINT`
+/// (optional) points instance-role mode at a mock IMDS in tests, or an
+/// unusual deployment; ignored under `Static`, matching
+/// [`S3Config::instance_metadata_endpoint`]'s own contract.
 pub fn s3_config_from_env() -> S3Config {
-    let get = |key: &str| std::env::var(key).unwrap_or_default();
+    s3_config_from_lookup(|key| std::env::var(key).ok())
+}
+
+/// [`s3_config_from_env`]'s logic over an injected lookup instead of the real
+/// process environment, so `RAVEL_S3_AUTH=instance-role` selection is testable
+/// without `std::env::set_var` (`unsafe` under the 2024 edition, and process
+/// env vars are global state that races across parallel tests regardless).
+fn s3_config_from_lookup(lookup: impl Fn(&str) -> Option<String>) -> S3Config {
+    let get = |key: &str| lookup(key).unwrap_or_default();
+    let auth = if lookup("RAVEL_S3_AUTH").as_deref() == Some("instance-role") {
+        S3AuthMode::InstanceRole
+    } else {
+        S3AuthMode::default()
+    };
     S3Config {
         bucket: get("RAVEL_S3_BUCKET"),
         region: get("RAVEL_S3_REGION"),
-        endpoint: std::env::var("RAVEL_S3_ENDPOINT").ok(),
+        endpoint: lookup("RAVEL_S3_ENDPOINT"),
         access_key_id: get("RAVEL_S3_ACCESS_KEY_ID"),
         secret_access_key: get("RAVEL_S3_SECRET_ACCESS_KEY"),
-        allow_http: std::env::var("RAVEL_S3_ALLOW_HTTP").as_deref() == Ok("true"),
-        force_path_style: std::env::var("RAVEL_S3_FORCE_PATH_STYLE").as_deref() != Ok("false"),
+        allow_http: lookup("RAVEL_S3_ALLOW_HTTP").as_deref() == Some("true"),
+        force_path_style: lookup("RAVEL_S3_FORCE_PATH_STYLE").as_deref() != Some("false"),
         kms_key_id: None,
         session_token: None,
         credentials_file: None,
-        auth: Default::default(),
-        instance_metadata_endpoint: None,
+        auth,
+        instance_metadata_endpoint: lookup("RAVEL_S3_INSTANCE_METADATA_ENDPOINT"),
     }
 }
 
@@ -62,5 +84,75 @@ pub fn store_from_env(kind: StoreKind) -> Arc<dyn ObjectStoreBackend> {
         StoreKind::S3 => {
             Arc::new(S3Store::new(s3_config_from_env()).expect("build S3Store from RAVEL_S3_* env"))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A fixed map, not the real process environment: `RAVEL_S3_AUTH`
+    /// selection must be provable without `std::env::set_var` (`unsafe`
+    /// under the 2024 edition) and without racing other tests over global
+    /// process env state.
+    fn lookup(pairs: &'static [(&'static str, &'static str)]) -> impl Fn(&str) -> Option<String> {
+        move |key| {
+            pairs
+                .iter()
+                .find(|(k, _)| *k == key)
+                .map(|(_, v)| v.to_string())
+        }
+    }
+
+    /// Issue #546: `RAVEL_S3_AUTH=instance-role` selects
+    /// `S3AuthMode::InstanceRole` and carries
+    /// `RAVEL_S3_INSTANCE_METADATA_ENDPOINT` through unchanged; the access
+    /// and secret key vars stay absent (not required under instance-role).
+    #[test]
+    fn instance_role_env_selects_instance_role_config() {
+        let cfg = s3_config_from_lookup(lookup(&[
+            ("RAVEL_S3_BUCKET", "ravel-bench"),
+            ("RAVEL_S3_REGION", "us-east-1"),
+            ("RAVEL_S3_AUTH", "instance-role"),
+            (
+                "RAVEL_S3_INSTANCE_METADATA_ENDPOINT",
+                "http://127.0.0.1:9999",
+            ),
+        ]));
+        assert_eq!(cfg.auth, S3AuthMode::InstanceRole);
+        assert_eq!(
+            cfg.instance_metadata_endpoint.as_deref(),
+            Some("http://127.0.0.1:9999")
+        );
+        assert_eq!(
+            cfg.access_key_id, "",
+            "instance-role mode must not require an inline access key"
+        );
+        assert_eq!(
+            cfg.secret_access_key, "",
+            "instance-role mode must not require an inline secret key"
+        );
+    }
+
+    /// The default (unset `RAVEL_S3_AUTH`) must keep selecting `Static`, byte-
+    /// identical to the pre-#546 behavior, so every existing bench bin that
+    /// never sets this var is unaffected.
+    #[test]
+    fn missing_auth_env_defaults_to_static() {
+        let cfg = s3_config_from_lookup(lookup(&[
+            ("RAVEL_S3_BUCKET", "ravel-bench"),
+            ("RAVEL_S3_REGION", "us-east-1"),
+        ]));
+        assert_eq!(cfg.auth, S3AuthMode::Static);
+        assert_eq!(cfg.instance_metadata_endpoint, None);
+    }
+
+    /// A value other than exactly `instance-role` -- a typo, a different
+    /// case -- must not silently select instance-role mode. Fail-closed to
+    /// the default rather than guessing at what the operator meant.
+    #[test]
+    fn unrecognized_auth_value_defaults_to_static() {
+        let cfg = s3_config_from_lookup(lookup(&[("RAVEL_S3_AUTH", "Instance-Role")]));
+        assert_eq!(cfg.auth, S3AuthMode::Static);
     }
 }


### PR DESCRIPTION
## What

`crates/ravel-bench/src/harness.rs`'s `s3_config_from_env` now honors
`RAVEL_S3_AUTH=instance-role` (ADR-0106) and `RAVEL_S3_INSTANCE_METADATA_ENDPOINT`.

## Why

Epic #537 T3. `S3AuthMode::InstanceRole` exists in `ravel-object-store`, but
`ravel-bench`'s env-driven `S3Config` construction always built `Static`, so
no bench bin could exercise EC2-IMDS-sourced credentials without a code
change.

## How

`RAVEL_S3_AUTH=instance-role` selects `S3AuthMode::InstanceRole`; any other
value, or unset, keeps `Static` — fail-closed to the existing default rather
than guessing at a typo. `RAVEL_S3_INSTANCE_METADATA_ENDPOINT` carries
through to `S3Config::instance_metadata_endpoint` unchanged. Under
instance-role, the access/secret key env vars simply aren't required;
`S3Store::new`'s own validation already rejects the mix if both end up set.

Split the env-reading into `s3_config_from_lookup`, a pure function over an
injected lookup closure, with `s3_config_from_env` now a one-line wrapper
over `std::env::var`. This repo's edition (2024) makes `std::env::set_var`
`unsafe`, which CLAUDE.md denies workspace-wide, and process env vars are
global mutable state that would race across parallel tests regardless — so
proving the auth-selection logic needed a fixed map, not the real
environment.

`src/bin/read_path_accounting.rs`'s raw `AmazonS3Builder` construction is
deliberately untouched, per the ticket's own scope note.

## Testing

Added `instance_role_env_selects_instance_role_config` (the ticket's named
acceptance test), plus `missing_auth_env_defaults_to_static` and
`unrecognized_auth_value_defaults_to_static` to pin both fail-closed paths.

Mutation-proofed: reverted the `RAVEL_S3_AUTH` branch to always return the
default, confirmed the acceptance test fails, restored it, confirmed the
full harness suite passes.

`scripts/gates.sh -p ravel-bench` green.

Fixes: #546
