### PR TITLE
docs: claim ADR-0108 histogram-aware range evaluation

### DIFF
--- a/docs/adrs/0108-range-eval-over-native-histograms.md
+++ b/docs/adrs/0108-range-eval-over-native-histograms.md
@@ -1,0 +1,3 @@
+# ADR-0108: Histogram-aware range evaluation for PromQL
+
+Status: claimed


### PR DESCRIPTION
Reserves the ADR number for the native-histogram range-evaluation epic (#525) so parallel epics cannot pick it. Full content lands after the approval gate.