### PR TITLE
feat(ravel-ingest): columnar write path through the router and shard buffer

### DIFF
--- a/crates/ravel-ingest/src/log_error.rs
+++ b/crates/ravel-ingest/src/log_error.rs
@@ -47,6 +47,17 @@ pub enum LogWriteError {
     /// (ADR-0052 section 3). Retryable once the background refresher re-reads.
     #[error("provisioning view stale: refusing to route on a view older than the refresh interval")]
     StaleProvisioningView,
+    /// A tenant's shard buffer already holds one representation (row-major or
+    /// columnar) and this write carried the other (ADR-0109 decision 5: a
+    /// tenant's shard buffer is columnar or row-major, never both). The two
+    /// forms are never silently merged; the write is refused fail-loud. Not
+    /// retryable at the shard level: identical input reproduces the same
+    /// refusal until the buffer flushes. In practice this cannot arise on any
+    /// live path (the bulk loader builds its own router in its own process
+    /// while OTLP traffic goes through the server's), so the variant is a
+    /// guard against a future caller mixing the two, not a live failure mode.
+    #[error("mixed buffer representation: {0}")]
+    MixedBufferRepresentation(String),
     /// The process-wide ingest buffer byte budget is at its ceiling
     /// (`--max-ingest-buffer-bytes`, ADR-0069 decision 1): charging this
     /// request's estimated buffered bytes would exceed it, so it is shed before
@@ -94,7 +105,9 @@ impl LogWriteError {
             | LogWriteError::Abandoned(_)
             | LogWriteError::StaleProvisioningView
             | LogWriteError::BufferBudgetExceeded => true,
-            LogWriteError::SegmentBuild(_) | LogWriteError::StreamIdCollision(_) => false,
+            LogWriteError::SegmentBuild(_)
+            | LogWriteError::StreamIdCollision(_)
+            | LogWriteError::MixedBufferRepresentation(_) => false,
             LogWriteError::PartialWrite { inner, .. } => inner.is_retryable(),
         }
     }

--- a/crates/ravel-ingest/src/log_router.rs
+++ b/crates/ravel-ingest/src/log_router.rs
@@ -12,8 +12,10 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use ravel_commit::rng::{RngSource, SystemRng};
+use ravel_logseg::{Bitmap, ColumnarLogBatch, DynColumn};
 use ravel_object_store::ObjectStoreBackend;
 use ravel_otlp::logs_normalize::NormalizedLogRecord;
+use ravel_types::logstream::AttrValue;
 use ravel_types::{CommitToken, TenantHash, shard_for_log};
 use tokio::sync::{mpsc, oneshot};
 
