### PR TITLE
fix(promql): reject binary operators over native histograms

### DIFF
--- a/crates/ravel-promql-difftest/corpus/binop.txt
+++ b/crates/ravel-promql-difftest/corpus/binop.txt
@@ -186,3 +186,31 @@ query: diff_group_left * on(job) diff_group_right
 kind: instant
 time: +0s
 mode: error
+
+# Native-histogram binop guard (#524): Prometheus implements real histogram
+# arithmetic/comparison semantics for these, Ravel does not yet and rejects
+# instead of silently combining the histogram element's meaningless
+# placeholder `value` (see ravel-promql's binop.rs `histogram_binop_unsupported`
+# and its unit tests for the full guard). `mode: ravel_error_prom_success`
+# (the same ADR-0030 one-sided-divergence shape used above) asserts exactly
+# this: Ravel errors, Prometheus succeeds, and any other outcome is a real
+# mismatch. `diff_native_hist` is the fixed dataset's native-histogram
+# counter series (see histogram_native.txt).
+
+name: error_scalar_vector_arith_over_histogram
+query: diff_native_hist * 2
+kind: instant
+time: +0s
+mode: ravel_error_prom_success
+
+name: error_vector_vector_arith_over_histogram
+query: diff_native_hist + diff_native_hist
+kind: instant
+time: +0s
+mode: ravel_error_prom_success
+
+name: error_comparison_over_histogram
+query: diff_native_hist > 0
+kind: instant
+time: +0s
+mode: ravel_error_prom_success

