### PR TITLE
perf(ravel-logseg): per-distinct dictionary encoding and bloom for columnar build

### DIFF
--- a/crates/ravel-codec/src/encoding.rs
+++ b/crates/ravel-codec/src/encoding.rs
@@ -491,6 +491,63 @@ pub fn encode_strings(values: &[&[u8]]) -> (Enc, Vec<u8>) {
     }
 }
 
+/// Encodes a string column already in dictionary shape. `present_ids[i]` is
+/// the dictionary index of present row `i` into `dict`, the column's distinct
+/// values (in any order); `dict` may hold entries no id references. Produces
+/// bytes byte-identical to `encode_strings(&values)` where
+/// `values[i] == dict[present_ids[i] as usize]`, but derives the
+/// dictionary-versus-plain choice and the sorted entry set from the referenced
+/// distinct values alone, never sorting or scanning the per-row values.
+///
+/// A dictionary-shaped columnar producer (ADR-0109 decision 3) calls this once
+/// per block so string encoding costs one sort per distinct value, not the
+/// `encode_strings` sort-plus-`partition_point` per row.
+pub fn encode_strings_dict(dict: &[&[u8]], present_ids: &[u32]) -> (Enc, Vec<u8>) {
+    if present_ids.is_empty() {
+        return (Enc::Plain, Vec::new());
+    }
+    // One pass over the per-row ids (integers) to mark the referenced entries;
+    // the sort below runs over those distinct values, never the per-row values.
+    let mut referenced = vec![false; dict.len()];
+    let mut distinct: Vec<&[u8]> = Vec::new();
+    for &id in present_ids {
+        let i = id as usize;
+        if !referenced[i] {
+            referenced[i] = true;
+            distinct.push(dict[i]);
+        }
+    }
+    distinct.sort_unstable();
+    distinct.dedup();
+
+    if dict_is_worth_it(distinct.len(), present_ids.len()) {
+        // Map each referenced dictionary index to its position in the sorted
+        // distinct set once (per distinct), so the per-row id is an integer
+        // lookup rather than a `partition_point` string search.
+        let mut pos_of = vec![0u32; dict.len()];
+        for (i, seen) in referenced.iter().enumerate() {
+            if *seen {
+                pos_of[i] = distinct.partition_point(|e| *e < dict[i]) as u32;
+            }
+        }
+        let mut out = Vec::new();
+        put_uvarint(&mut out, distinct.len() as u64);
+        for entry in &distinct {
+            put_uvarint(&mut out, entry.len() as u64);
+            out.extend_from_slice(entry);
+        }
+        let ids: Vec<u64> = present_ids
+            .iter()
+            .map(|&id| u64::from(pos_of[id as usize]))
+            .collect();
+        encode_dict_ids(&mut out, &ids, distinct.len());
+        (Enc::Dict, out)
+    } else {
+        let values: Vec<&[u8]> = present_ids.iter().map(|&id| dict[id as usize]).collect();
+        (Enc::Plain, enc_plain_strings(&values))
+    }
+}
+
 /// The non-fusing decode of a string column: either the plain per-value form,
 /// or the dictionary form kept intact (the distinct values plus one id per
 /// value). A dictionary page decoded this way keeps its structure instead of
@@ -1177,6 +1234,28 @@ mod string_dict_proptests {
             let (enc, bytes) = encode_strings(&refs);
             let got = decode_strings(enc, &bytes, refs.len()).expect("decode");
             prop_assert_eq!(got, vals);
+        }
+
+        /// `encode_strings_dict` fed a dictionary and per-row ids produces the
+        /// exact bytes `encode_strings` produces over the fused per-row values,
+        /// across both sides of the dict-versus-plain threshold, with an
+        /// unreferenced dictionary entry and a dictionary carrying duplicate
+        /// values both present.
+        #[test]
+        fn encode_strings_dict_matches_encode_strings(
+            dict in proptest::collection::vec(
+                proptest::collection::vec(any::<u8>(), 0..6), 1..8),
+            ids in proptest::collection::vec(0u32..8, 0..400),
+        ) {
+            // Keep ids in range of the generated dictionary.
+            let ids: Vec<u32> = ids.iter().map(|&i| i % dict.len() as u32).collect();
+            let dref: Vec<&[u8]> = dict.iter().map(|v| v.as_slice()).collect();
+            let fused: Vec<&[u8]> = ids.iter().map(|&i| dref[i as usize]).collect();
+
+            let (want_enc, want_bytes) = encode_strings(&fused);
+            let (got_enc, got_bytes) = encode_strings_dict(&dref, &ids);
+            prop_assert_eq!(got_enc, want_enc);
+            prop_assert_eq!(got_bytes, want_bytes);
         }
 
         #[test]

