### PR TITLE
perf(ravel-catalog): cache hot commit records across resolves

### DIFF
--- a/crates/ravel-catalog/src/cache.rs
+++ b/crates/ravel-catalog/src/cache.rs
@@ -1,13 +1,20 @@
 //! Bounded per-tenant cache of decoded commit records, keyed by full object
 //! key (docs/catalog-and-mvcc.md step 2, ADR-0010 §10).
 //!
-//! Capacity-cap eviction (FIFO): the simpler of the two strategies the ADR
-//! explicitly allows ("simple LRU or capacity cap per tenant"). Commit
-//! records are immutable once published (Phase 1 has no deletion), so
-//! eviction only costs a re-GET+decode on the next miss, never
-//! correctness. Field validation against the expected (tenant, signal,
-//! shard) happens in the caller on every hit and every fresh decode, not
-//! here: the cache only stores and evicts.
+//! LRU eviction, the other of the two strategies the ADR allows ("simple LRU
+//! or capacity cap per tenant"). The cache outlives any one resolve, so the
+//! hot ingest hours a query keeps returning to must not be evicted by a
+//! one-off wide scan or a fold's sweep of older buckets, which is exactly
+//! what insertion-order eviction does to them. Commit records are immutable
+//! once published (Phase 1 has no deletion), so eviction only costs a
+//! re-GET+decode on the next miss, never correctness. Field validation
+//! against the expected (tenant, signal, shard) happens in the caller on
+//! every hit and every fresh decode, not here: the cache only stores and
+//! evicts.
+//!
+//! A `capacity` of 0 is the disabled sentinel (matching
+//! [`CatalogConfig::byte_cache_max_bytes`](crate::CatalogConfig::byte_cache_max_bytes)):
+//! nothing is admitted at all, so every read falls through to a store GET.
 //!
 //! Every `get()` below also records a hit or a miss, and a hit's stored byte
 //! size, into the caller's [`QueryAccounting`] (ADR-0044): the
@@ -28,29 +35,77 @@ use ravel_types::{Signal, TenantHash};
 
 use crate::snapshot_format::{DecodedPart, DecodedPostings};
 
