### PR TITLE
feat(claude): nudge sessions toward epic-status.sh over hand-rolled gh calls

### DIFF
--- a/.claude/guards/epic-status-nudge.mjs
+++ b/.claude/guards/epic-status-nudge.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+// Nudges a session toward `scripts/epic-status.sh` instead of hand-rolled
+// `gh issue view`/`gh pr view` reconciliation (issue #613). Two modes,
+// wired to two different hook events because only one of them can safely
+// inject context:
+//
+//   track  (PostToolUse, matcher "Bash"): counts hand-rolled reconciliation
+//          calls since the last epic-status.sh run, in a small local state
+//          file. Never blocks anything -- PostToolUse cannot deny a call
+//          that already ran.
+//   nudge  (UserPromptSubmit): reads that counter and, past a threshold,
+//          writes a one-line reminder to stdout. UserPromptSubmit's stdout
+//          becomes additional context for the next turn; PreToolUse has no
+//          equivalent non-denying path in this harness, which is why this
+//          is not folded into pretooluse.mjs.
+//
+// State lives in a local, gitignored file. A missing or corrupt state file
+// degrades to "count starts at zero", never an error and never a block --
+// this hook can only ever add a reminder, not stop a tool call.
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+// Overridable so the test script can point at an isolated file instead of
+// this checkout's real counter; unset in every real invocation.
+const STATE_PATH =
+  process.env.EPIC_STATUS_NUDGE_STATE ??
+  resolve(HERE, "..", ".epic-status-nudge-state.json");
+const NUDGE_THRESHOLD = 8;
+
+// Matches an ad hoc reconciliation read: `gh issue view`, `gh pr view`, `gh
+// issue list`. Not `gh issue create`/`comment`/`close` and not `gh pr
+// create`/`merge` -- those are real actions, not a stand-in for
+// epic-status.sh.
+const RECONCILE_CALL = /\bgh\s+(issue|pr)\s+(view|list)\b/;
+const EPIC_STATUS_RUN = /\bscripts\/epic-status\.sh\b/;
+
+function readState() {
+  try {
+    const parsed = JSON.parse(readFileSync(STATE_PATH, "utf8"));
+    return typeof parsed?.count === "number" ? parsed : { count: 0 };
+  } catch {
+    return { count: 0 };
+  }
+}
+
+function writeState(state) {
+  try {
+    writeFileSync(STATE_PATH, JSON.stringify(state));
+  } catch {
+    // Best-effort: a failed write just means the next check starts from
+    // whatever was last persisted (or zero). Never throw from here.
+  }
+}
+
+function readStdinJSON() {
+  try {
+    return JSON.parse(readFileSync(0, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function track() {
+  const command = readStdinJSON()?.tool_input?.command;
+  if (typeof command !== "string") return;
+  const state = readState();
+  if (EPIC_STATUS_RUN.test(command)) {
+    state.count = 0;
+    writeState(state);
+  } else if (RECONCILE_CALL.test(command)) {
+    state.count = (state.count ?? 0) + 1;
+    writeState(state);
+  }
+}
+
+function nudge() {
+  const { count } = readState();
+  if (count >= NUDGE_THRESHOLD) {
+    process.stdout.write(
+      `${count} hand-rolled \`gh issue/pr view\`-style calls since the ` +
+        "last `scripts/epic-status.sh` run (issue #613). If you're " +
+        "tracking an epic, run epic-status.sh instead of continuing to " +
+        "poll by hand.",
+    );
+  }
+}
+
+const mode = process.argv[2];
+try {
+  if (mode === "track") track();
+  else if (mode === "nudge") nudge();
+} catch {
+  // Fail open: this hook only ever adds a reminder, never blocks or throws.
+}

--- a/.claude/guards/epic-status-nudge.test.sh
+++ b/.claude/guards/epic-status-nudge.test.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Cases the epic-status nudge must get right. Run:
+#   bash .claude/guards/epic-status-nudge.test.sh
+set -uo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")" && pwd)/epic-status-nudge.mjs"
+pass=0
+fail=0
+
+tmpstate="$(mktemp -d)/state.json"
+export EPIC_STATUS_NUDGE_STATE="$tmpstate"
+
+bash_payload() {
+  node -e 'process.stdout.write(JSON.stringify({tool_name:"Bash",tool_input:{command:process.argv[1]}}))' "$1"
+}
+
+track() {
+  printf '%s' "$(bash_payload "$1")" | node "$SCRIPT" track
+}
+
+nudge_output() {
+  node "$SCRIPT" nudge
+}
+
+count_in_state() {
+  node -e 'try{console.log(JSON.parse(require("fs").readFileSync(process.argv[1],"utf8")).count)}catch{console.log("MISSING")}' "$tmpstate"
+}
+
+check_count() {
+  local want="$1" label="$2" got
+  got="$(count_in_state)"
+  if [ "$got" = "$want" ]; then
+    pass=$((pass + 1))
+  else
+    printf 'FAIL  %-52s want count=%s, got %s\n' "$label" "$want" "$got"
+    fail=$((fail + 1))
+  fi
+}
+
+check_nudge() {
+  local want="$1" label="$2" out
+  out="$(nudge_output)"
+  if [ "$want" = "silent" ]; then
+    if [ -z "$out" ]; then
+      pass=$((pass + 1))
+    else
+      printf 'FAIL  %-52s want silent, got: %s\n' "$label" "$out"
+      fail=$((fail + 1))
+    fi
+  else
+    if printf '%s' "$out" | grep -q "epic-status.sh"; then
+      pass=$((pass + 1))
+    else
+      printf 'FAIL  %-52s want a reminder, got: %s\n' "$label" "$out"
+      fail=$((fail + 1))
+    fi
+  fi
+}
+
+# --- fresh state ----------------------------------------------------------
+rm -f "$tmpstate"
+check_nudge silent "no state file yet"
+
+# --- tracking counts only reconciliation-style gh reads --------------------
+track 'gh issue view 519 --repo NOFireAI/ravel'
+check_count 1 "gh issue view increments"
+track 'gh pr view 583 --repo NOFireAI/ravel'
+check_count 2 "gh pr view increments"
+track 'gh issue list --repo NOFireAI/ravel --state open'
+check_count 3 "gh issue list increments"
+track 'gh issue create --repo NOFireAI/ravel --title x --body y'
+check_count 3 "gh issue create does not count as reconciliation"
+track 'gh pr merge 583 --repo NOFireAI/ravel --auto'
+check_count 3 "gh pr merge does not count as reconciliation"
+track 'cargo test -p ravel-cli'
+check_count 3 "unrelated command does not count"
+
+# --- below threshold: silent -----------------------------------------------
+check_nudge silent "count 3 is below threshold"
+
+# --- cross threshold --------------------------------------------------------
+for _ in 1 2 3 4 5; do track 'gh issue view 1 --repo NOFireAI/ravel'; done
+check_count 8 "count reaches threshold"
+check_nudge remind "count 8 at threshold reminds"
+
+# --- epic-status.sh resets --------------------------------------------------
+track 'scripts/epic-status.sh 597'
+check_count 0 "epic-status.sh run resets the counter"
+check_nudge silent "silent again right after a reset"
+
+# --- malformed input never breaks anything ----------------------------------
+printf '' | node "$SCRIPT" track
+printf 'not json' | node "$SCRIPT" track
+printf '{"tool_name":"Bash","tool_input":{}}' | node "$SCRIPT" track
+check_count 0 "malformed/empty track calls leave the counter untouched"
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -20,6 +20,29 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PROJECT_DIR:-.}/.claude/guards/epic-status-nudge.mjs\" track",
+            "timeout": 5000
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PROJECT_DIR:-.}/.claude/guards/epic-status-nudge.mjs\" nudge",
+            "timeout": 5000
+          }
+        ]
+      }
     ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ node_modules/
 
 # graft's local graph cache - regenerable, not committed (run `graft build`).
 graft/
