### PR TITLE
feat(ravel-sql): whole-segment fast path for predicate-free full-window logs

### DIFF
--- a/crates/ravel-bench/src/logs_scan_scaling.rs
+++ b/crates/ravel-bench/src/logs_scan_scaling.rs
@@ -44,6 +44,22 @@
 //! segments, so this measures it over the fixture's full segment set and reports
 //! the serial wall time next to the same prunes issued concurrently.
 //!
+//! # #693 part 3 and why this fixture still runs the plan phase
+//!
+//! Issue #693 part 3 lets a predicate-free, full-window scan skip the plan phase
+//! entirely and read each relevant segment whole in one GET (`ravel_sql`'s
+//! `LogsScanExec::whole_segment_fast_path`). That fast path is gated on the same
+//! conjuncts `plan_segment`'s own fast path uses, which include
+//! `object_size > block_range_threshold`: the plan/scan re-probe it eliminates
+//! only exists above the block-range threshold, and at or below it the plan and
+//! scan reads already coalesce on the one `(0, object_size)` cache key. This
+//! fixture's objects are small (96 records, 6 blocks), well below the default
+//! 512 KiB threshold, so they stay on the plan-then-stripe path and every figure
+//! here -- the [`PlanningLatency`] measurement and the per-combo GET counts --
+//! is unchanged by #693 part 3. The fast path's request-count law (one
+//! whole-object read per segment, zero suffix probes) is measured instead by the
+//! above-threshold integration tests in `ravel-sql` and `ravel-query`.
+//!
 //! Report-only: it never changes library behavior. Gated on the `sql-latency`
 //! feature, like the other SQL scaling benches.
 #![allow(clippy::expect_used, clippy::unwrap_used)]
@@ -393,7 +409,7 @@ async fn measure_planning_latency(
             .plan_segment(seg, tenant_hash, &query, &accounting)
             .await
             .expect("plan segment");
-        if let Some((survivors, _)) = planned {
+        if let Some((survivors, _, _)) = planned {
             total_blocks += survivors;
         }
     }
@@ -418,7 +434,7 @@ async fn measure_planning_latency(
     assert_eq!(
         planned
             .iter()
-            .filter_map(|p| p.as_ref().map(|(s, _)| *s))
+            .filter_map(|p| p.as_ref().map(|(s, _, _)| *s))
             .sum::<usize>(),
         total_blocks,
         "both planning passes must prune to the same surviving-block count"

--- a/crates/ravel-query/src/log_fetcher.rs
+++ b/crates/ravel-query/src/log_fetcher.rs
@@ -141,14 +141,13 @@ pub struct LogQuery {
     /// which reads and returns exactly what it did before this field existed.
     ///
     /// The caller populates this from the resolved snapshot's attached
-    /// predicates. The resolver already surfaces them: it attaches
-    /// every pending request to `Snapshot::pending_erasure` on each resolve.
-    /// What is still missing is the last hop -- the `ravel-sql` scans that
-    /// build this query (`logs_scan`, `alerts_scan`, `audit_scan`) do not yet
-    /// map that field into this one, so on the SQL log surface this stays
-    /// empty and log erasure exclusion is inert. The metric surface needs no
-    /// such hop: `QueryEngine` reads `Snapshot::pending_erasure` directly at
-    /// its own fetch funnels.
+    /// predicates. The resolver already surfaces them: it attaches every pending
+    /// request to `Snapshot::pending_erasure` on each resolve. The SQL log scan
+    /// makes the last hop: `ravel_sql::logs_scan::LogsScanExec::execute` calls
+    /// [`LogQuery::with_erasure`] with the snapshot's pending predicates, so log
+    /// erasure exclusion is live on the SQL surface. The metric surface needs no
+    /// such hop: `QueryEngine` reads `Snapshot::pending_erasure` directly at its
+    /// own fetch funnels.
     pub erasure: Vec<ErasurePredicate>,
 }
 
@@ -573,6 +572,19 @@ impl LogSegmentFetcher {
         self.cache.is_some()
     }
 
+    /// The object-size threshold above which a tenant-aware fetch reads only
+    /// pruning-relevant blocks (ADR-0107,
+    /// [`with_block_range_threshold`](Self::with_block_range_threshold)). Exposed
+    /// so `ravel_sql::logs_scan`'s predicate-free full-window fast path (#693
+    /// part 3) can decide, with no I/O, whether a segment is in the band where
+    /// skipping the plan phase and reading the whole object in one GET actually
+    /// saves a probe: at or below this size the whole-object read is already the
+    /// only GET, so the fast path adds nothing.
+    #[must_use]
+    pub fn block_range_threshold(&self) -> u64 {
+        self.block_range_threshold
+    }
+
     /// Per-object relevance from the catalog summary alone, with no object
     /// read: true iff the segment's event-ts span (`SegmentRef`'s
     /// `min_event_ts_ns..=max_event_ts_ns`, the same bounds the footer carries)
@@ -837,6 +849,56 @@ impl LogSegmentFetcher {
         }))
     }
 
+    /// Whole-object streaming scan for the predicate-free full-window
+    /// whole-segment path (#693 part 3): reads the ENTIRE object in one
+    /// [`GetRange::Full`] GET, bypassing the block-range probe-and-range protocol
+    /// entirely, then opens the pruned, column-projected scan over all of its
+    /// blocks.
+    ///
+    /// This is the counterpart of
+    /// [`scan_accounted_with_tenant`](Self::scan_accounted_with_tenant) for a
+    /// segment that `ravel_sql::logs_scan` has proved (with zero I/O, from the
+    /// resolved snapshot) is fully contained in a predicate-free query window: it
+    /// is going to read every block, so a whole-object GET is strictly optimal --
+    /// no suffix probe, no per-block ranges, no coverage computation. Above the
+    /// block-range threshold `scan_accounted_with_tenant` would instead issue a
+    /// probe and then (all blocks being candidates) a coverage-crossover
+    /// whole-object GET, i.e. two GETs where this issues one. The whole object is
+    /// keyed `(0, object_size)`, the same key
+    /// [`tenant_bytes`](Self::tenant_bytes)'s whole-object read and
+    /// [`BlockRangeFetcher::fetch_object`]'s crossovers use, so it composes with
+    /// them under the cache's single-flight rather than adding a distinct extent.
+    ///
+    /// A single GET observes one object state, so no [`EtagPin`] is needed: the
+    /// multi-GET consistency the block-range path must defend does not arise here.
+    pub async fn scan_whole_accounted_with_tenant(
+        &self,
+        seg_ref: &SegmentRef,
+        tenant_hash: TenantHash,
+        query: &LogQuery,
+        columns: &ColumnSelection,
+        accounting: &QueryAccounting,
+    ) -> Result<Option<LogSegmentScan>, LogFetchError> {
+        if !Self::ts_range_relevant(seg_ref, query.ts_min_ns, query.ts_max_ns) {
+            return Ok(None);
+        }
+        let bytes = self
+            .whole_object_bytes(seg_ref, tenant_hash, accounting)
+            .await?;
+        let key = &seg_ref.data_object_key;
+        let span = decode_span();
+        let scan = span.in_scope(|| self.open_scan(key, &bytes, query, columns))?;
+        Ok(Some(LogSegmentScan {
+            bytes,
+            scan,
+            erasure: query.erasure.clone(),
+            span,
+            key: key.to_string(),
+            accounting: accounting.clone(),
+            finished: false,
+        }))
+    }
+
     /// Prune one segment for intra-segment scan partitioning (ADR-0102) WITHOUT
     /// decoding any block: returns how many of its blocks survive this query's
     /// pruning, plus the whole-segment [`ScanStats`] the prune produced, or
