### PR TITLE
fix: query cost on every exit path, and pin the fast path's PAGE_DIR projection

### DIFF
--- a/crates/ravel-query/src/log_fetcher.rs
+++ b/crates/ravel-query/src/log_fetcher.rs
@@ -1055,10 +1055,27 @@ impl LogSegmentFetcher {
             && Self::ts_range_relevant(seg_ref, query.ts_min_ns, query.ts_max_ns)
             && Self::plan_skip_decidable(query)
         {
-            let (footer, skip, field_dir, _stats) = self
-                .block_range
-                .fetch_plan_sections(seg_ref, tenant_hash, accounting)
-                .await?;
+            // The `page_fetch` phase span the other plan paths carry (#782), so
+            // the trace shows the probe and section GETs this branch issues.
+            // `s3_bytes` reports block bytes only, which are structurally zero
+            // here; the directory-overhead bytes are recorded in `accounting`.
+            let fetch_span = tracing::debug_span!(
+                "page_fetch",
+                signal = "logs",
+                s3_requests = tracing::field::Empty,
+                s3_bytes = tracing::field::Empty,
+            );
+            let (footer, skip, field_dir, stats) = async {
+                self.block_range
+                    .fetch_plan_sections(seg_ref, tenant_hash, accounting)
+                    .await
+            }
+            .instrument(fetch_span.clone())
+            .await?;
+            let requests = stats.probe_gets + stats.metadata_gets + stats.block_range_gets;
+            fetch_span.record("s3_requests", requests);
+            fetch_span.record("s3_bytes", stats.block_bytes_fetched);
+
             let refs: Vec<&Predicate> = query.prune.iter().collect();
             let numeric = field_dir.numeric_range_arms(&refs);
             let survivors = skip
@@ -4395,6 +4412,475 @@ mod plan_fast_path_tests {
         assert!(
             acc.snapshot().total_s3_bytes() > tail,
             "at-threshold: block-range fetch ran, not the footer-only probe"
+        );
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod whole_segment_projection_tests {
+    //! Pins #790: `scan_whole_accounted_with_tenant` (the predicate-free
+    //! whole-segment fast path, #693 part 3) decodes only the pages its
+    //! `ColumnSelection` projects, the same PAGE_DIR-driven per-page column
+    //! skip `decode_v4_block` already applies on every other scan path
+    //! (ADR-0699 decisions 1, 2, 5), rather than decoding every column of
+    //! every block after its one whole-object GET.
+
+    use super::*;
+    use ravel_catalog::SegmentLevel;
+    use ravel_logseg::writer::ObjectIdentity;
+    use ravel_logseg::{RlogWriter, stream_attrs_bytes};
+    use ravel_object_store::PutOptions;
+    use ravel_object_store::memory::MemoryStore;
+    use ravel_types::logstream::log_stream_id;
+    use uuid::Uuid;
+
+    const TENANT: TenantHash = TenantHash([11u8; 16]);
+    const CONTENT_HASH: [u8; 32] = [13u8; 32];
+    const KEY: &str = "t/whole-projection.rlog";
+
+    fn identity() -> ObjectIdentity {
+        ObjectIdentity {
+            tenant_hash: [11u8; 16],
+            shard: 0,
+            writer_id: [3u8; 16],
+            writer_epoch: 1,
+            writer_seq: 1,
+        }
+    }
+
+    fn record(ts: i64) -> LogRecord {
+        let resource = vec![("service.name".to_string(), AttrValue::Str("svc".into()))];
+        LogRecord {
+            stream_id: log_stream_id(&resource, "scope", "1.0", &[]),
+            stream_attrs: stream_attrs_bytes(&resource, "scope", "1.0", &[]),
+            ts_ns: ts,
+            observed_ts_ns: ts,
+            severity_num: 9,
+            severity_text: "INFO".into(),
+            body: format!("body-{ts}"),
+            trace_id: None,
+            span_id: None,
+            flags: 0,
+            attrs: vec![("request.id".to_string(), AttrValue::Str(format!("r{ts}")))],
+        }
+    }
+
+    /// One block per record (`block_target_records: 1`), all inside the one
+    /// default row group (`group_target_blocks` 32 covers `N` < 32 blocks), so
+    /// PAGE_DIR lists exactly one page per column per block with no
+    /// cross-group split to complicate the page count.
+    fn build_object(records: &[LogRecord]) -> Vec<u8> {
+        let cfg = RlogConfig {
+            block_target_records: 1,
+            ..RlogConfig::default()
+        };
+        let mut w = RlogWriter::new(cfg, identity());
+        for r in records {
+            w.push(r.clone()).expect("push");
+        }
+        w.finish().expect("finish")
+    }
+
+    fn seg_ref(size: u64, records: &[LogRecord]) -> SegmentRef {
+        let min = records.iter().map(|r| r.ts_ns).min().expect("nonempty");
+        let max = records.iter().map(|r| r.ts_ns).max().expect("nonempty");
+        SegmentRef {
+            data_object_key: KEY.to_string(),
+            object_size: size,
+            min_event_ts_ns: min,
+            max_event_ts_ns: max,
+            ingest_hour_bucket: 0,
+            sample_count: records.len() as u64,
+            series_count: 0,
+            shard: 0,
+            content_hash: CONTENT_HASH,
+            writer_id: Uuid::from_u128(1),
+            writer_epoch: 1,
+            writer_seq: 1,
+            created_unix_ns: 0,
+            level: SegmentLevel::L0,
+        }
+    }
+
+    async fn store_with_object(bytes: Vec<u8>) -> Arc<MemoryStore> {
+        let store = Arc::new(MemoryStore::new());
+        store
+            .put(KEY, Bytes::from(bytes), PutOptions::default())
+            .await
+            .expect("put");
+        store
+    }
+
+    /// Drains a whole-segment scan to completion and returns its final stats.
+    async fn drain(
+        f: &LogSegmentFetcher,
+        seg: &SegmentRef,
+        columns: &ColumnSelection,
+    ) -> ScanStats {
+        let acc = QueryAccounting::new();
+        let mut scan = f
+            .scan_whole_accounted_with_tenant(
+                seg,
+                TENANT,
+                &LogQuery::new(i64::MIN, i64::MAX),
+                columns,
+                &acc,
+            )
+            .await
+            .expect("scan")
+            .expect("relevant");
+        while scan.next_block().expect("next_block").is_some() {}
+        scan.stats()
+    }
+
+    /// A one-column projection (`ts`/`stream_ref` implicit, `body` requested --
+    /// the shape `SELECT ts, body FROM logs` resolves to, ADR-0087 decision 3)
+    /// through the whole-segment fast path decodes exactly `wanted` pages per
+    /// block and skips the rest. `wanted` is 3 by construction:
+    /// `ColumnSelection::fixed_only().with_body()` never touches the `attrs`/
+    /// `all_attrs` branch of `ColumnSelection::resolve` (`crates/ravel-logseg/
+    /// src/columns.rs`), so it resolves to exactly `{COL_TS, COL_STREAM_REF,
+    /// COL_BODY}` on any object, independent of that object's FIELD_DIR.
+    ///
+    /// `ColumnSelection::all()` on the SAME object is the baseline every other
+    /// page belongs to: `decode_v4_block`'s `wanted` closure (`crates/
+    /// ravel-logseg/src/reader.rs`) always returns `true` when `columns` is
+    /// `None` (which `all()` resolves to), so it decodes every page and skips
+    /// none. `all.pages_decoded - narrow.pages_decoded` is therefore exactly
+    /// the page count `narrow.pages_skipped` reports; the two are cross-checked
+    /// rather than asserted separately so a change that skips too many or too
+    /// few pages cannot land as a bytes-shrink alone.
+    ///
+    /// Non-vacuity: with `decode_v4_block`'s `let wanted = |cid: u32| match
+    /// columns { None => true, Some(set) => set.contains(&cid) };` changed to
+    /// always return `true` regardless of `columns` (decode every page, i.e.
+    /// reverting the projection this test pins), `narrow.pages_decoded` comes
+    /// out equal to `all.pages_decoded` and the `pages_decoded` assertion below
+    /// fails: `left: 48, right: 18` (confirmed by making exactly that edit and
+    /// rerunning). 48 is `8 * N`, this fixture's real per-block page count: the
+    /// seven fixed columns it populates (`ts`, `observed_ts`, `stream_ref`,
+    /// `severity_num`, `severity_text`, `body`, `flags`) plus its one dynamic
+    /// attribute column (`request.id`); `trace_id`/`span_id` are unset and get
+    /// no page, and nothing here overflows into `attrs_raw`.
+    #[tokio::test]
+    async fn narrow_projection_decodes_only_wanted_columns() {
+        const N: usize = 6;
+        let records: Vec<LogRecord> = (0..N as i64).map(record).collect();
+        let bytes = build_object(&records);
+        let total = bytes.len() as u64;
+        let seg = seg_ref(total, &records);
+        let store = store_with_object(bytes).await;
+        let f = LogSegmentFetcher::new(store);
+
+        let narrow = ColumnSelection::fixed_only().with_body();
+        let all_stats = drain(&f, &seg, &ColumnSelection::all()).await;
+        let narrow_stats = drain(&f, &seg, &narrow).await;
+
+        const WANTED: u64 = 3;
+        assert_eq!(
+            all_stats.pages_skipped, 0,
+            "ColumnSelection::all() decodes every page and skips none"
+        );
+        assert_eq!(
+            narrow_stats.pages_decoded,
+            WANTED * N as u64,
+            "one page per wanted column (ts, stream_ref, body) per block, over \
+             {N} blocks"
+        );
+        assert_eq!(
+            narrow_stats.pages_skipped,
+            all_stats.pages_decoded - narrow_stats.pages_decoded,
+            "every page the narrow selection didn't decode was skipped, not \
+             fetched or decoded"
+        );
+        assert!(
+            narrow_stats.page_bytes_decoded < all_stats.page_bytes_decoded,
+            "projecting to one column must decode fewer bytes than decoding \
+             every column: narrow {} B, all {} B",
+            narrow_stats.page_bytes_decoded,
+            all_stats.page_bytes_decoded
+        );
+        assert_eq!(
+            narrow_stats.blocks_scanned, N as u32,
+            "every block is still visited -- the fast path narrows decode, not \
+             which blocks it reads"
+        );
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod plan_skip_decidable_span_tests {
+    //! Pins #782: `plan_segment`'s skip-decidable branch (a query whose only
+    //! block-level predicate is a prune-only `NumRange` arm, #761) opens a
+    //! `page_fetch` span around its `fetch_plan_sections` read and records
+    //! that read's real request/byte counts on it, mirroring the pattern
+    //! `plan_segment_fast` and `plan_segment_block_stats` already carry.
+    //! Before the fix this branch's read was invisible to tracing: no span
+    //! wrapped it at all, so a trace over a query taking this branch showed
+    //! no `page_fetch` phase, only the ones plan_segment's other branches
+    //! open.
+
+    use super::*;
+    use ravel_catalog::SegmentLevel;
+    use ravel_logseg::writer::ObjectIdentity;
+    use ravel_logseg::{FieldSel, FieldType, RlogWriter, stream_attrs_bytes};
+    use ravel_object_store::PutOptions;
+    use ravel_object_store::memory::MemoryStore;
+    use ravel_types::logstream::log_stream_id;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+    use tracing_subscriber::layer::SubscriberExt;
+    use tracing_subscriber::util::SubscriberInitExt;
+    use uuid::Uuid;
+
+    const TENANT: TenantHash = TenantHash([21u8; 16]);
+    const CONTENT_HASH: [u8; 32] = [23u8; 32];
+    const KEY: &str = "t/skip-decidable-span.rlog";
+
+    fn identity() -> ObjectIdentity {
+        ObjectIdentity {
+            tenant_hash: [21u8; 16],
+            shard: 0,
+            writer_id: [4u8; 16],
+            writer_epoch: 1,
+            writer_seq: 1,
+        }
+    }
+
+    fn record(ts: i64, code: i64) -> LogRecord {
+        let resource = vec![("service.name".to_string(), AttrValue::Str("svc".into()))];
+        LogRecord {
+            stream_id: log_stream_id(&resource, "scope", "1.0", &[]),
+            stream_attrs: stream_attrs_bytes(&resource, "scope", "1.0", &[]),
+            ts_ns: ts,
+            observed_ts_ns: ts,
+            severity_num: 9,
+            severity_text: "INFO".into(),
+            body: "hello world".into(),
+            trace_id: None,
+            span_id: None,
+            flags: 0,
+            attrs: vec![("code".to_string(), AttrValue::I64(code))],
+        }
+    }
+
+    /// One block per record, so `n` records span `n` blocks -- irrelevant to
+    /// this test's own claim (it never inspects `ScanStats.blocks_*`), kept
+    /// only so the fixture matches the sibling modules' known-good shape.
+    fn build_object(records: &[LogRecord]) -> Vec<u8> {
+        let cfg = RlogConfig {
+            block_target_records: 1,
+            ..RlogConfig::default()
+        };
+        let mut w = RlogWriter::new(cfg, identity());
+        for r in records {
+            w.push(r.clone()).expect("push");
+        }
+        w.finish().expect("finish")
+    }
+
+    fn seg_ref(size: u64, records: &[LogRecord]) -> SegmentRef {
+        let min = records.iter().map(|r| r.ts_ns).min().expect("nonempty");
+        let max = records.iter().map(|r| r.ts_ns).max().expect("nonempty");
+        SegmentRef {
+            data_object_key: KEY.to_string(),
+            object_size: size,
+            min_event_ts_ns: min,
+            max_event_ts_ns: max,
+            ingest_hour_bucket: 0,
+            sample_count: records.len() as u64,
+            series_count: 0,
+            shard: 0,
+            content_hash: CONTENT_HASH,
+            writer_id: Uuid::from_u128(1),
+            writer_epoch: 1,
+            writer_seq: 1,
+            created_unix_ns: 0,
+            level: SegmentLevel::L0,
+        }
+    }
+
+    async fn store_with_object(bytes: Vec<u8>) -> Arc<MemoryStore> {
+        let store = Arc::new(MemoryStore::new());
+        store
+            .put(KEY, Bytes::from(bytes), PutOptions::default())
+            .await
+            .expect("put");
+        store
+    }
+
+    /// `block_range_threshold(0)` routes every object through the block-range
+    /// fetcher (`fetch_plan_sections`'s real path) rather than the small-object
+    /// whole-read shortcut, so the skip-decidable branch's own read is the one
+    /// under test.
+    fn fetcher(store: Arc<MemoryStore>) -> LogSegmentFetcher {
+        LogSegmentFetcher::new(store.clone())
+            .with_block_range_threshold(0)
+            .with_block_range(BlockRangeFetcher::new(store).with_whole_object_threshold(0))
+    }
+
+    /// The subset of a `page_fetch` span's fields this test asserts on.
+    #[derive(Default, Debug)]
+    struct Captured {
+        signal: Option<String>,
+        s3_requests: Option<u64>,
+        s3_bytes: Option<u64>,
+    }
+
+    struct FieldVisitor<'a>(&'a mut Captured);
+
+    impl tracing::field::Visit for FieldVisitor<'_> {
+        fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
+            match field.name() {
+                "s3_requests" => self.0.s3_requests = Some(value),
+                "s3_bytes" => self.0.s3_bytes = Some(value),
+                _ => {}
+            }
+        }
+
+        fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+            if field.name() == "signal" {
+                self.0.signal = Some(value.to_string());
+            }
+        }
+
+        fn record_debug(&mut self, _field: &tracing::field::Field, _value: &dyn std::fmt::Debug) {}
+    }
+
+    /// Records every `page_fetch` span's fields as of its close, keyed by span
+    /// id, so a test that opens exactly one such span can read back what it
+    /// carried once `plan_segment` returns and the span guard drops.
+    #[derive(Clone, Default)]
+    struct PageFetchCollector {
+        live: Arc<Mutex<HashMap<u64, (String, Captured)>>>,
+        closed: Arc<Mutex<Vec<Captured>>>,
+    }
+
+    impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for PageFetchCollector {
+        fn on_new_span(
+            &self,
+            attrs: &tracing::span::Attributes<'_>,
+            id: &tracing::span::Id,
+            _ctx: tracing_subscriber::layer::Context<'_, S>,
+        ) {
+            if attrs.metadata().name() != "page_fetch" {
+                return;
+            }
+            let mut captured = Captured::default();
+            attrs.record(&mut FieldVisitor(&mut captured));
+            if let Ok(mut live) = self.live.lock() {
+                live.insert(
+                    id.into_u64(),
+                    (attrs.metadata().name().to_string(), captured),
+                );
+            }
+        }
+
+        fn on_record(
+            &self,
+            id: &tracing::span::Id,
+            values: &tracing::span::Record<'_>,
+            _ctx: tracing_subscriber::layer::Context<'_, S>,
+        ) {
+            if let Ok(mut live) = self.live.lock()
+                && let Some((_, captured)) = live.get_mut(&id.into_u64())
+            {
+                values.record(&mut FieldVisitor(captured));
+            }
+        }
+
+        fn on_close(&self, id: tracing::span::Id, _ctx: tracing_subscriber::layer::Context<'_, S>) {
+            let taken = self
+                .live
+                .lock()
+                .ok()
+                .and_then(|mut live| live.remove(&id.into_u64()));
+            if let (Some((_, captured)), Ok(mut closed)) = (taken, self.closed.lock()) {
+                closed.push(captured);
+            }
+        }
+    }
+
+    /// A query whose only block-level predicate is a prune-only `NumRange` arm
+    /// takes `plan_segment`'s skip-decidable branch (`Self::plan_skip_decidable`:
+    /// `content` and `stream_attrs` empty, `prune` nonempty and every arm a
+    /// `NumRange`), which must open a `page_fetch` span around its
+    /// `fetch_plan_sections` read and record that read's real request/byte
+    /// counts on it -- not zero, not absent, the read this branch actually
+    /// issued.
+    ///
+    /// Non-vacuity: with the `fetch_span`/`.instrument(fetch_span.clone())`
+    /// wrapping removed from `plan_segment`'s skip-decidable branch (reverting
+    /// #782, i.e. calling `fetch_plan_sections` bare the way this branch did
+    /// before the fix), no span named `page_fetch` closes during this call at
+    /// all, `closed.len()` comes out `0`, and the `expect("plan_segment's \
+    /// skip-decidable branch opened exactly one page_fetch span")` below panics
+    /// instead of the two field assertions running.
+    ///
+    /// The subscriber is installed with the crate's own proven pattern for a
+    /// test-scoped tracing capture (`crates/ravel-query/src/fetcher.rs`'s
+    /// `phase_spans_never_record_onto_the_ambient_span_when_disabled`): a
+    /// `tracing_subscriber::registry()` layered with the collector and
+    /// installed via `set_default()`, held for the test body's scope. This is
+    /// thread-local, so it isolates cleanly from any `page_fetch` span a
+    /// concurrently-running sibling test opens under its own subscriber (or
+    /// none) -- unlike a process-global default, which every thread's spans
+    /// would route through and which this test's own sibling `plan_segment`
+    /// tests, several of which also open `page_fetch` spans, would pollute.
+    #[tokio::test]
+    async fn skip_decidable_branch_opens_page_fetch_span() {
+        let collector = PageFetchCollector::default();
+        let subscriber = tracing_subscriber::registry().with(collector.clone());
+        let _guard = subscriber.set_default();
+
+        const N: usize = 6;
+        let records: Vec<LogRecord> = (0..N as i64).map(|ts| record(ts, 500)).collect();
+        let bytes = build_object(&records);
+        let total = bytes.len() as u64;
+        let seg = seg_ref(total, &records);
+        let store = store_with_object(bytes).await;
+        let f = fetcher(store);
+        let acc = QueryAccounting::new();
+
+        let query = LogQuery::new(i64::MIN, i64::MAX).with_prune(Predicate::NumRange {
+            field: FieldSel::Attr("code".into()),
+            ty: FieldType::I64,
+            min: Some(0i64 as u64),
+            max: Some(1_000i64 as u64),
+        });
+        let (count, _stats, footer) = f
+            .plan_segment(&seg, TENANT, &query, &acc)
+            .await
+            .expect("plan_segment")
+            .expect("relevant segment");
+        assert_eq!(count, N, "wide NumRange bound excludes no block");
+        assert!(
+            footer.is_some(),
+            "skip-decidable branch forwards the parsed footer like the fast path does"
+        );
+
+        let closed = collector.closed.lock().expect("lock");
+        let span = closed
+            .first()
+            .expect("plan_segment's skip-decidable branch opened exactly one page_fetch span");
+        assert_eq!(
+            closed.len(),
+            1,
+            "exactly one page_fetch span for this one plan_segment call, not zero and not several"
+        );
+        assert_eq!(span.signal.as_deref(), Some("logs"));
+        assert!(
+            span.s3_requests.is_some_and(|n| n > 0),
+            "the span must carry the real request count fetch_plan_sections issued, got {:?}",
+            span.s3_requests
+        );
+        assert!(
+            span.s3_bytes.is_some(),
+            "the span must record s3_bytes (structurally 0 for this branch, but present, not \
+             Empty), got {:?}",
+            span.s3_bytes
         );
     }
 }

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -1712,9 +1712,15 @@ pages per block (`ts`, `stream_ref`, `body`) against 8 for
 `pages_skipped` exactly. A user observes the effect in `pages_decoded`/
 `page_bytes_decoded` on `ScanStats` (`EXPLAIN ANALYZE`'s per-partition page
 counters) and in reduced peak decode memory, never in request count or wire
-bytes -- those stay exactly where the #693-part-3 fast path already put them.
+bytes -- those stay exactly where the #693-part-3 fast path already put them. The
+"one GET per segment" figure counts one logical `GetRange::Full` read; a warm
+read cache serves it with zero store requests and zero wire bytes, as the
+tracing section states.
 Reachable from any predicate-free, fully-contained, narrow-projection
-statement that takes the fast path (`SELECT ts, body FROM logs` included).
+statement that takes the fast path. `SELECT ts, body FROM logs` is the
+worked example below: two selected SQL columns, and the reader also decodes
+the required `stream_ref`, which is why three pages per block survive and not
+one.
 Object size does not gate it: since #739 the fast path is chosen for a
 segment at or below the block-range threshold too, which is what the
 request-count paragraph above already states.

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -1714,8 +1714,10 @@ pages per block (`ts`, `stream_ref`, `body`) against 8 for
 counters) and in reduced peak decode memory, never in request count or wire
 bytes -- those stay exactly where the #693-part-3 fast path already put them.
 Reachable from any predicate-free, fully-contained, narrow-projection
