### PR TITLE
feat(ravel-bench): stream per-statement outcomes as JSON lines

### DIFF
--- a/crates/ravel-bench/src/bin/sql_latency_bench.rs
+++ b/crates/ravel-bench/src/bin/sql_latency_bench.rs
@@ -113,6 +113,12 @@ struct Args {
     /// earlier run used; recorded in the report's provenance.
     #[arg(long, default_value_t = ravel_query::DEFAULT_FETCH_CONCURRENCY)]
     fetch_concurrency: usize,
+    /// Append one JSON line per finished statement to this file as the run
+    /// goes (`{"outcome":"measured"|"skipped"|"failed", ...}`), flushed per
+    /// line. The full report still goes to stdout at the end; this is what
+    /// survives a run killed hours in.
+    #[arg(long, value_name = "PATH")]
+    progress_jsonl: Option<std::path::PathBuf>,
 }
 
 #[derive(Copy, Clone, Debug, clap::ValueEnum)]
@@ -222,6 +228,7 @@ async fn run(args: &Args) -> Result<SqlLatencyReport, ravel_bench::sql_latency::
                 deadline: Duration::from_secs(args.deadline_secs),
                 continue_on_error: args.continue_on_error,
                 fetch_concurrency: args.fetch_concurrency,
+                progress_jsonl: args.progress_jsonl.clone(),
             };
             run_tenant(&cfg).await
         }
@@ -244,6 +251,7 @@ async fn run(args: &Args) -> Result<SqlLatencyReport, ravel_bench::sql_latency::
                 deadline: Duration::from_secs(args.deadline_secs),
                 continue_on_error: args.continue_on_error,
                 fetch_concurrency: args.fetch_concurrency,
+                progress_jsonl: args.progress_jsonl.clone(),
             };
             run_generated(&cfg).await
         }

--- a/crates/ravel-bench/src/sql_latency.rs
+++ b/crates/ravel-bench/src/sql_latency.rs
@@ -287,6 +287,44 @@ pub struct FailedEntry {
     pub error: String,
 }
 
+/// One statement's outcome, emitted the moment it is known. This is what the
+/// progress stream carries: a run over a large dataset can take hours and the
+/// full [`SqlLatencyReport`] is only written at the end, so a crash or a kill
+/// late in the run would otherwise lose every number already measured.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "outcome", rename_all = "snake_case")]
+pub enum EntryEvent {
+    Measured(EntryReport),
+    Skipped(SkippedEntry),
+    Failed(FailedEntry),
+}
+
+/// An append-only JSON-lines sink for [`EntryEvent`]s, flushed after every
+/// line so the file is complete up to the last finished statement at any
+/// instant. `None` when no progress path was configured.
+struct ProgressSink {
+    file: std::fs::File,
+}
+
+impl ProgressSink {
+    fn open(path: &std::path::Path) -> Result<Self, Error> {
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+            .map_err(|e| format!("open progress file {}: {e}", path.display()))?;
+        Ok(ProgressSink { file })
+    }
+
+    fn write(&mut self, event: &EntryEvent) -> Result<(), Error> {
+        use std::io::Write;
+        let line = serde_json::to_string(event)?;
+        writeln!(self.file, "{line}")?;
+        self.file.flush()?;
+        Ok(())
+    }
+}
+
 /// The full report: provenance, dataset shape, measured statements, the
 /// statements skipped for an unsatisfied declared-column dependency, and the
 /// statements that ran and failed.
@@ -341,6 +379,10 @@ pub struct GenerateConfig {
     /// (ADR-0088's single coupled knob, `ravel-server --fetch-concurrency`).
     /// Defaults to [`ravel_query::DEFAULT_FETCH_CONCURRENCY`].
     pub fetch_concurrency: usize,
+    /// Append one JSON line per finished statement ([`EntryEvent`]) to this
+    /// file as the run goes, flushed per line, so a run killed hours in still
+    /// leaves every number it had measured. `None` writes nothing.
+    pub progress_jsonl: Option<std::path::PathBuf>,
 }
 
 /// Inputs for the loaded-tenant lane.
