### PR TITLE
fix(promql): irate/idelta histogram warnings, scale bug, and reset direction

### DIFF
--- a/crates/ravel-promql-difftest/corpus/histogram_native.txt
+++ b/crates/ravel-promql-difftest/corpus/histogram_native.txt
@@ -261,3 +261,60 @@ kind: instant
 time: +600s
 mode: unordered
 expect: empty
+
+# Counter-family functions over native histograms (ADR-0108 decision 5, #650).
+# Before #650 irate/idelta/resets/changes routed a pure-histogram window to a
+# silent Drop (empty, no annotation), diverging from Prometheus v3.13.1, which
+# defines all four over histograms. resets/changes reduce a histogram window to
+# a FLOAT (a reset/change count), so the existing float comparator applies and
+# both endpoints are pinned here. Over the monotonic counter dataset resets is
+# 0 (no downward step) and changes counts every adjacent differing pair; each
+# used to answer empty over histogram data.
+#
+# irate/idelta are pinned by ravel-promql unit tests
+# (tests/histogram_native.rs) rather than corpus entries: idelta over a counter
+# histogram makes Prometheus emit a NativeHistogramNotGauge warning (an
+# annotation), which this corpus deliberately excludes (see the header), and
+# irate's histogram-valued result is pinned by unit test alongside it.
+name: native_histogram_resets_range
+query: resets(diff_native_hist[5m])
+kind: range
+start: +300s
+end: +600s
+step: 60s
+mode: unordered
+
+name: native_histogram_resets_instant
+query: resets(diff_native_hist[5m])
+kind: instant
+time: +600s
+mode: unordered
+
+name: native_histogram_changes_range
+query: changes(diff_native_hist[5m])
+kind: range
+start: +300s
+end: +600s
+step: 60s
+mode: unordered
+
+name: native_histogram_changes_instant
+query: changes(diff_native_hist[5m])
+kind: instant
+time: +600s
+mode: unordered
+
+# Instant query whose top-level result is a range vector carrying native
+# histograms (#643). Prometheus answers with a matrix carrying the histogram
+# steps; Ravel's instant Value::Matrix is float-only, so rather than drop the
+# histograms at HTTP 200 it refuses with a typed 422 Unsupported (ADR-0108
+# decision 8). This is a one-sided divergence, registered with the ADR-0030
+# comparator mode (comparator.rs compare_ravel_error_prom_success): it asserts
+# exactly that Ravel errors by design while Prometheus succeeds. The refusal is
+# also covered by a ravel-promql unit test
+# (instant_matrix_selector_over_native_histograms_refuses_rather_than_dropping).
+name: native_histogram_instant_matrix_selector_refused
+query: diff_native_hist[5m]
+kind: instant
+time: +600s
+mode: ravel_error_prom_success

--- a/crates/ravel-promql-difftest/corpus/histogram_native.txt
+++ b/crates/ravel-promql-difftest/corpus/histogram_native.txt
@@ -15,11 +15,13 @@
 # `diff_native_hist` selector, or `sum(diff_native_hist_agg)` without a
 # `histogram_count`/`histogram_sum` wrapper) need a histogram-aware comparator,
 # still deferred. Entries that would make Prometheus emit a warning/info
-# annotation (mixed classic+native, float+histogram aggregation) are
-# deliberately excluded: the comparator matches annotation presence, so such
-# entries would mismatch on the annotation rather than the value. Those
-# behaviors are pinned by ravel-promql unit tests instead
-# (tests/histogram_native.rs) and listed in the P11 report.
+# annotation Ravel does NOT also emit (mixed classic+native, float+histogram
+# aggregation) are deliberately excluded: the comparator matches annotation
+# presence, so such entries would mismatch on the annotation rather than the
+# value. Those behaviors are pinned by ravel-promql unit tests instead
+# (tests/histogram_native.rs) and listed in the P11 report. An entry whose
+# warning Ravel now DOES emit is includable (the presence matches on both
+# sides); the idelta-over-a-counter entry below is the first such case (#650).
 #
 # NOT float-precision residue after all. The P11 report flagged two suspected
 # residues (bucket_bound arithmetic vs Prometheus' exponentialBounds tables for
@@ -271,11 +273,29 @@ expect: empty
 # 0 (no downward step) and changes counts every adjacent differing pair; each
 # used to answer empty over histogram data.
 #
-# irate/idelta are pinned by ravel-promql unit tests
-# (tests/histogram_native.rs) rather than corpus entries: idelta over a counter
-# histogram makes Prometheus emit a NativeHistogramNotGauge warning (an
-# annotation), which this corpus deliberately excludes (see the header), and
-# irate's histogram-valued result is pinned by unit test alongside it.
+# irate/idelta over histograms (#650). Ravel now raises the same counter/gauge
+# type-mismatch warnings Prometheus does (NativeHistogramNotCounter for irate
+# over a gauge, NativeHistogramNotGauge for idelta over a counter), so the two
+# counter-dataset directions can be pinned here: the comparator matches
+# annotation presence, and idelta over this counter histogram warns on both
+# sides while irate over it (a type-matched counter operation) warns on neither.
+# The two gauge-histogram directions (irate over a gauge -> NativeHistogramNot
+# Counter; idelta over a gauge -> no warning) need a GAUGE-hinted native
+# histogram series, which this dataset does not carry (generator.rs is out of
+# this task's scope); all four directions, including both gauge ones, are pinned
+# by ravel-promql unit tests (tests/histogram_native.rs).
+name: native_histogram_idelta_instant
+query: idelta(diff_native_hist[5m])
+kind: instant
+time: +600s
+mode: unordered
+
+name: native_histogram_irate_instant
+query: irate(diff_native_hist[5m])
+kind: instant
+time: +600s
+mode: unordered
+
 name: native_histogram_resets_range
 query: resets(diff_native_hist[5m])
 kind: range

--- a/crates/ravel-promql-difftest/src/scoring.rs
+++ b/crates/ravel-promql-difftest/src/scoring.rs
@@ -577,6 +577,19 @@ pub static REGISTRY: &[Construct] = &[
          matched histogram data, not the syntactic shape",
     ),
     rejected_modifier(
+        "instant matrix selector over native histograms",
+        "Unsupported: instant query returning a range vector of native \
+         histograms (422 execution)",
+        "a bare matrix selector is a valid instant query whose top-level \
+         result is a range vector; Ravel's instant `Value::Matrix` is \
+         float-only (the histogram-aware channel is the range endpoint's \
+         `RangeValue`, ADR-0108 decision 8), so a selector matching \
+         native-histogram data refuses in `eval_expr`'s `MatrixSelector` arm \
+         (issue #643) rather than silently dropping the histograms at HTTP \
+         200; distinct from the subquery-over-histograms refusal, which \
+         triggers inside `eval_subquery_matrix`",
+    ),
+    rejected_modifier(
         "binary operator over native histograms",
         "Unsupported: binary operator over native histograms (422 execution)",
         "the binop evaluator (`combine_value` and its callers) only ever \
@@ -799,6 +812,16 @@ pub static REJECTION_CASES: &[RejectionCase] = &[
         eval: RejectionEval::Instant,
         time_offset_ms: 0,
         message_contains: "binary operator over native histograms",
+    },
+    RejectionCase {
+        // +600s so the instant query's window matches the generated histogram
+        // series (its samples span the dataset's own range); a bare matrix
+        // selector matching histogram data is the #643 refusal.
+        construct: "instant matrix selector over native histograms",
+        query: "diff_native_hist[5m]",
+        eval: RejectionEval::Instant,
+        time_offset_ms: 600_000,
+        message_contains: "range vector of native histograms",
     },
 ];
 

--- a/crates/ravel-promql/src/aggregate.rs
+++ b/crates/ravel-promql/src/aggregate.rs
@@ -86,6 +86,7 @@ use ravel_types::{Label, LabelSet, METRIC_NAME_LABEL};
 use crate::eval::{
     Error, Evaluator, InstantSample, InstantVector, QueryWindow, Value,
     histogram_ignored_in_aggregation_info, invalid_quantile_warning,
+    mixed_floats_histograms_agg_warning,
 };
 use crate::functions::label::is_valid_label_name;
 use crate::functions::over_time::{kahan_sum_inc, quantile};
