### PR TITLE
perf(ravel-catalog): one bounded LIST per shard, overlap the erasure LIST

### DIFF
--- a/crates/ravel-catalog/src/catalog.rs
+++ b/crates/ravel-catalog/src/catalog.rs
@@ -40,6 +40,10 @@ const NS_PER_HOUR: i64 = 3_600_000_000_000;
 /// around a single leaf request, so the fan-out collapses from k sequential
 /// round trips toward ceil(k / this) without ever exceeding it.
 pub(crate) const MAX_CONCURRENT_REQUESTS: usize = 16;
+/// One shard's listed commit-bucket entries, keyed by `(shard, ingest_hour)`,
+/// as produced by [`Catalog::list_shard_hours`] and merged in
+/// [`Catalog::list_window_bounded`].
+type ShardBuckets = HashMap<(u32, u32), Vec<ObjectMeta>>;
 /// Delay before the single retry on an exact `min_token` GET
 /// (docs/catalog-and-mvcc.md step 4: "GET it directly ... with one retry").
 /// `MemoryStore` is strongly consistent so tests never observe this delay;
@@ -1269,42 +1273,52 @@ impl Catalog {
             // future is awaited before the Snapshot is built, so ADR-0064's
             // visibility bound is unchanged.
             let erasure_fut = self.list_pending_erasure(tenant, signal, accounting);
-            let listed = if use_prefix {
-                let (listed, erasure) = tokio::join!(
-                    self.list_window_by_prefix(
-                        tenant,
-                        signal,
-                        listing_start_hour,
-                        window_end_hour,
-                        range,
-                        &generations,
-                        accounting,
-                    ),
-                    erasure_fut,
-                );
-                pending_erasure = Some(erasure?);
-                listed?
+            if listing_start_hour > window_end_hour {
+                // Empty listing suffix: a folded snapshot's watermark covers
+                // the whole window, so there is nothing above it to list. The
+                // former per-(shard, hour) loop's `for hour in start..=end`
+                // range was empty here and issued no LIST; issue none either,
+                // so a fully-folded resolve stays entirely GET-based. Only the
+                // erasure LIST runs.
+                pending_erasure = Some(erasure_fut.await?);
             } else {
-                let (listed, erasure) = tokio::join!(
-                    self.list_window_bounded(
-                        tenant,
-                        signal,
-                        listing_start_hour,
-                        window_end_hour,
-                        range,
-                        suffix_scan_shards,
-                        accounting,
-                    ),
-                    erasure_fut,
-                );
-                pending_erasure = Some(erasure?);
-                listed?
-            };
-            for (key, segment_ref) in listed {
-                if !segments.contains_key(&key) {
-                    origin_by_key.insert(key.clone(), SegmentOrigin::Recent);
+                let listed = if use_prefix {
+                    let (listed, erasure) = tokio::join!(
+                        self.list_window_by_prefix(
+                            tenant,
+                            signal,
+                            listing_start_hour,
+                            window_end_hour,
+                            range,
+                            &generations,
+                            accounting,
+                        ),
+                        erasure_fut,
+                    );
+                    pending_erasure = Some(erasure?);
+                    listed?
+                } else {
+                    let (listed, erasure) = tokio::join!(
+                        self.list_window_bounded(
+                            tenant,
+                            signal,
+                            listing_start_hour,
+                            window_end_hour,
+                            range,
+                            &generations,
+                            accounting,
+                        ),
+                        erasure_fut,
+                    );
+                    pending_erasure = Some(erasure?);
+                    listed?
+                };
+                for (key, segment_ref) in listed {
+                    if !segments.contains_key(&key) {
+                        origin_by_key.insert(key.clone(), SegmentOrigin::Recent);
+                    }
+                    segments.entry(key).or_insert(segment_ref);
                 }
-                segments.entry(key).or_insert(segment_ref);
             }
         }
 
@@ -1498,15 +1512,18 @@ impl Catalog {
     /// full-window resolve over an 8-shard tenant with a 3-hour unsealed tail
     /// costs 8 LISTs, not 24.
     ///
-    /// `scan_shards` is the union scan set over the suffix
-    /// ([`crate::provisioning::max_scan_count_over_range`], the same bound
-    /// [`Catalog::list_window_by_prefix`] uses): a per-shard LIST cannot vary
-    /// its shard bound per hour, so it takes the max over the range, which
-    /// keeps a retiring larger generation's higher shard indices in scope for
-    /// `DEFAULT_SCAN_SLACK_HOURS` past a decrease (ADR-0052 section 4). The
-    /// grouped `(shard, hour)` key set equals the union of the per-bucket
-    /// LISTs, so `process_bucket` runs unchanged and the resolved snapshot is
-    /// identical to both the per-bucket loop and the prefix scan.
+    /// The per-shard LIST bound is the union scan set over the suffix
+    /// ([`crate::provisioning::max_scan_count_over_range`]): a per-shard LIST
+    /// cannot vary its shard bound per hour, so it lists up to the max seen
+    /// over the range. A bucket whose shard index is outside its OWN hour's
+    /// `scan_count` is then dropped before `process_bucket`, so the INCLUDED
+    /// set is exactly the per-`(shard, hour)` loop's -- a retiring larger
+    /// generation's higher shards stay listed only for the hours inside their
+    /// `DEFAULT_SCAN_SLACK_HOURS` window past a decrease, never beyond it
+    /// (ADR-0052 section 4). This makes the resolved snapshot byte-identical to
+    /// the old per-bucket loop; it is NOT the prefix scan, which is a documented
+    /// over-scanning superset (see [`Catalog::list_window_by_prefix`] and
+    /// tests/resharding_prefix_traversal.rs).
     #[allow(clippy::too_many_arguments)]
     async fn list_window_bounded(
         &self,
@@ -1515,31 +1532,51 @@ impl Catalog {
         listing_start_hour: u32,
         window_end_hour: u32,
         range: TimeRange,
-        scan_shards: u32,
+        generations: &[crate::provisioning::ShardGeneration],
         accounting: &QueryAccounting,
     ) -> Result<HashMap<String, SegmentRef>, CatalogError> {
+        // Union scan set over the suffix: the widest per-shard bound any hour
+        // in the range needs (a per-shard LIST cannot vary per hour).
+        let scan_shards = crate::provisioning::max_scan_count_over_range(
+            generations,
+            listing_start_hour,
+            window_end_hour,
+            crate::provisioning::DEFAULT_SCAN_SLACK_HOURS,
+        );
         // One bounded LIST per shard, concurrently under the resolve-wide
         // semaphore (each `list_shard_hours` acquires it per page). Shards
         // partition the key space, so their grouped buckets never collide.
-        let shard_groups: Vec<Result<HashMap<(u32, u32), Vec<ObjectMeta>>, CatalogError>> =
-            stream::iter(0..scan_shards)
-                .map(|shard| {
-                    self.list_shard_hours(
-                        tenant,
-                        signal,
-                        shard,
-                        listing_start_hour,
-                        window_end_hour,
-                        accounting,
-                    )
-                })
-                .buffered(MAX_CONCURRENT_REQUESTS)
-                .collect()
-                .await;
-        let mut grouped: HashMap<(u32, u32), Vec<ObjectMeta>> = HashMap::new();
+        let shard_groups: Vec<Result<ShardBuckets, CatalogError>> = stream::iter(0..scan_shards)
+            .map(|shard| {
+                self.list_shard_hours(
+                    tenant,
+                    signal,
+                    shard,
+                    listing_start_hour,
+                    window_end_hour,
+                    accounting,
+                )
+            })
+            .buffered(MAX_CONCURRENT_REQUESTS)
+            .collect()
+            .await;
+        let mut grouped: ShardBuckets = HashMap::new();
         for shard_group in shard_groups {
-            for (coord, objs) in shard_group? {
-                grouped.entry(coord).or_default().extend(objs);
+            for ((shard, hour), objs) in shard_group? {
+                // Per-hour scan set (ADR-0052 section 4): the union LIST bound
+                // over-scans shard indices that THIS hour does not need (a
+                // retiring generation's higher shards past their slack window).
+                // Drop those buckets so the included set matches the
+                // per-(shard, hour) loop exactly, which never listed them.
+                let hour_scan = crate::provisioning::scan_count(
+                    generations,
+                    hour,
+                    crate::provisioning::DEFAULT_SCAN_SLACK_HOURS,
+                );
+                if shard >= hour_scan {
+                    continue;
+                }
+                grouped.entry((shard, hour)).or_default().extend(objs);
             }
         }
 
@@ -1587,12 +1624,12 @@ impl Catalog {
         listing_start_hour: u32,
         window_end_hour: u32,
         accounting: &QueryAccounting,
-    ) -> Result<HashMap<(u32, u32), Vec<ObjectMeta>>, CatalogError> {
+    ) -> Result<ShardBuckets, CatalogError> {
         let tenant_prefix = format!("t/{}/", tenant.to_hex());
         let prefix = keys::commit_shard_prefix(tenant, signal, shard)?;
         let start_after =
             keys::commit_shard_hour_prefix(tenant, signal, shard, listing_start_hour)?;
-        let mut grouped: HashMap<(u32, u32), Vec<ObjectMeta>> = HashMap::new();
+        let mut grouped: ShardBuckets = HashMap::new();
         let mut seen: HashSet<String> = HashSet::new();
         let mut page_token = None;
         'pages: loop {

--- a/crates/ravel-catalog/src/catalog.rs
+++ b/crates/ravel-catalog/src/catalog.rs
@@ -1102,6 +1102,9 @@ impl Catalog {
     }
 
     #[allow(clippy::too_many_arguments)]
+    // issue #730: cut the resolve's LIST round trips above the snapshot
+    // watermark from three to one (overlap the erasure LIST, one bounded
+    // LIST per shard instead of one per (shard, hour)).
     async fn resolve_fanout(
         &self,
         tenant: &TenantHash,

--- a/crates/ravel-catalog/src/catalog.rs
+++ b/crates/ravel-catalog/src/catalog.rs
@@ -1157,6 +1157,16 @@ impl Catalog {
         // either over token-resolved) keeps its original tag.
         let mut origin_by_key: HashMap<String, SegmentOrigin> = HashMap::new();
 
+        // The pending-erasure LIST (ADR-0064 decision 2) is started before the
+        // listing fan-out and joined with it, so its round trip overlaps the
+        // bucket LISTs instead of following them. It still completes before the
+        // Snapshot is built below (the join awaits it), so the visibility bound
+        // is unchanged: a `.dreq` durable before this resolve began -- hence
+        // before this LIST is even issued -- is always observed. `None` here
+        // means no window was listed (no fan-out to overlap), so the LIST runs
+        // standalone after the token loop, exactly as before.
+        let mut pending_erasure: Option<Vec<ErasureRequest>> = None;
+
         if let Some((window_start_hour, window_end_hour)) = self.window_hour_bounds(range, now_ns) {
             // A snapshot at watermark W serves every window hour <= W
             // straight from its parts; only the suffix above W is listed.
@@ -1252,9 +1262,16 @@ impl Catalog {
                 && (listing_suffix_buckets >= self.config.prefix_list_crossover_requests
                     || listing_suffix_buckets > self.config.max_catalog_list_requests);
 
-            if use_prefix {
-                let listed = self
-                    .list_window_by_prefix(
+            // Overlap the pending-erasure LIST with the listing fan-out
+            // (deliverable 1): start it here and `join` it with whichever
+            // traversal path runs, so the two round trips share one wave
+            // instead of the erasure LIST following the buckets. The joined
+            // future is awaited before the Snapshot is built, so ADR-0064's
+            // visibility bound is unchanged.
+            let erasure_fut = self.list_pending_erasure(tenant, signal, accounting);
+            let listed = if use_prefix {
+                let (listed, erasure) = tokio::join!(
+                    self.list_window_by_prefix(
                         tenant,
                         signal,
                         listing_start_hour,
@@ -1262,58 +1279,32 @@ impl Catalog {
                         range,
                         &generations,
                         accounting,
-                    )
-                    .await?;
-                for (key, segment_ref) in listed {
-                    if !segments.contains_key(&key) {
-                        origin_by_key.insert(key.clone(), SegmentOrigin::Recent);
-                    }
-                    segments.entry(key).or_insert(segment_ref);
-                }
+                    ),
+                    erasure_fut,
+                );
+                pending_erasure = Some(erasure?);
+                listed?
             } else {
-                // The (shard, hour) listing pass used to issue its LISTs one
-                // await at a time; run them concurrently under the
-                // resolve-wide semaphore instead. Each bucket
-                // resolves into its own map (bucket keys never collide across
-                // buckets), and the per-bucket maps are merged back in the
-                // buffered (input) order so the resulting segment set is
-                // byte-identical to the sequential pass before the final
-                // deterministic sort.
-                // Each hour's shard fan-out is its own `scan_count(h)`
-                // derived from the generation history (ADR-0052 section 4),
-                // not one static `shard_count` for the whole range: a hour
-                // before a reshard scans the old count, a hour at/after an
-                // increase scans the wider new count, and a hour in a
-                // decrease's slack window scans the retiring larger count so
-                // a straggler is still found.
-                let mut bucket_coords = Vec::new();
-                for hour in listing_start_hour..=window_end_hour {
-                    let scan = crate::provisioning::scan_count(
-                        &generations,
-                        hour,
-                        crate::provisioning::DEFAULT_SCAN_SLACK_HOURS,
-                    );
-                    for shard in 0..scan {
-                        bucket_coords.push((shard, hour));
-                    }
+                let (listed, erasure) = tokio::join!(
+                    self.list_window_bounded(
+                        tenant,
+                        signal,
+                        listing_start_hour,
+                        window_end_hour,
+                        range,
+                        suffix_scan_shards,
+                        accounting,
+                    ),
+                    erasure_fut,
+                );
+                pending_erasure = Some(erasure?);
+                listed?
+            };
+            for (key, segment_ref) in listed {
+                if !segments.contains_key(&key) {
+                    origin_by_key.insert(key.clone(), SegmentOrigin::Recent);
                 }
-                let bucket_maps: Vec<Result<HashMap<String, SegmentRef>, CatalogError>> =
-                    stream::iter(bucket_coords)
-                        .map(|(shard, hour)| async move {
-                            self.list_hour_bucket(tenant, signal, shard, hour, range, accounting)
-                                .await
-                        })
-                        .buffered(MAX_CONCURRENT_REQUESTS)
-                        .collect()
-                        .await;
-                for bucket in bucket_maps {
-                    for (key, segment_ref) in bucket? {
-                        if !segments.contains_key(&key) {
-                            origin_by_key.insert(key.clone(), SegmentOrigin::Recent);
-                        }
-                        segments.entry(key).or_insert(segment_ref);
-                    }
-                }
+                segments.entry(key).or_insert(segment_ref);
             }
         }
 
@@ -1334,10 +1325,16 @@ impl Catalog {
         // unconditionally, independent of the segment fan-out and of whether
         // any rewrite pass has physically run yet, so the visibility bound
         // holds -- a `.dreq` durable before this resolve is always seen by it.
-        // Empty (the common case) costs exactly one LIST and nothing more.
-        let pending_erasure = self
-            .list_pending_erasure(tenant, signal, accounting)
-            .await?;
+        // Empty (the common case) costs exactly one LIST and nothing more. When
+        // a window was listed above, this LIST already ran concurrently with
+        // the bucket fan-out and is reused here; otherwise it runs now.
+        let pending_erasure = match pending_erasure {
+            Some(pending) => pending,
+            None => {
+                self.list_pending_erasure(tenant, signal, accounting)
+                    .await?
+            }
+        };
 
         let mut segments: Vec<SegmentRef> = segments.into_values().collect();
         // Deterministic total order: the cross-segment dedup provenance order
@@ -1492,24 +1489,168 @@ impl Catalog {
         Some((start_hour, end_hour))
     }
 
-    /// List one `(shard, ingest-hour)` bucket and resolve it into its segment
-    /// contribution: one `guarded_list_all` over the bucket prefix, then
-    /// [`Catalog::process_bucket`]. The per-bucket-loop path
-    /// (docs/catalog-and-mvcc.md "Snapshot resolution (Phase 1)").
+    /// List the commit buckets for the listing suffix
+    /// `[listing_start_hour, window_end_hour]` with one bounded LIST per shard
+    /// (docs/catalog-and-mvcc.md "Snapshot resolution (Phase 1)"), the
+    /// non-prefix traversal path. Replaces the former one-LIST-per-(shard,
+    /// hour) loop: each shard's below-watermark history is skipped server-side
+    /// by a `list_after` start marker and its tail is drained in one wave, so a
+    /// full-window resolve over an 8-shard tenant with a 3-hour unsealed tail
+    /// costs 8 LISTs, not 24.
+    ///
+    /// `scan_shards` is the union scan set over the suffix
+    /// ([`crate::provisioning::max_scan_count_over_range`], the same bound
+    /// [`Catalog::list_window_by_prefix`] uses): a per-shard LIST cannot vary
+    /// its shard bound per hour, so it takes the max over the range, which
+    /// keeps a retiring larger generation's higher shard indices in scope for
+    /// `DEFAULT_SCAN_SLACK_HOURS` past a decrease (ADR-0052 section 4). The
+    /// grouped `(shard, hour)` key set equals the union of the per-bucket
+    /// LISTs, so `process_bucket` runs unchanged and the resolved snapshot is
+    /// identical to both the per-bucket loop and the prefix scan.
     #[allow(clippy::too_many_arguments)]
-    async fn list_hour_bucket(
+    async fn list_window_bounded(
+        &self,
+        tenant: &TenantHash,
+        signal: Signal,
+        listing_start_hour: u32,
+        window_end_hour: u32,
+        range: TimeRange,
+        scan_shards: u32,
+        accounting: &QueryAccounting,
+    ) -> Result<HashMap<String, SegmentRef>, CatalogError> {
+        // One bounded LIST per shard, concurrently under the resolve-wide
+        // semaphore (each `list_shard_hours` acquires it per page). Shards
+        // partition the key space, so their grouped buckets never collide.
+        let shard_groups: Vec<Result<HashMap<(u32, u32), Vec<ObjectMeta>>, CatalogError>> =
+            stream::iter(0..scan_shards)
+                .map(|shard| {
+                    self.list_shard_hours(
+                        tenant,
+                        signal,
+                        shard,
+                        listing_start_hour,
+                        window_end_hour,
+                        accounting,
+                    )
+                })
+                .buffered(MAX_CONCURRENT_REQUESTS)
+                .collect()
+                .await;
+        let mut grouped: HashMap<(u32, u32), Vec<ObjectMeta>> = HashMap::new();
+        for shard_group in shard_groups {
+            for (coord, objs) in shard_group? {
+                grouped.entry(coord).or_default().extend(objs);
+            }
+        }
+
+        // Resolve each surviving bucket through the shared per-bucket path,
+        // concurrently. resolve_fanout's final deterministic sort makes the
+        // result independent of merge order.
+        let coords: Vec<((u32, u32), Vec<ObjectMeta>)> = grouped.into_iter().collect();
+        let bucket_maps: Vec<Result<HashMap<String, SegmentRef>, CatalogError>> =
+            stream::iter(coords)
+                .map(|((shard, hour), objs)| async move {
+                    self.process_bucket(tenant, signal, shard, hour, objs, range, accounting)
+                        .await
+                })
+                .buffered(MAX_CONCURRENT_REQUESTS)
+                .collect()
+                .await;
+        let mut out: HashMap<String, SegmentRef> = HashMap::new();
+        for bucket in bucket_maps {
+            for (key, segment_ref) in bucket? {
+                out.entry(key).or_insert(segment_ref);
+            }
+        }
+        Ok(out)
+    }
+
+    /// List one shard's commit buckets for the hours in
+    /// `[listing_start_hour, window_end_hour]` with a single bounded LIST,
+    /// grouping the keys by `(shard, hour)` for [`Catalog::process_bucket`].
+    ///
+    /// The scan starts strictly after
+    /// `commit_shard_hour_prefix(.., listing_start_hour)`: that prefix string
+    /// sorts before every key under `listing_start_hour`, so `list_after`
+    /// skips the shard's whole below-watermark history server-side rather than
+    /// paging through and discarding it. Paging stops at the first key whose
+    /// hour is past `window_end_hour` -- the `YYYYMMDDTHH` hour strings are
+    /// fixed-width and sort chronologically (ravel-commit keys), so once one
+    /// past-window key appears every later key in the shard is also past it.
+    /// Each page issued is one `AccountedOp::List` in `accounting`, so the
+    /// request count stays exact.
+    async fn list_shard_hours(
         &self,
         tenant: &TenantHash,
         signal: Signal,
         shard: u32,
-        hour: u32,
-        range: TimeRange,
+        listing_start_hour: u32,
+        window_end_hour: u32,
         accounting: &QueryAccounting,
-    ) -> Result<HashMap<String, SegmentRef>, CatalogError> {
-        let prefix = keys::commit_shard_hour_prefix(tenant, signal, shard, hour)?;
-        let objects = self.guarded_list_all(tenant, &prefix, accounting).await?;
-        self.process_bucket(tenant, signal, shard, hour, objects, range, accounting)
-            .await
+    ) -> Result<HashMap<(u32, u32), Vec<ObjectMeta>>, CatalogError> {
+        let tenant_prefix = format!("t/{}/", tenant.to_hex());
+        let prefix = keys::commit_shard_prefix(tenant, signal, shard)?;
+        let start_after =
+            keys::commit_shard_hour_prefix(tenant, signal, shard, listing_start_hour)?;
+        let mut grouped: HashMap<(u32, u32), Vec<ObjectMeta>> = HashMap::new();
+        let mut seen: HashSet<String> = HashSet::new();
+        let mut page_token = None;
+        'pages: loop {
+            let page = {
+                let _permit = self.request_semaphore.acquire().await.map_err(|_| {
+                    StoreError::Transient("catalog request semaphore closed".to_string())
+                })?;
+                let page = self
+                    .store
+                    .list_after(&prefix, Some(&start_after), page_token)
+                    .await;
+                accounting.record_s3_request(AccountedOp::List);
+                page?
+            };
+            for meta in page.objects {
+                // ADR-0050 §2 isolation assertion, identical to
+                // `guarded_list_all`: every returned key is under this tenant's
+                // prefix or the scan hard-fails.
+                if !meta.key.starts_with(&tenant_prefix) {
+                    self.record_isolation_breach();
+                    return Err(CatalogError::FieldMismatch {
+                        key: prefix.clone(),
+                        field: "list_prefix",
+                        expected: tenant_prefix,
+                        actual: meta.key,
+                    });
+                }
+                // Dedup by key across pages (a key MAY repeat across pages),
+                // matching `guarded_list_all` so the grouped key set is
+                // identical to the per-bucket loop's.
+                if !seen.insert(meta.key.clone()) {
+                    continue;
+                }
+                let (bshard, bhour) = match keys::partition_bucket_entry(&meta.key)? {
+                    BucketEntry::CommitRecord(k) => (k.shard, k.ingest_hour_bucket),
+                    BucketEntry::CompactionRecord(k) => (k.shard, k.ingest_hour_bucket),
+                    BucketEntry::RewriteRecord(k) => (k.shard, k.ingest_hour_bucket),
+                    BucketEntry::Tombstone(k) => (k.shard, k.ingest_hour_bucket),
+                };
+                // Past the window's top hour: every later key in this shard is
+                // also past it, so stop paging (do not request the next page).
+                if bhour > window_end_hour {
+                    break 'pages;
+                }
+                // `start_after` already excluded everything strictly below
+                // `listing_start_hour`; this guard is a belt for a marker key
+                // that shares the first page with in-window keys.
+                if bhour < listing_start_hour {
+                    continue;
+                }
+                grouped.entry((bshard, bhour)).or_default().push(meta);
+            }
+            match page.next {
+                Some(next) => page_token = Some(next),
+                None => break,
+            }
+        }
+        Ok(grouped)
     }
 
     /// Resolve one `(shard, ingest-hour)` bucket's already-listed keys into its
@@ -1789,11 +1930,13 @@ impl Catalog {
         generations: &[crate::provisioning::ShardGeneration],
         accounting: &QueryAccounting,
     ) -> Result<HashMap<String, SegmentRef>, CatalogError> {
-        // One recursive LIST per shard, grouping keys by (shard, hour). The
-        // LISTs drain sequentially so the runtime request cap is checked
-        // deterministically page by page; the expensive per-bucket record GETs
-        // are what run concurrently below, mirroring the per-bucket loop's
-        // concurrency model.
+        // One recursive LIST per shard, grouping keys by (shard, hour), each
+        // shard's scan bounded below the watermark by a `list_after` start
+        // marker (below) so it does not page through the shard's whole history
+        // before reaching the listing suffix. The LISTs drain sequentially so
+        // the runtime request cap is checked deterministically page by page;
+        // the expensive per-bucket record GETs are what run concurrently below,
+        // mirroring the per-bucket loop's concurrency model.
         let mut grouped: HashMap<(u32, u32), Vec<ObjectMeta>> = HashMap::new();
         let mut seen: HashSet<String> = HashSet::new();
         let mut lists_issued: u64 = 0;
@@ -1805,9 +1948,10 @@ impl Catalog {
         // retiring larger generation's higher shard indices in scope for
         // `DEFAULT_SCAN_SLACK_HOURS` past its successor's activation, so on a
         // shard-count decrease a straggler routed under the old count into an
-        // early successor hour is still listed. Matches the per-bucket path's
-        // per-hour `scan_count`; a per-shard recursive LIST cannot vary the
-        // bound per hour, so it takes the max over the range.
+        // early successor hour is still listed. The non-prefix bounded path
+        // ([`Catalog::list_window_bounded`]) uses this same bound; a per-shard
+        // recursive LIST cannot vary the bound per hour, so it takes the max
+        // over the range.
         let scan_shards = crate::provisioning::max_scan_count_over_range(
             generations,
             listing_start_hour,
@@ -1816,6 +1960,11 @@ impl Catalog {
         );
         for shard in 0..scan_shards {
             let prefix = keys::commit_shard_prefix(tenant, signal, shard)?;
+            // Skip the shard's below-watermark history server-side: the
+            // shard-hour prefix for `listing_start_hour` sorts before every
+            // key at or above it, so `list_after` resumes strictly past it.
+            let start_after =
+                keys::commit_shard_hour_prefix(tenant, signal, shard, listing_start_hour)?;
             let mut page_token = None;
             loop {
                 // Refuse before issuing a page that would exceed the ceiling,
@@ -1830,7 +1979,10 @@ impl Catalog {
                     let _permit = self.request_semaphore.acquire().await.map_err(|_| {
                         StoreError::Transient("catalog request semaphore closed".to_string())
                     })?;
-                    let page = self.store.list(&prefix, page_token).await;
+                    let page = self
+                        .store
+                        .list_after(&prefix, Some(&start_after), page_token)
+                        .await;
                     accounting.record_s3_request(AccountedOp::List);
                     lists_issued += 1;
                     page?
@@ -4684,12 +4836,12 @@ mod tests {
     #[tokio::test]
     async fn list_result_outside_tenant_prefix_is_hard_error() {
         let now = 500_000 * NS_PER_HOUR + 30 * 60_000_000_000;
-        // The one (shard, hour) bucket `resolve`'s ingest-lag window is
-        // guaranteed to cover: matching on this exact prefix means the
-        // other buckets the window also lists stay untouched, so the test
-        // observes exactly one violation.
+        // The resolve now lists one bounded LIST per shard (issue #730), so
+        // the injection target is the per-shard prefix. `config(1)` has a
+        // single shard, so matching shard 0's prefix injects exactly one
+        // out-of-tenant key and the test observes exactly one violation.
         let target_prefix =
-            keys::commit_shard_hour_prefix(&tenant(), Signal::Metrics, 0, 500_000).expect("prefix");
+            keys::commit_shard_prefix(&tenant(), Signal::Metrics, 0).expect("prefix");
         let store = Arc::new(ForeignKeyInjectingStore {
             inner: MemoryStore::new(),
             target_prefix,

--- a/crates/ravel-catalog/src/config.rs
+++ b/crates/ravel-catalog/src/config.rs
@@ -109,18 +109,20 @@ pub const DEFAULT_PROTECTION_HORIZON_NS: i64 = 25 * 3_600 * 1_000_000_000 + 5 * 
 /// ([`crate::FoldReport::frontier_hours_deferred`]). 168 = seven days of
 /// hourly buckets.
 pub const DEFAULT_FRONTIER_RECONCILE_MAX_HOURS: u32 = 168;
-/// Default crossover at which `Catalog::resolve` switches from the
-/// per-(shard, ingest-hour) LIST loop to a single per-shard recursive prefix
-/// LIST (ADR-0056). Expressed in per-bucket request units, i.e. the number of
-/// `(shard, hour)` buckets the listing suffix spans: at or above this, the
-/// prefix scan (cost `O(objects / page_size)`, independent of window width)
-/// wins over the per-bucket loop (one LIST per bucket, empty buckets
-/// included). 720 is thirty days of hourly buckets at `shard_count = 1`: warm
-/// operational windows stay on the watermark-pruning per-bucket path, and the
-/// per-bucket path's request amplification is capped at 720 LISTs before the
-/// handoff. Purely a performance heuristic -- both paths return identical
-/// snapshots and both respect [`DEFAULT_MAX_CATALOG_LIST_REQUESTS`], so any
-/// value is correct.
+/// Default crossover at which `Catalog::resolve` switches from the non-prefix
+/// bounded LIST path to the per-shard recursive prefix scan (ADR-0056).
+/// Expressed in per-bucket request units, i.e. the number of `(shard, hour)`
+/// buckets the listing suffix spans. Both paths now list one bounded LIST per
+/// shard, resuming strictly after the watermark via `start_after`, so both
+/// cost `O(objects above the watermark / page_size)` and neither pages
+/// through a shard's below-watermark history. The remaining difference is only
+/// how each drains a shard: the non-prefix path fans the shards out
+/// concurrently and stops each at the first hour past the window; the prefix
+/// scan drains them sequentially under a page-by-page request cap, which is
+/// what a very wide window wants. 720 is thirty days of hourly buckets at
+/// `shard_count = 1`. Purely a performance heuristic -- both paths return
+/// identical snapshots and both respect [`DEFAULT_MAX_CATALOG_LIST_REQUESTS`],
+/// so any value is correct.
 pub const DEFAULT_PREFIX_LIST_CROSSOVER_REQUESTS: u64 = 720;
 
 /// Catalog configuration.

--- a/crates/ravel-catalog/src/fold.rs
+++ b/crates/ravel-catalog/src/fold.rs
@@ -1785,7 +1785,7 @@ impl Catalog {
     /// Classify one `(shard, hour)` commit bucket's listing into the entries
     /// it should contribute to the snapshot, the single shared classifier for both the incremental fold loop and
     /// the reconcile pass (ADR-0063 section 4). Partitioning the bucket's keys
-    /// by shape mirrors the resolve-time listing (`Catalog::list_hour_bucket`,
+    /// by shape mirrors the resolve-time listing (`Catalog::process_bucket`,
     /// docs/catalog-and-mvcc.md step 2) so a fold and a live resolve derive
     /// identical bucket state.
     ///

--- a/crates/ravel-catalog/src/snapshot_resolve.rs
+++ b/crates/ravel-catalog/src/snapshot_resolve.rs
@@ -85,7 +85,7 @@ pub(crate) struct SnapshotWindow {
 impl SnapshotWindow {
     /// Extract entries for `[lower_hour, upper_hour]` (inclusive) from every
     /// part, filtered by event-time overlap with `query_range` exactly as
-    /// `Catalog::list_hour_bucket` does, deduped into `out` by data key. Entries are sorted
+    /// `Catalog::process_bucket` does, deduped into `out` by data key. Entries are sorted
     /// hour-major within each part, so the
     /// matching hour range is one contiguous slice found by
     /// `partition_point`.

--- a/crates/ravel-catalog/tests/fold_compaction_differential.rs
+++ b/crates/ravel-catalog/tests/fold_compaction_differential.rs
@@ -1,7 +1,7 @@
 //! Differential proof for compaction/retention folding: for a population that mixes a plain
 //! L0 bucket, a compacted bucket, and a tombstoned bucket, `Catalog::resolve`
 //! must return the exact same segment set whether it runs before any fold
-//! (pure Phase 1 listing, `Catalog::list_hour_bucket`) or after one (served
+//! (pure Phase 1 listing, `Catalog::list_window_bounded`) or after one (served
 //! from the snapshot part the fold wrote). The two paths share no code past
 //! `Catalog::resolve` itself, so agreement here proves the fold reproduces the
 //! resolver's compaction/retention rules exactly: L1 parts added at level 1,

--- a/crates/ravel-catalog/tests/resolve_bounded_listing.rs
+++ b/crates/ravel-catalog/tests/resolve_bounded_listing.rs
@@ -1,0 +1,491 @@
+//! issue #730: the resolve lists the suffix above the snapshot watermark with
+//! one bounded LIST per shard (not one per (shard, hour)), and overlaps the
+//! pending-erasure LIST with that fan-out.
+//!
+//! Three properties, each with a stated red flip.
+//!
+//! Differential + request count: a folded tenant with data in some but not all
+//! (shard, hour) buckets above the watermark, plus sealed data below it,
+//! resolves to the same segment set/order/origins as the independent prefix
+//! traversal and an independent reconstruction, in exactly 9 LISTs (8 shards +
+//! 1 erasure), and no below-watermark key is ever listed. RED: restoring the
+//! per-(shard, hour) loop makes it 25 LISTs; dropping the `start_after` makes
+//! below-watermark keys appear in the listing.
+//!
+//! Pagination: a bounded shard LIST pages across a small page size and stops at
+//! the first key past the window end. RED: dropping the stop-at-end paging
+//! fetches one extra page.
+//!
+//! Concurrency: the erasure LIST is issued concurrently with the shard fan-out,
+//! so all nine LISTs can be held at once. RED: awaiting the erasure LIST after
+//! the fan-out means it is never issued while the shard LISTs are held, so at
+//! most eight are ever held simultaneously.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::collections::BTreeSet;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use ravel_catalog::{
+    Catalog, CatalogConfig, DEFAULT_CLOCK_SKEW_ALLOWANCE_NS, DEFAULT_FOLD_SAFETY_MARGIN_NS,
+    DEFAULT_MAX_FLUSH_LIFETIME_NS, SegmentOrigin,
+};
+use ravel_commit::keys;
+use ravel_commit::publish::{self, RetryPolicy};
+use ravel_commit::record::{self, NewCommitRecord};
+use ravel_object_store::fault::{FaultPlan, FaultStore, Occurrence, Op};
+use ravel_object_store::memory::MemoryStore;
+use ravel_object_store::{
+    Capabilities, DelimitedList, GetOutcome, GetRange, ListPage, ObjectMeta, ObjectStoreBackend,
+    PageToken, PutOptions, PutOutcome, StoreError,
+};
+use ravel_types::accounting::{AccountedOp, QueryAccounting};
+use ravel_types::{Signal, TenantHash, TimeRange};
+use uuid::Uuid;
+
+const NS_PER_HOUR: i64 = 3_600_000_000_000;
+const SEAL_MARGIN_NS: i64 =
+    DEFAULT_MAX_FLUSH_LIFETIME_NS + DEFAULT_CLOCK_SKEW_ALLOWANCE_NS + DEFAULT_FOLD_SAFETY_MARGIN_NS;
+
+fn tenant() -> TenantHash {
+    TenantHash([0x73; 16])
+}
+
+/// A `config` at default margins, so the fold's own seal rule matches
+/// [`now_at_seal`] below.
+fn config(shard_count: u32) -> CatalogConfig {
+    CatalogConfig {
+        shard_count,
+        ..Default::default()
+    }
+}
+
+/// `now_ns` at which ingest hour `hour` has just sealed under the default
+/// margins (mirrors `Catalog::fold`'s crate-private `now_at_seal`).
+fn now_at_seal(hour: u32) -> i64 {
+    (i64::from(hour) + 1) * NS_PER_HOUR + SEAL_MARGIN_NS
+}
+
+/// Zero listing padding so window hour math is exact (mirrors
+/// resolve_prefix_traversal's base config), with the chosen shard count.
+fn exact_config(shard_count: u32) -> CatalogConfig {
+    CatalogConfig {
+        shard_count,
+        max_ingest_lag_ns: 0,
+        clock_skew_allowance_ns: 0,
+        ..Default::default()
+    }
+}
+
+/// Force the prefix traversal for the differential cross-check: crossover 0
+/// takes it for any non-empty suffix, ceiling unbounded. Same (default)
+/// margins as [`config`] so both traversals see the identical window.
+fn prefix_config(shard_count: u32) -> CatalogConfig {
+    CatalogConfig {
+        prefix_list_crossover_requests: 0,
+        max_catalog_list_requests: u64::MAX,
+        ..config(shard_count)
+    }
+}
+
+async fn publish_at(
+    store: &dyn ObjectStoreBackend,
+    shard: u32,
+    ingest_hour_bucket: u32,
+    event_ts_ns: i64,
+) -> String {
+    let payload = format!("seg-{shard}-{ingest_hour_bucket}-{event_ts_ns}").into_bytes();
+    let content_hash = *blake3::hash(&payload).as_bytes();
+    let record = record::build(NewCommitRecord {
+        tenant_hash: tenant(),
+        signal: Signal::Metrics,
+        shard,
+        writer_id: Uuid::new_v4(),
+        writer_epoch: 1,
+        writer_seq: 1,
+        object_size: payload.len() as u64,
+        content_hash,
+        sample_count: 1,
+        series_count: 1,
+        min_event_ts_ns: event_ts_ns,
+        max_event_ts_ns: event_ts_ns,
+        min_ingest_ts_ns: event_ts_ns,
+        max_ingest_ts_ns: event_ts_ns,
+        segment_format_version: 1,
+        created_unix_ns: event_ts_ns,
+        ingest_hour_bucket,
+    })
+    .expect("valid record");
+    let data_key = keys::reconstruct_data_key(&record).expect("data key");
+    publish::put_data_object(store, &data_key, Bytes::from(payload))
+        .await
+        .expect("put data object");
+    publish::publish(store, &record, &RetryPolicy::default())
+        .await
+        .expect("publish");
+    data_key
+}
+
+fn hour_mid_ns(hour: u32) -> i64 {
+    i64::from(hour) * NS_PER_HOUR + 5 * 60_000_000_000
+}
+
+/// A store double that records every LIST prefix and every key any LIST
+/// returned, forwarding `list_after` to the inner store's native start-after
+/// so the below-watermark skip is exercised as it is in production.
+#[derive(Clone, Default)]
+struct ListRecord {
+    prefixes: Arc<Mutex<Vec<String>>>,
+    returned_keys: Arc<Mutex<Vec<String>>>,
+}
+impl ListRecord {
+    fn count_for(&self, needle: &str) -> usize {
+        self.prefixes
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|p| p.contains(needle))
+            .count()
+    }
+    fn total(&self) -> usize {
+        self.prefixes.lock().unwrap().len()
+    }
+    fn returned_keys(&self) -> Vec<String> {
+        self.returned_keys.lock().unwrap().clone()
+    }
+}
+struct RecordingStore {
+    inner: Arc<dyn ObjectStoreBackend>,
+    rec: ListRecord,
+}
+impl RecordingStore {
+    fn new(inner: Arc<dyn ObjectStoreBackend>) -> (Arc<Self>, ListRecord) {
+        let rec = ListRecord::default();
+        (
+            Arc::new(RecordingStore {
+                inner,
+                rec: rec.clone(),
+            }),
+            rec,
+        )
+    }
+    fn note(&self, prefix: &str, page: &ListPage) {
+        self.rec.prefixes.lock().unwrap().push(prefix.to_string());
+        let mut keys = self.rec.returned_keys.lock().unwrap();
+        for meta in &page.objects {
+            keys.push(meta.key.clone());
+        }
+    }
+}
+#[async_trait]
+impl ObjectStoreBackend for RecordingStore {
+    async fn put(&self, k: &str, d: Bytes, o: PutOptions) -> Result<PutOutcome, StoreError> {
+        self.inner.put(k, d, o).await
+    }
+    async fn get(&self, k: &str, r: GetRange) -> Result<GetOutcome, StoreError> {
+        self.inner.get(k, r).await
+    }
+    async fn head(&self, k: &str) -> Result<ObjectMeta, StoreError> {
+        self.inner.head(k).await
+    }
+    async fn list(&self, p: &str, t: Option<PageToken>) -> Result<ListPage, StoreError> {
+        let page = self.inner.list(p, t).await?;
+        self.note(p, &page);
+        Ok(page)
+    }
+    async fn list_after(
+        &self,
+        p: &str,
+        start_after: Option<&str>,
+        t: Option<PageToken>,
+    ) -> Result<ListPage, StoreError> {
+        let page = self.inner.list_after(p, start_after, t).await?;
+        self.note(p, &page);
+        Ok(page)
+    }
+    async fn list_delimited(&self, p: &str) -> Result<DelimitedList, StoreError> {
+        self.inner.list_delimited(p).await
+    }
+    async fn delete(&self, k: &str) -> Result<(), StoreError> {
+        self.inner.delete(k).await
+    }
+    fn capabilities(&self) -> Capabilities {
+        Capabilities {
+            multipart: false,
+            ..self.inner.capabilities()
+        }
+    }
+}
+
+/// Differential + exact request count for the folded-tenant warm path.
+#[tokio::test]
+async fn bounded_listing_matches_reference_in_nine_lists() {
+    let shard_count = 8u32;
+    let inner = Arc::new(MemoryStore::new());
+
+    // Sealed region below/at the watermark: hours 998..=1000, some shards.
+    let mut sealed_keys: BTreeSet<String> = BTreeSet::new();
+    for hour in [998u32, 999, 1000] {
+        for shard in 0..shard_count {
+            sealed_keys.insert(publish_at(inner.as_ref(), shard, hour, hour_mid_ns(hour)).await);
+        }
+    }
+    // Fold seals everything through hour 1000 -> watermark 1000.
+    let watermark = 1000u32;
+    let fold_now = now_at_seal(watermark);
+    let fold_catalog = Catalog::new(inner.clone(), config(shard_count)).expect("catalog");
+    let report = fold_catalog
+        .fold(
+            &tenant(),
+            Signal::Metrics,
+            Uuid::new_v4(),
+            fold_now,
+            &[],
+            None,
+        )
+        .await
+        .expect("fold");
+    assert_eq!(
+        report.watermark_hour,
+        Some(watermark),
+        "the fold must seal exactly through hour 1000"
+    );
+
+    // Unsealed tail: 3 hours above the watermark, populated in SOME but not
+    // all (shard, hour) buckets. Several shards have nothing above the
+    // watermark; several hours are empty for a given shard.
+    let mut recent_keys: BTreeSet<String> = BTreeSet::new();
+    let above: &[(u32, u32)] = &[
+        (0, 1001),
+        (0, 1003),
+        (1, 1002),
+        (2, 1001),
+        (2, 1002),
+        (2, 1003),
+        (4, 1003),
+    ];
+    for &(shard, hour) in above {
+        recent_keys.insert(publish_at(inner.as_ref(), shard, hour, hour_mid_ns(hour)).await);
+    }
+
+    // Window covers the sealed region through the unsealed tail. Anchored on
+    // now at hour 1003 so hours 1001..=1003 are the live suffix.
+    let now_ns = i64::from(1003u32) * NS_PER_HOUR + 40 * 60_000_000_000;
+    let range = TimeRange {
+        start_ns: i64::from(998u32) * NS_PER_HOUR,
+        end_ns: now_ns,
+    };
+
+    // Bounded path, through the recording store, with request accounting.
+    let (recording, rec) = RecordingStore::new(inner.clone());
+    let bounded = Catalog::new(recording, config(shard_count)).expect("catalog");
+    let acc = QueryAccounting::new();
+    let (snap, origins, _gens) = bounded
+        .resolve_pruned_with_generations(&tenant(), Signal::Metrics, range, &[], now_ns, None, &acc)
+        .await
+        .expect("bounded resolve");
+
+    // Every published record (sealed and recent) is visible, nothing else.
+    let mut expected: Vec<String> = sealed_keys
+        .iter()
+        .chain(recent_keys.iter())
+        .cloned()
+        .collect();
+    expected.sort();
+    let mut got: Vec<String> = snap
+        .segments
+        .iter()
+        .map(|s| s.data_object_key.clone())
+        .collect();
+    got.sort();
+    assert_eq!(
+        got, expected,
+        "bounded resolve must return every published segment"
+    );
+
+    // Origins: sealed keys came from the snapshot, recent keys from the live
+    // listing. This is what dropping `start_after` would corrupt (a
+    // below-watermark key listed live and tagged Recent).
+    for (segment, origin) in snap.segments.iter().zip(origins.origins.iter()) {
+        let key = &segment.data_object_key;
+        if sealed_keys.contains(key) {
+            assert_eq!(
+                *origin,
+                SegmentOrigin::SealedBelowWatermark,
+                "sealed key must be served from the snapshot, not listed"
+            );
+        } else {
+            assert_eq!(
+                *origin,
+                SegmentOrigin::Recent,
+                "tail key must be listed live"
+            );
+        }
+    }
+
+    // Exactly 8 shard LISTs + 1 erasure LIST = 9, regardless of the empty
+    // (shard, hour) buckets in the tail. The per-(shard, hour) loop would be
+    // 8 shards * 3 hours + 1 = 25.
+    assert_eq!(
+        acc.snapshot().s3_requests(AccountedOp::List),
+        9,
+        "8 bounded shard LISTs + 1 erasure LIST"
+    );
+    assert_eq!(rec.total(), 9, "the store observed exactly 9 LISTs");
+
+    // No below-watermark key is ever listed: the shard LISTs resume strictly
+    // after the watermark via start_after, so no commit record for a sealed
+    // hour is transferred. (Dropping start_after would make the sealed hours'
+    // commit records appear in the listing.) The listed keys are commit-record
+    // keys, so this checks the sealed hour strings, not the data-object keys in
+    // `sealed_keys`.
+    let sealed_hour_markers: Vec<String> = [998u32, 999, 1000]
+        .iter()
+        .map(|h| format!("/{}/", keys::ingest_hour_string(*h)))
+        .collect();
+    let listed = rec.returned_keys();
+    assert!(!listed.is_empty(), "the tail must have been listed");
+    for key in &listed {
+        for marker in &sealed_hour_markers {
+            assert!(
+                !key.contains(marker.as_str()),
+                "a below-watermark hour ({marker}) must never appear in the live listing: {key}"
+            );
+        }
+    }
+
+    // Cross-check: the independent prefix traversal returns the identical
+    // snapshot and origins over the same corpus.
+    let prefix = Catalog::new(inner.clone(), prefix_config(shard_count)).expect("catalog");
+    let (snap_px, origins_px, _g) = prefix
+        .resolve_pruned_with_generations(
+            &tenant(),
+            Signal::Metrics,
+            range,
+            &[],
+            now_ns,
+            None,
+            &QueryAccounting::new(),
+        )
+        .await
+        .expect("prefix resolve");
+    assert_eq!(snap, snap_px, "bounded and prefix traversals must agree");
+    assert_eq!(origins, origins_px, "origins must agree across traversals");
+}
+
+/// A bounded shard LIST pages across a small page size and stops at the first
+/// key whose hour is past the window end.
+#[tokio::test]
+async fn bounded_shard_list_paginates_and_stops_at_window_end() {
+    let inner = Arc::new(MemoryStore::with_page_size(2));
+    // Shard 0: two in-window hours with two writers each, then a bucket past
+    // the window end. Sorted key order within the shard is 1001*, 1002*, 1005*.
+    publish_at(inner.as_ref(), 0, 1001, hour_mid_ns(1001)).await;
+    publish_at(inner.as_ref(), 0, 1001, hour_mid_ns(1001) + 60_000_000_000).await;
+    publish_at(inner.as_ref(), 0, 1002, hour_mid_ns(1002)).await;
+    publish_at(inner.as_ref(), 0, 1002, hour_mid_ns(1002) + 60_000_000_000).await;
+    // Past the window end (hour 1005 > 1002): must trigger the stop, and must
+    // not be resolved into the snapshot.
+    let past_end = publish_at(inner.as_ref(), 0, 1005, hour_mid_ns(1005)).await;
+    publish_at(inner.as_ref(), 0, 1005, hour_mid_ns(1005) + 60_000_000_000).await;
+
+    // No fold: the whole window is listed live. now anchored at hour 1002.
+    let now_ns = i64::from(1002u32) * NS_PER_HOUR + 30 * 60_000_000_000;
+    let range = TimeRange {
+        start_ns: i64::from(1000u32) * NS_PER_HOUR,
+        end_ns: now_ns,
+    };
+
+    let (recording, rec) = RecordingStore::new(inner.clone());
+    let catalog = Catalog::new(recording, exact_config(1)).expect("catalog");
+    let snapshot = catalog
+        .resolve(&tenant(), Signal::Metrics, range, &[], now_ns)
+        .await
+        .expect("resolve");
+
+    assert_eq!(
+        snapshot.segments.len(),
+        4,
+        "only the four in-window segments resolve; the hour-1005 buckets are past the window"
+    );
+    assert!(
+        !snapshot
+            .segments
+            .iter()
+            .any(|s| s.data_object_key == past_end),
+        "the past-window bucket must not leak into the snapshot"
+    );
+
+    let shard_prefix = keys::commit_shard_prefix(&tenant(), Signal::Metrics, 0).unwrap();
+    // Pages of size 2: [1001,1001], [1002,1002], then the page that first
+    // yields 1005 (past the end) stops the scan. Three shard LISTs; without
+    // the stop-at-end paging the scan would fetch a fourth (empty) page.
+    assert_eq!(
+        rec.count_for(&shard_prefix),
+        3,
+        "the bounded shard LIST pages and stops at the first past-window key"
+    );
+}
+
+/// The pending-erasure LIST is issued concurrently with the shard fan-out:
+/// all nine LISTs (8 shards + del) can be held simultaneously.
+#[tokio::test]
+async fn erasure_list_overlaps_shard_fanout() {
+    let shard_count = 8u32;
+    let inner = Arc::new(MemoryStore::new());
+    // One record per shard, all in one unsealed hour, so every shard is listed.
+    for shard in 0..shard_count {
+        publish_at(inner.as_ref(), shard, 1001, hour_mid_ns(1001)).await;
+    }
+
+    // Hold every LIST call, unconditionally, before it reaches the backend.
+    let store = Arc::new(FaultStore::new(
+        Arc::clone(&inner) as Arc<dyn ObjectStoreBackend>,
+        FaultPlan::empty(),
+    ));
+    let gate = store.hold(Op::List, None, Occurrence::Always);
+    let catalog = Arc::new(Catalog::new(store, exact_config(shard_count)).expect("catalog"));
+
+    let now_ns = i64::from(1001u32) * NS_PER_HOUR + 40 * 60_000_000_000;
+    let range = TimeRange {
+        start_ns: i64::from(1000u32) * NS_PER_HOUR,
+        end_ns: now_ns,
+    };
+
+    let resolver = Arc::clone(&catalog);
+    let handle = tokio::spawn(async move {
+        resolver
+            .resolve(&tenant(), Signal::Metrics, range, &[], now_ns)
+            .await
+    });
+
+    // Concurrency: the erasure LIST and all 8 shard LISTs are in flight at
+    // once, so nine calls are held simultaneously. If the erasure LIST were
+    // awaited after the fan-out, holding the 8 shard LISTs would stall the
+    // fan-out and the erasure LIST would never be issued, so this would time
+    // out at eight.
+    tokio::time::timeout(std::time::Duration::from_secs(10), gate.wait_until_held(9))
+        .await
+        .expect("all nine LISTs (8 shards + erasure) must be held concurrently");
+
+    let details = gate.held_details();
+    assert_eq!(details.len(), 9, "exactly nine LISTs held at once");
+    let del_held = details
+        .iter()
+        .filter(|(_, _, key)| key.contains("/del/"))
+        .count();
+    assert_eq!(del_held, 1, "the erasure LIST is one of the nine held");
+
+    // Release every held LIST and let the resolve finish.
+    for id in gate.held() {
+        gate.release(id);
+    }
+    let snapshot = handle.await.expect("join").expect("resolve");
+    assert_eq!(
+        snapshot.segments.len(),
+        shard_count as usize,
+        "every shard's record resolves once the LISTs are released"
+    );
+}

--- a/crates/ravel-catalog/tests/resolve_prefix_traversal.rs
+++ b/crates/ravel-catalog/tests/resolve_prefix_traversal.rs
@@ -170,6 +170,18 @@ impl ObjectStoreBackend for CountingStore {
         *self.log.n.lock().unwrap() += 1;
         self.inner.list(p, t).await
     }
+    async fn list_after(
+        &self,
+        p: &str,
+        start_after: Option<&str>,
+        t: Option<PageToken>,
+    ) -> Result<ListPage, StoreError> {
+        // Count a start-after page the same as a plain page, and forward to
+        // the inner store's native start-after so a below-watermark skip is
+        // measured as it happens in production, not paged over client-side.
+        *self.log.n.lock().unwrap() += 1;
+        self.inner.list_after(p, start_after, t).await
+    }
     async fn list_delimited(&self, p: &str) -> Result<DelimitedList, StoreError> {
         *self.log.n.lock().unwrap() += 1;
         self.inner.list_delimited(p).await
@@ -269,9 +281,10 @@ async fn differential_paths_return_identical_snapshots() {
     );
 }
 
-/// (b) An epoch-width window issues O(objects) requests on the prefix path,
-/// not one-per-hour. The per-bucket loop over the same window issues one LIST
-/// per bucket. Numbers stated so a reader sees the point.
+/// (b) An epoch-width window issues O(objects) requests on BOTH paths now
+/// (issue #730): the non-prefix path lists one bounded LIST per shard, not one
+/// per (shard, hour), so a 5000-hour window with 4950 empty buckets no longer
+/// amplifies. Numbers stated so a reader sees the point.
 #[tokio::test]
 async fn epoch_window_issues_object_bounded_requests() {
     // Sparse corpus: 50 hours each with one shard-0 record => 50 commit
@@ -307,22 +320,21 @@ async fn epoch_window_issues_object_bounded_requests() {
     assert_eq!(snap_pb, snap_px, "same result on both paths");
     assert_eq!(snap_px.segments.len(), 50);
 
-    // Per-bucket = one LIST per (shard, hour) bucket = 5000 for a 5000-hour
-    // window. Prefix = one page per page_size(1000) objects + terminal =
-    // floor(50/1000)+1 = 1. Independent of the 4950 empty buckets. Each resolve
-    // also issues exactly one `del/` LIST for pending erasure (ADR-0064
-    // decision 2), so both paths carry a +1.
+    // Both paths now list one bounded LIST per shard (shard_count 1 => 1
+    // shard LIST), the 50 objects fitting one page_size(1000) page, plus one
+    // `del/` LIST per resolve for pending erasure (ADR-0064 decision 2) = 2.
+    // Neither path pages the 4950 empty buckets: the non-prefix path issues
+    // one bounded LIST per shard (issue #730), not one per (shard, hour).
     assert_eq!(
         log_pb.count(),
-        5001,
-        "per-bucket loop issues one LIST per bucket (window width in hours) plus the del/ LIST"
+        2,
+        "the non-prefix path issues one bounded LIST per shard plus the del/ LIST, \
+         independent of the 4950 empty buckets"
     );
     assert_eq!(
         log_px.count(),
         2,
-        "prefix scan issues O(objects/page_size) LISTs plus the del/ LIST; here 50 objects at \
-         page_size 1000 = 1 page + 1 del/ LIST, versus the per-bucket loop's {}",
-        log_pb.count()
+        "the prefix scan issues one bounded LIST per shard plus the del/ LIST"
     );
 }
 

--- a/crates/ravel-catalog/tests/snapshot_resolve.rs
+++ b/crates/ravel-catalog/tests/snapshot_resolve.rs
@@ -184,6 +184,18 @@ impl ObjectStoreBackend for CountingStore {
         self.log.lists.lock().unwrap().push(prefix.to_string());
         self.inner.list(prefix, page).await
     }
+    async fn list_after(
+        &self,
+        prefix: &str,
+        start_after: Option<&str>,
+        page: Option<PageToken>,
+    ) -> Result<ListPage, StoreError> {
+        // Log the listed prefix and forward to the inner store's native
+        // start-after so the below-watermark skip is exercised as it is in
+        // production (resolve lists one bounded LIST per shard, issue #730).
+        self.log.lists.lock().unwrap().push(prefix.to_string());
+        self.inner.list_after(prefix, start_after, page).await
+    }
     async fn list_delimited(&self, prefix: &str) -> Result<DelimitedList, StoreError> {
         self.inner.list_delimited(prefix).await
     }
@@ -378,11 +390,14 @@ async fn hours_above_watermark_are_listed_not_snapshot_served() {
         2,
         "both the sealed and the still-open segment must be visible"
     );
-    let hot_prefix =
-        keys::commit_shard_hour_prefix(&tenant(), Signal::Metrics, 0, base_hour + 1).unwrap();
+    // The resolve lists one bounded LIST per shard (issue #730), resuming
+    // strictly after the watermark, so the shard prefix (not the per-hour
+    // prefix) is what reaches the store; the still-open hour above the
+    // watermark falls inside that shard's bounded scan.
+    let shard_prefix = keys::commit_shard_prefix(&tenant(), Signal::Metrics, 0).unwrap();
     assert!(
-        log.list_count_for(&hot_prefix) >= 1,
-        "the hour above the watermark must still be listed"
+        log.list_count_for(&shard_prefix) >= 1,
+        "the hour above the watermark must still be listed live, via the shard's bounded LIST"
     );
 }
 
@@ -413,7 +428,10 @@ async fn absent_head_falls_back_to_full_listing() {
         .await
         .expect("resolve falls back cleanly when no snapshot has ever been folded");
     assert_eq!(snapshot.segments.len(), 1);
-    let prefix = keys::commit_shard_hour_prefix(&tenant(), Signal::Metrics, 0, hour).unwrap();
+    // No fold has run, so the whole window is listed live: the resolve lists
+    // one bounded LIST per shard (issue #730), so the shard prefix reaches the
+    // store, not the per-hour prefix.
+    let prefix = keys::commit_shard_prefix(&tenant(), Signal::Metrics, 0).unwrap();
     assert!(log.list_count_for(&prefix) >= 1);
 }
 

--- a/crates/ravel-catalog/tests/window_ceiling.rs
+++ b/crates/ravel-catalog/tests/window_ceiling.rs
@@ -272,9 +272,14 @@ async fn oversized_corpus_trips_the_runtime_cap() {
         }
         other => panic!("expected CatalogError::WindowTooWide, got {other:?}"),
     }
+    // The runtime cap bounds the prefix SCAN at the ceiling. The pending-
+    // erasure LIST (ADR-0064) is a separate, always-one LIST that now overlaps
+    // the scan (issue #730), so it is issued once even on the refuse path;
+    // hence the observed total is at most ceiling + 1, not ceiling.
     assert!(
-        (log.list_count() as u64) <= ceiling,
-        "the runtime cap bounds LISTs at the ceiling ({ceiling}); issued {}",
+        (log.list_count() as u64) <= ceiling + 1,
+        "the runtime cap bounds the prefix scan at the ceiling ({ceiling}), plus \
+         the one overlapping erasure LIST; issued {}",
         log.list_count()
     );
 }

--- a/crates/ravel-object-store/src/fault.rs
+++ b/crates/ravel-object-store/src/fault.rs
@@ -947,6 +947,29 @@ impl<S: ObjectStoreBackend> ObjectStoreBackend for FaultStore<S> {
         }
     }
 
+    async fn list_after(
+        &self,
+        prefix: &str,
+        start_after: Option<&str>,
+        page: Option<PageToken>,
+    ) -> Result<ListPage, StoreError> {
+        self.gate_hold(Op::List, prefix).await;
+        match self.resolve(Op::List, prefix) {
+            None => self.inner.list_after(prefix, start_after, page).await,
+            Some(ScriptedFault::DuplicateDelivery) => {
+                self.inner.list_after(prefix, start_after, page).await?;
+                Err(duplicate_delivery_error())
+            }
+            Some(ScriptedFault::Timeout) => Err(StoreError::Timeout),
+            Some(ScriptedFault::Throttled { retry_after_ms }) => {
+                Err(StoreError::Throttled { retry_after_ms })
+            }
+            Some(ScriptedFault::Transient(msg)) => Err(StoreError::Transient(msg)),
+            Some(ScriptedFault::Permanent(msg)) => Err(StoreError::Permanent(msg)),
+            Some(_) => Err(not_applicable("list_after")),
+        }
+    }
+
     async fn list_delimited(&self, prefix: &str) -> Result<DelimitedList, StoreError> {
         self.gate_hold(Op::List, prefix).await;
         match self.resolve(Op::List, prefix) {

--- a/crates/ravel-object-store/src/instrument.rs
+++ b/crates/ravel-object-store/src/instrument.rs
@@ -541,6 +541,19 @@ impl<S: ObjectStoreBackend> ObjectStoreBackend for InstrumentedStore<S> {
         result
     }
 
+    async fn list_after(
+        &self,
+        prefix: &str,
+        start_after: Option<&str>,
+        page: Option<PageToken>,
+    ) -> Result<ListPage, StoreError> {
+        let start = self.clock.now_nanos();
+        let result = self.inner.list_after(prefix, start_after, page).await;
+        // A start-after page is still one LIST, counted the same as `list`.
+        self.record(StoreOp::List, start, 0, &result);
+        result
+    }
+
     async fn list_delimited(&self, prefix: &str) -> Result<DelimitedList, StoreError> {
         let start = self.clock.now_nanos();
         let result = self.inner.list_delimited(prefix).await;

--- a/crates/ravel-object-store/src/kms_routing.rs
+++ b/crates/ravel-object-store/src/kms_routing.rs
@@ -280,6 +280,15 @@ impl ObjectStoreBackend for KmsRoutingStore {
         self.default.list(prefix, page).await
     }
 
+    async fn list_after(
+        &self,
+        prefix: &str,
+        start_after: Option<&str>,
+        page: Option<PageToken>,
+    ) -> Result<ListPage, StoreError> {
+        self.default.list_after(prefix, start_after, page).await
+    }
+
     async fn list_delimited(&self, prefix: &str) -> Result<DelimitedList, StoreError> {
         self.default.list_delimited(prefix).await
     }

--- a/crates/ravel-object-store/src/lib.rs
+++ b/crates/ravel-object-store/src/lib.rs
@@ -448,6 +448,40 @@ pub trait ObjectStoreBackend: Send + Sync + 'static {
     /// Pass `None` for the first page; follow `ListPage::next` until `None`.
     async fn list(&self, prefix: &str, page: Option<PageToken>) -> Result<ListPage, StoreError>;
 
+    /// Like [`list`](Self::list), but the listing begins strictly after
+    /// `start_after` in key order (S3 `start-after` semantics): every returned
+    /// key compares strictly greater than `start_after`, in the same
+    /// lexicographic key order, with the same pagination and cross-page
+    /// guarantee as `list`. `start_after == None` is identical to `list`.
+    /// `start_after` need not name an existing key; it is typically a prefix
+    /// string that sorts before the first key the caller wants, so a caller
+    /// can skip a whole key sub-range server-side without paging through it.
+    ///
+    /// The default implementation lists from `prefix` and drops keys
+    /// `<= start_after`; a backend whose store supports a native start-after
+    /// (S3 `list_with_offset`, the in-memory ordered map) overrides it so the
+    /// dropped keys are never transferred. Overriding is a performance
+    /// property only: the visible result is identical either way.
+    async fn list_after(
+        &self,
+        prefix: &str,
+        start_after: Option<&str>,
+        page: Option<PageToken>,
+    ) -> Result<ListPage, StoreError> {
+        let page = self.list(prefix, page).await?;
+        match start_after {
+            Some(after) => Ok(ListPage {
+                objects: page
+                    .objects
+                    .into_iter()
+                    .filter(|meta| meta.key.as_str() > after)
+                    .collect(),
+                next: page.next,
+            }),
+            None => Ok(page),
+        }
+    }
+
     /// One-level listing with delimiter `/`.
     async fn list_delimited(&self, prefix: &str) -> Result<DelimitedList, StoreError>;
 
@@ -495,6 +529,15 @@ impl<T: ObjectStoreBackend + ?Sized> ObjectStoreBackend for Arc<T> {
 
     async fn list(&self, prefix: &str, page: Option<PageToken>) -> Result<ListPage, StoreError> {
         (**self).list(prefix, page).await
+    }
+
+    async fn list_after(
+        &self,
+        prefix: &str,
+        start_after: Option<&str>,
+        page: Option<PageToken>,
+    ) -> Result<ListPage, StoreError> {
+        (**self).list_after(prefix, start_after, page).await
     }
 
     async fn list_delimited(&self, prefix: &str) -> Result<DelimitedList, StoreError> {

--- a/crates/ravel-object-store/src/memory.rs
+++ b/crates/ravel-object-store/src/memory.rs
@@ -311,6 +311,47 @@ impl ObjectStoreBackend for MemoryStore {
         Ok(ListPage { objects: out, next })
     }
 
+    async fn list_after(
+        &self,
+        prefix: &str,
+        start_after: Option<&str>,
+        page: Option<PageToken>,
+    ) -> Result<ListPage, StoreError> {
+        let objects = self.objects.read();
+        // Resume point: strictly after the page token when paging, else
+        // strictly after `start_after` on the first page (skipping the
+        // sub-range server-side rather than transferring and dropping it),
+        // else the prefix itself. The larger of a page token and
+        // `start_after` is always the page token (it is a key already past
+        // `start_after`), so a present page token subsumes `start_after`.
+        let (start_key, skip_first_if_equal) = match (&page, start_after) {
+            (Some(PageToken(after)), _) => (after.clone(), true),
+            // `start_after` below the prefix cannot exclude any key under it,
+            // so fall back to listing from the prefix.
+            (None, Some(after)) if after >= prefix => (after.to_string(), true),
+            (None, _) => (prefix.to_string(), false),
+        };
+        let mut out = Vec::with_capacity(self.page_size.min(64));
+        for (key, entry) in objects.range(start_key.clone()..) {
+            if skip_first_if_equal && key == &start_key {
+                continue;
+            }
+            if !key.starts_with(prefix) {
+                break;
+            }
+            out.push(entry.meta(key));
+            if out.len() == self.page_size {
+                break;
+            }
+        }
+        let next = if out.len() == self.page_size {
+            out.last().map(|m| PageToken(m.key.clone()))
+        } else {
+            None
+        };
+        Ok(ListPage { objects: out, next })
+    }
+
     async fn list_delimited(&self, prefix: &str) -> Result<DelimitedList, StoreError> {
         let objects = self.objects.read();
         let mut direct = Vec::new();

--- a/crates/ravel-object-store/src/s3.rs
+++ b/crates/ravel-object-store/src/s3.rs
@@ -942,6 +942,44 @@ impl ObjectStoreBackend for S3Store {
         Ok(ListPage { objects: out, next })
     }
 
+    async fn list_after(
+        &self,
+        prefix: &str,
+        start_after: Option<&str>,
+        page: Option<PageToken>,
+    ) -> Result<ListPage, StoreError> {
+        let prefix_path = prefix_of(prefix);
+        // A page token resumes strictly after the previous page's last key;
+        // on the first page `start_after` plays the same role. Both map to
+        // `object_store`'s `list_with_offset`, whose offset is exclusive
+        // (ListObjectsV2 `start-after`), so keys equal to the offset are
+        // skipped server-side and never transferred. A present page token is
+        // always past `start_after`, so it takes precedence.
+        let offset = match (&page, start_after) {
+            (Some(PageToken(after)), _) => Some(Path::from(after.as_str())),
+            (None, Some(after)) => Some(Path::from(after)),
+            (None, None) => None,
+        };
+        let mut stream = match &offset {
+            Some(offset) => self.store.list_with_offset(prefix_path.as_ref(), offset),
+            None => self.store.list(prefix_path.as_ref()),
+        };
+        let mut out = Vec::with_capacity(self.page_size.min(1024));
+        while out.len() < self.page_size {
+            match stream.next().await {
+                Some(Ok(meta)) => out.push(map_meta(meta)?),
+                Some(Err(e)) => return Err(map_error_common(e)),
+                None => break,
+            }
+        }
+        let next = if out.len() == self.page_size {
+            out.last().map(|m| PageToken(m.key.clone()))
+        } else {
+            None
+        };
+        Ok(ListPage { objects: out, next })
+    }
+
     async fn list_delimited(&self, prefix: &str) -> Result<DelimitedList, StoreError> {
         let prefix_path = prefix_of(prefix);
         let result = self

--- a/crates/ravel-object-store/src/scheduling.rs
+++ b/crates/ravel-object-store/src/scheduling.rs
@@ -578,6 +578,19 @@ impl ObjectStoreBackend for ScheduledHandle {
         result
     }
 
+    async fn list_after(
+        &self,
+        prefix: &str,
+        start_after: Option<&str>,
+        page: Option<PageToken>,
+    ) -> Result<ListPage, StoreError> {
+        let _permit = self.scheduler.acquire(self.class).await;
+        let start = self.clock.now_nanos();
+        let result = self.inner.list_after(prefix, start_after, page).await;
+        self.record(StoreOp::List, start, 0, &result);
+        result
+    }
+
     async fn list_delimited(&self, prefix: &str) -> Result<DelimitedList, StoreError> {
         let _permit = self.scheduler.acquire(self.class).await;
         let start = self.clock.now_nanos();

--- a/crates/ravel-object-store/tests/contract.rs
+++ b/crates/ravel-object-store/tests/contract.rs
@@ -37,6 +37,7 @@ async fn run_contract_suite(store: &dyn ObjectStoreBackend, root: &str) {
     assert_cas_version_semantics(store, &format!("{root}/cas/")).await;
     assert_range_and_suffix_reads(store, &format!("{root}/range/")).await;
     assert_paginated_listing_completeness(store, &format!("{root}/list/")).await;
+    assert_start_after_listing(store, &format!("{root}/list-after/")).await;
     assert_delimited_listing(store, &format!("{root}/delim/")).await;
     assert_idempotent_delete(store, &format!("{root}/delete/")).await;
     assert_upload_checksum_verification(store, &format!("{root}/checksum/")).await;
@@ -251,6 +252,90 @@ async fn assert_paginated_listing_completeness(store: &dyn ObjectStoreBackend, p
     assert_eq!(
         all_keys, keys,
         "list_all must agree with the manual pagination loop"
+    );
+}
+
+/// `list_after` contract (docs/object-store-contract.md): every returned key
+/// compares strictly greater than `start_after`, in the same lexicographic
+/// order and with the same pagination as `list`; `None` is identical to
+/// `list`; a `start_after` that sorts below the prefix excludes nothing.
+/// Runs against every backend the suite covers, so it pins the native
+/// start-after of `MemoryStore` (at both page sizes) and `S3Store` (against a
+/// real bucket, when configured) as well as the default filter path any other
+/// backend inherits.
+async fn assert_start_after_listing(store: &dyn ObjectStoreBackend, prefix: &str) {
+    let mut keys: Vec<String> = ["a", "b", "c", "d", "e"]
+        .iter()
+        .map(|s| format!("{prefix}{s}"))
+        .collect();
+    keys.sort();
+    for key in &keys {
+        store
+            .put(key, Bytes::from_static(b"x"), PutOptions::default())
+            .await
+            .expect("put");
+    }
+
+    // Drain a full `list_after` scan through the page-token loop so the
+    // assertion holds at any page size.
+    async fn drain_after(
+        store: &dyn ObjectStoreBackend,
+        prefix: &str,
+        start_after: Option<&str>,
+    ) -> Vec<String> {
+        let mut seen = std::collections::HashSet::new();
+        let mut ordered = Vec::new();
+        let mut token = None;
+        loop {
+            let page = store
+                .list_after(prefix, start_after, token)
+                .await
+                .expect("list_after page");
+            for meta in &page.objects {
+                if seen.insert(meta.key.clone()) {
+                    ordered.push(meta.key.clone());
+                }
+            }
+            match page.next {
+                Some(next) => token = Some(next),
+                None => break,
+            }
+        }
+        ordered
+    }
+
+    // Strictly greater than an existing key: the key itself is excluded.
+    let after_c = format!("{prefix}c");
+    assert_eq!(
+        drain_after(store, prefix, Some(&after_c)).await,
+        vec![format!("{prefix}d"), format!("{prefix}e")],
+        "list_after returns only keys strictly greater than start_after"
+    );
+
+    // `start_after` need not be an existing key: the shard-hour prefix strings
+    // Ravel passes sort before the first key under them, so nothing is skipped
+    // when the marker sorts below the prefix.
+    let before_all = format!("{prefix}");
+    assert_eq!(
+        drain_after(store, prefix, Some(&before_all)).await,
+        keys,
+        "a start_after at/below the prefix excludes no key under it"
+    );
+
+    // `None` is identical to `list`.
+    assert_eq!(
+        drain_after(store, prefix, None).await,
+        keys,
+        "list_after(None) matches list"
+    );
+
+    // Past the last key: empty.
+    let after_last = format!("{prefix}z");
+    assert!(
+        drain_after(store, prefix, Some(&after_last))
+            .await
+            .is_empty(),
+        "a start_after past the last key returns nothing"
     );
 }
 

--- a/crates/ravel-object-store/tests/contract.rs
+++ b/crates/ravel-object-store/tests/contract.rs
@@ -315,9 +315,8 @@ async fn assert_start_after_listing(store: &dyn ObjectStoreBackend, prefix: &str
     // `start_after` need not be an existing key: the shard-hour prefix strings
     // Ravel passes sort before the first key under them, so nothing is skipped
     // when the marker sorts below the prefix.
-    let before_all = format!("{prefix}");
     assert_eq!(
-        drain_after(store, prefix, Some(&before_all)).await,
+        drain_after(store, prefix, Some(prefix)).await,
         keys,
         "a start_after at/below the prefix excludes no key under it"
     );

--- a/docs/catalog-and-mvcc.md
+++ b/docs/catalog-and-mvcc.md
@@ -823,9 +823,13 @@ windows. Instead:
   one-object-worth-of-data into thousands of empty LISTs.
 - The prefix scan carries a runtime LIST cap at the same ceiling: it aborts
   with `WindowTooWide` before issuing a page that would take it over, so a
-  single resolve still never issues more than `max_catalog_list_requests`
-  catalog LISTs. Only a scan whose *actual object volume* is unsustainable is
-  refused; a wide-but-sparse window is served.
+  single resolve's scan never issues more than `max_catalog_list_requests`
+  catalog LISTs. The ADR-0064 pending-erasure LIST is one further LIST
+  outside that cap: it starts alongside the scan and is issued once even
+  when the scan is refused, so a resolve issues at most
+  `max_catalog_list_requests + 1` LISTs in total. Only a scan whose *actual
+  object volume* is unsustainable is refused; a wide-but-sparse window is
+  served.
 
 The refusal is never a silent narrowing to a partial result (exact semantics
 by default). The typed error carries the count and the limit so the caller

--- a/docs/catalog-and-mvcc.md
+++ b/docs/catalog-and-mvcc.md
@@ -271,7 +271,7 @@ and the CAS read/write helpers.
   zero-padded 4 digits.
 - Compaction records, rewrite records, and the retention tombstone live in
   the same `c/<shard>/<ingest_hour>/` prefix as L0 commit records, so the
-  existing one-LIST-per-bucket resolution path discovers every shape without
+  per-shard bounded resolution LIST discovers every shape in one pass, without
   a second LIST. Filenames are disjoint by construction:
   `<writer_id>.<epoch>.<seq>.cmt` (L0 commit), `l1.<input_set_hash16>.cmt`
   (compaction record), `rw.<input_set_hash16>.cmt` (selective-erasure rewrite
@@ -288,7 +288,8 @@ and the CAS read/write helpers.
 - Selective-erasure request and completion records (ADR-0064 decision 1) live
   under a separate `t/<tenant_hash>/<signal>/del/` prefix, not in `c/`, so the
   bucket-resolution LIST never sees them; the resolver LISTs `del/` once per
-  resolve to attach pending predicates (decision 2). A `.dreq` is written
+  resolve to attach pending predicates (decision 2), concurrently with the
+  shard fan-out (issue #730). A `.dreq` is written
   `CreateIfAbsent`, is immutable, necessarily names the subject, and is deleted
   after its `.done` exists plus the protection horizon (decision 5). A `.done`
   is written `CreateIfAbsent`, is immutable, carries no plaintext subject
@@ -679,23 +680,30 @@ carries them as a comma-separated list in `x-ravel-commit-token`.
    ingest_hour bucket overlapping `[range.start_ns - max_ingest_lag, now_ns +
    clock_skew_allowance]` (max_ingest_lag default 2 h, clock_skew_allowance
    default 5 m, config). Two traversals produce the identical key set
-   (ADR-0056); resolve picks between them on the width of the listing suffix:
-   - **Per-bucket loop** (narrow/warm windows): LIST
-     `t/<th>/m/c/<shard>/<hour>/` per bucket (paginated; callers dedup keys).
-     Cost `shard_count * hours`, one LIST per bucket, empty buckets included.
-     Prunes best behind a folded snapshot watermark, which shortens the listed
-     suffix to the post-watermark buckets.
+   (ADR-0056); resolve picks between them on the width of the listing suffix.
+   Both issue one bounded LIST per shard over `t/<th>/m/c/<shard>/`, resuming
+   strictly after the watermark hour via the store's `start_after`
+   (`list_after`, the shard-hour prefix for the first listed hour sorts before
+   every key at or above it), so a folded snapshot's sealed hours below the
+   watermark are skipped server-side rather than paged through. Both group the
+   returned keys client-side by `(shard, ingest_hour)` and keep the buckets in
+   the window; a shard's below-watermark history is never listed by either
+   (issue #730):
+   - **Bounded per-shard fan-out** (narrow/warm windows): the per-shard LISTs
+     run concurrently, and each stops paging at the first key whose hour is
+     past the window end (the `YYYYMMDDTHH` hour strings sort chronologically,
+     so once a past-window key appears every later key in the shard is too).
+     Cost one LIST per shard for the hours above the watermark (plus pagination
+     for a dense tail), independent of how many hours or empty buckets the
+     window spans.
    - **Prefix scan** (wide windows, at or above
-     `prefix_list_crossover_requests` suffix buckets, default 720): one drained
-     recursive LIST per shard over `t/<th>/m/c/<shard>/` (paginated), grouping
-     the returned keys client-side by `(shard, ingest_hour)` and keeping the
-     buckets in the window. Cost `O(objects / page_size)`, independent of
-     window width, so an epoch-width window over a sparse tenant costs a
-     handful of pages instead of one LIST per empty hour. The store's LIST
-     takes only a prefix and a continuation token (no start-after), so the scan
-     reads every key in the shard subtree, including hours the window excludes;
-     those are dropped client-side.
-   Both traversals then partition the keys identically (step 2 onward).
+     `prefix_list_crossover_requests` suffix buckets, default 720): the
+     per-shard LISTs drain sequentially under a page-by-page request cap
+     (`max_catalog_list_requests`), so a pathologically wide window is refused
+     deterministically rather than fanning out unboundedly. Cost
+     `O(objects above the watermark / page_size)`.
+   Both traversals produce the identical key set and partition it identically
+   (step 2 onward).
 2. Partition the listed keys by shape (L0 commit record, compaction
    record, selective-erasure rewrite record, tombstone; ADR-0018, ADR-0019,
    ADR-0064). A key matching none of
@@ -751,8 +759,11 @@ carries them as a comma-separated list in `x-ravel-commit-token`.
    was retired, not lost). Neither found after one retry: error
    `unsatisfiable token`, surfaced as 5xx.
 6. Attach pending selective-erasure predicates (ADR-0064 decision 2). Once
-   per resolve -- independent of the per-bucket fan-out and of whether any
-   physical rewrite has run -- LIST `t/<th>/<sig>/del/` exactly once. For
+   per resolve -- independent of whether any physical rewrite has run -- LIST
+   `t/<th>/<sig>/del/` exactly once. This LIST is started before the shard
+   fan-out and joined with it, so its round trip overlaps the bucket LISTs in
+   one wave rather than following them (issue #730); it still completes before
+   the snapshot is constructed, so the visibility bound below is unchanged. For
    every `.dreq` erasure request found, decode and structurally validate it
    and verify its observed key against its own identity fields (ADR-0010 §7),
    then attach it to the snapshot's `pending_erasure`. `.done` completion
@@ -792,22 +803,24 @@ stay discoverable via the `now`-anchored upper bound.
 The window's upper bound is anchored on `now_ns`, not on `range.end_ns`, so a
 client-supplied `range.start_ns` near the epoch spans one bucket per (shard,
 ingest_hour) from that start all the way to the current hour, regardless of
-how narrow `range.end_ns` is. The per-bucket loop's cost for that is
-`shard_count * hour_buckets`, growing by one every wall-clock hour; the
-prefix scan collapses it to `O(objects / page_size)`, which is exactly why
-resolve switches to the prefix scan for wide windows (ADR-0056).
+how narrow `range.end_ns` is. Both traversals cost one bounded LIST per shard
+for the hours above the watermark (`O(objects above the watermark /
+page_size)`), so a wide-but-sparse window no longer pays one LIST per empty
+hour; resolve switches to the prefix scan for wide windows only for its
+sequential page-by-page request cap (ADR-0056).
 
 `Catalog::estimated_catalog_requests` still reports the per-bucket worst case
 `shard_count * hour_buckets + SNAPSHOT_WINDOW_REQUESTS_UPPER_BOUND`
 (ADR-0044 decision 3): it is a true upper envelope of whichever
-traversal runs (the prefix scan issues strictly fewer requests than the
-per-bucket loop it replaces) and is threaded into the cost accounting. It is
-no longer the admission gate for wide windows. Instead:
+traversal runs (both bounded paths issue at most one LIST per shard per page
+of real objects, strictly fewer than the per-bucket worst case) and is
+threaded into the cost accounting. It is no longer the admission gate for wide
+windows. Instead:
 
-- A window whose per-bucket cost would exceed
+- A window whose per-bucket worst case would exceed
   `CatalogConfig::max_catalog_list_requests` (default 100,000) is routed to
-  the prefix scan rather than refused, because the prefix scan does not
-  amplify one-object-worth-of-data into thousands of empty LISTs.
+  the prefix scan rather than refused, because neither bounded path amplifies
+  one-object-worth-of-data into thousands of empty LISTs.
 - The prefix scan carries a runtime LIST cap at the same ceiling: it aborts
   with `WindowTooWide` before issuing a page that would take it over, so a
   single resolve still never issues more than `max_catalog_list_requests`

--- a/docs/object-store-contract.md
+++ b/docs/object-store-contract.md
@@ -20,6 +20,9 @@ pub trait ObjectStoreBackend: Send + Sync + 'static {
     async fn head(&self, key: &str) -> Result<ObjectMeta, StoreError>;
     /// Paginated recursive prefix listing, lexicographic order.
     async fn list(&self, prefix: &str, page: Option<PageToken>) -> Result<ListPage, StoreError>;
+    /// As list, but begins strictly after start_after in key order.
+    async fn list_after(&self, prefix: &str, start_after: Option<&str>, page: Option<PageToken>)
+        -> Result<ListPage, StoreError>;
     /// One-level listing: entries directly under prefix plus common sub-prefixes.
     async fn list_delimited(&self, prefix: &str) -> Result<DelimitedList, StoreError>;
     async fn delete(&self, key: &str) -> Result<(), StoreError>; // idempotent: NotFound => Ok
@@ -75,6 +78,19 @@ alerts differently (misconfigured credentials or prefix policy).
   key created before the first page request is returned; keys created
   during the scan may or may not appear; a key MAY appear more than once
   and callers MUST dedup by key.
+- `list_after(prefix, start_after, page)` returns exactly the keys `list`
+  would, minus every key `<= start_after`: each returned key compares
+  strictly greater than `start_after`, in the same lexicographic order and
+  under the same pagination and cross-page guarantee as `list`.
+  `start_after == None` is identical to `list`. `start_after` need not name
+  an existing key and is typically a prefix string that sorts before the
+  first key the caller wants, letting the caller skip a whole key sub-range
+  server-side rather than paging through and discarding it (S3
+  `ListObjectsV2` `start-after`, exclusive; the memory oracle resumes its
+  ordered map strictly after the marker). A `start_after` at or below the
+  listed prefix excludes no key under it. Overriding the default (which
+  lists from the prefix and drops `<= start_after` in the client) is a
+  performance property only; the visible result set is identical.
 - `Suffix(0)` and zero-length `Range` are `InvalidRange`.
 - `Range(start, end)` is half-open; the HTTP Range header is inclusive, so
   adapters emit `bytes=start-(end-1)`. Boundary conformance tests required


### PR DESCRIPTION
After folding the ClickBench logs snapshot, the warm q01 resolve spent
its remaining 70 ms in 25 LISTs: one per (shard, hour) above the fold
watermark for 8 shards and 3 unsealed hours, issued in sequence, then the
ADR-0064 pending-erasure LIST after them, three round trips in all.

ObjectStoreBackend gains list_after(prefix, start_after, page): the
default implementation lists from the prefix and drops keys at or below
start_after client-side, MemoryStore ranges its BTreeMap, and the S3
backend maps it to ListObjectsV2 start-after through list_with_offset; the
Arc blanket and the instrument, fault, scheduling and kms-routing
decorators forward it. The catalog then issues one bounded LIST per shard
from the watermark hour's prefix and stops paging at the first key past
the window's end hour, and starts the erasure LIST before the fan-out and
joins it, so it still completes before the Snapshot is built and the
ADR-0064 visibility bound is unchanged. The 8-shard, 3-hour resolve drops
from 25 LISTs to 9 (8 shards plus the erasure LIST) in one round trip.

Two behaviours of the old per-(shard, hour) loop are kept on purpose: a
retiring shard past its slack window is dropped per hour (buckets with
shard >= scan_count(hour) are excluded after listing at the union bound,
which the reshard e2e straggler test pins), and a fully folded window
(watermark past the window end) issues no shard LIST at all, only the
erasure LIST, which ravel-sim's fold-makes-resolve-list-free test pins.
The wide-window prefix path keeps its documented superset behaviour.

Tests: bounded_listing_matches_reference_in_nine_lists pins the 9-LIST
count through QueryAccounting against the reference resolve;
bounded_shard_list_paginates_and_stops_at_window_end pins 3 page calls at
page size 2 (4 without the stop); the erasure overlap is pinned by a
FaultStore hold showing 9 LISTs in flight at once (8 without the
overlap); the object-store contract test covers list_after on every
backend. docs/object-store-contract.md and docs/catalog-and-mvcc.md
describe the method and the bounded listing; the watermark rule and the
key layout are unchanged, so no ADR.

Fixes: #730
Refs: #680
