### PR TITLE
feat: land the v4 lazy page scan, fold GET accounting, and the flush-window flag

### DIFF
--- a/crates/ravel-catalog/src/fold.rs
+++ b/crates/ravel-catalog/src/fold.rs
@@ -26,7 +26,7 @@ use ravel_object_store::{
 use ravel_proto::catalog::v1::{SnapshotEntry, SnapshotHead, SnapshotPartRef, SnapshotPostingsRef};
 use ravel_proto::commit::v1::{CommitRecord, CompactionPart, CompactionRecord, RewriteRecord};
 use ravel_segment::{ExpectedIdentity, ReaderLimits, SegmentError};
-use ravel_types::accounting::QueryAccounting;
+use ravel_types::accounting::{AccountedOp, QueryAccounting};
 use ravel_types::{METRIC_NAME_LABEL, Signal, TenantHash};
 use uuid::Uuid;
 
@@ -766,6 +766,18 @@ impl Catalog {
             .await?;
         let shard_generation_count = generations.len() as u32;
         let mut counters = RequestCounters::default();
+        // Fold the generation-history read's GET(s) into the fold's own
+        // counters. Under provisioning enforcement `read_scan_generations`
+        // funnels one provisioning-record GET through `guarded_get` (issue
+        // #729), charged only to the `accounting` handle this fold otherwise
+        // discards; without counting it here `FoldReport.get_requests`
+        // under-reports the store's real GETs by exactly one whenever
+        // enforcement is on (issue #770). The snapshot is taken before the
+        // retry loop reuses `accounting`, so it captures only this pre-loop
+        // read; every in-loop guarded GET is counted explicitly at its call
+        // site. With enforcement off the read issues no store request and this
+        // adds zero.
+        counters.get_requests += accounting.snapshot().s3_requests(AccountedOp::Get);
         let mut attempt: u32 = 0;
 
         // The tenant's effective retention window, read once per fold
@@ -799,6 +811,12 @@ impl Catalog {
                 default_retention_ns
             }
         };
+        // Count the tenant-config record GET. `read_config_values` issues one
+        // raw `store.get` per fold on every outcome (hit, absent, or error) and
+        // takes neither a counters nor an accounting handle, so it is otherwise
+        // invisible to the report. Read once before the retry loop, so it is one
+        // GET per fold regardless of how many CAS attempts the loop makes.
+        counters.get_requests += 1;
 
         loop {
             let head_state = self.get_head(&head_key, &mut counters).await?;
@@ -2117,7 +2135,7 @@ mod tests {
         FaultKind, FaultPlan, FaultStore, Occurrence, Op, Rule, ScriptedFault,
     };
     use ravel_object_store::memory::MemoryStore;
-    use ravel_object_store::{ObjectStoreBackend, PutOptions};
+    use ravel_object_store::{InstrumentedStore, ObjectStoreBackend, PutOptions};
     use ravel_proto::commit::v1::{CompactionInputIdentity, RetentionTombstone};
     use ravel_segment::{IngestBounds, SegmentIdentity, SegmentWriter, SeriesInput};
     use ravel_types::{Label, LabelSet, Sample, SeriesId, TenantId};
@@ -2767,9 +2785,9 @@ mod tests {
         assert!(!first.no_op);
         assert_eq!(first.entry_count, 1);
         assert!(first.postings_built);
-        // HEAD get (absent) + 1 commit-record load + 1 segment fetch to
-        // decode the sole entry's names.
-        assert_eq!(first.get_requests, 3);
+        // HEAD get (absent) + 1 tenant-config read + 1 commit-record load +
+        // 1 segment fetch to decode the sole entry's names.
+        assert_eq!(first.get_requests, 4);
 
         let now_2 = now_at_seal(12);
         publish_real_segment(
@@ -2790,11 +2808,95 @@ mod tests {
         assert!(!second.no_op);
         assert_eq!(second.entry_count, 2);
         assert!(second.postings_built);
-        // HEAD get + previous-part load + previous-postings load + 1 new
-        // commit-record load + 1 new segment fetch = 5: the first fold's
-        // "cpu" entry is neither re-loaded from the part nor re-decoded
+        // HEAD get + tenant-config read + previous-part load + previous-postings
+        // load + 1 new commit-record load + 1 new segment fetch = 6: the first
+        // fold's "cpu" entry is neither re-loaded from the part nor re-decoded
         // from its segment.
-        assert_eq!(second.get_requests, 5);
+        assert_eq!(second.get_requests, 6);
+    }
+
+    /// `FoldReport.get_requests` must equal the store's real observed GET count
+    /// on every path (issue #770). Two fold GETs were charged to the discarded
+    /// `QueryAccounting` handle or a bare `store.get` and never folded into the
+    /// report: the tenant-config read (every fold) and, under provisioning
+    /// enforcement, the generation-history read. The report is measured against
+    /// an `InstrumentedStore`'s own GET counter rather than a hand-written
+    /// constant, so the assertion tracks the code it checks.
+    ///
+    /// FLIP (pre-fix demonstration, either line reverted in `Catalog::fold`):
+    /// dropping `counters.get_requests += accounting.snapshot()...` leaves the
+    /// enforcement path reporting 4 against 5 observed; dropping
+    /// `counters.get_requests += 1` after the tenant-config read leaves both
+    /// paths reporting one below observed. Each makes an `assert_eq!` of report
+    /// against observed fail.
+    #[tokio::test]
+    async fn fold_report_get_requests_equals_observed_store_gets() {
+        // One rebuild fold over a fresh instrumented store holding a single
+        // sealed segment. Returns (FoldReport.get_requests, the store's real GET
+        // calls issued during the fold only). Publishing happens on the inner
+        // store before it is wrapped, so only the fold's own requests are
+        // measured.
+        async fn measured(enforce: bool) -> (u64, u64) {
+            let inner = MemoryStore::new();
+            let now = now_at_seal(10);
+            publish_real_segment(
+                &inner,
+                0,
+                Uuid::new_v4(),
+                1,
+                10,
+                now - NS_PER_HOUR,
+                &["cpu"],
+            )
+            .await;
+            let store = Arc::new(InstrumentedStore::new(inner));
+            let catalog = {
+                let catalog = Catalog::new(store.clone(), config(1)).expect("catalog");
+                if enforce {
+                    catalog.with_provisioning_enforcement()
+                } else {
+                    catalog
+                }
+            };
+
+            let before = store.metrics().snapshot();
+            let report = catalog
+                .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now, &[], None)
+                .await
+                .expect("fold");
+            let after = store.metrics().snapshot();
+
+            assert!(!report.no_op);
+            assert!(report.rebuilt);
+            (report.get_requests, after.get.calls - before.get.calls)
+        }
+
+        // Enforcement off: the report must equal the store's real GET count.
+        // The scan set is a single shard 0 either way (implicit generation 0 at
+        // shard_count 1), so the GETs are HEAD (absent) + tenant-config +
+        // commit-record load + segment fetch = 4.
+        let (off_report, off_observed) = measured(false).await;
+        assert_eq!(
+            off_report, off_observed,
+            "with enforcement off the report must equal the store's observed GETs"
+        );
+        assert_eq!(off_observed, 4);
+
+        // Enforcement on: `read_scan_generations` funnels exactly one extra GET
+        // (the provisioning-record read, NotFound here but still one request)
+        // through `guarded_get`. That is the GET issue #770 dropped; the report
+        // must now equal the store's real count on this path too.
+        let (on_report, on_observed) = measured(true).await;
+        assert_eq!(
+            on_report, on_observed,
+            "with enforcement on the report must equal the store's observed GETs"
+        );
+        assert_eq!(on_observed, 5);
+        assert_eq!(
+            on_observed,
+            off_observed + 1,
+            "enforcement issues exactly one extra GET, the provisioning read"
+        );
     }
 
     // ---- ADR-0063 T2: hour-partitioned sealed/tail parts ----

--- a/crates/ravel-logseg/src/reader.rs
+++ b/crates/ravel-logseg/src/reader.rs
@@ -8,6 +8,8 @@
 //! (scan the skip survivors) and surfaces a counter; corrupt BLOCKS data is a
 //! loud `Corrupted` error.
 
+use std::sync::Arc;
+
 use ravel_types::logstream::AttrValue;
 
 use crate::block::{ColumnPlan, DecodedBlock, PageCounters, read_block_columns, read_block_pages};
@@ -80,7 +82,14 @@ pub struct RlogReader<'a> {
     /// (ADR-0699 decision 2). Its presence is what selects the layout: a
     /// version-4 block's pages are located through this, a version-3 block's
     /// through its own header inside its contiguous byte range.
-    page_dir: Option<PageDir>,
+    ///
+    /// Behind an [`Arc`] so a [`BlockScan`] shares this one decoded copy and
+    /// resolves each surviving block's pages at decode time, rather than
+    /// materializing a `Vec<PageLoc>` per surviving block when the scan is
+    /// pruned: the survivor list then stays proportional to the surviving-block
+    /// count with one shared copy of the page metadata, not proportional to
+    /// surviving blocks times pages-per-block (issue #760).
+    page_dir: Option<Arc<PageDir>>,
     bloom: SectionDesc,
     /// Absent when the object was written with no indexed fields
     /// (docs/log-segment-format.md: POSTINGS is an optional section).
@@ -131,7 +140,7 @@ impl<'a> RlogReader<'a> {
                         skip.l0.len()
                     )));
                 }
