### PR TITLE
feat(maintain): stream the logs erasure rewrite through the k-way merge

### DIFF
--- a/crates/ravel-maintain/src/erasure_rewrite.rs
+++ b/crates/ravel-maintain/src/erasure_rewrite.rs
@@ -1174,6 +1174,13 @@ fn first_dropping_log_request(
 /// pruning index (ADR-0013), so a rewritten part carrying none loses a rare
 /// maintenance pass some query pruning, never correctness, the same shape of
 /// tradeoff as this module's documented exemplar-drop for metrics.
+///
+/// Peak memory is bounded the way the compactor's is (issue #725, following
+/// issue #711): inputs are read block by block through [`rlog::StreamCursor`]
+/// with a bounded read fan-out, and survivors land in a [`rlog::PartSink`] that
+/// opens the next part mid-stream once the current one reaches
+/// `max_l1_part_bytes`. A rewrite therefore emits N parts, never one part
+/// sized by the bucket.
 pub async fn build_rewrite_logs(
     store: &dyn ObjectStoreBackend,
     bucket: &Bucket,

--- a/crates/ravel-maintain/src/erasure_rewrite.rs
+++ b/crates/ravel-maintain/src/erasure_rewrite.rs
@@ -1289,8 +1289,11 @@ fn first_dropping_span_request(
 
 /// Decode-filter-reencode one SPANS bucket's live record set against every
 /// applicable request's matcher -- the SPANS sibling of [`build_rewrite_logs`],
-/// same whole-object-GET scope reduction, [`RspanReader::scan`] with an
-/// unbounded [`SpanQuery::ts_range`]. A span's whole [`ravel_rspan::SpanRecord`]
+/// still under the module doc's whole-object-GET scope reduction (which logs
+/// left behind in issue #725): every object named by `object_keys` is fetched
+/// whole and decoded with [`RspanReader::scan`] under an unbounded
+/// [`SpanQuery::ts_range`], and every survivor is pushed into one uncapped
+/// [`RspanWriter`]. A span's whole [`ravel_rspan::SpanRecord`]
 /// (including any links/events, which per that type's own field-shape and doc
 /// comment live only as opaque blob entries inside `attrs`, never as separate
 /// columns) is decoded, tested, and either pushed to the output writer intact
@@ -2203,6 +2206,7 @@ mod tests {
     use ravel_logseg::{
         LogStreamId, Predicate as LogPredicate, RlogConfig, RlogReader, RlogWriter,
     };
+    use ravel_object_store::fault::{FaultPlan, FaultStore, Occurrence, Op};
     use ravel_object_store::memory::MemoryStore;
     use ravel_segment::{SeriesInputV3, VERSION_V7};
     use ravel_types::{Label, METRIC_NAME_LABEL, SeriesId, TenantId, TimeRange};
@@ -2210,6 +2214,7 @@ mod tests {
 
     use super::*;
     use crate::clock::FixedClock;
+    use crate::config::MergeMemoryTracker;
     use crate::read::SeriesPlan;
     use crate::sweep::NoLeases;
 
@@ -3141,6 +3146,21 @@ mod tests {
         records: &[LogRecord],
         indexed_fields: &[&str],
     ) {
+        seed_logs_with(store, seq, records, indexed_fields, RlogConfig::default()).await;
+    }
+
+    /// [`seed_logs_indexed`] with the writer config too, so a fixture can pick
+    /// the input's block size. A memory test needs inputs of many small blocks:
+    /// at the 8192-record default an input's whole stream is one block, and the
+    /// merge's decode-side term would scale with the corpus for reasons that
+    /// have nothing to do with what is under test.
+    async fn seed_logs_with(
+        store: &dyn ObjectStoreBackend,
+        seq: u64,
+        records: &[LogRecord],
+        indexed_fields: &[&str],
+        cfg: RlogConfig,
+    ) {
         let th = tenant_hash();
         let writer_id = Uuid::from_u128(u128::from(seq));
         let identity = LogObjectIdentity {
@@ -3150,7 +3170,7 @@ mod tests {
             writer_epoch: EPOCH,
             writer_seq: seq,
         };
-        let mut w = RlogWriter::new(RlogConfig::default(), identity)
+        let mut w = RlogWriter::new(cfg, identity)
             .with_indexed_fields(indexed_fields.iter().map(|f| (*f).to_string()).collect());
         for r in records {
             w.push(r.clone()).expect("push log record");
@@ -3646,6 +3666,415 @@ mod tests {
         let expected_ts: std::collections::BTreeSet<i64> =
             expected.iter().map(|r| r.ts_ns).collect();
         assert_eq!(survivor_ts, expected_ts);
+    }
+
+    // --- bounded-memory logs erasure rewrite (issue #725) --------------------
+
+    /// Event-time base for the #725 fixtures: the start of the fixture
+    /// bucket's own ingest hour, so every record's event time sits inside the
+    /// hour its bucket is keyed by.
+    const SPLIT_BASE_NS: i64 = HOUR as i64 * NS_PER_HOUR;
+    /// The erased and kept `user_id` values. Deliberately the same length:
+    /// every surviving record must have the same [`rlog::estimate_record`]
+    /// value for [`expected_part_count`] to be arithmetic, not an observation.
+    const SPLIT_ERASED: &str = "erased-0";
+    const SPLIT_KEPT: &str = "kept-000";
+    /// Every fourth record belongs to the erased subject.
+    const SPLIT_ERASE_EVERY: i64 = 4;
+
+    fn split_subject_of(i: i64) -> &'static str {
+        if i % SPLIT_ERASE_EVERY == 0 {
+            SPLIT_ERASED
+        } else {
+            SPLIT_KEPT
+        }
+    }
+
+    /// One wide record of stream 0 at ordinal `i`: `rlog.rs`'s own #711 split
+    /// fixture shape (fixed attribute count, fixed key and value widths, a
+    /// zero-padded body and ordinal that do not change width over the range
+    /// these tests use) plus the `user_id` the erasure predicate matches.
+    fn wide_log_record(i: i64) -> LogRecord {
+        let mut attrs: Vec<(String, LogAttrValue)> = (0..8u32)
+            .map(|k| {
+                (
+                    format!("attr_{k:02}"),
+                    LogAttrValue::Str(format!("value-{:08}-{k:02}", i % 100_000_000)),
+                )
+            })
+            .collect();
+        attrs.push((
+            "user_id".to_string(),
+            LogAttrValue::Str(split_subject_of(i).to_string()),
+        ));
+        log_record(0, SPLIT_BASE_NS + i, &format!("row-{i:08}"), attrs)
+    }
+
+    /// The number of parts `survivors` equally-sized surviving records must
+    /// produce under `cap`: a part takes records until its running estimate
+    /// reaches the cap, so it holds `ceil(cap / estimate)` of them. Erased
+    /// records never enter a part, so they do not count here.
+    fn expected_part_count(record_estimate: u64, cap: u64, survivors: u64) -> u64 {
+        survivors.div_ceil(cap.div_ceil(record_estimate))
+    }
+
+    /// Seed `inputs` L0 objects covering ordinals `0..total` of
+    /// [`wide_log_record`], round-robin, so the canonical merge order
+    /// interleaves the inputs and every record's `ts_ns` is globally unique
+    /// (no tie-break to reason about).
+    async fn seed_split_inputs(
+        store: &dyn ObjectStoreBackend,
+        total: i64,
+        inputs: i64,
+        cfg: RlogConfig,
+    ) {
+        for j in 0..inputs {
+            let recs: Vec<LogRecord> = (0..total / inputs)
+                .map(|i| wide_log_record(i * inputs + j))
+                .collect();
+            seed_logs_with(store, j as u64 + 1, &recs, &[], cfg).await;
+        }
+    }
+
+    /// The one pending request these fixtures erase by.
+    fn split_pending() -> Vec<PendingErasureRequest> {
+        vec![PendingErasureRequest {
+            request_key: "unused-in-memory-only".to_string(),
+            request: logs_erasure_request(725, "user_id", SPLIT_ERASED),
+        }]
+    }
+
+    /// Issue #725: an erasure over a bucket whose SURVIVORS exceed
+    /// `max_l1_part_bytes` several times over emits exactly the number of
+    /// parts the cap implies, not one part sized by the bucket. Every erased
+    /// row is absent, every other row is present exactly once and in canonical
+    /// order across the part sequence, and the count conserves the ADR-0064
+    /// way: `sum(part.sample_count) + dropped == input`.
+    ///
+    /// The whole corpus is one stream, so this is the shape that had no split
+    /// point at all before the size rule: a single OTLP resource/scope, the
+    /// common shape for one busy service.
+    ///
+    /// Demonstrated red by restoring the single unbounded writer: in
+    /// `rlog::PartSink::push`, replace `over_cap = part.estimate >=
+    /// self.config.max_l1_part_bytes` with `over_cap = false`. Every survivor
+    /// then lands in one part and this fails at the part-count assertion with
+    /// `1 != 8`.
+    #[tokio::test]
+    async fn logs_erasure_splits_survivors_into_bounded_parts() {
+        const TOTAL: i64 = 800;
+        const INPUTS: i64 = 2;
+        const CAP: u64 = 64 * 1024;
+
+        let store = MemoryStore::new();
+        seed_split_inputs(&store, TOTAL, INPUTS, RlogConfig::default()).await;
+
+        let expected: Vec<LogRecord> = (0..TOTAL)
+            .filter(|i| split_subject_of(*i) == SPLIT_KEPT)
+            .map(wide_log_record)
+            .collect();
+        let survivors_expected = expected.len() as u64;
+        let dropped_expected = TOTAL as u64 - survivors_expected;
+        assert!(dropped_expected > 0, "the fixture must erase something");
+
+        // Every survivor has the same estimate, so the part count is
+        // arithmetic. Taken from ordinal 1, which is a kept row.
+        let record_estimate = rlog::estimate_record(&wide_log_record(1));
+        let expected_parts = expected_part_count(record_estimate, CAP, survivors_expected);
+        assert!(
+            expected_parts >= 4,
+            "fixture must exceed the cap several times over, got {expected_parts} parts"
+        );
+
+        let clock = FixedClock::new(sealed_now_ns());
+        let config = CompactorConfig {
+            max_l1_part_bytes: CAP,
+            ..CompactorConfig::default()
+        };
+        let mut memo = MaintainMemo::with_default_interval();
+        let outcome = erasure_rewrite_bucket(
+            &store,
+            &clock,
+            &config,
+            &NoLeases,
+            &logs_bucket(),
+            &split_pending(),
+            &mut memo,
+        )
+        .await
+        .expect("erasure rewrite");
+        let (parts, publish) = match outcome {
+            ErasureRewriteOutcome::Rewritten { parts, publish } => (parts, publish),
+            other => panic!("expected Rewritten, got {other:?}"),
+        };
+        assert_eq!(publish, PublishOutcome::Published);
+        assert_eq!(
+            parts as u64, expected_parts,
+            "cap {CAP} over {survivors_expected} survivors estimated at {record_estimate} bytes \
+             each"
+        );
+
+        let record = read_rewrite_record_for(&store, &logs_bucket()).await;
+        assert_eq!(record.parts.len() as u64, expected_parts);
+
+        // ADR-0064 accounting through N parts.
+        assert_eq!(record.drops.len(), 1);
+        assert_eq!(record.drops[0].dropped_count, dropped_expected);
+        let output_total: u64 = record.parts.iter().map(|p| p.sample_count).sum();
+        assert_eq!(
+            output_total + record.drops[0].dropped_count,
+            TOTAL as u64,
+            "sum(part.sample_count) + dropped must equal the whole input record set"
+        );
+
+        // Every erased row absent, every other row present exactly once, in
+        // canonical order across the part sequence.
+        let mut survivors = Vec::new();
+        for part in &record.parts {
+            let key = keys::reconstruct_rewrite_part_key(&record, part).expect("part key");
+            survivors.extend(decode_logs_part(&store, &key).await);
+        }
+        assert!(
+            !survivors.iter().any(|r| r
+                .attrs
+                .iter()
+                .any(|(k, v)| k == "user_id" && v == &LogAttrValue::Str(SPLIT_ERASED.to_string()))),
+            "no erased row may survive in any part"
+        );
+        assert_eq!(
+            survivors, expected,
+            "concatenating the parts in part order must reproduce exactly the kept rows, once \
+             each, in canonical order"
+        );
+
+        // The parts really are a split of one straddling stream: each carries
+        // the same single stream id, with adjacent non-overlapping event-time
+        // ranges.
+        let (stream0, _) = log_stream_ident(0);
+        let mut prev_max: Option<i64> = None;
+        for p in &record.parts {
+            assert_eq!(p.first_series_id, stream0.0.to_vec());
+            assert_eq!(p.last_series_id, stream0.0.to_vec());
+            assert!(p.min_event_ts_ns <= p.max_event_ts_ns);
+            if let Some(prev) = prev_max {
+                assert!(
+                    prev < p.min_event_ts_ns,
+                    "part event-time ranges must be adjacent and non-overlapping"
+                );
+            }
+            prev_max = Some(p.max_event_ts_ns);
+        }
+    }
+
+    /// Issue #725: the erasure rewrite's peak resident memory tracks the part
+    /// cap, not how many records it read or kept. The same single-stream shape
+    /// is erased at 2x and 8x the records; the tracker's total high-water must
+    /// barely move.
+    ///
+    /// Demonstrated red by the same flip as
+    /// [`logs_erasure_splits_survivors_into_bounded_parts`] (`over_cap =
+    /// false` in `rlog::PartSink::push`, restoring the single unbounded
+    /// writer): the writer term then holds every survivor, so the peak follows
+    /// the record count and the ratio goes to about 4, failing `ratio < 1.3`
+    /// while `parts > 1` fails too. Restoring the pre-#725
+    /// whole-object-GET-and-scan body of `build_rewrite_logs` instead makes
+    /// the tracker record nothing at all (that path has no cursor to account),
+    /// failing `peak > 0`.
+    #[tokio::test]
+    async fn logs_erasure_peak_scales_with_the_cap_not_the_survivor_count() {
+        const BASE: i64 = 400;
+        const INPUTS: i64 = 2;
+        const CAP: u64 = 64 * 1024;
+        // The inputs are re-blocked at 100 records so the decode-side term is
+        // the same at both scales (every input carries far more than one
+        // block); at the 8192-record default an input's whole stream would be
+        // one block and the transient term would scale with the corpus, which
+        // is not what this test is about.
+        const L0_BLOCK: usize = 100;
+        // At most one decoded block plus two raw blocks per input. Loose on
+        // purpose: the claim under test is the ratio.
+        const TRANSIENT_ALLOWANCE: u64 = 4 * 1024 * 1024;
+
+        let mut peaks = Vec::new();
+        for scale in [2i64, 8i64] {
+            let store = MemoryStore::new();
+            let total = BASE * scale;
+            seed_split_inputs(
+                &store,
+                total,
+                INPUTS,
+                RlogConfig {
+                    block_target_records: L0_BLOCK,
+                    ..RlogConfig::default()
+                },
+            )
+            .await;
+
+            let tracker = MergeMemoryTracker::new();
+            let config = CompactorConfig {
+                max_l1_part_bytes: CAP,
+                merge_memory_tracker: Some(tracker.clone()),
+                ..CompactorConfig::default()
+            };
+            let clock = FixedClock::new(sealed_now_ns());
+            let mut memo = MaintainMemo::with_default_interval();
+            let outcome = erasure_rewrite_bucket(
+                &store,
+                &clock,
+                &config,
+                &NoLeases,
+                &logs_bucket(),
+                &split_pending(),
+                &mut memo,
+            )
+            .await
+            .expect("erasure rewrite");
+            let parts = match outcome {
+                ErasureRewriteOutcome::Rewritten { parts, .. } => parts,
+                other => panic!("expected Rewritten, got {other:?}"),
+            };
+
+            let peak = tracker.peak_total_bytes();
+            println!(
+                "[mem:erasure #725] scale={scale} records={total} parts={parts} \
+                 peak_total={peak}B cap={CAP}B"
+            );
+            assert!(peak > 0, "the tracker must record real residency");
+            peaks.push((peak, parts));
+        }
+
+        // 4x the records, and the peak must not follow. Asserted before the
+        // shape checks below so the failure a regression produces is the ratio
+        // itself, with both numbers in the message.
+        let (two_x, eight_x) = (peaks[0].0 as f64, peaks[1].0 as f64);
+        let ratio = eight_x / two_x;
+        assert!(
+            ratio < 1.3,
+            "peak scaled with the survivor count: 2x={two_x} 8x={eight_x} ratio={ratio}"
+        );
+        for (scale, (peak, parts)) in [2, 8].into_iter().zip(peaks) {
+            assert!(
+                peak < 2 * CAP + TRANSIENT_ALLOWANCE,
+                "scale {scale}: peak {peak} exceeded 2x the cap plus the per-input transient"
+            );
+            assert!(parts > 1, "scale {scale}: the fixture must actually split");
+        }
+    }
+
+    /// Issue #725: `input_read_concurrency` changes only how many of the
+    /// rewrite's input reads are in flight, never a byte of its output. The
+    /// same bucket is erased at concurrency 1 and 8 and every part must be
+    /// byte-identical (BLAKE3 over the part objects themselves).
+    ///
+    /// The concurrency is proved to be real, not nominal: a FaultStore gate
+    /// holds every L0 data-object GET (`/l0/` names L0 data objects and
+    /// nothing else here), and at concurrency 8 exactly 8 are held
+    /// simultaneously while at concurrency 1 only ever 1 is.
+    ///
+    /// Demonstrated red by restoring the pre-#725 body of
+    /// `build_rewrite_logs`, whose `for object_key in object_keys { store.get(
+    /// object_key, GetRange::Full) }` loop reads one input at a time: the
+    /// `wait_until_held(8)` below then never reaches 8, and the
+    /// `expect("input reads must reach the configured concurrency in flight")`
+    /// on its timeout fires.
+    #[tokio::test]
+    async fn logs_erasure_input_read_concurrency_changes_timing_not_bytes() {
+        const INPUTS: i64 = 16;
+        const TOTAL: i64 = 320;
+
+        async fn erase_at(concurrency: usize) -> (Vec<[u8; 32]>, usize) {
+            let store = Arc::new(FaultStore::new(MemoryStore::new(), FaultPlan::empty()));
+            seed_split_inputs(store.as_ref(), TOTAL, INPUTS, RlogConfig::default()).await;
+
+            // Hold every L0 data-object GET so the in-flight count is
+            // observable. Commit records live under `/c/` and rewrite parts
+            // under `/l1/`, so neither is caught here.
+            let gate = store.hold(Op::Get, Some("/l0/".to_string()), Occurrence::Always);
+            let config = CompactorConfig {
+                max_l1_part_bytes: 64 * 1024,
+                input_read_concurrency: concurrency,
+                ..CompactorConfig::default()
+            };
+            let task = tokio::spawn({
+                let store = Arc::clone(&store);
+                async move {
+                    let clock = FixedClock::new(sealed_now_ns());
+                    let mut memo = MaintainMemo::with_default_interval();
+                    erasure_rewrite_bucket(
+                        store.as_ref(),
+                        &clock,
+                        &config,
+                        &NoLeases,
+                        &logs_bucket(),
+                        &split_pending(),
+                        &mut memo,
+                    )
+                    .await
+                    .expect("erasure rewrite");
+                }
+            });
+
+            // The first window fills to exactly `concurrency` and no further:
+            // `buffered` polls no more than that many futures at once. Bounded
+            // so a serialized read path fails here instead of hanging.
+            tokio::time::timeout(
+                std::time::Duration::from_secs(30),
+                gate.wait_until_held(concurrency),
+            )
+            .await
+            .expect("input reads must reach the configured concurrency in flight");
+            for _ in 0..64 {
+                tokio::task::yield_now().await;
+            }
+            let peak_in_flight = gate.held_count();
+
+            // From here on release everything the gate catches, so the rest of
+            // the run is never blocked. Parks on the gate's `Notify` rather
+            // than spinning.
+            let releaser = tokio::spawn({
+                let gate = gate.clone();
+                async move {
+                    loop {
+                        gate.wait_until_held(1).await;
+                        for id in gate.held() {
+                            gate.release(id);
+                        }
+                    }
+                }
+            });
+            task.await.expect("erasure task");
+
+            let record = read_rewrite_record_for(store.as_ref(), &logs_bucket()).await;
+            let mut hashes = Vec::with_capacity(record.parts.len());
+            for part in &record.parts {
+                let key = keys::reconstruct_rewrite_part_key(&record, part).expect("part key");
+                let got = store.get(&key, GetRange::Full).await.expect("get part");
+                hashes.push(*blake3::hash(got.data.as_ref()).as_bytes());
+            }
+            releaser.abort();
+            (hashes, peak_in_flight)
+        }
+
+        let (serial_hashes, serial_in_flight) = erase_at(1).await;
+        let (concurrent_hashes, concurrent_in_flight) = erase_at(8).await;
+
+        assert_eq!(
+            serial_in_flight, 1,
+            "concurrency 1 must never have two input GETs in flight"
+        );
+        assert_eq!(
+            concurrent_in_flight, 8,
+            "concurrency 8 must have exactly 8 input GETs in flight"
+        );
+        assert!(
+            serial_hashes.len() > 1,
+            "the fixture must split into several parts, got {}",
+            serial_hashes.len()
+        );
+        assert_eq!(
+            serial_hashes, concurrent_hashes,
+            "input_read_concurrency changed the rewritten parts' bytes"
+        );
     }
 
     /// Running the same LOGS rewrite twice from the same pre-publish state

--- a/crates/ravel-maintain/src/erasure_rewrite.rs
+++ b/crates/ravel-maintain/src/erasure_rewrite.rs
@@ -1,9 +1,10 @@
 //! Selective-erasure rewrite pass for the metrics (RSEG), logs (RLOG), and
 //! spans (RSPAN) signals (ADR-0064 decision 3).
 //! [`build_rewrite`] is the metrics (RSEG) driver; [`build_rewrite_logs`] and
-//! [`build_rewrite_spans`] are its logs/spans siblings, decoding whole
-//! `.rlog`/`.rspan` objects rather than RSEG's per-run catalogs (see
-//! [`build_rewrite_logs`]'s doc for why). [`erasure_rewrite_bucket`] dispatches
+//! [`build_rewrite_spans`] are its logs/spans siblings, working from whole
+//! object keys rather than RSEG's per-run catalogs. Logs stream those objects
+//! block by block through the compactor's own merge ([`build_rewrite_logs`]);
+//! spans still decode each object whole. [`erasure_rewrite_bucket`] dispatches
 //! to whichever of the three applies by `bucket.signal` and, on a successful
 //! publish, calls [`crate::scan::MaintainMemo::invalidate`] for the rewritten
 //! bucket's hour so the interior zone re-verifies immediately instead of
@@ -41,12 +42,17 @@
 //! [`ravel_segment::decode_run_histogram_pages`], filters, and re-encodes
 //! survivors via [`ravel_segment::encode_run_v4`]. It also does not replicate
 //! `build_parts`'s size-capped multi-part splitting or its coalesced ranged
-//! fetch: every live input/part is read with one whole-object GET and every
-//! bucket's survivors are written as a single output part. Both are
+//! fetch: every live metrics input/part is read with one whole-object GET and
+//! a metrics bucket's survivors are written as a single output part. Both are
 //! deliberate, transparent scope reductions for a first correct
 //! implementation (erasure rewrites are rare maintenance passes, not a
 //! request-hot path); a follow-up can adopt `build.rs`'s batching machinery
 //! without changing this module's public shape.
+//!
+//! That scope reduction no longer covers logs. [`build_rewrite_logs`] runs the
+//! RLOG compactor's own streaming merge and splits its survivors into
+//! `max_l1_part_bytes`-bounded parts (issue #725); metrics and spans still
+//! have the whole-object, single-part shape described above.
 //!
 //! ## Exemplars are dropped, not carried forward (open gap)
 //!
@@ -75,10 +81,7 @@ use futures::stream::{StreamExt, TryStreamExt, iter as stream_iter};
 use prost::Message;
 use ravel_commit::erasure;
 use ravel_commit::keys;
-use ravel_logseg::{
-    AttrValue as LogAttrValue, LogStreamId, Predicate as LogPredicate, RlogConfig, RlogReader,
-    RlogWriter,
-};
+use ravel_logseg::AttrValue as LogAttrValue;
 use ravel_object_store::{
     GetRange, ObjectStoreBackend, PutOptions, StoreError, UploadChecksum, list_all,
 };
@@ -691,13 +694,14 @@ async fn load_live_catalogs_and_target(
     }
 }
 
-/// Resolve `live` down to the whole-object keys [`build_rewrite_logs`] /
-/// [`build_rewrite_spans`] GET-and-decode-in-full and the [`RewriteSupersession`]
-/// target the eventual `RewriteRecord` names -- the LOGS/SPANS sibling of
+/// Resolve `live` down to the object keys [`build_rewrite_logs`] /
+/// [`build_rewrite_spans`] read and the [`RewriteSupersession`] target the
+/// eventual `RewriteRecord` names -- the LOGS/SPANS sibling of
 /// [`load_live_catalogs_and_target`], stopping short of that function's
-/// per-run [`InputCatalog`] fetch because the logs/spans rewrite path (module
-/// doc's scope reduction) decodes every live object whole rather than through
-/// ranged per-run catalogs, so there is no catalog to build here at all.
+/// per-run [`InputCatalog`] fetch because neither logs nor spans has an RSEG
+/// per-run catalog to build. What each driver then does with the keys differs:
+/// logs hand them to `rlog::load_catalogs_by_key` for a block-streaming merge,
+/// spans still GET each object whole.
 fn live_input_object_keys_and_target(
     live: LiveInputs,
 ) -> Result<(Vec<String>, RewriteSupersession)> {
@@ -1165,22 +1169,47 @@ fn first_dropping_log_request(
 /// Decode-filter-reencode one LOGS bucket's live record set against every
 /// applicable request's matcher, mirroring [`build_rewrite`]'s batching
 /// contract (every request in `requests` gets a `drops[]` entry, even a zero
-/// one) but not its per-run catalog machinery: this module's "single
-/// whole-object GET" scope reduction (top-of-module doc) means every object
-/// named by `object_keys` is fetched whole and every one of its records is
-/// decoded via [`RlogReader::scan`] with an unbounded [`LogPredicate::TsRange`],
-/// rather than range-fetching individual blocks. Records are pushed into one
-/// [`RlogWriter`] with no indexed fields at all -- POSTINGS is a widen-only
-/// pruning index (ADR-0013), so a rewritten part carrying none loses a rare
-/// maintenance pass some query pruning, never correctness, the same shape of
-/// tradeoff as this module's documented exemplar-drop for metrics.
+/// one).
 ///
-/// Peak memory is bounded the way the compactor's is (issue #725, following
-/// issue #711): inputs are read block by block through [`rlog::StreamCursor`]
-/// with a bounded read fan-out, and survivors land in a [`rlog::PartSink`] that
-/// opens the next part mid-stream once the current one reaches
-/// `max_l1_part_bytes`. A rewrite therefore emits N parts, never one part
-/// sized by the bucket.
+/// Survivors are written with no indexed fields at all -- POSTINGS is a
+/// widen-only pruning index (ADR-0013), so a rewritten part carrying none loses
+/// a rare maintenance pass some query pruning, never correctness, the same
+/// shape of tradeoff as this module's documented exemplar-drop for metrics.
+/// Regenerating the index sections from survivors (rather than carrying an
+/// input's through) is what makes an ADR-0064 `.done` claim true of the object
+/// itself, so this is a floor, not just a saving.
+///
+/// # Memory (issue #725)
+///
+/// This is [`rlog::merge_catalogs`], the same k-way block-streaming merge the
+/// compactor runs, with the erasure predicate as its per-record filter. So it
+/// inherits every bound issue #711 gave compaction: each input is read one
+/// block at a time by range (never whole), `input_read_concurrency` cursor
+/// opens are in flight at once, and survivors land in a `PartSink` that closes
+/// the in-progress part as soon as its overhead-aware estimate reaches
+/// `max_l1_part_bytes`, wherever in the merged record sequence that falls.
+/// Peak resident memory is therefore one part plus one decoded block per input,
+/// never the bucket.
+///
+/// It did NOT always work this way: this function used to GET every input whole
+/// and push every survivor into ONE unbounded [`RlogWriter`], so a bucket
+/// carrying one hot stream (3M wide ClickBench rows over ~270 inputs) held the
+/// raw object bytes and every decoded survivor at once, past the 45.7 GB
+/// resident the compactor peaked at before #711.
+///
+/// A rewrite therefore emits N parts. Nothing downstream assumed one: the
+/// conservation gate in [`publish_rewrite_record`] already sums
+/// `part.sample_count` over `build.parts` (ADR-0064 decision 3 point 4), the
+/// publish loop already PUTs each part under its own `part_index`-keyed
+/// content-addressed key, and the catalog already unions every part of a
+/// `RewriteRecord` into its own `SegmentRef`.
+///
+/// The input-side footer cross-check now runs on
+/// [`RlogInputCatalog::record_count`], read from the footer each catalog load
+/// already fetched, instead of from a whole-object GET. It fires after the
+/// merge rather than before the write, which changes nothing it protects: the
+/// merge is a `dry_run` build, so an abort here is still an abort before the
+/// first byte is written.
 pub async fn build_rewrite_logs(
     store: &dyn ObjectStoreBackend,
     bucket: &Bucket,
@@ -1189,87 +1218,45 @@ pub async fn build_rewrite_logs(
     requests: &[ApplicableLogRequest],
     input_set_hash: &[u8; 32],
 ) -> Result<RewriteBuild> {
-    let read_cfg = RlogConfig::default();
-    let full_range = LogPredicate::TsRange {
-        min_ns: i64::MIN,
-        max_ns: i64::MAX,
-    };
+    // `false`: this pass writes its parts with no indexed fields, so recovering
+    // each input's POSTINGS field list would cost a ranged GET per input and be
+    // discarded.
+    let catalogs = rlog::load_catalogs_by_key(store, config, object_keys, false).await?;
 
-    let mut input_sample_count: u64 = 0;
-    let mut output_sample_count: u64 = 0;
-    let mut footer_record_count: u64 = 0;
+    // Input-side record-count authority: each input object's RLOG footer
+    // declares its own `record_count`, written at flush/compact time
+    // independently of the decode path this pass runs. Summing it and
+    // cross-checking against the merge tally below closes the silent data-loss
+    // gap the conservation gate cannot: that gate proves survivors + drops ==
+    // the merge's own count, so a decode that silently dropped input records
+    // would satisfy it against a deflated input total and permanently supersede
+    // the originals. Metrics catches the same class via the catalog
+    // `run.sample_count` cross-check; logs/spans had no equivalent until here.
+    let footer_record_count = checked_sample_sum(catalogs.iter().map(|c| c.record_count))?;
+
     let mut dropped_counts = vec![0u64; requests.len()];
-
-    let identity = rlog::compactor_identity(bucket, config);
-    let mut writer = RlogWriter::new(read_cfg, identity);
-    let mut first_stream_id: Option<LogStreamId> = None;
-    let mut last_stream_id: Option<LogStreamId> = None;
-    let mut any_survivor = false;
-
-    for object_key in object_keys {
-        let got = store.get(object_key, GetRange::Full).await?;
-        // Input-side record-count authority: each input object's
-        // RLOG footer declares its own `record_count`, written at flush/compact
-        // time independently of the decode path this pass runs. Summing it and
-        // cross-checking against the scan tally below closes the silent
-        // data-loss gap the conservation gate cannot: that gate proves
-        // survivors + drops == the scan's own count, so a decode that silently
-        // dropped input records would satisfy it against a deflated input total
-        // and permanently supersede the originals. Metrics catches the same
-        // class via the catalog `run.sample_count` cross-check; logs/spans had
-        // no equivalent until here.
-        let footer = ravel_logseg::footer::open(got.data.as_ref())?;
-        footer_record_count = footer_record_count
-            .checked_add(footer.record_count)
-            .ok_or_else(|| {
-                MaintainError::Invariant("footer record_count sum overflowed u64".to_string())
-            })?;
-        let reader = RlogReader::new(got.data.as_ref(), &read_cfg)?;
-        let (records, _stats) = reader.scan(&full_range)?;
-        for record in records {
-            input_sample_count = input_sample_count.checked_add(1).ok_or_else(|| {
-                MaintainError::Invariant("input_sample_count sum overflowed u64".to_string())
-            })?;
-            match first_dropping_log_request(requests, &record.attrs, record.ts_ns) {
-                Some(i) => dropped_counts[i] += 1,
-                None => {
-                    output_sample_count = output_sample_count.checked_add(1).ok_or_else(|| {
-                        MaintainError::Invariant(
-                            "output_sample_count sum overflowed u64".to_string(),
-                        )
-                    })?;
-                    let sid = record.stream_id;
-                    first_stream_id = Some(first_stream_id.map_or(sid, |f| f.min(sid)));
-                    last_stream_id = Some(last_stream_id.map_or(sid, |l| l.max(sid)));
-                    any_survivor = true;
-                    writer.push(record)?;
-                }
+    // dry_run: true -- `publish_rewrite_record` PUTs `build.parts` itself, only
+    // after its conservation gate passes, mirroring how `build_rewrite_part`
+    // (metrics) also defers the PUT to that shared publish path.
+    let merged = rlog::merge_catalogs(
+        store,
+        config,
+        bucket,
+        &catalogs,
+        input_set_hash,
+        Vec::new(),
+        true,
+        &mut |record| match first_dropping_log_request(requests, &record.attrs, record.ts_ns) {
+            Some(i) => {
+                dropped_counts[i] += 1;
+                Ok(false)
             }
-        }
-    }
+            None => Ok(true),
+        },
+    )
+    .await?;
 
-    input_footer_cross_check(bucket, input_sample_count, footer_record_count)?;
-
-    let parts = if any_survivor {
-        // dry_run: true -- `publish_rewrite_record` PUTs `build.parts` itself,
-        // only after its conservation gate passes, mirroring how
-        // `build_rewrite_part` (metrics) also defers the PUT to that shared
-        // publish path instead of writing here.
-        let built = rlog::finalize_part(
-            store,
-            bucket,
-            writer,
-            first_stream_id,
-            last_stream_id,
-            input_set_hash,
-            0,
-            true,
-        )
-        .await?;
-        vec![built]
-    } else {
-        Vec::new()
-    };
+    input_footer_cross_check(bucket, merged.input_record_count, footer_record_count)?;
 
     let drops = requests
         .iter()
@@ -1281,9 +1268,9 @@ pub async fn build_rewrite_logs(
         .collect();
 
     Ok(RewriteBuild {
-        parts,
-        input_sample_count,
-        output_sample_count,
+        parts: merged.parts,
+        input_sample_count: merged.input_record_count,
+        output_sample_count: merged.output_record_count,
         drops,
     })
 }
@@ -2213,6 +2200,9 @@ mod tests {
 
     use ravel_catalog::{Catalog, CatalogConfig};
     use ravel_commit::record::{self, NewCommitRecord};
+    use ravel_logseg::{
+        LogStreamId, Predicate as LogPredicate, RlogConfig, RlogReader, RlogWriter,
+    };
     use ravel_object_store::memory::MemoryStore;
     use ravel_segment::{SeriesInputV3, VERSION_V7};
     use ravel_types::{Label, METRIC_NAME_LABEL, SeriesId, TenantId, TimeRange};

--- a/crates/ravel-maintain/src/rlog.rs
+++ b/crates/ravel-maintain/src/rlog.rs
@@ -113,6 +113,18 @@
 //! section reader); [`ravel_logseg::open_from_suffix`] is now the RLOG analogue
 //! of `ravel_segment::open_from_suffix` and closed that raw-bytes gap.
 //!
+//! # One merge, two callers
+//!
+//! [`merge_catalogs`] is that merge, and both RLOG writers of L1 parts run
+//! through it: compaction ([`RlogCodec::build_parts`]) keeping every record,
+//! and the ADR-0064 selective-erasure rewrite
+//! (`erasure_rewrite::build_rewrite_logs`) keeping the records no pending
+//! request's matcher drops (issue #725). The rewrite used to have its own
+//! whole-object read and its own single unbounded writer, which is how it
+//! reached the pre-#711 peak on the same tenant shape. Sharing the driver
+//! bounds it and keeps the two from drifting on merge order, on where a part
+//! splits, or on the cross-object stream-identity invariant.
+//!
 //! # What a reader must tolerate after the split
 //!
 //! Two consecutive parts of one compaction may carry the same `stream_id`,
@@ -192,7 +204,15 @@ pub struct RlogInputCatalog {
     /// The dynamic attribute names this input carries a POSTINGS entry for, as
     /// recovered by [`input_indexed_fields`]. Only the *names* survive into the
     /// merge; no posting list from an input is ever read (ADR-0049 decision 6).
+    /// Empty when the caller asked for no recovery (see
+    /// [`load_catalog_from_object`]).
     pub indexed_fields: Vec<String>,
+    /// This input object's own footer `record_count`, retained from the footer
+    /// this load already read. The erasure rewrite's input-side conservation
+    /// gate (`erasure_rewrite::input_footer_cross_check`) needs it, and taking
+    /// it from here is what lets that gate keep working without the
+    /// whole-object GET it used to read the footer from.
+    pub record_count: u64,
 }
 
 /// The logs codec: implements the [`SegmentCodec`] seam for `.rlog` objects.
@@ -207,55 +227,7 @@ impl SegmentCodec for RlogCodec {
         input: &InputRecord,
     ) -> Result<Self::Catalog> {
         let object_key = keys::reconstruct_data_key(&input.record)?;
-        let cfg = RlogConfig::default();
-
-        // Locate the footer and section directory from a suffix probe: one
-        // ranged GET, growing to a second only if the probe missed the footer
-        // (the RLOG analogue of the RSEG read path).
-        let probe = store
-            .get(&object_key, GetRange::Suffix(config.footer_probe_bytes))
-            .await?;
-        let total = probe.total_size;
-        let ftr = match footer::open_from_suffix(&probe.data, total)? {
-            SuffixOutcome::Ready(f) => f,
-            SuffixOutcome::NeedRange { offset, len } => {
-                let tail = store
-                    .get(&object_key, GetRange::Range(offset, offset + len))
-                    .await?;
-                match footer::open_from_suffix(&tail.data, total)? {
-                    SuffixOutcome::Ready(f) => f,
-                    SuffixOutcome::NeedRange { .. } => {
-                        return Err(MaintainError::Invariant(
-                            "rlog footer not covered by ranged fetch".into(),
-                        ));
-                    }
-                }
-            }
-        };
-
-        // Fetch and decode the three whole-read directory sections by range.
-        // BLOCKS and BLOOM are never fetched here; the merge streams blocks by
-        // range one stream at a time. FIELD_DIR is decoded (and validated) even
-        // though the merge rebuilds it, so a corrupt input fails loud here.
-        let stream_dir_raw =
-            fetch_section(store, &object_key, &ftr, kind::STREAM_DIR, &cfg).await?;
-        let field_dir_raw = fetch_section(store, &object_key, &ftr, kind::FIELD_DIR, &cfg).await?;
-        let skip_idx_raw = fetch_section(store, &object_key, &ftr, kind::SKIP_IDX, &cfg).await?;
-
-        // Which fields this input had indexed. Recovered here, while the
-        // object's footer and FIELD_DIR bytes are already at hand, and reduced
-        // immediately to a name list: the POSTINGS bytes themselves are dropped
-        // before this function returns and never take part in the merge.
-        let indexed_fields =
-            input_indexed_fields(store, &object_key, &ftr, &field_dir_raw, &cfg).await?;
-
-        let reader =
-            RlogRangeReader::from_sections(&ftr, &stream_dir_raw, &field_dir_raw, &skip_idx_raw)?;
-        Ok(RlogInputCatalog {
-            object_key,
-            reader,
-            indexed_fields,
-        })
+        load_catalog_from_object(store, config, object_key, true).await
     }
 
     async fn build_parts(
@@ -271,66 +243,263 @@ impl SegmentCodec for RlogCodec {
                 "inputs and catalogs length mismatch".to_string(),
             ));
         }
+        // The output's indexed-field list: the union of the inputs' (see
+        // `input_indexed_fields`). Every part of this compaction gets the same
+        // list, so a field is indexed uniformly across the output.
+        let indexed_fields = merged_indexed_fields(&catalogs);
+        // Compaction drops nothing, so every merged record is kept and the
+        // counts the driver returns are the input count twice over; the
+        // compaction-side conservation gate reads `part.sample_count`, not
+        // these.
+        let merged = merge_catalogs(
+            store,
+            config,
+            bucket,
+            &catalogs,
+            input_set_hash,
+            indexed_fields,
+            config.dry_run,
+            &mut |_| Ok(true),
+        )
+        .await?;
+        Ok(merged.parts)
+    }
+}
 
-        // Global stream_ref remap + cross-object stream-identity check. The
-        // merged set is the sorted union of every input's STREAM_DIR; the dense
-        // merged stream_ref is the ordinal in this set (the writer re-derives it
-        // per part, so we need only the ordering here). Two inputs claiming the
-        // same stream_id with different blobs is a fatal invariant breach.
-        let mut merged: BTreeMap<LogStreamId, Vec<u8>> = BTreeMap::new();
-        for catalog in &catalogs {
-            for entry in catalog.reader.stream_dir().entries() {
-                match merged.entry(entry.stream_id) {
-                    std::collections::btree_map::Entry::Vacant(slot) => {
-                        slot.insert(entry.blob.clone());
-                    }
-                    std::collections::btree_map::Entry::Occupied(slot) => {
-                        if slot.get() != &entry.blob {
-                            return Err(MaintainError::StreamAttrsConflict {
-                                stream_id: entry.stream_id.to_hex(),
-                                a_len: slot.get().len(),
-                                b_len: entry.blob.len(),
-                            });
-                        }
+/// The object-key-parametrized core of [`RlogCodec::load_input_catalog`],
+/// generalized so a caller holding an object key from something other than an
+/// L0 [`InputRecord`] can decode a catalog too. The erasure rewrite is that
+/// caller: its live input set is a list of whole-object keys (L0 data objects,
+/// or the parts of the live compaction/rewrite record), never `InputRecord`s.
+///
+/// `recover_indexed_fields` chooses whether [`input_indexed_fields`] runs. The
+/// compactor wants the list (its output re-indexes what its inputs indexed);
+/// the erasure rewrite writes its parts with no indexed fields at all
+/// (`erasure_rewrite::build_rewrite_logs`'s doc says why), so recovering a list
+/// it would discard would cost one extra ranged GET per input carrying
+/// POSTINGS and nothing else.
+pub(crate) async fn load_catalog_from_object(
+    store: &dyn ObjectStoreBackend,
+    config: &CompactorConfig,
+    object_key: String,
+    recover_indexed_fields: bool,
+) -> Result<RlogInputCatalog> {
+    let cfg = RlogConfig::default();
+
+    // Locate the footer and section directory from a suffix probe: one
+    // ranged GET, growing to a second only if the probe missed the footer
+    // (the RLOG analogue of the RSEG read path).
+    let probe = store
+        .get(&object_key, GetRange::Suffix(config.footer_probe_bytes))
+        .await?;
+    let total = probe.total_size;
+    let ftr = match footer::open_from_suffix(&probe.data, total)? {
+        SuffixOutcome::Ready(f) => f,
+        SuffixOutcome::NeedRange { offset, len } => {
+            let tail = store
+                .get(&object_key, GetRange::Range(offset, offset + len))
+                .await?;
+            match footer::open_from_suffix(&tail.data, total)? {
+                SuffixOutcome::Ready(f) => f,
+                SuffixOutcome::NeedRange { .. } => {
+                    return Err(MaintainError::Invariant(
+                        "rlog footer not covered by ranged fetch".into(),
+                    ));
+                }
+            }
+        }
+    };
+
+    // Fetch and decode the three whole-read directory sections by range.
+    // BLOCKS and BLOOM are never fetched here; the merge streams blocks by
+    // range one stream at a time. FIELD_DIR is decoded (and validated) even
+    // though the merge rebuilds it, so a corrupt input fails loud here.
+    let stream_dir_raw = fetch_section(store, &object_key, &ftr, kind::STREAM_DIR, &cfg).await?;
+    let field_dir_raw = fetch_section(store, &object_key, &ftr, kind::FIELD_DIR, &cfg).await?;
+    let skip_idx_raw = fetch_section(store, &object_key, &ftr, kind::SKIP_IDX, &cfg).await?;
+
+    // Which fields this input had indexed. Recovered here, while the
+    // object's footer and FIELD_DIR bytes are already at hand, and reduced
+    // immediately to a name list: the POSTINGS bytes themselves are dropped
+    // before this function returns and never take part in the merge.
+    let indexed_fields = if recover_indexed_fields {
+        input_indexed_fields(store, &object_key, &ftr, &field_dir_raw, &cfg).await?
+    } else {
+        Vec::new()
+    };
+
+    let record_count = ftr.record_count;
+    let reader =
+        RlogRangeReader::from_sections(&ftr, &stream_dir_raw, &field_dir_raw, &skip_idx_raw)?;
+    Ok(RlogInputCatalog {
+        object_key,
+        reader,
+        indexed_fields,
+        record_count,
+    })
+}
+
+/// One catalog per object key, `input_read_concurrency` loads in flight.
+///
+/// `buffered`, not `buffer_unordered`: the returned catalogs stay aligned
+/// one-to-one with `object_keys` in canonical order, which is the k-way
+/// merge's tie-break on equal `ts_ns` (see [`merge_stream_into_parts`]).
+pub(crate) async fn load_catalogs_by_key(
+    store: &dyn ObjectStoreBackend,
+    config: &CompactorConfig,
+    object_keys: &[String],
+    recover_indexed_fields: bool,
+) -> Result<Vec<RlogInputCatalog>> {
+    let mut pending = Vec::with_capacity(object_keys.len());
+    for object_key in object_keys {
+        pending.push(load_catalog_from_object(
+            store,
+            config,
+            object_key.clone(),
+            recover_indexed_fields,
+        ));
+    }
+    stream_iter(pending)
+        .buffered(config.input_read_concurrency.max(1))
+        .try_collect()
+        .await
+}
+
+/// What one run of [`merge_catalogs`] produced: the parts, and the record
+/// counts the caller's conservation gates need.
+pub(crate) struct MergeOutput {
+    /// Every part built, in part-index order.
+    pub parts: Vec<BuiltPart>,
+    /// Records the merge read out of the inputs, kept and dropped alike.
+    pub input_record_count: u64,
+    /// Records the filter kept, so the ones actually pushed into a part.
+    pub output_record_count: u64,
+}
+
+/// The shared k-way block-streaming merge: every input's records, in global
+/// `(stream_id, ts)` order, filtered through `keep`, partitioned into parts of
+/// at most `max_l1_part_bytes`.
+///
+/// Both callers of the RLOG merge run through here. Compaction
+/// ([`RlogCodec::build_parts`]) keeps every record; the ADR-0064 erasure
+/// rewrite (`erasure_rewrite::build_rewrite_logs`) keeps the records no pending
+/// request's matcher drops. Sharing the driver is what gives the rewrite the
+/// same memory bound issue #711 gave compaction (issue #725): peak resident
+/// memory is one decoded block per input plus the in-progress part, never the
+/// bucket. It also means the two cannot drift on merge order, on where a part
+/// splits, or on the stream-identity invariant below.
+///
+/// `indexed_fields` is the POSTINGS field list every part is written with, and
+/// `dry_run` decides whether each part is PUT as it closes: compaction PUTs
+/// here, while the erasure rewrite defers every PUT to its own publish path,
+/// which writes parts only after its conservation gate passes.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn merge_catalogs(
+    store: &dyn ObjectStoreBackend,
+    config: &CompactorConfig,
+    bucket: &Bucket,
+    catalogs: &[RlogInputCatalog],
+    input_set_hash: &[u8; 32],
+    indexed_fields: Vec<String>,
+    dry_run: bool,
+    keep: &mut (dyn FnMut(&LogRecord) -> Result<bool> + Send),
+) -> Result<MergeOutput> {
+    // Global stream_ref remap + cross-object stream-identity check. The
+    // merged set is the sorted union of every input's STREAM_DIR; the dense
+    // merged stream_ref is the ordinal in this set (the writer re-derives it
+    // per part, so we need only the ordering here). Two inputs claiming the
+    // same stream_id with different blobs is a fatal invariant breach.
+    let mut merged: BTreeMap<LogStreamId, Vec<u8>> = BTreeMap::new();
+    for catalog in catalogs {
+        for entry in catalog.reader.stream_dir().entries() {
+            match merged.entry(entry.stream_id) {
+                std::collections::btree_map::Entry::Vacant(slot) => {
+                    slot.insert(entry.blob.clone());
+                }
+                std::collections::btree_map::Entry::Occupied(slot) => {
+                    if slot.get() != &entry.blob {
+                        return Err(MaintainError::StreamAttrsConflict {
+                            stream_id: entry.stream_id.to_hex(),
+                            a_len: slot.get().len(),
+                            b_len: entry.blob.len(),
+                        });
                     }
                 }
             }
         }
+    }
 
-        // No whole-object fetch: the per-input ranged readers are already in the
-        // catalogs. Each stream's blocks are fetched by range one block at a
-        // time in the k-way merge below, so raw resident bytes stay bounded to
-        // one block per input, never a whole stream or the whole bucket.
-        let identity = compactor_identity(bucket, config);
-        // The output's indexed-field list: the union of the inputs' (see `input_indexed_fields`). Every part of this compaction gets
-        // the same list, so a field is indexed uniformly across the output.
-        let indexed_fields = merged_indexed_fields(&catalogs);
-        let tracker = config.merge_memory_tracker.as_ref();
-        let mut sink = PartSink {
+    // No whole-object fetch: the per-input ranged readers are already in the
+    // catalogs. Each stream's blocks are fetched by range one block at a
+    // time in the k-way merge below, so raw resident bytes stay bounded to
+    // one block per input, never a whole stream or the whole bucket.
+    let identity = compactor_identity(bucket, config);
+    let tracker = config.merge_memory_tracker.as_ref();
+    let mut sink = PartSink {
+        store,
+        bucket,
+        config,
+        input_set_hash,
+        identity,
+        indexed_fields,
+        tracker,
+        dry_run,
+        current: None,
+        parts: Vec::new(),
+        part_index: 0,
+    };
+    let mut counts = RecordCounts::default();
+
+    // Merge stream by stream in sorted stream_id order. Each stream is
+    // k-way merged from every input carrying it (ts-ascending, canonical
+    // input-order tie-break) straight into the current part's writer, and
+    // the part flushes the moment its accumulated record-heap estimate
+    // reaches `max_l1_part_bytes` -- mid-stream if that is where the cap
+    // falls (issue #711, ADR-0032 amendment 2026-08-26). No intermediate
+    // `Vec<LogRecord>` and no per-stream dedup: distinct submissions of
+    // identical content are distinct records (ADR-0032).
+    for stream_id in merged.keys() {
+        merge_stream_into_parts(
             store,
-            bucket,
-            config,
-            input_set_hash,
-            identity,
-            indexed_fields,
+            catalogs,
+            stream_id,
+            &mut sink,
             tracker,
-            current: None,
-            parts: Vec::new(),
-            part_index: 0,
-        };
+            keep,
+            &mut counts,
+        )
+        .await?;
+    }
+    let parts = sink.finish().await?;
+    Ok(MergeOutput {
+        parts,
+        input_record_count: counts.input,
+        output_record_count: counts.output,
+    })
+}
 
-        // Merge stream by stream in sorted stream_id order. Each stream is
-        // k-way merged from every input carrying it (ts-ascending, canonical
-        // input-order tie-break) straight into the current part's writer, and
-        // the part flushes the moment its accumulated record-heap estimate
-        // reaches `max_l1_part_bytes` -- mid-stream if that is where the cap
-        // falls (issue #711, ADR-0032 amendment 2026-08-26). No intermediate
-        // `Vec<LogRecord>` and no per-stream dedup: distinct submissions of
-        // identical content are distinct records (ADR-0032).
-        for stream_id in merged.keys() {
-            merge_stream_into_parts(store, &catalogs, stream_id, &mut sink, tracker).await?;
-        }
-        sink.finish().await
+/// The merge's running record tallies. Checked addition throughout: an
+/// overflowing tally is itself an invariant breach, never a silent wrap that
+/// could balance a caller's conservation gate against a wrong total.
+#[derive(Default)]
+struct RecordCounts {
+    input: u64,
+    output: u64,
+}
+
+impl RecordCounts {
+    fn add_input(&mut self) -> Result<()> {
+        self.input = self.input.checked_add(1).ok_or_else(|| {
+            MaintainError::Invariant("merged input record count overflowed u64".to_string())
+        })?;
+        Ok(())
+    }
+
+    fn add_output(&mut self) -> Result<()> {
+        self.output = self.output.checked_add(1).ok_or_else(|| {
+            MaintainError::Invariant("merged output record count overflowed u64".to_string())
+        })?;
+        Ok(())
     }
 }
 
@@ -359,6 +528,11 @@ struct PartSink<'a> {
     identity: ObjectIdentity,
     indexed_fields: Vec<String>,
     tracker: Option<&'a MergeMemoryTracker>,
+    /// Whether a closed part is encoded but not PUT. Not read from `config`:
+    /// the erasure rewrite defers every part PUT to its own publish path (which
+    /// writes them only after its conservation gate passes) while running with
+    /// a config whose `dry_run` is false.
+    dry_run: bool,
     current: Option<PartBuilder>,
     parts: Vec<BuiltPart>,
     part_index: u32,
@@ -395,7 +569,7 @@ impl PartSink<'_> {
                     self.bucket,
                     self.input_set_hash,
                     self.part_index,
-                    self.config.dry_run,
+                    self.dry_run,
                 )
                 .await?;
             self.parts.push(built);
@@ -668,10 +842,14 @@ async fn fetch_block(
 /// sort of the concatenation orders equal-`ts_ns` records by (input, position),
 /// exactly what selecting the minimum `(ts_ns, input_index)` head does here.
 ///
-/// Records go into `sink`, which closes the in-progress part and opens the next
-/// one the moment the size cap is reached -- possibly in the middle of this
-/// stream (issue #711). The merge order is unaffected: the sink is a pure
-/// partitioner over the sequence this function produces.
+/// Every merged record is tallied in `counts` and offered to `keep`; the ones
+/// it keeps go into `sink`, which closes the in-progress part and opens the
+/// next one the moment the size cap is reached -- possibly in the middle of
+/// this stream (issue #711). The merge order is unaffected: the sink is a pure
+/// partitioner over the sequence this function produces, and a dropped record
+/// shifts the split points without reordering anything. A record `keep`
+/// rejects is released here, so the ADR-0064 erasure rewrite's peak memory is
+/// bounded by its survivors' part, not by everything it read (issue #725).
 ///
 /// The cursors are opened concurrently (`input_read_concurrency` at a time):
 /// each open costs one ranged GET for the stream's first block, so a stream
@@ -683,6 +861,8 @@ async fn merge_stream_into_parts(
     stream_id: &LogStreamId,
     sink: &mut PartSink<'_>,
     tracker: Option<&MergeMemoryTracker>,
+    keep: &mut (dyn FnMut(&LogRecord) -> Result<bool> + Send),
+    counts: &mut RecordCounts,
 ) -> Result<()> {
     let concurrency = sink.config.input_read_concurrency.max(1);
     // Box each open-and-first-refill with an explicit `+ Send` bound before
@@ -721,7 +901,11 @@ async fn merge_stream_into_parts(
             break;
         };
         if let Some(rec) = cursors[bi].take_head() {
-            sink.push(rec).await?;
+            counts.add_input()?;
+            if keep(&rec)? {
+                counts.add_output()?;
+                sink.push(rec).await?;
+            }
         }
         cursors[bi].refill(store, tracker).await?;
     }

--- a/crates/ravel-maintain/src/rlog.rs
+++ b/crates/ravel-maintain/src/rlog.rs
@@ -1078,7 +1078,7 @@ const ATTR_SLOT_BYTES: u64 = std::mem::size_of::<(String, AttrValue)>() as u64;
 /// factor of the true heap rather than a small fraction of it, so a 256 MiB cap
 /// means roughly 256 MiB of live records. It still only decides where parts
 /// split, never correctness.
-fn estimate_record(r: &LogRecord) -> u64 {
+pub(crate) fn estimate_record(r: &LogRecord) -> u64 {
     let mut est = RECORD_SLOT_BYTES;
     est = est.saturating_add(alloc_estimate(r.stream_attrs.len() as u64));
     est = est.saturating_add(alloc_estimate(r.severity_text.len() as u64));

--- a/docs/adrs/0032-rlog-compaction-and-generic-maintain.md
+++ b/docs/adrs/0032-rlog-compaction-and-generic-maintain.md
@@ -305,11 +305,24 @@ order after loading, catalogs stay aligned to that order, and the merge
 is a deterministic k-way merge over it. A test asserts the parts are
 byte-identical at concurrency 1 and 8.
 
-### Not in scope
+### The erasure rewriter shares this merge (amended 2026-08-26)
 
-`build_rewrite_logs` (the ADR-0064 erasure rewriter for logs) still
-fetches every input object whole and pushes every survivor into a single
-`RlogWriter` with no size cap, by the deliberate scope reduction its own
-module documents. It has the same unbounded-writer shape this amendment
-removed from the compactor, and reaches it on the same tenant shape. It
-is not changed here; see the issue for the follow-up.
+As first written, this amendment left `build_rewrite_logs` (the ADR-0064
+erasure rewriter for logs) out of scope: it fetched every input object
+whole and pushed every survivor into a single `RlogWriter` with no size
+cap, the same unbounded-writer shape this amendment removed from the
+compactor, reached on the same tenant shape.
+
+That follow-up landed. `build_rewrite_logs` now runs the same k-way
+block-streaming merge, with the erasure predicate as a per-record filter
+and `input_read_concurrency` bounding its catalog loads, so it inherits
+every bound described above: one decoded block per input plus one
+in-progress part, never the bucket. A logs erasure rewrite therefore
+emits N parts, exactly as a compaction does, and for the same reason.
+Nothing downstream assumed one part: ADR-0064's conservation gate is
+already stated over `sum(output sample_count)`, the parts are already
+PUT under `part_index`-keyed content-addressed keys, and the catalog
+already unions every part of a `RewriteRecord`.
+
+The RSPAN erasure rewriter (`build_rewrite_spans`) still has the
+whole-object, single-writer shape; it was not part of that follow-up.


### PR DESCRIPTION
build_rewrite_logs fetched every input object whole, decoded every
record with RlogReader::scan, and pushed every surviving record into one
RlogWriter with no size cap, the shape #711 removed from the compactor.
On a ClickBench logs bucket (about 270 inputs, 350 MB compressed, 3M rows
of 105 attributes) an ADR-0064 erasure rewrite would hold the raw object
bytes and the decoded LogRecords at once, more than the 45.7 GB the
compactor peaked at before #711.

The compactor's merge is extracted into merge_catalogs, parameterized by
a per-record filter, the POSTINGS field list and whether closed parts
are PUT; RlogCodec::build_parts calls it with a keep-everything filter
and build_rewrite_logs calls it with the erasure predicate as its
filter. Inputs are read by block through StreamCursor with the read
fan-out bounded by input_read_concurrency, survivors drop into a
PartSink that flushes at max_l1_part_bytes with the overhead-aware
estimate, and the footer cross-check reads record_count from the ranged
footer after a dry-run build, still before any byte is written. Parts
carry no indexed fields, as before.

Each part is still written by the frozen ravel-logseg writer, which sorts
by (stream_ref, ts) with a stable tie-break that the merge's canonical
input order reproduces, so part bytes are unchanged; only the
partitioning of survivors into parts changes. No consumer assumed a
single part: publish_rewrite_record gates on sum(part.sample_count) and
keys each part by part_index, validate_rewrite and the catalog's fold
iterate record.parts, and the next rewrite resolves every part of a live
record as its inputs, so ADR-0064 needs no change; ADR-0032's amendment
no longer lists this path as unbounded.

Tests: 600 survivors under a 64 KiB cap produce 12 parts where 1 was
written before, every erased row absent and every other row present once
in canonical order with the count conserved; peak_total is identical at
800 and 3,200 records (322,444 B; ratio 1.00 where the single writer
gave 3.25); parts are byte-identical at input_read_concurrency 1 and 8
with 8 GETs held in flight. The spans rewrite (build_rewrite_spans) has
the same pre-fix shape and is reported separately.

Fixes: #725
Refs: #680
