### PR TITLE
docs: claim ADR-0109 columnar bulk-load fast path

### DIFF
--- a/docs/adrs/0109-columnar-bulk-load-fast-path.md
+++ b/docs/adrs/0109-columnar-bulk-load-fast-path.md
@@ -1,0 +1,3 @@
+# ADR-0109: Columnar bulk-load fast path for Parquet ingest
+
+Status: claimed


### PR DESCRIPTION
Reserves ADR-0109 for the columnar bulk-load fast path designed under #586.
The stub is a title and `Status: claimed` only; the full ADR replaces it
once approved.

Claiming the number on main before the ADR is written is what stops two
parallel epics from picking the same next-free number.

Refs: #586
