### PR TITLE
feat(ravel-cache): single-flight the tiered peek-then-defer path

### DIFF
--- a/crates/ravel-cache/src/tiered.rs
+++ b/crates/ravel-cache/src/tiered.rs
@@ -45,6 +45,17 @@
 //! key must still account for exactly one miss per logical request; see
 //! [`TieredCache::get`]'s own docstring for the double-counting pitfall this
 //! crate has already shipped and fixed once on the closure-based path.
+//!
+//! **A third path resolves a peek-then-defer miss under single-flight.**
+//! [`TieredCache::resolve_peeked_miss`] is for a caller that already peeked
+//! both tiers with `get`, saw a confirmed miss, and now wants to resolve it --
+//! but coalesced, so concurrent callers for one key collapse onto a single
+//! upstream fetch. Unlike `get`/`insert` it joins the single-flight (the same
+//! field `get_or_fetch` uses), and unlike `get_or_fetch` it consults neither
+//! tier before fetching and records no miss of its own, because the caller's
+//! `get` already accounted the one miss. `BlockRangeFetcher`'s per-extent
+//! peek-then-defer uses it so N cross-partition callers striping one segment
+//! issue one GET, not N.
 
 use std::sync::Arc;
 
@@ -196,6 +207,93 @@ where
             Source::Upstream
         };
         Ok((self.maybe_corrupt(bytes, from_cache), source))
+    }
+
+    /// Resolve a miss the caller ALREADY confirmed with [`get`](Self::get):
+    /// run `fetch` once behind single-flight and admit its result to **both**
+    /// tiers, **without** re-consulting either tier and **without** recording a
+    /// miss of this method's own.
+    ///
+    /// This is the coalesced companion to [`get`](Self::get)'s peek-then-defer
+    /// discipline (ADR-0046 decision 5), and it exists apart from
+    /// [`get_or_fetch`](Self::get_or_fetch) for one reason: the caller has
+    /// already peeked both tiers with `get` and seen a confirmed both-tier miss,
+    /// so `get_or_fetch`'s internal tier consultation would be redundant work
+    /// here and, worse, would count a SECOND miss on a key `get` already
+    /// accounted for -- exactly the double-count [`get`](Self::get)'s docstring
+    /// warns a peek-then-defer caller against. `BlockRangeFetcher` is that
+    /// caller: it peeks each candidate block with `get`, defers the miss, and
+    /// then resolves the deferred run through this method so N concurrent
+    /// cross-partition callers striping one RSEG/RLOG extent collapse onto one
+    /// upstream fetch instead of each issuing its own.
+    ///
+    /// It joins the **same** [`single_flight`](Self::single_flight) field
+    /// `get_or_fetch` uses, not a second coordinator, so a concurrent
+    /// `get_or_fetch` and a `resolve_peeked_miss` on the same key still coalesce
+    /// onto each other correctly. The stored single-flight value is
+    /// `(clean_bytes, false)`: this method's own leader never serves from a tier
+    /// (`false` = "not from cache", so the bytes are the fresh upstream fetch and
+    /// are never corrupted). A follower may instead ride a concurrent
+    /// `get_or_fetch` leader that served from disk (`true`); that flag is honored
+    /// on the way out so a disk-served ride is corruption-gated identically to
+    /// `get_or_fetch`.
+    ///
+    /// Accounting discipline (the invariant this method depends on): it records
+    /// **no miss** on either tier -- the caller's earlier `get` already recorded
+    /// the one accounted miss for this logical request, and layering a second
+    /// here would corrupt the request-hit-rate SLI, the bug this crate shipped
+    /// and fixed once already (see [`get`](Self::get)'s docstring). It **does**
+    /// record a single-flight collapse when a caller rides another caller's
+    /// leader (`self.ram.metrics().record_collapse()`, the same counter
+    /// `get_or_fetch`'s follower branch feeds), since that is real coalescing
+    /// worth surfacing on the SLI.
+    ///
+    /// On a fetch success the leader admits to **both** tiers (decision 3) via
+    /// the same dual-tier admission [`insert`](Self::insert) uses, so a later RAM
+    /// eviction is served from disk rather than re-paying the S3 round trip.
+    pub async fn resolve_peeked_miss<F, Fut>(
+        &self,
+        key: CacheKey,
+        fetch: F,
+    ) -> Result<Bytes, SingleFlightError<E>>
+    where
+        F: FnOnce() -> Fut + Send,
+        Fut: std::future::Future<Output = Result<Bytes, E>> + Send,
+    {
+        // No tier consultation: the caller peeked both tiers with `get` and got
+        // a confirmed miss, so re-reading here would be redundant and could
+        // count a second, unaccounted miss. The leader runs the upstream fetch
+        // once and, on success, admits to BOTH tiers (decision 3). `false`
+        // records that these bytes are the fresh upstream fetch, never a cache
+        // serve, so they are never corrupted.
+        let (outcome, role) = self
+            .single_flight
+            .run(key, move || async move {
+                let bytes = fetch().await?;
+                self.ram.insert(key, bytes.clone());
+                self.disk.insert(key, &bytes);
+                Ok((bytes, false))
+            })
+            .await;
+
+        let (bytes, from_cache) = match outcome {
+            Ok(value) => value,
+            Err(err) => return Err(err),
+        };
+        if role == Role::Follower {
+            // A follower rode another caller's leader (this method's or a
+            // concurrent `get_or_fetch`'s -- both share `single_flight`): count
+            // the collapse on the same SLI `get_or_fetch` feeds. This is the
+            // ONLY `metrics()` call this method makes; it records no miss of its
+            // own, because the caller's earlier `get` already recorded the one
+            // accounted miss for this logical request.
+            self.ram.metrics().record_collapse();
+        }
+        // `from_cache` is `false` for this method's own leader (it consults no
+        // tier), but a follower may have ridden a concurrent `get_or_fetch`
+        // leader that served from disk (`true`); honor it so a disk-served ride
+        // is corruption-gated exactly as `get_or_fetch`'s is.
+        Ok(self.maybe_corrupt(bytes, from_cache))
     }
 
     /// Read `key` through both tiers with **no** upstream fetch and **no**
