### PR TITLE
docs: mark ADR-0099's spans-scan deferral as delivered

### DIFF
--- a/docs/adrs/0099-columnar-decode-to-arrow.md
+++ b/docs/adrs/0099-columnar-decode-to-arrow.md
@@ -389,3 +389,8 @@ flowchart LR
   the spans scan (`crates/ravel-sql/src/spans_scan.rs`), which has the same
   row-rebuild shape and is left for a follow-up rather than widened into this
   epic.
+
+  The spans scan is no longer deferred: ADR-0110 delivered it, following this
+  ADR's decisions 1 to 3 for RSPAN. Columnar erasure evaluation is still open,
+  and is what forces ADR-0110's eligibility rule to fail closed to the row path
+  whenever an erasure predicate is pending.


### PR DESCRIPTION
ADR-0099 listed the spans scan among its deferred items. ADR-0110 delivered it across epic #630, so a reader of 0099 was being told a follow-up was outstanding when it had already landed.

The note also keeps the part that is still true: columnar erasure evaluation from the same deferred list is open, and it is precisely why ADR-0110's eligibility rule fails closed to the row path whenever an erasure predicate is pending. `is_erased_span` matches against the merged attribute map, which the fast path never builds.

Doc-currency follow-up rather than a same-commit update, because the behaviour landed across five PRs (#646, #658, #666, #670, #672) and this line belongs to none of them individually.

Refs: #630