### PR TITLE
feat(ravel-query): attach ADR-0046 disk tier at RSEG/RLOG read funnels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4959,6 +4959,7 @@ dependencies = [
  "ravel-types",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror",
  "tokio",
  "tonic",

--- a/crates/ravel-query/Cargo.toml
+++ b/crates/ravel-query/Cargo.toml
@@ -97,6 +97,11 @@ ravel-cache = { workspace = true }
 # so this is acyclic.
 ravel-maintain = { path = "../ravel-maintain", version = "0.10.0" }
 proptest = { workspace = true }
+# The ADR-0046 disk cache tier (crates/ravel-query/src/cache_correctness.rs)
+# needs a real on-disk directory to construct a `ravel_cache::DiskCache`; the
+# acceptance and double-counting tests build one in a temp dir. Version from
+# [workspace.dependencies].
+tempfile = { workspace = true }
 tokio = { workspace = true }
 tower = { workspace = true, features = ["util"] }
 uuid = { workspace = true }

--- a/crates/ravel-query/src/cache_correctness.rs
+++ b/crates/ravel-query/src/cache_correctness.rs
@@ -26,7 +26,7 @@
 use std::sync::Arc;
 
 use bytes::Bytes;
-use ravel_cache::{Cache, CacheKey, CacheLimits};
+use ravel_cache::{Cache, CacheKey, CacheLimits, DiskCache, TieredCache};
 use ravel_catalog::{SegmentLevel, SegmentRef};
 use ravel_logseg::writer::ObjectIdentity;
 use ravel_logseg::{AttrValue, LogRecord, RlogConfig, RlogWriter, stream_attrs_bytes};
@@ -45,8 +45,8 @@ use uuid::Uuid;
 
 use crate::fetcher::FetchedHistogramSeries;
 use crate::{
-    FetchError, FetchStats, FetchedSeriesSoa, LogFetchError, LogFetchOutput, LogQuery,
-    LogSegmentFetcher, SegmentFetcher,
+    BlockRangeFetcher, FetchError, FetchStats, FetchedSeriesSoa, LogFetchError, LogFetchOutput,
+    LogQuery, LogSegmentFetcher, SegmentFetcher,
 };
 
 const RSEG_TENANT: TenantHash = TenantHash([13u8; 16]);
@@ -1037,5 +1037,358 @@ async fn rlog_the_same_tenant_reads_its_own_cached_bytes_without_consulting_the_
         fault_store.fault_count(Op::Get, FaultKind::Permanent),
         0,
         "a same-tenant cache hit must not consult the store at all"
+    );
+}
+
+// ---- ADR-0046 disk tier (issue #95) --------------------------------------
+//
+// The tests above wire a RAM-only `Cache` into each funnel through
+// `with_cache`, which is what every production caller builds today (a query
+// node has no disk tier until #97 wires `--cache-dir`). The tests below prove
+// the funnels are equally correct when `with_cache` is handed a `TieredCache`
+// (RAM over disk), the second configuration the `ReadCache` enum this task
+// introduced can hold. `SegmentFetcher`/`LogSegmentFetcher`/`BlockRangeFetcher`
+// accept either via `impl Into<ReadCache>`, so these construct the disk-backed
+// variant directly, exactly as #97's server wiring will.
+
+/// Generous limits: nothing this suite's fixtures produce is evicted or refused.
+fn generous_cache_limits() -> CacheLimits {
+    CacheLimits::new(16 * 1024 * 1024, 100, 16 * 1024 * 1024)
+}
+
+/// RAM limits that refuse every real-sized entry (max entry bytes 1), so the
+/// RAM tier of a `TieredCache` stays empty and every cache hit falls through to
+/// the disk tier -- the configuration ADR-0046 decision 4's disk-tier
+/// acceptance gate needs.
+/// [`evicted_entry_falls_back_to_store_and_produces_correct_result`] above
+/// proves a `CacheLimits::new(1, 1, 1)` cache admits nothing.
+fn ram_rejecting_limits() -> CacheLimits {
+    CacheLimits::new(1, 1, 1)
+}
+
+/// ADR-0046 decision 4's acceptance gate on the DISK tier specifically
+/// (issue #95): a disk-served hit returning deliberately corrupted bytes must
+/// never let a query return a wrong result. Mirrors
+/// [`corrupted_cache_hits_never_produce_wrong_results`] but wires a
+/// `TieredCache` whose RAM tier refuses admission (so every hit is served from
+/// disk, proven by the disk hit counter) and is in corruption mode (so the
+/// disk-served bytes arrive corrupted, through `TieredCache`'s serve-time
+/// transform). Both fixtures cache the whole object under one key, so the
+/// corruption lands on the footer/header and the read fails closed with a typed
+/// error rather than decoding wrong data.
+///
+/// Prove-the-test: change either RAM tier below from `Cache::with_corruption` to
+/// `Cache::new` and the disk-served hit returns clean bytes, so the second fetch
+/// succeeds and the `is_err()` assertions fire. That corruption mode is exactly
+/// what this gate depends on. (Demonstrated failing during development by that
+/// substitution.)
+#[tokio::test]
+async fn corrupted_disk_tier_hits_never_produce_wrong_results() {
+    let tmp = tempfile::TempDir::new().expect("temp dir for the disk cache tier");
+
+    // Uncached baselines.
+    let (rseg_store, rseg_ref) = write_rseg_segment().await;
+    let rseg_backend: Arc<dyn ObjectStoreBackend> = rseg_store;
+    let (truth_soa, _s, truth_hist) = SegmentFetcher::new(rseg_backend.clone())
+        .fetch_soa_and_histograms(RSEG_TENANT, &rseg_ref, &[])
+        .await
+        .expect("uncached RSEG baseline");
+
+    let (rlog_store, rlog_ref) = write_rlog_segment().await;
+    let rlog_backend: Arc<dyn ObjectStoreBackend> = rlog_store;
+    let query = LogQuery::new(0, 19);
+    let truth_log = LogSegmentFetcher::new(rlog_backend.clone())
+        .fetch_accounted_with_tenant(&rlog_ref, RLOG_TENANT, &query, &QueryAccounting::new())
+        .await
+        .expect("uncached RLOG baseline")
+        .expect("segment overlaps");
+
+    // Disk-backed, corruption-mode caches: RAM refuses admission (hits come from
+    // disk), disk is generous. One per funnel so each disk hit counter is clean.
+    let rseg_disk = DiskCache::new(tmp.path().join("rseg"), generous_cache_limits());
+    let rseg_disk_metrics = rseg_disk.metrics();
+    let rseg_cache = Arc::new(TieredCache::new(
+        Cache::<crate::fetcher::CacheFetchError>::with_corruption(ram_rejecting_limits()),
+        rseg_disk,
+    ));
+    let rlog_disk = DiskCache::new(tmp.path().join("rlog"), generous_cache_limits());
+    let rlog_disk_metrics = rlog_disk.metrics();
+    let rlog_cache = Arc::new(TieredCache::new(
+        Cache::<crate::fetcher::CacheFetchError>::with_corruption(ram_rejecting_limits()),
+        rlog_disk,
+    ));
+
+    let seg_fetcher = SegmentFetcher::new(rseg_backend).with_cache(rseg_cache.clone());
+    let log_fetcher = LogSegmentFetcher::new(rlog_backend).with_cache(rlog_cache.clone());
+
+    // First call per funnel: a genuine both-tier miss populating the disk tier
+    // with CLEAN bytes (corruption applies only on a hit). Must match truth.
+    let acc = QueryAccounting::new();
+    let rseg_miss = seg_fetcher
+        .fetch_soa_and_histograms_accounted(RSEG_TENANT, &rseg_ref, &[], &acc)
+        .await;
+    assert_soa_hist_matches_or_errors(rseg_miss, &truth_soa, &truth_hist);
+    let log_acc = QueryAccounting::new();
+    let log_miss = log_fetcher
+        .fetch_accounted_with_tenant(&rlog_ref, RLOG_TENANT, &query, &log_acc)
+        .await;
+    assert_log_matches_or_errors(log_miss, &truth_log);
+
+    let rseg_hits_before = rseg_disk_metrics.snapshot().hits;
+    let rlog_hits_before = rlog_disk_metrics.snapshot().hits;
+
+    // Second call per funnel: RAM is empty, so the whole object is served from
+    // the disk tier -- corrupted. The read must fail closed with a typed error.
+    let rseg_hit = seg_fetcher
+        .fetch_soa_and_histograms_accounted(RSEG_TENANT, &rseg_ref, &[], &acc)
+        .await;
+    assert!(
+        rseg_hit.is_err(),
+        "a corrupted whole-object disk hit must fail closed with a typed error, not decode wrong \
+         data; got Ok"
+    );
+    let log_hit = log_fetcher
+        .fetch_accounted_with_tenant(&rlog_ref, RLOG_TENANT, &query, &log_acc)
+        .await;
+    assert!(
+        log_hit.is_err(),
+        "a corrupted whole-object disk hit on the log funnel must fail closed with a typed error; \
+         got {log_hit:?}"
+    );
+
+    // The hits were served from the DISK tier, not RAM (RAM refused admission):
+    // the gate this test names would not otherwise reach the disk tier at all.
+    assert!(
+        rseg_disk_metrics.snapshot().hits > rseg_hits_before,
+        "the RSEG hit must have been served from the disk tier"
+    );
+    assert!(
+        rlog_disk_metrics.snapshot().hits > rlog_hits_before,
+        "the RLOG hit must have been served from the disk tier"
+    );
+    assert!(
+        rseg_cache.is_empty() && rlog_cache.is_empty(),
+        "the RAM tier must be empty, so every hit was disk-served"
+    );
+}
+
+/// Deliverable 5: the same correctness path the RAM-only
+/// [`cache_hit_returns_bit_identical_result_to_uncached_fetch`] exercises, but
+/// against a disk-backed tier configuration with the hit served from disk. A
+/// CLEAN disk-tier hit must be bit-identical (including the NaN sample) to the
+/// uncached fetch, proving the disk tier introduces no regression on the
+/// non-corrupt path.
+#[tokio::test]
+async fn clean_disk_tier_hit_is_bit_identical_to_uncached_fetch() {
+    let tmp = tempfile::TempDir::new().expect("temp dir for the disk cache tier");
+    let (store, seg_ref) = write_rseg_segment().await;
+    let backend: Arc<dyn ObjectStoreBackend> = store;
+
+    let (mut truth, _s) = SegmentFetcher::new(backend.clone())
+        .fetch_soa(RSEG_TENANT, &seg_ref, &[])
+        .await
+        .expect("uncached fetch");
+    truth.sort_by_key(|s| s.series_id.0);
+
+    // RAM refuses admission so the hit is disk-served; no corruption.
+    let disk = DiskCache::new(tmp.path().join("clean"), generous_cache_limits());
+    let disk_metrics = disk.metrics();
+    let cache = Arc::new(TieredCache::new(
+        Cache::<crate::fetcher::CacheFetchError>::new(ram_rejecting_limits()),
+        disk,
+    ));
+    let fetcher = SegmentFetcher::new(backend).with_cache(cache.clone());
+
+    let (mut miss, _s) = fetcher
+        .fetch_soa(RSEG_TENANT, &seg_ref, &[])
+        .await
+        .expect("first fetch (both-tier miss)");
+    miss.sort_by_key(|s| s.series_id.0);
+    let hits_before = disk_metrics.snapshot().hits;
+    let (mut hit, _s) = fetcher
+        .fetch_soa(RSEG_TENANT, &seg_ref, &[])
+        .await
+        .expect("second fetch (disk-served hit)");
+    hit.sort_by_key(|s| s.series_id.0);
+
+    assert!(
+        disk_metrics.snapshot().hits > hits_before,
+        "the second fetch must be served from the disk tier"
+    );
+    assert!(
+        cache.is_empty(),
+        "RAM refused admission, so the hit was disk-served"
+    );
+    assert_eq!(miss.len(), truth.len());
+    assert_eq!(hit.len(), truth.len());
+    for (a, b) in miss.iter().zip(truth.iter()) {
+        assert!(
+            soa_bits_eq(a, b),
+            "disk-tier miss result must match uncached"
+        );
+    }
+    for (a, b) in hit.iter().zip(truth.iter()) {
+        assert!(
+            soa_bits_eq(a, b),
+            "clean disk-tier hit result must be bit-identical to uncached"
+        );
+    }
+}
+
+/// Deliverable 6: with NO disk tier configured -- the RAM-only `ReadCache::Ram`
+/// variant every production caller builds -- both funnels return results
+/// byte-for-byte identical to a fetch with no cache at all. This pins the
+/// "behavior is exactly today's" guarantee the enum change must preserve; the
+/// entire RAM suite above passing unchanged is the broader proof.
+#[tokio::test]
+async fn no_disk_tier_ram_only_matches_uncached_on_both_funnels() {
+    // RSEG.
+    let (rseg_store, rseg_ref) = write_rseg_segment().await;
+    let rseg_backend: Arc<dyn ObjectStoreBackend> = rseg_store;
+    let (mut truth_soa, _s) = SegmentFetcher::new(rseg_backend.clone())
+        .fetch_soa(RSEG_TENANT, &rseg_ref, &[])
+        .await
+        .expect("uncached RSEG fetch");
+    truth_soa.sort_by_key(|s| s.series_id.0);
+
+    let ram: Arc<Cache<crate::fetcher::CacheFetchError>> =
+        Arc::new(Cache::new(generous_cache_limits()));
+    let seg_fetcher = SegmentFetcher::new(rseg_backend).with_cache(ram);
+    // Miss then hit: both must equal the uncached truth.
+    for pass in ["ram miss", "ram hit"] {
+        let (mut got, _s) = seg_fetcher
+            .fetch_soa(RSEG_TENANT, &rseg_ref, &[])
+            .await
+            .unwrap_or_else(|e| panic!("RSEG {pass} fetch: {e:?}"));
+        got.sort_by_key(|s| s.series_id.0);
+        assert_eq!(got.len(), truth_soa.len(), "RSEG {pass} series count");
+        for (a, b) in got.iter().zip(truth_soa.iter()) {
+            assert!(
+                soa_bits_eq(a, b),
+                "RSEG {pass} must match uncached byte-for-byte"
+            );
+        }
+    }
+
+    // RLOG.
+    let (rlog_store, rlog_ref) = write_rlog_segment().await;
+    let rlog_backend: Arc<dyn ObjectStoreBackend> = rlog_store;
+    let query = LogQuery::new(0, 19);
+    let truth_log = LogSegmentFetcher::new(rlog_backend.clone())
+        .fetch_accounted_with_tenant(&rlog_ref, RLOG_TENANT, &query, &QueryAccounting::new())
+        .await
+        .expect("uncached RLOG fetch")
+        .expect("segment overlaps");
+
+    let ram: Arc<Cache<crate::fetcher::CacheFetchError>> =
+        Arc::new(Cache::new(generous_cache_limits()));
+    let log_fetcher = LogSegmentFetcher::new(rlog_backend).with_cache(ram);
+    for pass in ["ram miss", "ram hit"] {
+        let got = log_fetcher
+            .fetch_accounted_with_tenant(&rlog_ref, RLOG_TENANT, &query, &QueryAccounting::new())
+            .await
+            .unwrap_or_else(|e| panic!("RLOG {pass} fetch: {e:?}"))
+            .expect("segment overlaps");
+        assert_eq!(
+            got.records, truth_log.records,
+            "RLOG {pass} must match uncached byte-for-byte"
+        );
+    }
+}
+
+/// The double-counting discipline from ADR-0046's `TieredCache::get` docstring
+/// (issue #95, the "Read first" section): `BlockRangeFetcher`'s peek-then-defer
+/// pattern -- peek each candidate block with `ReadCache::get` (the one accounted
+/// miss) and resolve a miss through a later coalesced fetch -- must record
+/// exactly ONE miss per logical cache miss on the tiered tier's `CacheMetrics`,
+/// not two.
+///
+/// The RAM-only `Cache` is the oracle: its `get_or_fetch` is miss-only and never
+/// re-peeks, so a cold block-range fetch records exactly one miss per logical
+/// lookup -- the correct count. A `TieredCache` cold fetch of the same object
+/// with the same protocol must record the SAME number of misses on its RAM tier.
+/// The fetcher achieves this by resolving a peeked-then-deferred block through
+/// `ReadCache::fetch_peeked` (which `insert`s on the tiered tier rather than
+/// re-entering `TieredCache::get_or_fetch`, whose internal peek would count a
+/// second miss).
+///
+/// Prove-the-test: replace the two `cache.fetch_peeked(...)` calls in
+/// `BlockRangeFetcher::fetch_run` (log_fetcher.rs) with `cache.get_or_fetch(...)`
+/// and the tiered tier's miss count exceeds the oracle, so the final assertion
+/// fires. (Verified failing by that substitution during development.)
+#[tokio::test]
+async fn block_range_peek_then_defer_records_one_miss_per_logical_miss() {
+    let (store, seg_ref) = write_rlog_segment().await;
+    let backend: Arc<dyn ObjectStoreBackend> = store;
+    let (ts_min, ts_max) = (0, 19);
+
+    // Force the true block-range path: whole-object crossover off (threshold 0),
+    // a 64-byte suffix probe that does not cover the front blocks (so they are
+    // genuinely fetched, not probe-resident), and the coverage crossover
+    // disabled (>1.0) so it does not fall back to a whole-object GET that would
+    // skip fetch_blocks' per-block peek entirely.
+    let configure = |br: BlockRangeFetcher| {
+        br.with_whole_object_threshold(0)
+            .with_suffix_len(64)
+            .with_coverage_threshold(2.0)
+    };
+
+    // Oracle: RAM-only cache. `Cache::get_or_fetch` is miss-only, so each logical
+    // miss is exactly one `CacheMetrics` miss.
+    let ram_only: Arc<Cache<crate::fetcher::CacheFetchError>> =
+        Arc::new(Cache::new(generous_cache_limits()));
+    let ram_metrics_oracle = ram_only.metrics();
+    let br_ram = configure(BlockRangeFetcher::new(backend.clone()).with_cache(ram_only));
+    let (_bytes, stats) = br_ram
+        .fetch_object(
+            &seg_ref,
+            RLOG_TENANT,
+            ts_min,
+            ts_max,
+            &QueryAccounting::new(),
+        )
+        .await
+        .expect("oracle block-range fetch");
+    let oracle_misses = ram_metrics_oracle.snapshot().misses;
+
+    // The path must be genuinely exercised, or the discipline is untested.
+    assert!(
+        !stats.whole_object,
+        "the fixture must take the ranged path, not a whole-object crossover"
+    );
+    assert!(
+        stats.candidate_blocks >= 1,
+        "at least one candidate block must be fetched through the peek-then-defer path"
+    );
+    assert!(
+        oracle_misses >= 1,
+        "the cold fetch must record at least one miss"
+    );
+
+    // Tiered cache: same object, same protocol, cold. The RAM tier's miss count
+    // must equal the oracle -- a double-count would inflate it.
+    let tmp = tempfile::TempDir::new().expect("temp dir for the disk cache tier");
+    let ram = Cache::<crate::fetcher::CacheFetchError>::new(generous_cache_limits());
+    let ram_metrics_tiered = ram.metrics();
+    let disk = DiskCache::new(tmp.path().to_path_buf(), generous_cache_limits());
+    let tiered = Arc::new(TieredCache::new(ram, disk));
+    let br_tiered = configure(BlockRangeFetcher::new(backend).with_cache(tiered));
+    br_tiered
+        .fetch_object(
+            &seg_ref,
+            RLOG_TENANT,
+            ts_min,
+            ts_max,
+            &QueryAccounting::new(),
+        )
+        .await
+        .expect("tiered block-range fetch");
+
+    assert_eq!(
+        ram_metrics_tiered.snapshot().misses,
+        oracle_misses,
+        "the tiered tier must record exactly one miss per logical cache miss (peek-then-defer), \
+         not two: a second miss layered on the deferred fetch would inflate this above the \
+         RAM-only oracle of {oracle_misses}"
     );
 }