-statement large enough to take the fast path (`SELECT ts, body FROM logs`
-included).
+statement that takes the fast path (`SELECT ts, body FROM logs` included).
+Object size does not gate it: since #739 the fast path is chosen for a
+segment at or below the block-range threshold too, which is what the
+request-count paragraph above already states.
 
 The per-query DataFusion memory pool now bounds concurrently-held scan memory:
 the reservation grows when a decoded block and the batch built from it are held

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -202,7 +202,12 @@ is resolved against the object's own FIELD_DIR
   to qualify: a query with no prune arm is skip-decidable too, but its plan read
   already fetches only the ts-candidate blocks and warms exactly the extents the
   subset opens stripe, so planning it this way would trade one shared read for
-  N per-partition ones over the same bytes.
+  N per-partition ones over the same bytes. This branch's `fetch_plan_sections`
+  read is wrapped in its own `page_fetch` span (#782), recording the probe and
+  section GET count and `BlockRangeStats::block_bytes_fetched` on it, the same
+  way `plan_segment_fast` and `plan_segment_block_stats` already do — before
+  #782 this branch's read was the one plan-phase GET on the query path with no
+  span at all, invisible to a trace over a statement that took it.
 
 A predicate the skip index cannot decide — a `has_word`/text arm (bloom prunes
 it only at decode), an `attrs['k']='v'` POSTINGS equality, a stream filter —
@@ -1685,6 +1690,32 @@ many bytes the fetch brought in, and how many of the bytes already resident
 the decode actually needed. The instrument predates the version-4 fetcher and
 was what measured whether block-level pruning alone captured enough before
 PAGE_DIR shrank the wire fetch to columns.
+
+The predicate-free full-window whole-segment fast path (#693 part 3, above)
+is the one shape where the two axes never move together, by design (#790).
+It issues exactly one whole-object `GetRange::Full` GET per segment
+regardless of projection -- that request count is the fast path's entire
+reason to exist, and #790 does not change it -- so `page_bytes_fetched`
+always equals the object's full stored page bytes, on every projection.
+What #790 fixed is `page_bytes_decoded`: `scan_whole_accounted_with_tenant`
+already threaded the caller's `ColumnSelection` into the same
+`decode_v4_block` page-level skip every other read path uses, so a one-column
+scan (`SELECT ts, body FROM logs`, the report's own statement shape) was
+already decoding only that column's pages on a version-4 object -- but
+nothing pinned it, so the fast path's decode-time narrowing had no regression
+coverage and could have silently regressed to decoding every page without
+any test failing. `narrow_projection_decodes_only_wanted_columns`
+(`crates/ravel-query/src/log_fetcher.rs`) now pins it: a one-column
+projection over a 6-block, 8-column-per-block fixture decodes exactly 3
+pages per block (`ts`, `stream_ref`, `body`) against 8 for
+`ColumnSelection::all()` on the same object, and the difference matches
+`pages_skipped` exactly. A user observes the effect in `pages_decoded`/
+`page_bytes_decoded` on `ScanStats` (`EXPLAIN ANALYZE`'s per-partition page
+counters) and in reduced peak decode memory, never in request count or wire
+bytes -- those stay exactly where the #693-part-3 fast path already put them.
+Reachable from any predicate-free, fully-contained, narrow-projection
+statement large enough to take the fast path (`SELECT ts, body FROM logs`
+included).
 
 The per-query DataFusion memory pool now bounds concurrently-held scan memory:
 the reservation grows when a decoded block and the batch built from it are held

--- a/services/ravel-server/src/metrics.rs
+++ b/services/ravel-server/src/metrics.rs
@@ -2433,6 +2433,47 @@ pub struct QueryAccountingRow {
     pub counters: QueryCostCounters,
 }
 
+/// The final disposition of one query, recorded alongside its cost so a total
+/// can be split by outcome (issue #809). A closed set of four: every query
+/// exits as exactly one of these, never a fifth kind invented to describe an
+/// exit these do not cover.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum QueryOutcomeStatus {
+    Success,
+    Error,
+    Timeout,
+    Canceled,
+}
+
+impl QueryOutcomeStatus {
+    pub fn name(self) -> &'static str {
+        match self {
+            QueryOutcomeStatus::Success => "success",
+            QueryOutcomeStatus::Error => "error",
+            QueryOutcomeStatus::Timeout => "timeout",
+            QueryOutcomeStatus::Canceled => "canceled",
+        }
+    }
+}
+
+/// One rendered row of the per-query outcome-status split (issue #809): the
+/// (tenant bucket, status) key plus its accumulated [`QueryCostCounters`].
+/// `tenant` follows the same `None`-is-`other` convention as
+/// [`QueryAccountingRow`]. Kept as an independent map from `rows` rather than
+/// widening the existing `ravel_query_*` family's key by a `status` label: the
+/// existing family is fed only on success today (issue #680's stale-comment
+/// finding aside, error/timeout/canceled queries have never folded into it),
+/// and giving `render_query_family` a new label dimension would multiply its
+/// series count for a rendering path this ticket does not require. This row
+/// is queryable via [`QueryAccountingMetrics::outcome_snapshot`]; it does not
+/// (yet) render on `/metrics`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QueryOutcomeRow {
+    pub tenant: Option<TenantHash>,
+    pub status: QueryOutcomeStatus,
+    pub counters: QueryCostCounters,
+}
+
 /// Process-global aggregator for per-query cost accounting (ADR-0044 section
 /// 4), written once per completed query by every query handler and read at
 /// scrape time by [`metrics_handler`]. One instance per process, shared with
@@ -2457,6 +2498,10 @@ pub struct QueryAccountingRow {
 pub struct QueryAccountingMetrics {
     configured: HashSet<TenantHash>,
     rows: parking_lot::Mutex<HashMap<(Option<TenantHash>, WorkloadClass), QueryCostCounters>>,
+    /// The outcome-status split (issue #809), independent of `rows` above;
+    /// see [`QueryOutcomeRow`] for why it is a separate map.
+    outcomes:
+        parking_lot::Mutex<HashMap<(Option<TenantHash>, QueryOutcomeStatus), QueryCostCounters>>,
 }
 
 impl QueryAccountingMetrics {
@@ -2467,6 +2512,7 @@ impl QueryAccountingMetrics {
         QueryAccountingMetrics {
             configured,
             rows: parking_lot::Mutex::new(HashMap::new()),
+            outcomes: parking_lot::Mutex::new(HashMap::new()),
         }
     }
 
@@ -2530,6 +2576,68 @@ impl QueryAccountingMetrics {
                 .value()
                 .cmp(&tenant_label(b.tenant).value())
                 .then_with(|| a.workload_class.name().cmp(b.workload_class.name()))
+        });
+        out
+    }
+
+    /// Fold one completed query's actual counters and its pre-execution
+    /// estimate into the (tenant bucket, status) row (issue #809). Same
+    /// cardinality-bounding fold and `saturating_add` discipline as
+    /// [`QueryAccountingMetrics::record`], into the independent `outcomes`
+    /// map so this never changes what the existing `ravel_query_*` family
+    /// reports.
+    pub fn record_outcome(
+        &self,
+        tenant_hash: TenantHash,
+        status: QueryOutcomeStatus,
+        accounting: &QueryAccountingSnapshot,
+        estimate: &CostEstimate,
+    ) {
+        let bucket = self
+            .configured
+            .contains(&tenant_hash)
+            .then_some(tenant_hash);
+        let mut outcomes = self.outcomes.lock();
+        let acc = outcomes.entry((bucket, status)).or_default();
+        acc.queries = acc.queries.saturating_add(1);
+        acc.s3_requests = acc
+            .s3_requests
+            .saturating_add(accounting.total_s3_requests());
+        acc.s3_bytes = acc.s3_bytes.saturating_add(accounting.total_s3_bytes());
+        acc.cache_hits = acc.cache_hits.saturating_add(accounting.cache_hits);
+        acc.cache_misses = acc.cache_misses.saturating_add(accounting.cache_misses);
+        acc.decompressed_bytes = acc
+            .decompressed_bytes
+            .saturating_add(accounting.decompressed_bytes);
+        acc.estimated_requests = acc
+            .estimated_requests
+            .saturating_add(estimate.estimated_requests);
+        acc.estimated_store_bytes = acc
+            .estimated_store_bytes
+            .saturating_add(estimate.estimated_store_bytes);
+        acc.estimated_decompressed_bytes = acc
+            .estimated_decompressed_bytes
+            .saturating_add(estimate.estimated_decompressed_bytes);
+    }
+
+    /// A stable-ordered copy of every observed outcome-status row, mirroring
+    /// [`QueryAccountingMetrics::snapshot`]'s sort discipline (tenant label,
+    /// then a secondary key -- here the status name).
+    pub fn outcome_snapshot(&self) -> Vec<QueryOutcomeRow> {
+        let outcomes = self.outcomes.lock();
+        let mut out: Vec<QueryOutcomeRow> = outcomes
+            .iter()
+            .map(|((tenant, status), counters)| QueryOutcomeRow {
+                tenant: *tenant,
+                status: *status,
+                counters: *counters,
+            })
+            .collect();
+        out.sort_by(|a, b| {
+            tenant_label(a.tenant)
+                .value()
+                .cmp(&tenant_label(b.tenant).value())
+                .then_with(|| a.status.name().cmp(b.status.name()))
         });
         out
     }

--- a/services/ravel-server/src/metrics.rs
+++ b/services/ravel-server/src/metrics.rs
@@ -2422,6 +2422,37 @@ pub struct QueryCostCounters {
     pub estimated_decompressed_bytes: u64,
 }
 
+impl QueryCostCounters {
+    /// Fold one query's cost into this row.
+    ///
+    /// Both the workload-class family and the outcome-status family accumulate
+    /// the identical set of counters and differ only in which map and key they
+    /// select, so the arithmetic lives here once. Adding a field to this struct
+    /// and not to this method under-reports it in BOTH families rather than
+    /// silently in one, which is the failure mode the duplicated version had.
+    fn fold(&mut self, accounting: &QueryAccountingSnapshot, estimate: &CostEstimate) {
+        self.queries = self.queries.saturating_add(1);
+        self.s3_requests = self
+            .s3_requests
+            .saturating_add(accounting.total_s3_requests());
+        self.s3_bytes = self.s3_bytes.saturating_add(accounting.total_s3_bytes());
+        self.cache_hits = self.cache_hits.saturating_add(accounting.cache_hits);
+        self.cache_misses = self.cache_misses.saturating_add(accounting.cache_misses);
+        self.decompressed_bytes = self
+            .decompressed_bytes
+            .saturating_add(accounting.decompressed_bytes);
+        self.estimated_requests = self
+            .estimated_requests
+            .saturating_add(estimate.estimated_requests);
+        self.estimated_store_bytes = self
+            .estimated_store_bytes
+            .saturating_add(estimate.estimated_store_bytes);
+        self.estimated_decompressed_bytes = self
+            .estimated_decompressed_bytes
+            .saturating_add(estimate.estimated_decompressed_bytes);
+    }
+}
+
 /// One rendered row of the per-query cost family: the (tenant bucket, workload
 /// class) key plus its accumulated [`QueryCostCounters`]. `tenant` is `None`
 /// for the folded `other` bucket and `Some(hash)` for a configured tenant, the
@@ -2536,25 +2567,7 @@ impl QueryAccountingMetrics {
             .then_some(tenant_hash);
         let mut rows = self.rows.lock();
         let acc = rows.entry((bucket, workload_class)).or_default();
-        acc.queries = acc.queries.saturating_add(1);
-        acc.s3_requests = acc
-            .s3_requests
-            .saturating_add(accounting.total_s3_requests());
-        acc.s3_bytes = acc.s3_bytes.saturating_add(accounting.total_s3_bytes());
-        acc.cache_hits = acc.cache_hits.saturating_add(accounting.cache_hits);
-        acc.cache_misses = acc.cache_misses.saturating_add(accounting.cache_misses);
-        acc.decompressed_bytes = acc
-            .decompressed_bytes
-            .saturating_add(accounting.decompressed_bytes);
-        acc.estimated_requests = acc
-            .estimated_requests
-            .saturating_add(estimate.estimated_requests);
-        acc.estimated_store_bytes = acc
-            .estimated_store_bytes
-            .saturating_add(estimate.estimated_store_bytes);
-        acc.estimated_decompressed_bytes = acc
-            .estimated_decompressed_bytes
-            .saturating_add(estimate.estimated_decompressed_bytes);
+        acc.fold(accounting, estimate);
     }
 
     /// A stable-ordered copy of every observed row, for rendering. Order by
@@ -2599,25 +2612,7 @@ impl QueryAccountingMetrics {
             .then_some(tenant_hash);
         let mut outcomes = self.outcomes.lock();
         let acc = outcomes.entry((bucket, status)).or_default();
-        acc.queries = acc.queries.saturating_add(1);
-        acc.s3_requests = acc
-            .s3_requests
-            .saturating_add(accounting.total_s3_requests());
-        acc.s3_bytes = acc.s3_bytes.saturating_add(accounting.total_s3_bytes());
-        acc.cache_hits = acc.cache_hits.saturating_add(accounting.cache_hits);
-        acc.cache_misses = acc.cache_misses.saturating_add(accounting.cache_misses);
-        acc.decompressed_bytes = acc
-            .decompressed_bytes
-            .saturating_add(accounting.decompressed_bytes);
-        acc.estimated_requests = acc
-            .estimated_requests
-            .saturating_add(estimate.estimated_requests);
-        acc.estimated_store_bytes = acc
-            .estimated_store_bytes
-            .saturating_add(estimate.estimated_store_bytes);
-        acc.estimated_decompressed_bytes = acc
-            .estimated_decompressed_bytes
-            .saturating_add(estimate.estimated_decompressed_bytes);
+        acc.fold(accounting, estimate);
     }
 
     /// A stable-ordered copy of every observed outcome-status row, mirroring

--- a/services/ravel-server/src/sql.rs
+++ b/services/ravel-server/src/sql.rs
@@ -63,12 +63,13 @@ use ravel_object_store::ObjectStoreBackend;
 use ravel_query::QueryAdmissionController;
 use ravel_query::http::TenantResolver;
 use ravel_sql::{ErrorClass, SqlError, SqlExecutor, SqlRequest};
+use ravel_types::accounting::{AccountedOp, CostEstimate, QueryAccountingSnapshot};
 use ravel_types::{CommitToken, TenantHash, TimeRange};
 use serde::Deserialize;
 use serde_json::json;
 use tracing::Instrument;
 
-use crate::metrics::WorkloadClass;
+use crate::metrics::{QueryOutcomeStatus, WorkloadClass};
 
 /// The Arrow IPC stream media type, as registered by the Arrow project.
 pub const ARROW_STREAM_MEDIA_TYPE: &str = "application/vnd.apache.arrow.stream";
@@ -106,12 +107,10 @@ pub struct SqlState {
     /// The process-global per-query cost aggregator (ADR-0044 section 4).
     /// Each completed statement folds its accounting snapshot and cost
     /// estimate into it, tagged with the tenant hash and workload class, for
-    /// `/metrics`. One instance per process, shared with `/api/v1/analytics`.
-    ///
-    /// The Flight SQL and PromQL paths do not record into it yet: both build
-    /// their own `QueryAccounting` per request and report it in the response
-    /// only, so `/metrics` covers SQL and analytics traffic, not all query
-    /// traffic. Wiring them is future work.
+    /// `/metrics`. One instance per process, shared with `/api/v1/analytics`,
+    /// the Flight SQL path (`crate::flight::service`), and the PromQL path,
+    /// all of which hold it as `Arc<dyn QueryCostRecorder>` -- so `/metrics`
+    /// covers every query surface, not only `/api/v1/sql`.
     pub query_accounting: Arc<crate::metrics::QueryAccountingMetrics>,
     /// The fleet-global query concurrency ceiling (ADR-0061 decision 2), the one
     /// shared controller every query surface in the process gates against.
@@ -143,6 +142,98 @@ struct SqlBody {
     /// Read-your-write commit tokens.
     #[serde(default)]
     min_commit_token: Vec<String>,
+}
+
+/// Guarantees `run`'s query cost and outcome status reach
+/// `state.query_accounting` exactly once, on every exit from `run` -- success,
+/// error, and the one exit no `return` or `?` can reach: the enclosing
+/// request future being dropped mid-`.await` on `execute` (a client
+/// disconnect while the query is still doing object-store work). This is the
+/// same guard/`Drop` shape as `handle`'s `_permit`
+/// (`QueryAdmissionController`, ADR-0061 decision 2), applied to cost
+/// recording instead of concurrency admission.
+///
+/// `finish` is called immediately once `result` is known, before
+/// `submit_audit(..).await?` or `result.map_err(..)?` get a chance to return
+/// early, so both of those early returns run after the fold has already
+/// happened and cannot skip it. If `finish` is never reached -- the only way
+/// is the guard itself being dropped without `run` reaching that line, i.e.
+/// the whole `run` future dropped mid-`execute().await` -- `Drop::drop` runs
+/// unconditionally (Rust guarantees this for every value dropped by scope
+/// exit, `return`, `?`, panic, or an abandoned `.await`) and folds a
+/// zero-accounting `Canceled` record instead. There is no path through `run`
+/// that skips both.
+struct CostGuard<'a> {
+    metrics: &'a crate::metrics::QueryAccountingMetrics,
+    tenant_hash: TenantHash,
+    finished: bool,
+}
+
+impl<'a> CostGuard<'a> {
+    fn new(metrics: &'a crate::metrics::QueryAccountingMetrics, tenant_hash: TenantHash) -> Self {
+        CostGuard {
+            metrics,
+            tenant_hash,
+            finished: false,
+        }
+    }
+
+    /// Record the real outcome. Consumes the guard so a second call is a
+    /// compile error, not a double fold.
+    fn finish(
+        mut self,
+        status: QueryOutcomeStatus,
+        accounting: &QueryAccountingSnapshot,
+        estimate: &CostEstimate,
+    ) {
+        self.metrics
+            .record_outcome(self.tenant_hash, status, accounting, estimate);
+        self.finished = true;
+    }
+}
+
+impl Drop for CostGuard<'_> {
+    fn drop(&mut self) {
+        if !self.finished {
+            self.metrics.record_outcome(
+                self.tenant_hash,
+                QueryOutcomeStatus::Canceled,
+                &QueryAccountingSnapshot::default(),
+                &CostEstimate::new(0, 0, 0, 0, 0),
+            );
+        }
+    }
+}
+
+/// Best-effort outcome status and accounting for a failed query, derived from
+/// the `SqlError` variant alone. Only [`SqlError::TooManyBytesScanned`] and
+/// [`SqlError::RequestBudgetExceeded`] carry the exact counters that tripped
+/// them; every other variant -- including `DeadlineExceeded`, a wall-deadline
+/// timeout -- is recorded with a zero snapshot. This is a real gap, not an
+/// oversight: `SqlExecutor::execute` (crates/ravel-sql/src/executor.rs) owns
+/// its `QueryAccounting` handle entirely internally and exposes it only on
+/// `SqlOutcome` on the success path, so a timeout or any other error variant
+/// without its own embedded figures has no accounting data this module can
+/// reach. Closing that gap needs a ravel-sql API change (out of this task's
+/// `services/ravel-server`-only scope) to expose the live handle, or the
+/// figures, on every error path -- flagged in this task's report rather than
+/// worked around here.
+fn error_cost(err: &SqlError) -> (QueryOutcomeStatus, QueryAccountingSnapshot, CostEstimate) {
+    let status = match err.class() {
+        ErrorClass::Timeout => QueryOutcomeStatus::Timeout,
+        _ => QueryOutcomeStatus::Error,
+    };
+    let mut snapshot = QueryAccountingSnapshot::default();
+    match err {
+        SqlError::TooManyBytesScanned { scanned, .. } => {
+            snapshot.s3_bytes[AccountedOp::Get.index()] = *scanned;
+        }
+        SqlError::RequestBudgetExceeded { requests, .. } => {
+            snapshot.s3_requests[AccountedOp::Get.index()] = *requests;
+        }
+        _ => {}
+    }
+    (status, snapshot, CostEstimate::new(0, 0, 0, 0, 0))
 }
 
 async fn handle(State(state): State<SqlState>, req: Request<Body>) -> Response {
@@ -193,6 +284,11 @@ async fn run(state: &SqlState, req: Request<Body>) -> Result<Response, ApiError>
         s3_bytes = tracing::field::Empty,
     );
 
