### PR TITLE
fix(ravel-catalog): build postings over L1 entries in fold

### DIFF
--- a/crates/ravel-catalog/src/fold.rs
+++ b/crates/ravel-catalog/src/fold.rs
@@ -61,6 +61,10 @@ pub enum PostingsBuildError {
     BadContentHashLen(usize),
     #[error("entry writer_id must be 16 bytes, got {0}")]
     BadWriterIdLen(usize),
+    #[error("L1 entry writer_id (input_set_hash) must be 32 bytes, got {0}")]
+    BadInputSetHashLen(usize),
+    #[error("L1 entry writer_epoch (part_index) does not fit u32: {0}")]
+    BadPartIndex(u64),
     #[error("segment series entry has no {METRIC_NAME_LABEL} label")]
     MissingMetricName,
     #[error("unsupported segment format version {0}")]
@@ -1238,7 +1242,19 @@ impl Catalog {
             // fetched once -- a one-time full build, not a partial merge. A
             // build failure at any entry from `decode_start` onward aborts
             // the whole index, never publishes a partial one.
-            let postings_names = if entries.iter().all(|entry| entry.level == 0) {
+            //
+            // Level is not gated here: `fetch_segment_names` derives an L1
+            // entry's key and identity the same way `build_segment_ref_from_entry`
+            // does for a query read, so a compacted bucket's `__name__` set
+            // is decoded exactly like an L0 one. The forward-merge ordinal
+            // assumption a compaction rewrite breaks is guarded by
+            // `reconciled` above, not by level: a bucket whose content
+            // changed under an already-recorded ordinal (an L0 run superseded
+            // by its L1 compaction) always lands in `dirty_hours` and forces
+            // `decode_start = 0` here, while a bucket that arrives
+            // already-compacted on its first fold is a plain hour-major
+            // append and never disturbs a previously-recorded ordinal.
+            let postings_names = {
                 let (postings_baseline, postings_decode_start): (Vec<NamePostings>, usize) =
                     if rebuilt || reconciled {
                         (Vec::new(), 0)
@@ -1268,14 +1284,6 @@ impl Catalog {
                     &mut counters,
                 )
                 .await
-            } else {
-                // A level-1 (compaction) entry is present. The forward
-                // postings merge assumes append-only, hour-major L0 growth
-                // with stable ordinals, which a compaction rewrite breaks, and
-                // an L1 part carries no L0 segment to decode `__name__` from.
-                // Publish no postings ref so a resolve considers every entry
-                // exactly rather than pruning against a stale or partial index.
-                None
             };
             let mut postings_built = false;
             let mut postings_size = 0u64;
@@ -2015,6 +2023,16 @@ impl Catalog {
 /// single implementation is deliberate: two copies that must always agree
 /// would be a maintenance hazard, since a scrub is only meaningful if it
 /// derives names exactly the way the fold that wrote the postings did.
+///
+/// Level-aware key and identity derivation, matching
+/// `build_segment_ref_from_entry` (`snapshot_resolve.rs`) exactly: an L0
+/// entry's `writer_id`/`writer_epoch`/`writer_seq` are the flush's real
+/// writer identity, addressed with `keys::data_key`. An L1 entry has no
+/// writer identity of its own; the fold packs its `input_set_hash` into
+/// `writer_id` and its `part_index` into `writer_epoch`
+/// (`build_l1_snapshot_entry`), addressed with `keys::l1_part_key`, and its
+/// footer carries the nil/0 sentinel identity `ravel-query`'s fetcher checks
+/// L1 segments against (`expected_identity` in `ravel-query/src/fetcher.rs`).
 pub async fn fetch_segment_names(
     store: &dyn ObjectStoreBackend,
     tenant: &TenantHash,
@@ -2026,32 +2044,61 @@ pub async fn fetch_segment_names(
         .as_slice()
         .try_into()
         .map_err(|_| PostingsBuildError::BadContentHashLen(entry.content_hash.len()))?;
-    let writer_id_bytes: [u8; 16] = entry
-        .writer_id
-        .as_slice()
-        .try_into()
-        .map_err(|_| PostingsBuildError::BadWriterIdLen(entry.writer_id.len()))?;
-    let writer_id = Uuid::from_bytes(writer_id_bytes);
-    let data_key = keys::data_key(
-        tenant,
-        signal,
-        entry.shard,
-        writer_id,
-        entry.writer_epoch,
-        entry.writer_seq,
-        &content_hash,
-    )?;
+
+    let (data_key, expected) = if entry.level == 0 {
+        let writer_id_bytes: [u8; 16] = entry
+            .writer_id
+            .as_slice()
+            .try_into()
+            .map_err(|_| PostingsBuildError::BadWriterIdLen(entry.writer_id.len()))?;
+        let writer_id = Uuid::from_bytes(writer_id_bytes);
+        let data_key = keys::data_key(
+            tenant,
+            signal,
+            entry.shard,
+            writer_id,
+            entry.writer_epoch,
+            entry.writer_seq,
+            &content_hash,
+        )?;
+        let expected = ExpectedIdentity {
+            tenant_hash: tenant.0,
+            shard: entry.shard,
+            writer_id: writer_id.to_string(),
+            writer_epoch: entry.writer_epoch,
+            writer_seq: entry.writer_seq,
+        };
+        (data_key, expected)
+    } else {
+        let input_set_hash: [u8; 32] = entry
+            .writer_id
+            .as_slice()
+            .try_into()
+            .map_err(|_| PostingsBuildError::BadInputSetHashLen(entry.writer_id.len()))?;
+        let part_index = u32::try_from(entry.writer_epoch)
+            .map_err(|_| PostingsBuildError::BadPartIndex(entry.writer_epoch))?;
+        let data_key = keys::l1_part_key(
+            tenant,
+            signal,
+            entry.shard,
+            entry.ingest_hour_bucket,
+            &hex::encode(&input_set_hash[..8]),
+            part_index,
+            &hex::encode(&content_hash[..8]),
+        )?;
+        let expected = ExpectedIdentity {
+            tenant_hash: tenant.0,
+            shard: entry.shard,
+            writer_id: Uuid::nil().to_string(),
+            writer_epoch: 0,
+            writer_seq: 0,
+        };
+        (data_key, expected)
+    };
     let got = store.get(&data_key, GetRange::Full).await?;
 
     let limits = ReaderLimits::default();
     let location = ravel_segment::open_from_full(&got.data, limits)?;
-    let expected = ExpectedIdentity {
-        tenant_hash: tenant.0,
-        shard: entry.shard,
-        writer_id: writer_id.to_string(),
-        writer_epoch: entry.writer_epoch,
-        writer_seq: entry.writer_seq,
-    };
     ravel_segment::check_identity(&location.footer, &expected)?;
 
     // ADR-0027: v7 is the only supported version (`open_from_full` above has
@@ -3248,6 +3295,98 @@ mod tests {
         record
     }
 
+    /// Like `publish_real_segment`, but writes the real RSEG part as an L1
+    /// compaction output (`keys::l1_part_key`, footer identity nil/0/0 per
+    /// `build_l1_snapshot_entry`) with a `CompactionRecord` pointing at it,
+    /// instead of a `CommitRecord`-addressed L0 object. Needed so a test can
+    /// observe `Catalog::build_postings` actually GET and decode an L1
+    /// entry, the same way it already does for L0 via
+    /// `publish_real_segment`.
+    async fn publish_real_compaction(
+        store: &MemoryStore,
+        shard: u32,
+        ingest_hour_bucket: u32,
+        created_unix_ns: i64,
+        metrics: &[&str],
+    ) -> CompactionRecord {
+        let tenant_id = TenantId::new("fold-postings-fault-test");
+        let series: Vec<SeriesInput> = metrics
+            .iter()
+            .map(|metric| {
+                let labels = LabelSet::new(vec![Label {
+                    name: METRIC_NAME_LABEL.to_string(),
+                    value: (*metric).to_string(),
+                }])
+                .expect("valid labels");
+                let series_id = SeriesId::compute(&tenant_id, metric, &labels).expect("series id");
+                SeriesInput {
+                    series_id,
+                    labels,
+                    samples: vec![Sample {
+                        ts_ns: created_unix_ns,
+                        value: 1.0,
+                    }],
+                }
+            })
+            .collect();
+        let identity = SegmentIdentity {
+            tenant_hash: tenant().0,
+            shard,
+            writer_id: Uuid::nil().to_string(),
+            writer_epoch: 0,
+            writer_seq: 0,
+        };
+        let min_ingest_ts_ns = created_unix_ns - 1_000;
+        let max_ingest_ts_ns = created_unix_ns;
+        let bounds = IngestBounds {
+            min_ingest_ts_ns,
+            max_ingest_ts_ns,
+        };
+        let written = SegmentWriter::write(series, identity, bounds).expect("write segment");
+        let input_set_hash =
+            *blake3::hash(format!("l1-inputs-{shard}-{ingest_hour_bucket}").as_bytes()).as_bytes();
+        let part = CompactionPart {
+            part_index: 0,
+            first_series_id: vec![0u8; 16],
+            last_series_id: vec![0xffu8; 16],
+            content_hash: written.summary.blake3.to_vec(),
+            object_size: written.bytes.len() as u64,
+            sample_count: written.summary.sample_count,
+            series_count: written.summary.series_count,
+            run_count: 1,
+            min_event_ts_ns: written.summary.min_event_ts_ns,
+            max_event_ts_ns: written.summary.max_event_ts_ns,
+            segment_format_version: 3,
+        };
+        let record = CompactionRecord {
+            format_version: 1,
+            tenant_hash: tenant().0.to_vec(),
+            signal: signal::to_proto(Signal::Metrics).into(),
+            shard,
+            ingest_hour_bucket,
+            level: 1,
+            inputs: Vec::new(),
+            input_set_hash: input_set_hash.to_vec(),
+            parts: vec![part],
+            created_unix_ns,
+        };
+        let data_key =
+            keys::reconstruct_l1_part_key(&record, &record.parts[0]).expect("l1 part key");
+        publish::put_data_object(store, &data_key, written.bytes)
+            .await
+            .expect("put l1 part object");
+        let ckey = keys::compaction_record_key_for(&record).expect("compaction key");
+        store
+            .put(
+                &ckey,
+                Bytes::from(record.encode_to_vec()),
+                PutOptions::create_if_absent(),
+            )
+            .await
+            .expect("put compaction record");
+        record
+    }
+
     /// Publish a retention tombstone for `(shard, ingest_hour_bucket)`. The
     /// fold classifies a bucket as tombstoned from the key shape alone and
     /// never reads the body, so a minimal valid record suffices.
@@ -3376,6 +3515,50 @@ mod tests {
                 .any(|p| p.min_hour <= 10 && 10 <= p.watermark_hour),
             "a part still covers hour 10"
         );
+    }
+
+    /// Regression for issue #587: a fold used to skip postings entirely the
+    /// moment any L1 (compacted) entry was present, because
+    /// `fetch_segment_names` could only key and identity-check an L0 object.
+    /// A bucket set mixing one real L0 segment and one real L1 compaction
+    /// part must still build postings and cover both entries.
+    #[tokio::test]
+    async fn mixed_l0_l1_entries_still_build_postings() {
+        let store = Arc::new(MemoryStore::new());
+        let catalog = Catalog::new(store.clone(), config(1)).expect("catalog");
+
+        let now = now_at_seal(10);
+        publish_real_segment(
+            &store,
+            0,
+            Uuid::new_v4(),
+            1,
+            5,
+            now - 5 * NS_PER_HOUR,
+            &["cpu"],
+        )
+        .await;
+        publish_real_compaction(&store, 0, 8, now - 2 * NS_PER_HOUR, &["disk"]).await;
+
+        let report = catalog
+            .fold(&tenant(), Signal::Metrics, Uuid::new_v4(), now, &[], None)
+            .await
+            .expect("fold");
+
+        assert!(!report.no_op);
+        assert!(report.rebuilt);
+        assert_eq!(report.entry_count, 2);
+        assert!(
+            report.postings_built,
+            "postings must be built over a mixed L0/L1 entry set, not skipped"
+        );
+
+        let head = read_head(store.as_ref()).await;
+        assert!(head.postings.is_some());
+        let entries = collect_head_entries(store.as_ref(), &head).await;
+        let mut levels: Vec<u32> = entries.iter().map(|e| e.level).collect();
+        levels.sort_unstable();
+        assert_eq!(levels, vec![0, 1], "entry set is genuinely mixed L0/L1");
     }
 
     /// The reconcile pass must never reintroduce a duplicate entry identity.

--- a/crates/ravel-logseg/src/writer.rs
+++ b/crates/ravel-logseg/src/writer.rs
@@ -387,9 +387,7 @@ impl RlogWriter {
         for blob in streams.values() {
             for (k, v) in stream_attr_pairs(blob)? {
                 let (ty, _) = resolve_value(&v);
-                let eligible = indexed_names.contains(k.as_str())
-                    || matches!(ty, FieldType::I64 | FieldType::F64 | FieldType::Bool);
-                if eligible {
+                if stream_level_column_eligible(k.as_str(), ty, &indexed_names) {
                     distinct.insert((k, ty.to_u8()));
                 }
             }
@@ -885,9 +883,7 @@ impl RlogWriter {
         for blob in streams.values() {
             for (k, v) in stream_attr_pairs(blob)? {
                 let (ty, _) = resolve_value(&v);
-                let eligible = indexed_names.contains(k.as_str())
-                    || matches!(ty, FieldType::I64 | FieldType::F64 | FieldType::Bool);
-                if eligible {
+                if stream_level_column_eligible(k.as_str(), ty, &indexed_names) {
                     distinct.insert((k, ty.to_u8()));
                 }
             }
@@ -1613,6 +1609,27 @@ type ColumnIndex = HashMap<u8, HashMap<String, u32>>;
 /// keep every probe going through it so no call site reconstructs an owned key.
 fn column_lookup(column_of: &ColumnIndex, name: &str, ty_byte: u8) -> Option<u32> {
     column_of.get(&ty_byte).and_then(|m| m.get(name)).copied()
+}
+
+/// Whether a stream-level-only attribute `(name, ty)` earns a dynamic column
+/// even though no record carries it per-record. Two kinds qualify:
+///
+/// - an indexed name (ADR-0049 amendment), so `indexed_term_columns` can key
+///   its merged-view postings by a column, and
+/// - a numeric type (I64/F64/Bool), so `stat_winner_columns` has a column to
+///   key its NumStat by.
+///
+/// The row path ([`RlogWriter::build_object`]) and the columnar path
+/// ([`RlogWriter::build_object_columnar`]) both grant these columns, and the
+/// rule has to be identical on both or the two would assign different columns
+/// for the same records and break the byte-identity guarantee (ADR-0109
+/// decision 7). It lives here, called from both, so it cannot drift.
+fn stream_level_column_eligible(
+    name: &str,
+    ty: FieldType,
+    indexed_names: &std::collections::HashSet<&str>,
+) -> bool {
+    indexed_names.contains(name) || matches!(ty, FieldType::I64 | FieldType::F64 | FieldType::Bool)
 }
 
 /// Resolves one record into storage form: dense stream ref, dynamic columns
@@ -2568,6 +2585,86 @@ mod tests {
         // to it.
         assert!(fd.column("lib", FieldType::I64).is_some());
         assert_eq!(fd.len(), 3);
+    }
+
+    /// Both build paths grant the identical set of stream-level-only dynamic
+    /// columns. The grant rule (`stream_level_column_eligible`) is shared, so
+    /// the row path and the columnar path cannot diverge on which
+    /// resource/scope-only key earns a column. The fixture puts four keys only
+    /// on the stream blob -- no record carries them per-record, so every
+    /// FIELD_DIR entry is a stream-level grant -- covering each arm of the rule:
+    ///
+    /// - `idx.str`   Str, indexed     -> granted (indexed, non-grantable type)
+    /// - `both.i64`  I64, indexed     -> granted (indexed and numeric)
+    /// - `num.i64`   I64, not indexed -> granted (grantable type, not indexed)
+    /// - `plain.str` Str, not indexed -> denied (neither)
+    ///
+    /// so the granted set is exactly {idx.str/Str, both.i64/I64, num.i64/I64}
+    /// on both paths. Flip either call site back to a diverging inline rule
+    /// (drop the `indexed_names` clause on one, say) and the two sets stop
+    /// matching.
+    #[test]
+    fn both_build_paths_grant_same_stream_level_columns() {
+        let blob = stream_attrs_bytes(
+            &[
+                ("idx.str".into(), AttrValue::Str("x".into())),
+                ("both.i64".into(), AttrValue::I64(7)),
+                ("num.i64".into(), AttrValue::I64(3)),
+                ("plain.str".into(), AttrValue::Str("y".into())),
+            ],
+            "scope",
+            "1.0",
+            &[],
+        );
+        let indexed = vec!["idx.str".to_string(), "both.i64".to_string()];
+        // Every record carries the same stream blob and no per-record attrs, so
+        // the only columns the object can grant are the stream-level ones.
+        let records: Vec<LogRecord> = (0..6i64)
+            .map(|i| {
+                let mut r = base_record(0, i);
+                r.stream_attrs = blob.clone();
+                r
+            })
+            .collect();
+
+        let granted = |obj: &[u8]| -> Vec<(String, u8)> {
+            let footer = open(obj).expect("open");
+            let fd = read_field_dir(obj, &footer);
+            let mut set: Vec<(String, u8)> = fd
+                .entries()
+                .iter()
+                .map(|e| (e.name.clone(), e.ty.to_u8()))
+                .collect();
+            set.sort();
+            set
+        };
+
+        let mut rw =
+            RlogWriter::new(RlogConfig::default(), identity()).with_indexed_fields(indexed.clone());
+        for r in &records {
+            rw.push(r.clone()).expect("row push");
+        }
+        let row_obj = rw.finish().expect("row finish");
+
+        let mut cw =
+            RlogWriter::new(RlogConfig::default(), identity()).with_indexed_fields(indexed);
+        cw.push_columnar(ColumnarLogBatch::from_records(&records))
+            .expect("columnar push");
+        let col_obj = cw.finish().expect("columnar finish");
+
+        let mut expected: Vec<(String, u8)> = vec![
+            ("idx.str".to_string(), FieldType::Str.to_u8()),
+            ("both.i64".to_string(), FieldType::I64.to_u8()),
+            ("num.i64".to_string(), FieldType::I64.to_u8()),
+        ];
+        expected.sort();
+        assert_eq!(granted(&row_obj), expected, "row path granted set");
+        assert_eq!(granted(&col_obj), expected, "columnar path granted set");
+        assert_eq!(
+            granted(&row_obj),
+            granted(&col_obj),
+            "both paths grant the identical stream-level column set"
+        );
     }
 
     /// Decodes the STREAM_DIR of a written object.


### PR DESCRIPTION
The name-postings index was guarded on every entry being level 0, so the
first L1 compaction part in a bucket stopped postings being built for it
at all. A tenant that had ever been compacted therefore had a dead index
for those hours, which is the opposite of the intent: L1 parts are
themselves segments and carry the names the index exists to find.

Build postings across levels. The name decode already read any entry
regardless of level, so the guard was the only thing standing between a
compacted bucket and its index.

Also grant stream-level-only columns identically in the row and columnar
build paths. The two disagreed, so which columns a caller could see
depended on which builder ran, and that is a difference no caller asked
for.

Fixes: #587
Fixes: #623
