### PR TITLE
fix(claude): correct hook timeout and matching in epic-status nudge

### DIFF
--- a/.claude/guards/epic-status-nudge.mjs
+++ b/.claude/guards/epic-status-nudge.mjs
@@ -33,16 +33,47 @@ const NUDGE_THRESHOLD = 8;
 // Matches an ad hoc reconciliation read: `gh issue view`, `gh pr view`, `gh
 // issue list`. Not `gh issue create`/`comment`/`close` and not `gh pr
 // create`/`merge` -- those are real actions, not a stand-in for
-// epic-status.sh.
-const RECONCILE_CALL = /\bgh\s+(issue|pr)\s+(view|list)\b/;
-const EPIC_STATUS_RUN = /\bscripts\/epic-status\.sh\b/;
+// epic-status.sh. Anchored to the START of a command fragment (see
+// commandFragments) rather than searched anywhere in the string, so a commit
+// message or echo that merely mentions either phrase doesn't move the
+// counter -- only an actual invocation does.
+const RECONCILE_CALL = /^gh\s+(issue|pr)\s+(view|list)\b/;
+const EPIC_STATUS_RUN = /^(\.\/)?scripts\/epic-status\.sh\b/;
+
+// Splits a shell command on real command separators and strips a leading
+// `cd ... &&` or env-var assignment from each piece, so "cd x && gh issue
+// view 1" and "FOO=bar gh issue view 1" still match at the START of their
+// fragment. Mirrors pretooluse.mjs's HARMLESS_PREFIX approach, scaled down:
+// this only needs to avoid false positives/negatives on a soft nudge, not
+// close every shell-quoting escape hatch a security gate would.
+const CMD_SEPARATOR = /&&|\|\||[;|\n]/;
+const HARMLESS_PREFIX =
+  /^(\s*(cd\s+[^&;|]+&&|[A-Za-z_][A-Za-z0-9_]*=\S+)\s*)+/;
+
+function commandFragments(command) {
+  return command
+    .split(CMD_SEPARATOR)
+    .map((fragment) => fragment.replace(HARMLESS_PREFIX, "").trim())
+    .filter(Boolean);
+}
+
+function nonNegativeInt(value) {
+  return Number.isInteger(value) && value >= 0 ? value : 0;
+}
 
 function readState() {
   try {
     const parsed = JSON.parse(readFileSync(STATE_PATH, "utf8"));
-    return typeof parsed?.count === "number" ? parsed : { count: 0 };
+    return {
+      count: nonNegativeInt(parsed?.count),
+      // Count value at which nudge() last actually emitted a reminder, so a
+      // session that ignores it isn't re-reminded on every single following
+      // prompt -- only once it has accumulated another threshold's worth of
+      // hand-rolled calls past the last reminder.
+      lastNudgedAt: nonNegativeInt(parsed?.lastNudgedAt),
+    };
   } catch {
-    return { count: 0 };
+    return { count: 0, lastNudgedAt: 0 };
   }
 }
 
