### PR TITLE
feat(ravel-sql): exact integer avg and grouped accumulators for avg

### DIFF
--- a/crates/ravel-sql/src/avg.rs
+++ b/crates/ravel-sql/src/avg.rs
@@ -1,4 +1,5 @@
-//! Sequential-fold AVG/MEAN (ADR-0022 decisions 3, 4).
+//! Grouped-aware AVG/MEAN with two owned numerator kinds (ADR-0022 decisions
+//! 3, 4; ADR-0825 decisions 1, 2).
 //!
 //! DataFusion 54.1.0's built-in `avg` (`AvgAccumulator`, `average.rs`) sums
 //! each input batch with arrow's `compute::sum` kernel, which reduces
@@ -9,84 +10,118 @@
 //! root cause behind the ungrouped `sum` restriction the differential gate
 //! already documents (crate::minmax has the analogous story for min/max).
 //!
-//! This module replaces the built-in `avg`/`mean` with a UDAF whose numerator
-//! is a plain, sequential IEEE f64 fold over its own non-null input values, in
-//! the deterministic `(series_id, ts)` order v1 guarantees by executing
-//! aggregation single-partitioned above the sort-preserving merge. The fold is
-//! seeded with the first value rather than a zero seed, so a group of all
-//! `-0.0` values folds to `-0.0` (a `0.0` seed would flip it to `+0.0`). The
-//! numerator is divided by the non-null row count in one correctly rounded
-//! IEEE division; empty or all-NULL input yields NULL, never NaN or infinity.
+//! This module replaces the built-in `avg`/`mean` with a UDAF that owns two
+//! numerator kinds, selected by the coerced argument type ([`avg_kind`]):
 //!
-//! The summation is naive, not Kahan (ADR-0022 decision 3): the differential
-//! gate compares against a reference running this identical algorithm, so
-//! compensation buys no exactness, and this fold is internal to this UDAF --
-//! it does not touch, replace, or reuse the public `sum` aggregate, whose bits
-//! stay exactly as DataFusion's built-in produces them (ADR-0024, undecided,
-//! tracks whether `sum` should ever change).
+//! * **Float64 input**: a naive sequential IEEE f64 fold over the non-null
+//!   input values, seeded with the first value rather than a zero seed (so a
+//!   group of all `-0.0` values folds to `-0.0`; a `0.0` seed would flip it to
+//!   `+0.0`). Grouped execution ([`SequentialAvgGroupsAccumulator`]) folds
+//!   each group in the same row order a plain per-group accumulator would,
+//!   so the two paths are bit-identical. The differential gate compares
+//!   against a reference running this identical algorithm; the summation is
+//!   naive, not Kahan (ADR-0022 decision 3), because compensation buys no
+//!   exactness against that reference.
+//! * **Admitted integer input** (`Int8`-`Int64`, `UInt8`-`UInt32`, coerced to
+//!   `Int64` by [`SequentialAvg::coerce_types`] rather than delegating up to
+//!   Float64): exact `i128` accumulation with checked addition, so the result
+//!   is a function of the input multiset only, never of partitioning or merge
+//!   order (integer addition is associative and exact; no fold-order
+//!   dependence exists to pin). Partial state is `(Decimal128(38, 0) sum,
+//!   Int64 count)`; packing the `i128` sum into `Decimal128(38, 0)` is
+//!   checked, because `i128`'s range exceeds what 38 unscaled digits can
+//!   represent. Evaluation converts the exact sum to `f64` once and performs
+//!   one IEEE division by the count. Return type stays Float64 either way
+//!   (ADR-0825).
 //!
-//! Only the `avg`/`mean` names and only Float64 output are owned here. Metadata
-//! (name, aliases, signature, return type, coercion) delegates to the wrapped
-//! built-in so integer input still coerces to Float64 exactly as before, and
-//! any non-Float64 return type (the decimal and duration paths, unreachable on
-//! the v1 `samples` surface, whose only numeric column is Float64) delegates
-//! its accumulator to the built-in untouched.
+//! Any other input type (Decimal, Duration; unreachable on the v1 `samples`
+//! surface, whose only numeric column is Float64) delegates entirely to the
+//! wrapped built-in: metadata (name, aliases, return type) always delegates,
+//! and coercion delegates for every argument type this module does not own.
 //!
-//! The accumulator is a plain [`Accumulator`], never a `GroupsAccumulator`:
-//! [`SequentialAvg::groups_accumulator_supported`] returns false, so grouped
-//! execution runs one accumulator per group behind `GroupsAccumulatorAdapter`,
-//! folding each group's values in row order. State is `(sum, count)`; a merge
-//! of partial states adds sums with the same plain IEEE addition and adds
-//! counts, so a two-phase single-partition plan (one partial state per group)
-//! reconstitutes the same bits as a single-phase one. See ADR-0022.
+//! Both owned kinds implement a real [`GroupsAccumulator`]
+//! ([`SequentialAvgGroupsAccumulator`], [`ExactIntegerAvgGroupsAccumulator`]):
+//! [`SequentialAvg::groups_accumulator_supported`] returns true for them, so
+//! grouped execution no longer runs behind `GroupsAccumulatorAdapter`. Each
+//! stores flat per-group state (a sums vector and a counts vector indexed by
+//! group index) and folds every group's values in the row order the plan
+//! delivers them, so the grouped and ungrouped paths compute the identical
+//! fold for identical input. State is `(sum, count)` for both kinds; a merge
+//! of partial states adds sums (plain IEEE addition for Float64, checked
+//! `i128` addition for the integer kind) and adds counts, so a two-phase plan
+//! (one partial state per group) reconstitutes the same result as a
+//! single-phase one -- bit-identical for Float64, exact for the integer kind
+//! regardless of how partitioning or merge order differ. See ADR-0022 and
+//! ADR-0825.
 
 use std::sync::Arc;
 
-use datafusion::arrow::array::{Array, ArrayRef, Float64Array, Int64Array};
+use datafusion::arrow::array::{
+    Array, ArrayRef, BooleanArray, Decimal128Array, Float64Array, Int64Array,
+};
 use datafusion::arrow::compute::cast;
 use datafusion::arrow::datatypes::{DataType, Field, FieldRef};
 use datafusion::error::{DataFusionError, Result as DFResult};
 use datafusion::functions_aggregate::average::avg_udaf;
 use datafusion::logical_expr::function::{AccumulatorArgs, StateFieldsArgs};
+use datafusion::logical_expr::type_coercion::functions::fields_with_udf;
 use datafusion::logical_expr::{
-    Accumulator, AggregateUDF, AggregateUDFImpl, Documentation, ReversedUDAF, Signature,
+    Accumulator, AggregateUDF, AggregateUDFImpl, Documentation, EmitTo, GroupsAccumulator,
+    ReversedUDAF, Signature,
 };
 use datafusion::scalar::ScalarValue;
 
-/// The sequential-fold AVG UDAF, registered under `avg` (and its `mean` alias)
-/// to displace DataFusion's built-in whose lane-reduced batch sum is
-/// unpinnable (ADR-0022 decision 4).
+/// The sequential-fold AVG UDAF, registered under `avg` (and its `mean`
+/// alias) to displace DataFusion's built-in whose lane-reduced batch sum is
+/// unpinnable (ADR-0022 decision 4) and whose integer path always widens to
+/// Float64 before summing (ADR-0825).
 pub fn sequential_avg_udaf() -> AggregateUDF {
     AggregateUDF::new_from_impl(SequentialAvg::new())
 }
 
-/// An AVG/MEAN UDAF that owns Float64 numerator semantics (a naive sequential
-/// f64 fold divided by the non-null count) and delegates everything else to
-/// the wrapped built-in.
+/// An AVG/MEAN UDAF that owns Float64 and admitted-integer numerator
+/// semantics and delegates everything else to the wrapped built-in.
 ///
-/// Metadata methods forward to `inner` so the replacement is behaviourally
-/// identical outside of the Float64 numerator computation. Only
-/// [`Self::accumulator`] and [`Self::state_fields`] diverge, and only for
-/// Float64 output; [`Self::groups_accumulator_supported`] returns false so the
-/// plain accumulator runs per group.
+/// Metadata methods (name, aliases, return type) forward to `inner`. Coercion
+/// diverges for admitted integer arguments (kept as `Int64` instead of widened
+/// to Float64); everything else delegates to the built-in's own coercion via
+/// [`fields_with_udf`]. [`Self::state_fields`], [`Self::accumulator`],
+/// [`Self::groups_accumulator_supported`], and
+/// [`Self::create_groups_accumulator`] all dispatch on [`avg_kind`] of the
+/// (coerced) argument type.
 #[derive(Debug)]
 struct SequentialAvg {
-    /// The wrapped built-in `avg` (`avg_udaf()`), used for metadata delegation
-    /// and for non-Float64 output types.
+    /// The wrapped built-in `avg` (`avg_udaf()`), used for metadata
+    /// delegation and for non-owned input types.
     inner: Arc<dyn AggregateUDFImpl>,
+    /// The wrapped built-in as an `AggregateUDF`, used to run its own
+    /// Coercible-signature resolution via [`fields_with_udf`] for delegated
+    /// argument types. Calling `inner.coerce_types` directly is not an
+    /// option: the built-in signature is `Coercible`, and DataFusion never
+    /// calls an `AggregateUDFImpl::coerce_types` for a `Coercible` signature,
+    /// so the built-in never implements that method itself.
+    inner_udf: AggregateUDF,
+    /// A `TypeSignature::UserDefined` signature so DataFusion actually calls
+    /// [`Self::coerce_types`] (it does not for `Coercible`, which is what the
+    /// built-in uses).
+    signature: Signature,
 }
 
 impl SequentialAvg {
     fn new() -> Self {
+        let inner_udf: AggregateUDF = (*avg_udaf()).clone();
+        let volatility = inner_udf.signature().volatility;
         Self {
-            inner: avg_udaf().inner().clone(),
+            inner: inner_udf.inner().clone(),
+            inner_udf,
+            signature: Signature::user_defined(volatility),
         }
     }
 }
 
 // `AggregateUDFImpl` requires `DynEq`/`DynHash`; this impl carries no state of
