### PR TITLE
ci: gate ravel-bench's feature lanes locally and in the features job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -443,8 +443,13 @@ jobs:
   #   - ravel-bench --features parquet-baseline (arrow/parquet/object_store)
   #   - ravel-bench --features flight-egress    (ravel-sql/datafusion/flight)
   #   - ravel-bench --features profiling        (pprof/inferno flamegraph lane)
+  #   - ravel-bench --features flight-lane      (ravel-sql/arrow-flight; the
+  #                                              Flight SQL bench lane, PR #724)
   #   - ravel-bench --features sql-latency      (ravel-sql; the SQL corpus and
   #                                              its construct gate, ADR-0100)
+  #   - ravel-bench --features sql-latency,profiling,flight-lane (the widest
+  #                                              combination the ClickBench box
+  #                                              builds; RUNS its tests, #714/#732)
   #   - ravel-bench --features stage-timing     (ravel-ingest/stage-timing;
   #                                              per-stage ingest breakdown,
   #                                              ADR-0104. RUNS its test, does
@@ -489,6 +494,8 @@ jobs:
         run: cargo check --locked -p ravel-bench --features flight-egress
       - name: Check ravel-bench --features profiling
         run: cargo check --locked -p ravel-bench --features profiling
+      - name: Check ravel-bench --features flight-lane
+        run: cargo check --locked -p ravel-bench --features flight-lane
       - name: Check ravel-bench --features sql-latency
         run: cargo check --locked -p ravel-bench --features sql-latency --all-targets
         # The one lane here that also RUNS its tests. A compile probe is the
@@ -501,6 +508,8 @@ jobs:
         # the step above (same feature set, same target dir).
       - name: Test ravel-bench --features sql-latency
         run: cargo test --locked -p ravel-bench --features sql-latency
