### PR TITLE
feat(ravel-bench): execute the SQL corpus through Flight SQL

### DIFF
--- a/crates/ravel-bench/Cargo.toml
+++ b/crates/ravel-bench/Cargo.toml
@@ -142,6 +142,14 @@ stage-timing = ["ravel-ingest/stage-timing"]
 # same optional `ravel-sql` entry `flight-egress` uses (no second entry, so no
 # second datafusion/arrow activation) and the plain gates never compile it.
 sql-latency = ["dep:ravel-sql", "dep:datafusion", "dep:ravel-cache", "dep:ravel-rspan", "dep:futures"]
+# The `sql_latency_bench --flight` lane (issue #680): the same corpus executed
+# through a running `ravel-server`'s Flight SQL endpoint instead of an
+# in-process executor. Off by default. No new external crate: `arrow-flight`
+# is already the optional dependency `flight-egress` activates, at the same
+# workspace pin, and `ravel-sql` is already linked with its `flight-sql`
+# feature by the `sql-latency` entry above, so the client type and the service
+# it talks to come from one arrow-flight instance.
+flight-lane = ["sql-latency", "dep:arrow-flight", "dep:futures"]
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/crates/ravel-bench/Cargo.toml
+++ b/crates/ravel-bench/Cargo.toml
@@ -345,6 +345,13 @@ bench = false
 # Tripwire for the object_count invariant (issue #481): distinct data-object
 # keys reachable from the resolved snapshot equal the reported object_count.
 # Behind sql-latency because the L0 case drives the sql_latency harness.
+# The Flight SQL lane (issue #680). The body is gated on `flight-lane` (empty
+# crate without it), so this entry is harmless under every other feature set.
+[[test]]
+name = "sql_latency_flight_smoke"
+path = "tests/sql_latency_flight_smoke.rs"
+bench = false
+
 [[test]]
 name = "sql_latency_object_count_invariant"
 path = "tests/sql_latency_object_count_invariant.rs"

--- a/crates/ravel-bench/src/bin/sql_latency_bench.rs
+++ b/crates/ravel-bench/src/bin/sql_latency_bench.rs
@@ -13,6 +13,10 @@
 //!
 //! Loaded-tenant lane (needs a tenant already loaded by `ravel-cli load`):
 //! `... --bin sql_latency_bench -- --tenant <id> --store s3`
+//!
+//! Flight SQL lane (the same tenant, executed through a running server; needs
+//! the `flight-lane` feature on top of `sql-latency`):
+//! `... -- --tenant <id> --store s3 --flight 127.0.0.1:4317`
 #![allow(clippy::expect_used)]
 
 use std::process::ExitCode;
@@ -22,7 +26,8 @@ use clap::Parser;
 use ravel_bench::harness::{StoreKind, store_from_env};
 use ravel_bench::sql_corpus::{checked_default_corpus, load_external_corpus};
 use ravel_bench::sql_latency::{
-    Compaction, GenerateConfig, SqlLatencyReport, TenantConfigInput, run_generated, run_tenant,
+    Compaction, FlightTarget, GenerateConfig, SqlLatencyReport, TenantConfigInput, run_generated,
+    run_tenant,
 };
 use ravel_sql::DEFAULT_MAX_QUERY_BYTES;
 use ravel_types::TimeRange;
@@ -134,9 +139,21 @@ struct Args {
     #[arg(long, default_value_t = false)]
     sql_parallel_final_aggregation: bool,
     /// Execute each statement through a running `ravel-server`'s Flight SQL
-    /// endpoint (`host:port`) instead of the in-process executor.
-    #[arg(long, value_name = "HOST:PORT")]
+    /// endpoint (`host:port`, the server's `--listen-grpc`) instead of the
+    /// in-process executor, so the numbers are the ones a client of that server
+    /// would see. `--store`/`--tenant` are still required and still used: the
+    /// dataset stanza and the tenant's declared columns are resolved from the
+    /// object store directly, because a Flight client cannot read the catalog.
+    /// Needs the `flight-lane` build feature.
+    #[arg(long, value_name = "HOST:PORT", requires = "tenant")]
     flight: Option<String>,
+    /// Bearer credential for `--flight`, sent as `authorization: Bearer
+    /// <TOKEN>`; this is the token side of the server's `--tenant-token
+    /// <TOKEN>=<TENANT>` pair. Falls back to the `RAVEL_FLIGHT_TOKEN`
+    /// environment variable, which is the better place for it: a token on the
+    /// command line lands in the shell history and in `ps`.
+    #[arg(long = "flight-token", value_name = "TOKEN", requires = "flight")]
+    flight_token: Option<String>,
 }
 
 #[derive(Copy, Clone, Debug, clap::ValueEnum)]
@@ -249,6 +266,14 @@ async fn run(args: &Args) -> Result<SqlLatencyReport, ravel_bench::sql_latency::
                 progress_jsonl: args.progress_jsonl.clone(),
                 tenant_max_bytes: args.sql_tenant_max_bytes,
                 parallel_final_aggregation: args.sql_parallel_final_aggregation,
+                flight: args.flight.as_ref().map(|endpoint| FlightTarget {
+                    endpoint: endpoint.clone(),
+                    token: args.flight_token.clone().or_else(|| {
+                        std::env::var("RAVEL_FLIGHT_TOKEN")
+                            .ok()
+                            .filter(|t| !t.is_empty())
+                    }),
+                }),
             };
             run_tenant(&cfg).await
         }
@@ -290,6 +315,9 @@ fn print_human_table(report: &SqlLatencyReport) {
     );
     println!("  host       : {} logical cores", p.host_logical_cores);
     println!("  source     : {}  dataset={}", p.source, p.dataset_id);
