### PR TITLE
feat(ravel-bench): --fetch-concurrency for sql_latency_bench

### DIFF
--- a/crates/ravel-bench/src/bin/sql_latency_bench.rs
+++ b/crates/ravel-bench/src/bin/sql_latency_bench.rs
@@ -105,6 +105,14 @@ struct Args {
     /// the report, so a partial table is never mistaken for a complete one.
     #[arg(long, default_value_t = false)]
     continue_on_error: bool,
+    /// The executor's `fetch_concurrency` (ADR-0088): logs scan partition count
+    /// and the bound on in-flight segment fetches per query, the same knob as
+    /// `ravel-server --fetch-concurrency`. A full-scan statement's cold time is
+    /// latency-bound at the object store, so it moves nearly linearly with
+    /// this. Defaults to ravel-query's compiled-in value (8), the number every
+    /// earlier run used; recorded in the report's provenance.
+    #[arg(long, default_value_t = ravel_query::DEFAULT_FETCH_CONCURRENCY)]
+    fetch_concurrency: usize,
 }
 
 #[derive(Copy, Clone, Debug, clap::ValueEnum)]
@@ -213,6 +221,7 @@ async fn run(args: &Args) -> Result<SqlLatencyReport, ravel_bench::sql_latency::
                 cache_bytes: args.cache_bytes,
                 deadline: Duration::from_secs(args.deadline_secs),
                 continue_on_error: args.continue_on_error,
+                fetch_concurrency: args.fetch_concurrency,
             };
             run_tenant(&cfg).await
         }
@@ -234,6 +243,7 @@ async fn run(args: &Args) -> Result<SqlLatencyReport, ravel_bench::sql_latency::
                 cache_bytes: args.cache_bytes,
                 deadline: Duration::from_secs(args.deadline_secs),
                 continue_on_error: args.continue_on_error,
+                fetch_concurrency: args.fetch_concurrency,
             };
             run_generated(&cfg).await
         }
@@ -256,6 +266,7 @@ fn print_human_table(report: &SqlLatencyReport) {
     );
     println!("  runs/query : {}", p.runs);
     println!("  deadline   : {} s per statement", p.deadline_secs);
