### PR TITLE
feat(ravel-sql): default exact-typed parallel final aggregation on

### DIFF
--- a/crates/ravel-bench/src/bin/sql_latency_bench.rs
+++ b/crates/ravel-bench/src/bin/sql_latency_bench.rs
@@ -156,10 +156,20 @@ struct Args {
     /// used.
     #[arg(long, value_name = "BYTES", default_value_t = ravel_bench::sql_latency::DEFAULT_TENANT_MAX_BYTES)]
     sql_tenant_max_bytes: usize,
-    /// Let an exact-typed query repartition its final aggregation (ADR-0094),
-    /// the same knob as `ravel-server --sql-parallel-final-aggregation`. Off by
-    /// default, which is what every earlier run measured.
-    #[arg(long, default_value_t = false)]
+    /// Let an exact-typed query repartition its final aggregation (ADR-0094,
+    /// amended by issue #741), the same knob as `ravel-server
+    /// --sql-parallel-final-aggregation`. On by default; pass
+    /// `--sql-parallel-final-aggregation=false` (or the bare flag, which stays
+    /// accepted and still means on) to measure the pre-amendment
+    /// single-partition final. The effective value is recorded in the report's
+    /// provenance either way.
+    #[arg(
+        long,
+        num_args = 0..=1,
+        default_value_t = true,
+        default_missing_value = "true",
+        action = clap::ArgAction::Set,
+    )]
     sql_parallel_final_aggregation: bool,
     /// Execute each statement through a running `ravel-server`'s Flight SQL
     /// endpoint (`host:port`, the server's `--listen-grpc`) instead of the

