### PR TITLE
feat(ravel-bench): let sql_latency_bench raise the per-query memory budget

### DIFF
--- a/crates/ravel-bench/src/bin/sql_latency_bench.rs
+++ b/crates/ravel-bench/src/bin/sql_latency_bench.rs
@@ -276,11 +276,17 @@ async fn run(args: &Args) -> Result<SqlLatencyReport, ravel_bench::sql_latency::
     // 8,424-object tenant wastes the run and real S3 requests. It is not in
     // `measure_corpus` because library code deciding this from process-global
     // env makes an exported RAVEL_BENCH_PROFILE_SVG fail unrelated tests.
-    ravel_bench::profiling::runs_supported_with_profiling(
-        ravel_bench::profiling::profile_requested(),
-        args.runs,
-    )
-    .map_err(ravel_bench::sql_latency::Error::from)?;
+    // The Flight lane executes in `measure_over_flight`, which never constructs
+    // a `ProfileSession`, so no sampler exists there and the crash this guards
+    // cannot happen; refusing a Flight `--runs 3` (the default) would reject a
+    // safe run. Gate on the lanes that actually arm a sampler.
+    if args.flight.is_none() {
+        ravel_bench::profiling::runs_supported_with_profiling(
+            ravel_bench::profiling::profile_requested(),
+            args.runs,
+        )
+        .map_err(ravel_bench::sql_latency::Error::from)?;
+    }
     let entries = match &args.corpus {
         Some(path) => load_external_corpus(path)?,
         None => checked_default_corpus()?,

--- a/crates/ravel-bench/src/bin/sql_latency_bench.rs
+++ b/crates/ravel-bench/src/bin/sql_latency_bench.rs
@@ -58,6 +58,11 @@ struct Args {
     /// a heavy query that otherwise aborts with `query memory budget exhausted`.
     /// Defaults to ravel-sql's compiled-in 256 MiB, so an unset flag leaves the
     /// measured budget byte-for-byte unchanged.
+    ///
+    /// Applies to the in-process lanes only. It is not a Flight header, so under
+    /// `--flight` the server's own ceiling governs and this flag changes
+    /// nothing; the report records `sql_max_query_bytes_effective` as null
+    /// there rather than echoing what was asked for.
     #[arg(long = "sql-max-query-bytes", value_name = "BYTES", default_value_t = DEFAULT_MAX_QUERY_BYTES)]
     sql_max_query_bytes: usize,
     /// The engine's `max_segments` ceiling, the same knob as `ravel-server
@@ -263,6 +268,19 @@ async fn main() -> ExitCode {
 }
 
 async fn run(args: &Args) -> Result<SqlLatencyReport, ravel_bench::sql_latency::Error> {
+    // Refuse a profiled multi-run pass up front (issue #616): the pprof signal
+    // sampler segfaults probabilistically the longer it stays armed, so more
+    // runs crash rather than measure. Checked here, before the corpus load and
+    // before any store resolve, because it depends only on argv and the
+    // environment: refusing after a multi-minute LIST fan-out over a
+    // 8,424-object tenant wastes the run and real S3 requests. It is not in
+    // `measure_corpus` because library code deciding this from process-global
+    // env makes an exported RAVEL_BENCH_PROFILE_SVG fail unrelated tests.
+    ravel_bench::profiling::runs_supported_with_profiling(
+        ravel_bench::profiling::profile_requested(),
+        args.runs,
+    )
+    .map_err(ravel_bench::sql_latency::Error::from)?;
     let entries = match &args.corpus {
         Some(path) => load_external_corpus(path)?,
         None => checked_default_corpus()?,
@@ -391,7 +409,16 @@ fn print_human_table(report: &SqlLatencyReport) {
     println!("  fetch conc : {}", p.fetch_concurrency);
     let effective =
         parallel_final_aggregation_effective_label(p.parallel_final_aggregation_effective);
-    println!("  query max  : {} bytes", p.sql_max_query_bytes);
+    println!(
+        "  query max  : requested={} bytes  effective={}",
+        p.sql_max_query_bytes_requested,
+        match p.sql_max_query_bytes_effective {
+            Some(v) => format!("{v} bytes"),
+            // A Flight run does not send the ceiling to the server; the
+            // effective value is the server's own.
+            None => "unknown (server config)".to_string(),
+        }
+    );
     println!(
         "  tenant max : {} bytes  parallel final agg: requested={} effective={}",
         p.tenant_max_bytes, p.parallel_final_aggregation_requested, effective

--- a/crates/ravel-bench/src/bin/sql_latency_bench.rs
+++ b/crates/ravel-bench/src/bin/sql_latency_bench.rs
@@ -391,6 +391,7 @@ fn print_human_table(report: &SqlLatencyReport) {
     println!("  fetch conc : {}", p.fetch_concurrency);
     let effective =
         parallel_final_aggregation_effective_label(p.parallel_final_aggregation_effective);
+    println!("  query max  : {} bytes", p.sql_max_query_bytes);
     println!(
         "  tenant max : {} bytes  parallel final agg: requested={} effective={}",
         p.tenant_max_bytes, p.parallel_final_aggregation_requested, effective

--- a/crates/ravel-bench/src/profiling.rs
+++ b/crates/ravel-bench/src/profiling.rs
@@ -76,6 +76,14 @@
 //! profile nothing while adding the exposure that risks the crash. Take latency
 //! from a separate unprofiled multi-run pass.
 //!
+//! `sql_latency_bench` enforces this rather than trusting the operator to
+//! remember it: a run with the profiler armed (`PROFILE_ENV` set and the
+//! `profiling` feature compiled in) and `--runs > 1` is refused up front by
+//! [`runs_supported_with_profiling`] before the guard is built, so the failure
+//! is a clear error instead of a segfault partway through the first statement.
+//! The profiler alone (`--runs 1`) and repeated runs alone (profiler off) are
+//! both unaffected.
+//!
 //! # Concurrent-query segfault and the query-lane sampling rate (issue #680)
 //!
 //! The same hazard fires without repeated runs once the measured region goes
@@ -120,6 +128,48 @@
 /// measured region in a `pprof` CPU sampler and writes the flamegraph there. If
 /// it is unset, no profiler is started even when the feature is compiled in.
 pub const PROFILE_ENV: &str = "RAVEL_BENCH_PROFILE_SVG";
+
+/// Refuse a profiled run that would execute each statement more than once
+/// (issue #616). `pprof`'s signal sampler unwinds through libgcc's
+/// async-signal-unsafe path on every `SIGPROF` tick, and the crash is
+/// probabilistic in the number of unwinds; more runs of every statement raise
+/// that count and the profiled process has been observed to segfault (see the
+/// "Known instability under repeated execution" section of this module). One
+/// guard around the whole measured region does not close the hazard, so rather
+/// than segfault partway through a run this refuses the combination up front:
+/// take the flamegraph from `--runs 1` (one execution already fills it) and the
+/// latencies from a separate unprofiled multi-run pass.
+///
+/// Pure so the decision is testable without touching the process environment or
+/// arming a real sampler: `profile_requested` is whether a sampler would run
+/// (the `profiling` feature is on and [`PROFILE_ENV`] names a path), which
+/// [`profile_requested`] resolves for the live path.
+pub fn runs_supported_with_profiling(profile_requested: bool, runs: usize) -> Result<(), String> {
+    if profile_requested && runs > 1 {
+        return Err(format!(
+            "--runs > 1 is not supported with {PROFILE_ENV}; the profiler and repeated execution \
+             crash together, issue #616"
+        ));
+    }
+    Ok(())
+}
+
+/// Whether a CPU sampler would actually run for this process: the `profiling`
+/// feature is compiled in and [`PROFILE_ENV`] names a non-empty path. This is
+/// the condition [`runs_supported_with_profiling`] gates on. With the feature
+/// off no `pprof` guard is ever built, so the env var alone cannot crash a run
+/// and this is always `false`.
+#[cfg(feature = "profiling")]
+pub fn profile_requested() -> bool {
+    std::env::var_os(PROFILE_ENV).is_some_and(|v| !v.is_empty())
+}
+
+/// See the `profiling`-on variant. No sampler is linked in a default build, so
+/// a set [`PROFILE_ENV`] cannot crash a repeated run and nothing is refused.
+#[cfg(not(feature = "profiling"))]
+pub fn profile_requested() -> bool {
+    false
+}
 
 /// Sampling frequency in Hz for the ingest lane. 997 (a prime near 1 kHz)
 /// avoids aliasing against any periodic timer in the workload.
@@ -347,6 +397,44 @@ mod manifest_tests {
                 );
             }
         }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod refusal_tests {
+    use super::{PROFILE_ENV, runs_supported_with_profiling};
+
+    /// A profiled run (`RAVEL_BENCH_PROFILE_SVG` set, sampler linked) with
+    /// `--runs > 1` is refused up front with the exact message, rather than
+    /// segfaulting partway through the run (issue #616). Reverting the guard to
+    /// an unconditional `Ok(())` makes the first assertion fail. The decision is
+    /// pure so it needs no live sampler or process-env mutation.
+    #[test]
+    fn repeated_runs_refused_only_when_profiling() {
+        // The offending combination: profiler on and more than one run.
+        let err = runs_supported_with_profiling(true, 3)
+            .expect_err("a profiled multi-run pass must be refused");
+        assert_eq!(
+            err,
+            format!(
+                "--runs > 1 is not supported with {PROFILE_ENV}; the profiler and repeated \
+                 execution crash together, issue #616"
+            )
+        );
+
+        // Either alone is fine: a single profiled run is the supported profiling
+        // path, and repeated runs with the profiler off are stable.
+        assert!(
+            runs_supported_with_profiling(true, 1).is_ok(),
+            "one profiled run is the supported flamegraph path"
+        );
+        assert!(
+            runs_supported_with_profiling(false, 3).is_ok(),
+            "repeated runs are stable when no sampler is armed"
+        );
+        // A boundary: exactly one run is never refused, profiler or not.
+        assert!(runs_supported_with_profiling(false, 1).is_ok());
     }
 }
 

--- a/crates/ravel-bench/src/sql_latency.rs
+++ b/crates/ravel-bench/src/sql_latency.rs
@@ -193,6 +193,14 @@ pub struct Provenance {
     /// full-scan statement is latency-bound and moves nearly linearly with it.
     #[serde(default = "default_fetch_concurrency")]
     pub fetch_concurrency: usize,
+    /// The per-query DataFusion memory-pool ceiling for the run
+    /// (`ravel-server --sql-max-query-bytes`, ADR-0088). A statement that failed
+    /// with `query memory pool exhausted` was refused by this, not by
+    /// `tenant_max_bytes`. Recorded so a report states the per-query budget its
+    /// statements ran under; a report written before this field existed
+    /// deserializes to [`ravel_sql::DEFAULT_MAX_QUERY_BYTES`].
+    #[serde(default = "default_max_query_bytes")]
+    pub sql_max_query_bytes: usize,
     /// The tenant accountant's ceiling for the run. A statement that failed
     /// with `tenant memory budget exhausted` was refused by this, not by
     /// `max_query_bytes`.
@@ -241,6 +249,13 @@ pub struct Provenance {
 /// The tenant ceiling every run used before the knob was configurable.
 fn default_tenant_max_bytes() -> usize {
     DEFAULT_TENANT_MAX_BYTES
+}
+
+/// The per-query pool ceiling every run used before the knob was recorded in
+/// provenance (issue #615); also what a report written before the field existed
+/// deserializes to.
+fn default_max_query_bytes() -> usize {
+    DEFAULT_MAX_QUERY_BYTES
 }
 
 /// The engine segment ceiling every run used before the knob was configurable
@@ -1284,6 +1299,7 @@ pub async fn run_generated(cfg: &GenerateConfig) -> Result<SqlLatencyReport, Err
             cache_bytes: cfg.cache_bytes,
             deadline_secs: cfg.deadline.as_secs(),
             fetch_concurrency: cfg.fetch_concurrency.max(1),
+            sql_max_query_bytes: cfg.max_query_bytes,
             tenant_max_bytes: cfg.tenant_max_bytes.max(1),
             sql_max_segments: cfg.max_segments,
             parallel_final_aggregation_requested: cfg.parallel_final_aggregation,
@@ -1395,6 +1411,7 @@ pub async fn run_tenant(cfg: &TenantConfigInput) -> Result<SqlLatencyReport, Err
             cache_bytes: cfg.cache_bytes,
             deadline_secs: cfg.deadline.as_secs(),
             fetch_concurrency: cfg.fetch_concurrency.max(1),
+            sql_max_query_bytes: cfg.max_query_bytes,
             tenant_max_bytes: cfg.tenant_max_bytes.max(1),
             sql_max_segments: cfg.max_segments,
             parallel_final_aggregation_requested: cfg.parallel_final_aggregation,
@@ -2708,5 +2725,38 @@ mod tests {
         let executor =
             cold_executor(&store, &[], None, ExecutorSettings::default()).expect("build executor");
         assert_eq!(executor.config().max_query_bytes, DEFAULT_MAX_QUERY_BYTES);
+    }
+
+    /// The effective per-query pool ceiling is recorded in the run's provenance
+    /// block (issue #615): a run with a raised `--sql-max-query-bytes` records
+    /// exactly that value, and an unset flag records the compiled-in default.
+    /// Before the field existed the block carried no per-query budget at all, so
+    /// this assertion has nothing to read and fails to compile against the old
+    /// provenance; with the field present but unpopulated it would read the
+    /// serde default and the raised-value arm goes red.
+    #[tokio::test]
+    async fn provenance_records_effective_max_query_bytes() {
+        let store = empty_store();
+        provisioned_tenant(&store, "maxquerybytes-tenant").await;
+
+        let custom = DEFAULT_MAX_QUERY_BYTES * 4;
+        assert_ne!(custom, DEFAULT_MAX_QUERY_BYTES);
+        let mut cfg = tenant_cfg(&store, "maxquerybytes-tenant", None, 0);
+        cfg.entries = vec![entry("scan", "SELECT body FROM logs")];
+        cfg.max_query_bytes = custom;
+        let report = run_tenant(&cfg).await.expect("tenant lane runs");
+        assert_eq!(
+            report.provenance.sql_max_query_bytes, custom,
+            "the raised per-query pool ceiling is recorded in provenance"
+        );
+
+        // Unset flag (the config default): the block records the compiled-in
+        // budget byte-for-byte.
+        let cfg = tenant_cfg(&store, "maxquerybytes-tenant", None, 0);
+        let report = run_tenant(&cfg).await.expect("tenant lane runs");
+        assert_eq!(
+            report.provenance.sql_max_query_bytes, DEFAULT_MAX_QUERY_BYTES,
+            "an unset flag records the compiled-in per-query budget"
+        );
     }
 }

--- a/crates/ravel-bench/src/sql_latency.rs
+++ b/crates/ravel-bench/src/sql_latency.rs
@@ -864,6 +864,14 @@ pub async fn measure_corpus(
     // every entry's execution, both lanes (run_generated/run_tenant funnel
     // through this one function), so a query-side profile always reflects the
     // full corpus rather than one statement in isolation.
+    //
+    // Refuse a profiled multi-run pass before arming the sampler (issue #616):
+    // one guard already brackets the whole region, yet the pprof signal sampler
+    // still segfaults probabilistically the longer it stays armed, so more runs
+    // crash rather than measure. Take the flamegraph from `--runs 1` and the
+    // latencies from a separate unprofiled pass.
+    crate::profiling::runs_supported_with_profiling(crate::profiling::profile_requested(), runs)
+        .map_err(Error::from)?;
     let profile = crate::profiling::ProfileSession::from_env("sql_latency_bench");
 
     'entries: for entry in entries {

--- a/crates/ravel-bench/src/sql_latency.rs
+++ b/crates/ravel-bench/src/sql_latency.rs
@@ -193,14 +193,21 @@ pub struct Provenance {
     /// full-scan statement is latency-bound and moves nearly linearly with it.
     #[serde(default = "default_fetch_concurrency")]
     pub fetch_concurrency: usize,
-    /// The per-query DataFusion memory-pool ceiling for the run
-    /// (`ravel-server --sql-max-query-bytes`, ADR-0088). A statement that failed
-    /// with `query memory pool exhausted` was refused by this, not by
-    /// `tenant_max_bytes`. Recorded so a report states the per-query budget its
-    /// statements ran under; a report written before this field existed
-    /// deserializes to [`ravel_sql::DEFAULT_MAX_QUERY_BYTES`].
+    /// The per-query DataFusion memory-pool ceiling this run ASKED for
+    /// (`--sql-max-query-bytes`, ADR-0088). A report written before this field
+    /// existed deserializes to [`ravel_sql::DEFAULT_MAX_QUERY_BYTES`].
     #[serde(default = "default_max_query_bytes")]
-    pub sql_max_query_bytes: usize,
+    pub sql_max_query_bytes_requested: usize,
+    /// The ceiling that actually governed execution, or `None` when this
+    /// process cannot know it. The Flight lane does not send the setting to the
+    /// server (it is not a Flight header), so what governed there is the
+    /// server's own config: a statement that failed with `query memory pool
+    /// exhausted` on that lane was refused by a ceiling this report cannot
+    /// name. Recording the requested value as effective would let two Flight
+    /// tables taken at different `--sql-max-query-bytes` values look
+    /// comparable while having run under identical server ceilings.
+    #[serde(default)]
+    pub sql_max_query_bytes_effective: Option<usize>,
     /// The tenant accountant's ceiling for the run. A statement that failed
     /// with `tenant memory budget exhausted` was refused by this, not by
     /// `max_query_bytes`.
@@ -865,13 +872,11 @@ pub async fn measure_corpus(
     // through this one function), so a query-side profile always reflects the
     // full corpus rather than one statement in isolation.
     //
-    // Refuse a profiled multi-run pass before arming the sampler (issue #616):
-    // one guard already brackets the whole region, yet the pprof signal sampler
-    // still segfaults probabilistically the longer it stays armed, so more runs
-    // crash rather than measure. Take the flamegraph from `--runs 1` and the
-    // latencies from a separate unprofiled pass.
-    crate::profiling::runs_supported_with_profiling(crate::profiling::profile_requested(), runs)
-        .map_err(Error::from)?;
+    // The profiled multi-run refusal (issue #616) lives in the binary, not here:
+    // deciding it from process-global env inside library code would make an
+    // exported RAVEL_BENCH_PROFILE_SVG fail unrelated tests that legitimately
+    // pass runs > 1, and it would fire only after the resolve and LIST fan-out
+    // this function is called with.
     let profile = crate::profiling::ProfileSession::from_env("sql_latency_bench");
 
     'entries: for entry in entries {
@@ -1307,7 +1312,10 @@ pub async fn run_generated(cfg: &GenerateConfig) -> Result<SqlLatencyReport, Err
             cache_bytes: cfg.cache_bytes,
             deadline_secs: cfg.deadline.as_secs(),
             fetch_concurrency: cfg.fetch_concurrency.max(1),
-            sql_max_query_bytes: cfg.max_query_bytes,
+            sql_max_query_bytes_requested: cfg.max_query_bytes,
+            // In-process lane: the requested ceiling reaches the executor's
+            // `SqlConfig`, so it is also the effective one.
+            sql_max_query_bytes_effective: Some(cfg.max_query_bytes),
             tenant_max_bytes: cfg.tenant_max_bytes.max(1),
             sql_max_segments: cfg.max_segments,
             parallel_final_aggregation_requested: cfg.parallel_final_aggregation,
@@ -1419,7 +1427,14 @@ pub async fn run_tenant(cfg: &TenantConfigInput) -> Result<SqlLatencyReport, Err
             cache_bytes: cfg.cache_bytes,
             deadline_secs: cfg.deadline.as_secs(),
             fetch_concurrency: cfg.fetch_concurrency.max(1),
-            sql_max_query_bytes: cfg.max_query_bytes,
+            sql_max_query_bytes_requested: cfg.max_query_bytes,
+            // `settings` is passed only on the in-process arm of the match
+            // above, so on the Flight lane this ceiling never left the process
+            // and the server's own config governed instead.
+            sql_max_query_bytes_effective: match &cfg.flight {
+                Some(_) => None,
+                None => Some(cfg.max_query_bytes),
+            },
             tenant_max_bytes: cfg.tenant_max_bytes.max(1),
             sql_max_segments: cfg.max_segments,
             parallel_final_aggregation_requested: cfg.parallel_final_aggregation,
@@ -2735,13 +2750,14 @@ mod tests {
         assert_eq!(executor.config().max_query_bytes, DEFAULT_MAX_QUERY_BYTES);
     }
 
-    /// The effective per-query pool ceiling is recorded in the run's provenance
-    /// block (issue #615): a run with a raised `--sql-max-query-bytes` records
-    /// exactly that value, and an unset flag records the compiled-in default.
-    /// Before the field existed the block carried no per-query budget at all, so
-    /// this assertion has nothing to read and fails to compile against the old
-    /// provenance; with the field present but unpopulated it would read the
-    /// serde default and the raised-value arm goes red.
+    /// The per-query pool ceiling is recorded in the run's provenance block
+    /// (issue #615): a run with a raised `--sql-max-query-bytes` records exactly
+    /// that value, and an unset flag records the compiled-in default. The
+    /// in-process lane applies what it asks for, so `effective` is `Some` of the
+    /// same figure. Before the field existed the block carried no per-query
+    /// budget at all, so this assertion has nothing to read and fails to compile
+    /// against the old provenance; with the field present but unpopulated it
+    /// would read the serde default and the raised-value arm goes red.
     #[tokio::test]
     async fn provenance_records_effective_max_query_bytes() {
         let store = empty_store();
@@ -2754,8 +2770,13 @@ mod tests {
         cfg.max_query_bytes = custom;
         let report = run_tenant(&cfg).await.expect("tenant lane runs");
         assert_eq!(
-            report.provenance.sql_max_query_bytes, custom,
+            report.provenance.sql_max_query_bytes_requested, custom,
             "the raised per-query pool ceiling is recorded in provenance"
+        );
+        assert_eq!(
+            report.provenance.sql_max_query_bytes_effective,
+            Some(custom),
+            "the in-process lane applies the requested ceiling, so it is effective"
         );
 
         // Unset flag (the config default): the block records the compiled-in
@@ -2763,8 +2784,49 @@ mod tests {
         let cfg = tenant_cfg(&store, "maxquerybytes-tenant", None, 0);
         let report = run_tenant(&cfg).await.expect("tenant lane runs");
         assert_eq!(
-            report.provenance.sql_max_query_bytes, DEFAULT_MAX_QUERY_BYTES,
+            report.provenance.sql_max_query_bytes_requested, DEFAULT_MAX_QUERY_BYTES,
             "an unset flag records the compiled-in per-query budget"
+        );
+        assert_eq!(
+            report.provenance.sql_max_query_bytes_effective,
+            Some(DEFAULT_MAX_QUERY_BYTES),
+            "an unset flag is still effective on the in-process lane"
+        );
+    }
+
+    /// The recorded ceiling must be the one that GOVERNED, not the one that was
+    /// asked for. Echoing `cfg.max_query_bytes` into provenance passes an
+    /// equality check even when the value never reaches the executor, so this
+    /// pins the wiring instead: a ceiling small enough to refuse the statement
+    /// must actually refuse it. Replace `max_query_bytes: cfg.max_query_bytes`
+    /// in the `ExecutorSettings` built by `run_tenant` with the compiled-in
+    /// default and this goes red while the provenance assertions above stay
+    /// green, which is exactly the gap it exists to close.
+    #[tokio::test]
+    async fn a_tiny_max_query_bytes_actually_refuses_the_statement() {
+        let store = empty_store();
+        provisioned_tenant(&store, "maxquerybytes-wired").await;
+
+        let mut cfg = tenant_cfg(&store, "maxquerybytes-wired", None, 0);
+        cfg.entries = vec![entry(
+            "agg",
+            "SELECT body, count(*) FROM logs GROUP BY body",
+        )];
+        cfg.continue_on_error = true;
+        cfg.max_query_bytes = 1024;
+        let report = run_tenant(&cfg).await.expect("tenant lane runs");
+        assert_eq!(
+            report.provenance.sql_max_query_bytes_effective,
+            Some(1024),
+            "the tiny ceiling is recorded as effective on the in-process lane"
+        );
+        assert!(
+            !report.failed.is_empty(),
+            "a 1 KiB per-query pool must refuse the statement; if the ceiling never \
+             reached the executor the statement succeeds and `failed` is empty. \
+             failed={:?} entries={}",
+            report.failed,
+            report.entries.len()
         );
     }
 }

--- a/crates/ravel-bench/tests/sql_latency_flight_smoke.rs
+++ b/crates/ravel-bench/tests/sql_latency_flight_smoke.rs
@@ -342,6 +342,20 @@ async fn flight_lane_measures_every_statement_over_the_wire_without_scan_diagnos
         report.provenance.parallel_final_aggregation_effective, None,
         "a Flight run does not send the setting, so the effective value is unknown"
     );
+    // Same shape for the per-query pool ceiling (issue #615): `--sql-max-query-bytes`
+    // is not a Flight header either, and `ExecutorSettings` is passed only on the
+    // in-process arm, so the server's own ceiling governed. Echoing the local CLI
+    // value as effective would let two Flight tables taken at different
+    // `--sql-max-query-bytes` values look comparable while having run under
+    // identical server ceilings.
+    assert_eq!(
+        report.provenance.sql_max_query_bytes_requested, DEFAULT_MAX_QUERY_BYTES,
+        "the requested field carries this run's CLI value (flight_cfg's default)"
+    );
+    assert_eq!(
+        report.provenance.sql_max_query_bytes_effective, None,
+        "a Flight run does not send the ceiling, so the effective value is unknown"
+    );
     // The dataset stanza is still resolved from the store directly: a Flight
     // client cannot read the catalog.
     assert_eq!(report.dataset.object_count, 3);

--- a/docs/guides/clickbench.md
+++ b/docs/guides/clickbench.md
@@ -288,7 +288,10 @@ cargo run -p ravel-bench --features sql-latency --bin sql_latency_bench -- \
   abort with `query memory budget exhausted`; that aborts the whole run with no
   number for it. Pass a larger byte budget (for example `--sql-max-query-bytes
   1073741824` for 1 GiB) to measure it instead. Omitted, it defaults to
-  ravel-sql's compiled-in 256 MiB, leaving the measured budget unchanged.
+  ravel-sql's compiled-in 256 MiB, leaving the measured budget unchanged. The
+  effective value is recorded in the report's provenance as
+  `sql_max_query_bytes`, so two tables at different per-query budgets are not
+  mistaken for comparable.
 - `--shards <N>` sets how many shards the resolve scans. Omitted, it reads the
   tenant's durable provisioning record (the one `ravel-cli load` writes) and uses
   that record's shard ceiling, so a tenant loaded with `--shards 4` is measured

--- a/docs/guides/clickbench.md
+++ b/docs/guides/clickbench.md
@@ -289,9 +289,13 @@ cargo run -p ravel-bench --features sql-latency --bin sql_latency_bench -- \
   number for it. Pass a larger byte budget (for example `--sql-max-query-bytes
   1073741824` for 1 GiB) to measure it instead. Omitted, it defaults to
   ravel-sql's compiled-in 256 MiB, leaving the measured budget unchanged. The
-  effective value is recorded in the report's provenance as
-  `sql_max_query_bytes`, so two tables at different per-query budgets are not
-  mistaken for comparable.
+  report's provenance records it twice: `sql_max_query_bytes_requested` is what
+  the run asked for, and `sql_max_query_bytes_effective` is what governed. On
+  the in-process lanes they are the same. Under `--flight` the flag is not sent
+  to the server (it is not a Flight header), so the server's own ceiling
+  governed and `effective` is null: two Flight tables at different
+  `--sql-max-query-bytes` values are NOT comparable on that basis, and the null
+  is what stops them being mistaken for it.
 - `--shards <N>` sets how many shards the resolve scans. Omitted, it reads the
   tenant's durable provisioning record (the one `ravel-cli load` writes) and uses
   that record's shard ceiling, so a tenant loaded with `--shards 4` is measured
@@ -384,7 +388,9 @@ cargo run -p ravel-bench --features sql-latency --bin sql_latency_bench -- \
 
 To capture a CPU flamegraph of the corpus, build with `--features
 sql-latency,profiling` and set `RAVEL_BENCH_PROFILE_SVG` to the output path.
-For a profiled pass, run it with **`--runs 1`**, not `--runs 3`:
+For a profiled pass, run it with **`--runs 1`**, not `--runs 3`: with
+`RAVEL_BENCH_PROFILE_SVG` set, any `--runs` above 1 is REFUSED with an error
+rather than run (issue #616), so this is a rule the binary enforces, not advice.
 
 ```sh
 RAVEL_BENCH_PROFILE_SVG=/tmp/sql_latency.svg \
@@ -395,8 +401,8 @@ cargo run -p ravel-bench --features sql-latency,profiling --bin sql_latency_benc
 ```
 
 The profiler is a signal sampler, and running each statement more than once
-under a live sampler has been observed to segfault the process (issue #616);
-`--runs 1` is stable. This costs nothing for a profile: one execution already
+under a live sampler has been observed to segfault the process (issue #616), so
+the binary refuses that combination outright; `--runs 1` is stable. This costs nothing for a profile: one execution already
 yields a dense flamegraph, and profiled latency numbers are inflated by the
 sampler and not usable anyway. Take latency from a separate unprofiled `--runs
 3` pass, and read the flamegraph for CPU attribution only. See
@@ -466,9 +472,12 @@ Tick every line before putting two reports side by side.
 - Same instance type and the same instance. Issue #680 measured a 1.6x to 2x
   gap between two c6a.4xlarge boxes at identical settings, so a cross-box
   comparison carries the box id or it carries nothing.
-- Same `fetch_concurrency`, `cache_bytes`, `deadline_secs`, and
-  `sql_max_query_bytes`. The first three are in the provenance; the last is the
-  DataFusion pool ceiling the run was given.
+- Same `fetch_concurrency`, `cache_bytes`, `deadline_secs`, and per-query pool
+  ceiling. All four are in the provenance; compare on
+  `sql_max_query_bytes_effective`, not on what was requested. Where that field
+  is null (a `--flight` run), the ceiling that governed is the server's and is
+  not recorded here, so the two runs are comparable on it only if you know both
+  servers were configured the same.
 - Same allocator. An `LD_PRELOAD` of tcmalloc against the default glibc changes
   peak RSS by about 2x, and the allocator is not in the provenance, so it goes
   in the report's caption.


### PR DESCRIPTION
The `--sql-max-query-bytes` flag and its threading into the executor's
SqlConfig were already in place, but the effective per-query pool ceiling
was not recorded anywhere in the run's output, so a table raised past the
256 MiB default was indistinguishable from one at the default.

Record the effective per-query pool ceiling in the run's provenance as
sql_max_query_bytes (both in-process lanes and the Flight lane populate it
from the configured value), print it in the human table, and document that
the report carries it in the ClickBench guide's flag list. A report written
before the field existed deserializes to the compiled-in DEFAULT_MAX_QUERY_BYTES.

Two tables at different per-query budgets are refused a false comparison the
same way the tenant ceiling, segment ceiling, and fetch concurrency already
are.

Refs: #680
Fixes: #615


fix(ravel-bench): stop the profiler crashing under repeated runs

With RAVEL_BENCH_PROFILE_SVG set, `sql_latency_bench --runs 3` segfaulted
partway through the first statement, while `--runs 1` profiled and `--runs 3`
unprofiled both completed.

The guard is already built once around the whole measured section rather than
per run (measure_corpus constructs one ProfileSession before the entry loop and
