### PR TITLE
test(ravel-sql): spans columnar/row differential and Flight SQL reachability

### DIFF
--- a/crates/ravel-sql/tests/spans_differential.rs
+++ b/crates/ravel-sql/tests/spans_differential.rs
@@ -4,3 +4,593 @@
 //!
 //! See docs/adrs/0110-columnar-spans-scan.md decisions 3 and 7 for the
 //! eligibility rule and the fallback contract this test pins down.
+//!
+//! # Two comparisons, both cross-path
+//!
+//! The fast path and the row path emit identical output by construction, so the
+//! only way to prove they agree is to run the *same* input through both and
+//! compare byte for byte. Each generated case does that twice:
+//!
+//! - **Path agreement** (no erasure). The same corpus and projection run once
+//!   with no pending erasure (columnar when the projection excludes `attrs`,
+//!   ADR-0110 decision 3 clause a) and once forced onto the row path by a
+//!   no-match erasure predicate (which drains the row path yet removes nothing).
+//!   The two `Vec<RecordBatch>` must be equal, boundaries included, and the path
+//!   metrics must confirm which path each run took.
+//! - **Erasure fallback agreement**. A pending erasure predicate that *does*
+//!   match some spans forces the row path (decision 3 clause b), which excludes
+//!   the erased spans against the merged attribute map the fast path never
+//!   builds. Its output is compared against an independent reference: the same
+//!   projection over a corpus with the erased spans removed at generation time,
+//!   run with no erasure (columnar when eligible). This proves the row path's
+//!   erasure filtering agrees with the columnar path on the surviving rows, and
+//!   exercises the fallback in the differential rather than only in T3's unit
+//!   test.
+//!
+//! # The generator must carry attributes and events
+//!
+//! Every generated span carries a `user_id` attribute (the erasure target axis)
+//! and most carry `service.name`, an extra dynamic attribute, and one or more
+//! events. That is deliberate and load-bearing: an attribute-free, event-free
+//! corpus makes both paths decode exactly the same pages, so `pages_skipped` is
+//! zero and the whole columnar-vs-row comparison is vacuous (the fast path skips
+//! nothing, so it is not exercising the code that differs from the row path). Do
+//! not "simplify" the generator to drop attributes or events.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use datafusion::arrow::array::RecordBatch;
+use datafusion::arrow::compute::concat_batches;
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::execution::TaskContext;
+use datafusion::physical_plan::ExecutionPlan;
+use futures::StreamExt;
+use proptest::prelude::*;
+use proptest::test_runner::TestRunner;
+use ravel_catalog::{SegmentLevel, SegmentRef, Snapshot};
+use ravel_object_store::memory::MemoryStore;
+use ravel_object_store::{ObjectStoreBackend, PutOptions};
+use ravel_query::erasure::snapshot_pending_erasure_predicates;
+use ravel_rspan::{ObjectIdentity, RspanConfig, RspanWriter, SpanQuery, SpanRecord, StatusCode};
+use ravel_sql::{SPAN_COL_ATTRS, SpanSegmentFetcher, SpansScanExec, spans_schema};
+use ravel_types::TenantHash;
+use ravel_types::accounting::QueryAccounting;
+use uuid::Uuid;
+
+const TENANT: TenantHash = TenantHash([1u8; 16]);
+/// The public `spans` table has eleven columns (ADR-0041); a projection is any
+/// non-empty ordered subset of these indices.
+const SPAN_COL_COUNT: usize = 11;
+/// The erasure target attribute. A span is erasable iff its merged attributes
+/// carry exactly this `key = value`, which `is_erased_span` matches against
+/// (ravel-query's erasure module), so the erased set is known at generation.
+const ERASE_KEY: &str = "user_id";
+const ERASE_VALUE: &str = "erase-me";
+/// Proptest case count, matched to this crate's differential-suite convention
+/// (`tests/logs_differential.rs` fixes 48). Each case writes several small RSPAN
+/// objects and runs four scans (two comparisons, two paths each), so this keeps
+/// the suite's cost in line with the existing differential gates while covering
+/// a wide corpus / projection / erasure space.
+const CASES: u32 = 64;
+
+fn identity() -> ObjectIdentity {
+    ObjectIdentity {
+        tenant_hash: TENANT.0,
+        shard: 0,
+        writer_id: [2u8; 16],
+        writer_epoch: 1,
+        writer_seq: 1,
+    }
+}
+
+/// Cut a block every 2 records so a small object still has several blocks and
+/// the interleave across objects has something real to merge (matches
+/// `spans_columnar.rs`).
+fn small_blocks() -> RspanConfig {
+    RspanConfig {
+        block_target_records: 2,
+        ..RspanConfig::default()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Generated corpus
+// ---------------------------------------------------------------------------
+
+/// One generated span. `service`/`http_method` are optional so `service_name`
+/// (a nullable v3 column) and a dynamic attribute page are present in some rows
+/// and absent in others; `with_message` toggles the nullable `status_message`;
+/// `events` promotes an `_events_raw` blob into the nested event columns the
+/// fast path skips. `erasable` decides whether the row carries the erasure
+/// target attribute, so the survivor reference can be built at generation time.
+#[derive(Clone, Debug)]
+struct SpanSpec {
+    trace: u8,
+    span_id: u8,
+    start: i64,
+    service: Option<String>,
+    http_method: Option<String>,
+    events: usize,
+    with_message: bool,
+    erasable: bool,
+}
+
+impl SpanSpec {
+    /// Whether this span carries any attribute beyond the always-present
+    /// `user_id`, i.e. a page the attrs-excluding fast path can skip.
+    fn has_extra_attr(&self) -> bool {
+        self.service.is_some() || self.http_method.is_some() || self.events > 0
+    }
+}
+
+fn arb_span() -> impl Strategy<Value = SpanSpec> {
+    (
+        0u8..5,     // trace
+        0u8..4,     // span_id
+        0i64..1000, // start
+        prop::option::of(prop::sample::select(vec![
+            "checkout",
+            "payments",
+            "inventory",
+        ])),
+        prop::option::of(prop::sample::select(vec!["GET", "POST"])),
+        0usize..3,     // events
+        any::<bool>(), // with_message
+        any::<bool>(), // erasable
+    )
+        .prop_map(
+            |(trace, span_id, start, service, http_method, events, with_message, erasable)| {
+                SpanSpec {
+                    trace,
+                    span_id,
+                    start,
+                    service: service.map(str::to_string),
+                    http_method: http_method.map(str::to_string),
+                    events,
+                    with_message,
+                    erasable,
+                }
+            },
+        )
+}
+
+/// One object holds 1..=4 spans; a corpus holds 1..=3 objects. Objects stay
+/// non-empty so every object writes at least one block.
+fn arb_objects() -> impl Strategy<Value = Vec<Vec<SpanSpec>>> {
+    prop::collection::vec(prop::collection::vec(arb_span(), 1..=4), 1..=3)
+}
+
+/// A projection is a non-empty ordered subset of the eleven column indices. The
+/// permutation-then-prefix shape exercises both which columns are kept and the
+/// order they appear in, so column-order and null-placement wiring is covered.
+fn arb_projection() -> impl Strategy<Value = Vec<usize>> {
+    (
+        Just((0..SPAN_COL_COUNT).collect::<Vec<usize>>()).prop_shuffle(),
+        1..=SPAN_COL_COUNT,
+    )
+        .prop_map(|(perm, k)| perm.into_iter().take(k).collect())
+}
+
+#[derive(Clone, Debug)]
+struct Scenario {
+    objects: Vec<Vec<SpanSpec>>,
+    projection: Vec<usize>,
+}
+
+fn arb_scenario() -> impl Strategy<Value = Scenario> {
+    (arb_objects(), arb_projection()).prop_map(|(objects, projection)| Scenario {
+        objects,
+        projection,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Materializing the corpus into RSPAN objects
+// ---------------------------------------------------------------------------
+
+/// Length-delimited, hex-encoded `_events_raw` value: each event's verbatim
+/// payload prefixed with its uvarint length, concatenated and hex-encoded. This
+/// is the exact grammar `ravel_rspan::record::parse_events` splits on, so a
+/// non-empty blob sequence is always promoted into the nested event columns.
+fn events_raw_value(count: usize) -> String {
+    let mut raw = Vec::new();
+    for i in 0..count {
+        // A small, non-empty payload per event; the bytes are kept verbatim as
+        // the event's `attrs_blob`, so any non-empty sequence parses.
+        let payload = [0x08u8, 0x02, i as u8 + 1];
+        put_uvarint(&mut raw, payload.len() as u64);
+        raw.extend_from_slice(&payload);
+    }
+    let mut hex = String::with_capacity(raw.len() * 2);
+    for byte in raw {
+        hex.push_str(&format!("{byte:02x}"));
+    }
+    hex
+}
+
+fn put_uvarint(out: &mut Vec<u8>, mut n: u64) {
+    loop {
+        let mut byte = (n & 0x7f) as u8;
+        n >>= 7;
+        if n != 0 {
+            byte |= 0x80;
+        }
+        out.push(byte);
+        if n == 0 {
+            break;
+        }
+    }
+}
+
+fn build_span(spec: &SpanSpec) -> SpanRecord {
+    let mut attrs: Vec<(String, String)> = Vec::new();
+    if let Some(svc) = &spec.service {
+        attrs.push(("service.name".to_string(), svc.clone()));
+    }
+    if let Some(method) = &spec.http_method {
+        attrs.push(("http.method".to_string(), method.clone()));
+    }
+    // The erasure axis: an erasable span carries the target value, otherwise a
+    // non-matching one. Present on every span so the merged map is never empty.
+    attrs.push((
+        ERASE_KEY.to_string(),
+        if spec.erasable {
+            ERASE_VALUE.to_string()
+        } else {
+            "keep".to_string()
+        },
+    ));
+    if spec.events > 0 {
+        attrs.push(("_events_raw".to_string(), events_raw_value(spec.events)));
+    }
+    SpanRecord {
+        trace_id: [spec.trace; 16],
+        span_id: [spec.span_id; 8],
+        parent_span_id: if spec.span_id == 0 {
+            None
+        } else {
+            Some([spec.span_id - 1; 8])
+        },
+        name: format!("span-{}-{}", spec.trace, spec.span_id),
+        start_ts_ns: spec.start,
+        end_ts_ns: spec.start + 100,
+        status_code: StatusCode::Ok,
+        status_message: if spec.with_message {
+            Some(format!("msg-{}", spec.span_id))
+        } else {
+            None
+        },
+        attrs,
+    }
+}
+
+async fn write_object(store: &MemoryStore, key: &str, records: &[SpanRecord]) -> SegmentRef {
+    let mut w = RspanWriter::new(small_blocks(), identity());
+    for r in records {
+        w.push(r.clone());
+    }
+    let bytes = w.finish().expect("finish");
+    let size = bytes.len() as u64;
+    store
+        .put(key, bytes::Bytes::from(bytes), PutOptions::default())
+        .await
+        .expect("put object");
+
+    let min = records
+        .iter()
+        .map(|r| r.start_ts_ns)
+        .min()
+        .expect("nonempty");
+    let max = records.iter().map(|r| r.end_ts_ns).max().expect("nonempty");
+    SegmentRef {
+        data_object_key: key.to_string(),
+        object_size: size,
+        min_event_ts_ns: min,
+        max_event_ts_ns: max,
+        ingest_hour_bucket: 0,
+        sample_count: records.len() as u64,
+        series_count: 0,
+        shard: 0,
+        content_hash: [0u8; 32],
+        writer_id: Uuid::from_u128(1),
+        writer_epoch: 1,
+        writer_seq: 1,
+        created_unix_ns: 0,
+        level: SegmentLevel::L0,
+    }
+}
+
+/// Materialize a corpus of objects onto `store`, one RSPAN object per inner
+/// `Vec`, returning the L0 segment refs.
+async fn materialize(store: &MemoryStore, objects: &[Vec<SpanSpec>]) -> Vec<SegmentRef> {
+    let mut segments = Vec::new();
+    for (i, obj) in objects.iter().enumerate() {
+        let records: Vec<SpanRecord> = obj.iter().map(build_span).collect();
+        let key = format!("spans/obj-{i}.rspan");
+        segments.push(write_object(store, &key, &records).await);
+    }
+    segments
+}
+
+// ---------------------------------------------------------------------------
+// The scan under test (the shared `spans_columnar.rs` harness shape)
+// ---------------------------------------------------------------------------
+
+struct ScanRun {
+    batches: Vec<RecordBatch>,
+    columnar_batches: usize,
+    rowpath_batches: usize,
+    pages_decoded: usize,
+    pages_skipped: usize,
+}
+
+/// Execute a `SpansScanExec` directly over `segments` with the given projection
+/// and pending-erasure requests, returning its batches and the path metrics. A
+/// single partition keeps the emitted order deterministic so the two paths'
+/// batches compare byte for byte.
+async fn run_scan(
+    store: Arc<dyn ObjectStoreBackend>,
+    segments: Vec<SegmentRef>,
+    projection: Option<Vec<usize>>,
+    erasure_reqs: Vec<ravel_proto::commit::v1::ErasureRequest>,
+) -> ScanRun {
+    let erasure = snapshot_pending_erasure_predicates(&Snapshot {
+        segments: segments.clone(),
+        segments_pruned: 0,
+        pending_erasure: erasure_reqs,
+    });
+    let scan = SpansScanExec::new(
+        TENANT,
+        SpanSegmentFetcher::new(store),
+        &segments,
+        1,
+        SpanQuery::ts_range(i64::MIN, i64::MAX),
+        None,
+        None,
+        None,
+        None,
+        Arc::new(erasure),
+        projection,
+        QueryAccounting::new(),
+    )
+    .expect("build scan");
+
+    let mut stream = scan
+        .execute(0, Arc::new(TaskContext::default()))
+        .expect("execute");
+    let mut batches = Vec::new();
+    while let Some(next) = stream.next().await {
+        batches.push(next.expect("batch"));
+    }
+    drop(stream);
+
+    let metrics = scan.metrics().expect("metrics");
+    let count = |name: &str| metrics.sum_by_name(name).map(|v| v.as_usize()).unwrap_or(0);
+    ScanRun {
+        columnar_batches: count("columnar_batches"),
+        rowpath_batches: count("rowpath_batches"),
+        pages_decoded: count("pages_decoded"),
+        pages_skipped: count("pages_skipped"),
+        batches,
+    }
+}
+
+/// A pending erasure request matching `key = value` on the merged attribute map.
+fn erasure_req(key: &str, value: &str) -> ravel_proto::commit::v1::ErasureRequest {
+    ravel_proto::commit::v1::ErasureRequest {
+        predicate: vec![ravel_proto::commit::v1::ErasurePredicateMatcher {
+            key: key.to_string(),
+            value: value.to_string(),
+        }],
+        ..Default::default()
+    }
+}
+
+/// The scan's output as a single batch under the projected schema, so two runs
+/// over corpora with different block layouts (the erasure case) compare on rows
+/// alone, independent of how either side chunked its output. An empty run yields
+/// a zero-row batch with the same schema, so empty compares equal to empty.
+fn concat_run(run: &ScanRun, schema: &SchemaRef) -> RecordBatch {
+    concat_batches(schema, &run.batches).expect("concat batches")
+}
+
+fn total_rows(run: &ScanRun) -> usize {
+    run.batches.iter().map(|b| b.num_rows()).sum()
+}
+
+// ---------------------------------------------------------------------------
+// The gate
+// ---------------------------------------------------------------------------
+
+/// The acceptance test (ADR-0110 decision 7): over random RSPAN corpora and
+/// random projection subsets, the columnar fast path and the row path produce
+/// identical batches, and a pending erasure predicate forces the row path whose
+/// output still agrees with an independent survivor reference.
+///
+/// Run through a manual `TestRunner` rather than the `proptest!` macro so the
+/// per-case attribute/event/erasure shares can be tallied and reported (run with
+/// `--nocapture` to see them); the runner still shrinks a failing case.
+#[test]
+fn both_paths_agree_over_every_projection_subset() {
+    let total = AtomicU64::new(0);
+    let cases_with_extra_attr = AtomicU64::new(0);
+    let cases_with_events = AtomicU64::new(0);
+    let cases_with_erased_span = AtomicU64::new(0);
+
+    let mut runner = TestRunner::new(ProptestConfig::with_cases(CASES));
+    let result = runner.run(&arb_scenario(), |scn| {
+        total.fetch_add(1, Ordering::Relaxed);
+        let corpus_has_extra_attr = scn.objects.iter().flatten().any(SpanSpec::has_extra_attr);
+        let corpus_has_events = scn.objects.iter().flatten().any(|s| s.events > 0);
+        let corpus_has_erased = scn.objects.iter().flatten().any(|s| s.erasable);
+        if corpus_has_extra_attr {
+            cases_with_extra_attr.fetch_add(1, Ordering::Relaxed);
+        }
+        if corpus_has_events {
+            cases_with_events.fetch_add(1, Ordering::Relaxed);
+        }
+        if corpus_has_erased {
+            cases_with_erased_span.fetch_add(1, Ordering::Relaxed);
+        }
+
+        let projection = scn.projection.clone();
+        let excludes_attrs = !projection.contains(&SPAN_COL_ATTRS);
+        let proj_schema: SchemaRef = Arc::new(
+            spans_schema()
+                .project(&projection)
+                .expect("project spans schema"),
+        );
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async move {
+            // --- Comparison 1: columnar vs row agreement over the projection ---
+            let store = MemoryStore::new();
+            let segments = materialize(&store, &scn.objects).await;
+            let store: Arc<dyn ObjectStoreBackend> = Arc::new(store);
+
+            // No erasure: columnar when the projection excludes `attrs`.
+            let columnar =
+                run_scan(Arc::clone(&store), segments.clone(), Some(projection.clone()), Vec::new())
+                    .await;
+            // Same projection forced onto the row path by a no-match erasure,
+            // which removes nothing so the output is identical.
+            let rowpath = run_scan(
+                Arc::clone(&store),
+                segments.clone(),
+                Some(projection.clone()),
+                vec![erasure_req("__no_match_key__", "__no_match_value__")],
+            )
+            .await;
+
+            prop_assert_eq!(
+                &columnar.batches,
+                &rowpath.batches,
+                "fast path and row path disagree for projection {:?}",
+                projection
+            );
+
+            let rows = total_rows(&columnar);
+            if excludes_attrs {
+                if rows > 0 {
+                    prop_assert!(
+                        columnar.columnar_batches > 0,
+                        "an attrs-excluding projection over a non-empty corpus must take the fast path (projection {:?})",
+                        projection
+                    );
+                    prop_assert_eq!(
+                        columnar.rowpath_batches,
+                        0,
+                        "the fast path must not fall back for projection {:?}",
+                        projection
+                    );
+                    // Attributes and/or events are present in the corpus, so the
+                    // attrs-excluding decode skips their pages: proof the
+                    // comparison is not vacuous when the corpus carries them.
+                    if corpus_has_extra_attr {
+                        prop_assert!(
+                            columnar.pages_skipped > 0,
+                            "excluding attrs over a corpus with attribute/event pages must skip pages ({} decoded, {} skipped, projection {:?})",
+                            columnar.pages_decoded,
+                            columnar.pages_skipped,
+                            projection
+                        );
+                    }
+                }
+                prop_assert_eq!(
+                    rowpath.columnar_batches,
+                    0,
+                    "a no-match erasure must force the row path for projection {:?}",
+                    projection
+                );
+                if rows > 0 {
+                    prop_assert!(
+                        rowpath.rowpath_batches > 0,
+                        "the row path must have run under the no-match erasure (projection {:?})",
+                        projection
+                    );
+                }
+            } else {
+                // Projecting `attrs` is ineligible, so both runs take the row
+                // path; the equality above still guards row-path determinism.
+                if rows > 0 {
+                    prop_assert!(
+                        columnar.rowpath_batches > 0 && columnar.columnar_batches == 0,
+                        "an attrs-projecting query must take the row path (projection {:?})",
+                        projection
+                    );
+                }
+            }
+
+            // --- Comparison 2: erasure fallback agrees with the survivor reference ---
+            let erased = run_scan(
+                Arc::clone(&store),
+                segments.clone(),
+                Some(projection.clone()),
+                vec![erasure_req(ERASE_KEY, ERASE_VALUE)],
+            )
+            .await;
+
+            // Independent reference: the same projection over a corpus with the
+            // erasable spans removed at generation, run with no erasure (columnar
+            // when eligible). Objects that lose all their spans are dropped.
+            let survivor_objects: Vec<Vec<SpanSpec>> = scn
+                .objects
+                .iter()
+                .map(|obj| obj.iter().filter(|s| !s.erasable).cloned().collect::<Vec<_>>())
+                .filter(|obj: &Vec<SpanSpec>| !obj.is_empty())
+                .collect();
+            let survivor_store = MemoryStore::new();
+            let survivor_segments = materialize(&survivor_store, &survivor_objects).await;
+            let survivor_store: Arc<dyn ObjectStoreBackend> = Arc::new(survivor_store);
+            let reference = run_scan(
+                survivor_store,
+                survivor_segments,
+                Some(projection.clone()),
+                Vec::new(),
+            )
+            .await;
+
+            prop_assert_eq!(
+                concat_run(&erased, &proj_schema),
+                concat_run(&reference, &proj_schema),
+                "erasure fallback disagrees with the survivor reference for projection {:?}",
+                projection
+            );
+            prop_assert_eq!(
+                erased.columnar_batches,
+                0,
+                "a matching pending erasure must force the row path for projection {:?}",
+                projection
+            );
+            if total_rows(&erased) > 0 {
+                prop_assert!(
+                    erased.rowpath_batches > 0,
+                    "the row path must have run under a matching erasure (projection {:?})",
+                    projection
+                );
+            }
+
+            Ok(())
+        })?;
+        Ok(())
+    });
+
+    let total = total.load(Ordering::Relaxed).max(1);
+    eprintln!(
+        "spans_differential: {} cases; extra-attr {:.0}%, events {:.0}%, erased-span {:.0}%",
+        total,
+        100.0 * cases_with_extra_attr.load(Ordering::Relaxed) as f64 / total as f64,
+        100.0 * cases_with_events.load(Ordering::Relaxed) as f64 / total as f64,
+        100.0 * cases_with_erased_span.load(Ordering::Relaxed) as f64 / total as f64,
+    );
+
+    if let Err(err) = result {
+        panic!("differential failed: {err}");
+    }
+}

--- a/crates/ravel-sql/tests/spans_differential.rs
+++ b/crates/ravel-sql/tests/spans_differential.rs
@@ -1,0 +1,6 @@
+//! Differential proptest proving the spans columnar fast path and the row
+//! fallback path produce identical Arrow batches over every projection subset,
+//! including erasure-active scenarios that force the row path.
+//!
+//! See docs/adrs/0110-columnar-spans-scan.md decisions 3 and 7 for the
+//! eligibility rule and the fallback contract this test pins down.

--- a/crates/ravel-sql/tests/spans_provider.rs
+++ b/crates/ravel-sql/tests/spans_provider.rs
@@ -20,6 +20,11 @@
 
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
+// The Flight SQL reachability test drives the shared in-process harness, which
+// only links under the `flight-sql` feature.
+#[cfg(feature = "flight-sql")]
+mod util;
+
 use std::collections::BTreeSet;
 use std::sync::Arc;
 
@@ -490,4 +495,254 @@ async fn a_spans_scan_is_accounted() {
         expected_bytes,
         "the accounted GET records the whole object's transferred bytes"
     );
+}
+
+/// Reachability (ADR-0110 decisions 3-5): a `SELECT` over the `spans` table,
+/// driven through the real Flight SQL surface end to end (`GetFlightInfo` then
+/// `DoGet`), takes the columnar fast path.
+///
+/// The other tests in this file drive `SpansScanExec`/`SpansTableProvider`
+/// directly, which proves the code works; this proves a real caller on the
+/// shipping surface reaches it. The Flight round trip returns only record
+/// batches, not the scan's plan metrics, so "the columnar path ran" is asserted
+/// through the query's cost accounting instead: the columnar exit records
+/// `page_bytes_decoded` strictly below `page_bytes_fetched` whenever it skips a
+/// page (ADR-0110 decision 2), which the row path never does (it decodes every
+/// page, so the two are equal). A custom `QueryCostRecorder` captures the
+/// per-query snapshot the Flight service folds on stream end.
+///
+/// The fixture spans carry `service.name`, an extra dynamic attribute, and an
+/// event, so the attrs-excluding projection has attribute and event pages to
+/// skip; without them both paths decode the same pages and the metric proof is
+/// vacuous. Forcing the row path (making `columnar_static_eligible` return
+/// `false`, or projecting `attrs`) makes `page_bytes_decoded == page_bytes_fetched`
+/// and turns the metric assertion red.
+#[cfg(feature = "flight-sql")]
+mod flight_reachability {
+    use std::sync::{Arc, Mutex};
+
+    use datafusion::arrow::array::{Array, FixedSizeBinaryArray, Int64Array, StringArray};
+    use ravel_commit::keys;
+    use ravel_commit::publish::{self, RetryPolicy};
+    use ravel_commit::record::{self, NewCommitRecord};
+    use ravel_object_store::memory::MemoryStore;
+    use ravel_object_store::{ObjectStoreBackend, PutOptions};
+    use ravel_rspan::{ObjectIdentity, RspanConfig, RspanWriter, SpanRecord, StatusCode};
+    use ravel_types::Signal;
+    use ravel_types::accounting::{
+        CostEstimate, QueryAccountingSnapshot, QueryCostRecorder, QueryWorkloadClass,
+    };
+    use ravel_types::{TenantHash, TenantId};
+    use uuid::Uuid;
+
+    use crate::util::SegSpec;
+    use crate::util::flight_harness::Harness;
+    use crate::util::tenant_id;
+
+    const QUERY: &str =
+        "SELECT trace_id, name, start_ts, duration_ns FROM spans ORDER BY trace_id, start_ts";
+
+    /// A `QueryCostRecorder` that keeps every recorded snapshot, so the test can
+    /// read the execution snapshot the `DoGet` stream folds on end.
+    #[derive(Default)]
+    struct CapturingRecorder {
+        snapshots: Mutex<Vec<QueryAccountingSnapshot>>,
+    }
+
+    impl QueryCostRecorder for CapturingRecorder {
+        fn record(
+            &self,
+            accounting: &QueryAccountingSnapshot,
+            _estimate: &CostEstimate,
+            _tenant_hash: TenantHash,
+            _workload_class: QueryWorkloadClass,
+        ) {
+            self.snapshots
+                .lock()
+                .expect("recorder lock")
+                .push(*accounting);
+        }
+    }
+
+    /// Length-delimited, hex-encoded `_events_raw` value carrying one event, the
+    /// grammar `ravel_rspan::record::parse_events` promotes into event columns,
+    /// so the block has an event page the attrs-excluding decode skips.
+    fn one_event_raw() -> String {
+        // uvarint length prefix (3) then a small verbatim payload.
+        let raw = [0x03u8, 0x08, 0x02, 0x01];
+        raw.iter().map(|b| format!("{b:02x}")).collect()
+    }
+
+    fn span(trace: u8, span_id: u8, start: i64, name: &str) -> SpanRecord {
+        SpanRecord {
+            trace_id: [trace; 16],
+            span_id: [span_id; 8],
+            parent_span_id: None,
+            name: name.to_string(),
+            start_ts_ns: start,
+            end_ts_ns: start + 50,
+            status_code: StatusCode::Ok,
+            status_message: None,
+            attrs: vec![
+                ("service.name".to_string(), "checkout".to_string()),
+                ("http.method".to_string(), "GET".to_string()),
+                ("_events_raw".to_string(), one_event_raw()),
+            ],
+        }
+    }
+
+    /// Publish one RSPAN object as a real `Signal::Spans` commit record, so the
+    /// executor's `Catalog::resolve` finds it exactly as a production caller
+    /// would (no hand-built `Snapshot`).
+    async fn publish_spans_segment(
+        store: &dyn ObjectStoreBackend,
+        tenant: &TenantId,
+        records: &[SpanRecord],
+    ) {
+        let tenant_hash = tenant.hash();
+        let identity = ObjectIdentity {
+            tenant_hash: tenant_hash.0,
+            shard: 0,
+            writer_id: [2u8; 16],
+            writer_epoch: 1,
+            writer_seq: 1,
+        };
+        let mut w = RspanWriter::new(RspanConfig::default(), identity);
+        for r in records {
+            w.push(r.clone());
+        }
+        let bytes = w.finish().expect("finish object");
+        let min = records
+            .iter()
+            .map(|r| r.start_ts_ns)
+            .min()
+            .expect("nonempty");
+        let max = records.iter().map(|r| r.end_ts_ns).max().expect("nonempty");
+        let content_hash = *blake3::hash(&bytes).as_bytes();
+        let new_record = NewCommitRecord {
+            tenant_hash,
+            signal: Signal::Spans,
+            shard: 0,
+            writer_id: Uuid::from_u128(1),
+            writer_epoch: 1,
+            writer_seq: 1,
+            object_size: bytes.len() as u64,
+            content_hash,
+            sample_count: records.len() as u64,
+            series_count: 0,
+            min_event_ts_ns: min,
+            max_event_ts_ns: max,
+            min_ingest_ts_ns: min,
+            max_ingest_ts_ns: max,
+            segment_format_version: 1,
+            created_unix_ns: 0,
+            ingest_hour_bucket: 0,
+        };
+        let rec = record::build(new_record).expect("valid commit record");
+        let data_key = keys::reconstruct_data_key(&rec).expect("data key");
+        store
+            .put(&data_key, bytes::Bytes::from(bytes), PutOptions::default())
+            .await
+            .expect("put data object");
+        publish::publish(store, &rec, &RetryPolicy::default())
+            .await
+            .expect("publish");
+    }
+
+    #[tokio::test]
+    async fn flight_sql_spans_select_takes_the_columnar_path() {
+        let tenant = tenant_id("acme");
+        let recorder = Arc::new(CapturingRecorder::default());
+        let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+        // No metrics segments; the spans segment is published straight to the
+        // store the harness's catalog resolves against.
+        let no_specs: &[SegSpec] = &[];
+        let harness = Harness::build_with_recorder(
+            Arc::clone(&store),
+            &[(&tenant, no_specs)],
+            recorder.clone() as Arc<dyn QueryCostRecorder>,
+        )
+        .await;
+
+        // Two traces, two spans each, all carrying attributes and an event.
+        let records = vec![
+            span(0, 0, 100, "a-root"),
+            span(0, 1, 150, "a-child"),
+            span(1, 0, 200, "b-root"),
+            span(1, 1, 250, "b-child"),
+        ];
+        publish_spans_segment(harness.store.as_ref(), &tenant, &records).await;
+
+        let ticket = harness
+            .get_flight_info("acme", QUERY)
+            .await
+            .expect("flight info");
+        let batches = harness.do_get("acme", &ticket).await.expect("do get");
+
+        // The rows are correct: every span comes back, projected to
+        // (trace_id, name, start_ts, duration_ns) in (trace_id, start_ts) order.
+        let mut names = Vec::new();
+        let mut trace_ids = Vec::new();
+        for batch in &batches {
+            assert_eq!(batch.num_columns(), 4, "projected to four columns");
+            let trace = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<FixedSizeBinaryArray>()
+                .expect("trace_id column");
+            let name = batch
+                .column(1)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("name column");
+            let duration = batch
+                .column(3)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .expect("duration_ns column");
+            for i in 0..batch.num_rows() {
+                let tid: [u8; 16] = trace.value(i).try_into().expect("16-byte trace");
+                trace_ids.push(tid);
+                names.push(name.value(i).to_string());
+                assert_eq!(duration.value(i), 50, "duration_ns is end - start");
+            }
+        }
+        assert_eq!(
+            names,
+            vec![
+                "a-root".to_string(),
+                "a-child".to_string(),
+                "b-root".to_string(),
+                "b-child".to_string(),
+            ],
+            "every span is returned once, in (trace_id, start_ts) order"
+        );
+        assert_eq!(
+            trace_ids,
+            vec![[0u8; 16], [0u8; 16], [1u8; 16], [1u8; 16]],
+            "rows are emitted in trace_id ascending order"
+        );
+
+        // The columnar path ran: the execution snapshot decoded strictly fewer
+        // page bytes than it fetched, because the attrs-excluding projection
+        // skipped the attribute and event pages. The row path decodes every
+        // page, so the two would be equal. `get_flight_info` also records a
+        // planning snapshot with zero page bytes; the execution snapshot is the
+        // one with page bytes fetched, so pick the maximum.
+        let snapshots = recorder.snapshots.lock().expect("recorder lock");
+        let execution = snapshots
+            .iter()
+            .max_by_key(|s| s.page_bytes_fetched)
+            .expect("at least one recorded query");
+        assert!(
+            execution.page_bytes_fetched > 0,
+            "the spans scan must have decoded at least one block"
+        );
+        assert!(
+            execution.page_bytes_decoded < execution.page_bytes_fetched,
+            "the columnar fast path must skip pages: decoded {} of {} fetched",
+            execution.page_bytes_decoded,
+            execution.page_bytes_fetched,
+        );
+    }
 }


### PR DESCRIPTION
Prove the spans columnar fast path and the row path agree, and prove a real
caller in the shipping surface reaches the fast path (ADR-0110 decision 7).

The differential runs the same materialized RSPAN objects through both paths
and asserts RecordBatch equality, schema and column order and null placement
included, over every projection subset. It makes two comparisons rather than
one: columnar against the row path forced by a non-matching erasure predicate,
and the row path under a MATCHING erasure against an independent survivor
reference built by dropping erasable spans at generation time. The second is
what stops the erasure case being self-confirming.

The corpus is load-bearing, so its shape is measured rather than assumed: over
64 generated cases, 100% carried extra attributes, 97% carried events, and 88%
carried an erased span. An attribute-free, event-free corpus would make both
paths decode identical pages and the whole comparison vacuous.

The Flight SQL test publishes a real Signal::Spans commit record and drives
get_flight_info then do_get through the in-process harness, asserting both the
rows and the path.

One deviation from what was specified, reported rather than papered over. The
reachability test was asked to prove the path through the columnar_batches and
rowpath_batches metrics. Those are DataFusion Count metrics on the
SpansScanExec plan, readable only via scan.metrics(); the Flight SQL surface
returns batches plus a QueryAccountingSnapshot, which carries
page_bytes_fetched and page_bytes_decoded but not the batch counters. So the
test proves the path with decoded < fetched instead. That implication holds in
one direction only, which is the direction needed: the row path decodes every
page it fetches, so decoded strictly below fetched cannot happen on it. It does
require a corpus carrying skippable pages, which this one does.

Both assertions were demonstrated failing. Projecting attrs in the Flight SQL
query moves it to the row path and the metric assert fires with decoded 123 of
123 fetched, against 75 of 123 on the columnar path. Forcing eligibility where
the rule forbids it reddens the differential.

No src/ changes: this is a test-only task, and a test task that edits src to
make itself green destroys the only thing a differential proves.

Fixes: #640
Refs: #630
