### PR TITLE
fix(ravel-query): fold accounting on an abandoned log scan too

### DIFF
--- a/crates/ravel-query/src/log_fetcher.rs
+++ b/crates/ravel-query/src/log_fetcher.rs
@@ -336,7 +336,8 @@ impl LogSegmentScan {
     }
 
     /// Records the scan's block counters on the `decode` span, exactly once,
-    /// when an exit reports exhaustion.
+    /// when an exit reports exhaustion or, failing that, when the scan is
+    /// dropped (see the `Drop` impl below).
     fn finish(&mut self) {
         if self.finished {
             return;
@@ -354,6 +355,18 @@ impl LogSegmentScan {
             .add_page_bytes_fetched(stats.page_bytes_fetched);
         self.accounting
             .add_page_bytes_decoded(stats.page_bytes_decoded);
+    }
+}
+
+impl Drop for LogSegmentScan {
+    /// A scan a caller abandons before exhaustion (`GlobalLimitExec` dropping
+    /// the stream once a `LIMIT` is satisfied is the reachable case) never
+    /// hits either `next_block` exit's exhaustion arm, so without this,
+    /// `finish` never runs and the partial decode work it already did is
+    /// missing from the query's accounting (#617). `finish` is idempotent, so
+    /// this is a no-op on the already-exhausted path.
+    fn drop(&mut self) {
+        self.finish();
     }
 }
 

--- a/crates/ravel-query/tests/log_fetcher.rs
+++ b/crates/ravel-query/tests/log_fetcher.rs
@@ -1252,3 +1252,51 @@ async fn corrupt_block_is_a_typed_error_through_the_columnar_pass_through() {
         .expect_err("the row exit must reject the corrupt block");
     assert!(matches!(err, LogFetchError::Corrupt { .. }), "{err:?}");
 }
+
+/// A scan abandoned before exhaustion (the reachable case: `GlobalLimitExec`
+/// dropping the stream once a `LIMIT` is satisfied) must still fold the
+/// partial decode work it already did into the query's accounting handle
+/// (#617). Draining to exhaustion is the only path that previously recorded
+/// anything -- `Drop` is what makes an early-abandoned scan record too.
+#[tokio::test]
+async fn dropping_a_scan_before_exhaustion_still_records_page_accounting() {
+    let tenant = TenantHash([13u8; 16]);
+    let mem = MemoryStore::new();
+    let records = columnar_records();
+    let seg_ref = write_object(&mem, "logs/abandoned.rlog", &records).await;
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(mem);
+    let fetcher = LogSegmentFetcher::new(store);
+    let query = LogQuery::new(0, 5000);
+    let accounting = QueryAccounting::new();
+
+    let mut scan = fetcher
+        .scan_accounted_with_tenant(
+            &seg_ref,
+            tenant,
+            &query,
+            &ColumnSelection::all(),
+            &accounting,
+        )
+        .await
+        .expect("open scan")
+        .expect("in range");
+
+    // One block only -- the fixture spans several (block_target_records: 3
+    // over 12 records), so this leaves surviving blocks undecoded.
+    scan.next_block().expect("first block").expect("a block");
+    assert!(
+        scan.remaining_blocks() > 0,
+        "the fixture must span more than one block for this to be a real abandonment"
+    );
+    drop(scan);
+
+    let snapshot = accounting.snapshot();
+    assert!(
+        snapshot.page_bytes_fetched > 0,
+        "the one decoded block's fetched bytes must reach accounting even though the scan never exhausted"
+    );
+    assert!(
+        snapshot.page_bytes_decoded > 0,
+        "the one decoded block's decoded bytes must reach accounting even though the scan never exhausted"
+    );
+}


### PR DESCRIPTION
## Summary
- LogSegmentScan only folded page_bytes_fetched/page_bytes_decoded into
  the query's QueryAccounting handle on the exhaustion arm of
  next_block/next_block_columnar. A caller that dropped the scan early
  (GlobalLimitExec dropping the stream once LIMIT is satisfied is the
  reachable path — LogsScanExec has no limit pushdown) lost that
  accounting entirely, even though the scan had already done real
  decode work.
- Added a Drop impl that calls the existing, already-idempotent
  finish() unconditionally, so early abandonment now folds the partial
  counters too.

Sql/flight-sql feature-lane gates were deferred to PR CI: cold compile
of that lane alone exceeded the local 10-minute background-run cap on
this host, consistent with the pattern the last few PRs this week hit.

## Test plan
- [x] New test `dropping_a_scan_before_exhaustion_still_records_page_accounting`:
      opens a multi-block scan, decodes one block, drops it, asserts
      the accounting snapshot is non-zero.
- [x] Mutation-proofed: removed the Drop impl, confirmed the test fails
      with zero accounted bytes (the exact pre-fix bug), restored, reran
      green.
- [x] `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `scripts/affected-tests.sh -p ravel-query` (10 reverse-dependent crates) all green, doctests included.
- [ ] `sql`/`flight-sql` feature lanes — deferred to CI (see above).