+    // Constructed before `execute` is awaited so a dropped `run` future
+    // (client disconnect mid-query) still folds a Canceled record through its
+    // `Drop` -- see `CostGuard`'s doc comment for the full mechanism.
+    let cost_guard = CostGuard::new(&state.query_accounting, tenant_hash);
+
     // The query has now reached execution for a resolved tenant, so it is
     // auditable (ADR-0042 decision 4, ADR-0062 §2a). Run it, then submit
     // exactly one query-audit event for the outcome - success or the specific
@@ -209,6 +305,25 @@ async fn run(state: &SqlState, req: Request<Body>) -> Result<Response, ApiError>
         Ok(_) => QueryStatus::Ok,
         Err(_) => QueryStatus::Error,
     };
+
+    // Fold the real outcome on EVERY exit past this point (issue #809): this
+    // runs before `submit_audit`'s `?` and `result.map_err(..)?` below, so an
+    // audit-write failure or a redacted `SqlError` can no longer skip cost
+    // recording the way only the success path used to reach it.
+    match &result {
+        Ok(outcome) => {
+            cost_guard.finish(
+                QueryOutcomeStatus::Success,
+                &outcome.accounting,
+                &outcome.estimate,
+            );
+        }
+        Err(err) => {
+            let (outcome_status, snapshot, estimate) = error_cost(err);
+            cost_guard.finish(outcome_status, &snapshot, &estimate);
+        }
+    }
+
     submit_audit(
         state,
         tenant_hash,
@@ -227,7 +342,9 @@ async fn run(state: &SqlState, req: Request<Body>) -> Result<Response, ApiError>
     // the final counts on the span. The executor already built and dropped a
     // fresh `QueryAccounting` per attempt; `outcome.accounting` is the
     // successful attempt's snapshot, so a retried attempt's counters never
-    // bleed in.
+    // bleed in. Unchanged by the outcome-status fold above: this is the
+    // pre-existing `ravel_query_*` family, fed only on success as before, and
+    // `CostGuard` folds into its own independent map.
     span.record("s3_requests", outcome.accounting.total_s3_requests());
     span.record("s3_bytes", outcome.accounting.total_s3_bytes());
     state.query_accounting.record(

--- a/services/ravel-server/tests/query_cost_surfaces.rs
+++ b/services/ravel-server/tests/query_cost_surfaces.rs
@@ -631,4 +631,42 @@ mod flight {
             );
         }
     }
