### PR TITLE
feat(promql): carry native histograms through range evaluation

### DIFF
--- a/crates/ravel-promql/src/aggregate.rs
+++ b/crates/ravel-promql/src/aggregate.rs
@@ -419,6 +419,14 @@ fn eval_quantile(
     if !(0.0..=1.0).contains(&q) {
         ctx.warn(invalid_quantile_warning(q));
     }
+    // `quantile` has no defined native-histogram semantics in Prometheus
+    // (ADR-0108 decision 2): histogram elements are dropped, never treated as
+    // their meaningless `0.0` placeholder float. Filtering here keeps any float
+    // members of the same group and omits a group that held only histograms.
+    let input: InstantVector = input
+        .into_iter()
+        .filter(|s| s.histogram.is_none())
+        .collect();
     group_by(modifier, input, |s| s.value)
         .into_iter()
         .map(|(labels, values)| InstantSample {
@@ -537,6 +545,15 @@ fn eval_topk_bottomk(
         return Vec::new();
     }
     let k = k_raw as usize;
+
+    // `topk`/`bottomk` have no defined native-histogram semantics in Prometheus
+    // (ADR-0108 decision 2): a histogram element is dropped rather than ranked
+    // by its meaningless `0.0` placeholder float. Float members of the same
+    // group are kept and ranked as usual.
+    let input: InstantVector = input
+        .into_iter()
+        .filter(|s| s.histogram.is_none())
+        .collect();
 
     let mut out = Vec::new();
     for (_labels, members) in group_by(modifier, input, |s| s) {

--- a/crates/ravel-promql/src/eval.rs
+++ b/crates/ravel-promql/src/eval.rs
@@ -152,6 +152,114 @@ pub type RangeMatrix = Vec<(LabelSet, Vec<Sample>)>;
 /// result rendering yet.
 pub(crate) type HistogramMatrix = Vec<(LabelSet, Vec<crate::histogram::TimedHistogram>)>;
 
+/// One evaluated step of a histogram-aware range series: a float or a native
+/// histogram, the range counterpart of [`InstantSample`]'s `value`/`histogram`
+/// pair carrying only the reported timestamp (a range result never needs
+/// `orig_sample_ts_ns`). When `histogram` is `Some`, `value` is a meaningless
+/// `0.0` placeholder exactly as on [`InstantSample`], and histogram-aware
+/// consumers read `histogram` instead.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RangeSample {
+    pub ts_ns: i64,
+    pub value: f64,
+    pub histogram: Option<crate::histogram::FloatHistogram>,
+}
+
+impl RangeSample {
+    /// A plain float element (`histogram: None`).
+    pub(crate) fn scalar(ts_ns: i64, value: f64) -> Self {
+        RangeSample {
+            ts_ns,
+            value,
+            histogram: None,
+        }
+    }
+
+    /// A native-histogram element, with a placeholder `value` of `0.0`.
+    pub(crate) fn histogram(ts_ns: i64, histogram: crate::histogram::FloatHistogram) -> Self {
+        RangeSample {
+            ts_ns,
+            value: 0.0,
+            histogram: Some(histogram),
+        }
+    }
+}
+
+/// A histogram-aware range matrix: one entry per matched series, each with one
+/// [`RangeSample`] per evaluated step at which the series had a value. The
+/// native-histogram-carrying counterpart of [`RangeMatrix`]. This is the
+/// internal channel range evaluation fills end to end (ADR-0108 decision 1);
+/// [`Value::Matrix`] and [`Evaluator::eval_range_annotated`] stay float-only
+/// (histogram elements are dropped, never rendered as `0.0`) until T3 (#579)
+/// teaches the HTTP layer to render the histogram elements
+/// [`Evaluator::eval_range_hist_annotated`] exposes.
+pub type HistogramAwareMatrix = Vec<(LabelSet, Vec<RangeSample>)>;
+
+/// A histogram-aware range value: the range counterpart of [`Value`] whose
+/// matrix carries per-step native-histogram elements alongside floats.
+/// Returned by [`Evaluator::eval_range_hist_annotated`]; scalar/string
+/// top-level results are constant across the grid and carried unchanged.
+#[derive(Debug, Clone, PartialEq)]
+pub enum RangeValue {
+    Scalar(f64),
+    String(String),
+    Matrix(HistogramAwareMatrix),
+}
+
+impl RangeValue {
+    /// Project down to the float-only [`Value`] the current HTTP renderer
+    /// consumes: histogram elements are dropped (never emitted as a `0.0`
+    /// float, the silent-zeros defect ADR-0108 forbids), and a series left
+    /// with no float element is omitted.
+    pub(crate) fn into_value(self) -> Value {
+        match self {
+            RangeValue::Scalar(v) => Value::Scalar(v),
+            RangeValue::String(s) => Value::String(s),
+            RangeValue::Matrix(m) => Value::Matrix(hist_matrix_into_float(m)),
+        }
+    }
+}
+
+/// Wrap a float-only [`RangeMatrix`] into the histogram-aware form (every
+/// element a float, `histogram: None`). Used by range paths that produce only
+/// floats (top-level function calls) so their output joins the same channel as
+/// the selector and grid paths.
+pub(crate) fn float_matrix_into_hist(m: RangeMatrix) -> HistogramAwareMatrix {
+    m.into_iter()
+        .map(|(labels, samples)| {
+            let samples = samples
+                .into_iter()
+                .map(|s| RangeSample::scalar(s.ts_ns, s.value))
+                .collect();
+            (labels, samples)
+        })
+        .collect()
+}
+
+/// Project a [`HistogramAwareMatrix`] down to the float-only [`RangeMatrix`]
+/// [`Value::Matrix`] carries: histogram elements are dropped rather than
+/// rendered as a `0.0` float (ADR-0108's forbidden silent zeros), and a series
+/// left with no float element is omitted entirely.
+pub(crate) fn hist_matrix_into_float(m: HistogramAwareMatrix) -> RangeMatrix {
+    m.into_iter()
+        .filter_map(|(labels, samples)| {
+            let floats: Vec<Sample> = samples
+                .into_iter()
+                .filter(|s| s.histogram.is_none())
+                .map(|s| Sample {
+                    ts_ns: s.ts_ns,
+                    value: s.value,
+                })
+                .collect();
+            if floats.is_empty() {
+                None
+            } else {
+                Some((labels, floats))
+            }
+        })
+        .collect()
+}
+
 /// A typed evaluation result. Internal to `ravel-promql`: AST types from
 /// promql-parser still do not leak from the crate (ADR-0007 consequence).
 #[derive(Debug, Clone, PartialEq)]
@@ -659,6 +767,25 @@ impl Evaluator {
         end_ms: i64,
         step_ms: i64,
     ) -> Result<(Value, Annotations), Error> {
+        let (value, annotations) =
+            self.eval_range_hist_annotated(source, query, start_ms, end_ms, step_ms)?;
+        Ok((value.into_value(), annotations))
+    }
+
+    /// The histogram-aware form of [`Self::eval_range_annotated`]: identical
+    /// evaluation, but the matrix result is a [`HistogramAwareMatrix`] carrying
+    /// per-step native-histogram elements alongside floats (ADR-0108). This is
+    /// the seam T3 (#579) renders over HTTP; [`Self::eval_range_annotated`] is
+    /// the thin wrapper that projects histogram elements away for the current
+    /// float-only renderer (via [`RangeValue::into_value`]).
+    pub fn eval_range_hist_annotated(
+        &self,
+        source: &dyn SeriesSource,
+        query: &str,
+        start_ms: i64,
+        end_ms: i64,
+        step_ms: i64,
+    ) -> Result<(RangeValue, Annotations), Error> {
         if step_ms <= 0 {
             return Err(Error::NonPositiveStep { step_ms });
         }
@@ -703,13 +830,13 @@ impl Evaluator {
         // cursoring (ADR-0021 §1) becomes necessary; it is not needed yet.
         let (core, negate) = resolve_range_core(&expr)?;
         let value = match core {
-            RangeCore::Scalar(v) => Value::Scalar(if negate { -v } else { v }),
-            RangeCore::Str(s) => Value::String(s.to_string()),
+            RangeCore::Scalar(v) => RangeValue::Scalar(if negate { -v } else { v }),
+            RangeCore::Str(s) => RangeValue::String(s.to_string()),
             RangeCore::Selector(vs) => {
                 let matrix = self.eval_range_selector(
                     source, vs, start_ns, end_ns, step_ns, points, &ctx, negate,
                 )?;
-                Value::Matrix(matrix)
+                RangeValue::Matrix(matrix)
             }
             RangeCore::Call(call) => {
                 let matrix = crate::functions::eval_range_call(
@@ -720,7 +847,7 @@ impl Evaluator {
                 } else {
                     matrix
                 };
-                Value::Matrix(matrix)
+                RangeValue::Matrix(float_matrix_into_hist(matrix))
             }
             RangeCore::Generic(e) => {
                 let matrix =
@@ -728,7 +855,7 @@ impl Evaluator {
                         ctx.check_deadline()?;
                         self.eval_expr(source, e, t, &ctx)
                     })?;
-                Value::Matrix(matrix)
+                RangeValue::Matrix(matrix)
             }
         };
         Ok((value, ctx.annotations.into_inner()))
@@ -956,21 +1083,21 @@ impl Evaluator {
         }
         ctx.charge_budget(points, self.max_total_eval_points)?;
 
-        crate::functions::eval_instant_over_grid(start_ns, end_ns, step_ns, |t| {
+        let matrix = crate::functions::eval_instant_over_grid(start_ns, end_ns, step_ns, |t| {
             ctx.check_deadline()?;
             let value = self.eval_expr(source, &sq.expr, t, ctx)?;
             // Native-histogram series inside a subquery window are not yet
-            // supported. The subquery grid reducer (`eval_instant_over_grid`)
-            // keeps only the float value of each instant sample, so any
-            // histogram element the inner expression produces would be
-            // silently dropped and the subquery would return a wrong (empty)
-            // answer for that series. Detect the actual presence of matched
-            // histogram data and reject it as a typed `Error::Unsupported`
-            // (HTTP 422) instead. The trigger is real histogram data in the
-            // fetched window, not the subquery's syntactic shape: a float-only
-            // subquery (including `rate(x[5m:1m])` over float series) sees no
-            // histogram element here and keeps working exactly as before.
-            // Full histogram subquery support is not yet implemented.
+            // supported. The subquery grid reducer keeps only the float value
+            // of each instant sample below (`hist_matrix_into_float`), so any
+            // histogram element the inner expression produces would be silently
+            // dropped and the subquery would return a wrong (empty) answer for
+            // that series. Detect the actual presence of matched histogram data
+            // and reject it as a typed `Error::Unsupported` (HTTP 422) instead.
+            // The trigger is real histogram data in the fetched window, not the
+            // subquery's syntactic shape: a float-only subquery (including
+            // `rate(x[5m:1m])` over float series) sees no histogram element here
+            // and keeps working exactly as before. Full histogram subquery
+            // support is not yet implemented.
             if let Value::Vector(ref v) = value
                 && v.iter().any(|s| s.histogram.is_some())
             {
@@ -979,7 +1106,8 @@ impl Evaluator {
                 });
             }
             Ok(value)
-        })
+        })?;
+        Ok(hist_matrix_into_float(matrix))
     }
 
     /// The native-histogram counterpart of [`Self::eval_matrix_selector`] at
@@ -1026,6 +1154,15 @@ impl Evaluator {
     /// the whole grid, generalized to
     /// support `@` (which, when present, pins every step to the same
     /// instant rather than shifting with `t`).
+    ///
+    /// A native-histogram series matching the same selector is served from a
+    /// single `source.query_histograms` call over the same combined window
+    /// (ADR-0108 decision 3, fetch-boundedness): the read is issued once per
+    /// query window, never per grid step, so a bare histogram selector
+    /// produces a matrix of histogram elements instead of vanishing. Per step
+    /// the histogram is chosen with the same left-open `pick_histogram`
+    /// lookback rule the instant selector uses. A series is either float or
+    /// histogram in storage, so the two never collide.
     #[allow(clippy::too_many_arguments)]
     fn eval_range_selector(
         &self,
@@ -1037,7 +1174,7 @@ impl Evaluator {
         points: u64,
         ctx: &QueryWindow,
         negate: bool,
-    ) -> Result<RangeMatrix, Error> {
+    ) -> Result<HistogramAwareMatrix, Error> {
         let selector_matchers = build_matchers(vs)?;
         let offset_ns = signed_offset_ns(vs.offset.as_ref())?;
         let at_ts_ns = resolve_at(vs.at.as_ref(), ctx.start_ns, ctx.end_ns)?;
@@ -1074,10 +1211,41 @@ impl Evaluator {
                 if let Some((value, _orig_sample_ts_ns)) =
                     pick_sample(&s.samples, *sel_ts, self.lookback_delta_ns)
                 {
-                    samples.push(Sample {
-                        ts_ns: *reported_ts,
-                        value: if negate { -value } else { value },
-                    });
+                    samples.push(RangeSample::scalar(
+                        *reported_ts,
+                        if negate { -value } else { value },
+                    ));
+                }
+            }
+            if !samples.is_empty() {
+                let labels = if negate {
+                    drop_metric_name(s.labels)
+                } else {
+                    s.labels
+                };
+                out.push((labels, samples));
+            }
+        }
+
+        // Histogram series matching the same selector, one window fetch shared
+        // across every grid step.
+        let hist_series = source.query_histograms(&selector_matchers, window)?;
+        for s in hist_series {
+            let mut samples = Vec::new();
+            for (reported_ts, sel_ts) in &grid {
+                if let Some((histogram, _orig_sample_ts_ns)) =
+                    pick_histogram(&s.samples, *sel_ts, self.lookback_delta_ns)
+                {
+                    // Unary minus over a native-histogram element multiplies
+                    // every population by -1 (matching `negate_vector`).
+                    let histogram = if negate {
+                        let mut h = histogram;
+                        h.mul(-1.0);
+                        h
+                    } else {
+                        histogram
+                    };
+                    samples.push(RangeSample::histogram(*reported_ts, histogram));
                 }
             }
             if !samples.is_empty() {
@@ -2444,6 +2612,48 @@ mod tests {
             construct.contains("subquery over native histograms"),
             "construct {construct:?} should name the histogram-subquery construct for {query:?}"
         );
+    }
+
+    #[test]
+    fn range_selector_serves_native_histogram_elements() {
+        // A bare native-histogram range selector must produce a matrix of
+        // histogram elements, not vanish. Before the fix `eval_range_selector`
+        // issued `source.query` only (no `query_histograms` pass), so a
+        // histogram-only selector returned an empty matrix; the flipped
+        // assertion is `matrix.len() == 1`.
+        let source = TestSource::new()
+            .with_histogram_series(
+                &[("__name__", "h")],
+                &[(0, nh(2.0, 10.0)), (minutes(5) * 1_000_000, nh(4.0, 20.0))],
+            )
+            .expect("valid histogram series");
+        let (value, _annotations) = Evaluator::new()
+            .eval_range_hist_annotated(&source, "h", 0, minutes(5), minutes(1))
+            .expect("range evaluates");
+        let RangeValue::Matrix(matrix) = value else {
+            panic!("bare selector must be a matrix");
+        };
+        assert_eq!(matrix.len(), 1, "one histogram series");
+        let (_labels, samples) = &matrix[0];
+        // Grid steps at 0..=5 minutes: the t=0 sample is picked through 4m
+        // (inside the default 5m lookback), the 5m sample at 5m, so every step
+        // has a histogram element.
+        assert_eq!(samples.len(), 6, "one element per grid step");
+        for s in samples {
+            assert!(
+                s.histogram.is_some(),
+                "every element is a histogram, never a 0.0 float"
+            );
+        }
+        let first = samples[0].histogram.as_ref().expect("histogram element");
+        assert_eq!(first.count.to_bits(), 2.0_f64.to_bits());
+        assert_eq!(first.sum.to_bits(), 10.0_f64.to_bits());
+        let last = samples
+            .last()
+            .and_then(|s| s.histogram.as_ref())
+            .expect("histogram element");
+        assert_eq!(last.count.to_bits(), 4.0_f64.to_bits());
+        assert_eq!(last.sum.to_bits(), 20.0_f64.to_bits());
     }
 
     #[test]

--- a/crates/ravel-promql/src/functions/mod.rs
+++ b/crates/ravel-promql/src/functions/mod.rs
@@ -22,9 +22,9 @@ mod transform;
 use ravel_types::{LabelSet, Sample};
 
 use crate::eval::{
-    Error, Evaluator, InstantSample, InstantVector, QueryWindow, RangeMatrix, Value,
-    drop_metric_name, duration_to_ns, invalid_quantile_warning, possible_non_counter_info,
-    resolve_eval_ts, selector_eval_ts,
+    Error, Evaluator, HistogramAwareMatrix, InstantSample, InstantVector, QueryWindow, RangeMatrix,
+    RangeSample, Value, drop_metric_name, duration_to_ns, hist_matrix_into_float,
+    invalid_quantile_warning, possible_non_counter_info, resolve_eval_ts, selector_eval_ts,
 };
 use crate::histogram::{FloatHistogram, TimedHistogram};
 use crate::source::SeriesSource;
@@ -455,12 +455,16 @@ pub(crate) fn eval_range_call(
         // at a range-query top level, matching what it already did nested in
         // an arithmetic identity.
         FunctionKind::HistogramQuantile(f) => {
+            // Quantile/fraction results are float-valued, so the grid produces
+            // only float elements; project down to the float matrix this range
+            // call returns.
             eval_instant_over_grid(start_ns, end_ns, step_ns, |t| {
                 ctx.check_deadline()?;
                 let phi = scalar_arg(evaluator, source, &call.args.args[0], t, ctx)?;
                 let vector = vector_arg(evaluator, source, &call.args.args[1], t, ctx)?;
                 Ok(Value::Vector(to_instant_vector(f(phi, vector, ctx), t)))
             })
+            .map(hist_matrix_into_float)
         }
         FunctionKind::HistogramFraction(f) => {
             eval_instant_over_grid(start_ns, end_ns, step_ns, |t| {
@@ -473,6 +477,7 @@ pub(crate) fn eval_range_call(
                     t,
                 )))
             })
+            .map(hist_matrix_into_float)
         }
         FunctionKind::ScalarRangeVector(f) => {
             let scalar_expr = &call.args.args[0];
@@ -531,15 +536,24 @@ pub(crate) fn eval_range_call(
                 evaluator, source, arg, start_ns, end_ns, step_ns, ctx,
             )
         }
+        // A top-level `VectorMap`/`Instant` function call is a float-only range
+        // result today: any histogram element the per-step evaluation carries
+        // is projected away rather than rendered as a `0.0` float (the grid
+        // path that preserves histograms is `RangeCore::Generic`, top-level
+        // aggregates and binary expressions, handled in `eval.rs`). Histogram
+        // semantics for these function families are ADR-0108 decisions 4/5,
+        // out of this task's scope.
         FunctionKind::VectorMap(f) => eval_instant_over_grid(start_ns, end_ns, step_ns, |t| {
             ctx.check_deadline()?;
             let v = vector_arg(evaluator, source, &call.args.args[0], t, ctx)?;
             Ok(Value::Vector(f(v)))
-        }),
+        })
+        .map(hist_matrix_into_float),
         FunctionKind::Instant(f) => eval_instant_over_grid(start_ns, end_ns, step_ns, |t| {
             ctx.check_deadline()?;
             f(evaluator, source, call, t, ctx)
-        }),
+        })
+        .map(hist_matrix_into_float),
     }
 }
 
