### PR TITLE
fix(ravel-sql): keep string group keys off the RowConverter path

### DIFF
--- a/crates/ravel-sql/src/declared.rs
+++ b/crates/ravel-sql/src/declared.rs
@@ -43,8 +43,10 @@ use ravel_types::TenantHash;
 /// in-memory representation: `Str` reaching a client as
 /// `Dictionary(Int32, Utf8)` is what ADR-0099 decision 5 fixes. Grouping is
 /// separate. `Dictionary` is in none of DataFusion's specialized `GroupValues`
-/// arms, so a `GROUP BY` over a `Str` column falls to the `RowConverter` path,
-/// whose decode is bounded by `i32::MAX` bytes per emitted array (issue #737).
+/// arms, so a `GROUP BY` over a `Str` column would fall to the `RowConverter`
+/// path, whose decode is bounded by `i32::MAX` bytes per emitted array (issue
+/// #737); [`crate::DictionaryGroupKeysAsViews`] keeps it off that path without
+/// changing this mapping.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum DeclaredType {
     /// A `Str`-typed attribute, projected as Arrow `Dictionary(Int32, Utf8)`

--- a/crates/ravel-sql/src/declared.rs
+++ b/crates/ravel-sql/src/declared.rs
@@ -37,6 +37,14 @@ use ravel_types::TenantHash;
 /// (ADR-0090 decision 1), matching [`ravel_logseg::record::FieldType`]'s four
 /// non-float, non-nested variants. `f64`, date, and timestamp are deferred; see
 /// the module docs.
+///
+/// The Arrow type each variant maps to is `declared_arrow_type` in
+/// `crate::logs_schema`. That mapping is a wire contract, not a free choice of
+/// in-memory representation: `Str` reaching a client as
+/// `Dictionary(Int32, Utf8)` is what ADR-0099 decision 5 fixes. Grouping is
+/// separate. `Dictionary` is in none of DataFusion's specialized `GroupValues`
+/// arms, so a `GROUP BY` over a `Str` column falls to the `RowConverter` path,
+/// whose decode is bounded by `i32::MAX` bytes per emitted array (issue #737).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum DeclaredType {
     /// A `Str`-typed attribute, projected as Arrow `Dictionary(Int32, Utf8)`

--- a/crates/ravel-sql/src/error.rs
+++ b/crates/ravel-sql/src/error.rs
@@ -210,6 +210,20 @@ pub enum SqlError {
     #[error("internal ravel-sql error: {0}")]
     Internal(String),
 
+    /// A DataFusion operator panicked while the query's stream was being
+    /// polled, and [`crate::PinnedStream`] unwound it into an error rather
+    /// than letting it escape (issue #737).
+    ///
+    /// This is the last line, not a design: a panic that reaches here is a bug
+    /// in an operator or in a kernel it calls, and the fix belongs where the
+    /// panic is raised. What the boundary guarantees is that one query's bug
+    /// cannot take down the task serving it, or the process. The payload is
+    /// the panic message, which can quote arbitrary values an operator was
+    /// holding, so it redacts like [`SqlError::Internal`] and reaches the
+    /// server log only.
+    #[error("a query operator panicked: {0}")]
+    OperatorPanic(String),
+
     /// Reconstructed from a `DataFusionError::Shared` (checkpoint review
     /// finding, not in the original design): DataFusion wraps some errors
     /// in an `Arc` to hand the same error to multiple stream consumers, so
@@ -251,7 +265,8 @@ impl SqlError {
             | SqlError::ResourcesExhausted(_)
             | SqlError::Plan(_)
             | SqlError::Execution(_)
-            | SqlError::Internal(_) => ErrorClass::Unsupported,
+            | SqlError::Internal(_)
+            | SqlError::OperatorPanic(_) => ErrorClass::Unsupported,
             SqlError::Shared { class, .. } => *class,
         }
     }
@@ -306,7 +321,7 @@ impl SqlError {
             | SqlError::ResourcesExhausted(_) => self.to_string(),
             SqlError::Plan(_) => MSG_PLAN.to_string(),
             SqlError::Execution(_) => MSG_EXECUTION.to_string(),
-            SqlError::Internal(_) => MSG_INTERNAL.to_string(),
+            SqlError::Internal(_) | SqlError::OperatorPanic(_) => MSG_INTERNAL.to_string(),
             SqlError::Shared { message, .. } => message.clone(),
         }
     }

--- a/crates/ravel-sql/src/executor.rs
+++ b/crates/ravel-sql/src/executor.rs
@@ -765,14 +765,7 @@ impl SqlExecutor {
         )
         .map_err(plan_error)?;
         let schema = plan.schema();
-        let inner = execute_stream(Arc::clone(&plan), ctx.task_ctx()).map_err(plan_error)?;
-        Ok(PinnedStream {
-            _ctx: ctx,
-            inner,
-            schema,
-            breach,
-            plan,
-        })
+        PinnedStream::start(ctx, plan, schema, breach)
     }
 
     /// One `Catalog::resolve` plus the `max_segments` budget check. Resolves
@@ -1131,14 +1124,7 @@ impl PinnedQuery {
         // are equivalent: `execute_stream` is `create_physical_plan` then
         // `execute_stream(plan, task_ctx)`.
         let plan = frame.create_physical_plan().await.map_err(plan_error)?;
-        let inner = execute_stream(Arc::clone(&plan), ctx.task_ctx()).map_err(plan_error)?;
-        Ok(PinnedStream {
-            _ctx: ctx,
-            inner,
-            schema,
-            breach,
-            plan,
-        })
+        PinnedStream::start(ctx, plan, schema, breach)
     }
 }
 
@@ -1163,9 +1149,38 @@ pub struct PinnedStream {
     /// it changes nothing about execution: the operators live in `inner`, and
     /// this is the same `Arc` handle.
     plan: Arc<dyn ExecutionPlan>,
+    /// Set once an operator has panicked under [`Stream::poll_next`]. A stream
+    /// whose poll unwound is left in whatever state the panic interrupted, so
+    /// it is never polled again; this fuses it instead.
+    panicked: bool,
 }
 
 impl PinnedStream {
+    /// Execute `plan` under `ctx` and wrap its stream in this type's ceiling
+    /// and panic boundaries.
+    ///
+    /// This is the constructor [`PinnedQuery::execute`] uses. It is public so
+    /// a test can drive a plan the `SqlExecutor` path cannot produce: that
+    /// path registers exactly one table provider of its own choosing
+    /// (`crate::session::build_session`, security invariant 1), so an operator
+    /// that panics on demand has no way in through it.
+    pub fn start(
+        ctx: SessionContext,
+        plan: Arc<dyn ExecutionPlan>,
+        schema: SchemaRef,
+        breach: Arc<CeilingBreach>,
+    ) -> Result<Self, SqlError> {
+        let inner = execute_stream(Arc::clone(&plan), ctx.task_ctx()).map_err(plan_error)?;
+        Ok(PinnedStream {
+            _ctx: ctx,
+            inner,
+            schema,
+            breach,
+            plan,
+            panicked: false,
+        })
+    }
+
     /// The stream's schema, identical to the planned schema.
     pub fn schema(&self) -> SchemaRef {
         Arc::clone(&self.schema)
@@ -1204,9 +1219,51 @@ impl Stream for PinnedStream {
         if let Some(message) = self.breach.message() {
             return Poll::Ready(Some(Err(SqlError::ResourcesExhausted(message.to_string()))));
         }
-        self.inner
-            .poll_next_unpin(cx)
-            .map(|next| next.map(|batch| batch.map_err(execution_error)))
+        if self.panicked {
+            return Poll::Ready(None);
+        }
+        // The panic boundary (issue #737). A panic raised inside a DataFusion
+        // operator, or inside an arrow kernel it calls, unwinds through this
+        // poll: an `i32` offset overflow while a group-by table is decoded is
+        // the case that put it here, but nothing about the boundary is
+        // specific to that one. Unwinding past here kills whichever task is
+        // driving the query -- the HTTP handler or the Flight `DoGet` -- and
+        // the client sees a dropped connection rather than an error.
+        //
+        // `AssertUnwindSafe` is the honest annotation and not a shortcut: the
+        // borrows crossing the boundary really can be left inconsistent by a
+        // panic, which is exactly why `panicked` fuses the stream instead of
+        // resuming it. The default panic hook still runs, so the operator's
+        // own message and backtrace reach stderr before this returns.
+        let polled = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            self.inner.poll_next_unpin(cx)
+        }));
+        match polled {
+            Ok(next) => next.map(|next| next.map(|batch| batch.map_err(execution_error))),
+            Err(payload) => {
+                self.panicked = true;
+                // `payload.as_ref()`, not `&payload`: coercing the `Box`
+                // itself to `&dyn Any` would downcast the box rather than
+                // what it holds, and every arm would miss.
+                let message = panic_message(payload.as_ref());
+                Poll::Ready(Some(Err(SqlError::OperatorPanic(message))))
+            }
+        }
+    }
+}
+
+/// The message carried by a caught panic, for the server-side log.
+///
+/// `panic!` payloads are `&'static str` for a literal and `String` for a
+/// formatted message; anything else came from `panic_any` and has no text to
+/// recover.
+fn panic_message(payload: &(dyn std::any::Any + Send)) -> String {
+    if let Some(message) = payload.downcast_ref::<&'static str>() {
+        (*message).to_string()
+    } else if let Some(message) = payload.downcast_ref::<String>() {
+        message.clone()
+    } else {
+        "panic with a non-string payload".to_string()
     }
 }
 

