### PR TITLE
docs(ravel-sql): reject admitting avg to the parallel final aggregation

### DIFF
--- a/crates/ravel-sql/src/executor.rs
+++ b/crates/ravel-sql/src/executor.rs
@@ -1611,8 +1611,11 @@ fn aggregate_expr_is_exact(expr: &Expr, schema: &DFSchema) -> bool {
             None => false,
         },
         // `avg`/`mean` always run plain IEEE f64 addition (crate::avg), so they
-        // are never exact regardless of input type; any other name is outside
-        // the admitted aggregate set and fails closed.
+        // are never exact regardless of input type: an integer argument is
+        // coerced to Float64 before it reaches any accumulator, so the partial
+        // sum state is f64 there too and a cross-partition merge of it is
+        // order-dependent (ADR-0094's amendment for issue #771). Any other name
+        // is outside the admitted aggregate set and fails closed.
         _ => false,
     }
 }

--- a/crates/ravel-sql/tests/parallel_final_default.rs
+++ b/crates/ravel-sql/tests/parallel_final_default.rs
@@ -31,8 +31,13 @@
 //! Issue #771 proposed admitting `avg` over an integer column on the premise
 //! that its partial state is an exact `(sum, count)` pair. The ADR-0094
 //! amendment for #771 rejects that premise; three more tests pin the facts the
-//! rejection rests on, so a DataFusion upgrade or a UDAF change that made the
-//! premise true would go red here instead of leaving the amendment stale:
+//! rejection rests on. They are not a uniform staleness guard, and the
+//! amendment states which branch each one covers: a decimal partial state
+//! upstream reddens the first, an integer one does not (this crate's
+//! `SequentialAvg` displaces DataFusion's accumulator whenever the return type
+//! is Float64, so upstream's state never reaches the plan), and the
+//! order-dependence test is a pinned illustration that consults no symbol from
+//! either crate.
 //!
 //! - `avg_over_int_column_carries_a_float64_partial_sum_state`: the `Partial`
 //!   aggregate for `avg(k)` over a declared `Int64` `k` emits a **Float64**