@@ -388,6 +430,10 @@ pub struct TenantConfigInput {
     /// (ADR-0088's single coupled knob, `ravel-server --fetch-concurrency`).
     /// Defaults to [`ravel_query::DEFAULT_FETCH_CONCURRENCY`].
     pub fetch_concurrency: usize,
+    /// Append one JSON line per finished statement ([`EntryEvent`]) to this
+    /// file as the run goes, flushed per line, so a run killed hours in still
+    /// leaves every number it had measured. `None` writes nothing.
+    pub progress_jsonl: Option<std::path::PathBuf>,
 }
 
 fn percentile(sorted_ns: &[u64], pct: f64) -> u64 {
@@ -530,11 +576,13 @@ pub async fn measure_corpus(
     deadline: Duration,
     continue_on_error: bool,
     fetch_concurrency: usize,
+    progress_jsonl: Option<&std::path::Path>,
 ) -> Result<(Vec<EntryReport>, Vec<SkippedEntry>, Vec<FailedEntry>), Error> {
     let runs = runs.max(1);
     let mut measured = Vec::new();
     let mut skipped = Vec::new();
     let mut failed = Vec::new();
+    let mut progress = progress_jsonl.map(ProgressSink::open).transpose()?;
 
     // CPU flamegraph lane (issue #365's pattern; see crate::profiling). Covers
     // every entry's execution, both lanes (run_generated/run_tenant funnel
@@ -548,14 +596,18 @@ pub async fn measure_corpus(
         // entry must be skipped, not run: removing this guard lets the entry
         // execute and report a plausible-but-wrong latency.
         if let Some((missing_key, want)) = first_unsatisfied(entry, declared) {
-            skipped.push(SkippedEntry {
+            let skip = SkippedEntry {
                 id: entry.id.clone(),
                 missing_key: missing_key.clone(),
                 reason: format!(
                     "required declared column `{missing_key}` ({want:?}) is not satisfied by the \
                      dataset under measurement"
                 ),
-            });
+            };
+            if let Some(sink) = progress.as_mut() {
+                sink.write(&EntryEvent::Skipped(skip.clone()))?;
+            }
+            skipped.push(skip);
             continue;
         }
 
@@ -601,11 +653,15 @@ pub async fn measure_corpus(
             let outcome = match executor.execute(tenant_hash, &req).await {
                 Ok(outcome) => outcome,
                 Err(e) if continue_on_error => {
-                    failed.push(FailedEntry {
+                    let failure = FailedEntry {
                         id: entry.id.clone(),
                         run,
                         error: e.to_string(),
-                    });
+                    };
+                    if let Some(sink) = progress.as_mut() {
+                        sink.write(&EntryEvent::Failed(failure.clone()))?;
+                    }
+                    failed.push(failure);
                     continue 'entries;
                 }
                 Err(e) => {
@@ -642,7 +698,7 @@ pub async fn measure_corpus(
         let mut sorted = latencies_ns.clone();
         sorted.sort_unstable();
         let to_ms = |ns: u64| ns as f64 / 1e6;
-        measured.push(EntryReport {
+        let report = EntryReport {
             id: entry.id.clone(),
             min_ms: to_ms(*sorted.first().unwrap()),
             median_ms: to_ms(percentile(&sorted, 0.50)),
@@ -650,7 +706,11 @@ pub async fn measure_corpus(
             cold_ms: to_ms(cold_ns),
             rows_returned,
             scan,
-        });
+        };
+        if let Some(sink) = progress.as_mut() {
+            sink.write(&EntryEvent::Measured(report.clone()))?;
+        }
+        measured.push(report);
     }
 
     profile.finish();
@@ -735,6 +795,7 @@ pub async fn run_generated(cfg: &GenerateConfig) -> Result<SqlLatencyReport, Err
         cfg.deadline,
         cfg.continue_on_error,
         cfg.fetch_concurrency,
+        cfg.progress_jsonl.as_deref(),
     )
     .await?;
 
@@ -819,6 +880,7 @@ pub async fn run_tenant(cfg: &TenantConfigInput) -> Result<SqlLatencyReport, Err
         cfg.deadline,
         cfg.continue_on_error,
         cfg.fetch_concurrency,
+        cfg.progress_jsonl.as_deref(),
     )
     .await?;
 
@@ -1133,7 +1195,62 @@ mod tests {
             deadline: Duration::from_secs(30),
             continue_on_error: false,
             fetch_concurrency: DEFAULT_FETCH_CONCURRENCY,
+            progress_jsonl: None,
         }
+    }
+
+    /// Every statement outcome is appended to the progress file as a JSON
+    /// line the moment it is known, one line per statement in run order, so a
+    /// run cut short still leaves every finished number on disk. The final
+    /// report is built from the same values.
+    #[tokio::test]
+    async fn progress_jsonl_carries_every_outcome_in_order() {
+        let store = empty_store();
+        provisioned_tenant(&store, "progress-tenant").await;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("progress.jsonl");
+
+        let mut cfg = tenant_cfg(&store, "progress-tenant", None, 0);
+        cfg.entries = vec![
+            entry("fine", "SELECT body FROM logs"),
+            entry("broken", "SELECT no_such_column FROM logs"),
+            entry("also_fine", "SELECT ts FROM logs"),
+        ];
+        cfg.continue_on_error = true;
+        cfg.progress_jsonl = Some(path.clone());
+        let report = run_tenant(&cfg).await.expect("tenant lane runs");
+
+        let lines: Vec<EntryEvent> = std::fs::read_to_string(&path)
+            .expect("progress file")
+            .lines()
+            .map(|l| serde_json::from_str(l).expect("each line is an EntryEvent"))
+            .collect();
+        let ids: Vec<(&str, &str)> = lines
+            .iter()
+            .map(|e| match e {
+                EntryEvent::Measured(m) => ("measured", m.id.as_str()),
+                EntryEvent::Skipped(s) => ("skipped", s.id.as_str()),
+                EntryEvent::Failed(f) => ("failed", f.id.as_str()),
+            })
+            .collect();
+        assert_eq!(
+            ids,
+            vec![
+                ("measured", "fine"),
+                ("failed", "broken"),
+                ("measured", "also_fine")
+            ],
+            "one line per statement, in run order, each with its outcome"
+        );
+        assert_eq!(report.entries.len(), 2);
+        assert_eq!(report.failed.len(), 1);
+        let EntryEvent::Measured(first) = &lines[0] else {
+            panic!("first line is the measured entry");
+        };
+        assert_eq!(
+            first.rows_returned, report.entries[0].rows_returned,
+            "the streamed line carries the same numbers the report does"
+        );
     }
 
     /// A corpus entry with no declared-column dependency, so the tenant lane
@@ -1248,6 +1365,7 @@ mod tests {
             Duration::from_millis(20),
             true,
             DEFAULT_FETCH_CONCURRENCY,
+            None,
         )
         .await
         .expect("run continues past the expiry");

--- a/crates/ravel-bench/tests/sql_latency_object_count_invariant.rs
+++ b/crates/ravel-bench/tests/sql_latency_object_count_invariant.rs
@@ -96,6 +96,7 @@ async fn l0_object_count_equals_distinct_data_object_keys() {
         deadline: Duration::from_secs(30),
         continue_on_error: false,
         fetch_concurrency: DEFAULT_FETCH_CONCURRENCY,
+        progress_jsonl: None,
     };
     let report = run_generated(&cfg).await.expect("generated lane runs");
 

--- a/crates/ravel-bench/tests/sql_latency_smoke.rs
+++ b/crates/ravel-bench/tests/sql_latency_smoke.rs
@@ -53,6 +53,7 @@ fn small_generate_config(store: Arc<dyn ObjectStoreBackend>, runs: usize) -> Gen
         deadline: Duration::from_secs(30),
         continue_on_error: false,
         fetch_concurrency: DEFAULT_FETCH_CONCURRENCY,
+        progress_jsonl: None,
     }
 }
 
@@ -224,6 +225,7 @@ async fn an_entry_with_an_unsatisfied_required_declaration_is_skipped_with_the_k
         Duration::from_secs(30),
         false,
         DEFAULT_FETCH_CONCURRENCY,
+        None,
     )
     .await
     .expect("measure_corpus runs");

--- a/docs/guides/clickbench.md
+++ b/docs/guides/clickbench.md
@@ -265,6 +265,11 @@ cargo run -p ravel-bench --features sql-latency --bin sql_latency_bench -- \
   with this up to the host's cores; the value is recorded in the report's
   provenance as `fetch_concurrency`, and two tables at different values are
   not comparable without it.
+- `--progress-jsonl <PATH>` appends one JSON line per finished statement to
+  `PATH` as the run goes (`{"outcome":"measured",...}`, `"skipped"`,
+  `"failed"`), flushed per line. The full report still goes to stdout at the
+  end. Use it on every long run: a 43-statement pass over 100M rows takes
+  hours, and without it a kill or a crash at statement 40 leaves nothing.
 - A resolve that finds **0 objects** is now an error naming the tenant, the
   resolved shard count, the window, and `now_ns`, rather than a silent report
   over an empty dataset. A wrong `--window-hours` (the event-time span the


### PR DESCRIPTION
`sql_latency_bench` writes its report once, at the end. A 43-statement pass over the full ClickBench tenant takes hours (#680); three passes were cut short on 2026-08-25 and none left a number behind, because nothing is written until the last statement finishes.

`--progress-jsonl <PATH>` appends one JSON line per finished statement as the run goes, flushed per line:

```
{"outcome":"measured","id":"q01_count_all","cold_ms":142418.0,...}
{"outcome":"failed","id":"q29_...","run":0,"error":"query exceeded its 600000 ms wall deadline"}
{"outcome":"skipped","id":"...","missing_key":"...","reason":"..."}
```

`EntryEvent` is a tagged enum over the existing `EntryReport` / `SkippedEntry` / `FailedEntry`, so a line carries exactly what the final report's row carries. The report itself is unchanged. Both lanes thread the path through `measure_corpus`; the guide documents the flag.

Test: a three-statement tenant-lane corpus with one broken statement under `--continue-on-error`; the file holds exactly three lines in run order (`measured`, `failed`, `measured`) and the first line's `rows_returned` equals the report's.

Gates run locally on a warm target: fmt, `clippy -p ravel-bench --all-targets --features sql-latency,profiling`, `test -p ravel-bench --features sql-latency,profiling` (37 test binaries), `clippy --workspace --all-targets`.

Refs #680.
