### PR TITLE
perf(ravel-maintain): bound rlog compaction to one part, fan out input reads

### DIFF
--- a/crates/ravel-maintain/src/config.rs
+++ b/crates/ravel-maintain/src/config.rs
@@ -34,10 +34,10 @@ use uuid::Uuid;
 ///   `O(input_count * block_size)` and does NOT scale with stream/trace size.
 /// - [`Self::peak_total_bytes`]: `fetched + decoded + writer`, adding the
 ///   in-progress part's writer buffer. The writer term is bounded by
-///   `max_l1_part_bytes` (a part is flushed once its record-byte estimate
-///   reaches the cap on a stream boundary) and is the unavoidable
-///   content-addressing cost the ADR calls out: a part's key does not exist
-///   until the whole part is buffered.
+///   `max_l1_part_bytes` (a part is flushed as soon as its record-heap
+///   estimate reaches the cap, mid-stream if that is where the cap falls) and
+///   is the unavoidable content-addressing cost the ADR calls out: a part's
+///   key does not exist until the whole part is buffered.
 ///
 /// Production never installs one (`CompactorConfig::merge_memory_tracker` is
 /// `None`), so the hooks compile to a single `Option` check and add nothing.
@@ -140,6 +140,8 @@ pub const DEFAULT_MIN_COMPACTION_INPUTS: usize = 2;
 /// Default footer suffix-probe size. 64 KiB covers the footer + catalog of a
 /// typical L0 flush in one GET (docs/segment-format.md reader protocol).
 pub const DEFAULT_FOOTER_PROBE_BYTES: u64 = 64 * 1024;
+/// Default `input_read_concurrency`: 8 input reads in flight at once.
+pub const DEFAULT_INPUT_READ_CONCURRENCY: usize = 8;
 
 /// Default `grace`: 24 hours (docs/consistency-model.md "Deletion and GC").
 /// A shared floor for the orphan and unreferenced-part age gates.