--- a/crates/ravel-logseg/src/block.rs
+++ b/crates/ravel-logseg/src/block.rs
@@ -13,6 +13,7 @@ use std::collections::{HashMap, HashSet};
 use crate::encoding::{
     DecodedStrings, Enc, decode_bitmap, decode_f64, decode_fixed, decode_i64,
     decode_strings_columnar, encode_bitmap, encode_f64, encode_fixed, encode_i64, encode_strings,
+    encode_strings_dict,
 };
 use crate::error::LogSegError;
 use crate::page::{PageDesc, read_page, write_page};
@@ -451,6 +452,17 @@ fn winner_value(row: &ResolvedRow, column_id: u32) -> Option<&ColumnValue> {
         .map(|(_, v)| v)
 }
 
+/// A block's dictionary-shaped view of one Str/Bytes plan column: the column's
+/// distinct value set (`dict`, in any order, possibly with entries no id
+/// references) and one `Option<index into dict>` per block row (`Some` for a
+/// present row, `None` for absent). The encoder derives the sorted RLOG
+/// dictionary and the dict-versus-plain choice from the referenced distinct
+/// values, so string encoding costs a sort per distinct value, not per row.
+pub struct BlockStrDict<'a> {
+    pub dict: &'a [Vec<u8>],
+    pub ids: &'a [Option<u32>],
+}
+
 /// One block's data already in column-major form, the input to
 /// [`write_block_columnar`]. Each per-row slice has `n` entries; the optional
 /// fixed columns pair a per-row `*_present` bitmap with a dense `*_vals` slice
@@ -481,6 +493,12 @@ pub struct ColumnarBlockInput<'a> {
     /// stat winner for the column, `None` when the row contributes only to
     /// `null_count`.
     pub stat_values: &'a [Vec<Option<ColumnValue>>],
+    /// Per plan (in `plans` order): `Some` when the plan is a Str/Bytes column
+    /// supplied in dictionary shape, in which case its value page is encoded
+    /// via [`encode_strings_dict`] (per distinct value, ADR-0109 decision 3)
+    /// and `values[idx]` is ignored for that plan. `None` keeps the plain
+    /// per-row `values` path unchanged.
+    pub str_dicts: &'a [Option<BlockStrDict<'a>>],
 }
 
 /// Encodes one block from column-major input, byte-identical to
@@ -605,17 +623,26 @@ pub fn write_block_columnar(
                 );
             }
             FieldType::Str | FieldType::Bytes => {
-                let vv: Vec<&[u8]> = vals
-                    .iter()
-                    .filter_map(|v| match v {
-                        Some(ColumnValue::Str(x)) | Some(ColumnValue::Bytes(x)) => {
-                            Some(x.as_slice())
-                        }
-                        _ => None,
-                    })
-                    .collect();
-                let (enc, b) = encode_strings(&vv);
-                stage_column(&mut pages, cid, &present, enc, b);
+                if let Some(dp) = &input.str_dicts[idx] {
+                    // Dictionary-shaped column: encode per distinct value.
+                    let dpresent: Vec<bool> = dp.ids.iter().map(Option::is_some).collect();
+                    let present_ids: Vec<u32> = dp.ids.iter().filter_map(|x| *x).collect();
+                    let dref: Vec<&[u8]> = dp.dict.iter().map(Vec::as_slice).collect();
+                    let (enc, b) = encode_strings_dict(&dref, &present_ids);
+                    stage_column(&mut pages, cid, &dpresent, enc, b);
+                } else {
+                    let vv: Vec<&[u8]> = vals
+                        .iter()
+                        .filter_map(|v| match v {
+                            Some(ColumnValue::Str(x)) | Some(ColumnValue::Bytes(x)) => {
+                                Some(x.as_slice())
+                            }
+                            _ => None,
+                        })
+                        .collect();
+                    let (enc, b) = encode_strings(&vv);
+                    stage_column(&mut pages, cid, &present, enc, b);
+                }
             }
         }
     }

