### PR TITLE
fix(ravel-promql): reset native histograms on schema increase only

### DIFF
--- a/crates/ravel-promql-difftest/corpus/histogram_native.txt
+++ b/crates/ravel-promql-difftest/corpus/histogram_native.txt
@@ -49,7 +49,9 @@
 # Dataset: diff_native_hist{kind="counter"} is a monotonic counter native
 # histogram (schema 0, three positive buckets, populated zero bucket).
 # diff_native_hist_agg{i="1"|"2"} are two constant native histograms for
-# aggregation.
+# aggregation. diff_native_hist_schema{kind="counter"} is a monotonic counter
+# that changes schema up at sample 13 and back down at sample 27, for the
+# directional counter-reset entries near the end of this file.
 
 name: native_histogram_count
 query: histogram_count(diff_native_hist)
@@ -308,6 +310,66 @@ name: native_histogram_resets_instant
 query: resets(diff_native_hist[5m])
 kind: instant
 time: +600s
+mode: unordered
+
+# Schema transitions (#679). Prometheus' counter-reset detection is
+# DIRECTIONAL about the schema term: a schema INCREASE is a reset whatever the
+# buckets did (a decrease can hide in the newly visible finer resolution),
+# while a schema DECREASE is not, and the subtraction still runs after the
+# finer side is down-converted. Ravel's `FloatHistogram::detect_reset` used a
+# symmetric `self.scale != prev.scale`, so it called every decrease a reset
+# too; nothing here could catch it, because until this ticket the generator
+# emitted schema 0 for every sample of every series.
+#
+# `diff_native_hist_schema{kind="counter"}` (generator.rs
+# `schema_transition_counter`) is a monotonic counter with one positive bucket
+# at index 1, a constant zero bucket, and two schema changes: up at sample 13
+# (+390s) and back down at sample 27 (+810s). Every other reset input grows or
+# stays put, so the schema term is the only thing either side can be reacting
+# to at those two samples. The two windows below are each 5m wide and contain
+# exactly one transition: +600s covers (300s, 600s] and so sample 13, +990s
+# covers (690s, 990s] and so sample 27.
+#
+# Expected on both sides: 1 reset over the increase window, 0 over the
+# decrease window, and a rate whose count is the plain difference across the
+# decrease rather than the compensated later-sample-alone.
+#
+# NOT yet confirmed against the pinned binary: the change that added these was
+# executed on a host with no Prometheus binary and no network egress to fetch
+# one, so this is their first real oracle exposure. The Ravel side is pinned
+# independently by ravel-promql unit tests (histogram.rs
+# `no_reset_on_a_schema_decrease_whose_buckets_grew_once_aligned`,
+# `rate_subtracts_across_a_schema_decrease_instead_of_compensating`;
+# tests/histogram_native.rs
+# `resets_counts_a_schema_increase_but_not_a_schema_decrease`). One thing only
+# a real run can settle: Prometheus serves the counter-reset hint its chunk
+# layer derived, not the one remote write carried, and a schema change ends a
+# chunk. These entries assume the transition sample reads back as
+# UnknownCounterReset (so detection runs). If the oracle instead reports a
+# reset over the decrease window, the chunk header is what to look at first,
+# not the histogram.rs direction.
+name: native_histogram_resets_over_a_schema_increase
+query: resets(diff_native_hist_schema[5m])
+kind: instant
+time: +600s
+mode: unordered
+
+name: native_histogram_resets_over_a_schema_decrease
+query: resets(diff_native_hist_schema[5m])
+kind: instant
+time: +990s
+mode: unordered
+
+name: native_histogram_rate_count_over_a_schema_increase
+query: histogram_count(rate(diff_native_hist_schema[5m]))
+kind: instant
+time: +600s
+mode: unordered
+
+name: native_histogram_rate_count_over_a_schema_decrease
+query: histogram_count(rate(diff_native_hist_schema[5m]))
+kind: instant
+time: +990s
 mode: unordered
 
 name: native_histogram_changes_range

--- a/crates/ravel-promql-difftest/src/generator.rs
+++ b/crates/ravel-promql-difftest/src/generator.rs
@@ -43,11 +43,13 @@ impl GeneratedSeries {
 }
 
 /// One native-histogram sample in the generated dataset. Deliberately
-/// minimal: positive buckets only, integer counts, a fixed schema, which is
+/// minimal: positive buckets only, integer counts, which is
 /// enough to exercise the native `histogram_count`/`_sum`/`_avg`,
 /// `histogram_quantile`, `rate`, and `sum`/`avg` forms. `positive_buckets`
 /// are absolute counts (the remote-write encoder delta-encodes them);
