### PR TITLE
docs: document that the SQL samples table excludes histogram samples

### DIFF
--- a/crates/ravel-sql/src/conformance.rs
+++ b/crates/ravel-sql/src/conformance.rs
@@ -892,6 +892,20 @@ three-state scheme below is the resolution: enumerate the claimed surface, score
 over the part with a deliberate verified position, and keep any unresolved
 construct visible as an actionable miss.
 
+## The `samples` table
+
+The `samples` table exposes exactly four columns -- `ts`, `value`, `series_id`,
+and `labels` -- where `value` is a single `Float64`
+(`crates/ravel-sql/src/schema.rs`, `public_fields`). It has no column that can
+represent a native histogram. Native-histogram samples are excluded from the
+`samples` table entirely: a histogram sample carries no scalar float `value`,
+so it is never materialized as a row and no query can observe it. `SELECT
+count(*) FROM samples`, and every other count or aggregation over the table,
+therefore undercount on tenants that ingest histograms -- the histogram samples
+are silently absent, not present with a zero or null `value` (#581). This is a
+property of the table shape, not of any construct in the conformance table
+below, so it holds for every row that reads `samples`.
+
 ## The three states
 
 1. **Supported and covered** -- implemented, with a passing test proving it.

--- a/crates/ravel-sql/tests/conformance.rs
+++ b/crates/ravel-sql/tests/conformance.rs
@@ -781,6 +781,38 @@ async fn generate_and_check_conformance_doc() {
     );
 }
 
+/// The generated document states, in prose, that the `samples` table silently
+/// excludes native-histogram samples, so counts and aggregations over it
+/// undercount on tenants that ingest histograms (#581). The defect this guards
+/// is that `SELECT count(*) FROM samples` reports fewer rows than were ingested
+/// with no documentation saying why: the table's float-only shape
+/// (`schema.rs::public_fields`) has no column for a histogram sample.
+///
+/// The assertion reads the rendered output of `render_document`, not the
+/// committed file, so it fails the moment the generator stops emitting the
+/// statement rather than only when the committed doc drifts.
+#[tokio::test]
+async fn samples_table_documents_histogram_exclusion() {
+    let verified = verify_all().await;
+    let rendered = render_document(&verified);
+
+    // Collapse whitespace so the check is independent of where the generator's
+    // prose wraps: a rewrap that moves a line break mid-sentence must not break
+    // this assertion (only dropping the statement should).
+    let flat = rendered.split_whitespace().collect::<Vec<_>>().join(" ");
+
+    assert!(
+        flat.contains("Native-histogram samples are excluded from the `samples` table entirely"),
+        "the generated conformance doc must state that native-histogram samples are excluded \
+         from the samples table entirely (#581)"
+    );
+    assert!(
+        flat.contains("undercount on tenants that ingest histograms"),
+        "the generated conformance doc must state that counts and aggregations over the samples \
+         table undercount on tenants that ingest histograms (#581)"
+    );
+}
+
 /// The live example SQL each construct runs, checked against a committed
 /// manifest that the prose document's `REGEN_SQL_CONFORMANCE=1` does NOT touch.
 ///

--- a/docs/sql-conformance.md
+++ b/docs/sql-conformance.md
@@ -29,6 +29,20 @@ three-state scheme below is the resolution: enumerate the claimed surface, score
 over the part with a deliberate verified position, and keep any unresolved
 construct visible as an actionable miss.
 
+## The `samples` table
+
+The `samples` table exposes exactly four columns -- `ts`, `value`, `series_id`,
+and `labels` -- where `value` is a single `Float64`
+(`crates/ravel-sql/src/schema.rs`, `public_fields`). It has no column that can
+represent a native histogram. Native-histogram samples are excluded from the
+`samples` table entirely: a histogram sample carries no scalar float `value`,
+so it is never materialized as a row and no query can observe it. `SELECT
+count(*) FROM samples`, and every other count or aggregation over the table,
+therefore undercount on tenants that ingest histograms -- the histogram samples
+are silently absent, not present with a zero or null `value` (#581). This is a
+property of the table shape, not of any construct in the conformance table
+below, so it holds for every row that reads `samples`.
+
 ## The three states
 
 1. **Supported and covered** -- implemented, with a passing test proving it.


### PR DESCRIPTION
The SQL `samples` table exposes float samples only; native-histogram samples
are absent from it entirely. Nothing said so, which makes an empty result for
a histogram series look like missing data rather than a documented exclusion.

States the exclusion in the generated SQL conformance documentation, so it is
derived from the conformance definitions rather than hand-written prose that
drifts away from them.

Part of ADR-0108 (docs/adrs/0108-range-eval-over-native-histograms.md).

Fixes: #581
Refs: #573
