### PR TITLE
fix(scripts): stop auto-merging PRs before CodeRabbit reviews them

### DIFF
--- a/.claude/skills/merge-fleet-result/SKILL.md
+++ b/.claude/skills/merge-fleet-result/SKILL.md
@@ -39,8 +39,8 @@ actionable finding (a walkthrough-only comment with zero findings counts
 as clean), then merge by hand once CI is green:
 
 ```sh
-scripts/pr-review-status.sh <pr-number>   # one-line CI + CodeRabbit status
-gh pr merge <pr-number> --rebase
+scripts/pr-review-status.sh <pr-number>   # one-line status; on clean, prints
+                                           # the exact merge command to run
 ```
 
 `FLEET_MERGE_AUTO=1` restores the old `gh pr merge --auto --rebase`

--- a/.claude/skills/merge-fleet-result/SKILL.md
+++ b/.claude/skills/merge-fleet-result/SKILL.md
@@ -26,11 +26,26 @@ PASS, continue with the procedure below.
 checks must pass, and history is linear (rebase-merge only). No process,
 `fleet-result-merge.sh` included, pushes `main` directly. The script
 lands a result branch by cleaning its history, pushing that cleaned history
-to a `task/<id>/merge` head branch, opening a PR against `main`, and
-enabling auto-merge (`gh pr merge --auto --rebase`) so GitHub lands it the
-moment the required checks pass. The rebase-merge keeps each commit's own
-message, so per-commit `Fixes:`/`Refs:` trailers still close their issues
-when they land.
+to a `task/<id>/merge` head branch, and opening a PR against `main`. The
+rebase-merge keeps each commit's own message, so per-commit `Fixes:`/
+`Refs:` trailers still close their issues when they land.
+
+**The PR opens WITHOUT auto-merge by default (standing rule, 2026-08-26).**
+CodeRabbit's GitHub App reviews every PR but posts as a review comment, not
+a required status check, so `--auto` merges before that review lands --
+#749/#750 landed with 6 real CodeRabbit findings unaddressed this way. Wait
+for the `coderabbitai[bot]` review, fix or explicitly answer every
+actionable finding (a walkthrough-only comment with zero findings counts
+as clean), then merge by hand once CI is green:
+
+```sh
+scripts/pr-review-status.sh <pr-number>   # one-line CI + CodeRabbit status
+gh pr merge <pr-number> --rebase
+```
+
+`FLEET_MERGE_AUTO=1` restores the old `gh pr merge --auto --rebase`
+behavior for the rare case that genuinely does not need a CodeRabbit wait;
+do not set it out of impatience.
 
 ## Result-branch history is cleaned before the PR is opened
 
@@ -73,7 +88,7 @@ written before that discipline, or that slip.
 (refuses unless HEAD is a clean `main`/`origin/main`, so a stale HEAD can
 never produce a too-old merge base), does the history clean above, runs the
 local pre-flight gates on the cleaned tree, and only then pushes the PR
