### PR TITLE
feat(ravel-sql): report ts and has_word filters as Exact pushdown

### DIFF
--- a/crates/ravel-sql/src/logs_provider.rs
+++ b/crates/ravel-sql/src/logs_provider.rs
@@ -9,9 +9,11 @@
 //! [`LogSegmentFetcher::ts_range_relevant`] against the extracted ts bounds,
 //! and builds a single [`LogsScanExec`] leaf.
 //!
-//! `supports_filters_pushdown` returns `Inexact` for every filter, exactly like
-//! the metrics provider: DataFusion always re-applies the originals above the
-//! scan, so pruning may only widen. An attribute predicate (`attrs['k']='v'`) is
+//! `supports_filters_pushdown` returns `Inexact` for every filter except one
+//! that resolves purely to a `ts` bound and/or a `has_word` call, which the
+//! reader re-verifies per row and so answers `Exact` (issue #733). Everything
+//! else DataFusion re-applies above the scan, so pruning may only widen. An
+//! attribute predicate (`attrs['k']='v'`) is
 //! pushed only into the prune-only channel ([`LogsPushdown::prune`]), which
 //! drives POSTINGS block pruning inside the reader and is never evaluated per
 //! row: a stream-level or per-record prune used as a filter would be unsound
@@ -48,7 +50,7 @@ use crate::distributed::{WorkerSlice, WorkerSliceClient};
 use crate::distributed_rlog::{
     DistributedRlogContext, LOGS_ORDER_COLS, distributed_logs_plan, sort_slice_fragment,
 };
-use crate::logs_pushdown::{LogsPushdown, extract_logs};
+use crate::logs_pushdown::{LogsPushdown, extract_logs, filter_is_exact};
 use crate::logs_scan::LogsScanExec;
 use crate::logs_schema::{logs_schema, logs_schema_with_declared};
 
@@ -265,14 +267,55 @@ impl TableProvider for LogsTableProvider {
         TableType::Base
     }
 