@@ -24,7 +26,7 @@ use crate::generation::{DEFAULT_REFRESH_INTERVAL_NS, GenerationSwitch, Routed, l
 use crate::indexed_fields::IndexedFieldsOverlay;
 use crate::log_error::LogWriteError;
 use crate::log_metrics::LogIngestMetrics;
-use crate::log_shard::{LogShardActor, LogShardMsg, est_record_bytes};
+use crate::log_shard::{LogShardActor, LogShardMsg, est_columnar_bytes, est_record_bytes};
 use crate::router::WriteMode;
 #[cfg(feature = "stage-timing")]
 use crate::stage_timing::{LogStage, LogStageTimings};
@@ -132,13 +134,27 @@ impl LogIngestRouter {
         clock: Arc<dyn Clock>,
         indexed_fields: Arc<IndexedFieldsOverlay>,
     ) -> Self {
-        let metrics = Arc::new(LogIngestMetrics::default());
         // Production OS-entropy source for writer ids and PUT-retry jitter
         // (ADR-0068 decision 2). The log pipeline is not exercised by the
-        // seeded simulation driver, so this router has no injected variant;
-        // routing every draw through the seam still keeps `rand::rng()` and
-        // `Uuid::new_v4()` off this production path.
-        let rng: Arc<dyn RngSource> = Arc::new(SystemRng);
+        // seeded simulation driver, so this router has no injected variant on
+        // the production path; routing every draw through the seam still keeps
+        // `rand::rng()` and `Uuid::new_v4()` off it.
+        Self::with_rng(config, store, clock, indexed_fields, Arc::new(SystemRng))
+    }
+
+    /// Like [`Self::new_with_indexed_fields`] but with an injected
+    /// [`RngSource`]. A [`ravel_commit::rng::SeededRng`] here makes writer ids
+    /// deterministic, which the router-level byte-identity differential test
+    /// (row vs columnar) needs so two routers over two stores stamp the same
+    /// `ObjectIdentity` and object keys.
+    pub(crate) fn with_rng(
+        config: IngestConfig,
+        store: Arc<dyn ObjectStoreBackend>,
+        clock: Arc<dyn Clock>,
+        indexed_fields: Arc<IndexedFieldsOverlay>,
+        rng: Arc<dyn RngSource>,
+    ) -> Self {
+        let metrics = Arc::new(LogIngestMetrics::default());
         #[cfg(feature = "stage-timing")]
         let stage_timings = Arc::new(LogStageTimings::new());
         let factory = {
@@ -382,6 +398,22 @@ impl LogIngestRouter {
             return Ok(LogWriteReceipt::default());
         }
 
+        self.await_strict_acks(&set, ack_shards, ack_rxs, ack_deadline)
+            .await
+    }
+
+    /// Awaits the strict-mode acks of a dispatched write and folds them into a
+    /// receipt (or a classified error), shared verbatim by [`Self::write`] and
+    /// [`Self::write_columnar`] so the issue #296 partial-failure accounting has
+    /// exactly one implementation. `ack_shards[i]` is the shard `ack_rxs[i]`
+    /// belongs to; both are in ascending shard order.
+    async fn await_strict_acks(
+        &self,
+        set: &Arc<Vec<LogShardHandle>>,
+        ack_shards: Vec<u32>,
+        ack_rxs: Vec<oneshot::Receiver<Result<CommitToken, LogWriteError>>>,
+        ack_deadline: Duration,
+    ) -> Result<LogWriteReceipt, LogWriteError> {
         // `join_all` preserves input order, so `joined[i]` is `ack_shards[i]`.
         // On a deadline elapse the whole `join_all` future is dropped, so no
         // per-shard ack is observed: `AckTimeout` carries no recovered tokens
@@ -441,6 +473,87 @@ impl LogIngestRouter {
         Ok(LogWriteReceipt { tokens: durable })
     }
 
+    /// The columnar counterpart of [`Self::write`] (ADR-0109 decision 4): the
+    /// same sequence -- charge the ADR-0069 byte budget, resolve the generation
+    /// view, partition by shard, dispatch, await Strict acks -- with the
+    /// partition step building a per-shard [`ColumnarLogBatch`] instead of a
+    /// `Vec` per shard. Shard placement is `shard_for_log` over each row's
+    /// stream id, exactly as [`Self::write`]. The commit protocol, object key
+    /// layout, `WriteMode::Strict` ack contract, flush triggers, and RLOG format
+    /// are unchanged; only the buffered input shape differs.
+    ///
+    /// Until #605 wires the Parquet bulk loader, no shipping binary constructs a
+    /// [`ColumnarLogBatch`] to hand here; this is the router seam that loader
+    /// will call, reachable today only from tests.
+    pub async fn write_columnar(
+        &self,
+        tenant: ravel_types::TenantId,
+        batch: ColumnarLogBatch,
+        mode: WriteMode,
+        ack_deadline: Duration,
+    ) -> Result<LogWriteReceipt, LogWriteError> {
+        if batch.is_empty() {
+            return Ok(LogWriteReceipt::default());
+        }
+
+        // Global ingest byte budget (ADR-0069 decision 1): the columnar estimate
+        // equals the row path's `est_record_bytes` sum for the same records
+        // exactly, so the shared ceiling means the same thing on both paths. As
+        // in `write`, the charge is cloned into every shard message and refunded
+        // when the flush(es) holding these bytes complete or fail.
+        let estimate = est_columnar_bytes(&batch) as u64;
+        let charge = Arc::new(
+            self.budget
+                .try_charge(estimate)
+                .map_err(|_| LogWriteError::BufferBudgetExceeded)?,
+        );
+
+        // Route against the tenant's current generation view, exactly as `write`.
+        let set = self.active_set(tenant.hash(), self.clock.now_ns()).await?;
+        let shard_count = set.len() as u32;
+
+        // Partition into per-shard column selections. `partition_columnar`
+        // returns ascending-shard order and omits a shard with no rows, matching
+        // `write`'s sorted `by_shard` keys.
+        let by_shard = partition_columnar(&batch, shard_count);
+        if by_shard.is_empty() {
+            return Ok(LogWriteReceipt::default());
+        }
+
+        let mut ack_shards = Vec::with_capacity(by_shard.len());
+        let mut ack_rxs = Vec::with_capacity(by_shard.len());
+        for (shard, shard_batch) in by_shard {
+            let ack = match mode {
+                WriteMode::Strict => {
+                    let (tx, rx) = oneshot::channel();
+                    ack_shards.push(shard);
+                    ack_rxs.push(rx);
+                    Some(tx)
+                }
+                WriteMode::Buffered => None,
+            };
+            let msg = LogShardMsg::WriteColumnar {
+                tenant: tenant.clone(),
+                batch: Box::new(shard_batch),
+                ack,
+                charge: Some(Arc::clone(&charge)),
+            };
+            if set[shard as usize].tx.send(msg).await.is_err() {
+                // The actor task is gone; count the death once and surface the
+                // typed error rather than acking as if the batch landed.
+                self.mark_shard_dead(&set[shard as usize]);
+                return Err(LogWriteError::ShardUnavailable);
+            }
+        }
+
+        if mode == WriteMode::Buffered {
+            return Ok(LogWriteReceipt::default());
+        }
+
+        self.await_strict_acks(&set, ack_shards, ack_rxs, ack_deadline)
+            .await
+    }
+
     /// Records the first observation of a shard actor's death, deduped so a
     /// permanently dead shard is counted once no matter how many later writes
     /// route to it.
@@ -492,6 +605,139 @@ impl LogIngestRouter {
             let _ = rx.await;
         }
     }
+}
+
+/// Partitions a [`ColumnarLogBatch`] into per-shard sub-batches by
+/// `shard_for_log` over each row's stream id (ADR-0109 decision 4), the
+/// columnar analogue of [`LogIngestRouter::write`]'s `by_shard` grouping.
+///
+/// Each returned sub-batch is exactly what `ColumnarLogBatch::from_records`
+/// would build from that shard's rows taken in row order: dynamic columns keep
+/// the parent's `(name, type)`-sorted order and any the subset leaves all-absent
+/// are dropped (`from_records` over the subset would never have created them),
+/// and the stream directory is rebuilt id-ascending with dense refs. That
+/// equivalence is what makes each per-shard object byte-identical to the row
+/// path's, whose per-shard record vector this reproduces (the writer-level proof
+/// is #602). Returns ascending-shard order; a shard with no rows is omitted,
+/// exactly as the row path omits it.
+fn partition_columnar(batch: &ColumnarLogBatch, shard_count: u32) -> Vec<(u32, ColumnarLogBatch)> {
+    // Per-shard accumulator: the sub-batch under construction, the parent stream
+    // refs of its rows (remapped to dense child refs once all rows are seen),
+    // and one dense (cells, validity) pair per parent dynamic column.
+    struct Acc {
+        out: ColumnarLogBatch,
+        parent_refs: Vec<u32>,
+        dyn_cells: Vec<Vec<AttrValue>>,
+        dyn_validity: Vec<Bitmap>,
+    }
+    let ncol = batch.dyn_columns.len();
+    let mut accs: HashMap<u32, Acc> = HashMap::new();
+
+    // Dense-slot cursors into the parent's packed buffers, advanced once per row
+    // (regardless of shard) so a present cell reads the correct dense slot.
+    let mut trace_slot = 0usize;
+    let mut span_slot = 0usize;
+    let mut col_slot = vec![0usize; ncol];
+
+    for row in 0..batch.num_rows {
+        let stream_id = batch.stream_ids[batch.stream_refs[row] as usize];
+        let shard = shard_for_log(&stream_id, shard_count);
+        let acc = accs.entry(shard).or_insert_with(|| Acc {
+            out: ColumnarLogBatch::new(),
+            parent_refs: Vec::new(),
+            dyn_cells: vec![Vec::new(); ncol],
+            dyn_validity: vec![Bitmap::new(); ncol],
+        });
+
+        acc.out.num_rows += 1;
+        acc.out.ts_ns.push(batch.ts_ns[row]);
+        acc.out.observed_ts_ns.push(batch.observed_ts_ns[row]);
+        acc.out.severity_num.push(batch.severity_num[row]);
+        acc.out.flags.push(batch.flags[row]);
+        acc.out.severity_text.push(batch.severity_text.get(row));
+        acc.out.body.push(batch.body.get(row));
+
+        if batch.trace_id_validity.get(row) {
+            acc.out
+                .trace_id
+                .extend_from_slice(batch.trace_id_at(trace_slot));
+            acc.out.trace_id_validity.push(true);
+            trace_slot += 1;
+        } else {
+            acc.out.trace_id_validity.push(false);
+        }
+        if batch.span_id_validity.get(row) {
+            acc.out
+                .span_id
+                .extend_from_slice(batch.span_id_at(span_slot));
+            acc.out.span_id_validity.push(true);
+            span_slot += 1;
+        } else {
+            acc.out.span_id_validity.push(false);
+        }
+
+        acc.out
+            .residual_attrs
+            .push(batch.residual_attrs[row].clone());
+        acc.parent_refs.push(batch.stream_refs[row]);
+
+        for (c, slot) in col_slot.iter_mut().enumerate() {
+            let col = &batch.dyn_columns[c];
+            if col.validity.get(row) {
+                acc.dyn_cells[c].push(col.cells[*slot].clone());
+                acc.dyn_validity[c].push(true);
+                *slot += 1;
+            } else {
+                acc.dyn_validity[c].push(false);
+            }
+        }
+    }
+
+    let mut result: Vec<(u32, ColumnarLogBatch)> = Vec::with_capacity(accs.len());
+    for (shard, acc) in accs {
+        let Acc {
+            mut out,
+            parent_refs,
+            dyn_cells,
+            dyn_validity,
+        } = acc;
+
+        // Stream directory: distinct parent refs ascending. The parent's
+        // `stream_ids` are id-ascending, so ascending parent refs are
+        // id-ascending too; rebuild them as dense child refs.
+        let mut distinct: Vec<u32> = parent_refs.clone();
+        distinct.sort_unstable();
+        distinct.dedup();
+        let mut child_ref_of: HashMap<u32, u32> = HashMap::with_capacity(distinct.len());
+        for (child, &parent_ref) in distinct.iter().enumerate() {
+            child_ref_of.insert(parent_ref, child as u32);
+            out.stream_ids.push(batch.stream_ids[parent_ref as usize]);
+            out.stream_attrs
+                .push(batch.stream_attrs[parent_ref as usize].clone());
+        }
+        out.stream_refs = parent_refs
+            .iter()
+            .map(|parent_ref| child_ref_of[parent_ref])
+            .collect();
+
+        // Dynamic columns: keep the parent's `(name, type)` order, dropping any
+        // column the subset left all-absent.
+        for (c, (cells, validity)) in dyn_cells.into_iter().zip(dyn_validity).enumerate() {
+            if validity.count_present() == 0 {
+                continue;
+            }
+            out.dyn_columns.push(DynColumn {
+                name: batch.dyn_columns[c].name.clone(),
+                field_type: batch.dyn_columns[c].field_type,
+                cells,
+                validity,
+            });
+        }
+
+        result.push((shard, out));
+    }
+    result.sort_by_key(|(shard, _)| *shard);
+    result
 }
 
 #[cfg(test)]
@@ -715,5 +961,256 @@ mod tests {
             0,
             "no degraded routing when the store is healthy"
         );
+    }
+
+    // ---- ADR-0109 columnar write path ----
+
+    use ravel_commit::rng::SeededRng;
+    use ravel_logseg::{ColumnarLogBatch, LogRecord, stream_attrs_bytes};
+    use ravel_object_store::{GetRange, list_all};
+    use ravel_types::TenantId;
+    use ravel_types::logstream::log_stream_id;
+
+    /// A clock pinned to one instant: makes `epoch`, `flush_open_ns`, and every
+    /// clock-derived flush-identity field deterministic and identical across two
+    /// routers, which the byte-identity differential test requires. The tests
+    /// that use it drive flushes through `flush_all`, never the age tick, so the
+    /// real-timer default `sleep` is never depended on.
+    struct FixedClock(i64);
+    impl Clock for FixedClock {
+        fn now_ns(&self) -> i64 {
+            self.0
+        }
+    }
+
+    fn overlay() -> Arc<IndexedFieldsOverlay> {
+        Arc::new(IndexedFieldsOverlay::new(Arc::new(NoIndexedFields)))
+    }
+
+    /// Buffers every write without a size or age flush, so a single `flush_all`
+    /// drives exactly one flush per shard (seq 0 on both routers).
+    fn buffer_all() -> IngestConfig {
+        IngestConfig {
+            shard_count: 4,
+            target_bytes: 64 * 1024 * 1024,
+            max_flush_delay: Duration::from_secs(3600),
+            max_flush_delay_idle: Duration::from_secs(3600),
+            flush_tick: Duration::from_secs(3600),
+            ..IngestConfig::default()
+        }
+    }
+
+    fn to_logrecord(r: &NormalizedLogRecord) -> LogRecord {
+        LogRecord {
+            stream_id: r.stream_id,
+            stream_attrs: r.stream_attrs.clone(),
+            ts_ns: r.ts_ns,
+            observed_ts_ns: r.observed_ts_ns,
+            severity_num: r.severity_num,
+            severity_text: r.severity_text.clone(),
+            body: r.body.clone(),
+            trace_id: r.trace_id,
+            span_id: r.span_id,
+            flags: r.flags,
+            attrs: r.attrs.clone(),
+        }
+    }
+
+    /// Records spread across streams (so across shards) and carrying the
+    /// features that stress the two paths' agreement: multiple attribute types,
+    /// a within-record duplicate `(name, type)` that folds into `residual_attrs`,
+    /// a nested `Map` value that resolves to canonical bytes, and present/absent
+    /// trace and span ids.
+    fn diverse_records() -> Vec<NormalizedLogRecord> {
+        let mut out = Vec::new();
+        for i in 0..48u32 {
+            let host = format!("h{i}");
+            let res: Vec<(String, AttrValue)> = vec![
+                (
+                    "service.name".to_string(),
+                    AttrValue::Str("api".to_string()),
+                ),
+                ("host".to_string(), AttrValue::Str(host)),
+            ];
+            let stream_id = log_stream_id(&res, "scope", "", &[]);
+            let stream_attrs = stream_attrs_bytes(&res, "scope", "", &[]);
+            let mut attrs: Vec<(String, AttrValue)> = vec![
+                ("k_str".to_string(), AttrValue::Str(format!("v{i}"))),
+                ("k_int".to_string(), AttrValue::I64(i as i64)),
+                ("k_bool".to_string(), AttrValue::Bool(i % 2 == 0)),
+            ];
+            if i % 3 == 0 {
+                attrs.push(("k_str".to_string(), AttrValue::Str("dup".to_string())));
+            }
+            if i % 5 == 0 {
+                attrs.push((
+                    "nested".to_string(),
+                    AttrValue::Map(vec![("a".to_string(), AttrValue::Bool(true))]),
+                ));
+            }
+            let trace_id = if i % 2 == 0 {
+                Some([i as u8; 16])
+            } else {
+                None
+            };
+            let span_id = if i % 4 == 0 {
+                Some([(i as u8).wrapping_add(1); 8])
+            } else {
+                None
+            };
+            out.push(NormalizedLogRecord {
+                stream_id,
+                stream_attrs,
+                ts_ns: 1_000 + i as i64,
+                observed_ts_ns: 1_000 + i as i64,
+                severity_num: (i % 24) as u8,
+                severity_text: "INFO".to_string(),
+                body: format!("body {i}"),
+                trace_id,
+                span_id,
+                flags: i,
+                attrs,
+            });
+        }
+        out
+    }
+
+    async fn collect_objects(store: &dyn ObjectStoreBackend) -> Vec<(String, Vec<u8>)> {
+        let mut metas = list_all(store, "").await.expect("list all objects");
+        metas.sort_by(|a, b| a.key.cmp(&b.key));
+        let mut out = Vec::with_capacity(metas.len());
+        for meta in metas {
+            let bytes = store
+                .get(&meta.key, GetRange::Full)
+                .await
+                .expect("get object")
+                .data;
+            out.push((meta.key, bytes.to_vec()));
+        }
+        out
+    }
+
+    /// The acceptance anchor (ADR-0109 decision 7, router level): the same
+    /// records written through `write` and through `write_columnar` produce
+    /// byte-identical stored objects. Two routers over two stores share one
+    /// pinned clock and one seed, so `writer_id`, `epoch`, and `seq` match and
+    /// only a real drift in admission, coercion, dynamic-column assignment, or
+    /// stream-directory building could make a byte differ. Compared byte for
+    /// byte over every stored object (data and commit records both), not row
+    /// counts and not decoded content.
+    #[tokio::test]
+    async fn columnar_write_produces_the_same_objects_as_row_write() {
+        let seed = 0x00C0_FFEE_u64;
+        // A realistic wall-clock reading (2023): flush identity derives its hour
+        // bucket from this, and `checked_ingest_hour_bucket` rejects a reading
+        // below its plausibility floor.
+        let clock: Arc<dyn Clock> = Arc::new(FixedClock(1_700_000_000_000_000_000));
+
+        let store_row: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+        let router_row = LogIngestRouter::with_rng(
+            buffer_all(),
+            Arc::clone(&store_row),
+            Arc::clone(&clock),
+            overlay(),
+            Arc::new(SeededRng::new(seed)),
+        );
+
+        let store_col: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+        let router_col = LogIngestRouter::with_rng(
+            buffer_all(),
+            Arc::clone(&store_col),
+            Arc::clone(&clock),
+            overlay(),
+            Arc::new(SeededRng::new(seed)),
+        );
+
+        let tenant = TenantId::new("acme");
+        let records = diverse_records();
+        let shards: std::collections::HashSet<u32> = records
+            .iter()
+            .map(|r| shard_for_log(&r.stream_id, 4))
+            .collect();
+        assert!(
+            shards.len() > 1,
+            "the fixture must span multiple shards to exercise partitioning, spans {}",
+            shards.len()
+        );
+
+        router_row
+            .write(
+                tenant.clone(),
+                records.clone(),
+                WriteMode::Buffered,
+                Duration::from_secs(5),
+            )
+            .await
+            .expect("row buffered write enqueues");
+        router_row.flush_all().await;
+
+        let batch =
+            ColumnarLogBatch::from_records(&records.iter().map(to_logrecord).collect::<Vec<_>>());
+        router_col
+            .write_columnar(
+                tenant.clone(),
+                batch,
+                WriteMode::Buffered,
+                Duration::from_secs(5),
+            )
+            .await
+            .expect("columnar buffered write enqueues");
+        router_col.flush_all().await;
+
+        let objs_row = collect_objects(store_row.as_ref()).await;
+        let objs_col = collect_objects(store_col.as_ref()).await;
+        assert!(
+            !objs_row.is_empty(),
+            "the row path must have written at least one object"
+        );
+        assert_eq!(
+            objs_row, objs_col,
+            "row and columnar paths must produce byte-identical stored objects"
+        );
+    }
+
+    /// Each per-shard sub-batch `partition_columnar` builds is exactly what
+    /// `ColumnarLogBatch::from_records` would build from that shard's rows in row
+    /// order (dynamic-column order and drop, stream-directory rebuild, dense
+    /// slots). This is the structural invariant the byte-identity test relies
+    /// on, checked directly so a partition bug is localized here rather than
+    /// surfacing only as an opaque byte diff.
+    #[test]
+    fn partition_columnar_matches_from_records_per_shard() {
+        let shard_count = 4u32;
+        let records = diverse_records();
+        let logrecords: Vec<LogRecord> = records.iter().map(to_logrecord).collect();
+        let batch = ColumnarLogBatch::from_records(&logrecords);
+
+        let mut expected: std::collections::HashMap<u32, Vec<LogRecord>> =
+            std::collections::HashMap::new();
+        for lr in &logrecords {
+            let shard = shard_for_log(&lr.stream_id, shard_count);
+            expected.entry(shard).or_default().push(lr.clone());
+        }
+
+        let parts = partition_columnar(&batch, shard_count);
+        let seen: std::collections::HashSet<u32> = parts.iter().map(|(s, _)| *s).collect();
+        assert_eq!(
+            seen.len(),
+            parts.len(),
+            "each shard appears at most once in the partition"
+        );
+        assert_eq!(
+            seen,
+            expected.keys().copied().collect(),
+            "the partition covers exactly the shards the row path routes to"
+        );
+
+        for (shard, part) in parts {
+            let want = ColumnarLogBatch::from_records(&expected[&shard]);
+            assert_eq!(
+                part, want,
+                "shard {shard}'s partition must equal from_records of its rows"
+            );
+        }
     }
 }

