### PR TITLE
test(difftest): histogram-aware comparator and native-histogram corpus

### DIFF
--- a/crates/ravel-promql-difftest/corpus/histogram_native.txt
+++ b/crates/ravel-promql-difftest/corpus/histogram_native.txt
@@ -155,3 +155,109 @@ start: +300s
 end: +600s
 step: 60s
 mode: unordered
+
+# Range evaluation over native histograms (ADR-0108, #580). Before #577/#578/
+# #579 the range path silently destroyed histogram data three ways: the grid
+# collapse dropped a histogram element to a placeholder float 0.0 (silent
+# zeros); the range selector and the range arms of rate/*_over_time fetched
+# floats only, so bare histogram selectors and their reductions vanished
+# (silent empties); and absent_over_time built its answer from the float-only
+# fetch and returned 1 while histogram data flowed (false absence). Each shape
+# below carries a histogram result end to end and is paired with an
+# instant-kind counterpart, proving both endpoints return the same class of
+# answer (the ADR-0108 asymmetry requirement). These entries also depend on
+# the histogram-aware comparator: they compare histogram-valued elements, which
+# the old float-only comparator could not read.
+#
+# No tolerance on the rate/increase entries: the existing instant entries
+# native_histogram_rate_count and native_histogram_increase_sum already match
+# Prometheus bit-for-bit on this schema-0 dataset (the extrapolated-rate math
+# takes no libm powf on schema 0), so the histogram these produce should match
+# bit-for-bit too. If a first real RAVEL_DIFFTEST run measures a per-bucket or
+# count/sum ULP gap, a measured tolerance is added per ADR-0025, never guessed.
+
+# Silent-zeros shape: a top-level aggregate over a histogram element. The grid
+# collapse used to emit an all-zero float series here.
+name: native_histogram_sum_rate_range
+query: sum(rate(diff_native_hist[5m]))
+kind: range
+start: +300s
+end: +600s
+step: 60s
+mode: unordered
+
+name: native_histogram_sum_rate_instant
+query: sum(rate(diff_native_hist[5m]))
+kind: instant
+time: +600s
+mode: unordered
+
+# Silent-empties shape: the range arm of rate over a histogram counter. Its
+# window reducer (histogram_extrapolated_rate) was ported but unwired on the
+# range arm, so this used to vanish.
+name: native_histogram_rate_range
+query: rate(diff_native_hist[5m])
+kind: range
+start: +300s
+end: +600s
+step: 60s
+mode: unordered
+
+name: native_histogram_rate_instant
+query: rate(diff_native_hist[5m])
+kind: instant
+time: +600s
+mode: unordered
+
+# Silent-empties shape: a bare native-histogram selector as a range query. The
+# range selector fetched floats only, so the whole series used to disappear.
+name: native_histogram_bare_selector_range
+query: diff_native_hist
+kind: range
+start: +300s
+end: +600s
+step: 60s
+mode: unordered
+
+name: native_histogram_bare_selector_instant
+query: diff_native_hist
+kind: instant
+time: +600s
+mode: unordered
+
+# Silent-empties shape in the *_over_time family: count_over_time reduces
+# histogram samples to a float count of how many landed in the window. The
+# family reduced floats only, so this used to answer empty over histogram data.
+name: native_histogram_count_over_time_range
+query: count_over_time(diff_native_hist[5m])
+kind: range
+start: +300s
+end: +600s
+step: 60s
+mode: unordered
+
+name: native_histogram_count_over_time_instant
+query: count_over_time(diff_native_hist[5m])
+kind: instant
+time: +600s
+mode: unordered
+
+# False-absence shape: absent_over_time over a window that has histogram data
+# must answer empty (the data is present). The float-only fetch used to see no
+# samples and return 1, a permanently inverted liveness signal. The 15m window
+# spans the whole 30s-step dataset, so every grid point sees data.
+name: native_histogram_absent_over_time_range
+query: absent_over_time(diff_native_hist[15m])
+kind: range
+start: +300s
+end: +600s
+step: 60s
+mode: unordered
+expect: empty
+
+name: native_histogram_absent_over_time_instant
+query: absent_over_time(diff_native_hist[15m])
+kind: instant
+time: +600s
+mode: unordered
+expect: empty

