### PR TITLE
build: update chacha20 off the yanked 0.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -964,9 +964,9 @@ dependencies = [
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures",


### PR DESCRIPTION
chacha20 0.10.1 was yanked upstream, so `cargo deny check` fails its
advisories section on every branch and blocks every pull request, not
just the one where it was noticed. The same failure shape as the arrayref
yank of 2026-08-20.

Bump the lockfile to 0.10.2. No manifest change: nothing depends on
chacha20 directly, it arrives transitively, and only the resolved version
moves.

Verified with `cargo deny check` locally: advisories ok, bans ok,
licenses ok, sources ok.

Refs: #680