-// its own (the wrapped `inner` is a pure function of the built-in `avg`), so
-// all instances are equal.
+// its own (`inner`/`inner_udf`/`signature` are a pure function of the
+// built-in `avg`), so all instances are equal.
 impl PartialEq for SequentialAvg {
     fn eq(&self, _other: &Self) -> bool {
         true
@@ -99,11 +134,40 @@ impl std::hash::Hash for SequentialAvg {
     fn hash<H: std::hash::Hasher>(&self, _state: &mut H) {}
 }
 
-/// Whether `data_type` gets the sequential-fold accumulator. Only Float64
-/// output is owned here; decimal and duration outputs (unreachable on the v1
-/// `samples` surface) delegate to the built-in.
-fn is_owned(data_type: &DataType) -> bool {
-    data_type == &DataType::Float64
+/// The resolved argument types this UDAF coerces an admitted integer
+/// argument to `Int64` from, instead of delegating to the built-in's
+/// Float64-widening coercion (ADR-0825 decision 2). `UInt64` is excluded: it
+/// does not fit `Int64` without narrowing, so it keeps the built-in's
+/// Float64-widening behavior.
+fn is_admitted_integer(data_type: &DataType) -> bool {
+    matches!(
+        data_type,
+        DataType::Int8
+            | DataType::Int16
+            | DataType::Int32
+            | DataType::Int64
+            | DataType::UInt8
+            | DataType::UInt16
+            | DataType::UInt32
+    )
+}
+
+/// Which numerator kind owns a (coerced) argument type. Only ever inspected
+/// after coercion, so the integer case is always `Int64` (the target
+/// [`SequentialAvg::coerce_types`] admits integer arguments to).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AvgKind {
+    Float,
+    Integer,
+    Delegate,
+}
+
+fn avg_kind(data_type: &DataType) -> AvgKind {
+    match data_type {
+        DataType::Float64 => AvgKind::Float,
+        DataType::Int64 => AvgKind::Integer,
+        _ => AvgKind::Delegate,
+    }
 }
 
 impl AggregateUDFImpl for SequentialAvg {
@@ -116,25 +180,46 @@ impl AggregateUDFImpl for SequentialAvg {
     }
 
     fn signature(&self) -> &Signature {
-        self.inner.signature()
+        &self.signature
     }
 
     fn return_type(&self, arg_types: &[DataType]) -> DFResult<DataType> {
+        // The built-in's return type falls through to `Float64` for any
+        // argument type it does not special-case (Decimal, Duration), which
+        // includes `Int64`: admitting an integer argument to `Int64` in
+        // `coerce_types` does not change the return type (ADR-0825: "return
+        // type stays Float64").
         self.inner.return_type(arg_types)
     }
 
     fn coerce_types(&self, arg_types: &[DataType]) -> DFResult<Vec<DataType>> {
-        self.inner.coerce_types(arg_types)
+        if arg_types.len() == 1 && is_admitted_integer(&arg_types[0]) {
+            return Ok(vec![DataType::Int64]);
+        }
+        let fields: Vec<FieldRef> = arg_types
+            .iter()
+            .map(|data_type| Arc::new(Field::new("avg_arg", data_type.clone(), true)) as FieldRef)
+            .collect();
+        let coerced = fields_with_udf(&fields, &self.inner_udf)?;
+        Ok(coerced
+            .iter()
+            .map(|field| field.data_type().clone())
+            .collect())
     }
 
     fn state_fields(&self, args: StateFieldsArgs) -> DFResult<Vec<FieldRef>> {
-        if is_owned(args.return_field.data_type()) {
-            // Matches [`SequentialAvgAccumulator`]'s `state`/`merge_batch`: a
-            // nullable Float64 running sum (null until the first row) and an
-            // Int64 non-null count. Names are namespaced by the aggregate
-            // expression name so a two-phase plan's partial and final state
-            // schemas line up.
-            Ok(vec![
+        let kind = args
+            .input_fields
+            .first()
+            .map(|field| avg_kind(field.data_type()))
+            .unwrap_or(AvgKind::Delegate);
+        match kind {
+            // Matches [`SequentialAvgAccumulator`]/[`SequentialAvgGroupsAccumulator`]'s
+            // `state`/`merge_batch`: a nullable Float64 running sum (null
+            // until the first row) and an Int64 non-null count. Names are
+            // namespaced by the aggregate expression name so a two-phase
+            // plan's partial and final state schemas line up.
+            AvgKind::Float => Ok(vec![
                 Arc::new(Field::new(
                     format!("{}[avg_sum]", args.name),
                     DataType::Float64,
@@ -145,27 +230,68 @@ impl AggregateUDFImpl for SequentialAvg {
                     DataType::Int64,
                     true,
                 )),
-            ])
-        } else {
-            self.inner.state_fields(args)
+            ]),
+            // Matches [`ExactIntegerAvgAccumulator`]/[`ExactIntegerAvgGroupsAccumulator`]'s
+            // `state`/`merge_batch`: a nullable Decimal128(38, 0) exact sum
+            // (null when the group/partition saw no rows) and an Int64
+            // non-null count.
+            AvgKind::Integer => Ok(vec![
+                Arc::new(Field::new(
+                    format!("{}[avg_sum]", args.name),
+                    DataType::Decimal128(38, 0),
+                    true,
+                )),
+                Arc::new(Field::new(
+                    format!("{}[avg_count]", args.name),
+                    DataType::Int64,
+                    true,
+                )),
+            ]),
+            AvgKind::Delegate => self.inner.state_fields(args),
         }
     }
 
     fn accumulator(&self, acc_args: AccumulatorArgs) -> DFResult<Box<dyn Accumulator>> {
-        if is_owned(acc_args.return_field.data_type()) {
-            Ok(Box::new(SequentialAvgAccumulator::new()))
-        } else {
-            self.inner.accumulator(acc_args)
+        let kind = acc_args
+            .expr_fields
+            .first()
+            .map(|field| avg_kind(field.data_type()))
+            .unwrap_or(AvgKind::Delegate);
+        match kind {
+            AvgKind::Float => Ok(Box::new(SequentialAvgAccumulator::new())),
+            AvgKind::Integer => Ok(Box::new(ExactIntegerAvgAccumulator::new())),
+            AvgKind::Delegate => self.inner.accumulator(acc_args),
         }
     }
 
-    fn groups_accumulator_supported(&self, _args: AccumulatorArgs) -> bool {
-        // Run one plain accumulator per group behind `GroupsAccumulatorAdapter`
-        // so every group folds sequentially in row order; there is no
-        // sequential vectorized groups accumulator for v1 (ADR-0022 decision
-        // 3). The built-in's own groups accumulator is exactly the
-        // lane-parallel path this UDAF exists to replace.
-        false
+    fn groups_accumulator_supported(&self, args: AccumulatorArgs) -> bool {
+        let kind = args
+            .expr_fields
+            .first()
+            .map(|field| avg_kind(field.data_type()))
+            .unwrap_or(AvgKind::Delegate);
+        match kind {
+            // Both owned kinds have a real `GroupsAccumulator` (see below):
+            // no need to fall back to `GroupsAccumulatorAdapter`.
+            AvgKind::Float | AvgKind::Integer => true,
+            AvgKind::Delegate => self.inner.groups_accumulator_supported(args),
+        }
+    }
+
+    fn create_groups_accumulator(
+        &self,
+        args: AccumulatorArgs,
+    ) -> DFResult<Box<dyn GroupsAccumulator>> {
+        let kind = args
+            .expr_fields
+            .first()
+            .map(|field| avg_kind(field.data_type()))
+            .unwrap_or(AvgKind::Delegate);
+        match kind {
+            AvgKind::Float => Ok(Box::new(SequentialAvgGroupsAccumulator::new())),
+            AvgKind::Integer => Ok(Box::new(ExactIntegerAvgGroupsAccumulator::new())),
+            AvgKind::Delegate => self.inner.create_groups_accumulator(args),
+        }
     }
 
     fn reverse_expr(&self) -> ReversedUDAF {
@@ -177,10 +303,10 @@ impl AggregateUDFImpl for SequentialAvg {
     }
 }
 
-/// The plain per-group accumulator. `sum` is the running numerator, `None`
-/// until the first non-null value is seen; `count` is the number of non-null
-/// values folded. The result is `sum / count` in one IEEE division, or NULL
-/// when `count` is zero.
+/// The plain per-group accumulator for Float64 input. `sum` is the running
+/// numerator, `None` until the first non-null value is seen; `count` is the
+/// number of non-null values folded. The result is `sum / count` in one IEEE
+/// division, or NULL when `count` is zero.
 #[derive(Debug)]
 struct SequentialAvgAccumulator {
     /// The running numerator, or `None` until the first non-null value.
@@ -210,9 +336,8 @@ impl SequentialAvgAccumulator {
     }
 
     /// Fold every non-null value of `array` after widening it to Float64.
-    /// The input is already Float64 on the v1 surface (integer input is
-    /// coerced up before it reaches the accumulator); the cast is a no-op
-    /// clone there and exact for the integer case regardless.
+    /// The input is already Float64 on the v1 surface; the cast is a no-op
+    /// clone there.
     fn fold_values(&mut self, array: &ArrayRef) -> DFResult<()> {
         let float = as_float64(array)?;
         for i in 0..float.len() {
@@ -298,5 +423,598 @@ impl Accumulator for SequentialAvgAccumulator {
 
     fn size(&self) -> usize {
         std::mem::size_of_val(self)
+    }
+}
+
+/// Whether `opt_filter[row]` excludes `row` (absent filter admits every row;
+/// a null filter slot means "unknown", which DataFusion treats as excluded,
+/// the same as `false`).
+fn row_is_filtered(opt_filter: Option<&BooleanArray>, row: usize) -> bool {
+    match opt_filter {
+        None => false,
+        Some(filter) => filter.is_null(row) || !filter.value(row),
+    }
+}
+
+/// The flat per-group `GroupsAccumulator` for Float64 input (ADR-0825
+/// decision 1). `sums[group_index]` is `None` until that group's first
+/// non-null value; `counts[group_index]` is its non-null row count. Folds in
+/// the same row order [`SequentialAvgAccumulator`] would see for the same
+/// group, so the grouped and ungrouped paths are bit-identical.
+#[derive(Debug)]
+struct SequentialAvgGroupsAccumulator {
+    sums: Vec<Option<f64>>,
+    counts: Vec<i64>,
+}
+
+impl SequentialAvgGroupsAccumulator {
+    fn new() -> Self {
+        Self {
+            sums: Vec::new(),
+            counts: Vec::new(),
+        }
+    }
+
+    fn resize(&mut self, total_num_groups: usize) {
+        self.sums.resize(total_num_groups, None);
+        self.counts.resize(total_num_groups, 0);
+    }
+
+    fn fold(&mut self, group_index: usize, value: f64) {
+        self.sums[group_index] = Some(match self.sums[group_index] {
+            None => value,
+            Some(acc) => acc + value,
+        });
+    }
+}
+
+impl GroupsAccumulator for SequentialAvgGroupsAccumulator {
+    fn update_batch(
+        &mut self,
+        values: &[ArrayRef],
+        group_indices: &[usize],
+        opt_filter: Option<&BooleanArray>,
+        total_num_groups: usize,
+    ) -> DFResult<()> {
+        self.resize(total_num_groups);
+        let float = as_float64(&values[0])?;
+        for (row, &group_index) in group_indices.iter().enumerate() {
+            if row_is_filtered(opt_filter, row) {
+                continue;
+            }
+            if float.is_valid(row) {
+                self.fold(group_index, float.value(row));
+                self.counts[group_index] += 1;
+            }
+        }
+        Ok(())
+    }
+
+    fn merge_batch(
+        &mut self,
+        values: &[ArrayRef],
+        group_indices: &[usize],
+        opt_filter: Option<&BooleanArray>,
+        total_num_groups: usize,
+    ) -> DFResult<()> {
+        self.resize(total_num_groups);
+        let sums = as_float64(&values[0])?;
+        let counts = values[1]
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .ok_or_else(|| {
+                DataFusionError::Internal(
+                    "sequential avg: merge count state is not an Int64Array".to_string(),
+                )
+            })?;
+        for (row, &group_index) in group_indices.iter().enumerate() {
+            if row_is_filtered(opt_filter, row) {
+                continue;
+            }
+            if sums.is_valid(row) {
+                self.fold(group_index, sums.value(row));
+            }
+            if counts.is_valid(row) {
+                self.counts[group_index] += counts.value(row);
+            }
+        }
+        Ok(())
+    }
+
+    fn evaluate(&mut self, emit_to: EmitTo) -> DFResult<ArrayRef> {
+        let sums = emit_to.take_needed(&mut self.sums);
+        let counts = emit_to.take_needed(&mut self.counts);
+        let values: Float64Array = sums
+            .into_iter()
+            .zip(counts)
+            .map(|(sum, count)| match sum {
+                Some(sum) if count > 0 => Some(sum / count as f64),
+                _ => None,
+            })
+            .collect();
+        Ok(Arc::new(values))
+    }
+
+    fn state(&mut self, emit_to: EmitTo) -> DFResult<Vec<ArrayRef>> {
+        let sums = emit_to.take_needed(&mut self.sums);
+        let counts = emit_to.take_needed(&mut self.counts);
+        let sum_array: Float64Array = sums.into_iter().collect();
+        let count_array: Int64Array = counts.into_iter().map(Some).collect();
+        Ok(vec![Arc::new(sum_array), Arc::new(count_array)])
+    }
+
+    fn size(&self) -> usize {
+        self.sums.capacity() * std::mem::size_of::<Option<f64>>()
+            + self.counts.capacity() * std::mem::size_of::<i64>()
+    }
+}
+
+/// The largest unscaled magnitude `Decimal128(38, 0)` can represent: 38
+/// nines (`10^38 - 1`). `i128::MAX` (~1.7014e38) exceeds this, so packing an
+/// exact-integer-avg sum into `Decimal128(38, 0)` needs a checked bounds
+/// test, not just a checked `i128` add.
+const DECIMAL128_MAX_UNSCALED: i128 = 99_999_999_999_999_999_999_999_999_999_999_999_999;
+
+/// Check that `sum` fits in `Decimal128(38, 0)`'s unscaled range, returning a
+/// typed internal error (never a silent wrap or a panic) if it does not.
+fn checked_decimal128_value(sum: i128) -> DFResult<i128> {
+    if !(-DECIMAL128_MAX_UNSCALED..=DECIMAL128_MAX_UNSCALED).contains(&sum) {
+        return Err(DataFusionError::Internal(format!(
+            "exact integer avg: partial sum {sum} overflows Decimal128(38, 0)"
+        )));
+    }
+    Ok(sum)
+}
+
+/// Add `value` to `acc` with checked `i128` addition, returning a typed
+/// internal error (never a silent wrap or a panic) on overflow.
+fn checked_add_i128(acc: i128, value: i128) -> DFResult<i128> {
+    acc.checked_add(value).ok_or_else(|| {
+        DataFusionError::Internal(format!(
+            "exact integer avg: sum overflowed i128 accumulating {value} onto {acc}"
+        ))
+    })
+}
+
+/// Widen `array` to an `Int64Array`, cloning when it already is one. The
+/// input is already `Int64` on the v1 surface (admitted integer input is
+/// coerced up by [`SequentialAvg::coerce_types`] before it reaches the
+/// accumulator).
+fn as_int64(array: &ArrayRef) -> DFResult<Int64Array> {
+    let ints = if array.data_type() == &DataType::Int64 {
+        Arc::clone(array)
+    } else {
+        cast(array, &DataType::Int64)?
+    };
+    ints.as_any()
+        .downcast_ref::<Int64Array>()
+        .cloned()
+        .ok_or_else(|| {
+            DataFusionError::Internal(
+                "exact integer avg: cast to Int64 did not yield an Int64Array".to_string(),
+            )
+        })
+}
+
+fn as_decimal128(array: &ArrayRef) -> DFResult<Decimal128Array> {
+    array
+        .as_any()
+        .downcast_ref::<Decimal128Array>()
+        .cloned()
+        .ok_or_else(|| {
+            DataFusionError::Internal(
+                "exact integer avg: merge sum state is not a Decimal128Array".to_string(),
+            )
+        })
+}
+
+/// The plain per-group accumulator for admitted-integer input (ADR-0825
+/// decision 2). `sum` accumulates exactly in `i128` with checked addition, so
+/// it is a function of the input multiset only; integer addition is
+/// associative, so unlike the Float64 kind there is no fold-order dependence
+/// to pin. `count` is the number of non-null values folded. Evaluation
+/// converts the exact sum to `f64` once and performs one IEEE division by
+/// `count`.
+#[derive(Debug)]
+struct ExactIntegerAvgAccumulator {
+    sum: i128,
+    count: i64,
+}
+
+impl ExactIntegerAvgAccumulator {
+    fn new() -> Self {
+        Self { sum: 0, count: 0 }
+    }
+
+    fn fold(&mut self, value: i64) -> DFResult<()> {
+        self.sum = checked_add_i128(self.sum, i128::from(value))?;
+        self.count += 1;
+        Ok(())
+    }
+
+    fn fold_values(&mut self, array: &ArrayRef) -> DFResult<()> {
+        let ints = as_int64(array)?;
+        for i in 0..ints.len() {
+            if ints.is_valid(i) {
+                self.fold(ints.value(i))?;
+            }
+        }
+        Ok(())
+    }
+
+    /// The average as a Float64 `ScalarValue`: the exact `i128` sum widened
+    /// to `f64` once, divided by `count` in one IEEE division. NULL when no
+    /// non-null rows were seen.
+    fn output(&self) -> ScalarValue {
+        if self.count > 0 {
+            ScalarValue::Float64(Some(self.sum as f64 / self.count as f64))
+        } else {
+            ScalarValue::Float64(None)
+        }
+    }
+}
+
+impl Accumulator for ExactIntegerAvgAccumulator {
+    fn update_batch(&mut self, values: &[ArrayRef]) -> DFResult<()> {
+        self.fold_values(&values[0])
+    }
+
+    fn merge_batch(&mut self, states: &[ArrayRef]) -> DFResult<()> {
+        // states[0] is the Decimal128(38, 0) partial-sum column, states[1]
+        // the Int64 partial-count column (see `state_fields`). A partial
+        // state with no rows carries a null sum and a zero count.
+        let sums = as_decimal128(&states[0])?;
+        let counts = states[1]
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .ok_or_else(|| {
+                DataFusionError::Internal(
+                    "exact integer avg: merge count state is not an Int64Array".to_string(),
+                )
+            })?;
+        for i in 0..sums.len() {
+            if sums.is_valid(i) {
+                self.sum = checked_add_i128(self.sum, sums.value(i))?;
+            }
+            if counts.is_valid(i) {
+                self.count += counts.value(i);
+            }
+        }
+        Ok(())
+    }
+
+    fn state(&mut self) -> DFResult<Vec<ScalarValue>> {
+        let sum = if self.count > 0 {
+            ScalarValue::Decimal128(Some(checked_decimal128_value(self.sum)?), 38, 0)
+        } else {
+            ScalarValue::Decimal128(None, 38, 0)
+        };
+        Ok(vec![sum, ScalarValue::Int64(Some(self.count))])
+    }
+
+    fn evaluate(&mut self) -> DFResult<ScalarValue> {
+        Ok(self.output())
+    }
+
+    fn size(&self) -> usize {
+        std::mem::size_of_val(self)
+    }
+}
+
+/// The flat per-group `GroupsAccumulator` for admitted-integer input
+/// (ADR-0825 decision 2). `sums[group_index]` is the exact running `i128`
+/// numerator (starts at zero; integer addition is associative and exact, so
+/// unlike the Float64 kind a zero seed is not observable in the result).
+/// `counts[group_index]` is its non-null row count.
+#[derive(Debug)]
+struct ExactIntegerAvgGroupsAccumulator {
+    sums: Vec<i128>,
+    counts: Vec<i64>,
+}
+
+impl ExactIntegerAvgGroupsAccumulator {
+    fn new() -> Self {
+        Self {
+            sums: Vec::new(),
+            counts: Vec::new(),
+        }
+    }
+
+    fn resize(&mut self, total_num_groups: usize) {
+        self.sums.resize(total_num_groups, 0);
+        self.counts.resize(total_num_groups, 0);
+    }
+}
+
+impl GroupsAccumulator for ExactIntegerAvgGroupsAccumulator {
+    fn update_batch(
+        &mut self,
+        values: &[ArrayRef],
+        group_indices: &[usize],
+        opt_filter: Option<&BooleanArray>,
+        total_num_groups: usize,
+    ) -> DFResult<()> {
+        self.resize(total_num_groups);
+        let ints = as_int64(&values[0])?;
+        for (row, &group_index) in group_indices.iter().enumerate() {
+            if row_is_filtered(opt_filter, row) {
+                continue;
+            }
+            if ints.is_valid(row) {
+                self.sums[group_index] =
+                    checked_add_i128(self.sums[group_index], i128::from(ints.value(row)))?;
+                self.counts[group_index] += 1;
+            }
+        }
+        Ok(())
+    }
+
+    fn merge_batch(
+        &mut self,
+        values: &[ArrayRef],
+        group_indices: &[usize],
+        opt_filter: Option<&BooleanArray>,
+        total_num_groups: usize,
+    ) -> DFResult<()> {
+        self.resize(total_num_groups);
+        let sums = as_decimal128(&values[0])?;
+        let counts = values[1]
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .ok_or_else(|| {
+                DataFusionError::Internal(
+                    "exact integer avg: merge count state is not an Int64Array".to_string(),
+                )
+            })?;
+        for (row, &group_index) in group_indices.iter().enumerate() {
+            if row_is_filtered(opt_filter, row) {
+                continue;
+            }
+            if sums.is_valid(row) {
+                self.sums[group_index] = checked_add_i128(self.sums[group_index], sums.value(row))?;
+            }
+            if counts.is_valid(row) {
+                self.counts[group_index] += counts.value(row);
+            }
+        }
+        Ok(())
+    }
+
+    fn evaluate(&mut self, emit_to: EmitTo) -> DFResult<ArrayRef> {
+        let sums = emit_to.take_needed(&mut self.sums);
+        let counts = emit_to.take_needed(&mut self.counts);
+        let values: Float64Array = sums
+            .into_iter()
+            .zip(counts)
+            .map(|(sum, count)| {
+                if count > 0 {
+                    Some(sum as f64 / count as f64)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        Ok(Arc::new(values))
+    }
+
+    fn state(&mut self, emit_to: EmitTo) -> DFResult<Vec<ArrayRef>> {
+        let sums = emit_to.take_needed(&mut self.sums);
+        let counts = emit_to.take_needed(&mut self.counts);
+        let mut sum_values: Vec<Option<i128>> = Vec::with_capacity(sums.len());
+        for (sum, count) in sums.iter().zip(counts.iter()) {
+            if *count > 0 {
+                sum_values.push(Some(checked_decimal128_value(*sum)?));
+            } else {
+                sum_values.push(None);
+            }
+        }
+        let sum_array: Decimal128Array = sum_values
+            .into_iter()
+            .collect::<Decimal128Array>()
+            .with_precision_and_scale(38, 0)?;
+        let count_array: Int64Array = counts.into_iter().map(Some).collect();
+        Ok(vec![Arc::new(sum_array), Arc::new(count_array)])
+    }
+
+    fn size(&self) -> usize {
+        self.sums.capacity() * std::mem::size_of::<i128>()
+            + self.counts.capacity() * std::mem::size_of::<i64>()
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use proptest::prelude::*;
+
+    use super::*;
+
+    /// A quiet NaN with a chosen payload, so a bit-identity test can carry
+    /// distinguishable NaN inputs through instead of a single canonical NaN.
+    fn nan_with_payload(payload: u64) -> f64 {
+        f64::from_bits(0x7ff8_0000_0000_0000 | (payload & 0x000f_ffff_ffff_ffff))
+    }
+
+    fn float64_bits(sv: ScalarValue) -> Option<u64> {
+        match sv {
+            ScalarValue::Float64(Some(v)) => Some(v.to_bits()),
+            ScalarValue::Float64(None) => None,
+            other => panic!("expected a Float64 scalar, got {other:?}"),
+        }
+    }
+
+    /// `SequentialAvgAccumulator` (the plain, ungrouped path) and
+    /// `SequentialAvgGroupsAccumulator` (a single group folded through the
+    /// `GroupsAccumulator` path) must fold identical input in identical row
+    /// order, so they must produce bit-identical output for every case,
+    /// including NaN payloads and signed zero -- neither of which `==`
+    /// distinguishes, which is why every comparison here goes through
+    /// `to_bits()` (ADR-0022 decision 4, ADR-0825 decision 1).
+    #[test]
+    fn float_avg_grouped_matches_sequential_bit_for_bit() {
+        let cases: Vec<Vec<Option<f64>>> = vec![
+            vec![Some(1.0), Some(2.0), None, Some(3.5)],
+            vec![Some(-0.0), Some(-0.0), Some(-0.0)],
+            vec![Some(0.0), Some(-0.0)],
+            vec![Some(-0.0), Some(0.0)],
+            vec![
+                Some(nan_with_payload(1)),
+                Some(2.0),
+                Some(nan_with_payload(0xdead)),
+            ],
+            vec![Some(f64::INFINITY), Some(f64::NEG_INFINITY)],
+            vec![None, None],
+            vec![],
+        ];
+
+        for values in cases {
+            let array: ArrayRef = Arc::new(Float64Array::from(values.clone()));
+
+            let mut plain = SequentialAvgAccumulator::new();
+            plain.fold_values(&array).expect("fold must not fail");
+            let plain_bits = float64_bits(plain.output());
+
+            let mut grouped = SequentialAvgGroupsAccumulator::new();
+            let group_indices = vec![0usize; values.len()];
+            grouped
+                .update_batch(&[Arc::clone(&array)], &group_indices, None, 1)
+                .expect("update_batch must not fail");
+            let grouped_array = grouped
+                .evaluate(EmitTo::All)
+                .expect("evaluate must not fail");
+            let grouped_array = grouped_array
+                .as_any()
+                .downcast_ref::<Float64Array>()
+                .expect("evaluate must return a Float64Array");
+            let grouped_bits = if grouped_array.is_valid(0) {
+                Some(grouped_array.value(0).to_bits())
+            } else {
+                None
+            };
+
+            assert_eq!(
+                plain_bits, grouped_bits,
+                "plain and grouped float avg must be bit-identical for input {values:?}"
+            );
+        }
+    }
+
+    /// Three `-0.0` values folded with a zero seed would flip to `+0.0`
+    /// (`0.0 + -0.0 == 0.0` under IEEE 754); seeding with the first value
+    /// instead of zero keeps the running sum `-0.0`, and the division that
+    /// follows keeps the result `-0.0`.
+    #[test]
+    fn float_avg_seeds_with_first_value_not_zero() {
+        let array: ArrayRef = Arc::new(Float64Array::from(vec![-0.0, -0.0, -0.0]));
+        let mut acc = SequentialAvgAccumulator::new();
+        acc.fold_values(&array).expect("fold must not fail");
+        assert_eq!(
+            float64_bits(acc.output()),
+            Some((-0.0_f64).to_bits()),
+            "a zero seed would have flipped an all -0.0 group to +0.0"
+        );
+    }
+
+    #[test]
+    fn checked_add_i128_overflow_is_a_typed_error_not_a_panic_or_wrap() {
+        let err = checked_add_i128(i128::MAX, 1).expect_err("i128::MAX + 1 must overflow");
+        assert!(
+            matches!(err, DataFusionError::Internal(_)),
+            "expected a typed internal error, got {err:?}"
+        );
+        let err = checked_add_i128(i128::MIN, -1)
+            .expect_err("i128::MIN + -1 must overflow the other way");
+        assert!(matches!(err, DataFusionError::Internal(_)));
+    }
+
+    #[test]
+    fn checked_decimal128_value_overflow_is_a_typed_error_not_a_silent_wrap() {
+        let err = checked_decimal128_value(DECIMAL128_MAX_UNSCALED + 1)
+            .expect_err("one past the max unscaled magnitude must overflow");
+        assert!(
+            matches!(err, DataFusionError::Internal(_)),
+            "expected a typed internal error, got {err:?}"
+        );
+        let err = checked_decimal128_value(-DECIMAL128_MAX_UNSCALED - 1)
+            .expect_err("one past the min unscaled magnitude must overflow");
+        assert!(matches!(err, DataFusionError::Internal(_)));
+
+        checked_decimal128_value(DECIMAL128_MAX_UNSCALED).expect("the max magnitude itself fits");
+        checked_decimal128_value(-DECIMAL128_MAX_UNSCALED).expect("the min magnitude itself fits");
+    }
+
+    /// `ExactIntegerAvgAccumulator::fold` surfaces the same typed overflow
+    /// error `checked_add_i128` does, rather than swallowing it: an
+    /// accumulator already holding a sum near `i128::MAX` (only reachable in
+    /// practice via an adversarial number of merged partitions, but exercised
+    /// directly here) must fail closed instead of wrapping.
+    #[test]
+    fn exact_integer_avg_accumulator_overflow_surfaces_typed_error() {
+        let mut acc = ExactIntegerAvgAccumulator::new();
+        acc.sum = i128::MAX;
+        acc.count = 1;
+        let err = acc
+            .fold(1)
+            .expect_err("folding onto i128::MAX must overflow");
+        assert!(matches!(err, DataFusionError::Internal(_)));
+    }
+
+    fn merge_state_into(acc: &mut ExactIntegerAvgAccumulator, state: &[ScalarValue]) {
+        let arrays: Vec<ArrayRef> = state
+            .iter()
+            .map(|s| s.to_array().expect("state scalar must convert to an array"))
+            .collect();
+        acc.merge_batch(&arrays).expect("merge_batch must not fail");
+    }
+
+    proptest! {
+        /// Exact-integer avg's result is a function of the input multiset
+        /// only (ADR-0825 decision 2): splitting the same values across a
+        /// different number of partitions, and merging those partitions'
+        /// partial states in a different order, must never change the
+        /// result, down to the bit, because `i128` addition is associative
+        /// and exact and the partial-state pack/unpack is lossless within
+        /// `Decimal128(38, 0)`'s range. This is the property the sibling
+        /// `f64_partial_sum_merge_is_order_dependent` integration test shows
+        /// Float64-argument avg does NOT have.
+        #[test]
+        fn integer_avg_partition_and_merge_order_never_changes_the_result(
+            values in prop::collection::vec(-1_000_000_000_000i64..1_000_000_000_000i64, 0..64),
+            assignment in prop::collection::vec(0usize..3, 0..64),
+        ) {
+            let mut assignment = assignment;
+            assignment.resize(values.len(), 0);
+
+            let mut reference = ExactIntegerAvgAccumulator::new();
+            let all: ArrayRef = Arc::new(Int64Array::from(values.clone()));
+            reference.fold_values(&all).expect("fold must not fail");
+            let reference_bits = float64_bits(reference.output());
+
+            let mut partitions: [Vec<i64>; 3] = [Vec::new(), Vec::new(), Vec::new()];
+            for (&value, &part) in values.iter().zip(assignment.iter()) {
+                partitions[part].push(value);
+            }
+
+            let mut states = Vec::with_capacity(3);
+            for part in &partitions {
+                let mut acc = ExactIntegerAvgAccumulator::new();
+                let array: ArrayRef = Arc::new(Int64Array::from(part.clone()));
+                acc.fold_values(&array).expect("fold must not fail");
+                states.push(acc.state().expect("state must not fail"));
+            }
+
+            for order in [[0usize, 1, 2], [2, 1, 0], [1, 0, 2], [0, 2, 1]] {
+                let mut merged = ExactIntegerAvgAccumulator::new();
+                for idx in order {
+                    merge_state_into(&mut merged, &states[idx]);
+                }
+                prop_assert_eq!(
+                    reference_bits,
+                    float64_bits(merged.output()),
+                    "merge order {:?} produced a different result than the single-partition fold",
+                    order
+                );
+            }
+        }
     }
 }

--- a/crates/ravel-sql/src/avg.rs
+++ b/crates/ravel-sql/src/avg.rs
@@ -959,6 +959,32 @@ mod tests {
         assert!(matches!(err, DataFusionError::Internal(_)));
     }
 
+    /// The group and partition counts the grouped proptest fans over. Three
+    /// partitions is the smallest count that distinguishes merge order from
+    /// merge pairing; four groups keeps some groups empty in some partitions,
+    /// which is the case that exercises the null partial-sum branch.
+    const GROUPED_PROPTEST_GROUPS: usize = 4;
+    const GROUPED_PROPTEST_PARTITIONS: usize = 3;
+
+    /// Drain a grouped integer accumulator and return each group's result as
+    /// raw bits, so the comparison distinguishes values `==` would not.
+    fn grouped_integer_bits(acc: &mut ExactIntegerAvgGroupsAccumulator) -> Vec<Option<u64>> {
+        let array = acc.evaluate(EmitTo::All).expect("evaluate must not fail");
+        let array = array
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .expect("evaluate must return a Float64Array");
+        (0..array.len())
+            .map(|index| {
+                if array.is_valid(index) {
+                    Some(array.value(index).to_bits())
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
     fn merge_state_into(acc: &mut ExactIntegerAvgAccumulator, state: &[ScalarValue]) {
         let arrays: Vec<ArrayRef> = state
             .iter()
@@ -1016,5 +1042,105 @@ mod tests {
                 );
             }
         }
+
+        /// The same invariance, on the accumulator a real `GROUP BY` plan
+        /// actually runs. `ExactIntegerAvgGroupsAccumulator` does not share
+        /// `ExactIntegerAvgAccumulator`'s state code: its partial sums round
+        /// trip through a `Decimal128(38, 0)` array rather than staying an
+        /// `i128` in a scalar, and its merge reads them back per group. A
+        /// pack, unpack, or group-alignment defect in that path would change
+        /// the answer with the number of partitions while the ungrouped
+        /// sibling above stayed green.
+        #[test]
+        fn integer_avg_grouped_partition_and_merge_order_never_changes_the_result(
+            rows in prop::collection::vec(
+                (-1_000_000_000_000i64..1_000_000_000_000i64, 0usize..GROUPED_PROPTEST_GROUPS, 0usize..GROUPED_PROPTEST_PARTITIONS),
+                0..96,
+            ),
+        ) {
+            let mut reference = ExactIntegerAvgGroupsAccumulator::new();
+            let values: ArrayRef = Arc::new(Int64Array::from(
+                rows.iter().map(|&(value, _, _)| value).collect::<Vec<_>>(),
+            ));
+            let group_indices: Vec<usize> = rows.iter().map(|&(_, group, _)| group).collect();
+            reference
+                .update_batch(&[values], &group_indices, None, GROUPED_PROPTEST_GROUPS)
+                .expect("update_batch must not fail");
+            let reference_bits = grouped_integer_bits(&mut reference);
+
+            let mut states = Vec::with_capacity(GROUPED_PROPTEST_PARTITIONS);
+            for partition in 0..GROUPED_PROPTEST_PARTITIONS {
+                let mut acc = ExactIntegerAvgGroupsAccumulator::new();
+                let taken: Vec<(i64, usize)> = rows
+                    .iter()
+                    .filter(|&&(_, _, part)| part == partition)
+                    .map(|&(value, group, _)| (value, group))
+                    .collect();
+                let array: ArrayRef = Arc::new(Int64Array::from(
+                    taken.iter().map(|&(value, _)| value).collect::<Vec<_>>(),
+                ));
+                let indices: Vec<usize> = taken.iter().map(|&(_, group)| group).collect();
+                acc.update_batch(&[array], &indices, None, GROUPED_PROPTEST_GROUPS)
+                    .expect("update_batch must not fail");
+                states.push(acc.state(EmitTo::All).expect("state must not fail"));
+            }
+
+            let merge_indices: Vec<usize> = (0..GROUPED_PROPTEST_GROUPS).collect();
+            for order in [[0usize, 1, 2], [2, 1, 0], [1, 0, 2], [0, 2, 1]] {
+                let mut merged = ExactIntegerAvgGroupsAccumulator::new();
+                for idx in order {
+                    merged
+                        .merge_batch(&states[idx], &merge_indices, None, GROUPED_PROPTEST_GROUPS)
+                        .expect("merge_batch must not fail");
+                }
+                prop_assert_eq!(
+                    reference_bits.clone(),
+                    grouped_integer_bits(&mut merged),
+                    "merge order {:?} produced different per-group results than the single-partition fold",
+                    order
+                );
+            }
+        }
+    }
+
+    /// `EmitTo::First` must drain exactly the first `n` groups and leave the
+    /// remainder addressable at their shifted indices. An emit that returned
+    /// the right values but left `sums` and `counts` misaligned would
+    /// silently attribute later rows to the wrong group, which no
+    /// whole-batch test can see.
+    #[test]
+    fn exact_integer_grouped_emit_first_drains_and_shifts() {
+        let mut acc = ExactIntegerAvgGroupsAccumulator::new();
+        let values: ArrayRef = Arc::new(Int64Array::from(vec![10i64, 20, 30, 40, 100, 200]));
+        let group_indices = vec![0usize, 0, 1, 1, 2, 2];
+        acc.update_batch(&[values], &group_indices, None, 3)
+            .expect("update_batch must not fail");
+
+        let emitted = acc
+            .evaluate(EmitTo::First(2))
+            .expect("evaluate must not fail");
+        let emitted = emitted
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .expect("evaluate must return a Float64Array");
+        assert_eq!(
+            emitted.len(),
+            2,
+            "EmitTo::First(2) must emit exactly 2 groups"
+        );
+        assert_eq!(emitted.value(0), 15.0);
+        assert_eq!(emitted.value(1), 35.0);
+
+        let rest = acc.evaluate(EmitTo::All).expect("evaluate must not fail");
+        let rest = rest
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .expect("evaluate must return a Float64Array");
+        assert_eq!(rest.len(), 1, "one group must remain after draining two");
+        assert_eq!(
+            rest.value(0),
+            150.0,
+            "the surviving group's state must shift down, not be re-read at its old index"
+        );
     }
 }

--- a/crates/ravel-sql/src/executor.rs
+++ b/crates/ravel-sql/src/executor.rs
@@ -1610,12 +1610,24 @@ fn aggregate_expr_is_exact(expr: &Expr, schema: &DFSchema) -> bool {
             // A sum/min/max with no argument should not occur; fail closed.
             None => false,
         },
-        // `avg`/`mean` always run plain IEEE f64 addition (crate::avg), so they
-        // are never exact regardless of input type: an integer argument is
-        // coerced to Float64 before it reaches any accumulator, so the partial
-        // sum state is f64 there too and a cross-partition merge of it is
-        // order-dependent (ADR-0094's amendment for issue #771). Any other name
-        // is outside the admitted aggregate set and fails closed.
+        // `avg`/`mean` over a resolved integer input runs exact i128
+        // accumulation with checked addition (crate::avg, ADR-0825 decision
+        // 2): the analyzer coerces the admitted integer types (Int8-Int64,
+        // UInt8-UInt32) to Int64, so a resolved Int64 argument's partial sum
+        // is exact regardless of partitioning or merge order. A Float64
+        // argument still runs the plain IEEE f64 fold (ADR-0094's original
+        // amendment for issue #771) and stays never exact: that partial sum
+        // is order-dependent. Any other resolved type (Decimal, Duration) is
+        // unreachable on the v1 `samples` surface and fails closed.
+        "avg" | "mean" => match aggregate_function.params.args.first() {
+            Some(arg) => matches!(
+                arg.get_type(schema),
+                Ok(datafusion::arrow::datatypes::DataType::Int64)
+            ),
+            None => false,
+        },
+        // Any other name is outside the admitted aggregate set and fails
+        // closed.
         _ => false,
     }
 }
@@ -2062,7 +2074,7 @@ mod tests {
     /// alone. Proven by inspecting the coerced argument's type, not just that the
     /// code compiles.
     #[tokio::test]
-    async fn analyzer_coerces_avg_argument_to_float64() {
+    async fn analyzer_preserves_avg_integer_argument_as_int64() {
         use datafusion::arrow::datatypes::DataType;
 
         let exec = eviction_test_executor();
@@ -2098,13 +2110,55 @@ mod tests {
             .expect("argument type resolves");
         assert_eq!(
             arg_type,
-            DataType::Float64,
-            "the analyzer must coerce avg(int) to a Float64 argument"
+            DataType::Int64,
+            "an admitted integer argument to avg must stay Int64, not widen to Float64 (ADR-0825 decision 2)"
         );
-        // And avg is never exact regardless of that resolved type.
+        // And avg over that resolved Int64 argument is exact.
+        assert!(
+            aggregate_expr_is_exact(expr, schema),
+            "avg over a resolved integer input is exact-eligible (ADR-0094 amendment, ADR-0825 decision 3)"
+        );
+    }
+
+    #[tokio::test]
+    async fn analyzer_still_coerces_avg_float_argument_to_float64() {
+        use datafusion::arrow::datatypes::DataType;
+
+        let exec = eviction_test_executor();
+        let plan = exec
+            .analyzed_classification_plan(
+                TenantHash([9u8; 16]),
+                "SELECT avg(value) AS a FROM samples",
+                &[],
+            )
+            .await
+            .expect("throwaway avg plan analyzes");
+
+        let mut aggregates = Vec::new();
+        let mut distincts = Vec::new();
+        collect_aggregate_exprs(&plan, &mut aggregates, &mut distincts);
+        let aggregate = aggregates.first().expect("one aggregate node");
+        let schema = aggregate.input.schema().as_ref();
+        let expr = aggregate.aggr_expr.first().expect("one aggregate expr");
+        let inner = match expr {
+            Expr::Alias(alias) => alias.expr.as_ref(),
+            other => other,
+        };
+        let Expr::AggregateFunction(af) = inner else {
+            panic!("aggregate expression is not an AggregateFunction: {inner:?}");
+        };
+        let arg_type = af
+            .params
+            .args
+            .first()
+            .expect("avg has an argument")
+            .get_type(schema)
+            .expect("argument type resolves");
+        assert_eq!(arg_type, DataType::Float64);
+        // Float avg is never exact.
         assert!(
             !aggregate_expr_is_exact(expr, schema),
-            "avg is never exact-eligible (ADR-0094 decision 1)"
+            "avg over a Float64 input is never exact-eligible (ADR-0094 decision 1)"
         );
     }
 
@@ -2155,10 +2209,15 @@ mod tests {
                 .classify_exact_typed(t, "SELECT DISTINCT value FROM samples", &[])
                 .await
         );
-        // avg over integer input: not exact.
+        // avg over a resolved integer input: exact (ADR-0825 decision 3).
+        assert!(
+            exec.classify_exact_typed(t, "SELECT avg(CAST(value AS BIGINT)) FROM samples", &[])
+                .await
+        );
+        // avg over a float input: still not exact.
         assert!(
             !exec
-                .classify_exact_typed(t, "SELECT avg(CAST(value AS BIGINT)) FROM samples", &[])
+                .classify_exact_typed(t, "SELECT avg(value) FROM samples", &[])
                 .await
         );
         // A disqualifying float avg hidden inside a scalar subquery: not exact,

--- a/crates/ravel-sql/src/session.rs
+++ b/crates/ravel-sql/src/session.rs
@@ -68,8 +68,11 @@
 //! classification (`executor::SqlExecutor`) has proven every aggregate and
 //! GROUP BY key in the query is order/partition-independent -- `count`, and
 //! `sum`/`min`/`max` over a resolved non-float input, with no float group key;
-//! `avg`/`mean` (always plain IEEE f64 addition) and any float input or key are
-//! never eligible. It is `false` for every other query and behind a default-off
+//! `avg`/`mean` over a resolved integer input is eligible too (ADR-0825
+//! decision 3): its partial sum is exact `i128` accumulation, never plain f64
+//! addition. `avg`/`mean` over a resolved Float64 input (still plain IEEE f64
+//! addition) and any float input or key are never eligible. It is `false`
+//! for every other query and behind a default-off
 //! `SqlConfig` flag, so this is byte-identical to the old single-partition plan
 //! unless an operator opts in. The join/sort/window/file-scan knobs stay
 //! unconditionally `false`: their determinism requirements are out of ADR-0094's

--- a/crates/ravel-sql/tests/parallel_final_default.rs
+++ b/crates/ravel-sql/tests/parallel_final_default.rs
@@ -30,35 +30,46 @@
 //!
 //! Issue #771 proposed admitting `avg` over an integer column on the premise
 //! that its partial state is an exact `(sum, count)` pair. The ADR-0094
-//! amendment for #771 rejects that premise; three more tests pin the facts the
-//! rejection rests on. They are not a uniform staleness guard, and the
-//! amendment states which branch each one covers: a decimal partial state
-//! upstream reddens the first, an integer one does not (this crate's
-//! `SequentialAvg` displaces DataFusion's accumulator whenever the return type
-//! is Float64, so upstream's state never reaches the plan), and the
-//! order-dependence test is a pinned illustration that consults no symbol from
-//! either crate.
+//! amendment for #771 rejected that premise for DataFusion's own accumulator
+//! and this crate's original `SequentialAvg`, both of which folded every
+//! `avg` numerator as Float64 regardless of input type, making a
+//! cross-partition merge of the partial sum order-dependent.
 //!
-//! - `avg_over_int_column_carries_a_float64_partial_sum_state`: the `Partial`
-//!   aggregate for `avg(k)` over a declared `Int64` `k` emits a **Float64**
-//!   partial-sum state column, not an integer or decimal one.
-//! - `f64_partial_sum_merge_is_order_dependent_for_integer_input`: adding
-//!   Float64 partial sums of ordinary `i64` values in two different orders
-//!   yields two different bit patterns, so merging avg's partial states across
-//!   partitions is not exact.
-//! - `avg_group_by_int_key_agrees_and_stays_single_final` and
-//!   `avg_over_float_input_stays_single_partition`: a `GROUP BY` avg over the
-//!   integer column returns identical pinned values with the flag on and off
-//!   and keeps the single-partition final in both, even though its group key is
-//!   the non-float kind ADR-0094 otherwise admits; the float-input avg keeps it
-//!   too.
+//! ADR-0825 revisits that rejection for the integer case specifically: `avg`
+//! over a resolved integer argument (`Int8`-`Int64`, `UInt8`-`UInt32`) now
+//! stays `Int64` through the analyzed plan (crate::avg's `coerce_types`) and
+//! accumulates in `i128` with checked addition, so its partial state really
+//! is the exact `(Decimal128(38, 0) sum, Int64 count)` pair #771 wanted, and
+//! `aggregate_expr_is_exact` (`executor.rs`) admits it. `avg` over a Float64
+//! argument is untouched: it still folds as plain IEEE f64, still carries an
+//! order-dependent partial sum, and is still never exact. Four tests pin the
+//! facts on each side of that split:
 //!
-//! Both of those carry a `GROUP BY` because an **ungrouped** avg is the wrong
-//! shape to test the gate with: DataFusion does not repartition a single-row
-//! aggregate, so `avg_stays_single_partition_under_default` above holds whether
-//! or not the classifier admits avg (verified by admitting it and watching that
-//! test stay green while the grouped ones went red). The grouped shapes are the
-//! load-bearing guards.
+//! - `avg_over_int_column_carries_a_decimal128_partial_sum_state`: the
+//!   `Partial` aggregate for `avg(k)` over a declared `Int64` `k` emits a
+//!   **Decimal128(38, 0)** partial-sum state column, the exact-integer kind,
+//!   not a Float64 one.
+//! - `f64_partial_sum_merge_is_order_dependent`: adding Float64 partial sums
+//!   of ordinary `i64` values in two different orders yields two different
+//!   bit patterns. This is no longer why avg over an integer *column* is
+//!   non-exact (it isn't, per the point above), but it is exactly why avg
+//!   over a Float64 *argument* stays non-exact: that path still folds in
+//!   f64, whatever type the underlying column was declared as.
+//! - `avg_group_by_int_key_repartitions_final_under_default`: a `GROUP BY`
+//!   avg over the integer column now fans its final aggregation out under
+//!   the default (`FinalPartitioned` + a hash repartition), the same shape
+//!   `sum`/`COUNT(DISTINCT ...)` get, and returns identical pinned bits with
+//!   the flag on and off.
+//! - `avg_over_float_input_stays_single_partition`: the same `GROUP BY`
+//!   shape, but with an explicit Float64 argument, keeps the
+//!   single-partition final in both flag states -- proving the exact-integer
+//!   admission does not leak into the float path.
+//!
+//! Both of the last two carry a `GROUP BY` because an **ungrouped** aggregate
+//! is the wrong shape to test the gate with: DataFusion does not repartition
+//! a single-row aggregate, so `avg_stays_single_partition_under_default`
+//! above holds regardless of whether the classifier admits the statement.
+//! The grouped shapes are the load-bearing guards.
 
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
@@ -419,8 +430,12 @@ async fn opt_out_count_distinct_int_stays_single_partition() {
 
 #[tokio::test]
 async fn avg_stays_single_partition_under_default() {
-    // avg resolves to Float64 (a float accumulator), so it is not exact-typed
-    // and must keep the single-partition final even though the default is on.
+    // avg(k) over the declared Int64 column is exact-typed under ADR-0825,
+    // but an ungrouped aggregate is never repartitioned regardless of what
+    // the classifier says (a single scalar row has nothing to fan out), so
+    // this must keep the single-partition final even though the default is
+    // on. See `avg_group_by_int_key_repartitions_final_under_default` below
+    // for the grouped shape that actually exercises the classification gate.
     let fixture = Fixture::build(Fixture::config(
         SqlConfig::default().parallel_final_aggregation,
     ))
@@ -439,7 +454,7 @@ async fn avg_stays_single_partition_under_default() {
     );
     assert!(
         plan.contains("AggregateExec: mode=Final,"),
-        "the non-exact avg keeps the single-partition Final aggregate; got:\n{plan}"
+        "an ungrouped avg keeps the single-partition Final aggregate; got:\n{plan}"
     );
 }
 
@@ -463,17 +478,17 @@ fn expected_grouped_avg_rows() -> Vec<(i64, u64)> {
 }
 
 #[tokio::test]
-async fn avg_over_int_column_carries_a_float64_partial_sum_state() {
-    // Issue #771's premise was that avg over an integer column carries an exact
-    // (sum, count) partial state, making a cross-partition merge exact. It does
-    // not: DataFusion 54.1.0 coerces every non-decimal, non-duration avg
-    // argument to Float64 (average.rs:101-113 signature, :168 return type,
-    // :179 comment), and the accumulator that actually serves this plan holds
-    // the numerator as f64: this crate's `SequentialAvgAccumulator` (avg.rs),
-    // registered over the built-in. DataFusion's own `AvgAccumulator { sum:
-    // Option<f64>, count: u64 }` (average.rs:505-508) is the same shape, so the
-    // premise fails either way, but only the replacement is observable here.
-    // The partial state column type in the plan is the observable form.
+async fn avg_over_int_column_carries_a_decimal128_partial_sum_state() {
+    // Issue #771's premise was that avg over an integer column carries an
+    // exact (sum, count) partial state, making a cross-partition merge exact.
+    // ADR-0825 makes that premise true for the integer case: `k` is a
+    // declared Int64 column, an admitted integer type, so crate::avg's
+    // `coerce_types` keeps its argument Int64 instead of widening it to
+    // Float64, and `ExactIntegerAvgAccumulator`/
+    // `ExactIntegerAvgGroupsAccumulator` (avg.rs) accumulate the numerator in
+    // i128 with checked addition. Its partial state is `(Decimal128(38, 0)
+    // sum, Int64 count)`. The partial state column type in the plan is the
+    // observable form.
     let fixture = Fixture::build(Fixture::config(
         SqlConfig::default().parallel_final_aggregation,
     ))
@@ -487,17 +502,17 @@ async fn avg_over_int_column_carries_a_float64_partial_sum_state() {
         .find(|line| line.contains("AggregateExec: mode=Partial"))
         .unwrap_or_else(|| panic!("expected a Partial AggregateExec; got:\n{plan}"));
     assert!(
-        partial.contains("[avg_sum]:Float64"),
-        "avg's partial sum state over an Int64 column must be Float64 (issue #771's \
-         exact-(sum, count) premise is false); got:\n{partial}"
+        partial.contains("[avg_sum]:Decimal128(38, 0)"),
+        "avg's partial sum state over an admitted-integer column must be \
+         Decimal128(38, 0), the exact-integer kind (ADR-0825 decision 2); got:\n{partial}"
     );
     assert!(
         partial.contains("[avg_count]:Int64"),
         "avg's partial count state must be an integer count; got:\n{partial}"
     );
-    // The exact-typed aggregate for the same column, for contrast: sum(k)
-    // really does carry an Int64 partial state, which is why sum over an
-    // integer input is admitted and avg is not.
+    // The other exact-typed aggregate over the same column, for contrast:
+    // sum(k) carries a plain Int64 partial state (unchanged by ADR-0825,
+    // which explicitly does not touch the public `sum` aggregate).
     let sum_plan = fixture
         .physical_plan_text_with_schema("SELECT sum(k) AS s FROM logs")
         .await;
@@ -513,13 +528,13 @@ async fn avg_over_int_column_carries_a_float64_partial_sum_state() {
 
 #[tokio::test]
 async fn avg_over_float_input_stays_single_partition() {
-    // The other half of the #771 amendment: an avg whose input is float before
-    // coercion is excluded too. (The logs surface declares no float column
-    // type, so the float input is an explicit cast; the planner then drops the
-    // cast, because Float64 is where avg's coercion sends an Int64 argument
-    // anyway. That collapse is the amendment's second point in visible form:
-    // after analysis, avg over an integer column and avg over a float one are
-    // the same plan, so the classifier has no resolved type to admit one by.)
+    // ADR-0825 splits avg into two resolved-type kinds and only admits one:
+    // an explicit CAST(k AS DOUBLE) resolves to Float64 before the aggregate
+    // is classified, so it keeps the order-dependent f64 partial-sum
+    // accumulator and stays outside `aggregate_expr_is_exact`, unlike the
+    // bare Int64 column the sibling test above exercises. The logs surface
+    // declares no native float column, so this is the only way to put a
+    // Float64 argument in front of avg.
     // The statement carries an Int64 GROUP BY key for the reason the module doc
     // gives: an ungrouped aggregate is never repartitioned whatever the
     // classifier says, so only a grouped shape can tell an excluded avg from an
@@ -547,13 +562,18 @@ async fn avg_over_float_input_stays_single_partition() {
 }
 
 #[test]
-fn f64_partial_sum_merge_is_order_dependent_for_integer_input() {
+fn f64_partial_sum_merge_is_order_dependent() {
     // Three ordinary i64 values a log column can hold. Folded as f64 (which is
-    // what avg does, per the test above), the two groupings a repartitioned
-    // merge can produce differ in the last bit: 2^53 + 1 rounds back to 2^53,
-    // while 1 + 1 = 2 survives and 2^53 + 2 is representable. So the partial
-    // sums of a group split across partitions do not merge exactly, and the
-    // division that follows inherits the difference.
+    // what avg does whenever its argument resolves to Float64), the two
+    // groupings a repartitioned merge can produce differ in the last bit:
+    // 2^53 + 1 rounds back to 2^53, while 1 + 1 = 2 survives and 2^53 + 2 is
+    // representable. So the partial sums of a group split across partitions
+    // do not merge exactly, and the division that follows inherits the
+    // difference. This is no longer why avg over an integer *column* is
+    // non-exact -- ADR-0825 gives that case an exact i128 accumulator that
+    // never folds through f64 -- but it is exactly why avg over a Float64
+    // *argument* stays non-exact regardless of what the underlying column
+    // was declared as.
     let values: [i64; 3] = [1 << 53, 1, 1];
     let one_partition = ((values[0] as f64) + values[1] as f64) + values[2] as f64;
     let two_partitions = (values[0] as f64) + ((values[1] as f64) + values[2] as f64);
@@ -569,13 +589,18 @@ fn f64_partial_sum_merge_is_order_dependent_for_integer_input() {
     assert_ne!(
         one_partition.to_bits(),
         two_partitions.to_bits(),
-        "if f64 addition of these i64 values were associative, avg over integer \
-         input could merge across partitions exactly (issue #771)"
+        "if f64 addition of these i64 values were associative, avg over a Float64 \
+         argument could merge partial sums across partitions exactly"
     );
 }
 
 #[tokio::test]
-async fn avg_group_by_int_key_agrees_and_stays_single_final() {
+async fn avg_group_by_int_key_repartitions_final_under_default() {
+    // ADR-0825: avg over the admitted-integer column is exact-typed, so under
+    // the default it must get the same FinalPartitioned/Hash-repartition
+    // shape sum/COUNT(DISTINCT ...) get, and the opt-out must restore the
+    // single-partition final -- the same pair the COUNT(DISTINCT k) tests
+    // above pin, now for avg.
     let on = Fixture::build(Fixture::config(true)).await;
     let off = Fixture::build(Fixture::config(false)).await;
 
@@ -589,25 +614,31 @@ async fn avg_group_by_int_key_agrees_and_stays_single_final() {
     );
     assert_eq!(
         on_rows, off_rows,
-        "avg over an integer column must return identical bits with the flag on and off"
+        "avg over an integer column must return identical bits with the flag on and off: \
+         i128 addition is associative and exact, so partitioning cannot move the result"
     );
 
-    // And it stays on the single-partition final in both, which is why the two
-    // agree: the group key is Int64 (admissible on its own), so avg is the only
-    // disqualifier here.
-    for (label, plan) in [
-        ("flag on", on.physical_plan_text(GROUP_BY_AVG_SQL).await),
-        ("flag off", off.physical_plan_text(GROUP_BY_AVG_SQL).await),
-    ] {
-        assert!(
-            !plan.contains("AggregateExec: mode=FinalPartitioned"),
-            "{label}: an avg must never fan its final aggregation out; got:\n{plan}"
-        );
-        assert!(
-            plan.contains("AggregateExec: mode=Final,"),
-            "{label}: the avg keeps the single-partition Final aggregate; got:\n{plan}"
-        );
-    }
+    let on_plan = on.physical_plan_text(GROUP_BY_AVG_SQL).await;
+    assert!(
+        on_plan.contains("AggregateExec: mode=FinalPartitioned"),
+        "flag on: an exact-typed avg over an integer column must fan its final \
+         aggregation out; got:\n{on_plan}"
+    );
+    assert!(
+        on_plan.contains("RepartitionExec: partitioning=Hash"),
+        "flag on: the fanned-out final aggregate must be fed by a hash repartition; \
+         got:\n{on_plan}"
+    );
+
+    let off_plan = off.physical_plan_text(GROUP_BY_AVG_SQL).await;
+    assert!(
+        !off_plan.contains("AggregateExec: mode=FinalPartitioned"),
+        "flag off: the opt-out must not fan the final aggregation out; got:\n{off_plan}"
+    );
+    assert!(
+        off_plan.contains("AggregateExec: mode=Final,"),
+        "flag off: the opt-out keeps a single-partition Final aggregate; got:\n{off_plan}"
+    );
 }
 
 #[tokio::test]

--- a/crates/ravel-sql/tests/parallel_final_default.rs
+++ b/crates/ravel-sql/tests/parallel_final_default.rs
@@ -446,11 +446,11 @@ async fn avg_stays_single_partition_under_default() {
 
     assert!(
         !plan.contains("AggregateExec: mode=FinalPartitioned"),
-        "a float avg must never fan its final aggregation out, default or not; got:\n{plan}"
+        "an ungrouped integer avg must never fan its final aggregation out, default or not; got:\n{plan}"
     );
     assert!(
         !plan.contains("RepartitionExec: partitioning=Hash"),
-        "a float avg must never get a hash repartition, default or not; got:\n{plan}"
+        "an ungrouped integer avg must never get a hash repartition, default or not; got:\n{plan}"
     );
     assert!(
         plan.contains("AggregateExec: mode=Final,"),

--- a/docs/adrs/0022-floating-aggregate-exactness.md
+++ b/docs/adrs/0022-floating-aggregate-exactness.md
@@ -139,7 +139,11 @@ What the pinned datafusion 54.1.0 accumulators actually do
    exactness here, since the gate compares against a reference running
    the identical algorithm either way, and higher-accuracy summation is a
    different decision that re-enters through this same admission rule if
-   ever wanted.
+   ever wanted. Amended by ADR-0825: this f64 fold only runs when `avg`'s
+   argument resolves to Float64. An argument that resolves to an admitted
+   integer type instead coerces to Int64 and sums exactly in `i128`,
+   which needs no fold-order pinning at all, integer addition is
+   associative.
 4. **`avg`/`mean` are admitted via a custom UDAF**: decision 3's internal
    fold divided by the non-null row count in one correctly rounded IEEE
    division; a zero count yields NULL, never NaN or infinity. The row

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -1996,31 +1996,35 @@ the pre-amendment single-partition final for every query (the bare
 is per-query and decided from the query's fully type-coerced (analyzed) plan:
 
 - **Eligible:** `count(...)` and `count(DISTINCT ...)` over any type; `sum`,
-  `min`, `max` over a resolved **non-float** input.
-- **Never eligible:** `avg`/`mean` over **any** input type (their UDAF always
-  runs plain IEEE f64 addition, which is not associative once a running sum
-  exceeds 2^53, so it depends on the single-partition fold order); any `sum`,
-  `min`, `max` over a `Float16`/`Float32`/`Float64` input; and any **float
-  GROUP BY key** (including a bare `SELECT DISTINCT float_col`), because
-  `-0.0`/NaN payloads are bit-significant here and no merge-order-stable
-  representative bit pattern for a float group key is proven.
+  `min`, `max` over a resolved **non-float** input; `avg`/`mean` over a
+  resolved **integer** input (ADR-0825, amending the `#771` rejection below).
+- **Never eligible:** `avg`/`mean` over a resolved **Float64** input (its UDAF
+  runs plain IEEE f64 addition for that kind, which is not associative once a
+  running sum exceeds 2^53, so it depends on the single-partition fold order);
+  any `sum`, `min`, `max` over a `Float16`/`Float32`/`Float64` input; and any
+  **float GROUP BY key** (including a bare `SELECT DISTINCT float_col`),
+  because `-0.0`/NaN payloads are bit-significant here and no
+  merge-order-stable representative bit pattern for a float group key is
+  proven.
 
-`avg` over an **integer** column is excluded by that same rule, and the reason
-is worth stating because the shape looks admissible: an integer argument never
-reaches an accumulator as an integer. DataFusion coerces every non-decimal,
-non-duration `avg` argument to `Float64` before planning finishes, so the
-partial state a two-phase `avg` carries is a **Float64** sum with an integer
-count -- not the exact `(integer sum, count)` pair that would merge across
-partitions without loss. Merging those partial sums is f64 addition and depends
-on how the group was split. A second consequence of the same coercion: after
-analysis both `avg(int_col)` and `avg(float_col)` carry a `Float64` argument
-type, so the classifier has no resolved type by which it could admit one and
-reject the other. The two analyzed nodes are not otherwise identical -- coercion
-adds a cast to the integer case and name preservation renames it back -- so it
-is the argument type that defeats the classifier, not plan identity. See the ADR-0094 amendment for issue
-`#771`, which rejects admitting `avg` on this basis and lists the routes that
-could instead fix the wide-`GROUP BY` `avg` statements that exhaust the memory
-pool today (issue `#741`).
+Originally `avg` over an **integer** column was excluded by the same
+fold-order rule that excludes Float64 `avg`, for a reason the ADR-0094
+amendment for issue `#771` describes at length: DataFusion's built-in `avg`
+coerces every non-decimal, non-duration argument to `Float64` before planning
+finishes, so an integer argument never reached an accumulator as an integer,
+and the classifier had no resolved type by which it could tell `avg(int_col)`
+from `avg(float_col)` apart. ADR-0825 changes the premise: the `avg`/`mean`
+UDAF (`crate::avg`) now coerces an admitted integer argument (`Int8`-`Int64`,
+`UInt8`-`UInt32`) to `Int64` and keeps it there instead of widening to
+`Float64`, and sums it exactly in `i128` with checked addition. That partial
+state is the real `(exact sum, count)` pair issue `#771` found missing --
+carried as `(Decimal128(38, 0), Int64)` -- and integer addition is
+associative, so merging it across partitions in any order reproduces the
+single-partition result exactly. `avg(int_col)` and `avg(float_col)` are
+therefore no longer the same analyzed node: the integer argument keeps its
+Int64 type through analysis instead of widening, which is exactly what the
+classifier now keys on. `avg` over a Float64 argument is unaffected and stays
+excluded for the reason above.
 
 A single disqualifying aggregate or key anywhere in the query -- including inside
 a scalar/`IN`/`EXISTS` subquery -- forces the whole query onto the


### PR DESCRIPTION
The first CPU profile of the query path found GroupsAccumulatorAdapter at
42.67% of all scan CPU while SequentialAvgAccumulator's own methods were
0.38% and 0.12%. The cost was adapter machinery, not arithmetic: avg
declined to provide a groups accumulator, so grouped execution allocated
one boxed accumulator and its ScalarValues per group. All RLOG decode
combined was about 5%, so this one aggregate choice outweighed every open
I/O ticket. It also explains the two statements that fail: q33 groups by
WatchID and ClientIP with an avg and exhausts the pool, while q32 is the
same statement plus a WHERE clause and completes.

Float input keeps a sequential-order fold and is bit-identical to the
shipped path. The adapter also folded each group in input row order, so a
scalar row-order loop over flat per-group state sheds the adapter without
changing a single bit. No arrow reduction kernels: a lane-parallel
reduction would reorder the fold, which is the one thing ADR-0022 forbids.

Integer input stops delegating coercion and keeps Int64 in the analyzed
plan, summing into i128 with checked addition. Partial state is a
Decimal128(38, 0) sum and an Int64 count, and packing the i128 into
Decimal128 is checked rather than assumed. Integer addition is
associative and commutative, so every partitioning and every merge order
yields identical bits: the determinism guarantee is kept by exactness
instead of by ordering. That admits integer avg to ADR-0094's
repartitioned final, which its issue 771 amendment had rejected only
because the arithmetic underneath was inexact.

Float min and max get the same flat-state treatment under total_cmp.
Admitting them to the repartitioned final is deliberately out of scope.

Tests: bit-identical float avg between the plain and grouped paths over
NaN payloads, infinities, all-null and empty inputs; a proptest that
splits integer input across partitions and merges in varying orders
against a reference fold's bits; and overflow tests proving the checked
i128 addition and the Decimal128 pack surface typed errors rather than
wrapping.

Refs: #825
Refs: #740
