### PR TITLE
docs: warn that profiled sql_latency_bench is unstable at --runs > 1

### DIFF
--- a/crates/ravel-bench/src/profiling.rs
+++ b/crates/ravel-bench/src/profiling.rs
@@ -34,6 +34,47 @@
 //! worse than the real latencies. Read the flamegraph for CPU *attribution*
 //! only; quote latency numbers from an unprofiled run, never from a profiled
 //! one.
+//!
+//! # Known instability under repeated execution
+//!
+//! A single [`ProfileSession`] holds one `pprof::ProfilerGuard` live across the
+//! whole measured region. When that region runs each statement more than once
+//! (`sql_latency_bench --runs N` with `N > 1`, where the guard brackets every
+//! run of every corpus entry), the profiled process has been observed to
+//! segfault; `--runs 1`, and any run with profiling off, is stable (issue
+//! #616).
+//!
+//! The cause is upstream in the sampler, not in this crate's measurement loop
+//! or in the SQL engine under test. `pprof` is a signal sampler: each `SIGPROF`
+//! delivery unwinds the interrupted thread's stack from inside the signal
+//! handler, and that unwind goes through the platform unwinder
+//! (`backtrace::trace_unsynchronized`, i.e. libgcc's `_Unwind_Backtrace`),
+//! which is not async-signal-safe. `pprof`'s own documentation carries the
+//! gperftools warning verbatim: libgcc's unwind "is not safe to use from signal
+//! handlers", and a tick that lands while a thread is mid-unwind or holds the
+//! loader lock can deadlock or fault. The blocklist passed to the guard
+//! mitigates but cannot close this: it only suppresses samples whose
+//! interrupted instruction pointer is already inside a blocklisted segment, not
+//! one that faults while unwinding out of application code.
+//!
+//! Why `--runs 3` crosses a line `--runs 1` does not: the plan, the data, and
+//! the per-statement work are identical between the two. The only thing more
+//! runs change is how long the guard stays armed, and therefore how many
+//! async-signal-unsafe unwinds occur. The crash is probabilistic in that count,
+//! so more executions raise the odds of one tick landing in the unsafe window.
+//! That also means it is not deterministic on every host: it did not reproduce
+//! under this crate's own repeated attempts on an aarch64 Linux box (default
+//! and widened corpora, `--runs` up to 10, sampling frequency raised well past
+//! the default), which is consistent with a probability that varies with
+//! architecture, core count, and glibc rather than a fixed trigger. Do not read
+//! a clean profiled `--runs 3` on one host as evidence the hazard is absent.
+//!
+//! Operational guidance: for a profiled pass, use `--runs 1`. One execution per
+//! statement already produces a dense CPU flamegraph (the sampler accrues a
+//! stack every ~1 ms of on-CPU time), and the latency numbers from a profiled
+//! run are unusable anyway (see the section above), so the extra runs buy the
+//! profile nothing while adding the exposure that risks the crash. Take latency
+//! from a separate unprofiled multi-run pass.
 
 /// Environment variable naming the flamegraph SVG output path. When it is set
 /// and the crate was built with the `profiling` feature, a bench core wraps its

--- a/docs/guides/clickbench.md
+++ b/docs/guides/clickbench.md
@@ -190,6 +190,28 @@ cargo run -p ravel-bench --features sql-latency --bin sql_latency_bench -- \
   past the default 24 hours (relative to `--now-secs`, default the wall clock),
   or the catalog resolve will not see the segments.
 
+#### CPU flamegraph pass (use `--runs 1`)
+
+To capture a CPU flamegraph of the corpus, build with `--features
+sql-latency,profiling` and set `RAVEL_BENCH_PROFILE_SVG` to the output path.
+For a profiled pass, run it with **`--runs 1`**, not `--runs 3`:
+
+```sh
+RAVEL_BENCH_PROFILE_SVG=/tmp/sql_latency.svg \
+cargo run -p ravel-bench --features sql-latency,profiling --bin sql_latency_bench -- \
+  --tenant clickbench --store s3 \
+  --corpus benchmarks/clickbench/hits.corpus.json \
+  --runs 1 --compaction pre --window-hours 200000
+```
+
+The profiler is a signal sampler, and running each statement more than once
+under a live sampler has been observed to segfault the process (issue #616);
+`--runs 1` is stable. This costs nothing for a profile: one execution already
+yields a dense flamegraph, and profiled latency numbers are inflated by the
+sampler and not usable anyway. Take latency from a separate unprofiled `--runs
+3` pass, and read the flamegraph for CPU attribution only. See
+`crates/ravel-bench/src/profiling.rs` for the mechanism.
+
 ### How to read the report
 
 The bench prints the full report as JSON, then a human table. Per statement:


### PR DESCRIPTION
## Summary

`sql_latency_bench` segfaults when profiled with `--runs > 1` (each
statement re-executed under one live `pprof::ProfilerGuard`); `--runs
1` and unprofiled runs are both stable. Investigated whether this is a
fixable bug in this crate or an upstream sampler hazard.

Could not reproduce the crash on the fleet executor's sandbox (aarch64
Linux) despite heavy exposure: default corpus at `--runs 3` (22
attempts), a much larger dataset at `--runs 10`, and the sampling
frequency raised up to ~50x the default with load. All stable, all
produced valid flamegraphs.

Non-reproduction doesn't mean the hazard isn't real: `pprof` is a
signal sampler, and each `SIGPROF` delivery unwinds the interrupted
thread's stack via libgcc's `_Unwind_Backtrace`, which is documented
(by `pprof` itself, echoing gperftools) as not async-signal-safe. More
runs under one guard means more unwinds, which means more chances for
a tick to land mid-unwind. That's consistent with a crash that's
probabilistic and architecture/host-dependent rather than a fixed
trigger -- explaining both the original segfault on x86_64 and this
task's clean run on aarch64.

No code fix landed -- the measurement loop and `ProfileSession`
lifecycle in this crate are correct; the hazard is in the sampler
itself, not something to work around by restructuring how this crate
calls it. Documents the finding and the operational guidance instead:
use `--runs 1` for a profiled pass (one execution already produces a
dense flamegraph; profiled latency numbers are unusable regardless
since the sampler inflates them), take latency from a separate
unprofiled multi-run pass.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo check -p ravel-bench --features sql-latency,profiling`
      (docs-only change, confirmed the crate still compiles under the
      features the new doc section references)
- [x] Independently verified before opening this PR: cherry-picked
      into a dedicated worktree, diffed against the actual
      dispatch-time merge-base, confirmed scope matches (2 files,
      docs only), authorship already correct

Refs: #616
