### PR TITLE
feat(ravel-sql): typed predicate pushdown for declared logs columns

### DIFF
--- a/crates/ravel-sql/src/logs_provider.rs
+++ b/crates/ravel-sql/src/logs_provider.rs
@@ -191,7 +191,11 @@ impl LogsTableProvider {
         target_partitions: usize,
         filters: &[Expr],
     ) -> DFResult<Arc<dyn ExecutionPlan>> {
-        self.build_scan(target_partitions, &extract_logs(filters), None)
+        self.build_scan(
+            target_partitions,
+            &extract_logs(filters, self.declared.as_ref()),
+            None,
+        )
     }
 
     /// Admission (the sealed-segment cap) is decided exactly once, at
@@ -302,7 +306,7 @@ impl TableProvider for LogsTableProvider {
         }
 
         let target_partitions = state.config().target_partitions();
-        let pushdown = extract_logs(filters);
+        let pushdown = extract_logs(filters, self.declared.as_ref());
         // Projection pushdown reaches the reader (ADR-0087 decision 3): the
         // scan's output schema *is* the projection, and the resolved column set
         // stops the RLOG reader decoding the pages of columns nothing reads.
@@ -1245,6 +1249,436 @@ mod tests {
             rows(&batches),
             BTreeSet::from([(10, "out of window".to_string())]),
             "only the in-window (ts=5) row is erased; ts=10 survives"
+        );
+    }
+
+    // --- declared typed column pushdown (ADR-0093) ---------------------------
+
+    use crate::declared::{DeclaredColumn, DeclaredType};
+    use crate::logs_pushdown::extract_logs;
+
+    /// Twelve one-record blocks on one stream, ts 1..=12, each carrying a
+    /// per-record I64 `status_code = ts * 100`. The skip index folds a `NumStat`
+    /// for the (status_code, I64) column with no POSTINGS indexing needed.
+    fn i64_code_records() -> Vec<LogRecord> {
+        let worker = vec![("service.name".to_string(), s("worker"))];
+        (1..=12)
+            .map(|ts| {
+                record(
+                    &worker,
+                    &[("status_code".to_string(), AttrValue::I64(ts * 100))],
+                    ts,
+                    &format!("body {ts}"),
+                )
+            })
+            .collect()
+    }
+
+    fn i64_status_code() -> Vec<DeclaredColumn> {
+        vec![DeclaredColumn::new("status_code", DeclaredType::I64)]
+    }
+
+    /// TEST 1: a selective I64 comparison on a declared column reduces
+    /// `blocks_scanned` through the skip index (#331), following #331's own
+    /// counter-assertion pattern. `status_code >= 1100` keeps only the two
+    /// blocks whose code is 1100/1200; the other ten never decode.
+    #[tokio::test]
+    async fn declared_i64_comparison_reduces_blocks_scanned() {
+        let store = MemoryStore::new();
+        let seg = write_object_with(
+            &store,
+            "logs/decl-i64.rlog",
+            &i64_code_records(),
+            one_record_per_block(),
+            &[],
+        )
+        .await;
+        let store: Arc<dyn ObjectStoreBackend> = Arc::new(store);
+        let fetcher = LogSegmentFetcher::new(store);
+        let snapshot = Snapshot {
+            segments: vec![seg],
+            segments_pruned: 0,
+            pending_erasure: Vec::new(),
+        };
+        let provider = LogsTableProvider::new(
+            snapshot,
+            TenantHash([7u8; 16]),
+            fetcher,
+            QueryAccounting::new(),
+        )
+        .with_declared_columns(i64_status_code());
+        let ctx = logs_session(provider).expect("build session");
+
+        let (rows_got, counts) =
+            run_counted(&ctx, "SELECT ts, body FROM logs WHERE status_code >= 1100").await;
+        assert_eq!(
+            rows_got,
+            BTreeSet::from([(11, "body 11".to_string()), (12, "body 12".to_string())]),
+        );
+        assert_eq!(
+            counts,
+            ScanCounts {
+                total: 12,
+                scanned: 2,
+                pruned_by_postings: 0,
+            },
+            "the skip index leaves only the two in-range blocks"
+        );
+        assert!(
+            counts.scanned < counts.total,
+            "the numeric prune reduced blocks_scanned"
+        );
+    }
+
+    /// TEST 2: a selective declared-Str equality reduces `blocks_pruned_by_postings`
+    /// via POSTINGS, matching the existing `attrs['k']='v'` test's assertion shape.
+    /// `region` is indexed and only ts=5 carries `region = 'eu'`.
+    #[tokio::test]
+    async fn declared_str_equality_prunes_via_postings() {
+        let store = MemoryStore::new();
+        let worker = vec![("service.name".to_string(), s("worker"))];
+        let records: Vec<LogRecord> = (1..=12)
+            .map(|ts| {
+                let region = if ts == 5 { "eu" } else { "us" };
+                record(
+                    &worker,
+                    &[("region".to_string(), s(region))],
+                    ts,
+                    &format!("body {ts}"),
+                )
+            })
+            .collect();
+        let seg = write_object_with(
+            &store,
+            "logs/decl-str.rlog",
+            &records,
+            one_record_per_block(),
+            &["region"],
+        )
+        .await;
+        let store: Arc<dyn ObjectStoreBackend> = Arc::new(store);
+        let fetcher = LogSegmentFetcher::new(store);
+        let snapshot = Snapshot {
+            segments: vec![seg],
+            segments_pruned: 0,
+            pending_erasure: Vec::new(),
+        };
+        let provider = LogsTableProvider::new(
+            snapshot,
+            TenantHash([7u8; 16]),
+            fetcher,
+            QueryAccounting::new(),
+        )
+        .with_declared_columns(vec![DeclaredColumn::new("region", DeclaredType::Str)]);
+        let ctx = logs_session(provider).expect("build session");
+
+        let (rows_got, counts) =
+            run_counted(&ctx, "SELECT ts, body FROM logs WHERE region = 'eu'").await;
+        assert_eq!(rows_got, BTreeSet::from([(5, "body 5".to_string())]));
+        assert_eq!(
+            counts,
+            ScanCounts {
+                total: 12,
+                scanned: 1,
+                pruned_by_postings: 11,
+            },
+            "the declared-Str equality reached POSTINGS and left one block"
+        );
+    }
+
+    /// TEST 3: the same query with an extractable prune arm and without one
+    /// returns identical rows while reading a different number of blocks. The
+    /// pruned query is `status_code = 500`; the plain query OR-s it with a
+    /// body equality no record satisfies, an unextractable disjunction across
+    /// two columns, so `extract_logs` yields no prune arm and the scan decodes
+    /// every block. `FALSE OR FALSE` filters those rows in the residual, so the
+    /// rows are identical: the pair differs only in whether the prune bit.
+    #[tokio::test]
+    async fn declared_i64_prune_changes_no_row() {
+        let store = MemoryStore::new();
+        let seg = write_object_with(
+            &store,
+            "logs/decl-diff.rlog",
+            &i64_code_records(),
+            one_record_per_block(),
+            &[],
+        )
+        .await;
+        let store: Arc<dyn ObjectStoreBackend> = Arc::new(store);
+        let fetcher = LogSegmentFetcher::new(store);
+        let snapshot = Snapshot {
+            segments: vec![seg],
+            segments_pruned: 0,
+            pending_erasure: Vec::new(),
+        };
+        let provider = LogsTableProvider::new(
+            snapshot,
+            TenantHash([7u8; 16]),
+            fetcher,
+            QueryAccounting::new(),
+        )
+        .with_declared_columns(i64_status_code());
+        let ctx = logs_session(provider).expect("build session");
+
+        let (pruned_rows, pruned) =
+            run_counted(&ctx, "SELECT ts, body FROM logs WHERE status_code = 500").await;
+        let (plain_rows, plain) = run_counted(
+            &ctx,
+            "SELECT ts, body FROM logs WHERE status_code = 500 OR body = 'zzz'",
+        )
+        .await;
+
+        let expected = BTreeSet::from([(5, "body 5".to_string())]);
+        assert_eq!(pruned_rows, expected);
+        assert_eq!(plain_rows, expected);
+        assert_eq!(pruned_rows, plain_rows, "the prune changed no row");
+        assert_eq!(plain.scanned, 12, "the OR shape decodes every block");
+        assert_eq!(pruned.scanned, 1, "the equality prune leaves one block");
+        assert!(pruned.scanned < plain.scanned);
+    }
+
+    /// TEST 4: a predicate on a declared column absent from some objects (a
+    /// tenant that added the column later) still returns correct results. Object
+    /// A carries `status_code`; object B does not. The absence rule (a block with
+    /// no stat is never pruned, ADR-0013) is already proven at the reader; this
+    /// exercises it through this ADR's NEW extraction call site. Object B's two
+    /// blocks must all be SCANNED (not pruned by a stat they lack), which the
+    /// counter proves: a bug pruning no-stat objects would drop `scanned` to 2.
+    #[tokio::test]
+    async fn declared_column_absent_from_some_objects_returns_correct_results() {
+        let store = MemoryStore::new();
+        let worker = vec![("service.name".to_string(), s("worker"))];
+        let seg_a = write_object_with(
+            &store,
+            "logs/decl-a.rlog",
+            &i64_code_records(),
+            one_record_per_block(),
+            &[],
+        )
+        .await;
+        // Object B predates the column: ts 13/14, no `status_code` anywhere.
+        let b_records = vec![
+            record(&worker, &[], 13, "body 13"),
+            record(&worker, &[], 14, "body 14"),
+        ];
+        let seg_b = write_object_with(
+            &store,
+            "logs/decl-b.rlog",
+            &b_records,
+            one_record_per_block(),
+            &[],
+        )
+        .await;
+        let store: Arc<dyn ObjectStoreBackend> = Arc::new(store);
+        let fetcher = LogSegmentFetcher::new(store);
+        let snapshot = Snapshot {
+            segments: vec![seg_a, seg_b],
+            segments_pruned: 0,
+            pending_erasure: Vec::new(),
+        };
+        let provider = LogsTableProvider::new(
+            snapshot,
+            TenantHash([7u8; 16]),
+            fetcher,
+            QueryAccounting::new(),
+        )
+        .with_declared_columns(i64_status_code());
+        let ctx = logs_session(provider).expect("build session");
+
+        let (rows_got, counts) =
+            run_counted(&ctx, "SELECT ts, body FROM logs WHERE status_code >= 1100").await;
+        // B's rows have a NULL status_code, so the residual `>= 1100` drops them.
+        assert_eq!(
+            rows_got,
+            BTreeSet::from([(11, "body 11".to_string()), (12, "body 12".to_string())]),
+        );
+        assert_eq!(
+            counts,
+            ScanCounts {
+                total: 14,
+                scanned: 4,
+                pruned_by_postings: 0,
+            },
+            "A's ten out-of-range blocks prune; B's two no-stat blocks must NOT"
+        );
+    }
+
+    /// TEST 5: an `IN (v1, v2, v3)` over a declared I64 column returns correct
+    /// results even though the envelope range is coarser than the exact set. A
+    /// value strictly between the IN set's min and max but not a member (code
+    /// 500, between 200 and 800) exists in the data. The envelope `[200, 800]`
+    /// keeps its block (the prune alone cannot exclude it), so correctness rests
+    /// on the Inexact residual excluding it. Proven by the final row set: ts=3
+    /// (code 500) is absent, while its block WAS scanned.
+    #[tokio::test]
+    async fn declared_i64_in_list_envelope_is_corrected_by_residual() {
+        let store = MemoryStore::new();
+        let worker = vec![("service.name".to_string(), s("worker"))];
+        let codes = [100i64, 200, 500, 800, 900];
+        let records: Vec<LogRecord> = codes
+            .iter()
+            .enumerate()
+            .map(|(i, &code)| {
+                let ts = i as i64 + 1;
+                record(
+                    &worker,
+                    &[("status_code".to_string(), AttrValue::I64(code))],
+                    ts,
+                    &format!("body {ts}"),
+                )
+            })
+            .collect();
+        let seg = write_object_with(
+            &store,
+            "logs/decl-in.rlog",
+            &records,
+            one_record_per_block(),
+            &[],
+        )
+        .await;
+        let store: Arc<dyn ObjectStoreBackend> = Arc::new(store);
+        let fetcher = LogSegmentFetcher::new(store);
+        let snapshot = Snapshot {
+            segments: vec![seg],
+            segments_pruned: 0,
+            pending_erasure: Vec::new(),
+        };
+        let provider = LogsTableProvider::new(
+            snapshot,
+            TenantHash([7u8; 16]),
+            fetcher,
+            QueryAccounting::new(),
+        )
+        .with_declared_columns(i64_status_code());
+        let ctx = logs_session(provider).expect("build session");
+
+        let (rows_got, counts) = run_counted(
+            &ctx,
+            "SELECT ts, body FROM logs WHERE status_code IN (200, 800)",
+        )
+        .await;
+        // ts=3 (code 500) is inside the envelope but not in the set: the residual
+        // must exclude it, never the prune.
+        assert_eq!(
+            rows_got,
+            BTreeSet::from([(2, "body 2".to_string()), (4, "body 4".to_string())]),
+            "the in-envelope non-member (code 500) is excluded by the residual"
+        );
+        assert_eq!(
+            counts,
+            ScanCounts {
+                total: 5,
+                scanned: 3,
+                pruned_by_postings: 0,
+            },
+            "codes 100 and 900 prune; the envelope keeps 200/500/800's blocks"
+        );
+    }
+
+    /// TEST 8 (CRITICAL): the decline of `!=` and of a type-mismatched literal
+    /// must hold against the filters DataFusion's optimizer actually hands to
+    /// `TableProvider::scan`, not a hand-built `Expr`. A type-coercion pass can
+    /// rewrite `status_code > 2.5` into a `Cast`-wrapped comparison before the
+    /// extractor sees it; the extractor must still decline (a `Cast` is not a bare
+    /// `Expr::Column`, so resolution fails). Built over a real
+    /// `LogsTableProvider`/session and read off the optimized `LogicalPlan`.
+    #[tokio::test]
+    async fn declined_shapes_decline_on_real_optimized_filters() {
+        use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion};
+        use datafusion::logical_expr::LogicalPlan;
+
+        fn table_scan_filters(plan: &LogicalPlan) -> Vec<Expr> {
+            if let LogicalPlan::TableScan(ts) = plan {
+                return ts.filters.clone();
+            }
+            for input in plan.inputs() {
+                let f = table_scan_filters(input);
+                if !f.is_empty() {
+                    return f;
+                }
+            }
+            Vec::new()
+        }
+
+        fn contains_cast(e: &Expr) -> bool {
+            let mut found = false;
+            e.apply(|node| {
+                if matches!(node, Expr::Cast(_) | Expr::TryCast(_)) {
+                    found = true;
+                    Ok(TreeNodeRecursion::Stop)
+                } else {
+                    Ok(TreeNodeRecursion::Continue)
+                }
+            })
+            .expect("walk");
+            found
+        }
+
+        let store = MemoryStore::new();
+        let seg = write_object_with(
+            &store,
+            "logs/decl-real.rlog",
+            &i64_code_records(),
+            one_record_per_block(),
+            &[],
+        )
+        .await;
+        let store: Arc<dyn ObjectStoreBackend> = Arc::new(store);
+        let fetcher = LogSegmentFetcher::new(store);
+        let snapshot = Snapshot {
+            segments: vec![seg],
+            segments_pruned: 0,
+            pending_erasure: Vec::new(),
+        };
+        let provider = LogsTableProvider::new(
+            snapshot,
+            TenantHash([7u8; 16]),
+            fetcher,
+            QueryAccounting::new(),
+        )
+        .with_declared_columns(i64_status_code());
+        let ctx = logs_session(provider).expect("build session");
+        let declared = i64_status_code();
+
+        // `!=` on a declared column: the optimizer keeps it a `NotEq`, not in the
+        // comparison allowlist, so no prune arm.
+        let plan = ctx
+            .sql("SELECT ts, body FROM logs WHERE status_code != 500")
+            .await
+            .expect("plan")
+            .into_optimized_plan()
+            .expect("optimize");
+        let ne_filters = table_scan_filters(&plan);
+        assert!(
+            !ne_filters.is_empty(),
+            "the != predicate must reach the scan"
+        );
+        assert!(
+            extract_logs(&ne_filters, &declared).prune.is_empty(),
+            "!= must produce no prune arm on the real optimized filter"
+        );
+
+        // Type-mismatched literal: the optimizer coerces `status_code > 2.5` by
+        // casting the Int64 column to Float64. The extractor must decline on the
+        // Cast-wrapped operand it actually receives.
+        let plan = ctx
+            .sql("SELECT ts, body FROM logs WHERE status_code > 2.5")
+            .await
+            .expect("plan")
+            .into_optimized_plan()
+            .expect("optimize");
+        let cast_filters = table_scan_filters(&plan);
+        assert!(
+            !cast_filters.is_empty(),
+            "the mismatched comparison must reach the scan"
+        );
+        assert!(
+            cast_filters.iter().any(contains_cast),
+            "DataFusion is expected to insert a Cast for the Int64-vs-Float64 comparison"
+        );
+        assert!(
+            extract_logs(&cast_filters, &declared).prune.is_empty(),
+            "a Cast-wrapped comparison must produce no prune arm"
         );
     }
 }

