### PR TITLE
fix(ravel-sql): assign whole segments per partition on un-cached logs scan

### DIFF
--- a/crates/ravel-bench/src/logs_scan_scaling.rs
+++ b/crates/ravel-bench/src/logs_scan_scaling.rs
@@ -24,8 +24,10 @@
 //! [`crate::sql_latency`] and [`crate::pushdown_crossover`] use). The fetch unit
 //! is the whole object (ADR-0087 decision 3: no ranged block reader), so every
 //! partition owning blocks in a segment issues its own whole-object read at that
-//! segment's key. Un-cached, the partition count is capped at the segment count,
-//! so raising `target_partitions` past that changes nothing. Cache-wired, the
+//! segment's key. Un-cached, the partition count is capped at the segment count
+//! and each segment is assigned whole to one partition (ADR-0102's un-cached
+//! amendment), so raising `target_partitions` changes nothing at any value: the
+//! count is one plan read plus one scan read per segment. Cache-wired, the
 //! partition count keeps climbing and those repeated reads are what ADR-0046's
 //! single-flight cache absorbs.
 //!
@@ -170,9 +172,9 @@ pub struct ComboResult {
     pub blocks_total: u64,
     pub blocks_scanned: u64,
     /// Object-store GET requests the cold run issued (`QueryAccounting`). The
-    /// number this deliverable exists to report. Un-cached, the partition count
-    /// is capped at the segment count, so this stops moving once
-    /// `target_partitions` reaches that cap. Cache-wired, the partition count
+    /// number this deliverable exists to report. Un-cached, each segment is
+    /// assigned whole to one partition, so this is one plan read plus one scan
+    /// read per segment at every `target_partitions`. Cache-wired, the partition count
     /// keeps climbing and the repeated whole-object reads at one key are what
     /// single-flight absorbs. A figure for THIS fixture only, not a general
     /// result (see the module doc).

--- a/crates/ravel-bench/tests/logs_scan_scaling_smoke.rs
+++ b/crates/ravel-bench/tests/logs_scan_scaling_smoke.rs
@@ -170,18 +170,20 @@ async fn logs_scan_scaling_smoke_proves_cache_gated_fanout_and_request_count() {
         );
     }
 
