### PR TITLE
fix(scripts): fold a leading wip commit into the deliverable on fleet merges

### DIFF
--- a/.claude/skills/fleet-task-spec/SKILL.md
+++ b/.claude/skills/fleet-task-spec/SKILL.md
@@ -252,14 +252,17 @@ the same turn as the `fleet_dispatch` call, every time.
    shape (a short SHA, a remote-only branch name, another task's result
    ref) run `git fetch origin <ref> --quiet && git rev-parse FETCH_HEAD`
    first; dispatch only pushes objects the local repo already has.
-2. **Check `git status --short` on the primary checkout.** The dispatch
-   push refuses to run on ANY uncommitted or untracked file, including a
-   stray build artifact (a leftover `__pycache__/` has blocked dispatch
-   after dispatch before anyone looked). Remove a file only when you can
-   attribute it to a command you ran yourself (a `__pycache__/` from your
-   own compile check). Any file you cannot attribute to yourself is
-   another session's: wait 30 s and retry, up to 3 times, since it
-   reliably self-clears, and never touch it and never ask the user.
+2. **A dirty tree does not block the push; it matters only when the
+   dispatch takes local HEAD.** The dispatch push is ref-based: it pushes
+   the objects behind the `ref` resolved in step 1, and it does not refuse
+   on uncommitted or untracked files. Observed 2026-08-25 (#687): five
+   dispatches pushed fine with three untracked, non-ignored files present
+   the whole time. So do not clean up, wait, or retry over a dirty
+   `git status --short`, and never touch a file you cannot attribute to a
+   command you ran yourself: it is another session's. The caveat that does
+   survive is the HEAD-implicit dispatch: when a dispatch uses local HEAD
+   instead of an explicit ref, uncommitted work decides what gets built,
+   so commit it (or pass the step-1 ref explicitly) first.
 
 ## After dispatch
 

--- a/scripts/fleet-result-merge.sh
+++ b/scripts/fleet-result-merge.sh
@@ -42,6 +42,189 @@
 # anything.
 set -euo pipefail
 
+# --- History-cleaning helpers --------------------------------------------
+#
+# These are defined before any argument handling so the file can be sourced
+# to get the rewrite without running a merge; that is what
+# scripts/tests/fleet-result-merge-squash.test.sh drives.
+#
+# Two classes of commit have reached protected main through fleet result
+# branches and must never survive into the merge:
+#
+#   1. `wip:` headers: executors that commit work-in-progress snapshots
+#      and never reword them.
+#   2. Pure formatting/style fixups: a commit appended after a failed
+#      `cargo fmt --all --check` whose only content is reformatting.
+#
+# Detection heuristic (documented so it can be tuned):
+#   - wip: subject line begins with `wip:` (case-insensitive).
+#   - formatting fixup: subject contains `fmt` or `style fix`
+#     (case-insensitive) AND the commit's diff against its parent is empty
+#     under `git diff -w` (all changes are whitespace/indentation only).
+#     `-w` will not catch a reformat that rewraps lines, so this is a
+#     conservative filter: it squashes only the unambiguous cases and
+#     leaves anything with a real content change untouched.
+
+# Return the leading `wip:` (case-insensitive) stripped from a subject.
+strip_wip() {
+  local s="$1"
+  s="${s#"${s%%[![:space:]]*}"}"
+  shopt -s nocasematch
+  if [[ "${s}" == wip:* ]]; then
+    s="${s#*:}"
+  fi
+  shopt -u nocasematch
+  s="${s#"${s%%[![:space:]]*}"}"
+  printf '%s' "${s}"
+}
+
+# True if a subject already opens with a Conventional Commits type token.
+has_cc_type() {
+  [[ "$1" =~ ^[a-zA-Z]+(\([^\)]+\))?!?:[[:space:]] ]]
+}
+
+# True if <sha> is a commit the rewrite must not keep on its own, per the
+# heuristic above.
+is_flagged_commit() {
+  local sha="$1" subject parent flagged=0
+  subject="$(git log -1 --format=%s "${sha}")"
+  shopt -s nocasematch
+  if [[ "${subject}" == wip:* ]]; then
+    flagged=1
+  elif [[ "${subject}" == *fmt* || "${subject}" == *"style fix"* ]]; then
+    parent="$(git rev-parse "${sha}^")"
+    if [[ -z "$(git diff -w "${parent}" "${sha}")" ]]; then
+      flagged=1
+    fi
+  fi
+  shopt -u nocasematch
+  [[ ${flagged} -eq 1 ]]
+}
+
+# Print <message> with every trailer of <donor-message> that it does not
+# already carry appended to it, so a Refs:/Fixes:/Signed-off-by: that lived
+# only on a folded commit is never dropped.
+merge_trailers() {
+  local message="$1" donor="$2" tl
+  local -a targs=()
+  while IFS= read -r tl; do
+    if [[ -n "${tl}" ]]; then
+      targs+=(--trailer "${tl}")
+    fi
+  done < <(printf '%s\n' "${donor}" | git interpret-trailers --parse)
+  if [[ ${#targs[@]} -gt 0 ]]; then
+    printf '%s\n' "${message}" | git interpret-trailers \
+      --if-exists addIfDifferent --if-missing add "${targs[@]}"
+  else
+    printf '%s\n' "${message}"
+  fi
+}
+
+# Rebuild <base>..<result-sha> linearly on <rewrite-branch>, folding every
+# flagged commit into the substantive commit it belongs to, and print the
+# resulting commit sha. Progress output goes to stderr so the sha is the
+# only thing on stdout. Leaves HEAD on <rewrite-branch>.
+#
+# A flagged commit that FOLLOWS a substantive one folds backwards into it.
+# A flagged commit that PRECEDES every substantive one folds forwards into
+# the first substantive commit instead: the commit-early practice puts a
+# `wip:` snapshot first on nearly every fleet branch, and keeping it as a
+# separate commit ahead of the deliverable splits one change into two
+# commits on main. The deliverable's message, author and sign-off win; the
+# wip content rides along, and any trailer that lived only on the wip
+# commit is carried over.
+#
+# A branch whose commits are ALL flagged has nothing to fold into, so its
+# first commit is reworded instead: the `wip:` prefix is stripped and, if
+# what remains has no Conventional Commits type, `chore:` is prepended so
+# the subject stays valid. <fallback-label> names the task in the subject
+# of a wip commit that has no text left after stripping.
+fleet_rewrite_history() {
+  local base="$1" result_sha="$2" rewrite_branch="$3" fallback_label="$4"
+  local sha subject stripped new_subject body msg_file
+  # retained: HEAD already holds a commit rebuilt from this branch.
+  # pending_wip: that commit is a provisional wip fold still looking for the
+  # deliverable to be folded into.
+  local retained=0 pending_wip=0
+
+  {
+    git checkout -q -B "${rewrite_branch}" "${base}"
+
+    while IFS= read -r sha; do
+      if ! is_flagged_commit "${sha}"; then
+        if [[ ${pending_wip} -eq 1 ]]; then
+          # Fold the leading wip content forwards into this deliverable,
+          # whose message and author replace the provisional ones.
+          git cherry-pick -n "${sha}"
+          msg_file="$(mktemp)"
+          merge_trailers "$(git log -1 --format=%B "${sha}")" \
+            "$(git log -1 --format=%B HEAD)" >"${msg_file}"
+          # --amend keeps the amended commit's author unless it is given a
+          # new one explicitly; GIT_AUTHOR_* alone would leave the wip
+          # commit's author on the deliverable.
+          git commit --amend --no-verify --allow-empty \
+            --author="$(git log -1 --format='%an <%ae>' "${sha}")" \
+            --date="$(git log -1 --format=%aI "${sha}")" \
+            -F "${msg_file}"
+          rm -f "${msg_file}"
+          pending_wip=0
+        else
+          # Ordinary commit: replay verbatim (author preserved by cherry-pick).
+          git cherry-pick "${sha}"
+        fi
+        retained=1
+        continue
+      fi
+
+      if [[ ${retained} -eq 0 ]]; then
+        # Nothing retained to fold into yet: commit provisionally under a
+        # valid subject. The next substantive commit amends this message
+        # away; it survives only on an all-flagged branch.
+        subject="$(git log -1 --format=%s "${sha}")"
+        stripped="$(strip_wip "${subject}")"
+        if [[ -z "${stripped}" ]]; then
+          new_subject="chore: fleet result for task ${fallback_label}"
+        elif has_cc_type "${stripped}"; then
+          new_subject="${stripped}"
+        else
+          new_subject="chore: ${stripped}"
+        fi
+        body="$(git log -1 --format=%b "${sha}")"
+        msg_file="$(mktemp)"
+        if [[ -n "${body}" ]]; then
+          printf '%s\n\n%s\n' "${new_subject}" "${body}" >"${msg_file}"
+        else
+          printf '%s\n' "${new_subject}" >"${msg_file}"
+        fi
+        git cherry-pick -n "${sha}"
+        GIT_AUTHOR_NAME="$(git log -1 --format=%an "${sha}")" \
+        GIT_AUTHOR_EMAIL="$(git log -1 --format=%ae "${sha}")" \
+        GIT_AUTHOR_DATE="$(git log -1 --format=%aI "${sha}")" \
+          git commit --no-verify -F "${msg_file}"
+        rm -f "${msg_file}"
+        retained=1
+        pending_wip=1
+      else
+        # Fold into whatever HEAD holds, preserving its trailers.
+        git cherry-pick -n "${sha}"
+        msg_file="$(mktemp)"
+        merge_trailers "$(git log -1 --format=%B HEAD)" \
+          "$(git log -1 --format=%B "${sha}")" >"${msg_file}"
+        git commit --amend --no-verify --allow-empty -F "${msg_file}"
+        rm -f "${msg_file}"
+      fi
+    done < <(git rev-list --reverse "${base}..${result_sha}")
+  } >&2
+
+  git rev-parse HEAD
+}
+
+# Sourced rather than executed: stop here, with the helpers above defined and
+# nothing run. Everything below this line performs a merge.
+if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+  return 0
+fi
+
 if [[ $# -lt 2 ]]; then
   echo "usage: $0 <task-id> <message-file> [-p CRATE ...]" >&2
   exit 64
@@ -133,145 +316,21 @@ if [[ -n "$(git rev-list --merges "${base}..${result_sha}")" ]]; then
 fi
 
 # --- Squash wip:/formatting-fixup commits out of the result branch -------
-#
-# Two classes of commit have reached protected main through fleet result
-# branches and must never survive into the merge:
-#
-#   1. `wip:` headers: executors that commit work-in-progress snapshots
-#      and never reword them.
-#   2. Pure formatting/style fixups: a commit appended after a failed
-#      `cargo fmt --all --check` whose only content is reformatting.
-#
-# Detection heuristic (documented so it can be tuned):
-#   - wip: subject line begins with `wip:` (case-insensitive).
-#   - formatting fixup: subject contains `fmt` or `style fix`
-#     (case-insensitive) AND the commit's diff against its parent is empty
-#     under `git diff -w` (all changes are whitespace/indentation only).
-#     `-w` will not catch a reformat that rewraps lines, so this is a
-#     conservative filter: it squashes only the unambiguous cases and
-#     leaves anything with a real content change untouched.
-#
-# Rewrite: history is rebuilt linearly with cherry-pick. Each flagged commit
-# is folded (`fixup`-style) into the previous retained commit, but its own
-# Refs:/Fixes:/Signed-off-by: trailers are carried into that commit's
-# message if they are not already there, so a required trailer that lived
-# only on a `wip:` snapshot is never dropped. A flagged commit that is the
-# FIRST retained commit has nothing to fold into, so it is reworded instead:
-# its `wip:` prefix is stripped and, if what remains has no Conventional
-# Commits type, a `chore:` type is prepended so the subject stays valid.
-branch_commits=()
-while IFS= read -r c; do
-  branch_commits+=("${c}")
-done < <(git rev-list --reverse "${base}..${result_sha}")
-
-# Return the leading `wip:` (case-insensitive) stripped from a subject.
-strip_wip() {
-  local s="$1"
-  s="${s#"${s%%[![:space:]]*}"}"
-  shopt -s nocasematch
-  if [[ "${s}" == wip:* ]]; then
-    s="${s#*:}"
-  fi
-  shopt -u nocasematch
-  s="${s#"${s%%[![:space:]]*}"}"
-  printf '%s' "${s}"
-}
-
-# True if a subject already opens with a Conventional Commits type token.
-has_cc_type() {
-  [[ "$1" =~ ^[a-zA-Z]+(\([^\)]+\))?!?:[[:space:]] ]]
-}
-
+# The detection heuristic and the fold rules are documented on
+# is_flagged_commit and fleet_rewrite_history at the top of this file.
 need_rewrite=0
-for sha in "${branch_commits[@]+"${branch_commits[@]}"}"; do
-  subject="$(git log -1 --format=%s "${sha}")"
-  shopt -s nocasematch
-  if [[ "${subject}" == wip:* ]]; then
+while IFS= read -r c; do
+  if is_flagged_commit "${c}"; then
     need_rewrite=1
-  elif [[ "${subject}" == *fmt* || "${subject}" == *"style fix"* ]]; then
-    parent="$(git rev-parse "${sha}^")"
-    if [[ -z "$(git diff -w "${parent}" "${sha}")" ]]; then
-      need_rewrite=1
-    fi
   fi
-  shopt -u nocasematch
-done
+done < <(git rev-list --reverse "${base}..${result_sha}")
 
 clean_ref="${result_sha}"
 
 if [[ ${need_rewrite} -eq 1 ]]; then
   echo "==> Squashing wip:/formatting-fixup commits out of the result branch"
   rewrite_branch="_fleet_rewrite_${task_id//\//_}"
-  git checkout -q -B "${rewrite_branch}" "${base}"
-
-  have_real=0
-  for sha in "${branch_commits[@]+"${branch_commits[@]}"}"; do
-    subject="$(git log -1 --format=%s "${sha}")"
-    flagged=0
-    shopt -s nocasematch
-    if [[ "${subject}" == wip:* ]]; then
-      flagged=1
-    elif [[ "${subject}" == *fmt* || "${subject}" == *"style fix"* ]]; then
-      parent="$(git rev-parse "${sha}^")"
-      if [[ -z "$(git diff -w "${parent}" "${sha}")" ]]; then
-        flagged=1
-      fi
-    fi
-    shopt -u nocasematch
-
-    if [[ ${flagged} -eq 0 ]]; then
-      # Ordinary commit: replay verbatim (author preserved by cherry-pick).
-      git cherry-pick "${sha}"
-      have_real=1
-      continue
-    fi
-
-    if [[ ${have_real} -eq 0 ]]; then
-      # First retained commit is flagged: reword it into a valid subject.
-      stripped="$(strip_wip "${subject}")"
-      if [[ -z "${stripped}" ]]; then
-        new_subject="chore: fleet result for task ${task_id}"
-      elif has_cc_type "${stripped}"; then
-        new_subject="${stripped}"
-      else
-        new_subject="chore: ${stripped}"
-      fi
-      body="$(git log -1 --format=%b "${sha}")"
-      msg_file="$(mktemp)"
-      if [[ -n "${body}" ]]; then
-        printf '%s\n\n%s\n' "${new_subject}" "${body}" >"${msg_file}"
-      else
-        printf '%s\n' "${new_subject}" >"${msg_file}"
-      fi
-      git cherry-pick -n "${sha}"
-      GIT_AUTHOR_NAME="$(git log -1 --format=%an "${sha}")" \
-      GIT_AUTHOR_EMAIL="$(git log -1 --format=%ae "${sha}")" \
-      GIT_AUTHOR_DATE="$(git log -1 --format=%aI "${sha}")" \
-        git commit --no-verify -F "${msg_file}"
-      rm -f "${msg_file}"
-      have_real=1
-    else
-      # Fold into the previous retained commit, preserving its trailers.
-      git cherry-pick -n "${sha}"
-      targs=()
-      while IFS= read -r tl; do
-        [[ -n "${tl}" ]] && targs+=(--trailer "${tl}")
-      done < <(git log -1 --format=%B "${sha}" | git interpret-trailers --parse)
-      cur_msg="$(git log -1 --format=%B HEAD)"
-      msg_file="$(mktemp)"
-      if [[ ${#targs[@]} -gt 0 ]]; then
-        printf '%s\n' "${cur_msg}" | git interpret-trailers \
-          --if-exists addIfDifferent --if-missing add \
-          "${targs[@]}" >"${msg_file}"
-      else
-        printf '%s\n' "${cur_msg}" >"${msg_file}"
-      fi
-      git commit --amend --no-verify --allow-empty -F "${msg_file}"
-      rm -f "${msg_file}"
-    fi
-  done
-
-  clean_ref="$(git rev-parse HEAD)"
+  clean_ref="$(fleet_rewrite_history "${base}" "${result_sha}" "${rewrite_branch}" "${task_id}")"
   git checkout -q "${start_checkout}"
 fi
 # --- end squash step -----------------------------------------------------

--- a/scripts/tests/fleet-result-merge-squash.test.sh
+++ b/scripts/tests/fleet-result-merge-squash.test.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# History shapes scripts/fleet-result-merge.sh's rewrite must produce. Run:
+#   bash scripts/tests/fleet-result-merge-squash.test.sh
+#
+# The merge script is sourced, not executed, so only its rewrite helpers run:
+# every case builds a throwaway repo under $TMPDIR and rewrites it there.
+# Nothing is fetched, pushed, or merged.
+set -uo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")/.." && pwd)/fleet-result-merge.sh"
+# shellcheck source=../fleet-result-merge.sh
+source "${SCRIPT}"
+# The merge script turns on errexit for its own main body. Cases below capture
+# exit codes explicitly instead, and re-enable errexit inside their subshell.
+set +e
+
+tmproot="$(mktemp -d "${TMPDIR:-/tmp}/fleet-merge-squash.XXXXXX")"
+if [[ ! -d "${tmproot}" ]]; then
+  echo "FAIL  could not create a temp dir for the scratch repos" >&2
+  exit 1
+fi
+trap 'rm -rf "${tmproot}"' EXIT
+
+pass=0
+fail=0
+
+check_eq() {
+  local label="$1" want="$2" got="$3"
+  if [[ "${got}" == "${want}" ]]; then
+    pass=$((pass + 1))
+    printf 'ok    %s\n' "${label}"
+  else
+    fail=$((fail + 1))
+    printf 'FAIL  %s\n  want:\n%s\n  got:\n%s\n' "${label}" "${want}" "${got}"
+  fi
+}
+
+# new_repo <dir>: a scratch repo with one seed commit. Prints nothing; the
+# seed commit is the rewrite base.
+new_repo() {
+  local dir="$1"
+  mkdir -p "${dir}"
+  git -C "${dir}" init -q -b main
+  git -C "${dir}" config user.email "executor@example.test"
+  git -C "${dir}" config user.name "Scratch Executor"
+  git -C "${dir}" config commit.gpgsign false
+  printf 'seed\n' >"${dir}/README.md"
+  git -C "${dir}" add README.md
+  git -C "${dir}" commit -q -s -m "chore: seed the scratch repo"
+}
+
+# commit_in <dir> <file> <subject> <body> <author>: one commit adding <file>,
+# signed off by the repo identity so trailer handling is exercised.
+commit_in() {
+  local dir="$1" file="$2" subject="$3" body="$4" author="$5"
+  printf '%s\n' "${file}" >"${dir}/${file}"
+  git -C "${dir}" add -A
+  if [[ -n "${body}" ]]; then
+    git -C "${dir}" commit -q -s --author="${author}" -m "${subject}" -m "${body}"
+  else
+    git -C "${dir}" commit -q -s --author="${author}" -m "${subject}"
+  fi
+}
+
+# rewrite <dir> <base>: run the rewrite over <base>..HEAD in <dir> and print
+# the resulting sha. Progress and git chatter go to <dir>/rewrite.log.
+rewrite() {
+  local dir="$1" base="$2"
+  (
+    cd "${dir}" || exit 1
+    set -e
+    fleet_rewrite_history "${base}" "$(git rev-parse HEAD)" "_rewrite_test" "task-1234"
+  ) 2>"${dir}/rewrite.log"
+}
+
+# The three assertions each case makes: the commit shape (subject + author,
+# oldest first), the trailers of the final commit, and the files the rewrite
+# carried into the tree.
+shape_of() { git -C "$1" log --reverse --format='%s | %an <%ae>' "$2..$3"; }
+trailers_of() { git -C "$1" log -1 --format=%B "$2" | git interpret-trailers --parse; }
+files_of() { git -C "$1" ls-tree -r --name-only "$2"; }
+
+WIP_AUTHOR="Wip Author <wip@example.test>"
+DELIVERABLE_AUTHOR="Deliverable Author <deliverable@example.test>"
+SIGNOFF="Signed-off-by: Scratch Executor <executor@example.test>"
+
+run_case() {
+  local label="$1" dir="$2" want_shape="$3" want_trailers="$4" want_files="$5"
+  local base clean code=0
+  base="$(git -C "${dir}" rev-parse "HEAD~$6")"
+  clean="$(rewrite "${dir}" "${base}")" || code=$?
+  if [[ ${code} -ne 0 || -z "${clean}" ]]; then
+    fail=$((fail + 1))
+    printf 'FAIL  %s: rewrite exited %s\n' "${label}" "${code}"
+    cat "${dir}/rewrite.log"
+    return
+  fi
+  printf '\n--- %s ---\n' "${label}"
+  git -C "${dir}" log --reverse --format='commit %h  %an <%ae>%n%B----' "${base}..${clean}"
+  check_eq "${label}: commit shape" "${want_shape}" "$(shape_of "${dir}" "${base}" "${clean}")"
+  check_eq "${label}: trailers" "${want_trailers}" "$(trailers_of "${dir}" "${clean}")"
+  check_eq "${label}: files" "${want_files}" "$(files_of "${dir}" "${clean}")"
+}
+
+# (a) A leading wip: commit folds forwards into the deliverable that follows.
+# The deliverable's subject and author win; the wip's content and its
+# wip-only Refs: trailer ride along. This is issue #659: the old rewrite
+# reworded the wip to `chore:` and left it as a separate commit ahead of the
+# deliverable (PR #658, b6181104 on #602).
+dir="${tmproot}/wip-first"
+new_repo "${dir}"
+commit_in "${dir}" notes.txt "wip: doc comment for the new module" "Refs: #659" "${WIP_AUTHOR}"
+commit_in "${dir}" deliverable.txt "feat(scratch): add the deliverable" "The real change." "${DELIVERABLE_AUTHOR}"
+run_case "wip-first + feat" "${dir}" \
+  "feat(scratch): add the deliverable | ${DELIVERABLE_AUTHOR}" \
+  "${SIGNOFF}
+Refs: #659" \
+  "README.md
+deliverable.txt
+notes.txt" 2
+
+# (b) A trailing wip: fixup still folds backwards into the deliverable it
+# fixes up (the behavior that already worked; this pins it).
+dir="${tmproot}/wip-last"
+new_repo "${dir}"
+commit_in "${dir}" deliverable.txt "feat(scratch): add the deliverable" "The real change." "${DELIVERABLE_AUTHOR}"
+commit_in "${dir}" typo.txt "wip: fix a typo" "Refs: #659" "${WIP_AUTHOR}"
+run_case "feat + wip-fixup" "${dir}" \
+  "feat(scratch): add the deliverable | ${DELIVERABLE_AUTHOR}" \
+  "${SIGNOFF}
+Refs: #659" \
+  "README.md
+deliverable.txt
+typo.txt" 2
+
+# (c) A branch that is only wip: commits has nothing to fold forwards into,
+# so it keeps the rename behavior: one commit, `wip:` stripped, `chore:`
+# prepended, the first wip commit's author kept.
+dir="${tmproot}/only-wip"
+new_repo "${dir}"
+commit_in "${dir}" notes.txt "wip: doc comment for the new module" "Refs: #659" "${WIP_AUTHOR}"
+commit_in "${dir}" more.txt "wip: more notes" "" "${WIP_AUTHOR}"
+run_case "only wip" "${dir}" \
+  "chore: doc comment for the new module | ${WIP_AUTHOR}" \
+  "Refs: #659
+${SIGNOFF}" \
+  "README.md
+more.txt
+notes.txt" 2
+
+# (d) The forward fold consumes the FIRST deliverable only: a second
+# substantive commit stays its own commit.
+dir="${tmproot}/wip-first-two-feats"
+new_repo "${dir}"
+commit_in "${dir}" notes.txt "wip: doc comment for the new module" "Refs: #659" "${WIP_AUTHOR}"
+commit_in "${dir}" deliverable.txt "feat(scratch): add the deliverable" "The real change." "${DELIVERABLE_AUTHOR}"
+commit_in "${dir}" followup.txt "feat(scratch): add a follow-up" "More." "${DELIVERABLE_AUTHOR}"
+run_case "wip-first + feat + feat" "${dir}" \
+  "feat(scratch): add the deliverable | ${DELIVERABLE_AUTHOR}
+feat(scratch): add a follow-up | ${DELIVERABLE_AUTHOR}" \
+  "${SIGNOFF}" \
+  "README.md
+deliverable.txt
+followup.txt
+notes.txt" 3
+
+printf '\n%d passed, %d failed\n' "${pass}" "${fail}"
+if [[ ${fail} -ne 0 ]]; then
+  exit 1
+fi

--- a/scripts/verify-dispatch-gates.sh
+++ b/scripts/verify-dispatch-gates.sh
@@ -10,9 +10,11 @@
 # Usage: verify-dispatch-gates.sh <ref> <worktree-parent-dir>
 #
 # <ref> is anything `git worktree add` accepts: a branch, a tag, a SHA.
-# <worktree-parent-dir> MUST be outside this repo's working tree: an
-# untracked worktree left inside the repo blocks the next fleet_dispatch,
-# which refuses to run against a dirty primary checkout.
+# <worktree-parent-dir> MUST be outside this repo's working tree: a
+# worktree left inside the repo shows up as untracked content on the
+# primary checkout, gets swept into any dispatch that takes local HEAD
+# implicitly, and pollutes every `git status` a session reads (the
+# dispatch push itself is ref-based and does not refuse on it; #687).
 #
 # Prints each gate command as it runs. Exits 0 only if every gate passes;
 # on the first failure, prints which command failed and its exit code,


### PR DESCRIPTION
fix(scripts): fold a leading wip commit into the deliverable on fleet merges

fleet-result-merge.sh squashed wip and fixup commits that FOLLOWED a
substantive commit, but a wip commit that came first (the step-0
commit-early practice every fleet spec asks for) was renamed to chore:
and kept as its own commit ahead of the deliverable. The rewrite now
folds a leading flagged commit into the first substantive commit that
follows it: the deliverable's subject, body, author, author date and
sign-off win, the wip content rides along, and wip-only trailers are
added if missing. A branch that is only wip commits keeps the rename.
git commit --amend ignores GIT_AUTHOR_*, so the fold passes --author
and --date explicitly; the test caught the wrong attribution.

The rewrite is extracted into fleet_rewrite_history behind a source
guard so scripts/tests/fleet-result-merge-squash.test.sh can drive it
against scratch repos: wip-first + feat, feat + wip-fixup, only-wip,
and wip + feat + feat, asserting the exact log shape, trailers and
files (12 assertions; 3 fail with the fold disabled).

The fleet-task-spec skill's dispatch preflight said the push refuses on
any untracked file and prescribed a 30 s retry loop; five dispatches on
2026-08-25 pushed fine with untracked files present. The skill now says
the push is ref-based, and keeps the one real caveat: a dispatch that
takes local HEAD builds whatever is committed there.

Fixes: #659
Fixes: #687
Refs: #680
