### PR TITLE
feat(ravel-bench): report over-threshold read amplification per row

### DIFF
--- a/crates/ravel-bench/src/bin/logs_scan_scaling_bench.rs
+++ b/crates/ravel-bench/src/bin/logs_scan_scaling_bench.rs
@@ -7,10 +7,12 @@
 //! Sweeps DataFusion `target_partitions` (`--target-partitions 1,2,4,8,16`)
 //! over one fixed `logs` scan query and a FEW-segment / MANY-block dataset, so
 //! the undersubscribed case (segment count < target_partitions) this item fixes
-//! is what is measured. Each partition value is run with the read cache wired
-//! and un-wired, so the report shows both the scan fanning out past the segment
-//! count and the object-store GET count (flat with the cache, climbing without
-//! it).
+//! is what is measured. Each partition value is run four ways -- read cache
+//! wired and un-wired, crossed with ADR-0107's whole-object and above-threshold
+//! read shapes (issue #693) -- so the report shows the scan fanning out past the
+//! segment count, the object-store GET count on each shape, and the `reads/sg`
+//! and `bytes_x` columns that turn each row's readings into a single
+//! amplification factor.
 //!
 //! Report-only: a new standalone measurement tool, not wired into any
 //! production path. Gated on the `sql-latency` feature so the default build