+
+    /// Issue #809 deliverable 3 requires one statement traversing both Flight
+    /// SQL phases (`GetFlightInfo`, `DoGet`) to produce exactly one cost
+    /// record, so a per-statement total can be computed by summing `queries`
+    /// without double-counting. It currently produces TWO: `get_flight_info_statement`
+    /// in `crates/ravel-sql/src/flight/service.rs` calls `.record(...)` for the
+    /// resolve+plan phase, and `RecordOnStreamEnd::drop` in
+    /// `crates/ravel-sql/src/flight/stream.rs` calls `.record(...)` again when
+    /// the `DoGet` stream ends, per ADR-0044's documented "two-handle split" (see
+    /// `service.rs`'s own comment on the split). Both call sites are inside
+    /// `crates/ravel-sql`, out of this task's `services/ravel-server`-only
+    /// scope, so this test pins the CURRENT (wrong) count rather than asserting
+    /// the ticket's `count == 1` against code that cannot satisfy it without a
+    /// `ravel-sql` change. See this task's final report for the finding.
+    #[tokio::test]
+    async fn a_flight_sql_statement_currently_records_cost_twice_not_once() {
+        let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+        let tenant = TenantId::new("acme".to_string());
+        publish_segment(store.as_ref(), &tenant, 0).await;
+        let query_accounting = Arc::new(QueryAccountingMetrics::new(HashSet::new()));
+        let state = sql_state(Arc::clone(&store), &tenant, Arc::clone(&query_accounting));
+
+        run_flight_query(&state).await;
+
+        let total_queries: u64 = query_accounting
+            .snapshot()
+            .iter()
+            .map(|r| r.counters.queries)
+            .sum();
+        assert_eq!(
+            total_queries, 2,
+            "one Flight SQL statement currently folds two cost records (GetFlightInfo \
+             and DoGet each call `.record`), not one; issue #809 deliverable 3 names this \
+             as a required fix but the recording call sites are in crates/ravel-sql, out \
+             of this task's services/ravel-server-only scope -- this assertion pins today's \
+             actual (wrong) behavior rather than silently asserting the ticket's target"
+        );
+    }
 }