-    // The multiplier the segment-count cap bounds but does not remove: below the
-    // cap, raising `target_partitions` still adds whole-object reads, because
-    // every partition owning blocks in a segment opens that segment itself. Only
-    // a single-partition plan matches the pre-item-1 whole-segment request count.
-    let &max_tp = expected_partitions.iter().max().unwrap();
-    if min_tp == 1 && max_tp > 1 {
-        assert!(
-            get_by_combo[&(max_tp, false)] > get_by_combo[&(1, false)],
-            "un-cached GET count still climbs from a single partition to the cap: \
-             tp={max_tp} issued {}, tp=1 issued {}",
-            get_by_combo[&(max_tp, false)],
-            get_by_combo[&(1, false)]
+    // Un-cached, the unit of assignment is the whole segment (ADR-0102, the
+    // un-cached amendment): each segment is opened by exactly one partition, so
+    // raising `target_partitions` below the cap adds no whole-object reads
+    // either. The count is one plan read plus one scan read per segment at every
+    // partition value, which the single-partition run measures directly.
+    let uncached_baseline = get_by_combo[&(min_tp, false)];
+    for &tp in &expected_partitions {
+        assert_eq!(
+            get_by_combo[&(tp, false)],
+            uncached_baseline,
+            "un-cached GET count is flat across the whole sweep once segments \
+             are assigned whole: tp={tp} issued {}, tp={min_tp} issued \
+             {uncached_baseline}",
+            get_by_combo[&(tp, false)]
         );
     }
 }

--- a/crates/ravel-sql/src/logs_scan.rs
+++ b/crates/ravel-sql/src/logs_scan.rs
@@ -1,20 +1,28 @@
 //! `LogsScanExec`: the leaf of the `logs` pipeline, the log-signal sibling of
 //! [`crate::scan::RsegScanExec`] (ADR-0033).
 //!
-//! Partitions the snapshot's segments' *blocks* round-robin across
-//! `target_partitions` partitions (intra-segment scan partitioning, ADR-0102).
-//! Every `(segment, surviving-block)` unit across all segments is flattened
-//! into one ordered list (segment order, then block order) and unit `i` is
-//! assigned to partition `i % n`, where `n = target_partitions.max(1).
-//! min(total_block_count.max(1))`. This lets a query touching fewer segments
-//! than `target_partitions` still fan out to `target_partitions` partitions:
-//! the old segment-granular rule (`min(target_partitions, segment_count)`)
-//! pinned such a query to at most `segment_count` partitions.
+//! Partitions the snapshot's work across `target_partitions` partitions in one
+//! of two modes, chosen once at construction from whether the fetcher carries
+//! ADR-0046's read cache ([`LogSegmentFetcher::has_cache`], ADR-0102 amended by
+//! #693):
 //!
-//! That fan-out is gated on the fetcher carrying ADR-0046's read cache
-//! ([`LogSegmentFetcher::has_cache`]); an un-cached fetcher keeps the old
-//! `min(target_partitions, segment_count)` bound. See
-//! [`LogsScanExec::new`] and the request-count paragraph below for why.
+//! - **Cache-wired: intra-segment block striping.** Every `(segment,
+//!   surviving-block)` unit across all segments is flattened into one ordered
+//!   list (segment order, then block order) and unit `i` is assigned to
+//!   partition `i % n`, where `n = target_partitions.max(1).
+//!   min(total_block_count.max(1))`. This lets a query touching fewer segments
+//!   than `target_partitions` still fan out to `target_partitions` partitions:
+//!   the old segment-granular rule (`min(target_partitions, segment_count)`)
+//!   pinned such a query to at most `segment_count` partitions.
+//! - **Un-cached: segment-granular.** Each segment is assigned whole to one
+//!   partition (relevant segment `j` in snapshot order to partition `j % n`),
+//!   so every segment is opened by exactly one partition. The partition count is
+//!   capped at the segment count.
+//!
+//! The block-striping fan-out is gated on the cache because without single-
+//! flight to coalesce re-opens it would multiply object-store reads by the
+//! partition count. See [`LogsScanExec::new`], [`owned_work`], and the
+//! request-count paragraph below for why.
 //!
 //! The per-segment surviving-block counts the assignment needs are determined
 //! once, before draining, by [`LogSegmentFetcher::plan_segment`] (a prune with
@@ -37,16 +45,18 @@
 //! skip-index pruning kept. What those reads cost depends on the cache, and so
 //! does how many partitions are planned:
 //!
-//! - **Un-cached fetcher.** The partition count is capped at the segment count,
-//!   so the request count stops responding to `target_partitions` once that cap
-//!   binds. It is the pre-ADR-0102 whole-segment count only when the plan
-//!   collapses to a single partition; with `n > 1` partitions, every segment
-//!   holding at least `n` surviving blocks is opened by all `n` of them, so the
-//!   scan costs up to `n` read sequences per segment, and planning's prune
-//!   (`compute_plan_counts`) adds one more per relevant segment. The cap
-//!   bounds that multiplier by the segment count instead of letting
-//!   `target_partitions` set it; it does not remove it. `ravel-bench`'s
-//!   `logs_scan_scaling` report measures both.
+//! - **Un-cached fetcher.** The assignment is segment-granular (#693): each
+//!   segment is assigned whole to one partition ([`owned_work`]), so a segment
+//!   is opened by exactly one partition and issues exactly one scan read
+//!   sequence, whatever `target_partitions` is. The request count is one plan
+//!   read per relevant segment (`compute_plan_counts`) plus one scan read per
+//!   relevant segment, and the partition count is capped at the segment count
+//!   (a query touching fewer segments than `target_partitions` cannot fan out
+//!   past them, since a partition with no segment does no work). This is the
+//!   pre-ADR-0102 whole-segment request count restored: without the cache there
+//!   is no single-flight to coalesce re-opens, so striping a segment across
+//!   partitions would multiply object-store reads by the partition count for no
+//!   benefit. `ravel-bench`'s `logs_scan_scaling` report measures both.
 //! - **Cache-wired fetcher.** The partition count is `target_partitions`, so
 //!   several partitions can stripe one segment's blocks. Every GET of either
 //!   shape is keyed by the extent it fetched and routed through the cache's
@@ -449,6 +459,13 @@ pub struct LogsScanExec {
     /// applies. The remaining per-block clause (no `attrs_raw` overflow page) is
     /// checked as each block is decoded; see [`columnar_static_eligible`].
     columnar_eligible: bool,
+    /// The assignment mode, decided once at construction from
+    /// [`LogSegmentFetcher::has_cache`] (ADR-0102, amended by #693). `true` (a
+    /// cache is wired) stripes a segment's surviving blocks across partitions;
+    /// `false` assigns each segment whole to one partition, so an un-cached scan
+    /// opens each segment exactly once. Threaded into the stream and
+    /// [`owned_work`]; the same predicate gates `declared_partitions` above.
+    stripe_blocks: bool,
     properties: Arc<PlanProperties>,
     /// This query's accounting handle (ADR-0044), threaded into every
     /// per-partition fetch so log fetches are recorded like every other
@@ -600,7 +617,12 @@ impl LogsScanExec {
         // object-store GETs for no reason. So an un-cached fetcher falls back to
         // the pre-ADR-0102 bound, `min(target_partitions, segment_count)`, and
         // never plans a partition whose extra GETs nothing absorbs.
-        let declared_partitions = if fetcher.has_cache() {
+        // `stripe_blocks` decides both the partition count and the per-unit
+        // assignment, and is computed once from the same `has_cache` predicate:
+        // with the cache a segment's blocks stripe across partitions, without it
+        // each segment is assigned whole to one partition (see `owned_work`).
+        let stripe_blocks = fetcher.has_cache();
+        let declared_partitions = if stripe_blocks {
             target_partitions.max(1)
         } else {
             target_partitions.max(1).min(segments.len().max(1))
@@ -640,6 +662,7 @@ impl LogsScanExec {
             declared,
             schema,
             columnar_eligible,
+            stripe_blocks,
             properties,
             accounting,
             metrics: ExecutionPlanMetricsSet::new(),
@@ -769,6 +792,7 @@ impl ExecutionPlan for LogsScanExec {
             blocks: BlockMetrics::new(&self.metrics, partition),
             partition,
             target_partitions: self.target_partitions,
+            stripe_blocks: self.stripe_blocks,
             segments: Arc::clone(&self.segments),
             work: VecDeque::new(),
             reservation,
@@ -879,9 +903,21 @@ struct OwnedSeg {
     indices: Vec<usize>,
 }
 
-/// This partition's share of the flattened block assignment (ADR-0102): unit
-/// `i` in the segment-then-block order over all surviving blocks goes to
-/// partition `i % n`, with `n = target_partitions.max(1).min(total.max(1))`.
+/// This partition's share of the block assignment, in one of two modes
+/// (ADR-0102, amended by #693), both with `n = target_partitions.max(1).
+/// min(total.max(1))`.
+///
+/// - **`stripe_blocks` true** (a read cache is wired): the flattened block
+///   assignment. Unit `i` in the segment-then-block order over all surviving
+///   blocks goes to partition `i % n`, so a segment's blocks stripe across
+///   partitions and single-flight coalesces the re-opens.
+/// - **`stripe_blocks` false** (un-cached): the segment-granular assignment.
+///   Counting only segments with a surviving block, in snapshot order, segment
+///   `j` goes to partition `j % n` and that partition drains all of the
+///   segment's surviving block indices (`0..survivors`). Each segment is opened
+///   by exactly one partition, so with nothing to coalesce re-opens the scan
+///   still costs one read per segment rather than one per partition per segment.
+///
 /// Returns, per owned segment, the surviving-block indices this partition
 /// drains, in ascending order.
 fn owned_work(
@@ -889,23 +925,41 @@ fn owned_work(
     segments: &[SegmentRef],
     partition: usize,
     n: usize,
+    stripe_blocks: bool,
 ) -> VecDeque<OwnedSeg> {
     let mut work = VecDeque::new();
-    let mut global = 0usize;
-    for (seg_idx, plan) in counts.segs.iter().enumerate() {
-        let Some(plan) = plan else { continue };
-        let mut indices = Vec::new();
-        for local in 0..plan.survivors {
-            if (global + local) % n == partition {
-                indices.push(local);
+    if stripe_blocks {
+        let mut global = 0usize;
+        for (seg_idx, plan) in counts.segs.iter().enumerate() {
+            let Some(plan) = plan else { continue };
+            let mut indices = Vec::new();
+            for local in 0..plan.survivors {
+                if (global + local) % n == partition {
+                    indices.push(local);
+                }
+            }
+            global += plan.survivors;
+            if !indices.is_empty() {
+                work.push_back(OwnedSeg {
+                    seg: segments[seg_idx].clone(),
+                    indices,
+                });
             }
         }
-        global += plan.survivors;
-        if !indices.is_empty() {
-            work.push_back(OwnedSeg {
-                seg: segments[seg_idx].clone(),
-                indices,
-            });
+    } else {
+        let mut seg_ordinal = 0usize;
+        for (seg_idx, plan) in counts.segs.iter().enumerate() {
+            let Some(plan) = plan else { continue };
+            if plan.survivors == 0 {
+                continue;
+            }
+            if seg_ordinal % n == partition {
+                work.push_back(OwnedSeg {
+                    seg: segments[seg_idx].clone(),
+                    indices: (0..plan.survivors).collect(),
+                });
+            }
+            seg_ordinal += 1;
         }
     }
     work
@@ -1037,6 +1091,9 @@ struct LogScanStream {
     /// `(segment, block-index-list)` units this partition owns (ADR-0102).
     partition: usize,
     target_partitions: usize,
+    /// The assignment mode (ADR-0102, amended by #693): block striping when a
+    /// cache is wired, segment-granular otherwise. Passed to [`owned_work`].
+    stripe_blocks: bool,
     /// Every segment in the snapshot, snapshot order, shared with the exec. The
     /// owned-work computation indexes this by segment position.
     segments: Arc<Vec<SegmentRef>>,
@@ -1235,7 +1292,13 @@ impl Stream for LogScanStream {
                                 this.blocks.record_segment_totals(&plan.stats);
                             }
                         }
-                        this.work = owned_work(&counts, &this.segments, this.partition, n);
+                        this.work = owned_work(
+                            &counts,
+                            &this.segments,
+                            this.partition,
+                            n,
+                            this.stripe_blocks,
+                        );
                         this.state = LogScanState::NextSegment;
                     }
                     Poll::Ready(Err(e)) => return this.fail(e),

--- a/crates/ravel-sql/tests/logs_uncached_assignment.rs
+++ b/crates/ravel-sql/tests/logs_uncached_assignment.rs
@@ -1,0 +1,3 @@
+//! Tests for issue #693: un-cached logs scan assigns whole segments to
+//! partitions instead of striping every segment's blocks across all
+//! partitions.

--- a/crates/ravel-sql/tests/logs_uncached_assignment.rs
+++ b/crates/ravel-sql/tests/logs_uncached_assignment.rs
@@ -1,3 +1,374 @@
-//! Tests for issue #693: un-cached logs scan assigns whole segments to
+//! Tests for issue #693: the un-cached logs scan assigns whole segments to
 //! partitions instead of striping every segment's blocks across all
-//! partitions.
+//! partitions, so each segment is opened by exactly one partition.
+//!
+//! ADR-0102 stripes a snapshot's surviving blocks round-robin across
+//! `target_partitions`, which puts every segment's blocks into every partition
+//! and makes each partition open the segment itself. With ADR-0046's read cache
+//! wired, those re-opens single-flight onto one object-store request per extent.
+//! Without a cache nothing coalesces them, so the scan pays one whole-object GET
+//! per partition per segment. The fix (deliverable of #693) makes the un-cached
+//! path segment-granular: relevant segment `j` (snapshot order) goes to
+//! partition `j % n` and drains all of that segment's surviving blocks, so the
+//! scan issues exactly one plan read plus one scan read per segment. The cached
+//! path keeps the intra-segment block striping unchanged.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+mod util;
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
+
+use datafusion::arrow::array::{StringArray, TimestampNanosecondArray};
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::execution::TaskContext;
+use datafusion::physical_plan::{ExecutionPlan, collect};
+use ravel_cache::{Cache, CacheLimits};
+use ravel_catalog::{SegmentLevel, SegmentRef, Snapshot};
+use ravel_logseg::writer::ObjectIdentity;
+use ravel_logseg::{AttrValue, LogRecord, RlogConfig, RlogWriter, stream_attrs_bytes};
+use ravel_object_store::memory::MemoryStore;
+use ravel_object_store::{ObjectStoreBackend, PutOptions};
+use ravel_query::{CacheFetchError, LogSegmentFetcher};
+use ravel_sql::LogsTableProvider;
+use ravel_types::TenantHash;
+use ravel_types::accounting::QueryAccounting;
+use uuid::Uuid;
+
+use util::CountingStore;
+
+/// Number of segments (objects) in the fixture.
+const SEGMENTS: usize = 6;
+/// Records per object. With `block_target_records: 3` this is 4 blocks, each
+/// surviving the full-window scan, so every segment has exactly 4 surviving
+/// blocks (>= 4, the count the task pins).
+const RECORDS_PER_SEG: usize = 12;
+/// Surviving blocks per segment (`RECORDS_PER_SEG / block_target_records`).
+const BLOCKS_PER_SEG: usize = 4;
+/// Partitions requested for every plan in these tests.
+const PARTS: usize = 4;
+
+fn identity() -> ObjectIdentity {
+    ObjectIdentity {
+        tenant_hash: [7u8; 16],
+        shard: 0,
+        writer_id: [2u8; 16],
+        writer_epoch: 1,
+        writer_seq: 1,
+    }
+}
+
+/// Cut a block every 3 records so each 12-record object holds 4 blocks.
+fn small_blocks() -> RlogConfig {
+    RlogConfig {
+        block_target_records: 3,
+        ..RlogConfig::default()
+    }
+}
+
+/// A record on the single-`service.name` stream `svc`, with a unique `(ts, body)`.
+fn record(ts: i64, body: &str) -> LogRecord {
+    let resource = vec![(
+        "service.name".to_string(),
+        AttrValue::Str("svc".to_string()),
+    )];
+    LogRecord {
+        stream_id: ravel_types::logstream::log_stream_id(&resource, "scope", "1.0", &[]),
+        stream_attrs: stream_attrs_bytes(&resource, "scope", "1.0", &[]),
+        ts_ns: ts,
+        observed_ts_ns: ts,
+        severity_num: 9,
+        severity_text: "INFO".into(),
+        body: body.into(),
+        trace_id: None,
+        span_id: None,
+        flags: 0,
+        attrs: Vec::new(),
+    }
+}
+
+/// Write one RLOG object from `records`, put it at `key`, and return a matching
+/// L0 [`SegmentRef`] carrying the object's true ts span. `content_hash` must be
+/// unique per object: the read cache keys on it
+/// (`CacheKey::new(tenant, content_hash, ..)`), so a shared value would collide
+/// distinct segments in the cached test.
+async fn write_object(
+    store: &dyn ObjectStoreBackend,
+    key: &str,
+    content_hash: [u8; 32],
+    records: &[LogRecord],
+) -> SegmentRef {
+    let mut w = RlogWriter::new(small_blocks(), identity());
+    for r in records {
+        w.push(r.clone()).expect("push");
+    }
+    let bytes = w.finish().expect("finish");
+    let size = bytes.len() as u64;
+    store
+        .put(key, bytes::Bytes::from(bytes), PutOptions::default())
+        .await
+        .expect("put object");
+
+    let min = records.iter().map(|r| r.ts_ns).min().expect("nonempty");
+    let max = records.iter().map(|r| r.ts_ns).max().expect("nonempty");
+    SegmentRef {
+        data_object_key: key.to_string(),
+        object_size: size,
+        min_event_ts_ns: min,
+        max_event_ts_ns: max,
+        ingest_hour_bucket: 0,
+        sample_count: records.len() as u64,
+        series_count: 0,
+        shard: 0,
+        content_hash,
+        writer_id: Uuid::from_u128(1),
+        writer_epoch: 1,
+        writer_seq: 1,
+        created_unix_ns: 0,
+        level: SegmentLevel::L0,
+    }
+}
+
+/// The records for segment `s`: `RECORDS_PER_SEG` rows with globally unique
+/// `(ts, body)` so the row-set comparison is a genuine set equality.
+fn seg_records(s: usize) -> Vec<LogRecord> {
+    (0..RECORDS_PER_SEG)
+        .map(|i| {
+            let ts = (s * 1000 + i) as i64;
+            record(ts, &format!("s{s}-r{i}"))
+        })
+        .collect()
+}
+
+/// Build the six-object fixture on `store` and return the assembled snapshot
+/// plus the full `(ts, body)` row set that was written.
+async fn build_fixture(store: &dyn ObjectStoreBackend) -> (Snapshot, BTreeSet<(i64, String)>) {
+    let mut segments = Vec::with_capacity(SEGMENTS);
+    let mut want = BTreeSet::new();
+    for s in 0..SEGMENTS {
+        let recs = seg_records(s);
+        for r in &recs {
+            want.insert((r.ts_ns, r.body.clone()));
+        }
+        let mut content_hash = [0u8; 32];
+        content_hash[0] = (s + 1) as u8;
+        let seg = write_object(store, &format!("logs/seg{s}.rlog"), content_hash, &recs).await;
+        segments.push(seg);
+    }
+    let snapshot = Snapshot {
+        segments,
+        segments_pruned: 0,
+        pending_erasure: Vec::new(),
+    };
+    (snapshot, want)
+}
+
+fn provider(snapshot: Snapshot, fetcher: LogSegmentFetcher) -> LogsTableProvider {
+    LogsTableProvider::new(
+        snapshot,
+        TenantHash([7u8; 16]),
+        fetcher,
+        QueryAccounting::new(),
+    )
+}
+
+async fn collect_plan(plan: Arc<dyn ExecutionPlan>) -> Vec<RecordBatch> {
+    collect(plan, Arc::new(TaskContext::default()))
+        .await
+        .expect("collect")
+}
+
+/// The `(ts, body)` pairs in `batches` (public logs schema: ts col 0, body col 4).
+fn batches_to_rows(batches: &[RecordBatch]) -> BTreeSet<(i64, String)> {
+    let mut out = BTreeSet::new();
+    for batch in batches {
+        let ts = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<TimestampNanosecondArray>()
+            .expect("ts col");
+        let body = batch
+            .column(4)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("body col");
+        for i in 0..batch.num_rows() {
+            out.insert((ts.value(i), body.value(i).to_string()));
+        }
+    }
+    out
+}
+
+/// Walk to the `LogsScanExec` leaf.
+fn find_by_name(plan: &Arc<dyn ExecutionPlan>, name: &str) -> Option<Arc<dyn ExecutionPlan>> {
+    if plan.name() == name {
+        return Some(Arc::clone(plan));
+    }
+    plan.children().iter().find_map(|c| find_by_name(c, name))
+}
+
+/// Per-partition `blocks_scanned` from the executed `LogsScanExec`, partition
+/// index ascending. This is the observable that separates the two assignment
+/// modes: striping splits a 4-block segment across partitions, so a partition's
+/// count need not be a whole-segment multiple; segment-granular gives each
+/// partition only whole segments, so every count is a multiple of
+/// [`BLOCKS_PER_SEG`].
+fn per_partition_blocks_scanned(plan: &Arc<dyn ExecutionPlan>) -> Vec<usize> {
+    let set = find_by_name(plan, "LogsScanExec")
+        .expect("a LogsScanExec leaf")
+        .metrics()
+        .expect("the scan publishes metrics");
+    let mut by_partition: BTreeMap<usize, usize> = BTreeMap::new();
+    for m in set.iter() {
+        if m.value().name() == "blocks_scanned" {
+            let p = m
+                .partition()
+                .expect("blocks_scanned is a per-partition metric");
+            *by_partition.entry(p).or_default() += m.value().as_usize();
+        }
+    }
+    by_partition.into_values().collect()
+}
+
+/// Build ADR-0046's RAM read cache the way `ravel-bench`'s `build_read_cache`
+/// (crates/ravel-bench/src/sql_latency.rs) does: the whole budget as the
+/// per-entry cap so no small fixture object is rejected, one entry per 4 KiB of
+/// budget floored at 64.
+fn build_read_cache(cache_bytes: u64) -> Arc<Cache<CacheFetchError>> {
+    let max_entries = (cache_bytes / 4096).max(64) as usize;
+    Arc::new(Cache::new(CacheLimits::new(
+        cache_bytes,
+        max_entries,
+        cache_bytes,
+    )))
+}
+
+/// The pinned request-count property (#693, #680). Without a read cache the scan
+/// must open each of the six segments exactly once: one plan read per segment
+/// plus one scan read per segment, `2 * 6 = 12` whole-object GETs total.
+///
+/// Against the pre-fix ADR-0102 code this fails: block striping puts every
+/// segment's four blocks into all four partitions, each partition opens the
+/// segment itself, and nothing coalesces the re-opens, so the scan costs
+/// `6 + 6 * 4 = 30` GETs (one plan read per segment plus one scan read per
+/// partition per segment).
+#[tokio::test]
+async fn uncached_scan_opens_each_segment_once() {
+    let counting = CountingStore::new(Arc::new(MemoryStore::new()));
+    let store: Arc<dyn ObjectStoreBackend> = Arc::clone(&counting) as Arc<dyn ObjectStoreBackend>;
+    let (snapshot, _want) = build_fixture(store.as_ref()).await;
+
+    let fetcher = LogSegmentFetcher::new(Arc::clone(&store));
+    assert!(
+        !fetcher.has_cache(),
+        "this fixture must exercise the un-cached path"
+    );
+    let provider = provider(snapshot, fetcher);
+
+    let plan = provider.plan(PARTS).expect("plan");
+    let _ = collect_plan(plan).await;
+
+    assert_eq!(
+        counting.gets(),
+        (2 * SEGMENTS) as u64,
+        "un-cached scan must open each segment once: {SEGMENTS} plan reads + \
+         {SEGMENTS} scan reads. The pre-fix striped path issues \
+         {} (= {SEGMENTS} + {SEGMENTS} * {PARTS}).",
+        SEGMENTS + SEGMENTS * PARTS,
+    );
+}
+
+/// Segment-granular assignment loses and duplicates nothing: the rows returned
+/// are exactly the rows written.
+#[tokio::test]
+async fn uncached_segment_granular_returns_every_row_once() {
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+    let (snapshot, want) = build_fixture(store.as_ref()).await;
+
+    let fetcher = LogSegmentFetcher::new(Arc::clone(&store));
+    let provider = provider(snapshot, fetcher);
+
+    let plan = provider.plan(PARTS).expect("plan");
+    let batches = collect_plan(Arc::clone(&plan)).await;
+    let got = batches_to_rows(&batches);
+
+    assert_eq!(
+        got.len(),
+        SEGMENTS * RECORDS_PER_SEG,
+        "no row may be dropped or duplicated"
+    );
+    assert_eq!(
+        got, want,
+        "segment-granular scan output must equal the written rows"
+    );
+
+    // Every partition drains only whole segments, so each partition's
+    // blocks_scanned is a multiple of BLOCKS_PER_SEG (the striped path breaks
+    // this; see the cached test). Read off the executed `plan`.
+    let per = per_partition_blocks_scanned(&plan);
+    assert!(
+        per.iter().all(|&b| b % BLOCKS_PER_SEG == 0),
+        "segment-granular: every partition scans whole segments (multiples of \
+         {BLOCKS_PER_SEG}), got {per:?}"
+    );
+    assert_eq!(
+        per.iter().sum::<usize>(),
+        SEGMENTS * BLOCKS_PER_SEG,
+        "every surviving block is scanned exactly once"
+    );
+}
+
+/// With a read cache attached the intra-segment block striping is unchanged: a
+/// single segment's blocks are spread across partitions. This is asserted
+/// through the assignment (per-partition `blocks_scanned`), not the store: at
+/// least one partition scans a block count that is not a whole-segment multiple,
+/// which is only possible when a segment's four blocks land in more than one
+/// partition. The cached GET count stays within the segment-granular bound
+/// (`<= 2 * 6`) because single-flight coalesces the re-opens.
+#[tokio::test]
+async fn cached_path_still_stripes_blocks_across_partitions() {
+    let counting = CountingStore::new(Arc::new(MemoryStore::new()));
+    let store: Arc<dyn ObjectStoreBackend> = Arc::clone(&counting) as Arc<dyn ObjectStoreBackend>;
+    let (snapshot, want) = build_fixture(store.as_ref()).await;
+
+    let cache = build_read_cache(64 << 20);
+    let fetcher = LogSegmentFetcher::new(Arc::clone(&store)).with_cache(cache);
+    assert!(
+        fetcher.has_cache(),
+        "this fixture must exercise the cached path"
+    );
+    let provider = provider(snapshot, fetcher);
+
+    let plan = provider.plan(PARTS).expect("plan");
+    let batches = collect_plan(Arc::clone(&plan)).await;
+
+    // Correctness is unchanged either way.
+    assert_eq!(
+        batches_to_rows(&batches),
+        want,
+        "cached scan output must equal the written rows"
+    );
+
+    let per = per_partition_blocks_scanned(&plan);
+    assert!(
+        per.iter().any(|&b| b % BLOCKS_PER_SEG != 0),
+        "striped path must split a segment's {BLOCKS_PER_SEG} blocks across \
+         partitions, so some partition's blocks_scanned is not a multiple of \
+         {BLOCKS_PER_SEG}; got {per:?} (segment-granular would give only \
+         multiples of {BLOCKS_PER_SEG})"
+    );
+    assert_eq!(
+        per.iter().sum::<usize>(),
+        SEGMENTS * BLOCKS_PER_SEG,
+        "every surviving block is still scanned exactly once"
+    );
+
+    assert!(
+        counting.gets() <= (2 * SEGMENTS) as u64,
+        "single-flight must coalesce the re-opens to within the segment-granular \
+         bound of {} GETs; got {}",
+        2 * SEGMENTS,
+        counting.gets(),
+    );
+}

--- a/docs/adrs/0102-intra-segment-scan-partitioning-and-spill-policy.md
+++ b/docs/adrs/0102-intra-segment-scan-partitioning-and-spill-policy.md
@@ -300,3 +300,21 @@ flowchart TB
     Pool -->|"over budget"| Err["Typed budget error\n(disk manager disabled,\nnever silent spill)"]
     Pool -->|"within budget"| Result[Query result]
 ```
+
+## Amendment (2026-08-26, #693)
+
+Intra-segment block striping (decision 1) applies only when the fetcher
+carries ADR-0046's read cache. Without it the scan is segment-granular: each
+segment is assigned whole to one partition (relevant segment `j` in snapshot
+order to partition `j % n`), so it is opened by exactly one partition, and the
+partition count is capped at the segment count.
+
+The reason is that decision 1's whole premise for striping past segment count
+rests on single-flight coalescing the re-opens: `n` partitions sharing one
+segment each open it themselves, and only the cache collapses those onto one
+object-store request per extent. Without the cache nothing coalesces them, so
+striping would multiply object-store reads by the partition count (measured at
+~9x on the 8424-object tenant of #680), which is a regression, not a
+speed-up. The gate was always `LogSegmentFetcher::has_cache`; this amendment
+records that the same predicate now selects the assignment mode, not only the
+partition count.

--- a/docs/adrs/0102-intra-segment-scan-partitioning-and-spill-policy.md
+++ b/docs/adrs/0102-intra-segment-scan-partitioning-and-spill-policy.md
@@ -113,7 +113,9 @@ The shipped design (`crates/ravel-sql/src/logs_scan.rs`) resolves all four:
   `target_partitions.max(1).min(segment_count.max(1))`. `ravel-bench`'s
   `logs_scan_scaling` report measures both sides: on its fixture,
   cache-wired request count stays flat across the `target_partitions`
-  sweep, un-cached it climbs until the segment-count cap binds.
+  sweep, and un-cached it is flat too, at one plan read plus one scan read
+  per segment, because segments are assigned whole (amendment below; the
+  original draft had it climbing until the segment-count cap bound).
 - **Double-count fixed by assigning ownership of the whole-segment totals
   to one partition.** `blocks_total` and the postings-prune drop are
   recorded once, by partition 0 only, during the shared planning step;


### PR DESCRIPTION
ADR-0102 stripes a snapshot's surviving blocks round-robin across
target_partitions, which puts every segment's blocks into every partition
and makes each partition open the segment itself. With ADR-0046's read
cache wired those re-opens single-flight onto one object-store request
per extent. Without a cache nothing coalesces them, so on a real
8424-object tenant (#680) a full-window statement fetched the whole
dataset once in the plan phase and then up to target_partitions more
times in the scan: with 8 partitions, one plan read per segment plus one
scan read per partition per segment (6 + 6 * 4 = 30 GETs on the
6-segment fixture), about 9x the bytes of the pre-ADR-0102
segment-granular scan.

Decide the assignment mode once at construction from the same
LogSegmentFetcher::has_cache predicate the declared_partitions gate
already used, and thread it into the stream and owned_work. When the
fetcher has no cache the unit is the segment, not the block: relevant
segment j (snapshot order, counting only segments with a surviving block)
goes to partition j % n and drains all of its surviving block indices, so
each segment is opened by exactly one partition and the scan costs one
plan read plus one scan read per segment (12 GETs on the fixture). When a
cache is wired the block round-robin is unchanged byte for byte.

This is the first half of #693; the second half (predicate-free plan
skips the object read) landed separately as #707. ADR-0102 is amended
with the un-cached assignment rule.

Refs: #693
Refs: #680
