### PR TITLE
test(ravel-query): make nested-subquery deadline test deterministic

### DIFF
--- a/crates/ravel-query/tests/deadline_cancels_nested_subquery_evaluation.rs
+++ b/crates/ravel-query/tests/deadline_cancels_nested_subquery_evaluation.rs
@@ -1,25 +1,48 @@
-//! Nested subquery evaluation is interruptible at the query deadline: the
-//! evaluator yields at cross-level cost-budget checkpoints, so `QueryEngine`'s
-//! `tokio::time::timeout` wrapper (engine.rs) can interrupt a runaway nested
-//! evaluation rather than only firing after it finishes.
+//! A nested-subquery query's deadline surfaces through `QueryEngine::range`:
+//! when the evaluation cannot proceed, `QueryEngine`'s `tokio::time::timeout`
+//! wrapper (engine.rs) ends the call with `QueryError::DeadlineExceeded`
+//! rather than hanging.
 //!
 //! `ravel_promql::Evaluator` checks a wall-clock deadline
-//! (`with_deadline`/`QueryWindow::check_deadline`) between subquery grid
-//! steps, and `QueryEngine::{instant,range}_with_stats` derive that deadline
-//! from their own `Duration` parameter and pass it into the evaluator before
-//! the `tokio::time::timeout` wrapper ever polls it. This test proves the
-//! integration actually works end to end through `QueryEngine::range`, not
-//! just inside `ravel-promql`'s own unit tests.
+//! (`with_deadline`/`QueryWindow::check_deadline`) between subquery grid steps,
+//! and `QueryEngine::{instant,range}_with_stats` derive that deadline from
+//! their own `Duration` parameter and pass it into the evaluator before the
+//! `tokio::time::timeout` wrapper ever polls it. That the evaluator yields
+//! *mid-computation* at cost-budget checkpoints is `ravel-promql`'s own unit
+//! test (`short_deadline_cancels_a_long_running_nested_subquery_evaluation`);
+//! this test proves the deadline is wired end to end through
+//! `QueryEngine::range`.
+//!
+//! Determinism (#706): the earlier version raced a 20ms wall deadline against
+//! a deliberately heavy `max_over_time(up[1000s:1s])` (~1,000,000 evaluation
+//! points, ~1.5s in this debug build) and asserted the query returned in under
+//! 500ms. Under load that is a coin flip: on a 16-core host with 16 sibling
+//! nextest binaries running, the assertion failed 2 of 2 in a full
+//! `scripts/gates.sh` run yet passed 3 of 3 when the binary ran alone. The
+//! outcome depended on how much CPU the box could spare, not on the engine.
+//!
+//! The fix removes the host-speed assumption entirely. The one segment the
+//! query must read is parked inside a [`FaultStore`] hold gate
+//! (`hold(Op::Get, "rseg", Always)`), so the segment data-object GET never
+//! completes; commit-record reads (snapshot resolution) pass straight through,
+//! so the query reaches the fetch and then cannot make progress. Nothing can
+//! finish the evaluation, so the deadline is the only thing that can end the
+//! wait, and it does regardless of how loaded the host is. The gate's held
+//! count is the observable evidence that the read was parked (and, being
+//! left held, cancelled) when the deadline fired -- the deterministic
+//! replacement for the old timing assertion. Mirrors the parked-read pattern
+//! in `deadline_cancels_fetch.rs` and `crates/ravel-sql/tests/deadline.rs`.
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use ravel_catalog::{Catalog, CatalogConfig};
 use ravel_commit::publish::RetryPolicy;
 use ravel_commit::record::NewCommitRecord;
 use ravel_commit::{keys, publish, record};
 use ravel_object_store::ObjectStoreBackend;
+use ravel_object_store::fault::{FaultPlan, FaultStore, Occurrence, Op};
 use ravel_object_store::memory::MemoryStore;
 use ravel_query::{EngineConfig, QueryEngine, QueryError};
 use ravel_segment::{IngestBounds, SegmentIdentity, SegmentWriter, SeriesInput, WrittenSegment};
@@ -95,64 +118,73 @@ async fn publish_up_segment(
         .expect("publish")
 }
 
-/// `max_over_time(up[1000s:1s])` over a 1000-step outer range (1s step)
-/// re-evaluates its own ~1000-point inner subquery from scratch at every
-/// outer step: ~1,000,000 evaluation points total, comfortably under both
-/// the per-node `max_range_points` cap and the shared cross-level budget
-/// (default 1,000,000), so nothing rejects it outright -- measured in
-/// isolation (`ravel-promql`'s own `short_deadline_cancels_a_long_running_
-/// nested_subquery_evaluation` test, same debug build) at just over 1.5s to
-/// run to completion.
+/// `max_over_time(up[100s:1s])` is a nested subquery: `QueryEngine::range`
+/// re-evaluates the inner `up[100s:1s]` grid at each outer step. The query
+/// needs the `up` segment, so it issues one data-object GET -- and that GET is
+/// parked forever by the hold gate. With the read unable to complete, the
+/// evaluation cannot make progress, so the deadline is the only thing that can
+/// end the wait; the query must surface `DeadlineExceeded`.
 ///
