### PR TITLE
feat(ravel-bench): add --sql-max-query-bytes to sql_latency_bench

### DIFF
--- a/crates/ravel-bench/src/bin/sql_latency_bench.rs
+++ b/crates/ravel-bench/src/bin/sql_latency_bench.rs
@@ -24,6 +24,7 @@ use ravel_bench::sql_corpus::{checked_default_corpus, load_external_corpus};
 use ravel_bench::sql_latency::{
     Compaction, GenerateConfig, SqlLatencyReport, TenantConfigInput, run_generated, run_tenant,
 };
+use ravel_sql::DEFAULT_MAX_QUERY_BYTES;
 use ravel_types::TimeRange;
 
 #[derive(Parser, Debug)]
@@ -47,6 +48,13 @@ struct Args {
     /// of the checked-in corpus.
     #[arg(long)]
     corpus: Option<String>,
+    /// Per-query ceiling, in bytes, on the SQL DataFusion memory pool, mirroring
+    /// `ravel-server`'s `--sql-max-query-bytes` (ADR-0088). Raise it to measure
+    /// a heavy query that otherwise aborts with `query memory budget exhausted`.
+    /// Defaults to ravel-sql's compiled-in 256 MiB, so an unset flag leaves the
+    /// measured budget byte-for-byte unchanged.
+    #[arg(long = "sql-max-query-bytes", value_name = "BYTES", default_value_t = DEFAULT_MAX_QUERY_BYTES)]
+    sql_max_query_bytes: usize,
 
     // --- generated lane knobs ---------------------------------------------
     /// Distinct log records to generate.
@@ -167,6 +175,7 @@ async fn run(args: &Args) -> Result<SqlLatencyReport, ravel_bench::sql_latency::
                 },
                 now_ns,
                 compaction: args.compaction.into(),
+                max_query_bytes: args.sql_max_query_bytes,
             };
             run_tenant(&cfg).await
         }
@@ -184,6 +193,7 @@ async fn run(args: &Args) -> Result<SqlLatencyReport, ravel_bench::sql_latency::
                 records: args.records,
                 records_per_object: args.records_per_object,
                 extra_attrs: args.extra_attrs,
+                max_query_bytes: args.sql_max_query_bytes,
             };
             run_generated(&cfg).await
         }

--- a/crates/ravel-bench/src/sql_latency.rs
+++ b/crates/ravel-bench/src/sql_latency.rs
@@ -225,6 +225,13 @@ pub struct GenerateConfig {
     /// Extra distinct filler attribute keys per record, on top of the fixed
     /// `duration_ms` declared column, to widen the schema.
     pub extra_attrs: usize,
+    /// Per-query DataFusion memory-pool ceiling, in bytes, fed to
+    /// [`SqlConfig::max_query_bytes`]. Mirrors `ravel-server`'s
+    /// `--sql-max-query-bytes` (ADR-0088): raise it to measure a heavy query
+    /// that otherwise aborts with `query memory budget exhausted`. Defaults to
+    /// [`ravel_sql::DEFAULT_MAX_QUERY_BYTES`], so an unset flag leaves the
+    /// executor's budget byte-for-byte unchanged.
+    pub max_query_bytes: usize,
 }
 
 /// Inputs for the loaded-tenant lane.
