### PR TITLE
docs: correct the q37-q43 justification for time clustering

### DIFF
--- a/docs/adrs/0815-clustered-compaction-and-object-pruning.md
+++ b/docs/adrs/0815-clustered-compaction-and-object-pruning.md
@@ -8,9 +8,8 @@ README's issue-number rule.
 ## Context
 
 On the ClickBench reference tenant `clickbench-v4` (8,424 objects, 17,731
-blocks, 11.116 GB, 8 shards, RLOG v4), the narrow-time-window statement class
-q37-q43 already prunes well at block granularity and terribly at object
-granularity:
+blocks, 11.116 GB, 8 shards, RLOG v4), the selective statement class q37-q43
+already prunes well at block granularity and terribly at object granularity:
 
 | figure | value |
 |---|---|
@@ -22,17 +21,49 @@ granularity:
 | competitor wall, same shapes | 0.06-0.09 s |
 
 Block pruning works; object pruning does not exist. If the surviving 0.8% of
-blocks were clustered they would occupy roughly 0.8% of objects (~67); touching
-100% of objects to keep 0.8% of blocks means every object holds a few rows
-matching any narrow window. The corpus explains it: `hits.parquet` is
-CounterID-sorted (#560) and EventTime does not correlate with CounterID, so
-every flushed batch spans nearly the whole EventTime range, and every object's
+blocks were gathered into objects they would occupy roughly 0.8% of them (~67);
+touching 100% of objects to keep 0.8% of blocks means those blocks are spread
+over every object in the corpus.
+
+**What prunes on this corpus is CounterID, not time.** The attribution matters
+because it decides which corpus may measure this ADR, so state it exactly.
+q37-q42 filter `EventDate BETWEEN 15887 AND 15917`
+(benchmarks/clickbench/hits.corpus.json; the epoch-day mapping is
+docs/guides/clickbench.md). That is 2013-07-01 to 2013-07-31, and the `hits`
+corpus is entirely July 2013, so the date predicate selects the whole corpus
+and prunes nothing at all. The predicate that selects is `CounterID = 62`, at
+roughly 0.7-0.8% of rows. The measured 144 of 17,731 surviving blocks is 0.81%,
+which is CounterID's row share, not the share any time window would keep. q43
+is the one statement in the class carrying a real window (`EventDate BETWEEN
+15900 AND 15901`, two days), and it carries the same `CounterID = 62` arm.
+
+The mechanism behind the 144 blocks is entity locality in the load, not
+clustering of any kind. `hits.parquet` arrives sorted by `(CounterID,
+EventDate, ...)` (#560) and the load preserves those runs, so a block is
+near-single-CounterID and the block-level `CounterID` min/max arm excludes
+almost all of them. EventTime does not correlate with CounterID, so every
+flushed batch spans nearly the whole EventTime range, and every object's
 catalog-level `[min_event_ts, max_event_ts]` is therefore nearly the whole
 range. The resolve-time event-overlap filter (docs/catalog-and-mvcc.md,
 "Snapshot resolution" step 4, and the per-part event bounds on an L1
 `SegmentRef`) already excludes an object whose event range misses the query
 window without a data GET, but with every object's bounds spanning the whole
-range it excludes nothing.
+range it excludes nothing. Those two facts are consistent only under this
+attribution: wide event bounds are exactly why time excludes no object, while
+CounterID locality excludes 99.2% of blocks regardless.
+
+**So this corpus is where time-leading clustering backfires, and it must not be
+the corpus that justifies or measures it.** A global EventTime sort scatters
+each counter's rows evenly across the whole order. `CounterID = 62` holds
+roughly 800,000 of the corpus's 99,997,497 rows; spread evenly over the
+measured 17,731 blocks that is about **45** matching rows per block, so nearly
+every block would hold some, and the `CounterID` min/max
+arm would stop excluding anything, and q37-q42 would go from 144 surviving
+blocks to nearly all of them. q43 would improve modestly, because its two-day
+window is real. Decision 2 states what does justify the time-leading default,
+acceptance 1 states which corpus may carry the object-count claim, and
+acceptance 12 is the pre-registered A/B that must run before the key is
+enabled on any measured tenant.
 
 Two facts bound the design:
 
@@ -110,10 +141,24 @@ for EventTime) is an additive field on `TenantConfigRecord`, resolved
 override-over-default exactly as retention and admission limits already are. A
 tenant whose queries filter on a different low-cardinality dimension (say a
 `Region` column) sets the key to that column and gets object exclusion on it
-instead of on time; the default remains EventTime because the measured pain is
-narrow time windows. Which declared types are eligible as an override key,
+instead of on time. Which declared types are eligible as an override key,
 and the canonical order each clusters under, are defined in decision 3's
 eligibility subsection.
+
+**What justifies EventTime as the default, and what does not.** Not q37-q43:
+Context shows those statements are selected by `CounterID`, and a global
+EventTime sort would regress six of the seven. The default rests on organic
+telemetry instead, where two properties hold that the ClickBench corpus does
+not have. Queries are dominated by recent-time windows, so a narrow per-object
+EventTime bound is the bound most statements can use. Ingest arrival order
+already correlates with event time, so a time-leading merge concentrates rather
+than scatters: it tightens per-object bounds without spreading any entity's
+rows across more objects than the arrival order already did. The scattering
+hazard Context describes needs a bulk-loaded, entity-sorted corpus whose
+arrival order is uncorrelated with event time, which is exactly what ClickBench
+is. For the `clickbench-v4` tenant specifically the selective clustering key is
+`CounterID`, so that tenant belongs to the override-key path above rather than
+to the time-leading default. ADR-0849 §6 records the same split.
 
 A tenant whose queries filter on a **high-cardinality point** dimension
 (`WHERE UserID = c`) is not served by any single clustering key; that is point
@@ -506,7 +551,10 @@ data. Each consumer fails toward the outcome it can afford.
   ingest-hour key component, and decision 7 states the rule that covers it.
   This ADR specifies the output invariant; it does not subsume #593, it
   requires #593 to reach full effect on a time-uncorrelated ingest order and
-  composes with it.
+  composes with it. That is a statement about which TIER produces narrow
+  bounds, not about which corpus justifies the time-leading key: a
+  bulk-loaded, entity-sorted corpus is the case decision 2 excludes from the
+  default and acceptance 12 gates.
 - **#118 (rollup/downsampling tier):** orthogonal. Rollup is a lossy
   pre-aggregation that reduces row count; clustering is an exact reordering that
   preserves rows. A rollup tier's outputs can themselves be clustered by the
@@ -923,13 +971,16 @@ and #118, subsumes none, conflicts with none.
 
 ### 5. The conflicting-key problem, stated honestly
 
-A sort key leads with exactly one dimension. Time clustering answers the narrow
-EventTime window (q37-q43). A high-cardinality point lookup (`WHERE UserID =
-c`, q20) wants the surviving rows gathered by UserID, which a time-leading sort
-scatters across every part. A compound key `(ts, UserID)` does not fix this:
+A sort key leads with exactly one dimension. Time clustering answers a genuinely
+narrow EventTime window (of the measured statements, only q43 has one). A
+high-cardinality point lookup (`WHERE UserID = c`, q20) wants the surviving rows
+gathered by UserID, which a time-leading sort scatters across every part. The
+same scattering is what Context describes for `CounterID = 62` in q37-q42: a
+low-cardinality entity predicate is served by locality on that entity, and a
+time-leading sort destroys it. A compound key `(ts, UserID)` does not fix this:
 within each contiguous ts run UserID is still spread across the run's whole
 value domain, so a UserID predicate prunes nothing at object granularity; and
-`(UserID, ts)` destroys the time clustering the measured statements need. One
+`(UserID, ts)` destroys the time clustering a real window needs. One
 key cannot serve both, and this ADR does not claim it can.
 
 The answer for point lookups is the **POSTINGS attribute index (ADR-0049,
@@ -1303,18 +1354,39 @@ Each band is pre-registered before any measurement, on the tracking issue, with
 its reasoning. A figure must be emitted exactly once and inside its band; an
 absent or duplicated figure fails the same as one outside the band.
 
-1. **Objects opened for a narrow-window statement falls by at least an order of
-   magnitude.** Hard gate: q37-q43 opens `<= 842` objects (an order of
-   magnitude below the measured 8,424). Pre-registered expectation: `40-150`
-   objects. Reasoning: 144 surviving blocks are contiguous in EventTime once
-   clustered; at the corpus's block density (17,731 blocks / 8,424 objects =
-   2.1 blocks/object), preserved under the same block size and byte cap, 144
-   blocks occupy ~68 objects, plus at most a couple of boundary parts. With
-   256-MiB parts the count is lower still. A result in `(150, 842]` passes the
-   gate but is a pre-registration miss to investigate (clustering weaker than
-   the density argument predicts, e.g. L2 has not run and the window still
-   spans multiple within-hour part sets). Stated as an exact object count from
-   the resolve accounting, never as a wall-clock improvement.
+1. **Objects opened for a genuinely narrow-window statement fall in proportion
+   to the window, reaching an order of magnitude only when the window is at or
+   under a tenth of the corpus.** The reduction is proportional to `f`, not a
+   fixed order of magnitude at every width: claiming 10x for a window keeping
+   20% of rows would be arithmetically impossible, and the gate below is
+   proportional for that reason. The measurement corpus is an organic-arrival
+   telemetry corpus whose ingest order correlates with event time, never
+   `clickbench-v4`: Context states why that corpus's q37-q42 are selected by
+   `CounterID` and would regress, and acceptance 12 is the separate gate that
+   applies to it. The measured statement is a window keeping fraction `f` of
+   the corpus's rows with no other prunable predicate, and `f` is registered
+   with the band. Hard gate: objects opened `<= max(0.1, 4f) x` the
+   corpus's live object count. The gate is proportional to `f` rather than a
+   fixed fraction because a fixed ceiling and a proportional expectation
+   contradict each other whenever `f` exceeds the ceiling: a window keeping 20%
+   of rows cannot also open under 10% of objects, so a flat `0.1` would fail a
+   correct implementation on a wide window. Pre-registered expectation: within
+   `[f, 2f] x` the live object count, plus at most `G` boundary parts per
+   (shard, ingest hour) the window touches, where `G` is decision 4's stream
+   batching count for that bucket. The allowance must track `G` rather than
+   being fixed at one: decision 4 permits up to `G` boundary parts, so a fixed
+   allowance of one would reject a conforming clustered output whenever
+   `G > 1`. A statement whose registered `f`
+   exceeds `0.25` is not a narrow-window statement and does not belong in this
+   acceptance at all. Reasoning: the surviving rows are contiguous in EventTime
+   once clustered, so a window keeping `f` of the rows keeps about `f` of the
+   parts at the same block size and byte cap, and decision 4's stream batching
+   contributes at most one boundary part per batch, hence up to `G` in total. A result inside the hard
+   gate but outside that band passes but is a pre-registration miss to
+   investigate (clustering weaker than the contiguity argument predicts, e.g.
+   L2 has not run and the window still spans multiple within-hour part sets).
+   Stated as an exact object count from the resolve accounting, never as a
+   wall-clock improvement.
 2. **An excluded object costs ZERO GETs, asserted per phase.** For every object
    whose clustering-key bounds miss the query window, the data GETs attributed
    to it in the probe, scan, and decode phases are exactly 0; the only cost of
@@ -1484,6 +1556,67 @@ absent or duplicated figure fails the same as one outside the band.
     and tombstones -- retiring inputs whose superseding record never
     became live -- and the tombstones-exactly-0 assertion catches exactly
     that.
+12. **EventTime-leading clustering never touches a measured tenant without a
+    pre-registered A/B.** This is a process gate on enabling the feature, not
+    a unit test, and it is a precondition for any reported number. Before
+    `clustering_key` resolves to EventTime for a tenant whose figures are
+    reported anywhere, an A/B is registered on the tracking issue and then
+    run: same binary, same tenant, same corpus, one snapshot before
+    clustering and one after, with the expected direction and the pass band
+    for every figure written down BEFORE any number exists. Statement
+    coverage differs by which A/B this is, and the two must not be conflated.
+
+    For the **`clickbench-v4` negative control**, coverage is q37 through q43
+    inclusive and q43 is required rather than optional: it is the only statement
+    in the class with a genuine time window
+    (`EventDate BETWEEN 15900 AND 15901`) and therefore the only one expected to
+    improve, so a control that drops it cannot show the mechanism working at
+    all.
+
+    For the **telemetry enablement A/B**, q37-q43 do not apply: those
+    identifiers are defined solely by the ClickBench corpus, so requiring them
+    of a telemetry workload would require statements that workload does not
+    contain. That A/B names its own recent-window statements over
+    organically-arriving data and registers their own metric directions, in the
+    implementing ticket. q43's own registered directions, which differ BY METRIC and
+    are not a single "improves": its two-day window is about 6.5% of a 31-day
+    corpus, so
+    - **surviving blocks RISE** toward roughly 6.5%, because clustering kills
+      the `CounterID` arm here exactly as it does for q37-q42. **q43's own
+      pre-clustering baseline must be measured and registered first: it is NOT
+      the 144 of 17,731 figure**, which is q37-q42's. q43 carries extra arms
+      (`EventDate >= 15900`, `EventDate <= 15901`, `IsRefresh = 0`,
+      `DontCountHits = 0`), so its surviving-block count before clustering is
+      its own quantity, and registering a band against q37-q42's baseline would
+      measure from the wrong starting point;
+    - **objects opened FALL**, from every object toward roughly the same 6.5%,
+      because the two days become contiguous instead of scattered;
+    - **data GETs per phase FALL** with objects opened, not with blocks.
+    Registering "q43 improves" without splitting the metrics would pass on a
+    blocks regression or fail on an objects win. The mechanism is working only
+    if objects opened fall for q43 while q37-q42 show no object-level
+    improvement; if q43's objects do not fall, the regression bought nothing. Per-statement figures: surviving blocks, objects opened, and data
+    GETs per phase, each emitted exactly once. For `clickbench-v4` the
+    pre-registered direction is fixed by Context's arithmetic and is a
+    regression: q37-q42 surviving blocks rise from 144 toward 17,731 and
+    objects opened do not fall, while q43 improves. **That run is a NEGATIVE
+    CONTROL and is explicitly excluded from default-enablement evidence.** Its
+    purpose is to confirm the mechanism is understood — a `clickbench-v4` A/B
+    that did NOT regress q37-q42 would mean this ADR's Context is wrong and
+    would itself be the finding. Evidence FOR enabling EventTime as a default
+    must come from a telemetry-shaped workload (organic arrival order,
+    recent-window queries), never from this corpus. This is what ADR-0849 means
+    when it says clustering must not be justified by ClickBench: the corpus may
+    be measured, and must not be used as the argument. Numbers that arrive
+    before the registration are not a result (the repo's pre-registration
+    rule), and enabling the key on a measured tenant without a registered
+    A/B is a process violation of the same class as breaking decision 4's
+    rollout gate. **Registration and execution are not sufficient: enabling
+    EventTime as a default requires a telemetry A/B that PASSED its own
+    pre-registered band.** A registered A/B that ran and missed is a reason not
+    to enable, not a box ticked. The `clickbench-v4` negative control passing
+    (that is, regressing as predicted) is necessary but never sufficient on its
+    own.
 
 ## Alternatives considered
 

--- a/docs/adrs/0849-snapshot-bound-index-plane.md
+++ b/docs/adrs/0849-snapshot-bound-index-plane.md
@@ -574,7 +574,8 @@ number.
 
 The narrow, time-leading slice of ADR-0815 — cluster during compaction, lead
 with EventTime, publish narrow per-part bounds, exclude before any data GET — is
-**not sequenced by this ADR, and must not be measured on the ClickBench tenant.**
+**not sequenced by this ADR, and must not be justified by the ClickBench
+tenant.**
 An earlier draft landed it as item 2 on the strength of `q37`-`q43`, and
 Consequences now shows that reasoning was backwards: on that corpus a global
 EventTime sort would scatter the `CounterID` locality the surviving prune depends
@@ -586,11 +587,29 @@ serve both time ranges and high-cardinality point lookups — the latter is what
 point postings are for. What changes: EventTime-leading clustering is justified
 by **organic telemetry**, where ingest arrival order already correlates with
 event time and recent-window queries dominate, so the scattering hazard does not
-arise. It is therefore gated on a pre-registered A/B against `q37`-`q43` before
-touching any measured tenant, and on a target workload that is not a bulk-loaded
-entity-sorted corpus. For *this* tenant the selective clustering key would be
-`CounterID`, which is ADR-0815's deferred override-key path rather than the
-time-leading slice.
+arise. It is therefore gated on **two separate pre-registered A/Bs**, and they
+must not be conflated. Both are same binary, same tenant, one snapshot before
+clustering and one after, with the expected direction and pass band for every
+figure written down before any number exists. ADR-0815 acceptance 12 is these
+gates in normative form.
+
+1. **The `clickbench-v4` negative control.** Covers `q37` through `q43`
+   inclusive, `q43` required rather than optional: its `EventDate BETWEEN 15900
+   AND 15901` is the only genuine time window in the class, so it is the one
+   statement expected to improve and the only evidence the mechanism works at
+   all on this corpus. Its registered direction is a **regression** for
+   `q37`-`q42`. Passing means regressing as predicted, which confirms the
+   mechanism is understood; it is **never** evidence for enabling the key.
+2. **The telemetry enablement A/B**, which is what may justify enabling
+   EventTime as a default, and which must PASS its own band. `q37`-`q43` do not
+   apply to it: those identifiers are defined solely by the ClickBench corpus,
+   so requiring them of a telemetry workload would require statements that
+   workload does not contain. It names its own recent-window statements over
+   organically-arriving data and registers their own metric directions, in the
+   implementing ticket rather than here.
+
+For *this* tenant the selective clustering key would be `CounterID`, which is
+ADR-0815's deferred override-key path rather than the time-leading slice.
 
 ## Rejected alternatives
 
@@ -625,9 +644,13 @@ time-leading slice.
    handles ranges; postings handle points; neither substitutes for the other.
 
 7. **A general external-sort subsystem for arbitrary clustering keys, first.**
-   Rejected as sequencing: it is the most complex piece of ADR-0815 and its
-   value is unmeasured until basic time clustering has been landed and
-   measured. Deferred, not rejected on merit.
+   Rejected as sequencing: it is the most complex piece of ADR-0815, and this
+   ADR's own statistics pruning (§5) already covers `q37`-`q42` on this tenant
+   (and `q43`, whose real two-day window clustering would additionally help)
+   at far less machinery. Note the tension rather than hiding it: §6 states
+   that on this tenant the override key is the only clustering key that could
+   help, so the deferral is about complexity and sequencing, not about the
+   override path being the wrong key here. Deferred, not rejected on merit.
 
 ## Consequences
 
@@ -651,8 +674,12 @@ predicate is `CounterID = 62` at roughly 0.8% of rows, and the measured 144 of
 Pruning works today because the corpus arrives sorted by
 `(CounterID, EventDate, ...)` and the load preserves those runs, leaving blocks
 near-single-CounterID. A global EventTime sort would scatter each counter's rows
-evenly, leave roughly 60 matching rows in nearly every block, and stop that arm
-pruning at all. ADR-0815 carries the same misattribution.
+evenly, leave roughly 45 matching rows in nearly every block, and stop that arm
+pruning at all. `q43` is the exception and the only one: its window is
+`EventDate BETWEEN 15900 AND 15901`, two real days, so it would improve
+modestly. ADR-0815 carried the same misattribution in its Context and
+Acceptance; both were corrected under #859, and its acceptance 12 now carries
+the pre-registered A/B gate §6 refers to.
 
 **Queries that do not, and the honest count.** Full `SUM`/`AVG` over the corpus
 still scans without materialised aggregate states. **An index alone does not


### PR DESCRIPTION
Two ADRs justified EventTime-leading clustering by pointing at ClickBench statements q37-q43. That justification is factually wrong, and the error was load-bearing: it put clustering early in an epic's ordering on the strength of statements it would actually make worse.

## What was wrong

q37-q42 filter `EventDate BETWEEN 15887 AND 15917`. That is 2013-07-01 to 2013-07-31, and the `hits` corpus is entirely July 2013 — so the date predicate selects the whole corpus and prunes nothing. The predicate that actually selects is `CounterID = 62`, roughly 0.7-0.8% of rows, and the measured 144-of-17,731 surviving blocks is 0.81%: `CounterID`'s row share, not any time window's.

Pruning works today because `hits.parquet` arrives sorted by `(CounterID, EventDate, ...)` and the load preserves those runs, leaving blocks near-single-`CounterID`. It is **entity locality**, and the time window is incidental.

So a global EventTime sort would scatter each counter's ~800,000 rows evenly, leave about 60 matching rows in nearly every block, and stop the `CounterID` arm excluding anything. ADR-0815's own Context was already internally inconsistent about this — it stated that every batch spans nearly the whole EventTime range, which cannot be reconciled with time bounds selecting 0.8% of blocks.

## What this does not say

It does **not** say drop time clustering. Real telemetry queries are dominated by recent-time windows, and organic ingest arrival order already correlates with event time, so the scattering hazard does not arise there. It arises for bulk-loaded, entity-sorted corpora — which is exactly what ClickBench is. The flaw was justifying and measuring the change on the one corpus where it backfires. For this tenant the selective key would be `CounterID`, which is ADR-0815's deferred override-key path rather than the time-leading slice.

## Also resolved: two contradictions found while fixing it

**The A/B gate contradicted itself.** ADR-0849 said clustering "must not be measured on the ClickBench tenant" while also requiring a pre-registered A/B against q37-q43 — which *are* ClickBench statements. Resolved by naming that run a **negative control**, explicitly excluded from default-enablement evidence: a `clickbench-v4` A/B that did *not* regress q37-q42 would mean the Context is wrong and would itself be the finding. ADR-0849 now says "must not be **justified by**". Enabling EventTime as a default requires a telemetry A/B that **passed** its own band, not merely one registered and run.

**q43's expectations move in opposite directions by metric**, and an earlier draft said "both fall". Its two-day window is about 6.5% of a 31-day corpus, so surviving blocks **rise** (from 0.81%, which `CounterID` currently delivers, toward ~6.5%, since clustering kills that arm here too) while objects opened **fall** (the two days become contiguous). Data GETs track objects, not blocks. Registering "q43 improves" without splitting the metrics would pass on a blocks regression or fail on an objects win.

**A fixed gate contradicted a proportional band.** Acceptance 1 paired a hard `<= 0.1x` live-object ceiling with a `[f, 2f]` expectation — arithmetically impossible whenever `f > 0.1`. The gate is now `max(0.1, 4f)`, with `f > 0.25` disqualified from the acceptance entirely, and the headline no longer claims a fixed order of magnitude at every window width.

Fixes: #859
