### PR TITLE
docs: postings must carry a block bitmap, not just an entry ordinal

### DIFF
--- a/docs/adrs/0849-snapshot-bound-index-plane.md
+++ b/docs/adrs/0849-snapshot-bound-index-plane.md
@@ -231,6 +231,39 @@ Leaving this undefined would give an object class with no owner, reaped too
 early or never — which is how storage leaks and mysterious mid-fold failures
 both start.
 
+### 1b. A posting's payload is (part, entry, block bitmap), not an ordinal
+
+A posting that resolves only to a snapshot entry — an object — does **not**
+support this ADR's own acceptance criterion that `q20` becomes proportional to
+matching *blocks*. Having narrowed to a candidate object, the reader would still
+have to fetch that object's internal directory to learn which blocks match: an
+extra round trip and a directory probe (order 256 KiB) **per candidate object**.
+That is far better than reading the object whole, and it is not what was
+promised.
+
+So a point or gram posting carries at least:
+
+```text
+(part ordinal, entry ordinal, block/row-group bitmap)
+```
+
+The bitmap is what makes the acceptance criterion measurable, and it is what
+lets a candidate object be opened with page ranges on the first request rather
+than the second.
+
+**Two layers, both required, neither substituting for the other.** An S3 object
+is the unit of durability and atomic publication; it is not the unit of reading.
+RLOG v4 already stores independently addressable, independently compressed
+column pages plus a `PAGE_DIR` of their offsets and lengths, so a candidate
+object can be read as a few page ranges rather than in full. This ADR's index
+decides **which objects to open at all**; the existing page layout decides **how
+much of an opened object to read**. The per-object indexes that exist today help
+only after an object is already open, which is the gap this plane closes.
+
+The consequence for the acceptance criteria is that a bitmap-carrying posting is
+a requirement of the pack format, not an optimisation to add later: retrofitting
+it changes the pack layout and therefore its version.
+
 ### 2. Routing must never be per-object
 
 A point lookup resolves through a small cached root to one or a few leaves.
@@ -580,7 +613,9 @@ time-leading slice.
 
 **Queries that stop scanning.** `q02`, `q07` and `q08` become answerable at
 zero data GETs from statistics alone. `q20` becomes proportional to matching
-blocks rather than to corpus objects. `q23` is bounded by positive gram
+blocks rather than to corpus objects — but only because postings carry a block
+bitmap (§1b); an object-ordinal-only posting would leave a directory probe per
+candidate object and would not meet this criterion. `q23` is bounded by positive gram
 candidates — true, and possibly vacuous, since a common substring in a web
 corpus can appear in nearly every block, which is why item 4 is deferred behind
 a selectivity measurement rather than assumed.

--- a/docs/adrs/0849-snapshot-bound-index-plane.md
+++ b/docs/adrs/0849-snapshot-bound-index-plane.md
@@ -244,8 +244,28 @@ promised.
 So a point or gram posting carries at least:
 
 ```text
-(part ordinal, entry ordinal, block/row-group bitmap)
+(part ordinal, entry ordinal, BLOCK bitmap)
 ```
+
+**Block-level, not row-group-level.** These are not interchangeable and an
+earlier draft of this section wrote "block/row-group bitmap" as though they were.
+An RLOG row group holds consecutive blocks — 32 by default — so a
+row-group-granular bitmap cannot identify *which* block inside a group matched,
+and the reader would fetch the whole row-group chunk. That fails the
+block-proportional `q20` criterion this section exists to protect, by exactly the
+average group size.
+
+The reader already accepts the finer granularity:
+`PageDir::projected_page_ranges(group, blocks, columns)` takes a specific block
+list *and* an optional column set, so a block bitmap is directly usable and a
+row-group bitmap would discard a dimension the reader can already exploit. The
+alternative, enforcing one block per row group, is sound but pays it back in
+directory size and loses the grouping's own benefits.
+
+Before the pack version is published, a fixture must cover **multiple blocks in
+one row group with a posting matching only one of them**, since that is the only
+case that distinguishes a block bitmap from a row-group bitmap and the one a
+single-block-per-group fixture silently passes.
 
 The bitmap is what makes the acceptance criterion measurable, and it is what
 lets a candidate object be opened with page ranges on the first request rather


### PR DESCRIPTION
ADR-0849 said postings address snapshot-entry ordinals, while its own acceptance criterion says `q20` becomes proportional to matching **blocks**. Those are not compatible.

An entry ordinal identifies an object. A reader that has narrowed to a candidate object would still have to fetch that object's internal directory to learn which blocks match — an extra round trip and a directory probe of order 256 KiB **per candidate object**. Much better than reading the object whole, but not what the criterion promises, and the criterion is what the epic will be measured against.

Postings now carry at least `(part ordinal, entry ordinal, block/row-group bitmap)`. The bitmap is what makes the criterion measurable and what lets a candidate object be opened with page ranges on the first request rather than the second. It is a requirement of the pack format, not a later optimisation: retrofitting it changes the layout and therefore its version.

The new section also states a layering that was only implicit. An S3 object is the unit of durability and atomic publication, not the unit of reading. RLOG v4 already stores independently addressable, independently compressed column pages plus a `PAGE_DIR` of their offsets and lengths, so a candidate object can be read as a few page ranges. The index decides **which objects to open**; the page layout decides **how much of an opened object to read**. The per-object indexes that exist today help only after an object is already open, which is exactly the gap this plane closes.

Verified against the code while writing this: the 512 KiB whole-object threshold (`fetcher.rs:84`) and the 0.75 coverage crossover (`log_fetcher.rs:1789`, applied at `2900`) both exist as described. That crossover turns out to be the root cause of #862 — extents are resolved per block with no column selection, so a predicate-free statement covers ~100% of blocks and the crossover fires regardless of how few columns are projected.

Refs: #849
