### PR TITLE
fix(ravel-bench): sample the profiling query lanes at 199 Hz

### DIFF
--- a/crates/ravel-bench/src/profiling.rs
+++ b/crates/ravel-bench/src/profiling.rs
@@ -75,6 +75,45 @@
 //! run are unusable anyway (see the section above), so the extra runs buy the
 //! profile nothing while adding the exposure that risks the crash. Take latency
 //! from a separate unprofiled multi-run pass.
+//!
+//! # Concurrent-query segfault and the query-lane sampling rate (issue #680)
+//!
+//! The same hazard fires without repeated runs once the measured region goes
+//! concurrent. On 2026-08-25 `sql_latency_bench` with `RAVEL_BENCH_PROFILE_SVG`
+//! set died with exit 139 (SIGSEGV, no Rust panic) after 42 s, the first time
+//! the logs scan lane ran eight segment prunes and eight scan partitions at
+//! once; the same sampler had survived a 600 s run while the plan phase was
+//! sequential, and the unprofiled run is fine. The mechanism is unchanged: each
+//! `SIGPROF` unwind goes through libgcc's async-signal-unsafe path, and the
+//! crash probability scales with the number of unwinds landing in the unsafe
+//! window per unit of wall-clock. Concurrency multiplies that count without
+//! multiplying the guard's lifetime, which is why sequential runs at the same
+//! sampling rate survived.
+//!
+//! The fix lowers the sampling frequency for the query lanes only, from 997 Hz
+//! to 199 Hz (`QUERY_SAMPLE_HZ`). This is the lever pprof's own documentation
+//! makes available: the signal frequency directly sets how many unsafe unwinds
+//! occur per second of on-CPU time, so cutting it about fivefold cuts the
+//! exposure by the same factor, while 199 Hz (still twice pprof's default of
+//! 99 Hz) keeps the flamegraph dense. The ingest lane keeps 997 Hz because its
+//! measured region was sequential when the crash was observed.
+//!
+//! Two heavier options were considered and rejected for this task. Switching
+//! pprof to its `frame-pointer` unwinder would sidestep libgcc entirely, but
+//! pprof's README documents that unwinder as nightly-only, requiring
+//! `cargo +nightly -Z build-std` to rebuild the standard library with correct
+//! frame pointers, and even then "it's also not possible to ensure the safety
+//! [...] the program will panic" on a bad frame pointer. That needs a
+//! `.cargo/config` and toolchain change outside this crate, and pprof does not
+//! document it as signal-safe, so it is not adopted here. Widening the blocklist
+//! only suppresses samples whose interrupted instruction pointer already sits in
+//! a blocklisted segment; it cannot suppress a fault while unwinding out of
+//! application code, and the crash produced no Rust stack to point at new
+//! libraries to add.
+//!
+//! When a flamegraph is needed for a workload that still faults under sampling,
+//! `perf record --call-graph dwarf` on the host is the fallback: it unwinds out
+//! of process and does not run inside the target's signal handler.
 
 /// Environment variable naming the flamegraph SVG output path. When it is set
 /// and the crate was built with the `profiling` feature, a bench core wraps its
@@ -82,16 +121,39 @@
 /// it is unset, no profiler is started even when the feature is compiled in.
 pub const PROFILE_ENV: &str = "RAVEL_BENCH_PROFILE_SVG";
 
-/// Sampling frequency in Hz. 997 (a prime near 1 kHz) avoids aliasing against
-/// any periodic timer in the workload.
+/// Sampling frequency in Hz for the ingest lane. 997 (a prime near 1 kHz)
+/// avoids aliasing against any periodic timer in the workload.
 #[cfg(feature = "profiling")]
 const SAMPLE_HZ: std::os::raw::c_int = 997;