--- a/crates/ravel-sql/src/group_keys.rs
+++ b/crates/ravel-sql/src/group_keys.rs
@@ -1,0 +1,385 @@
+//! Keep dictionary-encoded string group keys off DataFusion's `RowConverter`
+//! aggregation path (issue #737).
+//!
+//! # The path a `GROUP BY` over a declared `Str` column takes
+//!
+//! A declared `Str` attribute column reaches Arrow as `Dictionary(Int32,
+//! Utf8)` (ADR-0099 decision 5, [`crate::declared::DeclaredType::Str`]). That
+//! type is a wire contract for what a client receives, and DataFusion 54 has
+//! no specialized group-value table for it: `Dictionary` appears in neither
+//! the single-column dispatch in
+//! `datafusion_physical_plan::aggregates::group_values::new_group_values` nor
+//! the `supported_type` list its multi-column `GroupValuesColumn` is built
+//! from. Both fall through to `GroupValuesRows`, which encodes every group key
+//! into arrow's comparable row format and decodes it back on emit.
+//!
+//! The decode is the problem. `GroupValuesRows::emit(EmitTo::All)` hands the
+//! whole table to `RowConverter::convert_rows`, and for a `Utf8` inner type
+//! that lands in `arrow_row::variable::decode_binary::<i32>`, which appends
+//! `i32` offsets into a single values buffer. One `Utf8` array cannot hold
+//! more than `i32::MAX` bytes, and the group table is decoded as one array,
+//! not in `batch_size` slices: the slicing in
+//! `aggregates::row_hash::GroupedHashAggregateStream` happens after the emit,
+//! on the batch the emit already built. A tenant with roughly ten million
+//! distinct URLs averaging 215 bytes crosses the limit and arrow panics with
+//! `offset overflow`. Nothing bounds it first. The memory pool cannot: the
+//! reservation is released before the emit. `EmitTo::First` would, but it is
+//! reachable only under a `GroupOrdering` or the early-emit path.
+//!
+//! # The rewrite
+//!
+//! [`DictionaryGroupKeysAsViews`] is a physical optimizer rule that casts
+//! every `Dictionary(_, Utf8 | LargeUtf8)` group key to `Utf8View` on the
+//! aggregate that first reads it, and casts the emitted group column straight
+//! back to its declared type in a projection directly above the aggregate that
+//! produces the final values. `Utf8View` is in both dispatch tables, so the
+//! aggregate uses `GroupValuesBytesView`, whose emitted array keeps its values
+//! in a list of 2 MiB blocks addressed by a per-view buffer index. There is no
+//! single offset buffer to overflow.
+//!
+//! `Utf8` would also leave the `RowConverter` path, and it is deliberately not
+//! what this rule casts to: `GroupValuesBytes::<i32>` has the same `i32`
+//! offsets in one values buffer, so it moves the panic rather than removing
+//! it.
+//!
+//! Both casts are cheap. Arrow special-cases `Dictionary(_, Utf8)` to
+//! `Utf8View` (`arrow_cast::cast::dictionary::dictionary_cast`) by reusing the
+//! dictionary's values buffer and building views over it, with no string data
+//! copied. The cast back runs on the emitted group column, which the aggregate
+//! stream has already sliced to `batch_size` rows, so the `Utf8` values buffer
+//! it packs is bounded by one output batch.
+//!
+//! # What the rule leaves alone
+//!
+//! - Grouping sets (`ROLLUP`, `CUBE`, `GROUPING SETS`). Their per-set NULL
+//!   placeholder expressions are typed to match each group expression, and
+//!   rewriting one side without the other would desynchronize them.
+//! - Any aggregate that already has an output ordering. Such an aggregate runs
+//!   under a `GroupOrdering`, which reaches `EmitTo::First` and so is already
+//!   bounded, and a cast in a projection above it is not guaranteed to carry
+//!   the ordering equivalence its parent may require.
+//!
+//! Everything else is unconditional: correctness of the rewrite does not
+//! depend on how many distinct keys a query actually has, so there is no
+//! threshold to get wrong.
+
+use std::sync::Arc;
+
+use datafusion::arrow::datatypes::{DataType, SchemaRef};
+use datafusion::common::Result as DFResult;
+use datafusion::common::config::ConfigOptions;
+use datafusion::common::tree_node::{Transformed, TransformedResult, TreeNode};
+use datafusion::physical_expr::PhysicalExpr;
+use datafusion::physical_expr::expressions::{CastExpr, Column};
+use datafusion::physical_optimizer::PhysicalOptimizerRule;
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion::physical_plan::aggregates::{AggregateExec, AggregateOutputMode, PhysicalGroupBy};
+use datafusion::physical_plan::projection::ProjectionExec;
+
+/// The in-memory type a dictionary-encoded string group key is grouped as.
+/// Nothing outside the aggregate observes it: the projection this rule inserts
+/// restores the aggregate's declared output type in the same plan.
+const GROUP_KEY_TYPE: DataType = DataType::Utf8View;
+
+/// The rule's name, as it appears in DataFusion's optimizer diagnostics.
+pub const DICTIONARY_GROUP_KEYS_RULE: &str = "dictionary_group_keys_as_views";
+
+/// Rewrites dictionary-encoded string group keys to `Utf8View` for the
+/// duration of an aggregation. See the module docs for why.
+#[derive(Debug, Default)]
+pub struct DictionaryGroupKeysAsViews;
+
+impl PhysicalOptimizerRule for DictionaryGroupKeysAsViews {
+    fn optimize(
+        &self,
+        plan: Arc<dyn ExecutionPlan>,
+        _config: &ConfigOptions,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        plan.transform_up(rewrite_aggregate).data()
+    }
+
+    fn name(&self) -> &str {
+        DICTIONARY_GROUP_KEYS_RULE
+    }
+
+    fn schema_check(&self) -> bool {
+        // The rule is required to be schema-preserving end to end, so let
+        // DataFusion assert it: a projection that failed to restore a declared
+        // column's type is a client-visible regression, not an internal detail.
+        true
+    }
+}
+
+/// True for the dictionary-encoded string types this rule redirects.
+fn is_dictionary_string(ty: &DataType) -> bool {
+    matches!(ty, DataType::Dictionary(_, value)
+        if matches!(**value, DataType::Utf8 | DataType::LargeUtf8))
+}
+
+/// Rewrite one plan node, bottom-up.
+///
+/// Two things happen here, and both are driven by the *current* input schema
+/// rather than by what this rule did to a lower node. That is what keeps a
+/// two-stage aggregation consistent: if the `Partial` stage was left alone,
+/// the `Final` stage above it sees a dictionary input and is left alone too.
+///
+/// 1. Cast dictionary-string group keys to `Utf8View`.
+/// 2. Rebuild the aggregate whenever its recorded schema disagrees with what
+///    its group expressions now produce. `AggregateExec::with_new_children`,
+///    which the tree walk used to install the rewritten child, carries the old
+///    schema forward verbatim; a `Final` stage over a rewritten `Partial`
+///    would otherwise claim `Dictionary` while its group values are
+///    `Utf8View`.
+fn rewrite_aggregate(
+    node: Arc<dyn ExecutionPlan>,
+) -> DFResult<Transformed<Arc<dyn ExecutionPlan>>> {
+    let Some(agg) = node.downcast_ref::<AggregateExec>() else {
+        return Ok(Transformed::no(node));
+    };
+    let group_by = agg.group_expr();
+    if group_by.has_grouping_set() || !group_by.null_expr().is_empty() {
+        return Ok(Transformed::no(node));
+    }
+
+    let input_schema = agg.input().schema();
+    let declared_schema = agg.schema();
+
+    // Only cast where the aggregate reads a dictionary column directly. A
+    // `Final` stage's group expressions are plain column references into a
+    // rewritten `Partial` output and are already `Utf8View` here, so this
+    // finds nothing and only the stale-schema rebuild below applies.
+    let ordered = agg.properties().output_ordering().is_some();
+    let mut cast_any = false;
+    let mut exprs = Vec::with_capacity(group_by.expr().len());
+    for (expr, name) in group_by.expr() {
+        let ty = expr.data_type(&input_schema)?;
+        if !ordered && is_dictionary_string(&ty) {
+            let cast = CastExpr::new(Arc::clone(expr), GROUP_KEY_TYPE, None);
+            exprs.push((Arc::new(cast) as Arc<dyn PhysicalExpr>, name.clone()));
+            cast_any = true;
+        } else {
+            exprs.push((Arc::clone(expr), name.clone()));
+        }
+    }
+
+    if !cast_any && !group_schema_is_stale(group_by, &input_schema, &declared_schema)? {
+        return Ok(Transformed::no(node));
+    }
+
+    let rebuilt = AggregateExec::try_new(
+        *agg.mode(),
+        PhysicalGroupBy::new(exprs, Vec::new(), group_by.groups().to_vec(), false),
+        agg.aggr_expr().to_vec(),
+        agg.filter_expr().to_vec(),
+        Arc::clone(agg.input()),
+        agg.input_schema(),
+    )?
+    .with_limit_options(agg.limit_options());
+    let rebuilt: Arc<dyn ExecutionPlan> = Arc::new(rebuilt);
+
+    if agg.mode().output_mode() == AggregateOutputMode::Partial {
+        // A partial stage's group columns are consumed only by the stage above
+        // it, which this same walk reaches next. Leave them as views so that
+        // stage groups on views too.
+        return Ok(Transformed::yes(rebuilt));
+    }
+    Ok(Transformed::yes(restore_schema(rebuilt, &declared_schema)?))
+}
+
+/// True when at least one group column of `declared_schema` no longer matches
+/// the type its group expression produces over `input_schema`.
+fn group_schema_is_stale(
+    group_by: &PhysicalGroupBy,
+    input_schema: &SchemaRef,
+    declared_schema: &SchemaRef,
+) -> DFResult<bool> {
+    for (idx, (expr, _)) in group_by.expr().iter().enumerate() {
+        // A schema narrower than its own group-by list is not something this
+        // rule can repair; leave the node alone rather than index past the end.
+        let Some(field) = declared_schema.fields().get(idx) else {
+            return Ok(false);
+        };
+        if expr.data_type(input_schema)? != *field.data_type() {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+/// Project `plan` back onto `target`, casting every column whose type this
+/// rule moved and passing the rest through by reference.
+///
+/// The projection is positional and name-preserving, so every expression above
+/// it resolves the same column at the same index with the same type: the
+/// rewrite is invisible to the rest of the plan and to the client.
+fn restore_schema(
+    plan: Arc<dyn ExecutionPlan>,
+    target: &SchemaRef,
+) -> DFResult<Arc<dyn ExecutionPlan>> {
+    let current = plan.schema();
+    if current.fields() == target.fields() {
+        return Ok(plan);
+    }
+    // Rebuilding an aggregate changes its group column types and nothing else,
+    // so the widths always agree. Say so as an error rather than as an index:
+    // a future DataFusion whose `create_schema` adds a column would otherwise
+    // panic here, in the code whose whole point is that a query does not.
+    if current.fields().len() != target.fields().len() {
+        return Err(datafusion::error::DataFusionError::Internal(format!(
+            "{DICTIONARY_GROUP_KEYS_RULE}: rebuilt aggregate has {} columns, expected {}",
+            current.fields().len(),
+            target.fields().len()
+        )));
+    }
+    let mut exprs: Vec<(Arc<dyn PhysicalExpr>, String)> = Vec::with_capacity(target.fields().len());
+    for (idx, field) in target.fields().iter().enumerate() {
+        let column = Arc::new(Column::new(field.name(), idx)) as Arc<dyn PhysicalExpr>;
+        let expr = if current.field(idx).data_type() == field.data_type() {
+            column
+        } else {
+            Arc::new(CastExpr::new(column, field.data_type().clone(), None))
+                as Arc<dyn PhysicalExpr>
+        };
+        exprs.push((expr, field.name().clone()));
+    }
+    Ok(Arc::new(ProjectionExec::try_new(exprs, plan)?))
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    use datafusion::arrow::array::{ArrayRef, DictionaryArray, Int64Array, StringArray};
+    use datafusion::arrow::datatypes::{Field, Int32Type, Schema};
+    use datafusion::arrow::record_batch::RecordBatch;
+    use datafusion::execution::session_state::SessionStateBuilder;
+    use datafusion::prelude::SessionContext;
+
+    fn dict_type() -> DataType {
+        DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8))
+    }
+
+    /// A session over one batch with a `Dictionary(Int32, Utf8)` key column and
+    /// an `Int64` payload. `with_rule` decides whether the rule under test is
+    /// installed, so the two halves of the differential differ in nothing else.
+    fn dict_context(with_rule: bool) -> SessionContext {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("k", dict_type(), true),
+            Field::new("v", DataType::Int64, false),
+        ]));
+        let keys: DictionaryArray<Int32Type> =
+            vec![Some("a"), Some("b"), Some("a")].into_iter().collect();
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(keys) as ArrayRef,
+                Arc::new(Int64Array::from(vec![1, 2, 3])) as ArrayRef,
+            ],
+        )
+        .expect("fixture batch builds");
+        let ctx = context(with_rule);
+        ctx.register_batch("t", batch).expect("table registers");
+        ctx
+    }
+
+    /// A default session, optionally carrying the rule, built the same way
+    /// `crate::session::build_session` does.
+    fn context(with_rule: bool) -> SessionContext {
+        let mut builder = SessionStateBuilder::new().with_default_features();
+        if with_rule {
+            builder = builder.with_physical_optimizer_rule(Arc::new(DictionaryGroupKeysAsViews));
+        }
+        SessionContext::new_with_state(builder.build())
+    }
+
+    fn collect_aggregates(plan: &Arc<dyn ExecutionPlan>, out: &mut Vec<Arc<dyn ExecutionPlan>>) {
+        if plan.is::<AggregateExec>() {
+            out.push(Arc::clone(plan));
+        }
+        for child in plan.children() {
+            collect_aggregates(child, out);
+        }
+    }
+
+    #[tokio::test]
+    async fn dictionary_group_key_groups_on_views_and_reads_back_as_a_dictionary() {
+        let ctx = dict_context(true);
+        let df = ctx
+            .sql("SELECT k, sum(v) AS total FROM t GROUP BY k")
+            .await
+            .expect("query plans");
+        let logical_schema = df.schema().as_arrow().clone();
+        let plan = df.create_physical_plan().await.expect("physical plan");
+
+        // The plan's output type is untouched: a caller still sees the
+        // declared dictionary column, and it still agrees with the logical
+        // schema DataFusion promised at plan time.
+        assert_eq!(plan.schema().field(0).data_type(), &dict_type());
+        assert_eq!(logical_schema.field(0).data_type(), &dict_type());
+
+        // ...and every aggregate inside it groups on views.
+        let mut aggregates = Vec::new();
+        collect_aggregates(&plan, &mut aggregates);
+        assert!(!aggregates.is_empty(), "the plan must contain an aggregate");
+        for agg in &aggregates {
+            assert_eq!(
+                agg.schema().field(0).data_type(),
+                &DataType::Utf8View,
+                "an aggregate still groups on a dictionary: {agg:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn results_and_types_match_the_unrewritten_plan() {
+        let sql = "SELECT k, sum(v) AS total FROM t GROUP BY k ORDER BY k";
+
+        let baseline = dict_context(false).sql(sql).await.expect("baseline plans");
+        let before_schema = baseline.schema().as_arrow().clone();
+        let before = baseline.collect().await.expect("baseline runs");
+
+        let rewritten = dict_context(true).sql(sql).await.expect("rewritten plans");
+        let after_schema = rewritten.schema().as_arrow().clone();
+        let after = rewritten.collect().await.expect("rewritten runs");
+
+        assert_eq!(before_schema, after_schema);
+        assert_eq!(before, after);
+        // The baseline really is the dictionary path this rule exists to avoid.
+        assert_eq!(before_schema.field(0).data_type(), &dict_type());
+    }
+
+    #[tokio::test]
+    async fn a_non_dictionary_group_key_is_untouched() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("k", DataType::Utf8, true),
+            Field::new("v", DataType::Int64, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(vec!["a", "b", "a"])) as ArrayRef,
+                Arc::new(Int64Array::from(vec![1, 2, 3])) as ArrayRef,
+            ],
+        )
+        .expect("fixture batch builds");
+        let ctx = context(true);
+        ctx.register_batch("t", batch).expect("table registers");
+
+        let plan = ctx
+            .sql("SELECT k, sum(v) FROM t GROUP BY k")
+            .await
+            .expect("query plans")
+            .create_physical_plan()
+            .await
+            .expect("physical plan");
+        let mut aggregates = Vec::new();
+        collect_aggregates(&plan, &mut aggregates);
+        assert!(!aggregates.is_empty());
+        for agg in &aggregates {
+            assert_eq!(agg.schema().field(0).data_type(), &DataType::Utf8);
+        }
+        // No projection was inserted above the aggregate: the rule declined.
+        assert_eq!(plan.schema().field(0).data_type(), &DataType::Utf8);
+    }
+}

