### PR TITLE
fix(ravel-query): numeric-arm pruning and PAGE_DIR chunk reads for logs scans

### DIFF
--- a/crates/ravel-logseg/src/columns.rs
+++ b/crates/ravel-logseg/src/columns.rs
@@ -155,7 +155,13 @@ impl ColumnSelection {
     /// Resolve to the concrete block column ids for one object, or `None` when
     /// every column is wanted (which [`crate::block::read_block_columns`] takes
     /// as "no filter").
-    pub(crate) fn resolve(&self, field_dir: &FieldDir) -> Option<HashSet<u32>> {
+    ///
+    /// Public because ADR-0699 decision 5 makes this selection a *fetch*
+    /// selection as well as a decode one: `ravel-query`'s version-4 fetcher
+    /// turns the resolved ids into the column chunks it reads by range, and it
+    /// must resolve them the same way the decode does or it would fetch a
+    /// different set of pages than the reader goes on to interpret.
+    pub fn resolve(&self, field_dir: &FieldDir) -> Option<HashSet<u32>> {
         if self.all {
             return None;
         }

--- a/crates/ravel-logseg/src/field_dir.rs
+++ b/crates/ravel-logseg/src/field_dir.rs
@@ -8,7 +8,8 @@
 //! over the cap, an unknown type byte, or truncation is `Corrupted`.
 
 use crate::error::LogSegError;
-use crate::record::FieldType;
+use crate::record::{FieldSel, FieldType, Predicate};
+use crate::skip_index::NumRangeArm;
 use crate::varint::{get_uvarint, put_uvarint};
 
 /// One FIELD_DIR entry.
@@ -61,6 +62,47 @@ impl FieldDir {
     /// The entry with the given column id, if present.
     pub fn by_column_id(&self, column_id: u32) -> Option<&FieldEntry> {
         self.entries.iter().find(|e| e.column_id == column_id)
+    }
+
+    /// Resolve prune-only [`Predicate::NumRange`] arms to
+    /// [`SkipIndex::candidate_blocks`](crate::skip_index::SkipIndex::
+    /// candidate_blocks) inputs, using this object's own column ids.
+    ///
+    /// Each arm names an attribute and its exact column type; it resolves to the
+    /// dynamic column [`FieldDir::column`] returns for that `(name, type)`. An
+    /// arm whose field does not resolve to such a column -- an unknown name, a
+    /// name stored only under other types, or a non-attribute selector -- yields
+    /// no [`NumRangeArm`] and so prunes nothing, the same degrade-safe
+    /// fallthrough the unindexed POSTINGS field takes (ADR-0013). The bounds pass
+    /// straight through as bit patterns; the range is prune-only, so the exact
+    /// residual stays the caller's job (ADR-0095 decision 6). Non-`NumRange` arms
+    /// (a POSTINGS `Equals`, an `And`) are ignored: they are not skip-index
+    /// pruning primitives.
+    ///
+    /// Shared by [`RlogReader::scan_blocks`](crate::RlogReader::scan_blocks) at
+    /// decode and by the query-side block-range fetcher at fetch, so both resolve
+    /// the exact same arms against the exact same directory (the arms a fetch
+    /// prunes on are byte-for-byte the arms decode prunes on).
+    pub fn numeric_range_arms(&self, prune: &[&Predicate]) -> Vec<NumRangeArm> {
+        let mut out = Vec::new();
+        for a in prune {
+            if let Predicate::NumRange {
+                field: FieldSel::Attr(name),
+                ty,
+                min,
+                max,
+            } = a
+                && let Some(entry) = self.column(name, *ty)
+            {
+                out.push(NumRangeArm {
+                    column_id: entry.column_id,
+                    ty: *ty,
+                    min_bits: *min,
+                    max_bits: *max,
+                });
+            }
+        }
+        out
     }
 
     /// Serializes the section in its uncompressed form.

--- a/crates/ravel-logseg/src/page_dir.rs
+++ b/crates/ravel-logseg/src/page_dir.rs
@@ -21,6 +21,8 @@
 //! guarantees is re-checked rather than assumed, and every violation is
 //! [`LogSegError::Corrupted`], never a panic and never a silent misread.
 
+use std::collections::HashSet;
+
 use crate::block::MAX_PAGES;
 use crate::encoding::Enc;
 use crate::error::LogSegError;
@@ -182,6 +184,51 @@ impl PageDir {
             .iter()
             .find(|c| c.column_id == column_id)?
             .extent()
+    }
+
+    /// The byte extents in BLOCKS, `(offset, stored length)`, of exactly the
+    /// pages row group `group` holds for the blocks named in `blocks` (indices
+    /// *within* the group, strictly ascending) and the columns `columns` keeps
+    /// (`None` keeps every column).
+    ///
+    /// This is what ADR-0699 decision 5's fetcher ranges over. A projection of
+    /// `k` columns over a group whose blocks all survive is `k` runs of
+    /// contiguous pages, one per column chunk; a group in which only some
+    /// blocks survive contributes only those blocks' pages, and the pruned
+    /// blocks' pages are the gaps the fetcher's coalescing rule decides whether
+    /// to read through or split around. One extent per page, ascending within a
+    /// chunk and with the chunks in `column_id` order, which is ascending
+    /// overall because a group's chunks are contiguous in that order.
+    ///
+    /// `None` when `group` is past the last group or a page offset overflows
+    /// (which [`Self::decode`] already rejects).
+    pub fn projected_page_ranges(
+        &self,
+        group: usize,
+        blocks: &[u32],
+        columns: Option<&HashSet<u32>>,
+    ) -> Option<Vec<(u64, u64)>> {
+        let g = self.groups.get(group)?;
+        let mut out = Vec::new();
+        for chunk in &g.chunks {
+            let keep = match columns {
+                None => true,
+                Some(set) => set.contains(&chunk.column_id),
+            };
+            let mut at = chunk.offset;
+            for p in &chunk.pages {
+                let start = at;
+                at = at.checked_add(p.len)?;
+                // `blocks` is ascending, so this stays a binary search rather
+                // than a linear scan: a default-sized group has 32 blocks and a
+                // wide object has one chunk per column, so a linear membership
+                // test here would be quadratic in the group.
+                if keep && blocks.binary_search(&p.block).is_ok() {
+                    out.push((start, p.len));
+                }
+            }
+        }
+        Some(out)
     }
 
     /// Total blocks the directory covers.
@@ -499,6 +546,74 @@ mod tests {
         assert_eq!(b2.len(), 1);
         assert_eq!(b2[0].offset, 41);
         assert!(dir.block_pages(3).is_none());
+    }
+
+    #[test]
+    fn projected_page_ranges_keeps_only_the_named_blocks_and_columns() {
+        let dir = sample();
+        // Every column, every block of group 0: the whole group, contiguous.
+        let all = dir
+            .projected_page_ranges(0, &[0, 1], None)
+            .expect("group 0");
+        assert_eq!(all, vec![(0, 10), (10, 12), (22, 3), (25, 7), (32, 9)]);
+
+        // One block of the group: block 1's page in each chunk, with block 0's
+        // pages left as the holes between them.
+        let b1 = dir.projected_page_ranges(0, &[1], None).expect("group 0");
+        assert_eq!(b1, vec![(10, 12), (32, 9)]);
+
+        // One column: that chunk's pages only. Column 5 carries a presence page
+        // and a value page for block 0, and both come back.
+        let c5 = dir
+            .projected_page_ranges(0, &[0, 1], Some(&HashSet::from([5])))
+            .expect("group 0");
+        assert_eq!(c5, vec![(22, 3), (25, 7), (32, 9)]);
+
+        // One block and one column: exactly the intersection.
+        let one = dir
+            .projected_page_ranges(0, &[0], Some(&HashSet::from([0])))
+            .expect("group 0");
+        assert_eq!(one, vec![(0, 10)]);
+
+        // A column the group does not carry contributes nothing, and a block
+        // index outside the group contributes nothing, neither being an error:
+        // the caller's selection is not a claim about this object's layout.
+        assert_eq!(
+            dir.projected_page_ranges(0, &[0, 1], Some(&HashSet::from([9])))
+                .expect("group 0"),
+            Vec::new()
+        );
+        assert_eq!(
+            dir.projected_page_ranges(0, &[7], None).expect("group 0"),
+            Vec::new()
+        );
+        // A group past the last is `None`, not an empty list.
+        assert_eq!(dir.projected_page_ranges(2, &[0], None), None);
+    }
+
+    /// The extents of every block and every column of a group are exactly the
+    /// group's chunk ranges laid end to end: a projection that keeps everything
+    /// reads the group's whole span, which is what lets the fetcher's coalescing
+    /// collapse it into one GET with no separate whole-group case.
+    #[test]
+    fn projected_page_ranges_over_everything_tiles_the_group() {
+        let dir = sample();
+        let group = &dir.groups[0];
+        let blocks: Vec<u32> = (0..group.block_count).collect();
+        let ranges = dir
+            .projected_page_ranges(0, &blocks, None)
+            .expect("group 0");
+        let mut at = group.chunks[0].offset;
+        for (offset, len) in &ranges {
+            assert_eq!(*offset, at, "the ranges are contiguous");
+            at += len;
+        }
+        let total: u64 = group
+            .chunks
+            .iter()
+            .map(|c| c.extent().expect("extent").1)
+            .sum();
+        assert_eq!(at - group.chunks[0].offset, total);
     }
 
     #[test]

--- a/crates/ravel-logseg/src/reader.rs
+++ b/crates/ravel-logseg/src/reader.rs
@@ -629,25 +629,7 @@ impl<'a> RlogReader<'a> {
     /// through as bit patterns; the range is prune-only, so the exact residual
     /// stays the caller's (SQL layer's) job (ADR-0095 decision 6, ADR-0013).
     fn numeric_range_arms(&self, arms: &[&Predicate]) -> Vec<NumRangeArm> {
-        let mut out = Vec::new();
-        for a in arms {
-            if let Predicate::NumRange {
-                field: FieldSel::Attr(name),
-                ty,
-                min,
-                max,
-            } = a
-                && let Some(entry) = self.field_dir.column(name, *ty)
-            {
-                out.push(NumRangeArm {
-                    column_id: entry.column_id,
-                    ty: *ty,
-                    min_bits: *min,
-                    max_bits: *max,
-                });
-            }
-        }
-        out
+        self.field_dir.numeric_range_arms(arms)
     }
 
     /// Whether `name` has any dynamic column of a type other than `Str` in this

--- a/crates/ravel-query/src/log_fetcher.rs
+++ b/crates/ravel-query/src/log_fetcher.rs
@@ -2630,11 +2630,14 @@ impl BlockRangeFetcher {
         // FIELD_DIR so `candidate_blocks` can drop blocks the numeric bounds
         // prove hold no match (#761). Without this the candidate set was ts-only
         // and every block survived, so a month-wide selective query crossed the
-        // coverage threshold and read the whole object. FIELD_DIR is a front
-        // section the ranged read fetches anyway (the loop below), so placing it
-        // here only reorders that GET; it is skipped entirely when the query
-        // carries no NumRange arm (a predicate-free or text-only query keeps the
-        // pre-#761 ts-only candidate set). Bloom/POSTINGS arms are not resolved
+        // coverage threshold and read the whole object. On the ranged branch
+        // FIELD_DIR is a front section the section loop below fetches anyway,
+        // so placing it here only reorders that GET; on the coverage-crossover
+        // branch it is one extra small GET in front of the whole-object read,
+        // unavoidable because the arms decide the candidate set that decides
+        // coverage. It is skipped entirely when the query carries no NumRange
+        // arm (a predicate-free or text-only query keeps the pre-#761 ts-only
+        // candidate set). Bloom/POSTINGS arms are not resolved
         // here: they narrow further at decode over the fetched buffer, which is
         // sound because that narrowing only ever skips a fetched block.
         let numeric: Vec<NumRangeArm> = if prune

--- a/crates/ravel-query/src/log_fetcher.rs
+++ b/crates/ravel-query/src/log_fetcher.rs
@@ -47,8 +47,9 @@ use bytes::Bytes;
 use ravel_cache::{CacheKey, SingleFlightError, Source};
 use ravel_catalog::SegmentRef;
 use ravel_logseg::block::NumStat;
+use ravel_logseg::field_dir::FieldDir;
 use ravel_logseg::footer::{self, SectionDesc, kind};
-use ravel_logseg::skip_index::{Level0Entry, SkipIndex, merge_stats};
+use ravel_logseg::skip_index::{Level0Entry, NumRangeArm, SkipIndex, merge_stats};
 use ravel_logseg::stream_dir::StreamDir;
 use ravel_logseg::{
     AttrValue, BlockScan, ColumnSelection, ColumnarBlockView, LogRecord, LogSegError, LogStreamId,
@@ -1022,6 +1023,59 @@ impl LogSegmentFetcher {
             return Ok(Some((n, stats, Some(footer))));
         }
 
+        // Skip-index-only survivor count (#761): when every block-level predicate
+        // the query carries is decidable from the skip index alone -- ts bounds
+        // and prune-only NumRange arms, no text/content arm, no attribute-equality
+        // POSTINGS prune, no stream filter -- the surviving-block count is exactly
+        // `candidate_blocks` over those arms, with no BLOCKS byte fetched and no
+        // block decoded. The reader's full prune (skip, then POSTINGS, then bloom)
+        // reduces to the skip step for such a query, so this count equals the
+        // survivor list a subset open will stripe over, and the footer read here
+        // carries forward so those opens skip their own probe (#693 part 3).
+        //
+        // The relevance check is the one the fallback's `tenant_bytes` runs: it
+        // is what turns an out-of-window segment into the `None` the caller
+        // drops, and unlike the fast path's containment test this branch's
+        // guard does not imply it.
+        if seg_ref.object_size > self.block_range_threshold
+            && seg_ref.min_event_ts_ns <= seg_ref.max_event_ts_ns
+            && Self::ts_range_relevant(seg_ref, query.ts_min_ns, query.ts_max_ns)
+            && Self::plan_skip_decidable(query)
+        {
+            let (footer, skip, field_dir, _stats) = self
+                .block_range
+                .fetch_plan_sections(seg_ref, tenant_hash, accounting)
+                .await?;
+            let refs: Vec<&Predicate> = query.prune.iter().collect();
+            let numeric = field_dir.numeric_range_arms(&refs);
+            let survivors = skip
+                .candidate_blocks(query.ts_min_ns, query.ts_max_ns, None, &numeric)
+                .len();
+            let blocks = skip.l0.len() as u32;
+            let plan_stats = ScanStats {
+                blocks_total: blocks,
+                blocks_after_skip: survivors as u32,
+                blocks_after_postings: survivors as u32,
+                blocks_after_bloom: survivors as u32,
+                blocks_scanned: 0,
+                pages_decoded: 0,
+                pages_skipped: 0,
+                page_bytes_fetched: 0,
+                page_bytes_decoded: 0,
+                bloom_degraded: false,
+                postings_degraded: false,
+            };
+            return Ok(Some((survivors, plan_stats, Some(footer))));
+        }
+
+        // Fallback: a predicate the skip index cannot decide (a `has_word`/text
+        // content arm with only a per-block bloom, an attribute-equality POSTINGS
+        // prune, a stream filter), or a below-threshold object. Read as before --
+        // the survivor count then needs the reader's full prune over the fetched
+        // buffer -- and hand no footer forward. This whole-object plan read is the
+        // amplification #761 could not remove for these shapes; the caller counts
+        // it (a `None` footer on a relevant segment) as a `plan_full_reads` so a
+        // report can see which queries still pay it.
         let Some(bytes) = self
             .tenant_bytes(seg_ref, tenant_hash, query, accounting)
             .await?
@@ -1031,12 +1085,51 @@ impl LogSegmentFetcher {
         let key = &seg_ref.data_object_key;
         let span = decode_span();
         let scan = span.in_scope(|| self.open_scan(key, &bytes, query, &ColumnSelection::all()))?;
-        // The slow branch decodes nothing that carries a reusable footer to the
-        // per-partition subset opens (#693 part 3, deliverable 2): a predicated
-        // or partially-overlapping query does not run `plan_segment_fast`, so
-        // there is no plan-phase footer to hand forward and each subset open
-        // establishes its own etag pin with its own suffix probe.
         Ok(Some((scan.remaining_blocks(), scan.stats(), None)))
+    }
+
+    /// Whether [`plan_segment`](Self::plan_segment)'s survivor count can be read
+    /// from the skip index alone, without fetching or decoding any block (#761).
+    ///
+    /// True when the query carries no block-level predicate the skip index cannot
+    /// evaluate: no content/text arm (those prune only via per-block bloom at
+    /// decode), no stream-attribute filter, and every prune-only arm a
+    /// [`Predicate::NumRange`] (an attribute-equality `Equals` prunes only via
+    /// POSTINGS). For such a query the reader's full prune -- skip, then POSTINGS,
+    /// then bloom -- collapses to its skip step, so `candidate_blocks` over the
+    /// resolved NumRange arms is the exact survivor list the scan will stripe,
+    /// and the count is safe to compute from SKIP_IDX + FIELD_DIR alone. Pending
+    /// erasure is ignored on purpose: it filters rows within surviving blocks
+    /// after decode, so it never changes which blocks survive or how many.
+    ///
+    /// At least one arm is required, so this stays the SELECTIVE path #761 is
+    /// about. A query with no prune arm at all would also be skip-decidable, but
+    /// planning it this way is a pessimization rather than a saving: its
+    /// plan-phase read is already only the ts-candidate blocks, and it warms
+    /// exactly the extents the per-partition subset opens then stripe, so
+    /// removing it would replace one shared read with N concurrent per-partition
+    /// ones for the same bytes. Such a query keeps the pre-#761 plan read (the
+    /// fully-contained case having taken `plan_segment_fast` above).
+    ///
+    /// Destructures `LogQuery` by name for the reason
+    /// [`LogQuery::is_block_predicate_free`] does: a false positive here would
+    /// publish a survivor count the scan does not stripe, so a future field must
+    /// be a build break rather than a silent gap.
+    fn plan_skip_decidable(query: &LogQuery) -> bool {
+        let LogQuery {
+            ts_min_ns: _,
+            ts_max_ns: _,
+            stream_attrs,
+            content,
+            prune,
+            erasure: _,
+        } = query;
+        content.is_empty()
+            && stream_attrs.is_empty()
+            && !prune.is_empty()
+            && prune
+                .iter()
+                .all(|p| matches!(p, Predicate::NumRange { .. }))
     }
 
     /// The predicate-free plan fast path (#693): read only the footer via the
@@ -1322,6 +1415,7 @@ impl LogSegmentFetcher {
                         tenant_hash,
                         query.ts_min_ns,
                         query.ts_max_ns,
+                        &query.prune,
                         footer,
                         accounting,
                     )
@@ -1643,6 +1737,11 @@ pub const DEFAULT_LOG_MAX_CONCURRENT_GETS: usize = 16;
 /// internal cap (`ravel_logseg::reader::MAX_BLOCKS`, not exported). A section
 /// claiming more blocks is treated as corrupt rather than allocated.
 const MAX_BLOCKS: u64 = 1 << 24;
+
+/// Upper bound on decoded FIELD_DIR entry count, mirroring the reader's own
+/// internal cap (`ravel_logseg::reader::MAX_FIELDS`, not exported). A section
+/// claiming more entries is treated as corrupt rather than allocated.
+const MAX_FIELDS: u64 = 1 << 20;
 
 /// Per-object counters from one [`BlockRangeFetcher::fetch_object`] call, for
 /// tests (the GET-count assertion of ADR-0107) and callers that want the
@@ -2144,18 +2243,52 @@ impl BlockRangeFetcher {
             .section(kind::SKIP_IDX)
             .ok_or_else(|| corrupt(key, LogSegError::Corrupted("missing SKIP_IDX".into())))?;
 
-        let stored = match resident_slice(&resident, skip_desc.offset, skip_desc.len) {
+        let raw = self
+            .plan_section_raw(
+                seg_ref,
+                tenant_hash,
+                skip_desc,
+                &resident,
+                &pin,
+                accounting,
+                &mut stats,
+            )
+            .await?;
+        let skip = SkipIndex::decode(&raw, MAX_BLOCKS).map_err(|source| corrupt(key, source))?;
+        Ok((skip, stats))
+    }
+
+    /// Decode one whole-compressed directory section from a region the probe
+    /// already left resident, or a cache-routed range GET when it did not.
+    /// Section-kind agnostic, so [`fetch_skip_index`](Self::fetch_skip_index)
+    /// and [`fetch_plan_sections`](Self::fetch_plan_sections) pull SKIP_IDX and
+    /// FIELD_DIR through the same path without an object-sized buffer, unlike
+    /// [`place_section`](Self::place_section), which needs an
+    /// [`ObjectAssembler`] to place into.
+    #[allow(clippy::too_many_arguments)]
+    async fn plan_section_raw(
+        &self,
+        seg_ref: &SegmentRef,
+        tenant_hash: TenantHash,
+        desc: &SectionDesc,
+        resident: &[(u64, Bytes)],
+        pin: &EtagPin,
+        accounting: &QueryAccounting,
+        stats: &mut BlockRangeStats,
+    ) -> Result<Vec<u8>, LogFetchError> {
+        let key = seg_ref.data_object_key.as_str();
+        let stored = match resident_slice(resident, desc.offset, desc.len) {
             Some(bytes) => bytes,
             None => {
-                let (start, end) = (skip_desc.offset, skip_desc.offset + skip_desc.len);
+                let (start, end) = (desc.offset, desc.offset + desc.len);
                 let (bytes, live) = self
                     .cached_extent(
                         seg_ref,
                         tenant_hash,
-                        skip_desc.offset,
-                        skip_desc.len,
+                        desc.offset,
+                        desc.len,
                         GetRange::Range(start, end),
-                        &pin,
+                        pin,
                         accounting,
                     )
                     .await?;
@@ -2165,11 +2298,72 @@ impl BlockRangeFetcher {
                 bytes
             }
         };
+        decode_section(&stored, desc, &self.cfg).map_err(|source| corrupt(key, source))
+    }
 
-        let raw =
-            decode_section(&stored, skip_desc, &self.cfg).map_err(|source| corrupt(key, source))?;
-        let skip = SkipIndex::decode(&raw, MAX_BLOCKS).map_err(|source| corrupt(key, source))?;
-        Ok((skip, stats))
+    /// Read the footer, SKIP_IDX, and FIELD_DIR for one segment and decode all
+    /// three, fetching no BLOCKS byte (#761): the plan phase's counterpart of
+    /// [`fetch_skip_index`](Self::fetch_skip_index) for a query carrying
+    /// prune-only NumRange arms. The footer is returned so the caller can carry
+    /// it to each per-partition subset open (they then skip re-probing, #693 part
+    /// 3), the SKIP_IDX drives the survivor count, and the FIELD_DIR resolves the
+    /// arms to this object's column ids so that count is computed with the same
+    /// pruning the scan will apply.
+    ///
+    /// One ADR-0107 suffix probe plus, where the probe did not already cover
+    /// them, one range GET per section: SKIP_IDX (near the tail, usually covered
+    /// by a production-sized probe) and FIELD_DIR (a front section, generally its
+    /// own GET). No whole-object crossover, so the caller must guarantee
+    /// `object_size > block_range_threshold` for the reason
+    /// [`fetch_footer`](Self::fetch_footer) documents.
+    pub async fn fetch_plan_sections(
+        &self,
+        seg_ref: &SegmentRef,
+        tenant_hash: TenantHash,
+        accounting: &QueryAccounting,
+    ) -> Result<(footer::LogFooter, SkipIndex, FieldDir, BlockRangeStats), LogFetchError> {
+        let key = seg_ref.data_object_key.as_str();
+        let mut stats = BlockRangeStats::default();
+        let pin = EtagPin::default();
+        let (footer, resident) = self
+            .probe_footer(seg_ref, tenant_hash, &pin, accounting, &mut stats)
+            .await?;
+
+        let skip_desc = *footer
+            .section(kind::SKIP_IDX)
+            .ok_or_else(|| corrupt(key, LogSegError::Corrupted("missing SKIP_IDX".into())))?;
+        let skip_raw = self
+            .plan_section_raw(
+                seg_ref,
+                tenant_hash,
+                &skip_desc,
+                &resident,
+                &pin,
+                accounting,
+                &mut stats,
+            )
+            .await?;
+        let skip =
+            SkipIndex::decode(&skip_raw, MAX_BLOCKS).map_err(|source| corrupt(key, source))?;
+
+        let field_desc = *footer
+            .section(kind::FIELD_DIR)
+            .ok_or_else(|| corrupt(key, LogSegError::Corrupted("missing FIELD_DIR".into())))?;
+        let field_raw = self
+            .plan_section_raw(
+                seg_ref,
+                tenant_hash,
+                &field_desc,
+                &resident,
+                &pin,
+                accounting,
+                &mut stats,
+            )
+            .await?;
+        let field_dir =
+            FieldDir::decode(&field_raw, MAX_FIELDS).map_err(|source| corrupt(key, source))?;
+
+        Ok((footer, skip, field_dir, stats))
     }
 
     /// Fetch one segment's object as an assembled, decode-ready buffer, reading
@@ -2189,8 +2383,16 @@ impl BlockRangeFetcher {
         ts_max_ns: i64,
         accounting: &QueryAccounting,
     ) -> Result<(Bytes, BlockRangeStats), LogFetchError> {
-        self.fetch_object_with_footer(seg_ref, tenant_hash, ts_min_ns, ts_max_ns, None, accounting)
-            .await
+        self.fetch_object_with_footer(
+            seg_ref,
+            tenant_hash,
+            ts_min_ns,
+            ts_max_ns,
+            &[],
+            None,
+            accounting,
+        )
+        .await
     }
 
     /// [`fetch_object`](Self::fetch_object), optionally reusing a
@@ -2210,6 +2412,13 @@ impl BlockRangeFetcher {
     /// different object fails its stored `crc32c`, a hard [`LogFetchError::Corrupt`]).
     /// Either way the fetch errors rather than assembling bytes from two object
     /// states. `None` keeps the probe-first behavior unchanged.
+    ///
+    /// `prune` carries the query's prune-only predicates (#761). Its NumRange
+    /// arms are resolved against this object's FIELD_DIR and applied to the
+    /// candidate-block selection, so a selective query reads only the surviving
+    /// blocks instead of tripping the coverage crossover into a whole-object GET.
+    /// See [`resolve_extents`](Self::resolve_extents) for why this stays
+    /// byte-identical to the unpruned read.
     #[allow(clippy::too_many_arguments)]
     pub async fn fetch_object_with_footer(
         &self,
@@ -2217,6 +2426,7 @@ impl BlockRangeFetcher {
         tenant_hash: TenantHash,
         ts_min_ns: i64,
         ts_max_ns: i64,
+        prune: &[Predicate],
         plan_footer: Option<&footer::LogFooter>,
         accounting: &QueryAccounting,
     ) -> Result<(Bytes, BlockRangeStats), LogFetchError> {
@@ -2382,13 +2592,15 @@ impl BlockRangeFetcher {
             .section(kind::BLOCKS)
             .ok_or_else(|| corrupt(key, LogSegError::Corrupted("missing BLOCKS".into())))?;
 
-        // SKIP_IDX first and alone. The coverage crossover below can decide the
-        // whole object is cheaper than the candidate ranges, and every OTHER
-        // section it would have fetched first is then wasted: a wide-time-range
-        // query on a large object would pay probe + section GETs and THEN a
-        // whole-object GET, strictly worse than the plain whole-object path it
-        // falls back to. Resolving the candidate extents needs SKIP_IDX and
-        // nothing else, so only SKIP_IDX is fetched before the decision.
+        // SKIP_IDX first, and nothing the candidate set does not need. The
+        // coverage crossover below can decide the whole object is cheaper than
+        // the candidate ranges, and every OTHER section fetched first is then
+        // wasted: a wide-time-range query on a large object would pay probe +
+        // section GETs and THEN a whole-object GET, strictly worse than the
+        // plain whole-object path it falls back to. Resolving the candidate
+        // extents needs SKIP_IDX always and FIELD_DIR only when the query
+        // carries a NumRange arm to resolve (#761), so those are the only two
+        // sections fetched before the decision, and the second only on demand.
         self.place_section(
             seg_ref,
             tenant_hash,
@@ -2414,7 +2626,46 @@ impl BlockRangeFetcher {
         let skip =
             SkipIndex::decode(&skip_raw, MAX_BLOCKS).map_err(|source| corrupt(key, source))?;
 
-        let extents = self.resolve_extents(key, &skip, blocks_desc.offset, ts_min_ns, ts_max_ns)?;
+        // Resolve the query's prune-only NumRange arms against THIS object's
+        // FIELD_DIR so `candidate_blocks` can drop blocks the numeric bounds
+        // prove hold no match (#761). Without this the candidate set was ts-only
+        // and every block survived, so a month-wide selective query crossed the
+        // coverage threshold and read the whole object. FIELD_DIR is a front
+        // section the ranged read fetches anyway (the loop below), so placing it
+        // here only reorders that GET; it is skipped entirely when the query
+        // carries no NumRange arm (a predicate-free or text-only query keeps the
+        // pre-#761 ts-only candidate set). Bloom/POSTINGS arms are not resolved
+        // here: they narrow further at decode over the fetched buffer, which is
+        // sound because that narrowing only ever skips a fetched block.
+        let numeric: Vec<NumRangeArm> = if prune
+            .iter()
+            .any(|p| matches!(p, Predicate::NumRange { .. }))
+        {
+            let field_dir = self
+                .place_and_decode_field_dir(
+                    seg_ref,
+                    tenant_hash,
+                    &footer,
+                    &pin,
+                    &mut asm,
+                    accounting,
+                    &mut stats,
+                )
+                .await?;
+            let refs: Vec<&Predicate> = prune.iter().collect();
+            field_dir.numeric_range_arms(&refs)
+        } else {
+            Vec::new()
+        };
+
+        let extents = self.resolve_extents(
+            key,
+            &skip,
+            blocks_desc.offset,
+            ts_min_ns,
+            ts_max_ns,
+            &numeric,
+        )?;
         stats.candidate_blocks = extents.len() as u64;
 
         // Coverage-based post-pruning crossover (ADR-0107 decision 1): when the
@@ -2458,11 +2709,12 @@ impl BlockRangeFetcher {
         // are not themselves listed sections. When the footer was carried the
         // probe was skipped, so on this (non-coverage) branch that tail is still
         // unplaced; place it now as one range over `[last_section_end,
-        // object_size)`. In practice a carried footer implies an all-candidate
-        // (predicate-free, fully-contained) query, whose coverage always crosses
-        // over above, so this range is only reached when a caller forces the
-        // ranged path; it keeps that path fail-safe rather than assembling a
-        // buffer with a zeroed trailer.
+        // object_size)`. Before #761 a carried footer implied an all-candidate
+        // (predicate-free, fully-contained) query whose coverage always crossed
+        // over above, so this range was unreachable in practice. The skip-index
+        // plan branch now carries a footer for a SELECTIVE query too, which is
+        // exactly the query that stays below the crossover, so this is a live
+        // per-segment range GET on that path rather than a fail-safe.
         if plan_footer.is_some() {
             let tail_start = footer
                 .sections
@@ -2526,6 +2778,21 @@ impl BlockRangeFetcher {
     /// absolute byte extent and stored crc. The byte extent is always the block's
     /// full extent from its SKIP_IDX level-0 entry, never a sub-block slice
     /// (ADR-0107 decision 1).
+    ///
+    /// `numeric` are the query's prune-only [`NumRangeArm`]s, already resolved to
+    /// this object's own column ids against its FIELD_DIR
+    /// ([`FieldDir::numeric_range_arms`]). They narrow the candidate set to the
+    /// blocks whose recorded numeric bounds can still hold a matching row, exactly
+    /// as [`ravel_logseg::RlogReader::scan_blocks`] narrows it at decode with the
+    /// same arms and the same directory. This is why fetch-side pruning is
+    /// byte-identical to the unpruned read: the skip index's per-block bounds are
+    /// conservative (ADR-0013), so a block dropped here is one the decode-side
+    /// prune would have dropped anyway, never a block a surviving row lives in.
+    /// Bloom/POSTINGS pruning is a strict further narrowing the reader still runs
+    /// over the fetched buffer, so it can only skip blocks this already fetched,
+    /// never demand one it did not. With `numeric` empty (a predicate the skip
+    /// index cannot decide, or none) every ts-candidate block is kept, the
+    /// pre-#761 behavior.
     fn resolve_extents(
         &self,
         key: &str,
@@ -2533,8 +2800,9 @@ impl BlockRangeFetcher {
         blocks_offset: u64,
         ts_min_ns: i64,
         ts_max_ns: i64,
+        numeric: &[NumRangeArm],
     ) -> Result<Vec<BlockExtent>, LogFetchError> {
-        let candidates = skip.candidate_blocks(ts_min_ns, ts_max_ns, None, &[]);
+        let candidates = skip.candidate_blocks(ts_min_ns, ts_max_ns, None, numeric);
         let mut out = Vec::with_capacity(candidates.len());
         for i in candidates {
             let entry = skip.l0.get(i).ok_or_else(|| {
@@ -2553,6 +2821,38 @@ impl BlockRangeFetcher {
             });
         }
         Ok(out)
+    }
+
+    /// Place the FIELD_DIR section into `asm` (via [`place_section`](Self::
+    /// place_section), so it single-flights and reuses an already-resident
+    /// region) and decode it, so the caller can resolve a query's prune-only
+    /// NumRange arms to this object's own column ids before the candidate set is
+    /// chosen. FIELD_DIR is compressed as a whole section (docs/log-segment-\
+    /// format.md), the same shape SKIP_IDX is decoded with just above.
+    #[allow(clippy::too_many_arguments)]
+    async fn place_and_decode_field_dir(
+        &self,
+        seg_ref: &SegmentRef,
+        tenant_hash: TenantHash,
+        footer: &footer::LogFooter,
+        pin: &EtagPin,
+        asm: &mut ObjectAssembler,
+        accounting: &QueryAccounting,
+        stats: &mut BlockRangeStats,
+    ) -> Result<FieldDir, LogFetchError> {
+        let key = seg_ref.data_object_key.as_str();
+        let desc = footer
+            .section(kind::FIELD_DIR)
+            .ok_or_else(|| corrupt(key, LogSegError::Corrupted("missing FIELD_DIR".into())))?;
+        self.place_section(seg_ref, tenant_hash, desc, pin, asm, accounting, stats)
+            .await?;
+        let start = usize::try_from(desc.offset).map_err(|_| corrupt_range(key))?;
+        let end = start
+            .checked_add(usize::try_from(desc.len).map_err(|_| corrupt_range(key))?)
+            .ok_or_else(|| corrupt_range(key))?;
+        let stored = asm.buf.get(start..end).ok_or_else(|| corrupt_range(key))?;
+        let raw = decode_section(stored, desc, &self.cfg).map_err(|source| corrupt(key, source))?;
+        FieldDir::decode(&raw, MAX_FIELDS).map_err(|source| corrupt(key, source))
     }
 
     /// Place one directory section into `asm`, fetching it through the read

--- a/crates/ravel-query/src/log_fetcher.rs
+++ b/crates/ravel-query/src/log_fetcher.rs
@@ -29,16 +29,24 @@
 //! Two read shapes, split by object size (ADR-0107). The tenant-aware funnels
 //! fetch an object at or below [`LogSegmentFetcher::with_block_range_threshold`]
 //! (512 KiB by default) with a single [`GetRange::Full`], which is every small
-//! RLOG object and every fixture here. Above it they read only the blocks
+//! RLOG object and every fixture here. Above it they read only the parts
 //! skip-index pruning proved relevant, through [`BlockRangeFetcher`]: a suffix
-//! probe that pins the etag, the directory sections, and coalesced
-//! candidate-block ranges, assembled into an object-sized buffer the unchanged
-//! reader decodes from. Every GET of either shape is routed through ADR-0046's
+//! probe that pins the etag, the directory sections, and coalesced ranges over
+//! the relevant data, assembled into an object-sized buffer the unchanged
+//! reader decodes from. What a "relevant part" is depends on the object's
+//! version. A version-3 object's block is one contiguous byte range, so the
+//! ranges are candidate blocks and the projection is a decode choice only. A
+//! version-4 object stores each row group's pages column-major and lists them
+//! in PAGE_DIR (ADR-0699), so a block is not a byte range at all: the ranges
+//! are the surviving blocks' pages inside each projected column's chunk, and
+//! the [`ColumnSelection`] the scan passes to decode is the fetch selection too
+//! (decision 5). Every GET of either shape is routed through ADR-0046's
 //! read cache when one is wired, keyed by the extent it fetched, so concurrent
 //! callers for the same extent collapse onto one request. The untenanted
 //! [`LogSegmentFetcher::fetch`]/[`LogSegmentFetcher::fetch_accounted`] entry
 //! points have no cache key and always read the whole object in one GET.
 
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use crate::erasure::ErasurePredicate;
@@ -49,6 +57,7 @@ use ravel_catalog::SegmentRef;
 use ravel_logseg::block::NumStat;
 use ravel_logseg::field_dir::FieldDir;
 use ravel_logseg::footer::{self, SectionDesc, kind};
+use ravel_logseg::page_dir::PageDir;
 use ravel_logseg::skip_index::{Level0Entry, NumRangeArm, SkipIndex, merge_stats};
 use ravel_logseg::stream_dir::StreamDir;
 use ravel_logseg::{
@@ -841,8 +850,12 @@ impl LogSegmentFetcher {
         query: &LogQuery,
         accounting: &QueryAccounting,
     ) -> Result<Option<LogFetchOutput>, LogFetchError> {
+        // This funnel's decode (`scan_bytes`) reads every column, so the fetch
+        // selection is the same: on a version-4 object it brings every column
+        // chunk of every surviving block (ADR-0699 decision 5).
+        let all = ColumnSelection::all();
         let Some(bytes) = self
-            .tenant_bytes(seg_ref, tenant_hash, query, accounting)
+            .tenant_bytes(seg_ref, tenant_hash, query, &all, accounting)
             .await?
         else {
             return Ok(None);
@@ -883,7 +896,7 @@ impl LogSegmentFetcher {
         accounting: &QueryAccounting,
     ) -> Result<Option<LogSegmentScan>, LogFetchError> {
         let Some(bytes) = self
-            .tenant_bytes(seg_ref, tenant_hash, query, accounting)
+            .tenant_bytes(seg_ref, tenant_hash, query, columns, accounting)
             .await?
         else {
             return Ok(None);
@@ -1076,15 +1089,16 @@ impl LogSegmentFetcher {
         // amplification #761 could not remove for these shapes; the caller counts
         // it (a `None` footer on a relevant segment) as a `plan_full_reads` so a
         // report can see which queries still pay it.
+        let all = ColumnSelection::all();
         let Some(bytes) = self
-            .tenant_bytes(seg_ref, tenant_hash, query, accounting)
+            .tenant_bytes(seg_ref, tenant_hash, query, &all, accounting)
             .await?
         else {
             return Ok(None);
         };
         let key = &seg_ref.data_object_key;
         let span = decode_span();
-        let scan = span.in_scope(|| self.open_scan(key, &bytes, query, &ColumnSelection::all()))?;
+        let scan = span.in_scope(|| self.open_scan(key, &bytes, query, &all))?;
         Ok(Some((scan.remaining_blocks(), scan.stats(), None)))
     }
 
@@ -1341,7 +1355,7 @@ impl LogSegmentFetcher {
         accounting: &QueryAccounting,
     ) -> Result<Option<LogSegmentScan>, LogFetchError> {
         let Some(bytes) = self
-            .tenant_bytes_with_footer(seg_ref, tenant_hash, query, footer, accounting)
+            .tenant_bytes_with_footer(seg_ref, tenant_hash, query, columns, footer, accounting)
             .await?
         else {
             return Ok(None);
@@ -1370,9 +1384,10 @@ impl LogSegmentFetcher {
         seg_ref: &SegmentRef,
         tenant_hash: TenantHash,
         query: &LogQuery,
+        columns: &ColumnSelection,
         accounting: &QueryAccounting,
     ) -> Result<Option<Bytes>, LogFetchError> {
-        self.tenant_bytes_with_footer(seg_ref, tenant_hash, query, None, accounting)
+        self.tenant_bytes_with_footer(seg_ref, tenant_hash, query, columns, None, accounting)
             .await
     }
 
@@ -1383,11 +1398,22 @@ impl LogSegmentFetcher {
     /// etag on the first section/block GET instead. `None` is the unchanged
     /// probe-first behavior. Below the threshold the whole-object read never
     /// probes anyway, so the footer is irrelevant there.
+    ///
+    /// `columns` is the same [`ColumnSelection`] the caller will hand the
+    /// decode. On a version-4 object it is the FETCH selection too (ADR-0699
+    /// decision 5): the block-range read brings one coalesced range per
+    /// surviving `(row group, projected column)` rather than every column of
+    /// every surviving block. A caller that decodes with a wider selection than
+    /// it fetched with would address pages this never brought, which is a typed
+    /// `Corrupted` error rather than wrong data, so the two must be the same
+    /// value.
+    #[allow(clippy::too_many_arguments)]
     async fn tenant_bytes_with_footer(
         &self,
         seg_ref: &SegmentRef,
         tenant_hash: TenantHash,
         query: &LogQuery,
+        columns: &ColumnSelection,
         footer: Option<&footer::LogFooter>,
         accounting: &QueryAccounting,
     ) -> Result<Option<Bytes>, LogFetchError> {
@@ -1416,6 +1442,7 @@ impl LogSegmentFetcher {
                         query.ts_min_ns,
                         query.ts_max_ns,
                         &query.prune,
+                        columns,
                         footer,
                         accounting,
                     )
@@ -1701,11 +1728,28 @@ impl LogSegmentFetcher {
 }
 
 /// Default suffix length of the etag-establishing probe GET (ADR-0107 decision
-/// 1). Mirrors `crate::fetcher::DEFAULT_SUFFIX_LEN`. The RLOG tail metadata
-/// (SKIP_IDX, BLOOM, POSTINGS) and the footer sit after the (large) BLOCKS
-/// section, so a suffix of this size normally covers the whole tail in one GET
-/// and no extra metadata GET is needed for them.
-pub const DEFAULT_LOG_SUFFIX_LEN: u64 = 64 * 1024;
+/// 1, ADR-0699 decision 5). The RLOG tail metadata (SKIP_IDX, PAGE_DIR, BLOOM,
+/// POSTINGS) and the footer sit after the (large) BLOCKS section, so a suffix
+/// of this size covers the whole tail in one GET and no extra metadata GET is
+/// needed for them.
+///
+/// 256 KiB rather than the 64 KiB this started at (issue #766). The plan phase
+/// needs SKIP_IDX, and under version 4 the fetch phase needs PAGE_DIR as well;
+/// both sit *before* BLOOM in the object, so a suffix probe reaches them only
+/// by spanning BLOOM too. On the reference ClickBench tenant BLOOM averages
+/// 86 KB, so the 64 KiB probe missed SKIP_IDX on 68.8% of above-threshold
+/// objects and cost 4,415 extra GETs per predicated statement. The
+/// `probe_covers_the_plan_sections_on_a_wide_row_group_object` test measures
+/// the tail on a 32-block-group, 105-column object and pins that this value
+/// covers it.
+///
+/// This is a request-count choice with a byte cost: the probe is a fixed
+/// per-object read that a narrow projection does not shrink, so on a small
+/// object it can dominate the column chunks themselves. It is cache-routed and
+/// shared by every partition and by the plan and scan phases of one statement,
+/// which is what keeps that cost to once per object per query rather than once
+/// per read. `BlockRangeFetcher::with_suffix_len` overrides it.
+pub const DEFAULT_LOG_SUFFIX_LEN: u64 = 256 * 1024;
 
 /// Default maximum gap between two wanted block extents that still get coalesced
 /// into a single GET. Same 64 KiB start as `crate::fetcher::DEFAULT_COALESCE_GAP`
@@ -1769,6 +1813,20 @@ pub struct BlockRangeStats {
     /// Set when a crossover (size-threshold pre-probe, or coverage-based
     /// post-pruning) took the whole-object path instead of range fetches.
     pub whole_object: bool,
+    /// Tail sections this read had to locate pages or blocks through that the
+    /// suffix probe's WINDOW did not cover, so a report can show the residual
+    /// miss rate the probe length leaves (issue #766). SKIP_IDX always counts;
+    /// PAGE_DIR counts on a version-4 object. FIELD_DIR and STREAM_DIR never
+    /// do: they sit at the object's front, where no suffix probe can reach them
+    /// at any length, so counting them would put a floor under the metric and
+    /// hide the quantity it exists to expose.
+    ///
+    /// Measured against the probe window, not against what the read cache
+    /// happened to hold, so it is a property of `suffix_len` and the object's
+    /// shape rather than of cache residency. A miss costs one extra GET, not
+    /// one per section: the missed tail sections are adjacent in the object and
+    /// are fetched as one coalesced range.
+    pub probe_misses: u64,
 }
 
 /// One candidate block's absolute byte extent in the object and its stored crc,
@@ -1783,6 +1841,25 @@ struct BlockExtent {
 }
 
 impl BlockExtent {
+    fn abs_end(&self) -> u64 {
+        self.abs_start.saturating_add(self.len)
+    }
+}
+
+/// One absolute byte extent of the object, with no checksum attached.
+///
+/// Version 4's fetch unit is a run of pages inside a column chunk (ADR-0699
+/// decision 5), which carries no checksum of its own: the per-page `crc32c`
+/// values live in PAGE_DIR and are verified at decode, one page at a time. So
+/// the version-4 path ranges over these rather than over [`BlockExtent`], whose
+/// `crc32c` a version-3 read verifies before the bytes are placed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct ByteExtent {
+    abs_start: u64,
+    len: u64,
+}
+
+impl ByteExtent {
     fn abs_end(&self) -> u64 {
         self.abs_start.saturating_add(self.len)
     }
@@ -2235,19 +2312,35 @@ impl BlockRangeFetcher {
         let key = seg_ref.data_object_key.as_str();
         let mut stats = BlockRangeStats::default();
         let pin = EtagPin::default();
-        let (footer, resident) = self
+        let (footer, mut resident) = self
             .probe_footer(seg_ref, tenant_hash, &pin, accounting, &mut stats)
             .await?;
 
-        let skip_desc = footer
+        let skip_desc = *footer
             .section(kind::SKIP_IDX)
             .ok_or_else(|| corrupt(key, LogSegError::Corrupted("missing SKIP_IDX".into())))?;
 
+        // SKIP_IDX only: this entry point's caller
+        // (`plan_segment_block_stats`) reads the index's own per-block figures
+        // and no page, so warming PAGE_DIR here would move bytes nothing goes on
+        // to use. `fetch_plan_sections`, whose caller IS followed by a scan,
+        // brings the pair.
+        self.ensure_tail_plan_sections(
+            seg_ref,
+            tenant_hash,
+            &footer,
+            &[kind::SKIP_IDX],
+            &mut resident,
+            &pin,
+            accounting,
+            &mut stats,
+        )
+        .await?;
         let raw = self
             .plan_section_raw(
                 seg_ref,
                 tenant_hash,
-                skip_desc,
+                &skip_desc,
                 &resident,
                 &pin,
                 accounting,
@@ -2256,6 +2349,65 @@ impl BlockRangeFetcher {
             .await?;
         let skip = SkipIndex::decode(&raw, MAX_BLOCKS).map_err(|source| corrupt(key, source))?;
         Ok((skip, stats))
+    }
+
+    /// Bring the named TAIL sections into `resident`. Sections the probe already
+    /// covered cost nothing; the rest are fetched as coalesced runs, so a probe
+    /// too short for two adjacent sections (SKIP_IDX and PAGE_DIR always are --
+    /// the writer emits PAGE_DIR immediately after SKIP_IDX) costs one extra GET
+    /// rather than two (issue #766). Every named section the probe WINDOW did
+    /// not cover is counted in [`BlockRangeStats::probe_misses`], whether or not
+    /// a GET was needed for it.
+    ///
+    /// A kind the footer does not carry is skipped, which is how a version-3
+    /// object passes PAGE_DIR here harmlessly.
+    #[allow(clippy::too_many_arguments)]
+    async fn ensure_tail_plan_sections(
+        &self,
+        seg_ref: &SegmentRef,
+        tenant_hash: TenantHash,
+        footer: &footer::LogFooter,
+        kinds: &[u32],
+        resident: &mut Vec<(u64, Bytes)>,
+        pin: &EtagPin,
+        accounting: &QueryAccounting,
+        stats: &mut BlockRangeStats,
+    ) -> Result<(), LogFetchError> {
+        let total_size = seg_ref.object_size;
+        let suffix = self.suffix_len.min(total_size);
+        let mut missing: Vec<ByteExtent> = Vec::new();
+        for &k in kinds {
+            let Some(desc) = footer.section(k) else {
+                continue;
+            };
+            if !probe_window_covers(desc, total_size, suffix) {
+                stats.probe_misses += 1;
+            }
+            if resident_slice(resident, desc.offset, desc.len).is_none() {
+                missing.push(ByteExtent {
+                    abs_start: desc.offset,
+                    len: desc.len,
+                });
+            }
+        }
+        for run in coalesce_byte_extents(&missing, self.coalesce_gap) {
+            let (bytes, live) = self
+                .cached_extent(
+                    seg_ref,
+                    tenant_hash,
+                    run.abs_start,
+                    run.len,
+                    GetRange::Range(run.abs_start, run.abs_end()),
+                    pin,
+                    accounting,
+                )
+                .await?;
+            if live {
+                stats.metadata_gets += 1;
+            }
+            resident.push((run.abs_start, bytes));
+        }
+        Ok(())
     }
 
     /// Decode one whole-compressed directory section from a region the probe
@@ -2325,13 +2477,30 @@ impl BlockRangeFetcher {
         let key = seg_ref.data_object_key.as_str();
         let mut stats = BlockRangeStats::default();
         let pin = EtagPin::default();
-        let (footer, resident) = self
+        let (footer, mut resident) = self
             .probe_footer(seg_ref, tenant_hash, &pin, accounting, &mut stats)
             .await?;
 
         let skip_desc = *footer
             .section(kind::SKIP_IDX)
             .ok_or_else(|| corrupt(key, LogSegError::Corrupted("missing SKIP_IDX".into())))?;
+        // SKIP_IDX and, on a version-4 object, PAGE_DIR: the pair is adjacent, so
+        // a probe too short for both costs one coalesced GET rather than two.
+        // PAGE_DIR is brought here even though the survivor count does not need
+        // it, because the scan this plan feeds locates its pages through it,
+        // fetches it under this same extent key, and would otherwise pay a
+        // second round trip for bytes the probe already had.
+        self.ensure_tail_plan_sections(
+            seg_ref,
+            tenant_hash,
+            &footer,
+            &[kind::SKIP_IDX, kind::PAGE_DIR],
+            &mut resident,
+            &pin,
+            accounting,
+            &mut stats,
+        )
+        .await?;
         let skip_raw = self
             .plan_section_raw(
                 seg_ref,
@@ -2389,6 +2558,36 @@ impl BlockRangeFetcher {
             ts_min_ns,
             ts_max_ns,
             &[],
+            &ColumnSelection::all(),
+            None,
+            accounting,
+        )
+        .await
+    }
+
+    /// [`fetch_object`](Self::fetch_object) with a column projection, which on
+    /// a version-4 object is a FETCH projection (ADR-0699 decision 5): the read
+    /// brings one coalesced range per surviving `(row group, projected column)`
+    /// instead of every column of every surviving block. On a version-3 object
+    /// `columns` changes nothing about what is fetched -- a block is one
+    /// contiguous range there and the projection is a decode choice only
+    /// (ADR-0087).
+    pub async fn fetch_object_projected(
+        &self,
+        seg_ref: &SegmentRef,
+        tenant_hash: TenantHash,
+        ts_min_ns: i64,
+        ts_max_ns: i64,
+        columns: &ColumnSelection,
+        accounting: &QueryAccounting,
+    ) -> Result<(Bytes, BlockRangeStats), LogFetchError> {
+        self.fetch_object_with_footer(
+            seg_ref,
+            tenant_hash,
+            ts_min_ns,
+            ts_max_ns,
+            &[],
+            columns,
             None,
             accounting,
         )
@@ -2419,6 +2618,11 @@ impl BlockRangeFetcher {
     /// blocks instead of tripping the coverage crossover into a whole-object GET.
     /// See [`resolve_extents`](Self::resolve_extents) for why this stays
     /// byte-identical to the unpruned read.
+    ///
+    /// `columns` is the query's [`ColumnSelection`]. On a version-4 object it
+    /// selects which column chunks are fetched as well as which are decoded
+    /// (ADR-0699 decision 5); on a version-3 object it is ignored by the fetch,
+    /// which reads whole blocks.
     #[allow(clippy::too_many_arguments)]
     pub async fn fetch_object_with_footer(
         &self,
@@ -2427,6 +2631,7 @@ impl BlockRangeFetcher {
         ts_min_ns: i64,
         ts_max_ns: i64,
         prune: &[Predicate],
+        columns: &ColumnSelection,
         plan_footer: Option<&footer::LogFooter>,
         accounting: &QueryAccounting,
     ) -> Result<(Bytes, BlockRangeStats), LogFetchError> {
@@ -2555,34 +2760,29 @@ impl BlockRangeFetcher {
         // `block_offset`/`block_len` describe a page span overlapping its
         // neighbours', with the block crc defined over its pages in column_id
         // order rather than over that span. The block-range protocol below
-        // assumes neither, so it reads a version-4 object whole: the same
-        // bytes the pre-ADR-0107 path moved, in one full-object GET on top of
-        // the suffix probe this guard runs after when no plan-carried footer
-        // was supplied (PAGE_DIR presence is only known from the footer). The
-        // probe is cache-routed, so concurrent partitions coalesce onto it.
-        //
-        // ADR-0699 decision 5 is what replaces this: PAGE_DIR turns each
-        // surviving `(row group, projected column)` into one coalesced range,
-        // which is strictly better than either path here. Until that lands, a
-        // version-4 object is fetched whole.
+        // assumes both, so a version-4 object takes decision 5's chunk path
+        // instead: PAGE_DIR turns each surviving `(row group, projected
+        // column)` into one coalesced range. Dispatched here, after the footer
+        // is resolved, because PAGE_DIR's presence is only known from the
+        // footer -- which covers both the probe path and the plan-carried
+        // footer path (#693 part 3).
         if footer.section(kind::PAGE_DIR).is_some() {
-            let (bytes, live) = self
-                .cached_extent(
+            return self
+                .fetch_object_v4(
                     seg_ref,
                     tenant_hash,
-                    0,
-                    total_size,
-                    GetRange::Full,
+                    ts_min_ns,
+                    ts_max_ns,
+                    prune,
+                    columns,
+                    &footer,
+                    plan_footer.is_none(),
+                    asm,
                     &pin,
                     accounting,
+                    stats,
                 )
-                .await?;
-            if live {
-                stats.block_range_gets = 1;
-                stats.block_bytes_fetched = bytes.len() as u64;
-            }
-            stats.whole_object = true;
-            return Ok((bytes, stats));
+                .await;
         }
 
         let skip_desc = footer
@@ -2775,6 +2975,384 @@ impl BlockRangeFetcher {
         )
         .await?;
         Ok((asm.into_bytes(), stats))
+    }
+
+    /// The version-4 read (ADR-0699 decision 5): one coalesced range per
+    /// surviving `(row group, projected column)`, instead of the version-3
+    /// protocol's one range per surviving block.
+    ///
+    /// The footer is already resolved -- by the suffix probe (`probed`), whose
+    /// bytes are already in `asm`, or carried from the plan phase -- so this
+    /// picks up at the directories. SKIP_IDX says which blocks survive, PAGE_DIR
+    /// says where their pages are, and the query's [`ColumnSelection`] resolved
+    /// against FIELD_DIR says which column chunks to read. The pages the
+    /// surviving blocks hold in the kept chunks become byte extents that the
+    /// same coalescing rule the version-3 path uses fuses into GETs: a pruned
+    /// block's pages are the gaps in those runs, read through when the gap is
+    /// under `coalesce_gap` and split around otherwise. When the selection keeps
+    /// every column and every block of a group survives, that group's pages are
+    /// one contiguous span and coalesce into exactly one range, which is why
+    /// there is no separate whole-group case here.
+    ///
+    /// # Checksums
+    ///
+    /// Nothing here verifies a block crc, and nothing can: under version 4 that
+    /// crc covers the block's pages in `column_id` order, which a projected read
+    /// does not hold (docs/log-segment-format.md, "BLOCKS"). Verification moves
+    /// to the decode instead, per page, against PAGE_DIR's own `crc32c`
+    /// (`decode_v4_block`), so every byte this fetch brings and the reader goes
+    /// on to interpret is still checksum-covered on its own access path
+    /// (ADR-0010 §4). A read whose selection keeps every one of a block's pages
+    /// verifies the block crc as well. That also makes the coalesced range a
+    /// legitimate cache unit even though it can span a pruned block's pages: a
+    /// corrupt cache hit fails at the first page crc it feeds the decode, the
+    /// same way a corrupt live fetch does, and the gap bytes are never
+    /// interpreted at all.
+    #[allow(clippy::too_many_arguments)]
+    async fn fetch_object_v4(
+        &self,
+        seg_ref: &SegmentRef,
+        tenant_hash: TenantHash,
+        ts_min_ns: i64,
+        ts_max_ns: i64,
+        prune: &[Predicate],
+        columns: &ColumnSelection,
+        footer: &footer::LogFooter,
+        probed: bool,
+        mut asm: ObjectAssembler,
+        pin: &EtagPin,
+        accounting: &QueryAccounting,
+        mut stats: BlockRangeStats,
+    ) -> Result<(Bytes, BlockRangeStats), LogFetchError> {
+        let key = seg_ref.data_object_key.as_str();
+        let total_size = seg_ref.object_size;
+        let blocks_desc = *footer
+            .section(kind::BLOCKS)
+            .ok_or_else(|| corrupt(key, LogSegError::Corrupted("missing BLOCKS".into())))?;
+        let skip_desc = *footer
+            .section(kind::SKIP_IDX)
+            .ok_or_else(|| corrupt(key, LogSegError::Corrupted("missing SKIP_IDX".into())))?;
+        let page_desc = *footer
+            .section(kind::PAGE_DIR)
+            .ok_or_else(|| corrupt(key, LogSegError::Corrupted("missing PAGE_DIR".into())))?;
+
+        // Issue #766's residual miss rate: the two tail sections this read has
+        // to locate pages through, counted against the probe WINDOW rather than
+        // against cache residency, so the figure reports what the probe length
+        // costs on this object's shape.
+        let suffix = self.suffix_len.min(total_size);
+        for desc in [&skip_desc, &page_desc] {
+            if !probe_window_covers(desc, total_size, suffix) {
+                stats.probe_misses += 1;
+            }
+        }
+
+        // A carried footer skipped the probe (#693 part 3), which on a
+        // version-4 object would leave every tail section -- SKIP_IDX, PAGE_DIR,
+        // BLOOM, POSTINGS -- and the footer/trailer bytes to be fetched one at a
+        // time. The plan phase that carried the footer already read that whole
+        // tail as its probe and admitted it under its extent key, so asking the
+        // cache for the same extent places all of it at once for no GET. Only
+        // done with a cache wired: without one every `cached_extent` call is a
+        // live GET, and re-reading the tail on the wire would move more bytes
+        // than the per-section reads it replaces.
+        if !probed && self.cache.is_some() && suffix > 0 {
+            let probe_start = total_size - suffix;
+            let (bytes, live) = self
+                .cached_extent(
+                    seg_ref,
+                    tenant_hash,
+                    probe_start,
+                    suffix,
+                    GetRange::Range(probe_start, total_size),
+                    pin,
+                    accounting,
+                )
+                .await?;
+            if live {
+                stats.probe_gets += 1;
+            }
+            asm.place(key, probe_start, &bytes)?;
+        }
+
+        // SKIP_IDX and PAGE_DIR first, and nothing the candidate set does not
+        // need: the coverage crossover below can still decide the whole object
+        // is cheaper, and every other section fetched before that decision would
+        // then be wasted (the same ordering rule the version-3 path follows).
+        // The two are adjacent in the object -- the writer emits PAGE_DIR
+        // immediately after SKIP_IDX -- so a probe that missed both costs one
+        // coalesced GET rather than two.
+        self.place_sections_coalesced(
+            seg_ref,
+            tenant_hash,
+            &[skip_desc, page_desc],
+            pin,
+            &mut asm,
+            accounting,
+            &mut stats,
+        )
+        .await?;
+        let skip_raw = self.placed_section_raw(key, &asm, &skip_desc)?;
+        let skip =
+            SkipIndex::decode(&skip_raw, MAX_BLOCKS).map_err(|source| corrupt(key, source))?;
+        let page_raw = self.placed_section_raw(key, &asm, &page_desc)?;
+        let page_dir = PageDir::decode(&page_raw).map_err(|source| corrupt(key, source))?;
+        page_dir
+            .validate_extents(blocks_desc.len)
+            .map_err(|source| corrupt(key, source))?;
+
+        // FIELD_DIR, when either channel needs it: the prune-only NumRange arms
+        // resolve to this object's column ids through it (#761), and so does the
+        // projection. An all-columns query with no numeric arm needs neither, and
+        // FIELD_DIR is a front section a suffix probe never covers, so skipping
+        // it there is a real saved GET.
+        let wants_numeric = prune
+            .iter()
+            .any(|p| matches!(p, Predicate::NumRange { .. }));
+        let (numeric, selected) = if wants_numeric || !columns.is_all() {
+            let field_dir = self
+                .place_and_decode_field_dir(
+                    seg_ref,
+                    tenant_hash,
+                    footer,
+                    pin,
+                    &mut asm,
+                    accounting,
+                    &mut stats,
+                )
+                .await?;
+            let numeric = if wants_numeric {
+                let refs: Vec<&Predicate> = prune.iter().collect();
+                field_dir.numeric_range_arms(&refs)
+            } else {
+                Vec::new()
+            };
+            // The same resolution `RlogReader::scan_blocks` runs on the same
+            // FIELD_DIR, so the pages fetched here are exactly the pages the
+            // decode addresses.
+            (numeric, columns.resolve(&field_dir))
+        } else {
+            (Vec::new(), None)
+        };
+
+        let candidates = skip.candidate_blocks(ts_min_ns, ts_max_ns, None, &numeric);
+        stats.candidate_blocks = candidates.len() as u64;
+        let wanted = projected_page_extents(
+            key,
+            &page_dir,
+            blocks_desc.offset,
+            &candidates,
+            selected.as_ref(),
+        )?;
+
+        // Coverage-based post-pruning crossover (ADR-0107 decision 1), against
+        // the BLOCKS section's own size for the reason the version-3 path
+        // documents. The numerator is now the projected page bytes rather than
+        // whole candidate blocks, so a narrow projection stays far below the
+        // threshold even when every block survives, and an all-columns read of
+        // every block reaches ~1.0 and takes the single GET.
+        let wanted_bytes: u64 = wanted.iter().map(|e| e.len).sum();
+        let coverage = wanted_bytes as f64 / blocks_desc.len.max(1) as f64;
+        if coverage >= self.coverage_threshold {
+            let (bytes, live) = self
+                .cached_extent(
+                    seg_ref,
+                    tenant_hash,
+                    0,
+                    total_size,
+                    GetRange::Full,
+                    pin,
+                    accounting,
+                )
+                .await?;
+            if live {
+                stats.block_range_gets = 1;
+                stats.block_bytes_fetched = bytes.len() as u64;
+            }
+            stats.whole_object = true;
+            // No per-block cache admission from the whole object here, unlike
+            // the version-3 path: a version-4 block is not a contiguous extent,
+            // so there is no block-keyed entry a later ranged read would look
+            // for. The chunk ranges are the cache unit instead, and this read
+            // resolved none of them.
+            return Ok((bytes, stats));
+        }
+
+        // The suffix probe normally places the object's tail -- the footer and
+        // trailer bytes `RlogReader` re-reads to open the assembled buffer,
+        // which are not themselves listed sections. A carried footer skipped the
+        // probe, so place that tail now (the version-3 path does the same).
+        if !probed {
+            let tail_start = footer
+                .sections
+                .iter()
+                .map(|s| s.offset + s.len)
+                .max()
+                .unwrap_or(0);
+            if tail_start < total_size && !asm.covers(tail_start, total_size) {
+                let (bytes, live) = self
+                    .cached_extent(
+                        seg_ref,
+                        tenant_hash,
+                        tail_start,
+                        total_size - tail_start,
+                        GetRange::Range(tail_start, total_size),
+                        pin,
+                        accounting,
+                    )
+                    .await?;
+                if live {
+                    stats.metadata_gets += 1;
+                }
+                asm.place(key, tail_start, &bytes)?;
+            }
+        }
+
+        // The remaining non-BLOCKS sections: STREAM_DIR/FIELD_DIR at the object
+        // front, and BLOOM/POSTINGS when a short probe missed them. The reader
+        // re-verifies each section's crc on decode, so a corrupt section hit
+        // fails closed there (ADR-0046).
+        for section in &footer.sections {
+            if section.kind == kind::BLOCKS {
+                continue;
+            }
+            self.place_section(
+                seg_ref,
+                tenant_hash,
+                section,
+                pin,
+                &mut asm,
+                accounting,
+                &mut stats,
+            )
+            .await?;
+        }
+
+        self.fetch_chunk_ranges(
+            seg_ref,
+            tenant_hash,
+            pin,
+            &wanted,
+            &mut asm,
+            accounting,
+            &mut stats,
+        )
+        .await?;
+        Ok((asm.into_bytes(), stats))
+    }
+
+    /// Fetch the coalesced page ranges into `asm`, every run concurrently,
+    /// through the same [`cached_extent`](Self::cached_extent) path every other
+    /// GET here takes: concurrent partitions striping one segment resolve the
+    /// identical candidate set and the identical projection, so they produce the
+    /// identical runs and collapse onto one real request each rather than one
+    /// per partition (ADR-0102 decision 1's premise), and the etag pin holds
+    /// across the sequence.
+    #[allow(clippy::too_many_arguments)]
+    async fn fetch_chunk_ranges(
+        &self,
+        seg_ref: &SegmentRef,
+        tenant_hash: TenantHash,
+        pin: &EtagPin,
+        wanted: &[ByteExtent],
+        asm: &mut ObjectAssembler,
+        accounting: &QueryAccounting,
+        stats: &mut BlockRangeStats,
+    ) -> Result<(), LogFetchError> {
+        let key = seg_ref.data_object_key.as_str();
+        let runs: Vec<ByteExtent> = coalesce_byte_extents(wanted, self.coalesce_gap)
+            .into_iter()
+            // A run the probe already brought costs nothing: its bytes are in
+            // `asm` at the right offsets already.
+            .filter(|r| !asm.covers(r.abs_start, r.abs_end()))
+            .collect();
+        let outcomes = futures::future::join_all(runs.iter().map(|run| async move {
+            let (bytes, live) = self
+                .cached_extent(
+                    seg_ref,
+                    tenant_hash,
+                    run.abs_start,
+                    run.len,
+                    GetRange::Range(run.abs_start, run.abs_end()),
+                    pin,
+                    accounting,
+                )
+                .await?;
+            Ok::<_, LogFetchError>((run.abs_start, bytes, live))
+        }))
+        .await;
+        for outcome in outcomes {
+            let (start, bytes, live) = outcome?;
+            if live {
+                stats.block_range_gets += 1;
+                stats.block_bytes_fetched =
+                    stats.block_bytes_fetched.saturating_add(bytes.len() as u64);
+            } else {
+                stats.block_cache_hits += 1;
+            }
+            asm.place(key, start, &bytes)?;
+        }
+        Ok(())
+    }
+
+    /// Place several sections into `asm` with one GET per coalesced run rather
+    /// than one per section, for sections a caller needs together. Sections
+    /// already covered by an earlier read cost nothing; the rest are merged
+    /// under the same `coalesce_gap` policy the block ranges use, which is what
+    /// keeps a probe too short for both SKIP_IDX and PAGE_DIR to one extra GET
+    /// instead of two (issue #766).
+    #[allow(clippy::too_many_arguments)]
+    async fn place_sections_coalesced(
+        &self,
+        seg_ref: &SegmentRef,
+        tenant_hash: TenantHash,
+        sections: &[SectionDesc],
+        pin: &EtagPin,
+        asm: &mut ObjectAssembler,
+        accounting: &QueryAccounting,
+        stats: &mut BlockRangeStats,
+    ) -> Result<(), LogFetchError> {
+        let key = seg_ref.data_object_key.as_str();
+        let missing: Vec<ByteExtent> = sections
+            .iter()
+            .filter(|s| !asm.covers(s.offset, s.offset + s.len))
+            .map(|s| ByteExtent {
+                abs_start: s.offset,
+                len: s.len,
+            })
+            .collect();
+        for run in coalesce_byte_extents(&missing, self.coalesce_gap) {
+            let (bytes, live) = self
+                .cached_extent(
+                    seg_ref,
+                    tenant_hash,
+                    run.abs_start,
+                    run.len,
+                    GetRange::Range(run.abs_start, run.abs_end()),
+                    pin,
+                    accounting,
+                )
+                .await?;
+            if live {
+                stats.metadata_gets += 1;
+            }
+            asm.place(key, run.abs_start, &bytes)?;
+        }
+        Ok(())
+    }
+
+    /// Decode one whole-compressed section out of the assembled buffer, where an
+    /// earlier `place_*` call already put its stored bytes.
+    fn placed_section_raw(
+        &self,
+        key: &str,
+        asm: &ObjectAssembler,
+        desc: &SectionDesc,
+    ) -> Result<Vec<u8>, LogFetchError> {
+        let stored = asm
+            .slice(desc.offset, desc.len)
+            .ok_or_else(|| corrupt_range(key))?;
+        decode_section(stored, desc, &self.cfg).map_err(|source| corrupt(key, source))
     }
 
     /// Resolve each candidate block index (from `skip.candidate_blocks`) to its
@@ -3322,9 +3900,31 @@ fn verify_block_crc(key: &str, bytes: &[u8], ext: &BlockExtent) -> Result<(), Lo
 /// meaningful (coalesced ranges are split back to per-block extents by the
 /// caller and each block's own crc is verified there).
 fn coalesce_extents(extents: &[BlockExtent], max_gap: u64) -> Vec<BlockExtent> {
+    let ranges: Vec<ByteExtent> = extents
+        .iter()
+        .map(|e| ByteExtent {
+            abs_start: e.abs_start,
+            len: e.len,
+        })
+        .collect();
+    coalesce_byte_extents(&ranges, max_gap)
+        .into_iter()
+        .map(|r| BlockExtent {
+            abs_start: r.abs_start,
+            len: r.len,
+            crc32c: 0,
+        })
+        .collect()
+}
+
+/// [`coalesce_extents`] over plain byte extents: the same rule (sort by start,
+/// join two runs whose gap is at most `max_gap`), applied to version 4's
+/// page-range fetch units. This is the one place the gap policy lives, so the
+/// version-3 block path and the version-4 chunk path cannot drift apart on it.
+fn coalesce_byte_extents(extents: &[ByteExtent], max_gap: u64) -> Vec<ByteExtent> {
     let mut ranges: Vec<(u64, u64)> = extents.iter().map(|e| (e.abs_start, e.abs_end())).collect();
     ranges.sort_by_key(|r| r.0);
-    let mut out: Vec<BlockExtent> = Vec::new();
+    let mut out: Vec<ByteExtent> = Vec::new();
     for (start, end) in ranges {
         if let Some(last) = out.last_mut()
             && start <= last.abs_end().saturating_add(max_gap)
@@ -3333,13 +3933,79 @@ fn coalesce_extents(extents: &[BlockExtent], max_gap: u64) -> Vec<BlockExtent> {
             last.len = new_end - last.abs_start;
             continue;
         }
-        out.push(BlockExtent {
+        out.push(ByteExtent {
             abs_start: start,
             len: end - start,
-            crc32c: 0,
         });
     }
     out
+}
+
+/// The absolute byte extents of exactly the pages the surviving blocks
+/// `candidates` hold for the columns `selected` keeps, over every row group
+/// holding at least one survivor (ADR-0699 decision 5). `selected` is `None`
+/// for an all-columns read.
+///
+/// `candidates` are whole-object level-0 block indices, strictly ascending, as
+/// [`SkipIndex::candidate_blocks`] returns them. PAGE_DIR's decode proves the
+/// groups partition the object's blocks into consecutive runs from block 0, so
+/// one forward pass over the groups splits the candidates between them with no
+/// per-block search. A candidate no group claims is corruption (the reader's
+/// own open checks the same invariant from the other side, PAGE_DIR block count
+/// against the skip index's), never a silently dropped block.
+fn projected_page_extents(
+    key: &str,
+    page_dir: &PageDir,
+    blocks_offset: u64,
+    candidates: &[usize],
+    selected: Option<&HashSet<u32>>,
+) -> Result<Vec<ByteExtent>, LogFetchError> {
+    let mut out = Vec::new();
+    let mut at = 0usize;
+    for (gi, group) in page_dir.groups.iter().enumerate() {
+        let group_end = u64::from(group.first_block) + u64::from(group.block_count);
+        let mut within: Vec<u32> = Vec::new();
+        while let Some(&b) = candidates.get(at) {
+            if b as u64 >= group_end {
+                break;
+            }
+            let b = u32::try_from(b).map_err(|_| corrupt_range(key))?;
+            let rel = b
+                .checked_sub(group.first_block)
+                .ok_or_else(|| corrupt_range(key))?;
+            within.push(rel);
+            at += 1;
+        }
+        if within.is_empty() {
+            continue;
+        }
+        let ranges = page_dir
+            .projected_page_ranges(gi, &within, selected)
+            .ok_or_else(|| corrupt_range(key))?;
+        for (offset, len) in ranges {
+            let abs_start = blocks_offset
+                .checked_add(offset)
+                .ok_or_else(|| corrupt_range(key))?;
+            out.push(ByteExtent { abs_start, len });
+        }
+    }
+    if at != candidates.len() {
+        return Err(corrupt(
+            key,
+            LogSegError::Corrupted("candidate block outside the page directory".into()),
+        ));
+    }
+    Ok(out)
+}
+
+/// Whether a suffix probe of `suffix` bytes over an object of `total_size`
+/// bytes covers `desc` entirely. This asks about the probe WINDOW, not about
+/// what any particular read has resident, so it answers "would a longer probe
+/// have saved this GET" rather than "did the cache hold it" (issue #766, the
+/// `probe_misses` counter).
+fn probe_window_covers(desc: &SectionDesc, total_size: u64, suffix: u64) -> bool {
+    let probe_start = total_size.saturating_sub(suffix);
+    desc.offset >= probe_start && desc.offset.saturating_add(desc.len) <= total_size
 }
 
 /// The canonical-byte needle for one stream-attribute equality: the single

--- a/crates/ravel-query/tests/log_block_range.rs
+++ b/crates/ravel-query/tests/log_block_range.rs
@@ -120,26 +120,16 @@ fn record_with_attrs(name: &str, ts: i64, body: &str) -> LogRecord {
 /// The block-range protocol under test is the version-3 one: it addresses each
 /// block by its SKIP_IDX byte range and verifies `block_crc32c` over exactly
 /// those bytes. RLOG version 4 (ADR-0699) makes neither true -- a block's pages
-/// are spread column-major across its row group -- so `BlockRangeFetcher` reads
-/// a version-4 object whole until ADR-0699 decision 5's PAGE_DIR-driven fetcher
-/// replaces this protocol. These fixtures therefore stay at version 3, which is
-/// what keeps the protocol covered; `version_4_object_is_read_whole` below pins
-/// the version-4 behaviour.
+/// are spread column-major across its row group -- so a version-4 object takes
+/// decision 5's column-chunk path instead, which `tests/log_page_dir_fetch.rs`
+/// covers. These fixtures therefore stay at version 3, which is what keeps this
+/// protocol covered.
 fn build_object(records: &[LogRecord]) -> Vec<u8> {
     let mut w = RlogWriter::new(one_record_blocks(), identity());
     for r in records {
         w.push(r.clone()).expect("push");
     }
     w.finish_v3_for_tests().expect("finish v3")
-}
-
-/// The same fixture at the current written version.
-fn build_object_v4(records: &[LogRecord]) -> Vec<u8> {
-    let mut w = RlogWriter::new(one_record_blocks(), identity());
-    for r in records {
-        w.push(r.clone()).expect("push");
-    }
-    w.finish().expect("finish v4")
 }
 
 /// A `SegmentRef` for an object of `size` bytes spanning `records`' ts range.
@@ -1311,71 +1301,12 @@ async fn page_decode_accounting_is_a_separate_axis_from_wire_bytes() {
 }
 
 // ---- Test 9: RLOG version 4 ----------------------------------------------
-
-/// A version-4 object is read whole, and its rows are the whole-object path's.
-///
-/// ADR-0699 stores a row group's pages column-major, so a block is no longer a
-/// contiguous byte range and its SKIP_IDX `block_offset`/`block_len` describe an
-/// overlapping page span, with `block_crc32c` defined over the block's pages in
-/// `column_id` order rather than over that span. The block-range protocol
-/// assumes neither, so it falls back rather than fetching ranges it cannot
-/// verify. This pins the fallback rather than leaving it to be discovered as a
-/// crc failure, and it is the test ADR-0699 decision 5's PAGE_DIR-driven
-/// fetcher replaces: when that lands, a version-4 object stops being read whole
-/// and this test becomes an assertion about column chunks.
-#[tokio::test]
-async fn version_4_object_is_read_whole_until_the_page_dir_fetcher_lands() {
-    let records: Vec<LogRecord> = (0..20)
-        .map(|ts| record("api", ts, if ts == 8 { "connection timeout" } else { "ok" }))
-        .collect();
-    let bytes = build_object_v4(&records);
-    assert_eq!(
-        footer::trailer_version(&bytes).expect("trailer version"),
-        footer::VERSION,
-        "the fixture is at the current written version"
-    );
-    assert!(
-        footer::open(&bytes)
-            .expect("footer")
-            .section(kind::PAGE_DIR)
-            .is_some(),
-        "a version-4 object carries PAGE_DIR"
-    );
-
-    let mem = Arc::new(MemoryStore::new());
-    mem.put("logs/v4.rlog", bytes.clone().into(), PutOptions::default())
-        .await
-        .expect("put");
-    let seg = seg_ref("logs/v4.rlog", bytes.len() as u64, &records);
-    let store: Arc<dyn ObjectStoreBackend> = mem;
-    let (_blocks_offset, _blocks_len, tail_len) = layout(&bytes);
-
-    let br = BlockRangeFetcher::new(Arc::clone(&store))
-        .with_whole_object_threshold(0)
-        .with_suffix_len(tail_len)
-        // A threshold the candidate coverage cannot reach, so a whole-object
-        // read here is the version-4 fallback and not the coverage crossover.
-        .with_coverage_threshold(1000.0);
-    let (got, stats) = br
-        .fetch_object(&seg, TENANT, 6, 13, &QueryAccounting::new())
-        .await
-        .expect("version-4 fetch succeeds");
-
-    assert!(stats.whole_object, "a version-4 object is read whole");
-    assert_eq!(
-        stats.candidate_blocks, 0,
-        "no block extents are resolved: the fallback returns before pruning"
-    );
-    assert_eq!(got.len(), bytes.len(), "the whole object is returned");
-    assert_eq!(got.as_ref(), bytes.as_slice());
-
-    // And the rows match the plain whole-object path, so the fallback is a
-    // fetch-strategy choice and nothing about what a query sees.
-    let query = LogQuery::new(6, 13);
-    let whole = LogSegmentFetcher::new(Arc::clone(&store))
-        .fetch(&seg, &query)
-        .await
-        .expect("whole fetch")
-        .expect("in range");
-    assert_eq!(whole.records.len(), 8, "ts 6..=13 inclusive");
-}
+//
+// A version-4 object does not take the protocol this file tests: its pages are
+// stored column-major inside row groups, so a block is neither a contiguous
+// byte range nor covered by a crc over one, and `BlockRangeFetcher` routes it
+// through ADR-0699 decision 5's column-chunk path instead. That path, and the
+// test that used to pin the interim whole-object fallback here
+// (`version_4_object_is_read_whole_until_the_page_dir_fetcher_lands`, now
+// `version_4_projected_read_fetches_one_range_per_group_and_column`), live in
+// `tests/log_page_dir_fetch.rs`.

--- a/crates/ravel-query/tests/log_page_dir_fetch.rs
+++ b/crates/ravel-query/tests/log_page_dir_fetch.rs
@@ -1,0 +1,1155 @@
+//! Integration tests for the RLOG version-4 column-chunk fetcher (ADR-0699
+//! decision 5, `ravel_query::BlockRangeFetcher`).
+//!
+//! Version 4 stores a row group's pages column-major and lists every page in
+//! PAGE_DIR, so a block is no longer a contiguous byte range and the ADR-0107
+//! block-range protocol does not apply to it. The fetcher instead resolves each
+//! surviving `(row group, projected column)` to the byte extents of that
+//! column's pages for the surviving blocks, coalesces them under the same gap
+//! policy, and fetches those. These tests pin what that buys and what it costs:
+//!
+//! 1. A projected read issues one probe plus one range per surviving `(group,
+//!    column)` and moves exactly those columns' page bytes.
+//! 2. A prune arm that leaves survivors in one group reads inside that group
+//!    only.
+//! 3. An all-columns read of every block still crosses over to one whole-object
+//!    GET at the 75% coverage threshold.
+//! 4. A page-crc corruption in a fetched chunk is a typed error; a corruption in
+//!    a column the projection dropped does not affect the projected read, which
+//!    verifies page crcs rather than the block crc it cannot compute.
+//! 5. The plan phase fetches no page byte.
+//! 6. Two partitions reading the same chunk collapse onto one store GET.
+//! 7. The default suffix probe covers the plan sections (footer, SKIP_IDX,
+//!    PAGE_DIR) of a wide, full-row-group object, so #766's second GET is gone.
+//! 8. What a chunk read decodes is what a whole-object read decodes.
+//!
+//! The oracle for 1-3 is PAGE_DIR itself, walked here independently of the
+//! fetcher's own walk, plus an exact literal so a silent change in either shows
+//! up as a number rather than as two agreeing derivations.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use async_trait::async_trait;
+use ravel_cache::{Cache, CacheLimits};
+use ravel_catalog::{SegmentLevel, SegmentRef};
+use ravel_logseg::field_dir::FieldDir;
+use ravel_logseg::footer::{self, LogFooter, kind};
+use ravel_logseg::page_dir::PageDir;
+use ravel_logseg::record::{COL_FLAGS, COL_STREAM_REF, COL_TS};
+use ravel_logseg::writer::ObjectIdentity;
+use ravel_logseg::{
+    AttrValue, ColumnSelection, FieldSel, FieldType, LogRecord, LogSegError, Predicate, RlogConfig,
+    RlogWriter, read_section, stream_attrs_bytes,
+};
+use ravel_object_store::fault::{FaultPlan, FaultStore, Occurrence, Op};
+use ravel_object_store::memory::MemoryStore;
+use ravel_object_store::{
+    Capabilities, DelimitedList, GetOutcome, GetRange, ListPage, ObjectMeta, ObjectStoreBackend,
+    PageToken, PutOptions, PutOutcome, StoreError,
+};
+use ravel_query::{BlockRangeFetcher, CacheFetchError, LogFetchError, LogQuery, LogSegmentFetcher};
+use ravel_types::TenantHash;
+use ravel_types::accounting::{AccountedOp, QueryAccounting};
+use uuid::Uuid;
+
+const TENANT: TenantHash = TenantHash([7u8; 16]);
+const CONTENT_HASH: [u8; 32] = [9u8; 32];
+const KEY: &str = "logs/v4.rlog";
+
+/// Two blocks to a row group and two records to a block, so the fixture has
+/// three row groups of two blocks each and a prune arm can leave survivors in
+/// exactly one of them.
+const GROUP_BLOCKS: usize = 2;
+const BLOCK_RECORDS: usize = 2;
+const GROUPS: usize = 3;
+const BLOCKS: usize = GROUPS * GROUP_BLOCKS;
+const RECORDS: usize = BLOCKS * BLOCK_RECORDS;
+
+/// Body filler per record. Large relative to every other column, so a
+/// projection that drops `body` is a large byte saving and the coverage
+/// crossover does not fire on it.
+const BODY_BYTES: usize = 8 * 1024;
+
+/// The declared numeric attribute every record carries: `code = <block index>`,
+/// so a `NumRange` arm on it selects an exact block subset the skip index can
+/// prune.
+const CODE_COL: &str = "code";
+
+fn identity() -> ObjectIdentity {
+    ObjectIdentity {
+        // Must match the fetch tenant: the RLOG read path enforces a footer
+        // tenant_hash check.
+        tenant_hash: [7u8; 16],
+        shard: 0,
+        writer_id: [2u8; 16],
+        writer_epoch: 1,
+        writer_seq: 1,
+    }
+}
+
+/// Pseudo-random printable filler, so the writer's body compression cannot
+/// shrink the fixture back to a size where every chunk range coalesces into one.
+fn filler(seed: u64, len: usize) -> String {
+    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+    let mut state = seed;
+    let mut out = String::with_capacity(len);
+    for _ in 0..len {
+        state = state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = state;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^= z >> 31;
+        out.push(ALPHABET[(z & 63) as usize] as char);
+    }
+    out
+}
+
+fn record(i: usize) -> LogRecord {
+    let resource = vec![("service.name".to_string(), AttrValue::Str("svc".into()))];
+    let block = i / BLOCK_RECORDS;
+    let ts = i as i64;
+    LogRecord {
+        stream_id: ravel_types::logstream::log_stream_id(&resource, "scope", "1.0", &[]),
+        stream_attrs: stream_attrs_bytes(&resource, "scope", "1.0", &[]),
+        ts_ns: ts,
+        observed_ts_ns: ts + 1,
+        severity_num: 9,
+        severity_text: if i.is_multiple_of(2) { "INFO" } else { "WARN" }.into(),
+        body: filler(i as u64, BODY_BYTES),
+        trace_id: None,
+        span_id: None,
+        // Nonzero and varying, so `flags` really carries a page in every block
+        // and the projection under test is not silently selecting an absent
+        // column.
+        flags: (i as u32 & 7) + 1,
+        attrs: vec![(CODE_COL.to_string(), AttrValue::I64(block as i64))],
+    }
+}
+
+fn records() -> Vec<LogRecord> {
+    (0..RECORDS).map(record).collect()
+}
+
+fn build_object(records: &[LogRecord]) -> Vec<u8> {
+    let cfg = RlogConfig {
+        block_target_records: BLOCK_RECORDS,
+        group_target_blocks: GROUP_BLOCKS,
+        ..RlogConfig::default()
+    };
+    let mut w = RlogWriter::new(cfg, identity());
+    for r in records {
+        w.push(r.clone()).expect("push");
+    }
+    w.finish().expect("finish v4")
+}
+
+fn seg_ref(size: u64, records: &[LogRecord]) -> SegmentRef {
+    let min = records.iter().map(|r| r.ts_ns).min().expect("nonempty");
+    let max = records.iter().map(|r| r.ts_ns).max().expect("nonempty");
+    SegmentRef {
+        data_object_key: KEY.to_string(),
+        object_size: size,
+        min_event_ts_ns: min,
+        max_event_ts_ns: max,
+        ingest_hour_bucket: 0,
+        sample_count: records.len() as u64,
+        series_count: 0,
+        shard: 0,
+        content_hash: CONTENT_HASH,
+        writer_id: Uuid::from_u128(1),
+        writer_epoch: 1,
+        writer_seq: 1,
+        created_unix_ns: 0,
+        level: SegmentLevel::L0,
+    }
+}
+
+// ---- directory oracles ---------------------------------------------------
+
+fn footer_of(bytes: &[u8]) -> LogFooter {
+    footer::open(bytes).expect("footer")
+}
+
+fn section_raw(bytes: &[u8], k: u32) -> Vec<u8> {
+    let f = footer_of(bytes);
+    let desc = f.section(k).expect("section present");
+    read_section(bytes, desc, &RlogConfig::default()).expect("section decode")
+}
+
+fn page_dir_of(bytes: &[u8]) -> PageDir {
+    PageDir::decode(&section_raw(bytes, kind::PAGE_DIR)).expect("PAGE_DIR")
+}
+
+fn field_dir_of(bytes: &[u8]) -> FieldDir {
+    FieldDir::decode(&section_raw(bytes, kind::FIELD_DIR), 1 << 20).expect("FIELD_DIR")
+}
+
+fn blocks_extent(bytes: &[u8]) -> (u64, u64) {
+    let f = footer_of(bytes);
+    let b = f.section(kind::BLOCKS).expect("BLOCKS");
+    (b.offset, b.len)
+}
+
+/// Bytes after the BLOCKS section: SKIP_IDX, PAGE_DIR, BLOOM, POSTINGS, then the
+/// footer and trailer. A probe suffix of exactly this length covers the whole
+/// tail and reaches no page.
+fn tail_len(bytes: &[u8]) -> u64 {
+    let (offset, len) = blocks_extent(bytes);
+    bytes.len() as u64 - (offset + len)
+}
+
+/// The absolute page extents a version-4 read must resolve for the whole-object
+/// block indices `blocks` and the column ids `selected` keeps (`None` keeps
+/// every column), coalesced at `gap`.
+///
+/// Written as an independent walk of PAGE_DIR rather than by calling the
+/// fetcher's own helper, so this is an oracle and not a restatement.
+fn expected_runs(
+    bytes: &[u8],
+    blocks: &[usize],
+    selected: Option<&HashSet<u32>>,
+    gap: u64,
+) -> Vec<(u64, u64)> {
+    let dir = page_dir_of(bytes);
+    let (blocks_offset, _) = blocks_extent(bytes);
+    let mut raw: Vec<(u64, u64)> = Vec::new();
+    for group in &dir.groups {
+        for chunk in &group.chunks {
+            let keep = selected.is_none_or(|s| s.contains(&chunk.column_id));
+            let mut at = chunk.offset;
+            for p in &chunk.pages {
+                let start = at;
+                at += p.len;
+                let whole = group.first_block as usize + p.block as usize;
+                if keep && blocks.contains(&whole) {
+                    raw.push((blocks_offset + start, p.len));
+                }
+            }
+        }
+    }
+    raw.sort_by_key(|r| r.0);
+    let mut out: Vec<(u64, u64)> = Vec::new();
+    for (start, len) in raw {
+        if let Some(last) = out.last_mut()
+            && start <= last.0 + last.1 + gap
+        {
+            let end = (last.0 + last.1).max(start + len);
+            last.1 = end - last.0;
+            continue;
+        }
+        out.push((start, len));
+    }
+    out
+}
+
+/// The `(offset, length)` byte span of one row group in the object: from its
+/// first column chunk to the end of its last.
+fn group_span(bytes: &[u8], group: usize) -> (u64, u64) {
+    let dir = page_dir_of(bytes);
+    let (blocks_offset, _) = blocks_extent(bytes);
+    let g = &dir.groups[group];
+    let mut start = u64::MAX;
+    let mut end = 0u64;
+    for c in &g.chunks {
+        let (offset, len) = c.extent().expect("chunk extent");
+        start = start.min(offset);
+        end = end.max(offset + len);
+    }
+    (blocks_offset + start, end - start)
+}
+
+/// The column ids a [`ColumnSelection`] resolves to against this object's
+/// FIELD_DIR: exactly what the fetcher and the decode both use.
+fn resolved(bytes: &[u8], sel: &ColumnSelection) -> Option<HashSet<u32>> {
+    sel.resolve(&field_dir_of(bytes))
+}
+
+// ---- store doubles -------------------------------------------------------
+
+/// Records every `get` range so a test can assert WHERE a read landed, not only
+/// how much it moved.
+struct RecordingStore {
+    inner: Arc<MemoryStore>,
+    full: AtomicU64,
+    suffix: AtomicU64,
+    ranges: std::sync::Mutex<Vec<(u64, u64)>>,
+}
+
+impl RecordingStore {
+    fn new(inner: Arc<MemoryStore>) -> Arc<Self> {
+        Arc::new(RecordingStore {
+            inner,
+            full: AtomicU64::new(0),
+            suffix: AtomicU64::new(0),
+            ranges: std::sync::Mutex::new(Vec::new()),
+        })
+    }
+    fn full_gets(&self) -> u64 {
+        self.full.load(Ordering::SeqCst)
+    }
+    fn suffix_gets(&self) -> u64 {
+        self.suffix.load(Ordering::SeqCst)
+    }
+    /// Every `[start, end)` range GET, in issue order.
+    fn ranges(&self) -> Vec<(u64, u64)> {
+        self.ranges.lock().expect("ranges").clone()
+    }
+    fn gets(&self) -> u64 {
+        self.full_gets() + self.suffix_gets() + self.ranges().len() as u64
+    }
+}
+
+#[async_trait]
+impl ObjectStoreBackend for RecordingStore {
+    async fn put(
+        &self,
+        key: &str,
+        data: bytes::Bytes,
+        opts: PutOptions,
+    ) -> Result<PutOutcome, StoreError> {
+        self.inner.put(key, data, opts).await
+    }
+    async fn get(&self, key: &str, range: GetRange) -> Result<GetOutcome, StoreError> {
+        match range {
+            GetRange::Full => {
+                self.full.fetch_add(1, Ordering::SeqCst);
+            }
+            GetRange::Suffix(_) => {
+                self.suffix.fetch_add(1, Ordering::SeqCst);
+            }
+            GetRange::Range(a, b) => self.ranges.lock().expect("ranges").push((a, b)),
+        }
+        self.inner.get(key, range).await
+    }
+    async fn head(&self, key: &str) -> Result<ObjectMeta, StoreError> {
+        self.inner.head(key).await
+    }
+    async fn list(&self, prefix: &str, page: Option<PageToken>) -> Result<ListPage, StoreError> {
+        self.inner.list(prefix, page).await
+    }
+    async fn list_delimited(&self, prefix: &str) -> Result<DelimitedList, StoreError> {
+        self.inner.list_delimited(prefix).await
+    }
+    async fn delete(&self, key: &str) -> Result<(), StoreError> {
+        self.inner.delete(key).await
+    }
+    fn capabilities(&self) -> Capabilities {
+        self.inner.capabilities()
+    }
+}
+
+async fn store_with(bytes: &[u8]) -> Arc<MemoryStore> {
+    let mem = Arc::new(MemoryStore::new());
+    mem.put(
+        KEY,
+        bytes::Bytes::copy_from_slice(bytes),
+        PutOptions::default(),
+    )
+    .await
+    .expect("put");
+    mem
+}
+
+/// A block-range fetcher forced onto the ranged path on this small fixture,
+/// with a probe sized to exactly the object tail (so it carries the footer,
+/// SKIP_IDX and PAGE_DIR and reaches no page) and no coalescing slack (so each
+/// column chunk is its own GET and the range count is the chunk count).
+fn ranged(store: Arc<dyn ObjectStoreBackend>, bytes: &[u8]) -> BlockRangeFetcher {
+    BlockRangeFetcher::new(store)
+        .with_whole_object_threshold(0)
+        .with_suffix_len(tail_len(bytes))
+        .with_coalesce_gap(0)
+}
+
+fn read_cache() -> Arc<Cache<CacheFetchError>> {
+    Arc::new(Cache::new(CacheLimits::new(64 << 20, 4096, 64 << 20)))
+}
+
+/// `code` in `[min, max]`, the prune-only numeric arm the SQL layer produces
+/// for a declared integer column (ADR-0095 decision 6).
+fn code_between(min: i64, max: i64) -> Predicate {
+    Predicate::NumRange {
+        field: FieldSel::Attr(CODE_COL.to_string()),
+        ty: FieldType::I64,
+        min: Some(min as u64),
+        max: Some(max as u64),
+    }
+}
+
+// ---- 1. projected read: one range per (group, column) ---------------------
+
+/// A projected read of `k` columns over `G` row groups issues one suffix probe,
+/// one GET for each of the two front sections the probe structurally cannot
+/// reach, and `G * k` chunk ranges -- and moves exactly those columns' page
+/// bytes, not the object.
+///
+/// This is the test the interim whole-object guard's
+/// `version_4_object_is_read_whole_until_the_page_dir_fetcher_lands` became.
+///
+/// Non-vacuity: restoring the guard (`fetch_object_with_footer`'s
+/// `if footer.section(kind::PAGE_DIR).is_some()` arm returning one
+/// `GetRange::Full`) makes this read 1 whole-object GET of the entire object,
+/// so `full_gets == 0`, the range count, and the byte assertions all fail.
+#[tokio::test]
+async fn version_4_projected_read_fetches_one_range_per_group_and_column() {
+    let recs = records();
+    let bytes = build_object(&recs);
+    let mem = store_with(&bytes).await;
+    let recording = RecordingStore::new(mem);
+    let store: Arc<dyn ObjectStoreBackend> = Arc::clone(&recording) as Arc<dyn ObjectStoreBackend>;
+
+    // ts, stream_ref and flags: three columns with unselected columns between
+    // them (observed_ts between 0 and 2; severity and body between 2 and 8), so
+    // no two of their chunks are adjacent and none coalesces at gap 0.
+    let sel = ColumnSelection::fixed_only().with_flags();
+    let ids = resolved(&bytes, &sel).expect("a projection, not all columns");
+    assert_eq!(
+        ids,
+        HashSet::from([COL_TS, COL_STREAM_REF, COL_FLAGS]),
+        "the fixture's projection is exactly three fixed columns"
+    );
+
+    let dir = page_dir_of(&bytes);
+    assert_eq!(dir.groups.len(), GROUPS, "fixture row-group count");
+    assert!(
+        dir.groups
+            .iter()
+            .all(|g| g.block_count as usize == GROUP_BLOCKS),
+        "every row group is full, so every group holds surviving blocks"
+    );
+
+    let all_blocks: Vec<usize> = (0..BLOCKS).collect();
+    let runs = expected_runs(&bytes, &all_blocks, Some(&ids), 0);
+    assert_eq!(
+        runs.len(),
+        GROUPS * ids.len(),
+        "one contiguous run per (row group, projected column)"
+    );
+
+    let seg = seg_ref(bytes.len() as u64, &recs);
+    let acc = QueryAccounting::new();
+    let (got, stats) = ranged(store, &bytes)
+        .fetch_object_projected(&seg, TENANT, i64::MIN, i64::MAX, &sel, &acc)
+        .await
+        .expect("projected fetch");
+
+    assert!(!stats.whole_object, "the object is not read whole");
+    assert_eq!(stats.probe_gets, 1, "one etag-establishing suffix probe");
+    assert_eq!(
+        stats.probe_misses, 0,
+        "the probe covers SKIP_IDX and PAGE_DIR"
+    );
+    assert_eq!(
+        stats.candidate_blocks, BLOCKS as u64,
+        "no predicate, so every block survives"
+    );
+    // 9 = 3 row groups x 3 projected columns. The exact literal alongside the
+    // oracle: a change in either the fixture's layout or the fetcher's walk has
+    // to move this number, not just keep two derivations agreeing.
+    assert_eq!(stats.block_range_gets, 9, "G*k chunk ranges");
+    assert_eq!(stats.block_range_gets, runs.len() as u64);
+    // STREAM_DIR and FIELD_DIR sit at the object's front; no suffix probe of
+    // any length reaches them, so they are one GET each on every ranged read.
+    assert_eq!(stats.metadata_gets, 2, "the two front sections");
+    assert_eq!(
+        recording.gets(),
+        12,
+        "1 probe + 2 front sections + 9 chunk ranges"
+    );
+    assert_eq!(recording.full_gets(), 0, "no whole-object GET");
+
+    // The chunk GETs are exactly the oracle's runs, so the fetch landed on the
+    // projected columns' pages and nothing else.
+    let mut issued: Vec<(u64, u64)> = recording
+        .ranges()
+        .into_iter()
+        .filter(|(a, b)| runs.iter().any(|(s, l)| a == s && b == &(s + l)))
+        .collect();
+    issued.sort_unstable();
+    let mut want: Vec<(u64, u64)> = runs.iter().map(|(s, l)| (*s, s + l)).collect();
+    want.sort_unstable();
+    assert_eq!(issued, want, "the chunk GETs are the resolved chunk ranges");
+
+    let chunk_bytes: u64 = runs.iter().map(|(_, l)| l).sum();
+    assert_eq!(
+        stats.block_bytes_fetched, chunk_bytes,
+        "block_bytes_fetched is exactly the projected columns' page bytes"
+    );
+    // The whole point: the wire bytes track the projection, not the object.
+    // 3 of ~9 columns, and the object is dominated by the unprojected `body`.
+    let object = bytes.len() as u64;
+    assert!(
+        chunk_bytes * 20 < object,
+        "the projection must move under 5% of the object: {chunk_bytes} of {object}"
+    );
+    assert!(
+        acc.snapshot().total_s3_bytes() < object,
+        "including the probe and the front sections, still under one whole-object read"
+    );
+    assert_eq!(got.len(), bytes.len(), "an object-sized decode buffer");
+}
+
+// ---- 2. pruned: ranges land in the surviving group only -------------------
+
+/// A numeric prune arm whose survivors all live in one row group makes the read
+/// land inside that group's byte span and nowhere else.
+///
+/// Non-vacuity: with the interim whole-object guard restored, the single GET is
+/// `GetRange::Full` over the object, so `full_gets == 0` fails and no range GET
+/// exists to check against the group span.
+#[tokio::test]
+async fn version_4_prune_reads_ranges_in_the_surviving_group_only() {
+    let recs = records();
+    let bytes = build_object(&recs);
+    let mem = store_with(&bytes).await;
+    let recording = RecordingStore::new(mem);
+    let store: Arc<dyn ObjectStoreBackend> = Arc::clone(&recording) as Arc<dyn ObjectStoreBackend>;
+
+    // `code = 0` keeps block 0 only, which is the first block of row group 0.
+    let prune = vec![code_between(0, 0)];
+    let sel = ColumnSelection::all();
+    let runs = expected_runs(&bytes, &[0], None, 0);
+
+    let seg = seg_ref(bytes.len() as u64, &recs);
+    let acc = QueryAccounting::new();
+    let (_got, stats) = ranged(store, &bytes)
+        .fetch_object_with_footer(&seg, TENANT, i64::MIN, i64::MAX, &prune, &sel, None, &acc)
+        .await
+        .expect("pruned fetch");
+
+    assert!(!stats.whole_object, "one of six blocks is far under 75%");
+    assert_eq!(
+        stats.candidate_blocks, 1,
+        "the numeric arm keeps exactly block 0"
+    );
+    // 8 = one range per column chunk block 0 carries a page for (ts,
+    // observed_ts, stream_ref, severity_num, severity_text, body, flags, code),
+    // none of them coalescing at gap 0 because block 1's page for the same
+    // column sits between every consecutive pair.
+    assert_eq!(stats.block_range_gets, 8, "one range per chunk of group 0");
+    assert_eq!(stats.block_range_gets, runs.len() as u64);
+    assert_eq!(recording.full_gets(), 0, "no whole-object GET");
+
+    let (g0_start, g0_len) = group_span(&bytes, 0);
+    let (g1_start, _) = group_span(&bytes, 1);
+    assert!(g1_start >= g0_start + g0_len, "the groups are disjoint");
+    for (start, end) in recording.ranges() {
+        // The front sections sit before BLOCKS; only the page ranges are
+        // checked against the group span.
+        let (blocks_offset, _) = blocks_extent(&bytes);
+        if start < blocks_offset {
+            continue;
+        }
+        assert!(
+            start >= g0_start && end <= g0_start + g0_len,
+            "range [{start},{end}) escaped row group 0 [{g0_start},{})",
+            g0_start + g0_len
+        );
+    }
+
+    let group_bytes: u64 = g0_len;
+    assert!(
+        stats.block_bytes_fetched < group_bytes,
+        "block 0's pages ({}) are a strict subset of its group ({group_bytes})",
+        stats.block_bytes_fetched
+    );
+}
+
+// ---- 3. the coverage crossover ------------------------------------------
+
+/// Selecting every column with every block surviving covers essentially all of
+/// BLOCKS, so the 75% coverage crossover fires and the object is read whole in
+/// one GET -- the crossover ADR-0107 introduced, preserved by the chunk path.
+///
+/// Non-vacuity: `with_coverage_threshold(2.0)` on the same fixture (a threshold
+/// coverage cannot reach) takes the ranged branch instead, and `full_gets == 1`
+/// fails with 0.
+#[tokio::test]
+async fn version_4_all_columns_all_blocks_crosses_over_to_one_whole_object_get() {
+    let recs = records();
+    let bytes = build_object(&recs);
+    let mem = store_with(&bytes).await;
+    let recording = RecordingStore::new(mem);
+    let store: Arc<dyn ObjectStoreBackend> = Arc::clone(&recording) as Arc<dyn ObjectStoreBackend>;
+
+    let (_, blocks_len) = blocks_extent(&bytes);
+    let runs = expected_runs(&bytes, &(0..BLOCKS).collect::<Vec<_>>(), None, 0);
+    let wanted: u64 = runs.iter().map(|(_, l)| l).sum();
+    assert!(
+        wanted as f64 / blocks_len as f64 >= 0.75,
+        "an all-columns, all-blocks read must clear the crossover: {wanted} of {blocks_len}"
+    );
+
+    let seg = seg_ref(bytes.len() as u64, &recs);
+    let acc = QueryAccounting::new();
+    let (got, stats) = ranged(store, &bytes)
+        .fetch_object_projected(
+            &seg,
+            TENANT,
+            i64::MIN,
+            i64::MAX,
+            &ColumnSelection::all(),
+            &acc,
+        )
+        .await
+        .expect("all-columns fetch");
+
+    assert!(stats.whole_object, "the crossover fired");
+    assert_eq!(recording.full_gets(), 1, "exactly one whole-object GET");
+    assert_eq!(stats.block_range_gets, 1, "counted as the one read it is");
+    assert_eq!(
+        stats.block_bytes_fetched,
+        bytes.len() as u64,
+        "the whole object"
+    );
+    assert_eq!(got.as_ref(), bytes.as_slice(), "and it is the object");
+    // The probe plus the crossover read, and nothing in between: no front
+    // section GET is paid before the decision (an all-columns query with no
+    // numeric arm needs no FIELD_DIR to resolve either channel).
+    assert_eq!(recording.gets(), 2, "the probe and the whole-object GET");
+}
+
+// ---- 4. checksums on a projected read ------------------------------------
+
+/// A flipped byte inside a chunk the projection FETCHES fails that page's
+/// PAGE_DIR crc32c and surfaces as a typed error, never as a decoded row.
+///
+/// Non-vacuity: this is the corruption the block crc used to catch. Under a
+/// projected version-4 read there is no block crc to check (the reader does not
+/// hold the block's other pages), so the page crc is the only thing standing
+/// between a flipped byte and a wrong value. Flipping the same byte with the
+/// page-crc check removed in `decode_v4_block` returns rows instead of erroring.
+#[tokio::test]
+async fn version_4_page_crc_corruption_in_a_fetched_chunk_is_a_typed_error() {
+    let recs = records();
+    let clean = build_object(&recs);
+    let sel = ColumnSelection::fixed_only().with_flags();
+    let ids = resolved(&clean, &sel).expect("a projection");
+
+    // A byte inside the first page of the `flags` chunk of row group 0, which
+    // the projection fetches and decodes.
+    let runs = expected_runs(&clean, &[0], Some(&ids), 0);
+    let flags_run = flags_chunk_range(&clean, 0);
+    let target = flags_run.0;
+    assert!(
+        runs.iter().any(|(s, l)| target >= *s && target < s + l),
+        "the corrupted byte must be inside a fetched chunk range"
+    );
+
+    let mut corrupt = clean.clone();
+    corrupt[target as usize] ^= 0xff;
+
+    let err = fetch_and_decode(&corrupt, &recs, &sel)
+        .await
+        .expect_err("a corrupted fetched page must not decode");
+    let LogFetchError::Corrupt { source, .. } = &err else {
+        panic!("expected Corrupt, got {err:?}");
+    };
+    let LogSegError::Corrupted(msg) = source else {
+        panic!("expected Corrupted, got {source:?}");
+    };
+    assert!(
+        msg.contains("page crc mismatch"),
+        "the page crc is what caught it, got {msg}"
+    );
+}
+
+/// A flipped byte in a column the projection DROPS does not affect the
+/// projected read: the page is never fetched, never decoded, and the block crc
+/// -- which that byte does break -- is not verified by a read that does not hold
+/// every one of the block's pages (docs/log-segment-format.md, "BLOCKS").
+/// An all-columns read of the same object does fail, which is what shows the
+/// corruption is real rather than the flip landing on padding.
+#[tokio::test]
+async fn version_4_corruption_outside_the_projection_leaves_it_intact() {
+    let recs = records();
+    let clean = build_object(&recs);
+    let sel = ColumnSelection::fixed_only().with_flags();
+    let ids = resolved(&clean, &sel).expect("a projection");
+
+    // A byte inside `body`'s chunk in row group 0: part of block 0's block crc,
+    // and outside every chunk the projection keeps.
+    let target = body_chunk_range(&clean, 0).0;
+    let kept = expected_runs(&clean, &(0..BLOCKS).collect::<Vec<_>>(), Some(&ids), 0);
+    assert!(
+        !kept.iter().any(|(s, l)| target >= *s && target < s + l),
+        "the corrupted byte must be outside every fetched chunk range"
+    );
+
+    let mut corrupt = clean.clone();
+    corrupt[target as usize] ^= 0xff;
+
+    let projected = fetch_and_decode(&corrupt, &recs, &sel)
+        .await
+        .expect("a projected read is unaffected by a dropped column's bytes");
+    let baseline = fetch_and_decode(&clean, &recs, &sel)
+        .await
+        .expect("clean projected read");
+    assert_eq!(
+        projected.len(),
+        RECORDS,
+        "every record still comes back through the projection"
+    );
+    assert_eq!(
+        projected, baseline,
+        "and byte-identically to the same read of the uncorrupted object"
+    );
+
+    // The corruption is genuine: a read that keeps every column does hold the
+    // block's pages, verifies both the page crc and the block crc, and fails.
+    let err = fetch_and_decode(&corrupt, &recs, &ColumnSelection::all())
+        .await
+        .expect_err("an all-columns read must catch it");
+    assert!(
+        matches!(err, LogFetchError::Corrupt { .. }),
+        "expected Corrupt, got {err:?}"
+    );
+}
+
+/// The absolute `(offset, len)` of one row group's `body` column chunk.
+fn body_chunk_range(bytes: &[u8], group: usize) -> (u64, u64) {
+    chunk_range(bytes, group, ravel_logseg::record::COL_BODY)
+}
+
+/// The absolute `(offset, len)` of one row group's `flags` column chunk.
+fn flags_chunk_range(bytes: &[u8], group: usize) -> (u64, u64) {
+    chunk_range(bytes, group, COL_FLAGS)
+}
+
+fn chunk_range(bytes: &[u8], group: usize, column_id: u32) -> (u64, u64) {
+    let (blocks_offset, _) = blocks_extent(bytes);
+    let (offset, len) = page_dir_of(bytes)
+        .chunk_range(group, column_id)
+        .expect("the fixture carries this column in this group");
+    (blocks_offset + offset, len)
+}
+
+/// Fetch `bytes` (as the stored object) through the version-4 chunk path with
+/// `sel`, then drain the scan, so a test can assert on what a projected read
+/// decodes rather than on the buffer it assembled.
+async fn fetch_and_decode(
+    bytes: &[u8],
+    recs: &[LogRecord],
+    sel: &ColumnSelection,
+) -> Result<Vec<LogRecord>, LogFetchError> {
+    let mem = store_with(bytes).await;
+    let store: Arc<dyn ObjectStoreBackend> = mem;
+    let fetcher = LogSegmentFetcher::new(Arc::clone(&store))
+        .with_block_range_threshold(0)
+        .with_block_range(ranged(store, bytes));
+    let seg = seg_ref(bytes.len() as u64, recs);
+    let query = LogQuery::new(i64::MIN, i64::MAX);
+    let acc = QueryAccounting::new();
+    let mut scan = fetcher
+        .scan_accounted_with_tenant(&seg, TENANT, &query, sel, &acc)
+        .await?
+        .expect("in range");
+    let mut out = Vec::new();
+    while let Some(rows) = scan.next_block()? {
+        out.extend(rows);
+    }
+    Ok(out)
+}
+
+// ---- 5. the plan phase reads no page -------------------------------------
+
+/// `plan_segment` on a version-4 object counts survivors from SKIP_IDX (and
+/// FIELD_DIR, to resolve the arm) and fetches no page byte: the probe plus at
+/// most one section GET, `page_bytes_fetched == 0`, and no block decoded.
+///
+/// Non-vacuity: forcing `plan_skip_decidable` to return `false` drops this query
+/// onto the plan fallback, which fetches the object through the scan path; the
+/// BLOCKS-overlap assertion then fails on the chunk ranges it issues, and the
+/// carried footer disappears. The decode-time `page_bytes_fetched == 0` is
+/// corroboration, not the guard: it is zero for any plan branch that opens no
+/// cursor, which is why the read-shape assertions are checked first.
+#[tokio::test]
+async fn plan_segment_on_a_version_4_object_fetches_no_page_bytes() {
+    let recs = records();
+    let bytes = build_object(&recs);
+    let mem = store_with(&bytes).await;
+    let recording = RecordingStore::new(mem);
+    let store: Arc<dyn ObjectStoreBackend> = Arc::clone(&recording) as Arc<dyn ObjectStoreBackend>;
+
+    let fetcher = LogSegmentFetcher::new(Arc::clone(&store))
+        .with_block_range_threshold(0)
+        .with_block_range(ranged(store, &bytes));
+    let seg = seg_ref(bytes.len() as u64, &recs);
+    let query = LogQuery::new(i64::MIN, i64::MAX).with_prune(code_between(0, 0));
+    let acc = QueryAccounting::new();
+
+    let (survivors, stats, footer) = fetcher
+        .plan_segment(&seg, TENANT, &query, &acc)
+        .await
+        .expect("plan_segment")
+        .expect("relevant segment");
+
+    assert_eq!(survivors, 1, "the numeric arm keeps one block");
+    assert_eq!(stats.blocks_total, BLOCKS as u32);
+    assert_eq!(stats.blocks_scanned, 0, "no block decoded");
+    assert_eq!(
+        stats.page_bytes_fetched, 0,
+        "the plan phase touches no page"
+    );
+    assert_eq!(stats.page_bytes_decoded, 0);
+    assert_eq!(recording.full_gets(), 0, "no whole-object plan read");
+    assert_eq!(
+        recording.suffix_gets(),
+        1,
+        "one etag-establishing suffix probe"
+    );
+    // The read shape is what actually carries the "no page byte" claim: the
+    // decode-time counters above are zero for any plan branch that opens no
+    // cursor, so they are corroboration rather than the guard. Every GET this
+    // made must lie outside the BLOCKS section.
+    let (blocks_offset, blocks_len) = blocks_extent(&bytes);
+    for (start, end) in recording.ranges() {
+        assert!(
+            end <= blocks_offset || start >= blocks_offset + blocks_len,
+            "range [{start},{end}) reached into BLOCKS [{blocks_offset},{})",
+            blocks_offset + blocks_len
+        );
+    }
+    // The probe covers the whole tail here, so the only range GET left is
+    // FIELD_DIR at the object front, which no suffix can reach.
+    assert_eq!(
+        recording.ranges().len(),
+        1,
+        "at most one section GET beyond the probe: {:?}",
+        recording.ranges()
+    );
+    assert!(
+        footer.is_some(),
+        "the footer is carried forward so the scan skips its own probe"
+    );
+}
+
+// ---- 6. two partitions, one chunk, one GET --------------------------------
+
+/// Two partitions resolving the same chunk range collapse onto one store GET.
+///
+/// The pair is made genuinely concurrent by a [`FaultStore`] hold gate: both
+/// tasks are in flight when the leader's GET is held, and the held count is
+/// read at that instant. A warm-up read over a different ts window leaves the
+/// probe and every section cached, so the only cold extent left is the one
+/// chunk range this asserts about.
+///
+/// Non-vacuity: dropping `.with_cache(..)` from `br` removes the single-flight
+/// entirely, and both the held count (2) and the released-GET count (2) fail.
+#[tokio::test]
+async fn concurrent_partitions_reading_one_chunk_collapse_onto_one_get() {
+    let recs = records();
+    let bytes = build_object(&recs);
+    let mem = store_with(&bytes).await;
+    let faulty = Arc::new(FaultStore::new(mem, FaultPlan::empty()));
+    let store: Arc<dyn ObjectStoreBackend> = Arc::clone(&faulty) as Arc<dyn ObjectStoreBackend>;
+
+    // `ts` and `stream_ref` with the production coalescing gap: their two chunks
+    // and the `observed_ts` chunk between them fuse into ONE range per row
+    // group, so the cold stage below is a single GET and "held count 1" is a
+    // statement about the pair rather than about one fetch's own concurrency.
+    let sel = ColumnSelection::fixed_only();
+    let ids = resolved(&bytes, &sel).expect("a projection");
+    let gap = ravel_query::DEFAULT_LOG_COALESCE_GAP;
+    let seg = seg_ref(bytes.len() as u64, &recs);
+    let cache = read_cache();
+    let br = ranged(Arc::clone(&store), &bytes)
+        .with_coalesce_gap(gap)
+        .with_cache(Arc::clone(&cache));
+
+    // Warm-up over row group 0 only (ts 0..=1 is block 0): admits the probe and
+    // both front sections, leaving the cold window below with nothing uncached
+    // but its own chunk range.
+    let warm = QueryAccounting::new();
+    br.fetch_object_projected(&seg, TENANT, 0, 1, &sel, &warm)
+        .await
+        .expect("warm-up fetch");
+
+    // The cold window: the last block, which lives in the last row group.
+    let (cold_min, cold_max) = ((RECORDS - BLOCK_RECORDS) as i64, (RECORDS - 1) as i64);
+    let cold_runs = expected_runs(&bytes, &[BLOCKS - 1], Some(&ids), gap);
+    assert_eq!(
+        cold_runs.len(),
+        1,
+        "the cold stage must be exactly one chunk range: {cold_runs:?}"
+    );
+
+    let gate = faulty.hold(Op::Get, Some(KEY.to_string()), Occurrence::Always);
+    let acc = QueryAccounting::new();
+    let mut tasks = Vec::new();
+    for _ in 0..2 {
+        let br = br.clone();
+        let seg = seg.clone();
+        let sel = sel.clone();
+        let acc = acc.clone();
+        tasks.push(tokio::spawn(async move {
+            br.fetch_object_projected(&seg, TENANT, cold_min, cold_max, &sel, &acc)
+                .await
+                .map(|(_, stats)| stats)
+        }));
+    }
+
+    // Wait for the leader's GET to be held, then leave the follower ample time
+    // to arrive. With single-flight it subscribes to the leader's in-flight
+    // fetch and the held count stays 1; without it, it issues its own GET for
+    // the same extent and the count goes to 2.
+    // Bounded: a fetch shape that issues no GET at this stage at all must fail
+    // the test, not hang it.
+    let mut waited = 0u32;
+    while gate.held_count() == 0 {
+        assert!(
+            waited < 5_000,
+            "no store GET was ever held: the cold window issued none"
+        );
+        waited += 1;
+        tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+    }
+    tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+    assert_eq!(
+        gate.held_count(),
+        1,
+        "both partitions want the same chunk range; only one GET is in flight"
+    );
+
+    let mut released = 0u64;
+    let mut spins = 0u32;
+    loop {
+        for (id, _, _) in gate.held_details() {
+            if gate.release(id) {
+                released += 1;
+            }
+        }
+        if tasks.iter().all(|t| t.is_finished()) && gate.held_count() == 0 {
+            break;
+        }
+        assert!(spins < 5_000, "the fetch pair never finished draining");
+        spins += 1;
+        tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+    }
+    for t in tasks {
+        let stats = t.await.expect("join").expect("fetch");
+        assert!(!stats.whole_object);
+    }
+
+    assert_eq!(
+        released, 1,
+        "one store GET for the pair, not one per partition"
+    );
+    assert_eq!(
+        acc.snapshot().s3_requests(AccountedOp::Get),
+        1,
+        "and the accounting agrees"
+    );
+}
+
+// ---- 7. the probe covers the plan sections -------------------------------
+
+/// The default suffix probe covers footer + SKIP_IDX + PAGE_DIR on a
+/// full-row-group, wide object, so a predicated statement pays one probe per
+/// object and no second GET for the plan sections (issue #766).
+///
+/// The measured section sizes are printed, because the probe length is chosen
+/// from them: this test is the measurement that justifies
+/// `DEFAULT_LOG_SUFFIX_LEN`, not only a guard on it.
+///
+/// Non-vacuity: reverting `DEFAULT_LOG_SUFFIX_LEN` to the 64 KiB it was before
+/// #766 makes the tail exceed the probe and both the `tail <= suffix` assertion
+/// and `probe_misses == 0` fail.
+#[tokio::test]
+async fn probe_covers_the_plan_sections_on_a_wide_row_group_object() {
+    // A full default-sized row group (32 blocks) of a 105-column object: the
+    // ClickBench tenant's width at the writer's default grouping. Small blocks
+    // keep the fixture cheap; PAGE_DIR is sized by the PAGE COUNT (105 columns
+    // x 32 blocks x 2 groups), which is what this measures, not by the records
+    // behind them.
+    const COLUMNS: usize = 105;
+    const WIDE_GROUP_BLOCKS: usize = 32;
+    const WIDE_GROUPS: usize = 2;
+    const WIDE_BLOCK_RECORDS: usize = 2;
+
+    let cfg = RlogConfig {
+        block_target_records: WIDE_BLOCK_RECORDS,
+        group_target_blocks: WIDE_GROUP_BLOCKS,
+        ..RlogConfig::default()
+    };
+    let mut w = RlogWriter::new(cfg, identity());
+    let resource = vec![("service.name".to_string(), AttrValue::Str("svc".into()))];
+    let total = WIDE_GROUPS * WIDE_GROUP_BLOCKS * WIDE_BLOCK_RECORDS;
+    for i in 0..total {
+        let attrs: Vec<(String, AttrValue)> = (0..COLUMNS)
+            .map(|c| (format!("col{c:03}"), AttrValue::I64((i * c) as i64)))
+            .collect();
+        w.push(LogRecord {
+            stream_id: ravel_types::logstream::log_stream_id(&resource, "scope", "1.0", &[]),
+            stream_attrs: stream_attrs_bytes(&resource, "scope", "1.0", &[]),
+            ts_ns: i as i64,
+            observed_ts_ns: i as i64,
+            severity_num: 9,
+            severity_text: "INFO".into(),
+            body: filler(i as u64, 512),
+            trace_id: None,
+            span_id: None,
+            flags: 1,
+            attrs,
+        })
+        .expect("push");
+    }
+    let bytes = w.finish().expect("finish");
+
+    let f = footer_of(&bytes);
+    let size_of = |k: u32| f.section(k).map(|d| d.len).unwrap_or(0);
+    let skip = f.section(kind::SKIP_IDX).expect("SKIP_IDX");
+    let tail = bytes.len() as u64 - skip.offset;
+    let dir = page_dir_of(&bytes);
+    let pages: usize = dir
+        .groups
+        .iter()
+        .flat_map(|g| g.chunks.iter())
+        .map(|c| c.pages.len())
+        .sum();
+    eprintln!(
+        "[wide v4 object] total={} blocks={} groups={} pages={} | SKIP_IDX={} PAGE_DIR={} \
+         BLOOM={} POSTINGS={} footer+trailer={} | tail(SKIP_IDX..end)={} suffix={}",
+        bytes.len(),
+        dir.block_count(),
+        dir.groups.len(),
+        pages,
+        size_of(kind::SKIP_IDX),
+        size_of(kind::PAGE_DIR),
+        size_of(kind::BLOOM),
+        size_of(kind::POSTINGS),
+        bytes.len() as u64
+            - f.sections
+                .iter()
+                .map(|s| s.offset + s.len)
+                .max()
+                .unwrap_or(0),
+        tail,
+        ravel_query::DEFAULT_LOG_SUFFIX_LEN,
+    );
+
+    assert_eq!(dir.groups.len(), WIDE_GROUPS, "two full row groups");
+    assert!(
+        dir.groups[0].chunks.len() >= COLUMNS,
+        "the fixture must really be {COLUMNS} columns wide, got {}",
+        dir.groups[0].chunks.len()
+    );
+    assert!(
+        tail <= ravel_query::DEFAULT_LOG_SUFFIX_LEN,
+        "one suffix probe of {} B must cover footer + SKIP_IDX + PAGE_DIR (+ the \
+         BLOOM and POSTINGS sitting between them), which is {tail} B here",
+        ravel_query::DEFAULT_LOG_SUFFIX_LEN,
+    );
+
+    // And end to end: a plan-phase read of this object at production defaults
+    // reports no probe miss.
+    let mem = store_with(&bytes).await;
+    let recording = RecordingStore::new(mem);
+    let store: Arc<dyn ObjectStoreBackend> = Arc::clone(&recording) as Arc<dyn ObjectStoreBackend>;
+    let recs: Vec<LogRecord> = Vec::new();
+    let _ = recs;
+    let seg = SegmentRef {
+        object_size: bytes.len() as u64,
+        min_event_ts_ns: 0,
+        max_event_ts_ns: total as i64,
+        sample_count: total as u64,
+        ..seg_ref(bytes.len() as u64, &[record(0)])
+    };
+    let acc = QueryAccounting::new();
+    let (_footer, _skip, _fd, stats) = BlockRangeFetcher::new(store)
+        .with_whole_object_threshold(0)
+        .fetch_plan_sections(&seg, TENANT, &acc)
+        .await
+        .expect("plan sections");
+    assert_eq!(stats.probe_gets, 1, "one probe");
+    assert_eq!(
+        stats.probe_misses, 0,
+        "the default probe covered SKIP_IDX and PAGE_DIR"
+    );
+    assert!(
+        recording.ranges().len() <= 1,
+        "at most one section GET beyond the probe, and only ever FIELD_DIR at \
+         the object front: {:?}",
+        recording.ranges()
+    );
+}
+
+// ---- 8. the chunk read decodes what a whole-object read decodes ------------
+
+/// The differential: for every projection, what the chunk path decodes equals
+/// what a whole-object read of the same object decodes, record for record.
+///
+/// Non-vacuity: with the interim whole-object guard restored both sides are the
+/// same whole-object read and the test cannot fail; it is meaningful only
+/// because the left side now fetches a strict subset of the object's bytes,
+/// which the byte assertion states.
+#[tokio::test]
+async fn version_4_chunk_read_decodes_what_a_whole_object_read_decodes() {
+    let recs = records();
+    let bytes = build_object(&recs);
+    let store: Arc<dyn ObjectStoreBackend> = store_with(&bytes).await;
+    let seg = seg_ref(bytes.len() as u64, &recs);
+    let query = LogQuery::new(i64::MIN, i64::MAX);
+
+    // `narrow` says whether the selection drops the object's dominant column
+    // (`body`, which is 8 KiB per record against a few bytes for everything
+    // else). Only a narrow selection is expected to move fewer bytes than the
+    // object: a selection that keeps `body` covers most of BLOCKS, so the 75%
+    // coverage crossover fires and the read is a probe plus one whole-object
+    // GET, which is MORE bytes than a plain whole-object read.
+    for (sel, narrow) in [
+        (ColumnSelection::all(), false),
+        (ColumnSelection::fixed_only(), true),
+        (ColumnSelection::fixed_only().with_flags(), true),
+        (
+            ColumnSelection::fixed_only()
+                .with_body()
+                .with_severity_num(),
+            false,
+        ),
+        (ColumnSelection::fixed_only().with_attr(CODE_COL), true),
+        (ColumnSelection::fixed_only().with_all_attrs(), true),
+    ] {
+        // Whole object in one GET, the pre-ADR-0699 read shape.
+        let whole = LogSegmentFetcher::new(Arc::clone(&store));
+        let mut want = Vec::new();
+        let mut scan = whole
+            .scan_accounted_with_tenant(&seg, TENANT, &query, &sel, &QueryAccounting::new())
+            .await
+            .expect("whole scan")
+            .expect("in range");
+        while let Some(rows) = scan.next_block().expect("decode") {
+            want.extend(rows);
+        }
+
+        let acc = QueryAccounting::new();
+        let chunked = LogSegmentFetcher::new(Arc::clone(&store))
+            .with_block_range_threshold(0)
+            .with_block_range(ranged(Arc::clone(&store), &bytes));
+        let mut got = Vec::new();
+        let mut scan = chunked
+            .scan_accounted_with_tenant(&seg, TENANT, &query, &sel, &acc)
+            .await
+            .expect("chunk scan")
+            .expect("in range");
+        while let Some(rows) = scan.next_block().expect("decode") {
+            got.extend(rows);
+        }
+
+        assert_eq!(got.len(), RECORDS, "every record comes back");
+        assert_eq!(got, want, "chunk read == whole-object read for {sel:?}");
+        if narrow {
+            let moved = acc.snapshot().total_s3_bytes();
+            assert!(
+                moved < bytes.len() as u64,
+                "a projected chunk read moves fewer bytes than the object \
+                 ({moved} vs {}) for {sel:?}",
+                bytes.len()
+            );
+        }
+    }
+}

--- a/crates/ravel-sql/src/logs_scan.rs
+++ b/crates/ravel-sql/src/logs_scan.rs
@@ -574,6 +574,15 @@ struct BlockMetrics {
     /// query (an `attrs` projection, a pending erasure predicate) or an
     /// eligible one that hit a block carrying an `attrs_raw` overflow page.
     rowpath_batches: Count,
+    /// Relevant segments whose plan phase had to read the whole object rather
+    /// than counting survivors from the skip index (#761). Two causes: a
+    /// predicate the skip index cannot decide (a `has_word`/text content arm,
+    /// which only bloom prunes and only at decode; an attribute-equality
+    /// POSTINGS prune; a stream filter), or an object at or below the
+    /// block-range threshold, which the fetch reads whole in one GET regardless.
+    /// Published once by partition 0, so a report can tell a fully-skip-planned
+    /// query from one still paying the plan-phase read.
+    plan_full_reads: Count,
 }
 
 impl BlockMetrics {
@@ -587,6 +596,7 @@ impl BlockMetrics {
             pages_skipped: MetricBuilder::new(metrics).counter("pages_skipped", partition),
             columnar_batches: MetricBuilder::new(metrics).counter("columnar_batches", partition),
             rowpath_batches: MetricBuilder::new(metrics).counter("rowpath_batches", partition),
+            plan_full_reads: MetricBuilder::new(metrics).counter("plan_full_reads", partition),
         }
     }
 
@@ -1117,6 +1127,13 @@ impl ExecutionPlan for LogsScanExec {
 struct PlanCounts {
     segs: Vec<Option<SegPlan>>,
     total_blocks: usize,
+    /// Relevant segments the plan phase read whole instead of counting from the
+    /// skip index (#761). A segment planned from footer alone or from the skip
+    /// index carries its plan footer forward (`SegPlan::footer` is `Some`); the
+    /// whole-object fallback carries none, so this is the count of relevant
+    /// segments with no footer, published as the `plan_full_reads` metric (see
+    /// [`BlockMetrics::plan_full_reads`] for the two causes).
+    full_reads: usize,
 }
 
 /// One relevant segment's contribution to [`PlanCounts`].
@@ -1193,10 +1210,16 @@ async fn compute_plan_counts(
         .await?;
     let mut segs = Vec::with_capacity(segments.len());
     let mut total_blocks = 0usize;
+    let mut full_reads = 0usize;
     for entry in planned {
         match entry {
             Some((survivors, stats, footer)) => {
                 total_blocks += survivors;
+                // A relevant segment planned from the skip index carries its
+                // footer forward; the whole-object fallback (#761) carries none.
+                if footer.is_none() {
+                    full_reads += 1;
+                }
                 segs.push(Some(SegPlan {
                     survivors,
                     stats,
@@ -1206,7 +1229,11 @@ async fn compute_plan_counts(
             None => segs.push(None),
         }
     }
-    Ok(Arc::new(PlanCounts { segs, total_blocks }))
+    Ok(Arc::new(PlanCounts {
+        segs,
+        total_blocks,
+        full_reads,
+    }))
 }
 
 /// One segment this partition owns blocks in, and the block-index list (into
@@ -1685,6 +1712,7 @@ impl Stream for LogScanStream {
                             for plan in counts.segs.iter().flatten() {
                                 this.blocks.record_segment_totals(&plan.stats);
                             }
+                            this.blocks.plan_full_reads.add(counts.full_reads);
                         }
                         this.work = owned_work(
                             &counts,

--- a/crates/ravel-sql/tests/logs_selective_scan_amplification.rs
+++ b/crates/ravel-sql/tests/logs_selective_scan_amplification.rs
@@ -574,12 +574,13 @@ async fn selective_numeric_reads_only_surviving_blocks() {
         q37.bytes,
         q37_block_bytes
     );
-    // 165,355 = 99,112 page bytes (8 surviving blocks x 12,389 B of pages across
-    // their eight column chunks) + 65,536 probe bytes (8 x 8 KiB) + 672
-    // front-section bytes (8 x (STREAM_DIR 62 + FIELD_DIR 22)). The page term is
-    // 15% of the full scan; the probe term is the fixed per-object directory
-    // cost, which on this deliberately tiny fixture is 40% of the total and on a
-    // production 1.3 MB object is a rounding error.
+    // 165,355 = 99,147 page bytes (the 8 surviving blocks' pages across their
+    // eight column chunks; blocks differ slightly in encoded size, so the term
+    // is the measured sum, not blocks x a constant) + 65,536 probe bytes
+    // (8 x 8 KiB) + 672 front-section bytes (8 x (STREAM_DIR 62 + FIELD_DIR
+    // 22)). The page term is 15% of the full scan; the probe term is the fixed
+    // per-object directory cost, which on this deliberately tiny fixture is
+    // 40% of the total and on a production 1.3 MB object is a rounding error.
     assert_eq!(
         q37.bytes, 165_355,
         "q37 moves the surviving blocks' page bytes plus the probe and the two \
@@ -691,8 +692,9 @@ async fn text_predicate_falls_back_to_full_object_read() {
     assert_eq!(text.rows, SEGMENTS, "one matching record per segment");
     // The whole objects are read: bytes ~ a full scan plus the probes, the
     // amplification #761 cannot remove for a text predicate. 715,612 = 649,900
-    // object bytes + 65,536 probe bytes (8 x 8 KiB), the plan phase's probe on
-    // top of the whole-object read its fallback then issues.
+    // object bytes + 65,536 probe bytes (8 x 8 KiB) + 176 FIELD_DIR bytes
+    // (8 x 22, read to resolve the arms before the fallback decides), the plan
+    // phase's cost on top of the whole-object read its fallback then issues.
     let full = measure("full_scan", &[], cache).await;
     assert_eq!(
         text.bytes, 715_612,

--- a/crates/ravel-sql/tests/logs_selective_scan_amplification.rs
+++ b/crates/ravel-sql/tests/logs_selective_scan_amplification.rs
@@ -1,38 +1,35 @@
-//! Reproduction fixture for issue #761: a selective logs statement moves as many
-//! object-store GETs and as many bytes as a predicate-free full scan of the same
-//! data, even though it decodes only a fraction of the blocks.
+//! Regression fixture for issue #761: a selective logs statement must move
+//! object-store bytes proportional to the blocks it keeps, not the full-scan
+//! bytes it once did.
 //!
-//! Root cause, from the code (`ravel_query::log_fetcher` and
-//! `ravel_sql::logs_scan`):
+//! The mechanism (`ravel_query::log_fetcher` and `ravel_sql::logs_scan`):
 //!
-//! - A query carrying any block-level predicate (a `has_word` content arm here,
-//!   a declared-column equality/`NumRange` prune arm for the ClickBench q20/q37
-//!   shapes) is NOT `LogQuery::is_block_predicate_free`, so `LogsScanExec` takes
-//!   the plan-then-stripe path, never #693's whole-segment fast path. The plan
-//!   phase (`compute_plan_counts` -> `LogSegmentFetcher::plan_segment`, slow
-//!   branch) fetches every relevant segment once, cold, before any partition
-//!   drains a block.
-//! - Above the block-range threshold that fetch is `BlockRangeFetcher::
-//!   fetch_object_with_footer`, whose candidate set is resolved by
-//!   `resolve_extents` -> `SkipIndex::candidate_blocks(ts_min, ts_max, None, &[])`.
-//!   It passes NO numeric/prune arms and NO stream refs: candidate selection is
-//!   ts-only. For a full (or month-wide) window every block is a ts candidate, so
-//!   the coverage crossover (candidate_bytes / BLOCKS-section bytes >= 0.75)
-//!   fires and one whole-object GET is issued. The selective predicate prunes
-//!   blocks only later, at DECODE, so it shrinks `blocks_scanned` but not the
-//!   bytes fetched.
+//! - A query carrying a block-level predicate (a declared-column `NumRange`
+//!   prune arm for the ClickBench q20/q37 shapes, or a `has_word` content arm) is
+//!   NOT `LogQuery::is_block_predicate_free`, so `LogsScanExec` takes the
+//!   plan-then-stripe path, never #693's whole-segment fast path. The plan phase
+//!   (`compute_plan_counts` -> `LogSegmentFetcher::plan_segment`) runs once per
+//!   segment before any partition drains a block.
+//! - Before #761 the plan slow branch read every segment WHOLE, and the scan's
+//!   `BlockRangeFetcher::fetch_object_with_footer` resolved candidates by
+//!   `SkipIndex::candidate_blocks(ts_min, ts_max, None, &[])` -- no numeric arms,
+//!   so every block was a ts candidate, the coverage crossover fired, and one
+//!   whole-object GET was issued. The selective predicate pruned blocks only at
+//!   DECODE, shrinking `blocks_scanned` but not the bytes fetched. That was
+//!   q37's "19,690 GETs / 11.7 GB to scan 144 of 17,731 blocks" against a full
+//!   scan's "8,424 GETs / 11.1 GB".
+//! - After #761 the NumRange arm is resolved against each object's FIELD_DIR and
+//!   applied to `candidate_blocks` both at fetch (so the scan reads only
+//!   surviving blocks) and in the plan phase (so it counts survivors from the
+//!   skip index and fetches no block, carrying the footer forward). A text
+//!   predicate the skip index cannot decide still falls back to a whole-object
+//!   read, counted in the `plan_full_reads` metric.
 //!
-//! Net: the selective query pays the full-scan's whole-object read PLUS a suffix
-//! probe per segment (the fast path pays neither), and decodes a fraction of the
-//! blocks. That is q37's "19,690 GETs / 11.7 GB to scan 144 of 17,731 blocks"
-//! against the full scan's "8,424 GETs / 11.1 GB", reproduced here as a ratio.
-//!
-//! The whole-object reads are served from a cache large enough to hold the whole
-//! fixture, so the plan-phase reads are the deterministic cost this test pins.
-//! `selective_reread_amplifies_bytes_under_cache_pressure` then shrinks the cache
-//! to show the scan-phase re-reads that push q20 past the object bytes on the
-//! wire (17.9 GB > 11.1 GB of objects); it asserts only the direction of the
-//! effect, because the exact figure is eviction- and scheduling-dependent.
+//! `selective_numeric_reads_only_surviving_blocks` pins the fixed numeric shapes
+//! (byte cost proportional to the surviving fraction; the >= 75% coverage
+//! crossover preserved). `text_predicate_falls_back_to_full_object_read` pins the
+//! deliberately-kept fallback. `selective_third_no_partition_multiplication_\
+//! under_cache_pressure` pins that eviction no longer re-reads whole objects.
 
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
@@ -53,7 +50,7 @@ use ravel_object_store::{
     PageToken, PutOptions, PutOutcome, StoreError,
 };
 use ravel_query::{BlockRangeFetcher, CacheFetchError, LogSegmentFetcher};
-use ravel_sql::{LogsTableProvider, has_word_udf};
+use ravel_sql::{DeclaredColumn, DeclaredType, LogsTableProvider, has_word_udf};
 use ravel_types::TenantHash;
 use ravel_types::accounting::{AccountedOp, QueryAccounting};
 use uuid::Uuid;
@@ -65,9 +62,10 @@ const TENANT: [u8; 16] = [7u8; 16];
 /// `relevant_segments >= target_partitions` conjunct.
 const SEGMENTS: usize = 8;
 const PARTS: usize = 8;
-/// Blocks per segment (one record per block). 6 so a `has_word` marker placed in
-/// one block per segment survives ~1/6 of the blocks (the very-selective q37
-/// shape) and a marker in two blocks survives ~1/3 (the q20 shape).
+/// Blocks per segment (one record per block). 6 so a `code = 0` arm keeps one
+/// block per segment (the very-selective q37 shape, 8/48), `code <= 1` keeps two
+/// (the q20 shape, 16/48), and `code <= 4` keeps five (40/48, above the 0.75
+/// coverage crossover).
 const BLOCKS_PER_SEG: usize = 6;
 const TOTAL_BLOCKS: usize = SEGMENTS * BLOCKS_PER_SEG;
 
@@ -81,13 +79,19 @@ const BODY_BYTES: usize = 16 * 1024;
 /// the coverage crossover issues, not the probe.
 const SUFFIX_LEN: u64 = 256;
 
-/// A marker word present in exactly the first block of every segment: a
-/// `has_word` query for it survives one block per segment (SEGMENTS of
-/// TOTAL_BLOCKS), the very-selective q37 shape.
+/// A marker word present in exactly the first block of every segment. A
+/// `has_word` query for it survives one block per segment, but bloom is a
+/// DECODE-only prune: the skip index cannot decide a text predicate, so this
+/// shape exercises the plan-phase whole-object fallback (`plan_full_reads`) that
+/// #761 could not remove.
 const MARKER_FEW: &str = "MARKERFEW";
-/// A marker word present in the first two blocks of every segment: ~1/3 of the
-/// blocks survive, the q20 shape.
-const MARKER_THIRD: &str = "MARKERTHIRD";
+
+/// The declared numeric column every record carries: `code = <block index>`
+/// (0..BLOCKS_PER_SEG). A `NumRange` prune arm on it (ClickBench q20/q37 shape)
+/// is skip-index decidable, so #761's fetch-side pruning applies. `code = 0`
+/// keeps one block per segment (q37); `code <= 1` keeps two (q20); `code <= 4`
+/// keeps five of six, above the coverage crossover.
+const CODE_COL: &str = "code";
 
 fn identity(seq: u64) -> ObjectIdentity {
     ObjectIdentity {
@@ -124,16 +128,13 @@ fn filler(seed: u64, len: usize) -> String {
     out
 }
 
-/// Body for block `blk` of segment `seg`: the block's markers (if any) as leading
-/// words, then unique filler so bloom pruning can isolate the marked block.
+/// Body for block `blk` of segment `seg`: the text marker (block 0 only) as a
+/// leading word, then unique filler so bloom pruning can isolate the marked
+/// block at decode.
 fn body(seg: usize, blk: usize) -> String {
     let mut head = String::new();
     if blk == 0 {
         head.push_str(MARKER_FEW);
-        head.push(' ');
-    }
-    if blk < 2 {
-        head.push_str(MARKER_THIRD);
         head.push(' ');
     }
     let seed = (seg as u64) << 32 | blk as u64;
@@ -157,7 +158,9 @@ fn record(seg: usize, blk: usize) -> LogRecord {
         trace_id: None,
         span_id: None,
         flags: 0,
-        attrs: Vec::new(),
+        // The declared numeric column: one distinct value per block, so a
+        // `NumRange` arm selects an exact block subset the skip index can prune.
+        attrs: vec![(CODE_COL.to_string(), AttrValue::I64(blk as i64))],
     }
 }
 
@@ -314,22 +317,17 @@ fn provider(
     acc: QueryAccounting,
 ) -> LogsTableProvider {
     LogsTableProvider::new(snapshot, TenantHash(TENANT), fetcher, acc)
+        .with_declared_columns(vec![DeclaredColumn::new(CODE_COL, DeclaredType::I64)])
 }
 
 fn find_scan(plan: &Arc<dyn ExecutionPlan>) -> Arc<dyn ExecutionPlan> {
-    if plan.name() == "LogsScanExec" {
-        return Arc::clone(plan);
+    fn walk(plan: &Arc<dyn ExecutionPlan>) -> Option<Arc<dyn ExecutionPlan>> {
+        if plan.name() == "LogsScanExec" {
+            return Some(Arc::clone(plan));
+        }
+        plan.children().iter().find_map(|c| walk(c))
     }
-    plan.children()
-        .iter()
-        .find_map(|c| {
-            if c.name() == "LogsScanExec" {
-                Some(Arc::clone(c))
-            } else {
-                Some(find_scan(c))
-            }
-        })
-        .expect("a LogsScanExec leaf")
+    walk(plan).expect("a LogsScanExec leaf")
 }
 
 fn sum_metric(plan: &Arc<dyn ExecutionPlan>, name: &str) -> usize {
@@ -351,6 +349,16 @@ fn has_word(marker: &str) -> Expr {
     has_word_udf().call(vec![col("body"), lit(marker)])
 }
 
+/// `code = v`: a point `NumRange` arm keeping the one block whose value is `v`.
+fn code_eq(v: i64) -> Expr {
+    col(CODE_COL).eq(lit(v))
+}
+
+/// `code <= v`: an upper-bounded `NumRange` arm keeping blocks `0..=v`.
+fn code_le(v: i64) -> Expr {
+    col(CODE_COL).lt_eq(lit(v))
+}
+
 /// One measured shape.
 struct Shape {
     label: &'static str,
@@ -361,6 +369,7 @@ struct Shape {
     blocks_scanned: usize,
     blocks_total: usize,
     rows: usize,
+    plan_full_reads: usize,
     acc_gets: u64,
     acc_bytes: u64,
 }
@@ -388,6 +397,7 @@ async fn measure(label: &'static str, filters: &[Expr], cache_bytes: u64) -> Sha
         blocks_scanned: sum_metric(&plan, "blocks_scanned"),
         blocks_total: sum_metric(&plan, "blocks_total"),
         rows,
+        plan_full_reads: sum_metric(&plan, "plan_full_reads"),
         acc_gets: snap.s3_requests(AccountedOp::Get),
         acc_bytes: snap.total_s3_bytes(),
     }
@@ -396,7 +406,7 @@ async fn measure(label: &'static str, filters: &[Expr], cache_bytes: u64) -> Sha
 fn report(s: &Shape) {
     eprintln!(
         "[{}] gets={} (full={} suffix={}) bytes={} blocks_scanned={}/{} rows={} \
-         | accounting: gets={} bytes={}",
+         plan_full_reads={} | accounting: gets={} bytes={}",
         s.label,
         s.gets,
         s.full_gets,
@@ -405,30 +415,41 @@ fn report(s: &Shape) {
         s.blocks_scanned,
         s.blocks_total,
         s.rows,
+        s.plan_full_reads,
         s.acc_gets,
         s.acc_bytes,
     );
 }
 
-/// The headline of issue #761: a selective statement issues MORE object-store
-/// GETs and reads roughly the SAME bytes as a predicate-free full scan of the
-/// same data, while decoding a small fraction of the blocks.
+/// The #761 fix on the selective (q37/q20) shapes: a `NumRange` prune arm the
+/// skip index can decide reads only the surviving blocks, not the whole object.
+/// The plan phase counts survivors from the skip index (one suffix probe per
+/// segment, no whole-object GET), the scan reads only the surviving blocks, and
+/// the byte cost is proportional to the surviving fraction rather than equal to
+/// a full scan. A shape whose survivors cover >= 75% of a segment still takes
+/// the coverage crossover into a whole-object GET, so the crossover is pinned
+/// too.
 #[tokio::test]
-async fn selective_scan_costs_more_gets_and_equal_bytes_as_full_scan() {
+async fn selective_numeric_reads_only_surviving_blocks() {
     // Cache large enough to hold the whole fixture with no eviction, so the
-    // deterministic cost is exactly the plan phase's cold reads.
+    // deterministic cost is exactly the cold plan + scan reads.
     let cache = 64 << 20;
 
     let full = measure("full_scan", &[], cache).await;
-    let q37 = measure("selective_few (q37)", &[has_word(MARKER_FEW)], cache).await;
-    let q20 = measure("selective_third (q20)", &[has_word(MARKER_THIRD)], cache).await;
+    // q37: one block per segment survives (8 of 48).
+    let q37 = measure("selective_few (q37)", &[code_eq(0)], cache).await;
+    // q20: two blocks per segment survive (16 of 48).
+    let q20 = measure("selective_third (q20)", &[code_le(1)], cache).await;
+    // Five of six blocks per segment survive (40 of 48): above the 0.75
+    // coverage crossover, so each scanned segment is still read whole.
+    let high = measure("high_coverage (>=75%)", &[code_le(4)], cache).await;
     report(&full);
     report(&q37);
     report(&q20);
+    report(&high);
 
-    // QueryAccounting agrees with the raw store counters on both axes: the
-    // deliverable's figures are the ones the engine records.
-    for s in [&full, &q37, &q20] {
+    // QueryAccounting agrees with the raw store counters on both axes.
+    for s in [&full, &q37, &q20, &high] {
         assert_eq!(
             s.acc_gets, s.gets,
             "{}: accounting GET count == store GETs",
@@ -447,89 +468,199 @@ async fn selective_scan_costs_more_gets_and_equal_bytes_as_full_scan() {
     }
 
     // Full scan: #693 whole-segment fast path. One whole-object GET per segment,
-    // zero suffix probes, every block scanned.
+    // zero suffix probes, every block scanned. Unchanged by #761.
     assert_eq!(
         full.full_gets, SEGMENTS as u64,
         "full scan: one whole-object GET per segment"
     );
+    assert_eq!(full.suffix_gets, 0, "full scan: no suffix probes");
     assert_eq!(
-        full.suffix_gets, 0,
-        "full scan: fast path issues no suffix probes"
+        full.gets, SEGMENTS as u64,
+        "full scan: exactly one GET per segment and nothing else"
     );
     assert_eq!(
         full.blocks_scanned, TOTAL_BLOCKS,
         "full scan decodes every block"
     );
+    assert_eq!(full.rows, TOTAL_BLOCKS, "full scan returns every record");
+    assert_eq!(
+        full.bytes, 650_087,
+        "full scan reads exactly the object bytes (the fixture now carries a \
+         declared numeric column per record, so the objects are marginally \
+         larger than the pre-#761 reproduction's 649,653)"
+    );
+    assert_eq!(full.plan_full_reads, 0, "full scan skips the plan phase");
 
-    // Selective (q37 shape): plan-then-stripe. The plan phase probes every
-    // segment (SEGMENTS suffix GETs) and the coverage crossover reads every
-    // segment whole (SEGMENTS full GETs); the cache absorbs the scan-phase
-    // re-reads. So it issues ~2x the full scan's GETs, and reads a whole object
-    // per segment despite decoding only ~1/BLOCKS_PER_SEG of the blocks.
+    // q37: the plan phase decides every segment from the skip index (one suffix
+    // probe per segment, no whole-object GET, no plan_full_reads), and the scan
+    // reads only the one surviving block per segment. NumRange is skip-decidable,
+    // so nothing falls back to a whole-object read.
     assert_eq!(
         q37.suffix_gets, SEGMENTS as u64,
-        "q37: one plan-phase probe per segment"
+        "q37: one plan-phase probe per segment, and the scan reuses the carried \
+         footer (no scan-phase probe)"
     );
     assert_eq!(
-        q37.full_gets, SEGMENTS as u64,
-        "q37: coverage crossover reads each segment whole"
+        q37.full_gets, 0,
+        "q37: no whole-object GET anywhere -- the numeric arm pruned the \
+         candidate set below the coverage crossover"
+    );
+    assert_eq!(
+        q37.plan_full_reads, 0,
+        "q37: the plan phase counted survivors from the skip index, fetching no \
+         block"
+    );
+    // Exact GET count: 8 suffix probes (plan) + the per-segment directory and
+    // single-block range reads the scan issues, with the 64 MiB cache absorbing
+    // every re-touch. No whole-object GET anywhere.
+    assert_eq!(q37.gets, 56, "q37: exact GET count with no eviction");
+    assert_eq!(
+        q37.blocks_scanned, SEGMENTS,
+        "q37 decodes exactly one block per segment"
+    );
+    assert_eq!(q37.rows, SEGMENTS, "q37 returns one record per segment");
+    // Bytes proportional to the 8 of 48 surviving blocks (plus per-segment
+    // directory reads and 8 suffix probes), a small fraction of a full scan --
+    // NOT the full-scan bytes the pre-#761 whole-object read moved. The upper
+    // bound fails if the fetch reads whole objects (the flip), the lower bound
+    // fails if it somehow reads fewer than the surviving blocks.
+    let q37_block_bytes = full.bytes * (SEGMENTS as u64) / (TOTAL_BLOCKS as u64);
+    assert!(
+        q37.bytes >= q37_block_bytes,
+        "q37 reads at least its surviving-block bytes ({} vs {})",
+        q37.bytes,
+        q37_block_bytes
     );
     assert!(
-        q37.gets > full.gets,
-        "q37 issues more GETs than the full scan ({} vs {})",
-        q37.gets,
-        full.gets
-    );
-    // Same bytes as the full scan (within the tiny suffix-probe overhead), even
-    // though it decodes far fewer blocks: the selective predicate never reached
-    // the fetch's candidate set.
-    assert!(
-        q37.bytes >= full.bytes
-            && q37.bytes <= full.bytes + (SEGMENTS as u64) * SUFFIX_LEN + full.bytes / 20,
-        "q37 reads ~the full-scan bytes ({} vs {})",
+        q37.bytes <= full.bytes * 2 / 5,
+        "q37 reads well under a full scan ({} vs {}), proportional to 8/48",
         q37.bytes,
         full.bytes
     );
+
+    // q20: two surviving blocks per segment. Same plan shape as q37; the scan
+    // reads twice as many blocks, so more bytes, still far under a full scan.
+    assert_eq!(
+        q20.suffix_gets, SEGMENTS as u64,
+        "q20: one probe per segment"
+    );
+    assert_eq!(q20.full_gets, 0, "q20: no whole-object GET");
+    assert_eq!(q20.plan_full_reads, 0, "q20: skip-index plan");
+    assert_eq!(q20.gets, 56, "q20: exact GET count with no eviction");
+    assert_eq!(
+        q20.blocks_scanned,
+        SEGMENTS * 2,
+        "q20 decodes two blocks per segment"
+    );
+    assert_eq!(
+        q20.rows,
+        SEGMENTS * 2,
+        "q20 returns two records per segment"
+    );
+    let q20_block_bytes = full.bytes * (2 * SEGMENTS as u64) / (TOTAL_BLOCKS as u64);
     assert!(
-        q37.blocks_scanned <= SEGMENTS * 2,
-        "q37 decodes ~one block per segment (got {})",
-        q37.blocks_scanned
+        q20.bytes >= q20_block_bytes,
+        "q20 reads at least its surviving-block bytes ({} vs {})",
+        q20.bytes,
+        q20_block_bytes
     );
     assert!(
-        (q37.blocks_scanned as f64) < (full.blocks_scanned as f64) / 2.0,
-        "q37 decodes far fewer blocks than the full scan ({} vs {})",
-        q37.blocks_scanned,
-        full.blocks_scanned
+        q20.bytes <= full.bytes * 3 / 5,
+        "q20 reads under a full scan ({} vs {}), proportional to 16/48",
+        q20.bytes,
+        full.bytes
+    );
+    assert!(
+        q20.bytes > q37.bytes,
+        "q20 reads more than q37 ({} vs {}): twice the surviving blocks",
+        q20.bytes,
+        q37.bytes
     );
 
-    // q20 shape (~1/3 of blocks survive): same fetch cost, more blocks decoded.
-    assert_eq!(q20.suffix_gets, SEGMENTS as u64);
-    assert_eq!(q20.full_gets, SEGMENTS as u64);
-    assert!(
-        q20.bytes >= full.bytes,
-        "q20 reads at least the full-scan bytes"
+    // High coverage (>= 75%): the numeric arm still prunes to five of six
+    // blocks, but that clears the 0.75 coverage crossover, so each scanned
+    // segment is read WHOLE -- one full GET per segment. The crossover is
+    // preserved by #761, not bypassed.
+    assert_eq!(
+        high.full_gets, SEGMENTS as u64,
+        "high coverage: the crossover still reads each scanned segment whole"
     );
+    assert_eq!(
+        high.plan_full_reads, 0,
+        "high coverage: the plan phase is still skip-index only (the crossover \
+         is a scan-phase decision)"
+    );
+    assert_eq!(
+        high.blocks_scanned,
+        SEGMENTS * 5,
+        "high coverage decodes five blocks per segment"
+    );
+    assert_eq!(high.rows, SEGMENTS * 5, "high coverage returns 40 records");
+}
+
+/// A text predicate (`has_word`) is bloom-pruned only at DECODE: the skip index
+/// cannot decide it, so #761's fetch-side pruning does not apply. The plan phase
+/// falls back to a whole-object read per segment (`plan_full_reads`), the scan
+/// still reads the whole object, and only the byte-decode is reduced (bloom
+/// leaves one block per segment). This pins the fallback the fix deliberately
+/// keeps for shapes the skip index cannot prune.
+#[tokio::test]
+async fn text_predicate_falls_back_to_full_object_read() {
+    let cache = 64 << 20;
+    let text = measure("text_fallback (has_word)", &[has_word(MARKER_FEW)], cache).await;
+    report(&text);
+
+    assert_eq!(
+        text.plan_full_reads, SEGMENTS,
+        "every relevant segment's plan phase read the whole object: the skip \
+         index cannot decide a text predicate"
+    );
+    assert_eq!(
+        text.full_gets, SEGMENTS as u64,
+        "the whole-object read the plan fallback issues, one per segment"
+    );
+    assert_eq!(
+        text.blocks_scanned, SEGMENTS,
+        "bloom still prunes to one block per segment at decode"
+    );
+    assert_eq!(text.rows, SEGMENTS, "one matching record per segment");
+    // The whole objects are read: bytes ~ a full scan, the amplification #761
+    // cannot remove for a text predicate.
+    let full = measure("full_scan", &[], cache).await;
     assert!(
-        q20.blocks_scanned >= q37.blocks_scanned,
-        "q20 decodes more blocks than q37 ({} vs {})",
-        q20.blocks_scanned,
-        q37.blocks_scanned
+        text.bytes >= full.bytes,
+        "text predicate still moves the full-object bytes ({} vs {})",
+        text.bytes,
+        full.bytes
     );
 }
 
-/// q20's other half: on a cache too small to hold the working set, the
-/// plan-phase whole-object reads are evicted before the scan phase re-reads
-/// them, so bytes on the wire exceed the object bytes (the reference's
-/// 17.9 GB > 11.1 GB). Only the direction is asserted: the exact figure is
-/// eviction- and scheduling-dependent, so this is not a byte-exact pin.
+/// The q20 shape under a cache too small to hold the working set: eviction can
+/// only add reads, but with #761 each surviving block is read at most once per
+/// scan, so the GET count does NOT multiply by the partition count the way the
+/// pre-fix whole-object re-reads did. Bounds the per-segment scan reads rather
+/// than pinning a single eviction-dependent figure.
 #[tokio::test]
-async fn selective_reread_amplifies_bytes_under_cache_pressure() {
-    let big = measure("q20_big_cache", &[has_word(MARKER_THIRD)], 64 << 20).await;
-    // A cache far smaller than the fixture's object bytes: plan-phase reads are
-    // evicted before the scan phase re-reads them.
-    let small = measure("q20_small_cache", &[has_word(MARKER_THIRD)], 32 << 10).await;
+async fn selective_third_no_partition_multiplication_under_cache_pressure() {
+    let big = measure("q20_big_cache", &[code_le(1)], 64 << 20).await;
+    // A cache far smaller than the fixture's object bytes.
+    let small = measure("q20_small_cache", &[code_le(1)], 32 << 10).await;
     report(&big);
     report(&small);
+
+    // No whole-object GET under either cache: the numeric arm keeps coverage
+    // below the crossover regardless of eviction.
+    assert_eq!(big.full_gets, 0, "q20 big cache: no whole-object GET");
+    assert_eq!(small.full_gets, 0, "q20 small cache: no whole-object GET");
+
+    // The plan phase's footer is carried in memory, not through the read cache,
+    // so eviction cannot make a subset open re-probe: one probe per segment
+    // under either cache size.
+    assert_eq!(
+        small.suffix_gets, SEGMENTS as u64,
+        "q20 small cache: still one probe per segment, the carried footer is \
+         not cache-resident state"
+    );
 
     // Eviction can only add reads, never remove them.
     assert!(
@@ -538,11 +669,23 @@ async fn selective_reread_amplifies_bytes_under_cache_pressure() {
         small.gets,
         big.gets
     );
+
+    // The decisive #761 bound: the bytes never reach even a single full scan of
+    // the objects. Each surviving block is owned by exactly one partition (the
+    // ADR-0102 stripe) and the plan phase decodes no block, so every surviving
+    // block is read once regardless of eviction; only the small directory
+    // sections are ever re-fetched. So the 17.9 GB > 11.1 GB whole-object
+    // re-read amplification the reproduction showed (bytes ~ 3x the object
+    // bytes) is gone: bytes stay below one full pass. Bytes, not GET count, is
+    // pinned here -- the raw GET count under eviction is scheduling-dependent,
+    // but no GET is ever a whole-object read (asserted above), so partitions
+    // cannot multiply the object bytes.
+    let full = measure("full_scan", &[], 64 << 20).await;
     assert!(
-        small.bytes > big.bytes,
-        "small cache moves more bytes than object size allows: {} vs {} (dataset objects ~{})",
+        small.bytes < full.bytes,
+        "q20 under pressure moves fewer bytes than a full scan ({} vs {}): each \
+         surviving block is read once, none of the pruned blocks at all",
         small.bytes,
-        big.bytes,
-        big.full_gets, // labelled below in the message we print
+        full.bytes
     );
 }

--- a/crates/ravel-sql/tests/logs_selective_scan_amplification.rs
+++ b/crates/ravel-sql/tests/logs_selective_scan_amplification.rs
@@ -1,0 +1,548 @@
+//! Reproduction fixture for issue #761: a selective logs statement moves as many
+//! object-store GETs and as many bytes as a predicate-free full scan of the same
+//! data, even though it decodes only a fraction of the blocks.
+//!
+//! Root cause, from the code (`ravel_query::log_fetcher` and
+//! `ravel_sql::logs_scan`):
+//!
+//! - A query carrying any block-level predicate (a `has_word` content arm here,
+//!   a declared-column equality/`NumRange` prune arm for the ClickBench q20/q37
+//!   shapes) is NOT `LogQuery::is_block_predicate_free`, so `LogsScanExec` takes
+//!   the plan-then-stripe path, never #693's whole-segment fast path. The plan
+//!   phase (`compute_plan_counts` -> `LogSegmentFetcher::plan_segment`, slow
+//!   branch) fetches every relevant segment once, cold, before any partition
+//!   drains a block.
+//! - Above the block-range threshold that fetch is `BlockRangeFetcher::
+//!   fetch_object_with_footer`, whose candidate set is resolved by
+//!   `resolve_extents` -> `SkipIndex::candidate_blocks(ts_min, ts_max, None, &[])`.
+//!   It passes NO numeric/prune arms and NO stream refs: candidate selection is
+//!   ts-only. For a full (or month-wide) window every block is a ts candidate, so
+//!   the coverage crossover (candidate_bytes / BLOCKS-section bytes >= 0.75)
+//!   fires and one whole-object GET is issued. The selective predicate prunes
+//!   blocks only later, at DECODE, so it shrinks `blocks_scanned` but not the
+//!   bytes fetched.
+//!
+//! Net: the selective query pays the full-scan's whole-object read PLUS a suffix
+//! probe per segment (the fast path pays neither), and decodes a fraction of the
+//! blocks. That is q37's "19,690 GETs / 11.7 GB to scan 144 of 17,731 blocks"
+//! against the full scan's "8,424 GETs / 11.1 GB", reproduced here as a ratio.
+//!
+//! The whole-object reads are served from a cache large enough to hold the whole
+//! fixture, so the plan-phase reads are the deterministic cost this test pins.
+//! `selective_reread_amplifies_bytes_under_cache_pressure` then shrinks the cache
+//! to show the scan-phase re-reads that push q20 past the object bytes on the
+//! wire (17.9 GB > 11.1 GB of objects); it asserts only the direction of the
+//! effect, because the exact figure is eviction- and scheduling-dependent.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use async_trait::async_trait;
+use datafusion::execution::TaskContext;
+use datafusion::logical_expr::{Expr, col, lit};
+use datafusion::physical_plan::{ExecutionPlan, collect};
+use ravel_cache::{Cache, CacheLimits};
+use ravel_catalog::{SegmentLevel, SegmentRef, Snapshot};
+use ravel_logseg::writer::ObjectIdentity;
+use ravel_logseg::{AttrValue, LogRecord, RlogConfig, RlogWriter, stream_attrs_bytes};
+use ravel_object_store::memory::MemoryStore;
+use ravel_object_store::{
+    Capabilities, DelimitedList, GetOutcome, GetRange, ListPage, ObjectMeta, ObjectStoreBackend,
+    PageToken, PutOptions, PutOutcome, StoreError,
+};
+use ravel_query::{BlockRangeFetcher, CacheFetchError, LogSegmentFetcher};
+use ravel_sql::{LogsTableProvider, has_word_udf};
+use ravel_types::TenantHash;
+use ravel_types::accounting::{AccountedOp, QueryAccounting};
+use uuid::Uuid;
+
+const TENANT: [u8; 16] = [7u8; 16];
+
+/// Segments in the fixture, and the partitions requested. Equal so a
+/// predicate-free full scan clears the fast path's
+/// `relevant_segments >= target_partitions` conjunct.
+const SEGMENTS: usize = 8;
+const PARTS: usize = 8;
+/// Blocks per segment (one record per block). 6 so a `has_word` marker placed in
+/// one block per segment survives ~1/6 of the blocks (the very-selective q37
+/// shape) and a marker in two blocks survives ~1/3 (the q20 shape).
+const BLOCKS_PER_SEG: usize = 6;
+const TOTAL_BLOCKS: usize = SEGMENTS * BLOCKS_PER_SEG;
+
+/// Body filler bytes per record. Large enough that each object clears the small
+/// block-range threshold this fixture sets, so every read takes ADR-0107's ranged
+/// path, and large relative to the tiny suffix probe so the probe is a rounding
+/// error in the byte figures rather than a second whole-object read.
+const BODY_BYTES: usize = 16 * 1024;
+/// Suffix probe length for the ranged path. Deliberately tiny so the probe's
+/// bytes do not dominate; the point of the byte figures is the whole-object read
+/// the coverage crossover issues, not the probe.
+const SUFFIX_LEN: u64 = 256;
+
+/// A marker word present in exactly the first block of every segment: a
+/// `has_word` query for it survives one block per segment (SEGMENTS of
+/// TOTAL_BLOCKS), the very-selective q37 shape.
+const MARKER_FEW: &str = "MARKERFEW";
+/// A marker word present in the first two blocks of every segment: ~1/3 of the
+/// blocks survive, the q20 shape.
+const MARKER_THIRD: &str = "MARKERTHIRD";
+
+fn identity(seq: u64) -> ObjectIdentity {
+    ObjectIdentity {
+        tenant_hash: TENANT,
+        shard: 0,
+        writer_id: [2u8; 16],
+        writer_epoch: 1,
+        writer_seq: seq,
+    }
+}
+
+fn one_record_blocks() -> RlogConfig {
+    RlogConfig {
+        block_target_records: 1,
+        ..RlogConfig::default()
+    }
+}
+
+/// Pseudo-random printable filler so the writer's body compression cannot shrink
+/// the object back below the block-range threshold (same trick the
+/// `logs_scan_scaling` bench uses).
+fn filler(seed: u64, len: usize) -> String {
+    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+    let mut state = seed;
+    let mut out = String::with_capacity(len);
+    for _ in 0..len {
+        state = state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = state;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^= z >> 31;
+        out.push(ALPHABET[(z & 63) as usize] as char);
+    }
+    out
+}
+
+/// Body for block `blk` of segment `seg`: the block's markers (if any) as leading
+/// words, then unique filler so bloom pruning can isolate the marked block.
+fn body(seg: usize, blk: usize) -> String {
+    let mut head = String::new();
+    if blk == 0 {
+        head.push_str(MARKER_FEW);
+        head.push(' ');
+    }
+    if blk < 2 {
+        head.push_str(MARKER_THIRD);
+        head.push(' ');
+    }
+    let seed = (seg as u64) << 32 | blk as u64;
+    format!("{head}{}", filler(seed, BODY_BYTES))
+}
+
+fn record(seg: usize, blk: usize) -> LogRecord {
+    let resource = vec![(
+        "service.name".to_string(),
+        AttrValue::Str("svc".to_string()),
+    )];
+    let ts = (seg * 1_000_000 + blk) as i64;
+    LogRecord {
+        stream_id: ravel_types::logstream::log_stream_id(&resource, "scope", "1.0", &[]),
+        stream_attrs: stream_attrs_bytes(&resource, "scope", "1.0", &[]),
+        ts_ns: ts,
+        observed_ts_ns: ts,
+        severity_num: 9,
+        severity_text: "INFO".into(),
+        body: body(seg, blk),
+        trace_id: None,
+        span_id: None,
+        flags: 0,
+        attrs: Vec::new(),
+    }
+}
+
+async fn write_segment(store: &dyn ObjectStoreBackend, seg: usize) -> SegmentRef {
+    let recs: Vec<LogRecord> = (0..BLOCKS_PER_SEG).map(|b| record(seg, b)).collect();
+    let mut w = RlogWriter::new(one_record_blocks(), identity((seg + 1) as u64));
+    for r in &recs {
+        w.push(r.clone()).expect("push");
+    }
+    let bytes = w.finish().expect("finish");
+    let size = bytes.len() as u64;
+    let key = format!("logs/seg{seg}.rlog");
+    let content_hash = *blake3::hash(&bytes).as_bytes();
+    store
+        .put(&key, bytes::Bytes::from(bytes), PutOptions::default())
+        .await
+        .expect("put");
+    let min = recs.iter().map(|r| r.ts_ns).min().unwrap();
+    let max = recs.iter().map(|r| r.ts_ns).max().unwrap();
+    SegmentRef {
+        data_object_key: key,
+        object_size: size,
+        min_event_ts_ns: min,
+        max_event_ts_ns: max,
+        ingest_hour_bucket: 0,
+        sample_count: recs.len() as u64,
+        series_count: 0,
+        shard: 0,
+        content_hash,
+        writer_id: Uuid::from_u128(1),
+        writer_epoch: 1,
+        writer_seq: (seg + 1) as u64,
+        created_unix_ns: 0,
+        level: SegmentLevel::L0,
+    }
+}
+
+async fn build_snapshot(store: &dyn ObjectStoreBackend) -> Snapshot {
+    let mut segments = Vec::with_capacity(SEGMENTS);
+    for s in 0..SEGMENTS {
+        segments.push(write_segment(store, s).await);
+    }
+    Snapshot {
+        segments,
+        segments_pruned: 0,
+        pending_erasure: Vec::new(),
+    }
+}
+
+// ---- byte- and shape-counting store --------------------------------------
+
+/// Counts store `get` calls by `GetRange` shape and sums the bytes each returned,
+/// so a test can read the exact wire cost independent of `QueryAccounting` (and
+/// cross-check the two agree).
+struct CountingStore {
+    inner: Arc<MemoryStore>,
+    full: AtomicU64,
+    suffix: AtomicU64,
+    range: AtomicU64,
+    bytes: AtomicU64,
+}
+
+impl CountingStore {
+    fn new(inner: Arc<MemoryStore>) -> Arc<Self> {
+        Arc::new(CountingStore {
+            inner,
+            full: AtomicU64::new(0),
+            suffix: AtomicU64::new(0),
+            range: AtomicU64::new(0),
+            bytes: AtomicU64::new(0),
+        })
+    }
+    fn gets(&self) -> u64 {
+        self.full.load(Ordering::SeqCst)
+            + self.suffix.load(Ordering::SeqCst)
+            + self.range.load(Ordering::SeqCst)
+    }
+    fn full_gets(&self) -> u64 {
+        self.full.load(Ordering::SeqCst)
+    }
+    fn suffix_gets(&self) -> u64 {
+        self.suffix.load(Ordering::SeqCst)
+    }
+    fn bytes(&self) -> u64 {
+        self.bytes.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl ObjectStoreBackend for CountingStore {
+    async fn put(
+        &self,
+        key: &str,
+        data: bytes::Bytes,
+        opts: PutOptions,
+    ) -> Result<PutOutcome, StoreError> {
+        self.inner.put(key, data, opts).await
+    }
+    async fn get(&self, key: &str, range: GetRange) -> Result<GetOutcome, StoreError> {
+        match range {
+            GetRange::Full => self.full.fetch_add(1, Ordering::SeqCst),
+            GetRange::Suffix(_) => self.suffix.fetch_add(1, Ordering::SeqCst),
+            GetRange::Range(_, _) => self.range.fetch_add(1, Ordering::SeqCst),
+        };
+        let got = self.inner.get(key, range).await?;
+        self.bytes
+            .fetch_add(got.data.len() as u64, Ordering::SeqCst);
+        Ok(got)
+    }
+    async fn head(&self, key: &str) -> Result<ObjectMeta, StoreError> {
+        self.inner.head(key).await
+    }
+    async fn list(&self, prefix: &str, page: Option<PageToken>) -> Result<ListPage, StoreError> {
+        self.inner.list(prefix, page).await
+    }
+    async fn list_delimited(&self, prefix: &str) -> Result<DelimitedList, StoreError> {
+        self.inner.list_delimited(prefix).await
+    }
+    async fn delete(&self, key: &str) -> Result<(), StoreError> {
+        self.inner.delete(key).await
+    }
+    fn capabilities(&self) -> Capabilities {
+        Capabilities {
+            multipart: false,
+            ..self.inner.capabilities()
+        }
+    }
+}
+
+fn read_cache(cache_bytes: u64) -> Arc<Cache<CacheFetchError>> {
+    let max_entries = (cache_bytes / 4096).max(64) as usize;
+    Arc::new(Cache::new(CacheLimits::new(
+        cache_bytes,
+        max_entries,
+        cache_bytes,
+    )))
+}
+
+/// A fetcher that treats every object as above the block-range threshold (ranged
+/// path), with a tiny suffix probe and ADR-0046's read cache sized to `cache_bytes`.
+fn fetcher(store: Arc<dyn ObjectStoreBackend>, cache_bytes: u64) -> LogSegmentFetcher {
+    let block_range = BlockRangeFetcher::new(Arc::clone(&store))
+        .with_suffix_len(SUFFIX_LEN)
+        .with_whole_object_threshold(0);
+    LogSegmentFetcher::new(store)
+        .with_block_range(block_range)
+        .with_cache(read_cache(cache_bytes))
+        .with_block_range_threshold(0)
+}
+
+fn provider(
+    snapshot: Snapshot,
+    fetcher: LogSegmentFetcher,
+    acc: QueryAccounting,
+) -> LogsTableProvider {
+    LogsTableProvider::new(snapshot, TenantHash(TENANT), fetcher, acc)
+}
+
+fn find_scan(plan: &Arc<dyn ExecutionPlan>) -> Arc<dyn ExecutionPlan> {
+    if plan.name() == "LogsScanExec" {
+        return Arc::clone(plan);
+    }
+    plan.children()
+        .iter()
+        .find_map(|c| {
+            if c.name() == "LogsScanExec" {
+                Some(Arc::clone(c))
+            } else {
+                Some(find_scan(c))
+            }
+        })
+        .expect("a LogsScanExec leaf")
+}
+
+fn sum_metric(plan: &Arc<dyn ExecutionPlan>, name: &str) -> usize {
+    let set = find_scan(plan).metrics().expect("metrics");
+    set.iter()
+        .filter(|m| m.value().name() == name)
+        .map(|m| m.value().as_usize())
+        .sum()
+}
+
+async fn drain(plan: Arc<dyn ExecutionPlan>) -> usize {
+    let batches = collect(plan, Arc::new(TaskContext::default()))
+        .await
+        .expect("collect");
+    batches.iter().map(|b| b.num_rows()).sum()
+}
+
+fn has_word(marker: &str) -> Expr {
+    has_word_udf().call(vec![col("body"), lit(marker)])
+}
+
+/// One measured shape.
+struct Shape {
+    label: &'static str,
+    gets: u64,
+    full_gets: u64,
+    suffix_gets: u64,
+    bytes: u64,
+    blocks_scanned: usize,
+    blocks_total: usize,
+    rows: usize,
+    acc_gets: u64,
+    acc_bytes: u64,
+}
+
+async fn measure(label: &'static str, filters: &[Expr], cache_bytes: u64) -> Shape {
+    let base = Arc::new(MemoryStore::new());
+    let snapshot = build_snapshot(base.as_ref()).await;
+    let counting = CountingStore::new(base);
+    let store: Arc<dyn ObjectStoreBackend> = Arc::clone(&counting) as Arc<dyn ObjectStoreBackend>;
+    let acc = QueryAccounting::new();
+    let prov = provider(snapshot, fetcher(store, cache_bytes), acc.clone());
+    let plan = if filters.is_empty() {
+        prov.plan(PARTS).expect("plan")
+    } else {
+        prov.plan_filters(PARTS, filters).expect("plan_filters")
+    };
+    let rows = drain(Arc::clone(&plan)).await;
+    let snap = acc.snapshot();
+    Shape {
+        label,
+        gets: counting.gets(),
+        full_gets: counting.full_gets(),
+        suffix_gets: counting.suffix_gets(),
+        bytes: counting.bytes(),
+        blocks_scanned: sum_metric(&plan, "blocks_scanned"),
+        blocks_total: sum_metric(&plan, "blocks_total"),
+        rows,
+        acc_gets: snap.s3_requests(AccountedOp::Get),
+        acc_bytes: snap.total_s3_bytes(),
+    }
+}
+
+fn report(s: &Shape) {
+    eprintln!(
+        "[{}] gets={} (full={} suffix={}) bytes={} blocks_scanned={}/{} rows={} \
+         | accounting: gets={} bytes={}",
+        s.label,
+        s.gets,
+        s.full_gets,
+        s.suffix_gets,
+        s.bytes,
+        s.blocks_scanned,
+        s.blocks_total,
+        s.rows,
+        s.acc_gets,
+        s.acc_bytes,
+    );
+}
+
+/// The headline of issue #761: a selective statement issues MORE object-store
+/// GETs and reads roughly the SAME bytes as a predicate-free full scan of the
+/// same data, while decoding a small fraction of the blocks.
+#[tokio::test]
+async fn selective_scan_costs_more_gets_and_equal_bytes_as_full_scan() {
+    // Cache large enough to hold the whole fixture with no eviction, so the
+    // deterministic cost is exactly the plan phase's cold reads.
+    let cache = 64 << 20;
+
+    let full = measure("full_scan", &[], cache).await;
+    let q37 = measure("selective_few (q37)", &[has_word(MARKER_FEW)], cache).await;
+    let q20 = measure("selective_third (q20)", &[has_word(MARKER_THIRD)], cache).await;
+    report(&full);
+    report(&q37);
+    report(&q20);
+
+    // QueryAccounting agrees with the raw store counters on both axes: the
+    // deliverable's figures are the ones the engine records.
+    for s in [&full, &q37, &q20] {
+        assert_eq!(
+            s.acc_gets, s.gets,
+            "{}: accounting GET count == store GETs",
+            s.label
+        );
+        assert_eq!(
+            s.acc_bytes, s.bytes,
+            "{}: accounting bytes == store bytes",
+            s.label
+        );
+        assert_eq!(
+            s.blocks_total, TOTAL_BLOCKS,
+            "{}: blocks_total is the whole snapshot",
+            s.label
+        );
+    }
+
+    // Full scan: #693 whole-segment fast path. One whole-object GET per segment,
+    // zero suffix probes, every block scanned.
+    assert_eq!(
+        full.full_gets, SEGMENTS as u64,
+        "full scan: one whole-object GET per segment"
+    );
+    assert_eq!(
+        full.suffix_gets, 0,
+        "full scan: fast path issues no suffix probes"
+    );
+    assert_eq!(
+        full.blocks_scanned, TOTAL_BLOCKS,
+        "full scan decodes every block"
+    );
+
+    // Selective (q37 shape): plan-then-stripe. The plan phase probes every
+    // segment (SEGMENTS suffix GETs) and the coverage crossover reads every
+    // segment whole (SEGMENTS full GETs); the cache absorbs the scan-phase
+    // re-reads. So it issues ~2x the full scan's GETs, and reads a whole object
+    // per segment despite decoding only ~1/BLOCKS_PER_SEG of the blocks.
+    assert_eq!(
+        q37.suffix_gets, SEGMENTS as u64,
+        "q37: one plan-phase probe per segment"
+    );
+    assert_eq!(
+        q37.full_gets, SEGMENTS as u64,
+        "q37: coverage crossover reads each segment whole"
+    );
+    assert!(
+        q37.gets > full.gets,
+        "q37 issues more GETs than the full scan ({} vs {})",
+        q37.gets,
+        full.gets
+    );
+    // Same bytes as the full scan (within the tiny suffix-probe overhead), even
+    // though it decodes far fewer blocks: the selective predicate never reached
+    // the fetch's candidate set.
+    assert!(
+        q37.bytes >= full.bytes
+            && q37.bytes <= full.bytes + (SEGMENTS as u64) * SUFFIX_LEN + full.bytes / 20,
+        "q37 reads ~the full-scan bytes ({} vs {})",
+        q37.bytes,
+        full.bytes
+    );
+    assert!(
+        q37.blocks_scanned <= SEGMENTS * 2,
+        "q37 decodes ~one block per segment (got {})",
+        q37.blocks_scanned
+    );
+    assert!(
+        (q37.blocks_scanned as f64) < (full.blocks_scanned as f64) / 2.0,
+        "q37 decodes far fewer blocks than the full scan ({} vs {})",
+        q37.blocks_scanned,
+        full.blocks_scanned
+    );
+
+    // q20 shape (~1/3 of blocks survive): same fetch cost, more blocks decoded.
+    assert_eq!(q20.suffix_gets, SEGMENTS as u64);
+    assert_eq!(q20.full_gets, SEGMENTS as u64);
+    assert!(
+        q20.bytes >= full.bytes,
+        "q20 reads at least the full-scan bytes"
+    );
+    assert!(
+        q20.blocks_scanned >= q37.blocks_scanned,
+        "q20 decodes more blocks than q37 ({} vs {})",
+        q20.blocks_scanned,
+        q37.blocks_scanned
+    );
+}
+
+/// q20's other half: on a cache too small to hold the working set, the
+/// plan-phase whole-object reads are evicted before the scan phase re-reads
+/// them, so bytes on the wire exceed the object bytes (the reference's
+/// 17.9 GB > 11.1 GB). Only the direction is asserted: the exact figure is
+/// eviction- and scheduling-dependent, so this is not a byte-exact pin.
+#[tokio::test]
+async fn selective_reread_amplifies_bytes_under_cache_pressure() {
+    let big = measure("q20_big_cache", &[has_word(MARKER_THIRD)], 64 << 20).await;
+    // A cache far smaller than the fixture's object bytes: plan-phase reads are
+    // evicted before the scan phase re-reads them.
+    let small = measure("q20_small_cache", &[has_word(MARKER_THIRD)], 32 << 10).await;
+    report(&big);
+    report(&small);
+
+    // Eviction can only add reads, never remove them.
+    assert!(
+        small.gets >= big.gets,
+        "small cache issues at least as many GETs ({} vs {})",
+        small.gets,
+        big.gets
+    );
+    assert!(
+        small.bytes > big.bytes,
+        "small cache moves more bytes than object size allows: {} vs {} (dataset objects ~{})",
+        small.bytes,
+        big.bytes,
+        big.full_gets, // labelled below in the message we print
+    );
+}

--- a/crates/ravel-sql/tests/logs_selective_scan_amplification.rs
+++ b/crates/ravel-sql/tests/logs_selective_scan_amplification.rs
@@ -30,6 +30,36 @@
 //! crossover preserved). `text_predicate_falls_back_to_full_object_read` pins the
 //! deliberately-kept fallback. `selective_third_no_partition_multiplication_\
 //! under_cache_pressure` pins that eviction no longer re-reads whole objects.
+//!
+//! # Version 4 (ADR-0699 decision 5)
+//!
+//! The writer emits version-4 objects, so the surviving blocks these figures
+//! are proportional to are no longer contiguous byte ranges: a block's pages sit
+//! one per column chunk inside its row group, and the fetch is one coalesced
+//! range per surviving `(row group, projected column)`. Every assertion below
+//! keeps its meaning; the literals are measured on version-4 objects and each
+//! says what it counts.
+//!
+//! Two fetcher settings this fixture pins deliberately, because the figures are
+//! meaningless without them:
+//!
+//! - `SUFFIX_LEN` is sized to cover the object tail (footer, SKIP_IDX, PAGE_DIR,
+//!   BLOOM), which is what `DEFAULT_LOG_SUFFIX_LEN` does at production object
+//!   sizes and what issue #766 raised it for. At the default 256 KiB a probe
+//!   would swallow this fixture's whole 81 KB object and there would be no byte
+//!   figure left to read.
+//! - `with_coalesce_gap(0)`. Under version 4 the hole between two wanted pages
+//!   of one column is the OTHER blocks' pages of that column, so the gap
+//!   threshold decides how many pruned blocks a range reads through. This
+//!   fixture's geometry is one row group of six blocks whose `body` pages are
+//!   ~12.4 KB each, so the hole between `body`'s surviving page and the next
+//!   wanted chunk is ~61.8 KB -- just under the 64 KiB default, which therefore
+//!   fuses the entire BLOCKS section into one range and puts the selective
+//!   shapes back at full-scan bytes. At the production geometry (32-block row
+//!   groups, ~6 KB pages) the same hole is ~186 KB and the default splits it.
+//!   ADR-0699 left this threshold "not decided ... until measured"; the
+//!   measurement is recorded in that ADR's as-built section, and this fixture
+//!   pins the byte proportionality rather than the threshold.
 
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
@@ -71,13 +101,17 @@ const TOTAL_BLOCKS: usize = SEGMENTS * BLOCKS_PER_SEG;
 
 /// Body filler bytes per record. Large enough that each object clears the small
 /// block-range threshold this fixture sets, so every read takes ADR-0107's ranged
-/// path, and large relative to the tiny suffix probe so the probe is a rounding
-/// error in the byte figures rather than a second whole-object read.
+/// path, and large enough that `body` dominates each block: it is the column a
+/// selective read still has to fetch a page of per surviving block, so it is
+/// what makes the byte figures track the surviving fraction.
 const BODY_BYTES: usize = 16 * 1024;
-/// Suffix probe length for the ranged path. Deliberately tiny so the probe's
-/// bytes do not dominate; the point of the byte figures is the whole-object read
-/// the coverage crossover issues, not the probe.
-const SUFFIX_LEN: u64 = 256;
+/// Suffix probe length for the ranged path: just over this fixture's 6,780-byte
+/// object tail (footer + SKIP_IDX 139 + PAGE_DIR 199 + BLOOM 6,250), so one
+/// probe per segment carries every plan section and the scan needs no second GET
+/// for them. That is what `DEFAULT_LOG_SUFFIX_LEN` does at production object
+/// sizes (issue #766); the production value would cover this whole 81 KB fixture
+/// object and leave no byte figure to read.
+const SUFFIX_LEN: u64 = 8192;
 
 /// A marker word present in exactly the first block of every segment. A
 /// `has_word` query for it survives one block per segment, but bloom is a
@@ -300,10 +334,13 @@ fn read_cache(cache_bytes: u64) -> Arc<Cache<CacheFetchError>> {
 }
 
 /// A fetcher that treats every object as above the block-range threshold (ranged
-/// path), with a tiny suffix probe and ADR-0046's read cache sized to `cache_bytes`.
+/// path), with a tail-sized suffix probe, no coalescing slack, and ADR-0046's
+/// read cache sized to `cache_bytes`. See this file's header for why those two
+/// settings are pinned rather than left at their defaults.
 fn fetcher(store: Arc<dyn ObjectStoreBackend>, cache_bytes: u64) -> LogSegmentFetcher {
     let block_range = BlockRangeFetcher::new(Arc::clone(&store))
         .with_suffix_len(SUFFIX_LEN)
+        .with_coalesce_gap(0)
         .with_whole_object_threshold(0);
     LogSegmentFetcher::new(store)
         .with_block_range(block_range)
@@ -483,11 +520,12 @@ async fn selective_numeric_reads_only_surviving_blocks() {
         "full scan decodes every block"
     );
     assert_eq!(full.rows, TOTAL_BLOCKS, "full scan returns every record");
+    // 649,900 = the eight version-4 objects' bytes exactly (81,144 B each plus
+    // rounding across the writer's per-object framing). One whole-object GET per
+    // segment and nothing else, so this is the object bytes and not a byte more.
     assert_eq!(
-        full.bytes, 650_087,
-        "full scan reads exactly the object bytes (the fixture now carries a \
-         declared numeric column per record, so the objects are marginally \
-         larger than the pre-#761 reproduction's 649,653)"
+        full.bytes, 649_900,
+        "full scan reads exactly the object bytes"
     );
     assert_eq!(full.plan_full_reads, 0, "full scan skips the plan phase");
 
@@ -510,10 +548,15 @@ async fn selective_numeric_reads_only_surviving_blocks() {
         "q37: the plan phase counted survivors from the skip index, fetching no \
          block"
     );
-    // Exact GET count: 8 suffix probes (plan) + the per-segment directory and
-    // single-block range reads the scan issues, with the 64 MiB cache absorbing
-    // every re-touch. No whole-object GET anywhere.
-    assert_eq!(q37.gets, 56, "q37: exact GET count with no eviction");
+    // Exact GET count: 8 plan probes plus 8 range GETs per segment. Under
+    // version 4 the surviving block's bytes are one page per column chunk of its
+    // row group, and this fixture's blocks carry pages in eight chunks (ts,
+    // observed_ts, stream_ref, severity_num, severity_text, body, flags, code),
+    // none of which coalesce at gap 0 because the pruned blocks' pages for the
+    // same column sit between them. The two front sections (STREAM_DIR,
+    // FIELD_DIR) and every tail section are absorbed by the probe and the 64 MiB
+    // cache. No whole-object GET anywhere.
+    assert_eq!(q37.gets, 72, "q37: exact GET count with no eviction");
     assert_eq!(
         q37.blocks_scanned, SEGMENTS,
         "q37 decodes exactly one block per segment"
@@ -531,6 +574,17 @@ async fn selective_numeric_reads_only_surviving_blocks() {
         q37.bytes,
         q37_block_bytes
     );
+    // 165,355 = 99,112 page bytes (8 surviving blocks x 12,389 B of pages across
+    // their eight column chunks) + 65,536 probe bytes (8 x 8 KiB) + 672
+    // front-section bytes (8 x (STREAM_DIR 62 + FIELD_DIR 22)). The page term is
+    // 15% of the full scan; the probe term is the fixed per-object directory
+    // cost, which on this deliberately tiny fixture is 40% of the total and on a
+    // production 1.3 MB object is a rounding error.
+    assert_eq!(
+        q37.bytes, 165_355,
+        "q37 moves the surviving blocks' page bytes plus the probe and the two \
+         front sections, not the object"
+    );
     assert!(
         q37.bytes <= full.bytes * 2 / 5,
         "q37 reads well under a full scan ({} vs {}), proportional to 8/48",
@@ -546,7 +600,11 @@ async fn selective_numeric_reads_only_surviving_blocks() {
     );
     assert_eq!(q20.full_gets, 0, "q20: no whole-object GET");
     assert_eq!(q20.plan_full_reads, 0, "q20: skip-index plan");
-    assert_eq!(q20.gets, 56, "q20: exact GET count with no eviction");
+    // Same shape as q37: 8 probes plus 8 chunk ranges per segment. q20's second
+    // surviving block per segment is ADJACENT to the first, so its page sits
+    // next to the first's in every chunk and the pair coalesces even at gap 0 --
+    // the range count is unchanged and only the bytes grow.
+    assert_eq!(q20.gets, 72, "q20: exact GET count with no eviction");
     assert_eq!(
         q20.blocks_scanned,
         SEGMENTS * 2,
@@ -563,6 +621,13 @@ async fn selective_numeric_reads_only_surviving_blocks() {
         "q20 reads at least its surviving-block bytes ({} vs {})",
         q20.bytes,
         q20_block_bytes
+    );
+    // 264,405 = 198,197 page bytes (16 surviving blocks) + the same 65,536 probe
+    // and 672 front-section bytes q37 pays: twice q37's page term, identical
+    // fixed term.
+    assert_eq!(
+        q20.bytes, 264_405,
+        "q20 moves twice q37's page bytes and the same fixed directory bytes"
     );
     assert!(
         q20.bytes <= full.bytes * 3 / 5,
@@ -624,9 +689,15 @@ async fn text_predicate_falls_back_to_full_object_read() {
         "bloom still prunes to one block per segment at decode"
     );
     assert_eq!(text.rows, SEGMENTS, "one matching record per segment");
-    // The whole objects are read: bytes ~ a full scan, the amplification #761
-    // cannot remove for a text predicate.
+    // The whole objects are read: bytes ~ a full scan plus the probes, the
+    // amplification #761 cannot remove for a text predicate. 715,612 = 649,900
+    // object bytes + 65,536 probe bytes (8 x 8 KiB), the plan phase's probe on
+    // top of the whole-object read its fallback then issues.
     let full = measure("full_scan", &[], cache).await;
+    assert_eq!(
+        text.bytes, 715_612,
+        "text fallback: the whole objects plus one plan probe each"
+    );
     assert!(
         text.bytes >= full.bytes,
         "text predicate still moves the full-object bytes ({} vs {})",
@@ -643,8 +714,10 @@ async fn text_predicate_falls_back_to_full_object_read() {
 #[tokio::test]
 async fn selective_third_no_partition_multiplication_under_cache_pressure() {
     let big = measure("q20_big_cache", &[code_le(1)], 64 << 20).await;
-    // A cache far smaller than the fixture's object bytes.
-    let small = measure("q20_small_cache", &[code_le(1)], 32 << 10).await;
+    // A cache five times smaller than the fixture's 650 KB of object bytes, so
+    // the probe and directory extents really are evicted between the plan pass
+    // and the per-partition scans.
+    let small = measure("q20_small_cache", &[code_le(1)], 128 << 10).await;
     report(&big);
     report(&small);
 
@@ -687,5 +760,14 @@ async fn selective_third_no_partition_multiplication_under_cache_pressure() {
          surviving block is read once, none of the pruned blocks at all",
         small.bytes,
         full.bytes
+    );
+    // 264,405 with no eviction (16 surviving blocks' page bytes plus the fixed
+    // probe and front-section bytes) against 479,147 under pressure: the
+    // difference is re-fetched probe and directory extents, never a re-read
+    // page. Both stay under the 649,900 a single full pass moves.
+    assert_eq!(big.bytes, 264_405, "q20 with no eviction");
+    assert_eq!(
+        small.bytes, 479_147,
+        "q20 under eviction: more directory re-reads, still under one full pass"
     );
 }

--- a/crates/ravel-types/src/accounting.rs
+++ b/crates/ravel-types/src/accounting.rs
@@ -118,6 +118,13 @@ struct Inner {
     /// regardless of column filtering. Decode-time column-filtering
     /// measurement, NOT wire bytes; see `ops`'s `s3_bytes` for wire bytes
     /// (ADR-0107 decision 4).
+    ///
+    /// Its name predates ADR-0699 and it is no longer a fetch figure on a
+    /// version-4 object: the column-chunk fetcher brings only the projected
+    /// columns' pages, so a page counted here may never have crossed the wire.
+    /// The gap to `page_bytes_decoded` is then what a whole-block read WOULD
+    /// have cost, which is the saving the chunk path made. The bytes actually
+    /// moved are `s3_bytes`, on every version.
     page_bytes_fetched: AtomicU64,
     /// Stored bytes of the pages a logs scan actually decoded after column
     /// filtering. Decode-time column-filtering measurement, NOT wire bytes; see
@@ -208,6 +215,9 @@ impl QueryAccounting {
     /// actual bytes moved over the wire stay measured by [`Self::add_s3_bytes`].
     /// Paired with [`Self::add_page_bytes_decoded`], the two expose how much of
     /// each fetched block a narrow projection throws away at decode.
+    ///
+    /// On a version-4 object (ADR-0699 decision 5) the unselected pages counted
+    /// here were never fetched at all; see the field's own documentation.
     pub fn add_page_bytes_fetched(&self, bytes: u64) {
         self.0
             .page_bytes_fetched

--- a/docs/adrs/0102-intra-segment-scan-partitioning-and-spill-policy.md
+++ b/docs/adrs/0102-intra-segment-scan-partitioning-and-spill-policy.md
@@ -521,3 +521,74 @@ publishes a DataFusion counter named for the first failing conjunct
 partition, and no such counter at all when the fast path fires. A latency report
 reading the scan's metrics can then state why a statement striped instead of
 inferring it from GET counts.
+
+## Amendment (2026-08-26, #761): the plan phase and the fetch prune by the numeric arms
+
+Decision 1's plan phase (`compute_plan_counts` -> `plan_segment`) resolves each
+segment's surviving-block count before any partition drains a block, and the
+scan reads those survivors through `BlockRangeFetcher`. The previous amendment
+removed the plan phase for a predicate-free statement. This one fixes the cost
+for a SELECTIVE one — the ClickBench q20 and q37-q43 shapes, a declared-column
+or `attrs` numeric predicate — which is not block-predicate-free and so always
+took the plan-then-stripe path.
+
+The defect: neither the plan phase nor the scan applied the query's prune-only
+`NumRange` arms to block selection. `plan_segment`'s slow branch opened each
+segment whole to count survivors, and the scan's
+`BlockRangeFetcher::resolve_extents` called `SkipIndex::candidate_blocks(ts, ts,
+None, &[])` with no numeric arms, so every block was a ts candidate, the
+coverage crossover fired, and the read collapsed to one whole-object GET. The
+predicate pruned blocks only at decode. On the 8,424-object tenant of #680 the
+selective q37 moved 11.7 GB to decode 144 of 17,731 blocks, and q20 moved 17.9
+GB — past the 11.1 GB of objects on disk, because a cold cache re-read each
+surviving segment once per owning partition.
+
+The fix resolves the `NumRange` arms against each object's own FIELD_DIR
+(`FieldDir::numeric_range_arms`, shared with the reader's decode-time prune so
+the arms are byte-for-byte identical) and applies them to `candidate_blocks` in
+both phases:
+
+1. **Fetch side.** `resolve_extents` takes the resolved arms and prunes the
+   candidate set before the coverage crossover is weighed, so a selective scan
+   reads only the surviving blocks. The crossover threshold (0.75) is unchanged:
+   it now fires only when the survivors genuinely cover >= 75% of the BLOCKS
+   section. This is byte-identical to the unpruned read — the skip index's
+   per-block bounds are conservative (ADR-0013), so a block dropped at fetch is
+   one the decode-side prune would have dropped anyway, and the reader still
+   runs the full skip/POSTINGS/bloom prune over the fetched buffer.
+2. **Plan side.** For a query the skip index can decide — ts bounds plus at
+   least one `NumRange` arm, no content/text arm, no attribute-equality POSTINGS
+   prune, no stream filter — `plan_segment` reads footer + SKIP_IDX (the probe)
+   plus the object's FIELD_DIR to resolve the arms, and returns
+   `candidate_blocks(...).len()` with no block fetched. That count equals the
+   survivor list the scan stripes, because for such a query the reader's full
+   prune reduces to its skip step. The footer it read is carried to each subset
+   open (#693 part 3), so those opens skip their own probe. At least one arm is
+   required so this stays the selective path: a query with no prune arm is
+   skip-decidable too, but its plan read already fetches only the ts-candidate
+   blocks and warms exactly the extents the subset opens stripe, so planning it
+   from the skip index would replace one shared read with N per-partition ones
+   for the same bytes.
+3. **Fallback.** A predicate the skip index cannot decide — a `has_word`/text
+   arm (bloom prunes it only at decode), an `attrs['k']='v'` POSTINGS equality,
+   a stream filter — still reads the whole object in the plan phase and is
+   counted in a new `plan_full_reads` DataFusion counter (published once, by
+   partition 0), so a report can see which statements still pay the plan-phase
+   whole-object read. A segment at or below the block-range threshold counts
+   there too: the fetch reads such an object whole in one GET regardless, so
+   planning it from the skip index would cost a second read, not save one.
+
+Reference figures on the 8,424-object tenant. The plan phase now reads, per
+segment, one 64 KiB suffix probe (footer + SKIP_IDX) plus one small FIELD_DIR
+range GET, and no block; the FIELD_DIR is a front section, so resolving the
+numeric arms costs one range GET per segment that the predicate-free path (a
+probe alone) does not pay. Bytes are dominated by the probes: q37-class drops
+from 19,690 GETs / 11.7 GB to about 8,700 GETs and 0.65 to 0.9 GB (about 8,424
+probes plus coalesced reads of about 144 surviving blocks), and q20 from 29,614
+GETs / 17.9 GB to about 4 to 4.7 GB (each of its ~6,592 surviving blocks read
+once, no whole-object re-read). GET counts stay near two to three per object,
+because the object count is the floor: the probe and the FIELD_DIR range are one
+each per relevant object no matter how selective the predicate is, and only the
+surviving-block reads scale with the predicate. The 0.75 coverage crossover is
+unchanged; a numeric predicate whose survivors still cover >= 75% of a segment
+reads that segment whole, exactly as before.

--- a/docs/adrs/0699-rlog-row-groups-and-page-directory.md
+++ b/docs/adrs/0699-rlog-row-groups-and-page-directory.md
@@ -346,21 +346,102 @@ does not supersede.
    groups so they pin it at the setting production runs with. Version 3 is
    unaffected: its group is one block, and it is the same code path.
 
-### Interim ravel-query reader (decision 5 not yet landed)
+### Decision 5 as built (2026-08-26): the ravel-query column-chunk fetcher
 
-Decision 5 (the PAGE_DIR-driven column-chunk fetcher) is not part of this
-change. Until it lands, every reader outside `ravel-logseg` that a version-4
-object reaches reads the object whole in one `GetRange::Full` GET rather than by
-block range: the ADR-0107 block-range protocol addresses a block by its SKIP_IDX
-byte range and verifies the block crc over exactly those bytes, and version 4
-makes neither hold (point 1 and point 3 above). A whole-object read is the same
-bytes and the same one GET the pre-ADR-0107 path used -- correct and no worse
-than before the version bump, strictly worse than decision 5 will be. This is a
-single guard in `LogSegmentFetcher::fetch_object_with_footer`, placed after the
-footer is resolved so it covers both the suffix-probe path and the plan-carried
-footer path (#693 part 3), and is pinned by
-`version_4_object_is_read_whole_until_the_page_dir_fetcher_lands` in
-`crates/ravel-query/tests/log_block_range.rs`. That test is what the decision-5
-fetcher half turns into its column-chunk assertion: the same fixture, asserting
-one coalesced ranged GET per surviving `(row group, projected column)` instead
-of one whole-object GET.
+Decision 5 landed in `crates/ravel-query/src/log_fetcher.rs`, replacing the
+interim guard that read a version-4 object whole. Five points the decision text
+left open were settled by the implementation; `docs/query-engine.md` states the
+resulting request law.
+
+5.1 **Where the version dispatch sits.** One branch in
+`BlockRangeFetcher::fetch_object_with_footer`, on `footer.section(PAGE_DIR)`,
+placed after the footer is resolved so it covers both the suffix-probe path and
+the plan-carried footer path (#693 part 3). PAGE_DIR's presence is only knowable
+from the footer, so no earlier placement is possible.
+
+5.2 **What the probe carries, and what a miss costs.**
+`DEFAULT_LOG_SUFFIX_LEN` rose from 64 KiB to 256 KiB (issue #766). The plan
+phase needs SKIP_IDX and the fetch phase needs PAGE_DIR, and both sit *before*
+BLOOM in the object, so a suffix probe reaches them only by spanning BLOOM too.
+Measured on a 32-block-group, 105-column object (7,168 pages, two full row
+groups): SKIP_IDX 31,082 B, PAGE_DIR 29,853 B, BLOOM 5,124 B, footer and trailer
+200 B, giving a 66,259 B tail -- 723 bytes past the old 64 KiB probe. On the
+reference ClickBench tenant BLOOM alone averages 86 KB, which is why that probe
+missed SKIP_IDX on 68.8% of above-threshold objects and cost 4,415 extra GETs
+per predicated statement. 256 KiB covers both shapes with headroom.
+
+A probe that still falls short costs ONE extra GET, not one per section: the
+writer emits PAGE_DIR immediately after SKIP_IDX, so the two are fetched as one
+coalesced range. `BlockRangeStats::probe_misses` counts, per object, how many of
+those tail sections the probe *window* failed to cover, so a report can show the
+residual miss rate. It is measured against the window rather than against cache
+residency, and it deliberately excludes STREAM_DIR and FIELD_DIR: those sit at
+the object's front, where no suffix probe of any length reaches them, so
+counting them would put a floor under the metric.
+
+The probe is a fixed per-object read that a narrow projection does not shrink.
+On a small object it can exceed the column chunks themselves; on the reference
+tenant's 1.3 MB objects it is 20%. It is cache-routed and shared by every
+partition and by both phases of one statement, so it is paid once per object per
+query, not once per read.
+
+5.3 **The coalescing rule for chunks, and the gap threshold this ADR left
+open.** The extents are per page, not per chunk: for each row group holding a
+surviving block, for each projected column's chunk, the pages the surviving
+blocks contribute. They are then merged by the same rule and the same
+`coalesce_gap` the version-3 block path uses (`coalesce_byte_extents` is the one
+implementation of the policy). A pruned block's pages are the holes in those
+runs. No separate whole-group case is needed: when the projection keeps every
+column and every block of a group survives, that group's pages are one
+contiguous span and coalesce into exactly one range.
+
+The "Consequences" section left the threshold across pruned blocks inside a
+chunk undecided until measured. The measurement, from the #761 fixture
+(`crates/ravel-sql/tests/logs_selective_scan_amplification.rs`): the hole
+between two wanted pages of one column is `(pruned blocks) x (page size)`, so
+the threshold's effect is a function of row-group geometry, not of object size.
+At the production shape -- 32-block groups, ~6 KB pages -- one surviving block
+in 32 leaves ~186 KB holes and the 64 KiB default splits them, which is the
+intended behaviour. At that fixture's shape -- one row group of six blocks,
+`body` pages of ~12.4 KB -- the hole between `body`'s surviving page and the
+next wanted chunk is ~61.8 KB, just under the default, so the default fuses the
+whole BLOCKS section into one range and returns the amplification #761 removed.
+The default is unchanged here (this ADR's rule is "ADR-0107's existing gap
+policy applies"), the fixture pins `with_coalesce_gap(0)` and says why, and the
+open question is now a measured one: a gap threshold expressed as an absolute
+byte count behaves differently at every row-group geometry, and the middle
+region (groups of roughly 4 to 10 blocks with pages of 6 to 16 KB) reads through
+every pruned page. Deciding a scale-relative rule is left to its own change.
+
+5.4 **The checksum rule for a projected read.** A projected fetch cannot verify
+the block crc and does not try: that crc covers the block's pages in `column_id`
+order (point 1 of the 2026-08-26 amendment), which a reader holding two of a
+hundred columns does not have. `decode_v4_block` verifies each page it reads
+against that page's own PAGE_DIR `crc32c` before decompressing it, and verifies
+the block crc as well exactly when the selection kept every one of the block's
+pages. Every byte the fetch brings and the reader interprets is therefore
+checksum-covered on its access path (ADR-0010 §4), and the holes inside a
+coalesced range are never interpreted at all. This is also what makes the
+coalesced range a legitimate cache unit despite spanning pruned pages: a corrupt
+cache hit fails at the first page crc the decode checks, exactly as a corrupt
+live fetch does. `docs/log-segment-format.md` ("BLOCKS") is the normative
+statement.
+
+5.5 **The crossover, and what the plan phase reads.** The coverage crossover is
+unchanged at 75%, but its numerator is now the projected page bytes rather than
+whole candidate blocks, still measured against the BLOCKS section's own size. A
+narrow projection therefore stays far below it even when every block survives,
+and an all-columns read of every block reaches ~1.0 and takes the single
+whole-object GET. On that branch no per-block cache entries are admitted, unlike
+the version-3 path: a version-4 block is not a contiguous extent, so there is no
+block-keyed entry a later ranged read would look for.
+
+`plan_segment` fetches no page on either of its version-4 branches. The
+predicate-free branch reads the footer alone; the skip-decidable branch reads
+footer, SKIP_IDX and FIELD_DIR, and brings PAGE_DIR alongside SKIP_IDX under the
+extent key the scan phase will use, so the scan finds it cached rather than
+paying a second round trip. A scan that carries a plan footer asks the cache for
+the probe extent itself (as a `Range` GET of the same bytes, so it keys
+identically), which places the footer, the trailer and every tail section at
+once for no GET; that is done only when a read cache is wired, because without
+one it would re-read the tail on the wire instead of the individual sections.

--- a/docs/adrs/0699-rlog-row-groups-and-page-directory.md
+++ b/docs/adrs/0699-rlog-row-groups-and-page-directory.md
@@ -197,10 +197,10 @@ pages skipped inside the range by the coalescing rule. The
 selection too.
 
 `plan_segment` (#691, #693) needs only survivor counts, and under this ADR
-those come from SKIP_IDX plus PAGE_DIR without touching any page. That is
-#693 part 2's "predicate-free plan needs no read" made structural: the plan
-phase reads three small sections per object and never a page, for every
-statement, not only the predicate-free ones.
+no plan ever touches a page. What it reads is scope-specific, and the
+as-built section below is normative: the predicate-free branch reads the
+footer alone, and the skip-decidable branch reads footer, SKIP_IDX and
+FIELD_DIR, bringing PAGE_DIR alongside for the scan phase.
 
 The RSEG format (metrics) is out of scope; it already has per-series
 ranges and its own fetcher.

--- a/docs/log-segment-format.md
+++ b/docs/log-segment-format.md
@@ -329,8 +329,9 @@ mandatory on their own access path, which is what keeps every interpreted byte
 checksum-covered (ADR-0010 §4, "Checksum coverage map" below). This is what
 lets a fetcher bring one coalesced byte range per `(row group, projected
 column)` and hand it to a projected decode: the range's holes -- pages of
-pruned blocks, and of columns the projection dropped -- are never interpreted,
-so nothing depends on a checksum over them.
+pruned blocks, and of columns the projection dropped -- may still be fetched
+when coalescing folds them into a requested range, but they are never
+interpreted, so nothing depends on a checksum over them.
 
 A reader may decode a *subset* of a block's columns (`read_block_columns`,
 ADR-0087); the SQL logs scan uses this to decode only the columns a query

--- a/docs/log-segment-format.md
+++ b/docs/log-segment-format.md
@@ -89,8 +89,14 @@ trailer byte except the crc field itself is covered (ADR-0010 §4).
 Identical in shape to RSEG v1:
 
 1. Reject objects smaller than 16 bytes as `Corrupted`.
-2. Suffix-GET 64 KiB (or the whole object if smaller). Verify `magic`,
-   `version`, `signal`, `reserved`.
+2. Suffix-GET the object's tail (or the whole object if smaller). Verify
+   `magic`, `version`, `signal`, `reserved`. The suffix length is a reader
+   choice, not a format constant: it should cover the footer and whatever tail
+   sections the reader is about to need, and a reader that guesses short
+   simply issues step 3's extra ranged GET. `ravel-query`'s log fetcher probes
+   256 KiB, sized so that one probe carries the footer, SKIP_IDX and PAGE_DIR
+   past the BLOOM section that sits between them (ADR-0699 decision 5, issue
+   #766).
 3. Require `footer_len > 0` and `16 + footer_len <= total_size`;
    otherwise `Corrupted`. If the suffix did not cover the footer, issue
    one more ranged GET.
@@ -320,7 +326,11 @@ PAGE_DIR, and is the order PAGE_DIR lists them in. A whole-block reader
 verifies it; a reader taking a subset of the columns cannot (it does not have
 the other pages) and verifies each page's own crc32c instead. Both are
 mandatory on their own access path, which is what keeps every interpreted byte
-checksum-covered (ADR-0010 §4, "Checksum coverage map" below).
+checksum-covered (ADR-0010 §4, "Checksum coverage map" below). This is what
+lets a fetcher bring one coalesced byte range per `(row group, projected
+column)` and hand it to a projected decode: the range's holes -- pages of
+pruned blocks, and of columns the projection dropped -- are never interpreted,
+so nothing depends on a checksum over them.
 
 A reader may decode a *subset* of a block's columns (`read_block_columns`,
 ADR-0087); the SQL logs scan uses this to decode only the columns a query

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -185,12 +185,15 @@ is resolved against the object's own FIELD_DIR
   surviving blocks before it weighs the coverage crossover, so a selective
   query reads only those blocks (and the crossover fires only when the
   survivors genuinely cover >= 75% of the BLOCKS section — the threshold is
-  unchanged). This is byte-identical to the unpruned read: the skip index's
+  unchanged). On a version-4 object the unit is the surviving blocks' pages in
+  the projected columns' chunks rather than whole blocks; see "Requests per
+  object on a version-4 object" below. This is byte-identical to the unpruned
+  read: the skip index's
   per-block bounds are conservative (ADR-0013), so a block dropped at fetch is
   one the decode-side prune would drop anyway, and the reader still runs the
   full skip/POSTINGS/bloom prune over the fetched buffer.
 - **Plan side.** `plan_segment` counts survivors from the skip index alone
-  (footer + SKIP_IDX via the 64 KiB suffix probe, plus the object's FIELD_DIR
+  (footer + SKIP_IDX via the 256 KiB suffix probe, plus the object's FIELD_DIR
   to resolve the arms) and fetches no block, carrying the footer forward so
   each per-partition subset open skips its own probe (#693 part 3). This is
   sound because for a query the skip index can decide — ts bounds and NumRange
@@ -209,21 +212,54 @@ segment at or below the block-range threshold counts there too: the fetch reads
 such an object whole in one GET regardless, so planning it from the skip index
 would cost a second read rather than save one.
 
-Reference figures on the 8,424-object ClickBench tenant. The plan phase reads,
-per segment, one 64 KiB suffix probe (footer + SKIP_IDX) plus one small
-FIELD_DIR range GET to resolve the arms — the FIELD_DIR is a front section, so
-it cannot be folded into the tail probe — and fetches no block. Bytes are
-dominated by the probes: q37-class drops from 19,690 GETs and 11.7 GB to
-between about 8,600 GETs (the ~8,424 probes plus coalesced reads of about 144
-surviving blocks, when the probe's cached suffix already covers FIELD_DIR) and
-about 17,000 GETs (a separate FIELD_DIR range GET on every object as well),
-at 0.65 to 0.9 GB either way; q20 from 29,614 GETs and 17.9 GB to about 4 to
-4.7 GB (each of its ~6,592 surviving blocks read once, never a whole-object
-re-read). GET counts stay near two to three per object, because the object
-count is the floor: the plan phase's probe and FIELD_DIR range are one each
-per relevant object however selective the predicate is, and only the
-surviving-block and directory reads scale with the predicate. These are
-predictions; the measured pass on the reference tenant replaces them.
+### Requests per object on a version-4 object
+
+A version-4 RLOG object (ADR-0699) stores each row group's pages column-major
+and lists every page in PAGE_DIR, so the fetch unit is a column chunk rather
+than a block. The request law for one statement over one such object:
+
+**One suffix probe, plus one coalesced range per surviving `(row group,
+projected column)`, plus a FIELD_DIR range only when the probe's cached suffix
+does not already cover it.** That is one to three GETs per object for a typical
+narrow projection over a small object, and it grows with `row_groups x
+projected_columns` rather than with the object's block count.
+
+The pieces, and why each is where it is:
+
+- The 256 KiB suffix probe brings the footer, SKIP_IDX and PAGE_DIR in one GET.
+  It was 64 KiB until issue #766: BLOOM (86 KB mean on the reference tenant)
+  sits between SKIP_IDX and the footer, so the shorter probe missed SKIP_IDX on
+  68.8% of above-threshold objects and cost 4,415 extra GETs per predicated
+  statement. A probe that still falls short costs one extra GET, not one per
+  section: SKIP_IDX and PAGE_DIR are adjacent and are fetched as one range, and
+  `BlockRangeStats::probe_misses` reports the residual rate.
+- STREAM_DIR and FIELD_DIR sit at the object's *front*, so no suffix probe of
+  any length reaches them. FIELD_DIR is read only when the query needs it (a
+  NumRange arm to resolve, or a projection narrower than every column), and it
+  is an extra GET only when the probe's cached suffix does not cover it — which
+  on a small object, where the probe spans the whole object, it does.
+- Chunk ranges: one per surviving `(row group, projected column)`, fewer when
+  adjacent chunks coalesce, and one for the whole group when the projection
+  keeps every column and every block of the group survives. Pruned blocks' pages
+  are the holes inside those runs, read through or split around by the
+  `coalesce_gap` policy.
+- The 75% coverage crossover still applies, now against the projected page
+  bytes: an all-columns read of every block takes a single whole-object GET
+  instead.
+
+Reference figures on the 8,424-object ClickBench tenant, at version 4. A
+single-column, predicate-free statement reads 8,424 probes plus about one
+coalesced range per object (these objects hold roughly two blocks, so one row
+group), moving on the order of `1/N` of each object for `N` columns of similar
+width — a few hundred MB against the 11.1 GB the version-3 whole-object reads
+moved for the same statement. A selective statement adds its FIELD_DIR range
+where the probe did not cover it and reads only the surviving blocks' pages:
+q37-class drops from 19,690 GETs and 11.7 GB, and q20-class from 29,614 GETs and
+17.9 GB, to between one and three GETs per relevant object either way. The
+object count is the floor in every case: the probe is one per relevant object
+however selective the predicate or narrow the projection, and only the chunk
+ranges scale with them. These are predictions; the measured pass on the
+reference tenant replaces them.
 
 Staleness: the evaluator recognizes the Prometheus staleness marker (the
 exact NaN bit pattern `0x7ff0_0000_0000_0002`, compared via

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -219,8 +219,9 @@ and lists every page in PAGE_DIR, so the fetch unit is a column chunk rather
 than a block. The request law for one statement over one such object:
 
 **One suffix probe, plus one coalesced range per surviving `(row group,
-projected column)`, plus a FIELD_DIR range only when the probe's cached suffix
-does not already cover it.** That is one to three GETs per object for a typical
+projected column)`, plus front-section ranges (STREAM_DIR always, FIELD_DIR
+when the query carries numeric arms) only when the probe's cached suffix does
+not already cover them.** That is one to four GETs per object for a typical
 narrow projection over a small object, and it grows with `row_groups x
 projected_columns` rather than with the object's block count.
 
@@ -1675,13 +1676,15 @@ These are a decode-time measurement, a **different axis** from the wire bytes th
 `page_fetch` span and `s3_bytes` record (and from `BlockRangeStats::
 block_bytes_fetched`, the T1 block-range fetch counter above): they count stored
 page bytes that a fetched block already holds, not bytes moved over the network,
-so a projection changes `page_bytes_decoded` without changing any wire counter.
-Reading them together tells both stories in one place -- how many bytes the fetch
-brought in, and how many of the bytes already resident the decode actually
-needed. The instrument exists to measure whether block-level pruning alone
-already captures most of the realistic win before a future per-page-crc RLOG
-section is proposed to shrink the wire fetch to columns (ADR-0107 "Explicitly out
-of scope").
+so under version 3 a projection changes `page_bytes_decoded` without changing
+any wire counter. Under version 4 (ADR-0699 decision 5) the projection IS the
+fetch selection, so the wire counters shrink with it and the two axes move
+together; the gap between them is then only the pruned-page holes coalescing
+chose to fetch. Reading them together tells both stories in one place -- how
+many bytes the fetch brought in, and how many of the bytes already resident
+the decode actually needed. The instrument predates the version-4 fetcher and
+was what measured whether block-level pruning alone captured enough before
+PAGE_DIR shrank the wire fetch to columns.
 
 The per-query DataFusion memory pool now bounds concurrently-held scan memory:
 the reservation grows when a decoded block and the batch built from it are held

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -158,6 +158,70 @@ so it joins the assignment rather than vetoing it (ADR-0102 amendment
 2026-08-26, #739 -- as a query-wide conjunct the threshold let one small tail
 object per `(shard, hour)` disqualify an entire 8,424-object snapshot).
 
+## Selective (predicated) logs scan: request count
+
+A statement with a block-level predicate — a declared-column or `attrs`
+numeric comparison (the ClickBench q20 and q37-q43 shapes), a text
+`has_word`, a stream filter — is not block-predicate-free, so it takes the
+plan-then-stripe path, never the whole-segment fast path above. Before #761
+that path read every relevant object WHOLE twice over: the plan phase opened
+each segment to count survivors, and the scan's `fetch_object_with_footer`
+resolved candidate blocks by `SkipIndex::candidate_blocks(ts, ts, None, &[])`
+— no numeric arms — so every block was a ts candidate, the coverage crossover
+(`candidate_bytes / BLOCKS-section bytes >= 0.75`) fired, and the read
+collapsed to one whole-object GET. The predicate pruned blocks only at decode,
+shrinking `blocks_scanned` but not the bytes moved. On the 8,424-object
+ClickBench tenant (#680) q37 moved 19,690 GETs and 11.7 GB to decode 144 of
+17,731 blocks, and q20 moved 29,614 GETs and 17.9 GB — more than the 11.1 GB
+of objects on disk, because a cold cache re-read each surviving segment once
+per owning partition.
+
+#761 makes the prune-only `NumRange` arms drive candidate selection. Each arm
+is resolved against the object's own FIELD_DIR
+(`FieldDir::numeric_range_arms`) to its column id, then applied to
+`candidate_blocks` in two places:
+
+- **Fetch side.** `fetch_object_with_footer` prunes the candidate set to the
+  surviving blocks before it weighs the coverage crossover, so a selective
+  query reads only those blocks (and the crossover fires only when the
+  survivors genuinely cover >= 75% of the BLOCKS section — the threshold is
+  unchanged). This is byte-identical to the unpruned read: the skip index's
+  per-block bounds are conservative (ADR-0013), so a block dropped at fetch is
+  one the decode-side prune would drop anyway, and the reader still runs the
+  full skip/POSTINGS/bloom prune over the fetched buffer.
+- **Plan side.** `plan_segment` counts survivors from the skip index alone
+  (footer + SKIP_IDX via the 64 KiB suffix probe, plus the object's FIELD_DIR
+  to resolve the arms) and fetches no block, carrying the footer forward so
+  each per-partition subset open skips its own probe (#693 part 3). This is
+  sound because for a query the skip index can decide — ts bounds and NumRange
+  arms only — the reader's full prune reduces to its skip step, so the count
+  equals the survivor list the scan stripes. It takes at least one NumRange arm
+  to qualify: a query with no prune arm is skip-decidable too, but its plan read
+  already fetches only the ts-candidate blocks and warms exactly the extents the
+  subset opens stripe, so planning it this way would trade one shared read for
+  N per-partition ones over the same bytes.
+
+A predicate the skip index cannot decide — a `has_word`/text arm (bloom prunes
+it only at decode), an `attrs['k']='v'` POSTINGS equality, a stream filter —
+still reads the whole object in the plan phase and is counted in the
+`plan_full_reads` metric, so a report can see which statements still pay it. A
+segment at or below the block-range threshold counts there too: the fetch reads
+such an object whole in one GET regardless, so planning it from the skip index
+would cost a second read rather than save one.
+
+Reference figures on the 8,424-object ClickBench tenant. The plan phase reads,
+per segment, one 64 KiB suffix probe (footer + SKIP_IDX) plus one small
+FIELD_DIR range GET to resolve the arms — the FIELD_DIR is a front section, so
+it cannot be folded into the tail probe — and fetches no block. Bytes are
+dominated by the probes: q37-class drops from 19,690 GETs and 11.7 GB to about
+8,700 GETs and 0.65 to 0.9 GB (the ~8,424 probes plus coalesced reads of about
+144 surviving blocks), and q20 from 29,614 GETs and 17.9 GB to about 4 to
+4.7 GB (each of its ~6,592 surviving blocks read once, never a whole-object
+re-read). GET counts stay near two to three per object, because the object
+count is the floor: the plan phase's probe and FIELD_DIR range are one each per
+relevant object however selective the predicate is, and only the
+surviving-block and directory reads scale with the predicate.
+
 Staleness: the evaluator recognizes the Prometheus staleness marker (the
 exact NaN bit pattern `0x7ff0_0000_0000_0002`, compared via
 `f64::to_bits()`, never `is_nan()`). A selector whose newest in-window

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -213,14 +213,17 @@ Reference figures on the 8,424-object ClickBench tenant. The plan phase reads,
 per segment, one 64 KiB suffix probe (footer + SKIP_IDX) plus one small
 FIELD_DIR range GET to resolve the arms — the FIELD_DIR is a front section, so
 it cannot be folded into the tail probe — and fetches no block. Bytes are
-dominated by the probes: q37-class drops from 19,690 GETs and 11.7 GB to about
-8,700 GETs and 0.65 to 0.9 GB (the ~8,424 probes plus coalesced reads of about
-144 surviving blocks), and q20 from 29,614 GETs and 17.9 GB to about 4 to
+dominated by the probes: q37-class drops from 19,690 GETs and 11.7 GB to
+between about 8,600 GETs (the ~8,424 probes plus coalesced reads of about 144
+surviving blocks, when the probe's cached suffix already covers FIELD_DIR) and
+about 17,000 GETs (a separate FIELD_DIR range GET on every object as well),
+at 0.65 to 0.9 GB either way; q20 from 29,614 GETs and 17.9 GB to about 4 to
 4.7 GB (each of its ~6,592 surviving blocks read once, never a whole-object
 re-read). GET counts stay near two to three per object, because the object
-count is the floor: the plan phase's probe and FIELD_DIR range are one each per
-relevant object however selective the predicate is, and only the
-surviving-block and directory reads scale with the predicate.
+count is the floor: the plan phase's probe and FIELD_DIR range are one each
+per relevant object however selective the predicate is, and only the
+surviving-block and directory reads scale with the predicate. These are
+predictions; the measured pass on the reference tenant replaces them.
 
 Staleness: the evaluator recognizes the Prometheus staleness marker (the
 exact NaN bit pattern `0x7ff0_0000_0000_0002`, compared via

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -176,7 +176,7 @@ ClickBench tenant (#680) q37 moved 19,690 GETs and 11.7 GB to decode 144 of
 of objects on disk, because a cold cache re-read each surviving segment once
 per owning partition.
 
-#761 makes the prune-only `NumRange` arms drive candidate selection. Each arm
+Issue #761 makes the prune-only `NumRange` arms drive candidate selection. Each arm
 is resolved against the object's own FIELD_DIR
 (`FieldDir::numeric_range_arms`) to its column id, then applied to
 `candidate_blocks` in two places:


### PR DESCRIPTION
Selective logs statements read the whole dataset, and version 4 objects were read whole regardless of the predicate or the projection. This lands the two halves together, plus the probe fix they share.

**Numeric-arm pruning (#761).** `BlockRangeFetcher::resolve_extents` resolved candidate blocks from the ts range alone, so prune-only `NumRange` arms never reached the fetch: coverage read 1.0, the coverage crossover collapsed every read into one whole-object GET, and the plan phase re-probed per partition on a cold cache. The arms are now resolved against each object's own FIELD_DIR and passed to `candidate_blocks`; a skip-decidable plan branch counts survivors from the skip index without fetching a block; a `plan_full_reads` counter names the statements that still pay the plan-phase read. A block dropped at fetch is one the decode-side prune would have dropped (the skip index's bounds are conservative, ADR-0013), so results are byte-identical.

**PAGE_DIR chunk reads (#699, ADR-0699 decision 5).** A version 4 object is no longer read whole: the fetcher resolves, per row group, the surviving blocks and the projected columns' page ranges inside each column chunk, coalesces them, and issues them through the same cached extent path (etag pin held, concurrent partitions coalesce). A projected decode verifies each fetched page's own crc32c; the block crc stays for whole-block readers (both mandatory on their own access path, ADR-0010 §4). The 75% coverage crossover to a whole read stays.

**Probe raise (#766).** The 64 KiB suffix probe missed SKIP_IDX on 68.8% of reference-tenant objects because BLOOM (mean 86 KB) sits between SKIP_IDX and the footer, costing 4,415 extra GETs per predicated statement. The probe is 256 KiB, sized so one probe carries footer + SKIP_IDX + PAGE_DIR on both measured shapes; a miss costs one coalesced GET and is counted in a new `probe_misses` metric (pinned 0 on the fixtures).

Fixture figures (`logs_selective_scan_amplification.rs`, re-pinned on version 4 objects with each literal explained): selective shapes issue no whole-object GET and move only the surviving blocks' projected page bytes; the full scan reads exactly the object bytes; the cache-pressure case stays below one full pass with one probe per segment. Every re-pinned assertion was demonstrated red against the interim whole-object guard.

Docs: ADR-0102 amendment, ADR-0699's interim-reader amendment replaced by the as-built decision 5, docs/log-segment-format.md (probe length is a reader choice; the crc rule that legalizes holes in a coalesced range), docs/query-engine.md (the version 4 request-count law and prediction ranges the v19 pass will replace with measurements).

Fixes: #761
Fixes: #699
Fixes: #766
Refs: #680
