### PR TITLE
fix(sql): drop the whole-segment fast path's threshold conjunct

### DIFF
--- a/crates/ravel-bench/src/logs_scan_scaling.rs
+++ b/crates/ravel-bench/src/logs_scan_scaling.rs
@@ -36,9 +36,11 @@
 //!   `over_threshold` values, both cache settings): #693 part 3's whole-segment
 //!   fast path (`LogsScanExec::whole_segment_fast_path`). The plan phase is
 //!   skipped, each segment is assigned whole to one partition, and each is read
-//!   once with a single full-range GET. `reads_per_segment` is 1 and
-//!   `bytes_amplification` is about 1.0, with zero suffix probes, whether or not
-//!   a cache is wired. Issue #739 dropped the threshold conjunct, so the
+//!   once with a single full-range GET. `reads_per_segment` is about 1 (it
+//!   divides every accounted GET by the segment count, and the resolve's one
+//!   catalog probe rides along, so 33 GETs over 32 segments reads 1.03) and
+//!   `bytes_amplification` is 1.0 within float slack (the probe carries no
+//!   bytes), with zero suffix probes, whether or not a cache is wired. Issue #739 dropped the threshold conjunct, so the
 //!   whole-object (below-threshold) rows now take this path too: object size no
 //!   longer decides the routing, and the cache has nothing left to absorb on
 //!   this shape.

--- a/crates/ravel-bench/src/logs_scan_scaling.rs
+++ b/crates/ravel-bench/src/logs_scan_scaling.rs
@@ -32,39 +32,43 @@
 //! this report's one statement (`SELECT ts, body FROM logs` over the full
 //! window, which carries no block predicate and contains every segment):
 //!
-//! - **over-threshold, either cache setting, `target_partitions` at or below
-//!   the segment count**: #693 part 3's whole-segment fast path
-//!   (`LogsScanExec::whole_segment_fast_path`). The plan phase is skipped, each
-//!   segment is assigned whole to one partition, and each is read once with a
-//!   single full-range GET. `reads_per_segment` is 1 and `bytes_amplification`
-//!   is about 1.0, with zero suffix probes, whether or not a cache is wired.
-//!   The cache has nothing left to absorb on this shape.
-//! - **over-threshold, cache wired, `target_partitions` above the segment
-//!   count**: the fast path's fourth conjunct (`relevant_segments >=
-//!   target_partitions`) fails, so the unchanged plan-then-stripe path runs.
-//!   The plan phase probes every segment, then each partition opens the
-//!   segments it holds blocks in and fetches its candidate blocks, and the
-//!   cache coalesces the repeats onto the extents already resident. This is the
-//!   only row in the sweep that still pays a plan phase on an above-threshold
-//!   object, and it is why the sweep keeps a partition value above the segment
-//!   count.
-//! - **whole-object (below-threshold shape), un-cached**: the plan-then-stripe
-//!   path with a whole-object read unit. Segments are assigned whole to one
-//!   partition each (the un-cached amendment), so the count is one plan read
-//!   plus one scan read per segment at every `target_partitions`.
-//! - **whole-object (below-threshold shape), cache wired**: the same two reads
-//!   per segment, except the scan read hits the cache: the plan and scan reads
-//!   share the one `(0, object_size)` key, so only the plan read reaches the
-//!   store.
+//! - **any row, `target_partitions` at or below the segment count** (both
+//!   `over_threshold` values, both cache settings): #693 part 3's whole-segment
+//!   fast path (`LogsScanExec::whole_segment_fast_path`). The plan phase is
+//!   skipped, each segment is assigned whole to one partition, and each is read
+//!   once with a single full-range GET. `reads_per_segment` is 1 and
+//!   `bytes_amplification` is about 1.0, with zero suffix probes, whether or not
+//!   a cache is wired. Issue #739 dropped the threshold conjunct, so the
+//!   whole-object (below-threshold) rows now take this path too: object size no
+//!   longer decides the routing, and the cache has nothing left to absorb on
+//!   this shape.
+//! - **cache wired, `target_partitions` above the segment count** (both
+//!   `over_threshold` values): the fast path's fourth conjunct
+//!   (`relevant_segments >= target_partitions`) fails, so the unchanged
+//!   plan-then-stripe path runs. The plan phase probes every segment, then each
+//!   partition opens the segments it holds blocks in and fetches its candidate
+//!   blocks, and the cache coalesces the repeats onto the extents already
+//!   resident. This is the only combination in the sweep that still pays a plan
+//!   phase, and it is why the sweep keeps a partition value above the segment
+//!   count. The `over_threshold` axis now decides only the read shape here (a
+//!   ranged sequence above the threshold, a whole-object read below it), not
+//!   whether the plan phase runs.
+//! - **un-cached, `target_partitions` above the segment count** (both
+//!   `over_threshold` values): the un-cached partition count is capped at the
+//!   segment count (the un-cached amendment), so `relevant_segments >=
+//!   target_partitions` still holds and the fast path fires. Each segment is
+//!   read once with a single full-range GET, so the GET count stays flat across
+//!   the sweep.
 //!
 //! An earlier version of this report pinned the un-cached over-threshold rows
 //! to `1 + min(partitions, blocks_per_segment)` passes over the dataset. That
 //! was intra-segment block striping's law: it assumed `n` partitions each
 //! opening the same segment and fetching their own candidate blocks. #693
 //! part 1 confined it to the cache-wired path, and #693 part 3 removed it from
-//! the predicate-free full-window shape entirely. It still governs the
-//! below-threshold and predicated paths, which is where the `over_threshold =
-//! false` rows and the above-segment-count row sit.
+//! the predicate-free full-window shape entirely. Since #739 that removal no
+//! longer depends on object size, so it governs the predicated paths and the
+//! cache-wired combos above the segment count, which is where the sole
+//! plan-then-stripe rows in this sweep sit.
 //!
 //! The sibling of [`crate::groupby_scaling`], aimed at the specific capability
 //! item 1 adds: a `logs` query touching FEWER segments than `target_partitions`
@@ -86,16 +90,19 @@
 //!
 //! It also reports the object-store request count each combination issues, read
 //! from the executed query's `QueryAccounting` (the same source
-//! [`crate::sql_latency`] and [`crate::pushdown_crossover`] use). Every partition
-//! owning blocks in a segment issues its own read sequence at that segment's key;
-//! the shape of the sequence is the `over_threshold` axis (one whole-object GET
-//! at or below the fetcher's block-range threshold, a suffix probe plus directory
-//! sections plus coalesced candidate blocks above it, ADR-0107). Un-cached, the
-//! partition count is capped at the segment count and each segment is assigned
-//! whole to one partition (ADR-0102's un-cached amendment), so raising
-//! `target_partitions` changes nothing at any value. Cache-wired, the partition
-//! count keeps climbing and those repeated reads are what ADR-0046's
-//! single-flight cache absorbs.
+//! [`crate::sql_latency`] and [`crate::pushdown_crossover`] use). On the fast
+//! path each relevant segment is read once with a single whole-object GET,
+//! whichever `over_threshold` value it carries. Only when the query stripes
+//! (the cache-wired combos above the segment count) does each partition owning
+//! blocks in a segment issue its own read sequence at that segment's key, and
+//! only there does the `over_threshold` axis change the sequence shape (one
+//! whole-object GET at or below the fetcher's block-range threshold, a suffix
+//! probe plus directory sections plus coalesced candidate blocks above it,
+//! ADR-0107). Un-cached, the partition count is capped at the segment count and
+//! each segment is assigned whole to one partition (ADR-0102's un-cached
+//! amendment), so raising `target_partitions` changes nothing at any value.
+//! Cache-wired above the segment count the partition count keeps climbing and
+//! those repeated reads are what ADR-0046's single-flight cache absorbs.
 //!
 //! Every request-count figure in this report is a measurement of THIS fixture --
 //! a `MemoryStore`, this segment/block/partition shape, and on the cached rows a
@@ -113,15 +120,23 @@
 //! # Why [`PlanningLatency`] is still worth measuring
 //!
 //! Issue #693 part 3 lets a predicate-free, full-window scan skip the plan phase
-//! entirely, which is exactly the shape this report's statement has, so on the
-//! `over_threshold` rows at or below the segment count no combo pays a plan
-//! phase at all. [`PlanningLatency`] is therefore not a component of those rows'
-//! wall time: it is the standing measurement of what a query that does NOT
-//! satisfy the fast path's conjuncts -- any predicate, a partial window overlap,
-//! a pending erasure, a below-threshold segment, or more partitions than
-//! relevant segments -- still pays before its first block is drained. The
-//! whole-object rows and the above-segment-count row are the combos in this
-//! sweep that pay it.
+//! entirely and read each relevant segment whole in one GET
+//! (`LogsScanExec::whole_segment_fast_path`), which is exactly the shape this
+//! report's statement has. That fast path was once gated on every segment sitting
+//! above the block-range threshold; issue #739 removed that conjunct, so object
+//! size no longer decides anything. Every combo at or below the segment count --
+//! both `over_threshold` values, both cache settings -- now takes the fast path
+//! and pays no plan phase at all. [`PlanningLatency`] is therefore not a component
+//! of those rows' wall time: it is the standing measurement of what a query that
+//! does NOT satisfy the fast path's conjuncts -- any predicate, a partial window
+//! overlap, a pending erasure, or more partitions than relevant segments -- still
+//! pays before its first block is drained. The cache-wired row above the segment
+//! count (32 relevant segments cannot fill 64 partitions) is the one combo in this
+//! sweep on the plan-then-stripe path, and the one that pays it.
+//!
+//! [`PlanningLatency`] is measured on its own fetchers by calling `plan_segment`
+//! directly, so that figure describes `compute_plan_counts`'s serialized await
+//! regardless of which path the swept combos take.
 //!
 //! Issue #693 tracks the request-count work this report's figures are quoted
 //! from.