--- a/crates/ravel-sql/src/lib.rs
+++ b/crates/ravel-sql/src/lib.rs
@@ -60,6 +60,7 @@ mod executor;
 pub mod flight;
 #[cfg(feature = "flight-sql")]
 mod flight_ticket;
+mod group_keys;
 mod labels;
 mod like_udf;
 mod logs_provider;
@@ -125,6 +126,7 @@ pub use flight_ticket::{
     FlightTicket, FlightTicketError, MAX_STATEMENT_LEN, SegmentPin, TICKET_KEY_LEN, TicketKey,
     derive_ticket_key,
 };
+pub use group_keys::{DICTIONARY_GROUP_KEYS_RULE, DictionaryGroupKeysAsViews};
 pub use logs_provider::LogsTableProvider;
 pub use logs_pushdown::{LogsPushdown, extract_logs};
 pub use logs_scan::LogsScanExec;

--- a/crates/ravel-sql/src/session.rs
+++ b/crates/ravel-sql/src/session.rs
@@ -95,6 +95,7 @@ use datafusion::execution::disk_manager::{DiskManagerBuilder, DiskManagerMode};
 use datafusion::execution::memory_pool::MemoryPool;
 use datafusion::execution::object_store::ObjectStoreRegistry;
 use datafusion::execution::runtime_env::RuntimeEnvBuilder;
