### PR TITLE
fix(ravel-sql): report span page metrics on the row path too

### DIFF
--- a/crates/ravel-bench/src/bin/spans_scan_bench.rs
+++ b/crates/ravel-bench/src/bin/spans_scan_bench.rs
@@ -187,7 +187,10 @@ fn print_human_table(doc: &Document) {
             s.rows_per_sec,
         );
     }
-    println!("  (* pgDec/pgSkp are columnar-path-only partition metrics; the row path reports 0)");
+    println!(
+        "  (* pgDec/pgSkp are partition metrics on both paths; the row path decodes \
+         every page of each block it scans and skips none)"
+    );
     println!();
     println!(
         "  page_bytes_decoded ratio (row/columnar): {:.3}",

--- a/crates/ravel-bench/src/spans_scan.rs
+++ b/crates/ravel-bench/src/spans_scan.rs
@@ -12,11 +12,12 @@
 //! numbers.
 //!
 //! Note on which "decoded" counter is comparable. The `pages_decoded`/
-//! `pages_skipped` PARTITION METRICS (ADR-0110 decision 5) are incremented only
-//! on the columnar path, so they read 0 on the row shape and cannot form a
-//! cross-path ratio. The quantity that IS recorded on both paths and that
-//! decision 7's regression test actually asserts on is `page_bytes_decoded` in
-//! `QueryAccounting` (decision 2): equal `page_bytes_fetched` on both shapes,
+//! `pages_skipped` PARTITION METRICS (ADR-0110 decision 5) are written on both
+//! paths since issue #669: the row shape reports every page of every block it
+//! scanned as decoded and none skipped, because it requests every column. They
+//! are page COUNTS, though, and a page's stored size varies by column, so the
+//! quantity decision 7's regression test asserts on stays `page_bytes_decoded`
+//! in `QueryAccounting` (decision 2): equal `page_bytes_fetched` on both shapes,
 //! strictly lower `page_bytes_decoded` on the columnar shape. This lane reports
 //! the partition metrics for transparency and computes the ratio on
 //! `page_bytes_decoded`.
@@ -141,15 +142,15 @@ pub struct ShapeResult {
     pub columnar_batches: usize,
     /// Batches the scan emitted through the unchanged row path.
     pub rowpath_batches: usize,
-    /// The `pages_decoded` PARTITION METRIC (ADR-0110 decision 5). This counter
-    /// is incremented ONLY on the columnar path (`spans_scan.rs` bumps it in the
-    /// `Prepared::Columnar` arm, never in the row arm), so it reads 0 on the row
-    /// shape. It is therefore NOT a cross-path comparable; the comparable
-    /// decoded quantity is [`page_bytes_decoded`](Self::page_bytes_decoded). See
-    /// the module report for the ADR/code note on this.
+    /// The `pages_decoded` PARTITION METRIC (ADR-0110 decision 5), written on
+    /// both paths (#669): on the row shape it is every page of every block the
+    /// scan decoded, on the columnar shape only the projected ones. Comparable
+    /// across shapes as a count; the byte-weighted comparison the ratio uses is
+    /// [`page_bytes_decoded`](Self::page_bytes_decoded).
     pub pages_decoded: usize,
-    /// The `pages_skipped` partition metric. Columnar path only; 0 on the row
-    /// path, for the same reason as [`pages_decoded`](Self::pages_decoded).
+    /// The `pages_skipped` partition metric. Nonzero on the columnar shape,
+    /// which walks past the attribute and event pages; 0 on the row shape, which
+    /// requests every column and so skips nothing.
     pub pages_skipped: usize,
     /// Stored bytes of the pages the scan actually fetched, from
     /// `QueryAccounting` (ADR-0107 decision 4). Recorded on BOTH paths and, per
@@ -202,9 +203,10 @@ pub struct Report {
     /// `attrs_including.page_bytes_decoded / attrs_free.page_bytes_decoded`, the
     /// cross-path decoded-bytes ratio (ADR-0110 decision 7). Above 1.0 when the
     /// columnar shape decoded fewer page bytes than the row shape; 1.0 means a
-    /// vacuous corpus with no pages to skip. This uses `page_bytes_decoded`, NOT
-    /// the columnar-only `pages_decoded` partition metric, which reads 0 on the
-    /// row shape and so cannot form a ratio.
+    /// vacuous corpus with no pages to skip. This uses `page_bytes_decoded`, not
+    /// the `pages_decoded` partition metric: that one counts pages, whose stored
+    /// sizes differ by column, so a count ratio would not weight the skipped
+    /// attribute and event pages by what they actually cost to decode.
     pub page_bytes_decoded_ratio: f64,
     /// `attrs_free.rows_per_sec / attrs_including.rows_per_sec`. Reported as a
     /// measured ratio, never described as "faster": interpret it against the
@@ -678,16 +680,27 @@ mod tests {
             report.attrs_free.rows, report.attrs_including.rows,
             "both shapes return the same rows"
         );
-        // The `pages_decoded`/`pages_skipped` partition metrics are columnar-only:
-        // the fast path skips pages, and the row path never touches these
-        // counters, so it reports 0 for both.
+        // The `pages_decoded`/`pages_skipped` partition metrics, on both paths
+        // (#669). Both shapes scan the same blocks over the same corpus, so the
+        // row shape's decoded count equals the columnar shape's decoded plus
+        // skipped: the same pages, split differently by the projection.
         assert!(
             report.attrs_free.pages_skipped > 0,
             "the columnar shape must skip attribute/event pages"
         );
         assert_eq!(
-            report.attrs_including.pages_decoded, 0,
-            "the row path does not publish the pages_decoded partition metric"
+            report.attrs_including.pages_skipped, 0,
+            "the row shape requests every column, so it skips no page"
+        );
+        assert_eq!(
+            report.attrs_including.pages_decoded,
+            report.attrs_free.pages_decoded + report.attrs_free.pages_skipped,
+            "the row shape decodes exactly the pages the columnar shape decoded \
+             plus the ones it skipped"
+        );
+        assert!(
+            report.attrs_including.pages_decoded > 0,
+            "the row shape must report the pages it decoded, not an unwritten 0"
         );
 
         // The cross-path decoded quantity is `page_bytes_decoded` (QueryAccounting),

--- a/crates/ravel-bench/src/spans_scan.rs
+++ b/crates/ravel-bench/src/spans_scan.rs
@@ -692,6 +692,9 @@ mod tests {
             report.attrs_including.pages_skipped, 0,
             "the row shape requests every column, so it skips no page"
         );
+        // Holds because this corpus's attrs-including shape takes the row path
+        // directly. A shape whose columnar attempt fell back on an `attrs_raw`
+        // block would carry that attempt's counts too and read higher (#669).
         assert_eq!(
             report.attrs_including.pages_decoded,
             report.attrs_free.pages_decoded + report.attrs_free.pages_skipped,

--- a/crates/ravel-query/src/span_fetcher.rs
+++ b/crates/ravel-query/src/span_fetcher.rs
@@ -84,6 +84,19 @@ pub struct SpanRow {
 pub struct SpanFetchOutput {
     pub records: Vec<SpanRow>,
     pub stats: ScanStats,
+    /// Column pages this fetch's decode decompressed, summed over the blocks it
+    /// scanned. The row exit decodes every page of every block it scans, so this
+    /// is the whole page count of the scanned blocks and
+    /// [`pages_skipped`](Self::pages_skipped) is 0. `ScanStats` carries no page
+    /// counters (only block ones), so these two ride here, from the same
+    /// per-block decode counts the page-byte accounting folds.
+    pub pages_decoded: usize,
+    /// Column pages this fetch's decode walked past because the projection
+    /// excluded them. Always 0 for the row exit, which requests every column;
+    /// it is a measured 0, not an absent counter, so a caller publishing it can
+    /// state the row path skipped nothing rather than leaving a metric unwritten
+    /// (#669).
+    pub pages_skipped: usize,
 }
 
 /// One candidate block resolved to its absolute, bounds-checked
@@ -439,6 +452,8 @@ impl SpanSegmentFetcher {
             accounting,
             page_bytes_fetched: 0,
             page_bytes_decoded: 0,
+            pages_decoded: 0,
+            pages_skipped: 0,
             finished: false,
         })
     }
@@ -544,6 +559,14 @@ pub struct SpanColumnarScan {
     accounting: QueryAccounting,
     page_bytes_fetched: u64,
     page_bytes_decoded: u64,
+    /// Column pages decoded and skipped across the blocks drained so far: the
+    /// count-side siblings of the `page_bytes_*` totals above, taken from the
+    /// same per-block decode. Exposed rather than folded into `accounting`
+    /// because a scan's caller publishes them as PARTITION metrics
+    /// (`SpansScanExec`'s `pages_decoded`/`pages_skipped`), which the
+    /// query-global accounting handle cannot express.
+    pages_decoded: usize,
+    pages_skipped: usize,
     /// Set once the accounting fold has run, so it runs exactly once.
     finished: bool,
 }
@@ -558,6 +581,19 @@ impl SpanColumnarScan {
     /// Candidate blocks not yet decoded.
     pub fn remaining_blocks(&self) -> usize {
         self.candidates.len() - self.cursor
+    }
+
+    /// Column pages the blocks drained so far decompressed. Read after the last
+    /// [`next_block`](Self::next_block), or at any point for the partial total.
+    pub fn pages_decoded(&self) -> usize {
+        self.pages_decoded
+    }
+
+    /// Column pages the blocks drained so far walked past because this scan's
+    /// projection excluded them. Always 0 when the scan requests every column
+    /// (the row exit).
+    pub fn pages_skipped(&self) -> usize {
+        self.pages_skipped
     }
 
     /// Decode the next candidate block and return it with its surviving row
@@ -582,6 +618,8 @@ impl SpanColumnarScan {
             .map_err(|source| corrupt(&self.key, source))?;
         self.page_bytes_fetched += decoded.page_bytes_fetched;
         self.page_bytes_decoded += decoded.page_bytes_decoded;
+        self.pages_decoded += decoded.block.pages_decoded();
+        self.pages_skipped += decoded.block.pages_skipped();
         self.stats.blocks_scanned += 1;
         let rows = surviving_rows(&decoded.block, &self.query)
             .map_err(|source| corrupt(&self.key, source))?;
@@ -831,6 +869,10 @@ fn build_span_row(block: &DecodedBlock, row: usize) -> Result<SpanRow, SpanSegEr
 /// primitive, so `fetch`/`fetch_accounted` share candidate selection, bloom
 /// probing, ts/`trace_id` filtering, and the page-byte fold with the columnar
 /// exit. Dropping the scan folds its accounting (`finish`).
+///
+/// The scan's page counts ride out on the output next to `stats`, so the row
+/// exit's caller can publish the same `pages_decoded`/`pages_skipped` figures
+/// the columnar exit's caller reads off each [`ColumnarBlock`] (#669).
 fn drain_rows(mut scan: SpanColumnarScan) -> Result<SpanFetchOutput, SpanFetchError> {
     let mut records = Vec::new();
     while let Some(block) = scan.next_block()? {
@@ -841,7 +883,12 @@ fn drain_rows(mut scan: SpanColumnarScan) -> Result<SpanFetchOutput, SpanFetchEr
         }
     }
     let stats = scan.stats();
-    Ok(SpanFetchOutput { records, stats })
+    Ok(SpanFetchOutput {
+        records,
+        stats,
+        pages_decoded: scan.pages_decoded(),
+        pages_skipped: scan.pages_skipped(),
+    })
 }
 
 /// The absolute, bounds-checked `[start, end)` byte range of one block within
@@ -1117,6 +1164,74 @@ mod tests {
             col_rows,
             row_out.records.len(),
             "both exits select the identical surviving-row multiset"
+        );
+    }
+
+    /// Issue #669: the row exit reports the page COUNTS its decode performed, so
+    /// its caller can publish the same `pages_decoded`/`pages_skipped` metrics
+    /// the columnar exit's caller publishes. Exact figures, from the fixture's
+    /// geometry: 6 spans cut every 2 records is 3 blocks, and each block stages
+    /// 13 pages (`trace_id`, `span_id`, `name`, `start_ts`, `end_ts`,
+    /// `status_code`, `service_name`, the two dynamic attribute columns, and the
+    /// four event columns; `parent_span_id`, `status_message`, and `attrs_raw`
+    /// have no value on any fixture span, and a column with no present value
+    /// stages no page). The row exit decodes all 39 and skips none; the
+    /// fixed-column projection splits those same 39 into 21 decoded and 18
+    /// skipped.
+    #[tokio::test]
+    async fn row_exit_reports_the_page_counts_the_columnar_exit_splits() {
+        let store = Arc::new(MemoryStore::new());
+        let records: Vec<SpanRecord> = (0..6)
+            .map(|i| {
+                span_with_attrs_and_events(
+                    trace(i + 1),
+                    span(i + 1),
+                    100 + i64::from(i),
+                    200 + i64::from(i),
+                )
+            })
+            .collect();
+        let seg = write_object(&store, 0, &records).await;
+        let fetcher = SpanSegmentFetcher::new(store);
+        let query = all_query();
+
+        let acct = QueryAccounting::new();
+        let row_out = fetcher
+            .fetch_accounted(&seg, TENANT, &query, None, None, &[], &acct)
+            .await
+            .expect("row fetch")
+            .expect("row output");
+        assert_eq!(row_out.stats.blocks_scanned, 3, "three blocks scanned");
+        assert_eq!(
+            (row_out.pages_decoded, row_out.pages_skipped),
+            (39, 0),
+            "the row exit decodes every page of every block it scans"
+        );
+
+        let mut scan = fetcher
+            .fetch_accounted_columnar(
+                &seg,
+                TENANT,
+                &query,
+                None,
+                None,
+                &[],
+                &FIXED_PROJECTION,
+                &QueryAccounting::new(),
+            )
+            .await
+            .expect("columnar fetch")
+            .expect("columnar scan");
+        while scan.next_block().expect("next block").is_some() {}
+        assert_eq!(
+            (scan.pages_decoded(), scan.pages_skipped()),
+            (21, 18),
+            "the fixed-column projection's split of those same pages"
+        );
+        assert_eq!(
+            scan.pages_decoded() + scan.pages_skipped(),
+            row_out.pages_decoded,
+            "both exits walk the same pages; only the split differs"
         );
     }
 

--- a/crates/ravel-sql/src/spans_scan.rs
+++ b/crates/ravel-sql/src/spans_scan.rs
@@ -93,9 +93,9 @@ const BATCH_ROWS: usize = 8192;
 const METRIC_COLUMNAR_BATCHES: &str = "columnar_batches";
 /// Metric name for the count of batches emitted by the row path fallback.
 const METRIC_ROWPATH_BATCHES: &str = "rowpath_batches";
-/// Metric name for the column pages the columnar decode decompressed.
+/// Metric name for the column pages the decode decompressed, on either path.
 const METRIC_PAGES_DECODED: &str = "pages_decoded";
-/// Metric name for the column pages the columnar decode walked past because the
+/// Metric name for the column pages the decode walked past because the
 /// projection excluded them: the page-level proof projection reached decode.
 const METRIC_PAGES_SKIPPED: &str = "pages_skipped";
 
@@ -211,7 +211,9 @@ pub struct SpansScanExec {
     /// Partition metrics (ADR-0110 decision 5): `columnar_batches`/
     /// `rowpath_batches` show which path a partition ran, and
     /// `pages_decoded`/`pages_skipped` show projection reaching decode, so
-    /// `EXPLAIN ANALYZE` and a test can assert eligibility directly.
+    /// `EXPLAIN ANALYZE` and a test can assert eligibility directly. Both page
+    /// counters are written on both paths (#669), so a zero always means the
+    /// decode did that much and never that the arm forgot to count.
     metrics: ExecutionPlanMetricsSet,
 }
 
@@ -411,10 +413,15 @@ impl ExecutionPlan for SpansScanExec {
 /// `SpansScanExec::metrics` exposes to `EXPLAIN ANALYZE`.
 #[derive(Clone)]
 struct SpanScanMetrics {
-    /// Column pages the columnar decode decompressed this partition.
+    /// Column pages this partition's decode decompressed, on whichever path it
+    /// ran (#669): the columnar attempt's per-block counts, the row path's, or
+    /// both when an `attrs_raw` block made the partition fall back after
+    /// decoding some blocks columnar.
     pages_decoded: Count,
-    /// Column pages the columnar decode skipped because the projection excluded
-    /// them. Zero on the row path, which decodes every page.
+    /// Column pages this partition's decode walked past because the projection
+    /// excluded them. A row-path partition reports 0 because it decodes every
+    /// page of every block it scans, which is a measurement of that path, not an
+    /// unwritten counter: `pages_decoded` is nonzero beside it.
     pages_skipped: Count,
     /// Output batches this partition built through the columnar fast path,
     /// straight from a [`ravel_rspan::ColumnarBlockView`] with no `SpanRecord`
@@ -477,8 +484,28 @@ enum Prepared {
     Rows {
         rows: Vec<SpanRow>,
         projection: Option<Arc<Vec<usize>>>,
+        /// Aggregate page counts across every block this partition decoded, for
+        /// the `pages_decoded`/`pages_skipped` metrics, exactly as the columnar
+        /// variant carries its own (#669). The row fetch decodes every page of
+        /// every block it scans, so `pages_skipped` is 0 unless an abandoned
+        /// columnar attempt contributed to it.
+        pages_decoded: usize,
+        pages_skipped: usize,
     },
     Columnar(ColumnarPartition),
+}
+
+/// What the columnar attempt produced: the materialized partition, or the
+/// `attrs_raw` fallback, carrying the pages the abandoned attempt had already
+/// decoded. Those pages really were decompressed (the query's page-byte
+/// accounting counts them too), so they belong in the partition's totals rather
+/// than being dropped because the attempt was discarded.
+enum ColumnarAttempt {
+    Ready(ColumnarPartition),
+    FellBack {
+        pages_decoded: usize,
+        pages_skipped: usize,
+    },
 }
 
 /// Fetch every segment in this partition and return its rows in `(trace_id,
@@ -525,12 +552,18 @@ async fn prepare_partition(
         });
     }
 
+    // Pages this partition's decode touched, published as the
+    // `pages_decoded`/`pages_skipped` metrics. Non-zero before the row loop only
+    // when an abandoned columnar attempt already decoded blocks.
+    let mut pages_decoded = 0usize;
+    let mut pages_skipped = 0usize;
+
     if attempt_columnar {
         // `attempt_columnar` implies the provider pushed a projection.
         let proj = projection
             .clone()
             .ok_or_else(|| DataFusionError::Internal("columnar scan without projection".into()))?;
-        if let Some(part) = prepare_columnar(
+        match prepare_columnar(
             &fetcher,
             tenant_hash,
             &segs,
@@ -543,10 +576,18 @@ async fn prepare_partition(
         )
         .await?
         {
-            return Ok(Prepared::Columnar(part));
+            ColumnarAttempt::Ready(part) => return Ok(Prepared::Columnar(part)),
+            // A block carried an `attrs_raw` overflow page: fall through to the
+            // row path for the whole partition, still emitting the projected
+            // schema, and keep the abandoned attempt's page counts.
+            ColumnarAttempt::FellBack {
+                pages_decoded: d,
+                pages_skipped: s,
+            } => {
+                pages_decoded = d;
+                pages_skipped = s;
+            }
         }
-        // A block carried an `attrs_raw` overflow page: fall through to the row
-        // path for the whole partition, still emitting the projected schema.
     }
 
     let mut out: Vec<SpanRow> = Vec::new();
@@ -566,6 +607,11 @@ async fn prepare_partition(
         else {
             continue;
         };
+        // The same decode-side counts the columnar arm reads off each block; the
+        // row fetch requests every column, so it decodes every page of every
+        // block it scanned and skips none (#669).
+        pages_decoded += output.pages_decoded;
+        pages_skipped += output.pages_skipped;
         out.extend(output.records);
     }
     // Selective-erasure exclusion (ADR-0064 decision 2): applied
@@ -585,13 +631,16 @@ async fn prepare_partition(
     Ok(Prepared::Rows {
         rows: out,
         projection,
+        pages_decoded,
+        pages_skipped,
     })
 }
 
 /// Drain the columnar exit for the whole partition (ADR-0110 decisions 3, 6).
-/// Returns `None` when a block carries an `attrs_raw` overflow page, signalling
-/// the caller to fall back to the row path; otherwise the held blocks and the
-/// stable `(trace_id, start_ts)` ordering over their surviving rows.
+/// Returns [`ColumnarAttempt::FellBack`] when a block carries an `attrs_raw`
+/// overflow page, signalling the caller to fall back to the row path; otherwise
+/// the held blocks and the stable `(trace_id, start_ts)` ordering over their
+/// surviving rows.
 #[allow(clippy::too_many_arguments)]
 async fn prepare_columnar(
     fetcher: &SpanSegmentFetcher,
@@ -603,7 +652,7 @@ async fn prepare_columnar(
     predicates: &[BloomPredicate<'_>],
     projection: &Arc<Vec<usize>>,
     accounting: &QueryAccounting,
-) -> DFResult<Option<ColumnarPartition>> {
+) -> DFResult<ColumnarAttempt> {
     let union = union_projected_columns(projection);
     let mut blocks: Vec<HeldBlock> = Vec::new();
     let mut pages_decoded = 0usize;
@@ -626,14 +675,20 @@ async fn prepare_columnar(
             continue;
         };
         while let Some(cb) = scan.next_block().map_err(SqlError::from)? {
+            // Counted before the eligibility check below: this block's pages
+            // were decompressed by `next_block` whether or not the partition
+            // goes on to abandon the attempt.
+            pages_decoded += cb.block.pages_decoded();
+            pages_skipped += cb.block.pages_skipped();
             // Last eligibility clause (ADR-0110 decision 3): a block carrying an
             // `attrs_raw` overflow page fails closed to the row path, answered
             // from page descriptors without decoding the page.
             if cb.block.has_attrs_raw_page() {
-                return Ok(None);
+                return Ok(ColumnarAttempt::FellBack {
+                    pages_decoded,
+                    pages_skipped,
+                });
             }
-            pages_decoded += cb.block.pages_decoded();
-            pages_skipped += cb.block.pages_skipped();
             if !cb.rows.is_empty() {
                 blocks.push(HeldBlock {
                     block: cb.block,
@@ -667,7 +722,7 @@ async fn prepare_columnar(
     keyed.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
     let order: Vec<(usize, usize)> = keyed.into_iter().map(|(_, _, bi, r)| (bi, r)).collect();
 
-    Ok(Some(ColumnarPartition {
+    Ok(ColumnarAttempt::Ready(ColumnarPartition {
         blocks,
         order,
         projection: Arc::clone(projection),
@@ -734,7 +789,18 @@ impl Stream for SpanScanStream {
         loop {
             match &mut this.state {
                 SpanScanState::Fetching(fut) => match fut.as_mut().poll(cx) {
-                    Poll::Ready(Ok(Prepared::Rows { rows, projection })) => {
+                    Poll::Ready(Ok(Prepared::Rows {
+                        rows,
+                        projection,
+                        pages_decoded,
+                        pages_skipped,
+                    })) => {
+                        // Published on this path for the same reason as on the
+                        // columnar one (#669): the counters are what an EXPLAIN
+                        // ANALYZE reader has to judge decode work by, and a
+                        // metric left unwritten reads as a measured zero.
+                        this.metrics.pages_decoded.add(pages_decoded);
+                        this.metrics.pages_skipped.add(pages_skipped);
                         this.state = SpanScanState::EmittingRows {
                             rows,
                             projection,

--- a/crates/ravel-sql/tests/spans_columnar.rs
+++ b/crates/ravel-sql/tests/spans_columnar.rs
@@ -35,7 +35,7 @@ use ravel_object_store::{ObjectStoreBackend, PutOptions};
 use ravel_query::erasure::snapshot_pending_erasure_predicates;
 use ravel_rspan::{ObjectIdentity, RspanConfig, RspanWriter, SpanQuery, SpanRecord, StatusCode};
 use ravel_sql::{
-    SPAN_COL_DURATION_NS, SPAN_COL_NAME, SPAN_COL_SERVICE_NAME, SPAN_COL_START_TS,
+    SPAN_COL_ATTRS, SPAN_COL_DURATION_NS, SPAN_COL_NAME, SPAN_COL_SERVICE_NAME, SPAN_COL_START_TS,
     SPAN_COL_TRACE_ID, SpanSegmentFetcher, SpansScanExec, spans_schema,
 };
 use ravel_types::TenantHash;
@@ -43,6 +43,31 @@ use ravel_types::accounting::QueryAccounting;
 use uuid::Uuid;
 
 const TENANT: TenantHash = TenantHash([1u8; 16]);
+
+/// The exact page geometry of [`two_object_corpus`], pinned so both paths'
+/// `pages_decoded`/`pages_skipped` partition metrics are asserted as figures
+/// rather than as "nonzero".
+///
+/// Geometry: two objects of three spans each, cut every two records
+/// ([`small_blocks`]), so four blocks (2 + 1 per object). Each block stages nine
+/// pages, one per column that has a value in it: `trace_id`, `span_id`, `name`,
+/// `start_ts`, `end_ts`, `status_code`, `status_message`, `service_name` (the
+/// v3 lift of `service.name`), and the dynamic `http.method` attribute column.
+/// `parent_span_id` and `attrs_raw` are `None` on every fixture span, and a
+/// column with no present value stages no page at all (`write_block`'s
+/// `stage_column`), so neither contributes. A full decode therefore touches
+/// 4 x 9 = 36 pages.
+const ROW_PAGES_DECODED: usize = 36;
+/// What the attrs-free projection of
+/// [`columnar_path_taken_for_attrs_free_projection_and_matches_row_path`]
+/// decodes out of those 36: `trace_id`, `name`, `start_ts`, `service_name`, and
+/// `end_ts` (unprojected, but decoded for `duration_ns` and the ts predicate),
+/// five pages per block over four blocks.
+const COLUMNAR_PAGES_DECODED: usize = 20;
+/// And the pages that projection walks past: `span_id`, `status_code`,
+/// `status_message`, and the dynamic attribute column, four pages per block
+/// over four blocks.
+const COLUMNAR_PAGES_SKIPPED: usize = ROW_PAGES_DECODED - COLUMNAR_PAGES_DECODED;
 
 fn identity() -> ObjectIdentity {
     ObjectIdentity {
@@ -269,12 +294,21 @@ async fn columnar_path_taken_for_attrs_free_projection_and_matches_row_path() {
         "the fast path must not fall back to the row path"
     );
     // The projection excludes the dynamic attribute pages, so decode skipped
-    // them: the page-level proof projection reached the decode.
-    assert!(
-        fast.pages_skipped > 0,
-        "excluding attrs must skip attribute pages ({} decoded, {} skipped)",
-        fast.pages_decoded,
-        fast.pages_skipped,
+    // them: the page-level proof projection reached the decode. Pinned exactly,
+    // not just `> 0`, so a change to what the fast path decodes is caught here
+    // rather than absorbed: over this corpus's four blocks the columnar decode
+    // touches COLUMNAR_PAGES_DECODED pages and walks past
+    // COLUMNAR_PAGES_SKIPPED, and their sum is the same whole-block page total
+    // the row path decodes (ROW_PAGES_DECODED).
+    assert_eq!(
+        (fast.pages_decoded, fast.pages_skipped),
+        (COLUMNAR_PAGES_DECODED, COLUMNAR_PAGES_SKIPPED),
+        "the columnar path's exact page split over this corpus"
+    );
+    assert_eq!(
+        fast.pages_decoded + fast.pages_skipped,
+        ROW_PAGES_DECODED,
+        "every page of every scanned block is either decoded or skipped"
     );
 
     // Row path: same projection, forced ineligible by a no-match erasure so it
@@ -314,6 +348,123 @@ async fn columnar_path_taken_for_attrs_free_projection_and_matches_row_path() {
         (0u8..6).map(|t| [t; 16]).collect::<Vec<_>>(),
         "the two objects were interleaved into 0,1,2,3,4,5"
     );
+}
+
+/// Issue #669: the `pages_decoded`/`pages_skipped` partition metrics mean the
+/// same thing on the row path as on the columnar one. An attrs-including
+/// projection is ineligible for the fast path, so this scan drains the row path,
+/// and the two counters report what its decode actually did: every page of every
+/// block it scanned decoded ([`ROW_PAGES_DECODED`]), none skipped.
+///
+/// Both figures are pinned exactly. The zero is the point as much as the nonzero
+/// one: before the row arm wrote these counters, `EXPLAIN ANALYZE` on an
+/// attrs-including query showed `pages_decoded=0, pages_skipped=0`, which reads
+/// as "this decode touched nothing" rather than "nobody counted". With the arm
+/// instrumented, `pages_decoded=36` beside `pages_skipped=0` says the true
+/// thing: the row path decodes whole blocks and skips nothing.
+///
+/// Flip to watch it fail: delete the two `this.metrics.pages_*.add(...)` lines
+/// from the `Prepared::Rows` arm of `SpanScanStream::poll_next`
+/// (`spans_scan.rs`), the uninstrumented state this closes. Both assertions
+/// below then report 0 for `pages_decoded` while `rowpath_batches` still proves
+/// the row path ran.
+#[tokio::test]
+async fn row_path_reports_the_pages_it_decoded() {
+    let store = MemoryStore::new();
+    let segments = two_object_corpus(&store).await;
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(store);
+
+    // Including `attrs` is the eligibility axis: the fast path never builds the
+    // merged map, so this projection drains the row path (ADR-0110 decision 3),
+    // with no erasure predicate needed to force it.
+    let projection = vec![SPAN_COL_TRACE_ID, SPAN_COL_NAME, SPAN_COL_ATTRS];
+    let run = run_scan(
+        Arc::clone(&store),
+        segments.clone(),
+        Some(projection),
+        Vec::new(),
+    )
+    .await;
+
+    assert_eq!(
+        run.columnar_batches, 0,
+        "an attrs-including projection must not run the columnar path"
+    );
+    assert!(
+        run.rowpath_batches > 0,
+        "the row path must have run for the attrs-including projection"
+    );
+
+    assert_eq!(
+        run.pages_decoded, ROW_PAGES_DECODED,
+        "the row path decodes every page of the four blocks it scanned"
+    );
+    assert_eq!(
+        run.pages_skipped, 0,
+        "and skips none: it requests every column, so nothing is walked past"
+    );
+
+    // The scan still returned the rows, projected: the metrics were not bought
+    // by changing what the row path emits.
+    let total: usize = run.batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(total, 6, "every span returned once");
+    let ids: Vec<[u8; 16]> = run.batches.iter().flat_map(|b| trace_ids(b, 0)).collect();
+    assert_eq!(
+        ids,
+        (0u8..6).map(|t| [t; 16]).collect::<Vec<_>>(),
+        "in (trace_id, start_ts) order across both objects"
+    );
+}
+
+/// The `attrs_raw` fallback's page counts (#669). An eligible query whose block
+/// turns out to carry an `attrs_raw` overflow page abandons the columnar attempt
+/// and re-reads the whole partition through the row path, so the partition's
+/// decode really did both: the projected pages of the block the attempt reached,
+/// then every page of that block again. Both show up in `pages_decoded`, and the
+/// attempt's skipped pages in `pages_skipped`, which is why this partition is
+/// the one case where a row-path scan reports a nonzero `pages_skipped`.
+///
+/// Geometry: one span carrying 1001 distinct dynamic attributes. RSPAN gives the
+/// first 1000 (sorted) their own columns and spills the last into `attrs_raw`
+/// (`MAX_DYNAMIC_COLUMNS` in `ravel-rspan`'s writer), so the single block holds
+/// 1000 dynamic pages plus `attrs_raw`, `trace_id`, `span_id`, `name`,
+/// `start_ts`, `end_ts`, `status_code`, `status_message`, and `service_name`:
+/// 1009 pages. The columnar attempt decodes 4 of them (`trace_id`, `start_ts`,
+/// `end_ts`, `name` -- the projection unioned with the ordering and predicate
+/// columns) and skips 1005; the row path then decodes all 1009.
+///
+/// Flip to watch it fail: drop the abandoned attempt's counts in
+/// `prepare_partition`'s `ColumnarAttempt::FellBack` arm (`pages_decoded = 0`,
+/// `pages_skipped = 0`). The metrics then report `(1009, 0)`, the row decode
+/// alone, and this reads as a partition that never attempted the fast path.
+#[tokio::test]
+async fn attrs_raw_fallback_counts_the_abandoned_attempt_and_the_row_decode() {
+    let store = MemoryStore::new();
+    let mut spill = span(0, 0, 10, "checkout", "spill");
+    spill.attrs = std::iter::once(("service.name".to_string(), "checkout".to_string()))
+        .chain((0..1001).map(|i| (format!("k{i:04}"), i.to_string())))
+        .collect();
+    let seg = write_object(&store, "spans/attrs-raw.rspan", &[spill]).await;
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(store);
+
+    // Eligible by query shape (no `attrs`, no erasure): the fallback is decided
+    // per block, at decode.
+    let projection = vec![SPAN_COL_TRACE_ID, SPAN_COL_NAME, SPAN_COL_START_TS];
+    let run = run_scan(store, vec![seg], Some(projection), Vec::new()).await;
+
+    assert_eq!(
+        run.columnar_batches, 0,
+        "an attrs_raw block must force the whole partition to the row path"
+    );
+    assert!(run.rowpath_batches > 0, "the row path must have run");
+    assert_eq!(
+        (run.pages_decoded, run.pages_skipped),
+        (4 + 1009, 1005),
+        "the abandoned columnar attempt's pages plus the row path's whole-block decode"
+    );
+
+    let total: usize = run.batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(total, 1, "the span is still returned exactly once");
 }
 
 /// The data-protection case (ADR-0110 decision 3): with a pending erasure

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -1872,9 +1872,15 @@ happened, and `EXPLAIN ANALYZE` prints them:
   proof of which one ran.
 - `pages_decoded` / `pages_skipped` — column pages the partition's decode
   decompressed and walked past. **Both counters are written on both paths.** The
-  row path decodes every page of every block it scans, so it reports its whole
-  page count as decoded and 0 as skipped; the columnar path reports the split
-  its projection produced. A zero therefore always means the decode did that
+  row path decodes every page of every block it scans, so a direct row scan
+  reports its whole page count as decoded and 0 as skipped; the columnar path
+  reports the split its projection produced. One case is neither: when an
+  `attrs_raw` block makes the columnar attempt fall back (ADR-0110 decision 3),
+  the partition carries the abandoned attempt's counts into the row path's, so
+  it reports that attempt's skipped pages as skipped and its decoded pages on
+  top of the row decode. Those pages were really decompressed -- the query's
+  `page_bytes_decoded` counts them too -- so the totals are the partition's
+  decode work, not one arm's. A zero therefore always means the decode did that
   much, never that the arm did not count (the row arm left both unwritten before
   issue #669, and an attrs-including `EXPLAIN ANALYZE` read as a decode that
   touched nothing).

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -1859,6 +1859,32 @@ of its disjuncts; a **cross-axis** disjunction (`status_code = 2 OR duration_ns
 > 5e8`) is refused. `trace_id` is a single-point lookup with no range primitive
 to union, so a `trace_id` disjunction is refused too.
 
+Scan paths and their partition metrics (ADR-0110). `SpansScanExec` runs one of
+two paths per partition: a columnar fast path that builds Arrow arrays straight
+from RSPAN's block view, taken when the projection excludes `attrs`, no pending
+erasure predicate applies, and no scanned block carries an `attrs_raw` overflow
+page; and the row path, which rebuilds each `SpanRecord` and is what a query
+touching `attrs` (`SELECT *` included) runs. Four partition metrics show what
+happened, and `EXPLAIN ANALYZE` prints them:
+
+- `columnar_batches` / `rowpath_batches` — batches emitted by each path. The two
+  paths' output is identical by construction, so these are the only external
+  proof of which one ran.
+- `pages_decoded` / `pages_skipped` — column pages the partition's decode
+  decompressed and walked past. **Both counters are written on both paths.** The
+  row path decodes every page of every block it scans, so it reports its whole
+  page count as decoded and 0 as skipped; the columnar path reports the split
+  its projection produced. A zero therefore always means the decode did that
+  much, never that the arm did not count (the row arm left both unwritten before
+  issue #669, and an attrs-including `EXPLAIN ANALYZE` read as a decode that
+  touched nothing).
+
+The page-byte counters on `QueryAccounting` (`page_bytes_fetched` /
+`page_bytes_decoded`, ADR-0107 decision 4) sit next to these on both paths, as
+they do for logs. They are the byte-weighted view of the same decode: page
+counts weight every page equally, while an attribute or event page usually
+carries far more bytes than a fixed-width one.
+
 ## Parallel final aggregation for exact-typed queries (ADR-0094)
 
 A query whose aggregation is provably order- and partition-independent


### PR DESCRIPTION
SpansScanExec published the pages_decoded/pages_skipped partition metrics
from the columnar prepare path only. A query that includes the attrs map
column is ineligible for the fast path and drains the row arm, which
never touched the two counters, so EXPLAIN ANALYZE printed
pages_decoded=0, pages_skipped=0 for a decode that had just decompressed
every page of every block it scanned. A zero that means "nobody counted"
cannot be told apart from one that means "the decode touched nothing".

The figures already existed on the row exit. It runs over the same
SpanColumnarScan primitive the columnar exit uses, decoding each block
under BlockProjection::All, and each decoded block reports its own page
counts, which is where the page-byte accounting reads its split from.
The scan now accumulates those counts next to the page_bytes totals it
folds into QueryAccounting, and SpanFetchOutput carries them out with
the rows, since ScanStats has block counters only. The spans scan sums
them across the segments in a partition and writes both metrics from the
row arm.

A partition that abandons the columnar attempt (a block carrying an
attrs_raw overflow page sends the whole partition to the row path)
carries the pages that attempt had already decoded into the row arm's
totals, so the metric covers the decode that really ran, the same way
page_bytes_decoded already did for that partition.

The row path skips no page, so pages_skipped stays 0 there. It is now a
measurement of that path rather than an unwritten counter: pages_decoded
is nonzero beside it, and both counters mean the same thing on both
paths.

ravel-sql's spans_fetcher.rs is a re-export of ravel_query::span_fetcher,
so the row arm's counters originate in ravel-query's module.

Tests pin exact figures rather than "nonzero", derived from each
fixture's block and page geometry:

- spans_columnar.rs, row path over the existing two-object corpus (four
  blocks of nine pages): 36 decoded, 0 skipped. Red against the
  uninstrumented arm, which reports 0 decoded.
- the same corpus's columnar figures, pinned exactly at 20 decoded and
  16 skipped, and asserted to sum to the row path's 36.
- the attrs_raw fallback: a span with 1001 dynamic attributes spills one
  key into attrs_raw, and the partition reports the abandoned attempt's
  4 decoded and 1005 skipped plus the row path's 1009 decoded.
- span_fetcher.rs, both exits over one corpus: the row exit reports
  (39, 0) and the fixed-column projection splits the same 39 pages into
  (21, 18).

The ravel-bench spans-scan lane asserted the old behavior ("the row path
does not publish the pages_decoded partition metric"); it now asserts
that the row shape's decoded count equals the columnar shape's decoded
plus skipped. The lane still computes its ratio on page_bytes_decoded,
because page counts weight every page equally.

Fixes: #669
Refs: #641
Refs: #680