--- a/crates/ravel-logseg/src/columnar_batch.rs
+++ b/crates/ravel-logseg/src/columnar_batch.rs
@@ -21,9 +21,11 @@
 //! like) are a follow-up performance refinement (#603 covers the dictionary
 //! shape); this task builds the plain-value, correctness-anchoring form.
 
+use std::collections::HashMap;
+
 use ravel_types::logstream::{AttrValue, LogStreamId};
 
-use crate::record::{FieldType, LogRecord, resolve_value};
+use crate::record::{ColumnValue, FieldType, LogRecord, resolve_value};
 
 /// A packed presence bitmap, one bit per row, LSB-first within each byte.
 ///
@@ -159,6 +161,24 @@ pub struct DynColumn {
     pub validity: Bitmap,
 }
 
+/// The dictionary shape of one Str/Bytes dynamic column (ADR-0109 decision 3,
+/// mirroring a decoded RLOG dictionary string column, ADR-0099 decision 4):
+/// a `distinct` value set and one `id` per PRESENT cell, parallel to the
+/// column's [`DynColumn::cells`]. `ids[slot]` indexes `distinct`, and
+/// `distinct[ids[slot]]` equals `resolve_value(&cells[slot]).1`'s bytes, so the
+/// writer can map each distinct value to its RLOG entry once per block instead
+/// of once per row. `distinct` may hold entries no id references. The set order
+/// is the producer's; the writer sorts it to match [`encode_strings`].
+///
+/// [`encode_strings`]: crate::encoding::encode_strings
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StrColumnDict {
+    /// Distinct value bytes, in the producer's order.
+    pub distinct: Vec<Vec<u8>>,
+    /// One index into `distinct` per present cell, parallel to `DynColumn::cells`.
+    pub ids: Vec<u32>,
+}
+
 /// A batch of log records in column-major form. Row `i` is assembled by reading
 /// index `i` (or the `i`-th present slot, for optional columns) out of each
 /// buffer. All per-row buffers describe the same `num_rows` rows.
@@ -200,6 +220,16 @@ pub struct ColumnarLogBatch {
     /// Dynamic attribute columns, one per distinct `(name, FieldType)`.
     pub dyn_columns: Vec<DynColumn>,
 
+    /// Optional dictionary shape per dynamic column: when non-empty this has
+    /// one entry per [`Self::dyn_columns`] entry, `Some` only for a Str/Bytes
+    /// column whose distinct set and per-cell ids the producer supplies (a
+    /// Parquet dictionary, #604). The writer then pays string encoding and
+    /// token bloom per distinct value, not per row (ADR-0109 decision 3). An
+    /// empty vector (the default) means no column carries a dictionary and the
+    /// writer takes the plain per-cell path unchanged, so this field is purely
+    /// additive: a producer built against the pre-#603 type leaves it empty.
+    pub dyn_col_dicts: Vec<Option<StrColumnDict>>,
+
     /// Per-row duplicate-loser attributes: the second and later occurrences of
     /// a `(name, type)` pair within one record, which cannot occupy that row's
     /// single column cell. Empty for almost every row. The writer folds these
@@ -226,6 +256,7 @@ impl ColumnarLogBatch {
             stream_ids: Vec::new(),
             stream_attrs: Vec::new(),
             dyn_columns: Vec::new(),
+            dyn_col_dicts: Vec::new(),
             residual_attrs: Vec::new(),
         }
     }