@@ -46,6 +48,11 @@ struct Args {
     /// Writer block target. Small so each segment holds many blocks.
     #[arg(long, default_value_t = 64)]
     block_target_records: usize,
+    /// Log body length in bytes. Must be large enough that each published object
+    /// clears ADR-0107's 512 KiB block-range threshold, or the `over_threshold`
+    /// rows measure a whole-object read under an above-threshold label.
+    #[arg(long, default_value_t = 256)]
+    body_bytes: usize,
     /// Comma-separated DataFusion `target_partitions` values to sweep. Straddle
     /// `--segments` so the report shows both the un-cached cap binding and the
     /// cache-wired fan-out continuing past it.
@@ -77,6 +84,7 @@ async fn main() {
             segments: args.segments,
             records_per_object: args.records_per_object,
             block_target_records: args.block_target_records,
+            body_bytes: args.body_bytes,
             target_partitions: args.target_partitions,
             runs: args.runs,
             deadline: Duration::from_secs(args.deadline_secs),
@@ -107,7 +115,16 @@ fn print_human_table(report: &Report) {
         "  block_target_records: {}",
         report.config.block_target_records
     );
+    println!("  body_bytes          : {}", report.config.body_bytes);
     println!("  total_records       : {}", report.config.total_records);
+    println!("  dataset_bytes       : {}", report.config.dataset_bytes);
+    println!(
+        "  min_object_bytes    : {} (over-threshold rows use block-range \
+         threshold {}; whole-object rows use {})",
+        report.config.min_object_bytes,
+        report.config.over_threshold_block_range_threshold,
+        report.config.whole_object_block_range_threshold,
+    );
     println!("  runs per combo      : {}", report.config.runs);
     println!();
     println!(
@@ -120,40 +137,46 @@ fn print_human_table(report: &Report) {
     );
     println!();
     println!(
-        "{:>7} | {:>6} | {:>8} | {:>9} | {:>8} | {:>7} | {:>8} | {:>10} | {:>10} | {:>10} | {:>14}",
+        "{:>7} | {:>6} | {:>7} | {:>8} | {:>9} | {:>8} | {:>7} | {:>8} | {:>9} | {:>9} | {:>10} | {:>10} | {:>10} | {:>14}",
         "target",
         "cache",
+        "overthr",
         "scanpart",
         "nonempty",
         "segments",
         "s3_gets",
         "cachehit",
+        "reads/sg",
+        "bytes_x",
         "med (ms)",
         "min (ms)",
         "max (ms)",
         "rows/sec",
     );
     println!(
-        "{:->7}-+-{:->6}-+-{:->8}-+-{:->9}-+-{:->8}-+-{:->7}-+-{:->8}-+-{:->10}-+-{:->10}-+-{:->10}-+-{:->14}",
-        "", "", "", "", "", "", "", "", "", "", ""
+        "{:->7}-+-{:->6}-+-{:->7}-+-{:->8}-+-{:->9}-+-{:->8}-+-{:->7}-+-{:->8}-+-{:->9}-+-{:->9}-+-{:->10}-+-{:->10}-+-{:->10}-+-{:->14}",
+        "", "", "", "", "", "", "", "", "", "", "", "", "", ""
     );
     for c in &report.combos {
         if let Some(err) = &c.error {
             println!(
-                "{:>7} | {:>6} | FAILED: {}",
-                c.target_partitions, c.cache_wired, err,
+                "{:>7} | {:>6} | {:>7} | FAILED: {}",
+                c.target_partitions, c.cache_wired, c.over_threshold, err,
             );
             continue;
         }
         println!(
-            "{:>7} | {:>6} | {:>8} | {:>9} | {:>8} | {:>7} | {:>8} | {:>10.3} | {:>10.3} | {:>10.3} | {:>14.0}",
+            "{:>7} | {:>6} | {:>7} | {:>8} | {:>9} | {:>8} | {:>7} | {:>8} | {:>9.2} | {:>9.2} | {:>10.3} | {:>10.3} | {:>10.3} | {:>14.0}",
             c.target_partitions,
             c.cache_wired,
+            c.over_threshold,
             c.scan_partitions,
             c.non_empty_partitions,
             c.segments_scanned,
             c.object_store_get_requests,
             c.cache_hits,
+            c.reads_per_segment,
+            c.bytes_amplification,
             c.median_ms,
             c.min_ms,
             c.max_ms,

--- a/crates/ravel-bench/src/logs_scan_scaling.rs
+++ b/crates/ravel-bench/src/logs_scan_scaling.rs
@@ -60,6 +60,9 @@
 //! whole-object read per segment, zero suffix probes) is measured instead by the
 //! above-threshold integration tests in `ravel-sql` and `ravel-query`.
 //!
+//! Issue #693 tracks the request-count work this report's figures are quoted
+//! from.
+//!
 //! Report-only: it never changes library behavior. Gated on the `sql-latency`
 //! feature, like the other SQL scaling benches.
 #![allow(clippy::expect_used, clippy::unwrap_used)]

--- a/crates/ravel-bench/src/logs_scan_scaling.rs
+++ b/crates/ravel-bench/src/logs_scan_scaling.rs
@@ -1,6 +1,71 @@
 //! Intra-segment scan-partitioning core-count scaling benchmark (ADR-0102
 //! decision 1, epic #361 item 1).
 //!
+//! # The four row kinds, and the amplification each one can show (issue #693)
+//!
+//! The request-count figures here used to come from a single configuration:
+//! whole-object reads served out of a cache sized to hold the entire dataset.
+//! That is the one configuration in which the amplification #693 measured
+//! cannot appear at all, because single-flight absorbs the repeats and a
+//! whole-object fetch hides how much of each object a partition actually
+//! needed. So the sweep carries two axes next to `target_partitions`:
+//!
+//! - `cache_wired`: ADR-0046's read cache on and off, the same counters read
+//!   from the same [`QueryAccounting`] fields on both sides.
+//! - `over_threshold`: whether each segment sits above the logs fetcher's
+//!   block-range threshold (ADR-0107). The fixture publishes objects that clear
+//!   the production [`ravel_query::DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD`] on
+//!   their own -- 96 records of 16 KiB body each -- and the `over_threshold`
+//!   rows use that production threshold unchanged. The whole-object rows read
+//!   the SAME objects with the threshold moved out of reach
+//!   ([`WHOLE_OBJECT_BLOCK_RANGE_THRESHOLD`]), so the two differ only in read
+//!   shape. Forcing the ranged path onto tiny objects with a threshold of 0 is
+//!   the other route, and it is rejected here: the suffix probe is a fixed
+//!   64 KiB ([`ravel_query::DEFAULT_LOG_SUFFIX_LEN`]), so on a 3 KiB object it
+//!   re-reads the whole object and every ranged read sequence costs about two
+//!   object-reads, which doubles the bytes figure as an artifact of object size
+//!   rather than of the path.
+//!
+//! Each row also carries two figures derived in the report rather than left to
+//! the reader: [`ComboResult::reads_per_segment`] and
+//! [`ComboResult::bytes_amplification`]. What the four row kinds measure, for
+//! this report's one statement (`SELECT ts, body FROM logs` over the full
+//! window, which carries no block predicate and contains every segment):
+//!
+//! - **over-threshold, either cache setting, `target_partitions` at or below
+//!   the segment count**: #693 part 3's whole-segment fast path
+//!   (`LogsScanExec::whole_segment_fast_path`). The plan phase is skipped, each
+//!   segment is assigned whole to one partition, and each is read once with a
+//!   single full-range GET. `reads_per_segment` is 1 and `bytes_amplification`
+//!   is about 1.0, with zero suffix probes, whether or not a cache is wired.
+//!   The cache has nothing left to absorb on this shape.
+//! - **over-threshold, cache wired, `target_partitions` above the segment
+//!   count**: the fast path's fourth conjunct (`relevant_segments >=
+//!   target_partitions`) fails, so the unchanged plan-then-stripe path runs.
+//!   The plan phase probes every segment, then each partition opens the
+//!   segments it holds blocks in and fetches its candidate blocks, and the
+//!   cache coalesces the repeats onto the extents already resident. This is the
+//!   only row in the sweep that still pays a plan phase on an above-threshold
+//!   object, and it is why the sweep keeps a partition value above the segment
+//!   count.
+//! - **whole-object (below-threshold shape), un-cached**: the plan-then-stripe
+//!   path with a whole-object read unit. Segments are assigned whole to one
+//!   partition each (the un-cached amendment), so the count is one plan read
+//!   plus one scan read per segment at every `target_partitions`.
+//! - **whole-object (below-threshold shape), cache wired**: the same two reads
+//!   per segment, except the scan read hits the cache: the plan and scan reads
+//!   share the one `(0, object_size)` key, so only the plan read reaches the
+//!   store.
+//!
+//! An earlier version of this report pinned the un-cached over-threshold rows
+//! to `1 + min(partitions, blocks_per_segment)` passes over the dataset. That
+//! was intra-segment block striping's law: it assumed `n` partitions each
+//! opening the same segment and fetching their own candidate blocks. #693
+//! part 1 confined it to the cache-wired path, and #693 part 3 removed it from
+//! the predicate-free full-window shape entirely. It still governs the
+//! below-threshold and predicated paths, which is where the `over_threshold =
+//! false` rows and the above-segment-count row sit.
+//!
 //! The sibling of [`crate::groupby_scaling`], aimed at the specific capability
 //! item 1 adds: a `logs` query touching FEWER segments than `target_partitions`
 //! used to pin to at most `segment_count` scan partitions
@@ -21,21 +86,22 @@
 //!
 //! It also reports the object-store request count each combination issues, read
 //! from the executed query's `QueryAccounting` (the same source
-//! [`crate::sql_latency`] and [`crate::pushdown_crossover`] use). The fetch unit
-//! is the whole object (ADR-0087 decision 3: no ranged block reader), so every
-//! partition owning blocks in a segment issues its own whole-object read at that
-//! segment's key. Un-cached, the partition count is capped at the segment count
-//! and each segment is assigned whole to one partition (ADR-0102's un-cached
-//! amendment), so raising `target_partitions` changes nothing at any value: the
-//! count is one plan read plus one scan read per segment. Cache-wired, the
-//! partition count keeps climbing and those repeated reads are what ADR-0046's
+//! [`crate::sql_latency`] and [`crate::pushdown_crossover`] use). Every partition
+//! owning blocks in a segment issues its own read sequence at that segment's key;
+//! the shape of the sequence is the `over_threshold` axis (one whole-object GET
+//! at or below the fetcher's block-range threshold, a suffix probe plus directory
+//! sections plus coalesced candidate blocks above it, ADR-0107). Un-cached, the
+//! partition count is capped at the segment count and each segment is assigned
+//! whole to one partition (ADR-0102's un-cached amendment), so raising
+//! `target_partitions` changes nothing at any value. Cache-wired, the partition
+//! count keeps climbing and those repeated reads are what ADR-0046's
 //! single-flight cache absorbs.
 //!
 //! Every request-count figure in this report is a measurement of THIS fixture --
-//! a `MemoryStore`, this segment/block/partition shape, a cache sized to hold the
-//! whole dataset with no eviction -- and not a general "no amplification" result
-//! about striping. Cache size, eviction, object size, and store latency all move
-//! it.
+//! a `MemoryStore`, this segment/block/partition shape, and on the cached rows a
+//! cache sized to hold the whole dataset with no eviction -- and not a general
+//! result about striping in either direction. Cache size, eviction, object size,
+//! and store latency all move it.
 //!
 //! Finally it reports the cost of the planning prune itself
 //! ([`PlanningLatency`]): `ravel_sql`'s `compute_plan_counts` awaits
@@ -44,21 +110,18 @@
 //! segments, so this measures it over the fixture's full segment set and reports
 //! the serial wall time next to the same prunes issued concurrently.
 //!
-//! # #693 part 3 and why this fixture still runs the plan phase
+//! # Why [`PlanningLatency`] is still worth measuring
 //!
 //! Issue #693 part 3 lets a predicate-free, full-window scan skip the plan phase
-//! entirely and read each relevant segment whole in one GET (`ravel_sql`'s
-//! `LogsScanExec::whole_segment_fast_path`). That fast path is gated on the same
-//! conjuncts `plan_segment`'s own fast path uses, which include
-//! `object_size > block_range_threshold`: the plan/scan re-probe it eliminates
-//! only exists above the block-range threshold, and at or below it the plan and
-//! scan reads already coalesce on the one `(0, object_size)` cache key. This
-//! fixture's objects are small (96 records, 6 blocks), well below the default
-//! 512 KiB threshold, so they stay on the plan-then-stripe path and every figure
-//! here -- the [`PlanningLatency`] measurement and the per-combo GET counts --
-//! is unchanged by #693 part 3. The fast path's request-count law (one
-//! whole-object read per segment, zero suffix probes) is measured instead by the
-//! above-threshold integration tests in `ravel-sql` and `ravel-query`.
+//! entirely, which is exactly the shape this report's statement has, so on the
+//! `over_threshold` rows at or below the segment count no combo pays a plan
+//! phase at all. [`PlanningLatency`] is therefore not a component of those rows'
+//! wall time: it is the standing measurement of what a query that does NOT
+//! satisfy the fast path's conjuncts -- any predicate, a partial window overlap,
+//! a pending erasure, a below-threshold segment, or more partitions than
+//! relevant segments -- still pays before its first block is drained. The
+//! whole-object rows and the above-segment-count row are the combos in this
+//! sweep that pay it.
 //!
 //! Issue #693 tracks the request-count work this report's figures are quoted
 //! from.
@@ -81,8 +144,8 @@ use ravel_logseg::{
 };
 use ravel_object_store::{ObjectStoreBackend, PutOptions};
 use ravel_query::{
-    ByteLimit, CacheFetchError, EngineConfig, LogQuery, LogSegmentFetcher, RequestLimit,
-    SegmentFetcher,
+    ByteLimit, CacheFetchError, DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD, EngineConfig, LogQuery,
+    LogSegmentFetcher, RequestLimit, SegmentFetcher,
 };
 use ravel_sql::{SpanSegmentFetcher, SqlConfig, SqlExecutor, SqlRequest};
 use ravel_types::accounting::{AccountedOp, QueryAccounting};
@@ -121,6 +184,12 @@ pub struct LogsScanScalingConfig {
     pub records_per_object: usize,
     /// Writer block target. Small so each segment holds many blocks.
     pub block_target_records: usize,
+    /// Log body length in bytes. Sized so the published objects clear
+    /// [`DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD`], which is what makes the
+    /// `over_threshold` rows a measurement of ADR-0107's ranged path and of
+    /// #693 part 3's fast path, rather than of a threshold override (see the
+    /// module doc).
+    pub body_bytes: usize,
     /// Swept `target_partitions` values (fed through `fetch_concurrency`).
     pub target_partitions: Vec<usize>,
     /// Timed repetitions per combination; the first is the cold run whose
@@ -137,8 +206,12 @@ impl LogsScanScalingConfig {
     /// [`PlanningLatency`] figure said nothing. The swept partition counts
     /// straddle the segment count on both sides (1 below it, 32 at it, 64 above
     /// it) so the report shows the un-cached cap binding and the cached fan-out
-    /// continuing past it. Objects stay small (96 records, 6 blocks each) to keep
-    /// the run cheap despite the segment count.
+    /// continuing past it, and the value above it is also what exercises the
+    /// whole-segment fast path's `relevant_segments >= target_partitions`
+    /// conjunct failing. Objects stay at 96 records and 6 blocks each to keep the
+    /// run cheap despite the segment count; their 16 KiB bodies are what carry
+    /// each one past [`DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD`], which the
+    /// `over_threshold` rows need (see the module doc).
     pub fn smoke(store: Arc<dyn ObjectStoreBackend>, store_label: &str) -> Self {
         LogsScanScalingConfig {
             store,
@@ -146,6 +219,7 @@ impl LogsScanScalingConfig {
             segments: 32,
             records_per_object: 96,
             block_target_records: 16,
+            body_bytes: 16 * 1024,
             target_partitions: vec![1, 32, 64],
             runs: 2,
             deadline: Duration::from_secs(60),
@@ -160,20 +234,49 @@ pub struct ReportConfig {
     pub segments: usize,
     pub records_per_object: usize,
     pub block_target_records: usize,
+    pub body_bytes: usize,
     pub total_records: usize,
+    /// Bytes of RLOG object the fixture published, summed over every segment.
+    /// The denominator of [`ComboResult::bytes_amplification`], so a row's
+    /// figure is "times the dataset" rather than a raw byte count nobody can
+    /// scale.
+    pub dataset_bytes: u64,
+    /// Size of the smallest object published. The `over_threshold` rows are only
+    /// honest if this exceeds [`OVER_THRESHOLD_BLOCK_RANGE_THRESHOLD`], so the
+    /// report carries it rather than asserting the shape in prose.
+    pub min_object_bytes: u64,
     pub target_partitions: Vec<usize>,
+    /// The block-range threshold the `over_threshold` rows build their fetcher
+    /// with: ADR-0107's production default, which every object in this fixture
+    /// exceeds.
+    pub over_threshold_block_range_threshold: u64,
+    /// The block-range threshold the whole-object rows build their fetcher with,
+    /// high enough that no object reaches it.
+    pub whole_object_block_range_threshold: u64,
     pub runs: usize,
     pub cores: usize,
     pub profile: String,
 }
 
-/// One `(target_partitions x cache)` measurement. Every non-axis field is read
-/// from the real plan or the executed query, never echoed from the request.
+/// One `(target_partitions x cache x over_threshold)` measurement. Every
+/// non-axis field is read from the real plan or the executed query, never echoed
+/// from the request; the two derived figures at the end are computed from those
+/// readings, not estimated.
 #[derive(Serialize)]
 pub struct ComboResult {
     pub target_partitions: usize,
     /// Whether ADR-0046's read cache was wired into the logs fetcher.
     pub cache_wired: bool,
+    /// Whether the logs fetcher was built with ADR-0107's production block-range
+    /// threshold ([`OVER_THRESHOLD_BLOCK_RANGE_THRESHOLD`]), which every object
+    /// in this fixture exceeds. False builds the same fetcher with the threshold
+    /// out of reach ([`WHOLE_OBJECT_BLOCK_RANGE_THRESHOLD`]), so the same objects
+    /// are read whole; the two rows differ only in read shape.
+    ///
+    /// The axis also decides whether #693 part 3's whole-segment fast path can
+    /// run: one of its conjuncts is `object_size > block_range_threshold`, so the
+    /// whole-object rows always take the plan-then-stripe path.
+    pub over_threshold: bool,
     /// Observed: the `LogsScanExec` node's declared output partition count in the
     /// real physical plan. Under block-level striping (ADR-0102) this is
     /// `target_partitions` when the cache is wired, even where the segment count
@@ -191,17 +294,42 @@ pub struct ComboResult {
     pub blocks_total: u64,
     pub blocks_scanned: u64,
     /// Object-store GET requests the cold run issued (`QueryAccounting`). The
-    /// number this deliverable exists to report. Un-cached, each segment is
-    /// assigned whole to one partition, so this is one plan read plus one scan
-    /// read per segment at every `target_partitions`. Cache-wired, the partition count
-    /// keeps climbing and the repeated whole-object reads at one key are what
-    /// single-flight absorbs. A figure for THIS fixture only, not a general
-    /// result (see the module doc).
+    /// number this deliverable exists to report.
+    ///
+    /// On the `over_threshold` rows whose partition count is at or below the
+    /// segment count, #693 part 3's whole-segment fast path skips the plan phase
+    /// and reads each segment once, so this is exactly `segments_scanned` --
+    /// zero plan probes -- with or without a cache. On the whole-object rows the
+    /// plan phase runs: un-cached, each segment is assigned whole to one
+    /// partition, so the count is one plan read plus one scan read per segment at
+    /// every `target_partitions`; cache-wired, the scan read hits the cache
+    /// entry the plan read populated. Above the segment count the cached rows
+    /// stripe blocks, and the repeated reads at one key are what single-flight
+    /// absorbs. A figure for THIS fixture only, not a general result (see the
+    /// module doc).
     pub object_store_get_requests: u64,
     /// Cache hits/misses the cold run recorded (zero when un-cached).
     pub cache_hits: u64,
     pub cache_misses: u64,
     pub object_store_bytes: u64,
+    /// Derived: [`Self::object_store_get_requests`] over
+    /// [`Self::segments_scanned`]. The "read sequences per segment" figure issue
+    /// #693 is about, as a number the harness reports rather than one a reader
+    /// divides by hand. Exactly 1.0 on the fast-path rows, which is the same
+    /// statement as "the plan phase issued zero probes".
+    pub reads_per_segment: f64,
+    /// Derived: [`Self::object_store_bytes`] over
+    /// [`ReportConfig::dataset_bytes`], i.e. how many times over the query read
+    /// the dataset it scanned. 1.0 is "each byte fetched once".
+    ///
+    /// About 1.0 on the fast-path rows: each segment is read whole exactly once,
+    /// and the only excess is the catalog traffic the same accounting counts.
+    /// On the whole-object un-cached rows it is about 2.0, one plan read plus one
+    /// scan read per segment. Only where blocks stripe across partitions -- the
+    /// cached rows above the segment count, and any predicated or
+    /// below-threshold query -- does the old
+    /// `1 + min(partitions, blocks_per_segment)` law still describe it.
+    pub bytes_amplification: f64,
     pub result_rows: usize,
     pub runs_taken: usize,
     pub min_ms: f64,
@@ -216,15 +344,30 @@ pub struct ComboResult {
 }
 
 impl ComboResult {
+    /// Blocks per segment on the fixture this row scanned, from the row's own
+    /// readings. The ceiling on how many partitions can open one segment, and so
+    /// the second term of block striping's
+    /// `1 + min(partitions, blocks_per_segment)` law -- which now describes only
+    /// the rows that still stripe (see [`Self::bytes_amplification`]).
+    #[must_use]
+    pub fn blocks_per_segment(&self) -> f64 {
+        if self.segments_scanned == 0 {
+            return 0.0;
+        }
+        self.blocks_total as f64 / self.segments_scanned as f64
+    }
+
     fn failed(
         target_partitions: usize,
         cache_wired: bool,
+        over_threshold: bool,
         scan_partitions: usize,
         error: String,
     ) -> Self {
         ComboResult {
             target_partitions,
             cache_wired,
+            over_threshold,
             scan_partitions,
             non_empty_partitions: 0,
             segments_scanned: 0,
@@ -234,6 +377,8 @@ impl ComboResult {
             cache_hits: 0,
             cache_misses: 0,
             object_store_bytes: 0,
+            reads_per_segment: 0.0,
+            bytes_amplification: 0.0,
             result_rows: 0,
             runs_taken: 0,
             min_ms: 0.0,
@@ -274,6 +419,25 @@ pub struct Report {
     /// What the per-segment serialized planning prune costs on this fixture.
     pub planning: PlanningLatency,
     pub combos: Vec<ComboResult>,
+}
+
+impl Report {
+    /// The single row at one point of the `(target_partitions x cache x
+    /// over_threshold)` sweep, so a caller naming a configuration cannot
+    /// silently read a neighbouring row's figures.
+    #[must_use]
+    pub fn combo(
+        &self,
+        target_partitions: usize,
+        cache_wired: bool,
+        over_threshold: bool,
+    ) -> Option<&ComboResult> {
+        self.combos.iter().find(|c| {
+            c.target_partitions == target_partitions
+                && c.cache_wired == cache_wired
+                && c.over_threshold == over_threshold
+        })
+    }
 }
 
 fn percentile(sorted_ns: &[u64], pct: f64) -> u64 {
@@ -337,31 +501,46 @@ fn available_cores() -> usize {
         .unwrap_or(1)
 }
 
+/// The block-range threshold the `over_threshold = false` rows build their logs
+/// fetcher with. No object can exceed `u64::MAX`, so those rows read whole
+/// objects on the same dataset the `over_threshold` rows read in ranges, and the
+/// two differ only in read shape.
+pub const WHOLE_OBJECT_BLOCK_RANGE_THRESHOLD: u64 = u64::MAX;
+
+/// The block-range threshold the `over_threshold = true` rows build their logs
+/// fetcher with: ADR-0107's production default, which the fixture's objects
+/// genuinely exceed rather than being routed around it.
+pub const OVER_THRESHOLD_BLOCK_RANGE_THRESHOLD: u64 = DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD;
+
 /// Build the few-segment / many-block dataset, then sweep every
-/// `(target_partitions x cache)` combination, returning the full report.
+/// `(target_partitions x cache x over_threshold)` combination, returning the
+/// full report.
 pub async fn run(config: &LogsScanScalingConfig) -> Report {
     let store = Arc::clone(&config.store);
     let tenant = TenantId::new(format!("bench-tenant-{}", Uuid::new_v4()));
     let tenant_hash = tenant.hash();
 
-    let total_records = publish_dataset(store.as_ref(), &tenant, config).await;
+    let dataset = publish_dataset(store.as_ref(), &tenant, config).await;
 
     let planning = measure_planning_latency(Arc::clone(&store), tenant_hash).await;
 
-    let mut combos = Vec::with_capacity(config.target_partitions.len() * 2);
+    let mut combos = Vec::with_capacity(config.target_partitions.len() * 4);
     for &tp in &config.target_partitions {
         for cache_wired in [false, true] {
-            let result = run_combo(
-                Arc::clone(&store),
-                tenant_hash,
-                tp,
-                cache_wired,
-                config.runs,
-                config.deadline,
-                total_records,
-            )
-            .await;
-            combos.push(result);
+            for over_threshold in [false, true] {
+                let result = run_combo(
+                    Arc::clone(&store),
+                    tenant_hash,
+                    tp,
+                    cache_wired,
+                    over_threshold,
+                    config.runs,
+                    config.deadline,
+                    &dataset,
+                )
+                .await;
+                combos.push(result);
+            }
         }
     }
 
@@ -372,8 +551,13 @@ pub async fn run(config: &LogsScanScalingConfig) -> Report {
             segments: config.segments,
             records_per_object: config.records_per_object,
             block_target_records: config.block_target_records,
-            total_records,
+            body_bytes: config.body_bytes,
+            total_records: dataset.total_records,
+            dataset_bytes: dataset.total_bytes,
+            min_object_bytes: dataset.min_object_bytes,
             target_partitions: config.target_partitions.clone(),
+            over_threshold_block_range_threshold: OVER_THRESHOLD_BLOCK_RANGE_THRESHOLD,
+            whole_object_block_range_threshold: WHOLE_OBJECT_BLOCK_RANGE_THRESHOLD,
             runs: config.runs,
             cores: available_cores(),
             profile: build_profile().to_string(),
@@ -451,17 +635,19 @@ async fn measure_planning_latency(
     }
 }
 
-/// One `(target_partitions, cache_wired)` measurement.
+/// One `(target_partitions, cache_wired, over_threshold)` measurement.
 #[allow(clippy::too_many_arguments)]
 async fn run_combo(
     store: Arc<dyn ObjectStoreBackend>,
     tenant_hash: TenantHash,
     target_partitions: usize,
     cache_wired: bool,
+    over_threshold: bool,
     runs: usize,
     deadline: Duration,
-    total_records: usize,
+    dataset: &Dataset,
 ) -> ComboResult {
+    let total_records = dataset.total_records;
     let engine = EngineConfig {
         max_series: usize::MAX,
         max_samples: usize::MAX,
@@ -480,9 +666,22 @@ async fn run_combo(
     // cache misses a warm repeat would elide.
     let catalog = match Catalog::new(Arc::clone(&store), CatalogConfig::default()) {
         Ok(c) => Arc::new(c),
-        Err(e) => return ComboResult::failed(target_partitions, cache_wired, 0, e.to_string()),
+        Err(e) => {
+            return ComboResult::failed(
+                target_partitions,
+                cache_wired,
+                over_threshold,
+                0,
+                e.to_string(),
+            );
+        }
     };
-    let mut logs_fetcher = LogSegmentFetcher::new(Arc::clone(&store));
+    let mut logs_fetcher =
+        LogSegmentFetcher::new(Arc::clone(&store)).with_block_range_threshold(if over_threshold {
+            OVER_THRESHOLD_BLOCK_RANGE_THRESHOLD
+        } else {
+            WHOLE_OBJECT_BLOCK_RANGE_THRESHOLD
+        });
     if cache_wired {
         // Big enough to hold every object with room to spare, so the striping's
         // repeated whole-object reads coalesce onto cache hits.
@@ -518,18 +717,42 @@ async fn run_combo(
         .await
     {
         Ok(s) => s,
-        Err(e) => return ComboResult::failed(target_partitions, cache_wired, 0, e.to_string()),
+        Err(e) => {
+            return ComboResult::failed(
+                target_partitions,
+                cache_wired,
+                over_threshold,
+                0,
+                e.to_string(),
+            );
+        }
     };
     let planned = match executor
         .plan_pinned(tenant_hash, snapshot, QUERY, &accounting, &[])
         .await
     {
         Ok(p) => p,
-        Err(e) => return ComboResult::failed(target_partitions, cache_wired, 0, e.to_string()),
+        Err(e) => {
+            return ComboResult::failed(
+                target_partitions,
+                cache_wired,
+                over_threshold,
+                0,
+                e.to_string(),
+            );
+        }
     };
     let plan = match planned.create_physical_plan().await {
         Ok(p) => p,
-        Err(e) => return ComboResult::failed(target_partitions, cache_wired, 0, e.to_string()),
+        Err(e) => {
+            return ComboResult::failed(
+                target_partitions,
+                cache_wired,
+                over_threshold,
+                0,
+                e.to_string(),
+            );
+        }
     };
     let scan_partitions = scan_partition_count(&plan);
 
@@ -542,6 +765,7 @@ async fn run_combo(
             return ComboResult::failed(
                 target_partitions,
                 cache_wired,
+                over_threshold,
                 scan_partitions,
                 e.to_string(),
             );
@@ -564,7 +788,13 @@ async fn run_combo(
     let non_empty_partitions = match count_non_empty_scan_partitions(&plan).await {
         Ok(n) => n,
         Err(e) => {
-            return ComboResult::failed(target_partitions, cache_wired, scan_partitions, e);
+            return ComboResult::failed(
+                target_partitions,
+                cache_wired,
+                over_threshold,
+                scan_partitions,
+                e,
+            );
         }
     };
 
@@ -577,6 +807,7 @@ async fn run_combo(
                 return ComboResult::failed(
                     target_partitions,
                     cache_wired,
+                    over_threshold,
                     scan_partitions,
                     e.to_string(),
                 );
@@ -603,9 +834,24 @@ async fn run_combo(
         total_records as f64 / (median_ns as f64 / 1e9)
     };
 
+    // The two derived figures, computed from this row's own readings so nobody
+    // has to divide the report by hand: reads per segment, and how many times
+    // over the query fetched the dataset it scanned.
+    let reads_per_segment = if segments_scanned == 0 {
+        0.0
+    } else {
+        object_store_get_requests as f64 / segments_scanned as f64
+    };
+    let bytes_amplification = if dataset.total_bytes == 0 {
+        0.0
+    } else {
+        object_store_bytes as f64 / dataset.total_bytes as f64
+    };
+
     ComboResult {
         target_partitions,
         cache_wired,
+        over_threshold,
         scan_partitions,
         non_empty_partitions,
         segments_scanned,
@@ -615,6 +861,8 @@ async fn run_combo(
         cache_hits,
         cache_misses,
         object_store_bytes,
+        reads_per_segment,
+        bytes_amplification,
         result_rows,
         runs_taken,
         min_ms: min_ns as f64 / 1e6,
@@ -667,15 +915,55 @@ fn resource() -> Vec<(String, AttrValue)> {
     )]
 }
 
+/// What the fixture published: the record count the query scans, and the byte
+/// count [`ComboResult::bytes_amplification`] divides by.
+struct Dataset {
+    total_records: usize,
+    total_bytes: u64,
+    min_object_bytes: u64,
+}
+
+/// Pseudo-random printable filler of `len` bytes, from a SplitMix64 stream
+/// seeded by `seed`.
+///
+/// The body dominates an RLOG record, and the writer compresses it: a repeated
+/// or templated body would collapse back under
+/// [`OVER_THRESHOLD_BLOCK_RANGE_THRESHOLD`] and quietly turn the
+/// `over_threshold` rows into whole-object rows with a different label.
+fn filler(seed: u64, len: usize) -> String {
+    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+    let mut state = seed;
+    let mut out = String::with_capacity(len);
+    for _ in 0..len {
+        state = state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = state;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^= z >> 31;
+        out.push(ALPHABET[(z & 63) as usize] as char);
+    }
+    out
+}
+
+/// The record body: the same human-readable head this bench always used, padded
+/// with [`filler`] to `body_bytes`.
+fn body_for(ts: i64, body_bytes: usize) -> String {
+    let head = format!("request {ts} ok");
+    match body_bytes.checked_sub(head.len() + 1) {
+        Some(pad) if pad > 0 => format!("{head} {}", filler(ts as u64, pad)),
+        _ => head,
+    }
+}
+
 /// Write `config.segments` RLOG objects, each carrying `records_per_object`
 /// records under `config.block_target_records`-record blocks, and publish each
-/// one's commit record so a real `Catalog::resolve` finds it. Returns the total
-/// record count the query scans.
+/// one's commit record so a real `Catalog::resolve` finds it. Returns the record
+/// and byte totals the sweep measures against.
 async fn publish_dataset(
     store: &dyn ObjectStoreBackend,
     tenant: &TenantId,
     config: &LogsScanScalingConfig,
-) -> usize {
+) -> Dataset {
     let segments = config.segments.max(1);
     let per_object = config.records_per_object.max(1);
     let tenant_hash = tenant.hash();
@@ -684,6 +972,8 @@ async fn publish_dataset(
         ..RlogConfig::default()
     };
     let mut total = 0usize;
+    let mut total_bytes = 0u64;
+    let mut min_object_bytes = u64::MAX;
     let mut ts = 1_000i64;
     for obj_idx in 0..segments {
         let writer_seq = (obj_idx + 1) as u64;
@@ -712,7 +1002,7 @@ async fn publish_dataset(
                     observed_ts_ns: ts,
                     severity_num: 9,
                     severity_text: "INFO".to_string(),
-                    body: format!("request {ts} ok"),
+                    body: body_for(ts, config.body_bytes),
                     trace_id: None,
                     span_id: None,
                     flags: 0,
@@ -723,6 +1013,8 @@ async fn publish_dataset(
             total += 1;
         }
         let bytes = writer.finish().expect("finish object");
+        total_bytes += bytes.len() as u64;
+        min_object_bytes = min_object_bytes.min(bytes.len() as u64);
         let new_record = NewCommitRecord {
             tenant_hash,
             signal: Signal::Logs,
@@ -758,5 +1050,13 @@ async fn publish_dataset(
             .await
             .expect("publish");
     }
-    total
+    Dataset {
+        total_records: total,
+        total_bytes,
+        min_object_bytes: if total_bytes == 0 {
+            0
+        } else {
+            min_object_bytes
+        },
+    }
 }

--- a/crates/ravel-bench/tests/logs_scan_scaling_smoke.rs
+++ b/crates/ravel-bench/tests/logs_scan_scaling_smoke.rs
@@ -1,13 +1,25 @@
 //! Acceptance test for the `logs_scan_scaling_bench` path (ADR-0102 decision 1,
-//! epic #361 item 1).
+//! epic #361 item 1; issue #693).
 //!
 //! Drives `logs_scan_scaling::run` in its smoke configuration end to end against
 //! an in-process `MemoryStore` and asserts the report proves what this item
 //! actually ships: with ADR-0046's read cache wired, an undersubscribed `logs`
 //! scan fans out to `target_partitions` block-level partitions (more than the
 //! segment count); without it the partition count is capped at the segment count
-//! and the object-store GET count therefore stops responding to
-//! `target_partitions` once the cap binds.
+//! and each segment is assigned whole to one partition, so the object-store GET
+//! count does not respond to `target_partitions` at all.
+//!
+//! It also pins the read-amplification figures issue #693 exists for. The
+//! report's statement is `SELECT ts, body FROM logs` over the full window, which
+//! is exactly the shape #693 part 3's whole-segment fast path serves, so on the
+//! `over_threshold` rows whose partition count fits inside the segment count the
+//! plan phase is skipped and each segment is read whole exactly once: one read
+//! per segment (the same statement as "the plan phase issued zero probes") and
+//! bytes amplification of about 1.0, cached and un-cached alike. The row whose
+//! partition count exceeds the segment count fails the fast path's fourth
+//! conjunct and takes the plan-then-stripe path instead; it is pinned
+//! separately, because it is the only combo in the sweep that still pays a plan
+//! phase on an above-threshold object.
 //!
 //! Gated on `sql-latency` (the module and bin's gate), so a default
 //! `cargo test -p ravel-bench` sees an empty crate rather than a link error. Run
@@ -18,8 +30,35 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use ravel_bench::logs_scan_scaling::{LogsScanScalingConfig, run};
+use ravel_bench::logs_scan_scaling::{ComboResult, LogsScanScalingConfig, run};
 use ravel_object_store::memory::MemoryStore;
+
+/// The resolved snapshot's own catalog GET. `QueryAccounting` counts it in the
+/// same `AccountedOp::Get` bucket as the scan's reads, so every per-segment
+/// request law below is stated with this much slack rather than pretending the
+/// scan is the only reader. It is one GET per query on this fixture, and it
+/// carries no bytes (the key it probes is absent), which is why the byte
+/// amplifications land on exact integers.
+const CATALOG_GET_SLACK: u64 = 1;
+
+/// Upper end of the band the `over_threshold` full-window rows must land in:
+/// one pass over the dataset, plus at most one further read of every segment.
+/// A per-partition read sequence, the shape block striping produced, would blow
+/// straight past it at 32 partitions.
+const MAX_FAST_PATH_AMPLIFICATION: f64 = 2.0;
+
+/// Float slack on a ratio that is an exact integer quotient of two byte counts.
+const EPS: f64 = 1e-9;
+
+/// Whether this row's scan could take #693 part 3's whole-segment fast path:
+/// above the block-range threshold, and with at least as many relevant segments
+/// as the plan declared partitions (the fast path's fourth conjunct, evaluated
+/// against the DECLARED count, which is what `LogsScanExec` compares). The
+/// statement itself is predicate-free and its window contains every segment, so
+/// those two conjuncts hold for every row in this sweep.
+fn takes_fast_path(c: &ComboResult, segments: usize) -> bool {
+    c.over_threshold && c.scan_partitions <= segments
+}
 
 #[tokio::test(flavor = "multi_thread")]
 async fn logs_scan_scaling_smoke_proves_cache_gated_fanout_and_request_count() {
@@ -34,8 +73,27 @@ async fn logs_scan_scaling_smoke_proves_cache_gated_fanout_and_request_count() {
     );
     assert_eq!(
         report.combos.len(),
-        expected_partitions.len() * 2,
-        "one entry per (target_partitions x cache) combination"
+        expected_partitions.len() * 4,
+        "one entry per (target_partitions x cache x over_threshold) combination"
+    );
+
+    // The `over_threshold` rows are only what they claim if the fixture's
+    // objects genuinely clear ADR-0107's threshold. Forcing the ranged path onto
+    // sub-threshold objects instead would make the 64 KiB suffix probe re-read
+    // each whole object, and would put the fast path out of reach entirely (its
+    // `object_size > block_range_threshold` conjunct), so every figure below
+    // would describe the plan-then-stripe path under an over-threshold label.
+    assert!(
+        report.config.min_object_bytes > report.config.over_threshold_block_range_threshold,
+        "the smallest published object ({} bytes) must exceed the block-range \
+         threshold ({} bytes) for the over_threshold rows to measure ADR-0107's \
+         above-threshold path",
+        report.config.min_object_bytes,
+        report.config.over_threshold_block_range_threshold
+    );
+    assert!(
+        report.config.dataset_bytes > 0,
+        "bytes_amplification needs a non-zero dataset to divide by"
     );
 
     // The planning prune's per-segment serialized await is only visible with
@@ -57,30 +115,35 @@ async fn logs_scan_scaling_smoke_proves_cache_gated_fanout_and_request_count() {
         report.planning.total_blocks
     );
 
-    let mut get_by_combo: HashMap<(usize, bool), u64> = HashMap::new();
+    let mut get_by_combo: HashMap<(usize, bool, bool), u64> = HashMap::new();
     for c in &report.combos {
+        let label = format!(
+            "tp={} cache={} over_threshold={}",
+            c.target_partitions, c.cache_wired, c.over_threshold
+        );
         assert!(
             c.error.is_none(),
-            "combo tp={} cache={} unexpectedly failed: {:?}",
-            c.target_partitions,
-            c.cache_wired,
+            "combo {label} unexpectedly failed: {:?}",
             c.error
         );
         assert!(
             c.median_ms > 0.0,
-            "combo tp={} cache={} must report non-zero timing",
-            c.target_partitions,
-            c.cache_wired
+            "combo {label} must report non-zero timing"
         );
         assert_eq!(
             c.result_rows, report.config.total_records,
-            "a bare `SELECT ts, body FROM logs` returns every record"
+            "a bare `SELECT ts, body FROM logs` returns every record ({label})"
+        );
+        assert_eq!(
+            c.segments_scanned, segments,
+            "every combo scans the whole fixture ({label})"
         );
 
         // The declared fan-out is `target_partitions` only when the read cache is
-        // wired (ADR-0102 decision 1's precondition: the fetch unit is the whole
-        // object, so the extra partitions' repeated reads need the cache to
-        // coalesce). Un-cached it falls back to the pre-item-1 bound.
+        // wired (ADR-0102 decision 1's precondition: the extra partitions'
+        // repeated reads need the cache to coalesce). Un-cached it falls back to
+        // the pre-item-1 bound. This is decided before execution, so the
+        // whole-segment fast path does not move it.
         let expected = if c.cache_wired {
             c.target_partitions
         } else {
@@ -88,102 +151,254 @@ async fn logs_scan_scaling_smoke_proves_cache_gated_fanout_and_request_count() {
         };
         assert_eq!(
             c.scan_partitions, expected,
-            "tp={} cache={}: expected {expected} scan partitions, got {}",
-            c.target_partitions, c.cache_wired, c.scan_partitions
+            "{label}: expected {expected} scan partitions, got {}",
+            c.scan_partitions
         );
 
-        // Every declared partition owns blocks on this fixture (192 blocks across
-        // at most 64 partitions), so the non-empty count matches the declared
-        // one -- and in the cached, undersubscribed case that exceeds the segment
-        // count, which is the capability this item adds.
+        // Every declared partition owns work on this fixture (32 segments and 192
+        // blocks across at most 64 partitions), on both the whole-segment and the
+        // block-striped assignment -- and in the cached, undersubscribed case
+        // that exceeds the segment count, which is the capability this item adds.
         assert_eq!(
             c.non_empty_partitions, expected,
-            "tp={} cache={}: every declared partition should decode blocks; got {}",
-            c.target_partitions, c.cache_wired, c.non_empty_partitions
+            "{label}: every declared partition should decode blocks; got {}",
+            c.non_empty_partitions
         );
         if c.cache_wired && c.target_partitions > segments {
             assert!(
                 c.non_empty_partitions > segments,
-                "cached tp={} (> {segments} segments) must fan out past the \
+                "cached {label} (> {segments} segments) must fan out past the \
                  segment count; got {}",
-                c.target_partitions,
                 c.non_empty_partitions
             );
         }
 
         get_by_combo.insert(
-            (c.target_partitions, c.cache_wired),
+            (c.target_partitions, c.cache_wired, c.over_threshold),
             c.object_store_get_requests,
         );
     }
 
-    // Request count, un-cached: once `target_partitions` reaches the segment
-    // count the partition count stops growing, so the GET count stops growing
-    // with it. This is the property the has_cache gate buys -- without it, every
-    // partition past the segment count added whole-object reads that nothing
-    // absorbed.
-    let at_cap = expected_partitions
-        .iter()
-        .copied()
-        .filter(|&tp| tp >= segments)
-        .collect::<Vec<_>>();
-    assert!(
-        at_cap.len() >= 2,
-        "the sweep must contain at least two `target_partitions` values at or \
-         above the segment count to show the un-cached count going flat; got {at_cap:?}"
-    );
-    let baseline = get_by_combo[&(at_cap[0], false)];
-    for &tp in &at_cap[1..] {
-        assert_eq!(
-            get_by_combo[&(tp, false)],
-            baseline,
-            "un-cached GET count must be flat once the segment-count cap binds: \
-             tp={tp} issued {}, tp={} issued {baseline}",
-            get_by_combo[&(tp, false)],
-            at_cap[0]
-        );
+    // Request count, un-cached: each segment is assigned whole to one partition
+    // (ADR-0102's un-cached amendment, #693 part 1), so raising
+    // `target_partitions` adds no reads at any value, below or above the cap.
+    // Checked on both read shapes: the shape changes what one read of a segment
+    // costs, not how many of them the plan issues.
+    let &min_tp = expected_partitions.iter().min().unwrap();
+    for over_threshold in [false, true] {
+        let baseline = get_by_combo[&(min_tp, false, over_threshold)];
+        for &tp in &expected_partitions {
+            assert_eq!(
+                get_by_combo[&(tp, false, over_threshold)],
+                baseline,
+                "un-cached GET count is flat across the whole sweep once segments \
+                 are assigned whole (over_threshold={over_threshold}): tp={tp} \
+                 issued {}, tp={min_tp} issued {baseline}",
+                get_by_combo[&(tp, false, over_threshold)]
+            );
+        }
     }
 
     // Request count, cache-wired: this is the side that keeps adding partitions
-    // past the segment count, so it is the side where repeated whole-object reads
-    // at one key actually happen. On this fixture -- a cache sized to hold every
-    // object, no eviction -- they coalesce completely and the GET count is flat
-    // across the sweep, and below the un-cached count at every partition value.
-    // "Flat" is a property of THIS fixture, not of striping: a cache too small to
-    // hold the working set would evict between partitions and issue GETs again.
-    let &min_tp = expected_partitions.iter().min().unwrap();
-    let cached_baseline = get_by_combo[&(min_tp, true)];
-    for &tp in &expected_partitions {
-        assert_eq!(
-            get_by_combo[&(tp, true)],
-            cached_baseline,
-            "cache-wired GET count is flat across the sweep on this fixture: \
-             tp={tp} issued {}, tp={min_tp} issued {cached_baseline}",
-            get_by_combo[&(tp, true)]
+    // past the segment count, so it is the side where repeated reads at one key
+    // actually happen. On this fixture -- a cache sized to hold every object, no
+    // eviction -- they coalesce completely and the GET count is flat, and never
+    // above the un-cached count. "Flat" is a property of THIS fixture, not of
+    // striping: a cache too small to hold the working set would evict between
+    // partitions and issue GETs again.
+    //
+    // Both claims are made only over rows that take the same path as their
+    // un-cached neighbour. The over-threshold row above the segment count is the
+    // exception in both directions: it drops out of the whole-segment fast path
+    // (fourth conjunct) while its un-cached neighbour stays in, so it pays a plan
+    // phase the other does not, and it is pinned on its own below.
+    for over_threshold in [false, true] {
+        let comparable = |tp: usize| {
+            let c = report.combo(tp, true, over_threshold).expect("cached row");
+            !over_threshold || takes_fast_path(c, segments)
+        };
+        let flat: Vec<usize> = expected_partitions
+            .iter()
+            .copied()
+            .filter(|&tp| comparable(tp))
+            .collect();
+        assert!(
+            flat.len() >= 2,
+            "the sweep needs at least two cache-wired rows on the same path to \
+             show the GET count going flat (over_threshold={over_threshold}); \
+             got {flat:?}"
+        );
+        let cached_baseline = get_by_combo[&(flat[0], true, over_threshold)];
+        for &tp in &flat {
+            assert_eq!(
+                get_by_combo[&(tp, true, over_threshold)],
+                cached_baseline,
+                "cache-wired GET count is flat across the sweep on this fixture \
+                 (over_threshold={over_threshold}): tp={tp} issued {}, tp={} \
+                 issued {cached_baseline}",
+                get_by_combo[&(tp, true, over_threshold)],
+                flat[0]
+            );
+            assert!(
+                get_by_combo[&(tp, true, over_threshold)]
+                    <= get_by_combo[&(tp, false, over_threshold)],
+                "cache-wired tp={tp} GET count ({}) must not exceed the un-cached \
+                 count ({}) at over_threshold={over_threshold}",
+                get_by_combo[&(tp, true, over_threshold)],
+                get_by_combo[&(tp, false, over_threshold)]
+            );
+        }
+    }
+
+    // Issue #693 part 3, the figure this report exists to carry. A
+    // block-predicate-free statement whose window contains every relevant
+    // segment, over segments above the block-range threshold, with at least as
+    // many relevant segments as declared partitions, skips the plan phase and
+    // reads each segment whole exactly once -- cached or not. So on every
+    // over-threshold row at or below the segment count the GET count is the
+    // segment count (plus the snapshot's own catalog read) and the bytes come to
+    // one pass over the dataset.
+    //
+    // The GET bound is what pins "zero plan probes": a plan phase costs one
+    // suffix probe per segment, which would put the count at 2x the segment
+    // count, far outside the slack.
+    let mut fast_path_rows = 0usize;
+    for c in report
+        .combos
+        .iter()
+        .filter(|c| takes_fast_path(c, segments))
+    {
+        fast_path_rows += 1;
+        let label = format!(
+            "tp={} cache={} over_threshold=true",
+            c.target_partitions, c.cache_wired
+        );
+        let segs = c.segments_scanned as u64;
+        assert!(
+            c.object_store_get_requests >= segs
+                && c.object_store_get_requests <= segs + CATALOG_GET_SLACK,
+            "{label}: the whole-segment fast path reads each of {segs} segments \
+             once and issues zero plan probes, so the GET count must be {segs} \
+             (plus at most {CATALOG_GET_SLACK} catalog read); got {} \
+             ({:.4} reads per segment)",
+            c.object_store_get_requests,
+            c.reads_per_segment
         );
         assert!(
-            get_by_combo[&(tp, true)] <= get_by_combo[&(tp, false)],
-            "cache-wired tp={tp} GET count ({}) must not exceed the un-cached \
-             count ({})",
-            get_by_combo[&(tp, true)],
-            get_by_combo[&(tp, false)]
+            c.bytes_amplification >= 1.0 - EPS
+                && c.bytes_amplification <= MAX_FAST_PATH_AMPLIFICATION,
+            "{label}: bytes_amplification {:.4} is outside the one-pass band \
+             [1.0, {MAX_FAST_PATH_AMPLIFICATION}]; {} bytes fetched over a {} \
+             byte dataset",
+            c.bytes_amplification,
+            c.object_store_bytes,
+            report.config.dataset_bytes
+        );
+    }
+    assert!(
+        fast_path_rows >= 4,
+        "the sweep must pin the fast path on both cache settings at more than one \
+         partition value; got {fast_path_rows} rows"
+    );
+    for cache_wired in [false, true] {
+        for &tp in expected_partitions.iter().filter(|&&tp| tp <= segments) {
+            let c = report
+                .combo(tp, cache_wired, true)
+                .expect("over-threshold row");
+            assert!(
+                takes_fast_path(c, segments),
+                "tp={tp} cache={cache_wired}: a partition value at or below the \
+                 segment count must stay on the fast path, but the plan declared \
+                 {} partitions",
+                c.scan_partitions
+            );
+        }
+    }
+
+    // The other side of the fourth conjunct: a row with MORE declared partitions
+    // than relevant segments cannot fill every partition from whole segments, so
+    // it falls back to plan-then-stripe. It pays a suffix probe per segment that
+    // the fast path skips, plus at least one open of every segment, so it reads
+    // strictly more than the same-shape row that keeps the fast path -- while
+    // staying under one extra pass over the dataset, because above the threshold
+    // each partition fetches only its own candidate blocks rather than the whole
+    // object.
+    let striped: Vec<&ComboResult> = report
+        .combos
+        .iter()
+        .filter(|c| c.over_threshold && c.scan_partitions > segments)
+        .collect();
+    assert!(
+        !striped.is_empty(),
+        "the sweep must contain a `target_partitions` value above the segment \
+         count ({segments}) so the fast path's relevant_segments >= \
+         target_partitions conjunct is exercised failing"
+    );
+    for c in striped {
+        let label = format!(
+            "tp={} cache={} over_threshold=true",
+            c.target_partitions, c.cache_wired
+        );
+        let segs = c.segments_scanned as u64;
+        assert!(
+            c.object_store_get_requests >= 2 * segs,
+            "{label}: off the fast path the plan phase probes each of {segs} \
+             segments and the scan opens each of them at least once, so the GET \
+             count must be at least {}; got {} over {:.1} blocks per segment",
+            2 * segs,
+            c.object_store_get_requests,
+            c.blocks_per_segment()
+        );
+        let fast = report
+            .combo(c.target_partitions, !c.cache_wired, true)
+            .expect("the same partition value on the other cache setting");
+        assert!(
+            takes_fast_path(fast, segments)
+                && c.object_store_get_requests > fast.object_store_get_requests,
+            "{label}: leaving the fast path must cost strictly more GETs than the \
+             tp={} row that keeps it; got {} against {}",
+            fast.target_partitions,
+            c.object_store_get_requests,
+            fast.object_store_get_requests
+        );
+        assert!(
+            c.bytes_amplification > 1.0 && c.bytes_amplification < 2.0,
+            "{label}: the striped path re-reads the probe and directory bytes the \
+             fast path never fetches, but fetches only candidate blocks per \
+             partition, so bytes_amplification must sit in (1.0, 2.0); got {:.4}",
+            c.bytes_amplification
         );
     }
 
-    // Un-cached, the unit of assignment is the whole segment (ADR-0102, the
-    // un-cached amendment): each segment is opened by exactly one partition, so
-    // raising `target_partitions` below the cap adds no whole-object reads
-    // either. The count is one plan read plus one scan read per segment at every
-    // partition value, which the single-partition run measures directly.
-    let uncached_baseline = get_by_combo[&(min_tp, false)];
-    for &tp in &expected_partitions {
-        assert_eq!(
-            get_by_combo[&(tp, false)],
-            uncached_baseline,
-            "un-cached GET count is flat across the whole sweep once segments \
-             are assigned whole: tp={tp} issued {}, tp={min_tp} issued \
-             {uncached_baseline}",
-            get_by_combo[&(tp, false)]
+    // The whole-object rows, which read the SAME objects with the block-range
+    // threshold moved out of reach: below the threshold the fast path does not
+    // apply, so the plan-then-stripe path runs and the plan read is a real
+    // whole-object read rather than a probe. Un-cached that is one plan read plus
+    // one scan read per segment; cache-wired the two share the one
+    // `(0, object_size)` key, so only the plan read reaches the store.
+    for c in report.combos.iter().filter(|c| !c.over_threshold) {
+        let label = format!(
+            "tp={} cache={} over_threshold=false",
+            c.target_partitions, c.cache_wired
+        );
+        let segs = c.segments_scanned as u64;
+        let (reads, amplification) = if c.cache_wired { (1, 1.0) } else { (2, 2.0) };
+        assert!(
+            c.object_store_get_requests >= reads * segs
+                && c.object_store_get_requests <= reads * segs + CATALOG_GET_SLACK,
+            "{label}: the whole-object path costs {reads} store read(s) per \
+             segment over {segs} segments, so the GET count must be {} (plus at \
+             most {CATALOG_GET_SLACK} catalog read); got {}",
+            reads * segs,
+            c.object_store_get_requests
+        );
+        assert!(
+            (c.bytes_amplification - amplification).abs() <= EPS,
+            "{label}: bytes_amplification must be {amplification:.1}; got {:.4} \
+             ({} bytes over a {} byte dataset)",
+            c.bytes_amplification,
+            c.object_store_bytes,
+            report.config.dataset_bytes
         );
     }
 }

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -1464,13 +1464,24 @@ not buy: it stops `target_partitions` from setting the multiplier, but below the
 cap a plan with `n` partitions still opens each sufficiently-blocky segment `n`
 times, and the planning prune that counts surviving blocks adds one more read
 per segment. `ravel-bench`'s `logs_scan_scaling` report measures the cached and
-un-cached request counts side by side; its figures describe that fixture (a
-`MemoryStore`, a cache sized to hold the whole dataset), not striping in
-general. `crates/ravel-query/tests/log_block_range.rs` pins the above-threshold
-cached case exactly: on its 906,791-byte fixture, 2 partitions and 8 partitions
-striping one segment both cost 6 store GETs (one probe, four directory
-sections, one coalesced candidate run), and 8 concurrent cold partitions cost
-the same 6.
+un-cached request counts side by side, on above-threshold and whole-object read
+shapes alike; its figures describe that fixture (a `MemoryStore`, and on the
+cached rows a cache sized to hold the whole dataset), not striping in general.
+Its over-threshold rows are what put a number on the residual multiplier, and
+what show where it no longer applies: each row carries reads per segment and
+bytes fetched over dataset bytes, derived in the report rather than left to the
+reader. For a block-predicate-free statement whose window contains every
+relevant segment — the report's `SELECT ts, body FROM logs`, and the shape the
+whole-segment fast path serves (#693 part 3) — those two figures are 1 and
+about 1.0 at every partition count that fits inside the segment count, with or
+without a cache: the plan phase is skipped and each segment is read whole once,
+so there is nothing left for the cache to absorb. The multiplier reappears on
+the row whose partition count exceeds the segment count, which falls back to
+plan-then-stripe. `crates/ravel-query/tests/log_block_range.rs` pins the
+above-threshold cached case exactly: on its 906,791-byte fixture, 2 partitions
+and 8 partitions striping one segment both cost 6 store GETs (one probe, four
+directory sections, one coalesced candidate run), and 8 concurrent cold
+partitions cost the same 6.
 
 The peak-memory consequence follows the same gate, with a second term above the
 block-range threshold. Concurrently-held *decoded* memory is bounded by block


### PR DESCRIPTION
The logs_scan_scaling report measured the ADR-0102 request-count claim on
objects small enough to be read whole, so the amplification issue #693
measured on the reference tenant could not appear in it. An earlier port
of this report (fleet cd21ff3c) pinned block striping's law, one plan
read plus one scan read per partition, which the #693 amendments to
ADR-0102 then removed: un-cached scans assign whole segments, and a
predicate-free full-window statement over above-threshold segments skips
the plan phase and reads each segment whole exactly once.

Add an over_threshold axis next to the cache axis, so each
target_partitions value carries four rows. The fixture publishes objects
that clear ADR-0107's production block-range threshold on their own (16
KiB pseudo-random bodies, 1.28 MB objects); the whole-object rows read
the same objects with the threshold moved out of reach, so the two differ
only in read shape. Each row carries reads_per_segment and
bytes_amplification against the published dataset size.

Measured on the smoke fixture (32 segments, 6 blocks each): every
over-threshold row at or below the segment count takes the whole-segment
fast path, cached or not, at 33 GETs (one per segment plus the resolve's
catalog probe), 1.0 bytes amplification and 1.03 reads per segment; the
cached over-threshold row above the segment count leaves the fast path
(32 relevant segments < 64 partitions) and stripes at 98 GETs, pinned on
its own with ADR-derived bounds; the below-threshold rows keep the
plan-then-stripe figures (2.0 un-cached, 1.0 cached). The acceptance
test asserts the fixture's smallest object exceeds the threshold (red
when the threshold is moved out of reach: the label lies) and the
per-path laws (red when a has_word predicate forces the fast path off:
193 GETs where 33 was due). docs/query-engine.md names the
over-threshold rows and the two derived figures with the 1.0 expectation,
and the module doc says which paths the old striping law still governs.

Refs: #693
Refs: #680
