### PR TITLE
test(ravel-sql): drop the global panic hook and guard the key-length arithmetic

### DIFF
--- a/crates/ravel-sql/tests/group_by_string_keys.rs
+++ b/crates/ravel-sql/tests/group_by_string_keys.rs
@@ -400,16 +400,16 @@ async fn a_panicking_operator_surfaces_as_a_typed_error() {
         .await
         .expect("physical plan builds");
 
-    // The default hook would print the planted panic and its backtrace, which
-    // is correct in production and only noise here. Silence it for the poll,
-    // then put the previous hook back so a genuine test failure still reports.
-    let previous = std::panic::take_hook();
-    std::panic::set_hook(Box::new(|_| {}));
+    // The panic surfaces as a typed error at the stream boundary, which is
+    // what the assertions below check; there is nothing to read off a panic
+    // hook. Leaving the global hook untouched matters: cargo test runs this
+    // binary's tests on parallel threads, so swapping it here would swallow a
+    // concurrent test's panic output for the duration of the poll. The default
+    // hook printing the planted panic's backtrace is harmless noise.
     let mut stream =
         PinnedStream::start(ctx, plan, schema, CeilingBreach::new()).expect("stream starts");
     let first = stream.next().await;
     let second = stream.next().await;
-    std::panic::set_hook(previous);
 
     let err = match first {
         Some(Err(err)) => err,
@@ -487,6 +487,12 @@ fn key_context(
         let values: Vec<String> = (next..end)
             .map(|i| {
                 let mut s = format!("https://example.test/{i:012}/");
+                assert!(
+                    key_len >= s.len(),
+                    "key_len ({key_len}) must be at least the built prefix length ({}) \
+                     so the padding subtraction cannot underflow",
+                    s.len()
+                );
                 s.push_str(&"p".repeat(key_len - s.len()));
                 s
             })


### PR DESCRIPTION
Two test-hygiene fixes in the string-keyed GROUP BY tests, deferred from
PR #777's review.

The operator-panic test swapped the process-wide panic hook for the two
awaited stream polls and restored it afterward. Because cargo test runs a
binary's tests on parallel threads, a panic in a concurrent test during
that window lost its output. The hook only silenced the planted panic's
backtrace, which is harmless noise; the test's real evidence is the typed
SqlError::OperatorPanic the stream surfaces and its redacted message,
which the assertions already check. Removing the hook swap keeps every
concurrent test's panic output intact and loses no coverage.

The stress fixture built each key by padding a fixed prefix up to key_len
with s.push_str(&"p".repeat(key_len - s.len())). That subtraction
underflows and panics if a future key_len constant is smaller than the
built prefix. Assert the precondition once with a clear message before
the subtraction rather than switching to saturating_sub, which would
silently produce a shorter key and invalidate what the stress test
measures.

Fixes: #779
Refs: #737
Refs: #680

