### PR TITLE
fix(ravel-codec): keep folded tokens alphanumeric under full case mapping

### DIFF
--- a/crates/ravel-codec/proptest-regressions/tokenizer.txt
+++ b/crates/ravel-codec/proptest-regressions/tokenizer.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 1d23458ab8cbb00026db21584c8dcd1aa47d51a465ce54ae13b548a89ba969c2 # shrinks to text = "İ"

--- a/crates/ravel-codec/src/tokenizer.rs
+++ b/crates/ravel-codec/src/tokenizer.rs
@@ -8,9 +8,15 @@
 /// Tokens of `text`: lowercase words split on any non-alphanumeric character.
 ///
 /// - split on `!char::is_alphanumeric` (Unicode-aware);
-/// - lowercase each token with `char::to_lowercase` (Unicode-aware);
+/// - lowercase each character with `char::to_lowercase` (Unicode-aware),
+///   dropping any resulting character that is not alphanumeric. Full case
+///   mapping can emit a combining mark (U+0130 `İ` lowercases to `i` +
+///   U+0307 COMBINING DOT ABOVE, a Mark); dropping it keeps every emitted
+///   character alphanumeric, and folds `İ` to `i` exactly as a query typed
+///   `istanbul` folds;
 /// - truncate each token to its longest character-boundary prefix of at most