+use datafusion::execution::session_state::SessionStateBuilder;
 use datafusion::logical_expr::registry::FunctionRegistry;
 use datafusion::object_store::ObjectStore;
 use datafusion::prelude::{SessionConfig, SessionContext};
@@ -102,6 +103,7 @@ use url::Url;
 
 use crate::avg::sequential_avg_udaf;
 use crate::config::SqlConfig;
+use crate::group_keys::DictionaryGroupKeysAsViews;
 use crate::logs_provider::LogsTableProvider;
 use crate::logs_udf::has_word_udf;
 use crate::map_field_planner::map_field_access_planner;
@@ -503,8 +505,22 @@ pub fn build_session(
         )
         .build_arc()?;
 
-    let mut ctx =
-        SessionContext::new_with_config_rt(session_config(config, exact_typed_aggregates), runtime);
+    // `SessionContext::new_with_config_rt` with one extra physical optimizer
+    // rule. `DictionaryGroupKeysAsViews` keeps a `GROUP BY` over a declared
+    // `Str` column (Arrow `Dictionary(Int32, Utf8)`) off DataFusion's
+    // `RowConverter` group-value path, whose emit cannot exceed `i32::MAX`
+    // decoded bytes in one array (issue #737). It is schema-preserving, so no
+    // caller sees a different result type; see `crate::group_keys`. Appended
+    // after the default rules, which is where `with_physical_optimizer_rule`
+    // puts it: the rewrite must see the final partial/final aggregation split
+    // that `EnforceDistribution` chose.
+    let state = SessionStateBuilder::new()
+        .with_config(session_config(config, exact_typed_aggregates))
+        .with_runtime_env(runtime)
+        .with_default_features()
+        .with_physical_optimizer_rule(Arc::new(DictionaryGroupKeysAsViews))
+        .build();
+    let mut ctx = SessionContext::new_with_state(state);
 
     // Register a hand-written `ExprPlanner` so `col['key']`
     // (`logs.attrs`, `samples.labels`) plans instead of failing with

