### PR TITLE
feat(ravel-query): pruning-proportional RLOG block-range fetcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4936,6 +4936,7 @@ dependencies = [
  "axum",
  "blake3",
  "bytes",
+ "crc32c",
  "criterion",
  "futures",
  "humantime",

--- a/crates/ravel-query/Cargo.toml
+++ b/crates/ravel-query/Cargo.toml
@@ -45,6 +45,12 @@ serde_json = { workspace = true }
 promql-parser = { workspace = true }
 humantime = { workspace = true }
 bytes = { workspace = true }
+# Independent per-block crc32c verification in the RLOG block-range fetcher
+# (ADR-0107 decision 3): the admitting funnel verifies each block's stored
+# `block_crc32c` before admission and re-verifies it on a cache hit. Already a
+# workspace dependency (ravel-logseg, ravel-segment, ravel-cache use it);
+# promoted to a direct dependency of this crate, not a new external one.
+crc32c = { workspace = true }
 tokio = { workspace = true }
 futures = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/ravel-query/src/config.rs
+++ b/crates/ravel-query/src/config.rs
@@ -154,6 +154,19 @@ pub struct EngineConfig {
     pub fetch_concurrency: usize,
     /// Step for a subquery that does not specify its own (`expr[5m:]`).
     pub default_evaluation_interval: Duration,
+    /// Object size above which a logs scan reads only the pruning-relevant
+    /// blocks of an RLOG object instead of the whole object (ADR-0107), i.e.
+    /// [`crate::LogSegmentFetcher::with_block_range_threshold`]. Not an engine
+    /// limit like the fields above: it rides here because this is the one config
+    /// the server folds its query flags into and hands to every fetcher it
+    /// constructs (`services/ravel-server/src/query.rs`'s `build_sql_state`),
+    /// which is where the logs fetcher is built.
+    ///
+    /// Defaults to [`crate::DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD`] (512 KiB).
+    /// `u64::MAX` reads every object whole, the pre-ADR-0107 behavior and the
+    /// mitigation for an operator who hits a regression on the block-range path;
+    /// `0` sends every object through it.
+    pub logs_block_range_threshold: u64,
 }
 
 impl Default for EngineConfig {
@@ -170,6 +183,7 @@ impl Default for EngineConfig {
             deadline: DEFAULT_DEADLINE,
             fetch_concurrency: DEFAULT_FETCH_CONCURRENCY,
             default_evaluation_interval: DEFAULT_EVALUATION_INTERVAL,
+            logs_block_range_threshold: crate::DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
         }
     }
 }

--- a/crates/ravel-query/src/distrib/service.rs
+++ b/crates/ravel-query/src/distrib/service.rs
@@ -1041,6 +1041,7 @@ fn map_log_fetch_error(err: LogFetchError) -> (pb::status::Code, String) {
         } => (pb::status::Code::SnapshotInvalidated, err.to_string()),
         LogFetchError::Store { .. } => (pb::status::Code::Unavailable, err.to_string()),
         LogFetchError::Corrupt { .. } => (pb::status::Code::Corrupt, err.to_string()),
+        LogFetchError::EtagChanged { .. } => (pb::status::Code::Corrupt, err.to_string()),
     }
 }
 