--- a/services/ravel-server/tests/sql_endpoint.rs
+++ b/services/ravel-server/tests/sql_endpoint.rs
@@ -1828,7 +1828,12 @@ async fn a_dropped_request_future_records_a_canceled_cost() {
     // Waits until the request is genuinely suspended inside the real GET
     // (`BlockingOnFirstGet::get` signals `entered` before blocking on
     // `proceed`), not until some fixed delay has elapsed.
-    entered.notified().await;
+    // Bounded on purpose. If a future change serves this read without issuing a
+    // `get` (a cache, a range-free plan, an early error), an unbounded wait
+    // would hang until the CI job times out with nothing naming the cause.
+    tokio::time::timeout(std::time::Duration::from_secs(30), entered.notified())
+        .await
+        .expect("the request must reach BlockingOnFirstGet::get; if it no longer issues a get, this test's premise is stale");
 
     // Abort, never signaling `proceed`: the request future -- including
     // `run`'s local `cost_guard` -- is dropped mid-`.await`, exactly as a

--- a/services/ravel-server/tests/sql_endpoint.rs
+++ b/services/ravel-server/tests/sql_endpoint.rs
@@ -1458,6 +1458,403 @@ async fn an_audit_write_failure_fails_the_query_closed_in_required_mode() {
     );
 }
 