@@ -511,6 +609,94 @@ mod tests {
             tiered.ram_metrics().snapshot().single_flight_collapses,
             7,
             "the 7 followers each record one collapse"
+        );
+    }
+
+    /// Eight callers that each already peeked-and-missed the same key (via
+    /// `get`, the one accounted miss per caller) then resolve that miss through
+    /// [`TieredCache::resolve_peeked_miss`]: the upstream `fetch` runs exactly
+    /// once (they collapse onto one leader), every caller receives identical
+    /// bytes, the seven followers each record one collapse, and -- critically --
+    /// the method records NO miss of its own on either tier, so the peek stays
+    /// the single accounted miss. A successful resolve admits to both tiers.
+    ///
+    /// This is the crate-level proof of #662's contract. To watch single-flight
+    /// bite, revert `resolve_peeked_miss` to run `fetch().await` directly
+    /// without the `self.single_flight.run(...)` wrapper (the pre-fix
+    /// `ReadCache::fetch_peeked` Tiered behavior): `upstream_calls` then reads 8,
+    /// not 1, and the exactly-one-fetch assertion fails.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn resolve_peeked_miss_collapses_concurrent_callers_to_one_fetch() {
+        let tmp = TempDir::new().unwrap();
+        let disk = DiskCache::new(tmp.path().to_path_buf(), generous_limits());
+        let ram: Cache<&'static str> = Cache::new(generous_limits());
+        let ram_metrics = ram.metrics();
+        let tiered = Arc::new(TieredCache::new(ram, disk));
+
+        let payload = Bytes::from_static(b"resolved once");
+        let key = test_key(1, payload.len() as u64);
+
+        // Every caller peeks first and genuinely misses both tiers -- exactly
+        // the BlockRangeFetcher peek-then-defer entry condition. These `get`
+        // calls are the one accounted miss per caller.
+        const CALLERS: usize = 8;
+        for _ in 0..CALLERS {
+            assert!(
+                tiered.get(&key).is_none(),
+                "precondition: a caller peeks and misses both tiers"
+            );
+        }
+        let misses_after_peeks = ram_metrics.snapshot().misses;
+
+        let upstream_calls = Arc::new(AtomicUsize::new(0));
+        let mut handles = Vec::new();
+        for _ in 0..CALLERS {
+            let tiered = tiered.clone();
+            let calls = upstream_calls.clone();
+            let payload = payload.clone();
+            handles.push(tokio::spawn(async move {
+                tiered
+                    .resolve_peeked_miss(key, move || {
+                        let calls = calls.clone();
+                        let payload = payload.clone();
+                        async move {
+                            calls.fetch_add(1, Ordering::SeqCst);
+                            // Hold the slot so the other callers arrive as
+                            // followers, not fresh leaders after the first
+                            // completes.
+                            tokio::time::sleep(Duration::from_millis(20)).await;
+                            Ok::<Bytes, &'static str>(payload)
+                        }
+                    })
+                    .await
+            }));
+        }
+        for handle in handles {
+            let bytes = handle.await.unwrap().unwrap();
+            assert_eq!(
+                bytes, payload,
+                "every caller receives the one fetched value"
+            );
+        }
+
+        assert_eq!(
+            upstream_calls.load(Ordering::SeqCst),
+            1,
+            "8 concurrent resolve_peeked_miss callers on one key must produce exactly one fetch"
+        );
+        assert_eq!(
+            ram_metrics.snapshot().single_flight_collapses,
+            (CALLERS - 1) as u64,
+            "the 7 followers each record one collapse"
+        );
+        assert_eq!(
+            ram_metrics.snapshot().misses,
+            misses_after_peeks,
+            "resolve_peeked_miss records NO miss of its own: the peek was the one accounted miss"
+        );
+        assert!(
+            tiered.disk.get(&key).is_some(),
+            "a successful resolve admits to the disk tier, not RAM alone"
         );
     }
 