--- a/crates/ravel-query/src/fetcher.rs
+++ b/crates/ravel-query/src/fetcher.rs
@@ -143,7 +143,20 @@ pub enum FetchError {
 #[derive(Debug, Clone)]
 pub enum CacheFetchError {
     Store(std::sync::Arc<StoreError>),
-    EtagChanged { key: String },
+    EtagChanged {
+        key: String,
+    },
+    /// The bytes a live GET inside the closure returned failed the checksum the
+    /// admitting funnel verifies before admitting them: RLOG's per-block
+    /// `block_crc32c` (`log_fetcher.rs`'s block-range funnel, ADR-0107 decision
+    /// 3). Its own variant so a single-flight follower sees the same hard
+    /// corruption error the leader did, rather than a transient store error it
+    /// would retry. The RSEG closure below verifies nothing inside
+    /// `get_or_fetch` and never produces this.
+    Corrupt {
+        key: String,
+        message: String,
+    },
 }
 
 /// Lets a `get_or_fetch` closure use `?` directly on a `store.get(..)` call
@@ -619,6 +632,22 @@ impl SegmentFetcher {
                 },
                 SingleFlightError::Upstream(CacheFetchError::EtagChanged { key }) => {
                     FetchError::EtagChanged { key }
+                }
+                // Unreachable from this closure: the RSEG path verifies page
+                // checksums when it decodes, not inside `get_or_fetch`, so it
+                // never constructs `Corrupt`. Handled explicitly rather than
+                // through a wildcard so adding an in-closure integrity check
+                // here cannot silently fall through as a store error.
+                // `FetchError::Corrupt` carries a `ravel_segment::SegmentError`,
+                // which this channel's string message cannot reconstruct.
+                SingleFlightError::Upstream(CacheFetchError::Corrupt { key, message }) => {
+                    FetchError::Store {
+                        key,
+                        source: StoreError::Transient(format!(
+                            "cache single-flight closure reported corrupt bytes, which the RSEG \
+                             funnel never produces: {message}"
+                        )),
+                    }
                 }
                 SingleFlightError::LeaderLost => FetchError::Store {
                     key: key.to_string(),

--- a/crates/ravel-query/src/lib.rs
+++ b/crates/ravel-query/src/lib.rs
@@ -27,8 +27,10 @@ pub use fetcher::{
     SegmentFetcher,
 };
 pub use log_fetcher::{
-    BlockRangeFetcher, BlockRangeStats, ColumnarBlockOutcome, LogFetchError, LogFetchOutput,
-    LogQuery, LogSegmentFetcher, LogSegmentScan, StreamAttrEquals,
+    BlockRangeFetcher, BlockRangeStats, ColumnarBlockOutcome, DEFAULT_LOG_COALESCE_GAP,
+    DEFAULT_LOG_COVERAGE_THRESHOLD, DEFAULT_LOG_MAX_CONCURRENT_GETS, DEFAULT_LOG_SUFFIX_LEN,
+    DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD, LogFetchError, LogFetchOutput, LogQuery, LogSegmentFetcher,
+    LogSegmentScan, StreamAttrEquals,
 };
 pub use query_admission::{
     QueryAdmissionController, QueryConcurrencyLimit, QueryPermit, QueryRejected,

--- a/crates/ravel-query/src/lib.rs
+++ b/crates/ravel-query/src/lib.rs
@@ -27,8 +27,8 @@ pub use fetcher::{
     SegmentFetcher,
 };
 pub use log_fetcher::{
-    ColumnarBlockOutcome, LogFetchError, LogFetchOutput, LogQuery, LogSegmentFetcher,
-    LogSegmentScan, StreamAttrEquals,
+    BlockRangeFetcher, BlockRangeStats, ColumnarBlockOutcome, LogFetchError, LogFetchOutput,
+    LogQuery, LogSegmentFetcher, LogSegmentScan, StreamAttrEquals,
 };
 pub use query_admission::{
     QueryAdmissionController, QueryConcurrencyLimit, QueryPermit, QueryRejected,

--- a/crates/ravel-query/src/log_fetcher.rs
+++ b/crates/ravel-query/src/log_fetcher.rs
@@ -37,16 +37,19 @@ use crate::erasure::ErasurePredicate;
 use bytes::Bytes;
 use ravel_cache::{Cache, CacheKey, SingleFlightError};
 use ravel_catalog::SegmentRef;
-use ravel_logseg::footer::{self, kind};
+use ravel_logseg::footer::{self, SectionDesc, kind};
+use ravel_logseg::skip_index::SkipIndex;
 use ravel_logseg::stream_dir::StreamDir;
 use ravel_logseg::{
     AttrValue, BlockScan, ColumnSelection, ColumnarBlockView, LogRecord, LogSegError, LogStreamId,
-    Predicate, RlogConfig, RlogReader, ScanStats, read_section,
+    Predicate, RlogConfig, RlogReader, ScanStats, SuffixOutcome, decode_section, open_from_suffix,
+    read_section,
 };
-use ravel_object_store::{GetRange, ObjectStoreBackend, StoreError};
+use ravel_object_store::{Etag, GetOutcome, GetRange, ObjectStoreBackend, StoreError};
 use ravel_types::TenantHash;
 use ravel_types::accounting::{AccountedOp, QueryAccounting};
 use ravel_types::logstream::canonical_attr_bytes;
+use tokio::sync::Semaphore;
 use tracing::Instrument;
 
 /// Upper bound on STREAM_DIR entries accepted when decoding the directory out
@@ -369,6 +372,15 @@ pub enum LogFetchError {
         #[source]
         source: LogSegError,
     },
+    /// The object's etag changed between the block-range fetcher's
+    /// etag-establishing probe and a later block-range or metadata GET, so the
+    /// store returned bytes from two different object states mid-sequence. The
+    /// single-GET whole-object funnels never observe this (one GET, one state);
+    /// [`BlockRangeFetcher`]'s multi-GET sequence removes that property and must
+    /// replace it explicitly, mirroring `crate::FetchError::EtagChanged`
+    /// (ADR-0107 decision 1).
+    #[error("etag changed between reads of log segment {key}: store returned inconsistent data")]
+    EtagChanged { key: String },
 }
 
 /// Fetches and scans one RLOG log segment at a time. Constructed with the same
@@ -385,14 +397,26 @@ pub struct LogSegmentFetcher {
     /// all tenants (`services/ravel-server/src/query.rs`), so caching cannot
     /// be wired into a method with no per-call tenant identity.
     cache: Option<Arc<Cache<crate::fetcher::CacheFetchError>>>,
+    /// Object size above which a tenant-aware fetch reads only the
+    /// pruning-relevant blocks through [`Self::block_range`] instead of the
+    /// whole object (ADR-0107). At or below it the whole-object path in
+    /// [`tenant_bytes`](Self::tenant_bytes) is unchanged, which keeps every
+    /// small-object read (all current test fixtures, and RLOG's typical object
+    /// size) byte-for-byte as before.
+    block_range_threshold: u64,
+    /// The block-range fetcher used for objects above `block_range_threshold`.
+    /// Kept in sync with `store`/`cfg`/`cache` by the builders.
+    block_range: BlockRangeFetcher,
 }
 
 impl LogSegmentFetcher {
     pub fn new(store: Arc<dyn ObjectStoreBackend>) -> Self {
         LogSegmentFetcher {
-            store,
+            store: store.clone(),
             cfg: RlogConfig::default(),
             cache: None,
+            block_range_threshold: DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
+            block_range: BlockRangeFetcher::new(store),
         }
     }
 
@@ -400,15 +424,51 @@ impl LogSegmentFetcher {
     #[must_use]
     pub fn with_config(mut self, cfg: RlogConfig) -> Self {
         self.cfg = cfg;
+        self.block_range = self.block_range.with_config(cfg);
         self
     }
 
     /// Wires ADR-0046's read cache into
-    /// [`fetch_accounted_with_tenant`](Self::fetch_accounted_with_tenant).
+    /// [`fetch_accounted_with_tenant`](Self::fetch_accounted_with_tenant) and,
+    /// per block, into the block-range path (ADR-0107 decision 3).
     #[must_use]
     pub fn with_cache(mut self, cache: Arc<Cache<crate::fetcher::CacheFetchError>>) -> Self {
-        self.cache = Some(cache);
+        self.cache = Some(cache.clone());
+        self.block_range = self.block_range.with_cache(cache);
         self
+    }
+
+    /// Overrides the object-size threshold above which the tenant-aware fetch
+    /// path reads only pruning-relevant blocks (ADR-0107). Also sets the
+    /// block-range fetcher's own size-threshold pre-probe crossover to the same
+    /// value, so the two agree: an object routed here (size above `n`) never
+    /// trips the inner "small object, read whole" crossover. `0` routes every
+    /// object through the true ranged path, which the tests use on small
+    /// fixtures.
+    #[must_use]
+    pub fn with_block_range_threshold(mut self, n: u64) -> Self {
+        self.block_range_threshold = n;
+        self.block_range = self.block_range.with_whole_object_threshold(n);
+        self
+    }
+
+    /// Replaces the block-range fetcher (ADR-0107) with a fully configured one,
+    /// for callers and tests that need to set the coalescing gap, coverage
+    /// crossover, or concurrency bound directly. The replacement keeps this
+    /// instance's `block_range_threshold`; pair it with
+    /// [`with_block_range_threshold`](Self::with_block_range_threshold) to route
+    /// small fixtures through it.
+    #[must_use]
+    pub fn with_block_range(mut self, block_range: BlockRangeFetcher) -> Self {
+        self.block_range = block_range;
+        self
+    }
+
+    /// The block-range fetcher this instance routes large-object reads through
+    /// (ADR-0107). Exposed so tests can drive the block-range protocol directly.
+    #[must_use]
+    pub fn block_range_fetcher(&self) -> &BlockRangeFetcher {
+        &self.block_range
     }
 
     /// Whether ADR-0046's read cache is wired ([`with_cache`](Self::with_cache)
@@ -776,6 +836,38 @@ impl LogSegmentFetcher {
         }
         let key = &seg_ref.data_object_key;
 
+        // ADR-0107: an object above the block-range threshold is fetched by
+        // reading only the blocks skip-index pruning proved relevant, not the
+        // whole object. Small objects (all current fixtures, RLOG's typical
+        // size) fall through to the unchanged whole-object path below. The
+        // block-range fetcher records its own store/cache accounting; this span
+        // reports its store-GET totals so the phase stays visible.
+        if seg_ref.object_size > self.block_range_threshold {
+            let fetch_span = tracing::debug_span!(
+                "page_fetch",
+                signal = "logs",
+                s3_requests = tracing::field::Empty,
+                s3_bytes = tracing::field::Empty,
+            );
+            let (bytes, stats) = async {
+                self.block_range
+                    .fetch_object(
+                        seg_ref,
+                        tenant_hash,
+                        query.ts_min_ns,
+                        query.ts_max_ns,
+                        accounting,
+                    )
+                    .await
+            }
+            .instrument(fetch_span.clone())
+            .await?;
+            let requests = stats.probe_gets + stats.metadata_gets + stats.block_range_gets;
+            fetch_span.record("s3_requests", requests);
+            fetch_span.record("s3_bytes", stats.block_bytes_fetched);
+            return Ok(Some(bytes));
+        }
+
         // Same two phases as `fetch_accounted`, spanned on the path production
         // log/alerts/audit traffic actually takes (ADR-0044 decision 5): the
         // whole-object GET (`page_fetch`) here, then the STREAM_DIR resolve +
@@ -1035,6 +1127,705 @@ impl LogSegmentFetcher {
         let raw = read_section(bytes, desc, &self.cfg)?;
         StreamDir::decode(&raw, MAX_STREAMS)
     }
+}
+
+/// Default suffix length of the etag-establishing probe GET (ADR-0107 decision
+/// 1). Mirrors `crate::fetcher::DEFAULT_SUFFIX_LEN`. The RLOG tail metadata
+/// (SKIP_IDX, BLOOM, POSTINGS) and the footer sit after the (large) BLOCKS
+/// section, so a suffix of this size normally covers the whole tail in one GET
+/// and no extra metadata GET is needed for them.
+pub const DEFAULT_LOG_SUFFIX_LEN: u64 = 64 * 1024;
+
+/// Default maximum gap between two wanted block extents that still get coalesced
+/// into a single GET. Same 64 KiB start as `crate::fetcher::DEFAULT_COALESCE_GAP`
+/// (ADR-0107 decision 1: "start at RSEG's 64 KiB").
+pub const DEFAULT_LOG_COALESCE_GAP: u64 = 64 * 1024;
+
+/// Default object size at or below which the size-threshold pre-probe crossover
+/// reads the whole object in one GET instead of probing and range-fetching
+/// (ADR-0107 decision 1, "size-threshold, pre-probe whole-object read"). Mirrors
+/// `crate::fetcher::DEFAULT_WHOLE_OBJECT_THRESHOLD` (512 KiB) exactly: below it
+/// the extra probe + per-range round trips cost more than the bytes they save.
+pub const DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD: u64 = 512 * 1024;
+
+/// Default coverage fraction at or above which the post-pruning crossover falls
+/// back to one whole-object GET (ADR-0107 decision 1, "coverage-based,
+/// post-pruning fallback"). When the coalesced candidate ranges already cover
+/// this much of the object, a single whole-object GET beats many range GETs plus
+/// the probe. This crossover is new to ADR-0107 and is a decompose-time
+/// measurement, not a claim about RSEG's behavior.
+pub const DEFAULT_LOG_COVERAGE_THRESHOLD: f64 = 0.75;
+
+/// Default bound on concurrent byte-range GETs one block-range fetch keeps in
+/// flight. Sized independently from `crate::fetcher::SegmentFetcher`'s semaphore
+/// (ADR-0107 decision 1: "sized independently for RLOG's call volume"); RSEG and
+/// RLOG never share the permit pool.
+pub const DEFAULT_LOG_MAX_CONCURRENT_GETS: usize = 16;
+
+/// Upper bound on decoded SKIP_IDX block count, mirroring the reader's own
+/// internal cap (`ravel_logseg::reader::MAX_BLOCKS`, not exported). A section
+/// claiming more blocks is treated as corrupt rather than allocated.
+const MAX_BLOCKS: u64 = 1 << 24;
+
+/// Per-object counters from one [`BlockRangeFetcher::fetch_object`] call, for
+/// tests (the GET-count assertion of ADR-0107) and callers that want the
+/// pruning-proportional figures. `block_range_gets`/`block_bytes_fetched` count
+/// only store round trips for candidate blocks (cache hits excluded), which is
+/// the pruning-proportional quantity; `probe_gets`/`metadata_gets` are the fixed
+/// directory overhead the protocol adds on top.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct BlockRangeStats {
+    /// Store GETs establishing the etag and footer (the suffix probe, plus a
+    /// footer-range chase if the suffix did not cover the whole footer).
+    pub probe_gets: u64,
+    /// Store GETs for non-BLOCKS directory sections not already covered by the
+    /// probe (STREAM_DIR/FIELD_DIR at the object front, and any tail section a
+    /// short probe missed).
+    pub metadata_gets: u64,
+    /// Store GETs for coalesced candidate-block ranges (cache misses only).
+    pub block_range_gets: u64,
+    /// Candidate blocks served from the read cache with no store round trip.
+    pub block_cache_hits: u64,
+    /// Stored bytes of candidate blocks read from the store (cache hits excluded).
+    pub block_bytes_fetched: u64,
+    /// Candidate blocks resolved from the skip index for this query.
+    pub candidate_blocks: u64,
+    /// Set when a crossover (size-threshold pre-probe, or coverage-based
+    /// post-pruning) took the whole-object path instead of range fetches.
+    pub whole_object: bool,
+}
+
+/// One candidate block's absolute byte extent in the object and its stored crc,
+/// resolved from a `SkipIndex` level-0 entry (`block_offset`/`block_len`/
+/// `block_crc32c`). The extent start is absolute: `blocks_offset + block_offset`
+/// (the same arithmetic `ravel_logseg::RlogRangeReader` uses).
+#[derive(Clone, Copy, Debug)]
+struct BlockExtent {
+    abs_start: u64,
+    len: u64,
+    crc32c: u32,
+}
+
+impl BlockExtent {
+    fn abs_end(&self) -> u64 {
+        self.abs_start.saturating_add(self.len)
+    }
+}
+
+/// Assembles an object-sized buffer from separately fetched regions so the
+/// existing whole-object reader ([`RlogReader`]/[`BlockScan`]) can decode from
+/// it unchanged: block extents are absolute offsets into the object, so the
+/// buffer must be indexable at those offsets. Only the fetched directory
+/// sections and candidate blocks are populated; the gap bytes between them (the
+/// pruned blocks) stay zero and are never read -- `BlockScan` restricted to the
+/// candidate blocks only slices the extents that were placed (ADR-0107: gap
+/// bytes "never interpreted, never verified").
+struct ObjectAssembler {
+    buf: Vec<u8>,
+    placed: Vec<(u64, u64)>,
+}
+
+impl ObjectAssembler {
+    fn new(total_size: usize) -> Self {
+        ObjectAssembler {
+            buf: vec![0u8; total_size],
+            placed: Vec::new(),
+        }
+    }
+
+    fn covers(&self, start: u64, end: u64) -> bool {
+        self.placed.iter().any(|(s, e)| *s <= start && end <= *e)
+    }
+
+    fn slice(&self, start: u64, len: u64) -> Option<&[u8]> {
+        let s = usize::try_from(start).ok()?;
+        let e = s.checked_add(usize::try_from(len).ok()?)?;
+        self.buf.get(s..e)
+    }
+
+    fn place(&mut self, key: &str, start: u64, bytes: &[u8]) -> Result<(), LogFetchError> {
+        let s = usize::try_from(start).map_err(|_| corrupt_range(key))?;
+        let e = s
+            .checked_add(bytes.len())
+            .ok_or_else(|| corrupt_range(key))?;
+        let slot = self.buf.get_mut(s..e).ok_or_else(|| corrupt_range(key))?;
+        slot.copy_from_slice(bytes);
+        self.placed
+            .push((start, start.saturating_add(bytes.len() as u64)));
+        Ok(())
+    }
+
+    fn into_bytes(self) -> Bytes {
+        Bytes::from(self.buf)
+    }
+}
+
+fn corrupt_range(key: &str) -> LogFetchError {
+    LogFetchError::Corrupt {
+        key: key.to_string(),
+        source: LogSegError::Corrupted("block-range assembly out of bounds".into()),
+    }
+}
+
+/// The RLOG-specific coalescing block-range fetcher (ADR-0107). It fetches only
+/// the blocks skip-index pruning proved relevant instead of one whole-object GET
+/// per segment, mirroring [`crate::SegmentFetcher`]'s protocol -- gap
+/// coalescing, whole-object crossover(s), etag pinning, and a bounded GET
+/// semaphore -- as its own implementation rather than a shared abstraction (RSEG
+/// and RLOG object layouts differ enough that a shared type would need leaky
+/// per-format branches; the "RSEG and RLOG never share fetch code" convention in
+/// this module's header stays intact).
+///
+/// The result is an object-sized [`Bytes`] with only the directory sections and
+/// candidate blocks populated, ready to hand to [`RlogReader`]/[`BlockScan`]
+/// unchanged: the reader re-prunes and decodes exactly the survivor blocks,
+/// which are a subset of the fetched candidate set, so decode never touches an
+/// unfetched gap. Cache admission is per block, not per coalesced GET (ADR-0107
+/// decision 3): after a live range GET, the response is split at block
+/// boundaries, each block's `block_crc32c` is verified independently, and one
+/// cache entry per block is admitted keyed `(tenant_hash, content_hash,
+/// abs_start, block_len)`; the gap bytes between blocks are discarded.
+#[derive(Clone)]
+pub struct BlockRangeFetcher {
+    store: Arc<dyn ObjectStoreBackend>,
+    cfg: RlogConfig,
+    /// ADR-0046's read cache, consulted per block (decision 3) and per directory
+    /// section. `None` sends every GET to the store.
+    cache: Option<Arc<Cache<crate::fetcher::CacheFetchError>>>,
+    suffix_len: u64,
+    coalesce_gap: u64,
+    whole_object_threshold: u64,
+    coverage_threshold: f64,
+    /// Bounds in-flight byte-range GETs. Its own instance, never shared with
+    /// `SegmentFetcher`'s RSEG semaphore (ADR-0107 decision 1).
+    get_semaphore: Arc<Semaphore>,
+}
+
+impl BlockRangeFetcher {
+    pub fn new(store: Arc<dyn ObjectStoreBackend>) -> Self {
+        BlockRangeFetcher {
+            store,
+            cfg: RlogConfig::default(),
+            cache: None,
+            suffix_len: DEFAULT_LOG_SUFFIX_LEN,
+            coalesce_gap: DEFAULT_LOG_COALESCE_GAP,
+            whole_object_threshold: DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
+            coverage_threshold: DEFAULT_LOG_COVERAGE_THRESHOLD,
+            get_semaphore: Arc::new(Semaphore::new(DEFAULT_LOG_MAX_CONCURRENT_GETS)),
+        }
+    }
+
+    #[must_use]
+    pub fn with_config(mut self, cfg: RlogConfig) -> Self {
+        self.cfg = cfg;
+        self
+    }
+
+    #[must_use]
+    pub fn with_cache(mut self, cache: Arc<Cache<crate::fetcher::CacheFetchError>>) -> Self {
+        self.cache = Some(cache);
+        self
+    }
+
+    #[must_use]
+    pub fn with_suffix_len(mut self, n: u64) -> Self {
+        self.suffix_len = n.max(1);
+        self
+    }
+
+    #[must_use]
+    pub fn with_coalesce_gap(mut self, n: u64) -> Self {
+        self.coalesce_gap = n;
+        self
+    }
+
+    /// Sets the size-threshold pre-probe crossover. An object whose size is at or
+    /// below `n` is read whole in one GET; `0` disables the size crossover (every
+    /// object takes the probe + range path), which the tests use to force the
+    /// ranged path on a small fixture.
+    #[must_use]
+    pub fn with_whole_object_threshold(mut self, n: u64) -> Self {
+        self.whole_object_threshold = n;
+        self
+    }
+
+    /// Sets the coverage-based post-pruning crossover fraction (0.0..=1.0). When
+    /// the coalesced candidate ranges cover at least this fraction of the object,
+    /// one whole-object GET is issued instead. A value `> 1.0` disables it.
+    #[must_use]
+    pub fn with_coverage_threshold(mut self, f: f64) -> Self {
+        self.coverage_threshold = f;
+        self
+    }
+
+    #[must_use]
+    pub fn with_max_concurrent_gets(mut self, n: usize) -> Self {
+        self.get_semaphore = Arc::new(Semaphore::new(n.max(1)));
+        self
+    }
+
+    /// One bounded store GET, recorded against `accounting`. A `NotFound` (or any
+    /// other store error) surfaces as [`LogFetchError::Store`], the SAME typed
+    /// error a whole-object GET already produces, so a `NotFound` on a pinned
+    /// segment maps to the existing `SnapshotInvalidated` retry path
+    /// (ADR-0107 decision 1; `ravel_sql::SqlError::is_segment_not_found`) without
+    /// a second mapping.
+    async fn store_get(
+        &self,
+        key: &str,
+        range: GetRange,
+        accounting: &QueryAccounting,
+    ) -> Result<GetOutcome, LogFetchError> {
+        let _permit = self
+            .get_semaphore
+            .acquire()
+            .await
+            .map_err(|_| LogFetchError::Store {
+                key: key.to_string(),
+                source: StoreError::Transient("fetch concurrency semaphore closed".to_string()),
+            })?;
+        let got = self
+            .store
+            .get(key, range)
+            .await
+            .map_err(|source| LogFetchError::Store {
+                key: key.to_string(),
+                source,
+            })?;
+        accounting.record_s3_request(AccountedOp::Get);
+        accounting.add_s3_bytes(AccountedOp::Get, got.data.len() as u64);
+        Ok(got)
+    }
+
+    /// A store GET whose etag is checked against the pinned `expected` etag: a
+    /// mismatch means the object was replaced mid-sequence and is a hard
+    /// [`LogFetchError::EtagChanged`] (ADR-0107 decision 1), never silently
+    /// mixed data.
+    async fn store_get_pinned(
+        &self,
+        key: &str,
+        range: GetRange,
+        expected: &Etag,
+        accounting: &QueryAccounting,
+    ) -> Result<GetOutcome, LogFetchError> {
+        let got = self.store_get(key, range, accounting).await?;
+        if &got.etag != expected {
+            return Err(LogFetchError::EtagChanged {
+                key: key.to_string(),
+            });
+        }
+        Ok(got)
+    }
+
+    /// Fetch one segment's object as an assembled, decode-ready buffer, reading
+    /// only the blocks skip-index pruning (over `[ts_min_ns, ts_max_ns]`) proved
+    /// relevant. Returns the buffer plus the [`BlockRangeStats`] for the fetch.
+    ///
+    /// The caller has already decided the object is ts-relevant. `ts_min_ns`/
+    /// `ts_max_ns` are the inclusive query bounds used for skip-index candidate
+    /// selection here; stream/POSTINGS/bloom/numeric pruning still runs at decode
+    /// inside the reader over the assembled buffer (it can only narrow the
+    /// candidate set further, so every survivor block is fetched).
+    pub async fn fetch_object(
+        &self,
+        seg_ref: &SegmentRef,
+        tenant_hash: TenantHash,
+        ts_min_ns: i64,
+        ts_max_ns: i64,
+        accounting: &QueryAccounting,
+    ) -> Result<(Bytes, BlockRangeStats), LogFetchError> {
+        let key = seg_ref.data_object_key.as_str();
+        let mut stats = BlockRangeStats::default();
+
+        // Size-threshold pre-probe crossover (ADR-0107 decision 1): a small
+        // object is read whole in one GET, mirroring `SegmentFetcher`.
+        if seg_ref.object_size != 0 && seg_ref.object_size <= self.whole_object_threshold {
+            let got = self.store_get(key, GetRange::Full, accounting).await?;
+            stats.probe_gets = 1;
+            stats.whole_object = true;
+            return Ok((got.data, stats));
+        }
+
+        // Etag-establishing probe: a suffix GET that pins the etag every later
+        // GET is checked against, and carries the footer (and, for a small
+        // object, the whole tail directory).
+        let suffix = self.suffix_len.min(seg_ref.object_size.max(1));
+        let probe = self
+            .store_get(key, GetRange::Suffix(suffix), accounting)
+            .await?;
+        stats.probe_gets = 1;
+        let total_size = probe.total_size;
+        let pinned = probe.etag.clone();
+        let total = usize::try_from(total_size).map_err(|_| corrupt_range(key))?;
+
+        let mut asm = ObjectAssembler::new(total);
+        let probe_start = total_size.saturating_sub(probe.data.len() as u64);
+        asm.place(key, probe_start, &probe.data)?;
+
+        // Footer: parse from the probe suffix, chasing one range if the suffix
+        // did not cover the whole footer (mirrors `SegmentFetcher::open_segment`).
+        let footer = match open_from_suffix(&probe.data, total_size)
+            .map_err(|source| corrupt(key, source))?
+        {
+            SuffixOutcome::Ready(footer) => footer,
+            SuffixOutcome::NeedRange { offset, len } => {
+                let got = self
+                    .store_get_pinned(
+                        key,
+                        GetRange::Range(offset, offset + len),
+                        &pinned,
+                        accounting,
+                    )
+                    .await?;
+                stats.probe_gets += 1;
+                asm.place(key, offset, &got.data)?;
+                match open_from_suffix(&got.data, total_size)
+                    .map_err(|source| corrupt(key, source))?
+                {
+                    SuffixOutcome::Ready(footer) => footer,
+                    SuffixOutcome::NeedRange { .. } => {
+                        return Err(corrupt(
+                            key,
+                            LogSegError::Corrupted("footer not covered".into()),
+                        ));
+                    }
+                }
+            }
+        };
+
+        // Fetch and place every non-BLOCKS directory section not already covered
+        // by the probe: STREAM_DIR/FIELD_DIR (object front) always, plus any tail
+        // section (SKIP_IDX/BLOOM/POSTINGS) a short probe missed. The reader
+        // re-verifies each section's crc on decode, so a corrupt section hit
+        // fails closed there (ADR-0046).
+        for section in &footer.sections {
+            if section.kind == kind::BLOCKS {
+                continue;
+            }
+            let (start, end) = (section.offset, section.offset + section.len);
+            if asm.covers(start, end) {
+                continue;
+            }
+            let bytes = self
+                .section_bytes(
+                    seg_ref,
+                    tenant_hash,
+                    section,
+                    &pinned,
+                    accounting,
+                    &mut stats,
+                )
+                .await?;
+            asm.place(key, section.offset, &bytes)?;
+        }
+
+        // Decode the skip index (now resident) and resolve the candidate blocks.
+        let skip_desc = footer
+            .section(kind::SKIP_IDX)
+            .ok_or_else(|| corrupt(key, LogSegError::Corrupted("missing SKIP_IDX".into())))?;
+        let blocks_desc = footer
+            .section(kind::BLOCKS)
+            .ok_or_else(|| corrupt(key, LogSegError::Corrupted("missing BLOCKS".into())))?;
+        let skip_start = usize::try_from(skip_desc.offset).map_err(|_| corrupt_range(key))?;
+        let skip_end = skip_start
+            .checked_add(usize::try_from(skip_desc.len).map_err(|_| corrupt_range(key))?)
+            .ok_or_else(|| corrupt_range(key))?;
+        let skip_stored = asm
+            .buf
+            .get(skip_start..skip_end)
+            .ok_or_else(|| corrupt_range(key))?;
+        let skip_raw = decode_section(skip_stored, skip_desc, &self.cfg)
+            .map_err(|source| corrupt(key, source))?;
+        let skip =
+            SkipIndex::decode(&skip_raw, MAX_BLOCKS).map_err(|source| corrupt(key, source))?;
+
+        let extents = self.resolve_extents(key, &skip, blocks_desc.offset, ts_min_ns, ts_max_ns)?;
+        stats.candidate_blocks = extents.len() as u64;
+
+        // Coverage-based post-pruning crossover (ADR-0107 decision 1): when the
+        // candidate ranges already cover most of the object, one whole-object GET
+        // beats many range GETs.
+        let candidate_bytes: u64 = extents.iter().map(|e| e.len).sum();
+        let coverage = candidate_bytes as f64 / total_size.max(1) as f64;
+        if coverage >= self.coverage_threshold {
+            let got = self
+                .store_get_pinned(key, GetRange::Full, &pinned, accounting)
+                .await?;
+            stats.block_range_gets = 1;
+            stats.whole_object = true;
+            // Still admit per-block cache entries so a later partition's fetch of
+            // a subset composes with this one (ADR-0107 decision 3).
+            self.admit_blocks_from_whole(seg_ref, tenant_hash, &got.data, &extents);
+            return Ok((got.data, stats));
+        }
+
+        self.fetch_blocks(
+            seg_ref,
+            tenant_hash,
+            &pinned,
+            &extents,
+            &mut asm,
+            accounting,
+            &mut stats,
+        )
+        .await?;
+        Ok((asm.into_bytes(), stats))
+    }
+
+    /// Resolve each candidate block index (from `skip.candidate_blocks`) to its
+    /// absolute byte extent and stored crc. The byte extent is always the block's
+    /// full extent from its SKIP_IDX level-0 entry, never a sub-block slice
+    /// (ADR-0107 decision 1).
+    fn resolve_extents(
+        &self,
+        key: &str,
+        skip: &SkipIndex,
+        blocks_offset: u64,
+        ts_min_ns: i64,
+        ts_max_ns: i64,
+    ) -> Result<Vec<BlockExtent>, LogFetchError> {
+        let candidates = skip.candidate_blocks(ts_min_ns, ts_max_ns, None, &[]);
+        let mut out = Vec::with_capacity(candidates.len());
+        for i in candidates {
+            let entry = skip.l0.get(i).ok_or_else(|| {
+                corrupt(
+                    key,
+                    LogSegError::Corrupted("skip block index out of range".into()),
+                )
+            })?;
+            let abs_start = blocks_offset
+                .checked_add(entry.block_offset)
+                .ok_or_else(|| corrupt_range(key))?;
+            out.push(BlockExtent {
+                abs_start,
+                len: entry.block_len,
+                crc32c: entry.block_crc32c,
+            });
+        }
+        Ok(out)
+    }
+
+    /// Fetch one directory section's stored bytes, through the read cache when
+    /// configured. The bytes are the section's exact `[offset, offset+len)`
+    /// stored form (crc-verified by the reader on decode); the cache key is the
+    /// section's own extent.
+    #[allow(clippy::too_many_arguments)]
+    async fn section_bytes(
+        &self,
+        seg_ref: &SegmentRef,
+        tenant_hash: TenantHash,
+        section: &SectionDesc,
+        pinned: &Etag,
+        accounting: &QueryAccounting,
+        stats: &mut BlockRangeStats,
+    ) -> Result<Bytes, LogFetchError> {
+        let key = seg_ref.data_object_key.as_str();
+        let cache_key = CacheKey::new(
+            tenant_hash.0,
+            seg_ref.content_hash,
+            section.offset,
+            section.len,
+        );
+        if let Some(cache) = &self.cache
+            && let Some(bytes) = cache.get(&cache_key)
+        {
+            accounting.record_cache_hit();
+            accounting.add_cache_bytes(bytes.len() as u64);
+            return Ok(bytes);
+        }
+        if self.cache.is_some() {
+            accounting.record_cache_miss();
+        }
+        let got = self
+            .store_get_pinned(
+                key,
+                GetRange::Range(section.offset, section.offset + section.len),
+                pinned,
+                accounting,
+            )
+            .await?;
+        stats.metadata_gets += 1;
+        if let Some(cache) = &self.cache {
+            cache.insert(cache_key, got.data.clone());
+        }
+        Ok(got.data)
+    }
+
+    /// Fetch the candidate blocks into `asm`: serve each from the per-block cache
+    /// when present (re-verifying `block_crc32c` on the cached bytes -- ADR-0046's
+    /// corrupt-hit gate, which this admitting funnel owns), coalesce the misses
+    /// within `coalesce_gap`, GET each coalesced range (etag-pinned, bounded by
+    /// the semaphore), split each response at block boundaries, verify each
+    /// block's crc independently, admit one cache entry per block, and place it.
+    #[allow(clippy::too_many_arguments)]
+    async fn fetch_blocks(
+        &self,
+        seg_ref: &SegmentRef,
+        tenant_hash: TenantHash,
+        pinned: &Etag,
+        extents: &[BlockExtent],
+        asm: &mut ObjectAssembler,
+        accounting: &QueryAccounting,
+        stats: &mut BlockRangeStats,
+    ) -> Result<(), LogFetchError> {
+        let key = seg_ref.data_object_key.as_str();
+        let mut missing: Vec<BlockExtent> = Vec::new();
+        for ext in extents {
+            // Already resident from the probe suffix (a probe wide enough to
+            // reach into BLOCKS): verify its crc from the buffer and admit it,
+            // but issue no GET. This keeps the probe from being re-fetched block
+            // by block, so the block-range GET count stays proportional to the
+            // blocks the probe did NOT already carry.
+            if asm.covers(ext.abs_start, ext.abs_end()) {
+                let block = asm
+                    .slice(ext.abs_start, ext.len)
+                    .ok_or_else(|| corrupt_range(key))?;
+                verify_block_crc(key, block, ext)?;
+                if let Some(cache) = &self.cache {
+                    let cache_key =
+                        CacheKey::new(tenant_hash.0, seg_ref.content_hash, ext.abs_start, ext.len);
+                    cache.insert(cache_key, Bytes::copy_from_slice(block));
+                }
+                continue;
+            }
+            let cache_key =
+                CacheKey::new(tenant_hash.0, seg_ref.content_hash, ext.abs_start, ext.len);
+            if let Some(cache) = &self.cache
+                && let Some(bytes) = cache.get(&cache_key)
+            {
+                // Corrupt-hit gate (ADR-0046 §4 / ADR-0107 decision 3): a cached
+                // block is re-verified against its stored crc before use, exactly
+                // as a live fetch of that block is, and fails closed on mismatch.
+                verify_block_crc(key, &bytes, ext)?;
+                accounting.record_cache_hit();
+                accounting.add_cache_bytes(bytes.len() as u64);
+                stats.block_cache_hits += 1;
+                asm.place(key, ext.abs_start, &bytes)?;
+                continue;
+            }
+            if self.cache.is_some() {
+                accounting.record_cache_miss();
+            }
+            missing.push(*ext);
+        }
+
+        for run in coalesce_extents(&missing, self.coalesce_gap) {
+            let (start, end) = (run.abs_start, run.abs_start.saturating_add(run.len));
+            let got = self
+                .store_get_pinned(key, GetRange::Range(start, end), pinned, accounting)
+                .await?;
+            stats.block_range_gets += 1;
+            stats.block_bytes_fetched = stats
+                .block_bytes_fetched
+                .saturating_add(got.data.len() as u64);
+            // Split the coalesced response at block boundaries, verify and admit
+            // one entry per block; the gap bytes between blocks are discarded,
+            // never cached, never interpreted (ADR-0107 decision 3).
+            for ext in &missing {
+                if ext.abs_start < start || ext.abs_end() > end {
+                    continue;
+                }
+                let rel = usize::try_from(ext.abs_start - start).map_err(|_| corrupt_range(key))?;
+                let rel_end = rel
+                    .checked_add(usize::try_from(ext.len).map_err(|_| corrupt_range(key))?)
+                    .ok_or_else(|| corrupt_range(key))?;
+                let block = got
+                    .data
+                    .get(rel..rel_end)
+                    .ok_or_else(|| corrupt_range(key))?;
+                verify_block_crc(key, block, ext)?;
+                if let Some(cache) = &self.cache {
+                    let cache_key =
+                        CacheKey::new(tenant_hash.0, seg_ref.content_hash, ext.abs_start, ext.len);
+                    cache.insert(cache_key, Bytes::copy_from_slice(block));
+                }
+                asm.place(key, ext.abs_start, block)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Split whole-object bytes (the coverage-crossover path) at block boundaries
+    /// and admit one verified cache entry per candidate block, so a later
+    /// partition's block-range fetch composes with this whole-object read
+    /// (ADR-0107 decision 3). A block whose crc does not verify is simply not
+    /// admitted; the reader's own decode still gates correctness of what is
+    /// returned.
+    fn admit_blocks_from_whole(
+        &self,
+        seg_ref: &SegmentRef,
+        tenant_hash: TenantHash,
+        object: &Bytes,
+        extents: &[BlockExtent],
+    ) {
+        let Some(cache) = &self.cache else {
+            return;
+        };
+        for ext in extents {
+            let (Ok(start), Ok(len)) = (usize::try_from(ext.abs_start), usize::try_from(ext.len))
+            else {
+                continue;
+            };
+            let Some(end) = start.checked_add(len) else {
+                continue;
+            };
+            let Some(block) = object.get(start..end) else {
+                continue;
+            };
+            if crc32c::crc32c(block) != ext.crc32c {
+                continue;
+            }
+            let cache_key =
+                CacheKey::new(tenant_hash.0, seg_ref.content_hash, ext.abs_start, ext.len);
+            cache.insert(cache_key, Bytes::copy_from_slice(block));
+        }
+    }
+}
+
+/// Verify one block's bytes against its stored `block_crc32c`; a mismatch is a
+/// hard [`LogFetchError::Corrupt`], never silently-wrong data (ADR-0107 decision
+/// 3). The block is the smallest unit the RLOG format can verify.
+fn verify_block_crc(key: &str, bytes: &[u8], ext: &BlockExtent) -> Result<(), LogFetchError> {
+    if bytes.len() as u64 != ext.len {
+        return Err(corrupt(
+            key,
+            LogSegError::Corrupted("block length mismatch".into()),
+        ));
+    }
+    if crc32c::crc32c(bytes) != ext.crc32c {
+        return Err(corrupt(
+            key,
+            LogSegError::Corrupted("block crc mismatch".into()),
+        ));
+    }
+    Ok(())
+}
+
+/// Merge candidate block extents into ordered, non-overlapping runs, joining two
+/// whole-block extents whose gap is at most `max_gap` into one range (the RLOG
+/// analogue of `crate::fetcher::coalesce_ranges`). Each returned `BlockExtent`
+/// describes a coalesced GET's `[abs_start, abs_start+len)`; its `crc32c` is not
+/// meaningful (coalesced ranges are split back to per-block extents by the
+/// caller and each block's own crc is verified there).
+fn coalesce_extents(extents: &[BlockExtent], max_gap: u64) -> Vec<BlockExtent> {
+    let mut ranges: Vec<(u64, u64)> = extents.iter().map(|e| (e.abs_start, e.abs_end())).collect();
+    ranges.sort_by_key(|r| r.0);
+    let mut out: Vec<BlockExtent> = Vec::new();
+    for (start, end) in ranges {
+        if let Some(last) = out.last_mut()
+            && start <= last.abs_end().saturating_add(max_gap)
+        {
+            let new_end = last.abs_end().max(end);
+            last.len = new_end - last.abs_start;
+            continue;
+        }
+        out.push(BlockExtent {
+            abs_start: start,
+            len: end - start,
+            crc32c: 0,
+        });
+    }
+    out
 }
 
 /// The canonical-byte needle for one stream-attribute equality: the single

--- a/crates/ravel-query/src/log_fetcher.rs
+++ b/crates/ravel-query/src/log_fetcher.rs
@@ -26,10 +26,18 @@
 //! is exact: ts-range pruning and the content predicates are evaluated exactly
 //! by the reader.
 //!
-//! v1 fetches the whole object with a single [`GetRange::Full`]. RLOG objects
-//! are not yet large enough to justify the suffix-then-range-chase read
-//! `SegmentFetcher` uses for RSEG; this may deserve revisiting once they
-//! grow.
+//! Two read shapes, split by object size (ADR-0107). The tenant-aware funnels
+//! fetch an object at or below [`LogSegmentFetcher::with_block_range_threshold`]
+//! (512 KiB by default) with a single [`GetRange::Full`], which is every small
+//! RLOG object and every fixture here. Above it they read only the blocks
+//! skip-index pruning proved relevant, through [`BlockRangeFetcher`]: a suffix
+//! probe that pins the etag, the directory sections, and coalesced
+//! candidate-block ranges, assembled into an object-sized buffer the unchanged
+//! reader decodes from. Every GET of either shape is routed through ADR-0046's
+//! read cache when one is wired, keyed by the extent it fetched, so concurrent
+//! callers for the same extent collapse onto one request. The untenanted
+//! [`LogSegmentFetcher::fetch`]/[`LogSegmentFetcher::fetch_accounted`] entry
+//! points have no cache key and always read the whole object in one GET.
 
 use std::sync::Arc;
 
@@ -472,11 +480,19 @@ impl LogSegmentFetcher {
     }
 
     /// Whether ADR-0046's read cache is wired ([`with_cache`](Self::with_cache)
-    /// was called). A caller that would issue several whole-object GETs at the
-    /// same key needs this: with a cache those coalesce onto one fetch through
-    /// single-flight, without one each is a real object-store request. ADR-0102
-    /// decision 1 names the cache as the precondition for that fan-out, and
-    /// `LogsScanExec::new` gates its partition count on this.
+    /// was called). A caller that would issue several GETs at the same key needs
+    /// this: with a cache those coalesce onto one fetch through single-flight,
+    /// without one each is a real object-store request. ADR-0102 decision 1 names
+    /// the cache as the precondition for that fan-out, and `LogsScanExec::new`
+    /// gates its partition count on this.
+    ///
+    /// This holds on both fetch shapes, which is what keeps that gate honest
+    /// (ADR-0107): at or below
+    /// [`with_block_range_threshold`](Self::with_block_range_threshold) the
+    /// coalesced request is the one whole-object GET keyed `(0, object_size)`;
+    /// above it, the block-range path's probe, directory sections, and per-block
+    /// ranges each coalesce on their own extent key, so a segment striped across
+    /// N partitions still costs one request per distinct extent rather than N.
     #[must_use]
     pub fn has_cache(&self) -> bool {
         self.cache.is_some()
@@ -708,10 +724,16 @@ impl LogSegmentFetcher {
     /// column it (or anything downstream of it, including its selective-erasure
     /// exclusion) reads.
     ///
-    /// The whole object is still fetched with one [`GetRange::Full`] GET: this
-    /// bounds *decoded* memory, not raw bytes. A ranged block read is
-    /// [`ravel_logseg::RlogRangeReader`]'s territory and out of scope here
-    /// (ADR-0087 decision 3).
+    /// This bounds *decoded* memory, not raw bytes: the object's bytes are
+    /// resident before the first block is decoded either way. Which read shape
+    /// produced them depends on the object's size
+    /// ([`with_block_range_threshold`](Self::with_block_range_threshold),
+    /// ADR-0107). At or below the threshold it is one [`GetRange::Full`] GET of
+    /// the whole object. Above it the bytes are an object-sized buffer with only
+    /// the directory sections and the pruning-relevant blocks populated, fetched
+    /// by [`BlockRangeFetcher`] as a probe plus coalesced block ranges, so the
+    /// raw bytes moved are proportional to pruning rather than to object size --
+    /// but the resident buffer is still object-sized, per call.
     pub async fn scan_accounted_with_tenant(
         &self,
         seg_ref: &SegmentRef,
@@ -754,7 +776,11 @@ impl LogSegmentFetcher {
     /// the same cache-aware funnel [`scan_accounted_with_tenant`](Self::
     /// scan_accounted_with_tenant) uses, so in production it is single-flight
     /// coalesced with the per-partition subset scans that follow rather than
-    /// issuing an extra distinct GET.
+    /// issuing an extra distinct GET. That holds on both read shapes: one
+    /// whole-object key at or below
+    /// [`with_block_range_threshold`](Self::with_block_range_threshold), and
+    /// per-extent keys (probe, sections, blocks) above it, each of which the
+    /// following subset scans hit rather than re-fetch (ADR-0107).
     ///
     /// [`scan_accounted_with_tenant`]: Self::scan_accounted_with_tenant
     pub async fn plan_segment(
@@ -926,29 +952,12 @@ impl LogSegmentFetcher {
             }
             .instrument(fetch_span.clone())
             .await
-            .map_err(|err| LogFetchError::Store {
-                    key: key.to_string(),
-                    source: match err {
-                        SingleFlightError::Upstream(crate::fetcher::CacheFetchError::Store(
-                            source,
-                        )) => crate::fetcher::clone_store_error(&source),
-                        // Unreachable in practice: this funnel never sets an
-                        // `expected_etag` (module doc, no suffix/range-chase
-                        // read exists to compare against), so its closure
-                        // never constructs `EtagChanged`. Handled explicitly
-                        // rather than a wildcard so a future etag check added
-                        // here can't silently fall through this arm.
-                        SingleFlightError::Upstream(
-                            crate::fetcher::CacheFetchError::EtagChanged { .. },
-                        ) => StoreError::Transient(
-                            "cache single-flight closure reported an etag change, which this funnel never produces"
-                                .to_string(),
-                        ),
-                        SingleFlightError::LeaderLost => StoreError::Transient(
-                            "cache single-flight leader lost before producing a result".to_string(),
-                        ),
-                    },
-                })?;
+            // Shared with the block-range path's mapping, which is the only one
+            // whose closure can produce the `EtagChanged`/`Corrupt` classes: this
+            // funnel's closure is one unconditional whole-object GET that
+            // verifies nothing, so those arms are unreachable here rather than
+            // wrong.
+            .map_err(|err| from_cache_error(key, err))?;
             // A miss issues one store GET for the resulting bytes. A
             // single-flight follower that rode another caller's GET is the
             // rare exception; recording one GET here still bounds this call's
@@ -1364,6 +1373,15 @@ impl BlockRangeFetcher {
         self
     }
 
+    /// Whether ADR-0046's read cache is wired into this fetcher. Every GET the
+    /// block-range protocol issues is routed through the cache's single-flight
+    /// when it is, which is what makes several partitions striping one segment
+    /// collapse onto one real GET (ADR-0102 decision 1's premise).
+    #[must_use]
+    pub fn has_cache(&self) -> bool {
+        self.cache.is_some()
+    }
+
     /// One bounded store GET, recorded against `accounting`. A `NotFound` (or any
     /// other store error) surfaces as [`LogFetchError::Store`], the SAME typed
     /// error a whole-object GET already produces, so a `NotFound` on a pinned
@@ -1397,24 +1415,81 @@ impl BlockRangeFetcher {
         Ok(got)
     }
 
-    /// A store GET whose etag is checked against the pinned `expected` etag: a
+    /// A store GET whose etag is checked against the sequence's pinned etag: a
     /// mismatch means the object was replaced mid-sequence and is a hard
     /// [`LogFetchError::EtagChanged`] (ADR-0107 decision 1), never silently
-    /// mixed data.
+    /// mixed data. The first live GET of a sequence establishes the pin (see
+    /// [`EtagPin`]).
     async fn store_get_pinned(
         &self,
         key: &str,
         range: GetRange,
-        expected: &Etag,
+        pin: &EtagPin,
         accounting: &QueryAccounting,
     ) -> Result<GetOutcome, LogFetchError> {
         let got = self.store_get(key, range, accounting).await?;
-        if &got.etag != expected {
-            return Err(LogFetchError::EtagChanged {
-                key: key.to_string(),
-            });
-        }
+        pin.check(key, &got.etag)?;
         Ok(got)
+    }
+
+    /// One absolute `[start, start + len)` extent of the object, served from
+    /// ADR-0046's read cache when it is resident and otherwise fetched with one
+    /// live etag-pinned GET that concurrent callers for the same extent collapse
+    /// onto through the cache's single-flight, exactly as the whole-object funnel
+    /// in [`LogSegmentFetcher::tenant_bytes`] does for its one key. Without a
+    /// cache every call is a live GET, as before.
+    ///
+    /// This is what keeps ADR-0102 decision 1's premise true above the
+    /// block-range threshold: the partitions striping one segment resolve the
+    /// same extents and coalesce onto one real request each instead of one per
+    /// partition.
+    ///
+    /// `range` is passed alongside `[start, len)` rather than derived from it
+    /// because the etag-establishing probe must stay a [`GetRange::Suffix`]
+    /// (a `Range` GET of the same bytes is a different request to the store)
+    /// while still keying as the absolute extent it returns.
+    ///
+    /// The returned flag is true when this call crossed the network, so callers
+    /// count only real store GETs. A single-flight follower that rode another
+    /// caller's in-flight GET reports true as well: the same attribution
+    /// convention `tenant_bytes` documents, which bounds this call's own cost
+    /// and never under-counts the query total.
+    #[allow(clippy::too_many_arguments)]
+    async fn cached_extent(
+        &self,
+        seg_ref: &SegmentRef,
+        tenant_hash: TenantHash,
+        start: u64,
+        len: u64,
+        range: GetRange,
+        pin: &EtagPin,
+        accounting: &QueryAccounting,
+    ) -> Result<(Bytes, bool), LogFetchError> {
+        let key = seg_ref.data_object_key.as_str();
+        let Some(cache) = &self.cache else {
+            let got = self.store_get_pinned(key, range, pin, accounting).await?;
+            check_extent_len(key, got.data.len(), len)?;
+            return Ok((got.data, true));
+        };
+        let cache_key = CacheKey::new(tenant_hash.0, seg_ref.content_hash, start, len);
+        if let Some(bytes) = cache.get(&cache_key) {
+            accounting.record_cache_hit();
+            accounting.add_cache_bytes(bytes.len() as u64);
+            return Ok((bytes, false));
+        }
+        accounting.record_cache_miss();
+        let bytes = cache
+            .get_or_fetch(cache_key, || async move {
+                let got = self
+                    .store_get_pinned(key, range, pin, accounting)
+                    .await
+                    .map_err(to_cache_error)?;
+                check_extent_len(key, got.data.len(), len).map_err(to_cache_error)?;
+                Ok(got.data)
+            })
+            .await
+            .map_err(|err| from_cache_error(key, err))?;
+        Ok((bytes, true))
     }
 
     /// Fetch one segment's object as an assembled, decode-ready buffer, reading
@@ -1436,52 +1511,102 @@ impl BlockRangeFetcher {
     ) -> Result<(Bytes, BlockRangeStats), LogFetchError> {
         let key = seg_ref.data_object_key.as_str();
         let mut stats = BlockRangeStats::default();
+        let pin = EtagPin::default();
 
-        // Size-threshold pre-probe crossover (ADR-0107 decision 1): a small
-        // object is read whole in one GET, mirroring `SegmentFetcher`.
-        if seg_ref.object_size != 0 && seg_ref.object_size <= self.whole_object_threshold {
+        // An object whose commit record carries no size cannot be range-planned
+        // at all: every range in this protocol, starting with the probe's own
+        // cache key, is derived from that size. Read it whole, uncached (the
+        // cache key would have to claim a length too).
+        if seg_ref.object_size == 0 {
             let got = self.store_get(key, GetRange::Full, accounting).await?;
             stats.probe_gets = 1;
             stats.whole_object = true;
+            stats.block_bytes_fetched = got.data.len() as u64;
             return Ok((got.data, stats));
         }
 
-        // Etag-establishing probe: a suffix GET that pins the etag every later
-        // GET is checked against, and carries the footer (and, for a small
-        // object, the whole tail directory).
-        let suffix = self.suffix_len.min(seg_ref.object_size.max(1));
-        let probe = self
-            .store_get(key, GetRange::Suffix(suffix), accounting)
-            .await?;
-        stats.probe_gets = 1;
-        let total_size = probe.total_size;
-        let pinned = probe.etag.clone();
+        // Size-threshold pre-probe crossover (ADR-0107 decision 1): a small
+        // object is read whole in one GET, mirroring `SegmentFetcher`. Keyed
+        // `(0, object_size)`, the same key `LogSegmentFetcher::tenant_bytes`
+        // gives its whole-object read, so the two compose and concurrent callers
+        // coalesce instead of each paying the GET.
+        if seg_ref.object_size <= self.whole_object_threshold {
+            let (bytes, live) = self
+                .cached_extent(
+                    seg_ref,
+                    tenant_hash,
+                    0,
+                    seg_ref.object_size,
+                    GetRange::Full,
+                    &pin,
+                    accounting,
+                )
+                .await?;
+            if live {
+                stats.probe_gets = 1;
+                stats.block_bytes_fetched = bytes.len() as u64;
+            }
+            stats.whole_object = true;
+            return Ok((bytes, stats));
+        }
+
+        // The object size from the commit record is the authoritative total on
+        // this path: it already decided the crossover above, it already keys the
+        // whole-object funnel's cache entry, and the probe's own cache key needs
+        // the suffix's absolute extent BEFORE the GET that would report a size.
+        // A size that disagrees with the stored object fails closed rather than
+        // silently mixing: the probe's length check rejects a short read, and a
+        // footer parsed at wrong absolute offsets is a `Corrupt`.
+        let total_size = seg_ref.object_size;
         let total = usize::try_from(total_size).map_err(|_| corrupt_range(key))?;
 
+        // Etag-establishing probe: a suffix GET that pins the etag every later
+        // live GET is checked against, and carries the footer (and, for a small
+        // object, the whole tail directory). Cache-routed like every other GET
+        // here, so concurrent partitions' probes collapse onto one request.
+        let suffix = self.suffix_len.min(total_size);
+        let probe_start = total_size - suffix;
+        let (probe_bytes, probe_live) = self
+            .cached_extent(
+                seg_ref,
+                tenant_hash,
+                probe_start,
+                suffix,
+                GetRange::Suffix(suffix),
+                &pin,
+                accounting,
+            )
+            .await?;
+        if probe_live {
+            stats.probe_gets = 1;
+        }
+
         let mut asm = ObjectAssembler::new(total);
-        let probe_start = total_size.saturating_sub(probe.data.len() as u64);
-        asm.place(key, probe_start, &probe.data)?;
+        asm.place(key, probe_start, &probe_bytes)?;
 
         // Footer: parse from the probe suffix, chasing one range if the suffix
         // did not cover the whole footer (mirrors `SegmentFetcher::open_segment`).
-        let footer = match open_from_suffix(&probe.data, total_size)
+        let footer = match open_from_suffix(&probe_bytes, total_size)
             .map_err(|source| corrupt(key, source))?
         {
             SuffixOutcome::Ready(footer) => footer,
             SuffixOutcome::NeedRange { offset, len } => {
-                let got = self
-                    .store_get_pinned(
-                        key,
+                let (bytes, live) = self
+                    .cached_extent(
+                        seg_ref,
+                        tenant_hash,
+                        offset,
+                        len,
                         GetRange::Range(offset, offset + len),
-                        &pinned,
+                        &pin,
                         accounting,
                     )
                     .await?;
-                stats.probe_gets += 1;
-                asm.place(key, offset, &got.data)?;
-                match open_from_suffix(&got.data, total_size)
-                    .map_err(|source| corrupt(key, source))?
-                {
+                if live {
+                    stats.probe_gets += 1;
+                }
+                asm.place(key, offset, &bytes)?;
+                match open_from_suffix(&bytes, total_size).map_err(|source| corrupt(key, source))? {
                     SuffixOutcome::Ready(footer) => footer,
                     SuffixOutcome::NeedRange { .. } => {
                         return Err(corrupt(
@@ -1493,39 +1618,32 @@ impl BlockRangeFetcher {
             }
         };
 
-        // Fetch and place every non-BLOCKS directory section not already covered
-        // by the probe: STREAM_DIR/FIELD_DIR (object front) always, plus any tail
-        // section (SKIP_IDX/BLOOM/POSTINGS) a short probe missed. The reader
-        // re-verifies each section's crc on decode, so a corrupt section hit
-        // fails closed there (ADR-0046).
-        for section in &footer.sections {
-            if section.kind == kind::BLOCKS {
-                continue;
-            }
-            let (start, end) = (section.offset, section.offset + section.len);
-            if asm.covers(start, end) {
-                continue;
-            }
-            let bytes = self
-                .section_bytes(
-                    seg_ref,
-                    tenant_hash,
-                    section,
-                    &pinned,
-                    accounting,
-                    &mut stats,
-                )
-                .await?;
-            asm.place(key, section.offset, &bytes)?;
-        }
-
-        // Decode the skip index (now resident) and resolve the candidate blocks.
         let skip_desc = footer
             .section(kind::SKIP_IDX)
             .ok_or_else(|| corrupt(key, LogSegError::Corrupted("missing SKIP_IDX".into())))?;
         let blocks_desc = footer
             .section(kind::BLOCKS)
             .ok_or_else(|| corrupt(key, LogSegError::Corrupted("missing BLOCKS".into())))?;
+
+        // SKIP_IDX first and alone. The coverage crossover below can decide the
+        // whole object is cheaper than the candidate ranges, and every OTHER
+        // section it would have fetched first is then wasted: a wide-time-range
+        // query on a large object would pay probe + section GETs and THEN a
+        // whole-object GET, strictly worse than the plain whole-object path it
+        // falls back to. Resolving the candidate extents needs SKIP_IDX and
+        // nothing else, so only SKIP_IDX is fetched before the decision.
+        self.place_section(
+            seg_ref,
+            tenant_hash,
+            skip_desc,
+            &pin,
+            &mut asm,
+            accounting,
+            &mut stats,
+        )
+        .await?;
+
+        // Decode the skip index (now resident) and resolve the candidate blocks.
         let skip_start = usize::try_from(skip_desc.offset).map_err(|_| corrupt_range(key))?;
         let skip_end = skip_start
             .checked_add(usize::try_from(skip_desc.len).map_err(|_| corrupt_range(key))?)
@@ -1543,26 +1661,65 @@ impl BlockRangeFetcher {
         stats.candidate_blocks = extents.len() as u64;
 
         // Coverage-based post-pruning crossover (ADR-0107 decision 1): when the
-        // candidate ranges already cover most of the object, one whole-object GET
-        // beats many range GETs.
+        // candidate ranges already cover most of the blocks, one whole-object GET
+        // beats many range GETs. The comparison is against the BLOCKS section's
+        // own size, not the object size: the numerator is BLOCKS-only candidate
+        // bytes, so measuring it against an object that also carries the
+        // directory sections can never reach 1.0 even when every block is a
+        // candidate, and under-triggers by exactly the metadata fraction.
         let candidate_bytes: u64 = extents.iter().map(|e| e.len).sum();
-        let coverage = candidate_bytes as f64 / total_size.max(1) as f64;
+        let coverage = candidate_bytes as f64 / blocks_desc.len.max(1) as f64;
         if coverage >= self.coverage_threshold {
-            let got = self
-                .store_get_pinned(key, GetRange::Full, &pinned, accounting)
+            // Keyed and single-flighted like every other GET here, on the same
+            // `(0, object_size)` key the whole-object funnel uses: without that,
+            // N partitions all crossing over would issue N whole-object GETs,
+            // which is the amplification this path exists to avoid.
+            let (bytes, live) = self
+                .cached_extent(
+                    seg_ref,
+                    tenant_hash,
+                    0,
+                    total_size,
+                    GetRange::Full,
+                    &pin,
+                    accounting,
+                )
                 .await?;
-            stats.block_range_gets = 1;
+            if live {
+                stats.block_range_gets = 1;
+                stats.block_bytes_fetched = bytes.len() as u64;
+            }
             stats.whole_object = true;
             // Still admit per-block cache entries so a later partition's fetch of
             // a subset composes with this one (ADR-0107 decision 3).
-            self.admit_blocks_from_whole(seg_ref, tenant_hash, &got.data, &extents);
-            return Ok((got.data, stats));
+            self.admit_blocks_from_whole(seg_ref, tenant_hash, &bytes, &extents);
+            return Ok((bytes, stats));
+        }
+
+        // The remaining non-BLOCKS sections: STREAM_DIR/FIELD_DIR (object front)
+        // and any tail section (BLOOM/POSTINGS) a short probe missed. The reader
+        // re-verifies each section's crc on decode, so a corrupt section hit
+        // fails closed there (ADR-0046).
+        for section in &footer.sections {
+            if section.kind == kind::BLOCKS {
+                continue;
+            }
+            self.place_section(
+                seg_ref,
+                tenant_hash,
+                section,
+                &pin,
+                &mut asm,
+                accounting,
+                &mut stats,
+            )
+            .await?;
         }
 
         self.fetch_blocks(
             seg_ref,
             tenant_hash,
-            &pinned,
+            &pin,
             &extents,
             &mut asm,
             accounting,
@@ -1605,64 +1762,58 @@ impl BlockRangeFetcher {
         Ok(out)
     }
 
-    /// Fetch one directory section's stored bytes, through the read cache when
-    /// configured. The bytes are the section's exact `[offset, offset+len)`
-    /// stored form (crc-verified by the reader on decode); the cache key is the
-    /// section's own extent.
+    /// Place one directory section into `asm`, fetching it through the read
+    /// cache's single-flight when it is not already covered by an earlier read.
+    /// The bytes are the section's exact `[offset, offset+len)` stored form
+    /// (crc-verified by the reader on decode) and the cache key is the section's
+    /// own extent, so two partitions missing the same section issue one GET
+    /// between them rather than one each.
     #[allow(clippy::too_many_arguments)]
-    async fn section_bytes(
+    async fn place_section(
         &self,
         seg_ref: &SegmentRef,
         tenant_hash: TenantHash,
         section: &SectionDesc,
-        pinned: &Etag,
+        pin: &EtagPin,
+        asm: &mut ObjectAssembler,
         accounting: &QueryAccounting,
         stats: &mut BlockRangeStats,
-    ) -> Result<Bytes, LogFetchError> {
+    ) -> Result<(), LogFetchError> {
         let key = seg_ref.data_object_key.as_str();
-        let cache_key = CacheKey::new(
-            tenant_hash.0,
-            seg_ref.content_hash,
-            section.offset,
-            section.len,
-        );
-        if let Some(cache) = &self.cache
-            && let Some(bytes) = cache.get(&cache_key)
-        {
-            accounting.record_cache_hit();
-            accounting.add_cache_bytes(bytes.len() as u64);
-            return Ok(bytes);
+        let (start, end) = (section.offset, section.offset + section.len);
+        if asm.covers(start, end) {
+            return Ok(());
         }
-        if self.cache.is_some() {
-            accounting.record_cache_miss();
-        }
-        let got = self
-            .store_get_pinned(
-                key,
-                GetRange::Range(section.offset, section.offset + section.len),
-                pinned,
+        let (bytes, live) = self
+            .cached_extent(
+                seg_ref,
+                tenant_hash,
+                section.offset,
+                section.len,
+                GetRange::Range(start, end),
+                pin,
                 accounting,
             )
             .await?;
-        stats.metadata_gets += 1;
-        if let Some(cache) = &self.cache {
-            cache.insert(cache_key, got.data.clone());
+        if live {
+            stats.metadata_gets += 1;
         }
-        Ok(got.data)
+        asm.place(key, section.offset, &bytes)
     }
 
     /// Fetch the candidate blocks into `asm`: serve each from the per-block cache
     /// when present (re-verifying `block_crc32c` on the cached bytes -- ADR-0046's
     /// corrupt-hit gate, which this admitting funnel owns), coalesce the misses
-    /// within `coalesce_gap`, GET each coalesced range (etag-pinned, bounded by
-    /// the semaphore), split each response at block boundaries, verify each
-    /// block's crc independently, admit one cache entry per block, and place it.
+    /// within `coalesce_gap`, and fetch every coalesced run concurrently through
+    /// [`fetch_run`](Self::fetch_run), which splits each response at block
+    /// boundaries, verifies each block's crc independently, admits one cache
+    /// entry per block, and hands the blocks back to be placed.
     #[allow(clippy::too_many_arguments)]
     async fn fetch_blocks(
         &self,
         seg_ref: &SegmentRef,
         tenant_hash: TenantHash,
-        pinned: &Etag,
+        pin: &EtagPin,
         extents: &[BlockExtent],
         asm: &mut ObjectAssembler,
         accounting: &QueryAccounting,
@@ -1709,40 +1860,161 @@ impl BlockRangeFetcher {
             missing.push(*ext);
         }
 
-        for run in coalesce_extents(&missing, self.coalesce_gap) {
-            let (start, end) = (run.abs_start, run.abs_start.saturating_add(run.len));
-            let got = self
-                .store_get_pinned(key, GetRange::Range(start, end), pinned, accounting)
-                .await?;
-            stats.block_range_gets += 1;
-            stats.block_bytes_fetched = stats
-                .block_bytes_fetched
-                .saturating_add(got.data.len() as u64);
-            // Split the coalesced response at block boundaries, verify and admit
-            // one entry per block; the gap bytes between blocks are discarded,
-            // never cached, never interpreted (ADR-0107 decision 3).
-            for ext in &missing {
-                if ext.abs_start < start || ext.abs_end() > end {
-                    continue;
-                }
-                let rel = usize::try_from(ext.abs_start - start).map_err(|_| corrupt_range(key))?;
-                let rel_end = rel
-                    .checked_add(usize::try_from(ext.len).map_err(|_| corrupt_range(key))?)
-                    .ok_or_else(|| corrupt_range(key))?;
-                let block = got
-                    .data
-                    .get(rel..rel_end)
-                    .ok_or_else(|| corrupt_range(key))?;
-                verify_block_crc(key, block, ext)?;
-                if let Some(cache) = &self.cache {
-                    let cache_key =
-                        CacheKey::new(tenant_hash.0, seg_ref.content_hash, ext.abs_start, ext.len);
-                    cache.insert(cache_key, Bytes::copy_from_slice(block));
-                }
-                asm.place(key, ext.abs_start, block)?;
+        // Every coalesced run concurrently, not one await at a time (mirrors
+        // `crate::fetcher::SegmentFetcher::ensure_ranges`' `join_all`). Awaiting
+        // the runs in series made `get_semaphore` inert: a sequential loop never
+        // has more than one GET in flight to bound.
+        let runs = coalesce_extents(&missing, self.coalesce_gap);
+        let outcomes = futures::future::join_all(runs.iter().map(|run| {
+            let blocks: Vec<BlockExtent> = missing
+                .iter()
+                .copied()
+                .filter(|e| e.abs_start >= run.abs_start && e.abs_end() <= run.abs_end())
+                .collect();
+            self.fetch_run(seg_ref, tenant_hash, pin, *run, blocks, accounting)
+        }))
+        .await;
+        for outcome in outcomes {
+            let run = outcome?;
+            stats.block_range_gets += run.gets;
+            stats.block_cache_hits += run.cache_hits;
+            stats.block_bytes_fetched = stats.block_bytes_fetched.saturating_add(run.bytes);
+            for (start, bytes) in run.blocks {
+                asm.place(key, start, &bytes)?;
             }
         }
         Ok(())
+    }
+
+    /// Fetch one coalesced run's blocks with one range GET, split at block
+    /// boundaries and verified block by block.
+    ///
+    /// With a cache attached the run is single-flighted on its FIRST block's
+    /// cache key: the partitions striping one segment resolve the identical
+    /// candidate set from the same skip index, so they produce the identical runs
+    /// and collapse onto one real GET instead of one each (ADR-0102 decision 1's
+    /// premise, which the block-range path would otherwise break). The key is a
+    /// block's own extent, never the coalesced run's, because cache admission
+    /// here is per block and a run's gap bytes are never cached (ADR-0107
+    /// decision 3): the leader verifies every block in the run and admits one
+    /// entry per block before it returns, so a follower finds the run's other
+    /// blocks resident and issues no GET of its own. A follower that still
+    /// misses one -- evicted in the meantime, or larger than the cache's
+    /// single-entry cap -- fetches that block alone, still single-flighted.
+    async fn fetch_run(
+        &self,
+        seg_ref: &SegmentRef,
+        tenant_hash: TenantHash,
+        pin: &EtagPin,
+        run: BlockExtent,
+        blocks: Vec<BlockExtent>,
+        accounting: &QueryAccounting,
+    ) -> Result<RunOutcome, LogFetchError> {
+        let key = seg_ref.data_object_key.as_str();
+        let range = GetRange::Range(run.abs_start, run.abs_end());
+        let Some(cache) = &self.cache else {
+            let got = self.store_get_pinned(key, range, pin, accounting).await?;
+            let blocks = split_run(key, run.abs_start, &got.data, &blocks)?;
+            return Ok(RunOutcome {
+                blocks,
+                gets: 1,
+                bytes: got.data.len() as u64,
+                cache_hits: 0,
+            });
+        };
+        let Some(lead) = blocks.first().copied() else {
+            // A run with no block in it cannot happen (runs are built from the
+            // blocks themselves), and fetching bytes no block claims would admit
+            // exactly the unverifiable gap bytes decision 3 forbids.
+            return Ok(RunOutcome::default());
+        };
+        let lead_key = CacheKey::new(
+            tenant_hash.0,
+            seg_ref.content_hash,
+            lead.abs_start,
+            lead.len,
+        );
+        // Set by our own closure, so `Some` after the await means this call led
+        // the fetch and already holds every block of the run; `None` means it
+        // followed another caller's in-flight GET.
+        let led: std::sync::OnceLock<(Vec<(u64, Bytes)>, u64)> = std::sync::OnceLock::new();
+        let lead_bytes = cache
+            .get_or_fetch(lead_key, || async {
+                let got = self
+                    .store_get_pinned(key, range, pin, accounting)
+                    .await
+                    .map_err(to_cache_error)?;
+                let split =
+                    split_run(key, run.abs_start, &got.data, &blocks).map_err(to_cache_error)?;
+                let Some((_, lead_bytes)) = split.first().cloned() else {
+                    return Err(to_cache_error(corrupt_range(key)));
+                };
+                // One entry per block, all verified above. The lead block's own
+                // admission is `get_or_fetch`'s, under the key it was called
+                // with, so it is admitted exactly once.
+                for (start, bytes) in split.iter().skip(1) {
+                    cache.insert(
+                        CacheKey::new(
+                            tenant_hash.0,
+                            seg_ref.content_hash,
+                            *start,
+                            bytes.len() as u64,
+                        ),
+                        bytes.clone(),
+                    );
+                }
+                let _ = led.set((split, got.data.len() as u64));
+                Ok(lead_bytes)
+            })
+            .await
+            .map_err(|err| from_cache_error(key, err))?;
+        if let Some((split, bytes)) = led.get() {
+            return Ok(RunOutcome {
+                blocks: split.clone(),
+                gets: 1,
+                bytes: *bytes,
+                cache_hits: 0,
+            });
+        }
+        // Follower: the lead block is the leader's own verified bytes, and the
+        // leader admitted the rest of the run before it returned.
+        let mut out = Vec::with_capacity(blocks.len());
+        out.push((lead.abs_start, lead_bytes));
+        let mut outcome = RunOutcome::default();
+        for ext in blocks.iter().skip(1) {
+            let block_key =
+                CacheKey::new(tenant_hash.0, seg_ref.content_hash, ext.abs_start, ext.len);
+            if let Some(bytes) = cache.get(&block_key) {
+                verify_block_crc(key, &bytes, ext)?;
+                accounting.record_cache_hit();
+                accounting.add_cache_bytes(bytes.len() as u64);
+                outcome.cache_hits += 1;
+                out.push((ext.abs_start, bytes));
+                continue;
+            }
+            accounting.record_cache_miss();
+            let bytes = cache
+                .get_or_fetch(block_key, || async {
+                    let got = self
+                        .store_get_pinned(
+                            key,
+                            GetRange::Range(ext.abs_start, ext.abs_end()),
+                            pin,
+                            accounting,
+                        )
+                        .await
+                        .map_err(to_cache_error)?;
+                    verify_block_crc(key, &got.data, ext).map_err(to_cache_error)?;
+                    Ok(got.data)
+                })
+                .await
+                .map_err(|err| from_cache_error(key, err))?;
+            outcome.gets += 1;
+            outcome.bytes = outcome.bytes.saturating_add(bytes.len() as u64);
+            out.push((ext.abs_start, bytes));
+        }
+        outcome.blocks = out;
+        Ok(outcome)
     }
 
     /// Split whole-object bytes (the coverage-crossover path) at block boundaries
@@ -1779,6 +2051,140 @@ impl BlockRangeFetcher {
                 CacheKey::new(tenant_hash.0, seg_ref.content_hash, ext.abs_start, ext.len);
             cache.insert(cache_key, Bytes::copy_from_slice(block));
         }
+    }
+}
+
+/// One coalesced run's fetched blocks (`(abs_start, bytes)`, crc-verified) plus
+/// the store cost this caller paid for them: `gets` real range GETs moving
+/// `bytes` stored bytes, and `cache_hits` blocks served with no round trip.
+///
+/// A single-flight follower that rode another caller's GET reports zero gets and
+/// zero bytes here, unlike [`BlockRangeFetcher::cached_extent`] and the
+/// whole-object funnels, which attribute one request to a follower because they
+/// cannot tell one from a leader. This path can: the leader is whichever call
+/// ran the closure. Reporting what actually crossed the network is strictly
+/// better information, and the block-range GET count is the figure ADR-0107's
+/// acceptance test is written against.
+#[derive(Default)]
+struct RunOutcome {
+    blocks: Vec<(u64, Bytes)>,
+    gets: u64,
+    bytes: u64,
+    cache_hits: u64,
+}
+
+/// The etag every LIVE GET of one fetch sequence is checked against (ADR-0107
+/// decision 1's mandatory etag pinning). Whichever live GET completes first pins
+/// it -- normally the suffix probe, or the first section/block GET when the probe
+/// was served from the read cache -- and every live GET after it must report the
+/// same etag or the fetch fails with [`LogFetchError::EtagChanged`] rather than
+/// assembling bytes from two object states.
+///
+/// Cache-served bytes are not checked against it and need no check: a cache key
+/// carries the object's `content_hash`, so an entry is by construction bytes of
+/// this exact content rather than of whatever the store holds now. What the pin
+/// has to rule out is a sequence of LIVE GETs spanning a replacement, which is
+/// exactly what it still does.
+#[derive(Default)]
+struct EtagPin(std::sync::OnceLock<Etag>);
+
+impl EtagPin {
+    /// Pin `got` if nothing is pinned yet, otherwise require it to match.
+    fn check(&self, key: &str, got: &Etag) -> Result<(), LogFetchError> {
+        if self.0.get_or_init(|| got.clone()) == got {
+            return Ok(());
+        }
+        Err(LogFetchError::EtagChanged {
+            key: key.to_string(),
+        })
+    }
+}
+
+/// A live GET must return exactly the extent that was asked for: a short read
+/// would be placed at the right offset with the wrong bytes after it, and cached
+/// under a key claiming a length it does not have.
+fn check_extent_len(key: &str, got: usize, want: u64) -> Result<(), LogFetchError> {
+    if got as u64 == want {
+        return Ok(());
+    }
+    Err(corrupt(
+        key,
+        LogSegError::Corrupted(format!("short read: got {got} bytes of {want}")),
+    ))
+}
+
+/// Split one coalesced run's response at block boundaries, verifying each
+/// block's `block_crc32c` independently before the caller can admit or place it.
+/// The gap bytes between blocks are dropped here: never cached, never
+/// interpreted (ADR-0107 decision 3).
+fn split_run(
+    key: &str,
+    run_start: u64,
+    data: &Bytes,
+    blocks: &[BlockExtent],
+) -> Result<Vec<(u64, Bytes)>, LogFetchError> {
+    let mut out = Vec::with_capacity(blocks.len());
+    for ext in blocks {
+        let offset = ext
+            .abs_start
+            .checked_sub(run_start)
+            .ok_or_else(|| corrupt_range(key))?;
+        let rel = usize::try_from(offset).map_err(|_| corrupt_range(key))?;
+        let rel_end = rel
+            .checked_add(usize::try_from(ext.len).map_err(|_| corrupt_range(key))?)
+            .ok_or_else(|| corrupt_range(key))?;
+        let block = data.get(rel..rel_end).ok_or_else(|| corrupt_range(key))?;
+        verify_block_crc(key, block, ext)?;
+        out.push((ext.abs_start, Bytes::copy_from_slice(block)));
+    }
+    Ok(out)
+}
+
+/// This module's error into the cache's single-flight error channel, preserving
+/// the class: a follower waiting on a leader's fetch must see the same store
+/// error, etag change, or hard corruption the leader saw, never a flattened one.
+fn to_cache_error(err: LogFetchError) -> crate::fetcher::CacheFetchError {
+    match err {
+        LogFetchError::Store { source, .. } => {
+            crate::fetcher::CacheFetchError::Store(Arc::new(source))
+        }
+        LogFetchError::EtagChanged { key } => crate::fetcher::CacheFetchError::EtagChanged { key },
+        LogFetchError::Corrupt { key, source } => crate::fetcher::CacheFetchError::Corrupt {
+            key,
+            message: source.to_string(),
+        },
+    }
+}
+
+/// The inverse of [`to_cache_error`], plus the single-flight channel's own
+/// `LeaderLost` (a leader whose future was cancelled or panicked before
+/// producing a result), which is transient and retryable.
+fn from_cache_error(
+    key: &str,
+    err: SingleFlightError<crate::fetcher::CacheFetchError>,
+) -> LogFetchError {
+    match err {
+        SingleFlightError::Upstream(crate::fetcher::CacheFetchError::Store(source)) => {
+            LogFetchError::Store {
+                key: key.to_string(),
+                source: crate::fetcher::clone_store_error(&source),
+            }
+        }
+        SingleFlightError::Upstream(crate::fetcher::CacheFetchError::EtagChanged { key }) => {
+            LogFetchError::EtagChanged { key }
+        }
+        SingleFlightError::Upstream(crate::fetcher::CacheFetchError::Corrupt { key, message }) => {
+            LogFetchError::Corrupt {
+                key,
+                source: LogSegError::Corrupted(message),
+            }
+        }
+        SingleFlightError::LeaderLost => LogFetchError::Store {
+            key: key.to_string(),
+            source: StoreError::Transient(
+                "cache single-flight leader lost before producing a result".to_string(),
+            ),
+        },
     }
 }
 

--- a/crates/ravel-query/tests/log_block_range.rs
+++ b/crates/ravel-query/tests/log_block_range.rs
@@ -1,0 +1,604 @@
+//! Integration tests for the RLOG block-range fetcher (ADR-0107,
+//! [`ravel_query::BlockRangeFetcher`]).
+//!
+//! The fetcher reads only the blocks skip-index pruning proved relevant instead
+//! of one whole-object GET per segment, assembling an object-sized buffer with
+//! only the directory sections and candidate blocks populated. These tests pin
+//! the five acceptance properties of the ADR:
+//!
+//! 1. Differential: over a candidate subset, the block-range path's decoded rows
+//!    are byte-identical to the whole-object path's.
+//! 2. Etag pinning: an etag change on a later block-range GET surfaces the typed
+//!    [`LogFetchError::EtagChanged`].
+//! 3. NotFound mapping: a `NotFound` on a GET surfaces the same
+//!    [`LogFetchError::Store`]`{ NotFound }` a whole-object fetch produces, the
+//!    shape `ravel_sql`'s `is_segment_not_found` maps to `SnapshotInvalidated`.
+//! 4. Corrupt-hit: a corrupted per-block cache hit fails closed, exactly like a
+//!    corrupt live fetch (ADR-0046 §4).
+//! 5. GET-count: the block-range GET count and byte volume are proportional to
+//!    the candidate fraction, not the object size.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use async_trait::async_trait;
+use ravel_cache::{Cache, CacheLimits};
+use ravel_catalog::{SegmentLevel, SegmentRef};
+use ravel_logseg::footer::{self, kind};
+use ravel_logseg::skip_index::SkipIndex;
+use ravel_logseg::writer::ObjectIdentity;
+use ravel_logseg::{
+    AttrValue, LogRecord, RlogConfig, RlogWriter, read_section, stream_attrs_bytes,
+};
+use ravel_object_store::memory::MemoryStore;
+use ravel_object_store::{
+    Capabilities, DelimitedList, Etag, GetOutcome, GetRange, ListPage, ObjectMeta,
+    ObjectStoreBackend, PageToken, PutOptions, PutOutcome, StoreError,
+};
+use ravel_query::{BlockRangeFetcher, LogFetchError, LogQuery, LogSegmentFetcher};
+use ravel_types::TenantHash;
+use ravel_types::accounting::QueryAccounting;
+use uuid::Uuid;
+
+const TENANT: TenantHash = TenantHash([7u8; 16]);
+const CONTENT_HASH: [u8; 32] = [9u8; 32];
+
+fn identity() -> ObjectIdentity {
+    ObjectIdentity {
+        // Must match the fetch tenant: the RLOG read path enforces a footer
+        // tenant_hash check.
+        tenant_hash: [7u8; 16],
+        shard: 0,
+        writer_id: [2u8; 16],
+        writer_epoch: 1,
+        writer_seq: 1,
+    }
+}
+
+/// One record per block, so an N-record object has N blocks and a ts-range
+/// query can select a strict, nontrivial subset of them.
+fn one_record_blocks() -> RlogConfig {
+    RlogConfig {
+        block_target_records: 1,
+        ..RlogConfig::default()
+    }
+}
+
+fn record(name: &str, ts: i64, body: &str) -> LogRecord {
+    let resource = vec![("service.name".to_string(), AttrValue::Str(name.to_string()))];
+    LogRecord {
+        stream_id: ravel_types::logstream::log_stream_id(&resource, "scope", "1.0", &[]),
+        stream_attrs: stream_attrs_bytes(&resource, "scope", "1.0", &[]),
+        ts_ns: ts,
+        observed_ts_ns: ts,
+        severity_num: 9,
+        severity_text: "INFO".into(),
+        body: body.into(),
+        trace_id: None,
+        span_id: None,
+        flags: 0,
+        attrs: Vec::new(),
+    }
+}
+
+/// Build one RLOG object's bytes from `records` (one block each).
+fn build_object(records: &[LogRecord]) -> Vec<u8> {
+    let mut w = RlogWriter::new(one_record_blocks(), identity());
+    for r in records {
+        w.push(r.clone()).expect("push");
+    }
+    w.finish().expect("finish")
+}
+
+/// A `SegmentRef` for an object of `size` bytes spanning `records`' ts range.
+fn seg_ref(key: &str, size: u64, records: &[LogRecord]) -> SegmentRef {
+    let min = records.iter().map(|r| r.ts_ns).min().expect("nonempty");
+    let max = records.iter().map(|r| r.ts_ns).max().expect("nonempty");
+    SegmentRef {
+        data_object_key: key.to_string(),
+        object_size: size,
+        min_event_ts_ns: min,
+        max_event_ts_ns: max,
+        ingest_hour_bucket: 0,
+        sample_count: records.len() as u64,
+        series_count: 0,
+        shard: 0,
+        content_hash: CONTENT_HASH,
+        writer_id: Uuid::from_u128(1),
+        writer_epoch: 1,
+        writer_seq: 1,
+        created_unix_ns: 0,
+        level: SegmentLevel::L0,
+    }
+}
+
+/// The object's BLOCKS-section absolute offset and its byte length, and the
+/// object's tail length (the bytes after the BLOCKS section, namely
+/// SKIP_IDX/BLOOM/POSTINGS then footer and trailer). A probe suffix of exactly
+/// `tail_len` covers the whole tail (so no tail-section GET is needed) but
+/// reaches no block.
+fn layout(bytes: &[u8]) -> (u64, u64, u64) {
+    let footer = footer::open(bytes).expect("footer");
+    let blocks = footer.section(kind::BLOCKS).expect("BLOCKS");
+    let tail_len = bytes.len() as u64 - (blocks.offset + blocks.len);
+    (blocks.offset, blocks.len, tail_len)
+}
+
+/// The candidate block extents `(abs_start, len, crc32c)` a ts query resolves,
+/// mirroring the fetcher, for the GET-count oracle.
+fn candidate_extents(bytes: &[u8], ts_min: i64, ts_max: i64) -> Vec<(u64, u64, u32)> {
+    let footer = footer::open(bytes).expect("footer");
+    let blocks = footer.section(kind::BLOCKS).expect("BLOCKS");
+    let skip_desc = footer.section(kind::SKIP_IDX).expect("SKIP_IDX");
+    let skip_raw = read_section(bytes, skip_desc, &RlogConfig::default()).expect("skip raw");
+    let skip = SkipIndex::decode(&skip_raw, 1 << 24).expect("skip decode");
+    skip.candidate_blocks(ts_min, ts_max, None, &[])
+        .into_iter()
+        .map(|i| {
+            let e = &skip.l0[i];
+            (blocks.offset + e.block_offset, e.block_len, e.block_crc32c)
+        })
+        .collect()
+}
+
+/// Number of maximal contiguous runs (gap 0) among candidate extents: the exact
+/// coalesced-GET count the fetcher issues with `coalesce_gap == 0`.
+fn contiguous_runs(mut ext: Vec<(u64, u64, u32)>) -> usize {
+    ext.sort_by_key(|e| e.0);
+    let mut runs = 0usize;
+    let mut prev_end: Option<u64> = None;
+    for (start, len, _) in ext {
+        match prev_end {
+            Some(e) if start <= e => {}
+            _ => runs += 1,
+        }
+        prev_end = Some(prev_end.map_or(start + len, |e| e.max(start + len)));
+    }
+    runs
+}
+
+// ---- store doubles -------------------------------------------------------
+
+/// Counts `get` calls; everything else delegates.
+struct CountingStore {
+    inner: Arc<MemoryStore>,
+    gets: AtomicU64,
+}
+
+impl CountingStore {
+    fn new(inner: Arc<MemoryStore>) -> Self {
+        CountingStore {
+            inner,
+            gets: AtomicU64::new(0),
+        }
+    }
+    fn get_count(&self) -> u64 {
+        self.gets.load(Ordering::SeqCst)
+    }
+}
+
+/// Swaps the etag of any `Range` GET starting at or beyond `blocks_offset` to a
+/// different value, so a block-range GET (never the front-metadata GETs, which
+/// start before `blocks_offset`, nor the `Suffix` probe) observes an etag
+/// different from the probe's.
+struct EtagSwapStore {
+    inner: Arc<MemoryStore>,
+    blocks_offset: u64,
+}
+
+/// Returns `NotFound` for any `Range` GET starting at or beyond `blocks_offset`,
+/// simulating a segment compacted away after its blocks were resolved.
+struct NotFoundOnBlockStore {
+    inner: Arc<MemoryStore>,
+    blocks_offset: u64,
+}
+
+#[async_trait]
+impl ObjectStoreBackend for CountingStore {
+    async fn put(
+        &self,
+        key: &str,
+        data: bytes::Bytes,
+        opts: PutOptions,
+    ) -> Result<PutOutcome, StoreError> {
+        self.inner.put(key, data, opts).await
+    }
+    async fn get(&self, key: &str, range: GetRange) -> Result<GetOutcome, StoreError> {
+        self.gets.fetch_add(1, Ordering::SeqCst);
+        self.inner.get(key, range).await
+    }
+    async fn head(&self, key: &str) -> Result<ObjectMeta, StoreError> {
+        self.inner.head(key).await
+    }
+    async fn list(&self, prefix: &str, page: Option<PageToken>) -> Result<ListPage, StoreError> {
+        self.inner.list(prefix, page).await
+    }
+    async fn list_delimited(&self, prefix: &str) -> Result<DelimitedList, StoreError> {
+        self.inner.list_delimited(prefix).await
+    }
+    async fn delete(&self, key: &str) -> Result<(), StoreError> {
+        self.inner.delete(key).await
+    }
+    fn capabilities(&self) -> Capabilities {
+        Capabilities {
+            multipart: false,
+            ..self.inner.capabilities()
+        }
+    }
+}
+
+#[async_trait]
+impl ObjectStoreBackend for EtagSwapStore {
+    async fn put(
+        &self,
+        key: &str,
+        data: bytes::Bytes,
+        opts: PutOptions,
+    ) -> Result<PutOutcome, StoreError> {
+        self.inner.put(key, data, opts).await
+    }
+    async fn get(&self, key: &str, range: GetRange) -> Result<GetOutcome, StoreError> {
+        let mut got = self.inner.get(key, range).await?;
+        if let GetRange::Range(start, _) = range
+            && start >= self.blocks_offset
+        {
+            got.etag = Etag("swapped-mid-sequence".to_string());
+        }
+        Ok(got)
+    }
+    async fn head(&self, key: &str) -> Result<ObjectMeta, StoreError> {
+        self.inner.head(key).await
+    }
+    async fn list(&self, prefix: &str, page: Option<PageToken>) -> Result<ListPage, StoreError> {
+        self.inner.list(prefix, page).await
+    }
+    async fn list_delimited(&self, prefix: &str) -> Result<DelimitedList, StoreError> {
+        self.inner.list_delimited(prefix).await
+    }
+    async fn delete(&self, key: &str) -> Result<(), StoreError> {
+        self.inner.delete(key).await
+    }
+    fn capabilities(&self) -> Capabilities {
+        Capabilities {
+            multipart: false,
+            ..self.inner.capabilities()
+        }
+    }
+}
+
+#[async_trait]
+impl ObjectStoreBackend for NotFoundOnBlockStore {
+    async fn put(
+        &self,
+        key: &str,
+        data: bytes::Bytes,
+        opts: PutOptions,
+    ) -> Result<PutOutcome, StoreError> {
+        self.inner.put(key, data, opts).await
+    }
+    async fn get(&self, key: &str, range: GetRange) -> Result<GetOutcome, StoreError> {
+        if let GetRange::Range(start, _) = range
+            && start >= self.blocks_offset
+        {
+            return Err(StoreError::NotFound);
+        }
+        self.inner.get(key, range).await
+    }
+    async fn head(&self, key: &str) -> Result<ObjectMeta, StoreError> {
+        self.inner.head(key).await
+    }
+    async fn list(&self, prefix: &str, page: Option<PageToken>) -> Result<ListPage, StoreError> {
+        self.inner.list(prefix, page).await
+    }
+    async fn list_delimited(&self, prefix: &str) -> Result<DelimitedList, StoreError> {
+        self.inner.list_delimited(prefix).await
+    }
+    async fn delete(&self, key: &str) -> Result<(), StoreError> {
+        self.inner.delete(key).await
+    }
+    fn capabilities(&self) -> Capabilities {
+        Capabilities {
+            multipart: false,
+            ..self.inner.capabilities()
+        }
+    }
+}
+
+/// A 20-block object (ts 0..=19, one record per block) whose ts query [6,13]
+/// selects a strict subset of blocks.
+fn subset_object() -> (Vec<LogRecord>, Vec<u8>) {
+    let records: Vec<LogRecord> = (0..20)
+        .map(|ts| record("api", ts, if ts == 8 { "connection timeout" } else { "ok" }))
+        .collect();
+    let bytes = build_object(&records);
+    (records, bytes)
+}
+
+// ---- Test 1: differential -----------------------------------------------
+
+/// The block-range path's decoded rows are byte-identical to the whole-object
+/// path's over the same candidate (ts) set, even though the block-range buffer
+/// holds only the candidate blocks (pruned blocks are zeroed gaps the reader
+/// never touches). The probe suffix is sized to the tail only, so the ranged
+/// path genuinely range-fetches the front metadata and the candidate blocks.
+#[tokio::test]
+async fn block_range_rows_match_whole_object_over_same_candidate_set() {
+    let (records, bytes) = subset_object();
+    let (blocks_offset, _blocks_len, tail_len) = layout(&bytes);
+    assert!(blocks_offset > 0 && tail_len > 0);
+
+    let mem = Arc::new(MemoryStore::new());
+    mem.put("logs/s.rlog", bytes.clone().into(), PutOptions::default())
+        .await
+        .expect("put");
+    let seg = seg_ref("logs/s.rlog", bytes.len() as u64, &records);
+    let store: Arc<dyn ObjectStoreBackend> = mem;
+
+    let query = LogQuery::new(6, 13);
+
+    // Whole-object path: plain `fetch` issues one GetRange::Full and scans it.
+    let whole = LogSegmentFetcher::new(Arc::clone(&store))
+        .fetch(&seg, &query)
+        .await
+        .expect("whole fetch")
+        .expect("in range");
+
+    // Block-range path: route every object through it, probe only the tail, and
+    // disable the coverage crossover so the true per-block ranged path runs.
+    let br = BlockRangeFetcher::new(Arc::clone(&store))
+        .with_whole_object_threshold(0)
+        .with_suffix_len(tail_len)
+        .with_coverage_threshold(2.0);
+    let ranged = LogSegmentFetcher::new(Arc::clone(&store))
+        .with_block_range_threshold(0)
+        .with_block_range(br)
+        .fetch_accounted_with_tenant(&seg, TENANT, &query, &QueryAccounting::new())
+        .await
+        .expect("ranged fetch")
+        .expect("in range");
+
+    assert!(!whole.records.is_empty(), "the subset is nontrivial");
+    assert_eq!(
+        whole.records, ranged.records,
+        "block-range decoded rows must be byte-identical to whole-object rows"
+    );
+
+    // The candidate set is a strict, nontrivial subset of the 20 blocks.
+    let cands = candidate_extents(&bytes, 6, 13);
+    assert!(
+        cands.len() > 1 && cands.len() < 20,
+        "candidate blocks must be a strict nontrivial subset, got {}",
+        cands.len()
+    );
+}
+
+// ---- Test 2: etag pinning ------------------------------------------------
+
+/// An etag change between the probe and a later block-range GET surfaces the
+/// typed [`LogFetchError::EtagChanged`]. The store swaps the etag on any GET at
+/// or beyond the BLOCKS offset, so the probe (a suffix over the tail) and the
+/// front-metadata GETs keep the pinned etag and a block-range GET is the one
+/// that observes the change.
+///
+/// Prove-the-test: with the etag check in `BlockRangeFetcher::store_get_pinned`
+/// removed (the `if &got.etag != expected` guard), the store still returns the
+/// correct bytes (only the etag differs), so the fetch succeeds silently and
+/// this assertion fails with `Ok`. Restoring the guard makes it pass.
+#[tokio::test]
+async fn etag_change_on_block_range_get_is_a_typed_error() {
+    let (records, bytes) = subset_object();
+    let (blocks_offset, _blocks_len, tail_len) = layout(&bytes);
+
+    let mem = Arc::new(MemoryStore::new());
+    mem.put("logs/e.rlog", bytes.clone().into(), PutOptions::default())
+        .await
+        .expect("put");
+    let seg = seg_ref("logs/e.rlog", bytes.len() as u64, &records);
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(EtagSwapStore {
+        inner: mem,
+        blocks_offset,
+    });
+
+    let br = BlockRangeFetcher::new(store)
+        .with_whole_object_threshold(0)
+        .with_suffix_len(tail_len)
+        .with_coverage_threshold(2.0);
+
+    let err = br
+        .fetch_object(&seg, TENANT, 6, 13, &QueryAccounting::new())
+        .await
+        .expect_err("etag change must surface as an error");
+    assert!(
+        matches!(err, LogFetchError::EtagChanged { .. }),
+        "expected EtagChanged, got {err:?}"
+    );
+}
+
+// ---- Test 3: NotFound mapping -------------------------------------------
+
+/// A `NotFound` on a block-range GET surfaces the SAME
+/// `LogFetchError::Store { source: NotFound }` a whole-object fetch produces for
+/// a vanished pinned segment. That shape is exactly what
+/// `ravel_sql::SqlError::is_segment_not_found` maps to the `SnapshotInvalidated`
+/// retry path, so no second mapping is introduced (ADR-0107 decision 1).
+#[tokio::test]
+async fn not_found_on_block_range_get_is_the_segment_not_found_shape() {
+    let (records, bytes) = subset_object();
+    let (blocks_offset, _blocks_len, tail_len) = layout(&bytes);
+
+    // Whole-object path oracle: a plain fetch of a missing object.
+    let empty = Arc::new(MemoryStore::new());
+    let seg_missing = seg_ref("logs/missing.rlog", bytes.len() as u64, &records);
+    let whole_err = LogSegmentFetcher::new(empty as Arc<dyn ObjectStoreBackend>)
+        .fetch(&seg_missing, &LogQuery::new(6, 13))
+        .await
+        .expect_err("missing object");
+    assert!(
+        matches!(
+            whole_err,
+            LogFetchError::Store {
+                source: StoreError::NotFound,
+                ..
+            }
+        ),
+        "whole-object NotFound shape, got {whole_err:?}"
+    );
+
+    // Block-range path: the segment exists for the probe/metadata but its blocks
+    // vanish (compacted away) before the block-range GET.
+    let mem = Arc::new(MemoryStore::new());
+    mem.put("logs/nf.rlog", bytes.clone().into(), PutOptions::default())
+        .await
+        .expect("put");
+    let seg = seg_ref("logs/nf.rlog", bytes.len() as u64, &records);
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(NotFoundOnBlockStore {
+        inner: mem,
+        blocks_offset,
+    });
+    let br = BlockRangeFetcher::new(store)
+        .with_whole_object_threshold(0)
+        .with_suffix_len(tail_len)
+        .with_coverage_threshold(2.0);
+    let err = br
+        .fetch_object(&seg, TENANT, 6, 13, &QueryAccounting::new())
+        .await
+        .expect_err("block NotFound");
+    assert!(
+        matches!(
+            err,
+            LogFetchError::Store {
+                source: StoreError::NotFound,
+                ..
+            }
+        ),
+        "block-range NotFound must be the same Store{{NotFound}} shape, got {err:?}"
+    );
+}
+
+// ---- Test 4: corrupt cache hit ------------------------------------------
+
+/// A corrupted per-block cache hit fails closed exactly like a corrupt live
+/// fetch (ADR-0046 §4 / ADR-0107 decision 3). Using `Cache::with_corruption`,
+/// the first `fetch_object` populates the per-block cache (a miss, clean bytes);
+/// the second is a genuine hit against the now-corrupted entry, which the
+/// fetcher's own `block_crc32c` re-verification must reject.
+///
+/// Prove-the-test: with the cache-hit `verify_block_crc(key, &bytes, ext)?`
+/// removed from `BlockRangeFetcher::fetch_blocks`, the corrupted block is placed
+/// into the assembled buffer and `fetch_object` returns `Ok`, so this assertion
+/// fails. Restoring the check makes it fail closed with `Corrupt`.
+#[tokio::test]
+async fn corrupt_per_block_cache_hit_fails_closed() {
+    let (records, bytes) = subset_object();
+    let (blocks_offset, _blocks_len, tail_len) = layout(&bytes);
+    let _ = blocks_offset;
+
+    let mem = Arc::new(MemoryStore::new());
+    mem.put("logs/c.rlog", bytes.clone().into(), PutOptions::default())
+        .await
+        .expect("put");
+    let seg = seg_ref("logs/c.rlog", bytes.len() as u64, &records);
+    let store: Arc<dyn ObjectStoreBackend> = mem;
+
+    let cache = Arc::new(Cache::with_corruption(CacheLimits::new(
+        1 << 20,
+        1024,
+        1 << 20,
+    )));
+    let br = BlockRangeFetcher::new(store)
+        .with_whole_object_threshold(0)
+        .with_suffix_len(tail_len)
+        .with_coverage_threshold(2.0)
+        .with_cache(cache);
+
+    // First call: cache miss, clean bytes, admits per-block entries.
+    let (_bytes, _stats) = br
+        .fetch_object(&seg, TENANT, 6, 13, &QueryAccounting::new())
+        .await
+        .expect("first fetch (miss) succeeds");
+
+    // Second call: a genuine per-block cache hit returns corrupted bytes.
+    let err = br
+        .fetch_object(&seg, TENANT, 6, 13, &QueryAccounting::new())
+        .await
+        .expect_err("corrupted cache hit must fail closed");
+    assert!(
+        matches!(err, LogFetchError::Corrupt { .. }),
+        "expected Corrupt on a corrupted block hit, got {err:?}"
+    );
+}
+
+// ---- Test 5: GET-count proportionality ----------------------------------
+
+/// The block-range GET count and byte volume are proportional to the candidate
+/// fraction, not the object size. With `coalesce_gap == 0`, the block-range GET
+/// count equals the number of maximal contiguous runs among candidate blocks; a
+/// suffix sized to the tail makes the fixed overhead exactly one probe GET plus
+/// one GET per uncovered front section (STREAM_DIR, FIELD_DIR). The asserted
+/// figures are exact, not "fewer than before".
+#[tokio::test]
+async fn block_range_get_count_is_proportional_to_candidate_fraction() {
+    let (records, bytes) = subset_object();
+    let (blocks_offset, blocks_len, tail_len) = layout(&bytes);
+    assert!(blocks_offset > 0 && blocks_len > 0);
+
+    let (ts_min, ts_max) = (6, 13);
+    let cands = candidate_extents(&bytes, ts_min, ts_max);
+    let candidate_bytes: u64 = cands.iter().map(|(_, len, _)| *len).sum();
+    let expected_runs = contiguous_runs(cands.clone());
+    let expected_candidates = cands.len() as u64;
+
+    let mem = Arc::new(MemoryStore::new());
+    mem.put("logs/g.rlog", bytes.clone().into(), PutOptions::default())
+        .await
+        .expect("put");
+    let seg = seg_ref("logs/g.rlog", bytes.len() as u64, &records);
+    let counting = Arc::new(CountingStore::new(mem));
+    let store: Arc<dyn ObjectStoreBackend> = counting.clone();
+
+    let br = BlockRangeFetcher::new(store)
+        .with_whole_object_threshold(0)
+        .with_suffix_len(tail_len)
+        .with_coalesce_gap(0)
+        .with_coverage_threshold(2.0);
+
+    let (_assembled, stats) = br
+        .fetch_object(&seg, TENANT, ts_min, ts_max, &QueryAccounting::new())
+        .await
+        .expect("ranged fetch");
+
+    // The candidate set is a known strict fraction of the 20 blocks.
+    assert_eq!(stats.candidate_blocks, expected_candidates);
+    assert!(
+        (2..=12).contains(&expected_candidates),
+        "sanity: subset fraction, got {expected_candidates}/20"
+    );
+
+    // Block-range GETs: exactly one per contiguous candidate run (gap 0).
+    assert_eq!(
+        stats.block_range_gets, expected_runs as u64,
+        "one coalesced GET per contiguous candidate run"
+    );
+    // Bytes read for blocks equal the candidate extents' total, and are a strict
+    // fraction of the object's block region (pruning-proportional).
+    assert_eq!(stats.block_bytes_fetched, candidate_bytes);
+    assert!(
+        candidate_bytes * 2 < blocks_len,
+        "candidate bytes {candidate_bytes} must be far under the block region {blocks_len}"
+    );
+
+    // Total store GETs: probe (1) + front metadata (STREAM_DIR + FIELD_DIR = 2)
+    // + one per contiguous candidate run. The tail (SKIP_IDX/BLOOM/POSTINGS +
+    // footer) is covered by the probe, so it costs no extra GET.
+    let expected_total = 1 + 2 + expected_runs as u64;
+    assert_eq!(
+        counting.get_count(),
+        expected_total,
+        "probe(1) + front-meta(2) + block runs({expected_runs})"
+    );
+    assert_eq!(stats.probe_gets, 1);
+    assert_eq!(stats.metadata_gets, 2);
+    assert!(!stats.whole_object);
+}

--- a/crates/ravel-query/tests/log_block_range.rs
+++ b/crates/ravel-query/tests/log_block_range.rs
@@ -17,6 +17,13 @@
 //!    corrupt live fetch (ADR-0046 §4).
 //! 5. GET-count: the block-range GET count and byte volume are proportional to
 //!    the candidate fraction, not the object size.
+//!
+//! Tests 1-5 all force the ranged path on a small fixture
+//! (`with_whole_object_threshold(0)`) or run without a cache. Tests 6-8 at the
+//! end of this file are the counterpart at PRODUCTION defaults: an object above
+//! the real 512 KiB threshold, a cache attached, and several partitions striping
+//! one segment -- the configuration ADR-0102 decision 1's fan-out gate grants,
+//! whose single-flight premise the block-range path has to keep true.
 
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
@@ -601,4 +608,423 @@ async fn block_range_get_count_is_proportional_to_candidate_fraction() {
     assert_eq!(stats.probe_gets, 1);
     assert_eq!(stats.metadata_gets, 2);
     assert!(!stats.whole_object);
+}
+
+// ---- Tests 6-8: production defaults, cached, multi-partition ---------------
+//
+// Everything below runs at the REAL 512 KiB `block_range_threshold` with a real
+// cache attached, on an object big enough to route there on its own. Tests 1-5
+// above all avoid that configuration (threshold 0, or no cache), which is
+// exactly the configuration ADR-0102 decision 1's fan-out gate grants: several
+// partitions striping ONE segment, coalescing onto one request each through
+// ADR-0046's single-flight.
+
+/// Records whose bodies are high-entropy enough that zstd level 3 cannot shrink
+/// the object back under the 512 KiB threshold: 24 KiB of 64-alphabet noise per
+/// record, one record per block. Deterministic (a fixed LCG), so the object's
+/// size and layout are the same on every run.
+fn big_records(count: i64) -> Vec<LogRecord> {
+    const ALPHABET: &[u8; 64] = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+/";
+    let mut state: u64 = 0x2545_F491_4F6C_DD1D;
+    (0..count)
+        .map(|ts| {
+            let mut body = String::with_capacity(24 * 1024);
+            for i in 0..24 * 1024 {
+                state = state
+                    .wrapping_mul(6364136223846793005)
+                    .wrapping_add(1442695040888963407);
+                // A space every 16 bytes keeps the body tokenizable rather than
+                // one enormous term, without lowering entropy meaningfully.
+                if i % 16 == 15 {
+                    body.push(' ');
+                } else {
+                    body.push(ALPHABET[(state >> 33) as usize % 64] as char);
+                }
+            }
+            record("api", ts, &body)
+        })
+        .collect()
+}
+
+/// An object above the production 512 KiB threshold: 40 one-record blocks of
+/// ~24 KiB each. Returns the records and the object bytes.
+fn large_object() -> (Vec<LogRecord>, Vec<u8>) {
+    let records = big_records(40);
+    let bytes = build_object(&records);
+    (records, bytes)
+}
+
+/// Non-BLOCKS sections the probe window `[total - suffix, total)` does NOT
+/// already cover: one metadata GET each.
+fn uncovered_sections(bytes: &[u8], suffix: u64) -> u64 {
+    let footer = footer::open(bytes).expect("footer");
+    let total = bytes.len() as u64;
+    let probe_start = total.saturating_sub(suffix);
+    footer
+        .sections
+        .iter()
+        .filter(|s| s.kind != kind::BLOCKS)
+        .filter(|s| s.offset < probe_start || s.offset + s.len > total)
+        .count() as u64
+}
+
+/// Coalesced runs among candidate extents at a gap threshold: the exact number
+/// of block-range GETs the fetcher issues for them.
+fn coalesced_runs(mut ext: Vec<(u64, u64, u32)>, gap: u64) -> u64 {
+    ext.sort_by_key(|e| e.0);
+    let mut runs = 0u64;
+    let mut prev_end: Option<u64> = None;
+    for (start, len, _) in ext {
+        match prev_end {
+            Some(end) if start <= end + gap => {}
+            _ => runs += 1,
+        }
+        prev_end = Some(prev_end.map_or(start + len, |e| e.max(start + len)));
+    }
+    runs
+}
+
+/// The whole fixed cost of one segment's block-range read at production
+/// defaults: the etag-establishing probe, one GET per non-BLOCKS section the
+/// probe missed, and one GET per coalesced candidate run. Asserts along the way
+/// that the fixture really exercises the path under test (above the threshold,
+/// candidates outside the probe window, coverage under the crossover).
+fn expected_segment_gets(bytes: &[u8], ts_min: i64, ts_max: i64) -> u64 {
+    let total = bytes.len() as u64;
+    assert!(
+        total > ravel_query::DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
+        "fixture must be above the production threshold, got {total} bytes"
+    );
+    let suffix = ravel_query::DEFAULT_LOG_SUFFIX_LEN;
+    let cands = candidate_extents(bytes, ts_min, ts_max);
+    assert!(
+        cands.len() > 1 && cands.len() < 40,
+        "candidates must be a strict nontrivial subset, got {}",
+        cands.len()
+    );
+    // No candidate may fall inside the probe window: a probe-covered block costs
+    // no GET, and the oracle below counts one GET per run.
+    let probe_start = total - suffix;
+    assert!(
+        cands
+            .iter()
+            .all(|(start, len, _)| start + len <= probe_start),
+        "fixture must select blocks outside the probe window"
+    );
+    // Under the coverage crossover, so the ranged path (not a whole-object GET)
+    // is what runs.
+    let footer = footer::open(bytes).expect("footer");
+    let blocks = footer.section(kind::BLOCKS).expect("BLOCKS");
+    let candidate_bytes: u64 = cands.iter().map(|(_, len, _)| *len).sum();
+    let coverage = candidate_bytes as f64 / blocks.len as f64;
+    assert!(
+        coverage < ravel_query::DEFAULT_LOG_COVERAGE_THRESHOLD,
+        "fixture must stay under the coverage crossover, got {coverage}"
+    );
+    1 + uncovered_sections(bytes, suffix)
+        + coalesced_runs(cands, ravel_query::DEFAULT_LOG_COALESCE_GAP)
+}
+
+/// [`CountingStore`] with a real object store's latency (a few ms per GET, far
+/// below S3's 15-80 ms). Concurrency tests need it: with a zero-latency store a
+/// leader can finish its whole fetch before a peer even asks, and
+/// `Cache::get_or_fetch` releases its in-flight slot just before it admits the
+/// bytes, so a peer landing in that microsecond window becomes a second leader
+/// for the same key and the request count stops being a function of the fetch
+/// protocol. Under any latency at all, concurrent callers for one key subscribe
+/// while the leader is still in flight, which is the behavior ADR-0046's
+/// single-flight exists to provide and the one this test is asserting about.
+struct SlowCountingStore {
+    inner: Arc<MemoryStore>,
+    gets: AtomicU64,
+}
+
+impl SlowCountingStore {
+    fn new(inner: Arc<MemoryStore>) -> Self {
+        SlowCountingStore {
+            inner,
+            gets: AtomicU64::new(0),
+        }
+    }
+    fn get_count(&self) -> u64 {
+        self.gets.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl ObjectStoreBackend for SlowCountingStore {
+    async fn put(
+        &self,
+        key: &str,
+        data: bytes::Bytes,
+        opts: PutOptions,
+    ) -> Result<PutOutcome, StoreError> {
+        self.inner.put(key, data, opts).await
+    }
+    async fn get(&self, key: &str, range: GetRange) -> Result<GetOutcome, StoreError> {
+        self.gets.fetch_add(1, Ordering::SeqCst);
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        self.inner.get(key, range).await
+    }
+    async fn head(&self, key: &str) -> Result<ObjectMeta, StoreError> {
+        self.inner.head(key).await
+    }
+    async fn list(&self, prefix: &str, page: Option<PageToken>) -> Result<ListPage, StoreError> {
+        self.inner.list(prefix, page).await
+    }
+    async fn list_delimited(&self, prefix: &str) -> Result<DelimitedList, StoreError> {
+        self.inner.list_delimited(prefix).await
+    }
+    async fn delete(&self, key: &str) -> Result<(), StoreError> {
+        self.inner.delete(key).await
+    }
+    fn capabilities(&self) -> Capabilities {
+        Capabilities {
+            multipart: false,
+            ..self.inner.capabilities()
+        }
+    }
+}
+
+fn big_cache() -> Arc<Cache<ravel_query::CacheFetchError>> {
+    // Far larger than the fixture, so nothing is evicted mid-test: an eviction
+    // would turn a cache hit into a real GET and make the count nondeterministic
+    // for a reason that has nothing to do with single-flight.
+    Arc::new(Cache::new(CacheLimits::new(1 << 26, 1 << 23, 1 << 26)))
+}
+
+/// Test 6: the production shape ADR-0102 decision 1 ships -- one shared
+/// `plan_segment` (the `OnceCell` in `LogsScanExec::compute_plan_counts`),
+/// then N partitions each draining its own stripe of the same segment's
+/// surviving blocks -- costs the SAME number of store GETs for any N.
+///
+/// The count asserted is exact, not "fewer than before": one etag-establishing
+/// probe, one GET per non-BLOCKS section the probe did not cover, and one GET
+/// per coalesced candidate run. Every partition after the planning read finds
+/// each of those extents already resident under its own cache key and issues
+/// nothing.
+///
+/// Prove-the-test: this fails on the pre-fix fetcher on the probe alone. The
+/// etag-establishing suffix GET was never cache-checked, so every partition and
+/// every `plan_segment` call paid one unconditionally: the count was
+/// `expected + N` rather than `expected`, and differed between N = 2 and N = 8.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn cached_partitions_striping_one_large_segment_cost_a_partition_independent_get_count() {
+    let (records, bytes) = large_object();
+    let (ts_min, ts_max) = (2, 11);
+    let expected = expected_segment_gets(&bytes, ts_min, ts_max);
+
+    let mut counts = Vec::new();
+    for partitions in [2usize, 8] {
+        let mem = Arc::new(MemoryStore::new());
+        mem.put("logs/big.rlog", bytes.clone().into(), PutOptions::default())
+            .await
+            .expect("put");
+        let counting = Arc::new(CountingStore::new(mem));
+        let store: Arc<dyn ObjectStoreBackend> = counting.clone();
+        let seg = seg_ref("logs/big.rlog", bytes.len() as u64, &records);
+        let query = LogQuery::new(ts_min, ts_max);
+
+        // Production defaults throughout: no threshold override, no probe-length
+        // override, no coverage override. Only the cache is wired, exactly as
+        // `build_sql_state` wires it.
+        let fetcher = LogSegmentFetcher::new(store).with_cache(big_cache());
+        assert!(
+            fetcher.has_cache(),
+            "the ADR-0102 fan-out gate this test stands in for reads has_cache()"
+        );
+
+        // The shared planning read, then the per-partition stripes.
+        let accounting = QueryAccounting::new();
+        let (surviving, _stats) = fetcher
+            .plan_segment(&seg, TENANT, &query, &accounting)
+            .await
+            .expect("plan")
+            .expect("in range");
+        assert!(
+            surviving > partitions,
+            "the stripe must be nontrivial: {surviving} surviving blocks over {partitions} \
+             partitions"
+        );
+
+        let mut tasks = Vec::new();
+        for p in 0..partitions {
+            let indices: Vec<usize> = (p..surviving).step_by(partitions).collect();
+            let fetcher = fetcher.clone();
+            let seg = seg.clone();
+            let query = query.clone();
+            tasks.push(tokio::spawn(async move {
+                let mut scan = fetcher
+                    .scan_accounted_with_tenant_subset(
+                        &seg,
+                        TENANT,
+                        &query,
+                        &ravel_logseg::ColumnSelection::all(),
+                        &indices,
+                        &QueryAccounting::new(),
+                    )
+                    .await
+                    .expect("subset scan")
+                    .expect("in range");
+                let mut rows = 0usize;
+                while let Some(block) = scan.next_block().expect("decode") {
+                    rows += block.len();
+                }
+                rows
+            }));
+        }
+        let mut rows = 0usize;
+        for task in tasks {
+            rows += task.await.expect("partition task");
+        }
+        assert_eq!(
+            rows,
+            (ts_max - ts_min + 1) as usize,
+            "the partitions together must return every matching row exactly once"
+        );
+
+        assert_eq!(
+            counting.get_count(),
+            expected,
+            "{partitions} partitions striping one segment must cost probe(1) + uncovered \
+             sections + coalesced runs = {expected} store GETs, independent of the partition count"
+        );
+        counts.push(counting.get_count());
+    }
+    assert_eq!(
+        counts[0], counts[1],
+        "the store GET count must not grow with the partition count"
+    );
+}
+
+/// Test 7: the same segment read by N partitions CONCURRENTLY from a cold
+/// cache, with no planning read to warm it. Nothing but ADR-0046's single-flight
+/// can hold the request count down here: every partition resolves the same
+/// probe, the same sections, and the same candidate run at the same moment.
+///
+/// The asserted count is exact and identical to test 6's: one GET per distinct
+/// extent, for any number of concurrent partitions. The pre-fix figure is
+/// `N * expected`. The store carries a few ms of latency per GET
+/// ([`SlowCountingStore`]) so the count is a function of the fetch protocol
+/// rather than of who happened to win a microsecond race on a zero-latency
+/// store; see that type's doc.
+///
+/// This also pins the per-partition memory shape the docs quote: each partition
+/// assembles its OWN object-sized buffer, so resident raw bytes above the
+/// threshold are `N * object_size`, not one shared object (the whole-object path
+/// below the threshold hands every partition a clone of one `Bytes`).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_cold_partitions_collapse_onto_one_get_per_extent() {
+    let (records, bytes) = large_object();
+    let (ts_min, ts_max) = (2, 11);
+    let expected = expected_segment_gets(&bytes, ts_min, ts_max);
+    const PARTITIONS: usize = 8;
+
+    let mem = Arc::new(MemoryStore::new());
+    mem.put(
+        "logs/cold.rlog",
+        bytes.clone().into(),
+        PutOptions::default(),
+    )
+    .await
+    .expect("put");
+    let counting = Arc::new(SlowCountingStore::new(mem));
+    let store: Arc<dyn ObjectStoreBackend> = counting.clone();
+    let seg = seg_ref("logs/cold.rlog", bytes.len() as u64, &records);
+
+    let br = BlockRangeFetcher::new(store).with_cache(big_cache());
+    let mut tasks = Vec::new();
+    for _ in 0..PARTITIONS {
+        let br = br.clone();
+        let seg = seg.clone();
+        tasks.push(tokio::spawn(async move {
+            br.fetch_object(&seg, TENANT, ts_min, ts_max, &QueryAccounting::new())
+                .await
+                .expect("concurrent block-range fetch")
+        }));
+    }
+    let mut resident_bytes = 0u64;
+    for task in tasks {
+        let (assembled, stats) = task.await.expect("partition task");
+        assert!(
+            !stats.whole_object,
+            "the fixture must take the ranged path, not a crossover"
+        );
+        assert_eq!(
+            assembled.len() as u64,
+            bytes.len() as u64,
+            "every partition assembles its own object-sized buffer"
+        );
+        resident_bytes += assembled.len() as u64;
+    }
+
+    assert_eq!(
+        counting.get_count(),
+        expected,
+        "{PARTITIONS} concurrent cold fetches of one segment must issue exactly one GET per \
+         distinct extent ({expected}: probe + uncovered sections + coalesced runs); \
+         un-coalesced the same work is {}",
+        expected * PARTITIONS as u64
+    );
+    assert_eq!(
+        resident_bytes,
+        bytes.len() as u64 * PARTITIONS as u64,
+        "resident raw bytes above the threshold are one object-sized buffer per partition"
+    );
+}
+
+/// Test 8: the per-block corrupt-hit gate (test 4's property) at production
+/// defaults, with ONLY the block entries resident.
+///
+/// Test 4 populates the whole cache and reads it back corrupted, which after
+/// probe caching (ADR-0107 + this fix) can trip at the probe's own decode rather
+/// than at the block gate. This one leaves the probe and the sections as misses
+/// -- `get_or_fetch` returns the leader's live bytes, which the corrupting cache
+/// never touches -- and pre-admits exactly the candidate blocks, so the ONLY
+/// corrupted hit is a block and the gate under test is the block gate.
+///
+/// Prove-the-test: with the cache-hit `verify_block_crc` removed from
+/// `fetch_blocks`, the corrupted block bytes are placed into the assembled
+/// buffer and this returns `Ok`.
+#[tokio::test]
+async fn corrupt_block_hit_fails_closed_with_only_blocks_resident() {
+    let (records, bytes) = large_object();
+    let (ts_min, ts_max) = (2, 11);
+    let cands = candidate_extents(&bytes, ts_min, ts_max);
+
+    let mem = Arc::new(MemoryStore::new());
+    mem.put("logs/cb.rlog", bytes.clone().into(), PutOptions::default())
+        .await
+        .expect("put");
+    let seg = seg_ref("logs/cb.rlog", bytes.len() as u64, &records);
+    let store: Arc<dyn ObjectStoreBackend> = mem;
+
+    let cache: Arc<Cache<ravel_query::CacheFetchError>> = Arc::new(Cache::with_corruption(
+        CacheLimits::new(1 << 26, 1 << 23, 1 << 26),
+    ));
+    // Pre-admit the candidate blocks (clean bytes, their real keys) and nothing
+    // else. `Cache::with_corruption` corrupts what a `get` serves, so each of
+    // these is a genuine corrupted per-block hit.
+    for (start, len, _) in &cands {
+        let (s, e) = (*start as usize, (*start + *len) as usize);
+        cache.insert(
+            ravel_cache::CacheKey::new(TENANT.0, CONTENT_HASH, *start, *len),
+            bytes::Bytes::copy_from_slice(&bytes[s..e]),
+        );
+    }
+
+    let err = LogSegmentFetcher::new(store)
+        .with_cache(cache)
+        .fetch_accounted_with_tenant(
+            &seg,
+            TENANT,
+            &LogQuery::new(ts_min, ts_max),
+            &QueryAccounting::new(),
+        )
+        .await
+        .expect_err("a corrupted per-block cache hit must fail closed");
+    assert!(
+        matches!(err, LogFetchError::Corrupt { .. }),
+        "expected Corrupt from the per-block gate, got {err:?}"
+    );
 }

--- a/crates/ravel-query/tests/log_block_range.rs
+++ b/crates/ravel-query/tests/log_block_range.rs
@@ -486,16 +486,28 @@ async fn not_found_on_block_range_get_is_the_segment_not_found_shape() {
 
 // ---- Test 4: corrupt cache hit ------------------------------------------
 
-/// A corrupted per-block cache hit fails closed exactly like a corrupt live
-/// fetch (ADR-0046 §4 / ADR-0107 decision 3). Using `Cache::with_corruption`,
-/// the first `fetch_object` populates the per-block cache (a miss, clean bytes);
-/// the second is a genuine hit against the now-corrupted entry, which the
-/// fetcher's own `block_crc32c` re-verification must reject.
+/// A corrupted cache hit fails closed exactly like a corrupt live fetch
+/// (ADR-0046 §4 / ADR-0107 decision 3). Using `Cache::with_corruption`, the
+/// first `fetch_object` populates the cache (misses, clean bytes -- probe,
+/// sections, and blocks alike); the second call re-reads every one of those
+/// entries, now corrupted.
 ///
-/// Prove-the-test: with the cache-hit `verify_block_crc(key, &bytes, ext)?`
-/// removed from `BlockRangeFetcher::fetch_blocks`, the corrupted block is placed
-/// into the assembled buffer and `fetch_object` returns `Ok`, so this assertion
-/// fails. Restoring the check makes it fail closed with `Corrupt`.
+/// This does NOT isolate the per-block gate: since this fix's probe caching
+/// (decision 2), the second call's probe hit is corrupted too, and its
+/// `open_from_suffix` decode fails with a bad-magic `Corrupted` error before
+/// any block is ever reached. That is still a genuine fail-closed result (a
+/// corrupted cache entry, wherever it lives, must never surface as `Ok`), but
+/// the failure this test actually exercises is the probe's decode-time
+/// rejection, not `fetch_blocks`'s `verify_block_crc`. Test
+/// `corrupt_block_hit_fails_closed_with_only_blocks_resident` isolates the
+/// per-block gate specifically, by pre-admitting only block entries so the
+/// probe and sections stay clean.
+///
+/// Prove-the-test: with the etag/footer decode's own corruption handling
+/// intact but every OTHER integrity check in the fetch path bypassed, this
+/// assertion still fails closed purely on the probe's corrupted bytes -- this
+/// test does not need `fetch_blocks`'s block-crc gate to pass, and does not
+/// prove it. See the isolated test above for that proof.
 #[tokio::test]
 async fn corrupt_per_block_cache_hit_fails_closed() {
     let (records, bytes) = subset_object();
@@ -983,6 +995,16 @@ async fn concurrent_cold_partitions_collapse_onto_one_get_per_extent() {
 /// never touches -- and pre-admits exactly the candidate blocks, so the ONLY
 /// corrupted hit is a block and the gate under test is the block gate.
 ///
+/// This calls `BlockRangeFetcher::fetch_object` directly rather than going
+/// through `LogSegmentFetcher::fetch_accounted_with_tenant`: the latter decodes
+/// the assembled buffer afterward, and the reader's own `read_block_columns`
+/// crc check (`ravel-logseg`) fires first and masks the fetcher's own cache-hit
+/// gate this test names -- confirmed by mutating the fetcher's gate alone and
+/// observing the suite stay green through the decode path. Calling
+/// `fetch_object` directly returns the assembled bytes without decoding them,
+/// so only `BlockRangeFetcher::fetch_blocks`'s own `verify_block_crc` can catch
+/// the corruption.
+///
 /// Prove-the-test: with the cache-hit `verify_block_crc` removed from
 /// `fetch_blocks`, the corrupted block bytes are placed into the assembled
 /// buffer and this returns `Ok`.
@@ -1013,14 +1035,9 @@ async fn corrupt_block_hit_fails_closed_with_only_blocks_resident() {
         );
     }
 
-    let err = LogSegmentFetcher::new(store)
-        .with_cache(cache)
-        .fetch_accounted_with_tenant(
-            &seg,
-            TENANT,
-            &LogQuery::new(ts_min, ts_max),
-            &QueryAccounting::new(),
-        )
+    let br = BlockRangeFetcher::new(store).with_cache(cache);
+    let err = br
+        .fetch_object(&seg, TENANT, ts_min, ts_max, &QueryAccounting::new())
         .await
         .expect_err("a corrupted per-block cache hit must fail closed");
     assert!(

--- a/crates/ravel-sql/src/error.rs
+++ b/crates/ravel-sql/src/error.rs
@@ -282,7 +282,9 @@ impl SqlError {
             },
             SqlError::LogFetch(fetch) => match fetch {
                 LogFetchError::Corrupt { .. } => MSG_CORRUPT.to_string(),
-                LogFetchError::Store { .. } => MSG_UNAVAILABLE.to_string(),
+                LogFetchError::Store { .. } | LogFetchError::EtagChanged { .. } => {
+                    MSG_UNAVAILABLE.to_string()
+                }
             },
             SqlError::SpanFetch(fetch) => match fetch {
                 // A cross-tenant object is an integrity violation of the fetched

--- a/crates/ravel-sql/src/logs_scan.rs
+++ b/crates/ravel-sql/src/logs_scan.rs
@@ -28,26 +28,32 @@
 //!
 //! # Object-store request count, and the cache gate
 //!
-//! The whole object is still fetched with one whole-object GET (ADR-0087
-//! decision 3: no ranged block reader here), so every partition that owns
-//! blocks in a segment issues its own whole-object read at that segment's key.
-//! What those reads cost depends on the cache, and so does how many partitions
-//! are planned:
+//! Every partition that owns blocks in a segment opens that segment itself, so
+//! it issues its own read sequence at that segment's key. The shape of that
+//! sequence depends on the object's size (ADR-0107,
+//! [`LogSegmentFetcher::with_block_range_threshold`], 512 KiB by default): at or
+//! below the threshold it is one whole-object GET; above it, a suffix probe, one
+//! GET per directory section, and coalesced GETs for the candidate blocks
+//! skip-index pruning kept. What those reads cost depends on the cache, and so
+//! does how many partitions are planned:
 //!
 //! - **Un-cached fetcher.** The partition count is capped at the segment count,
 //!   so the request count stops responding to `target_partitions` once that cap
 //!   binds. It is the pre-ADR-0102 whole-segment count only when the plan
 //!   collapses to a single partition; with `n > 1` partitions, every segment
 //!   holding at least `n` surviving blocks is opened by all `n` of them, so the
-//!   scan costs up to `n` whole-object reads per segment, and planning's prune
+//!   scan costs up to `n` read sequences per segment, and planning's prune
 //!   (`compute_plan_counts`) adds one more per relevant segment. The cap
 //!   bounds that multiplier by the segment count instead of letting
 //!   `target_partitions` set it; it does not remove it. `ravel-bench`'s
 //!   `logs_scan_scaling` report measures both.
 //! - **Cache-wired fetcher.** The partition count is `target_partitions`, so
-//!   several partitions can stripe one segment's blocks. The read cache keys the
-//!   whole object, so those reads coalesce onto one GET via single-flight, and
-//!   on the bench fixture the request count is flat across the whole
+//!   several partitions can stripe one segment's blocks. Every GET of either
+//!   shape is keyed by the extent it fetched and routed through the cache's
+//!   single-flight -- the whole object below the threshold, and the probe, each
+//!   section, and each block above it -- so the partitions striping one segment
+//!   coalesce onto one request per distinct extent rather than one sequence
+//!   each, and on the bench fixture the request count is flat across the whole
 //!   `target_partitions` sweep (planning's prune coalesces with them too).
 //!   Coalescing is not free of request count in general, though: a read that
 //!   misses the in-flight window, or finds its key already evicted, issues its
@@ -56,8 +62,11 @@
 //!   for the cache absorbing the repeat reads and for the extra scan
 //!   parallelism.
 //!
-//! A future ranged (per-block) reader would remove the trade entirely by making
-//! each partition's fetch cover only its own blocks.
+//! Above the threshold each partition's read already covers only the pruned
+//! candidate blocks rather than every byte of the segment, so bytes on the wire
+//! are pruning-proportional; what stays per-partition is the object-sized
+//! assembly buffer each one builds
+//! (`crates/ravel-query/tests/log_block_range.rs` measures both).
 //!
 //! Any "no amplification" or "flat request count" figure reported for this path
 //! (here, in `ravel-bench`'s `logs_scan_scaling` report, or in that bench's
@@ -577,15 +586,16 @@ impl LogsScanExec {
         //
         // Striping past the segment count is gated on the fetcher carrying
         // ADR-0046's read cache, which is the precondition ADR-0102 decision 1
-        // names for it: the fetch unit here is the whole object
-        // (`GetRange::Full`, no ranged block reader -- ADR-0087 decision 3), so K
-        // partitions sharing one segment issue K whole-object reads at the same
-        // key. With the cache those coalesce onto one GET through single-flight;
-        // without it each is a real request, and requesting more partitions than
-        // there are segments would multiply object-store GETs for no reason. So
-        // an un-cached fetcher falls back to the pre-ADR-0102 bound,
-        // `min(target_partitions, segment_count)`, and never plans a partition
-        // whose extra GETs nothing absorbs.
+        // names for it: K partitions sharing one segment each open it
+        // themselves, so each issues its own read sequence at that key -- one
+        // whole-object GET at or below the ADR-0107 block-range threshold, and a
+        // probe plus section and candidate-block ranges above it. With the cache
+        // every GET of either shape is keyed by its extent and coalesces onto one
+        // request through single-flight; without it each is a real request, and
+        // requesting more partitions than there are segments would multiply
+        // object-store GETs for no reason. So an un-cached fetcher falls back to
+        // the pre-ADR-0102 bound, `min(target_partitions, segment_count)`, and
+        // never plans a partition whose extra GETs nothing absorbs.
         let declared_partitions = if fetcher.has_cache() {
             target_partitions.max(1)
         } else {
@@ -809,8 +819,9 @@ fn plan_counts_future(
 
 /// Prune every segment once (no block decode) to build the shared block plan.
 /// Sequential on purpose: the reads are single-flight coalesced with the
-/// per-partition scans that follow, and this runs once per query, not per
-/// partition.
+/// per-partition scans that follow -- on the whole object's key below the
+/// ADR-0107 block-range threshold, and per extent (probe, sections, blocks)
+/// above it -- and this runs once per query, not per partition.
 async fn compute_plan_counts(
     ctx: &PartitionCtx,
     segments: &[SegmentRef],

--- a/crates/ravel-sql/tests/logs_provider.rs
+++ b/crates/ravel-sql/tests/logs_provider.rs
@@ -1322,3 +1322,110 @@ async fn like_matrix_plans_without_cast_and_matches_rows() {
         "LIKE's matched argument must be the bare dictionary column, not a CAST; plan was:\n{text}"
     );
 }
+
+/// Reachability of the RLOG block-range fetcher (ADR-0107) from a real `logs`
+/// SQL query: the same ts + `has_word` scan as
+/// `scan_prunes_by_ts_and_word_returns_exact_rows`, but with a
+/// `LogSegmentFetcher` whose block-range path is forced on (threshold 0) and
+/// configured to genuinely range-fetch (a tiny probe suffix so the front
+/// metadata and the candidate blocks are fetched by range, pruned blocks left as
+/// zeroed gaps, coverage crossover disabled). The scan's output must still equal
+/// the record-by-record oracle exactly, proving the block-range assembly decodes
+/// correctly through the whole SQL scan pipeline, not only a unit test.
+#[tokio::test]
+async fn logs_scan_over_block_range_fetcher_returns_exact_rows() {
+    let store = MemoryStore::new();
+
+    let obj_a: Vec<LogRecord> = (100..=110)
+        .map(|ts| {
+            record(
+                "api",
+                ts,
+                if ts == 105 {
+                    "connection timeout"
+                } else {
+                    "ok"
+                },
+            )
+        })
+        .collect();
+    let obj_b: Vec<LogRecord> = (1000..=1010)
+        .map(|ts| {
+            record(
+                "worker",
+                ts,
+                if ts == 1005 { "request timeout" } else { "ok" },
+            )
+        })
+        .collect();
+    let obj_c: Vec<LogRecord> = (200..=205)
+        .map(|ts| {
+            let body = match ts {
+                202 => "gateway timeout",
+                204 => "timed out",
+                _ => "ok",
+            };
+            record("api", ts, body)
+        })
+        .collect();
+
+    let ref_a = write_object(&store, "logs/a.rlog", &obj_a).await;
+    let ref_b = write_object(&store, "logs/b.rlog", &obj_b).await;
+    let ref_c = write_object(&store, "logs/c.rlog", &obj_c).await;
+
+    let snapshot = Snapshot {
+        segments: vec![ref_a, ref_b, ref_c],
+        segments_pruned: 0,
+        pending_erasure: Vec::new(),
+    };
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(store);
+
+    // Force the block-range path on for every object, with a tiny probe suffix
+    // (genuine range fetches, zeroed gaps for pruned blocks) and the coverage
+    // crossover disabled.
+    let block_range = ravel_query::BlockRangeFetcher::new(Arc::clone(&store))
+        .with_whole_object_threshold(0)
+        .with_suffix_len(64)
+        .with_coverage_threshold(2.0);
+    let fetcher = LogSegmentFetcher::new(Arc::clone(&store))
+        .with_block_range_threshold(0)
+        .with_block_range(block_range);
+
+    let provider = LogsTableProvider::new(
+        snapshot,
+        TenantHash([7u8; 16]),
+        fetcher,
+        QueryAccounting::new(),
+    );
+
+    let (lo, hi) = (100i64, 250i64);
+    let filters = vec![
+        col("ts").gt_eq(ts_lit(lo)),
+        col("ts").lt_eq(ts_lit(hi)),
+        has_word_udf().call(vec![col("body"), lit("timeout")]),
+    ];
+    let plan = provider.plan_filters(4, &filters).expect("build plan");
+    let batches = collect_plan(plan).await;
+    let got = batches_to_rows(&batches);
+
+    let mut want = BTreeSet::new();
+    for records in [&obj_a, &obj_b, &obj_c] {
+        for r in records {
+            if r.ts_ns >= lo && r.ts_ns <= hi && body_has_word(&r.body, "timeout") {
+                want.insert((r.ts_ns, r.body.clone()));
+            }
+        }
+    }
+    assert_eq!(
+        want,
+        BTreeSet::from([
+            (105, "connection timeout".to_string()),
+            (202, "gateway timeout".to_string()),
+        ]),
+        "oracle sanity"
+    );
+    assert_eq!(
+        got, want,
+        "block-range SQL scan output must equal the oracle exactly"
+    );
+}

--- a/docs/guides/caching.md
+++ b/docs/guides/caching.md
@@ -17,8 +17,16 @@ The cache stores byte ranges read from two kinds of objects:
 - **Metric segments (RSEG).** A metric query reads a segment's footer,
   then the catalog sections it needs, then only the page ranges that match
   the query. Each of these byte ranges is cached separately.
-- **Log objects (RLOG).** A log query reads a whole RLOG object at once,
-  so the cached unit is the whole object.
+- **Log objects (RLOG).** Which unit is cached depends on the object's
+  size, against `--logs-block-range-threshold` (512 KiB by default). A log
+  query reads a smaller object whole, so the cached unit is the whole
+  object. For a larger one it reads only the blocks time and predicate
+  pruning kept: a probe of the object's tail, the directory sections it
+  needs, and the candidate blocks (adjacent ones fetched together in one
+  request). Each of those is cached separately, one entry per block, so a
+  later query whose blocks partly overlap reuses what it can. Set the
+  threshold to `18446744073709551615` to read every log object whole, as
+  before this split existed.
 
 Both PromQL queries and SQL queries over the `samples` table use the
 metric path. SQL queries over the `logs` table use the log path.
@@ -56,6 +64,7 @@ attach a RAM cache. See "Known gaps" below.
 | `--cache-max-bytes <n>` | `268435456` (256 MiB) | Maximum bytes the RAM tier holds. Bounds **every** ADR-0046 cache in the process from one number: the fetcher cache and the catalog's byte cache both. Read once at startup; there is no live resize. |
 | `--cache-dir <path>` | none | Reserved for the disk tier. Setting it fails startup today (see "Known gaps"). |
 | `--disable-cache` | off | Turns **every** ADR-0046 cache off: the fetcher cache and the catalog's byte cache both. No cache is constructed at all, so query *results* are byte-for-byte the same as a build with no cache code, and the process holds no read-cache memory. This is the flag to set in a memory-constrained container. |
+| `--logs-block-range-threshold <bytes>` | `524288` (512 KiB) | Log-object size above which a `logs` query reads only the pruning-relevant blocks (a tail probe plus per-block ranges, cached per block) instead of the whole object. Set it to `18446744073709551615` to read every log object whole, the shape before this split existed; set it to `0` to use the block-range path for every object. Read once at startup. |
 
 ### Disk-tier max-age sweep
 

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -928,8 +928,13 @@ fields: `s3_requests`/`s3_bytes` on `catalog_resolve`, `segment_open`, and
 `page_fetch`; `segments_pruned` on `catalog_resolve`; `series_matched` on
 `catalog_decode`; `decompressed_bytes` on `decode`. The log-signal path
 (`LogSegmentFetcher::fetch_accounted` and the production
-`fetch_accounted_with_tenant`) carries the same `page_fetch` (recording
-its one whole-object GET, or zero on a cache hit) and `decode` span names.
+`fetch_accounted_with_tenant`) carries the same `page_fetch` and `decode`
+span names. What `page_fetch` records there depends on the object's size
+(ADR-0107): at or below the block-range threshold, its one whole-object GET,
+or zero on a cache hit; above it, the total store GETs the block-range
+sequence issued (probe, directory sections, coalesced candidate-block
+ranges) and the bytes they moved, again zero when every extent was a cache
+hit.
 
 Span fields otherwise carry only bounded values — `tenant_hash` as a hex
 string, `object_size`, matcher/series counts, and fixed-set kind strings
@@ -1309,25 +1314,43 @@ is the precondition ADR-0102 decision 1 names for it:
   `with_cache`): the scan declares `min(target_partitions, segment_count)`, the
   pre-ADR-0102 bound.
 
-The reason is the fetch unit. There is no ranged block reader on the SQL read
-path, so each partition that owns blocks in a segment fetches that segment's
-whole object. With the cache, those reads coalesce through single-flight on one
-key; without it, each is a real object-store GET, and partitions beyond the
-segment count would multiply GETs with nothing absorbing them. Note what the cap
-does and does not buy: it stops `target_partitions` from setting the multiplier,
-but below the cap a plan with `n` partitions still opens each sufficiently-blocky
-segment `n` times, and the planning prune that counts surviving blocks adds one
-more read per segment. `ravel-bench`'s `logs_scan_scaling` report measures the
-cached and un-cached request counts side by side; its figures describe that
-fixture (a `MemoryStore`, a cache sized to hold the whole dataset), not striping
-in general.
+The reason is the fetch unit. Each partition that owns blocks in a segment opens
+that segment itself, so each issues its own read sequence at that key. Which
+sequence depends on the object's size (ADR-0107,
+`--logs-block-range-threshold`, 512 KiB by default): at or below the threshold
+one whole-object GET; above it a suffix probe, one GET per directory section,
+and coalesced GETs covering only the candidate blocks skip-index pruning kept.
+With the cache, every GET of either shape is keyed by the extent it fetched and
+coalesces through single-flight — the whole object below the threshold, and the
+probe, each section, and each block above it — so `n` partitions striping one
+segment cost one request per distinct extent rather than `n` sequences. Without
+a cache each is a real object-store GET, and partitions beyond the segment count
+would multiply GETs with nothing absorbing them. Note what the cap does and does
+not buy: it stops `target_partitions` from setting the multiplier, but below the
+cap a plan with `n` partitions still opens each sufficiently-blocky segment `n`
+times, and the planning prune that counts surviving blocks adds one more read
+per segment. `ravel-bench`'s `logs_scan_scaling` report measures the cached and
+un-cached request counts side by side; its figures describe that fixture (a
+`MemoryStore`, a cache sized to hold the whole dataset), not striping in
+general. `crates/ravel-query/tests/log_block_range.rs` pins the above-threshold
+cached case exactly: on its 906,791-byte fixture, 2 partitions and 8 partitions
+striping one segment both cost 6 store GETs (one probe, four directory
+sections, one coalesced candidate run), and 8 concurrent cold partitions cost
+the same 6.
 
-The peak-memory consequence follows the same gate. Concurrently-held scan memory
-is bounded by block size times the number of partitions decoding at once, so
-only the cached configuration raises that bound above the old
+The peak-memory consequence follows the same gate, with a second term above the
+block-range threshold. Concurrently-held *decoded* memory is bounded by block
+size times the number of partitions decoding at once, so only the cached
+configuration raises that bound above the old
 `min(target_partitions, segment_count)` one — an un-cached deployment's bound is
-unchanged by ADR-0102. The per-query DataFusion pool enforces it either way:
-a partition count that would exceed the budget fails the query rather than
+unchanged by ADR-0102. Raw bytes behave differently on the two read shapes: at
+or below the threshold every partition shares one cached whole-object `Bytes`
+(a cheap clone), while above it each partition assembles its own object-sized
+buffer with only the fetched extents populated, so resident raw bytes are
+`n × object_size` even though bytes on the wire are pruning-proportional. The
+same test measures it: 8 partitions × 906,791 bytes = 7,254,328 resident bytes
+for one segment. The per-query DataFusion pool enforces the decoded bound either
+way: a partition count that would exceed the budget fails the query rather than
 spilling (ADR-0013).
 
 Two consequences an operator and a plan reader both see:
@@ -1575,9 +1598,13 @@ arrival order varies.
 ## Caching note
 
 ADR-0046 added a content-addressed RAM read-cache tier (`ravel-cache`,
-S3-FIFO eviction, single-flighted) consulted at three funnels:
-`SegmentFetcher::guarded_get`, `Catalog::guarded_get`, and
-`LogSegmentFetcher::fetch`. Cache keys are `(tenant_hash, content_hash, offset,
+S3-FIFO eviction, single-flighted) consulted at four funnels:
+`SegmentFetcher::guarded_get`, `Catalog::guarded_get`,
+`LogSegmentFetcher::fetch`, and — for an RLOG object above the block-range
+threshold — `BlockRangeFetcher` (ADR-0107), which routes its suffix probe, each
+directory section, and each candidate block through the cache on that extent's
+own key, admitting one entry per verified block and never a coalesced range.
+Cache keys are `(tenant_hash, content_hash, offset,
 len)`, so entries survive object-key churn and two writers producing
 identical bytes share one entry. Each funnel credits its own hit/miss and
 byte counters to `QueryAccounting` (ADR-0044), so a query's `EXPLAIN

--- a/services/ravel-server/src/config.rs
+++ b/services/ravel-server/src/config.rs
@@ -444,6 +444,22 @@ pub struct Cli {
     #[arg(long = "sql-parallel-final-aggregation")]
     pub sql_parallel_final_aggregation: bool,
 
+    /// Object size above which a logs scan reads only the pruning-relevant
+    /// blocks of an RLOG object (a suffix probe plus coalesced block-range GETs)
+    /// instead of one whole-object GET (ADR-0107), threaded into
+    /// `ravel_query::EngineConfig::logs_block_range_threshold` and from there
+    /// into `LogSegmentFetcher::with_block_range_threshold`.
+    ///
+    /// Defaults to [`DEFAULT_LOGS_BLOCK_RANGE_THRESHOLD`] (512 KiB), the
+    /// compiled-in crossover, so an unset flag is byte-identical to before it
+    /// existed. This is the mitigation knob for that path: set it to
+    /// `18446744073709551615` (`u64::MAX`) to read every object whole, the
+    /// pre-ADR-0107 shape, without a rollback; set it to `0` to send every
+    /// object through the block-range path. Read at startup only, like
+    /// `--disable-cache` and every other cache/read knob here.
+    #[arg(long = "logs-block-range-threshold", value_name = "BYTES", default_value_t = DEFAULT_LOGS_BLOCK_RANGE_THRESHOLD)]
+    pub logs_block_range_threshold: u64,
+
     /// Bound on concurrent in-flight segment fetches per query (ADR-0088),
     /// threaded into `ravel_query::EngineConfig::fetch_concurrency`. This is a
     /// single knob with three coupled effects, NOT decoupled by this change: it
@@ -938,6 +954,11 @@ pub struct QueryBudgets {
     /// (ADR-0094). Reaches `SqlConfig::parallel_final_aggregation`. Default
     /// `false`, so a server built without the flag is byte-identical to before.
     pub sql_parallel_final_aggregation: bool,
+    /// Object size above which a logs scan reads only the pruning-relevant RLOG
+    /// blocks instead of the whole object (ADR-0107). Reaches
+    /// `EngineConfig::logs_block_range_threshold` and from there
+    /// `LogSegmentFetcher::with_block_range_threshold`.
+    pub logs_block_range_threshold: u64,
 }
 
 impl Default for QueryBudgets {
@@ -948,6 +969,7 @@ impl Default for QueryBudgets {
             sql_max_query_bytes: DEFAULT_SQL_MAX_QUERY_BYTES,
             sql_tenant_max_bytes: DEFAULT_SQL_TENANT_MAX_BYTES,
             sql_parallel_final_aggregation: false,
+            logs_block_range_threshold: DEFAULT_LOGS_BLOCK_RANGE_THRESHOLD,
         }
     }
 }
@@ -965,10 +987,17 @@ impl QueryBudgets {
         ravel_query::EngineConfig {
             fetch_concurrency: self.fetch_concurrency,
             max_segments: self.max_segments,
+            logs_block_range_threshold: self.logs_block_range_threshold,
             ..base
         }
     }
 }
+
+/// Default `--logs-block-range-threshold`: the compiled-in ADR-0107 crossover
+/// (512 KiB), `ravel_query::DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD`. Named through
+/// that constant rather than repeated, so the flag's default cannot drift from
+/// the fetcher's own.
+pub const DEFAULT_LOGS_BLOCK_RANGE_THRESHOLD: u64 = ravel_query::DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD;
 
 /// Default `--cache-max-bytes`: generous enough to hold a working set of
 /// recently fetched segment/log byte ranges across a handful of concurrent
@@ -1634,6 +1663,7 @@ impl Cli {
             sql_max_query_bytes: self.sql_max_query_bytes,
             sql_tenant_max_bytes: self.sql_tenant_max_bytes,
             sql_parallel_final_aggregation: self.sql_parallel_final_aggregation,
+            logs_block_range_threshold: self.logs_block_range_threshold,
         }
     }
 
@@ -3665,6 +3695,50 @@ mod tests {
                 .apply_to_engine(EngineConfig::default())
                 .max_segments,
             EngineConfig::default().max_segments,
+        );
+    }
+
+    /// ADR-0107 reachability: `--logs-block-range-threshold` must reach the
+    /// `EngineConfig` `build_sql_state` reads when it builds the logs fetcher,
+    /// not stop at a parsed field. Same wiring trace as
+    /// [`fetch_concurrency_is_reachable_from_cli`]; the last hop from there is
+    /// `LogSegmentFetcher::with_block_range_threshold` in
+    /// `crate::query::build_sql_state`.
+    ///
+    /// `u64::MAX` is the value under test because it is the operator-facing
+    /// point of the flag: it turns the ADR-0107 block-range path off for every
+    /// object, which is the mitigation for a regression on that path.
+    #[test]
+    fn logs_block_range_threshold_is_reachable_from_cli() {
+        use ravel_query::EngineConfig;
+
+        assert_ne!(
+            u64::MAX,
+            ravel_query::DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
+            "the value under test must differ from the default, or an ignored flag would pass"
+        );
+
+        let cli = Cli::try_parse_from([
+            "ravel-server",
+            "--logs-block-range-threshold",
+            "18446744073709551615",
+        ])
+        .expect("flag parses");
+        let engine = cli.query_budgets().apply_to_engine(EngineConfig::default());
+        assert_eq!(
+            engine.logs_block_range_threshold,
+            u64::MAX,
+            "the logs fetcher's crossover must be the configured flag, not the compiled-in 512 KiB"
+        );
+
+        // Default path: unset flag leaves the crossover at the fetcher's own
+        // compiled-in constant.
+        let cli = Cli::try_parse_from(["ravel-server"]).expect("defaults parse");
+        assert_eq!(
+            cli.query_budgets()
+                .apply_to_engine(EngineConfig::default())
+                .logs_block_range_threshold,
+            ravel_query::DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
         );
     }
 

--- a/services/ravel-server/src/query.rs
+++ b/services/ravel-server/src/query.rs
@@ -257,7 +257,12 @@ pub fn build_sql_state(
     };
     let max_deadline = config.engine.deadline;
     let mut metrics_fetcher = SegmentFetcher::new(store.clone());
-    let mut logs_fetcher = LogSegmentFetcher::new(store.clone());
+    // ADR-0107's read-shape crossover, from `--logs-block-range-threshold` via
+    // `QueryBudgets::apply_to_engine`. This is the single wiring point for it, so
+    // an operator who sets the flag to `u64::MAX` gets whole-object logs reads
+    // (the pre-ADR-0107 shape) on every SQL logs scan this process serves.
+    let mut logs_fetcher = LogSegmentFetcher::new(store.clone())
+        .with_block_range_threshold(config.engine.logs_block_range_threshold);
     // The spans fetcher (RSPAN) reads the same object store, with the default
     // RspanConfig (ADR-0045 decision 5). It attaches no fetcher cache: unlike
     // the RSEG/RLOG fetchers it has no `with_cache` seam, and none is wired


### PR DESCRIPTION
Every RLOG logs scan issued one whole-object GET per candidate segment
regardless of how few blocks survived pruning. This adds a
BlockRangeFetcher (ADR-0107) that fetches only the blocks the skip
index already proved relevant, coalesced into range GETs, above a
512 KiB threshold. Below the threshold, or when the fetcher has no
read cache attached, the whole-object path is unchanged.

Checkpoint review of the first landing found the block-range path
never used ADR-0046's single-flight cache the way the existing
whole-object path does, which quietly broke the premise epic #361's
multi-partition fan-out gate depends on: above the new threshold, N
partitions striping one segment issued N+1 independent fetch
sequences instead of coalescing onto one. A follow-up fix
single-flights the block-range path's cache lookups (mirroring the
existing whole-object idiom), makes the etag-establishing probe
cache-checked too, runs coalesced GETs concurrently instead of
serially, reorders the coverage-based crossover check to avoid an
unnecessary whole-object fallback on wide-time-range queries, and
adds a --logs-block-range-threshold config flag.

A second checkpoint review found both corrupt-hit tests added by the
single-flight fix were vacuous against the block-level cache-hit gate
they claimed to prove: one now trips on the corrupted probe's own
decode before reaching any block, the other decodes through
ravel-logseg's reader, whose own crc check fires first and masks the
fetcher's gate. Fixed by calling the fetcher directly rather than
through the decoding entry point, verified failing with the gate
removed and passing with it restored.

Fixes: #564
Refs: #363
