### PR TITLE
fix(ravel-catalog): account and bound the provisioning-record reads

### DIFF
--- a/crates/ravel-catalog/src/catalog.rs
+++ b/crates/ravel-catalog/src/catalog.rs
@@ -232,6 +232,26 @@ pub struct Catalog {
     tenant_activity: Mutex<HashMap<TenantHash, i64>>,
 }
 
+/// Adapts [`Catalog::guarded_get`] to the provisioning module's
+/// [`crate::provisioning::AccountedRecordGet`], so the resolve-path provisioning
+/// reads (the generation history and the `shard_count` enforcement check) run
+/// through the same semaphore-bounded, accounted GET funnel as every other
+/// resolve GET (issue #729) rather than a raw `store.get`. Holds only borrows,
+/// so it is built cheaply per read from the resolve's own `&self` and
+/// `accounting`.
+struct GuardedRecordGet<'a> {
+    catalog: &'a Catalog,
+    accounting: &'a QueryAccounting,
+}
+
+impl crate::provisioning::AccountedRecordGet for GuardedRecordGet<'_> {
+    async fn accounted_get_full(&self, key: &str) -> Result<GetOutcome, StoreError> {
+        self.catalog
+            .guarded_get(key, GetRange::Full, self.accounting)
+            .await
+    }
+}
+
 impl Catalog {
     /// Errors if `config.shard_count == 0` (a resolvable catalog needs at
     /// least one shard).
@@ -353,6 +373,7 @@ impl Catalog {
         &self,
         tenant: &TenantHash,
         signal: Signal,
+        accounting: &QueryAccounting,
     ) -> Result<(), CatalogError> {
         if !self.enforce_provisioning {
             return Ok(());
@@ -364,13 +385,19 @@ impl Catalog {
         {
             return Ok(());
         }
-        let check = crate::provisioning::validate_or_adopt(
-            self.store.as_ref(),
+        // Route the check's record GET through `guarded_get` (issue #729): the
+        // read-only `CheckOnly` policy never writes or lists, so this is the
+        // same record read `validate_or_adopt(.., CheckOnly)` performs, now
+        // semaphore-bounded and recorded like every other resolve GET.
+        let getter = GuardedRecordGet {
+            catalog: self,
+            accounting,
+        };
+        let check = crate::provisioning::validate_check_only_accounted(
+            &getter,
             tenant,
             signal,
             self.config.shard_count,
-            0,
-            crate::provisioning::AbsentPolicy::CheckOnly,
         )
         .await?;
         // Only a `Matched` result is safe to cache forever: the record is
@@ -407,13 +434,22 @@ impl Catalog {
         &self,
         tenant: &TenantHash,
         signal: Signal,
+        accounting: &QueryAccounting,
     ) -> Result<Vec<crate::provisioning::ShardGeneration>, CatalogError> {
         if !self.enforce_provisioning {
             return Ok(vec![implicit_generation_zero(self.config.shard_count)]);
         }
-        match crate::provisioning::read_generations_from_store(self.store.as_ref(), tenant, signal)
-            .await?
-        {
+        // Route the generation-history GET through `guarded_get` (issue #729):
+        // this read runs on every resolve, so leaving it as a raw `store.get`
+        // under-counted a query's GETs by one and escaped the resolve
+        // semaphore. `accounting` may be a discarded handle for non-query
+        // callers (the fold path); the read still funnels through the same
+        // bounded entry point.
+        let getter = GuardedRecordGet {
+            catalog: self,
+            accounting,
+        };
+        match crate::provisioning::read_generations_accounted(&getter, tenant, signal).await? {
             Some(generations) => Ok(generations),
             None => Ok(vec![implicit_generation_zero(self.config.shard_count)]),
         }
@@ -1123,7 +1159,8 @@ impl Catalog {
         // catalog's configured shard_count disagrees with the (tenant, signal)'s
         // provisioning record, so a lower value never silently drops the shards
         // it omits. A no-op unless enforcement was opted into.
-        self.enforce_provisioning_once(tenant, signal).await?;
+        self.enforce_provisioning_once(tenant, signal, accounting)
+            .await?;
 
         // The generation history for the per-hour scan rule (ADR-0052 section
         // 4), read fresh (see `read_scan_generations`). A corrupt or misfiled
@@ -1149,7 +1186,9 @@ impl Catalog {
         // resolve computed its scan set from, not a later independent read (a
         // generation appended between the two reads would be invisible to the
         // gate while already visible in the resolved segments).
-        let mut generations = self.read_scan_generations(tenant, signal).await?;
+        let mut generations = self
+            .read_scan_generations(tenant, signal, accounting)
+            .await?;
 
         let mut segments: HashMap<String, SegmentRef> = HashMap::new();
         let mut segments_pruned = 0u64;
@@ -1933,21 +1972,23 @@ impl Catalog {
         Ok(out)
     }
 
-    /// The prefix-scan traversal path (ADR-0056): one drained recursive prefix
-    /// LIST per shard over [`keys::commit_shard_prefix`], grouped client-side
-    /// by `(shard, ingest-hour)` and resolved through
+    /// The prefix-scan traversal path (ADR-0056): one drained recursive
+    /// `list_after` per shard over [`keys::commit_shard_prefix`], grouped
+    /// client-side by `(shard, ingest-hour)` and resolved through
     /// [`Catalog::process_bucket`], for the window buckets in
     /// `[listing_start_hour, window_end_hour]`.
     ///
-    /// Cost is `O(objects / page_size)`, independent of window width, versus
-    /// the per-bucket loop's one LIST per bucket (ADR-0056 measurement). The
-    /// store's `list` cannot seek past a prefix (continuation token only, no
-    /// start-after), so the scan reads every commit key in each shard subtree,
-    /// including hours below `listing_start_hour`; those are dropped by the
-    /// client-side filter, exactly the buckets the per-bucket loop would have
-    /// skipped. The range scanned is unchanged, only the scan method
-    /// (ADR-0056 INTERACTION 2): a key in any in-range bucket, however far below the
-    /// window end, is still grouped and resolved.
+    /// Cost is `O(objects above the watermark / page_size)`, independent of
+    /// window width, versus the pre-ADR-0056 one LIST per `(shard, hour)`
+    /// bucket (ADR-0056 measurement). Each shard's scan resumes strictly past
+    /// the `listing_start_hour` shard-hour prefix via the `list_after` start
+    /// marker, so the shard's below-watermark history is skipped server-side
+    /// rather than paged through and discarded, exactly as the non-prefix
+    /// path ([`Catalog::list_window_bounded`]) does. What the recursive scan
+    /// still over-reads is the other end: keys past `window_end_hour`, which
+    /// the client-side filter drops. The range resolved is unchanged, only
+    /// the scan method (ADR-0056 INTERACTION 2): a key in any in-range bucket,
+    /// however far below the window end, is still grouped and resolved.
     ///
     /// A running LIST count is capped at
     /// [`CatalogConfig::max_catalog_list_requests`](crate::CatalogConfig::max_catalog_list_requests)
@@ -1956,6 +1997,13 @@ impl Catalog {
     /// runtime on the one path whose cost is not knowable before listing: a
     /// wide-but-sparse window is served, and only a scan whose actual object
     /// volume is unsustainable is refused.
+    ///
+    /// That page-by-page ceiling, and the `list_after` start marker, are why
+    /// this path records its own `AccountedOp::List` per page instead of
+    /// calling [`Catalog::guarded_list_all`], which takes no start marker and
+    /// drains unconditionally. The permit, the accounting, and the ADR-0050
+    /// section 2 tenant-prefix assertion are the same either way
+    /// (docs/catalog-and-mvcc.md "Query cost accounting").
     #[allow(clippy::too_many_arguments)]
     async fn list_window_by_prefix(
         &self,
@@ -3076,7 +3124,7 @@ mod tests {
     use ravel_object_store::InstrumentedStore;
     use ravel_object_store::PutOptions;
     use ravel_object_store::fault::{
-        FaultKind, FaultPlan, FaultStore, Op, Rule, ScriptedFault, Sequence,
+        FaultKind, FaultPlan, FaultStore, Occurrence, Op, Rule, ScriptedFault, Sequence,
     };
     use ravel_object_store::memory::MemoryStore;
 
@@ -3609,6 +3657,158 @@ mod tests {
             .resolve(&tenant(), Signal::Metrics, range, &[], now)
             .await
             .expect("enforcement off: resolve ignores the provisioning record");
+    }
+
+    /// Issue #729: with provisioning enforcement on, the generation-history
+    /// read every resolve performs must be an accounted GET through
+    /// `guarded_get`, not a raw `store.get`. Both catalogs are warmed with one
+    /// resolve (populating the record/HEAD caches, and memoizing the enforced
+    /// catalog's one-shot `shard_count` check), then a second resolve is
+    /// measured on each so the two run under identical cache warmth. The only
+    /// GET that then differs is the always-fresh generation read: enforcement
+    /// off synthesizes generation 0 with no store read, enforcement on reads
+    /// the record, so the enforced resolve issues exactly one more GET.
+    ///
+    /// FLIP (pre-fix demonstration): in `Catalog::read_scan_generations`,
+    /// replace `read_generations_accounted(&getter, tenant, signal)` with the
+    /// raw `read_generations_from_store(self.store.as_ref(), tenant, signal)`.
+    /// The generation GET then bypasses `guarded_get`, `on` stays equal to
+    /// `off`, and the `on == off + 1` assertion fails.
+    #[tokio::test]
+    async fn provisioning_generation_read_is_accounted_get() {
+        let store = Arc::new(MemoryStore::new());
+        let now = 500_000 * NS_PER_HOUR + 30 * 60_000_000_000;
+        publish_segment(&store, 0, 1, 500_000, now, now - 1_000, now).await;
+        // A record whose shard_count matches the configured value, so the
+        // resolve's scan set (and therefore every non-provisioning GET) is
+        // identical with enforcement on and off; the only difference is the
+        // provisioning read this change accounts for.
+        seed_provisioning_record(&store, 1).await;
+        let range = TimeRange {
+            start_ns: now - 1_000,
+            end_ns: now,
+        };
+
+        // Measure the second resolve of a catalog, after a warm-up resolve, so
+        // the record/HEAD caches are populated identically for both variants.
+        async fn measured_gets(catalog: &Catalog, range: TimeRange, now: i64) -> u64 {
+            catalog
+                .resolve(&tenant(), Signal::Metrics, range, &[], now)
+                .await
+                .expect("warm-up resolve");
+            let acc = QueryAccounting::new();
+            catalog
+                .resolve_with_accounting(&tenant(), Signal::Metrics, range, &[], now, &acc)
+                .await
+                .expect("measured resolve");
+            acc.snapshot().s3_requests(AccountedOp::Get)
+        }
+
+        let off_catalog = Catalog::new(store.clone(), config(1)).expect("catalog");
+        let off = measured_gets(&off_catalog, range, now).await;
+
+        let on_catalog = Catalog::new(store.clone(), config(1))
+            .expect("catalog")
+            .with_provisioning_enforcement();
+        let on = measured_gets(&on_catalog, range, now).await;
+
+        assert_eq!(
+            off, 1,
+            "warm resolve GET count with enforcement off: only the uncached HEAD read"
+        );
+        assert_eq!(
+            on,
+            off + 1,
+            "enforcement on adds exactly the generation-history GET, routed through guarded_get"
+        );
+    }
+
+    /// Issue #729: the resolve-path provisioning read is bounded by the resolve
+    /// request semaphore because it funnels through `guarded_get`, which holds a
+    /// permit around the store call. A FaultStore hold on the
+    /// provisioning-record GET blocks the resolve while that permit is held; a
+    /// raw `store.get` would issue the same GET but acquire no permit.
+    ///
+    /// FLIP (pre-fix demonstration): revert `enforce_provisioning_once` to the
+    /// raw `validate_or_adopt(self.store.as_ref(), .., CheckOnly)` call (and
+    /// `read_scan_generations` to `read_generations_from_store`). The held
+    /// provisioning GET then holds no resolve permit, so `available_permits()`
+    /// stays at `MAX_CONCURRENT_REQUESTS` and the `== MAX_CONCURRENT_REQUESTS -
+    /// 1` assertion fails.
+    #[tokio::test]
+    async fn provisioning_read_holds_a_resolve_semaphore_permit() {
+        let mem = MemoryStore::new();
+        let now = 500_000 * NS_PER_HOUR + 30 * 60_000_000_000;
+        publish_segment(&mem, 0, 1, 500_000, now, now - 1_000, now).await;
+        seed_provisioning_record(&mem, 1).await;
+        let store = Arc::new(FaultStore::new(mem, FaultPlan::empty()));
+
+        // Hold every provisioning-record GET inside the store until released.
+        // On a fresh enforcement-on catalog the first such GET is the
+        // `shard_count` enforcement check (`enforce_provisioning_once`), which
+        // runs before the listing fan-out.
+        let gate = store.hold(Op::Get, Some("/prov".to_string()), Occurrence::Always);
+
+        let catalog = Arc::new(
+            Catalog::new(store.clone(), config(1))
+                .expect("catalog")
+                .with_provisioning_enforcement(),
+        );
+        let range = TimeRange {
+            start_ns: now - 1_000,
+            end_ns: now,
+        };
+
+        assert_eq!(
+            catalog.request_semaphore.available_permits(),
+            MAX_CONCURRENT_REQUESTS,
+            "no permit is held before the resolve starts"
+        );
+
+        let acc = QueryAccounting::new();
+        let acc_task = acc.clone();
+        let cat_task = catalog.clone();
+        let task = tokio::spawn(async move {
+            cat_task
+                .resolve_with_accounting(&tenant(), Signal::Metrics, range, &[], now, &acc_task)
+                .await
+        });
+
+        gate.wait_until_held(1).await;
+        assert_eq!(
+            gate.held_count(),
+            1,
+            "the provisioning-record GET is in flight, blocked inside the store"
+        );
+        assert_eq!(
+            catalog.request_semaphore.available_permits(),
+            MAX_CONCURRENT_REQUESTS - 1,
+            "the held provisioning GET holds a resolve semaphore permit: it routed through \
+             guarded_get, not a raw store.get"
+        );
+
+        // Release every held provisioning GET (the enforcement check, then the
+        // generation-history read) so the resolve runs to completion. Bounded so
+        // a resolve that blocks on something other than this gate fails the test
+        // instead of hanging the suite.
+        let mut spins = 0;
+        while !task.is_finished() {
+            for id in gate.held() {
+                gate.release(id);
+            }
+            tokio::time::sleep(Duration::from_millis(1)).await;
+            spins += 1;
+            assert!(
+                spins < 10_000,
+                "resolve did not finish after releasing every held provisioning GET"
+            );
+        }
+        let snapshot = task.await.expect("join resolve task").expect("resolve");
+        assert_eq!(
+            snapshot.segments.len(),
+            1,
+            "once unblocked the resolve returns the published segment"
+        );
     }
 
     /// End-to-end: an older HEAD (`shard_generation_count` lower

--- a/crates/ravel-catalog/src/config.rs
+++ b/crates/ravel-catalog/src/config.rs
@@ -222,11 +222,15 @@ pub struct CatalogConfig {
     /// [`DEFAULT_MAX_CATALOG_LIST_REQUESTS`].
     pub max_catalog_list_requests: u64,
     /// Crossover, in `(shard, hour)` bucket units, at which `Catalog::resolve`
-    /// switches from the per-bucket LIST loop to a single per-shard recursive
-    /// prefix LIST (ADR-0056). When the listing suffix spans at least this many
-    /// buckets (`shard_count * listing_hours`), the prefix scan is used;
-    /// narrower windows keep the per-bucket loop, which prunes better behind a
-    /// folded snapshot watermark. A performance heuristic only: both paths
+    /// switches from the non-prefix bounded LIST path to the per-shard
+    /// recursive prefix scan (ADR-0056). When the listing suffix spans at least
+    /// this many buckets (`shard_count * listing_hours`), the prefix scan is
+    /// used. Both paths issue one bounded `list_after` per shard, resuming
+    /// strictly after the watermark, so neither pages through a shard's
+    /// below-watermark history; narrower windows keep the non-prefix path,
+    /// which fans the shards out concurrently and stops each at the first hour
+    /// past the window, while the prefix scan drains them sequentially under a
+    /// page-by-page request cap. A performance heuristic only: both paths
     /// return identical snapshots and both respect
     /// [`max_catalog_list_requests`](Self::max_catalog_list_requests). Default
     /// [`DEFAULT_PREFIX_LIST_CROSSOVER_REQUESTS`].

--- a/crates/ravel-catalog/src/fold.rs
+++ b/crates/ravel-catalog/src/fold.rs
@@ -750,18 +750,23 @@ impl Catalog {
         default_retention_ns: Option<i64>,
     ) -> Result<FoldReport, CatalogError> {
         let head_key = head_object_key(tenant, signal);
+        // Fold never runs on the query path (module docs above) and keeps
+        // its own `RequestCounters`; this handle exists only to satisfy the
+        // shared cache/load API's `QueryAccounting` parameter and is discarded.
+        // Declared before the generation read so that read's own GET (issue
+        // #729: it now funnels through `guarded_get`) has a handle to charge,
+        // discarded like every other fold-path GET.
+        let accounting = QueryAccounting::new();
         // The generation history for the read-side scan rule (ADR-0052 section
         // 4/5), read fresh (see `Catalog::read_scan_generations`). A fold must
         // enumerate the same per-hour shard set a resolve would, and records
         // the fan-out ceiling and generation count into the HEAD it writes.
-        let generations = self.read_scan_generations(tenant, signal).await?;
+        let generations = self
+            .read_scan_generations(tenant, signal, &accounting)
+            .await?;
         let shard_generation_count = generations.len() as u32;
         let mut counters = RequestCounters::default();
         let mut attempt: u32 = 0;
-        // Fold never runs on the query path (module docs above) and keeps
-        // its own `RequestCounters`; this handle exists only to satisfy the
-        // shared cache/load API's `QueryAccounting` parameter and is discarded.
-        let accounting = QueryAccounting::new();
 
         // The tenant's effective retention window, read once per fold
         // (loop-invariant). Bounds the retention-frontier reconcile pass below

--- a/crates/ravel-catalog/src/provisioning.rs
+++ b/crates/ravel-catalog/src/provisioning.rs
@@ -20,8 +20,12 @@
 //! EK); nothing here changes a recorded value, only refuses when config and
 //! record disagree.
 
+use std::future::Future;
+
 use prost::Message;
-use ravel_object_store::{GetRange, ObjectStoreBackend, PutMode, PutOptions, StoreError};
+use ravel_object_store::{
+    GetOutcome, GetRange, ObjectStoreBackend, PutMode, PutOptions, StoreError,
+};
 use ravel_proto::sys::v1 as sysproto;
 use ravel_types::{Signal, TenantHash};
 
@@ -802,8 +806,12 @@ pub fn read_generations_checked(
 /// stale-in-the-wrong-direction cached view could silently under-scan a query,
 /// and the operations are already GET-bounded, so the fresh GET is accepted in
 /// preference to a second staleness/caching policy with its own proof
-/// obligations. It does not route through the catalog's query-accounting GET
-/// funnel, matching the existing [`validate_or_adopt`] provisioning read.
+/// obligations. This raw-store entry point issues a plain `store.get`, for
+/// callers that hold no per-query accounting handle (ravel-maintain's migrate
+/// pass, ravel-bench's fixtures). The catalog resolve and fold paths call
+/// [`read_generations_accounted`] instead, so their provisioning-record GET
+/// funnels through `Catalog::guarded_get` and is both semaphore-bounded and
+/// recorded (issue #729).
 pub async fn read_generations_from_store(
     store: &dyn ObjectStoreBackend,
     tenant_hash: &TenantHash,
@@ -874,6 +882,40 @@ pub enum AbsentPolicy {
     CheckOnly,
 }
 
+/// Decode provisioning-record bytes, mapping a decode failure to a typed
+/// [`ProvisioningError::Decode`] naming the key. Shared by [`read_record`] (raw
+/// store path) and [`read_record_accounted`] (resolve funnel path) so the two
+/// decode a record identically regardless of how its bytes were fetched.
+fn decode_record(
+    key: &str,
+    bytes: &[u8],
+) -> Result<sysproto::ProvisioningRecord, ProvisioningError> {
+    sysproto::ProvisioningRecord::decode(bytes).map_err(|source| ProvisioningError::Decode {
+        key: key.to_string(),
+        source,
+    })
+}
+
+/// One object-store GET of a provisioning-record key, semaphore-bounded and
+/// recorded into a query's cost accounting by the resolve path that supplies it
+/// (issue #729). The catalog resolve path implements this over
+/// `Catalog::guarded_get`, so the generation-history read and the `shard_count`
+/// enforcement check funnel through the same resolve semaphore and per-query
+/// [`ravel_types::accounting::QueryAccounting`] as every other resolve GET,
+/// rather than a raw `store.get` that escapes both. Administrative touches
+/// (ingest adoption, reshard, floor raise, the maintain loop) run off any
+/// per-query accounting handle and keep the raw `store.get` path in
+/// [`read_record`]/[`validate_or_adopt`].
+pub(crate) trait AccountedRecordGet {
+    /// GET `key` at full range. Same result shape as
+    /// `ObjectStoreBackend::get(key, GetRange::Full)`, so a caller's decode and
+    /// `NotFound`-is-absent handling is identical to a raw read.
+    fn accounted_get_full(
+        &self,
+        key: &str,
+    ) -> impl Future<Output = Result<GetOutcome, StoreError>> + Send;
+}
+
 /// Read a (tenant, signal)'s provisioning record, if present. `NotFound` is
 /// `Ok(None)`, not an error: absence is a valid state with adoption semantics.
 async fn read_record(
@@ -881,19 +923,70 @@ async fn read_record(
     key: &str,
 ) -> Result<Option<sysproto::ProvisioningRecord>, ProvisioningError> {
     match store.get(key, GetRange::Full).await {
-        Ok(outcome) => {
-            let record =
-                sysproto::ProvisioningRecord::decode(outcome.data.as_ref()).map_err(|source| {
-                    ProvisioningError::Decode {
-                        key: key.to_string(),
-                        source,
-                    }
-                })?;
-            Ok(Some(record))
-        }
+        Ok(outcome) => Ok(Some(decode_record(key, outcome.data.as_ref())?)),
         Err(StoreError::NotFound) => Ok(None),
         Err(err) => Err(ProvisioningError::store(key, err)),
     }
+}
+
+/// [`read_record`] over an [`AccountedRecordGet`] instead of a raw store, so the
+/// GET is semaphore-bounded and recorded (issue #729). Identical decode and
+/// `NotFound`-is-`None` handling; the only difference is the funnel the GET
+/// takes.
+async fn read_record_accounted(
+    getter: &impl AccountedRecordGet,
+    key: &str,
+) -> Result<Option<sysproto::ProvisioningRecord>, ProvisioningError> {
+    match getter.accounted_get_full(key).await {
+        Ok(outcome) => Ok(Some(decode_record(key, outcome.data.as_ref())?)),
+        Err(StoreError::NotFound) => Ok(None),
+        Err(err) => Err(ProvisioningError::store(key, err)),
+    }
+}
+
+/// [`read_generations_from_store`] over an [`AccountedRecordGet`], for the
+/// catalog resolve path (issue #729). Identical decode, version/misfile/history
+/// validation, and absent-is-`None` semantics; the only difference is that the
+/// underlying provisioning-record GET runs through the resolve's accounted,
+/// semaphore-bounded funnel instead of a raw `store.get`.
+pub(crate) async fn read_generations_accounted(
+    getter: &impl AccountedRecordGet,
+    tenant_hash: &TenantHash,
+    signal: Signal,
+) -> Result<Option<Vec<ShardGeneration>>, ProvisioningError> {
+    let key = provisioning_key(tenant_hash, signal);
+    match read_record_accounted(getter, &key).await? {
+        Some(record) => Ok(Some(read_generations_checked(
+            &record,
+            &key,
+            tenant_hash,
+            signal,
+        )?)),
+        None => Ok(None),
+    }
+}
+
+/// The read-path ([`AbsentPolicy::CheckOnly`]) branch of [`validate_or_adopt`]
+/// over an [`AccountedRecordGet`], for the catalog resolve path (issue #729). It
+/// validates a present record's `shard_count` and generation history exactly as
+/// [`validate_or_adopt`] does under `CheckOnly`, returns
+/// [`ProvisioningCheck::FreshNoData`] when the record is absent, and never
+/// writes or lists (a query-only node may hold write-restricted credentials).
+/// The sole difference from `validate_or_adopt(.., CheckOnly)` is that the
+/// record GET runs through the resolve's accounted, semaphore-bounded funnel
+/// rather than a raw `store.get`.
+pub(crate) async fn validate_check_only_accounted(
+    getter: &impl AccountedRecordGet,
+    tenant_hash: &TenantHash,
+    signal: Signal,
+    shard_count: u32,
+) -> Result<ProvisioningCheck, ProvisioningError> {
+    let key = provisioning_key(tenant_hash, signal);
+    if let Some(record) = read_record_accounted(getter, &key).await? {
+        validate_record(&record, &key, tenant_hash, signal, shard_count)?;
+        return Ok(ProvisioningCheck::Matched);
+    }
+    Ok(ProvisioningCheck::FreshNoData)
 }
 
 /// Validate a decoded record against the (tenant, signal) it was read under and

--- a/crates/ravel-catalog/src/snapshot_resolve.rs
+++ b/crates/ravel-catalog/src/snapshot_resolve.rs
@@ -640,7 +640,14 @@ impl Catalog {
             return Ok(None);
         }
         let revalidated = self
-            .validate_head_against_generations(tenant, signal, head_key, &head, generations)
+            .validate_head_against_generations(
+                tenant,
+                signal,
+                head_key,
+                &head,
+                generations,
+                accounting,
+            )
             .await?;
 
         let bytes = got.data.len() as u64;
@@ -695,6 +702,7 @@ impl Catalog {
         head_key: &str,
         head: &SnapshotHead,
         generations: &[ShardGeneration],
+        accounting: &QueryAccounting,
     ) -> Result<Option<Vec<ShardGeneration>>, CatalogError> {
         if head_generations_acceptable(head, generations) {
             return Ok(None);
@@ -706,8 +714,11 @@ impl Catalog {
             return Err(head_shard_count_mismatch(head_key, head, generations));
         }
         // Re-read once, bypassing any caching (the read is uncached by
-        // construction), and recompute before failing.
-        let fresh = self.read_scan_generations(tenant, signal).await?;
+        // construction), and recompute before failing. This resolve-path read
+        // funnels through `guarded_get` like the first one (issue #729).
+        let fresh = self
+            .read_scan_generations(tenant, signal, accounting)
+            .await?;
         if head_generations_acceptable(head, &fresh) {
             return Ok(Some(fresh));
         }

--- a/docs/catalog-and-mvcc.md
+++ b/docs/catalog-and-mvcc.md
@@ -908,14 +908,39 @@ and `resolve_pruned` entry points are unchanged and pass a discarded
 `QueryAccounting` handle, so every existing caller keeps its current
 signature and behavior.
 
-`Catalog::guarded_get` and `Catalog::guarded_list_all` are the only two
-places a resolve issues an S3 request (both Phase 1 listing and Phase 2
-snapshot reads funnel through them), so accounting is recorded there, never
-at a call site: one `AccountedOp::Get` per GET attempt and one
+`Catalog::guarded_get` is the only place a resolve issues a GET, and
+`Catalog::guarded_list_all` is the LIST funnel for every path except the two
+shard-scan traversals named below. Accounting is recorded in the funnel,
+never at a call site: one `AccountedOp::Get` per GET attempt and one
 `AccountedOp::List` per LIST page, both unconditional; bytes are added only
 for a successful GET, matching `InstrumentedStore`'s convention that a
-failed request and a LIST move no bytes. `resolve`'s two funnels never issue
+failed request and a LIST move no bytes. `resolve`'s funnels never issue
 a HEAD.
+
+Every GET a resolve issues goes through `guarded_get`, including the two
+provisioning-record reads that provisioning enforcement adds: the generation
+history `Catalog::read_scan_generations` reads fresh on every resolve, and
+the one-shot `shard_count` check `Catalog::enforce_provisioning_once` runs on
+a (tenant, signal)'s first touch. Both were raw `store.get` calls that
+escaped the resolve semaphore and the accounting, so an enforcing catalog
+under-reported a query's GET count by one on every resolve, and by two on a
+(tenant, signal)'s first touch; they now take the same funnel as every other
+resolve GET. The raw `store.get` in `provisioning.rs` remains
+only on the administrative paths, which never run under a query and hold no
+per-query accounting: `validate_or_adopt`'s adoption write and its race
+re-read, `append_generation` (reshard), `raise_format_floor`, and
+`read_floors_from_store`.
+
+The two shard-scan LIST paths (`Catalog::list_window_bounded`, via
+`list_shard_hours`, and `Catalog::list_window_by_prefix`) record their own
+`AccountedOp::List` per page instead of going through `guarded_list_all`.
+Both need `list_after`'s start-after marker to skip a shard's
+below-watermark history server-side, which `guarded_list_all`'s plain `list`
+does not take, and the prefix scan additionally checks its runtime LIST
+ceiling before each page rather than draining unconditionally. Each still
+acquires the same request-semaphore permit per page and applies the same
+ADR-0050 section 2 tenant-prefix assertion, so the bound and the request
+count are what `guarded_list_all` would produce; only the code path differs.
 
 All five caches (`RecordCache`, `CompactionRecordCache`, `HeadCache`,
 `PartCache`, `PostingsCache`) record a cache hit or miss on every lookup and


### PR DESCRIPTION
With provisioning enforcement on, which ravel-server's build_catalog
enables, every resolve read the tenant's provisioning record through
read_scan_generations -> provisioning::read_record -> a raw store.get, and
the first touch of a tenant read it again through
enforce_provisioning_once -> validate_or_adopt. Neither went through
Catalog::guarded_get, so neither took a resolve permit nor landed in
QueryAccounting: object_store_get_requests under-reported a server's
per-query GETs by one, and the read escaped the request budget.
docs/catalog-and-mvcc.md's sentence that guarded_get and guarded_list_all
are the only places a resolve issues a request was false.

A pub(crate) AccountedRecordGet trait with a GuardedRecordGet adapter over
guarded_get carries the resolve's accounting into provisioning.rs, where
read_record_accounted, read_generations_accounted and
validate_check_only_accounted share one decode_record helper with the raw
read_record, so decode and the NotFound-is-None rule are unchanged.
read_scan_generations, enforce_provisioning_once, the HEAD re-validation
in snapshot_resolve.rs and the fold's generation read now go through it.
The raw reads that remain are administrative and not reachable from a
resolve: validate_or_adopt's adoption write and its AlreadyExists re-read,
the reshard and format-floor CAS loops, and the migrate pass's floor
reads; the doc names them, and names the two listing paths
(list_window_by_prefix and list_window_bounded) that account for their
pages by hand because they need list_after's start-after marker and check
the request ceiling before each page.

Every server-side resolve now reports one more GET than before: on the
test fixture the second resolve reads 2 with enforcement on and 1 off, and
the store-side call count is unchanged, so the bench figures move by
exactly one per statement. Tests pin the exact counts and, with a
FaultStore holding the provisioning GET, that the resolve holds a permit
while it waits (MAX_CONCURRENT_REQUESTS - 1 available), both red against
the raw path. The prefix_list_crossover_requests field doc in config.rs
no longer calls the bounded path a per-bucket LIST loop, and
list_window_by_prefix's doc no longer says the store cannot seek past a
prefix (the two stale comments a review found on #752).

Fixes: #729
Refs: #680
