### PR TITLE
test(ravel-bench): measure the columnar load path against the row path

### DIFF
--- a/crates/ravel-bench/Cargo.toml
+++ b/crates/ravel-bench/Cargo.toml
@@ -240,6 +240,15 @@ path = "src/bin/read_path_accounting.rs"
 required-features = ["parquet-baseline"]
 bench = false
 
+# ADR-0109 (#606) differential load bench: row path vs columnar fast path.
+# Behind `parquet-baseline` because it reads its bounded sample through the
+# arrow/parquet reader that feature gates.
+[[bin]]
+name = "columnar_load_compare"
+path = "src/bin/columnar_load_compare.rs"
+required-features = ["parquet-baseline"]
+bench = false
+
 [[bin]]
 name = "flight_sql_egress"
 path = "src/bin/flight_sql_egress.rs"
@@ -273,6 +282,15 @@ bench = false
 [[test]]
 name = "read_accounting"
 path = "tests/read_accounting.rs"
+bench = false
+
+# ADR-0109 (#606) acceptance test: the differential harness must drive both the
+# row and columnar paths over the same input, proven by the two reachability
+# counters. Behind `parquet-baseline` for the same reason as the bin above.
+[[test]]
+name = "columnar_load_compare"
+path = "tests/columnar_load_compare.rs"
+required-features = ["parquet-baseline"]
 bench = false
 
 [[test]]

--- a/crates/ravel-bench/src/bin/columnar_load_compare.rs
+++ b/crates/ravel-bench/src/bin/columnar_load_compare.rs
@@ -1,0 +1,94 @@
+//! ADR-0109 (#606): load one bounded ClickBench-shaped Parquet sample through
+//! the row path (`LogIngestRouter::write`) and the columnar fast path
+//! (`LogIngestRouter::write_columnar`) in the same process, and report the wall
+//! and CPU cost of each.
+//!
+//! Every figure is a LOCAL differential on a bounded synthetic sample over an
+//! in-memory store. It is not the ClickBench reference figure, it does not
+//! exercise ADR-0109 decision 3's dictionary path (#660), and it cannot see S3
+//! latency, multi-shard scaling, or real PUT round trips. See the module docs
+//! on `ravel_bench::columnar_load` for the full scope statement.
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use clap::Parser;
+
+use ravel_bench::columnar_load::{self, CorpusShape};
+
+#[derive(Debug, Parser)]
+#[command(about = "Differential load bench: row path vs columnar fast path (ADR-0109, #606)")]
+struct Args {
+    /// Corpus row count (bounded sample).
+    #[arg(long, default_value_t = 50_000)]
+    rows: usize,
+    /// Number of Int64 attribute columns.
+    #[arg(long, default_value_t = 60)]
+    int_cols: usize,
+    /// Number of Utf8 attribute columns.
+    #[arg(long, default_value_t = 40)]
+    str_cols: usize,
+    /// Shard count. One keeps the whole corpus on a single shard so the
+    /// differential is the write-path pivot and not shard fan-out.
+    #[arg(long, default_value_t = 1)]
+    shards: u32,
+    /// Rows per Strict write (one RLOG object per batch).
+    #[arg(long, default_value_t = 10_000)]
+    batch_rows: usize,
+}
+
+#[tokio::main]
+async fn main() {
+    let args = Args::parse();
+    let shape = CorpusShape {
+        rows: args.rows,
+        int_cols: args.int_cols,
+        str_cols: args.str_cols,
+    };
+
+    let report = columnar_load::run(shape, args.shards, args.batch_rows)
+        .await
+        .expect("comparison run");
+
+    let cpu_ms = |c: Option<std::time::Duration>| {
+        c.map(|d| format!("{:.1}", d.as_secs_f64() * 1e3))
+            .unwrap_or_else(|| "n/a".to_string())
+    };
+
+    println!("columnar-load differential (LOCAL, in-memory store, bounded sample)");
+    println!(
+        "  corpus           : {} rows, {} columns ({} attribute columns), {} bytes parquet",
+        report.corpus_rows, report.columns, report.attr_columns, report.parquet_bytes
+    );
+    println!(
+        "  config           : shards={} batch_rows={}",
+        report.shards, report.batch_rows
+    );
+    println!(
+        "  row path         : wall={:.1}ms cpu={}ms objects={} row_batches={} columnar_batches={}",
+        report.row.wall.as_secs_f64() * 1e3,
+        cpu_ms(report.row.cpu),
+        report.row.objects_written,
+        report.row.row_batches,
+        report.row.columnar_batches,
+    );
+    println!(
+        "  columnar path    : wall={:.1}ms cpu={}ms objects={} row_batches={} columnar_batches={}",
+        report.columnar.wall.as_secs_f64() * 1e3,
+        cpu_ms(report.columnar.cpu),
+        report.columnar.objects_written,
+        report.columnar.row_batches,
+        report.columnar.columnar_batches,
+    );
+    println!("  wall speedup     : {:.2}x (row / columnar)", report.wall_speedup());
+    match report.pivot_cpu_share() {
+        Some(share) => println!(
+            "  pivot CPU share  : {:.1}% of the row-path WRITE cpu (not of end-to-end load cpu; \
+             decode is excluded and shared by both paths)",
+            share * 100.0
+        ),
+        None => println!("  pivot CPU share  : n/a (CPU reading unavailable)"),
+    }
+    println!(
+        "  scope            : local differential, NOT the ClickBench reference; decision-3 \
+         dictionary path off (#660); S3/multi-shard/real-PUT not exercised"
+    );
+}

--- a/crates/ravel-bench/src/bin/columnar_load_compare.rs
+++ b/crates/ravel-bench/src/bin/columnar_load_compare.rs
@@ -78,7 +78,10 @@ async fn main() {
         report.columnar.row_batches,
         report.columnar.columnar_batches,
     );