+    if let Some(flight) = &p.flight_endpoint {
+        println!("  flight sql : {flight} (scan diagnostics are not on the wire)");
+    }
     println!(
         "  dataset    : {} objects, {} bytes, {} rows, layout={}, load={:.1}ms",
         d.object_count, d.stored_bytes, d.rows, d.layout, d.load_wall_ms
@@ -316,6 +344,17 @@ fn print_human_table(report: &SqlLatencyReport) {
         "", "", "", "", "", "", "", "", ""
     );
     for e in &report.entries {
+        // The Flight lane has no scan diagnostics to print (they are executor
+        // counters, and nothing carries them over the wire). `-` says absent;
+        // a `0` would read as "scanned nothing".
+        let (blocks_total, blocks_scanned, gets) = match &e.scan {
+            Some(scan) => (
+                scan.blocks_total.to_string(),
+                scan.blocks_scanned.to_string(),
+                scan.object_store_get_requests.to_string(),
+            ),
+            None => ("-".to_string(), "-".to_string(), "-".to_string()),
+        };
         println!(
             "  {:<32} | {:>9.3} | {:>9.3} | {:>9.3} | {:>9.3} | {:>7} | {:>7} | {:>7} | {:>7}",
             e.id,
@@ -324,9 +363,9 @@ fn print_human_table(report: &SqlLatencyReport) {
             e.max_ms,
             e.cold_ms,
             e.rows_returned,
-            e.scan.blocks_total,
-            e.scan.blocks_scanned,
-            e.scan.object_store_get_requests,
+            blocks_total,
+            blocks_scanned,
+            gets,
         );
     }
     if !report.skipped.is_empty() {

--- a/crates/ravel-bench/src/bin/sql_latency_bench.rs
+++ b/crates/ravel-bench/src/bin/sql_latency_bench.rs
@@ -133,6 +133,10 @@ struct Args {
     /// default, which is what every earlier run measured.
     #[arg(long, default_value_t = false)]
     sql_parallel_final_aggregation: bool,
+    /// Execute each statement through a running `ravel-server`'s Flight SQL
+    /// endpoint (`host:port`) instead of the in-process executor.
+    #[arg(long, value_name = "HOST:PORT")]
+    flight: Option<String>,
 }
 
 #[derive(Copy, Clone, Debug, clap::ValueEnum)]

--- a/crates/ravel-bench/src/sql_latency.rs
+++ b/crates/ravel-bench/src/sql_latency.rs
@@ -26,6 +26,17 @@
 //!   so the query would return wrong numbers with a plausible latency instead
 //!   of an error.
 //!
+//! The tenant lane has a second mode, behind the `flight-lane` feature: with
+//! [`TenantConfigInput::flight`] set it executes each statement through a
+//! running `ravel-server`'s Flight SQL endpoint instead of an in-process
+//! executor, so the number a user would see (server planning, gRPC, Arrow IPC
+//! encode and decode, all of it) can be produced from the same corpus into the
+//! same report. It still resolves the dataset stanza and the declared-column
+//! set from the object store directly, because a Flight client cannot read the
+//! tenant's catalog and the skip check needs the declarations. What it loses is
+//! [`ScanDiagnostics`]: those come off the executor's own counters, which no
+//! Flight response carries, so its entries report `scan: None`.
+//!
 //! Report-only: like the rest of `ravel-bench`, this never changes library
 //! behavior, it only measures it.
 #![allow(clippy::expect_used, clippy::unwrap_used)]
@@ -158,7 +169,7 @@ pub struct Provenance {
     pub endpoint: String,
     /// Logical cores on the measuring host.
     pub host_logical_cores: usize,
-    /// Which lane produced the run: `"generate"` or `"tenant"`.
+    /// Which lane produced the run: `"generate"`, `"tenant"`, or `"flight"`.
     pub source: String,
     /// The tenant the numbers describe (a generated run mints a unique id).
     pub dataset_id: String,
@@ -188,6 +199,12 @@ pub struct Provenance {
     /// Whether final aggregations were allowed to repartition (ADR-0094).
     #[serde(default)]
     pub parallel_final_aggregation: bool,
+    /// The Flight SQL endpoint (`host:port`) the statements were executed
+    /// against, or `None` for an in-process lane. Deliberately not `endpoint`
+    /// above: that one names the object store, and the two are different
+    /// machines in any deployment worth measuring.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub flight_endpoint: Option<String>,
 }
 
 /// The tenant ceiling every run used before the knob was configurable.
@@ -271,8 +288,12 @@ pub struct EntryReport {
     pub cold_ms: f64,
     /// Rows the statement returned.
     pub rows_returned: usize,
-    /// Where the time went.
-    pub scan: ScanDiagnostics,
+    /// Where the time went. `Some` for the in-process lanes, which read the
+    /// executor's own counters. `None` for the Flight lane: those counters are
+    /// executor-side state a Flight SQL response does not carry, and reporting
+    /// zeros would read as "nothing was scanned".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scan: Option<ScanDiagnostics>,
 }
 
 /// One statement that was not run because the dataset does not satisfy its
@@ -413,6 +434,25 @@ pub struct GenerateConfig {
     pub parallel_final_aggregation: bool,
 }
 
+/// Where the Flight lane sends its statements.
+///
+/// Present unconditionally so [`TenantConfigInput`] has one shape under every
+/// feature set; only the code that *uses* it is behind `flight-lane`, and a
+/// binary built without that feature refuses a run that sets this rather than
+/// silently measuring in process.
+#[derive(Clone, Debug)]
+pub struct FlightTarget {
+    /// `host:port` of the server's gRPC listener (`ravel-server
+    /// --listen-grpc`, which carries Flight SQL when the server is built with
+    /// its `flight-sql` feature).
+    pub endpoint: String,
+    /// Bearer credential the server's tenant resolver maps to the tenant under
+    /// measurement, sent as `authorization: Bearer <token>`. `None` sends no
+    /// credential, which only reaches a server configured to resolve tenants
+    /// some other way.
+    pub token: Option<String>,
+}
+
 /// Inputs for the loaded-tenant lane.
 pub struct TenantConfigInput {
     pub store: Arc<dyn ObjectStoreBackend>,
@@ -473,6 +513,12 @@ pub struct TenantConfigInput {
     /// `SqlConfig::parallel_final_aggregation`; `false` is the compiled-in
     /// default and what every earlier run used.
     pub parallel_final_aggregation: bool,
+    /// `Some` executes every statement through a running server's Flight SQL
+    /// endpoint instead of an in-process [`SqlExecutor`]. The dataset stanza
+    /// and the declared-column set are still resolved from `store` directly:
+    /// a Flight client cannot read the tenant's catalog, and the skip check
+    /// needs the declarations.
+    pub flight: Option<FlightTarget>,
 }
 
 fn percentile(sorted_ns: &[u64], pct: f64) -> u64 {
@@ -777,7 +823,7 @@ pub async fn measure_corpus(
             max_ms: to_ms(*sorted.last().unwrap()),
             cold_ms: to_ms(cold_ns),
             rows_returned,
-            scan,
+            scan: Some(scan),
         };
         if let Some(sink) = progress.as_mut() {
             sink.write(&EntryEvent::Measured(report.clone()))?;
@@ -788,6 +834,186 @@ pub async fn measure_corpus(
     profile.finish();
 
     Ok((measured, skipped, failed))
+}
+
+/// Measure `entries` by executing each statement through a running server's
+/// Flight SQL endpoint, the path an external client actually takes.
+///
+/// Same loop as [`measure_corpus`], same [`EntryReport`], same progress
+/// stream; the differences are forced by the wire. The skip check still runs
+/// off `declared`, which the caller resolved from the object store, because a
+/// Flight client cannot read the tenant's catalog. Every entry it produces
+/// carries `scan: None`: block counters, object-store request counts, and
+/// cache hits are executor-side state the Flight response does not carry.
+///
+/// The window travels in the request metadata (`x-ravel-start` /
+/// `x-ravel-end`, Unix float seconds), which is how ravel-sql's Flight service
+/// reads it -- the Flight SQL command itself carries no window. The deadline
+/// travels the same way as `x-ravel-timeout`, and the server clamps it to its
+/// own maximum.
+#[cfg(feature = "flight-lane")]
+async fn measure_over_flight(
+    target: &FlightTarget,
+    cfg: &TenantConfigInput,
+    declared: &[DeclaredColumn],
+) -> Result<(Vec<EntryReport>, Vec<SkippedEntry>, Vec<FailedEntry>), Error> {
+    use arrow_flight::sql::client::FlightSqlServiceClient;
+    use tonic::transport::Channel;
+
+    let runs = cfg.runs.max(1);
+    let mut measured = Vec::new();
+    let mut skipped = Vec::new();
+    let mut failed = Vec::new();
+    let mut progress = cfg
+        .progress_jsonl
+        .as_deref()
+        .map(ProgressSink::open)
+        .transpose()?;
+
+    let uri = format!("http://{}", target.endpoint);
+    let channel = Channel::from_shared(uri.clone())
+        .map_err(|e| format!("invalid Flight endpoint `{uri}`: {e}"))?;
+
+    'entries: for entry in &cfg.entries {
+        if let Some((missing_key, want)) = first_unsatisfied(entry, declared) {
+            let skip = SkippedEntry {
+                id: entry.id.clone(),
+                missing_key: missing_key.clone(),
+                reason: format!(
+                    "required declared column `{missing_key}` ({want:?}) is not satisfied by the \
+                     dataset under measurement"
+                ),
+            };
+            if let Some(sink) = progress.as_mut() {
+                sink.write(&EntryEvent::Skipped(skip.clone()))?;
+            }
+            skipped.push(skip);
+            continue;
+        }
+
+        // One client per entry, connected lazily. Lazily matters: an
+        // unreachable endpoint must surface as the statement's error inside the
+        // run loop, where `continue_on_error` governs it, rather than aborting
+        // the whole run before any entry has been attempted.
+        let mut client = FlightSqlServiceClient::new(channel.clone().connect_lazy());
+        if let Some(token) = &target.token {
+            client.set_header("authorization", format!("Bearer {token}"));
+        }
+        client.set_header("x-ravel-start", seconds_header(cfg.window.start_ns));
+        client.set_header("x-ravel-end", seconds_header(cfg.window.end_ns));
+        client.set_header("x-ravel-timeout", format!("{}", cfg.deadline.as_secs_f64()));
+
+        let mut latencies_ns = Vec::with_capacity(runs);
+        let mut cold_ns = 0u64;
+        let mut rows_returned = 0usize;
+
+        for run in 0..runs {
+            let start = Instant::now();
+            let rows = match execute_over_flight(&mut client, &entry.sql).await {
+                Ok(rows) => rows,
+                Err(e) if cfg.continue_on_error => {
+                    let failure = FailedEntry {
+                        id: entry.id.clone(),
+                        run,
+                        error: e.to_string(),
+                    };
+                    if let Some(sink) = progress.as_mut() {
+                        sink.write(&EntryEvent::Failed(failure.clone()))?;
+                    }
+                    failed.push(failure);
+                    continue 'entries;
+                }
+                Err(e) => {
+                    return Err(Error::from(format!(
+                        "entry `{}` failed to execute: {e}",
+                        entry.id
+                    )));
+                }
+            };
+            let elapsed_ns = start.elapsed().as_nanos() as u64;
+            latencies_ns.push(elapsed_ns);
+            if run == 0 {
+                cold_ns = elapsed_ns;
+                rows_returned = rows;
+            }
+        }
+
+        let mut sorted = latencies_ns.clone();
+        sorted.sort_unstable();
+        let to_ms = |ns: u64| ns as f64 / 1e6;
+        let report = EntryReport {
+            id: entry.id.clone(),
+            min_ms: to_ms(*sorted.first().unwrap()),
+            median_ms: to_ms(percentile(&sorted, 0.50)),
+            max_ms: to_ms(*sorted.last().unwrap()),
+            cold_ms: to_ms(cold_ns),
+            rows_returned,
+            scan: None,
+        };
+        if let Some(sink) = progress.as_mut() {
+            sink.write(&EntryEvent::Measured(report.clone()))?;
+        }
+        measured.push(report);
+    }
+
+    Ok((measured, skipped, failed))
+}
+
+/// Render a nanosecond instant as the Unix float seconds the window metadata
+/// keys are defined in.
+#[cfg(feature = "flight-lane")]
+fn seconds_header(ns: i64) -> String {
+    format!("{}", ns as f64 / 1e9)
+}
+
+/// One statement over Flight SQL: `GetFlightInfo` to plan and mint a ticket,
+/// then `DoGet` per endpoint to redeem it, draining every batch. Returns the
+/// rows the statement produced.
+#[cfg(feature = "flight-lane")]
+async fn execute_over_flight(
+    client: &mut arrow_flight::sql::client::FlightSqlServiceClient<tonic::transport::Channel>,
+    sql: &str,
+) -> Result<usize, Error> {
+    use futures::TryStreamExt;
+
+    let info = client
+        .execute(sql.to_string(), None)
+        .await
+        .map_err(|e| format!("GetFlightInfo: {e}"))?;
+
+    let mut rows = 0usize;
+    for endpoint in &info.endpoint {
+        let ticket = endpoint
+            .ticket
+            .clone()
+            .ok_or_else(|| "Flight endpoint carries no ticket".to_string())?;
+        let batches = client
+            .do_get(ticket)
+            .await
+            .map_err(|e| format!("DoGet: {e}"))?
+            .try_collect::<Vec<_>>()
+            .await
+            .map_err(|e| format!("decode Flight batches: {e}"))?;
+        rows += batches.iter().map(|batch| batch.num_rows()).sum::<usize>();
+    }
+    Ok(rows)
+}
+
+/// Refusal for a binary built without the `flight-lane` feature: the Flight
+/// client is not linked, so the only honest answer is an error naming the
+/// feature. Measuring in process instead would silently answer a different
+/// question than the one `--flight` asked.
+#[cfg(not(feature = "flight-lane"))]
+async fn measure_over_flight(
+    target: &FlightTarget,
+    _cfg: &TenantConfigInput,
+    _declared: &[DeclaredColumn],
+) -> Result<(Vec<EntryReport>, Vec<SkippedEntry>, Vec<FailedEntry>), Error> {
+    Err(Error::from(format!(
+        "cannot execute against Flight SQL endpoint `{}`: this binary was built without the \
+         `flight-lane` feature (rebuild with --features sql-latency,flight-lane)",
+        target.endpoint
+    )))
 }
 
 /// Resolve the dataset-level figures (bytes, object count, rows) from a
@@ -890,6 +1116,7 @@ pub async fn run_generated(cfg: &GenerateConfig) -> Result<SqlLatencyReport, Err
             fetch_concurrency: cfg.fetch_concurrency.max(1),
             tenant_max_bytes: cfg.tenant_max_bytes.max(1),
             parallel_final_aggregation: cfg.parallel_final_aggregation,
+            flight_endpoint: None,
         },
         dataset,
         entries,
@@ -952,21 +1179,29 @@ pub async fn run_tenant(cfg: &TenantConfigInput) -> Result<SqlLatencyReport, Err
         tenant_max_bytes: cfg.tenant_max_bytes,
         parallel_final_aggregation: cfg.parallel_final_aggregation,
     };
-    let (entries, skipped, failed) = measure_corpus(
-        &cfg.store,
-        tenant_hash,
-        &cfg.entries,
-        &declared,
-        cfg.runs,
-        cfg.window,
-        cfg.now_ns,
-        cfg.cache_bytes,
-        cfg.deadline,
-        cfg.continue_on_error,
-        cfg.progress_jsonl.as_deref(),
-        settings,
-    )
-    .await?;
+    // The two lanes measure the same statements over the same dataset stanza
+    // and the same declared-column set; they differ only in what executes the
+    // SQL, in process or across a gRPC channel to a server.
+    let (entries, skipped, failed) = match &cfg.flight {
+        Some(target) => measure_over_flight(target, cfg, &declared).await?,
+        None => {
+            measure_corpus(
+                &cfg.store,
+                tenant_hash,
+                &cfg.entries,
+                &declared,
+                cfg.runs,
+                cfg.window,
+                cfg.now_ns,
+                cfg.cache_bytes,
+                cfg.deadline,
+                cfg.continue_on_error,
+                cfg.progress_jsonl.as_deref(),
+                settings,
+            )
+            .await?
+        }
+    };
 
     Ok(SqlLatencyReport {
         provenance: Provenance {
@@ -974,7 +1209,10 @@ pub async fn run_tenant(cfg: &TenantConfigInput) -> Result<SqlLatencyReport, Err
             region: cfg.region.clone(),
             endpoint: cfg.endpoint.clone(),
             host_logical_cores: host_logical_cores(),
-            source: "tenant".to_string(),
+            source: match &cfg.flight {
+                Some(_) => "flight".to_string(),
+                None => "tenant".to_string(),
+            },
             dataset_id: cfg.tenant.clone(),
             runs: cfg.runs.max(1),
             cache_bytes: cfg.cache_bytes,
@@ -982,6 +1220,7 @@ pub async fn run_tenant(cfg: &TenantConfigInput) -> Result<SqlLatencyReport, Err
             fetch_concurrency: cfg.fetch_concurrency.max(1),
             tenant_max_bytes: cfg.tenant_max_bytes.max(1),
             parallel_final_aggregation: cfg.parallel_final_aggregation,
+            flight_endpoint: cfg.flight.as_ref().map(|t| t.endpoint.clone()),
         },
         dataset,
         entries,
@@ -1293,6 +1532,7 @@ mod tests {
             progress_jsonl: None,
             tenant_max_bytes: DEFAULT_TENANT_MAX_BYTES,
             parallel_final_aggregation: false,
+            flight: None,
         }
     }
 

--- a/crates/ravel-bench/tests/sql_latency_flight_smoke.rs
+++ b/crates/ravel-bench/tests/sql_latency_flight_smoke.rs
@@ -1,0 +1,413 @@
+//! Smoke tests for `sql_latency_bench`'s Flight SQL lane (issue #680), behind
+//! the `flight-lane` feature.
+//!
+//! The lane exists because the in-process lanes measure the SQL executor as a
+//! library, and a ClickBench number a user would see goes through
+//! `ravel-server` over Flight SQL. So these tests refuse to stub the
+//! transport: they stand up ravel-sql's real [`RavelFlightSqlService`] on a
+//! real `tonic` listener on `127.0.0.1:0` over a `MemoryStore` tenant, and
+//! drive the lane's own client against it. (ravel-sql's own `Harness` calls
+//! the service's trait methods in process and lives in `ravel-sql/tests/util`,
+//! which is not reachable from this crate; a listener is both available and
+//! the stronger check, since the lane's whole point is the wire.)
+//!
+//! What they pin:
+//!
+//! - the lane reports the rows the server actually returned, `scan` absent,
+//!   `source == "flight"`, one entry per corpus statement, and one progress
+//!   line per finished statement;
+//! - a transport failure (a closed port) is the statement's error: recorded in
+//!   `failed` under `--continue-on-error`, and fatal without it.
+#![cfg(feature = "flight-lane")]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use ravel_bench::sql_corpus::{CorpusEntry, Modification};
+use ravel_bench::sql_latency::{
+    FlightTarget, GenerateConfig, TenantConfigInput, run_generated, run_tenant,
+};
+use ravel_object_store::ObjectStoreBackend;
+use ravel_object_store::memory::MemoryStore;
+use ravel_query::{
+    DEFAULT_FETCH_CONCURRENCY, LogSegmentFetcher, QueryAdmissionController, QueryConcurrencyLimit,
+    SegmentFetcher,
+};
+use ravel_sql::{
+    DEFAULT_MAX_QUERY_BYTES, FlightAuth, FlightClock, FlightSqlConfig, RavelFlightSqlService,
+    SpanSegmentFetcher, SqlConfig, SqlExecutor,
+};
+use ravel_types::accounting::NoopQueryCostRecorder;
+use ravel_types::{CommitToken, TenantHash, TenantId, TimeRange};
+use tonic::metadata::MetadataMap;
+use tonic::transport::Server;
+use tonic::transport::server::TcpIncoming;
+
+/// The frozen query clock the generated lane writes against: its records land
+/// in ingest-hour bucket 0 near the epoch, so a resolve over `[0, NOW_NS]`
+/// stays bounded.
+const NOW_NS: i64 = 4 * 3_600_000_000_000;
+
+/// The bearer credential the served tenant answers to.
+const TOKEN: &str = "flight-lane-token";
+
+/// Records written, split across three RLOG objects.
+const RECORDS: usize = 60;
+const RECORDS_PER_OBJECT: usize = 20;
+
+// ---------------------------------------------------------------------------
+// The two deployment-owned traits, as fixed test doubles
+// ---------------------------------------------------------------------------
+
+/// A tenant resolver over a fixed `Bearer <token>` map, deny by default.
+struct FixedAuth(HashMap<String, TenantHash>);
+
+impl FlightAuth for FixedAuth {
+    fn tenant(&self, metadata: &MetadataMap) -> Result<TenantHash, tonic::Status> {
+        let raw = metadata
+            .get("authorization")
+            .and_then(|value| value.to_str().ok())
+            .ok_or_else(|| tonic::Status::unauthenticated("missing tenant credentials"))?;
+        self.0
+            .get(raw)
+            .copied()
+            .ok_or_else(|| tonic::Status::unauthenticated("invalid tenant credentials"))
+    }
+
+    fn min_commit_tokens(
+        &self,
+        _metadata: &MetadataMap,
+    ) -> Result<Vec<CommitToken>, tonic::Status> {
+        Ok(Vec::new())
+    }
+}
+
+/// A clock frozen at the generated dataset's query clock, so ticket expiry and
+/// the resolve's `now_ns` are deterministic.
+struct FrozenClock(i64);
+
+impl FlightClock for FrozenClock {
+    fn now_ns(&self) -> i64 {
+        self.0
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Fixture
+// ---------------------------------------------------------------------------
+
+/// The corpus this suite measures: two statements, each projecting one column
+/// of every row, so `rows_returned` is exactly the rows written. Neither
+/// requires a declared column, so neither can be skipped.
+fn two_statement_corpus() -> Vec<CorpusEntry> {
+    ["SELECT body FROM logs", "SELECT severity_text FROM logs"]
+        .iter()
+        .enumerate()
+        .map(|(i, sql)| CorpusEntry {
+            id: format!("flight_scan_{i}"),
+            sql: (*sql).to_string(),
+            constructs: vec!["select".to_string()],
+            expected_rows: Some(RECORDS),
+            upstream_id: None,
+            modified: Modification::Verbatim,
+            required_declarations: Vec::new(),
+        })
+        .collect()
+}
+
+/// Publish a three-object logs dataset for one tenant by running the
+/// generated lane over a throwaway one-statement corpus, and return the tenant
+/// it minted.
+async fn publish_dataset(store: Arc<dyn ObjectStoreBackend>) -> TenantId {
+    let report = run_generated(&GenerateConfig {
+        store,
+        store_backend: "memory".to_string(),
+        region: "n/a".to_string(),
+        endpoint: "n/a".to_string(),
+        entries: vec![CorpusEntry {
+            id: "seed".to_string(),
+            sql: "SELECT count(*) FROM logs".to_string(),
+            constructs: vec!["count".to_string()],
+            expected_rows: Some(1),
+            upstream_id: None,
+            modified: Modification::Verbatim,
+            required_declarations: Vec::new(),
+        }],
+        runs: 1,
+        records: RECORDS,
+        records_per_object: RECORDS_PER_OBJECT,
+        extra_attrs: 2,
+        max_query_bytes: DEFAULT_MAX_QUERY_BYTES,
+        cache_bytes: 0,
+        deadline: Duration::from_secs(30),
+        continue_on_error: false,
+        fetch_concurrency: DEFAULT_FETCH_CONCURRENCY,
+        progress_jsonl: None,
+    })
+    .await
+    .expect("generated lane publishes the dataset");
+    assert_eq!(
+        report.dataset.object_count, 3,
+        "{RECORDS} records at {RECORDS_PER_OBJECT} per object is 3 objects"
+    );
+    assert_eq!(
+        report.dataset.rows, RECORDS as u64,
+        "every record is durable"
+    );
+    TenantId::new(report.provenance.dataset_id)
+}
+
+/// Serve ravel-sql's Flight SQL service over `store` for `tenant` on an
+/// ephemeral loopback port. Returns the bound address; the server task is
+/// detached and dies with the test process.
+async fn serve_flight(
+    store: Arc<dyn ObjectStoreBackend>,
+    tenant: &TenantId,
+) -> std::net::SocketAddr {
+    let catalog = Arc::new(
+        ravel_catalog::Catalog::new(Arc::clone(&store), ravel_catalog::CatalogConfig::default())
+            .expect("catalog"),
+    );
+    let executor = Arc::new(SqlExecutor::new(
+        catalog,
+        SegmentFetcher::new(Arc::clone(&store)),
+        LogSegmentFetcher::new(Arc::clone(&store)),
+        SpanSegmentFetcher::new(Arc::clone(&store)),
+        SqlConfig::default(),
+        1 << 30,
+    ));
+    let mut tenants = HashMap::new();
+    tenants.insert(format!("Bearer {TOKEN}"), tenant.hash());
+    let service = RavelFlightSqlService::new(
+        executor,
+        Arc::new(FixedAuth(tenants)),
+        Arc::new(FrozenClock(NOW_NS)),
+        FlightSqlConfig {
+            max_deadline: Duration::from_secs(30),
+            ..FlightSqlConfig::default()
+        },
+        Arc::new(NoopQueryCostRecorder),
+        QueryAdmissionController::shared(QueryConcurrencyLimit::Unlimited),
+    );
+
+    let incoming =
+        TcpIncoming::bind("127.0.0.1:0".parse().expect("loopback addr")).expect("bind listener");
+    let addr = incoming.local_addr().expect("listener local addr");
+    tokio::spawn(async move {
+        Server::builder()
+            .add_service(arrow_flight::flight_service_server::FlightServiceServer::new(service))
+            .serve_with_incoming(incoming)
+            .await
+            .expect("serve Flight SQL");
+    });
+    addr
+}
+
+/// A tenant-lane config pointed at `flight`, over the dataset in `store`.
+fn flight_cfg(
+    store: Arc<dyn ObjectStoreBackend>,
+    tenant: &TenantId,
+    flight: FlightTarget,
+    runs: usize,
+    continue_on_error: bool,
+    progress_jsonl: Option<std::path::PathBuf>,
+) -> TenantConfigInput {
+    TenantConfigInput {
+        store,
+        store_backend: "memory".to_string(),
+        region: "n/a".to_string(),
+        endpoint: "n/a".to_string(),
+        tenant: tenant.as_str().to_string(),
+        entries: two_statement_corpus(),
+        runs,
+        window: TimeRange {
+            start_ns: 0,
+            end_ns: NOW_NS,
+        },
+        now_ns: NOW_NS,
+        compaction: ravel_bench::sql_latency::Compaction::Pre,
+        max_query_bytes: DEFAULT_MAX_QUERY_BYTES,
+        // The generated lane writes shard 0 only and leaves no provisioning
+        // record, so the shard count has to be named.
+        shards: Some(1),
+        cache_bytes: 0,
+        deadline: Duration::from_secs(30),
+        continue_on_error,
+        fetch_concurrency: DEFAULT_FETCH_CONCURRENCY,
+        progress_jsonl,
+        flight: Some(flight),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn flight_lane_measures_every_statement_over_the_wire_without_scan_diagnostics() {
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+    let tenant = publish_dataset(Arc::clone(&store)).await;
+    let addr = serve_flight(Arc::clone(&store), &tenant).await;
+
+    let progress = tempfile::NamedTempFile::new().expect("progress file");
+    let report = run_tenant(&flight_cfg(
+        Arc::clone(&store),
+        &tenant,
+        FlightTarget {
+            endpoint: addr.to_string(),
+            token: Some(TOKEN.to_string()),
+        },
+        2,
+        false,
+        Some(progress.path().to_path_buf()),
+    ))
+    .await
+    .expect("flight lane runs");
+
+    assert!(
+        report.failed.is_empty(),
+        "no statement failed: {:?}",
+        report.failed
+    );
+    assert!(
+        report.skipped.is_empty(),
+        "neither statement declares a dependency"
+    );
+    assert_eq!(report.entries.len(), 2, "one entry per corpus statement");
+
+    // The rows come back over the wire, not from a local executor. Pinned to
+    // the exact count the dataset holds: `> 0` would hold just as well if the
+    // lane drained only the first batch of the first endpoint, which is the
+    // way an IPC-draining bug actually presents.
+    //
+    // Prove-the-test: this is the assertion that fires when the drain is
+    // defeated. Changing `rows += batches.iter().map(|batch|
+    // batch.num_rows()).sum::<usize>();` in `execute_over_flight`
+    // (src/sql_latency.rs) to `rows += batches.first().map(|batch|
+    // batch.num_rows()).unwrap_or(0);` still returns a plausible non-zero
+    // number and still passes every other assertion here, and fails this one.
+    for entry in &report.entries {
+        assert_eq!(
+            entry.rows_returned, RECORDS,
+            "entry `{}` must report every row the server returned",
+            entry.id
+        );
+        assert!(entry.cold_ms > 0.0, "entry `{}` cold time > 0", entry.id);
+        assert!(
+            entry.min_ms <= entry.median_ms && entry.median_ms <= entry.max_ms,
+            "entry `{}` violates min<=median<=max",
+            entry.id
+        );
+        // Executor-side counters are not on the wire, so the lane must report
+        // their absence rather than zeros that would read as "scanned
+        // nothing".
+        assert!(
+            entry.scan.is_none(),
+            "entry `{}` must carry no scan diagnostics over Flight",
+            entry.id
+        );
+    }
+
+    assert_eq!(report.provenance.source, "flight");
+    assert_eq!(
+        report.provenance.flight_endpoint.as_deref(),
+        Some(addr.to_string().as_str()),
+        "the provenance names the Flight endpoint, not the object store's"
+    );
+    assert_eq!(
+        report.provenance.endpoint, "n/a",
+        "the object-store endpoint field is left alone"
+    );
+    // The dataset stanza is still resolved from the store directly: a Flight
+    // client cannot read the catalog.
+    assert_eq!(report.dataset.object_count, 3);
+    assert_eq!(report.dataset.rows, RECORDS as u64);
+
+    // `scan` is omitted from the JSON rather than serialized as null, and the
+    // report still round-trips.
+    let json = serde_json::to_string(&report).expect("report serializes");
+    assert!(!json.contains("\"scan\""), "absent scan is omitted: {json}");
+    serde_json::from_str::<ravel_bench::sql_latency::SqlLatencyReport>(&json)
+        .expect("report round-trips");
+
+    let lines = std::fs::read_to_string(progress.path()).expect("progress file readable");
+    assert_eq!(
+        lines.lines().count(),
+        2,
+        "one progress line per finished statement: {lines}"
+    );
+}
+
+#[tokio::test]
+async fn a_closed_port_fails_the_statement_rather_than_the_transport_silently_passing() {
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+    let tenant = publish_dataset(Arc::clone(&store)).await;
+
+    // Bind and immediately drop, so the port is known-closed rather than
+    // guessed. Nothing serves it.
+    let closed = {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+        listener.local_addr().expect("addr")
+    };
+    let target = FlightTarget {
+        endpoint: closed.to_string(),
+        token: Some(TOKEN.to_string()),
+    };
+
+    // With --continue-on-error the run completes and records the transport
+    // error against each statement.
+    //
+    // Prove-the-test: the line this guards is `let mut client =
+    // FlightSqlServiceClient::new(channel.clone().connect_lazy());` in
+    // `measure_over_flight` (src/sql_latency.rs). Connecting eagerly instead
+    // (`channel.clone().connect().await.map_err(...)?`) makes an unreachable
+    // server abort the run with `connect: transport error` no matter what
+    // `continue_on_error` says, so `run_tenant` below returns `Err` and this
+    // `expect` fires. Verified by running it.
+    let report = run_tenant(&flight_cfg(
+        Arc::clone(&store),
+        &tenant,
+        target.clone(),
+        2,
+        true,
+        None,
+    ))
+    .await
+    .expect("the run completes when asked to continue past failures");
+    assert!(
+        report.entries.is_empty(),
+        "an unreachable server produces no measurement: {:?}",
+        report.entries
+    );
+    assert_eq!(
+        report.failed.len(),
+        2,
+        "both statements are recorded failed"
+    );
+    for failure in &report.failed {
+        assert_eq!(failure.run, 0, "the first run is the one that failed");
+        assert!(
+            failure.error.contains("GetFlightInfo"),
+            "the recorded error names the RPC that could not connect: {}",
+            failure.error
+        );
+    }
+
+    // Without it, the first failure aborts the run.
+    let err = run_tenant(&flight_cfg(
+        Arc::clone(&store),
+        &tenant,
+        target,
+        2,
+        false,
+        None,
+    ))
+    .await
+    .expect_err("an unreachable server aborts a run that was not told to continue");
+    assert!(
+        err.to_string().contains("failed to execute"),
+        "the abort names the statement: {err}"
+    );
+}

--- a/crates/ravel-bench/tests/sql_latency_smoke.rs
+++ b/crates/ravel-bench/tests/sql_latency_smoke.rs
@@ -138,15 +138,27 @@ async fn generated_lane_reports_per_query_min_median_max_and_scan_diagnostics() 
 
     // Scan diagnostics: at least one statement scans blocks over the durable
     // objects, proving the block counters are wired rather than always zero.
+    // Every in-process entry carries them; only the Flight lane reports `None`.
+    for e in &report.entries {
+        assert!(
+            e.scan.is_some(),
+            "the in-process lane reports scan diagnostics for `{}`",
+            e.id
+        );
+    }
+    let scans: Vec<&ravel_bench::sql_latency::ScanDiagnostics> = report
+        .entries
+        .iter()
+        .filter_map(|e| e.scan.as_ref())
+        .collect();
     assert!(
-        report.entries.iter().any(|e| e.scan.blocks_total > 0),
+        scans.iter().any(|s| s.blocks_total > 0),
         "at least one entry must report a non-zero blocks_total"
     );
     assert!(
-        report
-            .entries
+        scans
             .iter()
-            .any(|e| e.scan.segments == report.dataset.object_count),
+            .any(|s| s.segments == report.dataset.object_count),
         "a full-window statement sees every dataset segment"
     );
 
@@ -160,22 +172,23 @@ async fn generated_lane_reports_per_query_min_median_max_and_scan_diagnostics() 
     let scanning = report
         .entries
         .iter()
-        .filter(|e| e.scan.blocks_total > 0)
-        .max_by_key(|e| e.scan.object_store_get_requests)
+        .filter_map(|e| e.scan.as_ref().map(|s| (e, s)))
+        .filter(|(_, s)| s.blocks_total > 0)
+        .max_by_key(|(_, s)| s.object_store_get_requests)
         .expect("at least one entry scans blocks");
     assert!(
-        scanning.scan.object_store_get_requests >= report.dataset.object_count as u64,
+        scanning.1.object_store_get_requests >= report.dataset.object_count as u64,
         "entry `{}` charged {} GETs for a {}-object dataset: fewer GETs than \
          objects means the accounting is under-counting reads",
-        scanning.id,
-        scanning.scan.object_store_get_requests,
+        scanning.0.id,
+        scanning.1.object_store_get_requests,
         report.dataset.object_count
     );
     assert!(
-        scanning.scan.object_store_bytes >= 1_024,
+        scanning.1.object_store_bytes >= 1_024,
         "entry `{}` charged only {} object-store bytes across {} objects",
-        scanning.id,
-        scanning.scan.object_store_bytes,
+        scanning.0.id,
+        scanning.1.object_store_bytes,
         report.dataset.object_count
     );
 

--- a/docs/guides/clickbench.md
+++ b/docs/guides/clickbench.md
@@ -338,7 +338,8 @@ The bench prints the full report as JSON, then a human table. Per statement:
   was slow: `segments`, `blocks_total`, `blocks_scanned`,
   `blocks_pruned_by_postings` (POSTINGS pruning selectivity), plus the cold run's
   object-store GET/LIST request counts, bytes transferred, and fetch-cache
-  hits/misses/bytes.
+  hits/misses/bytes. Present for the in-process lanes only; the `--flight` lane
+  of step 6 omits the whole block, for the reason given there.
 
 Dataset-level, independent of any one query:
 
@@ -351,8 +352,9 @@ Dataset-level, independent of any one query:
 - **rows** and the **pre-/post-compaction layout label**.
 
 Provenance (backend, region, endpoint, host logical cores, source, dataset id,
-runs, `cache_bytes`, `deadline_secs`, `fetch_concurrency`) is recorded beside
-the numbers so two runs are comparable or provably not.
+runs, `cache_bytes`, `deadline_secs`, `fetch_concurrency`, and
+`flight_endpoint` when step 6's lane ran) is recorded beside the numbers so
+two runs are comparable or provably not.
 
 ## Reading a report against ClickBench
 
@@ -396,7 +398,100 @@ column paid. A full-window statement over an N-object tenant reads every
 object, because the plan phase reads the whole dataset; issues #693 and #699
 are the two open changes to that. So the figure to compare across runs is bytes
 per second at the reported `host_logical_cores`, not the statement's row count.
+## 6. Through the server (Flight SQL)
 
+Everything above measures the SQL executor as a library, in the bench's own
+process. A number a user would see goes through `ravel-server` over Flight SQL:
+server-side planning and admission, gRPC, Arrow IPC encode on the server and
+decode on the client. Those are different numbers, and the second one is what a
+published result claims. The `--flight` lane runs the same corpus, over the same
+tenant, into the same report, through a running server.
+
+Start the server against the same bucket, built with its `flight-sql` feature.
+Flight SQL is served on the gRPC listener:
+
+```sh
+cargo run -p ravel-server --features flight-sql --bin ravel-server -- \
+  --mode query \
+  --store s3 \
+  --listen-grpc 127.0.0.1:4317 \
+  --tenant-token "$RAVEL_FLIGHT_TOKEN=clickbench" \
+  --shards 4 \
+  --fetch-concurrency 8 \
+  --sql-max-query-bytes 1073741824 \
+  --sql-tenant-max-bytes 2147483648 \
+  --cache-max-bytes 268435456
+```
+
+The flags that must mirror the bench's, or the two tables are not comparable:
+
+- `--fetch-concurrency` is the same ADR-0088 knob as the bench's flag of the
+  same name (logs scan partitions and in-flight segment fetches per query). This
+  is the one that moves a cold full scan the most; set both sides to the same
+  value and record it.
+- `--sql-max-query-bytes` is the per-query DataFusion memory-pool ceiling. A
+  statement that fits the bench's budget and not the server's aborts on the
+  server with `query memory budget exhausted` and lands in `failed`.
+- `--sql-tenant-max-bytes` has no bench counterpart: it is the server's
+  per-tenant ceiling across concurrent queries, which an in-process lane running
+  one statement at a time never reaches. Set it above
+  `--sql-max-query-bytes` so it is not the binding limit for a serial run.
+- Cache flags: the bench's `--cache-bytes` attaches an ADR-0046 read cache to
+  its own fetcher; the server's equivalent is `--cache-max-bytes` (plus
+  `--cache-dir` for the disk tier, and `--disable-cache` to turn it off). To
+  compare against a `--cache-bytes 0` bench run, start the server with
+  `--disable-cache`; otherwise match the byte budgets. The server's cache is
+  process-wide and survives between statements, so a warm server does not
+  reproduce the bench's per-statement cold run.
+
+Then point the bench at it. Two lines:
+
+```sh
+export RAVEL_FLIGHT_TOKEN=<the token side of --tenant-token>
+cargo run -p ravel-bench --features sql-latency,flight-lane --bin sql_latency_bench -- \
+  --tenant clickbench --store s3 --flight 127.0.0.1:4317 \
+  --corpus benchmarks/clickbench/hits.corpus.json \
+  --runs 3 --compaction pre --window-hours 200000 \
+  --fetch-concurrency 8 --sql-max-query-bytes 1073741824
+```
+
+- `--flight <host:port>` is the server's `--listen-grpc` address. It needs the
+  `flight-lane` build feature; without it the run fails with an error naming the
+  feature rather than quietly measuring in process.
+- `--flight-token <TOKEN>` passes the credential on the command line;
+  `RAVEL_FLIGHT_TOKEN` is the better place for it, since a token in the argument
+  vector lands in the shell history and in `ps`. It is sent as `authorization:
+  Bearer <TOKEN>` and must be the token side of the server's `--tenant-token
+  <TOKEN>=<TENANT>` pair.
+- `--store` and `--tenant` are still required and still used. The dataset stanza
+  (objects, bytes, rows, layout) and the tenant's declared columns are resolved
+  from the object store **directly**, not through the server: a Flight client
+  cannot read the tenant's catalog, and the declared-column skip check needs the
+  declarations. So this lane needs object-store credentials as well as a server.
+- `--window-hours` / `--now-secs` reach the server in the request metadata, as
+  `x-ravel-start` and `x-ravel-end` in Unix float seconds. The Flight SQL
+  command carries no window of its own, so this is how ravel-sql's Flight
+  service reads it, exactly as the HTTP endpoint reads `start`/`end` from the
+  JSON body. `--deadline-secs` travels the same way as `x-ravel-timeout` and is
+  clamped by the server's own maximum, which a client can shorten but never
+  extend.
+- `--runs`, `--corpus`, `--continue-on-error`, and `--progress-jsonl` behave
+  exactly as in step 5.
+
+**The Flight lane's report has no `scan` block.** `segments`, `blocks_total`,
+`blocks_scanned`, `blocks_pruned_by_postings`, the object-store GET/LIST counts,
+the bytes, and the cache hits and misses are all read off the executor's own
+counters inside the process that ran the query. A Flight SQL response carries
+result batches, not the server's internal accounting, so the bench has no way to
+observe them from the client side. Rather than report zeros, which would read as
+"this statement scanned nothing", the `scan` field is omitted from the JSON
+entirely and the human table prints `-` in those columns. `provenance.source` is
+`"flight"` and `provenance.flight_endpoint` names the address, so a report
+cannot be mistaken for an in-process one. Everything else -- `cold_ms`,
+`min_ms`, `median_ms`, `max_ms`, `rows_returned`, `skipped`, `failed`, and the
+progress stream -- is identical. When you need the attribution, run step 5's
+in-process lane over the same tenant and read the two tables together: the
+in-process one says where the time went, this one says what the user waits.
 ## Gap list: ClickBench statements the construct gate rejects
 
 Running a 43-query suite against a supported-construct gate means some queries


### PR DESCRIPTION
sql_latency_bench measured the SQL executor as a library, in the same
process as the harness. The number a user sees goes through ravel-server
over Flight SQL: server-side planning, gRPC, Arrow IPC encode on one side
and decode on the other. Those are different numbers, and only the second
one is what a published ClickBench result claims.

`--flight <host:port>` (with `--flight-token`, or `RAVEL_FLIGHT_TOKEN`)
routes the tenant lane's statements through a running server's Flight SQL
endpoint instead of the in-process executor: one GetFlightInfo plus DoGet
per run, every batch drained, rows counted. The window travels in the
request metadata as `x-ravel-start` / `x-ravel-end` in Unix float
seconds, which is how ravel-sql's Flight service reads it, and
`--deadline-secs` as `x-ravel-timeout`.

The report keeps its shape. `provenance.source` becomes "flight" and
`provenance.flight_endpoint` carries the address; `endpoint` still names
the object store. The wire loses the scan diagnostics (block counters,
object-store request counts, cache hits are the executor's own counters
and no Flight response carries them), so `EntryReport::scan` is an
Option: Some for the in-process lanes, None here, printed as `-` rather
than a 0 that would read as "scanned nothing".

Behind a `flight-lane` cargo feature, off by default. No new external
crate: arrow-flight is already this crate's optional dependency at the
workspace pin. Built without the feature, `--flight` fails naming it
rather than quietly measuring in process.

The test stands up ravel-sql's real Flight SQL service on a tonic
listener over a MemoryStore tenant and drives the lane's client against
it: rows returned equal rows reported (fails with 20 vs 60 when only the
first batch is counted), scan absent rather than zeroed, one progress
line per statement; pointed at a closed port, each statement lands in
`failed` under `--continue-on-error` and the run aborts without it, which
is why the client connects lazily. docs/guides/clickbench.md gains step 6
(server flags that must mirror the bench's, the two bench lines, and why
the Flight report has no scan block).

Refs: #680