--- a/crates/ravel-promql-difftest/src/scoring.rs
+++ b/crates/ravel-promql-difftest/src/scoring.rs
@@ -254,9 +254,15 @@ pub enum Probe {
     Shape(Shape),
     /// Any entry carrying a `tolerance:` field (ADR-0025's allowlist).
     ToleranceEntry,
-    /// Any entry using `mode: ravel_error_prom_success` (ADR-0030's
-    /// allowlist).
-    DivergenceModeEntry,
+    /// Any entry using `mode: ravel_error_prom_success` whose `name` also
+    /// contains this marker substring. The mode alone is not distinguishing:
+    /// more than one accepted divergence can use it (ADR-0030's per-node
+    /// point cap and issue #524's histogram-binop guard both do), so a
+    /// bare mode match would double-count one divergence's corpus entries
+    /// as evidence for another's `Construct` row. The marker scopes each
+    /// registry entry to only the corpus entries actually naming it (e.g.
+    /// `"subquery"` for ADR-0030's `error_*subquery*` entries).
+    DivergenceModeEntry(&'static str),
     /// Not expressible as corpus query text. Intentionally-rejected
     /// constructs use this: their evidence is a rejection case in
     /// [`REJECTION_CASES`], not a corpus entry.
@@ -570,6 +576,18 @@ pub static REGISTRY: &[Construct] = &[
          histogram element would be silently dropped; the trigger is \
          matched histogram data, not the syntactic shape",
     ),
+    rejected_modifier(
+        "binary operator over native histograms",
+        "Unsupported: binary operator over native histograms (422 execution)",
+        "the binop evaluator (`combine_value` and its callers) only ever \
+         reads a sample's plain float `value`, which is a meaningless 0.0 \
+         placeholder for a histogram element (issue #524); guarded before \
+         any value combination so the fabricated-zero result is never \
+         produced. `corpus/binop.txt`'s `error_*_over_histogram` entries \
+         (mode: ravel_error_prom_success) additionally pin that Prometheus \
+         itself succeeds here, so this is a real capability gap, not a \
+         shared limitation",
+    ),
     // ---- Binary operators ----
     binop("+", corpus("corpus/binop.txt")),
     binop("-", corpus("corpus/binop.txt")),
@@ -693,7 +711,7 @@ pub static REGISTRY: &[Construct] = &[
         name: "subquery per-node point cap",
         category: Category::Divergence,
         state: ConstructState::AcceptedDivergence { adr: "ADR-0030" },
-        probe: Probe::DivergenceModeEntry,
+        probe: Probe::DivergenceModeEntry("subquery"),
         note: "Ravel's per-subquery-node 11,000-point budget has no \
                Prometheus counterpart, so Ravel rejects by design where \
                Prometheus accepts; the comparator asserts exactly that shape",
@@ -774,6 +792,13 @@ pub static REJECTION_CASES: &[RejectionCase] = &[
         eval: RejectionEval::Instant,
         time_offset_ms: 600_000,
         message_contains: "subquery over native histograms",
+    },
+    RejectionCase {
+        construct: "binary operator over native histograms",
+        query: "diff_native_hist * 2",
+        eval: RejectionEval::Instant,
+        time_offset_ms: 0,
+        message_contains: "binary operator over native histograms",
     },
 ];
 
@@ -1148,7 +1173,9 @@ pub fn exercises(probe: Probe, tokens: &[Token], entry: &CorpusEntry) -> bool {
             .any(|t| t.brace_depth > 0 && matches!(&t.tok, Tok::Op(op) if op == sym)),
         Probe::Shape(shape) => exercises_shape(shape, tokens),
         Probe::ToleranceEntry => entry.tolerance_ulps.is_some(),
-        Probe::DivergenceModeEntry => entry.mode == ComparisonMode::RavelErrorPromSuccess,
+        Probe::DivergenceModeEntry(marker) => {
+            entry.mode == ComparisonMode::RavelErrorPromSuccess && entry.name.contains(marker)
+        }
         Probe::None => false,
     }
 }
@@ -2284,21 +2311,45 @@ mod tests {
             &toleranced
         ));
         assert!(!exercises(
-            Probe::DivergenceModeEntry,
+            Probe::DivergenceModeEntry(""),
             &lex(&toleranced.query),
             &toleranced
         ));
 
         let diverging = parse_corpus(
-            "name: d\nquery: up\nkind: instant\ntime: +0s\nmode: ravel_error_prom_success\n",
+            "name: error_subquery_over_x\nquery: up\nkind: instant\ntime: +0s\nmode: ravel_error_prom_success\n",
         )
         .expect("parse")
         .pop()
         .expect("one entry");
         assert!(exercises(
-            Probe::DivergenceModeEntry,
+            Probe::DivergenceModeEntry("subquery"),
             &lex(&diverging.query),
             &diverging
+        ));
+    }
+
+    #[test]
+    fn divergence_probe_marker_does_not_cross_match_a_different_divergence() {
+        // Two entries can both use `mode: ravel_error_prom_success` for
+        // unrelated reasons (ADR-0030's subquery point cap, issue #524's
+        // histogram-binop guard); a registry row's marker must not count
+        // the other's corpus entries as its own evidence.
+        let histogram_entry = parse_corpus(
+            "name: error_binop_over_histogram\nquery: h * 2\nkind: instant\ntime: +0s\nmode: ravel_error_prom_success\n",
+        )
+        .expect("parse")
+        .pop()
+        .expect("one entry");
+        assert!(!exercises(
+            Probe::DivergenceModeEntry("subquery"),
+            &lex(&histogram_entry.query),
+            &histogram_entry
+        ));
+        assert!(exercises(
+            Probe::DivergenceModeEntry("histogram"),
+            &lex(&histogram_entry.query),
+            &histogram_entry
         ));
     }
 

--- a/crates/ravel-promql/src/binop.rs
+++ b/crates/ravel-promql/src/binop.rs
@@ -77,6 +77,29 @@ fn is_set_operator(op: TokenId) -> bool {
     matches!(op, T_LAND | T_LOR | T_LUNLESS)
 }
 
+/// Whether any element of `v` is a native-histogram sample.
+fn has_histogram(v: &InstantVector) -> bool {
+    v.iter().any(|s| s.histogram.is_some())
+}
+
+/// Native-histogram arithmetic/comparison is not yet implemented (issue
+/// #524): [`combine_value`] and its callers only ever read `l`/`r` as plain
+/// `f64`, so a histogram element's real value is invisible to them and its
+/// `value` field is a meaningless `0.0` placeholder (see
+/// [`crate::eval::InstantSample::histogram`]'s doc comment). Combining that
+/// placeholder would silently fabricate a wrong answer -- exactly the
+/// defect this guard exists to prevent -- so every arithmetic/comparison
+/// binop rejects histogram-carrying operands with a typed error instead.
+/// Set operators (`and`/`or`/`unless`) are unaffected: they pass matched
+/// [`InstantSample`](crate::eval::InstantSample)s through unchanged (label
+/// matching only, no value combination), so they already handle histogram
+/// operands correctly and are not guarded here.
+fn histogram_binop_unsupported() -> Error {
+    Error::Unsupported {
+        construct: "binary operator over native histograms".to_string(),
+    }
+}
+
 /// Go's `math.Mod`/C `fmod` semantics: Rust's float `%` already implements
 /// truncated-division remainder (sign follows the dividend), matching
 /// Prometheus' `%` bit for bit in the general case.