@@ -354,6 +385,53 @@ impl ColumnarLogBatch {
         }
 
         batch
+    }
+
+    /// Fills [`Self::dyn_col_dicts`] with the dictionary shape of every
+    /// Str/Bytes dynamic column, derived from its plain `cells`: the distinct
+    /// value bytes in first-seen order plus one id per present cell. This is
+    /// the bridge the writer-level differential test uses to drive the writer's
+    /// dictionary fast path from records; a producer that already holds Parquet
+    /// dictionaries (#604) supplies the shape directly instead. Non-string
+    /// columns get `None`. Idempotent in effect; overwrites any prior value.
+    pub fn with_dictionaries(mut self) -> Self {
+        let mut dicts: Vec<Option<StrColumnDict>> = Vec::with_capacity(self.dyn_columns.len());
+        for c in &self.dyn_columns {
+            match c.field_type {
+                FieldType::Str | FieldType::Bytes => {
+                    let mut interner: HashMap<Vec<u8>, u32> = HashMap::new();
+                    let mut distinct: Vec<Vec<u8>> = Vec::new();
+                    let mut ids: Vec<u32> = Vec::with_capacity(c.cells.len());
+                    for cell in &c.cells {
+                        let bytes = match resolve_value(cell).1 {
+                            ColumnValue::Str(b) | ColumnValue::Bytes(b) => b,
+                            // A Str/Bytes column resolves only to Str/Bytes; any
+                            // other value would be a mis-typed column, so fall
+                            // back to the plain path rather than guess.
+                            _ => {
+                                distinct.clear();
+                                ids.clear();
+                                break;
+                            }
+                        };
+                        let next = distinct.len() as u32;
+                        let id = *interner.entry(bytes.clone()).or_insert_with(|| {
+                            distinct.push(bytes);
+                            next
+                        });
+                        ids.push(id);
+                    }
+                    if ids.len() == c.cells.len() {
+                        dicts.push(Some(StrColumnDict { distinct, ids }));
+                    } else {
+                        dicts.push(None);
+                    }
+                }
+                _ => dicts.push(None),
+            }
+        }
+        self.dyn_col_dicts = dicts;
+        self
     }
 }
 

--- a/crates/ravel-logseg/src/lib.rs
+++ b/crates/ravel-logseg/src/lib.rs
@@ -39,7 +39,7 @@ pub use ravel_codec::{bloom, bloom_section, encoding, tokenizer};
 // decoded block, so decision 4 can change how columns are stored without
 // touching a caller.
 pub use columnar::{AttrColumn, ColumnarBlockView, StrDictColumn};
-pub use columnar_batch::{Bitmap, ColumnarLogBatch, DynColumn, VarBytes};
+pub use columnar_batch::{Bitmap, ColumnarLogBatch, DynColumn, StrColumnDict, VarBytes};
 pub use columns::ColumnSelection;
 pub use error::LogSegError;
 pub use footer::{SuffixOutcome, open_from_suffix};

--- a/crates/ravel-logseg/src/writer.rs
+++ b/crates/ravel-logseg/src/writer.rs
@@ -9,11 +9,13 @@
 //! the footer and trailer. Identical input yields byte-identical output.
 
 use std::collections::btree_map::Entry;
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
 use ravel_types::logstream::{AttrValue, LogStreamId, canonical_attr_bytes};
 
-use crate::block::{ColumnPlan, ColumnarBlockInput, write_block, write_block_columnar};
+use crate::block::{
+    BlockStrDict, ColumnPlan, ColumnarBlockInput, write_block, write_block_columnar,
+};
 use crate::bloom::BloomBuilder;
 use crate::bloom_section::encode_bloom_section;
 use crate::columnar_batch::ColumnarLogBatch;
@@ -1006,6 +1008,67 @@ impl RlogWriter {
             }
         }
 