+      - name: Test ravel-bench --features sql-latency,profiling,flight-lane
+        run: cargo test --locked -p ravel-bench --features sql-latency,profiling,flight-lane
       - name: Check ravel-bench --features stage-timing
         run: cargo check --locked -p ravel-bench --features stage-timing --all-targets
         # RUN the stage-timing acceptance test, not merely compile it (ADR-0104

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,8 +94,11 @@ cargo clippy -p ravel-server -p ravel-sql --features flight-sql --all-targets --
 cargo test   -p ravel-server -p ravel-sql --features flight-sql
 ```
 
-`scripts/gates.sh` runs these when the crates are in scope. Do not skip
-them: a workspace gate can print "All gates passed" on a tree where
+`scripts/gates.sh` runs these when the crates are in scope. It also runs a
+ravel-bench lane (`--features sql-latency,profiling,flight-lane` clippy and
+tests, plus `--features stage-timing`) whenever ravel-bench, ravel-sql,
+ravel-query, or ravel-ingest is in scope, matching CI's `features` job. Do
+not skip them: a workspace gate can print "All gates passed" on a tree where
 `--features sql` fails to compile, because the broken call site sits in a
 target the default feature set never builds.
 

--- a/scripts/gates.sh
+++ b/scripts/gates.sh
@@ -93,16 +93,21 @@ else
   cargo test --locked --doc --profile ci "${crate_args[@]}"
 fi
 
-# Feature-gated surfaces (issues #609, #616). ravel-server's `sql` and
-# `flight-sql` features are off by default, so nothing above compiles the SQL
-# handler, the Flight SQL service, or their tests. Without these lanes a local
-# run prints "All gates passed" on a tree CI rejects. That happened while
-# rebasing #511: the workspace gate was green and `--features sql` failed with
-# E0061 on a call site that had gone stale under a textually clean merge.
+# Feature-gated surfaces (issues #609, #616, #714, #732). ravel-server's `sql`
+# and `flight-sql` features, and ravel-bench's bench-lane features, are off by
+# default, so nothing above compiles the SQL handler, the Flight SQL service,
+# the bench lanes, or their tests. Without these lanes a local run prints "All
+# gates passed" on a tree CI rejects. That happened while rebasing #511: the
+# workspace gate was green and `--features sql` failed with E0061 on a call
+# site that had gone stale under a textually clean merge. It happened again for
+# ravel-bench: #712 merged on a receipt but went red in CI's features job
+# because gates.sh never built ravel-bench's sql-latency tests, and #724's
+# `flight-lane` feature left main uncompilable under
+# `--features sql-latency,profiling,flight-lane` because nothing gated it.
 #
-# Mirrors CI's `lint` and `flight-sql` jobs. In scoped mode these run only
-# when the affected crates are named, so `-p ravel-logseg` does not pay for a
-# ravel-server build it did not ask for.
+# Mirrors CI's `lint`, `flight-sql`, and `features` jobs. In scoped mode these
+# run only when the affected crates are named, so `-p ravel-logseg` does not
+# pay for a ravel-server build it did not ask for.
 run_feature_lane() {
   local feature="$1"
   shift
@@ -118,12 +123,19 @@ run_feature_lane() {
 }
 
 want_features=0
+want_bench=0
 if [[ ${#crate_args[@]} -eq 0 ]]; then
   want_features=1
+  want_bench=1
 else
   for arg in "${crate_args[@]}"; do
     case "${arg}" in
       ravel-server | ravel-sql) want_features=1 ;;
+    esac
+    # ravel-bench's feature tests exercise these crates, so any of them in
+    # scope should pay for the bench lanes.
+    case "${arg}" in
+      ravel-bench | ravel-sql | ravel-query | ravel-ingest) want_bench=1 ;;
     esac
   done
 fi
@@ -131,6 +143,19 @@ fi
 if [[ ${want_features} -eq 1 ]]; then
   run_feature_lane sql -p ravel-server
   run_feature_lane flight-sql -p ravel-server -p ravel-sql
+fi
+
+# ravel-bench bench lanes. The ClickBench box builds
+# `--features sql-latency,profiling` and `--features
+# sql-latency,profiling,flight-lane`; gate the widest combination so a break in
+# any of the three features (SQL corpus, profiling, Flight SQL bench) is caught
+# locally. stage-timing is a separate lane CI checks and runs, kept at parity.
+if [[ ${want_bench} -eq 1 ]]; then
+  run_feature_lane sql-latency,profiling,flight-lane -p ravel-bench
+  echo "==> cargo check --locked -p ravel-bench --features stage-timing"
+  cargo check --locked -p ravel-bench --features stage-timing
+  echo "==> cargo test --locked -p ravel-bench --features stage-timing"
+  cargo test --locked -p ravel-bench --features stage-timing
 fi
 
 # --- Gates-pass receipt ---------------------------------------------------


### PR DESCRIPTION
scripts/gates.sh ran the workspace gate plus ravel-server's sql and
flight-sql lanes, and CI's features job checked ravel-bench's
parquet-baseline, flight-egress, profiling and sql-latency features and
tested sql-latency and stage-timing. Neither compiled ravel-bench's
sql-latency tests locally, and neither built the flight-lane feature at
all. Two receipt-merged PRs paid for that today: #712 went red in the
features job on logs_scan_scaling_smoke.rs after a clean local gate, and
#724's flight-lane smoke test was left uncompilable on main because no
gate anywhere built it.

gates.sh gains a ravel-bench lane: clippy and tests with
`--features sql-latency,profiling,flight-lane` (the widest combination
the ClickBench box builds) plus check and test with `--features
stage-timing`, run in workspace mode and in scoped mode whenever
ravel-bench, ravel-sql, ravel-query or ravel-ingest is named, since
ravel-bench's feature tests exercise those crates. The receipt is still
written only after every lane passes on a clean tree. The features job
gains `Check ravel-bench --features flight-lane` and `Test ravel-bench
--features sql-latency,profiling,flight-lane`, same shape as the
existing steps. CLAUDE.md's Gates section names the lane.

Running the new lane on main at 5109af2c fails on the #724 defect it was
written for (`missing fields parallel_final_aggregation and
tenant_max_bytes` in sql_latency_flight_smoke.rs), which #720 repairs;
this lands after it.

Fixes: #714
Fixes: #732
Refs: #680