+/// One cached commit record plus the recency stamp that positions it in
+/// [`TenantCache::by_use`].
+struct RecordEntry {
+    record: Arc<CommitRecord>,
+    /// Size of the raw object this was decoded from, captured at insert so a
+    /// hit never re-derives it (see the module docs on accounting).
+    bytes: u64,
+    use_tick: u64,
+}
+
 #[derive(Default)]
 struct TenantCache {
-    entries: HashMap<String, (Arc<CommitRecord>, u64)>,
-    /// Insertion order, oldest first, for capacity-cap eviction.
-    order: std::collections::VecDeque<String>,
+    entries: HashMap<String, RecordEntry>,
+    /// Recency index, least-recently-used first: `use_tick -> key`, in step
+    /// with `entries`. A monotonic tick keeps a touch O(log n) rather than
+    /// the O(n) a queue would cost, which matters because a single resolve
+    /// over a hot ingest hour touches every entry twice (the concurrent
+    /// prewarm, then the sequential include pass).
+    by_use: std::collections::BTreeMap<u64, String>,
+    next_tick: u64,
 }
 
 impl TenantCache {
+    /// Return the entry for `key` and mark it most-recently-used, or `None`
+    /// when absent (an absent key leaves the recency order untouched).
+    fn touch(&mut self, key: &str) -> Option<(Arc<CommitRecord>, u64)> {
+        let tick = self.next_tick;
+        let entry = self.entries.get_mut(key)?;
+        let previous = entry.use_tick;
+        entry.use_tick = tick;
+        let hit = (entry.record.clone(), entry.bytes);
+        self.by_use.remove(&previous);
+        self.by_use.insert(tick, key.to_string());
+        self.next_tick += 1;
+        Some(hit)
+    }
+
     fn insert(&mut self, key: String, record: Arc<CommitRecord>, bytes: u64, capacity: usize) {
-        if self.entries.contains_key(&key) {
+        if capacity == 0 {
             return;
         }
-        self.entries.insert(key.clone(), (record, bytes));
-        self.order.push_back(key);
-        while self.order.len() > capacity.max(1) {
-            if let Some(oldest) = self.order.pop_front() {
-                self.entries.remove(&oldest);
-            }
+        // Already held: records are immutable, so keep the stored value and
+        // only refresh its recency.
+        if self.touch(&key).is_some() {
+            return;
+        }
+        let tick = self.next_tick;
+        self.next_tick += 1;
+        self.entries.insert(
+            key.clone(),
+            RecordEntry {
+                record,
+                bytes,
+                use_tick: tick,
+            },
+        );
+        self.by_use.insert(tick, key);
+        while self.entries.len() > capacity {
+            let Some((_, evicted)) = self.by_use.pop_first() else {
+                break;
+            };
+            self.entries.remove(&evicted);
         }
     }
 }
 
-/// Decoded-record cache, partitioned by tenant.
+/// Decoded-record cache, partitioned by tenant. Process-wide: one `Catalog`
+/// is built per process and held for its lifetime, so an entry admitted by one
+/// resolve is served to every later resolve over the same object key, which is
+/// what makes a repeated resolve over an unsealed ingest hour cost its LISTs
+/// and nothing else (issue #783).
 #[derive(Default)]
 pub(crate) struct RecordCache {
     tenants: Mutex<HashMap<TenantHash, TenantCache>>,
@@ -66,8 +121,8 @@ impl RecordCache {
         let hit = self
             .tenants
             .lock()
-            .get(tenant)
-            .and_then(|c| c.entries.get(key).cloned());
+            .get_mut(tenant)
+            .and_then(|c| c.touch(key));
         match hit {
             Some((record, bytes)) => {
                 accounting.record_cache_hit();
@@ -104,7 +159,7 @@ impl RecordCache {
     pub(crate) fn invalidate_prefix(&self, tenant: &TenantHash, prefix: &str) {
         if let Some(cache) = self.tenants.lock().get_mut(tenant) {
             cache.entries.retain(|k, _| !k.starts_with(prefix));
-            cache.order.retain(|k| !k.starts_with(prefix));
+            cache.by_use.retain(|_, k| !k.starts_with(prefix));
         }
     }
 
@@ -542,6 +597,83 @@ mod tests {
         assert!(cache.get(&tenant, "k2", &accounting).is_some());
         assert!(cache.get(&tenant, "k3", &accounting).is_some());
         assert!(cache.get(&tenant, "k4", &accounting).is_some());
+    }
+
+    /// The one case that separates LRU from insertion-order eviction: a read
+    /// of the oldest entry protects it, and the next-oldest goes instead. A
+    /// hot ingest hour queries keep returning to must survive a wider scan
+    /// admitted after it (issue #783), which insertion-order eviction cannot
+    /// give.
+    #[test]
+    fn lru_evicts_the_least_recently_used() {
+        let cache = RecordCache::default();
+        let tenant = TenantHash([16; 16]);
+        let accounting = QueryAccounting::new();
+        for i in 0..3 {
+            cache.insert(tenant, format!("k{i}"), Arc::new(record([16; 16], 0)), 1, 3);
+        }
+        // Read the oldest-inserted entry: now the least-recently-used is k1.
+        assert!(cache.get(&tenant, "k0", &accounting).is_some());
+        cache.insert(
+            tenant,
+            "k3".to_string(),
+            Arc::new(record([16; 16], 0)),
+            1,
+            3,
+        );
+
+        assert!(
+            cache.get(&tenant, "k0", &accounting).is_some(),
+            "the re-read entry must survive; insertion-order eviction would have dropped it"
+        );
+        assert!(
+            cache.get(&tenant, "k1", &accounting).is_none(),
+            "the least-recently-used entry must be the one evicted"
+        );
+        assert!(cache.get(&tenant, "k2", &accounting).is_some());
+        assert!(cache.get(&tenant, "k3", &accounting).is_some());
+    }
+
+    /// A re-insert of a key already held refreshes its recency rather than
+    /// being ignored: the resolve's prewarm and include passes both go
+    /// through `insert`/`get` for the same key, so an ignored re-insert would
+    /// leave a record the resolve just used looking stale to eviction.
+    #[test]
+    fn reinsert_refreshes_recency() {
+        let cache = RecordCache::default();
+        let tenant = TenantHash([17; 16]);
+        let accounting = QueryAccounting::new();
+        for i in 0..3 {
+            cache.insert(tenant, format!("k{i}"), Arc::new(record([17; 16], 0)), 1, 3);
+        }
+        cache.insert(
+            tenant,
+            "k0".to_string(),
+            Arc::new(record([17; 16], 0)),
+            1,
+            3,
+        );
+        cache.insert(
+            tenant,
+            "k3".to_string(),
+            Arc::new(record([17; 16], 0)),
+            1,
+            3,
+        );
+
+        assert!(cache.get(&tenant, "k0", &accounting).is_some());
+        assert!(cache.get(&tenant, "k1", &accounting).is_none());
+    }
+
+    /// `0` is the disabled sentinel: nothing is admitted, so every read is a
+    /// miss and falls through to a store GET.
+    #[test]
+    fn zero_capacity_admits_nothing() {
+        let cache = RecordCache::default();
+        let tenant = TenantHash([18; 16]);
+        let accounting = QueryAccounting::new();
+        cache.insert(tenant, "k".to_string(), Arc::new(record([18; 16], 0)), 1, 0);
+        assert!(cache.get(&tenant, "k", &accounting).is_none());
     }
 
     #[test]

--- a/crates/ravel-catalog/src/config.rs
+++ b/crates/ravel-catalog/src/config.rs
@@ -6,9 +6,25 @@ use crate::snapshot_format;
 pub const DEFAULT_MAX_INGEST_LAG_NS: i64 = 2 * 60 * 60 * 1_000_000_000;
 /// Default `clock_skew_allowance`: 5 minutes, in nanoseconds.
 pub const DEFAULT_CLOCK_SKEW_ALLOWANCE_NS: i64 = 5 * 60 * 1_000_000_000;
-/// Default bound on decoded commit records cached per tenant. Not named in
-/// the ADR; a capacity cap is the simpler of the two eviction strategies it
-/// explicitly allows ("simple LRU or capacity cap per tenant").
+/// Default bound on decoded commit records cached per tenant, in entries.
+/// Not named in the ADR, which allows "simple LRU or capacity cap per
+/// tenant"; the cache is an LRU (crate::cache).
+///
+/// 10,000 entries is sized so a tenant with a 10,000-segment hot region --
+/// the unsealed `max_flush_lifetime + clock_skew_allowance +
+/// fold_safety_margin` tail every query touches, since no fold has sealed it
+/// yet -- fits entirely, so a repeated resolve over it re-issues no
+/// per-record GET (issue #783). An entry costs roughly 750 bytes: a 119-byte
+/// commit key held twice (the map key and the recency index), the 200-byte
+/// decoded `CommitRecord` plus about 200 bytes of its own heap (tenant hash,
+/// writer uuid, data object key, content hash), and the two maps' slot
+/// overhead. The default is therefore about 8 MB per actively-queried tenant,
+/// reclaimed by the idle-tenant sweep
+/// ([`Catalog::evict_idle_tenants`](crate::Catalog::evict_idle_tenants)).
+///
+/// `0` is the disabled sentinel: nothing is admitted and every record read
+/// falls through to a store GET, matching
+/// [`CatalogConfig::byte_cache_max_bytes`]'s own `0` sentinel.
 pub const DEFAULT_CACHE_CAPACITY_PER_TENANT: usize = 10_000;
 /// Default `max_flush_lifetime`: 1 hour, in nanoseconds. The GC interlock
 /// (ADR-0010 §11) forbids publishing a commit record after this long past
@@ -161,8 +177,10 @@ pub struct CatalogConfig {
     /// absorb writer clock skew, in nanoseconds. Default 5m
     /// ([`DEFAULT_CLOCK_SKEW_ALLOWANCE_NS`]).
     pub clock_skew_allowance_ns: i64,
-    /// Bound on decoded commit records cached per tenant. Default
-    /// [`DEFAULT_CACHE_CAPACITY_PER_TENANT`].
+    /// Bound on decoded commit records cached per tenant, in entries, evicted
+    /// least-recently-used. `0` disables the cache entirely. Default
+    /// [`DEFAULT_CACHE_CAPACITY_PER_TENANT`], which carries the per-entry size
+    /// and the hot-region sizing rationale.
     pub cache_capacity_per_tenant: usize,
     /// Longest a writer may take to publish a commit record after its
     /// ingest hour ends, in nanoseconds. Part of the seal-watermark margin (ADR-0020). Default

--- a/crates/ravel-catalog/tests/hot_record_cache.rs
+++ b/crates/ravel-catalog/tests/hot_record_cache.rs
@@ -1,0 +1,469 @@
+//! Issue #783: a repeated resolve over an unsealed ingest hour costs its
+//! LISTs and nothing else.
+//!
+//! The newest `max_flush_lifetime + clock_skew_allowance +
+//! fold_safety_margin` of any tenant is always unsealed, so no snapshot part
+//! covers it and every query resolves it by listing the buckets and reading
+//! each commit record. The LIST must run every time (it is what discovers new
+//! records); the per-record GET must not, because a commit record is
+//! immutable once published. These tests pin that split by exact GET counts
+//! against a store double that records every key, and pin what the bound and
+//! a mid-resolve fault do to it.
+//!
+//! The red lever for four of these is one line: the `return Ok(cached)` in
+//! `Catalog::load_and_validate`'s cache-first branch. With it removed,
+//! `repeat_resolve_over_unsealed_buckets_costs_the_lists_only` and
+//! `a_bound_at_the_hot_region_size_keeps_the_saving` report 24 record GETs
+//! where they demand 12 (both of `process_bucket`'s passes re-read every
+//! record), `record_published_between_resolves_is_fetched_exactly_once`
+//! likewise reports 24 for 12, and
+//! `a_faulted_record_get_leaves_the_other_records_cached` names all 24 reads
+//! where it demands the one faulted key.
+//! `cache_disabled_refetches_every_record_every_resolve` pins that same red
+//! permanently through the `0` bound, and
+//! `a_bound_below_the_hot_region_loses_the_saving` is red at a bound of 12.
+//!
+//! Which entry a full cache evicts is an LRU question, not a resolve-cost
+//! one; `lru_evicts_the_least_recently_used` and `zero_capacity_admits_nothing`
+//! in `src/cache.rs` pin it deterministically.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use ravel_catalog::{Catalog, CatalogConfig, CatalogError};
+use ravel_commit::keys;
+use ravel_commit::publish::{self, RetryPolicy};
+use ravel_commit::record::{self, NewCommitRecord};
+use ravel_object_store::fault::{
+    FaultKind, FaultPlan, FaultStore, Occurrence, Op, Rule, ScriptedFault,
+};
+use ravel_object_store::memory::MemoryStore;
+use ravel_object_store::{
+    Capabilities, DelimitedList, GetOutcome, GetRange, ListPage, ObjectMeta, ObjectStoreBackend,
+    PageToken, PutOptions, PutOutcome, StoreError,
+};
+use ravel_types::accounting::QueryAccounting;
+use ravel_types::{Signal, TenantHash, TimeRange};
+use uuid::Uuid;
+
+const NS_PER_HOUR: i64 = 3_600_000_000_000;
+/// First of the two unsealed ingest hours every test below publishes into.
+const HOUR_A: u32 = 800_000;
+const HOUR_B: u32 = HOUR_A + 1;
+
+fn tenant() -> TenantHash {
+    TenantHash([0x5c; 16])
+}
+
+/// A single shard so the listing fan-out is one bounded LIST, and the default
+/// record-cache bound unless a test overrides it.
+fn config(cache_capacity_per_tenant: usize) -> CatalogConfig {
+    CatalogConfig {
+        shard_count: 1,
+        cache_capacity_per_tenant,
+        ..Default::default()
+    }
+}
+
+/// The `now_ns` every test resolves at: mid-way through `HOUR_B`, so both
+/// hours sit inside the query window and neither is sealed.
+fn now_ns() -> i64 {
+    i64::from(HOUR_B) * NS_PER_HOUR + 30 * 60_000_000_000
+}
+
+fn window() -> TimeRange {
+    TimeRange {
+        start_ns: i64::from(HOUR_A) * NS_PER_HOUR,
+        end_ns: now_ns(),
+    }
+}
+
+/// True for an L0 commit-record key (`<writer_id>.<epoch>.<seq>.cmt`), false
+/// for the compaction (`l1.`) and rewrite (`rw.`) record shapes that share the
+/// suffix, and for every other object the resolve reads (HEAD, the
+/// provisioning record, data objects). This is the per-record GET issue #783
+/// counts.
+fn is_commit_record_key(key: &str) -> bool {
+    let file = key.rsplit('/').next().unwrap_or(key);
+    file.ends_with(".cmt") && !file.starts_with("l1.") && !file.starts_with("rw.")
+}
+
+/// Every GET and LIST the catalog issued, by key, so a test can assert both
+/// how many record GETs a resolve made and exactly which records they named.
+#[derive(Clone, Default)]
+struct Calls {
+    gets: Arc<Mutex<Vec<String>>>,
+    lists: Arc<Mutex<Vec<String>>>,
+}
+
+impl Calls {
+    fn record_gets(&self) -> Vec<String> {
+        self.gets
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|k| is_commit_record_key(k))
+            .cloned()
+            .collect()
+    }
+
+    fn record_get_count(&self) -> usize {
+        self.record_gets().len()
+    }
+
+    fn list_count(&self) -> usize {
+        self.lists.lock().unwrap().len()
+    }
+
+    fn reset(&self) {
+        self.gets.lock().unwrap().clear();
+        self.lists.lock().unwrap().clear();
+    }
+}
+
+struct CountingStore {
+    inner: Arc<dyn ObjectStoreBackend>,
+    calls: Calls,
+}
+
+impl CountingStore {
+    fn new(inner: Arc<dyn ObjectStoreBackend>) -> (Arc<Self>, Calls) {
+        let calls = Calls::default();
+        (
+            Arc::new(CountingStore {
+                inner,
+                calls: calls.clone(),
+            }),
+            calls,
+        )
+    }
+}
+
+#[async_trait]
+impl ObjectStoreBackend for CountingStore {
+    async fn put(&self, k: &str, d: Bytes, o: PutOptions) -> Result<PutOutcome, StoreError> {
+        self.inner.put(k, d, o).await
+    }
+    async fn get(&self, k: &str, r: GetRange) -> Result<GetOutcome, StoreError> {
+        self.calls.gets.lock().unwrap().push(k.to_string());
+        self.inner.get(k, r).await
+    }
+    async fn head(&self, k: &str) -> Result<ObjectMeta, StoreError> {
+        self.inner.head(k).await
+    }
+    async fn list(&self, p: &str, t: Option<PageToken>) -> Result<ListPage, StoreError> {
+        self.calls.lists.lock().unwrap().push(p.to_string());
+        self.inner.list(p, t).await
+    }
+    async fn list_after(
+        &self,
+        p: &str,
+        s: Option<&str>,
+        t: Option<PageToken>,
+    ) -> Result<ListPage, StoreError> {
+        self.calls.lists.lock().unwrap().push(p.to_string());
+        self.inner.list_after(p, s, t).await
+    }
+    async fn list_delimited(&self, p: &str) -> Result<DelimitedList, StoreError> {
+        self.inner.list_delimited(p).await
+    }
+    async fn delete(&self, k: &str) -> Result<(), StoreError> {
+        self.inner.delete(k).await
+    }
+    fn capabilities(&self) -> Capabilities {
+        Capabilities {
+            multipart: false,
+            ..self.inner.capabilities()
+        }
+    }
+}
+
+/// Publish one L0 segment (data object plus commit record) under a writer
+/// identity derived from `index`, and return its commit-record key.
+///
+/// `Uuid::from_u128(index + 1)` for `index` below 12 renders as a
+/// hex-ascending uuid, and a commit key ends
+/// `<writer_id>.<epoch>.<seq:020>.cmt`, so listing order inside a bucket is
+/// exactly ascending `index`. Every test below relies on that to name "the
+/// n-th record".
+async fn publish(store: &dyn ObjectStoreBackend, hour: u32, index: u64) -> String {
+    let payload = format!("seg-{hour}-{index}").into_bytes();
+    let content_hash = *blake3::hash(&payload).as_bytes();
+    let event_ts_ns = i64::from(hour) * NS_PER_HOUR + 60_000_000_000 * (index as i64 + 1);
+    let writer_id = Uuid::from_u128(u128::from(index) + 1);
+    let rec = record::build(NewCommitRecord {
+        tenant_hash: tenant(),
+        signal: Signal::Metrics,
+        shard: 0,
+        writer_id,
+        writer_epoch: 1,
+        writer_seq: index,
+        object_size: payload.len() as u64,
+        content_hash,
+        sample_count: 1,
+        series_count: 1,
+        min_event_ts_ns: event_ts_ns,
+        max_event_ts_ns: event_ts_ns,
+        min_ingest_ts_ns: event_ts_ns,
+        max_ingest_ts_ns: event_ts_ns,
+        segment_format_version: 1,
+        created_unix_ns: event_ts_ns,
+        ingest_hour_bucket: hour,
+    })
+    .expect("valid record");
+    let data_key = keys::reconstruct_data_key(&rec).expect("data key");
+    publish::put_data_object(store, &data_key, Bytes::from(payload))
+        .await
+        .expect("put data object");
+    publish::publish(store, &rec, &RetryPolicy::default())
+        .await
+        .expect("publish");
+    keys::commit_key_for_record(&rec).expect("commit key")
+}
+
+/// The twelve-record, two-unsealed-bucket fixture: records 0..6 in `HOUR_A`,
+/// records 6..12 in `HOUR_B`, returned in listing order.
+async fn publish_twelve(store: &dyn ObjectStoreBackend) -> Vec<String> {
+    let mut keys = Vec::with_capacity(12);
+    for index in 0..6u64 {
+        keys.push(publish(store, HOUR_A, index).await);
+    }
+    for index in 6..12u64 {
+        keys.push(publish(store, HOUR_B, index).await);
+    }
+    keys
+}
+
+async fn resolve(catalog: &Catalog) -> Result<ravel_catalog::Snapshot, CatalogError> {
+    catalog
+        .resolve_with_accounting(
+            &tenant(),
+            Signal::Metrics,
+            window(),
+            &[],
+            now_ns(),
+            &QueryAccounting::new(),
+        )
+        .await
+}
+
+/// The property issue #783 asks for: over two unsealed buckets holding twelve
+/// commit records, the first resolve pays one GET per record and the second
+/// pays none, while both pay the same LISTs and return the identical segment
+/// set.
+#[tokio::test]
+async fn repeat_resolve_over_unsealed_buckets_costs_the_lists_only() {
+    let inner = Arc::new(MemoryStore::new());
+    publish_twelve(inner.as_ref()).await;
+    let (store, calls) = CountingStore::new(inner);
+    let catalog = Catalog::new(store, config(10_000)).expect("catalog");
+
+    let first = resolve(&catalog).await.expect("first resolve");
+    let first_gets = calls.record_get_count();
+    let first_lists = calls.list_count();
+    calls.reset();
+
+    let second = resolve(&catalog).await.expect("second resolve");
+    let second_gets = calls.record_get_count();
+    let second_lists = calls.list_count();
+
+    assert_eq!(
+        first_gets, 12,
+        "a cold resolve must GET each of the twelve commit records exactly once"
+    );
+    assert_eq!(
+        second_gets, 0,
+        "a repeated resolve over the same unsealed buckets must issue no record GET"
+    );
+    assert_eq!(
+        (first_lists, second_lists),
+        (2, 2),
+        "both resolves must still pay the same LISTs (one bounded shard LIST plus the \
+         pending-erasure LIST): the LIST is what discovers new records"
+    );
+    assert_eq!(
+        first, second,
+        "the cached resolve must return the identical snapshot, by value"
+    );
+    assert_eq!(first.segments.len(), 12);
+}
+
+/// The `0` bound disables the cache, which is this file's standing red for
+/// the test above: every resolve then re-reads every record. Twenty-four, not
+/// twelve, because `process_bucket` reads each record twice with nothing
+/// cached in between (the concurrent `prewarm_commit_records` pass, then the
+/// sequential include pass).
+///
+/// This asserts the resolve cost of a disabled cache, which a bound of 1
+/// would also produce; that `0` specifically admits nothing rather than
+/// silently meaning 1 is pinned by `zero_capacity_admits_nothing` in
+/// `src/cache.rs`.
+#[tokio::test]
+async fn cache_disabled_refetches_every_record_every_resolve() {
+    let inner = Arc::new(MemoryStore::new());
+    publish_twelve(inner.as_ref()).await;
+    let (store, calls) = CountingStore::new(inner);
+    let catalog = Catalog::new(store, config(0)).expect("catalog");
+
+    let first = resolve(&catalog).await.expect("first resolve");
+    let first_gets = calls.record_get_count();
+    calls.reset();
+    let second = resolve(&catalog).await.expect("second resolve");
+
+    assert_eq!(first_gets, 24);
+    assert_eq!(
+        calls.record_get_count(),
+        24,
+        "with the cache disabled the second resolve must re-read every record"
+    );
+    assert_eq!(
+        first, second,
+        "the cache is an optimization only: disabling it must not change the snapshot"
+    );
+}
+
+/// A record published between two resolves is the one thing the LIST is for.
+/// It costs exactly one GET, and the twelve already cached cost none.
+#[tokio::test]
+async fn record_published_between_resolves_is_fetched_exactly_once() {
+    let inner = Arc::new(MemoryStore::new());
+    publish_twelve(inner.as_ref()).await;
+    let (store, calls) = CountingStore::new(inner.clone());
+    let catalog = Catalog::new(store, config(10_000)).expect("catalog");
+
+    let first = resolve(&catalog).await.expect("first resolve");
+    assert_eq!(calls.record_get_count(), 12);
+    calls.reset();
+
+    let thirteenth = publish(inner.as_ref(), HOUR_B, 12).await;
+
+    let second = resolve(&catalog).await.expect("second resolve");
+    assert_eq!(
+        calls.record_gets(),
+        vec![thirteenth],
+        "only the newly published record may be fetched; the twelve cached ones must not be"
+    );
+    assert_eq!(first.segments.len(), 12);
+    assert_eq!(
+        second.segments.len(),
+        13,
+        "the LIST must still discover the new record"
+    );
+}
+
+/// The bound is enforced: set below the hot region's size it cannot hold it,
+/// so the saving disappears and every resolve pays full price again.
+///
+/// The exact count is 24 per resolve, not 8, and the shape is worth stating.
+/// With a bound below a bucket's record count, `process_bucket`'s two passes
+/// evict each other: the concurrent prewarm admits all six of a bucket's
+/// records and keeps the four it touched last, then the sequential include
+/// pass walks all six in listing order, missing on the ones the prewarm
+/// dropped and evicting the ones it kept as it refills. Neither pass ever
+/// serves the other, so both buckets pay 6 + 6. Sizing the bound at or above
+/// the hot region (the default, 10,000 entries) is what avoids this: raising
+/// this test's bound to 12 takes the second resolve to 0.
+///
+/// Which four entries a bound of 4 retains is an LRU question, pinned
+/// directly and deterministically by `lru_evicts_the_least_recently_used`
+/// in `src/cache.rs`; this test pins the resolve-level cost of a bound that
+/// does not fit.
+#[tokio::test]
+async fn a_bound_below_the_hot_region_loses_the_saving() {
+    let inner = Arc::new(MemoryStore::new());
+    publish_twelve(inner.as_ref()).await;
+    let (store, calls) = CountingStore::new(inner);
+    let catalog = Catalog::new(store, config(4)).expect("catalog");
+
+    let first = resolve(&catalog).await.expect("first resolve");
+    assert_eq!(calls.record_get_count(), 24);
+    calls.reset();
+
+    let second = resolve(&catalog).await.expect("second resolve");
+    let second_gets = calls.record_get_count();
+    assert_eq!(
+        second_gets, 24,
+        "a bound of 4 cannot hold the twelve-record hot set, so every pass misses"
+    );
+    assert!(
+        second_gets >= 8,
+        "a cache holding at most 4 of 12 can never serve more than 4 of a pass's reads"
+    );
+    assert_eq!(
+        first, second,
+        "eviction is a cost, never a correctness change: the snapshot is identical"
+    );
+}
+
+/// The same fixture at a bound that does fit: the control for the test above,
+/// so its 24 reads as "the bound was too small", not "the cache never works".
+#[tokio::test]
+async fn a_bound_at_the_hot_region_size_keeps_the_saving() {
+    let inner = Arc::new(MemoryStore::new());
+    publish_twelve(inner.as_ref()).await;
+    let (store, calls) = CountingStore::new(inner);
+    let catalog = Catalog::new(store, config(12)).expect("catalog");
+
+    resolve(&catalog).await.expect("first resolve");
+    assert_eq!(calls.record_get_count(), 12);
+    calls.reset();
+    resolve(&catalog).await.expect("second resolve");
+    assert_eq!(calls.record_get_count(), 0);
+}
+
+/// A GET fault on the fifth record's key fails the first resolve with the
+/// existing typed store error, and leaves every record whose GET did complete
+/// in the cache. The second resolve (fault spent) re-reads only what the
+/// first did not cache.
+///
+/// One GET, not eight: `prewarm_commit_records` issues all six of the
+/// bucket's GETs concurrently and only then returns the first error, so the
+/// five that succeeded are already cached and only the faulted record is
+/// missing. The second resolve's prewarm re-reads exactly that one, and its
+/// include pass is served from the cache.
+#[tokio::test]
+async fn a_faulted_record_get_leaves_the_other_records_cached() {
+    let inner = Arc::new(MemoryStore::new());
+    let keys = publish_twelve(inner.as_ref()).await;
+    let fifth = keys[4].clone();
+
+    let plan = FaultPlan::empty().with_rule(
+        Rule::new(
+            Op::Get,
+            ScriptedFault::Permanent("record GET failed".into()),
+        )
+        .with_key_contains(fifth.clone())
+        .with_occurrence(Occurrence::Nth(1)),
+    );
+    let faulting = Arc::new(FaultStore::new(inner, plan));
+    let (store, calls) = CountingStore::new(faulting.clone());
+    let catalog = Catalog::new(store, config(10_000)).expect("catalog");
+
+    let err = resolve(&catalog)
+        .await
+        .expect_err("a faulted record GET must fail the resolve, never yield a partial snapshot");
+    assert!(
+        matches!(err, CatalogError::Store(StoreError::Permanent(_))),
+        "expected the existing typed store error, got {err:?}"
+    );
+    assert_eq!(
+        faulting.fault_count(Op::Get, FaultKind::Permanent),
+        1,
+        "the fault must actually have fired"
+    );
+    calls.reset();
+
+    let second = resolve(&catalog)
+        .await
+        .expect("second resolve, fault spent");
+    let second_gets = calls.record_gets();
+    assert_eq!(
+        second_gets,
+        vec![fifth],
+        "only the record whose GET faulted may be re-read; the eleven cached ones must not be"
+    );
+    assert_eq!(second.segments.len(), 12);
+}

--- a/docs/catalog-and-mvcc.md
+++ b/docs/catalog-and-mvcc.md
@@ -713,6 +713,33 @@ carries them as a comma-separated list in `x-ravel-commit-token`.
    bound the cache per tenant. Records are immutable and never invalidated,
    except: observing a tombstone for a bucket invalidates that bucket's
    cached commit and compaction records (the trigger ADR-0010 §10 promises).
+
+   That cache is per process and outlives any one resolve, which is what
+   makes a repeated resolve over an unsealed ingest hour cost its LISTs and
+   nothing else (issue #783). The newest `max_flush_lifetime +
+   clock_skew_allowance + fold_safety_margin` of any tenant is always
+   unsealed, so no snapshot part covers it and every query touching recent
+   data resolves it through this step; without the cache that is one GET per
+   hot commit record, per query. Caching by object key alone is sound because
+   a commit record never changes once written: its identity is pinned at
+   flush open (see "Pinned flush identity") and the object is immutable, so
+   only the bucket's LIST result can grow. The LIST therefore still runs on
+   every resolve -- it is what discovers records published since the last one
+   -- and only the per-record GET and decode are skipped. A record the LIST
+   names and the cache does not hold is fetched; a cached record the LIST no
+   longer names is simply never consulted, since the resolve builds its
+   segment set from the LIST (retention and GC remove records only after
+   their bucket is sealed and folded). A hit is counted as a cache hit with
+   the cached object's byte size and issues no GET; a miss is counted as a
+   miss and pays the GET, exactly as the part and postings caches do. The
+   bound is `cache_capacity_per_tenant`, in entries, evicted
+   least-recently-used so a hot ingest hour survives a wider one-off scan or
+   a fold's sweep of older buckets. Its default of 10,000 entries is sized to
+   hold a 10,000-segment hot region whole, at roughly 750 bytes per entry
+   (about 8 MB per actively-queried tenant); `0` disables the cache. A bound
+   below a bucket's record count is worse than a small cache: this step's two
+   passes (the concurrent prewarm, then the sequential include walk) then
+   evict each other's entries and every record is read twice.
 3. Tombstone present: the bucket contributes nothing to the snapshot.
    Otherwise, build ONE unified exclusion mechanism over the bucket
    (ADR-0064 unifies rewrite supersession with compaction's, rather than
@@ -946,8 +973,10 @@ All five caches (`RecordCache`, `CompactionRecordCache`, `HeadCache`,
 `PartCache`, `PostingsCache`) record a cache hit or miss on every lookup and
 add the cached object's original wire-encoded byte size on a hit; a miss
 does not double-count bytes the funnel GET that filled the cache already
-recorded. `HeadCache` additionally carries a process-wide capacity bound
-(`head_cache_capacity`, default 10,000 (tenant, signal) entries, FIFO
+recorded. `RecordCache` evicts least-recently-used within its per-tenant
+bound (`cache_capacity_per_tenant`); the other three per-tenant caches evict
+by insertion order. `HeadCache` additionally carries a process-wide capacity
+bound (`head_cache_capacity`, default 10,000 (tenant, signal) entries, FIFO
 eviction), closing the one cache of the five that previously had a TTL but
 no bound on the number of tenants it could grow to hold.
 


### PR DESCRIPTION
Issue #783 measured a SELECT COUNT(*) over a tenant whose logs snapshot
was empty at 14.1 s and 8,426 GETs, one per commit record, and a full
scan at 16,850 GETs at identical CPU. The newest max_flush_lifetime +
clock_skew_allowance + fold_safety_margin of any tenant is always
unsealed, so no snapshot part covers it and every query touching recent
data resolves that region by listing its buckets and reading each commit
record.

The per-process record cache the ticket asks for was already in the
resolve path: Catalog::load_and_validate has been cache-first against
RecordCache, keyed by full object key, since before this change, and a
measurement here confirms a repeated resolve over two unsealed buckets
holding twelve records issues twelve record GETs and then zero, with the
same LIST count both times. What was missing was the eviction policy the
ticket names, a stated bound rationale, and any regression pin on the
property. This commit supplies those.

RecordCache now evicts least-recently-used rather than by insertion
order. A read refreshes an entry's recency, and a re-insert of a key
already held refreshes it too rather than being ignored, so a hot ingest
hour that queries keep returning to survives a wider one-off scan or a
fold's sweep of older buckets. Recency is a monotonic tick plus a
BTreeMap index, so a touch is O(log n): a single resolve over a hot hour
touches every entry twice, once in the concurrent prewarm and once in the
sequential include pass. A capacity of 0 now disables the cache outright
instead of silently meaning 1, matching byte_cache_max_bytes's own 0
sentinel.

Keying by object key alone is sound because a commit record never
changes once written: its identity is pinned at flush open and the object
is immutable, so only a hot bucket's LIST result can grow. The LIST still
runs on every resolve, since that is what discovers new records; only the
per-record GET and decode are skipped. A record the LIST names and the
cache does not hold is fetched, and a cached record the LIST no longer
names is never consulted. Accounting is unchanged: a hit records a cache
hit with the cached object's byte size and issues no GET, a miss records
a miss and pays the GET.

cache_capacity_per_tenant keeps its default of 10,000 entries, now
documented as sized to hold a 10,000-segment hot region whole at roughly
750 bytes per entry, about 8 MB per actively-queried tenant. The
per-entry figure is a 119-byte commit key held twice, the 200-byte
decoded CommitRecord plus about 200 bytes of its own heap, and the two
maps' slot overhead.

The new tests pin exact figures against a store double that records every
key. Twelve records across two unsealed buckets: twelve record GETs then
zero, two LISTs both times, identical snapshots by value. A thirteenth
record published between the two resolves is fetched exactly once and
named. A GET fault on the fifth record's key fails the first resolve with
the existing typed store error, the FaultStore counter proves the fault
fired, and the second resolve re-reads only that one record. Two bound
tests bracket the sizing: at a bound of 4 both resolves cost 24 GETs
because the prewarm and include passes evict each other, and at 12 the
second costs 0. Disabling the cache costs 24 GETs on every resolve. Unit
tests pin the LRU choice itself and the 0 sentinel.

Fixes: #783
Refs: #680