-///   64 bytes;
+///   64 bytes, measured on the folded characters so a length-changing
+///   lowercase can neither exceed the cap nor split a codepoint;
 /// - drop empty tokens; keep duplicates (deduplication is the bloom's job).
 pub fn tokens(text: &str) -> Vec<Vec<u8>> {
     /// Byte cap on a single token (docs/log-segment-format.md constant).
@@ -38,8 +44,14 @@ pub fn tokens(text: &str) -> Vec<Vec<u8>> {
                 continue;
             }
             for lc in ch.to_lowercase() {
-                // Appending this lowercased char must keep the token within
-                // the 64-byte cap on a character boundary.
+                // Full case mapping can emit a non-alphanumeric character
+                // (U+0130 lowercases to 'i' + U+0307 COMBINING DOT ABOVE).
+                // Drop it so every emitted character stays alphanumeric.
+                if !lc.is_alphanumeric() {
+                    continue;
+                }
+                // Appending this folded char must keep the token within the
+                // 64-byte cap on a character boundary.
                 if cur.len() + lc.len_utf8() > TOKEN_MAX_BYTES {
                     truncated = true;
                     break;
@@ -102,6 +114,80 @@ mod tests {
     fn unicode_word_is_lowercased() {
         // A single uppercase multi-byte word lowercases and stays one token.
         assert_eq!(toks("STRASSE"), vec![b"strasse".to_vec()]);
+    }
+
+    #[test]
+    fn full_case_mapping_stays_alphanumeric() {
+        // U+0130 LATIN CAPITAL LETTER I WITH DOT ABOVE lowercases under the
+        // full Unicode case mapping to "i" + U+0307 COMBINING DOT ABOVE.
+        // U+0307 is a Mark, not alphanumeric: the fold drops it so the token
+        // is plain "i".
+        assert_eq!(toks("İ"), vec![b"i".to_vec()]);
+        for tok in toks("İ") {
+            let s = std::str::from_utf8(&tok).expect("valid utf-8");
+            assert!(s.chars().all(|c| c.is_alphanumeric()));
+        }
+    }
+
+    #[test]
+    fn dotted_i_folds_to_ascii_across_case() {
+        // "İstanbul", "ISTANBUL" and "istanbul" must all fold to the same
+        // single token, so a query for any casing hits a document written
+        // with any other.
+        let expected = vec![b"istanbul".to_vec()];
+        assert_eq!(toks("İstanbul"), expected);
+        assert_eq!(toks("ISTANBUL"), expected);
+        assert_eq!(toks("istanbul"), expected);
+    }
+
+    #[test]
+    fn combining_marks_after_letter_fold_to_letter() {
+        // Combining marks are not alphanumeric, so they act as separators:
+        // a letter followed only by marks yields just the letter.
+        assert_eq!(toks("a\u{0301}\u{0300}\u{0307}"), vec![b"a".to_vec()]);
+    }
+
+    #[test]
+    fn fold_expanding_near_cap_never_splits_a_codepoint() {
+        // Each 'İ' folds to a single ASCII 'i' (the combining mark is
+        // dropped), so 100 of them fill the 64-byte token exactly and the
+        // cap lands on a character boundary.
+        let dotted = "İ".repeat(100);
+        let out = tokens(&dotted);
+        assert_eq!(out.len(), 1);
+        assert!(out[0].len() <= 64);
+        let s = std::str::from_utf8(&out[0])
+            .expect("cap must stay on a char boundary, never splitting a codepoint");
+        assert!(s.chars().all(|c| c.is_alphanumeric()));
+
+        // A word built from characters whose lowercase is two bytes wide
+        // ('Α' -> 'α', 2 bytes) reaches the byte cap on a whole character:
+        // 32 characters is 64 bytes, so the token is capped at 32 chars and
+        // never straddles a codepoint.
+        let greek = "Α".repeat(64);
+        let out = tokens(&greek);
+        assert_eq!(out.len(), 1);
+        assert!(out[0].len() <= 64);
+        let s = std::str::from_utf8(&out[0])
+            .expect("cap must stay on a char boundary, never splitting a codepoint");
+        assert_eq!(s.chars().count(), 32);
+        assert!(s.chars().all(|c| c.is_alphanumeric()));
+    }
+
+    /// Symmetry: the write path (bloom insertion / POSTINGS) and the read
+    /// path (word/phrase match) must fold identically. They can only do so
+    /// because both call this one `tokens` function; this test pins that a
+    /// query term and the indexed body fold to the same token through the
+    /// same function, so the two sides cannot drift.
+    #[test]
+    fn write_and_read_paths_fold_through_one_function() {
+        // Simulates the ingest side (indexing a body) and the query side
+        // (folding a user's search word) for the same word in different
+        // casings.
+        let indexed = tokens("İstanbul was Constantinople");
+        let query = tokens("ISTANBUL");
+        assert_eq!(query, vec![b"istanbul".to_vec()]);
+        assert!(indexed.contains(&query[0]));
     }
 
     /// Acceptance test: pins the four normative rules from

--- a/docs/log-segment-format.md
+++ b/docs/log-segment-format.md
@@ -1014,9 +1014,15 @@ defines word semantics identically on the write and read paths:
 
 - split on any non-alphanumeric character (`char::is_alphanumeric`,
   Unicode-aware);
-- lowercase each token (`char::to_lowercase`, Unicode-aware);
+- lowercase each character (`char::to_lowercase`, Unicode-aware), dropping
+  any resulting character that is not alphanumeric. Full case mapping can
+  emit a combining mark: U+0130 `İ` lowercases to `i` + U+0307 COMBINING
+  DOT ABOVE (a Mark), so the mark is dropped and `İ` folds to `i`, matching
+  what a query typed `istanbul` produces. This keeps every emitted
+  character alphanumeric;
 - truncate each token to its longest character-boundary prefix of at most
-  64 bytes;
+  64 bytes, measured on the folded characters so a length-changing
+  lowercase can neither exceed the cap nor split a codepoint;
 - drop empty tokens; keep duplicates (deduplication is the bloom's job).
 
 A multi-token query word is a phrase: the scan requires all its tokens to

--- a/docs/log-segment-format.md
+++ b/docs/log-segment-format.md
@@ -1025,6 +1025,16 @@ defines word semantics identically on the write and read paths:
   lowercase can neither exceed the cap nor split a codepoint;
 - drop empty tokens; keep duplicates (deduplication is the bloom's job).
 
+A change to these rules is not a format version bump (token bytes are
+not a pinned invariant; the bloom framing and POSTINGS structure are),
+but it does change what an already-written object indexed. An object
+written under an earlier fold keeps its old token keys in its bloom and
+POSTINGS, so a query folded under the current rules can miss a word in
+that object. The miss is a false negative only: a bloom or POSTINGS
+negative prunes, and the exact scan re-tokenizes with the current rules,
+so no wrong row is returned. Re-ingesting or compacting the object
+rewrites its tokens under the current rules.
+
 A multi-token query word is a phrase: the scan requires all its tokens to
 be present, in order, in the tokenized field value; a single-token word
 requires containment.


### PR DESCRIPTION
The word tokenizer lowercases each character with char::to_lowercase, a
full Unicode case mapping. Some characters expand to more than one
character, and some of those are not alphanumeric: U+0130 LATIN CAPITAL
LETTER I WITH DOT ABOVE lowercases to "i" + U+0307 COMBINING DOT ABOVE,
and U+0307 is a Mark. The tokenizer emitted that mark inside the token,
which breaks the invariant the module states and the proptest checks
(every character of every emitted token is alphanumeric). The proptest
found it on a box gate and shrank the input to "İ".

The fold is now total: after lowercasing each character, drop any
resulting character that is not alphanumeric, then apply the 64-byte cap
on the folded characters. "İ" folds to "i", exactly what a query typed
"istanbul" folds to, so both casings hit the same token. The cap runs
after the fold and only appends whole characters, so a length-changing
lowercase can neither exceed 64 bytes nor split a codepoint. This is the
rule for every mark- or length-changing lowercase, not a special case for
U+0130.

Write and read fold identically because both call the one tokens()
function (ravel-logseg re-exports ravel_codec::tokenizer): bloom
insertion and POSTINGS on ingest, has_word and text predicates on query.
A test pins that a query term and an indexed body fold to the same token
through that function.

Persisted-format impact: no format version changes; the RSEG layout,
bloom framing, and POSTINGS structure are unchanged. Only the token bytes
for text containing a mark- or length-changing lowercase change. An
object written before this change carries the old marked token, so a
query folded with the new rule misses that word on that object. That is a
false negative only: a bloom negative prunes, and the exact scan uses
this same tokenizer, so no wrong rows are returned. Re-ingesting or
compacting the object rewrites the token. The proptest regression file
replays the shrunk "İ" seed on every run; PROPTEST_CASES=20000 passes.

Fixes: #765
Refs: #680