@@ -463,11 +468,12 @@ async fn avg_over_int_column_carries_a_float64_partial_sum_state() {
     // (sum, count) partial state, making a cross-partition merge exact. It does
     // not: DataFusion 54.1.0 coerces every non-decimal, non-duration avg
     // argument to Float64 (average.rs:101-113 signature, :168 return type,
-    // :179 comment) and both accumulators that can serve this plan hold the
-    // numerator as f64 (`AvgAccumulator { sum: Option<f64>, count: u64 }`,
-    // average.rs:505-508; this crate's replacement `SequentialAvgAccumulator`,
-    // avg.rs, likewise). The partial state column type in the plan is the
-    // observable form of that fact.
+    // :179 comment), and the accumulator that actually serves this plan holds
+    // the numerator as f64: this crate's `SequentialAvgAccumulator` (avg.rs),
+    // registered over the built-in. DataFusion's own `AvgAccumulator { sum:
+    // Option<f64>, count: u64 }` (average.rs:505-508) is the same shape, so the
+    // premise fails either way, but only the replacement is observable here.
+    // The partial state column type in the plan is the observable form.
     let fixture = Fixture::build(Fixture::config(
         SqlConfig::default().parallel_final_aggregation,
     ))

--- a/crates/ravel-sql/tests/parallel_final_default.rs
+++ b/crates/ravel-sql/tests/parallel_final_default.rs
@@ -27,13 +27,40 @@
 //! - `both_plan_shapes_agree_on_the_count`: the two plan shapes return the
 //!   identical `COUNT(DISTINCT k)` over a several-partition `MemoryStore`
 //!   fixture.
+//!
+//! Issue #771 proposed admitting `avg` over an integer column on the premise
+//! that its partial state is an exact `(sum, count)` pair. The ADR-0094
+//! amendment for #771 rejects that premise; three more tests pin the facts the
+//! rejection rests on, so a DataFusion upgrade or a UDAF change that made the
+//! premise true would go red here instead of leaving the amendment stale:
+//!
+//! - `avg_over_int_column_carries_a_float64_partial_sum_state`: the `Partial`
+//!   aggregate for `avg(k)` over a declared `Int64` `k` emits a **Float64**
+//!   partial-sum state column, not an integer or decimal one.
+//! - `f64_partial_sum_merge_is_order_dependent_for_integer_input`: adding
+//!   Float64 partial sums of ordinary `i64` values in two different orders
+//!   yields two different bit patterns, so merging avg's partial states across
+//!   partitions is not exact.
+//! - `avg_group_by_int_key_agrees_and_stays_single_final` and
+//!   `avg_over_float_input_stays_single_partition`: a `GROUP BY` avg over the
+//!   integer column returns identical pinned values with the flag on and off
+//!   and keeps the single-partition final in both, even though its group key is
+//!   the non-float kind ADR-0094 otherwise admits; the float-input avg keeps it
+//!   too.
+//!
+//! Both of those carry a `GROUP BY` because an **ungrouped** avg is the wrong
+//! shape to test the gate with: DataFusion does not repartition a single-row
+//! aggregate, so `avg_stays_single_partition_under_default` above holds whether
+//! or not the classifier admits avg (verified by admitting it and watching that
+//! test stay green while the grouped ones went red). The grouped shapes are the
+//! load-bearing guards.
 
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
 use std::sync::Arc;
 use std::time::Duration;
 
-use datafusion::arrow::array::Int64Array;
+use datafusion::arrow::array::{Float64Array, Int64Array};
 use datafusion::physical_plan::displayable;
 use ravel_catalog::{Catalog, CatalogConfig, Snapshot};
 use ravel_commit::publish::RetryPolicy;
@@ -222,6 +249,62 @@ impl Fixture {
         format!("{}", displayable(plan.as_ref()).indent(true))
     }
 
+    /// The same physical plan as [`Self::physical_plan_text`], rendered with
+    /// each operator's output schema, so an aggregate's partial-state column
+    /// types are visible in the text (issue #771).
+    async fn physical_plan_text_with_schema(&self, sql: &str) -> String {
+        let accounting = QueryAccounting::new();
+        let planned = self
+            .executor
+            .plan_pinned(
+                tenant().hash(),
+                self.snapshot().await,
+                sql,
+                &accounting,
+                &declared(),
+            )
+            .await
+            .expect("plan_pinned");
+        let plan = planned
+            .create_physical_plan()
+            .await
+            .expect("physical plan builds");
+        format!(
+            "{}",
+            displayable(plan.as_ref())
+                .set_show_schema(true)
+                .indent(true)
+        )
+    }
+
+    /// Every `(group_key, avg)` row `sql` returns, sorted by group key. The
+    /// avg column is read as raw bits so the comparison is bit-exact.
+    async fn grouped_avg_rows(&self, sql: &str) -> Vec<(i64, u64)> {
+        let outcome = self
+            .executor
+            .execute(tenant().hash(), &request(sql))
+            .await
+            .expect("query executes");
+        let mut rows = Vec::new();
+        for batch in outcome.output.batches() {
+            let keys = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .expect("group key is Int64");
+            let avgs = batch
+                .column(1)
+                .as_any()
+                .downcast_ref::<Float64Array>()
+                .expect("avg is Float64");
+            for row in 0..batch.num_rows() {
+                rows.push((keys.value(row), avgs.value(row).to_bits()));
+            }
+        }
+        rows.sort_unstable();
+        rows
+    }
+
     /// The single scalar `COUNT(DISTINCT k)` returns, executed end to end.
     async fn count_distinct_k(&self) -> i64 {
         let outcome = self
@@ -353,6 +436,172 @@ async fn avg_stays_single_partition_under_default() {
         plan.contains("AggregateExec: mode=Final,"),
         "the non-exact avg keeps the single-partition Final aggregate; got:\n{plan}"
     );
+}
+
+/// The `GROUP BY` avg under test (issue #771). Its group key is `Int64`, the
+/// non-float kind ADR-0094 admits, and its aggregate argument is the declared
+/// `Int64` column, so `avg` is the only reason this plan is not exact-typed.
+/// Group 1 (`k` in 1, 5, 7 across every object) has a sum that does not divide
+/// evenly by its count, so the pinned value exercises the float division.
+const GROUP_BY_AVG_SQL: &str =
+    "SELECT k % 2 AS g, avg(k) AS a FROM logs WHERE k IN (1, 2, 5, 7, 8) GROUP BY g ORDER BY g";
+
+/// The exact rows `GROUP_BY_AVG_SQL` must return on this fixture, avg as bits.
+///
+/// Every object writes each `k` once, so group 0 folds `2` and `8` `OBJECTS`
+/// times each (sum 40, count 8) and group 1 folds `1`, `5` and `7` `OBJECTS`
+/// times each (sum 52, count 12). 52/12 is 13/3, which has no finite binary
+/// expansion: the expected bits are the correctly rounded IEEE quotient, not a
+/// transcribed decimal.
+fn expected_grouped_avg_rows() -> Vec<(i64, u64)> {
+    vec![(0, 5.0_f64.to_bits()), (1, (13.0_f64 / 3.0).to_bits())]
+}
+
+#[tokio::test]
+async fn avg_over_int_column_carries_a_float64_partial_sum_state() {
+    // Issue #771's premise was that avg over an integer column carries an exact
+    // (sum, count) partial state, making a cross-partition merge exact. It does
+    // not: DataFusion 54.1.0 coerces every non-decimal, non-duration avg
+    // argument to Float64 (average.rs:101-113 signature, :168 return type,
+    // :179 comment) and both accumulators that can serve this plan hold the
+    // numerator as f64 (`AvgAccumulator { sum: Option<f64>, count: u64 }`,
+    // average.rs:505-508; this crate's replacement `SequentialAvgAccumulator`,
+    // avg.rs, likewise). The partial state column type in the plan is the
+    // observable form of that fact.
+    let fixture = Fixture::build(Fixture::config(
+        SqlConfig::default().parallel_final_aggregation,
+    ))
+    .await;
+    let plan = fixture
+        .physical_plan_text_with_schema("SELECT avg(k) AS a FROM logs")
+        .await;
+
+    let partial = plan
+        .lines()
+        .find(|line| line.contains("AggregateExec: mode=Partial"))
+        .unwrap_or_else(|| panic!("expected a Partial AggregateExec; got:\n{plan}"));
+    assert!(
+        partial.contains("[avg_sum]:Float64"),
+        "avg's partial sum state over an Int64 column must be Float64 (issue #771's \
+         exact-(sum, count) premise is false); got:\n{partial}"
+    );
+    assert!(
+        partial.contains("[avg_count]:Int64"),
+        "avg's partial count state must be an integer count; got:\n{partial}"
+    );
+    // The exact-typed aggregate for the same column, for contrast: sum(k)
+    // really does carry an Int64 partial state, which is why sum over an
+    // integer input is admitted and avg is not.
+    let sum_plan = fixture
+        .physical_plan_text_with_schema("SELECT sum(k) AS s FROM logs")
+        .await;
+    let sum_partial = sum_plan
+        .lines()
+        .find(|line| line.contains("AggregateExec: mode=Partial"))
+        .unwrap_or_else(|| panic!("expected a Partial AggregateExec; got:\n{sum_plan}"));
+    assert!(
+        sum_partial.contains("sum(logs.k)[sum]:Int64"),
+        "sum over an Int64 column must carry an Int64 partial state; got:\n{sum_partial}"
+    );
+}
+
+#[tokio::test]
+async fn avg_over_float_input_stays_single_partition() {
+    // The other half of the #771 amendment: an avg whose input is float before
+    // coercion is excluded too. (The logs surface declares no float column
+    // type, so the float input is an explicit cast; the planner then drops the
+    // cast, because Float64 is where avg's coercion sends an Int64 argument
+    // anyway. That collapse is the amendment's second point in visible form:
+    // after analysis, avg over an integer column and avg over a float one are
+    // the same plan, so the classifier has no resolved type to admit one by.)
+    // The statement carries an Int64 GROUP BY key for the reason the module doc
+    // gives: an ungrouped aggregate is never repartitioned whatever the
+    // classifier says, so only a grouped shape can tell an excluded avg from an
+    // admitted one.
+    let fixture = Fixture::build(Fixture::config(
+        SqlConfig::default().parallel_final_aggregation,
+    ))
+    .await;
+    let plan = fixture
+        .physical_plan_text("SELECT k % 2 AS g, avg(CAST(k AS DOUBLE)) AS a FROM logs GROUP BY g")
+        .await;
+
+    assert!(
+        !plan.contains("AggregateExec: mode=FinalPartitioned"),
+        "avg over a float input must not fan its final aggregation out; got:\n{plan}"
+    );
+    assert!(
+        !plan.contains("RepartitionExec: partitioning=Hash"),
+        "avg over a float input must not get a hash repartition; got:\n{plan}"
+    );
+    assert!(
+        plan.contains("AggregateExec: mode=Final,"),
+        "avg over a float input keeps the single-partition Final aggregate; got:\n{plan}"
+    );
+}
+
+#[test]
+fn f64_partial_sum_merge_is_order_dependent_for_integer_input() {
+    // Three ordinary i64 values a log column can hold. Folded as f64 (which is
+    // what avg does, per the test above), the two groupings a repartitioned
+    // merge can produce differ in the last bit: 2^53 + 1 rounds back to 2^53,
+    // while 1 + 1 = 2 survives and 2^53 + 2 is representable. So the partial
+    // sums of a group split across partitions do not merge exactly, and the
+    // division that follows inherits the difference.
+    let values: [i64; 3] = [1 << 53, 1, 1];
+    let one_partition = ((values[0] as f64) + values[1] as f64) + values[2] as f64;
+    let two_partitions = (values[0] as f64) + ((values[1] as f64) + values[2] as f64);
+
+    assert_eq!(
+        one_partition.to_bits(),
+        (9_007_199_254_740_992.0_f64).to_bits()
+    );
+    assert_eq!(
+        two_partitions.to_bits(),
+        (9_007_199_254_740_994.0_f64).to_bits()
+    );
+    assert_ne!(
+        one_partition.to_bits(),
+        two_partitions.to_bits(),
+        "if f64 addition of these i64 values were associative, avg over integer \
+         input could merge across partitions exactly (issue #771)"
+    );
+}
+
+#[tokio::test]
+async fn avg_group_by_int_key_agrees_and_stays_single_final() {
+    let on = Fixture::build(Fixture::config(true)).await;
+    let off = Fixture::build(Fixture::config(false)).await;
+
+    let on_rows = on.grouped_avg_rows(GROUP_BY_AVG_SQL).await;
+    let off_rows = off.grouped_avg_rows(GROUP_BY_AVG_SQL).await;
+
+    assert_eq!(
+        on_rows,
+        expected_grouped_avg_rows(),
+        "the pinned per-group averages must come back bit for bit"
+    );
+    assert_eq!(
+        on_rows, off_rows,
+        "avg over an integer column must return identical bits with the flag on and off"
+    );
+
+    // And it stays on the single-partition final in both, which is why the two
+    // agree: the group key is Int64 (admissible on its own), so avg is the only
+    // disqualifier here.
+    for (label, plan) in [
+        ("flag on", on.physical_plan_text(GROUP_BY_AVG_SQL).await),
+        ("flag off", off.physical_plan_text(GROUP_BY_AVG_SQL).await),
+    ] {
+        assert!(
+            !plan.contains("AggregateExec: mode=FinalPartitioned"),
+            "{label}: an avg must never fan its final aggregation out; got:\n{plan}"
+        );
+        assert!(
+            plan.contains("AggregateExec: mode=Final,"),
+            "{label}: the avg keeps the single-partition Final aggregate; got:\n{plan}"
+        );
+    }
 }
 
 #[tokio::test]

--- a/docs/adrs/0094-parallel-final-aggregation-exact-typed.md
+++ b/docs/adrs/0094-parallel-final-aggregation-exact-typed.md
@@ -688,3 +688,127 @@ and it is why some high-cardinality statements still fail with the parallel
 final on. Do not read this amendment as a claim that every high-cardinality
 `GROUP BY` now completes: it fixes the final-merge exhaustion for the
 exact-typed class, not the partial-stage one.
+
+## Amendment 2026-08-26 (issue #771): `avg` over integer input, rejected
+
+Status: Rejected. `avg`/`mean` remain never eligible, over every input type.
+Decision 1's classification is unchanged and no code changed with this
+amendment; what changed is that the exclusion now has DataFusion 54.1.0's
+own accumulator state cited against it, and tests that pin the cited facts.
+
+**The proposal.** Issue #771 (under epic #680) argued that `avg` over an
+integer column should be admitted to the repartitioned final: its partial
+state is a `(sum, count)` pair whose merge across partitions would be exact
+integer addition, with the only float step being one division per group after
+the merge, computed identically in one partition or many. On that premise the
+exactness argument that excludes float `GROUP BY` keys and float sums would
+not apply, and ClickBench `q33_watch_ip_aggregates_all` (an `avg` over a wide
+`GROUP BY`, which exhausts the 8 GiB pool while its four sibling statements
+complete in 12-16 s under the parallel final, issue #741) would join the
+admitted class.
+
+**The premise is false.** `avg` over an integer column does not carry an
+exact integer sum anywhere in DataFusion 54.1.0, because the integer never
+reaches an accumulator:
+
+- `avg`'s signature coerces every integer or float argument to Float64:
+  `TypeSignature::Coercible` with `Coercion::new_implicit(TypeSignatureClass::
+  Native(logical_float64()), vec![TypeSignatureClass::Integer,
+  TypeSignatureClass::Float], NativeType::Float64)`
+  (`datafusion-functions-aggregate-54.1.0/src/average.rs:101-113`). Only
+  Decimal and Duration arguments keep their own type.
+- Its return type for everything but Decimal and Duration is Float64
+  (`average.rs:137-170`, the `_ => Ok(DataType::Float64)` arm at
+  `average.rs:168`).
+- The accumulator dispatch's own comment says so: "Numeric types are converted
+  to Float64 via `coerce_avg_type` during logical plan creation"
+  (`average.rs:179`), and the non-distinct dispatch for that case is
+  `(Float64, Float64) => Ok(Box::<AvgAccumulator>::default())`
+  (`average.rs:224`).
+- `AvgAccumulator` holds the numerator as f64:
+  `pub struct AvgAccumulator { sum: Option<f64>, count: u64 }`
+  (`average.rs:505-508`). `update_batch` folds with `*v += x` on f64
+  (`average.rs:511-518`), and `merge_batch` merges partial states the same
+  way -- "sums are summed", `sum(states[1].as_primitive::<Float64Type>())`
+  then `*v += x` (`average.rs:544-554`). The state fields are
+  `count: UInt64` plus `sum` typed as the (already coerced to Float64) input
+  (`average.rs:317-331`).
+
+So the merge across partitions is f64 addition, not exact integer addition.
+f64 addition is not associative once a running sum passes 2^53, which
+ordinary `i64` log values reach: summing `2^53`, `1`, `1` gives
+`9007199254740992` when folded left to right and `9007199254740994` when the
+two small values are added in a sibling partition first. Two partitionings of
+one group therefore produce two different numerators and two different
+quotients. This is pinned by
+`f64_partial_sum_merge_is_order_dependent_for_integer_input`
+(`crates/ravel-sql/tests/parallel_final_default.rs`).
+
+**This crate's `avg` is stricter still.** The `avg` a Ravel session actually
+executes is not the built-in: `session.rs:611` registers `crate::avg`'s
+`SequentialAvg` UDAF over the name and its `mean` alias (ADR-0022 decisions
+3, 4). It delegates signature, return type and coercion to the built-in, so
+integer input coerces to Float64 exactly as above, and its own state is
+`(Float64 sum, Int64 count)` with a `merge_batch` that adds partial sums with
+plain IEEE addition (`avg.rs`, `state_fields` and
+`SequentialAvgAccumulator::merge_batch`). It exists specifically to guarantee
+a bit-reproducible result by folding in the deterministic `(series_id, ts)`
+order that v1 gets from executing aggregation single-partitioned. Admitting
+`avg` would break that UDAF's stated precondition directly, not merely risk a
+rounding difference.
+
+**A second, independent obstacle.** Decision 1 classifies from the *analyzed*
+(type-coerced) plan, by resolved type. After coercion, `avg(int_col)` and
+`avg(float_col)` are the same expression shape with the same Float64 argument
+type -- the planner even drops an explicit `CAST(int_col AS DOUBLE)` inside
+`avg`, because Float64 is where the integer was going anyway. There is no
+resolved type by which the classifier could admit the integer case and keep
+excluding the float one; doing it would require classifying from the
+pre-coercion plan or reaching through the coercion cast into the input
+schema, which is a change to decision 1's foundation and not a new arm in
+`aggregate_expr_is_exact`.
+
+**Prior art.** This is the second time the proposal has been made and
+rejected. The Context section above records the first: an earlier draft of
+this ADR admitted `avg`/`mean` over non-float input on the same reasoning and
+was corrected by adversarial review before any code was written. That
+rejection argued from `crate::avg`'s module doc; this one adds the upstream
+accumulator's source, so the next reader does not have to re-derive either.
+
+**No q33 measurement is pre-registered, because nothing changes.** The
+pre-registration this amendment was asked to carry -- q33 completing in 12-20
+s at 8,424 GETs / 11.1 GB with no pool exhaustion, like its four siblings --
+would only be meaningful for a change that admits q33's `avg` to the
+repartitioned final. This amendment admits nothing, so q33's behavior is
+byte-for-byte what it is today: its `avg` keeps the single-partition final
+and it still exhausts the 8 GiB pool. Issue #741's q33 failure is therefore
+**not** addressed here and stays open. The routes that could address it, none
+of which this amendment takes:
+
+- Rewrite `avg(x)` over an integer column into `sum(x) / count(x)` before
+  classification, so the exact integer `sum` (already admitted) does the
+  cross-partition work and one division per group happens after the merge.
+  This is the proposal's arithmetic, obtained by changing the plan rather
+  than by misclassifying the existing accumulator. It needs its own ADR: it
+  changes NULL and overflow behavior at the edges (`sum` of an empty group,
+  integer overflow wrapping) and it must agree with ADR-0022's fold for the
+  cases where both can run.
+- Reduce the partial stage's footprint instead of the final's (issue #737,
+  `skip_partial_aggregation`), which is where a wide `GROUP BY` spends the
+  memory the final merge then inherits.
+- Accept a documented tolerance for `avg`, which ADR-0013's differential gate
+  currently forbids.
+
+**Tests pinning this amendment** (all in
+`crates/ravel-sql/tests/parallel_final_default.rs`, alongside the
+classification tests in `executor.rs`):
+`avg_over_int_column_carries_a_float64_partial_sum_state` reads the
+`Partial` aggregate's state schema out of the physical plan and asserts the
+avg sum state is Float64 while `sum(k)` over the same Int64 column carries an
+Int64 one; `f64_partial_sum_merge_is_order_dependent_for_integer_input` pins
+the non-associativity above by bit pattern;
+`avg_group_by_int_key_agrees_and_stays_single_final` and
+`avg_over_float_input_stays_single_partition` pin the plan shape and the
+exact per-group values on a fixture. If a future DataFusion release gives
+`avg` an exact integer or decimal partial state, the first of those goes red
+and this amendment is the thing to revisit.

--- a/docs/adrs/0094-parallel-final-aggregation-exact-typed.md
+++ b/docs/adrs/0094-parallel-final-aggregation-exact-typed.md
@@ -692,8 +692,8 @@ exact-typed class, not the partial-stage one.
 ## Amendment 2026-08-26 (issue #771): `avg` over integer input, rejected
 
 Status: Rejected. `avg`/`mean` remain never eligible, over every input type.
-Decision 1's classification is unchanged and no code changed with this
-amendment; what changed is that the exclusion now has DataFusion 54.1.0's
+Decision 1's classification is unchanged and no behavior changed with this
+amendment (the only source edit is a comment on the classifier's `avg` arm); what changed is that the exclusion now has DataFusion 54.1.0's
 own accumulator state cited against it, and tests that pin the cited facts.
 
 **The proposal.** Issue #771 (under epic #680) argued that `avg` over an
@@ -759,9 +759,13 @@ rounding difference.
 
 **A second, independent obstacle.** Decision 1 classifies from the *analyzed*
 (type-coerced) plan, by resolved type. After coercion, `avg(int_col)` and
-`avg(float_col)` are the same expression shape with the same Float64 argument
-type -- the planner even drops an explicit `CAST(int_col AS DOUBLE)` inside
-`avg`, because Float64 is where the integer was going anyway. There is no
+`avg(float_col)` carry the same Float64 argument type. Nothing is dropped: type
+coercion *adds* a cast to the integer case and leaves an already-Float64
+explicit cast alone, and name preservation then aliases the coerced integer
+case back to `avg(logs.k)` while the explicit-cast case keeps the longer name.
+So the two analyzed nodes are not identical -- they differ by field name -- and
+it is the resolved argument type, not plan identity, that defeats the
+classifier. There is no
 resolved type by which the classifier could admit the integer case and keep
 excluding the float one; doing it would require classifying from the
 pre-coercion plan or reaching through the coercion cast into the input
@@ -785,6 +789,11 @@ and it still exhausts the 8 GiB pool. Issue #741's q33 failure is therefore
 **not** addressed here and stays open. The routes that could address it, none
 of which this amendment takes:
 
+- Rework `crate::avg`'s numerator to genuine fixed-point or integer arithmetic
+  for non-float input, which is the route the rejected-alternatives section of
+  this ADR's own body already left open. It is listed first here because a
+  reader who takes this amendment's list as exhaustive would otherwise never
+  find it.
 - Rewrite `avg(x)` over an integer column into `sum(x) / count(x)` before
   classification, so the exact integer `sum` (already admitted) does the
   cross-partition work and one division per group happens after the merge.
@@ -808,7 +817,23 @@ avg sum state is Float64 while `sum(k)` over the same Int64 column carries an
 Int64 one; `f64_partial_sum_merge_is_order_dependent_for_integer_input` pins
 the non-associativity above by bit pattern;
 `avg_group_by_int_key_agrees_and_stays_single_final` and
-`avg_over_float_input_stays_single_partition` pin the plan shape and the
-exact per-group values on a fixture. If a future DataFusion release gives
-`avg` an exact integer or decimal partial state, the first of those goes red
-and this amendment is the thing to revisit.
+`avg_over_float_input_stays_single_partition` pin the plan shape on a fixture.
+
+State the staleness guard per branch, because it does not hold uniformly. A
+DataFusion release that gave `avg` an exact **decimal** partial state would
+redden `avg_over_int_column_carries_a_float64_partial_sum_state`: a decimal
+return type makes `SequentialAvg` delegate, so upstream's state fields reach
+the plan. An exact **integer** partial state would not, because `SequentialAvg`
+displaces DataFusion's accumulator entirely and hardcodes its own
+`(Float64, Int64)` state whenever the return type is Float64, so upstream's
+state never reaches the plan to be observed. The guard that does cover the
+integer case is pre-existing: `analyzer_coerces_avg_argument_to_float64`
+asserts the analyzed argument type is Float64, and reddens if DataFusion stops
+coercing integers.
+
+`f64_partial_sum_merge_is_order_dependent_for_integer_input` is a pinned
+illustration, not a guard: it asserts constants about IEEE doubles and
+references no symbol from this crate or DataFusion, so a rework of
+`SequentialAvg`'s numerator to fixed-point arithmetic leaves it green. It
+documents why the premise is false; it does not detect the premise becoming
+true.

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -1973,6 +1973,21 @@ is per-query and decided from the query's fully type-coerced (analyzed) plan:
   `-0.0`/NaN payloads are bit-significant here and no merge-order-stable
   representative bit pattern for a float group key is proven.
 
+`avg` over an **integer** column is excluded by that same rule, and the reason
+is worth stating because the shape looks admissible: an integer argument never
+reaches an accumulator as an integer. DataFusion coerces every non-decimal,
+non-duration `avg` argument to `Float64` before planning finishes, so the
+partial state a two-phase `avg` carries is a **Float64** sum with an integer
+count -- not the exact `(integer sum, count)` pair that would merge across
+partitions without loss. Merging those partial sums is f64 addition and depends
+on how the group was split. A second consequence of the same coercion: after
+analysis, `avg(int_col)` and `avg(float_col)` are the same plan with the same
+`Float64` argument type, so the classifier has no resolved type by which it
+could admit one and reject the other. See the ADR-0094 amendment for issue
+`#771`, which rejects admitting `avg` on this basis and lists the routes that
+could instead fix the wide-`GROUP BY` `avg` statements that exhaust the memory
+pool today (issue `#741`).
+
 A single disqualifying aggregate or key anywhere in the query -- including inside
 a scalar/`IN`/`EXISTS` subquery -- forces the whole query onto the
 single-partition plan: `repartition_aggregations` is one session-wide switch, not

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -1981,9 +1981,11 @@ partial state a two-phase `avg` carries is a **Float64** sum with an integer
 count -- not the exact `(integer sum, count)` pair that would merge across
 partitions without loss. Merging those partial sums is f64 addition and depends
 on how the group was split. A second consequence of the same coercion: after
-analysis, `avg(int_col)` and `avg(float_col)` are the same plan with the same
-`Float64` argument type, so the classifier has no resolved type by which it
-could admit one and reject the other. See the ADR-0094 amendment for issue
+analysis both `avg(int_col)` and `avg(float_col)` carry a `Float64` argument
+type, so the classifier has no resolved type by which it could admit one and
+reject the other. The two analyzed nodes are not otherwise identical -- coercion
+adds a cast to the integer case and name preservation renames it back -- so it
+is the argument type that defeats the classifier, not plan identity. See the ADR-0094 amendment for issue
 `#771`, which rejects admitting `avg` on this basis and lists the routes that
 could instead fix the wide-`GROUP BY` `avg` statements that exhaust the memory
 pool today (issue `#741`).


### PR DESCRIPTION
Issue #771 proposed admitting avg over integer input to the parallel final
aggregation, on the premise that an integer argument keeps an exact integer
partial sum. The premise is false, so this change records why instead of
making the change.

DataFusion coerces every integer argument to Float64 during logical plan
creation, before it reaches any accumulator; only Decimal and Duration keep
their type. Ravel does not use the built-in accumulator anyway: sessions
register SequentialAvg (ADR-0022), whose state is a Float64 sum folded with
plain IEEE addition and whose stated precondition is the deterministic
(series_id, ts) ordering that only a single partition provides. Merging that
state across partitions is order-dependent, which a test demonstrates with a
counterexample at 2^53.

There is a third, independent obstacle: after analysis, avg over an integer
column and avg over a float column are the same plan with the same Float64
argument, so the classifier has no resolved type to admit one by. Admitting
avg would require classifying before coercion, which changes the foundation
of ADR-0094 decision 1 rather than extending it.

The classifier is unchanged. This adds an ADR-0094 amendment recording the
rejection with citations, four tests that pin each leg of the reasoning, and
an expanded comment at the classifier's avg arm so the next reader does not
re-derive it.

Refs: #771
