### PR TITLE
fix(query): scope distributed slice byte budget to actual fan-out width

### DIFF
--- a/crates/ravel-query/src/distrib/federation.rs
+++ b/crates/ravel-query/src/distrib/federation.rs
@@ -212,7 +212,12 @@ impl Federation {
 
         let encoded_matchers = codec::encode_matchers(&matchers);
         let encoded_erasure = codec::encode_erasure(&erasure);
-        let budgets = encode_budgets(&config);
+        // Not a slice fan-out: each remote cluster resolves its own snapshot
+        // and enforces its own admission independently (ADR-0071), so its
+        // request carries the tenant's whole byte budget, not a scoped-down
+        // fraction of it (issue #588's fix is specific to `mod.rs`'s local
+        // slice fan-out, where every slice shares one snapshot's budget).
+        let budgets = encode_budgets(&config, 1);
         let tenant_bytes = tenant_hash.0.to_vec();
         let signal_disc = codec::signal_to_u32(signal);
 

--- a/crates/ravel-query/src/distrib/mod.rs
+++ b/crates/ravel-query/src/distrib/mod.rs
@@ -165,7 +165,7 @@ impl Distributed {
 
         let encoded_matchers = codec::encode_matchers(matchers);
         let encoded_erasure = codec::encode_erasure(erasure);
-        let budgets = encode_budgets(config);
+        let budgets = encode_budgets(config, slices.len());
         let tenant_bytes = tenant_hash.0.to_vec();
         let signal_disc = codec::signal_to_u32(signal);
         // One query id for the whole query (ADR-0071 amendment, decision 2): the
@@ -459,7 +459,7 @@ impl Distributed {
 
         let encoded_matchers = codec::encode_matchers(matchers);
         let encoded_erasure = codec::encode_erasure(erasure);
-        let budgets = encode_budgets(config);
+        let budgets = encode_budgets(config, slices.len());
         let tenant_bytes = tenant_hash.0.to_vec();
         let signal_disc = codec::signal_to_u32(signal);
         let query_id = query_id_bytes(&tenant_bytes, signal_disc, deadline_unix_ns, snapshot);
@@ -615,7 +615,7 @@ impl Distributed {
 
         let encoded_matchers = codec::encode_matchers(matchers);
         let encoded_erasure = codec::encode_erasure(erasure);
-        let budgets = encode_budgets(config);
+        let budgets = encode_budgets(config, slices.len());
         let tenant_bytes = tenant_hash.0.to_vec();
         let signal_disc = codec::signal_to_u32(signal);
         let query_id = query_id_bytes(&tenant_bytes, signal_disc, deadline_unix_ns, snapshot);
@@ -1018,15 +1018,36 @@ pub(crate) fn span_order_key(row: &SpanRow) -> SpanOrderKey {
     )
 }
 
-/// Maps a per-slice `Budgets` share from the engine config. `Unlimited` bytes
-/// map to `0`, the wire's "no cap" sentinel (a real query never scans zero
-/// bytes, so the value is unambiguous).
-fn encode_budgets(config: &EngineConfig) -> pb::Budgets {
+/// Maps a per-slice `Budgets` share from the engine config. `Unlimited`
+/// bytes map to `0`, the wire's "no cap" sentinel (a real query never scans
+/// zero bytes, so the value is unambiguous).
+///
+/// `max_bytes_scanned` is divided evenly across `slice_count` (issue #588):
+/// every slice used to carry the tenant's FULL byte budget verbatim, so a
+/// `max_parallel_slices`-wide fan-out (default 8) could authorize, fetch,
+/// and pay for up to 8x the configured budget before the coordinator's
+/// post-merge re-check observed anything -- final accounting and the
+/// refused outcome were correct, but the overspend already happened. Each
+/// local distrib call site passes the ACTUAL slice count `partition_snapshot`
+/// produced, not the configured cap, so the per-slice shares still sum to
+/// exactly the tenant's budget (up to floor-division slack) even when fewer
+/// slices are dispatched than `max_parallel_slices` allows. Federation's
+/// call site passes `1`: each remote cluster resolves its own snapshot and
+/// enforces its own admission independently (ADR-0071), so its request
+/// carries the tenant's whole budget by design, not a fraction of this
+/// coordinator's local fan-out.
+///
+/// `max_series`/`max_samples`/`max_segments` stay unscoped: those are
+/// count-based caps already re-checked per slice as results return
+/// (`QueryError::TooManySeries` etc.), unlike bytes, which was only
+/// re-checked after every slice's work had already been paid for. Dividing
+/// them too would only tighten an already-sound cap for no reason.
+fn encode_budgets(config: &EngineConfig, slice_count: usize) -> pb::Budgets {
     pb::Budgets {
         max_series: config.max_series as u64,
         max_samples: config.max_samples as u64,
         max_bytes_scanned: match config.max_bytes_scanned {
-            ByteLimit::Bounded(n) => n,
+            ByteLimit::Bounded(n) => n / (slice_count.max(1) as u64),
             ByteLimit::Unlimited => 0,
         },
         max_segments: config.max_segments as u64,

--- a/crates/ravel-query/src/distrib/tests.rs
+++ b/crates/ravel-query/src/distrib/tests.rs
@@ -1210,6 +1210,235 @@ fn coordinator_reenforces_bytes_budget_over_lying_worker() {
     });
 }
 
+// --- byte budget scoped by actual slice count (issue #588) -----------------
+
+/// A [`SliceFetcher`] double that records every `request.budgets` it receives
+/// (so a test can assert what each dispatched slice was actually authorized
+/// for) and answers with an empty, successful response.
+struct RecordingBudgetWorker {
+    seen: Arc<std::sync::Mutex<Vec<pb::Budgets>>>,
+}
+
+#[async_trait::async_trait]
+impl SliceFetcher for RecordingBudgetWorker {
+    async fn fetch(&self, request: pb::FetchRequest) -> Result<SliceResponse, DistribError> {
+        if let Some(budgets) = request.budgets {
+            self.seen.lock().expect("lock").push(budgets);
+        }
+        Ok(SliceResponse {
+            scalar: Vec::new(),
+            histogram: Vec::new(),
+            partials: Vec::new(),
+            accounting: QueryAccounting::new().snapshot(),
+            stats: crate::fetcher::FetchStats::default(),
+            series_returned: 0,
+            samples_returned: 0,
+            status: pb::status::Code::Ok,
+            status_message: String::new(),
+        })
+    }
+}
+
+async fn sharded_snapshot(store: &MemoryStore, shard_count: u32) -> Snapshot {
+    let mut segments = Vec::new();
+    for shard in 0..shard_count {
+        segments.push(
+            write_segment(
+                store,
+                u64::from(shard),
+                shard,
+                100,
+                &[SeriesDesc {
+                    metric: format!("m{shard}"),
+                    samples: vec![(NS, 1.0f64.to_bits())],
+                }],
+            )
+            .await,
+        );
+    }
+    Snapshot {
+        segments,
+        segments_pruned: 0,
+        pending_erasure: Vec::new(),
+    }
+}
+
+/// ADR-0071 (issue #588): every slice used to carry the tenant's FULL byte
+/// budget verbatim, so a `max_parallel_slices`-wide fan-out could authorize
+/// up to Nx the configured budget before the coordinator's post-merge
+/// re-check observed anything. Three shards at cap 3 dispatch three slices;
+/// each must be authorized for exactly a third of the query's byte budget,
+/// summing to no more than the configured total. `max_series`/
+/// `max_samples`/`max_segments` stay unscoped (deliberately, per the fix's
+/// doc comment): each slice still carries the full count-based caps.
+///
+/// Mutation proof: reverting `encode_budgets` in `mod.rs` to the pre-fix
+/// `max_bytes_scanned: n` (no division) makes the per-slice assertion below
+/// fail with `900`, not `300`.
+#[test]
+fn distrib_fetch_scopes_byte_budget_by_actual_slice_count() {
+    let rt = Runtime::new().expect("runtime");
+    rt.block_on(async {
+        let store = MemoryStore::new();
+        let snapshot = sharded_snapshot(&store, 3).await;
+        let seen = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let distributed = Distributed::new(
+            Arc::new(RecordingBudgetWorker {
+                seen: Arc::clone(&seen),
+            }),
+            DistribThresholds {
+                min_store_bytes: 0,
+                min_segments: 0,
+                max_parallel_slices: 3,
+            },
+        );
+        let config = EngineConfig {
+            max_bytes_scanned: crate::config::ByteLimit::Bounded(900),
+            max_series: 42,
+            max_samples: 43,
+            max_segments: 44,
+            ..EngineConfig::default()
+        };
+        let accounting = QueryAccounting::new();
+        distributed
+            .fetch(
+                TENANT,
+                Signal::Metrics,
+                &snapshot,
+                &[],
+                &[],
+                &accounting,
+                &config,
+                i64::MAX,
+                None,
+            )
+            .await
+            .expect("fetch succeeds");
+
+        let recorded = seen.lock().expect("lock");
+        assert_eq!(recorded.len(), 3, "all three slices dispatched once");
+        for budgets in recorded.iter() {
+            assert_eq!(
+                budgets.max_bytes_scanned, 300,
+                "each of 3 slices gets a third of the 900-byte budget, not the whole thing"
+            );
+            assert_eq!(budgets.max_series, 42, "count-based caps stay unscoped");
+            assert_eq!(budgets.max_samples, 43, "count-based caps stay unscoped");
+            assert_eq!(budgets.max_segments, 44, "count-based caps stay unscoped");
+        }
+        let total: u64 = recorded.iter().map(|b| b.max_bytes_scanned).sum();
+        assert!(
+            total <= 900,
+            "the sum of every slice's share must never exceed the configured budget"
+        );
+    });
+}
+
+/// The division must scope to how many slices `partition_snapshot` actually
+/// produced, not the configured `max_parallel_slices` cap: two shards at cap
+/// 8 dispatch only two slices, so each must get half the budget, not an
+/// eighth. Dividing by the cap instead of the real count would starve every
+/// slice with a spurious budget far below what the query is actually
+/// entitled to.
+#[test]
+fn distrib_fetch_scopes_byte_budget_by_real_not_configured_slice_count() {
+    let rt = Runtime::new().expect("runtime");
+    rt.block_on(async {
+        let store = MemoryStore::new();
+        let snapshot = sharded_snapshot(&store, 2).await;
+        let seen = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let distributed = Distributed::new(
+            Arc::new(RecordingBudgetWorker {
+                seen: Arc::clone(&seen),
+            }),
+            DistribThresholds {
+                min_store_bytes: 0,
+                min_segments: 0,
+                max_parallel_slices: 8,
+            },
+        );
+        let config = EngineConfig {
+            max_bytes_scanned: crate::config::ByteLimit::Bounded(1_000),
+            ..EngineConfig::default()
+        };
+        let accounting = QueryAccounting::new();
+        distributed
+            .fetch(
+                TENANT,
+                Signal::Metrics,
+                &snapshot,
+                &[],
+                &[],
+                &accounting,
+                &config,
+                i64::MAX,
+                None,
+            )
+            .await
+            .expect("fetch succeeds");
+
+        let recorded = seen.lock().expect("lock");
+        assert_eq!(recorded.len(), 2, "only two shards, so only two slices");
+        for budgets in recorded.iter() {
+            assert_eq!(
+                budgets.max_bytes_scanned, 500,
+                "two real slices split the budget in half, not by the cap of 8"
+            );
+        }
+    });
+}
+
+/// `Unlimited` stays the wire's `0` sentinel regardless of slice count: a
+/// query with no configured byte cap must not have one manufactured by
+/// dividing `0` (or crashing on it).
+#[test]
+fn distrib_fetch_unlimited_byte_budget_stays_the_zero_sentinel_across_slices() {
+    let rt = Runtime::new().expect("runtime");
+    rt.block_on(async {
+        let store = MemoryStore::new();
+        let snapshot = sharded_snapshot(&store, 3).await;
+        let seen = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let distributed = Distributed::new(
+            Arc::new(RecordingBudgetWorker {
+                seen: Arc::clone(&seen),
+            }),
+            DistribThresholds {
+                min_store_bytes: 0,
+                min_segments: 0,
+                max_parallel_slices: 3,
+            },
+        );
+        let config = EngineConfig {
+            max_bytes_scanned: crate::config::ByteLimit::Unlimited,
+            ..EngineConfig::default()
+        };
+        let accounting = QueryAccounting::new();
+        distributed
+            .fetch(
+                TENANT,
+                Signal::Metrics,
+                &snapshot,
+                &[],
+                &[],
+                &accounting,
+                &config,
+                i64::MAX,
+                None,
+            )
+            .await
+            .expect("fetch succeeds");
+
+        let recorded = seen.lock().expect("lock");
+        assert_eq!(recorded.len(), 3);
+        for budgets in recorded.iter() {
+            assert_eq!(
+                budgets.max_bytes_scanned, 0,
+                "unlimited stays the 0 sentinel"
+            );
+        }
+    });
+}
+
 // --- snapshot invalidation collapses to one retryable error ----------------
 
 /// A [`SliceFetcher`] double that returns a `SnapshotInvalidated` summary for


### PR DESCRIPTION
## Summary

Every slice of a distributed query carried the tenant's full
`max_bytes_scanned` byte budget verbatim, not a share of it. With
`DEFAULT_MAX_PARALLEL_SLICES` at 8, a single distributed query could
authorize and pay for up to 8x the configured byte budget across
workers before the coordinator's post-merge re-check observed
anything -- correct final accounting, but free amplification for a
noisy tenant along the way.

## What changed

- `encode_budgets` (`crates/ravel-query/src/distrib/mod.rs`) now
  divides `max_bytes_scanned` by the actual number of slices
  `partition_snapshot` produced for the query, not the configured
  `max_parallel_slices` cap -- dividing by the cap would under-provision
  every slice whenever fewer slices are dispatched than the cap allows.
  `Unlimited` stays the wire's `0` sentinel regardless of slice count.
- `max_series`/`max_samples`/`max_segments` stay unscoped, per the
  issue's own guidance: those are count-based caps already re-checked
  per slice as results return; bytes was the one only re-checked after
  the fact.
- Federation's remote-cluster fan-out (`federation.rs`) is a different
  dimension and deliberately passes `1` (unscoped): each remote
  resolves its own snapshot and enforces its own admission
  independently (ADR-0071).
- Three new tests record every `FetchRequest.budgets` a mock worker
  receives, including the case that would silently regress if the
  division used the cap instead of the real slice count. All three
  demonstrated failing against the pre-fix unscoped budget (mutation-
  proofed by hand).

## Not run locally

`sql`/`flight-sql` feature-lane gates weren't run locally: another
worktree was mid a cold workspace check/clippy on this host when I
went to gate, and this host runs one cold gate at a time. This change
doesn't touch any sql/flight-sql-gated code path. PR CI runs both
lanes as required checks.

## Test plan

- [x] `cargo test -p ravel-query --lib` (325 passed)
- [x] `scripts/gates.sh -p ravel-query` (fmt, clippy, test, doctest)
- [x] All three new tests demonstrated failing against the pre-fix code
- [ ] PR CI (sql, flight-sql feature lanes)

Refs: #588
