### PR TITLE
feat(ravel-sql): report exact count and ts span for contained ts bounds

### DIFF
--- a/crates/ravel-sql/src/logs_scan.rs
+++ b/crates/ravel-sql/src/logs_scan.rs
@@ -784,20 +784,35 @@ impl ExecutionPlan for LogsScanExec {
         Some(self.metrics.clone_inner())
     }
 
-    /// Report the exact row count for a predicate-free, erasure-free
-    /// `COUNT(*)` straight from the catalog's committed row counts, so
-    /// DataFusion's `AggregateStatistics` physical-optimizer rule rewrites the
-    /// aggregate into a literal and never executes this scan (issue #698). On
-    /// the ClickBench tenant (issue #680) a scanning `count(*)` moved 23 GB
-    /// from object storage to add up 8424 numbers the resolve already had.
+    /// Report the exact row count and `ts` span straight from the catalog's
+    /// committed row counts and segment bounds, for any query where nothing
+    /// removes a row the committed counts still include: no content/prune
+    /// predicate, no pending erasure, and a `ts` bound (if any) that fully
+    /// CONTAINS every resolved segment (issue #698, widened by #723).
+    ///
+    /// For the genuinely predicate-free query (no `ts` bound at all, the
+    /// trivial contained case) this statistic reaches DataFusion's
+    /// `AggregateStatistics` physical-optimizer rule undisturbed and the rule
+    /// rewrites the aggregate into a literal, so this scan is never executed
+    /// (issue #698: on the ClickBench tenant, issue #680, a scanning
+    /// `count(*)` moved 23 GB from object storage to add up 8424 numbers the
+    /// resolve already had). For a query with an actual, contained `ts`
+    /// bound, this leaf statistic is still correct, but
+    /// `LogsTableProvider::supports_filters_pushdown` reports every filter
+    /// `Inexact`, so DataFusion keeps a `FilterExec` re-applying the bound
+    /// above this node; that `FilterExec` reports its own (non-exact)
+    /// statistics rather than passing this one through, so the rewrite does
+    /// not fire and the query still scans. Issue #733 tracks closing that
+    /// reachability gap; until then this method is correct but only
+    /// end-to-end effective for the no-bound case.
     ///
     /// `num_rows` is `Exact` only for the whole-plan request (`partition` is
     /// `None`) and only when [`Self::stats_are_exact`] holds; a per-partition
     /// request gets `Absent`, because a partition's count is its lazily
     /// resolved striped share of the blocks, not known here. Under the same
     /// condition the `ts` column's `column_statistics` report an `Exact`