+
+# Local, per-checkout state for .claude/guards/epic-status-nudge.mjs.
+.claude/.epic-status-nudge-state.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,6 +156,17 @@ the fallback becomes no-op status polls that burn turns and tokens.
   Run it instead of repeated `gh issue view` reads, and post a one-line
   status to the epic ledger at each state transition so the user can
   self-serve.
+- Both of the above are standing behavior, not something to do only when
+  asked (issue #613: over four days, `epic-status.sh` ran 15 times
+  against 440 hand-rolled `gh issue view` calls, and every fleet task
+  death in that window was found by someone remembering to reconcile,
+  never by an error surfacing on its own). Concretely: run
+  `scripts/epic-status.sh <epic>` for every epic you are actively
+  driving before dispatching new work on it, and again at each idle
+  wakeup while a wave is in flight -- not only in response to a status
+  question. On a terminal fleet event (a dispatched task reaching
+  done/failed), send a `PushNotification` as part of handling that
+  event, not only after the user asks what happened.
 
 ### CI workflow changes
 


### PR DESCRIPTION
## Summary

Over four days, `epic-status.sh` ran 15 times against 440 hand-rolled
`gh issue view`/`gh pr view` calls, and every fleet task death in that
window was found by someone remembering to reconcile, never by an
error surfacing on its own. CLAUDE.md already named `epic-status.sh`
as the one answer to "where are we at", but nothing pushed a session
toward actually running it.

- Strengthens the CLAUDE.md directive: reconciliation and terminal
  fleet-event notification are standing behavior, not something to do
  only when asked.
- Adds a soft nudge via two hooks:
  - `PostToolUse` (Bash) counts hand-rolled `gh issue/pr view`/`list`
    calls in a local, gitignored state file, resetting to zero on
    every `scripts/epic-status.sh` run.
  - `UserPromptSubmit` reads that counter and, past a threshold (8),
    writes a one-line reminder to stdout, which becomes additional
    context on the next turn.
  - Split across two events because `PreToolUse` has no proven
    non-blocking context-injection path in this harness (it can only
    allow/deny); `UserPromptSubmit`'s stdout-as-context is already a
    working pattern here (graft's own hooks use it).
  - The hook only ever adds a reminder. A missing or corrupt state
    file degrades to a silent zero-count, never a block.

Not in scope, and said so explicitly on the corrected issue: the
original ticket read as wanting a GitHub Actions cron job and
fleet-event push notifications. The user clarified this is about
local session execution, not CI, and the fleet-notification half
belongs in the `claude-fleet` infra repo, not here -- corrected #613's
body to match before implementing.

## Test plan

- [x] `node --check` both hook scripts
- [x] `bash .claude/guards/epic-status-nudge.test.sh` -- 13/13 pass
      (counts real reconciliation calls, ignores `gh issue create`/`gh
      pr merge`, resets on `epic-status.sh`, stays silent below
      threshold, reminds at threshold, never breaks on malformed
      input)
- [x] `bash .claude/guards/pretooluse.test.sh` -- unaffected, still
      32/32
- [x] `.claude/settings.json` validated as JSON
- [x] End-to-end simulation with the exact command strings from
      `settings.json` (`CLAUDE_PROJECT_DIR` substitution included):
      8 tracked calls produced `{"count":8}` in the real state path,
      and the nudge script printed the reminder

Refs: #613