+        // Dictionary fast path (ADR-0109 decision 3): for each Str/Bytes plan
+        // column whose every contributing batch column arrived dictionary-
+        // shaped, build one per-object distinct table and a per-global-row
+        // index into it. The block string encode and the token bloom then run
+        // per distinct value, not per row. A plan column with any plain
+        // contributor stays on the per-row `col_values` path built above,
+        // untouched, so byte-identity with the row path is preserved either way.
+        let mut plan_uses_dict = vec![false; num_plans];
+        let mut global_dict: Vec<Vec<Vec<u8>>> = vec![Vec::new(); num_plans];
+        let mut col_dict_ids: Vec<Vec<Option<u32>>> = vec![Vec::new(); num_plans];
+        {
+            let mut interners: Vec<HashMap<Vec<u8>, u32>> = vec![HashMap::new(); num_plans];
+            for (pi, (_, ty, _)) in columns.iter().enumerate() {
+                if matches!(ty, FieldType::Str | FieldType::Bytes) {
+                    plan_uses_dict[pi] = true;
+                    col_dict_ids[pi] = vec![None; total_rows];
+                }
+            }
+            for (bi, b) in batches.iter().enumerate() {
+                let base = bases[bi];
+                for (ci, c) in b.dyn_columns.iter().enumerate() {
+                    if !matches!(c.field_type, FieldType::Str | FieldType::Bytes) {
+                        continue;
+                    }
+                    let Some(cid) = column_lookup(&column_of, &c.name, c.field_type.to_u8()) else {
+                        continue; // overflowed the budget: folds into attrs_raw
+                    };
+                    let pi = plan_of_cid[&cid];
+                    if !plan_uses_dict[pi] {
+                        continue; // already poisoned by a plain contributor
+                    }
+                    let Some(d) = b.dyn_col_dicts.get(ci).and_then(Option::as_ref) else {
+                        plan_uses_dict[pi] = false; // plain contributor: fall back
+                        continue;
+                    };
+                    let mut slot = 0usize;
+                    for row in 0..b.num_rows {
+                        if !c.validity.get(row) {
+                            continue;
+                        }
+                        let val = &d.distinct[d.ids[slot] as usize];
+                        slot += 1;
+                        let next = global_dict[pi].len() as u32;
+                        let gid = *interners[pi].entry(val.clone()).or_insert_with(|| {
+                            global_dict[pi].push(val.clone());
+                            next
+                        });
+                        col_dict_ids[pi][base + row] = Some(gid);
+                    }
+                }
+            }
+        }
+        // Str plan column ids on the dict path: their per-row bloom tokens are
+        // set once per distinct value below, so the per-row loop skips them.
+        let dict_str_cids: HashSet<u32> = columns
+            .iter()
+            .enumerate()
+            .filter(|(pi, (_, ty, _))| plan_uses_dict[*pi] && matches!(ty, FieldType::Str))
+            .map(|(_, (_, _, cid))| *cid)
+            .collect();
+
         // Finish each row: sort its columnar occurrences by column id (matching
         // the row path's BTreeMap collection), resolve the merged view, and
         // project it into POSTINGS terms, NumStat winners, and attrs_raw.