--- a/crates/ravel-ingest/src/log_shard.rs
+++ b/crates/ravel-ingest/src/log_shard.rs
@@ -38,7 +38,9 @@ use ravel_commit::keys;
 use ravel_commit::publish::{self, PublishError, RetryPolicy};
 use ravel_commit::record::{self, NewCommitRecord};
 use ravel_commit::rng::RngSource;
-use ravel_logseg::{LogRecord, LogSegError, ObjectIdentity, RlogConfig, RlogWriter};
+use ravel_logseg::{
+    ColumnarLogBatch, LogRecord, LogSegError, ObjectIdentity, RlogConfig, RlogWriter,
+};
 use ravel_object_store::ObjectStoreBackend;
 use ravel_otlp::logs_normalize::NormalizedLogRecord;
 use ravel_proto::commit::v1::CommitRecord;
@@ -72,6 +74,23 @@ pub(crate) enum LogShardMsg {
         /// bytes -- when the flush's outcome is reached. `None` only for a test
         /// write that bypasses the budget; production charges via
         /// [`crate::LogIngestRouter`].
+        charge: Option<Arc<IngestByteCharge>>,
+    },
+    /// The columnar counterpart of [`LogShardMsg::Write`] (ADR-0109 decision
+    /// 5): one already-partitioned [`ColumnarLogBatch`] for this shard,
+    /// buffered column-major and pushed to the writer with
+    /// [`RlogWriter::push_columnar`] at flush. A tenant buffer that already
+    /// holds row-major records refuses this and vice versa; the two shapes are
+    /// never merged.
+    WriteColumnar {
+        tenant: TenantId,
+        /// Boxed to keep the enum small: a [`ColumnarLogBatch`] is far larger
+        /// than the other variants, and boxing moves that size off every
+        /// `LogShardMsg` the channel carries.
+        batch: Box<ColumnarLogBatch>,
+        ack: Option<LogAck>,
+        /// This request's ADR-0069 byte-budget charge, held until flush exactly
+        /// as [`LogShardMsg::Write`]'s `charge` is.
         charge: Option<Arc<IngestByteCharge>>,
     },
     /// Flush every buffered tenant now, regardless of size/age thresholds.