-    /// Inexact for every filter: the provider prunes what it can (widen-only),
-    /// but DataFusion must always re-apply the original filters above the scan.
-    /// Never `Exact` (carried over from the metrics provider).
+    /// `Exact` for a filter that resolves purely to a `ts` bound and/or a
+    /// `has_word` content predicate; `Inexact` for everything else (issue #733).
+    ///
+    /// The split follows which reader channel the extracted predicate lands in
+    /// ([`crate::logs_pushdown`]):
+    ///
+    /// - `ts` bounds and `has_word` arms go to the exact channel
+    ///   ([`LogsPushdown::ts_lo`]/[`LogsPushdown::ts_hi`],
+    ///   [`LogsPushdown::content`]), which `ravel_query`'s `combined_predicate`
+    ///   folds into the single `Predicate` the reader re-verifies per decoded
+    ///   row: `ravel_logseg::reader`'s `eval` reads that row's own `ts` for
+    ///   `Predicate::TsRange` and that row's own field text for
+    ///   `Predicate::HasWord`. Nothing survives for a residual to re-check, so
+    ///   the filter can be deleted from the plan. Deleting it is what lets
+    ///   `LogsScanExec`'s exact leaf statistics reach DataFusion's
+    ///   `AggregateStatistics` rule: a `FilterExec` above the scan would report
+    ///   its own non-exact statistics instead of passing the leaf's through.
+    /// - Everything else -- an `attrs['k'] = 'v'` equality, every declared typed
+    ///   column predicate (ADR-0093) -- goes to the prune-only
+    ///   [`LogsPushdown::prune`] channel. `open_scan` passes that channel
+    ///   separately from the exact predicate and the reader uses it for block
+    ///   pruning ONLY, never per row, so DataFusion's residual stays the sole
+    ///   exact evaluator and the filter must stay `Inexact`.
+    ///
+    /// A filter the extractor recognizes only in part (a `ts` bound AND-ed with
+    /// an unrecognized sub-expression in one unsplit `Expr`) is `Inexact`, not
+    /// partially credited, and so is one it recognizes nothing in.
     fn supports_filters_pushdown(
         &self,
         filters: &[&Expr],
     ) -> DFResult<Vec<TableProviderFilterPushDown>> {
-        Ok(vec![TableProviderFilterPushDown::Inexact; filters.len()])
+        // The distributed coordinator path fans out to workers without pushing
+        // any filter (see `scan` below), so every filter it plans MUST come back
+        // as a residual above the fan-out. Reporting `Exact` there would delete
+        // a predicate nothing re-applies.
+        #[cfg(feature = "flight-sql")]
+        if self.distributed.is_some() {
+            return Ok(vec![TableProviderFilterPushDown::Inexact; filters.len()]);
+        }
+        Ok(filters
+            .iter()
+            .map(|f| {
+                if filter_is_exact(f, self.declared.as_ref()) {
+                    TableProviderFilterPushDown::Exact
+                } else {
+                    TableProviderFilterPushDown::Inexact
+                }
+            })
+            .collect())
     }
 
     async fn scan(
@@ -286,9 +329,11 @@ impl TableProvider for LogsTableProvider {
         // instead of scanning locally. The scan's `_limit` is honored as a
         // fetch-stop hint across the distributed partitions, with the exact limit
         // re-applied above the merge (over-fetch is safe, under-fetch is not).
-        // Filters are re-applied above the returned plan by DataFusion (the
-        // provider reports `Inexact`), so not pushing them to workers only widens
-        // each worker's read, never changes a row. The `logs` provider carries no
+        // Filters are re-applied above the returned plan by DataFusion (with a
+        // coordinator installed, `supports_filters_pushdown` reports `Inexact`
+        // for every filter for exactly this reason), so not pushing them to
+        // workers only widens each worker's read, never changes a row. The
+        // `logs` provider carries no
         // per-query byte budget (admission is decided at resolve time), so the
         // fan-out folds bytes into the query accounting under an `Unlimited`
         // ceiling, matching the local path.
@@ -314,11 +359,13 @@ impl TableProvider for LogsTableProvider {
         // dropped columns the scan had already paid to decode and materialize.
         //
         // The projection DataFusion hands us already contains every column its
-        // residual `FilterExec` above this scan will read: pushdown is
-        // `Inexact`, so the optimizer keeps the filters' columns in the scan's
-        // projection. `LogsScanExec` separately adds the columns its own pushed
-        // content predicates and pending erasure predicates need, which are not
-        // visible in the projection at all.
+        // residual `FilterExec` above this scan will read: an `Inexact` filter
+        // survives above the scan, so the optimizer keeps its columns in the
+        // scan's projection. An `Exact` one does not survive and its columns may
+        // well be projected out, which is safe because `LogsScanExec` separately
+        // adds the columns its own pushed content predicates and pending erasure
+        // predicates need (`logs_scan::resolve_columns`); those are not visible
+        // in the projection at all.
         self.build_scan(target_partitions, &pushdown, projection)
     }
 }
@@ -1695,6 +1742,217 @@ mod tests {
         assert!(
             extract_logs(&cast_filters, &declared).prune.is_empty(),
             "a Cast-wrapped comparison must produce no prune arm"
+        );
+    }
+
+    // --- exact filter pushdown (issue #733) ----------------------------------
+
+    /// A provider over an empty snapshot: `supports_filters_pushdown` is a pure
+    /// function of the filter and the declared vocabulary, so it needs no data
+    /// and issues no I/O.
+    fn pushdown_provider(declared: Vec<DeclaredColumn>) -> LogsTableProvider {
+        let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+        LogsTableProvider::new(
+            Snapshot {
+                segments: Vec::new(),
+                segments_pruned: 0,
+                pending_erasure: Vec::new(),
+            },
+            TenantHash([7u8; 16]),
+            LogSegmentFetcher::new(store),
+            QueryAccounting::new(),
+        )
+        .with_declared_columns(declared)
+    }
+
+    fn pushdown_for(provider: &LogsTableProvider, filter: &Expr) -> TableProviderFilterPushDown {
+        let mut v = provider
+            .supports_filters_pushdown(&[filter])
+            .expect("supports_filters_pushdown");
+        assert_eq!(v.len(), 1, "one verdict per filter");
+        v.remove(0)
+    }
+
+    fn ts_lit(v: i64) -> Expr {
+        datafusion::prelude::lit(datafusion::scalar::ScalarValue::TimestampNanosecond(
+            Some(v),
+            None,
+        ))
+    }
+
+    /// Every filter that resolves purely to a `ts` bound and/or a `has_word`
+    /// call is `Exact`: both land in the channel `ravel_logseg::reader`'s `eval`
+    /// re-verifies against the row's own value, so nothing is left for a
+    /// residual.
+    #[test]
+    fn pure_ts_bound_and_has_word_filters_are_exact() {
+        use datafusion::prelude::{col, lit};
+
+        use crate::logs_udf::has_word_udf;
+
+        let p = pushdown_provider(Vec::new());
+        let between = Expr::Between(datafusion::logical_expr::Between {
+            expr: Box::new(col("ts")),
+            negated: false,
+            low: Box::new(ts_lit(100)),
+            high: Box::new(ts_lit(200)),
+        });
+        let cases = [
+            col("ts").gt_eq(ts_lit(100)),
+            col("ts").lt(ts_lit(200)),
+            col("ts").eq(ts_lit(150)),
+            // A flipped operand order is the same bound.
+            ts_lit(100).lt_eq(col("ts")),
+            between,
+            // Two ts bounds AND-ed inside ONE unsplit filter expression.
+            col("ts")
+                .gt_eq(ts_lit(100))
+                .and(col("ts").lt_eq(ts_lit(200))),
+            has_word_udf().call(vec![col("body"), lit("timeout")]),
+            has_word_udf().call(vec![col("severity_text"), lit("error")]),
+            // A ts bound AND a content predicate together, unsplit.
+            col("ts")
+                .gt_eq(ts_lit(100))
+                .and(has_word_udf().call(vec![col("body"), lit("timeout")])),
+        ];
+        for filter in cases {
+            assert_eq!(
+                pushdown_for(&p, &filter),
+                TableProviderFilterPushDown::Exact,
+                "must be Exact: {filter:?}"
+            );
+        }
+    }
+
+    /// Everything the extractor routes to the prune-only channel stays
+    /// `Inexact`: the reader uses a prune arm for block pruning only and never
+    /// evaluates it per row, so DataFusion's residual is the sole exact
+    /// evaluator. An `attrs['k'] = 'v'` map equality and a declared typed column
+    /// predicate (ADR-0093) are both in that channel.
+    #[test]
+    fn prune_channel_filters_stay_inexact() {
+        use datafusion::functions::core::expr_fn::get_field;
+        use datafusion::prelude::{col, lit};
+
+        let p = pushdown_provider(i64_status_code());
+        let cases = [
+            get_field(col("attrs"), "service.name").eq(lit("api")),
+            col("status_code").eq(lit(500i64)),
+            col("status_code").gt(lit(500i64)),
+            col("status_code").in_list(vec![lit(200i64), lit(404i64)], false),
+        ];
+        for filter in cases {
+            assert_eq!(
+                pushdown_for(&p, &filter),
+                TableProviderFilterPushDown::Inexact,
+                "a prune-channel filter must stay Inexact: {filter:?}"
+            );
+        }
+    }
+
+    /// A filter the extractor recognizes only in part is `Inexact`, never
+    /// partially credited. Reporting `Exact` deletes the WHOLE filter from the
+    /// plan, so a `ts` bound AND-ed with anything not itself exactly verified
+    /// would silently drop that other conjunct's rows.
+    ///
+    /// DataFusion normally splits top-level `AND`s into separate filters before
+    /// pushdown, so these compound shapes are a fail-closed guard rather than a
+    /// shape seen every day.
+    #[test]
+    fn partially_recognized_compound_filters_are_inexact() {
+        use datafusion::functions::core::expr_fn::get_field;
+        use datafusion::prelude::{col, lit};
+
+        let p = pushdown_provider(i64_status_code());
+        let like = Expr::Like(datafusion::logical_expr::Like {
+            negated: false,
+            expr: Box::new(col("body")),
+            pattern: Box::new(lit("%time%")),
+            escape_char: None,
+            case_insensitive: false,
+        });
+        let cases = [
+            // A ts bound AND an attrs-map equality: the equality is prune-only.
+            col("ts")
+                .gt_eq(ts_lit(100))
+                .and(get_field(col("attrs"), "k").eq(lit("v"))),
+            // A ts bound AND a declared-column predicate: likewise prune-only.
+            col("ts")
+                .gt_eq(ts_lit(100))
+                .and(col("status_code").eq(lit(500i64))),
+            // A ts bound AND a shape the extractor recognizes in NEITHER
+            // channel: `LIKE` is deliberately never pushed (soundness, see
+            // crate::logs_pushdown), so the residual must keep it.
+            col("ts").gt_eq(ts_lit(100)).and(like),
+        ];
+        for filter in cases {
+            assert_eq!(
+                pushdown_for(&p, &filter),
+                TableProviderFilterPushDown::Inexact,
+                "a partially recognized filter must be Inexact: {filter:?}"
+            );
+        }
+    }
+
+    /// An expression the extractor recognizes nothing in keeps the unchanged
+    /// `Inexact` default. It must never fall through to `Exact`.
+    #[test]
+    fn unrecognized_filters_stay_inexact() {
+        use datafusion::prelude::{col, lit};
+
+        use crate::logs_udf::has_word_udf;
+
+        let p = pushdown_provider(Vec::new());
+        let negated_between = Expr::Between(datafusion::logical_expr::Between {
+            expr: Box::new(col("ts")),
+            negated: true,
+            low: Box::new(ts_lit(100)),
+            high: Box::new(ts_lit(200)),
+        });
+        let cases = [
+            // Not in the ts comparison allowlist.
+            col("ts").not_eq(ts_lit(100)),
+            Expr::Not(Box::new(col("ts").gt_eq(ts_lit(100)))),
+            negated_between,
+            // An integer literal is an ambiguous ts scale and is rejected.
+            col("ts").gt_eq(lit(100i64)),
+            // `has_word` over a column with no field selector.
+            has_word_udf().call(vec![col("attrs"), lit("timeout")]),
+            // A fixed column with no extraction path at all.
+            col("severity_num").eq(lit(5i64)),
+            // A disjunction of two ts bounds is not one range.
+            datafusion::logical_expr::or(col("ts").gt_eq(ts_lit(100)), col("ts").lt(ts_lit(10))),
+        ];
+        for filter in cases {
+            assert_eq!(
+                pushdown_for(&p, &filter),
+                TableProviderFilterPushDown::Inexact,
+                "an unrecognized filter must stay Inexact: {filter:?}"
+            );
+        }
+    }
+
+    /// The verdicts line up with the filters positionally, so a mixed set is
+    /// reported per filter rather than collapsed to one answer.
+    #[test]
+    fn verdicts_are_reported_per_filter_in_order() {
+        use datafusion::functions::core::expr_fn::get_field;
+        use datafusion::prelude::{col, lit};
+
+        let p = pushdown_provider(Vec::new());
+        let ts = col("ts").gt_eq(ts_lit(100));
+        let attrs = get_field(col("attrs"), "k").eq(lit("v"));
+        let hi = col("ts").lt_eq(ts_lit(200));
+        let verdicts = p
+            .supports_filters_pushdown(&[&ts, &attrs, &hi])
+            .expect("supports_filters_pushdown");
+        assert_eq!(
+            verdicts,
+            vec![
+                TableProviderFilterPushDown::Exact,
+                TableProviderFilterPushDown::Inexact,
+                TableProviderFilterPushDown::Exact,
+            ]
         );
     }
 }