@@ -560,33 +574,36 @@ pub(crate) fn eval_instant_over_grid(
     end_ns: i64,
     step_ns: i64,
     mut step_fn: impl FnMut(i64) -> Result<Value, Error>,
-) -> Result<RangeMatrix, Error> {
-    let mut series: Vec<(LabelSet, Vec<Sample>)> = Vec::new();
+) -> Result<HistogramAwareMatrix, Error> {
+    let mut series: Vec<(LabelSet, Vec<RangeSample>)> = Vec::new();
     let mut t = start_ns;
     while t <= end_ns {
         match step_fn(t)? {
             Value::Vector(v) => {
                 for s in v {
+                    // Preserve the element type per step: a histogram element
+                    // is materialized as a histogram range element, not
+                    // collapsed to its meaningless `0.0` placeholder float
+                    // (ADR-0108 decision 2, the silent-zeros fix). This keeps
+                    // the grid path (top-level aggregates and binary
+                    // expressions) faithful to the instant path it re-runs at
+                    // each step.
+                    let element = match s.histogram {
+                        Some(h) => RangeSample::histogram(t, h),
+                        None => RangeSample::scalar(t, s.value),
+                    };
                     match series.iter_mut().find(|(labels, _)| *labels == s.labels) {
-                        Some((_, samples)) => samples.push(Sample {
-                            ts_ns: t,
-                            value: s.value,
-                        }),
-                        None => series.push((
-                            s.labels,
-                            vec![Sample {
-                                ts_ns: t,
-                                value: s.value,
-                            }],
-                        )),
+                        Some((_, samples)) => samples.push(element),
+                        None => series.push((s.labels, vec![element])),
                     }
                 }
             }
             Value::Scalar(x) => {
                 let labels = LabelSet::default();
+                let element = RangeSample::scalar(t, x);
                 match series.iter_mut().find(|(l, _)| *l == labels) {
-                    Some((_, samples)) => samples.push(Sample { ts_ns: t, value: x }),
-                    None => series.push((labels, vec![Sample { ts_ns: t, value: x }])),
+                    Some((_, samples)) => samples.push(element),
+                    None => series.push((labels, vec![element])),
                 }
             }
             other => {
@@ -1497,5 +1514,149 @@ mod tests {
             samples[1].value.is_finite(),
             "second step: tm=5.0 is now in lookback, predict_linear must use this step's own duration"
         );
+    }
+
+    /// A simple scale-0 native histogram carrying `count`/`sum`, one positive
+    /// bucket, for the range-grid aggregation tests below.
+    fn nh(count: f64, sum: f64) -> FloatHistogram {
+        FloatHistogram {
+            counter_reset_hint: ResetHint::Unknown,
+            scale: 0,
+            zero_threshold: 0.0,
+            zero_count: 0.0,
+            count,
+            sum,
+            positive_spans: vec![Span {
+                offset: 1,
+                length: 1,
+            }],
+            negative_spans: Vec::new(),
+            positive_buckets: vec![count],
+            negative_buckets: Vec::new(),
+            custom_values: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn range_grid_keeps_histogram_elements_from_top_level_sum() {
+        // A top-level `sum` over native-histogram series is a `RangeCore::Generic`
+        // grid path. Before the fix `eval_instant_over_grid` collapsed each
+        // `InstantSample` into `Sample { ts_ns, value }`, discarding the
+        // histogram and emitting the meaningless `0.0` placeholder; the flipped
+        // assertion is `samples[0].histogram.is_some()` (it was `None`, value
+        // `0.0`, pre-fix).
+        let source = TestSource::new()
+            .with_histogram_series(&[("__name__", "h"), ("i", "1")], &[(0, nh(2.0, 10.0))])
+            .expect("valid histogram series")
+            .with_histogram_series(&[("__name__", "h"), ("i", "2")], &[(0, nh(2.0, 10.0))])
+            .expect("valid histogram series");
+        let (value, _annotations) = Evaluator::new()
+            .eval_range_hist_annotated(&source, "sum(h)", 0, 60_000, 60_000)
+            .expect("range evaluates");
+        let crate::eval::RangeValue::Matrix(matrix) = value else {
+            panic!("sum over histograms must be a matrix");
+        };
+        assert_eq!(matrix.len(), 1, "one aggregated group");
+        let samples = &matrix[0].1;
+        assert!(!samples.is_empty(), "at least one grid step");
+        for s in samples {
+            let h = s
+                .histogram
+                .as_ref()
+                .expect("sum over histograms yields a histogram element, not a 0.0 float");
+            assert_eq!(h.count.to_bits(), 4.0_f64.to_bits(), "2 + 2 populations");
+            assert_eq!(h.sum.to_bits(), 20.0_f64.to_bits(), "10 + 10 sums");
+        }
+    }
+
+    #[test]
+    fn range_grid_count_yields_floats_for_histogram_inputs() {
+        // `count` over histogram inputs is a float, per the ADR-0108 per-operator
+        // table. The float value (2) was already correct pre-fix; what the new
+        // histogram-aware channel makes assertable is that this element is a
+        // float element (`histogram: None`), never routed through histogram
+        // aggregation. The flipped line is `samples[0].histogram.is_none()`
+        // alongside the value: it is only observable through
+        // `eval_range_hist_annotated`, which did not exist pre-fix.
+        let source = TestSource::new()
+            .with_histogram_series(&[("__name__", "h"), ("i", "1")], &[(0, nh(2.0, 10.0))])
+            .expect("valid histogram series")
+            .with_histogram_series(&[("__name__", "h"), ("i", "2")], &[(0, nh(3.0, 12.0))])
+            .expect("valid histogram series");
+        let (value, _annotations) = Evaluator::new()
+            .eval_range_hist_annotated(&source, "count(h)", 0, 60_000, 60_000)
+            .expect("range evaluates");
+        let crate::eval::RangeValue::Matrix(matrix) = value else {
+            panic!("count over histograms must be a matrix");
+        };
+        assert_eq!(matrix.len(), 1, "one group");
+        let samples = &matrix[0].1;
+        assert!(!samples.is_empty(), "at least one grid step");
+        for s in samples {
+            assert!(
+                s.histogram.is_none(),
+                "count is a float element, never a histogram"
+            );
+            assert_eq!(
+                s.value.to_bits(),
+                2.0_f64.to_bits(),
+                "two histogram members"
+            );
+        }
+    }
+
+    #[test]
+    fn range_grid_undefined_aggregations_drop_histogram_inputs() {
+        // `quantile` has no defined native-histogram semantics: Prometheus drops
+        // histogram elements. Before the fix `eval_quantile` grouped on the
+        // meaningless `0.0` placeholder float of each histogram element, so a
+        // histogram-only group produced a bogus `0.0` float series; the flipped
+        // assertion is `matrix.is_empty()` (it had one `0.0`-valued series
+        // pre-fix).
+        let source = TestSource::new()
+            .with_histogram_series(&[("__name__", "h"), ("i", "1")], &[(0, nh(2.0, 10.0))])
+            .expect("valid histogram series")
+            .with_histogram_series(&[("__name__", "h"), ("i", "2")], &[(0, nh(3.0, 12.0))])
+            .expect("valid histogram series");
+        let (value, _annotations) = Evaluator::new()
+            .eval_range_hist_annotated(&source, "quantile(0.5, h)", 0, 60_000, 60_000)
+            .expect("range evaluates");
+        let crate::eval::RangeValue::Matrix(matrix) = value else {
+            panic!("quantile must be a matrix");
+        };
+        assert!(
+            matrix.is_empty(),
+            "a histogram-only quantile group is dropped, not emitted as a 0.0 float: {matrix:?}"
+        );
+    }
+
+    #[test]
+    fn grouping_by_preserves_histogram_element_type() {
+        // `sum by (i)` over histogram series keeps each group's element a
+        // histogram end to end (through both grid materialization and the
+        // grouping rebuild). Before the fix the grid dropped the histogram
+        // field, so every group's element was a `0.0` float; the flipped
+        // assertion is `samples[0].histogram.is_some()` for each group.
+        let source = TestSource::new()
+            .with_histogram_series(&[("__name__", "h"), ("i", "1")], &[(0, nh(2.0, 10.0))])
+            .expect("valid histogram series")
+            .with_histogram_series(&[("__name__", "h"), ("i", "2")], &[(0, nh(5.0, 25.0))])
+            .expect("valid histogram series");
+        let (value, _annotations) = Evaluator::new()
+            .eval_range_hist_annotated(&source, "sum by (i) (h)", 0, 60_000, 60_000)
+            .expect("range evaluates");
+        let crate::eval::RangeValue::Matrix(matrix) = value else {
+            panic!("grouped sum must be a matrix");
+        };
+        assert_eq!(matrix.len(), 2, "one group per distinct i label");
+        for (labels, samples) in &matrix {
+            assert!(!samples.is_empty(), "each group has at least one grid step");
+            for s in samples {
+                assert!(
+                    s.histogram.is_some(),
+                    "group {labels:?} preserves its histogram element type"
+                );
+            }
+        }
     }
 }

--- a/crates/ravel-promql/src/lib.rs
+++ b/crates/ravel-promql/src/lib.rs
@@ -32,8 +32,8 @@ pub mod testsource;
 
 pub use eval::{
     Annotations, DEFAULT_LOOKBACK_NS, DEFAULT_MAX_RANGE_POINTS, DEFAULT_MAX_TOTAL_EVAL_POINTS,
-    DEFAULT_SUBQUERY_STEP_NS, Error, Evaluator, InstantSample, InstantVector, QueryWindow,
-    RangeMatrix, Value, ms_to_ns, ns_to_ms_floor,
+    DEFAULT_SUBQUERY_STEP_NS, Error, Evaluator, HistogramAwareMatrix, InstantSample, InstantVector,
+    QueryWindow, RangeMatrix, RangeSample, RangeValue, Value, ms_to_ns, ns_to_ms_floor,
 };
 // ADR-0103 aggregation pushdown: the coordinator (`ravel-query`) derives a
 // count_over_time reduction window on the distributed path and asserts it

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -321,6 +321,27 @@ data, not the syntactic shape: a float-only subquery, including
 `rate(x[5m:1m])` over float series, is unaffected. Real histogram subquery
 support is future work.
 
+Range evaluation carries native-histogram elements end to end inside the
+evaluator (ADR-0108, issue #577). The internal range result is a
+histogram-aware matrix (`RangeSample`, a per-step float-or-histogram element
+mirroring the instant `InstantSample`), filled by three paths: a bare
+histogram selector fetches its series once per query window via
+`query_histograms` and picks a histogram per grid step under the same
+left-open lookback rule the instant selector uses; the grid path
+(`RangeCore::Generic`, top-level aggregates and binary expressions)
+materializes each step's histogram element instead of collapsing it to a
+`0.0` placeholder float, so range output stays faithful to the instant path
+per step. Per-operator aggregation follows Prometheus 3.x: `sum`/`avg` over
+histogram elements produce histogram elements, `count` a float, and the
+operators Prometheus leaves undefined for histograms (`min`, `max`,
+`stddev`, `stdvar`, `quantile`, `topk`, `bottomk`) drop the histogram
+elements. `by`/`without` grouping preserves element type. The
+histogram-aware result is exposed by `Evaluator::eval_range_hist_annotated`;
+`Evaluator::eval_range_annotated` (and the current HTTP renderer) still
+project histogram elements away rather than render them as `0.0` floats, so
+the standard `histograms` field on range responses is future work (issue
+#579).
+
 The max-samples budget is **count-yielded**: samples are counted as the
 lazy k-way merge emits them (post-dedup), and the budget trips at exactly
 `max + 1`. It does not count a fully materialized per-timestamp window


### PR DESCRIPTION
Range evaluation collapsed every native-histogram element to a `0.0`
placeholder float, which is why `/api/v1/query_range` returned matrices of
zeros for top-level aggregates and binary expressions over histogram series,
and empty results for bare histogram selectors, all with HTTP 200.

The internal range result becomes a histogram-aware matrix: `RangeSample` is
a per-step float-or-histogram element mirroring the instant path's
`InstantSample`. A bare histogram selector fetches its series once per query
window and picks a histogram per grid step under the same left-open lookback
rule the instant selector uses. The grid path materializes each step's
histogram element instead of the placeholder, so a range step now agrees with
what the instant path would return for that timestamp.

Per-operator aggregation follows Prometheus 3.x: `sum` and `avg` over
histogram elements produce histogram elements, `count` produces a float, and
the operators Prometheus leaves undefined for histograms (`min`, `max`,
`stddev`, `stdvar`, `quantile`, `topk`, `bottomk`) drop histogram elements.
`by` and `without` grouping preserve element type.

This is the evaluator half only. `eval_range_annotated` and the HTTP renderer
still project histogram elements away rather than render them, so range
responses do not yet carry a `histograms` field; that is #579. The
user-visible symptom is not fixed by this commit alone.

First task of ADR-0108 (docs/adrs/0108-range-eval-over-native-histograms.md).

Fixes: #577
Refs: #573
