### PR TITLE
fix: multipart abort metrics, per-shard skew metrics, and bench layout labelling

### DIFF
--- a/crates/ravel-bench/src/bin/sql_latency_bench.rs
+++ b/crates/ravel-bench/src/bin/sql_latency_bench.rs
@@ -26,8 +26,8 @@ use clap::Parser;
 use ravel_bench::harness::{StoreKind, store_from_env};
 use ravel_bench::sql_corpus::{checked_default_corpus, load_external_corpus};
 use ravel_bench::sql_latency::{
-    Compaction, FlightTarget, GenerateConfig, SqlLatencyReport, TenantConfigInput, run_generated,
-    run_tenant,
+    Compaction, DatasetInfo, FlightTarget, GenerateConfig, SqlLatencyReport, TenantConfigInput,
+    run_generated, run_tenant,
 };
 use ravel_sql::DEFAULT_MAX_QUERY_BYTES;
 use ravel_types::TimeRange;
@@ -102,10 +102,14 @@ struct Args {
     extra_attrs: usize,
 
     // --- tenant lane knobs ------------------------------------------------
-    /// Which layout the tenant is in. ADR-0100 decision 4 requires the report
-    /// to state this rather than guess.
-    #[arg(long, value_enum, default_value_t = CompactionArg::Pre)]
-    compaction: CompactionArg,
+    /// The operator's belief about which layout the tenant is in, checked
+    /// against the resolved snapshot rather than trusted (issue #834): the
+    /// report's `dataset.layout` is always derived from the tenant's actual
+    /// segment levels, never from this flag. Unset skips the check; set, a
+    /// disagreement refuses the run instead of printing a label that
+    /// contradicts what the snapshot holds.
+    #[arg(long, value_enum)]
+    compaction: Option<CompactionArg>,
     /// Upper bound (unix seconds) of the resolve window and the injected query
     /// clock. Defaults to the wall clock at startup.
     #[arg(long)]
@@ -326,7 +330,7 @@ async fn run(args: &Args) -> Result<SqlLatencyReport, ravel_bench::sql_latency::
                     end_ns: now_ns,
                 },
                 now_ns,
-                compaction: args.compaction.into(),
+                compaction: args.compaction.map(Into::into),
                 max_query_bytes: args.sql_max_query_bytes,
                 shards: args.shards,
                 cache_bytes: args.cache_bytes,
@@ -393,6 +397,23 @@ fn parallel_final_aggregation_effective_label(effective: Option<bool>) -> String
     }
 }
 
+/// The `dataset` report line, shared by the human table and (structurally,
+/// via the same `DatasetInfo` fields) the JSON output, so the two cannot
+/// disagree (issue #834). `layout` is always the observed value on `d`, never
+/// an echo of `--compaction`. `load=` is appended only when `d.load_wall_ms`
+/// is `Some`: a run that performed no load (the `--tenant` lane) omits the
+/// figure entirely rather than rendering a measured-looking `0.0ms`.
+fn dataset_line(d: &DatasetInfo) -> String {
+    let mut line = format!(
+        "{} objects, {} bytes, {} rows, layout={}",
+        d.object_count, d.stored_bytes, d.rows, d.layout
+    );
+    if let Some(load_ms) = d.load_wall_ms {
+        line.push_str(&format!(", load={load_ms:.1}ms"));
+    }
+    line
+}
+
 fn print_human_table(report: &SqlLatencyReport) {
     let p = &report.provenance;
     let d = &report.dataset;
@@ -406,10 +427,7 @@ fn print_human_table(report: &SqlLatencyReport) {
     if let Some(flight) = &p.flight_endpoint {
         println!("  flight sql : {flight} (scan diagnostics are not on the wire)");
     }
-    println!(
-        "  dataset    : {} objects, {} bytes, {} rows, layout={}, load={:.1}ms",
-        d.object_count, d.stored_bytes, d.rows, d.layout, d.load_wall_ms
-    );
+    println!("  dataset    : {}", dataset_line(d));
     println!("  runs/query : {}", p.runs);
     println!("  deadline   : {} s per statement", p.deadline_secs);
     println!("  fetch conc : {}", p.fetch_concurrency);
@@ -538,5 +556,56 @@ mod tests {
             parallel_final_aggregation_effective_label(Some(false)),
             "false"
         );
+    }
+
+    fn dataset(layout: &str, load_wall_ms: Option<f64>) -> DatasetInfo {
+        DatasetInfo {
+            load_wall_ms,
+            stored_bytes: 4096,
+            object_count: 3,
+            rows: 60,
+            layout: layout.to_string(),
+        }
+    }
+
+    /// Both layout directions must show up verbatim in the printed line
+    /// (issue #834): a fix that hardcodes one direction passes only one of
+    /// these two assertions.
+    #[test]
+    fn dataset_line_reports_both_layout_directions() {
+        assert!(dataset_line(&dataset("pre-compaction", None)).contains("layout=pre-compaction"));
+        assert!(dataset_line(&dataset("post-compaction", None)).contains("layout=post-compaction"));
+    }
+
+    /// A run with no load omits the figure entirely rather than rendering a
+    /// measured-looking `0.0ms` (issue #834).
+    #[test]
+    fn dataset_line_omits_load_when_absent_and_shows_it_when_present() {
+        assert!(!dataset_line(&dataset("pre-compaction", None)).contains("load="));
+        assert!(dataset_line(&dataset("pre-compaction", Some(12.5))).contains("load=12.5ms"));
+    }
+
+    /// The human table's `layout`/`load` substrings must agree with what the
+    /// same `DatasetInfo` serializes to in JSON: both read off one struct, so
+    /// there is exactly one code path per field, not two that can drift
+    /// apart.
+    #[test]
+    fn dataset_line_agrees_with_json_serialization() {
+        let with_load = dataset("post-compaction", Some(7.0));
+        let json = serde_json::to_value(&with_load).expect("DatasetInfo serializes");
+        assert_eq!(json["layout"], "post-compaction");
+        assert_eq!(json["load_wall_ms"], 7.0);
+        assert!(dataset_line(&with_load).contains("layout=post-compaction"));
+        assert!(dataset_line(&with_load).contains("load=7.0ms"));
+
+        let no_load = dataset("pre-compaction", None);
+        let json = serde_json::to_value(&no_load).expect("DatasetInfo serializes");
+        assert!(
+            json.get("load_wall_ms").is_none(),
+            "load_wall_ms must be omitted from JSON when absent, not null: {json}"
+        );
+        assert_eq!(json["layout"], "pre-compaction");
+        assert!(dataset_line(&no_load).contains("layout=pre-compaction"));
+        assert!(!dataset_line(&no_load).contains("load="));
     }
 }

--- a/crates/ravel-bench/src/sql_latency.rs
+++ b/crates/ravel-bench/src/sql_latency.rs
@@ -47,8 +47,8 @@ use std::time::{Duration, Instant};
 use datafusion::physical_plan::displayable;
 use ravel_cache::{Cache, CacheLimits};
 use ravel_catalog::{
-    Catalog, CatalogConfig, DeclaredColumnType, read_config_values, read_generations_from_store,
-    shard_ceiling,
+    Catalog, CatalogConfig, DeclaredColumnType, SegmentLevel, read_config_values,
+    read_generations_from_store, shard_ceiling,
 };
 use ravel_commit::publish::RetryPolicy;
 use ravel_commit::record::NewCommitRecord;