--- a/crates/ravel-sql/src/logs_provider.rs
+++ b/crates/ravel-sql/src/logs_provider.rs
@@ -1505,16 +1505,27 @@ mod tests {
 
     /// TEST 5: an `IN (v1, v2, v3)` over a declared I64 column returns correct
     /// results even though the envelope range is coarser than the exact set. A
-    /// value strictly between the IN set's min and max but not a member (code
-    /// 500, between 200 and 800) exists in the data. The envelope `[200, 800]`
-    /// keeps its block (the prune alone cannot exclude it), so correctness rests
-    /// on the Inexact residual excluding it. Proven by the final row set: ts=3
-    /// (code 500) is absent, while its block WAS scanned.
+    /// value strictly between the IN set's min and max but not a member exists
+    /// in the data. The envelope range keeps its block (the prune alone cannot
+    /// exclude it), so correctness rests on the Inexact residual excluding it.
+    /// Proven by the final row set.
+    ///
+    /// Checkpoint review found the original two-value form of this test
+    /// (`IN (200, 800)`) does not exercise `declared_in_list_predicate`
+    /// (`logs_pushdown.rs`) at all: DataFusion's own simplifier rewrites a
+    /// two-element `IN` into `col = a OR col = b` before the scan sees it, so
+    /// the test was actually driving `declared_i64_or_envelope`'s OR handling,
+    /// not the `Expr::InList` arm its own doc names. A five-element `IN`
+    /// survives as a real `InList` through the optimizer (confirmed by
+    /// inspecting the optimized `TableScan.filters`), so this uses five
+    /// values to close that gap. Mutating the InList envelope down to a
+    /// single point reddens this test (5 of 6 matching rows silently
+    /// dropped); the two-value form stayed green under that same mutation.
     #[tokio::test]
     async fn declared_i64_in_list_envelope_is_corrected_by_residual() {
         let store = MemoryStore::new();
         let worker = vec![("service.name".to_string(), s("worker"))];
-        let codes = [100i64, 200, 500, 800, 900];
+        let codes = [100i64, 200, 300, 500, 700, 800, 900];
         let records: Vec<LogRecord> = codes
             .iter()
             .enumerate()
@@ -1554,24 +1565,29 @@ mod tests {
 
         let (rows_got, counts) = run_counted(
             &ctx,
-            "SELECT ts, body FROM logs WHERE status_code IN (200, 800)",
+            "SELECT ts, body FROM logs WHERE status_code IN (200, 300, 700, 800)",
         )
         .await;
-        // ts=3 (code 500) is inside the envelope but not in the set: the residual
-        // must exclude it, never the prune.
+        // ts=4 (code 500) is inside the envelope [200, 800] but not in the set:
+        // the residual must exclude it, never the prune.
         assert_eq!(
             rows_got,
-            BTreeSet::from([(2, "body 2".to_string()), (4, "body 4".to_string())]),
+            BTreeSet::from([
+                (2, "body 2".to_string()),
+                (3, "body 3".to_string()),
+                (5, "body 5".to_string()),
+                (6, "body 6".to_string()),
+            ]),
             "the in-envelope non-member (code 500) is excluded by the residual"
         );
         assert_eq!(
             counts,
             ScanCounts {
-                total: 5,
-                scanned: 3,
+                total: 7,
+                scanned: 5,
                 pruned_by_postings: 0,
             },
-            "codes 100 and 900 prune; the envelope keeps 200/500/800's blocks"
+            "codes 100 and 900 prune; the envelope keeps 200/300/500/700/800's blocks"
         );
     }
 

--- a/crates/ravel-sql/src/logs_pushdown.rs
+++ b/crates/ravel-sql/src/logs_pushdown.rs
@@ -65,11 +65,71 @@
 //! The `attrs['k']` subscript *syntax* plans through the hand-written
 //! `crate::map_field_planner` `ExprPlanner`; the older note that it
 //! failed planning under `features = ["sql"]` is closed.
+//!
+//! # How declared typed columns are pushed (prune-only, ADR-0093)
+//!
+//! A tenant may *declare* an attribute key as a native typed column (ADR-0090),
+//! so a query reads `status_code = 500` against a real `Int64`/`Boolean`/
+//! `Binary`/dictionary Arrow column rather than `attrs['status_code'] = '500'`
+//! over the stringified map. A bare `Expr::Column` whose name is not one of the
+//! nine fixed `logs` columns ([`crate::logs_schema`]) is resolved against the
+//! tenant's declared vocabulary ([`crate::declared`]) and, on a match, dispatched
+//! by its [`DeclaredType`] into the same two prune primitives the `attrs`/`ts`
+//! shapes already feed. This is an **allowlist**, not a best-effort translation:
+//! only the shapes below are extracted, and every other shape declines exactly
+//! as an undeclared column would (declining to prune is always widen-safe).
+//!
+//! - `I64`/`Bool` + `<`,`<=`,`>`,`>=`,`=`, or `BETWEEN`, against a literal whose
+//!   `ScalarValue` type exactly matches the declared type -> a
+//!   [`Predicate::NumRange`] with bit-pattern bounds ([`ravel_logseg::block`]'s
+//!   `NumStat` encoding: an `i64` as its two's-complement `u64`, a `bool` as
+//!   `0`/`1`). This drives `SkipIndex::candidate_blocks` (#331); it carries no
+//!   POSTINGS version gate.
+//! - `I64` + `IN (v1, v2, ...)` -> ONE envelope `NumRange` spanning
+//!   `[min(vs), max(vs)]`, never one arm per value. `Predicate` has no
+//!   disjunction and the reader intersects arms, so a per-value arm would prove
+//!   some block disjoint that the full `IN` does not, silently dropping rows. The
+//!   envelope is deliberately coarser (it also spans values between the listed
+//!   ones); the `Inexact` residual excludes those, never the prune. The same
+//!   envelope is recognized in two forms: a literal `Expr::InList` (a large list)
+//!   and a same-column `col = v1 OR col = v2 OR ...` disjunction, which is what
+//!   DataFusion's simplifier rewrites a *small* `IN` into before the scan ever
+//!   sees it. A disjunction across different columns, or of any non-equality
+//!   shape, is not a representable single range and declines (widen-safe).
+//! - `Str`/`Bytes` + `=`, against a matching-type literal ->
+//!   [`Predicate::Equals`] on `FieldSel::Attr`, byte-identical to the
+//!   `attrs['k'] = 'v'` predicate, feeding POSTINGS. `Str`/`Bytes` `IN (...)` is
+//!   not extracted (a disjunction, as above).
+//! - Anything else -- `!=`, `NOT`, a negated `BETWEEN`, `IS [NOT] NULL`, a
+//!   general `OR` (anything but the same-column I64 equality union above), a
+//!   range operator on a `Str`/`Bytes` column, or a literal whose type does not
+//!   match the declared type (including a `Cast`-wrapped operand DataFusion's own
+//!   coercion may have inserted, which is no longer a bare `Expr::Column` and so
+//!   fails resolution) -- is not extracted. A mismatched literal is never coerced
+//!   to fit.
+//!
+//! Two soundness caveats are inherited unchanged, not introduced here. The
+//! equality half inherits the POSTINGS-section-version decline (a section written
+//! before the #333 fix declines all equality pruning) and the over-conservative
+//! "a name that also carries a non-`Str` column declines entirely" rule from the
+//! existing `attrs['k']='v'` path. The `NumRange` half has neither: under
+//! ADR-0095's single-version RLOG regime every stat is merged-view-correct, and
+//! an absent stat is "no information", never "no match" (ADR-0013), so an object
+//! predating the column's declaration falls through and is scanned, not pruned.
+//!
+//! F64 is out of scope (no `DeclaredType::F64` exists yet). The dispatch is one
+//! `match` on [`DeclaredType`], so F64 is a one-arm addition once its plumbing
+//! lands -- but that arm MUST honor [`Predicate::NumRange`]'s float contract
+//! (widen a zero-including range across both `0.0`/`-0.0` bit patterns, never
+//! build a bound from a NaN literal); the I64/Bool code here does not, because
+//! neither case is reachable for an integer or boolean literal.
 
-use datafusion::logical_expr::{BinaryExpr, Expr, Operator};
+use datafusion::logical_expr::expr::InList;
+use datafusion::logical_expr::{Between, BinaryExpr, Expr, Operator};
 use datafusion::scalar::ScalarValue;
-use ravel_logseg::{AttrValue, FieldSel, Predicate};
+use ravel_logseg::{AttrValue, FieldSel, FieldType, Predicate};
 
+use crate::declared::{DeclaredColumn, DeclaredType};
 use crate::logs_udf::HAS_WORD_UDF;
 
 /// The scalar UDF name an `attrs['k']` subscript lowers to
@@ -113,28 +173,33 @@ impl LogsPushdown {
 
 /// Extract all sound pushdown from a `logs` filter set. Each element of
 /// `filters` is an implicit top-level AND conjunct; nested `AND`s are split too.
-pub fn extract_logs(filters: &[Expr]) -> LogsPushdown {
+///
+/// `declared` is the tenant's declared typed attribute columns (ADR-0090),
+/// resolved once per plan by `SqlExecutor` and threaded down. An empty slice
+/// reproduces the pre-ADR-0093 behavior exactly: a bare `Expr::Column` resolves
+/// against nothing, so only the `ts`/`attrs`/`has_word` shapes are extracted.
+pub fn extract_logs(filters: &[Expr], declared: &[DeclaredColumn]) -> LogsPushdown {
     let mut out = LogsPushdown::default();
     for f in filters {
-        walk_conjunct(f, &mut out);
+        walk_conjunct(f, &mut out, declared);
     }
     out
 }
 
-fn walk_conjunct(expr: &Expr, out: &mut LogsPushdown) {
+fn walk_conjunct(expr: &Expr, out: &mut LogsPushdown, declared: &[DeclaredColumn]) {
     if let Expr::BinaryExpr(BinaryExpr { left, op, right }) = expr
         && *op == Operator::And
     {
-        walk_conjunct(left, out);
-        walk_conjunct(right, out);
+        walk_conjunct(left, out, declared);
+        walk_conjunct(right, out, declared);
         return;
     }
-    handle_leaf(expr, out);
+    handle_leaf(expr, out, declared);
 }
 
-fn handle_leaf(expr: &Expr, out: &mut LogsPushdown) {
+fn handle_leaf(expr: &Expr, out: &mut LogsPushdown, declared: &[DeclaredColumn]) {
     match expr {
-        Expr::BinaryExpr(be) => handle_binary(be, out),
+        Expr::BinaryExpr(be) => handle_binary(be, out, declared),
         Expr::Between(bt) if !bt.negated => {
             // BETWEEN low AND high desugars to `ts >= low AND ts <= high`. A
             // negated BETWEEN is an OR of two ranges: not sound to narrow.
@@ -145,6 +210,17 @@ fn handle_leaf(expr: &Expr, out: &mut LogsPushdown) {
                 if let Some(hi) = lit_ts_ns(&bt.high) {
                     tighten_hi(out, hi);
                 }
+            } else if let Some(p) = declared_between_predicate(bt, declared) {
+                out.prune.push(p);
+            }
+        }
+        // `col IN (v1, v2, ...)` is an `Expr::InList`, not a `BinaryExpr`, so it
+        // never flows through `handle_binary`; a declared I64 column's `IN` gets
+        // its own envelope-range arm here. The `attrs['k'] IN (...)` shape has a
+        // `get_field` (not a bare `Expr::Column`) subscript and so declines.
+        Expr::InList(il) if !il.negated => {
+            if let Some(p) = declared_in_list_predicate(il, declared) {
+                out.prune.push(p);
             }
         }
         // A bare `has_word(col, 'literal')` boolean predicate.
@@ -157,7 +233,7 @@ fn handle_leaf(expr: &Expr, out: &mut LogsPushdown) {
     }
 }
 
-fn handle_binary(be: &BinaryExpr, out: &mut LogsPushdown) {
+fn handle_binary(be: &BinaryExpr, out: &mut LogsPushdown, declared: &[DeclaredColumn]) {
     // ts vs literal timestamp comparison (either operand order).
     if let Some((op, ts_ns)) = ts_comparison(be) {
         apply_ts_bound(out, op, ts_ns);
@@ -169,6 +245,302 @@ fn handle_binary(be: &BinaryExpr, out: &mut LogsPushdown) {
     // and drop resource/scope-only matches (see the module doc).
     if let Some(p) = attr_equality_predicate(be) {
         out.prune.push(p);
+        return;
+    }
+    // A comparison against a declared typed column (ADR-0093). Resolved only for
+    // a non-fixed column name; dispatched by declared type into the same
+    // prune-only NumRange/Equals primitives.
+    if let Some(p) = declared_comparison_predicate(be, declared) {
+        out.prune.push(p);
+        return;
+    }
+    // A same-column I64 disjunction of equalities: how DataFusion's simplifier
+    // delivers a small `col IN (v1, v2, ...)`, expanded to
+    // `col = v1 OR col = v2 OR ...` before the scan sees it. It reduces to the
+    // same one envelope range the `Expr::InList` arm builds (see the module
+    // doc's IN note). A disjunct on any other column or of any other shape
+    // declines the whole OR (widen-safe).
+    if let Some(p) = declared_i64_or_envelope(be, declared) {
+        out.prune.push(p);
+    }
+}
+
+// --- declared typed column extraction (ADR-0093) ------------------------------
+
+/// The nine fixed `logs` schema columns ([`crate::logs_schema::logs_schema`]).
+/// A bare `Expr::Column` naming one of these is handled by the fixed-column path
+/// (only `ts` extracts anything today) and is NEVER resolved against declared
+/// columns, even if a tenant also happens to declare a column of the same name:
+/// the fixed schema always wins, per ADR-0093's resolution-order guard.
+const FIXED_LOG_COLUMNS: [&str; 9] = [
+    "ts",
+    "observed_ts",
+    "severity_num",
+    "severity_text",
+    "body",
+    "trace_id",
+    "span_id",
+    "flags",
+    "attrs",
+];
+
+fn is_fixed_log_column(name: &str) -> bool {
+    FIXED_LOG_COLUMNS.contains(&name)
+}
+
+/// The declared column a bare, non-fixed `Expr::Column` resolves to, or `None`
+/// for a fixed name, a non-column expression (including a `Cast`-wrapped
+/// column), or a name outside the tenant's declared vocabulary.
+fn resolve_declared<'a>(e: &Expr, declared: &'a [DeclaredColumn]) -> Option<&'a DeclaredColumn> {
+    let Expr::Column(c) = e else {
+        return None;
+    };
+    if is_fixed_log_column(&c.name) {
+        return None;
+    }
+    declared.iter().find(|d| d.key == c.name)
+}
+
+/// A comparison (`<`, `<=`, `>`, `>=`, `=`, either operand order) against a
+/// declared typed column, resolved to a prune-only [`Predicate`]. Range
+/// operators on `Str`/`Bytes`, any negation, and a type-mismatched literal all
+/// decline (return `None`), per ADR-0093's allowlist.
+fn declared_comparison_predicate(
+    be: &BinaryExpr,
+    declared: &[DeclaredColumn],
+) -> Option<Predicate> {
+    // Orient the comparison so `op`/`lit` describe `column op literal`.
+    let (dc, op, lit) = if let Some(dc) = resolve_declared(&be.left, declared) {
+        (dc, be.op, be.right.as_ref())
+    } else {
+        let dc = resolve_declared(&be.right, declared)?;
+        (dc, flip_op(be.op)?, be.left.as_ref())
+    };
+    match dc.ty {
+        DeclaredType::I64 => {
+            let v = lit_i64(lit)?;
+            let (min, max) = int_range_bounds(op, v)?;
+            Some(num_range(&dc.key, FieldType::I64, min, max))
+        }
+        DeclaredType::Bool => {
+            let b = lit_bool(lit)?;
+            let (min, max) = int_range_bounds(op, b as i64)?;
+            Some(num_range(&dc.key, FieldType::Bool, min, max))
+        }
+        DeclaredType::Str => {
+            let value = str_eq_value(op, lit)?;
+            Some(Predicate::Equals {
+                field: FieldSel::Attr(dc.key.clone()),
+                value,
+            })
+        }
+        DeclaredType::Bytes => {
+            let value = bytes_eq_value(op, lit)?;
+            Some(Predicate::Equals {
+                field: FieldSel::Attr(dc.key.clone()),
+                value,
+            })
+        }
+    }
+}
+
+/// `col BETWEEN low AND high` (non-negated) against a declared I64/Bool column ->
+/// an inclusive [`Predicate::NumRange`]. `Str`/`Bytes` decline (POSTINGS is an
+/// equality index, no ordered range). Both bounds must be matching-type literals,
+/// or the whole shape declines.
+fn declared_between_predicate(bt: &Between, declared: &[DeclaredColumn]) -> Option<Predicate> {
+    let dc = resolve_declared(&bt.expr, declared)?;
+    let (ty, lo, hi) = match dc.ty {
+        DeclaredType::I64 => (FieldType::I64, lit_i64(&bt.low)?, lit_i64(&bt.high)?),
+        DeclaredType::Bool => (
+            FieldType::Bool,
+            lit_bool(&bt.low)? as i64,
+            lit_bool(&bt.high)? as i64,
+        ),
+        DeclaredType::Str | DeclaredType::Bytes => return None,
+    };
+    Some(num_range(&dc.key, ty, Some(lo), Some(hi)))
+}
+
+/// `col IN (v1, v2, ...)` (non-negated) against a declared I64 column -> ONE
+/// envelope [`Predicate::NumRange`] spanning `[min(vs), max(vs)]`. Bool/Str/Bytes
+/// `IN` and an empty list decline; any non-`Int64` member declines the whole
+/// shape (an unreadable member could match a real row, so a partial envelope
+/// would be unsound). See the module doc for why this is one range, not one per
+/// value.
+fn declared_in_list_predicate(il: &InList, declared: &[DeclaredColumn]) -> Option<Predicate> {
+    let dc = resolve_declared(&il.expr, declared)?;
+    if dc.ty != DeclaredType::I64 || il.list.is_empty() {
+        return None;
+    }
+    let mut lo = i64::MAX;
+    let mut hi = i64::MIN;
+    for e in &il.list {
+        let v = lit_i64(e)?;
+        lo = lo.min(v);
+        hi = hi.max(v);
+    }
+    Some(num_range(&dc.key, FieldType::I64, Some(lo), Some(hi)))
+}
+
+/// An `OR`-rooted conjunct recognized as `col = v1 OR col = v2 OR ...` on ONE
+/// declared I64 column -> the same envelope [`Predicate::NumRange`] the
+/// `Expr::InList` arm builds. This is the shape DataFusion's simplifier rewrites
+/// a small `col IN (...)` into before the scan. `None` unless the expr is an
+/// `OR` whose every disjunct is an equality on the *same* declared I64 column
+/// against an exact `Int64` literal: a cross-column or non-equality disjunct
+/// makes the union unrepresentable as one range, so the whole OR declines
+/// (declining to prune is widen-safe).
+fn declared_i64_or_envelope(be: &BinaryExpr, declared: &[DeclaredColumn]) -> Option<Predicate> {
+    if be.op != Operator::Or {
+        return None;
+    }
+    let mut disjuncts = Vec::new();
+    flatten_or(&be.left, &mut disjuncts);
+    flatten_or(&be.right, &mut disjuncts);
+
+    let mut name: Option<&str> = None;
+    let mut lo = i64::MAX;
+    let mut hi = i64::MIN;
+    for d in disjuncts {
+        let (dc, v) = eq_i64_on_declared(d, declared)?;
+        match name {
+            Some(n) if n != dc.key => return None,
+            _ => name = Some(&dc.key),
+        }
+        lo = lo.min(v);
+        hi = hi.max(v);
+    }
+    let name = name?;
+    Some(num_range(name, FieldType::I64, Some(lo), Some(hi)))
+}
+
+/// Collect the leaf disjuncts of a (possibly nested) `OR` tree into `out`.
+fn flatten_or<'a>(e: &'a Expr, out: &mut Vec<&'a Expr>) {
+    if let Expr::BinaryExpr(be) = e
+        && be.op == Operator::Or
+    {
+        flatten_or(&be.left, out);
+        flatten_or(&be.right, out);
+    } else {
+        out.push(e);
+    }
+}
+
+/// `col = <Int64 literal>` (either operand order) on a declared I64 column ->
+/// the column and value, or `None` for any other shape.
+fn eq_i64_on_declared<'a>(
+    e: &Expr,
+    declared: &'a [DeclaredColumn],
+) -> Option<(&'a DeclaredColumn, i64)> {
+    let Expr::BinaryExpr(be) = e else {
+        return None;
+    };
+    if be.op != Operator::Eq {
+        return None;
+    }
+    let (dc, v) = if let Some(dc) = resolve_declared(&be.left, declared) {
+        (dc, lit_i64(&be.right)?)
+    } else {
+        let dc = resolve_declared(&be.right, declared)?;
+        (dc, lit_i64(&be.left)?)
+    };
+    if dc.ty != DeclaredType::I64 {
+        return None;
+    }
+    Some((dc, v))
+}
+
+/// The inclusive `[min, max]` bounds an integer comparison denotes, in i64
+/// space, or `None` for an operator outside the allowlist or a bound that would
+/// overflow (declining is widen-safe). Applies to Bool too, via its `0`/`1`
+/// mapping.
+fn int_range_bounds(op: Operator, v: i64) -> Option<(Option<i64>, Option<i64>)> {
+    Some(match op {
+        Operator::Eq => (Some(v), Some(v)),
+        Operator::GtEq => (Some(v), None),
+        Operator::Gt => (Some(v.checked_add(1)?), None),
+        Operator::LtEq => (None, Some(v)),
+        Operator::Lt => (None, Some(v.checked_sub(1)?)),
+        _ => return None,
+    })
+}
+
+/// Build a prune-only [`Predicate::NumRange`] on `name`, encoding the inclusive
+/// i64-space bounds as the two's-complement `u64` bit pattern
+/// [`ravel_logseg::block`]'s `NumStat` stores (for `Bool`, the `0`/`1` mapping is
+/// already the identity under this cast).
+fn num_range(name: &str, ty: FieldType, min: Option<i64>, max: Option<i64>) -> Predicate {
+    Predicate::NumRange {
+        field: FieldSel::Attr(name.to_string()),
+        ty,
+        min: min.map(|v| v as u64),
+        max: max.map(|v| v as u64),
+    }
+}
+
+/// The `AttrValue::Str` value of an `= 'literal'` comparison on a declared Str
+/// column, or `None` for any non-`=` operator or non-string literal. A declared
+/// Str column is Arrow `Dictionary(Int32, Utf8)` (ADR-0099), so DataFusion's
+/// type coercion wraps the compared literal in a `Dictionary` scalar; unwrap it
+/// to the same UTF-8 the POSTINGS `Equals` predicate keys on.
+fn str_eq_value(op: Operator, lit: &Expr) -> Option<AttrValue> {
+    if op != Operator::Eq {
+        return None;
+    }
+    let Expr::Literal(sv, _) = lit else {
+        return None;
+    };
+    Some(AttrValue::Str(scalar_utf8(sv)?))
+}
+
+/// The UTF-8 string a scalar carries, unwrapping a `Dictionary` scalar to its
+/// value (a declared Str column's coerced literal), or `None` for a non-string
+/// scalar.
+fn scalar_utf8(sv: &ScalarValue) -> Option<String> {
+    match sv {
+        ScalarValue::Utf8(Some(s))
+        | ScalarValue::LargeUtf8(Some(s))
+        | ScalarValue::Utf8View(Some(s)) => Some(s.clone()),
+        ScalarValue::Dictionary(_, inner) => scalar_utf8(inner),
+        _ => None,
+    }
+}
+
+/// The `AttrValue::Bytes` value of an `= X'..'` comparison on a declared Bytes
+/// column, or `None` for any non-`=` operator or non-binary literal.
+fn bytes_eq_value(op: Operator, lit: &Expr) -> Option<AttrValue> {
+    if op != Operator::Eq {
+        return None;
+    }
+    Some(AttrValue::Bytes(lit_bytes(lit)?))
+}
+
+/// An i64 literal, exactly. Only `ScalarValue::Int64` matches: a narrower or
+/// wider integer type, or a float, is a type mismatch that declines rather than
+/// coerces (ADR-0093).
+fn lit_i64(e: &Expr) -> Option<i64> {
+    match e {
+        Expr::Literal(ScalarValue::Int64(Some(v)), _) => Some(*v),
+        _ => None,
+    }
+}
+
+/// A boolean literal, exactly.
+fn lit_bool(e: &Expr) -> Option<bool> {
+    match e {
+        Expr::Literal(ScalarValue::Boolean(Some(b)), _) => Some(*b),
+        _ => None,
+    }
+}
+
+/// A binary literal, in any of DataFusion's binary scalar shapes.
+fn lit_bytes(e: &Expr) -> Option<Vec<u8>> {
+    match e {
+        Expr::Literal(ScalarValue::Binary(Some(b)), _)
+        | Expr::Literal(ScalarValue::LargeBinary(Some(b)), _)
+        | Expr::Literal(ScalarValue::BinaryView(Some(b)), _) => Some(b.clone()),
+        _ => None,
     }
 }
 
@@ -348,7 +720,10 @@ mod tests {
 
     #[test]
     fn ts_bounds_and_between() {
-        let p = extract_logs(&[col("ts").gt_eq(ts_lit(100)), col("ts").lt(ts_lit(200))]);
+        let p = extract_logs(
+            &[col("ts").gt_eq(ts_lit(100)), col("ts").lt(ts_lit(200))],
+            &[],
+        );
         assert_eq!((p.ts_lo, p.ts_hi), (Some(100), Some(199)));
         assert_eq!((p.ts_min(), p.ts_max()), (100, 199));
 
@@ -358,7 +733,7 @@ mod tests {
             low: Box::new(ts_lit(10)),
             high: Box::new(ts_lit(20)),
         });
-        let p = extract_logs(&[e]);
+        let p = extract_logs(&[e], &[]);
         assert_eq!((p.ts_lo, p.ts_hi), (Some(10), Some(20)));
     }
 
@@ -370,14 +745,14 @@ mod tests {
         // An OR anywhere at the top level contributes no bound.
         let range = and(col("ts").gt_eq(ts_lit(100)), col("ts").lt(ts_lit(200)));
         let mixed = or(range, col("severity_num").gt(lit(5)));
-        let p = extract_logs(&[mixed]);
+        let p = extract_logs(&[mixed], &[]);
         assert_eq!((p.ts_lo, p.ts_hi), (None, None));
     }
 
     #[test]
     fn has_word_becomes_content_predicate() {
         let e = has_word_udf().call(vec![col("body"), lit("timeout")]);
-        let p = extract_logs(&[e]);
+        let p = extract_logs(&[e], &[]);
         assert_eq!(
             p.content,
             vec![Predicate::HasWord {
@@ -388,7 +763,7 @@ mod tests {
 
         // has_word over a non-text/unrecognized column contributes nothing.
         let e = has_word_udf().call(vec![col("attrs"), lit("timeout")]);
-        assert!(extract_logs(&[e]).content.is_empty());
+        assert!(extract_logs(&[e], &[]).content.is_empty());
     }
 
     #[test]
@@ -402,7 +777,7 @@ mod tests {
             escape_char: None,
             case_insensitive: false,
         });
-        let p = extract_logs(&[like]);
+        let p = extract_logs(&[like], &[]);
         assert!(p.content.is_empty());
     }
 
@@ -410,7 +785,7 @@ mod tests {
     fn unrecognized_shapes_contribute_nothing() {
         // A binary that is neither a ts comparison nor an attrs equality.
         let be = BinaryExpr::new(Box::new(col("flags")), Operator::Eq, Box::new(lit(1u32)));
-        let p = extract_logs(&[Expr::BinaryExpr(be)]);
+        let p = extract_logs(&[Expr::BinaryExpr(be)], &[]);
         assert_eq!(p, LogsPushdown::default());
     }
 
@@ -426,14 +801,14 @@ mod tests {
         }];
 
         let eq = get_field(col("attrs"), "service.name").eq(lit("api"));
-        let p = extract_logs(&[eq]);
+        let p = extract_logs(&[eq], &[]);
         assert_eq!(p.prune, expected);
         assert!(p.content.is_empty(), "the equality must not become content");
         assert_eq!((p.ts_lo, p.ts_hi), (None, None));
 
         // The value on the left extracts the identical predicate.
         let eq_flipped = lit("api").eq(get_field(col("attrs"), "service.name"));
-        let p = extract_logs(&[eq_flipped]);
+        let p = extract_logs(&[eq_flipped], &[]);
         assert_eq!(p.prune, expected);
         assert!(p.content.is_empty());
 
@@ -441,7 +816,7 @@ mod tests {
         // either channel. The intersecting prune channel cannot represent it
         // soundly; a disjunctive form is not yet supported.
         let in_list = get_field(col("attrs"), "k").in_list(vec![lit("a"), lit("b")], false);
-        let p = extract_logs(&[in_list]);
+        let p = extract_logs(&[in_list], &[]);
         assert!(p.content.is_empty());
         assert!(p.prune.is_empty(), "IN must not populate the prune channel");
     }
@@ -451,8 +826,273 @@ mod tests {
         // Only the `attrs` map is prunable; a subscript on any other column
         // contributes nothing to either channel.
         let eq = get_field(col("resource"), "service.name").eq(lit("api"));
-        let p = extract_logs(&[eq]);
+        let p = extract_logs(&[eq], &[]);
         assert!(p.prune.is_empty());
         assert!(p.content.is_empty());
+    }
+
+    // --- declared typed column extraction (ADR-0093) -------------------------
+
+    fn i64_decl() -> Vec<DeclaredColumn> {
+        vec![DeclaredColumn::new("status_code", DeclaredType::I64)]
+    }
+
+    fn num_range_arm(ty: FieldType, min: Option<u64>, max: Option<u64>) -> Predicate {
+        Predicate::NumRange {
+            field: FieldSel::Attr("status_code".into()),
+            ty,
+            min,
+            max,
+        }
+    }
+
+    /// Every I64 comparison operator, either operand order, maps to the inclusive
+    /// bit-pattern range it denotes. `>`/`<` shift by one in integer space; a
+    /// flipped operand order flips the operator.
+    #[test]
+    fn i64_comparisons_map_to_num_range() {
+        let d = i64_decl();
+        let cases = [
+            (col("status_code").eq(lit(500i64)), Some(500), Some(500)),
+            (col("status_code").gt_eq(lit(500i64)), Some(500), None),
+            (col("status_code").gt(lit(500i64)), Some(501), None),
+            (col("status_code").lt_eq(lit(500i64)), None, Some(500)),
+            (col("status_code").lt(lit(500i64)), None, Some(499)),
+            // Flipped operand order: `500 < status_code` is `status_code > 500`.
+            (lit(500i64).lt(col("status_code")), Some(501), None),
+        ];
+        for (expr, min, max) in cases {
+            let p = extract_logs(std::slice::from_ref(&expr), &d);
+            assert_eq!(
+                p.prune,
+                vec![num_range_arm(FieldType::I64, min, max)],
+                "unexpected range for {expr:?}"
+            );
+            assert!(p.content.is_empty());
+            assert_eq!((p.ts_lo, p.ts_hi), (None, None));
+        }
+    }
+
+    /// A declared Bool column: `= true`/`= false` degenerate to the `1`/`0`
+    /// point range `bool_stat` folds under, sharing the I64 extraction path.
+    #[test]
+    fn bool_equality_maps_to_bit_point_range() {
+        let d = vec![DeclaredColumn::new("is_active", DeclaredType::Bool)];
+        let p = extract_logs(&[col("is_active").eq(lit(true))], &d);
+        assert_eq!(
+            p.prune,
+            vec![Predicate::NumRange {
+                field: FieldSel::Attr("is_active".into()),
+                ty: FieldType::Bool,
+                min: Some(1),
+                max: Some(1),
+            }]
+        );
+        let p = extract_logs(&[col("is_active").eq(lit(false))], &d);
+        assert_eq!(
+            p.prune,
+            vec![Predicate::NumRange {
+                field: FieldSel::Attr("is_active".into()),
+                ty: FieldType::Bool,
+                min: Some(0),
+                max: Some(0),
+            }]
+        );
+    }
+
+    /// A declared I64 `BETWEEN low AND high` is one inclusive range; a negated
+    /// BETWEEN (an OR of two half-lines) is not extracted.
+    #[test]
+    fn i64_between_maps_to_inclusive_range() {
+        let d = i64_decl();
+        let between = Expr::Between(datafusion::logical_expr::Between {
+            expr: Box::new(col("status_code")),
+            negated: false,
+            low: Box::new(lit(200i64)),
+            high: Box::new(lit(499i64)),
+        });
+        let p = extract_logs(&[between], &d);
+        assert_eq!(
+            p.prune,
+            vec![num_range_arm(FieldType::I64, Some(200), Some(499))]
+        );
+
+        let negated = Expr::Between(datafusion::logical_expr::Between {
+            expr: Box::new(col("status_code")),
+            negated: true,
+            low: Box::new(lit(200i64)),
+            high: Box::new(lit(499i64)),
+        });
+        let p = extract_logs(&[negated], &d);
+        assert!(
+            p.prune.is_empty(),
+            "a negated BETWEEN must not be extracted"
+        );
+    }
+
+    /// A declared I64 `IN (v1, v2, v3)` collapses to ONE envelope range spanning
+    /// the set's min and max, never one arm per value.
+    #[test]
+    fn i64_in_list_maps_to_one_envelope_range() {
+        let d = i64_decl();
+        let in_list =
+            col("status_code").in_list(vec![lit(200i64), lit(404i64), lit(500i64)], false);
+        let p = extract_logs(&[in_list], &d);
+        assert_eq!(
+            p.prune,
+            vec![num_range_arm(FieldType::I64, Some(200), Some(500))],
+            "IN must produce a single [min, max] envelope, not one arm per value"
+        );
+    }
+
+    /// A small `col IN (...)` reaches the scan as `col = v1 OR col = v2 OR ...`
+    /// (DataFusion's simplifier expands it). That same-column I64 disjunction
+    /// collapses to the SAME envelope range the `Expr::InList` arm builds.
+    #[test]
+    fn same_column_i64_or_disjunction_maps_to_envelope() {
+        let d = i64_decl();
+        let or_expr = or(
+            or(
+                col("status_code").eq(lit(200i64)),
+                col("status_code").eq(lit(404i64)),
+            ),
+            col("status_code").eq(lit(500i64)),
+        );
+        let p = extract_logs(&[or_expr], &d);
+        assert_eq!(
+            p.prune,
+            vec![num_range_arm(FieldType::I64, Some(200), Some(500))],
+            "a same-column equality OR is the small-IN envelope"
+        );
+    }
+
+    /// A cross-column OR (or any non-equality disjunct) is not a representable
+    /// single range and must not extract: one disjunct's range would prune a
+    /// block the full disjunction keeps.
+    #[test]
+    fn cross_column_or_is_not_extracted() {
+        let d = vec![
+            DeclaredColumn::new("status_code", DeclaredType::I64),
+            DeclaredColumn::new("shard", DeclaredType::I64),
+        ];
+        // Different declared columns.
+        let mixed = or(
+            col("status_code").eq(lit(200i64)),
+            col("shard").eq(lit(3i64)),
+        );
+        assert!(extract_logs(&[mixed], &d).prune.is_empty());
+
+        // A non-equality disjunct on the same column.
+        let ranged = or(
+            col("status_code").eq(lit(200i64)),
+            col("status_code").gt(lit(400i64)),
+        );
+        assert!(extract_logs(&[ranged], &d).prune.is_empty());
+
+        // A disjunct on an undeclared column.
+        let undeclared = or(
+            col("status_code").eq(lit(200i64)),
+            col("body").eq(lit("zzz")),
+        );
+        assert!(extract_logs(&[undeclared], &d).prune.is_empty());
+    }
+
+    /// A `NOT IN` is an AND of inequalities, a different shape; not extracted.
+    #[test]
+    fn i64_negated_in_list_is_not_extracted() {
+        let d = i64_decl();
+        let in_list = col("status_code").in_list(vec![lit(200i64), lit(404i64)], true);
+        let p = extract_logs(&[in_list], &d);
+        assert!(p.prune.is_empty());
+    }
+
+    /// A declared Str column's `=` maps to the same `Equals` predicate the
+    /// `attrs['k'] = 'v'` shape builds, feeding POSTINGS.
+    #[test]
+    fn str_equality_maps_to_attr_equals() {
+        let d = vec![DeclaredColumn::new("region", DeclaredType::Str)];
+        let p = extract_logs(&[col("region").eq(lit("eu"))], &d);
+        assert_eq!(
+            p.prune,
+            vec![Predicate::Equals {
+                field: FieldSel::Attr("region".into()),
+                value: AttrValue::Str("eu".into()),
+            }]
+        );
+        // A range operator on a Str column has no ordered index; declines.
+        let p = extract_logs(&[col("region").gt(lit("eu"))], &d);
+        assert!(
+            p.prune.is_empty(),
+            "a Str range operator must not be extracted"
+        );
+        // Str IN is a disjunction POSTINGS cannot represent; declines.
+        let p = extract_logs(
+            &[col("region").in_list(vec![lit("eu"), lit("us")], false)],
+            &d,
+        );
+        assert!(p.prune.is_empty(), "a Str IN must not be extracted");
+    }
+
+    /// TEST 6: `!=` and a `NOT`-wrapped equality on a declared column produce no
+    /// prune arm at all. `NumRange` is a single contiguous range and cannot
+    /// express the complement of a point (ADR-0093).
+    #[test]
+    fn not_equal_and_negation_produce_no_prune_arm() {
+        let d = i64_decl();
+
+        let ne = extract_logs(&[col("status_code").not_eq(lit(500i64))], &d);
+        assert!(ne.prune.is_empty(), "!= must produce no prune arm");
+
+        let negated = extract_logs(
+            &[Expr::Not(Box::new(col("status_code").eq(lit(500i64))))],
+            &d,
+        );
+        assert!(
+            negated.prune.is_empty(),
+            "a NOT-wrapped equality must produce no prune arm"
+        );
+
+        // Bool's point-complement coincidence must NOT be special-cased either.
+        let bd = vec![DeclaredColumn::new("is_active", DeclaredType::Bool)];
+        let bne = extract_logs(&[col("is_active").not_eq(lit(true))], &bd);
+        assert!(bne.prune.is_empty(), "bool != must produce no prune arm");
+    }
+
+    /// TEST 7: a comparison against a type-mismatched literal (a float against a
+    /// declared I64 column) produces no prune arm. A mismatched literal is never
+    /// coerced to fit; extraction declines.
+    #[test]
+    fn type_mismatched_literal_produces_no_prune_arm() {
+        let d = i64_decl();
+        let p = extract_logs(&[col("status_code").gt(lit(2.5f64))], &d);
+        assert!(
+            p.prune.is_empty(),
+            "a float literal against an I64 column must not extract"
+        );
+        // A string literal against an I64 column likewise declines.
+        let p = extract_logs(&[col("status_code").eq(lit("500"))], &d);
+        assert!(p.prune.is_empty());
+    }
+
+    /// The resolution-order guard: a fixed schema name is never resolved against
+    /// declared columns, even when a tenant declares one of the same name. A
+    /// declared `severity_num` must not turn the fixed `severity_num = 5` into a
+    /// prune arm (the fixed-column path owns that name).
+    #[test]
+    fn a_fixed_name_is_never_resolved_as_declared() {
+        let d = vec![DeclaredColumn::new("severity_num", DeclaredType::I64)];
+        let p = extract_logs(&[col("severity_num").eq(lit(5i64))], &d);
+        assert!(
+            p.prune.is_empty(),
+            "a fixed schema name must take the fixed-column path, not declared resolution"
+        );
+    }
+
+    /// A bare column that matches no declared column falls through unchanged:
+    /// scanned, not pruned, exactly as before this ADR.
+    #[test]
+    fn undeclared_column_falls_through() {
+        let p = extract_logs(&[col("status_code").eq(lit(500i64))], &[]);
+        assert_eq!(p, LogsPushdown::default());
     }
 }

--- a/crates/ravel-sql/src/logs_scan.rs
+++ b/crates/ravel-sql/src/logs_scan.rs
@@ -281,10 +281,14 @@ fn attr_value_memory(v: &AttrValue) -> usize {
 ///   [`FIRST_DECLARED_COL`]; DataFusion already folds a residual-filter column
 ///   into the projection it hands the scan, so a declared column named only in
 ///   a `WHERE` clause is still decoded. This adds the declared key to the
-///   selection exactly like the content- and erasure-predicate contributors do;
-///   declared-column predicates are NOT extracted into the prune or
-///   content-predicate channels in this ADR (a typed comparison is a residual
-///   filter above the scan; typed-predicate pushdown is #278).
+///   selection exactly like the content- and erasure-predicate contributors do.
+///   Since #278/ADR-0093, an I64/Bool comparison or a Str/Bytes equality on a
+///   declared column IS extracted into the prune-only channel
+///   (`crate::logs_pushdown::extract_logs`) -- see that module's doc for the
+///   exact allowlist. The declared column is still, separately, added to the
+///   selection here regardless, because the prune channel narrows candidate
+///   blocks but never substitutes for DataFusion's own Inexact residual
+///   re-evaluation of the original predicate above the scan.
 ///
 /// The prune-only channel contributes nothing: its arms drive POSTINGS block
 /// pruning and are never evaluated per row, so no page has to be decoded for

--- a/docs/guides/query.md
+++ b/docs/guides/query.md
@@ -331,11 +331,23 @@ column. Declared keys still appear in `attrs`. A declaration comes from the serv
 `--typed-attr-column` flags or from the durable per-tenant override written by
 `ravel-cli typed-attr-column set`, and a query process picks a durable change
 up within 60s. Querying an undeclared column is an unknown-column error, and a
-row whose stored value has another type reads NULL rather than being cast. See
+row whose stored value has another type reads NULL rather than being cast.
+
+A predicate on a declared column now prunes blocks before decode (ADR-0093), so
+it is no longer slower than the equivalent `attrs['k']` filter. A selective
+`i64`/`bool` comparison, `BETWEEN`, or `i64` `IN (...)` skips blocks through the
+RLOG skip index (`status_code > 500`, `is_active = true`, `status_code IN (200,
+404)`), and a `str`/`bytes` equality prunes through POSTINGS exactly like
+`attrs['k'] = 'v'`. Pruning is always widen-only: the original predicate is
+re-applied above the scan, so the `IN` envelope's coarser range and any
+type-mismatched shape (`!=`, a range on a `str` column, a float compared to an
+`i64` column) never change which rows return, only which blocks the fetch reads.
+Two caveats carry over unchanged: the `str`/`bytes` equality half sees no
+pruning benefit on a POSTINGS section written before the #333 write-path fix, and
+a name that also carries a non-`str` column anywhere declines equality pruning
+for that name. See
 [operations.md](operations.md#declared-typed-attribute-columns-adr-0090) and
-docs/query-engine.md for the full contract, including why an equality predicate
-moved onto a declared column is slower than the equivalent `attrs['k'] = 'v'`
-today.
+docs/query-engine.md for the full contract.
 
 ### Declaring typed attribute columns
 

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -1212,6 +1212,39 @@ never drop a true result):
   match. The merged `attrs` residual evaluates the equality exactly.
   `attrs['k'] IN (...)` stays unextracted, because an `IN` list is a
   disjunction the intersecting prune channel cannot represent soundly.
+- A predicate on a **declared typed column** (ADR-0093). `extract_logs` resolves
+  a bare `Expr::Column` whose name is not one of the nine fixed columns against
+  the tenant's declared vocabulary and dispatches on the declared type:
+  - `i64`/`bool` with `<`, `<=`, `>`, `>=`, `=`, or `BETWEEN` against a
+    matching-type literal → a prune-only `Predicate::NumRange` with bit-pattern
+    bounds, driving the RLOG skip index's per-block `NumStat` min/max (ADR-0095,
+    #331). `status_code > 500` and `is_active = true` now skip blocks that
+    provably hold no matching value.
+  - `i64` `IN (v1, v2, ...)` → ONE envelope `NumRange` spanning `[min, max]`, not
+    one arm per value (the reader intersects prune arms, so a per-value arm would
+    drop rows the full `IN` keeps). The envelope is coarser than the exact set,
+    so a value between the listed ones is excluded by the residual, never the
+    prune. DataFusion's simplifier rewrites a small `IN` into a same-column
+    `col = v1 OR col = v2 OR ...` disjunction before the scan; that shape maps to
+    the same envelope.
+  - `str`/`bytes` `=` against a matching-type literal → the same
+    `Predicate::Equals` the `attrs['k'] = 'v'` shape builds, driving POSTINGS.
+  Everything else — `!=`, `NOT`, negated `BETWEEN`, `IS [NOT] NULL`, a general
+  `OR`, a range operator on a `str`/`bytes` column, a `str`/`bytes` `IN`, or a
+  type-mismatched literal (including one DataFusion coercion has already wrapped
+  in a `Cast`, which is no longer a bare column) — is not extracted and scans as
+  before. Two soundness caveats are inherited, not new: the equality half
+  declines all pruning on a POSTINGS section written before the #333 write-path
+  fix (a section-version gate, so no per-predicate code carries it), and inherits
+  the over-conservative rule that a name also carrying a non-`str` column
+  anywhere declines equality pruning entirely (a performance no-op, not a
+  correctness gap). The `NumRange` half has no version gate: under ADR-0095's
+  single-version RLOG regime every stat is merged-view-correct, and a block with
+  no stat for the column (an object predating the declaration) is scanned, never
+  pruned (ADR-0013). `f64` is not reachable yet (no declared `f64` type); its
+  future arm must honor `NumRange`'s float contract (widen a zero-including range
+  across both `0.0`/`-0.0` bit patterns, never build a bound from a NaN literal),
+  which the i64/bool code does not need.
 
 ### Declared typed attribute columns (ADR-0090)
 
@@ -1264,15 +1297,18 @@ last resolved declaration instead and counts
 [guides/operations.md](guides/operations.md#declared-typed-attribute-columns-adr-0090)
 for the operator-facing contract.
 
-Predicates on a declared column are NOT pushed down in this version: a typed
-comparison is evaluated as a residual filter above the scan (typed-predicate
-pushdown is #278). A declared column referenced by the query's projection --
-which DataFusion also folds residual-filter columns into -- is decoded by the
-scan's column selection, so `WHERE` on a declared column still decodes only the
-pages it needs. The practical consequence: moving an equality predicate from
-`attrs['k'] = 'v'` (which prunes blocks through POSTINGS) to a declared
-`k = 'v'` makes it slower until #278 lands. Declare for typed comparisons and
-aggregates, which the map cannot express at all.
+Predicates on a declared column are pushed down as prune-only arms (ADR-0093):
+an `i64`/`bool` comparison or `BETWEEN` and an `i64` `IN` drive the skip index,
+and a `str`/`bytes` equality drives POSTINGS, exactly as the "Supported
+predicates" list above describes. The pushdown is always `Inexact`, so the typed
+comparison is still re-evaluated exactly as a residual filter above the scan; the
+prune only changes which blocks the fetch decodes. A declared column referenced
+by the query's projection -- which DataFusion also folds residual-filter columns
+into -- is decoded by the scan's column selection, so `WHERE` on a declared
+column decodes only the pages it needs. Moving an equality predicate from
+`attrs['k'] = 'v'` to a declared `k = 'v'` now prunes through the same POSTINGS
+index (subject to the section-version caveat above). Declare for typed
+comparisons and aggregates, which the map cannot express at all.
 
 There is also a wire-size trade for a *high-cardinality* `str` column. ADR-0099
 decision 5's "leaves that case exactly as expensive as it is today" is a


### PR DESCRIPTION
ADR-0093: a predicate written against a declared logs column
(status_code = 500), not the attrs['status_code'] = 500 subscript
syntax, now prunes blocks the same way the subscript form already
does. One shared resolver in logs_pushdown.rs recognizes a bare
Expr::Column matching a declared, non-fixed-schema column and
dispatches on its DeclaredType to two already-landed, independently
sound primitives: Predicate::NumRange (I64/Bool comparisons and
BETWEEN, via epic #331) and Predicate::Equals against POSTINGS
(Str/Bytes equality, via #333's fixed write path). No new Predicate
variant, no ravel-logseg change.

An IN list over a declared I64 column extracts to a single envelope
range rather than one range per value -- the prune channel intersects
its arms, so a range per value would be unsound (an arm covering only
one of several values would independently prove some blocks disjoint
that the full set does not exclude). Everything outside the allowlist
(!=, NOT, IS NULL, OR across columns, a range operator on Str/Bytes, a
type-mismatched or cast-wrapped literal) declines extraction rather
than risk an unsound translation; DataFusion's own Inexact residual
stays the sole exact evaluator either way.

Checkpoint review independently reproduced the soundness properties
with its own mutation tests (the encoding across the I64 sign
boundary, the absence-is-no-information rule from this new call site,
the fixed-column resolution-order guard, both primitives' separate
version-decline stories) and confirmed no silent-row-drop. Two fixes
applied from that review: the IN-envelope end-to-end test was
accidentally exercising a same-column OR rewrite DataFusion's own
simplifier produces for a two-value IN, not the InList code path it
named -- widened to five values and mutation-proofed for real; and a
stale comment claiming declared-column predicates aren't extracted.

A third finding -- the shipped code also extracts a same-column
OR-of-equalities shape (the exact form DataFusion rewrites a small IN
into), which is provably sound but contradicts three places in
ADR-0093's text that say OR declines -- is filed as #632 for a human
decision on reconciling the ADR, not resolved in this PR.

Fixes: #625
Refs: #278