--- a/crates/ravel-bench/src/sql_latency.rs
+++ b/crates/ravel-bench/src/sql_latency.rs
@@ -449,9 +449,10 @@ pub struct GenerateConfig {
     /// both have to be raised together to measure a heavy aggregate.
     pub tenant_max_bytes: usize,
     /// Whether an exact-typed query may repartition its final aggregation
-    /// (ADR-0094, `ravel-server --sql-parallel-final-aggregation`). Reaches
-    /// `SqlConfig::parallel_final_aggregation`; `false` is the compiled-in
-    /// default and what every earlier run used.
+    /// (ADR-0094 amended by issue #741, `ravel-server
+    /// --sql-parallel-final-aggregation`). Reaches
+    /// `SqlConfig::parallel_final_aggregation`; `true` is the compiled-in
+    /// default, and `--sql-parallel-final-aggregation=false` is the opt-out.
     pub parallel_final_aggregation: bool,
     /// The engine's `max_segments` ceiling, the same knob as `ravel-server
     /// --max-segments`. Reaches `SqlConfig::engine.max_segments`; a statement
@@ -543,9 +544,10 @@ pub struct TenantConfigInput {
     /// both have to be raised together to measure a heavy aggregate.
     pub tenant_max_bytes: usize,
     /// Whether an exact-typed query may repartition its final aggregation
-    /// (ADR-0094, `ravel-server --sql-parallel-final-aggregation`). Reaches
-    /// `SqlConfig::parallel_final_aggregation`; `false` is the compiled-in
-    /// default and what every earlier run used.
+    /// (ADR-0094 amended by issue #741, `ravel-server
+    /// --sql-parallel-final-aggregation`). Reaches
+    /// `SqlConfig::parallel_final_aggregation`; `true` is the compiled-in
+    /// default, and `--sql-parallel-final-aggregation=false` is the opt-out.
     pub parallel_final_aggregation: bool,
     /// The engine's `max_segments` ceiling, the same knob as `ravel-server
     /// --max-segments`. Reaches `SqlConfig::engine.max_segments`; a statement
@@ -681,7 +683,7 @@ impl Default for ExecutorSettings {
             shard_count: 1,
             fetch_concurrency: DEFAULT_FETCH_CONCURRENCY,
             tenant_max_bytes: DEFAULT_TENANT_MAX_BYTES,
-            parallel_final_aggregation: false,
+            parallel_final_aggregation: true,
             max_segments: DEFAULT_MAX_SEGMENTS,
         }
     }
@@ -2119,7 +2121,9 @@ mod tests {
     /// SECOND limit under `max_query_bytes`: raising only the per-query pool
     /// leaves a heavy aggregate refused by the tenant accountant with a
     /// different error (issue #680 hit exactly that on 18 ClickBench
-    /// statements). Restoring either compiled-in default fails this.
+    /// statements). Under the #741 amendment the default is on, so the override
+    /// threaded here is the `false` opt-out; both directions must reach the
+    /// executor.
     #[test]
     fn cold_executor_threads_tenant_and_parallel_agg_overrides() {
         let store = empty_store();
@@ -2131,18 +2135,24 @@ mod tests {
             None,
             ExecutorSettings {
                 tenant_max_bytes: custom_tenant,
-                parallel_final_aggregation: true,
+                parallel_final_aggregation: false,
                 ..ExecutorSettings::default()
             },
         )
         .expect("build executor");
         assert_eq!(executor.max_tenant_bytes(), custom_tenant);
-        assert!(executor.config().parallel_final_aggregation);
+        assert!(
+            !executor.config().parallel_final_aggregation,
+            "the false opt-out must reach the executor"
+        );
 
         let executor =
             cold_executor(&store, &[], None, ExecutorSettings::default()).expect("build executor");
         assert_eq!(executor.max_tenant_bytes(), DEFAULT_TENANT_MAX_BYTES);
-        assert!(!executor.config().parallel_final_aggregation);
+        assert!(
+            executor.config().parallel_final_aggregation,
+            "the amended default (issue #741) reaches the executor as on"
+        );
     }
 
     /// The deadline a run used is part of its provenance.

--- a/crates/ravel-sql/src/config.rs
+++ b/crates/ravel-sql/src/config.rs
@@ -39,7 +39,8 @@ pub struct SqlConfig {
     /// measured `RecordBatch` sizes, never a sample count.
     pub max_query_bytes: usize,
     /// Whether an exact-typed query is allowed to repartition its final
-    /// aggregation (ADR-0094 decision 4). Process-wide, default `false`: a
+    /// aggregation (ADR-0094 decision 4). Issue #741 revisits this default.
+    /// Process-wide, default `false`: a
     /// per-query classification (ADR-0094 decision 1) only ever flips
     /// DataFusion's `repartition_aggregations` on when this is `true` *and*
     /// every aggregate expression and GROUP BY key in the query is provably

--- a/crates/ravel-sql/src/config.rs
+++ b/crates/ravel-sql/src/config.rs
@@ -39,13 +39,18 @@ pub struct SqlConfig {
     /// measured `RecordBatch` sizes, never a sample count.
     pub max_query_bytes: usize,
     /// Whether an exact-typed query is allowed to repartition its final
-    /// aggregation (ADR-0094 decision 4). Issue #741 revisits this default.
-    /// Process-wide, default `false`: a
+    /// aggregation (ADR-0094 decision 4, amended 2026-08-26 by issue #741).
+    /// Process-wide, default `true`: a
     /// per-query classification (ADR-0094 decision 1) only ever flips
     /// DataFusion's `repartition_aggregations` on when this is `true` *and*
     /// every aggregate expression and GROUP BY key in the query is provably
-    /// order/partition-independent. Set once at server startup
-    /// (`services/ravel-server`); no live-reload, like every other field here.
+    /// order/partition-independent (`count`, `count distinct`, and
+    /// `sum`/`min`/`max` over non-float input; never `avg` or any float
+    /// accumulator or key). A non-exact-typed plan keeps the single-partition
+    /// final byte for byte whatever this is set to. `false` is the operator
+    /// opt-out, restoring the pre-amendment single-partition final for every
+    /// query. Set once at server startup (`services/ravel-server`); no
+    /// live-reload, like every other field here.
     pub parallel_final_aggregation: bool,
     /// Whether the partial aggregation stage may give up early on a
     /// high-cardinality group key (issue #680, ADR-0102 decision 2 amendment).
@@ -80,7 +85,7 @@ impl Default for SqlConfig {
         SqlConfig {
             engine: EngineConfig::default(),
             max_query_bytes: DEFAULT_MAX_QUERY_BYTES,
-            parallel_final_aggregation: false,
+            parallel_final_aggregation: true,
             skip_partial_aggregation: true,
         }
     }
@@ -132,15 +137,18 @@ impl SqlConfig {
 mod tests {
     use super::*;
 
-    /// ADR-0094: a proper S3-backed production-scale measurement (issue #458)
-    /// found parallel final aggregation not robustly faster than serial at
-    /// any measured partition count, so the flag's default stays `false`.
-    /// This pins that decision -- a future measurement that finds a real win
-    /// and flips the default should update this assertion in the same
-    /// change, not discover it broken in an unrelated PR.
+    /// ADR-0094 amendment (2026-08-26, issue #741): a production-scale
+    /// measurement on the 8,424-object ClickBench tenant (issue #680) found the
+    /// single-partition final aggregate exhausted an 8 GiB per-query pool at 32
+    /// scan partitions on high-cardinality GROUP BY / COUNT(DISTINCT) (nine
+    /// statements failed), while repartitioning the exact-typed final ran those
+    /// in 44-50 s with no determinism cost. The default is therefore `true`.
+    /// This pins that decision -- a change that flips it back to `false` is a
+    /// change to that ClickBench outcome and should update this assertion in the
+    /// same change, not discover it broken in an unrelated PR.
     #[test]
-    fn parallel_final_aggregation_defaults_to_false() {
-        assert!(!SqlConfig::default().parallel_final_aggregation);
+    fn parallel_final_aggregation_defaults_to_true() {
+        assert!(SqlConfig::default().parallel_final_aggregation);
     }
 
     /// Issue #680: the early give-up is on by default. It is the fix for a

--- a/crates/ravel-sql/tests/parallel_final_default.rs
+++ b/crates/ravel-sql/tests/parallel_final_default.rs
@@ -1,0 +1,374 @@
+//! Issue #741 (ADR-0094 amendment): `parallel_final_aggregation` is on by
+//! default, so an exact-typed logs aggregate repartitions its final stage with
+//! no operator flag set. These tests drive the real
+//! `SqlExecutor::plan_pinned` / `execute` path over a `logs` table with a
+//! declared `Int64` column, so they prove the whole chain the amendment turns
+//! on by default: the per-query classification (ADR-0094 decision 1), the
+//! `repartition_aggregations` flip (decision 2), and the `SqlConfig`
+//! default itself.
+//!
+//! Three properties are pinned:
+//!
+//! - `default_session_count_distinct_int_repartitions_final`: with
+//!   `SqlConfig::default()` (flag now on), the physical plan of
+//!   `SELECT COUNT(DISTINCT k) FROM logs` over a declared `Int64` `k` carries a
+//!   `AggregateExec: mode=FinalPartitioned` above a
+//!   `RepartitionExec: partitioning=Hash`. This is the assertion that goes red
+//!   if the default is flipped back to `false` (prove-the-test: the single
+//!   flipped line is `parallel_final_aggregation: true` in
+//!   crates/ravel-sql/src/config.rs).
+//! - `opt_out_count_distinct_int_stays_single_partition`: the same statement
+//!   with the opt-out (`parallel_final_aggregation: false`) keeps
+//!   `mode=Final` above `CoalescePartitionsExec` and carries neither the
+//!   `FinalPartitioned` mode nor a `Hash` repartition.
+//! - `avg_stays_single_partition_under_default`: a non-exact-typed plan (`avg`,
+//!   resolved to `Float64`) keeps the single-partition final under the new
+//!   default, proving the default flip did not weaken the classification gate.
+//! - `both_plan_shapes_agree_on_the_count`: the two plan shapes return the
+//!   identical `COUNT(DISTINCT k)` over a several-partition `MemoryStore`
+//!   fixture.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use datafusion::arrow::array::Int64Array;
+use datafusion::physical_plan::displayable;
+use ravel_catalog::{Catalog, CatalogConfig, Snapshot};
+use ravel_commit::publish::RetryPolicy;
+use ravel_commit::record::NewCommitRecord;
+use ravel_commit::{keys, publish, record};
+use ravel_logseg::writer::ObjectIdentity;
+use ravel_logseg::{AttrValue, LogRecord, RlogConfig, RlogWriter, stream_attrs_bytes};
+use ravel_object_store::memory::MemoryStore;
+use ravel_object_store::{ObjectStoreBackend, PutOptions};
+use ravel_query::{EngineConfig, LogSegmentFetcher, SegmentFetcher};
+use ravel_sql::{
+    DeclaredColumn, DeclaredType, SpanSegmentFetcher, SqlConfig, SqlExecutor, SqlRequest,
+    StaticDeclaredColumns,
+};
+use ravel_types::accounting::QueryAccounting;
+use ravel_types::{Signal, TenantId, TimeRange};
+use uuid::Uuid;
+
+/// RLOG objects the fixture publishes; also the scan's fan-out at
+/// `fetch_concurrency == OBJECTS`, so the fanned-out plan really reaches this
+/// many partitions.
+const OBJECTS: usize = 4;
+
+/// Distinct values of the declared `Int64` key `k`. Each object writes all of
+/// them, so every scan partition holds the whole value space and a repartition
+/// of the final aggregate has real work to move.
+const DISTINCT_K: i64 = 50;
+
+fn tenant() -> TenantId {
+    TenantId::new("adr94-741-parallel-default".to_string())
+}
+
+/// The one declared column under test: an `Int64` attribute `k`. A
+/// `COUNT(DISTINCT k)` over it is exact-typed under ADR-0094 decision 1.
+fn declared() -> Vec<DeclaredColumn> {
+    vec![DeclaredColumn::new("k", DeclaredType::I64)]
+}
+
+/// One log record on a fixed single-`service.name` stream carrying `k=value`.
+fn record(ts: i64, value: i64) -> LogRecord {
+    let resource = vec![(
+        "service.name".to_string(),
+        AttrValue::Str("api".to_string()),
+    )];
+    LogRecord {
+        stream_id: ravel_types::logstream::log_stream_id(&resource, "scope", "1.0", &[]),
+        stream_attrs: stream_attrs_bytes(&resource, "scope", "1.0", &[]),
+        ts_ns: ts,
+        observed_ts_ns: ts,
+        severity_num: 9,
+        severity_text: "INFO".into(),
+        body: String::new(),
+        trace_id: None,
+        span_id: None,
+        flags: 0,
+        attrs: vec![("k".to_string(), AttrValue::I64(value))],
+    }
+}
+
+/// Publish one RLOG object (index `object`) carrying every value in
+/// `0..DISTINCT_K`, on a ts range disjoint from the other objects.
+async fn publish_object(store: &dyn ObjectStoreBackend, tenant: &TenantId, object: usize) {
+    let base_ts = object as i64 * 100_000;
+    let records: Vec<LogRecord> = (0..DISTINCT_K).map(|v| record(base_ts + v, v)).collect();
+
+    let identity = ObjectIdentity {
+        tenant_hash: tenant.hash().0,
+        shard: 0,
+        writer_id: *Uuid::from_u128(0x741_0000 + object as u128).as_bytes(),
+        writer_epoch: 1,
+        writer_seq: object as u64 + 1,
+    };
+    let mut w = RlogWriter::new(RlogConfig::default(), identity);
+    for r in &records {
+        w.push(r.clone()).expect("push");
+    }
+    let bytes = w.finish().expect("finish");
+    let min = records.iter().map(|r| r.ts_ns).min().expect("nonempty");
+    let max = records.iter().map(|r| r.ts_ns).max().expect("nonempty");
+    let new_record = NewCommitRecord {
+        tenant_hash: tenant.hash(),
+        signal: Signal::Logs,
+        shard: 0,
+        writer_id: Uuid::from_u128(0x741_0000 + object as u128),
+        writer_epoch: 1,
+        writer_seq: object as u64 + 1,
+        object_size: bytes.len() as u64,
+        content_hash: [object as u8; 32],
+        sample_count: records.len() as u64,
+        series_count: 1,
+        min_event_ts_ns: min,
+        max_event_ts_ns: max,
+        min_ingest_ts_ns: min,
+        max_ingest_ts_ns: max,
+        segment_format_version: 1,
+        created_unix_ns: 10,
+        ingest_hour_bucket: 0,
+    };
+    let rec = record::build(new_record).expect("valid logs commit record");
+    let data_key = keys::reconstruct_data_key(&rec).expect("logs data key");
+    store
+        .put(&data_key, bytes::Bytes::from(bytes), PutOptions::default())
+        .await
+        .expect("put rlog object");
+    publish::publish(store, &rec, &RetryPolicy::default())
+        .await
+        .expect("publish logs commit record");
+}
+
+/// A logs fixture over `OBJECTS` RLOG objects, with an executor whose
+/// `SqlConfig` is `config` and whose declared column source carries `k`.
+struct Fixture {
+    executor: SqlExecutor,
+    catalog: Arc<Catalog>,
+}
+
+impl Fixture {
+    async fn build(config: SqlConfig) -> Self {
+        let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+        let t = tenant();
+        for object in 0..OBJECTS {
+            publish_object(store.as_ref(), &t, object).await;
+        }
+        let catalog =
+            Arc::new(Catalog::new(Arc::clone(&store), CatalogConfig::default()).expect("catalog"));
+        let executor = SqlExecutor::new(
+            Arc::clone(&catalog),
+            SegmentFetcher::new(Arc::clone(&store)),
+            LogSegmentFetcher::new(Arc::clone(&store)),
+            SpanSegmentFetcher::new(Arc::clone(&store)),
+            config,
+            1 << 30,
+        )
+        .with_declared_column_source(Arc::new(StaticDeclaredColumns::new(declared())));
+        Fixture { executor, catalog }
+    }
+
+    /// A config with the ADR-0094 flag set as given and a fan-out that reaches
+    /// every published object.
+    fn config(parallel_final_aggregation: bool) -> SqlConfig {
+        SqlConfig {
+            engine: EngineConfig {
+                fetch_concurrency: OBJECTS,
+                ..EngineConfig::default()
+            },
+            parallel_final_aggregation,
+            ..SqlConfig::default()
+        }
+    }
+
+    async fn snapshot(&self) -> Snapshot {
+        self.catalog
+            .resolve(
+                &tenant().hash(),
+                Signal::Logs,
+                TimeRange {
+                    start_ns: 0,
+                    end_ns: 1_000_000,
+                },
+                &[],
+                1_000_000,
+            )
+            .await
+            .expect("resolve logs snapshot")
+    }
+
+    /// The indented physical-plan text for `sql`, planned through the real
+    /// `plan_pinned` path (so the classification ran) with `k` declared.
+    async fn physical_plan_text(&self, sql: &str) -> String {
+        let accounting = QueryAccounting::new();
+        let planned = self
+            .executor
+            .plan_pinned(
+                tenant().hash(),
+                self.snapshot().await,
+                sql,
+                &accounting,
+                &declared(),
+            )
+            .await
+            .expect("plan_pinned");
+        let plan = planned
+            .create_physical_plan()
+            .await
+            .expect("physical plan builds");
+        format!("{}", displayable(plan.as_ref()).indent(true))
+    }
+
+    /// The single scalar `COUNT(DISTINCT k)` returns, executed end to end.
+    async fn count_distinct_k(&self) -> i64 {
+        let outcome = self
+            .executor
+            .execute(tenant().hash(), &request(COUNT_DISTINCT_SQL))
+            .await
+            .expect("query executes");
+        let batch = outcome
+            .output
+            .batches()
+            .iter()
+            .find(|b| b.num_rows() == 1)
+            .cloned()
+            .expect("one scalar row");
+        batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("a count aggregate is Int64")
+            .value(0)
+    }
+}
+
+fn request(sql: &str) -> SqlRequest {
+    SqlRequest {
+        sql: sql.to_string(),
+        window: TimeRange {
+            start_ns: 0,
+            end_ns: 1_000_000,
+        },
+        min_tokens: Vec::new(),
+        now_ns: 1_000_000,
+        deadline: Duration::from_secs(30),
+    }
+}
+
+/// The exact-typed statement under test: a single-distinct count over the
+/// declared `Int64` key. DataFusion rewrites it into a `GROUP BY k` under a
+/// scalar count, so the group aggregate below the count is the partial/final
+/// pair ADR-0094 repartitions.
+const COUNT_DISTINCT_SQL: &str = "SELECT COUNT(DISTINCT k) AS d FROM logs";
+
+/// The 0-based line index of the first plan line containing `needle`.
+fn line_of(plan: &str, needle: &str) -> usize {
+    plan.lines()
+        .position(|l| l.contains(needle))
+        .unwrap_or_else(|| panic!("expected a plan line containing {needle:?}; got:\n{plan}"))
+}
+
+#[tokio::test]
+async fn default_session_count_distinct_int_repartitions_final() {
+    // SqlConfig::default() carries the ADR-0094 amendment default (flag on), so
+    // no explicit set here: this is exactly the shape a shipped server plans.
+    let fixture = Fixture::build(Fixture::config(
+        SqlConfig::default().parallel_final_aggregation,
+    ))
+    .await;
+    assert!(
+        SqlConfig::default().parallel_final_aggregation,
+        "the amendment default must be on; this test proves what that default plans"
+    );
+
+    let plan = fixture.physical_plan_text(COUNT_DISTINCT_SQL).await;
+    assert!(
+        plan.contains("AggregateExec: mode=FinalPartitioned"),
+        "an exact-typed COUNT(DISTINCT int) under the default must fan its final \
+         aggregation across partitions (FinalPartitioned); got:\n{plan}"
+    );
+    assert!(
+        plan.contains("RepartitionExec: partitioning=Hash"),
+        "the fanned-out final aggregate must be fed by a hash repartition; got:\n{plan}"
+    );
+    // The FinalPartitioned aggregate sits above the hash repartition that feeds
+    // it (parents print first in an indented plan).
+    assert!(
+        line_of(&plan, "AggregateExec: mode=FinalPartitioned")
+            < line_of(&plan, "RepartitionExec: partitioning=Hash"),
+        "FinalPartitioned must sit above the Hash repartition that feeds it; got:\n{plan}"
+    );
+}
+
+#[tokio::test]
+async fn opt_out_count_distinct_int_stays_single_partition() {
+    let fixture = Fixture::build(Fixture::config(false)).await;
+    let plan = fixture.physical_plan_text(COUNT_DISTINCT_SQL).await;
+
+    // The opt-out restores the single-partition final: the group aggregate is
+    // gathered under CoalescePartitionsExec, not repartitioned.
+    assert!(
+        !plan.contains("AggregateExec: mode=FinalPartitioned"),
+        "the opt-out must not fan the final aggregation out; got:\n{plan}"
+    );
+    assert!(
+        !plan.contains("RepartitionExec: partitioning=Hash"),
+        "the opt-out must not insert a hash repartition for the aggregate; got:\n{plan}"
+    );
+    assert!(
+        plan.contains("AggregateExec: mode=Final,"),
+        "the opt-out keeps a single-partition Final aggregate; got:\n{plan}"
+    );
+    assert!(
+        line_of(&plan, "AggregateExec: mode=Final,") < line_of(&plan, "CoalescePartitionsExec"),
+        "the single-partition Final aggregate must sit above the CoalescePartitionsExec \
+         that gathers its input; got:\n{plan}"
+    );
+}
+
+#[tokio::test]
+async fn avg_stays_single_partition_under_default() {
+    // avg resolves to Float64 (a float accumulator), so it is not exact-typed
+    // and must keep the single-partition final even though the default is on.
+    let fixture = Fixture::build(Fixture::config(
+        SqlConfig::default().parallel_final_aggregation,
+    ))
+    .await;
+    let plan = fixture
+        .physical_plan_text("SELECT avg(k) AS a FROM logs")
+        .await;
+
+    assert!(
+        !plan.contains("AggregateExec: mode=FinalPartitioned"),
+        "a float avg must never fan its final aggregation out, default or not; got:\n{plan}"
+    );
+    assert!(
+        !plan.contains("RepartitionExec: partitioning=Hash"),
+        "a float avg must never get a hash repartition, default or not; got:\n{plan}"
+    );
+    assert!(
+        plan.contains("AggregateExec: mode=Final,"),
+        "the non-exact avg keeps the single-partition Final aggregate; got:\n{plan}"
+    );
+}
+
+#[tokio::test]
+async fn both_plan_shapes_agree_on_the_count() {
+    let on = Fixture::build(Fixture::config(true)).await;
+    let off = Fixture::build(Fixture::config(false)).await;
+
+    let on_count = on.count_distinct_k().await;
+    let off_count = off.count_distinct_k().await;
+
+    assert_eq!(
+        on_count, DISTINCT_K,
+        "the repartitioned final must count every distinct key value"
+    );
+    assert_eq!(
+        on_count, off_count,
+        "the repartitioned and single-partition plans must return the identical count"
+    );
+}

--- a/docs/adrs/0094-parallel-final-aggregation-exact-typed.md
+++ b/docs/adrs/0094-parallel-final-aggregation-exact-typed.md
@@ -608,3 +608,65 @@ flowchart TD
     REPART --> EXEC["real session, plan, execute"]
     SINGLE --> EXEC
 ```
+
+## Amendment 2026-08-26 (issue #741): default flips to `true`
+
+Status: Accepted (amends decision 4's default; the classification of
+decision 1 and the determinism argument of decision 3 are unchanged).
+
+The original decision shipped `parallel_final_aggregation` defaulting to
+`false`, on the strength of the earlier synthetic-load measurement, which
+found parallel not robustly faster than serial at any partition count.
+This amendment flips the default to `true` for the exact-typed class only.
+The classification gate is untouched: a non-exact-typed plan still gets the
+single-partition final byte for byte, and nothing here changes which plans
+are eligible.
+
+**Evidence.** Measured on the 8,424-object ClickBench tenant (issue #680)
+at 32 scan partitions with an 8 GiB per-query memory pool:
+
+- With the flag **off**, every high-cardinality `GROUP BY` /
+  `COUNT(DISTINCT)` statement runs its `Final` aggregate in a single
+  partition under `CoalescePartitionsExec`. That serial final exhausted
+  the 8 GiB pool: **nine statements failed** outright with a pool-exhausted
+  error (not merely slow — refused, because spilling is disabled by design,
+  ADR-0013/ADR-0102 decision 3).
+- With the flag **on**, `COUNT(DISTINCT UserID)` completes in **44–50 s**,
+  and four more previously-failing statements complete at **47–50 s** — the
+  same figure as a plain full scan, i.e. the aggregate stops being the
+  bottleneck. The read-only trace found **no determinism cost** for the
+  exact-typed class: the partition of the group set cannot change any
+  aggregated value (`count`, `count distinct`, and integer `sum`/`min`/`max`
+  are all partition-order-independent), and output order without an explicit
+  `ORDER BY` was already unguaranteed (see `docs/query-engine.md`), so the
+  repartitioned merge order changes nothing a client was entitled to rely
+  on. Decision 3's caveat — that the hash exchange carries every forwarded
+  row when the #728 probe fires — held only as a *slower*, never a
+  *failing*, path.
+
+The measurement therefore inverts decision 4's default-follows-measurement
+conclusion for the exact-typed class: the serial final is not merely slower
+at scale, it fails queries that the parallel final completes, and it does so
+with no correctness or determinism cost for that class.
+
+**Opt-out.** The behavior remains a single process-wide switch with no
+live-reload. `SqlConfig::parallel_final_aggregation` now defaults to `true`;
+the server flag `--sql-parallel-final-aggregation` stays accepted and still
+means on, and `--sql-parallel-final-aggregation=false` is the operator
+opt-out (a clap bool value parser: `num_args = 0..=1`, `default_value_t =
+true`, `default_missing_value = "true"`, `action = Set`). Setting it to
+`false` restores the exact pre-amendment single-partition final for every
+query. The bench (`sql_latency_bench`) carries the same shape and its
+report's provenance records the effective value.
+
+**Still excluded (unchanged).** `avg`/`mean` over any input type remain
+never eligible (their fold is IEEE f64 addition, not associative past
+2^53), as does any `sum`/`min`/`max` over a float input and any float
+`GROUP BY` key (including a bare `SELECT DISTINCT float_col`). A single
+disqualifying aggregate or key anywhere in the query — including inside a
+scalar/`IN`/`EXISTS` subquery — still forces the whole query onto the
+single-partition plan. This amendment changes only the default of the gate,
+not the gate. It also does not touch the *string-keyed partial* stage that
+exhausts the pool for a different reason (`partitions x distinct` pre-final
+state); that is issue #680's separate `skip_partial_aggregation` fix, which
+was already on by default.

--- a/docs/guides/clickbench.md
+++ b/docs/guides/clickbench.md
@@ -301,8 +301,13 @@ cargo run -p ravel-bench --features sql-latency --bin sql_latency_bench -- \
   heavy aggregate needs both raised together. Default 1 GiB, what every earlier
   run used.
 - `--sql-parallel-final-aggregation` lets an exact-typed query repartition its
-  final aggregation (ADR-0094), the same knob as the server flag of that name.
-  Off by default; a `GROUP BY` over a high-cardinality key is where it shows.
+  final aggregation (ADR-0094, amended by issue #741), the same knob as the
+  server flag of that name. On by default; a `GROUP BY` or `COUNT(DISTINCT)`
+  over a high-cardinality key is where it shows (the amendment measured nine
+  such statements moving from pool-exhausted failures to 44-50 s here). Pass
+  `--sql-parallel-final-aggregation=false` to measure the pre-amendment
+  single-partition final; the bare flag stays accepted and still means on. The
+  effective value is recorded in the report's provenance.
 - `--sql-max-segments <N>` is the engine's `max_segments` ceiling, the same knob
   as `ravel-server --max-segments`: the number of sealed, below-watermark
   segments a statement may fan out over before it is refused with `query fans

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -1739,19 +1739,24 @@ to union, so a `trace_id` disjunction is refused too.
 
 ## Parallel final aggregation for exact-typed queries (ADR-0094)
 
-Every SQL query plans its aggregation single-partitioned by default: DataFusion's
-`repartition_aggregations` knob is off, so a `Partial` `AggregateExec` runs per
-scan partition, a `CoalescePartitionsExec` collapses them into one stream, and a
-single serial `Final` `AggregateExec` produces the result. This keeps float
-aggregation bit-exact against the differential gate (ADR-0013), whose reference
-depends on a deterministic fold order.
+A query whose aggregation is provably order- and partition-independent
+(exact-typed) fans its `Final` stage across partitions behind a
+hash-partitioning `RepartitionExec`; every other query plans single-partitioned:
+DataFusion's `repartition_aggregations` knob stays off, so a `Partial`
+`AggregateExec` runs per scan partition, a `CoalescePartitionsExec` collapses
+them into one stream, and a single serial `Final` `AggregateExec` produces the
+result. The single-partition plan keeps float aggregation bit-exact against the
+differential gate (ADR-0013), whose reference depends on a deterministic fold
+order.
 
-`--sql-parallel-final-aggregation` (the process-wide `SqlConfig`
-`parallel_final_aggregation`, default off; no live-reload, flipping it needs a
-restart) lets a query whose aggregation is provably order- and
-partition-independent instead fan its `Final` stage across partitions behind a
-hash-partitioning `RepartitionExec`. Admission is per-query and decided from the
-query's fully type-coerced (analyzed) plan:
+This behavior is on by default (`SqlConfig::parallel_final_aggregation`, amended
+to `true` on 2026-08-26 by issue #741; see the ADR-0094 amendment for the
+ClickBench measurement that motivated it). It is process-wide with no
+live-reload, so flipping it needs a restart, and
+`--sql-parallel-final-aggregation=false` is the operator opt-out that restores
+the pre-amendment single-partition final for every query (the bare
+`--sql-parallel-final-aggregation` stays accepted and still means on). Admission
+is per-query and decided from the query's fully type-coerced (analyzed) plan:
 
 - **Eligible:** `count(...)` and `count(DISTINCT ...)` over any type; `sum`,
   `min`, `max` over a resolved **non-float** input.
@@ -1768,7 +1773,7 @@ a scalar/`IN`/`EXISTS` subquery -- forces the whole query onto the
 single-partition plan: `repartition_aggregations` is one session-wide switch, not
 a per-node choice. Any error building or analyzing the classification plan
 fails closed to the single-partition plan (a missed optimization, never a wrong
-result). With the flag off, no classification runs and every query is
+result). With the opt-out set, no classification runs and every query is
 single-partition, byte-identical to before this feature existed.
 
 Row order is unaffected. A `GROUP BY` without an explicit `ORDER BY` has **no

--- a/services/ravel-server/src/config.rs
+++ b/services/ravel-server/src/config.rs
@@ -487,17 +487,26 @@ pub struct Cli {
     pub sql_tenant_max_bytes: usize,
 
     /// Allow an exact-typed SQL query to repartition its final aggregation
-    /// (ADR-0094), threaded into `ravel_sql::SqlConfig::parallel_final_aggregation`.
-    /// Off by default: a process with this unset plans every aggregation
-    /// single-partitioned, byte-identical to before this flag existed. When set,
-    /// a per-query classification flips DataFusion's `repartition_aggregations`
-    /// on only for a query whose aggregates and GROUP BY keys are all provably
-    /// order/partition-independent (`count`, and `sum`/`min`/`max` over non-float
-    /// input, no float group key); `avg`/`mean` and any float input or key are
-    /// never eligible and stay single-partitioned. Process-wide, not per-tenant;
-    /// flipping it needs a restart, like every other SQL budget. Meaningful only
-    /// in a build with the `sql` feature; inert otherwise.
-    #[arg(long = "sql-parallel-final-aggregation")]
+    /// (ADR-0094, amended 2026-08-26 by issue #741), threaded into
+    /// `ravel_sql::SqlConfig::parallel_final_aggregation`. On by default: a
+    /// per-query classification flips DataFusion's `repartition_aggregations`
+    /// on for a query whose aggregates and GROUP BY keys are all provably
+    /// order/partition-independent (`count`, `count distinct`, and
+    /// `sum`/`min`/`max` over non-float input, no float group key);
+    /// `avg`/`mean` and any float input or key are never eligible and stay
+    /// single-partitioned. Pass `--sql-parallel-final-aggregation=false` (or the
+    /// bare `--sql-parallel-final-aggregation`, which stays accepted and still
+    /// means on) to control it; `false` is the operator opt-out that restores
+    /// the pre-amendment single-partition final for every query. Process-wide,
+    /// not per-tenant; flipping it needs a restart, like every other SQL budget.
+    /// Meaningful only in a build with the `sql` feature; inert otherwise.
+    #[arg(
+        long = "sql-parallel-final-aggregation",
+        num_args = 0..=1,
+        default_value_t = true,
+        default_missing_value = "true",
+        action = clap::ArgAction::Set,
+    )]
     pub sql_parallel_final_aggregation: bool,
 
     /// Object size above which a logs scan reads only the pruning-relevant
@@ -1012,8 +1021,10 @@ pub struct QueryBudgets {
     /// accountant (`max_tenant_bytes`).
     pub sql_tenant_max_bytes: usize,
     /// Whether an exact-typed SQL query may repartition its final aggregation
-    /// (ADR-0094). Reaches `SqlConfig::parallel_final_aggregation`. Default
-    /// `false`, so a server built without the flag is byte-identical to before.
+    /// (ADR-0094, amended by issue #741). Reaches
+    /// `SqlConfig::parallel_final_aggregation`. Default `true`; the
+    /// `--sql-parallel-final-aggregation=false` opt-out restores the
+    /// single-partition final.
     pub sql_parallel_final_aggregation: bool,
     /// Object size above which a logs scan reads only the pruning-relevant RLOG
     /// blocks instead of the whole object (ADR-0107). Reaches
@@ -1029,7 +1040,7 @@ impl Default for QueryBudgets {
             max_segments: ravel_query::DEFAULT_MAX_SEGMENTS,
             sql_max_query_bytes: DEFAULT_SQL_MAX_QUERY_BYTES,
             sql_tenant_max_bytes: DEFAULT_SQL_TENANT_MAX_BYTES,
-            sql_parallel_final_aggregation: false,
+            sql_parallel_final_aggregation: true,
             logs_block_range_threshold: DEFAULT_LOGS_BLOCK_RANGE_THRESHOLD,
         }
     }
@@ -3815,8 +3826,8 @@ mod tests {
         assert_eq!(budgets.sql_max_query_bytes, DEFAULT_SQL_MAX_QUERY_BYTES);
         assert_eq!(budgets.sql_tenant_max_bytes, DEFAULT_SQL_TENANT_MAX_BYTES);
         assert!(
-            !budgets.sql_parallel_final_aggregation,
-            "ADR-0094: exact-typed final-aggregation repartitioning defaults off"
+            budgets.sql_parallel_final_aggregation,
+            "ADR-0094 amendment (#741): exact-typed final-aggregation repartitioning defaults on"
         );
         // The two EngineConfig-bound defaults leave a base config untouched.
         assert_eq!(

--- a/services/ravel-server/src/lib.rs
+++ b/services/ravel-server/src/lib.rs
@@ -1298,9 +1298,10 @@ pub async fn start(
                 // 256 MiB and the compiled-in 1 GiB tenant ceiling.
                 config.query_budgets.sql_max_query_bytes,
                 config.query_budgets.sql_tenant_max_bytes,
-                // ADR-0094: the exact-typed final-aggregation repartition switch,
-                // from `--sql-parallel-final-aggregation`. Default-off, so an
-                // unset flag leaves every SQL query single-partitioned.
+                // ADR-0094 (amended by #741): the exact-typed final-aggregation
+                // repartition switch, from `--sql-parallel-final-aggregation`.
+                // Default-on; the `=false` opt-out leaves every SQL query
+                // single-partitioned.
                 config.query_budgets.sql_parallel_final_aggregation,
                 query_accounting.clone(),
                 query_admission.clone(),

--- a/services/ravel-server/src/query.rs
+++ b/services/ravel-server/src/query.rs
@@ -241,11 +241,11 @@ pub const DEFAULT_MAX_QUERY_BYTES: usize = ravel_sql::DEFAULT_MAX_QUERY_BYTES;
 /// operator's override the value the executor's pool and per-tenant accountant
 /// actually enforce.
 ///
-/// `parallel_final_aggregation` (ADR-0094 decision 4) is the process-wide
-/// switch, from `--sql-parallel-final-aggregation`, that lets an exact-typed
-/// query repartition its final aggregation. Default `false`; threaded here so an
-/// operator's opt-in is the value the executor's classification gate actually
-/// reads rather than `SqlConfig::default()`'s off.
+/// `parallel_final_aggregation` (ADR-0094 decision 4, amended by issue #741) is
+/// the process-wide switch, from `--sql-parallel-final-aggregation`, that lets
+/// an exact-typed query repartition its final aggregation. Default `true`;
+/// threaded here so an operator's `=false` opt-out is the value the executor's
+/// classification gate actually reads rather than `SqlConfig::default()`'s on.
 ///
 /// `declared_columns` is the source of each tenant's declared typed attribute
 /// columns (ADR-0090 decision 2), installed on the executor with
@@ -278,9 +278,9 @@ pub fn build_sql_state(
     let config = SqlConfig {
         engine: engine_config,
         max_query_bytes,
-        // ADR-0094: the process-wide exact-typed repartition switch, from
-        // `--sql-parallel-final-aggregation`. Default-off leaves every query
-        // single-partitioned exactly as before.
+        // ADR-0094 (amended by #741): the process-wide exact-typed repartition
+        // switch, from `--sql-parallel-final-aggregation`. Default-on; the
+        // `=false` opt-out leaves every query single-partitioned.
         parallel_final_aggregation,
         // Issue #680 / ADR-0102 decision 2's amendment: the shipped default,
         // with no flag. Nothing an operator sets should be able to reintroduce
@@ -660,21 +660,30 @@ mod tests {
     /// ADR-0094 reachability: `--sql-parallel-final-aggregation` must reach the
     /// `SqlConfig::parallel_final_aggregation` the executor's classification
     /// gate reads, not stop at a parsed field. Traced from the CLI through
-    /// `query_budgets()` and `build_sql_state` to `executor.config()`. Default
-    /// unset stays `false`, so the shipped posture is single-partition.
+    /// `query_budgets()` and `build_sql_state` to `executor.config()`. Under the
+    /// #741 amendment the default is on, and the `=false` opt-out reaches the
+    /// executor as `false`.
     #[test]
     fn sql_parallel_final_aggregation_is_reachable_from_cli() {
+        // Bare flag: still accepted, still means on.
         let state = sql_state_from_cli(&["ravel-server", "--sql-parallel-final-aggregation"]);
         assert!(
             state.executor.config().parallel_final_aggregation,
-            "the SQL executor must carry the configured flag, not the default false"
+            "the bare flag must carry the executor to on"
         );
 
-        // Unset: the default-off posture, single-partition for every query.
-        let state = sql_state_from_cli(&["ravel-server"]);
+        // The opt-out reaches the executor as false.
+        let state = sql_state_from_cli(&["ravel-server", "--sql-parallel-final-aggregation=false"]);
         assert!(
             !state.executor.config().parallel_final_aggregation,
-            "default must stay off (ADR-0094 decision 4)"
+            "the =false opt-out must reach the executor as single-partition"
+        );
+
+        // Unset: the amended default-on posture (issue #741).
+        let state = sql_state_from_cli(&["ravel-server"]);
+        assert!(
+            state.executor.config().parallel_final_aggregation,
+            "default must be on (ADR-0094 amendment, issue #741)"
         );
     }
 


### PR DESCRIPTION
ADR-0094 shipped parallel_final_aggregation off by default: exact-typed
logs GROUP BY plans ran Partial(32) -> CoalescePartitionsExec -> Final in
one partition, so every ClickBench GROUP BY statement that spilled did so
in the single Final partition regardless of the pool size (v14/v15 on
#680: q05/q06/q09/q14/q36 exhausted 8 GiB). v17 measured the same five
statements with the flag on at 47-50 s each, fitting in the same pool.

The default flips to true. The flag stays, as a clap bool value parser on
both the server (--sql-parallel-final-aggregation[=true|false]) and
sql_latency_bench: unset and the bare flag mean on, =false opts out. The
classification is unchanged: only exact-typed keys repartition; avg and
string-keyed plans keep the single-partition Final, which ADR-0094's
amendment records with the measurements and the explicit exclusions.

Tests: crates/ravel-sql/tests/parallel_final_default.rs pins the default
session's plan text (FinalPartitioned above a hash RepartitionExec), the
=false opt-out (mode=Final above CoalescePartitionsExec), avg staying
single-partition under the new default, and identical counts on both
shapes. The server and bench reachability tests now assert the on
default and the =false arm; the config default tests flipped with it.
Docs: ADR-0094 amendment, docs/query-engine.md aggregation section,
server and bench flag docs, docs/guides/clickbench.md.

Fixes: #741
Refs: #680