+// ---------------------------------------------------------------------------
+// Cost recorded on every exit path (issue #809): a query's actual accounting
+// must reach `state.query_accounting` whether it succeeds, fails, times out,
+// or the request future is dropped mid-flight -- not only on the happy path.
+// ---------------------------------------------------------------------------
+
+/// Like [`build_router_with_sink`], but with a caller-chosen [`SqlConfig`] and
+/// returning the [`QueryAccountingMetrics`] handle so a test can inspect
+/// [`QueryAccountingMetrics::outcome_snapshot`] after driving a request.
+fn build_router_with_config(
+    store: Arc<dyn ObjectStoreBackend>,
+    tokens: HashMap<String, TenantId>,
+    sql_config: SqlConfig,
+) -> (Router, Arc<ravel_server::metrics::QueryAccountingMetrics>) {
+    build_router_with_config_and_deadline(store, tokens, sql_config, Duration::from_secs(30))
+}
+
+/// Like [`build_router_with_config`], but also lets a test set the server's
+/// wall-deadline ceiling. `SqlState::max_deadline`, not
+/// `SqlConfig::engine.deadline`, is what `build_request` clamps a request's
+/// deadline to (`services/ravel-server/src/sql.rs`'s `build_request`); the
+/// wall deadline the HTTP endpoint actually enforces
+/// (`tokio::time::timeout` around `SqlExecutor::execute`,
+/// crates/ravel-sql/src/executor.rs) comes from here, not from the engine
+/// config a caller might expect.
+fn build_router_with_config_and_deadline(
+    store: Arc<dyn ObjectStoreBackend>,
+    tokens: HashMap<String, TenantId>,
+    sql_config: SqlConfig,
+    max_deadline: Duration,
+) -> (Router, Arc<ravel_server::metrics::QueryAccountingMetrics>) {
+    let catalog =
+        Arc::new(Catalog::new(Arc::clone(&store), CatalogConfig::default()).expect("catalog"));
+    let executor = SqlExecutor::new(
+        catalog,
+        SegmentFetcher::new(store.clone()),
+        LogSegmentFetcher::new(store.clone()),
+        ravel_sql::SpanSegmentFetcher::new(store.clone()),
+        sql_config,
+        1 << 30,
+    );
+    let query_accounting = Arc::new(ravel_server::metrics::QueryAccountingMetrics::new(
+        std::collections::HashSet::new(),
+    ));
+    let app = router(SqlState {
+        executor: Arc::new(executor),
+        tenant_resolver: Arc::new(StaticBearerTokenResolver::new(tokens)),
+        store,
+        clock: Arc::new(FixedClock),
+        max_deadline,
+        query_accounting: Arc::clone(&query_accounting),
+        query_admission: ravel_query::QueryAdmissionController::shared(
+            ravel_query::QueryConcurrencyLimit::Unlimited,
+        ),
+        audit_sink: Arc::new(ravel_maintain::NoopQueryAuditSink),
+    });
+    (app, query_accounting)
+}
+
+/// The one row in `outcome_snapshot()` matching `status`, or a panic naming
+/// what was there instead -- so a wrong-status regression fails with the
+/// actual rows, not just "not found".
+fn only_outcome_row(
+    query_accounting: &ravel_server::metrics::QueryAccountingMetrics,
+    status: ravel_server::metrics::QueryOutcomeStatus,
+) -> ravel_server::metrics::QueryOutcomeRow {
+    let rows = query_accounting.outcome_snapshot();
+    let matching: Vec<_> = rows.iter().filter(|r| r.status == status).collect();
+    assert_eq!(
+        matching.len(),
+        1,
+        "expected exactly one {status:?} row, got: {rows:?}"
+    );
+    *matching[0]
+}
+
+/// A query that reads real objects and then fails must record the actual
+/// bytes it read, not zero. `TooManyBytesScanned` is the one `SqlError`
+/// variant (besides `RequestBudgetExceeded`) that carries an exact figure the
+/// executor measured, so the test proves the recorded figure against a
+/// dynamically-learned baseline rather than a hand-computed magic number: the
+/// baseline run (unbounded budget) and the tripped run read the identical
+/// fixture through the identical query, so their real bytes-scanned totals
+/// must be identical, and the trip fires only after that real fetch
+/// completed (`crates/ravel-sql/src/scan.rs`'s `prepare_partition`, out of
+/// this task's scope, checks the running total once per completed segment
+/// fetch, mirroring the same incremental checkpoint
+/// `ravel_query::segment_admission` uses for PromQL).
+#[tokio::test]
+async fn a_query_that_reads_objects_then_fails_records_the_bytes_it_actually_read() {
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+    let tenant = TenantId::new("acme".to_string());
+    publish_segment(store.as_ref(), &tenant, 0, "m", &[(100, 1.0), (200, 2.5)]).await;
+    let query = "SELECT ts, value FROM samples ORDER BY ts";
+
+    // Baseline: an unbounded run records the real bytes-scanned total on
+    // success.
+    let (baseline_app, baseline_accounting) =
+        build_router_with_config(Arc::clone(&store), tokens(&[("acme-token", "acme")]), {
+            let mut cfg = SqlConfig::default();
+            cfg.engine.max_bytes_scanned = ravel_query::ByteLimit::Unlimited;
+            cfg
+        });
+    let (status, value) = post_json(&baseline_app, "acme-token", query).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "baseline query must succeed: {value}"
+    );
+    let baseline = only_outcome_row(
+        &baseline_accounting,
+        ravel_server::metrics::QueryOutcomeStatus::Success,
+    );
+    assert!(
+        baseline.counters.s3_bytes > 0,
+        "the query must have read real bytes for this test to be meaningful"
+    );
+
+    // Same fixture, same query, budget set one byte below the baseline's real
+    // total: the fetch that already happened is what trips the check, so the
+    // error's `scanned` figure must equal the baseline's real total exactly.
+    let (tripped_app, tripped_accounting) =
+        build_router_with_config(Arc::clone(&store), tokens(&[("acme-token", "acme")]), {
+            let mut cfg = SqlConfig::default();
+            cfg.engine.max_bytes_scanned =
+                ravel_query::ByteLimit::Bounded(baseline.counters.s3_bytes - 1);
+            cfg
+        });
+    let (status, value) = post_json(&tripped_app, "acme-token", query).await;
+    assert_eq!(
+        status,
+        StatusCode::UNPROCESSABLE_ENTITY,
+        "a budget trip must be a client-visible error, not silently succeed: {value}"
+    );
+
+    let errored = only_outcome_row(
+        &tripped_accounting,
+        ravel_server::metrics::QueryOutcomeStatus::Error,
+    );
+    assert_eq!(
+        errored.counters.s3_bytes, baseline.counters.s3_bytes,
+        "the failed query's recorded bytes must match what it actually read, not zero \
+         and not an estimate"
+    );
+    assert_eq!(errored.counters.queries, 1);
+    // No Success or Canceled row: the query recorded exactly once, as Error.
+    assert!(
+        tripped_accounting
+            .outcome_snapshot()
+            .iter()
+            .all(|r| r.status == ravel_server::metrics::QueryOutcomeStatus::Error)
+    );
+}
+
+/// A backend wrapping `inner` whose `get` sleeps for `delay` (real tokio
+/// time) before delegating. `MemoryStore`'s own operations never yield to the
+/// executor, so `tokio::time::timeout` (`crates/ravel-sql/src/executor.rs`)
+/// never gets a chance to race a bare `MemoryStore`: the wrapped future
+/// resolves on its very first poll regardless of how small the configured
+/// deadline is, timer included. This wrapper forces a genuine `.await` that
+/// returns `Pending` for real wall-clock time, so a short deadline set below
+/// `delay` deterministically fires while a real GET is outstanding.
+struct DelayedGet<S> {
+    inner: S,
+    delay: Duration,
+}
+
+#[async_trait::async_trait]
+impl<S: ObjectStoreBackend> ObjectStoreBackend for DelayedGet<S> {
+    async fn put(
+        &self,
+        key: &str,
+        data: bytes::Bytes,
+        opts: PutOptions,
+    ) -> Result<ravel_object_store::PutOutcome, ravel_object_store::StoreError> {
+        self.inner.put(key, data, opts).await
+    }
+
+    async fn get(
+        &self,
+        key: &str,
+        range: GetRange,
+    ) -> Result<ravel_object_store::GetOutcome, ravel_object_store::StoreError> {
+        tokio::time::sleep(self.delay).await;
+        self.inner.get(key, range).await
+    }
+
+    async fn head(
+        &self,
+        key: &str,
+    ) -> Result<ravel_object_store::ObjectMeta, ravel_object_store::StoreError> {
+        self.inner.head(key).await
+    }
+
+    async fn list(
+        &self,
+        prefix: &str,
+        page: Option<ravel_object_store::PageToken>,
+    ) -> Result<ravel_object_store::ListPage, ravel_object_store::StoreError> {
+        self.inner.list(prefix, page).await
+    }
+
+    async fn list_delimited(
+        &self,
+        prefix: &str,
+    ) -> Result<ravel_object_store::DelimitedList, ravel_object_store::StoreError> {
+        self.inner.list_delimited(prefix).await
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), ravel_object_store::StoreError> {
+        self.inner.delete(key).await
+    }
+
+    fn capabilities(&self) -> ravel_object_store::Capabilities {
+        self.inner.capabilities()
+    }
+}
+
+/// A query that exceeds its wall-clock deadline must record `Timeout`, not
+/// `Error` and not nothing. `DelayedGet` (200ms) plus a 5ms deadline makes the
+/// trip fire deterministically while a real GET is genuinely outstanding, the
+/// same shape issue #809's motivating incident describes.
+///
+/// This test proves the STATUS split only: it does NOT prove the recorded
+/// cost reflects that real object-store work, because `SqlExecutor::execute`
+/// (crates/ravel-sql/src/executor.rs, out of this task's
+/// `services/ravel-server`-only scope) keeps its `QueryAccounting` handle
+/// entirely internal and does not expose it, or the figures it holds, on a
+/// `DeadlineExceeded` return -- so `error_cost` in `sql.rs` has no non-zero
+/// figures to record for this variant (see its doc comment). Closing that
+/// gap needs a `ravel-sql` API change, out of scope here and named in this
+/// task's final report.
+#[tokio::test]
+async fn a_query_that_exceeds_its_deadline_records_timeout_status() {
+    let inner: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+    let tenant = TenantId::new("acme".to_string());
+    publish_segment(inner.as_ref(), &tenant, 0, "m", &[(100, 1.0), (200, 2.5)]).await;
+    let delayed_store: Arc<dyn ObjectStoreBackend> = Arc::new(DelayedGet {
+        inner,
+        delay: Duration::from_millis(200),
+    });
+
+    let (app, query_accounting) = build_router_with_config_and_deadline(
+        delayed_store,
+        tokens(&[("acme-token", "acme")]),
+        SqlConfig::default(),
+        Duration::from_millis(5),
+    );
+
+    let (status, value) = post_json(&app, "acme-token", "SELECT ts, value FROM samples").await;
+    assert_eq!(
+        status,
+        StatusCode::GATEWAY_TIMEOUT,
+        "a deadline trip must reach the client as a timeout status: {value}"
+    );
+
+    let timed_out = only_outcome_row(
+        &query_accounting,
+        ravel_server::metrics::QueryOutcomeStatus::Timeout,
+    );
+    assert_eq!(timed_out.counters.queries, 1);
+}
+
+/// A backend wrapping `inner` whose `get` signals `entered` the instant it is
+/// called, then blocks on `proceed` before delegating -- so a test can drive
+/// a request until it is genuinely suspended inside a real in-flight GET,
+/// then tear the request future down without ever unblocking it. Every other
+/// method delegates straight through.
+struct BlockingOnFirstGet<S> {
+    inner: S,
+    entered: Arc<tokio::sync::Notify>,
+    proceed: Arc<tokio::sync::Notify>,
+}
+
+#[async_trait::async_trait]
+impl<S: ObjectStoreBackend> ObjectStoreBackend for BlockingOnFirstGet<S> {
+    async fn put(
+        &self,
+        key: &str,
+        data: bytes::Bytes,
+        opts: PutOptions,
+    ) -> Result<ravel_object_store::PutOutcome, ravel_object_store::StoreError> {
+        self.inner.put(key, data, opts).await
+    }
+
+    async fn get(
+        &self,
+        key: &str,
+        range: GetRange,
+    ) -> Result<ravel_object_store::GetOutcome, ravel_object_store::StoreError> {
+        self.entered.notify_one();
+        self.proceed.notified().await;
+        self.inner.get(key, range).await
+    }
+
+    async fn head(
+        &self,
+        key: &str,
+    ) -> Result<ravel_object_store::ObjectMeta, ravel_object_store::StoreError> {
+        self.inner.head(key).await
+    }
+
+    async fn list(
+        &self,
+        prefix: &str,
+        page: Option<ravel_object_store::PageToken>,
+    ) -> Result<ravel_object_store::ListPage, ravel_object_store::StoreError> {
+        self.inner.list(prefix, page).await
+    }
+
+    async fn list_delimited(
+        &self,
+        prefix: &str,
+    ) -> Result<ravel_object_store::DelimitedList, ravel_object_store::StoreError> {
+        self.inner.list_delimited(prefix).await
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), ravel_object_store::StoreError> {
+        self.inner.delete(key).await
+    }
+
+    fn capabilities(&self) -> ravel_object_store::Capabilities {
+        self.inner.capabilities()
+    }
+}
+
+/// Deliverable 5: the request future being DROPPED mid-flight (a client
+/// disconnect while a real GET is outstanding), not merely returning an
+/// error, must still record a `Canceled` cost. This is reachable from a real
+/// caller today: axum drops the whole per-request future, `CostGuard`
+/// included, the instant a client disconnects mid-query, exactly as `.abort()`
+/// drops this test's spawned task below -- `handle`/`run` never gets a chance
+/// to run any code after the dropped `.await`, which is the entire point of
+/// `CostGuard` living in a `Drop` impl rather than at the end of the happy
+/// path.
+#[tokio::test]
+async fn a_dropped_request_future_records_a_canceled_cost() {
+    let inner: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+    let tenant = TenantId::new("acme".to_string());
+    publish_segment(inner.as_ref(), &tenant, 0, "m", &[(100, 1.0), (200, 2.5)]).await;
+
+    let entered = Arc::new(tokio::sync::Notify::new());
+    let proceed = Arc::new(tokio::sync::Notify::new());
+    let blocking_store: Arc<dyn ObjectStoreBackend> = Arc::new(BlockingOnFirstGet {
+        inner,
+        entered: Arc::clone(&entered),
+        proceed: Arc::clone(&proceed),
+    });
+
+    let (app, query_accounting) = build_router_with_config(
+        blocking_store,
+        tokens(&[("acme-token", "acme")]),
+        SqlConfig::default(),
+    );
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/api/v1/sql")
+        .header(header::CONTENT_TYPE, "application/json")
+        .header(header::AUTHORIZATION, "Bearer acme-token")
+        .body(Body::from(body(
+            "SELECT ts, value FROM samples ORDER BY ts",
+        )))
+        .expect("build request");
+
+    let task = tokio::spawn(async move { app.oneshot(request).await });
+
+    // Waits until the request is genuinely suspended inside the real GET
+    // (`BlockingOnFirstGet::get` signals `entered` before blocking on
+    // `proceed`), not until some fixed delay has elapsed.
+    entered.notified().await;
+
+    // Abort, never signaling `proceed`: the request future -- including
+    // `run`'s local `cost_guard` -- is dropped mid-`.await`, exactly as a
+    // real client disconnect would drop it. Nothing after the blocked
+    // `.await` ever runs; `entered`/`proceed` are otherwise unused after this.
+    task.abort();
+    let joined = task.await;
+    assert!(
+        joined.is_err() && joined.unwrap_err().is_cancelled(),
+        "the request future must have been aborted, not completed"
+    );
+
+    let canceled = only_outcome_row(
+        &query_accounting,
+        ravel_server::metrics::QueryOutcomeStatus::Canceled,
+    );
+    assert_eq!(canceled.counters.queries, 1);
+    // No Success or Error row: the only fold that happened was the Drop path.
+    assert!(
+        query_accounting
+            .outcome_snapshot()
+            .iter()
+            .all(|r| r.status == ravel_server::metrics::QueryOutcomeStatus::Canceled)
+    );
+}
+
 /// Reachability for the last task of epic #360: a tenant's declared `Str`
 /// column must arrive as Arrow `Dictionary(Int32, Utf8)` when queried through
 /// the shipping server's real Flight SQL surface, not merely inside ravel-sql.


