### PR TITLE
test: replace timing-dependent assertions with deterministic gates

### DIFF
--- a/crates/ravel-cache/src/lib.rs
+++ b/crates/ravel-cache/src/lib.rs
@@ -89,11 +89,15 @@ pub use tiered::{Source, TieredCache};
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
+    use std::future::Future;
+    use std::pin::Pin;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::task::Poll;
     use std::time::Duration;
 
     use bytes::Bytes;
+    use tokio::sync::oneshot;
     use tokio::time::timeout;
 
     use super::*;
@@ -104,72 +108,132 @@ mod tests {
         CacheKey::new([7u8; 16], content_hash, 0, 0)
     }
 
+    /// Poll `future` exactly once and report whether it completed. The first
+    /// poll of a `SingleFlight::run` future is where it takes the in-flight
+    /// map lock and becomes a leader or a follower, so polling once is how
+    /// these tests make follower registration an ordering they enforce rather
+    /// than a wall-clock race decided by how promptly the runtime schedules a
+    /// spawned task against a leader that holds its slot for a fixed sleep.
+    async fn poll_once<F: Future>(future: &mut Pin<Box<F>>) -> Poll<F::Output> {
+        std::future::poll_fn(|cx| Poll::Ready(future.as_mut().poll(cx))).await
+    }
+
     #[tokio::test]
     async fn single_flight_collapses_concurrent_misses_and_propagates_errors() {
         let flight: Arc<SingleFlight<CacheKey, Bytes, &'static str>> =
             Arc::new(SingleFlight::new());
         let key = test_key(1);
+        const CALLERS: usize = 8;
 
         // N concurrent misses on one key produce exactly one upstream
-        // call, and every waiter receives the same bytes.
+        // call, and every waiter receives the same bytes. The leader is held
+        // inside its fetch by a `oneshot` this test releases only after every
+        // follower has been polled once, so exactly one of the N is the leader
+        // by construction.
         let upstream_calls = Arc::new(AtomicUsize::new(0));
-        let mut handles = Vec::new();
-        for _ in 0..8 {
+        let follower_fetches = Arc::new(AtomicUsize::new(0));
+        let (entered_tx, entered_rx) = oneshot::channel();
+        let (release_tx, release_rx) = oneshot::channel();
+        let leader = {
             let flight = flight.clone();
             let upstream_calls = upstream_calls.clone();
-            handles.push(tokio::spawn(async move {
+            tokio::spawn(async move {
                 flight
-                    .run(key, move || {
-                        let upstream_calls = upstream_calls.clone();
-                        async move {
-                            upstream_calls.fetch_add(1, Ordering::SeqCst);
-                            tokio::time::sleep(Duration::from_millis(20)).await;
-                            Ok::<Bytes, &'static str>(Bytes::from_static(b"payload"))
-                        }
+                    .run(key, move || async move {
+                        upstream_calls.fetch_add(1, Ordering::SeqCst);
+                        let _ = entered_tx.send(());
+                        let _ = release_rx.await;
+                        Ok::<Bytes, &'static str>(Bytes::from_static(b"payload"))
                     })
                     .await
-            }));
+            })
+        };
+        entered_rx.await.unwrap();
+
+        let mut followers = Vec::new();
+        for _ in 1..CALLERS {
+            let ran = follower_fetches.clone();
+            followers.push(Box::pin(flight.run(key, move || async move {
+                ran.fetch_add(1, Ordering::SeqCst);
+                Ok::<Bytes, &'static str>(Bytes::from_static(b"never"))
+            })));
         }
-        for handle in handles {
-            let (result, _role) = handle.await.unwrap();
+        for follower in &mut followers {
+            assert!(
+                poll_once(follower).await.is_pending(),
+                "a follower parks on the held leader instead of completing on its own"
+            );
+        }
+        release_tx.send(()).expect("the leader is still parked");
+
+        for follower in followers {
+            let (result, role) = follower.await;
             assert_eq!(result.unwrap().as_ref(), b"payload".as_slice());
+            assert_eq!(role, Role::Follower, "every later caller is a follower");
         }
+        let (result, role) = leader.await.unwrap();
+        assert_eq!(result.unwrap().as_ref(), b"payload".as_slice());
+        assert_eq!(role, Role::Leader, "the held caller is the one leader");
         assert_eq!(
             upstream_calls.load(Ordering::SeqCst),
             1,
             "N concurrent misses on one key must produce exactly one upstream call"
         );
+        assert_eq!(
+            follower_fetches.load(Ordering::SeqCst),
+            0,
+            "a follower never runs its own fetch"
+        );
 
         // A failing upstream call reaches every waiter as an error,
-        // rather than hanging any of them.
+        // rather than hanging any of them. Held the same way.
         let key2 = test_key(2);
         let upstream_calls2 = Arc::new(AtomicUsize::new(0));
-        let mut handles = Vec::new();
-        for _ in 0..8 {
+        let (entered_tx, entered_rx) = oneshot::channel();
+        let (release_tx, release_rx) = oneshot::channel();
+        let leader = {
             let flight = flight.clone();
             let upstream_calls2 = upstream_calls2.clone();
-            handles.push(tokio::spawn(async move {
+            tokio::spawn(async move {
                 flight
-                    .run(key2, move || {
-                        let upstream_calls2 = upstream_calls2.clone();
-                        async move {
-                            upstream_calls2.fetch_add(1, Ordering::SeqCst);
-                            tokio::time::sleep(Duration::from_millis(20)).await;
-                            Err::<Bytes, &'static str>("upstream exploded")
-                        }
+                    .run(key2, move || async move {
+                        upstream_calls2.fetch_add(1, Ordering::SeqCst);
+                        let _ = entered_tx.send(());
+                        let _ = release_rx.await;
+                        Err::<Bytes, &'static str>("upstream exploded")
                     })
                     .await
-            }));
+            })
+        };
+        entered_rx.await.unwrap();
+
+        let mut followers = Vec::new();
+        for _ in 1..CALLERS {
+            followers.push(Box::pin(flight.run(key2, || async {
+                Ok::<Bytes, &'static str>(Bytes::from_static(b"never"))
+            })));
         }
-        for handle in handles {
-            let (result, _role) = handle.await.unwrap();
+        for follower in &mut followers {
+            assert!(
+                poll_once(follower).await.is_pending(),
+                "a follower parks on the held leader instead of completing on its own"
+            );
+        }
+        release_tx.send(()).expect("the leader is still parked");
+
+        for follower in followers {
+            let (result, role) = follower.await;
             match result {
                 Err(SingleFlightError::Upstream(message)) => {
                     assert_eq!(message, "upstream exploded")
                 }
                 other => panic!("expected every waiter to see the upstream error, got {other:?}"),
             }
+            assert_eq!(role, Role::Follower);
         }
+        let (result, role) = leader.await.unwrap();
+        assert!(matches!(result, Err(SingleFlightError::Upstream(_))));
+        assert_eq!(role, Role::Leader);
         assert_eq!(upstream_calls2.load(Ordering::SeqCst), 1);
 
         // A second, later miss on the same key after the first completed
@@ -197,36 +261,41 @@ mod tests {
             Arc::new(SingleFlight::new());
 
         // A leader that panics before producing a result must not leave a
-        // concurrent follower waiting forever.
+        // concurrent follower waiting forever. The leader parks inside its
+        // fetch until this test releases it, and the follower is registered
+        // (polled once) before that release, so "the follower joined while the
+        // leader was still in flight" is ordered here rather than raced
+        // between a 2 ms and a 10 ms sleep.
         let key = test_key(100);
+        let (entered_tx, entered_rx) = oneshot::channel();
+        let (release_tx, release_rx) = oneshot::channel::<()>();
         let leader = {
             let flight = flight.clone();
             tokio::spawn(async move {
                 flight
-                    .run(key, || async {
-                        tokio::time::sleep(Duration::from_millis(10)).await;
+                    .run(key, move || async move {
+                        let _ = entered_tx.send(());
+                        let _ = release_rx.await;
                         panic!("leader blew up before producing a result");
                     })
                     .await
             })
         };
-        tokio::time::sleep(Duration::from_millis(2)).await;
+        entered_rx.await.unwrap();
+
         let follower_ran = Arc::new(AtomicUsize::new(0));
-        let follower = {
-            let flight = flight.clone();
-            let follower_ran = follower_ran.clone();
-            tokio::spawn(async move {
-                flight
-                    .run(key, move || {
-                        let follower_ran = follower_ran.clone();
-                        async move {
-                            follower_ran.fetch_add(1, Ordering::SeqCst);
-                            Ok::<Bytes, &'static str>(Bytes::from_static(b"never"))
-                        }
-                    })
-                    .await
-            })
+        let mut follower = {
+            let ran = follower_ran.clone();
+            Box::pin(flight.run(key, move || async move {
+                ran.fetch_add(1, Ordering::SeqCst);
+                Ok::<Bytes, &'static str>(Bytes::from_static(b"never"))
+            }))
         };
+        assert!(
+            poll_once(&mut follower).await.is_pending(),
+            "the follower parks on the still-in-flight leader"
+        );
+        release_tx.send(()).expect("the leader is still parked");
 
         assert!(
             leader.await.is_err(),
@@ -234,8 +303,7 @@ mod tests {
         );
         let (follower_result, follower_role) = timeout(Duration::from_secs(2), follower)
             .await
-            .expect("a panicking leader must not leave a follower parked forever")
-            .expect("follower task must not itself panic");
+            .expect("a panicking leader must not leave a follower parked forever");
         assert!(matches!(
             follower_result,
             Err(SingleFlightError::LeaderLost)
@@ -248,37 +316,39 @@ mod tests {
         );
 
         // A leader whose task is cancelled before it produces a result
-        // must not leave a concurrent follower waiting forever either.
+        // must not leave a concurrent follower waiting forever either. The
+        // leader parks on a `oneshot` whose sender this test never fires, so
+        // it is still in flight when the abort lands -- no 60 s sleep to
+        // outrun and no 10 ms windows to lose.
         let key2 = test_key(101);
+        let (entered_tx, entered_rx) = oneshot::channel();
+        let (_never_tx, never_rx) = oneshot::channel::<()>();
         let leader2 = {
             let flight = flight.clone();
             tokio::spawn(async move {
                 flight
-                    .run(key2, || async {
-                        tokio::time::sleep(Duration::from_secs(60)).await;
+                    .run(key2, move || async move {
+                        let _ = entered_tx.send(());
+                        let _ = never_rx.await;
                         Ok::<Bytes, &'static str>(Bytes::from_static(b"unreachable"))
                     })
                     .await
             })
         };
-        tokio::time::sleep(Duration::from_millis(10)).await;
-        let follower2 = {
-            let flight = flight.clone();
-            tokio::spawn(async move {
-                flight
-                    .run(key2, || async {
-                        Ok::<Bytes, &'static str>(Bytes::from_static(b"never"))
-                    })
-                    .await
-            })
-        };
-        tokio::time::sleep(Duration::from_millis(10)).await;
+        entered_rx.await.unwrap();
+
+        let mut follower2 = Box::pin(flight.run(key2, || async {
+            Ok::<Bytes, &'static str>(Bytes::from_static(b"never"))
+        }));
+        assert!(
+            poll_once(&mut follower2).await.is_pending(),
+            "the follower parks on the still-in-flight leader"
+        );
         leader2.abort();
 
         let (follower2_result, _role) = timeout(Duration::from_secs(2), follower2)
             .await
-            .expect("a cancelled leader must not leave a follower parked forever")
-            .expect("follower task must not itself panic");
+            .expect("a cancelled leader must not leave a follower parked forever");
         assert!(matches!(
             follower2_result,
             Err(SingleFlightError::LeaderLost)

--- a/crates/ravel-cache/src/tiered.rs
+++ b/crates/ravel-cache/src/tiered.rs
@@ -500,12 +500,14 @@ async fn corrupted_disk_hit_is_corrupted_through_ram_readthrough() {
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
+    use std::future::Future;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::time::Duration;
+    use std::task::Poll;
 
     use bytes::Bytes;
     use tempfile::TempDir;
+    use tokio::sync::oneshot;
 
     use super::fixtures::{generous_limits, test_key};
     use super::*;
@@ -560,6 +562,12 @@ mod tests {
     /// Concurrent RAM+disk misses on one key collapse to a single upstream
     /// fetch (ADR-0046 decision 5, spanning both tiers): every waiter gets the
     /// same bytes, and the fetch closure runs exactly once.
+    ///
+    /// The leader is held in its fetch by a `oneshot` this test releases, and
+    /// each follower's future is polled once before that release. That first
+    /// poll is where `SingleFlight::run` takes the in-flight map lock, so
+    /// "the followers joined while the leader was still in flight" is an
+    /// ordering this test enforces rather than a wall-clock race it can lose.
     #[tokio::test]
     async fn single_flight_collapses_concurrent_misses_to_one_upstream() {
         let tmp = TempDir::new().unwrap();
@@ -570,44 +578,68 @@ mod tests {
         let payload = Bytes::from_static(b"fetched once");
         let key = test_key(1, payload.len() as u64);
         let upstream_calls = Arc::new(AtomicUsize::new(0));
+        let follower_fetches = Arc::new(AtomicUsize::new(0));
 
-        let mut handles = Vec::new();
-        for _ in 0..8 {
+        const CALLERS: usize = 8;
+        let (entered_tx, entered_rx) = oneshot::channel();
+        let (release_tx, release_rx) = oneshot::channel();
+        let leader = {
             let tiered = tiered.clone();
             let calls = upstream_calls.clone();
             let payload = payload.clone();
-            handles.push(tokio::spawn(async move {
+            tokio::spawn(async move {
                 tiered
-                    .get_or_fetch(key, move || {
-                        let calls = calls.clone();
-                        let payload = payload.clone();
-                        async move {
-                            calls.fetch_add(1, Ordering::SeqCst);
-                            // Hold the slot so the other callers arrive as
-                            // followers rather than each starting a fresh
-                            // leader after the first completes.
-                            tokio::time::sleep(Duration::from_millis(20)).await;
-                            Ok::<Bytes, &'static str>(payload)
-                        }
+                    .get_or_fetch(key, move || async move {
+                        calls.fetch_add(1, Ordering::SeqCst);
+                        let _ = entered_tx.send(());
+                        let _ = release_rx.await;
+                        Ok::<Bytes, &'static str>(payload)
                     })
                     .await
-            }));
+            })
+        };
+        entered_rx.await.expect("the leader reaches its fetch");
+
+        let mut followers = Vec::new();
+        for _ in 1..CALLERS {
+            let ran = follower_fetches.clone();
+            followers.push(Box::pin(tiered.get_or_fetch(key, move || async move {
+                ran.fetch_add(1, Ordering::SeqCst);
+                Ok::<Bytes, &'static str>(Bytes::from_static(b"never"))
+            })));
         }
-        for handle in handles {
-            let (bytes, _source) = handle.await.unwrap().unwrap();
+        for follower in &mut followers {
+            let first = std::future::poll_fn(|cx| Poll::Ready(follower.as_mut().poll(cx))).await;
+            assert!(
+                first.is_pending(),
+                "a follower parks on the held leader instead of completing on its own"
+            );
+        }
+        release_tx.send(()).expect("the leader is still parked");
+
+        for follower in followers {
+            let (bytes, _source) = follower.await.unwrap();
             assert_eq!(
                 bytes, payload,
                 "every waiter receives the one fetched value"
             );
         }
+        let (bytes, _source) = leader.await.unwrap().unwrap();
+        assert_eq!(bytes, payload, "the leader receives its own fetched value");
+
         assert_eq!(
             upstream_calls.load(Ordering::SeqCst),
             1,
             "8 concurrent misses on one key must produce exactly one upstream fetch"
         );
         assert_eq!(
+            follower_fetches.load(Ordering::SeqCst),
+            0,
+            "a follower never runs its own fetch"
+        );
+        assert_eq!(
             tiered.ram_metrics().snapshot().single_flight_collapses,
-            7,
+            (CALLERS - 1) as u64,
             "the 7 followers each record one collapse"
         );
     }
@@ -625,7 +657,12 @@ mod tests {
     /// without the `self.single_flight.run(...)` wrapper (the pre-fix
     /// `ReadCache::fetch_peeked` Tiered behavior): `upstream_calls` then reads 8,
     /// not 1, and the exactly-one-fetch assertion fails.
-    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    ///
+    /// The leader is held in its fetch by a `oneshot` this test releases, and
+    /// each follower's future is polled once (the poll that takes the
+    /// in-flight map lock) before that release, so no wall-clock hold decides
+    /// whether a caller lands as a follower or as a second leader.
+    #[tokio::test]
     async fn resolve_peeked_miss_collapses_concurrent_callers_to_one_fetch() {
         let tmp = TempDir::new().unwrap();
         let disk = DiskCache::new(tmp.path().to_path_buf(), generous_limits());
@@ -649,40 +686,65 @@ mod tests {
         let misses_after_peeks = ram_metrics.snapshot().misses;
 
         let upstream_calls = Arc::new(AtomicUsize::new(0));
-        let mut handles = Vec::new();
-        for _ in 0..CALLERS {
+        let follower_fetches = Arc::new(AtomicUsize::new(0));
+        let (entered_tx, entered_rx) = oneshot::channel();
+        let (release_tx, release_rx) = oneshot::channel();
+        let leader = {
             let tiered = tiered.clone();
             let calls = upstream_calls.clone();
             let payload = payload.clone();
-            handles.push(tokio::spawn(async move {
+            tokio::spawn(async move {
                 tiered
-                    .resolve_peeked_miss(key, move || {
-                        let calls = calls.clone();
-                        let payload = payload.clone();
-                        async move {
-                            calls.fetch_add(1, Ordering::SeqCst);
-                            // Hold the slot so the other callers arrive as
-                            // followers, not fresh leaders after the first
-                            // completes.
-                            tokio::time::sleep(Duration::from_millis(20)).await;
-                            Ok::<Bytes, &'static str>(payload)
-                        }
+                    .resolve_peeked_miss(key, move || async move {
+                        calls.fetch_add(1, Ordering::SeqCst);
+                        let _ = entered_tx.send(());
+                        let _ = release_rx.await;
+                        Ok::<Bytes, &'static str>(payload)
                     })
                     .await
-            }));
+            })
+        };
+        entered_rx.await.expect("the leader reaches its fetch");
+
+        let mut followers = Vec::new();
+        for _ in 1..CALLERS {
+            let ran = follower_fetches.clone();
+            followers.push(Box::pin(tiered.resolve_peeked_miss(
+                key,
+                move || async move {
+                    ran.fetch_add(1, Ordering::SeqCst);
+                    Ok::<Bytes, &'static str>(Bytes::from_static(b"never"))
+                },
+            )));
         }
-        for handle in handles {
-            let bytes = handle.await.unwrap().unwrap();
+        for follower in &mut followers {
+            let first = std::future::poll_fn(|cx| Poll::Ready(follower.as_mut().poll(cx))).await;
+            assert!(
+                first.is_pending(),
+                "a follower parks on the held leader instead of completing on its own"
+            );
+        }
+        release_tx.send(()).expect("the leader is still parked");
+
+        for follower in followers {
+            let bytes = follower.await.unwrap();
             assert_eq!(
                 bytes, payload,
                 "every caller receives the one fetched value"
             );
         }
+        let bytes = leader.await.unwrap().unwrap();
+        assert_eq!(bytes, payload, "the leader receives its own fetched value");
 
         assert_eq!(
             upstream_calls.load(Ordering::SeqCst),
             1,
             "8 concurrent resolve_peeked_miss callers on one key must produce exactly one fetch"
+        );
+        assert_eq!(
+            follower_fetches.load(Ordering::SeqCst),
+            0,
+            "a follower never runs its own fetch"
         );
         assert_eq!(
             ram_metrics.snapshot().single_flight_collapses,

--- a/crates/ravel-catalog/tests/compaction_resolution.rs
+++ b/crates/ravel-catalog/tests/compaction_resolution.rs
@@ -385,23 +385,58 @@ async fn mixed_level_snapshot_sort_is_deterministic() {
     let start = range.start_ns;
 
     // An unlisted L0 (survives) plus a compaction record with two parts.
-    let unlisted = l0_record(Uuid::new_v4(), 0, 9, HOUR, start + 100, start, start + 100);
-    let input = l0_record(Uuid::new_v4(), 0, 1, HOUR, start + 100, start, start + 100);
+    //
+    // Both writer ids are pinned rather than drawn. The snapshot sort
+    // tie-breaks on writer_id, so with random ids the only order this test
+    // could state is "whatever the previous resolve produced" -- which is
+    // satisfied by a sort that varies from run to run, exactly the property
+    // the test name claims is impossible. Pinned, the expected sequence is
+    // written down below, so a change to the sort key fails here instead of
+    // silently reordering snapshots.
+    let unlisted = l0_record(
+        Uuid::from_u128(0x9),
+        0,
+        9,
+        HOUR,
+        start + 100,
+        start,
+        start + 100,
+    );
+    let input = l0_record(
+        Uuid::from_u128(0x1),
+        0,
+        1,
+        HOUR,
+        start + 100,
+        start,
+        start + 100,
+    );
     put_l0(store.as_ref(), &unlisted).await;
     put_l0(store.as_ref(), &input).await;
-    put_compaction_record(
+    let parts = vec![
+        part(0, start, start + 100, 7),
+        part(1, start, start + 100, 3),
+    ];
+    let (compaction, _) = put_compaction_record(
         store.as_ref(),
         0,
         HOUR,
         &[&input],
-        vec![
-            part(0, start, start + 100, 7),
-            part(1, start, start + 100, 3),
-        ],
+        parts.clone(),
         start + 100,
         b"set-1",
     )
     .await;
+
+    // The two L1 parts share the compaction record's created_unix_ns with the
+    // surviving L0, so the sort falls through to writer_epoch/writer_seq: the
+    // parts carry 0 and the L0 carries seq 9, putting both parts first, in
+    // part_index order, with the L0 last.
+    let expected = vec![
+        keys::reconstruct_l1_part_key(&compaction, &parts[0]).expect("part 0 key"),
+        keys::reconstruct_l1_part_key(&compaction, &parts[1]).expect("part 1 key"),
+        keys::reconstruct_data_key(&unlisted).expect("unlisted L0 data key"),
+    ];
 
     let first = catalog
         .resolve(&tenant(), Signal::Metrics, range, &[], now)
@@ -421,7 +456,12 @@ async fn mixed_level_snapshot_sort_is_deterministic() {
         .iter()
         .map(|s| s.data_object_key.clone())
         .collect();
-    assert_eq!(order1, order2, "sort is a deterministic total order");
+    assert_eq!(
+        order1, expected,
+        "the sort is a fixed total order over fixed inputs, not merely a \
+         repeatable one"
+    );
+    assert_eq!(order2, expected, "and it repeats across resolves");
     assert_eq!(first.segments.len(), 3);
 }
 

--- a/crates/ravel-ingest/tests/backpressure_and_structure.rs
+++ b/crates/ravel-ingest/tests/backpressure_and_structure.rs
@@ -62,9 +62,13 @@ async fn full_channel_blocks_the_producer_instead_of_growing_memory() {
             .await;
     });
 
-    // Give the actor a chance to pick up the first write and block inside
-    // its flush before we start filling the channel behind it.
-    tokio::time::sleep(Duration::from_millis(20)).await;
+    // Wait for the actor to actually be held inside its flush before filling
+    // the channel behind it. Sleeping a fixed 20 ms here made the whole
+    // premise of the test ("the actor has stopped draining") a race: if the
+    // stall had not been entered yet, the actor was still draining and the
+    // channel never filled, so the "one more write blocks" assertion below
+    // would be measuring nothing.
+    stalling.wait_until_stalled().await;
 
     // Fill the channel to its configured depth with buffered writes. This
     // takes one write more than `channel_depth` under pipelined flushes

--- a/crates/ravel-ingest/tests/common/mod.rs
+++ b/crates/ravel-ingest/tests/common/mod.rs
@@ -370,6 +370,7 @@ pub struct StallingStore {
     hits: AtomicU64,
     gate: Notify,
     released: AtomicBool,
+    stalled: Notify,
 }
 
 impl StallingStore {
@@ -381,12 +382,31 @@ impl StallingStore {
             hits: AtomicU64::new(0),
             gate: Notify::new(),
             released: AtomicBool::new(false),
+            stalled: Notify::new(),
         }
     }
 
     pub fn release(&self) {
         self.released.store(true, Ordering::SeqCst);
         self.gate.notify_waiters();
+    }
+
+    /// Park until the `stall_on`-th matching `put` has entered the stall, so a
+    /// test can act on "the actor is now held mid-flush" as a fact rather than
+    /// sleeping for a while and hoping. Mirrors
+    /// `FaultStore::wait_until_held`. Returns immediately if the stall has
+    /// already been entered.
+    pub async fn wait_until_stalled(&self) {
+        loop {
+            if self.hits.load(Ordering::SeqCst) >= self.stall_on {
+                return;
+            }
+            let notified = self.stalled.notified();
+            if self.hits.load(Ordering::SeqCst) >= self.stall_on {
+                return;
+            }
+            notified.await;
+        }
     }
 
     async fn wait_for_release(&self) {
@@ -414,6 +434,7 @@ impl ObjectStoreBackend for StallingStore {
         if key.contains(self.key_contains.as_str()) {
             let hit = self.hits.fetch_add(1, Ordering::SeqCst) + 1;
             if hit == self.stall_on {
+                self.stalled.notify_waiters();
                 self.wait_for_release().await;
             }
         }

--- a/crates/ravel-ingest/tests/pinned_identity.rs
+++ b/crates/ravel-ingest/tests/pinned_identity.rs
@@ -10,7 +10,9 @@ use std::time::Duration;
 
 use common::{TestClock, make_point, tenant};
 use ravel_ingest::{IngestConfig, IngestRouter, WriteMode};
-use ravel_object_store::fault::{FaultPlan, FaultStore, Occurrence, Op, Rule, ScriptedFault};
+use ravel_object_store::fault::{
+    FaultKind, FaultPlan, FaultStore, Occurrence, Op, Rule, ScriptedFault,
+};
 use ravel_object_store::memory::MemoryStore;
 use ravel_object_store::{ObjectStoreBackend, list_all};
 use ravel_types::Signal;
@@ -31,7 +33,8 @@ async fn retry_across_hour_boundary_keeps_the_pinned_ingest_hour() {
             .with_key_contains("/l0/")
             .with_occurrence(Occurrence::Nth(1)),
     );
-    let store: Arc<dyn ObjectStoreBackend> = Arc::new(FaultStore::new(MemoryStore::new(), plan));
+    let fault_store = Arc::new(FaultStore::new(MemoryStore::new(), plan));
+    let store: Arc<dyn ObjectStoreBackend> = fault_store.clone();
     let clock = TestClock::new(start_ns);
     let config = IngestConfig {
         shard_count: 1,
@@ -65,7 +68,23 @@ async fn retry_across_hour_boundary_keeps_the_pinned_ingest_hour() {
             Duration::from_secs(5)
         ),
         async {
-            tokio::time::sleep(Duration::from_millis(5)).await;
+            // Advance only once the first data PUT has actually faulted, so
+            // the clock genuinely moves while the retry is in flight. A flat
+            // 5 ms sleep here could land after the flush had already closed
+            // on a fast host, leaving the hour assertion below trivially
+            // true and this test proving nothing.
+            let mut retried = false;
+            for _ in 0..2_000 {
+                if fault_store.fault_count(Op::Put, FaultKind::DuplicateDelivery) > 0 {
+                    retried = true;
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(1)).await;
+            }
+            assert!(
+                retried,
+                "the retry this test advances the clock across was never injected"
+            );
             clock.advance_ns(20_000_000_000);
         },
     );

--- a/crates/ravel-ingest/tests/pipelined_flushes.rs
+++ b/crates/ravel-ingest/tests/pipelined_flushes.rs
@@ -77,9 +77,12 @@ async fn pipelined_flushes_overlap_and_ack_isolation() {
             .await
     });
 
-    // Give the actor a beat to process acme's write and pin its flush before
-    // globex's write is even sent, so submission order is unambiguous.
-    tokio::time::sleep(Duration::from_millis(20)).await;
+    // Submission order must be unambiguous: the seq assertion at the end of
+    // this test is "acme was pinned first", and a 20 ms sleep here only made
+    // that likely. Acme's flush reaching the held data PUT proves the actor
+    // already processed acme's write and pinned its identity, so globex
+    // cannot be pinned first no matter how the runtime schedules it.
+    gate.wait_until_held(1).await;
 
     let globex_router = Arc::clone(&router);
     let globex_tenant = globex.clone();
@@ -279,7 +282,7 @@ async fn pipelining_reaches_the_full_configured_depth_of_three() {
     let gate = fault_store.hold(Op::Put, Some("/l0/".to_string()), Occurrence::Always);
 
     let mut writes = Vec::new();
-    for t in &tenants {
+    for (i, t) in tenants.iter().enumerate() {
         let router = Arc::clone(&router);
         let t = t.clone();
         writes.push(tokio::spawn(async move {
@@ -291,8 +294,10 @@ async fn pipelining_reaches_the_full_configured_depth_of_three() {
         // Stagger submission so the actor pins each flush's identity before
         // the next tenant's write is even sent; not load-bearing for this
         // test's assertion (unlike the ack-isolation test above), but keeps
-        // the three writes from racing each other into the channel.
-        tokio::time::sleep(Duration::from_millis(10)).await;
+        // the three writes from racing each other into the channel. Waiting
+        // for this tenant's own PUT to reach the gate is what a 10 ms sleep
+        // was approximating.
+        gate.wait_until_held(i + 1).await;
     }
 
     gate.wait_until_held(3).await;

--- a/crates/ravel-ingest/tests/router_drop_flush.rs
+++ b/crates/ravel-ingest/tests/router_drop_flush.rs
@@ -94,16 +94,22 @@ async fn dropping_router_flushes_buffered_points() {
     // (services/ravel-server/src/lib.rs).
     drop(router);
 
-    // Give the detached actor task time to notice the closed channel, flush,
-    // and stop. The MemoryStore PUTs complete promptly.
-    for _ in 0..10 {
-        tokio::task::yield_now().await;
+    // The detached actor task notices the closed channel, flushes, and stops
+    // on its own. Wait for the commit record it writes rather than for a flat
+    // 100 ms: a slow host then takes longer instead of failing, and a host
+    // that never writes one fails on the assertion below rather than on the
+    // length of a sleep.
+    let mut objects = Vec::new();
+    for _ in 0..2_000 {
+        objects = list_all(store.as_ref(), "t/").await.expect("list");
+        if objects.iter().any(|o| o.key.contains("/c/")) {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(1)).await;
     }
-    tokio::time::sleep(Duration::from_millis(100)).await;
 
     // The observable outcome: the buffered point was flushed, not silently
     // discarded. A data object and its commit record are now in the store.
-    let objects = list_all(store.as_ref(), "t/").await.expect("list");
     assert!(
         !objects.is_empty(),
         "dropping the router must flush buffered points, but the \

--- a/crates/ravel-maintain/src/audit_pipeline.rs
+++ b/crates/ravel-maintain/src/audit_pipeline.rs
@@ -422,6 +422,8 @@ async fn flush_batch(
 mod tests {
     use super::*;
 
+    use std::future::Future;
+    use std::task::Poll;
     use std::time::Duration;
 
     use ravel_commit::keys;
@@ -640,27 +642,32 @@ mod tests {
         let config = pipeline_config(1000, Duration::from_secs(3600));
         let pipeline = Arc::new(AuditPipeline::spawn(store.clone(), tenant, config));
 
-        // Submit in the background; these stay buffered (below max_batch, before
-        // max_age) so their `submit` futures are still pending.
-        let mut handles = Vec::new();
-        for i in 0..2 {
-            let pipeline = pipeline.clone();
-            handles.push(tokio::spawn(async move {
-                pipeline.submit(test_event(13_000 + i, 7)).await
-            }));
+        // Both events must be queued before the shutdown drain runs, or the
+        // drain has nothing to flush and this test asserts nothing. `submit`
+        // sends into the flush task's channel and only then awaits its
+        // completion oneshot, so polling each future exactly once puts both
+        // events in the queue and leaves both callers pending -- the state
+        // this test needs, established by construction rather than by giving
+        // two spawned tasks 50 ms of wall clock to get there.
+        let mut submissions: Vec<_> = (0..2)
+            .map(|i| Box::pin(pipeline.submit(test_event(13_000 + i, 7))))
+            .collect();
+        for submission in &mut submissions {
+            let first = std::future::poll_fn(|cx| Poll::Ready(submission.as_mut().poll(cx))).await;
+            assert!(
+                first.is_pending(),
+                "a buffered submit stays pending until its batch flushes"
+            );
         }
-        // Give the two submissions time to reach the flush task's buffer.
-        tokio::time::sleep(Duration::from_millis(50)).await;
 
         pipeline
             .shutdown()
             .await
             .expect("shutdown drains and flushes");
 
-        for handle in handles {
-            handle
+        for submission in submissions {
+            submission
                 .await
-                .expect("submit task")
                 .expect("a buffered event is flushed by shutdown, not discarded");
         }
         assert_eq!(

--- a/crates/ravel-promql/src/eval.rs
+++ b/crates/ravel-promql/src/eval.rs
@@ -3522,25 +3522,33 @@ mod tests {
     }
 
     #[test]
-    fn short_deadline_cancels_a_long_running_nested_subquery_evaluation() {
+    fn expired_deadline_cancels_a_long_running_nested_subquery_before_any_query() {
         // `max_over_time(up[1000s:1s])` over a 1000-step outer range (1000
         // points, 1s step) re-evaluates its ~1000-point inner subquery from
-        // scratch at every outer step: ~1,000,000 total
-        // evaluation points, comfortably under both the per-node
-        // `max_range_points` cap and the shared `max_total_eval_points`
-        // budget, so without a deadline this runs to completion -- measured
-        // separately at just over 1.5s in this same debug build. With a
-        // 20ms deadline, the evaluator's own `check_deadline` (fired inside
-        // the per-outer-step subquery re-evaluation loop, once per inner
-        // grid point too) must notice and stop well before that, not after
-        // running the full ~1,000,000-point computation and only then
-        // reporting a timeout: the assertion on `elapsed` is what tells the
-        // two apart, since a bug that dropped every `check_deadline` call
-        // would still return `DeadlineExceeded` eventually (via a future
-        // outer wrapper) but only after the full ~1.5s of work.
+        // scratch at every outer step: ~1,000,000 total evaluation points,
+        // comfortably under both the per-node `max_range_points` cap and the
+        // shared `max_total_eval_points` budget, so without a deadline this
+        // runs to completion, issuing one storage query per inner grid point
+        // (the same one-query-per-inner-point accounting
+        // `repeated_nested_subquery_reevaluation_is_rejected_by_shared_budget`
+        // pins at 30 queries for its 6x5 grid).
+        //
+        // `check_deadline` runs at the top of both the outer and the inner
+        // grid step, so with a deadline that is already in the past the
+        // evaluation must stop before it touches storage at all. The bug this
+        // rules out is an evaluator whose only deadline check is an outer
+        // wrapper: it would still return `DeadlineExceeded`, but only after
+        // running the full ~1,000,000-point computation, so `query_count`
+        // would read 1,000,000 rather than 0.
+        //
+        // The measure is work done, counted exactly, not wall clock. This
+        // test used to set a 20 ms deadline and assert `elapsed < 500 ms`
+        // against a workload measured at just over 1.5 s in this same debug
+        // build: a 3x margin over a figure that moves with host load, which
+        // is a red gate run on a busy host rather than a bug. A deadline in
+        // the past is in the past on every host.
         let source = one_series_source();
-        let deadline = Instant::now() + std::time::Duration::from_millis(20);
-        let start = Instant::now();
+        let deadline = Instant::now() - std::time::Duration::from_millis(1);
         let err = Evaluator::new()
             .with_deadline(deadline)
             .range(
@@ -3550,14 +3558,14 @@ mod tests {
                 1_000_000 + 999_000,
                 1_000,
             )
-            .expect_err("a deadline in the past relative to the workload must fire");
-        let elapsed = start.elapsed();
+            .expect_err("a deadline already in the past must fire");
         assert!(matches!(err, Error::DeadlineExceeded));
-        assert!(
-            elapsed < std::time::Duration::from_millis(500),
-            "evaluation must be cancelled soon after the 20ms deadline, not \
-             after running the full ~1,000,000-point computation (which \
-             takes over 1.5s in this same debug build); took {elapsed:?}"
+        assert_eq!(
+            source.query_count(),
+            0,
+            "an expired deadline must be noticed by the in-grid check before \
+             any storage query, not after the full 1,000,000-point \
+             computation with only an outer wrapper reporting the timeout"
         );
     }
 

--- a/services/ravel-cli/src/load.rs
+++ b/services/ravel-cli/src/load.rs
@@ -3877,7 +3877,12 @@ type = "i64"
     /// other PUT and every non-PUT call passes straight through.
     struct FirstPutHoldStore {
         inner: Arc<dyn ObjectStoreBackend>,
-        hold: Duration,
+        /// Hold the first data PUT until the decoder has queued this many
+        /// batches, then snapshot the count. The bounded decode channel is
+        /// what stops the decoder, so this target is reached (and not
+        /// exceeded) as a property of the code rather than of how many
+        /// batches the host managed inside a fixed hold.
+        hold_until_queued: usize,
         queued: Arc<std::sync::atomic::AtomicUsize>,
         first_seen: Arc<std::sync::atomic::AtomicBool>,
         snapshot: Arc<std::sync::Mutex<Option<usize>>>,
@@ -3893,7 +3898,14 @@ type = "i64"
         ) -> Result<ravel_object_store::PutOutcome, ravel_object_store::StoreError> {
             use std::sync::atomic::Ordering;
             if key.contains("/l0/") && !self.first_seen.swap(true, Ordering::SeqCst) {
-                tokio::time::sleep(self.hold).await;
+                // Bounded so a regression that stops the decoder short fails
+                // the assertion on the snapshot rather than hanging the suite.
+                for _ in 0..10_000 {
+                    if self.queued.load(Ordering::SeqCst) >= self.hold_until_queued {
+                        break;
+                    }
+                    tokio::time::sleep(Duration::from_millis(1)).await;
+                }
                 *self.snapshot.lock().expect("snapshot lock") =
                     Some(self.queued.load(Ordering::SeqCst));
             }
@@ -3993,7 +4005,12 @@ type = "i64"
         let snapshot = Arc::new(std::sync::Mutex::new(None));
         let store = Arc::new(FirstPutHoldStore {
             inner: Arc::new(MemoryStore::new()),
-            hold: Duration::from_millis(300),
+            // The channel bound stops the decoder at exactly this many
+            // (1 consumed by the loop + QUEUE_DEPTH buffered), which is also
+            // what the assertions below pin. Holding until the decoder gets
+            // there replaces a fixed 300 ms hold whose outcome was however
+            // many batches the host happened to decode in that window.
+            hold_until_queued: QUEUE_DEPTH + 1,
             queued: Arc::clone(&queued),
             first_seen: Arc::new(AtomicBool::new(false)),
             snapshot: Arc::clone(&snapshot),

--- a/services/ravel-server/src/maintain.rs
+++ b/services/ravel-server/src/maintain.rs
@@ -2193,9 +2193,18 @@ mod tests {
         // Two replicas, each with the default membership/timing. A single clock
         // reading for both heartbeats keeps both fresh within the liveness
         // window.
+        //
+        // Both process ids are pinned, for the reason [`PINNED_WORKER_ID`]
+        // records: rendezvous ownership is a pure function of the process id,
+        // so with two random ids the split this test is named for is a draw,
+        // not a fact. All 8 shards land on one replica one run in 256, and the
+        // old draw-independent assertions below (each shard owned by exactly
+        // one of the two, the two memos summing to the unit count) all still
+        // hold on that draw while proving nothing about partitioning. Pinned,
+        // the split itself is asserted.
         let now = 1_000 * TEST_NS_PER_HOUR;
-        let a = WorkerSet::with_defaults(now);
-        let b = WorkerSet::with_defaults(now);
+        let a = WorkerSet::with_defaults(now).with_process_id(PINNED_WORKER_ID);
+        let b = WorkerSet::with_defaults(now).with_process_id(PINNED_PEER_ID);
         a.write_heartbeat(&store, now).await.expect("a heartbeat");
         b.write_heartbeat(&store, now).await.expect("b heartbeat");
 
@@ -2209,8 +2218,8 @@ mod tests {
 
         // Ownership is computed identically by both, and every unit is owned by
         // exactly one replica (disjoint and complete).
-        let mut owned_by_a = 0u32;
-        let mut owned_by_b = 0u32;
+        let mut a_shards = Vec::new();
+        let mut b_shards = Vec::new();
         for shard in 0..SHARDS {
             let a_owns = a.owns_unit(&live_a, &tenant, Signal::Metrics, shard);
             let b_owns = b.owns_unit(&live_b, &tenant, Signal::Metrics, shard);
@@ -2219,11 +2228,28 @@ mod tests {
                 "shard {shard} must be owned by exactly one of the two replicas"
             );
             if a_owns {
-                owned_by_a += 1;
+                a_shards.push(shard);
             } else {
-                owned_by_b += 1;
+                b_shards.push(shard);
             }
         }
+        // The exact split the two pinned ids produce under (acme, Metrics).
+        // Any other partition, including one that still leaves both replicas
+        // non-empty, means `unit_key` or the weight function changed and the
+        // ids must be re-pinned deliberately; the same expected split is
+        // asserted in `reseed_and_seeding_track_genuine_ownership_handoff`.
+        assert_eq!(
+            a_shards,
+            [1, 2, 3, 4, 5, 7],
+            "PINNED_WORKER_ID's rendezvous share under (acme, Metrics) moved"
+        );
+        assert_eq!(
+            b_shards,
+            [0, 6],
+            "PINNED_PEER_ID's rendezvous share under (acme, Metrics) moved"
+        );
+        let owned_by_a = a_shards.len() as u32;
+        let owned_by_b = b_shards.len() as u32;
         assert_eq!(owned_by_a + owned_by_b, SHARDS, "every unit is owned");
 
         // Run both replicas' ticks over the same tenant, each with its own cold

--- a/services/ravel-server/tests/ingest_concurrency_e2e.rs
+++ b/services/ravel-server/tests/ingest_concurrency_e2e.rs
@@ -161,6 +161,40 @@ async fn drain_until_done<T>(gate: &GateHandle, tasks: &[tokio::task::JoinHandle
     .expect("held requests drain within 10s");
 }
 
+/// Poll `/metrics` until `want` metric points have been admitted into shard
+/// buffers, which is the precondition the shedding tests need: a request whose
+/// point is buffered has already passed the in-flight ingest ceiling and is
+/// parked awaiting its flush's ack, so it is holding one of the permits. The
+/// counter is monotonic, so this cannot see a transient. Returns the last
+/// value read, for the assertion's message.
+async fn wait_for_buffered_items(client: &reqwest::Client, base: &str, want: u64) -> u64 {
+    let mut seen = 0;
+    for _ in 0..1_000 {
+        let body = client
+            .get(format!("{base}/metrics"))
+            .send()
+            .await
+            .expect("metrics scrape completes")
+            .text()
+            .await
+            .expect("metrics body is text");
+        seen = body
+            .lines()
+            .find(|line| {
+                line.starts_with("ravel_ingest_buffered_items_total")
+                    && line.contains("signal=\"metrics\"")
+            })
+            .and_then(|line| line.rsplit(' ').next())
+            .and_then(|value| value.parse::<u64>().ok())
+            .unwrap_or(0);
+        if seen >= want {
+            return seen;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    seen
+}
+
 async fn durable_metric_object_count(store: &dyn ObjectStoreBackend) -> usize {
     let prefix = format!("t/{}/m/l0/", TenantId::new(TENANT).hash().to_hex());
     list_all(store, &prefix)
@@ -204,11 +238,18 @@ async fn http_third_concurrent_request_over_limit_is_shed() {
         })
         .collect();
 
-    // Give the two admitted requests time to pass admission, enqueue on the
-    // shard, and (once the shard's flush timer fires) reach the held PUT --
-    // all far faster than it takes for either task to finish, since finishing
-    // requires this test to release the gate first.
-    tokio::time::sleep(Duration::from_millis(300)).await;
+    // Both admitted requests must have passed the ceiling and be parked
+    // awaiting their flush before the third is sent: the ceiling has to be
+    // saturated for the third to be shed at all. Waiting for both points to
+    // reach a shard buffer proves it. The 300 ms sleep this replaces only made
+    // it likely, and on a host slow enough to miss the window the third
+    // request is admitted and the 429 assertion below fails for a scheduling
+    // reason rather than a product one.
+    let buffered = wait_for_buffered_items(&client, &base, 2).await;
+    assert_eq!(
+        buffered, 2,
+        "both admitted requests must have buffered their point, so both hold a permit"
+    );
     assert!(
         held_tasks.iter().all(|t| !t.is_finished()),
         "both admitted requests must still be in flight, blocked on the held flush"
@@ -289,6 +330,7 @@ async fn grpc_third_concurrent_request_over_limit_is_shed() {
     let store: Arc<dyn ObjectStoreBackend> = fault.clone();
     let running = start_test_server(store.clone(), IngestConcurrencyLimit::Bounded(2)).await;
     let grpc_addr = running.grpc_addr.expect("gateway mode binds gRPC");
+    let http_base = format!("http://{}", running.http_addr);
 
     let data_key_prefix = format!("t/{}/m/l0/", TenantId::new(TENANT).hash().to_hex());
     let gate = fault.hold(Op::Put, Some(data_key_prefix), Occurrence::Always);
@@ -315,7 +357,13 @@ async fn grpc_third_concurrent_request_over_limit_is_shed() {
         })
         .collect();
 
-    tokio::time::sleep(Duration::from_millis(300)).await;
+    // Same saturation precondition as the HTTP case above, waited for rather
+    // than slept through.
+    let buffered = wait_for_buffered_items(&reqwest::Client::new(), &http_base, 2).await;
+    assert_eq!(
+        buffered, 2,
+        "both admitted gRPC requests must have buffered their point, so both hold a permit"
+    );
     assert!(
         held_tasks.iter().all(|t| !t.is_finished()),
         "both admitted gRPC requests must still be in flight, blocked on the held flush"

--- a/services/ravel-server/tests/maintain_ownership_metrics_e2e.rs
+++ b/services/ravel-server/tests/maintain_ownership_metrics_e2e.rs
@@ -248,22 +248,20 @@ async fn two_maintain_workers_reach_and_report_full_ownership_on_real_metrics() 
     );
 
     // A fresh discovery cycle must run under the now-converged live set
-    // before `units_owned` reflects the final partition; the maintenance
-    // interval is 1s, so this comfortably waits for one.
-    tokio::time::sleep(Duration::from_secs(3)).await;
-
-    // A single scrape pair can race `run_discovery_cycle`'s
-    // `set_units_owned(0)`-then-accumulate window (maintain.rs): a scrape
-    // landing between one worker's reset and its tenant loop finishing sees
-    // a transient undercount. Poll a short, bounded number of times rather
-    // than lengthening the fixed sleep above -- the reset window is a few
-    // microseconds, so this almost always succeeds on the first scrape and
-    // only retries across a genuine race.
+    // before `units_owned` reflects the final partition (the maintenance
+    // interval is 1s), and a single scrape pair can also race
+    // `run_discovery_cycle`'s `set_units_owned(0)`-then-accumulate window
+    // (maintain.rs): a scrape landing between one worker's reset and its
+    // tenant loop finishing sees a transient undercount. Both are covered by
+    // polling to the same total window this used to spend as a fixed 3s sleep
+    // plus a shorter poll. A fixed sleep in front of a bounded poll only
+    // lengthens the test: it cannot make a slow discovery cycle arrive, and
+    // the poll already tolerates one.
     let expected_total = u64::from(SHARD_COUNT) * 3;
     let mut owned_a = 0;
     let mut owned_b = 0;
     let mut settled = false;
-    for _ in 0..25 {
+    for _ in 0..40 {
         let body_a = scrape(&client, &base_a).await;
         let body_b = scrape(&client, &base_b).await;
         owned_a = sample_value(&body_a, "ravel_maintain_units_owned{mode=\"maintain\"}")


### PR DESCRIPTION
Seven test suites asserted on wall-clock behavior: fixed sleeps standing in
for a condition, elapsed-time bands standing in for work done, and a repeat
of an order standing in for the order itself. Each is a flake waiting for a
slow or busy runner, and several had already cost gate reruns.

Each suite now waits on the thing it means. The cache single-flight tests
gate on the injected hold rather than sleeping. The catalog test asserts the
exact snapshot order instead of asserting it twice. The maintain audit test
queues its events before the shutdown drain rather than racing it. The
ingest tests wait on an injected hold. The promql deadline test counts the
work the deadline stopped rather than the seconds it took. The server test
pins the replica split and waits on the ceiling. The loader test holds the
first PUT on the queue depth rather than for 300 ms.

This is a partial sweep. Issue #778 stays open: candidate sites remain, and
they need triage rather than a blind pass, because not every sleep in a test
is a defect and an unpinned identifier only matters where a test asserts on
something derived from it.

Refs: #778