-/// `positive_spans` are `(offset, length)` pairs.
+/// `positive_spans` are `(offset, length)` pairs. `schema` is per sample, and
+/// one series ([`schema_transition_counter`]) changes it mid-series in both
+/// directions so the counter-reset schema term has an oracle.
 #[derive(Debug, Clone)]
 pub struct GeneratedHistogramPoint {
     pub ts_ms: i64,
@@ -157,10 +159,22 @@ pub fn generate(config: &DatasetConfig) -> Dataset {
     }
 }
 
+/// Sample index at which `diff_native_hist_schema` switches from schema 0 up
+/// to schema 1 (a schema INCREASE, which Prometheus treats as a counter reset
+/// whatever the buckets did).
+pub const SCHEMA_INCREASE_AT: usize = 13;
+
+/// Sample index at which `diff_native_hist_schema` switches from schema 1 back
+/// down to schema 0 (a schema DECREASE, which is only a reset if a bucket
+/// shrank once both sides are aligned to the coarser schema).
+pub const SCHEMA_DECREASE_AT: usize = 27;
+
 /// Native-histogram series for the native-histogram corpus: a monotonic counter histogram
 /// (`diff_native_hist`, cumulative bucket counts growing each scrape, reset
-/// hint NO after the first sample) and a two-series family
-/// (`diff_native_hist_agg`, `i="1"`/`i="2"`) for `sum`/`avg` aggregation.
+/// hint NO after the first sample), a two-series family
+/// (`diff_native_hist_agg`, `i="1"`/`i="2"`) for `sum`/`avg` aggregation, and
+/// a schema-transition counter (`diff_native_hist_schema`) that changes schema
+/// in both directions mid-series.
 /// Schema 0, three positive buckets from index 1, zero bucket populated, so
 /// `histogram_quantile` has interior buckets to interpolate.
 fn native_histogram_families(config: &DatasetConfig) -> Vec<GeneratedHistogramSeries> {
@@ -190,7 +204,73 @@ fn native_histogram_families(config: &DatasetConfig) -> Vec<GeneratedHistogramSe
             .collect(),
     };
 
-    vec![counter, agg("1", vec![1, 2, 3]), agg("2", vec![4, 5, 6])]
+    vec![
+        counter,
+        agg("1", vec![1, 2, 3]),
+        agg("2", vec![4, 5, 6]),
+        schema_transition_counter(&timestamps),
+    ]
+}
+
+/// A monotonic counter native histogram that changes schema twice: up at
+/// [`SCHEMA_INCREASE_AT`] (0 -> 1) and back down at [`SCHEMA_DECREASE_AT`]
+/// (1 -> 0). Prometheus' counter-reset detection is directional about that
+/// schema term (an increase is a reset on its own, a decrease is only a reset
+/// if an aligned bucket shrank), so without a series that transitions in both
+/// directions the differential gate cannot tell a directional implementation
+/// from a symmetric one (issue #679).
+///
+/// Two shape choices make the schema term the ONLY thing either side can be
+/// reacting to:
+///
+/// * One positive bucket at index 1 throughout. Down-converting index 1 from
+///   any finer schema lands on index 1 again (`((1 - 1) >> shift) + 1 == 1`),
+///   so the aligned per-bucket comparison across the decrease is a plain
+///   `later >= earlier` on one number, with no merge to reason about.
+/// * Every population strictly grows and the zero bucket is constant, so the
+///   count, zero-count, and per-bucket checks can never fire.
+///
+/// The reset hint is UNKNOWN on the first sample of each schema run and NO
+/// elsewhere, modelling what a reader sees out of a Prometheus histogram
+/// chunk: a schema change ends the current chunk, and samples after a chunk's
+/// first carry NotCounterReset. UNKNOWN at the transitions is what makes both
+/// sides actually run detection there rather than short-circuit on the hint.
+fn schema_transition_counter(timestamps: &[i64]) -> GeneratedHistogramSeries {
+    let points = timestamps
+        .iter()
+        .enumerate()
+        .map(|(i, ts)| {
+            let schema = if i < SCHEMA_INCREASE_AT {
+                0
+            } else if i < SCHEMA_DECREASE_AT {
+                1
+            } else {
+                0
+            };
+            let bucket = 2 * (i as u64 + 1);
+            let zero_count = 1;
+            let reset_hint = if i == 0 || i == SCHEMA_INCREASE_AT || i == SCHEMA_DECREASE_AT {
+                0
+            } else {
+                2
+            };
+            GeneratedHistogramPoint {
+                ts_ms: *ts,
+                schema,
+                zero_threshold: 1e-9,
+                zero_count,
+                count: bucket + zero_count,
+                sum: bucket as f64 * 1.5,
+                positive_spans: vec![(1, 1)],
+                positive_buckets: vec![bucket],
+                reset_hint,
+            }
+        })
+        .collect();
+    GeneratedHistogramSeries {
+        labels: metric("diff_native_hist_schema", &[("kind", "counter")]),
+        points,
+    }
 }
 
 /// Build one histogram point from absolute positive bucket counts at schema 0.