-    println!("  wall speedup     : {:.2}x (row / columnar)", report.wall_speedup());
+    println!(
+        "  wall speedup     : {:.2}x (row / columnar)",
+        report.wall_speedup()
+    );
     match report.pivot_cpu_share() {
         Some(share) => println!(
             "  pivot CPU share  : {:.1}% of the row-path WRITE cpu (not of end-to-end load cpu; \

--- a/crates/ravel-bench/src/columnar_load.rs
+++ b/crates/ravel-bench/src/columnar_load.rs
@@ -40,15 +40,13 @@ use arrow::record_batch::RecordBatch;
 use parquet::arrow::ArrowWriter;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 
-use ravel_ingest::{
-    Clock, IngestConfig, LogIngestRouter, SystemClock, WriteMode,
-};
+use ravel_ingest::{Clock, IngestConfig, LogIngestRouter, SystemClock, WriteMode};
 use ravel_logseg::{ColumnarLogBatch, LogRecord, stream_attrs_bytes};
-use ravel_object_store::memory::MemoryStore;
 use ravel_object_store::ObjectStoreBackend;
+use ravel_object_store::memory::MemoryStore;
 use ravel_otlp::logs_normalize::NormalizedLogRecord;
-use ravel_types::logstream::{AttrValue, log_stream_id};
 use ravel_types::TenantId;
+use ravel_types::logstream::{AttrValue, log_stream_id};
 
 /// Ack deadline for each Strict write. Generous: the in-memory store never
 /// blocks, but a loaded host can still stretch a flush.
@@ -57,8 +55,10 @@ const WRITE_ACK_DEADLINE: Duration = Duration::from_secs(120);
 /// The fixed resource+scope identity every corpus record shares. A single
 /// stream keeps every row on one shard, so the row-vs-columnar differential is
 /// the write-path pivot alone and not a difference in shard fan-out.
-const RESOURCE_ATTRS: &[(&str, &str)] =
-    &[("service.name", "clickbench-local"), ("dataset", "hits-sample")];
+const RESOURCE_ATTRS: &[(&str, &str)] = &[
+    ("service.name", "clickbench-local"),
+    ("dataset", "hits-sample"),
+];
 
 /// Which write path a measurement drove. The row path
 /// ([`LogIngestRouter::write`]) is the differential reference; the columnar
@@ -131,7 +131,11 @@ pub struct CompareReport {
 impl CompareReport {
     /// Row-path wall divided by columnar-path wall.
     pub fn wall_speedup(&self) -> f64 {
-        self.columnar.wall.as_secs_f64().max(f64::MIN_POSITIVE).recip()
+        self.columnar
+            .wall
+            .as_secs_f64()
+            .max(f64::MIN_POSITIVE)
+            .recip()
             * self.row.wall.as_secs_f64()
     }
 
@@ -194,7 +198,9 @@ fn corpus_schema(shape: CorpusShape) -> SchemaRef {
 /// column, the shape a dictionary-encoded categorical export takes.
 fn corpus_batch(shape: CorpusShape, schema: &SchemaRef) -> RecordBatch {
     let n = shape.rows;
-    let ts: Vec<i64> = (0..n).map(|r| 1_700_000_000_000_000_000 + r as i64 * 1_000_000).collect();
+    let ts: Vec<i64> = (0..n)
+        .map(|r| 1_700_000_000_000_000_000 + r as i64 * 1_000_000)
+        .collect();
     let body: Vec<String> = (0..n)
         .map(|r| format!("request {} served in {}ms", r, r % 250))
         .collect();
@@ -204,13 +210,17 @@ fn corpus_batch(shape: CorpusShape, schema: &SchemaRef) -> RecordBatch {
     columns.push(Arc::new(StringArray::from(body)));
 
     for c in 0..shape.int_cols {
-        let col: Vec<i64> = (0..n).map(|r| (r as i64).wrapping_mul(31).wrapping_add(c as i64)).collect();
+        let col: Vec<i64> = (0..n)
+            .map(|r| (r as i64).wrapping_mul(31).wrapping_add(c as i64))
+            .collect();
         columns.push(Arc::new(Int64Array::from(col)));
     }
     for c in 0..shape.str_cols {
         // A small per-column alphabet (16 distinct values) so the column reads
         // like a low-cardinality categorical, the ClickBench-typical shape.
-        let col: Vec<String> = (0..n).map(|r| format!("s{c:02}_{}", (r + c) % 16)).collect();
+        let col: Vec<String> = (0..n)
+            .map(|r| format!("s{c:02}_{}", (r + c) % 16))
+            .collect();
         columns.push(Arc::new(StringArray::from(col)));
     }
 
@@ -240,7 +250,9 @@ pub fn decode_corpus(parquet_bytes: &[u8]) -> Result<Vec<NormalizedLogRecord>, C
     let bytes = bytes::Bytes::copy_from_slice(parquet_bytes);
     let builder = ParquetRecordBatchReaderBuilder::try_new(bytes)
         .map_err(|e| CompareError::Parquet(e.to_string()))?;
-    let reader = builder.build().map_err(|e| CompareError::Parquet(e.to_string()))?;
+    let reader = builder
+        .build()
+        .map_err(|e| CompareError::Parquet(e.to_string()))?;
 
     let res: Vec<(String, AttrValue)> = RESOURCE_ATTRS
         .iter()
@@ -426,7 +438,12 @@ async fn measure_path(
                 report.columnar_batches += 1;
                 let n = batch.num_rows as u64;
                 let r = router
-                    .write_columnar(tenant.clone(), *batch, WriteMode::Strict, WRITE_ACK_DEADLINE)
+                    .write_columnar(
+                        tenant.clone(),
+                        *batch,
+                        WriteMode::Strict,
+                        WRITE_ACK_DEADLINE,
+                    )
                     .await
                     .map_err(|e| CompareError::Write {
                         path: "columnar",

--- a/crates/ravel-bench/src/columnar_load.rs
+++ b/crates/ravel-bench/src/columnar_load.rs
@@ -1,0 +1,502 @@
+//! Differential harness for ADR-0109's columnar bulk-load fast path (#606).
+//!
+//! It loads one bounded Parquet sample twice through the *same* in-process
+//! `LogIngestRouter`: once as `Vec<NormalizedLogRecord>` through
+//! [`LogIngestRouter::write`] (the pre-ADR row path, kept as the differential
+//! reference), and once as a [`ColumnarLogBatch`] through
+//! [`LogIngestRouter::write_columnar`] (the fast path). The only thing that
+//! differs between the two runs is the write-path input shape, so the wall and
+//! CPU delta between them isolates the per-row pivot the fast path removes
+//! (`RlogWriter::push` gathers each dynamic column per row; `push_columnar`
+//! stages it from contiguous per-column data).
+//!
+//! Scope, stated so the number cannot be over-read (this is why the harness
+//! exists at all, #606):
+//!
+//! - **Local, bounded sample. Not the ClickBench reference figure.** The
+//!   corpus is a small synthetic ClickBench-shaped table built in this process,
+//!   not the full `hits.parquet` on the c6a.4xlarge/S3 reference box. Every
+//!   figure this harness produces is a local differential, never the reference
+//!   result.
+//! - **Measures the epic WITHOUT ADR-0109 decision 3 contributing.** The
+//!   columnar batch is built through [`ColumnarLogBatch::from_records`], which
+//!   does not attach dictionaries, so the dictionary-preserving column and
+//!   dictionary-aware bloom path (#660) never engages -- exactly as it fails to
+//!   engage on ClickBench-shaped plain-`BYTE_ARRAY` Parquet. Decision 8's
+//!   arithmetic counted those savings; this harness does not see them.
+//! - **In-memory store.** The router writes to a [`MemoryStore`]. S3 latency,
+//!   multi-shard fan-out scaling, and real PUT round trips are invisible here;
+//!   the CRC32C over the in-memory PUT is the only object-store work timed.
+//!
+//! Report-only: this crate never changes library behavior, it only measures it.
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use arrow::array::{ArrayRef, Int64Array, StringArray};
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use arrow::record_batch::RecordBatch;
+use parquet::arrow::ArrowWriter;
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+
+use ravel_ingest::{
+    Clock, IngestConfig, LogIngestRouter, SystemClock, WriteMode,
+};
+use ravel_logseg::{ColumnarLogBatch, LogRecord, stream_attrs_bytes};
+use ravel_object_store::memory::MemoryStore;
+use ravel_object_store::ObjectStoreBackend;
+use ravel_otlp::logs_normalize::NormalizedLogRecord;
+use ravel_types::logstream::{AttrValue, log_stream_id};
+use ravel_types::TenantId;
+
+/// Ack deadline for each Strict write. Generous: the in-memory store never
+/// blocks, but a loaded host can still stretch a flush.
+const WRITE_ACK_DEADLINE: Duration = Duration::from_secs(120);
+
+/// The fixed resource+scope identity every corpus record shares. A single
+/// stream keeps every row on one shard, so the row-vs-columnar differential is
+/// the write-path pivot alone and not a difference in shard fan-out.
+const RESOURCE_ATTRS: &[(&str, &str)] =
+    &[("service.name", "clickbench-local"), ("dataset", "hits-sample")];
+
+/// Which write path a measurement drove. The row path
+/// ([`LogIngestRouter::write`]) is the differential reference; the columnar
+/// path ([`LogIngestRouter::write_columnar`]) is ADR-0109's fast path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LoadPath {
+    Row,
+    Columnar,
+}
+
+impl LoadPath {
+    pub fn label(self) -> &'static str {
+        match self {
+            LoadPath::Row => "row",
+            LoadPath::Columnar => "columnar",
+        }
+    }
+}
+
+/// A harness failure. The router's own errors carry rich structure; here they
+/// are flattened to a string, since a bench does not act on the classification.
+#[derive(Debug, thiserror::Error)]
+pub enum CompareError {
+    #[error("parquet: {0}")]
+    Parquet(String),
+    #[error("{path} write failed: {cause}")]
+    Write { path: &'static str, cause: String },
+}
+
+/// One path's measured result over the whole corpus.
+#[derive(Debug, Clone)]
+pub struct PathReport {
+    pub path: LoadPath,
+    pub rows_processed: u64,
+    pub objects_written: usize,
+    /// Batches driven through [`LogIngestRouter::write`]. Nonzero only on the
+    /// row path. This and `columnar_batches` are the reachability signals that
+    /// prove the comparison ran two *different* paths rather than measuring one
+    /// path twice: each counter is incremented in the same match arm that calls
+    /// its router method, so a flip of the method leaves the counter behind.
+    pub row_batches: u64,
+    /// Batches driven through [`LogIngestRouter::write_columnar`]. Nonzero only
+    /// on the columnar path.
+    pub columnar_batches: u64,
+    /// Wall time of the timed region (the write loop only; corpus decode and
+    /// per-batch input construction happen before it).
+    pub wall: Duration,
+    /// Process CPU (user + system) consumed across the timed region, sampled
+    /// from `/proc/self/stat`. Process-wide, so it includes the tokio runtime's
+    /// worker threads; both paths pay the same runtime overhead, so their
+    /// difference remains the pivot. `None` when the reading is unavailable
+    /// (non-Linux, or an unparseable stat line).
+    pub cpu: Option<Duration>,
+}
+
+/// The two paths' reports plus the shared input description.
+#[derive(Debug, Clone)]
+pub struct CompareReport {
+    pub row: PathReport,
+    pub columnar: PathReport,
+    pub corpus_rows: usize,
+    /// Total Parquet columns (ts + body + attribute columns).
+    pub columns: usize,
+    pub attr_columns: usize,
+    pub shards: u32,
+    pub batch_rows: usize,
+    pub parquet_bytes: usize,
+}
+
+impl CompareReport {
+    /// Row-path wall divided by columnar-path wall.
+    pub fn wall_speedup(&self) -> f64 {
+        self.columnar.wall.as_secs_f64().max(f64::MIN_POSITIVE).recip()
+            * self.row.wall.as_secs_f64()
+    }
+
+    /// The pivot's share of the row-path *write* CPU, as a fraction:
+    /// `(cpu_row - cpu_columnar) / cpu_row`. `None` when either CPU reading is
+    /// missing. This is the write-path share, not the end-to-end load share:
+    /// the full bulk load also pays Parquet decode on both paths, which this
+    /// differential excludes, so the pivot's share of total load CPU is lower.
+    pub fn pivot_cpu_share(&self) -> Option<f64> {
+        let row = self.row.cpu?.as_secs_f64();
+        let col = self.columnar.cpu?.as_secs_f64();
+        if row <= 0.0 {
+            return None;
+        }
+        Some((row - col) / row)
+    }
+}
+
+// ------------------------------------------------------------------ corpus
+
+/// Column layout of the synthetic corpus: `int_cols` `Int64` attribute columns
+/// and `str_cols` `Utf8` attribute columns, plus `ts` and `body`. ClickBench's
+/// `hits` is ~105 columns, integer-heavy with a string minority; the defaults
+/// mirror that shape and land in the wide regime where `wide_gather` shows the
+/// per-row pivot dominating the block encode.
+#[derive(Debug, Clone, Copy)]
+pub struct CorpusShape {
+    pub rows: usize,
+    pub int_cols: usize,
+    pub str_cols: usize,
+}
+
+impl Default for CorpusShape {
+    fn default() -> Self {
+        CorpusShape {
+            rows: 50_000,
+            int_cols: 60,
+            str_cols: 40,
+        }
+    }
+}
+
+fn corpus_schema(shape: CorpusShape) -> SchemaRef {
+    let mut fields = vec![
+        Field::new("ts", DataType::Int64, false),
+        Field::new("body", DataType::Utf8, false),
+    ];
+    for i in 0..shape.int_cols {
+        fields.push(Field::new(format!("int_{i:02}"), DataType::Int64, false));
+    }
+    for i in 0..shape.str_cols {
+        fields.push(Field::new(format!("str_{i:02}"), DataType::Utf8, false));
+    }
+    Arc::new(Schema::new(fields))
+}
+
+/// Builds one deterministic ClickBench-shaped `RecordBatch`. Values are derived
+/// from the row and column indices (no RNG), so the corpus is byte-stable
+/// across runs and hosts. String columns repeat over a small alphabet per
+/// column, the shape a dictionary-encoded categorical export takes.
+fn corpus_batch(shape: CorpusShape, schema: &SchemaRef) -> RecordBatch {
+    let n = shape.rows;
+    let ts: Vec<i64> = (0..n).map(|r| 1_700_000_000_000_000_000 + r as i64 * 1_000_000).collect();
+    let body: Vec<String> = (0..n)
+        .map(|r| format!("request {} served in {}ms", r, r % 250))
+        .collect();
+
+    let mut columns: Vec<ArrayRef> = Vec::with_capacity(2 + shape.int_cols + shape.str_cols);
+    columns.push(Arc::new(Int64Array::from(ts)));
+    columns.push(Arc::new(StringArray::from(body)));
+
+    for c in 0..shape.int_cols {
+        let col: Vec<i64> = (0..n).map(|r| (r as i64).wrapping_mul(31).wrapping_add(c as i64)).collect();
+        columns.push(Arc::new(Int64Array::from(col)));
+    }
+    for c in 0..shape.str_cols {
+        // A small per-column alphabet (16 distinct values) so the column reads
+        // like a low-cardinality categorical, the ClickBench-typical shape.
+        let col: Vec<String> = (0..n).map(|r| format!("s{c:02}_{}", (r + c) % 16)).collect();
+        columns.push(Arc::new(StringArray::from(col)));
+    }
+
+    RecordBatch::try_new(Arc::clone(schema), columns).expect("build corpus batch")
+}
+
+/// Encodes the corpus to an in-memory Parquet buffer with the default writer
+/// properties (plain `BYTE_ARRAY` for the string columns, so the read-back
+/// carries no Arrow `Dictionary` type and #660's dictionary path stays off).
+pub fn clickbench_shaped_parquet(shape: CorpusShape) -> Vec<u8> {
+    let schema = corpus_schema(shape);
+    let batch = corpus_batch(shape, &schema);
+    let mut buf: Vec<u8> = Vec::new();
+    let mut writer = ArrowWriter::try_new(&mut buf, schema, None).expect("arrow writer");
+    writer.write(&batch).expect("write batch");
+    writer.close().expect("close writer");
+    buf
+}
+
+/// Reads `parquet_bytes` back through the real async-capable Parquet reader and
+/// maps each row to a [`NormalizedLogRecord`]: `ts`/`body` to their fields, and
+/// every attribute column to one per-record attribute (`Int64` to
+/// [`AttrValue::I64`], `Utf8` to [`AttrValue::Str`]). Every record shares the
+/// [`RESOURCE_ATTRS`] stream identity. This decode runs once and feeds both
+/// paths, so it is not part of the differential.
+pub fn decode_corpus(parquet_bytes: &[u8]) -> Result<Vec<NormalizedLogRecord>, CompareError> {
+    let bytes = bytes::Bytes::copy_from_slice(parquet_bytes);
+    let builder = ParquetRecordBatchReaderBuilder::try_new(bytes)
+        .map_err(|e| CompareError::Parquet(e.to_string()))?;
+    let reader = builder.build().map_err(|e| CompareError::Parquet(e.to_string()))?;
+
+    let res: Vec<(String, AttrValue)> = RESOURCE_ATTRS
+        .iter()
+        .map(|(k, v)| ((*k).to_string(), AttrValue::Str((*v).to_string())))
+        .collect();
+    let scope_attrs: Vec<(String, AttrValue)> = Vec::new();
+    let stream_id = log_stream_id(&res, "bench", "", &scope_attrs);
+    let stream_attrs = stream_attrs_bytes(&res, "bench", "", &scope_attrs);
+
+    let mut records = Vec::new();
+    for batch in reader {
+        let batch = batch.map_err(|e| CompareError::Parquet(e.to_string()))?;
+        let schema = batch.schema();
+        let ts = batch
+            .column_by_name("ts")
+            .and_then(|c| c.as_any().downcast_ref::<Int64Array>())
+            .ok_or_else(|| CompareError::Parquet("missing Int64 `ts` column".into()))?;
+        let body = batch
+            .column_by_name("body")
+            .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+            .ok_or_else(|| CompareError::Parquet("missing Utf8 `body` column".into()))?;
+
+        // Pre-resolve the attribute columns once per batch.
+        enum Col<'a> {
+            I64(&'a Int64Array),
+            Str(&'a StringArray),
+        }
+        let mut attr_cols: Vec<(String, Col)> = Vec::new();
+        for (idx, field) in schema.fields().iter().enumerate() {
+            let name = field.name();
+            if name == "ts" || name == "body" {
+                continue;
+            }
+            let arr = batch.column(idx);
+            let col = match arr.data_type() {
+                DataType::Int64 => Col::I64(
+                    arr.as_any()
+                        .downcast_ref::<Int64Array>()
+                        .ok_or_else(|| CompareError::Parquet(format!("{name}: not Int64")))?,
+                ),
+                DataType::Utf8 => Col::Str(
+                    arr.as_any()
+                        .downcast_ref::<StringArray>()
+                        .ok_or_else(|| CompareError::Parquet(format!("{name}: not Utf8")))?,
+                ),
+                other => {
+                    return Err(CompareError::Parquet(format!(
+                        "{name}: unexpected column type {other:?}"
+                    )));
+                }
+            };
+            attr_cols.push((name.clone(), col));
+        }
+
+        for row in 0..batch.num_rows() {
+            let mut attrs: Vec<(String, AttrValue)> = Vec::with_capacity(attr_cols.len());
+            for (name, col) in &attr_cols {
+                let v = match col {
+                    Col::I64(a) => AttrValue::I64(a.value(row)),
+                    Col::Str(a) => AttrValue::Str(a.value(row).to_string()),
+                };
+                attrs.push((name.clone(), v));
+            }
+            let ts_ns = ts.value(row);
+            records.push(NormalizedLogRecord {
+                stream_id,
+                stream_attrs: stream_attrs.clone(),
+                ts_ns,
+                observed_ts_ns: ts_ns,
+                severity_num: 9,
+                severity_text: "INFO".to_string(),
+                body: body.value(row).to_string(),
+                trace_id: None,
+                span_id: None,
+                flags: 0,
+                attrs,
+            });
+        }
+    }
+    Ok(records)
+}
+
+// ------------------------------------------------------------------ measure
+
+/// A field-for-field rename of a [`NormalizedLogRecord`] into the
+/// [`LogRecord`] shape [`ColumnarLogBatch::from_records`] consumes.
+fn to_logrecord(r: &NormalizedLogRecord) -> LogRecord {
+    LogRecord {
+        stream_id: r.stream_id,
+        stream_attrs: r.stream_attrs.clone(),
+        ts_ns: r.ts_ns,
+        observed_ts_ns: r.observed_ts_ns,
+        severity_num: r.severity_num,
+        severity_text: r.severity_text.clone(),
+        body: r.body.clone(),
+        trace_id: r.trace_id,
+        span_id: r.span_id,
+        flags: r.flags,
+        attrs: r.attrs.clone(),
+    }
+}
+
+/// One prefetched batch's input, already in the shape its path's router method
+/// consumes. Both variants are built *before* the timed region: the row vec is
+/// cloned and the columnar batch is pivoted by `from_records` up front, exactly
+/// as the shipping loader builds its columnar batch in the decode task, off the
+/// flush critical path. So the timed region is the router call alone.
+enum Built {
+    Row(Vec<NormalizedLogRecord>),
+    Columnar(Box<ColumnarLogBatch>),
+}
+
+fn config(shards: u32) -> IngestConfig {
+    // `target_bytes: 1` flushes each write as one RLOG object inside the size
+    // trigger, so every batch is one object with no lingering buffer, and flush
+    // timing stays off the wall clock. Same config the CLI loader uses.
+    IngestConfig {
+        shard_count: shards,
+        target_bytes: 1,
+        ..IngestConfig::default()
+    }
+}
+
+/// Runs the whole corpus through one path and returns its measured report.
+///
+/// The per-batch input is built for `path` before the timed region; the timed
+/// region is the write loop. `row_batches`/`columnar_batches` are each bumped
+/// in the same match arm that calls the path's router method -- the reachability
+/// signal that proves this run drove the path it claims to.
+async fn measure_path(
+    path: LoadPath,
+    records: &[NormalizedLogRecord],
+    shards: u32,
+    batch_rows: usize,
+) -> Result<PathReport, CompareError> {
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+    let clock: Arc<dyn Clock> = Arc::new(SystemClock);
+    let router = LogIngestRouter::new(config(shards), Arc::clone(&store), clock);
+    let tenant = TenantId::new("clickbench-local");
+
+    // Build every batch's input up front (outside the timed region). This is
+    // the decisive line the acceptance test's flip targets: selecting `Row`
+    // here for the columnar path makes the columnar run measure the row path.
+    let batches: Vec<Built> = records
+        .chunks(batch_rows.max(1))
+        .map(|chunk| match path {
+            LoadPath::Row => Built::Row(chunk.to_vec()),
+            LoadPath::Columnar => {
+                let logrecs: Vec<LogRecord> = chunk.iter().map(to_logrecord).collect();
+                Built::Columnar(Box::new(ColumnarLogBatch::from_records(&logrecs)))
+            }
+        })
+        .collect();
+
+    let mut report = PathReport {
+        path,
+        rows_processed: 0,
+        objects_written: 0,
+        row_batches: 0,
+        columnar_batches: 0,
+        wall: Duration::ZERO,
+        cpu: None,
+    };
+
+    let cpu_start = process_cpu();
+    let wall_start = Instant::now();
+    for built in batches {
+        let receipt = match built {
+            Built::Row(recs) => {
+                report.row_batches += 1;
+                let n = recs.len() as u64;
+                let r = router
+                    .write(tenant.clone(), recs, WriteMode::Strict, WRITE_ACK_DEADLINE)
+                    .await
+                    .map_err(|e| CompareError::Write {
+                        path: "row",
+                        cause: e.to_string(),
+                    })?;
+                report.rows_processed += n;
+                r
+            }
+            Built::Columnar(batch) => {
+                report.columnar_batches += 1;
+                let n = batch.num_rows as u64;
+                let r = router
+                    .write_columnar(tenant.clone(), *batch, WriteMode::Strict, WRITE_ACK_DEADLINE)
+                    .await
+                    .map_err(|e| CompareError::Write {
+                        path: "columnar",
+                        cause: e.to_string(),
+                    })?;
+                report.rows_processed += n;
+                r
+            }
+        };
+        report.objects_written += receipt.tokens.len();
+    }
+    // Strict acks already guarantee durability; this is a defensive no-op.
+    router.flush_all().await;
+    report.wall = wall_start.elapsed();
+    report.cpu = match (cpu_start, process_cpu()) {
+        (Some(a), Some(b)) => b.checked_sub(a),
+        _ => None,
+    };
+    Ok(report)
+}
+
+/// Loads the same decoded corpus through both paths and returns both reports.
+/// Runs the row path first, then the columnar path, each on its own fresh
+/// router and store so neither warms the other's caches.
+pub async fn compare(
+    records: &[NormalizedLogRecord],
+    shape: CorpusShape,
+    shards: u32,
+    batch_rows: usize,
+    parquet_bytes: usize,
+) -> Result<CompareReport, CompareError> {
+    let row = measure_path(LoadPath::Row, records, shards, batch_rows).await?;
+    let columnar = measure_path(LoadPath::Columnar, records, shards, batch_rows).await?;
+    Ok(CompareReport {
+        row,
+        columnar,
+        corpus_rows: records.len(),
+        columns: 2 + shape.int_cols + shape.str_cols,
+        attr_columns: shape.int_cols + shape.str_cols,
+        shards,
+        batch_rows,
+        parquet_bytes,
+    })
+}
+
+/// Convenience: build the sample, decode it, and run the comparison.
+pub async fn run(
+    shape: CorpusShape,
+    shards: u32,
+    batch_rows: usize,
+) -> Result<CompareReport, CompareError> {
+    let parquet = clickbench_shaped_parquet(shape);
+    let records = decode_corpus(&parquet)?;
+    compare(&records, shape, shards, batch_rows, parquet.len()).await
+}
+
+/// Process CPU time (user + system) from `/proc/self/stat`, or `None` off Linux
+/// or on an unparseable line. Fields 14 (`utime`) and 15 (`stime`) are in clock
+/// ticks; Linux fixes `USER_HZ` at 100, so one tick is 10ms.
+fn process_cpu() -> Option<Duration> {
+    let stat = std::fs::read_to_string("/proc/self/stat").ok()?;
+    // The `comm` field is parenthesized and may contain spaces or ')', so split
+    // after the last ')': the remaining fields start at `state` (field 3).
+    let rest = &stat[stat.rfind(')')? + 1..];
+    let fields: Vec<&str> = rest.split_whitespace().collect();
+    // utime is field 14 -> index 11 after `state`; stime is field 15 -> 12.
+    let utime: u64 = fields.get(11)?.parse().ok()?;
+    let stime: u64 = fields.get(12)?.parse().ok()?;
+    const USER_HZ: u64 = 100;
+    Some(Duration::from_nanos(
+        (utime + stime).saturating_mul(1_000_000_000 / USER_HZ),
+    ))
+}

--- a/crates/ravel-bench/src/lib.rs
+++ b/crates/ravel-bench/src/lib.rs
@@ -3,6 +3,8 @@
 
 pub mod bench_env;
 pub mod codecs;
+#[cfg(feature = "parquet-baseline")]
+pub mod columnar_load;
 pub mod concurrent;
 pub mod distrib_crossover;
 pub mod e2e;

--- a/crates/ravel-bench/tests/columnar_load_compare.rs
+++ b/crates/ravel-bench/tests/columnar_load_compare.rs
@@ -1,0 +1,97 @@
+//! Acceptance test for the ADR-0109 differential harness (#606): the comparison
+//! must run BOTH the row path (`LogIngestRouter::write`) and the columnar path
+//! (`LogIngestRouter::write_columnar`) over the same input, so it cannot
+//! silently degenerate into measuring one path twice.
+//!
+//! The proof is the two reachability counters. `row_batches` is bumped only in
+//! the match arm that calls `write`; `columnar_batches` only in the arm that
+//! calls `write_columnar`. A run that measured the row path twice would report
+//! `columnar_batches == 0` for the columnar run, and this test fails there.
+//!
+//! Demonstrated failing before the fix (issue #606 acceptance): flipping the
+//! decisive line in `measure_path` (the `LoadPath::Columnar` arm of the
+//! per-batch input `match`) to `Built::Row(chunk.to_vec())` makes the columnar
+//! run drive `write`, leaving `columnar_batches == 0`. The
+//! `columnar_run_drove_write_columnar` assertion below then fails with:
+//!   "the columnar run must drive write_columnar, got columnar_batches=0".
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use ravel_bench::columnar_load::{self, CorpusShape};
+
+/// A small corpus: enough rows for two batches per path, wide enough to have a
+/// real per-row pivot, but fast to build and load under the test gate.
+fn small_shape() -> CorpusShape {
+    CorpusShape {
+        rows: 2_000,
+        int_cols: 12,
+        str_cols: 8,
+    }
+}
+
+#[tokio::test]
+async fn comparison_runs_both_paths_over_the_same_input() {
+    let shape = small_shape();
+    let shards = 1;
+    let batch_rows = 800; // 2000 rows -> 3 batches per path.
+
+    let parquet = columnar_load::clickbench_shaped_parquet(shape);
+    let records = columnar_load::decode_corpus(&parquet).expect("decode corpus");
+    assert_eq!(
+        records.len(),
+        shape.rows,
+        "the decoded corpus must have one record per source row"
+    );
+
+    let report = columnar_load::compare(&records, shape, shards, batch_rows, parquet.len())
+        .await
+        .expect("comparison run");
+
+    // Both paths saw the same input.
+    assert_eq!(
+        report.row.rows_processed, report.columnar.rows_processed,
+        "both paths must process the same row count"
+    );
+    assert_eq!(
+        report.row.rows_processed, shape.rows as u64,
+        "the row path must process every corpus row"
+    );
+    assert_eq!(
+        report.row.objects_written, report.columnar.objects_written,
+        "the same input over the same shard count must write the same object count"
+    );
+    assert!(
+        report.row.objects_written > 0,
+        "the load must actually write objects"
+    );
+
+    // The row run drove `write` and only `write`.
+    assert!(
+        report.row.row_batches > 0,
+        "the row run must drive write, got row_batches=0"
+    );
+    assert_eq!(
+        report.row.columnar_batches, 0,
+        "the row run must never drive write_columnar, got columnar_batches={}",
+        report.row.columnar_batches
+    );
+
+    // The columnar run drove `write_columnar` and only `write_columnar`. This is
+    // the assertion the pre-fix flip trips.
+    assert!(
+        report.columnar.columnar_batches > 0,
+        "the columnar run must drive write_columnar, got columnar_batches={}",
+        report.columnar.columnar_batches
+    );
+    assert_eq!(
+        report.columnar.row_batches, 0,
+        "the columnar run must never drive write, got row_batches={}",
+        report.columnar.row_batches
+    );
+
+    // The two runs are distinct paths, not one path measured twice: each drove
+    // its own method the same number of batches, and neither drove the other's.
+    assert_eq!(
+        report.row.row_batches, report.columnar.columnar_batches,
+        "row and columnar runs must cover the same number of batches by their own method"
+    );
+}

--- a/docs/adrs/0109-columnar-bulk-load-fast-path.md
+++ b/docs/adrs/0109-columnar-bulk-load-fast-path.md
@@ -259,6 +259,44 @@ not a production profile. Wave 1 lands that microbench as a permanent
 measurement is a before-and-after on the reference box, not this
 arithmetic.
 
+**Measured (issue #606): the arithmetic above does not hold at ClickBench
+width.** The first end-to-end differential between the two write paths
+contradicts the leap from the gather microbench ratio to "roughly 78 points of
+load CPU". It is a local figure (`ravel-bench`'s `columnar_load_compare`,
+x86_64 EPYC-Rome, 8 cores, release, in-memory `MemoryStore`, `--shards 1`) on a
+bounded synthetic ClickBench-shaped sample, not the reference-box result, and
+it deliberately excludes decision 3's dictionary path (which does not engage on
+plain-`BYTE_ARRAY` ClickBench Parquet anyway, issue #660) and all S3, multi-
+shard, and real-PUT cost:
+
+- At ~100 attribute columns (ClickBench's shape) the columnar path shows **no
+  measurable write-path CPU reduction** over the row path -- three runs at
+  50,000 rows landed between -4% and +1%, i.e. within run-to-run noise, the
+  columnar path if anything marginally slower.
+- A reduction appears only at 300 attribute columns (~14-16%, three times
+  wider than ClickBench). The saving scales super-linearly with column count,
+  consistent with the removed cost being the quadratic gather, but that term is
+  not a large share of the full object build at ClickBench width.
+
+The microbench this decision rests on is real and reproduces: on the same host
+`wide_gather` (`--quick`) puts the isolated gather at ~99% of `write_block` at
+105 columns (413 ms vs 419 ms) and ~23% at 10. What does not survive is the
+inference from that ratio to the end-to-end load. Two costs the arithmetic
+counted as removed are still paid on the landed columnar path: `resolve_row`'s
+per-row merged-view and `attrs_raw` derivation is reproduced per row inside
+`build_object_columnar` (only the `column_of` probe and the gather change
+shape), and the columnar block build materializes a dense per-column value
+matrix whose copies replace part of the gather it removes. The 25-35%-of-CPU
+remainder and the "under 10 minutes on 16 cores" wall-time target are therefore
+**not confirmed by this measurement**; whether they hold on the reference box
+with the full ClickBench corpus and decision 3 engaged remains the open
+before-and-after that measurement (still unpaid here) is meant to answer. This
+result is not evidence the fast path is worthless -- it removes a genuinely
+quadratic cost and it wins at high column counts -- but it is evidence that the
+specific magnitude decision 8 predicted does not appear at ClickBench width in
+the write path this harness can see. See docs/ingest.md ("CPU cost of the
+columnar load path vs the row path (measured)") for the full method and scope.
+
 ## Rejected alternatives
 
 **Bypass the router: have the CLI build and commit RLOG objects directly.**

--- a/docs/ingest.md
+++ b/docs/ingest.md
@@ -700,6 +700,72 @@ also visible and grows with shared-label cardinality. The only object-store
 work is the CRC32C over the in-memory PUT; a real S3 backend adds network
 I/O this in-memory profile omits.
 
+## CPU cost of the columnar load path vs the row path (measured)
+
+ADR-0109 replaced the bulk loader's per-row write path
+(`LogIngestRouter::write`, which pivots each row into columns inside the RLOG
+writer) with a columnar fast path (`LogIngestRouter::write_columnar`, which
+stages contiguous per-column arrays and skips the `write_block` gather and the
+per-attribute `column_of` probe). Decision 8 of that ADR *argued from a
+microbench ratio* that removing the pivot addresses roughly 78 points of load
+CPU; no end-to-end number had ever been measured. This is the first one
+(`ravel-bench`'s `columnar_load_compare` bin, issue #606).
+
+- Host: x86_64, AMD EPYC-Rome, 8 logical cores, ~15 GiB RAM. Build profile:
+  `release`.
+- Workload: a synthetic ClickBench-shaped Parquet sample (integer-heavy with a
+  string minority, values derived from row/column indices) decoded once and
+  loaded through both paths on a fresh in-process router and `MemoryStore`
+  each. `--shards 1` (whole corpus on one shard, so the differential is the
+  write-path pivot alone and not shard fan-out), `--batch-rows 10000`
+  (one RLOG object per batch, Strict acks).
+- CPU is process user+system time from `/proc/self/stat` across the write loop
+  only; the Parquet decode and the columnar-batch build both happen before the
+  timed region, exactly as the shipping loader builds its columnar batch in the
+  decode task off the flush critical path.
+
+Measured, at two column widths (three runs each at 100 columns, two at 300):
+
+| corpus | rows | row-path write CPU | columnar-path write CPU | pivot share of row write CPU |
+|---|---|---|---|---|
+| 100 attribute columns (ClickBench width) | 50,000 | ~7.0-7.5 s | ~7.3-7.5 s | **-4% to +1% (no measurable reduction)** |
+| 300 attribute columns (exaggerated width) | 20,000 | ~13.7-14.0 s | ~11.8-12.1 s | ~14-16% |
+
+At the ClickBench-representative ~100-column shape the columnar path is within
+run-to-run noise of the row path (if anything marginally slower); a reduction
+only becomes visible (~15%) at 300 columns, three times wider than ClickBench's
+~105. The saving scales super-linearly with column count, consistent with the
+removed cost being the quadratic gather, but that quadratic term is not yet a
+large share of the full object build at ClickBench width: the columnar path
+still pays the per-row merged-view/`attrs_raw` derivation `build_object_columnar`
+retains, plus block framing, compression, indexing, and the object PUT, none of
+which the pivot removal touches.
+
+What this measurement supports and what it does not:
+
+- **It is a local differential on a bounded synthetic sample, not the
+  ClickBench reference figure.** The reference-box run (c6a.4xlarge, full
+  `hits.parquet`, S3) is deliberately out of scope. Nothing here should be read
+  as the reference result.
+- **It measures the epic WITHOUT ADR-0109 decision 3 contributing.** The
+  columnar batch is built through `ColumnarLogBatch::from_records`, which
+  attaches no dictionaries, so the dictionary-preserving column and
+  dictionary-aware bloom path never engages -- exactly as it fails to engage on
+  ClickBench-shaped plain-`BYTE_ARRAY` Parquet (issue #660, arrow-rs fuses the
+  column's dictionary away on decode). Decision 8's arithmetic counted those
+  savings; this number does not include them.
+- **The store is in-memory.** S3 latency, multi-shard fan-out scaling, and real
+  PUT round trips are invisible to this harness; the CRC32C over the in-memory
+  PUT is the only object-store work timed. The differential also excludes the
+  Parquet decode (shared by both paths), so it reports the pivot's share of the
+  *write* CPU, not of end-to-end load CPU, which is lower again.
+- The isolated microbench decision 8 rests on is
+  `crates/ravel-logseg/benches/wide_gather.rs`: on this host (`--quick`) the
+  gather is ~23% of `write_block` at 10 columns and ~99% of it at 105
+  (gather 413 ms vs `write_block` 419 ms). The gather dominating the isolated
+  block encode does **not** translate into a proportional end-to-end write-path
+  saving at that width, which is the gap this measurement exposes.
+
 ## Metrics (self-observability)
 
 `IngestMetrics` (crates/ravel-ingest/src/metrics.rs) exposes process-global


### PR DESCRIPTION
ADR-0109 decision 8 predicted, from a gather microbench ratio, that removing
the per-row pivot would address roughly 78 points of load CPU and put a
16-core reference load under ten minutes. That was arithmetic. This is the
first measurement anyone has taken, and it contradicts it.

A differential harness loads the same bounded sample through both paths in
one process and reports wall time and CPU for each. At ~100 attribute
columns, ClickBench's shape, the columnar path shows no measurable
write-path CPU reduction: three runs at 50,000 rows landed between -4% and
+1%, within noise. A reduction appears only at 300 columns, around 14-16%.

The microbench itself reproduces exactly: the isolated gather is ~99% of
`write_block` at 105 columns and ~23% at 10. What does not survive is the
inference from that ratio to the end-to-end load. Two costs the arithmetic
counted as removed are still paid: the per-row merged-view and `attrs_raw`
derivation is reproduced inside `build_object_columnar`, and the columnar
block build materializes a dense per-column value matrix whose copies
replace part of the gather they remove.

ADR-0109 decision 8 is amended in place to say this. The estimate is not
restated as confirmed and its range is not widened to cover the result.

The figure is local and deliberately narrow, and the amendment lists what it
cannot see rather than summarizing it: no S3 or real object-store latency,
single shard, no real PUT round trips, no decision 3 dictionary path (which
does not engage on ClickBench Parquet at all, #660), and no Parquet decode,
which happens once before the timed region.

The acceptance test exists because the comparison could otherwise degenerate
into measuring one path twice: it asserts the columnar run actually drove
`write_columnar`, and was demonstrated failing when that arm is pointed back
at the row path.

Reported and not fixed, outside this task's scope: `cargo clippy -p
ravel-bench --features parquet-baseline --all-targets` fails on
`large_enum_variant` in `src/bin/read_path_accounting.rs`. It is latent
because no default gate or CI job compiles that feature's bin lane.

Fixes: #606
Refs: #597, #660
