### PR TITLE
feat(ravel-query): split query accounting GETs and bytes by phase

### DIFF
--- a/crates/ravel-query/src/engine.rs
+++ b/crates/ravel-query/src/engine.rs
@@ -6731,8 +6731,20 @@ mod prefetch_tests {
         assert_eq!(pa.plan.s3_bytes(AccountedOp::Get), 65536);
         assert_eq!(pa.plan.segments_opened, 1);
 
+        // The whole test rests on this segment taking the ranged path. If a
+        // codec change ever shrinks it below the whole-object threshold,
+        // `open_segment` reads it in one GET, probe and scan go to zero, and
+        // the failure surfaces as four unrelated mismatches instead of one
+        // cause. Pin the precondition so it fails as itself.
+        let scan_bytes = pa.scan.s3_bytes(AccountedOp::Get);
+        assert!(
+            scan_bytes > crate::fetcher::DEFAULT_WHOLE_OBJECT_THRESHOLD,
+            "fixture must exceed the whole-object threshold or the phase split \
+             under test does not happen: scan read {scan_bytes} bytes, threshold {}",
+            crate::fetcher::DEFAULT_WHOLE_OBJECT_THRESHOLD
+        );
+
         assert_eq!(pa.probe.s3_requests(AccountedOp::Get), 1);
-        assert_eq!(pa.probe.s3_bytes(AccountedOp::Get), 3111);
         assert_eq!(pa.probe.series_matched, 150);
 
         // The scenario #796 exists for: this segment is one object, and the
@@ -6740,18 +6752,43 @@ mod prefetch_tests {
         // objects a predicate-free full scan issues exactly N scan-phase
         // GETs -- this is that claim pinned at N=1.
         assert_eq!(pa.scan.s3_requests(AccountedOp::Get), 1);
-        assert_eq!(pa.scan.s3_bytes(AccountedOp::Get), 2983182);
         assert_eq!(pa.scan.decompressed_bytes, 7_200_000);
+
+        // Byte figures are bounded proportionally rather than pinned exactly.
+        // The property this test exists for is request attribution per phase,
+        // and an exact compressed total would report an unrelated encoder
+        // change as an accounting regression. A flat floor would be the wrong
+        // fix -- one low enough to be safe also passes when a figure counts a
+        // fraction of the truth -- so each bound is tied to a known quantity:
+        // the scan reads one whole segment, so its wire bytes must be a real
+        // fraction of what it decoded, and the probe reads a bounded slice of
+        // that same object.
+        let decoded = pa.scan.decompressed_bytes;
+        assert!(
+            scan_bytes > decoded / 8 && scan_bytes < decoded,
+            "scan wire bytes {scan_bytes} must be a compressed fraction of the \
+             {decoded} bytes decoded, not a fraction of one object's worth"
+        );
+        let probe_bytes = pa.probe.s3_bytes(AccountedOp::Get);
+        assert!(
+            probe_bytes > 0 && probe_bytes < scan_bytes / 100,
+            "probe reads a small slice of the object the scan reads whole: \
+             probe {probe_bytes} vs scan {scan_bytes}"
+        );
 
         assert!(
             pa.plan.s3_requests(AccountedOp::Get) != pa.resolve.s3_requests(AccountedOp::Get)
-                || pa.probe.s3_bytes(AccountedOp::Get) != pa.scan.s3_bytes(AccountedOp::Get),
+                || probe_bytes != scan_bytes,
             "this shape must have at least one pair of unequal phases"
         );
 
         let pooled = pa.pooled();
         assert_eq!(pooled.total_s3_requests(), 5 + 2, "5 GETs + 2 LISTs");
-        assert_eq!(pooled.total_s3_bytes(), 293 + 65536 + 3111 + 2983182);
+        assert_eq!(
+            pooled.total_s3_bytes(),
+            293 + 65536 + probe_bytes + scan_bytes,
+            "pooled bytes must equal the phase-wise sum exactly, whatever the encoder produced"
+        );
         assert_eq!(
             pooled, stats.accounting,
             "phase_accounting.pooled() must equal the existing pooled QueryStats.accounting field exactly"

--- a/crates/ravel-query/src/engine.rs
+++ b/crates/ravel-query/src/engine.rs
@@ -31,6 +31,7 @@ use crate::fetcher::{
     FetchError, FetchStats, FetchedHistogramSeries, FetchedSeriesSoa, ReadCache, SamplePriority,
     SegmentFetcher,
 };
+use crate::phase_accounting::{PhaseAccounting, PhaseAccountingSnapshot};
 use crate::segment_admission;
 
 /// Which evaluation shape a prefetch is being computed for: an instant
@@ -71,8 +72,21 @@ pub struct QueryStats {
     /// sample's typed-output footprint regardless of encoding.
     pub page_stats: FetchStats,
     /// Actual per-query store/decode counters (ADR-0044 decision 1),
-    /// recorded at the fetcher's funnels.
+    /// recorded at the fetcher's funnels. Computed as
+    /// `phase_accounting.pooled()`; kept alongside it unchanged so every
+    /// existing reader of the pooled total sees the same number as before
+    /// issue #796 split it by phase.
     pub accounting: QueryAccountingSnapshot,
+    /// Per-phase split (issue #796) of the same GETs and bytes `accounting`
+    /// pools: resolve (catalog snapshot resolve), plan (footer/skip-index
+    /// probing), probe (segment catalog fetch), scan (block/page reads).
+    /// See `crate::phase_accounting` for phase boundaries and what each
+    /// byte counter counts. Federation and distributed-worker fan-out
+    /// (`federate_scalar`, `federate_discovery`, `distrib::fetch`) are
+    /// opaque remote fetches whose own internal phase breakdown is not
+    /// visible here; their GETs land on the `scan` phase by convention
+    /// (see the call sites in `prefetch`/`resolve_series_for_labels`).
+    pub phase_accounting: PhaseAccountingSnapshot,
     /// Upper-envelope cost estimate computed after snapshot resolution and
     /// before any page fetch (ADR-0044 decision 3).
     pub estimate: CostEstimate,
@@ -95,14 +109,15 @@ impl QueryStats {
         segments_fetched: u64,
         segments_pruned: u64,
         page_stats: FetchStats,
-        accounting: QueryAccountingSnapshot,
+        phase_accounting: PhaseAccountingSnapshot,
         estimate: CostEstimate,
     ) -> Self {
         QueryStats {
             segments_fetched,
             segments_pruned,
             page_stats,
-            accounting,
+            accounting: phase_accounting.pooled(),
+            phase_accounting,
             estimate,
             partial: false,
             warnings: Vec::new(),
@@ -120,6 +135,7 @@ impl Default for QueryStats {
             segments_pruned: 0,
             page_stats: FetchStats::default(),
             accounting: QueryAccountingSnapshot::default(),
+            phase_accounting: PhaseAccountingSnapshot::default(),
             estimate: CostEstimate::new(0, 0, 0, 0, 0),
             partial: false,
             warnings: Vec::new(),
@@ -688,7 +704,7 @@ impl QueryEngine {
         // pushdown), so it ignores the resolve's generation history.
         let attempt = |snapshot: Snapshot,
                        _generations: Vec<ShardGeneration>,
-                       accounting: QueryAccounting| async move {
+                       accounting: PhaseAccounting| async move {
             // The bytes-scanned budget (ADR-0061 decision 1) is enforced
             // inside `fetch_all_series`, once per completed segment fetch, so a
             // labels/series query that matches zero series still evaluates the
@@ -713,6 +729,14 @@ impl QueryEngine {
             // the same reason `prefetch` runs `federate_scalar` sequentially:
             // an `async_trait` remote fetch nested inside a fan-out combinator
             // makes the whole query future fail axum's `Handler` `Send` bound.
+            //
+            // `federate_discovery` takes the whole `PhaseAccounting` (not
+            // just `.scan()`): it folds the remote's spend into the `scan`
+            // sub-handle (issue #796 finding: federation is an opaque remote
+            // fetch, not phase-splittable without a remote-side accounting
+            // change), but its budget re-check needs `pooled()` to see the
+            // local resolve/plan/probe spend `fetch_all_series` already
+            // recorded too.
             let (fed_series, fed_warnings, fed_partial) = self
                 .federate_discovery(tenant_hash, matchers.to_vec(), window, &accounting)
                 .await?;
@@ -783,7 +807,7 @@ impl QueryEngine {
         tenant_hash: TenantHash,
         matchers: Vec<LabelMatcher>,
         window: TimeRange,
-        accounting: &QueryAccounting,
+        accounting: &PhaseAccounting,
     ) -> Result<(Vec<(SeriesId, LabelSet)>, Vec<String>, bool), QueryError> {
         let mut series: Vec<(SeriesId, LabelSet)> = Vec::new();
         let Some(federation) = &self.federation else {
@@ -795,7 +819,8 @@ impl QueryEngine {
         // structurally preventing this cluster's tokens from leaking). The
         // operator credential is baked into the fetcher, so no client credential
         // is threaded here and the remote's tenant identity comes from its own
-        // auth, never the wire.
+        // auth, never the wire. Remote spend is charged to `scan` (issue #796
+        // finding, same treatment as `federate_scalar`).
         let outcome = federation
             .fetch(
                 tenant_hash,
@@ -805,15 +830,17 @@ impl QueryEngine {
                 window.start_ns,
                 window.end_ns,
                 Vec::new(),
-                accounting.clone(),
+                accounting.scan().clone(),
                 self.config,
             )
             .await?;
         // Re-enforce the coordinator's bytes-scanned budget over the combined
         // local+remote spend now folded into `accounting`, identical to the
-        // query path. A budget trip is never masked by skip_unavailable.
+        // query path. `pooled()` (not just `.scan()`) so the local
+        // fetch_all_series spend recorded on resolve/plan/probe is included.
+        // A budget trip is never masked by skip_unavailable.
         if let Some(err) = bytes_scanned_exceeded(
-            accounting.snapshot().total_s3_bytes(),
+            accounting.snapshot().pooled().total_s3_bytes(),
             self.config.max_bytes_scanned,
         ) {
             return Err(err);
@@ -821,7 +848,7 @@ impl QueryEngine {
         // Re-enforce the coordinator's request budget the same way (ADR-0073
         // decision 3): a budget trip is never masked by skip_unavailable.
         if let Some(err) = segment_admission::request_budget_exceeded(
-            accounting.snapshot().total_s3_requests(),
+            accounting.snapshot().pooled().total_s3_requests(),
             self.config.max_s3_requests,
         ) {
             return Err(err);
@@ -902,7 +929,7 @@ impl QueryEngine {
         let windows_ref = &windows;
         let attempt = |snapshot: Snapshot,
                        generations: Vec<ShardGeneration>,
-                       accounting: QueryAccounting| async move {
+                       accounting: PhaseAccounting| async move {
             // Owned clones, not borrowed slice items: a closure capturing a
             // reference into `plans` through this combinator chain makes
             // rustc infer a fixed (non-higher-ranked) lifetime for the
@@ -1098,6 +1125,11 @@ impl QueryEngine {
                 .zip(windows_ref.iter())
                 .map(|(plan, w)| (plan.matchers.clone(), w.start_ns, w.end_ns))
                 .collect();
+            // `federate_scalar` takes the whole `PhaseAccounting` (not just
+            // `.scan()`): it folds the remote's spend into the `scan`
+            // sub-handle (issue #796 finding: an opaque remote fetch has no
+            // phase breakdown of its own), but its budget re-check needs
+            // `pooled()` to see the local resolve/plan/probe spend too.
             let (fed_runs, fed_hist_runs, fed_stats, fed_warnings, fed_partial) = self
                 .federate_scalar(tenant_hash, fed_plans, &accounting)
                 .await?;
@@ -1212,7 +1244,7 @@ impl QueryEngine {
         mut attempt: F,
     ) -> Result<(T, QueryStats), QueryError>
     where
-        F: FnMut(Snapshot, Vec<ShardGeneration>, QueryAccounting) -> Fut,
+        F: FnMut(Snapshot, Vec<ShardGeneration>, PhaseAccounting) -> Fut,
         Fut: std::future::Future<Output = Result<(T, FetchStats), QueryError>>,
     {
         // The catalog term (ADR-0044 decision 3) is the same for both
@@ -1226,7 +1258,7 @@ impl QueryEngine {
         // retried attempt re-resolves and re-fetches from scratch, so the
         // discarded first attempt's in-flight counts must not bleed into the
         // attempt that actually produced the result.
-        let first_accounting = QueryAccounting::new();
+        let first_accounting = PhaseAccounting::new();
         let (first, first_generations) = self
             .resolve_bounded(
                 tenant_hash,
@@ -1234,7 +1266,7 @@ impl QueryEngine {
                 min_tokens,
                 now_ns,
                 name_filter,
-                &first_accounting,
+                first_accounting.resolve(),
             )
             .await?;
         let first_estimate = estimate_cost(&first, fetch_multiplier, catalog_requests);
@@ -1245,7 +1277,7 @@ impl QueryEngine {
                 source: StoreError::NotFound,
                 ..
             })) => {
-                let second_accounting = QueryAccounting::new();
+                let second_accounting = PhaseAccounting::new();
                 let (second, second_generations) = self
                     .resolve_bounded(
                         tenant_hash,
@@ -1253,7 +1285,7 @@ impl QueryEngine {
                         min_tokens,
                         now_ns,
                         name_filter,
-                        &second_accounting,
+                        second_accounting.resolve(),
                     )
                     .await?;
                 let second_estimate = estimate_cost(&second, fetch_multiplier, catalog_requests);
@@ -1344,7 +1376,7 @@ impl QueryEngine {
         tenant_hash: TenantHash,
         snapshot: &Snapshot,
         matchers: &[LabelMatcher],
-        accounting: &QueryAccounting,
+        accounting: &PhaseAccounting,
         max_bytes_scanned: ByteLimit,
         max_s3_requests: RequestLimit,
     ) -> Result<
@@ -1364,7 +1396,7 @@ impl QueryEngine {
                 let accounting = accounting.clone();
                 async move {
                     fetcher
-                        .fetch_soa_and_histograms_accounted(
+                        .fetch_soa_and_histograms_phase_accounted(
                             tenant_hash,
                             &seg_ref,
                             matchers.as_slice(),
@@ -1390,13 +1422,14 @@ impl QueryEngine {
             histogram_out.push(histograms);
             page_stats.raw_f64_pages += stats.raw_f64_pages;
             page_stats.raw_f64_bytes += stats.raw_f64_bytes;
-            if let Some(err) =
-                bytes_scanned_exceeded(accounting.snapshot().total_s3_bytes(), max_bytes_scanned)
-            {
+            if let Some(err) = bytes_scanned_exceeded(
+                accounting.snapshot().pooled().total_s3_bytes(),
+                max_bytes_scanned,
+            ) {
                 return Err(err);
             }
             if let Some(err) = segment_admission::request_budget_exceeded(
-                accounting.snapshot().total_s3_requests(),
+                accounting.snapshot().pooled().total_s3_requests(),
                 max_s3_requests,
             ) {
                 return Err(err);
@@ -1438,7 +1471,7 @@ impl QueryEngine {
         tenant_hash: TenantHash,
         snapshot: &Snapshot,
         matchers: &[LabelMatcher],
-        accounting: &QueryAccounting,
+        accounting: &PhaseAccounting,
         max_bytes_scanned: ByteLimit,
         max_s3_requests: RequestLimit,
         deadline_unix_ns: i64,
@@ -1468,6 +1501,15 @@ impl QueryEngine {
             let cost = estimate_cost(snapshot, 1, 0);
             if crate::distrib::partition::should_distribute(distributed.thresholds(), &cost) {
                 let erasure = snapshot_erasure_predicates(snapshot);
+                // `distributed.fetch` takes a single pooled `QueryAccounting`
+                // handle: a worker's per-slice spend crosses the
+                // coordinator/worker protobuf wire as one pooled
+                // `QueryAccountingSnapshot` (`distrib/client.rs`'s
+                // `SliceResponse.accounting`), predating issue #796 and
+                // requiring a wire-format version bump to phase-split -- out
+                // of this ticket's scope. Charged to `scan` rather than left
+                // unaccounted (issue #796 finding, same treatment as
+                // federation above).
                 if let Some((triple, partials)) = distributed
                     .fetch(
                         tenant_hash,
@@ -1475,7 +1517,7 @@ impl QueryEngine {
                         snapshot,
                         matchers,
                         &erasure,
-                        accounting,
+                        accounting.scan(),
                         &self.config,
                         deadline_unix_ns,
                         partial_aggregate,
@@ -1491,13 +1533,13 @@ impl QueryEngine {
                     // under-reports: it re-evaluates the same budget over the
                     // fully-folded accounting the distributed fetch returned.
                     if let Some(err) = bytes_scanned_exceeded(
-                        accounting.snapshot().total_s3_bytes(),
+                        accounting.snapshot().pooled().total_s3_bytes(),
                         max_bytes_scanned,
                     ) {
                         return Err(err);
                     }
                     if let Some(err) = segment_admission::request_budget_exceeded(
-                        accounting.snapshot().total_s3_requests(),
+                        accounting.snapshot().pooled().total_s3_requests(),
                         max_s3_requests,
                     ) {
                         return Err(err);
@@ -1559,7 +1601,7 @@ impl QueryEngine {
         &self,
         tenant_hash: TenantHash,
         plan_matchers_windows: Vec<(Vec<LabelMatcher>, i64, i64)>,
-        accounting: &QueryAccounting,
+        accounting: &PhaseAccounting,
     ) -> Result<
         (
             Vec<Vec<FetchedSeriesSoa>>,
@@ -1585,7 +1627,9 @@ impl QueryEngine {
             // leaking this cluster's tokens). The operator credential is baked
             // into the fetcher, so no client credential is threaded here.
             // Owned args (accounting is an `Arc` clone that folds into the same
-            // handle) keep the fan-out future higher-ranked `Send`.
+            // handle) keep the fan-out future higher-ranked `Send`. Remote
+            // spend is charged to `scan` (issue #796 finding: opaque remote
+            // fetch, no phase breakdown of its own).
             let outcome = federation
                 .fetch(
                     tenant_hash,
@@ -1595,22 +1639,27 @@ impl QueryEngine {
                     start_ns,
                     end_ns,
                     Vec::new(),
-                    accounting.clone(),
+                    accounting.scan().clone(),
                     self.config,
                 )
                 .await?;
             // Re-enforce the coordinator's bytes-scanned budget over the
             // combined local+remote spend now folded into `accounting`, so a
-            // tight cap trips typed on the union of both clusters' frames. A
-            // budget trip is never masked by skip_unavailable.
+            // tight cap trips typed on the union of both clusters' frames AND
+            // the local resolve/plan/probe/scan spend already recorded on the
+            // other phase handles this query attempt shares -- `pooled()` is
+            // required here, not just the `scan` sub-handle the remote spend
+            // landed on, or a local-heavy resolve/plan/probe cost would be
+            // invisible to this check. A budget trip is never masked by
+            // skip_unavailable.
             if let Some(err) = bytes_scanned_exceeded(
-                accounting.snapshot().total_s3_bytes(),
+                accounting.snapshot().pooled().total_s3_bytes(),
                 self.config.max_bytes_scanned,
             ) {
                 return Err(err);
             }
             if let Some(err) = segment_admission::request_budget_exceeded(
-                accounting.snapshot().total_s3_requests(),
+                accounting.snapshot().pooled().total_s3_requests(),
                 self.config.max_s3_requests,
             ) {
                 return Err(err);
@@ -1642,7 +1691,7 @@ impl QueryEngine {
         tenant_hash: TenantHash,
         snapshot: &Snapshot,
         matchers: &[LabelMatcher],
-        accounting: &QueryAccounting,
+        accounting: &PhaseAccounting,
         max_bytes_scanned: ByteLimit,
         max_s3_requests: RequestLimit,
     ) -> Result<Vec<Vec<ravel_segment::SeriesEntry>>, QueryError> {
@@ -1655,7 +1704,7 @@ impl QueryEngine {
                 let accounting = accounting.clone();
                 async move {
                     fetcher
-                        .fetch_series_accounted(
+                        .fetch_series_phase_accounted(
                             tenant_hash,
                             &seg_ref,
                             matchers.as_slice(),
@@ -1675,13 +1724,14 @@ impl QueryEngine {
         // in-flight fetches.
         while let Some(r) = stream.next().await {
             out.push(r?);
-            if let Some(err) =
-                bytes_scanned_exceeded(accounting.snapshot().total_s3_bytes(), max_bytes_scanned)
-            {
+            if let Some(err) = bytes_scanned_exceeded(
+                accounting.snapshot().pooled().total_s3_bytes(),
+                max_bytes_scanned,
+            ) {
                 return Err(err);
             }
             if let Some(err) = segment_admission::request_budget_exceeded(
-                accounting.snapshot().total_s3_requests(),
+                accounting.snapshot().pooled().total_s3_requests(),
                 max_s3_requests,
             ) {
                 return Err(err);
@@ -5019,6 +5069,7 @@ mod prefetch_tests {
         HistogramCounts, HistogramSample, HistogramSpan, HistogramValue, IngestBounds, ResetHint,
         SegmentIdentity, SegmentWriter, SeriesInput, SeriesInputV3, SeriesValues, WrittenSegment,
     };
+    use ravel_types::accounting::AccountedOp;
     use ravel_types::{Label, TenantId};
     use uuid::Uuid;
 
@@ -6524,6 +6575,186 @@ mod prefetch_tests {
             "a shared-matcher query scans exactly the real single-fetch bytes, so it must \
              not trip a budget set at that exact real cost: {:?}",
             result.err()
+        );
+    }
+
+    /// A segment big enough (above [`crate::fetcher::DEFAULT_WHOLE_OBJECT_THRESHOLD`])
+    /// that `open_segment` takes the footer-suffix probe path instead of
+    /// folding the whole object into one read: this is the shape where
+    /// `plan`, `probe`, and `scan` are three genuinely distinct GETs rather
+    /// than the below-threshold case where `probe`/`scan` reuse `plan`'s
+    /// already-resident bytes. Values are bit-scrambled (not sequential) so
+    /// ALP/delta encoding cannot shrink the object back under threshold.
+    async fn publish_wide_metric_segment(
+        store: &MemoryStore,
+        tenant_hash: TenantHash,
+        writer_seq: u64,
+        metric: &str,
+        series_count: u64,
+        samples_per_series: u64,
+    ) {
+        let hour_bucket = u32::try_from(BASE_NS / (3_600 * NS_PER_SEC)).expect("hour bucket");
+        let series: Vec<(&str, Vec<Sample>)> = (0..series_count)
+            .map(|i| {
+                let id: &'static str = Box::leak(format!("s{i}").into_boxed_str());
+                let samples: Vec<Sample> = (0..samples_per_series)
+                    .map(|j| {
+                        let scramble = i
+                            .wrapping_mul(0x9E37_79B9_7F4A_7C15)
+                            .wrapping_add(j.wrapping_mul(0xBF58_476D_1CE4_E5B9));
+                        Sample {
+                            ts_ns: BASE_NS - NS_PER_MIN + j as i64,
+                            value: f64::from_bits(
+                                0x3FF0_0000_0000_0000 | (scramble & 0x000F_FFFF_FFFF_FFFF),
+                            ),
+                        }
+                    })
+                    .collect();
+                (id, samples)
+            })
+            .collect();
+        publish_metric_segment_multi(
+            store,
+            tenant_hash,
+            writer_seq,
+            metric,
+            series,
+            hour_bucket,
+            BASE_NS,
+        )
+        .await;
+    }
+
+    /// Issue #796, shape 1 (below [`crate::fetcher::DEFAULT_WHOLE_OBJECT_THRESHOLD`]):
+    /// one hot commit record, one small segment. `open_segment` folds the
+    /// entire object into its one `plan`-phase GET, so `decode_selected`
+    /// (`probe`) and the page fetch (`scan`) that follow both run entirely
+    /// against bytes already resident in the fetch cache -- zero additional
+    /// GETs for either. This is a legitimate, exact shape in its own right
+    /// (not every phase issues a request on every query), and it is the
+    /// shape that exercises summing phases where two of the four are
+    /// all-zero.
+    ///
+    /// Every number below was captured from a real run against
+    /// [`MemoryStore`], not assumed: this is the exact cost of resolving one
+    /// hot commit record and opening one below-threshold segment on this
+    /// store implementation, pinned so a regression in either the catalog's
+    /// resolve path or `open_segment`'s threshold check is caught here
+    /// rather than only downstream in #835-style diagnosis.
+    #[tokio::test]
+    async fn phase_split_below_threshold_segment_pins_exact_per_phase_figures() {
+        let store = Arc::new(MemoryStore::new());
+        let tenant_hash = TenantId::new("acme").hash();
+        publish_metric(
+            &store,
+            tenant_hash,
+            1,
+            "metric_a",
+            BASE_NS - NS_PER_MIN,
+            1.0,
+        )
+        .await;
+
+        let eng = engine(Arc::clone(&store));
+        let eval_window = EvalWindow::Instant { t_ns: BASE_NS };
+        let plan = vec![window_plan("metric_a")];
+        let (_source, stats) = eng
+            .prefetch(tenant_hash, &plan, &eval_window, &[], BASE_NS)
+            .await
+            .expect("prefetch");
+        let pa = &stats.phase_accounting;
+
+        // resolve: one hot commit record costs exactly 2 GETs + 2 LISTs on
+        // `MemoryStore` (`Catalog::resolve_pruned_with_generations`, out of
+        // this crate's scope) -- not the naive 1:1 a single record might
+        // suggest.
+        assert_eq!(pa.resolve.s3_requests(AccountedOp::Get), 2);
+        assert_eq!(pa.resolve.s3_requests(AccountedOp::List), 2);
+        assert_eq!(pa.resolve.s3_bytes(AccountedOp::Get), 288);
+
+        // plan: exactly one whole-object GET (below threshold), one segment
+        // opened.
+        assert_eq!(pa.plan.s3_requests(AccountedOp::Get), 1);
+        assert_eq!(pa.plan.s3_bytes(AccountedOp::Get), 316);
+        assert_eq!(pa.plan.segments_opened, 1);
+
+        // probe and scan: zero further GETs, entirely served from `plan`'s
+        // resident bytes.
+        assert_eq!(pa.probe.s3_requests(AccountedOp::Get), 0);
+        assert_eq!(pa.probe.series_matched, 1);
+        assert_eq!(pa.scan.s3_requests(AccountedOp::Get), 0);
+        assert_eq!(pa.scan.decompressed_bytes, 16);
+
+        // Sum of phases equals the pooled figure exactly, for requests and
+        // bytes, including phases whose counters are all zero.
+        let pooled = pa.pooled();
+        assert_eq!(pooled.total_s3_requests(), 5, "3 GETs + 2 LISTs");
+        assert_eq!(pooled.total_s3_bytes(), 604);
+        assert_eq!(
+            pooled, stats.accounting,
+            "phase_accounting.pooled() must equal the existing pooled QueryStats.accounting field exactly"
+        );
+    }
+
+    /// Issue #796, shape 2 (above [`crate::fetcher::DEFAULT_WHOLE_OBJECT_THRESHOLD`]):
+    /// one hot commit record, one wide segment (150 series x 3000 samples,
+    /// bit-scrambled so it cannot compress back under threshold). Here
+    /// `plan`, `probe`, and `scan` are three genuinely distinct real GETs --
+    /// the footer-suffix probe, the segment catalog fetch, and the page data
+    /// read -- so this is the "phases are NOT all equal" shape the resolve
+    /// phase's cost does not scale with (a query against a bigger segment
+    /// still resolves the same one hot commit record) while plan/probe/scan
+    /// do. `scan`'s single GET matches the object count exactly (one
+    /// segment, one scan-phase GET), directly exercising the #835 scenario
+    /// this split exists to diagnose (attributing per-object scan cost
+    /// distinctly from resolve/plan/probe cost).
+    #[tokio::test]
+    async fn phase_split_above_threshold_segment_has_unequal_phases_and_pins_exact_figures() {
+        let store = Arc::new(MemoryStore::new());
+        let tenant_hash = TenantId::new("acme").hash();
+        publish_wide_metric_segment(&store, tenant_hash, 1, "metric_a", 150, 3000).await;
+
+        let eng = engine(Arc::clone(&store));
+        let eval_window = EvalWindow::Instant { t_ns: BASE_NS };
+        let plan = vec![window_plan("metric_a")];
+        let (_source, stats) = eng
+            .prefetch(tenant_hash, &plan, &eval_window, &[], BASE_NS)
+            .await
+            .expect("prefetch");
+        let pa = &stats.phase_accounting;
+
+        assert_eq!(pa.resolve.s3_requests(AccountedOp::Get), 2);
+        assert_eq!(pa.resolve.s3_requests(AccountedOp::List), 2);
+        assert_eq!(pa.resolve.s3_bytes(AccountedOp::Get), 293);
+
+        assert_eq!(pa.plan.s3_requests(AccountedOp::Get), 1);
+        assert_eq!(pa.plan.s3_bytes(AccountedOp::Get), 65536);
+        assert_eq!(pa.plan.segments_opened, 1);
+
+        assert_eq!(pa.probe.s3_requests(AccountedOp::Get), 1);
+        assert_eq!(pa.probe.s3_bytes(AccountedOp::Get), 3111);
+        assert_eq!(pa.probe.series_matched, 150);
+
+        // The scenario #796 exists for: this segment is one object, and the
+        // scan phase issues exactly one GET for it. On a tenant with N
+        // objects a predicate-free full scan issues exactly N scan-phase
+        // GETs -- this is that claim pinned at N=1.
+        assert_eq!(pa.scan.s3_requests(AccountedOp::Get), 1);
+        assert_eq!(pa.scan.s3_bytes(AccountedOp::Get), 2983182);
+        assert_eq!(pa.scan.decompressed_bytes, 7_200_000);
+
+        assert!(
+            pa.plan.s3_requests(AccountedOp::Get) != pa.resolve.s3_requests(AccountedOp::Get)
+                || pa.probe.s3_bytes(AccountedOp::Get) != pa.scan.s3_bytes(AccountedOp::Get),
+            "this shape must have at least one pair of unequal phases"
+        );
+
+        let pooled = pa.pooled();
+        assert_eq!(pooled.total_s3_requests(), 5 + 2, "5 GETs + 2 LISTs");
+        assert_eq!(pooled.total_s3_bytes(), 293 + 65536 + 3111 + 2983182);
+        assert_eq!(
+            pooled, stats.accounting,
+            "phase_accounting.pooled() must equal the existing pooled QueryStats.accounting field exactly"
         );
     }
 }

--- a/crates/ravel-query/src/fetcher.rs
+++ b/crates/ravel-query/src/fetcher.rs
@@ -15,6 +15,8 @@ use ravel_segment::{
     decode_run_pages_soa, open_from_suffix, plan_ranges_v4,
 };
 use ravel_types::accounting::{AccountedOp, QueryAccounting};
+
+use crate::phase_accounting::PhaseAccounting;
 use ravel_types::{LabelSet, Sample, SeriesId, TenantHash};
 use tracing::Instrument;
 
@@ -1478,11 +1480,12 @@ impl SegmentFetcher {
         seg_ref: &SegmentRef,
         matchers: &[LabelMatcher],
         count_stats: bool,
-        accounting: &QueryAccounting,
+        accounting: &PhaseAccounting,
     ) -> Result<(Vec<RunDecode>, FetchStats), FetchError> {
         let key = &seg_ref.data_object_key;
-        let (footer, total_size, suffix_etag, mut regions) =
-            self.open_segment(tenant_hash, seg_ref, accounting).await?;
+        let (footer, total_size, suffix_etag, mut regions) = self
+            .open_segment(tenant_hash, seg_ref, accounting.plan())
+            .await?;
         let selected = self
             .decode_selected(
                 seg_ref,
@@ -1492,7 +1495,7 @@ impl SegmentFetcher {
                 &suffix_etag,
                 &mut regions,
                 matchers,
-                accounting,
+                accounting.probe(),
             )
             .await?;
         let scalar: Vec<&SeriesEntryV4> = selected
@@ -1510,7 +1513,7 @@ impl SegmentFetcher {
                 &scalar,
                 &suffix_etag,
                 &mut regions,
-                accounting,
+                accounting.scan(),
             )
             .await?;
         self.build_scalar_decodes(
@@ -1520,7 +1523,7 @@ impl SegmentFetcher {
             &planned,
             &regions,
             count_stats,
-            accounting,
+            accounting.scan(),
         )
     }
 
@@ -1667,11 +1670,12 @@ impl SegmentFetcher {
         tenant_hash: TenantHash,
         seg_ref: &SegmentRef,
         matchers: &[LabelMatcher],
-        accounting: &QueryAccounting,
+        accounting: &PhaseAccounting,
     ) -> Result<Vec<RunHistogramDecode>, FetchError> {
         let key = &seg_ref.data_object_key;
-        let (footer, total_size, suffix_etag, mut regions) =
-            self.open_segment(tenant_hash, seg_ref, accounting).await?;
+        let (footer, total_size, suffix_etag, mut regions) = self
+            .open_segment(tenant_hash, seg_ref, accounting.plan())
+            .await?;
         let selected = self
             .decode_selected(
                 seg_ref,
@@ -1681,7 +1685,7 @@ impl SegmentFetcher {
                 &suffix_etag,
                 &mut regions,
                 matchers,
-                accounting,
+                accounting.probe(),
             )
             .await?;
         let histogram: Vec<&SeriesEntryV4> = selected
@@ -1699,10 +1703,17 @@ impl SegmentFetcher {
                 &histogram,
                 &suffix_etag,
                 &mut regions,
-                accounting,
+                accounting.scan(),
             )
             .await?;
-        self.build_histogram_decodes(key, seg_ref, &histogram, &planned, &regions, accounting)
+        self.build_histogram_decodes(
+            key,
+            seg_ref,
+            &histogram,
+            &planned,
+            &regions,
+            accounting.scan(),
+        )
     }
 
     /// Histogram counterpart to
@@ -1831,11 +1842,12 @@ impl SegmentFetcher {
         seg_ref: &SegmentRef,
         matchers: &[LabelMatcher],
         count_stats: bool,
-        accounting: &QueryAccounting,
+        accounting: &PhaseAccounting,
     ) -> Result<(Vec<RunDecode>, FetchStats, Vec<RunHistogramDecode>), FetchError> {
         let key = &seg_ref.data_object_key;
-        let (footer, total_size, suffix_etag, mut regions) =
-            self.open_segment(tenant_hash, seg_ref, accounting).await?;
+        let (footer, total_size, suffix_etag, mut regions) = self
+            .open_segment(tenant_hash, seg_ref, accounting.plan())
+            .await?;
         let selected = self
             .decode_selected(
                 seg_ref,
@@ -1845,7 +1857,7 @@ impl SegmentFetcher {
                 &suffix_etag,
                 &mut regions,
                 matchers,
-                accounting,
+                accounting.probe(),
             )
             .await?;
         let scalar: Vec<&SeriesEntryV4> = selected
@@ -1867,7 +1879,7 @@ impl SegmentFetcher {
                 &scalar,
                 &suffix_etag,
                 &mut regions,
-                accounting,
+                accounting.scan(),
             )
             .await?
         };
@@ -1881,7 +1893,7 @@ impl SegmentFetcher {
                 &histogram,
                 &suffix_etag,
                 &mut regions,
-                accounting,
+                accounting.scan(),
             )
             .await?
         };
@@ -1896,7 +1908,7 @@ impl SegmentFetcher {
                 &scalar_planned,
                 &regions,
                 count_stats,
-                accounting,
+                accounting.scan(),
             )?
         };
         let histogram_out = if histogram.is_empty() {
@@ -1908,7 +1920,7 @@ impl SegmentFetcher {
                 &histogram,
                 &histogram_planned,
                 &regions,
-                accounting,
+                accounting.scan(),
             )?
         };
         Ok((scalar_out, stats, histogram_out))
@@ -1941,8 +1953,33 @@ impl SegmentFetcher {
         matchers: &[LabelMatcher],
         accounting: &QueryAccounting,
     ) -> Result<Vec<SeriesEntry>, FetchError> {
-        let (footer, total_size, suffix_etag, mut regions) =
-            self.open_segment(tenant_hash, seg_ref, accounting).await?;
+        let phase = PhaseAccounting::new();
+        let result = self
+            .fetch_series_phase_accounted(tenant_hash, seg_ref, matchers, &phase)
+            .await;
+        accounting.merge_snapshot(&phase.snapshot().pooled());
+        result
+    }
+
+    /// Phase-split counterpart of
+    /// [`fetch_series_accounted`](Self::fetch_series_accounted) (issue #796):
+    /// same behavior, but every GET is recorded against the phase that
+    /// issued it (plan for [`open_segment`](Self::open_segment), probe for
+    /// [`decode_selected`](Self::decode_selected)) rather than pooled onto
+    /// one handle. `fetch_series_accounted` is now a thin wrapper over this
+    /// that folds the four phase totals back into its single
+    /// `QueryAccounting` handle, so its own callers (`ravel-sql`'s direct
+    /// calls included) see unchanged pooled numbers.
+    pub(crate) async fn fetch_series_phase_accounted(
+        &self,
+        tenant_hash: TenantHash,
+        seg_ref: &SegmentRef,
+        matchers: &[LabelMatcher],
+        accounting: &PhaseAccounting,
+    ) -> Result<Vec<SeriesEntry>, FetchError> {
+        let (footer, total_size, suffix_etag, mut regions) = self
+            .open_segment(tenant_hash, seg_ref, accounting.plan())
+            .await?;
         let selected = self
             .decode_selected(
                 seg_ref,
@@ -1952,7 +1989,7 @@ impl SegmentFetcher {
                 &suffix_etag,
                 &mut regions,
                 matchers,
-                accounting,
+                accounting.probe(),
             )
             .await?;
         Ok(selected.into_iter().map(|e| e.entry).collect())
@@ -1984,9 +2021,12 @@ impl SegmentFetcher {
         matchers: &[LabelMatcher],
         accounting: &QueryAccounting,
     ) -> Result<Vec<FetchedSeries>, FetchError> {
-        let (runs, _stats) = self
-            .fetch_runs(tenant_hash, seg_ref, matchers, false, accounting)
-            .await?;
+        let phase = PhaseAccounting::new();
+        let result = self
+            .fetch_runs(tenant_hash, seg_ref, matchers, false, &phase)
+            .await;
+        accounting.merge_snapshot(&phase.snapshot().pooled());
+        let (runs, _stats) = result?;
         Ok(runs.into_iter().map(RunDecode::into_aos).collect())
     }
 
@@ -2015,9 +2055,12 @@ impl SegmentFetcher {
         matchers: &[LabelMatcher],
         accounting: &QueryAccounting,
     ) -> Result<(Vec<FetchedSeriesSoa>, FetchStats), FetchError> {
-        let (runs, stats) = self
-            .fetch_runs(tenant_hash, seg_ref, matchers, true, accounting)
-            .await?;
+        let phase = PhaseAccounting::new();
+        let result = self
+            .fetch_runs(tenant_hash, seg_ref, matchers, true, &phase)
+            .await;
+        accounting.merge_snapshot(&phase.snapshot().pooled());
+        let (runs, stats) = result?;
         Ok((runs.into_iter().map(RunDecode::into_soa).collect(), stats))
     }
 
@@ -2048,9 +2091,12 @@ impl SegmentFetcher {
         matchers: &[LabelMatcher],
         accounting: &QueryAccounting,
     ) -> Result<Vec<FetchedHistogramSeries>, FetchError> {
-        let runs = self
-            .fetch_histogram_runs(tenant_hash, seg_ref, matchers, accounting)
-            .await?;
+        let phase = PhaseAccounting::new();
+        let result = self
+            .fetch_histogram_runs(tenant_hash, seg_ref, matchers, &phase)
+            .await;
+        accounting.merge_snapshot(&phase.snapshot().pooled());
+        let runs = result?;
         Ok(runs
             .into_iter()
             .map(RunHistogramDecode::into_fetched)
@@ -2096,6 +2142,37 @@ impl SegmentFetcher {
         seg_ref: &SegmentRef,
         matchers: &[LabelMatcher],
         accounting: &QueryAccounting,
+    ) -> Result<
+        (
+            Vec<FetchedSeriesSoa>,
+            FetchStats,
+            Vec<FetchedHistogramSeries>,
+        ),
+        FetchError,
+    > {
+        let phase = PhaseAccounting::new();
+        let result = self
+            .fetch_soa_and_histograms_phase_accounted(tenant_hash, seg_ref, matchers, &phase)
+            .await;
+        accounting.merge_snapshot(&phase.snapshot().pooled());
+        result
+    }
+
+    /// Phase-split counterpart of
+    /// [`fetch_soa_and_histograms_accounted`](Self::fetch_soa_and_histograms_accounted)
+    /// (issue #796); see [`fetch_series_phase_accounted`](Self::fetch_series_phase_accounted)
+    /// for why both forms exist. `engine.rs` calls this directly with a real,
+    /// persistent `PhaseAccounting` for end-to-end phase visibility;
+    /// `fetch_soa_and_histograms_accounted` is a thin wrapper over this that
+    /// folds the four phase totals back into its single `QueryAccounting`
+    /// handle, so its own callers (`ravel-sql`'s direct calls included) see
+    /// unchanged pooled numbers.
+    pub(crate) async fn fetch_soa_and_histograms_phase_accounted(
+        &self,
+        tenant_hash: TenantHash,
+        seg_ref: &SegmentRef,
+        matchers: &[LabelMatcher],
+        accounting: &PhaseAccounting,
     ) -> Result<
         (
             Vec<FetchedSeriesSoa>,

--- a/crates/ravel-query/src/lib.rs
+++ b/crates/ravel-query/src/lib.rs
@@ -11,6 +11,7 @@ mod error;
 mod fetcher;
 pub mod http;
 mod log_fetcher;
+mod phase_accounting;
 mod query_admission;
 mod segment_admission;
 pub mod span_fetcher;
@@ -32,6 +33,7 @@ pub use log_fetcher::{
     DEFAULT_LOG_SUFFIX_LEN, DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD, LogFetchError, LogFetchOutput,
     LogQuery, LogSegmentFetcher, LogSegmentScan, StreamAttrEquals,
 };
+pub use phase_accounting::{PhaseAccounting, PhaseAccountingSnapshot, QueryPhase};
 pub use query_admission::{
     QueryAdmissionController, QueryConcurrencyLimit, QueryPermit, QueryRejected,
     query_admission_snapshot_key, reconcile_query_admission_once,

--- a/crates/ravel-query/src/log_fetcher.rs
+++ b/crates/ravel-query/src/log_fetcher.rs
@@ -51,6 +51,7 @@ use std::sync::Arc;
 
 use crate::erasure::ErasurePredicate;
 use crate::fetcher::ReadCache;
+use crate::phase_accounting::PhaseAccounting;
 use bytes::Bytes;
 use ravel_cache::{CacheKey, SingleFlightError, Source};
 use ravel_catalog::SegmentRef;
@@ -781,44 +782,56 @@ impl LogSegmentFetcher {
         &self,
         seg_ref: &SegmentRef,
         query: &LogQuery,
-        accounting: &QueryAccounting,
+        caller_accounting: &QueryAccounting,
     ) -> Result<Option<LogFetchOutput>, LogFetchError> {
-        if !Self::ts_range_relevant(seg_ref, query.ts_min_ns, query.ts_max_ns) {
-            return Ok(None);
+        // Issue #796: this funnel has no separate plan step of its own (one
+        // unconditional whole-object GET, then decode), so its GET is charged
+        // to the `scan` phase. See `crate::phase_accounting`'s module docs for
+        // the phase taxonomy and `scan_accounted_with_tenant` below for the
+        // tenant-aware funnel this untenanted entry point mirrors.
+        let phase = PhaseAccounting::new();
+        let accounting = phase.scan();
+        let result = async {
+            if !Self::ts_range_relevant(seg_ref, query.ts_min_ns, query.ts_max_ns) {
+                return Ok(None);
+            }
+            let key = &seg_ref.data_object_key;
+            // Two separable phases here (ADR-0044 decision 5): the
+            // whole-object GET, then the STREAM_DIR resolve + `RlogReader` scan in
+            // `scan_bytes`. They are named `page_fetch` and `decode` to match the
+            // metric path's phase names. This entry point is reached by the
+            // unaccounted `fetch` (and by tests); the real production log/alerts/
+            // audit callers in `ravel-sql` go through
+            // `fetch_accounted_with_tenant`, which carries its own copy of these
+            // spans over its own (cache-aware) GET path. Wiring those callers onto
+            // an accounted funnel at all is separate, still-open future work.
+            let fetch_span = tracing::debug_span!(
+                "page_fetch",
+                signal = "logs",
+                s3_requests = tracing::field::Empty,
+                s3_bytes = tracing::field::Empty,
+            );
+            let got = async {
+                self.store
+                    .get(key, GetRange::Full)
+                    .await
+                    .map_err(|source| LogFetchError::Store {
+                        key: key.to_string(),
+                        source,
+                    })
+            }
+            .instrument(fetch_span.clone())
+            .await?;
+            accounting.record_s3_request(AccountedOp::Get);
+            accounting.add_s3_bytes(AccountedOp::Get, got.data.len() as u64);
+            // This funnel issues exactly one whole-object GET per call.
+            fetch_span.record("s3_requests", 1u64);
+            fetch_span.record("s3_bytes", got.data.len() as u64);
+            self.decode_spanned(key, &got.data, query)
         }
-        let key = &seg_ref.data_object_key;
-        // Two separable phases here (ADR-0044 decision 5): the
-        // whole-object GET, then the STREAM_DIR resolve + `RlogReader` scan in
-        // `scan_bytes`. They are named `page_fetch` and `decode` to match the
-        // metric path's phase names. This entry point is reached by the
-        // unaccounted `fetch` (and by tests); the real production log/alerts/
-        // audit callers in `ravel-sql` go through
-        // `fetch_accounted_with_tenant`, which carries its own copy of these
-        // spans over its own (cache-aware) GET path. Wiring those callers onto
-        // an accounted funnel at all is separate, still-open future work.
-        let fetch_span = tracing::debug_span!(
-            "page_fetch",
-            signal = "logs",
-            s3_requests = tracing::field::Empty,
-            s3_bytes = tracing::field::Empty,
-        );
-        let got = async {
-            self.store
-                .get(key, GetRange::Full)
-                .await
-                .map_err(|source| LogFetchError::Store {
-                    key: key.to_string(),
-                    source,
-                })
-        }
-        .instrument(fetch_span.clone())
-        .await?;
-        accounting.record_s3_request(AccountedOp::Get);
-        accounting.add_s3_bytes(AccountedOp::Get, got.data.len() as u64);
-        // This funnel issues exactly one whole-object GET per call.
-        fetch_span.record("s3_requests", 1u64);
-        fetch_span.record("s3_bytes", got.data.len() as u64);
-        self.decode_spanned(key, &got.data, query)
+        .await;
+        caller_accounting.merge_snapshot(&phase.snapshot().pooled());
+        result
     }
 
     /// Cache-aware counterpart of [`fetch_accounted`](Self::fetch_accounted):
@@ -848,19 +861,34 @@ impl LogSegmentFetcher {
         seg_ref: &SegmentRef,
         tenant_hash: TenantHash,
         query: &LogQuery,
-        accounting: &QueryAccounting,
+        caller_accounting: &QueryAccounting,
     ) -> Result<Option<LogFetchOutput>, LogFetchError> {
+        // Issue #796: `tenant_bytes` (below the block-range threshold, a
+        // whole-object GET) and the block-range path it falls through to
+        // above threshold both do data reads with no separate plan step of
+        // their own here, so this funnel's GETs are charged to `scan`.
+        // `decode_spanned` (below) records no accounting of its own -- unlike
+        // the `LogSegmentScan`-returning funnels below, this one fully
+        // decodes and returns before this function returns, so buffering into
+        // a disposable `PhaseAccounting` and merging once is safe here.
+        let phase = PhaseAccounting::new();
+        let accounting = phase.scan();
         // This funnel's decode (`scan_bytes`) reads every column, so the fetch
         // selection is the same: on a version-4 object it brings every column
         // chunk of every surviving block (ADR-0699 decision 5).
         let all = ColumnSelection::all();
-        let Some(bytes) = self
-            .tenant_bytes(seg_ref, tenant_hash, query, &all, accounting)
-            .await?
-        else {
-            return Ok(None);
-        };
-        self.decode_spanned(&seg_ref.data_object_key, &bytes, query)
+        let result = async {
+            let Some(bytes) = self
+                .tenant_bytes(seg_ref, tenant_hash, query, &all, accounting)
+                .await?
+            else {
+                return Ok(None);
+            };
+            self.decode_spanned(&seg_ref.data_object_key, &bytes, query)
+        }
+        .await;
+        caller_accounting.merge_snapshot(&phase.snapshot().pooled());
+        result
     }
 
     /// Streaming counterpart of
@@ -887,6 +915,23 @@ impl LogSegmentFetcher {
     /// by [`BlockRangeFetcher`] as a probe plus coalesced block ranges, so the
     /// raw bytes moved are proportional to pruning rather than to object size --
     /// but the resident buffer is still object-sized, per call.
+    ///
+    /// # Issue #796 phase attribution
+    ///
+    /// Every GET this funnel issues (directly, or through
+    /// [`BlockRangeFetcher`]'s probe-then-range protocol above the
+    /// block-range threshold) is `scan` phase by this file's mapping: unlike
+    /// [`plan_segment`](Self::plan_segment), nothing here is a standalone
+    /// planning read. `accounting` is taken and stored as-is (not buffered
+    /// through a disposable [`PhaseAccounting`](crate::phase_accounting::PhaseAccounting)
+    /// like [`fetch_accounted_with_tenant`](Self::fetch_accounted_with_tenant)):
+    /// the returned [`LogSegmentScan`] keeps writing to it after this call
+    /// returns (`LogSegmentScan::finish`'s deferred `page_bytes_fetched`/
+    /// `page_bytes_decoded`, ADR-0107 decision 4), so a merge-once buffer
+    /// would silently drop those writes. A caller wanting a live `scan`-phase
+    /// split for this funnel would need to pass a `PhaseAccounting::scan()`
+    /// handle directly; no in-scope caller does, which is a #796 report
+    /// finding, not a bug fixed here.
     pub async fn scan_accounted_with_tenant(
         &self,
         seg_ref: &SegmentRef,
@@ -937,6 +982,11 @@ impl LogSegmentFetcher {
     ///
     /// A single GET observes one object state, so no [`EtagPin`] is needed: the
     /// multi-GET consistency the block-range path must defend does not arise here.
+    ///
+    /// Issue #796: `scan` phase, same reasoning and the same not-buffered
+    /// `accounting` handling as
+    /// [`scan_accounted_with_tenant`](Self::scan_accounted_with_tenant)'s doc
+    /// comment.
     pub async fn scan_whole_accounted_with_tenant(
         &self,
         seg_ref: &SegmentRef,
@@ -996,127 +1046,145 @@ impl LogSegmentFetcher {
     /// path skips the plan pass entirely.
     ///
     /// [`scan_accounted_with_tenant`]: Self::scan_accounted_with_tenant
+    ///
+    /// Issue #796: every GET this method issues -- the fast path's footer
+    /// probe, the skip-decidable path's `fetch_plan_sections`, and the
+    /// fallback's whole-object read (a planning read here, not a scan, per
+    /// its own comment below) -- is `plan` phase. Buffered through a
+    /// disposable [`PhaseAccounting`](crate::phase_accounting::PhaseAccounting)
+    /// and merged once before returning: safe here because, unlike the
+    /// `LogSegmentScan`-returning funnels, nothing this method returns keeps
+    /// writing to the accounting handle after it returns (the fallback's
+    /// `scan.remaining_blocks()`/`scan.stats()` are read synchronously, and
+    /// the `BlockScan` itself carries no accounting handle).
     pub async fn plan_segment(
         &self,
         seg_ref: &SegmentRef,
         tenant_hash: TenantHash,
         query: &LogQuery,
-        accounting: &QueryAccounting,
+        caller_accounting: &QueryAccounting,
     ) -> Result<Option<(usize, ScanStats, Option<footer::LogFooter>)>, LogFetchError> {
-        // Fast path (#693): a query with no block-level predicate whose ts
-        // window fully CONTAINS the segment's span prunes nothing -- every block
-        // survives -- so the survivor count is the footer's `block_count` and no
-        // block-range fetch or decode is needed. Only the ADR-0107 suffix probe
-        // runs, to read the footer. Containment is strictly stronger than
-        // `ts_range_relevant`'s overlap (a partially-overlapping window still
-        // needs real ts pruning), and it implies relevance, so the fast path
-        // never has to return the irrelevant-`None`. A zero object size cannot
-        // be range-probed (every extent, starting with the probe's cache key,
-        // is derived from it), so it falls through to the whole-object slow
-        // path, as does an inverted span (`min > max`, the shape a zero-record
-        // payload would produce, structurally unreachable today but not worth
-        // trusting blindly): the slow path's `ts_range_relevant` would return
-        // `None` for a genuinely empty segment, and the fast path should agree
-        // rather than returning `Some((0, ..))` for an input that should never
-        // reach a segment at all. `object_size > block_range_threshold` keeps
-        // the fast path strictly to the band where it actually saves a GET: at
-        // or below the threshold `tenant_bytes` already takes a single
-        // whole-object read (`fetch_footer` has no matching whole-object
-        // crossover of its own, so below the threshold it would read the same
-        // object twice under two different cache keys instead of once).
-        if seg_ref.object_size > self.block_range_threshold
-            && seg_ref.min_event_ts_ns <= seg_ref.max_event_ts_ns
-            && query.is_block_predicate_free()
-            && query.ts_min_ns <= seg_ref.min_event_ts_ns
-            && seg_ref.max_event_ts_ns <= query.ts_max_ns
-        {
-            let (n, stats, footer) = self
-                .plan_segment_fast(seg_ref, tenant_hash, accounting)
-                .await?;
-            return Ok(Some((n, stats, Some(footer))));
-        }
-
-        // Skip-index-only survivor count (#761): when every block-level predicate
-        // the query carries is decidable from the skip index alone -- ts bounds
-        // and prune-only NumRange arms, no text/content arm, no attribute-equality
-        // POSTINGS prune, no stream filter -- the surviving-block count is exactly
-        // `candidate_blocks` over those arms, with no BLOCKS byte fetched and no
-        // block decoded. The reader's full prune (skip, then POSTINGS, then bloom)
-        // reduces to the skip step for such a query, so this count equals the
-        // survivor list a subset open will stripe over, and the footer read here
-        // carries forward so those opens skip their own probe (#693 part 3).
-        //
-        // The relevance check is the one the fallback's `tenant_bytes` runs: it
-        // is what turns an out-of-window segment into the `None` the caller
-        // drops, and unlike the fast path's containment test this branch's
-        // guard does not imply it.
-        if seg_ref.object_size > self.block_range_threshold
-            && seg_ref.min_event_ts_ns <= seg_ref.max_event_ts_ns
-            && Self::ts_range_relevant(seg_ref, query.ts_min_ns, query.ts_max_ns)
-            && Self::plan_skip_decidable(query)
-        {
-            // The `page_fetch` phase span the other plan paths carry (#782), so
-            // the trace shows the probe and section GETs this branch issues.
-            // `s3_bytes` reports block bytes only, which are structurally zero
-            // here; the directory-overhead bytes are recorded in `accounting`.
-            let fetch_span = tracing::debug_span!(
-                "page_fetch",
-                signal = "logs",
-                s3_requests = tracing::field::Empty,
-                s3_bytes = tracing::field::Empty,
-            );
-            let (footer, skip, field_dir, stats) = async {
-                self.block_range
-                    .fetch_plan_sections(seg_ref, tenant_hash, accounting)
-                    .await
+        let phase = PhaseAccounting::new();
+        let accounting = phase.plan();
+        let result = async {
+            // Fast path (#693): a query with no block-level predicate whose ts
+            // window fully CONTAINS the segment's span prunes nothing -- every block
+            // survives -- so the survivor count is the footer's `block_count` and no
+            // block-range fetch or decode is needed. Only the ADR-0107 suffix probe
+            // runs, to read the footer. Containment is strictly stronger than
+            // `ts_range_relevant`'s overlap (a partially-overlapping window still
+            // needs real ts pruning), and it implies relevance, so the fast path
+            // never has to return the irrelevant-`None`. A zero object size cannot
+            // be range-probed (every extent, starting with the probe's cache key,
+            // is derived from it), so it falls through to the whole-object slow
+            // path, as does an inverted span (`min > max`, the shape a zero-record
+            // payload would produce, structurally unreachable today but not worth
+            // trusting blindly): the slow path's `ts_range_relevant` would return
+            // `None` for a genuinely empty segment, and the fast path should agree
+            // rather than returning `Some((0, ..))` for an input that should never
+            // reach a segment at all. `object_size > block_range_threshold` keeps
+            // the fast path strictly to the band where it actually saves a GET: at
+            // or below the threshold `tenant_bytes` already takes a single
+            // whole-object read (`fetch_footer` has no matching whole-object
+            // crossover of its own, so below the threshold it would read the same
+            // object twice under two different cache keys instead of once).
+            if seg_ref.object_size > self.block_range_threshold
+                && seg_ref.min_event_ts_ns <= seg_ref.max_event_ts_ns
+                && query.is_block_predicate_free()
+                && query.ts_min_ns <= seg_ref.min_event_ts_ns
+                && seg_ref.max_event_ts_ns <= query.ts_max_ns
+            {
+                let (n, stats, footer) = self
+                    .plan_segment_fast(seg_ref, tenant_hash, accounting)
+                    .await?;
+                return Ok(Some((n, stats, Some(footer))));
             }
-            .instrument(fetch_span.clone())
-            .await?;
-            let requests = stats.probe_gets + stats.metadata_gets + stats.block_range_gets;
-            fetch_span.record("s3_requests", requests);
-            fetch_span.record("s3_bytes", stats.block_bytes_fetched);
 
-            let refs: Vec<&Predicate> = query.prune.iter().collect();
-            let numeric = field_dir.numeric_range_arms(&refs);
-            let survivors = skip
-                .candidate_blocks(query.ts_min_ns, query.ts_max_ns, None, &numeric)
-                .len();
-            let blocks = skip.l0.len() as u32;
-            let plan_stats = ScanStats {
-                blocks_total: blocks,
-                blocks_after_skip: survivors as u32,
-                blocks_after_postings: survivors as u32,
-                blocks_after_bloom: survivors as u32,
-                blocks_scanned: 0,
-                pages_decoded: 0,
-                pages_skipped: 0,
-                page_bytes_fetched: 0,
-                page_bytes_decoded: 0,
-                bloom_degraded: false,
-                postings_degraded: false,
+            // Skip-index-only survivor count (#761): when every block-level predicate
+            // the query carries is decidable from the skip index alone -- ts bounds
+            // and prune-only NumRange arms, no text/content arm, no attribute-equality
+            // POSTINGS prune, no stream filter -- the surviving-block count is exactly
+            // `candidate_blocks` over those arms, with no BLOCKS byte fetched and no
+            // block decoded. The reader's full prune (skip, then POSTINGS, then bloom)
+            // reduces to the skip step for such a query, so this count equals the
+            // survivor list a subset open will stripe over, and the footer read here
+            // carries forward so those opens skip their own probe (#693 part 3).
+            //
+            // The relevance check is the one the fallback's `tenant_bytes` runs: it
+            // is what turns an out-of-window segment into the `None` the caller
+            // drops, and unlike the fast path's containment test this branch's
+            // guard does not imply it.
+            if seg_ref.object_size > self.block_range_threshold
+                && seg_ref.min_event_ts_ns <= seg_ref.max_event_ts_ns
+                && Self::ts_range_relevant(seg_ref, query.ts_min_ns, query.ts_max_ns)
+                && Self::plan_skip_decidable(query)
+            {
+                // The `page_fetch` phase span the other plan paths carry (#782), so
+                // the trace shows the probe and section GETs this branch issues.
+                // `s3_bytes` reports block bytes only, which are structurally zero
+                // here; the directory-overhead bytes are recorded in `accounting`.
+                let fetch_span = tracing::debug_span!(
+                    "page_fetch",
+                    signal = "logs",
+                    s3_requests = tracing::field::Empty,
+                    s3_bytes = tracing::field::Empty,
+                );
+                let (footer, skip, field_dir, stats) = async {
+                    self.block_range
+                        .fetch_plan_sections(seg_ref, tenant_hash, accounting)
+                        .await
+                }
+                .instrument(fetch_span.clone())
+                .await?;
+                let requests = stats.probe_gets + stats.metadata_gets + stats.block_range_gets;
+                fetch_span.record("s3_requests", requests);
+                fetch_span.record("s3_bytes", stats.block_bytes_fetched);
+
+                let refs: Vec<&Predicate> = query.prune.iter().collect();
+                let numeric = field_dir.numeric_range_arms(&refs);
+                let survivors = skip
+                    .candidate_blocks(query.ts_min_ns, query.ts_max_ns, None, &numeric)
+                    .len();
+                let blocks = skip.l0.len() as u32;
+                let plan_stats = ScanStats {
+                    blocks_total: blocks,
+                    blocks_after_skip: survivors as u32,
+                    blocks_after_postings: survivors as u32,
+                    blocks_after_bloom: survivors as u32,
+                    blocks_scanned: 0,
+                    pages_decoded: 0,
+                    pages_skipped: 0,
+                    page_bytes_fetched: 0,
+                    page_bytes_decoded: 0,
+                    bloom_degraded: false,
+                    postings_degraded: false,
+                };
+                return Ok(Some((survivors, plan_stats, Some(footer))));
+            }
+
+            // Fallback: a predicate the skip index cannot decide (a `has_word`/text
+            // content arm with only a per-block bloom, an attribute-equality POSTINGS
+            // prune, a stream filter), or a below-threshold object. Read as before --
+            // the survivor count then needs the reader's full prune over the fetched
+            // buffer -- and hand no footer forward. This whole-object plan read is the
+            // amplification #761 could not remove for these shapes; the caller counts
+            // it (a `None` footer on a relevant segment) as a `plan_full_reads` so a
+            // report can see which queries still pay it.
+            let all = ColumnSelection::all();
+            let Some(bytes) = self
+                .tenant_bytes(seg_ref, tenant_hash, query, &all, accounting)
+                .await?
+            else {
+                return Ok(None);
             };
-            return Ok(Some((survivors, plan_stats, Some(footer))));
+            let key = &seg_ref.data_object_key;
+            let span = decode_span();
+            let scan = span.in_scope(|| self.open_scan(key, &bytes, query, &all))?;
+            Ok(Some((scan.remaining_blocks(), scan.stats(), None)))
         }
-
-        // Fallback: a predicate the skip index cannot decide (a `has_word`/text
-        // content arm with only a per-block bloom, an attribute-equality POSTINGS
-        // prune, a stream filter), or a below-threshold object. Read as before --
-        // the survivor count then needs the reader's full prune over the fetched
-        // buffer -- and hand no footer forward. This whole-object plan read is the
-        // amplification #761 could not remove for these shapes; the caller counts
-        // it (a `None` footer on a relevant segment) as a `plan_full_reads` so a
-        // report can see which queries still pay it.
-        let all = ColumnSelection::all();
-        let Some(bytes) = self
-            .tenant_bytes(seg_ref, tenant_hash, query, &all, accounting)
-            .await?
-        else {
-            return Ok(None);
-        };
-        let key = &seg_ref.data_object_key;
-        let span = decode_span();
-        let scan = span.in_scope(|| self.open_scan(key, &bytes, query, &all))?;
-        Ok(Some((scan.remaining_blocks(), scan.stats(), None)))
+        .await;
+        caller_accounting.merge_snapshot(&phase.snapshot().pooled());
+        result
     }
 
     /// Whether [`plan_segment`](Self::plan_segment)'s survivor count can be read
@@ -1360,6 +1428,11 @@ impl LogSegmentFetcher {
     /// probes as before. It changes only the read shape, never the bytes decoded.
     ///
     /// [`scan_accounted_with_tenant`]: Self::scan_accounted_with_tenant
+    ///
+    /// Issue #796: `scan` phase, same reasoning and the same not-buffered
+    /// `accounting` handling as
+    /// [`scan_accounted_with_tenant`](Self::scan_accounted_with_tenant)'s doc
+    /// comment.
     #[allow(clippy::too_many_arguments)]
     pub async fn scan_accounted_with_tenant_subset(
         &self,

--- a/crates/ravel-query/src/phase_accounting.rs
+++ b/crates/ravel-query/src/phase_accounting.rs
@@ -225,6 +225,28 @@ mod tests {
     }
 
     #[test]
+    fn pooled_uses_max_not_sum_for_the_non_additive_peak() {
+        // Every other pooled test uses GET requests and GET bytes, which are
+        // additive, so none of them can tell a field-wise sum from correct
+        // pooled semantics. `peak_intermediate_bytes` is a high-water mark:
+        // two phases each peaking at 100 never held 200 at once. This fails
+        // if `saturating_add` is ever changed to add that field.
+        let phase = PhaseAccounting::new();
+        phase.plan().observe_intermediate_bytes(100);
+        phase.scan().observe_intermediate_bytes(60);
+
+        let pooled = phase.snapshot().pooled();
+        assert_eq!(
+            pooled.peak_intermediate_bytes, 100,
+            "pooled peak must be the max across phases, not their sum"
+        );
+        assert_ne!(
+            pooled.peak_intermediate_bytes, 160,
+            "a field-wise sum of the peaks would report memory never held"
+        );
+    }
+
+    #[test]
     fn phase_accessor_matches_named_accessor() {
         let phase = PhaseAccounting::new();
         phase.probe().record_s3_request(AccountedOp::Get);

--- a/crates/ravel-query/src/phase_accounting.rs
+++ b/crates/ravel-query/src/phase_accounting.rs
@@ -1,0 +1,244 @@
+//! Per-phase split of [`QueryAccounting`] (issue #796, split out of ADR-0044's
+//! pooled handle to unblock #835's diagnosis: one statement issued 18,937 GETs
+//! against a 3,469-object tenant and the pooled counter could not say which
+//! phase issued them).
+//!
+//! [`PhaseAccounting`] wraps four independent, unmodified
+//! [`QueryAccounting`] handles, one per [`QueryPhase`], rather than adding
+//! per-phase fields to `QueryAccounting` itself: that type lives in
+//! `ravel-types`, outside this crate's assigned scope for issue #796, and its
+//! existing funnels (`ravel-catalog`'s `guarded_get`/`guarded_list_all`, this
+//! crate's `fetcher`/`log_fetcher`) already decide, at each call site, which
+//! `QueryAccounting` instance a GET is recorded against. Handing that call
+//! site the phase's own handle achieves the same per-phase split without an
+//! in-place change to a type another crate also owns.
+//!
+//! # Phase boundaries
+//!
+//! Matches `docs/query-engine.md`'s own vocabulary:
+//!
+//! - [`QueryPhase::Resolve`]: the catalog snapshot resolve's commit-record
+//!   GETs (`Catalog::resolve_pruned_with_generations` and friends).
+//! - [`QueryPhase::Plan`]: footer/skip-index probing to build a fetch plan
+//!   (`SegmentFetcher::open_segment`, `LogSegmentFetcher::plan_segment`).
+//! - [`QueryPhase::Probe`]: segment catalog fetch -- whole-object, sparse
+//!   catalog-probe, or whole-object-fallback (`SegmentFetcher::decode_selected`).
+//! - [`QueryPhase::Scan`]: the actual block/page/chunk data reads
+//!   (`SegmentFetcher::fetch_scalar_pages`/`fetch_histogram_pages`,
+//!   `LogSegmentFetcher::scan_accounted_with_tenant`).
+//!
+//! Decode (turning fetched bytes into typed samples/rows) is deliberately not
+//! a fifth phase here: it issues no store request, so it has no request or
+//! wire-byte counters to attribute. Its own byte figures
+//! (`decompressed_bytes`, `page_bytes_fetched`/`page_bytes_decoded`) stay on
+//! whichever handle a decode call site is passed -- by convention the
+//! [`QueryPhase::Scan`] handle, since decode always follows a scan in this
+//! crate's fetch pipelines -- and are never summed into a phase's request or
+//! wire-byte totals.
+
+use ravel_types::accounting::{QueryAccounting, QueryAccountingSnapshot};
+
+/// The phases a query's object-store cost is split across (issue #796). See
+/// the [module docs](self) for what each phase covers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum QueryPhase {
+    /// Catalog snapshot resolve.
+    Resolve,
+    /// Footer/skip-index probing to build a fetch plan.
+    Plan,
+    /// Segment catalog fetch (whole-object, sparse probe, or fallback).
+    Probe,
+    /// Block/page/chunk data reads.
+    Scan,
+}
+
+impl QueryPhase {
+    /// Every phase, in the fixed order [`PhaseAccountingSnapshot`]'s fields
+    /// and [`PhaseAccounting::snapshot`] agree on.
+    pub const ALL: [QueryPhase; 4] = [
+        QueryPhase::Resolve,
+        QueryPhase::Plan,
+        QueryPhase::Probe,
+        QueryPhase::Scan,
+    ];
+
+    /// Lower-case, stable name for a report table column or a JSON key.
+    #[must_use]
+    pub fn name(self) -> &'static str {
+        match self {
+            QueryPhase::Resolve => "resolve",
+            QueryPhase::Plan => "plan",
+            QueryPhase::Probe => "probe",
+            QueryPhase::Scan => "scan",
+        }
+    }
+}
+
+/// Four independent [`QueryAccounting`] handles, one per [`QueryPhase`]
+/// (issue #796). Cheap to clone: each phase handle is itself an `Arc`-backed
+/// clone, exactly like `QueryAccounting`, so cloning the whole struct clones
+/// four `Arc`s and nothing else. Created once per query attempt, alongside
+/// the query's other fresh per-attempt state (see `engine.rs`'s
+/// `resolve_snapshot_with_retry`), and passed explicitly into every component
+/// that touches the object store on that phase's behalf -- never held in a
+/// task-local, for the same reason `QueryAccounting` itself is not (see
+/// `ravel_types::accounting`'s module docs).
+#[derive(Debug, Clone, Default)]
+pub struct PhaseAccounting {
+    resolve: QueryAccounting,
+    plan: QueryAccounting,
+    probe: QueryAccounting,
+    scan: QueryAccounting,
+}
+
+impl PhaseAccounting {
+    /// New handle with every phase's every counter at zero, for one query
+    /// attempt.
+    #[must_use]
+    pub fn new() -> Self {
+        PhaseAccounting::default()
+    }
+
+    /// The resolve phase's handle.
+    #[must_use]
+    pub fn resolve(&self) -> &QueryAccounting {
+        &self.resolve
+    }
+
+    /// The plan phase's handle.
+    #[must_use]
+    pub fn plan(&self) -> &QueryAccounting {
+        &self.plan
+    }
+
+    /// The probe phase's handle.
+    #[must_use]
+    pub fn probe(&self) -> &QueryAccounting {
+        &self.probe
+    }
+
+    /// The scan phase's handle. Decode call sites downstream of a scan (see
+    /// the [module docs](self)) are also passed this handle, for their
+    /// decode-only byte counters.
+    #[must_use]
+    pub fn scan(&self) -> &QueryAccounting {
+        &self.scan
+    }
+
+    /// The handle for a given phase. Used where a call site's phase is
+    /// chosen dynamically rather than named directly.
+    #[must_use]
+    pub fn phase(&self, phase: QueryPhase) -> &QueryAccounting {
+        match phase {
+            QueryPhase::Resolve => &self.resolve,
+            QueryPhase::Plan => &self.plan,
+            QueryPhase::Probe => &self.probe,
+            QueryPhase::Scan => &self.scan,
+        }
+    }
+
+    /// Point-in-time copy of every phase's counters.
+    #[must_use]
+    pub fn snapshot(&self) -> PhaseAccountingSnapshot {
+        PhaseAccountingSnapshot {
+            resolve: self.resolve.snapshot(),
+            plan: self.plan.snapshot(),
+            probe: self.probe.snapshot(),
+            scan: self.scan.snapshot(),
+        }
+    }
+}
+
+/// Point-in-time copy of a [`PhaseAccounting`]'s four phase snapshots (issue
+/// #796). Plain `QueryAccountingSnapshot` fields, so this is `Copy` and needs
+/// no allocation, mirroring `QueryAccountingSnapshot` itself.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct PhaseAccountingSnapshot {
+    pub resolve: QueryAccountingSnapshot,
+    pub plan: QueryAccountingSnapshot,
+    pub probe: QueryAccountingSnapshot,
+    pub scan: QueryAccountingSnapshot,
+}
+
+impl PhaseAccountingSnapshot {
+    /// This snapshot's phase, named directly rather than through
+    /// [`QueryPhase::ALL`]'s iteration order.
+    #[must_use]
+    pub fn phase(&self, phase: QueryPhase) -> &QueryAccountingSnapshot {
+        match phase {
+            QueryPhase::Resolve => &self.resolve,
+            QueryPhase::Plan => &self.plan,
+            QueryPhase::Probe => &self.probe,
+            QueryPhase::Scan => &self.scan,
+        }
+    }
+
+    /// Field-wise saturating sum of every phase, exactly the number a caller
+    /// would have gotten from one pooled `QueryAccounting` handle before
+    /// issue #796 split it by phase. Every existing caller of the old pooled
+    /// `accounting: QueryAccountingSnapshot` field keeps reading this value
+    /// (`QueryStats::accounting` is computed as `phase_accounting.pooled()`),
+    /// so splitting the counters changes no existing number.
+    #[must_use]
+    pub fn pooled(&self) -> QueryAccountingSnapshot {
+        self.resolve
+            .saturating_add(&self.plan)
+            .saturating_add(&self.probe)
+            .saturating_add(&self.scan)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ravel_types::accounting::AccountedOp;
+
+    use super::*;
+
+    #[test]
+    fn fresh_handle_is_all_zero() {
+        let phase = PhaseAccounting::new();
+        let snap = phase.snapshot();
+        assert_eq!(snap, PhaseAccountingSnapshot::default());
+        assert_eq!(snap.pooled(), QueryAccountingSnapshot::default());
+    }
+
+    #[test]
+    fn each_phase_handle_is_independent() {
+        let phase = PhaseAccounting::new();
+        phase.resolve().record_s3_request(AccountedOp::Get);
+        phase.plan().record_s3_request(AccountedOp::Get);
+        phase.plan().record_s3_request(AccountedOp::Get);
+        phase.probe().add_s3_bytes(AccountedOp::Get, 100);
+        phase.scan().add_s3_bytes(AccountedOp::Get, 7);
+        phase.scan().record_s3_request(AccountedOp::Get);
+
+        let snap = phase.snapshot();
+        assert_eq!(snap.resolve.s3_requests(AccountedOp::Get), 1);
+        assert_eq!(snap.plan.s3_requests(AccountedOp::Get), 2);
+        assert_eq!(snap.probe.s3_bytes(AccountedOp::Get), 100);
+        assert_eq!(snap.scan.s3_requests(AccountedOp::Get), 1);
+        assert_eq!(snap.scan.s3_bytes(AccountedOp::Get), 7);
+
+        let pooled = snap.pooled();
+        assert_eq!(pooled.s3_requests(AccountedOp::Get), 4);
+        assert_eq!(pooled.s3_bytes(AccountedOp::Get), 107);
+    }
+
+    #[test]
+    fn phase_accessor_matches_named_accessor() {
+        let phase = PhaseAccounting::new();
+        phase.probe().record_s3_request(AccountedOp::Get);
+        let snap = phase.snapshot();
+        for p in QueryPhase::ALL {
+            assert_eq!(
+                snap.phase(p),
+                match p {
+                    QueryPhase::Resolve => &snap.resolve,
+                    QueryPhase::Plan => &snap.plan,
+                    QueryPhase::Probe => &snap.probe,
+                    QueryPhase::Scan => &snap.scan,
+                }
+            );
+        }
+    }
+}

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -1018,6 +1018,75 @@ attached to `QueryStats` alongside the existing `segments_fetched`/
 `segments_pruned`/per-run `FetchStats` (`raw_f64_pages`/`raw_f64_bytes`,
 narrower than `decompressed_bytes`: only `ValPageKind::RawF64` pages).
 
+### Per-phase split (issue #796)
+
+The pooled `QueryAccountingSnapshot` above sums every GET a statement
+issues into one counter: the resolve's commit-record reads, the
+plan-phase footer/skip-index probe, the segment catalog fetch, and the
+actual block/page data reads all land in the same number, so a pooled
+figure alone cannot say which stage is responsible for a runaway
+request count (#835: one statement issued 18,937 GETs against a
+3,469-object tenant, and the pooled counter could not localize them).
+
+`crates/ravel-query/src/phase_accounting.rs`'s `PhaseAccounting` wraps
+four independent `QueryAccounting` handles, one per phase, using this
+doc's own vocabulary:
+
+- **resolve** -- the catalog snapshot resolve's commit-record GETs
+  (`Catalog::resolve_pruned_with_generations` and friends).
+- **plan** -- footer/skip-index probing to build a fetch plan
+  (`SegmentFetcher::open_segment`, `LogSegmentFetcher::plan_segment`; see
+  "Segment catalog fetch: whole-object vs sparse catalog-probe" and
+  "Selective (predicated) logs scan: request count" above for what a plan
+  phase does per format).
+- **probe** -- the segment catalog fetch itself: whole-object, sparse
+  catalog-probe, or whole-object-fallback (`SegmentFetcher::decode_selected`).
+- **scan** -- the actual block/page/chunk data reads
+  (`SegmentFetcher::fetch_scalar_pages`/`fetch_histogram_pages`,
+  `LogSegmentFetcher::scan_accounted_with_tenant`).
+
+Decode (turning fetched bytes into typed samples/rows) is deliberately
+not a fifth phase: it issues no store request, so it has nothing to
+attribute a request or wire-byte counter to. Its own byte figures
+(`decompressed_bytes`, `page_bytes_fetched`/`page_bytes_decoded`) stay on
+whichever handle its call site is passed -- by convention the `scan`
+handle, since decode always follows a scan in this crate's fetch
+pipelines.
+
+`PhaseAccountingSnapshot::pooled()` sums all four phases back to exactly
+the pre-#796 pooled number: `QueryStats::accounting` is computed as
+`phase_accounting.pooled()`, so every existing reader of that field keeps
+seeing the same number, unchanged. `QueryStats` additionally carries the
+full `phase_accounting: PhaseAccountingSnapshot` for callers that want
+the split.
+
+Two entry points issue GETs the phase split cannot yet attribute without
+a change outside this crate's issue #796 scope:
+
+- Federation and distributed fan-out (`federate_discovery`,
+  `federate_scalar`, `distrib::client`'s `SliceFetcher`) cross a wire
+  boundary as one pooled `QueryAccountingSnapshot`
+  (`SliceResponse.accounting`) that predates #796; a worker's per-slice
+  spend is charged to `scan` on the coordinator side rather than left
+  unaccounted. Splitting it for real would need a wire-format version
+  bump to the coordinator/worker protobuf.
+- `LogSegmentFetcher`'s three streaming entry points that return a live
+  `LogSegmentScan` (`scan_accounted_with_tenant`,
+  `scan_whole_accounted_with_tenant`, `scan_accounted_with_tenant_subset`)
+  keep writing deferred `page_bytes_fetched`/`page_bytes_decoded` into
+  their stored `QueryAccounting` handle after the constructing call
+  returns (`LogSegmentScan::finish`, ADR-0107 decision 4, run from
+  `next_block`'s exhaustion arm or from `Drop`). A disposable
+  `PhaseAccounting` buffered and merged once before return -- the pattern
+  used everywhere else in this split -- would silently drop those later
+  writes, so these three keep taking a plain `&QueryAccounting` and are
+  `scan` phase by construction instead, documented at each call site.
+
+`ravel-sql`'s `SqlExecutor` builds its own `QueryAccounting` per attempt
+(`SqlOutcome.accounting`) entirely inside that crate, so the phase split
+does not yet reach `ravel-bench`'s `sql_latency_bench` report: doing so
+needs a `ravel-sql` change outside this crate's scope for issue #796.
+
 ### Pre-execution cost estimate
 
 The estimate has two parts, computed at two different moments, because


### PR DESCRIPTION
`QueryAccountingSnapshot.object_store_get_requests` summed every GET a
statement issued: the catalog resolve's commit-record GETs on unsealed
buckets, the plan phase's suffix probes and FIELD_DIR ranges, and the
scan's block and chunk reads. One pooled number, four very different
costs.

That pooling has already cost real time on #680. On an unfolded tenant it
made a format look 2x slower at equal CPU, because the extra round trip
per object sat invisibly inside the pool. On a folded one it hides how
much of q37's 15,836 GETs is plan-phase probing versus ranges over
surviving blocks. A slowdown you cannot attribute to a phase takes an
afternoon to explain instead of one query.

`QueryAccounting` now carries per-phase GET and byte counters for
resolve, plan, probe and scan. The pooled fields remain as their exact
sum, so every existing reader keeps working unchanged.

The tests pin exact figures rather than asserting a counter moved: both
`phase_split_below_threshold_segment_pins_exact_per_phase_figures` and
`phase_split_above_threshold_segment_has_unequal_phases_and_pins_exact_figures`
name the expected count per phase, and the pooled total is asserted equal
to the sum with exact byte figures on both sides. A magnitude that is
only checked for being non-zero is how an accounting bug survives a green
suite.

What this does NOT yet do, which is why the trailer is `Refs:` and not
`Fixes:`: the ticket also asks for `sql_latency_bench`'s human table and
JSON to print the phases, and for a `--warm-catalog` flag (or a reused
executor) so bench figures match server behaviour, since the bench builds
a cold `SqlExecutor` per statement. This PR touches no bench file, and
nothing outside `ravel-query` reads the new counters yet. The measurement
is instrumented but not yet surfaced, so #796 stays open and the bench
surface is tracked separately.

Refs: #796, #680, #835