@@ -556,6 +636,102 @@ mod tests {
             .filter(|s| s.metric_name() == "diff_native_hist_agg")
             .count();
         assert_eq!(agg, 2);
+    }
+
+    #[allow(clippy::expect_used)]
+    fn schema_transition_series() -> GeneratedHistogramSeries {
+        generate(&DatasetConfig::default())
+            .histogram_series
+            .into_iter()
+            .find(|s| s.metric_name() == "diff_native_hist_schema")
+            .expect("schema-transition series present")
+    }
+
+    #[test]
+    fn schema_transition_series_changes_schema_in_both_directions() {
+        let series = schema_transition_series();
+        assert!(
+            series.points.len() > SCHEMA_DECREASE_AT,
+            "the dataset must be long enough to carry both transitions"
+        );
+        for (i, point) in series.points.iter().enumerate() {
+            let expected = if (SCHEMA_INCREASE_AT..SCHEMA_DECREASE_AT).contains(&i) {
+                1
+            } else {
+                0
+            };
+            assert_eq!(point.schema, expected, "schema at sample {i}");
+        }
+        let transitions: Vec<(usize, i32, i32)> = series
+            .points
+            .windows(2)
+            .enumerate()
+            .filter(|(_, w)| w[0].schema != w[1].schema)
+            .map(|(i, w)| (i + 1, w[0].schema, w[1].schema))
+            .collect();
+        assert_eq!(
+            transitions,
+            vec![(SCHEMA_INCREASE_AT, 0, 1), (SCHEMA_DECREASE_AT, 1, 0)],
+            "exactly one increase and one decrease, at the declared indices"
+        );
+    }
+
+    #[test]
+    fn schema_transition_series_leaves_the_schema_term_as_the_only_reset_signal() {
+        // Every other input to Prometheus' counter-reset detection is
+        // monotonic or constant, so whatever either side reports at the two
+        // transitions is the schema term and nothing else.
+        let series = schema_transition_series();
+        for pair in series.points.windows(2) {
+            assert!(
+                pair[1].count > pair[0].count,
+                "count must strictly grow: {:?} -> {:?}",
+                pair[0].count,
+                pair[1].count
+            );
+            assert_eq!(
+                pair[0].zero_count, pair[1].zero_count,
+                "constant zero bucket"
+            );
+            assert_eq!(
+                pair[0].zero_threshold.to_bits(),
+                pair[1].zero_threshold.to_bits(),
+                "a changing zero threshold is its own reset signal"
+            );
+            assert_eq!(
+                pair[0].positive_spans,
+                vec![(1, 1)],
+                "one bucket at index 1"
+            );
+            assert!(
+                pair[1].positive_buckets[0] > pair[0].positive_buckets[0],
+                "the single bucket must strictly grow"
+            );
+        }
+    }
+
+    #[test]
+    fn schema_transition_series_hints_unknown_exactly_at_the_transitions() {
+        // UNKNOWN is what makes detection actually run; a NO hint at a
+        // transition would short-circuit both implementations and the entry
+        // would prove nothing about the schema direction.
+        let series = schema_transition_series();
+        let unknown: Vec<usize> = series
+            .points
+            .iter()
+            .enumerate()
+            .filter(|(_, p)| p.reset_hint == 0)
+            .map(|(i, _)| i)
+            .collect();
+        assert_eq!(unknown, vec![0, SCHEMA_INCREASE_AT, SCHEMA_DECREASE_AT]);
+        assert!(
+            series
+                .points
+                .iter()
+                .enumerate()
+                .all(|(i, p)| p.reset_hint == 0 || (i > 0 && p.reset_hint == 2)),
+            "every other sample hints NO"
+        );
     }
 
     #[test]