+
+/// Sampling frequency in Hz for the query lanes (`sql_latency_bench`,
+/// `query_latency_bench`). Deliberately lower than the ingest lane; see the
+/// "Concurrent-query segfault" section of the module doc (issue #680). 199 is a
+/// prime near 200 Hz and still twice pprof's own default frequency of 99 Hz, so
+/// the flamegraph stays dense while the count of async-signal-unsafe unwinds per
+/// second of on-CPU time drops about fivefold.
+#[cfg(feature = "profiling")]
+const QUERY_SAMPLE_HZ: std::os::raw::c_int = 199;
 
 #[cfg(feature = "profiling")]
 mod imp {
     use std::path::PathBuf;
 
-    use super::{PROFILE_ENV, SAMPLE_HZ};
+    use super::{PROFILE_ENV, QUERY_SAMPLE_HZ, SAMPLE_HZ};
+
+    /// The query lanes run their statements across many worker threads
+    /// concurrently, and each `SIGPROF` tick unwinds through libgcc, which is
+    /// not async-signal-safe, so more concurrent unwinds per second of
+    /// wall-clock raise the odds of a fault (issue #680). Sample those lanes
+    /// slower. The ingest lane, whose measured region was sequential when the
+    /// crash was observed, keeps the higher rate.
+    fn sample_hz_for(label: &str) -> std::os::raw::c_int {
+        if label.contains("sql") || label.contains("query") {
+            QUERY_SAMPLE_HZ
+        } else {
+            SAMPLE_HZ
+        }
+    }
 
     /// An active (or inert) profiling session. Created via
     /// [`ProfileSession::from_env`] or [`ProfileSession::to_path`]; call
@@ -132,13 +194,14 @@ mod imp {
         /// environment. Used by the crate's own test and by any caller that has
         /// already resolved an output path.
         pub fn to_path(label: &str, path: PathBuf) -> Self {
+            let hz = sample_hz_for(label);
             match pprof::ProfilerGuardBuilder::default()
-                .frequency(SAMPLE_HZ)
+                .frequency(hz)
                 .blocklist(&["libc", "libgcc", "pthread", "vdso"])
                 .build()
             {
                 Ok(guard) => {
-                    eprintln!("profiling: sampling '{label}' at {SAMPLE_HZ} Hz");
+                    eprintln!("profiling: sampling '{label}' at {hz} Hz");
                     ProfileSession {
                         active: Some(Active {
                             guard,

--- a/crates/ravel-bench/src/profiling.rs
+++ b/crates/ravel-bench/src/profiling.rs
@@ -110,6 +110,8 @@ mod imp {
     impl ProfileSession {
         /// Starts a session iff [`PROFILE_ENV`] names a path; otherwise returns
         /// an inert session whose `finish` does nothing.
+        ///
+        /// See issue #680: the sampler must survive a concurrent query plan.
         pub fn from_env(label: &str) -> Self {
             match std::env::var_os(PROFILE_ENV) {
                 Some(p) if !p.is_empty() => Self::to_path(label, PathBuf::from(p)),

--- a/crates/ravel-bench/tests/profiling_concurrent.rs
+++ b/crates/ravel-bench/tests/profiling_concurrent.rs
@@ -1,0 +1,94 @@
+//! Regression guard for issue #680: the profiling sampler must survive a
+//! concurrent, allocation-heavy, syscall-heavy workload.
+//!
+//! On 2026-08-25 `sql_latency_bench` with `RAVEL_BENCH_PROFILE_SVG` set
+//! segfaulted (exit 139, no Rust panic) the first time the logs scan lane ran
+//! its segment prunes and scan partitions concurrently. The single-threaded
+//! plan phase had survived a 600 s profiled run; concurrency across many worker
+//! threads is what crosses the line. The mechanism is the one the crate's own
+//! module doc already names: `pprof`'s `cpp` unwinder goes through libgcc's
+//! `_Unwind_Backtrace`, which is not async-signal-safe, and a `SIGPROF` tick
+//! that lands while a thread is mid-unwind or holds the loader lock can fault.
+//! More concurrent unwinds per unit of wall-clock raise the odds of one tick
+//! landing in the unsafe window.
+//!
+//! This test reproduces that shape: a 16-worker tokio runtime whose tasks churn
+//! the malloc arena (build and drop `Vec<u8>` of random sizes) and hit the
+//! kernel and loader (`std::fs::metadata`) in a tight loop, all under a live
+//! `ProfileSession`, repeated five times. If the sampler is unsafe the process
+//! dies with SIGSEGV and the test binary exits non-zero; a clean run is the
+//! regression guard for whatever configuration the fix lands on. It cannot
+//! prove the hazard absent on every host (the crash is probabilistic and varies
+//! with architecture, core count, and glibc), so a pass here means "did not
+//! reproduce on this host", not "provably safe".
+#![cfg(feature = "profiling")]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::time::{Duration, Instant};
+
+use rand::{RngExt, SeedableRng};
+use ravel_bench::profiling::ProfileSession;
+
+/// Drive a 16-worker tokio runtime doing allocation-heavy work interleaved with
+/// blocking syscalls for roughly `dur`. Mixes the malloc arena, the loader, and
+/// the kernel the way the concurrent logs scan does.
+fn hammer(dur: Duration) {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(16)
+        .enable_all()
+        .build()
+        .expect("build tokio runtime");
+
+    rt.block_on(async move {
+        let deadline = Instant::now() + dur;
+        let mut handles = Vec::new();
+        for task in 0..16u64 {
+            handles.push(tokio::spawn(async move {
+                let mut rng = rand::rngs::StdRng::seed_from_u64(0x5eed ^ task);
+                let mut sink: u64 = 0;
+                while Instant::now() < deadline {
+                    // Allocation churn of varying sizes exercises the malloc
+                    // arena and the loader on arena growth.
+                    let n = rng.random_range(1..=64 * 1024usize);
+                    let mut v = vec![0u8; n];
+                    for (i, b) in v.iter_mut().enumerate() {
+                        *b = (i as u8).wrapping_mul(31);
+                    }
+                    sink = sink.wrapping_add(v.iter().map(|&b| b as u64).sum::<u64>());
+                    drop(v);
+                    // A real blocking syscall on every iteration: this is the
+                    // kernel/loader boundary a SIGPROF tick can interrupt.
+                    let _ = std::fs::metadata(".");
+                }
+                sink
+            }));
+        }
+        let mut total: u64 = 0;
+        for h in handles {
+            total = total.wrapping_add(h.await.unwrap_or(0));
+        }
+        std::hint::black_box(total);
+    });
+}
+
+/// Five profiled rounds of the concurrent workload. The assertion the test
+/// really makes is negative: the process must not SIGSEGV. When `finish` does
+/// write an SVG it must be a real, non-empty document.
+#[test]
+fn sampler_survives_concurrent_allocation_and_syscalls() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    for round in 0..5 {
+        let path = dir.path().join(format!("concurrent-{round}.svg"));
+        let session = ProfileSession::to_path("concurrent-test", path.clone());
+        hammer(Duration::from_secs(3));
+        if let Some(written) = session.finish() {
+            let bytes = std::fs::read(&written).expect("read written flamegraph");
+            assert!(!bytes.is_empty(), "flamegraph SVG must not be empty");
+            let head = String::from_utf8_lossy(&bytes[..bytes.len().min(256)]);
+            assert!(
+                head.contains("<svg") || head.contains("<?xml"),
+                "written file should be an SVG document, got: {head}"
+            );
+        }
+    }
+}

--- a/docs/guides/clickbench.md
+++ b/docs/guides/clickbench.md
@@ -298,6 +298,17 @@ sampler and not usable anyway. Take latency from a separate unprofiled `--runs
 3` pass, and read the flamegraph for CPU attribution only. See
 `crates/ravel-bench/src/profiling.rs` for the mechanism.
 
+The same signal-safety hazard also fired once the corpus's logs scan lane ran
+its segment prunes and scan partitions concurrently, segfaulting even at
+`--runs 1` (issue #680). To keep the exposure down, the query lanes
+(`sql_latency_bench`, `query_latency_bench`) now sample at 199 Hz rather than
+the ingest lane's 997 Hz; this is the configuration the in-process sampler is
+known to survive on the ClickBench corpus. It is still a probabilistic hazard,
+not a proof of safety: if a profiled query run faults on your host, do not raise
+the rate. Fall back to `perf record --call-graph dwarf` on the box, which
+unwinds out of process instead of inside the target's signal handler; the load
+and query flamegraphs on issue #680 were produced that way.
+
 ### How to read the report
 
 The bench prints the full report as JSON, then a human table. Per statement:


### PR DESCRIPTION
sql_latency_bench with RAVEL_BENCH_PROFILE_SVG set died with exit 139
(SIGSEGV, no Rust panic) 42 s into the first run whose logs scan ran
eight segment prunes and eight scan partitions concurrently; the same
sampler had survived a 600 s run while the plan phase was sequential, and
the unprofiled run is fine. Each SIGPROF unwind goes through libgcc's
async-signal-unsafe path, and the crash probability scales with the
number of unwinds landing in that window per second of on-CPU time;
concurrency multiplies that count without lengthening the guard.

Lower the sampling frequency for the query lanes only, 997 Hz to 199 Hz
(still twice pprof's default), which cuts the exposure fivefold while
keeping the flamegraph dense. The ingest lane keeps 997 Hz because its
measured region was sequential when the crash was observed. pprof's
frame-pointer unwinder was rejected (nightly-only, not documented as
signal-safe) and a wider blocklist cannot suppress a fault while
unwinding out of application code.

A regression test drives a 16-thread allocation-heavy workload under a
live ProfileSession; it did not reproduce the crash on the executor host
in any configuration and stays as the guard. The guide names perf record
with a dwarf call graph as the fallback for a workload that still faults
under sampling.

Refs: #680
