### PR TITLE
Enforce four CLAUDE.md rules with a PreToolUse hook

### DIFF
--- a/.claude/guards/pretooluse.mjs
+++ b/.claude/guards/pretooluse.mjs
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+// PreToolUse guard: refuses tool calls that CLAUDE.md forbids, so the rule
+// does not depend on a session choosing to remember it.
+//
+// Contract: reads the hook payload on stdin, prints a PreToolUse decision on
+// stdout, exits 0. Any parse or filesystem error means allow: a guard that
+// blocks on its own bug would kill unattended fleet tasks.
+
+import { readFileSync, existsSync, statSync } from "node:fs";
+import { dirname, resolve, sep } from "node:path";
+
+const WAKEUP_FLOOR_SECONDS = 900;
+
+function allow() {
+  process.stdout.write("{}");
+  process.exit(0);
+}
+
+function deny(reason) {
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: reason,
+      },
+    }),
+  );
+  process.exit(0);
+}
+
+function readStdin() {
+  try {
+    return JSON.parse(readFileSync(0, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+// --- Bash rules ---------------------------------------------------------
+
+// Commands whose exit code is a gate. Matched only in command position, so
+// a gate name quoted inside a grep pattern is not a gate.
+const GATE_HEAD = /^(cargo\s+(clippy|test|nextest|fmt|build|check)|(\.\/)?scripts\/(gates|affected-tests|verify-dispatch-gates)\.sh)\b/;
+// Things that may legitimately precede a gate on the same command line.
+const HARMLESS_PREFIX = /^(\s*(cd\s+[^&;|]+&&|[A-Za-z_][A-Za-z0-9_]*=[^\s]+|time|nice(\s+-n\s*-?\d+)?|env|bash|sh|zsh)\s*)+/;
+const MASKING_FILTER = /^\s*(tail|head|grep|rg|sed)\b/;
+const MASKING_ECHO = /&&\s*echo\b/;
+
+// zsh marks these read-only; assigning to one kills the enclosing loop with
+// no output that looks like a failure.
+const RESERVED_ASSIGN = /(^|[;&|(]|\bdo\b|\bthen\b|\blocal\b|\bexport\b)\s*(status|path|argv|PWD)=/;
+
+function splitStatements(command) {
+  // Rough statement split. Over-splitting only weakens a rule; it never
+  // invents a violation, because each rule needs its whole pattern in one
+  // fragment.
+  return command.split(/\n|;/);
+}
+
+// Split on a real pipe, leaving `||` alone.
+function splitPipeline(stmt) {
+  return stmt.split(/\|(?!\|)/);
+}
+
+function startsWithGate(fragment) {
+  return GATE_HEAD.test(fragment.replace(HARMLESS_PREFIX, ""));
+}
+
+function checkBash(command) {
+  if (typeof command !== "string" || command === "") return;
+
+  for (const raw of splitStatements(command)) {
+    const stmt = raw.trim();
+    if (stmt === "") continue;
+
+    const stages = splitPipeline(stmt);
+    if (stages.length > 1 && startsWithGate(stages[0].trim())) {
+      const filtered = stages.slice(1).some((s) => MASKING_FILTER.test(s));
+      if (filtered) {
+        deny(
+          "A gate piped into tail/head/grep/rg/sed reports the pipe's exit " +
+            "code, not the gate's. Run the gate on its own and read its " +
+            "output, or write the output to a file and grep the file " +
+            "afterwards.",
+        );
+      }
+    }
+
+    if (startsWithGate(stmt) && MASKING_ECHO.test(stmt)) {
+      deny(
+        "`&& echo MARKER` after a gate masks the gate's exit code. Run the " +
+          "gate alone and check its status directly.",
+      );
+    }
+
+    // A heredoc body is not shell, and scratchpad heredocs are allowed.
+    if (!command.includes("<<") && RESERVED_ASSIGN.test(stmt)) {
+      deny(
+        "zsh reserves status, path, argv and PWD. Assigning to one fails " +
+          "with `read-only variable` and silently kills the enclosing " +
+          "loop. Use a different name (rc, target_path, args).",
+      );
+    }
+  }
+}
+
+// --- Edit/Write rules ---------------------------------------------------
+
+function gitDirFor(startPath) {
+  let dir = existsSync(startPath) && statSync(startPath).isDirectory()
+    ? startPath
+    : dirname(startPath);
+  for (let i = 0; i < 64; i += 1) {
+    const candidate = resolve(dir, ".git");
+    if (existsSync(candidate)) return { repoRoot: dir, gitPath: candidate };
+    const parent = dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+  return null;
+}
+
+// A dispatched fleet clone IS the isolated workspace, and CLAUDE.md exempts
+// it. Two independent signals, because a false block there loses a task:
+// the clone lives under the fleet work root, and it hosts no linked
+// worktrees of its own.
+function isExemptCheckout(repoRoot, gitPath) {
+  if (process.env.RAVEL_GUARD_ALLOW_PRIMARY === "1") return true;
+  const normalized = repoRoot.split(sep).join("/");
+  if (normalized.includes("/fleet/work/") || normalized.includes("/var/lib/fleet")) {
+    return true;
+  }
+  return !existsSync(resolve(gitPath, "worktrees"));
+}
+
+function checkFileWrite(filePath) {
+  if (typeof filePath !== "string" || filePath === "") return;
+  const found = gitDirFor(resolve(filePath));
+  if (!found) return; // outside any repo: scratchpad, /tmp, home dotfiles
+  const { repoRoot, gitPath } = found;
+
+  // A linked worktree records .git as a file pointing at the real git dir.
+  if (!statSync(gitPath).isDirectory()) return;
+
+  if (isExemptCheckout(repoRoot, gitPath)) return;
+
+  deny(
+    `${repoRoot} is the primary checkout, and another session can hold ` +
+      "in-flight state there. Create a worktree first " +
+      "(`git worktree add -b <branch> ../<name> origin/main`) and edit " +
+      "inside it. This rule has no doc-only or one-file exception.",
+  );
+}
+
+// --- ScheduleWakeup rule ------------------------------------------------
+
+function checkWakeup(input) {
+  if (input?.stop === true) return;
+  const delay = input?.delaySeconds;
+  if (typeof delay !== "number") return;
+  if (delay < WAKEUP_FLOOR_SECONDS) {
+    deny(
+      `delaySeconds ${delay} is below the ${WAKEUP_FLOOR_SECONDS}s floor. ` +
+        "Each wakeup re-reads the whole session context, and 56% of them " +
+        "in the last review found nothing. Arm a Monitor on the event " +
+        "instead, and keep the wakeup as a long fallback.",
+    );
+  }
+}
+
+// --- entry --------------------------------------------------------------
+
+try {
+  const payload = readStdin();
+  if (!payload) allow();
+
+  const tool = payload.tool_name;
+  const input = payload.tool_input ?? {};
+
+  if (tool === "Bash") checkBash(input.command);
+  else if (tool === "Write" || tool === "Edit" || tool === "MultiEdit") {
+    checkFileWrite(input.file_path);
+  } else if (tool === "ScheduleWakeup") checkWakeup(input);
+} catch {
+  // fall through to allow
+}
+
+allow();

--- a/.claude/guards/pretooluse.test.sh
+++ b/.claude/guards/pretooluse.test.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Cases the PreToolUse guard must get right. Run: bash .claude/guards/pretooluse.test.sh
+set -uo pipefail
+
+GUARD="$(cd "$(dirname "$0")" && pwd)/pretooluse.mjs"
+pass=0
+fail=0
+
+# want: allow | deny
+check() {
+  local want="$1" label="$2" payload="$3" out decision
+  out=$(printf '%s' "$payload" | node "$GUARD" 2>&1) || {
+    printf 'FAIL  %-52s guard exited non-zero: %s\n' "$label" "$out"
+    fail=$((fail + 1))
+    return
+  }
+  if printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+    decision=deny
+  else
+    decision=allow
+  fi
+  if [ "$decision" = "$want" ]; then
+    pass=$((pass + 1))
+  else
+    printf 'FAIL  %-52s want %s, got %s\n' "$label" "$want" "$decision"
+    fail=$((fail + 1))
+  fi
+}
+
+bash_payload() {
+  node -e 'process.stdout.write(JSON.stringify({tool_name:"Bash",tool_input:{command:process.argv[1]}}))' "$1"
+}
+
+# --- gate masking -------------------------------------------------------
+check deny  "cargo test piped to tail"        "$(bash_payload 'cargo test -p ravel-sql | tail -20')"
+check deny  "gates.sh piped to grep"          "$(bash_payload 'scripts/gates.sh | grep -E "All gates"')"
+check deny  "clippy with cd prefix, to head"  "$(bash_payload 'cd /repo && cargo clippy --workspace | head -40')"
+check deny  "nextest && echo MARKER"          "$(bash_payload 'cargo nextest run && echo DONE')"
+check allow "cargo test alone"                "$(bash_payload 'cargo test -p ravel-sql')"
+check allow "cargo test redirected to a file" "$(bash_payload 'cargo test -p ravel-sql > /tmp/out.txt 2>&1')"
+check allow "grep for the words cargo test"   "$(bash_payload 'grep -rn "cargo test" docs/ | head -5')"
+check allow "cargo metadata into jq"          "$(bash_payload 'cargo metadata --format-version 1 | jq -r .packages')"
+check allow "git log into head"               "$(bash_payload 'git log --oneline | head -5')"
+check allow "grepping a saved gate log"       "$(bash_payload 'grep -c FAILED /tmp/gate.log')"
+
+# --- zsh reserved names -------------------------------------------------
+check deny  "bare status="                    "$(bash_payload 'status=0')"
+check deny  "local status="                   "$(bash_payload 'run_it || local status=$?')"
+check deny  "path= after semicolon"           "$(bash_payload 'echo hi; path=/tmp')"
+check allow "rc= is fine"                     "$(bash_payload 'run_it || rc=$?')"
+check allow "PATH= is not path="              "$(bash_payload 'export PATH=/usr/bin:$PATH')"
+check allow "--status= flag"                  "$(bash_payload 'gh pr list --status=open')"
+check allow "status inside a jq filter"       "$(bash_payload "jq -r 'select(.status==\"done\")' t.json")"
+check allow "python heredoc assigning path"   "$(bash_payload 'python3 - <<PY
+path="/tmp/x"
+print(path)
+PY')"
+
+# --- ScheduleWakeup -----------------------------------------------------
+wakeup() {
+  node -e 'process.stdout.write(JSON.stringify({tool_name:"ScheduleWakeup",tool_input:JSON.parse(process.argv[1])}))' "$1"
+}
+check deny  "wakeup 300s"                     "$(wakeup '{"delaySeconds":300,"noop":true}')"
+check deny  "wakeup 600s"                     "$(wakeup '{"delaySeconds":600,"noop":false}')"
+check allow "wakeup 900s"                     "$(wakeup '{"delaySeconds":900,"noop":true}')"
+check allow "wakeup 1800s"                    "$(wakeup '{"delaySeconds":1800,"noop":true}')"
+check allow "wakeup stop"                     "$(wakeup '{"stop":true}')"
+
+# --- Edit/Write worktree isolation --------------------------------------
+write_to() {
+  node -e 'process.stdout.write(JSON.stringify({tool_name:"Edit",tool_input:{file_path:process.argv[1]}}))' "$1"
+}
+tmproot=$(mktemp -d)
+mkdir -p "$tmproot/primary/.git/worktrees/wt" "$tmproot/primary/src"
+: > "$tmproot/primary/src/lib.rs"
+mkdir -p "$tmproot/linked/src"
+printf 'gitdir: %s/primary/.git/worktrees/wt\n' "$tmproot" > "$tmproot/linked/.git"
+: > "$tmproot/linked/src/lib.rs"
+mkdir -p "$tmproot/clone/.git" "$tmproot/clone/src"
+: > "$tmproot/clone/src/lib.rs"
+mkdir -p "$tmproot/scratch"
+: > "$tmproot/scratch/notes.md"
+
+check deny  "edit inside the primary checkout" "$(write_to "$tmproot/primary/src/lib.rs")"
+check allow "edit inside a linked worktree"    "$(write_to "$tmproot/linked/src/lib.rs")"
+check allow "edit in a clone with no worktrees" "$(write_to "$tmproot/clone/src/lib.rs")"
+check allow "edit outside any repo"            "$(write_to "$tmproot/scratch/notes.md")"
+# Subshell so the escape hatch cannot leak into later cases; the subshell's
+# own counters are lost, so score it here.
+if (
+  export RAVEL_GUARD_ALLOW_PRIMARY=1
+  printf '%s' "$(write_to "$tmproot/primary/src/lib.rs")" | node "$GUARD" |
+    grep -q '"permissionDecision":"deny"'
+); then
+  printf 'FAIL  %-52s want allow, got deny\n' "escape hatch env set"
+  fail=$((fail + 1))
+else
+  pass=$((pass + 1))
+fi
+rm -rf "$tmproot"
+
+# --- malformed input must never block -----------------------------------
+check allow "empty stdin"                      ""
+check allow "not json"                         "wat"
+check allow "unknown tool"                     '{"tool_name":"Read","tool_input":{"file_path":"/etc/hosts"}}'
+check allow "bash with no command"             '{"tool_name":"Bash","tool_input":{}}'
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,5 +6,20 @@
   "skillOverrides": {
     "claude-in-chrome": "off",
     "dataviz": "off"
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash|Edit|Write|MultiEdit|ScheduleWakeup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PROJECT_DIR:-.}/.claude/guards/pretooluse.mjs\"",
+            "timeout": 10,
+            "statusMessage": "Checking guards"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.claude/skills/deliver-epic/SKILL.md
+++ b/.claude/skills/deliver-epic/SKILL.md
@@ -19,6 +19,7 @@ stage.
 
 | Stage | Output | Gate |
 |---|---|---|
+| 0 Measure | Profiled baseline on the real workload | a number, not a hypothesis |
 | 1 Design | ADR + epic issue | HUMAN APPROVAL (only one) |
 | 2 Decompose | Task table, DAG, waves, sub-issues | waves have zero file overlap |
 | 3 Execute | Fleet dispatch per wave, ledger entries | all tasks terminal |
@@ -28,36 +29,49 @@ stage.
 Stages 3-5 loop per wave. Wave N+1 is not dispatched until wave N has
 landed on main.
 
+## Stage 0 - Measure
+
+A performance epic aimed by a report instead of a profile spends its
+whole budget on the wrong half of the system. Before Stage 1:
+
+1. Run the real target workload end to end and record where the time
+   goes, per phase. Use the profile-hotspot skill; the CLI and bench
+   crates already carry stage-timing and flamegraph lanes.
+2. Write the numbers into the epic issue body: total, the phase that
+   dominates, and the measurement command so anyone can re-run it.
+3. The epic's Decision must name the measured bottleneck it attacks and
+   the number it moves. "The audit suggests X is slow" is not a
+   bottleneck; a stage timing is.
+
+Skip Stage 0 only for an epic with no performance claim at all. If you
+skip it, say so in the epic body and say why.
+
 ## Stage 1 - Design
 
 1. Research against the actual codebase: Explore subagents over the
    crates the intent touches, plus their normative docs from the
    CLAUDE.md doc map. Never read vendored dependency sources.
-2. Claim the ADR number the moment you pick it, before writing the full
-   ADR. Commit a one-line stub at `docs/adrs/NNNN-<slug>.md` (next free
-   number) containing just a title line and `Status: claimed`, and land
-   it on main through its own small PR right away. The reservation is
-   then visible on main to every other in-flight epic, so two parallel
-   epics cannot pick the same number. A number reserved only locally
-   collides: nothing hits main until after the approval gate, and two
-   parallel epics pick the same next-free number. Then write the full
-   ADR (Context, Decision, Rejected alternatives, each with the
-   concrete reason it lost, Consequences) into the same path,
-   overwriting the stub's content. Include at least one diagram
-   (Mermaid: component or data-flow; trust-boundary for anything
-   security-shaped). The approval gate is the most expensive place in
-   the pipeline to loop back, and a prose-only ADR has cost an extra
-   approval round trip there when the approver sent it back for
-   diagrams. If any frozen format is touched,
-   follow the format-change skill before writing the full ADR.
-3. Open the epic issue:
+2. Open the epic issue FIRST:
    `gh issue create --title "Epic: <feature>" --body-file <body>`
-   Body: intent paragraph, ADR path, empty `## Tasks` checklist, empty
-   `## Ledger` section.
+   Body: intent paragraph, Stage 0 numbers, empty `## Tasks` checklist,
+   empty `## Ledger` section. Then assign it to yourself
+   (`gh issue edit <n> --add-assignee @me`). The assignee is the claim:
+   ownership that lives only in a session's head collides the moment a
+   second session picks "the next obvious thing".
+3. **The ADR number is the epic issue number.** GitHub allocates issue
+   numbers atomically, so two parallel epics cannot collide, and no
+   reservation step is needed. Write the full ADR at
+   `docs/adrs/NNNN-<slug>.md` where NNNN is the zero-padded issue
+   number. Sections: Context, Decision, Rejected alternatives (each with
+   the concrete reason it lost), Consequences. Include at least one
+   diagram (Mermaid: component or data-flow; trust-boundary for anything
+   security-shaped) - a prose-only ADR has cost an extra approval round
+   trip. If any frozen format is touched, follow the format-change skill
+   before writing the full ADR.
 4. STOP. Present ADR summary, rejected alternatives, and issue number.
-   The stub from step 2 is already on main (that only reserves the
-   number); do not commit the full ADR content yet. This is the only
-   mandatory human gate; on approval, commit the full ADR over the stub
+   Nothing is committed yet: there is no stub to land, because the issue
+   number already reserves the ADR number. This is the only mandatory
+   human gate; on approval, commit the ADR
    (`docs: add ADR-NNNN <title>`, trailer `Refs: #<epic>`), push, and
    proceed without further confirmation.
 

--- a/.claude/skills/fleet-task-spec/SKILL.md
+++ b/.claude/skills/fleet-task-spec/SKILL.md
@@ -30,6 +30,8 @@ just the unattended one.
 ## Template
 
 ```
+EXPECTS_REF: yes
+
 HARNESS REQUIREMENT (overrides CLAUDE.md's workspace-isolation section for
 you specifically -- you are a fleet executor, not a local subagent sharing
 someone else's session tree): commit directly on this dispatched checkout's
@@ -106,6 +108,26 @@ commit:
   flipped line in your report. A test that cannot fail proves nothing.
 - **Stray files**: nothing staged that the deliverables do not name
   (scratch scripts, logs, `__pycache__/`, editor droppings).
+
+## Commit before the slow gates, not after
+
+A task is killed mid-run more often than it fails: over one four-day
+window, 27 of 165 dispatched tasks died, and 13 of those were account
+rate limits that kill the agent at provisioning or mid-stream with no
+warning and no result ref. Only committed work survives. So the spec
+orders the work commit-first:
+
+1. Format in place, then make the change compile and pass the scoped
+   tests.
+2. `git commit -s` the working state.
+3. Run the full gate list. Amend or add a fixup commit if a gate fails.
+
+A kill during step 3 then costs a re-run of the gates, not a re-run of
+the whole task. Two tasks in that window were lost the other way round.
+
+Never tell an executor to start a long gate in the background and wait
+for a notification: the task ends when the agent's turn ends, and a task
+that ended waiting for a background test run pushed nothing.
 
 ## Executor test scope
 
@@ -245,9 +267,20 @@ Record the returned task_id, arm the watch command from the dispatch
 response as a persistent Monitor, and merge with the merge-fleet-result
 skill when it lands. `fleet_status` needs the full task UUID; an 8-char
 short form returns "not found". Result branches appear at
-refs/heads/task/<task-id>/result; a done status with no result ref means
-the agent never committed, and the workdir is already gone. Re-dispatch;
-do not try to recover.
+refs/heads/task/<task-id>/result.
+
+**Every spec declares, in its first line, whether it produces a branch:**
+`EXPECTS_REF: yes` for an implementation task, `EXPECTS_REF: no` for a
+read-only review, audit, or research task. Without that declaration a
+missing result ref is ambiguous, and the ambiguity is not rare: over one
+four-day window, 30 of the 33 no-ref tasks were reviews that produce no
+branch by design, so a blanket "no ref means lost" rule generates 30
+false alarms and trains the orchestrator to ignore the real ones. With
+the declaration:
+
+- `EXPECTS_REF: yes` and no ref = the agent never committed and the
+  workdir is gone. Re-dispatch; do not try to recover.
+- `EXPECTS_REF: no` and no ref = expected. The deliverable is the report.
 
 Do not trust `fleet_status`'s text at face value: it has printed a
 `result at refs/heads/task/<id>/result` line even when that ref was never

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,6 +257,17 @@ Fast, dependency-free checks that fail closed BEFORE a known-expensive
 mistake. Each encodes a failure class that recurs; run the relevant one
 as a precondition, not after the damage.
 
+Four of these no longer depend on being remembered.
+`.claude/guards/pretooluse.mjs` runs as a PreToolUse hook and refuses the
+tool call outright: a gate piped into `tail`/`head`/`grep`/`rg`/`sed` or
+followed by `&& echo`, an assignment to zsh's reserved `status`/`path`/
+`argv`/`PWD`, a `ScheduleWakeup` under 900 s, and an `Edit`/`Write`
+inside the primary checkout. It fails open on any internal error, and it
+exempts a dispatched fleet clone (which is itself the isolated
+workspace). `RAVEL_GUARD_ALLOW_PRIMARY=1` is the escape hatch for the
+last rule. Its cases live in `.claude/guards/pretooluse.test.sh`; add one
+there before changing a rule.
+
 - `scripts/guards/assert-worktree.sh`: exits non-zero if the cwd is the
   PRIMARY checkout rather than a linked worktree. Run it before the first
   edit/commit of any isolated unit of work. A concurrent session can hold

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -2,6 +2,12 @@
 
 One decision per document. Status: Proposed | Accepted | Superseded.
 
+Numbering: ADR 0001 through 0109 are sequential. From ADR 0110 onward the
+number is the GitHub issue number of the epic that produced it, so the
+sequence jumps. GitHub allocates issue numbers atomically, which removes
+the collision that sequential numbering had between parallel sessions and
+the reservation commit that used to work around it.
+
 | # | Title | Status |
 |---|-------|--------|
 | [0001](0001-object-native-l0.md) | Object-native L0, no local WAL | Accepted |


### PR DESCRIPTION
Turns four recurring CLAUDE.md rules into a PreToolUse hook that refuses
the tool call, and changes three process rules that a hook cannot reach.

A review of the last four days of sessions found that every guard in this
repo requires a session to choose to invoke it. `.claude/settings.json`
had PostToolUse, SessionStart, Stop and UserPromptSubmit hooks and no
PreToolUse hook, so nothing in the stack could refuse a call.

## What the hook blocks

- A gate (`cargo test|clippy|nextest|fmt|build|check`, `gates.sh`,
  `affected-tests.sh`, `verify-dispatch-gates.sh`) piped into
  `tail`/`head`/`grep`/`rg`/`sed`, or followed by `&& echo`. The
  pipeline's exit code is not the gate's; this shape has reported a
  failing test as green.
- An assignment to `status`, `path`, `argv` or `PWD`. zsh marks them
  read-only and the failure kills the enclosing loop silently.
- A `ScheduleWakeup` under 900 seconds. 148 of 262 wakeups in the review
  window were no-ops, each paying a full context re-read.
- An `Edit`/`Write` inside the primary checkout, where a concurrent
  session can hold in-flight state.

It fails open on any internal error, and exempts a dispatched fleet clone
(which is itself the isolated workspace) by two independent signals.
`RAVEL_GUARD_ALLOW_PRIMARY=1` overrides the last rule.
`.claude/guards/pretooluse.test.sh` has 32 cases, weighted toward the
false positives that would make the guard unusable.

## Process changes

- `deliver-epic` gains Stage 0: a profiled baseline on the real workload
  before any ADR. The last performance program got its first per-stage
  timing on day 5, and it contradicted the audit the work had been aimed
  by.
- The ADR number is now the epic issue number. GitHub allocates issue
  numbers atomically, which removes both the collision that sequential
  numbering had between parallel sessions and the reservation PR that
  worked around it. ADRs 0001-0109 are unchanged; the sequence jumps from
  0110.
- `fleet-task-spec` requires an `EXPECTS_REF` declaration, so a missing
  result ref is only an alarm when a branch was expected, and orders the
  executor's work commit-first so a mid-run kill costs a gate re-run
  rather than the whole task.

## Verification

`bash .claude/guards/pretooluse.test.sh` — 32 passed. Mutation-checked:
lowering the wakeup floor to 1 makes two cases fail, so the suite is not
vacuous. No Rust files touched; `cargo fmt --all --check` is clean.
