### PR TITLE
feat(promql): native histograms through range counter and over_time functions

### DIFF
--- a/crates/ravel-promql/src/aggregate.rs
+++ b/crates/ravel-promql/src/aggregate.rs
@@ -84,7 +84,8 @@ use promql_parser::parser::{AggregateExpr, LabelModifier};
 use ravel_types::{Label, LabelSet, METRIC_NAME_LABEL};
 
 use crate::eval::{
-    Error, Evaluator, InstantSample, InstantVector, QueryWindow, Value, invalid_quantile_warning,
+    Error, Evaluator, InstantSample, InstantVector, QueryWindow, Value,
+    histogram_ignored_in_aggregation_info, invalid_quantile_warning,
 };
 use crate::functions::label::is_valid_label_name;
 use crate::functions::over_time::{kahan_sum_inc, quantile};
@@ -122,6 +123,7 @@ pub(crate) fn eval_aggregate(
                 agg.modifier.as_ref(),
                 input,
                 eval_ts_ns,
+                ctx,
             )))
         }
         T_QUANTILE => {
@@ -140,6 +142,7 @@ pub(crate) fn eval_aggregate(
                 agg.modifier.as_ref(),
                 input,
                 eval_ts_ns,
+                ctx,
             )))
         }
         T_LIMITK | T_LIMIT_RATIO => {
@@ -239,12 +242,13 @@ fn eval_plain_aggregate(
     modifier: Option<&LabelModifier>,
     input: InstantVector,
     eval_ts_ns: i64,
+    ctx: &QueryWindow,
 ) -> InstantVector {
     // Group full samples (not just their float values) so `sum`/`avg` can see
     // native-histogram members.
     group_by(modifier, input, |s| s)
         .into_iter()
-        .filter_map(|(labels, members)| reduce_group_samples(op, labels, members, eval_ts_ns))
+        .filter_map(|(labels, members)| reduce_group_samples(op, labels, members, eval_ts_ns, ctx))
         .collect()
 }
 
@@ -260,6 +264,7 @@ fn reduce_group_samples(
     labels: LabelSet,
     members: Vec<InstantSample>,
     eval_ts_ns: i64,
+    ctx: &QueryWindow,
 ) -> Option<InstantSample> {
     match op {
         T_SUM | T_AVG => {
@@ -297,6 +302,13 @@ fn reduce_group_samples(
         )),
         T_GROUP => Some(InstantSample::scalar(labels, eval_ts_ns, eval_ts_ns, 1.0)),
         T_MIN | T_MAX | T_STDDEV | T_STDVAR => {
+            // Float-only in Prometheus (ADR-0108 decisions 2/6a): a histogram
+            // member is dropped and the drop is annotated
+            // (`HistogramIgnoredInAggregationInfo`), rather than silently
+            // ignored. A group of only histograms is omitted entirely.
+            if members.iter().any(|s| s.histogram.is_some()) {
+                ctx.info(histogram_ignored_in_aggregation_info(aggregation_name(op)));
+            }
             let values: Vec<f64> = members
                 .iter()
                 .filter(|s| s.histogram.is_none())
@@ -313,6 +325,18 @@ fn reduce_group_samples(
             ))
         }
         _ => unreachable!("reduce_group_samples called with non-plain aggregator {op}"),
+    }
+}
+
+/// The operator name Prometheus names in a `HistogramIgnoredInAggregationInfo`
+/// annotation, for the float-only aggregators that drop histogram members.
+fn aggregation_name(op: TokenId) -> &'static str {
+    match op {
+        T_MIN => "min",
+        T_MAX => "max",
+        T_STDDEV => "stddev",
+        T_STDVAR => "stdvar",
+        _ => unreachable!("aggregation_name called with a non-dropping aggregator {op}"),
     }
 }
 
@@ -421,8 +445,14 @@ fn eval_quantile(
     }
     // `quantile` has no defined native-histogram semantics in Prometheus
     // (ADR-0108 decision 2): histogram elements are dropped, never treated as
-    // their meaningless `0.0` placeholder float. Filtering here keeps any float
-    // members of the same group and omits a group that held only histograms.
+    // their meaningless `0.0` placeholder float. Prometheus annotates the drop
+    // (`HistogramIgnoredInAggregationInfo`), the difftest comparator checks for
+    // it, and the ADR pins drop-and-annotate (decision 6a). Filtering here
+    // keeps any float members of the same group and omits a group that held
+    // only histograms.
+    if input.iter().any(|s| s.histogram.is_some()) {
+        ctx.info(histogram_ignored_in_aggregation_info("quantile"));
+    }
     let input: InstantVector = input
         .into_iter()
         .filter(|s| s.histogram.is_none())