+    println!("  fetch conc : {}", p.fetch_concurrency);
     if p.cache_bytes > 0 {
         println!("  read cache : {} bytes", p.cache_bytes);
     } else {

--- a/crates/ravel-bench/src/sql_latency.rs
+++ b/crates/ravel-bench/src/sql_latency.rs
@@ -45,7 +45,9 @@ use ravel_logseg::{
     AttrValue, LogRecord, ObjectIdentity, RlogConfig, RlogWriter, stream_attrs_bytes,
 };
 use ravel_object_store::{ObjectStoreBackend, PutOptions};
-use ravel_query::{CacheFetchError, LogSegmentFetcher, SegmentFetcher};
+use ravel_query::{
+    CacheFetchError, DEFAULT_FETCH_CONCURRENCY, EngineConfig, LogSegmentFetcher, SegmentFetcher,
+};
 use ravel_sql::{
     DeclaredColumn, DeclaredType, SpanSegmentFetcher, SqlConfig, SqlExecutor, SqlRequest,
     StaticDeclaredColumns,
@@ -169,6 +171,17 @@ pub struct Provenance {
     /// `failed`, not as a latency.
     #[serde(default = "default_deadline_secs")]
     pub deadline_secs: u64,
+    /// The executor's `fetch_concurrency` (logs scan partitions and in-flight
+    /// segment fetches per query). Recorded because the cold floor of a
+    /// full-scan statement is latency-bound and moves nearly linearly with it.
+    #[serde(default = "default_fetch_concurrency")]
+    pub fetch_concurrency: usize,
+}
+
+/// What every run used before the knob was configurable (issue #680); also
+/// what a report written before the field existed deserializes to.
+fn default_fetch_concurrency() -> usize {
+    DEFAULT_FETCH_CONCURRENCY
 }
 
 /// The deadline every run used before it became configurable (issue #688);
@@ -323,6 +336,11 @@ pub struct GenerateConfig {
     /// [`SqlLatencyReport::failed`] and the run moves on; when `false` the first
     /// failure aborts the run with its error.
     pub continue_on_error: bool,
+    /// [`EngineConfig::fetch_concurrency`] for the executor: the logs scan's
+    /// partition count and the bound on in-flight segment fetches per query
+    /// (ADR-0088's single coupled knob, `ravel-server --fetch-concurrency`).
+    /// Defaults to [`ravel_query::DEFAULT_FETCH_CONCURRENCY`].
+    pub fetch_concurrency: usize,
 }
 
 /// Inputs for the loaded-tenant lane.
@@ -365,6 +383,11 @@ pub struct TenantConfigInput {
     /// [`SqlLatencyReport::failed`] and the run moves on; when `false` the first
     /// failure aborts the run with its error.
     pub continue_on_error: bool,
+    /// [`EngineConfig::fetch_concurrency`] for the executor: the logs scan's
+    /// partition count and the bound on in-flight segment fetches per query
+    /// (ADR-0088's single coupled knob, `ravel-server --fetch-concurrency`).
+    /// Defaults to [`ravel_query::DEFAULT_FETCH_CONCURRENCY`].
+    pub fetch_concurrency: usize,
 }
 
 fn percentile(sorted_ns: &[u64], pct: f64) -> u64 {
@@ -452,6 +475,7 @@ fn cold_executor(
     max_query_bytes: usize,
     shard_count: u32,
     cache: Option<Arc<Cache<CacheFetchError>>>,
+    fetch_concurrency: usize,
 ) -> Result<SqlExecutor, Error> {
     let catalog = Arc::new(Catalog::new(
         Arc::clone(store),
@@ -471,6 +495,10 @@ fn cold_executor(
         SpanSegmentFetcher::new(Arc::clone(store)),
         SqlConfig {
             max_query_bytes,
+            engine: EngineConfig {
+                fetch_concurrency: fetch_concurrency.max(1),
+                ..EngineConfig::default()
+            },
             ..SqlConfig::default()
         },
         1 << 30,
@@ -501,6 +529,7 @@ pub async fn measure_corpus(
     cache_bytes: u64,
     deadline: Duration,
     continue_on_error: bool,
+    fetch_concurrency: usize,
 ) -> Result<(Vec<EntryReport>, Vec<SkippedEntry>, Vec<FailedEntry>), Error> {
     let runs = runs.max(1);
     let mut measured = Vec::new();
@@ -535,7 +564,14 @@ pub async fn measure_corpus(
         // across entries would warm one statement from another's reads over the
         // same segments.
         let cache = (cache_bytes > 0).then(|| build_read_cache(cache_bytes));
-        let executor = cold_executor(store, declared, max_query_bytes, shard_count, cache)?;
+        let executor = cold_executor(
+            store,
+            declared,
+            max_query_bytes,
+            shard_count,
+            cache,
+            fetch_concurrency,
+        )?;
         let req = SqlRequest {
             sql: entry.sql.clone(),
             window,
@@ -698,6 +734,7 @@ pub async fn run_generated(cfg: &GenerateConfig) -> Result<SqlLatencyReport, Err
         cfg.cache_bytes,
         cfg.deadline,
         cfg.continue_on_error,
+        cfg.fetch_concurrency,
     )
     .await?;
 
@@ -712,6 +749,7 @@ pub async fn run_generated(cfg: &GenerateConfig) -> Result<SqlLatencyReport, Err
             runs: cfg.runs.max(1),
             cache_bytes: cfg.cache_bytes,
             deadline_secs: cfg.deadline.as_secs(),
+            fetch_concurrency: cfg.fetch_concurrency.max(1),
         },
         dataset,
         entries,
@@ -780,6 +818,7 @@ pub async fn run_tenant(cfg: &TenantConfigInput) -> Result<SqlLatencyReport, Err
         cfg.cache_bytes,
         cfg.deadline,
         cfg.continue_on_error,
+        cfg.fetch_concurrency,
     )
     .await?;
 
@@ -794,6 +833,7 @@ pub async fn run_tenant(cfg: &TenantConfigInput) -> Result<SqlLatencyReport, Err
             runs: cfg.runs.max(1),
             cache_bytes: cfg.cache_bytes,
             deadline_secs: cfg.deadline.as_secs(),
+            fetch_concurrency: cfg.fetch_concurrency.max(1),
         },
         dataset,
         entries,
@@ -1092,6 +1132,7 @@ mod tests {
             cache_bytes,
             deadline: Duration::from_secs(30),
             continue_on_error: false,
+            fetch_concurrency: DEFAULT_FETCH_CONCURRENCY,
         }
     }
 
@@ -1206,6 +1247,7 @@ mod tests {
             0,
             Duration::from_millis(20),
             true,
+            DEFAULT_FETCH_CONCURRENCY,
         )
         .await
         .expect("run continues past the expiry");
@@ -1422,15 +1464,29 @@ mod tests {
         // Fetcher cache ON: a fresh executor (cold catalog byte cache, cold
         // fetcher cache), one run.
         let cache = build_read_cache(64 << 20);
-        let cached = cold_executor(&store, &[], DEFAULT_MAX_QUERY_BYTES, 1, Some(cache))
-            .expect("build cached executor");
+        let cached = cold_executor(
+            &store,
+            &[],
+            DEFAULT_MAX_QUERY_BYTES,
+            1,
+            Some(cache),
+            DEFAULT_FETCH_CONCURRENCY,
+        )
+        .expect("build cached executor");
         let on = cached.execute(th, &req).await.expect("cached run");
 
         // Fetcher cache OFF: a fresh executor (identical cold catalog byte cache,
         // no fetcher cache), one run. The catalog contribution is the same in
         // both, so any delta is the fetcher cache alone.
-        let uncached = cold_executor(&store, &[], DEFAULT_MAX_QUERY_BYTES, 1, None)
-            .expect("build uncached executor");
+        let uncached = cold_executor(
+            &store,
+            &[],
+            DEFAULT_MAX_QUERY_BYTES,
+            1,
+            None,
+            DEFAULT_FETCH_CONCURRENCY,
+        )
+        .expect("build uncached executor");
         let off = uncached.execute(th, &req).await.expect("uncached run");
 
         let get_on = on.accounting.s3_requests(AccountedOp::Get);
@@ -1456,12 +1512,34 @@ mod tests {
     /// reverting `cold_executor` to `SqlConfig::default()` makes this fail rather
     /// than pass on a coincidental default (its companion test covers the
     /// default itself).
+    /// `--fetch-concurrency` must land on `EngineConfig::fetch_concurrency`
+    /// (the logs scan's partition count and in-flight fetch bound), not stop at
+    /// a parsed field; reverting `cold_executor` to `EngineConfig::default()`
+    /// fails this on the distinct value.
+    #[test]
+    fn cold_executor_threads_fetch_concurrency_override() {
+        let store = empty_store();
+        let custom = DEFAULT_FETCH_CONCURRENCY * 4;
+        assert_ne!(custom, DEFAULT_FETCH_CONCURRENCY);
+        let executor = cold_executor(&store, &[], DEFAULT_MAX_QUERY_BYTES, 1, None, custom)
+            .expect("build executor");
+        assert_eq!(executor.config().engine.fetch_concurrency, custom);
+        let executor = cold_executor(&store, &[], DEFAULT_MAX_QUERY_BYTES, 1, None, 0)
+            .expect("build executor");
+        assert_eq!(
+            executor.config().engine.fetch_concurrency,
+            1,
+            "a zero is clamped to one partition, never a zero-partition plan"
+        );
+    }
+
     #[test]
     fn cold_executor_threads_max_query_bytes_override() {
         let store = empty_store();
         let custom = DEFAULT_MAX_QUERY_BYTES * 4;
         assert_ne!(custom, DEFAULT_MAX_QUERY_BYTES);
-        let executor = cold_executor(&store, &[], custom, 1, None).expect("build executor");
+        let executor = cold_executor(&store, &[], custom, 1, None, DEFAULT_FETCH_CONCURRENCY)
+            .expect("build executor");
         assert_eq!(executor.config().max_query_bytes, custom);
     }
 
@@ -1472,8 +1550,15 @@ mod tests {
     #[test]
     fn cold_executor_defaults_to_compiled_in_budget() {
         let store = empty_store();
-        let executor =
-            cold_executor(&store, &[], DEFAULT_MAX_QUERY_BYTES, 1, None).expect("build executor");
+        let executor = cold_executor(
+            &store,
+            &[],
+            DEFAULT_MAX_QUERY_BYTES,
+            1,
+            None,
+            DEFAULT_FETCH_CONCURRENCY,
+        )
+        .expect("build executor");
         assert_eq!(executor.config().max_query_bytes, DEFAULT_MAX_QUERY_BYTES);
     }
 }

--- a/crates/ravel-bench/tests/sql_latency_object_count_invariant.rs
+++ b/crates/ravel-bench/tests/sql_latency_object_count_invariant.rs
@@ -26,6 +26,8 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 
+use ravel_query::DEFAULT_FETCH_CONCURRENCY;
+
 use prost::Message;
 use ravel_bench::sql_corpus::checked_default_corpus;
 use ravel_bench::sql_latency::{GenerateConfig, run_generated};
@@ -93,6 +95,7 @@ async fn l0_object_count_equals_distinct_data_object_keys() {
         cache_bytes: 0,
         deadline: Duration::from_secs(30),
         continue_on_error: false,
+        fetch_concurrency: DEFAULT_FETCH_CONCURRENCY,
     };
     let report = run_generated(&cfg).await.expect("generated lane runs");
 

--- a/crates/ravel-bench/tests/sql_latency_smoke.rs
+++ b/crates/ravel-bench/tests/sql_latency_smoke.rs
@@ -19,6 +19,8 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use ravel_query::DEFAULT_FETCH_CONCURRENCY;
+
 use ravel_bench::sql_corpus::{
     CorpusEntry, Modification, RequiredDeclaration, RequiredDeclaredType, checked_default_corpus,
 };
@@ -50,6 +52,7 @@ fn small_generate_config(store: Arc<dyn ObjectStoreBackend>, runs: usize) -> Gen
         cache_bytes: 0,
         deadline: Duration::from_secs(30),
         continue_on_error: false,
+        fetch_concurrency: DEFAULT_FETCH_CONCURRENCY,
     }
 }
 
@@ -220,6 +223,7 @@ async fn an_entry_with_an_unsatisfied_required_declaration_is_skipped_with_the_k
         0,
         Duration::from_secs(30),
         false,
+        DEFAULT_FETCH_CONCURRENCY,
     )
     .await
     .expect("measure_corpus runs");

--- a/docs/guides/clickbench.md
+++ b/docs/guides/clickbench.md
@@ -228,6 +228,15 @@ cargo run -p ravel-bench --features sql-latency --bin sql_latency_bench -- \
   so a partial table cannot pass for a complete one. Pair it with `--runs 1`
   and a generous `--deadline-secs` for the first pass over a new dataset, then
   choose the deadline for the `--runs 3` table from what that pass measured.
+- `--fetch-concurrency <N>` is the executor's `fetch_concurrency` (ADR-0088),
+  the same knob as `ravel-server --fetch-concurrency`: the logs scan's
+  partition count and the bound on in-flight segment fetches per query. Default
+  8, ravel-query's compiled-in value and what every earlier run used. A
+  full-scan statement's cold time is latency-bound at the object store (a few
+  hundred KB per GET, a few MB/s per connection), so it moves nearly linearly
+  with this up to the host's cores; the value is recorded in the report's
+  provenance as `fetch_concurrency`, and two tables at different values are
+  not comparable without it.
 - A resolve that finds **0 objects** is now an error naming the tenant, the
   resolved shard count, the window, and `now_ns`, rather than a silent report
   over an empty dataset. A wrong `--window-hours` (the event-time span the


### PR DESCRIPTION
`sql_latency_bench` built its executor with `SqlConfig::default()`, so every run used ravel-query's compiled-in `fetch_concurrency` of 8: eight logs scan partitions and at most eight segment fetches in flight. On the full ClickBench tenant (#680) a full-scan statement is latency-bound at the object store (~240 KB per GET, 5.5 MB/s per connection, 44 MB/s over the eight), so its cold floor moves nearly linearly with this knob, and the bench had no way to set it.

- `--fetch-concurrency <N>` (default 8, behaviour unchanged when unset), threaded into `EngineConfig::fetch_concurrency` exactly as `ravel-server --fetch-concurrency` is, clamped to at least 1.
- Recorded in the report's provenance as `fetch_concurrency` (`#[serde(default)]` to the compiled-in value, so older reports still deserialize) and printed in the human table, so two tables at different values are not mistaken for comparable.
- Guide step 5 documents it.

Test: `cold_executor_threads_fetch_concurrency_override` builds the executor at 32 and at 0 and reads `config().engine.fetch_concurrency` back (32, and 1 for the clamp). Restoring `EngineConfig::default()` in `cold_executor` fails it: `left: 8, right: 32`.

Gates run locally on a warm target: fmt, `clippy -p ravel-bench --all-targets --features sql-latency,profiling`, `test -p ravel-bench --features sql-latency,profiling` (37 test binaries), `clippy --workspace --all-targets`.

Refs #680.