--- a/crates/ravel-promql-difftest/src/comparator.rs
+++ b/crates/ravel-promql-difftest/src/comparator.rs
@@ -18,6 +18,23 @@
 //! project's `-0.0` bit-significance rule is a matter of principle, not
 //! magnitude, so the zero boundary is always exact-bit-compared.
 //!
+//! Native-histogram elements (ADR-0108 decision 10) compare by a canonical
+//! semantic form, never a byte layout: two engines can encode the same
+//! histogram with different internal span layouts, so the wire form is what is
+//! compared. A vector element carries either a float `value` or a native
+//! `histogram`; a matrix series carries float steps under `values` and
+//! histogram steps under `histograms`, either or both across its grid. Which
+//! channel an element uses is part of its series identity, so a series
+//! Prometheus returns as a histogram and Ravel returns as a float (or the
+//! reverse) is a mismatch, not a match. A histogram value's bucket structure
+//! (each bucket's interval-openness code and its lower/upper boundaries, in
+//! order) and its per-bucket counts compare exactly; the histogram's total
+//! `count` and `sum` compare under the same bit-exact-or-ULP value rule as any
+//! float, so an entry's `tolerance:` field reaches them because both engines
+//! compute extrapolated rates independently. Boundaries and counts are parsed
+//! from their Prometheus value strings and bit-compared, so a formatting
+//! difference over the same `f64` is never a divergence.
+//!
 //! A corpus entry may also opt into the one-sided
 //! [`ComparisonMode::RavelErrorPromSuccess`] mode (ADR-0030's allowlist):
 //! an accepted, per-entry, by-design divergence where Ravel rejects a query
@@ -136,19 +153,170 @@ fn label_key(metric: &Json) -> String {
         .join(",")
 }
 