--- a/crates/ravel-sql/tests/group_by_string_keys.rs
+++ b/crates/ravel-sql/tests/group_by_string_keys.rs
@@ -1,0 +1,660 @@
+//! Issue #737: a string-keyed `GROUP BY` must not be able to panic the
+//! process, and must not reach the `RowConverter` group-value path that can.
+//!
+//! Three properties, in the order the fix delivers them:
+//!
+//! - `declared_str_group_by_groups_on_views_and_returns_its_declared_type`:
+//!   the plan. A `GROUP BY` over a declared `Str` column, through a real
+//!   `SqlExecutor` over a `MemoryStore` tenant, groups on `Utf8View` in every
+//!   aggregate stage and still hands the caller a `Dictionary(Int32, Utf8)`
+//!   column with the same rows a dictionary-keyed grouping produces.
+//! - `a_panicking_operator_surfaces_as_a_typed_error`: the boundary. A plan
+//!   whose scan panics mid-poll yields `SqlError::OperatorPanic` instead of
+//!   unwinding out of whichever task drives the stream, the stream is fused
+//!   afterwards, and a `SqlExecutor` in the same process serves the next
+//!   statement normally.
+//! - `stress_overflowing_group_table_never_panics`: the two together at the
+//!   scale that produced the original report, behind
+//!   `RAVEL_SQL_GROUP_BY_STRESS=1` because it moves gigabytes. See its own
+//!   doc comment.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::fmt;
+use std::sync::Arc;
+use std::time::Duration;
+
+use datafusion::arrow::array::{Array, ArrayRef, DictionaryArray, Int64Array, StringArray};
+use datafusion::arrow::datatypes::{DataType, Field, Int32Type, Schema, SchemaRef};
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::catalog::{Session, TableProvider};
+use datafusion::common::Result as DFResult;
+use datafusion::datasource::TableType;
+use datafusion::execution::{SendableRecordBatchStream, TaskContext};
+use datafusion::logical_expr::Expr;
+use datafusion::physical_expr::EquivalenceProperties;
+use datafusion::physical_plan::aggregates::AggregateExec;
+use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties,
+};
+use datafusion::prelude::{SessionConfig, SessionContext};
+use futures::StreamExt;
+use ravel_catalog::{Catalog, CatalogConfig};
+use ravel_commit::publish::RetryPolicy;
+use ravel_commit::record::NewCommitRecord;
+use ravel_commit::{keys, publish, record};
+use ravel_logseg::writer::ObjectIdentity;
+use ravel_logseg::{AttrValue, LogRecord, RlogConfig, RlogWriter, stream_attrs_bytes};
+use ravel_object_store::memory::MemoryStore;
+use ravel_object_store::{ObjectStoreBackend, PutOptions};
+use ravel_query::{LogSegmentFetcher, SegmentFetcher};
+use ravel_sql::{
+    CeilingBreach, DeclaredColumn, DeclaredType, DictionaryGroupKeysAsViews, ErrorClass,
+    MSG_INTERNAL, PinnedStream, SpanSegmentFetcher, SqlConfig, SqlError, SqlExecutor, SqlRequest,
+    StaticDeclaredColumns, TenantDelegatingPool, TenantMemoryAccountant,
+};
+use ravel_types::accounting::QueryAccounting;
+use ravel_types::{Signal, TenantId, TimeRange};
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+fn dict_type() -> DataType {
+    DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8))
+}
+
+fn request(sql: &str) -> SqlRequest {
+    SqlRequest {
+        sql: sql.to_string(),
+        window: TimeRange {
+            start_ns: 0,
+            end_ns: 1_000_000,
+        },
+        min_tokens: Vec::new(),
+        now_ns: 1_000_000,
+        deadline: Duration::from_secs(60),
+    }
+}
+
+/// Every `AggregateExec` in `plan`, deepest last.
+fn aggregates(plan: &Arc<dyn ExecutionPlan>, out: &mut Vec<Arc<dyn ExecutionPlan>>) {
+    if plan.is::<AggregateExec>() {
+        out.push(Arc::clone(plan));
+    }
+    for child in plan.children() {
+        aggregates(child, out);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// A logs tenant with one declared `Str` column
+// ---------------------------------------------------------------------------
+
+/// The declared attribute key, and the SQL column name it takes.
+const URL_KEY: &str = "url";
+
+fn tenant() -> TenantId {
+    TenantId::new("group-by-string-keys-737".to_string())
+}
+
+fn log_record(ts: i64, url: &str) -> LogRecord {
+    let resource = vec![(
+        "service.name".to_string(),
+        AttrValue::Str("api".to_string()),
+    )];
+    LogRecord {
+        stream_id: ravel_types::logstream::log_stream_id(&resource, "scope", "1.0", &[]),
+        stream_attrs: stream_attrs_bytes(&resource, "scope", "1.0", &[]),
+        ts_ns: ts,
+        observed_ts_ns: ts,
+        severity_num: 9,
+        severity_text: "INFO".into(),
+        body: "req".into(),
+        trace_id: None,
+        span_id: None,
+        flags: 0,
+        attrs: vec![(URL_KEY.to_string(), AttrValue::Str(url.to_string()))],
+    }
+}
+
+/// Write one RLOG object holding `records` and publish its commit record, so a
+/// real `Catalog::resolve` finds it.
+async fn publish_logs(store: &dyn ObjectStoreBackend, tenant: &TenantId, records: &[LogRecord]) {
+    let identity = ObjectIdentity {
+        tenant_hash: tenant.hash().0,
+        shard: 0,
+        writer_id: [3u8; 16],
+        writer_epoch: 1,
+        writer_seq: 1,
+    };
+    let mut writer = RlogWriter::new(RlogConfig::default(), identity);
+    for r in records {
+        writer.push(r.clone()).expect("push record");
+    }
+    let bytes = writer.finish().expect("finish rlog");
+    let min = records.iter().map(|r| r.ts_ns).min().expect("nonempty");
+    let max = records.iter().map(|r| r.ts_ns).max().expect("nonempty");
+    let rec = record::build(NewCommitRecord {
+        tenant_hash: tenant.hash(),
+        signal: Signal::Logs,
+        shard: 0,
+        writer_id: Uuid::from_u128(9_737),
+        writer_epoch: 1,
+        writer_seq: 1,
+        object_size: bytes.len() as u64,
+        content_hash: [7u8; 32],
+        sample_count: records.len() as u64,
+        series_count: 1,
+        min_event_ts_ns: min,
+        max_event_ts_ns: max,
+        min_ingest_ts_ns: min,
+        max_ingest_ts_ns: max,
+        segment_format_version: 1,
+        created_unix_ns: 10,
+        ingest_hour_bucket: 0,
+    })
+    .expect("valid logs commit record");
+    let data_key = keys::reconstruct_data_key(&rec).expect("logs data key");
+    store
+        .put(&data_key, bytes::Bytes::from(bytes), PutOptions::default())
+        .await
+        .expect("put rlog object");
+    publish::publish(store, &rec, &RetryPolicy::default())
+        .await
+        .expect("publish logs commit record");
+}
+
+fn executor_over(store: Arc<dyn ObjectStoreBackend>, declared: Vec<DeclaredColumn>) -> SqlExecutor {
+    let catalog =
+        Arc::new(Catalog::new(Arc::clone(&store), CatalogConfig::default()).expect("catalog"));
+    SqlExecutor::new(
+        catalog,
+        SegmentFetcher::new(Arc::clone(&store)),
+        LogSegmentFetcher::new(Arc::clone(&store)),
+        SpanSegmentFetcher::new(Arc::clone(&store)),
+        SqlConfig::default(),
+        1 << 30,
+    )
+    .with_declared_column_source(Arc::new(StaticDeclaredColumns::new(declared)))
+}
+
+/// A tenant whose records carry `URL_KEY`, with that key declared as a `Str`
+/// column so it projects as `Dictionary(Int32, Utf8)` (ADR-0099 decision 5).
+async fn declared_url_executor() -> SqlExecutor {
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+    let records: Vec<LogRecord> = [
+        "https://example.test/a",
+        "https://example.test/b",
+        "https://example.test/a",
+        "https://example.test/c",
+        "https://example.test/a",
+    ]
+    .iter()
+    .enumerate()
+    .map(|(i, url)| log_record(i as i64 + 1, url))
+    .collect();
+    publish_logs(store.as_ref(), &tenant(), &records).await;
+    executor_over(store, vec![DeclaredColumn::new(URL_KEY, DeclaredType::Str)])
+}
+
+/// Deliverable 1, end to end through the real executor: the aggregate stages
+/// group on `Utf8View`, and nothing a caller can observe changed.
+#[tokio::test]
+async fn declared_str_group_by_groups_on_views_and_returns_its_declared_type() {
+    let executor = declared_url_executor().await;
+    let sql = format!(
+        "SELECT {URL_KEY}, count(*) AS hits FROM logs GROUP BY {URL_KEY} ORDER BY {URL_KEY}"
+    );
+
+    // The plan: every aggregate stage groups on a view, so none of them can
+    // reach `GroupValuesRows`, and the plan's own output type is unchanged.
+    let accounting = QueryAccounting::new();
+    let declared = executor
+        .resolve_declared_columns(tenant().hash(), request(&sql).now_ns)
+        .await;
+    let (snapshot, _) = executor
+        .resolve_snapshot(tenant().hash(), &request(&sql), &accounting)
+        .await
+        .expect("snapshot resolves");
+    let planned = executor
+        .plan_pinned(tenant().hash(), snapshot, &sql, &accounting, &declared)
+        .await
+        .expect("query plans");
+    let plan = planned
+        .create_physical_plan()
+        .await
+        .expect("physical plan builds");
+    let mut stages = Vec::new();
+    aggregates(&plan, &mut stages);
+    assert!(
+        !stages.is_empty(),
+        "the query must plan at least one aggregate"
+    );
+    for stage in &stages {
+        assert_eq!(
+            stage.schema().field(0).data_type(),
+            &DataType::Utf8View,
+            "an aggregate stage still groups on a dictionary key: {stage:?}"
+        );
+    }
+    assert_eq!(plan.schema().field(0).data_type(), &dict_type());
+
+    // The result: the declared wire type, and the rows the data implies.
+    let outcome = executor
+        .execute(tenant().hash(), &request(&sql))
+        .await
+        .expect("query runs");
+    let mut rows: Vec<(String, i64)> = Vec::new();
+    for batch in outcome.output.batches() {
+        assert_eq!(batch.column(0).data_type(), &dict_type());
+        let keys = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<DictionaryArray<Int32Type>>()
+            .expect("group column is a dictionary");
+        let values = keys
+            .values()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("dictionary values are strings");
+        let hits = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("count is Int64");
+        for row in 0..batch.num_rows() {
+            let key = values.value(keys.keys().value(row) as usize).to_string();
+            rows.push((key, hits.value(row)));
+        }
+    }
+    assert_eq!(
+        rows,
+        vec![
+            ("https://example.test/a".to_string(), 3),
+            ("https://example.test/b".to_string(), 1),
+            ("https://example.test/c".to_string(), 1),
+        ]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// A scan that panics on demand
+// ---------------------------------------------------------------------------
+
+/// The message the planted panic raises, asserted on so the test cannot pass
+/// on some unrelated panic.
+const PLANTED_PANIC: &str = "planted operator panic (issue #737)";
+
+/// A table whose scan panics the first time its stream is polled.
+///
+/// The `SqlExecutor` path cannot plant this: it registers exactly one table
+/// provider of its own choosing (`build_session`, security invariant 1). The
+/// test drives `PinnedStream` directly instead, which is the same boundary
+/// every transport polls through.
+#[derive(Debug)]
+struct PanickingTable {
+    schema: SchemaRef,
+}
+
+#[async_trait::async_trait]
+impl TableProvider for PanickingTable {
+    fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.schema)
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::Base
+    }
+
+    async fn scan(
+        &self,
+        _state: &dyn Session,
+        _projection: Option<&Vec<usize>>,
+        _filters: &[Expr],
+        _limit: Option<usize>,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        Ok(Arc::new(PanickingExec::new(Arc::clone(&self.schema))))
+    }
+}
+
+#[derive(Debug)]
+struct PanickingExec {
+    schema: SchemaRef,
+    properties: Arc<PlanProperties>,
+}
+
+impl PanickingExec {
+    fn new(schema: SchemaRef) -> Self {
+        let properties = Arc::new(PlanProperties::new(
+            EquivalenceProperties::new(Arc::clone(&schema)),
+            Partitioning::UnknownPartitioning(1),
+            EmissionType::Incremental,
+            Boundedness::Bounded,
+        ));
+        PanickingExec { schema, properties }
+    }
+}
+
+impl DisplayAs for PanickingExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "PanickingExec")
+    }
+}
+
+impl ExecutionPlan for PanickingExec {
+    fn name(&self) -> &str {
+        "PanickingExec"
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        Vec::new()
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        _children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        Ok(self)
+    }
+
+    fn execute(
+        &self,
+        _partition: usize,
+        _context: Arc<TaskContext>,
+    ) -> DFResult<SendableRecordBatchStream> {
+        let schema = Arc::clone(&self.schema);
+        // Panic inside the stream's poll, which is where an arrow kernel
+        // called by a real operator raises one.
+        let stream = futures::stream::once(async { panic!("{PLANTED_PANIC}") });
+        Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
+    }
+}
+
+/// Deliverable 2: a panic inside a DataFusion operator becomes a typed error
+/// at the executor's stream boundary, the stream is fused afterwards, and the
+/// process is still able to serve the next statement.
+#[tokio::test]
+async fn a_panicking_operator_surfaces_as_a_typed_error() {
+    let schema = Arc::new(Schema::new(vec![Field::new("v", DataType::Int64, false)]));
+    let ctx = SessionContext::new();
+    ctx.register_table(
+        "boom",
+        Arc::new(PanickingTable {
+            schema: Arc::clone(&schema),
+        }),
+    )
+    .expect("table registers");
+    let plan = ctx
+        .sql("SELECT v FROM boom")
+        .await
+        .expect("query plans")
+        .create_physical_plan()
+        .await
+        .expect("physical plan builds");
+
+    // The default hook would print the planted panic and its backtrace, which
+    // is correct in production and only noise here. Silence it for the poll,
+    // then put the previous hook back so a genuine test failure still reports.
+    let previous = std::panic::take_hook();
+    std::panic::set_hook(Box::new(|_| {}));
+    let mut stream =
+        PinnedStream::start(ctx, plan, schema, CeilingBreach::new()).expect("stream starts");
+    let first = stream.next().await;
+    let second = stream.next().await;
+    std::panic::set_hook(previous);
+
+    let err = match first {
+        Some(Err(err)) => err,
+        other => panic!("expected a typed error from the panicking operator, got {other:?}"),
+    };
+    let SqlError::OperatorPanic(detail) = &err else {
+        panic!("expected SqlError::OperatorPanic, got {err:?}");
+    };
+    assert!(
+        detail.contains(PLANTED_PANIC),
+        "the planted panic's message must survive into the server-side detail: {detail}"
+    );
+    // ...and no part of it reaches the client.
+    assert_eq!(err.client_message(), MSG_INTERNAL);
+    assert_eq!(err.class(), ErrorClass::Unsupported);
+    assert!(
+        second.is_none(),
+        "a stream whose poll unwound must be fused, not polled again: {second:?}"
+    );
+
+    // The process is intact: a real executor in the same process serves the
+    // next statement.
+    let executor = declared_url_executor().await;
+    let outcome = executor
+        .execute(tenant().hash(), &request("SELECT count(*) AS n FROM logs"))
+        .await
+        .expect("the next statement still runs");
+    assert_eq!(outcome.output.batches().len(), 1);
+    assert_eq!(
+        outcome.output.batches()[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("count is Int64")
+            .value(0),
+        5
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The overflow, at scale
+// ---------------------------------------------------------------------------
+
+/// Distinct group keys the stress test builds.
+const STRESS_DISTINCT: usize = 600_000;
+/// Bytes per key. `STRESS_DISTINCT * STRESS_KEY_LEN` is about 2.46 GB, past
+/// `i32::MAX`, which is the only property that matters. The original report
+/// reached the same total with roughly ten million keys of 215 bytes; fewer,
+/// longer keys get there with a fixture a test can actually build.
+const STRESS_KEY_LEN: usize = 4096;
+/// Keys per input batch, so no single source array carries more than a few
+/// tens of megabytes.
+const STRESS_BATCH: usize = 8_192;
+
+/// A session over `distinct` distinct `Dictionary(Int32, Utf8)` keys of
+/// `key_len` bytes each, pinned to one partition so every key lands in one
+/// group table. `pool`, when given, is installed as the session's memory pool
+/// so the caller can read the aggregation's high-water mark off its accounting
+/// handle.
+fn key_context(
+    with_rule: bool,
+    distinct: usize,
+    key_len: usize,
+    pool: Option<Arc<dyn datafusion::execution::memory_pool::MemoryPool>>,
+) -> SessionContext {
+    use datafusion::datasource::MemTable;
+    use datafusion::execution::runtime_env::RuntimeEnvBuilder;
+    use datafusion::execution::session_state::SessionStateBuilder;
+
+    let schema = Arc::new(Schema::new(vec![Field::new("k", dict_type(), false)]));
+    let mut batches = Vec::new();
+    let mut next = 0usize;
+    while next < distinct {
+        let end = (next + STRESS_BATCH).min(distinct);
+        let values: Vec<String> = (next..end)
+            .map(|i| {
+                let mut s = format!("https://example.test/{i:012}/");
+                s.push_str(&"p".repeat(key_len - s.len()));
+                s
+            })
+            .collect();
+        let dict: DictionaryArray<Int32Type> = values.iter().map(|s| Some(s.as_str())).collect();
+        batches.push(
+            RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(dict) as ArrayRef])
+                .expect("key batch builds"),
+        );
+        next = end;
+    }
+
+    let mut builder = SessionStateBuilder::new()
+        .with_config(SessionConfig::new().with_target_partitions(1))
+        .with_default_features();
+    if let Some(pool) = pool {
+        let runtime = RuntimeEnvBuilder::new()
+            .with_memory_pool(pool)
+            .build_arc()
+            .expect("runtime builds");
+        builder = builder.with_runtime_env(runtime);
+    }
+    if with_rule {
+        builder = builder.with_physical_optimizer_rule(Arc::new(DictionaryGroupKeysAsViews));
+    }
+    let ctx = SessionContext::new_with_state(builder.build());
+    let table = MemTable::try_new(schema, vec![batches]).expect("mem table builds");
+    ctx.register_table("t", Arc::new(table))
+        .expect("table registers");
+    ctx
+}
+
+fn stress_context(with_rule: bool) -> SessionContext {
+    key_context(with_rule, STRESS_DISTINCT, STRESS_KEY_LEN, None)
+}
+
+/// Distinct keys the peak-memory measurement uses, and their length. Sized so
+/// both halves complete (`MEASURE_DISTINCT * MEASURE_KEY_LEN` is about 51 MB,
+/// far under `i32::MAX`): the point here is the group table's cost, and a
+/// comparison needs the un-rewritten half to finish.
+const MEASURE_DISTINCT: usize = 200_000;
+const MEASURE_KEY_LEN: usize = 256;
+
+/// The peak memory-pool bytes a dictionary-keyed `GROUP BY` reaches with and
+/// without the rewrite, printed rather than asserted on.
+///
+/// Environment-gated with the stress test: a threshold here would be a
+/// threshold on DataFusion's group-table internals, which is not this repo's
+/// contract to pin. What it produces is the number a report or an ADR can
+/// quote, measured rather than reasoned about.
+#[tokio::test]
+async fn stress_report_peak_pool_bytes() {
+    if std::env::var("RAVEL_SQL_GROUP_BY_STRESS").as_deref() != Ok("1") {
+        eprintln!("skipped: set RAVEL_SQL_GROUP_BY_STRESS=1 to run");
+        return;
+    }
+    for with_rule in [false, true] {
+        let accounting = QueryAccounting::new();
+        let pool = Arc::new(TenantDelegatingPool::new(
+            8 << 30,
+            TenantMemoryAccountant::new(8 << 30),
+            CeilingBreach::new(),
+            accounting.clone(),
+        ));
+        let ctx = key_context(
+            with_rule,
+            MEASURE_DISTINCT,
+            MEASURE_KEY_LEN,
+            Some(pool as Arc<dyn datafusion::execution::memory_pool::MemoryPool>),
+        );
+        let batches = ctx
+            .sql("SELECT k, count(*) AS n FROM t GROUP BY k")
+            .await
+            .expect("query plans")
+            .collect()
+            .await
+            .expect("query runs");
+        let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(rows, MEASURE_DISTINCT);
+        let peak = accounting.snapshot().peak_intermediate_bytes;
+        let label = if with_rule {
+            "Utf8View"
+        } else {
+            "RowConverter"
+        };
+        eprintln!(
+            "peak_intermediate_bytes[{label}] = {peak} over {MEASURE_DISTINCT} keys \
+             of {MEASURE_KEY_LEN} bytes"
+        );
+    }
+}
+
+/// The original failure, reproduced and then fixed, at the scale that produces
+/// it. Environment-gated (`RAVEL_SQL_GROUP_BY_STRESS=1`): the fixture alone is
+/// about 2.5 GB and the un-rewritten half allocates roughly as much again, so
+/// it has no place in the default suite.
+///
+/// Two runs over the same query and the same data, differing only in whether
+/// the rewrite is installed:
+///
+/// - Without it, `GROUP BY` on the dictionary key falls to `GroupValuesRows`,
+///   whose emit decodes every key into one `Utf8` array and overflows its
+///   `i32` offsets. That must reach the caller as `SqlError::OperatorPanic`
+///   through the stream boundary, never as an escaping panic.
+/// - With it, the same query returns every distinct group.
+#[tokio::test]
+async fn stress_overflowing_group_table_never_panics() {
+    if std::env::var("RAVEL_SQL_GROUP_BY_STRESS").as_deref() != Ok("1") {
+        eprintln!("skipped: set RAVEL_SQL_GROUP_BY_STRESS=1 to run");
+        return;
+    }
+    let sql = "SELECT k, count(*) AS n FROM t GROUP BY k";
+
+    // Without the rewrite: the RowConverter path, which cannot decode this
+    // many bytes into one array.
+    let ctx = stress_context(false);
+    let plan = ctx
+        .sql(sql)
+        .await
+        .expect("query plans")
+        .create_physical_plan()
+        .await
+        .expect("physical plan builds");
+    let schema = plan.schema();
+    let previous = std::panic::take_hook();
+    std::panic::set_hook(Box::new(|_| {}));
+    let mut stream =
+        PinnedStream::start(ctx, plan, schema, CeilingBreach::new()).expect("stream starts");
+    let mut unrewritten_rows = 0usize;
+    let mut unrewritten_error = None;
+    while let Some(next) = stream.next().await {
+        match next {
+            Ok(batch) => unrewritten_rows += batch.num_rows(),
+            Err(err) => {
+                unrewritten_error = Some(err);
+                break;
+            }
+        }
+    }
+    std::panic::set_hook(previous);
+    match unrewritten_error {
+        Some(SqlError::OperatorPanic(detail)) => {
+            eprintln!("unrewritten path: typed error, detail = {detail}");
+            assert!(
+                detail.contains("offset overflow"),
+                "the unrewritten path must fail on the i32 offset limit: {detail}"
+            );
+        }
+        Some(other) => panic!("unexpected error from the unrewritten path: {other:?}"),
+        // A future DataFusion that bounds the emit itself would land here.
+        // That is a pass, not a failure: the point is that it did not panic.
+        None => {
+            eprintln!("unrewritten path: completed with {unrewritten_rows} rows, no overflow");
+            assert_eq!(unrewritten_rows, STRESS_DISTINCT);
+        }
+    }
+
+    // With the rewrite: the full result.
+    let rewritten = stress_context(true)
+        .sql(sql)
+        .await
+        .expect("query plans")
+        .collect()
+        .await
+        .expect("the rewritten plan runs to completion");
+    let rows: usize = rewritten.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(rows, STRESS_DISTINCT);
+    for batch in &rewritten {
+        assert_eq!(batch.column(0).data_type(), &dict_type());
+    }
+}

--- a/docs/adrs/0099-columnar-decode-to-arrow.md
+++ b/docs/adrs/0099-columnar-decode-to-arrow.md
@@ -394,3 +394,38 @@ flowchart LR
   ADR's decisions 1 to 3 for RSPAN. Columnar erasure evaluation is still open,
   and is what forces ADR-0110's eligibility rule to fail closed to the row path
   whenever an erasure predicate is pending.
+
+## Amendment: decision 5 is a wire type, not a grouping type (issue #737)
+
+Decision 5 fixes `Dictionary(Int32, Utf8)` as the type a declared `Str` column
+is scanned into and delivered as. That part stands unchanged: the scan builds
+dictionary arrays on both paths, the Flight statement path resends
+dictionaries, and a client sees the same column type it saw before.
+
+What the decision did not say, and was read as saying, is that the same type is
+what the engine groups on. It is not, and cannot be. DataFusion 54 has no
+specialized group-value table for `Dictionary`, so a `GROUP BY` over a declared
+`Str` column falls to `GroupValuesRows`, whose emit decodes the whole group
+table into one array through `arrow_row`'s `i32` offsets and panics with
+`offset overflow` past `i32::MAX` bytes of key data. A ClickBench-shaped tenant
+reaches that in one query.
+
+The `logs` table therefore now groups such a column as `Utf8View` for the
+duration of the aggregation, and casts it back to `Dictionary(Int32, Utf8)` in
+a projection directly above the aggregate that produces final values. The rule
+is `DictionaryGroupKeysAsViews` (`crates/ravel-sql/src/group_keys.rs`),
+installed by `build_session` on every session. The rewrite is schema-preserving
+by construction and DataFusion asserts it (the rule sets `schema_check`), so
+this amendment changes an in-memory representation inside one operator and
+nothing on the wire. `Utf8View`, not `Utf8`: the latter carries the same `i32`
+offsets in a single values buffer and would move the limit rather than remove
+it.
+
+Two follow-ups this amendment does not close:
+
+- A single `Utf8` group key (`attrs['k']`, which is what a non-declaring tenant
+  writes) takes `GroupValuesBytes::<i32>`, whose emit has its own `i32` offset
+  limit in one values buffer. The rule above does not touch it, because that
+  path is not what issue #737 reported.
+- `severity_text` is still `Utf8`, unchanged and still deferred for the reason
+  decision 5 gives.

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -1751,6 +1751,51 @@ count), so a client that needs a stable order must add `ORDER BY`. The result
 *content* is identical across partition counts for an admitted query; only
 arrival order varies.
 