@@ -254,8 +255,9 @@ fn eval_plain_aggregate(
 
 /// Reduce one group to its output sample, or `None` to omit the group. `sum`
 /// and `avg` aggregate native histograms when the group holds them; a group
-/// mixing float and histogram members is dropped (Prometheus emits an
-/// "incompatible sample types" annotation and produces no output for it).
+/// mixing float and histogram members is dropped with a warning
+/// (`MixedFloatsHistogramsAggWarning`), matching Prometheus, which produces no
+/// output for such a group.
 /// `min`/`max`/`stddev`/`stdvar` ignore histogram members (float-only
 /// in Prometheus, with an annotation), omitting a group with no float member.
 /// `count` counts every member; `group` is always 1.
@@ -271,7 +273,14 @@ fn reduce_group_samples(
             let (hists, floats): (Vec<InstantSample>, Vec<InstantSample>) =
                 members.into_iter().partition(|s| s.histogram.is_some());
             if !hists.is_empty() && !floats.is_empty() {
-                // Mixed float/histogram group: dropped with an annotation.
+                // Mixed float/histogram group: Prometheus cannot combine the two
+                // types and drops the group with a warning
+                // (`MixedFloatsHistogramsAggWarning`), never silently (ADR-0108
+                // decision 6a, issue #649). The difftest comparator matches
+                // warning presence, so the drop must be annotated. This is a
+                // warning, distinct from the float-only aggregators' "ignored
+                // histogram" info: the whole group is dropped, not a member.
+                ctx.warn(mixed_floats_histograms_agg_warning());
                 return None;
             }
             if !hists.is_empty() {

--- a/crates/ravel-promql/src/eval.rs
+++ b/crates/ravel-promql/src/eval.rs
@@ -402,6 +402,19 @@ pub(crate) fn histogram_ignored_in_aggregation_info(aggregation: &str) -> String
     format!("ignored histogram in {aggregation} aggregation")
 }
 
+/// Prometheus' `MixedFloatsHistogramsAggWarning` message: a `sum`/`avg` group
+/// held both float and native-histogram members, which cannot be combined, so
+/// Prometheus drops the group with this warning (ADR-0108 decision 6a, issue
+/// #649). A warning, not an info: unlike the float-only aggregators that merely
+/// ignore a histogram member of an otherwise-float group
+/// ([`histogram_ignored_in_aggregation_info`]), here a whole group is dropped
+/// because its members are type-incompatible. Verified against the pinned
+/// Prometheus v3.13.1 binary (`promql/engine.go` aggregation, `hasFloat &&
+/// hasHistogram` case) rather than the float-only "ignored histogram" info.
+pub(crate) fn mixed_floats_histograms_agg_warning() -> String {
+    "encountered a mix of histograms and floats for aggregation".to_string()
+}
+
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum Error {
@@ -927,9 +940,31 @@ impl Evaluator {
             Expr::VectorSelector(vs) => self
                 .eval_vector_selector(source, vs, eval_ts_ns, ctx)
                 .map(Value::Vector),
-            Expr::MatrixSelector(ms) => self
-                .eval_matrix_selector(source, ms, eval_ts_ns, ctx)
-                .map(Value::Matrix),
+            Expr::MatrixSelector(ms) => {
+                // A bare matrix selector is a valid instant query whose
+                // top-level result is a range vector (rendered as a matrix).
+                // Ravel's `Value::Matrix` is float-only (the histogram-aware
+                // channel is the range endpoint's `RangeValue`, ADR-0108), so a
+                // selector matching native-histogram data would silently drop
+                // it at HTTP 200. Refuse with a typed 422 instead (ADR-0108
+                // decision 8, issue #643); a float-only matrix selector is
+                // unaffected. This arm is reached only for a top-level (or
+                // paren/unary-wrapped) instant matrix selector: a range query
+                // rejects a top-level range vector in `resolve_range_core`, and
+                // a subquery over histograms already refuses upstream in
+                // `eval_subquery_matrix`.
+                if !self
+                    .eval_histogram_matrix_selector(source, ms, eval_ts_ns, ctx, false)?
+                    .is_empty()
+                {
+                    return Err(Error::Unsupported {
+                        construct: "instant query returning a range vector of native histograms"
+                            .to_string(),
+                    });
+                }
+                self.eval_matrix_selector(source, ms, eval_ts_ns, ctx)
+                    .map(Value::Matrix)
+            }
             Expr::Call(c) => crate::functions::eval_call(self, source, c, eval_ts_ns, ctx),
             Expr::Binary(b) => crate::binop::eval_binary(self, source, b, eval_ts_ns, ctx),
             Expr::Aggregate(a) => {
@@ -1816,6 +1851,60 @@ mod tests {
 
     fn minutes(m: i64) -> i64 {
         m * 60_000
+    }
+
+    #[test]
+    fn instant_matrix_selector_over_native_histograms_refuses_rather_than_dropping() {
+        use crate::histogram::{FloatHistogram, ResetHint, Span};
+        // ADR-0108 / issue #643: a bare matrix selector is a valid instant
+        // query whose top-level result is a range vector. Ravel's
+        // `Value::Matrix` is float-only, so a selector matching
+        // native-histogram data would silently drop it at HTTP 200; it must
+        // refuse with a typed `Error::Unsupported` (422) instead. Before this
+        // fix the histogram series simply vanished and the query returned an
+        // empty matrix with status 200. A float-only matrix selector is
+        // unaffected.
+        let h = FloatHistogram {
+            counter_reset_hint: ResetHint::Unknown,
+            scale: 0,
+            zero_threshold: 0.0,
+            zero_count: 0.0,
+            count: 2.0,
+            sum: 6.0,
+            positive_spans: vec![Span {
+                offset: 1,
+                length: 1,
+            }],
+            negative_spans: Vec::new(),
+            positive_buckets: vec![2.0],
+            negative_buckets: Vec::new(),
+            custom_values: Vec::new(),
+        };
+        let hist_src = TestSource::new()
+            .with_histogram_series(&[("__name__", "h")], &[(minutes(1), h)])
+            .expect("valid histogram series");
+        let err = Evaluator::new()
+            .eval_instant(&hist_src, "h[5m]", minutes(5))
+            .expect_err("instant matrix over histograms must refuse, not drop");
+        assert!(
+            matches!(err, Error::Unsupported { .. }),
+            "expected Error::Unsupported, got {err:?}"
+        );
+
+        let float_src = TestSource::new()
+            .with_series(
+                &[("__name__", "m")],
+                &[(minutes(1), 1.0), (minutes(2), 2.0)],
+            )
+            .expect("valid series");
+        let value = Evaluator::new()
+            .eval_instant(&float_src, "m[5m]", minutes(5))
+            .expect("a float-only matrix selector still evaluates");
+        assert!(
+            matches!(value, Value::Matrix(_)),
+            "float matrix selector still renders a matrix, got {}",
+            value.type_name()
+        );
     }
 
     // --- Warning/info annotations ---

--- a/crates/ravel-promql/src/functions/mod.rs
+++ b/crates/ravel-promql/src/functions/mod.rs
@@ -383,6 +383,13 @@ pub(crate) fn eval_range_call(
                         // A histogram-only window: the float reducer `f` has no
                         // histogram form, so route by member name to the shared
                         // over_time histogram policy (ADR-0108 decision 5).
+                        // `irate`/`idelta` over a histogram pair whose
+                        // counter/gauge typing does not match the operation
+                        // raises the same warning as the instant arm; the
+                        // annotation sink de-duplicates across grid steps.
+                        if let Some(warning) = maybe_hist_type_warning(name, hists) {
+                            ctx.warn(warning);
+                        }
                         return histogram_range_element(
                             over_time::histogram_over_time(name, hists),
                             reported_ts_ns,
@@ -616,6 +623,28 @@ pub(crate) fn eval_range_call(
     }
 }
 
+/// The counter/gauge type-mismatch warning `irate`/`idelta` over a native-
+/// histogram window raises (Prometheus' `instantValue` histogram branch), or
+/// `None` for any other function or a type-matched pair. Shared by the instant
+/// dispatch ([`append_histogram_over_time`]) and the range dispatch
+/// ([`eval_range_call`]'s `RangeVector` arm) so both endpoints annotate
+/// identically. Only `irate`/`idelta` reach this: every other range-vector
+/// member routes its histogram window through the same
+/// [`over_time::histogram_over_time`] policy without a counter/gauge assumption.
+fn maybe_hist_type_warning(name: &str, hists: &[TimedHistogram]) -> Option<String> {
+    let is_rate = match name {
+        "irate" => true,
+        "idelta" => false,
+        _ => return None,
+    };
+    match rate::instant_value_hist_type_warning(hists, is_rate)? {
+        rate::InstantHistTypeWarning::NotCounter => {
+            Some(rate::native_histogram_not_counter_warning())
+        }
+        rate::InstantHistTypeWarning::NotGauge => Some(rate::native_histogram_not_gauge_warning()),
+    }
+}
+
 /// Map a native-histogram [`over_time::HistOverTime`] outcome to a range
 /// element at `reported_ts_ns` (ADR-0108 decision 5): a float or histogram
 /// result becomes the matching [`RangeSample`], a drop becomes `None`.
@@ -654,6 +683,9 @@ fn append_histogram_over_time(
     let hmatrix =
         evaluator.eval_histogram_matrix_selector(source, ms, eval_ts_ns, ctx, keep_metric_name)?;
     for (labels, samples) in hmatrix {
+        if let Some(warning) = maybe_hist_type_warning(name, &samples) {
+            ctx.warn(warning);
+        }
         match over_time::histogram_over_time(name, &samples) {
             over_time::HistOverTime::Float(v) => {
                 out.push(InstantSample::scalar(labels, eval_ts_ns, eval_ts_ns, v));

--- a/crates/ravel-promql/src/functions/mod.rs
+++ b/crates/ravel-promql/src/functions/mod.rs
@@ -623,14 +623,15 @@ pub(crate) fn eval_range_call(
     }
 }
 
-/// The counter/gauge type-mismatch warning `irate`/`idelta` over a native-
-/// histogram window raises (Prometheus' `instantValue` histogram branch), or
-/// `None` for any other function or a type-matched pair. Shared by the instant
-/// dispatch ([`append_histogram_over_time`]) and the range dispatch
+/// The type-mismatch warning `irate`/`idelta` over a native-histogram window
+/// raises (Prometheus' `instantValue` histogram branch), or `None` for any
+/// other function or a type-matched pair. Shared by the instant dispatch
+/// ([`append_histogram_over_time`]) and the range dispatch
 /// ([`eval_range_call`]'s `RangeVector` arm) so both endpoints annotate
 /// identically. Only `irate`/`idelta` reach this: every other range-vector
 /// member routes its histogram window through the same
-/// [`over_time::histogram_over_time`] policy without a counter/gauge assumption.
+/// [`over_time::histogram_over_time`] policy without a counter/gauge or
+/// schema-type assumption.
 fn maybe_hist_type_warning(name: &str, hists: &[TimedHistogram]) -> Option<String> {
     let is_rate = match name {
         "irate" => true,
@@ -642,6 +643,9 @@ fn maybe_hist_type_warning(name: &str, hists: &[TimedHistogram]) -> Option<Strin
             Some(rate::native_histogram_not_counter_warning())
         }
         rate::InstantHistTypeWarning::NotGauge => Some(rate::native_histogram_not_gauge_warning()),
+        rate::InstantHistTypeWarning::MixedSchemas => {
+            Some(rate::mixed_exponential_custom_schemas_warning())
+        }
     }
 }
 

--- a/crates/ravel-promql/src/functions/over_time.rs
+++ b/crates/ravel-promql/src/functions/over_time.rs
@@ -58,10 +58,18 @@ pub(crate) enum HistOverTime {
 ///   (Prometheus' `len(s.Floats) + len(s.Histograms)`).
 /// - `last_over_time` returns the newest histogram in the window.
 /// - `present_over_time` is 1 for any non-empty window regardless of type.
+/// - `irate`/`idelta` produce a native-histogram result over a histogram
+///   window (Prometheus' `instantValue` histogram branch, issue #650), via
+///   [`super::rate::instant_value_hist`]; `resets`/`changes` produce a float
+///   count of counter resets / value changes, via
+///   [`super::rate::resets_hist`]/[`super::rate::changes_hist`].
 /// - every other member (`min`/`max`/`stddev`/`stdvar`/`quantile_over_time`,
-///   `predict_linear`, `deriv`, `irate`/`idelta`/`resets`/`changes`) is
-///   float-only in Prometheus and drops the histogram window with no
-///   annotation, per [`HistOverTime::Drop`].
+///   `predict_linear`, `deriv`) is float-only in Prometheus and drops the
+///   histogram window with no annotation, per [`HistOverTime::Drop`]. `deriv`
+///   is included here deliberately: for a pure-histogram window its
+///   `len(Floats) == 0` early return drops with no annotation, so the drop IS
+///   the oracle-faithful behavior (issue #650's `deriv` framing is corrected in
+///   the fix report).
 pub(crate) fn histogram_over_time(name: &str, hists: &[TimedHistogram]) -> HistOverTime {
     match name {
         "sum_over_time" => match sum_histograms(hists.iter().map(|(_, h)| h)) {
@@ -75,6 +83,16 @@ pub(crate) fn histogram_over_time(name: &str, hists: &[TimedHistogram]) -> HistO
         "count_over_time" => HistOverTime::Float(hists.len() as f64),
         "last_over_time" => HistOverTime::Histogram(hists[hists.len() - 1].1.clone()),
         "present_over_time" => HistOverTime::Float(1.0),
+        "irate" => match super::rate::instant_value_hist(hists, true) {
+            Some(h) => HistOverTime::Histogram(h),
+            None => HistOverTime::Drop,
+        },
+        "idelta" => match super::rate::instant_value_hist(hists, false) {
+            Some(h) => HistOverTime::Histogram(h),
+            None => HistOverTime::Drop,
+        },
+        "resets" => HistOverTime::Float(super::rate::resets_hist(hists)),
+        "changes" => HistOverTime::Float(super::rate::changes_hist(hists)),
         _ => HistOverTime::Drop,
     }
 }

--- a/crates/ravel-promql/src/functions/rate.rs
+++ b/crates/ravel-promql/src/functions/rate.rs
@@ -16,7 +16,7 @@
 
 use ravel_types::Sample;
 
-use crate::histogram::{self, FloatHistogram, TimedHistogram};
+use crate::histogram::{self, FloatHistogram, ResetHint, TimedHistogram};
 
 use super::{FunctionDef, FunctionKind, RangeWindow};
 
@@ -292,6 +292,69 @@ fn instant_value(samples: &[Sample], is_rate: bool) -> Option<f64> {
         result_value /= ms_to_seconds(ns_to_ms(sampled_interval_ns));
     }
     Some(result_value)
+}
+
+/// `irate`/`idelta` over a native-histogram window (Prometheus' `instantValue`
+/// histogram branch): only the last two histograms matter. `idelta`
+/// (`is_rate == false`) always takes the raw difference `last - previous`;
+/// `irate` (`is_rate == true`) skips the subtraction when the pair is a counter
+/// reset (leaving the later histogram, mirroring the float path where a reset
+/// makes the result the last value alone) and then divides by the sampled
+/// interval in seconds. Two samples at the same timestamp have no defined
+/// result and drop, exactly like the float path (`sampledInterval == 0`). The
+/// result is marked gauge-typed, matching Prometheus' `Compact`-then-set-hint
+/// step (the trailing `Compact(0)` only removes empty buckets, which the JSON
+/// renderer already omits, so it is not reproduced here).
+pub(crate) fn instant_value_hist(
+    samples: &[TimedHistogram],
+    is_rate: bool,
+) -> Option<FloatHistogram> {
+    if samples.len() < 2 {
+        return None;
+    }
+    let (last_ts, last) = &samples[samples.len() - 1];
+    let (prev_ts, previous) = &samples[samples.len() - 2];
+    let sampled_interval_ns = last_ts - prev_ts;
+    if sampled_interval_ns == 0 {
+        return None;
+    }
+    let mut result = last.clone();
+    if !is_rate || !last.detect_reset(previous) {
+        result.sub_assign(previous);
+    }
+    result.counter_reset_hint = ResetHint::Gauge;
+    if is_rate {
+        result.div(ms_to_seconds(ns_to_ms(sampled_interval_ns)));
+    }
+    Some(result)
+}
+
+/// `resets` over a native-histogram window (Prometheus' `funcResets` histogram
+/// path): count adjacent pairs where the later histogram is a counter reset
+/// relative to the earlier one ([`FloatHistogram::detect_reset`]). A float, not
+/// a histogram, exactly like the float `resets`.
+pub(crate) fn resets_hist(samples: &[TimedHistogram]) -> f64 {
+    let mut resets = 0i64;
+    for pair in samples.windows(2) {
+        if pair[1].1.detect_reset(&pair[0].1) {
+            resets += 1;
+        }
+    }
+    resets as f64
+}
+
+/// `changes` over a native-histogram window (Prometheus' `funcChanges`
+/// histogram path): count adjacent pairs of unequal histograms (Prometheus'
+/// data-equality `!Equals`, [`FloatHistogram::equals`]). A float, like the
+/// float `changes`.
+pub(crate) fn changes_hist(samples: &[TimedHistogram]) -> f64 {
+    let mut changes = 0i64;
+    for pair in samples.windows(2) {
+        if !pair[1].1.equals(&pair[0].1) {
+            changes += 1;
+        }
+    }
+    changes as f64
 }
 
 /// Port of Prometheus' `linearRegression`: ordinary least squares over the
@@ -685,5 +748,66 @@ mod tests {
             range_hist, instant_hist,
             "the range arm must reduce through the same histogram reducer as the instant arm"
         );
+    }
+
+    #[test]
+    fn irate_hist_takes_last_two_and_divides_by_interval() {
+        // Two histogram samples 30s apart, counts 2 then 8, no reset. irate
+        // takes the raw difference (count 6, sum 30) and divides by the 30s
+        // interval in seconds: 6/30 and 30/30. Result is gauge-typed.
+        let samples = [
+            (ms(0), nh_counter(2.0, 10.0)),
+            (ms(30_000), nh_counter(8.0, 40.0)),
+        ];
+        let got = instant_value_hist(&samples, true).expect("2 samples");
+        assert_eq!(got.count.to_bits(), (6.0_f64 / 30.0).to_bits());
+        assert_eq!(got.sum.to_bits(), (30.0_f64 / 30.0).to_bits());
+        assert_eq!(got.counter_reset_hint, histogram::ResetHint::Gauge);
+    }
+
+    #[test]
+    fn idelta_hist_is_the_raw_difference_without_division_or_reset_detection() {
+        // idelta does not divide and does not detect resets: last - previous,
+        // even when the counter went down.
+        let samples = [
+            (ms(0), nh_counter(8.0, 40.0)),
+            (ms(30_000), nh_counter(2.0, 10.0)),
+        ];
+        let got = instant_value_hist(&samples, false).expect("2 samples");
+        assert_eq!(got.count.to_bits(), (2.0_f64 - 8.0).to_bits());
+        assert_eq!(got.sum.to_bits(), (10.0_f64 - 40.0).to_bits());
+    }
+
+    #[test]
+    fn irate_idelta_hist_fewer_than_two_or_zero_interval_is_none() {
+        let one = [(ms(0), nh_counter(1.0, 1.0))];
+        assert!(instant_value_hist(&one, true).is_none());
+        let same_ts = [
+            (ms(10_000), nh_counter(1.0, 1.0)),
+            (ms(10_000), nh_counter(2.0, 2.0)),
+        ];
+        assert!(instant_value_hist(&same_ts, true).is_none());
+        assert!(instant_value_hist(&same_ts, false).is_none());
+    }
+
+    #[test]
+    fn resets_and_changes_over_histograms_count_transitions() {
+        // counts 2 -> 8 -> 5: one reset (the 8->5 shrink) and two changes (both
+        // adjacent pairs differ).
+        let samples = [
+            (ms(0), nh_counter(2.0, 10.0)),
+            (ms(30_000), nh_counter(8.0, 40.0)),
+            (ms(60_000), nh_counter(5.0, 25.0)),
+        ];
+        assert_eq!(resets_hist(&samples), 1.0, "one downward step 8->5");
+        assert_eq!(changes_hist(&samples), 2.0, "both adjacent pairs differ");
+
+        // A constant series has no resets and no changes.
+        let constant = [
+            (ms(0), nh_counter(3.0, 12.0)),
+            (ms(30_000), nh_counter(3.0, 12.0)),
+        ];
+        assert_eq!(resets_hist(&constant), 0.0);
+        assert_eq!(changes_hist(&constant), 0.0);
     }
 }

--- a/crates/ravel-promql/src/functions/rate.rs
+++ b/crates/ravel-promql/src/functions/rate.rs
@@ -305,6 +305,19 @@ fn instant_value(samples: &[Sample], is_rate: bool) -> Option<f64> {
 /// result is marked gauge-typed, matching Prometheus' `Compact`-then-set-hint
 /// step (the trailing `Compact(0)` only removes empty buckets, which the JSON
 /// renderer already omits, so it is not reproduced here).
+///
+/// The two samples are adjacent samples of the same series but can carry
+/// different schemas (RSEG down-converts a flush whose bucket count exceeds its
+/// limit, so two flushes of one series can persist at different scales), so
+/// both are aligned to the coarser schema before any index-map arithmetic,
+/// exactly as [`histogram::histogram_rate`] does across its whole window.
+/// `detect_reset` and `sub_assign` both assume a comparable schema, so the
+/// alignment happens before either. A custom-buckets operand cannot be
+/// rescaled, so [`FloatHistogram::copy_to_scale`] returns it unchanged and the
+/// subsequent arithmetic combines the index maps as-is, the same shape
+/// `histogram_rate` produces for that mismatch (this crate does not reproduce
+/// Prometheus' outright refusal to combine an exponential-schema histogram with
+/// a custom-buckets one).
 pub(crate) fn instant_value_hist(
     samples: &[TimedHistogram],
     is_rate: bool,
@@ -318,15 +331,79 @@ pub(crate) fn instant_value_hist(
     if sampled_interval_ns == 0 {
         return None;
     }
-    let mut result = last.clone();
-    if !is_rate || !last.detect_reset(previous) {
-        result.sub_assign(previous);
+    let min_scale = previous.scale.min(last.scale);
+    let last = last.copy_to_scale(min_scale);
+    let previous = previous.copy_to_scale(min_scale);
+
+    let mut result = last;
+    if !is_rate || !result.detect_reset(&previous) {
+        result.sub_assign(&previous);
     }
     result.counter_reset_hint = ResetHint::Gauge;
     if is_rate {
         result.div(ms_to_seconds(ns_to_ms(sampled_interval_ns)));
     }
     Some(result)
+}
+
+/// Which counter/gauge type mismatch an `irate`/`idelta` over a native-
+/// histogram pair triggers, mirroring Prometheus' `instantValue` histogram
+/// branch: `irate` (a counter operation) over a gauge-typed pair warns the
+/// metric is not a counter, and `idelta` (a gauge operation) over a pair that
+/// is not gauge-typed warns the metric is not a gauge.
+pub(crate) enum InstantHistTypeWarning {
+    /// `irate` was asked to treat a gauge-typed native histogram as a counter.
+    NotCounter,
+    /// `idelta` was asked to treat a non-gauge native histogram as a gauge.
+    NotGauge,
+}
+
+/// Whether `irate`/`idelta` over the last two histograms in `samples` should
+/// raise a counter/gauge type-mismatch warning (Prometheus' `instantValue`
+/// histogram branch: `NativeHistogramNotCounter` for `irate` over a gauge-hinted
+/// pair, `NativeHistogramNotGauge` for `idelta` over a pair that is not both
+/// gauge-hinted). The check reads each histogram's own `counter_reset_hint` on
+/// entry, before [`instant_value_hist`] overwrites the result's hint with
+/// [`ResetHint::Gauge`]. Returns `None` when no result is produced (fewer than
+/// two samples, or a zero sampled interval), so the warning fires only
+/// alongside a value, exactly as Prometheus' own early returns gate it.
+pub(crate) fn instant_value_hist_type_warning(
+    samples: &[TimedHistogram],
+    is_rate: bool,
+) -> Option<InstantHistTypeWarning> {
+    if samples.len() < 2 {
+        return None;
+    }
+    let (last_ts, last) = &samples[samples.len() - 1];
+    let (prev_ts, previous) = &samples[samples.len() - 2];
+    if last_ts - prev_ts == 0 {
+        return None;
+    }
+    let last_gauge = last.counter_reset_hint == ResetHint::Gauge;
+    let prev_gauge = previous.counter_reset_hint == ResetHint::Gauge;
+    if is_rate {
+        (last_gauge || prev_gauge).then_some(InstantHistTypeWarning::NotCounter)
+    } else {
+        (!last_gauge || !prev_gauge).then_some(InstantHistTypeWarning::NotGauge)
+    }
+}
+
+/// Prometheus' `NativeHistogramNotCounterWarning` message: `irate` (a counter
+/// operation) was applied to a gauge-typed native histogram. Like Ravel's other
+/// ported annotations (`invalid_quantile_warning`,
+/// `mixed_floats_histograms_agg_warning`), this carries the core Prometheus
+/// wording without the `PromQL warning:` prefix, source position, or trailing
+/// metric-name clause Prometheus appends; the differential comparator matches
+/// annotation presence, not text.
+pub(crate) fn native_histogram_not_counter_warning() -> String {
+    "this native histogram metric is not a counter".to_string()
+}
+
+/// Prometheus' `NativeHistogramNotGaugeWarning` message: `idelta` (a gauge
+/// operation) was applied to a native histogram that is not gauge-typed. Same
+/// text convention as [`native_histogram_not_counter_warning`].
+pub(crate) fn native_histogram_not_gauge_warning() -> String {
+    "this native histogram metric is not a gauge".to_string()
 }
 
 /// `resets` over a native-histogram window (Prometheus' `funcResets` histogram

--- a/crates/ravel-promql/src/functions/rate.rs
+++ b/crates/ravel-promql/src/functions/rate.rs
@@ -307,17 +307,37 @@ fn instant_value(samples: &[Sample], is_rate: bool) -> Option<f64> {
 /// renderer already omits, so it is not reproduced here).
 ///
 /// The two samples are adjacent samples of the same series but can carry
-/// different schemas (RSEG down-converts a flush whose bucket count exceeds its
-/// limit, so two flushes of one series can persist at different scales), so
-/// both are aligned to the coarser schema before any index-map arithmetic,
-/// exactly as [`histogram::histogram_rate`] does across its whole window.
-/// `detect_reset` and `sub_assign` both assume a comparable schema, so the
-/// alignment happens before either. A custom-buckets operand cannot be
-/// rescaled, so [`FloatHistogram::copy_to_scale`] returns it unchanged and the
-/// subsequent arithmetic combines the index maps as-is, the same shape
-/// `histogram_rate` produces for that mismatch (this crate does not reproduce
-/// Prometheus' outright refusal to combine an exponential-schema histogram with
-/// a custom-buckets one).
+/// different schemas (RSEG down-converts a flush whose bucket count exceeds
+/// its limit, so two flushes of one series can persist at different scales).
+/// `irate`'s reset check is directional (oracle-verified against three
+/// adjacent-schema shapes, see `functions::rate::tests` and
+/// `tests/histogram_native.rs`): a schema INCREASE (`last.scale >
+/// previous.scale`) is always a reset, since Prometheus never risks
+/// comparing a coarser earlier histogram against newly-visible finer detail.
+/// A schema DECREASE is only a reset if the buckets, once aligned to the
+/// common coarser schema, actually shrank -- `FloatHistogram::detect_reset`'s
+/// own `self.scale != prev.scale` shortcut cannot be called directly on the
+/// unaligned pair for this direction (it would flag every decrease as a
+/// reset, which the oracle disproves), so the decrease path aligns first and
+/// lets `detect_reset` fall through to its real `bucket_shrank` check --
+/// safe post-alignment, since both operands then share one scale and
+/// `detect_reset`'s own scale-mismatch branch never fires. `idelta` has no
+/// reset escape at all (always aligns and subtracts) once a schema-type
+/// mismatch is ruled out; this increase/decrease asymmetry is irate-only.
+/// `histogram_rate` (rate/increase/delta) does not share this directional
+/// logic and keeps its own established behavior (histogram.rs) unchanged.
+///
+/// An exponential-schema sample paired with a custom-buckets one is a
+/// separate case `copy_to_scale` cannot bridge (a custom-buckets operand
+/// reports a schema sentinel far outside the exponential range, and rescaling
+/// the other operand to it overflows the bucket-index shift). Prometheus
+/// refuses to combine the two: `irate` treats the mismatch as a reset (`Sub`
+/// never runs, the later histogram is returned alone) and `idelta` (which
+/// always subtracts) has no reset escape, so it returns no value at all,
+/// alongside [`mixed_exponential_custom_schemas_warning`]. Detect this before
+/// `min_scale`/`copy_to_scale` are ever computed, not by hardening
+/// `copy_to_scale`'s shift arithmetic: even a bounded shift would silently
+/// combine bucket layouts Prometheus does not consider comparable.
 pub(crate) fn instant_value_hist(
     samples: &[TimedHistogram],
     is_rate: bool,
@@ -331,13 +351,47 @@ pub(crate) fn instant_value_hist(
     if sampled_interval_ns == 0 {
         return None;
     }
-    let min_scale = previous.scale.min(last.scale);
-    let last = last.copy_to_scale(min_scale);
-    let previous = previous.copy_to_scale(min_scale);
 
-    let mut result = last;
-    if !is_rate || !result.detect_reset(&previous) {
-        result.sub_assign(&previous);
+    let schema_type_mismatch = previous.uses_custom_buckets() != last.uses_custom_buckets();
+    if schema_type_mismatch && !is_rate {
+        // idelta cannot combine an exponential-schema histogram with a
+        // custom-buckets one and has no reset escape hatch; the warning is
+        // raised by instant_value_hist_type_warning's caller.
+        return None;
+    }
+
+    let mut result = last.clone();
+    if is_rate {
+        // irate's reset check is directional, oracle-verified against three
+        // adjacent-schema shapes (see the crate's checkpoint history for
+        // #650): a schema INCREASE (finer detail newly visible) is always a
+        // reset, matching `FloatHistogram::detect_reset`'s plain
+        // `self.scale != prev.scale` shortcut, which this deliberately does
+        // NOT call directly on unaligned operands for the decrease direction
+        // -- doing so was tried and is wrong (it flags every decrease as a
+        // reset, when Prometheus only does when a bucket actually shrank). A
+        // schema DECREASE (and the custom/exponential mismatch above) must
+        // instead align to the common coarser schema first and let
+        // `detect_reset` fall through to its real `bucket_shrank` check
+        // (safe to call post-alignment: both operands share the aligned
+        // scale, so `detect_reset`'s own scale-mismatch branch never fires).
+        let min_scale = previous.scale.min(last.scale);
+        let is_reset = schema_type_mismatch
+            || last.scale > previous.scale
+            || result
+                .copy_to_scale(min_scale)
+                .detect_reset(&previous.copy_to_scale(min_scale));
+        if !is_reset {
+            result = result.copy_to_scale(min_scale);
+            result.sub_assign(&previous.copy_to_scale(min_scale));
+        }
+    } else {
+        // idelta always subtracts (no reset escape at all) once a schema-type
+        // mismatch has been ruled out above; the schema-increase/decrease
+        // asymmetry above is irate-only.
+        let min_scale = previous.scale.min(last.scale);
+        result = result.copy_to_scale(min_scale);
+        result.sub_assign(&previous.copy_to_scale(min_scale));
     }
     result.counter_reset_hint = ResetHint::Gauge;
     if is_rate {
@@ -346,27 +400,38 @@ pub(crate) fn instant_value_hist(
     Some(result)
 }
 
-/// Which counter/gauge type mismatch an `irate`/`idelta` over a native-
-/// histogram pair triggers, mirroring Prometheus' `instantValue` histogram
-/// branch: `irate` (a counter operation) over a gauge-typed pair warns the
-/// metric is not a counter, and `idelta` (a gauge operation) over a pair that
-/// is not gauge-typed warns the metric is not a gauge.
+/// Which type-mismatch warning an `irate`/`idelta` over a native-histogram
+/// pair triggers, mirroring Prometheus' `instantValue` histogram branch:
+/// `irate` (a counter operation) over a gauge-typed pair warns the metric is
+/// not a counter; `idelta` (a gauge operation) over a pair that is not
+/// gauge-typed warns the metric is not a gauge; either function over a pair
+/// mixing an exponential-schema histogram with a custom-buckets one warns
+/// the schemas don't match (only reachable for `idelta` -- `irate` treats
+/// that mismatch as a silent reset, see [`instant_value_hist`]).
 pub(crate) enum InstantHistTypeWarning {
     /// `irate` was asked to treat a gauge-typed native histogram as a counter.
     NotCounter,
     /// `idelta` was asked to treat a non-gauge native histogram as a gauge.
     NotGauge,
+    /// One operand is custom-buckets and the other exponential-schema.
+    MixedSchemas,
 }
 
 /// Whether `irate`/`idelta` over the last two histograms in `samples` should
-/// raise a counter/gauge type-mismatch warning (Prometheus' `instantValue`
-/// histogram branch: `NativeHistogramNotCounter` for `irate` over a gauge-hinted
-/// pair, `NativeHistogramNotGauge` for `idelta` over a pair that is not both
-/// gauge-hinted). The check reads each histogram's own `counter_reset_hint` on
+/// raise a type-mismatch warning (Prometheus' `instantValue` histogram
+/// branch: [`InstantHistTypeWarning::MixedSchemas`] for an exponential/
+/// custom-buckets pair, `NativeHistogramNotCounter` for `irate` over a
+/// gauge-hinted pair, `NativeHistogramNotGauge` for `idelta` over a pair that
+/// is not both gauge-hinted). The schema-type check runs first since it is
+/// unrelated to counter/gauge hints and `irate` never warns on it (the
+/// mismatch is a silent reset there, not a value-suppressing warning). The
+/// counter/gauge check reads each histogram's own `counter_reset_hint` on
 /// entry, before [`instant_value_hist`] overwrites the result's hint with
-/// [`ResetHint::Gauge`]. Returns `None` when no result is produced (fewer than
-/// two samples, or a zero sampled interval), so the warning fires only
-/// alongside a value, exactly as Prometheus' own early returns gate it.
+/// [`ResetHint::Gauge`]. Returns `None` when no warning applies, or when no
+/// result is produced (fewer than two samples, or a zero sampled interval),
+/// so a warning fires only alongside a value or alongside `idelta`'s
+/// mismatch-driven empty result, exactly as Prometheus' own early returns
+/// gate it.
 pub(crate) fn instant_value_hist_type_warning(
     samples: &[TimedHistogram],
     is_rate: bool,
@@ -378,6 +443,13 @@ pub(crate) fn instant_value_hist_type_warning(
     let (prev_ts, previous) = &samples[samples.len() - 2];
     if last_ts - prev_ts == 0 {
         return None;
+    }
+    if previous.uses_custom_buckets() != last.uses_custom_buckets() {
+        return if is_rate {
+            None
+        } else {
+            Some(InstantHistTypeWarning::MixedSchemas)
+        };
     }
     let last_gauge = last.counter_reset_hint == ResetHint::Gauge;
     let prev_gauge = previous.counter_reset_hint == ResetHint::Gauge;
@@ -404,6 +476,13 @@ pub(crate) fn native_histogram_not_counter_warning() -> String {
 /// text convention as [`native_histogram_not_counter_warning`].
 pub(crate) fn native_histogram_not_gauge_warning() -> String {
     "this native histogram metric is not a gauge".to_string()
+}
+
+/// Prometheus' mixed-schema warning: an exponential-schema histogram and a
+/// custom-buckets one appear adjacent in one series' window. Same text
+/// convention as [`native_histogram_not_counter_warning`].
+pub(crate) fn mixed_exponential_custom_schemas_warning() -> String {
+    "vector contains a mix of histograms with exponential and custom buckets schemas".to_string()
 }
 
 /// `resets` over a native-histogram window (Prometheus' `funcResets` histogram

--- a/crates/ravel-promql/src/histogram.rs
+++ b/crates/ravel-promql/src/histogram.rs
@@ -125,11 +125,54 @@ impl FloatHistogram {
         }
     }
 
-    /// Divide by `scalar` (Prometheus' `FloatHistogram.Div`): implemented as
-    /// `mul(1/scalar)` exactly as Prometheus does, so the reciprocal rounding
-    /// matches.
+    /// Divide by `scalar` (Prometheus' `FloatHistogram.Div`): each population
+    /// (zero, count, sum, and every bucket) is divided by `scalar` directly,
+    /// field for field, exactly as Prometheus' `Div` does. This is NOT
+    /// `mul(1/scalar)`: for a non-power-of-two divisor the two round
+    /// differently, and only the direct division matches the pinned binary.
+    /// Ravel's only callers pass a positive scalar (`avg`'s group size,
+    /// `irate`'s sampled interval), so Prometheus' `scalar == 0`
+    /// bucket-clearing and `scalar < 0` gauge-hint special cases are
+    /// unreachable and not reproduced here.
     pub fn div(&mut self, scalar: f64) {
-        self.mul(1.0 / scalar);
+        self.zero_count /= scalar;
+        self.count /= scalar;
+        self.sum /= scalar;
+        for b in &mut self.positive_buckets {
+            *b /= scalar;
+        }
+        for b in &mut self.negative_buckets {
+            *b /= scalar;
+        }
+    }
+
+    /// Prometheus' `FloatHistogram.Equals`: *data* equality, not mathematical
+    /// equality, so `count`/`sum`/`zero_count` and every bucket compare by bit
+    /// pattern (`NaN`/`-0.0` are data-distinct), `scale`/`zero_threshold` by
+    /// value, and the span layouts exactly. `counter_reset_hint` is
+    /// deliberately not compared. Used by `changes` over native histograms,
+    /// which counts a change whenever two adjacent samples are not `Equals`.
+    pub fn equals(&self, other: &FloatHistogram) -> bool {
+        if self.scale != other.scale
+            || self.zero_threshold != other.zero_threshold
+            || self.zero_count.to_bits() != other.zero_count.to_bits()
+            || self.count.to_bits() != other.count.to_bits()
+            || self.sum.to_bits() != other.sum.to_bits()
+        {
+            return false;
+        }
+        if self.uses_custom_buckets() != other.uses_custom_buckets() {
+            return false;
+        }
+        if self.uses_custom_buckets()
+            && !float_buckets_match(&self.custom_values, &other.custom_values)
+        {
+            return false;
+        }
+        self.positive_spans == other.positive_spans
+            && self.negative_spans == other.negative_spans
+            && float_buckets_match(&self.positive_buckets, &other.positive_buckets)
+            && float_buckets_match(&self.negative_buckets, &other.negative_buckets)
     }
 
     /// `histogram_count`: the stored observation count.
@@ -348,6 +391,14 @@ fn bucket_shrank(prev: &BTreeMap<i32, f64>, curr: &BTreeMap<i32, f64>) -> bool {
         }
     }
     false
+}
+
+/// Per-element bit-pattern equality of two bucket (or custom-value) vectors,
+/// Prometheus' `floatBucketsMatch`: same length and every element equal by
+/// `f64::to_bits`, so `NaN`/`-0.0` are data-distinct, matching Prometheus'
+/// data-equality contract for [`FloatHistogram::equals`].
+fn float_buckets_match(a: &[f64], b: &[f64]) -> bool {
+    a.len() == b.len() && a.iter().zip(b).all(|(x, y)| x.to_bits() == y.to_bits())
 }
 
 /// Merge two side index maps with `self + sign*other` per bucket, keeping a
@@ -901,6 +952,40 @@ mod tests {
         let r = avg_histograms(list.iter()).expect("non-empty");
         assert_eq!(r.count, 3.0);
         assert_eq!(r.sum, 6.0);
+    }
+
+    #[test]
+    fn div_divides_each_field_directly_not_via_reciprocal() {
+        // Dividing by a non-power-of-two (3) is where direct division and
+        // `mul(1/3)` diverge in the last place. Prometheus' `Div` divides
+        // each field directly; the result must match `x / 3.0`, bit for bit,
+        // NOT `x * (1.0 / 3.0)`.
+        let mut h = positive(0, 1, &[10.0, 20.0], 30.0);
+        h.zero_count = 5.0;
+        h.count += 5.0; // 35 total
+        h.div(3.0);
+        assert_eq!(h.count.to_bits(), (35.0_f64 / 3.0).to_bits());
+        assert_eq!(h.sum.to_bits(), (30.0_f64 / 3.0).to_bits());
+        assert_eq!(h.zero_count.to_bits(), (5.0_f64 / 3.0).to_bits());
+        assert_eq!(h.positive_buckets[0].to_bits(), (10.0_f64 / 3.0).to_bits());
+        assert_eq!(h.positive_buckets[1].to_bits(), (20.0_f64 / 3.0).to_bits());
+    }
+
+    #[test]
+    fn equals_ignores_counter_reset_hint_but_compares_populations() {
+        let a = positive(0, 1, &[1.0, 2.0], 3.0);
+        let mut b = a.clone();
+        b.counter_reset_hint = ResetHint::Gauge;
+        assert!(
+            a.equals(&b),
+            "counter_reset_hint is not part of data equality"
+        );
+
+        let c = positive(0, 1, &[1.0, 3.0], 3.0);
+        assert!(!a.equals(&c), "a differing bucket population is not equal");
+
+        let d = positive(0, 1, &[1.0, 2.0], 4.0);
+        assert!(!a.equals(&d), "a differing sum is not equal");
     }
 
     #[test]

--- a/crates/ravel-promql/tests/histogram_native.rs
+++ b/crates/ravel-promql/tests/histogram_native.rs
@@ -12,7 +12,7 @@
 
 use ravel_promql::histogram::{FloatHistogram, ResetHint, Span};
 use ravel_promql::testsource::TestSource;
-use ravel_promql::{Evaluator, InstantSample};
+use ravel_promql::{Evaluator, InstantSample, Value};
 
 /// A positive-only histogram at scale 0, one span from index 1, `counts`
 /// consecutive buckets. Bucket i (1-based) covers `(2^(i-1), 2^i]`.
@@ -196,6 +196,162 @@ fn rate_over_a_native_histogram_compensates_a_counter_reset() {
         (got[0].value - (5.0 * 1.5 / 300.0)).abs() < 1e-12,
         "got {}",
         got[0].value
+    );
+}
+
+#[test]
+fn mixed_float_and_histogram_group_warns_when_dropped_by_sum_and_avg() {
+    // A float series and a histogram series collapse into one group under
+    // sum()/avg(); the type-incompatible group is dropped WITH a warning
+    // (Prometheus' MixedFloatsHistogramsAggWarning), never silently. Before the
+    // #649 fix the group was dropped with no annotation at all, so this
+    // assertion on a non-empty `warnings()` failed. The annotation is a
+    // WARNING, not the float-only aggregators' "ignored histogram" info.
+    for op in ["sum", "avg"] {
+        let src = TestSource::new()
+            .with_series(&[("__name__", "m"), ("i", "1")], &[(0, 5.0)])
+            .expect("valid")
+            .with_histogram_series(&[("__name__", "m"), ("i", "2")], &[(0, hist(&[3.0], 3.0))])
+            .expect("valid");
+        let (value, annos) = Evaluator::new()
+            .eval_instant_annotated(&src, &format!("{op}(m)"), 0)
+            .expect("evaluates");
+        let Value::Vector(out) = value else {
+            panic!("{op} is a vector");
+        };
+        assert!(
+            out.is_empty(),
+            "{op}: mixed group must be dropped, got {out:?}"
+        );
+        assert!(
+            annos
+                .warnings()
+                .iter()
+                .any(|w| w.contains("mix of histograms and floats")),
+            "{op}: dropping a mixed group must warn, warnings={:?}",
+            annos.warnings()
+        );
+        assert!(
+            annos.infos().is_empty(),
+            "{op}: the drop is a warning, not an info: {:?}",
+            annos.infos()
+        );
+    }
+}
+
+#[test]
+fn irate_over_a_native_histogram_yields_a_histogram_element() {
+    // Two histogram samples 30s apart in the (0, 300s] window, counts 2 then 8,
+    // no reset. irate divides the raw difference (count 6, sum 30) by the 30s
+    // interval: count 0.2, sum 1.0. Before the #650 fix the histogram window
+    // routed to Drop and the query returned empty.
+    let src = TestSource::new()
+        .with_histogram_series(
+            &[("__name__", "h")],
+            &[
+                (sec_ns(270), hist(&[2.0], 10.0)),
+                (sec_ns(300), hist(&[8.0], 40.0)),
+            ],
+        )
+        .expect("valid series");
+    let got = Evaluator::new()
+        .instant(&src, "irate(h[5m])", 5 * 60_000)
+        .expect("evaluates");
+    assert_eq!(got.len(), 1);
+    let h = got[0]
+        .histogram
+        .as_ref()
+        .expect("irate over histograms yields a histogram element, not empty");
+    assert!((h.count - 0.2).abs() < 1e-12, "count {}", h.count);
+    assert!((h.sum - 1.0).abs() < 1e-12, "sum {}", h.sum);
+}
+
+#[test]
+fn idelta_over_a_native_histogram_yields_a_histogram_element() {
+    // idelta is the raw last-minus-previous difference with no per-second
+    // division (and no reset detection): counts 8 then 2 gives count -6,
+    // sum -30. Before the #650 fix this returned empty.
+    let src = TestSource::new()
+        .with_histogram_series(
+            &[("__name__", "h")],
+            &[
+                (sec_ns(270), hist(&[8.0], 40.0)),
+                (sec_ns(300), hist(&[2.0], 10.0)),
+            ],
+        )
+        .expect("valid series");
+    let got = Evaluator::new()
+        .instant(&src, "idelta(h[5m])", 5 * 60_000)
+        .expect("evaluates");
+    assert_eq!(got.len(), 1);
+    let h = got[0]
+        .histogram
+        .as_ref()
+        .expect("idelta over histograms yields a histogram element, not empty");
+    assert!((h.count - (-6.0)).abs() < 1e-12, "count {}", h.count);
+    assert!((h.sum - (-30.0)).abs() < 1e-12, "sum {}", h.sum);
+}
+
+#[test]
+fn resets_and_changes_over_a_native_histogram_are_floats() {
+    // counts 2 -> 8 -> 5 across three in-window samples: resets counts the one
+    // downward step (8->5) as a float 1; changes counts both differing adjacent
+    // pairs as a float 2. Both are floats, never histogram elements. Before the
+    // #650 fix each returned empty.
+    let src = TestSource::new()
+        .with_histogram_series(
+            &[("__name__", "h")],
+            &[
+                (sec_ns(60), hist(&[2.0], 10.0)),
+                (sec_ns(180), hist(&[8.0], 40.0)),
+                (sec_ns(300), hist(&[5.0], 25.0)),
+            ],
+        )
+        .expect("valid series");
+    let resets = Evaluator::new()
+        .instant(&src, "resets(h[5m])", 5 * 60_000)
+        .expect("evaluates");
+    assert_eq!(resets.len(), 1);
+    assert!(resets[0].histogram.is_none(), "resets is a float");
+    assert_eq!(resets[0].value, 1.0);
+
+    let changes = Evaluator::new()
+        .instant(&src, "changes(h[5m])", 5 * 60_000)
+        .expect("evaluates");
+    assert_eq!(changes.len(), 1);
+    assert!(changes[0].histogram.is_none(), "changes is a float");
+    assert_eq!(changes[0].value, 2.0);
+}
+
+#[test]
+fn deriv_over_a_pure_histogram_window_drops_with_no_annotation() {
+    // #650's deriv framing corrected: Prometheus' funcDeriv takes its
+    // `len(Floats) < 2` early return for a pure-histogram window, dropping with
+    // NO annotation. This matches Ravel's existing behavior, so deriv needs no
+    // code change. A single Ravel series is monotype (float OR histogram), so
+    // deriv can never see a mixed float+histogram window here at all.
+    let src = TestSource::new()
+        .with_histogram_series(
+            &[("__name__", "h")],
+            &[
+                (sec_ns(180), hist(&[2.0], 10.0)),
+                (sec_ns(300), hist(&[8.0], 40.0)),
+            ],
+        )
+        .expect("valid series");
+    let (value, annos) = Evaluator::new()
+        .eval_instant_annotated(&src, "deriv(h[5m])", 5 * 60_000)
+        .expect("evaluates");
+    let Value::Vector(out) = value else {
+        panic!("deriv is a vector");
+    };
+    assert!(
+        out.is_empty(),
+        "deriv drops a pure-histogram window: {out:?}"
+    );
+    assert!(
+        annos.is_empty(),
+        "deriv's histogram drop carries no annotation: {annos:?}"
     );
 }
 

--- a/crates/ravel-promql/tests/histogram_native.rs
+++ b/crates/ravel-promql/tests/histogram_native.rs
@@ -36,6 +36,30 @@ fn hist(counts: &[f64], sum: f64) -> FloatHistogram {
     }
 }
 
+/// A positive-only histogram at an arbitrary `scale`, one span from
+/// `first_index`, `counts` consecutive buckets. Lets a test build two adjacent
+/// samples of one series at different schemas, the shape RSEG persists when a
+/// flush down-converts a scale to fit its bucket-count limit.
+fn hist_scale(scale: i32, first_index: i32, counts: &[f64], sum: f64) -> FloatHistogram {
+    let total: f64 = counts.iter().sum();
+    FloatHistogram {
+        counter_reset_hint: ResetHint::Unknown,
+        scale,
+        zero_threshold: 0.0,
+        zero_count: 0.0,
+        count: total,
+        sum,
+        positive_spans: vec![Span {
+            offset: first_index,
+            length: counts.len() as u32,
+        }],
+        negative_spans: Vec::new(),
+        positive_buckets: counts.to_vec(),
+        negative_buckets: Vec::new(),
+        custom_values: Vec::new(),
+    }
+}
+
 fn sec_ns(s: i64) -> i64 {
     s * 1_000_000_000
 }
@@ -352,6 +376,202 @@ fn deriv_over_a_pure_histogram_window_drops_with_no_annotation() {
     assert!(
         annos.is_empty(),
         "deriv's histogram drop carries no annotation: {annos:?}"
+    );
+}
+
+#[test]
+fn idelta_aligns_schemas_before_subtracting_adjacent_samples() {
+    // The two window samples carry DIFFERENT schemas: the earlier at scale 1
+    // (buckets at indices 1,2 = [1,2], which both fold into scale-0 index 1 for
+    // a rescaled total of 3), the later at scale 0 (index 1 = [10]). idelta must
+    // down-convert both to the coarser scale 0 before subtracting, so the result
+    // is the single bucket 10 - 3 = 7.
+    //
+    // The flipped assertion is `h.positive_buckets == [7.0]`: before the schema
+    // alignment fix, `sub_assign` combined the two operands' raw index maps with
+    // no rescale ({1:10} minus {1:1, 2:2}), producing the garbage two-bucket
+    // result [9.0, -2.0] instead.
+    let src = TestSource::new()
+        .with_histogram_series(
+            &[("__name__", "h")],
+            &[
+                (sec_ns(270), hist_scale(1, 1, &[1.0, 2.0], 3.0)),
+                (sec_ns(300), hist_scale(0, 1, &[10.0], 20.0)),
+            ],
+        )
+        .expect("valid series");
+    let got = Evaluator::new()
+        .instant(&src, "idelta(h[5m])", 5 * 60_000)
+        .expect("evaluates");
+    assert_eq!(got.len(), 1);
+    let h = got[0]
+        .histogram
+        .as_ref()
+        .expect("idelta over histograms yields a histogram element");
+    assert_eq!(h.scale, 0, "aligned to the coarser schema");
+    assert_eq!(
+        h.positive_buckets,
+        vec![7.0],
+        "schema-aligned single bucket 10 - 3, not the pre-fix garbage [9, -2]"
+    );
+    assert_eq!(
+        h.positive_spans,
+        vec![Span {
+            offset: 1,
+            length: 1
+        }]
+    );
+    assert_eq!(h.count, 7.0, "count 10 - 3");
+    assert_eq!(h.sum, 17.0, "sum 20 - 3");
+}
+
+#[test]
+fn irate_aligns_schemas_before_reset_detection_and_subtracting() {
+    // Same mismatched-schema pair as the idelta test, 30s apart. After aligning
+    // both to scale 0 the counts grow (3 -> 10) with no bucket shrink, so it is
+    // NOT a reset: irate subtracts (single bucket 10 - 3 = 7) and divides by the
+    // 30s interval, giving count 7/30.
+    //
+    // The flipped assertion is `h.count == 7/30`: before the fix, `detect_reset`
+    // was handed operands of different scales, which it treats as a schema
+    // change (a reset), so irate skipped the subtraction entirely and returned
+    // the later histogram alone divided by 30s, i.e. count 10/30.
+    let src = TestSource::new()
+        .with_histogram_series(
+            &[("__name__", "h")],
+            &[
+                (sec_ns(270), hist_scale(1, 1, &[1.0, 2.0], 3.0)),
+                (sec_ns(300), hist_scale(0, 1, &[10.0], 20.0)),
+            ],
+        )
+        .expect("valid series");
+    let got = Evaluator::new()
+        .instant(&src, "irate(h[5m])", 5 * 60_000)
+        .expect("evaluates");
+    assert_eq!(got.len(), 1);
+    let h = got[0]
+        .histogram
+        .as_ref()
+        .expect("irate over histograms yields a histogram element");
+    assert_eq!(h.scale, 0, "aligned to the coarser schema");
+    assert!(
+        (h.count - 7.0 / 30.0).abs() < 1e-12,
+        "count (10 - 3)/30, not the pre-fix reset-skipped 10/30: {}",
+        h.count
+    );
+    assert!(
+        (h.sum - 17.0 / 30.0).abs() < 1e-12,
+        "sum (20 - 3)/30: {}",
+        h.sum
+    );
+}
+
+/// A one-bucket native histogram at scale 0 with the given counter-reset hint,
+/// for the `irate`/`idelta` counter/gauge type-warning tests.
+fn hinted(hint: ResetHint, count: f64, sum: f64) -> FloatHistogram {
+    let mut h = hist(&[count], sum);
+    h.counter_reset_hint = hint;
+    h
+}
+
+#[test]
+fn idelta_over_a_counter_histogram_warns_not_gauge() {
+    // idelta is a gauge operation. Over a counter-hinted native histogram pair
+    // Prometheus raises NativeHistogramNotGauge. Before the #650 warning fix the
+    // histogram branch emitted no annotation, so this `warnings()` assertion
+    // flipped (it was empty). The result element is still produced.
+    let src = TestSource::new()
+        .with_histogram_series(
+            &[("__name__", "h")],
+            &[
+                (sec_ns(270), hinted(ResetHint::No, 2.0, 10.0)),
+                (sec_ns(300), hinted(ResetHint::No, 8.0, 40.0)),
+            ],
+        )
+        .expect("valid series");
+    let (value, annos) = Evaluator::new()
+        .eval_instant_annotated(&src, "idelta(h[5m])", 5 * 60_000)
+        .expect("evaluates");
+    let Value::Vector(out) = value else {
+        panic!("idelta is a vector");
+    };
+    assert_eq!(out.len(), 1, "idelta still yields a histogram element");
+    assert!(
+        annos.warnings().iter().any(|w| w.contains("not a gauge")),
+        "idelta over a counter histogram must warn it is not a gauge: {:?}",
+        annos.warnings()
+    );
+}
+
+#[test]
+fn irate_over_a_gauge_histogram_warns_not_counter() {
+    // irate is a counter operation. Over a gauge-hinted native histogram pair
+    // Prometheus raises NativeHistogramNotCounter. A gauge hint suppresses reset
+    // detection, so irate still subtracts and divides: the element is produced
+    // and the warning fires. The flipped assertion is the non-empty
+    // `warnings()`.
+    let src = TestSource::new()
+        .with_histogram_series(
+            &[("__name__", "h")],
+            &[
+                (sec_ns(270), hinted(ResetHint::Gauge, 2.0, 10.0)),
+                (sec_ns(300), hinted(ResetHint::Gauge, 8.0, 40.0)),
+            ],
+        )
+        .expect("valid series");
+    let (value, annos) = Evaluator::new()
+        .eval_instant_annotated(&src, "irate(h[5m])", 5 * 60_000)
+        .expect("evaluates");
+    let Value::Vector(out) = value else {
+        panic!("irate is a vector");
+    };
+    assert_eq!(out.len(), 1, "irate still yields a histogram element");
+    assert!(
+        annos.warnings().iter().any(|w| w.contains("not a counter")),
+        "irate over a gauge histogram must warn it is not a counter: {:?}",
+        annos.warnings()
+    );
+}
+
+#[test]
+fn irate_over_a_counter_histogram_and_idelta_over_a_gauge_do_not_warn() {
+    // The type-matched directions must NOT warn: irate over a counter-hinted
+    // pair, and idelta over a gauge-hinted pair. This guards against
+    // over-warning (a warning on the correct usage would be a false positive).
+    let counter = TestSource::new()
+        .with_histogram_series(
+            &[("__name__", "h")],
+            &[
+                (sec_ns(270), hinted(ResetHint::No, 2.0, 10.0)),
+                (sec_ns(300), hinted(ResetHint::No, 8.0, 40.0)),
+            ],
+        )
+        .expect("valid series");
+    let (_v, annos) = Evaluator::new()
+        .eval_instant_annotated(&counter, "irate(h[5m])", 5 * 60_000)
+        .expect("evaluates");
+    assert!(
+        annos.warnings().is_empty(),
+        "irate over a counter histogram must not warn: {:?}",
+        annos.warnings()
+    );
+
+    let gauge = TestSource::new()
+        .with_histogram_series(
+            &[("__name__", "h")],
+            &[
+                (sec_ns(270), hinted(ResetHint::Gauge, 2.0, 10.0)),
+                (sec_ns(300), hinted(ResetHint::Gauge, 8.0, 40.0)),
+            ],
+        )
+        .expect("valid series");
+    let (_v, annos) = Evaluator::new()
+        .eval_instant_annotated(&gauge, "idelta(h[5m])", 5 * 60_000)
+        .expect("evaluates");
+    assert!(
+        annos.warnings().is_empty(),
+        "idelta over a gauge histogram must not warn: {:?}",
+        annos.warnings()
     );
 }
 

--- a/crates/ravel-promql/tests/histogram_native.rs
+++ b/crates/ravel-promql/tests/histogram_native.rs
@@ -587,3 +587,141 @@ fn histogram_fraction_native_over_a_selector() {
         .expect("evaluates");
     assert_eq!(floats(&got), vec![0.5]);
 }
+
+/// A one-bucket custom-buckets (NHCB) native histogram, for the
+/// exponential/custom-buckets mismatch tests. `scale: -53` is Prometheus'
+/// sentinel for custom boundaries (see [`FloatHistogram::uses_custom_buckets`]).
+fn custom_buckets_hist(count: f64, sum: f64) -> FloatHistogram {
+    FloatHistogram {
+        counter_reset_hint: ResetHint::Unknown,
+        scale: -53,
+        zero_threshold: 0.0,
+        zero_count: 0.0,
+        count,
+        sum,
+        positive_spans: vec![Span {
+            offset: 0,
+            length: 1,
+        }],
+        negative_spans: Vec::new(),
+        positive_buckets: vec![count],
+        negative_buckets: Vec::new(),
+        custom_values: vec![1.0, 2.0],
+    }
+}
+
+#[test]
+fn irate_treats_a_schema_increase_as_a_reset_even_without_bucket_shrink() {
+    // prev at scale 0 (count 3), last at scale 2 (count 10): every aligned
+    // bucket GROWS, so a structural bucket-shrink check alone would say "not a
+    // reset" -- but Prometheus always treats a schema INCREASE as a reset
+    // regardless of bucket population, since it cannot rule out a decrease
+    // hidden at the newly-visible finer resolution. Oracle-verified (pinned
+    // Prometheus 3.13.1): irate on this exact shape returns count 10/30, not
+    // (10-3)/30. This is the direction the second #650 checkpoint review
+    // found regressed by aligning-then-detect_reset (it made this case wrong
+    // while fixing the schema-decrease case) and the schema-increase
+    // direction had zero test coverage before this ticket. The flipped
+    // assertion is `h.count == 10.0/30.0`: a bucket-shrink-only check (no
+    // increase shortcut) would instead compute 7.0/30.0.
+    let src = TestSource::new()
+        .with_histogram_series(
+            &[("__name__", "h")],
+            &[
+                (sec_ns(270), hist_scale(0, 0, &[3.0], 6.0)),
+                (sec_ns(300), hist_scale(2, 0, &[10.0], 20.0)),
+            ],
+        )
+        .expect("valid series");
+    let got = Evaluator::new()
+        .instant(&src, "irate(h[5m])", 5 * 60_000)
+        .expect("evaluates");
+    assert_eq!(got.len(), 1);
+    let h = got[0]
+        .histogram
+        .as_ref()
+        .expect("irate over histograms yields a histogram element");
+    assert_eq!(h.scale, 2, "reset keeps the later histogram's own scale");
+    assert!(
+        (h.count - 10.0 / 30.0).abs() < 1e-12,
+        "schema increase is always a reset: last.count/30, not (last-prev)/30: {}",
+        h.count
+    );
+}
+
+#[test]
+fn irate_over_mismatched_exponential_and_custom_bucket_schemas_does_not_panic() {
+    // prev is custom-buckets (NHCB), last is exponential-schema: copy_to_scale
+    // cannot bridge the two (the custom-buckets sentinel scale is far outside
+    // the exponential range), so before this fix `min_scale`/`copy_to_scale`
+    // were computed unconditionally and this shift-overflowed in
+    // FloatHistogram::copy_to_scale, panicking in a dev/ci build (the flipped
+    // behavior: no panic, no subtraction, the later histogram alone divided
+    // by the interval, no warning -- Prometheus treats this mismatch as a
+    // reset for irate).
+    let src = TestSource::new()
+        .with_histogram_series(
+            &[("__name__", "h")],
+            &[
+                (sec_ns(270), custom_buckets_hist(3.0, 6.0)),
+                (sec_ns(300), hist_scale(0, 0, &[10.0], 20.0)),
+            ],
+        )
+        .expect("valid series");
+    let (value, annos) = Evaluator::new()
+        .eval_instant_annotated(&src, "irate(h[5m])", 5 * 60_000)
+        .expect("evaluates (must not panic)");
+    let Value::Vector(out) = value else {
+        panic!("irate is a vector");
+    };
+    assert_eq!(out.len(), 1, "mismatch is a reset, not a dropped element");
+    let h = out[0].histogram.as_ref().expect("histogram element");
+    assert!(
+        (h.count - 10.0 / 30.0).abs() < 1e-12,
+        "reset keeps the later histogram alone: {}",
+        h.count
+    );
+    assert!(
+        annos.warnings().is_empty(),
+        "irate does not warn on this mismatch, it silently resets: {:?}",
+        annos.warnings()
+    );
+}
+
+#[test]
+fn idelta_over_mismatched_exponential_and_custom_bucket_schemas_warns_and_drops() {
+    // Same mismatched pair as the irate test. idelta has no reset escape, so
+    // it cannot combine the two at all: Prometheus returns no value plus a
+    // mixed-schemas warning (before this fix, min_scale/copy_to_scale were
+    // computed unconditionally and this shift-overflowed and panicked instead
+    // of returning empty).
+    let src = TestSource::new()
+        .with_histogram_series(
+            &[("__name__", "h")],
+            &[
+                (sec_ns(270), custom_buckets_hist(3.0, 6.0)),
+                (sec_ns(300), hist_scale(0, 0, &[10.0], 20.0)),
+            ],
+        )
+        .expect("valid series");
+    let (value, annos) = Evaluator::new()
+        .eval_instant_annotated(&src, "idelta(h[5m])", 5 * 60_000)
+        .expect("evaluates (must not panic)");
+    let Value::Vector(out) = value else {
+        panic!("idelta is a vector");
+    };
+    assert_eq!(
+        out.len(),
+        0,
+        "idelta cannot combine mismatched schemas, so it drops rather than \
+         emitting a wrong value"
+    );
+    assert!(
+        annos
+            .warnings()
+            .iter()
+            .any(|w| w.contains("mix of histograms with exponential and custom buckets")),
+        "idelta over mismatched schemas must warn: {:?}",
+        annos.warnings()
+    );
+}

--- a/crates/ravel-query/src/http/json.rs
+++ b/crates/ravel-query/src/http/json.rs
@@ -443,6 +443,15 @@ pub fn instant_value_to_json(value: Value, time_ms: i64) -> Result<QueryData, Ap
             format_value(v),
         ))),
         Value::String(s) => Ok(QueryData::String((ms_to_seconds(time_ms)?, s))),
+        // An instant query's top-level `Value::Matrix` is float-only by
+        // construction: the histogram-aware channel is the range endpoint's
+        // `RangeValue` (ADR-0108), and the two instant shapes that reach this
+        // arm both keep histograms out of it -- a subquery over native
+        // histograms refuses upstream (`eval_subquery_matrix`), and a bare
+        // matrix selector matching histogram data refuses in
+        // `eval_expr`'s `MatrixSelector` arm (issue #643). So `histograms` is
+        // always empty here; a histogram-carrying instant range vector is a
+        // typed 422, never a silent HTTP 200 with the histograms dropped.
         Value::Matrix(matrix) => Ok(QueryData::Matrix(
             matrix
                 .into_iter()

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -1075,15 +1075,15 @@ conformance_table`; regenerate that same command with
 `RAVEL_UPDATE_CONFORMANCE_TABLE=1`. Do not edit the block between
 the markers by hand.
 
-Surface: 132 constructs over 236 corpus entries in 10 corpus files.
+Surface: 133 constructs over 238 corpus entries in 10 corpus files.
 
 | State | Constructs |
 | --- | --- |
 | supported | 124 |
-| intentionally rejected | 6 |
+| intentionally rejected | 7 |
 | accepted divergence | 2 |
 | unclassified | 0 |
-| **score** (supported + intentionally rejected + accepted divergence / total) | **132/132 = 100%** |
+| **score** (supported + intentionally rejected + accepted divergence / total) | **133/133 = 100%** |
 
 | Construct | Category | State | Evidence |
 | --- | --- | --- | --- |
@@ -1106,6 +1106,7 @@ Surface: 132 constructs over 236 corpus entries in 10 corpus files.
 | `group_left` | modifier | supported | `corpus/binop.txt`, 2 entries |
 | `group_right` | modifier | supported | `corpus/binop.txt`, 1 entry |
 | `ignoring` | modifier | supported | `corpus/binop.txt`, 1 entry |
+| instant matrix selector over native histograms | modifier | intentionally rejected | `Unsupported: instant query returning a range vector of native histograms (422 execution)`; rejection verified; a bare matrix selector is a valid instant query whose top-level result is a range vector; Ravel's instant `Value::Matrix` is float-only (the histogram-aware channel is the range endpoint's `RangeValue`, ADR-0108 decision 8), so a selector matching native-histogram data refuses in `eval_expr`'s `MatrixSelector` arm (issue #643) rather than silently dropping the histograms at HTTP 200; distinct from the subquery-over-histograms refusal, which triggers inside `eval_subquery_matrix` |
 | label matcher != | modifier | supported | `corpus/selectors.txt`, 1 entry |
 | label matcher !~ | modifier | supported | `corpus/selectors.txt`, 1 entry |
 | label matcher = | modifier | supported | `corpus/selectors.txt`, 8 entries |

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -191,6 +191,18 @@ The within-segment GET/byte model is the `selective_read_accounting` bench.
   `resultType: matrix`, and Ravel matches that. Such a matrix already
   carries its own per-series timestamps from the evaluator, so no grid
   repetition is synthesized.
+- Matrix rendering (both `/api/v1/query_range` and an instant query that
+  returns a matrix) carries native-histogram steps in a `histograms` array
+  alongside the float `values` array, per element type per timestamp, using
+  Prometheus' `[ts, {count, sum, buckets}]` encoding (ADR-0108); a
+  float-only series omits `histograms` and a histogram-only series omits
+  `values`. One exception on the instant endpoint: an instant query whose
+  top-level expression is a range vector *carrying native histograms* (a bare
+  histogram matrix selector such as `h[5m]`, or a subquery over histogram
+  data) is not rendered as a matrix with dropped histograms; it returns a
+  typed 422 `Unsupported` instead (ADR-0108 decision 8), because the instant
+  matrix channel is float-only. Range queries render histogram matrices
+  normally.
 
 ## Budgets (Phase 1: static config)
 
@@ -1063,7 +1075,7 @@ conformance_table`; regenerate that same command with
 `RAVEL_UPDATE_CONFORMANCE_TABLE=1`. Do not edit the block between
 the markers by hand.
 
-Surface: 132 constructs over 231 corpus entries in 10 corpus files.
+Surface: 132 constructs over 236 corpus entries in 10 corpus files.
 
 | State | Constructs |
 | --- | --- |


### PR DESCRIPTION
Closes three separate bugs found by two rounds of adversarial checkpoint
review of native-histogram PromQL support (#649/#650/#643).

First commit (stacked on the already-reviewed #649/#650/#643 fix):
adds schema alignment before subtracting adjacent native-histogram
samples in irate/idelta (a mismatched-schema pair previously ran
sub_assign's index-map arithmetic on incomparable bucket bounds), wires
the missing NativeHistogramNotCounter/NativeHistogramNotGauge warnings
Prometheus raises on a counter/gauge type mismatch, and registers the
#643 typed-422 refusal in the ADR-0035 conformance table with a real
rejection case instead of only a corpus entry.

Second commit fixes two regressions a follow-up checkpoint review found
in the first, both oracle-verified against the pinned Prometheus 3.13.1
binary: aligning schemas before calling detect_reset broke the
schema-increase direction (must always be a reset, independent of
bucket population), and an exponential/custom-buckets schema mismatch
made the alignment arithmetic overflow a bucket-index shift, panicking
in dev/ci and silently wrapping to wrong buckets in release. Both are
fixed with three new tests, each demonstrated failing against the
commit they fix.

Refs: #650
Refs: #643
Refs: #679