--- a/crates/ravel-query/src/fetcher.rs
+++ b/crates/ravel-query/src/fetcher.rs
@@ -279,18 +279,25 @@ impl ReadCache {
     /// fetch): run `fetch` and admit the result, WITHOUT recording a second miss
     /// on top of the peek's.
     ///
+    /// Both tiers single-flight concurrent callers onto one `fetch` while
+    /// keeping the caller's earlier `get` as the one accounted miss, so
+    /// `BlockRangeFetcher`'s peek-then-defer pattern collapses concurrent
+    /// cross-partition misses of one extent onto a single upstream GET on either
+    /// variant (ADR-0102 decision 1, ADR-0046 decision 5).
+    ///
     /// The RAM tier uses its miss-only [`Cache::get_or_fetch`], which
     /// single-flights concurrent callers onto one `fetch` and never re-peeks, so
-    /// the caller's earlier `get` stays the one accounted miss while
-    /// cross-partition coordination is preserved (ADR-0102 decision 1). The
-    /// tiered tier cannot reuse `get_or_fetch` here: it peeks both tiers again,
-    /// which would record a SECOND miss for a key the caller already peeked
-    /// ([`TieredCache::get`]'s documented double-count pitfall). It therefore
-    /// runs `fetch` directly and admits via [`TieredCache::insert`] (no miss
-    /// recorded), the fetch-free discipline ADR-0046 prescribes for a
-    /// peeked-then-deferred key. `fetch`'s own coalescing -- `BlockRangeFetcher`
-    /// splits one range GET into per-block entries inside the closure -- is
-    /// unaffected either way.
+    /// the caller's earlier `get` stays the one accounted miss. The tiered tier
+    /// cannot reuse its own [`TieredCache::get_or_fetch`] here: that re-peeks
+    /// both tiers, recording a SECOND miss for a key the caller already peeked
+    /// ([`TieredCache::get`]'s documented double-count pitfall). It instead uses
+    /// [`TieredCache::resolve_peeked_miss`], which joins the same single-flight
+    /// as `get_or_fetch` (so concurrent callers coalesce onto one leader) but
+    /// skips the tier consultation and records no miss of its own, admitting the
+    /// fetched bytes to both tiers -- the fetch-free-on-peek discipline ADR-0046
+    /// prescribes for a peeked-then-deferred key. `fetch`'s own coalescing --
+    /// `BlockRangeFetcher` splits one range GET into per-block entries inside the
+    /// closure -- is unaffected either way.
     pub(crate) async fn fetch_peeked<F, Fut>(
         &self,
         key: CacheKey,
@@ -302,13 +309,7 @@ impl ReadCache {
     {
         match self {
             ReadCache::Ram(ram) => ram.get_or_fetch(key, fetch).await,
-            ReadCache::Tiered(tiered) => match fetch().await {
-                Ok(bytes) => {
-                    tiered.insert(key, bytes.clone());
-                    Ok(bytes)
-                }
-                Err(err) => Err(SingleFlightError::Upstream(err)),
-            },
+            ReadCache::Tiered(tiered) => tiered.resolve_peeked_miss(key, fetch).await,
         }
     }
 }

--- a/crates/ravel-query/tests/log_block_range.rs
+++ b/crates/ravel-query/tests/log_block_range.rs
@@ -31,7 +31,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use async_trait::async_trait;
-use ravel_cache::{Cache, CacheLimits};
+use ravel_cache::{Cache, CacheLimits, DiskCache, TieredCache};
 use ravel_catalog::{SegmentLevel, SegmentRef};
 use ravel_logseg::footer::{self, kind};
 use ravel_logseg::skip_index::SkipIndex;
@@ -834,6 +834,18 @@ fn big_cache() -> Arc<Cache<ravel_query::CacheFetchError>> {
     Arc::new(Cache::new(CacheLimits::new(1 << 26, 1 << 23, 1 << 26)))
 }
 
+/// A `TieredCache` (RAM over a temp-dir `DiskCache`) sized like [`big_cache`] so
+/// nothing is evicted mid-test, constructed exactly as #97's server wiring will
+/// (and as `cache_correctness.rs`'s disk-tier tests already do). Both tiers are
+/// generous: the point of the tiered test below is the single-flight collapse,
+/// not eviction.
+fn big_tiered_cache(dir: &std::path::Path) -> Arc<TieredCache<ravel_query::CacheFetchError>> {
+    let limits = CacheLimits::new(1 << 26, 1 << 23, 1 << 26);
+    let ram = Cache::new(limits);
+    let disk = DiskCache::new(dir.to_path_buf(), limits);
+    Arc::new(TieredCache::new(ram, disk))
+}
+
 /// Test 6: the production shape ADR-0102 decision 1 ships -- one shared
 /// `plan_segment` (the `OnceCell` in `LogsScanExec::compute_plan_counts`),
 /// then N partitions each draining its own stripe of the same segment's
@@ -1011,6 +1023,80 @@ async fn concurrent_cold_partitions_collapse_onto_one_get_per_extent() {
         resident_bytes,
         bytes.len() as u64 * PARTITIONS as u64,
         "resident raw bytes above the threshold are one object-sized buffer per partition"
+    );
+}
+
+/// Test 7b (issue #662): the reachability proof for the tiered tier. The same
+/// property test 7 pins on a RAM-only cache -- N cold concurrent partitions
+/// striping one segment collapse onto exactly one GET per distinct extent --
+/// must hold when the fetcher's cache is a `ReadCache::Tiered` (RAM over a real
+/// disk `DiskCache`) instead. This is the disk-backed tier ADR-0046's
+/// single-flight (decision 5) has to span, and the funnel reaches it through
+/// `BlockRangeFetcher::fetch_run`'s `ReadCache::fetch_peeked` -- now
+/// `TieredCache::resolve_peeked_miss` -- exactly as the RAM branch reaches
+/// `Cache::get_or_fetch`.
+///
+/// The count asserted is identical to test 7's: one GET per distinct extent for
+/// any number of concurrent partitions. `SlowCountingStore`'s 50ms padding (per
+/// #618's flake history) keeps the count a function of the fetch protocol rather
+/// than of a microsecond race, exactly as in test 7.
+///
+/// Prove-the-test: this is the tiered-tier equivalent of test 7's proof. Revert
+/// `TieredCache::resolve_peeked_miss` to run `fetch().await` directly with no
+/// single-flight (the pre-#662 `ReadCache::fetch_peeked` Tiered arm), and the
+/// count becomes `N * expected` rather than `expected`, so this assertion fires.
+/// (Demonstrated failing by that revert during development.)
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_cold_partitions_collapse_onto_one_get_per_extent_tiered() {
+    let (records, bytes) = large_object();
+    let (ts_min, ts_max) = (2, 11);
+    let expected = expected_segment_gets(&bytes, ts_min, ts_max);
+    const PARTITIONS: usize = 8;
+
+    let mem = Arc::new(MemoryStore::new());
+    mem.put(
+        "logs/cold-tiered.rlog",
+        bytes.clone().into(),
+        PutOptions::default(),
+    )
+    .await
+    .expect("put");
+    let counting = Arc::new(SlowCountingStore::new(mem));
+    let store: Arc<dyn ObjectStoreBackend> = counting.clone();
+    let seg = seg_ref("logs/cold-tiered.rlog", bytes.len() as u64, &records);
+
+    let tmp = tempfile::TempDir::new().expect("temp dir for the disk cache tier");
+    let br = BlockRangeFetcher::new(store).with_cache(big_tiered_cache(tmp.path()));
+    let mut tasks = Vec::new();
+    for _ in 0..PARTITIONS {
+        let br = br.clone();
+        let seg = seg.clone();
+        tasks.push(tokio::spawn(async move {
+            br.fetch_object(&seg, TENANT, ts_min, ts_max, &QueryAccounting::new())
+                .await
+                .expect("concurrent tiered block-range fetch")
+        }));
+    }
+    for task in tasks {
+        let (assembled, stats) = task.await.expect("partition task");
+        assert!(
+            !stats.whole_object,
+            "the fixture must take the ranged path, not a crossover"
+        );
+        assert_eq!(
+            assembled.len() as u64,
+            bytes.len() as u64,
+            "every partition assembles its own object-sized buffer"
+        );
+    }
+
+    assert_eq!(
+        counting.get_count(),
+        expected,
+        "{PARTITIONS} concurrent cold fetches of one segment through a TIERED cache must issue \
+         exactly one GET per distinct extent ({expected}: probe + uncovered sections + coalesced \
+         runs); un-coalesced the same work is {}",
+        expected * PARTITIONS as u64
     );
 }
 


### PR DESCRIPTION
TieredCache had no fetch-free single-flight entry point, so
ReadCache::fetch_peeked's Tiered arm ran the caller's fetch closure
directly with no coalescing. Two concurrent callers that each peeked the
same key with get, both missed both tiers, and both resolved through
fetch_peeked therefore issued two independent upstream fetches on the
disk-backed tier, where the RAM-only tier collapses them onto one via
Cache::get_or_fetch. BlockRangeFetcher striping one RSEG/RLOG extent
across N partitions issued N range GETs instead of one, once a disk tier
is configured. This was #95's own checkpoint review finding, filed as
#662 and made a prerequisite for #97.

Adds TieredCache::resolve_peeked_miss: it joins the same single_flight
field get_or_fetch uses, so a concurrent get_or_fetch and this method on
one key still coalesce onto each other, but it consults neither tier
before running fetch (the caller already peeked with get) and records no
miss of its own, only a collapse when a caller rides another's leader.
fetch_peeked's Tiered arm now routes through it, so the peek-then-defer
collapse holds on the disk tier exactly as on RAM.

Checkpoint review passed, mutation-proofed both new tests (the crate-level
concurrent-fetch-count test, executed and reverted; the BlockRangeFetcher
reachability test, verified by reading and tracing since the local disk
volume was too tight to safely rebuild ravel-query's test target). Four
non-blocking findings (two stale comments describing the pre-fix behavior,
a bounded follower mis-attribution when a resolve_peeked_miss leader skips
a disk-resident key, and a missing CRC check on a follower's lead bytes
that only matters once the Tiered variant is reachable and corruption mode
is on) filed as #667.

The Tiered variant remains unreachable from production until #97 wires
--cache-dir; this fix removes the single-flight gap #97's own task would
otherwise have shipped as a live regression the moment a disk tier is
configured.

Fixes: #662
Refs: #12, #95