-                Some(dir)
+                Some(Arc::new(dir))
             }
             None => None,
         };
@@ -400,6 +409,12 @@ impl<'a> RlogReader<'a> {
 
         // Locate the survivors. Nothing is read or decoded here: the caller
         // drives the decode one block at a time through `BlockScan::next_block`.
+        // A version-4 survivor is named by its whole-object block index only;
+        // its pages are resolved through the shared PAGE_DIR at decode time
+        // (`BlockScan::decode_block`), so the survivor list holds one fixed-size
+        // handle per surviving block rather than a `Vec<PageLoc>` of that
+        // block's pages, keeping it O(surviving blocks) not O(surviving blocks
+        // times pages-per-block) (issue #760).
         let mut blocks = Vec::with_capacity(survivors.len());
         for &b in &survivors {
             let entry =
@@ -407,22 +422,13 @@ impl<'a> RlogReader<'a> {
                     LogSegError::Corrupted("skip block index out of range".into())
                 })?;
             match &self.page_dir {
-                Some(dir) => {
-                    let index = u32::try_from(b)
+                Some(_) => {
+                    let block_index = u32::try_from(b)
                         .map_err(|_| LogSegError::Corrupted("block index range".into()))?;
-                    let mut pages = dir
-                        .block_pages(index)
-                        .ok_or_else(|| LogSegError::Corrupted("block not in page_dir".into()))?;
-                    for p in &mut pages {
-                        p.offset = self
-                            .blocks_offset
-                            .checked_add(p.offset)
-                            .ok_or_else(|| LogSegError::Corrupted("page offset overflow".into()))?;
-                    }
                     blocks.push(BlockLoc::V4 {
                         record_count: entry.record_count as usize,
                         crc32c: entry.block_crc32c,
-                        pages,
+                        block_index,
                     });
                 }
                 None => {
@@ -446,6 +452,8 @@ impl<'a> RlogReader<'a> {
             columns: columns.resolve(&self.field_dir),
             content: content.clone(),
             blocks,
+            page_dir: self.page_dir.clone(),
+            blocks_offset: self.blocks_offset,
             next: 0,
             stats,
             current: None,
@@ -516,6 +524,8 @@ impl<'a> RlogReader<'a> {
             columns: None,
             content: Predicate::And(Vec::new()),
             blocks: Vec::new(),
+            page_dir: None,
+            blocks_offset: 0,
             next: 0,
             stats,
             current: None,
@@ -720,19 +730,25 @@ impl<'a> RlogReader<'a> {
 /// Where one surviving block's bytes are, copied out of the skip index (and,
 /// for version 4, PAGE_DIR) so a [`BlockScan`] can locate it without borrowing
 /// the reader.
-#[derive(Clone, Debug, PartialEq, Eq)]
+///
+/// `Copy` is load-bearing: it is what proves a survivor entry cannot own a
+/// `Vec<PageLoc>`, so the pruned survivor list holds one fixed-size handle per
+/// surviving block, not that block's page list. Reintroducing a per-block page
+/// vector here (the pre-#760 shape) fails to compile against this derive.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum BlockLoc {
     /// Version 3: one contiguous `header || pages` extent, covered by one crc.
     V3 { start: u64, len: u64, crc32c: u32 },
-    /// Version 4: the block's pages, each at its own absolute offset, in
-    /// `column_id` order (ADR-0699 decision 1). `crc32c` is the block crc,
-    /// which is now defined over the concatenation of exactly these pages in
-    /// exactly this order, so it is verifiable only by a reader that took all
-    /// of them; a page-subset read verifies each page's own crc instead.
+    /// Version 4: the whole-object block index, resolved to the block's pages
+    /// through the [`BlockScan`]'s shared PAGE_DIR at decode time rather than
+    /// carried here (issue #760). `crc32c` is the block crc, defined over the
+    /// concatenation of the block's pages in `column_id` order, so it is
+    /// verifiable only by a reader that took all of them; a page-subset read
+    /// verifies each page's own crc instead.
     V4 {
         record_count: usize,
         crc32c: u32,
-        pages: Vec<PageLoc>,
+        block_index: u32,
     },
 }
 
@@ -757,6 +773,16 @@ pub struct BlockScan {
     /// The exact per-row filter, re-evaluated against every decoded row.
     content: Predicate,
     blocks: Vec<BlockLoc>,
+    /// The object's shared decoded PAGE_DIR (version 4 only; `None` under
+    /// version 3). One [`Arc`] copy per scan, cloned from the reader, through
+    /// which [`Self::decode_block`] resolves each version-4 survivor's pages at
+    /// decode time. This is what keeps the pruned survivor list proportional to
+    /// the surviving-block count rather than to blocks times pages-per-block
+    /// (issue #760).
+    page_dir: Option<Arc<PageDir>>,
+    /// Absolute offset of the BLOCKS section, added to the PAGE_DIR-relative
+    /// page offsets when a version-4 block is resolved at decode time.
+    blocks_offset: u64,
     next: usize,
     stats: ScanStats,
     /// The block [`Self::decode_block`] most recently decoded, held only for as
@@ -912,16 +938,35 @@ impl BlockScan {
             BlockLoc::V4 {
                 record_count,
                 crc32c,
-                ref pages,
-            } => decode_v4_block(
-                object_bytes,
-                0,
-                record_count,
-                crc32c,
-                pages,
-                &self.plans,
-                self.columns.as_ref(),
-            )?,
+                block_index,
+            } => {
+                // Resolve the block's pages now, from the shared PAGE_DIR,
+                // rather than from a per-block list built at scan time (issue
+                // #760). `block_pages` returns offsets relative to the BLOCKS
+                // section; shift them to absolute object offsets, exactly what
+                // the scan-time build produced, so the decode is byte-identical.
+                let dir = self.page_dir.as_ref().ok_or_else(|| {
+                    LogSegError::Corrupted("version-4 block without page_dir".into())
+                })?;
+                let mut pages = dir
+                    .block_pages(block_index)
+                    .ok_or_else(|| LogSegError::Corrupted("block not in page_dir".into()))?;
+                for p in &mut pages {
+                    p.offset = self
+                        .blocks_offset
+                        .checked_add(p.offset)
+                        .ok_or_else(|| LogSegError::Corrupted("page offset overflow".into()))?;
+                }
+                decode_v4_block(
+                    object_bytes,
+                    0,
+                    record_count,
+                    crc32c,
+                    &pages,
+                    &self.plans,
+                    self.columns.as_ref(),
+                )?
+            }
         };
         self.stats.blocks_scanned += 1;
         self.stats.pages_decoded += decoded.pages_decoded() as u64;
@@ -1662,6 +1707,209 @@ mod tests {
             w.push(r).expect("push");
         }
         w.finish().expect("finish")
+    }
+
+    /// A record carrying `cols` int columns and `cols` string columns, all
+    /// present in every row, so each is its own dynamic column and contributes
+    /// at least one value page per block: the object is wide enough that a
+    /// block's page count dwarfs 1.
+    fn wide_rec(ts: i64, cols: usize) -> LogRecord {
+        let mut attrs = Vec::with_capacity(2 * cols);
+        for c in 0..cols as i64 {
+            attrs.push((format!("i{c}"), AttrValue::I64(ts * 31 + c)));
+            attrs.push((format!("s{c}"), AttrValue::Str(format!("v{c}-{ts}"))));
+        }
+        LogRecord {
+            stream_id: sid(0),
+            stream_attrs: crate::record::stream_attrs_bytes(
+                &[("service.name".into(), AttrValue::Str("svc".into()))],
+                "scope",
+                "1",
+                &[],
+            ),
+            ts_ns: ts,
+            observed_ts_ns: ts,
+            severity_num: 9,
+            severity_text: "INFO".into(),
+            body: format!("body {ts}"),
+            trace_id: Some([(ts % 251) as u8; 16]),
+            span_id: Some([(ts % 251) as u8; 8]),
+            flags: ts as u32 & 0xf,
+            attrs,
+        }
+    }
+
+    /// The number of resident page-location handles the pruned survivor list
+    /// holds: one whole-object block index per surviving version-4 block, one
+    /// extent per surviving version-3 block. This is one handle per surviving
+    /// block, never one per page: `BlockLoc` is `Copy` (asserted below), so an
+    /// entry cannot own a `Vec<PageLoc>`, and the sum is the survivor count.
+    fn resident_page_locations(scan: &BlockScan) -> usize {
+        scan.blocks
+            .iter()
+            .map(|b| match b {
+                BlockLoc::V4 { .. } | BlockLoc::V3 { .. } => 1,
+            })
+            .sum()
+    }
+
+    /// The version-4 survivor list holds one shared copy of the page metadata
+    /// and resolves each block's pages at decode time, so the pruning stage
+    /// retains one fixed-size handle per surviving block, not that block's page
+    /// list: the resident page-location count is the surviving-block count, not
+    /// blocks times pages-per-block (issue #760).
+    #[test]
+    fn v4_scan_survivor_list_is_o_surviving_blocks_not_blocks_times_pages() {
+        // A survivor entry is a fixed-size Copy handle. `Vec<PageLoc>` is not
+        // `Copy`, so the pre-#760 shape (a per-block page vector in `BlockLoc`)
+        // would not compile here: this pins the O(1)-per-survivor structure at
+        // compile time, so the resident count below cannot silently regress to
+        // one PageLoc per page.
+        fn assert_copy<T: Copy>() {}
+        assert_copy::<BlockLoc>();
+
+        // A wide (50 dynamic columns => >=50 pages/block), long (8 blocks over
+        // 2 row groups) version-4 object.
+        const COLS: usize = 25; // 25 int + 25 str = 50 dynamic columns
+        const RECS_PER_BLOCK: usize = 4;
+        const BLOCKS: usize = 8;
+        const GROUP: usize = 4; // 8 blocks / 4-block groups = 2 groups
+        let cfg = RlogConfig {
+            block_target_records: RECS_PER_BLOCK,
+            group_target_blocks: GROUP,
+            ..RlogConfig::default()
+        };
+        let recs: Vec<LogRecord> = (0..(BLOCKS * RECS_PER_BLOCK) as i64)
+            .map(|ts| wide_rec(ts, COLS))
+            .collect();
+        let obj = build(cfg, recs);
+
+        let reader = RlogReader::new(&obj, &cfg).expect("open reader");
+        let dir = reader
+            .page_dir
+            .clone()
+            .expect("version-4 object has a PAGE_DIR");
+        assert_eq!(dir.block_count(), BLOCKS as u64, "8 blocks as configured");
+        assert_eq!(
+            dir.groups.len(),
+            2,
+            "8 blocks at a 4-block group is 2 groups"
+        );
+
+        // Pages per block: the wide corpus makes this comfortably >= 50, so
+        // blocks x pages is an order of magnitude above the block count.
+        let pages_per_block: Vec<usize> = (0..BLOCKS as u32)
+            .map(|b| dir.block_pages(b).expect("block in dir").len())
+            .collect();
+        let min_p = *pages_per_block.iter().min().expect("blocks");
+        assert!(
+            min_p >= 50,
+            "fixture must be wide: pages-per-block {pages_per_block:?} (min {min_p}) must be >= 50"
+        );
+        let total_pages: usize = pages_per_block.iter().sum();
+
+        // Shape 1: all blocks survive (predicate-free scan).
+        let all = reader
+            .scan_blocks(&Predicate::And(Vec::new()), &[], &ColumnSelection::all())
+            .expect("scan all");
+        assert_eq!(all.blocks.len(), BLOCKS, "all 8 blocks survive");
+        // One shared copy of the page metadata, not one per survivor.
+        assert!(
+            Arc::ptr_eq(
+                all.page_dir.as_ref().expect("scan holds page_dir"),
+                reader.page_dir.as_ref().expect("reader holds page_dir"),
+            ),
+            "the scan shares the reader's one decoded PAGE_DIR"
+        );
+        let all_resident = resident_page_locations(&all);
+        println!(
+            "all-survive: survivors={} resident_page_locations={all_resident} \
+             (pre-#760 would retain total_pages={total_pages} across 8 blocks x {min_p}+ pages)",
+            all.blocks.len()
+        );
+        assert_eq!(
+            all_resident, BLOCKS,
+            "resident page-location handles must equal the surviving-block count"
+        );
+        assert_ne!(
+            all_resident, total_pages,
+            "the survivor list must not hold one handle per page (blocks x pages)"
+        );
+
+        // Shape 2: all blocks pruned but one. Each block holds 4 consecutive
+        // ts; [0,3] is exactly block 0, so the ts prune drops the other 7.
+        let one = reader
+            .scan_blocks(
+                &Predicate::TsRange {
+                    min_ns: 0,
+                    max_ns: 3,
+                },
+                &[],
+                &ColumnSelection::all(),
+            )
+            .expect("scan one");
+        assert_eq!(one.blocks.len(), 1, "ts range [0,3] leaves exactly block 0");
+        let one_resident = resident_page_locations(&one);
+        println!(
+            "one-survivor: survivors={} resident_page_locations={one_resident} \
+             (pre-#760 would retain pages_per_block[0]={} for the surviving block)",
+            one.blocks.len(),
+            pages_per_block[0]
+        );
+        assert_eq!(
+            one_resident, 1,
+            "one surviving block retains exactly one resident page-location handle"
+        );
+        assert_ne!(
+            one_resident, pages_per_block[0],
+            "the surviving block must not hold its whole page list resident"
+        );
+    }
+
+    /// The lazy page resolution decodes byte-for-byte what the eager build did:
+    /// the version-4 decode equals the version-3 decode of the same corpus,
+    /// record for record, over a multi-block, multi-page, multi-group segment.
+    #[test]
+    fn v4_lazy_page_resolution_decodes_identically() {
+        const COLS: usize = 25;
+        let cfg = RlogConfig {
+            block_target_records: 4,
+            group_target_blocks: 4,
+            ..RlogConfig::default()
+        };
+        let recs: Vec<LogRecord> = (0..32i64).map(|ts| wide_rec(ts, COLS)).collect();
+
+        let mut w4 = RlogWriter::new(cfg, identity());
+        for r in &recs {
+            w4.push(r.clone()).expect("push v4");
+        }
+        let v4 = w4.finish().expect("finish v4");
+
+        let mut w3 = RlogWriter::new(cfg, identity());
+        for r in &recs {
+            w3.push(r.clone()).expect("push v3");
+        }
+        let v3 = w3.finish_v3_for_tests().expect("finish v3");
+
+        let pred = Predicate::And(Vec::new());
+        let (rows4, _) = RlogReader::new(&v4, &cfg)
+            .expect("open v4")
+            .scan(&pred)
+            .expect("scan v4");
+        let (rows3, _) = RlogReader::new(&v3, &cfg)
+            .expect("open v3")
+            .scan(&pred)
+            .expect("scan v3");
+
+        assert_eq!(
+            rows4.len(),
+            32,
+            "every record survives a predicate-free scan"
+        );
+        assert_eq!(
+            rows4, rows3,
+            "lazy version-4 page resolution decodes identically to version 3"
+        );
     }
 
     #[test]

--- a/services/ravel-cli/src/load.rs
+++ b/services/ravel-cli/src/load.rs
@@ -74,6 +74,13 @@ pub const DEFAULT_BATCH_ROWS: usize = 10_000;
 /// with `--pipeline-depth`'s own in-flight-write working set.
 pub const DEFAULT_DECODE_QUEUE_BATCHES: usize = 2;
 
+/// Default per-shard bound on concurrently in-flight flushes (issue #807), the
+/// `--max-inflight-flushes` lever. Pinned to
+/// [`IngestConfig::max_inflight_flushes`]'s own default by
+/// `default_max_inflight_flushes_matches_ingest_config`, so the loader's
+/// out-of-the-box flush pipelining stays exactly the server's.
+pub const DEFAULT_MAX_INFLIGHT_FLUSHES: u32 = 1;
+
 /// Ack deadline for each Strict write. Generous: a bulk load values completing
 /// over racing a slow store.
 const WRITE_ACK_DEADLINE: Duration = Duration::from_secs(60);
@@ -270,6 +277,7 @@ pub async fn run(
     batch_rows: usize,
     read_cursors: Option<usize>,
     pipeline_depth: usize,
+    max_inflight_flushes: u32,
     decode_queue_batches: usize,
     now_ns: i64,
 ) -> anyhow::Result<()> {
@@ -282,6 +290,7 @@ pub async fn run(
         batch_rows,
         read_cursors,
         pipeline_depth,
+        max_inflight_flushes,
         decode_queue_batches,
         now_ns,
         &mut std::io::stderr(),
@@ -306,6 +315,7 @@ pub(crate) async fn run_warning_to(
     batch_rows: usize,
     read_cursors: Option<usize>,
     pipeline_depth: usize,
+    max_inflight_flushes: u32,
     decode_queue_batches: usize,
     now_ns: i64,
     warnings: &mut dyn std::io::Write,
@@ -330,6 +340,7 @@ pub(crate) async fn run_warning_to(
         batch_rows,
         read_cursors,
         pipeline_depth,
+        max_inflight_flushes,
         decode_queue_batches,
         now_ns,
         Arc::new(SystemClock),
@@ -557,6 +568,9 @@ impl LoadError {
 ///   first-touch path `services/ravel-server` runs; the router then resolves
 ///   the active generation from that record itself.
 /// - `batch_rows` rows are written per Strict flush.
+/// - The per-shard flush window is [`DEFAULT_MAX_INFLIGHT_FLUSHES`] and the
+///   decode-queue depth [`DEFAULT_DECODE_QUEUE_BATCHES`]; [`load_instrumented`]
+///   is the seam that takes either as a parameter.
 /// - `now_ns` is the ingest-time anchor for the future-skew check (the past-lag
 ///   check is deliberately omitted per ADR-0089). Bucketing is by the router's
 ///   own clock (load-time wall clock), independent of the records' event times.
@@ -594,6 +608,7 @@ pub async fn load(
         batch_rows,
         read_cursors,
         pipeline_depth,
+        DEFAULT_MAX_INFLIGHT_FLUSHES,
         DEFAULT_DECODE_QUEUE_BATCHES,
         now_ns,
         clock,
@@ -628,6 +643,7 @@ async fn load_instrumented(
     batch_rows: usize,
     read_cursors: Option<usize>,
     pipeline_depth: usize,
+    max_inflight_flushes: u32,
     decode_queue_batches: usize,
     now_ns: i64,
     clock: Arc<dyn Clock>,
@@ -663,6 +679,19 @@ async fn load_instrumented(
         return Err(LoadError::Setup(
             "--read-cursors must be at least 1, or omitted for automatic sizing \
              (min(shard count, row-group count)); 0 was given"
+                .to_string(),
+        ));
+    }
+    // Same shape as the guards above: `--max-inflight-flushes` is the
+    // operator-facing lever bounding how many flushes one shard may run at once
+    // (issue #807). A bound of 0 is a semaphore no flush can ever acquire, so
+    // the shard actor would park on its first flush trigger forever; reject it
+    // here rather than silently clamping to 1.
+    if max_inflight_flushes == 0 {
+        return Err(LoadError::Setup(
+            "--max-inflight-flushes must be at least 1 (the number of flushes one shard may have \
+             in flight at once); 0 would deadlock every flush, since a shard could never acquire \
+             a permit to run one"
                 .to_string(),
         ));
     }
@@ -711,10 +740,18 @@ async fn load_instrumented(
     // unawaited future does no I/O until polled; spawning is what makes the S3
     // PUT round trips overlap). `write`/`write_columnar` take `&self`, so this
     // is the only change the router's own type needs.
+    //
+    // `max_inflight_flushes` is the second, inner concurrency window (issue
+    // #807): `pipeline_depth` bounds the writes the loader keeps outstanding,
+    // this bounds the flushes each shard actor may run at once, and the two
+    // multiply. It reaches the shard actors' flush semaphores unmodified
+    // (`Semaphore::new(config.max_inflight_flushes as usize)` in
+    // crates/ravel-ingest/src/log_shard.rs); nothing downstream clamps it.
     let router = Arc::new(LogIngestRouter::new(
         IngestConfig {
             shard_count: shards,
             target_bytes: 1,
+            max_inflight_flushes,
             ..IngestConfig::default()
         },
         Arc::clone(&store),
@@ -3453,6 +3490,7 @@ type = "i64"
             10_000,
             None,
             1,
+            DEFAULT_MAX_INFLIGHT_FLUSHES,
             DEFAULT_DECODE_QUEUE_BATCHES,
             NOW_NS,
             &mut sink,
@@ -3644,6 +3682,7 @@ type = "i64"
             10,
             None,
             1,
+            DEFAULT_MAX_INFLIGHT_FLUSHES,
             0,
             NOW_NS,
             Arc::new(FixedClock(NOW_NS)),
@@ -3661,6 +3700,65 @@ type = "i64"
             err.to_string()
                 .contains("--decode-queue-batches must be at least 1"),
             "the error names the lever: {err}"
+        );
+    }
+
+    /// `--max-inflight-flushes 0` is rejected with a typed [`LoadError::Setup`]
+    /// before any work, mirroring `pipeline_depth_zero_is_rejected` (issue
+    /// #807). A bound of 0 builds `Semaphore::new(0)` in every shard actor, a
+    /// permit no flush can ever acquire, so the guard makes it unreachable
+    /// rather than letting the first flush trigger park forever.
+    ///
+    /// Non-vacuity (prove-the-test): the message assertion is what carries the
+    /// weight. With the guard deleted, this fixture still fails, but on the
+    /// missing-file open further down, so the `LoadError::Setup(_)` shape alone
+    /// would pass while the flag went unvalidated; only the
+    /// `--max-inflight-flushes must be at least 1` text distinguishes the two.
+    #[tokio::test]
+    async fn max_inflight_flushes_zero_is_rejected() {
+        use ravel_object_store::memory::MemoryStore;
+        let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+        let m = base_mapping();
+        let err = load_instrumented(
+            store,
+            Path::new("/nonexistent.parquet"),
+            "acme",
+            &m,
+            4,
+            10,
+            None,
+            1,
+            0,
+            DEFAULT_DECODE_QUEUE_BATCHES,
+            NOW_NS,
+            Arc::new(FixedClock(NOW_NS)),
+            LoadPath::Columnar,
+            None,
+            None,
+        )
+        .await
+        .expect_err("max_inflight_flushes of 0 is rejected");
+        assert!(
+            matches!(err, LoadError::Setup(_)),
+            "a typed setup error, got: {err}"
+        );
+        assert!(
+            err.to_string()
+                .contains("--max-inflight-flushes must be at least 1"),
+            "the error names the lever: {err}"
+        );
+    }
+
+    /// The loader's `--max-inflight-flushes` default is the ingest layer's own
+    /// default, not an independent literal that can drift from it: omitting the
+    /// flag must leave a load running exactly the flush pipelining
+    /// `IngestConfig` ships with.
+    #[test]
+    fn default_max_inflight_flushes_matches_ingest_config() {
+        assert_eq!(
+            DEFAULT_MAX_INFLIGHT_FLUSHES,
+            IngestConfig::default().max_inflight_flushes,
+            "the CLI default must track IngestConfig::max_inflight_flushes"
         );
     }
 
@@ -3848,6 +3946,7 @@ type = "i64"
                     2,
                     None,
                     2,
+                    DEFAULT_MAX_INFLIGHT_FLUSHES,
                     depth,
                     NOW_NS,
                     Arc::new(FixedClock(NOW_NS)),
@@ -4013,6 +4112,7 @@ type = "i64"
             2,
             None,
             1,
+            DEFAULT_MAX_INFLIGHT_FLUSHES,
             QUEUE_DEPTH,
             NOW_NS,
             Arc::new(FixedClock(NOW_NS)),
@@ -4313,6 +4413,7 @@ type = "i64"
             2,
             None,
             1,
+            DEFAULT_MAX_INFLIGHT_FLUSHES,
             DEFAULT_DECODE_QUEUE_BATCHES,
             NOW_NS,
             Arc::new(FixedClock(NOW_NS)),
@@ -4696,6 +4797,7 @@ type = "i64"
             batch_rows,
             Some(1),
             1,
+            DEFAULT_MAX_INFLIGHT_FLUSHES,
             DEFAULT_DECODE_QUEUE_BATCHES,
             NOW_NS,
             &mut sink,
@@ -4723,6 +4825,7 @@ type = "i64"
             batch_rows,
             Some(4),
             1,
+            DEFAULT_MAX_INFLIGHT_FLUSHES,
             DEFAULT_DECODE_QUEUE_BATCHES,
             NOW_NS,
             &mut sink,
@@ -4764,6 +4867,7 @@ type = "i64"
             batch_rows,
             Some(1),
             1,
+            DEFAULT_MAX_INFLIGHT_FLUSHES,
             DEFAULT_DECODE_QUEUE_BATCHES,
             NOW_NS,
             &mut sink,
@@ -5646,6 +5750,7 @@ type = "i64"
             batch_rows,
             read_cursors,
             1,
+            DEFAULT_MAX_INFLIGHT_FLUSHES,
             DEFAULT_DECODE_QUEUE_BATCHES,
             now_ns,
             clock,
@@ -5937,6 +6042,125 @@ type = "i64"
             max_d3 >= 3,
             "at --pipeline-depth 3 the write window reaches three concurrently outstanding PUTs, \
              got {max_d3}"
+        );
+    }
+
+    /// `--max-inflight-flushes` is load-bearing, not accepted-and-ignored, and
+    /// it is a genuinely different window from `--pipeline-depth`: it bounds the
+    /// flushes ONE SHARD may run at once, where `--pipeline-depth` bounds the
+    /// writes the loader keeps outstanding across all shards. Every batch here
+    /// lands on the same shard (`--shards 1`), so the shard's flush semaphore is
+    /// the only thing that can serialize them, and `--pipeline-depth 4` is held
+    /// above every flush setting under test so the loader's own window is never
+    /// the binding constraint.
+    ///
+    /// Four rows, one row per batch, each data-object PUT held 50ms while the
+    /// store tracks the running maximum of concurrently outstanding data-object
+    /// PUTs. Both arms assert an exact figure, not a floor: the semaphore is a
+    /// hard ceiling (a shard may not exceed its permit count) and, with four
+    /// batches queued behind a four-deep loader window, it is also reached.
+    ///
+    /// Non-vacuity (prove-the-test): confirmed failing against the pre-change
+    /// code by deleting the `max_inflight_flushes,` field from the
+    /// `IngestConfig` literal in `load_instrumented`, which is exactly the state
+    /// before this ticket -- the flag parsed and threaded but never reaching the
+    /// router. The window then falls back to `IngestConfig::default()`'s 1 and
+    /// the `flushes = 3` arm observes a high-water mark of 1 instead of 3. The
+    /// `flushes = 1` arm is the control: it reads 1 either way, so on its own it
+    /// proves nothing, which is why the higher setting is asserted exactly.
+    #[tokio::test]
+    async fn max_inflight_flushes_bounds_concurrent_flushes_per_shard() {
+        use parquet::arrow::ArrowWriter;
+        use ravel_object_store::memory::MemoryStore;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        /// Rows, and therefore single-row batches, in the fixture. One more
+        /// than the highest flush window under test, so the window (not the
+        /// supply of batches) is what the high-water mark measures.
+        const BATCHES: usize = 4;
+        /// Held above every flush setting under test: the loader's own window
+        /// must never be the binding constraint on this fixture.
+        const PIPELINE_DEPTH: usize = 4;
+
+        async fn max_concurrent_at_flush_window(flushes: u32) -> usize {
+            // One shard, so every batch's flush contends for the same shard
+            // actor's semaphore. Distinct hosts keep the objects distinct
+            // without changing routing.
+            let shards = 1u32;
+            let hosts: Vec<String> = (0..BATCHES).map(|i| format!("h{i}")).collect();
+
+            let dir = tempfile::tempdir().expect("tempdir");
+            let pq = dir.path().join("flush_window.parquet");
+            let cols: Vec<(String, ArrayRef)> = vec![
+                ("ts".to_string(), i64_col(vec![NOW_NS; BATCHES])),
+                ("svc".to_string(), str_col(vec!["api"; BATCHES])),
+                (
+                    "host".to_string(),
+                    str_col(hosts.iter().map(|h| h.as_str()).collect()),
+                ),
+            ];
+            let b = RecordBatch::try_from_iter(cols).expect("record batch");
+            let file = std::fs::File::create(&pq).expect("create parquet");
+            let mut writer = ArrowWriter::try_new(file, b.schema(), None).expect("arrow writer");
+            writer.write(&b).expect("write batch");
+            writer.close().expect("close writer");
+
+            let m = parse_mapping(
+                "ts_column = \"ts\"\nts_unit = \"nanos\"\n\n\
+                 [[resource_attribute]]\nkey = \"service.name\"\ncolumn = \"svc\"\ntype = \"str\"\n\n\
+                 [[resource_attribute]]\nkey = \"host\"\ncolumn = \"host\"\ntype = \"str\"\n",
+            )
+            .expect("valid mapping");
+
+            let max_in_flight = Arc::new(AtomicUsize::new(0));
+            let store = Arc::new(InstrumentedPutStore {
+                inner: Arc::new(MemoryStore::new()),
+                delays: vec![("/l0/", Duration::from_millis(50))],
+                in_flight: Arc::new(AtomicUsize::new(0)),
+                max_in_flight: Arc::clone(&max_in_flight),
+                watch_prefixes: Vec::new(),
+                watch_started: Arc::new(AtomicUsize::new(0)),
+                watch_completed: Arc::new(AtomicUsize::new(0)),
+            });
+
+            let report = load_instrumented(
+                store as Arc<dyn ObjectStoreBackend>,
+                &pq,
+                "acme",
+                &m,
+                shards,
+                1,
+                None,
+                PIPELINE_DEPTH,
+                flushes,
+                DEFAULT_DECODE_QUEUE_BATCHES,
+                NOW_NS,
+                Arc::new(FixedClock(NOW_NS)),
+                LoadPath::Columnar,
+                None,
+                None,
+            )
+            .await
+            .expect("the load succeeds");
+            assert_eq!(
+                report.rows_processed, BATCHES as u64,
+                "every row is written"
+            );
+            max_in_flight.load(Ordering::SeqCst)
+        }
+
+        let max_w1 = max_concurrent_at_flush_window(1).await;
+        assert_eq!(
+            max_w1, 1,
+            "at --max-inflight-flushes 1 the shard runs exactly one flush at a time even with \
+             --pipeline-depth {PIPELINE_DEPTH} handing it {BATCHES} writes, got {max_w1}"
+        );
+
+        let max_w3 = max_concurrent_at_flush_window(3).await;
+        assert_eq!(
+            max_w3, 3,
+            "at --max-inflight-flushes 3 the shard runs exactly three flushes at once: the \
+             semaphore is the ceiling and {BATCHES} queued batches reach it, got {max_w3}"
         );
     }
 

--- a/services/ravel-cli/src/main.rs
+++ b/services/ravel-cli/src/main.rs
@@ -277,6 +277,28 @@ enum Command {
         /// this gap cannot occur. `0` is rejected.
         #[arg(long, default_value_t = 1)]
         pipeline_depth: usize,
+        /// Number of flushes one shard may have in flight at once (issue #807).
+        /// This bounds the shard actor's own flush pipeline, PER SHARD: the
+        /// loader writes one RLOG object per batch per involved shard, and with
+        /// the default `1` a shard actor must wait for the previous object's
+        /// PUT and commit-record publish before it starts the next one, so a
+        /// second batch landing on the same shard queues behind the first even
+        /// when `--pipeline-depth` has already handed both to the router. The
+        /// resulting ceiling on genuinely concurrent flushes is roughly
+        /// `--shards` x this value, capped additionally by `--pipeline-depth`
+        /// (the loader never keeps more than that many writes outstanding, so a
+        /// value above `--pipeline-depth` cannot be reached). The cost is
+        /// memory: each in-flight flush holds its built object, and the buffered
+        /// records it was built from, resident until that flush's terminal
+        /// outcome (its commit record published, or its retry budget exhausted),
+        /// so the per-shard resident flush working set scales by this value. A
+        /// Strict write's acknowledgement is unchanged by the setting: each
+        /// flush answers its own waiters only after its own data object and its
+        /// own commit record have landed. `1` preserves today's
+        /// one-flush-per-shard behavior. `0` is rejected: it is a semaphore no
+        /// flush can ever acquire, which would deadlock the shard.
+        #[arg(long, default_value_t = ravel_cli::load::DEFAULT_MAX_INFLIGHT_FLUSHES)]
+        max_inflight_flushes: u32,
         /// Number of decoded batches allowed to sit queued between the Parquet
         /// decode/build stage and the shard writers (issue #680). A bounded
         /// channel decouples the two: the reader decodes batch N+1 (and, with
@@ -1356,6 +1378,7 @@ async fn main() -> anyhow::Result<()> {
             batch_rows,
             read_cursors,
             pipeline_depth,
+            max_inflight_flushes,
             decode_queue_batches,
         } => {
             let profile = ravel_cli::cli_profiling::ProfileSession::from_env("ravel-cli-load");
@@ -1368,6 +1391,7 @@ async fn main() -> anyhow::Result<()> {
                 batch_rows,
                 read_cursors,
                 pipeline_depth,
+                max_inflight_flushes,
                 decode_queue_batches,
                 now_ns()?,
             )


### PR DESCRIPTION
Three independent results from epic #680, batched into one gate because they
touch disjoint crates and the gate boxes are the throughput limit tonight.

The RLOG v4 reader resolved every surviving block's page list for the whole
scan, so the survivor list cost blocks times pages rather than the number of
surviving blocks. It now resolves page locations lazily, and decode results
are byte-identical to the eager path.

FoldReport::get_requests omitted the provisioning generation GET under
enforcement, so a fold reported fewer requests than it issued. Every request
the fold makes is now counted under the phase that issued it. An undercount
here is what makes a later regression unattributable.

The bulk loader exposes --max-inflight-flushes, the per-shard flush window
that until now could only be set from a test. Its default stays 1 and
ravel-ingest is untouched, so no behaviour changes unless an operator asks
for it; 0 is rejected with a typed error because it would deadlock every
flush. Exposing the knob is not changing it, and ADR-0807 records why the
default stays where it is.

Fixes: #760
Fixes: #770
Refs: #807
Refs: #680