+## String-keyed `GROUP BY`, and the panic boundary under it
+
+A declared `Str` column reaches Arrow as `Dictionary(Int32, Utf8)` (ADR-0099
+decision 5). That is the type a client receives, and it is deliberately not the
+type the engine groups on. DataFusion 54 has no specialized group-value table
+for `Dictionary`: it is absent from both the single-column dispatch in
+`aggregates::group_values::new_group_values` and the `supported_type` list the
+multi-column `GroupValuesColumn` is built from, so a `GROUP BY` over one falls
+through to `GroupValuesRows`. That table encodes each key into arrow's
+comparable row format and decodes the whole table back into one array on emit,
+through `arrow_row`'s `i32` offsets. A tenant with enough distinct keys to
+cross `i32::MAX` bytes of key data crosses it inside that single decode, and
+nothing bounds it first: the aggregate stream slices its output to `batch_size`
+only after the emit has already built the batch, and the memory pool
+reservation is released before it.
+
+`DictionaryGroupKeysAsViews` (`crates/ravel-sql/src/group_keys.rs`), a physical
+optimizer rule every session installs, casts dictionary-encoded string group
+keys to `Utf8View` on the aggregate that first reads them and casts the emitted
+group column back to its declared type in a projection directly above the
+aggregate that produces final values. `Utf8View` is in both of DataFusion's
+dispatch tables, so the grouping runs on `GroupValuesBytesView`, which stores
+its values in a list of 2 MiB blocks addressed per view and has no single
+offset buffer to overflow. `Utf8` would also leave the row-converter path and
+is deliberately not what the rule casts to: it carries the same `i32` offsets
+in one buffer, so it would move the limit rather than remove it. Both casts are
+cheap -- arrow builds views directly over an existing dictionary's values
+buffer without copying string data -- and neither is visible to a caller: the
+projection restores the column's name, position, and declared type, so the
+query's result schema is identical with and without the rule. Grouping sets and
+aggregates that already carry an output ordering are left on the original path;
+an ordered aggregate emits incrementally (`EmitTo::First`) and is bounded
+already.
+
+Underneath that sits a guarantee that does not depend on the rewrite being
+right. Every batch from every SQL transport passes through `PinnedStream`, and
+its poll catches an unwinding panic raised anywhere in the plan and returns
+`SqlError::OperatorPanic` instead, then fuses the stream. A panic in an
+operator or in an arrow kernel it calls is a bug, and the fix belongs where it
+is raised; what the boundary guarantees is that such a bug fails one query with
+a typed error rather than unwinding out of the task serving it. The panic
+message reaches the server log only: like `SqlError::Internal` it redacts to a
+fixed client string, because a panic payload can quote whatever values the
+operator was holding.
+
 ## Caching note
 
 ADR-0046 added a content-addressed RAM read-cache tier (`ravel-cache`,


### PR DESCRIPTION
ClickBench q35 (GROUP BY a wide URL column over 100M rows) panicked in
arrow-row's RowConverter with an i32 offset overflow, and every
string-keyed GROUP BY (q29, q34, q35) exhausted the pool at the partial
stage: a Dictionary(Int32, Utf8) group key is in none of DataFusion's
specialised GroupValues kinds, so it falls to GroupValuesRows, which
packs every key through the row converter into one i32-offset buffer.

A physical optimizer rule, DictionaryGroupKeysAsViews, installed by
build_session, walks the plan bottom-up and casts Dictionary(_, Utf8 |
LargeUtf8) group keys to Utf8View on the first AggregateExec that reads
them, rebuilds each AggregateExec with try_new so the Final stage's input
schema follows the rewritten Partial, and restores the declared type in a
ProjectionExec above the Final aggregate; schema_check is on so
DataFusion asserts the round trip. Utf8View keys land on
GroupValuesBytesView, whose emit appends into 2 MiB blocks addressed by
a per-view buffer index with no i32 offset buffer. The cast in is
arrow-cast's dictionary fast path (no string copy) and the cast back
runs on batches already sliced to batch_size. Plain Utf8 was evaluated
and rejected: GroupValuesBytes carries the same i32 offsets.

A statement can still fail; it can no longer take the process with it.
PinnedStream::poll_next wraps the inner poll in catch_unwind, surfaces a
panic as SqlError::OperatorPanic (client message redacted, full text in
the server log) and fuses the stream; both PinnedStream construction
sites, including the Flight worker fragment, go through one start.

Tests: a declared Str column through the real SqlExecutor on an RLOG
tenant groups on Utf8View at every aggregate stage and returns the
declared Dictionary(Int32, Utf8) with rows asserted by value (red with the
rule's type test forced false); a panicking TableProvider yields
OperatorPanic with the planted message redacted, a fused second poll, and
the executor serving the next statement. Measured on 200,000 distinct
256-byte keys in one partition: pool peak 161 MB on the row converter,
130 MB on views. docs/query-engine.md gains the string-key section and
the never-panic guarantee; ADR-0099 records that decision 5's Dictionary
mapping is a wire type, not a grouping type.

Fixes: #737
Refs: #740
Refs: #680
