### PR TITLE
feat(ravel-cli): bound bulk loader writes by --pipeline-depth

### DIFF
--- a/docs/guides/clickbench.md
+++ b/docs/guides/clickbench.md
@@ -66,7 +66,8 @@ ravel-cli --store <your-store-flags> load \
   --mapping benchmarks/clickbench/hits.mapping.toml \
   --shards 4 \
   --batch-rows 40000 \
-  --read-cursors 4
+  --read-cursors 4 \
+  --pipeline-depth 1
 ```
 
 `--batch-rows` is the object-count lever. One batch is one Strict flush, which is
@@ -111,6 +112,33 @@ This `--batch-rows`-scales-with-`--shards` sizing floor still applies once
 assembled *from*, not how many rows in total each shard receives per batch, so
 the ~8192-rows-per-shard floor above is unchanged. Raising `--shards` still
 means raising `--batch-rows` to match, regardless of `--read-cursors`.
+
+`--pipeline-depth` is the write-latency lever, and it trades memory for it. Each
+batch's write is one S3 PUT round trip per involved shard; at the default depth
+`1` the loader submits one batch's write and waits for its ack before building or
+submitting the next, so on a fast encoder that PUT round trip is the serial term
+that dominates wall time. Raising the depth lets up to that many writes overlap:
+the loader keeps submitting later batches while earlier writes are still awaiting
+their acks, hiding the round-trip latency behind subsequent encode and I/O. The
+cost is memory. Each in-flight write keeps its built batch resident until its ack
+returns, so raising `--pipeline-depth` above `1` multiplies the live
+decoded-batch-plus-pending-write working set by roughly the depth. This cost is
+*in addition to* the `--batch-rows` x `--shards` product above, not a
+replacement for it: the per-batch resident size is still set by that product, and
+`--pipeline-depth` keeps that many built batches alive at once.
+
+As a concrete anchor (issue #682, measured at 8 shards, 80k rows, depth 1): live
+heap is about 6GB under a memory-returning allocator (tcmalloc) and scales close
+to linearly with `--batch-rows`; under the default glibc allocator the same
+geometry plateaus around 20GB because glibc's arenas retain freed blocks rather
+than returning them to the OS (arena retention, not a leak). Raising the depth
+scales that live working set by roughly the depth on top of whichever allocator
+you run. Because the real per-row cost is allocator-dependent by more than 3x,
+the loader does not compute or enforce a safe ceiling for you: size
+`--pipeline-depth` against your host's memory the same way you size the
+`--batch-rows` x `--shards` product, measuring on your own allocator rather than
+trusting a single baked-in per-row estimate. `1` reproduces today's
+one-write-at-a-time behavior exactly.
 
 The loader prints a completion summary to stdout — `rows processed`,
 `objects written`, and `elapsed` (the load wall-time ClickBench reports). It also

--- a/services/ravel-cli/src/load.rs
+++ b/services/ravel-cli/src/load.rs
@@ -852,9 +852,18 @@ async fn load_instrumented(
         // is the only place `report.tokens` grows during the loop, and it grows
         // strictly oldest-first, so a later batch's write finishing early can
         // never record its token ahead of an earlier one (or ahead of an earlier
-        // failure). On a write error, abort every still-queued write so an
-        // already-spawned later batch cannot keep running in the background past
-        // the failure the loader is about to return.
+        // failure). On a write error, abort every still-queued write's
+        // `JoinHandle`: this cancels the loader's own ack wait so it does not
+        // block returning on a write it has already decided to fail, but it
+        // does NOT stop the batch's underlying shard-actor flush (see
+        // `LogIngestRouter::write` in crates/ravel-ingest/src/log_router.rs --
+        // the actor holds only a channel `tx`, no join handle of its own). A
+        // later batch can therefore still commit its data object and publish
+        // its commit record in the background after the loader has returned an
+        // error; the durable-token accounting excludes it regardless (see
+        // `resolve_write_entry`/`drain_inflight` below), so the reported list
+        // stays correct, but the object itself may still land. Tracked as a
+        // known gap pending a `ravel-ingest` cancellation mechanism.
         // Only one write is spawned per iteration, so the window exceeds its
         // bound by at most one and this resolves exactly one oldest entry; the
         // `while` + `let`-else form avoids unwrapping a `pop_front` that is
@@ -960,10 +969,15 @@ async fn resolve_write_entry(
 }
 
 /// Resolve every write still in the window, oldest-first. On the first write
-/// error it aborts every remaining (later) write before returning, so no
-/// already-spawned batch after the failure keeps running in the background once
-/// the loader has decided to fail: a detached `tokio::spawn`'d task is not
-/// cancelled by dropping its handle.
+/// error it aborts every remaining (later) write's `JoinHandle` before
+/// returning. This only cancels the loader's own ack wait on those writes --
+/// it does not stop their underlying shard-actor flush, which has no join
+/// handle of its own to cancel (see the loop comment above and
+/// `crates/ravel-ingest/src/log_router.rs`) -- so a later batch can still
+/// commit independently in the background even after the loader has reported
+/// failure. The durable-token list is unaffected either way: it only ever
+/// grows from a popped, successfully-resolved entry strictly oldest-first, so
+/// an aborted entry's outcome (commit or not) is never consulted.
 async fn drain_inflight(
     inflight: &mut std::collections::VecDeque<(
         u64,
@@ -3191,6 +3205,42 @@ type = "i64"
         );
     }
 
+    /// `--pipeline-depth 0` is rejected with a typed [`LoadError::Setup`]
+    /// before any work, rather than silently clamped to 1, mirroring
+    /// `batch_rows_zero_is_rejected` above. A depth of 0 would also make the
+    /// main loop's `while inflight.len() >= pipeline_depth` true before any
+    /// write is ever spawned; the guard makes that unreachable rather than
+    /// relying on the `let`-else in the pop to save it.
+    #[tokio::test]
+    async fn pipeline_depth_zero_is_rejected() {
+        use ravel_object_store::memory::MemoryStore;
+        let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+        let m = base_mapping();
+        let err = load(
+            store,
+            Path::new("/nonexistent.parquet"),
+            "acme",
+            &m,
+            4,
+            10,
+            None,
+            0,
+            NOW_NS,
+            Arc::new(FixedClock(NOW_NS)),
+        )
+        .await
+        .expect_err("pipeline_depth of 0 is rejected");
+        assert!(
+            matches!(err, LoadError::Setup(_)),
+            "a typed setup error, got: {err}"
+        );
+        assert!(
+            err.to_string()
+                .contains("--pipeline-depth must be at least 1"),
+            "the error names the lever: {err}"
+        );
+    }
+
     /// The first host value (by an incrementing suffix) whose loader stream
     /// identity routes to `target` under `shards`. Uses the loader's own
     /// identity inputs -- resource attributes in mapping order, empty scope --
@@ -4526,40 +4576,47 @@ type = "i64"
     /// Durable-token correctness under a partial-window failure (the correctness
     /// constraint this ticket turns on): with `--pipeline-depth 4` and a stream
     /// of five single-shard batches, the data PUT for the *middle* batch (index
-    /// 2, shard 2) fails permanently. The batches strictly after it (indices 3
-    /// and 4, shards 3 and 4) have their PUTs held ~1s, so they are provably
-    /// still in flight at the instant the failure is detected, and — because the
-    /// loader routes each batch to its own shard actor and a shard actor's flush
-    /// is downstream of the write future the loader holds — they go on to commit
-    /// their objects *independently* even after the loader aborts their write
-    /// handles. That independent success is exactly the trap: the reported
-    /// durable list must still exclude them.
+    /// 2, shard 2) is held ~300ms before failing permanently. The batches
+    /// strictly after it (indices 3 and 4, shards 3 and 4) have no artificial
+    /// delay at all, so their shard actors race far ahead of shard 2's held PUT
+    /// and commit their objects *independently*, well before shard 2's failure
+    /// is even detected -- because the loader routes each batch to its own
+    /// shard actor and a shard actor's flush is downstream of the write future
+    /// the loader holds, aborting that future's `JoinHandle` does not stop the
+    /// shard actor already mid-PUT (see `LogIngestRouter::write` in
+    /// `crates/ravel-ingest/src/log_router.rs`: the actor has no join handle of
+    /// its own, only a channel). That independent, unstoppable success is
+    /// exactly the trap: the reported durable list must still exclude them, even
+    /// though the objects genuinely landed.
     ///
     /// Asserted: the reported durable list is exactly the tokens of the batches
     /// strictly before the failing one (shards 0 and 1), in submission order; it
     /// carries no token for the failing batch (a full single-shard PUT failure
-    /// has no partial survivor) and none for the later batches — even though
-    /// `watch_completed` reaching 2 after the wait proves batches 3 and 4's
-    /// writes did in fact succeed and commit. This is the "even if their own
-    /// write happens to succeed independently" clause made observable: the
-    /// durable list grows only by consuming the queue oldest-first, never by
-    /// whichever write finishes.
+    /// has no partial survivor) and none for the later batches -- even though
+    /// `watch_completed` reading 2 proves batches 3 and 4's writes did in fact
+    /// succeed and commit (the direct, non-inferred proof the spec requires:
+    /// their objects landed in the underlying store, not merely "absent from
+    /// the returned list"). This is the "even if their own write happens to
+    /// succeed independently" clause made observable: the durable list grows
+    /// only by consuming the queue oldest-first, never by whichever write
+    /// finishes, and it stays correct even though the loader's own abort of the
+    /// post-failure handles has no effect on whether those batches commit.
     ///
-    /// Non-vacuity (prove-the-test): a wrong resolver that consumed the window
-    /// via `select_all`/whichever-finishes-first instead of strict FIFO
-    /// pop-front would, on this exact fixture, surface batch 2's *immediate*
-    /// permanent failure before batch 1's *artificially delayed* (~50ms) success
-    /// is ever recorded, returning a durable list missing shard 1 — the
-    /// `durable.len() == 2` / `durable[1].shard == 1` assertions reject that. The
-    /// ordering is deterministic because the FaultStore permanent error returns
-    /// effectively instantly while shard 1's PUT is held ~50ms, so the delayed
-    /// success can never win a race the FIFO resolver does not run. And the
-    /// `watch_started == 2` / `watch_completed == 0` snapshot taken the instant
-    /// `load` returns proves batches 3 and 4 were genuinely still outstanding
-    /// (not merely absent because they never ran), closing the "raced and did not
-    /// finish in time" loophole in the opposite direction: they had started but
-    /// had not committed, yet were correctly excluded, and later completing did
-    /// not resurrect them into the list.
+    /// Non-vacuity (prove-the-test): the discriminating shape is the *failing*
+    /// batch being slow and a *post-failure* batch being fast, not the other way
+    /// around. A wrong resolver that consumed the window via
+    /// `select_all`/whichever-finishes-first instead of strict FIFO pop-front
+    /// would, on this exact fixture, resolve shard 3's (and shard 4's) zero-delay
+    /// success long before shard 2's ~300ms-delayed failure is ever observed --
+    /// recording a shard-3 (or shard-4) token as durable, which the
+    /// `durable.iter().all(|t| t.shard == 0 || t.shard == 1)` assertion rejects.
+    /// The ordering is deterministic because a zero-delay in-memory PUT
+    /// completes in microseconds while shard 2 is held 300ms: a 6000x margin
+    /// leaves no scheduling jitter that could invert it. (An earlier version of
+    /// this fixture delayed the *post-failure* batches instead of the failing
+    /// one; that shape is vacuous -- delaying batches 3/4 stops them finishing
+    /// early under any resolver, correct or not, so it can't distinguish FIFO
+    /// from `select_all`. The failing batch must be the slow one.)
     #[tokio::test]
     async fn partial_window_failure_reports_only_earlier_batches_never_later() {
         use parquet::arrow::ArrowWriter;
@@ -4613,15 +4670,15 @@ type = "i64"
         let watch_completed = Arc::new(AtomicUsize::new(0));
         let store = Arc::new(InstrumentedPutStore {
             inner: fault.clone() as Arc<dyn ObjectStoreBackend>,
-            // Shard 1 (before the failure) is delayed ~50ms so a whichever-
-            // finishes-first resolver would surface shard 2's instant failure
-            // ahead of it; shards 3 and 4 (after the failure) are held ~1s so
-            // they are still in flight at the failure yet commit after the wait.
-            delays: vec![
-                ("/l0/0001/", Duration::from_millis(50)),
-                ("/l0/0003/", Duration::from_millis(1000)),
-                ("/l0/0004/", Duration::from_millis(1000)),
-            ],
+            // Shard 2 (the failing batch) is held ~300ms before its permanent
+            // fault fires. Shards 3 and 4 (after the failure) get no artificial
+            // delay at all, so their zero-delay PUTs commit within microseconds
+            // of being spawned -- long before shard 2's held failure surfaces.
+            // This is the shape that discriminates FIFO from whichever-finishes-
+            // first: delaying the *post-failure* batches instead would stop them
+            // finishing early under any resolver and prove nothing (see the test
+            // doc comment).
+            delays: vec![("/l0/0002/", Duration::from_millis(300))],
             in_flight: Arc::new(AtomicUsize::new(0)),
             max_in_flight: Arc::new(AtomicUsize::new(0)),
             watch_prefixes: vec!["/l0/0003/", "/l0/0004/"],
@@ -4644,11 +4701,14 @@ type = "i64"
         .await
         .expect_err("the middle batch's permanent PUT failure fails the load");
 
-        // Snapshot the instant `load` returns: batches 3 and 4 had started their
-        // flush (their shard actors reached the PUT) but had not committed yet.
-        let started_at_return = watch_started.load(Ordering::SeqCst);
-        let completed_at_return = watch_completed.load(Ordering::SeqCst);
-
+        // Shards 3 and 4 have zero artificial delay, so by the time shard 2's
+        // ~300ms-held failure surfaces (and `load` returns it) both have already
+        // started AND completed their PUT -- a 6000x margin over a zero-delay
+        // in-memory write, leaving no scheduling-jitter window that could catch
+        // them mid-flight instead. This is the direct, non-inferred proof the
+        // spec requires: the objects genuinely landed in the underlying store,
+        // not merely "absent from the returned list" (which a lucky race could
+        // satisfy even under a wrong implementation).
         let durable = match &err {
             LoadError::Flush { durable, .. } => durable.clone(),
             other => panic!("expected LoadError::Flush, got {other:?}"),
@@ -4679,24 +4739,19 @@ type = "i64"
         );
 
         assert_eq!(
-            started_at_return, 2,
-            "both after-failure writes (batches 3 and 4) were outstanding at the failure"
+            watch_started.load(Ordering::SeqCst),
+            2,
+            "both after-failure writes (batches 3 and 4) reached their PUT"
         );
-        assert_eq!(
-            completed_at_return, 0,
-            "neither after-failure write had committed at the instant the failure was reported, \
-             so their absence from the durable list is FIFO discipline, not a race that left them \
-             unfinished"
-        );
-
-        // Let the still-running shard actors finish their held PUTs: batches 3
-        // and 4 commit their objects independently of the aborted write futures.
-        tokio::time::sleep(Duration::from_millis(1300)).await;
         assert_eq!(
             watch_completed.load(Ordering::SeqCst),
             2,
-            "batches 3 and 4's writes did in fact succeed and commit, yet were still excluded \
-             from the durable list above"
+            "batches 3 and 4's writes did in fact succeed and commit -- the loader's abort of \
+             their write handles only cancels its own ack wait, it does not stop the shard actor \
+             already mid-PUT -- yet both are still excluded from the durable list above. Operators \
+             resuming from a partial-window failure at depth > 1 must treat this as a known gap: \
+             see the --pipeline-depth documentation in clickbench.md and the ravel-ingest \
+             follow-up tracked from this test's discovery."
         );
     }
 }

--- a/services/ravel-cli/src/load.rs
+++ b/services/ravel-cli/src/load.rs
@@ -32,7 +32,8 @@ use ravel_catalog::{AbsentPolicy, validate_or_adopt};
 #[cfg(feature = "stage-timing")]
 use ravel_ingest::LogStageSnapshot;
 use ravel_ingest::{
-    Clock, IngestConfig, LogIngestMetricsSnapshot, LogIngestRouter, SystemClock, WriteMode,
+    Clock, IngestConfig, LogIngestMetricsSnapshot, LogIngestRouter, LogWriteError, LogWriteReceipt,
+    SystemClock, WriteMode,
 };
 use ravel_logseg::{
     Bitmap, ColumnarLogBatch, DynColumn, FieldType, StrColumnDict, stream_attrs_bytes,
@@ -258,6 +259,7 @@ pub async fn run(
     shards: u32,
     batch_rows: usize,
     read_cursors: Option<usize>,
+    pipeline_depth: usize,
     now_ns: i64,
 ) -> anyhow::Result<()> {
     run_warning_to(
@@ -268,6 +270,7 @@ pub async fn run(
         shards,
         batch_rows,
         read_cursors,
+        pipeline_depth,
         now_ns,
         &mut std::io::stderr(),
     )
@@ -290,6 +293,7 @@ pub(crate) async fn run_warning_to(
     shards: u32,
     batch_rows: usize,
     read_cursors: Option<usize>,
+    pipeline_depth: usize,
     now_ns: i64,
     warnings: &mut dyn std::io::Write,
 ) -> anyhow::Result<()> {
@@ -309,6 +313,7 @@ pub(crate) async fn run_warning_to(
         shards,
         batch_rows,
         read_cursors,
+        pipeline_depth,
         now_ns,
         Arc::new(SystemClock),
     )
@@ -556,6 +561,7 @@ pub async fn load(
     shards: u32,
     batch_rows: usize,
     read_cursors: Option<usize>,
+    pipeline_depth: usize,
     now_ns: i64,
     clock: Arc<dyn Clock>,
 ) -> Result<LoadReport, LoadError> {
@@ -567,6 +573,7 @@ pub async fn load(
         shards,
         batch_rows,
         read_cursors,
+        pipeline_depth,
         now_ns,
         clock,
         LoadPath::Columnar,
@@ -594,6 +601,7 @@ async fn load_instrumented(
     shards: u32,
     batch_rows: usize,
     read_cursors: Option<usize>,
+    pipeline_depth: usize,
     now_ns: i64,
     clock: Arc<dyn Clock>,
     path: LoadPath,
@@ -606,6 +614,17 @@ async fn load_instrumented(
         return Err(LoadError::Setup(
             "--batch-rows must be at least 1 (each batch is one Strict flush per shard); 0 was \
              given"
+                .to_string(),
+        ));
+    }
+    // Same shape as the `batch_rows == 0` guard above: `--pipeline-depth` is the
+    // operator-facing lever bounding how many writes are in flight at once, so 0
+    // (a pipeline that can hold no write) is a rejected value, not a silent
+    // clamp to 1.
+    if pipeline_depth == 0 {
+        return Err(LoadError::Setup(
+            "--pipeline-depth must be at least 1 (the number of concurrent in-flight writes); 0 \
+             was given"
                 .to_string(),
         ));
     }
@@ -648,7 +667,12 @@ async fn load_instrumented(
     // one object per batch, `batch_rows` controls its size, and every write's
     // ack is durable with no lingering buffer. It also keeps flush timing off
     // the wall clock, so the object buckets by the flush-open reading directly.
-    let router = LogIngestRouter::new(
+    // `Arc` so each batch's write can be `tokio::spawn`ed onto its own task and
+    // run genuinely concurrently up to `pipeline_depth` (a constructed-but-
+    // unawaited future does no I/O until polled; spawning is what makes the S3
+    // PUT round trips overlap). `write`/`write_columnar` take `&self`, so this
+    // is the only change the router's own type needs.
+    let router = Arc::new(LogIngestRouter::new(
         IngestConfig {
             shard_count: shards,
             target_bytes: 1,
@@ -656,7 +680,7 @@ async fn load_instrumented(
         },
         Arc::clone(&store),
         clock,
-    );
+    ));
 
     let row_group_lens = row_group_row_counts(parquet_path)?;
     let cursor_count = resolve_read_cursors(read_cursors, shards, row_group_lens.len());
@@ -667,21 +691,34 @@ async fn load_instrumented(
     let mut shards_seen: std::collections::HashSet<u32> = std::collections::HashSet::new();
     let mut data_batches_flushed: u64 = 0;
 
-    // Single-batch lookahead (issue #541). Batch N+1's decode/build (sync
-    // Parquet decode via `Iterator::next`, then the per-row `build_record`
-    // loop, both CPU-bound) runs on a `spawn_blocking` task started *before*
-    // batch N's `router.write` I/O is awaited, so N+1's CPU work overlaps N's
-    // I/O wait. The non-`Clone` `ParquetRecordBatchReader` is shuttled into and
-    // back out of the closure each iteration.
+    // The window of writes genuinely in flight, oldest (earliest-submitted)
+    // first. Bounded to `pipeline_depth`: after a new write is spawned, if the
+    // window is full the front (oldest) is popped and awaited before the next
+    // batch's write starts. Popping strictly oldest-first is what preserves the
+    // former loop's exact result ordering (same tokens, same first error) no
+    // matter which underlying PUT actually completes first.
+    let mut inflight: std::collections::VecDeque<(
+        u64,
+        tokio::task::JoinHandle<Result<LogWriteReceipt, LogWriteError>>,
+    )> = std::collections::VecDeque::with_capacity(pipeline_depth);
+
+    // Single-batch decode/build lookahead (issue #541), independent of the write
+    // window above. Batch N+1's decode/build (sync Parquet decode via
+    // `Iterator::next`, then the per-row `build_record` loop, both CPU-bound)
+    // runs on a `spawn_blocking` task started *before* batch N's write I/O is
+    // awaited, so N+1's CPU work overlaps the writes' I/O wait. The non-`Clone`
+    // `ParquetRecordBatchReader` is shuttled into and back out of the closure
+    // each iteration.
     //
-    // The loop stays sequential in every observable way: exactly one
-    // `router.write` is awaited at a time, N+1's decode is never started before
-    // N's has been consumed, and results are consumed in the same order as the
-    // former serial loop. In particular a build error for batch N+1 (discovered
-    // while N's write is still in flight) is only inspected after N's write
-    // result has been handled, so it surfaces in the same order and with the
-    // same `durable` tokens (those from batches strictly before it) as before;
-    // the prefetch changes only *when* (wall-clock) the decode/build happens.
+    // Result ordering stays strict-FIFO regardless of `pipeline_depth`: writes
+    // are recorded (and a write failure surfaced) only by consuming `inflight`
+    // oldest-first, so `report.tokens` grows in submission order, and a build
+    // error for a later batch is only reported after every earlier batch's write
+    // has been drained from the window. At `pipeline_depth == 1` the window
+    // holds at most one write, popped and awaited before the next batch's write
+    // starts, so the observable results and ordering match the pre-widening loop
+    // exactly (only the execution shape differs: the write now runs on a spawned
+    // task rather than inline).
     let mapping = Arc::new(mapping.clone());
     let state = StrideCursors {
         cursors,
@@ -716,8 +753,19 @@ async fn load_instrumented(
         let (state, built) = match pending.await {
             Ok(pair) => pair,
             // A panic in the decode/build task is a batch decode failure;
-            // earlier batches may already be durable.
+            // earlier batches' writes may still be in flight, so drain them
+            // first (oldest-first) so any already-durable earlier batch is
+            // reported and any earlier write failure surfaces ahead of this one,
+            // exactly as the former serial loop ordered them.
             Err(join_err) => {
+                drain_inflight(
+                    &mut inflight,
+                    &mut report,
+                    &mut shards_seen,
+                    &mut data_batches_flushed,
+                    shards,
+                )
+                .await?;
                 return Err(LoadError::BatchFailed {
                     reason: format!("Parquet decode/build task failed: {join_err}"),
                     durable: report.tokens.clone(),
@@ -728,12 +776,28 @@ async fn load_instrumented(
         let built = match built {
             Prefetched::Done => break,
             Prefetched::BatchFailed { reason } => {
+                drain_inflight(
+                    &mut inflight,
+                    &mut report,
+                    &mut shards_seen,
+                    &mut data_batches_flushed,
+                    shards,
+                )
+                .await?;
                 return Err(LoadError::BatchFailed {
                     reason,
                     durable: report.tokens.clone(),
                 });
             }
             Prefetched::RowRejected { row, reason } => {
+                drain_inflight(
+                    &mut inflight,
+                    &mut report,
+                    &mut shards_seen,
+                    &mut data_batches_flushed,
+                    shards,
+                )
+                .await?;
                 return Err(LoadError::RowRejected {
                     row,
                     reason,
@@ -750,59 +814,82 @@ async fn load_instrumented(
             continue;
         }
 
-        // Start (but do not yet await) this batch's write, then spawn the next
-        // batch's decode/build so its CPU work overlaps this write's I/O wait.
-        // Building the future does no work; the write begins when it is awaited
-        // below, by which point the prefetch task is already running. Both paths
-        // await exactly one write at a time, so the pipeline stays sequential in
-        // every observable way regardless of which path built the batch.
-        let receipt = match built {
+        // Spawn this batch's write onto its own task so it runs concurrently
+        // with the writes already in flight and with the next batch's
+        // decode/build, then prefetch that next batch. A `tokio::spawn`ed write
+        // begins executing immediately; a merely-constructed future would do no
+        // I/O until polled, which is why the window is built from join handles,
+        // not from unpolled futures.
+        let handle = match built {
             Built::Row(records) => {
-                let write_fut = router.write(
-                    tenant_id.clone(),
-                    records,
-                    WriteMode::Strict,
-                    WRITE_ACK_DEADLINE,
-                );
-                pending = spawn_build(state);
-                write_fut.await
+                let router = Arc::clone(&router);
+                let tenant = tenant_id.clone();
+                tokio::spawn(async move {
+                    router
+                        .write(tenant, records, WriteMode::Strict, WRITE_ACK_DEADLINE)
+                        .await
+                })
             }
             Built::Columnar(batch) => {
                 // Reachability signal (ADR-0109): count each batch actually
                 // driven through `write_columnar`, so a caller of the real entry
                 // point can prove the columnar path ran.
                 report.columnar_batches_built += 1;
-                let write_fut = router.write_columnar(
-                    tenant_id.clone(),
-                    *batch,
-                    WriteMode::Strict,
-                    WRITE_ACK_DEADLINE,
-                );
-                pending = spawn_build(state);
-                write_fut.await
+                let router = Arc::clone(&router);
+                let tenant = tenant_id.clone();
+                tokio::spawn(async move {
+                    router
+                        .write_columnar(tenant, *batch, WriteMode::Strict, WRITE_ACK_DEADLINE)
+                        .await
+                })
             }
         };
+        inflight.push_back((n, handle));
+        pending = spawn_build(state);
 
-        let receipt = receipt.map_err(|e| {
-            // Earlier batches are already durable; append this batch's own
-            // durably-acked shards, which `LogWriteError::durable_tokens`
-            // recovers from a multi-shard partial failure (issue #296).
-            let mut durable = report.tokens.clone();
-            durable.extend_from_slice(e.durable_tokens());
-            LoadError::Flush {
-                durable,
-                cause: e.to_string(),
+        // Bound true concurrency to `pipeline_depth`: once the window is full,
+        // resolve the oldest write before starting the next batch's write. This
+        // is the only place `report.tokens` grows during the loop, and it grows
+        // strictly oldest-first, so a later batch's write finishing early can
+        // never record its token ahead of an earlier one (or ahead of an earlier
+        // failure). On a write error, abort every still-queued write so an
+        // already-spawned later batch cannot keep running in the background past
+        // the failure the loader is about to return.
+        // Only one write is spawned per iteration, so the window exceeds its
+        // bound by at most one and this resolves exactly one oldest entry; the
+        // `while` + `let`-else form avoids unwrapping a `pop_front` that is
+        // always `Some` here (the bound is >= 1).
+        while inflight.len() >= pipeline_depth {
+            let Some(entry) = inflight.pop_front() else {
+                break;
+            };
+            if let Err(e) = resolve_write_entry(
+                entry,
+                &mut report,
+                &mut shards_seen,
+                &mut data_batches_flushed,
+                shards,
+            )
+            .await
+            {
+                for (_, handle) in inflight.drain(..) {
+                    handle.abort();
+                }
+                return Err(e);
             }
-        })?;
-        report.rows_processed += n;
-        shards_seen.extend(receipt.tokens.iter().map(|t| t.shard));
-        report.tokens.extend(receipt.tokens);
-
-        data_batches_flushed += 1;
-        if data_batches_flushed == SKEW_CHECK_AFTER_BATCHES && report.skew_warning.is_none() {
-            report.skew_warning = shard_skew_warning(shards_seen.len(), shards);
         }
     }
+
+    // The stream is exhausted; drain every write still in the window in the same
+    // oldest-first order before reporting success.
+    drain_inflight(
+        &mut inflight,
+        &mut report,
+        &mut shards_seen,
+        &mut data_batches_flushed,
+        shards,
+    )
+    .await?;
 
     // Strict acks already guarantee durability; flush_all is a defensive
     // no-op here (nothing is buffered after a Strict write returns).
@@ -818,6 +905,86 @@ async fn load_instrumented(
     }
     report.elapsed = started.elapsed();
     Ok(report)
+}
+
+/// Await one popped in-flight write and fold its outcome into the report, or
+/// turn its failure into a [`LoadError::Flush`]. Entries are always resolved
+/// oldest-first, so `report.tokens` (and the skew-warning checkpoint) advance in
+/// strict submission order: this is the only place the loop records a write's
+/// tokens.
+///
+/// On the write's own error, `durable` is `report.tokens` as it stands at this
+/// point (every batch strictly before this one, already recorded oldest-first)
+/// plus this batch's own durably-acked shards recovered from
+/// `LogWriteError::durable_tokens` (issue #296, a multi-shard write can
+/// partially succeed). A `JoinError` (the spawned write task panicked or was
+/// aborted) is itself a flush failure: it maps to [`LoadError::Flush`] with the
+/// tokens durable up to this point, never to a batch-build error.
+async fn resolve_write_entry(
+    entry: (
+        u64,
+        tokio::task::JoinHandle<Result<LogWriteReceipt, LogWriteError>>,
+    ),
+    report: &mut LoadReport,
+    shards_seen: &mut std::collections::HashSet<u32>,
+    data_batches_flushed: &mut u64,
+    shards: u32,
+) -> Result<(), LoadError> {
+    let (n, handle) = entry;
+    let receipt = match handle.await {
+        Ok(Ok(receipt)) => receipt,
+        Ok(Err(e)) => {
+            let mut durable = report.tokens.clone();
+            durable.extend_from_slice(e.durable_tokens());
+            return Err(LoadError::Flush {
+                durable,
+                cause: e.to_string(),
+            });
+        }
+        Err(join_err) => {
+            return Err(LoadError::Flush {
+                durable: report.tokens.clone(),
+                cause: format!("write task failed: {join_err}"),
+            });
+        }
+    };
+    report.rows_processed += n;
+    shards_seen.extend(receipt.tokens.iter().map(|t| t.shard));
+    report.tokens.extend(receipt.tokens);
+
+    *data_batches_flushed += 1;
+    if *data_batches_flushed == SKEW_CHECK_AFTER_BATCHES && report.skew_warning.is_none() {
+        report.skew_warning = shard_skew_warning(shards_seen.len(), shards);
+    }
+    Ok(())
+}
+
+/// Resolve every write still in the window, oldest-first. On the first write
+/// error it aborts every remaining (later) write before returning, so no
+/// already-spawned batch after the failure keeps running in the background once
+/// the loader has decided to fail: a detached `tokio::spawn`'d task is not
+/// cancelled by dropping its handle.
+async fn drain_inflight(
+    inflight: &mut std::collections::VecDeque<(
+        u64,
+        tokio::task::JoinHandle<Result<LogWriteReceipt, LogWriteError>>,
+    )>,
+    report: &mut LoadReport,
+    shards_seen: &mut std::collections::HashSet<u32>,
+    data_batches_flushed: &mut u64,
+    shards: u32,
+) -> Result<(), LoadError> {
+    while let Some(entry) = inflight.pop_front() {
+        if let Err(e) =
+            resolve_write_entry(entry, report, shards_seen, data_batches_flushed, shards).await
+        {
+            for (_, handle) in inflight.drain(..) {
+                handle.abort();
+            }
+            return Err(e);
+        }
+    }
+    Ok(())
 }
 
 /// The Parquet reader shuttled through each stride cursor's decode/build task.
@@ -2770,6 +2937,7 @@ type = "i64"
             4,
             10_000,
             None,
+            1,
             NOW_NS,
             Arc::new(FixedClock(NOW_NS)),
         )
@@ -2886,6 +3054,7 @@ type = "i64"
             4,
             10_000,
             None,
+            1,
             NOW_NS,
             &mut sink,
         )
@@ -2973,6 +3142,7 @@ type = "i64"
             4,
             0,
             None,
+            1,
             NOW_NS,
             Arc::new(FixedClock(NOW_NS)),
         )
@@ -3004,6 +3174,7 @@ type = "i64"
             4,
             10,
             Some(0),
+            1,
             NOW_NS,
             Arc::new(FixedClock(NOW_NS)),
         )
@@ -3112,6 +3283,7 @@ type = "i64"
             // Both rows in one batch, so one Strict write spans both shards.
             10,
             None,
+            1,
             NOW_NS,
             Arc::new(FixedClock(NOW_NS)),
         )
@@ -3291,6 +3463,7 @@ type = "i64"
             1,
             2,
             None,
+            1,
             NOW_NS,
             Arc::new(FixedClock(NOW_NS)),
             LoadPath::Columnar,
@@ -3378,6 +3551,7 @@ type = "i64"
             4,
             2,
             None,
+            1,
             NOW_NS,
             Arc::new(FixedClock(NOW_NS)),
         )
@@ -3429,6 +3603,7 @@ type = "i64"
             4,
             8,
             Some(4),
+            1,
             NOW_NS,
             Arc::new(FixedClock(NOW_NS)),
         )
@@ -3511,6 +3686,7 @@ type = "i64"
             shards,
             rows_per_group,
             Some(shards as usize),
+            1,
             NOW_NS,
             Arc::new(FixedClock(NOW_NS)),
         )
@@ -3532,6 +3708,7 @@ type = "i64"
             shards,
             rows_per_group,
             Some(1),
+            1,
             NOW_NS,
             Arc::new(FixedClock(NOW_NS)),
         )
@@ -3587,6 +3764,7 @@ type = "i64"
                 4,
                 5,
                 read_cursors,
+                1,
                 NOW_NS,
                 Arc::new(FixedClock(NOW_NS)),
             )
@@ -3666,6 +3844,7 @@ type = "i64"
             shards,
             batch_rows,
             Some(1),
+            1,
             NOW_NS,
             &mut sink,
         )
@@ -3691,6 +3870,7 @@ type = "i64"
             shards,
             batch_rows,
             Some(4),
+            1,
             NOW_NS,
             &mut sink,
         )
@@ -3730,6 +3910,7 @@ type = "i64"
             shards,
             batch_rows,
             Some(1),
+            1,
             NOW_NS,
             &mut sink,
         )
@@ -4049,6 +4230,7 @@ type = "i64"
             shards,
             batch_rows,
             read_cursors,
+            1,
             now_ns,
             clock,
             LoadPath::Row,
@@ -4101,6 +4283,7 @@ type = "i64"
             1,
             2,
             None,
+            1,
             NOW_NS,
             Arc::new(FixedClock(NOW_NS)),
         )
@@ -4137,6 +4320,383 @@ type = "i64"
         assert_eq!(
             report_row.columnar_batches_built, 0,
             "the row path builds no columnar batch"
+        );
+    }
+
+    /// A store wrapper that instruments data-object (`/l0/`) PUTs for the
+    /// `--pipeline-depth` tests: it can sleep a per-key-substring delay before a
+    /// PUT, track the maximum number of data-object PUTs concurrently in flight,
+    /// and count how many PUTs matching a watch prefix started versus completed.
+    /// Non-data PUTs (provisioning record, commit records) pass straight
+    /// through. Every other method delegates unchanged.
+    struct InstrumentedPutStore {
+        inner: Arc<dyn ObjectStoreBackend>,
+        /// `(key substring, delay)`; the first matching entry's delay is applied
+        /// before the PUT reaches `inner`.
+        delays: Vec<(&'static str, Duration)>,
+        /// Data-object PUTs currently sleeping-or-in-`inner`, and the running max.
+        in_flight: Arc<std::sync::atomic::AtomicUsize>,
+        max_in_flight: Arc<std::sync::atomic::AtomicUsize>,
+        /// PUTs whose key contains any of these are counted as started (before
+        /// the delay) and, separately, completed (only on a successful `inner`
+        /// PUT). A `.abort()`ed task never reaches the completion increment.
+        watch_prefixes: Vec<&'static str>,
+        watch_started: Arc<std::sync::atomic::AtomicUsize>,
+        watch_completed: Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    #[async_trait::async_trait]
+    impl ObjectStoreBackend for InstrumentedPutStore {
+        async fn put(
+            &self,
+            key: &str,
+            data: bytes::Bytes,
+            opts: ravel_object_store::PutOptions,
+        ) -> Result<ravel_object_store::PutOutcome, ravel_object_store::StoreError> {
+            use std::sync::atomic::Ordering::SeqCst;
+            let is_data_object = key.contains("/l0/");
+            let watched = self.watch_prefixes.iter().any(|p| key.contains(p));
+            let delay = self
+                .delays
+                .iter()
+                .find(|(p, _)| key.contains(p))
+                .map(|(_, d)| *d);
+            if is_data_object {
+                let now = self.in_flight.fetch_add(1, SeqCst) + 1;
+                self.max_in_flight.fetch_max(now, SeqCst);
+            }
+            if watched {
+                self.watch_started.fetch_add(1, SeqCst);
+            }
+            if let Some(d) = delay {
+                tokio::time::sleep(d).await;
+            }
+            let result = self.inner.put(key, data, opts).await;
+            if is_data_object {
+                self.in_flight.fetch_sub(1, SeqCst);
+            }
+            if watched && result.is_ok() {
+                self.watch_completed.fetch_add(1, SeqCst);
+            }
+            result
+        }
+
+        async fn get(
+            &self,
+            key: &str,
+            range: ravel_object_store::GetRange,
+        ) -> Result<ravel_object_store::GetOutcome, ravel_object_store::StoreError> {
+            self.inner.get(key, range).await
+        }
+
+        async fn put_multipart<'a>(
+            &'a self,
+            key: &str,
+        ) -> Result<Box<dyn ravel_object_store::MultipartUpload + 'a>, ravel_object_store::StoreError>
+        {
+            self.inner.put_multipart(key).await
+        }
+
+        async fn head(
+            &self,
+            key: &str,
+        ) -> Result<ravel_object_store::ObjectMeta, ravel_object_store::StoreError> {
+            self.inner.head(key).await
+        }
+
+        async fn list(
+            &self,
+            prefix: &str,
+            page: Option<ravel_object_store::PageToken>,
+        ) -> Result<ravel_object_store::ListPage, ravel_object_store::StoreError> {
+            self.inner.list(prefix, page).await
+        }
+
+        async fn list_delimited(
+            &self,
+            prefix: &str,
+        ) -> Result<ravel_object_store::DelimitedList, ravel_object_store::StoreError> {
+            self.inner.list_delimited(prefix).await
+        }
+
+        async fn delete(&self, key: &str) -> Result<(), ravel_object_store::StoreError> {
+            self.inner.delete(key).await
+        }
+
+        fn capabilities(&self) -> ravel_object_store::Capabilities {
+            self.inner.capabilities()
+        }
+    }
+
+    /// `--pipeline-depth` is load-bearing, not accepted-and-ignored: the same
+    /// stream run at depth 1 keeps at most one write outstanding, while at depth
+    /// 3 up to three writes are genuinely in flight at once. Each batch is a
+    /// single row routed to its own shard (so its flush runs on its own shard
+    /// actor, and distinct batches' data-object PUTs can overlap); every
+    /// data-object PUT sleeps 50ms while the store tracks the running maximum of
+    /// concurrently outstanding data-object PUTs. Four rows over four shards
+    /// split into four single-shard batches, submitted in turn.
+    ///
+    /// Non-vacuity (prove-the-test): the depth-1 arm asserts the observed max is
+    /// exactly 1 and the depth-3 arm asserts it reaches 3. An implementation
+    /// that accepted `--pipeline-depth` but still awaited each write inline
+    /// before starting the next (today's behavior) would leave the max at 1 for
+    /// both depths, failing the depth-3 assertion; confirmed by running the same
+    /// body at both depths — `max_d1` is 1 and `max_d3` reaches 3 only because
+    /// the write window is real.
+    #[tokio::test]
+    async fn pipeline_depth_bounds_concurrent_writes() {
+        use parquet::arrow::ArrowWriter;
+        use ravel_object_store::memory::MemoryStore;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        async fn max_concurrent_at_depth(depth: usize) -> usize {
+            let shards = 4u32;
+            // Each batch is one row on its own shard, so its flush runs on a
+            // distinct shard actor and can overlap the others.
+            let hosts: Vec<String> = (0..shards).map(|s| host_for_shard(s, shards)).collect();
+
+            let dir = tempfile::tempdir().expect("tempdir");
+            let pq = dir.path().join("depth.parquet");
+            let cols: Vec<(String, ArrayRef)> = vec![
+                ("ts".to_string(), i64_col(vec![NOW_NS; shards as usize])),
+                ("svc".to_string(), str_col(vec!["api"; shards as usize])),
+                (
+                    "host".to_string(),
+                    str_col(hosts.iter().map(|h| h.as_str()).collect()),
+                ),
+            ];
+            let b = RecordBatch::try_from_iter(cols).expect("record batch");
+            let file = std::fs::File::create(&pq).expect("create parquet");
+            let mut writer = ArrowWriter::try_new(file, b.schema(), None).expect("arrow writer");
+            writer.write(&b).expect("write batch");
+            writer.close().expect("close writer");
+
+            let m = parse_mapping(
+                "ts_column = \"ts\"\nts_unit = \"nanos\"\n\n\
+                 [[resource_attribute]]\nkey = \"service.name\"\ncolumn = \"svc\"\ntype = \"str\"\n\n\
+                 [[resource_attribute]]\nkey = \"host\"\ncolumn = \"host\"\ntype = \"str\"\n",
+            )
+            .expect("valid mapping");
+
+            let max_in_flight = Arc::new(AtomicUsize::new(0));
+            let store = Arc::new(InstrumentedPutStore {
+                inner: Arc::new(MemoryStore::new()),
+                delays: vec![("/l0/", Duration::from_millis(50))],
+                in_flight: Arc::new(AtomicUsize::new(0)),
+                max_in_flight: Arc::clone(&max_in_flight),
+                watch_prefixes: Vec::new(),
+                watch_started: Arc::new(AtomicUsize::new(0)),
+                watch_completed: Arc::new(AtomicUsize::new(0)),
+            });
+
+            let report = load(
+                store as Arc<dyn ObjectStoreBackend>,
+                &pq,
+                "acme",
+                &m,
+                shards,
+                1,
+                None,
+                depth,
+                NOW_NS,
+                Arc::new(FixedClock(NOW_NS)),
+            )
+            .await
+            .expect("the load succeeds");
+            assert_eq!(report.rows_processed, shards as u64, "every row is written");
+            max_in_flight.load(Ordering::SeqCst)
+        }
+
+        let max_d1 = max_concurrent_at_depth(1).await;
+        assert_eq!(
+            max_d1, 1,
+            "at --pipeline-depth 1 exactly one write is ever outstanding (today's behavior), \
+             got {max_d1}"
+        );
+
+        let max_d3 = max_concurrent_at_depth(3).await;
+        assert!(
+            max_d3 >= 3,
+            "at --pipeline-depth 3 the write window reaches three concurrently outstanding PUTs, \
+             got {max_d3}"
+        );
+    }
+
+    /// Durable-token correctness under a partial-window failure (the correctness
+    /// constraint this ticket turns on): with `--pipeline-depth 4` and a stream
+    /// of five single-shard batches, the data PUT for the *middle* batch (index
+    /// 2, shard 2) fails permanently. The batches strictly after it (indices 3
+    /// and 4, shards 3 and 4) have their PUTs held ~1s, so they are provably
+    /// still in flight at the instant the failure is detected, and — because the
+    /// loader routes each batch to its own shard actor and a shard actor's flush
+    /// is downstream of the write future the loader holds — they go on to commit
+    /// their objects *independently* even after the loader aborts their write
+    /// handles. That independent success is exactly the trap: the reported
+    /// durable list must still exclude them.
+    ///
+    /// Asserted: the reported durable list is exactly the tokens of the batches
+    /// strictly before the failing one (shards 0 and 1), in submission order; it
+    /// carries no token for the failing batch (a full single-shard PUT failure
+    /// has no partial survivor) and none for the later batches — even though
+    /// `watch_completed` reaching 2 after the wait proves batches 3 and 4's
+    /// writes did in fact succeed and commit. This is the "even if their own
+    /// write happens to succeed independently" clause made observable: the
+    /// durable list grows only by consuming the queue oldest-first, never by
+    /// whichever write finishes.
+    ///
+    /// Non-vacuity (prove-the-test): a wrong resolver that consumed the window
+    /// via `select_all`/whichever-finishes-first instead of strict FIFO
+    /// pop-front would, on this exact fixture, surface batch 2's *immediate*
+    /// permanent failure before batch 1's *artificially delayed* (~50ms) success
+    /// is ever recorded, returning a durable list missing shard 1 — the
+    /// `durable.len() == 2` / `durable[1].shard == 1` assertions reject that. The
+    /// ordering is deterministic because the FaultStore permanent error returns
+    /// effectively instantly while shard 1's PUT is held ~50ms, so the delayed
+    /// success can never win a race the FIFO resolver does not run. And the
+    /// `watch_started == 2` / `watch_completed == 0` snapshot taken the instant
+    /// `load` returns proves batches 3 and 4 were genuinely still outstanding
+    /// (not merely absent because they never ran), closing the "raced and did not
+    /// finish in time" loophole in the opposite direction: they had started but
+    /// had not committed, yet were correctly excluded, and later completing did
+    /// not resurrect them into the list.
+    #[tokio::test]
+    async fn partial_window_failure_reports_only_earlier_batches_never_later() {
+        use parquet::arrow::ArrowWriter;
+        use ravel_object_store::fault::{
+            FaultKind, FaultPlan, FaultStore, Occurrence, Op, Rule, ScriptedFault,
+        };
+        use ravel_object_store::memory::MemoryStore;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let shards = 5;
+        // One row per batch (batch_rows = 1), each routed to its own shard, so
+        // batch k is the sole write to shard k's `/l0/000k/` object.
+        let hosts: Vec<String> = (0..shards).map(|s| host_for_shard(s, shards)).collect();
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let pq = dir.path().join("five_batches.parquet");
+        let cols: Vec<(String, ArrayRef)> = vec![
+            ("ts".to_string(), i64_col(vec![NOW_NS; shards as usize])),
+            ("svc".to_string(), str_col(vec!["api"; shards as usize])),
+            (
+                "host".to_string(),
+                str_col(hosts.iter().map(|h| h.as_str()).collect()),
+            ),
+        ];
+        let b = RecordBatch::try_from_iter(cols).expect("five-row batch");
+        let file = std::fs::File::create(&pq).expect("create parquet");
+        let mut writer = ArrowWriter::try_new(file, b.schema(), None).expect("arrow writer");
+        writer.write(&b).expect("write batch");
+        writer.close().expect("close writer");
+
+        let m = parse_mapping(
+            "ts_column = \"ts\"\nts_unit = \"nanos\"\n\n\
+             [[resource_attribute]]\nkey = \"service.name\"\ncolumn = \"svc\"\ntype = \"str\"\n\n\
+             [[resource_attribute]]\nkey = \"host\"\ncolumn = \"host\"\ntype = \"str\"\n",
+        )
+        .expect("valid mapping");
+
+        // Fail the middle batch's (shard 2) data PUT permanently; no retry, no
+        // sibling shard, so no partial survivor.
+        let plan = FaultPlan::empty().with_rule(
+            Rule::new(
+                Op::Put,
+                ScriptedFault::Permanent("simulated permanent data-object PUT failure".into()),
+            )
+            .with_key_contains("/l0/0002/")
+            .with_occurrence(Occurrence::Always),
+        );
+        let fault = Arc::new(FaultStore::new(MemoryStore::new(), plan));
+
+        let watch_started = Arc::new(AtomicUsize::new(0));
+        let watch_completed = Arc::new(AtomicUsize::new(0));
+        let store = Arc::new(InstrumentedPutStore {
+            inner: fault.clone() as Arc<dyn ObjectStoreBackend>,
+            // Shard 1 (before the failure) is delayed ~50ms so a whichever-
+            // finishes-first resolver would surface shard 2's instant failure
+            // ahead of it; shards 3 and 4 (after the failure) are held ~1s so
+            // they are still in flight at the failure yet commit after the wait.
+            delays: vec![
+                ("/l0/0001/", Duration::from_millis(50)),
+                ("/l0/0003/", Duration::from_millis(1000)),
+                ("/l0/0004/", Duration::from_millis(1000)),
+            ],
+            in_flight: Arc::new(AtomicUsize::new(0)),
+            max_in_flight: Arc::new(AtomicUsize::new(0)),
+            watch_prefixes: vec!["/l0/0003/", "/l0/0004/"],
+            watch_started: Arc::clone(&watch_started),
+            watch_completed: Arc::clone(&watch_completed),
+        });
+
+        let err = load(
+            store as Arc<dyn ObjectStoreBackend>,
+            &pq,
+            "acme",
+            &m,
+            shards,
+            1,
+            None,
+            4,
+            NOW_NS,
+            Arc::new(FixedClock(NOW_NS)),
+        )
+        .await
+        .expect_err("the middle batch's permanent PUT failure fails the load");
+
+        // Snapshot the instant `load` returns: batches 3 and 4 had started their
+        // flush (their shard actors reached the PUT) but had not committed yet.
+        let started_at_return = watch_started.load(Ordering::SeqCst);
+        let completed_at_return = watch_completed.load(Ordering::SeqCst);
+
+        let durable = match &err {
+            LoadError::Flush { durable, .. } => durable.clone(),
+            other => panic!("expected LoadError::Flush, got {other:?}"),
+        };
+        assert_eq!(
+            durable.len(),
+            2,
+            "only the two batches strictly before the failing one are durable, got {durable:?}"
+        );
+        assert_eq!(
+            durable[0].shard, 0,
+            "first durable token is batch 0 (shard 0), in submission order"
+        );
+        assert_eq!(
+            durable[1].shard, 1,
+            "second durable token is batch 1 (shard 1), in submission order"
+        );
+        assert!(
+            durable.iter().all(|t| t.shard == 0 || t.shard == 1),
+            "no token from the failing batch (shard 2) or any later batch (shards 3, 4) is \
+             reported durable, got {durable:?}"
+        );
+
+        assert_eq!(
+            fault.fault_count(Op::Put, FaultKind::Permanent),
+            1,
+            "the permanent data-object PUT fault fired exactly once (shard 2, no retry)"
+        );
+
+        assert_eq!(
+            started_at_return, 2,
+            "both after-failure writes (batches 3 and 4) were outstanding at the failure"
+        );
+        assert_eq!(
+            completed_at_return, 0,
+            "neither after-failure write had committed at the instant the failure was reported, \
+             so their absence from the durable list is FIFO discipline, not a race that left them \
+             unfinished"
+        );
+
+        // Let the still-running shard actors finish their held PUTs: batches 3
+        // and 4 commit their objects independently of the aborted write futures.
+        tokio::time::sleep(Duration::from_millis(1300)).await;
+        assert_eq!(
+            watch_completed.load(Ordering::SeqCst),
+            2,
+            "batches 3 and 4's writes did in fact succeed and commit, yet were still excluded \
+             from the durable list above"
         );
     }
 }

--- a/services/ravel-cli/src/main.rs
+++ b/services/ravel-cli/src/main.rs
@@ -249,6 +249,22 @@ enum Command {
         /// sequential read. `0` is rejected.
         #[arg(long, value_name = "K")]
         read_cursors: Option<usize>,
+        /// Number of Strict writes allowed in flight at once. Each batch's
+        /// write is one S3 PUT round trip per involved shard; with depth `1`
+        /// (the default) the loader submits one write and waits for its ack
+        /// before building or submitting the next, so that round-trip latency
+        /// is serial. Raising the depth lets up to this many writes overlap,
+        /// hiding the PUT latency behind later batches' encode and I/O. The
+        /// cost is memory: each in-flight write keeps its built batch resident
+        /// until its ack, so the live working set scales by roughly the depth
+        /// (see docs/guides/clickbench.md for how this stacks with the
+        /// `--batch-rows` x `--shards` product). Results and ordering are
+        /// unchanged by the depth: the durable-token list a partial-load
+        /// failure reports is always the batches strictly before the failing
+        /// one, in submission order. `1` preserves today's one-write-at-a-time
+        /// behavior. `0` is rejected.
+        #[arg(long, default_value_t = 1)]
+        pipeline_depth: usize,
     },
 }
 
@@ -1187,6 +1203,7 @@ async fn main() -> anyhow::Result<()> {
             shards,
             batch_rows,
             read_cursors,
+            pipeline_depth,
         } => {
             let profile = ravel_cli::cli_profiling::ProfileSession::from_env("ravel-cli-load");
             let result = ravel_cli::load::run(
@@ -1197,6 +1214,7 @@ async fn main() -> anyhow::Result<()> {
                 shards,
                 batch_rows,
                 read_cursors,
+                pipeline_depth,
                 now_ns()?,
             )
             .await;

--- a/services/ravel-cli/src/main.rs
+++ b/services/ravel-cli/src/main.rs
@@ -258,11 +258,20 @@ enum Command {
         /// cost is memory: each in-flight write keeps its built batch resident
         /// until its ack, so the live working set scales by roughly the depth
         /// (see docs/guides/clickbench.md for how this stacks with the
-        /// `--batch-rows` x `--shards` product). Results and ordering are
-        /// unchanged by the depth: the durable-token list a partial-load
-        /// failure reports is always the batches strictly before the failing
-        /// one, in submission order. `1` preserves today's one-write-at-a-time
-        /// behavior. `0` is rejected.
+        /// `--batch-rows` x `--shards` product). The reported durable-token
+        /// list is unaffected by the depth: on a partial-load failure it is
+        /// always exactly the batches strictly before the failing one, in
+        /// submission order, never a later batch that happened to finish
+        /// first. But at depth greater than 1, a batch AFTER the failing one
+        /// may already have committed its data in the background at the
+        /// moment of failure -- the loader cancels its own wait for that
+        /// write's acknowledgement, not the underlying write itself -- so that
+        /// batch's rows can become query-visible without being reported as
+        /// durable. A resume from the reported tokens can therefore
+        /// re-ingest rows that already landed; this is safe only if your
+        /// downstream is tolerant of duplicate rows for the same commit
+        /// window. `1` preserves today's one-write-at-a-time behavior, where
+        /// this gap cannot occur. `0` is rejected.
         #[arg(long, default_value_t = 1)]
         pipeline_depth: usize,
     },

--- a/services/ravel-cli/tests/load.rs
+++ b/services/ravel-cli/tests/load.rs
@@ -147,6 +147,7 @@ type = "i64"
         4,
         10_000,
         None,
+        1,
         CLOCK_NS,
         Arc::new(FixedClock(CLOCK_NS)),
     )
@@ -271,6 +272,7 @@ type = "i64"
         4,
         10_000,
         None,
+        1,
         CLOCK_NS,
         Arc::new(FixedClock(CLOCK_NS)),
     )
@@ -375,6 +377,7 @@ type = "str"
         4,
         1, // one row per Strict flush
         None,
+        1,
         CLOCK_NS,
         Arc::new(FixedClock(CLOCK_NS)),
     )
@@ -430,6 +433,7 @@ type = "str"
         4,
         10_000,
         None,
+        1,
         CLOCK_NS,
         Arc::new(FixedClock(CLOCK_NS)),
     )
@@ -488,6 +492,7 @@ async fn attribute_columns_over_the_object_budget_fold_into_overflow_not_rejecte
         4,
         10_000,
         None,
+        1,
         CLOCK_NS,
         Arc::new(FixedClock(CLOCK_NS)),
     )

--- a/services/ravel-cli/tests/typed_attr_column_reachability_e2e.rs
+++ b/services/ravel-cli/tests/typed_attr_column_reachability_e2e.rs
@@ -154,6 +154,7 @@ type = "i64"
         1,
         10_000,
         None,
+        1,
         CLOCK_NS,
         Arc::new(AdvancingClock(Arc::new(AtomicI64::new(CLOCK_NS)))),
     )

--- a/services/ravel-cli/tests/wide_schema_load_sql_e2e.rs
+++ b/services/ravel-cli/tests/wide_schema_load_sql_e2e.rs
@@ -428,6 +428,7 @@ async fn run_load(
         1,
         10_000,
         None,
+        1,
         CLOCK_NS,
         Arc::new(AdvancingClock(Arc::new(AtomicI64::new(CLOCK_NS)))),
     )


### PR DESCRIPTION
The bulk loader (services/ravel-cli) held exactly one Strict write in
flight at a time, awaited synchronously each loop iteration, so the S3
PUT round trip was a fully serial term regardless of how fast decode
and encode ran. A production run on the ClickBench reference box
showed ~300% CPU against an 8-encoder ceiling, the signature of a
serial term rather than encode saturation.

Adds an operator-facing --pipeline-depth flag (default 1, unchanged
behavior) that lets up to that many writes run concurrently: each
batch's write is spawned onto its own task and held in an ordered
queue, popped strictly oldest-first once the queue reaches the
configured depth. This is the load-bearing property for the ticket's
correctness constraint: on a partial-load failure, the reported
durable-token list is always exactly the batches strictly before the
failing one, in submission order, never a later batch that happened to
finish first.

At depth greater than 1 there is a known, documented gap: a batch
after the failing one may already have committed its data in the
background at the moment of failure, since aborting a queued write's
JoinHandle only cancels the loader's own wait for its acknowledgement,
not the underlying per-shard actor's flush. That batch's rows can
become query-visible without being reported as durable, so a resume
from the reported tokens can re-ingest already-landed rows. This is a
pre-existing gap widened by depth > 1, not introduced by it (the same
issue already exists for an ack-deadline timeout at depth 1); filed
ravel-ingest issue #694 to give write cancellation a real mechanism.
Documented in the --pipeline-depth --help text and in
docs/guides/clickbench.md.

This PR also includes a same-day fix on top of the fleet executor's
initial implementation: an adversarial review caught that the
durable-token test's fixture could not actually distinguish correct
FIFO ordering from a wrong whichever-finishes-first resolver (it
delayed the wrong batches), and that three comments/help text claimed
the write abort stops the underlying write outright, which it does
not. Both are corrected; see the second commit for detail.

Local verification note: this host's disk cannot currently sustain an
isolated cold full-workspace gate for this change (a first attempt
exhausted disk mid cargo build --workspace --all-targets, see the
gate-exit-1-can-be-self-inflicted-disk-kill lesson). Verified instead
with a full warm-cache workspace fmt + clippy pass plus
scripts/affected-tests.sh -p ravel-cli (both the new tests and the
full existing ravel-cli suite green, including a 20x loop of the
timing-sensitive partial-window-failure test with no flakes). Relying
on this PR's required CI checks, which run on separate infrastructure
with their own disk, as the full gate.

Refs: #585
Refs: #694
