### PR TITLE
fix(ravel-bench): record the Flight run's aggregation setting as requested, not effective

### DIFF
--- a/crates/ravel-bench/src/bin/sql_latency_bench.rs
+++ b/crates/ravel-bench/src/bin/sql_latency_bench.rs
@@ -161,8 +161,13 @@ struct Args {
     /// --sql-parallel-final-aggregation`. On by default; pass
     /// `--sql-parallel-final-aggregation=false` (or the bare flag, which stays
     /// accepted and still means on) to measure the pre-amendment
-    /// single-partition final. The effective value is recorded in the report's
-    /// provenance either way.
+    /// single-partition final. This local value is recorded in the report's
+    /// provenance as `parallel_final_aggregation_requested`. For an in-process
+    /// lane it reaches the executor and so is also the effective value; under
+    /// `--flight` it does NOT reach the server (the setting is not on the Flight
+    /// wire), so the report's `parallel_final_aggregation_effective` is null and
+    /// the server's own default (on) governs unless the server was started
+    /// otherwise.
     #[arg(
         long,
         num_args = 0..=1,
@@ -370,9 +375,15 @@ fn print_human_table(report: &SqlLatencyReport) {
     println!("  runs/query : {}", p.runs);
     println!("  deadline   : {} s per statement", p.deadline_secs);
     println!("  fetch conc : {}", p.fetch_concurrency);
+    let effective = match p.parallel_final_aggregation_effective {
+        Some(v) => v.to_string(),
+        // A Flight run does not send the setting to the server; the effective
+        // value is the server's own (its default is on).
+        None => "unknown (server default)".to_string(),
+    };
     println!(
-        "  tenant max : {} bytes  parallel final agg: {}",
-        p.tenant_max_bytes, p.parallel_final_aggregation
+        "  tenant max : {} bytes  parallel final agg: requested={} effective={}",
+        p.tenant_max_bytes, p.parallel_final_aggregation_requested, effective
     );
     println!(
         "  max segs   : {}  explain: {}",

--- a/crates/ravel-bench/src/sql_latency.rs
+++ b/crates/ravel-bench/src/sql_latency.rs
@@ -205,9 +205,26 @@ pub struct Provenance {
     /// with that error was refused by this, not by any byte ceiling.
     #[serde(default = "default_max_segments")]
     pub sql_max_segments: usize,
-    /// Whether final aggregations were allowed to repartition (ADR-0094).
+    /// What this benchmark process was *asked* to do about repartitioning an
+    /// exact-typed final aggregation (ADR-0094): the local
+    /// `--sql-parallel-final-aggregation` CLI value. This is only the request,
+    /// not necessarily what governed execution -- see
+    /// `parallel_final_aggregation_effective`. Named `requested` (not the bare
+    /// `parallel_final_aggregation`) precisely because the two can differ under
+    /// the Flight lane.
+    #[serde(default, alias = "parallel_final_aggregation")]
+    pub parallel_final_aggregation_requested: bool,
+    /// The value that actually governed execution, when this harness knows it.
+    /// `Some(v)` for an in-process lane (`generate`/`tenant`), which applies the
+    /// requested value directly to `SqlConfig::parallel_final_aggregation`.
+    /// `None` for the Flight lane: the benchmark does not send this setting over
+    /// the wire (it is not a Flight header), so a Flight run's effective value is
+    /// the running server's own -- the compiled-in default (`true`, on) unless
+    /// the server was started with `--sql-parallel-final-aggregation=false`.
+    /// Recording `None` rather than the local request stops a Flight report from
+    /// claiming a setting it never established.
     #[serde(default)]
-    pub parallel_final_aggregation: bool,
+    pub parallel_final_aggregation_effective: Option<bool>,
     /// Whether the run wrote a per-statement physical plan (`--explain`). The
     /// plans are a side artifact under `--explain-dir`, never part of the
     /// numbers above.
@@ -1223,7 +1240,10 @@ pub async fn run_generated(cfg: &GenerateConfig) -> Result<SqlLatencyReport, Err
             fetch_concurrency: cfg.fetch_concurrency.max(1),
             tenant_max_bytes: cfg.tenant_max_bytes.max(1),
             sql_max_segments: cfg.max_segments,
-            parallel_final_aggregation: cfg.parallel_final_aggregation,
+            parallel_final_aggregation_requested: cfg.parallel_final_aggregation,
+            // In-process lane: the requested value reaches the executor's
+            // `SqlConfig`, so it is also the effective one.
+            parallel_final_aggregation_effective: Some(cfg.parallel_final_aggregation),
             explain: cfg.explain_dir.is_some(),
             flight_endpoint: None,
         },
@@ -1331,7 +1351,15 @@ pub async fn run_tenant(cfg: &TenantConfigInput) -> Result<SqlLatencyReport, Err
             fetch_concurrency: cfg.fetch_concurrency.max(1),
             tenant_max_bytes: cfg.tenant_max_bytes.max(1),
             sql_max_segments: cfg.max_segments,
-            parallel_final_aggregation: cfg.parallel_final_aggregation,
+            parallel_final_aggregation_requested: cfg.parallel_final_aggregation,
+            // The Flight lane does not send this setting to the server (it is not
+            // a Flight header), so what governed execution is the server's own
+            // config, unknown to this process: record `None`. An in-process
+            // tenant run applies the requested value directly, so it is effective.
+            parallel_final_aggregation_effective: match &cfg.flight {
+                Some(_) => None,
+                None => Some(cfg.parallel_final_aggregation),
+            },
             explain: cfg.explain_dir.is_some(),
             flight_endpoint: cfg.flight.as_ref().map(|t| t.endpoint.clone()),
         },
@@ -1887,6 +1915,40 @@ mod tests {
         assert!(
             !off_dir.path().join("agg.txt").exists(),
             "explain off writes no plan file"
+        );
+    }
+
+    /// An in-process (`tenant`) run applies its `parallel_final_aggregation`
+    /// request directly to the executor's `SqlConfig`, so the report records it
+    /// under both `_requested` and `_effective`, equal. (The Flight lane, where
+    /// the setting is not on the wire and `_effective` is `None`, is pinned by
+    /// `sql_latency_flight_smoke.rs` under the `flight-lane` feature.)
+    #[tokio::test]
+    async fn in_process_report_records_requested_and_effective_equal() {
+        let store = empty_store();
+        provisioned_tenant(&store, "agg-tenant").await;
+
+        let mut cfg = tenant_cfg(&store, "agg-tenant", None, 0);
+        cfg.entries = vec![entry("scan", "SELECT body FROM logs")];
+        cfg.parallel_final_aggregation = true;
+        let report = run_tenant(&cfg).await.expect("tenant lane runs");
+        assert!(
+            report.provenance.parallel_final_aggregation_requested,
+            "the requested field carries the config value"
+        );
+        assert_eq!(
+            report.provenance.parallel_final_aggregation_effective,
+            Some(true),
+            "an in-process run's effective value is the applied request"
+        );
+
+        cfg.parallel_final_aggregation = false;
+        let report = run_tenant(&cfg).await.expect("tenant lane runs");
+        assert!(!report.provenance.parallel_final_aggregation_requested);
+        assert_eq!(
+            report.provenance.parallel_final_aggregation_effective,
+            Some(false),
+            "requested and effective stay equal for an in-process run"
         );
     }
 

--- a/crates/ravel-bench/tests/sql_latency_flight_smoke.rs
+++ b/crates/ravel-bench/tests/sql_latency_flight_smoke.rs
@@ -328,6 +328,20 @@ async fn flight_lane_measures_every_statement_over_the_wire_without_scan_diagnos
         report.provenance.endpoint, "n/a",
         "the object-store endpoint field is left alone"
     );
+    // The Flight lane does not send `parallel_final_aggregation` to the server,
+    // so the report must record the local CLI value only as *requested*
+    // (`flight_cfg` sets it false), and the *effective* value as unknown
+    // (`None`): the server's own config governed, and this process cannot know
+    // it. Recording the local value as effective (the bug this fixes) would have
+    // `parallel_final_aggregation_effective == Some(false)` here.
+    assert!(
+        !report.provenance.parallel_final_aggregation_requested,
+        "the requested field carries this run's CLI value (false)"
+    );
+    assert_eq!(
+        report.provenance.parallel_final_aggregation_effective, None,
+        "a Flight run does not send the setting, so the effective value is unknown"
+    );
     // The dataset stanza is still resolved from the store directly: a Flight
     // client cannot read the catalog.
     assert_eq!(report.dataset.object_count, 3);

--- a/docs/adrs/0094-parallel-final-aggregation-exact-typed.md
+++ b/docs/adrs/0094-parallel-final-aggregation-exact-typed.md
@@ -641,8 +641,14 @@ at 32 scan partitions with an 8 GiB per-query memory pool:
   `ORDER BY` was already unguaranteed (see `docs/query-engine.md`), so the
   repartitioned merge order changes nothing a client was entitled to rely
   on. Decision 3's caveat — that the hash exchange carries every forwarded
-  row when the #728 probe fires — held only as a *slower*, never a
-  *failing*, path.
+  row when the #728 probe fires — held as a *slower*, not a *failing*, path
+  **under the measured 8 GiB per-query pool**. That is a result about this
+  configuration, not an unconditional property: the redistribution buffer
+  still moves the memory ceiling (the scoping sweep hit `Memory Exhausted
+  while SpillPool (DiskManager is disabled)` on a parallel-plan combination,
+  recorded above), so the exhaustion risk stands and a smaller pool or a
+  larger group set can still fail the parallel path. Spilling is disabled by
+  design (ADR-0013), so there is no softer degradation.
 
 The measurement therefore inverts decision 4's default-follows-measurement
 conclusion for the exact-typed class: the serial final is not merely slower
@@ -666,7 +672,19 @@ never eligible (their fold is IEEE f64 addition, not associative past
 disqualifying aggregate or key anywhere in the query — including inside a
 scalar/`IN`/`EXISTS` subquery — still forces the whole query onto the
 single-partition plan. This amendment changes only the default of the gate,
-not the gate. It also does not touch the *string-keyed partial* stage that
-exhausts the pool for a different reason (`partitions x distinct` pre-final
-state); that is issue #680's separate `skip_partial_aggregation` fix, which
-was already on by default.
+not the gate.
+
+**Final stage only; the partial stage is a separate problem (#737).** This
+ADR governs the *final* aggregation stage. Its gate excludes float aggregates
+and float `GROUP BY` keys; a **non-float `GROUP BY` key, string keys
+included, is admitted** and its final is repartitioned. Repartitioning the
+final does not touch the *partial* stage, and a high-cardinality `GROUP BY`
+(the ClickBench string-keyed statements are the ones this bites) can still
+exhaust the per-query pool at the `Partial` `AggregateExec` -- the
+`partitions x distinct` pre-final state materialized per scan partition --
+even when its final is repartitioned. That partial-stage memory problem is
+tracked separately as issue #737 (the `skip_partial_aggregation` mitigation),
+and it is why some high-cardinality statements still fail with the parallel
+final on. Do not read this amendment as a claim that every high-cardinality
+`GROUP BY` now completes: it fixes the final-merge exhaustion for the
+exact-typed class, not the partial-stage one.

--- a/docs/guides/clickbench.md
+++ b/docs/guides/clickbench.md
@@ -303,11 +303,19 @@ cargo run -p ravel-bench --features sql-latency --bin sql_latency_bench -- \
 - `--sql-parallel-final-aggregation` lets an exact-typed query repartition its
   final aggregation (ADR-0094, amended by issue #741), the same knob as the
   server flag of that name. On by default; a `GROUP BY` or `COUNT(DISTINCT)`
-  over a high-cardinality key is where it shows (the amendment measured nine
-  such statements moving from pool-exhausted failures to 44-50 s here). Pass
-  `--sql-parallel-final-aggregation=false` to measure the pre-amendment
-  single-partition final; the bare flag stays accepted and still means on. The
-  effective value is recorded in the report's provenance.
+  over a high-cardinality key is where it shows. With the flag off, nine such
+  statements failed with a pool-exhausted error; with it on, **five of those
+  nine** (`COUNT(DISTINCT UserID)` and four more) moved to 44-50 s, while the
+  other **four (q29, q33, q34, q35) still exhaust the pool** for a separate
+  reason (see the ADR-0094 2026-08-26 amendment and its "still excluded" note).
+  Pass `--sql-parallel-final-aggregation=false` to measure the pre-amendment
+  single-partition final; the bare flag stays accepted and still means on. This
+  local value is recorded in the report's provenance as
+  `parallel_final_aggregation_requested`; for an in-process (`--tenant`) run it
+  is also the effective value (`parallel_final_aggregation_effective`), but a
+  `--flight` run does not send the setting to the server, so its effective value
+  is the server's own default (on) unless the server was started otherwise, and
+  the report records `parallel_final_aggregation_effective` as null.
 - `--sql-max-segments <N>` is the engine's `max_segments` ceiling, the same knob
   as `ravel-server --max-segments`: the number of sealed, below-watermark
   segments a statement may fan out over before it is refused with `query fans
@@ -392,9 +400,12 @@ Dataset-level, independent of any one query:
 - **rows** and the **pre-/post-compaction layout label**.
 
 Provenance (backend, region, endpoint, host logical cores, source, dataset id,
-runs, `cache_bytes`, `deadline_secs`, `fetch_concurrency`, and
-`flight_endpoint` when step 6's lane ran) is recorded beside the numbers so
-two runs are comparable or provably not.
+runs, `cache_bytes`, `deadline_secs`, `fetch_concurrency`,
+`parallel_final_aggregation_requested` (the local CLI value) and
+`parallel_final_aggregation_effective` (the value that governed execution:
+equal to the request for an in-process lane, null for a `--flight` run whose
+effective setting is the server's), and `flight_endpoint` when step 6's lane
+ran) is recorded beside the numbers so two runs are comparable or provably not.
 
 ## Reading a report against ClickBench
 

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -1776,6 +1776,18 @@ fails closed to the single-partition plan (a missed optimization, never a wrong
 result). With the opt-out set, no classification runs and every query is
 single-partition, byte-identical to before this feature existed.
 
+A **non-float `GROUP BY` key, string keys included, is eligible**: the gate
+rejects only *float* group keys (and float/`avg` aggregates), so a string-keyed
+`GROUP BY count(...)` is admitted and its final is repartitioned. This governs
+the **final** stage only. It does not address the **partial** stage: a
+high-cardinality `GROUP BY` can still exhaust the per-query memory pool at the
+`Partial` `AggregateExec` -- the `partitions x distinct` pre-final state
+materialized per scan partition -- even with the final repartitioned. That
+partial-stage memory problem is a separate concern, tracked as issue #737 (the
+`skip_partial_aggregation` mitigation); it is why some high-cardinality
+statements still fail with parallel final aggregation on. Do not read this
+feature as making every high-cardinality `GROUP BY` complete.
+
 Row order is unaffected. A `GROUP BY` without an explicit `ORDER BY` has **no
 row-order guarantee** in this engine -- single-partition or repartitioned, and
 unchanged by ADR-0094. Under repartitioned final aggregation the physical merge

--- a/scripts/gates.sh
+++ b/scripts/gates.sh
@@ -152,8 +152,8 @@ fi
 # locally. stage-timing is a separate lane CI checks and runs, kept at parity.
 if [[ ${want_bench} -eq 1 ]]; then
   run_feature_lane sql-latency,profiling,flight-lane -p ravel-bench
-  echo "==> cargo check --locked -p ravel-bench --features stage-timing"
-  cargo check --locked -p ravel-bench --features stage-timing
+  echo "==> cargo check --locked -p ravel-bench --features stage-timing --all-targets"
+  cargo check --locked -p ravel-bench --features stage-timing --all-targets
   echo "==> cargo test --locked -p ravel-bench --features stage-timing"
   cargo test --locked -p ravel-bench --features stage-timing
 fi


### PR DESCRIPTION
Under --flight sql_latency_bench does not send parallel_final_aggregation
to the server, but its report recorded the local CLI value as the
effective setting, so a `--sql-parallel-final-aggregation=false --flight`
run could report false while a default-on server executed with true. The
report now carries parallel_final_aggregation_requested (the CLI value;
the old field name is accepted as a serde alias) and
parallel_final_aggregation_effective, which the in-process lanes set to
the requested value and the Flight lane leaves unknown; the human table
prints both. The flight smoke test pins the Flight case (it failed
against the old code with Some(false) where None is due) and a new
in-process test pins the two equal.

The rest are the review findings on #749 and #750: the ADR-0094 amendment
no longer calls the parallel path never-failing next to a recorded
SpillPool exhaustion (it held under the measured 8 GiB pool; the risk
stands); the ADR and docs/query-engine.md distinguish the final-stage
repartitioning this ADR governs from the partial-stage memory problem
tracked as #737; docs/guides/clickbench.md says five of the nine memory
statements completed with the flag on and names the four (q29, q33, q34,
q35) that still exhaust the pool, and its provenance inventory lists the
two new fields; scripts/gates.sh's local stage-timing check gains
--all-targets to match the CI features job.

One finding was not applied as written: it asked the docs to state that
string-keyed GROUP BY stays on the single-partition final, but the
executor's classification (plan_is_exact_typed) rejects only float keys,
so a string-keyed count or non-float sum/min/max does repartition; the
docs say what the code does and attribute the string-key failures to the
partial stage (#737).

Fixes: #753
Refs: #741
Refs: #680