--- a/crates/ravel-promql/src/functions/rate.rs
+++ b/crates/ravel-promql/src/functions/rate.rs
@@ -309,23 +309,18 @@ fn instant_value(samples: &[Sample], is_rate: bool) -> Option<f64> {
 /// The two samples are adjacent samples of the same series but can carry
 /// different schemas (RSEG down-converts a flush whose bucket count exceeds
 /// its limit, so two flushes of one series can persist at different scales).
-/// `irate`'s reset check is directional (oracle-verified against three
+/// The reset check is directional (oracle-verified against three
 /// adjacent-schema shapes, see `functions::rate::tests` and
-/// `tests/histogram_native.rs`): a schema INCREASE (`last.scale >
-/// previous.scale`) is always a reset, since Prometheus never risks
-/// comparing a coarser earlier histogram against newly-visible finer detail.
-/// A schema DECREASE is only a reset if the buckets, once aligned to the
-/// common coarser schema, actually shrank -- `FloatHistogram::detect_reset`'s
-/// own `self.scale != prev.scale` shortcut cannot be called directly on the
-/// unaligned pair for this direction (it would flag every decrease as a
-/// reset, which the oracle disproves), so the decrease path aligns first and
-/// lets `detect_reset` fall through to its real `bucket_shrank` check --
-/// safe post-alignment, since both operands then share one scale and
-/// `detect_reset`'s own scale-mismatch branch never fires. `idelta` has no
-/// reset escape at all (always aligns and subtracts) once a schema-type
-/// mismatch is ruled out; this increase/decrease asymmetry is irate-only.
-/// `histogram_rate` (rate/increase/delta) does not share this directional
-/// logic and keeps its own established behavior (histogram.rs) unchanged.
+/// `tests/histogram_native.rs`): a schema INCREASE is always a reset, since
+/// Prometheus never risks comparing a coarser earlier histogram against
+/// newly-visible finer detail, while a schema DECREASE is only a reset if the
+/// buckets, once aligned to the common coarser schema, actually shrank. That
+/// direction now lives where Prometheus keeps it, in
+/// [`FloatHistogram::detect_reset`] (issue #679), so `irate` calls it on the
+/// raw pair the way Prometheus' `instantValue` does rather than carrying its
+/// own copy of the rule. `idelta` has no reset escape at all (always aligns
+/// and subtracts) once a schema-type mismatch is ruled out; the
+/// increase/decrease asymmetry is irate-only.
 ///
 /// An exponential-schema sample paired with a custom-buckets one is a
 /// separate case `copy_to_scale` cannot bridge (a custom-buckets operand
@@ -362,26 +357,15 @@ pub(crate) fn instant_value_hist(
 
     let mut result = last.clone();
     if is_rate {
-        // irate's reset check is directional, oracle-verified against three
-        // adjacent-schema shapes (see the crate's checkpoint history for
-        // #650): a schema INCREASE (finer detail newly visible) is always a
-        // reset, matching `FloatHistogram::detect_reset`'s plain
-        // `self.scale != prev.scale` shortcut, which this deliberately does
-        // NOT call directly on unaligned operands for the decrease direction
-        // -- doing so was tried and is wrong (it flags every decrease as a
-        // reset, when Prometheus only does when a bucket actually shrank). A
-        // schema DECREASE (and the custom/exponential mismatch above) must
-        // instead align to the common coarser schema first and let
-        // `detect_reset` fall through to its real `bucket_shrank` check
-        // (safe to call post-alignment: both operands share the aligned
-        // scale, so `detect_reset`'s own scale-mismatch branch never fires).
-        let min_scale = previous.scale.min(last.scale);
-        let is_reset = schema_type_mismatch
-            || last.scale > previous.scale
-            || result
-                .copy_to_scale(min_scale)
-                .detect_reset(&previous.copy_to_scale(min_scale));
+        // `detect_reset` carries the whole directional rule (#679), so this is
+        // Prometheus' `instantValue` shape: subtract unless the pair is a
+        // reset. The `schema_type_mismatch` short-circuit stays ahead of it
+        // because an explicit `No`/`Gauge` hint would otherwise send an
+        // exponential/custom-buckets pair into `copy_to_scale`, whose
+        // bucket-index shift cannot bridge the custom-buckets sentinel.
+        let is_reset = schema_type_mismatch || last.detect_reset(previous);
         if !is_reset {
+            let min_scale = previous.scale.min(last.scale);
             result = result.copy_to_scale(min_scale);
             result.sub_assign(&previous.copy_to_scale(min_scale));
         }

--- a/crates/ravel-promql/src/histogram.rs
+++ b/crates/ravel-promql/src/histogram.rs
@@ -33,6 +33,7 @@
 //!   (rate windows, aggregation groups) operates on one producer's series, so
 //!   this holds in practice, but it is not the general Prometheus behavior.
 
+use std::borrow::Cow;
 use std::collections::BTreeMap;
 
 /// Counter-reset provenance carried alongside a native histogram, mirroring
@@ -277,9 +278,27 @@ impl FloatHistogram {
 
     /// Detect whether `self` is a counter reset relative to `prev`,
     /// Prometheus' `FloatHistogram.DetectReset`: an explicit hint decides when
-    /// present, otherwise any shrink in count, zero-count, or a per-bucket
-    /// population is a reset. Used by the counter-reset compensation loop in
-    /// [`histogram_rate`].
+    /// present, otherwise a shrink in count or zero-count, a schema increase,
+    /// or a shrink in any per-bucket population is a reset. Used by the
+    /// counter-reset compensation loop in [`histogram_rate`] and by
+    /// `irate`/`resets`.
+    ///
+    /// The schema term is DIRECTIONAL, exactly as Prometheus is
+    /// (`h.Schema > previous.Schema`), not a symmetric "the schemas differ":
+    ///
+    /// | `self.scale` vs `prev.scale` | reset from the schema term |
+    /// |---|---|
+    /// | increase (`self` finer) | yes, unconditionally |
+    /// | equal | no |
+    /// | decrease (`self` coarser) | no; the buckets are compared at `self.scale` |
+    ///
+    /// An increase is a reset whatever the bucket populations say, because a
+    /// decrease can hide at the newly-visible finer resolution where no
+    /// comparison against the coarser earlier value can see it. A decrease
+    /// hides nothing: `prev` down-converts to `self.scale` exactly (Prometheus
+    /// iterates `prev`'s buckets at `self`'s schema), so the per-bucket
+    /// comparison runs on aligned bounds and a still-growing counter is not a
+    /// reset.
     pub fn detect_reset(&self, prev: &FloatHistogram) -> bool {
         match self.counter_reset_hint {
             ResetHint::Gauge => false,
@@ -289,12 +308,26 @@ impl FloatHistogram {
                 if self.count < prev.count || self.zero_count < prev.zero_count {
                     return true;
                 }
-                // A schema change or a shrink in any bucket population is a
-                // reset. Comparing by absolute bucket index handles differing
-                // span layouts.
-                if self.scale != prev.scale {
+                // An exponential-schema value and a custom-buckets one are not
+                // comparable in either direction: the custom-buckets sentinel
+                // scale sits far outside the exponential range, so neither
+                // side can be rescaled onto the other's bounds (issue #678).
+                // Report a reset rather than rescale across the sentinel.
+                if self.uses_custom_buckets() != prev.uses_custom_buckets() {
                     return true;
                 }
+                if self.scale > prev.scale {
+                    return true;
+                }
+                // Align `prev` down to `self`'s (equal or coarser) scale so the
+                // per-bucket comparison reads the same bounds on both sides;
+                // equal scales borrow it untouched. Comparing by absolute
+                // bucket index then handles differing span layouts.
+                let prev = if self.scale < prev.scale {
+                    Cow::Owned(prev.copy_to_scale(self.scale))
+                } else {
+                    Cow::Borrowed(prev)
+                };
                 bucket_shrank(&prev.positive_index_map(), &self.positive_index_map())
                     || bucket_shrank(&prev.negative_index_map(), &self.negative_index_map())
             }
@@ -680,6 +713,13 @@ pub fn histogram_rate(samples: &[TimedHistogram], is_counter: bool) -> Option<Fl
     result.sub_assign(&prev0.copy_to_scale(min_scale));
 
     if is_counter {
+        // Reset detection runs on the raw adjacent pair, not on the
+        // min_scale-aligned copies, exactly as Prometheus' second
+        // `histogramRate` pass does: `detect_reset` owns the schema direction
+        // (an increase between the pair is a reset; a decrease aligns inside
+        // it), and pre-aligning both operands to the window minimum would hide
+        // an increase that happened between two samples the window later
+        // down-converts to one common scale.
         let mut prev = prev0.clone();
         for (_, curr) in &samples[1..] {
             if curr.detect_reset(&prev) {
@@ -929,6 +969,121 @@ mod tests {
     }
 
     #[test]
+    fn detect_reset_on_a_schema_increase_even_when_every_bucket_grew() {
+        // prev at scale 0 (count 3), curr at scale 2 (count 10): nothing
+        // shrank, but a finer schema can hide a decrease inside the newly
+        // visible resolution, so Prometheus' `h.Schema > previous.Schema`
+        // makes an increase a reset unconditionally.
+        let prev = positive(0, 1, &[3.0], 6.0);
+        let curr = positive(2, 1, &[10.0], 20.0);
+        assert!(
+            curr.detect_reset(&prev),
+            "a schema increase is a reset on its own"
+        );
+    }
+
+    #[test]
+    fn no_reset_on_a_schema_decrease_whose_buckets_grew_once_aligned() {
+        // prev at scale 1 holds indices {1:1, 2:2}; curr at the coarser scale 0
+        // holds {1:10}. Down-converting prev to scale 0 merges both of its
+        // buckets into index 1 (((1-1)>>1)+1 == ((2-1)>>1)+1 == 1) for 3, and
+        // 10 >= 3, so no bucket shrank and this is NOT a reset.
+        //
+        // The flipped line is `detect_reset`'s schema term: the symmetric
+        // `if self.scale != prev.scale { return true }` it replaced reported a
+        // reset here, since the two scales merely differ.
+        let prev = positive(1, 1, &[1.0, 2.0], 3.0);
+        let curr = positive(0, 1, &[10.0], 20.0);
+        assert!(
+            !curr.detect_reset(&prev),
+            "a schema decrease is only a reset if an aligned bucket shrank"
+        );
+    }
+
+    #[test]
+    fn reset_on_a_schema_decrease_whose_aligned_bucket_shrank() {
+        // The other half of the decrease direction: prev at scale 1 aligns to
+        // {1:11} at scale 0, curr holds {1:4, 2:20}. The total count GREW
+        // (11 -> 24), so only the per-bucket comparison at the common scale
+        // catches the drop in index 1 (11 -> 4).
+        let prev = positive(1, 1, &[5.0, 6.0], 11.0);
+        let curr = positive(0, 1, &[4.0, 20.0], 48.0);
+        assert!(
+            curr.count > prev.count,
+            "the count check must not decide it"
+        );
+        assert!(
+            curr.detect_reset(&prev),
+            "an aligned bucket shrank, so the decrease is a reset"
+        );
+    }
+
+    #[test]
+    fn detect_reset_at_equal_scales_is_the_plain_bucket_comparison() {
+        // Equal scales contribute nothing on their own: growth is not a reset,
+        // a per-bucket shrink under a growing total count still is.
+        let prev = positive(2, 1, &[5.0, 5.0], 10.0);
+        let grown = positive(2, 1, &[6.0, 7.0], 13.0);
+        assert!(!grown.detect_reset(&prev), "equal scales, nothing shrank");
+
+        let shrunk_bucket = positive(2, 1, &[3.0, 20.0], 23.0);
+        assert!(
+            shrunk_bucket.count > prev.count,
+            "the count check must not decide it"
+        );
+        assert!(
+            shrunk_bucket.detect_reset(&prev),
+            "equal scales, index 1 shrank 5 -> 3"
+        );
+    }
+
+    #[test]
+    fn rate_subtracts_across_a_schema_decrease_instead_of_compensating() {
+        // The value the decrease direction is worth: prev at scale 1
+        // ({1:1, 2:2}, count 3, sum 3), curr at scale 0 ({1:10}, count 10,
+        // sum 20). Both align to scale 0, prev merging to {1:3}, so the window
+        // reduction is the plain difference: bucket 10 - 3 = 7, count 7,
+        // sum 20 - 3 = 17.
+        //
+        // The flipped assertions are `r.count == 7.0` and
+        // `r.positive_buckets == [7.0]`: with `detect_reset`'s old symmetric
+        // `self.scale != prev.scale`, the pair read as a reset, so the
+        // compensation loop added prev back and produced count 10, sum 20,
+        // bucket 10 -- the later sample alone, with the earlier one's growth
+        // silently discarded.
+        let prev = positive(1, 1, &[1.0, 2.0], 3.0);
+        let curr = positive(0, 1, &[10.0], 20.0);
+        let r = histogram_rate(&[(0, prev), (60_000_000_000, curr)], true).expect("2 samples");
+        assert_eq!(r.scale, 0, "reduced at the coarser of the two scales");
+        assert_eq!(r.count, 7.0, "10 - 3, not the compensated 10");
+        assert_eq!(r.sum, 17.0, "20 - 3, not the compensated 20");
+        assert_eq!(
+            r.positive_buckets,
+            vec![7.0],
+            "index 1 is 10 - (1 + 2), not the compensated 10"
+        );
+        assert_eq!(
+            r.positive_spans,
+            vec![Span {
+                offset: 1,
+                length: 1
+            }]
+        );
+    }
+
+    #[test]
+    fn rate_still_compensates_across_a_schema_increase() {
+        // The unchanged direction, through the same reducer: prev at scale 0
+        // (count 3), curr at scale 2 (count 10). The increase is a reset, so
+        // the raw difference (10 - 3 = 7) gets prev added back for 10.
+        let prev = positive(0, 1, &[3.0], 6.0);
+        let curr = positive(2, 1, &[10.0], 20.0);
+        let r = histogram_rate(&[(0, prev), (60_000_000_000, curr)], true).expect("2 samples");
+        assert_eq!(r.count, 10.0, "reset compensation restores the later count");
+        assert_eq!(r.sum, 20.0);
+    }
+
+    #[test]
     fn rate_of_monotonic_window_is_the_difference() {
         // Two samples, counts 2 then 6 in bucket (1,2]. No reset. rate window
         // reduction (before the caller's per-second factor) is the plain
@@ -1041,6 +1196,33 @@ mod tests {
             negative_buckets: Vec::new(),
             custom_values: vec![1.0, 2.0],
         }
+    }
+
+    #[test]
+    fn detect_reset_over_mismatched_exponential_and_custom_schemas_does_not_rescale() {
+        // The custom-buckets sentinel (-53) reads as a schema DECREASE against
+        // any exponential scale, so without the schema-type guard the aligning
+        // branch would hand `copy_to_scale` a 53-bit bucket-index shift. The
+        // pair is not comparable in either direction: report a reset.
+        let prev = positive(0, 1, &[10.0], 20.0);
+        let curr = custom_buckets(12.0, 24.0);
+        assert!(
+            curr.count > prev.count,
+            "the count check must not decide it"
+        );
+        assert!(
+            curr.detect_reset(&prev),
+            "an exponential/custom-buckets pair is a reset, not a rescale"
+        );
+        // The other direction reads as an increase (any exponential scale is
+        // above the sentinel) and is a reset too, again with a growing count
+        // so the cheap count check is not what decides it.
+        let custom_prev = custom_buckets(10.0, 20.0);
+        let exponential_curr = positive(0, 1, &[12.0], 24.0);
+        assert!(
+            exponential_curr.detect_reset(&custom_prev),
+            "and the same in the other direction"
+        );
     }
 
     #[test]

--- a/crates/ravel-promql/tests/histogram_native.rs
+++ b/crates/ravel-promql/tests/histogram_native.rs
@@ -725,3 +725,89 @@ fn idelta_over_mismatched_exponential_and_custom_bucket_schemas_warns_and_drops(
         annos.warnings()
     );
 }
+
+#[test]
+fn resets_counts_a_schema_increase_but_not_a_schema_decrease() {
+    // `resets` is `FloatHistogram::detect_reset` reduced to a float, so it
+    // reads the schema direction straight out (#679). The increase pair
+    // (scale 0 -> 2) is a reset even though its buckets grew; the decrease
+    // pair (scale 1 -> 0) is not, because prev's two scale-1 buckets merge to
+    // 3 at scale 0 and 10 >= 3.
+    //
+    // The flipped assertion is the decrease case's `vec![0.0]`: with
+    // `detect_reset`'s old symmetric `self.scale != prev.scale` schema term,
+    // any schema change counted, so both windows answered 1.
+    let increase = TestSource::new()
+        .with_histogram_series(
+            &[("__name__", "h")],
+            &[
+                (sec_ns(270), hist_scale(0, 1, &[3.0], 6.0)),
+                (sec_ns(300), hist_scale(2, 1, &[10.0], 20.0)),
+            ],
+        )
+        .expect("valid series");
+    let got = Evaluator::new()
+        .instant(&increase, "resets(h[5m])", 5 * 60_000)
+        .expect("evaluates");
+    assert_eq!(floats(&got), vec![1.0], "a schema increase is a reset");
+
+    let decrease = TestSource::new()
+        .with_histogram_series(
+            &[("__name__", "h")],
+            &[
+                (sec_ns(270), hist_scale(1, 1, &[1.0, 2.0], 3.0)),
+                (sec_ns(300), hist_scale(0, 1, &[10.0], 20.0)),
+            ],
+        )
+        .expect("valid series");
+    let got = Evaluator::new()
+        .instant(&decrease, "resets(h[5m])", 5 * 60_000)
+        .expect("evaluates");
+    assert_eq!(
+        floats(&got),
+        vec![0.0],
+        "a schema decrease whose aligned buckets grew is not a reset"
+    );
+}
+
+#[test]
+fn rate_subtracts_across_a_schema_decrease_end_to_end() {
+    // The same decrease pair through `rate`, which reaches `detect_reset` via
+    // `histogram_rate`'s compensation loop rather than `irate`'s pairwise
+    // check. The window reduction is 10 - 3 = 7 with sum 20 - 3 = 17; `rate`
+    // then scales both by one extrapolation factor, so this pins their ratio
+    // rather than a hand-computed absolute: sum/count must be (20 - 3)/(10 -
+    // 3), the ratio the raw difference has and the compensated result (20/10)
+    // does not.
+    //
+    // The flipped assertion is `sum / count == 17/7`: before the fix the pair
+    // read as a reset, the loop added prev back, and the ratio was 20/10.
+    let src = TestSource::new()
+        .with_histogram_series(
+            &[("__name__", "h")],
+            &[
+                (sec_ns(270), hist_scale(1, 1, &[1.0, 2.0], 3.0)),
+                (sec_ns(300), hist_scale(0, 1, &[10.0], 20.0)),
+            ],
+        )
+        .expect("valid series");
+    let got = Evaluator::new()
+        .instant(&src, "rate(h[5m])", 5 * 60_000)
+        .expect("evaluates");
+    assert_eq!(got.len(), 1);
+    let h = got[0]
+        .histogram
+        .as_ref()
+        .expect("rate over histograms yields a histogram element");
+    assert_eq!(h.scale, 0, "reduced at the coarser of the two scales");
+    assert_eq!(
+        h.positive_buckets.len(),
+        1,
+        "the aligned single bucket, not a two-bucket unaligned merge"
+    );
+    let ratio = h.sum / h.count;
+    assert!(
+        (ratio - 17.0 / 7.0).abs() < 1e-12,
+        "sum/count must be (20-3)/(10-3), not the reset-compensated 20/10: {ratio}"
+    );
+}

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -1248,7 +1248,7 @@ conformance_table`; regenerate that same command with
 `RAVEL_UPDATE_CONFORMANCE_TABLE=1`. Do not edit the block between
 the markers by hand.
 
-Surface: 133 constructs over 238 corpus entries in 10 corpus files.
+Surface: 133 constructs over 242 corpus entries in 10 corpus files.
 
 | State | Constructs |
 | --- | --- |
@@ -1347,7 +1347,7 @@ Surface: 133 constructs over 238 corpus entries in 10 corpus files.
 | `exp` | function | supported | `corpus/transform.txt`, 1 entry |
 | `floor` | function | supported | `corpus/transform.txt`, 1 entry |
 | `histogram_avg` | function | supported | `corpus/histogram_native.txt`, 1 entry |
-| `histogram_count` | function | supported | `corpus/histogram_native.txt`, 3 entries |
+| `histogram_count` | function | supported | `corpus/histogram_native.txt`, 5 entries |
 | `histogram_fraction` | function | supported | `corpus/histogram_classic.txt`, 3 entries |
 | `histogram_quantile` | function | supported | `corpus/histogram_classic.txt`, 8 entries |
 | `histogram_stddev` | function | intentionally rejected | `Unsupported: function call (422 execution)`; rejection verified; not in ravel-promql's function registry; native-histogram dispersion is not implemented |


### PR DESCRIPTION
FloatHistogram::detect_reset treated any schema difference between two
adjacent samples as a counter reset. Prometheus is directional about that
term: only a schema increase from the earlier sample to the later one is a
reset on its own.

  earlier -> later      reset from the schema term
  increase (finer)      yes, whatever the buckets did
  equal                 no
  decrease (coarser)    no, unless an aligned bucket shrank

An increase is a reset unconditionally because a decrease can hide inside
the newly visible finer resolution, where no comparison against the coarser
earlier value can see it. A decrease hides nothing, so the subtraction still
runs: the earlier, finer histogram down-converts to the later one's scale
first (copy_to_scale, the same merge Prometheus' bucket iterator performs
when it walks the previous value at the current schema), and the per-bucket
comparison then reads the same bounds on both sides. When the pair is not a
reset, rate/increase/delta go on to subtract at the window's coarsest scale
exactly as before, so a schema decrease now yields the real difference
rather than the later sample alone.

The symmetric check was reached from two directions. histogram_rate's
counter-reset compensation loop calls detect_reset on raw adjacent pairs and
so carried the identical bug. irate had worked around it in
functions/rate.rs by pre-aligning both operands and special-casing the
increase; that rule now lives in detect_reset, where Prometheus keeps it, so
instant_value_hist calls it on the raw pair the way instantValue does.

An exponential-schema value paired with a custom-buckets one reads as a
decrease against the -53 sentinel, which no rescale can bridge (#678), so
detect_reset reports a reset for that pair in either direction rather than
handing copy_to_scale a 53-bit bucket-index shift.

Nothing exercised a schema transition before: the difftest generator emitted
schema 0 for every sample of every series. It now also builds
diff_native_hist_schema, a monotonic counter that steps schema up at sample
13 and back down at sample 27, with one positive bucket, a constant zero
bucket, and strictly growing populations, so the schema term is the only
reset input in play at either transition. Four corpus entries query it in
both directions. Those entries have not met the pinned Prometheus binary
yet: the host this was written on has neither the binary nor network egress
to fetch one. The corpus comment says so and names the first thing to check
if the oracle disagrees.

Fixes: #679
Refs: #676
Refs: #680