--- a/crates/ravel-sql/src/logs_pushdown.rs
+++ b/crates/ravel-sql/src/logs_pushdown.rs
@@ -2,9 +2,10 @@
 //! invariant the metrics pushdown obeys (crate::pushdown): pruning may only
 //! ever *widen* the read set relative to the query's true need, never narrow
 //! it. `LogsTableProvider::supports_filters_pushdown` returns `Inexact` for
-//! every filter, so DataFusion always re-applies the originals above the scan;
-//! exactness comes from that residual plus the scan re-applying nothing
-//! destructive.
+//! every filter except one it can prove the reader re-verifies per row
+//! ([`filter_is_exact`]: a pure `ts` bound and/or `has_word` call), so
+//! DataFusion re-applies every other original above the scan; exactness comes
+//! from that residual plus the scan re-applying nothing destructive.
 //!
 //! Recognized shapes (everything else contributes nothing and widens):
 //!
@@ -184,6 +185,62 @@ pub fn extract_logs(filters: &[Expr], declared: &[DeclaredColumn]) -> LogsPushdo
         walk_conjunct(f, &mut out, declared);
     }
     out
+}
+
+/// Whether `filter` is captured EXACTLY by the ts and content channels, with
+/// nothing left over for a residual to evaluate.
+///
+/// [`crate::logs_provider::LogsTableProvider::supports_filters_pushdown`]
+/// reports `TableProviderFilterPushDown::Exact` for exactly the filters this
+/// answers `true` for, which deletes them from the plan. So it fails closed:
+/// every conjunct of `filter` must be a shape whose pushed predicate is
+/// *equivalent* to it, not merely implied by it.
+///
+/// Two shapes qualify, and only because the reader re-verifies both per row
+/// (`ravel_logseg::reader`'s `eval`, its `Predicate::TsRange` and
+/// `Predicate::HasWord` arms both read the row's own value): a `ts` bound and a
+/// `has_word(col, 'literal')` call. Everything routed to the prune-only
+/// [`LogsPushdown::prune`] channel, and everything not recognized at all,
+/// answers `false`.
+pub fn filter_is_exact(filter: &Expr, declared: &[DeclaredColumn]) -> bool {
+    if let Expr::BinaryExpr(BinaryExpr { left, op, right }) = filter
+        && *op == Operator::And
+    {
+        return filter_is_exact(left, declared) && filter_is_exact(right, declared);
+    }
+    leaf_is_exact(filter, declared)
+}
+
+/// [`filter_is_exact`] for one non-`AND` conjunct. The extraction is
+/// [`handle_leaf`] itself and the shapes are recognized with the same primitives
+/// it dispatches on, so the two cannot disagree about what is recognized. What
+/// is added here is per-shape *completeness*: which channel field the shape must
+/// have populated for the pushed predicate to mean the whole leaf. A bound the
+/// extractor dropped (an overflowing `ts > <max literal>`, a `BETWEEN` with a
+/// non-timestamp edge) leaves its field `None`, so this answers `false` and the
+/// filter stays `Inexact`. A shape `handle_leaf` learns to recognize later also
+/// answers `false` until it is added here.
+fn leaf_is_exact(expr: &Expr, declared: &[DeclaredColumn]) -> bool {
+    let mut out = LogsPushdown::default();
+    handle_leaf(expr, &mut out, declared);
+    if !out.prune.is_empty() {
+        return false;
+    }
+    match expr {
+        // A `ts` comparison denotes one bound, or two for `=`; all of them must
+        // have survived `apply_ts_bound`.
+        Expr::BinaryExpr(be) => match ts_comparison(be) {
+            Some((Operator::Eq, _)) => out.ts_lo.is_some() && out.ts_hi.is_some(),
+            Some((Operator::Gt | Operator::GtEq, _)) => out.ts_lo.is_some(),
+            Some((Operator::Lt | Operator::LtEq, _)) => out.ts_hi.is_some(),
+            _ => false,
+        },
+        Expr::Between(bt) if !bt.negated && is_ts_col(&bt.expr) => {
+            out.ts_lo.is_some() && out.ts_hi.is_some()
+        }
+        Expr::ScalarFunction(sf) if sf.func.name() == HAS_WORD_UDF => !out.content.is_empty(),
+        _ => false,
+    }
 }
 
 fn walk_conjunct(expr: &Expr, out: &mut LogsPushdown, declared: &[DeclaredColumn]) {

--- a/crates/ravel-sql/src/logs_scan.rs
+++ b/crates/ravel-sql/src/logs_scan.rs
@@ -181,8 +181,10 @@
 //! not extracted into the fetch at all ([`crate::logs_pushdown`]).
 //!
 //! Correctness comes solely from the merged `attrs` column plus the residual.
-//! Pushdown is always `Inexact`, so DataFusion re-applies the *original*
-//! predicate against the emitted batch. [`build_batch`] populates the `attrs`
+//! An attribute predicate's pushdown is always `Inexact`
+//! ([`crate::logs_pushdown::filter_is_exact`] answers `true` for the ts and
+//! `has_word` shapes only), so DataFusion re-applies the *original* predicate
+//! against the emitted batch. [`build_batch`] populates the `attrs`
 //! column from the fully merged view (ADR-0033 amendment), so the
 //! residual evaluates `attrs['k'] = 'v'` against exactly the data a row's SQL
 //! semantics demand: a resource-only match survives (the residual sees it in the
@@ -871,15 +873,11 @@ impl ExecutionPlan for LogsScanExec {
     /// rewrites the aggregate into a literal, so this scan is never executed
     /// (issue #698: on the ClickBench tenant, issue #680, a scanning
     /// `count(*)` moved 23 GB from object storage to add up 8424 numbers the
-    /// resolve already had). For a query with an actual, contained `ts`
-    /// bound, this leaf statistic is still correct, but
-    /// `LogsTableProvider::supports_filters_pushdown` reports every filter
-    /// `Inexact`, so DataFusion keeps a `FilterExec` re-applying the bound
-    /// above this node; that `FilterExec` reports its own (non-exact)
-    /// statistics rather than passing this one through, so the rewrite does
-    /// not fire and the query still scans. Issue #733 tracks closing that
-    /// reachability gap; until then this method is correct but only
-    /// end-to-end effective for the no-bound case.
+    /// resolve already had). A query with an actual, contained `ts` bound now
+    /// reaches the rule the same way: `LogsTableProvider::supports_filters_\
+    /// pushdown` reports a pure `ts` bound `Exact` (issue #733), so no
+    /// `FilterExec` survives above this node to report its own non-exact
+    /// statistics in place of this one.
     ///
     /// `num_rows` is `Exact` only for the whole-plan request (`partition` is
     /// `None`) and only when [`Self::stats_are_exact`] holds; a per-partition

--- a/crates/ravel-sql/tests/logs_count_from_stats.rs
+++ b/crates/ravel-sql/tests/logs_count_from_stats.rs
@@ -511,6 +511,109 @@ async fn clipping_ts_bound_reports_absent() {
     assert_eq!(store.gets(), 0, "computing statistics reads no objects");
 }
 
+// ---------------------------------------------------------------------------
+// Issue #733: the caller-side half that makes #723's leaf statistic reachable.
+// `LogsTableProvider::supports_filters_pushdown` reports a filter that resolves
+// purely to a `ts` bound (or a `has_word` call) as `Exact`, so no `FilterExec`
+// survives above the scan to report its own non-exact statistics in place of
+// the leaf's. The two tests below pin the whole physical-plan rewrite, which
+// #723's own checkpoint review named as the missing coverage.
+
+/// A contained `ts` bound answers `COUNT(*)` from the catalog with no scan at
+/// all: `AggregateStatistics` rewrites the aggregate into a literal because
+/// nothing sits between it and `LogsScanExec`'s `Exact` leaf count. So the
+/// physical plan holds neither a `FilterExec` nor a `LogsScanExec`, and the
+/// query reads zero objects.
+///
+/// `ts BETWEEN 50 AND 400` (ns) fully contains the three segments' 100..312
+/// span, which is exactly #723's `contained_ts_bound_reports_exact_count_and_\
+/// span_with_zero_gets` fixture.
+///
+/// Pre-fix (with `supports_filters_pushdown` reverted to
+/// `Ok(vec![TableProviderFilterPushDown::Inexact; filters.len()])`): the plan
+/// contains a real `FilterExec` over `LogsScanExec` and `store.gets()` is 3.
+#[tokio::test]
+async fn contained_ts_bound_count_needs_no_filter_and_no_scan() {
+    let store = CountingStore::new(Arc::new(MemoryStore::new()));
+    let snapshot = three_objects(&store).await;
+
+    let ctx = logs_session(provider_over(Arc::clone(&store), snapshot)).expect("session");
+    let plan = ctx
+        .sql(
+            "SELECT COUNT(*) FROM logs \
+             WHERE ts BETWEEN TIMESTAMP '1970-01-01 00:00:00.000000050' \
+             AND TIMESTAMP '1970-01-01 00:00:00.000000400'",
+        )
+        .await
+        .expect("plan")
+        .create_physical_plan()
+        .await
+        .expect("physical plan");
+    let plan_str = displayable(plan.as_ref()).indent(true).to_string();
+    assert!(
+        !plan_str.contains("FilterExec"),
+        "an exactly-pushed ts bound must leave no residual filter; plan was:\n{plan_str}"
+    );
+    assert!(
+        !plan_str.contains("LogsScanExec"),
+        "the count must be answered from statistics, not scanned; plan was:\n{plan_str}"
+    );
+
+    let batches = collect(Arc::clone(&plan), ctx.task_ctx())
+        .await
+        .expect("collect");
+    assert_eq!(count_from_batches(&batches), 31, "7 + 11 + 13");
+    assert_eq!(store.gets(), 0, "the count answer must read no objects");
+}
+
+/// The fix must not over-widen to the prune-only channel. The SAME contained
+/// `ts` bound, AND-ed with an `attrs['k'] = 'v'` equality, keeps a real
+/// `FilterExec` (the equality is `Inexact`: the reader uses a prune arm for
+/// block pruning only and never evaluates it per row) and a real
+/// `LogsScanExec`, and reads objects.
+///
+/// Every record carries the resource attribute `service.name = api`, so the
+/// answer is still 31: the surviving residual changes the plan, not the rows.
+#[tokio::test]
+async fn ts_bound_with_an_attrs_equality_keeps_the_filter_and_the_scan() {
+    let store = CountingStore::new(Arc::new(MemoryStore::new()));
+    let snapshot = three_objects(&store).await;
+
+    let ctx = logs_session(provider_over(Arc::clone(&store), snapshot)).expect("session");
+    let plan = ctx
+        .sql(
+            "SELECT COUNT(*) FROM logs \
+             WHERE ts BETWEEN TIMESTAMP '1970-01-01 00:00:00.000000050' \
+             AND TIMESTAMP '1970-01-01 00:00:00.000000400' \
+             AND attrs['service.name'] = 'api'",
+        )
+        .await
+        .expect("plan")
+        .create_physical_plan()
+        .await
+        .expect("physical plan");
+    let plan_str = displayable(plan.as_ref()).indent(true).to_string();
+    assert!(
+        plan_str.contains("FilterExec"),
+        "the prune-only attrs equality must stay Inexact and survive as a \
+         residual; plan was:\n{plan_str}"
+    );
+    assert!(
+        plan_str.contains("LogsScanExec"),
+        "a prune-channel predicate must fail closed to a scan; plan was:\n{plan_str}"
+    );
+
+    let batches = collect(Arc::clone(&plan), ctx.task_ctx())
+        .await
+        .expect("collect");
+    assert_eq!(
+        count_from_batches(&batches),
+        31,
+        "every record carries service.name = api"
+    );
+    assert!(store.gets() > 0, "a scanning count must read objects");
+}
+
 /// Regression guard on the trivial instance (no ts bound at all): the widened
 /// condition must still report the exact count, and now also the exact ts span,
 /// since `[i64::MIN, i64::MAX]` contains every segment.

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -112,20 +112,26 @@ or attribute-equality prune, or any pending selective erasure in the snapshot
 
 This exact leaf statistic only reaches DataFusion's `AggregateStatistics`
 rule end to end when no `FilterExec` survives above the scan to intercept
-it: `LogsTableProvider::supports_filters_pushdown` currently reports
-`Inexact` for every filter unconditionally (crates/ravel-sql/src/
-logs_provider.rs), so DataFusion keeps re-applying any pushed filter,
-`ts` bound included, in a `FilterExec` above `LogsScanExec`, and that
-`FilterExec` reports its own (non-exact) statistics rather than passing
-the leaf's `Exact` count through. In practice the zero-GET rewrite fires
-today only for the genuinely predicate-free query (no `ts` bound, no
-content, no prune) -- the only shape with no filter left to push down at
-all. The contained-`ts`-bound case computes a correct `Exact` leaf
-statistic (and its `ts` min/max still reach the planner as a leaf
-property), but a `COUNT(*)` with a contained `ts` bound still scans today;
-making `supports_filters_pushdown` report the bound as `Exact` when it is
-already absorbed by this containment check is a separate, unimplemented
-follow-up (issue #733).
+it, because a `FilterExec` reports its own (non-exact) statistics rather
+than passing the leaf's `Exact` count through. So
+`LogsTableProvider::supports_filters_pushdown` (crates/ravel-sql/src/
+logs_provider.rs) reports `Exact` for a filter that resolves purely to a
+`ts` bound and/or a `has_word` content predicate (issue #733), which
+deletes it from the plan: both land in the channel the RLOG reader
+re-verifies against each decoded row's own value (`ravel_logseg`'s `eval`,
+its `Predicate::TsRange` and `Predicate::HasWord` arms), so no residual is
+needed. A `COUNT(*)` over a contained `ts` bound therefore takes the same
+zero-GET path the genuinely predicate-free query does.
+
+Every other filter stays `Inexact`. An `attrs['k'] = 'v'` equality and
+every declared typed column predicate (ADR-0093) go to the prune-only
+channel, which the reader uses for block pruning ONLY and never evaluates
+per row, so DataFusion's residual remains the sole exact evaluator; a
+filter recognized only in part (a `ts` bound AND-ed with an unrecognized
+sub-expression in one unsplit expression) is `Inexact` too, never
+partially credited. A distributed coordinator (ADR-0071) also reports
+every filter `Inexact`, since its fan-out pushes no filter to the workers
+and needs each one back as a residual.
 
 ## Predicate-free full-window logs scan: request count
 


### PR DESCRIPTION
LogsTableProvider::supports_filters_pushdown returned Inexact for every
filter unconditionally, so DataFusion always kept a FilterExec above
LogsScanExec re-applying whatever was pushed. That FilterExec reports
its own non-exact statistics rather than passing the leaf's through,
which is why #723's widened exact leaf count for a contained ts bound
never reached DataFusion's AggregateStatistics rule: correct at the
leaf, unreachable end to end.

Report Exact for a filter that resolves purely to a ts bound and/or a
has_word content predicate. Both land in the channel the RLOG reader
re-verifies against each decoded row's own value: ravel_logseg's eval
reads the row's ts for Predicate::TsRange and the row's own field text
for Predicate::HasWord, and ravel_query's combined_predicate folds both
into the exact predicate it hands the reader. Nothing survives for a
residual to re-check, so the filter can be deleted from the plan, and a
COUNT(*) over a contained ts bound now takes the same zero-GET path a
predicate-free one does.

Everything else stays Inexact. An attrs['k'] = 'v' equality and every
declared typed column predicate go to the prune-only channel, which
open_scan passes separately from the exact predicate and the reader
uses for block pruning only, never per row; DataFusion's residual stays
the sole exact evaluator there. The check is filter_is_exact in
logs_pushdown, which reuses the existing handle_leaf classifier for the
extraction rather than deriving a second one, and adds only the
per-shape completeness rule: which channel field a recognized shape
must have populated for the pushed predicate to mean the whole leaf. A
filter recognized only in part, and one recognized not at all, both
answer false and stay Inexact.

A provider acting as a distributed coordinator keeps the blanket
Inexact. Its fan-out pushes no filter to the workers at all and needs
every one back as a residual above the merge, so an Exact verdict there
would delete a predicate nothing re-applies.

Gated on ravel-clickbench-1 (director's box, label g733): full gate
list including the sql and flight-sql feature lanes, PASS on tree
dc577406.

Refs: #733