@@ -131,6 +150,46 @@ pub(crate) fn est_record_bytes(rec: &NormalizedLogRecord) -> usize {
     rec.body.len() + rec.severity_text.len() + rec.stream_attrs.len() + attr_bytes + 32
 }
 
+/// The [`est_record_bytes`] byte estimate computed column-wise over a
+/// [`ColumnarLogBatch`] (ADR-0109 decision 6). This must equal the sum of
+/// [`est_record_bytes`] over the records the batch was built from, exactly, so
+/// the one process-wide ADR-0069 ceiling means the same thing on both the row
+/// and columnar paths.
+///
+/// Term by term against [`est_record_bytes`]: `body` and `severity_text` are
+/// each the concatenated value bytes across all rows (a `VarBytes` holds one
+/// value per row); `stream_attrs` is summed per row through each row's stream
+/// reference (the batch dedups the blob per distinct stream, so it is
+/// re-expanded here to match the row path's per-record charge); every dynamic
+/// column cell and every `residual_attrs` entry is one attribute occurrence,
+/// each charging its `(String, AttrValue)` pair header, its key bytes, and its
+/// [`attr_value_len`] exactly as the row path charges the same occurrence; and
+/// the fixed 32 (two timestamps, severity_num, flags, optional trace/span ids)
+/// is charged per row.
+pub(crate) fn est_columnar_bytes(batch: &ColumnarLogBatch) -> usize {
+    let body = batch.body.data().len();
+    let severity_text = batch.severity_text.data().len();
+    let stream_attrs: usize = batch
+        .stream_refs
+        .iter()
+        .map(|&r| batch.stream_attrs[r as usize].len())
+        .sum();
+
+    let mut attr_bytes = 0usize;
+    for col in &batch.dyn_columns {
+        for cell in &col.cells {
+            attr_bytes += size_of::<(String, AttrValue)>() + col.name.len() + attr_value_len(cell);
+        }
+    }
+    for row in &batch.residual_attrs {
+        for (k, v) in row {
+            attr_bytes += size_of::<(String, AttrValue)>() + k.len() + attr_value_len(v);
+        }
+    }
+
+    body + severity_text + stream_attrs + attr_bytes + 32 * batch.num_rows
+}
+
 /// Type-level bridge from the OTLP-independent [`NormalizedLogRecord`] to the
 /// writer's [`LogRecord`]. Every field maps one to one; there is no data
 /// transformation, only a struct rename.
@@ -150,6 +209,18 @@ fn to_logseg_record(rec: NormalizedLogRecord) -> LogRecord {
     }
 }
 
+/// A tenant's buffered payload: one representation at a time (ADR-0109 decision
+/// 5). `Empty` is the pre-first-write state that accepts either shape; once a
+/// write lands, the buffer is `Rows` or `Columnar` until it flushes, and the
+/// other shape is refused.
+#[derive(Default)]
+enum BufContent {
+    #[default]
+    Empty,
+    Rows(Vec<NormalizedLogRecord>),
+    Columnar(Vec<ColumnarLogBatch>),
+}
+
 /// One tenant's accumulated log records in a single shard buffer, the
 /// log-pipeline counterpart of [`crate::shard::TenantBuf`].
 ///
@@ -157,7 +228,7 @@ fn to_logseg_record(rec: NormalizedLogRecord) -> LogRecord {
 /// docs): the fail-loud collision check is [`RlogWriter::finish`]'s job.
 #[derive(Default)]
 struct LogTenantBuf {
-    records: Vec<NormalizedLogRecord>,
+    content: BufContent,
     est_bytes: usize,
     oldest_arrival_ns: Option<i64>,
     min_ingest_ts_ns: Option<i64>,
@@ -182,16 +253,65 @@ impl LogTenantBuf {
         });
     }
 
