### PR TITLE
fix(ravel-sql): plan logs scans with concurrent segment prunes

### DIFF
--- a/crates/ravel-sql/src/logs_scan.rs
+++ b/crates/ravel-sql/src/logs_scan.rs
@@ -189,7 +189,7 @@ use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties, RecordBatchStream,
     SendableRecordBatchStream,
 };
-use futures::Stream;
+use futures::{Stream, StreamExt, TryStreamExt};
 use ravel_catalog::SegmentRef;
 use ravel_logseg::{
     AttrColumn, ColumnSelection, ColumnarBlockView, FieldSel, FieldType, LogRecord, Predicate,
@@ -748,13 +748,15 @@ impl ExecutionPlan for LogsScanExec {
 
         // The block-level assignment needs each segment's surviving-block count,
         // which a prune must produce (async). The first partition to poll runs
-        // that prune for every segment through the shared `counts` cell; the
-        // rest await its result. Building the future here (not awaiting it)
-        // keeps `execute` synchronous, as DataFusion requires.
+        // that prune for every segment through the shared `counts` cell, with
+        // as many prunes in flight as the scan has partitions; the rest await
+        // its result. Building the future here (not awaiting it) keeps
+        // `execute` synchronous, as DataFusion requires.
         let counts_fut = plan_counts_future(
             Arc::clone(&self.counts),
             Arc::clone(&ctx),
             Arc::clone(&self.segments),
+            self.target_partitions,
         );
 
         Ok(Box::pin(LogScanStream {
@@ -812,33 +814,54 @@ fn plan_counts_future(
     cell: Arc<OnceCell<Arc<PlanCounts>>>,
     ctx: Arc<PartitionCtx>,
     segments: Arc<Vec<SegmentRef>>,
+    plan_concurrency: usize,
 ) -> CountsFuture {
     Box::pin(async move {
         let counts = cell
-            .get_or_try_init(|| compute_plan_counts(&ctx, &segments))
+            .get_or_try_init(|| compute_plan_counts(&ctx, &segments, plan_concurrency))
             .await?;
         Ok(Arc::clone(counts))
     })
 }
 
 /// Prune every segment once (no block decode) to build the shared block plan.
-/// Sequential on purpose: the reads are single-flight coalesced with the
-/// per-partition scans that follow -- on the whole object's key below the
-/// ADR-0107 block-range threshold, and per extent (probe, sections, blocks)
-/// above it -- and this runs once per query, not per partition.
+///
+/// The prunes run `plan_concurrency` at a time (`buffered`, so `segs` keeps
+/// snapshot order and [`owned_work`] can index it by segment position). Every
+/// partition awaits this whole pass before it drains anything, so the plan
+/// phase sits alone on the query's critical path: run serially it costs one
+/// object-store round trip per segment in sequence (issue #691 measured about
+/// 20 minutes per statement on 8424 objects, one GET in flight for the whole
+/// time). Concurrency here changes only how many of those reads are in flight,
+/// never their count (still one plan read sequence per segment) or their
+/// semantics (the first error aborts the plan, and `get_or_try_init` does not
+/// cache it); the fetcher's own in-flight GET semaphore remains the global
+/// bound, so an oversized `plan_concurrency` is safe.
 async fn compute_plan_counts(
     ctx: &PartitionCtx,
     segments: &[SegmentRef],
+    plan_concurrency: usize,
 ) -> DFResult<Arc<PlanCounts>> {
+    // Not-yet-polled futures, one per segment, so `buffered` decides how many
+    // run at once. Built with a loop rather than a `map` closure: a closure
+    // returning a future that borrows its argument cannot satisfy the
+    // higher-ranked bound this `Send` boxed future needs.
+    let mut prunes = Vec::with_capacity(segments.len());
+    for seg in segments {
+        prunes.push(
+            ctx.fetcher
+                .plan_segment(seg, ctx.tenant_hash, &ctx.query, &ctx.accounting),
+        );
+    }
+    let planned: Vec<Option<(usize, ScanStats)>> = futures::stream::iter(prunes)
+        .buffered(plan_concurrency.max(1))
+        .map_err(SqlError::from)
+        .try_collect()
+        .await?;
     let mut segs = Vec::with_capacity(segments.len());
     let mut total_blocks = 0usize;
-    for seg in segments {
-        let planned = ctx
-            .fetcher
-            .plan_segment(seg, ctx.tenant_hash, &ctx.query, &ctx.accounting)
-            .await
-            .map_err(SqlError::from)?;
-        match planned {
+    for entry in planned {
+        match entry {
             Some((survivors, stats)) => {
                 total_blocks += survivors;
                 segs.push(Some(SegPlan { survivors, stats }));

--- a/crates/ravel-sql/tests/logs_plan_concurrency.rs
+++ b/crates/ravel-sql/tests/logs_plan_concurrency.rs
@@ -1,0 +1,160 @@
+//! The logs scan's plan phase (`compute_plan_counts`, ADR-0102) prunes every
+//! segment before any partition drains. Issue #691: that pass ran one prune at
+//! a time, so a query over N objects paid N sequential object-store round
+//! trips before scanning anything (about 20 minutes on 8424 objects). This
+//! pins the fix: the prunes run `target_partitions` at a time.
+//!
+//! The evidence is a `FaultStore` gate that holds every GET: how many GETs are
+//! held at once is exactly how many prunes are in flight. A sequential plan
+//! phase never holds more than one, so the "at least two held" wait below
+//! times out against it; the bound is pinned by the held count settling at
+//! `target_partitions` with more segments than that still unplanned.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use datafusion::execution::TaskContext;
+use datafusion::physical_plan::collect;
+use ravel_catalog::{SegmentLevel, SegmentRef, Snapshot};
+use ravel_logseg::writer::ObjectIdentity;
+use ravel_logseg::{AttrValue, LogRecord, RlogConfig, RlogWriter, stream_attrs_bytes};
+use ravel_object_store::fault::{FaultPlan, FaultStore, Occurrence, Op};
+use ravel_object_store::memory::MemoryStore;
+use ravel_object_store::{ObjectStoreBackend, PutOptions};
+use ravel_query::LogSegmentFetcher;
+use ravel_sql::LogsTableProvider;
+use ravel_types::TenantHash;
+use ravel_types::accounting::QueryAccounting;
+use uuid::Uuid;
+
+const TENANT: TenantHash = TenantHash([7u8; 16]);
+
+fn identity() -> ObjectIdentity {
+    ObjectIdentity {
+        tenant_hash: TENANT.0,
+        shard: 0,
+        writer_id: [2u8; 16],
+        writer_epoch: 1,
+        writer_seq: 1,
+    }
+}
+
+fn record(ts: i64) -> LogRecord {
+    let resource = vec![(
+        "service.name".to_string(),
+        AttrValue::Str("api".to_string()),
+    )];
+    LogRecord {
+        stream_id: ravel_types::logstream::log_stream_id(&resource, "scope", "1.0", &[]),
+        stream_attrs: stream_attrs_bytes(&resource, "scope", "1.0", &[]),
+        ts_ns: ts,
+        observed_ts_ns: ts,
+        severity_num: 9,
+        severity_text: "INFO".into(),
+        body: format!("event {ts}"),
+        trace_id: None,
+        span_id: None,
+        flags: 0,
+        attrs: Vec::new(),
+    }
+}
+
+async fn write_object(store: &MemoryStore, key: &str, records: &[LogRecord]) -> SegmentRef {
+    let mut w = RlogWriter::new(
+        RlogConfig {
+            block_target_records: 3,
+            ..RlogConfig::default()
+        },
+        identity(),
+    );
+    for r in records {
+        w.push(r.clone()).expect("push");
+    }
+    let bytes = w.finish().expect("finish");
+    let size = bytes.len() as u64;
+    store
+        .put(key, bytes::Bytes::from(bytes), PutOptions::default())
+        .await
+        .expect("put object");
+    let min = records.iter().map(|r| r.ts_ns).min().expect("nonempty");
+    let max = records.iter().map(|r| r.ts_ns).max().expect("nonempty");
+    SegmentRef {
+        data_object_key: key.to_string(),
+        object_size: size,
+        min_event_ts_ns: min,
+        max_event_ts_ns: max,
+        ingest_hour_bucket: 0,
+        sample_count: records.len() as u64,
+        series_count: 0,
+        shard: 0,
+        content_hash: [0u8; 32],
+        writer_id: Uuid::from_u128(1),
+        writer_epoch: 1,
+        writer_seq: 1,
+        created_unix_ns: 0,
+        level: SegmentLevel::L0,
+    }
+}
+
+/// Six relevant segments, a scan planned at four partitions, every GET held:
+/// the plan phase parks exactly four prunes at once (the partition count, not
+/// one, and not all six).
+#[tokio::test]
+async fn plan_phase_prunes_target_partitions_segments_at_a_time() {
+    const SEGMENTS: usize = 6;
+    const TARGET_PARTITIONS: usize = 4;
+
+    let plain = MemoryStore::new();
+    let mut segments = Vec::with_capacity(SEGMENTS);
+    for i in 0..SEGMENTS {
+        let base = (i as i64) * 100;
+        let records: Vec<LogRecord> = (base..base + 6).map(record).collect();
+        segments.push(write_object(&plain, &format!("logs/{i}.rlog"), &records).await);
+    }
+
+    // Wrap after the writes: the gate holds GETs only, but keeping the fixture
+    // writes on the plain store makes the ordering obvious.
+    let faulty = Arc::new(FaultStore::new(plain, FaultPlan::empty()));
+    let gate = faulty.hold(Op::Get, None, Occurrence::Always);
+    let store: Arc<dyn ObjectStoreBackend> = Arc::clone(&faulty) as Arc<dyn ObjectStoreBackend>;
+
+    let provider = LogsTableProvider::new(
+        Snapshot {
+            segments,
+            segments_pruned: 0,
+            pending_erasure: Vec::new(),
+        },
+        TENANT,
+        LogSegmentFetcher::new(store),
+        QueryAccounting::new(),
+    );
+    let plan = provider.plan(TARGET_PARTITIONS).expect("build plan");
+    let query = tokio::spawn(collect(plan, Arc::new(TaskContext::default())));
+
+    // A sequential plan phase holds one GET and never a second one, so this
+    // wait is the red line against the pre-#691 code.
+    tokio::time::timeout(Duration::from_secs(5), gate.wait_until_held(2))
+        .await
+        .expect("at least two segment prunes must be in flight at once");
+
+    // The in-flight count settles at the partition count: not one, and not all
+    // six segments.
+    tokio::time::timeout(
+        Duration::from_secs(5),
+        gate.wait_until_held(TARGET_PARTITIONS),
+    )
+    .await
+    .expect("the plan phase reaches target_partitions prunes in flight");
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    assert_eq!(
+        gate.held_count(),
+        TARGET_PARTITIONS,
+        "prunes in flight are bounded by target_partitions"
+    );
+
+    // The query can never finish while every GET is held; it is the gate that
+    // was under test, not the result.
+    query.abort();
+}


### PR DESCRIPTION
Every `logs` query plans its ADR-0102 block assignment by pruning each resolved segment (`plan_segment`) before any partition drains, and `compute_plan_counts` awaited those prunes one at a time. On a tenant of 8424 objects that is one object-store round trip per segment in sequence: about 20 minutes per statement with exactly one GET in flight, before a single block is decoded. Measured on the ClickBench box (#680): one established S3 connection for the process's whole life, 2.7% CPU, every thread parked in `futex_wait`, `count(*)` unable to finish inside 600 s, with and without a read cache. The comment on the loop said the reads coalesce with the partition scans that follow; they cannot, because the partitions await the loop's completion first.

The prunes now run `target_partitions` at a time through a `buffered` stream.

What did not change, for anyone reviewing an ADR-0102 file:

- **Order**: `buffered`, not `buffer_unordered`, so `PlanCounts.segs` stays in snapshot order and `owned_work` still indexes it by segment position.
- **Request count**: still one plan read sequence per segment; only how many are in flight changed. The module docs' "planning's prune adds one more per relevant segment" note stays true.
- **Error semantics**: the first error still aborts the plan, and `get_or_try_init` still does not cache it.
- **Global bound**: the fetcher's in-flight GET semaphore (`DEFAULT_LOG_MAX_CONCURRENT_GETS`) still caps actual concurrent GETs, so an oversized partition count is safe.

The futures are built with a loop rather than an `iter().map` closure: a closure returning a future that borrows its argument does not satisfy the higher-ranked bound the `Send` boxed plan future needs (rustc's "implementation of `FnOnce` is not general enough").

Test (`crates/ravel-sql/tests/logs_plan_concurrency.rs`), demonstrated red first: six relevant segments, a plan at four partitions, a `FaultStore` gate holding every GET. Against the sequential plan phase (`buffered(1)`) the "at least two GETs held" wait times out after 5 s (`Elapsed`); with the fix the held count settles at exactly four with two segments still unplanned, which pins both the concurrency and its bound.

Gates run locally on a warm target: fmt, `clippy -p ravel-sql --all-targets`, `test -p ravel-sql`, `check -p ravel-bench --features sql-latency,profiling` (the bench box's build path), `clippy --workspace --all-targets`. The `sql` / `flight-sql` server lanes ride this PR's required checks.

Not in this PR (noted on #691): a statement with no predicate has nothing to prune, so the plan phase could skip the reads entirely; and whether `plan_segment` reads most of each object above the block-range threshold (10 GB fetched in the first 20 minutes of `count(*)`).

Fixes #691. Refs #680, ADR-0102.
