### PR TITLE
feat(ravel-query): add page-level decode accounting for logs scans

### DIFF
--- a/crates/ravel-logseg/src/block.rs
+++ b/crates/ravel-logseg/src/block.rs
@@ -1297,9 +1297,6 @@ mod tests {
         assert!(all.str_col_fused(COL_BODY).is_some());
     }
 
-    /// A filter never weakens the integrity checks: the block crc still covers
-    /// the whole block, so a corrupted byte inside a *skipped* column's page is
-    /// still caught.
     /// `page_bytes_fetched`/`page_bytes_decoded` split each block's page bytes
     /// by the column filter (ADR-0107 decision 4). Every dynamic column here is
     /// present in every row, so each maps to exactly one page and the byte
@@ -1404,6 +1401,9 @@ mod tests {
         );
     }
 
+    /// A filter never weakens the integrity checks: the block crc still covers
+    /// the whole block, so a corrupted byte inside a *skipped* column's page is
+    /// still caught.
     #[test]
     fn column_filter_still_verifies_the_whole_block_crc() {
         let plans = vec![ColumnPlan {

--- a/crates/ravel-logseg/src/block.rs
+++ b/crates/ravel-logseg/src/block.rs
@@ -512,6 +512,8 @@ pub struct DecodedBlock {
     attrs_raw_page: bool,
     pages_decoded: usize,
     pages_skipped: usize,
+    page_bytes_fetched: u64,
+    page_bytes_decoded: u64,
 }
 
 impl DecodedBlock {
@@ -530,6 +532,24 @@ impl DecodedBlock {
     /// projection reached the page level rather than being applied after decode.
     pub fn pages_skipped(&self) -> usize {
         self.pages_skipped
+    }
+
+    /// Stored bytes of every page present in this block, regardless of whether
+    /// the column filter kept it: the "fetched" side of ADR-0107 decision 4's
+    /// decode-time column-filtering measurement. Summed from each
+    /// [`PageDesc::len`], so it counts stored (post-compression) bytes, the same
+    /// units the block's payload occupies -- decode-time accounting, not wire
+    /// bytes.
+    pub fn page_bytes_fetched(&self) -> u64 {
+        self.page_bytes_fetched
+    }
+
+    /// Stored bytes of the pages this decode actually decompressed and decoded,
+    /// i.e. only the columns the filter kept: the "decoded" side of the same
+    /// measurement. Equal to [`Self::page_bytes_fetched`] for an all-columns
+    /// decode; strictly less whenever a projection skipped any present page.
+    pub fn page_bytes_decoded(&self) -> u64 {
+        self.page_bytes_decoded
     }
 
     /// Whether this block carries any page for the `attrs_raw` overflow column.
@@ -806,6 +826,11 @@ pub fn read_block_columns(
     let mut page_bytes: Vec<Option<Vec<u8>>> = Vec::with_capacity(descs.len());
     let mut pages_decoded = 0usize;
     let mut pages_skipped = 0usize;
+    // "Fetched" sums every present page's stored length; "decoded" sums only the
+    // pages the filter kept. Their gap is the column-filtering waste (ADR-0107
+    // decision 4). Stored (post-compression) bytes, matching `PageDesc::len`.
+    let mut page_bytes_fetched = 0u64;
+    let mut page_bytes_decoded = 0u64;
     for d in &descs {
         let len = usize::try_from(d.len)
             .map_err(|_| LogSegError::Corrupted("page len out of range".into()))?;
@@ -815,9 +840,11 @@ pub fn read_block_columns(
         let stored = bytes
             .get(pos..end)
             .ok_or_else(|| LogSegError::Corrupted("page range out of bounds".into()))?;
+        page_bytes_fetched = page_bytes_fetched.saturating_add(d.len);
         if wanted(d.column_id) {
             page_bytes.push(Some(read_page(stored, d, max_uncomp)?));
             pages_decoded += 1;
+            page_bytes_decoded = page_bytes_decoded.saturating_add(d.len);
         } else {
             page_bytes.push(None);
             pages_skipped += 1;
@@ -857,6 +884,8 @@ pub fn read_block_columns(
         attrs_raw_page: descs.iter().any(|d| d.column_id == COL_ATTRS_RAW),
         pages_decoded,
         pages_skipped,
+        page_bytes_fetched,
+        page_bytes_decoded,
     };
 
     for column_id in order {
@@ -1271,6 +1300,110 @@ mod tests {
     /// A filter never weakens the integrity checks: the block crc still covers
     /// the whole block, so a corrupted byte inside a *skipped* column's page is
     /// still caught.
+    /// `page_bytes_fetched`/`page_bytes_decoded` split each block's page bytes
+    /// by the column filter (ADR-0107 decision 4). Every dynamic column here is
+    /// present in every row, so each maps to exactly one page and the byte
+    /// totals are the sums of those pages' stored lengths -- pinned exactly by
+    /// decomposition, not by inequality: fetched is the sum over every present
+    /// column, decoded is the sum over only the kept columns.
+    #[test]
+    fn page_byte_accounting_splits_fetched_and_decoded_by_filter() {
+        let plans: Vec<ColumnPlan> = (10..15)
+            .map(|column_id| ColumnPlan {
+                column_id,
+                ty: FieldType::Str,
+            })
+            .collect();
+        let mut rows = Vec::new();
+        for i in 0..64i64 {
+            let mut r = row(0, 1000 + i);
+            for p in &plans {
+                r.columns.push((
+                    p.column_id,
+                    ColumnValue::Str(format!("c{}r{i}", p.column_id).into_bytes()),
+                ));
+            }
+            rows.push(r);
+        }
+        let out = write_block(&rows, &plans, 3).expect("write");
+
+        // Single-column decode of one raw column id: its one page's stored bytes.
+        // `read_block_columns` takes raw ids and adds nothing implicit, so this
+        // isolates exactly that column's page (present in every row => no
+        // presence bitmap, one page per column).
+        let single = |cid: u32| {
+            let keep: HashSet<u32> = HashSet::from([cid]);
+            read_block_columns(&out.bytes, out.crc32c, &plans, 1 << 30, Some(&keep))
+                .expect("read")
+                .page_bytes_decoded()
+        };
+
+        let all = read_block(&out.bytes, out.crc32c, &plans, 1 << 30).expect("read all");
+        let fetched = all.page_bytes_fetched();
+        assert!(fetched > 0);
+        assert_eq!(
+            all.page_bytes_decoded(),
+            fetched,
+            "an all-columns decode decodes every fetched page byte"
+        );
+
+        // Fetched is the exact sum over every present column's page bytes: the
+        // seven always-present fixed columns plus the five dynamic ones.
+        let present: [u32; 12] = [
+            COL_TS,
+            COL_OBSERVED_TS,
+            COL_STREAM_REF,
+            COL_SEVERITY_NUM,
+            COL_FLAGS,
+            COL_SEVERITY_TEXT,
+            COL_BODY,
+            10,
+            11,
+            12,
+            13,
+            14,
+        ];
+        let fetched_oracle: u64 = present.iter().map(|&c| single(c)).sum();
+        assert_eq!(
+            fetched, fetched_oracle,
+            "fetched bytes are the sum of every present column's page bytes"
+        );
+
+        // A strict projection: decoded is exactly the kept columns' page bytes,
+        // fetched is unchanged, and the split is exact (decoded + skipped ==
+        // fetched).
+        let keep: HashSet<u32> = HashSet::from([COL_TS, 11, 13]);
+        let projected =
+            read_block_columns(&out.bytes, out.crc32c, &plans, 1 << 30, Some(&keep)).expect("read");
+        assert_eq!(
+            projected.page_bytes_fetched(),
+            fetched,
+            "fetched is filter-independent: every present page counts"
+        );
+        let kept_oracle: u64 = single(COL_TS) + single(11) + single(13);
+        assert_eq!(
+            projected.page_bytes_decoded(),
+            kept_oracle,
+            "decoded is exactly the kept columns' page bytes"
+        );
+        assert!(
+            projected.page_bytes_decoded() < fetched,
+            "a strict projection decodes strictly fewer bytes than are present: {} < {}",
+            projected.page_bytes_decoded(),
+            fetched
+        );
+        let skipped_bytes = fetched - projected.page_bytes_decoded();
+        let skipped_oracle: u64 = present
+            .iter()
+            .filter(|c| !keep.contains(c))
+            .map(|&c| single(c))
+            .sum();
+        assert_eq!(
+            skipped_bytes, skipped_oracle,
+            "skipped bytes are exactly the excluded columns' page bytes"
+        );
+    }
+
     #[test]
     fn column_filter_still_verifies_the_whole_block_crc() {
         let plans = vec![ColumnPlan {

--- a/crates/ravel-logseg/src/reader.rs
+++ b/crates/ravel-logseg/src/reader.rs
@@ -55,6 +55,15 @@ pub struct ScanStats {
     /// their column. Zero for an all-columns scan; the observable proof that
     /// column projection reached the page level (ADR-0087 decision 3).
     pub pages_skipped: u64,
+    /// Stored bytes of pages present in the blocks this scan decoded,
+    /// regardless of the [`ColumnSelection`]. A decode-time column-filtering
+    /// measurement, distinct from any wire-byte count. Grows as blocks are
+    /// decoded (ADR-0107 decision 4).
+    pub page_bytes_fetched: u64,
+    /// Stored bytes of the pages this scan actually decoded after column
+    /// filtering. Equal to `page_bytes_fetched` for an all-columns scan; the
+    /// gap to it is the column-filtering waste (ADR-0107 decision 4).
+    pub page_bytes_decoded: u64,
 }
 
 /// An opened RLOG object ready to scan.
@@ -825,6 +834,14 @@ impl BlockScan {
         self.stats.blocks_scanned += 1;
         self.stats.pages_decoded += decoded.pages_decoded() as u64;
         self.stats.pages_skipped += decoded.pages_skipped() as u64;
+        self.stats.page_bytes_fetched = self
+            .stats
+            .page_bytes_fetched
+            .saturating_add(decoded.page_bytes_fetched());
+        self.stats.page_bytes_decoded = self
+            .stats
+            .page_bytes_decoded
+            .saturating_add(decoded.page_bytes_decoded());
 
         for row in 0..decoded.record_count() {
             if eval(

--- a/crates/ravel-query/src/distrib/codec.rs
+++ b/crates/ravel-query/src/distrib/codec.rs
@@ -1426,6 +1426,15 @@ pub fn decode_accounting(snap: pb::QueryAccountingSnapshot) -> QueryAccountingSn
         segments_pruned: snap.segments_pruned,
         series_matched: snap.series_matched,
         bytes_reused: snap.bytes_reused,
+        // `page_bytes_fetched`/`page_bytes_decoded` (ADR-0107 decision 4) are
+        // process-local decode-time accounting and are NOT carried on this wire
+        // form: `pb::QueryAccountingSnapshot` is a frozen proto schema, and
+        // adding a field to it is an ADR-gated change out of this counter's
+        // scope. The ADR-0071 fan-out coordinator therefore does not aggregate a
+        // remote worker's page-byte totals; single-process queries account them
+        // in full. Decoded back as zero below.
+        page_bytes_fetched: 0,
+        page_bytes_decoded: 0,
         peak_intermediate_bytes: snap.peak_intermediate_bytes,
     }
 }
@@ -2965,9 +2974,29 @@ mod tests {
             segments_pruned: 64,
             series_matched: 128,
             bytes_reused: 256,
+            // Non-zero on purpose: this pair is process-local decode-time
+            // accounting (ADR-0107 decision 4) and is deliberately NOT carried
+            // on the frozen wire proto, so it must decode back as zero, unlike
+            // every other field which round-trips.
+            page_bytes_fetched: 900,
+            page_bytes_decoded: 300,
             peak_intermediate_bytes: 512,
         };
-        assert_eq!(decode_accounting(encode_accounting(&snap)), snap);
+        let round = decode_accounting(encode_accounting(&snap));
+        assert_eq!(
+            round.page_bytes_fetched, 0,
+            "decode-time page bytes are not on the wire proto"
+        );
+        assert_eq!(round.page_bytes_decoded, 0);
+        assert_eq!(
+            round,
+            QueryAccountingSnapshot {
+                page_bytes_fetched: 0,
+                page_bytes_decoded: 0,
+                ..snap
+            },
+            "every other field round-trips unchanged"
+        );
     }
 
     #[test]

--- a/crates/ravel-query/src/log_fetcher.rs
+++ b/crates/ravel-query/src/log_fetcher.rs
@@ -227,6 +227,11 @@ pub struct LogSegmentScan {
     span: tracing::Span,
     /// The object key, for error attribution.
     key: String,
+    /// This query's accounting handle, folded once at exhaustion with the
+    /// scan's decode-time `page_bytes_fetched`/`page_bytes_decoded` totals
+    /// (ADR-0107 decision 4). The same handle T1's fetch path already recorded
+    /// wire bytes against; these are a separate, additive axis.
+    accounting: QueryAccounting,
     /// Set once [`next_block`](Self::next_block) has reported exhaustion, so
     /// the span's counters are recorded exactly once.
     finished: bool,
@@ -340,6 +345,15 @@ impl LogSegmentScan {
         let stats = self.scan.stats();
         self.span.record("blocks_scanned", stats.blocks_scanned);
         self.span.record("blocks_total", stats.blocks_total);
+        // Decode-time column-filtering accounting (ADR-0107 decision 4), folded
+        // once at exhaustion into the query's handle: page_bytes_fetched vs.
+        // page_bytes_decoded expose how much of each fetched block a narrow
+        // projection discards. A separate, additive axis from the wire bytes T1
+        // records through `add_s3_bytes`; see the QueryAccounting field docs.
+        self.accounting
+            .add_page_bytes_fetched(stats.page_bytes_fetched);
+        self.accounting
+            .add_page_bytes_decoded(stats.page_bytes_decoded);
     }
 }
 
@@ -757,6 +771,7 @@ impl LogSegmentFetcher {
             erasure: query.erasure.clone(),
             span,
             key: key.to_string(),
+            accounting: accounting.clone(),
             finished: false,
         }))
     }
@@ -841,6 +856,7 @@ impl LogSegmentFetcher {
             erasure: query.erasure.clone(),
             span,
             key: key.to_string(),
+            accounting: accounting.clone(),
             finished: false,
         }))
     }

--- a/crates/ravel-query/tests/log_block_range.rs
+++ b/crates/ravel-query/tests/log_block_range.rs
@@ -800,7 +800,11 @@ impl ObjectStoreBackend for SlowCountingStore {
     }
     async fn get(&self, key: &str, range: GetRange) -> Result<GetOutcome, StoreError> {
         self.gets.fetch_add(1, Ordering::SeqCst);
-        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        // 50ms, not 5ms (see #618): under real host contention, tokio task
+        // scheduling delays alone can exceed a few ms, reopening the race
+        // this sleep exists to close (see the type doc above). 50ms is still
+        // well under S3's real 15-80ms and gives ample headroom.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
         self.inner.get(key, range).await
     }
     async fn head(&self, key: &str) -> Result<ObjectMeta, StoreError> {

--- a/crates/ravel-query/tests/log_block_range.rs
+++ b/crates/ravel-query/tests/log_block_range.rs
@@ -46,7 +46,7 @@ use ravel_object_store::{
 };
 use ravel_query::{BlockRangeFetcher, LogFetchError, LogQuery, LogSegmentFetcher};
 use ravel_types::TenantHash;
-use ravel_types::accounting::QueryAccounting;
+use ravel_types::accounting::{AccountedOp, QueryAccounting};
 use uuid::Uuid;
 
 const TENANT: TenantHash = TenantHash([7u8; 16]);
@@ -87,6 +87,31 @@ fn record(name: &str, ts: i64, body: &str) -> LogRecord {
         span_id: None,
         flags: 0,
         attrs: Vec::new(),
+    }
+}
+
+/// A record carrying five distinct string attributes, so its block gets five
+/// dynamic columns a narrow projection can skip (on top of the always-present
+/// fixed columns). Used by the decode-accounting test to create real
+/// column-filtering waste.
+fn record_with_attrs(name: &str, ts: i64, body: &str) -> LogRecord {
+    let resource = vec![("service.name".to_string(), AttrValue::Str(name.to_string()))];
+    let attrs = ["a", "b", "c", "d", "e"]
+        .iter()
+        .map(|k| (k.to_string(), AttrValue::Str(format!("{k}{ts}"))))
+        .collect();
+    LogRecord {
+        stream_id: ravel_types::logstream::log_stream_id(&resource, "scope", "1.0", &[]),
+        stream_attrs: stream_attrs_bytes(&resource, "scope", "1.0", &[]),
+        ts_ns: ts,
+        observed_ts_ns: ts,
+        severity_num: 9,
+        severity_text: "INFO".into(),
+        body: body.into(),
+        trace_id: None,
+        span_id: None,
+        flags: 0,
+        attrs,
     }
 }
 
@@ -1043,5 +1068,135 @@ async fn corrupt_block_hit_fails_closed_with_only_blocks_resident() {
     assert!(
         matches!(err, LogFetchError::Corrupt { .. }),
         "expected Corrupt from the per-block gate, got {err:?}"
+    );
+}
+
+// ---- Decode-time page accounting (ADR-0107 decision 4) --------------------
+
+/// `page_bytes_fetched`/`page_bytes_decoded` (ADR-0107 decision 4) populate on
+/// the same `QueryAccounting` handle T1 records wire bytes against, as a
+/// SEPARATE, ADDITIVE axis -- not a repurposing of the wire-byte counters.
+///
+/// The fixture forces the T1 block-range path (`with_block_range_threshold(0)`),
+/// so both axes are exercised in one scan. Two scans over the same segment, one
+/// all-columns and one projecting a single attribute, prove the split:
+///
+/// - Wire bytes (`total_s3_bytes`, `AccountedOp::Get`) are IDENTICAL across the
+///   two projections and non-zero: column filtering is decode-time only, so the
+///   block-range path fetches the same bytes regardless of the projection. This
+///   is the regression guard that the new pair did not repurpose an existing
+///   wire counter.
+/// - `page_bytes_fetched` is filter-independent (every present page counts) and
+///   equal across the two scans; `page_bytes_decoded` is strictly smaller under
+///   the narrow projection -- the column-filtering waste this axis measures.
+/// - The `QueryAccounting` totals equal the scan's own `ScanStats` totals,
+///   proving `LogSegmentScan::finish` folds them through exactly.
+#[tokio::test]
+async fn page_decode_accounting_is_a_separate_axis_from_wire_bytes() {
+    let records: Vec<LogRecord> = (0..12)
+        .map(|ts| record_with_attrs("api", ts, "body"))
+        .collect();
+    let bytes = build_object(&records);
+    let (_blocks_offset, _blocks_len, tail_len) = layout(&bytes);
+    let (ts_min, ts_max) = (3, 9);
+
+    let mem = Arc::new(MemoryStore::new());
+    mem.put("logs/pa.rlog", bytes.clone().into(), PutOptions::default())
+        .await
+        .expect("put");
+    let seg = seg_ref("logs/pa.rlog", bytes.len() as u64, &records);
+    let store: Arc<dyn ObjectStoreBackend> = mem;
+    let query = LogQuery::new(ts_min, ts_max);
+
+    // Fresh fetcher per scan (no cache), forced onto the T1 block-range path so
+    // the wire-byte counters are genuinely exercised alongside the new pair.
+    let run = |columns: ravel_logseg::ColumnSelection| {
+        let store = Arc::clone(&store);
+        let seg = seg.clone();
+        let query = query.clone();
+        async move {
+            let br = BlockRangeFetcher::new(Arc::clone(&store))
+                .with_whole_object_threshold(0)
+                .with_suffix_len(tail_len)
+                .with_coverage_threshold(2.0);
+            let fetcher = LogSegmentFetcher::new(store)
+                .with_block_range_threshold(0)
+                .with_block_range(br);
+            let acc = QueryAccounting::new();
+            let mut scan = fetcher
+                .scan_accounted_with_tenant(&seg, TENANT, &query, &columns, &acc)
+                .await
+                .expect("scan")
+                .expect("in range");
+            let mut rows = 0usize;
+            while let Some(block) = scan.next_block().expect("decode") {
+                rows += block.len();
+            }
+            let stats = scan.stats();
+            (acc.snapshot(), stats, rows)
+        }
+    };
+
+    let (all_snap, all_stats, all_rows) = run(ravel_logseg::ColumnSelection::all()).await;
+    let (proj_snap, proj_stats, proj_rows) =
+        run(ravel_logseg::ColumnSelection::fixed_only().with_attr("a")).await;
+
+    // Both projections match the same rows (projection changes decode, not which
+    // rows survive the exact filter).
+    assert_eq!(
+        all_rows, proj_rows,
+        "projection must not change matched rows"
+    );
+    assert_eq!(
+        all_rows,
+        (ts_max - ts_min + 1) as usize,
+        "ts range [3,9] selects seven one-record blocks"
+    );
+
+    // finish() folds the scan's ScanStats page-byte totals into the handle
+    // exactly (deliverable 3 wiring).
+    assert_eq!(all_snap.page_bytes_fetched, all_stats.page_bytes_fetched);
+    assert_eq!(all_snap.page_bytes_decoded, all_stats.page_bytes_decoded);
+    assert_eq!(proj_snap.page_bytes_fetched, proj_stats.page_bytes_fetched);
+    assert_eq!(proj_snap.page_bytes_decoded, proj_stats.page_bytes_decoded);
+
+    // An all-columns scan decodes every fetched page byte.
+    assert!(all_snap.page_bytes_fetched > 0, "some pages were decoded");
+    assert_eq!(
+        all_snap.page_bytes_decoded, all_snap.page_bytes_fetched,
+        "an all-columns scan decodes every fetched page byte"
+    );
+
+    // Fetched is filter-independent: the projection fetched the same pages.
+    assert_eq!(
+        proj_snap.page_bytes_fetched, all_snap.page_bytes_fetched,
+        "page_bytes_fetched counts every present page, projection or not"
+    );
+    // Decoded is strictly smaller under the narrow projection: real waste.
+    assert!(
+        proj_snap.page_bytes_decoded < proj_snap.page_bytes_fetched,
+        "narrow projection must decode strictly fewer page bytes: {} < {}",
+        proj_snap.page_bytes_decoded,
+        proj_snap.page_bytes_fetched
+    );
+
+    // The regression guard: wire bytes are UNCHANGED by projection and by the
+    // new pair. Same query, same pruning, same block-range fetch, so T1's
+    // wire-byte and GET counters are byte-identical across the two scans; the
+    // page-byte pair is additive, not a repurposing of these counters.
+    assert!(
+        all_snap.total_s3_bytes() > 0,
+        "T1 block-range fetch must record wire bytes"
+    );
+    assert_eq!(
+        all_snap.total_s3_bytes(),
+        proj_snap.total_s3_bytes(),
+        "wire bytes are unchanged by projection; page-byte pair is a separate axis"
+    );
+    assert!(all_snap.s3_requests(AccountedOp::Get) > 0);
+    assert_eq!(
+        all_snap.s3_requests(AccountedOp::Get),
+        proj_snap.s3_requests(AccountedOp::Get),
+        "the T1 GET count is unmoved by the decode-time pair"
     );
 }

--- a/crates/ravel-types/src/accounting.rs
+++ b/crates/ravel-types/src/accounting.rs
@@ -114,6 +114,15 @@ struct Inner {
     segments_pruned: AtomicU64,
     series_matched: AtomicU64,
     bytes_reused: AtomicU64,
+    /// Stored bytes of pages present in the RLOG blocks a logs scan decoded,
+    /// regardless of column filtering. Decode-time column-filtering
+    /// measurement, NOT wire bytes; see `ops`'s `s3_bytes` for wire bytes
+    /// (ADR-0107 decision 4).
+    page_bytes_fetched: AtomicU64,
+    /// Stored bytes of the pages a logs scan actually decoded after column
+    /// filtering. Decode-time column-filtering measurement, NOT wire bytes; see
+    /// `ops`'s `s3_bytes` for wire bytes (ADR-0107 decision 4).
+    page_bytes_decoded: AtomicU64,
     /// Recorded as a running maximum (compare-and-swap loop), never a sum;
     /// see [`QueryAccounting::observe_intermediate_bytes`].
     peak_intermediate_bytes: AtomicU64,
@@ -193,6 +202,27 @@ impl QueryAccounting {
         self.0.bytes_reused.fetch_add(bytes, Ordering::Relaxed);
     }
 
+    /// Add stored bytes of pages present in the RLOG blocks a logs scan
+    /// decoded, regardless of column filtering (the "fetched" side of ADR-0107
+    /// decision 4's decode-time measurement). This is NOT wire-byte accounting:
+    /// actual bytes moved over the wire stay measured by [`Self::add_s3_bytes`].
+    /// Paired with [`Self::add_page_bytes_decoded`], the two expose how much of
+    /// each fetched block a narrow projection throws away at decode.
+    pub fn add_page_bytes_fetched(&self, bytes: u64) {
+        self.0
+            .page_bytes_fetched
+            .fetch_add(bytes, Ordering::Relaxed);
+    }
+
+    /// Add stored bytes of the pages a logs scan actually decoded after column
+    /// filtering (the "decoded" side of ADR-0107 decision 4). NOT wire bytes;
+    /// see [`Self::add_s3_bytes`] for wire bytes.
+    pub fn add_page_bytes_decoded(&self, bytes: u64) {
+        self.0
+            .page_bytes_decoded
+            .fetch_add(bytes, Ordering::Relaxed);
+    }
+
     /// Update the peak intermediate byte high-water mark. This is a
     /// maximum, never a sum: call it with the current intermediate size at
     /// each point it might grow, and the counter keeps the largest value
@@ -241,6 +271,8 @@ impl QueryAccounting {
         saturating_fetch_add(&self.0.segments_pruned, other.segments_pruned);
         saturating_fetch_add(&self.0.series_matched, other.series_matched);
         saturating_fetch_add(&self.0.bytes_reused, other.bytes_reused);
+        saturating_fetch_add(&self.0.page_bytes_fetched, other.page_bytes_fetched);
+        saturating_fetch_add(&self.0.page_bytes_decoded, other.page_bytes_decoded);
         self.observe_intermediate_bytes(other.peak_intermediate_bytes);
     }
 
@@ -266,6 +298,8 @@ impl QueryAccounting {
             segments_pruned: self.0.segments_pruned.load(Ordering::Relaxed),
             series_matched: self.0.series_matched.load(Ordering::Relaxed),
             bytes_reused: self.0.bytes_reused.load(Ordering::Relaxed),
+            page_bytes_fetched: self.0.page_bytes_fetched.load(Ordering::Relaxed),
+            page_bytes_decoded: self.0.page_bytes_decoded.load(Ordering::Relaxed),
             peak_intermediate_bytes: self.0.peak_intermediate_bytes.load(Ordering::Relaxed),
         }
     }
@@ -289,6 +323,16 @@ pub struct QueryAccountingSnapshot {
     pub segments_pruned: u64,
     pub series_matched: u64,
     pub bytes_reused: u64,
+    /// Stored bytes of pages present in the RLOG blocks a logs scan decoded,
+    /// regardless of column filtering. A decode-time column-filtering
+    /// measurement, NOT wire bytes; see [`Self::s3_bytes`] for wire bytes
+    /// (ADR-0107 decision 4).
+    pub page_bytes_fetched: u64,
+    /// Stored bytes of the pages a logs scan actually decoded after column
+    /// filtering. Equal to `page_bytes_fetched` for an all-columns scan; the
+    /// gap to it is the column-filtering waste. NOT wire bytes; see
+    /// [`Self::s3_bytes`] for wire bytes (ADR-0107 decision 4).
+    pub page_bytes_decoded: u64,
     pub peak_intermediate_bytes: u64,
 }
 
@@ -354,6 +398,12 @@ impl QueryAccountingSnapshot {
             segments_pruned: self.segments_pruned.saturating_add(other.segments_pruned),
             series_matched: self.series_matched.saturating_add(other.series_matched),
             bytes_reused: self.bytes_reused.saturating_add(other.bytes_reused),
+            page_bytes_fetched: self
+                .page_bytes_fetched
+                .saturating_add(other.page_bytes_fetched),
+            page_bytes_decoded: self
+                .page_bytes_decoded
+                .saturating_add(other.page_bytes_decoded),
             peak_intermediate_bytes: self
                 .peak_intermediate_bytes
                 .max(other.peak_intermediate_bytes),

--- a/docs/guides/caching.md
+++ b/docs/guides/caching.md
@@ -140,6 +140,39 @@ These counters cover every ADR-0046 cache in the process. Request hit rate is
 bytes_admitted)`. Filter by the `cache` label for one cache's rate, or omit it
 (let PromQL sum the series) for the whole process.
 
+## Sizing for logs column-filtering waste
+
+A logs (RLOG) query's `QueryAccounting` carries two decode-time byte counters
+next to its wire-byte counters (ADR-0107 decision 4): `page_bytes_fetched`, the
+stored bytes of every page present in the blocks the query decoded, and
+`page_bytes_decoded`, the stored bytes of only the pages the query's column
+projection kept. These are a decode-time measurement, not a wire measurement:
+they count bytes a fetched block already holds, distinct from `s3_bytes` (the
+actual bytes moved over the network). Column filtering today is decode-time only
+-- a narrow projection skips decompressing the pages it does not need, but the
+whole block still arrives on the wire, because RLOG has no per-page checksum to
+verify a sub-block fetch against.
+
+The ratio `page_bytes_decoded / page_bytes_fetched` is the interpretation lever.
+When it is close to 1, the query decodes nearly everything its blocks contain and
+a larger cache working set is the main way to make repeat runs cheaper. When it
+is small -- most fetched page bytes are thrown away by column filtering, the
+wide-schema, narrow-projection shape -- the same block is being fetched and cached
+in full to serve a few columns. Two responses apply: narrow the projection
+further where the query allows it (fewer columns decoded per block, though not
+fewer bytes fetched until a future per-page-crc format change lands), and size the
+cache to the *working set of whole blocks* the workload touches rather than to the
+decoded byte volume, since the cache admits and holds whole blocks regardless of
+how little of each a given query decodes. A small decoded fraction across a
+tenant's queries is the signal that its cache should be sized against block
+footprint, not against what its projections actually read.
+
+A concrete measured ratio for a representative workload is not quoted here: no
+`ravel-bench` logs run was executed in the environment this guidance was written
+in, so a fabricated number is deliberately avoided. Read the two counters off a
+real query's accounting (or `EXPLAIN ANALYZE`, which surfaces the sibling
+`pages_decoded`/`pages_skipped` counts) to get the ratio for your own workload.
+
 ## Known gaps
 
 - **`--cache-dir` is not wired up.** The disk tier (`DiskCache`) exists

--- a/docs/guides/caching.md
+++ b/docs/guides/caching.md
@@ -169,9 +169,13 @@ footprint, not against what its projections actually read.
 
 A concrete measured ratio for a representative workload is not quoted here: no
 `ravel-bench` logs run was executed in the environment this guidance was written
-in, so a fabricated number is deliberately avoided. Read the two counters off a
-real query's accounting (or `EXPLAIN ANALYZE`, which surfaces the sibling
-`pages_decoded`/`pages_skipped` counts) to get the ratio for your own workload.
+in, so a fabricated number is deliberately avoided. Neither counter is exposed
+through the server's query-facing accounting today (`EXPLAIN ANALYZE` surfaces
+only the sibling page-count fields, `pages_decoded`/`pages_skipped`, not their
+byte-denominated equivalents), so to see the ratio for your own workload, drive
+the query through `QueryAccounting` in-process -- an in-process `ravel-bench`
+run against `crates/ravel-bench/src/logs_scan_scaling.rs` is the existing
+example -- rather than reading it off a running server.
 
 ## Known gaps
 

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -1381,6 +1381,28 @@ Two consequences an operator and a plan reader both see:
 alongside its block counters, so `EXPLAIN ANALYZE` shows how much of each block
 the projection avoided touching.
 
+Two decode-time byte counters sit next to those page counts on the query's
+`QueryAccounting` handle (ADR-0107 decision 4): `page_bytes_fetched`, the stored
+(post-compression) bytes of every page present in the blocks a scan decoded,
+regardless of the projection; and `page_bytes_decoded`, the stored bytes of only
+the pages the `ColumnSelection` kept. `LogSegmentScan::finish` folds each scan's
+`ScanStats` totals into the handle once, at exhaustion. Their gap is the
+column-filtering waste: for an all-columns scan they are equal; for a
+wide-schema, narrow-projection query `page_bytes_decoded` can be a small
+fraction of `page_bytes_fetched`.
+
+These are a decode-time measurement, a **different axis** from the wire bytes the
+`page_fetch` span and `s3_bytes` record (and from `BlockRangeStats::
+block_bytes_fetched`, the T1 block-range fetch counter above): they count stored
+page bytes that a fetched block already holds, not bytes moved over the network,
+so a projection changes `page_bytes_decoded` without changing any wire counter.
+Reading them together tells both stories in one place -- how many bytes the fetch
+brought in, and how many of the bytes already resident the decode actually
+needed. The instrument exists to measure whether block-level pruning alone
+already captures most of the realistic win before a future per-page-crc RLOG
+section is proposed to shrink the wire fetch to columns (ADR-0107 "Explicitly out
+of scope").
+
 The per-query DataFusion memory pool now bounds concurrently-held scan memory:
 the reservation grows when a decoded block and the batch built from it are held
 and shrinks as each is released. It is not a cumulative-output budget, and


### PR DESCRIPTION
ADR-0107 decision 4: two new QueryAccounting counters,
page_bytes_fetched and page_bytes_decoded, measuring how much of a
decoded RLOG block's page bytes survive column filtering. This is
decode-time accounting distinct from the existing wire-level s3_bytes
and T1's block_bytes_fetched; a query whose decoded fraction is small
is a candidate for a narrower projection or a bigger cache working
set, since the cache admits and holds whole blocks regardless of how
little of each a given query decodes.

Checkpoint review verified the fetched/decoded semantics against the
actual block decode path, confirmed no double-counting across the row
and columnar exits, confirmed additivity to QueryAccounting (no
existing counter's behavior changed), and reproduced the new test's
exact-byte-count assertions with its own mutation proofs. Two small
doc issues found in review are fixed here: caching.md pointed operators
at EXPLAIN ANALYZE for these counters, which doesn't surface them
today (only the sibling page-count fields do); and a new test's doc
comment had an unrelated crc-integrity paragraph misattributed to it
from a different, now-undocumented test.

Two accounting-fidelity gaps found in review are filed as follow-ups,
not blockers: an exhaustion-only fold undercounts a scan LIMIT
abandons before completion (inherited pattern, matches the existing
EXPLAIN counters' behavior), and the distributed accounting path
silently zeros both new counters since the wire proto has no field for
them yet (latent, no caller dispatches this accounting across the wire
today). See #617.

Fixes: #565
Refs: #363