-    /// Appends `records` to this buffer and returns the estimated byte cost
-    /// added (per [`est_record_bytes`]). Unlike the metrics buffer this never
-    /// fails: the stream-id collision check is deferred to
-    /// [`RlogWriter::finish`] at flush time, so a merge cannot reject.
-    fn merge(&mut self, records: Vec<NormalizedLogRecord>, arrival_ns: i64) -> usize {
-        self.note_arrival(arrival_ns);
+    /// Appends row-major `records` to this buffer and returns the estimated
+    /// byte cost added (per [`est_record_bytes`]). Refuses fail-loud if the
+    /// buffer already holds columnar batches (ADR-0109 decision 5); no state is
+    /// mutated on that refusal. Unlike the metrics buffer this never fails on
+    /// stream identity: that collision check is deferred to
+    /// [`RlogWriter::finish`] at flush time.
+    fn merge_rows(
+        &mut self,
+        records: Vec<NormalizedLogRecord>,
+        arrival_ns: i64,
+    ) -> Result<usize, LogWriteError> {
         let bytes_added: usize = records.iter().map(est_record_bytes).sum();
-        self.records.extend(records);
+        match &mut self.content {
+            BufContent::Empty => self.content = BufContent::Rows(records),
+            BufContent::Rows(existing) => existing.extend(records),
+            BufContent::Columnar(_) => {
+                return Err(LogWriteError::MixedBufferRepresentation(
+                    "row-major write into a tenant buffer already holding columnar batches".into(),
+                ));
+            }
+        }
+        self.note_arrival(arrival_ns);
         self.est_bytes += bytes_added;
-        bytes_added
+        Ok(bytes_added)
+    }
+
+    /// Appends one columnar `batch` to this buffer and returns the estimated
+    /// byte cost added (per [`est_columnar_bytes`], equal to the row path's
+    /// number for the same records). Refuses fail-loud if the buffer already
+    /// holds row-major records (ADR-0109 decision 5); no state is mutated on
+    /// that refusal. The caller passes only non-empty batches.
+    fn merge_columnar(
+        &mut self,
+        batch: ColumnarLogBatch,
+        arrival_ns: i64,
+    ) -> Result<usize, LogWriteError> {
+        let bytes_added = est_columnar_bytes(&batch);
+        match &mut self.content {
+            BufContent::Empty => self.content = BufContent::Columnar(vec![batch]),
+            BufContent::Columnar(existing) => existing.push(batch),
+            BufContent::Rows(_) => {
+                return Err(LogWriteError::MixedBufferRepresentation(
+                    "columnar write into a tenant buffer already holding row-major records".into(),
+                ));
+            }
+        }
+        self.note_arrival(arrival_ns);
+        self.est_bytes += bytes_added;
+        Ok(bytes_added)
+    }
+
+    /// Total buffered record (row) count across whichever representation the
+    /// buffer holds, for the channel-close summary line.
+    fn record_count(&self) -> u64 {
+        match &self.content {
+            BufContent::Empty => 0,
+            BufContent::Rows(records) => records.len() as u64,
+            BufContent::Columnar(batches) => batches.iter().map(|b| b.num_rows as u64).sum(),
+        }
     }
 }
 