@@ -273,9 +288,12 @@ pub struct ComboResult {
     /// out of reach ([`WHOLE_OBJECT_BLOCK_RANGE_THRESHOLD`]), so the same objects
     /// are read whole; the two rows differ only in read shape.
     ///
-    /// The axis also decides whether #693 part 3's whole-segment fast path can
-    /// run: one of its conjuncts is `object_size > block_range_threshold`, so the
-    /// whole-object rows always take the plan-then-stripe path.
+    /// Issue #739 dropped the fast path's `object_size > block_range_threshold`
+    /// conjunct, so this axis no longer decides whether #693 part 3's
+    /// whole-segment fast path can run: the whole-object rows take the fast path
+    /// at or below the segment count exactly like the over-threshold rows. It
+    /// now decides only the read shape on the plan-then-stripe path (the
+    /// cache-wired combos above the segment count).
     pub over_threshold: bool,
     /// Observed: the `LogsScanExec` node's declared output partition count in the
     /// real physical plan. Under block-level striping (ADR-0102) this is
@@ -296,17 +314,16 @@ pub struct ComboResult {
     /// Object-store GET requests the cold run issued (`QueryAccounting`). The
     /// number this deliverable exists to report.
     ///
-    /// On the `over_threshold` rows whose partition count is at or below the
-    /// segment count, #693 part 3's whole-segment fast path skips the plan phase
-    /// and reads each segment once, so this is exactly `segments_scanned` --
-    /// zero plan probes -- with or without a cache. On the whole-object rows the
-    /// plan phase runs: un-cached, each segment is assigned whole to one
-    /// partition, so the count is one plan read plus one scan read per segment at
-    /// every `target_partitions`; cache-wired, the scan read hits the cache
-    /// entry the plan read populated. Above the segment count the cached rows
-    /// stripe blocks, and the repeated reads at one key are what single-flight
-    /// absorbs. A figure for THIS fixture only, not a general result (see the
-    /// module doc).
+    /// On every row whose partition count is at or below the segment count --
+    /// both `over_threshold` values, with or without a cache -- #693 part 3's
+    /// whole-segment fast path skips the plan phase and reads each segment once,
+    /// so this is exactly `segments_scanned` plus the catalog slack, with zero
+    /// plan probes (since #739, object size no longer changes this). Above the
+    /// segment count the un-cached rows still take the fast path (the partition
+    /// count is capped at the segment count), while the cached rows decline it
+    /// and stripe blocks, and the repeated reads at one key are what
+    /// single-flight absorbs. A figure for THIS fixture only, not a general
+    /// result (see the module doc).
     pub object_store_get_requests: u64,
     /// Cache hits/misses the cold run recorded (zero when un-cached).
     pub cache_hits: u64,
@@ -324,11 +341,11 @@ pub struct ComboResult {
     ///
     /// About 1.0 on the fast-path rows: each segment is read whole exactly once,
     /// and the only excess is the catalog traffic the same accounting counts.
-    /// On the whole-object un-cached rows it is about 2.0, one plan read plus one
-    /// scan read per segment. Only where blocks stripe across partitions -- the
-    /// cached rows above the segment count, and any predicated or
-    /// below-threshold query -- does the old
-    /// `1 + min(partitions, blocks_per_segment)` law still describe it.
+    /// Since #739 the whole-object rows at or below the segment count take the
+    /// fast path too, so they are also about 1.0. Only where blocks stripe
+    /// across partitions -- the cached rows above the segment count, and any
+    /// predicated query -- does the old `1 + min(partitions, blocks_per_segment)`
+    /// law still describe it.
     pub bytes_amplification: f64,
     pub result_rows: usize,
     pub runs_taken: usize,

--- a/crates/ravel-bench/src/sql_latency.rs
+++ b/crates/ravel-bench/src/sql_latency.rs
@@ -2331,6 +2331,14 @@ mod tests {
     /// not asserted -- the cold run already hits, and the catalog cache
     /// contributes hits of its own. Building the cached arm without `with_cache`
     /// collapses both deltas to zero, which is what flips the assertions red.
+    ///
+    /// The `has_word` predicate is what keeps the query on that plan-then-scan
+    /// path (issue #739). A predicate-free full-window statement now takes
+    /// `LogsScanExec`'s whole-segment fast path, which reads each segment exactly
+    /// once and so leaves the fetcher cache nothing to absorb within a run -- the
+    /// double read this test is about is precisely what that path eliminates. The
+    /// fixture's single record body is `request 0 timeout after 30s`, so the
+    /// predicate matches it and the returned rows are the same as without it.
     #[tokio::test]
     async fn cache_flag_cuts_store_gets_within_a_run() {
         use ravel_types::accounting::AccountedOp;
@@ -2340,7 +2348,7 @@ mod tests {
         let th = tenant.hash();
         write_shard_objects(&store, &tenant, 0, 1).await;
         let req = SqlRequest {
-            sql: "SELECT body FROM logs".to_string(),
+            sql: "SELECT body FROM logs WHERE has_word(body, 'timeout')".to_string(),
             window: TimeRange {
                 start_ns: 0,
                 end_ns: NOW_NS,

--- a/crates/ravel-bench/tests/logs_scan_scaling_smoke.rs
+++ b/crates/ravel-bench/tests/logs_scan_scaling_smoke.rs
@@ -11,15 +11,20 @@
 //!
 //! It also pins the read-amplification figures issue #693 exists for. The
 //! report's statement is `SELECT ts, body FROM logs` over the full window, which
-//! is exactly the shape #693 part 3's whole-segment fast path serves, so on the
-//! `over_threshold` rows whose partition count fits inside the segment count the
-//! plan phase is skipped and each segment is read whole exactly once: one read
-//! per segment (the same statement as "the plan phase issued zero probes") and
-//! bytes amplification of about 1.0, cached and un-cached alike. The row whose
-//! partition count exceeds the segment count fails the fast path's fourth
-//! conjunct and takes the plan-then-stripe path instead; it is pinned
-//! separately, because it is the only combo in the sweep that still pays a plan
-//! phase on an above-threshold object.
+//! is exactly the shape #693 part 3's whole-segment fast path serves. Issue #739
+//! dropped the fast path's block-range-threshold conjunct, so object size no
+//! longer gates it: on every row whose declared partition count fits inside the
+//! segment count -- both `over_threshold` values, cached and un-cached alike --
+//! the plan phase is skipped and each segment is read whole exactly once: one
+//! read per segment (the same statement as "the plan phase issued zero probes")
+//! and bytes amplification of about 1.0. Only the cache-wired row whose partition
+//! count exceeds the segment count fails the fast path's fourth conjunct and
+//! stripes; it is pinned separately as the one combo in the sweep that declines
+//! the fast path. On its over-threshold read shape the striping is visible as
+//! extra probe and directory GETs; on its whole-object read shape the plan pass
+//! and every partition's open share one `(0, object_size)` cache key, so
+//! single-flight coalesces them and only the plan pass, not a GET, is what the
+//! fast path removes there.
 //!
 //! Gated on `sql-latency` (the module and bin's gate), so a default
 //! `cargo test -p ravel-bench` sees an empty crate rather than a link error. Run
@@ -41,23 +46,24 @@ use ravel_object_store::memory::MemoryStore;
 /// amplifications land on exact integers.
 const CATALOG_GET_SLACK: u64 = 1;
 
-/// Upper end of the band the `over_threshold` full-window rows must land in:
-/// one pass over the dataset, plus at most one further read of every segment.
-/// A per-partition read sequence, the shape block striping produced, would blow
-/// straight past it at 32 partitions.
+/// Upper end of the band the fast-path full-window rows must land in (both read
+/// shapes, since #739): one pass over the dataset, plus at most one further read
+/// of every segment. A per-partition read sequence, the shape block striping
+/// produced, would blow straight past it at 32 partitions.
 const MAX_FAST_PATH_AMPLIFICATION: f64 = 2.0;
 
 /// Float slack on a ratio that is an exact integer quotient of two byte counts.
 const EPS: f64 = 1e-9;
 
-/// Whether this row's scan could take #693 part 3's whole-segment fast path:
-/// above the block-range threshold, and with at least as many relevant segments
-/// as the plan declared partitions (the fast path's fourth conjunct, evaluated
-/// against the DECLARED count, which is what `LogsScanExec` compares). The
-/// statement itself is predicate-free and its window contains every segment, so
-/// those two conjuncts hold for every row in this sweep.
+/// Whether this row's scan takes #693 part 3's whole-segment fast path: at least
+/// as many relevant segments as the plan declared partitions (the fast path's
+/// fourth conjunct, evaluated against the DECLARED count, which is what
+/// `LogsScanExec` compares). Since #739 dropped the block-range-threshold
+/// conjunct, object size no longer enters into it, so this is the only conjunct
+/// that varies across the sweep: the statement is predicate-free and its window
+/// contains every segment, so the other three hold for every row.
 fn takes_fast_path(c: &ComboResult, segments: usize) -> bool {
-    c.over_threshold && c.scan_partitions <= segments
+    c.scan_partitions <= segments
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -207,15 +213,16 @@ async fn logs_scan_scaling_smoke_proves_cache_gated_fanout_and_request_count() {
     // striping: a cache too small to hold the working set would evict between
     // partitions and issue GETs again.
     //
-    // Both claims are made only over rows that take the same path as their
-    // un-cached neighbour. The over-threshold row above the segment count is the
-    // exception in both directions: it drops out of the whole-segment fast path
-    // (fourth conjunct) while its un-cached neighbour stays in, so it pays a plan
-    // phase the other does not, and it is pinned on its own below.
+    // Both claims are made only over the cache-wired rows that stay on the fast
+    // path. The row above the segment count is the exception on both axes: it
+    // drops out of the whole-segment fast path (fourth conjunct) while its
+    // un-cached neighbour, capped at the segment count, stays in. It is pinned on
+    // its own below, where the two read shapes diverge (the over-threshold one
+    // pays visible probe GETs, the whole-object one coalesces onto the same key).
     for over_threshold in [false, true] {
         let comparable = |tp: usize| {
             let c = report.combo(tp, true, over_threshold).expect("cached row");
-            !over_threshold || takes_fast_path(c, segments)
+            takes_fast_path(c, segments)
         };
         let flat: Vec<usize> = expected_partitions
             .iter()
@@ -252,10 +259,10 @@ async fn logs_scan_scaling_smoke_proves_cache_gated_fanout_and_request_count() {
 
     // Issue #693 part 3, the figure this report exists to carry. A
     // block-predicate-free statement whose window contains every relevant
-    // segment, over segments above the block-range threshold, with at least as
-    // many relevant segments as declared partitions, skips the plan phase and
-    // reads each segment whole exactly once -- cached or not. So on every
-    // over-threshold row at or below the segment count the GET count is the
+    // segment, with at least as many relevant segments as declared partitions,
+    // skips the plan phase and reads each segment whole exactly once -- cached or
+    // not, and since #739 whatever the object size. So on every row at or below
+    // the segment count, on both `over_threshold` values, the GET count is the
     // segment count (plus the snapshot's own catalog read) and the bytes come to
     // one pass over the dataset.
     //
@@ -270,8 +277,8 @@ async fn logs_scan_scaling_smoke_proves_cache_gated_fanout_and_request_count() {
     {
         fast_path_rows += 1;
         let label = format!(
-            "tp={} cache={} over_threshold=true",
-            c.target_partitions, c.cache_wired
+            "tp={} cache={} over_threshold={}",
+            c.target_partitions, c.cache_wired, c.over_threshold
         );
         let segs = c.segments_scanned as u64;
         assert!(
@@ -296,37 +303,52 @@ async fn logs_scan_scaling_smoke_proves_cache_gated_fanout_and_request_count() {
         );
     }
     assert!(
-        fast_path_rows >= 4,
-        "the sweep must pin the fast path on both cache settings at more than one \
-         partition value; got {fast_path_rows} rows"
+        fast_path_rows >= 8,
+        "the sweep must pin the fast path on both cache settings and both \
+         `over_threshold` values at more than one partition value; got \
+         {fast_path_rows} rows"
     );
-    for cache_wired in [false, true] {
-        for &tp in expected_partitions.iter().filter(|&&tp| tp <= segments) {
-            let c = report
-                .combo(tp, cache_wired, true)
-                .expect("over-threshold row");
-            assert!(
-                takes_fast_path(c, segments),
-                "tp={tp} cache={cache_wired}: a partition value at or below the \
-                 segment count must stay on the fast path, but the plan declared \
-                 {} partitions",
-                c.scan_partitions
-            );
+    for over_threshold in [false, true] {
+        for cache_wired in [false, true] {
+            for &tp in expected_partitions.iter().filter(|&&tp| tp <= segments) {
+                let c = report
+                    .combo(tp, cache_wired, over_threshold)
+                    .expect("swept row");
+                assert!(
+                    takes_fast_path(c, segments),
+                    "tp={tp} cache={cache_wired} over_threshold={over_threshold}: \
+                     a partition value at or below the segment count must stay on \
+                     the fast path since #739, but the plan declared {} partitions",
+                    c.scan_partitions
+                );
+            }
         }
     }
 
     // The other side of the fourth conjunct: a row with MORE declared partitions
     // than relevant segments cannot fill every partition from whole segments, so
-    // it falls back to plan-then-stripe. It pays a suffix probe per segment that
-    // the fast path skips, plus at least one open of every segment, so it reads
-    // strictly more than the same-shape row that keeps the fast path -- while
-    // staying under one extra pass over the dataset, because above the threshold
-    // each partition fetches only its own candidate blocks rather than the whole
-    // object.
+    // it declines the fast path and falls back to plan-then-stripe. Only the
+    // cache-wired row above the segment count reaches this -- the un-cached count
+    // is capped at the segment count -- and since #739 it reaches it on BOTH
+    // `over_threshold` values, so both are pinned off the fast path here. What
+    // the striping COSTS then depends on the read shape, and the two diverge:
+    //
+    // - Above the threshold each partition opens its owned segments with a suffix
+    //   probe, one GET per directory section, and coalesced candidate blocks. The
+    //   probe and section GETs are real work the fast path skips, so the row
+    //   reads strictly more than its fast-path neighbour -- at least one probe per
+    //   segment on top of one open each (>= 2x the segment count) -- while staying
+    //   under one extra pass over the dataset, because each partition fetches only
+    //   its own candidate blocks rather than the whole object.
+    // - At or below the threshold every partition's open, and the plan pass, is a
+    //   whole-object `GetRange::Full` on the one `(0, object_size)` cache key, so
+    //   single-flight coalesces them all. The striped row then issues the SAME GET
+    //   count and reads the SAME single pass as its fast-path neighbour: leaving
+    //   the fast path costs the plan pass, not a GET (ADR-0102's #739 amendment).
     let striped: Vec<&ComboResult> = report
         .combos
         .iter()
-        .filter(|c| c.over_threshold && c.scan_partitions > segments)
+        .filter(|c| c.scan_partitions > segments)
         .collect();
     assert!(
         !striped.is_empty(),
@@ -334,71 +356,87 @@ async fn logs_scan_scaling_smoke_proves_cache_gated_fanout_and_request_count() {
          count ({segments}) so the fast path's relevant_segments >= \
          target_partitions conjunct is exercised failing"
     );
+    let mut striped_over_threshold = 0usize;
+    let mut striped_whole_object = 0usize;
     for c in striped {
         let label = format!(
-            "tp={} cache={} over_threshold=true",
-            c.target_partitions, c.cache_wired
+            "tp={} cache={} over_threshold={}",
+            c.target_partitions, c.cache_wired, c.over_threshold
         );
         let segs = c.segments_scanned as u64;
         assert!(
-            c.object_store_get_requests >= 2 * segs,
-            "{label}: off the fast path the plan phase probes each of {segs} \
-             segments and the scan opens each of them at least once, so the GET \
-             count must be at least {}; got {} over {:.1} blocks per segment",
-            2 * segs,
-            c.object_store_get_requests,
-            c.blocks_per_segment()
+            !takes_fast_path(c, segments) && c.scan_partitions > segments,
+            "{label}: a row above the segment count must decline the fast path; \
+             the plan declared {} partitions",
+            c.scan_partitions
         );
+        // The fast-path neighbour: the same partition value and read shape on the
+        // other cache setting, capped at the segment count and so still on the
+        // fast path.
         let fast = report
-            .combo(c.target_partitions, !c.cache_wired, true)
+            .combo(c.target_partitions, !c.cache_wired, c.over_threshold)
             .expect("the same partition value on the other cache setting");
         assert!(
-            takes_fast_path(fast, segments)
-                && c.object_store_get_requests > fast.object_store_get_requests,
-            "{label}: leaving the fast path must cost strictly more GETs than the \
-             tp={} row that keeps it; got {} against {}",
-            fast.target_partitions,
-            c.object_store_get_requests,
-            fast.object_store_get_requests
+            takes_fast_path(fast, segments),
+            "{label}: the un-cached neighbour is capped at the segment count and \
+             must stay on the fast path; it declared {} partitions",
+            fast.scan_partitions
         );
-        assert!(
-            c.bytes_amplification > 1.0 && c.bytes_amplification < 2.0,
-            "{label}: the striped path re-reads the probe and directory bytes the \
-             fast path never fetches, but fetches only candidate blocks per \
-             partition, so bytes_amplification must sit in (1.0, 2.0); got {:.4}",
-            c.bytes_amplification
-        );
+        if c.over_threshold {
+            striped_over_threshold += 1;
+            assert!(
+                c.object_store_get_requests >= 2 * segs,
+                "{label}: off the fast path the plan phase probes each of {segs} \
+                 segments and the scan opens each of them at least once, so the \
+                 GET count must be at least {}; got {} over {:.1} blocks per \
+                 segment",
+                2 * segs,
+                c.object_store_get_requests,
+                c.blocks_per_segment()
+            );
+            assert!(
+                c.object_store_get_requests > fast.object_store_get_requests,
+                "{label}: leaving the fast path on the ranged read shape must cost \
+                 strictly more GETs than the tp={} row that keeps it; got {} \
+                 against {}",
+                fast.target_partitions,
+                c.object_store_get_requests,
+                fast.object_store_get_requests
+            );
+            assert!(
+                c.bytes_amplification > 1.0 && c.bytes_amplification < 2.0,
+                "{label}: the striped path re-reads the probe and directory bytes \
+                 the fast path never fetches, but fetches only candidate blocks \
+                 per partition, so bytes_amplification must sit in (1.0, 2.0); got \
+                 {:.4}",
+                c.bytes_amplification
+            );
+        } else {
+            striped_whole_object += 1;
+            assert_eq!(
+                c.object_store_get_requests, fast.object_store_get_requests,
+                "{label}: on the whole-object read shape the plan pass and every \
+                 partition's open share the one `(0, object_size)` cache key, so \
+                 single-flight coalesces them and the striped row issues the same \
+                 GET count as its fast-path neighbour ({}); got {}",
+                fast.object_store_get_requests, c.object_store_get_requests
+            );
+            assert!(
+                (c.bytes_amplification - 1.0).abs() <= EPS,
+                "{label}: coalesced whole-object reads move one pass over the \
+                 dataset, so bytes_amplification must be 1.0; got {:.4} ({} bytes \
+                 over a {} byte dataset)",
+                c.bytes_amplification,
+                c.object_store_bytes,
+                report.config.dataset_bytes
+            );
+        }
     }
-
-    // The whole-object rows, which read the SAME objects with the block-range
-    // threshold moved out of reach: below the threshold the fast path does not
-    // apply, so the plan-then-stripe path runs and the plan read is a real
-    // whole-object read rather than a probe. Un-cached that is one plan read plus
-    // one scan read per segment; cache-wired the two share the one
-    // `(0, object_size)` key, so only the plan read reaches the store.
-    for c in report.combos.iter().filter(|c| !c.over_threshold) {
-        let label = format!(
-            "tp={} cache={} over_threshold=false",
-            c.target_partitions, c.cache_wired
-        );
-        let segs = c.segments_scanned as u64;
-        let (reads, amplification) = if c.cache_wired { (1, 1.0) } else { (2, 2.0) };
-        assert!(
-            c.object_store_get_requests >= reads * segs
-                && c.object_store_get_requests <= reads * segs + CATALOG_GET_SLACK,
-            "{label}: the whole-object path costs {reads} store read(s) per \
-             segment over {segs} segments, so the GET count must be {} (plus at \
-             most {CATALOG_GET_SLACK} catalog read); got {}",
-            reads * segs,
-            c.object_store_get_requests
-        );
-        assert!(
-            (c.bytes_amplification - amplification).abs() <= EPS,
-            "{label}: bytes_amplification must be {amplification:.1}; got {:.4} \
-             ({} bytes over a {} byte dataset)",
-            c.bytes_amplification,
-            c.object_store_bytes,
-            report.config.dataset_bytes
-        );
-    }
+    assert_eq!(
+        (striped_over_threshold, striped_whole_object),
+        (1, 1),
+        "the sweep must stripe exactly the cache-wired row above the segment \
+         count on each read shape; got {striped_over_threshold} over-threshold \
+         and {striped_whole_object} whole-object striped rows"
+    );
 }

--- a/crates/ravel-sql/src/logs_scan.rs
+++ b/crates/ravel-sql/src/logs_scan.rs
@@ -75,19 +75,25 @@
 //!   past the segment count *can* raise the GET count above the whole-segment
 //!   path's, and that is the cost ADR-0102 accepts in exchange for the cache
 //!   absorbing the repeat reads and for the extra scan parallelism.
-//! - **Predicate-free full-window fast path (#693 part 3).** When the query has
-//!   no block-level predicate, no pending erasure, and its window fully contains
-//!   every relevant, above-threshold segment, and there are at least
-//!   `target_partitions` such segments, the plan phase is skipped entirely
+//! - **Predicate-free full-window fast path (#693 part 3, amended by #739).**
+//!   When the query has no block-level predicate, no pending erasure, and its
+//!   window fully contains every relevant segment, and there are at least
+//!   `target_partitions` of them, the plan phase is skipped entirely
 //!   ([`LogsScanExec::whole_segment_fast_path`]): whole segments are assigned
 //!   round-robin (the same rule the un-cached path uses), and each is read in one
 //!   whole-object GET ([`LogSegmentFetcher::scan_whole_accounted_with_tenant`]),
 //!   so the request count is exactly one GET per relevant segment, zero suffix
-//!   probes. When there are fewer relevant segments than partitions the striped
+//!   probes. Object size does not enter into it: a segment at or below the
+//!   block-range threshold is read whole by both entries, on the same
+//!   `(0, object_size)` cache key, so it joins the assignment without changing
+//!   what is read (#739 -- as a query-wide conjunct the threshold let one small
+//!   tail object per `(shard, hour)` veto an entire 8,424-object snapshot).
+//!   When there are fewer relevant segments than partitions the striped
 //!   path runs instead, but the plan footer it read is carried to each subset
 //!   open ([`LogSegmentFetcher::fetch_object_with_footer`]) so those opens skip
 //!   their own re-probe. Any other query shape runs the plan-then-stripe path
-//!   above unchanged.
+//!   above unchanged, and publishes a `fast_path_rejected_*` counter naming the
+//!   conjunct that sent it there.
 //!
 //! Above the threshold each partition's read already covers only the pruned
 //! candidate blocks rather than every byte of the segment, so bytes on the wire
@@ -495,6 +501,47 @@ pub struct LogsScanExec {
     metrics: ExecutionPlanMetricsSet,
 }
 
+/// Which conjunct kept a statement off the predicate-free full-window
+/// whole-segment fast path (issue #739). Recorded as a DataFusion counter by
+/// [`BlockMetrics::record_fast_path_rejection`] so a report reading the scan's
+/// metrics can say why a statement striped instead of guessing from GET counts.
+///
+/// The variants are exactly the query-wide conjuncts
+/// [`LogsScanExec::whole_segment_fast_path`] tests, in the order it tests them,
+/// and the first failure wins: a query with both a content predicate and a
+/// partial window reports [`Self::BlockPredicate`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum FastPathRejection {
+    /// The snapshot carries a pending selective erasure (ADR-0064 decision 2).
+    PendingErasure,
+    /// The query carries a content, prune-only, or stream-attribute arm, so a
+    /// block can be excluded and the survivor count is not the block count.
+    BlockPredicate,
+    /// Some relevant segment is not fully contained in the query window (a
+    /// partial ts overlap), or its catalog span is ill-formed (`min > max`), so
+    /// containment cannot be proved without reading the segment.
+    SegmentNotContained,
+    /// Fewer relevant segments than partitions: whole-segment round-robin would
+    /// leave partitions empty, which is the striped path's job.
+    FewerSegmentsThanPartitions,
+}
+
+impl FastPathRejection {
+    /// The counter name this reason is published under. One static name per
+    /// variant, so `EXPLAIN ANALYZE` and any metrics reader see the reason
+    /// directly rather than a numeric code they must decode.
+    fn metric_name(self) -> &'static str {
+        match self {
+            FastPathRejection::PendingErasure => "fast_path_rejected_pending_erasure",
+            FastPathRejection::BlockPredicate => "fast_path_rejected_block_predicate",
+            FastPathRejection::SegmentNotContained => "fast_path_rejected_segment_not_contained",
+            FastPathRejection::FewerSegmentsThanPartitions => {
+                "fast_path_rejected_fewer_segments_than_partitions"
+            }
+        }
+    }
+}
+
 /// The per-partition block counters this scan publishes as DataFusion metrics.
 ///
 /// They are the only externally visible difference the prune channel makes:
@@ -539,6 +586,25 @@ impl BlockMetrics {
             columnar_batches: MetricBuilder::new(metrics).counter("columnar_batches", partition),
             rowpath_batches: MetricBuilder::new(metrics).counter("rowpath_batches", partition),
         }
+    }
+
+    /// Publishes why this partition did NOT take the whole-segment fast path
+    /// (issue #739): one increment on the counter named by `reason`, per
+    /// partition, exactly once per `execute` call that struck out. The counter is
+    /// created only when a rejection happens, so a statement that takes the fast
+    /// path publishes none of these names at all.
+    ///
+    /// Takes the metrics set rather than living on `self` because the rejection
+    /// is decided before the per-partition [`BlockMetrics`] is built, and because
+    /// which counter exists depends on the reason.
+    fn record_fast_path_rejection(
+        metrics: &ExecutionPlanMetricsSet,
+        partition: usize,
+        reason: FastPathRejection,
+    ) {
+        MetricBuilder::new(metrics)
+            .counter(reason.metric_name(), partition)
+            .add(1);
     }
 
     /// Accumulates one segment's *whole-segment* prune totals: `blocks_total`
@@ -744,18 +810,18 @@ impl LogsScanExec {
     }
 
     /// Whether this scan can take the predicate-free full-window whole-segment
-    /// fast path (#693 part 3, deliverable 1), returning the count of relevant
-    /// (ts-overlapping) segments when it can. Decided with ZERO I/O from the
-    /// resolved snapshot and `query`, using the same conjuncts
-    /// [`ravel_query::LogSegmentFetcher::plan_segment`]'s own fast-path gate uses
-    /// per segment:
+    /// fast path (#693 part 3 deliverable 1, amended by #739), returning the
+    /// count of relevant (ts-overlapping) segments when it can and the conjunct
+    /// that refused when it cannot. Decided with ZERO I/O from the resolved
+    /// snapshot and `query`:
     ///
-    /// - the query carries no block-level predicate
+    /// - the snapshot carries no pending selective erasure, and the query
+    ///   carries no block-level predicate
     ///   ([`LogQuery::is_block_predicate_free`]: no content, prune-only,
     ///   stream-attribute, or pending-erasure arm), and
-    /// - every relevant segment has a well-formed span (`min <= max`), is above
-    ///   the fetcher's block-range threshold, and is fully CONTAINED in the
-    ///   window (`ts_min <= seg.min && seg.max <= ts_max`). Containment is
+    /// - every relevant segment has a well-formed span (`min <= max`) and is
+    ///   fully CONTAINED in the window
+    ///   (`ts_min <= seg.min && seg.max <= ts_max`). Containment is
     ///   strictly stronger than the overlap
     ///   [`LogsTableProvider::pruned_segments`] already filtered on, so no block
     ///   of a relevant segment can fall outside the window and every block
@@ -765,23 +831,38 @@ impl LogsScanExec {
     /// whole-segment round-robin still fills every partition. Fewer segments than
     /// partitions is the striped path's job (deliverable 2 carries the plan
     /// footer there so its subset opens still skip re-probing); a partial
-    /// overlap, a predicate, a pending erasure, or a below-threshold segment all
-    /// fall to the unchanged plan-then-stripe path, byte for byte.
+    /// overlap, a predicate, or a pending erasure falls to the unchanged
+    /// plan-then-stripe path, byte for byte.
     ///
-    /// The threshold conjunct keeps this strictly to the band where skipping the
-    /// plan phase saves a GET: at or below the threshold a segment is already
-    /// read whole in one GET on both the plan and scan paths (they coalesce on
-    /// the same `(0, object_size)` cache key), so the fast path would add nothing
-    /// and would only diverge from the existing small-object tests.
+    /// # The block-range threshold is not a conjunct (issue #739)
     ///
-    /// Issue #739 revisits the threshold conjunct: it is query-wide here, so a
-    /// single below-threshold tail object disqualifies every segment in the
-    /// snapshot.
-    fn whole_segment_fast_path(&self, query: &LogQuery) -> Option<usize> {
-        if !query.is_block_predicate_free() {
-            return None;
+    /// It used to be one, query-wide: every relevant segment had to satisfy
+    /// `object_size > block_range_threshold`, on the reasoning that at or below
+    /// the threshold there is no probe to save. Query-wide, that made a single
+    /// small object veto the whole snapshot. A bulk load leaves one small tail
+    /// object per `(shard, hour)`, so on the 8,424-object ClickBench tenant
+    /// (#680) a predicate-free full-window statement striped after all and issued
+    /// 22,473 GETs instead of 8,424.
+    ///
+    /// The conjunct is gone rather than made per segment, because per segment it
+    /// decides nothing: at or below the threshold
+    /// [`ravel_query::LogSegmentFetcher::scan_whole_accounted_with_tenant`] and
+    /// the striped path's ranged entry both land in the same `whole_object_bytes`
+    /// read -- one `GetRange::Full` on the `(0, object_size)` cache key, the same
+    /// accounting, and no etag pin on either, since one GET observes one object
+    /// state. So a sub-threshold segment reads identically whichever entry opens
+    /// it, and it can join the whole-segment assignment while the above-threshold
+    /// segments around it keep the probe the fast path removes.
+    fn whole_segment_fast_path(&self, query: &LogQuery) -> Result<usize, FastPathRejection> {
+        // Checked ahead of `is_block_predicate_free` (which folds erasure in)
+        // only so the recorded reason names erasure rather than the generic
+        // block-predicate arm.
+        if !self.erasure.is_empty() {
+            return Err(FastPathRejection::PendingErasure);
         }
-        let threshold = self.fetcher.block_range_threshold();
+        if !query.is_block_predicate_free() {
+            return Err(FastPathRejection::BlockPredicate);
+        }
         let mut relevant = 0usize;
         for seg in self.segments.iter() {
             if !LogSegmentFetcher::ts_range_relevant(seg, self.ts_min, self.ts_max) {
@@ -789,14 +870,16 @@ impl LogsScanExec {
             }
             relevant += 1;
             let contained = seg.min_event_ts_ns <= seg.max_event_ts_ns
-                && seg.object_size > threshold
                 && self.ts_min <= seg.min_event_ts_ns
                 && seg.max_event_ts_ns <= self.ts_max;
             if !contained {
-                return None;
+                return Err(FastPathRejection::SegmentNotContained);
             }
         }
-        (relevant >= self.target_partitions).then_some(relevant)
+        if relevant < self.target_partitions {
+            return Err(FastPathRejection::FewerSegmentsThanPartitions);
+        }
+        Ok(relevant)
     }
 
     fn compute_properties(schema: &SchemaRef, n: usize) -> PlanProperties {
@@ -967,34 +1050,38 @@ impl ExecutionPlan for LogsScanExec {
             accounting: self.accounting.clone(),
         });
 
-        // #693 part 3 deliverable 1: a predicate-free query whose window fully
-        // contains every relevant, above-threshold segment, with at least
-        // `target_partitions` of them, skips the plan phase entirely. Each
-        // partition computes its whole-segment round-robin share with no I/O and
-        // opens each owned segment with one whole-object GET (no plan probe, no
-        // scan-side probe). Any other shape falls to the plan-then-stripe path
-        // below, byte for byte.
-        let (work, fast_whole_segment, state) = if let Some(relevant) =
-            self.whole_segment_fast_path(&ctx.query)
-        {
-            let n = self.target_partitions.max(1).min(relevant.max(1));
-            let work = owned_whole_segments(&self.segments, self.ts_min, self.ts_max, partition, n);
-            (work, true, LogScanState::NextSegment)
-        } else {
-            // The block-level assignment needs each segment's surviving-block
-            // count, which a prune must produce (async). The first partition
-            // to poll runs that prune for every segment through the shared
-            // `counts` cell, with as many prunes in flight as the scan has
-            // partitions; the rest await its result. Building the future here
-            // (not awaiting it) keeps `execute` synchronous, as DataFusion
-            // requires.
-            let counts_fut = plan_counts_future(
-                Arc::clone(&self.counts),
-                Arc::clone(&ctx),
-                Arc::clone(&self.segments),
-                self.target_partitions,
-            );
-            (VecDeque::new(), false, LogScanState::Planning(counts_fut))
+        // #693 part 3 deliverable 1, amended by #739: a predicate-free query
+        // whose window fully contains every relevant segment, with at least
+        // `target_partitions` of them, skips the plan phase entirely, whatever
+        // those segments' sizes are. Each partition computes its whole-segment
+        // round-robin share with no I/O and opens each owned segment with one
+        // whole-object GET (no plan probe, no scan-side probe). Any other shape
+        // falls to the plan-then-stripe path below, byte for byte, and records
+        // which conjunct sent it there.
+        let (work, fast_whole_segment, state) = match self.whole_segment_fast_path(&ctx.query) {
+            Ok(relevant) => {
+                let n = self.target_partitions.max(1).min(relevant.max(1));
+                let work =
+                    owned_whole_segments(&self.segments, self.ts_min, self.ts_max, partition, n);
+                (work, true, LogScanState::NextSegment)
+            }
+            Err(reason) => {
+                BlockMetrics::record_fast_path_rejection(&self.metrics, partition, reason);
+                // The block-level assignment needs each segment's surviving-block
+                // count, which a prune must produce (async). The first partition
+                // to poll runs that prune for every segment through the shared
+                // `counts` cell, with as many prunes in flight as the scan has
+                // partitions; the rest await its result. Building the future here
+                // (not awaiting it) keeps `execute` synchronous, as DataFusion
+                // requires.
+                let counts_fut = plan_counts_future(
+                    Arc::clone(&self.counts),
+                    Arc::clone(&ctx),
+                    Arc::clone(&self.segments),
+                    self.target_partitions,
+                );
+                (VecDeque::new(), false, LogScanState::Planning(counts_fut))
+            }
         };
 
         Ok(Box::pin(LogScanStream {

--- a/crates/ravel-sql/src/logs_scan.rs
+++ b/crates/ravel-sql/src/logs_scan.rs
@@ -773,6 +773,10 @@ impl LogsScanExec {
     /// read whole in one GET on both the plan and scan paths (they coalesce on
     /// the same `(0, object_size)` cache key), so the fast path would add nothing
     /// and would only diverge from the existing small-object tests.
+    ///
+    /// Issue #739 revisits the threshold conjunct: it is query-wide here, so a
+    /// single below-threshold tail object disqualifies every segment in the
+    /// snapshot.
     fn whole_segment_fast_path(&self, query: &LogQuery) -> Option<usize> {
         if !query.is_block_predicate_free() {
             return None;

--- a/crates/ravel-sql/tests/logs_plan_concurrency.rs
+++ b/crates/ravel-sql/tests/logs_plan_concurrency.rs
@@ -9,6 +9,13 @@
 //! phase never holds more than one, so the "at least two held" wait below
 //! times out against it; the bound is pinned by the held count settling at
 //! `target_partitions` with more segments than that still unplanned.
+//!
+//! The fixture carries a pending erasure predicate that matches nothing, which
+//! drops no row and prunes no block but keeps the scan off the predicate-free
+//! full-window whole-segment fast path. That fast path skips the plan phase
+//! altogether, and since #739 it no longer excludes small objects, so without the
+//! predicate the held GETs below would be the fast path's per-partition segment
+//! opens -- the same count, measuring nothing about `compute_plan_counts`.
 
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
@@ -124,7 +131,16 @@ async fn plan_phase_prunes_target_partitions_segments_at_a_time() {
         Snapshot {
             segments,
             segments_pruned: 0,
-            pending_erasure: Vec::new(),
+            // Matches no record in the fixture: it prunes nothing and erases
+            // nothing, it only keeps the scan on the plan-then-stripe path (see
+            // the module doc).
+            pending_erasure: vec![ravel_proto::commit::v1::ErasureRequest {
+                predicate: vec![ravel_proto::commit::v1::ErasurePredicateMatcher {
+                    key: "absent-key".to_string(),
+                    value: "absent-value".to_string(),
+                }],
+                ..Default::default()
+            }],
         },
         TENANT,
         LogSegmentFetcher::new(store),

--- a/crates/ravel-sql/tests/logs_uncached_assignment.rs
+++ b/crates/ravel-sql/tests/logs_uncached_assignment.rs
@@ -12,6 +12,13 @@
 //! partition `j % n` and drains all of that segment's surviving blocks, so the
 //! scan issues exactly one plan read plus one scan read per segment. The cached
 //! path keeps the intra-segment block striping unchanged.
+//!
+//! Every fixture here carries a pending erasure predicate that matches nothing
+//! ([`non_matching_erasure`]), which changes no row and prunes no block but does
+//! keep the scan off the predicate-free full-window whole-segment fast path. That
+//! fast path bypasses the assignment rule these tests are about, and since #739
+//! it no longer excludes small objects, so without the predicate a bare
+//! full-window `SELECT` over this fixture would never reach `owned_work`.
 
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
@@ -164,6 +171,53 @@ async fn build_fixture(store: &dyn ObjectStoreBackend) -> (Snapshot, BTreeSet<(i
     (snapshot, want)
 }
 
+/// A pending erasure predicate that matches NOTHING in this fixture: no record
+/// carries the key `absent-key`, so `retain_log_records` drops no row and every
+/// block still survives pruning. Its only effect is to make the query not
+/// block-predicate-free, which keeps the scan off the predicate-free full-window
+/// whole-segment fast path.
+///
+/// These tests pin the ADR-0102/#693 assignment rule (`owned_work`: whole
+/// segments un-cached, block striping cached), and that rule only runs when the
+/// fast path declines. Until #739 the fixture declined it for free, because the
+/// fast path also required every segment to be above the block-range threshold
+/// and these objects are a few KiB. #739 removed that conjunct, so a bare
+/// full-window `SELECT` over this fixture now takes the fast path and never
+/// reaches `owned_work`. This restores the shape under test without perturbing a
+/// single row or block.
+fn non_matching_erasure() -> Vec<ravel_proto::commit::v1::ErasureRequest> {
+    vec![ravel_proto::commit::v1::ErasureRequest {
+        predicate: vec![ravel_proto::commit::v1::ErasurePredicateMatcher {
+            key: "absent-key".to_string(),
+            value: "absent-value".to_string(),
+        }],
+        ..Default::default()
+    }]
+}
+
+/// Sum a counter metric across every partition of the executed `LogsScanExec`.
+fn sum_metric(plan: &Arc<dyn ExecutionPlan>, name: &str) -> usize {
+    let set = find_by_name(plan, "LogsScanExec")
+        .expect("a LogsScanExec leaf")
+        .metrics()
+        .expect("the scan publishes metrics");
+    set.iter()
+        .filter(|m| m.value().name() == name)
+        .map(|m| m.value().as_usize())
+        .sum()
+}
+
+/// Assert the executed `plan` really ran the plan-then-stripe path, by the
+/// rejection reason the scan publishes when it declines the fast path (#739).
+/// Without this a future change could put these fixtures back on the fast path
+/// and the assignment assertions below would pass vacuously.
+fn assert_declined_fast_path(plan: &Arc<dyn ExecutionPlan>) {
+    assert!(
+        sum_metric(plan, "fast_path_rejected_pending_erasure") > 0,
+        "these fixtures must reach the assignment rule, not the whole-segment fast path"
+    );
+}
+
 fn provider(snapshot: Snapshot, fetcher: LogSegmentFetcher) -> LogsTableProvider {
     LogsTableProvider::new(
         snapshot,
@@ -257,7 +311,8 @@ fn build_read_cache(cache_bytes: u64) -> Arc<Cache<CacheFetchError>> {
 async fn uncached_scan_opens_each_segment_once() {
     let counting = CountingStore::new(Arc::new(MemoryStore::new()));
     let store: Arc<dyn ObjectStoreBackend> = Arc::clone(&counting) as Arc<dyn ObjectStoreBackend>;
-    let (snapshot, _want) = build_fixture(store.as_ref()).await;
+    let (mut snapshot, _want) = build_fixture(store.as_ref()).await;
+    snapshot.pending_erasure = non_matching_erasure();
 
     let fetcher = LogSegmentFetcher::new(Arc::clone(&store));
     assert!(
@@ -267,7 +322,8 @@ async fn uncached_scan_opens_each_segment_once() {
     let provider = provider(snapshot, fetcher);
 
     let plan = provider.plan(PARTS).expect("plan");
-    let _ = collect_plan(plan).await;
+    let _ = collect_plan(Arc::clone(&plan)).await;
+    assert_declined_fast_path(&plan);
 
     assert_eq!(
         counting.gets(),
@@ -284,13 +340,15 @@ async fn uncached_scan_opens_each_segment_once() {
 #[tokio::test]
 async fn uncached_segment_granular_returns_every_row_once() {
     let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
-    let (snapshot, want) = build_fixture(store.as_ref()).await;
+    let (mut snapshot, want) = build_fixture(store.as_ref()).await;
+    snapshot.pending_erasure = non_matching_erasure();
 
     let fetcher = LogSegmentFetcher::new(Arc::clone(&store));
     let provider = provider(snapshot, fetcher);
 
     let plan = provider.plan(PARTS).expect("plan");
     let batches = collect_plan(Arc::clone(&plan)).await;
+    assert_declined_fast_path(&plan);
     let got = batches_to_rows(&batches);
 
     assert_eq!(
@@ -330,7 +388,8 @@ async fn uncached_segment_granular_returns_every_row_once() {
 async fn cached_path_still_stripes_blocks_across_partitions() {
     let counting = CountingStore::new(Arc::new(MemoryStore::new()));
     let store: Arc<dyn ObjectStoreBackend> = Arc::clone(&counting) as Arc<dyn ObjectStoreBackend>;
-    let (snapshot, want) = build_fixture(store.as_ref()).await;
+    let (mut snapshot, want) = build_fixture(store.as_ref()).await;
+    snapshot.pending_erasure = non_matching_erasure();
 
     let cache = build_read_cache(64 << 20);
     let fetcher = LogSegmentFetcher::new(Arc::clone(&store)).with_cache(cache);
@@ -342,6 +401,7 @@ async fn cached_path_still_stripes_blocks_across_partitions() {
 
     let plan = provider.plan(PARTS).expect("plan");
     let batches = collect_plan(Arc::clone(&plan)).await;
+    assert_declined_fast_path(&plan);
 
     // Correctness is unchanged either way.
     assert_eq!(

--- a/crates/ravel-sql/tests/logs_whole_segment_fast_path.rs
+++ b/crates/ravel-sql/tests/logs_whole_segment_fast_path.rs
@@ -1,7 +1,7 @@
-//! Tests for issue #693 part 3 deliverable 1: a predicate-free, full-window
-//! logs statement whose window fully contains every relevant, above-threshold
-//! segment (and there are at least `target_partitions` of them) skips the plan
-//! phase entirely and reads each segment whole in ONE object-store GET.
+//! Tests for issue #693 part 3 deliverable 1, as amended by issue #739: a
+//! predicate-free, full-window logs statement whose window fully contains every
+//! relevant segment (and there are at least `target_partitions` of them) skips
+//! the plan phase entirely and reads each segment whole in ONE object-store GET.
 //!
 //! Post-#707 such a statement paid, per segment, a plan-phase suffix probe
 //! (`plan_segment_fast`) plus a scan-side re-probe per partition-open plus a
@@ -11,12 +11,18 @@
 //! whole-window case: the request count is exactly one whole-object GET per
 //! segment and zero suffix probes.
 //!
-//! The fixture uses objects ABOVE the block-range threshold (the fast path is
-//! gated there, matching `plan_segment`'s own gate): below the threshold the
-//! plan and scan reads already coalesce on one whole-object cache key, so there
-//! is no probe to save. Making the objects above-threshold is what lets the
-//! probe-count assertion mean something: the striped path would probe, the fast
-//! path does not.
+//! Most fixtures here use objects ABOVE the block-range threshold, which is what
+//! lets the probe-count assertion mean something: the striped path would probe,
+//! the fast path does not.
+//!
+//! Issue #739 then removed the threshold as a conjunct. It was query-wide, so one
+//! small object -- the tail a bulk load leaves per `(shard, hour)` -- vetoed the
+//! whole snapshot; a sub-threshold segment is read whole by the whole-segment
+//! entry and by the striped path's ranged entry alike, on the same
+//! `(0, object_size)` cache key, so it joins the assignment without changing what
+//! is read. `mixed_threshold_snapshot_takes_the_fast_path` pins that, and the
+//! `rejection_reason_*` tests pin the `fast_path_rejected_*` counter the scan
+//! publishes when a query-wide conjunct does fail.
 
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
@@ -159,6 +165,43 @@ async fn build_fixture(store: &dyn ObjectStoreBackend) -> (Snapshot, BTreeSet<(i
         pending_erasure: Vec::new(),
     };
     (snapshot, want)
+}
+
+/// [`build_fixture`] plus one deliberately smaller tail segment, the shape a bulk
+/// load leaves behind (one small object per `(shard, hour)`). Returns the
+/// snapshot, the full written row set, and the tail's object size, which callers
+/// use as the block-range threshold so the tail lands at or below it and the
+/// `SEGMENTS` full segments land above it.
+async fn build_fixture_with_tail(
+    store: &dyn ObjectStoreBackend,
+) -> (Snapshot, BTreeSet<(i64, String)>, u64) {
+    let (mut snapshot, mut want) = build_fixture(store).await;
+    let ts = (SEGMENTS * 1000) as i64;
+    let tail_record = record(ts, "tail-r0");
+    want.insert((ts, tail_record.body.clone()));
+    let mut content_hash = [0u8; 32];
+    content_hash[0] = (SEGMENTS + 1) as u8;
+    let tail = write_object(store, "logs/tail.rlog", content_hash, &[tail_record]).await;
+    let tail_size = tail.object_size;
+
+    // Prove the fixture actually splits across the threshold it is about to set:
+    // if a one-record object were not strictly smaller than a three-record one,
+    // every segment would sit on the same side and the test would pass for the
+    // wrong reason.
+    let smallest_full = snapshot
+        .segments
+        .iter()
+        .map(|s| s.object_size)
+        .min()
+        .expect("SEGMENTS full segments");
+    assert!(
+        tail_size < smallest_full,
+        "the tail object ({tail_size} B) must be strictly smaller than every full \
+         segment (smallest {smallest_full} B) for the threshold split to be real"
+    );
+
+    snapshot.segments.push(tail);
+    (snapshot, want, tail_size)
 }
 
 fn provider(snapshot: Snapshot, fetcher: LogSegmentFetcher) -> LogsTableProvider {
@@ -363,9 +406,11 @@ async fn predicate_free_full_window_reads_one_whole_object_per_segment() {
 }
 
 /// The fast path returns byte-identical rows to the striped path over the same
-/// data. The striped path is forced by raising the block-range threshold above
-/// the object size, so the fast-path gate's `object_size > threshold` conjunct
-/// fails and the unchanged plan-then-stripe path runs.
+/// data. The striped path is forced by asking for more partitions than there are
+/// relevant segments, so the `relevant_segments >= target_partitions` conjunct
+/// fails and the unchanged plan-then-stripe path runs. (It used to be forced by
+/// raising the block-range threshold above the object size; #739 removed that
+/// conjunct, so a high threshold no longer stripes anything.)
 #[tokio::test]
 async fn fast_path_rows_match_the_striped_path() {
     let base = Arc::new(MemoryStore::new());
@@ -382,16 +427,18 @@ async fn fast_path_rows_match_the_striped_path() {
         .await,
     );
 
-    let striped = LogSegmentFetcher::new(Arc::clone(&store))
-        .with_cache(build_read_cache(64 << 20))
-        .with_block_range_threshold(u64::MAX);
-    let striped_rows = batches_to_rows(
-        &collect_plan(
-            provider(snapshot, striped)
-                .plan(PARTS)
-                .expect("striped plan"),
-        )
-        .await,
+    let striped = above_threshold_fetcher(Arc::clone(&store));
+    let striped_plan = provider(snapshot, striped)
+        .plan(SEGMENTS * 2)
+        .expect("striped plan");
+    let striped_rows = batches_to_rows(&collect_plan(Arc::clone(&striped_plan)).await);
+    assert_eq!(
+        sum_metric(
+            &striped_plan,
+            "fast_path_rejected_fewer_segments_than_partitions"
+        ),
+        SEGMENTS * 2,
+        "the comparison run must actually be on the striped path"
     );
 
     assert_eq!(fast_rows, striped_rows, "fast and striped rows must match");
@@ -411,6 +458,16 @@ async fn assert_takes_striped_path(
     parts: usize,
     pending_erasure: Vec<ravel_proto::commit::v1::ErasureRequest>,
 ) -> u64 {
+    run_striped(filters, parts, pending_erasure).await.0
+}
+
+/// [`assert_takes_striped_path`], also handing back the executed plan so a caller
+/// can read the `fast_path_rejected_*` counters off its metrics.
+async fn run_striped(
+    filters: &[datafusion::logical_expr::Expr],
+    parts: usize,
+    pending_erasure: Vec<ravel_proto::commit::v1::ErasureRequest>,
+) -> (u64, Arc<dyn ExecutionPlan>) {
     let base = Arc::new(MemoryStore::new());
     let (mut snapshot, _want) = build_fixture(base.as_ref()).await;
     snapshot.pending_erasure = pending_erasure;
@@ -421,8 +478,8 @@ async fn assert_takes_striped_path(
     let plan = provider(snapshot, fetcher)
         .plan_filters(parts, filters)
         .expect("plan");
-    let _ = collect_plan(plan).await;
-    counting.suffix_gets()
+    let _ = collect_plan(Arc::clone(&plan)).await;
+    (counting.suffix_gets(), plan)
 }
 
 #[tokio::test]
@@ -482,5 +539,184 @@ async fn conjunct_fewer_segments_than_partitions_takes_striped_path() {
     assert_eq!(
         probes, SEGMENTS as u64,
         "undersubscribed striped path: one plan suffix probe per segment, none per open"
+    );
+}
+
+// ---- issue #739: the threshold is not a query-wide conjunct ---------------
+
+/// Every `fast_path_rejected_*` counter the scan can publish. A test that expects
+/// one of them asserts the other three are absent, so a reason is pinned rather
+/// than merely present.
+const REJECTION_METRICS: [&str; 4] = [
+    "fast_path_rejected_pending_erasure",
+    "fast_path_rejected_block_predicate",
+    "fast_path_rejected_segment_not_contained",
+    "fast_path_rejected_fewer_segments_than_partitions",
+];
+
+/// Assert `expected` is the only rejection reason the executed `plan` recorded,
+/// with one increment per partition. `None` asserts no rejection at all, i.e.
+/// the fast path fired.
+fn assert_rejection(plan: &Arc<dyn ExecutionPlan>, expected: Option<(&str, usize)>) {
+    for name in REJECTION_METRICS {
+        let got = sum_metric(plan, name);
+        let want = match expected {
+            Some((n, count)) if n == name => count,
+            _ => 0,
+        };
+        assert_eq!(got, want, "{name}: expected {want} increments, got {got}");
+    }
+}
+
+/// #739: a snapshot mixing `SEGMENTS` above-threshold segments with one
+/// sub-threshold tail segment still takes the fast path, and reads each of the
+/// `SEGMENTS + 1` segments in exactly one whole-object GET with zero probes.
+///
+/// Before #739 the threshold conjunct was query-wide, so the single tail object
+/// disqualified all `SEGMENTS + 1`: the whole statement striped, paying one plan
+/// suffix probe per above-threshold segment. That is what this test is red
+/// against.
+#[tokio::test]
+async fn mixed_threshold_snapshot_takes_the_fast_path() {
+    const RELEVANT: usize = SEGMENTS + 1;
+
+    let base = Arc::new(MemoryStore::new());
+    let (snapshot, want, tail_size) = build_fixture_with_tail(base.as_ref()).await;
+
+    let counting = ShapeCountingStore::new(base);
+    let store: Arc<dyn ObjectStoreBackend> = Arc::clone(&counting) as Arc<dyn ObjectStoreBackend>;
+    // `object_size > threshold` is false at exactly `tail_size`, so the tail is
+    // the one sub-threshold segment and every full segment is above it.
+    let fetcher = LogSegmentFetcher::new(store)
+        .with_cache(build_read_cache(64 << 20))
+        .with_block_range_threshold(tail_size);
+
+    // PARTS <= RELEVANT, so the `relevant >= target_partitions` conjunct holds.
+    let plan = provider(snapshot, fetcher).plan(PARTS).expect("plan");
+    let batches = collect_plan(Arc::clone(&plan)).await;
+
+    assert_eq!(
+        counting.suffix_gets(),
+        0,
+        "one sub-threshold segment must not put the statement back on the probing \
+         striped path (full={}, range={})",
+        counting.full_gets(),
+        counting.range_gets()
+    );
+    assert_eq!(
+        counting.range_gets(),
+        0,
+        "the fast path issues no byte-range GETs"
+    );
+    assert_eq!(
+        counting.full_gets(),
+        RELEVANT as u64,
+        "exactly one whole-object read per relevant segment, tail included"
+    );
+    assert_rejection(&plan, None);
+
+    assert_eq!(
+        batches_to_rows(&batches),
+        want,
+        "every written row, including the tail's, exactly once"
+    );
+
+    // Recorded once per segment, not once per partition and not once per open.
+    assert_eq!(
+        sum_metric(&plan, "blocks_total"),
+        SEGMENTS * BLOCKS_PER_SEG + 1,
+        "blocks_total covers the full segments plus the tail's single block"
+    );
+    assert_eq!(
+        sum_metric(&plan, "blocks_scanned"),
+        SEGMENTS * BLOCKS_PER_SEG + 1,
+        "every block is scanned exactly once"
+    );
+}
+
+/// The mixed snapshot's rows are identical to what the same data returns on the
+/// striped path (forced by oversubscribing partitions), so joining the tail to
+/// the whole-segment assignment changed the read shape and nothing else.
+#[tokio::test]
+async fn mixed_threshold_rows_match_the_striped_path() {
+    let base = Arc::new(MemoryStore::new());
+    let (snapshot, want, tail_size) = build_fixture_with_tail(base.as_ref()).await;
+    let store: Arc<dyn ObjectStoreBackend> = base;
+
+    let fetcher = || {
+        LogSegmentFetcher::new(Arc::clone(&store))
+            .with_cache(build_read_cache(64 << 20))
+            .with_block_range_threshold(tail_size)
+    };
+
+    let fast_plan = provider(snapshot.clone(), fetcher())
+        .plan(PARTS)
+        .expect("fast");
+    let fast_rows = batches_to_rows(&collect_plan(Arc::clone(&fast_plan)).await);
+    assert_rejection(&fast_plan, None);
+
+    let striped_parts = (SEGMENTS + 1) * 2;
+    let striped_plan = provider(snapshot, fetcher())
+        .plan(striped_parts)
+        .expect("striped");
+    let striped_rows = batches_to_rows(&collect_plan(Arc::clone(&striped_plan)).await);
+    assert_rejection(
+        &striped_plan,
+        Some((
+            "fast_path_rejected_fewer_segments_than_partitions",
+            striped_parts,
+        )),
+    );
+
+    assert_eq!(fast_rows, striped_rows, "fast and striped rows must match");
+    assert_eq!(fast_rows, want, "and both equal the written rows");
+}
+
+// ---- issue #739 deliverable 2: the recorded rejection reason -------------
+
+#[tokio::test]
+async fn rejection_reason_block_predicate() {
+    use datafusion::logical_expr::{col, lit};
+    let expr = ravel_sql::has_word_udf().call(vec![col("body"), lit("s0-r0")]);
+    let (_probes, plan) = run_striped(&[expr], PARTS, Vec::new()).await;
+    assert_rejection(&plan, Some(("fast_path_rejected_block_predicate", PARTS)));
+}
+
+#[tokio::test]
+async fn rejection_reason_segment_not_contained() {
+    use datafusion::common::ScalarValue;
+    use datafusion::logical_expr::{col, lit};
+    let global_max = ((SEGMENTS - 1) * 1000 + (RECORDS_PER_SEG - 1)) as i64;
+    let expr = col("ts").lt_eq(lit(ScalarValue::TimestampNanosecond(
+        Some(global_max - 1),
+        None,
+    )));
+    let (_probes, plan) = run_striped(&[expr], PARTS, Vec::new()).await;
+    assert_rejection(
+        &plan,
+        Some(("fast_path_rejected_segment_not_contained", PARTS)),
+    );
+}
+
+#[tokio::test]
+async fn rejection_reason_pending_erasure() {
+    let erasure = vec![ravel_proto::commit::v1::ErasureRequest {
+        predicate: vec![ravel_proto::commit::v1::ErasurePredicateMatcher {
+            key: "service.name".to_string(),
+            value: "svc".to_string(),
+        }],
+        ..Default::default()
+    }];
+    let (_probes, plan) = run_striped(&[], PARTS, erasure).await;
+    assert_rejection(&plan, Some(("fast_path_rejected_pending_erasure", PARTS)));
+}
+
+#[tokio::test]
+async fn rejection_reason_fewer_segments_than_partitions() {
+    let parts = SEGMENTS * 2;
+    let (_probes, plan) = run_striped(&[], parts, Vec::new()).await;
+    assert_rejection(
+        &plan,
+        Some(("fast_path_rejected_fewer_segments_than_partitions", parts)),
     );
 }

--- a/docs/adrs/0102-intra-segment-scan-partitioning-and-spill-policy.md
+++ b/docs/adrs/0102-intra-segment-scan-partitioning-and-spill-policy.md
@@ -477,3 +477,47 @@ there is no probe to eliminate. `BlockMetrics::record_segment_totals` moves from
 the partition-0 planning hack to per-segment scan stats on this path (each
 segment has exactly one owning partition, so the whole-segment totals are still
 recorded exactly once).
+
+## Amendment (2026-08-26, #739): the block-range threshold is no longer a conjunct
+
+The amendment above lists four conjuncts, and conjunct 3 requires every relevant
+segment to be above the block-range threshold. That conjunct is removed. The
+other three (block-predicate freedom, no pending erasure, and at least
+`target_partitions` relevant segments) and the containment half of conjunct 3
+are unchanged, so conjunct 3 now reads: every relevant (ts-overlapping) segment
+has a well-formed span and is fully CONTAINED in the query window.
+
+The threshold conjunct was query-wide, and that is what broke: a bulk load leaves
+one small tail object per `(shard, hour)`, so a single sub-512-KiB object
+disqualified every segment in the snapshot. Measured on the 8,424-object
+ClickBench tenant (#680), a predicate-free full-window
+`COUNT(DISTINCT UserID)` at 32 partitions issued 22,473 GETs where the fast path
+would have issued 8,424 plus the resolve's own reads: the fast path never fired,
+because one object out of 8,424 sat below the threshold.
+
+It is removed rather than evaluated per segment because per segment it decides
+nothing. At or below the threshold both entries land in the same
+`LogSegmentFetcher::whole_object_bytes`: the whole-segment entry
+(`scan_whole_accounted_with_tenant`) calls it unconditionally, and the striped
+path's `tenant_bytes_with_footer` falls through to it for exactly the objects
+the threshold excludes. That is one `GetRange::Full` on the `(0, object_size)`
+cache key, the same `QueryAccounting` records, and no `EtagPin` on either side,
+since a single GET observes a single object state. So a sub-threshold segment
+reads identically whichever entry opens it, and it can be assigned whole to one
+partition without changing a byte of what is read, while the above-threshold
+segments around it keep the probe elimination this fast path exists for.
+
+The consequence the earlier text worried about is real and accepted: a snapshot
+whose segments are ALL at or below the threshold now takes the fast path too,
+where it previously striped. Nothing is read differently there either -- the
+plan phase's whole-object read and the scan's are the same cache key, so what
+the fast path removes is the plan pass itself, not a GET.
+
+When a conjunct does fail, the scan now says which one. `LogsScanExec::execute`
+publishes a DataFusion counter named for the first failing conjunct
+(`fast_path_rejected_pending_erasure`, `fast_path_rejected_block_predicate`,
+`fast_path_rejected_segment_not_contained`,
+`fast_path_rejected_fewer_segments_than_partitions`), one increment per
+partition, and no such counter at all when the fast path fires. A latency report
+reading the scan's metrics can then state why a statement striped instead of
+inferring it from GET counts.

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -133,20 +133,24 @@ Every OTHER predicate-free, full-window logs statement — `SUM`, `AVG`,
 `GROUP BY`, `ORDER BY ... LIMIT` over the whole table — still executes
 `LogsScanExec`, but issues exactly one whole-object GET per relevant segment and
 ZERO suffix probes (#693 part 3). When the query carries no block-level
-predicate and no pending erasure, its window fully contains every relevant,
-above-threshold segment, and there are at least `target_partitions` such
-segments, `LogsScanExec` skips its plan phase entirely: no block can be pruned,
+predicate and no pending erasure, its window fully contains every relevant
+segment, and there are at least `target_partitions` of them, `LogsScanExec`
+skips its plan phase entirely: no block can be pruned,
 so it assigns whole segments round-robin (one owner per segment) and reads each
 in a single `GetRange::Full`. That removes both probe classes the pre-#693-part-3
 path paid above the block-range threshold — the plan-phase footer probe and the
 per-open scan-side re-probe — which on the 8424-object ClickBench tenant (#680)
 were a combined ~24,700 probes on top of the 8,424 whole-object reads for one
 `SELECT`. When any of those conditions fails the unchanged plan-then-stripe path
-runs (its plan phase probes each segment once); a footer read there is carried
-to the per-partition subset opens so they skip re-probing (ADR-0107 amendment
-2026-08-26). At or below the block-range threshold the plan and scan reads
-already coalesce on one whole-object cache key, so the fast path is gated above
-it, where there is a probe to save.
+runs (its plan phase probes each segment once), and the scan publishes a
+`fast_path_rejected_*` counter naming the conjunct that sent it there; a footer
+read there is carried to the per-partition subset opens so they skip re-probing
+(ADR-0107 amendment 2026-08-26). Object size is not one of the conditions: a
+segment at or below the block-range threshold is read whole by the whole-segment
+entry and by the striped path alike, on the same `(0, object_size)` cache key,
+so it joins the assignment rather than vetoing it (ADR-0102 amendment
+2026-08-26, #739 -- as a query-wide conjunct the threshold let one small tail
+object per `(shard, hour)` disqualify an entire 8,424-object snapshot).
 
 Staleness: the evaluator recognizes the Prometheus staleness marker (the
 exact NaN bit pattern `0x7ff0_0000_0000_0002`, compared via
@@ -1484,17 +1488,21 @@ per segment. `ravel-bench`'s `logs_scan_scaling` report measures the cached and
 un-cached request counts side by side, on above-threshold and whole-object read
 shapes alike; its figures describe that fixture (a `MemoryStore`, and on the
 cached rows a cache sized to hold the whole dataset), not striping in general.
-Its over-threshold rows are what put a number on the residual multiplier, and
-what show where it no longer applies: each row carries reads per segment and
-bytes fetched over dataset bytes, derived in the report rather than left to the
-reader. For a block-predicate-free statement whose window contains every
-relevant segment — the report's `SELECT ts, body FROM logs`, and the shape the
-whole-segment fast path serves (#693 part 3) — those two figures are 1 and
-about 1.0 at every partition count that fits inside the segment count, with or
-without a cache: the plan phase is skipped and each segment is read whole once,
-so there is nothing left for the cache to absorb. The multiplier reappears on
-the row whose partition count exceeds the segment count, which falls back to
-plan-then-stripe. `crates/ravel-query/tests/log_block_range.rs` pins the
+Its rows put a number on the residual multiplier and show where it no longer
+applies: each row carries reads per segment and bytes fetched over dataset
+bytes, derived in the report rather than left to the reader. For a
+block-predicate-free statement whose window contains every relevant segment —
+the report's `SELECT ts, body FROM logs`, and the shape the whole-segment fast
+path serves (#693 part 3, amended by #739) — those two figures are 1 and about
+1.0 at every partition count that fits inside the segment count, on both read
+shapes and with or without a cache: since #739 dropped the block-range-threshold
+conjunct, object size no longer gates the fast path, so the plan phase is skipped
+and each segment is read whole once, and there is nothing left for the cache to
+absorb. The multiplier reappears only on the cache-wired row whose partition
+count exceeds the segment count, which falls back to plan-then-stripe — and even
+there only on the above-threshold read shape, since a whole-object stripe
+coalesces onto the one `(0, object_size)` cache key.
+`crates/ravel-query/tests/log_block_range.rs` pins the
 above-threshold cached case exactly: on its 906,791-byte fixture, 2 partitions
 and 8 partitions striping one segment both cost 6 store GETs (one probe, four
 directory sections, one coalesced candidate run), and 8 concurrent cold

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -1493,9 +1493,11 @@ applies: each row carries reads per segment and bytes fetched over dataset
 bytes, derived in the report rather than left to the reader. For a
 block-predicate-free statement whose window contains every relevant segment —
 the report's `SELECT ts, body FROM logs`, and the shape the whole-segment fast
-path serves (#693 part 3, amended by #739) — those two figures are 1 and about
-1.0 at every partition count that fits inside the segment count, on both read
-shapes and with or without a cache: since #739 dropped the block-range-threshold
+path serves (#693 part 3, amended by #739) — those two figures are about 1
+(the reads figure divides every accounted GET by the segment count, so the
+resolve's one catalog probe lifts it slightly above 1: 1.03 on the 32-segment
+fixture) and 1.0 at every partition count that fits inside the segment count,
+on both read shapes and with or without a cache: since #739 dropped the block-range-threshold
 conjunct, object size no longer gates the fast path, so the plan phase is skipped
 and each segment is read whole once, and there is nothing left for the cache to
 absorb. The multiplier reappears only on the cache-wired row whose partition


### PR DESCRIPTION
The whole-segment fast path (#693 part 3) fired only when every relevant
segment was above the block-range threshold. A bulk load leaves a small
tail object per (shard, hour), and one sub-512 KiB object routed all
8,424 segments of the ClickBench tenant through the plan-then-stripe
path: a predicate-free full-window statement issued 22,473 GETs where the
fast path yields one whole-object read per segment.

A sub-threshold segment reads identically on either path: the
whole-segment entry (scan_whole_accounted_with_tenant) calls
whole_object_bytes unconditionally, and the striped path's
tenant_bytes_with_footer falls through to the same single GetRange::Full
with the same cache key and accounting for object_size <=
block_range_threshold, with no etag pin on either side. So the conjunct
came out; predicate freedom, window containment of every relevant
segment, no pending erasure, and relevant_segments >= target_partitions
remain query-wide. When the fast path is not taken the rejecting
conjunct is recorded as a per-partition metrics counter
(fast_path_rejected_<reason>, FastPathRejection: PendingErasure,
BlockPredicate, SegmentNotContained, FewerSegmentsThanPartitions), so a
report can say why a statement striped.

Tests: four above-threshold segments plus one sub-threshold tail take
the fast path at 5 whole-object reads and 0 suffix or range GETs (9 with
the conjunct restored), with rows identical to the striped path; one
test per rejection reason asserts its counter alone appears. Two
logs_uncached_assignment fixtures and logs_plan_concurrency were kept
off the fast path only by the threshold; they gain a no-op pending
erasure predicate (matching no record) so they keep pinning the striped
path and the concurrent plan phase, each asserting the rejection counter
so they cannot go vacuous. ravel-bench's cache_flag_cuts_store_gets test
gains a has_word predicate for the same reason, and the
logs_scan_scaling module doc no longer claims its small-object fixture
stays off the fast path. ADR-0102's fast-path amendment carries the
per-segment rule; docs/query-engine.md's request-count paragraph is
updated.

Ported onto main after #745 added the over_threshold axis to the
logs_scan_scaling report: with the conjunct gone, object size decides
nothing, so the whole-object rows take the fast path at or below the
segment count too and only the cache-wired 64-partition row stripes. The
smoke test's takes_fast_path drops its over_threshold conjunct and pins
both axes; against #745's test the port fails at the cache-wired
over_threshold=false flatness check (tp=64 stripes at 98 GETs against 33),
and with the conjunct restored the ported test fails at the fast-path
request count (65 GETs where 33 is due).

Fixes: #739
Refs: #693
Refs: #680