@@ -66,26 +97,30 @@ function readStdinJSON() {
 function track() {
   const command = readStdinJSON()?.tool_input?.command;
   if (typeof command !== "string") return;
+  const fragments = commandFragments(command);
   const state = readState();
-  if (EPIC_STATUS_RUN.test(command)) {
-    state.count = 0;
-    writeState(state);
-  } else if (RECONCILE_CALL.test(command)) {
-    state.count = (state.count ?? 0) + 1;
-    writeState(state);
+  if (fragments.some((fragment) => EPIC_STATUS_RUN.test(fragment))) {
+    writeState({ count: 0, lastNudgedAt: 0 });
+  } else if (fragments.some((fragment) => RECONCILE_CALL.test(fragment))) {
+    writeState({ ...state, count: state.count + 1 });
   }
 }
 
 function nudge() {
-  const { count } = readState();
-  if (count >= NUDGE_THRESHOLD) {
-    process.stdout.write(
-      `${count} hand-rolled \`gh issue/pr view\`-style calls since the ` +
-        "last `scripts/epic-status.sh` run (issue #613). If you're " +
-        "tracking an epic, run epic-status.sh instead of continuing to " +
-        "poll by hand.",
-    );
+  const state = readState();
+  if (
+    state.count < NUDGE_THRESHOLD ||
+    state.count < state.lastNudgedAt + NUDGE_THRESHOLD
+  ) {
+    return;
   }
+  process.stdout.write(
+    `${state.count} hand-rolled \`gh issue/pr view\`-style calls since the ` +
+      "last `scripts/epic-status.sh` run (issue #613). If you're " +
+      "tracking an epic, run epic-status.sh instead of continuing to " +
+      "poll by hand.",
+  );
+  writeState({ ...state, lastNudgedAt: state.count });
 }
 
 const mode = process.argv[2];

--- a/.claude/guards/epic-status-nudge.test.sh
+++ b/.claude/guards/epic-status-nudge.test.sh
@@ -7,7 +7,9 @@ SCRIPT="$(cd "$(dirname "$0")" && pwd)/epic-status-nudge.mjs"
 pass=0
 fail=0
 
-tmpstate="$(mktemp -d)/state.json"
+tmpdir="$(mktemp -d)" || { echo "FAIL  could not create a temp dir for test state" >&2; exit 1; }
+trap 'rm -rf "$tmpdir"' EXIT
+tmpstate="$tmpdir/state.json"
 export EPIC_STATUS_NUDGE_STATE="$tmpstate"
 
 bash_payload() {
@@ -32,7 +34,7 @@ check_count() {
   if [ "$got" = "$want" ]; then
     pass=$((pass + 1))
   else
-    printf 'FAIL  %-52s want count=%s, got %s\n' "$label" "$want" "$got"
+    printf 'FAIL  %-58s want count=%s, got %s\n' "$label" "$want" "$got"
     fail=$((fail + 1))
   fi
 }
@@ -44,14 +46,14 @@ check_nudge() {
     if [ -z "$out" ]; then
       pass=$((pass + 1))
     else
-      printf 'FAIL  %-52s want silent, got: %s\n' "$label" "$out"
+      printf 'FAIL  %-58s want silent, got: %s\n' "$label" "$out"
       fail=$((fail + 1))
     fi
   else
     if printf '%s' "$out" | grep -q "epic-status.sh"; then
       pass=$((pass + 1))
     else
-      printf 'FAIL  %-52s want a reminder, got: %s\n' "$label" "$out"
+      printf 'FAIL  %-58s want a reminder, got: %s\n' "$label" "$out"
       fail=$((fail + 1))
     fi
   fi
@@ -75,18 +77,41 @@ check_count 3 "gh pr merge does not count as reconciliation"
 track 'cargo test -p ravel-cli'
 check_count 3 "unrelated command does not count"
 
+# --- matching is anchored to a command position, not a substring search ----
+track 'git commit -m "explain why scripts/epic-status.sh is broken"'
+check_count 3 "a commit message mentioning epic-status.sh does not reset"
+track 'echo "run gh issue view instead"'
+check_count 3 "a string merely mentioning gh issue view does not increment"
+track 'cd /tmp && gh issue view 42 --repo NOFireAI/ravel'
+check_count 4 "a gh call after a harmless cd prefix still counts"
+track 'GH_TOKEN=x gh issue view 42 --repo NOFireAI/ravel'
+check_count 5 "a gh call after an env-var prefix still counts"
+
 # --- below threshold: silent -----------------------------------------------
-check_nudge silent "count 3 is below threshold"
+check_nudge silent "count 5 is below threshold"
 
 # --- cross threshold --------------------------------------------------------
-for _ in 1 2 3 4 5; do track 'gh issue view 1 --repo NOFireAI/ravel'; done
+for _ in 1 2 3; do track 'gh issue view 1 --repo NOFireAI/ravel'; done
 check_count 8 "count reaches threshold"
 check_nudge remind "count 8 at threshold reminds"
+check_nudge silent "does not repeat the same reminder on the very next prompt"
+
+# --- climbing further past a nudge reminds again ----------------------------
+for _ in 1 2 3 4 5 6 7 8; do track 'gh issue view 1 --repo NOFireAI/ravel'; done
+check_count 16 "count climbs past the first nudge"
+check_nudge remind "reminds again after another threshold's worth of calls"
 
 # --- epic-status.sh resets --------------------------------------------------
 track 'scripts/epic-status.sh 597'
 check_count 0 "epic-status.sh run resets the counter"
 check_nudge silent "silent again right after a reset"
+
+# --- epic-status.sh only counts as a real command, not a mention -----------
+for _ in 1 2 3 4 5 6 7 8; do track 'gh issue view 1 --repo NOFireAI/ravel'; done
+check_count 8 "count reaches threshold again after the reset"
+check_nudge remind "reminds again after the reset and a fresh climb"
+track './scripts/epic-status.sh 597'
+check_count 0 "a ./-prefixed epic-status.sh run also resets"
 
 # --- malformed input never breaks anything ----------------------------------
 printf '' | node "$SCRIPT" track

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -28,7 +28,7 @@
           {
             "type": "command",
             "command": "node \"${CLAUDE_PROJECT_DIR:-.}/.claude/guards/epic-status-nudge.mjs\" track",
-            "timeout": 5000
+            "timeout": 5
           }
         ]
       }
@@ -39,7 +39,7 @@
           {
             "type": "command",
             "command": "node \"${CLAUDE_PROJECT_DIR:-.}/.claude/guards/epic-status-nudge.mjs\" nudge",
-            "timeout": 5000
+            "timeout": 5
           }
         ]
       }


### PR DESCRIPTION
## Summary
- `epic-status-nudge.mjs`'s `PostToolUse`/`UserPromptSubmit` hooks were given `timeout: 5000`; this harness's hook timeouts are seconds (the sibling `PreToolUse` hook already uses `10`), so `5000` meant an ~83-minute stall risk on every Bash call and user prompt if the tracker ever hung. Fixed to `5`.
- The reconciliation-call and epic-status-run regexes matched anywhere in the command string, not just at an actual invocation, so a commit message or echo merely mentioning either phrase moved the counter. Now anchored to the start of a shell command fragment (split on `&&`/`||`/`;`/`|`, harmless `cd`/env-var prefixes stripped, mirroring `pretooluse.mjs`'s `HARMLESS_PREFIX`).
- The reminder used to fire unchanged on every single prompt once the counter crossed 8, forever, regardless of relevance, until an `epic-status.sh` run happened to reset it. Now it fires once per threshold crossing and waits for another full threshold's worth of calls before firing again.

Found in code review of #626 after it merged.

## Test plan
- [x] `bash .claude/guards/epic-status-nudge.test.sh` — 23/23 pass (rewritten with new anchoring and repeat-nudge cases)
- [x] Mutation-checked both fixes: reverting the anchoring turns 7 cases red, reverting the repeat-nudge decay turns 1 case red
- [x] `bash .claude/guards/pretooluse.test.sh` — 32/32 pass, no regression
- [x] `.claude/settings.json` validated as JSON
