### PR TITLE
feat(query): render native histograms in range-query JSON

### DIFF
--- a/crates/ravel-query/src/engine.rs
+++ b/crates/ravel-query/src/engine.rs
@@ -14,8 +14,8 @@ use ravel_catalog::{Catalog, SegmentRef, ShardGeneration, Snapshot};
 use ravel_object_store::{ObjectStoreBackend, StoreError};
 use ravel_promql::{
     Annotations, Evaluator, FloatHistogram, HistogramSeriesData, LabelMatcher, MatchOp, PlanAnchor,
-    SelectorPlan, SeriesData, SeriesSource, SourceError, Span, Value, from_ast_matchers,
-    has_or_group, matches_series, ms_to_ns, plan_selectors,
+    RangeValue, SelectorPlan, SeriesData, SeriesSource, SourceError, Span, Value,
+    from_ast_matchers, has_or_group, matches_series, ms_to_ns, plan_selectors,
 };
 use ravel_proto::queryfrag::v1 as pb;
 use ravel_segment::ReaderLimits;
@@ -537,6 +537,39 @@ impl QueryEngine {
         now_ns: i64,
         deadline: Duration,
     ) -> Result<(Value, Annotations, QueryStats), QueryError> {
+        let (value, annotations, stats) = self
+            .range_hist_with_stats_annotated(
+                tenant_hash,
+                query,
+                start_ms,
+                end_ms,
+                step_ms,
+                min_tokens,
+                now_ns,
+                deadline,
+            )
+            .await?;
+        Ok((range_value_into_value(value), annotations, stats))
+    }
+
+    /// Same as [`Self::range_with_stats_annotated`], but the matrix result is a
+    /// histogram-aware [`RangeValue`] carrying per-step native-histogram
+    /// elements alongside floats (ADR-0108 decision 9), the form the HTTP
+    /// range renderer needs to emit Prometheus' `histograms` field. The
+    /// float-only [`Self::range_with_stats_annotated`] is the thin wrapper that
+    /// projects histogram elements away for callers that only render floats.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn range_hist_with_stats_annotated(
+        &self,
+        tenant_hash: TenantHash,
+        query: &str,
+        start_ms: i64,
+        end_ms: i64,
+        step_ms: i64,
+        min_tokens: &[CommitToken],
+        now_ns: i64,
+        deadline: Duration,
+    ) -> Result<(RangeValue, Annotations, QueryStats), QueryError> {
         let eval_deadline = Instant::now() + deadline;
         let outcome = tokio::time::timeout(
             deadline,
@@ -566,7 +599,7 @@ impl QueryEngine {
         min_tokens: &[CommitToken],
         now_ns: i64,
         eval_deadline: Instant,
-    ) -> Result<(Value, Annotations, QueryStats), QueryError> {
+    ) -> Result<(RangeValue, Annotations, QueryStats), QueryError> {
         if step_ms <= 0 {
             return Err(QueryError::NonPositiveStep { step_ms });
         }
@@ -590,7 +623,7 @@ impl QueryEngine {
             .with_deadline(eval_deadline);
         let (value, annotations) =
             tracing::debug_span!("evaluate", eval_kind = "range").in_scope(|| {
-                evaluator.eval_range_annotated(&source, query, start_ms, end_ms, step_ms)
+                evaluator.eval_range_hist_annotated(&source, query, start_ms, end_ms, step_ms)
             })?;
         Ok((value, annotations, stats))
     }
@@ -1786,6 +1819,39 @@ pub(crate) fn bytes_scanned_exceeded(
 /// the case that actually demonstrates early interruption. Both are the
 /// same condition from a caller's perspective, so both collapse to the one
 /// variant already documented and tested against.
+/// Project a histogram-aware [`RangeValue`] down to the float-only [`Value`]
+/// the non-histogram range callers (`range`, `range_with_stats`) consume:
+/// histogram elements are dropped rather than rendered as a `0.0` float
+/// (ADR-0108's forbidden silent zeros), and a series left with no float
+/// element is omitted entirely. Mirrors `RangeValue::into_value` in
+/// `ravel-promql`, replicated here because that projection is crate-private.
+fn range_value_into_value(value: RangeValue) -> Value {
+    match value {
+        RangeValue::Scalar(v) => Value::Scalar(v),
+        RangeValue::String(s) => Value::String(s),
+        RangeValue::Matrix(matrix) => Value::Matrix(
+            matrix
+                .into_iter()
+                .filter_map(|(labels, samples)| {
+                    let floats: Vec<Sample> = samples
+                        .into_iter()
+                        .filter(|s| s.histogram.is_none())
+                        .map(|s| Sample {
+                            ts_ns: s.ts_ns,
+                            value: s.value,
+                        })
+                        .collect();
+                    if floats.is_empty() {
+                        None
+                    } else {
+                        Some((labels, floats))
+                    }
+                })
+                .collect(),
+        ),
+    }
+}
+
 fn unify_deadline<T>(
     outcome: Result<Result<T, QueryError>, tokio::time::error::Elapsed>,
     deadline: Duration,

--- a/crates/ravel-query/src/http/handlers.rs
+++ b/crates/ravel-query/src/http/handlers.rs
@@ -318,7 +318,7 @@ async fn handle_query_range(
     // request's resolved `[start, end]` range.
     let exec = state
         .engine
-        .range_with_stats_annotated(
+        .range_hist_with_stats_annotated(
             tenant_hash,
             query,
             start_ms,

--- a/crates/ravel-query/src/http/json.rs
+++ b/crates/ravel-query/src/http/json.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 
-use ravel_promql::{FloatHistogram, Value, ms_to_ns};
+use ravel_promql::{FloatHistogram, RangeSample, RangeValue, Value, ms_to_ns};
 use ravel_types::accounting::AccountedOp;
 use ravel_types::{LabelSet, SeriesId};
 use serde::{Serialize, Serializer};
@@ -274,10 +274,20 @@ pub struct VectorResult {
     pub histogram: Option<(Timestamp, HistogramJson)>,
 }
 
+/// One range-vector (matrix) series. Prometheus renders float steps under a
+/// `values` array and native-histogram steps under a `histograms` array, per
+/// element type per timestamp; a series may carry either or both across its
+/// grid (a series that switches representation mid-range is float at some
+/// steps and histogram at others). Both are `omitempty`, matching
+/// Prometheus' `web/api/v1` matrix sample shape, so a float-only series omits
+/// `histograms` and a histogram-only series omits `values`.
 #[derive(Debug, Serialize)]
 pub struct MatrixResult {
     pub metric: HashMap<String, String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub values: Vec<(Timestamp, String)>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub histograms: Vec<(Timestamp, HistogramJson)>,
 }
 
 /// Prometheus' `model.SampleHistogram` JSON shape for a native (exponential)
@@ -442,6 +452,7 @@ pub fn instant_value_to_json(value: Value, time_ms: i64) -> Result<QueryData, Ap
                         .into_iter()
                         .map(|s| (ts_ns_to_seconds(s.ts_ns), format_value(s.value)))
                         .collect(),
+                    histograms: Vec::new(),
                 })
                 .collect(),
         )),
@@ -456,43 +467,50 @@ pub fn instant_value_to_json(value: Value, time_ms: i64) -> Result<QueryData, Ap
 /// that repetition, which `eval_range` deliberately defers to the wire
 /// format layer.
 pub fn range_value_to_json(
-    value: Value,
+    value: RangeValue,
     start_ms: i64,
     end_ms: i64,
     step_ms: i64,
 ) -> Result<QueryData, ApiError> {
     match value {
-        Value::Matrix(matrix) => Ok(QueryData::Matrix(
+        RangeValue::Matrix(matrix) => Ok(QueryData::Matrix(
             matrix
                 .into_iter()
-                .map(|(labels, samples)| MatrixResult {
-                    metric: labels_to_map(&labels),
-                    values: samples
-                        .into_iter()
-                        .map(|s| (ts_ns_to_seconds(s.ts_ns), format_value(s.value)))
-                        .collect(),
-                })
+                .map(|(labels, samples)| range_series_to_matrix_result(labels, samples))
                 .collect(),
         )),
-        Value::Scalar(v) => Ok(QueryData::Matrix(vec![repeated_matrix_result(
+        RangeValue::Scalar(v) => Ok(QueryData::Matrix(vec![repeated_matrix_result(
             start_ms,
             end_ms,
             step_ms,
             format_value(v),
         )?])),
-        Value::String(s) => Ok(QueryData::Matrix(vec![repeated_matrix_result(
+        RangeValue::String(s) => Ok(QueryData::Matrix(vec![repeated_matrix_result(
             start_ms, end_ms, step_ms, s,
         )?])),
-        // eval_range's own contract (crates/ravel-promql/src/eval.rs) never
-        // produces an instant vector from a range query; handled explicitly
-        // rather than left to panic if that contract ever changes.
-        Value::Vector(_) => Err(ApiError::BadData(
-            ravel_promql::Error::WrongType {
-                expected: "scalar, string, or range vector",
-                got: "instant vector",
-            }
-            .to_string(),
-        )),
+    }
+}
+
+/// Split one range-vector series' per-step [`RangeSample`]s into Prometheus'
+/// two per-element-type arrays: float steps under `values`, native-histogram
+/// steps under `histograms`. A histogram step's placeholder `0.0` float
+/// (`RangeSample::histogram`) is never emitted as a float; it renders as a
+/// histogram element through the same [`histogram_to_json`] encoder the
+/// instant path uses, keeping the two endpoints byte-compatible.
+fn range_series_to_matrix_result(labels: LabelSet, samples: Vec<RangeSample>) -> MatrixResult {
+    let mut values = Vec::new();
+    let mut histograms = Vec::new();
+    for s in samples {
+        let ts = ts_ns_to_seconds(s.ts_ns);
+        match s.histogram {
+            Some(h) => histograms.push((ts, histogram_to_json(&h))),
+            None => values.push((ts, format_value(s.value))),
+        }
+    }
+    MatrixResult {
+        metric: labels_to_map(&labels),
+        values,
+        histograms,
     }
 }
 
@@ -524,6 +542,7 @@ fn repeated_matrix_result(
     Ok(MatrixResult {
         metric: HashMap::new(),
         values,
+        histograms: Vec::new(),
     })
 }
 
@@ -620,7 +639,7 @@ mod tests {
     #[test]
     fn range_scalar_repeats_the_value_across_the_whole_grid() {
         let data = range_value_to_json(
-            Value::Scalar(3.0),
+            RangeValue::Scalar(3.0),
             1_700_000_000_000,
             1_700_000_002_000,
             1_000,
@@ -639,7 +658,7 @@ mod tests {
     #[test]
     fn range_string_repeats_the_value_across_the_whole_grid() {
         let data = range_value_to_json(
-            Value::String("idle".to_string()),
+            RangeValue::String("idle".to_string()),
             1_700_000_000_000,
             1_700_000_001_000,
             1_000,
@@ -849,6 +868,103 @@ mod tests {
     }
 
     #[test]
+    fn range_result_renders_native_histogram_field() {
+        // A range-vector series whose steps are native histograms renders each
+        // step under Prometheus' `histograms` array (not `values`), shaped
+        // `[ts, {count, sum, buckets}]` with the same per-element encoding the
+        // instant path uses. The float `values` array is absent (omitempty) on
+        // a histogram-only series. This histogram matches
+        // `instant_vector_renders_native_histogram_element`: a negative bucket
+        // (-2,-1] (boundaries 1), a zero bucket (-0.5,0.5] (boundaries 3), and
+        // a positive bucket (1,2] (boundaries 0).
+        use ravel_promql::{FloatHistogram, ResetHint, Span};
+        use ravel_types::{Label, LabelSet};
+
+        let make_hist = |sum: f64| FloatHistogram {
+            counter_reset_hint: ResetHint::Unknown,
+            scale: 0,
+            zero_threshold: 0.5,
+            zero_count: 4.0,
+            count: 9.0,
+            sum,
+            positive_spans: vec![Span {
+                offset: 1,
+                length: 1,
+            }],
+            negative_spans: vec![Span {
+                offset: 1,
+                length: 1,
+            }],
+            positive_buckets: vec![2.0],
+            negative_buckets: vec![3.0],
+            custom_values: Vec::new(),
+        };
+        let labels = LabelSet::new(vec![Label {
+            name: "__name__".to_string(),
+            value: "req_latency".to_string(),
+        }])
+        .expect("valid labels");
+        let matrix = vec![(
+            labels,
+            vec![
+                RangeSample {
+                    ts_ns: 1_700_000_000_000_000_000,
+                    value: 0.0,
+                    histogram: Some(make_hist(4.5)),
+                },
+                RangeSample {
+                    ts_ns: 1_700_000_060_000_000_000,
+                    value: 0.0,
+                    histogram: Some(make_hist(5.5)),
+                },
+            ],
+        )];
+
+        let data = range_value_to_json(
+            RangeValue::Matrix(matrix),
+            1_700_000_000_000,
+            1_700_000_060_000,
+            60_000,
+        )
+        .expect("histogram matrix renders");
+        let json = serde_json::to_value(&data).expect("serializes");
+        assert_eq!(json["resultType"], "matrix");
+        let elem = &json["result"][0];
+        assert_eq!(elem["metric"]["__name__"], "req_latency");
+        // A histogram-only series carries no float `values` array.
+        assert!(
+            elem.get("values").is_none(),
+            "no values field on a histogram-only series"
+        );
+        let hists = &elem["histograms"];
+        assert!(hists.is_array(), "histograms is an array");
+        assert_eq!(hists.as_array().expect("array").len(), 2, "one per step");
+        // First step: timestamp, count/sum as strings, buckets exact.
+        assert_eq!(hists[0][0], 1_700_000_000, "first step timestamp");
+        assert_eq!(hists[0][1]["count"], "9");
+        assert_eq!(hists[0][1]["sum"], "4.5");
+        assert_eq!(
+            hists[0][1]["buckets"],
+            serde_json::json!([
+                [1, "-2", "-1", "3"],
+                [3, "-0.5", "0.5", "4"],
+                [0, "1", "2", "2"],
+            ])
+        );
+        // Second step carries its own timestamp and sum.
+        assert_eq!(hists[1][0], 1_700_000_060, "second step timestamp");
+        assert_eq!(hists[1][1]["sum"], "5.5");
+        assert_eq!(
+            hists[1][1]["buckets"],
+            serde_json::json!([
+                [1, "-2", "-1", "3"],
+                [3, "-0.5", "0.5", "4"],
+                [0, "1", "2", "2"],
+            ])
+        );
+    }
+
+    #[test]
     fn instant_vector_renders_float_element_under_value_field() {
         // A plain float vector element keeps the `value` field and carries no
         // `histogram` field, so the two element shapes stay disjoint.
@@ -876,17 +992,5 @@ mod tests {
             elem.get("histogram").is_none(),
             "no histogram field on a float element"
         );
-    }
-
-    #[test]
-    fn range_vector_is_rejected_as_wrong_type() {
-        // eval_range's contract never produces a bare instant vector, but
-        // this defensive arm must still reject it rather than panic.
-        let err = range_value_to_json(Value::Vector(vec![]), 0, 1_000, 1_000)
-            .expect_err("vector must be rejected at range type-check");
-        match err {
-            ApiError::BadData(msg) => assert!(msg.contains("instant vector")),
-            other => panic!("expected BadData, got a different ApiError: {other:?}"),
-        }
     }
 }

--- a/crates/ravel-query/src/http/mod.rs
+++ b/crates/ravel-query/src/http/mod.rs
@@ -161,3 +161,232 @@ pub fn router(state: AppState) -> Router {
         .with_state(state)
         .merge(compat)
 }
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::too_many_arguments)]
+mod tests {
+    //! Endpoint-level reachability proof for native-histogram range results:
+    //! a real RSEG v5 segment carrying histogram samples is published to a
+    //! `MemoryStore`, queried through the production axum router via
+    //! `tower::ServiceExt::oneshot`, and the rendered `histograms` field is
+    //! asserted in full. A unit test on the encoder alone cannot show that a
+    //! range request actually reaches it; this does.
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use axum::Router;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use ravel_catalog::{Catalog, CatalogConfig};
+    use ravel_commit::publish::RetryPolicy;
+    use ravel_commit::record::NewCommitRecord;
+    use ravel_commit::{keys, publish, record};
+    use ravel_object_store::ObjectStoreBackend;
+    use ravel_object_store::memory::MemoryStore;
+    use ravel_segment::{
+        HistogramCounts, HistogramSample, HistogramSpan, HistogramValue, IngestBounds, ResetHint,
+        SegmentIdentity, SegmentWriter, SeriesInputV3, SeriesValues, WrittenSegment,
+    };
+    use ravel_types::{Label, LabelSet, SeriesId, Signal, TenantId};
+    use serde_json::Value as JsonValue;
+    use tower::ServiceExt;
+    use uuid::Uuid;
+
+    use super::{AppState, StaticBearerTokenResolver, router};
+    use crate::{EngineConfig, QueryEngine};
+
+    const NS_PER_SEC: i64 = 1_000_000_000;
+    const NS_PER_MIN: i64 = 60 * NS_PER_SEC;
+    const NS_PER_HOUR: i64 = 60 * NS_PER_MIN;
+
+    fn now_ns() -> i64 {
+        let dur = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock after epoch");
+        let secs = i64::try_from(dur.as_secs()).expect("seconds fit i64");
+        secs * NS_PER_SEC
+    }
+
+    /// The native histogram both samples carry: total count 9 (zero_count 4,
+    /// one positive bucket count 2, one negative bucket count 3), sum 4.5. With
+    /// `scale = 0` the positive span at offset 1 is the bucket `(1, 2]`, the
+    /// negative span at offset 1 is `(-2, -1]`, and `zero_threshold = 0.5`
+    /// makes the zero bucket `(-0.5, 0.5]`. Matches the instant-path element in
+    /// `json::tests::instant_vector_renders_native_histogram_element`, so both
+    /// endpoints are proven to render the same shape.
+    fn histogram_value() -> HistogramValue {
+        HistogramValue {
+            scale: 0,
+            zero_threshold: 0.5,
+            sum: Some(4.5),
+            custom_values: None,
+            positive_spans: vec![HistogramSpan {
+                offset: 1,
+                length: 1,
+            }],
+            negative_spans: vec![HistogramSpan {
+                offset: 1,
+                length: 1,
+            }],
+            counts: HistogramCounts::Int {
+                zero_count: 4,
+                count: 9,
+                positive: vec![2],
+                negative: vec![3],
+            },
+            reset_hint: ResetHint::Unknown,
+        }
+    }
+
+    #[tokio::test]
+    async fn range_query_endpoint_serves_native_histogram_matrices() {
+        let store = Arc::new(MemoryStore::new());
+        let tenant_id = TenantId::new("tenant-hist".to_string());
+        let tenant_hash = tenant_id.hash();
+        // Floor to a whole minute so every grid instant is a whole-second
+        // (and whole-minute) value the step assertions can name exactly.
+        let now = (now_ns() / NS_PER_MIN) * NS_PER_MIN;
+        let hour_bucket = u32::try_from(now / NS_PER_HOUR).expect("hour bucket");
+
+        let metric = "req_latency";
+        let labels = LabelSet::new(vec![Label {
+            name: "__name__".to_string(),
+            value: metric.to_string(),
+        }])
+        .expect("valid labels");
+        let series_id = SeriesId::compute(&tenant_id, metric, &labels).expect("series id");
+        let series = vec![SeriesInputV3 {
+            series_id,
+            labels,
+            values: SeriesValues::Histogram(vec![
+                HistogramSample {
+                    ts_ns: now - 4 * NS_PER_MIN,
+                    value: histogram_value(),
+                },
+                HistogramSample {
+                    ts_ns: now - 2 * NS_PER_MIN,
+                    value: histogram_value(),
+                },
+            ]),
+        }];
+
+        let writer_id = Uuid::new_v4();
+        let identity = SegmentIdentity {
+            tenant_hash: tenant_hash.0,
+            shard: 0,
+            writer_id: writer_id.to_string(),
+            writer_epoch: 1,
+            writer_seq: 1,
+        };
+        let bounds = IngestBounds {
+            min_ingest_ts_ns: 0,
+            max_ingest_ts_ns: 0,
+        };
+        let written: WrittenSegment =
+            SegmentWriter::write_histograms(series, identity, bounds).expect("write segment");
+
+        let new_record = NewCommitRecord {
+            tenant_hash,
+            signal: Signal::Metrics,
+            shard: 0,
+            writer_id,
+            writer_epoch: 1,
+            writer_seq: 1,
+            object_size: written.bytes.len() as u64,
+            content_hash: written.summary.blake3,
+            sample_count: written.summary.sample_count,
+            series_count: written.summary.series_count,
+            min_event_ts_ns: written.summary.min_event_ts_ns,
+            max_event_ts_ns: written.summary.max_event_ts_ns,
+            min_ingest_ts_ns: written.summary.min_event_ts_ns,
+            max_ingest_ts_ns: written.summary.max_event_ts_ns,
+            segment_format_version: 1,
+            created_unix_ns: now,
+            ingest_hour_bucket: hour_bucket,
+        };
+        let rec = record::build(new_record).expect("valid commit record");
+        let data_key = keys::reconstruct_data_key(&rec).expect("data key");
+        let backend: Arc<dyn ObjectStoreBackend> = store.clone();
+        publish::put_data_object(backend.as_ref(), &data_key, written.bytes)
+            .await
+            .expect("put data object");
+        publish::publish(backend.as_ref(), &rec, &RetryPolicy::default())
+            .await
+            .expect("publish");
+
+        let mut tokens = HashMap::new();
+        tokens.insert("secret-hist".to_string(), tenant_id.clone());
+        let catalog =
+            Arc::new(Catalog::new(backend.clone(), CatalogConfig::default()).expect("catalog"));
+        let engine = Arc::new(QueryEngine::new(catalog, backend, EngineConfig::default()));
+        let state = AppState::new(engine, Arc::new(StaticBearerTokenResolver::new(tokens)));
+        let app: Router = router(state);
+
+        let start = (now - 4 * NS_PER_MIN) / NS_PER_SEC;
+        let end = (now - NS_PER_MIN) / NS_PER_SEC;
+        let uri = format!("/api/v1/query_range?query={metric}&start={start}&end={end}&step=60s");
+        let request = Request::builder()
+            .method("GET")
+            .uri(&uri)
+            .header("authorization", "Bearer secret-hist")
+            .body(Body::empty())
+            .expect("build request");
+        let response = match app.oneshot(request).await {
+            Ok(response) => response,
+            Err(never) => match never {},
+        };
+        let status = response.status();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let json: JsonValue = serde_json::from_slice(&body).expect("parse json");
+
+        assert_eq!(status, StatusCode::OK, "body: {json}");
+        assert_eq!(json["status"], "success", "body: {json}");
+        assert_eq!(json["data"]["resultType"], "matrix");
+        let results = json["data"]["result"]
+            .as_array()
+            .expect("matrix result array");
+        assert_eq!(results.len(), 1, "one series, body: {json}");
+        let elem = &results[0];
+        assert_eq!(elem["metric"]["__name__"], "req_latency");
+        // The float `values` array is absent on a histogram-only series.
+        assert!(
+            elem.get("values").is_none(),
+            "no values field on a histogram-only series, body: {json}"
+        );
+        let hists = elem["histograms"]
+            .as_array()
+            .expect("histograms array present");
+        // The two source samples (at -4min and -2min) carry across the whole
+        // [-4min, -1min] grid by lookback, so every one of the four 60s steps
+        // renders a histogram element.
+        let expected_ts: Vec<i64> = (1..=4)
+            .rev()
+            .map(|k| (now - k * NS_PER_MIN) / NS_PER_SEC)
+            .collect();
+        assert_eq!(hists.len(), 4, "one histogram per grid step, body: {json}");
+        // Every rendered step carries the exact shape the source samples encode:
+        // its own grid timestamp, count/sum as strings, and the three buckets
+        // in cumulative order.
+        for (step, want_ts) in hists.iter().zip(expected_ts) {
+            assert_eq!(
+                step[0].as_i64().expect("integer step timestamp"),
+                want_ts,
+                "step timestamp, body: {json}"
+            );
+            assert_eq!(step[1]["count"], "9");
+            assert_eq!(step[1]["sum"], "4.5");
+            assert_eq!(
+                step[1]["buckets"],
+                serde_json::json!([
+                    [1, "-2", "-1", "3"],
+                    [3, "-0.5", "0.5", "4"],
+                    [0, "1", "2", "2"],
+                ]),
+                "bucket contents, body: {json}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Range results carried only float steps, so a range query over native
histograms returned an empty or zero-filled matrix with HTTP 200 even after
#577 taught the evaluator to carry histogram elements. The evaluator had the
data and the renderer threw it away.

`MatrixResult` gains a `histograms` field beside `values`, both omitted when
empty the way Prometheus omits them. Range rendering splits each series' steps
by element type: floats under `values`, histograms under `histograms`, shaped
`[ts, {count, sum, buckets}]`. The encoder is the instant path's existing
`histogram_to_json`, reused rather than reimplemented, which is what makes the
output the same bytes Prometheus 3.x emits, so Grafana and the difftest client
parse it unmodified.

The HTTP handler now evaluates through the histogram-aware range value. The
float-only entry point stays as a thin projection, so no other caller changed.
Error mapping is untouched.

Verified end to end, not just at the encoder: a range request drives the
production axum router against a real RSEG histogram segment and asserts the
rendered `histograms` field, including exact bucket contents.

One shape is knowingly still float-only and is filed as #643: an instant query
whose top-level expression is a range vector renders through the instant
matrix arm.

Fixes: #579
Refs: #573