--- a/crates/ravel-query/src/fetcher.rs
+++ b/crates/ravel-query/src/fetcher.rs
@@ -4,7 +4,7 @@
 
 use bytes::Bytes;
 use futures::future::join_all;
-use ravel_cache::{Cache, CacheKey, SingleFlightError};
+use ravel_cache::{Cache, CacheKey, SingleFlightError, Source, TieredCache};
 use ravel_catalog::{SegmentLevel, SegmentRef};
 use ravel_object_store::{Etag, GetOutcome, GetRange, ObjectStoreBackend, StoreError, Version};
 use ravel_promql::{LabelMatcher, matches_series};
@@ -166,6 +166,150 @@ pub enum CacheFetchError {
 impl From<StoreError> for CacheFetchError {
     fn from(err: StoreError) -> Self {
         CacheFetchError::Store(std::sync::Arc::new(err))
+    }
+}
+
+/// The read-cache handle a fetcher holds (ADR-0046 decision 1), either the RAM
+/// tier alone or the RAM-over-disk [`TieredCache`], behind one interface the
+/// RSEG and RLOG read funnels consult without committing to a concrete tier.
+///
+/// - [`ReadCache::Ram`] is today's exact behavior: the bare RAM [`Cache`] every
+///   existing caller constructs. A query node has no disk tier until #97 wires
+///   `--cache-dir`, so this is the only variant production builds; it writes no
+///   local files and needs no Tokio runtime to construct. Its
+///   [`Cache::get_or_fetch`] is miss-only and never re-peeks, so a caller may
+///   peek with [`ReadCache::get`] and then resolve a miss through
+///   [`ReadCache::fetch_peeked`] with the peek as the one accounted miss.
+/// - [`ReadCache::Tiered`] is the RAM-over-disk handle: a disk-served hit is
+///   single-flighted and corruption-gated per ADR-0046 decisions 3-5. It is
+///   constructed only by this crate's tests today (and #97's wiring later); the
+///   funnels route through it wherever it is present.
+///
+/// This mirrors the precedent issue #96 set for `ravel-catalog`'s byte cache
+/// (`ByteCache`): a small tier-dispatching wrapper rather than committing each
+/// fetcher field to one concrete type, so a RAM-only caller never has to invent
+/// a disabled `DiskCache`. Both variants carry the same [`CacheFetchError`]
+/// upstream-fetch error (the tiered single-flight already requires a `Clone`
+/// error and `CacheFetchError` is), so unlike `ByteCache` the two share one
+/// error type.
+#[derive(Clone)]
+pub enum ReadCache {
+    /// RAM tier only (no disk configured): today's exact behavior.
+    Ram(std::sync::Arc<Cache<CacheFetchError>>),
+    /// RAM over local disk (ADR-0046 decision 3): disk-served hits are
+    /// single-flighted and corruption-gated.
+    Tiered(std::sync::Arc<TieredCache<CacheFetchError>>),
+}
+
+impl From<std::sync::Arc<Cache<CacheFetchError>>> for ReadCache {
+    fn from(ram: std::sync::Arc<Cache<CacheFetchError>>) -> Self {
+        ReadCache::Ram(ram)
+    }
+}
+
+impl From<std::sync::Arc<TieredCache<CacheFetchError>>> for ReadCache {
+    fn from(tiered: std::sync::Arc<TieredCache<CacheFetchError>>) -> Self {
+        ReadCache::Tiered(tiered)
+    }
+}
+
+impl ReadCache {
+    /// Peek every tier with no upstream fetch, serving a hit and returning
+    /// `None` on a genuine miss (recording its own hit/miss on the cache's
+    /// `CacheMetrics`). The fetch-free half a caller uses when its miss handling
+    /// cannot be expressed as one upstream-fetch closure: `BlockRangeFetcher`'s
+    /// per-block peek, which defers a miss to a later coalesced GET.
+    pub(crate) fn get(&self, key: &CacheKey) -> Option<Bytes> {
+        match self {
+            ReadCache::Ram(ram) => ram.get(key),
+            ReadCache::Tiered(tiered) => tiered.get(key),
+        }
+    }
+
+    /// Admit already-fetched, already-verified bytes into every tier with no
+    /// upstream fetch and no single-flight (`BlockRangeFetcher`'s per-block
+    /// admission, ADR-0107 decision 3). Records no miss, so it never layers a
+    /// second miss on top of one a prior [`get`](Self::get) peek already
+    /// recorded for the same key.
+    pub(crate) fn insert(&self, key: CacheKey, value: Bytes) {
+        match self {
+            ReadCache::Ram(ram) => ram.insert(key, value),
+            ReadCache::Tiered(tiered) => tiered.insert(key, value),
+        }
+    }
+
+    /// Read `key` through the cache, running `fetch` only on a genuine miss in
+    /// every tier, and reporting whether the bytes came from a tier
+    /// ([`Source::Cache`]) or from the fetch ([`Source::Upstream`]) so the caller
+    /// accounts for the hit/miss exactly once. This is the single-call
+    /// read-through the RSEG funnel ([`SegmentFetcher::cached_get`]) and the
+    /// block-range extent/probe funnel ([`BlockRangeFetcher::cached_extent`])
+    /// use; the caller must NOT also peek with [`get`](Self::get) first (that
+    /// would record the miss twice on the tiered tier).
+    ///
+    /// The tiered tier's [`TieredCache::get_or_fetch`] peeks both tiers
+    /// internally and returns the real [`Source`]. The RAM tier's
+    /// [`Cache::get_or_fetch`] is miss-only, so the RAM branch peeks once here (a
+    /// hit is [`Source::Cache`]) and runs the miss-only fetch on a miss (always
+    /// [`Source::Upstream`]); neither branch counts the miss twice.
+    pub(crate) async fn get_or_fetch<F, Fut>(
+        &self,
+        key: CacheKey,
+        fetch: F,
+    ) -> Result<(Bytes, Source), SingleFlightError<CacheFetchError>>
+    where
+        F: FnOnce() -> Fut + Send,
+        Fut: std::future::Future<Output = Result<Bytes, CacheFetchError>> + Send,
+    {
+        match self {
+            ReadCache::Tiered(tiered) => tiered.get_or_fetch(key, fetch).await,
+            ReadCache::Ram(ram) => {
+                if let Some(bytes) = ram.get(&key) {
+                    return Ok((bytes, Source::Cache));
+                }
+                ram.get_or_fetch(key, fetch)
+                    .await
+                    .map(|bytes| (bytes, Source::Upstream))
+            }
+        }
+    }
+
+    /// Resolve a key the caller ALREADY peeked-and-missed with
+    /// [`get`](Self::get) (`BlockRangeFetcher`'s peek-then-defer coalesced
+    /// fetch): run `fetch` and admit the result, WITHOUT recording a second miss
+    /// on top of the peek's.
+    ///
+    /// The RAM tier uses its miss-only [`Cache::get_or_fetch`], which
+    /// single-flights concurrent callers onto one `fetch` and never re-peeks, so
+    /// the caller's earlier `get` stays the one accounted miss while
+    /// cross-partition coordination is preserved (ADR-0102 decision 1). The
+    /// tiered tier cannot reuse `get_or_fetch` here: it peeks both tiers again,
+    /// which would record a SECOND miss for a key the caller already peeked
+    /// ([`TieredCache::get`]'s documented double-count pitfall). It therefore
+    /// runs `fetch` directly and admits via [`TieredCache::insert`] (no miss
+    /// recorded), the fetch-free discipline ADR-0046 prescribes for a
+    /// peeked-then-deferred key. `fetch`'s own coalescing -- `BlockRangeFetcher`
+    /// splits one range GET into per-block entries inside the closure -- is
+    /// unaffected either way.
+    pub(crate) async fn fetch_peeked<F, Fut>(
+        &self,
+        key: CacheKey,
+        fetch: F,
+    ) -> Result<Bytes, SingleFlightError<CacheFetchError>>
+    where
+        F: FnOnce() -> Fut + Send,
+        Fut: std::future::Future<Output = Result<Bytes, CacheFetchError>> + Send,
+    {
+        match self {
+            ReadCache::Ram(ram) => ram.get_or_fetch(key, fetch).await,
+            ReadCache::Tiered(tiered) => match fetch().await {
+                Ok(bytes) => {
+                    tiered.insert(key, bytes.clone());
+                    Ok(bytes)
+                }
+                Err(err) => Err(SingleFlightError::Upstream(err)),
+            },
+        }
     }
 }
 
@@ -374,10 +518,12 @@ pub struct SegmentFetcher {
     /// ADR-0046's read cache, consulted by `guarded_get` for every
     /// byte-range (and whole-object) GET. `None` -- the default from
     /// `new` -- reproduces exactly the pre-cache behavior: every GET goes
-    /// to the store. Shared across clones, and safe to share across
-    /// tenants: the cache key is derived per call from the caller-supplied
-    /// `tenant_hash`, never fixed on the fetcher itself.
-    cache: Option<std::sync::Arc<Cache<CacheFetchError>>>,
+    /// to the store. Either tier configuration (RAM-only or RAM-over-disk,
+    /// see [`ReadCache`]); every production caller builds the RAM variant.
+    /// Shared across clones, and safe to share across tenants: the cache key
+    /// is derived per call from the caller-supplied `tenant_hash`, never
+    /// fixed on the fetcher itself.
+    cache: Option<ReadCache>,
 }
 
 impl SegmentFetcher {
@@ -398,9 +544,14 @@ impl SegmentFetcher {
     /// Wires ADR-0046's read cache into every GET `guarded_get` issues
     /// (decision 1). A `SegmentFetcher` built with plain `new` and never
     /// given a cache behaves exactly as it did before this cache existed.
+    ///
+    /// Accepts either tier configuration through [`ReadCache`]: an
+    /// `Arc<Cache<CacheFetchError>>` (RAM-only, what every production caller
+    /// passes) or an `Arc<TieredCache<CacheFetchError>>` (RAM over disk) both
+    /// convert via [`From`], so existing call sites are unchanged.
     #[must_use]
-    pub fn with_cache(mut self, cache: std::sync::Arc<Cache<CacheFetchError>>) -> Self {
-        self.cache = Some(cache);
+    pub fn with_cache(mut self, cache: impl Into<ReadCache>) -> Self {
+        self.cache = Some(cache.into());
         self
     }
 
@@ -584,7 +735,7 @@ impl SegmentFetcher {
     #[allow(clippy::too_many_arguments)]
     async fn cached_get(
         &self,
-        cache: &std::sync::Arc<Cache<CacheFetchError>>,
+        cache: &ReadCache,
         seg_ref: &SegmentRef,
         tenant_hash: TenantHash,
         range: GetRange,
@@ -596,20 +747,15 @@ impl SegmentFetcher {
         let key = seg_ref.data_object_key.as_str();
         let cache_key = CacheKey::new(tenant_hash.0, seg_ref.content_hash, start, end - start);
 
-        if let Some(bytes) = cache.get(&cache_key) {
-            accounting.record_cache_hit();
-            accounting.add_cache_bytes(bytes.len() as u64);
-            // Bytes were resident in the cache before this call asked, so no
-            // store round trip happened and this call adds nothing to its
-            // span's S3 counts (ADR-0044 decision 5).
-            return Ok((
-                placeholder_outcome(bytes, seg_ref.object_size),
-                GetCost::default(),
-            ));
-        }
-        accounting.record_cache_miss();
-
-        let bytes = cache
+        // One read-through call, then account for it from the returned
+        // [`Source`]. A single call avoids the peek-then-`get_or_fetch`
+        // double-count on the tiered tier (see [`ReadCache::get_or_fetch`] and
+        // [`TieredCache::get`]): [`Source::Cache`] means the bytes were resident
+        // in a tier before this call asked (a hit, possibly disk-served -- no
+        // store round trip, so nothing added to this span's S3 counts), and
+        // [`Source::Upstream`] means the store GET inside the closure ran (a
+        // leader miss) or this call rode another's in-flight GET (a follower).
+        let (bytes, source) = cache
             .get_or_fetch(cache_key, || async move {
                 let got = self
                     .store_get(key, range, accounting)
@@ -656,19 +802,30 @@ impl SegmentFetcher {
                     ),
                 },
             })?;
-        // A miss issued one store GET for these bytes (leader), or rode another
-        // caller's in-flight GET (follower). Either way attribute one logical
-        // GET, as `log_fetcher.rs`'s `fetch_accounted_with_tenant` does: it does
-        // not try to distinguish the rare follower, since recording one GET
-        // bounds this call's own attribution and never under-counts the query
-        // total. `record_cache_hit` above (the only zero-cost path) is the sole
-        // case that came from cache, so this arm always crossed the network from
-        // this caller's point of view.
-        let cost = GetCost {
-            requests: 1,
-            bytes: bytes.len() as u64,
-        };
-        Ok((placeholder_outcome(bytes, seg_ref.object_size), cost))
+        match source {
+            Source::Cache => {
+                accounting.record_cache_hit();
+                accounting.add_cache_bytes(bytes.len() as u64);
+                Ok((
+                    placeholder_outcome(bytes, seg_ref.object_size),
+                    GetCost::default(),
+                ))
+            }
+            // A miss issued one store GET for these bytes (leader), or rode
+            // another caller's in-flight GET (follower). Either way attribute one
+            // logical GET, as `log_fetcher.rs`'s `fetch_accounted_with_tenant`
+            // does: it does not try to distinguish the rare follower, since
+            // recording one GET bounds this call's own attribution and never
+            // under-counts the query total.
+            Source::Upstream => {
+                accounting.record_cache_miss();
+                let cost = GetCost {
+                    requests: 1,
+                    bytes: bytes.len() as u64,
+                };
+                Ok((placeholder_outcome(bytes, seg_ref.object_size), cost))
+            }
+        }
     }
 
     async fn ensure_ranges(

--- a/crates/ravel-query/src/lib.rs
+++ b/crates/ravel-query/src/lib.rs
@@ -23,8 +23,8 @@ pub use config::{
 pub use engine::{Coverage, QueryEngine, QueryStats, snapshot_erasure_predicates};
 pub use error::QueryError;
 pub use fetcher::{
-    CacheFetchError, FetchError, FetchStats, FetchedSeries, FetchedSeriesSoa, SamplePriority,
-    SegmentFetcher,
+    CacheFetchError, FetchError, FetchStats, FetchedSeries, FetchedSeriesSoa, ReadCache,
+    SamplePriority, SegmentFetcher,
 };
 pub use log_fetcher::{
     BlockRangeFetcher, BlockRangeStats, ColumnarBlockOutcome, DEFAULT_LOG_COALESCE_GAP,

--- a/crates/ravel-query/src/log_fetcher.rs
+++ b/crates/ravel-query/src/log_fetcher.rs
@@ -42,8 +42,9 @@
 use std::sync::Arc;
 
 use crate::erasure::ErasurePredicate;
+use crate::fetcher::ReadCache;
 use bytes::Bytes;
-use ravel_cache::{Cache, CacheKey, SingleFlightError};
+use ravel_cache::{CacheKey, SingleFlightError, Source};
 use ravel_catalog::SegmentRef;
 use ravel_logseg::footer::{self, SectionDesc, kind};
 use ravel_logseg::skip_index::SkipIndex;
@@ -430,8 +431,10 @@ pub struct LogSegmentFetcher {
     /// needs. `fetch`/`fetch_accounted` never consult it and are unchanged by
     /// its presence: the one production `LogSegmentFetcher` is shared across
     /// all tenants (`services/ravel-server/src/query.rs`), so caching cannot
-    /// be wired into a method with no per-call tenant identity.
-    cache: Option<Arc<Cache<crate::fetcher::CacheFetchError>>>,
+    /// be wired into a method with no per-call tenant identity. Either tier
+    /// configuration (see [`ReadCache`]); every production caller builds the
+    /// RAM variant.
+    cache: Option<ReadCache>,
     /// Object size above which a tenant-aware fetch reads only the
     /// pruning-relevant blocks through [`Self::block_range`] instead of the
     /// whole object (ADR-0107). At or below it the whole-object path in
@@ -465,11 +468,15 @@ impl LogSegmentFetcher {
 
     /// Wires ADR-0046's read cache into
     /// [`fetch_accounted_with_tenant`](Self::fetch_accounted_with_tenant) and,
-    /// per block, into the block-range path (ADR-0107 decision 3).
+    /// per block, into the block-range path (ADR-0107 decision 3). Accepts
+    /// either tier configuration through [`ReadCache`] (an `Arc<Cache<..>>` or
+    /// an `Arc<TieredCache<..>>` both convert via [`From`]), so existing call
+    /// sites are unchanged.
     #[must_use]
-    pub fn with_cache(mut self, cache: Arc<Cache<crate::fetcher::CacheFetchError>>) -> Self {
-        self.cache = Some(cache.clone());
-        self.block_range = self.block_range.with_cache(cache);
+    pub fn with_cache(mut self, cache: impl Into<ReadCache>) -> Self {
+        let cache = cache.into();
+        self.block_range = self.block_range.with_cache(cache.clone());
+        self.cache = Some(cache);
         self
     }
 
@@ -960,42 +967,46 @@ impl LogSegmentFetcher {
         };
 
         let cache_key = CacheKey::new(tenant_hash.0, seg_ref.content_hash, 0, seg_ref.object_size);
-        let bytes = if let Some(bytes) = cache.get(&cache_key) {
-            accounting.record_cache_hit();
-            accounting.add_cache_bytes(bytes.len() as u64);
-            // Served from cache: no S3 GET on this call.
-            fetch_span.record("s3_requests", 0u64);
-            fetch_span.record("s3_bytes", 0u64);
-            bytes
-        } else {
-            accounting.record_cache_miss();
-            let bytes = async {
-                cache
-                    .get_or_fetch(cache_key, || async move {
-                        let got = self.store.get(key, GetRange::Full).await?;
-                        accounting.record_s3_request(AccountedOp::Get);
-                        accounting.add_s3_bytes(AccountedOp::Get, got.data.len() as u64);
-                        Ok(got.data)
-                    })
-                    .await
+        // One read-through call, accounted from the returned [`Source`]: a
+        // single call avoids the peek-then-`get_or_fetch` double-count on the
+        // tiered tier (see [`ReadCache::get_or_fetch`]).
+        let (bytes, source) = async {
+            cache
+                .get_or_fetch(cache_key, || async move {
+                    let got = self.store.get(key, GetRange::Full).await?;
+                    accounting.record_s3_request(AccountedOp::Get);
+                    accounting.add_s3_bytes(AccountedOp::Get, got.data.len() as u64);
+                    Ok(got.data)
+                })
+                .await
+        }
+        .instrument(fetch_span.clone())
+        .await
+        // Shared with the block-range path's mapping, which is the only one
+        // whose closure can produce the `EtagChanged`/`Corrupt` classes: this
+        // funnel's closure is one unconditional whole-object GET that
+        // verifies nothing, so those arms are unreachable here rather than
+        // wrong.
+        .map_err(|err| from_cache_error(key, err))?;
+        match source {
+            Source::Cache => {
+                accounting.record_cache_hit();
+                accounting.add_cache_bytes(bytes.len() as u64);
+                // Served from cache: no S3 GET on this call.
+                fetch_span.record("s3_requests", 0u64);
+                fetch_span.record("s3_bytes", 0u64);
             }
-            .instrument(fetch_span.clone())
-            .await
-            // Shared with the block-range path's mapping, which is the only one
-            // whose closure can produce the `EtagChanged`/`Corrupt` classes: this
-            // funnel's closure is one unconditional whole-object GET that
-            // verifies nothing, so those arms are unreachable here rather than
-            // wrong.
-            .map_err(|err| from_cache_error(key, err))?;
             // A miss issues one store GET for the resulting bytes. A
             // single-flight follower that rode another caller's GET is the
             // rare exception; recording one GET here still bounds this call's
             // own attribution and never under-counts the query total, which is
             // what the span is for.
-            fetch_span.record("s3_requests", 1u64);
-            fetch_span.record("s3_bytes", bytes.len() as u64);
-            bytes
-        };
+            Source::Upstream => {
+                accounting.record_cache_miss();
+                fetch_span.record("s3_requests", 1u64);
+                fetch_span.record("s3_bytes", bytes.len() as u64);
+            }
+        }
         Ok(Some(bytes))
     }
 
@@ -1328,8 +1339,9 @@ pub struct BlockRangeFetcher {
     store: Arc<dyn ObjectStoreBackend>,
     cfg: RlogConfig,
     /// ADR-0046's read cache, consulted per block (decision 3) and per directory
-    /// section. `None` sends every GET to the store.
-    cache: Option<Arc<Cache<crate::fetcher::CacheFetchError>>>,
+    /// section. `None` sends every GET to the store. Either tier configuration
+    /// (see [`ReadCache`]); every production caller builds the RAM variant.
+    cache: Option<ReadCache>,
     suffix_len: u64,
     coalesce_gap: u64,
     whole_object_threshold: u64,
@@ -1360,8 +1372,8 @@ impl BlockRangeFetcher {
     }
 
     #[must_use]
-    pub fn with_cache(mut self, cache: Arc<Cache<crate::fetcher::CacheFetchError>>) -> Self {
-        self.cache = Some(cache);
+    pub fn with_cache(mut self, cache: impl Into<ReadCache>) -> Self {
+        self.cache = Some(cache.into());
         self
     }
 
@@ -1501,13 +1513,11 @@ impl BlockRangeFetcher {
             return Ok((got.data, true));
         };
         let cache_key = CacheKey::new(tenant_hash.0, seg_ref.content_hash, start, len);
-        if let Some(bytes) = cache.get(&cache_key) {
-            accounting.record_cache_hit();
-            accounting.add_cache_bytes(bytes.len() as u64);
-            return Ok((bytes, false));
-        }
-        accounting.record_cache_miss();
-        let bytes = cache
+        // One read-through call, accounted from the returned [`Source`]: a single
+        // call avoids the peek-then-`get_or_fetch` double-count on the tiered
+        // tier (see [`ReadCache::get_or_fetch`]). The returned flag is `live`
+        // (this call crossed the network), which is [`Source::Upstream`].
+        let (bytes, source) = cache
             .get_or_fetch(cache_key, || async move {
                 let got = self
                     .store_get_pinned(key, range, pin, accounting)
@@ -1518,7 +1528,17 @@ impl BlockRangeFetcher {
             })
             .await
             .map_err(|err| from_cache_error(key, err))?;
-        Ok((bytes, true))
+        match source {
+            Source::Cache => {
+                accounting.record_cache_hit();
+                accounting.add_cache_bytes(bytes.len() as u64);
+                Ok((bytes, false))
+            }
+            Source::Upstream => {
+                accounting.record_cache_miss();
+                Ok((bytes, true))
+            }
+        }
     }
 
     /// Fetch one segment's object as an assembled, decode-ready buffer, reading
@@ -1967,8 +1987,17 @@ impl BlockRangeFetcher {
         // the fetch and already holds every block of the run; `None` means it
         // followed another caller's in-flight GET.
         let led: std::sync::OnceLock<(Vec<(u64, Bytes)>, u64)> = std::sync::OnceLock::new();
+        // `fetch_peeked`, not `get_or_fetch`: fetch_blocks already peeked every
+        // block of this run with `cache.get` (the one accounted miss), so a
+        // second read-through here would re-peek and double-count the miss on
+        // the tiered tier. The RAM tier's `fetch_peeked` is its miss-only
+        // `get_or_fetch` and keeps single-flight (concurrent partitions collapse
+        // onto one leader); the tiered tier runs the fetch and `insert`s with no
+        // second miss. Either way `led` is set inside the closure iff THIS call
+        // ran it, so `led.get().is_some()` still distinguishes leader from
+        // follower.
         let lead_bytes = cache
-            .get_or_fetch(lead_key, || async {
+            .fetch_peeked(lead_key, || async {
                 let got = self
                     .store_get_pinned(key, range, pin, accounting)
                     .await
@@ -2022,8 +2051,11 @@ impl BlockRangeFetcher {
                 continue;
             }
             accounting.record_cache_miss();
+            // `fetch_peeked` for the same reason as the lead above: this block
+            // was just peeked with `cache.get`, so the deferred fetch must not
+            // re-count the miss on the tiered tier.
             let bytes = cache
-                .get_or_fetch(block_key, || async {
+                .fetch_peeked(block_key, || async {
                     let got = self
                         .store_get_pinned(
                             key,


### PR DESCRIPTION
SegmentFetcher, LogSegmentFetcher, and BlockRangeFetcher can now hold
ADR-0046's two-tier RAM-over-disk read cache, so a disk-served hit is
single-flighted and corruption-gated at the RSEG and RLOG read funnels,
not just the RAM tier.

Each fetcher's cache field becomes a ReadCache enum with two variants,
following the precedent #96 set for ravel-catalog's ByteCache. Ram holds
the bare RAM Cache every production caller builds today (a query node has
no disk tier until #97 wires --cache-dir), so the not-yet-disk-configured
path is unchanged: it writes no local files and returns identical
results. Tiered holds ravel_cache::TieredCache. with_cache now takes
impl Into<ReadCache>, so every existing call site is unchanged.

The RSEG cached_get and block-range cached_extent/tenant_bytes funnels
became a single read-through get_or_fetch instead of a peek plus a
get_or_fetch, because that peek-then-fetch pattern would record two
misses for one logical miss on the tiered tier, the double-count pitfall
TieredCache::get's own docs warn about (this crate shipped and fixed the
identical bug once already on a different path, #651).
BlockRangeFetcher::fetch_run keeps its per-block peek as the one
accounted miss and resolves a deferred miss through a new
ReadCache::fetch_peeked, which runs the fetch and inserts with no second
miss on the tiered tier.

Four new tests prove a corrupted disk-served hit fails closed at both the
RSEG and RLOG whole-object funnels, a clean disk hit is bit-identical to
an uncached fetch, the no-disk-tier path is unchanged, and the tiered
peek-then-defer pattern records exactly one miss per logical miss.

Checkpoint review passed, mutation-proofed against three independent
breaks. It found the block-range peek-then-defer path bypasses
TieredCache's single-flight on the Tiered variant specifically, which
breaks ADR-0102's cross-partition collapse for that path once a disk tier
is actually configured; filed as #662 and made a prerequisite for #97.
Four smaller findings (a miss-accounting change on the fetch-error
branch, a test docstring overclaiming what it pins, a stale prove-the-
test note, and an untested block-range corruption path) filed as #663.

Fixes: #95
Refs: #12