@@ -245,6 +252,13 @@ pub struct TenantConfigInput {
     pub now_ns: i64,
     /// Which layout the operator is measuring.
     pub compaction: Compaction,
+    /// Per-query DataFusion memory-pool ceiling, in bytes, fed to
+    /// [`SqlConfig::max_query_bytes`]. Mirrors `ravel-server`'s
+    /// `--sql-max-query-bytes` (ADR-0088): raise it to measure a heavy query
+    /// that otherwise aborts with `query memory budget exhausted`. Defaults to
+    /// [`ravel_sql::DEFAULT_MAX_QUERY_BYTES`], so an unset flag leaves the
+    /// executor's budget byte-for-byte unchanged.
+    pub max_query_bytes: usize,
 }
 
 fn percentile(sorted_ns: &[u64], pct: f64) -> u64 {
@@ -303,6 +317,7 @@ fn declaration_union(entries: &[CorpusEntry]) -> Vec<DeclaredColumn> {
 fn cold_executor(
     store: &Arc<dyn ObjectStoreBackend>,
     declared: &[DeclaredColumn],
+    max_query_bytes: usize,
 ) -> Result<SqlExecutor, Error> {
     let catalog = Arc::new(Catalog::new(Arc::clone(store), CatalogConfig::default())?);
     Ok(SqlExecutor::new(
@@ -310,7 +325,10 @@ fn cold_executor(
         SegmentFetcher::new(Arc::clone(store)),
         LogSegmentFetcher::new(Arc::clone(store)),
         SpanSegmentFetcher::new(Arc::clone(store)),
-        SqlConfig::default(),
+        SqlConfig {
+            max_query_bytes,
+            ..SqlConfig::default()
+        },
         1 << 30,
     )
     .with_declared_column_source(Arc::new(StaticDeclaredColumns::new(declared.to_vec()))))
@@ -325,6 +343,7 @@ fn cold_executor(
 /// first run is the cold number. An entry whose `required_declarations` are not
 /// all satisfied by `declared` is skipped with its missing key named and never
 /// executed.
+#[allow(clippy::too_many_arguments)]
 pub async fn measure_corpus(
     store: &Arc<dyn ObjectStoreBackend>,
     tenant_hash: TenantHash,
@@ -333,6 +352,7 @@ pub async fn measure_corpus(
     runs: usize,
     window: TimeRange,
     now_ns: i64,
+    max_query_bytes: usize,
 ) -> Result<(Vec<EntryReport>, Vec<SkippedEntry>), Error> {
     let runs = runs.max(1);
     let mut measured = Vec::new();
@@ -361,7 +381,7 @@ pub async fn measure_corpus(
             continue;
         }
 
-        let executor = cold_executor(store, declared)?;
+        let executor = cold_executor(store, declared, max_query_bytes)?;
         let req = SqlRequest {
             sql: entry.sql.clone(),
             window,
@@ -495,6 +515,7 @@ pub async fn run_generated(cfg: &GenerateConfig) -> Result<SqlLatencyReport, Err
         cfg.runs,
         window,
         NOW_NS,
+        cfg.max_query_bytes,
     )
     .await?;
 
@@ -546,6 +567,7 @@ pub async fn run_tenant(cfg: &TenantConfigInput) -> Result<SqlLatencyReport, Err
         cfg.runs,
         cfg.window,
         cfg.now_ns,
+        cfg.max_query_bytes,
     )
     .await?;
 
@@ -711,4 +733,42 @@ fn build_records(count: usize, extra_attrs: usize) -> Vec<LogRecord> {
             }
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ravel_object_store::memory::MemoryStore;
+    use ravel_sql::DEFAULT_MAX_QUERY_BYTES;
+
+    fn empty_store() -> Arc<dyn ObjectStoreBackend> {
+        Arc::new(MemoryStore::new())
+    }
+
+    /// The `--sql-max-query-bytes` value threaded through `GenerateConfig`/
+    /// `TenantConfigInput` into `measure_corpus` must land on
+    /// `SqlConfig::max_query_bytes`, not stop at a parsed field. A value distinct
+    /// from the compiled-in default proves the override is wired end to end;
+    /// reverting `cold_executor` to `SqlConfig::default()` makes this fail rather
+    /// than pass on a coincidental default (its companion test covers the
+    /// default itself).
+    #[test]
+    fn cold_executor_threads_max_query_bytes_override() {
+        let store = empty_store();
+        let custom = DEFAULT_MAX_QUERY_BYTES * 4;
+        assert_ne!(custom, DEFAULT_MAX_QUERY_BYTES);
+        let executor = cold_executor(&store, &[], custom).expect("build executor");
+        assert_eq!(executor.config().max_query_bytes, custom);
+    }
+
+    /// Passing the default (an omitted flag) leaves the measured budget
+    /// byte-for-byte unchanged. Paired with the override test so a regression
+    /// that silently drops the override cannot pass by leaving the default
+    /// coincidentally correct.
+    #[test]
+    fn cold_executor_defaults_to_compiled_in_budget() {
+        let store = empty_store();
+        let executor = cold_executor(&store, &[], DEFAULT_MAX_QUERY_BYTES).expect("build executor");
+        assert_eq!(executor.config().max_query_bytes, DEFAULT_MAX_QUERY_BYTES);
+    }
 }

--- a/crates/ravel-bench/tests/sql_latency_object_count_invariant.rs
+++ b/crates/ravel-bench/tests/sql_latency_object_count_invariant.rs
@@ -39,6 +39,7 @@ use ravel_proto::commit::v1::CompactionRecord;
 use ravel_segment::{
     IngestBounds, SegmentIdentity, SegmentWriter, SeriesInput, VERSION_V7, WrittenSegment,
 };
+use ravel_sql::DEFAULT_MAX_QUERY_BYTES;
 use ravel_types::{
     Label, LabelSet, METRIC_NAME_LABEL, Sample, SeriesId, Signal, TenantHash, TenantId, TimeRange,
 };
@@ -87,6 +88,7 @@ async fn l0_object_count_equals_distinct_data_object_keys() {
         records: 60,
         records_per_object: 20,
         extra_attrs: 4,
+        max_query_bytes: DEFAULT_MAX_QUERY_BYTES,
     };
     let report = run_generated(&cfg).await.expect("generated lane runs");
 

--- a/crates/ravel-bench/tests/sql_latency_smoke.rs
+++ b/crates/ravel-bench/tests/sql_latency_smoke.rs
@@ -24,6 +24,7 @@ use ravel_bench::sql_corpus::{
 use ravel_bench::sql_latency::{GenerateConfig, measure_corpus, run_generated};
 use ravel_object_store::ObjectStoreBackend;
 use ravel_object_store::memory::MemoryStore;
+use ravel_sql::DEFAULT_MAX_QUERY_BYTES;
 use ravel_types::{TenantId, TimeRange};
 
 /// The frozen query clock the generated lane uses (`4h` in ns); the generated
@@ -44,6 +45,7 @@ fn small_generate_config(store: Arc<dyn ObjectStoreBackend>, runs: usize) -> Gen
         records: 60,
         records_per_object: 20,
         extra_attrs: 4,
+        max_query_bytes: DEFAULT_MAX_QUERY_BYTES,
     }
 }
 
@@ -209,6 +211,7 @@ async fn an_entry_with_an_unsatisfied_required_declaration_is_skipped_with_the_k
         1,
         window,
         NOW_NS,
+        DEFAULT_MAX_QUERY_BYTES,
     )
     .await
     .expect("measure_corpus runs");

--- a/docs/guides/clickbench.md
+++ b/docs/guides/clickbench.md
@@ -189,6 +189,13 @@ cargo run -p ravel-bench --features sql-latency --bin sql_latency_bench -- \
   span. ClickBench's `EventTime` values are from 2013, so widen the window well
   past the default 24 hours (relative to `--now-secs`, default the wall clock),
   or the catalog resolve will not see the segments.
+- `--sql-max-query-bytes` raises the per-query DataFusion memory-pool ceiling,
+  mirroring `ravel-server`'s flag of the same name (ADR-0088). A heavy statement
+  (a wide `SELECT *` with a row-wise filter and a pre-`LIMIT` `ORDER BY`) can
+  abort with `query memory budget exhausted`; that aborts the whole run with no
+  number for it. Pass a larger byte budget (for example `--sql-max-query-bytes
+  1073741824` for 1 GiB) to measure it instead. Omitted, it defaults to
+  ravel-sql's compiled-in 256 MiB, leaving the measured budget unchanged.
 
 ### How to read the report
 


### PR DESCRIPTION
## Summary

- `sql_latency_bench` always built its `SqlConfig` via `SqlConfig::default()`,
  so the per-query DataFusion memory-pool budget was hardcoded to
  `DEFAULT_MAX_QUERY_BYTES` (256 MiB). A heavy statement (a wide
  `SELECT *` with a row-wise filter and a pre-`LIMIT` `ORDER BY`) could
  abort the whole bench run with "query memory budget exhausted" and no
  way to raise the budget to actually measure it.
- Adds `--sql-max-query-bytes`, mirroring `ravel-server`'s flag of the
  same name and unit (ADR-0088), threaded through `GenerateConfig` and
  `TenantConfigInput` into `measure_corpus`/`cold_executor` so both the
  generated and loaded-tenant lanes honor it. Defaults to
  `DEFAULT_MAX_QUERY_BYTES`, so omitting it leaves current behavior
  byte-for-byte unchanged.
- Documents when to raise it in the clickbench guide's step-5 example,
  naming the exact error text to grep for.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p ravel-bench --features sql-latency --all-targets -- -D warnings`
- [x] `cargo test -p ravel-bench --features sql-latency` (42 lib +
      full integration suite, green)
- [x] Independently verified before opening this PR: cherry-picked into
      a dedicated worktree, diffed against the actual dispatch-time
      merge-base, reran the full gate list clean, authorship rewritten
      to the correct identity

**Known gap, not blocking**: no test exercises `run_tenant` at all
(only `run_generated` is covered) — confirmed by hardcoding
`run_tenant`'s `measure_corpus` call to `ravel_sql::DEFAULT_MAX_QUERY_BYTES`
and observing the full test suite still passes. The wiring itself is
correct (verified by reading the code — `run_tenant` passes
`cfg.max_query_bytes` symmetrically with `run_generated`), but nothing
would catch a future regression specifically in the tenant lane, which
is the lane a real ClickBench run against a loaded dataset actually
uses. Worth a small follow-up test exercising `run_tenant` directly.

Refs: #615
