### PR TITLE
fix(ravel-query): hand --fetch-concurrency to the logs fetcher's GET pool

### DIFF
--- a/crates/ravel-bench/src/sql_latency.rs
+++ b/crates/ravel-bench/src/sql_latency.rs
@@ -530,7 +530,12 @@ fn cold_executor(
             ..CatalogConfig::default()
         },
     )?);
-    let mut log_fetcher = LogSegmentFetcher::new(Arc::clone(store));
+    // The same wiring `ravel-server` does (issue #700): without it the logs
+    // fetcher's permit pool stays at its compiled-in 16 and a scan planned at
+    // more partitions than that queues on it, so the bench would measure a
+    // ceiling the flag cannot move.
+    let mut log_fetcher = LogSegmentFetcher::new(Arc::clone(store))
+        .with_max_concurrent_gets(fetch_concurrency.max(1));
     if let Some(cache) = cache {
         log_fetcher = log_fetcher.with_cache(cache);
     }
@@ -1121,7 +1126,17 @@ mod tests {
         shard: u32,
         objects: usize,
     ) {
-        let records = build_records(objects.max(1), 0);
+        write_records_as_objects(store, tenant, shard, &build_records(objects.max(1), 0)).await;
+    }
+
+    /// One RLOG object per record in `records`, each with its own commit
+    /// record, on `shard`.
+    async fn write_records_as_objects(
+        store: &Arc<dyn ObjectStoreBackend>,
+        tenant: &TenantId,
+        shard: u32,
+        records: &[LogRecord],
+    ) {
         let writer_id = Uuid::from_u128(0x5100_0100 + u128::from(shard));
         for (obj_idx, rec) in records.iter().enumerate() {
             let writer_seq = (obj_idx + 1) as u64;
@@ -1382,6 +1397,102 @@ mod tests {
             gate.held_count() >= 1,
             "the expiry came from a GET the gate was holding, not from anything else"
         );
+    }
+
+    /// `fetch_concurrency` bounds the in-flight GETs, not just the partition
+    /// count: with every GET held behind a gate, an executor built at 24
+    /// parks 24 of them. Before issue #700 the logs fetcher kept its own
+    /// compiled-in cap of 16 whatever the knob said, so this waited forever
+    /// at 16.
+    #[tokio::test]
+    async fn fetch_concurrency_bounds_in_flight_gets() {
+        use ravel_object_store::fault::{FaultPlan, FaultStore, Occurrence, Op};
+
+        const FETCH_CONCURRENCY: usize = 24;
+        let faulty = Arc::new(FaultStore::new(MemoryStore::new(), FaultPlan::empty()));
+        let store: Arc<dyn ObjectStoreBackend> = Arc::clone(&faulty) as Arc<dyn ObjectStoreBackend>;
+        let tenant = TenantId::new("gets-tenant");
+        // The permit pool guards the block-range path only (objects above the
+        // ADR-0107 threshold); a small object is one whole-object GET that
+        // never takes a permit. So every object here carries a
+        // poorly-compressible body well above the threshold, making the pool
+        // the thing under test.
+        let mut records = build_records(40, 0);
+        let mut seed = 0x2545_f491_4f6c_dd1du64;
+        for rec in &mut records {
+            let mut body = String::with_capacity(2 << 20);
+            while body.len() < (2 << 20) {
+                seed = seed
+                    .wrapping_mul(6364136223846793005)
+                    .wrapping_add(1442695040888963407);
+                let sym = ((seed >> 58) as u8) % 62;
+                body.push(char::from(match sym {
+                    0..=25 => b'a' + sym,
+                    26..=51 => b'A' + (sym - 26),
+                    _ => b'0' + (sym - 52),
+                }));
+            }
+            rec.body = body;
+        }
+        write_records_as_objects(&store, &tenant, 0, &records).await;
+        // Hold data-object reads only: the catalog resolve's own GETs (`l/HEAD`,
+        // commit records) run before any partition exists, and holding those
+        // would stop the query before the pool is ever touched.
+        let gate = faulty.hold(Op::Get, Some("/l/l0/".to_string()), Occurrence::Always);
+
+        let window = TimeRange {
+            start_ns: 0,
+            end_ns: NOW_NS,
+        };
+        let run = tokio::spawn({
+            let store = Arc::clone(&store);
+            let th = tenant.hash();
+            async move {
+                measure_corpus(
+                    &store,
+                    th,
+                    &[entry("q", "SELECT body FROM logs")],
+                    &[],
+                    1,
+                    window,
+                    NOW_NS,
+                    DEFAULT_MAX_QUERY_BYTES,
+                    1,
+                    0,
+                    Duration::from_secs(30),
+                    true,
+                    FETCH_CONCURRENCY,
+                    None,
+                )
+                .await
+            }
+        });
+        if tokio::time::timeout(
+            Duration::from_secs(5),
+            gate.wait_until_held(FETCH_CONCURRENCY),
+        )
+        .await
+        .is_err()
+        {
+            panic!(
+                "fetch_concurrency GETs are in flight at once, not the compiled-in 16: held {} \
+                 of {} after 5 s; held keys: {:?}",
+                gate.held_count(),
+                FETCH_CONCURRENCY,
+                gate.held_details()
+                    .iter()
+                    .map(|(_, op, key)| format!("{op:?} {key}"))
+                    .take(4)
+                    .collect::<Vec<_>>()
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        assert_eq!(
+            gate.held_count(),
+            FETCH_CONCURRENCY,
+            "in-flight GETs are bounded by fetch_concurrency"
+        );
+        run.abort();
     }
 
     /// The deadline a run used is part of its provenance.

--- a/crates/ravel-query/src/log_fetcher.rs
+++ b/crates/ravel-query/src/log_fetcher.rs
@@ -494,6 +494,17 @@ impl LogSegmentFetcher {
         self
     }
 
+    /// Bounds the in-flight object-store GETs of the block-range path (ADR-0107
+    /// decision 1's permit pool, [`DEFAULT_LOG_MAX_CONCURRENT_GETS`] by
+    /// default). This is the seam `--fetch-concurrency` (ADR-0088) reaches the
+    /// logs signal through; a scan planned at more partitions than this pool
+    /// has permits queues on it (issue #700).
+    #[must_use]
+    pub fn with_max_concurrent_gets(mut self, n: usize) -> Self {
+        self.block_range = self.block_range.with_max_concurrent_gets(n);
+        self
+    }
+
     /// Replaces the block-range fetcher (ADR-0107) with a fully configured one,
     /// for callers and tests that need to set the coalescing gap, coverage
     /// crossover, or concurrency bound directly. The replacement keeps this

--- a/docs/adrs/0107-pruning-proportional-logs-fetch.md
+++ b/docs/adrs/0107-pruning-proportional-logs-fetch.md
@@ -294,3 +294,14 @@ flowchart LR
   introduced.
 - No frozen-format change, no version bump, no dual-reader window: RLOG's
   on-disk bytes are untouched. This ADR is fetch-path and accounting only.
+
+## Amendment 2026-08-26 (issue #700)
+
+"Sized independently for RLOG's call volume" in decision 1 means the RLOG
+permit pool is separate from RSEG's, not that it is fixed. Its size is
+`--fetch-concurrency` (ADR-0088), handed to the fetcher by
+`LogSegmentFetcher::with_max_concurrent_gets` at the two places that build
+one for queries (`ravel-server`'s query wiring and `sql_latency_bench`).
+Before this amendment nothing set it, so every logs scan ran at most 16
+GETs in flight regardless of the flag, and a 100M-row `count(*)` measured
+the same 160 s at `--fetch-concurrency` 16 and 32.

--- a/services/ravel-server/src/query.rs
+++ b/services/ravel-server/src/query.rs
@@ -289,8 +289,14 @@ pub fn build_sql_state(
     // `QueryBudgets::apply_to_engine`. This is the single wiring point for it, so
     // an operator who sets the flag to `u64::MAX` gets whole-object logs reads
     // (the pre-ADR-0107 shape) on every SQL logs scan this process serves.
+    // `--fetch-concurrency` is documented (ADR-0088) as the knob that bounds
+    // S3 GET concurrency; the logs fetcher keeps its own permit pool (ADR-0107
+    // decision 1, separate from RSEG's), so the bound has to be handed to it
+    // here or the pool stays at its compiled-in 16 whatever the flag says
+    // (issue #700).
     let mut logs_fetcher = LogSegmentFetcher::new(store.clone())
-        .with_block_range_threshold(config.engine.logs_block_range_threshold);
+        .with_block_range_threshold(config.engine.logs_block_range_threshold)
+        .with_max_concurrent_gets(config.engine.fetch_concurrency);
     // The spans fetcher (RSPAN) reads the same object store, with the default
     // RspanConfig (ADR-0045 decision 5). It attaches no fetcher cache: unlike
     // the RSEG/RLOG fetchers it has no `with_cache` seam, and none is wired


### PR DESCRIPTION
`--fetch-concurrency` (ADR-0088) is documented as one knob with three coupled effects, the third being S3 GET concurrency. For the logs signal that effect did not exist: the block-range fetcher (ADR-0107) bounds in-flight GETs with its own permit pool, `DEFAULT_LOG_MAX_CONCURRENT_GETS = 16`, and `with_max_concurrent_gets` lived only on the inner `BlockRangeFetcher` with no caller in `ravel-server` or the bench. A scan planned at 32 partitions queued on 16 permits. On the ClickBench tenant (#680) q01 measured ~145 s at `fetch_concurrency` 16 and 32 alike.

- `LogSegmentFetcher::with_max_concurrent_gets` forwards to the block-range pool.
- `ravel-server`'s query wiring and `sql_latency_bench`'s `cold_executor` call it with the configured `fetch_concurrency`.
- ADR-0107 amendment: "sized independently" means separate from RSEG's pool, not fixed.

Test (`fetch_concurrency_bounds_in_flight_gets`): 40 objects above the block-range threshold (2 MiB poorly-compressible bodies, so the permit pool is the path under test; a small object is one whole-object GET that never takes a permit), every data-object GET held behind a `FaultStore` gate scoped to `/l/l0/` (the catalog's own `l/HEAD` read must pass), executor at 24. Red with the bench wiring removed: `held 16 of 24 after 5 s`. Green with it: 24.

Gates run locally on a warm target: fmt; `clippy -p ravel-bench -p ravel-query --all-targets` with the bench features; `test -p ravel-bench` (features) and `test -p ravel-query`; `cargo check -p ravel-server --features sql`; `clippy --workspace --all-targets`. The `sql`/`flight-sql` server test lanes ride this PR's required checks.

Fixes #700. Refs #680, ADR-0088, ADR-0107.