@@ -130,13 +130,37 @@ pub enum TenantLaneError {
         end_ns: i64,
         now_ns: i64,
     },
+    /// `--compaction` asserted a layout that disagrees with what the tenant's
+    /// resolved snapshot actually contains. The label itself is always the
+    /// observed one ([`DatasetInfo::layout`] is never an echo of this flag,
+    /// issue #834); this is a separate, optional sanity check that fails
+    /// closed when the operator's belief about the tenant is stale, instead
+    /// of letting a mislabeled report through silently.
+    #[error(
+        "--compaction {asserted} disagrees with tenant `{tenant}`'s resolved snapshot: observed \
+         layout is `{observed}` across {object_count} resolved objects; recheck the tenant or \
+         drop the wrong --compaction flag"
+    )]
+    CompactionMismatch {
+        tenant: String,
+        asserted: &'static str,
+        observed: String,
+        object_count: usize,
+    },
 }
 
-/// Whether the measured object layout is a freshly loaded tenant (many small
-/// objects) or one the maintenance machinery has compacted (fewer, larger).
-/// ADR-0100 decision 4 requires the report to *state* this rather than guess,
-/// so the `--tenant` lane takes it as an operator-supplied flag; the generated
-/// lane is always freshly written and never compacted.
+/// An operator's belief about whether the measured tenant is a freshly loaded
+/// layout (many small objects) or one the maintenance machinery has compacted
+/// (fewer, larger).
+///
+/// This no longer supplies [`DatasetInfo::layout`] (issue #834: a
+/// `--compaction pre` label survived a real compaction and nearly entered a
+/// published comparison unchallenged). `layout` is always derived from the
+/// resolved snapshot's segment levels: any [`SegmentLevel::L1`] segment means
+/// compaction has run over at least part of the tenant. `Compaction` now
+/// feeds only an optional check ([`TenantConfigInput::compaction`]): when the
+/// operator states one, the tenant lane refuses to run if it disagrees with
+/// what the snapshot actually is, rather than silently trusting either side.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Compaction {
     /// A freshly loaded (or freshly generated) layout, never compacted.
@@ -287,10 +311,13 @@ fn default_deadline_secs() -> u64 {
 /// The dataset as it sits in the object store, independent of any one query.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct DatasetInfo {
-    /// Wall time to build and publish the dataset. Measured for the generated
-    /// lane; `0.0` for the `--tenant` lane, whose load happened out of process
-    /// through `ravel-cli` and is not this harness's to time.
-    pub load_wall_ms: f64,
+    /// Wall time to build and publish the dataset. `Some` for the generated
+    /// lane, which builds and times it in process. `None` for the `--tenant`
+    /// lane: its load happened out of process through `ravel-cli` before this
+    /// run started, so there is nothing here to time, and a load that never
+    /// ran must never render as a measured `0.0ms` (issue #834).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub load_wall_ms: Option<f64>,
     /// Bytes stored across the dataset's data objects (summed over the resolved
     /// snapshot's segments).
     pub stored_bytes: u64,
@@ -301,7 +328,11 @@ pub struct DatasetInfo {
     pub object_count: usize,
     /// Durable rows across the dataset (summed segment sample counts).
     pub rows: u64,
-    /// `"pre-compaction"` or `"post-compaction"`: which layout was measured.
+    /// `"pre-compaction"` or `"post-compaction"`: which layout the tenant's
+    /// resolved snapshot actually contains, derived from each segment's
+    /// `SegmentLevel` (any `L1` segment means compaction has run over at
+    /// least part of the tenant). Observed, never an echo of an operator flag
+    /// (issue #834).
     pub layout: String,
 }
 
@@ -573,8 +604,13 @@ pub struct TenantConfigInput {
     pub window: TimeRange,
     /// Injected clock reading bounding that window.
     pub now_ns: i64,
-    /// Which layout the operator is measuring.
-    pub compaction: Compaction,
+    /// The operator's optional belief about which layout the tenant is in,
+    /// checked against the resolved snapshot rather than trusted (issue
+    /// #834). `Some` refuses the run if it disagrees with what the snapshot's
+    /// segments actually are; `None` skips the check. Either way,
+    /// `SqlLatencyReport::dataset.layout` is always the observed value, never
+    /// this flag echoed back.
+    pub compaction: Option<Compaction>,
     /// Per-query DataFusion memory-pool ceiling, in bytes, fed to
     /// [`SqlConfig::max_query_bytes`]. Mirrors `ravel-server`'s
     /// `--sql-max-query-bytes` (ADR-0088): raise it to measure a heavy query
@@ -1212,16 +1248,25 @@ async fn measure_over_flight(
     )))
 }
 
-/// Resolve the dataset-level figures (bytes, object count, rows) from a
-/// full-window catalog resolve over the logs signal. Shared by both lanes so
-/// object count is defined identically however the dataset was written.
+/// Resolve the dataset-level figures (bytes, object count, rows, layout)
+/// from a full-window catalog resolve over the logs signal. Shared by both
+/// lanes so every figure is defined identically however the dataset was
+/// written.
+///
+/// `layout` is derived here, never taken as a parameter (issue #834): a
+/// resolved snapshot with any [`SegmentLevel::L1`] segment has had
+/// compaction run over at least part of it, so it is reported
+/// `"post-compaction"`; an all-L0 snapshot is `"pre-compaction"`. This is the
+/// same signal ADR-0018's L0/L1 discriminator already carries per segment,
+/// read off the resolve every caller already performs -- no new state, no
+/// operator input, and no way for it to drift from what the tenant actually
+/// is.
 async fn dataset_info(
     store: &Arc<dyn ObjectStoreBackend>,
     tenant_hash: TenantHash,
     window: TimeRange,
     now_ns: i64,
-    load_wall_ms: f64,
-    compaction: Compaction,
+    load_wall_ms: Option<f64>,
     shard_count: u32,
 ) -> Result<DatasetInfo, Error> {
     let catalog = Arc::new(Catalog::new(
@@ -1236,12 +1281,21 @@ async fn dataset_info(
         .await?;
     let stored_bytes = snapshot.segments.iter().map(|s| s.object_size).sum();
     let rows = snapshot.segments.iter().map(|s| s.sample_count).sum();
+    let layout = if snapshot
+        .segments
+        .iter()
+        .any(|s| matches!(s.level, SegmentLevel::L1 { .. }))
+    {
+        Compaction::Post.label()
+    } else {
+        Compaction::Pre.label()
+    };
     Ok(DatasetInfo {
         load_wall_ms,
         stored_bytes,
         object_count: snapshot.segments.len(),
         rows,
-        layout: compaction.label().to_string(),
+        layout: layout.to_string(),
     })
 }
 
@@ -1270,8 +1324,7 @@ pub async fn run_generated(cfg: &GenerateConfig) -> Result<SqlLatencyReport, Err
         tenant_hash,
         window,
         NOW_NS,
-        load_wall_ms,
-        Compaction::Pre,
+        Some(load_wall_ms),
         shard_count,
     )
     .await?;
@@ -1361,8 +1414,7 @@ pub async fn run_tenant(cfg: &TenantConfigInput) -> Result<SqlLatencyReport, Err
         tenant_hash,
         cfg.window,
         cfg.now_ns,
-        0.0,
-        cfg.compaction,
+        None,
         shard_count,
     )
     .await?;
@@ -1378,6 +1430,22 @@ pub async fn run_tenant(cfg: &TenantConfigInput) -> Result<SqlLatencyReport, Err
             now_ns: cfg.now_ns,
         }
         .into());
