### PR TITLE
feat(ravel-cli): let catalog fold/inspect/verify act on any signal

### DIFF
--- a/docs/guides/operations.md
+++ b/docs/guides/operations.md
@@ -240,9 +240,9 @@ above).
 | `ravel-cli maintain migrate --tenant <n> --signal <metrics\|logs\|spans> [--shards <n>] [--target-version <n>] [--family <name>] [--budget-records <n>]` | `--shards` default `4`, `--budget-records` default `0` (unlimited) | Migrates every live record below `--target-version` (defaults to the signal's current supported version) and raises the recorded format floor once a fresh re-audit confirms nothing below it survives (see "Format migration" below). Resumable: re-run to continue from the durable cursor after a budget stop. A refused raise ("FOUND STRAGGLERS") means genuine live data still below target, not a self-inflicted false positive -- no interleaved `sweep` is needed for this to converge. |
 | `ravel-cli maintain verify-custody --tenant <n> [--shards <n>]` | `--shards` default `4` | Read-only, no `--dry-run` (nothing is written or deleted). Re-verifies the content-addressed chain at rest: every live data object's key-embedded `hash16` against its actual content hash, and every surviving compaction record's referenced inputs (a mismatch is an anomaly; an input the sweeper already legitimately reclaimed past its protection horizon is reported separately, not as an anomaly). Exits nonzero on any anomaly. |
 | `ravel-cli catalog list --tenant <name> [--hours <n>] [--shards <n>]` | `--hours` default `1`, `--shards` default `4` | Lists commit records that the catalog resolves for that tenant over the last `hours` hours. `--shards` must match the shard count the data was written with. |
-| `ravel-cli catalog fold --tenant <name> [--shards <n>]` | `--shards` default `4` | One-shot catalog fold: seals every eligible hour into a new snapshot part and CAS-advances HEAD. Prints the fold report (watermark before/after, buckets folded, entry count, request counts). This is the same operation that the background fold task runs on a timer. |
-| `ravel-cli catalog inspect --tenant <name>` | | Decodes and prints HEAD and every referenced snapshot part: watermark, part keys, hashes, entry counts. It reports rather than errors when no HEAD exists yet. |
-| `ravel-cli catalog verify --tenant <name>` | | Re-lists every sealed commit record and diffs it against the current snapshot. Prints counts of entries missing from or mismatched against the snapshot; exits nonzero on any divergence. It reports rather than errors when no HEAD exists yet. |
+| `ravel-cli catalog fold --tenant <name> [--shards <n>] [--signal <metrics\|logs\|spans>]` | `--shards` default `4`, `--signal` default `metrics` | One-shot catalog fold for one (tenant, signal): seals every eligible hour into a new snapshot part and CAS-advances that signal's HEAD. Prints the fold report (watermark before/after, buckets folded, entry count, request counts). A tenant's logs snapshot is a separate object from its metrics snapshot, so a logs or spans tenant is never folded unless `--signal` names it; without a snapshot, every query on that signal lists and reads every commit record in its window. Folding metrics on a logs-only tenant reports `entry_count 0` and publishes an empty metrics HEAD. This is the same operation the background fold task runs on a timer, which covers all three signals (metrics, logs, and spans) in every mode except `--mode maintain`, where it does not run at all. |
+| `ravel-cli catalog inspect --tenant <name> [--signal <metrics\|logs\|spans>]` | `--signal` default `metrics` | Decodes and prints that signal's HEAD and every referenced snapshot part: watermark, part keys, hashes, entry counts. Names the signal both as a word and as the numeric proto value read off the object, so a HEAD stamped with a signal other than the one asked for is visible. It reports rather than errors when no HEAD exists yet, which is what a logs tenant inspected without `--signal logs` looks like. |
+| `ravel-cli catalog verify --tenant <name> [--signal <metrics\|logs\|spans>]` | `--signal` default `metrics` | Re-lists every sealed commit record for that signal and diffs it against that signal's snapshot. Prints counts of entries missing from or mismatched against the snapshot; exits nonzero on any divergence. It reports rather than errors when no HEAD exists yet, so on a logs tenant it reports "nothing to verify" unless `--signal logs` is given. Verify each signal the tenant actually writes. |
 | `ravel-cli provision adopt --tenant <name> --shards <n> [--signal <metrics\|logs\|spans>]` | | Writes the durable `shard_count` provisioning record for a tenant with pre-ADR data, ahead of any server touching it (ADR-0050 section 5). Runs the same adoption path the server runs: writes the record only when every observed shard index is below `--shards`, and refuses (writing nothing, exiting nonzero) when a higher index proves `--shards` would hide data. Prints one line per signal. A signal with no data and no record is left untouched (its record is written on first ingest). |
 | `ravel-cli typed-attr-column show <tenant>` | | Prints the tenant's durable declared typed attribute columns (ADR-0090 decision 1) from `TenantConfig.typed_attr_columns`, in schema-append order. Distinguishes three states: no config record, a record with no declaration (both leave the deployment default in force), and a present declaration (which replaces the default, including when it is explicitly empty). |
 | `ravel-cli typed-attr-column set <tenant> [KEY:TYPE ...]` | | Replaces the tenant's durable declaration wholesale, validated on the same rules the server's flags are (empty key, duplicate key, conflicting types, fixed-column collision), then swapped with `CasVersion` so a concurrent write is a reported conflict rather than a silent overwrite. Not additive and with no per-key remove: pass the full intended list. Passing no declaration writes an explicit empty one, which means "this tenant declares nothing" and is distinct from having no override. Every other field of the record is carried through unchanged. A query-serving process picks the change up within its staleness horizon (60s); no restart is needed. |
@@ -280,7 +280,8 @@ that already-sealed bucket becomes invisible to non-token queries. A
 key directly, never through the snapshot. This is the one failure mode
 that needs an operator repair rather than resolving itself:
 
-1. Run `ravel-cli catalog verify --tenant <name>` (per signal). A nonzero
+1. Run `ravel-cli catalog verify --tenant <name> --signal <signal>` (once per
+   signal the tenant writes; `--signal` defaults to metrics). A nonzero
    exit and a nonempty "missing from snapshot" count confirm sealed
    commits that the snapshot does not know about.
 2. Delete the tenant's HEAD object for the affected signal:
@@ -289,12 +290,12 @@ that needs an operator repair rather than resolving itself:
    (`mc rm` against MinIO, `aws s3 rm` against S3). Deleting HEAD is safe.
    `Catalog::fold` treats an absent HEAD as "no snapshot yet" and rebuilds
    one from a full listing rather than errors.
-3. Run `ravel-cli catalog fold --tenant <name> --shards <n>` (or wait for
-   the next background fold tick). The fold report's `rebuilt: true` line
-   confirms that it rebuilt from scratch rather than extended the prior
-   snapshot.
-4. Re-run `ravel-cli catalog verify --tenant <name>` to confirm that the
-   divergence is gone.
+3. Run `ravel-cli catalog fold --tenant <name> --shards <n> --signal <signal>`
+   for the affected signal (or wait for the next background fold tick). The
+   fold report's `rebuilt: true` line confirms that it rebuilt from scratch
+   rather than extended the prior snapshot.
+4. Re-run `ravel-cli catalog verify --tenant <name> --signal <signal>` to
+   confirm that the divergence is gone.
 
 There is no `catalog fold --force-rebuild` flag. Deleting HEAD is the
 supported way to force one, because it reuses the same absent-HEAD path that
@@ -2065,13 +2066,14 @@ reattach.
 
    ```sh
    ravel-cli maintain verify-custody --tenant <name>
-   ravel-cli catalog verify --tenant <name>
+   ravel-cli catalog verify --tenant <name> --signal <signal>
    ```
 
    `verify-custody` re-hashes every live data object against its key and
    confirms every surviving record's data is present; `catalog verify`
-   re-lists sealed records and diffs them against the snapshot. Both must be
-   clean (exit zero) before you trust the repair.
+   re-lists sealed records and diffs them against the snapshot for the one
+   signal `--signal` names (default metrics), so run it once per signal the
+   tenant writes. Both must be clean (exit zero) before you trust the repair.
 4. **Resume maintenance.** Restart the `--mode maintain` process without the
    `--maintain-tenant` restriction (or restart the stopped one). The sweeper
    now sees the reconstructed records and treats their data objects as

--- a/services/ravel-cli/src/catalog.rs
+++ b/services/ravel-cli/src/catalog.rs
@@ -3,13 +3,21 @@
 //! referenced snapshot part), and `verify` (re-list sealed commit records
 //! and diff against the snapshot). Built strictly against `ravel-catalog`'s
 //! public API: no new methods added to that crate for this tool.
+//!
+//! Every one of the three is per (tenant, signal), exactly as
+//! `ravel_catalog::Catalog::fold` and the ADR-0020 resolve are: a tenant's
+//! logs snapshot is a different object from its metrics snapshot, and folding
+//! one leaves the other untouched. `--signal` selects which, defaulting to
+//! metrics.
 
 use std::sync::Arc;
 
-use ravel_catalog::{CatalogConfig, PartLimits};
+use ravel_catalog::{CatalogConfig, FoldReport, PartLimits};
 use ravel_object_store::{GetRange, ObjectStoreBackend};
 use ravel_types::{Signal, TenantHash, TenantId};
 use uuid::Uuid;
+
+use crate::maintain::SignalArg;
 
 /// HEAD object key (docs/catalog-and-mvcc.md key layout, frozen format).
 /// Duplicated here rather than imported: `ravel-catalog` only exposes the
@@ -19,12 +27,19 @@ fn head_key(tenant: &TenantHash, signal: Signal) -> String {
     format!("t/{}/catalog/{}/HEAD", tenant.to_hex(), signal.key_prefix())
 }
 
-/// Folds one signal's catalog snapshot for a tenant (issue #718).
+/// Folds one signal's catalog snapshot for a tenant, and returns the report it
+/// printed so a caller (the tests) can assert on it rather than on stdout.
+///
+/// `signal` picks which snapshot is folded. A logs or spans tenant is folded
+/// only when `signal` names it: folding metrics on a logs tenant seals nothing
+/// and publishes an empty metrics HEAD, leaving every logs query to re-derive
+/// its snapshot by listing and reading every commit record (issue #718).
 pub async fn fold(
     store: Arc<dyn ObjectStoreBackend>,
     tenant: &str,
     shard_count: u32,
-) -> anyhow::Result<()> {
+    signal: SignalArg,
+) -> anyhow::Result<FoldReport> {
     let catalog_config = CatalogConfig {
         shard_count,
         ..CatalogConfig::default()
@@ -43,10 +58,11 @@ pub async fn fold(
     let now = crate::now_ns()?;
     let folder_id = Uuid::new_v4();
     let report = catalog
-        .fold(&tenant_hash, Signal::Metrics, folder_id, now, &[], None)
+        .fold(&tenant_hash, signal.to_signal(), folder_id, now, &[], None)
         .await
         .map_err(|err| anyhow::anyhow!("fold failed: {err}"))?;
 
+    println!("signal: {}", signal_word(signal.to_signal()));
     println!("no_op: {}", report.no_op);
     println!("rebuilt: {}", report.rebuilt);
     println!(
@@ -60,12 +76,16 @@ pub async fn fold(
     println!("list_requests: {}", report.list_requests);
     println!("get_requests: {}", report.get_requests);
     println!("put_requests: {}", report.put_requests);
-    Ok(())
+    Ok(report)
 }
 
-pub async fn inspect(store: Arc<dyn ObjectStoreBackend>, tenant: &str) -> anyhow::Result<()> {
+pub async fn inspect(
+    store: Arc<dyn ObjectStoreBackend>,
+    tenant: &str,
+    signal: SignalArg,
+) -> anyhow::Result<()> {
     let mut out = String::new();
-    let result = render_inspect(store, tenant, &mut out).await;
+    let result = render_inspect(store, tenant, signal, &mut out).await;
     // Print whatever was rendered even on error: a part fetch/decode failure
     // partway through must not discard the HEAD fields and every earlier
     // part's ref this call already rendered -- an operator inspecting a
@@ -75,7 +95,7 @@ pub async fn inspect(store: Arc<dyn ObjectStoreBackend>, tenant: &str) -> anyhow
     result
 }
 
-/// Decodes the tenant's metrics HEAD and every referenced snapshot part into
+/// Decodes the tenant's HEAD for `signal` and every referenced snapshot part into
 /// the human-readable report `inspect` prints, appending into `out` as it
 /// goes so a failure partway through still leaves everything rendered so far
 /// in `out` for the caller to print. Returns `Err` (with `out` still holding
@@ -90,10 +110,11 @@ pub async fn inspect(store: Arc<dyn ObjectStoreBackend>, tenant: &str) -> anyhow
 pub async fn render_inspect(
     store: Arc<dyn ObjectStoreBackend>,
     tenant: &str,
+    signal: SignalArg,
     out: &mut String,
 ) -> anyhow::Result<()> {
     let tenant_hash = TenantId::new(tenant).hash();
-    let key = head_key(&tenant_hash, Signal::Metrics);
+    let key = head_key(&tenant_hash, signal.to_signal());
 
     let head_bytes = match store.get(&key, GetRange::Full).await {
         Ok(outcome) => outcome.data,
@@ -110,7 +131,14 @@ pub async fn render_inspect(
         "tenant_hash: {}\n",
         hex::encode(&head.tenant_hash)
     ));
-    out.push_str(&format!("signal: {}\n", head.signal));
+    // Both the word and the numeric proto value: the word is what an operator
+    // reads, the number is what is actually on the object, and the two differing
+    // from the `--signal` that was asked for is itself the finding.
+    out.push_str(&format!(
+        "signal: {} ({})\n",
+        head_signal_word(head.signal),
+        head.signal
+    ));
     out.push_str(&format!("shard_count: {}\n", head.shard_count));
     out.push_str(&format!("watermark_hour: {}\n", head.watermark_hour));
     out.push_str(&format!(
@@ -157,6 +185,31 @@ pub async fn render_inspect(
     Ok(())
 }
 
+/// The `--signal` spelling of a [`Signal`], so every report names the signal
+/// with the same word the flag accepts.
+fn signal_word(signal: Signal) -> &'static str {
+    match signal {
+        Signal::Metrics => "metrics",
+        Signal::Logs => "logs",
+        Signal::Spans => "spans",
+        Signal::Profiles => "profiles",
+        Signal::Alerts => "alerts",
+        Signal::Audit => "audit",
+    }
+}
+
+/// The same word for a `SnapshotHead.signal` field as read off the object,
+/// which is a raw proto enum value and so can be a value no signal maps to.
+fn head_signal_word(raw: u32) -> &'static str {
+    match i32::try_from(raw)
+        .ok()
+        .and_then(|value| ravel_commit::signal::from_proto(value).ok())
+    {
+        Some(signal) => signal_word(signal),
+        None => "unknown",
+    }
+}
+
 fn format_identity(id: &ravel_catalog::EntryIdentity) -> String {
     format!(
         "shard={} ingest_hour_bucket={} writer_id={} writer_epoch={} writer_seq={}",
@@ -182,26 +235,34 @@ fn format_uuid_bytes(bytes: &[u8]) -> String {
 /// record are reported but never fail verification: retention deleting a
 /// commit record after it has been folded produces exactly this shape and is
 /// expected, not a divergence.
-pub async fn verify(store: Arc<dyn ObjectStoreBackend>, tenant: &str) -> anyhow::Result<()> {
+pub async fn verify(
+    store: Arc<dyn ObjectStoreBackend>,
+    tenant: &str,
+    signal: SignalArg,
+) -> anyhow::Result<()> {
     let tenant_hash = TenantId::new(tenant).hash();
 
     // The comparison itself lives in `ravel-catalog` (ADR-0059 decision 2) so
     // the scheduled scrubber and this CLI share one implementation. This
     // command keeps its own presentation: the `println!` report and the nonzero
     // exit (via `anyhow::bail!`) on a real divergence.
-    let report =
-        match ravel_catalog::verify_seal_divergence(store.as_ref(), &tenant_hash, Signal::Metrics)
-            .await
-            .map_err(|err| anyhow::anyhow!("{err}"))?
-        {
-            Some(report) => report,
-            None => {
-                let key = head_key(&tenant_hash, Signal::Metrics);
-                println!("no HEAD found at {key}; nothing folded yet, nothing to verify");
-                return Ok(());
-            }
-        };
+    let report = match ravel_catalog::verify_seal_divergence(
+        store.as_ref(),
+        &tenant_hash,
+        signal.to_signal(),
+    )
+    .await
+    .map_err(|err| anyhow::anyhow!("{err}"))?
+    {
+        Some(report) => report,
+        None => {
+            let key = head_key(&tenant_hash, signal.to_signal());
+            println!("no HEAD found at {key}; nothing folded yet, nothing to verify");
+            return Ok(());
+        }
+    };
 
+    println!("signal: {}", signal_word(signal.to_signal()));
     println!("watermark_hour: {}", report.watermark_hour);
     println!(
         "sealed commit records (re-listed): {}",
@@ -309,7 +370,7 @@ mod tests {
             .expect("put head");
 
         let mut report = String::new();
-        render_inspect(store.clone(), tenant, &mut report)
+        render_inspect(store.clone(), tenant, SignalArg::Metrics, &mut report)
             .await
             .expect("inspect renders");
 
@@ -368,7 +429,9 @@ mod tests {
         .await
         .expect("append generation 1");
 
-        fold(store.clone(), tenant, 1).await.expect("cli fold");
+        fold(store.clone(), tenant, 1, SignalArg::Metrics)
+            .await
+            .expect("cli fold");
 
         let head_bytes = store
             .get(&head_key(&tenant_hash, Signal::Metrics), GetRange::Full)

--- a/services/ravel-cli/src/catalog.rs
+++ b/services/ravel-cli/src/catalog.rs
@@ -19,6 +19,7 @@ fn head_key(tenant: &TenantHash, signal: Signal) -> String {
     format!("t/{}/catalog/{}/HEAD", tenant.to_hex(), signal.key_prefix())
 }
 
+/// Folds one signal's catalog snapshot for a tenant (issue #718).
 pub async fn fold(
     store: Arc<dyn ObjectStoreBackend>,
     tenant: &str,

--- a/services/ravel-cli/src/main.rs
+++ b/services/ravel-cli/src/main.rs
@@ -725,23 +725,40 @@ enum CatalogCommand {
         #[arg(long, default_value_t = 4)]
         shards: u32,
     },
-    /// One-shot catalog fold for a tenant.
+    /// One-shot catalog fold for one (tenant, signal).
+    ///
+    /// A tenant's snapshot is per signal: a logs or spans tenant is never
+    /// folded unless `--signal` names it. Folding metrics on a logs-only
+    /// tenant seals nothing and publishes an empty metrics HEAD, leaving
+    /// every logs query to list and read every commit record.
     Fold {
         #[arg(long)]
         tenant: String,
         #[arg(long, default_value_t = 4)]
         shards: u32,
+        /// Which signal's snapshot to fold. Defaults to metrics, so an
+        /// existing invocation keeps its meaning.
+        #[arg(long, value_enum, default_value = "metrics")]
+        signal: SignalArg,
     },
-    /// Decode and print HEAD and every referenced snapshot part.
+    /// Decode and print HEAD and every referenced snapshot part for one
+    /// (tenant, signal).
     Inspect {
         #[arg(long)]
         tenant: String,
+        /// Which signal's HEAD to decode. Defaults to metrics.
+        #[arg(long, value_enum, default_value = "metrics")]
+        signal: SignalArg,
     },
-    /// Re-list sealed commit records and diff against the snapshot; exits
-    /// nonzero if the snapshot is missing or mismatches sealed history.
+    /// Re-list sealed commit records for one (tenant, signal) and diff against
+    /// that signal's snapshot; exits nonzero if the snapshot is missing or
+    /// mismatches sealed history.
     Verify {
         #[arg(long)]
         tenant: String,
+        /// Which signal's snapshot to verify. Defaults to metrics.
+        #[arg(long, value_enum, default_value = "metrics")]
+        signal: SignalArg,
     },
 }
 
@@ -829,14 +846,21 @@ async fn main() -> anyhow::Result<()> {
                 },
         } => catalog_list(&cli.store, &tenant, hours, shards).await,
         Command::Catalog {
-            command: CatalogCommand::Fold { tenant, shards },
-        } => catalog::fold(store::build_store(&cli.store)?, &tenant, shards).await,
+            command:
+                CatalogCommand::Fold {
+                    tenant,
+                    shards,
+                    signal,
+                },
+        } => catalog::fold(store::build_store(&cli.store)?, &tenant, shards, signal)
+            .await
+            .map(|_report| ()),
         Command::Catalog {
-            command: CatalogCommand::Inspect { tenant },
-        } => catalog::inspect(store::build_store(&cli.store)?, &tenant).await,
+            command: CatalogCommand::Inspect { tenant, signal },
+        } => catalog::inspect(store::build_store(&cli.store)?, &tenant, signal).await,
         Command::Catalog {
-            command: CatalogCommand::Verify { tenant },
-        } => catalog::verify(store::build_store(&cli.store)?, &tenant).await,
+            command: CatalogCommand::Verify { tenant, signal },
+        } => catalog::verify(store::build_store(&cli.store)?, &tenant, signal).await,
         Command::Maintain {
             command:
                 MaintainCommand::CompactBucket {

--- a/services/ravel-cli/src/main.rs
+++ b/services/ravel-cli/src/main.rs
@@ -751,8 +751,9 @@ enum CatalogCommand {
         signal: SignalArg,
     },
     /// Re-list sealed commit records for one (tenant, signal) and diff against
-    /// that signal's snapshot; exits nonzero if the snapshot is missing or
-    /// mismatches sealed history.
+    /// that signal's snapshot; exits nonzero if the snapshot mismatches sealed
+    /// history. A missing snapshot is reported (nothing folded yet) and exits
+    /// zero.
     Verify {
         #[arg(long)]
         tenant: String,

--- a/services/ravel-cli/tests/catalog.rs
+++ b/services/ravel-cli/tests/catalog.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 
 use bytes::Bytes;
 use ravel_cli::catalog;
+use ravel_cli::maintain::SignalArg;
 use ravel_commit::keys;
 use ravel_commit::publish::{self, RetryPolicy};
 use ravel_commit::record::{self, NewCommitRecord};
@@ -82,17 +83,30 @@ async fn fold_then_inspect_then_verify_round_trips_cleanly() {
     publish_segment(&store, tenant, 0, 1, created).await;
     publish_segment(&store, tenant, 0, 2, created).await;
 
-    catalog::fold(store.clone() as Arc<dyn ObjectStoreBackend>, tenant, 1)
-        .await
-        .expect("fold succeeds");
+    catalog::fold(
+        store.clone() as Arc<dyn ObjectStoreBackend>,
+        tenant,
+        1,
+        SignalArg::Metrics,
+    )
+    .await
+    .expect("fold succeeds");
 
-    catalog::inspect(store.clone() as Arc<dyn ObjectStoreBackend>, tenant)
-        .await
-        .expect("inspect succeeds against a freshly folded HEAD");
+    catalog::inspect(
+        store.clone() as Arc<dyn ObjectStoreBackend>,
+        tenant,
+        SignalArg::Metrics,
+    )
+    .await
+    .expect("inspect succeeds against a freshly folded HEAD");
 
-    catalog::verify(store.clone() as Arc<dyn ObjectStoreBackend>, tenant)
-        .await
-        .expect("verify finds no divergence right after a fold");
+    catalog::verify(
+        store.clone() as Arc<dyn ObjectStoreBackend>,
+        tenant,
+        SignalArg::Metrics,
+    )
+    .await
+    .expect("verify finds no divergence right after a fold");
 }
 
 #[tokio::test]
@@ -102,17 +116,26 @@ async fn verify_fails_when_a_sealed_record_is_missing_from_the_snapshot() {
     let created = now_ns() - SEALED_AGE_NS;
     publish_segment(&store, tenant, 0, 1, created).await;
 
-    catalog::fold(store.clone() as Arc<dyn ObjectStoreBackend>, tenant, 1)
-        .await
-        .expect("fold succeeds");
+    catalog::fold(
+        store.clone() as Arc<dyn ObjectStoreBackend>,
+        tenant,
+        1,
+        SignalArg::Metrics,
+    )
+    .await
+    .expect("fold succeeds");
 
     // Published after the fold ran, so it is sealed but not yet folded in:
     // the snapshot under-counts relative to the sealed commit history.
     publish_segment(&store, tenant, 0, 2, created).await;
 
-    let err = catalog::verify(store.clone() as Arc<dyn ObjectStoreBackend>, tenant)
-        .await
-        .expect_err("verify must fail when a sealed record is missing from the snapshot");
+    let err = catalog::verify(
+        store.clone() as Arc<dyn ObjectStoreBackend>,
+        tenant,
+        SignalArg::Metrics,
+    )
+    .await
+    .expect_err("verify must fail when a sealed record is missing from the snapshot");
     assert!(
         err.to_string().contains("missing"),
         "unexpected error: {err}"
@@ -124,10 +147,10 @@ async fn inspect_and_verify_report_cleanly_with_no_head_yet() {
     let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
     let tenant = "acme";
 
-    catalog::inspect(store.clone(), tenant)
+    catalog::inspect(store.clone(), tenant, SignalArg::Metrics)
         .await
         .expect("inspect on an absent HEAD reports rather than errors");
-    catalog::verify(store.clone(), tenant)
+    catalog::verify(store.clone(), tenant, SignalArg::Metrics)
         .await
         .expect("verify on an absent HEAD reports rather than errors");
 }
@@ -150,9 +173,13 @@ async fn inspect_rejects_a_corrupt_head() {
         .await
         .expect("seed a corrupt HEAD object");
 
-    let err = catalog::inspect(store as Arc<dyn ObjectStoreBackend>, "acme")
-        .await
-        .expect_err("corrupt HEAD must be a typed error, not a panic or silent success");
+    let err = catalog::inspect(
+        store as Arc<dyn ObjectStoreBackend>,
+        "acme",
+        SignalArg::Metrics,
+    )
+    .await
+    .expect_err("corrupt HEAD must be a typed error, not a panic or silent success");
     assert!(
         err.to_string().contains("corrupt"),
         "unexpected error: {err}"
@@ -231,9 +258,14 @@ async fn inspect_preserves_partial_output_when_a_part_fetch_fails() {
         .expect("seed the head");
 
     let mut out = String::new();
-    let err = catalog::render_inspect(store as Arc<dyn ObjectStoreBackend>, "acme", &mut out)
-        .await
-        .expect_err("a missing part must surface as a typed error");
+    let err = catalog::render_inspect(
+        store as Arc<dyn ObjectStoreBackend>,
+        "acme",
+        SignalArg::Metrics,
+        &mut out,
+    )
+    .await
+    .expect_err("a missing part must surface as a typed error");
     assert!(
         err.to_string().contains("missing"),
         "unexpected error: {err}"

--- a/services/ravel-cli/tests/catalog_signal.rs
+++ b/services/ravel-cli/tests/catalog_signal.rs
@@ -1,0 +1,369 @@
+//! `ravel-cli catalog fold/inspect/verify --signal` (issue #718): the three
+//! commands act on the signal named by the flag, not on metrics only.
+//!
+//! Driven in-process against one shared `MemoryStore`, the same pattern (and
+//! for the same reason) as `tests/catalog.rs`: a subprocess-per-invocation of
+//! the binary gets its own empty in-memory store, so a
+//! publish -> fold -> resolve scenario cannot be built that way without a
+//! persistent S3/MinIO backend, unavailable here.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::sync::Arc;
+
+use bytes::Bytes;
+use ravel_cli::catalog;
+use ravel_cli::maintain::SignalArg;
+use ravel_commit::keys;
+use ravel_commit::publish::{self, RetryPolicy};
+use ravel_commit::record::{self, NewCommitRecord};
+use ravel_logseg::{
+    LogRecord, LogStreamId, ObjectIdentity, RlogConfig, RlogWriter, stream_attrs_bytes,
+};
+use ravel_object_store::fault::{FaultPlan, FaultStore, Op, Sequence, SequenceStep};
+use ravel_object_store::memory::MemoryStore;
+use ravel_object_store::{GetRange, ObjectStoreBackend};
+use ravel_types::logstream::AttrValue;
+use ravel_types::{Signal, TenantHash, TenantId, TimeRange};
+use uuid::Uuid;
+
+const NS_PER_HOUR: i64 = 3_600_000_000_000;
+
+/// Default seal margins sum to 1h20m, but hour-bucket quantization means
+/// anything under ~2h20m can land on the wrong side of
+/// `sealed_watermark_hour`'s boundary depending on which minute of the hour
+/// the test runs in. 3h clears that with room to spare (same constant as
+/// `tests/catalog.rs`).
+const SEALED_AGE_NS: i64 = 3 * NS_PER_HOUR;
+
+/// How many RLOG objects (and therefore commit records) the logs tenant gets.
+/// Small, and split across two shards so the fold lists more than one commit
+/// bucket.
+const PUBLISHED_OBJECTS: u64 = 6;
+
+const SHARD_COUNT: u32 = 2;
+
+/// Passthrough steps per counting sequence. A `Sequence`'s progress is clamped
+/// to its step count, so this must exceed the largest count any case here can
+/// reach (the metrics-flipped red case reads every one of
+/// [`PUBLISHED_OBJECTS`] commit records) for the assertions to be exact rather
+/// than saturated.
+const COUNT_STEPS: usize = 256;
+
+fn now_ns() -> i64 {
+    ravel_cli::now_ns().expect("system clock readable")
+}
+
+fn head_key(tenant: &TenantHash, signal: Signal) -> String {
+    format!("t/{}/catalog/{}/HEAD", tenant.to_hex(), signal.key_prefix())
+}
+
+/// Publish one real RLOG object plus its L0 commit record for the logs signal.
+async fn publish_rlog(
+    store: &MemoryStore,
+    tenant: &str,
+    shard: u32,
+    seq: u64,
+    observed_ts_ns: i64,
+) {
+    let tenant_hash = TenantId::new(tenant).hash();
+    let writer_id = Uuid::new_v4();
+    let epoch = 1u64;
+
+    let stream_attrs = stream_attrs_bytes(
+        &[("service.name".into(), AttrValue::Str("svc".into()))],
+        "scope",
+        "1.0",
+        &[],
+    );
+    let log = LogRecord {
+        stream_id: LogStreamId([u8::try_from(seq % 256).expect("fits u8"); 16]),
+        stream_attrs,
+        ts_ns: observed_ts_ns - 1_000,
+        observed_ts_ns,
+        severity_num: 9,
+        severity_text: "INFO".into(),
+        body: format!("log-{shard}-{seq}"),
+        trace_id: None,
+        span_id: None,
+        flags: 0,
+        attrs: Vec::new(),
+    };
+    let identity = ObjectIdentity {
+        tenant_hash: tenant_hash.0,
+        shard,
+        writer_id: writer_id.into_bytes(),
+        writer_epoch: epoch,
+        writer_seq: seq,
+    };
+    let mut writer = RlogWriter::new(RlogConfig::default(), identity);
+    writer.push(log).expect("push log record");
+    let object = Bytes::from(writer.finish().expect("finish rlog"));
+    let content_hash = *blake3::hash(&object).as_bytes();
+
+    let ingest_hour_bucket = u32::try_from(observed_ts_ns / NS_PER_HOUR).expect("fits u32");
+    let commit = record::build(NewCommitRecord {
+        tenant_hash,
+        signal: Signal::Logs,
+        shard,
+        writer_id,
+        writer_epoch: epoch,
+        writer_seq: seq,
+        object_size: object.len() as u64,
+        content_hash,
+        sample_count: 1,
+        series_count: 1,
+        min_event_ts_ns: observed_ts_ns - 1_000,
+        max_event_ts_ns: observed_ts_ns,
+        min_ingest_ts_ns: observed_ts_ns,
+        max_ingest_ts_ns: observed_ts_ns,
+        segment_format_version: u32::from(ravel_logseg::footer::VERSION),
+        created_unix_ns: observed_ts_ns,
+        ingest_hour_bucket,
+    })
+    .expect("valid logs commit record");
+    let data_key = keys::reconstruct_data_key(&commit).expect("data key");
+    publish::put_data_object(store, &data_key, object)
+        .await
+        .expect("put rlog data object");
+    publish::publish(store, &commit, &RetryPolicy::default())
+        .await
+        .expect("publish logs commit record");
+}
+
+/// Seed a logs-only tenant whose every commit record sits in a sealed hour.
+async fn seed_logs_tenant(store: &MemoryStore, tenant: &str) {
+    let observed = now_ns() - SEALED_AGE_NS;
+    for seq in 0..PUBLISHED_OBJECTS {
+        let shard = u32::try_from(seq % u64::from(SHARD_COUNT)).expect("fits u32");
+        publish_rlog(store, tenant, shard, seq + 1, observed).await;
+    }
+}
+
+/// A `FaultStore` whose plan injects nothing and only counts: sequence 0
+/// counts `get` calls under the tenant's logs catalog prefix (HEAD and
+/// snapshot parts), sequence 1 counts `get` calls under its logs commit-record
+/// prefix. The two patterns are disjoint, so each call lands in exactly one.
+/// Counting through `FaultStore` rather than a bespoke wrapper keeps the same
+/// store type every other failure-path test in this crate uses.
+fn counting_store(
+    inner: Arc<MemoryStore>,
+    tenant_hash: &TenantHash,
+) -> Arc<FaultStore<Arc<MemoryStore>>> {
+    let steps = vec![SequenceStep::Passthrough; COUNT_STEPS];
+    let plan = FaultPlan::empty()
+        .with_sequence(
+            Sequence::new(Op::Get)
+                .with_key_contains(format!("t/{}/catalog/l/", tenant_hash.to_hex()))
+                .with_steps(steps.clone()),
+        )
+        .with_sequence(
+            Sequence::new(Op::Get)
+                .with_key_contains(format!("t/{}/l/c/", tenant_hash.to_hex()))
+                .with_steps(steps),
+        );
+    Arc::new(FaultStore::new(inner, plan))
+}
+
+const CATALOG_GETS: usize = 0;
+const COMMIT_GETS: usize = 1;
+
+/// The point of `--signal logs`: after a logs fold, a logs resolve over the
+/// whole published window is served entirely from the snapshot. It GETs the
+/// logs HEAD and each of its parts and reads no commit record at all, instead
+/// of listing and GETting every one of them (issue #718: 8,425 GETs and 13-14s
+/// cold on a 100M-row logs tenant, because the CLI only ever folded metrics).
+///
+/// Red demonstration: flip `FOLD_SIGNAL` below to `SignalArg::Metrics` (the
+/// pre-#718 hardcoded value). Measured: `entry_count 0`, no logs HEAD, an
+/// empty metrics HEAD written instead, and the logs resolve falls back to
+/// listing with 6 commit-record GETs and 1 catalog GET instead of 0 and 2.
+#[tokio::test]
+async fn fold_signal_logs_folds_the_logs_snapshot_and_a_logs_resolve_reads_no_commit_record() {
+    const FOLD_SIGNAL: SignalArg = SignalArg::Logs;
+
+    let inner = Arc::new(MemoryStore::new());
+    let tenant = "cli-fold-logs";
+    let tenant_hash = TenantId::new(tenant).hash();
+    seed_logs_tenant(&inner, tenant).await;
+
+    let report = catalog::fold(
+        inner.clone() as Arc<dyn ObjectStoreBackend>,
+        tenant,
+        SHARD_COUNT,
+        FOLD_SIGNAL,
+    )
+    .await
+    .expect("cli fold succeeds");
+
+    assert_eq!(
+        report.entry_count, PUBLISHED_OBJECTS,
+        "a logs fold must cover every published logs object exactly; folding \
+         metrics on this tenant covers none"
+    );
+
+    // The snapshot landed under the logs key, and the metrics key was never
+    // written: the two are separate objects.
+    let logs_head = head_key(&tenant_hash, Signal::Logs);
+    let head_bytes = inner
+        .get(&logs_head, GetRange::Full)
+        .await
+        .expect("the logs HEAD is the key the fold wrote")
+        .data;
+    assert!(
+        inner
+            .get(&head_key(&tenant_hash, Signal::Metrics), GetRange::Full)
+            .await
+            .is_err(),
+        "a logs fold must not write the tenant's metrics HEAD"
+    );
+
+    let head = ravel_catalog::decode_head(&head_bytes).expect("decode logs HEAD");
+    assert_eq!(
+        head.parts.len(),
+        1,
+        "this tenant is far below snapshot_part_max_entries, so one part; the \
+         expected GET count below is HEAD + this many parts"
+    );
+
+    // Now resolve the full published window for the logs signal through the
+    // counting store.
+    let counting = counting_store(inner.clone(), &tenant_hash);
+    let catalog = ravel_catalog::Catalog::new(
+        counting.clone() as Arc<dyn ObjectStoreBackend>,
+        ravel_catalog::CatalogConfig {
+            shard_count: SHARD_COUNT,
+            ..ravel_catalog::CatalogConfig::default()
+        },
+    )
+    .expect("build catalog");
+
+    let now = now_ns();
+    let range = TimeRange {
+        start_ns: now - SEALED_AGE_NS - NS_PER_HOUR,
+        end_ns: now,
+    };
+    let snapshot = catalog
+        .resolve(&tenant_hash, Signal::Logs, range, &[], now)
+        .await
+        .expect("resolve the logs signal");
+    assert_eq!(
+        snapshot.segments.len() as u64,
+        PUBLISHED_OBJECTS,
+        "the resolve must still see every published object"
+    );
+
+    assert_eq!(
+        counting.sequence_progress(COMMIT_GETS),
+        0,
+        "a snapshot-served logs resolve GETs no commit record; folding metrics \
+         instead leaves it GETting all {PUBLISHED_OBJECTS} of them"
+    );
+    // Exactly HEAD plus one GET per snapshot part: no re-read, no postings
+    // object (a logs fold writes none, ADR-0033), nothing else under the
+    // tenant's logs catalog prefix. Folding metrics instead makes this 1: the
+    // absent-logs-HEAD probe, after which the resolve falls back to listing.
+    assert_eq!(
+        counting.sequence_progress(CATALOG_GETS),
+        1 + head.parts.len() as u64,
+        "the whole resolve cost is the logs HEAD plus its {} snapshot part(s)",
+        head.parts.len()
+    );
+}
+
+/// `catalog inspect --signal logs` decodes the logs HEAD and names the signal
+/// with the word, not only the numeric proto value.
+#[tokio::test]
+async fn inspect_signal_logs_prints_the_signal_word() {
+    let store = Arc::new(MemoryStore::new());
+    let tenant = "cli-inspect-logs";
+    seed_logs_tenant(&store, tenant).await;
+
+    catalog::fold(
+        store.clone() as Arc<dyn ObjectStoreBackend>,
+        tenant,
+        SHARD_COUNT,
+        SignalArg::Logs,
+    )
+    .await
+    .expect("cli fold succeeds");
+
+    let mut out = String::new();
+    catalog::render_inspect(
+        store.clone() as Arc<dyn ObjectStoreBackend>,
+        tenant,
+        SignalArg::Logs,
+        &mut out,
+    )
+    .await
+    .expect("inspect renders the logs HEAD");
+
+    assert!(
+        out.contains("signal: logs"),
+        "inspect must name the signal with the word, got:\n{out}"
+    );
+    assert!(
+        out.contains("parts: 1"),
+        "inspect must have decoded the logs HEAD the fold wrote, got:\n{out}"
+    );
+}
+
+/// `catalog verify --signal logs` compares the logs snapshot against the logs
+/// sealed commit history. Before #718 it always read the metrics HEAD, so on
+/// this tenant it reported "nothing folded yet" no matter what the logs
+/// snapshot looked like.
+#[tokio::test]
+async fn verify_signal_logs_checks_the_logs_snapshot() {
+    let store = Arc::new(MemoryStore::new());
+    let tenant = "cli-verify-logs";
+    seed_logs_tenant(&store, tenant).await;
+
+    catalog::fold(
+        store.clone() as Arc<dyn ObjectStoreBackend>,
+        tenant,
+        SHARD_COUNT,
+        SignalArg::Logs,
+    )
+    .await
+    .expect("cli fold succeeds");
+
+    catalog::verify(
+        store.clone() as Arc<dyn ObjectStoreBackend>,
+        tenant,
+        SignalArg::Logs,
+    )
+    .await
+    .expect("a freshly folded logs snapshot matches its sealed commit history");
+
+    // A logs commit record published after the fold is sealed but unfolded, so
+    // the logs snapshot now under-counts: verify must fail on the logs signal.
+    publish_rlog(
+        &store,
+        tenant,
+        0,
+        PUBLISHED_OBJECTS + 1,
+        now_ns() - SEALED_AGE_NS,
+    )
+    .await;
+    let err = catalog::verify(
+        store.clone() as Arc<dyn ObjectStoreBackend>,
+        tenant,
+        SignalArg::Logs,
+    )
+    .await
+    .expect_err("verify must fail when a sealed logs record is missing from the logs snapshot");
+    assert!(
+        err.to_string().contains("missing"),
+        "unexpected error: {err}"
+    );
+
+    // The same tenant has no metrics snapshot at all, and verifying metrics
+    // reports exactly that rather than the logs divergence above.
+    catalog::verify(
+        store.clone() as Arc<dyn ObjectStoreBackend>,
+        tenant,
+        SignalArg::Metrics,
+    )
+    .await
+    .expect("no metrics HEAD on a logs-only tenant is 'nothing to verify', not a divergence");
+}


### PR DESCRIPTION
`ravel-cli catalog fold`, `catalog inspect` and `catalog verify` hardcoded
Signal::Metrics while Catalog::fold and the ADR-0020 snapshot-backed
resolve are signal-parameterized. A logs tenant could therefore never be
folded from the CLI: on the 100M-row ClickBench logs tenant `catalog
fold` returned buckets_folded 0 and wrote an empty metrics HEAD, and
every logs query re-derived the snapshot from all 8,424 commit records
(8,425 GETs, 13-14 s cold, about 1 s warm even for a count(*) that no
longer scans).

`--signal <metrics|logs|spans>` on the three subcommands, default
metrics so existing invocations keep their meaning, reusing maintain's
SignalArg value parser and threaded to Catalog::fold, the HEAD key and
verify_seal_divergence. fold returns the FoldReport it prints; inspect
prints the signal as a word next to the numeric proto value read off
the object. The operations guide rows carry the flag and say that a
tenant's logs snapshot is separate from its metrics snapshot, and that
ravel-server's fold::spawn covers all three signals in every mode except
Maintain (ADR-0055).

The test folds a MemoryStore logs tenant through the CLI entry point
and asserts entry_count equals the published object count exactly and
the HEAD key is the logs key, then resolves Signal::Logs through a
counting FaultStore: commit-record GETs exactly 0, logs-catalog GETs
exactly 1 HEAD + parts.len(). Flipping the fold to Signal::Metrics
reproduces the issue (entry_count 0, a metrics HEAD, a resolve that
reads every commit record).

Fixes: #718
Refs: #680