@@ -161,6 +184,9 @@ fn eval_scalar_vector(
     modifier: &BinModifier,
     scalar_is_lhs: bool,
 ) -> Result<InstantVector, Error> {
+    if has_histogram(&vector) {
+        return Err(histogram_binop_unsupported());
+    }
     let drop_name = should_drop_metric_name(op, modifier.return_bool);
     let mut out = Vec::with_capacity(vector.len());
     for s in vector {
@@ -204,6 +230,9 @@ fn eval_vector_vector(
             T_LUNLESS => set_unless(lhs, rhs, matching),
             _ => unreachable!("is_set_operator matched an unhandled token"),
         });
+    }
+    if has_histogram(&lhs) || has_histogram(&rhs) {
+        return Err(histogram_binop_unsupported());
     }
     match &modifier.card {
         VectorMatchCardinality::OneToOne => one_to_one(op, lhs, rhs, modifier),
@@ -489,6 +518,36 @@ fn set_or(
 mod tests {
     use crate::eval::{Error, Evaluator, Value};
     use crate::testsource::TestSource;
+
+    /// One native histogram, mirroring `eval::tests::nh`'s fixture.
+    fn nh(count: f64, sum: f64) -> crate::histogram::FloatHistogram {
+        crate::histogram::FloatHistogram {
+            counter_reset_hint: crate::histogram::ResetHint::Unknown,
+            scale: 0,
+            zero_threshold: 0.0,
+            zero_count: 0.0,
+            count,
+            sum,
+            positive_spans: vec![crate::histogram::Span {
+                offset: 1,
+                length: 1,
+            }],
+            negative_spans: Vec::new(),
+            positive_buckets: vec![count],
+            negative_buckets: Vec::new(),
+            custom_values: Vec::new(),
+        }
+    }
+
+    fn expect_histogram_binop_unsupported(err: Error) {
+        let Error::Unsupported { construct } = err else {
+            panic!("expected Unsupported, got {err:?}");
+        };
+        assert!(
+            construct.contains("binary operator over native histograms"),
+            "construct {construct:?} should name the histogram-binop construct"
+        );
+    }
 
     fn source() -> TestSource {
         TestSource::new()
@@ -831,5 +890,77 @@ mod tests {
             .instant(&src, "many + on(job) group_left one", 0)
             .expect_err("one-side duplicate must be rejected even though many-side matches");
         assert!(matches!(err, Error::AmbiguousMatch { .. }));
+    }
+
+    /// Issue #524: a binop over a native histogram must be a typed error,
+    /// never a silently fabricated float computed from the histogram
+    /// element's meaningless placeholder `value` (always `0.0`).
+    #[test]
+    fn scalar_vector_arithmetic_over_histogram_is_unsupported() {
+        let src = TestSource::new()
+            .with_histogram_series(&[("__name__", "h"), ("job", "x")], &[(0, nh(6.0, 42.0))])
+            .expect("valid histogram series");
+        let err = Evaluator::new()
+            .instant(&src, "h * 2", 0)
+            .expect_err("h * 2 must be rejected, not silently computed on a placeholder 0.0");
+        expect_histogram_binop_unsupported(err);
+    }
+
+    #[test]
+    fn vector_vector_arithmetic_over_two_histograms_is_unsupported() {
+        let src = TestSource::new()
+            .with_histogram_series(&[("__name__", "h"), ("job", "x")], &[(0, nh(6.0, 42.0))])
+            .expect("valid histogram series");
+        let err = Evaluator::new()
+            .instant(&src, "h + h", 0)
+            .expect_err("h + h must be rejected, not silently computed on placeholder 0.0s");
+        expect_histogram_binop_unsupported(err);
+    }
+
+    #[test]
+    fn vector_vector_arithmetic_mixed_histogram_and_float_is_unsupported() {
+        // Histogram on the lhs, plain float on the rhs: the guard must fire
+        // regardless of which side carries the histogram.
+        let src = TestSource::new()
+            .with_histogram_series(&[("__name__", "h"), ("job", "x")], &[(0, nh(6.0, 42.0))])
+            .expect("valid histogram series")
+            .with_series(&[("__name__", "f"), ("job", "x")], &[(0, 3.0)])
+            .expect("valid series");
+        let err = Evaluator::new()
+            .instant(&src, "h + on(job) f", 0)
+            .expect_err("h + f must be rejected: h's value is a meaningless placeholder");
+        expect_histogram_binop_unsupported(err);
+    }
+
+    #[test]
+    fn comparison_over_histogram_is_unsupported() {
+        let src = TestSource::new()
+            .with_histogram_series(&[("__name__", "h"), ("job", "x")], &[(0, nh(6.0, 42.0))])
+            .expect("valid histogram series");
+        let err = Evaluator::new()
+            .instant(&src, "h > 5", 0)
+            .expect_err("comparing a histogram's placeholder value must be rejected");
+        expect_histogram_binop_unsupported(err);
+    }
+
+    /// Set operators pass matched samples through unchanged (no value
+    /// combination), so they already handle histogram operands correctly
+    /// and must NOT be guarded: this pins that `and` keeps working, so a
+    /// future change can't silently widen the guard onto set operators.
+    #[test]
+    fn set_operator_and_over_histograms_is_unaffected() {
+        let src = TestSource::new()
+            .with_histogram_series(&[("__name__", "h"), ("job", "x")], &[(0, nh(6.0, 42.0))])
+            .expect("valid histogram series")
+            .with_series(&[("__name__", "g"), ("job", "x")], &[(0, 1.0)])
+            .expect("valid series");
+        let v = Evaluator::new()
+            .instant(&src, "h and on(job) g", 0)
+            .expect("set operators over histograms must keep working");
+        assert_eq!(v.len(), 1);
+        assert!(
+            v[0].histogram.is_some(),
+            "the histogram element must survive `and` unchanged"
+        );
     }
 }

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -1016,23 +1016,23 @@ conformance_table`; regenerate that same command with
 `RAVEL_UPDATE_CONFORMANCE_TABLE=1`. Do not edit the block between
 the markers by hand.
 
-Surface: 131 constructs over 218 corpus entries in 10 corpus files.
+Surface: 132 constructs over 221 corpus entries in 10 corpus files.
 
 | State | Constructs |
 | --- | --- |
 | supported | 124 |
-| intentionally rejected | 5 |
+| intentionally rejected | 6 |
 | accepted divergence | 2 |
 | unclassified | 0 |
-| **score** (supported + intentionally rejected + accepted divergence / total) | **131/131 = 100%** |
+| **score** (supported + intentionally rejected + accepted divergence / total) | **132/132 = 100%** |
 
 | Construct | Category | State | Evidence |
 | --- | --- | --- | --- |
 | aggregate expression | ast node | supported | `corpus/aggregate.txt`, 20 entries |
-| binary expression | ast node | supported | `corpus/binop.txt`, 28 entries |
+| binary expression | ast node | supported | `corpus/binop.txt`, 31 entries |
 | function call | ast node | supported | `corpus/transform.txt`, 59 entries |
 | matrix selector | ast node | supported | `corpus/selectors.txt`, 4 entries |
-| number literal | ast node | supported | `corpus/binop.txt`, 14 entries |
+| number literal | ast node | supported | `corpus/binop.txt`, 16 entries |
 | paren expression | ast node | supported | `corpus/selectors.txt`, 2 entries |
 | string literal | ast node | supported | `corpus/transform.txt`, 6 entries |
 | `subquery` | ast node | supported | `corpus/subquery.txt`, 11 entries |
@@ -1041,6 +1041,7 @@ Surface: 131 constructs over 218 corpus entries in 10 corpus files.
 | @ <timestamp> | modifier | supported | `corpus/selectors.txt`, 2 entries |
 | @ end() | modifier | supported | `corpus/selectors.txt`, 1 entry |
 | @ start() | modifier | supported | `corpus/selectors.txt`, 1 entry |
+| binary operator over native histograms | modifier | intentionally rejected | `Unsupported: binary operator over native histograms (422 execution)`; rejection verified; the binop evaluator (`combine_value` and its callers) only ever reads a sample's plain float `value`, which is a meaningless 0.0 placeholder for a histogram element (issue #524); guarded before any value combination so the fabricated-zero result is never produced. `corpus/binop.txt`'s `error_*_over_histogram` entries (mode: ravel_error_prom_success) additionally pin that Prometheus itself succeeds here, so this is a real capability gap, not a shared limitation |
 | `bool` | modifier | supported | `corpus/binop.txt`, 7 entries |
 | `by` | modifier | supported | `corpus/aggregate.txt`, 11 entries |
 | `group_left` | modifier | supported | `corpus/binop.txt`, 2 entries |
@@ -1059,14 +1060,14 @@ Surface: 131 constructs over 218 corpus entries in 10 corpus files.
 | `without` | modifier | supported | `corpus/aggregate.txt`, 1 entry |
 | `!=` | binary operator | supported | `corpus/binop.txt`, 2 entries |
 | `%` | binary operator | supported | `corpus/binop.txt`, 1 entry |
-| `*` | binary operator | supported | `corpus/binop.txt`, 5 entries |
-| `+` | binary operator | supported | `corpus/binop.txt`, 4 entries |
+| `*` | binary operator | supported | `corpus/binop.txt`, 6 entries |
+| `+` | binary operator | supported | `corpus/binop.txt`, 5 entries |
 | `-` | binary operator | supported | `corpus/binop.txt`, 1 entry |
 | `/` | binary operator | supported | no difftest corpus entry; proven by `ravel-promql`'s `scalar_scalar_arithmetic_and_bool_comparison` |
 | `<` | binary operator | supported | no difftest corpus entry; proven by `ravel-promql`'s `scalar_vector_filter_and_bool_both_directions` |
 | `<=` | binary operator | supported | `corpus/binop.txt`, 2 entries |
 | `==` | binary operator | supported | `corpus/binop.txt`, 2 entries |
-| `>` | binary operator | supported | `corpus/binop.txt`, 3 entries |
+| `>` | binary operator | supported | `corpus/binop.txt`, 4 entries |
 | `>=` | binary operator | supported | `corpus/binop.txt`, 1 entry |
 | `^` | binary operator | supported | `corpus/binop.txt`, 2 entries |
 | `and` | binary operator | supported | `corpus/binop.txt`, 1 entry |


### PR DESCRIPTION
## What

The binop evaluator (`crates/ravel-promql/src/binop.rs`) never checked
a sample's `histogram` field before combining values. A native-histogram
element carries `value: 0.0` as a meaningless placeholder, so any binop
touching a histogram operand silently computed a wrong answer: `h * 2`
and `h + h` returned zeros, `rate(h[5m]) / rate(g[5m])` returned NaN or
zeros, comparisons produced phantom filtered results. Every case
answered HTTP 200 with no warning.

Guard-first fix, as the issue names acceptable: every value-combining
binop path (scalar/vector, one-to-one, group_left/group_right) now
rejects histogram-carrying operands with a typed 422 `Unsupported`
error instead of computing on the placeholder. Real histogram
arithmetic semantics are a larger follow-up.

Set operators (`and`/`or`/`unless`) are explicitly NOT guarded: they
pass matched samples through unchanged (label matching only, no value
combination), so they already handle histogram operands correctly. A
test pins this so a future change can't silently widen the guard onto
them and regress currently-working queries.

## Testing

- `binop.rs` unit tests for `h * 2`, `h + h`, mixed `h + f`, and a
  comparison, each asserting the typed `Unsupported` error, plus a test
  proving `and` keeps working over histograms.
- Difftest corpus entries (`mode: ravel_error_prom_success`) proving
  the real pinned Prometheus binary computes actual histogram
  semantics where Ravel now refuses — confirms this is a genuine
  capability gap, not a shared limitation.
- Every guard call site confirmed to fail its test when temporarily
  removed (mutation-proof), including the RejectionCase-driven
  conformance test, which drives the guard through the same
  HTTP-envelope-shaped path the real endpoint uses.

## Incidental fix: conformance-table generator scoping

Adding the new corpus entries surfaced that
`Probe::DivergenceModeEntry` blanket-matched every corpus entry using
`mode: ravel_error_prom_success` into a single hardcoded ADR-0030
("subquery per-node point cap") bucket, regardless of the actual
reason. Without a fix, the new entries would have silently inflated
that unrelated row's evidence count in the generated conformance
table (`docs/query-engine.md`) rather than being attributed to this
fix. Scoped the probe with a name-substring marker so each
divergence/rejection registry row only counts corpus entries that
actually belong to it; added a unit test pinning that two divergences
using the same comparator mode don't cross-count each other's
entries.

Fixes: #524
