### PR TITLE
fix: shard skew metrics, on-demand fold, explicit S3 timeouts, bench labelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,16 @@ Flight SQL, exemplars, alerting, and analytics. The
 [traces guide](docs/guides/traces.md) covers querying spans over the `spans`
 SQL table.
 
+One maintenance route sits alongside them: `POST /api/v1/admin/fold` triggers
+a catalog fold for the authenticated tenant and one named signal, instead of
+waiting for the background fold's next tick. It takes the same bearer token
+the query routes take, and its response says which of three things happened --
+a snapshot was `published`, `nothing_eligible` was found to fold, or a
+concurrent fold won the `HEAD` compare-and-swap (`lost_cas`). Right after a
+load the honest answer is `nothing_eligible`: an ingest hour is not foldable
+until the sealing window behind it has elapsed. See
+[architecture](docs/architecture.md#on-demand-catalog-fold).
+
 ## Kubernetes
 
 The operator runs the same ingest and query round trip on a real cluster. This

--- a/crates/ravel-bench/src/bin/sql_latency_bench.rs
+++ b/crates/ravel-bench/src/bin/sql_latency_bench.rs
@@ -466,12 +466,15 @@ fn print_human_table(report: &SqlLatencyReport) {
         p.sql_max_segments, p.explain
     );
     println!(
-        "  warm cat   : {} (resolve phase {})",
-        p.warm_catalog,
-        if p.warm_catalog {
-            "warm after the first statement, as a server's would be"
-        } else {
-            "cold per statement; overstates server resolve cost"
+        "  warm cat   : {}",
+        match p.warm_catalog {
+            Some(true) =>
+                "true (resolve phase warm after the first statement, as a server's would be)",
+            Some(false) =>
+                "false (resolve phase cold per statement; overstates server resolve cost)",
+            // The Flight lane builds no in-process executor, so the flag
+            // governed nothing on the wire (issue #857 review).
+            None => "n/a (Flight lane; the server governs resolve caching)",
         }
     );
     if p.cache_bytes > 0 {

--- a/crates/ravel-bench/src/bin/sql_latency_bench.rs
+++ b/crates/ravel-bench/src/bin/sql_latency_bench.rs
@@ -88,6 +88,18 @@ struct Args {
     /// `<id>.txt` per statement. Required when `--explain` is set.
     #[arg(long = "explain-dir", value_name = "DIR", requires = "explain")]
     explain_dir: Option<std::path::PathBuf>,
+    /// Reuse one `SqlExecutor` (and its in-process catalog caches) across every
+    /// statement instead of building a fresh cold executor per statement. A
+    /// server holds one process-level catalog and `RecordCache` for a tenant's
+    /// whole query stream, so its resolve phase is warm for every statement
+    /// after the first; without this flag the bench builds a cold executor per
+    /// statement and re-pays the resolve GETs each time, overstating
+    /// resolve-phase cost relative to that server (issue #857). Under it, only
+    /// the first statement's cold run is a genuine cold resolve. Applies to the
+    /// in-process lanes only; the Flight lane executes against a running server
+    /// that is already process-warm, so this flag does not reach it.
+    #[arg(long)]
+    warm_catalog: bool,
 
     // --- generated lane knobs ---------------------------------------------
     /// Distinct log records to generate.
@@ -342,6 +354,7 @@ async fn run(args: &Args) -> Result<SqlLatencyReport, ravel_bench::sql_latency::
                 parallel_final_aggregation: args.sql_parallel_final_aggregation,
                 max_segments: args.sql_max_segments,
                 explain_dir: explain_dir.clone(),
+                warm_catalog: args.warm_catalog,
                 flight: args.flight.as_ref().map(|endpoint| FlightTarget {
                     endpoint: endpoint.clone(),
                     token: args.flight_token.clone().or_else(|| {
@@ -377,6 +390,7 @@ async fn run(args: &Args) -> Result<SqlLatencyReport, ravel_bench::sql_latency::
                 parallel_final_aggregation: args.sql_parallel_final_aggregation,
                 max_segments: args.sql_max_segments,
                 explain_dir: explain_dir.clone(),
+                warm_catalog: args.warm_catalog,
             };
             run_generated(&cfg).await
         }
@@ -450,6 +464,15 @@ fn print_human_table(report: &SqlLatencyReport) {
     println!(
         "  max segs   : {}  explain: {}",
         p.sql_max_segments, p.explain
+    );
+    println!(
+        "  warm cat   : {} (resolve phase {})",
+        p.warm_catalog,
+        if p.warm_catalog {
+            "warm after the first statement, as a server's would be"
+        } else {
+            "cold per statement; overstates server resolve cost"
+        }
     );
     if p.cache_bytes > 0 {
         println!("  read cache : {} bytes", p.cache_bytes);

--- a/crates/ravel-bench/src/sql_latency.rs
+++ b/crates/ravel-bench/src/sql_latency.rs
@@ -275,17 +275,35 @@ pub struct Provenance {
     /// `RecordCache` for a tenant's whole query stream, so its resolve phase is
     /// warm for every statement after the first; a cold-per-statement bench
     /// re-pays the resolve GETs on every statement and so overstates
-    /// resolve-phase cost relative to that server (issue #857). Recorded so a
-    /// report states which of the two regimes it measured: under `true`, only
-    /// the first statement's run 0 is a genuine cold resolve.
+    /// resolve-phase cost relative to that server (issue #857).
+    ///
+    /// `Some(v)` for an in-process lane (`generate`/`tenant`), which builds the
+    /// executor the flag governs: under `Some(true)`, only the first statement's
+    /// run 0 is a genuine cold resolve. `None` for the Flight lane: it builds no
+    /// in-process executor, so the flag governs nothing there and reporting its
+    /// value would be a mislabelled measurement (the same class of defect as the
+    /// effective-ceiling fields above avoid on that lane). See
+    /// [`recorded_warm_catalog`].
     #[serde(default)]
-    pub warm_catalog: bool,
+    pub warm_catalog: Option<bool>,
     /// The Flight SQL endpoint (`host:port`) the statements were executed
     /// against, or `None` for an in-process lane. Deliberately not `endpoint`
     /// above: that one names the object store, and the two are different
     /// machines in any deployment worth measuring.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub flight_endpoint: Option<String>,
+}
+
+/// The `warm_catalog` regime a report should record. `--warm-catalog` reuses
+/// one in-process [`SqlExecutor`] across statements, so it governs only the
+/// in-process lanes; the Flight lane builds no such executor
+/// ([`measure_over_flight`] runs each statement over the wire), so the flag
+/// changes nothing there. Recording its value on that lane would claim a regime
+/// the run never measured (issue #857 review), so a Flight run records `None`,
+/// exactly as the effective-ceiling fields do. `flight` is
+/// `cfg.flight.is_some()`.
+fn recorded_warm_catalog(flight: bool, warm_catalog: bool) -> Option<bool> {
+    if flight { None } else { Some(warm_catalog) }
 }
 
 /// The tenant ceiling every run used before the knob was configurable.
@@ -1432,7 +1450,9 @@ pub async fn run_generated(cfg: &GenerateConfig) -> Result<SqlLatencyReport, Err
             // `SqlConfig`, so it is also the effective one.
             parallel_final_aggregation_effective: Some(cfg.parallel_final_aggregation),
             explain: cfg.explain_dir.is_some(),
-            warm_catalog: cfg.warm_catalog,
+            // The generate lane is always in-process (no Flight target), so the
+            // flag governed the run it describes.
+            warm_catalog: recorded_warm_catalog(false, cfg.warm_catalog),
             flight_endpoint: None,
         },
         dataset,
@@ -1573,7 +1593,10 @@ pub async fn run_tenant(cfg: &TenantConfigInput) -> Result<SqlLatencyReport, Err
                 None => Some(cfg.parallel_final_aggregation),
             },
             explain: cfg.explain_dir.is_some(),
-            warm_catalog: cfg.warm_catalog,
+            // Not-applicable on the Flight lane: it builds no in-process
+            // executor, so `--warm-catalog` governed nothing there (issue #857
+            // review). The in-process tenant lane applies it directly.
+            warm_catalog: recorded_warm_catalog(cfg.flight.is_some(), cfg.warm_catalog),
             flight_endpoint: cfg.flight.as_ref().map(|t| t.endpoint.clone()),
         },
         dataset,
@@ -2719,16 +2742,54 @@ mod tests {
         cfg.entries = vec![entry("q", "SELECT body FROM logs")];
         cfg.warm_catalog = true;
         let report = run_tenant(&cfg).await.expect("tenant lane runs");
-        assert!(
+        assert_eq!(
             report.provenance.warm_catalog,
-            "warm-catalog on is recorded"
+            Some(true),
+            "warm-catalog on is recorded on the in-process tenant lane"
         );
 
         cfg.warm_catalog = false;
         let report = run_tenant(&cfg).await.expect("tenant lane runs");
-        assert!(
-            !report.provenance.warm_catalog,
-            "warm-catalog off is recorded"
+        assert_eq!(
+            report.provenance.warm_catalog,
+            Some(false),
+            "warm-catalog off is recorded on the in-process tenant lane"
+        );
+    }
+
+    /// Item 2 (issue #857 review): the Flight lane builds no in-process
+    /// executor, so `--warm-catalog` governs nothing there. A `--flight
+    /// --warm-catalog` run must therefore not report `warm_catalog: true`; it
+    /// records the regime as not-applicable, exactly as the effective-ceiling
+    /// fields do. The Flight lane cannot run without a live server, so this
+    /// tests the recording rule and its serialisation directly.
+    ///
+    /// Prove-the-test: reverting `recorded_warm_catalog` to `Some(warm_catalog)`
+    /// unconditionally makes the flight case serialise `true`, failing both the
+    /// `None` assertion and the "not true" serialisation assertion below.
+    #[test]
+    fn flight_lane_never_records_warm_catalog_as_true() {
+        // The recording rule: in-process lanes carry the flag; the Flight lane
+        // is not-applicable regardless of the flag.
+        assert_eq!(recorded_warm_catalog(true, true), None);
+        assert_eq!(recorded_warm_catalog(true, false), None);
+        assert_eq!(recorded_warm_catalog(false, true), Some(true));
+        assert_eq!(recorded_warm_catalog(false, false), Some(false));
+
+        // The serialised report of a `--flight --warm-catalog` run must not
+        // claim `true`.
+        let flight_warm = serde_json::json!({
+            "warm_catalog": recorded_warm_catalog(true, true),
+        });
+        assert_ne!(
+            flight_warm["warm_catalog"],
+            serde_json::json!(true),
+            "a Flight run must not serialise warm_catalog: true"
+        );
+        assert_eq!(
+            flight_warm["warm_catalog"],
+            serde_json::Value::Null,
+            "a Flight run serialises warm_catalog as not-applicable (null)"
         );
     }
 

--- a/crates/ravel-bench/src/sql_latency.rs
+++ b/crates/ravel-bench/src/sql_latency.rs
@@ -269,6 +269,17 @@ pub struct Provenance {
     /// numbers above.
     #[serde(default)]
     pub explain: bool,
+    /// Whether one `SqlExecutor` (and its in-process catalog caches) was reused
+    /// across every statement (`--warm-catalog`), instead of a fresh cold
+    /// executor per statement. A server holds one process-level catalog and
+    /// `RecordCache` for a tenant's whole query stream, so its resolve phase is
+    /// warm for every statement after the first; a cold-per-statement bench
+    /// re-pays the resolve GETs on every statement and so overstates
+    /// resolve-phase cost relative to that server (issue #857). Recorded so a
+    /// report states which of the two regimes it measured: under `true`, only
+    /// the first statement's run 0 is a genuine cold resolve.
+    #[serde(default)]
+    pub warm_catalog: bool,
     /// The Flight SQL endpoint (`host:port`) the statements were executed
     /// against, or `None` for an in-process lane. Deliberately not `endpoint`
     /// above: that one names the object store, and the two are different
@@ -567,6 +578,13 @@ pub struct GenerateConfig {
     /// are readable per statement. Not timed and not part of the report's
     /// numbers. `None` writes no plan.
     pub explain_dir: Option<std::path::PathBuf>,
+    /// Reuse one `SqlExecutor` (and its in-process catalog caches) across every
+    /// statement (`--warm-catalog`) instead of building a fresh cold executor
+    /// per statement. See [`Provenance::warm_catalog`] for why this matters: a
+    /// server's resolve phase is warm for every statement after the first, and
+    /// a cold-per-statement bench diverges from it by re-paying the resolve
+    /// GETs each time (issue #857).
+    pub warm_catalog: bool,
 }
 
 /// Where the Flight lane sends its statements.
@@ -676,6 +694,11 @@ pub struct TenantConfigInput {
     /// a Flight client cannot read the tenant's catalog, and the skip check
     /// needs the declarations.
     pub flight: Option<FlightTarget>,
+    /// Reuse one `SqlExecutor` (and its in-process catalog caches) across every
+    /// statement (`--warm-catalog`) instead of building a fresh cold executor
+    /// per statement. See [`Provenance::warm_catalog`]. Ignored by the Flight
+    /// lane, which builds no in-process executor.
+    pub warm_catalog: bool,
 }
 
 fn percentile(sorted_ns: &[u64], pct: f64) -> u64 {
@@ -881,6 +904,13 @@ async fn explain_plan_text(
 /// first run is the cold number. An entry whose `required_declarations` are not
 /// all satisfied by `declared` is skipped with its missing key named and never
 /// executed.
+///
+/// When `warm_catalog` is set, one executor (and one read cache, when
+/// `cache_bytes > 0`) is built once and reused for every statement instead of
+/// a fresh one per statement. This mirrors a server's process-level catalog and
+/// `RecordCache`, whose resolve phase is warm for every statement after the
+/// first; under it only the first statement's run 0 is a genuine cold resolve
+/// (issue #857).
 #[allow(clippy::too_many_arguments)]
 pub async fn measure_corpus(
     store: &Arc<dyn ObjectStoreBackend>,
@@ -895,6 +925,7 @@ pub async fn measure_corpus(
     continue_on_error: bool,
     progress_jsonl: Option<&std::path::Path>,
     settings: ExecutorSettings,
+    warm_catalog: bool,
     explain_dir: Option<&std::path::Path>,
 ) -> Result<(Vec<EntryReport>, Vec<SkippedEntry>, Vec<FailedEntry>), Error> {
     let runs = runs.max(1);
@@ -902,6 +933,18 @@ pub async fn measure_corpus(
     let mut skipped = Vec::new();
     let mut failed = Vec::new();
     let mut progress = progress_jsonl.map(ProgressSink::open).transpose()?;
+
+    // `--warm-catalog`: one executor (and one read cache) reused across every
+    // statement, so the catalog resolve of every statement after the first is
+    // served from the warm in-process `RecordCache`/`HeadCache`, exactly as a
+    // server's process-level catalog would (issue #857). Built once here; the
+    // per-entry `None` path below keeps the cold-per-statement default.
+    let shared_executor = if warm_catalog {
+        let cache = (cache_bytes > 0).then(|| build_read_cache(cache_bytes));
+        Some(cold_executor(store, declared, cache, settings)?)
+    } else {
+        None
+    };
 
     // CPU flamegraph lane (issue #365's pattern; see crate::profiling). Covers
     // every entry's execution, both lanes (run_generated/run_tenant funnel
@@ -936,12 +979,24 @@ pub async fn measure_corpus(
             continue;
         }
 
-        // A fresh cache per entry (not per run) so run 0 is genuinely cold while
-        // later runs of the SAME statement can serve from it; sharing one cache
-        // across entries would warm one statement from another's reads over the
-        // same segments.
-        let cache = (cache_bytes > 0).then(|| build_read_cache(cache_bytes));
-        let executor = cold_executor(store, declared, cache, settings)?;
+        // Cold default: a fresh cache and executor per entry (not per run) so
+        // run 0 is genuinely cold while later runs of the SAME statement can
+        // serve from it; sharing one cache across entries would warm one
+        // statement from another's reads over the same segments. Under
+        // `--warm-catalog` the one `shared_executor` built above is reused
+        // instead, deliberately warming each statement from the last.
+        // The cold path builds a fresh executor owned by this iteration;
+        // `owned_executor` holds it alive for the run loop below. The warm path
+        // borrows the one `shared_executor` instead and leaves this unused.
+        let owned_executor;
+        let executor: &SqlExecutor = match &shared_executor {
+            Some(shared) => shared,
+            None => {
+                let cache = (cache_bytes > 0).then(|| build_read_cache(cache_bytes));
+                owned_executor = cold_executor(store, declared, cache, settings)?;
+                &owned_executor
+            }
+        };
         let req = SqlRequest {
             sql: entry.sql.clone(),
             window,
@@ -959,7 +1014,7 @@ pub async fn measure_corpus(
         // configuration error (`--explain-dir` unwritable), not a query result.
         if let Some(dir) = explain_dir
             && let Ok(plan_text) =
-                explain_plan_text(&executor, tenant_hash, &req, &entry.sql, declared).await
+                explain_plan_text(executor, tenant_hash, &req, &entry.sql, declared).await
         {
             let path = dir.join(format!("{}.txt", entry.id));
             std::fs::write(&path, plan_text)
@@ -1349,6 +1404,7 @@ pub async fn run_generated(cfg: &GenerateConfig) -> Result<SqlLatencyReport, Err
         cfg.continue_on_error,
         cfg.progress_jsonl.as_deref(),
         settings,
+        cfg.warm_catalog,
         cfg.explain_dir.as_deref(),
     )
     .await?;
@@ -1376,6 +1432,7 @@ pub async fn run_generated(cfg: &GenerateConfig) -> Result<SqlLatencyReport, Err
             // `SqlConfig`, so it is also the effective one.
             parallel_final_aggregation_effective: Some(cfg.parallel_final_aggregation),
             explain: cfg.explain_dir.is_some(),
+            warm_catalog: cfg.warm_catalog,
             flight_endpoint: None,
         },
         dataset,
@@ -1474,6 +1531,7 @@ pub async fn run_tenant(cfg: &TenantConfigInput) -> Result<SqlLatencyReport, Err
                 cfg.continue_on_error,
                 cfg.progress_jsonl.as_deref(),
                 settings,
+                cfg.warm_catalog,
                 cfg.explain_dir.as_deref(),
             )
             .await?
@@ -1515,6 +1573,7 @@ pub async fn run_tenant(cfg: &TenantConfigInput) -> Result<SqlLatencyReport, Err
                 None => Some(cfg.parallel_final_aggregation),
             },
             explain: cfg.explain_dir.is_some(),
+            warm_catalog: cfg.warm_catalog,
             flight_endpoint: cfg.flight.as_ref().map(|t| t.endpoint.clone()),
         },
         dataset,
@@ -1830,6 +1889,7 @@ mod tests {
             max_segments: DEFAULT_MAX_SEGMENTS,
             explain_dir: None,
             flight: None,
+            warm_catalog: false,
         }
     }
 
@@ -2215,6 +2275,7 @@ mod tests {
             true,
             None,
             ExecutorSettings::default(),
+            false,
             None,
         )
         .await
@@ -2299,6 +2360,7 @@ mod tests {
                         fetch_concurrency: FETCH_CONCURRENCY,
                         ..ExecutorSettings::default()
                     },
+                    false,
                     None,
                 )
                 .await
@@ -2529,6 +2591,147 @@ mod tests {
         }
     }
 
+    /// The cold run 0 GET count of every entry, in entry order. Index 0 of
+    /// `per_run_accounting` is the cold run; the pooled `QueryAccounting` the
+    /// executor surfaces is all the phase attribution `SqlExecutor::execute`
+    /// exposes (issue #857 report), and the catalog resolve's GETs are a
+    /// component of it.
+    fn cold_gets(entries: &[EntryReport]) -> Vec<u64> {
+        entries
+            .iter()
+            .map(|e| {
+                e.per_run_accounting
+                    .as_ref()
+                    .expect("in-process lane records per-run accounting")[0]
+                    .object_store_get_requests
+            })
+            .collect()
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn measure_same_statement(
+        store: &Arc<dyn ObjectStoreBackend>,
+        tenant_hash: TenantHash,
+        statements: usize,
+        warm_catalog: bool,
+    ) -> Vec<EntryReport> {
+        let entries: Vec<CorpusEntry> = (0..statements)
+            .map(|i| entry(&format!("q{i}"), "SELECT body FROM logs"))
+            .collect();
+        let window = TimeRange {
+            start_ns: 0,
+            end_ns: NOW_NS,
+        };
+        let (measured, _skipped, failed) = measure_corpus(
+            store,
+            tenant_hash,
+            &entries,
+            &[],
+            1,
+            window,
+            NOW_NS,
+            0,
+            Duration::from_secs(30),
+            false,
+            None,
+            ExecutorSettings::default(),
+            warm_catalog,
+            None,
+        )
+        .await
+        .expect("measure_corpus runs");
+        assert!(failed.is_empty(), "no statement fails: {failed:?}");
+        assert_eq!(measured.len(), statements, "every statement is measured");
+        measured
+    }
+
+    /// `--warm-catalog` reuses one executor across statements, so the catalog
+    /// resolve of every statement after the first is served from the warm
+    /// in-process `RecordCache`/`HeadCache` instead of re-listing and re-GETting
+    /// the commit records. The resolve GETs are a component of the pooled
+    /// `object_store_get_requests` the executor surfaces, so with the flag on
+    /// they stop recurring: later statements cost strictly fewer GETs than the
+    /// first and plateau. With the flag off (a fresh cold executor per
+    /// statement, the default) every statement re-pays the same resolve GETs,
+    /// so the per-statement GET count is flat and higher. This is the divergence
+    /// from server behaviour issue #857 names (a server holds one process-level
+    /// catalog for a tenant's whole query stream).
+    ///
+    /// Reverting `measure_corpus` to build a cold executor per statement under
+    /// `warm_catalog` (dropping the `shared_executor` branch) makes the warm
+    /// arm behave like the cold one, so the `warm[later] < warm[0]` assertion
+    /// flips red.
+    #[tokio::test]
+    async fn warm_catalog_reuses_resolve_across_statements() {
+        let store = empty_store();
+        let tenant = TenantId::new("warm-catalog-tenant");
+        // Several small objects, each its own commit record, so the resolve's
+        // per-commit-record GETs are a visible share of every statement's cost
+        // and the warm/cold difference is unambiguous.
+        write_shard_objects(&store, &tenant, 0, 8).await;
+        let th = tenant.hash();
+        const STATEMENTS: usize = 4;
+
+        let cold = measure_same_statement(&store, th, STATEMENTS, false).await;
+        let warm = measure_same_statement(&store, th, STATEMENTS, true).await;
+
+        let cold_g = cold_gets(&cold);
+        let warm_g = cold_gets(&warm);
+
+        // Cold: a fresh executor per statement re-pays the same GETs every time.
+        for i in 1..STATEMENTS {
+            assert_eq!(
+                cold_g[i], cold_g[0],
+                "cold executor re-pays the same GETs on every statement: {cold_g:?}"
+            );
+        }
+        // Warm: the first statement warms the catalog; every statement after it
+        // pays strictly fewer GETs (the resolve component no longer recurs) and
+        // the count plateaus.
+        assert!(
+            warm_g[1] < warm_g[0],
+            "the warm catalog serves the resolve of later statements: {warm_g:?}"
+        );
+        for i in 2..STATEMENTS {
+            assert_eq!(
+                warm_g[i], warm_g[1],
+                "warm per-statement GETs plateau once the catalog is warm: {warm_g:?}"
+            );
+        }
+        // The whole point of the flag: a later warm statement costs fewer GETs
+        // than the same statement on the cold path.
+        assert!(
+            warm_g[STATEMENTS - 1] < cold_g[STATEMENTS - 1],
+            "a warm later statement costs fewer GETs than the cold path's: warm {warm_g:?} \
+             vs cold {cold_g:?}"
+        );
+    }
+
+    /// Provenance records which regime the run measured, so a report states
+    /// whether its resolve-phase figures are server-like (warm) or
+    /// cold-per-statement.
+    #[tokio::test]
+    async fn warm_catalog_is_recorded_in_provenance() {
+        let store = empty_store();
+        provisioned_tenant(&store, "warm-prov-tenant").await;
+
+        let mut cfg = tenant_cfg(&store, "warm-prov-tenant", None, 0);
+        cfg.entries = vec![entry("q", "SELECT body FROM logs")];
+        cfg.warm_catalog = true;
+        let report = run_tenant(&cfg).await.expect("tenant lane runs");
+        assert!(
+            report.provenance.warm_catalog,
+            "warm-catalog on is recorded"
+        );
+
+        cfg.warm_catalog = false;
+        let report = run_tenant(&cfg).await.expect("tenant lane runs");
+        assert!(
+            !report.provenance.warm_catalog,
+            "warm-catalog off is recorded"
+        );
+    }
+
     /// The `--cache-bytes` cache is not inert: attaching it to the log fetcher
     /// cuts object-store GETs and adds fetch-cache hits.
     ///
@@ -2692,6 +2895,7 @@ mod tests {
             false,
             None,
             ExecutorSettings::default(),
+            false,
             None,
         )
         .await
@@ -2768,6 +2972,7 @@ mod tests {
             false,
             None,
             ExecutorSettings::default(),
+            false,
             None,
         )
         .await
@@ -3088,6 +3293,7 @@ mod tests {
             parallel_final_aggregation: false,
             max_segments: DEFAULT_MAX_SEGMENTS,
             explain_dir: None,
+            warm_catalog: false,
         };
         let gen_report = run_generated(&gen_cfg).await.expect("generated lane runs");
         let load_ms = gen_report

--- a/crates/ravel-bench/tests/sql_latency_flight_smoke.rs
+++ b/crates/ravel-bench/tests/sql_latency_flight_smoke.rs
@@ -149,6 +149,7 @@ async fn publish_dataset(store: Arc<dyn ObjectStoreBackend>) -> TenantId {
         parallel_final_aggregation: false,
         max_segments: ravel_query::DEFAULT_MAX_SEGMENTS,
         explain_dir: None,
+        warm_catalog: false,
     })
     .await
     .expect("generated lane publishes the dataset");
@@ -246,6 +247,7 @@ fn flight_cfg(
         max_segments: ravel_query::DEFAULT_MAX_SEGMENTS,
         explain_dir: None,
         flight: Some(flight),
+        warm_catalog: false,
     }
 }
 

--- a/crates/ravel-bench/tests/sql_latency_object_count_invariant.rs
+++ b/crates/ravel-bench/tests/sql_latency_object_count_invariant.rs
@@ -101,6 +101,7 @@ async fn l0_object_count_equals_distinct_data_object_keys() {
         parallel_final_aggregation: false,
         max_segments: ravel_query::DEFAULT_MAX_SEGMENTS,
         explain_dir: None,
+        warm_catalog: false,
     };
     let report = run_generated(&cfg).await.expect("generated lane runs");
 

--- a/crates/ravel-bench/tests/sql_latency_smoke.rs
+++ b/crates/ravel-bench/tests/sql_latency_smoke.rs
@@ -58,6 +58,7 @@ fn small_generate_config(store: Arc<dyn ObjectStoreBackend>, runs: usize) -> Gen
         parallel_final_aggregation: false,
         max_segments: ravel_query::DEFAULT_MAX_SEGMENTS,
         explain_dir: None,
+        warm_catalog: false,
     }
 }
 
@@ -241,6 +242,7 @@ async fn an_entry_with_an_unsatisfied_required_declaration_is_skipped_with_the_k
         false,
         None,
         ravel_bench::sql_latency::ExecutorSettings::default(),
+        false,
         None,
     )
     .await

--- a/crates/ravel-ingest/src/lib.rs
+++ b/crates/ravel-ingest/src/lib.rs
@@ -58,7 +58,7 @@ pub use lifecycle::{
 pub use log_error::LogWriteError;
 pub use log_metrics::{LogIngestMetrics, LogIngestMetricsSnapshot};
 pub use log_router::{LogIndexedFields, LogIngestRouter, LogWriteReceipt, NoIndexedFields};
-pub use metrics::{FlushTrigger, IngestMetrics, IngestMetricsSnapshot};
+pub use metrics::{FlushTrigger, IngestMetrics, IngestMetricsSnapshot, ShardSkewStats};
 pub use metrics_meta_sink::{
     DEFAULT_MAX_CAS_RETRIES, DEFAULT_METADATA_FLUSH_WINDOW, FlushSummary, MetadataSink,
     MetadataSinkConfig, catalog_metric_kind,

--- a/crates/ravel-ingest/src/metrics.rs
+++ b/crates/ravel-ingest/src/metrics.rs
@@ -163,9 +163,18 @@ pub struct IngestMetrics {
     /// Like `in_flight_flushes` above, it carries a per-shard dimension the
     /// flat `Copy` [`IngestMetricsSnapshot`] cannot hold, so it is read via
     /// [`IngestMetrics::shard_skew_by_shard`] rather than folded into the
-    /// snapshot. Keyed by shard index; a shard that never enqueued or processed
-    /// a message has no entry, equivalent to all-zero.
-    shard_skew: Mutex<HashMap<u32, ShardSkewCounters>>,
+    /// snapshot.
+    ///
+    /// Lock-free, one [`ShardSkewAtomics`] per shard, indexed by shard number.
+    /// `record_shard_enqueued`/`record_shard_processed` run once per `Write`
+    /// message, so this path must not serialise every shard on one lock: a
+    /// process-wide mutex here would add a contention point to the very path
+    /// #865 measures and could manufacture the throughput limit it exists to
+    /// test for. Preallocated to `shard_count` by [`IngestMetrics::new`] (the
+    /// shard set is fixed for the process); `IngestMetrics::default()` allocates
+    /// none, and any shard index outside the slice is dropped rather than
+    /// counted, matching the best-effort nature of this observability.
+    shard_skew: Box<[ShardSkewAtomics]>,
     /// Metadata-record GETs issued by the metric metadata sink's flush window
     /// (ADR-0085 decision 1). The ADR budgets one GET per tenant per window
     /// with a non-empty pending set, so this is the counter an operator checks
@@ -199,16 +208,21 @@ pub struct IngestMetrics {
     put_attribution: TenantPutAttribution,
 }
 
-/// Accumulator behind [`IngestMetrics::shard_skew`], one per shard. Held under
-/// the map's `Mutex`; the public [`ShardSkewStats`] is its point-in-time copy
-/// with `queue_depth` derived.
+/// Accumulator behind [`IngestMetrics::shard_skew`], one per shard. Each field
+/// is an independent [`AtomicU64`] so the per-message enqueue/process path
+/// updates its own shard with no lock and no cross-shard contention; the public
+/// [`ShardSkewStats`] is its point-in-time copy with `queue_depth` derived. All
+/// updates and reads use `Relaxed`: these are monotonic self-observability
+/// counters, not a synchronisation edge, so a snapshot that catches
+/// `messages_processed` incremented a moment before its matching `on_actor_ns`
+/// addend simply reports a cumulative sum one message behind, which self-heals.
 #[derive(Debug, Default)]
-struct ShardSkewCounters {
-    messages_enqueued: u64,
-    messages_processed: u64,
-    on_actor_ns: u64,
-    flush_permit_wait_ns: u64,
-    off_actor_ns: u64,
+struct ShardSkewAtomics {
+    messages_enqueued: AtomicU64,
+    messages_processed: AtomicU64,
+    on_actor_ns: AtomicU64,
+    flush_permit_wait_ns: AtomicU64,
+    off_actor_ns: AtomicU64,
 }
 
 /// Point-in-time per-shard ingest-skew figures (issue #865). Read via
@@ -325,6 +339,20 @@ pub struct IngestMetricsSnapshot {
 }
 
 impl IngestMetrics {
+    /// Metrics for a router of `shard_count` shards. Preallocates the lock-free
+    /// per-shard skew accumulators (issue #865): the shard set is fixed for the
+    /// process, so the per-message path indexes straight into the slice with no
+    /// lock. `IngestMetrics::default()` allocates none, which suits the many
+    /// tests and sinks that never touch the per-shard counters.
+    pub fn new(shard_count: u32) -> Self {
+        IngestMetrics {
+            shard_skew: (0..shard_count)
+                .map(|_| ShardSkewAtomics::default())
+                .collect(),
+            ..Default::default()
+        }
+    }
+
     pub(crate) fn record_flush(&self, trigger: FlushTrigger) {
         let counter = match trigger {
             FlushTrigger::Size => &self.flushes_by_size,
@@ -370,27 +398,24 @@ impl IngestMetrics {
     /// `messages_enqueued - messages_processed` is the depth still in the
     /// channel.
     pub(crate) fn record_shard_enqueued(&self, shard: u32) {
-        let mut map = self
-            .shard_skew
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        map.entry(shard).or_default().messages_enqueued += 1;
+        if let Some(s) = self.shard_skew.get(shard as usize) {
+            s.messages_enqueued.fetch_add(1, Ordering::Relaxed);
+        }
     }
 
     /// One `Write` message pulled and handled by shard `shard`'s actor, plus
     /// the injected-`Clock` nanoseconds the actor spent handling it -- the
     /// on-actor serial section, excluding both the flush that runs off the
     /// actor and any flush-permit wait the caller already subtracted (issue
-    /// #865). Recorded together in one lock so a reader never sees a processed
-    /// count without its matching on-actor time.
+    /// #865). The `on_actor_ns` addend is stored before the processed count is
+    /// bumped, so a concurrent reader is at worst one message behind on the
+    /// count, never crediting a processed message with no time (see
+    /// [`ShardSkewAtomics`] on the `Relaxed` ordering).
     pub(crate) fn record_shard_processed(&self, shard: u32, on_actor_ns: u64) {
-        let mut map = self
-            .shard_skew
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        let entry = map.entry(shard).or_default();
-        entry.messages_processed += 1;
-        entry.on_actor_ns = entry.on_actor_ns.saturating_add(on_actor_ns);
+        if let Some(s) = self.shard_skew.get(shard as usize) {
+            s.on_actor_ns.fetch_add(on_actor_ns, Ordering::Relaxed);
+            s.messages_processed.fetch_add(1, Ordering::Relaxed);
+        }
     }
 
     /// One flush trigger's injected-`Clock` wait on shard `shard`'s
@@ -400,12 +425,9 @@ impl IngestMetrics {
     /// so charging it as actor work would say "the actor is busy" exactly when
     /// the truth is "flushes are backed up".
     pub(crate) fn record_shard_flush_permit_wait_ns(&self, shard: u32, wait_ns: u64) {
-        let mut map = self
-            .shard_skew
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        let entry = map.entry(shard).or_default();
-        entry.flush_permit_wait_ns = entry.flush_permit_wait_ns.saturating_add(wait_ns);
+        if let Some(s) = self.shard_skew.get(shard as usize) {
+            s.flush_permit_wait_ns.fetch_add(wait_ns, Ordering::Relaxed);
+        }
     }
 
     /// One completed flush task's injected-`Clock` nanoseconds, attributed to
@@ -416,12 +438,9 @@ impl IngestMetrics {
     /// what pipelining is for; see [`ShardSkewStats`] for why that is not
     /// double-counting.
     pub(crate) fn record_shard_off_actor_ns(&self, shard: u32, off_actor_ns: u64) {
-        let mut map = self
-            .shard_skew
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        let entry = map.entry(shard).or_default();
-        entry.off_actor_ns = entry.off_actor_ns.saturating_add(off_actor_ns);
+        if let Some(s) = self.shard_skew.get(shard as usize) {
+            s.off_actor_ns.fetch_add(off_actor_ns, Ordering::Relaxed);
+        }
     }
 
     /// Point-in-time per-shard skew figures, sorted by shard index (issue
@@ -429,28 +448,39 @@ impl IngestMetrics {
     /// is derived here as `messages_enqueued - messages_processed`, saturating
     /// at 0.
     pub fn shard_skew_by_shard(&self) -> Vec<(u32, ShardSkewStats)> {
-        let map = self
-            .shard_skew
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        let mut out: Vec<(u32, ShardSkewStats)> = map
+        // Preallocated by shard index, so iteration is already shard-ordered. A
+        // shard that never enqueued or processed a message reads all-zero and is
+        // omitted, matching the prior map's "absent, equivalent to all-zero".
+        self.shard_skew
             .iter()
-            .map(|(&shard, c)| {
-                (
-                    shard,
+            .enumerate()
+            .filter_map(|(shard, s)| {
+                let messages_enqueued = s.messages_enqueued.load(Ordering::Relaxed);
+                let messages_processed = s.messages_processed.load(Ordering::Relaxed);
+                let on_actor_ns = s.on_actor_ns.load(Ordering::Relaxed);
+                let flush_permit_wait_ns = s.flush_permit_wait_ns.load(Ordering::Relaxed);
+                let off_actor_ns = s.off_actor_ns.load(Ordering::Relaxed);
+                if messages_enqueued == 0
+                    && messages_processed == 0
+                    && on_actor_ns == 0
+                    && flush_permit_wait_ns == 0
+                    && off_actor_ns == 0
+                {
+                    return None;
+                }
+                Some((
+                    shard as u32,
                     ShardSkewStats {
-                        messages_enqueued: c.messages_enqueued,
-                        messages_processed: c.messages_processed,
-                        queue_depth: c.messages_enqueued.saturating_sub(c.messages_processed),
-                        on_actor_ns: c.on_actor_ns,
-                        flush_permit_wait_ns: c.flush_permit_wait_ns,
-                        off_actor_ns: c.off_actor_ns,
+                        messages_enqueued,
+                        messages_processed,
+                        queue_depth: messages_enqueued.saturating_sub(messages_processed),
+                        on_actor_ns,
+                        flush_permit_wait_ns,
+                        off_actor_ns,
                     },
-                )
+                ))
             })
-            .collect();
-        out.sort_unstable_by_key(|&(shard, _)| shard);
-        out
+            .collect()
     }
 
     /// Attribute one completed flush's PUTs to `tenant` (success-time,
@@ -590,6 +620,7 @@ impl IngestMetrics {
 }
 
 #[cfg(test)]
+#[allow(clippy::expect_used)]
 mod tests {
     use super::*;
 
@@ -654,7 +685,7 @@ mod tests {
 
     #[test]
     fn shard_skew_tracks_per_shard_throughput_and_time_split() {
-        let metrics = IngestMetrics::default();
+        let metrics = IngestMetrics::new(2);
         // Shard 0 takes three messages, shard 1 takes one: a skewed load.
         metrics.record_shard_enqueued(0);
         metrics.record_shard_enqueued(0);
@@ -707,7 +738,7 @@ mod tests {
     /// added as its own accumulator, not carved out of one of the other two.
     #[test]
     fn flush_permit_wait_accumulates_without_touching_the_other_two_spans() {
-        let metrics = IngestMetrics::default();
+        let metrics = IngestMetrics::new(1);
         metrics.record_shard_processed(0, 40);
         metrics.record_shard_off_actor_ns(0, 500);
         metrics.record_shard_flush_permit_wait_ns(0, 60);
@@ -736,7 +767,7 @@ mod tests {
         // router, process on the actor), so a snapshot can catch a processed
         // increment before its enqueue is visible. Depth must read 0, never
         // underflow to u64::MAX.
-        let metrics = IngestMetrics::default();
+        let metrics = IngestMetrics::new(3);
         metrics.record_shard_processed(2, 0);
         let skew = metrics.shard_skew_by_shard();
         assert_eq!(
@@ -753,6 +784,74 @@ mod tests {
                 }
             )]
         );
+    }
+
+    /// Item 3 (issue #865 review): the per-message enqueue/process path is
+    /// lock-free per shard. It must still count exactly under concurrent
+    /// multi-shard load, and concurrent writers to one shard must not lose an
+    /// increment to a racing `fetch_add`. Several threads hammer each shard at
+    /// once: every increment must land on its own shard, and every shard's
+    /// totals must equal the number of messages driven into it.
+    ///
+    /// This is the evidence the review asked for that the lock-free rewrite
+    /// loses no counts: an atomic `fetch_add` is read-modify-write, so a lost
+    /// update would show here as a per-shard total below the exact expected
+    /// figure. The process-wide mutex it replaced was the contention point on
+    /// the very path #865 measures; per-shard atomics remove it without giving
+    /// up exactness.
+    #[test]
+    fn shard_skew_counts_are_exact_under_concurrent_multi_shard_load() {
+        use std::sync::Arc;
+        use std::thread;
+
+        const SHARDS: u32 = 8;
+        const THREADS_PER_SHARD: u64 = 4;
+        const MSGS_PER_THREAD: u64 = 5_000;
+        const PER_MSG_NS: u64 = 7;
+        let expected_per_shard = THREADS_PER_SHARD * MSGS_PER_THREAD;
+
+        let metrics = Arc::new(IngestMetrics::new(SHARDS));
+        let mut handles = Vec::new();
+        for shard in 0..SHARDS {
+            for _ in 0..THREADS_PER_SHARD {
+                let metrics = Arc::clone(&metrics);
+                handles.push(thread::spawn(move || {
+                    for _ in 0..MSGS_PER_THREAD {
+                        metrics.record_shard_enqueued(shard);
+                        metrics.record_shard_processed(shard, PER_MSG_NS);
+                    }
+                }));
+            }
+        }
+        for h in handles {
+            h.join().expect("skew writer thread");
+        }
+
+        let skew = metrics.shard_skew_by_shard();
+        assert_eq!(
+            skew.len(),
+            SHARDS as usize,
+            "every shard recorded activity: {skew:?}"
+        );
+        for (shard, stats) in skew {
+            assert_eq!(
+                stats.messages_enqueued, expected_per_shard,
+                "shard {shard} enqueued count is exact under concurrent load"
+            );
+            assert_eq!(
+                stats.messages_processed, expected_per_shard,
+                "shard {shard} processed count is exact under concurrent load"
+            );
+            assert_eq!(
+                stats.on_actor_ns,
+                expected_per_shard * PER_MSG_NS,
+                "shard {shard} on-actor time sums every message exactly"
+            );
+            assert_eq!(
+                stats.queue_depth, 0,
+                "shard {shard} enqueued and processed counts match, so depth is 0"
+            );
+        }
     }
 
     #[test]

--- a/crates/ravel-ingest/src/metrics.rs
+++ b/crates/ravel-ingest/src/metrics.rs
@@ -3,13 +3,17 @@
 //!
 //! # Counting convention
 //!
-//! Every counter here is a monotonic process-global total. There is **no
-//! per-shard and no per-tenant dimension**: a single [`IngestMetrics`] is
-//! constructed once by the router and shared by every shard actor through an
-//! `Arc`, so a value is the sum across all shards and all tenants of this
-//! process. The dimensioned model docs/ingest.md describes (per-shard buffered
-//! bytes/points, per-shard latency histograms, per-tenant accepted/rejected
-//! points) is not implemented here; that doc marks it as tracked future work.
+//! Every counter in [`IngestMetricsSnapshot`] is a monotonic process-global
+//! total with **no per-shard and no per-tenant dimension**: a single
+//! [`IngestMetrics`] is constructed once by the router and shared by every
+//! shard actor through an `Arc`, so a value is the sum across all shards and
+//! all tenants of this process. Two per-shard dimensions sit outside that flat
+//! snapshot, each read through its own accessor: the in-flight-flush gauge
+//! ([`IngestMetrics::in_flight_flushes_by_shard`]) and the ingest-skew figures
+//! ([`IngestMetrics::shard_skew_by_shard`], issue #865: per-shard message
+//! throughput, queue depth, and the on-actor/off-actor time split). The
+//! per-tenant dimensioned model and per-shard latency histograms docs/ingest.md
+//! still lists as future work are not implemented here.
 //!
 //! Two timing conventions coexist, and mixing them up misreads the numbers:
 //!
@@ -633,13 +637,19 @@ mod tests {
         let metrics = IngestMetrics::default();
         metrics.record_shard_processed(2, 0);
         let skew = metrics.shard_skew_by_shard();
-        assert_eq!(skew, vec![(2, ShardSkewStats {
-            messages_enqueued: 0,
-            messages_processed: 1,
-            queue_depth: 0,
-            on_actor_ns: 0,
-            off_actor_ns: 0,
-        })]);
+        assert_eq!(
+            skew,
+            vec![(
+                2,
+                ShardSkewStats {
+                    messages_enqueued: 0,
+                    messages_processed: 1,
+                    queue_depth: 0,
+                    on_actor_ns: 0,
+                    off_actor_ns: 0,
+                }
+            )]
+        );
     }
 
     #[test]

--- a/crates/ravel-ingest/src/metrics.rs
+++ b/crates/ravel-ingest/src/metrics.rs
@@ -11,9 +11,10 @@
 //! snapshot, each read through its own accessor: the in-flight-flush gauge
 //! ([`IngestMetrics::in_flight_flushes_by_shard`]) and the ingest-skew figures
 //! ([`IngestMetrics::shard_skew_by_shard`], issue #865: per-shard message
-//! throughput, queue depth, and the on-actor/off-actor time split). The
-//! per-tenant dimensioned model and per-shard latency histograms docs/ingest.md
-//! still lists as future work are not implemented here.
+//! throughput, queue depth, and the three-way on-actor / flush-permit-wait /
+//! off-actor time split). The per-tenant dimensioned model and per-shard
+//! latency histograms docs/ingest.md still lists as future work are not
+//! implemented here.
 //!
 //! Two timing conventions coexist, and mixing them up misreads the numbers:
 //!
@@ -156,8 +157,9 @@ pub struct IngestMetrics {
     /// via [`IngestMetrics::in_flight_flushes_by_shard`].
     in_flight_flushes: Mutex<HashMap<u32, i64>>,
     /// Per-shard ingest-skew accounting (issue #865): message throughput and
-    /// the on-actor/off-actor time split, so an argument about shard-actor
-    /// throughput rests on measured per-shard figures rather than assertion.
+    /// the on-actor / flush-permit-wait / off-actor time split, so an argument
+    /// about shard-actor throughput rests on measured per-shard figures rather
+    /// than assertion.
     /// Like `in_flight_flushes` above, it carries a per-shard dimension the
     /// flat `Copy` [`IngestMetricsSnapshot`] cannot hold, so it is read via
     /// [`IngestMetrics::shard_skew_by_shard`] rather than folded into the
@@ -205,6 +207,7 @@ struct ShardSkewCounters {
     messages_enqueued: u64,
     messages_processed: u64,
     on_actor_ns: u64,
+    flush_permit_wait_ns: u64,
     off_actor_ns: u64,
 }
 
@@ -212,6 +215,36 @@ struct ShardSkewCounters {
 /// [`IngestMetrics::shard_skew_by_shard`]; a benchmark reaches it through
 /// [`crate::IngestRouter::metrics`], the same handle it already reads
 /// [`IngestMetrics::in_flight_flushes_by_shard`] through.
+///
+/// # The three time spans
+///
+/// `on_actor_ns`, `flush_permit_wait_ns`, and `off_actor_ns` partition a
+/// shard's flush pipeline into three spans that share no nanosecond of any
+/// sampled interval. Each is bracketed on the injected [`crate::Clock`] at a
+/// distinct code boundary in `shard.rs`, and the three boundaries are
+/// consecutive:
+///
+/// 1. `on_actor_ns` runs from the actor pulling a `Write` message off its
+///    channel to `handle_write` returning, **minus** any permit wait nested
+///    inside that call.
+/// 2. `flush_permit_wait_ns` runs from `flush_tenant` reaching the
+///    `max_inflight_flushes` semaphore acquire to that acquire granting a
+///    permit.
+/// 3. `off_actor_ns` runs from the spawned flush task entering `run_flush`
+///    (permit already held) to `run_flush` returning.
+///
+/// Spans 1 and 2 both accrue on the actor task and are therefore disjoint in
+/// wall time as well: together they account for the actor's whole
+/// `Write`-handling window, and `on_actor_ns + flush_permit_wait_ns` can never
+/// exceed the wall time the actor spent handling messages. Span 3 accrues in
+/// spawned tasks that run *concurrently* with the actor, which is the entire
+/// point of ADR-0067's pipelining, so it is a sum over concurrent tasks: at
+/// `max_inflight_flushes > 1` it can legitimately exceed wall time, and it
+/// overlaps spans 1 and 2 in wall time. Overlapping in wall time is not
+/// double-counting: no single sampled interval is added to two counters. In
+/// particular, the interval an actor spends parked in span 2 is wall-time
+/// concurrent with a *prior* flush's span 3, and is charged to the actor side
+/// exactly once, as permit wait, never as actor work.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct ShardSkewStats {
     /// `Write` messages the router sent into this shard's channel.
@@ -228,15 +261,30 @@ pub struct ShardSkewStats {
     /// than underflowing.
     pub queue_depth: u64,
     /// Injected-`Clock` nanoseconds the actor task spent processing this
-    /// shard's `Write` messages: the serial merge-and-pin section that runs ON
-    /// the actor. It excludes the flush, which ADR-0067 moved into a spawned
-    /// task off the actor; that time lands in `off_actor_ns`.
+    /// shard's `Write` messages: the serial merge-and-pin work the actor
+    /// genuinely serialises, and nothing else. It excludes the flush, which
+    /// ADR-0067 moved into a spawned task (`off_actor_ns`), and it excludes the
+    /// wait for a flush permit (`flush_permit_wait_ns`), which is a prior
+    /// flush's duration rather than work this actor performs.
     pub on_actor_ns: u64,
+    /// Injected-`Clock` nanoseconds this shard spent parked on the
+    /// `max_inflight_flushes` semaphore before a flush task could be spawned
+    /// (ADR-0067 decision 2). This runs on the actor task, but it is not actor
+    /// work: the actor is stalled waiting for an earlier flush of this same
+    /// shard to release its permit, so this is the shard's flush backpressure
+    /// signal. A rising figure here says flushing is the bottleneck; a rising
+    /// `on_actor_ns` says the single-threaded actor is.
+    ///
+    /// Counted for every flush trigger, not only the size trigger inside
+    /// `handle_write`: an age or manual flush parks on the same semaphore.
+    pub flush_permit_wait_ns: u64,
     /// Injected-`Clock` nanoseconds spent in this shard's flush tasks, which
     /// run OFF the actor (ADR-0067): exemplar admission, encode, and both PUTs.
-    /// Kept distinct from `on_actor_ns` so a future measurement can tell an
-    /// actor-thread bottleneck from a flush bottleneck -- the exact ambiguity a
-    /// single figure cannot resolve.
+    /// Measured from inside the spawned task with the permit already held, so
+    /// it never re-counts `flush_permit_wait_ns`. Kept distinct from
+    /// `on_actor_ns` so a measurement can tell an actor-thread bottleneck from
+    /// a flush bottleneck -- the exact ambiguity a single figure cannot
+    /// resolve.
     pub off_actor_ns: u64,
 }
 
@@ -331,9 +379,10 @@ impl IngestMetrics {
 
     /// One `Write` message pulled and handled by shard `shard`'s actor, plus
     /// the injected-`Clock` nanoseconds the actor spent handling it -- the
-    /// on-actor serial section, excluding the flush that runs off the actor
-    /// (issue #865). Recorded together in one lock so a reader never sees a
-    /// processed count without its matching on-actor time.
+    /// on-actor serial section, excluding both the flush that runs off the
+    /// actor and any flush-permit wait the caller already subtracted (issue
+    /// #865). Recorded together in one lock so a reader never sees a processed
+    /// count without its matching on-actor time.
     pub(crate) fn record_shard_processed(&self, shard: u32, on_actor_ns: u64) {
         let mut map = self
             .shard_skew
@@ -344,10 +393,28 @@ impl IngestMetrics {
         entry.on_actor_ns = entry.on_actor_ns.saturating_add(on_actor_ns);
     }
 
+    /// One flush trigger's injected-`Clock` wait on shard `shard`'s
+    /// `max_inflight_flushes` semaphore (issue #865). Recorded by `flush_tenant`
+    /// for every trigger, and excluded by the actor loop from the `on_actor_ns`
+    /// it reports for the same message: the wait is a prior flush's duration,
+    /// so charging it as actor work would say "the actor is busy" exactly when
+    /// the truth is "flushes are backed up".
+    pub(crate) fn record_shard_flush_permit_wait_ns(&self, shard: u32, wait_ns: u64) {
+        let mut map = self
+            .shard_skew
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let entry = map.entry(shard).or_default();
+        entry.flush_permit_wait_ns = entry.flush_permit_wait_ns.saturating_add(wait_ns);
+    }
+
     /// One completed flush task's injected-`Clock` nanoseconds, attributed to
-    /// the shard it flushed (issue #865). Off-actor by construction: the flush
-    /// runs in a spawned task (ADR-0067), so this time never overlaps the
-    /// actor's own `on_actor_ns`.
+    /// the shard it flushed (issue #865). Bracketed inside the spawned task
+    /// with the permit already held (ADR-0067), so it re-counts neither the
+    /// actor's `on_actor_ns` nor the `flush_permit_wait_ns` that preceded the
+    /// spawn. It does run concurrently with the actor in wall time, which is
+    /// what pipelining is for; see [`ShardSkewStats`] for why that is not
+    /// double-counting.
     pub(crate) fn record_shard_off_actor_ns(&self, shard: u32, off_actor_ns: u64) {
         let mut map = self
             .shard_skew
@@ -376,6 +443,7 @@ impl IngestMetrics {
                         messages_processed: c.messages_processed,
                         queue_depth: c.messages_enqueued.saturating_sub(c.messages_processed),
                         on_actor_ns: c.on_actor_ns,
+                        flush_permit_wait_ns: c.flush_permit_wait_ns,
                         off_actor_ns: c.off_actor_ns,
                     },
                 )
@@ -599,6 +667,9 @@ mod tests {
         metrics.record_shard_processed(1, 50);
         // Flush time lands off the actor, and only on shard 0 here.
         metrics.record_shard_off_actor_ns(0, 9_000);
+        // Shard 0's second flush trigger found the semaphore at its bound and
+        // parked; that wait is its own span, not part of either figure above.
+        metrics.record_shard_flush_permit_wait_ns(0, 700);
 
         let skew = metrics.shard_skew_by_shard();
         assert_eq!(
@@ -611,6 +682,7 @@ mod tests {
                         messages_processed: 2,
                         queue_depth: 1,
                         on_actor_ns: 300,
+                        flush_permit_wait_ns: 700,
                         off_actor_ns: 9_000,
                     }
                 ),
@@ -621,10 +693,40 @@ mod tests {
                         messages_processed: 1,
                         queue_depth: 0,
                         on_actor_ns: 50,
+                        flush_permit_wait_ns: 0,
                         off_actor_ns: 0,
                     }
                 ),
             ]
+        );
+    }
+
+    /// The three time spans accumulate independently: a permit wait recorded
+    /// for a shard must move neither `on_actor_ns` nor `off_actor_ns`, and
+    /// repeated waits sum rather than replace. Pins that the third counter was
+    /// added as its own accumulator, not carved out of one of the other two.
+    #[test]
+    fn flush_permit_wait_accumulates_without_touching_the_other_two_spans() {
+        let metrics = IngestMetrics::default();
+        metrics.record_shard_processed(0, 40);
+        metrics.record_shard_off_actor_ns(0, 500);
+        metrics.record_shard_flush_permit_wait_ns(0, 60);
+        metrics.record_shard_flush_permit_wait_ns(0, 90);
+
+        let skew = metrics.shard_skew_by_shard();
+        assert_eq!(
+            skew,
+            vec![(
+                0,
+                ShardSkewStats {
+                    messages_enqueued: 0,
+                    messages_processed: 1,
+                    queue_depth: 0,
+                    on_actor_ns: 40,
+                    flush_permit_wait_ns: 150,
+                    off_actor_ns: 500,
+                }
+            )]
         );
     }
 
@@ -646,6 +748,7 @@ mod tests {
                     messages_processed: 1,
                     queue_depth: 0,
                     on_actor_ns: 0,
+                    flush_permit_wait_ns: 0,
                     off_actor_ns: 0,
                 }
             )]

--- a/crates/ravel-ingest/src/metrics.rs
+++ b/crates/ravel-ingest/src/metrics.rs
@@ -151,6 +151,15 @@ pub struct IngestMetrics {
     /// struct (see the module docs' "no per-shard dimension" note); read it
     /// via [`IngestMetrics::in_flight_flushes_by_shard`].
     in_flight_flushes: Mutex<HashMap<u32, i64>>,
+    /// Per-shard ingest-skew accounting (issue #865): message throughput and
+    /// the on-actor/off-actor time split, so an argument about shard-actor
+    /// throughput rests on measured per-shard figures rather than assertion.
+    /// Like `in_flight_flushes` above, it carries a per-shard dimension the
+    /// flat `Copy` [`IngestMetricsSnapshot`] cannot hold, so it is read via
+    /// [`IngestMetrics::shard_skew_by_shard`] rather than folded into the
+    /// snapshot. Keyed by shard index; a shard that never enqueued or processed
+    /// a message has no entry, equivalent to all-zero.
+    shard_skew: Mutex<HashMap<u32, ShardSkewCounters>>,
     /// Metadata-record GETs issued by the metric metadata sink's flush window
     /// (ADR-0085 decision 1). The ADR budgets one GET per tenant per window
     /// with a non-empty pending set, so this is the counter an operator checks
@@ -182,6 +191,49 @@ pub struct IngestMetrics {
     /// than folded into [`IngestMetricsSnapshot`] (which is `Copy`). See
     /// [`crate::attribution`] for the counting convention and eviction policy.
     put_attribution: TenantPutAttribution,
+}
+
+/// Accumulator behind [`IngestMetrics::shard_skew`], one per shard. Held under
+/// the map's `Mutex`; the public [`ShardSkewStats`] is its point-in-time copy
+/// with `queue_depth` derived.
+#[derive(Debug, Default)]
+struct ShardSkewCounters {
+    messages_enqueued: u64,
+    messages_processed: u64,
+    on_actor_ns: u64,
+    off_actor_ns: u64,
+}
+
+/// Point-in-time per-shard ingest-skew figures (issue #865). Read via
+/// [`IngestMetrics::shard_skew_by_shard`]; a benchmark reaches it through
+/// [`crate::IngestRouter::metrics`], the same handle it already reads
+/// [`IngestMetrics::in_flight_flushes_by_shard`] through.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ShardSkewStats {
+    /// `Write` messages the router sent into this shard's channel.
+    pub messages_enqueued: u64,
+    /// `Write` messages this shard's actor pulled and handled. `FlushNow` and
+    /// `Shutdown` are excluded from both this and `messages_enqueued`: they are
+    /// control messages, not ingest load, and counting them would break the
+    /// enqueued-minus-processed depth identity below.
+    pub messages_processed: u64,
+    /// Messages enqueued into this shard's channel but not yet processed by its
+    /// actor, at snapshot time: `messages_enqueued - messages_processed`.
+    /// Saturating, so a read that catches the two counters mid-update (enqueue
+    /// runs on the router task, process on the actor task) reports 0 rather
+    /// than underflowing.
+    pub queue_depth: u64,
+    /// Injected-`Clock` nanoseconds the actor task spent processing this
+    /// shard's `Write` messages: the serial merge-and-pin section that runs ON
+    /// the actor. It excludes the flush, which ADR-0067 moved into a spawned
+    /// task off the actor; that time lands in `off_actor_ns`.
+    pub on_actor_ns: u64,
+    /// Injected-`Clock` nanoseconds spent in this shard's flush tasks, which
+    /// run OFF the actor (ADR-0067): exemplar admission, encode, and both PUTs.
+    /// Kept distinct from `on_actor_ns` so a future measurement can tell an
+    /// actor-thread bottleneck from a flush bottleneck -- the exact ambiguity a
+    /// single figure cannot resolve.
+    pub off_actor_ns: u64,
 }
 
 /// Point-in-time copy of [`IngestMetrics`] for scraping. See the
@@ -259,6 +311,74 @@ impl IngestMetrics {
             .collect();
         counts.sort_unstable_by_key(|&(shard, _)| shard);
         counts
+    }
+
+    /// One `Write` message sent by the router into shard `shard`'s channel
+    /// (issue #865). Enqueue-time: counted at the router's `send`, so
+    /// `messages_enqueued - messages_processed` is the depth still in the
+    /// channel.
+    pub(crate) fn record_shard_enqueued(&self, shard: u32) {
+        let mut map = self
+            .shard_skew
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        map.entry(shard).or_default().messages_enqueued += 1;
+    }
+
+    /// One `Write` message pulled and handled by shard `shard`'s actor, plus
+    /// the injected-`Clock` nanoseconds the actor spent handling it -- the
+    /// on-actor serial section, excluding the flush that runs off the actor
+    /// (issue #865). Recorded together in one lock so a reader never sees a
+    /// processed count without its matching on-actor time.
+    pub(crate) fn record_shard_processed(&self, shard: u32, on_actor_ns: u64) {
+        let mut map = self
+            .shard_skew
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let entry = map.entry(shard).or_default();
+        entry.messages_processed += 1;
+        entry.on_actor_ns = entry.on_actor_ns.saturating_add(on_actor_ns);
+    }
+
+    /// One completed flush task's injected-`Clock` nanoseconds, attributed to
+    /// the shard it flushed (issue #865). Off-actor by construction: the flush
+    /// runs in a spawned task (ADR-0067), so this time never overlaps the
+    /// actor's own `on_actor_ns`.
+    pub(crate) fn record_shard_off_actor_ns(&self, shard: u32, off_actor_ns: u64) {
+        let mut map = self
+            .shard_skew
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let entry = map.entry(shard).or_default();
+        entry.off_actor_ns = entry.off_actor_ns.saturating_add(off_actor_ns);
+    }
+
+    /// Point-in-time per-shard skew figures, sorted by shard index (issue
+    /// #865). A shard with no recorded activity is simply absent. `queue_depth`
+    /// is derived here as `messages_enqueued - messages_processed`, saturating
+    /// at 0.
+    pub fn shard_skew_by_shard(&self) -> Vec<(u32, ShardSkewStats)> {
+        let map = self
+            .shard_skew
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let mut out: Vec<(u32, ShardSkewStats)> = map
+            .iter()
+            .map(|(&shard, c)| {
+                (
+                    shard,
+                    ShardSkewStats {
+                        messages_enqueued: c.messages_enqueued,
+                        messages_processed: c.messages_processed,
+                        queue_depth: c.messages_enqueued.saturating_sub(c.messages_processed),
+                        on_actor_ns: c.on_actor_ns,
+                        off_actor_ns: c.off_actor_ns,
+                    },
+                )
+            })
+            .collect();
+        out.sort_unstable_by_key(|&(shard, _)| shard);
+        out
     }
 
     /// Attribute one completed flush's PUTs to `tenant` (success-time,
@@ -458,6 +578,68 @@ mod tests {
         metrics.record_inflight_flush_delta(0, -1);
         assert_eq!(metrics.in_flight_flushes_by_shard(), vec![(0, 1), (1, 1)]);
         assert_eq!(metrics.snapshot().in_flight_flushes_total, 2);
+    }
+
+    #[test]
+    fn shard_skew_tracks_per_shard_throughput_and_time_split() {
+        let metrics = IngestMetrics::default();
+        // Shard 0 takes three messages, shard 1 takes one: a skewed load.
+        metrics.record_shard_enqueued(0);
+        metrics.record_shard_enqueued(0);
+        metrics.record_shard_enqueued(0);
+        metrics.record_shard_enqueued(1);
+        // Two of shard 0's three, and shard 1's one, have been processed; the
+        // third message for shard 0 is still in the channel.
+        metrics.record_shard_processed(0, 100);
+        metrics.record_shard_processed(0, 200);
+        metrics.record_shard_processed(1, 50);
+        // Flush time lands off the actor, and only on shard 0 here.
+        metrics.record_shard_off_actor_ns(0, 9_000);
+
+        let skew = metrics.shard_skew_by_shard();
+        assert_eq!(
+            skew,
+            vec![
+                (
+                    0,
+                    ShardSkewStats {
+                        messages_enqueued: 3,
+                        messages_processed: 2,
+                        queue_depth: 1,
+                        on_actor_ns: 300,
+                        off_actor_ns: 9_000,
+                    }
+                ),
+                (
+                    1,
+                    ShardSkewStats {
+                        messages_enqueued: 1,
+                        messages_processed: 1,
+                        queue_depth: 0,
+                        on_actor_ns: 50,
+                        off_actor_ns: 0,
+                    }
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn shard_queue_depth_saturates_when_processed_leads_enqueued() {
+        // The two counters are updated on different tasks (enqueue on the
+        // router, process on the actor), so a snapshot can catch a processed
+        // increment before its enqueue is visible. Depth must read 0, never
+        // underflow to u64::MAX.
+        let metrics = IngestMetrics::default();
+        metrics.record_shard_processed(2, 0);
+        let skew = metrics.shard_skew_by_shard();
+        assert_eq!(skew, vec![(2, ShardSkewStats {
+            messages_enqueued: 0,
+            messages_processed: 1,
+            queue_depth: 0,
+            on_actor_ns: 0,
+            off_actor_ns: 0,
+        })]);
     }
 
     #[test]

--- a/crates/ravel-ingest/src/metrics.rs
+++ b/crates/ravel-ingest/src/metrics.rs
@@ -44,9 +44,30 @@ use std::collections::HashMap;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
 
+use ravel_catalog::MAX_SHARD_COUNT;
 use ravel_types::TenantHash;
 
 use crate::attribution::TenantPutAttribution;
+
+/// Shard indices [`IngestMetrics::new`] preallocates per-shard skew
+/// accumulators for.
+///
+/// Set to [`MAX_SHARD_COUNT`], the largest `shard_count` a provisioning record
+/// may declare for any generation: `provisioning.rs` rejects anything outside
+/// `1..=10000` as `GenerationDefect::CountOutOfRange`, and the live routing
+/// count is `ravel_catalog::active_shard_count` over those validated
+/// generations. So no generation this process can activate produces a shard
+/// index at or above this capacity, which is what makes the "an index outside
+/// the slice is dropped" fallback unreachable in practice rather than a hole
+/// the way sizing to `config.shard_count` was.
+///
+/// The cost is one allocation of `MAX_SHARD_COUNT * size_of::<ShardSkewAtomics>()`
+/// (10 000 * 40 bytes = 400 KiB) per router, once at construction, against a
+/// metric whose entire purpose is to be trusted (issue #865). A growable
+/// lock-free structure would save most of that, at the cost of an indexing
+/// scheme on the per-message hot path; a flat slice keeps that path a single
+/// bounds-checked index.
+pub const SHARD_SKEW_CAPACITY: u32 = MAX_SHARD_COUNT;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FlushTrigger {
@@ -170,10 +191,24 @@ pub struct IngestMetrics {
     /// message, so this path must not serialise every shard on one lock: a
     /// process-wide mutex here would add a contention point to the very path
     /// #865 measures and could manufacture the throughput limit it exists to
-    /// test for. Preallocated to `shard_count` by [`IngestMetrics::new`] (the
-    /// shard set is fixed for the process); `IngestMetrics::default()` allocates
-    /// none, and any shard index outside the slice is dropped rather than
-    /// counted, matching the best-effort nature of this observability.
+    /// test for.
+    ///
+    /// Preallocated by [`IngestMetrics::new`] to [`SHARD_SKEW_CAPACITY`], which
+    /// covers every shard index `write_points` can route to, not just the
+    /// configured `shard_count`. The shard set is *not* fixed for the process:
+    /// [`crate::generation::GenerationSwitch`] keeps one shard-actor set per
+    /// distinct `shard_count` seen and takes the live count from the tenant's
+    /// generation history (`ravel_catalog::active_shard_count`), so a tenant
+    /// that activates a larger generation routes to indices above
+    /// `config.shard_count` (ADR-0052 section 2). Sizing to `shard_count` would
+    /// drop exactly those shards, and dropping them biases the measurement
+    /// toward reporting *less* skew than there is, in a metric that exists to
+    /// settle a skew argument (issue #865).
+    ///
+    /// `IngestMetrics::default()` allocates none. An index at or above the
+    /// slice is still dropped rather than counted, matching the best-effort
+    /// nature of this observability; [`SHARD_SKEW_CAPACITY`] is chosen so no
+    /// generation the catalog accepts can reach that case.
     shard_skew: Box<[ShardSkewAtomics]>,
     /// Metadata-record GETs issued by the metric metadata sink's flush window
     /// (ADR-0085 decision 1). The ADR budgets one GET per tenant per window
@@ -211,11 +246,34 @@ pub struct IngestMetrics {
 /// Accumulator behind [`IngestMetrics::shard_skew`], one per shard. Each field
 /// is an independent [`AtomicU64`] so the per-message enqueue/process path
 /// updates its own shard with no lock and no cross-shard contention; the public
-/// [`ShardSkewStats`] is its point-in-time copy with `queue_depth` derived. All
-/// updates and reads use `Relaxed`: these are monotonic self-observability
-/// counters, not a synchronisation edge, so a snapshot that catches
-/// `messages_processed` incremented a moment before its matching `on_actor_ns`
-/// addend simply reports a cumulative sum one message behind, which self-heals.
+/// [`ShardSkewStats`] is its point-in-time copy with `queue_depth` derived.
+///
+/// # Ordering of the `on_actor_ns` / `messages_processed` pair
+///
+/// The two are separate atomics, so a reader cannot get an instantaneous
+/// snapshot of both. What it does get is a one-directional guarantee, which is
+/// the direction that matters for the derived mean `on_actor_ns /
+/// messages_processed`:
+///
+/// - The writer adds to `on_actor_ns` with `Relaxed`, then bumps
+///   `messages_processed` with `Release`.
+/// - [`IngestMetrics::shard_skew_by_shard`] loads `messages_processed` with
+///   `Acquire` **first**, then `on_actor_ns` with `Relaxed`.
+///
+/// The `Release`/`Acquire` pair and the release sequence formed by the chain of
+/// `fetch_add` read-modify-writes make every `on_actor_ns` addend that preceded
+/// a counted message visible to that reader. So a message can never be counted
+/// without its time, which would report the actor as *faster* than it is --
+/// precisely the direction that would manufacture evidence for the claim this
+/// metric exists to test (issue #865, and the earlier defect where permit wait
+/// was folded into `on_actor_ns`).
+///
+/// The opposite tear is still observable and is deliberate: a reader can see an
+/// `on_actor_ns` addend whose message has not yet been counted, so the mean can
+/// read high by at most one in-flight message's time per concurrent actor. Both
+/// counters are cumulative, so that self-heals on the next read. All other
+/// fields are plain `Relaxed` monotonic counters with no paired counter to tear
+/// against.
 #[derive(Debug, Default)]
 struct ShardSkewAtomics {
     messages_enqueued: AtomicU64,
@@ -339,16 +397,22 @@ pub struct IngestMetricsSnapshot {
 }
 
 impl IngestMetrics {
-    /// Metrics for a router of `shard_count` shards. Preallocates the lock-free
-    /// per-shard skew accumulators (issue #865): the shard set is fixed for the
-    /// process, so the per-message path indexes straight into the slice with no
-    /// lock. `IngestMetrics::default()` allocates none, which suits the many
-    /// tests and sinks that never touch the per-shard counters.
+    /// Metrics for a router whose generation-0 set has `shard_count` shards.
+    /// Preallocates the lock-free per-shard skew accumulators (issue #865) so
+    /// the per-message path indexes straight into the slice with no lock.
+    ///
+    /// The preallocation is [`SHARD_SKEW_CAPACITY`], not `shard_count`: a
+    /// tenant that activates a larger generation routes to shard indices above
+    /// the configured count (ADR-0052 section 2), and those must be counted
+    /// too. `shard_count` still participates only as a lower bound, for a
+    /// process configured above the catalog's own ceiling.
+    ///
+    /// `IngestMetrics::default()` allocates none, which suits the many tests
+    /// and sinks that never touch the per-shard counters.
     pub fn new(shard_count: u32) -> Self {
+        let capacity = shard_count.max(SHARD_SKEW_CAPACITY) as usize;
         IngestMetrics {
-            shard_skew: (0..shard_count)
-                .map(|_| ShardSkewAtomics::default())
-                .collect(),
+            shard_skew: (0..capacity).map(|_| ShardSkewAtomics::default()).collect(),
             ..Default::default()
         }
     }
@@ -408,13 +472,15 @@ impl IngestMetrics {
     /// on-actor serial section, excluding both the flush that runs off the
     /// actor and any flush-permit wait the caller already subtracted (issue
     /// #865). The `on_actor_ns` addend is stored before the processed count is
-    /// bumped, so a concurrent reader is at worst one message behind on the
-    /// count, never crediting a processed message with no time (see
-    /// [`ShardSkewAtomics`] on the `Relaxed` ordering).
+    /// bumped, and the count is bumped with `Release` against the `Acquire`
+    /// load in [`IngestMetrics::shard_skew_by_shard`], so a concurrent reader
+    /// is at worst one message behind on the count and never credits a
+    /// processed message with no time. See [`ShardSkewAtomics`] for why that
+    /// one direction is the one worth paying an ordering for.
     pub(crate) fn record_shard_processed(&self, shard: u32, on_actor_ns: u64) {
         if let Some(s) = self.shard_skew.get(shard as usize) {
             s.on_actor_ns.fetch_add(on_actor_ns, Ordering::Relaxed);
-            s.messages_processed.fetch_add(1, Ordering::Relaxed);
+            s.messages_processed.fetch_add(1, Ordering::Release);
         }
     }
 
@@ -447,6 +513,12 @@ impl IngestMetrics {
     /// #865). A shard with no recorded activity is simply absent. `queue_depth`
     /// is derived here as `messages_enqueued - messages_processed`, saturating
     /// at 0.
+    ///
+    /// This is not an instantaneous snapshot of all five counters: they are
+    /// independent atomics under concurrent recording. The one guarantee is
+    /// that `messages_processed` never runs ahead of the `on_actor_ns` it
+    /// belongs to; see [`ShardSkewAtomics`] for the ordering and for the bound
+    /// on the tear in the other direction.
     pub fn shard_skew_by_shard(&self) -> Vec<(u32, ShardSkewStats)> {
         // Preallocated by shard index, so iteration is already shard-ordered. A
         // shard that never enqueued or processed a message reads all-zero and is
@@ -456,7 +528,10 @@ impl IngestMetrics {
             .enumerate()
             .filter_map(|(shard, s)| {
                 let messages_enqueued = s.messages_enqueued.load(Ordering::Relaxed);
-                let messages_processed = s.messages_processed.load(Ordering::Relaxed);
+                // Acquire, and before `on_actor_ns`: pairs with the `Release`
+                // in `record_shard_processed` so every counted message's time
+                // addend is already visible below.
+                let messages_processed = s.messages_processed.load(Ordering::Acquire);
                 let on_actor_ns = s.on_actor_ns.load(Ordering::Relaxed);
                 let flush_permit_wait_ns = s.flush_permit_wait_ns.load(Ordering::Relaxed);
                 let off_actor_ns = s.off_actor_ns.load(Ordering::Relaxed);
@@ -852,6 +927,99 @@ mod tests {
                 "shard {shard} enqueued and processed counts match, so depth is 0"
             );
         }
+    }
+
+    /// The shard set is not fixed for the process: a tenant whose provisioning
+    /// record activates a larger generation routes to shard indices above
+    /// `config.shard_count` (ADR-0052 section 2, `generation.rs`). Sizing the
+    /// skew slice to `config.shard_count` dropped every one of those shards
+    /// silently, which biases the #865 measurement toward reporting less skew
+    /// than there is.
+    ///
+    /// The premise is derived here rather than asserted: `active_shard_count`
+    /// is the same pure rule `GenerationSwitch` routes on, so the shard index
+    /// under test is one the router really can produce.
+    #[test]
+    fn shard_skew_covers_indices_above_the_configured_shard_count() {
+        use ravel_catalog::{ShardGeneration, active_shard_count};
+
+        const CONFIGURED: u32 = 4;
+        let generations = vec![
+            ShardGeneration {
+                generation: 0,
+                shard_count: CONFIGURED,
+                activation_hour: 0,
+                appended_unix_ns: 0,
+            },
+            ShardGeneration {
+                generation: 1,
+                shard_count: 16,
+                activation_hour: 100,
+                appended_unix_ns: 1,
+            },
+        ];
+        let live = active_shard_count(&generations, 100);
+        assert_eq!(live, 16, "generation 1 is active at hour 100");
+        assert!(
+            live > CONFIGURED,
+            "the routed count must exceed the configured one for this test to mean anything"
+        );
+
+        let metrics = IngestMetrics::new(CONFIGURED);
+        // The highest index generation 1 routes to, well above `CONFIGURED`.
+        let shard = live - 1;
+        metrics.record_shard_enqueued(shard);
+        metrics.record_shard_enqueued(shard);
+        metrics.record_shard_enqueued(shard);
+        metrics.record_shard_processed(shard, 7_000);
+        metrics.record_shard_flush_permit_wait_ns(shard, 11);
+        metrics.record_shard_off_actor_ns(shard, 13);
+
+        // Exact values, not "an entry exists" or "some count > 0": the defect
+        // is a silently missing entry, so the assertion has to fail both when
+        // the entry is absent and when any figure in it is wrong.
+        assert_eq!(
+            metrics.shard_skew_by_shard(),
+            vec![(
+                shard,
+                ShardSkewStats {
+                    messages_enqueued: 3,
+                    messages_processed: 1,
+                    queue_depth: 2,
+                    on_actor_ns: 7_000,
+                    flush_permit_wait_ns: 11,
+                    off_actor_ns: 13,
+                }
+            )]
+        );
+    }
+
+    /// The capacity covers the whole domain a validated provisioning record can
+    /// declare, so the "index outside the slice is dropped" fallback is
+    /// unreachable for any generation the catalog accepts. Pins the top of the
+    /// range as well as the bottom: a capacity off by one at the ceiling would
+    /// lose exactly the largest reshard.
+    #[test]
+    fn shard_skew_covers_the_largest_generation_the_catalog_accepts() {
+        let metrics = IngestMetrics::new(1);
+        let highest = ravel_catalog::MAX_SHARD_COUNT - 1;
+        metrics.record_shard_enqueued(highest);
+        metrics.record_shard_processed(highest, 42);
+
+        assert_eq!(
+            metrics.shard_skew_by_shard(),
+            vec![(
+                highest,
+                ShardSkewStats {
+                    messages_enqueued: 1,
+                    messages_processed: 1,
+                    queue_depth: 0,
+                    on_actor_ns: 42,
+                    flush_permit_wait_ns: 0,
+                    off_actor_ns: 0,
+                }
+            )]
+        );
     }
 
     #[test]

--- a/crates/ravel-ingest/src/router.rs
+++ b/crates/ravel-ingest/src/router.rs
@@ -102,7 +102,10 @@ impl IngestRouter {
         clock: Arc<dyn Clock>,
         rng: Arc<dyn RngSource>,
     ) -> Self {
-        let metrics = Arc::new(IngestMetrics::default());
+        // Preallocate the lock-free per-shard skew accumulators for this
+        // router's fixed shard set (issue #865), so the per-message enqueue and
+        // process paths never contend on a shared lock.
+        let metrics = Arc::new(IngestMetrics::new(config.shard_count));
         #[cfg(feature = "stage-timing")]
         let stage_timings = Arc::new(MetricStageTimings::new());
         // Each generation's shard-actor set gets a fresh writer identity, so

--- a/crates/ravel-ingest/src/router.rs
+++ b/crates/ravel-ingest/src/router.rs
@@ -428,6 +428,10 @@ impl IngestRouter {
                 self.mark_shard_dead(&set[shard as usize]);
                 return Err(WriteError::ShardUnavailable);
             }
+            // The message is now in the shard's channel (issue #865): count it
+            // as enqueued. The actor counts it processed when it pulls it, so
+            // enqueued-minus-processed is the shard's current queue depth.
+            self.metrics.record_shard_enqueued(shard);
         }
         // Routing ends at dispatch: the strict-mode ack wait below is downstream
         // durability (merge/encode/PUT happen in the shard), not a router stage.

--- a/crates/ravel-ingest/src/shard.rs
+++ b/crates/ravel-ingest/src/shard.rs
@@ -952,7 +952,16 @@ impl ShardActor {
                 msg = self.rx.recv() => {
                     match msg {
                         Some(ShardMsg::Write { tenant, points, exemplars, ack, charge }) => {
+                            // Per-shard skew (issue #865): time the serial
+                            // on-actor section only. The flush this may open runs
+                            // in a spawned task whose time is recorded off-actor
+                            // in `flush_tenant`; `handle_write` returns once that
+                            // task is spawned, so this delta never includes it.
+                            let started_ns = self.clock.now_ns();
                             self.handle_write(tenant, points, exemplars, ack, charge).await;
+                            let on_actor_ns =
+                                self.clock.now_ns().saturating_sub(started_ns).max(0) as u64;
+                            self.metrics.record_shard_processed(self.shard, on_actor_ns);
                         }
                         Some(ShardMsg::FlushNow { done }) => {
                             self.flush_all(FlushTrigger::Manual).await;
@@ -1281,10 +1290,20 @@ impl ShardActor {
             shard: self.shard,
         };
         let ctx = Arc::clone(&self.ctx);
+        // Per-shard skew (issue #865): time the whole flush, which runs here off
+        // the actor (ADR-0067). Bracketing `run_flush` on the injected clock,
+        // rather than inside it, keeps the measurement out of the pinned-identity
+        // path and captures every exit `run_flush` takes, abandonment included.
+        let clock = Arc::clone(&self.clock);
+        let metrics = Arc::clone(&self.metrics);
+        let shard = self.shard;
         self.flushes.spawn(async move {
             let _permit = permit;
             let _guard = guard;
+            let started_ns = clock.now_ns();
             ctx.run_flush(pinned).await;
+            let off_actor_ns = clock.now_ns().saturating_sub(started_ns).max(0) as u64;
+            metrics.record_shard_off_actor_ns(shard, off_actor_ns);
         });
     }
 }

--- a/crates/ravel-ingest/src/shard.rs
+++ b/crates/ravel-ingest/src/shard.rs
@@ -10,9 +10,10 @@
 //! how many such tasks may run at once per shard via a semaphore acquired
 //! before spawning; at the bound, the acquire blocks the flush trigger (and
 //! therefore the actor's ability to pull its next message), which is exactly
-//! where backpressure is meant to propagate. The adaptive age trigger
-//! (ADR-0067 decision 3) is `age_threshold_ns`/`adaptive_age_threshold_ns`
-//! below.
+//! where backpressure is meant to propagate, and is measured as its own span
+//! (`flush_permit_wait_ns`, issue #865) rather than charged to either the
+//! actor or the flush it waits on. The adaptive age trigger (ADR-0067
+//! decision 3) is `age_threshold_ns`/`adaptive_age_threshold_ns` below.
 
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
@@ -954,13 +955,23 @@ impl ShardActor {
                         Some(ShardMsg::Write { tenant, points, exemplars, ack, charge }) => {
                             // Per-shard skew (issue #865): time the serial
                             // on-actor section only. The flush this may open runs
-                            // in a spawned task whose time is recorded off-actor
-                            // in `flush_tenant`; `handle_write` returns once that
-                            // task is spawned, so this delta never includes it.
+                            // in a spawned task, timed off-actor in `flush_tenant`.
+                            // `handle_write` returns once that task is spawned, so
+                            // this delta excludes the flush itself -- but NOT the
+                            // `max_inflight_flushes` acquire that precedes the
+                            // spawn, which at the bound parks here for a prior
+                            // flush's remaining duration. That wait is backpressure,
+                            // not actor work, and is already counted (once) as
+                            // `flush_permit_wait_ns`, so subtract it rather than let
+                            // it read as "the actor is busy" whenever flushing is
+                            // the real bottleneck.
                             let started_ns = self.clock.now_ns();
-                            self.handle_write(tenant, points, exemplars, ack, charge).await;
-                            let on_actor_ns =
+                            let permit_wait_ns = self
+                                .handle_write(tenant, points, exemplars, ack, charge)
+                                .await;
+                            let elapsed_ns =
                                 self.clock.now_ns().saturating_sub(started_ns).max(0) as u64;
+                            let on_actor_ns = elapsed_ns.saturating_sub(permit_wait_ns);
                             self.metrics.record_shard_processed(self.shard, on_actor_ns);
                         }
                         Some(ShardMsg::FlushNow { done }) => {
@@ -1010,6 +1021,10 @@ impl ShardActor {
         }
     }
 
+    /// Returns the injected-`Clock` nanoseconds this call spent parked on the
+    /// flush-permit semaphore, so the actor loop can exclude them from
+    /// `on_actor_ns` (issue #865). Zero on every path that opens no flush, and
+    /// zero when a permit was free.
     async fn handle_write(
         &mut self,
         tenant: TenantId,
@@ -1017,11 +1032,11 @@ impl ShardActor {
         exemplars: Vec<IngestExemplar>,
         ack: Option<Ack>,
         charge: Option<Arc<IngestByteCharge>>,
-    ) {
+    ) -> u64 {
         if points.is_empty() && exemplars.is_empty() && ack.is_none() {
             // Nothing buffered: drop the charge now so its bytes are refunded
             // rather than held for a message that touched no buffer.
-            return;
+            return 0;
         }
         let arrival_ns = self.clock.now_ns();
         let points_len = points.len() as u64;
@@ -1050,7 +1065,7 @@ impl ShardActor {
                 if let Some(ack) = ack {
                     self.ctx.ack_waiters(vec![ack], Err(err));
                 }
-                return;
+                return 0;
             }
         };
         // Merge times only the sample-buffer append, matching the logs merge;
@@ -1075,8 +1090,9 @@ impl ShardActor {
             .map(|b| b.est_bytes >= target_bytes)
             .unwrap_or(false);
         if should_flush && let Some(buf) = self.tenants.remove(&tenant) {
-            self.flush_tenant(tenant, buf, FlushTrigger::Size).await;
+            return self.flush_tenant(tenant, buf, FlushTrigger::Size).await;
         }
+        0
     }
 
     /// A buffer with a strict-mode waiter or at least `min_flush_bytes`
@@ -1195,7 +1211,18 @@ impl ShardActor {
     /// An empty buffer (exemplars only, no samples) never reaches the
     /// semaphore or a spawned task at all: there is nothing to encode, and a
     /// flush identity pinned for nothing would burn a `seq` for no object.
-    async fn flush_tenant(&mut self, tenant: TenantId, buf: TenantBuf, trigger: FlushTrigger) {
+    ///
+    /// Returns the injected-`Clock` nanoseconds spent parked on that semaphore
+    /// (issue #865), already recorded as this shard's `flush_permit_wait_ns`.
+    /// The return value exists only so a caller that brackets on-actor time
+    /// around this call can subtract it; callers that do not (`flush_aged`,
+    /// `flush_all`) drop it, and the counter is still recorded for them.
+    async fn flush_tenant(
+        &mut self,
+        tenant: TenantId,
+        buf: TenantBuf,
+        trigger: FlushTrigger,
+    ) -> u64 {
         let TenantBuf {
             series,
             exemplars,
@@ -1221,7 +1248,7 @@ impl ShardActor {
             // that ever changes, this returns without acking and the router
             // reads the dropped oneshot as a dead shard.
             debug_assert!(waiters.is_empty());
-            return;
+            return 0;
         }
         self.metrics.record_flush(trigger);
 
@@ -1235,7 +1262,7 @@ impl ShardActor {
                 self.metrics.record_abandoned_input_rejected();
                 self.ctx
                     .ack_waiters(waiters, Err(WriteError::SegmentBuild(msg)));
-                return;
+                return 0;
             }
         };
         let deadline_ns =
@@ -1277,6 +1304,14 @@ impl ShardActor {
         // itself awaited from `handle_write`/`flush_aged`/`flush_all`, that
         // park keeps the actor from pulling its next channel message,
         // exactly the backpressure path the bounded mpsc already relies on.
+        //
+        // Per-shard skew (issue #865): that park is its own span, bracketed on
+        // the injected clock from here to the grant. It sits between the actor's
+        // merge-and-pin work and the spawned flush's own span, and belongs to
+        // neither: what elapses here is a PRIOR flush's remaining duration, so
+        // folding it into `on_actor_ns` would report an actor bottleneck at
+        // exactly the moment flushing is the bottleneck.
+        let permit_wait_start_ns = self.clock.now_ns();
         let permit = match Arc::clone(&self.semaphore).acquire_owned().await {
             Ok(permit) => permit,
             Err(_) => panic!(
@@ -1284,6 +1319,13 @@ impl ShardActor {
                 self.shard
             ),
         };
+        let permit_wait_ns = self
+            .clock
+            .now_ns()
+            .saturating_sub(permit_wait_start_ns)
+            .max(0) as u64;
+        self.metrics
+            .record_shard_flush_permit_wait_ns(self.shard, permit_wait_ns);
         self.metrics.record_inflight_flush_delta(self.shard, 1);
         let guard = InFlightFlushGuard {
             metrics: Arc::clone(&self.metrics),
@@ -1294,6 +1336,8 @@ impl ShardActor {
         // the actor (ADR-0067). Bracketing `run_flush` on the injected clock,
         // rather than inside it, keeps the measurement out of the pinned-identity
         // path and captures every exit `run_flush` takes, abandonment included.
+        // The bracket opens inside the spawned task, with the permit already
+        // held, so the wait for that permit is not counted here as well.
         let clock = Arc::clone(&self.clock);
         let metrics = Arc::clone(&self.metrics);
         let shard = self.shard;
@@ -1305,6 +1349,7 @@ impl ShardActor {
             let off_actor_ns = clock.now_ns().saturating_sub(started_ns).max(0) as u64;
             metrics.record_shard_off_actor_ns(shard, off_actor_ns);
         });
+        permit_wait_ns
     }
 }
 

--- a/crates/ravel-ingest/tests/shard_skew.rs
+++ b/crates/ravel-ingest/tests/shard_skew.rs
@@ -1,0 +1,236 @@
+//! Per-shard ingest-skew metrics (issue #865). Drives loads through a live
+//! `IngestRouter` and asserts the per-shard message counts and the
+//! on-actor/off-actor time split, so a future argument about shard-actor
+//! throughput can rest on these figures instead of assertion.
+#![allow(clippy::expect_used)]
+
+mod common;
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use common::{SlowStore, TestClock, make_point, tenant};
+use ravel_ingest::{IngestConfig, IngestRouter, ShardSkewStats, WriteMode};
+use ravel_object_store::ObjectStoreBackend;
+use ravel_object_store::memory::MemoryStore;
+use ravel_types::{METRIC_NAME_LABEL, SeriesId, Signal, TenantId, shard_for};
+
+const BASE_NS: i64 = 1_700_000_000_000_000_000;
+
+/// A metric name whose series id routes to `target` under `shard_count`.
+/// Routing is `shard_for` over the series id's leading bytes, and the id is a
+/// hash of the labels, so the shard cannot be chosen by construction; this
+/// searches metric names until one lands on the wanted shard. Deterministic:
+/// the same tenant, name, and label set always hash to the same id.
+fn metric_for_shard(tenant: &TenantId, target: u32, shard_count: u32) -> String {
+    for i in 0..100_000u32 {
+        let name = format!("m{i}");
+        let labels = common::build_labels(&[(METRIC_NAME_LABEL, name.as_str())]);
+        let series_id = SeriesId::compute(tenant, &name, &labels).expect("series id");
+        if shard_for(&series_id, shard_count) == target {
+            return name;
+        }
+    }
+    panic!("no metric name routed to shard {target} of {shard_count}");
+}
+
+fn skew_map(router: &IngestRouter) -> HashMap<u32, ShardSkewStats> {
+    router.metrics().shard_skew_by_shard().into_iter().collect()
+}
+
+fn base_config(shard_count: u32) -> IngestConfig {
+    IngestConfig {
+        shard_count,
+        // Large so no size or age trigger fires on its own: every flush in
+        // these tests is the explicit `flush_all` drain, keeping message and
+        // time accounting driven by the test rather than by a background tick.
+        target_bytes: 8 * 1024 * 1024,
+        max_flush_delay: Duration::from_secs(3600),
+        max_flush_delay_idle: Duration::from_secs(3600),
+        flush_tick: Duration::from_secs(3600),
+        ..IngestConfig::default()
+    }
+}
+
+/// A deliberately skewed load -- eight messages to one shard, one each to two
+/// others -- must show the skew in the per-shard processed counts, pinned to
+/// the exact numbers the fixed input dictates (not merely "hot > cold").
+#[tokio::test]
+async fn skewed_load_shows_exact_per_shard_processed_counts() {
+    let shard_count = 4;
+    let clock = TestClock::new(BASE_NS);
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+    let router = IngestRouter::new(
+        base_config(shard_count),
+        Arc::clone(&store),
+        Signal::Metrics,
+        clock.clone(),
+    );
+
+    let tenant = tenant("acme");
+    let hot = metric_for_shard(&tenant, 0, shard_count);
+    let warm1 = metric_for_shard(&tenant, 1, shard_count);
+    let warm2 = metric_for_shard(&tenant, 2, shard_count);
+
+    // Each `write` sends exactly one message to the one shard its point routes
+    // to. Eight to shard 0, one to shard 1, one to shard 2; shard 3 gets none.
+    for _ in 0..8 {
+        write_one(&router, &tenant, &hot).await;
+    }
+    write_one(&router, &tenant, &warm1).await;
+    write_one(&router, &tenant, &warm2).await;
+
+    // Drain: after `flush_all` returns, every earlier Write message has been
+    // processed (the actor pulls its channel in FIFO order, so the FlushNow it
+    // acknowledges sits behind them all).
+    router.flush_all().await;
+
+    let skew = skew_map(&router);
+    assert_eq!(skew[&0].messages_processed, 8, "hot shard processed count");
+    assert_eq!(skew[&1].messages_processed, 1);
+    assert_eq!(skew[&2].messages_processed, 1);
+    assert_eq!(
+        skew.get(&3).map(|s| s.messages_processed),
+        None,
+        "a shard that received no message has no entry, not a zero row"
+    );
+    // Enqueued matches processed once drained, and the depth is empty.
+    for shard in [0u32, 1, 2] {
+        assert_eq!(
+            skew[&shard].messages_enqueued,
+            skew[&shard].messages_processed
+        );
+        assert_eq!(skew[&shard].queue_depth, 0);
+    }
+    // The skew is in the asserted direction, not just present.
+    assert!(skew[&0].messages_processed > skew[&1].messages_processed);
+    assert!(skew[&0].messages_processed > skew[&2].messages_processed);
+
+    router.shutdown().await;
+}
+
+/// An even load must produce even per-shard counts: one message each. This
+/// pins that the skew signal above is a property of the load, not an artifact
+/// of the counter (e.g. every message miscounted onto shard 0).
+#[tokio::test]
+async fn even_load_shows_even_per_shard_processed_counts() {
+    let shard_count = 4;
+    let clock = TestClock::new(BASE_NS);
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+    let router = IngestRouter::new(
+        base_config(shard_count),
+        Arc::clone(&store),
+        Signal::Metrics,
+        clock.clone(),
+    );
+
+    let tenant = tenant("acme");
+    let metrics: Vec<String> = (0..shard_count)
+        .map(|s| metric_for_shard(&tenant, s, shard_count))
+        .collect();
+    for m in &metrics {
+        write_one(&router, &tenant, m).await;
+    }
+    router.flush_all().await;
+
+    let skew = skew_map(&router);
+    assert_eq!(
+        skew.len() as u32,
+        shard_count,
+        "every shard saw one message"
+    );
+    for shard in 0..shard_count {
+        assert_eq!(
+            skew[&shard].messages_processed, 1,
+            "shard {shard} under an even load"
+        );
+        assert_eq!(skew[&shard].messages_enqueued, 1);
+        assert_eq!(skew[&shard].queue_depth, 0);
+    }
+
+    router.shutdown().await;
+}
+
+/// The on-actor/off-actor split is the point of the whole measurement: a slow
+/// flush must land its time in `off_actor_ns` (the spawned flush task) and
+/// leave `on_actor_ns` (the actor's serial merge/pin section) untouched. The
+/// slowness is injected through `SlowStore` on the injected clock, so the
+/// figure is exact and deterministic, not a wall-clock band.
+#[tokio::test]
+async fn slow_flush_time_lands_off_actor_not_on_actor() {
+    const SLOW: Duration = Duration::from_secs(5);
+    let clock = TestClock::new(BASE_NS);
+    let slow_store = Arc::new(SlowStore::new(
+        MemoryStore::new(),
+        clock.clone(),
+        "/l0/", // the data-object PUT; the commit-record PUT ("/c/") stays fast
+        SLOW,
+    ));
+    let store: Arc<dyn ObjectStoreBackend> = slow_store.clone();
+
+    let config = IngestConfig {
+        // Comfortably longer than SLOW so the flush is not abandoned: this test
+        // is about a slow-but-successful flush, not the abandonment path.
+        max_flush_lifetime: Duration::from_secs(60),
+        ..base_config(1)
+    };
+    let router = IngestRouter::new(config, Arc::clone(&store), Signal::Metrics, clock.clone());
+
+    let tenant = tenant("acme");
+    // Buffered write: acknowledged at enqueue, handled by the actor at the
+    // current clock with no store call, so the on-actor section advances the
+    // injected clock by nothing.
+    router
+        .write(
+            tenant.clone(),
+            vec![make_point(&tenant, "cpu", &[("h", "a")], 1_000, 1.0)],
+            WriteMode::Buffered,
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("buffered write acknowledged at enqueue");
+
+    // Drive the flush and, once its data PUT is genuinely in flight (stalled on
+    // the injected clock), advance the clock by exactly SLOW so the PUT
+    // completes. The flush task brackets `run_flush` on the same clock, so its
+    // recorded off-actor time is exactly SLOW.
+    tokio::join!(router.flush_all(), async {
+        while slow_store.hits() < 1 {
+            tokio::task::yield_now().await;
+        }
+        clock.advance_ns(SLOW.as_nanos() as i64);
+    });
+
+    let skew = skew_map(&router);
+    let shard0 = skew[&0];
+    assert_eq!(
+        shard0.on_actor_ns, 0,
+        "the actor's serial section did no clock-advancing work; the slow flush \
+         runs off the actor and must not be charged here"
+    );
+    assert_eq!(
+        shard0.off_actor_ns,
+        SLOW.as_nanos() as u64,
+        "the slow flush's whole duration must be charged to off-actor time"
+    );
+    assert!(
+        shard0.off_actor_ns > shard0.on_actor_ns,
+        "off-actor time must carry the flush cost, on-actor must not"
+    );
+    assert_eq!(shard0.messages_processed, 1);
+
+    router.shutdown().await;
+}
+
+async fn write_one(router: &IngestRouter, tenant: &TenantId, metric: &str) {
+    router
+        .write(
+            tenant.clone(),
+            vec![make_point(tenant, metric, &[], 1_000, 1.0)],
+            WriteMode::Buffered,
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("buffered write acknowledged at enqueue");
+}

--- a/crates/ravel-ingest/tests/shard_skew.rs
+++ b/crates/ravel-ingest/tests/shard_skew.rs
@@ -1,7 +1,20 @@
 //! Per-shard ingest-skew metrics (issue #865). Drives loads through a live
-//! `IngestRouter` and asserts the per-shard message counts and the
-//! on-actor/off-actor time split, so a future argument about shard-actor
-//! throughput can rest on these figures instead of assertion.
+//! `IngestRouter` and asserts the per-shard message counts and the three-way
+//! on-actor / flush-permit-wait / off-actor time split, so a future argument
+//! about shard-actor throughput can rest on these figures instead of assertion.
+//!
+//! The three spans and where each starts and stops:
+//!
+//! 1. `on_actor_ns`: actor pulls a `Write` off its channel -> `handle_write`
+//!    returns, minus any permit wait nested inside.
+//! 2. `flush_permit_wait_ns`: `flush_tenant` reaches the `max_inflight_flushes`
+//!    acquire -> that acquire grants.
+//! 3. `off_actor_ns`: the spawned flush task enters `run_flush` (permit held)
+//!    -> `run_flush` returns.
+//!
+//! 1 and 2 both accrue on the actor task, so they are disjoint in wall time
+//! too. 3 accrues in tasks that run concurrently with the actor, which is what
+//! ADR-0067's pipelining is for.
 #![allow(clippy::expect_used)]
 
 mod common;
@@ -11,7 +24,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use common::{SlowStore, TestClock, make_point, tenant};
-use ravel_ingest::{IngestConfig, IngestRouter, ShardSkewStats, WriteMode};
+use ravel_ingest::{IngestConfig, IngestMetrics, IngestRouter, ShardSkewStats, WriteMode};
 use ravel_object_store::ObjectStoreBackend;
 use ravel_object_store::memory::MemoryStore;
 use ravel_types::{METRIC_NAME_LABEL, SeriesId, Signal, TenantId, shard_for};
@@ -37,6 +50,16 @@ fn metric_for_shard(tenant: &TenantId, target: u32, shard_count: u32) -> String 
 
 fn skew_map(router: &IngestRouter) -> HashMap<u32, ShardSkewStats> {
     router.metrics().shard_skew_by_shard().into_iter().collect()
+}
+
+/// One shard's figures read through a metrics handle rather than the router,
+/// for tests that must call the router-consuming `shutdown` (which joins every
+/// flush task) before the final read.
+fn skew_of(metrics: &IngestMetrics, shard: u32) -> ShardSkewStats {
+    metrics
+        .shard_skew_by_shard()
+        .into_iter()
+        .collect::<HashMap<u32, ShardSkewStats>>()[&shard]
 }
 
 fn base_config(shard_count: u32) -> IngestConfig {
@@ -218,9 +241,238 @@ async fn slow_flush_time_lands_off_actor_not_on_actor() {
         shard0.off_actor_ns > shard0.on_actor_ns,
         "off-actor time must carry the flush cost, on-actor must not"
     );
+    assert_eq!(
+        shard0.flush_permit_wait_ns, 0,
+        "one flush against a free permit never parks on the semaphore"
+    );
     assert_eq!(shard0.messages_processed, 1);
 
     router.shutdown().await;
+}
+
+/// Config for the two permit-wait tests below: one shard, one flush permit, and
+/// a `target_bytes` of 1 so every write is a size trigger. The age and tick
+/// thresholds stay at `base_config`'s hour, so the only thing that opens a
+/// flush is a write, and the only thing that advances the clock is the test.
+fn contended_flush_config() -> IngestConfig {
+    IngestConfig {
+        // Any single point clears this, so every write is a size trigger.
+        target_bytes: 1,
+        // One permit: the second concurrent flush trigger must park.
+        max_inflight_flushes: 1,
+        // Comfortably longer than the whole scripted timeline, so no flush is
+        // abandoned: these tests are about slow-but-successful flushes.
+        max_flush_lifetime: Duration::from_secs(600),
+        ..base_config(1)
+    }
+}
+
+/// Spins until the shard actor has merged `n` points in total. `buffered_*` is
+/// incremented in `handle_write` before the flush trigger, and the only
+/// suspension point between that increment and the flush-permit acquire is the
+/// acquire itself, so on the current-thread runtime `#[tokio::test]` provides,
+/// observing this count from the test task means the actor has already reached
+/// (and parked on) that acquire.
+async fn await_points_merged(router: &IngestRouter, n: u64) {
+    while router.metrics().snapshot().buffered_points_total < n {
+        tokio::task::yield_now().await;
+    }
+}
+
+/// Spins until `store` has entered its artificial delay `n` times, i.e. `n`
+/// flushes have their data PUT genuinely in flight and stalled on the injected
+/// clock.
+async fn await_slow_puts(store: &SlowStore, n: u64) {
+    while store.hits() < n {
+        tokio::task::yield_now().await;
+    }
+}
+
+/// The defect this test exists for: at `max_inflight_flushes`, a size-triggered
+/// write's `handle_write` parks on the flush semaphore, and what elapses there
+/// is a PRIOR flush's remaining duration -- time `flush_tenant` already charges
+/// to `off_actor_ns`. Charging it to `on_actor_ns` as well both double-counts
+/// the interval and makes the actor read as busy at exactly the moment flushing
+/// is the bottleneck, which would manufacture evidence for the shard-actor
+/// throughput claim #865 was filed to test.
+///
+/// Fixed input, exact figures. The first flush's data PUT costs SLOW; the clock
+/// is advanced by PRE_WAIT while it is in flight and before the second write, so
+/// the actor parks for exactly the remaining SLOW - PRE_WAIT. That remainder
+/// must land in `flush_permit_wait_ns` and nowhere else -- in particular it must
+/// be strictly less than the flush it waited on, so the counter cannot be a copy
+/// of `off_actor_ns`.
+#[tokio::test]
+async fn permit_wait_lands_in_its_own_counter_not_in_on_actor() {
+    const SLOW: Duration = Duration::from_secs(5);
+    const PRE_WAIT: Duration = Duration::from_secs(2);
+    const REMAINING_NS: u64 = 3_000_000_000; // SLOW - PRE_WAIT
+
+    let clock = TestClock::new(BASE_NS);
+    let slow_store = Arc::new(SlowStore::new(
+        MemoryStore::new(),
+        clock.clone(),
+        "/l0/", // the data-object PUT; the commit-record PUT ("/c/") stays fast
+        SLOW,
+    ));
+    let store: Arc<dyn ObjectStoreBackend> = slow_store.clone();
+    let router = IngestRouter::new(
+        contended_flush_config(),
+        Arc::clone(&store),
+        Signal::Metrics,
+        clock.clone(),
+    );
+    let tenant = tenant("acme");
+
+    // Write 1 opens flush A, which takes the only permit and stalls in its data
+    // PUT until the test advances the clock.
+    write_one(&router, &tenant, "cpu").await;
+    await_slow_puts(&slow_store, 1).await;
+
+    // Burn PRE_WAIT of flush A's SLOW before the second write, so the wait the
+    // actor is about to take is a strict subset of flush A's own span.
+    clock.advance_ns(PRE_WAIT.as_nanos() as i64);
+
+    // Write 2: the actor merges it (no clock-advancing work), opens a size
+    // flush, and parks on the semaphore at the bound.
+    write_one(&router, &tenant, "cpu").await;
+    await_points_merged(&router, 2).await;
+
+    // Retire flush A's remaining SLOW - PRE_WAIT. Its permit is released, and
+    // the actor's park ends at that same instant.
+    clock.advance_ns(REMAINING_NS as i64);
+
+    // Flush B now holds the permit and stalls the same way; retire it too so
+    // both flushes reach a terminal outcome and nothing is abandoned.
+    await_slow_puts(&slow_store, 2).await;
+    clock.advance_ns(SLOW.as_nanos() as i64);
+
+    // `shutdown` consumes the router and joins every flush task, so take the
+    // metrics handle first and read the final figures through it.
+    let metrics = router.metrics_handle();
+    router.shutdown().await;
+
+    let shard0 = skew_of(&metrics, 0);
+    assert_eq!(shard0.messages_processed, 2);
+    assert_eq!(
+        shard0.flush_permit_wait_ns, REMAINING_NS,
+        "the second write parked for flush A's remaining {REMAINING_NS}ns; that is \
+         backpressure and belongs in the permit-wait span"
+    );
+    assert_eq!(
+        shard0.on_actor_ns, 0,
+        "the actor's merge-and-pin work advanced the injected clock by nothing; \
+         charging it the permit wait would report an actor bottleneck at exactly \
+         the moment flushing is the bottleneck"
+    );
+    assert_eq!(
+        shard0.off_actor_ns,
+        2 * SLOW.as_nanos() as u64,
+        "two flushes at SLOW each, measured inside the spawned tasks"
+    );
+    assert!(
+        shard0.flush_permit_wait_ns < SLOW.as_nanos() as u64,
+        "the wait is the part of flush A the actor was still parked through \
+         ({REMAINING_NS}ns of {}ns), not a second copy of that flush's whole span",
+        SLOW.as_nanos()
+    );
+
+    // Wall window on the injected clock: PRE_WAIT + REMAINING + SLOW.
+    let elapsed_ns = (clock.now() - BASE_NS) as u64;
+    assert_eq!(elapsed_ns, 2 * SLOW.as_nanos() as u64);
+    assert!(
+        shard0.on_actor_ns + shard0.flush_permit_wait_ns <= elapsed_ns,
+        "spans 1 and 2 both accrue on the actor task, so together they can never \
+         exceed the window"
+    );
+}
+
+/// The double-counting check, on a scenario whose every span is known: three
+/// size-triggered writes at `max_inflight_flushes == 1`, each flush costing
+/// SLOW, so the flush tasks are serialized and their spans tile the whole
+/// window exactly once.
+///
+/// The actor does no clock-advancing work at all here: every nanosecond in the
+/// window belongs to a flush task. So `on_actor_ns` must be 0, and
+/// `on_actor_ns + off_actor_ns` must not exceed the window -- an actor-work span
+/// and a flush span cannot both own the same wall nanosecond. Folding the permit
+/// wait into `on_actor_ns` breaks exactly that: it reports 2 * SLOW of actor
+/// work inside a 3 * SLOW window that `off_actor_ns` already accounts for in
+/// full, for 5 * SLOW of attributed work in a window that holds 3.
+#[tokio::test]
+async fn the_three_spans_do_not_double_count_a_known_window() {
+    const SLOW: Duration = Duration::from_secs(5);
+    const FLUSHES: u64 = 3;
+
+    let clock = TestClock::new(BASE_NS);
+    let slow_store = Arc::new(SlowStore::new(
+        MemoryStore::new(),
+        clock.clone(),
+        "/l0/",
+        SLOW,
+    ));
+    let store: Arc<dyn ObjectStoreBackend> = slow_store.clone();
+    let router = IngestRouter::new(
+        contended_flush_config(),
+        Arc::clone(&store),
+        Signal::Metrics,
+        clock.clone(),
+    );
+    let tenant = tenant("acme");
+
+    // Write 1 opens the first flush against a free permit.
+    write_one(&router, &tenant, "cpu").await;
+    await_slow_puts(&slow_store, 1).await;
+
+    // Writes 2 and 3 each open a flush that must park for a full SLOW: the
+    // preceding flush has only just started when its successor's write lands.
+    for merged in [2u64, 3] {
+        write_one(&router, &tenant, "cpu").await;
+        await_points_merged(&router, merged).await;
+        clock.advance_ns(SLOW.as_nanos() as i64);
+        await_slow_puts(&slow_store, merged).await;
+    }
+    // Retire the third flush.
+    clock.advance_ns(SLOW.as_nanos() as i64);
+
+    let metrics = router.metrics_handle();
+    router.shutdown().await;
+
+    let elapsed_ns = (clock.now() - BASE_NS) as u64;
+    assert_eq!(
+        elapsed_ns,
+        FLUSHES * SLOW.as_nanos() as u64,
+        "three serialized flushes at SLOW each"
+    );
+
+    let shard0 = skew_of(&metrics, 0);
+    assert_eq!(shard0.messages_processed, 3);
+
+    // The double-count assertion first, so it is what fails if the spans ever
+    // overlap again rather than being masked by an exact-figure assert above it.
+    assert!(
+        shard0.on_actor_ns + shard0.off_actor_ns <= elapsed_ns,
+        "actor work and flush execution cannot both own the same wall nanosecond: \
+         on_actor_ns={} + off_actor_ns={} exceeds the {elapsed_ns}ns window, which \
+         means one interval was counted twice",
+        shard0.on_actor_ns,
+        shard0.off_actor_ns
+    );
+    assert!(
+        shard0.on_actor_ns + shard0.flush_permit_wait_ns <= elapsed_ns,
+        "the two actor-task spans are disjoint and bounded by the window"
+    );
+
+    assert_eq!(shard0.on_actor_ns, 0);
+    assert_eq!(
+        shard0.flush_permit_wait_ns,
+        2 * SLOW.as_nanos() as u64,
+        "writes 2 and 3 each parked for one whole preceding flush"
+    );
+    assert_eq!(
+        shard0.off_actor_ns, elapsed_ns,
+        "one permit serializes the flushes, so their spans tile the window once"
+    );
 }
 
 async fn write_one(router: &IngestRouter, tenant: &TenantId, metric: &str) {

--- a/crates/ravel-ingest/tests/shard_skew.rs
+++ b/crates/ravel-ingest/tests/shard_skew.rs
@@ -219,9 +219,7 @@ async fn slow_flush_time_lands_off_actor_not_on_actor() {
     // completes. The flush task brackets `run_flush` on the same clock, so its
     // recorded off-actor time is exactly SLOW.
     tokio::join!(router.flush_all(), async {
-        while slow_store.hits() < 1 {
-            tokio::task::yield_now().await;
-        }
+        await_slow_puts(&slow_store, 1).await;
         clock.advance_ns(SLOW.as_nanos() as i64);
     });
 
@@ -267,6 +265,14 @@ fn contended_flush_config() -> IngestConfig {
     }
 }
 
+/// Upper bound on the injected-clock spin helpers below. The happy path only
+/// yields a handful of times before the condition holds, so this real-clock
+/// timeout never fires there and no injected time passes. If the actor never
+/// reaches the expected state, the wrapped spin fails naming the condition it
+/// was waiting on instead of hanging until the harness kills the whole run
+/// (issue #865 review, item 6).
+const SPIN_TIMEOUT: Duration = Duration::from_secs(30);
+
 /// Spins until the shard actor has merged `n` points in total. `buffered_*` is
 /// incremented in `handle_write` before the flush trigger, and the only
 /// suspension point between that increment and the flush-permit acquire is the
@@ -274,18 +280,36 @@ fn contended_flush_config() -> IngestConfig {
 /// observing this count from the test task means the actor has already reached
 /// (and parked on) that acquire.
 async fn await_points_merged(router: &IngestRouter, n: u64) {
-    while router.metrics().snapshot().buffered_points_total < n {
-        tokio::task::yield_now().await;
-    }
+    tokio::time::timeout(SPIN_TIMEOUT, async {
+        while router.metrics().snapshot().buffered_points_total < n {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| {
+        panic!(
+            "actor never merged {n} points within {SPIN_TIMEOUT:?}: reached {}",
+            router.metrics().snapshot().buffered_points_total
+        )
+    });
 }
 
 /// Spins until `store` has entered its artificial delay `n` times, i.e. `n`
 /// flushes have their data PUT genuinely in flight and stalled on the injected
 /// clock.
 async fn await_slow_puts(store: &SlowStore, n: u64) {
-    while store.hits() < n {
-        tokio::task::yield_now().await;
-    }
+    tokio::time::timeout(SPIN_TIMEOUT, async {
+        while store.hits() < n {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| {
+        panic!(
+            "store never reached {n} slow PUTs within {SPIN_TIMEOUT:?}: reached {}",
+            store.hits()
+        )
+    });
 }
 
 /// The defect this test exists for: at `max_inflight_flushes`, a size-triggered

--- a/crates/ravel-object-store/src/s3.rs
+++ b/crates/ravel-object-store/src/s3.rs
@@ -71,15 +71,16 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
 
 use bytes::Bytes;
 use futures::StreamExt;
 use object_store::aws::{AmazonS3, AmazonS3Builder, AwsCredentialProvider};
 use object_store::path::Path;
 use object_store::{
-    GetOptions as OsGetOptions, GetRange as OsGetRange, MultipartUpload as OsMultipartUpload,
-    ObjectStore, ObjectStoreExt, PutMode as OsPutMode, PutOptions as OsPutOptions, PutPayload,
-    UpdateVersion,
+    ClientOptions, GetOptions as OsGetOptions, GetRange as OsGetRange,
+    MultipartUpload as OsMultipartUpload, ObjectStore, ObjectStoreExt, PutMode as OsPutMode,
+    PutOptions as OsPutOptions, PutPayload, UpdateVersion,
 };
 
 use crate::{
@@ -228,6 +229,125 @@ pub struct S3Config {
     pub instance_metadata_endpoint: Option<String>,
 }
 
+/// Deliberate HTTP-client tuning for the S3 backend (#851).
+///
+/// `object_store` builds its `AmazonS3` client on inherited `ClientOptions`
+/// defaults unless a `ClientOptions` is installed: a 30 s request timeout, a
+/// 5 s connect timeout, and no pool-idle cap (reqwest's ~90 s). None of those
+/// numbers were chosen by this repo, and the request timeout in particular is
+/// a hole in the deadline model: on the read path Ravel runs (same-region S3,
+/// r6a.4xlarge, up to 10 Gbps sustained, hundreds of concurrent fetches per
+/// query) a single hung connection holds a concurrency slot for 30 s while the
+/// query's own deadline is usually shorter, so the timeout never fires as a
+/// safety net. Every value below is set on purpose, with the reasoning that
+/// set it, so a future reader can retune from evidence rather than guess.
+///
+/// This is a separate struct rather than fields on [`S3Config`] because
+/// `S3Config` is built by struct literal (no `..default`) in several crates
+/// outside this one's edit scope; adding fields there would not compile.
+/// [`S3Store::new`] applies [`S3HttpConfig::default`]; [`S3Store::with_http_config`]
+/// overrides it. The default values are the deliberate choices; the fields
+/// exist so tests and unusual deployments can set a non-default value that
+/// reaches the client.
+///
+/// **Retry interaction / worst case.** `object_store` runs its own internal
+/// retry loop per logical operation (`RetryConfig`, unchanged here: default
+/// `max_retries = 10`, `retry_timeout = 180 s`, jittered exponential backoff),
+/// and a request timeout is a *retryable* error. The loop checks its budget
+/// *before* each retry, so no new attempt starts once 180 s have elapsed since
+/// the first, but the final in-flight attempt still runs its full
+/// `request_timeout`. The worst-case wall time for one logical operation is
+/// therefore about `retry_timeout + request_timeout` = 180 s + 20 s ≈ 200 s of
+/// internal retrying. In practice every caller passes a deadline and the trait
+/// honors cancellation by drop (docs/object-store-contract.md, "Rules for
+/// callers"), so the query deadline — typically well under 180 s — bounds one
+/// operation first. Lowering `request_timeout` shortens each attempt but does
+/// not change this 180 s ceiling; only `RetryConfig` would, and tuning it is
+/// out of this change's scope.
+#[derive(Debug, Clone)]
+pub struct S3HttpConfig {
+    /// Overall per-request timeout: connect through response-body-complete.
+    ///
+    /// Inherited default is 30 s. It must stay above the tail of the single
+    /// largest request on the wire — an 8 MiB multipart part
+    /// ([`MULTIPART_PART_SIZE`]) or a whole-object GET — even on a badly
+    /// degraded connection: 8 MiB at a pathological ~5 Mbps (0.625 MB/s, ~2000x
+    /// below this box's line rate) is ~13 s, plus connect and TLS. 20 s clears
+    /// that with margin while cutting a hung connection's slot occupancy by a
+    /// third versus the inherited 30 s. It is deliberately still conservative:
+    /// there is no tail-latency measurement in this repo to justify going lower
+    /// (toward ~10 s), and a timeout below the real tail turns a slow-but-
+    /// succeeding request into a retry storm. Tighten only with a measurement.
+    pub request_timeout: Duration,
+    /// TCP + TLS connect-phase timeout.
+    ///
+    /// Inherited default is 5 s. An in-region connect completes in single-digit
+    /// to low-tens of milliseconds; the Linux initial SYN retransmit is ~1 s, so
+    /// 3 s tolerates one lost SYN with margin while failing a black-holed path
+    /// ~40% faster than the 5 s default, letting a retry re-dial a fresh 5-tuple
+    /// within a typical query deadline. AWS's own latency-sensitive guidance
+    /// (cited by `object_store`'s `ClientOptions::default`) recommends ~3.1 s.
+    pub connect_timeout: Duration,
+    /// How long an idle pooled connection is kept before it is recycled.
+    ///
+    /// Inherited default is unset (reqwest keeps idle connections ~90 s).
+    /// Hundreds of concurrent fetches per query reuse warm TLS across back-to-
+    /// back query phases (sub-second to few-second gaps), so we keep a generous
+    /// window rather than tearing connections down after each wave — but we cap
+    /// it below reqwest's ~90 s so a connection an intermediary or S3 silently
+    /// half-closed during a longer idle gap is recycled locally before it is
+    /// handed to a new request (reusing a dead socket costs a broken-pipe plus a
+    /// retry). 30 s balances warm reuse against stale-socket risk; the exact
+    /// value wants a keep-alive/idle-close measurement against the real endpoint.
+    pub pool_idle_timeout: Duration,
+    /// HTTP/2 keep-alive ping interval. See the type note on why this is inert
+    /// under the HTTP/1.1 default we keep.
+    pub http2_keep_alive_interval: Duration,
+    /// HTTP/2 keep-alive ping acknowledgement timeout. See the type note.
+    pub http2_keep_alive_timeout: Duration,
+}
+
+impl Default for S3HttpConfig {
+    fn default() -> Self {
+        S3HttpConfig {
+            request_timeout: Duration::from_secs(20),
+            connect_timeout: Duration::from_secs(3),
+            pool_idle_timeout: Duration::from_secs(30),
+            http2_keep_alive_interval: Duration::from_secs(10),
+            http2_keep_alive_timeout: Duration::from_secs(10),
+        }
+    }
+}
+
+/// Build the `object_store` [`ClientOptions`] from an [`S3HttpConfig`], setting
+/// every value #851 cares about explicitly rather than inheriting it.
+///
+/// **HTTP/2 keep-alive is set but inert under the transport we use.**
+/// `object_store`'s `ClientOptions` default is HTTP/1.1-only (arrow-rs#5194:
+/// HTTP/2 is measurably slower for the bulk transfers S3 reads are), and we do
+/// not force HTTP/2, so reqwest never negotiates it and the keep-alive ping
+/// knobs below never fire. They are set anyway so the client is correct *if* a
+/// future deployment enables HTTP/2: a black-holed connection is then detected
+/// within ~interval+timeout (≈20 s) instead of only at `request_timeout`.
+/// `with_http2_keep_alive_while_idle` extends that detection to connections
+/// sitting idle in the pool, not only those with an active stream. Under the
+/// HTTP/1.1 default that actually runs, connection liveness is covered by
+/// `connect_timeout` (dead connect), the request timeout (hung request), and
+/// `pool_idle_timeout` (stale pooled socket) instead.
+///
+/// `pool_max_idle_per_host` is deliberately left unset (no cap): hundreds of
+/// concurrent per-query fetches want a large warm pool, and an idle cap would
+/// force reconnect churn under exactly the load this deployment runs.
+fn client_options(http: &S3HttpConfig) -> ClientOptions {
+    ClientOptions::new()
+        .with_timeout(http.request_timeout)
+        .with_connect_timeout(http.connect_timeout)
+        .with_pool_idle_timeout(http.pool_idle_timeout)
+        .with_http2_keep_alive_interval(http.http2_keep_alive_interval)
+        .with_http2_keep_alive_timeout(http.http2_keep_alive_timeout)
+        .with_http2_keep_alive_while_idle()
+}
+
 /// S3 / MinIO backend implementing [`ObjectStoreBackend`] over
 /// `object_store`'s `AmazonS3` client.
 pub struct S3Store {
@@ -260,8 +380,19 @@ pub struct S3Store {
 }
 
 impl S3Store {
+    /// Build with the deliberate [`S3HttpConfig::default`] HTTP-client tuning
+    /// (#851). Every current caller uses this; it sets the request/connect/
+    /// pool-idle timeouts and HTTP/2 keep-alive explicitly rather than
+    /// inheriting `object_store`'s defaults.
     pub fn new(config: S3Config) -> Result<Self, StoreError> {
-        let (builder, credential_provider, instance_role_provider) = Self::builder(&config)?;
+        Self::with_http_config(config, S3HttpConfig::default())
+    }
+
+    /// Build with an explicit [`S3HttpConfig`], overriding the default HTTP
+    /// client tuning (#851). Exists so an unusual deployment or a test can set
+    /// a non-default timeout and have it reach the constructed client.
+    pub fn with_http_config(config: S3Config, http: S3HttpConfig) -> Result<Self, StoreError> {
+        let (builder, credential_provider, instance_role_provider) = Self::builder(&config, &http)?;
         let store = builder
             .build()
             .map_err(|e| StoreError::Permanent(format!("failed to build S3 client: {e}")))?;
@@ -354,6 +485,7 @@ impl S3Store {
     #[allow(clippy::type_complexity)]
     fn builder(
         config: &S3Config,
+        http: &S3HttpConfig,
     ) -> Result<
         (
             AmazonS3Builder,
@@ -362,9 +494,14 @@ impl S3Store {
         ),
         StoreError,
     > {
+        // Install the explicit HTTP client tuning (#851) first: the per-knob
+        // client setters below (`with_allow_http`) mutate the same
+        // `ClientOptions`, whereas `with_client_options` replaces it wholesale,
+        // so it has to come before them or it would clobber `allow_http`.
         let mut builder = AmazonS3Builder::new()
             .with_bucket_name(&config.bucket)
-            .with_region(&config.region);
+            .with_region(&config.region)
+            .with_client_options(client_options(http));
         // The inline key setters exist only under Static: `InstanceRole` never
         // signs with a static key, and setting one would be exactly the mix the
         // check below forbids.
@@ -1370,10 +1507,13 @@ mod tests {
         let config = test_config();
         assert!(config.kms_key_id.is_none());
 
-        // The historical build path, reproduced verbatim without any KMS knob.
+        // The historical build path, reproduced verbatim without any KMS knob,
+        // plus the #851 client options every build now installs (in the same
+        // position `builder` sets them, before the per-knob client setters).
         let mut baseline = AmazonS3Builder::new()
             .with_bucket_name(&config.bucket)
             .with_region(&config.region)
+            .with_client_options(client_options(&S3HttpConfig::default()))
             .with_access_key_id(&config.access_key_id)
             .with_secret_access_key(&config.secret_access_key)
             .with_allow_http(config.allow_http)
@@ -1385,7 +1525,9 @@ mod tests {
         assert_eq!(
             format!(
                 "{:?}",
-                S3Store::builder(&config).expect("no credentials file").0
+                S3Store::builder(&config, &S3HttpConfig::default())
+                    .expect("no credentials file")
+                    .0
             ),
             format!("{baseline:?}"),
             "None kms_key_id must not change the builder"
@@ -1397,7 +1539,9 @@ mod tests {
         assert_ne!(
             format!(
                 "{:?}",
-                S3Store::builder(&with_key).expect("no credentials file").0
+                S3Store::builder(&with_key, &S3HttpConfig::default())
+                    .expect("no credentials file")
+                    .0
             ),
             format!("{baseline:?}"),
             "Some kms_key_id must change the builder"
@@ -1412,16 +1556,97 @@ mod tests {
         assert_ne!(
             format!(
                 "{:?}",
-                S3Store::builder(&with_token)
+                S3Store::builder(&with_token, &S3HttpConfig::default())
                     .expect("no credentials file")
                     .0
             ),
             format!(
                 "{:?}",
-                S3Store::builder(&baseline).expect("no credentials file").0
+                S3Store::builder(&baseline, &S3HttpConfig::default())
+                    .expect("no credentials file")
+                    .0
             ),
             "a session token must change the builder"
         );
+    }
+
+    /// Every HTTP-client value #851 sets is installed on the builder `.build()`
+    /// consumes, and matches what [`client_options`] produced. The builder's
+    /// `get_config_value` is the observable seam: the built `AmazonS3` client
+    /// exposes no config readback, so a refactor that dropped
+    /// `.with_client_options(..)` in [`S3Store::builder`] would make these read
+    /// back `object_store`'s inherited defaults and fail here rather than
+    /// silently reverting the timeouts. Flip: delete the `.with_client_options`
+    /// call in `builder` and the `Timeout` case (and the inherited-vs-configured
+    /// assertion below) fail, the latter because the builder then reads the
+    /// inherited "30s".
+    #[test]
+    fn http_client_options_reach_the_builder() {
+        use object_store::ClientConfigKey;
+        use object_store::aws::AmazonS3ConfigKey;
+
+        let http = S3HttpConfig::default();
+        let reference = client_options(&http);
+        let builder = S3Store::builder(&test_config(), &http)
+            .expect("no credentials file")
+            .0;
+
+        for key in [
+            ClientConfigKey::Timeout,
+            ClientConfigKey::ConnectTimeout,
+            ClientConfigKey::PoolIdleTimeout,
+            ClientConfigKey::Http2KeepAliveInterval,
+            ClientConfigKey::Http2KeepAliveTimeout,
+            ClientConfigKey::Http2KeepAliveWhileIdle,
+        ] {
+            assert_eq!(
+                builder.get_config_value(&AmazonS3ConfigKey::Client(key)),
+                reference.get_config_value(&key),
+                "builder must carry the configured {key:?}"
+            );
+        }
+
+        // The request timeout specifically must be the deliberate value, not
+        // object_store's inherited 30 s default -- the exact hole #851 closes.
+        let inherited = ClientOptions::default().get_config_value(&ClientConfigKey::Timeout);
+        let configured =
+            builder.get_config_value(&AmazonS3ConfigKey::Client(ClientConfigKey::Timeout));
+        assert_ne!(
+            configured, inherited,
+            "the request timeout must be deliberately set, not inherited (30s)"
+        );
+    }
+
+    /// A non-default value set through the config mechanism ([`S3HttpConfig`],
+    /// applied via [`S3Store::with_http_config`]/[`S3Store::builder`]) reaches
+    /// the client, so the values are configurable and not just hard-coded.
+    #[test]
+    fn non_default_http_config_reaches_the_client() {
+        use object_store::ClientConfigKey;
+        use object_store::aws::AmazonS3ConfigKey;
+
+        let http = S3HttpConfig {
+            // Not the 20 s default, nor object_store's 30 s inherited default.
+            request_timeout: Duration::from_secs(7),
+            ..S3HttpConfig::default()
+        };
+        let builder = S3Store::builder(&test_config(), &http)
+            .expect("no credentials file")
+            .0;
+        let got = builder.get_config_value(&AmazonS3ConfigKey::Client(ClientConfigKey::Timeout));
+        assert_eq!(
+            got,
+            client_options(&http).get_config_value(&ClientConfigKey::Timeout),
+            "a non-default request timeout set through config must reach the client"
+        );
+        assert_ne!(
+            got,
+            client_options(&S3HttpConfig::default()).get_config_value(&ClientConfigKey::Timeout),
+            "the configured value must differ from the default, proving the path is live"
+        );
+        // The full construction path (build() included) accepts the override.
+        S3Store::with_http_config(test_config(), http)
+            .expect("a non-default http config must build");
     }
 
     /// Stand up a minimal always-succeeding mock IMDS on an ephemeral loopback
@@ -1500,7 +1725,7 @@ mod tests {
                 ("session_token", with_token),
                 ("credentials_file", with_file),
             ] {
-                let err = S3Store::builder(&config)
+                let err = S3Store::builder(&config, &S3HttpConfig::default())
                     .expect_err(&format!("InstanceRole + {label} must be rejected"));
                 assert!(
                     matches!(err, StoreError::Permanent(_)),
@@ -1510,7 +1735,7 @@ mod tests {
 
             // All-absent against the same working endpoint builds cleanly: the
             // rejections above are the mix guard, not a blanket refusal.
-            S3Store::builder(&clean)
+            S3Store::builder(&clean, &S3HttpConfig::default())
                 .expect("all-absent InstanceRole must build against a working IMDS");
         })
         .await
@@ -1538,16 +1763,18 @@ mod tests {
         let (instance_debug, baseline_debug) = tokio::task::spawn_blocking(move || {
             let instance_debug = format!(
                 "{:?}",
-                S3Store::builder(&instance_role)
+                S3Store::builder(&instance_role, &S3HttpConfig::default())
                     .expect("instance-role builder must construct against the mock")
                     .0
             );
-            // Every non-credential setter the InstanceRole path applies, with
-            // no key setters and no provider: the one difference must be the
-            // installed credential provider.
+            // Every non-credential setter the InstanceRole path applies (the
+            // #851 client options included), with no key setters and no
+            // provider: the one difference must be the installed credential
+            // provider.
             let mut baseline = AmazonS3Builder::new()
                 .with_bucket_name(&baseline_config.bucket)
                 .with_region(&baseline_config.region)
+                .with_client_options(client_options(&S3HttpConfig::default()))
                 .with_allow_http(baseline_config.allow_http)
                 .with_virtual_hosted_style_request(!baseline_config.force_path_style);
             if let Some(endpoint) = &baseline_config.endpoint {
@@ -1579,7 +1806,8 @@ mod tests {
         let mut config = test_config();
         config.session_token = Some("inline-token".to_string());
         config.credentials_file = Some(path);
-        let (_, provider, _) = S3Store::builder(&config).expect("valid credentials file");
+        let (_, provider, _) =
+            S3Store::builder(&config, &S3HttpConfig::default()).expect("valid credentials file");
         let provider = provider.expect("a credentials file must produce a provider");
         let credential = provider.get_credential().await.expect("file credentials");
         assert_eq!(

--- a/crates/ravel-object-store/src/s3.rs
+++ b/crates/ravel-object-store/src/s3.rs
@@ -73,7 +73,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 use futures::StreamExt;
 use object_store::aws::{AmazonS3, AmazonS3Builder, AwsCredentialProvider};
 use object_store::path::Path;
@@ -134,6 +134,61 @@ const _: () = assert!(crate::MULTIPART_MAX_PARTS * MULTIPART_PART_SIZE >= 64 * 1
 /// compactor writing several objects at once must not open an unbounded
 /// number of connections per object.
 const MULTIPART_UPLOAD_CONCURRENCY: usize = 4;
+
+/// How many of a bounded whole-object read's ranged GETs
+/// ([`S3Store::get_whole_object`]) are in flight at once. Same reasoning and
+/// same value as [`MULTIPART_UPLOAD_CONCURRENCY`] on the write side: enough
+/// parallel connections that splitting a large read does not serialise its
+/// round trips, few enough that a query fetching many objects at once does not
+/// multiply its connection count by the chunk count of each.
+const WHOLE_OBJECT_GET_CONCURRENCY: usize = 4;
+
+/// Transfer rate the per-request body bound is sized against: 5 Mbps
+/// (0.625 MB/s), roughly 2000x below this deployment's line rate (same-region
+/// S3 from an r6a.4xlarge, up to 10 Gbps sustained).
+///
+/// This is a *floor*, not an estimate: it is the rate below which a request is
+/// treated as failed rather than slow. Sizing the bound against it is what lets
+/// [`S3HttpConfig::request_timeout`] stay a fixed number while the objects
+/// Ravel reads do not — see that field for the arithmetic.
+pub const FLOOR_TRANSFER_BYTES_PER_SEC: u64 = 625_000;
+
+/// The share of [`S3HttpConfig::request_timeout`] reserved for everything that
+/// is not body transfer: TCP connect, the TLS handshake, and S3's
+/// time-to-first-byte on a degraded path. Deducted before
+/// [`S3HttpConfig::max_request_body_bytes`] converts what is left into bytes at
+/// [`FLOOR_TRANSFER_BYTES_PER_SEC`].
+///
+/// Twice the 3 s [`S3HttpConfig::connect_timeout`], so a connect that consumes
+/// its whole budget still leaves room for a slow first byte.
+const REQUEST_OVERHEAD_ALLOWANCE: Duration = Duration::from_secs(6);
+
+/// Floor on [`S3HttpConfig::max_request_body_bytes`]. Below roughly this size
+/// the per-request round trip dominates the transfer, so a whole-object read
+/// split this finely costs more in requests than the bound buys back. A
+/// `request_timeout` configured so tight that the floor binds (under
+/// `REQUEST_OVERHEAD_ALLOWANCE + 1 MiB / FLOOR_TRANSFER_BYTES_PER_SEC`, about
+/// 7.7 s) cannot satisfy the floor-bandwidth criterion at any non-degenerate
+/// chunk size; the default satisfies it with margin, and the compile-time
+/// assertion below pins that.
+const MIN_REQUEST_BODY_BYTES: usize = 1024 * 1024;
+
+/// The [`S3HttpConfig::request_timeout`] default, named so the compile-time
+/// check below can state the criterion against it.
+const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(20);
+
+// The criterion `request_timeout`'s doc comment states, checked at compile time
+// rather than left to a reader re-deriving it: the largest body any single
+// request carries (`MULTIPART_PART_SIZE`, the cap on both the multipart part
+// size and the whole-object read chunk) transfers inside the default timeout at
+// FLOOR_TRANSFER_BYTES_PER_SEC, with REQUEST_OVERHEAD_ALLOWANCE left over for
+// connect, TLS, and time-to-first-byte. Lowering the default timeout or raising
+// the part size without re-deriving the pair fails the build here.
+const _: () = assert!(
+    (MULTIPART_PART_SIZE as u64).div_ceil(FLOOR_TRANSFER_BYTES_PER_SEC)
+        + REQUEST_OVERHEAD_ALLOWANCE.as_secs()
+        <= DEFAULT_REQUEST_TIMEOUT.as_secs()
+);
 
 /// How [`S3Store`] sources AWS credentials (ADR-0106).
 ///
@@ -271,13 +326,37 @@ pub struct S3HttpConfig {
     /// Inherited default is 30 s. It must stay above the tail of the single
     /// largest request on the wire — an 8 MiB multipart part
     /// ([`MULTIPART_PART_SIZE`]) or a whole-object GET — even on a badly
-    /// degraded connection: 8 MiB at a pathological ~5 Mbps (0.625 MB/s, ~2000x
-    /// below this box's line rate) is ~13 s, plus connect and TLS. 20 s clears
-    /// that with margin while cutting a hung connection's slot occupancy by a
-    /// third versus the inherited 30 s. It is deliberately still conservative:
-    /// there is no tail-latency measurement in this repo to justify going lower
-    /// (toward ~10 s), and a timeout below the real tail turns a slow-but-
-    /// succeeding request into a retry storm. Tighten only with a measurement.
+    /// degraded connection.
+    ///
+    /// **The largest case is the read side, and it is bounded rather than
+    /// assumed.** A whole-object read is the only request whose size is set by
+    /// the data instead of by this crate: `max_l1_part_bytes` defaults to
+    /// 256 MiB, 32x an 8 MiB part, so a fixed timeout sized for a part cannot
+    /// also cover an unranged GET. [`S3Store::get`] therefore never issues one:
+    /// [`GetRange::Full`] is served as ranged requests of at most
+    /// [`S3HttpConfig::max_request_body_bytes`] each, which is derived from
+    /// *this field* — so the criterion holds for whatever value is configured
+    /// here, not only for the default.
+    ///
+    /// The arithmetic, for the largest request rather than the smallest: at the
+    /// default 20 s, [`REQUEST_OVERHEAD_ALLOWANCE`] takes 6 s for connect, TLS,
+    /// and time-to-first-byte, leaving 14 s of transfer. At a pathological
+    /// ~5 Mbps ([`FLOOR_TRANSFER_BYTES_PER_SEC`], 0.625 MB/s, ~2000x below this
+    /// box's line rate) that carries 8.75 MB, and the bound is capped at
+    /// [`MULTIPART_PART_SIZE`] (8 MiB = 8.39 MB, ~13.4 s at the floor) so read
+    /// and write share one largest-request-on-the-wire. A 256 MiB L1 compaction
+    /// part is then 32 requests that each fit the timeout, not one ~410 s
+    /// request against a 20 s ceiling that can only time out and burn the retry
+    /// budget re-attempting a request that never fits. A compile-time assertion
+    /// next to those constants pins the inequality.
+    ///
+    /// 20 s also cuts a hung connection's slot occupancy by a third versus the
+    /// inherited 30 s. It is deliberately still conservative: there is no
+    /// tail-latency measurement in this repo to justify going lower (toward
+    /// ~10 s), and a timeout below the real tail turns a slow-but-succeeding
+    /// request into a retry storm. Tighten only with a measurement — and note
+    /// that tightening it also shrinks `max_request_body_bytes`, so a
+    /// whole-object read pays it back in extra requests.
     pub request_timeout: Duration,
     /// TCP + TLS connect-phase timeout.
     ///
@@ -307,10 +386,40 @@ pub struct S3HttpConfig {
     pub http2_keep_alive_timeout: Duration,
 }
 
+impl S3HttpConfig {
+    /// The largest body a single request may carry and still finish inside
+    /// [`S3HttpConfig::request_timeout`] at [`FLOOR_TRANSFER_BYTES_PER_SEC`],
+    /// after [`REQUEST_OVERHEAD_ALLOWANCE`] is set aside for connect, TLS, and
+    /// time-to-first-byte.
+    ///
+    /// This is what makes the timeout's criterion something the code satisfies
+    /// rather than something the doc asserts: [`S3Store::get`] splits a
+    /// [`GetRange::Full`] read into ranged requests of at most this many bytes,
+    /// so no request on the wire is larger than the timeout can carry. Capped
+    /// at [`MULTIPART_PART_SIZE`] so the read and write paths share one largest
+    /// request, and floored at [`MIN_REQUEST_BODY_BYTES`] so an extremely tight
+    /// configured timeout degrades into more requests rather than into
+    /// unboundedly many.
+    ///
+    /// A caller-supplied [`GetRange::Range`] is *not* bounded by this: the
+    /// caller asked for exactly those bytes, and silently splitting a range the
+    /// caller sized itself would hide the cost from the code that chose it.
+    pub fn max_request_body_bytes(&self) -> usize {
+        let transfer_budget = self
+            .request_timeout
+            .saturating_sub(REQUEST_OVERHEAD_ALLOWANCE);
+        let millis = u64::try_from(transfer_budget.as_millis()).unwrap_or(u64::MAX);
+        let bytes = millis.saturating_mul(FLOOR_TRANSFER_BYTES_PER_SEC) / 1000;
+        usize::try_from(bytes)
+            .unwrap_or(usize::MAX)
+            .clamp(MIN_REQUEST_BODY_BYTES, MULTIPART_PART_SIZE)
+    }
+}
+
 impl Default for S3HttpConfig {
     fn default() -> Self {
         S3HttpConfig {
-            request_timeout: Duration::from_secs(20),
+            request_timeout: DEFAULT_REQUEST_TIMEOUT,
             connect_timeout: Duration::from_secs(3),
             pool_idle_timeout: Duration::from_secs(30),
             http2_keep_alive_interval: Duration::from_secs(10),
@@ -353,6 +462,11 @@ fn client_options(http: &S3HttpConfig) -> ClientOptions {
 pub struct S3Store {
     store: AmazonS3,
     page_size: usize,
+    /// Largest body [`S3Store::get_whole_object`] asks for in one request,
+    /// resolved once from the [`S3HttpConfig`] this store was built with
+    /// ([`S3HttpConfig::max_request_body_bytes`]) so the per-request derivation
+    /// is not repeated on every read.
+    max_get_chunk: usize,
     /// `Some` only when [`S3Config::credentials_file`] was set; kept
     /// alongside the `AmazonS3` client (which holds its own clone as an
     /// opaque `object_store::CredentialProvider` trait object) purely so
@@ -399,6 +513,7 @@ impl S3Store {
         Ok(S3Store {
             store,
             page_size: LIST_PAGE_SIZE,
+            max_get_chunk: http.max_request_body_bytes(),
             credential_provider,
             instance_role_provider,
             multipart_abort_failures: AtomicU64::new(0),
@@ -1069,6 +1184,165 @@ impl S3Store {
             }
         }
     }
+
+    /// One GET, ranged or not, reduced to the three things this adapter needs
+    /// from it. `if_match` rides along as an `If-Match` precondition, used by
+    /// [`S3Store::get_whole_object`] to pin every request of a split read to
+    /// one version of the object.
+    async fn get_one(
+        &self,
+        key: &str,
+        range: Option<OsGetRange>,
+        if_match: Option<String>,
+    ) -> Result<GetChunk, StoreError> {
+        let result = self
+            .store
+            .get_opts(
+                &path_of(key),
+                OsGetOptions {
+                    range,
+                    if_match,
+                    ..Default::default()
+                },
+            )
+            .await
+            .map_err(map_get_error)?;
+        let etag = result
+            .meta
+            .e_tag
+            .clone()
+            .ok_or_else(|| StoreError::Permanent(format!("S3 returned no ETag for {key}")))?;
+        // For a partial response this is the total object size parsed out of
+        // `Content-Range`, not the length of the slice returned, which is what
+        // makes one bounded request enough to learn how many more to issue.
+        let total_size = result.meta.size;
+        let data = result.bytes().await.map_err(map_error_common)?;
+        Ok(GetChunk {
+            data,
+            etag,
+            total_size,
+        })
+    }
+
+    /// [`GetRange::Full`] as bounded requests: complete-object semantics for
+    /// the caller, no single request larger than
+    /// [`S3HttpConfig::max_request_body_bytes`] on the wire.
+    ///
+    /// An unranged GET is the only request this adapter issues whose size the
+    /// data decides rather than this crate, so it is the one that can outgrow
+    /// [`S3HttpConfig::request_timeout`] — a 256 MiB L1 compaction part cannot
+    /// finish inside 20 s at the floor rate the timeout is sized against, and
+    /// retrying it only re-runs a request that never fits. Splitting it makes
+    /// every request one the timeout can carry.
+    ///
+    /// **Cost.** An object at or below the chunk size is exactly one request,
+    /// as before; above it, `ceil(size / chunk)` requests, up to
+    /// [`WHOLE_OBJECT_GET_CONCURRENCY`] of them in flight. Wire bytes are
+    /// unchanged (the ranges partition the object exactly and none overlap)
+    /// apart from one extra set of response headers per additional request;
+    /// neither figure counts `object_store`'s internal retries, which sit
+    /// inside each request.
+    ///
+    /// **One version, or an error.** Every request after the first carries the
+    /// first's ETag as an `If-Match`, so an object overwritten mid-read fails
+    /// the read instead of splicing two versions into one buffer. Data objects
+    /// are immutable, so this is a guard on the mutable-pointer keys, and those
+    /// are small enough to take the single-request path anyway.
+    async fn get_whole_object(&self, key: &str) -> Result<GetOutcome, StoreError> {
+        let chunk = self.max_get_chunk as u64;
+        let first = match self
+            .get_one(key, Some(OsGetRange::Bounded(0..chunk)), None)
+            .await
+        {
+            Ok(first) => first,
+            // A zero-byte object has no satisfiable range, so a ranged request
+            // for one is a 416. That is the single whole-object read the
+            // bounded form cannot express; re-issue it unranged, where an empty
+            // body is a legal 200. `GetRange::Full` carries no caller range, so
+            // an unsatisfiable range here can only mean an empty object.
+            Err(StoreError::InvalidRange(_)) => {
+                let whole = self.get_one(key, None, None).await?;
+                return Ok(GetOutcome {
+                    data: whole.data,
+                    etag: Etag(whole.etag.clone()),
+                    version: Version(whole.etag),
+                    total_size: whole.total_size,
+                });
+            }
+            Err(e) => return Err(e),
+        };
+
+        let total_size = first.total_size;
+        if first.data.len() as u64 >= total_size {
+            return Ok(GetOutcome {
+                data: first.data,
+                etag: Etag(first.etag.clone()),
+                version: Version(first.etag),
+                total_size,
+            });
+        }
+
+        let mut ranges = Vec::new();
+        let mut offset = first.data.len() as u64;
+        while offset < total_size {
+            let end = (offset + chunk).min(total_size);
+            ranges.push(offset..end);
+            offset = end;
+        }
+
+        let capacity = usize::try_from(total_size).map_err(|_| {
+            StoreError::Permanent(format!(
+                "get of {key}: object of {total_size} bytes does not fit in memory"
+            ))
+        })?;
+        let mut data = BytesMut::with_capacity(capacity);
+        data.extend_from_slice(&first.data);
+
+        // `buffered`, not `buffer_unordered`: the pieces are concatenated in
+        // issue order, so they must be yielded in issue order.
+        let etag = first.etag.clone();
+        {
+            let mut inflight = futures::stream::iter(ranges.into_iter().map(|range| {
+                self.get_one(key, Some(OsGetRange::Bounded(range)), Some(etag.clone()))
+            }))
+            .buffered(WHOLE_OBJECT_GET_CONCURRENCY);
+            while let Some(piece) = inflight.next().await {
+                let piece = piece.map_err(|e| match e {
+                    // The `If-Match` failed: the object was overwritten between
+                    // this read's first request and this one. Retryable,
+                    // because a fresh read sees one consistent version.
+                    StoreError::PreconditionFailed => StoreError::Transient(format!(
+                        "get of {key}: object was overwritten during a bounded whole-object read"
+                    )),
+                    other => other,
+                })?;
+                data.extend_from_slice(&piece.data);
+            }
+        }
+
+        if data.len() as u64 != total_size {
+            return Err(StoreError::Transient(format!(
+                "get of {key}: assembled {} bytes from bounded requests, expected {total_size}",
+                data.len()
+            )));
+        }
+        Ok(GetOutcome {
+            data: data.freeze(),
+            etag: Etag(first.etag.clone()),
+            version: Version(first.etag),
+            total_size,
+        })
+    }
+}
+
+/// One GET response reduced to what [`ObjectStoreBackend::get`] needs:
+/// the bytes it returned, the object's ETag, and the object's *total* size
+/// (from `Content-Range` on a partial response, so it is the whole object's
+/// size even when the body is one chunk of it).
+struct GetChunk {
+    data: Bytes,
+    etag: String,
+    total_size: u64,
 }
 
 #[async_trait::async_trait]
@@ -1137,7 +1411,10 @@ impl ObjectStoreBackend for S3Store {
 
     async fn get(&self, key: &str, range: GetRange) -> Result<GetOutcome, StoreError> {
         let os_range = match range {
-            GetRange::Full => None,
+            // The one request whose size the caller does not choose, so the one
+            // that has to be bounded here to stay inside
+            // `S3HttpConfig::request_timeout`.
+            GetRange::Full => return self.get_whole_object(key).await,
             GetRange::Range(start, end) => {
                 if start >= end {
                     return Err(StoreError::InvalidRange(format!(
@@ -1151,30 +1428,12 @@ impl ObjectStoreBackend for S3Store {
             }
             GetRange::Suffix(n) => Some(OsGetRange::Suffix(n)),
         };
-        let path = path_of(key);
-        let result = self
-            .store
-            .get_opts(
-                &path,
-                OsGetOptions {
-                    range: os_range,
-                    ..Default::default()
-                },
-            )
-            .await
-            .map_err(map_get_error)?;
-        let etag = result
-            .meta
-            .e_tag
-            .clone()
-            .ok_or_else(|| StoreError::Permanent(format!("S3 returned no ETag for {key}")))?;
-        let total_size = result.meta.size;
-        let data = result.bytes().await.map_err(map_error_common)?;
+        let chunk = self.get_one(key, os_range, None).await?;
         Ok(GetOutcome {
-            data,
-            etag: Etag(etag.clone()),
-            version: Version(etag),
-            total_size,
+            data: chunk.data,
+            etag: Etag(chunk.etag.clone()),
+            version: Version(chunk.etag),
+            total_size: chunk.total_size,
         })
     }
 

--- a/crates/ravel-object-store/tests/s3_http_faults.rs
+++ b/crates/ravel-object-store/tests/s3_http_faults.rs
@@ -54,7 +54,7 @@ use axum::http::{HeaderMap, Method, StatusCode, Uri, header};
 use axum::response::Response;
 use bytes::Bytes;
 use parking_lot::Mutex;
-use ravel_object_store::s3::{MULTIPART_THRESHOLD, S3Config, S3Store};
+use ravel_object_store::s3::{MULTIPART_THRESHOLD, S3Config, S3HttpConfig, S3Store};
 use ravel_object_store::{GetRange, ObjectStoreBackend, PutOptions, StoreError};
 
 /// Bucket name the fake serves. Path-style requests put it in the first path
@@ -122,14 +122,28 @@ enum Fault {
     DropMidResponse,
 }
 
-/// One request as the server saw it: which operation, which key, when, and
-/// which fault (if any) was served for it.
+/// One request as the server saw it: which operation, which key, when, which
+/// fault (if any) was served for it, and the byte range it asked for.
+///
+/// `range` is what makes "the adapter bounded this read" observable from the
+/// server side rather than inferred from the bytes that came back.
 #[derive(Clone, Debug)]
 struct Seen {
     op: Op,
     key: String,
     at: Instant,
     fault: Option<Fault>,
+    /// Inclusive `[start, end]` from the request's `Range` header, absent for
+    /// an unranged request.
+    range: Option<(u64, u64)>,
+}
+
+impl Seen {
+    /// Bytes this request asked for, or `None` if it was unranged (i.e. asked
+    /// for the whole object, however large that turns out to be).
+    fn range_len(&self) -> Option<u64> {
+        self.range.map(|(start, end)| end - start + 1)
+    }
 }
 
 #[derive(Default)]
@@ -164,12 +178,13 @@ impl FakeState {
         self.always.lock().get(&op).copied()
     }
 
-    fn record(&self, op: Op, key: &str, fault: Option<Fault>) {
+    fn record(&self, op: Op, key: &str, fault: Option<Fault>, range: Option<(u64, u64)>) {
         self.log.lock().push(Seen {
             op,
             key: key.to_string(),
             at: Instant::now(),
             fault,
+            range,
         });
     }
 }
@@ -209,7 +224,19 @@ impl FakeS3 {
     /// [`S3Config::endpoint`] override. No new configuration surface: this is
     /// the same field a MinIO deployment sets.
     fn store(&self) -> S3Store {
-        S3Store::new(S3Config {
+        S3Store::new(self.config()).expect("a fake-endpoint S3Store must build")
+    }
+
+    /// The same store under an explicit [`S3HttpConfig`]. Used by the bounded
+    /// whole-object read tests: the read chunk is derived from
+    /// `request_timeout`, so a shorter timeout gives a small enough chunk to
+    /// exercise splitting on a test-sized object.
+    fn store_with_http(&self, http: S3HttpConfig) -> S3Store {
+        S3Store::with_http_config(self.config(), http).expect("a fake-endpoint S3Store must build")
+    }
+
+    fn config(&self) -> S3Config {
+        S3Config {
             bucket: BUCKET.to_string(),
             region: "us-east-1".to_string(),
             endpoint: Some(format!("http://{}", self.addr)),
@@ -222,8 +249,7 @@ impl FakeS3 {
             credentials_file: None,
             auth: Default::default(),
             instance_metadata_endpoint: None,
-        })
-        .expect("a fake-endpoint S3Store must build")
+        }
     }
 
     /// Serve `faults` in order for the next N requests of `op`, then serve
@@ -349,27 +375,53 @@ fn error_response(status: StatusCode, code: &str, message: &str) -> Response {
     )
 }
 
-/// A 200 whose body starts and then stops short of the declared
+/// A response whose body starts and then stops short of the declared
 /// `Content-Length`. hyper aborts the connection when the body stream errors,
 /// so the client sees a message that ended early.
-fn drop_mid_response() -> Response {
+///
+/// Answers a ranged request 206 with a matching `Content-Range`, exactly as a
+/// real endpoint would. Serving 200 to a ranged request instead would be
+/// rejected as a non-partial response before the body was ever read, so the
+/// injected mid-body drop would never be what the test exercised.
+fn drop_mid_response(headers: &HeaderMap) -> Response {
     let stream = futures::stream::iter(vec![
         Ok::<Bytes, std::io::Error>(Bytes::from_static(b"partial-object-prefix")),
         Err(std::io::Error::other(
             "injected mid-response connection drop",
         )),
     ]);
-    build(
-        StatusCode::OK,
-        vec![
-            (header::ETAG, "\"dropped\"".to_string()),
-            (header::LAST_MODIFIED, LAST_MODIFIED.to_string()),
-            // Far more than the stream delivers, so the client's read ends
-            // early rather than looking like a complete short object.
-            (header::CONTENT_LENGTH, "65536".to_string()),
-        ],
-        Body::from_stream(stream),
-    )
+    let mut response_headers = vec![
+        (header::ETAG, "\"dropped\"".to_string()),
+        (header::LAST_MODIFIED, LAST_MODIFIED.to_string()),
+    ];
+    // Declared length is far more than the stream delivers in either case, so
+    // the client's read ends early rather than looking like a complete short
+    // object.
+    let status = match requested_range(headers) {
+        Some((start, end)) => {
+            response_headers.push((
+                header::CONTENT_RANGE,
+                format!("bytes {start}-{end}/{}", end + 1),
+            ));
+            response_headers.push((header::CONTENT_LENGTH, (end - start + 1).to_string()));
+            StatusCode::PARTIAL_CONTENT
+        }
+        None => {
+            response_headers.push((header::CONTENT_LENGTH, "65536".to_string()));
+            StatusCode::OK
+        }
+    };
+    build(status, response_headers, Body::from_stream(stream))
+}
+
+/// The inclusive `[start, end]` a `Range: bytes=start-end` header asks for.
+/// `None` for an absent header or any form this fake does not need to parse
+/// (an open-ended or suffix range), which the adapter's bounded reads never
+/// send.
+fn requested_range(headers: &HeaderMap) -> Option<(u64, u64)> {
+    let spec = headers.get(header::RANGE)?.to_str().ok()?;
+    let (start, end) = spec.strip_prefix("bytes=")?.split_once('-')?;
+    Some((start.parse().ok()?, end.parse().ok()?))
 }
 
 /// Serve a `Range` header against `data`, or the whole object when absent.
@@ -428,7 +480,7 @@ async fn handle(
         .unwrap_or_default();
 
     let fault = state.take_fault(op);
-    state.record(op, &key, fault);
+    state.record(op, &key, fault, requested_range(&headers));
 
     match fault {
         Some(Fault::ServiceUnavailable) => error_response(
@@ -459,7 +511,7 @@ async fn handle(
             "AccessDenied",
             "Access Denied by the fake endpoint.",
         ),
-        Some(Fault::DropMidResponse) => drop_mid_response(),
+        Some(Fault::DropMidResponse) => drop_mid_response(&headers),
         Some(Fault::Pass) | None => serve(&state, op, &key, &query, &headers, data),
     }
 }
@@ -906,6 +958,223 @@ async fn connection_dropped_mid_response_surfaces_retryable() {
             StoreError::Transient(_) | StoreError::Timeout | StoreError::Throttled { .. }
         ),
         "a dropped connection must classify as a transport failure, got {error:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Bounded whole-object reads
+// ---------------------------------------------------------------------------
+
+/// An [`S3HttpConfig`] whose read chunk is 1 MiB, so a test-sized object is
+/// enough to exercise splitting.
+///
+/// 7 s of `request_timeout` minus the 6 s connect/TLS/first-byte allowance
+/// leaves 1 s of transfer, which carries 625 000 bytes at the 5 Mbps floor the
+/// bound is sized against; that is under the 1 MiB minimum chunk, so the bound
+/// floors there. Asserted below rather than assumed, so a change to any of the
+/// three constants surfaces here instead of silently changing what these tests
+/// cover.
+fn small_chunk_http() -> S3HttpConfig {
+    S3HttpConfig {
+        request_timeout: Duration::from_secs(7),
+        ..Default::default()
+    }
+}
+
+/// A distinguishable byte at every offset, so a read that concatenates its
+/// pieces in the wrong order, drops one, or overlaps two fails on content and
+/// not only on length.
+fn patterned(len: usize) -> Vec<u8> {
+    (0..len).map(|i| (i % 251) as u8).collect()
+}
+
+/// The property [`S3HttpConfig::request_timeout`]'s stated criterion rests on:
+/// no single request carries more than the timeout can transfer at the floor
+/// rate, *including* a whole-object read, whose size the data chooses rather
+/// than this crate.
+///
+/// Before this was fixed, `GetRange::Full` mapped straight to an unranged GET,
+/// so a 256 MiB L1 compaction part went out as one request against a 20 s
+/// ceiling it needs ~410 s to satisfy at that floor rate: it could only time
+/// out, and then spend the retry budget re-issuing a request that never fits.
+/// The assertion is on what the *server* saw, so a client that still sent one
+/// unranged GET cannot pass it.
+#[tokio::test]
+async fn whole_object_read_is_split_into_requests_the_timeout_can_carry() {
+    let fake = FakeS3::start().await;
+    let http = small_chunk_http();
+    let bound = http.max_request_body_bytes();
+    assert_eq!(
+        bound,
+        1024 * 1024,
+        "this test's object size is written against a 1 MiB bound"
+    );
+    let store = fake.store_with_http(http);
+
+    // Deliberately not a multiple of the bound: the final request is short, so
+    // an off-by-one in the range arithmetic shows up as wrong bytes.
+    let size = 5 * bound + 123;
+    let object = patterned(size);
+    fake.seed("fault/bounded-read", &object);
+
+    let outcome = store
+        .get("fault/bounded-read", GetRange::Full)
+        .await
+        .expect("a bounded whole-object read must return the object");
+
+    // Complete-object semantics for the caller: same bytes, same total size.
+    assert_eq!(outcome.data.len(), size, "every byte of the object arrived");
+    assert_eq!(
+        &outcome.data[..],
+        &object[..],
+        "bytes are exact and in order"
+    );
+    assert_eq!(outcome.total_size, size as u64);
+
+    let gets = fake.requests(Op::Get);
+    assert_eq!(
+        gets.len(),
+        size.div_ceil(bound),
+        "the read must be issued as ceil(size / bound) requests, saw {gets:?}"
+    );
+    for seen in &gets {
+        let len = seen
+            .range_len()
+            .expect("every request of a bounded read carries a Range header");
+        assert!(
+            len <= bound as u64,
+            "a request asked for {len} bytes, above the {bound}-byte bound the \
+             request timeout is sized for"
+        );
+    }
+    // The ranges partition the object exactly: no gap, no overlap, so wire
+    // bytes are the object's size and not more.
+    let mut covered: Vec<(u64, u64)> = gets.iter().filter_map(|seen| seen.range).collect();
+    covered.sort_unstable();
+    let mut next = 0u64;
+    for (start, end) in covered {
+        assert_eq!(start, next, "ranges must be contiguous from 0");
+        next = end + 1;
+    }
+    assert_eq!(
+        next, size as u64,
+        "the ranges together must cover exactly the object"
+    );
+}
+
+/// The cost of the fix is bounded to objects that need it: an object at or
+/// under the chunk bound is still exactly one request, as it was before.
+/// Pinned because a request is the expensive unit on this store, and the
+/// overwhelming majority of reads here (footers, index objects, commit
+/// records) sit far below the bound.
+#[tokio::test]
+async fn whole_object_read_below_the_bound_stays_one_request() {
+    let fake = FakeS3::start().await;
+    let http = small_chunk_http();
+    let bound = http.max_request_body_bytes();
+    let store = fake.store_with_http(http);
+
+    let object = patterned(bound);
+    fake.seed("fault/exactly-one-chunk", &object);
+
+    let outcome = store
+        .get("fault/exactly-one-chunk", GetRange::Full)
+        .await
+        .expect("an object at the bound must read in one request");
+    assert_eq!(&outcome.data[..], &object[..]);
+    assert_eq!(
+        fake.count(Op::Get),
+        1,
+        "an object at or below the bound costs exactly one request"
+    );
+}
+
+/// A zero-byte object has no satisfiable range, so the bounded form cannot
+/// express it and a real endpoint answers 416. The read must still succeed and
+/// return an empty object, at the cost of one extra unranged request -- the one
+/// case where the split path issues more requests than bytes require.
+#[tokio::test]
+async fn whole_object_read_of_an_empty_object_falls_back_to_unranged() {
+    let fake = FakeS3::start().await;
+    let store = fake.store_with_http(small_chunk_http());
+    fake.seed("fault/empty", b"");
+
+    let outcome = store
+        .get("fault/empty", GetRange::Full)
+        .await
+        .expect("a zero-byte object must read as an empty object, not an InvalidRange error");
+    assert!(outcome.data.is_empty());
+    assert_eq!(outcome.total_size, 0);
+
+    let gets = fake.requests(Op::Get);
+    assert_eq!(gets.len(), 2, "one refused ranged probe, then one unranged");
+    assert!(
+        gets[0].range.is_some() && gets[1].range.is_none(),
+        "the fallback must be the unranged form, saw {gets:?}"
+    );
+}
+
+/// A caller-supplied range is passed through untouched, however large. The
+/// caller sized that request itself, and splitting it here would hide the cost
+/// from the code that chose it; the bound exists for `GetRange::Full`, which
+/// carries no caller-chosen size.
+#[tokio::test]
+async fn a_caller_supplied_range_is_never_split() {
+    let fake = FakeS3::start().await;
+    let http = small_chunk_http();
+    let bound = http.max_request_body_bytes();
+    let store = fake.store_with_http(http);
+
+    let object = patterned(4 * bound);
+    fake.seed("fault/caller-range", &object);
+
+    let wanted = 3 * bound;
+    let outcome = store
+        .get("fault/caller-range", GetRange::Range(0, wanted as u64))
+        .await
+        .expect("a caller range must be served");
+    assert_eq!(&outcome.data[..], &object[..wanted]);
+
+    let gets = fake.requests(Op::Get);
+    assert_eq!(
+        gets.len(),
+        1,
+        "one caller range is one request, saw {gets:?}"
+    );
+    assert_eq!(gets[0].range_len(), Some(wanted as u64));
+}
+
+/// The bound is derived from `request_timeout`, so the criterion holds for a
+/// configured value and not only for the default. Pins both ends of the clamp:
+/// the default sits at the 8 MiB cap that the multipart part size sets, and a
+/// very tight timeout floors at 1 MiB rather than shrinking without limit.
+#[tokio::test]
+async fn the_request_body_bound_tracks_the_configured_timeout() {
+    let default = S3HttpConfig::default();
+    assert_eq!(
+        default.max_request_body_bytes(),
+        8 * 1024 * 1024,
+        "the default timeout's transfer budget is capped at the multipart part size"
+    );
+
+    let tight = S3HttpConfig {
+        request_timeout: Duration::from_secs(1),
+        ..Default::default()
+    };
+    assert_eq!(
+        tight.max_request_body_bytes(),
+        1024 * 1024,
+        "a timeout below the overhead allowance floors the bound rather than reaching zero"
+    );
+
+    let middling = S3HttpConfig {
+        request_timeout: Duration::from_secs(14),
+        ..Default::default()
+    };
+    assert_eq!(
+        middling.max_request_body_bytes(),
+        8 * 625_000,
+        "8 s of transfer budget at the 5 Mbps floor is 5 MB, under the cap"
     );
 }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -385,17 +385,22 @@ refused with 403. There is no separate platform-operator credential in
 `ravel-server` today, so folding a tenant means holding that tenant's
 credential.
 
-**Admission.** Concurrent calls for one `(tenant, signal)` collapse into a
-single fold, through the same request-coalescing primitive the read cache
-uses: one call runs the fold, the others wait on its result and issue no
-object-store work at all, and each response reports which it was in
-`coalesced`. That is the route's admission gate. A fold LISTs commit records,
-GETs parts, and PUTs new parts plus `HEAD` whether or not anything turns out
-to be eligible, and a credential resolves to exactly one tenant, so this
-bounds any one caller to a single in-flight fold per signal. The route takes
-no query-admission permit: a fold is deferred maintenance traffic, runs on
-the background store handle (ADR-0070) like the scheduled fold, and must not
-be charged against the query hot path's ceiling.
+**Admission.** A fold LISTs commit records, GETs parts, and PUTs new parts
+plus `HEAD` whether or not anything turns out to be eligible, so two gates keep
+a caller from multiplying that cost. Concurrent calls for one `(tenant,
+signal)` collapse into a single fold, through the same request-coalescing
+primitive the read cache uses: one call runs the fold, the others wait on its
+result and issue no object-store work at all, and each response reports which
+it was in `coalesced`. That bounds concurrency, not rate: sequential calls do
+not overlap, so coalescing alone would let a caller run one full fold per call.
+The rate gate closes that: before folding, the route reads `HEAD` and, if it
+was published more recently than the fold interval (the same value the
+scheduled loop skips a tick on), returns `throttled` without listing anything.
+A credential resolves to exactly one tenant, so together the two gates bound
+any one caller to a single fold per signal per interval. The route takes no
+query-admission permit: a fold is deferred maintenance traffic, runs on the
+background store handle (ADR-0070) like the scheduled fold, and must not be
+charged against the query hot path's ceiling.
 
 **Concurrency.** Safe to call concurrently with the scheduled fold and with
 itself. A fold publishes through the `HEAD` CAS protocol
@@ -403,15 +408,16 @@ itself. A fold publishes through the `HEAD` CAS protocol
 corruption; the endpoint takes no lock over the catalog, and the coalescing
 above never queues behind a fold this process did not start.
 
-**Outcomes.** Every completed call is 200 and names one of three statuses,
-because "published a snapshot" and "there was nothing to publish" are
-different facts an operator has to tell apart:
+**Outcomes.** Every completed call is 200 and names one of four statuses,
+because "published a snapshot", "there was nothing to publish", and "a fold ran
+too recently to run another" are different facts an operator has to tell apart:
 
 | `status` | Meaning |
 |---|---|
 | `published` | A new snapshot was published: `HEAD` now names content that differs from what it named before. |
 | `nothing_eligible` | No commit was eligible to fold. The response's `head_advanced` says whether the sealing watermark still moved (`true`, a watermark-only rewrite over empty hours) or `HEAD` was untouched (`false`). |
 | `lost_cas` | A concurrent fold (the scheduled loop, or another call) won the `HEAD` CAS. That fold's snapshot is the current `HEAD`; this call published none. |
+| `throttled` | The rate gate declined to fold because `HEAD` was published more recently than the fold interval. No listing ran, so this call makes no eligibility claim; it is deliberately distinct from `nothing_eligible`, which asserts a negative the throttle never checked. |
 
 `nothing_eligible` is the expected answer immediately after a load, and is
 not a failure: a fold seals an ingest hour only once `max_flush_lifetime +
@@ -433,11 +439,16 @@ a comparison that cannot be completed answers `published` and logs, because
 `nothing_eligible` asserts that no commit entered or left and an incomplete
 comparison has not shown that.
 
-A request that fails before the fold runs is an error body, not an outcome:
-401 with no credential, 400 for a missing or unknown `signal` or a malformed
-body, 403 for a body naming another tenant, 503 for a store or catalog fault
-(logged in full server-side, redacted in the response like the query
-surfaces').
+A request that fails is an error body, not an outcome: 401 with no credential,
+400 for a missing or unknown `signal` or a malformed body, 403 for a body
+naming another tenant, 503 for a store or catalog fault (logged in full
+server-side, redacted in the response like the query surfaces'). The
+authentication and validation errors (401/400/403) do precede the fold, so on
+them no object-store work happened. A 503 does not carry that guarantee: it is
+also returned for a `CatalogError` raised by `Catalog::fold` itself and for a
+lost single-flight leader, and in both cases the fold may have already written
+snapshot parts before failing. Treat a 503 as "the outcome is unknown, retry",
+not as "nothing was written".
 
 ## Alert evaluation
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -177,8 +177,9 @@ Sigma/OCSF: later phases. See the spec docs as they land.
 `ravel-server` binds up to three listeners:
 
 - `--listen-http`: OTLP HTTP-protobuf, Remote Write, `/api/v1/*` query and
-  analytics routes, `/api/v1/sql` (feature `sql`), and the mode-independent
-  `/healthz`, `/readyz`, `/metrics` routes.
+  analytics routes, `/api/v1/sql` (feature `sql`), the on-demand fold route
+  `/api/v1/admin/fold` (below), and the mode-independent `/healthz`,
+  `/readyz`, `/metrics` routes.
 - `--listen-grpc`: OTLP gRPC and, under the `flight-sql` feature, Flight SQL.
   Bound only in the modes and feature combinations that serve one of those.
   Under `--distributed-query` it also carries the cluster-internal
@@ -353,6 +354,65 @@ applies the requested op to each series of the matrix, capping a call at 1000
 series and each `change_point` series at 2000 points (approximation via
 `downsample` is opt-in and visible). Unlike the SQL path it needs no cargo
 feature, since it links no Arrow or DataFusion.
+
+## On-demand catalog fold
+
+The catalog fold normally runs on the background loop in `ravel-server`'s
+`fold.rs`, on a jittered `--fold-interval` cadence over every discovered
+tenant. `POST /api/v1/admin/fold` is the on-demand form of the same
+operation, for one tenant and one signal (issue #785). It calls the same
+`Catalog::fold` entry point with the same per-process `folder_id` and the same
+CLI-derived retention window; it does not change the scheduled fold's cadence
+or behaviour, and there is no all-tenants variant.
+
+Request body (`signal` is required; `tenant` is optional):
+
+```json
+{"signal": "metrics", "tenant": "acme"}
+```
+
+`signal` is one of `metrics`, `logs`, `spans`, and is never defaulted: a
+tenant holds each signal's snapshot independently, so a default would make
+"folded the wrong signal" indistinguishable from "the window was empty".
+
+**Authorization.** The route is mounted on `--listen-http` and on the mTLS
+listener, in the modes that serve a query surface, and it authenticates
+through the deployment's configured `TenantResolver` chain -- the same
+credential `/api/v1/query` and `/api/v1/sql` require. The fold runs for the
+tenant that credential resolves to, and nothing else: if the body names a
+tenant, the name must hash to the authenticated tenant or the request is
+refused with 403. There is no separate platform-operator credential in
+`ravel-server` today, so folding a tenant means holding that tenant's
+credential.
+
+**Concurrency.** Safe to call concurrently with the scheduled fold and with
+itself. A fold publishes through the `HEAD` CAS protocol
+(docs/catalog-and-mvcc.md), so a losing CAS is an ordinary outcome, not
+corruption; the endpoint takes no lock of its own.
+
+**Outcomes.** Every completed call is 200 and names one of three statuses,
+because "published a snapshot" and "there was nothing to publish" are
+different facts an operator has to tell apart:
+
+| `status` | Meaning |
+|---|---|
+| `published` | A new snapshot was published: `HEAD` now names content that differs from what it named before. |
+| `nothing_eligible` | No commit was eligible to fold. The response's `head_advanced` says whether the sealing watermark still moved (`true`, a watermark-only rewrite over empty hours) or `HEAD` was untouched (`false`). |
+| `lost_cas` | A concurrent fold (the scheduled loop, or another call) won the `HEAD` CAS. That fold's snapshot is the current `HEAD`; this call published none. |
+
+`nothing_eligible` is the expected answer immediately after a load, and is
+not a failure: a fold seals an ingest hour only once `max_flush_lifetime +
+clock_skew_allowance + fold_safety_margin` has elapsed after that hour ends
+(docs/catalog-and-mvcc.md). The response also carries the underlying fold
+report -- watermark hours, buckets folded, entry count, and the per-phase
+request counts -- so a call that published can be checked against what it
+claims.
+
+A request that fails before the fold runs is an error body, not an outcome:
+401 with no credential, 400 for a missing or unknown `signal` or a malformed
+body, 403 for a body naming another tenant, 503 for a store or catalog fault
+(logged in full server-side, redacted in the response like the query
+surfaces').
 
 ## Alert evaluation
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -385,10 +385,23 @@ refused with 403. There is no separate platform-operator credential in
 `ravel-server` today, so folding a tenant means holding that tenant's
 credential.
 
+**Admission.** Concurrent calls for one `(tenant, signal)` collapse into a
+single fold, through the same request-coalescing primitive the read cache
+uses: one call runs the fold, the others wait on its result and issue no
+object-store work at all, and each response reports which it was in
+`coalesced`. That is the route's admission gate. A fold LISTs commit records,
+GETs parts, and PUTs new parts plus `HEAD` whether or not anything turns out
+to be eligible, and a credential resolves to exactly one tenant, so this
+bounds any one caller to a single in-flight fold per signal. The route takes
+no query-admission permit: a fold is deferred maintenance traffic, runs on
+the background store handle (ADR-0070) like the scheduled fold, and must not
+be charged against the query hot path's ceiling.
+
 **Concurrency.** Safe to call concurrently with the scheduled fold and with
 itself. A fold publishes through the `HEAD` CAS protocol
 (docs/catalog-and-mvcc.md), so a losing CAS is an ordinary outcome, not
-corruption; the endpoint takes no lock of its own.
+corruption; the endpoint takes no lock over the catalog, and the coalescing
+above never queues behind a fold this process did not start.
 
 **Outcomes.** Every completed call is 200 and names one of three statuses,
 because "published a snapshot" and "there was nothing to publish" are
@@ -407,6 +420,18 @@ clock_skew_allowance + fold_safety_margin` has elapsed after that hour ends
 report -- watermark hours, buckets folded, entry count, and the per-phase
 request counts -- so a call that published can be checked against what it
 claims.
+
+`published` and `nothing_eligible` are told apart by the entry set the two
+`HEAD`s name, never by their entry totals: a single fold can fold new commits
+in and drop entries through a retention tombstone in the same pass, and when
+those cancel the total is identical over content that changed. Snapshot parts
+are content addressed, so a part carrying the same hash on both sides needs
+no read and only the remainder is fetched; a watermark-only rewrite leaves
+exactly one part differing. The GETs this costs are reported under their own
+`classify_get_requests` field rather than summed into the fold's counts, and
+a comparison that cannot be completed answers `published` and logs, because
+`nothing_eligible` asserts that no commit entered or left and an incomplete
+comparison has not shown that.
 
 A request that fails before the fold runs is an error body, not an outcome:
 401 with no credential, 400 for a missing or unknown `signal` or a malformed

--- a/docs/ingest.md
+++ b/docs/ingest.md
@@ -875,8 +875,15 @@ a rising `off_actor_ns` with a flat permit wait means flushes are slow but not
 yet backed up.
 
 `on_actor_ns` and `flush_permit_wait_ns` both accrue on the actor task, so they
-are disjoint in wall time as well as in code: together they account for the
-actor's whole `Write`-handling window, and their sum can never exceed it.
+are disjoint in wall time as well as in code: no wall-clock interval is charged
+to both. They do not, however, jointly equal the actor's `Write`-handling
+window. `on_actor_ns` is scoped to `Write` handling, but `flush_permit_wait_ns`
+is recorded in `flush_tenant`, which the actor also reaches from `flush_aged`
+and `flush_all`: an age-triggered or manual flush parks on the same semaphore
+outside any `Write`-handling window, and that wait still lands in
+`flush_permit_wait_ns`. So permit wait can accrue when no `Write` is being
+handled, and the two counters' sum can exceed the `Write`-handling window by
+exactly those out-of-band flush waits.
 `off_actor_ns` accrues in spawned tasks that run *concurrently* with the actor,
 which is exactly what ADR-0067's pipelining is for, so it is a sum over
 concurrent tasks: at `max_inflight_flushes > 1` it can legitimately exceed wall

--- a/docs/ingest.md
+++ b/docs/ingest.md
@@ -854,6 +854,41 @@ in-flight flushes today; wiring either into an operator scrape is a follow-up in
   nanoseconds, split three ways. See "The three time spans" below; reading any
   two of them as if they were the whole split misattributes backpressure.
 
+#### Which shards are covered
+
+Every shard index the write path can route to, not only the `shard_count` the
+process was configured with. The shard set is not fixed for the lifetime of the
+process: `GenerationSwitch` (ADR-0052 section 2) keeps one shard-actor set per
+distinct `shard_count` seen and takes the live count from the tenant's
+generation history via `active_shard_count`, so a tenant that activates a larger
+generation routes to indices above the configured count. The accumulators are
+therefore preallocated to `MAX_SHARD_COUNT` (10 000, the ceiling
+`provisioning.rs` validates every generation's `shard_count` against), so no
+generation the catalog accepts can route to an index the metric drops. Sizing to
+the configured count instead would omit exactly the shards a reshard adds, and
+omitting shards biases this measurement toward reporting *less* skew than there
+is -- the direction that would manufacture agreement with the claim the metric
+exists to test.
+
+#### What a single read does and does not guarantee
+
+`shard_skew_by_shard()` reads five independent atomics per shard, so under
+concurrent recording it is not an instantaneous snapshot of all five. One
+direction is guaranteed and one is not:
+
+- `messages_processed` never runs ahead of the `on_actor_ns` it belongs to: the
+  actor adds the time with `Relaxed` and then bumps the count with `Release`,
+  and the reader loads the count with `Acquire` before the time. A counted
+  message therefore always has its time addend included, so the derived mean
+  `on_actor_ns / messages_processed` can never read low because of a torn pair.
+- The reverse tear is observable: a time addend whose message has not yet been
+  counted, so the mean can read high by at most one in-flight message per
+  concurrent actor. Both counters are cumulative, so a later read self-heals.
+
+`queue_depth` is derived at read time from two counters updated on different
+tasks and is saturating for the same reason; it can read 0 when a processed
+increment is visible before its enqueue.
+
 #### The three time spans
 
 The split is the point of the whole measurement: without it, a figure cannot

--- a/docs/ingest.md
+++ b/docs/ingest.md
@@ -831,8 +831,34 @@ Counters recorded today:
   `max_inflight_flushes` at its default of 1, this never exceeds
   `shard_count`.
 
-Tracked future work (not yet implemented): a per-shard
-and per-tenant dimensioned model — per-shard buffered bytes/points, flush
-build/put/commit latency histograms, ack latency, and queue depth; per-tenant
-accepted/rejected points and bytes. It requires a metrics backend that these
-flat atomics do not provide and is out of scope for the counters above.
+### Per-shard skew (issue #865)
+
+To make per-shard ingest skew measurable -- so an argument about shard-actor
+throughput rests on data, not assertion -- `IngestMetrics` also carries a
+per-shard dimension, read via `IngestMetrics::shard_skew_by_shard()` (and
+reachable from a benchmark through `IngestRouter::metrics()`, the same handle
+`in_flight_flushes_by_shard` is read through). It is not part of the flat
+`IngestMetricsSnapshot`, whose `Copy` shape holds no per-shard dimension, so the
+process `/metrics` surface renders it no more than it renders per-shard
+in-flight flushes today; wiring either into an operator scrape is a follow-up in
+`services/ravel-server`. Per shard (`ShardSkewStats`):
+
+- `messages_enqueued`: `Write` messages the router sent into the shard's
+  channel, counted at the router's `send`.
+- `messages_processed`: `Write` messages the shard actor pulled and handled.
+  `FlushNow`/`Shutdown` are excluded from both counts: they are control
+  messages, not ingest load.
+- `queue_depth`: `messages_enqueued - messages_processed` at read time
+  (saturating), the messages still in the channel.
+- `on_actor_ns` vs `off_actor_ns`: injected-`Clock` nanoseconds spent in the
+  actor's serial merge/pin section versus in the flush task ADR-0067 runs off
+  the actor (encode plus both PUTs). The split is the point: without it a
+  measurement cannot tell an actor-thread bottleneck from a flush bottleneck.
+  The actor returns from `handle_write` once the flush task is spawned, so its
+  on-actor time never includes the flush.
+
+Still tracked future work (not yet implemented): a per-tenant dimensioned
+model and per-shard latency histograms -- per-shard buffered bytes/points,
+flush build/put/commit and ack latency distributions; per-tenant
+accepted/rejected points and bytes. Those require a metrics backend that these
+flat atomics and the per-shard maps above do not provide.

--- a/docs/ingest.md
+++ b/docs/ingest.md
@@ -850,12 +850,46 @@ in-flight flushes today; wiring either into an operator scrape is a follow-up in
   messages, not ingest load.
 - `queue_depth`: `messages_enqueued - messages_processed` at read time
   (saturating), the messages still in the channel.
-- `on_actor_ns` vs `off_actor_ns`: injected-`Clock` nanoseconds spent in the
-  actor's serial merge/pin section versus in the flush task ADR-0067 runs off
-  the actor (encode plus both PUTs). The split is the point: without it a
-  measurement cannot tell an actor-thread bottleneck from a flush bottleneck.
-  The actor returns from `handle_write` once the flush task is spawned, so its
-  on-actor time never includes the flush.
+- `on_actor_ns`, `flush_permit_wait_ns`, `off_actor_ns`: injected-`Clock`
+  nanoseconds, split three ways. See "The three time spans" below; reading any
+  two of them as if they were the whole split misattributes backpressure.
+
+#### The three time spans
+
+The split is the point of the whole measurement: without it, a figure cannot
+tell an actor-thread bottleneck from a flush bottleneck, and a two-way split
+cannot tell either of those from flush backpressure. Each span is bracketed on
+the injected `Clock` at a distinct boundary in `crates/ravel-ingest/src/shard.rs`,
+and the three boundaries are consecutive, so no nanosecond of any sampled
+interval is charged to more than one counter.
+
+| Counter | Starts | Stops | What it means |
+|---|---|---|---|
+| `on_actor_ns` | the actor pulls a `Write` off its channel | `handle_write` returns, minus any permit wait nested inside | merge-and-pin work the single-threaded actor genuinely serialises |
+| `flush_permit_wait_ns` | `flush_tenant` reaches the `max_inflight_flushes` acquire | that acquire grants a permit | this shard's flush backpressure: the actor is stalled on an earlier flush of the same shard |
+| `off_actor_ns` | the spawned flush task enters `run_flush`, permit already held | `run_flush` returns (success or abandonment) | exemplar admission, encode, and both PUTs |
+
+Read them as: a rising `on_actor_ns` means the actor is the bottleneck; a rising
+`flush_permit_wait_ns` means flushing is, and the actor is merely waiting on it;
+a rising `off_actor_ns` with a flat permit wait means flushes are slow but not
+yet backed up.
+
+`on_actor_ns` and `flush_permit_wait_ns` both accrue on the actor task, so they
+are disjoint in wall time as well as in code: together they account for the
+actor's whole `Write`-handling window, and their sum can never exceed it.
+`off_actor_ns` accrues in spawned tasks that run *concurrently* with the actor,
+which is exactly what ADR-0067's pipelining is for, so it is a sum over
+concurrent tasks: at `max_inflight_flushes > 1` it can legitimately exceed wall
+time, and it overlaps the other two in wall time. That overlap is not
+double-counting -- no sampled interval lands in two counters.
+
+The interval an actor spends parked in `flush_permit_wait_ns` is wall-time
+concurrent with a *prior* flush's `off_actor_ns`, and it is charged to the actor
+side exactly once, as permit wait, never as actor work. Folding it into
+`on_actor_ns` instead (as the first cut of this metric did) both double-counts
+that interval and inverts the reading: the actor reports busy precisely when the
+truth is that flushes are backed up. `crates/ravel-ingest/tests/shard_skew.rs`
+pins both properties on fixed input.
 
 Still tracked future work (not yet implemented): a per-tenant dimensioned
 model and per-shard latency histograms -- per-shard buffered bytes/points,

--- a/docs/object-store-contract.md
+++ b/docs/object-store-contract.md
@@ -90,6 +90,35 @@ correctness but are inert under the client's HTTP/1.1 default (which we keep:
 HTTP/2 is slower for bulk S3 transfers), so under HTTP/1.1 connection liveness
 comes from the connect, request, and pool-idle timeouts.
 
+**A fixed timeout requires a bounded request, so the adapter bounds one.** Every
+request size is chosen by this crate except one: a whole-object read, whose size
+is whatever the object is. `max_l1_part_bytes` defaults to 256 MiB, 32x an 8 MiB
+multipart part, so no fixed timeout can cover both. `S3Store::get` therefore
+never issues an unranged GET: `GetRange::Full` is served as ranged requests of
+at most `S3HttpConfig::max_request_body_bytes()` bytes each, derived from the
+configured `request_timeout` as
+`(request_timeout - 6 s of connect/TLS/first-byte allowance) * 625 000 B/s`
+(a 5 Mbps floor rate), capped at the 8 MiB multipart part size so read and write
+share one largest-request-on-the-wire. At the default 20 s that is 8 MiB, ~13.4 s
+at the floor rate, inside the 14 s transfer budget; a compile-time assertion in
+`s3.rs` pins the inequality. A caller-supplied `GetRange::Range` is passed
+through unsplit: the caller sized that request itself.
+
+Cost of the split, in requests and wire bytes as transferred, excluding
+`object_store`'s internal per-request retries:
+
+| Object size | Requests | Wire bytes |
+|---|---|---|
+| 0 | 2 (one 416-refused ranged probe, then one unranged) | 0 body bytes |
+| 1 byte .. bound | 1 | the object |
+| above the bound | `ceil(size / bound)`, up to 4 in flight | the object, plus one response header set per additional request |
+
+The ranges partition the object exactly, so no byte is fetched twice. Every
+request after the first carries the first's ETag as an `If-Match`, so an object
+overwritten mid-read fails the read (retryable) rather than splicing two
+versions together; data objects are immutable, and the mutable pointer keys are
+all far below the bound, so this is a guard rather than a live path.
+
 **Worst-case wall time for one logical operation.** A request timeout is a
 retryable error, and `object_store` runs its own internal retry loop
 (`RetryConfig`, unchanged: `max_retries = 10`, `retry_timeout = 180 s`,

--- a/docs/object-store-contract.md
+++ b/docs/object-store-contract.md
@@ -65,6 +65,42 @@ jittered exponential backoff. `AlreadyExists` on `CreateIfAbsent` is a
 *protocol signal*, not an error to retry. `AccessDenied` is permanent and
 alerts differently (misconfigured credentials or prefix policy).
 
+### HTTP client timeouts (S3 adapter)
+
+The `S3Store` adapter builds its `object_store` `AmazonS3` client on an
+explicit `ClientOptions` (`S3HttpConfig`), so the request, connect, and
+pool-idle timeouts are deliberate values this repo chose, not whatever the
+dependency happens to default to. The `S3HttpConfig` doc comment carries the
+per-value reasoning; the values (defaults, overridable via
+`S3Store::with_http_config`) are:
+
+| Value | Configured | Inherited default it replaces |
+|---|---|---|
+| Request timeout (connect → body complete) | 20 s | 30 s |
+| Connect timeout (TCP + TLS) | 3 s | 5 s |
+| Pool idle timeout | 30 s | ~90 s (reqwest, uncapped) |
+| HTTP/2 keep-alive interval / ack timeout | 10 s / 10 s, while-idle on | disabled |
+
+The request timeout must stay above the tail of the largest single request on
+the wire (an 8 MiB multipart part or a whole-object GET) even on a badly
+degraded connection, so it is set conservatively at 20 s pending a tail-latency
+measurement to tighten it; a timeout below the real tail turns a slow-but-
+succeeding request into a retry storm. The HTTP/2 keep-alive knobs are set for
+correctness but are inert under the client's HTTP/1.1 default (which we keep:
+HTTP/2 is slower for bulk S3 transfers), so under HTTP/1.1 connection liveness
+comes from the connect, request, and pool-idle timeouts.
+
+**Worst-case wall time for one logical operation.** A request timeout is a
+retryable error, and `object_store` runs its own internal retry loop
+(`RetryConfig`, unchanged: `max_retries = 10`, `retry_timeout = 180 s`,
+jittered exponential backoff), stopping before it *starts* a retry once 180 s
+have elapsed since the first attempt. The final in-flight attempt still runs
+its full 20 s, so one logical operation can spend about `retry_timeout +
+request_timeout` = 180 s + 20 s ≈ 200 s inside the adapter before surfacing an
+error. Callers bound this from above: every caller passes a deadline and the
+trait honors cancellation by drop, so the query deadline (usually well under
+180 s) is what ends one operation in practice.
+
 ### Semantics adapters MUST honor
 
 - Conditional-put failure maps by mode: under `CreateIfAbsent` a

--- a/docs/object-store-contract.md
+++ b/docs/object-store-contract.md
@@ -98,10 +98,14 @@ never issues an unranged GET: `GetRange::Full` is served as ranged requests of
 at most `S3HttpConfig::max_request_body_bytes()` bytes each, derived from the
 configured `request_timeout` as
 `(request_timeout - 6 s of connect/TLS/first-byte allowance) * 625 000 B/s`
-(a 5 Mbps floor rate), capped at the 8 MiB multipart part size so read and write
-share one largest-request-on-the-wire. At the default 20 s that is 8 MiB, ~13.4 s
-at the floor rate, inside the 14 s transfer budget; a compile-time assertion in
-`s3.rs` pins the inequality. A caller-supplied `GetRange::Range` is passed
+(a 5 Mbps floor rate), clamped to `[1 MiB, 8 MiB]`: the upper bound is the
+multipart part size, so read and write share one largest-request-on-the-wire,
+and the lower bound stops a tight `request_timeout` splitting a whole-object
+read so finely that the per-request round trips cost more than the bound buys
+back. At the default 20 s the derived value is 8 MiB, ~13.4 s at the floor rate,
+inside the 14 s transfer budget; a compile-time assertion in `s3.rs` pins the
+inequality. Below a `request_timeout` of about 7.7 s the 1 MiB floor binds and
+the formula above no longer predicts the chunk size. A caller-supplied `GetRange::Range` is passed
 through unsplit: the caller sized that request itself.
 
 Cost of the split, in requests and wire bytes as transferred, excluding

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/var/lib/fleet/cache/npm-modules/2ca157bd-0888-4457-89fb-6e4ffbde4fb3

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/var/lib/fleet/cache/npm-modules/2ca157bd-0888-4457-89fb-6e4ffbde4fb3

--- a/services/ravel-cli/src/store.rs
+++ b/services/ravel-cli/src/store.rs
@@ -333,22 +333,42 @@ mod tests {
             let Some(data) = found else {
                 return StatusCode::NOT_FOUND.into_response();
             };
+            // All three RFC 7233 byte-range forms, not just the closed one:
+            // `S3Store::get` emits `bytes=-N` for `GetRange::Suffix`, which is
+            // how every footer in this codebase is read, so a mock that parses
+            // only `bytes=A-B` fails such a request with 416 for a reason that
+            // has nothing to do with the code under test.
             let requested = headers
                 .get(header::RANGE)
                 .and_then(|value| value.to_str().ok())
                 .and_then(|spec| spec.strip_prefix("bytes=")?.split_once('-'))
-                .map(|(start, end)| (start.parse::<usize>(), end.parse::<usize>()));
+                .map(|(start, end)| {
+                    let len = data.len();
+                    match (start.trim(), end.trim()) {
+                        // bytes=-N: the last N bytes.
+                        ("", n) => n.parse::<usize>().ok().and_then(|n| {
+                            (n > 0 && len > 0).then(|| (len.saturating_sub(n), len - 1))
+                        }),
+                        // bytes=A-: from A through the end.
+                        (s, "") => s
+                            .parse::<usize>()
+                            .ok()
+                            .and_then(|s| (s < len).then(|| (s, len - 1))),
+                        // bytes=A-B, inclusive, clamped to the object.
+                        (s, e) => match (s.parse::<usize>(), e.parse::<usize>()) {
+                            (Ok(s), Ok(e)) if s < len && s <= e => Some((s, e.min(len - 1))),
+                            _ => None,
+                        },
+                    }
+                });
             let (status, body, content_range) = match requested {
                 None => (StatusCode::OK, data.clone(), None),
-                Some((Ok(start), Ok(end))) if start < data.len() => {
-                    let end = end.min(data.len() - 1);
-                    (
-                        StatusCode::PARTIAL_CONTENT,
-                        data.slice(start..end + 1),
-                        Some(format!("bytes {start}-{end}/{}", data.len())),
-                    )
-                }
-                Some(_) => return StatusCode::RANGE_NOT_SATISFIABLE.into_response(),
+                Some(Some((start, end))) => (
+                    StatusCode::PARTIAL_CONTENT,
+                    data.slice(start..end + 1),
+                    Some(format!("bytes {start}-{end}/{}", data.len())),
+                ),
+                Some(None) => return StatusCode::RANGE_NOT_SATISFIABLE.into_response(),
             };
             let mut response = (
                 status,

--- a/services/ravel-cli/src/store.rs
+++ b/services/ravel-cli/src/store.rs
@@ -314,9 +314,15 @@ mod tests {
             (StatusCode::OK, [(header::ETAG, "\"mock-etag\"")], "").into_response()
         }
 
+        /// Serves `Range` the way a real S3-compatible endpoint does: 206 with
+        /// a `Content-Range`, or 416 when no part of the range exists. The
+        /// adapter reads a whole object as bounded ranged requests, so a mock
+        /// that answered 200 here would be rejected as a non-partial response
+        /// before its body was ever read.
         async fn get_object(
             State(state): State<Arc<MockS3>>,
             AxumPath((_bucket, key)): AxumPath<(String, String)>,
+            headers: HeaderMap,
         ) -> Response {
             let found = state
                 .objects
@@ -324,18 +330,44 @@ mod tests {
                 .expect("objects lock")
                 .get(&key)
                 .cloned();
-            match found {
-                Some(data) => (
-                    StatusCode::OK,
-                    [
-                        (header::ETAG, "\"mock-etag\""),
-                        (header::LAST_MODIFIED, "Wed, 21 Oct 2020 07:28:00 GMT"),
-                    ],
-                    data,
-                )
-                    .into_response(),
-                None => StatusCode::NOT_FOUND.into_response(),
+            let Some(data) = found else {
+                return StatusCode::NOT_FOUND.into_response();
+            };
+            let requested = headers
+                .get(header::RANGE)
+                .and_then(|value| value.to_str().ok())
+                .and_then(|spec| spec.strip_prefix("bytes=")?.split_once('-'))
+                .map(|(start, end)| (start.parse::<usize>(), end.parse::<usize>()));
+            let (status, body, content_range) = match requested {
+                None => (StatusCode::OK, data.clone(), None),
+                Some((Ok(start), Ok(end))) if start < data.len() => {
+                    let end = end.min(data.len() - 1);
+                    (
+                        StatusCode::PARTIAL_CONTENT,
+                        data.slice(start..end + 1),
+                        Some(format!("bytes {start}-{end}/{}", data.len())),
+                    )
+                }
+                Some(_) => return StatusCode::RANGE_NOT_SATISFIABLE.into_response(),
+            };
+            let mut response = (
+                status,
+                [
+                    (header::ETAG, "\"mock-etag\"".to_string()),
+                    (
+                        header::LAST_MODIFIED,
+                        "Wed, 21 Oct 2020 07:28:00 GMT".to_string(),
+                    ),
+                ],
+                body,
+            )
+                .into_response();
+            if let Some(value) = content_range
+                && let Ok(value) = value.parse()
+            {
+                response.headers_mut().insert(header::CONTENT_RANGE, value);
             }
+            response
         }
 
         let state = Arc::new(MockS3::default());

--- a/services/ravel-server/src/fold.rs
+++ b/services/ravel-server/src/fold.rs
@@ -340,7 +340,9 @@ async fn head_fresh_enough(
 /// `t/<tenant_hash>/catalog/<signal>/HEAD`. Reconstructed here rather than
 /// imported because it names a `pub(crate)` helper inside `ravel-catalog`;
 /// this task only ever uses it for the freshness peek above, never to
-/// mutate the object.
-fn head_key(tenant: &TenantHash, signal: Signal) -> String {
+/// mutate the object, and so does
+/// [`crate::fold_on_demand`], which shares this one spelling of the key
+/// rather than growing a second copy.
+pub(crate) fn head_key(tenant: &TenantHash, signal: Signal) -> String {
     format!("t/{}/catalog/{}/HEAD", tenant.to_hex(), signal.key_prefix())
 }

--- a/services/ravel-server/src/fold.rs
+++ b/services/ravel-server/src/fold.rs
@@ -332,7 +332,17 @@ async fn head_fresh_enough(
     let Ok(head) = ravel_catalog::decode_head(&got.data) else {
         return false;
     };
-    let age_ns = now_ns.saturating_sub(head.created_unix_ns);
+    head_is_fresh(head.created_unix_ns, now_ns, interval)
+}
+
+/// Whether a HEAD published at `created_unix_ns` is younger than `interval` as
+/// of `now_ns`. The freshness predicate behind [`head_fresh_enough`], factored
+/// out so the on-demand route ([`crate::fold_on_demand`]) applies the same rule
+/// to a HEAD it has already read rather than growing a second freshness notion.
+/// A zero `interval` is never fresh (age is always `>= 0`), which is how a
+/// caller opts out of the gate.
+pub(crate) fn head_is_fresh(created_unix_ns: i64, now_ns: i64, interval: Duration) -> bool {
+    let age_ns = now_ns.saturating_sub(created_unix_ns);
     age_ns >= 0 && (age_ns as u128) < interval.as_nanos()
 }
 

--- a/services/ravel-server/src/fold_on_demand.rs
+++ b/services/ravel-server/src/fold_on_demand.rs
@@ -777,6 +777,7 @@ mod tests {
 
     use axum::http::Request as HttpRequest;
     use bytes::Bytes;
+    use prost::Message as _;
     use ravel_catalog::CatalogConfig;
     use ravel_commit::publish::{self, RetryPolicy};
     use ravel_commit::record::{self, NewCommitRecord};
@@ -787,6 +788,7 @@ mod tests {
     use ravel_object_store::PutOptions;
     use ravel_object_store::fault::{FaultStore, Occurrence, Op};
     use ravel_object_store::memory::MemoryStore;
+    use ravel_proto::commit::v1::RetentionTombstone;
     use ravel_query::http::StaticBearerTokenResolver;
     use ravel_types::logstream::log_stream_id;
     use tower::ServiceExt;
@@ -1032,6 +1034,141 @@ mod tests {
         );
     }
 
+    /// Publishes a retention tombstone for `(shard, ingest_hour_bucket)` on
+    /// the logs signal. The fold classifies a bucket as tombstoned from the
+    /// key shape alone and never reads the body, so a minimal valid record is
+    /// enough (matching `ravel_catalog::fold`'s own fixture).
+    async fn publish_retention_tombstone(
+        store: &dyn ObjectStoreBackend,
+        tenant: &TenantHash,
+        shard: u32,
+        ingest_hour_bucket: u32,
+    ) {
+        let record = RetentionTombstone {
+            format_version: 1,
+            tenant_hash: tenant.0.to_vec(),
+            signal: ravel_commit::signal::to_proto(Signal::Logs).into(),
+            shard,
+            ingest_hour_bucket,
+            retired_at_ns: 0,
+            retention_window_ns: 0,
+            record_count_observed: 0,
+        };
+        let key = ravel_commit::keys::retention_tombstone_key_for(&record).expect("tombstone key");
+        store
+            .put(
+                &key,
+                Bytes::from(record.encode_to_vec()),
+                PutOptions::create_if_absent(),
+            )
+            .await
+            .expect("put retention tombstone");
+    }
+
+    /// The outcome must turn on what the snapshot names, not on how many
+    /// entries it names. One fold folds a newly sealed commit in and, in the
+    /// same pass, applies a retention tombstone that drops an older bucket:
+    /// the entry total is identical on both sides while `HEAD` names
+    /// different content. That is a publish, and answering `nothing_eligible`
+    /// to it would tell an operator their fold did nothing when it moved
+    /// their catalog.
+    #[tokio::test]
+    async fn a_fold_whose_additions_and_retirements_cancel_still_reports_published() {
+        let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+        let tenant = TenantId::new("fold-on-demand-cancelling");
+        let tenant_hash = tenant.hash();
+        let base_hour = NOW_NS / NS_PER_HOUR;
+        // Both sealed at NOW_NS (the watermark there is base_hour - 3).
+        let retired_hour = (base_hour - 5) as u32;
+        let kept_hour = (base_hour - 4) as u32;
+        // Sealed only at NOW_NS + 2h, so the second fold's watermark advance
+        // is what folds it in.
+        let added_hour = (base_hour - 2) as u32;
+
+        seed_log_commit(store.as_ref(), &tenant, retired_hour, 0).await;
+        seed_log_commit(store.as_ref(), &tenant, kept_hour, 1).await;
+
+        let catalog = catalog(store.clone());
+        let first = fold_once(
+            catalog.as_ref(),
+            store.as_ref(),
+            &tenant_hash,
+            Signal::Logs,
+            Uuid::from_u128(1),
+            NOW_NS,
+            None,
+        )
+        .await
+        .expect("first fold");
+        assert_eq!(first.outcome, FoldOutcome::Published);
+        let entries_before = first
+            .report
+            .expect("the first fold carries a report")
+            .entry_count;
+        assert_eq!(entries_before, 2, "both seeded hours are folded in");
+
+        // One entry enters and one leaves, in the same fold.
+        seed_log_commit(store.as_ref(), &tenant, added_hour, 2).await;
+        publish_retention_tombstone(store.as_ref(), &tenant_hash, 0, retired_hour).await;
+
+        let second = fold_once(
+            catalog.as_ref(),
+            store.as_ref(),
+            &tenant_hash,
+            Signal::Logs,
+            Uuid::from_u128(1),
+            NOW_NS + 2 * NS_PER_HOUR,
+            None,
+        )
+        .await
+        .expect("second fold");
+        let report = second.report.expect("the second fold carries a report");
+        // Non-vacuity: the fixture only exercises the defect if the totals
+        // really do cancel. If this ever stops holding, the outcome assertion
+        // below would pass for the wrong reason.
+        assert_eq!(
+            report.entry_count, entries_before,
+            "the fixture must cancel: an equal entry total over changed content"
+        );
+        assert!(
+            report.watermark_hour > Some(retired_hour),
+            "the second fold must have advanced past the retired hour"
+        );
+        assert_eq!(
+            second.outcome,
+            FoldOutcome::Published,
+            "the snapshot names different content, so this call published"
+        );
+        assert!(second.head_advanced);
+
+        // What the snapshot names is what changed: the retired hour is gone
+        // and the newly sealed one is there.
+        let head_bytes = store
+            .get(
+                &crate::fold::head_key(&tenant_hash, Signal::Logs),
+                GetRange::Full,
+            )
+            .await
+            .expect("HEAD present");
+        let head = ravel_catalog::decode_head(&head_bytes.data).expect("decode HEAD");
+        let mut hours = Vec::new();
+        for part in &head.parts {
+            let bytes = store
+                .get(&part.key, GetRange::Full)
+                .await
+                .expect("part present");
+            let decoded =
+                ravel_catalog::decode_part(&bytes.data, &PartLimits::default()).expect("part");
+            hours.extend(decoded.entries.iter().map(|e| e.ingest_hour_bucket));
+        }
+        hours.sort_unstable();
+        assert_eq!(
+            hours,
+            vec![kept_hour, added_hour],
+            "the retired hour left the snapshot and the newly sealed one entered it"
+        );
+    }
+
     /// Concurrent-CAS path: two folds race on the same tenant. A `FaultStore`
     /// hold gate makes the interleaving deterministic (`MemoryStore` never
     /// yields, so without it the first fold would simply run to completion
@@ -1173,14 +1310,71 @@ mod tests {
         (status, bytes.to_vec())
     }
 
+    /// Records the `error` field of every WARN event, so the next test can
+    /// prove a rejected credential leaves a server-side record rather than
+    /// vanishing into the 401.
+    #[derive(Default, Clone)]
+    struct WarnErrorCapture(Arc<parking_lot::Mutex<Vec<String>>>);
+
+    impl<S> tracing_subscriber::Layer<S> for WarnErrorCapture
+    where
+        S: tracing::Subscriber,
+    {
+        fn on_event(
+            &self,
+            event: &tracing::Event<'_>,
+            _ctx: tracing_subscriber::layer::Context<'_, S>,
+        ) {
+            if *event.metadata().level() != tracing::Level::WARN {
+                return;
+            }
+            struct Visitor(Option<String>);
+            impl tracing::field::Visit for Visitor {
+                fn record_debug(
+                    &mut self,
+                    field: &tracing::field::Field,
+                    value: &dyn std::fmt::Debug,
+                ) {
+                    if field.name() == "error" {
+                        self.0 = Some(format!("{value:?}"));
+                    }
+                }
+            }
+            let mut visitor = Visitor(None);
+            event.record(&mut visitor);
+            if let Some(error) = visitor.0 {
+                self.0.lock().push(error);
+            }
+        }
+    }
+
     /// The route carries the same authorization the tenant-scoped query
-    /// routes do: no credential, no fold.
+    /// routes do: no credential, no fold. The resolver's error is kept
+    /// server-side rather than discarded on the way to the 401: the resolver
+    /// chain can fail for reasons that are not a bad credential (an
+    /// unreachable durable auth map), and a bare 401 records none of them.
+    ///
+    /// Non-vacuity: the handler previously mapped the error with `|_|`, so the
+    /// capture stays empty against that code and this test fails on its
+    /// second assertion while the status assertion alone passes either way.
     #[tokio::test]
-    async fn an_unauthenticated_request_is_refused() {
+    async fn an_unauthenticated_request_is_refused_and_logged() {
+        use tracing_subscriber::layer::SubscriberExt as _;
+
         let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
         let catalog = catalog(store.clone());
+
+        let captured: Arc<parking_lot::Mutex<Vec<String>>> = Arc::default();
+        let subscriber = tracing_subscriber::registry().with(WarnErrorCapture(captured.clone()));
+        let _guard = tracing::subscriber::set_default(subscriber);
+
         let (status, _) = post(state(store, catalog), None, r#"{"signal":"logs"}"#).await;
         assert_eq!(status, StatusCode::UNAUTHORIZED);
+        assert_eq!(
+            captured.lock().as_slice(),
+            &["unauthenticated request".to_string()],
+            "the resolver's error must reach the log, not just the caller's 401"
+        );
     }
 
     /// The signal is required and never defaulted, and a tenant named in the
@@ -1230,5 +1424,150 @@ mod tests {
         let body: serde_json::Value = serde_json::from_slice(&body).expect("JSON body");
         assert_eq!(body["status"], "nothing_eligible");
         assert_eq!(body["published"], false);
+        assert_eq!(body["coalesced"], false);
+    }
+
+    /// The other side of the same surface: a tenant with a long-sealed hour
+    /// gets the published outcome and the merged fold report, under the field
+    /// names an operator reads. Only the HTTP layer is under test here (the
+    /// classification itself is covered above), but a dropped or renamed
+    /// field in the merge reaches an operator with nothing else to catch it.
+    ///
+    /// `state()` installs the real `SystemClock`, so the seeded hour is
+    /// relative to the current wall-clock hour rather than the fixed `NOW_NS`
+    /// the direct `fold_once` tests use.
+    #[tokio::test]
+    async fn the_response_names_the_published_outcome_and_the_fold_report() {
+        let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+        let tenant = TenantId::new("fold-on-demand-http");
+        let now_ns = SystemClock.now_ns();
+        // Three hours back: past the default sealing sum of max_flush_lifetime
+        // (1h) + clock_skew_allowance (5m) + fold_safety_margin (15m) no
+        // matter where inside the current hour the clock sits.
+        let sealed_hour = (now_ns / NS_PER_HOUR - 3) as u32;
+        seed_log_commit(store.as_ref(), &tenant, sealed_hour, 0).await;
+
+        let catalog = catalog(store.clone());
+        let (status, body) = post(
+            state(store, catalog),
+            Some(TOKEN),
+            r#"{"signal":"logs","tenant":"fold-on-demand-http"}"#,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        let body: serde_json::Value = serde_json::from_slice(&body).expect("JSON body");
+        assert_eq!(body["status"], "published");
+        assert_eq!(body["published"], true);
+        assert_eq!(body["head_advanced"], true);
+        assert_eq!(body["coalesced"], false);
+        assert_eq!(body["signal"], "logs");
+        assert_eq!(
+            body["entry_count"], 1,
+            "the seeded commit is the one entry folded in"
+        );
+        // The watermark covers the seeded hour. Not equality: the sealing sum
+        // is 1h20m, so the hour it lands in depends on where inside the
+        // current hour the wall clock sits, and pinning it would make this
+        // test pass or fail by the minute.
+        assert!(
+            body["watermark_hour"]
+                .as_u64()
+                .is_some_and(|hour| hour >= u64::from(sealed_hour)),
+            "the watermark must cover the seeded hour {sealed_hour}: {body}"
+        );
+        for field in [
+            "buckets_folded",
+            "parts_total",
+            "rebuilt",
+            "previous_watermark_hour",
+            "list_requests",
+            "get_requests",
+            "put_requests",
+            "classify_get_requests",
+        ] {
+            assert!(
+                body.get(field).is_some(),
+                "the merged report must carry {field}: {body}"
+            );
+        }
+        assert!(
+            body["buckets_folded"].as_u64().is_some_and(|n| n > 0),
+            "a fold that folded an entry listed at least one commit bucket"
+        );
+    }
+
+    /// The route's admission gate: two calls in flight for one
+    /// (tenant, signal) run ONE fold, and the one that did not run it says so
+    /// in `coalesced` while reporting the same outcome.
+    ///
+    /// The interleaving is forced, not hoped for. A `FaultStore` hold parks
+    /// the first fold inside its `HEAD` PUT, so the second call is issued
+    /// while the first is genuinely in flight; the releaser task cannot run
+    /// until both request futures have parked, because a `current_thread`
+    /// runtime only schedules it once the task driving them yields.
+    ///
+    /// Non-vacuity: without the gate both calls fold. The second would then
+    /// win the CAS the first is held on, so the two responses would carry
+    /// different statuses (`lost_cas` and `published`) and neither would be
+    /// coalesced -- the shape the race test above asserts deliberately.
+    #[tokio::test]
+    async fn two_concurrent_calls_for_one_tenant_run_one_fold() {
+        let fault_store = Arc::new(FaultStore::new(MemoryStore::new(), Default::default()));
+        let store: Arc<dyn ObjectStoreBackend> = fault_store.clone();
+        let tenant = TenantId::new("fold-on-demand-http");
+        let tenant_hash = tenant.hash();
+        let now_ns = SystemClock.now_ns();
+        let sealed_hour = (now_ns / NS_PER_HOUR - 3) as u32;
+        seed_log_commit(store.as_ref(), &tenant, sealed_hour, 0).await;
+
+        let head = crate::fold::head_key(&tenant_hash, Signal::Logs);
+        let gate = fault_store.hold(Op::Put, Some(head.clone()), Occurrence::Nth(1));
+
+        // One state, so both calls share the one coalescing gate the way two
+        // requests on one listener do.
+        let state = state(store.clone(), catalog(store.clone()));
+
+        let releaser = {
+            let gate = gate.clone();
+            tokio::spawn(async move {
+                gate.wait_until_held(1).await;
+                let held = gate.held_details();
+                assert_eq!(held.len(), 1, "exactly one call is held: {held:?}");
+                assert_eq!(held[0].2, head, "the held call is the HEAD CAS");
+                assert!(gate.release(held[0].0), "release the held HEAD CAS");
+            })
+        };
+
+        let body = r#"{"signal":"logs"}"#;
+        let (first, second) = tokio::join!(
+            post(state.clone(), Some(TOKEN), body),
+            post(state.clone(), Some(TOKEN), body),
+        );
+        releaser.await.expect("releaser task");
+
+        let mut bodies = Vec::new();
+        for (status, raw) in [first, second] {
+            assert_eq!(status, StatusCode::OK);
+            bodies.push(serde_json::from_slice::<serde_json::Value>(&raw).expect("JSON body"));
+        }
+        let coalesced: Vec<bool> = bodies
+            .iter()
+            .map(|b| b["coalesced"].as_bool().expect("coalesced is a bool"))
+            .collect();
+        assert_eq!(
+            coalesced.iter().filter(|c| **c).count(),
+            1,
+            "exactly one of the two calls ran the fold: {bodies:?}"
+        );
+        assert_eq!(
+            bodies[0]["status"], bodies[1]["status"],
+            "the coalesced call reports the fold it joined: {bodies:?}"
+        );
+        assert_eq!(bodies[0]["status"], "published");
+        assert_eq!(
+            bodies[0]["entry_count"], bodies[1]["entry_count"],
+            "both responses carry the one fold's report"
+        );
+        assert_eq!(gate.held_count(), 0, "no call is left held");
     }
 }

--- a/services/ravel-server/src/fold_on_demand.rs
+++ b/services/ravel-server/src/fold_on_demand.rs
@@ -28,6 +28,28 @@
 //! to, and an operator holding several tenants' credentials gets a check that
 //! they used the one they meant.
 //!
+//! # Admission
+//!
+//! Concurrent calls for one `(tenant, signal)` collapse into a single fold
+//! through [`SingleFlight`], the coalescing primitive the read cache already
+//! uses: one call runs the fold, every other call in flight for that key
+//! waits on its result and issues no object-store work of its own, and each
+//! response says which it was in `coalesced`. That is this route's admission
+//! gate. A fold is object-store-heavy -- it LISTs commit records, GETs parts,
+//! and PUTs new parts plus `HEAD` -- and it does that work whether or not
+//! anything turns out to be eligible, so an unguarded route would multiply
+//! that cost by the caller's own concurrency. A credential resolves to
+//! exactly one tenant (see Authorization above), so this bounds any one
+//! caller to one in-flight fold per signal, which is the same load the
+//! scheduled loop already places on that tenant.
+//!
+//! The route deliberately does not take a `QueryAdmissionController` permit
+//! the way the query surfaces do. A fold is deferred maintenance traffic and
+//! runs on the background store handle (ADR-0070); charging it against the
+//! query hot path's ceiling would let an operator's folds shed queries, and a
+//! permit bounds concurrency without removing the duplicated work that
+//! coalescing removes outright.
+//!
 //! # Concurrency
 //!
 //! Safe to call concurrently with the scheduled fold and with itself, because
@@ -35,9 +57,10 @@
 //! (docs/catalog-and-mvcc.md): every folder writes its parts under
 //! content-addressed keys and then compare-and-swaps `HEAD`. A losing CAS is
 //! an ordinary outcome, not corruption -- the loser re-reads `HEAD` and either
-//! rebases or stops, and no caller's data is lost either way. This module adds
-//! no lock of its own; a lock would only convert a cheap CAS loss into a
-//! queue.
+//! rebases or stops, and no caller's data is lost either way. The coalescing
+//! above is not a lock over the catalog: it deduplicates this route's own
+//! concurrent calls and never blocks or queues behind a fold this process did
+//! not start.
 //!
 //! # Outcomes
 //!
@@ -45,7 +68,11 @@
 //! `status` field ([`FoldOutcome`]):
 //!
 //! - `published`: this call wrote a new snapshot, advancing `HEAD` to name
-//!   content that differs from what it named before.
+//!   content that differs from what it named before. "Differs" is decided by
+//!   comparing the entry set the two `HEAD`s name, never by their entry
+//!   totals: one fold can fold new commits in and drop entries through a
+//!   retention tombstone in the same pass, and the two can cancel to an
+//!   identical total over a snapshot whose content changed.
 //! - `nothing_eligible`: no commit was eligible to fold. A fold seals an
 //!   ingest hour only once `max_flush_lifetime + clock_skew_allowance +
 //!   fold_safety_margin` has elapsed after that hour ends, so a fold
@@ -60,6 +87,7 @@
 //!   call) won the `HEAD` CAS. The catalog is fine and the winner's snapshot
 //!   is published; this call did not publish one.
 
+use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use axum::Router;
@@ -68,10 +96,12 @@ use axum::extract::{Request, State};
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::routing::post;
-use ravel_catalog::{Catalog, CatalogError, FoldReport};
+use ravel_cache::{Role, SingleFlight, SingleFlightError};
+use ravel_catalog::{Catalog, CatalogError, FoldReport, PartLimits, decode_head, decode_part};
 use ravel_ingest::Clock;
 use ravel_maintain::RetentionConfig;
 use ravel_object_store::{GetRange, ObjectStoreBackend, StoreError};
+use ravel_proto::catalog::v1::{SnapshotHead, SnapshotPartRef};
 use ravel_query::http::TenantResolver;
 use ravel_types::{Signal, TenantHash, TenantId};
 use serde::Deserialize;
@@ -151,7 +181,27 @@ pub struct OnDemandFold {
     /// operator's question is whether any data was eligible -- but the
     /// watermark move is real and is never hidden.
     pub head_advanced: bool,
+    /// Object-store GETs this route issued outside [`Catalog::fold`]: the
+    /// `HEAD` reads that bracket the fold, plus any snapshot part read to
+    /// decide whether the entry set changed. Reported separately from the
+    /// fold report's own `get_requests` because it is a different phase's
+    /// cost, and two phases' request counts are not summable into one figure.
+    pub classify_get_requests: u64,
 }
+
+/// Coalescing key: one in-flight fold per `(tenant, signal)`, which is the
+/// granularity [`Catalog::fold`] itself operates at.
+type FoldKey = (TenantHash, Signal);
+
+/// The route's admission gate (see the module docs): concurrent calls for one
+/// `(tenant, signal)` run one fold and share its result.
+///
+/// The value is `Arc`-wrapped because [`SingleFlight`] hands every waiter a
+/// clone, and so is the error: [`CatalogError`] is not `Clone` (it carries
+/// non-cloneable store and format errors), and an `Arc` shares the one real
+/// error rather than flattening it to a string that the 503 path could no
+/// longer log in full.
+pub type FoldInFlight = SingleFlight<FoldKey, Arc<OnDemandFold>, Arc<CatalogError>>;
 
 /// Shared state for the route: the same [`Catalog`] the query paths resolve
 /// through and the scheduled fold folds with, the store (read directly for the
@@ -173,6 +223,11 @@ pub struct OnDemandFoldState {
     /// The deployment-default retention window source (ADR-0078), the same
     /// `RetentionConfig` the scheduled fold and the Maintain-mode sweep use.
     pub retention: Arc<RetentionConfig>,
+    /// The route's admission gate. One instance per process, shared by every
+    /// listener this route is mounted on, so a call arriving on the mTLS
+    /// listener coalesces with a concurrent one on `--listen-http` instead of
+    /// running a second fold for the same tenant.
+    pub in_flight: Arc<FoldInFlight>,
 }
 
 /// The `/api/v1/admin/fold` router.
@@ -248,27 +303,48 @@ async fn run(state: &OnDemandFoldState, req: Request<Body>) -> Result<Response, 
     let now_ns = state.clock.now_ns();
     let default_retention_ns = state.retention.window_for(&tenant_hash);
 
-    let result = fold_once(
-        state.catalog.as_ref(),
-        state.store.as_ref(),
-        &tenant_hash,
-        signal,
-        state.folder_id,
-        now_ns,
-        default_retention_ns,
-    )
-    .await
-    .map_err(|err| {
+    // The admission gate (module docs): a concurrent call for this
+    // (tenant, signal) joins the fold already running instead of starting a
+    // second one over the same objects.
+    let (outcome, role) = state
+        .in_flight
+        .run((tenant_hash, signal), || async {
+            fold_once(
+                state.catalog.as_ref(),
+                state.store.as_ref(),
+                &tenant_hash,
+                signal,
+                state.folder_id,
+                now_ns,
+                default_retention_ns,
+            )
+            .await
+            .map(Arc::new)
+            .map_err(Arc::new)
+        })
+        .await;
+
+    let result = outcome.map_err(|err| {
         // Same redaction discipline as the query surfaces: a `CatalogError`
         // embeds the physical object key, and the tenant hash inside it, so
         // the full error is logged server-side and the caller gets a
-        // class-level message.
-        tracing::warn!(
-            tenant = %tenant_hash.to_hex(),
-            signal = ?signal,
-            error = %err,
-            "on-demand catalog fold failed"
-        );
+        // class-level message. A lost leader (the coalesced-into call was
+        // cancelled, typically a client disconnect) is reported the same way:
+        // nothing is known about the fold's outcome, and the call is
+        // retryable.
+        match &err {
+            SingleFlightError::Upstream(err) => tracing::warn!(
+                tenant = %tenant_hash.to_hex(),
+                signal = ?signal,
+                error = %err,
+                "on-demand catalog fold failed"
+            ),
+            SingleFlightError::LeaderLost => tracing::warn!(
+                tenant = %tenant_hash.to_hex(),
+                signal = ?signal,
+                "on-demand catalog fold: the fold this call coalesced into was cancelled"
+            ),
+        }
         ApiError {
             status: StatusCode::SERVICE_UNAVAILABLE,
             error_type: "unavailable",
@@ -276,10 +352,12 @@ async fn run(state: &OnDemandFoldState, req: Request<Body>) -> Result<Response, 
         }
     })?;
 
+    let coalesced = role == Role::Follower;
     tracing::info!(
         tenant = %tenant_hash.to_hex(),
         signal = ?signal,
         outcome = result.outcome.as_str(),
+        coalesced,
         watermark_hour = ?result.report.as_ref().and_then(|r| r.watermark_hour),
         "on-demand catalog fold complete"
     );
@@ -291,6 +369,13 @@ async fn run(state: &OnDemandFoldState, req: Request<Body>) -> Result<Response, 
         "message": result.outcome.message(),
         "tenant_hash": tenant_hash.to_hex(),
         "signal": body.signal,
+        // `true` when this request did not run the fold itself but coalesced
+        // into one already in flight for the same (tenant, signal) and is
+        // reporting that fold's outcome. The catalog state the outcome
+        // describes is this request's answer either way; what differs is
+        // which request paid for it.
+        "coalesced": coalesced,
+        "classify_get_requests": result.classify_get_requests,
     });
     if let Some(report) = &result.report {
         // `as_object_mut` is `Some` for the literal above, which is an object;
@@ -332,8 +417,8 @@ async fn run(state: &OnDemandFoldState, req: Request<Body>) -> Result<Response, 
 ///   somebody else published while this call was folding.
 /// - A fold whose sealing watermark advanced over hours that held no commits
 ///   rewrites `HEAD` and reports `no_op: false`, having folded nothing. The
-///   previous `HEAD`'s entry count tells that apart from a fold that really
-///   changed the snapshot's content.
+///   two `HEAD`s' entry sets tell that apart from a fold that really changed
+///   the snapshot's content (see [`snapshot_content_changed`]).
 pub async fn fold_once(
     catalog: &Catalog,
     store: &dyn ObjectStoreBackend,
@@ -343,36 +428,68 @@ pub async fn fold_once(
     now_ns: i64,
     default_retention_ns: Option<i64>,
 ) -> Result<OnDemandFold, CatalogError> {
-    let before = read_head(store, tenant, signal)
+    let mut gets = 0u64;
+    let before = read_head(store, tenant, signal, &mut gets)
         .await
         .map_err(CatalogError::Store)?;
-    let entries_before = head_entry_count(before.as_deref());
 
     match catalog
         .fold(tenant, signal, folder_id, now_ns, &[], default_retention_ns)
         .await
     {
         Ok(report) if !report.no_op => {
-            // `HEAD` was rewritten. Whether anything was *eligible* is a
-            // second question: an ingest hour that seals while holding no
-            // commit still advances the watermark, and the resulting snapshot
-            // names exactly the entries the previous one did. Comparing the
-            // entry counts answers it in either direction -- a fold that
-            // folds new commits in, and one that drops entries through a
-            // retention tombstone, both changed the snapshot's content.
-            let outcome = if report.entry_count == entries_before {
-                FoldOutcome::NothingEligible
-            } else {
+            // `HEAD` was rewritten by this call. Whether anything was
+            // *eligible* is a second question: an ingest hour that seals while
+            // holding no commit still advances the watermark, and the
+            // resulting snapshot names exactly the entries the previous one
+            // did. Only the entry set answers that. Entry totals do not: a
+            // single fold can fold new commits in and drop entries through a
+            // retention tombstone, and if those cancel, the total is
+            // unchanged over content that is not.
+            let after = match read_head(store, tenant, signal, &mut gets).await {
+                Ok(after) => after,
+                Err(err) => {
+                    // The fold published; only the check of what it published
+                    // failed. `nothing_eligible` is a definite negative claim,
+                    // so it is never the answer to a check that did not run.
+                    tracing::warn!(
+                        tenant = %tenant.to_hex(),
+                        signal = ?signal,
+                        error = %err,
+                        "on-demand catalog fold: HEAD unreadable after a publishing fold; \
+                         reporting published without the content comparison"
+                    );
+                    return Ok(OnDemandFold {
+                        outcome: FoldOutcome::Published,
+                        report: Some(report),
+                        head_advanced: true,
+                        classify_get_requests: gets,
+                    });
+                }
+            };
+            let changed = snapshot_content_changed(
+                store,
+                tenant,
+                signal,
+                before.as_deref(),
+                after.as_deref(),
+                &mut gets,
+            )
+            .await;
+            let outcome = if changed {
                 FoldOutcome::Published
+            } else {
+                FoldOutcome::NothingEligible
             };
             Ok(OnDemandFold {
                 outcome,
                 report: Some(report),
                 head_advanced: true,
+                classify_get_requests: gets,
             })
         }
         Ok(report) => {
-            let after = read_head(store, tenant, signal)
+            let after = read_head(store, tenant, signal, &mut gets)
                 .await
                 .map_err(CatalogError::Store)?;
             let outcome = if after == before {
@@ -384,6 +501,7 @@ pub async fn fold_once(
                 outcome,
                 report: Some(report),
                 head_advanced: false,
+                classify_get_requests: gets,
             })
         }
         // The catalog retries a losing CAS internally and only surfaces this
@@ -401,6 +519,7 @@ pub async fn fold_once(
                 outcome: FoldOutcome::LostCas,
                 report: None,
                 head_advanced: false,
+                classify_get_requests: gets,
             })
         }
         Err(err) => Err(err),
@@ -415,7 +534,9 @@ async fn read_head(
     store: &dyn ObjectStoreBackend,
     tenant: &TenantHash,
     signal: Signal,
+    gets: &mut u64,
 ) -> Result<Option<Vec<u8>>, StoreError> {
+    *gets += 1;
     match store
         .get(&crate::fold::head_key(tenant, signal), GetRange::Full)
         .await
@@ -426,25 +547,195 @@ async fn read_head(
     }
 }
 
-/// Entries named by a `HEAD` object, summed over its parts. `0` for an absent
-/// `HEAD`, and for one this process cannot decode -- both mean "no snapshot
-/// content to compare against", and a fold over either rebuilds from the
-/// commit layout anyway.
-fn head_entry_count(head: Option<&[u8]>) -> u64 {
-    head.and_then(|bytes| ravel_catalog::decode_head(bytes).ok())
-        .map(|head| head.parts.iter().map(|part| part.entry_count).sum())
-        .unwrap_or(0)
+/// Snapshot parts read to compare two `HEAD`s' entry sets, per side. Only
+/// parts whose content actually changed are ever read (see
+/// [`snapshot_content_changed`]): a watermark-only rewrite changes exactly one
+/// (the tail), and a rebuild that re-derives the same entries changes none,
+/// because a part's `blake3` is over its bytes. A remainder larger than this
+/// means many parts' contents differ, which is already the answer, so the cap
+/// bounds the comparison's cost without changing what it concludes.
+const MAX_COMPARED_PARTS: usize = 8;
+
+/// Whether the entry set named by `HEAD` differs between `before` and `after`.
+///
+/// This never errors: it answers the classification question, and the fold it
+/// classifies has already published. When the comparison cannot be completed
+/// (an undecodable `HEAD`, a part that has since been swept, a remainder past
+/// [`MAX_COMPARED_PARTS`]) it answers `true` and logs, because
+/// `nothing_eligible` asserts that no commit entered or left the snapshot and
+/// that is not something an incomplete comparison has shown.
+///
+/// The comparison is cheap in every ordinary case. Parts are content
+/// addressed, so a part carrying the same `blake3` on both sides holds the
+/// same entries by construction and needs no read; only the remainder on each
+/// side is fetched and decoded.
+async fn snapshot_content_changed(
+    store: &dyn ObjectStoreBackend,
+    tenant: &TenantHash,
+    signal: Signal,
+    before: Option<&[u8]>,
+    after: Option<&[u8]>,
+    gets: &mut u64,
+) -> bool {
+    let after = match after.map(decode_head) {
+        Some(Ok(head)) => head,
+        other => {
+            tracing::warn!(
+                tenant = %tenant.to_hex(),
+                signal = ?signal,
+                present = other.is_some(),
+                "on-demand catalog fold: the new HEAD did not decode; \
+                 reporting published without the content comparison"
+            );
+            return true;
+        }
+    };
+    // An absent previous HEAD is the empty snapshot, which is a real
+    // comparand: a first fold over hours that hold nothing publishes a HEAD
+    // naming zero entries, and nothing was eligible for it either. A present
+    // but undecodable one is not, and falls through to the mismatch below.
+    let before: Option<SnapshotHead> = match before.map(decode_head) {
+        None => None,
+        Some(Ok(head)) => Some(head),
+        Some(Err(err)) => {
+            tracing::warn!(
+                tenant = %tenant.to_hex(),
+                signal = ?signal,
+                error = %err,
+                "on-demand catalog fold: the previous HEAD did not decode; \
+                 reporting published without the content comparison"
+            );
+            return true;
+        }
+    };
+    let before_parts: &[SnapshotPartRef] = before.as_ref().map_or(&[], |head| &head.parts);
+
+    if entry_total(before_parts) != entry_total(&after.parts) {
+        return true;
+    }
+    let before_only = parts_absent_from(before_parts, &after.parts);
+    let after_only = parts_absent_from(&after.parts, before_parts);
+    if before_only.is_empty() && after_only.is_empty() {
+        return false;
+    }
+    if before_only.len() > MAX_COMPARED_PARTS || after_only.len() > MAX_COMPARED_PARTS {
+        tracing::warn!(
+            tenant = %tenant.to_hex(),
+            signal = ?signal,
+            before_only = before_only.len(),
+            after_only = after_only.len(),
+            "on-demand catalog fold: too many parts differ to compare entry sets; \
+             reporting published"
+        );
+        return true;
+    }
+    let (Some(before_entries), Some(after_entries)) = (
+        read_entry_ids(store, tenant, signal, &before_only, gets).await,
+        read_entry_ids(store, tenant, signal, &after_only, gets).await,
+    ) else {
+        return true;
+    };
+    before_entries != after_entries
+}
+
+/// Entries named across a `HEAD`'s parts.
+fn entry_total(parts: &[SnapshotPartRef]) -> u64 {
+    parts.iter().map(|part| part.entry_count).sum()
+}
+
+/// The parts of `parts` whose bytes no part of `other` also names. Matching is
+/// on `blake3` alone: it is the hash of the part's full bytes, and the part
+/// key embeds a prefix of it, so equal hashes mean equal entries.
+fn parts_absent_from<'a>(
+    parts: &'a [SnapshotPartRef],
+    other: &[SnapshotPartRef],
+) -> Vec<&'a SnapshotPartRef> {
+    let present: BTreeSet<&[u8]> = other.iter().map(|part| part.blake3.as_slice()).collect();
+    parts
+        .iter()
+        .filter(|part| !present.contains(part.blake3.as_slice()))
+        .collect()
+}
+
+/// One snapshot entry's identity plus the object it names:
+/// `(level, shard, ingest_hour_bucket, writer_id, writer_epoch, writer_seq,
+/// content_hash)`. The leading tuple is the fold's own dedup key
+/// (`ravel_catalog::EntryIdentity`); `content_hash` is carried too so a
+/// rewritten entry for one identity counts as a change.
+type EntryId = (u32, u32, u32, Vec<u8>, u64, u64, Vec<u8>);
+
+/// Every entry identity across `parts`, or `None` if any part could not be
+/// read or decoded (the caller then declines to claim the sets are equal).
+async fn read_entry_ids(
+    store: &dyn ObjectStoreBackend,
+    tenant: &TenantHash,
+    signal: Signal,
+    parts: &[&SnapshotPartRef],
+    gets: &mut u64,
+) -> Option<BTreeSet<EntryId>> {
+    let limits = PartLimits::default();
+    let mut ids = BTreeSet::new();
+    for part in parts {
+        *gets += 1;
+        let bytes = match store.get(&part.key, GetRange::Full).await {
+            Ok(got) => got.data,
+            Err(err) => {
+                tracing::warn!(
+                    tenant = %tenant.to_hex(),
+                    signal = ?signal,
+                    key = %part.key,
+                    error = %err,
+                    "on-demand catalog fold: a snapshot part named by HEAD could not be read"
+                );
+                return None;
+            }
+        };
+        let decoded = match decode_part(&bytes, &limits) {
+            Ok(decoded) => decoded,
+            Err(err) => {
+                tracing::warn!(
+                    tenant = %tenant.to_hex(),
+                    signal = ?signal,
+                    key = %part.key,
+                    error = %err,
+                    "on-demand catalog fold: a snapshot part named by HEAD did not decode"
+                );
+                return None;
+            }
+        };
+        for entry in decoded.entries {
+            ids.insert((
+                entry.level,
+                entry.shard,
+                entry.ingest_hour_bucket,
+                entry.writer_id,
+                entry.writer_epoch,
+                entry.writer_seq,
+                entry.content_hash,
+            ));
+        }
+    }
+    Some(ids)
 }
 
 fn authenticate(state: &OnDemandFoldState, headers: &HeaderMap) -> Result<TenantId, ApiError> {
-    state
-        .tenant_resolver
-        .resolve(headers)
-        .map_err(|_| ApiError {
+    state.tenant_resolver.resolve(headers).map_err(|err| {
+        // The same discipline the fold path applies to a catalog fault: the
+        // caller gets a class-level answer, the server keeps the error. A
+        // resolver that failed because its durable auth map was unreachable
+        // is a deployment fault, not a bad credential, and a bare 401 leaves
+        // no trace of it anywhere.
+        tracing::warn!(
+            error = %err,
+            route = FOLD_ROUTE,
+            "on-demand catalog fold: tenant resolution failed"
+        );
+        ApiError {
             status: StatusCode::UNAUTHORIZED,
             error_type: "unauthorized",
             message: "authentication required".to_string(),
-        })
+        }
+    })
 }
 
 /// The endpoint's error shape, mirroring the sibling query endpoints' typed
@@ -852,6 +1143,7 @@ mod tests {
             clock: Arc::new(SystemClock),
             folder_id: Uuid::from_u128(1),
             retention: Arc::new(RetentionConfig::default()),
+            in_flight: Arc::new(FoldInFlight::new()),
         }
     }
 

--- a/services/ravel-server/src/fold_on_demand.rs
+++ b/services/ravel-server/src/fold_on_demand.rs
@@ -1,0 +1,856 @@
+//! `POST /api/v1/admin/fold`: an operator-triggered catalog fold for one
+//! tenant and one signal (issue #785).
+//!
+//! The scheduled fold ([`crate::fold`]) runs on a fixed cadence over every
+//! discovered tenant. This route is the on-demand form of the same operation:
+//! one tenant, one signal, one [`Catalog::fold`] call, with the identical
+//! arguments the background loop passes (a per-process `folder_id`, an
+//! injected clock, and the deployment-default retention window resolved from
+//! the same CLI-derived [`RetentionConfig`]). It changes nothing about the
+//! scheduled fold's cadence or behavior, and it adds no second fold
+//! mechanism: both call the one `Catalog::fold` entry point.
+//!
+//! # Authorization
+//!
+//! The same authorization every tenant-scoped route on `--listen-http` (and
+//! the mTLS listener) requires: the configured
+//! [`TenantResolver`] chain resolves the request's credential to a
+//! [`TenantId`], and the fold runs for exactly that tenant. There is no
+//! separate admin auth path in this crate to reuse, and inventing one is out
+//! of scope, so the credential that authorizes reading a tenant's data
+//! (`/api/v1/sql`, `/api/v1/query`) is the credential that authorizes folding
+//! its catalog. A fold neither reveals data nor destroys any: it rewrites a
+//! query-cost index the tenant already owns.
+//!
+//! The body may also name the tenant explicitly. When it does, the name must
+//! hash to the authenticated tenant or the request is refused with 403: the
+//! endpoint never folds a tenant other than the one the credential resolves
+//! to, and an operator holding several tenants' credentials gets a check that
+//! they used the one they meant.
+//!
+//! # Concurrency
+//!
+//! Safe to call concurrently with the scheduled fold and with itself, because
+//! a fold publishes through the `HEAD` CAS protocol
+//! (docs/catalog-and-mvcc.md): every folder writes its parts under
+//! content-addressed keys and then compare-and-swaps `HEAD`. A losing CAS is
+//! an ordinary outcome, not corruption -- the loser re-reads `HEAD` and either
+//! rebases or stops, and no caller's data is lost either way. This module adds
+//! no lock of its own; a lock would only convert a cheap CAS loss into a
+//! queue.
+//!
+//! # Outcomes
+//!
+//! Three distinct outcomes, always 200, always named in the response body's
+//! `status` field ([`FoldOutcome`]):
+//!
+//! - `published`: this call wrote a new snapshot and advanced `HEAD`.
+//! - `nothing_eligible`: nothing was sealable, so no snapshot was published
+//!   and `HEAD` is untouched. A fold seals an ingest hour only once
+//!   `max_flush_lifetime + clock_skew_allowance + fold_safety_margin` has
+//!   elapsed after that hour ends, so a fold triggered right after a load
+//!   seals nothing. That is the rule working, not a failure, which is exactly
+//!   why it is a separate status rather than a `published` with zero counters.
+//! - `lost_cas`: a concurrent fold (the scheduled loop, or another operator
+//!   call) won the `HEAD` CAS. The catalog is fine and the winner's snapshot
+//!   is published; this call did not publish one.
+
+use std::sync::Arc;
+
+use axum::Router;
+use axum::body::Body;
+use axum::extract::{Request, State};
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::routing::post;
+use ravel_catalog::{Catalog, CatalogError, FoldReport};
+use ravel_ingest::Clock;
+use ravel_maintain::RetentionConfig;
+use ravel_object_store::{GetRange, ObjectStoreBackend, StoreError};
+use ravel_query::http::TenantResolver;
+use ravel_types::{Signal, TenantHash, TenantId};
+use serde::Deserialize;
+use serde_json::json;
+use uuid::Uuid;
+
+/// The route an operator invokes. Named here so the wiring, the tests, and
+/// the doc all refer to one string.
+pub const FOLD_ROUTE: &str = "/api/v1/admin/fold";
+
+/// Cap on the request body. The request is a signal name and an optional
+/// tenant name; this mirrors the defensive bound the sibling query handlers
+/// apply.
+const MAX_BODY_BYTES: usize = 64 * 1024;
+
+/// What an on-demand fold actually did. These are three different facts an
+/// operator needs to tell apart, so they are three values rather than a
+/// boolean plus a log line.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FoldOutcome {
+    /// A new snapshot was published and `HEAD` now names it.
+    Published,
+    /// Nothing was eligible to fold: no ingest hour has sealed beyond the
+    /// previous watermark, so no snapshot was published and `HEAD` is
+    /// unchanged.
+    NothingEligible,
+    /// A concurrent fold won the `HEAD` CAS. This call published nothing; the
+    /// winner's snapshot is what `HEAD` names.
+    LostCas,
+}
+
+impl FoldOutcome {
+    /// The wire spelling, and the one an operator greps for.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            FoldOutcome::Published => "published",
+            FoldOutcome::NothingEligible => "nothing_eligible",
+            FoldOutcome::LostCas => "lost_cas",
+        }
+    }
+
+    /// One sentence for a human reading the response, because the two
+    /// non-publishing outcomes are the ones that get misread as a broken
+    /// feature.
+    fn message(self) -> &'static str {
+        match self {
+            FoldOutcome::Published => "a new catalog snapshot was published",
+            FoldOutcome::NothingEligible => {
+                "nothing was eligible to fold, so no snapshot was published and HEAD is \
+                 unchanged; an ingest hour seals only once max_flush_lifetime + \
+                 clock_skew_allowance + fold_safety_margin has elapsed after that hour ends"
+            }
+            FoldOutcome::LostCas => {
+                "a concurrent fold won the HEAD compare-and-swap; this call published no \
+                 snapshot and the winner's snapshot is the current HEAD"
+            }
+        }
+    }
+}
+
+/// One on-demand fold's result: the outcome plus the underlying report when
+/// there is one. The report is `None` only for a [`FoldOutcome::LostCas`]
+/// reached by exhausting the catalog's own CAS retries, where no fold attempt
+/// produced a report.
+#[derive(Debug)]
+pub struct OnDemandFold {
+    pub outcome: FoldOutcome,
+    pub report: Option<FoldReport>,
+}
+
+/// Shared state for the route: the same [`Catalog`] the query paths resolve
+/// through and the scheduled fold folds with, the store (read directly for the
+/// `HEAD` before/after comparison below), the deployment's tenant resolver,
+/// an injected clock, this process's `folder_id`, and the CLI-derived
+/// retention config the scheduled fold also passes into every fold.
+#[derive(Clone)]
+pub struct OnDemandFoldState {
+    pub catalog: Arc<Catalog>,
+    pub store: Arc<dyn ObjectStoreBackend>,
+    pub tenant_resolver: Arc<dyn TenantResolver>,
+    /// Injected clock. Library logic never calls `SystemTime::now()`; the
+    /// handler reads it once per request and passes that `now_ns` into the
+    /// fold, so the sealing window is deterministic under test.
+    pub clock: Arc<dyn Clock>,
+    /// One `folder_id` per process start, matching [`crate::fold::spawn`]'s
+    /// rule (proto/ravel/catalog.proto, `SnapshotHead.folder_id`).
+    pub folder_id: Uuid,
+    /// The deployment-default retention window source (ADR-0078), the same
+    /// `RetentionConfig` the scheduled fold and the Maintain-mode sweep use.
+    pub retention: Arc<RetentionConfig>,
+}
+
+/// The `/api/v1/admin/fold` router.
+pub fn router(state: OnDemandFoldState) -> Router {
+    Router::new()
+        .route(FOLD_ROUTE, post(handle))
+        .with_state(state)
+}
+
+#[derive(Debug, Deserialize)]
+struct FoldBody {
+    /// Which signal's catalog to fold. Required, never defaulted: a tenant can
+    /// hold metrics, logs, and spans independently, and folding metrics on a
+    /// logs-only tenant seals nothing while reporting a perfectly healthy
+    /// `nothing_eligible`. A silent default would make that indistinguishable
+    /// from a real empty window.
+    signal: String,
+    /// Optional explicit tenant name, checked against the authenticated
+    /// tenant. Present or absent, the fold only ever runs for the tenant the
+    /// credential resolves to.
+    #[serde(default)]
+    tenant: Option<String>,
+}
+
+/// Parses the `signal` field. Only the three signals the fold task itself
+/// covers are accepted; the rest are control-plane shards with no snapshot to
+/// fold.
+fn parse_signal(raw: &str) -> Option<Signal> {
+    match raw {
+        "metrics" => Some(Signal::Metrics),
+        "logs" => Some(Signal::Logs),
+        "spans" => Some(Signal::Spans),
+        _ => None,
+    }
+}
+
+async fn handle(State(state): State<OnDemandFoldState>, req: Request<Body>) -> Response {
+    match run(&state, req).await {
+        Ok(response) => response,
+        Err(err) => err.into_response(),
+    }
+}
+
+async fn run(state: &OnDemandFoldState, req: Request<Body>) -> Result<Response, ApiError> {
+    let headers = req.headers().clone();
+    let tenant = authenticate(state, &headers)?;
+    let tenant_hash = tenant.hash();
+
+    let body = axum::body::to_bytes(req.into_body(), MAX_BODY_BYTES)
+        .await
+        .map_err(|e| ApiError::bad_request(format!("could not read request body: {e}")))?;
+    let body: FoldBody = serde_json::from_slice(&body)
+        .map_err(|e| ApiError::bad_request(format!("invalid JSON request body: {e}")))?;
+
+    let signal = parse_signal(&body.signal).ok_or_else(|| {
+        ApiError::bad_request(format!(
+            "unknown signal {:?}; expected one of \"metrics\", \"logs\", \"spans\"",
+            body.signal
+        ))
+    })?;
+
+    if let Some(named) = &body.tenant
+        && TenantId::new(named.clone()).hash() != tenant_hash
+    {
+        return Err(ApiError {
+            status: StatusCode::FORBIDDEN,
+            error_type: "forbidden",
+            message: "the tenant named in the request body is not the authenticated tenant"
+                .to_string(),
+        });
+    }
+
+    let now_ns = state.clock.now_ns();
+    let default_retention_ns = state.retention.window_for(&tenant_hash);
+
+    let result = fold_once(
+        state.catalog.as_ref(),
+        state.store.as_ref(),
+        &tenant_hash,
+        signal,
+        state.folder_id,
+        now_ns,
+        default_retention_ns,
+    )
+    .await
+    .map_err(|err| {
+        // Same redaction discipline as the query surfaces: a `CatalogError`
+        // embeds the physical object key, and the tenant hash inside it, so
+        // the full error is logged server-side and the caller gets a
+        // class-level message.
+        tracing::warn!(
+            tenant = %tenant_hash.to_hex(),
+            signal = ?signal,
+            error = %err,
+            "on-demand catalog fold failed"
+        );
+        ApiError {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            error_type: "unavailable",
+            message: "the catalog fold could not complete; retry".to_string(),
+        }
+    })?;
+
+    tracing::info!(
+        tenant = %tenant_hash.to_hex(),
+        signal = ?signal,
+        outcome = result.outcome.as_str(),
+        watermark_hour = ?result.report.as_ref().and_then(|r| r.watermark_hour),
+        "on-demand catalog fold complete"
+    );
+
+    let mut payload = json!({
+        "status": result.outcome.as_str(),
+        "published": result.outcome == FoldOutcome::Published,
+        "message": result.outcome.message(),
+        "tenant_hash": tenant_hash.to_hex(),
+        "signal": body.signal,
+    });
+    if let Some(report) = &result.report {
+        // `as_object_mut` is `Some` for the literal above, which is an object;
+        // the fields are merged rather than nested so a small response stays
+        // one flat record an operator can read at a glance.
+        if let Some(map) = payload.as_object_mut() {
+            map.insert("watermark_hour".into(), json!(report.watermark_hour));
+            map.insert(
+                "previous_watermark_hour".into(),
+                json!(report.previous_watermark_hour),
+            );
+            map.insert("rebuilt".into(), json!(report.rebuilt));
+            map.insert("buckets_folded".into(), json!(report.buckets_folded));
+            map.insert("entry_count".into(), json!(report.entry_count));
+            map.insert("parts_total".into(), json!(report.parts_total));
+            map.insert("list_requests".into(), json!(report.list_requests));
+            map.insert("get_requests".into(), json!(report.get_requests));
+            map.insert("put_requests".into(), json!(report.put_requests));
+        }
+    }
+    Ok((StatusCode::OK, axum::Json(payload)).into_response())
+}
+
+/// One on-demand fold, with the outcome classified. Separated from the HTTP
+/// layer so a test drives the three outcomes without a transport, exactly as
+/// [`crate::maintain::run_tick`] is separated from its timer.
+///
+/// `now_ns` is the caller's clock reading: this function never reads a clock,
+/// so the sealing window is deterministic under test.
+///
+/// Classification needs the `HEAD` object from before the fold, because
+/// [`Catalog::fold`]'s own report cannot distinguish the two non-publishing
+/// cases on its own. A fold that loses the `HEAD` CAS re-reads `HEAD`, finds
+/// the winner's watermark already covers its own, and returns a `no_op`
+/// report -- byte-identical in shape to the report for "nothing has sealed".
+/// The `HEAD` object itself tells them apart: unchanged means nothing
+/// happened, changed means somebody else published while this call was
+/// folding.
+pub async fn fold_once(
+    catalog: &Catalog,
+    store: &dyn ObjectStoreBackend,
+    tenant: &TenantHash,
+    signal: Signal,
+    folder_id: Uuid,
+    now_ns: i64,
+    default_retention_ns: Option<i64>,
+) -> Result<OnDemandFold, CatalogError> {
+    let before = read_head(store, tenant, signal)
+        .await
+        .map_err(CatalogError::Store)?;
+
+    match catalog
+        .fold(tenant, signal, folder_id, now_ns, &[], default_retention_ns)
+        .await
+    {
+        Ok(report) if !report.no_op => Ok(OnDemandFold {
+            outcome: FoldOutcome::Published,
+            report: Some(report),
+        }),
+        Ok(report) => {
+            let after = read_head(store, tenant, signal)
+                .await
+                .map_err(CatalogError::Store)?;
+            let outcome = if after == before {
+                FoldOutcome::NothingEligible
+            } else {
+                FoldOutcome::LostCas
+            };
+            Ok(OnDemandFold {
+                outcome,
+                report: Some(report),
+            })
+        }
+        // The catalog retries a losing CAS internally and only surfaces this
+        // once its retry budget is spent, which takes a sustained run of
+        // concurrent winners. It is still a lost race, not corruption, so it
+        // is reported as one rather than as a fold failure.
+        Err(CatalogError::FoldCasRetriesExhausted { attempts, .. }) => {
+            tracing::info!(
+                tenant = %tenant.to_hex(),
+                signal = ?signal,
+                attempts,
+                "on-demand catalog fold exhausted its HEAD CAS retries; concurrent folders won"
+            );
+            Ok(OnDemandFold {
+                outcome: FoldOutcome::LostCas,
+                report: None,
+            })
+        }
+        Err(err) => Err(err),
+    }
+}
+
+/// The current `HEAD` object's bytes, or `None` when no fold has ever
+/// published for this `(tenant, signal)`. Read directly rather than through
+/// the catalog's cached view: this is the before/after identity the outcome
+/// classification turns on, so a cached answer would be exactly wrong.
+async fn read_head(
+    store: &dyn ObjectStoreBackend,
+    tenant: &TenantHash,
+    signal: Signal,
+) -> Result<Option<Vec<u8>>, StoreError> {
+    match store
+        .get(&crate::fold::head_key(tenant, signal), GetRange::Full)
+        .await
+    {
+        Ok(got) => Ok(Some(got.data.to_vec())),
+        Err(StoreError::NotFound) => Ok(None),
+        Err(err) => Err(err),
+    }
+}
+
+fn authenticate(state: &OnDemandFoldState, headers: &HeaderMap) -> Result<TenantId, ApiError> {
+    state.tenant_resolver.resolve(headers).map_err(|_| ApiError {
+        status: StatusCode::UNAUTHORIZED,
+        error_type: "unauthorized",
+        message: "authentication required".to_string(),
+    })
+}
+
+/// The endpoint's error shape, mirroring the sibling query endpoints' typed
+/// JSON body.
+struct ApiError {
+    status: StatusCode,
+    error_type: &'static str,
+    message: String,
+}
+
+impl ApiError {
+    fn bad_request(message: String) -> Self {
+        ApiError {
+            status: StatusCode::BAD_REQUEST,
+            error_type: "bad_data",
+            message,
+        }
+    }
+}
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> Response {
+        (
+            self.status,
+            axum::Json(json!({
+                "status": "error",
+                "errorType": self.error_type,
+                "error": self.message,
+            })),
+        )
+            .into_response()
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    use axum::http::Request as HttpRequest;
+    use bytes::Bytes;
+    use ravel_catalog::CatalogConfig;
+    use ravel_commit::publish::{self, RetryPolicy};
+    use ravel_commit::record::{self, NewCommitRecord};
+    use ravel_ingest::SystemClock;
+    use ravel_logseg::{
+        AttrValue, LogRecord, ObjectIdentity, RlogConfig, RlogWriter, stream_attrs_bytes,
+    };
+    use ravel_object_store::PutOptions;
+    use ravel_object_store::fault::{FaultStore, Occurrence, Op};
+    use ravel_object_store::memory::MemoryStore;
+    use ravel_query::http::StaticBearerTokenResolver;
+    use ravel_types::logstream::log_stream_id;
+    use tower::ServiceExt;
+
+    const NS_PER_HOUR: i64 = 3_600_000_000_000;
+    const TOKEN: &str = "operator-token";
+
+    /// A fixed "now" well past any real ingest hour used below, so the
+    /// sealing arithmetic in these tests never depends on the wall clock.
+    const NOW_NS: i64 = 100_000 * NS_PER_HOUR;
+
+    fn catalog(store: Arc<dyn ObjectStoreBackend>) -> Arc<Catalog> {
+        Arc::new(
+            Catalog::new(
+                store,
+                CatalogConfig {
+                    shard_count: 1,
+                    ..CatalogConfig::default()
+                },
+            )
+            .expect("build catalog"),
+        )
+    }
+
+    /// Seeds one durable log flush (a real RLOG object plus its commit
+    /// record) at `ingest_hour`, the same shape `tests/fold_e2e.rs` seeds.
+    /// Writing the commit at a chosen hour, rather than ingesting live, is
+    /// what makes the sealing window deterministic: the fold's eligibility
+    /// depends on `now_ns - end(ingest_hour)`, and both are chosen here.
+    async fn seed_log_commit(
+        store: &dyn ObjectStoreBackend,
+        tenant: &TenantId,
+        ingest_hour: u32,
+        seq: u64,
+    ) {
+        let tenant_hash = tenant.hash();
+        let shard = 0u32;
+        let writer_id = Uuid::from_u128(0x0000_0000_0000_0000_0000_0000_0000_0007);
+        let epoch = 1u64;
+
+        let resource_attrs = vec![(
+            "service.name".to_string(),
+            AttrValue::Str("checkout".to_string()),
+        )];
+        let stream_attrs = stream_attrs_bytes(&resource_attrs, "", "", &[]);
+        let stream_id = log_stream_id(&resource_attrs, "", "", &[]);
+        let created_unix_ns = i64::from(ingest_hour) * NS_PER_HOUR;
+
+        let identity = ObjectIdentity {
+            tenant_hash: tenant_hash.0,
+            shard,
+            writer_id: writer_id.into_bytes(),
+            writer_epoch: epoch,
+            writer_seq: seq,
+        };
+        let mut writer = RlogWriter::new(RlogConfig::default(), identity);
+        writer
+            .push(LogRecord {
+                stream_id,
+                stream_attrs,
+                ts_ns: created_unix_ns,
+                observed_ts_ns: created_unix_ns,
+                severity_num: 9,
+                severity_text: "INFO".to_string(),
+                body: "checkout completed".to_string(),
+                trace_id: None,
+                span_id: None,
+                flags: 0,
+                attrs: Vec::new(),
+            })
+            .expect("push log record");
+        let bytes = writer.finish().expect("finish RLOG object");
+
+        let content_hash = [0x5au8; 32];
+        let data_key = ravel_commit::keys::data_key(
+            &tenant_hash,
+            Signal::Logs,
+            shard,
+            writer_id,
+            epoch,
+            seq,
+            &content_hash,
+        )
+        .expect("build data key");
+        store
+            .put(&data_key, Bytes::from(bytes), PutOptions::create_if_absent())
+            .await
+            .expect("put RLOG object");
+
+        let commit = record::build(NewCommitRecord {
+            tenant_hash,
+            signal: Signal::Logs,
+            shard,
+            writer_id,
+            writer_epoch: epoch,
+            writer_seq: seq,
+            object_size: 0,
+            content_hash,
+            sample_count: 1,
+            series_count: 1,
+            min_event_ts_ns: created_unix_ns,
+            max_event_ts_ns: created_unix_ns,
+            min_ingest_ts_ns: created_unix_ns,
+            max_ingest_ts_ns: created_unix_ns,
+            segment_format_version: u32::from(ravel_ingest::LOG_SEGMENT_FORMAT_VERSION),
+            created_unix_ns,
+            ingest_hour_bucket: ingest_hour,
+        })
+        .expect("build commit record");
+        publish::publish(store, &commit, &RetryPolicy::default())
+            .await
+            .expect("publish commit record");
+    }
+
+    /// Happy path: a tenant with a long-sealed ingest hour folds, the outcome
+    /// is `published`, and the snapshot the response claims really exists --
+    /// `HEAD` is present and names a part object that is present too.
+    #[tokio::test]
+    async fn an_eligible_tenant_folds_and_publishes_a_snapshot() {
+        let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+        let tenant = TenantId::new("fold-on-demand-eligible");
+        let tenant_hash = tenant.hash();
+        // Three hours behind `now`, well past the default sealing sum of
+        // max_flush_lifetime (1h) + clock_skew_allowance (5m) +
+        // fold_safety_margin (15m).
+        let sealed_hour = (NOW_NS / NS_PER_HOUR - 3) as u32;
+        seed_log_commit(store.as_ref(), &tenant, sealed_hour, 0).await;
+
+        let catalog = catalog(store.clone());
+        let result = fold_once(
+            catalog.as_ref(),
+            store.as_ref(),
+            &tenant_hash,
+            Signal::Logs,
+            Uuid::from_u128(1),
+            NOW_NS,
+            None,
+        )
+        .await
+        .expect("fold");
+
+        assert_eq!(
+            result.outcome,
+            FoldOutcome::Published,
+            "a sealed hour must publish"
+        );
+        let report = result.report.expect("a published fold carries a report");
+        assert_eq!(report.watermark_hour, Some(sealed_hour));
+        assert_eq!(report.entry_count, 1, "the seeded commit must be folded in");
+
+        // The claimed snapshot exists: HEAD is readable, and every part it
+        // names is present in the store.
+        let head_bytes = store
+            .get(
+                &crate::fold::head_key(&tenant_hash, Signal::Logs),
+                GetRange::Full,
+            )
+            .await
+            .expect("HEAD present after a published fold");
+        let head = ravel_catalog::decode_head(&head_bytes.data).expect("decode HEAD");
+        assert_eq!(head.watermark_hour, sealed_hour);
+        assert!(!head.parts.is_empty(), "a published HEAD names parts");
+        for part in &head.parts {
+            store
+                .get(&part.key, GetRange::Full)
+                .await
+                .unwrap_or_else(|err| panic!("part {} named by HEAD is missing: {err}", part.key));
+        }
+    }
+
+    /// Nothing-eligible path: the tenant's only write lands in the current
+    /// hour, which cannot be sealed yet. The outcome is exactly
+    /// `nothing_eligible` -- not a failure, and not a claimed publish -- and
+    /// no HEAD was written.
+    #[tokio::test]
+    async fn a_tenant_with_unsealable_writes_reports_nothing_eligible() {
+        let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+        let tenant = TenantId::new("fold-on-demand-unsealed");
+        let tenant_hash = tenant.hash();
+        // The hour `now` sits in: it has not even ended, let alone aged out
+        // the sealing sum.
+        let current_hour = (NOW_NS / NS_PER_HOUR) as u32;
+        seed_log_commit(store.as_ref(), &tenant, current_hour, 0).await;
+
+        let catalog = catalog(store.clone());
+        let result = fold_once(
+            catalog.as_ref(),
+            store.as_ref(),
+            &tenant_hash,
+            Signal::Logs,
+            Uuid::from_u128(1),
+            NOW_NS,
+            None,
+        )
+        .await
+        .expect("fold");
+
+        assert_eq!(
+            result.outcome,
+            FoldOutcome::NothingEligible,
+            "a write in the current hour is not sealable, so nothing is eligible"
+        );
+        let report = result.report.expect("a no-op fold still carries a report");
+        assert!(report.no_op, "the underlying fold must be a no-op");
+        let head = store
+            .get(
+                &crate::fold::head_key(&tenant_hash, Signal::Logs),
+                GetRange::Full,
+            )
+            .await;
+        assert!(
+            matches!(head, Err(StoreError::NotFound)),
+            "no snapshot may be published when nothing is eligible"
+        );
+    }
+
+    /// Concurrent-CAS path: two folds race on the same tenant. A `FaultStore`
+    /// hold gate makes the interleaving deterministic (`MemoryStore` never
+    /// yields, so without it the first fold would simply run to completion
+    /// before the second started): the first fold is held at its `HEAD` PUT
+    /// while the second runs to completion and publishes, then the first is
+    /// released into a `HEAD` that has moved under it.
+    ///
+    /// Exactly one publishes; the loser reports `lost_cas`.
+    #[tokio::test]
+    async fn two_racing_folds_publish_once_and_the_loser_reports_lost_cas() {
+        let fault_store = Arc::new(FaultStore::new(MemoryStore::new(), Default::default()));
+        let store: Arc<dyn ObjectStoreBackend> = fault_store.clone();
+        let tenant = TenantId::new("fold-on-demand-race");
+        let tenant_hash = tenant.hash();
+        let sealed_hour = (NOW_NS / NS_PER_HOUR - 3) as u32;
+        seed_log_commit(store.as_ref(), &tenant, sealed_hour, 0).await;
+
+        let head = crate::fold::head_key(&tenant_hash, Signal::Logs);
+        // Hold only the FIRST HEAD PUT. The second fold's HEAD PUT is the
+        // second match, so it passes straight through and publishes.
+        let gate = fault_store.hold(Op::Put, Some(head.clone()), Occurrence::Nth(1));
+
+        // Each racer gets its own Catalog (its own cached HEAD view), the way
+        // two separate processes would.
+        let catalog_a = catalog(store.clone());
+        let store_a = store.clone();
+        let racer_a = tokio::spawn(async move {
+            fold_once(
+                catalog_a.as_ref(),
+                store_a.as_ref(),
+                &tenant_hash,
+                Signal::Logs,
+                Uuid::from_u128(0xa),
+                NOW_NS,
+                None,
+            )
+            .await
+        });
+
+        // Racer A is now blocked inside its HEAD PUT, before the CAS reaches
+        // the backend. This assertion is the proof that the race is real: the
+        // test does not proceed until a HEAD PUT is genuinely in flight.
+        gate.wait_until_held(1).await;
+        let held = gate.held_details();
+        assert_eq!(held.len(), 1, "exactly one call is held: {held:?}");
+        assert_eq!(held[0].1, Op::Put);
+        assert_eq!(held[0].2, head, "the held call is the HEAD CAS");
+
+        let catalog_b = catalog(store.clone());
+        let result_b = fold_once(
+            catalog_b.as_ref(),
+            store.as_ref(),
+            &tenant_hash,
+            Signal::Logs,
+            Uuid::from_u128(0xb),
+            NOW_NS,
+            None,
+        )
+        .await
+        .expect("racer B fold");
+        assert_eq!(
+            result_b.outcome,
+            FoldOutcome::Published,
+            "racer B ran while A was held, so B wins the CAS"
+        );
+        assert_eq!(
+            gate.held_count(),
+            1,
+            "racer A must still be held while B publishes; otherwise the race did not happen"
+        );
+
+        // Release A into a HEAD that B already moved.
+        assert!(gate.release(held[0].0), "release the held HEAD CAS");
+        let result_a = racer_a.await.expect("racer A task").expect("racer A fold");
+        assert_eq!(
+            result_a.outcome,
+            FoldOutcome::LostCas,
+            "racer A lost the HEAD CAS and must say so"
+        );
+        assert_eq!(
+            gate.held_count(),
+            0,
+            "no call is left held once A is released"
+        );
+
+        // Exactly one snapshot generation is published, and it is B's.
+        let head_bytes = store
+            .get(&head, GetRange::Full)
+            .await
+            .expect("HEAD present after the race");
+        let decoded = ravel_catalog::decode_head(&head_bytes.data).expect("decode HEAD");
+        assert_eq!(decoded.watermark_hour, sealed_hour);
+        assert_eq!(
+            decoded.folder_id,
+            Uuid::from_u128(0xb).into_bytes().to_vec(),
+            "the published HEAD is racer B's, not racer A's"
+        );
+    }
+
+    fn state(store: Arc<dyn ObjectStoreBackend>, catalog: Arc<Catalog>) -> OnDemandFoldState {
+        let tokens = std::collections::HashMap::from([(
+            TOKEN.to_string(),
+            TenantId::new("fold-on-demand-http"),
+        )]);
+        OnDemandFoldState {
+            catalog,
+            store,
+            tenant_resolver: Arc::new(StaticBearerTokenResolver::new(tokens)),
+            clock: Arc::new(SystemClock),
+            folder_id: Uuid::from_u128(1),
+            retention: Arc::new(RetentionConfig::default()),
+        }
+    }
+
+    async fn post(state: OnDemandFoldState, token: Option<&str>, body: &str) -> (StatusCode, Vec<u8>) {
+        let mut builder = HttpRequest::builder()
+            .method("POST")
+            .uri(FOLD_ROUTE)
+            .header("content-type", "application/json");
+        if let Some(token) = token {
+            builder = builder.header("authorization", format!("Bearer {token}"));
+        }
+        let request = builder
+            .body(Body::from(body.to_string()))
+            .expect("build request");
+        let response = router(state)
+            .oneshot(request)
+            .await
+            .expect("route the request");
+        let status = response.status();
+        let bytes = axum::body::to_bytes(response.into_body(), 1 << 20)
+            .await
+            .expect("read body");
+        (status, bytes.to_vec())
+    }
+
+    /// The route carries the same authorization the tenant-scoped query
+    /// routes do: no credential, no fold.
+    #[tokio::test]
+    async fn an_unauthenticated_request_is_refused() {
+        let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+        let catalog = catalog(store.clone());
+        let (status, _) = post(state(store, catalog), None, r#"{"signal":"logs"}"#).await;
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+    }
+
+    /// The signal is required and never defaulted, and a tenant named in the
+    /// body must be the authenticated one.
+    #[tokio::test]
+    async fn a_missing_signal_or_a_foreign_tenant_is_refused() {
+        let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+        let catalog = catalog(store.clone());
+        let (status, _) = post(state(store.clone(), catalog.clone()), Some(TOKEN), "{}").await;
+        assert_eq!(status, StatusCode::BAD_REQUEST, "signal is required");
+
+        let (status, _) = post(
+            state(store.clone(), catalog.clone()),
+            Some(TOKEN),
+            r#"{"signal":"nonsense"}"#,
+        )
+        .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST, "unknown signal is refused");
+
+        let (status, _) = post(
+            state(store, catalog),
+            Some(TOKEN),
+            r#"{"signal":"logs","tenant":"some-other-tenant"}"#,
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::FORBIDDEN,
+            "the body may not name a tenant other than the authenticated one"
+        );
+    }
+
+    /// The HTTP surface reports the outcome, not just a success: a tenant
+    /// with nothing sealable gets 200 with `status: nothing_eligible` and
+    /// `published: false`.
+    #[tokio::test]
+    async fn the_response_names_the_nothing_eligible_outcome() {
+        let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+        let catalog = catalog(store.clone());
+        let (status, body) = post(
+            state(store, catalog),
+            Some(TOKEN),
+            r#"{"signal":"logs","tenant":"fold-on-demand-http"}"#,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        let body: serde_json::Value = serde_json::from_slice(&body).expect("JSON body");
+        assert_eq!(body["status"], "nothing_eligible");
+        assert_eq!(body["published"], false);
+    }
+}

--- a/services/ravel-server/src/fold_on_demand.rs
+++ b/services/ravel-server/src/fold_on_demand.rs
@@ -30,18 +30,27 @@
 //!
 //! # Admission
 //!
+//! A fold is object-store-heavy -- it LISTs commit records, GETs parts, and
+//! PUTs new parts plus `HEAD` -- and it does that work whether or not anything
+//! turns out to be eligible. Two independent gates keep an operator (or a
+//! script) from multiplying that cost:
+//!
 //! Concurrent calls for one `(tenant, signal)` collapse into a single fold
 //! through [`SingleFlight`], the coalescing primitive the read cache already
 //! uses: one call runs the fold, every other call in flight for that key
 //! waits on its result and issues no object-store work of its own, and each
-//! response says which it was in `coalesced`. That is this route's admission
-//! gate. A fold is object-store-heavy -- it LISTs commit records, GETs parts,
-//! and PUTs new parts plus `HEAD` -- and it does that work whether or not
-//! anything turns out to be eligible, so an unguarded route would multiply
-//! that cost by the caller's own concurrency. A credential resolves to
-//! exactly one tenant (see Authorization above), so this bounds any one
-//! caller to one in-flight fold per signal, which is the same load the
-//! scheduled loop already places on that tenant.
+//! response says which it was in `coalesced`. A credential resolves to exactly
+//! one tenant (see Authorization above), so this bounds any one caller to one
+//! in-flight fold per signal.
+//!
+//! `SingleFlight` bounds *concurrency*, not *rate*: sequential calls do not
+//! overlap, so each would otherwise run a full fold. The rate gate closes that:
+//! before folding, the route reads `HEAD` and, if it was published more
+//! recently than the fold interval (the same `fold_interval`
+//! [`crate::fold`]'s `head_fresh_enough` skips a scheduled tick on), returns
+//! [`FoldOutcome::Throttled`] without listing anything. A caller hammering the
+//! route sequentially therefore triggers at most one fold per interval, the
+//! same load the scheduled loop already places on that tenant.
 //!
 //! The route deliberately does not take a `QueryAdmissionController` permit
 //! the way the query surfaces do. A fold is deferred maintenance traffic and
@@ -86,9 +95,14 @@
 //! - `lost_cas`: a concurrent fold (the scheduled loop, or another operator
 //!   call) won the `HEAD` CAS. The catalog is fine and the winner's snapshot
 //!   is published; this call did not publish one.
+//! - `throttled`: the rate gate declined to fold because `HEAD` was published
+//!   more recently than the fold interval. No listing ran, so this call makes
+//!   no eligibility claim -- it is deliberately not folded into
+//!   `nothing_eligible`, which asserts a negative the throttle never checked.
 
 use std::collections::BTreeSet;
 use std::sync::Arc;
+use std::time::Duration;
 
 use axum::Router;
 use axum::body::Body;
@@ -133,6 +147,15 @@ pub enum FoldOutcome {
     /// A concurrent fold won the `HEAD` CAS. This call published nothing; the
     /// winner's snapshot is what `HEAD` names.
     LostCas,
+    /// The rate gate declined to run a fold because `HEAD` was published more
+    /// recently than the fold interval. Distinct from `NothingEligible`: this
+    /// call did no listing and made no eligibility claim: it only observed that
+    /// a fold ran recently enough that another would be wasted object-store
+    /// work. `NothingEligible` asserts a definite negative (no commit entered or
+    /// left the snapshot); a throttle never ran the check that could assert it,
+    /// so reusing that status would be the mislabelled-measurement defect the
+    /// review flagged elsewhere.
+    Throttled,
 }
 
 impl FoldOutcome {
@@ -142,6 +165,7 @@ impl FoldOutcome {
             FoldOutcome::Published => "published",
             FoldOutcome::NothingEligible => "nothing_eligible",
             FoldOutcome::LostCas => "lost_cas",
+            FoldOutcome::Throttled => "throttled",
         }
     }
 
@@ -161,6 +185,10 @@ impl FoldOutcome {
             FoldOutcome::LostCas => {
                 "a concurrent fold won the HEAD compare-and-swap; this call published no \
                  snapshot and the winner's snapshot is the current HEAD"
+            }
+            FoldOutcome::Throttled => {
+                "a fold ran for this tenant and signal more recently than the fold interval, so \
+                 this call did not run another; retry after the interval elapses"
             }
         }
     }
@@ -228,6 +256,13 @@ pub struct OnDemandFoldState {
     /// listener coalesces with a concurrent one on `--listen-http` instead of
     /// running a second fold for the same tenant.
     pub in_flight: Arc<FoldInFlight>,
+    /// The scheduled fold's interval, reused as the on-demand route's rate gate
+    /// (the same value [`crate::fold`]'s `head_fresh_enough` skips a tick on). A
+    /// call whose `HEAD` is fresher than this returns [`FoldOutcome::Throttled`]
+    /// without folding: [`SingleFlight`] bounds concurrency, and this bounds
+    /// rate, so a caller issuing sequential calls cannot drive one full
+    /// `Catalog::fold` (a LIST, GETs, and PUTs) per call.
+    pub fold_interval: Duration,
 }
 
 /// The `/api/v1/admin/fold` router.
@@ -317,6 +352,7 @@ async fn run(state: &OnDemandFoldState, req: Request<Body>) -> Result<Response, 
                 state.folder_id,
                 now_ns,
                 default_retention_ns,
+                state.fold_interval,
             )
             .await
             .map(Arc::new)
@@ -406,6 +442,11 @@ async fn run(state: &OnDemandFoldState, req: Request<Body>) -> Result<Response, 
 /// `now_ns` is the caller's clock reading: this function never reads a clock,
 /// so the sealing window is deterministic under test.
 ///
+/// `fold_interval` is the rate gate: a `HEAD` published within it of `now_ns`
+/// returns [`FoldOutcome::Throttled`] before any listing. `Duration::ZERO`
+/// disables the gate (a HEAD's age is always non-negative), which is how the
+/// direct-call tests exercise the fold outcomes without throttling.
+///
 /// Classification needs the `HEAD` object from before the fold, because
 /// [`Catalog::fold`]'s own report cannot distinguish the non-publishing cases
 /// on its own:
@@ -419,6 +460,7 @@ async fn run(state: &OnDemandFoldState, req: Request<Body>) -> Result<Response, 
 ///   rewrites `HEAD` and reports `no_op: false`, having folded nothing. The
 ///   two `HEAD`s' entry sets tell that apart from a fold that really changed
 ///   the snapshot's content (see [`snapshot_content_changed`]).
+#[allow(clippy::too_many_arguments)]
 pub async fn fold_once(
     catalog: &Catalog,
     store: &dyn ObjectStoreBackend,
@@ -427,11 +469,31 @@ pub async fn fold_once(
     folder_id: Uuid,
     now_ns: i64,
     default_retention_ns: Option<i64>,
+    fold_interval: Duration,
 ) -> Result<OnDemandFold, CatalogError> {
     let mut gets = 0u64;
     let before = read_head(store, tenant, signal, &mut gets)
         .await
         .map_err(CatalogError::Store)?;
+
+    // Rate gate (see the module docs' "# Admission"): if a fold published this
+    // HEAD more recently than the fold interval, decline rather than repeat a
+    // LIST/GET/PUT sequence a sequential caller would otherwise pay per call.
+    // `SingleFlight` above only deduplicates *concurrent* calls, so this is the
+    // gate that bounds rate. A zero interval never trips (age is always `>= 0`),
+    // which is how the direct-call tests opt out. The `before` read is the one
+    // this gate needs, so it costs no extra GET.
+    if let Some(bytes) = &before
+        && let Ok(head) = decode_head(bytes)
+        && crate::fold::head_is_fresh(head.created_unix_ns, now_ns, fold_interval)
+    {
+        return Ok(OnDemandFold {
+            outcome: FoldOutcome::Throttled,
+            report: None,
+            head_advanced: false,
+            classify_get_requests: gets,
+        });
+    }
 
     match catalog
         .fold(tenant, signal, folder_id, now_ns, &[], default_retention_ns)
@@ -930,6 +992,7 @@ mod tests {
             Uuid::from_u128(1),
             NOW_NS,
             None,
+            Duration::ZERO,
         )
         .await
         .expect("fold");
@@ -990,6 +1053,7 @@ mod tests {
             Uuid::from_u128(1),
             NOW_NS,
             None,
+            Duration::ZERO,
         )
         .await
         .expect("fold");
@@ -1019,6 +1083,7 @@ mod tests {
             Uuid::from_u128(1),
             NOW_NS,
             None,
+            Duration::ZERO,
         )
         .await
         .expect("second fold");
@@ -1097,6 +1162,7 @@ mod tests {
             Uuid::from_u128(1),
             NOW_NS,
             None,
+            Duration::ZERO,
         )
         .await
         .expect("first fold");
@@ -1119,6 +1185,7 @@ mod tests {
             Uuid::from_u128(1),
             NOW_NS + 2 * NS_PER_HOUR,
             None,
+            Duration::ZERO,
         )
         .await
         .expect("second fold");
@@ -1204,6 +1271,7 @@ mod tests {
                 Uuid::from_u128(0xa),
                 NOW_NS,
                 None,
+                Duration::ZERO,
             )
             .await
         });
@@ -1226,6 +1294,7 @@ mod tests {
             Uuid::from_u128(0xb),
             NOW_NS,
             None,
+            Duration::ZERO,
         )
         .await
         .expect("racer B fold");
@@ -1268,6 +1337,80 @@ mod tests {
         );
     }
 
+    /// Item 1 (rate gate): [`SingleFlight`] deduplicates only *concurrent*
+    /// calls, so a caller issuing calls sequentially would otherwise run a full
+    /// `Catalog::fold` -- a LIST, GETs, and PUTs -- on every one. With a nonzero
+    /// `fold_interval`, only the first of a rapid sequential burst folds; every
+    /// later call whose `HEAD` is still fresher than the interval is throttled
+    /// before listing anything.
+    ///
+    /// The count is exact and taken from the fold reports, not merely the
+    /// response shape: exactly one call carries a report (it ran the fold) and
+    /// that report is the only listing the burst did.
+    ///
+    /// Prove-the-test: flip `interval` to `Duration::ZERO` (marked below) and
+    /// the gate is disabled -- every call folds, `folds_run` becomes `N`, and
+    /// the first assertion fails. That is the failure shape the current
+    /// (pre-gate) behavior produced.
+    #[tokio::test]
+    async fn sequential_calls_within_the_interval_run_one_fold() {
+        let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+        let tenant = TenantId::new("fold-on-demand-rate");
+        let tenant_hash = tenant.hash();
+        let sealed_hour = (NOW_NS / NS_PER_HOUR - 3) as u32;
+        seed_log_commit(store.as_ref(), &tenant, sealed_hour, 0).await;
+
+        let catalog = catalog(store.clone());
+        // Flip to `Duration::ZERO` to disable the gate and watch this test fail.
+        let interval = Duration::from_secs(5 * 60);
+
+        const N: usize = 5;
+        let mut outcomes = Vec::new();
+        let mut total_list_requests = 0u64;
+        for _ in 0..N {
+            let result = fold_once(
+                catalog.as_ref(),
+                store.as_ref(),
+                &tenant_hash,
+                Signal::Logs,
+                Uuid::from_u128(1),
+                NOW_NS,
+                None,
+                interval,
+            )
+            .await
+            .expect("fold");
+            if let Some(report) = &result.report {
+                total_list_requests += report.list_requests;
+            }
+            outcomes.push(result.outcome);
+        }
+
+        let folds_run = outcomes
+            .iter()
+            .filter(|o| **o != FoldOutcome::Throttled)
+            .count();
+        assert_eq!(
+            folds_run, 1,
+            "exactly one sequential call within the interval runs a fold: {outcomes:?}"
+        );
+        assert_eq!(
+            outcomes[0],
+            FoldOutcome::Published,
+            "the first call folds the sealed hour and publishes"
+        );
+        assert!(
+            outcomes[1..].iter().all(|o| *o == FoldOutcome::Throttled),
+            "every later call in the burst is throttled: {outcomes:?}"
+        );
+        // The one fold that ran did the only listing; the throttled calls
+        // carried no report and listed nothing.
+        assert!(
+            total_list_requests > 0,
+            "the fold that ran listed commit records"
+        );
+    }
+
     fn state(store: Arc<dyn ObjectStoreBackend>, catalog: Arc<Catalog>) -> OnDemandFoldState {
         let tokens = std::collections::HashMap::from([(
             TOKEN.to_string(),
@@ -1281,6 +1424,10 @@ mod tests {
             folder_id: Uuid::from_u128(1),
             retention: Arc::new(RetentionConfig::default()),
             in_flight: Arc::new(FoldInFlight::new()),
+            // The HTTP tests below drive single or concurrent calls against a
+            // store with no prior HEAD, so the rate gate never trips; a zero
+            // interval keeps that explicit and independent of the wall clock.
+            fold_interval: Duration::ZERO,
         }
     }
 

--- a/services/ravel-server/src/fold_on_demand.rs
+++ b/services/ravel-server/src/fold_on_demand.rs
@@ -44,13 +44,18 @@
 //! Three distinct outcomes, always 200, always named in the response body's
 //! `status` field ([`FoldOutcome`]):
 //!
-//! - `published`: this call wrote a new snapshot and advanced `HEAD`.
-//! - `nothing_eligible`: nothing was sealable, so no snapshot was published
-//!   and `HEAD` is untouched. A fold seals an ingest hour only once
-//!   `max_flush_lifetime + clock_skew_allowance + fold_safety_margin` has
-//!   elapsed after that hour ends, so a fold triggered right after a load
-//!   seals nothing. That is the rule working, not a failure, which is exactly
-//!   why it is a separate status rather than a `published` with zero counters.
+//! - `published`: this call wrote a new snapshot, advancing `HEAD` to name
+//!   content that differs from what it named before.
+//! - `nothing_eligible`: no commit was eligible to fold. A fold seals an
+//!   ingest hour only once `max_flush_lifetime + clock_skew_allowance +
+//!   fold_safety_margin` has elapsed after that hour ends, so a fold
+//!   triggered right after a load seals nothing. That is the rule working,
+//!   not a failure, which is exactly why it is a separate status rather than
+//!   a `published` with zero counters. The response's `head_advanced` field
+//!   separates the two shapes this outcome takes: `false` when `HEAD` was
+//!   left untouched, `true` when the sealing watermark moved over hours that
+//!   held nothing to fold, so the new snapshot names the same entries the old
+//!   one did.
 //! - `lost_cas`: a concurrent fold (the scheduled loop, or another operator
 //!   call) won the `HEAD` CAS. The catalog is fine and the winner's snapshot
 //!   is published; this call did not publish one.
@@ -87,11 +92,13 @@ const MAX_BODY_BYTES: usize = 64 * 1024;
 /// boolean plus a log line.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FoldOutcome {
-    /// A new snapshot was published and `HEAD` now names it.
+    /// A new snapshot was published: `HEAD` now names content that differs
+    /// from what it named before this call.
     Published,
-    /// Nothing was eligible to fold: no ingest hour has sealed beyond the
-    /// previous watermark, so no snapshot was published and `HEAD` is
-    /// unchanged.
+    /// Nothing was eligible to fold: no commit entered or left the snapshot,
+    /// either because no ingest hour has sealed beyond the previous watermark
+    /// (`head_advanced: false`) or because the hours that did seal held
+    /// nothing to fold (`head_advanced: true`, a watermark-only rewrite).
     NothingEligible,
     /// A concurrent fold won the `HEAD` CAS. This call published nothing; the
     /// winner's snapshot is what `HEAD` names.
@@ -115,9 +122,11 @@ impl FoldOutcome {
         match self {
             FoldOutcome::Published => "a new catalog snapshot was published",
             FoldOutcome::NothingEligible => {
-                "nothing was eligible to fold, so no snapshot was published and HEAD is \
-                 unchanged; an ingest hour seals only once max_flush_lifetime + \
-                 clock_skew_allowance + fold_safety_margin has elapsed after that hour ends"
+                "nothing was eligible to fold: no commit entered or left the snapshot, so the \
+                 catalog names exactly what it named before (see head_advanced for whether the \
+                 sealing watermark still moved). An ingest hour seals only once \
+                 max_flush_lifetime + clock_skew_allowance + fold_safety_margin has elapsed \
+                 after that hour ends, so a fold run right after a load seals nothing"
             }
             FoldOutcome::LostCas => {
                 "a concurrent fold won the HEAD compare-and-swap; this call published no \
@@ -135,6 +144,13 @@ impl FoldOutcome {
 pub struct OnDemandFold {
     pub outcome: FoldOutcome,
     pub report: Option<FoldReport>,
+    /// Whether this call rewrote `HEAD`. Reported separately from the outcome
+    /// because the two can differ: a fold whose sealing watermark advanced
+    /// over hours holding nothing foldable rewrites `HEAD` while folding no
+    /// entry at all. That is a [`FoldOutcome::NothingEligible`] -- the
+    /// operator's question is whether any data was eligible -- but the
+    /// watermark move is real and is never hidden.
+    pub head_advanced: bool,
 }
 
 /// Shared state for the route: the same [`Catalog`] the query paths resolve
@@ -271,6 +287,7 @@ async fn run(state: &OnDemandFoldState, req: Request<Body>) -> Result<Response, 
     let mut payload = json!({
         "status": result.outcome.as_str(),
         "published": result.outcome == FoldOutcome::Published,
+        "head_advanced": result.head_advanced,
         "message": result.outcome.message(),
         "tenant_hash": tenant_hash.to_hex(),
         "signal": body.signal,
@@ -305,13 +322,18 @@ async fn run(state: &OnDemandFoldState, req: Request<Body>) -> Result<Response, 
 /// so the sealing window is deterministic under test.
 ///
 /// Classification needs the `HEAD` object from before the fold, because
-/// [`Catalog::fold`]'s own report cannot distinguish the two non-publishing
-/// cases on its own. A fold that loses the `HEAD` CAS re-reads `HEAD`, finds
-/// the winner's watermark already covers its own, and returns a `no_op`
-/// report -- byte-identical in shape to the report for "nothing has sealed".
-/// The `HEAD` object itself tells them apart: unchanged means nothing
-/// happened, changed means somebody else published while this call was
-/// folding.
+/// [`Catalog::fold`]'s own report cannot distinguish the non-publishing cases
+/// on its own:
+///
+/// - A fold that loses the `HEAD` CAS re-reads `HEAD`, finds the winner's
+///   watermark already covers its own, and returns a `no_op` report --
+///   identical in shape to the report for "nothing has sealed". The `HEAD`
+///   object tells them apart: unchanged means nothing happened, changed means
+///   somebody else published while this call was folding.
+/// - A fold whose sealing watermark advanced over hours that held no commits
+///   rewrites `HEAD` and reports `no_op: false`, having folded nothing. The
+///   previous `HEAD`'s entry count tells that apart from a fold that really
+///   changed the snapshot's content.
 pub async fn fold_once(
     catalog: &Catalog,
     store: &dyn ObjectStoreBackend,
@@ -324,15 +346,31 @@ pub async fn fold_once(
     let before = read_head(store, tenant, signal)
         .await
         .map_err(CatalogError::Store)?;
+    let entries_before = head_entry_count(before.as_deref());
 
     match catalog
         .fold(tenant, signal, folder_id, now_ns, &[], default_retention_ns)
         .await
     {
-        Ok(report) if !report.no_op => Ok(OnDemandFold {
-            outcome: FoldOutcome::Published,
-            report: Some(report),
-        }),
+        Ok(report) if !report.no_op => {
+            // `HEAD` was rewritten. Whether anything was *eligible* is a
+            // second question: an ingest hour that seals while holding no
+            // commit still advances the watermark, and the resulting snapshot
+            // names exactly the entries the previous one did. Comparing the
+            // entry counts answers it in either direction -- a fold that
+            // folds new commits in, and one that drops entries through a
+            // retention tombstone, both changed the snapshot's content.
+            let outcome = if report.entry_count == entries_before {
+                FoldOutcome::NothingEligible
+            } else {
+                FoldOutcome::Published
+            };
+            Ok(OnDemandFold {
+                outcome,
+                report: Some(report),
+                head_advanced: true,
+            })
+        }
         Ok(report) => {
             let after = read_head(store, tenant, signal)
                 .await
@@ -345,6 +383,7 @@ pub async fn fold_once(
             Ok(OnDemandFold {
                 outcome,
                 report: Some(report),
+                head_advanced: false,
             })
         }
         // The catalog retries a losing CAS internally and only surfaces this
@@ -361,6 +400,7 @@ pub async fn fold_once(
             Ok(OnDemandFold {
                 outcome: FoldOutcome::LostCas,
                 report: None,
+                head_advanced: false,
             })
         }
         Err(err) => Err(err),
@@ -386,12 +426,25 @@ async fn read_head(
     }
 }
 
+/// Entries named by a `HEAD` object, summed over its parts. `0` for an absent
+/// `HEAD`, and for one this process cannot decode -- both mean "no snapshot
+/// content to compare against", and a fold over either rebuilds from the
+/// commit layout anyway.
+fn head_entry_count(head: Option<&[u8]>) -> u64 {
+    head.and_then(|bytes| ravel_catalog::decode_head(bytes).ok())
+        .map(|head| head.parts.iter().map(|part| part.entry_count).sum())
+        .unwrap_or(0)
+}
+
 fn authenticate(state: &OnDemandFoldState, headers: &HeaderMap) -> Result<TenantId, ApiError> {
-    state.tenant_resolver.resolve(headers).map_err(|_| ApiError {
-        status: StatusCode::UNAUTHORIZED,
-        error_type: "unauthorized",
-        message: "authentication required".to_string(),
-    })
+    state
+        .tenant_resolver
+        .resolve(headers)
+        .map_err(|_| ApiError {
+            status: StatusCode::UNAUTHORIZED,
+            error_type: "unauthorized",
+            message: "authentication required".to_string(),
+        })
 }
 
 /// The endpoint's error shape, mirroring the sibling query endpoints' typed
@@ -528,7 +581,11 @@ mod tests {
         )
         .expect("build data key");
         store
-            .put(&data_key, Bytes::from(bytes), PutOptions::create_if_absent())
+            .put(
+                &data_key,
+                Bytes::from(bytes),
+                PutOptions::create_if_absent(),
+            )
             .await
             .expect("put RLOG object");
 
@@ -615,8 +672,12 @@ mod tests {
 
     /// Nothing-eligible path: the tenant's only write lands in the current
     /// hour, which cannot be sealed yet. The outcome is exactly
-    /// `nothing_eligible` -- not a failure, and not a claimed publish -- and
-    /// no HEAD was written.
+    /// `nothing_eligible` -- not a failure, and not a claimed publish -- in
+    /// both shapes it takes: the first call moves the sealing watermark over
+    /// hours holding nothing (`head_advanced: true`, zero entries), and the
+    /// second, with the watermark already there, leaves HEAD untouched
+    /// (`head_advanced: false`). Neither may claim a publish, because the
+    /// operator's write is still unsealed in both.
     #[tokio::test]
     async fn a_tenant_with_unsealable_writes_reports_nothing_eligible() {
         let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
@@ -645,17 +706,38 @@ mod tests {
             FoldOutcome::NothingEligible,
             "a write in the current hour is not sealable, so nothing is eligible"
         );
-        let report = result.report.expect("a no-op fold still carries a report");
-        assert!(report.no_op, "the underlying fold must be a no-op");
-        let head = store
-            .get(
-                &crate::fold::head_key(&tenant_hash, Signal::Logs),
-                GetRange::Full,
-            )
-            .await;
+        let report = result.report.expect("the fold carries a report");
+        assert_eq!(
+            report.entry_count, 0,
+            "the unsealed write must not appear in the snapshot"
+        );
         assert!(
-            matches!(head, Err(StoreError::NotFound)),
-            "no snapshot may be published when nothing is eligible"
+            result.head_advanced,
+            "the sealing watermark still moves over the empty hours behind it"
+        );
+
+        // Second call, same clock: the watermark is already where the sealing
+        // rule allows, so this one is a true no-op and leaves HEAD alone.
+        let again = fold_once(
+            catalog.as_ref(),
+            store.as_ref(),
+            &tenant_hash,
+            Signal::Logs,
+            Uuid::from_u128(1),
+            NOW_NS,
+            None,
+        )
+        .await
+        .expect("second fold");
+        assert_eq!(
+            again.outcome,
+            FoldOutcome::NothingEligible,
+            "still nothing sealable, so still nothing eligible"
+        );
+        assert!(!again.head_advanced, "HEAD must be left untouched");
+        assert!(
+            again.report.expect("the fold carries a report").no_op,
+            "the underlying fold must be a no-op"
         );
     }
 
@@ -773,7 +855,11 @@ mod tests {
         }
     }
 
-    async fn post(state: OnDemandFoldState, token: Option<&str>, body: &str) -> (StatusCode, Vec<u8>) {
+    async fn post(
+        state: OnDemandFoldState,
+        token: Option<&str>,
+        body: &str,
+    ) -> (StatusCode, Vec<u8>) {
         let mut builder = HttpRequest::builder()
             .method("POST")
             .uri(FOLD_ROUTE)

--- a/services/ravel-server/src/lib.rs
+++ b/services/ravel-server/src/lib.rs
@@ -631,7 +631,9 @@ fn remote_write_state(
 /// `store` is the foreground, ack-bearing object-store handle (ADR-0070
 /// decision 1): the ingest routers, the catalog, and every query surface use
 /// it. `store_background` is the maintenance-class handle: the maintain, fold,
-/// and scrub loops use it. The two come from a `ClassedStore`; in the default
+/// and scrub loops use it, and so does the on-demand fold route, which runs
+/// the scheduled fold's work on an operator's trigger rather than a timer's.
+/// The two come from a `ClassedStore`; in the default
 /// passthrough construction they are the same `Arc`, so this split changes
 /// nothing at runtime and only becomes load-bearing once `--store-scheduling`
 /// installs the real scheduler. Every other object-store consumer here (the
@@ -1375,23 +1377,33 @@ pub async fn start(
         // triggers. Authorization is the deployment's tenant resolver, the
         // same credential the query routes above require.
         let on_demand_fold_retention = Arc::new(config.maintain.retention.clone());
+        // One coalescing gate for the process, shared by both listeners: a
+        // fold triggered on the mTLS listener and one triggered on
+        // `--listen-http` for the same (tenant, signal) run once, not twice.
+        let on_demand_fold_in_flight = Arc::new(fold_on_demand::FoldInFlight::new());
         let on_demand_fold_state = fold_on_demand::OnDemandFoldState {
             catalog: catalog.clone(),
-            store: store.clone(),
+            // Background class (ADR-0070), matching the scheduled fold below:
+            // an on-demand fold runs the identical LIST/GET/PUT sequence over
+            // the same objects, so it is the same deferred maintenance
+            // traffic and must not share the query hot path's bounds.
+            store: store_background.clone(),
             tenant_resolver: config.tenant_resolver.clone(),
             clock: Arc::new(SystemClock),
             folder_id: on_demand_folder_id,
             retention: on_demand_fold_retention.clone(),
+            in_flight: on_demand_fold_in_flight.clone(),
         };
         http_router = http_router.merge(fold_on_demand::router(on_demand_fold_state));
         if let Some(mtls) = &config.mtls_listener {
             let mtls_fold_state = fold_on_demand::OnDemandFoldState {
                 catalog: catalog.clone(),
-                store: store.clone(),
+                store: store_background.clone(),
                 tenant_resolver: mtls.resolver.clone(),
                 clock: Arc::new(SystemClock),
                 folder_id: on_demand_folder_id,
                 retention: on_demand_fold_retention,
+                in_flight: on_demand_fold_in_flight,
             };
             mtls_router = mtls_router.merge(fold_on_demand::router(mtls_fold_state));
         }

--- a/services/ravel-server/src/lib.rs
+++ b/services/ravel-server/src/lib.rs
@@ -20,6 +20,7 @@ pub mod flight_auth;
 #[cfg(feature = "flight-sql")]
 pub mod flight_deadline;
 pub mod fold;
+pub mod fold_on_demand;
 pub mod gc_config;
 pub mod health;
 pub mod idle_tenant_state;
@@ -1170,6 +1171,16 @@ pub async fn start(
     // `fold::spawn` below in every non-maintain mode; the sweep is spawned
     // afterwards and needs its own `Arc`.
     let sweep_catalog = catalog.clone();
+    // One `folder_id` for every on-demand fold this process serves
+    // (`/api/v1/admin/fold`, issue #785), matching `fold::spawn`'s
+    // one-per-process rule for the scheduled loop
+    // (proto/ravel/catalog.proto, `SnapshotHead.folder_id`). Drawn from the
+    // same OS-entropy source (ADR-0068 decision 2) rather than
+    // `Uuid::new_v4()` directly.
+    let on_demand_folder_id = {
+        use ravel_commit::rng::RngSource as _;
+        ravel_commit::rng::SystemRng.new_uuid()
+    };
     // The SQL executor the idle-tenant sweep evicts idle memory accountants
     // from. Assigned inside the query block below (the one place the executor
     // is built) and read at the sweep spawn site; `None` in a mode that builds
@@ -1353,6 +1364,36 @@ pub async fn start(
                 audit_sink: Arc::new(ravel_maintain::NoopQueryAuditSink),
             };
             mtls_router = mtls_router.merge(analytics::router(mtls_analytics_state));
+        }
+
+        // POST /api/v1/admin/fold (issue #785): the on-demand form of the
+        // background fold below, for one tenant and one signal. Mounted in
+        // exactly the modes that run the scheduled fold task and serve a
+        // query surface, sharing the same `Catalog`, the same CLI-derived
+        // retention config, and one `folder_id` per process, so an operator
+        // call and a scheduled tick are the same operation with different
+        // triggers. Authorization is the deployment's tenant resolver, the
+        // same credential the query routes above require.
+        let on_demand_fold_retention = Arc::new(config.maintain.retention.clone());
+        let on_demand_fold_state = fold_on_demand::OnDemandFoldState {
+            catalog: catalog.clone(),
+            store: store.clone(),
+            tenant_resolver: config.tenant_resolver.clone(),
+            clock: Arc::new(SystemClock),
+            folder_id: on_demand_folder_id,
+            retention: on_demand_fold_retention.clone(),
+        };
+        http_router = http_router.merge(fold_on_demand::router(on_demand_fold_state));
+        if let Some(mtls) = &config.mtls_listener {
+            let mtls_fold_state = fold_on_demand::OnDemandFoldState {
+                catalog: catalog.clone(),
+                store: store.clone(),
+                tenant_resolver: mtls.resolver.clone(),
+                clock: Arc::new(SystemClock),
+                folder_id: on_demand_folder_id,
+                retention: on_demand_fold_retention,
+            };
+            mtls_router = mtls_router.merge(fold_on_demand::router(mtls_fold_state));
         }
 
         // GET/POST /api/v1/query_exemplars (ADR-0047 decision 4):

--- a/services/ravel-server/src/lib.rs
+++ b/services/ravel-server/src/lib.rs
@@ -1393,6 +1393,7 @@ pub async fn start(
             folder_id: on_demand_folder_id,
             retention: on_demand_fold_retention.clone(),
             in_flight: on_demand_fold_in_flight.clone(),
+            fold_interval: config.fold.fold_interval,
         };
         http_router = http_router.merge(fold_on_demand::router(on_demand_fold_state));
         if let Some(mtls) = &config.mtls_listener {
@@ -1404,6 +1405,7 @@ pub async fn start(
                 folder_id: on_demand_folder_id,
                 retention: on_demand_fold_retention,
                 in_flight: on_demand_fold_in_flight,
+                fold_interval: config.fold.fold_interval,
             };
             mtls_router = mtls_router.merge(fold_on_demand::router(mtls_fold_state));
         }

--- a/services/ravel-server/src/store.rs
+++ b/services/ravel-server/src/store.rs
@@ -899,9 +899,15 @@ mod tests {
             (StatusCode::OK, [(header::ETAG, "\"mock-etag\"")], "").into_response()
         }
 
+        /// Serves `Range` the way a real S3-compatible endpoint does: 206 with
+        /// a `Content-Range`, or 416 when no part of the range exists. The
+        /// adapter reads a whole object as bounded ranged requests, so a mock
+        /// that answered 200 here would be rejected as a non-partial response
+        /// before its body was ever read.
         async fn get_object(
             State(state): State<Arc<MockS3>>,
             AxumPath((_bucket, key)): AxumPath<(String, String)>,
+            headers: HeaderMap,
         ) -> Response {
             let found = state
                 .objects
@@ -909,18 +915,44 @@ mod tests {
                 .expect("objects lock")
                 .get(&key)
                 .cloned();
-            match found {
-                Some(data) => (
-                    StatusCode::OK,
-                    [
-                        (header::ETAG, "\"mock-etag\""),
-                        (header::LAST_MODIFIED, "Wed, 21 Oct 2020 07:28:00 GMT"),
-                    ],
-                    data,
-                )
-                    .into_response(),
-                None => StatusCode::NOT_FOUND.into_response(),
+            let Some(data) = found else {
+                return StatusCode::NOT_FOUND.into_response();
+            };
+            let requested = headers
+                .get(header::RANGE)
+                .and_then(|value| value.to_str().ok())
+                .and_then(|spec| spec.strip_prefix("bytes=")?.split_once('-'))
+                .map(|(start, end)| (start.parse::<usize>(), end.parse::<usize>()));
+            let (status, body, content_range) = match requested {
+                None => (StatusCode::OK, data.clone(), None),
+                Some((Ok(start), Ok(end))) if start < data.len() => {
+                    let end = end.min(data.len() - 1);
+                    (
+                        StatusCode::PARTIAL_CONTENT,
+                        data.slice(start..end + 1),
+                        Some(format!("bytes {start}-{end}/{}", data.len())),
+                    )
+                }
+                Some(_) => return StatusCode::RANGE_NOT_SATISFIABLE.into_response(),
+            };
+            let mut response = (
+                status,
+                [
+                    (header::ETAG, "\"mock-etag\"".to_string()),
+                    (
+                        header::LAST_MODIFIED,
+                        "Wed, 21 Oct 2020 07:28:00 GMT".to_string(),
+                    ),
+                ],
+                body,
+            )
+                .into_response();
+            if let Some(value) = content_range
+                && let Ok(value) = value.parse()
+            {
+                response.headers_mut().insert(header::CONTENT_RANGE, value);
             }
+            response
         }
 
         let state = Arc::new(MockS3::default());

--- a/services/ravel-server/src/store.rs
+++ b/services/ravel-server/src/store.rs
@@ -918,22 +918,42 @@ mod tests {
             let Some(data) = found else {
                 return StatusCode::NOT_FOUND.into_response();
             };
+            // All three RFC 7233 byte-range forms, not just the closed one:
+            // `S3Store::get` emits `bytes=-N` for `GetRange::Suffix`, which is
+            // how every footer in this codebase is read, so a mock that parses
+            // only `bytes=A-B` fails such a request with 416 for a reason that
+            // has nothing to do with the code under test.
             let requested = headers
                 .get(header::RANGE)
                 .and_then(|value| value.to_str().ok())
                 .and_then(|spec| spec.strip_prefix("bytes=")?.split_once('-'))
-                .map(|(start, end)| (start.parse::<usize>(), end.parse::<usize>()));
+                .map(|(start, end)| {
+                    let len = data.len();
+                    match (start.trim(), end.trim()) {
+                        // bytes=-N: the last N bytes.
+                        ("", n) => n.parse::<usize>().ok().and_then(|n| {
+                            (n > 0 && len > 0).then(|| (len.saturating_sub(n), len - 1))
+                        }),
+                        // bytes=A-: from A through the end.
+                        (s, "") => s
+                            .parse::<usize>()
+                            .ok()
+                            .and_then(|s| (s < len).then(|| (s, len - 1))),
+                        // bytes=A-B, inclusive, clamped to the object.
+                        (s, e) => match (s.parse::<usize>(), e.parse::<usize>()) {
+                            (Ok(s), Ok(e)) if s < len && s <= e => Some((s, e.min(len - 1))),
+                            _ => None,
+                        },
+                    }
+                });
             let (status, body, content_range) = match requested {
                 None => (StatusCode::OK, data.clone(), None),
-                Some((Ok(start), Ok(end))) if start < data.len() => {
-                    let end = end.min(data.len() - 1);
-                    (
-                        StatusCode::PARTIAL_CONTENT,
-                        data.slice(start..end + 1),
-                        Some(format!("bytes {start}-{end}/{}", data.len())),
-                    )
-                }
-                Some(_) => return StatusCode::RANGE_NOT_SATISFIABLE.into_response(),
+                Some(Some((start, end))) => (
+                    StatusCode::PARTIAL_CONTENT,
+                    data.slice(start..end + 1),
+                    Some(format!("bytes {start}-{end}/{}", data.len())),
+                ),
+                Some(None) => return StatusCode::RANGE_NOT_SATISFIABLE.into_response(),
             };
             let mut response = (
                 status,

--- a/services/ravel-server/tests/tenant_kms_e2e.rs
+++ b/services/ravel-server/tests/tenant_kms_e2e.rs
@@ -293,7 +293,12 @@ async fn mock_s3_handler(
                             .body(Body::empty())
                             .expect("build response"),
                         Some(Some((start, end))) => {
+                            // Content-Length is the length the GET would
+                            // return, computed before the HEAD body is
+                            // suppressed. Deriving it from the sent body makes
+                            // every object look zero-length to `S3Store::head`.
                             let slice = bytes.slice(start..end + 1);
+                            let content_length = slice.len();
                             let response_body = if method == Method::HEAD {
                                 Bytes::new()
                             } else {
@@ -303,12 +308,14 @@ async fn mock_s3_handler(
                                 .status(StatusCode::PARTIAL_CONTENT)
                                 .header("ETag", etag.clone())
                                 .header("Last-Modified", "Wed, 21 Oct 2015 07:28:00 GMT")
-                                .header("Content-Length", response_body.len().to_string())
+                                .header("Content-Length", content_length.to_string())
                                 .header("Content-Range", format!("bytes {start}-{end}/{len}"))
                                 .body(Body::from(response_body))
                                 .expect("build response")
                         }
                         None => {
+                            // Same rule as the ranged arm: the full
+                            // representation length, not the sent body length.
                             let response_body = if method == Method::HEAD {
                                 Bytes::new()
                             } else {
@@ -318,7 +325,7 @@ async fn mock_s3_handler(
                                 .status(StatusCode::OK)
                                 .header("ETag", etag.clone())
                                 .header("Last-Modified", "Wed, 21 Oct 2015 07:28:00 GMT")
-                                .header("Content-Length", response_body.len().to_string())
+                                .header("Content-Length", len.to_string())
                                 .body(Body::from(response_body))
                                 .expect("build response")
                         }

--- a/services/ravel-server/tests/tenant_kms_e2e.rs
+++ b/services/ravel-server/tests/tenant_kms_e2e.rs
@@ -262,18 +262,67 @@ async fn mock_s3_handler(
             let objects = mock.objects.lock().expect("mock objects lock");
             match objects.get(&key) {
                 Some((bytes, etag)) => {
-                    let response_body = if method == Method::HEAD {
-                        Bytes::new()
-                    } else {
-                        bytes.clone()
-                    };
-                    Response::builder()
-                        .status(StatusCode::OK)
-                        .header("ETag", etag.clone())
-                        .header("Last-Modified", "Wed, 21 Oct 2015 07:28:00 GMT")
-                        .header("Content-Length", response_body.len().to_string())
-                        .body(Body::from(response_body))
-                        .expect("build response")
+                    // A ranged GET must answer 206 with only the requested
+                    // bytes. `object_store` rejects a 200 to a Range request
+                    // with "Received non-partial response when range
+                    // requested", so ignoring the header here fails the caller
+                    // for a reason unrelated to what these tests assert.
+                    // All three RFC 7233 forms: `bytes=A-B`, `bytes=A-`, and
+                    // `bytes=-N`, the suffix form every footer read uses.
+                    let len = bytes.len();
+                    let range = headers
+                        .get(axum::http::header::RANGE)
+                        .and_then(|value| value.to_str().ok())
+                        .and_then(|spec| spec.strip_prefix("bytes=")?.split_once('-'))
+                        .map(|(start, end)| match (start.trim(), end.trim()) {
+                            ("", n) => n.parse::<usize>().ok().and_then(|n| {
+                                (n > 0 && len > 0).then(|| (len.saturating_sub(n), len - 1))
+                            }),
+                            (s, "") => s
+                                .parse::<usize>()
+                                .ok()
+                                .and_then(|s| (s < len).then(|| (s, len - 1))),
+                            (s, e) => match (s.parse::<usize>(), e.parse::<usize>()) {
+                                (Ok(s), Ok(e)) if s < len && s <= e => Some((s, e.min(len - 1))),
+                                _ => None,
+                            },
+                        });
+                    match range {
+                        Some(None) => Response::builder()
+                            .status(StatusCode::RANGE_NOT_SATISFIABLE)
+                            .body(Body::empty())
+                            .expect("build response"),
+                        Some(Some((start, end))) => {
+                            let slice = bytes.slice(start..end + 1);
+                            let response_body = if method == Method::HEAD {
+                                Bytes::new()
+                            } else {
+                                slice
+                            };
+                            Response::builder()
+                                .status(StatusCode::PARTIAL_CONTENT)
+                                .header("ETag", etag.clone())
+                                .header("Last-Modified", "Wed, 21 Oct 2015 07:28:00 GMT")
+                                .header("Content-Length", response_body.len().to_string())
+                                .header("Content-Range", format!("bytes {start}-{end}/{len}"))
+                                .body(Body::from(response_body))
+                                .expect("build response")
+                        }
+                        None => {
+                            let response_body = if method == Method::HEAD {
+                                Bytes::new()
+                            } else {
+                                bytes.clone()
+                            };
+                            Response::builder()
+                                .status(StatusCode::OK)
+                                .header("ETag", etag.clone())
+                                .header("Last-Modified", "Wed, 21 Oct 2015 07:28:00 GMT")
+                                .header("Content-Length", response_body.len().to_string())
+                                .body(Body::from(response_body))
+                                .expect("build response")
+                        }
+                    }
                 }
                 None => Response::builder()
                     .status(StatusCode::NOT_FOUND)


### PR DESCRIPTION
Four independent fleet results, batched into one PR because their file scopes are disjoint and one cold gate run covers all four. Gate `gb4` passed; gated head and tree verified as `053f57e9` / `450ba183` by re-deriving them as the gate user rather than trusting the script's output, which prints an empty `tree=` on a git dubious-ownership error.

### #865 — per-shard ingest skew metrics, with the double-count fixed (`ravel-ingest`)

An outside review claimed single-threaded shard actors cap ingest throughput and proposed a thread pool. A code check found the actor's serial execution *is* what provides per-shard ordering and that the expensive flush already runs off the actor thread, so this lands measurement only, not a redesign.

The first attempt had a real defect caught in review: `on_actor_ns` absorbed flush-permit wait time, which `off_actor_ns` already counted. The crate's own docs prove it — `shard.rs:11` says the semaphore is "acquired before spawning; at the bound, the acquire blocks the flush trigger". So at `max_inflight_flushes` the metric would have read "actor is busy" precisely when the truth was "flushes are backed up" — manufacturing evidence for the claim this ticket was filed to test. Now three non-overlapping spans with permit wait counted separately, because that duration is itself the backpressure signal an operator wants rather than noise to discard.

### #785 — operator-triggered catalog fold, with five review fixes (`services/ravel-server`)

A fold for one named tenant, under the same authorization as the existing maintenance routes, safe to call concurrently with the scheduled fold and with itself. The response distinguishes **published** from **nothing eligible**, which matters because a fold triggered right after a load seals nothing — correct behaviour that would otherwise look like a broken feature.

Review found five defects; the three substantive ones: the route passed through neither `query_admission` nor `ingest_concurrency` while re-running object-store work on every call including the cheap case; classification on `entry_count` equality misreported a real publish as `nothing_eligible` when a fold both folds commits in and drops entries via a retention tombstone; and it used the foreground store handle where the scheduled fold running identical `Catalog::fold` work uses `store_background` under ADR-0070's "fold is deferred maintenance traffic".

### #851 — explicit S3 HTTP client timeouts (`ravel-object-store`)

No `ClientOptions` was constructed anywhere, so request timeout, connect timeout, pool idle and keep-alive were all inherited defaults — including a 30 s request timeout nothing chose. That is longer than any healthy request here, so a hung connection held a concurrency slot past the query's own deadline. Values are now set deliberately and configurably, with the retry interaction stated: `object_store` retries internally, so timeout times retry count is the real worst case for one logical operation.

### #857 — surface the per-phase accounting and add `--warm-catalog` (`ravel-bench`)

`PhaseAccounting` landed under #796 with per-phase GET and byte counters for resolve, plan, probe and scan — and nothing outside `ravel-query` read it, so a bench report could not answer "did that change move probe cost or scan cost". A recent investigation had to be done by reading source for exactly that reason.

Two traps were specified out of it, both from things that already bit this project. The split is emitted **per run**, not only aggregated: the aggregate `scan` field reports run 0 only, and reading it instead of per-run figures once made a cache default read as a 2.26x regression. And zeros are emitted and parsed explicitly, because a warm run legitimately reports 0 bytes and 0 GETs — zero is the most interesting value a cost counter can report, and a truthiness-style pick would silently drop it.

`--warm-catalog` reuses the `SqlExecutor` across statements. Previously the bench built a cold executor per statement, so a resolve over unsealed buckets paid its GETs on every statement where the server's per-process `RecordCache` would not — making bench resolve-phase figures diverge from server behaviour for that reason alone.

No closing keywords in any of the ten commits: all four tickets close on measurements taken after merge.