+    }
+    // `dataset.layout` above is always the observed value; this is a separate,
+    // optional check of the operator's belief against it (issue #834). Refuse
+    // rather than let a stale `--compaction` claim sit next to a report that
+    // silently disagrees with it.
+    if let Some(asserted) = cfg.compaction {
+        let observed_post = dataset.layout == Compaction::Post.label();
+        if (asserted == Compaction::Post) != observed_post {
+            return Err(TenantLaneError::CompactionMismatch {
+                tenant: cfg.tenant.clone(),
+                asserted: asserted.label(),
+                observed: dataset.layout.clone(),
+                object_count: dataset.object_count,
+            }
+            .into());
+        }
     }
     let settings = ExecutorSettings {
         max_query_bytes: cfg.max_query_bytes,
@@ -1749,7 +1817,7 @@ mod tests {
                 end_ns: NOW_NS,
             },
             now_ns: NOW_NS,
-            compaction: Compaction::Pre,
+            compaction: None,
             max_query_bytes: DEFAULT_MAX_QUERY_BYTES,
             shards,
             cache_bytes,
@@ -2346,7 +2414,7 @@ mod tests {
         };
 
         // Pre-fix: shard_count 1 resolves shard 0 only.
-        let pre = dataset_info(&store, th, window, NOW_NS, 0.0, Compaction::Pre, 1)
+        let pre = dataset_info(&store, th, window, NOW_NS, None, 1)
             .await
             .expect("resolve at shard_count 1");
         assert_eq!(
@@ -2355,7 +2423,7 @@ mod tests {
         );
 
         // Fix: shard_count 2 counts both shards.
-        let post = dataset_info(&store, th, window, NOW_NS, 0.0, Compaction::Pre, 2)
+        let post = dataset_info(&store, th, window, NOW_NS, None, 2)
             .await
             .expect("resolve at shard_count 2");
         assert_eq!(
@@ -2827,6 +2895,210 @@ mod tests {
              failed={:?} entries={}",
             report.failed,
             report.entries.len()
+        );
+    }
+
+    /// A 1-shard tenant with `objects` hour-0 RLOG objects, a provisioning
+    /// record, and a real compaction over that bucket (issue #834): unlike
+    /// [`folded_tenant`], which only seals the hour for `max_segments`
+    /// accounting, this drives `ravel_maintain::compact_bucket` so the
+    /// resolved snapshot's segments are genuinely `SegmentLevel::L1`, the
+    /// ground truth `dataset_info`'s derived `layout` reads. `objects` must be
+    /// at least `DEFAULT_MIN_COMPACTION_INPUTS` (2) or the bucket has too few
+    /// inputs to compact.
+    async fn compacted_tenant(store: &Arc<dyn ObjectStoreBackend>, name: &str, objects: usize) {
+        let tenant = TenantId::new(name);
+        let tenant_hash = tenant.hash();
+        write_shard_objects(store, &tenant, 0, objects).await;
+        validate_or_adopt(
+            store.as_ref(),
+            &tenant_hash,
+            Signal::Logs,
+            1,
+            10,
+            AbsentPolicy::CreateFromConfig,
+        )
+        .await
+        .expect("write provisioning record");
+
+        let clock = ravel_maintain::FixedClock::new(NOW_NS);
+        let config = ravel_maintain::CompactorConfig::default();
+        let bucket = ravel_maintain::Bucket::new(tenant_hash, Signal::Logs, 0, 0);
+        let outcome = ravel_maintain::compact_bucket(store.as_ref(), &clock, &config, &bucket)
+            .await
+            .expect("compact hour-0 bucket");
+        assert!(
+            matches!(outcome, ravel_maintain::CompactionOutcome::Compacted { .. }),
+            "fixture must actually compact, got {outcome:?}"
+        );
+    }
+
+    /// `dataset_info` must report BOTH layout directions from the same
+    /// derivation, not a hardcoded string: an all-L0 tenant is
+    /// `"pre-compaction"` and a tenant with a real compaction over its bucket
+    /// is `"post-compaction"` (issue #834). A one-directional fix -- for
+    /// instance one that always returns `Compaction::Pre.label()` -- passes
+    /// only the first of these two assertions.
+    ///
+    /// Prove-the-test: reverting `dataset_info`'s `layout` to echo a
+    /// `Compaction` parameter fixed at `Compaction::Pre` (the pre-#834
+    /// behavior) makes the `post` assertion below fail with
+    /// `left: "post-compaction", right: "pre-compaction"` -- exactly the
+    /// mislabel this ticket reports (a compacted tenant printed
+    /// `layout=pre-compaction`).
+    #[tokio::test]
+    async fn dataset_info_layout_reports_both_directions_from_observed_state() {
+        let window = TimeRange {
+            start_ns: 0,
+            end_ns: NOW_NS,
+        };
+
+        let pre_store = empty_store();
+        provisioned_tenant(&pre_store, "layout-pre-tenant").await;
+        let pre = dataset_info(
+            &pre_store,
+            TenantId::new("layout-pre-tenant").hash(),
+            window,
+            NOW_NS,
+            None,
+            1,
+        )
+        .await
+        .expect("resolve pre-compaction tenant");
+        assert_eq!(pre.layout, "pre-compaction");
+
+        let post_store = empty_store();
+        compacted_tenant(&post_store, "layout-post-tenant", 2).await;
+        let post = dataset_info(
+            &post_store,
+            TenantId::new("layout-post-tenant").hash(),
+            window,
+            NOW_NS,
+            None,
+            1,
+        )
+        .await
+        .expect("resolve post-compaction tenant");
+        assert_eq!(
+            post.layout, "post-compaction",
+            "a tenant with a real compaction over its bucket must report \
+             post-compaction, derived from the resolved snapshot's L1 segments, \
+             not echoed from an operator flag"
+        );
+    }
+
+    /// `run_tenant`'s end-to-end report agrees with `dataset_info` on both
+    /// directions, and JSON serializes the same value the struct holds (one
+    /// code path, not two that could drift apart).
+    #[tokio::test]
+    async fn run_tenant_reports_observed_layout_not_the_compaction_flag() {
+        let store = empty_store();
+        compacted_tenant(&store, "run-tenant-post-layout", 2).await;
+        let mut cfg = tenant_cfg(&store, "run-tenant-post-layout", None, 0);
+        // The operator's belief is wrong (stale `--compaction pre`), but the
+        // flag is unset here so no CompactionMismatch refusal fires; the
+        // report must still say what the snapshot actually is.
+        cfg.compaction = None;
+        let report = run_tenant(&cfg).await.expect("tenant lane runs");
+        assert_eq!(report.dataset.layout, "post-compaction");
+        let json = serde_json::to_value(&report.dataset).expect("DatasetInfo serializes");
+        assert_eq!(json["layout"], "post-compaction");
+    }
+
+    /// An operator's stated `--compaction` belief is checked against the
+    /// observed snapshot, in both mismatch directions, and refuses rather
+    /// than letting a report print next to a silently wrong assertion (issue
+    /// #834 deliverable 3). Agreement in either direction runs cleanly.
+    #[tokio::test]
+    async fn compaction_flag_mismatch_refuses_in_both_directions() {
+        let post_store = empty_store();
+        compacted_tenant(&post_store, "mismatch-post-tenant", 2).await;
+        let mut cfg = tenant_cfg(&post_store, "mismatch-post-tenant", None, 0);
+        cfg.compaction = Some(Compaction::Pre);
+        let err = run_tenant(&cfg)
+            .await
+            .expect_err("asserting pre-compaction on a compacted tenant must refuse");
+        assert!(
+            err.to_string().contains("disagrees with"),
+            "error must name the disagreement: {err}"
+        );
+
+        let pre_store = empty_store();
+        provisioned_tenant(&pre_store, "mismatch-pre-tenant").await;
+        let mut cfg = tenant_cfg(&pre_store, "mismatch-pre-tenant", None, 0);
+        cfg.compaction = Some(Compaction::Post);
+        let err = run_tenant(&cfg)
+            .await
+            .expect_err("asserting post-compaction on an uncompacted tenant must refuse");
+        assert!(
+            err.to_string().contains("disagrees with"),
+            "error must name the disagreement: {err}"
+        );
+
+        // Agreement in either direction runs cleanly (this is a check, not a
+        // ban on stating the flag at all).
+        let agree_store = empty_store();
+        compacted_tenant(&agree_store, "mismatch-agree-tenant", 2).await;
+        let mut cfg = tenant_cfg(&agree_store, "mismatch-agree-tenant", None, 0);
+        cfg.compaction = Some(Compaction::Post);
+        run_tenant(&cfg)
+            .await
+            .expect("a --compaction flag that agrees with the observed layout must not refuse");
+    }
+
+    /// A run that performed no load must report `load_wall_ms` as `None`, not
+    /// a measured-looking `0.0`, and JSON must OMIT the key entirely rather
+    /// than serialize a `null` (issue #834 deliverable 2): a reader scanning
+    /// for the key's presence, not its value, is how this is meant to be
+    /// checked at the wire level.
+    #[tokio::test]
+    async fn tenant_lane_omits_load_wall_ms_generated_lane_reports_it() {
+        let store = empty_store();
+        provisioned_tenant(&store, "no-load-tenant").await;
+        let cfg = tenant_cfg(&store, "no-load-tenant", None, 0);
+        let report = run_tenant(&cfg).await.expect("tenant lane runs");
+        assert_eq!(
+            report.dataset.load_wall_ms, None,
+            "the tenant lane performed no load in this invocation"
+        );
+        let json = serde_json::to_value(&report.dataset).expect("DatasetInfo serializes");
+        assert!(
+            json.get("load_wall_ms").is_none(),
+            "load_wall_ms must be absent from JSON, not null, when no load ran: {json}"
+        );
+
+        let gen_store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+        let gen_cfg = GenerateConfig {
+            store: gen_store,
+            store_backend: "memory".to_string(),
+            region: "n/a".to_string(),
+            endpoint: "n/a".to_string(),
+            entries: Vec::new(),
+            runs: 1,
+            records: 4,
+            records_per_object: 4,
+            extra_attrs: 0,
+            max_query_bytes: DEFAULT_MAX_QUERY_BYTES,
+            cache_bytes: 0,
+            deadline: Duration::from_secs(30),
+            continue_on_error: false,
+            fetch_concurrency: DEFAULT_FETCH_CONCURRENCY,
+            progress_jsonl: None,
+            tenant_max_bytes: DEFAULT_TENANT_MAX_BYTES,
+            parallel_final_aggregation: false,
+            max_segments: DEFAULT_MAX_SEGMENTS,
+            explain_dir: None,
+        };
+        let gen_report = run_generated(&gen_cfg).await.expect("generated lane runs");
+        let load_ms = gen_report
+            .dataset
+            .load_wall_ms
+            .expect("the generated lane builds and times its own load");
+        assert!(load_ms >= 0.0, "load wall time must be a real duration");
+        let json = serde_json::to_value(&gen_report.dataset).expect("DatasetInfo serializes");
+        assert!(
+            json.get("load_wall_ms").is_some(),
+            "load_wall_ms must be present in JSON when the lane actually loaded: {json}"
         );
     }
 }

--- a/crates/ravel-bench/tests/sql_latency_flight_smoke.rs
+++ b/crates/ravel-bench/tests/sql_latency_flight_smoke.rs
@@ -231,7 +231,7 @@ fn flight_cfg(
             end_ns: NOW_NS,
         },
         now_ns: NOW_NS,
-        compaction: ravel_bench::sql_latency::Compaction::Pre,
+        compaction: None,
         max_query_bytes: DEFAULT_MAX_QUERY_BYTES,
         // The generated lane writes shard 0 only and leaves no provisioning
         // record, so the shard count has to be named.

--- a/crates/ravel-object-store/src/conformance.rs
+++ b/crates/ravel-object-store/src/conformance.rs
@@ -267,7 +267,7 @@ pub async fn probe_object_lock<S: ObjectLockProbeSource + ?Sized>(source: &S) ->
 //
 // ADR-0064 makes bucket versioning and lifecycle rules a normative contract:
 // versioning OFF unless paired with a noncurrent-version expiration rule, the
-// `AbortIncompleteMultipartUpload` rule recommended, and no other expiration
+// `AbortIncompleteMultipartUpload` rule REQUIRED (#864), and no other expiration
 // rule on any Ravel prefix. Like the Object Lock probe above, this is
 // informational-plus-alarming, never startup-blocking: `object_store` 0.14 has
 // no bucket-policy query, so a real backend reports every field `Unknown`
@@ -327,7 +327,7 @@ impl LifecycleRuleStatus {
 
 /// Observed (or unknown) required-bucket-configuration state (ADR-0064 §7).
 /// Reports the three settings the ADR names: object versioning, the
-/// `AbortIncompleteMultipartUpload` lifecycle rule (recommended), and the
+/// `AbortIncompleteMultipartUpload` lifecycle rule (REQUIRED, #864), and the
 /// noncurrent-version expiration rule (required only when versioning is on).
 #[derive(Debug, Clone)]
 pub struct BucketConfigProbe {
@@ -378,13 +378,18 @@ pub fn bucket_config_alarms(probe: &BucketConfigProbe) -> Vec<String> {
                 .to_string(),
         );
     }
-    // Recommended, not required: the abort-incomplete-multipart rule
-    // (ADR-0064 §7 point 3; also converts S5-19's undocumented dependency into
-    // a documented one).
+    // REQUIRED (#864): the abort-incomplete-multipart rule (ADR-0064 §7 point 3;
+    // also converts S5-19's undocumented dependency into a documented one).
+    // Emitted under NOTE rather than ALARM only because no vendor API this crate
+    // calls can observe the rule, so the probe cannot establish compliance
+    // either way. The prefix reflects the probe's limits, not a weaker rule.
     if probe.abort_incomplete_multipart_upload == LifecycleRuleStatus::Absent {
         alarms.push(
-            "NOTE: the recommended AbortIncompleteMultipartUpload lifecycle rule (7 days) is not \
-             configured (ADR-0064 §7 point 3). Incomplete multipart uploads will accumulate."
+            "NOTE: the REQUIRED AbortIncompleteMultipartUpload lifecycle rule (7 days or \
+             less) is not configured (ADR-0064 §7 point 3). Its absence violates the bucket \
+             configuration contract: nothing in Ravel reaps abandoned multipart uploads, so \
+             their parts stay billable indefinitely. The NOTE prefix reflects the probe's \
+             limits, not an optional requirement."
                 .to_string(),
         );
     }
@@ -1240,7 +1245,7 @@ mod tests {
     }
 
     /// A compliant versioned bucket (ADR-0064 §7): versioning on, and both the
-    /// noncurrent-version expiration and the recommended abort-incomplete rule
+    /// noncurrent-version expiration and the required abort-incomplete rule
     /// present, raises no alarm.
     #[tokio::test]
     async fn bucket_config_compliant_versioned_bucket_has_no_alarms() {
@@ -1275,7 +1280,8 @@ mod tests {
 
     /// The load-bearing non-compliant case (S4-12): versioning on with no
     /// noncurrent-version expiration rule alarms as an unsupported
-    /// configuration; a missing abort-incomplete rule adds an advisory note.
+    /// configuration; a missing abort-incomplete rule adds a NOTE, which marks a
+    /// contract violation the probe cannot confirm rather than an optional gap.
     #[tokio::test]
     async fn bucket_config_versioned_without_noncurrent_rule_alarms() {
         let source = FixedBucketConfig(BucketConfigProbe {

--- a/crates/ravel-object-store/src/s3.rs
+++ b/crates/ravel-object-store/src/s3.rs
@@ -70,6 +70,7 @@
 
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use bytes::Bytes;
 use futures::StreamExt;
@@ -241,6 +242,20 @@ pub struct S3Store {
     /// as `credential_provider`, so [`S3Store::credential_refresh_failures`]
     /// can read its counter (ADR-0106).
     instance_role_provider: Option<Arc<InstanceRoleCredentialProvider>>,
+    /// Best-effort aborts in [`S3Store::put_via_multipart`] whose
+    /// `AbortMultipartUpload` request itself returned an error, so the upload's
+    /// parts are certainly orphaned until the bucket's
+    /// `AbortIncompleteMultipartUpload` lifecycle rule reaps them (#864). Read
+    /// via [`S3Store::multipart_abort_failures`].
+    multipart_abort_failures: AtomicU64,
+    /// Multipart uploads opened by [`S3Store::put_via_multipart`] that ended
+    /// without a successful abort for any reason: a failed abort (also counted
+    /// in `multipart_abort_failures`) or a future dropped mid-upload before
+    /// either completion or abort ran (deadline cancellation, task teardown).
+    /// The two are distinguishable because only the first also moves
+    /// `multipart_abort_failures`; the difference isolates the dropped case.
+    /// Read via [`S3Store::multipart_uploads_unreaped`] (#864).
+    multipart_uploads_unreaped: AtomicU64,
 }
 
 impl S3Store {
@@ -254,6 +269,8 @@ impl S3Store {
             page_size: LIST_PAGE_SIZE,
             credential_provider,
             instance_role_provider,
+            multipart_abort_failures: AtomicU64::new(0),
+            multipart_uploads_unreaped: AtomicU64::new(0),
         })
     }
 
@@ -279,6 +296,32 @@ impl S3Store {
             .as_deref()
             .map(InstanceRoleCredentialProvider::refresh_failures)
             .unwrap_or(0)
+    }
+
+    /// Count of best-effort aborts in [`S3Store::put_via_multipart`] whose
+    /// `AbortMultipartUpload` request itself returned an error (#864). Each one
+    /// leaves the failed upload's parts orphaned on the bucket, billed until
+    /// the `AbortIncompleteMultipartUpload` lifecycle rule
+    /// (docs/object-store-contract.md, "Required bucket configuration") reaps
+    /// them; a non-zero value with that rule absent is a live cost leak. The
+    /// best-effort abort is deliberate: this counts the failure rather than
+    /// blocking or retrying it.
+    pub fn multipart_abort_failures(&self) -> u64 {
+        self.multipart_abort_failures.load(Ordering::Relaxed)
+    }
+
+    /// Count of multipart uploads opened by [`S3Store::put_via_multipart`] that
+    /// ended without a successful abort for any reason (#864): either the abort
+    /// itself failed (which also increments
+    /// [`S3Store::multipart_abort_failures`]) or the upload future was dropped
+    /// mid-flight before completion or abort ran, so no abort was even attempted
+    /// (a deadline cancellation or task teardown). Subtracting
+    /// `multipart_abort_failures` isolates the dropped case, which is otherwise
+    /// invisible: a completed upload and a cleanly aborted one never count here.
+    /// A hard process crash (SIGKILL) drops no futures and so increments
+    /// nothing; that case is inferable only from S3's own list of open uploads.
+    pub fn multipart_uploads_unreaped(&self) -> u64 {
+        self.multipart_uploads_unreaped.load(Ordering::Relaxed)
     }
 
     /// Build the `AmazonS3Builder` from a [`S3Config`], with no network
@@ -738,7 +781,69 @@ impl MultipartUpload for S3MultipartUpload {
     }
 }
 
+/// Increments the "ended without a successful abort" counter (#864) when
+/// dropped, unless disarmed first. Armed right after a multipart upload is
+/// opened and disarmed only on a clean complete or a successful abort, so a
+/// future dropped mid-upload (deadline cancellation, task teardown) still
+/// records the orphaned upload; without it, only a failed abort call would be
+/// visible.
+struct UnreapedGuard<'a> {
+    counter: &'a AtomicU64,
+    armed: bool,
+}
+
+impl<'a> UnreapedGuard<'a> {
+    fn armed(counter: &'a AtomicU64) -> Self {
+        Self {
+            counter,
+            armed: true,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for UnreapedGuard<'_> {
+    fn drop(&mut self) {
+        if self.armed {
+            self.counter.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+}
+
 impl S3Store {
+    /// Abort a failed multipart upload best effort, observing the outcome
+    /// rather than acting on it: the abort is deliberately never retried and
+    /// never blocking (docs/object-store-contract.md, "Visibility and abort").
+    /// A successful abort disarms `unreaped` because the parts were released. A
+    /// failed abort leaves them orphaned until the bucket's
+    /// `AbortIncompleteMultipartUpload` lifecycle rule reaps them, so it
+    /// increments `multipart_abort_failures`, logs the key for an operator to
+    /// grep, and leaves `unreaped` armed so the upload also counts there (#864).
+    async fn abort_best_effort(
+        &self,
+        key: &str,
+        upload: &mut Box<dyn OsMultipartUpload>,
+        unreaped: &mut UnreapedGuard<'_>,
+    ) {
+        match upload.abort().await {
+            Ok(()) => unreaped.disarm(),
+            Err(e) => {
+                self.multipart_abort_failures
+                    .fetch_add(1, Ordering::Relaxed);
+                tracing::warn!(
+                    phase = "multipart_abort",
+                    key = %key,
+                    error = %map_error_common(e),
+                    "multipart abort failed; upload parts orphaned until the \
+                     AbortIncompleteMultipartUpload lifecycle rule reaps them"
+                );
+            }
+        }
+    }
+
     /// The [`MULTIPART_THRESHOLD`] path of [`ObjectStoreBackend::put`]: cut the
     /// buffer into [`MULTIPART_PART_SIZE`] parts, upload at most
     /// [`MULTIPART_UPLOAD_CONCURRENCY`] of them at a time, then complete. Any
@@ -762,6 +867,12 @@ impl S3Store {
             .put_multipart(&path)
             .await
             .map_err(map_error_common)?;
+
+        // The upload now exists on the server: every early return or dropped
+        // future from here until a clean complete or a successful abort leaves
+        // parts billed. The guard records that as an unreaped upload (#864);
+        // it is disarmed only on a clean resolution.
+        let mut unreaped = UnreapedGuard::armed(&self.multipart_uploads_unreaped);
 
         // Every part but the last is exactly MULTIPART_PART_SIZE, which is
         // both above S3's minimum and uniform, as R2-class backends require.
@@ -790,14 +901,19 @@ impl S3Store {
             }
         }
         if let Some(e) = failure {
-            let _ = upload.abort().await;
+            self.abort_best_effort(key, &mut upload, &mut unreaped)
+                .await;
             return Err(e);
         }
 
         match upload.complete().await {
-            Ok(result) => outcome_of(key, result),
+            Ok(result) => {
+                unreaped.disarm();
+                outcome_of(key, result)
+            }
             Err(e) => {
-                let _ = upload.abort().await;
+                self.abort_best_effort(key, &mut upload, &mut unreaped)
+                    .await;
                 Err(map_error_common(e))
             }
         }
@@ -1159,6 +1275,34 @@ mod tests {
             .await
             .expect_err("put_part after abort must fail");
         assert!(matches!(after_abort, StoreError::Permanent(_)));
+    }
+
+    /// The unreaped-upload guard (#864) counts on drop only while armed, so a
+    /// multipart upload future dropped mid-flight (deadline cancellation, task
+    /// teardown) records the orphaned upload, while a clean complete or a
+    /// successful abort disarms it and records nothing. This is the mechanism
+    /// that makes the "process died mid-upload" case visible rather than only
+    /// the "abort itself failed" one.
+    #[test]
+    fn unreaped_guard_counts_on_drop_only_while_armed() {
+        let counter = AtomicU64::new(0);
+        // Armed and dropped without a clean resolution: the dropped-mid-upload
+        // case. It counts.
+        drop(UnreapedGuard::armed(&counter));
+        assert_eq!(
+            counter.load(Ordering::Relaxed),
+            1,
+            "an armed guard must count the orphaned upload on drop"
+        );
+        // Disarmed before drop: the clean-resolution case. It does not count.
+        let mut guard = UnreapedGuard::armed(&counter);
+        guard.disarm();
+        drop(guard);
+        assert_eq!(
+            counter.load(Ordering::Relaxed),
+            1,
+            "a disarmed guard must not count on drop"
+        );
     }
 
     fn test_config() -> S3Config {

--- a/crates/ravel-object-store/src/s3.rs
+++ b/crates/ravel-object-store/src/s3.rs
@@ -243,10 +243,11 @@ pub struct S3Store {
     /// can read its counter (ADR-0106).
     instance_role_provider: Option<Arc<InstanceRoleCredentialProvider>>,
     /// Best-effort aborts in [`S3Store::put_via_multipart`] whose
-    /// `AbortMultipartUpload` request itself returned an error, so the upload's
-    /// parts are certainly orphaned until the bucket's
-    /// `AbortIncompleteMultipartUpload` lifecycle rule reaps them (#864). Read
-    /// via [`S3Store::multipart_abort_failures`].
+    /// `AbortMultipartUpload` request returned an error, so cleanup was NOT
+    /// CONFIRMED from here (#864). Not proof of orphaning: S3 can apply
+    /// `complete` or `abort` and then fail the response, so this can count an
+    /// upload that is already a visible object. Reconcile against S3's own list
+    /// of open uploads. Read via [`S3Store::multipart_abort_failures`].
     multipart_abort_failures: AtomicU64,
     /// Multipart uploads opened by [`S3Store::put_via_multipart`] that ended
     /// without a successful abort for any reason: a failed abort (also counted
@@ -299,13 +300,18 @@ impl S3Store {
     }
 
     /// Count of best-effort aborts in [`S3Store::put_via_multipart`] whose
-    /// `AbortMultipartUpload` request itself returned an error (#864). Each one
-    /// leaves the failed upload's parts orphaned on the bucket, billed until
-    /// the `AbortIncompleteMultipartUpload` lifecycle rule
+    /// `AbortMultipartUpload` request returned an error (#864).
+    ///
+    /// This is a **cleanup-not-confirmed** count, not a count of orphans. S3 can
+    /// apply the operation and then fail the response, and an abort issued after
+    /// an ambiguous `complete()` can fail precisely because the upload already
+    /// completed — a visible object with nothing to reap, counted here anyway.
+    /// So a non-zero value means "reconcile against S3's list of open uploads",
+    /// and only the uploads that really are incomplete are billed until the
+    /// `AbortIncompleteMultipartUpload` lifecycle rule
     /// (docs/object-store-contract.md, "Required bucket configuration") reaps
-    /// them; a non-zero value with that rule absent is a live cost leak. The
-    /// best-effort abort is deliberate: this counts the failure rather than
-    /// blocking or retrying it.
+    /// them. The best-effort abort is deliberate: this counts the unconfirmed
+    /// outcome rather than blocking or retrying it.
     pub fn multipart_abort_failures(&self) -> u64 {
         self.multipart_abort_failures.load(Ordering::Relaxed)
     }
@@ -817,11 +823,18 @@ impl S3Store {
     /// Abort a failed multipart upload best effort, observing the outcome
     /// rather than acting on it: the abort is deliberately never retried and
     /// never blocking (docs/object-store-contract.md, "Visibility and abort").
-    /// A successful abort disarms `unreaped` because the parts were released. A
-    /// failed abort leaves them orphaned until the bucket's
-    /// `AbortIncompleteMultipartUpload` lifecycle rule reaps them, so it
-    /// increments `multipart_abort_failures`, logs the key for an operator to
-    /// grep, and leaves `unreaped` armed so the upload also counts there (#864).
+    /// A successful abort disarms `unreaped` because the parts were released.
+    ///
+    /// An abort that returns `Err` is recorded as **cleanup not confirmed**, not
+    /// as proof that parts are orphaned, and the distinction is deliberate: a
+    /// response can fail after S3 has already applied the operation. In
+    /// particular, after an ambiguous `complete()` error the subsequent abort can
+    /// fail *because the upload already completed*, in which case there is a
+    /// visible object and nothing to reap. Both counters therefore mean "the
+    /// outcome was not confirmed from here", and an operator reconciles against
+    /// remote state (or the lifecycle rule does) rather than trusting them as a
+    /// count of billable orphans. Treating `Err` as confirmed orphaning would
+    /// over-report by exactly the ambiguous-completion case (#864).
     async fn abort_best_effort(
         &self,
         key: &str,
@@ -837,7 +850,8 @@ impl S3Store {
                     phase = "multipart_abort",
                     key = %key,
                     error = %map_error_common(e),
-                    "multipart abort failed; upload parts orphaned until the \
+                    "multipart abort not confirmed; if the upload did not \
+                     already complete, its parts stay billable until the \
                      AbortIncompleteMultipartUpload lifecycle rule reaps them"
                 );
             }

--- a/crates/ravel-object-store/tests/s3_http_faults.rs
+++ b/crates/ravel-object-store/tests/s3_http_faults.rs
@@ -1041,6 +1041,85 @@ async fn put_above_threshold_leaves_no_object_when_a_part_fails() {
     );
 }
 
+/// When the best-effort abort of a failed multipart put *itself* fails, the
+/// parts are orphaned on the bucket and billed until the
+/// `AbortIncompleteMultipartUpload` lifecycle rule reaps them. #864 makes that
+/// invisible failure countable: `multipart_abort_failures` must read exactly 1
+/// (not `> 0`) for the one abort that erred, and `multipart_uploads_unreaped`
+/// must also read 1 because the upload ended without a successful abort.
+#[tokio::test]
+async fn failed_multipart_abort_is_counted_exactly_once() {
+    let fake = FakeS3::start().await;
+    let store = fake.store();
+    // One part succeeds, the rest are refused: the put fails and must abort.
+    fake.script(Op::UploadPart, [Fault::Pass]);
+    fake.always(Op::UploadPart, Fault::AccessDenied);
+    // And the abort request itself is refused, so the parts stay orphaned.
+    // 403 is permanent, so object_store issues exactly one AbortMultipart.
+    fake.always(Op::AbortMultipart, Fault::AccessDenied);
+
+    let payload = Bytes::from(vec![9u8; MULTIPART_THRESHOLD + 1]);
+    let error = store
+        .put("fault/abort-fails", payload, PutOptions::default())
+        .await
+        .expect_err("a refused part must fail the put");
+    assert!(
+        !error.is_retryable(),
+        "a 403 on a part is permanent, got {error:?}"
+    );
+
+    assert_eq!(
+        fake.count(Op::AbortMultipart),
+        1,
+        "a failed multipart put must attempt exactly one abort"
+    );
+    assert_eq!(
+        store.multipart_abort_failures(),
+        1,
+        "the one abort that returned an error must be counted exactly once"
+    );
+    assert_eq!(
+        store.multipart_uploads_unreaped(),
+        1,
+        "an upload whose abort failed ended without a successful abort"
+    );
+}
+
+/// The counter cannot be firing unconditionally: the same failed-part put with
+/// a *healthy* abort endpoint leaves `multipart_abort_failures` at exactly 0.
+/// The abort succeeds, so the upload was cleanly reaped and
+/// `multipart_uploads_unreaped` is 0 too.
+#[tokio::test]
+async fn successful_multipart_abort_leaves_failure_counter_at_zero() {
+    let fake = FakeS3::start().await;
+    let store = fake.store();
+    fake.script(Op::UploadPart, [Fault::Pass]);
+    fake.always(Op::UploadPart, Fault::AccessDenied);
+    // AbortMultipart is left healthy (default Pass), so the abort succeeds.
+
+    let payload = Bytes::from(vec![9u8; MULTIPART_THRESHOLD + 1]);
+    store
+        .put("fault/abort-ok", payload, PutOptions::default())
+        .await
+        .expect_err("a refused part must fail the put");
+
+    assert_eq!(
+        fake.count(Op::AbortMultipart),
+        1,
+        "the failed put must still abort so parts are not left billed"
+    );
+    assert_eq!(
+        store.multipart_abort_failures(),
+        0,
+        "a successful abort must not increment the failed-abort counter"
+    );
+    assert_eq!(
+        store.multipart_uploads_unreaped(),
+        0,
+        "a cleanly aborted upload did not end without a successful abort"
+    );
+}
+
 /// `SlowDown` inside a 200 response body is S3's documented behavior for
 /// `CompleteMultipartUpload`, and it is a protocol signal rather than a
 /// success: the client must retry it, and the upload must complete correctly

--- a/docs/object-store-contract.md
+++ b/docs/object-store-contract.md
@@ -170,16 +170,39 @@ the reason compaction's crash story degrades to wasted work rather than corrupt
 state). `abort` releases the uploaded parts. It is best effort against the
 server but final for the handle: an upload S3 never heard the abort for leaves
 orphaned parts, which are billed until a bucket lifecycle rule reaps them, and
-never a readable object. Operators SHOULD configure such a rule
-(`AbortIncompleteMultipartUpload`) on Ravel buckets. Because `put()`'s
+never a readable object. **A bucket that Ravel writes multipart uploads to MUST
+configure `AbortIncompleteMultipartUpload`**, with a cleanup period of 7 days or
+less. This is not a recommendation: a failed abort or a future dropped
+mid-upload can leave billable parts indefinitely, and nothing in Ravel reaps
+them, so the lifecycle rule is the only mechanism that bounds the cost. Because `put()`'s
 above-threshold multipart path aborts best effort and discards the result
 (it never retries or blocks on the abort), that failure is otherwise silent:
-`S3Store::multipart_abort_failures` counts aborts whose request itself
-returned an error (parts certainly orphaned, so a non-zero value with the
-lifecycle rule absent is a live cost leak), and `S3Store::multipart_uploads_unreaped`
-counts multipart uploads that ended without a successful abort for any reason
-(a failed abort, or a future dropped mid-upload before any abort ran);
-subtracting the first from the second isolates the dropped case. Both read a
+`S3Store::multipart_abort_failures` counts aborts whose request returned an
+error, and `S3Store::multipart_uploads_unreaped` counts multipart uploads that
+ended without a successful abort for any reason (a failed abort, or a future
+dropped mid-upload with its abort unresolved). Note the two do not partition
+cleanly: if the future is cancelled while `upload.abort().await` is still
+pending, the guard increments `multipart_uploads_unreaped` while
+`multipart_abort_failures` does not, even though an abort request WAS attempted
+and may well have been applied server-side. So the difference between them
+counts "no confirmed abort outcome", which includes both "no abort was issued"
+and "an abort was issued and its result is unknown".
+
+Both counters cover only uploads that reached the point where the guard is
+armed. `put_via_multipart` arms `UnreapedGuard` *after*
+`put_multipart(&path).await` returns, so if `CreateMultipartUpload` is accepted
+server-side and the future is cancelled before its response arrives, an open
+upload exists that neither counter ever sees. That window is bounded by the
+lifecycle rule and by nothing else, which is a further reason the rule is
+required rather than advisory.
+
+Read both as **outcomes that were not confirmed**, not as a count of billable
+orphans. An abort can return an error after S3 has already applied the
+operation, and in particular an abort issued after an ambiguous `complete()`
+error can fail precisely *because the upload already completed* — leaving a
+visible object and nothing to reap, while both counters rise. So a non-zero
+value means "reconcile against S3's own list of open uploads", not "this many
+orphans exist". Both read a
 process-local `AtomicU64` on the `S3Store`; a hard process crash increments
 neither, so that case stays inferable only from S3's own list of open uploads.
 
@@ -441,9 +464,11 @@ adapter contract:
    a manifest, or provenance data outside any path Ravel's own retention
    logic controls.
 3. **Two sanctioned lifecycle rules**, and only these:
-   - `AbortIncompleteMultipartUpload` (recommended, 7 days) — cleans up
-     abandoned multipart uploads; absence does not violate the contract,
-     it just lets incomplete uploads accumulate.
+   - `AbortIncompleteMultipartUpload` (REQUIRED, 7 days or less) — cleans up
+     abandoned multipart uploads. **Its absence violates the bucket
+     configuration contract**, because nothing in Ravel reaps abandoned
+     uploads: a failed abort or a future dropped mid-upload leaves billable
+     parts indefinitely, and this rule is the only mechanism that bounds them.
    - The noncurrent-version expiration rule required by point 1 when
      versioning is ON.
 4. **Object Lock, compliance mode**, on the protected prefixes: `sys/*`,
@@ -470,8 +495,12 @@ report what a backend affirmatively discloses, via
 qualification" above) plus `bucket_config_alarms`, which turns an observed
 [`BucketConfigProbe`] into `"ALARM:"`-prefixed strings for a genuine
 contract violation (point 1's versioning/expiration pairing) and
-`"NOTE:"`-prefixed strings for an advisory gap (the recommended
-multipart-abort rule). Every production backend reports
+`"NOTE:"`-prefixed strings where the probe cannot establish compliance. The
+multipart-abort rule is REQUIRED (point 3), so its absence is a contract
+violation and not an advisory gap; it is reported under `"NOTE:"` only because
+this crate calls no vendor API that can observe the rule, so the probe cannot
+determine compliance either way. The prefix reflects the limits of the probe,
+never a weaker requirement. Every production backend reports
 [`ObjectLockStatus::Unknown`] and every `BucketConfigProbe` field
 `Unknown` through these traits today — there is no vendor API this crate
 calls to populate anything else — so today these probes are informational

--- a/docs/object-store-contract.md
+++ b/docs/object-store-contract.md
@@ -171,7 +171,17 @@ state). `abort` releases the uploaded parts. It is best effort against the
 server but final for the handle: an upload S3 never heard the abort for leaves
 orphaned parts, which are billed until a bucket lifecycle rule reaps them, and
 never a readable object. Operators SHOULD configure such a rule
-(`AbortIncompleteMultipartUpload`) on Ravel buckets.
+(`AbortIncompleteMultipartUpload`) on Ravel buckets. Because `put()`'s
+above-threshold multipart path aborts best effort and discards the result
+(it never retries or blocks on the abort), that failure is otherwise silent:
+`S3Store::multipart_abort_failures` counts aborts whose request itself
+returned an error (parts certainly orphaned, so a non-zero value with the
+lifecycle rule absent is a live cost leak), and `S3Store::multipart_uploads_unreaped`
+counts multipart uploads that ended without a successful abort for any reason
+(a failed abort, or a future dropped mid-upload before any abort ran);
+subtracting the first from the second isolates the dropped case. Both read a
+process-local `AtomicU64` on the `S3Store`; a hard process crash increments
+neither, so that case stays inferable only from S3's own list of open uploads.
 
 **Retry and failure.** Nothing retries internally beyond what `object_store`'s
 client already does per request. A `put_part` that still fails *poisons the


### PR DESCRIPTION
Three independent fleet results, batched into one PR because their file scopes are disjoint (`ravel-object-store`, `ravel-ingest`, `ravel-bench`) and one cold gate run covers all three. Gate `gbatch` passed on a cold remote box; gated head and tree verified as `0afcb7a0` / `dbb5445a`.

### #864 — count failed and unreaped multipart aborts (`ravel-object-store`)

A failed multipart abort leaves orphaned S3 parts that keep costing money, and there was no metric, so an operator could not tell whether the required bucket lifecycle rule was present and working. The best-effort abort behaviour is unchanged and deliberately so — it is correct, it was just invisible. Documented alongside the lifecycle-rule requirement in `docs/object-store-contract.md`.

Trailer is `Refs:`, not `Fixes:` — an operator-facing metric is only done once something exposes it to an operator.

### #865 — per-shard ingest skew metrics (`ravel-ingest`)

An outside review claimed single-threaded shard actors cap ingest scalability and proposed a thread pool per actor. A code check found the actor's serial execution *is* what provides per-shard ordering, and that the expensive flush already runs off the actor thread — so the claim was overstated and the proposed fix would have traded away the invariant. This lands measurement only: per-shard counters plus the on-actor versus off-actor time split, which is the distinction whose absence produced the wrong claim in the first place.

Trailer is `Refs:` — the ticket asks for a measurement to be taken, and taking it happens after this lands.

### #834 — derive the bench layout from observed state (`ravel-bench`)

`sql_latency_bench`'s header printed `layout=pre-compaction` on a tenant that had already compacted 8,424 objects down to 3,469, and `load=0.0ms` on a pass that performed no load. Both are label defects beside correct figures, which is what makes them dangerous: the label is the stamp a later reader uses to decide whether two passes are comparable, and a pass mislabelled `pre-compaction` would be compared against a genuine pre-compaction pass as if the object layout were held constant when it had moved 2.43x.

Now `layout` is always derived from the tenant's observed state and never echoes `--compaction`, and `load=` is appended only when a load actually happened rather than printing a measured-looking zero. `Fixes: #834` — both halves are addressed and tested.

### Note on one result

#865's result branch carried a stray `node_modules` symlink pointing at the executor's own scratch path (`/var/lib/fleet/cache/npm-modules/<task-uuid>`), swept in by a harness `add -A`. It is dangling anywhere but that executor and was stripped before gating.