@@ -850,13 +912,22 @@ impl LogSegmentFetcher {
     /// nothing (`blocks_scanned`/`pages_*` in the returned stats are therefore
     /// zero; the totals describe the whole segment). The byte read goes through
     /// the same cache-aware funnel [`scan_accounted_with_tenant`](Self::
-    /// scan_accounted_with_tenant) uses, so in production it is single-flight
-    /// coalesced with the per-partition subset scans that follow rather than
-    /// issuing an extra distinct GET. That holds on both read shapes: one
-    /// whole-object key at or below
-    /// [`with_block_range_threshold`](Self::with_block_range_threshold), and
-    /// per-extent keys (probe, sections, blocks) above it, each of which the
-    /// following subset scans hit rather than re-fetch (ADR-0107).
+    /// scan_accounted_with_tenant) uses and admits the same per-extent cache
+    /// entries.
+    ///
+    /// It does NOT single-flight with the per-partition subset scans that
+    /// follow, though: `ravel_sql::logs_scan` awaits the whole plan pass behind a
+    /// `OnceCell` barrier before any partition drains, so the plan read is the
+    /// FIRST, cold touch of each extent and completes before the subset scans
+    /// even start -- there is no concurrent in-flight GET for them to collapse
+    /// onto. A subset scan then either reuses a cache entry the plan admitted or,
+    /// if it was already evicted, issues its own GET (issue #691 measured the
+    /// probe landing in S3-FIFO probation at freq 0 and being evicted before the
+    /// scan). The way to avoid the extra read is not to coalesce it but to
+    /// eliminate it: #693 part 3 carries this footer forward
+    /// ([`fetch_object_with_footer`](Self::fetch_object_with_footer)) so a subset
+    /// scan skips its own probe, and the predicate-free full-window whole-segment
+    /// path skips the plan pass entirely.
     ///
     /// [`scan_accounted_with_tenant`]: Self::scan_accounted_with_tenant
     pub async fn plan_segment(
@@ -865,7 +936,7 @@ impl LogSegmentFetcher {
         tenant_hash: TenantHash,
         query: &LogQuery,
         accounting: &QueryAccounting,
-    ) -> Result<Option<(usize, ScanStats)>, LogFetchError> {
+    ) -> Result<Option<(usize, ScanStats, Option<footer::LogFooter>)>, LogFetchError> {
         // Fast path (#693): a query with no block-level predicate whose ts
         // window fully CONTAINS the segment's span prunes nothing -- every block
         // survives -- so the survivor count is the footer's `block_count` and no
@@ -893,10 +964,10 @@ impl LogSegmentFetcher {
             && query.ts_min_ns <= seg_ref.min_event_ts_ns
             && seg_ref.max_event_ts_ns <= query.ts_max_ns
         {
-            return Ok(Some(
-                self.plan_segment_fast(seg_ref, tenant_hash, accounting)
-                    .await?,
-            ));
+            let (n, stats, footer) = self
+                .plan_segment_fast(seg_ref, tenant_hash, accounting)
+                .await?;
+            return Ok(Some((n, stats, Some(footer))));
         }
 
         let Some(bytes) = self
@@ -908,12 +979,20 @@ impl LogSegmentFetcher {
         let key = &seg_ref.data_object_key;
         let span = decode_span();
         let scan = span.in_scope(|| self.open_scan(key, &bytes, query, &ColumnSelection::all()))?;
-        Ok(Some((scan.remaining_blocks(), scan.stats())))
+        // The slow branch decodes nothing that carries a reusable footer to the
+        // per-partition subset opens (#693 part 3, deliverable 2): a predicated
+        // or partially-overlapping query does not run `plan_segment_fast`, so
+        // there is no plan-phase footer to hand forward and each subset open
+        // establishes its own etag pin with its own suffix probe.
+        Ok(Some((scan.remaining_blocks(), scan.stats(), None)))
     }
 
     /// The predicate-free plan fast path (#693): read only the footer via the
     /// ADR-0107 suffix probe and derive the whole-segment plan counts from
-    /// `footer.block_count` without fetching or decoding any block.
+    /// `footer.block_count` without fetching or decoding any block. Returns the
+    /// parsed [`footer::LogFooter`] alongside the counts so the per-partition
+    /// subset opens can reuse it and skip re-probing (#693 part 3, deliverable
+    /// 2; see [`fetch_object_with_footer`](Self::fetch_object_with_footer)).
     ///
     /// For a genuinely predicate-free, ts-contained query these are exactly the
     /// counts real pruning would compute: every block survives every stage, so
@@ -929,7 +1008,7 @@ impl LogSegmentFetcher {
         seg_ref: &SegmentRef,
         tenant_hash: TenantHash,
         accounting: &QueryAccounting,
-    ) -> Result<(usize, ScanStats), LogFetchError> {
+    ) -> Result<(usize, ScanStats, footer::LogFooter), LogFetchError> {
         // The `page_fetch` phase span the slow path also carries, so the trace
         // shows the probe this path issues. `s3_bytes` reports block bytes only
         // (zero here, matching the slow path's block-range branch convention);
@@ -969,7 +1048,7 @@ impl LogSegmentFetcher {
             bloom_degraded: false,
             postings_degraded: false,
         };
-        Ok((n, plan_stats))
+        Ok((n, plan_stats, footer))
     }
 
     /// [`scan_accounted_with_tenant`](Self::scan_accounted_with_tenant),
@@ -986,7 +1065,16 @@ impl LogSegmentFetcher {
     /// totals from being counted once per partition (see `ravel_sql::
     /// logs_scan`).
     ///
+    /// `footer`, when `Some`, is the [`footer::LogFooter`] a prior
+    /// [`plan_segment`](Self::plan_segment) fast path already read for this exact
+    /// (immutable) object (#693 part 3, deliverable 2). Supplying it lets the
+    /// block-range read skip its own etag-establishing suffix probe and pin on
+    /// the first section/block GET instead (see
+    /// [`fetch_object_with_footer`](Self::fetch_object_with_footer)); `None`
+    /// probes as before. It changes only the read shape, never the bytes decoded.
+    ///
     /// [`scan_accounted_with_tenant`]: Self::scan_accounted_with_tenant
+    #[allow(clippy::too_many_arguments)]
     pub async fn scan_accounted_with_tenant_subset(
         &self,
         seg_ref: &SegmentRef,
@@ -994,10 +1082,11 @@ impl LogSegmentFetcher {
         query: &LogQuery,
         columns: &ColumnSelection,
         indices: &[usize],
+        footer: Option<&footer::LogFooter>,
         accounting: &QueryAccounting,
     ) -> Result<Option<LogSegmentScan>, LogFetchError> {
         let Some(bytes) = self
-            .tenant_bytes(seg_ref, tenant_hash, query, accounting)
+            .tenant_bytes_with_footer(seg_ref, tenant_hash, query, footer, accounting)
             .await?
         else {
             return Ok(None);
@@ -1028,10 +1117,28 @@ impl LogSegmentFetcher {
         query: &LogQuery,
         accounting: &QueryAccounting,
     ) -> Result<Option<Bytes>, LogFetchError> {
+        self.tenant_bytes_with_footer(seg_ref, tenant_hash, query, None, accounting)
+            .await
+    }
+
+    /// [`tenant_bytes`](Self::tenant_bytes), optionally carrying a plan-phase
+    /// [`footer::LogFooter`] (#693 part 3, deliverable 2). When `footer` is
+    /// `Some` and the object is above the block-range threshold, the block-range
+    /// read skips its own suffix probe and uses the carried footer, pinning the
+    /// etag on the first section/block GET instead. `None` is the unchanged
+    /// probe-first behavior. Below the threshold the whole-object read never
+    /// probes anyway, so the footer is irrelevant there.
+    async fn tenant_bytes_with_footer(
+        &self,
+        seg_ref: &SegmentRef,
+        tenant_hash: TenantHash,
+        query: &LogQuery,
+        footer: Option<&footer::LogFooter>,
+        accounting: &QueryAccounting,
+    ) -> Result<Option<Bytes>, LogFetchError> {
         if !Self::ts_range_relevant(seg_ref, query.ts_min_ns, query.ts_max_ns) {
             return Ok(None);
         }
-        let key = &seg_ref.data_object_key;
 
         // ADR-0107: an object above the block-range threshold is fetched by
         // reading only the blocks skip-index pruning proved relevant, not the
@@ -1048,11 +1155,12 @@ impl LogSegmentFetcher {
             );
             let (bytes, stats) = async {
                 self.block_range
-                    .fetch_object(
+                    .fetch_object_with_footer(
                         seg_ref,
                         tenant_hash,
                         query.ts_min_ns,
                         query.ts_max_ns,
+                        footer,
                         accounting,
                     )
                     .await
@@ -1064,6 +1172,29 @@ impl LogSegmentFetcher {
             fetch_span.record("s3_bytes", stats.block_bytes_fetched);
             return Ok(Some(bytes));
         }
+
+        Ok(Some(
+            self.whole_object_bytes(seg_ref, tenant_hash, accounting)
+                .await?,
+        ))
+    }
+
+    /// One whole-object [`GetRange::Full`] read, cache-keyed `(0, object_size)`,
+    /// with the `page_fetch` span and accounting the tenant-aware funnels share.
+    /// The caller has already decided the object is relevant; this only fetches.
+    ///
+    /// Used by the below-threshold branch of
+    /// [`tenant_bytes_with_footer`](Self::tenant_bytes_with_footer) and by the
+    /// predicate-free full-window whole-segment path
+    /// ([`scan_whole_accounted_with_tenant`](Self::scan_whole_accounted_with_tenant),
+    /// #693 part 3), which reads the whole object in one GET regardless of size.
+    async fn whole_object_bytes(
+        &self,
+        seg_ref: &SegmentRef,
+        tenant_hash: TenantHash,
+        accounting: &QueryAccounting,
+    ) -> Result<Bytes, LogFetchError> {
+        let key = &seg_ref.data_object_key;
 
         // Same two phases as `fetch_accounted`, spanned on the path production
         // log/alerts/audit traffic actually takes (ADR-0044 decision 5): the
@@ -1098,7 +1229,7 @@ impl LogSegmentFetcher {
             accounting.add_s3_bytes(AccountedOp::Get, got.data.len() as u64);
             fetch_span.record("s3_requests", 1u64);
             fetch_span.record("s3_bytes", got.data.len() as u64);
-            return Ok(Some(got.data));
+            return Ok(got.data);
         };
 
         let cache_key = CacheKey::new(tenant_hash.0, seg_ref.content_hash, 0, seg_ref.object_size);
@@ -1142,7 +1273,7 @@ impl LogSegmentFetcher {
                 fetch_span.record("s3_bytes", bytes.len() as u64);
             }
         }
-        Ok(Some(bytes))
+        Ok(bytes)
     }
 
     /// Runs [`scan_bytes`](Self::scan_bytes) inside the log path's `decode`
@@ -1779,6 +1910,37 @@ impl BlockRangeFetcher {
         ts_max_ns: i64,
         accounting: &QueryAccounting,
     ) -> Result<(Bytes, BlockRangeStats), LogFetchError> {
+        self.fetch_object_with_footer(seg_ref, tenant_hash, ts_min_ns, ts_max_ns, None, accounting)
+            .await
+    }
+
+    /// [`fetch_object`](Self::fetch_object), optionally reusing a
+    /// [`footer::LogFooter`] a prior plan phase already read for this exact
+    /// (immutable) object (#693 part 3, deliverable 2).
+    ///
+    /// When `plan_footer` is `Some`, the etag-establishing suffix probe is
+    /// skipped: the carried footer already gives every section's offset and
+    /// length, so the read goes straight to fetching SKIP_IDX, the remaining
+    /// directory sections, and the candidate blocks. The [`EtagPin`] is then
+    /// established on the FIRST of those live GETs
+    /// ([`store_get_pinned`](Self::store_get_pinned)) rather than on the probe,
+    /// and still fails closed: a mid-sequence replacement makes a later live GET
+    /// report a different etag ([`LogFetchError::EtagChanged`]), and a
+    /// replacement that predates the whole sequence is caught by the carried
+    /// footer's per-section crc (a section read at the old offset from a
+    /// different object fails its stored `crc32c`, a hard [`LogFetchError::Corrupt`]).
+    /// Either way the fetch errors rather than assembling bytes from two object
+    /// states. `None` keeps the probe-first behavior unchanged.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn fetch_object_with_footer(
+        &self,
+        seg_ref: &SegmentRef,
+        tenant_hash: TenantHash,
+        ts_min_ns: i64,
+        ts_max_ns: i64,
+        plan_footer: Option<&footer::LogFooter>,
+        accounting: &QueryAccounting,
+    ) -> Result<(Bytes, BlockRangeStats), LogFetchError> {
         let key = seg_ref.data_object_key.as_str();
         let mut stats = BlockRangeStats::default();
         let pin = EtagPin::default();
@@ -1829,60 +1991,71 @@ impl BlockRangeFetcher {
         // footer parsed at wrong absolute offsets is a `Corrupt`.
         let total_size = seg_ref.object_size;
         let total = usize::try_from(total_size).map_err(|_| corrupt_range(key))?;
-
-        // Etag-establishing probe: a suffix GET that pins the etag every later
-        // live GET is checked against, and carries the footer (and, for a small
-        // object, the whole tail directory). Cache-routed like every other GET
-        // here, so concurrent partitions' probes collapse onto one request.
-        let suffix = self.suffix_len.min(total_size);
-        let probe_start = total_size - suffix;
-        let (probe_bytes, probe_live) = self
-            .cached_extent(
-                seg_ref,
-                tenant_hash,
-                probe_start,
-                suffix,
-                GetRange::Suffix(suffix),
-                &pin,
-                accounting,
-            )
-            .await?;
-        if probe_live {
-            stats.probe_gets = 1;
-        }
-
         let mut asm = ObjectAssembler::new(total);
-        asm.place(key, probe_start, &probe_bytes)?;
 
-        // Footer: parse from the probe suffix, chasing one range if the suffix
-        // did not cover the whole footer (mirrors `SegmentFetcher::open_segment`).
-        let footer = match open_from_suffix(&probe_bytes, total_size)
-            .map_err(|source| corrupt(key, source))?
-        {
-            SuffixOutcome::Ready(footer) => footer,
-            SuffixOutcome::NeedRange { offset, len } => {
-                let (bytes, live) = self
+        // Footer: reused from the plan phase when carried (deliverable 2), else
+        // read via the etag-establishing suffix probe. The probe is a suffix GET
+        // that pins the etag every later live GET is checked against and carries
+        // the footer (and, for a small object, the whole tail directory);
+        // cache-routed like every other GET here, so concurrent partitions'
+        // probes collapse onto one request. When the footer is carried the probe
+        // is skipped entirely and the pin is established below on the first live
+        // section/block GET instead; the carried footer's per-section crc still
+        // catches a replaced object (see the method doc).
+        let footer = match plan_footer {
+            Some(f) => f.clone(),
+            None => {
+                let suffix = self.suffix_len.min(total_size);
+                let probe_start = total_size - suffix;
+                let (probe_bytes, probe_live) = self
                     .cached_extent(
                         seg_ref,
                         tenant_hash,
-                        offset,
-                        len,
-                        GetRange::Range(offset, offset + len),
+                        probe_start,
+                        suffix,
+                        GetRange::Suffix(suffix),
                         &pin,
                         accounting,
                     )
                     .await?;
-                if live {
-                    stats.probe_gets += 1;
+                if probe_live {
+                    stats.probe_gets = 1;
                 }
-                asm.place(key, offset, &bytes)?;
-                match open_from_suffix(&bytes, total_size).map_err(|source| corrupt(key, source))? {
+                asm.place(key, probe_start, &probe_bytes)?;
+                // Parse from the probe suffix, chasing one range if the suffix
+                // did not cover the whole footer (mirrors
+                // `SegmentFetcher::open_segment`).
+                match open_from_suffix(&probe_bytes, total_size)
+                    .map_err(|source| corrupt(key, source))?
+                {
                     SuffixOutcome::Ready(footer) => footer,
-                    SuffixOutcome::NeedRange { .. } => {
-                        return Err(corrupt(
-                            key,
-                            LogSegError::Corrupted("footer not covered".into()),
-                        ));
+                    SuffixOutcome::NeedRange { offset, len } => {
+                        let (bytes, live) = self
+                            .cached_extent(
+                                seg_ref,
+                                tenant_hash,
+                                offset,
+                                len,
+                                GetRange::Range(offset, offset + len),
+                                &pin,
+                                accounting,
+                            )
+                            .await?;
+                        if live {
+                            stats.probe_gets += 1;
+                        }
+                        asm.place(key, offset, &bytes)?;
+                        match open_from_suffix(&bytes, total_size)
+                            .map_err(|source| corrupt(key, source))?
+                        {
+                            SuffixOutcome::Ready(footer) => footer,
+                            SuffixOutcome::NeedRange { .. } => {
+                                return Err(corrupt(
+                                    key,
+                                    LogSegError::Corrupted("footer not covered".into()),
+                                ));
+                            }
+                        }
                     }
                 }
             }
@@ -1964,6 +2137,42 @@ impl BlockRangeFetcher {
             // a subset composes with this one (ADR-0107 decision 3).
             self.admit_blocks_from_whole(seg_ref, tenant_hash, &bytes, &extents);
             return Ok((bytes, stats));
+        }
+
+        // The suffix probe normally places the object's tail -- the footer and
+        // trailer bytes `RlogReader` re-reads to open the assembled buffer, which
+        // are not themselves listed sections. When the footer was carried the
+        // probe was skipped, so on this (non-coverage) branch that tail is still
+        // unplaced; place it now as one range over `[last_section_end,
+        // object_size)`. In practice a carried footer implies an all-candidate
+        // (predicate-free, fully-contained) query, whose coverage always crosses
+        // over above, so this range is only reached when a caller forces the
+        // ranged path; it keeps that path fail-safe rather than assembling a
+        // buffer with a zeroed trailer.
+        if plan_footer.is_some() {
+            let tail_start = footer
+                .sections
+                .iter()
+                .map(|s| s.offset + s.len)
+                .max()
+                .unwrap_or(0);
+            if tail_start < total_size && !asm.covers(tail_start, total_size) {
+                let (bytes, live) = self
+                    .cached_extent(
+                        seg_ref,
+                        tenant_hash,
+                        tail_start,
+                        total_size - tail_start,
+                        GetRange::Range(tail_start, total_size),
+                        &pin,
+                        accounting,
+                    )
+                    .await?;
+                if live {
+                    stats.metadata_gets += 1;
+                }
+                asm.place(key, tail_start, &bytes)?;
+            }
         }
 
         // The remaining non-BLOCKS sections: STREAM_DIR/FIELD_DIR (object front)
@@ -2710,7 +2919,7 @@ mod plan_fast_path_tests {
 
         // Predicate-free, ts window strictly contains [min, max].
         let query = LogQuery::new(i64::MIN, i64::MAX);
-        let (count, stats) = f
+        let (count, stats, _footer) = f
             .plan_segment(&seg, TENANT, &query, &acc)
             .await
             .expect("plan_segment")
@@ -2748,7 +2957,7 @@ mod plan_fast_path_tests {
 
         // Exact span bounds: ts_min == min_event_ts_ns, ts_max == max_event_ts_ns.
         let query = LogQuery::new(seg.min_event_ts_ns, seg.max_event_ts_ns);
-        let (count, _stats) = f
+        let (count, _stats, _footer) = f
             .plan_segment(&seg, TENANT, &query, &acc)
             .await
             .expect("plan_segment")
@@ -2780,7 +2989,7 @@ mod plan_fast_path_tests {
             word: "hello".into(),
         });
         let acc = QueryAccounting::new();
-        let (count, _) = f
+        let (count, _, _) = f
             .plan_segment(&seg, TENANT, &q, &acc)
             .await
             .expect("plan")
@@ -2798,7 +3007,7 @@ mod plan_fast_path_tests {
             AttrValue::Str("svc".into()),
         ));
         let acc = QueryAccounting::new();
-        let (count, _) = f
+        let (count, _, _) = f
             .plan_segment(&seg, TENANT, &q, &acc)
             .await
             .expect("plan")
@@ -2815,7 +3024,7 @@ mod plan_fast_path_tests {
             vec![("request.id".into(), "r0".into())],
         )]);
         let acc = QueryAccounting::new();
-        let (count, _) = f
+        let (count, _, _) = f
             .plan_segment(&seg, TENANT, &q, &acc)
             .await
             .expect("plan")
@@ -2831,7 +3040,7 @@ mod plan_fast_path_tests {
         // run and the survivor count is N-2, not N.
         let q = LogQuery::new(2, i64::MAX);
         let acc = QueryAccounting::new();
-        let (count, _) = f
+        let (count, _, _) = f
             .plan_segment(&seg, TENANT, &q, &acc)
             .await
             .expect("plan")
@@ -2853,7 +3062,7 @@ mod plan_fast_path_tests {
             word: "hello".into(),
         });
         let acc = QueryAccounting::new();
-        let (count, _) = f
+        let (count, _, _) = f
             .plan_segment(&seg, TENANT, &q, &acc)
             .await
             .expect("plan")
@@ -2891,7 +3100,7 @@ mod plan_fast_path_tests {
             );
         let query = LogQuery::new(i64::MIN, i64::MAX);
         let acc = QueryAccounting::new();
-        let (count, _) = f
+        let (count, _, _) = f
             .plan_segment(&seg, TENANT, &query, &acc)
             .await
             .expect("plan")

--- a/crates/ravel-query/tests/log_block_range.rs
+++ b/crates/ravel-query/tests/log_block_range.rs
@@ -889,7 +889,7 @@ async fn cached_partitions_striping_one_large_segment_cost_a_partition_independe
 
         // The shared planning read, then the per-partition stripes.
         let accounting = QueryAccounting::new();
-        let (surviving, _stats) = fetcher
+        let (surviving, _stats, _footer) = fetcher
             .plan_segment(&seg, TENANT, &query, &accounting)
             .await
             .expect("plan")
@@ -914,6 +914,7 @@ async fn cached_partitions_striping_one_large_segment_cost_a_partition_independe
                         &query,
                         &ravel_logseg::ColumnSelection::all(),
                         &indices,
+                        None,
                         &QueryAccounting::new(),
                     )
                     .await

--- a/crates/ravel-query/tests/log_footer_carry.rs
+++ b/crates/ravel-query/tests/log_footer_carry.rs
@@ -1,0 +1,396 @@
+//! Integration tests for issue #693 part 3 deliverable 2: a [`footer::LogFooter`]
+//! read once by the plan phase ([`LogSegmentFetcher::plan_segment`]'s fast path)
+//! is carried into each per-partition subset open so the open reuses it and skips
+//! its own etag-establishing suffix probe.
+//!
+//! Two properties:
+//!
+//! 1. Footer carried -> the subset open issues NO suffix probe (the plan's is the
+//!    only one); footer omitted -> it probes again. Measured on an un-cached
+//!    fetcher so the probe is a real store GET either way (a cache would coalesce
+//!    the second probe onto the first and hide the difference the way a
+//!    non-evicting fixture always does; the point here is the request the fetcher
+//!    ISSUES, not what a cache absorbs).
+//! 2. The footer-carried open still pins the etag on its first live section/block
+//!    GET, so an object replaced mid-sequence surfaces the typed
+//!    [`LogFetchError::EtagChanged`] rather than assembling bytes from two object
+//!    states -- fail-closed, never mixed rows.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use async_trait::async_trait;
+use ravel_catalog::{SegmentLevel, SegmentRef};
+use ravel_logseg::footer::{self, kind};
+use ravel_logseg::writer::ObjectIdentity;
+use ravel_logseg::{
+    AttrValue, ColumnSelection, LogRecord, RlogConfig, RlogWriter, stream_attrs_bytes,
+};
+use ravel_object_store::memory::MemoryStore;
+use ravel_object_store::{
+    Capabilities, DelimitedList, Etag, GetOutcome, GetRange, ListPage, ObjectMeta,
+    ObjectStoreBackend, PageToken, PutOptions, PutOutcome, StoreError,
+};
+use ravel_query::{BlockRangeFetcher, LogQuery, LogSegmentFetcher};
+use ravel_types::TenantHash;
+use ravel_types::accounting::QueryAccounting;
+use uuid::Uuid;
+
+const TENANT: TenantHash = TenantHash([7u8; 16]);
+const CONTENT_HASH: [u8; 32] = [9u8; 32];
+const KEY: &str = "logs/seg.rlog";
+/// Records, one block each, so the object carries this many blocks.
+const N: usize = 6;
+
+fn identity() -> ObjectIdentity {
+    ObjectIdentity {
+        tenant_hash: [7u8; 16],
+        shard: 0,
+        writer_id: [2u8; 16],
+        writer_epoch: 1,
+        writer_seq: 1,
+    }
+}
+
+fn record(ts: i64) -> LogRecord {
+    let resource = vec![(
+        "service.name".to_string(),
+        AttrValue::Str("svc".to_string()),
+    )];
+    LogRecord {
+        stream_id: ravel_types::logstream::log_stream_id(&resource, "scope", "1.0", &[]),
+        stream_attrs: stream_attrs_bytes(&resource, "scope", "1.0", &[]),
+        ts_ns: ts,
+        observed_ts_ns: ts,
+        severity_num: 9,
+        severity_text: "INFO".into(),
+        body: format!("request {ts} ok"),
+        trace_id: None,
+        span_id: None,
+        flags: 0,
+        attrs: Vec::new(),
+    }
+}
+
+fn build_object() -> Vec<u8> {
+    let cfg = RlogConfig {
+        block_target_records: 1,
+        ..RlogConfig::default()
+    };
+    let mut w = RlogWriter::new(cfg, identity());
+    for ts in 0..N as i64 {
+        w.push(record(ts)).expect("push");
+    }
+    w.finish().expect("finish")
+}
+
+fn seg_ref(size: u64) -> SegmentRef {
+    SegmentRef {
+        data_object_key: KEY.to_string(),
+        object_size: size,
+        min_event_ts_ns: 0,
+        max_event_ts_ns: (N - 1) as i64,
+        ingest_hour_bucket: 0,
+        sample_count: N as u64,
+        series_count: 0,
+        shard: 0,
+        content_hash: CONTENT_HASH,
+        writer_id: Uuid::from_u128(1),
+        writer_epoch: 1,
+        writer_seq: 1,
+        created_unix_ns: 0,
+        level: SegmentLevel::L0,
+    }
+}
+
+/// Bytes after the BLOCKS section (SKIP_IDX/BLOOM/POSTINGS then footer/trailer):
+/// a probe suffix of exactly this length covers the whole tail (footer parses
+/// with no range chase) yet reaches no block byte, so the block reads are real
+/// byte-range GETs.
+fn tail_len(bytes: &[u8]) -> u64 {
+    let f = footer::open(bytes).expect("footer");
+    let b = f.section(kind::BLOCKS).expect("BLOCKS");
+    bytes.len() as u64 - (b.offset + b.len)
+}
+
+/// Absolute end of the BLOCKS section: block GETs start below this, every tail
+/// section (SKIP_IDX/BLOOM/POSTINGS) at or above it.
+fn blocks_end(bytes: &[u8]) -> u64 {
+    let f = footer::open(bytes).expect("footer");
+    let b = f.section(kind::BLOCKS).expect("BLOCKS");
+    b.offset + b.len
+}
+
+/// An un-cached fetcher forced onto the ranged path (threshold 0), with the probe
+/// sized to the tail and the coverage crossover disabled, so a footer-carried
+/// open genuinely range-fetches SKIP_IDX and the blocks rather than reading the
+/// whole object.
+fn ranged_fetcher(store: Arc<dyn ObjectStoreBackend>, tail: u64) -> LogSegmentFetcher {
+    LogSegmentFetcher::new(Arc::clone(&store))
+        .with_block_range(
+            BlockRangeFetcher::new(store)
+                .with_suffix_len(tail)
+                .with_whole_object_threshold(0)
+                .with_coverage_threshold(2.0)
+                .with_coalesce_gap(0),
+        )
+        .with_block_range_threshold(0)
+}
+
+// ---- shape-counting store ------------------------------------------------
+
+struct SuffixCountingStore {
+    inner: Arc<MemoryStore>,
+    suffix: AtomicU64,
+}
+
+impl SuffixCountingStore {
+    fn new(inner: Arc<MemoryStore>) -> Arc<Self> {
+        Arc::new(SuffixCountingStore {
+            inner,
+            suffix: AtomicU64::new(0),
+        })
+    }
+    fn suffix_gets(&self) -> u64 {
+        self.suffix.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl ObjectStoreBackend for SuffixCountingStore {
+    async fn put(
+        &self,
+        key: &str,
+        data: bytes::Bytes,
+        opts: PutOptions,
+    ) -> Result<PutOutcome, StoreError> {
+        self.inner.put(key, data, opts).await
+    }
+    async fn get(&self, key: &str, range: GetRange) -> Result<GetOutcome, StoreError> {
+        if matches!(range, GetRange::Suffix(_)) {
+            self.suffix.fetch_add(1, Ordering::SeqCst);
+        }
+        self.inner.get(key, range).await
+    }
+    async fn head(&self, key: &str) -> Result<ObjectMeta, StoreError> {
+        self.inner.head(key).await
+    }
+    async fn list(&self, prefix: &str, page: Option<PageToken>) -> Result<ListPage, StoreError> {
+        self.inner.list(prefix, page).await
+    }
+    async fn list_delimited(&self, prefix: &str) -> Result<DelimitedList, StoreError> {
+        self.inner.list_delimited(prefix).await
+    }
+    async fn delete(&self, key: &str) -> Result<(), StoreError> {
+        self.inner.delete(key).await
+    }
+    fn capabilities(&self) -> Capabilities {
+        Capabilities {
+            multipart: false,
+            ..self.inner.capabilities()
+        }
+    }
+}
+
+/// Swaps the etag of any `Range` GET that starts BELOW `blocks_end` (the front
+/// directory sections and the candidate blocks), so the footer-carried open's
+/// first live GET (SKIP_IDX, at or above `blocks_end`) pins one etag and a later
+/// front-section/block GET reports a different one -- the mid-sequence
+/// replacement the pin must catch.
+struct EtagSwapStore {
+    inner: Arc<MemoryStore>,
+    blocks_end: u64,
+}
+
+#[async_trait]
+impl ObjectStoreBackend for EtagSwapStore {
+    async fn put(
+        &self,
+        key: &str,
+        data: bytes::Bytes,
+        opts: PutOptions,
+    ) -> Result<PutOutcome, StoreError> {
+        self.inner.put(key, data, opts).await
+    }
+    async fn get(&self, key: &str, range: GetRange) -> Result<GetOutcome, StoreError> {
+        let mut got = self.inner.get(key, range).await?;
+        if let GetRange::Range(start, _) = range
+            && start < self.blocks_end
+        {
+            got.etag = Etag("swapped-mid-sequence".to_string());
+        }
+        Ok(got)
+    }
+    async fn head(&self, key: &str) -> Result<ObjectMeta, StoreError> {
+        self.inner.head(key).await
+    }
+    async fn list(&self, prefix: &str, page: Option<PageToken>) -> Result<ListPage, StoreError> {
+        self.inner.list(prefix, page).await
+    }
+    async fn list_delimited(&self, prefix: &str) -> Result<DelimitedList, StoreError> {
+        self.inner.list_delimited(prefix).await
+    }
+    async fn delete(&self, key: &str) -> Result<(), StoreError> {
+        self.inner.delete(key).await
+    }
+    fn capabilities(&self) -> Capabilities {
+        Capabilities {
+            multipart: false,
+            ..self.inner.capabilities()
+        }
+    }
+}
+
+async fn store_with_object(bytes: Vec<u8>) -> Arc<MemoryStore> {
+    let store = Arc::new(MemoryStore::new());
+    store
+        .put(KEY, bytes::Bytes::from(bytes), PutOptions::default())
+        .await
+        .expect("put");
+    store
+}
+
+/// Plan the segment (one suffix probe), then a footer-carried subset open issues
+/// NONE, so the whole statement pays exactly one suffix probe -- the plan's.
+/// Omitting the footer probes again, for two. Rows are identical either way.
+#[tokio::test]
+async fn footer_carried_subset_open_skips_the_probe() {
+    let bytes = build_object();
+    let total = bytes.len() as u64;
+    let tail = tail_len(&bytes);
+    let seg = seg_ref(total);
+    let query = LogQuery::new(i64::MIN, i64::MAX);
+    let indices: Vec<usize> = (0..N).collect();
+
+    // Footer carried: plan probe (1) + subset open (0) = 1 total.
+    let counting = SuffixCountingStore::new(store_with_object(bytes.clone()).await);
+    let store: Arc<dyn ObjectStoreBackend> = Arc::clone(&counting) as Arc<dyn ObjectStoreBackend>;
+    let fetcher = ranged_fetcher(store, tail);
+    let acc = QueryAccounting::new();
+    let (survivors, _stats, footer) = fetcher
+        .plan_segment(&seg, TENANT, &query, &acc)
+        .await
+        .expect("plan")
+        .expect("relevant");
+    assert_eq!(survivors, N, "every block survives the full window");
+    let footer = footer.expect("the fast plan path carries a footer");
+    assert_eq!(
+        counting.suffix_gets(),
+        1,
+        "the plan phase issues exactly one suffix probe"
+    );
+    let mut scan = fetcher
+        .scan_accounted_with_tenant_subset(
+            &seg,
+            TENANT,
+            &query,
+            &ColumnSelection::all(),
+            &indices,
+            Some(&footer),
+            &acc,
+        )
+        .await
+        .expect("subset scan")
+        .expect("relevant");
+    let mut rows_with_footer = 0usize;
+    while let Some(block) = scan.next_block().expect("decode") {
+        rows_with_footer += block.len();
+    }
+    assert_eq!(
+        counting.suffix_gets(),
+        1,
+        "a footer-carried open issues no suffix probe of its own: total stays 1"
+    );
+
+    // Footer omitted (the red control): the open probes again, for two total.
+    let counting2 = SuffixCountingStore::new(store_with_object(bytes).await);
+    let store2: Arc<dyn ObjectStoreBackend> = Arc::clone(&counting2) as Arc<dyn ObjectStoreBackend>;
+    let fetcher2 = ranged_fetcher(store2, tail);
+    let acc2 = QueryAccounting::new();
+    let _ = fetcher2
+        .plan_segment(&seg, TENANT, &query, &acc2)
+        .await
+        .expect("plan")
+        .expect("relevant");
+    let mut scan2 = fetcher2
+        .scan_accounted_with_tenant_subset(
+            &seg,
+            TENANT,
+            &query,
+            &ColumnSelection::all(),
+            &indices,
+            None,
+            &acc2,
+        )
+        .await
+        .expect("subset scan")
+        .expect("relevant");
+    let mut rows_no_footer = 0usize;
+    while let Some(block) = scan2.next_block().expect("decode") {
+        rows_no_footer += block.len();
+    }
+    assert_eq!(
+        counting2.suffix_gets(),
+        2,
+        "omitting the footer makes the open re-probe: plan probe + open probe"
+    );
+    assert_eq!(
+        rows_with_footer, rows_no_footer,
+        "carrying the footer changes the read shape, never the rows"
+    );
+    assert_eq!(rows_with_footer, N, "all blocks decoded");
+}
+
+/// A footer-carried open still fails closed on a mid-sequence object
+/// replacement: its first live GET pins the etag, and a later GET reporting a
+/// different one surfaces [`LogFetchError::EtagChanged`] rather than mixing
+/// bytes from two object states.
+#[tokio::test]
+async fn footer_carried_open_still_catches_an_etag_change() {
+    let bytes = build_object();
+    let total = bytes.len() as u64;
+    let tail = tail_len(&bytes);
+    let end = blocks_end(&bytes);
+    let seg = seg_ref(total);
+    let query = LogQuery::new(i64::MIN, i64::MAX);
+    let indices: Vec<usize> = (0..N).collect();
+
+    // Plan on a clean store to obtain the footer.
+    let base = store_with_object(bytes).await;
+    let plan_fetcher = ranged_fetcher(Arc::clone(&base) as Arc<dyn ObjectStoreBackend>, tail);
+    let acc = QueryAccounting::new();
+    let (_survivors, _stats, footer) = plan_fetcher
+        .plan_segment(&seg, TENANT, &query, &acc)
+        .await
+        .expect("plan")
+        .expect("relevant");
+    let footer = footer.expect("the fast plan path carries a footer");
+
+    // Now the scan runs against a store that swaps the etag on the front-section
+    // and block GETs, simulating a replacement after the SKIP_IDX GET pinned the
+    // etag.
+    let swap = Arc::new(EtagSwapStore {
+        inner: base,
+        blocks_end: end,
+    });
+    let store: Arc<dyn ObjectStoreBackend> = swap;
+    let fetcher = ranged_fetcher(store, tail);
+    let result = fetcher
+        .scan_accounted_with_tenant_subset(
+            &seg,
+            TENANT,
+            &query,
+            &ColumnSelection::all(),
+            &indices,
+            Some(&footer),
+            &QueryAccounting::new(),
+        )
+        .await;
+    let err = result.err().map(|e| e.to_string());
+    assert!(
+        matches!(&err, Some(m) if m.contains("etag changed")),
+        "a footer-carried open must catch a mid-sequence etag change, got {err:?}"
+    );
+}

--- a/crates/ravel-sql/src/logs_scan.rs
+++ b/crates/ravel-sql/src/logs_scan.rs
@@ -933,6 +933,8 @@ fn plan_counts_future(
 /// semantics (the first error aborts the plan, and `get_or_try_init` does not
 /// cache it); the fetcher's own in-flight GET semaphore remains the global
 /// bound, so an oversized `plan_concurrency` is safe.
+// Issue #693 part 3: the predicate-free full-window fast path in `execute`
+// skips this whole pass; see `owned_work` and `plan_segment_fast`.
 async fn compute_plan_counts(
     ctx: &PartitionCtx,
     segments: &[SegmentRef],

--- a/crates/ravel-sql/src/logs_scan.rs
+++ b/crates/ravel-sql/src/logs_scan.rs
@@ -63,14 +63,31 @@
 //!   single-flight -- the whole object below the threshold, and the probe, each
 //!   section, and each block above it -- so the partitions striping one segment
 //!   coalesce onto one request per distinct extent rather than one sequence
-//!   each, and on the bench fixture the request count is flat across the whole
-//!   `target_partitions` sweep (planning's prune coalesces with them too).
-//!   Coalescing is not free of request count in general, though: a read that
-//!   misses the in-flight window, or finds its key already evicted, issues its
-//!   own GET. So striding past the segment count *can* raise the GET count above
-//!   the whole-segment path's, and that is the cost ADR-0102 accepts in exchange
-//!   for the cache absorbing the repeat reads and for the extra scan
-//!   parallelism.
+//!   each, and on the bench fixture the scan reads are flat across the whole
+//!   `target_partitions` sweep. The plan reads do NOT coalesce with them: a
+//!   [`tokio::sync::OnceCell`] barrier makes every partition await the whole
+//!   plan pass before draining, so each plan read is the first, cold touch of
+//!   its extent and completes before any scan read starts -- there is no
+//!   concurrent in-flight GET for the scan to collapse onto, and an evicted plan
+//!   entry is simply re-fetched by the scan (issue #691). Coalescing is not free
+//!   of request count in general either: a read that misses the in-flight
+//!   window, or finds its key already evicted, issues its own GET. So striding
+//!   past the segment count *can* raise the GET count above the whole-segment
+//!   path's, and that is the cost ADR-0102 accepts in exchange for the cache
+//!   absorbing the repeat reads and for the extra scan parallelism.
+//! - **Predicate-free full-window fast path (#693 part 3).** When the query has
+//!   no block-level predicate, no pending erasure, and its window fully contains
+//!   every relevant, above-threshold segment, and there are at least
+//!   `target_partitions` such segments, the plan phase is skipped entirely
+//!   ([`LogsScanExec::whole_segment_fast_path`]): whole segments are assigned
+//!   round-robin (the same rule the un-cached path uses), and each is read in one
+//!   whole-object GET ([`LogSegmentFetcher::scan_whole_accounted_with_tenant`]),
+//!   so the request count is exactly one GET per relevant segment, zero suffix
+//!   probes. When there are fewer relevant segments than partitions the striped
+//!   path runs instead, but the plan footer it read is carried to each subset
+//!   open ([`LogSegmentFetcher::fetch_object_with_footer`]) so those opens skip
+//!   their own re-probe. Any other query shape runs the plan-then-stripe path
+//!   above unchanged.
 //!
 //! Above the threshold each partition's read already covers only the pruned
 //! candidate blocks rather than every byte of the segment, so bytes on the wire
@@ -202,6 +219,7 @@ use datafusion::physical_plan::{
 };
 use futures::{Stream, StreamExt, TryStreamExt};
 use ravel_catalog::SegmentRef;
+use ravel_logseg::footer::LogFooter;
 use ravel_logseg::{
     AttrColumn, ColumnSelection, ColumnarBlockView, FieldSel, FieldType, LogRecord, Predicate,
     ScanStats,
@@ -529,11 +547,16 @@ impl BlockMetrics {
     /// because a degraded postings section leaves the two counts equal rather
     /// than ordered by construction).
     ///
-    /// Recorded once per relevant segment by partition 0 during planning
-    /// (ADR-0102), never per partition: several partitions stripe one segment's
-    /// blocks, and each re-prunes the whole segment to open its own subset, so
-    /// attributing the whole-segment totals per partition would multiply them.
-    /// The per-partition decode counts come from [`Self::record_scan`] instead.
+    /// On the striped path this is recorded once per relevant segment by
+    /// partition 0 during planning (ADR-0102), never per partition: several
+    /// partitions stripe one segment's blocks, and each re-prunes the whole
+    /// segment to open its own subset, so attributing the whole-segment totals
+    /// per partition would multiply them. On the predicate-free full-window
+    /// whole-segment fast path (#693 part 3) there is no plan phase, but each
+    /// segment has exactly one owning partition, so its owner records these
+    /// totals once at exhaustion straight from the scan's own stats -- still
+    /// exactly once per segment. Either way the per-partition decode counts come
+    /// from [`Self::record_scan`].
     fn record_segment_totals(&self, stats: &ScanStats) {
         self.total.add(stats.blocks_total as usize);
         self.pruned_by_postings.add(
@@ -706,6 +729,58 @@ impl LogsScanExec {
             && self.erasure.is_empty()
     }
 
+    /// Whether this scan can take the predicate-free full-window whole-segment
+    /// fast path (#693 part 3, deliverable 1), returning the count of relevant
+    /// (ts-overlapping) segments when it can. Decided with ZERO I/O from the
+    /// resolved snapshot and `query`, using the same conjuncts
+    /// [`ravel_query::LogSegmentFetcher::plan_segment`]'s own fast-path gate uses
+    /// per segment:
+    ///
+    /// - the query carries no block-level predicate
+    ///   ([`LogQuery::is_block_predicate_free`]: no content, prune-only,
+    ///   stream-attribute, or pending-erasure arm), and
+    /// - every relevant segment has a well-formed span (`min <= max`), is above
+    ///   the fetcher's block-range threshold, and is fully CONTAINED in the
+    ///   window (`ts_min <= seg.min && seg.max <= ts_max`). Containment is
+    ///   strictly stronger than the overlap
+    ///   [`LogsTableProvider::pruned_segments`] already filtered on, so no block
+    ///   of a relevant segment can fall outside the window and every block
+    ///   survives -- the survivor count is the whole segment.
+    ///
+    /// and finally there are at least `target_partitions` relevant segments, so
+    /// whole-segment round-robin still fills every partition. Fewer segments than
+    /// partitions is the striped path's job (deliverable 2 carries the plan
+    /// footer there so its subset opens still skip re-probing); a partial
+    /// overlap, a predicate, a pending erasure, or a below-threshold segment all
+    /// fall to the unchanged plan-then-stripe path, byte for byte.
+    ///
+    /// The threshold conjunct keeps this strictly to the band where skipping the
+    /// plan phase saves a GET: at or below the threshold a segment is already
+    /// read whole in one GET on both the plan and scan paths (they coalesce on
+    /// the same `(0, object_size)` cache key), so the fast path would add nothing
+    /// and would only diverge from the existing small-object tests.
+    fn whole_segment_fast_path(&self, query: &LogQuery) -> Option<usize> {
+        if !query.is_block_predicate_free() {
+            return None;
+        }
+        let threshold = self.fetcher.block_range_threshold();
+        let mut relevant = 0usize;
+        for seg in self.segments.iter() {
+            if !LogSegmentFetcher::ts_range_relevant(seg, self.ts_min, self.ts_max) {
+                continue;
+            }
+            relevant += 1;
+            let contained = seg.min_event_ts_ns <= seg.max_event_ts_ns
+                && seg.object_size > threshold
+                && self.ts_min <= seg.min_event_ts_ns
+                && seg.max_event_ts_ns <= self.ts_max;
+            if !contained {
+                return None;
+            }
+        }
+        (relevant >= self.target_partitions).then_some(relevant)
+    }
+
     fn compute_properties(schema: &SchemaRef, n: usize) -> PlanProperties {
         let eq = EquivalenceProperties::new(Arc::clone(schema));
         PlanProperties::new(
@@ -841,18 +916,35 @@ impl ExecutionPlan for LogsScanExec {
             accounting: self.accounting.clone(),
         });
 
-        // The block-level assignment needs each segment's surviving-block count,
-        // which a prune must produce (async). The first partition to poll runs
-        // that prune for every segment through the shared `counts` cell, with
-        // as many prunes in flight as the scan has partitions; the rest await
-        // its result. Building the future here (not awaiting it) keeps
-        // `execute` synchronous, as DataFusion requires.
-        let counts_fut = plan_counts_future(
-            Arc::clone(&self.counts),
-            Arc::clone(&ctx),
-            Arc::clone(&self.segments),
-            self.target_partitions,
-        );
+        // #693 part 3 deliverable 1: a predicate-free query whose window fully
+        // contains every relevant, above-threshold segment, with at least
+        // `target_partitions` of them, skips the plan phase entirely. Each
+        // partition computes its whole-segment round-robin share with no I/O and
+        // opens each owned segment with one whole-object GET (no plan probe, no
+        // scan-side probe). Any other shape falls to the plan-then-stripe path
+        // below, byte for byte.
+        let (work, fast_whole_segment, state) = if let Some(relevant) =
+            self.whole_segment_fast_path(&ctx.query)
+        {
+            let n = self.target_partitions.max(1).min(relevant.max(1));
+            let work = owned_whole_segments(&self.segments, self.ts_min, self.ts_max, partition, n);
+            (work, true, LogScanState::NextSegment)
+        } else {
+            // The block-level assignment needs each segment's surviving-block
+            // count, which a prune must produce (async). The first partition
+            // to poll runs that prune for every segment through the shared
+            // `counts` cell, with as many prunes in flight as the scan has
+            // partitions; the rest await its result. Building the future here
+            // (not awaiting it) keeps `execute` synchronous, as DataFusion
+            // requires.
+            let counts_fut = plan_counts_future(
+                Arc::clone(&self.counts),
+                Arc::clone(&ctx),
+                Arc::clone(&self.segments),
+                self.target_partitions,
+            );
+            (VecDeque::new(), false, LogScanState::Planning(counts_fut))
+        };
 
         Ok(Box::pin(LogScanStream {
             schema: Arc::clone(&self.schema),
@@ -865,16 +957,18 @@ impl ExecutionPlan for LogsScanExec {
             partition,
             target_partitions: self.target_partitions,
             stripe_blocks: self.stripe_blocks,
+            fast_whole_segment,
             segments: Arc::clone(&self.segments),
-            work: VecDeque::new(),
+            work,
             reservation,
             held: 0,
             emitted: 0,
             pending: Pending::None,
             current_seg: None,
             current_indices: Vec::new(),
+            current_footer: None,
             seg_columnar_blocks: 0,
-            state: LogScanState::Planning(counts_fut),
+            state,
         }))
     }
 }
@@ -898,6 +992,11 @@ struct SegPlan {
     /// consumes `blocks_total` and the postings drop). `blocks_scanned`/`pages`
     /// are zero here -- planning decodes nothing.
     stats: ScanStats,
+    /// The footer the plan fast path read for this segment (#693 part 3,
+    /// deliverable 2), or `None` when the plan slow branch opened the scan
+    /// instead. Carried to each per-partition subset open through [`OwnedSeg`] so
+    /// the open reuses it and skips its own suffix probe.
+    footer: Option<LogFooter>,
 }
 
 type CountsFuture = Pin<Box<dyn Future<Output = DFResult<Arc<PlanCounts>>> + Send>>;
@@ -951,7 +1050,7 @@ async fn compute_plan_counts(
                 .plan_segment(seg, ctx.tenant_hash, &ctx.query, &ctx.accounting),
         );
     }
-    let planned: Vec<Option<(usize, ScanStats)>> = futures::stream::iter(prunes)
+    let planned: Vec<Option<(usize, ScanStats, Option<LogFooter>)>> = futures::stream::iter(prunes)
         .buffered(plan_concurrency.max(1))
         .map_err(SqlError::from)
         .try_collect()
@@ -960,9 +1059,13 @@ async fn compute_plan_counts(
     let mut total_blocks = 0usize;
     for entry in planned {
         match entry {
-            Some((survivors, stats)) => {
+            Some((survivors, stats, footer)) => {
                 total_blocks += survivors;
-                segs.push(Some(SegPlan { survivors, stats }));
+                segs.push(Some(SegPlan {
+                    survivors,
+                    stats,
+                    footer,
+                }));
             }
             None => segs.push(None),
         }
@@ -975,6 +1078,10 @@ async fn compute_plan_counts(
 struct OwnedSeg {
     seg: SegmentRef,
     indices: Vec<usize>,
+    /// The plan-phase footer for this segment (#693 part 3, deliverable 2),
+    /// carried to the subset open so it skips its own suffix probe. `None` on the
+    /// whole-segment fast path (no plan phase) and when the plan slow branch ran.
+    footer: Option<LogFooter>,
 }
 
 /// This partition's share of the block assignment, in one of two modes
@@ -1017,6 +1124,7 @@ fn owned_work(
                 work.push_back(OwnedSeg {
                     seg: segments[seg_idx].clone(),
                     indices,
+                    footer: plan.footer.clone(),
                 });
             }
         }
@@ -1031,10 +1139,47 @@ fn owned_work(
                 work.push_back(OwnedSeg {
                     seg: segments[seg_idx].clone(),
                     indices: (0..plan.survivors).collect(),
+                    footer: plan.footer.clone(),
                 });
             }
             seg_ordinal += 1;
         }
+    }
+    work
+}
+
+/// The predicate-free full-window whole-segment assignment (#693 part 3,
+/// deliverable 1): the same round-robin [`owned_work`]'s un-cached branch uses,
+/// but computed with NO plan phase at all. Relevant (ts-overlapping) segments in
+/// snapshot order are numbered `0..`, and segment `j` goes to partition `j % n`,
+/// which then drains the whole segment through [`open_segment_whole`]. `n` is the
+/// same `min(target_partitions, relevant)` the caller derives, so every
+/// partition gets whole segments and none is split.
+///
+/// Each relevant segment is proved fully contained in the query window and
+/// predicate-free before this runs (see [`LogsScanExec::whole_segment_fast_path`]),
+/// so every block survives and the block-index list is unused here.
+fn owned_whole_segments(
+    segments: &[SegmentRef],
+    ts_min: i64,
+    ts_max: i64,
+    partition: usize,
+    n: usize,
+) -> VecDeque<OwnedSeg> {
+    let mut work = VecDeque::new();
+    let mut ordinal = 0usize;
+    for seg in segments {
+        if !LogSegmentFetcher::ts_range_relevant(seg, ts_min, ts_max) {
+            continue;
+        }
+        if ordinal % n == partition {
+            work.push_back(OwnedSeg {
+                seg: seg.clone(),
+                indices: Vec::new(),
+                footer: None,
+            });
+        }
+        ordinal += 1;
     }
     work
 }
@@ -1056,7 +1201,12 @@ type OpenFuture = Pin<Box<dyn Future<Output = DFResult<Option<LogSegmentScan>>> 
 /// `Ok(None)` means the catalog summary proved the segment irrelevant, with no
 /// GET issued -- which cannot happen for a segment that was already counted
 /// with survivors, but is handled as end-of-segment rather than panicking.
-fn open_segment_subset(ctx: Arc<PartitionCtx>, seg: SegmentRef, indices: Vec<usize>) -> OpenFuture {
+fn open_segment_subset(
+    ctx: Arc<PartitionCtx>,
+    seg: SegmentRef,
+    indices: Vec<usize>,
+    footer: Option<LogFooter>,
+) -> OpenFuture {
     Box::pin(async move {
         let scan = ctx
             .fetcher
@@ -1066,6 +1216,29 @@ fn open_segment_subset(ctx: Arc<PartitionCtx>, seg: SegmentRef, indices: Vec<usi
                 &ctx.query,
                 &ctx.columns,
                 &indices,
+                footer.as_ref(),
+                &ctx.accounting,
+            )
+            .await
+            .map_err(SqlError::from)?;
+        Ok(scan)
+    })
+}
+
+/// Fetch one whole segment's object in a single GET and open its pruned,
+/// column-projected scan over all of its blocks (#693 part 3, deliverable 1).
+/// Used only on the predicate-free full-window whole-segment path, where the
+/// segment is assigned to exactly one partition and every block survives, so a
+/// whole-object read is optimal and no plan phase or suffix probe is needed.
+fn open_segment_whole(ctx: Arc<PartitionCtx>, seg: SegmentRef) -> OpenFuture {
+    Box::pin(async move {
+        let scan = ctx
+            .fetcher
+            .scan_whole_accounted_with_tenant(
+                &seg,
+                ctx.tenant_hash,
+                &ctx.query,
+                &ctx.columns,
                 &ctx.accounting,
             )
             .await
@@ -1168,6 +1341,13 @@ struct LogScanStream {
     /// The assignment mode (ADR-0102, amended by #693): block striping when a
     /// cache is wired, segment-granular otherwise. Passed to [`owned_work`].
     stripe_blocks: bool,
+    /// The predicate-free full-window whole-segment fast path (#693 part 3,
+    /// deliverable 1). When set, `work` was filled by [`owned_whole_segments`]
+    /// with no plan phase, each segment is opened with one whole-object GET
+    /// ([`open_segment_whole`]), and the segment's whole-segment prune totals are
+    /// recorded per segment at exhaustion (each segment has one owner, so no
+    /// double count) instead of by partition 0 during planning.
+    fast_whole_segment: bool,
     /// Every segment in the snapshot, snapshot order, shared with the exec. The
     /// owned-work computation indexes this by segment position.
     segments: Arc<Vec<SegmentRef>>,
@@ -1188,6 +1368,10 @@ struct LogScanStream {
     /// current_seg`], kept so the `attrs_raw` fallback re-opens the row path
     /// over the SAME list (ADR-0102). Set alongside `current_seg`.
     current_indices: Vec<usize>,
+    /// The plan-phase footer for [`Self::current_seg`] (#693 part 3, deliverable
+    /// 2), kept so the `attrs_raw` fallback re-opens the subset with the same
+    /// footer it first used. `None` on the whole-segment fast path.
+    current_footer: Option<LogFooter>,
     /// How many of this partition's blocks in the current segment the columnar
     /// fast path has already emitted. The `attrs_raw` fallback re-opens the
     /// segment over `current_indices` and skips this many positions so none is
@@ -1379,15 +1563,28 @@ impl Stream for LogScanStream {
                     Poll::Pending => return Poll::Pending,
                 },
                 LogScanState::NextSegment => match this.work.pop_front() {
-                    Some(OwnedSeg { seg, indices }) => {
+                    Some(OwnedSeg {
+                        seg,
+                        indices,
+                        footer,
+                    }) => {
                         this.current_seg = Some(seg.clone());
                         this.current_indices = indices.clone();
+                        this.current_footer = footer.clone();
                         this.seg_columnar_blocks = 0;
-                        this.state = LogScanState::Opening(open_segment_subset(
-                            Arc::clone(&this.ctx),
-                            seg,
-                            indices,
-                        ));
+                        // Whole-segment fast path reads the object in one GET
+                        // (#693 part 3); the striped path opens only this
+                        // partition's subset, reusing the plan footer if any.
+                        this.state = if this.fast_whole_segment {
+                            LogScanState::Opening(open_segment_whole(Arc::clone(&this.ctx), seg))
+                        } else {
+                            LogScanState::Opening(open_segment_subset(
+                                Arc::clone(&this.ctx),
+                                seg,
+                                indices,
+                                footer,
+                            ))
+                        };
                     }
                     None => {
                         this.state = LogScanState::Done;
@@ -1481,6 +1678,13 @@ impl Stream for LogScanStream {
                         Step::Failed(e) => return this.fail(e),
                         Step::Exhausted(stats) => {
                             this.blocks.record_scan(&stats);
+                            // The whole-segment fast path has no plan phase, so
+                            // the whole-segment prune totals are recorded here,
+                            // per segment (one owner per segment, no double
+                            // count), instead of by partition 0 during planning.
+                            if this.fast_whole_segment {
+                                this.blocks.record_segment_totals(&stats);
+                            }
                             this.state = LogScanState::NextSegment;
                         }
                         Step::Fallback => {
@@ -1512,11 +1716,16 @@ impl Stream for LogScanStream {
                                     ));
                                 }
                             };
-                            let fut = open_segment_subset(
-                                Arc::clone(&this.ctx),
-                                seg,
-                                this.current_indices.clone(),
-                            );
+                            let fut = if this.fast_whole_segment {
+                                open_segment_whole(Arc::clone(&this.ctx), seg)
+                            } else {
+                                open_segment_subset(
+                                    Arc::clone(&this.ctx),
+                                    seg,
+                                    this.current_indices.clone(),
+                                    this.current_footer.clone(),
+                                )
+                            };
                             this.state = LogScanState::ReopenRows {
                                 fut,
                                 skip: this.seg_columnar_blocks,
@@ -1552,6 +1761,9 @@ impl Stream for LogScanStream {
                             Ok(None) => {
                                 let stats = scan.stats();
                                 this.blocks.record_scan(&stats);
+                                if this.fast_whole_segment {
+                                    this.blocks.record_segment_totals(&stats);
+                                }
                                 this.state = LogScanState::NextSegment;
                             }
                             Err(e) => return this.fail(SqlError::from(e).into()),
@@ -1569,6 +1781,9 @@ impl Stream for LogScanStream {
                         Ok(None) => {
                             let stats = scan.stats();
                             this.blocks.record_scan(&stats);
+                            if this.fast_whole_segment {
+                                this.blocks.record_segment_totals(&stats);
+                            }
                             this.state = LogScanState::NextSegment;
                         }
                         Err(e) => return this.fail(SqlError::from(e).into()),

--- a/crates/ravel-sql/tests/logs_whole_segment_fast_path.rs
+++ b/crates/ravel-sql/tests/logs_whole_segment_fast_path.rs
@@ -1,0 +1,486 @@
+//! Tests for issue #693 part 3 deliverable 1: a predicate-free, full-window
+//! logs statement whose window fully contains every relevant, above-threshold
+//! segment (and there are at least `target_partitions` of them) skips the plan
+//! phase entirely and reads each segment whole in ONE object-store GET.
+//!
+//! Post-#707 such a statement paid, per segment, a plan-phase suffix probe
+//! (`plan_segment_fast`) plus a scan-side re-probe per partition-open plus a
+//! whole-object read (the coverage crossover), and the plan probe never
+//! coalesced with the scan reads because the `OnceCell` plan barrier made it the
+//! first, cold touch. This deliverable removes both probe classes for the
+//! whole-window case: the request count is exactly one whole-object GET per
+//! segment and zero suffix probes.
+//!
+//! The fixture uses objects ABOVE the block-range threshold (the fast path is
+//! gated there, matching `plan_segment`'s own gate): below the threshold the
+//! plan and scan reads already coalesce on one whole-object cache key, so there
+//! is no probe to save. Making the objects above-threshold is what lets the
+//! probe-count assertion mean something: the striped path would probe, the fast
+//! path does not.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::collections::BTreeSet;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use async_trait::async_trait;
+use datafusion::arrow::array::{StringArray, TimestampNanosecondArray};
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::execution::TaskContext;
+use datafusion::physical_plan::{ExecutionPlan, collect};
+use ravel_cache::{Cache, CacheLimits};
+use ravel_catalog::{SegmentLevel, SegmentRef, Snapshot};
+use ravel_logseg::writer::ObjectIdentity;
+use ravel_logseg::{AttrValue, LogRecord, RlogConfig, RlogWriter, stream_attrs_bytes};
+use ravel_object_store::memory::MemoryStore;
+use ravel_object_store::{
+    Capabilities, DelimitedList, GetOutcome, GetRange, ListPage, ObjectMeta, ObjectStoreBackend,
+    PageToken, PutOptions, PutOutcome, StoreError,
+};
+use ravel_query::{CacheFetchError, LogSegmentFetcher};
+use ravel_sql::LogsTableProvider;
+use ravel_types::TenantHash;
+use ravel_types::accounting::QueryAccounting;
+use uuid::Uuid;
+
+/// Segments in the fixture, and the partitions requested for the fast-path plan.
+/// Equal so `relevant_segments >= target_partitions` holds and each segment is
+/// assigned whole to one partition.
+const SEGMENTS: usize = 4;
+const PARTS: usize = 4;
+/// One record per block, three records per object, so each segment has exactly
+/// three blocks (2-3, the count the task pins) and every one survives the full
+/// window.
+const RECORDS_PER_SEG: usize = 3;
+const BLOCKS_PER_SEG: usize = 3;
+
+fn identity() -> ObjectIdentity {
+    ObjectIdentity {
+        tenant_hash: [7u8; 16],
+        shard: 0,
+        writer_id: [2u8; 16],
+        writer_epoch: 1,
+        writer_seq: 1,
+    }
+}
+
+fn one_record_blocks() -> RlogConfig {
+    RlogConfig {
+        block_target_records: 1,
+        ..RlogConfig::default()
+    }
+}
+
+fn record(ts: i64, body: &str) -> LogRecord {
+    let resource = vec![(
+        "service.name".to_string(),
+        AttrValue::Str("svc".to_string()),
+    )];
+    LogRecord {
+        stream_id: ravel_types::logstream::log_stream_id(&resource, "scope", "1.0", &[]),
+        stream_attrs: stream_attrs_bytes(&resource, "scope", "1.0", &[]),
+        ts_ns: ts,
+        observed_ts_ns: ts,
+        severity_num: 9,
+        severity_text: "INFO".into(),
+        body: body.into(),
+        trace_id: None,
+        span_id: None,
+        flags: 0,
+        attrs: Vec::new(),
+    }
+}
+
+async fn write_object(
+    store: &dyn ObjectStoreBackend,
+    key: &str,
+    content_hash: [u8; 32],
+    records: &[LogRecord],
+) -> SegmentRef {
+    let mut w = RlogWriter::new(one_record_blocks(), identity());
+    for r in records {
+        w.push(r.clone()).expect("push");
+    }
+    let bytes = w.finish().expect("finish");
+    let size = bytes.len() as u64;
+    store
+        .put(key, bytes::Bytes::from(bytes), PutOptions::default())
+        .await
+        .expect("put object");
+
+    let min = records.iter().map(|r| r.ts_ns).min().expect("nonempty");
+    let max = records.iter().map(|r| r.ts_ns).max().expect("nonempty");
+    SegmentRef {
+        data_object_key: key.to_string(),
+        object_size: size,
+        min_event_ts_ns: min,
+        max_event_ts_ns: max,
+        ingest_hour_bucket: 0,
+        sample_count: records.len() as u64,
+        series_count: 0,
+        shard: 0,
+        content_hash,
+        writer_id: Uuid::from_u128(1),
+        writer_epoch: 1,
+        writer_seq: 1,
+        created_unix_ns: 0,
+        level: SegmentLevel::L0,
+    }
+}
+
+fn seg_records(s: usize) -> Vec<LogRecord> {
+    (0..RECORDS_PER_SEG)
+        .map(|i| {
+            let ts = (s * 1000 + i) as i64;
+            record(ts, &format!("s{s}-r{i}"))
+        })
+        .collect()
+}
+
+/// Build the fixture on `store` and return the snapshot plus the full `(ts, body)`
+/// row set written.
+async fn build_fixture(store: &dyn ObjectStoreBackend) -> (Snapshot, BTreeSet<(i64, String)>) {
+    let mut segments = Vec::with_capacity(SEGMENTS);
+    let mut want = BTreeSet::new();
+    for s in 0..SEGMENTS {
+        let recs = seg_records(s);
+        for r in &recs {
+            want.insert((r.ts_ns, r.body.clone()));
+        }
+        let mut content_hash = [0u8; 32];
+        content_hash[0] = (s + 1) as u8;
+        let seg = write_object(store, &format!("logs/seg{s}.rlog"), content_hash, &recs).await;
+        segments.push(seg);
+    }
+    let snapshot = Snapshot {
+        segments,
+        segments_pruned: 0,
+        pending_erasure: Vec::new(),
+    };
+    (snapshot, want)
+}
+
+fn provider(snapshot: Snapshot, fetcher: LogSegmentFetcher) -> LogsTableProvider {
+    LogsTableProvider::new(
+        snapshot,
+        TenantHash([7u8; 16]),
+        fetcher,
+        QueryAccounting::new(),
+    )
+}
+
+async fn collect_plan(plan: Arc<dyn ExecutionPlan>) -> Vec<RecordBatch> {
+    collect(plan, Arc::new(TaskContext::default()))
+        .await
+        .expect("collect")
+}
+
+fn batches_to_rows(batches: &[RecordBatch]) -> BTreeSet<(i64, String)> {
+    let mut out = BTreeSet::new();
+    for batch in batches {
+        let ts = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<TimestampNanosecondArray>()
+            .expect("ts col");
+        let body = batch
+            .column(4)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("body col");
+        for i in 0..batch.num_rows() {
+            out.insert((ts.value(i), body.value(i).to_string()));
+        }
+    }
+    out
+}
+
+fn find_by_name(plan: &Arc<dyn ExecutionPlan>, name: &str) -> Option<Arc<dyn ExecutionPlan>> {
+    if plan.name() == name {
+        return Some(Arc::clone(plan));
+    }
+    plan.children().iter().find_map(|c| find_by_name(c, name))
+}
+
+/// Sum a per-partition counter metric across every partition of the executed
+/// `LogsScanExec`.
+fn sum_metric(plan: &Arc<dyn ExecutionPlan>, name: &str) -> usize {
+    let set = find_by_name(plan, "LogsScanExec")
+        .expect("a LogsScanExec leaf")
+        .metrics()
+        .expect("the scan publishes metrics");
+    set.iter()
+        .filter(|m| m.value().name() == name)
+        .map(|m| m.value().as_usize())
+        .sum()
+}
+
+fn build_read_cache(cache_bytes: u64) -> Arc<Cache<CacheFetchError>> {
+    let max_entries = (cache_bytes / 4096).max(64) as usize;
+    Arc::new(Cache::new(CacheLimits::new(
+        cache_bytes,
+        max_entries,
+        cache_bytes,
+    )))
+}
+
+// ---- shape-counting store ------------------------------------------------
+
+/// Counts `get` calls split by `GetRange` shape, so a test can pin the exact
+/// number of suffix probes vs whole-object reads vs byte-range GETs a scan
+/// issues.
+struct ShapeCountingStore {
+    inner: Arc<MemoryStore>,
+    full: AtomicU64,
+    suffix: AtomicU64,
+    range: AtomicU64,
+}
+
+impl ShapeCountingStore {
+    fn new(inner: Arc<MemoryStore>) -> Arc<Self> {
+        Arc::new(ShapeCountingStore {
+            inner,
+            full: AtomicU64::new(0),
+            suffix: AtomicU64::new(0),
+            range: AtomicU64::new(0),
+        })
+    }
+    fn full_gets(&self) -> u64 {
+        self.full.load(Ordering::SeqCst)
+    }
+    fn suffix_gets(&self) -> u64 {
+        self.suffix.load(Ordering::SeqCst)
+    }
+    fn range_gets(&self) -> u64 {
+        self.range.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl ObjectStoreBackend for ShapeCountingStore {
+    async fn put(
+        &self,
+        key: &str,
+        data: bytes::Bytes,
+        opts: PutOptions,
+    ) -> Result<PutOutcome, StoreError> {
+        self.inner.put(key, data, opts).await
+    }
+    async fn get(&self, key: &str, range: GetRange) -> Result<GetOutcome, StoreError> {
+        match range {
+            GetRange::Full => self.full.fetch_add(1, Ordering::SeqCst),
+            GetRange::Suffix(_) => self.suffix.fetch_add(1, Ordering::SeqCst),
+            GetRange::Range(_, _) => self.range.fetch_add(1, Ordering::SeqCst),
+        };
+        self.inner.get(key, range).await
+    }
+    async fn head(&self, key: &str) -> Result<ObjectMeta, StoreError> {
+        self.inner.head(key).await
+    }
+    async fn list(&self, prefix: &str, page: Option<PageToken>) -> Result<ListPage, StoreError> {
+        self.inner.list(prefix, page).await
+    }
+    async fn list_delimited(&self, prefix: &str) -> Result<DelimitedList, StoreError> {
+        self.inner.list_delimited(prefix).await
+    }
+    async fn delete(&self, key: &str) -> Result<(), StoreError> {
+        self.inner.delete(key).await
+    }
+    fn capabilities(&self) -> Capabilities {
+        Capabilities {
+            multipart: false,
+            ..self.inner.capabilities()
+        }
+    }
+}
+
+/// A fetcher whose block-range threshold is 0, so every non-empty object counts
+/// as ABOVE the threshold (the band the fast path is gated to), with ADR-0046's
+/// read cache wired.
+fn above_threshold_fetcher(store: Arc<dyn ObjectStoreBackend>) -> LogSegmentFetcher {
+    LogSegmentFetcher::new(store)
+        .with_cache(build_read_cache(64 << 20))
+        .with_block_range_threshold(0)
+}
+
+// ---- deliverable 1: the fast path ----------------------------------------
+
+/// The whole-window fast path issues exactly one whole-object GET per segment and
+/// ZERO suffix probes, returns every written row once, and its BlockMetrics
+/// totals equal the snapshot's block totals exactly once.
+#[tokio::test]
+async fn predicate_free_full_window_reads_one_whole_object_per_segment() {
+    let base = Arc::new(MemoryStore::new());
+    let (snapshot, want) = build_fixture(base.as_ref()).await;
+
+    let counting = ShapeCountingStore::new(base);
+    let store: Arc<dyn ObjectStoreBackend> = Arc::clone(&counting) as Arc<dyn ObjectStoreBackend>;
+    let fetcher = above_threshold_fetcher(store);
+    let plan = provider(snapshot, fetcher).plan(PARTS).expect("plan");
+    let batches = collect_plan(Arc::clone(&plan)).await;
+
+    // Exact request-count law: one whole-object read per segment, no probes,
+    // no byte-range GETs.
+    assert_eq!(
+        counting.suffix_gets(),
+        0,
+        "fast path issues no suffix probes: got {}",
+        counting.suffix_gets()
+    );
+    assert_eq!(
+        counting.range_gets(),
+        0,
+        "fast path issues no byte-range GETs: got {}",
+        counting.range_gets()
+    );
+    assert_eq!(
+        counting.full_gets(),
+        SEGMENTS as u64,
+        "fast path issues exactly one whole-object read per segment"
+    );
+
+    // Rows are exactly the written set (identical to what the striped path
+    // returns; see `fast_path_rows_match_the_striped_path`).
+    assert_eq!(
+        batches_to_rows(&batches),
+        want,
+        "fast path returns every written row once"
+    );
+
+    // BlockMetrics totals equal the snapshot's block totals, exactly once: a
+    // segment opened twice (a broken assignment) would double these.
+    assert_eq!(
+        sum_metric(&plan, "blocks_total"),
+        SEGMENTS * BLOCKS_PER_SEG,
+        "blocks_total is the whole snapshot's block count, recorded once"
+    );
+    assert_eq!(
+        sum_metric(&plan, "blocks_scanned"),
+        SEGMENTS * BLOCKS_PER_SEG,
+        "every block is scanned exactly once"
+    );
+}
+
+/// The fast path returns byte-identical rows to the striped path over the same
+/// data. The striped path is forced by raising the block-range threshold above
+/// the object size, so the fast-path gate's `object_size > threshold` conjunct
+/// fails and the unchanged plan-then-stripe path runs.
+#[tokio::test]
+async fn fast_path_rows_match_the_striped_path() {
+    let base = Arc::new(MemoryStore::new());
+    let (snapshot, want) = build_fixture(base.as_ref()).await;
+    let store: Arc<dyn ObjectStoreBackend> = base;
+
+    let fast = above_threshold_fetcher(Arc::clone(&store));
+    let fast_rows = batches_to_rows(
+        &collect_plan(
+            provider(snapshot.clone(), fast)
+                .plan(PARTS)
+                .expect("fast plan"),
+        )
+        .await,
+    );
+
+    let striped = LogSegmentFetcher::new(Arc::clone(&store))
+        .with_cache(build_read_cache(64 << 20))
+        .with_block_range_threshold(u64::MAX);
+    let striped_rows = batches_to_rows(
+        &collect_plan(
+            provider(snapshot, striped)
+                .plan(PARTS)
+                .expect("striped plan"),
+        )
+        .await,
+    );
+
+    assert_eq!(fast_rows, striped_rows, "fast and striped rows must match");
+    assert_eq!(fast_rows, want, "and both equal the written rows");
+}
+
+// ---- deliverable 1: each fail-closed conjunct takes the striped path ------
+
+/// Every conjunct-failing shape runs the plan-then-stripe path instead of the
+/// fast path, which a big-cache fixture makes observable as exactly `SEGMENTS`
+/// suffix probes (one per segment, from the plan phase; the per-partition opens
+/// hit the cached probe or carry the plan footer and add none) and zero
+/// whole-object reads through the fast-path entry. The fast path issues the
+/// opposite: zero suffix probes.
+async fn assert_takes_striped_path(
+    filters: &[datafusion::logical_expr::Expr],
+    parts: usize,
+    pending_erasure: Vec<ravel_proto::commit::v1::ErasureRequest>,
+) -> u64 {
+    let base = Arc::new(MemoryStore::new());
+    let (mut snapshot, _want) = build_fixture(base.as_ref()).await;
+    snapshot.pending_erasure = pending_erasure;
+
+    let counting = ShapeCountingStore::new(base);
+    let store: Arc<dyn ObjectStoreBackend> = Arc::clone(&counting) as Arc<dyn ObjectStoreBackend>;
+    let fetcher = above_threshold_fetcher(store);
+    let plan = provider(snapshot, fetcher)
+        .plan_filters(parts, filters)
+        .expect("plan");
+    let _ = collect_plan(plan).await;
+    counting.suffix_gets()
+}
+
+#[tokio::test]
+async fn conjunct_has_word_predicate_takes_striped_path() {
+    use datafusion::logical_expr::{col, lit};
+    // `has_word(body, 's0-r0')` -> a content predicate, so not predicate-free.
+    let expr = ravel_sql::has_word_udf().call(vec![col("body"), lit("s0-r0")]);
+    let probes = assert_takes_striped_path(&[expr], PARTS, Vec::new()).await;
+    assert_eq!(
+        probes, SEGMENTS as u64,
+        "a content predicate runs the plan phase: one suffix probe per segment"
+    );
+}
+
+#[tokio::test]
+async fn conjunct_partial_ts_window_takes_striped_path() {
+    use datafusion::common::ScalarValue;
+    use datafusion::logical_expr::{col, lit};
+    // A ts upper bound that cuts the last segment's last block: every segment
+    // still overlaps (so all are relevant), but the last is not contained, so
+    // the containment conjunct fails.
+    let global_max = ((SEGMENTS - 1) * 1000 + (RECORDS_PER_SEG - 1)) as i64;
+    let cut = global_max - 1;
+    let expr = col("ts").lt_eq(lit(ScalarValue::TimestampNanosecond(Some(cut), None)));
+    let probes = assert_takes_striped_path(&[expr], PARTS, Vec::new()).await;
+    assert_eq!(
+        probes, SEGMENTS as u64,
+        "a segment-cutting ts bound runs the plan phase: one suffix probe per segment"
+    );
+}
+
+#[tokio::test]
+async fn conjunct_pending_erasure_takes_striped_path() {
+    // A pending erasure request on the snapshot makes the query
+    // not-block-predicate-free even with no WHERE clause.
+    let erasure = vec![ravel_proto::commit::v1::ErasureRequest {
+        predicate: vec![ravel_proto::commit::v1::ErasurePredicateMatcher {
+            key: "service.name".to_string(),
+            value: "svc".to_string(),
+        }],
+        ..Default::default()
+    }];
+    let probes = assert_takes_striped_path(&[], PARTS, erasure).await;
+    assert_eq!(
+        probes, SEGMENTS as u64,
+        "a pending erasure runs the plan phase: one suffix probe per segment"
+    );
+}
+
+#[tokio::test]
+async fn conjunct_fewer_segments_than_partitions_takes_striped_path() {
+    // relevant_segments (4) < target_partitions (8): the whole-segment
+    // assignment cannot fill every partition, so the striped path runs. The plan
+    // footer it reads is carried to each block-subset open (deliverable 2), so
+    // the opens add no probe and the count is exactly one per segment.
+    let probes = assert_takes_striped_path(&[], SEGMENTS * 2, Vec::new()).await;
+    assert_eq!(
+        probes, SEGMENTS as u64,
+        "undersubscribed striped path: one plan suffix probe per segment, none per open"
+    );
+}

--- a/docs/adrs/0102-intra-segment-scan-partitioning-and-spill-policy.md
+++ b/docs/adrs/0102-intra-segment-scan-partitioning-and-spill-policy.md
@@ -327,3 +327,50 @@ striping would multiply object-store reads by the partition count (measured at
 speed-up. The gate was always `LogSegmentFetcher::has_cache`; this amendment
 records that the same predicate now selects the assignment mode, not only the
 partition count.
+
+## Amendment (2026-08-26, #693 part 3): predicate-free full-window whole-segment assignment
+
+Decision 1 stripes a snapshot's surviving blocks across partitions and resolves
+the per-segment surviving-block counts up front, once, through a plan phase
+(`compute_plan_counts`, `LogSegmentFetcher::plan_segment`) behind a `OnceCell`
+barrier. For a predicate-free full-window statement that plan phase is pure
+overhead: no block can be pruned, so every segment's survivor count is its whole
+block count, known from the footer with no block decode. Worse, above the
+block-range threshold (ADR-0107) the plan phase issues one suffix probe per
+segment that never coalesces with the scan reads — the barrier makes it the
+first, cold touch, and it is evicted from S3-FIFO probation before the scan (on
+the 8424-object tenant of #680 that was 8,424 plan probes plus ~16,300 scan-side
+re-probes plus 8,424 whole-object reads for a single `SELECT`).
+
+So for a statement that satisfies all four conjuncts below, the plan phase is
+skipped entirely and whole segments are assigned round-robin — the same rule the
+un-cached path uses (segment `j` in snapshot order to partition `j % n`, `n =
+min(target_partitions, relevant_segments)`) — with each segment read whole in
+one GET (`scan_whole_accounted_with_tenant`, a single `GetRange::Full`, no
+probe). The request count becomes exactly one whole-object read per relevant
+segment, zero suffix probes.
+
+The four conjuncts, all decidable from the resolved snapshot with zero I/O (they
+reuse `plan_segment`'s own fast-path gate per segment):
+
+1. the query is block-predicate-free (`LogQuery::is_block_predicate_free`: no
+   content, prune-only, or stream-attribute arm);
+2. the snapshot carries no pending selective erasure (folded into (1) via
+   `LogQuery::erasure`), since erasure removes rows the committed counts still
+   include;
+3. every relevant (ts-overlapping) segment is above the block-range threshold,
+   has a well-formed span, and is fully CONTAINED in the query window
+   (`ts_min <= seg.min && seg.max <= ts_max`) — strictly stronger than the
+   overlap the provider already pruned on, so every block of every relevant
+   segment survives; and
+4. there are at least `target_partitions` relevant segments, so whole-segment
+   round-robin still fills every partition.
+
+When any conjunct fails, the unchanged plan-then-stripe path runs. The
+`object_size > block_range_threshold` conjunct keeps the fast path to the band
+where it actually saves a request: at or below the threshold the plan and scan
+reads already coalesce on the one `(0, object_size)` whole-object cache key, so
+there is no probe to eliminate. `BlockMetrics::record_segment_totals` moves from
+the partition-0 planning hack to per-segment scan stats on this path (each
+segment has exactly one owning partition, so the whole-segment totals are still
+recorded exactly once).

--- a/docs/adrs/0107-pruning-proportional-logs-fetch.md
+++ b/docs/adrs/0107-pruning-proportional-logs-fetch.md
@@ -305,3 +305,35 @@ one for queries (`ravel-server`'s query wiring and `sql_latency_bench`).
 Before this amendment nothing set it, so every logs scan ran at most 16
 GETs in flight regardless of the flag, and a 100M-row `count(*)` measured
 the same 160 s at `--fetch-concurrency` 16 and 32.
+
+## Amendment 2026-08-26 (issue #693 part 3): a footer carried from the plan phase establishes the etag pin on the first data GET
+
+Decision 1 establishes the mandatory etag pin on the suffix probe: the probe is
+the first live GET of the sequence, so its etag is what every later block-range
+or metadata GET is checked against. Issue #693 part 3 adds a second way in.
+`LogSegmentFetcher::plan_segment`'s predicate-free fast path already reads and
+parses the footer via the probe; it now returns that `LogFooter`, and
+`ravel_sql::logs_scan` carries it into each per-partition subset open
+(`fetch_object_with_footer`). Given the footer, that open skips its own suffix
+probe — the footer already gives every section's offset and length — and
+establishes the pin on the FIRST live section or block GET instead
+(`store_get_pinned`, normally the SKIP_IDX GET).
+
+This is still fail-closed, and no `ravel-logseg` change is needed. Two distinct
+replacement cases:
+
+- A replacement DURING the open's own GET sequence makes a later live GET report
+  a different etag than the first one pinned, exactly as the probe path catches
+  it: `LogFetchError::EtagChanged`, never a buffer assembled from two states.
+- A replacement BEFORE the open even starts is caught by the carried footer's
+  per-section `crc32c`: a section read at the old offset from a different object
+  fails its stored crc on decode (`decode_section`), a hard `LogFetchError::Corrupt`.
+
+The pin is per-open, not carried across calls: the footer struct is reused, but
+each open re-verifies the bytes it reads. Because a footer is only ever carried
+for a predicate-free, fully-contained query, every block is a candidate and the
+coverage crossover reads the whole object, which supplies the footer and trailer
+bytes `RlogReader` re-parses to open the assembled buffer. The block-range
+(non-coverage) branch, reachable only when a caller forces the ranged path,
+places that tail region explicitly so a footer-carried open never assembles a
+buffer with a zeroed trailer.

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -110,6 +110,27 @@ rows the committed counts still include. So an operator who sees a `COUNT(*)`
 answered with zero GETs is seeing the by-design fast path, and one predicate
 or one pending erasure is enough to put the read back on the scan.
 
+## Predicate-free full-window logs scan: request count
+
+Every OTHER predicate-free, full-window logs statement — `SUM`, `AVG`,
+`GROUP BY`, `ORDER BY ... LIMIT` over the whole table — still executes
+`LogsScanExec`, but issues exactly one whole-object GET per relevant segment and
+ZERO suffix probes (#693 part 3). When the query carries no block-level
+predicate and no pending erasure, its window fully contains every relevant,
+above-threshold segment, and there are at least `target_partitions` such
+segments, `LogsScanExec` skips its plan phase entirely: no block can be pruned,
+so it assigns whole segments round-robin (one owner per segment) and reads each
+in a single `GetRange::Full`. That removes both probe classes the pre-#693-part-3
+path paid above the block-range threshold — the plan-phase footer probe and the
+per-open scan-side re-probe — which on the 8424-object ClickBench tenant (#680)
+were a combined ~24,700 probes on top of the 8,424 whole-object reads for one
+`SELECT`. When any of those conditions fails the unchanged plan-then-stripe path
+runs (its plan phase probes each segment once); a footer read there is carried
+to the per-partition subset opens so they skip re-probing (ADR-0107 amendment
+2026-08-26). At or below the block-range threshold the plan and scan reads
+already coalesce on one whole-object cache key, so the fast path is gated above
+it, where there is a probe to save.
+
 Staleness: the evaluator recognizes the Prometheus staleness marker (the
 exact NaN bit pattern `0x7ff0_0000_0000_0002`, compared via
 `f64::to_bits()`, never `is_nan()`). A selector whose newest in-window


### PR DESCRIPTION
Post-#707 a predicate-free full-window logs statement on the 8424-object
ClickBench tenant still issued 33,122 GETs: 8,424 plan-phase suffix
probes (fetch_footer from plan_segment_fast, consumed only for
footer.block_count), about 16,300 scan-side re-probes (fetch_object's
identical probe once per segment-open, 2.1 blocks per segment striped
over 8 partitions), and 8,424 whole-object reads. The plan probe is never
coalesced with the scan probe: the plan barrier makes it the first, cold
touch, and the probe lands in S3-FIFO probation at freq 0 and is evicted
before the scan.

Two changes. LogsScanExec::whole_segment_fast_path skips the plan phase
entirely when the query is block-predicate free (no content, prune,
stream-attribute or pending-erasure arm), every relevant segment's span
is contained in the window, every relevant segment is above the
block-range threshold with a well-formed span (the same conjuncts
plan_segment's own fast gate uses), and relevant_segments >=
target_partitions: whole segments are assigned round-robin (segment j to
partition j % n, the rule #693 part 1 uses un-cached) and opened with
the whole-segment scan entry, and BlockMetrics totals are recorded per
segment by its single owner instead of by partition 0. When any
conjunct fails the plan-then-stripe path runs unchanged. And
plan_segment_fast now returns the parsed LogFooter, SegPlan carries it,
and a footer-carried fetch_object skips the scan-side suffix probe,
establishing the etag pin on the first data GET instead (a replaced
object is still caught there, never silently mixed). ravel-logseg is
untouched: the reader re-parses the footer from the assembled buffer,
which the whole-object read supplies.

On the test fixture (4 above-threshold segments, 3 blocks each, cache
wired, 4 partitions) the fast path issues 0 suffix probes, 0 byte-range
GETs and 4 whole-object reads with blocks_total = blocks_scanned = 12
recorded once; forcing the plan phase brings the probes back to 4, and
breaking the assignment doubles the totals. The footer-carried subset
open issues 1 probe per segment (the plan's) instead of 2. The
logs_scan_scaling smoke fixture's objects are below the threshold, so
its figures are unchanged by construction; its module doc says so.
ADR-0102 and ADR-0107 carry dated amendments (the four conjuncts; the
pin moving from the probe to the first data GET), docs/query-engine.md
the request count for a predicate-free full-window statement, and the
three stale coalescing/erasure comments are corrected.

Refs: #693
Refs: #680