@@ -299,6 +301,20 @@ pub struct CompactorConfig {
     pub min_compaction_inputs: usize,
     /// Suffix-probe size for the first footer GET of each input.
     pub footer_probe_bytes: u64,
+    /// How many per-input reads a compaction or rewrite keeps in flight at
+    /// once: the commit-record GETs of [`crate::read::load_inputs`] and the
+    /// per-input catalog loads that follow it. A bucket with hundreds of
+    /// inputs otherwise pays one full store round trip per input in sequence,
+    /// which dominates the merge on any real object store.
+    ///
+    /// This bounds request concurrency only, never resident bytes: a catalog
+    /// is directory metadata (KBs), and the merge itself still streams one
+    /// block at a time per cursor. Values below 1 are treated as 1. Output
+    /// bytes do not depend on it -- inputs are re-sorted into canonical order
+    /// after loading and the merge is a deterministic k-way merge over that
+    /// order -- so raising it can change timing but never content. Default
+    /// [`DEFAULT_INPUT_READ_CONCURRENCY`] (8).
+    pub input_read_concurrency: usize,
     /// This compactor process's uuid. Informational only: it is recorded in
     /// each part's footer `writer_id` and never enters dedup priority.
     /// Default is the nil uuid; the service sets a real one.
@@ -403,6 +419,7 @@ impl Default for CompactorConfig {
             max_l1_part_bytes: DEFAULT_MAX_L1_PART_BYTES,
             min_compaction_inputs: DEFAULT_MIN_COMPACTION_INPUTS,
             footer_probe_bytes: DEFAULT_FOOTER_PROBE_BYTES,
+            input_read_concurrency: DEFAULT_INPUT_READ_CONCURRENCY,
             compactor_writer_id: Uuid::nil(),
             grace_ns: DEFAULT_GRACE_NS,
             protection_horizon_ns: DEFAULT_PROTECTION_HORIZON_NS,

--- a/crates/ravel-maintain/src/erasure_rewrite.rs
+++ b/crates/ravel-maintain/src/erasure_rewrite.rs
@@ -71,6 +71,7 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 
 use bytes::Bytes;
+use futures::stream::{StreamExt, TryStreamExt, iter as stream_iter};
 use prost::Message;
 use ravel_commit::erasure;
 use ravel_commit::keys;
@@ -576,10 +577,12 @@ async fn resolve_live_inputs(
     store: &dyn ObjectStoreBackend,
     bucket: &Bucket,
     listing: &BucketListing,
+    concurrency: usize,
 ) -> Result<LiveInputs> {
     match resolve_live_record(store, bucket, listing).await? {
         LiveRecord::RawL0 => {
-            let inputs = crate::read::load_inputs(store, bucket, &listing.commit_keys).await?;
+            let inputs =
+                crate::read::load_inputs(store, bucket, &listing.commit_keys, concurrency).await?;
             Ok(LiveInputs::RawL0(inputs))
         }
         LiveRecord::Existing { key, body } => Ok(LiveInputs::Existing { key, body }),
@@ -644,10 +647,18 @@ async fn load_live_catalogs_and_target(
 ) -> Result<(Vec<InputCatalog>, RewriteSupersession)> {
     match live {
         LiveInputs::RawL0(inputs) => {
-            let mut catalogs = Vec::with_capacity(inputs.len());
-            for input in &inputs {
-                catalogs.push(crate::read::load_input_catalog(store, config, input).await?);
-            }
+            // `buffered`, not `buffer_unordered`: the catalogs stay aligned
+            // one-to-one with `inputs` in canonical order (the merge's
+            // tie-break depends on it) while `input_read_concurrency` loads
+            // are in flight.
+            let catalogs: Vec<InputCatalog> = stream_iter(
+                inputs
+                    .iter()
+                    .map(|input| crate::read::load_input_catalog(store, config, input)),
+            )
+            .buffered(config.input_read_concurrency.max(1))
+            .try_collect()
+            .await?;
             let identities = inputs
                 .iter()
                 .map(|i| CompactionInputIdentity {
@@ -1765,7 +1776,7 @@ pub async fn erasure_rewrite_bucket(
     // record set's actual event-time bounds, not the bucket's ingest-hour
     // key, so it can only run after `resolve_live_inputs`'s cheap metadata
     // GET, unlike the old purely key-derived prefilter this replaced.
-    let live = resolve_live_inputs(store, bucket, &listing).await?;
+    let live = resolve_live_inputs(store, bucket, &listing, config.input_read_concurrency).await?;
     let (min_event_ts_ns, max_event_ts_ns) = live_input_event_bounds(&live);
     let overlapping: Vec<&PendingErasureRequest> = pending
         .iter()
@@ -2083,7 +2094,13 @@ pub async fn bucket_erasure_completion(
     // The live view a snapshot would serve: raw L0 records whose identity no
     // record excluded, compaction records no rewrite superseded, and rewrite
     // records no newer rewrite superseded.
-    let l0_inputs = crate::read::load_inputs(store, bucket, &listing.commit_keys).await?;
+    let l0_inputs = crate::read::load_inputs(
+        store,
+        bucket,
+        &listing.commit_keys,
+        config.input_read_concurrency,
+    )
+    .await?;
     let live_l0: Vec<&crate::read::InputRecord> = l0_inputs
         .iter()
         .filter(|ir| {
@@ -2611,7 +2628,7 @@ mod tests {
         let listing = crate::read::list_bucket(&store, &b)
             .await
             .expect("list bucket");
-        let live = resolve_live_inputs(&store, &b, &listing)
+        let live = resolve_live_inputs(&store, &b, &listing, 1)
             .await
             .expect("resolve live inputs");
         let (catalogs, supersession) = load_live_catalogs_and_target(&store, &config, live)
@@ -3502,7 +3519,7 @@ mod tests {
         let listing = crate::read::list_bucket(&store, &b)
             .await
             .expect("list bucket");
-        let live = resolve_live_inputs(&store, &b, &listing)
+        let live = resolve_live_inputs(&store, &b, &listing, 1)
             .await
             .expect("resolve live inputs");
         let (object_keys, supersession) =
@@ -3951,7 +3968,7 @@ mod tests {
         let listing = crate::read::list_bucket(&store, &b)
             .await
             .expect("list bucket");
-        let live = resolve_live_inputs(&store, &b, &listing)
+        let live = resolve_live_inputs(&store, &b, &listing, 1)
             .await
             .expect("resolve live inputs");
         let (object_keys, supersession) =
@@ -4693,7 +4710,7 @@ mod tests {
         let listing = crate::read::list_bucket(store.as_ref(), &bucket())
             .await
             .expect("list bucket");
-        let inputs = crate::read::load_inputs(store.as_ref(), &bucket(), &listing.commit_keys)
+        let inputs = crate::read::load_inputs(store.as_ref(), &bucket(), &listing.commit_keys, 1)
             .await
             .expect("load inputs");
         let l0_key_by_seq: HashMap<u64, String> = inputs
@@ -4900,7 +4917,7 @@ mod tests {
         let listing = crate::read::list_bucket(&store, &logs_bucket())
             .await
             .expect("list bucket");
-        let inputs = crate::read::load_inputs(&store, &logs_bucket(), &listing.commit_keys)
+        let inputs = crate::read::load_inputs(&store, &logs_bucket(), &listing.commit_keys, 1)
             .await
             .expect("load inputs");
         assert_eq!(inputs.len(), 1);

--- a/crates/ravel-maintain/src/erasure_rewrite.rs
+++ b/crates/ravel-maintain/src/erasure_rewrite.rs
@@ -650,15 +650,16 @@ async fn load_live_catalogs_and_target(
             // `buffered`, not `buffer_unordered`: the catalogs stay aligned
             // one-to-one with `inputs` in canonical order (the merge's
             // tie-break depends on it) while `input_read_concurrency` loads
-            // are in flight.
-            let catalogs: Vec<InputCatalog> = stream_iter(
-                inputs
-                    .iter()
-                    .map(|input| crate::read::load_input_catalog(store, config, input)),
-            )
-            .buffered(config.input_read_concurrency.max(1))
-            .try_collect()
-            .await?;
+            // are in flight. Futures are built in a plain loop, not a
+            // `.map()` closure, for the reason `crate::rewrite` documents.
+            let mut pending = Vec::with_capacity(inputs.len());
+            for input in &inputs {
+                pending.push(crate::read::load_input_catalog(store, config, input));
+            }
+            let catalogs: Vec<InputCatalog> = stream_iter(pending)
+                .buffered(config.input_read_concurrency.max(1))
+                .try_collect()
+                .await?;
             let identities = inputs
                 .iter()
                 .map(|i| CompactionInputIdentity {

--- a/crates/ravel-maintain/src/erasure_rewrite.rs
+++ b/crates/ravel-maintain/src/erasure_rewrite.rs
@@ -3477,6 +3477,180 @@ mod tests {
         );
     }
 
+    /// ADR-0064 conservation through a mid-stream part split (issue #711).
+    ///
+    /// The bucket holds one log stream whose records exceed the compactor's
+    /// part cap several times over, so a real `compact_bucket` publishes a
+    /// compaction record naming SEVERAL L1 parts that all carry the same
+    /// `stream_id` -- the shape that did not exist before #711, when a stream
+    /// never straddled a part boundary. An erasure then runs over that
+    /// compacted bucket: it resolves the compaction record as its live input,
+    /// reads every one of its parts, and must conserve the count across all of
+    /// them (`input == output + dropped`, ADR-0064 decision 3 point 4).
+    ///
+    /// Non-vacuity is asserted, not assumed: the compaction must have produced
+    /// more than one part, and the erasure must have dropped a non-zero count
+    /// spread across more than one of those parts.
+    ///
+    /// Flip-line proof: in `publish_rewrite_record`, flipping `if
+    /// reconstructed != build.input_sample_count` to `==` makes a conservation
+    /// break publishable, and the `assert_eq!` on the surviving record set
+    /// below is what then fails. Removing the loop over `object_keys` in
+    /// `build_rewrite_logs` (reading only the first part) leaves the gate
+    /// itself to reject the run, failing `expect("erasure rewrite")`.
+    #[tokio::test]
+    async fn logs_erasure_conserves_count_through_a_mid_stream_part_split() {
+        const RECORDS: i64 = 400;
+        const CAP: u64 = 32 * 1024;
+        // Every fourth record belongs to the erased subject.
+        const ERASED_EVERY: i64 = 4;
+
+        let store = MemoryStore::new();
+        // One stream, wide rows, half in each of two L0 inputs.
+        let subject_of = |i: i64| {
+            if i % ERASED_EVERY == 0 {
+                "erased-subject"
+            } else {
+                "kept-subject"
+            }
+        };
+        let make = |i: i64| {
+            let mut attrs: Vec<(String, LogAttrValue)> = (0..8u32)
+                .map(|k| {
+                    (
+                        format!("attr_{k:02}"),
+                        LogAttrValue::Str(format!("value-{i:08}-{k:02}")),
+                    )
+                })
+                .collect();
+            attrs.push((
+                "user_id".to_string(),
+                LogAttrValue::Str(subject_of(i).to_string()),
+            ));
+            log_record(
+                0,
+                i64::from(HOUR) * NS_PER_HOUR + i,
+                &format!("row-{i:08}"),
+                attrs,
+            )
+        };
+        let all: Vec<LogRecord> = (0..RECORDS).map(make).collect();
+        for (j, chunk) in all.chunks(RECORDS as usize / 2).enumerate() {
+            seed_logs(&store, j as u64 + 1, chunk).await;
+        }
+
+        let clock = FixedClock::new(sealed_now_ns());
+        let config = CompactorConfig {
+            max_l1_part_bytes: CAP,
+            ..CompactorConfig::default()
+        };
+
+        // A real compaction first: this is what produces the straddling parts.
+        crate::compact::compact_bucket(&store, &clock, &config, &logs_bucket())
+            .await
+            .expect("compact");
+        let listing = crate::read::list_bucket(&store, &logs_bucket())
+            .await
+            .expect("list bucket");
+        assert_eq!(listing.compaction_record_keys.len(), 1);
+        let got = store
+            .get(&listing.compaction_record_keys[0], GetRange::Full)
+            .await
+            .expect("get compaction record");
+        let crec = CompactionRecord::decode(got.data.as_ref()).expect("decode");
+        assert!(
+            crec.parts.len() > 1,
+            "the fixture must split into several parts, got {}",
+            crec.parts.len()
+        );
+        let (stream0, _) = log_stream_ident(0);
+        for part in &crec.parts {
+            assert_eq!(
+                part.first_series_id,
+                stream0.0.to_vec(),
+                "every part must carry the one straddling stream"
+            );
+        }
+        // The erased subject really spans more than one part.
+        let mut parts_touching_subject = 0;
+        for part in &crec.parts {
+            let key = keys::reconstruct_l1_part_key(&crec, part).expect("part key");
+            let rows = decode_logs_part(&store, &key).await;
+            if rows.iter().any(|r| {
+                r.attrs.iter().any(|(k, v)| {
+                    k == "user_id" && v == &LogAttrValue::Str("erased-subject".to_string())
+                })
+            }) {
+                parts_touching_subject += 1;
+            }
+        }
+        assert!(
+            parts_touching_subject > 1,
+            "the erased subject must span several parts, touched {parts_touching_subject}"
+        );
+
+        let pending = vec![PendingErasureRequest {
+            request_key: "unused-in-memory-only".to_string(),
+            request: logs_erasure_request(7, "user_id", "erased-subject"),
+        }];
+        let mut memo = MaintainMemo::with_default_interval();
+        let outcome = erasure_rewrite_bucket(
+            &store,
+            &clock,
+            &config,
+            &NoLeases,
+            &logs_bucket(),
+            &pending,
+            &mut memo,
+        )
+        .await
+        .expect("erasure rewrite");
+        let publish = match outcome {
+            ErasureRewriteOutcome::Rewritten { publish, .. } => publish,
+            other => panic!("expected Rewritten, got {other:?}"),
+        };
+        assert_eq!(publish, PublishOutcome::Published);
+
+        // Conservation: input == output + dropped, over every part of the
+        // split compaction.
+        let expected_dropped = (0..RECORDS)
+            .filter(|i| subject_of(*i) == "erased-subject")
+            .count();
+        let record = read_rewrite_record_for(&store, &logs_bucket()).await;
+        assert_eq!(record.drops.len(), 1);
+        assert_eq!(
+            record.drops[0].dropped_count as usize, expected_dropped,
+            "every erased row across every part must be counted once"
+        );
+        let output_total: u64 = record.parts.iter().map(|p| p.sample_count).sum();
+        assert_eq!(
+            output_total + record.drops[0].dropped_count,
+            RECORDS as u64,
+            "output + dropped must equal the split bucket's whole record set"
+        );
+
+        // And the surviving rows are exactly the non-subject rows.
+        let mut survivors = Vec::new();
+        for part in &record.parts {
+            let key = keys::reconstruct_rewrite_part_key(&record, part).expect("part key");
+            survivors.extend(decode_logs_part(&store, &key).await);
+        }
+        let expected: Vec<LogRecord> = (0..RECORDS)
+            .filter(|i| subject_of(*i) == "kept-subject")
+            .map(make)
+            .collect();
+        assert_eq!(
+            survivors.len(),
+            expected.len(),
+            "exactly the non-subject rows survive"
+        );
+        let survivor_ts: std::collections::BTreeSet<i64> =
+            survivors.iter().map(|r| r.ts_ns).collect();
+        let expected_ts: std::collections::BTreeSet<i64> =
+            expected.iter().map(|r| r.ts_ns).collect();
+        assert_eq!(survivor_ts, expected_ts);
+    }
+
     /// Running the same LOGS rewrite twice from the same pre-publish state
     /// converges on one `RewriteRecord`, never a double count of dropped
     /// records -- the LOGS sibling of the metrics

--- a/crates/ravel-maintain/src/migrate.rs
+++ b/crates/ravel-maintain/src/migrate.rs
@@ -520,7 +520,13 @@ pub async fn migrate_family(
                 && listing.compaction_record_keys.is_empty()
                 && !listing.commit_keys.is_empty()
             {
-                let inputs = load_inputs(store, &bucket, &listing.commit_keys).await?;
+                let inputs = load_inputs(
+                    store,
+                    &bucket,
+                    &listing.commit_keys,
+                    config.input_read_concurrency,
+                )
+                .await?;
                 let l0_below = inputs
                     .iter()
                     .filter(|i| i.record.segment_format_version < target_version)

--- a/crates/ravel-maintain/src/read.rs
+++ b/crates/ravel-maintain/src/read.rs
@@ -12,6 +12,10 @@
 //! fetched lazily during the merge ([`crate::build`]) with ranged GETs, so
 //! peak memory is bounded by catalog metadata plus one in-flight part buffer, not by the whole bucket's page data.
 
+use std::future::Future;
+use std::pin::Pin;
+
+use futures::stream::{StreamExt, TryStreamExt, iter as stream_iter};
 use ravel_commit::keys::{self, BucketEntry};
 use ravel_commit::record;
 use ravel_object_store::{GetRange, ObjectStoreBackend, StoreError, list_all};
@@ -101,23 +105,34 @@ pub struct InputRecord {
 /// its own identity fields (ADR-0010 §7 discipline) and its signal against
 /// the bucket, then sort the inputs canonically by
 /// `(writer_id, writer_epoch, writer_seq)`.
+///
+/// The GETs run `concurrency` at a time (`CompactorConfig::input_read_concurrency`).
+/// A bucket with hundreds of L0 inputs is otherwise one full store round trip
+/// per input in sequence. Completion order does not reach the caller: the
+/// canonical sort below re-establishes the one ordering the merge's tie-break
+/// depends on, and `(writer_id, writer_epoch, writer_seq)` is unique per input
+/// (it is what the commit key is built from), so the sort is total and the
+/// result is identical at any concurrency.
 pub async fn load_inputs(
     store: &dyn ObjectStoreBackend,
     bucket: &Bucket,
     commit_keys: &[String],
+    concurrency: usize,
 ) -> Result<Vec<InputRecord>> {
-    let mut inputs = Vec::with_capacity(commit_keys.len());
-    for key in commit_keys {
-        let got = store.get(key, GetRange::Full).await?;
-        let record = record::decode(&got.data)?;
-        // The record's key must reconstruct to the key we listed it at.
-        verify_commit_key(&record, key)?;
-        verify_input_matches_bucket(bucket, &record)?;
-        inputs.push(InputRecord {
-            commit_key: key.clone(),
-            record,
-        });
-    }
+    // Box each GET future with an explicit `+ Send` bound before handing it to
+    // `buffer_unordered`, the same workaround `crate::build::fetch_batch_pages`
+    // documents: a bare `async` block borrowing the `&dyn ObjectStoreBackend`
+    // makes rustc infer a late-bound lifetime whose `Send` it cannot prove is
+    // general enough where the maintain loop is `tokio::spawn`ed.
+    type InputFuture<'f> = Pin<Box<dyn Future<Output = Result<InputRecord>> + Send + 'f>>;
+    let futures: Vec<InputFuture<'_>> = commit_keys
+        .iter()
+        .map(|key| Box::pin(load_one_input(store, bucket, key)) as InputFuture<'_>)
+        .collect();
+    let mut inputs: Vec<InputRecord> = stream_iter(futures)
+        .buffer_unordered(concurrency.max(1))
+        .try_collect()
+        .await?;
     inputs.sort_by(|a, b| {
         (
             a.record.writer_id.as_str(),
@@ -131,6 +146,25 @@ pub async fn load_inputs(
             ))
     });
     Ok(inputs)
+}
+
+/// GET, decode and verify one L0 commit record. Named (not an inline `async`
+/// block) so its future is `Send`-general over the borrowed store; see the
+/// call site in [`load_inputs`].
+async fn load_one_input(
+    store: &dyn ObjectStoreBackend,
+    bucket: &Bucket,
+    key: &str,
+) -> Result<InputRecord> {
+    let got = store.get(key, GetRange::Full).await?;
+    let record = record::decode(&got.data)?;
+    // The record's key must reconstruct to the key we listed it at.
+    verify_commit_key(&record, key)?;
+    verify_input_matches_bucket(bucket, &record)?;
+    Ok(InputRecord {
+        commit_key: key.to_string(),
+        record,
+    })
 }
 
 /// Verify a decoded commit record reconstructs to the key it was fetched at

--- a/crates/ravel-maintain/src/rewrite.rs
+++ b/crates/ravel-maintain/src/rewrite.rs
@@ -111,14 +111,20 @@ pub async fn rewrite_and_publish<C: SegmentCodec>(
     // compaction's pipeline. `buffered` (not `buffer_unordered`) keeps that
     // alignment while `input_read_concurrency` catalog loads are in flight:
     // it yields results in input order regardless of completion order.
-    let catalogs: Vec<C::Catalog> = stream_iter(
-        inputs
-            .iter()
-            .map(|input| C::load_input_catalog(store, config, input)),
-    )
-    .buffered(config.input_read_concurrency.max(1))
-    .try_collect()
-    .await?;
+    //
+    // The futures are built in a plain loop rather than a `.map()` closure:
+    // a closure returning a future that borrows its `&InputRecord` argument is
+    // inferred as higher-ranked over that lifetime, and its auto-traits then
+    // fail to leak through the stream adapter with "implementation of `FnOnce`
+    // is not general enough" wherever the maintain loop is `tokio::spawn`ed.
+    let mut pending = Vec::with_capacity(inputs.len());
+    for input in &inputs {
+        pending.push(C::load_input_catalog(store, config, input));
+    }
+    let catalogs: Vec<C::Catalog> = stream_iter(pending)
+        .buffered(config.input_read_concurrency.max(1))
+        .try_collect()
+        .await?;
 
     let parts = C::build_parts(store, config, bucket, &inputs, catalogs, &hash).await?;
 

--- a/crates/ravel-maintain/src/rewrite.rs
+++ b/crates/ravel-maintain/src/rewrite.rs
@@ -54,6 +54,7 @@
 //! the identical content-addressed parts and converges at the record's
 //! `CreateIfAbsent`, the same statelessness compaction has.
 
+use futures::stream::{StreamExt, TryStreamExt, iter as stream_iter};
 use ravel_object_store::ObjectStoreBackend;
 use ravel_types::Signal;
 
@@ -101,17 +102,23 @@ pub async fn rewrite_and_publish<C: SegmentCodec>(
     conservation: impl ConservationPredicate,
     start_ns: i64,
 ) -> Result<RewriteOutcome> {
-    let inputs = load_inputs(store, bucket, commit_keys).await?;
+    let inputs = load_inputs(store, bucket, commit_keys, config.input_read_concurrency).await?;
     C::validate_rewrite_inputs(&inputs)?;
     let hash = input_set_hash(&inputs);
 
     // Catalogs aligned one-to-one with `inputs` (canonical order): the merge
     // relies on that alignment for deterministic tie-breaking, same as
-    // compaction's pipeline.
-    let mut catalogs = Vec::with_capacity(inputs.len());
-    for input in &inputs {
-        catalogs.push(C::load_input_catalog(store, config, input).await?);
-    }
+    // compaction's pipeline. `buffered` (not `buffer_unordered`) keeps that
+    // alignment while `input_read_concurrency` catalog loads are in flight:
+    // it yields results in input order regardless of completion order.
+    let catalogs: Vec<C::Catalog> = stream_iter(
+        inputs
+            .iter()
+            .map(|input| C::load_input_catalog(store, config, input)),
+    )
+    .buffered(config.input_read_concurrency.max(1))
+    .try_collect()
+    .await?;
 
     let parts = C::build_parts(store, config, bucket, &inputs, catalogs, &hash).await?;
 
@@ -209,7 +216,13 @@ pub async fn migrate_bucket_format(
     // version without reading it). `load_inputs` verifies each record's key and
     // bucket, so the eligibility read rides on the same decode the rewrite
     // needs anyway.
-    let inputs = load_inputs(store, bucket, &listing.commit_keys).await?;
+    let inputs = load_inputs(
+        store,
+        bucket,
+        &listing.commit_keys,
+        config.input_read_concurrency,
+    )
+    .await?;
     let needs_migration = inputs
         .iter()
         .any(|i| i.record.segment_format_version < target_version);
@@ -893,7 +906,7 @@ mod tests {
         seed(&store, 2, vec![series("beta", &[(20, 2.0)])]).await;
         let b = bucket();
         let listing = list_bucket(&store, &b).await.expect("list");
-        let inputs = load_inputs(&store, &b, &listing.commit_keys)
+        let inputs = load_inputs(&store, &b, &listing.commit_keys, 1)
             .await
             .expect("inputs");
         let hash = input_set_hash(&inputs);

--- a/crates/ravel-maintain/src/rlog.rs
+++ b/crates/ravel-maintain/src/rlog.rs
@@ -1057,21 +1057,24 @@ async fn fetch_section(
 #[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
     use std::collections::BTreeSet;
+    use std::sync::Arc;
 
     use bytes::Bytes;
     use proptest::prelude::*;
     use prost::Message;
+    use ravel_catalog::{Catalog, CatalogConfig};
     use ravel_commit::record::{self, NewCommitRecord};
     use ravel_logseg::field_dir::FieldDir;
     use ravel_logseg::record::FieldType;
     use ravel_logseg::skip_index::SkipIndex;
     use ravel_logseg::{FieldSel, RlogConfig, RlogReader, RlogWriter, footer, read_section};
     use ravel_logseg::{LogRecord, Predicate, stream_attrs_bytes, writer::ObjectIdentity};
+    use ravel_object_store::fault::{FaultPlan, FaultStore, Occurrence, Op};
     use ravel_object_store::memory::MemoryStore;
     use ravel_object_store::{GetRange, ObjectStoreBackend, PutOptions, list_all};
     use ravel_proto::commit::v1::CompactionRecord;
     use ravel_types::logstream::{AttrValue, LogStreamId, canonical_attr_bytes, log_stream_id};
-    use ravel_types::{Signal, TenantHash, TenantId};
+    use ravel_types::{Signal, TenantHash, TenantId, TimeRange};
     use uuid::Uuid;
 
     use super::*;
@@ -2147,6 +2150,372 @@ mod tests {
         let mut expected = a.clone();
         expected.extend(b.clone());
         assert_eq!(canon_multiset(&l1), canon_multiset(&expected));
+    }
+
+    // --- mid-stream part splitting (issue #711) ------------------------------
+
+    /// Event-time base for the split fixtures: the start of the fixture
+    /// bucket's own ingest hour, so every record's event time sits inside the
+    /// hour its bucket is keyed by and the catalog's listing window covers it.
+    const SPLIT_BASE_NS: i64 = HOUR as i64 * NS_PER_HOUR;
+
+    /// One wide record of stream 0 at ordinal `i`. Every record this builds has
+    /// the *same* [`estimate_record`] value -- fixed attribute count, fixed key
+    /// lengths, fixed value lengths, and a zero-padded body and ordinal that do
+    /// not change width over the range the tests use -- so a part's record
+    /// capacity is `ceil(cap / estimate)` exactly and the part count is
+    /// arithmetic, not an observation.
+    fn wide_record(i: i64) -> LogRecord {
+        let attrs: Vec<(String, AttrValue)> = (0..8u32)
+            .map(|k| {
+                (
+                    format!("attr_{k:02}"),
+                    AttrValue::Str(format!("value-{:08}-{k:02}", i % 100_000_000)),
+                )
+            })
+            .collect();
+        record(0, SPLIT_BASE_NS + i, &format!("row-{i:08}"), attrs)
+    }
+
+    /// The number of parts a single-stream corpus of `records` records must
+    /// produce under `cap`: a part takes records until its running estimate
+    /// reaches the cap, so it holds `ceil(cap / estimate)` of them.
+    fn expected_part_count(record_estimate: u64, cap: u64, records: u64) -> u64 {
+        let per_part = cap.div_ceil(record_estimate);
+        records.div_ceil(per_part)
+    }
+
+    /// Read a compacted logs bucket back the way a query does: through the real
+    /// [`ravel_catalog::Catalog`] resolve, then decode every segment it serves,
+    /// concatenated in the resolver's own segment order.
+    async fn resolver_rows(store: &Arc<MemoryStore>, range: TimeRange) -> Vec<LogRecord> {
+        let catalog = Catalog::new(
+            Arc::clone(store) as Arc<dyn ObjectStoreBackend>,
+            CatalogConfig {
+                shard_count: SHARD + 1,
+                ..CatalogConfig::default()
+            },
+        )
+        .expect("catalog");
+        let resolved = catalog
+            .resolve(&tenant_hash(), Signal::Logs, range, &[], sealed_now_ns())
+            .await
+            .expect("resolve");
+        let mut rows = Vec::new();
+        for segment in &resolved.segments {
+            let got = store
+                .get(&segment.data_object_key, GetRange::Full)
+                .await
+                .expect("get segment");
+            rows.extend(decode_all(got.data.as_ref()));
+        }
+        rows
+    }
+
+    /// Issue #711: a bucket whose records all belong to ONE stream, and whose
+    /// total estimated heap exceeds `max_l1_part_bytes` several times over,
+    /// splits into exactly the number of parts the cap implies. The stream
+    /// straddles every boundary.
+    ///
+    /// Demonstrated red by restoring the pre-#711 between-streams-only check:
+    /// delete the `if over_cap { self.flush().await?; }` block from
+    /// `PartSink::push` and re-add the flush to `build_parts`'s
+    /// `for stream_id in merged.keys()` loop (`if part.estimate >=
+    /// config.max_l1_part_bytes { sink.flush().await?; }` after
+    /// `merge_stream_into_parts`). The part count collapses to 1 and this test
+    /// fails at `assert_eq!(parts.len() as u64, expected_parts)` with
+    /// `1 != 10`.
+    #[tokio::test]
+    async fn single_stream_bucket_splits_into_bounded_parts() {
+        const PER_INPUT: i64 = 600;
+        const INPUTS: i64 = 2;
+        const CAP: u64 = 64 * 1024;
+        let total = (PER_INPUT * INPUTS) as u64;
+
+        let store = Arc::new(MemoryStore::new());
+        // Interleaved by input but globally unique in ts, so the canonical
+        // merge order is a plain ts-ascending sequence with no tie-break.
+        let per_input: Vec<Vec<LogRecord>> = (0..INPUTS)
+            .map(|j| {
+                (0..PER_INPUT)
+                    .map(|i| wide_record(i * INPUTS + j))
+                    .collect()
+            })
+            .collect();
+        for (j, recs) in per_input.iter().enumerate() {
+            seed(
+                store.as_ref(),
+                Uuid::from_u128(j as u128 + 1),
+                j as u64 + 1,
+                recs,
+            )
+            .await;
+        }
+
+        let record_estimate = estimate_record(&wide_record(0));
+        let expected_parts = expected_part_count(record_estimate, CAP, total);
+        assert!(
+            expected_parts >= 4,
+            "fixture must exceed the cap several times over, got {expected_parts} parts"
+        );
+
+        let config = CompactorConfig {
+            max_l1_part_bytes: CAP,
+            ..CompactorConfig::default()
+        };
+        let clock = FixedClock::new(sealed_now_ns());
+        compact_bucket(store.as_ref(), &clock, &config, &bucket())
+            .await
+            .expect("compact");
+
+        let (rec, parts) = read_output(store.as_ref()).await;
+        assert_eq!(
+            parts.len() as u64,
+            expected_parts,
+            "cap {CAP} over {total} records estimated at {record_estimate} bytes each"
+        );
+
+        // Every record exactly once, across the parts, in canonical order.
+        let mut merged: Vec<LogRecord> = Vec::new();
+        for p in &parts {
+            merged.extend(decode_all(p));
+        }
+        let expected: Vec<LogRecord> = (0..total as i64).map(wide_record).collect();
+        assert_eq!(merged.len() as u64, total, "no record lost or duplicated");
+        assert_eq!(
+            canon_multiset(&merged),
+            canon_multiset(&expected),
+            "the part union must equal the input union"
+        );
+        assert_eq!(
+            merged.iter().map(|r| r.ts_ns).collect::<Vec<_>>(),
+            expected.iter().map(|r| r.ts_ns).collect::<Vec<_>>(),
+            "concatenating the parts in part order must reproduce canonical order"
+        );
+
+        // The stream really straddles: every part carries the one stream id,
+        // and the parts' bounds are adjacent and non-overlapping in event time.
+        let (stream0, _) = stream_ident(0);
+        let mut prev_max: Option<i64> = None;
+        let mut summed: u64 = 0;
+        for p in &rec.parts {
+            assert_eq!(p.first_series_id, stream0.0.to_vec());
+            assert_eq!(p.last_series_id, stream0.0.to_vec());
+            assert!(p.min_event_ts_ns <= p.max_event_ts_ns);
+            if let Some(prev) = prev_max {
+                assert!(
+                    prev < p.min_event_ts_ns,
+                    "part event-time ranges must be adjacent and non-overlapping"
+                );
+            }
+            prev_max = Some(p.max_event_ts_ns);
+            summed += p.sample_count;
+        }
+        assert_eq!(summed, total, "sum(part.sample_count) conserves the count");
+
+        // And the query path serves exactly those rows back.
+        let rows = resolver_rows(
+            &store,
+            TimeRange {
+                start_ns: SPLIT_BASE_NS,
+                end_ns: SPLIT_BASE_NS + total as i64 + 1,
+            },
+        )
+        .await;
+        assert_eq!(
+            canon_multiset(&rows),
+            canon_multiset(&expected),
+            "the resolver must serve the same rows the unsplit bucket held"
+        );
+    }
+
+    /// Issue #711: peak resident memory tracks the part cap, not the record
+    /// count. The same single-stream shape is compacted at 2x and 8x the
+    /// records; the tracker's total high-water must barely move.
+    ///
+    /// Demonstrated red against the unsplit code (the same flip as
+    /// `single_stream_bucket_splits_into_bounded_parts`): the whole stream then
+    /// lands in one writer, so the writer term is the whole corpus and the
+    /// ratio goes to about 4 (the ratio of the two record counts), failing
+    /// `ratio < 1.3`.
+    #[tokio::test]
+    async fn merge_peak_total_scales_with_the_cap_not_the_record_count() {
+        const BASE: i64 = 400;
+        const CAP: u64 = 256 * 1024;
+        const INPUTS: i64 = 2;
+        // The inputs are re-blocked at 100 records so the decode-side term is
+        // the same at both scales (every input carries far more than one
+        // block); at the 8192-record default an input's whole stream would be
+        // one block and the transient term would scale with the corpus, which
+        // is not what this test is about.
+        const L0_BLOCK: i64 = 100;
+        // At most one decoded block plus two raw blocks per input. Loose on
+        // purpose: the claim under test is the ratio.
+        const TRANSIENT_ALLOWANCE: u64 = 4 * 1024 * 1024;
+
+        let mut peaks = Vec::new();
+        for scale in [2i64, 8i64] {
+            let store = MemoryStore::new();
+            let total = BASE * scale;
+            for j in 0..INPUTS {
+                let recs: Vec<LogRecord> = (0..total / INPUTS)
+                    .map(|i| wide_record(i * INPUTS + j))
+                    .collect();
+                seed_l0(
+                    &store,
+                    Uuid::from_u128(j as u128 + 1),
+                    j as u64 + 1,
+                    &recs,
+                    RlogConfig {
+                        block_target_records: L0_BLOCK as usize,
+                        ..RlogConfig::default()
+                    },
+                    &[],
+                )
+                .await;
+            }
+
+            let tracker = MergeMemoryTracker::new();
+            let config = CompactorConfig {
+                max_l1_part_bytes: CAP,
+                merge_memory_tracker: Some(tracker.clone()),
+                ..CompactorConfig::default()
+            };
+            let clock = FixedClock::new(sealed_now_ns());
+            compact_bucket(&store, &clock, &config, &bucket())
+                .await
+                .expect("compact");
+
+            let (_rec, parts) = read_output(&store).await;
+            let peak = tracker.peak_total_bytes();
+            println!(
+                "[mem:rlog #711] scale={scale} records={total} parts={} \
+                 peak_total={peak}B cap={CAP}B",
+                parts.len()
+            );
+            assert!(peak > 0, "the tracker must record real residency");
+            peaks.push((peak, parts.len()));
+        }
+
+        // 4x the records, and the peak must not follow. Asserted before the
+        // shape checks below so the failure a regression produces is the
+        // ratio itself, with both numbers in the message.
+        let (two_x, eight_x) = (peaks[0].0 as f64, peaks[1].0 as f64);
+        let ratio = eight_x / two_x;
+        assert!(
+            ratio < 1.3,
+            "peak scaled with the record count: 2x={two_x} 8x={eight_x} ratio={ratio}"
+        );
+        for (scale, (peak, parts)) in [2, 8].into_iter().zip(peaks) {
+            assert!(
+                peak < 2 * CAP + TRANSIENT_ALLOWANCE,
+                "scale {scale}: peak {peak} exceeded 2x the cap plus the per-input transient"
+            );
+            assert!(parts > 1, "scale {scale}: the fixture must actually split");
+        }
+    }
+
+    // --- concurrent input reads (issue #711) ---------------------------------
+
+    /// Issue #711: `input_read_concurrency` changes only how many reads are in
+    /// flight, never a byte of the output. The same bucket is compacted at
+    /// concurrency 1 and 8 and every part must be byte-identical.
+    ///
+    /// The concurrency is proved to be real, not nominal: a FaultStore gate
+    /// holds every commit-record GET, and at concurrency 8 exactly 8 are held
+    /// simultaneously while at concurrency 1 only ever 1 is. Without the
+    /// fan-out the `wait_until_held(8)` below never returns and the test hangs
+    /// rather than passing vacuously.
+    #[tokio::test]
+    async fn input_read_concurrency_changes_timing_not_bytes() {
+        const INPUTS: u64 = 16;
+
+        async fn compact_at(concurrency: usize) -> (Vec<[u8; 32]>, usize) {
+            let store = Arc::new(FaultStore::new(MemoryStore::new(), FaultPlan::empty()));
+            for j in 0..INPUTS {
+                let recs: Vec<LogRecord> = (0..40i64)
+                    .map(|i| wide_record(i * INPUTS as i64 + j as i64))
+                    .collect();
+                seed(
+                    store.as_ref(),
+                    Uuid::from_u128(u128::from(j) + 1),
+                    j + 1,
+                    &recs,
+                )
+                .await;
+            }
+
+            // Hold every commit-record GET (".cmt" names commit records and
+            // nothing else) so the in-flight count is observable.
+            let gate = store.hold(Op::Get, Some(".cmt".to_string()), Occurrence::Always);
+            let config = CompactorConfig {
+                max_l1_part_bytes: 64 * 1024,
+                input_read_concurrency: concurrency,
+                ..CompactorConfig::default()
+            };
+            let task = tokio::spawn({
+                let store = Arc::clone(&store);
+                async move {
+                    let clock = FixedClock::new(sealed_now_ns());
+                    compact_bucket(store.as_ref(), &clock, &config, &bucket())
+                        .await
+                        .expect("compact");
+                }
+            });
+
+            // The first window fills to exactly `concurrency` and no further:
+            // `buffer_unordered` polls no more than that many futures at once.
+            gate.wait_until_held(concurrency).await;
+            for _ in 0..64 {
+                tokio::task::yield_now().await;
+            }
+            let peak_in_flight = gate.held_count();
+
+            // From here on release everything the gate catches, so the rest of
+            // the run (and `read_output`'s own read of the compaction record,
+            // which shares the `.cmt` suffix) is never blocked. Parks on the
+            // gate's `Notify` rather than spinning.
+            let releaser = tokio::spawn({
+                let gate = gate.clone();
+                async move {
+                    loop {
+                        gate.wait_until_held(1).await;
+                        for id in gate.held() {
+                            gate.release(id);
+                        }
+                    }
+                }
+            });
+            task.await.expect("compaction task");
+
+            let (_rec, parts) = read_output(store.as_ref()).await;
+            releaser.abort();
+            let hashes = parts
+                .iter()
+                .map(|p| *blake3::hash(p).as_bytes())
+                .collect::<Vec<_>>();
+            (hashes, peak_in_flight)
+        }
+
+        let (serial_hashes, serial_in_flight) = compact_at(1).await;
+        let (concurrent_hashes, concurrent_in_flight) = compact_at(8).await;
+
+        assert_eq!(
+            serial_in_flight, 1,
+            "concurrency 1 must never have two commit-record GETs in flight"
+        );
+        assert_eq!(
+            concurrent_in_flight, 8,
+            "concurrency 8 must hold exactly 8 commit-record GETs at once"
+        );
+        assert!(
+            serial_hashes.len() > 1,
+            "the fixture must split into several parts"
+        );
+        assert_eq!(
+            serial_hashes, concurrent_hashes,
+            "concurrent input reads must produce byte-identical parts"
+        );
     }
 
     // --- bounded-memory k-way merge ------------------------------

--- a/crates/ravel-maintain/src/rlog.rs
+++ b/crates/ravel-maintain/src/rlog.rs
@@ -56,7 +56,7 @@
 //! one writer implementation, so an L0 write and an L1 merge cannot drift. The
 //! only ravel-logseg addition this required is `finish_compacted` itself.
 //!
-//! # Memory (ADR-0065 decision 4)
+//! # Memory (ADR-0065 decision 4, ADR-0032 amendment 2026-08-26)
 //!
 //! The read side ([`RlogCodec::load_input_catalog`]) retains only per-input
 //! catalog metadata: a [`RlogRangeReader`] holding the decoded STREAM_DIR,
@@ -76,7 +76,10 @@
 //! [`StreamCursor`] per input that decodes exactly one block at a time
 //! ([`RlogRangeReader::stream_blocks`] +
 //! [`RlogRangeReader::decode_block`]), fetching the next block's bytes by range
-//! only once the previous block is drained. A record's `(stream_ref, ts)`
+//! only once the previous block is drained (one block ahead: the fetch for
+//! block `n + 1` rides along with block `n`'s, so the cursor advances two
+//! blocks per round trip while its raw residency stays at two blocks). A
+//! record's `(stream_ref, ts)`
 //! stored order makes each input's stream one ts-ascending sequence spread
 //! across ascending blocks, so N inputs carrying the same stream are a standard
 //! k-way merge ordered by `ts_ns`, ties broken by canonical input order. That
@@ -90,19 +93,45 @@
 //! unchanged by the k-way merge), plus at most one decoded block per input
 //! carrying the current stream (`O(input_count * block_size)`, independent of
 //! stream size), plus the in-progress part's writer buffer. The writer buffer
-//! is bounded by `max_l1_part_bytes` -- a part is flushed on a stream boundary
-//! once its record-byte estimate reaches the cap -- and holding a whole part
-//! before its content-addressed key exists is unavoidable, not a regression.
+//! is bounded by `max_l1_part_bytes`: [`PartSink`] closes the in-progress part
+//! as soon as its [`estimate_record`] total reaches the cap, wherever in the
+//! merged record sequence that falls, so a stream may span consecutive parts.
+//! It did NOT always work this way -- the check used to run only between
+//! streams, on the "a stream never straddles two parts" invariant this module
+//! and ADR-0032 once stated -- and a bucket carrying one OTLP resource/scope
+//! (one stream) therefore had no split point at all: 3M wide rows of one
+//! ClickBench logs stream held the whole hour in one writer at 45.7 GB
+//! resident. Issue #711 replaced the invariant with the size bound; parts are
+//! still written by the frozen [`RlogWriter`] unchanged, so only the
+//! partitioning of records into parts changed, never a part's bytes. Holding
+//! one whole part before its content-addressed key exists remains unavoidable.
 //! The [`MergeMemoryTracker`] seam accounts these terms at their real
 //! allocation/decode points and records a high-water mark; the acceptance test
-//! asserts that mark stays under a fixed bound while a hot stream grows.
+//! asserts that mark stays proportional to the cap while a hot stream grows.
 //!
 //! The first RLOG merge held every input object whole (RLOG then had no ranged
 //! section reader); [`ravel_logseg::open_from_suffix`] is now the RLOG analogue
 //! of `ravel_segment::open_from_suffix` and closed that raw-bytes gap.
+//!
+//! # What a reader must tolerate after the split
+//!
+//! Two consecutive parts of one compaction may carry the same `stream_id`,
+//! with adjacent, non-overlapping `(first_series_id, last_series_id)` bounds
+//! (part `k`'s last equals part `k+1`'s first) and adjacent event-time ranges.
+//! Nothing in the read path prunes on those bounds -- the catalog turns every
+//! part into its own `SegmentRef` and the resolver unions them -- so a split
+//! stream reads back as the same row set in the same order. Record
+//! conservation (`sum(part.sample_count)`, the compaction and ADR-0064 erasure
+//! gates) is likewise unaffected: splitting repartitions records, it never
+//! adds or drops one. The one aggregate that does change is
+//! `sum(part.series_count)`, which counts a straddling stream once per part it
+//! appears in; it is reported, never used as a gate.
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::future::Future;
+use std::pin::Pin;
 
+use futures::stream::{StreamExt, TryStreamExt, iter as stream_iter};
 use ravel_commit::keys;
 use ravel_logseg::field_dir::FieldDir;
 use ravel_logseg::footer::{self, SuffixOutcome, kind};
@@ -277,64 +306,127 @@ impl SegmentCodec for RlogCodec {
         // the same list, so a field is indexed uniformly across the output.
         let indexed_fields = merged_indexed_fields(&catalogs);
         let tracker = config.merge_memory_tracker.as_ref();
-        let mut parts = Vec::new();
-        let mut part_index: u32 = 0;
-        let mut current: Option<PartBuilder> = None;
+        let mut sink = PartSink {
+            store,
+            bucket,
+            config,
+            input_set_hash,
+            identity,
+            indexed_fields,
+            tracker,
+            current: None,
+            parts: Vec::new(),
+            part_index: 0,
+        };
 
         // Merge stream by stream in sorted stream_id order. Each stream is
         // k-way merged from every input carrying it (ts-ascending, canonical
-        // input-order tie-break) straight into the current part's writer; a
-        // part flushes on a stream boundary once its accumulated record-byte
-        // estimate reaches the size cap (so a stream never straddles two parts,
-        // the log analogue of RSEG's series-boundary split). No intermediate
+        // input-order tie-break) straight into the current part's writer, and
+        // the part flushes the moment its accumulated record-heap estimate
+        // reaches `max_l1_part_bytes` -- mid-stream if that is where the cap
+        // falls (issue #711, ADR-0032 amendment 2026-08-26). No intermediate
         // `Vec<LogRecord>` and no per-stream dedup: distinct submissions of
         // identical content are distinct records (ADR-0032).
         for stream_id in merged.keys() {
-            let part = current.get_or_insert_with(|| PartBuilder::new(&identity, &indexed_fields));
-            merge_stream_into_part(store, &catalogs, stream_id, part, tracker).await?;
-            // Flush on this stream boundary once the part reaches the cap. The
-            // `take` is `Some` here (just inserted above); the `if let` avoids
-            // an `unwrap`/`expect` on the critical path rather than asserting.
-            let over_cap = part.estimate >= config.max_l1_part_bytes && !part.is_empty();
-            if over_cap && let Some(builder) = current.take() {
-                let built = builder
-                    .finish(store, bucket, input_set_hash, part_index, config.dry_run)
-                    .await?;
-                parts.push(built);
-                part_index += 1;
-                if let Some(t) = tracker {
-                    t.set_writer_bytes(0);
-                }
-            }
+            merge_stream_into_parts(store, &catalogs, stream_id, &mut sink, tracker).await?;
         }
-        if let Some(part) = current
-            && !part.is_empty()
-        {
-            let built = part
-                .finish(store, bucket, input_set_hash, part_index, config.dry_run)
+        sink.finish().await
+    }
+}
+
+/// The sequence of L1 parts one merge produces, and the one place a part is
+/// closed and a new one opened.
+///
+/// The split rule is a pure size rule: push records in the merge's canonical
+/// order, and close the in-progress part as soon as its
+/// [`PartBuilder::estimate`] reaches `max_l1_part_bytes`, wherever in the
+/// record sequence that falls. That is the whole of issue #711: the check used
+/// to run only between streams, so a bucket whose records all belong to one
+/// stream (one OTLP resource/scope, the common shape for a single busy
+/// service) held its entire row set live in one writer.
+///
+/// Consecutive parts may therefore carry the same `stream_id` at their shared
+/// boundary, with adjacent, non-overlapping `(series_id, ts)` ranges. Records
+/// still enter each part in global `(stream_id, ts)` order, so every part is
+/// individually sorted and is written by the frozen [`RlogWriter`] unchanged:
+/// only the partitioning of records into parts differs, never a part's bytes
+/// given its record set.
+struct PartSink<'a> {
+    store: &'a dyn ObjectStoreBackend,
+    bucket: &'a Bucket,
+    config: &'a CompactorConfig,
+    input_set_hash: &'a [u8; 32],
+    identity: ObjectIdentity,
+    indexed_fields: Vec<String>,
+    tracker: Option<&'a MergeMemoryTracker>,
+    current: Option<PartBuilder>,
+    parts: Vec<BuiltPart>,
+    part_index: u32,
+}
+
+impl PartSink<'_> {
+    /// Push one merged record, opening a part if none is in progress and
+    /// closing it once the cap is reached.
+    async fn push(&mut self, r: LogRecord) -> Result<()> {
+        if self.current.is_none() {
+            self.current = Some(PartBuilder::new(&self.identity, &self.indexed_fields));
+        }
+        let mut over_cap = false;
+        if let Some(part) = self.current.as_mut() {
+            part.push(r, self.tracker)?;
+            over_cap = part.estimate >= self.config.max_l1_part_bytes;
+        }
+        if over_cap {
+            self.flush().await?;
+        }
+        Ok(())
+    }
+
+    /// Close the in-progress part, if any, and PUT it. A part is never empty
+    /// here: [`Self::push`] only ever calls this after pushing a record, and
+    /// [`Self::finish`] guards on `is_empty`.
+    async fn flush(&mut self) -> Result<()> {
+        // The `if let` (rather than an `unwrap`/`expect`) keeps the critical
+        // path free of a panic path; a `None` here is a no-op, not a lie.
+        if let Some(builder) = self.current.take() {
+            let built = builder
+                .finish(
+                    self.store,
+                    self.bucket,
+                    self.input_set_hash,
+                    self.part_index,
+                    self.config.dry_run,
+                )
                 .await?;
-            parts.push(built);
-            if let Some(t) = tracker {
+            self.parts.push(built);
+            self.part_index += 1;
+            if let Some(t) = self.tracker {
                 t.set_writer_bytes(0);
             }
         }
+        Ok(())
+    }
 
-        Ok(parts)
+    /// Close the trailing part and yield every part built, in part-index order.
+    async fn finish(mut self) -> Result<Vec<BuiltPart>> {
+        if self.current.as_ref().is_some_and(|p| !p.is_empty()) {
+            self.flush().await?;
+        }
+        Ok(self.parts)
     }
 }
 
 /// One in-progress L1 part: the shared [`RlogWriter`] the merged records push
-/// into directly, plus the running record-byte estimate that decides where the
-/// part splits (a stream boundary once the estimate reaches `max_l1_part_bytes`)
-/// and feeds the [`MergeMemoryTracker`]'s writer term. Holding a whole part's
-/// records before [`PartBuilder::finish`] stamps its content-addressed key is
-/// unavoidable (the key is a hash of the whole object); the k-way merge is what
-/// keeps everything *else* bounded.
+/// into directly, plus the running record-heap estimate that decides where the
+/// part splits (wherever the estimate reaches `max_l1_part_bytes`, see
+/// [`PartSink`]) and feeds the [`MergeMemoryTracker`]'s writer term. Holding a
+/// whole part's records before [`PartBuilder::finish`] stamps its
+/// content-addressed key is unavoidable (the key is a hash of the whole
+/// object); the k-way merge is what keeps everything *else* bounded.
 struct PartBuilder {
     writer: RlogWriter,
     /// Sum of [`estimate_record`] over every pushed record: the split trigger
-    /// (matching the old accumulator's `batch_bytes`) and the writer-buffer
-    /// term the tracker records.
+    /// and the writer-buffer term the tracker records.
     estimate: u64,
     min_stream: Option<LogStreamId>,
     max_stream: Option<LogStreamId>,
@@ -416,6 +508,10 @@ struct StreamCursor<'a> {
     /// The current block's decoded-byte estimate, held live in the tracker
     /// until the block is released.
     block_bytes: u64,
+    /// The next block's raw bytes, already fetched (issue #711). At most one:
+    /// the prefetch is one block ahead, so the cursor's raw-byte residency is
+    /// two blocks, not the stream.
+    prefetched: Option<(StreamBlockLoc, bytes::Bytes)>,
     /// The next record to merge, or `None` once the cursor is exhausted.
     head: Option<LogRecord>,
 }
@@ -440,6 +536,7 @@ impl<'a> StreamCursor<'a> {
             next_loc: 0,
             block: Vec::new().into_iter(),
             block_bytes: 0,
+            prefetched: None,
             head: None,
         }))
     }
@@ -463,7 +560,8 @@ impl<'a> StreamCursor<'a> {
     /// Load the next record into `head`: the next record of the current block,
     /// or the first record of the next non-empty block (fetched by range and
     /// decoded here), or `None` when the stream is exhausted in this input. At
-    /// most one block's raw bytes and one decoded block are resident at a time.
+    /// most one decoded block plus at most two blocks' raw bytes (the one being
+    /// decoded and the one prefetched behind it) are resident at a time.
     async fn refill(
         &mut self,
         store: &dyn ObjectStoreBackend,
@@ -475,24 +573,16 @@ impl<'a> StreamCursor<'a> {
         }
         // Current block drained: release it and pull the next non-empty block.
         self.release_block(tracker);
-        while self.next_loc < self.locs.len() {
-            let loc = self.locs[self.next_loc].clone();
-            self.next_loc += 1;
-            let got = store
-                .get(self.object_key, GetRange::Range(loc.start(), loc.end()))
-                .await?;
-            let raw_len = got.data.len() as u64;
-            if let Some(t) = tracker {
-                t.block_fetched(raw_len);
-            }
-            let recs = self.reader.decode_block(&loc, got.data.as_ref())?;
+        while let Some((loc, data)) = self.next_raw_block(store, tracker).await? {
+            let raw_len = data.len() as u64;
+            let recs = self.reader.decode_block(&loc, data.as_ref())?;
             let decoded_bytes: u64 = recs.iter().map(estimate_record).sum();
             if let Some(t) = tracker {
                 // Records both raw and decoded resident at the high-water
                 // instant, then drops the raw buffer.
                 t.block_decoded(raw_len, decoded_bytes);
             }
-            drop(got);
+            drop(data);
             self.block_bytes = decoded_bytes;
             self.block = recs.into_iter();
             if let Some(rec) = self.block.next() {
@@ -506,6 +596,68 @@ impl<'a> StreamCursor<'a> {
         self.head = None;
         Ok(())
     }
+
+    /// The next candidate block's raw bytes, or `None` once the candidate list
+    /// is exhausted.
+    ///
+    /// The GET for the block *after* it is issued in the same concurrent
+    /// `try_join` and its bytes are kept in `prefetched` (issue #711), so the
+    /// cursor advances two blocks per round trip instead of one. Futures are
+    /// lazy, so a stored-but-unpolled future would not be in flight; joining
+    /// the two fetches is what actually overlaps them. Residency stays
+    /// bounded: exactly one prefetched raw block per cursor, never a window
+    /// that grows with the stream.
+    async fn next_raw_block(
+        &mut self,
+        store: &dyn ObjectStoreBackend,
+        tracker: Option<&MergeMemoryTracker>,
+    ) -> Result<Option<(StreamBlockLoc, bytes::Bytes)>> {
+        if let Some((loc, data)) = self.prefetched.take() {
+            return Ok(Some((loc, data)));
+        }
+        let Some(loc) = self.take_next_loc() else {
+            return Ok(None);
+        };
+        let data = match self.take_next_loc() {
+            Some(ahead) => {
+                let (a, b) = futures::try_join!(
+                    fetch_block(store, self.object_key, &loc),
+                    fetch_block(store, self.object_key, &ahead)
+                )?;
+                if let Some(t) = tracker {
+                    t.block_fetched(b.len() as u64);
+                }
+                self.prefetched = Some((ahead, b));
+                a
+            }
+            None => fetch_block(store, self.object_key, &loc).await?,
+        };
+        if let Some(t) = tracker {
+            t.block_fetched(data.len() as u64);
+        }
+        Ok(Some((loc, data)))
+    }
+
+    /// Consume the next candidate block location, if any.
+    fn take_next_loc(&mut self) -> Option<StreamBlockLoc> {
+        let loc = self.locs.get(self.next_loc)?.clone();
+        self.next_loc += 1;
+        Some(loc)
+    }
+}
+
+/// One block's raw bytes by range. Named (not an inline `async` block) so its
+/// future is `Send`-general over the borrowed store; see
+/// [`StreamCursor::next_raw_block`].
+async fn fetch_block(
+    store: &dyn ObjectStoreBackend,
+    object_key: &str,
+    loc: &StreamBlockLoc,
+) -> Result<bytes::Bytes> {
+    let got = store
+        .get(object_key, GetRange::Range(loc.start(), loc.end()))
+        .await?;
+    Ok(got.data)
 }
 
 /// K-way merge one stream from every input carrying it into `part`, in
@@ -516,23 +668,41 @@ impl<'a> StreamCursor<'a> {
 /// sort of the concatenation orders equal-`ts_ns` records by (input, position),
 /// exactly what selecting the minimum `(ts_ns, input_index)` head does here.
 ///
-/// Issue #711: peak memory here is bounded by one part, not one stream.
-async fn merge_stream_into_part(
+/// Records go into `sink`, which closes the in-progress part and opens the next
+/// one the moment the size cap is reached -- possibly in the middle of this
+/// stream (issue #711). The merge order is unaffected: the sink is a pure
+/// partitioner over the sequence this function produces.
+///
+/// The cursors are opened concurrently (`input_read_concurrency` at a time):
+/// each open costs one ranged GET for the stream's first block, so a stream
+/// carried by hundreds of inputs would otherwise serialize hundreds of round
+/// trips before the first record merges.
+async fn merge_stream_into_parts(
     store: &dyn ObjectStoreBackend,
     catalogs: &[RlogInputCatalog],
     stream_id: &LogStreamId,
-    part: &mut PartBuilder,
+    sink: &mut PartSink<'_>,
     tracker: Option<&MergeMemoryTracker>,
 ) -> Result<()> {
-    let mut cursors: Vec<StreamCursor> = Vec::new();
-    for (idx, catalog) in catalogs.iter().enumerate() {
-        if let Some(mut cursor) = StreamCursor::open(catalog, idx, stream_id)? {
-            cursor.refill(store, tracker).await?;
-            if cursor.head.is_some() {
-                cursors.push(cursor);
-            }
-        }
-    }
+    let concurrency = sink.config.input_read_concurrency.max(1);
+    // Box each open-and-first-refill with an explicit `+ Send` bound before
+    // `buffered`, the workaround `crate::build::fetch_batch_pages` documents
+    // for futures that borrow the `&dyn ObjectStoreBackend`. `buffered` keeps
+    // canonical input order, which is the k-way merge's tie-break.
+    type CursorFuture<'f, 'a> =
+        Pin<Box<dyn Future<Output = Result<Option<StreamCursor<'a>>>> + Send + 'f>>;
+    let opens: Vec<CursorFuture<'_, '_>> = catalogs
+        .iter()
+        .enumerate()
+        .map(|(idx, catalog)| {
+            Box::pin(open_cursor(store, catalog, idx, stream_id, tracker)) as CursorFuture<'_, '_>
+        })
+        .collect();
+    let opened: Vec<Option<StreamCursor>> = stream_iter(opens)
+        .buffered(concurrency)
+        .try_collect()
+        .await?;
+    let mut cursors: Vec<StreamCursor> = opened.into_iter().flatten().collect();
     loop {
         // Pick the cursor whose head has the minimum (ts_ns, input_index).
         // input_index is unique per cursor, so the key is a total order and the
@@ -551,11 +721,30 @@ async fn merge_stream_into_part(
             break;
         };
         if let Some(rec) = cursors[bi].take_head() {
-            part.push(rec, tracker)?;
+            sink.push(rec).await?;
         }
         cursors[bi].refill(store, tracker).await?;
     }
     Ok(())
+}
+
+/// Open one input's cursor over `stream_id` and load its first record. Named
+/// (not an inline `async` block) so its future is `Send`-general over the
+/// borrowed store; see the call site in [`merge_stream_into_parts`]. Returns
+/// `None` when the input does not carry the stream, or carries no record for
+/// it.
+async fn open_cursor<'a>(
+    store: &'a dyn ObjectStoreBackend,
+    catalog: &'a RlogInputCatalog,
+    input_index: usize,
+    stream_id: &LogStreamId,
+    tracker: Option<&MergeMemoryTracker>,
+) -> Result<Option<StreamCursor<'a>>> {
+    let Some(mut cursor) = StreamCursor::open(catalog, input_index, stream_id)? else {
+        return Ok(None);
+    };
+    cursor.refill(store, tracker).await?;
+    Ok(cursor.head.is_some().then_some(cursor))
 }
 
 /// Encode one in-progress part's writer into an L1 object and PUT it: run the
@@ -575,7 +764,10 @@ async fn merge_stream_into_part(
 ///
 /// `first_stream_id`/`last_stream_id` are the part's inclusive stream-id bounds
 /// accumulated as records were pushed (streams are merged in sorted id order,
-/// so `first` is the smallest and `last` the largest id in the part).
+/// so `first` is the smallest and `last` the largest id in the part). Since
+/// issue #711 a part may open or close in the middle of a stream, so one part's
+/// `last` may equal the next part's `first`; the bounds are adjacent, not
+/// strictly disjoint.
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn finalize_part(
     store: &dyn ObjectStoreBackend,
@@ -654,31 +846,98 @@ pub(crate) fn compactor_identity(bucket: &Bucket, config: &CompactorConfig) -> O
     }
 }
 
-/// A rough uncompressed byte estimate for one record, for the part size cap.
-/// Approximate on purpose (like RSEG's accumulated page-byte estimate): it only
-/// decides where parts split, never correctness.
+/// Per-heap-allocation bookkeeping charged on top of the bytes asked for: the
+/// allocator header plus size-class rounding. A deliberate flat figure, in the
+/// range a general-purpose allocator costs for the small allocations a
+/// [`LogRecord`] is made of.
+const ALLOC_OVERHEAD_BYTES: u64 = 16;
+
+/// The `Vec<LogRecord>` slot one record occupies in the writer, whatever its
+/// payload: 10 fixed fields, three `String`/`Vec` headers, and the `attrs`
+/// vector header.
+const RECORD_SLOT_BYTES: u64 = std::mem::size_of::<LogRecord>() as u64;
+
+/// One `(String, AttrValue)` slot in a record's `attrs` vector: the key's
+/// `String` header plus the widest `AttrValue` variant, before any of their
+/// heap payloads.
+const ATTR_SLOT_BYTES: u64 = std::mem::size_of::<(String, AttrValue)>() as u64;
+
+/// The Rust-side heap one merged [`LogRecord`] occupies while it waits in the
+/// in-progress part's writer, which is what `max_l1_part_bytes` caps
+/// (issue #711). This is deliberately NOT the record's encoded size: the
+/// writer holds row-major `LogRecord`s, and for a wide log row (the ClickBench
+/// shape: ~105 attributes) the Rust representation is an order of magnitude
+/// larger than the bytes it compresses to. Sizing the cap against payload
+/// bytes is what let one 3M-row stream reach 45 GB resident under a nominal
+/// 256 MiB cap.
+///
+/// The formula, one term per real allocation:
+///
+/// ```text
+/// estimate(record) = RECORD_SLOT_BYTES                       // its Vec slot
+///                  + alloc(stream_attrs.len())               // per-row resource/scope copy
+///                  + alloc(severity_text.len())
+///                  + alloc(body.len())
+///                  + alloc(attrs.len() * ATTR_SLOT_BYTES)    // the attrs vector itself
+///                  + sum over attrs of
+///                        alloc(key.len()) + value(v)
+///
+/// alloc(n)  = 0 if n == 0 else n + ALLOC_OVERHEAD_BYTES
+/// value(v)  = alloc(len) for Str/Bytes
+///           = alloc(items.len() * slot) + sum of element values for List/Map
+///           = 0 for I64/F64/Bool, which live inline in the enum and are
+///             already counted by the slot term that holds them
+/// ```
+///
+/// It stays an estimate -- it does not model allocator size classes, `String`
+/// capacity above `len`, or shared allocations -- but it is now within a small
+/// factor of the true heap rather than a small fraction of it, so a 256 MiB cap
+/// means roughly 256 MiB of live records. It still only decides where parts
+/// split, never correctness.
 fn estimate_record(r: &LogRecord) -> u64 {
-    let mut est: u64 = 48; // fixed-column overhead per row
-    est += r.body.len() as u64;
-    est += r.severity_text.len() as u64;
+    let mut est = RECORD_SLOT_BYTES;
+    est = est.saturating_add(alloc_estimate(r.stream_attrs.len() as u64));
+    est = est.saturating_add(alloc_estimate(r.severity_text.len() as u64));
+    est = est.saturating_add(alloc_estimate(r.body.len() as u64));
+    est = est.saturating_add(alloc_estimate(r.attrs.len() as u64 * ATTR_SLOT_BYTES));
     for (k, v) in &r.attrs {
-        est += k.len() as u64 + attr_value_estimate(v);
+        est = est.saturating_add(alloc_estimate(k.len() as u64));
+        est = est.saturating_add(attr_value_estimate(v));
     }
     est
 }
 
+/// One heap allocation of `n` payload bytes, or nothing at all when `n` is 0
+/// (an empty `String`/`Vec` allocates nothing).
+fn alloc_estimate(n: u64) -> u64 {
+    if n == 0 {
+        0
+    } else {
+        n.saturating_add(ALLOC_OVERHEAD_BYTES)
+    }
+}
+
+/// The heap one attribute *value* owns beyond its slot in the containing
+/// vector. Scalars own none: they live inline in the [`AttrValue`] enum, whose
+/// size the slot term already carries.
 fn attr_value_estimate(v: &AttrValue) -> u64 {
     match v {
-        AttrValue::Str(s) => s.len() as u64 + 2,
-        AttrValue::Bytes(b) => b.len() as u64 + 2,
-        AttrValue::List(items) => items.iter().map(attr_value_estimate).sum::<u64>() + 2,
-        AttrValue::Map(kvs) => {
-            kvs.iter()
-                .map(|(k, v)| k.len() as u64 + attr_value_estimate(v))
-                .sum::<u64>()
-                + 2
+        AttrValue::Str(s) => alloc_estimate(s.len() as u64),
+        AttrValue::Bytes(b) => alloc_estimate(b.len() as u64),
+        AttrValue::List(items) => {
+            let slots = items.len() as u64 * std::mem::size_of::<AttrValue>() as u64;
+            items
+                .iter()
+                .map(attr_value_estimate)
+                .fold(alloc_estimate(slots), u64::saturating_add)
         }
-        _ => 8,
+        AttrValue::Map(kvs) => {
+            let slots = kvs.len() as u64 * ATTR_SLOT_BYTES;
+            kvs.iter()
+                .map(|(k, v)| alloc_estimate(k.len() as u64).saturating_add(attr_value_estimate(v)))
+                .fold(alloc_estimate(slots), u64::saturating_add)
+        }
+        AttrValue::I64(_) | AttrValue::F64(_) | AttrValue::Bool(_) => 0,
     }
 }
 
@@ -1828,11 +2087,16 @@ mod tests {
         assert_eq!(stats.blocks_scanned, 0, "a pruned block is never scanned");
     }
 
+    /// Many distinct streams and a tiny part cap: parts get ascending,
+    /// non-overlapping stream-id ranges and the union of records is preserved.
+    ///
+    /// Since issue #711 the ranges are *adjacent*, not strictly disjoint: a
+    /// part can close mid-stream, so one part's `last_series_id` may equal the
+    /// next part's `first_series_id`. This test therefore asserts `<=` between
+    /// parts; the strict-disjointness case is covered by the record-level
+    /// checks in `single_stream_bucket_splits_into_bounded_parts`.
     #[tokio::test]
-    async fn part_splitting_keeps_streams_whole_and_disjoint() {
-        // Many distinct streams and a tiny part cap force splits on stream
-        // boundaries: parts get disjoint, ascending stream-id ranges (a stream
-        // never straddles two parts), and the union of records is preserved.
+    async fn part_splitting_keeps_stream_ranges_ordered_and_non_overlapping() {
         let store = MemoryStore::new();
         let mk = |seq_body: &str| -> Vec<LogRecord> {
             (0..20u32)
@@ -1857,7 +2121,8 @@ mod tests {
         let (rec, parts) = read_output(&store).await;
         assert!(parts.len() >= 2, "tiny cap must split into parts");
 
-        // Part stream-id ranges are disjoint and ascending.
+        // Part stream-id ranges are ascending and non-overlapping (adjacent at
+        // a mid-stream split, strictly increasing otherwise).
         let mut prev_last: Option<[u8; 16]> = None;
         for (i, p) in rec.parts.iter().enumerate() {
             let first: [u8; 16] = p.first_series_id.as_slice().try_into().unwrap();
@@ -1865,8 +2130,8 @@ mod tests {
             assert!(first <= last);
             if let Some(pl) = prev_last {
                 assert!(
-                    pl < first,
-                    "part stream ranges must be disjoint and ordered"
+                    pl <= first,
+                    "part stream ranges must be ordered and non-overlapping"
                 );
             }
             prev_last = Some(last);
@@ -1908,15 +2173,18 @@ mod tests {
         // l0_blocked_cfg's block target: each input is re-blocked at 1000
         // records, so a grown stream spans many blocks per input.
         const L0_BLOCK: u64 = 1000;
-        // A generous per-record upper bound (estimate_record for these tiny
-        // records is ~53 bytes); the bound is intentionally loose so it tracks
+        // A generous per-record upper bound. `estimate_record` charges the
+        // record's Rust-side heap since issue #711, so these tiny records
+        // estimate at ~270 bytes rather than the ~53 payload bytes this bound
+        // was first sized against; it stays intentionally loose so it tracks
         // block size and input count, not the exact estimate.
-        const PER_RECORD_BOUND: u64 = 256;
-        // At most one raw block plus one decoded block resident per input.
+        const PER_RECORD_BOUND: u64 = 1024;
+        // At most one decoded block plus two raw blocks (the one being decoded
+        // and the one prefetched behind it) resident per input.
         const TRANSIENT_BOUND: u64 = INPUTS as u64 * 2 * L0_BLOCK * PER_RECORD_BOUND;
-        // Rough bytes-per-record for the "stream size" the peak is compared
-        // against (only used for reporting and the not-scaling assertion).
-        const PER_RECORD_APPROX: i64 = 53;
+        // Rough estimated bytes-per-record for the "stream size" the peak is
+        // compared against (reporting and the not-scaling assertion only).
+        const PER_RECORD_APPROX: i64 = 270;
 
         // records-per-input at the base scale and 10x.
         let scales = [3_000i64, 30_000i64];
@@ -1950,9 +2218,12 @@ mod tests {
                 .await
                 .expect("compact");
 
-            // One hot stream => exactly one part (a stream never straddles).
+            // 90k tiny records estimate at ~24 MB, far under the 256 MiB
+            // default cap, so this corpus still lands in one part. (Since
+            // issue #711 that is a consequence of the cap, not of a
+            // one-stream-per-part rule.)
             let (_rec, parts) = read_output(&store).await;
-            assert_eq!(parts.len(), 1, "one stream is one part");
+            assert_eq!(parts.len(), 1, "corpus is well under the part cap");
             assert_eq!(
                 decode_all(&parts[0]).len() as i64,
                 records_per_input * i64::from(INPUTS),
@@ -2232,12 +2503,12 @@ mod tests {
         }
 
         /// The same union-equality property under a tiny part cap that forces
-        /// the merge to split across multiple parts on stream boundaries, so the
-        /// "concatenate all parts" side of the differential actually crosses part
-        /// boundaries (the large-cap test above never leaves one part). 512 bytes
-        /// is below a handful of records' estimate, so any multi-stream corpus
-        /// splits; single-stream corpora stay one part (a stream never straddles)
-        /// and still exercise the property.
+        /// the merge to split across multiple parts, so the "concatenate all
+        /// parts" side of the differential actually crosses part boundaries
+        /// (the large-cap test above never leaves one part). 512 bytes is
+        /// below a single record's estimate, so every corpus splits -- since
+        /// issue #711 that includes a single-stream corpus, which splits
+        /// mid-stream rather than staying in one part.
         #[test]
         fn differential_holds_across_part_boundaries(corpus in corpus_strategy()) {
             let rt = tokio::runtime::Builder::new_current_thread()

--- a/crates/ravel-maintain/src/rlog.rs
+++ b/crates/ravel-maintain/src/rlog.rs
@@ -515,6 +515,8 @@ impl<'a> StreamCursor<'a> {
 /// already ts-ascending (the format's `(stream_ref, ts)` order), so a stable
 /// sort of the concatenation orders equal-`ts_ns` records by (input, position),
 /// exactly what selecting the minimum `(ts_ns, input_index)` head does here.
+///
+/// Issue #711: peak memory here is bounded by one part, not one stream.
 async fn merge_stream_into_part(
     store: &dyn ObjectStoreBackend,
     catalogs: &[RlogInputCatalog],

--- a/crates/ravel-maintain/tests/crash_matrix.rs
+++ b/crates/ravel-maintain/tests/crash_matrix.rs
@@ -187,7 +187,7 @@ async fn row10_racing_compactors_loser_converges_and_repairs() {
     // Loser rebuilds its parts (CreateIfAbsent over the winner's identical
     // parts is a no-op) ...
     let listing = read::list_bucket(&store, &bucket).await.unwrap();
-    let inputs = read::load_inputs(&store, &bucket, &listing.commit_keys)
+    let inputs = read::load_inputs(&store, &bucket, &listing.commit_keys, 1)
         .await
         .unwrap();
     let hash = read::input_set_hash(&inputs);
@@ -289,7 +289,7 @@ async fn row11_already_exists_different_hash_alarms() {
 
     // Build our parts (with our hash) and try to publish.
     let listing = read::list_bucket(&store, &bucket).await.unwrap();
-    let inputs = read::load_inputs(&store, &bucket, &listing.commit_keys)
+    let inputs = read::load_inputs(&store, &bucket, &listing.commit_keys, 1)
         .await
         .unwrap();
     let mut catalogs = Vec::new();
@@ -348,7 +348,7 @@ async fn row13_past_deadline_abandons_without_publishing() {
     let clock = FixedClock::new(start_ns + config.max_compaction_lifetime_ns + 1);
 
     let listing = read::list_bucket(&store, &bucket).await.unwrap();
-    let inputs = read::load_inputs(&store, &bucket, &listing.commit_keys)
+    let inputs = read::load_inputs(&store, &bucket, &listing.commit_keys, 1)
         .await
         .unwrap();
     let hash = read::input_set_hash(&inputs);

--- a/docs/adrs/0032-rlog-compaction-and-generic-maintain.md
+++ b/docs/adrs/0032-rlog-compaction-and-generic-maintain.md
@@ -202,3 +202,114 @@ construction once the codec seam exists.
 - `docs/log-segment-format.md` and `proto/ravel/logseg.proto` are
   amended in the same commits as the code that implements each change,
   per the doc-currency rule.
+
+## Amendment 2026-08-26: a part never exceeds the size cap; a stream may span parts
+
+Status: accepted. Supersedes the one-stream-per-part rule that the RLOG
+merge implemented under "stream-merge N inputs into size-capped output
+parts" above. Issue #711.
+
+### What changed
+
+The original RLOG compactor split parts on stream boundaries only: it
+merged one whole stream into the in-progress part, then compared the
+part's accumulated record-byte estimate against `max_l1_part_bytes` and
+opened a new part if the cap was reached. The invariant that produced -
+"a stream never straddles two parts", the log analogue of RSEG's
+series-boundary split - is replaced by a pure size bound:
+
+> A part never exceeds `max_l1_part_bytes` of estimated live record heap.
+> A stream may span consecutive parts.
+
+The cap is now checked after every merged record, so a part closes
+wherever in the merged record sequence the cap falls.
+
+### Why
+
+An RLOG stream is one `(resource, scope)` pair. A tenant sending one
+OTLP resource and scope - a single service, the ordinary shape for logs -
+puts its entire hour into one stream, so a stream-boundary split rule
+gives that bucket no split point at all. Measured on one (shard, hour)
+bucket of a 16-shard ClickBench logs tenant (about 270 RLOG inputs,
+350 MB compressed, 3M rows of 105 attributes, one stream):
+`ravel-cli maintain compact-bucket --signal logs` ran over 12 minutes at
+45.7 GB resident on one core. The k-way block-streaming merge of
+ADR-0065 decision 4 had already bounded the read side to one decoded
+block per input; what was left unbounded was the writer, which held every
+merged record of the stream as a row-major `LogRecord`.
+
+The size estimate was the second half of the defect. It counted payload
+bytes (body, severity text, attribute keys and values) while the writer
+holds `LogRecord`s, whose Rust representation for a wide row is an order
+of magnitude larger: per-row `String` and `Vec` headers and allocations,
+a per-row copy of the resource/scope blob, and one `(String, AttrValue)`
+slot per attribute, which for 105 attributes is 12-16 KB of heap per row
+against roughly 1 KB of payload. A nominal 256 MiB cap therefore
+permitted several GB of live records even where a split point existed.
+`estimate_record` now charges the record's Rust-side heap, term by term
+(the formula is stated above the function in `crates/ravel-maintain/src/rlog.rs`),
+so 256 MiB of estimate is roughly 256 MiB of heap.
+
+Both halves are needed. Moving the check alone would still let a part
+grow past the cap by the estimate's error factor; fixing the estimate
+alone would still leave a single-stream bucket with nowhere to split.
+
+### What readers must tolerate
+
+The bytes of a part are unchanged: each part is still written by the
+frozen `ravel-logseg` writer, from records still pushed in global
+`(stream_id, ts)` order, so every part is individually sorted and
+self-describing exactly as before. Only the partitioning of records into
+parts changed. Concretely:
+
+- **Two consecutive parts of one compaction may carry the same
+  `stream_id`.** `CompactionPart.first_series_id` and `last_series_id`
+  are then *adjacent* rather than strictly disjoint: part `k`'s `last`
+  may equal part `k+1`'s `first`. Their event-time ranges remain
+  non-overlapping and ascending, because records enter parts in ts order
+  within a stream.
+- **Nothing may prune on those bounds assuming disjointness.** Today
+  nothing does: `ravel_catalog`'s `build_l1_segment_ref` turns every part
+  into its own `SegmentRef` and the resolver unions them, filtering on
+  event time only. A future pruning optimization over the series bounds
+  must treat them as a closed interval that a neighbour may share, not as
+  a partition.
+- **Record conservation is unaffected.** The compaction gate
+  (`conserve_exact`) and ADR-0064's erasure gate both sum
+  `part.sample_count`; splitting repartitions records and never adds or
+  drops one.
+- **`sum(part.series_count)` is no longer a distinct-stream count.** A
+  stream that straddles a boundary is counted once per part it appears
+  in. That aggregate is reported (`maintain status`, `CompactionRecord`)
+  and never used as a gate, so this is a reporting change, not a
+  correctness one. A caller that needs the true distinct-stream count of
+  a compaction must union the parts' `STREAM_DIR`s.
+- **Part counts rise, and parts get smaller on disk than the cap
+  suggests.** The cap now bounds estimated heap, not encoded bytes, so a
+  wide-row bucket produces more, individually smaller, L1 objects than
+  the same nominal cap produced before. That is the intended trade:
+  bounded compactor memory in exchange for more objects. Operators who
+  want fewer, larger parts raise `max_l1_part_bytes` deliberately, with
+  the memory cost now visible in the same number.
+
+### Input read concurrency
+
+The same issue covers the compaction read path, which was a chain of
+sequential awaits: one commit-record GET per input, then one catalog load
+per input, then one block GET per cursor advance. A new
+`CompactorConfig::input_read_concurrency` (default 8) bounds how many of
+those are in flight, and each stream cursor prefetches one block ahead.
+This is a latency change only. Output bytes cannot depend on it: inputs
+are re-sorted into canonical `(writer_id, writer_epoch, writer_seq)`
+order after loading, catalogs stay aligned to that order, and the merge
+is a deterministic k-way merge over it. A test asserts the parts are
+byte-identical at concurrency 1 and 8.
+
+### Not in scope
+
+`build_rewrite_logs` (the ADR-0064 erasure rewriter for logs) still
+fetches every input object whole and pushes every survivor into a single
+`RlogWriter` with no size cap, by the deliberate scope reduction its own
+module documents. It has the same unbounded-writer shape this amendment
+removed from the compactor, and reaches it on the same tenant shape. It
+is not changed here; see the issue for the follow-up.


### PR DESCRIPTION
`maintain compact-bucket --signal logs` on one (shard, hour) bucket of a
16-shard ClickBench logs tenant (about 270 RLOG inputs, 350 MB
compressed, 3M rows of 105 attributes, one OTLP resource/scope = one
stream) ran 12+ minutes at 45.7 GB RSS on one core. The read side was
already block-streamed (ADR-0065's k-way merge holds one decoded block
per input), but merge_stream_into_part pushed every merged LogRecord
into one RlogWriter and the max_l1_part_bytes check ran only between
streams, because a stream never straddled two parts. A single-stream
bucket therefore held its whole row set as row-major LogRecords, 12-16
KB of heap per row, and the estimate that fed the cap counted payload
bytes only.

Parts now split within a stream: PartSink::push flushes the in-progress
part the moment its estimate reaches max_l1_part_bytes and opens the
next one mid-stream, so peak live records are bounded by one part
regardless of stream size. Consecutive parts may carry the same
stream_id with adjacent series-id/ts bounds; every reader of parts (the
resolver's part union, the catalog bounds, ADR-0064 erasure accounting
which sums sample_count, maintain status) tolerates that, and each part
is still written by the frozen ravel-logseg writer unchanged, so the
RLOG bytes of a part are unaffected; only the partitioning of records
into parts changes. sum(part.series_count) counts a straddling stream
once per part; every consumer treats it as reporting, never a gate.

estimate_record now charges the Rust-side heap of a LogRecord (its Vec
slot, the stream_attrs copy, body, severity, the attrs vector and each
key and value, with a 16-byte allocator overhead per allocation), so
256 MiB of estimate is about 256 MiB of heap: a 9-attribute row
estimates at 1165 bytes where the payload-only figure was about 370.

Input reads fan out with bounded concurrency from a new
CompactorConfig::input_read_concurrency (default 8): commit-record
loads, per-input catalog loads, and one prefetched block per cursor.
The k-way merge re-establishes the canonical order, so output bytes are
unchanged.

Tests: a single-stream bucket several times over the cap produces
exactly ceil(records / ceil(cap / estimate)) parts (22 on the fixture;
1 with the between-streams-only check restored), every record appears
once in canonical order with adjacent, non-overlapping bounds, and the
resolver reads back the same rows; peak_total at 2x and 8x the records
is identical (ratio 1.000; 3.40 unsplit); parts are byte-identical
(BLAKE3) at input_read_concurrency 1 and 8 with exactly 1 and 8
commit-record GETs held in flight; ADR-0064 erasure through a split
stream conserves the count. ADR-0032 carries a dated amendment replacing
the one-stream-per-part invariant with the per-part heap bound and
listing what readers tolerate; the rlog.rs module doc no longer claims
the writer term is bounded by a stream boundary.

Not in scope, reported: erasure_rewrite's build_rewrite_logs has the
same unbounded single-writer shape (whole-object GETs, every survivor in
one RlogWriter, no cap); LogRecord::stream_attrs lives in ravel-logseg,
so the per-row resource blob copy stays.

Refs: #711
Refs: #680