+/// The channel an element carries: a float value (`value`/`values`), a native
+/// histogram (`histogram`/`histograms`), or both across a matrix series' grid.
+/// Part of a series' identity: a series Prometheus returns as a histogram and
+/// Ravel returns as a float for the same label set is a divergence, so the two
+/// must never sort into the same identity slot.
+fn element_channel(elem: &Json) -> &'static str {
+    let has_float = elem.get("value").is_some_and(|v| !v.is_null())
+        || elem
+            .get("values")
+            .and_then(Json::as_array)
+            .is_some_and(|a| !a.is_empty());
+    let has_hist = elem.get("histogram").is_some_and(|v| !v.is_null())
+        || elem
+            .get("histograms")
+            .and_then(Json::as_array)
+            .is_some_and(|a| !a.is_empty());
+    match (has_float, has_hist) {
+        (true, true) => "float+histogram",
+        (false, true) => "histogram",
+        (true, false) => "float",
+        (false, false) => "empty",
+    }
+}
+
+/// A result element's identity for order-insensitive comparison: its full
+/// label set plus the channel it uses. The `\u{1f}` unit separator keeps the
+/// two parts from colliding (no label name or value contains it).
+fn series_identity(elem: &Json) -> String {
+    format!("{}\u{1f}{}", label_key(&elem["metric"]), element_channel(elem))
+}
+
+/// A vector element's native `histogram` field, if present and non-null.
+fn histogram_field(elem: &Json) -> Option<&Json> {
+    elem.get("histogram").filter(|v| !v.is_null())
+}
+
+/// A named array field, or an empty slice when the field is absent (Prometheus
+/// omits `values`/`histograms` when a series has no steps of that channel).
+fn array_field<'a>(elem: &'a Json, field: &str) -> &'a [Json] {
+    elem.get(field)
+        .and_then(Json::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or(&[])
+}
+
+/// One `SampleHistogram` bucket's field `i` as a Prometheus value string.
+fn bucket_str(arr: &[Json], i: usize) -> Result<&str, String> {
+    arr[i]
+        .as_str()
+        .ok_or_else(|| format!("histogram bucket field {i} is not a string"))
+}
+
+/// One histogram scalar field (`count`/`sum`) parsed to its `f64`.
+fn histogram_scalar(h: &Json, field: &str) -> Result<f64, String> {
+    let s = h
+        .get(field)
+        .and_then(Json::as_str)
+        .ok_or_else(|| format!("histogram missing string field '{field}'"))?;
+    parse_sample_value(s)
+}
+
+/// Compares one `[boundaries, lower, upper, count]` bucket tuple. The
+/// interval-openness code is an exact integer identity; the lower/upper
+/// boundaries and the per-bucket count are parsed from their value strings and
+/// bit-compared exactly. Bucket structure and counts do not take the entry's
+/// ULP tolerance: that applies only to the histogram's total `count`/`sum`.
+fn bucket_equal(a: &Json, b: &Json) -> Result<bool, String> {
+    let a_arr = a.as_array().ok_or("histogram bucket is not an array")?;
+    let b_arr = b.as_array().ok_or("histogram bucket is not an array")?;
+    if a_arr.len() != 4 || b_arr.len() != 4 {
+        return Err(format!(
+            "histogram bucket has {} / {} elements, expected 4",
+            a_arr.len(),
+            b_arr.len()
+        ));
+    }
+    if a_arr[0] != b_arr[0] {
+        return Ok(false);
+    }
+    for i in [1usize, 2, 3] {
+        let a_v = parse_sample_value(bucket_str(a_arr, i)?)?;
+        let b_v = parse_sample_value(bucket_str(b_arr, i)?)?;
+        if !values_equal(a_v, b_v, None) {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+/// Compares two Prometheus `SampleHistogram` JSON objects
+/// (`{count, sum, buckets}`) for semantic equality: the bucket structure and
+/// per-bucket counts exact, the total `count`/`sum` under the entry's
+/// bit-exact-or-ULP value rule.
+fn histogram_json_equal(a: &Json, b: &Json, tolerance_ulps: Option<u32>) -> Result<bool, String> {
+    if !values_equal(
+        histogram_scalar(a, "count")?,
+        histogram_scalar(b, "count")?,
+        tolerance_ulps,
+    ) {
+        return Ok(false);
+    }
+    if !values_equal(
+        histogram_scalar(a, "sum")?,
+        histogram_scalar(b, "sum")?,
+        tolerance_ulps,
+    ) {
+        return Ok(false);
+    }
+    let a_buckets = array_field(a, "buckets");
+    let b_buckets = array_field(b, "buckets");
+    if a_buckets.len() != b_buckets.len() {
+        return Ok(false);
+    }
+    for (ab, bb) in a_buckets.iter().zip(b_buckets.iter()) {
+        if !bucket_equal(ab, bb)? {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+/// Compares one `[<ts>, <histogram>]` sample pair: the timestamp exact, the
+/// histogram object by [`histogram_json_equal`].
+fn histogram_pair_equal(a: &Json, b: &Json, tolerance_ulps: Option<u32>) -> Result<bool, String> {
+    let a_arr = a.as_array().ok_or("histogram sample is not a 2-element array")?;
+    let b_arr = b.as_array().ok_or("histogram sample is not a 2-element array")?;
+    if a_arr.len() != 2 || b_arr.len() != 2 {
+        return Err(format!(
+            "histogram sample has {} / {} elements, expected 2",
+            a_arr.len(),
+            b_arr.len()
+        ));
+    }
+    let a_ts = a_arr[0]
+        .as_f64()
+        .ok_or("histogram sample timestamp is not a number")?;
+    let b_ts = b_arr[0]
+        .as_f64()
+        .ok_or("histogram sample timestamp is not a number")?;
+    if a_ts != b_ts {
+        return Ok(false);
+    }
+    histogram_json_equal(&a_arr[1], &b_arr[1], tolerance_ulps)
+}
+
 fn vector_result_equal(a: &Json, b: &Json, tolerance_ulps: Option<u32>) -> Result<bool, String> {
     if a["metric"] != b["metric"] {
         return Ok(false);
     }
-    sample_pair_equal(&a["value"], &b["value"], tolerance_ulps)
+    match (histogram_field(a), histogram_field(b)) {
+        (Some(ah), Some(bh)) => histogram_pair_equal(ah, bh, tolerance_ulps),
+        (None, None) => sample_pair_equal(&a["value"], &b["value"], tolerance_ulps),
+        // Channel divergence: one engine returns a float element, the other a
+        // native histogram, for the same series. Never a match.
+        _ => Ok(false),
+    }
 }
 
 fn matrix_result_equal(a: &Json, b: &Json, tolerance_ulps: Option<u32>) -> Result<bool, String> {
     if a["metric"] != b["metric"] {
         return Ok(false);
     }
-    let a_values = a["values"].as_array().ok_or("matrix values not an array")?;
-    let b_values = b["values"].as_array().ok_or("matrix values not an array")?;
+    let a_values = array_field(a, "values");
+    let b_values = array_field(b, "values");
     if a_values.len() != b_values.len() {
         return Ok(false);
     }
@@ -157,12 +325,22 @@ fn matrix_result_equal(a: &Json, b: &Json, tolerance_ulps: Option<u32>) -> Resul
             return Ok(false);
         }
     }
+    let a_hist = array_field(a, "histograms");
+    let b_hist = array_field(b, "histograms");
+    if a_hist.len() != b_hist.len() {
+        return Ok(false);
+    }
+    for (av, bv) in a_hist.iter().zip(b_hist.iter()) {
+        if !histogram_pair_equal(av, bv, tolerance_ulps)? {
+            return Ok(false);
+        }
+    }
     Ok(true)
 }
 
-fn sort_by_label_key(results: &[Json]) -> Vec<Json> {
+fn sort_by_series_identity(results: &[Json]) -> Vec<Json> {
     let mut sorted: Vec<Json> = results.to_vec();
-    sorted.sort_by_key(|r| label_key(&r["metric"]));
+    sorted.sort_by_key(series_identity);
     sorted
 }
 
@@ -379,8 +557,8 @@ fn compare_series(
         ComparisonMode::Unordered
         | ComparisonMode::ExpectError
         | ComparisonMode::RavelErrorPromSuccess => (
-            sort_by_label_key(&prom_results),
-            sort_by_label_key(&ravel_results),
+            sort_by_series_identity(&prom_results),
+            sort_by_series_identity(&ravel_results),
         ),
     };
     for (index, (p, r)) in prom_ordered.iter().zip(ravel_ordered.iter()).enumerate() {
@@ -713,6 +891,241 @@ mod tests {
             compare(ComparisonMode::Unordered, None, &prom, &ravel),
             Verdict::Match
         );
+    }
+
+    // ---- Native-histogram elements (ADR-0108 decision 10) ----
+
+    /// A vector `/api/v1/query` envelope wrapping one native-histogram element.
+    fn histogram_vector(hist: Json) -> Json {
+        json!({
+            "status": "success",
+            "data": {
+                "resultType": "vector",
+                "result": [{"metric": {"__name__": "h"}, "histogram": [1.0, hist]}]
+            }
+        })
+    }
+
+    /// A matrix `/api/v1/query_range` envelope wrapping one native-histogram
+    /// series with a single step.
+    fn histogram_matrix(hist: Json) -> Json {
+        json!({
+            "status": "success",
+            "data": {
+                "resultType": "matrix",
+                "result": [{"metric": {"__name__": "h"}, "histograms": [[1.0, hist]]}]
+            }
+        })
+    }
+
+    /// A three-bucket schema-0 native histogram in Prometheus' JSON shape.
+    fn sample_histogram() -> Json {
+        json!({
+            "count": "6",
+            "sum": "16",
+            "buckets": [[0, "1", "2", "2"], [0, "2", "4", "3"], [0, "4", "8", "1"]]
+        })
+    }
+
+    #[test]
+    fn identical_histogram_vector_elements_match() {
+        let body = histogram_vector(sample_histogram());
+        assert_eq!(
+            compare(ComparisonMode::Unordered, None, &body, &body),
+            Verdict::Match
+        );
+    }
+
+    #[test]
+    fn identical_histogram_matrix_series_match() {
+        let body = histogram_matrix(sample_histogram());
+        assert_eq!(
+            compare(ComparisonMode::Unordered, None, &body, &body),
+            Verdict::Match
+        );
+    }
+
+    /// The silent-zeros shape (ADR-0108 context 1): the grid collapse dropped
+    /// the histogram and emitted a placeholder float. Prometheus returns the
+    /// histogram; pre-fix Ravel returns `value: "0"` for the same series. The
+    /// channel divergence is a mismatch. This is what a range
+    /// `sum(rate(h[5m]))` entry would have flipped red pre-fix.
+    #[test]
+    fn a_float_zero_where_prometheus_returns_a_histogram_is_caught() {
+        let prom = histogram_vector(sample_histogram());
+        let ravel = json!({
+            "status": "success",
+            "data": {
+                "resultType": "vector",
+                "result": [{"metric": {"__name__": "h"}, "value": [1.0, "0"]}]
+            }
+        });
+        assert!(matches!(
+            compare(ComparisonMode::Unordered, None, &prom, &ravel),
+            Verdict::Mismatch(_)
+        ));
+    }
+
+    /// The silent-zeros shape on the range endpoint: a matrix step Prometheus
+    /// returns as a histogram, pre-fix Ravel as an all-zero float step.
+    #[test]
+    fn a_float_zero_matrix_step_where_prometheus_returns_a_histogram_is_caught() {
+        let prom = histogram_matrix(sample_histogram());
+        let ravel = json!({
+            "status": "success",
+            "data": {
+                "resultType": "matrix",
+                "result": [{"metric": {"__name__": "h"}, "values": [[1.0, "0"]]}]
+            }
+        });
+        assert!(matches!(
+            compare(ComparisonMode::Unordered, None, &prom, &ravel),
+            Verdict::Mismatch(_)
+        ));
+    }
+
+    /// The silent-empties shape (ADR-0108 context 2): a bare histogram
+    /// selector or a histogram `rate` whose range arm dropped the histogram
+    /// input, so pre-fix Ravel returns an empty result where Prometheus
+    /// returns a histogram series. Caught as a result-length mismatch.
+    #[test]
+    fn a_dropped_histogram_series_where_prometheus_returns_one_is_caught() {
+        let prom = histogram_matrix(sample_histogram());
+        let ravel = json!({
+            "status": "success",
+            "data": {"resultType": "matrix", "result": []}
+        });
+        assert!(matches!(
+            compare(ComparisonMode::Unordered, None, &prom, &ravel),
+            Verdict::Mismatch(_)
+        ));
+    }
+
+    /// The false-absence shape (ADR-0108 context 3): `absent_over_time(h[15m])`
+    /// with histogram data flowing. Prometheus sees the data and returns empty;
+    /// pre-fix Ravel's float-only fetch sees nothing and returns 1. Caught as a
+    /// result-length mismatch.
+    #[test]
+    fn a_false_absence_marker_where_prometheus_returns_empty_is_caught() {
+        let prom = json!({
+            "status": "success",
+            "data": {"resultType": "vector", "result": []}
+        });
+        let ravel = json!({
+            "status": "success",
+            "data": {
+                "resultType": "vector",
+                "result": [{"metric": {}, "value": [1.0, "1"]}]
+            }
+        });
+        assert!(matches!(
+            compare(ComparisonMode::Unordered, None, &prom, &ravel),
+            Verdict::Mismatch(_)
+        ));
+    }
+
+    /// Two histograms differing only in one bucket's count are a mismatch even
+    /// under a generous total-count/sum tolerance: bucket counts are exact, so
+    /// a wrong bucket cannot hide behind a tolerance meant for the aggregate
+    /// floats.
+    #[test]
+    fn a_bucket_count_divergence_is_caught_even_under_tolerance() {
+        let prom = histogram_vector(sample_histogram());
+        let mut other = sample_histogram();
+        other["buckets"][1][3] = json!("4");
+        let ravel = histogram_vector(other);
+        assert!(matches!(
+            compare(ComparisonMode::Unordered, Some(u32::MAX), &prom, &ravel),
+            Verdict::Mismatch(_)
+        ));
+    }
+
+    /// A bucket boundary difference (a different schema/resolution) is a
+    /// mismatch: the bucket structure is compared exactly.
+    #[test]
+    fn a_bucket_boundary_divergence_is_caught() {
+        let prom = histogram_vector(sample_histogram());
+        let mut other = sample_histogram();
+        other["buckets"][2][2] = json!("16");
+        let ravel = histogram_vector(other);
+        assert!(matches!(
+            compare(ComparisonMode::Unordered, None, &prom, &ravel),
+            Verdict::Mismatch(_)
+        ));
+    }
+
+    /// The histogram's total `count`/`sum` take the entry's ULP tolerance,
+    /// because both engines compute extrapolated rates independently: a
+    /// few-ULP drift in `sum` matches under tolerance and mismatches without.
+    #[test]
+    fn a_histogram_sum_within_tolerance_matches_and_without_it_does_not() {
+        let base = 16.0_f64;
+        let drifted = f64::from_bits(base.to_bits() + 3);
+        let prom = histogram_vector(sample_histogram());
+        let mut other = sample_histogram();
+        other["sum"] = json!(drifted.to_string());
+        let ravel = histogram_vector(other);
+        assert_eq!(
+            compare(ComparisonMode::Unordered, Some(4), &prom, &ravel),
+            Verdict::Match
+        );
+        assert!(matches!(
+            compare(ComparisonMode::Unordered, None, &prom, &ravel),
+            Verdict::Mismatch(_)
+        ));
+    }
+
+    /// A histogram whose buckets are listed in a different order is not the
+    /// same histogram: bucket order is cumulative-ascending and structural.
+    #[test]
+    fn a_reordered_bucket_list_is_a_mismatch() {
+        let prom = histogram_vector(sample_histogram());
+        let reordered = json!({
+            "count": "6",
+            "sum": "16",
+            "buckets": [[0, "2", "4", "3"], [0, "1", "2", "2"], [0, "4", "8", "1"]]
+        });
+        let ravel = histogram_vector(reordered);
+        assert!(matches!(
+            compare(ComparisonMode::Unordered, None, &prom, &ravel),
+            Verdict::Mismatch(_)
+        ));
+    }
+
+    /// Two equal histograms whose boundary strings are formatted differently
+    /// for the same numeric value still match: boundaries are parsed and
+    /// bit-compared, not string-compared.
+    #[test]
+    fn equal_boundaries_formatted_differently_still_match() {
+        let prom = histogram_vector(sample_histogram());
+        let reformatted = json!({
+            "count": "6",
+            "sum": "16",
+            "buckets": [[0, "1.0", "2", "2"], [0, "2", "4", "3"], [0, "4", "8", "1"]]
+        });
+        let ravel = histogram_vector(reformatted);
+        assert_eq!(
+            compare(ComparisonMode::Unordered, None, &prom, &ravel),
+            Verdict::Match
+        );
+    }
+
+    /// A histogram element and a float element for the same label set are a
+    /// channel divergence, caught even when both sides carry one result.
+    #[test]
+    fn a_histogram_vs_float_channel_divergence_is_caught() {
+        let prom = histogram_vector(sample_histogram());
+        let ravel = json!({
+            "status": "success",
+            "data": {
+                "resultType": "vector",
+                "result": [{"metric": {"__name__": "h"}, "value": [1.0, "6"]}]
+            }
+        });
+        assert!(matches!(
+            compare(ComparisonMode::Unordered, None, &prom, &ravel),
+            Verdict::Mismatch(_)
+        ));
     }
 
     #[test]

--- a/crates/ravel-promql-difftest/src/comparator.rs
+++ b/crates/ravel-promql-difftest/src/comparator.rs
@@ -181,7 +181,11 @@ fn element_channel(elem: &Json) -> &'static str {
 /// label set plus the channel it uses. The `\u{1f}` unit separator keeps the
 /// two parts from colliding (no label name or value contains it).
 fn series_identity(elem: &Json) -> String {
-    format!("{}\u{1f}{}", label_key(&elem["metric"]), element_channel(elem))
+    format!(
+        "{}\u{1f}{}",
+        label_key(&elem["metric"]),
+        element_channel(elem)
+    )
 }
 
 /// A vector element's native `histogram` field, if present and non-null.
@@ -277,8 +281,12 @@ fn histogram_json_equal(a: &Json, b: &Json, tolerance_ulps: Option<u32>) -> Resu
 /// Compares one `[<ts>, <histogram>]` sample pair: the timestamp exact, the
 /// histogram object by [`histogram_json_equal`].
 fn histogram_pair_equal(a: &Json, b: &Json, tolerance_ulps: Option<u32>) -> Result<bool, String> {
-    let a_arr = a.as_array().ok_or("histogram sample is not a 2-element array")?;
-    let b_arr = b.as_array().ok_or("histogram sample is not a 2-element array")?;
+    let a_arr = a
+        .as_array()
+        .ok_or("histogram sample is not a 2-element array")?;
+    let b_arr = b
+        .as_array()
+        .ok_or("histogram sample is not a 2-element array")?;
     if a_arr.len() != 2 || b_arr.len() != 2 {
         return Err(format!(
             "histogram sample has {} / {} elements, expected 2",

--- a/crates/ravel-promql/src/eval.rs
+++ b/crates/ravel-promql/src/eval.rs
@@ -2683,6 +2683,41 @@ mod tests {
     }
 
     #[test]
+    fn range_rate_over_a_histogram_does_not_raise_the_non_counter_info() {
+        // A native histogram carries its own counter-reset hint, so Prometheus
+        // does not apply the metric-name heuristic to it: `rate()` over a
+        // histogram series raises no `PossibleNonCounterInfo` even though the
+        // name lacks a counter suffix. The instant arm gets this for free by
+        // reducing floats and histograms into separate values; the range arm
+        // puts both in one matrix, so it emitted the info for a
+        // histogram-only selector. Caught by #580's corpus on its first CI run
+        // as `native_histogram_rate_range`: prometheus=false ravel=true.
+        let source = TestSource::new()
+            .with_histogram_series(
+                &[("__name__", "diff_native_hist")],
+                &[
+                    (minutes(1) * NS_PER_MS, nh(2.0, 10.0)),
+                    (minutes(4) * NS_PER_MS, nh(6.0, 40.0)),
+                ],
+            )
+            .expect("valid histogram series");
+        let (_value, annotations) = Evaluator::new()
+            .eval_range_hist_annotated(
+                &source,
+                "rate(diff_native_hist[5m])",
+                minutes(5),
+                minutes(5),
+                minutes(1),
+            )
+            .expect("range evaluates");
+        assert!(
+            annotations.infos().is_empty(),
+            "no non-counter-name info for a histogram rate: {:?}",
+            annotations.infos()
+        );
+    }
+
+    #[test]
     fn range_selector_serves_native_histogram_elements() {
         // A bare native-histogram range selector must produce a matrix of
         // histogram elements, not vanish. Before the fix `eval_range_selector`

--- a/crates/ravel-promql/src/functions/mod.rs
+++ b/crates/ravel-promql/src/functions/mod.rs
@@ -483,9 +483,17 @@ pub(crate) fn eval_range_call(
                     }
                 },
             )?;
-            // Gated on the reduced output, matching the instant arm and
-            // Prometheus (the check follows the too-few-samples early return).
-            maybe_info_non_counter_selector_name(call.func.name, arg, !result.is_empty(), ctx);
+            // Gated on the reduced FLOAT output, matching the instant arm and
+            // Prometheus (the check follows the too-few-samples early return,
+            // and lives in the float branch: a native histogram carries its own
+            // counter-reset hint, so the metric-name heuristic does not apply
+            // to it). The instant arm gets this for free because it reduces
+            // floats and histograms into separate values; here both land in one
+            // matrix, so the float elements have to be counted explicitly.
+            let produced_a_float = result
+                .iter()
+                .any(|(_, samples)| samples.iter().any(|s| s.histogram.is_none()));
+            maybe_info_non_counter_selector_name(call.func.name, arg, produced_a_float, ctx);
             Ok(result)
         }
         // `histogram_quantile`/`histogram_fraction` group and reduce a whole

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -1063,7 +1063,7 @@ conformance_table`; regenerate that same command with
 `RAVEL_UPDATE_CONFORMANCE_TABLE=1`. Do not edit the block between
 the markers by hand.
 
-Surface: 132 constructs over 221 corpus entries in 10 corpus files.
+Surface: 132 constructs over 231 corpus entries in 10 corpus files.
 
 | State | Constructs |
 | --- | --- |


### PR DESCRIPTION
The differential gate could not see native histograms at all. The comparator
knew only the `value` field, so a Ravel result that returned a float zero, an
empty series, or a false absence marker where Prometheus returned a histogram
compared as agreeing. Every bug this epic fixed was invisible to the gate that
exists to catch exactly that.

The comparator now recognizes the `histograms` field on vector and matrix
elements and compares a canonical semantic form: schema, zero threshold and
count, spans and bucket counts exact, with `count` and `sum` under the
existing tolerance rules because both engines compute extrapolated rates
independently. Series identity includes which channel an element uses, so a
histogram answered as a float is a mismatch rather than a near miss. Byte
layout is deliberately not compared: two equal histograms can differ in span
layout and comparing bytes would fail correct answers.

Ten corpus entries cover the shapes ADR-0108 enumerated, each with an instant
counterpart: a bare selector, `rate`, `sum(rate(...))`, `count_over_time` and
`absent_over_time` with histogram data flowing.

Two things this does not establish, stated because a green gate is exactly
what invites the assumption. The pinned-Prometheus differential run did not
execute on the executor: no binary was available, the test skips when
`RAVEL_DIFFTEST` is unset, and that run is CI's to make. What was verified
locally is that the comparator distinguishes each pre-fix shape from the
correct answer, via unit tests that feed the exact pre-fix JSON and assert a
mismatch. And the corpus does not cover the three shapes found during this
epic and filed as #643, #649 and #650; those need their entries added as part
of their own fixes, or they will ship green a second time.

Fixes: #580
Refs: #573
