### PR TITLE
fix(sql): attribute spill-disabled refusals to pool occupancy

### DIFF
--- a/crates/ravel-sql/src/config.rs
+++ b/crates/ravel-sql/src/config.rs
@@ -41,6 +41,47 @@ pub const DEFAULT_MAX_QUERY_BYTES: usize = 256 * 1024 * 1024;
 /// 105 columns and sorts and filters on two, i.e. 103 surplus columns.
 pub const DEFAULT_LATE_MATERIALIZATION_EXTRA_COLUMNS: usize = 8;
 
+/// Under-count of DataFusion 54's `GroupValues::size()` against the real
+/// hashbrown allocation of the group-key table (issue #740, finding 2).
+/// `size()` charges `capacity() * entry_size`, where `capacity()` is the
+/// table's usable slot count at the 7/8 load factor, and it counts no control
+/// bytes. The real allocation is `buckets * entry_size` (with
+/// `buckets = capacity / (7/8)`) plus one control byte per bucket and the
+/// group width, so for an Int64 group table (16-byte entry: value plus group
+/// index) the ratio is `(8/7) * ((entry_size + 1) / entry_size) = 8*17/(7*16)
+/// = 1.2143`, which the #740 trace saw as 570 MB real against 470 MB reported
+/// for 17M groups. Rounded up to two decimals so the factor is an upper
+/// bound on the under-count, not an estimate of it.
+pub const GROUP_VALUES_UNDERCOUNT_FACTOR: f64 = 1.22;
+
+/// Transient over-allocation while a hashbrown group table doubles (issue
+/// #740, finding 3). A grow allocates the new table before freeing the old,
+/// so a doubling holds `old + new = steady/2 + steady = 1.5 * steady` at its
+/// peak, and DataFusion grows the pool reservation only after the resize
+/// completes (`row_hash.rs` ~745/793), so the pool holds the pre-batch figure
+/// while that transient peak is live. The peak is bounded at 1.5x the settled
+/// real size because hashbrown never grows by more than doubling.
+pub const GROUP_VALUES_RESIZE_TRANSIENT_FACTOR: f64 = 1.5;
+
+/// Combined compensation applied to a reported `GroupValues::size()` figure to
+/// bound the real peak the pool must survive: the under-count times the resize
+/// transient, `1.22 * 1.5 = 1.83`. Both defects are upstream in DataFusion 54
+/// (documented in the ADR-0102 amendment for #740); this crate cannot fix
+/// either from outside DataFusion, so it compensates its own ceiling math by
+/// this factor rather than trusting the reported figure. See
+/// [`compensated_group_values_ceiling`].
+pub const GROUP_VALUES_CEILING_COMPENSATION: f64 =
+    GROUP_VALUES_UNDERCOUNT_FACTOR * GROUP_VALUES_RESIZE_TRANSIENT_FACTOR;
+
+/// Inflate a reported `GroupValues::size()` estimate to an upper bound on the
+/// real hashbrown peak, by [`GROUP_VALUES_CEILING_COMPENSATION`]. A caller
+/// sizing an aggregate stage against the memory budget must compare the budget
+/// to this, not to the raw `size()`, or a table that reports fitting will in
+/// fact allocate up to 1.83x that and overrun (issue #740, findings 2 and 3).
+pub fn compensated_group_values_ceiling(reported_size: usize) -> usize {
+    ((reported_size as f64) * GROUP_VALUES_CEILING_COMPENSATION).ceil() as usize
+}
+
 /// Per-query ravel-sql configuration: the shared engine budgets plus the
 /// SQL-only per-query memory-pool byte budget.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/ravel-sql/src/config.rs
+++ b/crates/ravel-sql/src/config.rs
@@ -80,7 +80,25 @@ pub const GROUP_VALUES_CEILING_COMPENSATION: f64 =
 /// fact allocate up to 1.83x that and overrun (issue #740, findings 2 and 3).
 pub fn compensated_group_values_ceiling(reported_size: usize) -> usize {
     ((reported_size as f64) * GROUP_VALUES_CEILING_COMPENSATION).ceil() as usize
+        + GROUP_VALUES_FIXED_OVERHEAD_CEILING
 }
+
+/// Control-group bytes hashbrown allocates alongside the buckets that
+/// `GroupValues::size()` counts in neither its capacity nor its entry width.
+/// Unlike the per-bucket control byte, which is a fixed fraction of the
+/// reported figure and is therefore covered by the multiplicative
+/// compensation, this part does not scale, so a purely multiplicative ceiling
+/// under-bounds every small table.
+const GROUP_VALUES_FIXED_OVERHEAD_BYTES: usize = 16;
+
+/// [`GROUP_VALUES_FIXED_OVERHEAD_BYTES`] carried through the same resize
+/// transient the multiplicative factor models, so the sum is an upper bound at
+/// every table size rather than only asymptotically. Without it the ceiling is
+/// below the modelled peak for every table under roughly 512 buckets: at 8
+/// buckets the reported figure is 112, the real allocation 152, the modelled
+/// peak 228, and the multiplicative ceiling alone returns 205.
+const GROUP_VALUES_FIXED_OVERHEAD_CEILING: usize =
+    (GROUP_VALUES_FIXED_OVERHEAD_BYTES as f64 * GROUP_VALUES_RESIZE_TRANSIENT_FACTOR) as usize + 1;
 
 /// Per-query ravel-sql configuration: the shared engine budgets plus the
 /// SQL-only per-query memory-pool byte budget.

--- a/crates/ravel-sql/src/error.rs
+++ b/crates/ravel-sql/src/error.rs
@@ -75,6 +75,21 @@ pub const MSG_EXECUTION: &str = "the SQL query failed during execution";
 /// bugs; the caller gets nothing actionable and the server logs everything.
 pub const MSG_INTERNAL: &str = "internal query engine error";
 