-head, opens the PR, and turns on auto-merge.
+head and opens the PR (without auto-merge; see above).
 
 ```sh
 TASK=<task-id>
@@ -122,19 +137,33 @@ scripts/fleet-result-merge.sh $TASK message.txt   # add -p CRATE to scope local 
 - `gh api` sends every `-f` value as a string. A boolean or number field
   needs `-F` (`-F strict=false`), or the API answers with
   `"false" is not a boolean`.
-- `gh pr merge --auto --rebase` can fail once with a GraphQL error naming
-  a merge method you never requested ("squash merging is not allowed").
-  That is API flakiness around enabling auto-merge: retry once before
-  investigating repo settings.
+- `gh pr merge --auto --rebase` (only under `FLEET_MERGE_AUTO=1`, or the
+  final by-hand merge once CodeRabbit is clean) can fail once with a
+  GraphQL error naming a merge method you never requested ("squash merging
+  is not allowed"). That is API flakiness around enabling auto-merge:
+  retry once before investigating repo settings.
+- Disabling auto-merge on a PR that is already mid-merge fails silently:
+  GitHub can complete a merge within seconds of a required check going
+  green, and a `gh pr merge --disable-auto` call that loses that race just
+  finds the PR already merged. This is why the default is to never enable
+  auto-merge in the first place, not to enable-then-disable it.
 
 ## After the PR is open
 
-Auto-merge lands the PR once the required checks pass; `--delete-branch`
-removes the `task/$TASK/merge` head once it merges. The script deliberately
-leaves `task/$TASK/result` and `task/$TASK/start` in place: enabling
-auto-merge is not landing, and deleting them before the checks finish would
-mean a failed check leaves the PR open with no way to recover the original
-result branch.
+Poll `scripts/pr-review-status.sh <number>` until it reports clean (CI
+green, CodeRabbit reviewed, no open inline comments), fixing or answering
+every finding along the way, then land it by hand:
+
+```sh
+gh pr merge <number> --rebase --delete-branch
+```
+
+This removes the `task/$TASK/merge` head once it merges. The script
+deliberately leaves `task/$TASK/result` and `task/$TASK/start` in place
+regardless of merge mode: opening a PR is not landing, and deleting them
+before the checks (and the CodeRabbit wait) finish would mean a failed
+check or an unresolved finding leaves the PR open with no way to recover
+the original result branch.
 
 Watch the PR (`gh pr view <number> --json state,mergedAt`) until it reports
 merged. Once merged, delete the task refs yourself:

--- a/.claude/skills/merge-fleet-result/SKILL.md
+++ b/.claude/skills/merge-fleet-result/SKILL.md
@@ -150,16 +150,24 @@ scripts/fleet-result-merge.sh $TASK message.txt   # add -p CRATE to scope local 
 
 ## After the PR is open
 
-Poll `scripts/pr-review-status.sh <number>` until CI is green and it
-reports a CodeRabbit review against the PR's current head commit. Its
-inline-comment count does not drop to zero once you fix something -- the
-REST API never removes a comment just because the code it flagged
-changed -- so "clean" here means every comment has been individually
-read and its finding fixed or explicitly answered (a reply on the
-thread, or a commit message noting why it doesn't apply), never that
-the count reaches zero. A walkthrough-only review with zero comments
-from the start is the one case that is actually clean by count. Once
-every finding is accounted for, land it by hand:
+**Under `FLEET_MERGE_AUTO=1`** (auto-merge already enabled): just poll
+`gh pr view <number> --json state,mergedAt` until it reports merged, then
+go straight to cleanup below. Do not run a second, manual `gh pr merge`
+against a PR GitHub is already landing for you.
+
+**Otherwise** (the default): poll `scripts/pr-review-status.sh <number>`
+until CI is green, `mergeStateStatus` is `CLEAN` or `UNSTABLE` (`DIRTY`/
+`DRAFT`/`BEHIND` mean it isn't mergeable regardless of CI or review state
+-- resolve those first), and it reports a CodeRabbit review against the
+PR's current head commit with a state other than `CHANGES_REQUESTED`.
+The review's inline-comment count does not drop to zero once you fix
+something -- the REST API never removes a comment just because the code
+it flagged changed -- so "clean" here means every comment has been
+individually read and its finding fixed or explicitly answered (a reply
+on the thread, or a commit message noting why it doesn't apply), never
+that the count reaches zero. A walkthrough-only review with zero
+comments from the start is the one case that is actually clean by count.
+Once every finding is accounted for, land it by hand:
 
 ```sh
 gh pr merge <number> --rebase --delete-branch

--- a/.claude/skills/merge-fleet-result/SKILL.md
+++ b/.claude/skills/merge-fleet-result/SKILL.md
@@ -159,18 +159,21 @@ against a PR GitHub is already landing for you.
 until CI is green, `mergeStateStatus` is `CLEAN` or `UNSTABLE` (`DIRTY`/
 `DRAFT`/`BEHIND` mean it isn't mergeable regardless of CI or review state
 -- resolve those first), and it reports a CodeRabbit review against the