### PR DESCRIPTION
Two independent fixes, gated together because box time is the bottleneck and their file scopes are disjoint (`services/ravel-server` vs `crates/ravel-query`). Full workspace gate passed on this exact tree (`10eddbd9`) including both the `sql` and `flight-sql` feature lanes.

## #809 — record query cost on every SQL exit path

Cost metrics omitted any query that did not complete successfully, so a query that fetched objects for two minutes and then timed out read as free. That is a measurement-integrity gap: a figure recorded only on the success path cannot be reconciled against a bill.

Cost and a final status (success, error, timeout, canceled) are now recorded on every exit path, at a point a `return` cannot skip. This matters concretely for the ClickBench work: the v20 and v22 passes each had a statement fail after doing real object-store work, and that cost was invisible.

## #790 / #782 — pin the projection, and span the skip-decidable read

Worth being explicit that **#790's premise was wrong**, and this PR does not do what the ticket asked.

The ticket says the predicate-free whole-segment fast path bypasses PAGE_DIR projection. It does not. `log_fetcher.rs`'s own module doc says so: *"the `ColumnSelection` the scan passes to decode is the fetch selection too"*. A one-column scan already decoded only that column's pages. What was missing was any test that would fail if that regressed.

That mattered: an earlier attempt took the ticket at its word, built a new fetch sequence for a path that already held the whole object in memory, and turned one whole-object GET per segment into **3.03** — caught by `logs_scan_scaling_smoke`'s exact 32-GET assertion. This PR instead pins the existing behaviour: `narrow_projection_decodes_only_wanted_columns` asserts the exact page count (3 of 8 per block for a two-column selection on a 6-block fixture) with the gap matching `pages_skipped`. Request count is unchanged and `logs_scan_scaling_smoke.rs` is untouched — verified at zero lines changed.

#782: the skip-decidable plan branch issued its `fetch_plan_sections` read with no span, unlike the fast path and the full-decode fallback. It now opens a `page_fetch` span carrying the request count and `block_bytes_fetched`. Its test installs a thread-local subscriber rather than a global one, after a global subscriber proved to pick up sibling tests' spans under concurrent runs.

## Note on CI

The `supply-chain` check fails repo-wide right now: `chacha20` 0.10.1 was yanked upstream, so `cargo deny check` fails its advisories section on every branch. #838 fixes it with a one-line lockfile bump and should merge first.

Fixes: #809
Fixes: #790
Fixes: #782
Refs: #680