@@ -540,6 +570,7 @@ fn eval_topk_bottomk(
     modifier: Option<&LabelModifier>,
     input: InstantVector,
     eval_ts_ns: i64,
+    ctx: &QueryWindow,
 ) -> InstantVector {
     if k_raw.is_nan() || k_raw < 1.0 {
         return Vec::new();
@@ -548,8 +579,17 @@ fn eval_topk_bottomk(
 
     // `topk`/`bottomk` have no defined native-histogram semantics in Prometheus
     // (ADR-0108 decision 2): a histogram element is dropped rather than ranked
-    // by its meaningless `0.0` placeholder float. Float members of the same
-    // group are kept and ranked as usual.
+    // by its meaningless `0.0` placeholder float. Prometheus annotates the drop
+    // (`HistogramIgnoredInAggregationInfo`) and the ADR pins drop-and-annotate
+    // (decision 6a). Float members of the same group are kept and ranked as
+    // usual.
+    if input.iter().any(|s| s.histogram.is_some()) {
+        ctx.info(histogram_ignored_in_aggregation_info(if is_top {
+            "topk"
+        } else {
+            "bottomk"
+        }));
+    }
     let input: InstantVector = input
         .into_iter()
         .filter(|s| s.histogram.is_none())

--- a/crates/ravel-promql/src/eval.rs
+++ b/crates/ravel-promql/src/eval.rs
@@ -53,6 +53,7 @@ use std::time::Instant;
 
 use ravel_types::{Label, LabelSet, METRIC_NAME_LABEL, Sample, TimeRange};
 
+use crate::histogram::TimedHistogram;
 use crate::matchers;
 use crate::source::{LabelMatcher, MatchOp, SeriesSource, SourceError};
 
@@ -388,6 +389,17 @@ pub(crate) fn possible_non_counter_info(metric_name: &str) -> String {
         "metric might not be a counter, name does not end in _total/_sum/_count/_bucket: \
          {metric_name:?}"
     )
+}
+
+/// Prometheus' `HistogramIgnoredInAggregationInfo` message: an aggregation
+/// with no defined native-histogram semantics
+/// (`min`/`max`/`stddev`/`stdvar`/`quantile`/`topk`/`bottomk`) encountered
+/// histogram members and dropped them (ADR-0108 decisions 2/6a). An info, not
+/// a warning, matching the pinned binary, which wraps `PromQLInfo`: any float
+/// members of the group still aggregate; only the histogram members are
+/// ignored. `aggregation` is the operator name (`"min"`, `"topk"`, ...).
+pub(crate) fn histogram_ignored_in_aggregation_info(aggregation: &str) -> String {
+    format!("ignored histogram in {aggregation} aggregation")
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -843,11 +855,11 @@ impl Evaluator {
                     self, source, call, start_ns, end_ns, step_ns, points, &ctx,
                 )?;
                 let matrix = if negate {
-                    negate_matrix(matrix)
+                    negate_hist_matrix(matrix)
                 } else {
                     matrix
                 };
-                RangeValue::Matrix(float_matrix_into_hist(matrix))
+                RangeValue::Matrix(matrix)
             }
             RangeCore::Generic(e) => {
                 let matrix =
@@ -1123,6 +1135,7 @@ impl Evaluator {
         ms: &promql_parser::parser::MatrixSelector,
         eval_ts_ns: i64,
         ctx: &QueryWindow,
+        keep_metric_name: bool,
     ) -> Result<HistogramMatrix, Error> {
         let selector_matchers = build_matchers(&ms.vs)?;
         let sel_ts_ns = selector_eval_ts(&ms.vs, eval_ts_ns, ctx)?;
@@ -1143,7 +1156,12 @@ impl Evaluator {
                 .map(|sample| (sample.ts_ns, sample.value))
                 .collect();
             if !samples.is_empty() {
-                out.push((drop_metric_name(s.labels), samples));
+                let labels = if keep_metric_name {
+                    s.labels
+                } else {
+                    drop_metric_name(s.labels)
+                };
+                out.push((labels, samples));
             }
         }
         Ok(out)
@@ -1284,8 +1302,8 @@ impl Evaluator {
         points: u64,
         ctx: &QueryWindow,
         keep_metric_name: bool,
-        reduce: impl Fn(&[Sample], i64, i64, i64, i64) -> Option<f64>,
-    ) -> Result<RangeMatrix, Error> {
+        reduce: impl Fn(&[Sample], &[TimedHistogram], i64, i64, i64, i64) -> Option<RangeSample>,
+    ) -> Result<HistogramAwareMatrix, Error> {
         let selector_matchers = build_matchers(&ms.vs)?;
         let offset_ns = signed_offset_ns(ms.vs.offset.as_ref())?;
         let at_ts_ns = resolve_at(ms.vs.at.as_ref(), ctx.start_ns, ctx.end_ns)?;
@@ -1345,17 +1363,63 @@ impl Evaluator {
                 if window_samples.is_empty() {
                     continue;
                 }
-                if let Some(value) = reduce(
+                if let Some(element) = reduce(
+                    window_samples,
+                    &[],
+                    *window_start,
+                    *sel_ts,
+                    range_ns,
+                    *reported_ts,
+                ) {
+                    out_samples.push(element);
+                }
+            }
+            if !out_samples.is_empty() {
+                let labels = if keep_metric_name {
+                    s.labels
+                } else {
+                    drop_metric_name(s.labels)
+                };
+                out.push((labels, out_samples));
+            }
+        }
+
+        // Native-histogram series matching the same selector, fetched once over
+        // the same combined window (ADR-0108 decisions 3/4/5: the histogram
+        // read channel rides alongside the float one, never per grid step). A
+        // series is either float or histogram in storage, so a histogram
+        // series never collides with a float series above; its window slice is
+        // reduced through the same closure with an empty float slice, letting
+        // each range-vector function pick its own histogram behavior (a
+        // histogram reduction, a float such as `count_over_time`, or a drop).
+        let hist_series = source.query_histograms(&selector_matchers, window)?;
+        for s in hist_series {
+            let live: Vec<TimedHistogram> =
+                s.samples.into_iter().map(|h| (h.ts_ns, h.value)).collect();
+
+            let mut lo = 0usize;
+            let mut hi = 0usize;
+            let mut out_samples = Vec::new();
+            for (reported_ts, sel_ts, window_start) in &grid {
+                while lo < live.len() && live[lo].0 <= *window_start {
+                    lo += 1;
+                }
+                while hi < live.len() && live[hi].0 <= *sel_ts {
+                    hi += 1;
+                }
+                let window_samples = &live[lo..hi];
+                if window_samples.is_empty() {
+                    continue;
+                }
+                if let Some(element) = reduce(
+                    &[],
                     window_samples,
                     *window_start,
                     *sel_ts,
                     range_ns,
                     *reported_ts,
                 ) {
-                    out_samples.push(Sample {
-                        ts_ns: *reported_ts,
-                        value,
-                    });
+                    out_samples.push(element);
                 }
             }
             if !out_samples.is_empty() {
@@ -1550,19 +1614,23 @@ fn negate_vector(v: InstantVector) -> InstantVector {
         .collect()
 }
 
-/// Negate every sample's value in a range matrix. Unlike [`negate_vector`],
-/// `__name__` is not dropped here: a function call's result labels already
-/// had it dropped unconditionally by
-/// [`Evaluator::eval_range_matrix_reduction`], before negation is even
-/// considered.
-fn negate_matrix(m: RangeMatrix) -> RangeMatrix {
+/// Negate every element of a [`HistogramAwareMatrix`], multiplying a
+/// native-histogram element's populations by -1 (exactly as [`negate_vector`]
+/// does per instant sample) and negating a float element's value. Unlike
+/// [`negate_vector`], `__name__` is left untouched: a function call's result
+/// labels already had it dropped unconditionally by
+/// [`Evaluator::eval_range_matrix_reduction`], before negation is considered.
+fn negate_hist_matrix(m: HistogramAwareMatrix) -> HistogramAwareMatrix {
     m.into_iter()
         .map(|(labels, samples)| {
             let negated = samples
                 .into_iter()
-                .map(|s| Sample {
-                    ts_ns: s.ts_ns,
-                    value: -s.value,
+                .map(|s| match s.histogram {
+                    Some(mut h) => {
+                        h.mul(-1.0);
+                        RangeSample::histogram(s.ts_ns, h)
+                    }
+                    None => RangeSample::scalar(s.ts_ns, -s.value),
                 })
                 .collect();
             (labels, negated)

--- a/crates/ravel-promql/src/functions/mod.rs
+++ b/crates/ravel-promql/src/functions/mod.rs
@@ -23,8 +23,9 @@ use ravel_types::{LabelSet, Sample};
 
 use crate::eval::{
     Error, Evaluator, HistogramAwareMatrix, InstantSample, InstantVector, QueryWindow, RangeMatrix,
-    RangeSample, Value, drop_metric_name, duration_to_ns, hist_matrix_into_float,
-    invalid_quantile_warning, possible_non_counter_info, resolve_eval_ts, selector_eval_ts,
+    RangeSample, Value, drop_metric_name, duration_to_ns, float_matrix_into_hist,
+    hist_matrix_into_float, invalid_quantile_warning, possible_non_counter_info, resolve_eval_ts,
+    selector_eval_ts,
 };
 use crate::histogram::{FloatHistogram, TimedHistogram};
 use crate::source::SeriesSource;
@@ -216,24 +217,43 @@ pub(crate) fn eval_call(
                 }
             }
             let matrix = eval_matrix_arg(evaluator, source, arg, eval_ts_ns, ctx)?;
-            Ok(Value::Vector(apply_reduce(
-                matrix,
+            let mut out = apply_reduce(matrix, eval_ts_ns, keep_name, |samples| f(samples, window));
+            // Histogram-only series matching the same selector: reduced by the
+            // shared over_time histogram policy so the instant endpoint answers
+            // the same class as the range endpoint (ADR-0108 decision 5, the
+            // instant/range parity fix). Float-only members drop here exactly
+            // as the oracle does.
+            append_histogram_over_time(
+                evaluator,
+                source,
+                arg,
+                call.func.name,
                 eval_ts_ns,
                 keep_name,
-                |samples| f(samples, window),
-            )))
+                ctx,
+                &mut out,
+            )?;
+            Ok(Value::Vector(out))
         }
         FunctionKind::RangeVectorScalar(f) => {
             let arg = matrix_arg(&call.args.args[0])?;
             let t = scalar_arg(evaluator, source, &call.args.args[1], eval_ts_ns, ctx)?;
             let window = range_window(arg, eval_ts_ns, ctx)?;
             let matrix = eval_matrix_arg(evaluator, source, arg, eval_ts_ns, ctx)?;
-            Ok(Value::Vector(apply_reduce(
-                matrix,
+            let mut out = apply_reduce(matrix, eval_ts_ns, false, |samples| f(samples, window, t));
+            // `predict_linear`: float-only, so any histogram-only series is
+            // dropped by the shared policy (no annotation), matching the oracle.
+            append_histogram_over_time(
+                evaluator,
+                source,
+                arg,
+                call.func.name,
                 eval_ts_ns,
                 false,
-                |samples| f(samples, window, t),
-            )))
+                ctx,
+                &mut out,
+            )?;
+            Ok(Value::Vector(out))
         }
         FunctionKind::RangeVectorFloatOrHist { float, hist } => {
             let arg = matrix_arg(&call.args.args[0])?;
@@ -255,7 +275,7 @@ pub(crate) fn eval_call(
             // the histogram series here.
             if let MatrixArg::Selector(ms) = arg {
                 let hmatrix =
-                    evaluator.eval_histogram_matrix_selector(source, ms, eval_ts_ns, ctx)?;
+                    evaluator.eval_histogram_matrix_selector(source, ms, eval_ts_ns, ctx, false)?;
                 for (labels, samples) in hmatrix {
                     if let Some(h) = hist(&samples, window) {
                         out.push(InstantSample::histogram(labels, eval_ts_ns, eval_ts_ns, h));
@@ -292,24 +312,31 @@ pub(crate) fn eval_call(
             // sits inside the reduce closure so it fires once per matched series
             // (deduped by the annotation sink) and, like Prometheus, not at all
             // when no series matched.
-            Ok(Value::Vector(apply_reduce(
-                matrix,
+            let mut out = apply_reduce(matrix, eval_ts_ns, false, |samples| {
+                maybe_warn_invalid_quantile(q, ctx);
+                f(q, samples, window)
+            });
+            // `quantile_over_time`: float-only, so a histogram-only series is
+            // dropped by the shared policy with no annotation (its out-of-range
+            // `q` warning likewise fires only for float windows), matching the
+            // oracle's `len(Floats) == 0` early return.
+            append_histogram_over_time(
+                evaluator,
+                source,
+                arg,
+                call.func.name,
                 eval_ts_ns,
                 false,
-                |samples| {
-                    maybe_warn_invalid_quantile(q, ctx);
-                    f(q, samples, window)
-                },
-            )))
+                ctx,
+                &mut out,
+            )?;
+            Ok(Value::Vector(out))
         }
         FunctionKind::AbsentOverTime => {
             let arg = matrix_arg(&call.args.args[0])?;
-            let matrix = eval_matrix_arg(evaluator, source, arg, eval_ts_ns, ctx)?;
             Ok(Value::Vector(over_time::absent_over_time_instant(
-                over_time::matrix_arg_absent_labels(arg),
-                matrix,
-                eval_ts_ns,
-            )))
+                evaluator, source, arg, eval_ts_ns, ctx,
+            )?))
         }
         FunctionKind::VectorMap(f) => {
             let v = vector_arg(evaluator, source, &call.args.args[0], eval_ts_ns, ctx)?;
@@ -334,12 +361,13 @@ pub(crate) fn eval_range_call(
     step_ns: i64,
     points: u64,
     ctx: &QueryWindow,
-) -> Result<RangeMatrix, Error> {
+) -> Result<HistogramAwareMatrix, Error> {
     let def = lookup(call.func.name).ok_or_else(|| unregistered_function_error(call.func.name))?;
     match def.kind {
         FunctionKind::RangeVector(f) => {
             let arg = matrix_arg(&call.args.args[0])?;
             let keep_name = range_vector_keeps_metric_name(call.func.name);
+            let name = call.func.name;
             eval_matrix_arg_range_reduction(
                 evaluator,
                 source,
@@ -350,7 +378,16 @@ pub(crate) fn eval_range_call(
                 points,
                 ctx,
                 keep_name,
-                |samples, window_start_ns, sel_ts_ns, range_ns, reported_ts_ns| {
+                |samples, hists, window_start_ns, sel_ts_ns, range_ns, reported_ts_ns| {
+                    if !hists.is_empty() {
+                        // A histogram-only window: the float reducer `f` has no
+                        // histogram form, so route by member name to the shared
+                        // over_time histogram policy (ADR-0108 decision 5).
+                        return histogram_range_element(
+                            over_time::histogram_over_time(name, hists),
+                            reported_ts_ns,
+                        );
+                    }
                     f(
                         samples,
                         RangeWindow {
@@ -360,6 +397,7 @@ pub(crate) fn eval_range_call(
                             eval_ts_ns: reported_ts_ns,
                         },
                     )
+                    .map(|v| RangeSample::scalar(reported_ts_ns, v))
                 },
             )
         }
@@ -384,26 +422,29 @@ pub(crate) fn eval_range_call(
                 points,
                 ctx,
                 false,
-                |samples, window_start_ns, sel_ts_ns, range_ns, reported_ts_ns| match scalar_arg(
-                    evaluator,
-                    source,
-                    scalar_expr,
-                    reported_ts_ns,
-                    ctx,
-                ) {
-                    Ok(t) => f(
-                        samples,
-                        RangeWindow {
-                            start_ns: window_start_ns,
-                            end_ns: sel_ts_ns,
-                            range_ns,
-                            eval_ts_ns: reported_ts_ns,
-                        },
-                        t,
-                    ),
-                    Err(e) => {
-                        *err.borrow_mut() = Some(e);
-                        None
+                |samples, hists, window_start_ns, sel_ts_ns, range_ns, reported_ts_ns| {
+                    // `predict_linear` is float-only in Prometheus: a
+                    // histogram-only window takes its `len(Floats) == 0`
+                    // early return, dropping with no annotation.
+                    if !hists.is_empty() {
+                        return None;
+                    }
+                    match scalar_arg(evaluator, source, scalar_expr, reported_ts_ns, ctx) {
+                        Ok(t) => f(
+                            samples,
+                            RangeWindow {
+                                start_ns: window_start_ns,
+                                end_ns: sel_ts_ns,
+                                range_ns,
+                                eval_ts_ns: reported_ts_ns,
+                            },
+                            t,
+                        )
+                        .map(|v| RangeSample::scalar(reported_ts_ns, v)),
+                        Err(e) => {
+                            *err.borrow_mut() = Some(e);
+                            None
+                        }
                     }
                 },
             )?;
@@ -412,11 +453,11 @@ pub(crate) fn eval_range_call(
             }
             Ok(matrix)
         }
-        FunctionKind::RangeVectorFloatOrHist { float, hist: _ } => {
-            // Range queries reduce only the float series: a histogram-valued
-            // range result cannot be rendered by the HTTP JSON layer and no
-            // read path feeds native histograms into a range query yet.
-            // The float reduction is identical to `RangeVector`.
+        FunctionKind::RangeVectorFloatOrHist { float, hist } => {
+            // `rate`/`increase`/`delta`: the float reducer serves float series
+            // and the native-histogram reducer serves histogram series, exactly
+            // mirroring the instant arm's dispatch. A histogram window reduces
+            // to one histogram element (ADR-0108 decision 4).
             let arg = matrix_arg(&call.args.args[0])?;
             let result = eval_matrix_arg_range_reduction(
                 evaluator,
@@ -428,18 +469,22 @@ pub(crate) fn eval_range_call(
                 points,
                 ctx,
                 false,
-                |samples, window_start_ns, sel_ts_ns, range_ns, reported_ts_ns| {
-                    float(
-                        samples,
-                        RangeWindow {
-                            start_ns: window_start_ns,
-                            end_ns: sel_ts_ns,
-                            range_ns,
-                            eval_ts_ns: reported_ts_ns,
-                        },
-                    )
+                |samples, hists, window_start_ns, sel_ts_ns, range_ns, reported_ts_ns| {
+                    let window = RangeWindow {
+                        start_ns: window_start_ns,
+                        end_ns: sel_ts_ns,
+                        range_ns,
+                        eval_ts_ns: reported_ts_ns,
+                    };
+                    if !hists.is_empty() {
+                        hist(hists, window).map(|h| RangeSample::histogram(reported_ts_ns, h))
+                    } else {
+                        float(samples, window).map(|v| RangeSample::scalar(reported_ts_ns, v))
+                    }
                 },
             )?;
+            // Gated on the reduced output, matching the instant arm and
+            // Prometheus (the check follows the too-few-samples early return).
             maybe_info_non_counter_selector_name(call.func.name, arg, !result.is_empty(), ctx);
             Ok(result)
         }
@@ -456,15 +501,14 @@ pub(crate) fn eval_range_call(
         // an arithmetic identity.
         FunctionKind::HistogramQuantile(f) => {
             // Quantile/fraction results are float-valued, so the grid produces
-            // only float elements; project down to the float matrix this range
-            // call returns.
+            // only float elements; the histogram-aware matrix carries them
+            // unchanged.
             eval_instant_over_grid(start_ns, end_ns, step_ns, |t| {
                 ctx.check_deadline()?;
                 let phi = scalar_arg(evaluator, source, &call.args.args[0], t, ctx)?;
                 let vector = vector_arg(evaluator, source, &call.args.args[1], t, ctx)?;
                 Ok(Value::Vector(to_instant_vector(f(phi, vector, ctx), t)))
             })
-            .map(hist_matrix_into_float)
         }
         FunctionKind::HistogramFraction(f) => {
             eval_instant_over_grid(start_ns, end_ns, step_ns, |t| {
@@ -477,7 +521,6 @@ pub(crate) fn eval_range_call(
                     t,
                 )))
             })
-            .map(hist_matrix_into_float)
         }
         FunctionKind::ScalarRangeVector(f) => {
             let scalar_expr = &call.args.args[0];
@@ -499,29 +542,34 @@ pub(crate) fn eval_range_call(
                 points,
                 ctx,
                 false,
-                |samples, window_start_ns, sel_ts_ns, range_ns, reported_ts_ns| match scalar_arg(
-                    evaluator,
-                    source,
-                    scalar_expr,
-                    reported_ts_ns,
-                    ctx,
-                ) {
-                    Ok(q) => {
-                        maybe_warn_invalid_quantile(q, ctx);
-                        f(
-                            q,
-                            samples,
-                            RangeWindow {
-                                start_ns: window_start_ns,
-                                end_ns: sel_ts_ns,
-                                range_ns,
-                                eval_ts_ns: reported_ts_ns,
-                            },
-                        )
+                |samples, hists, window_start_ns, sel_ts_ns, range_ns, reported_ts_ns| {
+                    // `quantile_over_time` is float-only in Prometheus: a
+                    // histogram-only window takes its `len(Floats) == 0` early
+                    // return, dropping the series with no annotation. The
+                    // out-of-range-`q` warning fires there only after a float
+                    // element exists, so it is likewise skipped here.
+                    if !hists.is_empty() {
+                        return None;
                     }
-                    Err(e) => {
-                        *err.borrow_mut() = Some(e);
-                        None
+                    match scalar_arg(evaluator, source, scalar_expr, reported_ts_ns, ctx) {
+                        Ok(q) => {
+                            maybe_warn_invalid_quantile(q, ctx);
+                            f(
+                                q,
+                                samples,
+                                RangeWindow {
+                                    start_ns: window_start_ns,
+                                    end_ns: sel_ts_ns,
+                                    range_ns,
+                                    eval_ts_ns: reported_ts_ns,
+                                },
+                            )
+                            .map(|v| RangeSample::scalar(reported_ts_ns, v))
+                        }
+                        Err(e) => {
+                            *err.borrow_mut() = Some(e);
+                            None
+                        }
                     }
                 },
             )?;
@@ -535,6 +583,7 @@ pub(crate) fn eval_range_call(
             over_time::absent_over_time_range(
                 evaluator, source, arg, start_ns, end_ns, step_ns, ctx,
             )
+            .map(float_matrix_into_hist)
         }
         // A top-level `VectorMap`/`Instant` function call is a float-only range
         // result today: any histogram element the per-step evaluation carries
@@ -542,19 +591,72 @@ pub(crate) fn eval_range_call(
         // path that preserves histograms is `RangeCore::Generic`, top-level
         // aggregates and binary expressions, handled in `eval.rs`). Histogram
         // semantics for these function families are ADR-0108 decisions 4/5,
-        // out of this task's scope.
+        // out of this task's scope; the round-trip through
+        // `hist_matrix_into_float` drops the histogram elements explicitly
+        // rather than emitting them as `0.0` floats.
         FunctionKind::VectorMap(f) => eval_instant_over_grid(start_ns, end_ns, step_ns, |t| {
             ctx.check_deadline()?;
             let v = vector_arg(evaluator, source, &call.args.args[0], t, ctx)?;
             Ok(Value::Vector(f(v)))
         })
-        .map(hist_matrix_into_float),
+        .map(|m| float_matrix_into_hist(hist_matrix_into_float(m))),
         FunctionKind::Instant(f) => eval_instant_over_grid(start_ns, end_ns, step_ns, |t| {
             ctx.check_deadline()?;
             f(evaluator, source, call, t, ctx)
         })
-        .map(hist_matrix_into_float),
+        .map(|m| float_matrix_into_hist(hist_matrix_into_float(m))),
     }
+}
+
+/// Map a native-histogram [`over_time::HistOverTime`] outcome to a range
+/// element at `reported_ts_ns` (ADR-0108 decision 5): a float or histogram
+/// result becomes the matching [`RangeSample`], a drop becomes `None`.
+fn histogram_range_element(
+    outcome: over_time::HistOverTime,
+    reported_ts_ns: i64,
+) -> Option<RangeSample> {
+    match outcome {
+        over_time::HistOverTime::Float(v) => Some(RangeSample::scalar(reported_ts_ns, v)),
+        over_time::HistOverTime::Histogram(h) => Some(RangeSample::histogram(reported_ts_ns, h)),
+        over_time::HistOverTime::Drop => None,
+    }
+}
+
+/// Append native-histogram `_over_time` results to an instant range-vector
+/// function's output (ADR-0108 decision 5, the instant/range parity fix): a
+/// histogram-only series matching the same selector is reduced by the shared
+/// [`over_time::histogram_over_time`] policy so both endpoints answer the same
+/// class of value. Only a matrix selector can carry histograms into this
+/// family (a subquery over native histograms errors upstream in
+/// `eval_subquery_matrix`), so a subquery argument contributes nothing.
+#[allow(clippy::too_many_arguments)]
+fn append_histogram_over_time(
+    evaluator: &Evaluator,
+    source: &dyn SeriesSource,
+    arg: MatrixArg,
+    name: &str,
+    eval_ts_ns: i64,
+    keep_metric_name: bool,
+    ctx: &QueryWindow,
+    out: &mut InstantVector,
+) -> Result<(), Error> {
+    let MatrixArg::Selector(ms) = arg else {
+        return Ok(());
+    };
+    let hmatrix =
+        evaluator.eval_histogram_matrix_selector(source, ms, eval_ts_ns, ctx, keep_metric_name)?;
+    for (labels, samples) in hmatrix {
+        match over_time::histogram_over_time(name, &samples) {
+            over_time::HistOverTime::Float(v) => {
+                out.push(InstantSample::scalar(labels, eval_ts_ns, eval_ts_ns, v));
+            }
+            over_time::HistOverTime::Histogram(h) => {
+                out.push(InstantSample::histogram(labels, eval_ts_ns, eval_ts_ns, h));
+            }
+            over_time::HistOverTime::Drop => {}
+        }
+    }
+    Ok(())
 }
 
 /// Evaluate an [`FunctionKind::VectorMap`] or [`FunctionKind::Instant`]
@@ -638,8 +740,8 @@ fn eval_matrix_arg_range_reduction(
     points: u64,
     ctx: &QueryWindow,
     keep_metric_name: bool,
-    reduce: impl Fn(&[Sample], i64, i64, i64, i64) -> Option<f64>,
-) -> Result<RangeMatrix, Error> {
+    reduce: impl Fn(&[Sample], &[TimedHistogram], i64, i64, i64, i64) -> Option<RangeSample>,
+) -> Result<HistogramAwareMatrix, Error> {
     match arg {
         MatrixArg::Selector(ms) => evaluator.eval_range_matrix_reduction(
             source,
@@ -653,8 +755,12 @@ fn eval_matrix_arg_range_reduction(
             reduce,
         ),
         MatrixArg::Subquery(sq) => {
+            // A subquery yields only float samples: `eval_subquery_matrix`
+            // rejects native histograms upstream with `Error::Unsupported`
+            // rather than dropping them, so the histogram slice handed to
+            // `reduce` is always empty here.
             let range_ns = duration_to_ns(sq.range)?;
-            let mut series: Vec<(LabelSet, Vec<Sample>)> = Vec::new();
+            let mut series: Vec<(LabelSet, Vec<RangeSample>)> = Vec::new();
             let mut t = start_ns;
             while t <= end_ns {
                 ctx.check_deadline()?;
@@ -665,15 +771,17 @@ fn eval_matrix_arg_range_reduction(
                     if samples.is_empty() {
                         continue;
                     }
-                    if let Some(value) = reduce(&samples, window_start_ns, sel_ts_ns, range_ns, t) {
+                    if let Some(element) =
+                        reduce(&samples, &[], window_start_ns, sel_ts_ns, range_ns, t)
+                    {
                         let labels = if keep_metric_name {
                             labels
                         } else {
                             drop_metric_name(labels)
                         };
                         match series.iter_mut().find(|(l, _)| *l == labels) {
-                            Some((_, out)) => out.push(Sample { ts_ns: t, value }),
-                            None => series.push((labels, vec![Sample { ts_ns: t, value }])),
+                            Some((_, out)) => out.push(element),
+                            None => series.push((labels, vec![element])),
                         }
                     }
                 }
@@ -1631,12 +1739,52 @@ mod tests {
     }
 
     #[test]
+    fn range_grid_undefined_aggregations_annotate_the_drop() {
+        // The drop of a histogram element by `min`/`max`/`stddev`/`stdvar`/
+        // `quantile`/`topk`/`bottomk` must carry Prometheus'
+        // `HistogramIgnoredInAggregationInfo`, not be silent (ADR-0108
+        // decision 6a; the difftest comparator checks annotation presence).
+        // Before item 6a these drops emitted no annotation; the flipped
+        // assertion is the non-empty `infos()` naming the aggregation.
+        let source = TestSource::new()
+            .with_histogram_series(&[("__name__", "h"), ("i", "1")], &[(0, nh(2.0, 10.0))])
+            .expect("valid histogram series")
+            .with_histogram_series(&[("__name__", "h"), ("i", "2")], &[(0, nh(3.0, 12.0))])
+            .expect("valid histogram series");
+        for (op, expected) in [
+            ("min(h)", "ignored histogram in min aggregation"),
+            ("max(h)", "ignored histogram in max aggregation"),
+            ("stddev(h)", "ignored histogram in stddev aggregation"),
+            ("stdvar(h)", "ignored histogram in stdvar aggregation"),
+            (
+                "quantile(0.5, h)",
+                "ignored histogram in quantile aggregation",
+            ),
+            ("topk(1, h)", "ignored histogram in topk aggregation"),
+            ("bottomk(1, h)", "ignored histogram in bottomk aggregation"),
+        ] {
+            let (_value, annotations) = Evaluator::new()
+                .eval_range_hist_annotated(&source, op, 0, 60_000, 60_000)
+                .expect("range evaluates");
+            assert!(
+                annotations.infos().iter().any(|m| m == expected),
+                "{op} must annotate the histogram drop with {expected:?}, got {:?}",
+                annotations.infos()
+            );
+        }
+    }
+
+    #[test]
     fn grouping_by_preserves_histogram_element_type() {
         // `sum by (i)` over histogram series keeps each group's element a
         // histogram end to end (through both grid materialization and the
-        // grouping rebuild). Before the fix the grid dropped the histogram
-        // field, so every group's element was a `0.0` float; the flipped
-        // assertion is `samples[0].histogram.is_some()` for each group.
+        // grouping rebuild), AND carries the correct per-group population: each
+        // `i` label groups a single distinct series, so its summed histogram
+        // must be exactly that series' own `count`/`sum`, not a `0.0`
+        // placeholder and not another group's value. Before the fix the grid
+        // dropped the histogram field, so every group's element was a `0.0`
+        // float; the flipped assertions are `s.histogram.is_some()` and the
+        // exact `count`/`sum` bit-patterns per group.
         let source = TestSource::new()
             .with_histogram_series(&[("__name__", "h"), ("i", "1")], &[(0, nh(2.0, 10.0))])
             .expect("valid histogram series")
@@ -1650,11 +1798,38 @@ mod tests {
         };
         assert_eq!(matrix.len(), 2, "one group per distinct i label");
         for (labels, samples) in &matrix {
+            let i = labels
+                .iter()
+                .find(|l| l.name == "i")
+                .map(|l| l.value.clone())
+                .expect("group keeps its `i` label");
+            // `sum` drops `__name__`; the only surviving label is the group key.
+            assert!(
+                labels
+                    .iter()
+                    .all(|l| l.name != ravel_types::METRIC_NAME_LABEL),
+                "group {labels:?} drops __name__"
+            );
+            let (want_count, want_sum) = match i.as_str() {
+                "1" => (2.0_f64, 10.0_f64),
+                "2" => (5.0_f64, 25.0_f64),
+                other => panic!("unexpected group i={other}"),
+            };
             assert!(!samples.is_empty(), "each group has at least one grid step");
             for s in samples {
-                assert!(
-                    s.histogram.is_some(),
-                    "group {labels:?} preserves its histogram element type"
+                let h = s
+                    .histogram
+                    .as_ref()
+                    .unwrap_or_else(|| panic!("group i={i} preserves its histogram element type"));
+                assert_eq!(
+                    h.count.to_bits(),
+                    want_count.to_bits(),
+                    "group i={i} keeps its own population count"
+                );
+                assert_eq!(
+                    h.sum.to_bits(),
+                    want_sum.to_bits(),
+                    "group i={i} keeps its own observation sum"
                 );
             }
         }

--- a/crates/ravel-promql/src/functions/over_time.rs
+++ b/crates/ravel-promql/src/functions/over_time.rs
@@ -20,9 +20,64 @@
 use ravel_types::{Label, LabelSet, METRIC_NAME_LABEL, Sample};
 
 use crate::eval::{Error, Evaluator, InstantSample, InstantVector, QueryWindow, RangeMatrix};
+use crate::histogram::{FloatHistogram, TimedHistogram, avg_histograms, sum_histograms};
 use crate::source::SeriesSource;
 
 use super::{FunctionDef, FunctionKind, MatrixArg, RangeWindow};
+
+/// The outcome of reducing one `_over_time` window that holds native
+/// histograms rather than floats. In Ravel's storage model a series is
+/// purely float or purely histogram, so this is reached only for a
+/// histogram-only window and never mixes with the float reducers above.
+pub(crate) enum HistOverTime {
+    /// A float result (`count_over_time`'s sample count, `present_over_time`'s
+    /// constant 1).
+    Float(f64),
+    /// A native-histogram result (`sum`/`avg`/`last_over_time`).
+    Histogram(FloatHistogram),
+    /// This member has no defined native-histogram semantics in the pinned
+    /// Prometheus v3.13.1 binary, so the histogram window produces no output.
+    /// Matching the oracle exactly: for a histogram-only window every
+    /// float-only `_over_time` member takes Prometheus'
+    /// `if len(samples.Floats) == 0 { return }` early exit, which yields no
+    /// element and, because that return precedes the histogram-ignored
+    /// annotation, no annotation either.
+    Drop,
+}
+
+/// Reduce a native-histogram `_over_time` window per the pinned Prometheus
+/// v3.13.1 behavior for each member (ADR-0108 decision 5). `hists` is the
+/// window's histogram samples in ascending timestamp order and is never
+/// empty. Shared by the range dispatch (`eval_range_call`) and the instant
+/// dispatch (`eval_call`) so both endpoints answer identically.
+///
+/// - `sum_over_time`/`avg_over_time` fold the window with the same
+///   [`sum_histograms`]/[`avg_histograms`] helpers the `sum`/`avg`
+///   aggregations use.
+/// - `count_over_time` counts histogram samples exactly as it counts floats
+///   (Prometheus' `len(s.Floats) + len(s.Histograms)`).
+/// - `last_over_time` returns the newest histogram in the window.
+/// - `present_over_time` is 1 for any non-empty window regardless of type.
+/// - every other member (`min`/`max`/`stddev`/`stdvar`/`quantile_over_time`,
+///   `predict_linear`, `deriv`, `irate`/`idelta`/`resets`/`changes`) is
+///   float-only in Prometheus and drops the histogram window with no
+///   annotation, per [`HistOverTime::Drop`].
+pub(crate) fn histogram_over_time(name: &str, hists: &[TimedHistogram]) -> HistOverTime {
+    match name {
+        "sum_over_time" => match sum_histograms(hists.iter().map(|(_, h)| h)) {
+            Some(h) => HistOverTime::Histogram(h),
+            None => HistOverTime::Drop,
+        },
+        "avg_over_time" => match avg_histograms(hists.iter().map(|(_, h)| h)) {
+            Some(h) => HistOverTime::Histogram(h),
+            None => HistOverTime::Drop,
+        },
+        "count_over_time" => HistOverTime::Float(hists.len() as f64),
+        "last_over_time" => HistOverTime::Histogram(hists[hists.len() - 1].1.clone()),
+        "present_over_time" => HistOverTime::Float(1.0),
+        _ => HistOverTime::Drop,
+    }
+}
 
 pub(crate) const FUNCTIONS: &[FunctionDef] = &[
     FunctionDef {
@@ -234,25 +289,60 @@ pub(crate) fn kahan_sum_inc(inc: f64, sum: f64, c: f64) -> (f64, f64) {
 }
 
 /// `absent_over_time` at one instant: unlike every other function in this
-/// family, it is not a per-series reduction of `matrix`'s rows. It reports
-/// whether the whole range vector argument matched nothing at all, and if
-/// so synthesizes exactly one output series from `labels`
+/// family, it is not a per-series reduction of the argument's rows. It reports
+/// whether the whole range vector argument matched nothing at all, and if so
+/// synthesizes exactly one output series from the selector's matchers
 /// ([`matrix_arg_absent_labels`]).
+///
+/// Presence counts native-histogram samples as well as floats (ADR-0108
+/// decision 7): a histogram-only stream is live, so `absent_over_time` over it
+/// must return empty, not affirmatively 1. Reading only the float fetch was
+/// the false-positive liveness alert (issue #578) this fixes.
 pub(crate) fn absent_over_time_instant(
-    labels: LabelSet,
-    matrix: RangeMatrix,
+    evaluator: &Evaluator,
+    source: &dyn SeriesSource,
+    arg: MatrixArg,
     eval_ts_ns: i64,
-) -> InstantVector {
-    if !matrix.is_empty() {
-        return Vec::new();
+    ctx: &QueryWindow,
+) -> Result<InstantVector, Error> {
+    if matrix_arg_has_samples(evaluator, source, arg, eval_ts_ns, ctx)? {
+        return Ok(Vec::new());
     }
-    vec![InstantSample {
-        labels,
+    Ok(vec![InstantSample {
+        labels: matrix_arg_absent_labels(arg),
         ts_ns: eval_ts_ns,
         orig_sample_ts_ns: eval_ts_ns,
         value: 1.0,
         histogram: None,
-    }]
+    }])
+}
+
+/// Whether a matrix-typed argument matches any sample at `eval_ts_ns`, float
+/// or native histogram. A subquery yields only floats (`eval_subquery_matrix`
+/// rejects histograms upstream), so its histogram channel is skipped.
+fn matrix_arg_has_samples(
+    evaluator: &Evaluator,
+    source: &dyn SeriesSource,
+    arg: MatrixArg,
+    eval_ts_ns: i64,
+    ctx: &QueryWindow,
+) -> Result<bool, Error> {
+    match arg {
+        MatrixArg::Selector(ms) => {
+            if !evaluator
+                .eval_matrix_selector(source, ms, eval_ts_ns, ctx)?
+                .is_empty()
+            {
+                return Ok(true);
+            }
+            Ok(!evaluator
+                .eval_histogram_matrix_selector(source, ms, eval_ts_ns, ctx, false)?
+                .is_empty())
+        }
+        MatrixArg::Subquery(sq) => Ok(!evaluator
+            .eval_subquery_matrix(source, sq, eval_ts_ns, ctx)?
+            .is_empty()),
+    }
 }
 
 /// `absent_over_time` over a range query's grid: absence is evaluated
@@ -278,11 +368,10 @@ pub(crate) fn absent_over_time_range(
     let mut out_samples = Vec::new();
     let mut t = start_ns;
     while t <= end_ns {
-        let matrix = match arg {
-            MatrixArg::Selector(ms) => evaluator.eval_matrix_selector(source, ms, t, ctx)?,
-            MatrixArg::Subquery(sq) => evaluator.eval_subquery_matrix(source, sq, t, ctx)?,
-        };
-        if matrix.is_empty() {
+        // Absence at this step means the window held neither a float nor a
+        // native-histogram sample (ADR-0108 decision 7): a histogram-only
+        // stream is present, so the step must not report 1.
+        if !matrix_arg_has_samples(evaluator, source, arg, t, ctx)? {
             out_samples.push(Sample {
                 ts_ns: t,
                 value: 1.0,
@@ -663,5 +752,220 @@ mod tests {
             promql_parser::parser::Expr::Subquery(sq) => sq,
             other => panic!("expected a subquery, got {other:?}"),
         }
+    }
+
+    /// A scale-0 native histogram carrying `count`/`sum` in one positive
+    /// bucket, for the native-histogram `_over_time` tests below.
+    fn nh(count: f64, sum: f64) -> FloatHistogram {
+        use crate::histogram::{ResetHint, Span};
+        FloatHistogram {
+            counter_reset_hint: ResetHint::Unknown,
+            scale: 0,
+            zero_threshold: 0.0,
+            zero_count: 0.0,
+            count,
+            sum,
+            positive_spans: vec![Span {
+                offset: 1,
+                length: 1,
+            }],
+            negative_spans: Vec::new(),
+            positive_buckets: vec![count],
+            negative_buckets: Vec::new(),
+            custom_values: Vec::new(),
+        }
+    }
+
+    /// Three native-histogram samples of `h` at 0/60s/120s, the shared fixture
+    /// for the range/instant `_over_time` histogram tests. Populations are
+    /// distinct so a wrong reduction (summing the wrong members, or reading a
+    /// `0.0` placeholder) yields a different, detectable value.
+    fn histogram_source() -> crate::testsource::TestSource {
+        crate::testsource::TestSource::new()
+            .with_histogram_series(
+                &[("__name__", "h")],
+                &[
+                    (ms(0), nh(2.0, 10.0)),
+                    (ms(60_000), nh(3.0, 15.0)),
+                    (ms(120_000), nh(5.0, 25.0)),
+                ],
+            )
+            .expect("valid histogram series")
+    }
+
+    #[test]
+    fn sum_over_time_produces_native_histogram_elements() {
+        use crate::eval::{Evaluator, RangeValue};
+
+        // `sum_over_time(h[5m])` over a histogram-only window folds the three
+        // window histograms with `sum_histograms` into one histogram element
+        // (count 2+3+5=10, sum 10+15+25=50). Before item 2 the range arm
+        // fetched floats only and the histogram series vanished, leaving an
+        // empty matrix: the flipped assertion is `s.histogram` being `Some`
+        // with count 10 (pre-fix the matrix was empty).
+        let source = histogram_source();
+        let (value, _annos) = Evaluator::new()
+            .eval_range_hist_annotated(&source, "sum_over_time(h[5m])", 120_000, 120_000, 60_000)
+            .expect("range evaluates");
+        let RangeValue::Matrix(matrix) = value else {
+            panic!("sum_over_time is a matrix");
+        };
+        assert_eq!(matrix.len(), 1, "one histogram series");
+        let samples = &matrix[0].1;
+        assert_eq!(samples.len(), 1, "one grid step at t=120s");
+        let h = samples[0]
+            .histogram
+            .as_ref()
+            .expect("sum_over_time over histograms yields a histogram element");
+        assert_eq!(h.count.to_bits(), 10.0_f64.to_bits(), "2 + 3 + 5");
+        assert_eq!(h.sum.to_bits(), 50.0_f64.to_bits(), "10 + 15 + 25");
+    }
+
+    #[test]
+    fn count_over_time_counts_native_histogram_samples() {
+        use crate::eval::{Evaluator, RangeValue};
+
+        // `count_over_time(h[5m])` counts histogram samples exactly as it
+        // counts floats (Prometheus' `len(Floats) + len(Histograms)`): three
+        // samples in the window is a float `3`, never a histogram element.
+        // Before item 2 the histogram series vanished and the matrix was
+        // empty; the flipped assertion is the float value `3` with
+        // `histogram: None`.
+        let source = histogram_source();
+        let (value, _annos) = Evaluator::new()
+            .eval_range_hist_annotated(&source, "count_over_time(h[5m])", 120_000, 120_000, 60_000)
+            .expect("range evaluates");
+        let RangeValue::Matrix(matrix) = value else {
+            panic!("count_over_time is a matrix");
+        };
+        assert_eq!(matrix.len(), 1, "one series");
+        let samples = &matrix[0].1;
+        assert_eq!(samples.len(), 1, "one grid step");
+        assert!(
+            samples[0].histogram.is_none(),
+            "count_over_time is a float element, never a histogram"
+        );
+        assert_eq!(
+            samples[0].value.to_bits(),
+            3.0_f64.to_bits(),
+            "three histogram samples in the window"
+        );
+    }
+
+    #[test]
+    fn last_over_time_returns_the_native_histogram_element() {
+        use crate::eval::{Evaluator, RangeValue};
+
+        // `last_over_time(h[5m])` returns the newest histogram in the window
+        // verbatim (the 120s sample, count 5 sum 25), keeping every label
+        // including `__name__`. Before item 2 the histogram series vanished;
+        // the flipped assertion is the returned histogram's count 5.
+        let source = histogram_source();
+        let (value, _annos) = Evaluator::new()
+            .eval_range_hist_annotated(&source, "last_over_time(h[5m])", 120_000, 120_000, 60_000)
+            .expect("range evaluates");
+        let RangeValue::Matrix(matrix) = value else {
+            panic!("last_over_time is a matrix");
+        };
+        assert_eq!(matrix.len(), 1, "one series");
+        let (labels, samples) = &matrix[0];
+        assert!(
+            labels
+                .iter()
+                .any(|l| l.name == METRIC_NAME_LABEL && l.value == "h"),
+            "last_over_time keeps __name__: {labels:?}"
+        );
+        assert_eq!(samples.len(), 1, "one grid step");
+        let h = samples[0]
+            .histogram
+            .as_ref()
+            .expect("last_over_time over histograms returns the histogram element");
+        assert_eq!(h.count.to_bits(), 5.0_f64.to_bits(), "newest sample count");
+        assert_eq!(h.sum.to_bits(), 25.0_f64.to_bits(), "newest sample sum");
+    }
+
+    #[test]
+    fn absent_over_time_sees_native_histogram_presence() {
+        use crate::eval::Evaluator;
+
+        // `absent_over_time(h[5m])` must return empty while histogram data
+        // flows: a histogram-only stream is present. Before item 4 presence
+        // was read from the float fetch only, so this affirmatively returned
+        // 1 (the false-positive liveness alert). The flipped assertion is that
+        // the result is empty.
+        let source = histogram_source();
+        let present = Evaluator::new()
+            .instant(&source, "absent_over_time(h[5m])", 120_000)
+            .expect("evaluates");
+        assert!(
+            present.is_empty(),
+            "a live histogram stream is present, so absent_over_time is empty: {present:?}"
+        );
+
+        // Control: no series at all, so absence still reports 1.
+        let empty = crate::testsource::TestSource::new();
+        let absent = Evaluator::new()
+            .instant(&empty, "absent_over_time(h[5m])", 120_000)
+            .expect("evaluates");
+        assert_eq!(absent.len(), 1, "genuinely absent series reports 1");
+        assert_eq!(absent[0].value.to_bits(), 1.0_f64.to_bits());
+    }
+
+    #[test]
+    fn instant_count_over_time_counts_native_histogram_samples() {
+        use crate::eval::Evaluator;
+
+        // The instant endpoint must answer the same class as the range
+        // endpoint (item 5): `count_over_time(h[5m])` at an instant counts the
+        // three histogram samples as a float `3`. Before item 5 the instant
+        // matrix arg fetched floats only, so the histogram series read as
+        // empty and no series was returned. The flipped assertion is the
+        // single float `3`.
+        let source = histogram_source();
+        let out = Evaluator::new()
+            .instant(&source, "count_over_time(h[5m])", 120_000)
+            .expect("evaluates");
+        assert_eq!(out.len(), 1, "one series at the instant endpoint");
+        assert!(out[0].histogram.is_none(), "count is a float");
+        assert_eq!(
+            out[0].value.to_bits(),
+            3.0_f64.to_bits(),
+            "three histogram samples counted at the instant endpoint"
+        );
+    }
+
+    #[test]
+    fn instant_quantile_over_time_drops_histogram_inputs_like_the_oracle() {
+        use crate::eval::{Evaluator, Value};
+
+        // `quantile_over_time` is float-only in Prometheus v3.13.1: a
+        // histogram-only window takes its `if len(el.Floats) == 0 { return }`
+        // early exit, yielding no element and (because that return precedes
+        // the histogram-ignored annotation) no annotation. Ravel must drop the
+        // histogram series the same way, never emit a spurious value and never
+        // warn. The flipped assertion: forcing the `quantile_over_time` arm of
+        // `histogram_over_time` to return a `Float` instead of `Drop` makes
+        // this fail with a non-empty result.
+        let source = histogram_source();
+        let (value, annos) = Evaluator::new()
+            .eval_instant_annotated(&source, "quantile_over_time(0.5, h[5m])", 120_000)
+            .expect("evaluates");
+        let Value::Vector(out) = value else {
+            panic!("quantile_over_time is a vector");
+        };
+        assert!(
+            out.is_empty(),
+            "quantile_over_time drops histogram-only inputs like the oracle: {out:?}"
+        );
+        assert!(
+            annos.warnings().is_empty(),
+            "the oracle emits no annotation for a histogram-only quantile window: {:?}",
+            annos.warnings()
+        );
+        assert!(
+            annos.infos().is_empty(),
+            "no info annotation either for a pure-histogram quantile window: {:?}",
+            annos.infos()
+        );
     }
 }

--- a/crates/ravel-promql/src/functions/rate.rs
+++ b/crates/ravel-promql/src/functions/rate.rs
@@ -606,4 +606,84 @@ mod tests {
         let got = delta(&samples, window(0, 60_000, 60_000)).expect("2+ samples");
         assert_eq!(got, f64::INFINITY);
     }
+
+    /// A scale-0 counter native histogram carrying `count`/`sum` in one
+    /// positive bucket, for the range/instant parity test below.
+    fn nh_counter(count: f64, sum: f64) -> FloatHistogram {
+        use crate::histogram::{ResetHint, Span};
+        FloatHistogram {
+            counter_reset_hint: ResetHint::Unknown,
+            scale: 0,
+            zero_threshold: 0.0,
+            zero_count: 0.0,
+            count,
+            sum,
+            positive_spans: vec![Span {
+                offset: 1,
+                length: 1,
+            }],
+            negative_spans: Vec::new(),
+            positive_buckets: vec![count],
+            negative_buckets: Vec::new(),
+            custom_values: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn range_rate_over_native_histogram_matches_the_instant_arm() {
+        use crate::eval::{RangeValue, Value};
+        use crate::testsource::TestSource;
+
+        // A native-histogram counter with two increasing samples in the
+        // window. The instant arm already reduces it through
+        // `histogram_extrapolated_rate`; the range arm must dispatch to the
+        // same reducer over the same window and produce the bit-identical
+        // histogram element. Before item 1, the range arm ignored `hist: _`
+        // and the histogram series vanished, so the range matrix was empty:
+        // the flipped assertion is the `range_hist == instant_hist` equality
+        // (pre-fix the range side had no histogram element at all).
+        // Samples land inside the left-open window `(0, 120s]`: the 2m window
+        // at t=120s excludes an edge sample at exactly t=0.
+        let source = TestSource::new()
+            .with_histogram_series(
+                &[("__name__", "h")],
+                &[
+                    (ms(60_000), nh_counter(2.0, 10.0)),
+                    (ms(120_000), nh_counter(6.0, 30.0)),
+                ],
+            )
+            .expect("valid histogram series");
+        let evaluator = crate::eval::Evaluator::new();
+
+        let instant = evaluator
+            .eval_instant(&source, "rate(h[2m])", 120_000)
+            .expect("instant evaluates");
+        let Value::Vector(instant) = instant else {
+            panic!("rate is a vector");
+        };
+        assert_eq!(instant.len(), 1, "one histogram series");
+        let instant_hist = instant[0]
+            .histogram
+            .as_ref()
+            .expect("instant rate over a histogram yields a histogram element");
+
+        let (range, _annos) = evaluator
+            .eval_range_hist_annotated(&source, "rate(h[2m])", 120_000, 120_000, 60_000)
+            .expect("range evaluates");
+        let RangeValue::Matrix(matrix) = range else {
+            panic!("range rate is a matrix");
+        };
+        assert_eq!(matrix.len(), 1, "one histogram series");
+        let samples = &matrix[0].1;
+        assert_eq!(samples.len(), 1, "one grid step at t=120s");
+        let range_hist = samples[0]
+            .histogram
+            .as_ref()
+            .expect("range rate over a histogram yields a histogram element, not an empty series");
+
+        assert_eq!(
+            range_hist, instant_hist,
+            "the range arm must reduce through the same histogram reducer as the instant arm"
+        );
+    }
 }

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -335,12 +335,33 @@ per step. Per-operator aggregation follows Prometheus 3.x: `sum`/`avg` over
 histogram elements produce histogram elements, `count` a float, and the
 operators Prometheus leaves undefined for histograms (`min`, `max`,
 `stddev`, `stdvar`, `quantile`, `topk`, `bottomk`) drop the histogram
-elements. `by`/`without` grouping preserves element type. The
-histogram-aware result is exposed by `Evaluator::eval_range_hist_annotated`;
-`Evaluator::eval_range_annotated` (and the current HTTP renderer) still
-project histogram elements away rather than render them as `0.0` floats, so
-the standard `histograms` field on range responses is future work (issue
-#579).
+elements and annotate the drop with an info
+(`HistogramIgnoredInAggregationInfo`, "ignored histogram in <op>
+aggregation"), never a silent drop. `by`/`without` grouping preserves
+element type.
+
+The range counter functions and the `_over_time` family carry histograms too
+(ADR-0108 decisions 4/5, issue #578). `rate`/`increase`/`delta` reduce a
+histogram window to a histogram element through the same
+`histogram_extrapolated_rate` reducer the instant arm uses.
+`sum_over_time`/`avg_over_time` produce a histogram element,
+`count_over_time` counts histogram samples as a float, `last_over_time`
+returns the newest histogram, and `present_over_time` is 1 for any non-empty
+window. The float-only members (`min`/`max`/`stddev`/`stdvar`/
+`quantile_over_time`, `predict_linear`, `irate`/`idelta`/`resets`/`changes`/
+`deriv`) drop a histogram-only window, matching the pinned Prometheus
+v3.13.1 binary exactly: its `if len(samples.Floats) == 0 { return }` early
+exit yields no element and, because that return precedes the
+histogram-ignored annotation, no annotation either. Both endpoints answer
+the same class of value: the instant dispatch fetches the histogram matrix
+alongside the float one, so a histogram-only series is no longer read as
+empty. `absent`/`absent_over_time` count a native-histogram sample as
+presence, so a histogram-only stream never reads as absent.
+
+The histogram-aware result is exposed by
+`Evaluator::eval_range_hist_annotated`; `Evaluator::eval_range_annotated`
+(and any float-only caller) projects histogram elements away rather than
+render them as `0.0` floats.
 
 The max-samples budget is **count-yielded**: samples are counted as the
 lazy k-way merge emits them (post-dedup), and the budget trips at exactly


### PR DESCRIPTION
The range arms of `rate`, `increase` and `delta` ignored histogram inputs
entirely, and the `*_over_time` family dropped histogram series before the
reduction saw them. `absent_over_time` counted only float samples, so a
histogram-only series read as absent and fired a liveness alert while data
was flowing. All of it silent, with HTTP 200.

The range arms now dispatch to the existing `histogram_extrapolated_rate`
that the instant arms already used, rather than a second implementation.
`sum_over_time` and `avg_over_time` produce histogram elements,
`count_over_time` a float count of histogram samples, `last_over_time` the
histogram element it saw. `absent_over_time` and `absent` treat presence as
float OR histogram samples. The same policy is applied at the instant
endpoint, whose matrix argument went through a float-only fetch and so read
histogram series as empty there too.

Every remaining member follows the pinned Prometheus v3.13.1 behaviour,
verified against its source per member rather than assumed. One consequence
is worth recording: because a Ravel series is purely float or purely
histogram, a histogram-only window hits Prometheus' floats-empty early
return, which yields an empty result with NO annotation. So
drop-without-annotation is oracle-correct for `min`, `max`, `stddev`,
`stdvar` and `quantile_over_time`, and adding annotations there would break
difftest parity rather than improve it.

The drop paths that Prometheus does annotate now annotate: the
quantile/topk/bottomk filters that landed unannotated in #577, and the
inherited min/max/stddev/stdvar drops. `docs/query-engine.md` regains the
ADR's wording.

Two gaps are known and filed rather than left silent: #649 (sum/avg over a
mixed float and histogram group still drop without the mixed-type warning)
and #650 (irate, idelta, resets, changes and deriv drop where the oracle
defines semantics).

Fixes: #578
Refs: #573