+/// Substring DataFusion embeds in the `ResourcesExhausted` a spill-capable
+/// operator raises when the pool refuses its `try_grow` and the disk manager
+/// is disabled (ADR-0102 decision 3): an external sort raises
+/// `"Memory Exhausted while Sorting (DiskManager is disabled)"`, a
+/// `RepartitionExec` output channel `"... while SpillPool (DiskManager is
+/// disabled)"`.
+///
+/// The text names the operator that HOLDS the reservation it could not grow
+/// (the exchange, the sorter), not the consumer that FILLED the pool (the
+/// aggregate hash tables), and carries no byte figures. On its own it
+/// misattributes the exhaustion and tells the caller nothing about how close
+/// to the limit the query was. [`SqlError::resources_exhausted_reattributed`]
+/// rewrites it from the pool's own occupancy at the moment of refusal.
+pub const MSG_SPILL_DISABLED_MARKER: &str = "DiskManager is disabled";
+
 /// The client-visible class of a [`SqlError`]. The HTTP layer maps this to
 /// a status code and an error-type tag; it never inspects the error itself.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -239,6 +254,37 @@ pub enum SqlError {
 }
 
 impl SqlError {
+    /// Re-attribute a disabled-disk-manager spill refusal to the pool that
+    /// actually filled, from the pool's `used`/`limit` at the moment of
+    /// refusal (read from `MemoryPool::reserved()` and its configured limit).
+    ///
+    /// When `raw` carries [`MSG_SPILL_DISABLED_MARKER`], DataFusion has named
+    /// the spilling operator (the sort, the `RepartitionExec` exchange) and
+    /// supplied no byte figures. This replaces that message with the query
+    /// pool's occupancy: attribution is by CONSUMER, not by holder -- the
+    /// figures are the whole query pool's `used`/`limit` (what the aggregate
+    /// tables filled), not the spilling exchange's own small reservation, and
+    /// the message says so. When `raw` is not a spill-disabled message it is
+    /// returned unchanged as a plain [`SqlError::ResourcesExhausted`], so a
+    /// caller can route every native `ResourcesExhausted` through this without
+    /// classifying it first.
+    ///
+    /// The rewritten text carries only byte counts and a limit -- no object
+    /// key, no tenant identity -- so it echoes to the client verbatim like the
+    /// other budget errors ([`SqlError::client_message`]).
+    pub fn resources_exhausted_reattributed(raw: &str, used: usize, limit: usize) -> Self {
+        if raw.contains(MSG_SPILL_DISABLED_MARKER) {
+            SqlError::ResourcesExhausted(format!(
+                "the query memory pool is full and spill is disabled: {used} of {limit} bytes \
+                 reserved across the query's operators when a spill was requested (attribution \
+                 is by the consumers that filled the pool, not the operator that requested the \
+                 spill)"
+            ))
+        } else {
+            SqlError::ResourcesExhausted(raw.to_string())
+        }
+    }
+
     /// The client-visible class, for HTTP status selection.
     pub fn class(&self) -> ErrorClass {
         match self {

--- a/crates/ravel-sql/src/executor.rs
+++ b/crates/ravel-sql/src/executor.rs
@@ -80,7 +80,7 @@ use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion};
 use datafusion::dataframe::DataFrame;
 use datafusion::error::DataFusionError;
 use datafusion::execution::SendableRecordBatchStream;
-use datafusion::execution::memory_pool::{MemoryPool, UnboundedMemoryPool};
+use datafusion::execution::memory_pool::{MemoryLimit, MemoryPool, UnboundedMemoryPool};
 use datafusion::logical_expr::{Aggregate, Distinct, Expr, ExprSchemable, LogicalPlan};
 use datafusion::physical_plan::{ExecutionPlan, execute_stream};
 use datafusion::prelude::SessionContext;
@@ -1153,6 +1153,14 @@ pub struct PinnedStream {
     /// whose poll unwound is left in whatever state the panic interrupted, so
     /// it is never polled again; this fuses it instead.
     panicked: bool,
+    /// The pool installed on `ctx`'s `RuntimeEnv` (issue #740). Read at every
+    /// execution-error mapping so a `ResourcesExhausted` DataFusion raises
+    /// against a spill-capable operator (which names the operator holding the
+    /// reservation, not the consumer that filled it) can be re-attributed from
+    /// this pool's own `used`/`limit`, the same pool `try_grow` refused
+    /// against. Derived from `ctx` in [`Self::start`] rather than threaded in
+    /// separately, so no caller of `start` changes.
+    pool: Arc<dyn MemoryPool>,
 }
 
 impl PinnedStream {
@@ -1170,6 +1178,12 @@ impl PinnedStream {
         schema: SchemaRef,
         breach: Arc<CeilingBreach>,
     ) -> Result<Self, SqlError> {
+        // The same pool `build_session` installed on `ctx`'s `RuntimeEnv`
+        // (`crate::session`), read back here rather than passed in: every
+        // `ResourcesExhausted` this stream maps needs it, and deriving it from
+        // `ctx` keeps every `start` caller (the local path, the Flight SQL
+        // worker fragment, and the panic-boundary test) unchanged.
+        let pool = Arc::clone(&ctx.runtime_env().memory_pool);
         let inner = execute_stream(Arc::clone(&plan), ctx.task_ctx()).map_err(plan_error)?;
         Ok(PinnedStream {
             _ctx: ctx,
@@ -1178,6 +1192,7 @@ impl PinnedStream {
             breach,
             plan,
             panicked: false,
+            pool,
         })
     }
 
@@ -1239,7 +1254,10 @@ impl Stream for PinnedStream {
             self.inner.poll_next_unpin(cx)
         }));
         match polled {
-            Ok(next) => next.map(|next| next.map(|batch| batch.map_err(execution_error))),
+            Ok(next) => {
+                let pool = Arc::clone(&self.pool);
+                next.map(|next| next.map(|batch| batch.map_err(|e| execution_error(e, &pool))))
+            }
             Err(payload) => {
                 self.panicked = true;
                 // `payload.as_ref()`, not `&payload`: coercing the `Box`
@@ -1336,13 +1354,37 @@ fn plan_error(err: DataFusionError) -> SqlError {
 /// message can distinguish "this query cannot be planned" from "this query
 /// failed while running", which is the only diagnostic signal that survives
 /// redaction.
-fn execution_error(err: DataFusionError) -> SqlError {
-    match take_sql_error(err) {
+///
+/// `pool` is the stream's own `MemoryPool` (issue #740): a `ResourcesExhausted`
+/// reaching here can be a spill-capable operator's refusal (a `RepartitionExec`
+/// exchange or an external sort, named by DataFusion's own message, with no
+/// byte figures) rather than this pool's own `try_grow` text (which already
+/// names its budget and figures). [`SqlError::resources_exhausted_reattributed`]
+/// tells the two apart and rewrites only the former, from `pool`'s occupancy at
+/// this moment; the caller does not need to classify the message itself.
+///
+/// `take_sql_error` already unwraps a `ResourcesExhausted` at any wrapper depth
+/// into `Ok(SqlError::ResourcesExhausted(msg))` (its own doc comment above),
+/// so the re-attribution runs after that recovery, on the recovered
+/// `SqlError::ResourcesExhausted` itself, not in the `Err` branch below (which
+/// a bare or wrapped `ResourcesExhausted` never reaches).
+fn execution_error(err: DataFusionError, pool: &Arc<dyn MemoryPool>) -> SqlError {
+    let sql = match take_sql_error(err) {
         Ok(sql) => sql,
         Err(other) => match other {
             DataFusionError::ResourcesExhausted(msg) => SqlError::ResourcesExhausted(msg),
-            other => SqlError::Execution(other.to_string()),
+            other => return SqlError::Execution(other.to_string()),
         },
+    };
+    match sql {
+        SqlError::ResourcesExhausted(msg) => {
+            let limit = match pool.memory_limit() {
+                MemoryLimit::Finite(limit) => limit,
+                MemoryLimit::Infinite | MemoryLimit::Unknown => usize::MAX,
+            };
+            SqlError::resources_exhausted_reattributed(&msg, pool.reserved(), limit)
+        }
+        other => other,
     }
 }
 
@@ -2049,10 +2091,55 @@ mod tests {
 
     #[test]
     fn resources_exhausted_keeps_its_own_counts() {
+        // A message without MSG_SPILL_DISABLED_MARKER is not DataFusion's
+        // spill-refusal shape (issue #740); `execution_error` must pass it
+        // through unchanged rather than substituting the pool's own figures,
+        // so the pool here is a throwaway the reattribution never reads.
+        let pool: Arc<dyn MemoryPool> = Arc::new(UnboundedMemoryPool::default());
         let df = DataFusionError::ResourcesExhausted("needs 40 bytes, limit 8".to_string());
-        let err = execution_error(df);
+        let err = execution_error(df, &pool);
         assert!(matches!(err, SqlError::ResourcesExhausted(_)));
         assert!(err.client_message().contains("limit 8"));
+    }
+
+    /// Issue #740, finding 1: a `RepartitionExec` output channel's spill
+    /// refusal (DataFusion 54's `"... SpillPool (DiskManager is disabled)"`,
+    /// carrying no byte figures) is re-attributed from the stream's own pool
+    /// occupancy at the moment of refusal, not passed through with the
+    /// exchange's name and no figures. Exercises the real seam
+    /// [`execution_error`] runs at (issue #740's named caller,
+    /// [`PinnedStream::poll_next`]'s `batch.map_err`), with a real
+    /// `TenantDelegatingPool` reserved to a known figure rather than a bare
+    /// `resources_exhausted_reattributed` unit call.
+    #[test]
+    fn a_spill_refusal_from_the_streams_own_pool_names_its_occupancy() {
+        use datafusion::execution::memory_pool::MemoryConsumer;
+
+        let tenant = TenantMemoryAccountant::new(1 << 30);
+        let pool: Arc<dyn MemoryPool> = Arc::new(crate::memory::TenantDelegatingPool::new(
+            8000,
+            tenant,
+            CeilingBreach::new(),
+            QueryAccounting::new(),
+        ));
+        let consumer = MemoryConsumer::new("GroupedHashAggregateStream[0]").register(&pool);
+        consumer.try_grow(6144).expect("within the query ceiling");
+
+        let df = DataFusionError::ResourcesExhausted(
+            "Memory Exhausted while SpillPool (DiskManager is disabled)".to_string(),
+        );
+        let err = execution_error(df, &pool);
+        let SqlError::ResourcesExhausted(message) = &err else {
+            panic!("still a typed ResourcesExhausted; got {err:?}");
+        };
+        assert!(
+            message.contains("6144") && message.contains("8000"),
+            "message must name the pool's reserved bytes and limit; got {message:?}"
+        );
+        assert!(
+            !message.contains("SpillPool"),
+            "the exchange's own name must not survive re-attribution; got {message:?}"
+        );
     }
 
     /// ADR-0094 report sanity check: the analyzer step

--- a/crates/ravel-sql/src/lib.rs
+++ b/crates/ravel-sql/src/lib.rs
@@ -99,7 +99,11 @@ pub use audit_pushdown::{AuditPushdown, extract_audit};
 pub use audit_schema::{
     AUDIT_COL_ATTRS, AUDIT_COL_BODY, AUDIT_COL_SEVERITY_TEXT, AUDIT_COL_TS, audit_schema,
 };
-pub use config::{DEFAULT_LATE_MATERIALIZATION_EXTRA_COLUMNS, DEFAULT_MAX_QUERY_BYTES, SqlConfig};
+pub use config::{
+    DEFAULT_LATE_MATERIALIZATION_EXTRA_COLUMNS, DEFAULT_MAX_QUERY_BYTES,
+    GROUP_VALUES_CEILING_COMPENSATION, GROUP_VALUES_RESIZE_TRANSIENT_FACTOR,
+    GROUP_VALUES_UNDERCOUNT_FACTOR, SqlConfig, compensated_group_values_ceiling,
+};
 pub use declared::{DeclaredColumn, DeclaredColumnSource, DeclaredType, StaticDeclaredColumns};
 #[cfg(feature = "flight-sql")]
 pub use distributed::{
@@ -114,8 +118,8 @@ pub use distributed_rlog::{
     sort_slice_fragment,
 };
 pub use error::{
-    ErrorClass, MSG_CORRUPT, MSG_EXECUTION, MSG_INTERNAL, MSG_PLAN, MSG_UNAVAILABLE,
-    MSG_UNSATISFIABLE, SqlError,
+    ErrorClass, MSG_CORRUPT, MSG_EXECUTION, MSG_INTERNAL, MSG_PLAN, MSG_SPILL_DISABLED_MARKER,
+    MSG_UNAVAILABLE, MSG_UNSATISFIABLE, SqlError,
 };
 pub use executor::{PinnedQuery, PinnedStream, SqlExecutor, SqlOutcome, SqlRequest, SqlStats};
 #[cfg(feature = "flight-sql")]

--- a/crates/ravel-sql/src/memory.rs
+++ b/crates/ravel-sql/src/memory.rs
@@ -98,14 +98,16 @@ impl TenantMemoryAccountant {
     }
 
     /// Reserve `additional` bytes if doing so stays at or under the ceiling.
-    /// Returns `Err` (reserving nothing) when it would overflow the tenant
-    /// budget. CAS loop so concurrent queries account correctly.
-    fn try_grow(&self, additional: usize) -> Result<(), ()> {
+    /// Returns `Err(used)` (reserving nothing) when it would overflow the
+    /// tenant budget, where `used` is the bytes reserved at the moment of
+    /// refusal so the caller can name the pool's occupancy, not just the
+    /// rejected delta. CAS loop so concurrent queries account correctly.
+    fn try_grow(&self, additional: usize) -> Result<(), usize> {
         let mut cur = self.used.load(Ordering::Acquire);
         loop {
             let next = cur.saturating_add(additional);
             if next > self.limit {
-                return Err(());
+                return Err(cur);
             }
             match self
                 .used
@@ -216,13 +218,14 @@ impl TenantDelegatingPool {
     }
 
     /// Reserve `additional` against the query budget only. CAS loop; returns
-    /// the new query total on success, reserving nothing on overflow.
-    fn query_try_grow(&self, additional: usize) -> Result<usize, ()> {
+    /// the new query total on success, and `Err(used)` reserving nothing on
+    /// overflow, where `used` is the bytes reserved at the moment of refusal.
+    fn query_try_grow(&self, additional: usize) -> Result<usize, usize> {
         let mut cur = self.query_used.load(Ordering::Acquire);
         loop {
             let next = cur.saturating_add(additional);
             if next > self.query_limit {
-                return Err(());
+                return Err(cur);
             }
             match self.query_used.compare_exchange_weak(
                 cur,
@@ -318,20 +321,22 @@ impl MemoryPool for TenantDelegatingPool {
     fn try_grow(&self, _reservation: &MemoryReservation, additional: usize) -> DFResult<()> {
         // Query budget first: a query must trip its own pool before it can
         // threaten the tenant budget.
-        let query_total = self.query_try_grow(additional).map_err(|()| {
+        let query_total = self.query_try_grow(additional).map_err(|used| {
             DataFusionError::ResourcesExhausted(format!(
-                "query memory pool exhausted: {additional} more bytes exceeds per-query limit {}",
+                "query memory pool exhausted: {additional} more bytes on top of {used} \
+                 already reserved exceeds per-query limit {}",
                 self.query_limit
             ))
         })?;
         self.accounting
             .observe_intermediate_bytes(query_total as u64);
-        if self.tenant.try_grow(additional).is_err() {
+        if let Err(used) = self.tenant.try_grow(additional) {
             // Roll the query reservation back so a tenant-budget failure
             // leaves nothing reserved on either budget.
             self.query_shrink(additional);
             return Err(DataFusionError::ResourcesExhausted(format!(
-                "tenant memory budget exhausted: {additional} more bytes exceeds tenant limit {}",
+                "tenant memory budget exhausted: {additional} more bytes on top of {used} \
+                 already reserved exceeds tenant limit {}",
                 self.tenant.limit()
             )));
         }

--- a/crates/ravel-sql/src/memory.rs
+++ b/crates/ravel-sql/src/memory.rs
@@ -328,8 +328,6 @@ impl MemoryPool for TenantDelegatingPool {
                 self.query_limit
             ))
         })?;
-        self.accounting
-            .observe_intermediate_bytes(query_total as u64);
         if let Err(used) = self.tenant.try_grow(additional) {
             // Roll the query reservation back so a tenant-budget failure
             // leaves nothing reserved on either budget.
@@ -340,6 +338,12 @@ impl MemoryPool for TenantDelegatingPool {
                 self.tenant.limit()
             )));
         }
+        // Observed only once BOTH budgets have granted the growth. Recording it
+        // before the tenant check leaves a peak for bytes that no successful
+        // reservation ever held, because the query reservation above is rolled
+        // back on a tenant refusal: the peak would outlive the allocation.
+        self.accounting
+            .observe_intermediate_bytes(query_total as u64);
         Ok(())
     }
 

--- a/crates/ravel-sql/tests/memory_ceiling_and_budget_errors.rs
+++ b/crates/ravel-sql/tests/memory_ceiling_and_budget_errors.rs
@@ -431,13 +431,17 @@ async fn a_high_cardinality_aggregation_is_refused_by_the_aggregate_not_the_scan
 
 /// ADR-0102 decision 3: with the disk manager disabled, a large `ORDER BY` that
 /// overruns the budget through DataFusion's external sort also fails as
-/// `SqlError::ResourcesExhausted` -- but its message originates in
+/// `SqlError::ResourcesExhausted`. Its raw message originates in
 /// `DiskManager::create_tmp_file`
 /// (`"Memory Exhausted while Sorting (DiskManager is disabled)"`), propagated as
-/// `DataFusionError::ResourcesExhausted` and mapped to the same
-/// `SqlError::ResourcesExhausted` variant the aggregation path uses. Same typed
-/// variant, distinct message from the aggregation case (which is the pool's
-/// `try_grow` text) -- confirmed here by matching the disk-manager wording.
+/// `DataFusionError::ResourcesExhausted` -- the same pass-through shape issue
+/// #740 (finding 1) covers for the aggregation/exchange path: it names the
+/// operator that asked to spill, not the consumers that filled the pool, and
+/// carries no byte figures. `execution_error` re-attributes it the same way,
+/// via `SqlError::resources_exhausted_reattributed` keying off
+/// `MSG_SPILL_DISABLED_MARKER` ("DiskManager is disabled") in the raw message,
+/// so the client-visible text below no longer contains that literal DataFusion
+/// wording; it names the pool's own occupancy and limit instead.
 ///
 /// `ORDER BY value` forces a real external sort: the pipeline output is already
 /// ordered by `(series_id, ts)`, so ordering by `ts` alone could be elided,
@@ -445,9 +449,10 @@ async fn a_high_cardinality_aggregation_is_refused_by_the_aggregate_not_the_scan
 ///
 /// Prove-the-test: with the `with_disk_manager_builder(...Disabled)` line
 /// removed, the sorter's spill attempt reaches the default `OsTmpDirectory`
-/// disk manager and the overrun instead surfaces as the pool's
-/// `"query memory pool exhausted: ..."` error (no disk-manager wording), so the
-/// `contains("DiskManager is disabled")` assertion below fails. Verified by
+/// disk manager and the overrun instead surfaces as the pool's own
+/// `"query memory pool exhausted: ..."` `try_grow` refusal, which does not
+/// contain `MSG_SPILL_DISABLED_MARKER` and so is passed through unchanged --
+/// the `contains("spill is disabled")` assertion below fails. Verified by
 /// removing the line and observing that exact message.
 #[tokio::test]
 async fn a_large_order_by_over_budget_is_resources_exhausted() {
@@ -484,14 +489,35 @@ async fn a_large_order_by_over_budget_is_resources_exhausted() {
         matches!(err, SqlError::ResourcesExhausted(_)),
         "ORDER BY over budget must fail typed rather than spill; got {err:?}"
     );
-    // The sort path's message originates from the disabled disk manager, a
-    // different source than the aggregation path's pool `try_grow`; both are the
-    // same typed variant, and the distinct message is expected.
+    // The sort path's raw message originates from the disabled disk manager, a
+    // different source than the aggregation path's pool `try_grow` text; both
+    // are re-attributed to the same client-visible shape by `execution_error`
+    // (issue #740), so both assert the reattributed wording, not DataFusion's
+    // own text.
     let SqlError::ResourcesExhausted(msg) = &err else {
         unreachable!("asserted above");
     };
     assert!(
-        msg.contains("DiskManager is disabled"),
-        "the sort path's error must name the disabled disk manager; got {msg:?}"
+        msg.contains("spill is disabled"),
+        "the sort path's error must be re-attributed as a disabled-spill \
+         refusal, not passed through with DataFusion's own wording; got {msg:?}"
+    );
+    assert!(
+        !msg.contains("DiskManager is disabled") && !msg.contains("Sorting"),
+        "DataFusion's own operator wording must not survive re-attribution; \
+         got {msg:?}"
+    );
+    // Nothing else in this single-partition pipeline holds a reservation on
+    // this pool before the sort's own first (and only) grow attempt, which
+    // already exceeds the whole per-query budget in one call -- so the
+    // pool's occupancy at the moment of refusal is 0, not a partial fill.
+    // Pinned exact per this repo's number-pinning rule; a DataFusion version
+    // that changes the external sorter's batching would change this figure
+    // and this assertion would catch it.
+    assert!(
+        msg.contains("0 of 16777216 bytes reserved"),
+        "the reattributed message must name the pool's exact occupancy and \
+         the query's configured limit (16777216 = max_query_bytes above); \
+         got {msg:?}"
     );
 }

--- a/crates/ravel-sql/tests/memory_group_values_compensation.rs
+++ b/crates/ravel-sql/tests/memory_group_values_compensation.rs
@@ -1,0 +1,107 @@
+//! The `GroupValues` under-count compensation (issue #740, findings 2 and 3).
+//!
+//! DataFusion 54's `GroupValues::size()` reports `capacity() * entry_size`,
+//! where `capacity()` is the hashbrown table's usable slot count at the 7/8
+//! load factor and no control bytes are counted. The real allocation is the
+//! full bucket count (`capacity / (7/8)`, a power of two) times the entry
+//! size, plus one control byte per bucket and the group width. For an Int64
+//! group table that gap is about 21%, which the #740 trace saw as 570 MB real
+//! against 470 MB reported for 17M groups.
+//!
+//! On top of that steady gap, a table that is mid-resize holds the old and the
+//! new allocation at once (finding 3), a transient bounded at 1.5x the settled
+//! real size. [`compensated_group_values_ceiling`] folds both into one factor
+//! and this test pins that the compensated ceiling bounds the real allocation,
+//! red with the factor at 1.0.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use ravel_sql::{GROUP_VALUES_CEILING_COMPENSATION, compensated_group_values_ceiling};
+
+/// Bytes a `GroupValues` slot occupies for an Int64 group key: the 8-byte
+/// value plus the 8-byte group index the hashbrown table stores. This is the
+/// `entry_size` `GroupValues::size()` multiplies `capacity()` by.
+const ENTRY: usize = 16;
+
+/// One control byte per bucket plus the SIMD group width hashbrown allocates
+/// alongside the buckets; `size()` counts none of it.
+const GROUP_CTRL_WIDTH: usize = 16;
+
+/// The reported figure (`GroupValues::size()`): usable capacity times entry
+/// size. `capacity == buckets * 7 / 8`.
+fn reported_size(buckets: usize) -> usize {
+    (buckets * 7 / 8) * ENTRY
+}
+
+/// The real allocation the #740 trace measured: every bucket, plus one control
+/// byte per bucket, plus the group width.
+fn real_size(buckets: usize) -> usize {
+    buckets * ENTRY + buckets + GROUP_CTRL_WIDTH
+}
+
+/// The compensated ceiling bounds the real steady allocation of an Int64 group
+/// table, and the reported figure alone (the factor-1.0 case) does not.
+#[test]
+fn the_compensated_ceiling_bounds_the_real_group_values_allocation() {
+    // 2^25 buckets: usable 29,360,128 slots, the settled table behind the
+    // #740 trace's 17M-group aggregate (reported ~470 MB, real ~570 MB).
+    let buckets = 1usize << 25;
+    let reported = reported_size(buckets);
+    let real = real_size(buckets);
+
+    // Sanity-anchor against the trace's decimal-MB figures.
+    assert_eq!(reported, 469_762_048, "reported ~470 MB");
+    assert_eq!(real, 570_425_360, "real ~570 MB");
+
+    // The under-count ratio, pinned to two decimals (finding 2).
+    let ratio = real as f64 / reported as f64;
+    assert_eq!(
+        (ratio * 100.0).round() / 100.0,
+        1.21,
+        "GroupValues::size() under-reports the real allocation by ~21%; got {ratio}"
+    );
+
+    // The fix: the compensated ceiling is at least the real allocation.
+    let compensated = compensated_group_values_ceiling(reported);
+    assert!(
+        compensated >= real,
+        "the compensated ceiling {compensated} must bound the real allocation {real}"
+    );
+
+    // Red with the factor at 1.0: an uncompensated ceiling is the reported
+    // figure, which is below the real allocation and would let the table
+    // overrun a budget it reported fitting.
+    assert!(
+        reported < real,
+        "the uncompensated (factor 1.0) ceiling under-reserves: {reported} < {real}"
+    );
+
+    // The compensation also bounds the mid-resize transient peak (finding 3):
+    // old + new = 1.5x the settled real size.
+    let transient_peak = real + real / 2;
+    assert!(
+        compensated >= transient_peak,
+        "the compensated ceiling {compensated} must bound the resize transient \
+         {transient_peak} (1.5x the settled real size)"
+    );
+}
+
+/// The compensation factor is the documented product `1.22 * 1.5 = 1.83`, and
+/// it is a strict upper bound on the measured under-count ratio so
+/// `compensated >= real` cannot depend on rounding luck.
+#[test]
+fn the_compensation_factor_is_the_documented_product_and_bounds_the_ratio() {
+    assert_eq!(
+        (GROUP_VALUES_CEILING_COMPENSATION * 100.0).round() / 100.0,
+        1.83,
+        "compensation is 1.22 (under-count) * 1.5 (resize transient)"
+    );
+
+    let buckets = 1usize << 25;
+    let measured_ratio = real_size(buckets) as f64 / reported_size(buckets) as f64;
+    assert!(
+        GROUP_VALUES_CEILING_COMPENSATION > measured_ratio,
+        "the factor {GROUP_VALUES_CEILING_COMPENSATION} must strictly exceed the measured \
+         steady under-count ratio {measured_ratio}"
+    );
+}

--- a/crates/ravel-sql/tests/memory_group_values_compensation.rs
+++ b/crates/ravel-sql/tests/memory_group_values_compensation.rs
@@ -16,7 +16,10 @@
 
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
-use ravel_sql::{GROUP_VALUES_CEILING_COMPENSATION, compensated_group_values_ceiling};
+use ravel_sql::{
+    GROUP_VALUES_CEILING_COMPENSATION, GROUP_VALUES_RESIZE_TRANSIENT_FACTOR,
+    compensated_group_values_ceiling,
+};
 
 /// Bytes a `GroupValues` slot occupies for an Int64 group key: the 8-byte
 /// value plus the 8-byte group index the hashbrown table stores. This is the
@@ -104,4 +107,26 @@ fn the_compensation_factor_is_the_documented_product_and_bounds_the_ratio() {
         "the factor {GROUP_VALUES_CEILING_COMPENSATION} must strictly exceed the measured \
          steady under-count ratio {measured_ratio}"
     );
+}
+
+/// The ceiling must bound the modelled peak at EVERY table size, not only
+/// asymptotically. A purely multiplicative compensation does not: the reported
+/// figure omits a fixed control-group allocation that does not scale, so at 8
+/// buckets the real size is 152 against a reported 112, the modelled 1.5x peak
+/// is 228, and 112 * 1.83 is 205. Every table below roughly 512 buckets was
+/// under-bounded. Remove the fixed-overhead term from
+/// `compensated_group_values_ceiling` and this goes red at the first size.
+#[test]
+fn the_compensated_ceiling_bounds_small_tables_too() {
+    for buckets in [8usize, 16, 32, 64, 128, 256, 512] {
+        let reported = reported_size(buckets);
+        let modelled_peak =
+            (real_size(buckets) as f64 * GROUP_VALUES_RESIZE_TRANSIENT_FACTOR).ceil() as usize;
+        let ceiling = compensated_group_values_ceiling(reported);
+        assert!(
+            ceiling >= modelled_peak,
+            "buckets={buckets}: ceiling {ceiling} must bound the modelled peak {modelled_peak}              (reported {reported}, real {})",
+            real_size(buckets)
+        );
+    }
 }

--- a/crates/ravel-sql/tests/memory_pool_attribution.rs
+++ b/crates/ravel-sql/tests/memory_pool_attribution.rs
@@ -1,0 +1,132 @@
+//! Attribution of a disabled-disk-manager spill refusal (issue #740, finding
+//! 1). A `RepartitionExec` output channel refused by the pool falls to
+//! `create_in_progress_file("SpillPool")`, and with the disk manager disabled
+//! (ADR-0102 decision 3) that raises
+//! `"Memory Exhausted while SpillPool (DiskManager is disabled)"`. The message
+//! names the exchange that HOLDS the reservation, not the aggregate tables
+//! that FILLED the pool, and carries no byte figures.
+//!
+//! [`SqlError::resources_exhausted_reattributed`] rewrites it from the pool's
+//! own `reserved()`/limit at the moment of refusal. This test pins the exact
+//! figures from a real [`TenantDelegatingPool`] and shows the rewrite is red
+//! against the pass-through message.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::sync::Arc;
+
+use datafusion::execution::memory_pool::{MemoryConsumer, MemoryLimit, MemoryPool};
+use ravel_sql::{
+    CeilingBreach, MSG_SPILL_DISABLED_MARKER, SqlError, TenantDelegatingPool,
+    TenantMemoryAccountant,
+};
+use ravel_types::accounting::QueryAccounting;
+
+/// The message DataFusion 54 raises from a `RepartitionExec` output channel
+/// whose `try_grow` the pool refused, once the disk manager is disabled.
+const SPILL_MSG: &str = "Memory Exhausted while SpillPool (DiskManager is disabled)";
+
+/// A spill refusal surfaces as the typed `ResourcesExhausted` carrying the
+/// pool's `used`/`limit` (exact figures read from `MemoryPool::reserved()` and
+/// the configured limit), not the pass-through exchange message.
+///
+/// Prove-the-test: [`SqlError::resources_exhausted_reattributed`] returns the
+/// raw message verbatim when it lacks [`MSG_SPILL_DISABLED_MARKER`], so a
+/// build that skipped the marker branch (or one that reverted to
+/// `ResourcesExhausted(raw)`) would carry `"SpillPool"` and neither figure --
+/// every assertion below on the two figures and on the marker's absence goes
+/// red. The `pass_through` binding at the end is exactly that reverted form,
+/// asserted to be the message the fix must NOT produce.
+#[test]
+fn a_spill_refusal_reports_the_pools_used_and_limit_not_the_exchange() {
+    const QUERY_LIMIT: usize = 8000;
+    const RESERVED: usize = 6144;
+
+    let tenant = TenantMemoryAccountant::new(1 << 30);
+    let pool: Arc<dyn MemoryPool> = Arc::new(TenantDelegatingPool::new(
+        QUERY_LIMIT,
+        tenant,
+        CeilingBreach::new(),
+        QueryAccounting::new(),
+    ));
+
+    // The aggregate hash tables are what filled the pool: reserve their bytes
+    // through the pool so `reserved()` reads the real occupancy at the moment
+    // the (separate) exchange's spill is refused.
+    let aggregate = MemoryConsumer::new("GroupedHashAggregateStream[0]").register(&pool);
+    aggregate.try_grow(RESERVED).expect("within the ceiling");
+    assert_eq!(
+        pool.reserved(),
+        RESERVED,
+        "the pool holds the aggregate bytes"
+    );
+
+    let MemoryLimit::Finite(limit) = pool.memory_limit() else {
+        panic!("the query pool declares a finite limit");
+    };
+    assert_eq!(
+        limit, QUERY_LIMIT,
+        "the pool's limit is the configured ceiling"
+    );
+    let err = SqlError::resources_exhausted_reattributed(SPILL_MSG, pool.reserved(), limit);
+
+    let SqlError::ResourcesExhausted(message) = &err else {
+        panic!("a spill refusal must stay a typed ResourcesExhausted; got {err:?}");
+    };
+    // The exact figures from the fixture's pool, both present.
+    assert!(
+        message.contains("6144"),
+        "message must name the reserved bytes (used); got {message:?}"
+    );
+    assert!(
+        message.contains("8000"),
+        "message must name the limit; got {message:?}"
+    );
+    // Attribution is by consumer, not by the spilling holder: the exchange's
+    // own name is gone and the message says whose bytes these are.
+    assert!(
+        !message.contains("SpillPool") && !message.contains(MSG_SPILL_DISABLED_MARKER),
+        "the reattributed message must drop the exchange/spill wording; got {message:?}"
+    );
+    assert!(
+        message.contains("consumer"),
+        "the message must state attribution is by consumer; got {message:?}"
+    );
+
+    // The figures survive the client boundary verbatim (a budget error).
+    let client = err.client_message();
+    assert!(
+        client.contains("6144") && client.contains("8000"),
+        "{client}"
+    );
+
+    // Red against the pass-through: the message the fix must NOT produce is the
+    // raw exchange text with no figures.
+    let pass_through = SqlError::ResourcesExhausted(SPILL_MSG.to_string());
+    assert_ne!(
+        message,
+        &SPILL_MSG.to_string(),
+        "the fix must not echo the exchange message"
+    );
+    assert!(
+        pass_through.to_string().contains("SpillPool")
+            && !pass_through.to_string().contains("6144"),
+        "the pass-through form names the exchange and carries no figure, which is the \
+         regression this test guards"
+    );
+}
+
+/// A native `ResourcesExhausted` that is NOT a disabled-disk spill (the pool's
+/// own `try_grow` text, which already carries figures) passes through
+/// unchanged, so the reattribution helper is safe to route every native
+/// `ResourcesExhausted` through.
+#[test]
+fn a_non_spill_message_passes_through_unchanged() {
+    let raw = "query memory pool exhausted: 4096 more bytes on top of 6144 already reserved \
+               exceeds per-query limit 8000";
+    let err = SqlError::resources_exhausted_reattributed(raw, 6144, 8000);
+    let SqlError::ResourcesExhausted(message) = &err else {
+        panic!("still a ResourcesExhausted; got {err:?}");
+    };
+    assert_eq!(message, raw, "a non-spill message is returned verbatim");
+}

--- a/docs/adrs/0102-intra-segment-scan-partitioning-and-spill-policy.md
+++ b/docs/adrs/0102-intra-segment-scan-partitioning-and-spill-policy.md
@@ -592,3 +592,69 @@ each per relevant object no matter how selective the predicate is, and only the
 surviving-block reads scale with the predicate. The 0.75 coverage crossover is
 unchanged; a numeric predicate whose survivors still cover >= 75% of a segment
 reads that segment whole, exactly as before.
+
+## Amendment (2026-08-27, #740): the pass-through spill error misattributes, and `GroupValues::size()` under-counts
+
+Decision 3 above shipped the disabled-disk-manager spill as a typed
+`ResourcesExhausted`, mapped through unchanged from whatever DataFusion 54
+happened to raise. Production traces on the #680 ClickBench tenant found two
+defects that decision alone did not cover.
+
+**Finding 1: the pass-through message names the wrong operator.** A
+`RepartitionExec` output channel refused by the pool falls to
+`create_in_progress_file("SpillPool")`, and with the disk manager disabled
+that raises `"Memory Exhausted while SpillPool (DiskManager is disabled)"` (an
+external sort raises the equivalent `"... while Sorting ..."`). The message
+names the operator that HOLDS the reservation it could not grow, not the
+consumer that FILLED the pool (the aggregate hash tables), and carries no
+byte figures. `SqlError::resources_exhausted_reattributed` (`ravel-sql`,
+`error.rs`) rewrites any `ResourcesExhausted` carrying the
+`"DiskManager is disabled"` substring from the query's own
+`MemoryPool::reserved()`/limit at the moment of refusal, read at the one seam
+every batch from either transport crosses:
+`PinnedStream::poll_next`'s `execution_error` mapping (`executor.rs`), which
+now reads `ctx`'s installed pool back off `SessionContext::runtime_env()`
+rather than trusting the message. A message without the marker (this crate's
+own `try_grow` text, or any other native `ResourcesExhausted`) passes through
+unchanged.
+
+This is a substring match on an upstream string DataFusion owns, not a
+structured discriminant: DataFusion's `MemoryConsumer`/`DiskManager` types
+carry no typed "spill refused, disk disabled" variant to match on instead, so
+there is no more precise handle available from outside the crate. A DataFusion
+upgrade that rewords the message stops the rewrite silently -- every pool
+failure downgrades back to the pre-#740 pass-through, not a compile error or a
+panic. `memory_pool_attribution.rs` pins the exact current string as a
+`const SPILL_MSG` local to the test (deliberately not reading
+`MSG_SPILL_DISABLED_MARKER`'s own substring back out, which would make the
+test tautological against itself) and pins `TenantDelegatingPool` figures the
+rewrite must reproduce; a DataFusion bump that changes the wording turns this
+red instead of leaving the misattribution unnoticed.
+
+**Findings 2 and 3: `GroupValues::size()` under-counts, and a resize doubles
+it.** DataFusion 54's `GroupValues::size()` reports `capacity() * entry_size`
+-- `capacity()` is the hashbrown table's usable slot count at the 7/8 load
+factor, with no control bytes counted. The real allocation is the full bucket
+count (`capacity / (7/8)`, always a power of two) times `entry_size`, plus one
+control byte per bucket plus the SIMD group width; for an Int64 group table
+(16-byte entry) that gap is about 21%, matching a production trace that saw
+570 MB real against 470 MB reported for a 17M-group aggregate (finding 2).
+Separately, a hashbrown table mid-resize holds the old and the new allocation
+at once, a transient peak of 1.5x the settled real size, while the pool
+reservation still reflects the pre-resize figure until the resize completes
+(finding 3). `GROUP_VALUES_CEILING_COMPENSATION` (`ravel-sql`, `config.rs`) is
+the product of both factors (1.22 x 1.5 = 1.83), and
+`compensated_group_values_ceiling` inflates a reported `size()` to a
+documented upper bound on the real peak; `memory_group_values_compensation.rs`
+pins the factor and shows it strictly exceeds the measured steady under-count
+ratio.
+
+As of this amendment, `compensated_group_values_ceiling` has no caller: no
+code in `ravel-sql` reads `GroupValues::size()` to size an aggregate stage
+before running it (there is no pre-execution admission check for group-by
+cardinality; the pool's own `try_grow` is a post-hoc ceiling on the bytes
+DataFusion actually asked to reserve, not a predictive one). Findings 2 and 3
+are recorded and the compensation factor is derived and pinned so a future
+admission check has a bound to use, but nothing exercises it on a real query
+path yet; that wiring is unclaimed follow-up work, not part of this
+amendment's fix.


### PR DESCRIPTION
A query refused because the disk manager is disabled surfaced DataFusion's
own wording, which names spilling rather than the budget that actually
refused the work. An operator reading it learned that something could not
spill, not which ceiling was reached or how full it was.

Reattribute the refusal to the pool that raised it, reporting the observed
occupancy alongside the limit, so the error names the figure a reader can
act on.

The reattribution keys off a literal substring of DataFusion's message,
which is fragile by construction: an upstream reword would silently stop
matching and the unattributed wording would return. The test pins the
exact marker text so that upgrade breaks a test rather than quietly
degrading every pool refusal, and the assertion checks the reattributed
wording and the exact observed occupancy rather than that some error
occurred.

This does not make q29 or q33 pass. Those two exhaust the pool because
grouped avg allocates per group behind DataFusion's accumulator adapter,
which ADR-0825 addresses; accounting them more precisely changes when they
fail, not whether the state fits.

Fixes: #740
Refs: #825