@@ -237,12 +357,64 @@ struct LogPinnedFlush {
     deadline_ns: i64,
     min_ingest_ts_ns: i64,
     max_ingest_ts_ns: i64,
-    records: Vec<NormalizedLogRecord>,
+    payload: FlushPayload,
     waiters: Vec<LogAck>,
     /// The global ingest-byte-budget charges this flush's buffer held (ADR-0069).
     /// Carried into the flush task purely so they are dropped -- and the bytes
     /// refunded -- when the flush's terminal outcome is reached, no earlier.
     charges: Vec<Arc<IngestByteCharge>>,
+}
+
+/// One flush's buffered payload, in whichever representation the tenant buffer
+/// held (ADR-0109 decision 5). The row and columnar arms produce byte-identical
+/// RLOG objects for the same records; the writer-level differential test in
+/// `ravel-logseg` (#602) is the proof of that.
+enum FlushPayload {
+    Rows(Vec<NormalizedLogRecord>),
+    Columnar(Vec<ColumnarLogBatch>),
+}
+
+impl FlushPayload {
+    /// Distinct stream count, event-time bounds, and total row count over the
+    /// payload, the commit-record fields [`RlogWriter`] does not surface after
+    /// `finish()`. Computed identically to the row path's single pass whichever
+    /// representation this is: a `ColumnarLogBatch` already carries its distinct
+    /// stream ids, so the union across batches is the same distinct set the row
+    /// path derives by inserting every record's `stream_id`.
+    fn commit_stats(&self) -> (u64, i64, i64, u64) {
+        let mut stream_ids: HashSet<LogStreamId> = HashSet::new();
+        let mut min_event_ts_ns = i64::MAX;
+        let mut max_event_ts_ns = i64::MIN;
+        let mut sample_count: u64 = 0;
+        match self {
+            FlushPayload::Rows(records) => {
+                for rec in records {
+                    stream_ids.insert(rec.stream_id);
+                    min_event_ts_ns = min_event_ts_ns.min(rec.ts_ns);
+                    max_event_ts_ns = max_event_ts_ns.max(rec.ts_ns);
+                }
+                sample_count = records.len() as u64;
+            }
+            FlushPayload::Columnar(batches) => {
+                for batch in batches {
+                    for id in &batch.stream_ids {
+                        stream_ids.insert(*id);
+                    }
+                    for &ts in &batch.ts_ns {
+                        min_event_ts_ns = min_event_ts_ns.min(ts);
+                        max_event_ts_ns = max_event_ts_ns.max(ts);
+                    }
+                    sample_count += batch.num_rows as u64;
+                }
+            }
+        }
+        (
+            stream_ids.len() as u64,
+            min_event_ts_ns,
+            max_event_ts_ns,
+            sample_count,
+        )
+    }
 }
 
 impl LogFlushCtx {
@@ -269,7 +441,7 @@ impl LogFlushCtx {
             deadline_ns,
             min_ingest_ts_ns,
             max_ingest_ts_ns,
-            records,
+            payload,
             waiters,
             charges,
         } = pinned;
@@ -278,22 +450,15 @@ impl LogFlushCtx {
         // ADR-0069 budget refund for exactly the bytes this buffer held.
         let _charges = charges;
 
-        // One pass over the batch computes the commit-record fields RlogWriter
-        // does not surface after `finish()`: the distinct stream count (the log
-        // analogue of series_count) and the event-time bounds. `records` is
-        // never empty here: the actor's `flush_tenant` returns before spawning
-        // for an empty buffer, so `min_event_ts_ns`/`max_event_ts_ns` always
-        // see at least one record.
-        let mut stream_ids: HashSet<LogStreamId> = HashSet::new();
-        let mut min_event_ts_ns = i64::MAX;
-        let mut max_event_ts_ns = i64::MIN;
-        for rec in &records {
-            stream_ids.insert(rec.stream_id);
-            min_event_ts_ns = min_event_ts_ns.min(rec.ts_ns);
-            max_event_ts_ns = max_event_ts_ns.max(rec.ts_ns);
-        }
-        let series_count = stream_ids.len() as u64;
-        let sample_count = records.len() as u64;
+        // One pass over the payload computes the commit-record fields
+        // RlogWriter does not surface after `finish()`: the distinct stream
+        // count (the log analogue of series_count) and the event-time bounds.
+        // The payload is never empty here: the actor's `flush_tenant` returns
+        // before spawning for an empty buffer, so `min_event_ts_ns`/
+        // `max_event_ts_ns` always see at least one record. The row and columnar
+        // arms derive an identical distinct-stream set, event-time range, and
+        // row count for the same records.
+        let (series_count, min_event_ts_ns, max_event_ts_ns, sample_count) = payload.commit_stats();
 
         // Resolve this tenant's POSTINGS indexed-field list (ADR-0049 decision
         // 3) once per object and hand it to the writer. An empty list leaves the
@@ -330,12 +495,18 @@ impl LogFlushCtx {
         let encode_start = std::time::Instant::now();
         let mut writer =
             RlogWriter::new(RlogConfig::default(), identity).with_indexed_fields(indexed_fields);
-        for rec in records {
-            if let Err(e) = writer.push(to_logseg_record(rec)) {
-                self.metrics.record_abandoned_input_rejected();
-                self.ack_waiters(waiters, Err(LogWriteError::SegmentBuild(e.to_string())));
-                return;
-            }
+        let push_result = match payload {
+            FlushPayload::Rows(records) => records
+                .into_iter()
+                .try_for_each(|rec| writer.push(to_logseg_record(rec))),
+            FlushPayload::Columnar(batches) => batches
+                .into_iter()
+                .try_for_each(|batch| writer.push_columnar(batch)),
+        };
+        if let Err(e) = push_result {
+            self.metrics.record_abandoned_input_rejected();
+            self.ack_waiters(waiters, Err(LogWriteError::SegmentBuild(e.to_string())));
+            return;
         }
         let bytes = match writer.finish_with_stats() {
             Ok((bytes, stats)) => {
@@ -685,6 +856,9 @@ impl LogShardActor {
                         Some(LogShardMsg::Write { tenant, records, ack, charge }) => {
                             self.handle_write(tenant, records, ack, charge).await;
                         }
+                        Some(LogShardMsg::WriteColumnar { tenant, batch, ack, charge }) => {
+                            self.handle_write_columnar(tenant, *batch, ack, charge).await;
+                        }
                         Some(LogShardMsg::FlushNow { done }) => {
                             self.flush_all(FlushTrigger::Manual).await;
                             let _ = done.send(());
@@ -749,11 +923,83 @@ impl LogShardActor {
         let buf = self.tenants.entry(tenant.clone()).or_default();
         #[cfg(feature = "stage-timing")]
         let merge_start = std::time::Instant::now();
-        let bytes_added = buf.merge(records, arrival_ns);
+        let bytes_added = match buf.merge_rows(records, arrival_ns) {
+            Ok(bytes_added) => bytes_added,
+            Err(err) => {
+                // A row write into a columnar buffer: refuse fail-loud. Nothing
+                // was buffered, so drop the charge to refund its bytes (ADR-0069)
+                // and answer the waiter with the typed error rather than a panic
+                // or a silent merge (ADR-0109 decision 5).
+                drop(charge);
+                if let Some(ack) = ack {
+                    let _ = ack.send(Err(err));
+                }
+                return;
+            }
+        };
         #[cfg(feature = "stage-timing")]
         merge_timings.record(LogStage::Merge, merge_start.elapsed());
         // The records are now buffered: hold their budget charge with the buffer
         // until it flushes (ADR-0069).
+        if let Some(charge) = charge {
+            buf.charges.push(charge);
+        }
+        if let Some(ack) = ack {
+            buf.waiters.push(ack);
+        }
+        self.metrics
+            .record_buffered(bytes_added as u64, records_len);
+
+        let should_flush = self
+            .tenants
+            .get(&tenant)
+            .map(|b| b.est_bytes >= target_bytes)
+            .unwrap_or(false);
+        if should_flush && let Some(buf) = self.tenants.remove(&tenant) {
+            self.flush_tenant(tenant, buf, FlushTrigger::Size).await;
+        }
+    }
+
+    /// The columnar counterpart of [`Self::handle_write`] (ADR-0109 decision 5):
+    /// buffers one already-partitioned [`ColumnarLogBatch`] for `tenant`,
+    /// refusing fail-loud if the buffer already holds row-major records. The
+    /// flush-trigger accounting (`est_bytes >= target_bytes`), the charge and
+    /// waiter handling, and the size-flush path are identical to the row path.
+    async fn handle_write_columnar(
+        &mut self,
+        tenant: TenantId,
+        batch: ColumnarLogBatch,
+        ack: Option<LogAck>,
+        charge: Option<Arc<IngestByteCharge>>,
+    ) {
+        if batch.is_empty() && ack.is_none() {
+            // Nothing buffered: dropping `charge` here refunds its bytes.
+            return;
+        }
+        let arrival_ns = self.clock.now_ns();
+        let records_len = batch.num_rows as u64;
+        let target_bytes = self.config.target_bytes;
+
+        #[cfg(feature = "stage-timing")]
+        let merge_timings = Arc::clone(&self.ctx.stage_timings);
+        let buf = self.tenants.entry(tenant.clone()).or_default();
+        #[cfg(feature = "stage-timing")]
+        let merge_start = std::time::Instant::now();
+        let bytes_added = match buf.merge_columnar(batch, arrival_ns) {
+            Ok(bytes_added) => bytes_added,
+            Err(err) => {
+                // A columnar write into a row-major buffer: refuse fail-loud,
+                // exactly as the row path refuses the reverse. Drop the charge
+                // (refund) and answer the waiter with the typed error.
+                drop(charge);
+                if let Some(ack) = ack {
+                    let _ = ack.send(Err(err));
+                }
+                return;
+            }
+        };
+        #[cfg(feature = "stage-timing")]
+        merge_timings.record(LogStage::Merge, merge_start.elapsed());
         if let Some(charge) = charge {
             buf.charges.push(charge);
         }
@@ -810,11 +1056,7 @@ impl LogShardActor {
     /// Returns `(tenant_count, buffered_record_count)` across every buffered
     /// tenant, for the channel-close log line.
     fn buffered_summary(&self) -> (usize, u64) {
-        let records: u64 = self
-            .tenants
-            .values()
-            .map(|buf| buf.records.len() as u64)
-            .sum();
+        let records: u64 = self.tenants.values().map(|buf| buf.record_count()).sum();
         (self.tenants.len(), records)
     }
 
@@ -857,27 +1099,44 @@ impl LogShardActor {
     /// `seq` for no object.
     async fn flush_tenant(&mut self, tenant: TenantId, buf: LogTenantBuf, trigger: FlushTrigger) {
         let LogTenantBuf {
-            records,
+            content,
             min_ingest_ts_ns,
             max_ingest_ts_ns,
             waiters,
             charges,
             ..
         } = buf;
-        if records.is_empty() {
-            // Nothing to write, so no flush task runs: dropping `charges` here
-            // is the ADR-0069 refund for this (record-less) buffer.
-            drop(charges);
-            // `waiters` is empty here by construction: the log router mints a
-            // strict-mode ack only for a shard that actually received records
-            // (`by_shard` only holds shards with at least one record, and the
-            // ack rides that same shard message), so a record-less buffer has
-            // nobody to answer. If that ever changes, this returns without
-            // acking and the router reads the dropped oneshot as a dead shard;
-            // the assert makes the invariant loud rather than silently dropping.
-            debug_assert!(waiters.is_empty());
-            return;
-        }
+        // `waiters` is empty on the record-less paths below by construction: the
+        // log router mints a strict-mode ack only for a shard that actually
+        // received records (`by_shard`/the columnar partition only holds shards
+        // with at least one row, and the ack rides that same shard message), so
+        // a record-less buffer has nobody to answer. If that ever changes, this
+        // returns without acking and the router reads the dropped oneshot as a
+        // dead shard; the assert makes the invariant loud rather than silently
+        // dropping. Dropping `charges` on those paths is the ADR-0069 refund.
+        let payload = match content {
+            BufContent::Empty => {
+                drop(charges);
+                debug_assert!(waiters.is_empty());
+                return;
+            }
+            BufContent::Rows(records) => {
+                if records.is_empty() {
+                    drop(charges);
+                    debug_assert!(waiters.is_empty());
+                    return;
+                }
+                FlushPayload::Rows(records)
+            }
+            BufContent::Columnar(batches) => {
+                if batches.iter().all(|b| b.is_empty()) {
+                    drop(charges);
+                    debug_assert!(waiters.is_empty());
+                    return;
+                }
+                FlushPayload::Columnar(batches)
+            }
+        };
         self.metrics.record_flush(trigger);
 
         let tenant_hash = tenant.hash();
@@ -915,7 +1174,7 @@ impl LogShardActor {
             deadline_ns,
             min_ingest_ts_ns,
             max_ingest_ts_ns,
-            records,
+            payload,
             waiters,
             charges,
         };
@@ -2029,5 +2288,269 @@ mod tests {
             expected,
             "a header must be charged at the top Map, the List, and the inner Map"
         );
+    }
+
+    // ---- ADR-0109 columnar path (decisions 3, 5, 6) ----
+
+    use proptest::prelude::*;
+
+    /// A record built consistently (stream id derived from its resource attrs,
+    /// so `stream_attrs` is stable for a stream id), carrying an arbitrary
+    /// dynamic-attribute list -- keys and value types may repeat within one
+    /// record, exercising the residual (`attrs_raw`) fold.
+    fn record_strategy() -> impl Strategy<Value = NormalizedLogRecord> {
+        (
+            proptest::collection::vec(("[a-z]{1,4}", "[a-z0-9]{0,6}"), 1..3),
+            proptest::collection::vec(("[a-z]{1,5}", attr_value_strategy()), 0..8),
+            "[ -~]{0,12}",
+            "[A-Z]{0,6}",
+            any::<u8>(),
+            any::<u32>(),
+            proptest::option::of(any::<[u8; 16]>()),
+            proptest::option::of(any::<[u8; 8]>()),
+        )
+            .prop_map(
+                |(res_kv, attrs, body, severity_text, severity_num, flags, trace_id, span_id)| {
+                    let res: Vec<(String, AttrValue)> = res_kv
+                        .into_iter()
+                        .map(|(k, v)| (k, AttrValue::Str(v)))
+                        .collect();
+                    let stream_id = ravel_types::logstream::log_stream_id(&res, "scope", "", &[]);
+                    let stream_attrs = stream_attrs_bytes(&res, "scope", "", &[]);
+                    NormalizedLogRecord {
+                        stream_id,
+                        stream_attrs,
+                        ts_ns: 1,
+                        observed_ts_ns: 1,
+                        severity_num,
+                        severity_text,
+                        body,
+                        trace_id,
+                        span_id,
+                        flags,
+                        attrs,
+                    }
+                },
+            )
+    }
+
+    /// An arbitrary [`AttrValue`], including nested `List`/`Map` so the per-level
+    /// header terms of the estimate are exercised.
+    fn attr_value_strategy() -> impl Strategy<Value = AttrValue> {
+        let leaf = prop_oneof![
+            any::<String>().prop_map(AttrValue::Str),
+            any::<i64>().prop_map(AttrValue::I64),
+            any::<f64>().prop_map(AttrValue::F64),
+            any::<bool>().prop_map(AttrValue::Bool),
+            proptest::collection::vec(any::<u8>(), 0..8).prop_map(AttrValue::Bytes),
+        ];
+        leaf.prop_recursive(3, 16, 4, |inner| {
+            prop_oneof![
+                proptest::collection::vec(inner.clone(), 0..4).prop_map(AttrValue::List),
+                proptest::collection::vec(("[a-z]{1,4}", inner), 0..4).prop_map(AttrValue::Map),
+            ]
+        })
+    }
+
+    proptest! {
+        /// ADR-0109 decision 6: the columnar byte estimate must equal the row
+        /// path's `est_record_bytes` sum for the same records exactly, so the
+        /// one ADR-0069 ceiling means the same thing on both paths. Over
+        /// generated records, including attribute-heavy and nested ones.
+        #[test]
+        fn columnar_byte_estimate_equals_row_estimate(
+            records in proptest::collection::vec(record_strategy(), 0..12)
+        ) {
+            let row_total: usize = records.iter().map(est_record_bytes).sum();
+            let logrecords: Vec<LogRecord> =
+                records.iter().map(|r| to_logseg_record(r.clone())).collect();
+            let batch = ColumnarLogBatch::from_records(&logrecords);
+            prop_assert_eq!(est_columnar_bytes(&batch), row_total);
+        }
+    }
+
+    /// The same equality on a deliberately attribute-heavy record: 200 distinct
+    /// names each observed with two types (so 400 dynamic columns), a within-
+    /// record duplicate `(name, type)` that folds into `residual_attrs`, and a
+    /// nested `Map`/`List` value. A drift in any per-attribute term (the pair
+    /// header, the key bytes, or `attr_value_len`) between the two paths breaks
+    /// it.
+    #[test]
+    fn columnar_byte_estimate_equals_row_estimate_attribute_heavy() {
+        let mut attrs: Vec<(String, AttrValue)> = Vec::new();
+        for i in 0..200u32 {
+            attrs.push((format!("k{i}"), AttrValue::Str(format!("value-{i}"))));
+            attrs.push((format!("k{i}"), AttrValue::I64(i as i64)));
+        }
+        // A duplicate (k0, Str): the first won the column cell above, so this
+        // folds into residual_attrs on both paths.
+        attrs.push(("k0".to_string(), AttrValue::Str("dup".to_string())));
+        attrs.push((
+            "nested".to_string(),
+            AttrValue::Map(vec![(
+                "a".to_string(),
+                AttrValue::List(vec![AttrValue::I64(1), AttrValue::Str("x".to_string())]),
+            )]),
+        ));
+        let res = vec![(
+            "service.name".to_string(),
+            AttrValue::Str("api".to_string()),
+        )];
+        let rec = NormalizedLogRecord {
+            stream_id: ravel_types::logstream::log_stream_id(&res, "scope", "", &[]),
+            stream_attrs: stream_attrs_bytes(&res, "scope", "", &[]),
+            ts_ns: 1,
+            observed_ts_ns: 1,
+            severity_num: 9,
+            severity_text: "INFO".to_string(),
+            body: "hello".to_string(),
+            trace_id: None,
+            span_id: None,
+            flags: 0,
+            attrs,
+        };
+        let row_total = est_record_bytes(&rec);
+        let batch = ColumnarLogBatch::from_records(&[to_logseg_record(rec)]);
+        assert_eq!(est_columnar_bytes(&batch), row_total);
+    }
+
+    /// ADR-0109 decision 5: a tenant's shard buffer is columnar or row-major,
+    /// never both. A columnar write into a row-major buffer is refused with a
+    /// typed error, and a row-major write into a columnar buffer likewise --
+    /// never a panic and never a silent merge. `no_size_flush` keeps the first
+    /// write buffered so the second meets a populated buffer of the other shape.
+    #[tokio::test]
+    async fn mixed_representation_write_is_refused_in_both_directions() {
+        // Direction 1: a row-major buffer refuses a columnar write.
+        {
+            let h = Harness::spawn(no_size_flush(Duration::from_secs(3600)));
+            let tenant = TenantId::new("acme");
+            let row = norm_record(&[("service.name", "api")], "scope", 1_000, "row");
+            let (a1, _r1) = oneshot::channel();
+            h.tx.send(LogShardMsg::Write {
+                tenant: tenant.clone(),
+                records: vec![row],
+                ack: Some(a1),
+                charge: None,
+            })
+            .await
+            .expect("send buffered row write");
+
+            let batch = ColumnarLogBatch::from_records(&[to_logseg_record(norm_record(
+                &[("service.name", "api")],
+                "scope",
+                2_000,
+                "col",
+            ))]);
+            let (a2, r2) = oneshot::channel();
+            h.tx.send(LogShardMsg::WriteColumnar {
+                tenant: tenant.clone(),
+                batch: Box::new(batch),
+                ack: Some(a2),
+                charge: None,
+            })
+            .await
+            .expect("send columnar write");
+            let err = r2
+                .await
+                .expect("ack sender not dropped")
+                .expect_err("a columnar write into a row-major buffer is refused");
+            assert!(
+                matches!(err, LogWriteError::MixedBufferRepresentation(_)),
+                "expected the typed mixed-representation error, got {err:?}"
+            );
+            h.shutdown().await;
+        }
+
+        // Direction 2: a columnar buffer refuses a row-major write.
+        {
+            let h = Harness::spawn(no_size_flush(Duration::from_secs(3600)));
+            let tenant = TenantId::new("acme");
+            let batch = ColumnarLogBatch::from_records(&[to_logseg_record(norm_record(
+                &[("service.name", "api")],
+                "scope",
+                1_000,
+                "col",
+            ))]);
+            let (a1, _r1) = oneshot::channel();
+            h.tx.send(LogShardMsg::WriteColumnar {
+                tenant: tenant.clone(),
+                batch: Box::new(batch),
+                ack: Some(a1),
+                charge: None,
+            })
+            .await
+            .expect("send buffered columnar write");
+
+            let row = norm_record(&[("service.name", "api")], "scope", 2_000, "row");
+            let (a2, r2) = oneshot::channel();
+            h.tx.send(LogShardMsg::Write {
+                tenant: tenant.clone(),
+                records: vec![row],
+                ack: Some(a2),
+                charge: None,
+            })
+            .await
+            .expect("send row write");
+            let err = r2
+                .await
+                .expect("ack sender not dropped")
+                .expect_err("a row-major write into a columnar buffer is refused");
+            assert!(
+                matches!(err, LogWriteError::MixedBufferRepresentation(_)),
+                "expected the typed mixed-representation error, got {err:?}"
+            );
+            h.shutdown().await;
+        }
+    }
+
+    /// A columnar buffer round-trips through the flush to a readable RLOG object
+    /// exactly as the row path does: same commit-record fields and the same
+    /// scanned records. Proves `run_flush`'s columnar arm (push_columnar +
+    /// commit_stats) is wired, not just that it compiles.
+    #[tokio::test]
+    async fn columnar_size_flush_round_trips_to_a_readable_rlog_object() {
+        let h = Harness::spawn(flush_on_first());
+        let tenant = TenantId::new("acme");
+        let records = [
+            to_logseg_record(norm_record(
+                &[("service.name", "api")],
+                "scope",
+                1_000,
+                "first",
+            )),
+            to_logseg_record(norm_record(
+                &[("service.name", "api")],
+                "scope",
+                2_000,
+                "second",
+            )),
+        ];
+        let batch = ColumnarLogBatch::from_records(&records);
+
+        let (ack_tx, ack_rx) = oneshot::channel();
+        h.tx.send(LogShardMsg::WriteColumnar {
+            tenant: tenant.clone(),
+            batch: Box::new(batch),
+            ack: Some(ack_tx),
+            charge: None,
+        })
+        .await
+        .expect("send columnar write");
+        let token = ack_rx
+            .await
+            .expect("ack sender not dropped")
+            .expect("strict columnar write commits");
+
+        let (rec, scanned) = read_back(h.store.as_ref(), &tenant.hash(), &token).await;
+        assert_eq!(rec.sample_count, 2, "both rows in one RLOG object");
+        assert_eq!(rec.series_count, 1, "both rows share one stream");
+        assert_eq!(scanned.len(), 2, "every row reads back");
+
+        let snap = h.metrics.snapshot();
+        assert_eq!(snap.flushes_by_size, 1);
+        assert_eq!(snap.acks_ok, 1);
+        assert_eq!(snap.stream_id_collisions, 0);
+        h.shutdown().await;
     }
 }

--- a/crates/ravel-ingest/tests/log_router.rs
+++ b/crates/ravel-ingest/tests/log_router.rs
@@ -19,7 +19,9 @@ use common::{TestClock, tenant};
 use ravel_commit::keys;
 use ravel_commit::record::{self, NewCommitRecord};
 use ravel_ingest::{IngestConfig, LogIngestRouter, LogWriteError, WriteMode};
-use ravel_logseg::{Predicate, RlogConfig, RlogReader, stream_attrs_bytes};
+use ravel_logseg::{
+    ColumnarLogBatch, LogRecord, Predicate, RlogConfig, RlogReader, stream_attrs_bytes,
+};
 use ravel_object_store::fault::{
     FaultKind, FaultPlan, FaultStore, Occurrence, Op, Rule, ScriptedFault,
 };
@@ -451,6 +453,104 @@ async fn partial_failure_recovers_the_surviving_shards_token() {
     );
 
     // Prove the injected fault fired: the victim shard's data PUT was rejected.
+    assert_eq!(
+        store.fault_count(Op::Put, FaultKind::Permanent),
+        1,
+        "the permanent data-object PUT fault fired exactly once (shard 0, no retry)"
+    );
+
+    router.shutdown().await;
+}
+
+/// A field-for-field rename of a [`NormalizedLogRecord`] into a [`LogRecord`],
+/// so a fixture built for the row path can seed a [`ColumnarLogBatch`] for the
+/// columnar path with the identical records.
+fn to_logrecord(r: &NormalizedLogRecord) -> LogRecord {
+    LogRecord {
+        stream_id: r.stream_id,
+        stream_attrs: r.stream_attrs.clone(),
+        ts_ns: r.ts_ns,
+        observed_ts_ns: r.observed_ts_ns,
+        severity_num: r.severity_num,
+        severity_text: r.severity_text.clone(),
+        body: r.body.clone(),
+        trace_id: r.trace_id,
+        span_id: r.span_id,
+        flags: r.flags,
+        attrs: r.attrs.clone(),
+    }
+}
+
+/// Issue #296 on the columnar path (ADR-0109 decision 4): a multi-shard Strict
+/// `write_columnar` where one shard's flush is abandoned (its data-object PUT
+/// fails permanently) while a sibling shard commits durably in the same call.
+/// The failure must still surface as an error, and the sibling's commit token
+/// must be recoverable via `LogWriteError::durable_tokens`. This proves the
+/// partial-failure durable-token accounting is unchanged by the new input
+/// shape: `write_columnar` folds acks through the exact same `await_strict_acks`
+/// path as `write`.
+///
+/// The injected fault is asserted via the `FaultStore` counter so the test
+/// proves the abandonment actually fired.
+#[tokio::test]
+async fn columnar_partial_failure_recovers_the_surviving_shards_token() {
+    let shard_count = 4;
+    let plan = FaultPlan::empty().with_rule(
+        Rule::new(
+            Op::Put,
+            ScriptedFault::Permanent("simulated permanent data-object PUT failure".into()),
+        )
+        .with_key_contains("/l0/0000/")
+        .with_occurrence(Occurrence::Always),
+    );
+    let store = Arc::new(FaultStore::new(MemoryStore::new(), plan));
+    let clock = TestClock::new(BASE_NS);
+    let router = LogIngestRouter::new(
+        flush_on_first(shard_count),
+        store.clone() as Arc<dyn ObjectStoreBackend>,
+        clock.clone(),
+    );
+
+    let tenant = tenant("acme");
+    let victim = record_on_shard(0, shard_count, 1_000, "victim");
+    let survivor = record_on_shard(1, shard_count, 2_000, "survivor");
+    assert_ne!(
+        shard_for_log(&victim.stream_id, shard_count),
+        shard_for_log(&survivor.stream_id, shard_count),
+        "the fixture must span two shards"
+    );
+
+    // One batch carrying both records; `write_columnar` partitions it back to
+    // the two shards by `shard_for_log`, exactly as `write` groups the records.
+    let batch = ColumnarLogBatch::from_records(&[to_logrecord(&victim), to_logrecord(&survivor)]);
+    let err = router
+        .write_columnar(
+            tenant.clone(),
+            batch,
+            WriteMode::Strict,
+            Duration::from_secs(5),
+        )
+        .await
+        .expect_err("one shard's flush was abandoned, so the write is a failure");
+
+    assert!(
+        err.is_retryable(),
+        "an abandoned-flush partial write stays retryable, got {err}"
+    );
+
+    let recovered = err.durable_tokens();
+    assert_eq!(
+        recovered.len(),
+        1,
+        "exactly the surviving shard's token is recoverable, got {recovered:?}"
+    );
+    let records = read_back(store.as_ref(), &tenant.hash(), &recovered[0]).await;
+    assert_eq!(records.len(), 1);
+    assert_eq!(
+        records[0].body, "survivor",
+        "the recovered token points at the shard that actually committed"
+    );
+
     assert_eq!(
         store.fault_count(Op::Put, FaultKind::Permanent),
         1,


### PR DESCRIPTION
A `ColumnarLogBatch` now crosses the ingest router and the shard buffer
without being unpacked into records, so the columnar shape built by the
loader survives all the way to the RLOG writer.

`LogIngestRouter::write_columnar` runs the same sequence `write` does: charge
the ADR-0069 byte budget, resolve the generation view, partition by shard,
dispatch, await Strict acks. The partition step builds a per-shard batch by
row selection instead of a `Vec` per shard, and placement stays
`shard_for_log` over each row's stream id. The strict-ack wait is extracted
so the partial-failure durable-token accounting from #296 has one
implementation shared by both paths rather than two that can drift.

The shard buffer holds either rows or columns and never both. A tenant buffer
holding one representation refuses a write in the other with a typed
`MixedBufferRepresentation` error, in both directions: no panic, and no
silent merge of two representations into one object.

The columnar byte estimate is exactly equal to `est_record_bytes` summed over
the same records, not approximately equal, so the process-wide ingest ceiling
means the same thing on both paths. A proptest over attribute-heavy and
nested records pins that equality.

The commit protocol, flush triggers, `WriteMode::Strict` ack semantics, the
#296 accounting and the object key layout are unchanged.

No shipping binary constructs a `ColumnarLogBatch` yet, so `write_columnar`
is reachable today only from tests. The Parquet bulk loader (#605) is what
wires it to a real caller.

Decisions 4, 5 and 6 of ADR-0109.

Fixes: #604
Refs: #597
