### PR TITLE
docs: claim ADR-0110 columnar spans scan

### DIFF
--- a/docs/adrs/0110-columnar-spans-scan.md
+++ b/docs/adrs/0110-columnar-spans-scan.md
@@ -1,0 +1,3 @@
+# ADR-0110: Columnar decode-to-Arrow for the SQL spans scan
+
+Status: claimed


### PR DESCRIPTION
Reserves ADR number 0110 for the columnar decode-to-Arrow spans-scan epic (ADR-0099's explicitly deferred follow-up for crates/ravel-sql/src/spans_scan.rs).

Stub only: title plus Status: claimed. The full ADR content overwrites this file once the design is approved. Landing the reservation on main first keeps two parallel epics from picking the same next-free number.