-PR's current head commit with a state other than `CHANGES_REQUESTED`.
-The review's inline-comment count does not drop to zero once you fix
-something -- the REST API never removes a comment just because the code
-it flagged changed -- so "clean" here means every comment has been
-individually read and its finding fixed or explicitly answered (a reply
-on the thread, or a commit message noting why it doesn't apply), never
-that the count reaches zero. A walkthrough-only review with zero
-comments from the start is the one case that is actually clean by count.
-Once every finding is accounted for, land it by hand:
+PR's current head commit in state `APPROVED` or `COMMENTED` (`PENDING`,
+`DISMISSED`, and `CHANGES_REQUESTED` are all not clean). The review's
+inline-comment count does not drop to zero once you fix something --
+the REST API never removes a comment just because the code it flagged
+changed -- so "clean" here means every comment has been individually
+read and its finding fixed or explicitly answered (a reply on the
+thread, or a commit message noting why it doesn't apply), never that
+the count reaches zero. A walkthrough-only review with zero comments
+from the start is the one case that is actually clean by count. Once
+every finding is accounted for, `pr-review-status.sh` prints the exact
+merge command, pinned to the head SHA it just checked via
+`--match-head-commit` so the merge refuses if the branch moved since:
 
 ```sh
-gh pr merge <number> --rebase --delete-branch
+gh pr merge <number> --rebase --delete-branch --match-head-commit <sha>
 ```
 
 This removes the `task/$TASK/merge` head once it merges. The script

--- a/.claude/skills/merge-fleet-result/SKILL.md
+++ b/.claude/skills/merge-fleet-result/SKILL.md
@@ -33,7 +33,7 @@ rebase-merge keeps each commit's own message, so per-commit `Fixes:`/
 **The PR opens WITHOUT auto-merge by default (standing rule, 2026-08-26).**
 CodeRabbit's GitHub App reviews every PR but posts as a review comment, not
 a required status check, so `--auto` merges before that review lands --
-#749/#750 landed with 6 real CodeRabbit findings unaddressed this way. Wait
+\#749/\#750 landed with 6 real CodeRabbit findings unaddressed this way. Wait
 for the `coderabbitai[bot]` review, fix or explicitly answer every
 actionable finding (a walkthrough-only comment with zero findings counts
 as clean), then merge by hand once CI is green:
@@ -150,9 +150,16 @@ scripts/fleet-result-merge.sh $TASK message.txt   # add -p CRATE to scope local 
 
 ## After the PR is open
 
-Poll `scripts/pr-review-status.sh <number>` until it reports clean (CI
-green, CodeRabbit reviewed, no open inline comments), fixing or answering
-every finding along the way, then land it by hand:
+Poll `scripts/pr-review-status.sh <number>` until CI is green and it
+reports a CodeRabbit review against the PR's current head commit. Its
+inline-comment count does not drop to zero once you fix something -- the
+REST API never removes a comment just because the code it flagged
+changed -- so "clean" here means every comment has been individually
+read and its finding fixed or explicitly answered (a reply on the
+thread, or a commit message noting why it doesn't apply), never that
+the count reaches zero. A walkthrough-only review with zero comments
+from the start is the one case that is actually clean by count. Once
+every finding is accounted for, land it by hand:
 
 ```sh
 gh pr merge <number> --rebase --delete-branch

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,14 +231,23 @@ connection, a pushed-but-broken main).
   claim; look at what actually landed.
 - `scripts/fleet-result-merge.sh <task-id> <message-file> [-p CRATE ...]`:
   cleans `wip:`/fixup commits out of the reviewed result branch, runs
-  `gates.sh`, and opens a PR against `main` with auto-merge enabled
-  (`main` is protected; the script never pushes or merges it directly).
-  Task refs are left on origin until the PR is confirmed merged; see the
-  merge-fleet-result skill for that step. Write the PR message to
-  `<message-file>` first (trailers included; line 1 is the title, the
-  body starts at line 3); this script does not construct one for you.
-  Run `fleet-result-inspect.sh` first: this script does not pause for
-  review, it assumes you already decided the scope is correct.
+  `gates.sh`, and opens a PR against `main` (`main` is protected; the
+  script never pushes or merges it directly). The PR opens WITHOUT
+  auto-merge by default (standing rule, 2026-08-26): CodeRabbit's GitHub
+  App reviews every PR as a comment, not a required status check, so
+  `--auto` used to merge before that review landed (#749/#750 shipped
+  with 6 real findings unaddressed this way). Wait for the
+  `coderabbitai[bot]` review, fix or answer every actionable finding (a
+  walkthrough-only comment with zero findings counts as clean; check with
+  `scripts/pr-review-status.sh <pr-number>`), then merge by hand:
+  `gh pr merge <pr-number> --rebase`. `FLEET_MERGE_AUTO=1` restores the
+  old auto-merge behavior for the rare case that genuinely does not need
+  the wait. Task refs are left on origin until the PR is confirmed
+  merged; see the merge-fleet-result skill for that step. Write the PR
+  message to `<message-file>` first (trailers included; line 1 is the
+  title, the body starts at line 3); this script does not construct one
+  for you. Run `fleet-result-inspect.sh` first: this script does not
+  pause for review, it assumes you already decided the scope is correct.
   `FLEET_MERGE_SKIP_GATES=1` skips the local `gates.sh` run and lets the
   PR's required checks be the gate; the cost is learning about a red PR
   from CI instead of immediately. The precondition is mechanical:
@@ -249,6 +258,15 @@ connection, a pushed-but-broken main).
   receipt: rerun the gates. The script also runs `assert-gh-auth.sh`
   first and `assert-clean-authorship.sh` on the rewritten history before
   it pushes.
+- `scripts/pr-review-status.sh <pr-number>`: one-line status for the
+  wait-for-CodeRabbit-then-merge-by-hand flow -- `mergeStateStatus`, the
+  CI check rollup (pass/pending/fail counts, failing check names), and
+  the `coderabbitai[bot]` review count plus its inline-comment count. The
+  REST comments endpoint carries no resolved/unresolved field (that's a
+  GraphQL review-thread concept), so a nonzero comment count needs a
+  human/session read of `gh api repos/.../pulls/<n>/comments` to judge
+  whether each was already fixed or answered; the script only tells you
+  there's something to read.
 - `scripts/verify-dispatch-gates.sh <ref> <scratchpad-dir>`: the tier-1
   gate check behind the `verify-dispatch` skill: an isolated worktree
   outside the repo, a cold `CARGO_TARGET_DIR`, and the full workspace

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -239,10 +239,12 @@ connection, a pushed-but-broken main).
   with 6 real findings unaddressed this way). Wait for the
   `coderabbitai[bot]` review, fix or answer every actionable finding (a
   walkthrough-only comment with zero findings counts as clean; check with
-  `scripts/pr-review-status.sh <pr-number>`), then merge by hand:
-  `gh pr merge <pr-number> --rebase`. `FLEET_MERGE_AUTO=1` restores the
-  old auto-merge behavior for the rare case that genuinely does not need
-  the wait. Task refs are left on origin until the PR is confirmed
+  `scripts/pr-review-status.sh <pr-number>`), then run the exact merge
+  command it prints once clean (it pins `--match-head-commit` to the SHA
+  it just checked, so a stale check can't land unreviewed code).
+  `FLEET_MERGE_AUTO=1` restores the old auto-merge behavior for the rare
+  case that genuinely does not need the wait. Task refs are left on
+  origin until the PR is confirmed
   merged; see the merge-fleet-result skill for that step. Write the PR
   message to `<message-file>` first (trailers included; line 1 is the
   title, the body starts at line 3); this script does not construct one

--- a/scripts/fleet-result-merge.sh
+++ b/scripts/fleet-result-merge.sh
@@ -4,8 +4,20 @@
 # status checks, linear history / rebase-merge only, no direct pushes), so
 # this script never merges or pushes to main itself. It cleans the result
 # branch's history (see the squash step below), pushes the cleaned history
-# to a PR head branch, opens a PR, and enables auto-merge (--rebase) so
-# GitHub lands it once the required checks pass.
+# to a PR head branch, and opens a PR.
+#
+# The PR is opened WITHOUT auto-merge by default (standing rule, 2026-08-26):
+# CodeRabbit's GitHub App reviews every PR but posts as a review comment, not
+# a required status check, so `--auto` merges before that review lands.
+# #749/#750 landed with 6 real CodeRabbit findings unaddressed this way. Wait
+# for the coderabbitai[bot] review, fix or explicitly answer every actionable
+# finding it raises (a walkthrough-only comment with zero findings counts as
+# clean), then merge by hand once CI is green:
+#   gh pr merge <n> --rebase
+# `scripts/pr-review-status.sh <n>` prints CI + CodeRabbit status in one line.
+# FLEET_MERGE_AUTO=1 restores the old behavior (`gh pr merge --auto --rebase`)
+# for a case that genuinely does not need a CodeRabbit wait; do not set this
+# out of impatience, only when you have already confirmed no review applies.
 #
 # Run fleet-result-inspect.sh first and review its output; this script
 # does not pause for review, it assumes you already decided the diff scope
@@ -377,7 +389,7 @@ fi
 echo "==> Pushing cleaned history to ${pr_branch}"
 git push --force-with-lease origin "${clean_ref}:refs/heads/${pr_branch}"
 
-echo "==> Opening pull request and enabling auto-merge (--rebase)"
+echo "==> Opening pull request"
 pr_title="$(head -n 1 "${message_file}")"
 second_line="$(sed -n '2p' "${message_file}")"
 if [[ -n "${second_line}" ]]; then
@@ -387,18 +399,34 @@ if [[ -n "${second_line}" ]]; then
 fi
 body_file="$(mktemp)"
 tail -n +3 "${message_file}" >"${body_file}"
-gh pr create --base main --head "${pr_branch}" \
-  --title "${pr_title}" --body-file "${body_file}"
+pr_url="$(gh pr create --base main --head "${pr_branch}" \
+  --title "${pr_title}" --body-file "${body_file}" | tail -n 1)"
 rm -f "${body_file}"
-gh pr merge --auto --rebase --delete-branch "${pr_branch}"
+pr_number="${pr_url##*/}"
 
-# Do NOT delete the task/<id>/result and task/<id>/start refs here: auto-merge
-# only enables the merge, it does not wait for required checks. Deleting them
-# now, before the PR has actually landed, reintroduces the exact silent-loss
-# shape this script exists to prevent: if a required check later fails, the
-# PR sits open with no way to recover the original result branch, and this
-# script would already have reported success. The task refs are cleaned up by
-# the merge-fleet-result skill's "after the PR is open" step, once it has
+if [[ "${FLEET_MERGE_AUTO:-0}" == "1" ]]; then
+  echo "==> FLEET_MERGE_AUTO=1: enabling auto-merge (--rebase)"
+  gh pr merge --auto --rebase --delete-branch "${pr_number}"
+  echo "Opened PR for task ${task_id}; auto-merge (--rebase) will land it once required checks pass."
+else
+  echo "==> Opened without auto-merge (standing rule): wait for coderabbitai[bot], then merge by hand"
+  echo "  ${pr_url}"
+  echo "  Check status:   ${script_dir}/pr-review-status.sh ${pr_number}"
+  echo "  Or by hand:     gh pr checks ${pr_number}"
+  echo "                  gh api repos/NOFireAI/ravel/pulls/${pr_number}/reviews"
+  echo "                  gh api repos/NOFireAI/ravel/pulls/${pr_number}/comments"
+  echo "  Once CI is green and no actionable CodeRabbit finding is open"
+  echo "  (a walkthrough-only comment with zero findings counts as clean):"
+  echo "    gh pr merge ${pr_number} --rebase"
+fi
+
+# Do NOT delete the task/<id>/result and task/<id>/start refs here, with or
+# without auto-merge: this script reporting success does not mean the PR has
+# landed. Deleting them now reintroduces the exact silent-loss shape this
+# script exists to prevent: if a required check (or an unresolved CodeRabbit
+# finding) later blocks the merge, the PR sits open with no way to recover
+# the original result branch. The task refs are cleaned up by the
+# merge-fleet-result skill's "after the PR is open" step, once it has
 # confirmed via `gh pr view --json state,mergedAt` that the PR actually merged.
 
 # Drop the temp rewrite branch now that it is safely pushed.
@@ -407,6 +435,5 @@ if [[ -n "${rewrite_branch}" ]]; then
   rewrite_branch=""
 fi
 
-echo "Opened PR for task ${task_id}; auto-merge (--rebase) will land it once required checks pass."
 echo "Task refs (task/${task_id}/result, task/${task_id}/start) are left in place;"
 echo "delete them only after confirming the PR merged (see merge-fleet-result skill)."

--- a/scripts/fleet-result-merge.sh
+++ b/scripts/fleet-result-merge.sh
@@ -415,9 +415,10 @@ else
   echo "  Or by hand:     gh pr checks ${pr_number}"
   echo "                  gh api repos/NOFireAI/ravel/pulls/${pr_number}/reviews"
   echo "                  gh api repos/NOFireAI/ravel/pulls/${pr_number}/comments"
-  echo "  Once CI is green and no actionable CodeRabbit finding is open"
-  echo "  (a walkthrough-only comment with zero findings counts as clean):"
-  echo "    gh pr merge ${pr_number} --rebase"
+  echo "  Once ${script_dir}/pr-review-status.sh ${pr_number} reports clean, run the"
+  echo "  exact merge command it prints (it pins --match-head-commit to the SHA it"
+  echo "  just checked, so the merge refuses if the branch moved since):"
+  echo "    gh pr merge ${pr_number} --rebase --delete-branch --match-head-commit <sha from pr-review-status.sh>"
 fi
 
 # Do NOT delete the task/<id>/result and task/<id>/start refs here, with or

--- a/scripts/pr-review-status.sh
+++ b/scripts/pr-review-status.sh
@@ -16,15 +16,38 @@ state="$(echo "${pr_json}" | jq -r '.state')"
 merge_state="$(echo "${pr_json}" | jq -r '.mergeStateStatus')"
 head_sha="$(echo "${pr_json}" | jq -r '.headRefOid')"
 
-pending=$(echo "${pr_json}" | jq '[.statusCheckRollup[]? | select(.status=="IN_PROGRESS" or .status=="QUEUED" or .status=="PENDING")] | length')
-success=$(echo "${pr_json}" | jq '[.statusCheckRollup[]? | select(.conclusion=="SUCCESS")] | length')
-failing=$(echo "${pr_json}" | jq '[.statusCheckRollup[]? | select(.conclusion=="FAILURE" or .conclusion=="CANCELLED" or .conclusion=="TIMED_OUT")] | length')
-failing_names=$(echo "${pr_json}" | jq -r '[.statusCheckRollup[]? | select(.conclusion=="FAILURE" or .conclusion=="CANCELLED" or .conclusion=="TIMED_OUT") | .name] | join(",")')
-# Every check must resolve to a conclusion this script recognizes as
-# accepted (SUCCESS, or NEUTRAL/SKIPPED, which GitHub also treats as
-# passing) before CI counts as settled; a status this script has never
-# seen must not silently fall out of both the success and failing counts.
-other=$(echo "${pr_json}" | jq '[.statusCheckRollup[]? | select(.status=="COMPLETED" and (.conclusion|IN("SUCCESS","FAILURE","CANCELLED","TIMED_OUT","NEUTRAL","SKIPPED")|not))] | length')
+# `statusCheckRollup` can mix two shapes: a `CheckRun` (GitHub Actions and
+# most modern integrations -- `status`/`conclusion`, name in `.name`) and a
+# legacy `StatusContext` (the older commit-status API some third-party
+# integrations still use -- `state` only, name in `.context`). Classify each
+# entry once, by shape, into one bucket, so neither shape nor an unrecognized
+# value inside a recognized shape can silently vanish from every count.
+normalized="$(echo "${pr_json}" | jq '
+  [.statusCheckRollup[]? | {
+    name: (.name // .context // "unknown"),
+    class: (
+      if has("state") then
+        (if .state=="SUCCESS" then "success"
+         elif (.state=="PENDING" or .state=="EXPECTED") then "pending"
+         elif (.state=="FAILURE" or .state=="ERROR") then "failing"
+         else "other" end)
+      elif has("status") then
+        (if .status!="COMPLETED" then "pending"
+         elif (.conclusion=="SUCCESS" or .conclusion=="NEUTRAL" or .conclusion=="SKIPPED") then "success"
+         elif (.conclusion=="FAILURE" or .conclusion=="CANCELLED" or .conclusion=="TIMED_OUT") then "failing"
+         else "other" end)
+      else "other" end
+    )
+  }]')"
+pending=$(echo "${normalized}" | jq '[.[] | select(.class=="pending")] | length')
+success=$(echo "${normalized}" | jq '[.[] | select(.class=="success")] | length')
+failing=$(echo "${normalized}" | jq '[.[] | select(.class=="failing")] | length')
+failing_names=$(echo "${normalized}" | jq -r '[.[] | select(.class=="failing") | .name] | join(",")')
+# Every check must land in success/pending/failing above (an ACTION_REQUIRED
+# or STALE conclusion, an unrecognized state value, or a shape this script
+# has never seen) before CI counts as settled; this catches whatever falls
+# through all three.
+other=$(echo "${normalized}" | jq '[.[] | select(.class=="other")] | length')
 
 # `--paginate` on an array-returning endpoint writes one JSON array per page,
 # back to back, not one combined array -- `jq -s add` slurps every page into
@@ -68,6 +91,8 @@ elif [[ "${merge_state}" == "DIRTY" || "${merge_state}" == "DRAFT" || "${merge_s
   echo "  -> mergeState is ${merge_state}; not mergeable regardless of CI/CodeRabbit state below"
 elif [[ "${cr_reviews}" == "0" ]]; then
   echo "  -> no CodeRabbit review against the current head commit yet; do not merge until one lands"
+elif [[ "${cr_last_state}" == "CHANGES_REQUESTED" ]]; then
+  echo "  -> CodeRabbit's current-head review is CHANGES_REQUESTED; not clean regardless of inline comment count"
 elif [[ "${failing}" != "0" ]]; then
   echo "  -> CI has failing/cancelled checks; not clean to merge"
 elif [[ "${other}" != "0" ]]; then

--- a/scripts/pr-review-status.sh
+++ b/scripts/pr-review-status.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# One-line status for a Ravel PR under the wait-for-CodeRabbit-then-merge-
+# by-hand rule (2026-08-26): mergeStateStatus, the CI check rollup, and the
+# coderabbitai[bot] review/finding counts, in one call instead of the three
+# or four `gh` invocations every session was hand-rolling.
+#
+# Usage: pr-review-status.sh <pr-number>
+set -euo pipefail
+
+pr="${1:?usage: pr-review-status.sh <pr-number>}"
+repo="NOFireAI/ravel"
+
+pr_json="$(gh pr view "${pr}" --repo "${repo}" \
+  --json state,mergeStateStatus,statusCheckRollup)"
+state="$(echo "${pr_json}" | jq -r '.state')"
+merge_state="$(echo "${pr_json}" | jq -r '.mergeStateStatus')"
+
+pending=$(echo "${pr_json}" | jq '[.statusCheckRollup[]? | select(.status=="IN_PROGRESS" or .status=="QUEUED" or .status=="PENDING")] | length')
+success=$(echo "${pr_json}" | jq '[.statusCheckRollup[]? | select(.conclusion=="SUCCESS")] | length')
+failing=$(echo "${pr_json}" | jq '[.statusCheckRollup[]? | select(.conclusion=="FAILURE" or .conclusion=="CANCELLED" or .conclusion=="TIMED_OUT")] | length')
+failing_names=$(echo "${pr_json}" | jq -r '[.statusCheckRollup[]? | select(.conclusion=="FAILURE" or .conclusion=="CANCELLED" or .conclusion=="TIMED_OUT") | .name] | join(",")')
+
+reviews_json="$(gh api "repos/${repo}/pulls/${pr}/reviews" --paginate 2>/dev/null || echo '[]')"
+cr_reviews=$(echo "${reviews_json}" | jq '[.[] | select(.user.login=="coderabbitai[bot]")] | length')
+cr_last_state=$(echo "${reviews_json}" | jq -r '[.[] | select(.user.login=="coderabbitai[bot]")] | last | .state // "none"')
+
+# The REST review-comments endpoint carries no resolved/unresolved field
+# (resolution is a review-THREAD concept, GraphQL-only) -- this reports the
+# raw inline-comment count. A nonzero count needs a human/session read of
+# `gh api repos/${repo}/pulls/${pr}/comments` to judge whether each finding
+# was already fixed or answered; this script cannot tell that for you.
+comments_json="$(gh api "repos/${repo}/pulls/${pr}/comments" --paginate 2>/dev/null || echo '[]')"
+cr_comments=$(echo "${comments_json}" | jq '[.[] | select(.user.login=="coderabbitai[bot]")] | length')
+
+summary="PR #${pr}: state=${state} mergeState=${merge_state} CI=${success} pass/${pending} pending/${failing} fail"
+if [[ "${failing}" != "0" ]]; then
+  summary="${summary} (${failing_names})"
+fi
+summary="${summary} | CodeRabbit: reviews=${cr_reviews} last=${cr_last_state} inline_comments=${cr_comments}"
+echo "${summary}"
+
+if [[ "${cr_reviews}" == "0" ]]; then
+  echo "  -> no CodeRabbit review posted yet; do not merge until one lands"
+elif [[ "${cr_comments}" != "0" ]]; then
+  echo "  -> ${cr_comments} CodeRabbit inline comment(s); read them and confirm each is fixed or answered before merging"
+elif [[ "${failing}" != "0" ]]; then
+  echo "  -> CI has failing/cancelled checks; not clean to merge"
+elif [[ "${pending}" != "0" ]]; then
+  echo "  -> CI still running; wait"
+else
+  echo "  -> clean: CI green, CodeRabbit reviewed with zero inline comments (walkthrough-only counts as clean)"
+fi

--- a/scripts/pr-review-status.sh
+++ b/scripts/pr-review-status.sh
@@ -11,42 +11,73 @@ pr="${1:?usage: pr-review-status.sh <pr-number>}"
 repo="NOFireAI/ravel"
 
 pr_json="$(gh pr view "${pr}" --repo "${repo}" \
-  --json state,mergeStateStatus,statusCheckRollup)"
+  --json state,mergeStateStatus,statusCheckRollup,headRefOid)"
 state="$(echo "${pr_json}" | jq -r '.state')"
 merge_state="$(echo "${pr_json}" | jq -r '.mergeStateStatus')"
+head_sha="$(echo "${pr_json}" | jq -r '.headRefOid')"
 
 pending=$(echo "${pr_json}" | jq '[.statusCheckRollup[]? | select(.status=="IN_PROGRESS" or .status=="QUEUED" or .status=="PENDING")] | length')
 success=$(echo "${pr_json}" | jq '[.statusCheckRollup[]? | select(.conclusion=="SUCCESS")] | length')
 failing=$(echo "${pr_json}" | jq '[.statusCheckRollup[]? | select(.conclusion=="FAILURE" or .conclusion=="CANCELLED" or .conclusion=="TIMED_OUT")] | length')
 failing_names=$(echo "${pr_json}" | jq -r '[.statusCheckRollup[]? | select(.conclusion=="FAILURE" or .conclusion=="CANCELLED" or .conclusion=="TIMED_OUT") | .name] | join(",")')
+# Every check must resolve to a conclusion this script recognizes as
+# accepted (SUCCESS, or NEUTRAL/SKIPPED, which GitHub also treats as
+# passing) before CI counts as settled; a status this script has never
+# seen must not silently fall out of both the success and failing counts.
+other=$(echo "${pr_json}" | jq '[.statusCheckRollup[]? | select(.status=="COMPLETED" and (.conclusion|IN("SUCCESS","FAILURE","CANCELLED","TIMED_OUT","NEUTRAL","SKIPPED")|not))] | length')
 
-reviews_json="$(gh api "repos/${repo}/pulls/${pr}/reviews" --paginate 2>/dev/null || echo '[]')"
-cr_reviews=$(echo "${reviews_json}" | jq '[.[] | select(.user.login=="coderabbitai[bot]")] | length')
-cr_last_state=$(echo "${reviews_json}" | jq -r '[.[] | select(.user.login=="coderabbitai[bot]")] | last | .state // "none"')
+# `--paginate` on an array-returning endpoint writes one JSON array per page,
+# back to back, not one combined array -- `jq -s add` slurps every page into
+# a single flat array regardless of how many pages came back. No `|| echo
+# '[]'` fallback: a real gh api failure (auth, rate limit, network) must
+# abort the script (set -e), not be reported as "zero reviews found", which
+# would read as "not reviewed yet, don't merge" instead of "the check itself
+# didn't run".
+reviews_json="$(gh api "repos/${repo}/pulls/${pr}/reviews" --paginate | jq -s 'add')"
+# Only a review against the PR's CURRENT head commit counts: a stale review
+# from before the last push covers code that no longer exists on the branch.
+cr_reviews=$(echo "${reviews_json}" | jq --arg sha "${head_sha}" \
+  '[.[] | select(.user.login=="coderabbitai[bot]" and .commit_id==$sha)] | length')
+cr_last_state=$(echo "${reviews_json}" | jq -r --arg sha "${head_sha}" \
+  '[.[] | select(.user.login=="coderabbitai[bot]" and .commit_id==$sha)] | last | .state // "none"')
 
 # The REST review-comments endpoint carries no resolved/unresolved field
 # (resolution is a review-THREAD concept, GraphQL-only) -- this reports the
 # raw inline-comment count. A nonzero count needs a human/session read of
 # `gh api repos/${repo}/pulls/${pr}/comments` to judge whether each finding
-# was already fixed or answered; this script cannot tell that for you.
-comments_json="$(gh api "repos/${repo}/pulls/${pr}/comments" --paginate 2>/dev/null || echo '[]')"
+# was already fixed or answered; this script cannot tell that for you. A
+# comment's own count never drops to zero just because the code it flagged
+# changed, so "clean" below means CI green plus a current-head review, not
+# zero comments -- see the merge-fleet-result skill.
+comments_json="$(gh api "repos/${repo}/pulls/${pr}/comments" --paginate | jq -s 'add')"
 cr_comments=$(echo "${comments_json}" | jq '[.[] | select(.user.login=="coderabbitai[bot]")] | length')
 
 summary="PR #${pr}: state=${state} mergeState=${merge_state} CI=${success} pass/${pending} pending/${failing} fail"
+if [[ "${other}" != "0" ]]; then
+  summary="${summary}/${other} unrecognized"
+fi
 if [[ "${failing}" != "0" ]]; then
   summary="${summary} (${failing_names})"
 fi
-summary="${summary} | CodeRabbit: reviews=${cr_reviews} last=${cr_last_state} inline_comments=${cr_comments}"
+summary="${summary} | CodeRabbit: reviews@head=${cr_reviews} last=${cr_last_state} inline_comments=${cr_comments}"
 echo "${summary}"
 
-if [[ "${cr_reviews}" == "0" ]]; then
-  echo "  -> no CodeRabbit review posted yet; do not merge until one lands"
-elif [[ "${cr_comments}" != "0" ]]; then
-  echo "  -> ${cr_comments} CodeRabbit inline comment(s); read them and confirm each is fixed or answered before merging"
+if [[ "${state}" != "OPEN" ]]; then
+  echo "  -> PR is ${state}, not open; nothing to merge"
+elif [[ "${merge_state}" == "DIRTY" || "${merge_state}" == "DRAFT" || "${merge_state}" == "BEHIND" ]]; then
+  echo "  -> mergeState is ${merge_state}; not mergeable regardless of CI/CodeRabbit state below"
+elif [[ "${cr_reviews}" == "0" ]]; then
+  echo "  -> no CodeRabbit review against the current head commit yet; do not merge until one lands"
 elif [[ "${failing}" != "0" ]]; then
   echo "  -> CI has failing/cancelled checks; not clean to merge"
+elif [[ "${other}" != "0" ]]; then
+  echo "  -> CI has ${other} check(s) in an unrecognized state; verify by hand before merging"
 elif [[ "${pending}" != "0" ]]; then
   echo "  -> CI still running; wait"
+elif [[ "${cr_comments}" != "0" ]]; then
+  echo "  -> ${cr_comments} CodeRabbit inline comment(s); read them and confirm each is fixed or answered before merging"
+elif [[ "${merge_state}" != "CLEAN" && "${merge_state}" != "UNSTABLE" ]]; then
+  echo "  -> every check and review looks clean, but mergeState is ${merge_state} (not CLEAN/UNSTABLE); verify by hand before merging"
 else
-  echo "  -> clean: CI green, CodeRabbit reviewed with zero inline comments (walkthrough-only counts as clean)"
+  echo "  -> clean: CI green, CodeRabbit reviewed the current head with zero inline comments"
 fi

--- a/scripts/pr-review-status.sh
+++ b/scripts/pr-review-status.sh
@@ -75,7 +75,7 @@ cr_last_state=$(echo "${reviews_json}" | jq -r --arg sha "${head_sha}" \
 comments_json="$(gh api "repos/${repo}/pulls/${pr}/comments" --paginate | jq -s 'add')"
 cr_comments=$(echo "${comments_json}" | jq '[.[] | select(.user.login=="coderabbitai[bot]")] | length')
 
-summary="PR #${pr}: state=${state} mergeState=${merge_state} CI=${success} pass/${pending} pending/${failing} fail"
+summary="PR #${pr} @ ${head_sha}: state=${state} mergeState=${merge_state} CI=${success} pass/${pending} pending/${failing} fail"
 if [[ "${other}" != "0" ]]; then
   summary="${summary}/${other} unrecognized"
 fi
@@ -91,8 +91,8 @@ elif [[ "${merge_state}" == "DIRTY" || "${merge_state}" == "DRAFT" || "${merge_s
   echo "  -> mergeState is ${merge_state}; not mergeable regardless of CI/CodeRabbit state below"
 elif [[ "${cr_reviews}" == "0" ]]; then
   echo "  -> no CodeRabbit review against the current head commit yet; do not merge until one lands"
-elif [[ "${cr_last_state}" == "CHANGES_REQUESTED" ]]; then
-  echo "  -> CodeRabbit's current-head review is CHANGES_REQUESTED; not clean regardless of inline comment count"
+elif [[ "${cr_last_state}" != "APPROVED" && "${cr_last_state}" != "COMMENTED" ]]; then
+  echo "  -> CodeRabbit's current-head review state is ${cr_last_state} (need APPROVED or COMMENTED); not clean"
 elif [[ "${failing}" != "0" ]]; then
   echo "  -> CI has failing/cancelled checks; not clean to merge"
 elif [[ "${other}" != "0" ]]; then
@@ -105,4 +105,5 @@ elif [[ "${merge_state}" != "CLEAN" && "${merge_state}" != "UNSTABLE" ]]; then
   echo "  -> every check and review looks clean, but mergeState is ${merge_state} (not CLEAN/UNSTABLE); verify by hand before merging"
 else
   echo "  -> clean: CI green, CodeRabbit reviewed the current head with zero inline comments"
+  echo "  -> gh pr merge ${pr} --rebase --delete-branch --match-head-commit ${head_sha}"
 fi


### PR DESCRIPTION
CodeRabbit's GitHub App reviews every PR but posts as a review comment,
not a required status check. fleet-result-merge.sh enabled auto-merge
right after opening a PR, so it landed the moment CI went green, before
CodeRabbit's comment even posted. #749 and #750 merged this way with 6
real findings never looked at.

fleet-result-merge.sh now opens the PR without auto-merge by default
and prints the PR URL plus the commands to check its state. Land it by
hand once CI is green and CodeRabbit has reviewed with no open finding
left (a walkthrough-only comment with zero findings counts as clean):
`gh pr merge <n> --rebase`. `FLEET_MERGE_AUTO=1` restores the old
auto-merge behavior for a case that genuinely does not need the wait.

Adds `scripts/pr-review-status.sh <n>`, a one-line summary of a PR's CI
rollup and CodeRabbit review/comment counts.

Updated the merge-fleet-result skill and CLAUDE.md's script list to
describe the new flow.

This PR itself follows the new rule: opened without auto-merge.

Refs: #680