### PR TITLE
fix(promql): guard query text against parser stack overflow

### DIFF
--- a/crates/ravel-promql/src/complexity_guard.rs
+++ b/crates/ravel-promql/src/complexity_guard.rs
@@ -1,0 +1,248 @@
+//! Pre-parse structural-complexity guard for raw PromQL query text (issue
+//! #529).
+//!
+//! `promql_parser::parser::parse` is a hand-written recursive-descent
+//! parser with no depth guard of its own, and it recurses at least once per
+//! structural token it consumes (a paren, a bracket, a unary operator, a
+//! binary/logical operator). A query built to maximize any one of those
+//! aborts the process with a stack overflow *during parsing*, before any
+//! AST exists to walk — which rules out a post-parse `check_ast`-style
+//! guard as the sole defense: by the time an AST is available to inspect,
+//! the crash has already happened. This module scans the raw query text
+//! instead, so the reject happens before `promql_parser::parser::parse` is
+//! ever called.
+//!
+//! The bound enforced is deliberately not "nesting depth": an early design
+//! of this guard counted only bracket depth and consecutive unary-operator
+//! runs, and was proven insufficient by direct experiment — a flat chain of
+//! binary operators with no brackets at all (`1+1+1+...+1`) and a flat
+//! chain of `and` (`up and up and ... and up`) both crash the parser at a
+//! similar depth to the bracket/unary cases, because the parser recurses
+//! once per operator regardless of whether the query text nests visually.
+//! Rather than enumerate every construct that can trigger recursion (a
+//! whack-a-mole that would remain unsound against a construct nobody
+//! thought to test), this guard bounds a simpler, sound invariant: a
+//! recursive-descent parser cannot recurse more times than it has
+//! structural characters to consume, so capping
+//! `count(non-whitespace chars outside string literals and comments)`
+//! caps parse (and any downstream AST-walk) depth by construction, for
+//! every construct, tested or not.
+//!
+//! String literals (`'...'`/`"..."`, backslash-escaped) and line comments
+//! (`#` to end of line) are excluded from the count on purpose: a label
+//! matcher's regex value (`job=~"a|b|c|...|zzz"`) can legitimately be very
+//! long without adding any parser recursion, since matcher values are
+//! opaque string tokens to the parser, not re-parsed structure.
+//!
+//! # Calibrating [`MAX_QUERY_COMPLEXITY`]
+//!
+//! Measured empirically against `promql-parser` 0.10.0 on a 2 MiB stack
+//! (tokio's worker-thread default, which this crate's evaluator runs on),
+//! via a standalone probe outside the workspace build:
+//!
+//! | construct                          | chars/level | survives | aborts |
+//! |-------------------------------------|:-----------:|:--------:|:------:|
+//! | `(((...up...)))`  (paren nesting)   | 2           | 32,000   | 34,000 |
+//! | `-------...up`    (unary run)       | 1           | 30,000   | 40,000 |
+//! | `1+1+1+...+1`     (binary chain)    | 2           | 30,000   | 35,000 |
+//! | `up and up and...`(logical chain)   | ~7          | 30,000   | 40,000 |
+//!
+//! The tightest floor in raw character count is the unary case (survives
+//! at 30,000 characters). [`MAX_QUERY_COMPLEXITY`] sits about 60x under
+//! that floor, which comfortably absorbs any difference between this
+//! probe's frame size and a release build's, and between a parse frame and
+//! an `eval_expr` frame, without needing to prove those sizes match.
+//!
+//! A single matcher list (`up{a="1",b="2",...}`) is not itself a
+//! recursion risk — confirmed by probing a 100,000-matcher selector, which
+//! parses without incident (the parser builds it as a flat `Vec`, not a
+//! recursive structure) — but this guard does not special-case brace
+//! interiors: an adversarial, syntactically-invalid payload inside `{...}`
+//! has not been verified safe from triggering the parser's recursive
+//! error-recovery path, and the whole point of the sound-invariant
+//! approach above is to not depend on a per-construct safety argument.
+//! [`MAX_QUERY_COMPLEXITY`] is sized to still comfortably fit a real
+//! query's non-string structure (function calls, `by`/`without` clauses,
+//! a few dozen matcher names/operators) even without that exclusion.
+
+use std::fmt;
+
+/// Maximum count of non-whitespace characters outside string literals and
+/// line comments a query's text may contain. See the module documentation
+/// for how this was measured and why it bounds parser (and AST-walk)
+/// recursion depth for every construct, not just the ones tested.
+pub const MAX_QUERY_COMPLEXITY: usize = 500;
+
+/// `query`'s structural character count exceeded [`MAX_QUERY_COMPLEXITY`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QueryTooComplex {
+    /// The count at which the scan stopped (one past the max).
+    pub count: usize,
+    /// [`MAX_QUERY_COMPLEXITY`], carried alongside the measured count so
+    /// callers can report both without reaching back into this module.
+    pub max: usize,
+}
+
+impl fmt::Display for QueryTooComplex {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "query complexity {} exceeds the maximum of {} structural characters; simplify the expression",
+            self.count, self.max
+        )
+    }
+}
+
+impl std::error::Error for QueryTooComplex {}
+
+/// Scans `query`'s raw text for excessive structural complexity, outside
+/// string literals and line comments. Call this before
+/// `promql_parser::parser::parse`, not after: the crash this guards
+/// against happens during parsing itself.
+pub fn check(query: &str) -> Result<(), QueryTooComplex> {
+    #[derive(PartialEq)]
+    enum Mode {
+        Normal,
+        Single,
+        Double,
+        Comment,
+    }
+
+    let mut mode = Mode::Normal;
+    let mut escaped = false;
+    let mut count: usize = 0;
+
+    for c in query.chars() {
+        match mode {
+            Mode::Comment => {
+                if c == '\n' {
+                    mode = Mode::Normal;
+                }
+                continue;
+            }
+            Mode::Single | Mode::Double => {
+                if escaped {
+                    escaped = false;
+                } else if c == '\\' {
+                    escaped = true;
+                } else if (mode == Mode::Single && c == '\'') || (mode == Mode::Double && c == '"')
+                {
+                    mode = Mode::Normal;
+                }
+                continue;
+            }
+            Mode::Normal => {}
+        }
+
+        match c {
+            '\'' => mode = Mode::Single,
+            '"' => mode = Mode::Double,
+            '#' => mode = Mode::Comment,
+            c if c.is_whitespace() => {}
+            _ => {
+                count += 1;
+                if count > MAX_QUERY_COMPLEXITY {
+                    return Err(QueryTooComplex {
+                        count,
+                        max: MAX_QUERY_COMPLEXITY,
+                    });
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ordinary_query_passes() {
+        assert!(check(r#"rate(http_requests_total{job="api"}[5m])"#).is_ok());
+    }
+
+    #[test]
+    fn deep_paren_nesting_rejected() {
+        let query = format!("{}{}{}", "(".repeat(400), "up", ")".repeat(400));
+        let err = check(&query).expect_err("must be rejected");
+        assert_eq!(err.max, MAX_QUERY_COMPLEXITY);
+        assert!(err.count > MAX_QUERY_COMPLEXITY);
+    }
+
+    #[test]
+    fn deep_unary_run_rejected() {
+        let query = format!("{}up", "-".repeat(600));
+        assert!(check(&query).is_err());
+    }
+
+    #[test]
+    fn flat_binary_chain_rejected() {
+        // No brackets and no unary run at all: the case that proved a
+        // bracket/unary-only guard insufficient.
+        let mut query = String::from("1");
+        for _ in 0..600 {
+            query.push_str("+1");
+        }
+        assert!(check(&query).is_err());
+    }
+
+    #[test]
+    fn flat_logical_chain_rejected() {
+        let mut query = String::from("up");
+        for _ in 0..200 {
+            query.push_str(" and up");
+        }
+        assert!(check(&query).is_err());
+    }
+
+    #[test]
+    fn error_message_names_complexity_not_nesting() {
+        // A flat chain has no nesting at all; the message must not claim
+        // "depth" or "nesting" for a rejection that fires on flatness.
+        let mut query = String::from("1");
+        for _ in 0..600 {
+            query.push_str("+1");
+        }
+        let err = check(&query).expect_err("must be rejected");
+        let msg = err.to_string();
+        assert!(msg.contains("complexity"), "{msg}");
+        assert!(!msg.contains("nest"), "{msg}");
+        assert!(!msg.contains("depth"), "{msg}");
+    }
+
+    #[test]
+    fn long_regex_matcher_value_not_counted() {
+        // The regex payload lives in a quoted string; it must not
+        // contribute to the structural count no matter how long it is.
+        let alternation = (0..300)
+            .map(|i| format!("v{i}"))
+            .collect::<Vec<_>>()
+            .join("|");
+        let query = format!(r#"up{{job=~"{alternation}"}}"#);
+        assert!(check(&query).is_ok());
+    }
+
+    #[test]
+    fn moderate_flat_matcher_list_passes() {
+        let matchers: Vec<String> = (0..50).map(|i| format!("l{i}=\"v\"")).collect();
+        let query = format!("up{{{}}}", matchers.join(","));
+        assert!(check(&query).is_ok());
+    }
+
+    #[test]
+    fn paren_nesting_inside_comment_ignored() {
+        let query = format!("# {}\nup", "(".repeat(400));
+        assert!(check(&query).is_ok());
+    }
+
+    #[test]
+    fn escaped_quote_inside_string_does_not_end_it() {
+        // A closing paren right after an escaped quote must still be seen
+        // as inside the string, not as the start of fresh structure.
+        let query = format!(r#"up{{job="a\"{}"}}"#, "(".repeat(400));
+        assert!(check(&query).is_ok());
+    }
+}

--- a/crates/ravel-promql/src/eval.rs
+++ b/crates/ravel-promql/src/eval.rs
@@ -318,6 +318,8 @@ pub enum Error {
     InvalidRegex { pattern: String, reason: String },
     #[error("multiple matches for labels: {detail}")]
     AmbiguousMatch { detail: String },
+    #[error(transparent)]
+    TooComplex(#[from] crate::complexity_guard::QueryTooComplex),
 }
 
 /// Default PromQL lookback: 5 minutes, in nanoseconds (ADR-0007). This is
@@ -588,6 +590,7 @@ impl Evaluator {
         query: &str,
         t_ms: i64,
     ) -> Result<(Value, Annotations), Error> {
+        crate::complexity_guard::check(query)?;
         let expr = promql_parser::parser::parse(query).map_err(Error::Parse)?;
         let t_ns = ms_to_ns(t_ms)?;
         let ctx = QueryWindow {
@@ -679,6 +682,7 @@ impl Evaluator {
             });
         }
 
+        crate::complexity_guard::check(query)?;
         let expr = promql_parser::parser::parse(query).map_err(Error::Parse)?;
         let ctx = QueryWindow {
             start_ns,
@@ -2667,6 +2671,44 @@ mod tests {
             .eval_instant(&TestSource::new(), r#""hello""#, 0)
             .expect("evaluates");
         assert_eq!(result, Value::String("hello".to_string()));
+    }
+
+    /// A query built to exceed [`crate::complexity_guard::MAX_QUERY_COMPLEXITY`]
+    /// must fail with a typed error, not attempt to parse (issue #529). The
+    /// query used here is a flat operator chain with no parens at all: it is
+    /// the construct that proved a bracket/unary-only guard insufficient, and
+    /// it stays orders of magnitude below the depth that would actually
+    /// crash `promql_parser::parser::parse` (see the module docs on
+    /// `complexity_guard` for the measured crash thresholds) -- this test
+    /// proves the guard rejects it, not that the unguarded parser survives it.
+    #[test]
+    fn overly_complex_instant_query_is_rejected_not_parsed() {
+        let mut query = String::from("1");
+        for _ in 0..300 {
+            query.push_str("+1");
+        }
+        let err = Evaluator::new()
+            .eval_instant(&TestSource::new(), &query, 0)
+            .expect_err("must be rejected before parsing");
+        assert!(
+            matches!(err, Error::TooComplex(_)),
+            "expected Error::TooComplex, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn overly_complex_range_query_is_rejected_not_parsed() {
+        let mut query = String::from("1");
+        for _ in 0..300 {
+            query.push_str("+1");
+        }
+        let err = Evaluator::new()
+            .eval_range(&TestSource::new(), &query, 0, minutes(1), minutes(1))
+            .expect_err("must be rejected before parsing");
+        assert!(
+            matches!(err, Error::TooComplex(_)),
+            "expected Error::TooComplex, got {err:?}"
+        );
     }
 
     #[test]

--- a/crates/ravel-promql/src/lib.rs
+++ b/crates/ravel-promql/src/lib.rs
@@ -20,6 +20,7 @@
 
 mod aggregate;
 mod binop;
+pub mod complexity_guard;
 mod eval;
 mod functions;
 pub mod histogram;

--- a/crates/ravel-promql/src/plan.rs
+++ b/crates/ravel-promql/src/plan.rs
@@ -71,6 +71,7 @@ pub fn plan_selectors(
     eval_start_ms: i64,
     eval_end_ms: i64,
 ) -> Result<Vec<SelectorPlan>, Error> {
+    crate::complexity_guard::check(query)?;
     let expr = promql_parser::parser::parse(query).map_err(Error::Parse)?;
     let start_ns = eval::ms_to_ns(eval_start_ms)?;
     let end_ns = eval::ms_to_ns(eval_end_ms)?;
@@ -310,6 +311,22 @@ fn resolve_selector(
 #[allow(clippy::expect_used)]
 mod tests {
     use super::*;
+
+    /// Issue #529: `plan_selectors` parses independently of the evaluator,
+    /// so it needs its own guard against a query built to exceed
+    /// [`crate::complexity_guard::MAX_QUERY_COMPLEXITY`].
+    #[test]
+    fn overly_complex_query_is_rejected_not_parsed() {
+        let mut query = String::from("1");
+        for _ in 0..300 {
+            query.push_str("+1");
+        }
+        let err = plan_selectors(&query, 0, 0).expect_err("must be rejected before parsing");
+        assert!(
+            matches!(err, Error::TooComplex(_)),
+            "expected Error::TooComplex, got {err:?}"
+        );
+    }
 
     #[test]
     fn bare_selector_has_default_lookback_range_and_no_offset() {

--- a/crates/ravel-promql/src/redact.rs
+++ b/crates/ravel-promql/src/redact.rs
@@ -61,11 +61,16 @@ const TOKEN_HEX_LEN: usize = 16;
 /// ADR keeps readable, so it is never tokenized.
 const METRIC_NAME_LABEL: &str = "__name__";
 
-/// A failure to redact a query. The only failure mode is the underlying
-/// parser rejecting malformed input; the walk and re-render are infallible.
+/// A failure to redact a query. The only failure modes are the underlying
+/// parser rejecting malformed input and the pre-parse complexity guard
+/// ([`crate::complexity_guard`]) rejecting an excessively complex one; the
+/// walk and re-render are infallible.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum RedactError {
-    /// `query` did not parse as PromQL.
+    /// `query` did not parse as PromQL, or was rejected before parsing for
+    /// exceeding the complexity guard (issue #529): a malformed audit-log
+    /// query and a maliciously deep one are both PromQL text this module
+    /// cannot turn into a redacted record.
     ///
     /// Carries no parser detail on purpose: `promql_parser`'s own error
     /// message echoes fragments of the offending input verbatim (an illegal
@@ -100,6 +105,7 @@ pub fn audit_token(token_key: &[u8; 32], value: &[u8]) -> String {
 /// operands change, and only into other valid values. See the module docs for
 /// the exact redaction rules (and why numeric literals stay readable).
 pub fn redact(query: &str, token_key: &[u8; 32]) -> Result<String, RedactError> {
+    crate::complexity_guard::check(query).map_err(|_| RedactError::Parse)?;
     let mut expr = parser::parse(query).map_err(|_| RedactError::Parse)?;
     redact_expr(&mut expr, token_key);
     Ok(expr.to_string())
@@ -283,6 +289,19 @@ mod tests {
     #[test]
     fn malformed_input_returns_typed_error_without_panic() {
         let err = redact("up{job=", &KEY_A).expect_err("must reject malformed input");
+        assert!(matches!(err, RedactError::Parse));
+    }
+
+    /// Issue #529: the audit trail calls `redact` on every query it
+    /// records, so it needs the same pre-parse complexity guard the
+    /// evaluator has, not just a well-formed-syntax check.
+    #[test]
+    fn overly_complex_query_returns_typed_error_without_panic() {
+        let mut query = String::from("1");
+        for _ in 0..300 {
+            query.push_str("+1");
+        }
+        let err = redact(&query, &KEY_A).expect_err("must reject an overly complex query");
         assert!(matches!(err, RedactError::Parse));
     }
 

--- a/crates/ravel-query/src/engine.rs
+++ b/crates/ravel-query/src/engine.rs
@@ -2236,6 +2236,7 @@ mod name_filter_tests {
 /// so the pre-fetch window this computes lines up with what the evaluator
 /// itself will later select.
 fn parse_selector(query: &str) -> Result<(Vec<LabelMatcher>, i64), QueryError> {
+    ravel_promql::complexity_guard::check(query).map_err(|e| QueryError::Parse(e.to_string()))?;
     let expr = promql_parser::parser::parse(query).map_err(QueryError::Parse)?;
     let vs = match expr {
         Expr::VectorSelector(vs) => vs,
@@ -3538,6 +3539,23 @@ mod tests {
     use ravel_types::{Label, LabelSet, SeriesId};
 
     use super::*;
+
+    /// Issue #529: the labels/series HTTP endpoints
+    /// (`http/handlers.rs`'s `match[]` parameter) reach `parse_selector`
+    /// through this wrapper before the evaluator's own parse ever runs, so
+    /// it needs the same pre-parse complexity guard.
+    #[test]
+    fn overly_complex_match_selector_is_rejected_not_parsed() {
+        let mut selector = String::from("1");
+        for _ in 0..300 {
+            selector.push_str("+1");
+        }
+        let err = parse_match_selector(&selector).expect_err("must be rejected before parsing");
+        assert!(
+            matches!(err, QueryError::Parse(_)),
+            "expected QueryError::Parse, got {err:?}"
+        );
+    }
 
     /// A cluster-local (or all-remotes-healthy) query is `Complete`: its stats
     /// carry `partial = false`, so no coverage gap is reported (ADR-0071

--- a/crates/ravel-query/src/http/error.rs
+++ b/crates/ravel-query/src/http/error.rs
@@ -187,6 +187,7 @@ fn redacted_storage_message(err: &QueryError) -> Option<&'static str> {
 fn from_eval_error(inner: &ravel_promql::Error, outer: &QueryError) -> ApiError {
     match inner {
         ravel_promql::Error::Parse(_)
+        | ravel_promql::Error::TooComplex(_)
         | ravel_promql::Error::TimeOverflow
         | ravel_promql::Error::NonPositiveStep { .. }
         | ravel_promql::Error::InvalidRange { .. }
@@ -417,6 +418,20 @@ mod tests {
             expected: "instant vector",
             got: "range vector",
         });
+        match ApiError::from(err) {
+            ApiError::BadData(_) => {}
+            other => panic!("expected BadData, got a different ApiError variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn eval_too_complex_maps_to_bad_data_not_unavailable() {
+        // A query rejected by the pre-parse complexity guard (issue #529)
+        // is a malformed-input-shaped rejection, exactly like Parse: it
+        // must not fall into the catch-all's blanket 503 redaction.
+        let err = QueryError::Eval(ravel_promql::Error::TooComplex(
+            ravel_promql::complexity_guard::QueryTooComplex { count: 9, max: 3 },
+        ));
         match ApiError::from(err) {
             ApiError::BadData(_) => {}
             other => panic!("expected BadData, got a different ApiError variant: {other:?}"),
@@ -683,6 +698,11 @@ mod tests {
                 })
             },
             || QueryError::Eval(PromErr::TooManyPoints { points: 9, max: 3 }),
+            || {
+                QueryError::Eval(PromErr::TooComplex(
+                    ravel_promql::complexity_guard::QueryTooComplex { count: 9, max: 3 },
+                ))
+            },
             || {
                 QueryError::Eval(PromErr::AmbiguousMatch {
                     detail: "many-to-many".to_string(),


### PR DESCRIPTION
## What

`promql_parser::parser::parse` has no recursion-depth guard. A query
built to maximize paren nesting, unary-operator runs, or a flat
binary/logical operator chain aborts the process with a stack overflow
during parsing, well under the request body's 1 MiB cap. The crash
kills every tenant's in-flight query sharing that process.

Adds `ravel_promql::complexity_guard`, a pre-parse scan of raw query
text called before every `promql_parser::parser::parse` call site in
the workspace, rejecting a query whose count of non-whitespace
characters outside string literals/comments exceeds 500.

## Deviation from the issue's stated fix shape

The issue's preferred fix was a post-parse `check_ast` depth check.
Measurement against a standalone probe crate (outside the workspace
build) showed the crash happens **during parsing**, before any AST
exists, so a post-parse check never runs for the attack that matters.
The guard here runs before `parse()` instead.

The issue's framing was also "nesting depth." An earlier design of
this guard counted only bracket depth and unary-operator run length,
matching that framing, and was disproven by direct experiment: a flat
chain of binary/logical operators with no brackets at all crashes the
parser at a similar depth, because the parser recurses once per
operator regardless of visual nesting. The guard instead bounds a
sound invariant (structural character count, see the module doc in
`complexity_guard.rs` for the full writeup and measured crash
thresholds per construct) rather than enumerating recursion triggers.

## Testing

- Every entry point (`eval_instant`/`eval_range` in `eval.rs`,
  `plan_selectors`, `redact`, and `ravel-query`'s selector pre-parse)
  has a regression test asserting a typed error, not a parse attempt.
- Each guarded call site was confirmed to fail its new test when the
  guard call was temporarily removed (mutation-proof).
- `complexity_guard`'s own unit tests cover the bracket, unary,
  flat-binary-chain, flat-logical-chain, and quote/comment-awareness
  cases, plus a "message doesn't say nesting" assertion since flat
  chains have no nesting.

## Scope

The OTLP nested-attribute conversion in `ravel-otlp` has a similar
unguarded recursion, currently safe only because prost caps decode
nesting at 100. Filed as a fast follow: #574.

Fixes: #529