-    /// min/max spanning every touched segment (issue #723); every other
-    /// column's stays `Absent`. `total_byte_size` stays `Absent`.
+    /// min/max spanning every touched segment; every other column's stays
+    /// `Absent`. `total_byte_size` stays `Absent`.
     fn partition_statistics(&self, partition: Option<usize>) -> DFResult<Arc<Statistics>> {
         // Validate the partition index exactly as the trait default does, so an
         // out-of-range request is an internal error, never a silent answer.
@@ -834,7 +849,7 @@ impl ExecutionPlan for LogsScanExec {
             if let (Some(min), Some(max)) = (
                 self.segments.iter().map(|s| s.min_event_ts_ns).min(),
                 self.segments.iter().map(|s| s.max_event_ts_ns).max(),
-            ) && let Some(ts_idx) = self.schema.fields().iter().position(|f| f.name() == "ts")
+            ) && let Some(ts_idx) = self.projection.iter().position(|&i| i == LOG_COL_TS)
             {
                 let col = &mut stats.column_statistics[ts_idx];
                 col.min_value = Precision::Exact(ScalarValue::TimestampNanosecond(Some(min), None));

--- a/crates/ravel-sql/src/logs_scan.rs
+++ b/crates/ravel-sql/src/logs_scan.rs
@@ -200,6 +200,7 @@ use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties, RecordBatchStream,
     SendableRecordBatchStream, Statistics,
 };
+use datafusion::scalar::ScalarValue;
 use futures::{Stream, StreamExt, TryStreamExt};
 use ravel_catalog::SegmentRef;
 use ravel_logseg::{
@@ -678,12 +679,23 @@ impl LogsScanExec {
     /// partition used to have, which only reinforces that no ordering can be
     /// declared. Downstream operators that need one get an explicit sort.
     /// Whether the sum of the snapshot's `SegmentRef::sample_count` values is
-    /// the exact row count of this scan's output (issue #698). It is only when
-    /// nothing between the committed counts and the emitted rows can remove a
-    /// row:
+    /// the exact row count of this scan's output, and its ts span the exact
+    /// min/max over every touched segment (issue #698, widened by issue #723).
+    /// Both hold only when nothing between the committed counts and the emitted
+    /// rows can remove a row:
     ///
-    /// - no ts bound: `ts_min`/`ts_max` are the no-op sentinels a `None`
-    ///   `LogsPushdown::ts_lo`/`ts_hi` lower to (`i64::MIN`/`i64::MAX`);
+    /// - the ts bound fully contains every resolved segment: `ts_min <=
+    ///   seg.min_event_ts_ns && seg.max_event_ts_ns <= ts_max` (inclusive) for
+    ///   every entry in `self.segments`, matching the fast-path containment
+    ///   convention in `ravel_query::log_fetcher`. A bound that clips even one
+    ///   segment removes rows the sum still counts (and leaves the true span
+    ///   unknown), so it fails closed; reading a clipped segment's real count
+    ///   from its block index is issue #721. The no-ts-bound case (`i64::MIN`/
+    ///   `i64::MAX`, the sentinels a `None` `LogsPushdown::ts_lo`/`ts_hi` lower
+    ///   to) is the trivial instance: every segment's span is inside
+    ///   `[i64::MIN, i64::MAX]`. `self.segments` is already the ts-relevant
+    ///   (overlapping) subset the provider resolved, so a fully-out-of-range
+    ///   segment never reaches this check;
     /// - no content predicate (`LogsPushdown::content`, the `has_word` arms
     ///   evaluated exactly per row);
     /// - no attribute-equality prune predicate (`LogsPushdown::prune`); a prune
@@ -698,12 +710,14 @@ impl LogsScanExec {
     /// `LogsPushdown` has exactly these four fields (`ts_lo`, `ts_hi`,
     /// `content`, `prune`); each is covered here, and `erasure` comes from the
     /// resolved snapshot rather than the pushdown.
-    fn count_is_exact(&self) -> bool {
-        self.ts_min == i64::MIN
-            && self.ts_max == i64::MAX
-            && self.content.is_empty()
+    fn stats_are_exact(&self) -> bool {
+        self.content.is_empty()
             && self.prune.is_empty()
             && self.erasure.is_empty()
+            && self
+                .segments
+                .iter()
+                .all(|seg| self.ts_min <= seg.min_event_ts_ns && seg.max_event_ts_ns <= self.ts_max)
     }
 
     fn compute_properties(schema: &SchemaRef, n: usize) -> PlanProperties {
@@ -778,10 +792,12 @@ impl ExecutionPlan for LogsScanExec {
     /// from object storage to add up 8424 numbers the resolve already had.
     ///
     /// `num_rows` is `Exact` only for the whole-plan request (`partition` is
-    /// `None`) and only when [`Self::count_is_exact`] holds; a per-partition
+    /// `None`) and only when [`Self::stats_are_exact`] holds; a per-partition
     /// request gets `Absent`, because a partition's count is its lazily
-    /// resolved striped share of the blocks, not known here. `total_byte_size`
-    /// and every `column_statistics` stay `Absent` (ts min/max is a follow-up).
+    /// resolved striped share of the blocks, not known here. Under the same
+    /// condition the `ts` column's `column_statistics` report an `Exact`
+    /// min/max spanning every touched segment (issue #723); every other
+    /// column's stays `Absent`. `total_byte_size` stays `Absent`.
     fn partition_statistics(&self, partition: Option<usize>) -> DFResult<Arc<Statistics>> {
         // Validate the partition index exactly as the trait default does, so an
         // out-of-range request is an internal error, never a silent answer.
@@ -795,7 +811,7 @@ impl ExecutionPlan for LogsScanExec {
         }
 
         let mut stats = Statistics::new_unknown(&self.schema());
-        if partition.is_none() && self.count_is_exact() {
+        if partition.is_none() && self.stats_are_exact() {
             // Sum in u64 with checked addition; overflow of either the sum or
             // the usize conversion falls back to Absent rather than a wrong
             // count or a panic.
@@ -807,6 +823,22 @@ impl ExecutionPlan for LogsScanExec {
                 && let Ok(n) = usize::try_from(total)
             {
                 stats.num_rows = Precision::Exact(n);
+            }
+
+            // The ts span is exactly `[min(min_event_ts_ns), max(max_event_ts_ns)]`
+            // over the touched segments: the containment check in
+            // `stats_are_exact` proves the bound removes no rows, so no segment's
+            // extremum is clipped away. Report it on the `ts` column wherever the
+            // projection keeps it (a projected-out ts leaves nothing to fill);
+            // empty segments leave both `None`, so the column stays `Absent`.
+            if let (Some(min), Some(max)) = (
+                self.segments.iter().map(|s| s.min_event_ts_ns).min(),
+                self.segments.iter().map(|s| s.max_event_ts_ns).max(),
+            ) && let Some(ts_idx) = self.schema.fields().iter().position(|f| f.name() == "ts")
+            {
+                let col = &mut stats.column_statistics[ts_idx];
+                col.min_value = Precision::Exact(ScalarValue::TimestampNanosecond(Some(min), None));
+                col.max_value = Precision::Exact(ScalarValue::TimestampNanosecond(Some(max), None));
             }
         }
         Ok(Arc::new(stats))

--- a/crates/ravel-sql/tests/logs_count_from_stats.rs
+++ b/crates/ravel-sql/tests/logs_count_from_stats.rs
@@ -15,8 +15,10 @@ use std::sync::Arc;
 
 use datafusion::arrow::array::Int64Array;
 use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::common::stats::Precision;
 use datafusion::functions_aggregate::expr_fn::count;
-use datafusion::physical_plan::{collect, displayable};
+use datafusion::logical_expr::Expr;
+use datafusion::physical_plan::{Statistics, collect, displayable};
 use datafusion::prelude::{SessionContext, col, lit};
 use datafusion::scalar::ScalarValue;
 use ravel_catalog::{Catalog, CatalogConfig, SegmentLevel, SegmentRef, Snapshot};
@@ -364,4 +366,169 @@ async fn count_with_pending_erasure_scans() {
         .expect("collect");
     assert_eq!(count_from_batches(&batches), 3, "5 records minus 2 erased");
     assert!(store.gets() > 0, "a scanning count must read objects");
+}
+
+// ---------------------------------------------------------------------------
+// Issue #723: widen the exact-stats condition so a ts bound that fully contains
+// every resolved segment still reports an exact row count and an exact ts span.
+//
+// These exercise `LogsScanExec::partition_statistics(None)` directly, over the
+// bare scan `LogsTableProvider::plan_filters` builds. That is the entry point
+// DataFusion's `AggregateStatistics` rule consults, and it needs no object-store
+// I/O, so a `CountingStore` pins exactly zero GETs. The three predicate-fallback
+// tests above still cover the whole-plan rewrite for the no-predicate case.
+
+const NON_TS_COLS: &[usize] = &[ravel_sql::LOG_COL_OBSERVED_TS, ravel_sql::LOG_COL_BODY];
+
+/// Build the bare scan for `filters` over `snapshot` and return its whole-plan
+/// statistics. `plan_filters` returns a `LogsScanExec` with no residual filter,
+/// so the reported stats are the scan's own.
+fn scan_stats(store: &Arc<CountingStore>, snapshot: Snapshot, filters: &[Expr]) -> Arc<Statistics> {
+    let provider = provider_over(Arc::clone(store), snapshot);
+    let plan = provider.plan_filters(4, filters).expect("plan_filters");
+    plan.partition_statistics(None)
+        .expect("partition_statistics")
+}
+
+fn ts_ns(v: i64) -> Precision<ScalarValue> {
+    Precision::Exact(ScalarValue::TimestampNanosecond(Some(v), None))
+}
+
+/// Three objects at ts 100..106, 200..210, 300..312 (7 + 11 + 13 = 31 records).
+async fn three_objects(store: &Arc<CountingStore>) -> Snapshot {
+    let s1 = write_object(&**store, "logs/o1.rlog", &seg_records(100, 7)).await;
+    let s2 = write_object(&**store, "logs/o2.rlog", &seg_records(200, 11)).await;
+    let s3 = write_object(&**store, "logs/o3.rlog", &seg_records(300, 13)).await;
+    snapshot_of(vec![s1, s2, s3], Vec::new())
+}
+
+/// Deliverables 1 and 2: a ts bound that strictly contains every segment
+/// (`ts BETWEEN 50 AND 400`, segments span 100..312) reports an `Exact` count
+/// of 31 and an `Exact` ts span of `[100, 312]`, with zero object-store GETs.
+/// Every non-ts column's stats stay `Absent`.
+///
+/// Pre-fix (`stats_are_exact` reverted to `count_is_exact`'s
+/// `self.ts_min == i64::MIN && self.ts_max == i64::MAX`): a present ts bound
+/// makes the condition false, so `num_rows` and the ts column are both `Absent`
+/// and both assertions below fail.
+#[tokio::test]
+async fn contained_ts_bound_reports_exact_count_and_span_with_zero_gets() {
+    let store = CountingStore::new(Arc::new(MemoryStore::new()));
+    let snapshot = three_objects(&store).await;
+
+    let filters = vec![
+        col("ts")
+            .gt_eq(ts_lit(50))
+            .and(col("ts").lt_eq(ts_lit(400))),
+    ];
+    let stats = scan_stats(&store, snapshot, &filters);
+
+    assert_eq!(stats.num_rows, Precision::Exact(31), "7 + 11 + 13");
+    assert_eq!(
+        stats.column_statistics[ravel_sql::LOG_COL_TS].min_value,
+        ts_ns(100),
+        "ts min is the smallest segment min_event_ts_ns"
+    );
+    assert_eq!(
+        stats.column_statistics[ravel_sql::LOG_COL_TS].max_value,
+        ts_ns(312),
+        "ts max is the largest segment max_event_ts_ns"
+    );
+    for &c in NON_TS_COLS {
+        assert_eq!(
+            stats.column_statistics[c].min_value,
+            Precision::Absent,
+            "non-ts column {c} min stays Absent"
+        );
+        assert_eq!(
+            stats.column_statistics[c].max_value,
+            Precision::Absent,
+            "non-ts column {c} max stays Absent"
+        );
+    }
+    assert_eq!(store.gets(), 0, "answering from stats reads no objects");
+}
+
+/// Boundary case for deliverable 1's inclusive containment: a bound whose edges
+/// exactly equal the extreme segment `min_event_ts_ns`/`max_event_ts_ns`
+/// (`ts BETWEEN 100 AND 312`) still counts as fully contained, so the count and
+/// span are still `Exact`.
+#[tokio::test]
+async fn ts_bound_touching_segment_edges_is_contained() {
+    let store = CountingStore::new(Arc::new(MemoryStore::new()));
+    let snapshot = three_objects(&store).await;
+
+    let filters = vec![
+        col("ts")
+            .gt_eq(ts_lit(100))
+            .and(col("ts").lt_eq(ts_lit(312))),
+    ];
+    let stats = scan_stats(&store, snapshot, &filters);
+
+    assert_eq!(stats.num_rows, Precision::Exact(31));
+    assert_eq!(
+        stats.column_statistics[ravel_sql::LOG_COL_TS].min_value,
+        ts_ns(100)
+    );
+    assert_eq!(
+        stats.column_statistics[ravel_sql::LOG_COL_TS].max_value,
+        ts_ns(312)
+    );
+    assert_eq!(store.gets(), 0);
+}
+
+/// Deliverable 3: a bound that clips even one segment (`ts BETWEEN 100 AND 305`,
+/// which excludes ts 306..312 of the third segment) must fail closed. Both the
+/// count and the ts span stay `Absent` so the plan falls back to a real scan;
+/// this must never regress into an inexact count. Reading the clipped segment's
+/// real count from its block index is issue #721, not attempted here.
+#[tokio::test]
+async fn clipping_ts_bound_reports_absent() {
+    let store = CountingStore::new(Arc::new(MemoryStore::new()));
+    let snapshot = three_objects(&store).await;
+
+    let filters = vec![
+        col("ts")
+            .gt_eq(ts_lit(100))
+            .and(col("ts").lt_eq(ts_lit(305))),
+    ];
+    let stats = scan_stats(&store, snapshot, &filters);
+
+    assert_eq!(
+        stats.num_rows,
+        Precision::Absent,
+        "a clipped segment makes the summed count an overcount"
+    );
+    assert_eq!(
+        stats.column_statistics[ravel_sql::LOG_COL_TS].min_value,
+        Precision::Absent,
+        "the ts span is unknown when a segment is clipped"
+    );
+    assert_eq!(
+        stats.column_statistics[ravel_sql::LOG_COL_TS].max_value,
+        Precision::Absent
+    );
+    assert_eq!(store.gets(), 0, "computing statistics reads no objects");
+}
+
+/// Regression guard on the trivial instance (no ts bound at all): the widened
+/// condition must still report the exact count, and now also the exact ts span,
+/// since `[i64::MIN, i64::MAX]` contains every segment.
+#[tokio::test]
+async fn no_ts_bound_reports_exact_count_and_span() {
+    let store = CountingStore::new(Arc::new(MemoryStore::new()));
+    let snapshot = three_objects(&store).await;
+
+    let stats = scan_stats(&store, snapshot, &[]);
+
+    assert_eq!(stats.num_rows, Precision::Exact(31));
+    assert_eq!(
+        stats.column_statistics[ravel_sql::LOG_COL_TS].min_value,
+        ts_ns(100)
+    );
+    assert_eq!(
+        stats.column_statistics[ravel_sql::LOG_COL_TS].max_value,
+        ts_ns(312)
+    );
+    assert_eq!(store.gets(), 0);
 }

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -100,15 +100,32 @@ the plan contains no `LogsScanExec` and the query issues zero object-store
 GETs. Every `sample_count` is written by the commit record, so the sum is
 known the moment `Catalog::resolve` returns; before this, counting the full
 ClickBench tenant (issue #680, 8424 objects, 100M rows) took 142 s and moved
-23 GB from object storage to add up numbers the resolve already had. The scan
-falls back to the exact-count-by-scanning path (row count reported `Absent`,
-the rule does not fire, `LogsScanExec` stays in the plan) whenever the count
-of committed rows is not the query's answer: any pushed predicate at all (a
-`ts` bound, a `has_word` content predicate, or an attribute-equality prune),
-or any pending selective erasure in the snapshot (ADR-0064), which removes
-rows the committed counts still include. So an operator who sees a `COUNT(*)`
-answered with zero GETs is seeing the by-design fast path, and one predicate
-or one pending erasure is enough to put the read back on the scan.
+23 GB from object storage to add up numbers the resolve already had. The leaf
+also reports an `Exact` `num_rows`/`ts` span (issue #723) when a `ts` bound is
+present but fully CONTAINS every resolved segment -- the bound removes no
+row, so the sum is still exact -- not only in the no-bound case. The leaf
+falls back to `Absent` (the rule does not fire on it, `LogsScanExec` stays in
+the plan) whenever the count of committed rows is not the query's answer: a
+`ts` bound that clips at least one segment, any `has_word` content predicate
+or attribute-equality prune, or any pending selective erasure in the snapshot
+(ADR-0064), which removes rows the committed counts still include.
+
+This exact leaf statistic only reaches DataFusion's `AggregateStatistics`
+rule end to end when no `FilterExec` survives above the scan to intercept
+it: `LogsTableProvider::supports_filters_pushdown` currently reports
+`Inexact` for every filter unconditionally (crates/ravel-sql/src/
+logs_provider.rs), so DataFusion keeps re-applying any pushed filter,
+`ts` bound included, in a `FilterExec` above `LogsScanExec`, and that
+`FilterExec` reports its own (non-exact) statistics rather than passing
+the leaf's `Exact` count through. In practice the zero-GET rewrite fires
+today only for the genuinely predicate-free query (no `ts` bound, no
+content, no prune) -- the only shape with no filter left to push down at
+all. The contained-`ts`-bound case computes a correct `Exact` leaf
+statistic (and its `ts` min/max still reach the planner as a leaf
+property), but a `COUNT(*)` with a contained `ts` bound still scans today;
+making `supports_filters_pushdown` report the bound as `Exact` when it is
+already absorbed by this containment check is a separate, unimplemented
+follow-up (issue #733).
 
 Staleness: the evaluator recognizes the Prometheus staleness marker (the
 exact NaN bit pattern `0x7ff0_0000_0000_0002`, compared via


### PR DESCRIPTION
LogsScanExec::partition_statistics only reported an exact COUNT(*) and
ts min/max when no ts bound was pushed at all. A ts-bounded query whose
every resolved segment already sits fully inside the pushed range (the
most common ClickBench-shaped query, "last N days" on a partitioned
tenant) still fell back to reporting Absent, even though the sum of
SegmentRef::sample_count over those segments is exactly as valid as in
the no-bound case.

Widens stats_are_exact (renamed from count_is_exact) so the condition
holds whenever the ts bound fully contains every resolved segment
(inclusive containment, matching the convention ravel_query::log_fetcher
already uses), not only when there is no bound. Under the same
condition, the ts column's statistics now report an Exact min/max over
the touched segments, which was previously Absent unconditionally.

A ts bound that clips even one segment still falls back to Absent for
both, unchanged from today -- reading that segment's real count from
its block index is issue #721's separate, harder problem.

Second commit fixes gaps an opus checkpoint review found before merge:
the doc comments and docs/query-engine.md claimed the zero-GET
AggregateStatistics rewrite fires end to end for any contained ts
bound. It does not today: LogsTableProvider::supports_filters_pushdown
reports every filter Inexact unconditionally, so DataFusion keeps a
FilterExec re-applying the ts bound above this scan, and that
FilterExec's own statistics block the rewrite from ever seeing the
leaf's exact count. Confirmed by an end-to-end probe: a contained-bound
COUNT(*) still issued 6 GETs and a real scan. Filed #733 for that
reachability gap and corrected both doc sites to describe the real,
narrower effective scope (the rewrite still fires end to end only for
the genuinely predicate-free query). Also hardened the ts-column lookup
to use the resolved projection index instead of a name-string match.

Refs: #723
