### PR TITLE
perf(ravel-logseg): bound the columnar writer's peak by one block

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4757,6 +4757,7 @@ dependencies = [
  "ravel-codec",
  "ravel-proto",
  "ravel-types",
+ "stats_alloc",
  "thiserror",
  "zstd",
 ]

--- a/crates/ravel-logseg/Cargo.toml
+++ b/crates/ravel-logseg/Cargo.toml
@@ -18,6 +18,12 @@ prost = { workspace = true }
 [dev-dependencies]
 proptest = { workspace = true }
 criterion = { workspace = true }
+# Peak-live-bytes measurement for the columnar writer memory test. Pinned to
+# the same 0.1.10 the ravel-sql/ravel-otlp allocation tests already use; the
+# workspace forbids `unsafe_code`, so a hand-rolled counting allocator will not
+# compile and the instrumented global allocator this crate provides is used
+# instead (issue #682).
+stats_alloc = "0.1.10"
 
 [lints]
 workspace = true

--- a/crates/ravel-logseg/src/writer.rs
+++ b/crates/ravel-logseg/src/writer.rs
@@ -1071,15 +1071,6 @@ impl RlogWriter {
                 }
             }
         }
-        // Str plan column ids on the dict path: their per-row bloom tokens are
-        // set once per distinct value below, so the per-row loop skips them.
-        let dict_str_cids: HashSet<u32> = columns
-            .iter()
-            .enumerate()
-            .filter(|(pi, (_, ty, _))| plan_uses_dict[*pi] && matches!(ty, FieldType::Str))
-            .map(|(_, (_, _, cid))| *cid)
-            .collect();
-
         // Sort rows by (stream_ref, ts) exactly as the row path sorts
         // ResolvedRows; `sort_by` is stable, so ties keep the appended order.
         let mut perm: Vec<usize> = (0..total_rows).collect();
@@ -1202,10 +1193,13 @@ impl RlogWriter {
                 blk_cols.push(cols);
             }
 
+            // Present columns and their FIELD_DIR occurrence counts, read from
+            // the cids before the values are moved into the page below.
             let mut present_cols: BTreeSet<u32> = BTreeSet::new();
             for cols in &blk_cols {
                 for (cid, _) in cols {
                     present_cols.insert(*cid);
+                    *col_present.entry(*cid).or_insert(0) += 1;
                 }
             }
             let mut plan_cols: BTreeSet<u32> = present_cols.clone();