@@ -1143,10 +1206,41 @@ impl RlogWriter {
                 .iter()
                 .map(|p| {
                     let plan_idx = plan_of_cid[&p.column_id];
-                    block_rows
-                        .iter()
-                        .map(|&g| col_values[plan_idx][g].clone())
-                        .collect()
+                    if plan_uses_dict[plan_idx] {
+                        // The dict path below carries this column's page; the
+                        // per-row value gather is skipped.
+                        Vec::new()
+                    } else {
+                        block_rows
+                            .iter()
+                            .map(|&g| col_values[plan_idx][g].clone())
+                            .collect()
+                    }
+                })
+                .collect();
+            // Owned per-block dict ids (one Option<index> per block row) for
+            // every dict-path plan, referenced by `str_dicts_v` below.
+            let str_dict_ids_v: Vec<Option<Vec<Option<u32>>>> = plans
+                .iter()
+                .map(|p| {
+                    let plan_idx = plan_of_cid[&p.column_id];
+                    plan_uses_dict[plan_idx].then(|| {
+                        block_rows
+                            .iter()
+                            .map(|&g| col_dict_ids[plan_idx][g])
+                            .collect()
+                    })
+                })
+                .collect();
+            let str_dicts_v: Vec<Option<BlockStrDict>> = plans
+                .iter()
+                .enumerate()
+                .map(|(i, p)| {
+                    let plan_idx = plan_of_cid[&p.column_id];
+                    str_dict_ids_v[i].as_ref().map(|ids| BlockStrDict {
+                        dict: &global_dict[plan_idx],
+                        ids,
+                    })
                 })
                 .collect();
             let stat_v: Vec<Vec<Option<ColumnValue>>> = plans
@@ -1178,6 +1272,7 @@ impl RlogWriter {
                 plans: &plans,
                 values: &values_v,
                 stat_values: &stat_v,
+                str_dicts: &str_dicts_v,
             };
             let out = write_block_columnar(&input, self.cfg.zstd_level)?;
 
@@ -1189,7 +1284,11 @@ impl RlogWriter {
                 insert_text(&mut builder, COL_SEVERITY_TEXT, g_sevtext[g]);
                 for (cid, v) in &g_cols[g] {
                     if let ColumnValue::Str(bytes) = v {
-                        insert_text(&mut builder, *cid, bytes);
+                        // Dict-path Str columns are tokenized per distinct value
+                        // after this loop; skip their per-row occurrence here.
+                        if !dict_str_cids.contains(cid) {
+                            insert_text(&mut builder, *cid, bytes);
+                        }
                     }
                 }
                 for (cid, v) in &g_indexed_terms[g] {
@@ -1204,6 +1303,27 @@ impl RlogWriter {
                     if field_map.len() > self.cfg.postings_max_distinct {
                         postings_terms.remove(cid);
                         postings_capped.insert(*cid);
+                    }
+                }
+            }
+            // Dict-path Str columns: tokenize each distinct value present in the
+            // block exactly once. Bloom bit setting is idempotent, so these set
+            // the same bits the per-row path would, at per-distinct cost.
+            for p in &plans {
+                let plan_idx = plan_of_cid[&p.column_id];
+                if !(plan_uses_dict[plan_idx] && matches!(p.ty, FieldType::Str)) {
+                    continue;
+                }
+                let mut seen: HashSet<u32> = HashSet::new();
+                for &g in block_rows {
+                    if let Some(gid) = col_dict_ids[plan_idx][g]
+                        && seen.insert(gid)
+                    {
+                        insert_text(
+                            &mut builder,
+                            p.column_id,
+                            &global_dict[plan_idx][gid as usize],
+                        );
                     }
                 }
             }
@@ -2867,6 +2987,26 @@ mod tests {
             w.finish_with_stats().expect("columnar finish")
         }
 
+        /// Like [`columnar_object`], but attaches the dictionary shape to every
+        /// batch ([`ColumnarLogBatch::with_dictionaries`]) so the writer takes
+        /// the per-distinct dictionary encode and bloom path (ADR-0109
+        /// decision 3, #603).
+        fn columnar_object_dict(
+            cfg: RlogConfig,
+            recs: &[LogRecord],
+            nbatches: usize,
+        ) -> (Vec<u8>, WriteStats) {
+            let mut w = RlogWriter::new(cfg, identity()).with_indexed_fields(indexed());
+            for chunk in split(recs, nbatches) {
+                if chunk.is_empty() {
+                    continue;
+                }
+                w.push_columnar(ColumnarLogBatch::from_records(chunk).with_dictionaries())
+                    .expect("columnar push");
+            }
+            w.finish_with_stats().expect("columnar finish")
+        }
+
         proptest! {
             #![proptest_config(ProptestConfig::with_cases(256))]
 
@@ -2890,6 +3030,50 @@ mod tests {
                 };
                 let (rb, rs) = row_object(cfg, &records);
                 let (cb, cs) = columnar_object(cfg, &records, nbatches);
+                prop_assert_eq!(rs, cs);
+                prop_assert!(rb == cb, "object bytes differ: row {} vs col {}", rb.len(), cb.len());
+            }
+        }
+
+        proptest! {
+            #![proptest_config(ProptestConfig::with_cases(256))]
+
+            /// The #603 anchor: pushing the same records through the row path and
+            /// through the columnar path with dictionary-shaped string columns
+            /// yields byte-identical objects and field-identical `WriteStats`.
+            ///
+            /// Each record gets three controlled string columns so the encoder's
+            /// dict-versus-plain threshold (`dict_is_worth_it`) is straddled
+            /// within a block: `same` is one identical value across every row
+            /// (distinct = 1, dictionary wins), `uniq` is a distinct value per
+            /// row (dictionary loses, plain wins), and `lc` draws from a 1-2
+            /// value pool (dictionary wins). `bin` is a low-cardinality `Bytes`
+            /// column (dictionary-encoded but never bloomed). The `arb_record`
+            /// attributes still bring `List`/`Map`-derived `Bytes` columns,
+            /// duplicate keys, per-type splitting, and overflow.
+            #[test]
+            fn dictionary_columns_match_row_build_byte_for_byte(
+                mut records in proptest::collection::vec(arb_record(), 1..25),
+                max_dyn in 6usize..16,
+                nbatches in 1usize..4,
+                lc_pool in proptest::collection::vec("[a-z]{1,3}", 1..3),
+            ) {
+                for (i, r) in records.iter_mut().enumerate() {
+                    r.attrs.push(("same".into(), AttrValue::Str("K".into())));
+                    r.attrs.push(("uniq".into(), AttrValue::Str(format!("u{i}"))));
+                    r.attrs
+                        .push(("lc".into(), AttrValue::Str(lc_pool[i % lc_pool.len()].clone())));
+                    r.attrs
+                        .push(("bin".into(), AttrValue::Bytes(vec![(i % 2) as u8])));
+                }
+                let cfg = RlogConfig {
+                    max_dynamic_columns: max_dyn,
+                    block_target_records: 5,
+                    block_max_bytes: 8192,
+                    ..RlogConfig::default()
+                };
+                let (rb, rs) = row_object(cfg, &records);
+                let (cb, cs) = columnar_object_dict(cfg, &records, nbatches);
                 prop_assert_eq!(rs, cs);
                 prop_assert!(rb == cb, "object bytes differ: row {} vs col {}", rb.len(), cb.len());
             }


### PR DESCRIPTION
Two costs in the columnar object build were proportional to rows where the
data only justifies proportional to distinct values. Parquet already groups
those distinct values, so the information was there and unused.

String attribute columns gain a dictionary shape: a distinct set plus one id
per row, carried alongside the existing plain form. When every contributing
batch column for a name is dictionary-shaped, the writer builds one
per-object distinct table and maps each distinct value to its RLOG dictionary
entry once per block rather than once per row. A column with any plain
contributor stays on the untouched per-row path.

The page bytes are unchanged by construction: `encode_strings_dict` derives
its sorted entries and its dictionary-versus-plain choice from the referenced
distinct values and the row count, which is exactly what `encode_strings`
computes from the fused per-row values.

The per-block token bloom follows the same rule. `insert_text` tokenized
every string value of every row; over a dictionary column it now runs once
per distinct value per block. Bloom bit setting is idempotent, so the section
bytes do not change, and the differential test proves that rather than
asserting it. The saving is `1 - distinct/rows`, largest on the wide
low-cardinality columns this targets.

The change to `ColumnarLogBatch` is additive: a new `StrColumnDict` type, a
new `dyn_col_dicts` field defaulting to empty, and a `with_dictionaries`
constructor. No existing field, method or constructor changed, and
`from_records` leaves the new field empty, so a producer written against the
previous shape takes the unchanged path.

`ravel-codec` gains `encode_strings_dict` because the dictionary-versus-plain
page helpers are private to that module; reusing them is what keeps the
output byte-identical.

Decision 3 of ADR-0109.

Fixes: #603
Refs: #597