-/// With a 20ms deadline, `QueryEngine::range`'s evaluator must notice and
-/// stop long before that -- not after running the full computation and
-/// only then reporting a timeout. `elapsed` is what tells the two apart: a
-/// regression that dropped the evaluator's own deadline check would still
-/// eventually return `DeadlineExceeded` (via the outer `tokio::time::
-/// timeout`), but only after the full ~1.5s of synchronous work, since
-/// nothing inside that work would ever yield or check the deadline itself.
-///
-/// Refs: #706.
+/// The evidence that the read was genuinely parked (and, being left held,
+/// cancelled by the deadline drop) is `gate.held_count() == 1`: the segment
+/// GET registered inside the gate and was never released. Removing the gate
+/// (see the module doc) lets the read complete, the small query finishes well
+/// under the deadline, and the `DeadlineExceeded` assertion fails -- so this
+/// test cannot pass vacuously. Refs: #706.
 #[tokio::test]
 async fn short_deadline_cancels_nested_subquery_reevaluation_through_the_engine() {
     let tenant_id = TenantId::new("tenant-a".to_string());
     let tenant_hash = tenant_id.hash();
 
-    let store = MemoryStore::new();
-    let token = publish_up_segment(&store, &tenant_id, tenant_hash).await;
-    let backend: Arc<dyn ObjectStoreBackend> = Arc::new(store);
+    // Publish onto a plain store, then wrap it so the segment data-object read
+    // can be parked. Publishing through the wrapper first would park the
+    // publish itself.
+    let inner = MemoryStore::new();
+    let token = publish_up_segment(&inner, &tenant_id, tenant_hash).await;
+
+    let fault_store = FaultStore::new(inner, FaultPlan::default());
+    // Park every segment data-object GET (keys carry `rseg`); commit-record
+    // reads that resolve the snapshot pass straight through, so the query
+    // reaches the fetch and then cannot proceed.
+    let gate = fault_store.hold(Op::Get, Some("rseg".to_string()), Occurrence::Always);
+    let backend: Arc<dyn ObjectStoreBackend> = Arc::new(fault_store);
 
     let catalog =
         Arc::new(Catalog::new(backend.clone(), CatalogConfig::default()).expect("catalog"));
     let engine = QueryEngine::new(catalog, backend, EngineConfig::default());
 
+    // A small outer range: when the read is NOT parked the whole query runs in
+    // a couple of milliseconds, far under the deadline, so the red state (gate
+    // removed) returns `Ok` and the error-variant assertion fails.
     let start_ms = 1_000_000;
-    let end_ms = start_ms + 999_000;
+    let end_ms = start_ms + 10_000;
     let step_ms = 1_000;
 
-    let start = Instant::now();
     let result = engine
         .range(
             tenant_hash,
-            "max_over_time(up[1000s:1s])",
+            "max_over_time(up[100s:1s])",
             start_ms,
             end_ms,
             step_ms,
             &[token],
             SAMPLE_TS_NS,
-            Duration::from_millis(20),
+            // Realistic once nothing can complete under it: the parked read
+            // guarantees the deadline is what ends the wait, not the host's
+            // speed.
+            Duration::from_millis(50),
         )
         .await;
-    let elapsed = start.elapsed();
 
     assert!(
         matches!(result, Err(QueryError::DeadlineExceeded { .. })),
         "expected DeadlineExceeded, got {result:?}"
     );
-    assert!(
-        elapsed < Duration::from_millis(500),
-        "the query must be cancelled soon after the 20ms deadline, not after \
-         running the full ~1,000,000-point computation (over 1.5s in this \
-         same debug build); took {elapsed:?}"
+    assert_eq!(
+        gate.held_count(),
+        1,
+        "the nested subquery's segment read must have been parked in the gate \
+         when the deadline fired: the deadline was the only thing that could \
+         end the wait"
     );
 }

--- a/crates/ravel-query/tests/deadline_cancels_nested_subquery_evaluation.rs
+++ b/crates/ravel-query/tests/deadline_cancels_nested_subquery_evaluation.rs
@@ -111,6 +111,8 @@ async fn publish_up_segment(
 /// eventually return `DeadlineExceeded` (via the outer `tokio::time::
 /// timeout`), but only after the full ~1.5s of synchronous work, since
 /// nothing inside that work would ever yield or check the deadline itself.
+///
+/// Refs: #706.
 #[tokio::test]
 async fn short_deadline_cancels_nested_subquery_reevaluation_through_the_engine() {
     let tenant_id = TenantId::new("tenant-a".to_string());


### PR DESCRIPTION
short_deadline_cancels_nested_subquery_reevaluation_through_the_engine
raced a 20ms wall deadline against a deliberately heavy
max_over_time(up[1000s:1s]) (about 1,000,000 evaluation points, 1.5 s in
a debug build) and asserted the query returned within 500ms. That made
the outcome depend on how much CPU the host could spare, not on the
engine. On a 16-core host with 16 sibling nextest binaries running it
failed 2 of 2 in a full scripts/gates.sh run yet passed 3 of 3 alone on
the same binary.

Park the one segment the query must read inside a FaultStore hold gate
(hold(Op::Get, "rseg", Always)) so the data-object GET never completes,
while commit-record reads (snapshot resolution) pass straight through.
The evaluation then cannot make progress, so the deadline is the only
thing that can end the wait and it fires regardless of host load. The
gate's held count (== 1) is the deterministic evidence that the segment
read was parked, and left held, when the deadline cancelled it, replacing
the old timing assertion. The outer range is shrunk so that when the gate
is removed the read completes and the query returns Ok well under the
deadline, so the test cannot pass vacuously (flipping the held key to one
that never matches makes the query return Ok in 0.01 s and the assertion
fail). The query stays a nested subquery and the assertion still requires
QueryError::DeadlineExceeded. Mirrors the parked-read pattern in
deadline_cancels_fetch.rs and crates/ravel-sql/tests/deadline.rs. No
library code changes: the engine's cancellation was already correct.

A sweep of sub-200ms deadlines next to real work in crates/ravel-query
tests found no other case: deadline_cancels_fetch.rs already parks its
read, and the remaining short durations are injected latencies or sleeps,
not deadline races.

Fixes: #706
Refs: #680