@@ -1250,8 +1244,10 @@ impl RlogWriter {
                 .filter_map(|&g| g_attrs_raw[g].as_deref())
                 .collect();
 
-            // Per-plan value pages, scattered from this block's materialized
-            // occurrences; dict-path plans carry their page below instead.
+            // Per-plan value pages, filled by moving each occurrence's value out
+            // of the materialized list (consumed here, never cloned): the bytes
+            // live in exactly one place, the page. Dict-path plans carry their
+            // page below instead, so their moved value is simply dropped.
             let mut values_v: Vec<Vec<Option<ColumnValue>>> = plans
                 .iter()
                 .map(|p| {
@@ -1262,18 +1258,18 @@ impl RlogWriter {
                     }
                 })
                 .collect();
-            for (li, cols) in blk_cols.iter().enumerate() {
+            for (li, cols) in blk_cols.into_iter().enumerate() {
                 for (cid, cv) in cols {
-                    if !plan_uses_dict[plan_of_cid[cid]] {
-                        values_v[plan_pos[cid]][li] = Some(cv.clone());
+                    if !plan_uses_dict[plan_of_cid[&cid]] {
+                        values_v[plan_pos[&cid]][li] = Some(cv);
                     }
                 }
             }
             let mut stat_v: Vec<Vec<Option<ColumnValue>>> =
                 plans.iter().map(|_| vec![None; n]).collect();
-            for (li, stat) in blk_stat.iter().enumerate() {
+            for (li, stat) in blk_stat.into_iter().enumerate() {
                 for (cid, cv) in stat {
-                    stat_v[plan_pos[cid]][li] = Some(cv.clone());
+                    stat_v[plan_pos[&cid]][li] = Some(cv);
                 }
             }
             // Owned per-block dict ids (one Option<index> per block row) for
@@ -1330,15 +1326,6 @@ impl RlogWriter {
             for (li, &g) in block_rows.iter().enumerate() {
                 insert_text(&mut builder, COL_BODY, g_body[g]);
                 insert_text(&mut builder, COL_SEVERITY_TEXT, g_sevtext[g]);
-                for (cid, v) in &blk_cols[li] {
-                    if let ColumnValue::Str(bytes) = v {
-                        // Dict-path Str columns are tokenized per distinct value
-                        // after this loop; skip their per-row occurrence here.
-                        if !dict_str_cids.contains(cid) {
-                            insert_text(&mut builder, *cid, bytes);
-                        }
-                    }
-                }
                 for (cid, v) in &blk_indexed[li] {
                     if postings_capped.contains(cid) {
                         continue;
@@ -1351,6 +1338,20 @@ impl RlogWriter {
                     if field_map.len() > self.cfg.postings_max_distinct {
                         postings_terms.remove(cid);
                         postings_capped.insert(*cid);
+                    }
+                }
+            }
+            // String-column bloom from the value pages. Bloom bit setting is
+            // idempotent, so plan-major insertion sets the same bits the per-row
+            // path did. Dict-path Str columns are tokenized per distinct value
+            // below instead (their page is empty here).
+            for (pos, p) in plans.iter().enumerate() {
+                if plan_uses_dict[plan_of_cid[&p.column_id]] || !matches!(p.ty, FieldType::Str) {
+                    continue;
+                }
+                for cell in &values_v[pos] {
+                    if let Some(ColumnValue::Str(bytes)) = cell {
+                        insert_text(&mut builder, p.column_id, bytes);
                     }
                 }
             }
@@ -1387,11 +1388,6 @@ impl RlogWriter {
             }
             for cid in &present_cols {
                 *col_blocks.entry(*cid).or_insert(0) += 1;
-            }
-            for cols in &blk_cols {
-                for (cid, _) in cols {
-                    *col_present.entry(*cid).or_insert(0) += 1;
-                }
             }
 
             let block_offset = blocks_bytes.len() as u64;

--- a/crates/ravel-logseg/src/writer.rs
+++ b/crates/ravel-logseg/src/writer.rs
@@ -942,15 +942,33 @@ impl RlogWriter {
         let mut col_values: Vec<Vec<Option<ColumnValue>>> = vec![vec![None; total_rows]; num_plans];
         let mut col_stat: Vec<Vec<Option<ColumnValue>>> = vec![vec![None; total_rows]; num_plans];
 
+        // Tracked names (indexed union numstat), interned once into a flat table
+        // so the per-row occurrence lists key by a small slot index instead of
+        // allocating a fresh `String` and a `BTreeMap` node per tracked cell
+        // (the small-allocation churn glibc never returns to the OS, #682). The
+        // table is name-sorted, so ascending slot order is ascending name order:
+        // [`record_level_winners_slot`] reproduces [`record_level_winners`]'s
+        // name-sorted output from it byte for byte.
+        let mut tracked_name_vec: Vec<&str> = indexed_names
+            .iter()
+            .chain(numstat_names.iter())
+            .copied()
+            .collect();
+        tracked_name_vec.sort_unstable();
+        tracked_name_vec.dedup();
+        let tracked_slot: HashMap<&str, u32> = tracked_name_vec
+            .iter()
+            .enumerate()
+            .map(|(i, n)| (*n, i as u32))
+            .collect();
+
         // Per-row in-budget columnar occurrences (row.columns), overflow
         // attributes (attrs_raw source), and the tracked-name occurrences the
-        // merged view is resolved from.
+        // merged view is resolved from (keyed by tracked slot, not name).
         let mut g_cols: Vec<Vec<(u32, ColumnValue)>> = vec![Vec::new(); total_rows];
         let mut g_overflow: Vec<Vec<(String, AttrValue)>> = vec![Vec::new(); total_rows];
-        let mut tracked_cols: Vec<BTreeMap<String, Vec<(u8, ColumnValue)>>> =
-            vec![BTreeMap::new(); total_rows];
-        let mut tracked_overflow: Vec<BTreeMap<String, Vec<AttrValue>>> =
-            vec![BTreeMap::new(); total_rows];
+        let mut tracked_cols: Vec<Vec<(u32, u8, ColumnValue)>> = vec![Vec::new(); total_rows];
+        let mut tracked_overflow: Vec<Vec<(u32, AttrValue)>> = vec![Vec::new(); total_rows];
 
         for (bi, b) in batches.iter().enumerate() {
             let base = bases[bi];
@@ -974,19 +992,18 @@ impl RlogWriter {
                             col_values[plan_idx][grow] = Some(cv.clone());
                             g_cols[grow].push((cid, cv.clone()));
                             if tracked {
-                                tracked_cols[grow]
-                                    .entry(c.name.clone())
-                                    .or_default()
-                                    .push((ty.to_u8(), cv));
+                                tracked_cols[grow].push((
+                                    tracked_slot[c.name.as_str()],
+                                    ty.to_u8(),
+                                    cv,
+                                ));
                             }
                         }
                         None => {
                             g_overflow[grow].push((c.name.clone(), cell.clone()));
                             if tracked {
                                 tracked_overflow[grow]
-                                    .entry(c.name.clone())
-                                    .or_default()
-                                    .push(cell.clone());
+                                    .push((tracked_slot[c.name.as_str()], cell.clone()));
                             }
                         }
                     }
@@ -999,10 +1016,7 @@ impl RlogWriter {
                     let tracked =
                         indexed_names.contains(k.as_str()) || numstat_names.contains(k.as_str());
                     if tracked {
-                        tracked_overflow[grow]
-                            .entry(k.clone())
-                            .or_default()
-                            .push(v.clone());
+                        tracked_overflow[grow].push((tracked_slot[k.as_str()], v.clone()));
                     }
                 }
             }
@@ -1080,7 +1094,11 @@ impl RlogWriter {
             if !g_overflow[grow].is_empty() {
                 g_attrs_raw[grow] = Some(canonical_attr_bytes(&g_overflow[grow]));
             }
-            let winners = record_level_winners(&tracked_cols[grow], &tracked_overflow[grow]);
+            let winners = record_level_winners_slot(
+                &tracked_cols[grow],
+                &tracked_overflow[grow],
+                &tracked_name_vec,
+            );
             let seed = stream_tracked
                 .get(&g_stream_id[grow])
                 .map_or(&[][..], Vec::as_slice);
@@ -1799,6 +1817,58 @@ fn record_level_winners(
         }
         if let Some(winner) = combined.pop() {
             out.insert(name.clone(), winner);
+        }
+    }
+    out
+}
+
+/// The slot-keyed counterpart of [`record_level_winners`], used by the columnar
+/// path. `cols` and `overflow` are one record's tracked occurrences flattened
+/// (`(tracked slot, ...)`) rather than grouped in a per-record `BTreeMap`, so no
+/// name is cloned and no map node is allocated per cell (#682). `names` maps a
+/// slot back to its name; because the slot table is name-sorted, iterating slots
+/// ascending yields the same name order [`record_level_winners`] produces, and
+/// the winner rule (columnar occurrences ascending by type byte, then overflow
+/// occurrences ascending by canonical value bytes, last wins) is identical, so
+/// the returned map is byte-for-byte the same.
+fn record_level_winners_slot(
+    cols: &[(u32, u8, ColumnValue)],
+    overflow: &[(u32, ravel_types::logstream::AttrValue)],
+    names: &[&str],
+) -> BTreeMap<String, (u8, ColumnValue)> {
+    let mut slots: BTreeSet<u32> = BTreeSet::new();
+    for (slot, _, _) in cols {
+        slots.insert(*slot);
+    }
+    for (slot, _) in overflow {
+        slots.insert(*slot);
+    }
+
+    let mut out: BTreeMap<String, (u8, ColumnValue)> = BTreeMap::new();
+    for slot in slots {
+        let mut combined: Vec<(u8, ColumnValue)> = Vec::new();
+        // Columnar occurrences first, ascending by type byte.
+        let mut cs: Vec<(u8, ColumnValue)> = cols
+            .iter()
+            .filter(|(s, _, _)| *s == slot)
+            .map(|(_, ty, cv)| (*ty, cv.clone()))
+            .collect();
+        cs.sort_by_key(|(ty, _)| *ty);
+        combined.extend(cs);
+        // Overflow occurrences next, ascending by the canonical encoding of a
+        // one-entry value set (the same order `attrs_raw` stores them).
+        let mut keyed: Vec<(Vec<u8>, (u8, ColumnValue))> = overflow
+            .iter()
+            .filter(|(s, _)| *s == slot)
+            .map(|(_, v)| {
+                let (ty, cv) = resolve_value(v);
+                (canonical_value_bytes(v), (ty.to_u8(), cv))
+            })
+            .collect();
+        keyed.sort_by(|a, b| a.0.cmp(&b.0));
+        combined.extend(keyed.into_iter().map(|(_, entry)| entry));
+        if let Some(winner) = combined.pop() {
+            out.insert(names[slot as usize].to_string(), winner);
         }
     }
     out

--- a/crates/ravel-logseg/src/writer.rs
+++ b/crates/ravel-logseg/src/writer.rs
@@ -908,11 +908,15 @@ impl RlogWriter {
         let mut g_span: Vec<Option<&[u8]>> = Vec::with_capacity(total_rows);
         let mut g_stream_id: Vec<LogStreamId> = Vec::with_capacity(total_rows);
         let mut g_stream_ref: Vec<u32> = Vec::with_capacity(total_rows);
+        // Source batch of each global row, so a block can map a scattered `grow`
+        // back to its source cells when it materializes its rows (#682).
+        let mut g_batch: Vec<u32> = Vec::with_capacity(total_rows);
 
-        for b in batches {
+        for (bi, b) in batches.iter().enumerate() {
             let mut trace_slot = 0usize;
             let mut span_slot = 0usize;
             for row in 0..b.num_rows {
+                g_batch.push(bi as u32);
                 g_ts.push(b.ts_ns[row]);
                 g_obs.push(b.observed_ts_ns[row]);
                 g_sev.push(b.severity_num[row]);
@@ -937,18 +941,12 @@ impl RlogWriter {
             }
         }
 
-        // Per-plan, per-row value and stat arrays: contiguous per column, so a
-        // block's value page is an O(1) index per row, never a gather.
-        let mut col_values: Vec<Vec<Option<ColumnValue>>> = vec![vec![None; total_rows]; num_plans];
-        let mut col_stat: Vec<Vec<Option<ColumnValue>>> = vec![vec![None; total_rows]; num_plans];
-
         // Tracked names (indexed union numstat), interned once into a flat table
-        // so the per-row occurrence lists key by a small slot index instead of
-        // allocating a fresh `String` and a `BTreeMap` node per tracked cell
-        // (the small-allocation churn glibc never returns to the OS, #682). The
-        // table is name-sorted, so ascending slot order is ascending name order:
-        // [`record_level_winners_slot`] reproduces [`record_level_winners`]'s
-        // name-sorted output from it byte for byte.
+        // so a row's tracked occurrences key by a small slot index instead of a
+        // fresh `String` and `BTreeMap` node per cell (#682). The table is
+        // name-sorted, so ascending slot order is ascending name order and
+        // [`record_level_winners_slot`] reproduces [`record_level_winners`]
+        // byte for byte.
         let mut tracked_name_vec: Vec<&str> = indexed_names
             .iter()
             .chain(numstat_names.iter())
@@ -962,21 +960,35 @@ impl RlogWriter {
             .map(|(i, n)| (*n, i as u32))
             .collect();
 
-        // Per-row in-budget columnar occurrences (row.columns), overflow
-        // attributes (attrs_raw source), and the tracked-name occurrences the
-        // merged view is resolved from (keyed by tracked slot, not name).
-        let mut g_cols: Vec<Vec<(u32, ColumnValue)>> = vec![Vec::new(); total_rows];
-        let mut g_overflow: Vec<Vec<(String, AttrValue)>> = vec![Vec::new(); total_rows];
-        let mut tracked_cols: Vec<Vec<(u32, u8, ColumnValue)>> = vec![Vec::new(); total_rows];
-        let mut tracked_overflow: Vec<Vec<(u32, AttrValue)>> = vec![Vec::new(); total_rows];
+        // Per (batch, column) word-level popcount prefix over the presence
+        // bitmap. A block materializes its rows from source (below), and this
+        // lets it find one (column, row)'s dense-cell slot in O(1) instead of
+        // holding every resolved value for the whole batch. At one u32 per 64
+        // rows per column it is a tiny fraction of one value copy; it is the
+        // only whole-batch structure the per-block path adds where the old path
+        // held `col_values`/`col_stat`/`g_cols` for the whole batch (#682).
+        let col_rank: Vec<Vec<Vec<u32>>> = batches
+            .iter()
+            .map(|b| {
+                b.dyn_columns
+                    .iter()
+                    .map(|c| presence_word_prefix(c.validity.bytes()))
+                    .collect()
+            })
+            .collect();
 
+        // `attrs_raw` (whole batch, overflow only) and the value part of each
+        // row's `row_estimate`. Both are needed before the block cut, so they
+        // are computed here in one source pass. Overflow attributes are gathered
+        // in the same order (dyn-column order, then residual order) the row path
+        // folds them, so `canonical_attr_bytes` reproduces it byte for byte; the
+        // estimate reads source cell sizes without copying any value.
+        let mut g_overflow: Vec<Vec<(String, AttrValue)>> = vec![Vec::new(); total_rows];
+        let mut g_est_dyn: Vec<usize> = vec![0; total_rows];
         for (bi, b) in batches.iter().enumerate() {
             let base = bases[bi];
             for c in &b.dyn_columns {
-                let ty_byte = c.field_type.to_u8();
-                let cid_opt = column_lookup(&column_of, &c.name, ty_byte);
-                let tracked = indexed_names.contains(c.name.as_str())
-                    || numstat_names.contains(c.name.as_str());
+                let in_budget = column_lookup(&column_of, &c.name, c.field_type.to_u8()).is_some();
                 let mut slot = 0usize;
                 for row in 0..b.num_rows {
                     if !c.validity.get(row) {
@@ -985,27 +997,10 @@ impl RlogWriter {
                     let cell = &c.cells[slot];
                     slot += 1;
                     let grow = base + row;
-                    let (ty, cv) = resolve_value(cell);
-                    match cid_opt {
-                        Some(cid) => {
-                            let plan_idx = plan_of_cid[&cid];
-                            col_values[plan_idx][grow] = Some(cv.clone());
-                            g_cols[grow].push((cid, cv.clone()));
-                            if tracked {
-                                tracked_cols[grow].push((
-                                    tracked_slot[c.name.as_str()],
-                                    ty.to_u8(),
-                                    cv,
-                                ));
-                            }
-                        }
-                        None => {
-                            g_overflow[grow].push((c.name.clone(), cell.clone()));
-                            if tracked {
-                                tracked_overflow[grow]
-                                    .push((tracked_slot[c.name.as_str()], cell.clone()));
-                            }
-                        }
+                    if in_budget {
+                        g_est_dyn[grow] += columnar_estimate(cell);
+                    } else {
+                        g_overflow[grow].push((c.name.clone(), cell.clone()));
                     }
                 }
             }
@@ -1013,22 +1008,24 @@ impl RlogWriter {
                 let grow = base + row;
                 for (k, v) in extras {
                     g_overflow[grow].push((k.clone(), v.clone()));
-                    let tracked =
-                        indexed_names.contains(k.as_str()) || numstat_names.contains(k.as_str());
-                    if tracked {
-                        tracked_overflow[grow].push((tracked_slot[k.as_str()], v.clone()));
-                    }
                 }
             }
         }
+        let mut g_attrs_raw: Vec<Option<Vec<u8>>> = vec![None; total_rows];
+        for grow in 0..total_rows {
+            if !g_overflow[grow].is_empty() {
+                g_attrs_raw[grow] = Some(canonical_attr_bytes(&g_overflow[grow]));
+            }
+        }
+        drop(g_overflow);
 
         // Dictionary fast path (ADR-0109 decision 3): for each Str/Bytes plan
         // column whose every contributing batch column arrived dictionary-
         // shaped, build one per-object distinct table and a per-global-row
         // index into it. The block string encode and the token bloom then run
         // per distinct value, not per row. A plan column with any plain
-        // contributor stays on the per-row `col_values` path built above,
-        // untouched, so byte-identity with the row path is preserved either way.
+        // contributor falls back to the per-block materialized value page, so
+        // byte-identity with the row path is preserved either way.
         let mut plan_uses_dict = vec![false; num_plans];
         let mut global_dict: Vec<Vec<Vec<u8>>> = vec![Vec::new(); num_plans];
         let mut col_dict_ids: Vec<Vec<Option<u32>>> = vec![Vec::new(); num_plans];
@@ -1083,34 +1080,6 @@ impl RlogWriter {
             .map(|(_, (_, _, cid))| *cid)
             .collect();
 
-        // Finish each row: sort its columnar occurrences by column id (matching
-        // the row path's BTreeMap collection), resolve the merged view, and
-        // project it into POSTINGS terms, NumStat winners, and attrs_raw.
-        let mut g_attrs_raw: Vec<Option<Vec<u8>>> = vec![None; total_rows];
-        let mut g_indexed_terms: Vec<Vec<(u32, ColumnValue)>> = vec![Vec::new(); total_rows];
-        let mut g_stat_winners: Vec<Vec<(u32, ColumnValue)>> = vec![Vec::new(); total_rows];
-        for grow in 0..total_rows {
-            g_cols[grow].sort_by_key(|(cid, _)| *cid);
-            if !g_overflow[grow].is_empty() {
-                g_attrs_raw[grow] = Some(canonical_attr_bytes(&g_overflow[grow]));
-            }
-            let winners = record_level_winners_slot(
-                &tracked_cols[grow],
-                &tracked_overflow[grow],
-                &tracked_name_vec,
-            );
-            let seed = stream_tracked
-                .get(&g_stream_id[grow])
-                .map_or(&[][..], Vec::as_slice);
-            let resolved = resolved_tracked_values(seed, &winners);
-            g_indexed_terms[grow] = indexed_term_columns(&resolved, &indexed_names, &column_of);
-            let stat_winners = stat_winner_columns(&resolved, &numstat_names, &column_of);
-            for (cid, cv) in &stat_winners {
-                col_stat[plan_of_cid[cid]][grow] = Some(cv.clone());
-            }
-            g_stat_winners[grow] = stat_winners;
-        }
-
         // Sort rows by (stream_ref, ts) exactly as the row path sorts
         // ResolvedRows; `sort_by` is stable, so ties keep the appended order.
         let mut perm: Vec<usize> = (0..total_rows).collect();
@@ -1120,7 +1089,8 @@ impl RlogWriter {
                 .then_with(|| g_ts[a].cmp(&g_ts[b]))
         });
 
-        // Chunk into blocks, reproducing chunk_blocks/row_estimate column-wise.
+        // Chunk into blocks, reproducing chunk_blocks/row_estimate. The dynamic
+        // part is precomputed in `g_est_dyn`; the rest is byte-identical.
         let row_estimate = |grow: usize| -> usize {
             let mut est = 40usize;
             est += g_body[grow].len();
@@ -1128,12 +1098,7 @@ impl RlogWriter {
             if let Some(raw) = &g_attrs_raw[grow] {
                 est += raw.len();
             }
-            for (_, v) in &g_cols[grow] {
-                est += match v {
-                    ColumnValue::Str(b) | ColumnValue::Bytes(b) => b.len() + 2,
-                    _ => 8,
-                };
-            }
+            est += g_est_dyn[grow];
             est
         };
         let mut spans: Vec<std::ops::Range<usize>> = Vec::new();
@@ -1178,15 +1143,74 @@ impl RlogWriter {
             let block_rows = &perm[span.clone()];
             let blk_idx_u32 = blk_idx as u32;
 
+            // Materialize only this block's rows from source: each row's
+            // in-budget columnar occurrences (cid-sorted) and its merged-view
+            // POSTINGS terms and NumStat winners. `attrs_raw` is already whole
+            // batch. This is the one copy of one block's cells that bounds the
+            // peak (#682); nothing built here is retained past the block.
+            let n = block_rows.len();
+            let mut blk_cols: Vec<Vec<(u32, ColumnValue)>> = Vec::with_capacity(n);
+            let mut blk_indexed: Vec<Vec<(u32, ColumnValue)>> = Vec::with_capacity(n);
+            let mut blk_stat: Vec<Vec<(u32, ColumnValue)>> = Vec::with_capacity(n);
+            for &grow in block_rows {
+                let bi = g_batch[grow] as usize;
+                let b = &batches[bi];
+                let local = grow - bases[bi];
+                let mut cols: Vec<(u32, ColumnValue)> = Vec::new();
+                let mut t_cols: Vec<(u32, u8, ColumnValue)> = Vec::new();
+                let mut t_over: Vec<(u32, AttrValue)> = Vec::new();
+                for (ci, c) in b.dyn_columns.iter().enumerate() {
+                    if !c.validity.get(local) {
+                        continue;
+                    }
+                    let slot = presence_rank(&col_rank[bi][ci], c.validity.bytes(), local);
+                    let cell = &c.cells[slot];
+                    let tracked = indexed_names.contains(c.name.as_str())
+                        || numstat_names.contains(c.name.as_str());
+                    let (ty, cv) = resolve_value(cell);
+                    match column_lookup(&column_of, &c.name, c.field_type.to_u8()) {
+                        Some(cid) => {
+                            if tracked {
+                                t_cols.push((
+                                    tracked_slot[c.name.as_str()],
+                                    ty.to_u8(),
+                                    cv.clone(),
+                                ));
+                            }
+                            cols.push((cid, cv));
+                        }
+                        None => {
+                            if tracked {
+                                t_over.push((tracked_slot[c.name.as_str()], cell.clone()));
+                            }
+                        }
+                    }
+                }
+                for (k, v) in &b.residual_attrs[local] {
+                    if indexed_names.contains(k.as_str()) || numstat_names.contains(k.as_str()) {
+                        t_over.push((tracked_slot[k.as_str()], v.clone()));
+                    }
+                }
+                cols.sort_by_key(|(cid, _)| *cid);
+                let winners = record_level_winners_slot(&t_cols, &t_over, &tracked_name_vec);
+                let seed = stream_tracked
+                    .get(&g_stream_id[grow])
+                    .map_or(&[][..], Vec::as_slice);
+                let resolved = resolved_tracked_values(seed, &winners);
+                blk_indexed.push(indexed_term_columns(&resolved, &indexed_names, &column_of));
+                blk_stat.push(stat_winner_columns(&resolved, &numstat_names, &column_of));
+                blk_cols.push(cols);
+            }
+
             let mut present_cols: BTreeSet<u32> = BTreeSet::new();
-            for &g in block_rows {
-                for (cid, _) in &g_cols[g] {
+            for cols in &blk_cols {
+                for (cid, _) in cols {
                     present_cols.insert(*cid);
                 }
             }
             let mut plan_cols: BTreeSet<u32> = present_cols.clone();
-            for &g in block_rows {
-                for (cid, _) in &g_stat_winners[g] {
+            for stat in &blk_stat {
+                for (cid, _) in stat {
                     plan_cols.insert(*cid);
                 }
             }
@@ -1197,8 +1221,13 @@ impl RlogWriter {
                     ty: ty_of_column[cid],
                 })
                 .collect();
+            let plan_pos: HashMap<u32, usize> = plans
+                .iter()
+                .enumerate()
+                .map(|(i, p)| (p.column_id, i))
+                .collect();
 
-            // Column-major block inputs, gathered by the sort permutation.
+            // Column-major fixed inputs, gathered by the sort permutation.
             let ts_v: Vec<i64> = block_rows.iter().map(|&g| g_ts[g]).collect();
             let obs_v: Vec<i64> = block_rows.iter().map(|&g| g_obs[g]).collect();
             let sref_v: Vec<u32> = block_rows.iter().map(|&g| g_stream_ref[g]).collect();
@@ -1220,22 +1249,33 @@ impl RlogWriter {
                 .iter()
                 .filter_map(|&g| g_attrs_raw[g].as_deref())
                 .collect();
-            let values_v: Vec<Vec<Option<ColumnValue>>> = plans
+
+            // Per-plan value pages, scattered from this block's materialized
+            // occurrences; dict-path plans carry their page below instead.
+            let mut values_v: Vec<Vec<Option<ColumnValue>>> = plans
                 .iter()
                 .map(|p| {
-                    let plan_idx = plan_of_cid[&p.column_id];
-                    if plan_uses_dict[plan_idx] {
-                        // The dict path below carries this column's page; the
-                        // per-row value gather is skipped.
+                    if plan_uses_dict[plan_of_cid[&p.column_id]] {
                         Vec::new()
                     } else {
-                        block_rows
-                            .iter()
-                            .map(|&g| col_values[plan_idx][g].clone())
-                            .collect()
+                        vec![None; n]
                     }
                 })
                 .collect();
+            for (li, cols) in blk_cols.iter().enumerate() {
+                for (cid, cv) in cols {
+                    if !plan_uses_dict[plan_of_cid[cid]] {
+                        values_v[plan_pos[cid]][li] = Some(cv.clone());
+                    }
+                }
+            }
+            let mut stat_v: Vec<Vec<Option<ColumnValue>>> =
+                plans.iter().map(|_| vec![None; n]).collect();
+            for (li, stat) in blk_stat.iter().enumerate() {
+                for (cid, cv) in stat {
+                    stat_v[plan_pos[cid]][li] = Some(cv.clone());
+                }
+            }
             // Owned per-block dict ids (one Option<index> per block row) for
             // every dict-path plan, referenced by `str_dicts_v` below.
             let str_dict_ids_v: Vec<Option<Vec<Option<u32>>>> = plans
@@ -1259,16 +1299,6 @@ impl RlogWriter {
                         dict: &global_dict[plan_idx],
                         ids,
                     })
-                })
-                .collect();
-            let stat_v: Vec<Vec<Option<ColumnValue>>> = plans
-                .iter()
-                .map(|p| {
-                    let plan_idx = plan_of_cid[&p.column_id];
-                    block_rows
-                        .iter()
-                        .map(|&g| col_stat[plan_idx][g].clone())
-                        .collect()
                 })
                 .collect();
 
@@ -1297,10 +1327,10 @@ impl RlogWriter {
             // Bloom over body, severity_text, and string columns; POSTINGS over
             // each row's merged-view indexed terms.
             let mut builder = BloomBuilder::new(self.cfg.bloom_seed);
-            for &g in block_rows {
+            for (li, &g) in block_rows.iter().enumerate() {
                 insert_text(&mut builder, COL_BODY, g_body[g]);
                 insert_text(&mut builder, COL_SEVERITY_TEXT, g_sevtext[g]);
-                for (cid, v) in &g_cols[g] {
+                for (cid, v) in &blk_cols[li] {
                     if let ColumnValue::Str(bytes) = v {
                         // Dict-path Str columns are tokenized per distinct value
                         // after this loop; skip their per-row occurrence here.
@@ -1309,7 +1339,7 @@ impl RlogWriter {
                         }
                     }
                 }
-                for (cid, v) in &g_indexed_terms[g] {
+                for (cid, v) in &blk_indexed[li] {
                     if postings_capped.contains(cid) {
                         continue;
                     }
@@ -1358,8 +1388,8 @@ impl RlogWriter {
             for cid in &present_cols {
                 *col_blocks.entry(*cid).or_insert(0) += 1;
             }
-            for &g in block_rows {
-                for (cid, _) in &g_cols[g] {
+            for cols in &blk_cols {
+                for (cid, _) in cols {
                     *col_present.entry(*cid).or_insert(0) += 1;
                 }
             }
@@ -1872,6 +1902,61 @@ fn record_level_winners_slot(
         }
     }
     out
+}
+
+/// A per-64-row popcount prefix over a presence bitmap's bytes: `out[w]` is the
+/// number of set bits in the first `w` 8-byte words. Paired with
+/// [`presence_rank`] it turns a `(column, row)` lookup into the column's dense
+/// cell slot into an O(1) probe, so the columnar writer materializes a block's
+/// values from source instead of holding every value for the whole batch (#682).
+fn presence_word_prefix(bytes: &[u8]) -> Vec<u32> {
+    let num_words = bytes.len().div_ceil(8);
+    let mut prefix = Vec::with_capacity(num_words + 1);
+    let mut acc = 0u32;
+    prefix.push(0);
+    for w in 0..num_words {
+        let start = w * 8;
+        let end = (start + 8).min(bytes.len());
+        for &byte in &bytes[start..end] {
+            acc += byte.count_ones();
+        }
+        prefix.push(acc);
+    }
+    prefix
+}
+
+/// The dense-cell slot of present row `local`: the count of set presence bits
+/// before it, which is the number of present rows the column stored ahead of it.
+/// `prefix` is [`presence_word_prefix`] of the same `bytes`. The caller must have
+/// checked `local` is present.
+fn presence_rank(prefix: &[u32], bytes: &[u8], local: usize) -> usize {
+    let w = local / 64;
+    let mut rank = prefix[w] as usize;
+    let byte_start = w * 8;
+    let full_bytes = (local % 64) / 8;
+    for k in 0..full_bytes {
+        rank += bytes[byte_start + k].count_ones() as usize;
+    }
+    let rem = local % 8;
+    if rem != 0 {
+        rank += (bytes[byte_start + full_bytes] & ((1u8 << rem) - 1)).count_ones() as usize;
+    }
+    rank
+}
+
+/// The `row_estimate` contribution of one in-budget columnar cell, read from the
+/// source attribute without resolving (copying) its value. Matches the value
+/// sizing [`row_estimate`] applies to a [`ColumnValue`]: string/bytes columns
+/// count their byte length plus two, every numeric column a flat eight, and a
+/// `List`/`Map` its canonical `Bytes` encoding (the only case that must encode).
+fn columnar_estimate(cell: &ravel_types::logstream::AttrValue) -> usize {
+    use ravel_types::logstream::AttrValue;
+    match cell {
+        AttrValue::Str(s) => s.len() + 2,
+        AttrValue::Bytes(b) => b.len() + 2,
+        AttrValue::I64(_) | AttrValue::F64(_) | AttrValue::Bool(_) => 8,
+        other => canonical_value_bytes(other).len() + 2,
+    }
 }
 
 /// Splits row indices into block spans by record target and an estimated

--- a/crates/ravel-logseg/tests/columnar_writer_memory.rs
+++ b/crates/ravel-logseg/tests/columnar_writer_memory.rs
@@ -1,2 +1,267 @@
 //! Peak-memory and byte-identity regression tests for
-//! `RlogWriter::build_object_columnar`, issue #682.
+//! `RlogWriter::build_object_columnar` (issue #682).
+//!
+//! Before the fix the columnar writer resolved the whole batch into dense
+//! per-column value/stat arrays plus per-row occurrence and merged-view lists,
+//! so peak live memory grew with `--batch-rows`: ~4.0 GB at 65_536 rows on the
+//! synthetic batch below (a 131_072-row, 16-shard load did not fit a 31 GB
+//! host). The fix materializes one block's cells at a time, so the peak is
+//! bounded by one block and is independent of the batch size, without changing
+//! a single output byte.
+//!
+//! This file contains EXACTLY ONE test on purpose: it installs the instrumented
+//! global allocator and measures peak live bytes with a sidecar sampler thread,
+//! so a second test allocating in the same process would pollute the figure
+//! (`cargo test` runs a binary's tests on threads; nextest runs each in its own
+//! process). The workspace forbids `unsafe_code`, so a hand-rolled counting
+//! allocator will not compile; `stats_alloc`'s instrumented allocator (already
+//! used by the ravel-sql/ravel-otlp allocation tests) is used instead, and peak
+//! (max live) is derived by sampling it, since it exposes only cumulative
+//! counters.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::alloc::System;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::thread;
+
+use ravel_logseg::{
+    AttrValue, Bitmap, ColumnarLogBatch, DynColumn, FieldType, LogStreamId, ObjectIdentity,
+    RlogConfig, RlogWriter, VarBytes, stream_attrs_bytes,
+};
+use stats_alloc::{INSTRUMENTED_SYSTEM, StatsAlloc};
+
+#[global_allocator]
+static GLOBAL: &StatsAlloc<System> = &INSTRUMENTED_SYSTEM;
+
+const NUM_COLUMNS: usize = 105;
+
+/// BLAKE3 of the synthetic object at each batch size, computed against the
+/// PRE-FIX writer (before this change) and unchanged by every step of the fix.
+/// A mismatch means the fix altered an output byte, which it must never do.
+const HASH_8K: &str = "c13ffbb6ebb2f8aacd29302267f5a3c052ddc61c8332735d2afd7fc782c81071";
+const HASH_64K: &str = "0da2d9e1bf96a9c5ff9a79de9ec037dde78255ed2ef741887bd2f0243750017a";
+
+/// Peak-live-bytes bound as a multiple of the total cell payload `P`. Measured
+/// K = peak(65536) / P = 1.865 after the fix; rounded up to the next 0.5. The
+/// pre-fix writer measured K ~= 44 (peak ~4.0 GB against P ~90 MB), so this
+/// bound is red before the fix by more than an order of magnitude.
+const K_PEAK_OVER_P: f64 = 2.0;
+
+/// Peak-memory ratio between the two batch sizes. The fix makes the peak
+/// independent of batch size (measured 1.16); the pre-fix writer's peak is
+/// linear in batch size, so this ratio was ~7 (8x the rows, ~8x the peak).
+const MAX_BATCH_PEAK_RATIO: f64 = 2.0;
+
+/// A deterministic pool of variable-length strings (8..=64 bytes). Low
+/// cardinality so the compressed BLOCKS section stays small relative to one
+/// block's materialized working set, which is what the batch-size-independence
+/// bound measures; `P` still counts every cell's full byte length, so the
+/// magnitude bound stays meaningful.
+fn string_pool() -> Vec<Vec<u8>> {
+    (0..128u32)
+        .map(|i| {
+            let len = 8 + (i as usize % 57);
+            (0..len)
+                .map(|j| b'a' + ((i as u8 + j as u8) % 26))
+                .collect()
+        })
+        .collect()
+}
+
+/// Builds a synthetic columnar batch of `n` rows by `NUM_COLUMNS` mixed-type
+/// dynamic columns (i64/str/bool/f64 cycled), strings 8..64 bytes, ~10% nulls,
+/// one stream, deterministically. Returns the batch and `P`, the total resolved
+/// cell payload in bytes (string/bytes cells count their length, numeric cells
+/// 8), computed from the batch itself.
+fn build_batch(n: usize) -> (ColumnarLogBatch, u64) {
+    let pool = string_pool();
+    let mut batch = ColumnarLogBatch::new();
+    batch.num_rows = n;
+
+    let mut body = VarBytes::new();
+    let mut sev = VarBytes::new();
+    for row in 0..n {
+        batch.ts_ns.push(row as i64);
+        batch.observed_ts_ns.push(row as i64);
+        batch.severity_num.push(9);
+        batch.flags.push(0);
+        body.push(b"log line");
+        sev.push(b"INFO");
+        batch.trace_id_validity.push(false);
+        batch.span_id_validity.push(false);
+        batch.stream_refs.push(0);
+    }
+    batch.body = body;
+    batch.severity_text = sev;
+
+    let sid = LogStreamId([7u8; 16]);
+    batch.stream_ids.push(sid);
+    batch.stream_attrs.push(stream_attrs_bytes(
+        &[("service.name".into(), AttrValue::Str("svc".into()))],
+        "scope",
+        "1.0",
+        &[],
+    ));
+
+    let mut p: u64 = 0;
+    for j in 0..NUM_COLUMNS {
+        let kind = j % 4;
+        let field_type = match kind {
+            0 => FieldType::Str,
+            1 => FieldType::I64,
+            2 => FieldType::Bool,
+            _ => FieldType::F64,
+        };
+        let mut validity = Bitmap::new();
+        let mut cells: Vec<AttrValue> = Vec::new();
+        for row in 0..n {
+            let present = (row * 31 + j * 7) % 10 != 0;
+            validity.push(present);
+            if !present {
+                continue;
+            }
+            let value = match kind {
+                0 => {
+                    let s = &pool[(row * 7 + j * 13) % pool.len()];
+                    p += s.len() as u64;
+                    AttrValue::Str(String::from_utf8(s.clone()).unwrap())
+                }
+                1 => {
+                    p += 8;
+                    AttrValue::I64(row as i64 * 1000 + j as i64)
+                }
+                2 => {
+                    p += 8;
+                    AttrValue::Bool((row + j) % 2 == 0)
+                }
+                _ => {
+                    p += 8;
+                    AttrValue::F64(row as f64 * 0.5 + j as f64)
+                }
+            };
+            cells.push(value);
+        }
+        batch.dyn_columns.push(DynColumn {
+            name: format!("attr_{j:03}"),
+            field_type,
+            cells,
+            validity,
+        });
+    }
+    batch.residual_attrs = vec![Vec::new(); n];
+    (batch, p)
+}
+
+fn cfg() -> RlogConfig {
+    RlogConfig {
+        // Record-count governed, uniform 8192-row blocks at both batch sizes,
+        // so one block's working set is the same constant regardless of the
+        // batch size; block_max_bytes is lifted out of the way.
+        block_target_records: 8192,
+        block_max_bytes: 1 << 30,
+        ..RlogConfig::default()
+    }
+}
+
+fn identity() -> ObjectIdentity {
+    ObjectIdentity {
+        tenant_hash: [1u8; 16],
+        shard: 0,
+        writer_id: [2u8; 16],
+        writer_epoch: 1,
+        writer_seq: 1,
+    }
+}
+
+/// Runs `f`, sampling live allocated bytes from a spinning sidecar thread, and
+/// returns `f`'s result plus the peak live-byte delta observed during the call.
+/// The peak is a plateau (the block working set is held across each block's
+/// zstd encode), so the sampler catches the same maximum deterministically.
+fn measure_peak<R, F: FnOnce() -> R>(f: F) -> (R, usize) {
+    let stop = Arc::new(AtomicBool::new(false));
+    let peak = Arc::new(AtomicUsize::new(0));
+    let base = INSTRUMENTED_SYSTEM.stats();
+    let s2 = stop.clone();
+    let p2 = peak.clone();
+    let handle = thread::spawn(move || {
+        loop {
+            // Live bytes = allocated - deallocated. stats_alloc already folds a
+            // realloc's growth into bytes_allocated (and a shrink into
+            // bytes_deallocated), so bytes_reallocated must NOT be added here or
+            // every Vec growth would count twice.
+            let cur = INSTRUMENTED_SYSTEM.stats();
+            let live = (cur.bytes_allocated as i64 - base.bytes_allocated as i64)
+                - (cur.bytes_deallocated as i64 - base.bytes_deallocated as i64);
+            if live > 0 {
+                p2.fetch_max(live as usize, Ordering::Relaxed);
+            }
+            if s2.load(Ordering::Relaxed) {
+                break;
+            }
+            std::hint::spin_loop();
+        }
+    });
+    let r = f();
+    stop.store(true, Ordering::Relaxed);
+    handle.join().unwrap();
+    (r, peak.load(Ordering::Relaxed))
+}
+
+/// Builds one object through the columnar writer, returning its bytes, `P`, and
+/// the peak live bytes during `finish`.
+fn build_object(n: usize) -> (Vec<u8>, u64, usize) {
+    let (batch, p) = build_batch(n);
+    let (bytes, peak) = measure_peak(|| {
+        let mut w = RlogWriter::new(cfg(), identity());
+        w.push_columnar(batch).expect("push");
+        w.finish().expect("finish")
+    });
+    (bytes, p, peak)
+}
+
+#[test]
+fn columnar_writer_peak_is_bounded_and_batch_independent() {
+    let (obj8k, _p8k, peak8k) = build_object(8_192);
+    let (obj64k, p64k, peak64k) = build_object(65_536);
+
+    // Byte identity: the fix must not change any output byte.
+    assert_eq!(
+        blake3::hash(&obj8k).to_hex().as_str(),
+        HASH_8K,
+        "columnar object bytes changed at 8192 rows"
+    );
+    assert_eq!(
+        blake3::hash(&obj64k).to_hex().as_str(),
+        HASH_64K,
+        "columnar object bytes changed at 65536 rows"
+    );
+
+    // Magnitude: peak live bytes at 65536 rows are within K * P. Pinned
+    // proportionally to the payload, not to a flat floor: the pre-fix writer's
+    // dense whole-batch arrays put this at ~44 * P.
+    let bound = (K_PEAK_OVER_P * p64k as f64) as usize;
+    assert!(
+        peak64k <= bound,
+        "peak {peak64k} exceeds K*P: K={K_PEAK_OVER_P}, P={p64k}, bound={bound} \
+         (measured K={:.3})",
+        peak64k as f64 / p64k as f64,
+    );
+
+    // Batch-size independence (what the per-block materialization exists for):
+    // 8x the rows must not cost anywhere near 8x the peak. Pre-fix this ratio
+    // is ~7 (linear in batch size).
+    let ratio = peak64k as f64 / peak8k as f64;
+    assert!(
+        ratio <= MAX_BATCH_PEAK_RATIO,
+        "peak ratio {ratio:.3} exceeds {MAX_BATCH_PEAK_RATIO}: \
+         peak(8192)={peak8k}, peak(65536)={peak64k}",
+    );
+
+    eprintln!(
+        "peak(8192)={peak8k} peak(65536)={peak64k} P(65536)={p64k} \
+         K={:.3} ratio={ratio:.3}",
+        peak64k as f64 / p64k as f64,
+    );
+}

--- a/crates/ravel-logseg/tests/columnar_writer_memory.rs
+++ b/crates/ravel-logseg/tests/columnar_writer_memory.rs
@@ -1,0 +1,2 @@
+//! Peak-memory and byte-identity regression tests for
+//! `RlogWriter::build_object_columnar`, issue #682.


### PR DESCRIPTION
build_object_columnar resolved a whole batch into dense per-column value
and stat arrays plus per-row occurrence and merged-view lists before it
cut a single block, and kept three to four copies of every cell alive at
once. Peak live memory therefore grew with --batch-rows: a 100M-row
ClickBench load at 65,536 rows peaked at 25.6 GB RSS, and the 131,072-row
batches a 16-shard load needs (the 8192-rows-per-shard floor) did not fit
a 31 GB host at all.

Three steps, each byte-identical on the wire:

Intern the tracked column names once per call into a flat table and carry
slot indices, removing a per-row String clone and two per-row BTreeMaps.

Decide the block cut first and materialize one block's cells at a time,
so the peak is bounded by a block rather than by the batch.

Keep one copy of a block's cells: consume the values at block-write time
instead of cloning them, and read only the column id where only the id
was needed.

Measured on a synthetic 105-column batch: peak 2.67 GB to 168 MB at
65,536 rows, and the peak is now flat across batch sizes (ratio 1.16
between 8,192 and 65,536 rows, was about 7). The test pins peak live
bytes as a multiple of the batch's own cell payload and pins the object's
BLAKE3 at both batch sizes against hashes computed from the pre-fix
writer, so an output-byte change fails it.

Fixes: #682
Refs: #680
