### PR TITLE
perf(ravel-query): drive log fetch range decisions from a request cost

### DIFF
--- a/crates/ravel-query/src/lib.rs
+++ b/crates/ravel-query/src/lib.rs
@@ -31,7 +31,7 @@ pub use log_fetcher::{
     BlockRangeFetcher, BlockRangeStats, BlockStatsReport, ColumnarBlockOutcome,
     DEFAULT_LOG_COALESCE_GAP, DEFAULT_LOG_COVERAGE_THRESHOLD, DEFAULT_LOG_MAX_CONCURRENT_GETS,
     DEFAULT_LOG_SUFFIX_LEN, DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD, LogFetchError, LogFetchOutput,
-    LogQuery, LogSegmentFetcher, LogSegmentScan, StreamAttrEquals,
+    LogQuery, LogSegmentFetcher, LogSegmentScan, StreamAttrEquals, WHOLE_OBJECT_REQUEST_MULTIPLE,
 };
 pub use phase_accounting::{PhaseAccounting, PhaseAccountingSnapshot, QueryPhase};
 pub use query_admission::{

--- a/crates/ravel-query/src/log_fetcher.rs
+++ b/crates/ravel-query/src/log_fetcher.rs
@@ -1891,7 +1891,7 @@ pub const DEFAULT_LOG_COALESCE_GAP: u64 = 64 * 1024;
 /// GETs/object measured on q20), so it cannot save enough bytes to pay for
 /// itself until the object exceeds this many request-costs. 5 x 1.8 MiB ~= 8.9
 /// MiB reproduces q20's measured whole-object break-even.
-const WHOLE_OBJECT_REQUEST_MULTIPLE: u64 = 5;
+pub const WHOLE_OBJECT_REQUEST_MULTIPLE: u64 = 5;
 
 /// Floor on the size-threshold pre-probe crossover, under the
 /// request-cost-derived default. An object at or below the effective threshold

--- a/crates/ravel-query/src/log_fetcher.rs
+++ b/crates/ravel-query/src/log_fetcher.rs
@@ -597,6 +597,17 @@ impl LogSegmentFetcher {
         self
     }
 
+    /// Sets the block-range fetcher's request cost
+    /// ([`BlockRangeFetcher::with_request_cost_bytes`]), the byte-denominated
+    /// cost of one store round trip that drives its whole-object crossover and
+    /// coalescing gap (ADR-0107). A property of the store and instance, not the
+    /// RLOG format.
+    #[must_use]
+    pub fn with_request_cost_bytes(mut self, n: u64) -> Self {
+        self.block_range = self.block_range.with_request_cost_bytes(n);
+        self
+    }
+
     /// Replaces the block-range fetcher (ADR-0107) with a fully configured one,
     /// for callers and tests that need to set the coalescing gap, coverage
     /// crossover, or concurrency bound directly. The replacement keeps this
@@ -1841,16 +1852,56 @@ impl LogSegmentFetcher {
 /// per read. `BlockRangeFetcher::with_suffix_len` overrides it.
 pub const DEFAULT_LOG_SUFFIX_LEN: u64 = 256 * 1024;
 
-/// Default maximum gap between two wanted block extents that still get coalesced
-/// into a single GET. Same 64 KiB start as `crate::fetcher::DEFAULT_COALESCE_GAP`
-/// (ADR-0107 decision 1: "start at RSEG's 64 KiB").
+/// Default cost of one store request, expressed as a latency-bandwidth product:
+/// the byte volume whose transfer time (at the store's single-stream bandwidth)
+/// equals one request's round-trip latency. This is the exchange rate between
+/// the two things a range-vs-whole-object decision trades: a saved request is
+/// worth this many saved bytes, so a decision that avoids `k` requests to move
+/// `b` extra bytes is a win exactly when `b < k * request_cost`.
+///
+/// The default is derived from q20 on in-region S3 from an r6a.4xlarge at 8
+/// concurrent fetch permits: 20.95 ms of occupied permit time per GET, of which
+/// ~1.01 ms is payload transfer at ~90 MB/s single-stream, so ~95% of each
+/// request is round-trip latency. 20.95 ms x 90 MB/s ~= 1.8 MiB of transfer buys
+/// one round trip.
+///
+/// This is a property of the STORE AND INSTANCE (its latency and per-stream
+/// bandwidth at the fetch concurrency in use), NOT of the RLOG format, which is
+/// why it is a configurable tunable rather than a frozen constant: a different
+/// store, a cross-region bucket, or a different permit count has a different
+/// value, and every one of the fetch-layer thresholds below is derived from it
+/// so that recalibrating the store recalibrates all of them at once.
+/// [`BlockRangeFetcher::with_request_cost_bytes`] overrides it.
+pub const DEFAULT_LOG_REQUEST_COST_BYTES: u64 = 1_887_437; // ~1.8 MiB
+
+/// Floor on the coalescing gap, under the request-cost-derived default. Two
+/// wanted extents separated by less than the effective gap fuse into one GET.
+/// The principled value is [`DEFAULT_LOG_REQUEST_COST_BYTES`]: it is never worth
+/// a second request to skip a hole whose bytes cost less to transfer than the
+/// request would cost, so the effective gap is the request cost (much larger
+/// than this floor). This 64 KiB floor (`crate::fetcher::DEFAULT_COALESCE_GAP`,
+/// ADR-0107 decision 1: "start at RSEG's 64 KiB") applies only when a caller
+/// drives the request cost below it.
 pub const DEFAULT_LOG_COALESCE_GAP: u64 = 64 * 1024;
 
-/// Default object size at or below which the size-threshold pre-probe crossover
-/// reads the whole object in one GET instead of probing and range-fetching
-/// (ADR-0107 decision 1, "size-threshold, pre-probe whole-object read"). Mirrors
-/// `crate::fetcher::DEFAULT_WHOLE_OBJECT_THRESHOLD` (512 KiB) exactly: below it
-/// the extra probe + per-range round trips cost more than the bytes they save.
+/// Multiple of the request cost at which a whole-object read breaks even against
+/// the probe+ranged path. The ranged protocol adds on the order of this many
+/// store round trips over a single whole-object GET (a probe, one coalesced
+/// front-section GET, and a small number of block/chunk-run GETs -- ~5.46
+/// GETs/object measured on q20), so it cannot save enough bytes to pay for
+/// itself until the object exceeds this many request-costs. 5 x 1.8 MiB ~= 8.9
+/// MiB reproduces q20's measured whole-object break-even.
+const WHOLE_OBJECT_REQUEST_MULTIPLE: u64 = 5;
+
+/// Floor on the size-threshold pre-probe crossover, under the
+/// request-cost-derived default. An object at or below the effective threshold
+/// is read whole in one GET instead of probing and range-fetching (ADR-0107
+/// decision 1, "size-threshold, pre-probe whole-object read"). The principled
+/// value is `WHOLE_OBJECT_REQUEST_MULTIPLE * request_cost`: below it the extra
+/// round trips the ranged path adds cost more than the bytes they could save at
+/// ANY selectivity. This 512 KiB floor (matching
+/// `crate::fetcher::DEFAULT_WHOLE_OBJECT_THRESHOLD`) applies only when a caller
+/// drives the request cost low enough that the derived threshold falls under it.
 pub const DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD: u64 = 512 * 1024;
 
 /// Default coverage fraction at or above which the post-pruning crossover falls
@@ -2055,9 +2106,20 @@ pub struct BlockRangeFetcher {
     /// (see [`ReadCache`]); every production caller builds the RAM variant.
     cache: Option<ReadCache>,
     suffix_len: u64,
-    coalesce_gap: u64,
-    whole_object_threshold: u64,
+    /// Coalescing gap. `None` derives it from `request_cost_bytes` (the
+    /// principled default); `Some(n)` pins it, which the tests use to force an
+    /// exact run count. See [`Self::effective_coalesce_gap`].
+    coalesce_gap: Option<u64>,
+    /// Size-threshold pre-probe crossover. `None` derives it from
+    /// `request_cost_bytes`; `Some(n)` pins it (and `Some(0)` forces the ranged
+    /// path). See [`Self::effective_whole_object_threshold`].
+    whole_object_threshold: Option<u64>,
     coverage_threshold: f64,
+    /// Cost of one store request as a byte volume (a latency-bandwidth product);
+    /// the single quantity every range-vs-whole-object decision here is driven
+    /// from ([`DEFAULT_LOG_REQUEST_COST_BYTES`]). A property of the store and
+    /// instance, so it is a tunable, not a constant.
+    request_cost_bytes: u64,
     /// Bounds in-flight byte-range GETs. Its own instance, never shared with
     /// `SegmentFetcher`'s RSEG semaphore (ADR-0107 decision 1).
     get_semaphore: Arc<Semaphore>,
@@ -2070,9 +2132,10 @@ impl BlockRangeFetcher {
             cfg: RlogConfig::default(),
             cache: None,
             suffix_len: DEFAULT_LOG_SUFFIX_LEN,
-            coalesce_gap: DEFAULT_LOG_COALESCE_GAP,
-            whole_object_threshold: DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
+            coalesce_gap: None,
+            whole_object_threshold: None,
             coverage_threshold: DEFAULT_LOG_COVERAGE_THRESHOLD,
+            request_cost_bytes: DEFAULT_LOG_REQUEST_COST_BYTES,
             get_semaphore: Arc::new(Semaphore::new(DEFAULT_LOG_MAX_CONCURRENT_GETS)),
         }
     }
@@ -2097,18 +2160,55 @@ impl BlockRangeFetcher {
 
     #[must_use]
     pub fn with_coalesce_gap(mut self, n: u64) -> Self {
-        self.coalesce_gap = n;
+        self.coalesce_gap = Some(n);
         self
     }
 
-    /// Sets the size-threshold pre-probe crossover. An object whose size is at or
-    /// below `n` is read whole in one GET; `0` disables the size crossover (every
-    /// object takes the probe + range path), which the tests use to force the
-    /// ranged path on a small fixture.
+    /// Sets the size-threshold pre-probe crossover explicitly, overriding the
+    /// request-cost-derived default. An object whose size is at or below `n` is
+    /// read whole in one GET; `0` disables the size crossover (every object takes
+    /// the probe + range path), which the tests use to force the ranged path on a
+    /// small fixture.
     #[must_use]
     pub fn with_whole_object_threshold(mut self, n: u64) -> Self {
-        self.whole_object_threshold = n;
+        self.whole_object_threshold = Some(n);
         self
+    }
+
+    /// Sets the cost of one store request as a byte volume (a latency-bandwidth
+    /// product; see [`DEFAULT_LOG_REQUEST_COST_BYTES`]). This drives the
+    /// whole-object crossover and the coalescing gap whenever those are left at
+    /// their defaults, so recalibrating the store (a faster tier, a cross-region
+    /// bucket, a different fetch concurrency) recalibrates every fetch-layer
+    /// range-vs-whole-object decision through this one knob.
+    #[must_use]
+    pub fn with_request_cost_bytes(mut self, n: u64) -> Self {
+        self.request_cost_bytes = n;
+        self
+    }
+
+    /// The coalescing gap in effect: an explicit [`Self::with_coalesce_gap`]
+    /// override when set, else the request cost (floored by
+    /// [`DEFAULT_LOG_COALESCE_GAP`]). It is never worth a second request to skip
+    /// a hole whose bytes transfer for less than one request costs, so the
+    /// principled gap is exactly one request cost.
+    fn effective_coalesce_gap(&self) -> u64 {
+        self.coalesce_gap
+            .unwrap_or_else(|| self.request_cost_bytes.max(DEFAULT_LOG_COALESCE_GAP))
+    }
+
+    /// The size-threshold pre-probe crossover in effect: an explicit
+    /// [`Self::with_whole_object_threshold`] override when set (including the `0`
+    /// that forces the ranged path), else `WHOLE_OBJECT_REQUEST_MULTIPLE`
+    /// request-costs (floored by [`DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD`]). Below
+    /// the break-even the ranged path's extra round trips cost more than the
+    /// bytes they could save at any selectivity, so the whole-object read wins.
+    fn effective_whole_object_threshold(&self) -> u64 {
+        self.whole_object_threshold.unwrap_or_else(|| {
+            self.request_cost_bytes
+                .saturating_mul(WHOLE_OBJECT_REQUEST_MULTIPLE)
+                .max(DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD)
+        })
     }
 
     /// Sets the coverage-based post-pruning crossover fraction (0.0..=1.0). When
@@ -2480,7 +2580,7 @@ impl BlockRangeFetcher {
                 });
             }
         }
-        for run in coalesce_byte_extents(&missing, self.coalesce_gap) {
+        for run in coalesce_byte_extents(&missing, self.effective_coalesce_gap()) {
             let (bytes, live) = self
                 .cached_extent(
                     seg_ref,
@@ -2745,8 +2845,12 @@ impl BlockRangeFetcher {
         // object is read whole in one GET, mirroring `SegmentFetcher`. Keyed
         // `(0, object_size)`, the same key `LogSegmentFetcher::tenant_bytes`
         // gives its whole-object read, so the two compose and concurrent callers
-        // coalesce instead of each paying the GET.
-        if seg_ref.object_size <= self.whole_object_threshold {
+        // coalesce instead of each paying the GET. The threshold is request-cost
+        // driven (deliverable 2): below the break-even the ranged path's extra
+        // round trips cost more than the bytes they could save at any
+        // selectivity, so the whole-object read is the faster option even though
+        // it moves the most bytes.
+        if seg_ref.object_size <= self.effective_whole_object_threshold() {
             let (bytes, live) = self
                 .cached_extent(
                     seg_ref,
@@ -3034,12 +3138,29 @@ impl BlockRangeFetcher {
             }
         }
 
-        // The remaining non-BLOCKS sections: STREAM_DIR/FIELD_DIR (object front)
-        // and any tail section (BLOOM/POSTINGS) a short probe missed. The reader
-        // re-verifies each section's crc on decode, so a corrupt section hit
-        // fails closed there (ADR-0046).
+        // The two front sections (STREAM_DIR/FIELD_DIR): one coalesced GET over
+        // their adjacent span (deliverable 4), skipped entirely when an earlier
+        // FIELD_DIR resolution already brought them.
+        self.place_front_sections(
+            seg_ref,
+            tenant_hash,
+            &footer,
+            &pin,
+            &mut asm,
+            accounting,
+            &mut stats,
+        )
+        .await?;
+
+        // Any remaining tail section (BLOOM/POSTINGS) a short probe missed: one
+        // GET each, never coalesced with the front across the BLOCKS gap. The
+        // reader re-verifies each section's crc on decode, so a corrupt section
+        // hit fails closed there (ADR-0046).
         for section in &footer.sections {
-            if section.kind == kind::BLOCKS {
+            if matches!(
+                section.kind,
+                kind::BLOCKS | kind::STREAM_DIR | kind::FIELD_DIR
+            ) {
                 continue;
             }
             self.place_section(
@@ -3298,12 +3419,30 @@ impl BlockRangeFetcher {
             }
         }
 
-        // The remaining non-BLOCKS sections: STREAM_DIR/FIELD_DIR at the object
-        // front, and BLOOM/POSTINGS when a short probe missed them. The reader
-        // re-verifies each section's crc on decode, so a corrupt section hit
-        // fails closed there (ADR-0046).
+        // The two front sections (STREAM_DIR/FIELD_DIR): one coalesced GET over
+        // their adjacent span (deliverable 4). On the narrow-projection path
+        // `place_and_decode_field_dir` already brought both, so this is a no-op
+        // there; on an all-columns v4 read it is the read's one front GET.
+        self.place_front_sections(
+            seg_ref,
+            tenant_hash,
+            footer,
+            pin,
+            &mut asm,
+            accounting,
+            &mut stats,
+        )
+        .await?;
+
+        // Any remaining tail section (BLOOM/POSTINGS) a short probe missed: one
+        // GET each, never coalesced with the front across the BLOCKS gap. The
+        // reader re-verifies each section's crc on decode, so a corrupt section
+        // hit fails closed there (ADR-0046).
         for section in &footer.sections {
-            if section.kind == kind::BLOCKS {
+            if matches!(
+                section.kind,
+                kind::BLOCKS | kind::STREAM_DIR | kind::FIELD_DIR
+            ) {
                 continue;
             }
             self.place_section(
@@ -3350,7 +3489,7 @@ impl BlockRangeFetcher {
         stats: &mut BlockRangeStats,
     ) -> Result<(), LogFetchError> {
         let key = seg_ref.data_object_key.as_str();
-        let runs: Vec<ByteExtent> = coalesce_byte_extents(wanted, self.coalesce_gap)
+        let runs: Vec<ByteExtent> = coalesce_byte_extents(wanted, self.effective_coalesce_gap())
             .into_iter()
             // A run the probe already brought costs nothing: its bytes are in
             // `asm` at the right offsets already.
@@ -3411,7 +3550,7 @@ impl BlockRangeFetcher {
                 len: s.len,
             })
             .collect();
-        for run in coalesce_byte_extents(&missing, self.coalesce_gap) {
+        for run in coalesce_byte_extents(&missing, self.effective_coalesce_gap()) {
             let (bytes, live) = self
                 .cached_extent(
                     seg_ref,
@@ -3494,12 +3633,79 @@ impl BlockRangeFetcher {
         Ok(out)
     }
 
-    /// Place the FIELD_DIR section into `asm` (via [`place_section`](Self::
-    /// place_section), so it single-flights and reuses an already-resident
-    /// region) and decode it, so the caller can resolve a query's prune-only
-    /// NumRange arms to this object's own column ids before the candidate set is
-    /// chosen. FIELD_DIR is compressed as a whole section (docs/log-segment-\
-    /// format.md), the same shape SKIP_IDX is decoded with just above.
+    /// Place the object's two front directory sections -- STREAM_DIR (kind 1)
+    /// then FIELD_DIR (kind 2), which the writer emits ADJACENT at the object
+    /// front (docs/log-segment-format.md) -- in ONE range GET over their combined
+    /// span, instead of one GET each (deliverable 4). No suffix probe of any
+    /// length reaches a front section, so without coalescing the two are two of
+    /// the ~5.46 store round trips an object's ranged read costs (ADR-0107), for
+    /// a byte volume that is a rounding error against one request cost; presenting
+    /// them together to one GET removes one whole request per object. A section
+    /// already resident (an earlier call, or a footer that omits one of the two)
+    /// costs nothing, and the span then covers only whichever remains. Counts one
+    /// [`BlockRangeStats::metadata_gets`] when it fetches, never a `probe_miss`
+    /// (the front is unreachable by any probe, so counting it there would put a
+    /// floor under that metric -- see the `probe_misses` field doc).
+    #[allow(clippy::too_many_arguments)]
+    async fn place_front_sections(
+        &self,
+        seg_ref: &SegmentRef,
+        tenant_hash: TenantHash,
+        footer: &footer::LogFooter,
+        pin: &EtagPin,
+        asm: &mut ObjectAssembler,
+        accounting: &QueryAccounting,
+        stats: &mut BlockRangeStats,
+    ) -> Result<(), LogFetchError> {
+        let key = seg_ref.data_object_key.as_str();
+        let mut start = u64::MAX;
+        let mut end = 0u64;
+        for k in [kind::STREAM_DIR, kind::FIELD_DIR] {
+            let Some(desc) = footer.section(k) else {
+                continue;
+            };
+            if asm.covers(desc.offset, desc.offset + desc.len) {
+                continue;
+            }
+            start = start.min(desc.offset);
+            end = end.max(desc.offset + desc.len);
+        }
+        if start >= end {
+            return Ok(());
+        }
+        let (bytes, live) = self
+            .cached_extent(
+                seg_ref,
+                tenant_hash,
+                start,
+                end - start,
+                GetRange::Range(start, end),
+                pin,
+                accounting,
+            )
+            .await?;
+        if live {
+            stats.metadata_gets += 1;
+        }
+        asm.place(key, start, &bytes)
+    }
+
+    /// Place FIELD_DIR into `asm` (via [`place_section`](Self::place_section), on
+    /// its own per-section cache key, so a subset scan reuses the FIELD_DIR the
+    /// plan phase already cached under that key) and decode it, so the caller can
+    /// resolve a query's prune-only NumRange arms and its projection to this
+    /// object's own column ids before the candidate set is chosen.
+    ///
+    /// STREAM_DIR is deliberately NOT coalesced in here: this runs BEFORE the
+    /// coverage crossover, and a query that then crosses over to a whole-object
+    /// read never needs STREAM_DIR, so bringing it eagerly would move directory
+    /// bytes the crossover discards. STREAM_DIR is instead brought by
+    /// [`place_front_sections`](Self::place_front_sections) after the crossover,
+    /// where -- with FIELD_DIR already resident -- it is the only remaining front
+    /// section and coalesces with nothing; on an all-columns read that skips this
+    /// method both front sections arrive cold there and coalesce into one GET.
+    /// FIELD_DIR is compressed as a whole section (docs/log-segment-format.md),
+    /// the same shape SKIP_IDX is decoded with just above.
     #[allow(clippy::too_many_arguments)]
     async fn place_and_decode_field_dir(
         &self,
@@ -3512,17 +3718,18 @@ impl BlockRangeFetcher {
         stats: &mut BlockRangeStats,
     ) -> Result<FieldDir, LogFetchError> {
         let key = seg_ref.data_object_key.as_str();
-        let desc = footer
+        let desc = *footer
             .section(kind::FIELD_DIR)
             .ok_or_else(|| corrupt(key, LogSegError::Corrupted("missing FIELD_DIR".into())))?;
-        self.place_section(seg_ref, tenant_hash, desc, pin, asm, accounting, stats)
+        self.place_section(seg_ref, tenant_hash, &desc, pin, asm, accounting, stats)
             .await?;
         let start = usize::try_from(desc.offset).map_err(|_| corrupt_range(key))?;
         let end = start
             .checked_add(usize::try_from(desc.len).map_err(|_| corrupt_range(key))?)
             .ok_or_else(|| corrupt_range(key))?;
         let stored = asm.buf.get(start..end).ok_or_else(|| corrupt_range(key))?;
-        let raw = decode_section(stored, desc, &self.cfg).map_err(|source| corrupt(key, source))?;
+        let raw =
+            decode_section(stored, &desc, &self.cfg).map_err(|source| corrupt(key, source))?;
         FieldDir::decode(&raw, MAX_FIELDS).map_err(|source| corrupt(key, source))
     }
 
@@ -3628,7 +3835,7 @@ impl BlockRangeFetcher {
         // `crate::fetcher::SegmentFetcher::ensure_ranges`' `join_all`). Awaiting
         // the runs in series made `get_semaphore` inert: a sequential loop never
         // has more than one GET in flight to bound.
-        let runs = coalesce_extents(&missing, self.coalesce_gap);
+        let runs = coalesce_extents(&missing, self.effective_coalesce_gap());
         let outcomes = futures::future::join_all(runs.iter().map(|run| {
             let blocks: Vec<BlockExtent> = missing
                 .iter()

--- a/crates/ravel-query/tests/log_block_range.rs
+++ b/crates/ravel-query/tests/log_block_range.rs
@@ -1378,7 +1378,8 @@ async fn page_decode_accounting_is_a_separate_axis_from_wire_bytes() {
 // whole-object one.
 
 /// The size-threshold crossover is request-cost driven: with the request cost
-/// set so the break-even (`WHOLE_OBJECT_REQUEST_MULTIPLE` = 5 request-costs)
+/// set so the break-even (`WHOLE_OBJECT_REQUEST_MULTIPLE` request-costs, read
+/// from the production constant rather than restated here)
 /// lands at 700 KiB, the crossover sits at 700 KiB and not at the 512 KiB
 /// byte-only floor, WITHOUT any explicit `with_whole_object_threshold` -- the
 /// decision consults the request cost alone. Request counts are exact, not
@@ -1405,7 +1406,10 @@ async fn whole_object_vs_ranged_is_driven_by_the_request_cost() {
     // 5 * 140 KiB = 700 KiB break-even, above the 512 KiB floor so the
     // request-derived value (not the floor) is what decides.
     const REQUEST_COST: u64 = 140 * 1024;
-    let break_even = 5 * REQUEST_COST;
+    // Derived from the production constant, never a literal: if the policy's
+    // multiple changes, the fixture bounds below must move with it or this test
+    // silently stops covering the interval where the two rules disagree.
+    let break_even = ravel_query::WHOLE_OBJECT_REQUEST_MULTIPLE * REQUEST_COST;
 
     // Small side: the 20-block subset object, far under the break-even.
     let (small_recs, small_bytes) = subset_object();

--- a/crates/ravel-query/tests/log_block_range.rs
+++ b/crates/ravel-query/tests/log_block_range.rs
@@ -588,8 +588,8 @@ async fn corrupt_per_block_cache_hit_fails_closed() {
 /// fraction, not the object size. With `coalesce_gap == 0`, the block-range GET
 /// count equals the number of maximal contiguous runs among candidate blocks; a
 /// suffix sized to the tail makes the fixed overhead exactly one probe GET plus
-/// one GET per uncovered front section (STREAM_DIR, FIELD_DIR). The asserted
-/// figures are exact, not "fewer than before".
+/// one coalesced GET for the two adjacent front sections (STREAM_DIR, FIELD_DIR,
+/// deliverable 4). The asserted figures are exact, not "fewer than before".
 #[tokio::test]
 async fn block_range_get_count_is_proportional_to_candidate_fraction() {
     let (records, bytes) = subset_object();
@@ -641,17 +641,22 @@ async fn block_range_get_count_is_proportional_to_candidate_fraction() {
         "candidate bytes {candidate_bytes} must be far under the block region {blocks_len}"
     );
 
-    // Total store GETs: probe (1) + front metadata (STREAM_DIR + FIELD_DIR = 2)
-    // + one per contiguous candidate run. The tail (SKIP_IDX/BLOOM/POSTINGS +
-    // footer) is covered by the probe, so it costs no extra GET.
-    let expected_total = 1 + 2 + expected_runs as u64;
+    // Total store GETs: probe (1) + front metadata (STREAM_DIR + FIELD_DIR are
+    // adjacent at the object front and fetched together in ONE coalesced GET,
+    // deliverable 4) + one per contiguous candidate run. The tail
+    // (SKIP_IDX/BLOOM/POSTINGS + footer) is covered by the probe, so it costs no
+    // extra GET.
+    let expected_total = 1 + 1 + expected_runs as u64;
     assert_eq!(
         counting.get_count(),
         expected_total,
-        "probe(1) + front-meta(2) + block runs({expected_runs})"
+        "probe(1) + coalesced front-meta(1) + block runs({expected_runs})"
     );
     assert_eq!(stats.probe_gets, 1);
-    assert_eq!(stats.metadata_gets, 2);
+    assert_eq!(
+        stats.metadata_gets, 1,
+        "STREAM_DIR + FIELD_DIR fetched in one coalesced front-section GET"
+    );
     assert!(!stats.whole_object);
 }
 
@@ -699,18 +704,48 @@ fn large_object() -> (Vec<LogRecord>, Vec<u8>) {
     (records, bytes)
 }
 
-/// Non-BLOCKS sections the probe window `[total - suffix, total)` does NOT
-/// already cover: one metadata GET each.
+/// An object inside the ONLY interval where a byte-only 512 KiB threshold and a
+/// 700 KiB request-cost break-even disagree: 27 one-record blocks of ~24 KiB
+/// each, 612181 bytes. That is 87893 B above
+/// [`ravel_query::DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD`], which would range-fetch
+/// it, and 104619 B below the 700 KiB break-even
+/// `whole_object_vs_ranged_is_driven_by_the_request_cost` configures, which
+/// reads it whole. `big_records` is deterministic, so the size is the same on
+/// every run; that test asserts both bounds so a fixture-generation change
+/// cannot drift it out of the window unnoticed.
+fn medium_object() -> (Vec<LogRecord>, Vec<u8>) {
+    let records = big_records(27);
+    let bytes = build_object(&records);
+    (records, bytes)
+}
+
+/// The fixed non-BLOCKS section GET cost the probe window `[total - suffix,
+/// total)` does NOT already cover: the two adjacent FRONT sections (STREAM_DIR,
+/// FIELD_DIR) as ONE coalesced GET when either is uncovered (deliverable 4;
+/// always uncovered here, since a suffix probe never reaches the front), plus
+/// one GET per uncovered TAIL section.
 fn uncovered_sections(bytes: &[u8], suffix: u64) -> u64 {
     let footer = footer::open(bytes).expect("footer");
     let total = bytes.len() as u64;
     let probe_start = total.saturating_sub(suffix);
-    footer
-        .sections
-        .iter()
-        .filter(|s| s.kind != kind::BLOCKS)
-        .filter(|s| s.offset < probe_start || s.offset + s.len > total)
-        .count() as u64
+    let is_front = |k: u32| k == kind::STREAM_DIR || k == kind::FIELD_DIR;
+    let mut front_get = 0u64;
+    let mut tail_gets = 0u64;
+    for s in &footer.sections {
+        if s.kind == kind::BLOCKS {
+            continue;
+        }
+        let uncovered = s.offset < probe_start || s.offset + s.len > total;
+        if !uncovered {
+            continue;
+        }
+        if is_front(s.kind) {
+            front_get = 1;
+        } else {
+            tail_gets += 1;
+        }
+    }
+    front_get + tail_gets
 }
 
 /// Coalesced runs among candidate extents at a gap threshold: the exact number
@@ -886,10 +921,17 @@ async fn cached_partitions_striping_one_large_segment_cost_a_partition_independe
         let seg = seg_ref("logs/big.rlog", bytes.len() as u64, &records);
         let query = LogQuery::new(ts_min, ts_max);
 
-        // Production defaults throughout: no threshold override, no probe-length
-        // override, no coverage override. Only the cache is wired, exactly as
-        // `build_sql_state` wires it.
-        let fetcher = LogSegmentFetcher::new(store).with_cache(big_cache());
+        // Production defaults for probe length and coverage; the cache is wired
+        // exactly as `build_sql_state` wires it. The request cost is lowered to
+        // 64 KiB so this deliberately sub-MB fixture stays ABOVE the
+        // request-aware whole-object threshold (5 x request-cost, floored at 512
+        // KiB) and exercises the ranged protocol this test is about. The
+        // single-flight/coalescing property under test is independent of the
+        // request cost, and at 64 KiB the effective coalescing gap is the
+        // 64 KiB `DEFAULT_LOG_COALESCE_GAP` the oracle uses.
+        let fetcher = LogSegmentFetcher::new(store)
+            .with_cache(big_cache())
+            .with_request_cost_bytes(ravel_query::DEFAULT_LOG_COALESCE_GAP);
         assert!(
             fetcher.has_cache(),
             "the ADR-0102 fan-out gate this test stands in for reads has_cache()"
@@ -994,7 +1036,11 @@ async fn concurrent_cold_partitions_collapse_onto_one_get_per_extent() {
     let store: Arc<dyn ObjectStoreBackend> = counting.clone();
     let seg = seg_ref("logs/cold.rlog", bytes.len() as u64, &records);
 
-    let br = BlockRangeFetcher::new(store).with_cache(big_cache());
+    // Request cost lowered to 64 KiB so this sub-MB fixture stays above the
+    // request-aware whole-object threshold and takes the ranged path; see test 6.
+    let br = BlockRangeFetcher::new(store)
+        .with_cache(big_cache())
+        .with_request_cost_bytes(ravel_query::DEFAULT_LOG_COALESCE_GAP);
     let mut tasks = Vec::new();
     for _ in 0..PARTITIONS {
         let br = br.clone();
@@ -1075,7 +1121,11 @@ async fn concurrent_cold_partitions_collapse_onto_one_get_per_extent_tiered() {
     let seg = seg_ref("logs/cold-tiered.rlog", bytes.len() as u64, &records);
 
     let tmp = tempfile::TempDir::new().expect("temp dir for the disk cache tier");
-    let br = BlockRangeFetcher::new(store).with_cache(big_tiered_cache(tmp.path()));
+    // Request cost lowered to 64 KiB so this sub-MB fixture stays above the
+    // request-aware whole-object threshold and takes the ranged path; see test 6.
+    let br = BlockRangeFetcher::new(store)
+        .with_cache(big_tiered_cache(tmp.path()))
+        .with_request_cost_bytes(ravel_query::DEFAULT_LOG_COALESCE_GAP);
     let mut tasks = Vec::new();
     for _ in 0..PARTITIONS {
         let br = br.clone();
@@ -1159,7 +1209,13 @@ async fn corrupt_block_hit_fails_closed_with_only_blocks_resident() {
         );
     }
 
-    let br = BlockRangeFetcher::new(store).with_cache(cache);
+    // Request cost lowered to 64 KiB so this sub-MB fixture stays above the
+    // request-aware whole-object threshold and takes the per-block ranged path
+    // whose cache-hit gate is under test (see test 6); a whole-object read would
+    // never consult the pre-admitted per-block entries.
+    let br = BlockRangeFetcher::new(store)
+        .with_cache(cache)
+        .with_request_cost_bytes(ravel_query::DEFAULT_LOG_COALESCE_GAP);
     let err = br
         .fetch_object(&seg, TENANT, ts_min, ts_max, &QueryAccounting::new())
         .await
@@ -1310,3 +1366,226 @@ async fn page_decode_accounting_is_a_separate_axis_from_wire_bytes() {
 // (`version_4_object_is_read_whole_until_the_page_dir_fetcher_lands`, now
 // `version_4_projected_read_fetches_one_range_per_group_and_column`), live in
 // `tests/log_page_dir_fetch.rs`.
+
+// ---- Tests 10-11: the request-cost-driven decisions (issues #835, #862) -----
+//
+// The whole-object-vs-ranged decision is driven from one configurable quantity,
+// the request cost (a latency-bandwidth product; `BlockRangeFetcher::
+// with_request_cost_bytes`), not from a byte-only size threshold. Test 10 pins
+// that by reading an object the byte-only rule would range-fetch whole, because
+// the request cost says so; test 11 pins that a large coalescing gap (also
+// driven from the request cost) never turns a genuinely narrow read into a
+// whole-object one.
+
+/// The size-threshold crossover is request-cost driven: with the request cost
+/// set so the break-even (`WHOLE_OBJECT_REQUEST_MULTIPLE` = 5 request-costs)
+/// lands at 700 KiB, the crossover sits at 700 KiB and not at the 512 KiB
+/// byte-only floor, WITHOUT any explicit `with_whole_object_threshold` -- the
+/// decision consults the request cost alone. Request counts are exact, not
+/// "fewer than before".
+///
+/// Prove-the-test: the byte-only rule (`<= self.whole_object_threshold`, a `u64`
+/// defaulting to 512 KiB) and the request-cost rule (`<=
+/// self.effective_whole_object_threshold()`, 700 KiB here) disagree on exactly
+/// one interval, [512 KiB, 700 KiB): ranged under the former, whole under the
+/// latter. So only a fixture inside that interval can fail. The small
+/// (`subset_object`, tiny bodies, far under 512 KiB) and large (960 KiB)
+/// fixtures sit outside it and are read the same way under both rules -- they
+/// anchor the two ends, they do not discriminate. `medium_object` (612181 B,
+/// above 512 KiB and below 700 KiB) is inside it: reverting that
+/// comparison in `fetch_object_with_footer` to the byte-only field puts it on
+/// the probe+ranged path, so `medium_stats.whole_object` and the exact
+/// one-GET count both fail. Its ts window is narrow enough to stay under the
+/// coverage crossover, so nothing routes it back to a whole-object read once the
+/// size rule sends it ranged, and both of its size bounds are asserted below: a
+/// fixture-generation change that drifted it out of the interval would restore
+/// the vacuity with no assertion firing.
+#[tokio::test]
+async fn whole_object_vs_ranged_is_driven_by_the_request_cost() {
+    // 5 * 140 KiB = 700 KiB break-even, above the 512 KiB floor so the
+    // request-derived value (not the floor) is what decides.
+    const REQUEST_COST: u64 = 140 * 1024;
+    let break_even = 5 * REQUEST_COST;
+
+    // Small side: the 20-block subset object, far under the break-even.
+    let (small_recs, small_bytes) = subset_object();
+    let small_total = small_bytes.len() as u64;
+    assert!(
+        small_total < break_even,
+        "small fixture {small_total} must sit below the {break_even} B break-even"
+    );
+    let small_mem = Arc::new(MemoryStore::new());
+    small_mem
+        .put(
+            "logs/small.rlog",
+            small_bytes.clone().into(),
+            PutOptions::default(),
+        )
+        .await
+        .expect("put small");
+    let small_seg = seg_ref("logs/small.rlog", small_total, &small_recs);
+    let small_counting = Arc::new(CountingStore::new(small_mem));
+    let small_store: Arc<dyn ObjectStoreBackend> = small_counting.clone();
+    let (_small_buf, small_stats) = BlockRangeFetcher::new(small_store)
+        .with_request_cost_bytes(REQUEST_COST)
+        .fetch_object(
+            &small_seg,
+            TENANT,
+            i64::MIN,
+            i64::MAX,
+            &QueryAccounting::new(),
+        )
+        .await
+        .expect("small fetch");
+    assert!(
+        small_stats.whole_object,
+        "an object below the break-even is read whole"
+    );
+    assert_eq!(
+        small_counting.get_count(),
+        1,
+        "the whole-object read is exactly one GET"
+    );
+    assert_eq!(small_stats.block_range_gets, 0, "no ranged block GETs");
+
+    // Large side: the 40-block, ~960 KiB object, above the break-even.
+    let (large_recs, large_bytes) = large_object();
+    let large_total = large_bytes.len() as u64;
+    assert!(
+        large_total > break_even,
+        "large fixture {large_total} must sit above the {break_even} B break-even"
+    );
+    let (_blocks_offset, _blocks_len, tail) = layout(&large_bytes);
+    let (ts_min, ts_max) = (2, 11);
+    let cands = candidate_extents(&large_bytes, ts_min, ts_max);
+    let effective_gap = REQUEST_COST.max(ravel_query::DEFAULT_LOG_COALESCE_GAP);
+    let expected_runs = coalesced_runs(cands.clone(), effective_gap);
+    assert!(
+        !cands.is_empty() && (cands.len() as u64) < 40,
+        "a strict nontrivial candidate subset, got {}",
+        cands.len()
+    );
+
+    let large_mem = Arc::new(MemoryStore::new());
+    large_mem
+        .put(
+            "logs/large.rlog",
+            large_bytes.clone().into(),
+            PutOptions::default(),
+        )
+        .await
+        .expect("put large");
+    let large_seg = seg_ref("logs/large.rlog", large_total, &large_recs);
+    let large_counting = Arc::new(CountingStore::new(large_mem));
+    let large_store: Arc<dyn ObjectStoreBackend> = large_counting.clone();
+    let (_large_buf, large_stats) = BlockRangeFetcher::new(large_store)
+        .with_request_cost_bytes(REQUEST_COST)
+        // Probe the tail exactly, so the front sections are the only uncovered
+        // metadata and the candidate GETs are clean.
+        .with_suffix_len(tail)
+        .fetch_object(&large_seg, TENANT, ts_min, ts_max, &QueryAccounting::new())
+        .await
+        .expect("large fetch");
+    assert!(
+        !large_stats.whole_object,
+        "an object above the break-even takes the ranged path"
+    );
+    assert_eq!(
+        large_stats.probe_gets, 1,
+        "one etag-establishing suffix probe"
+    );
+    assert_eq!(
+        large_stats.metadata_gets, 1,
+        "STREAM_DIR + FIELD_DIR in one coalesced front-section GET"
+    );
+    assert_eq!(
+        large_stats.block_range_gets, expected_runs,
+        "one coalesced GET per candidate run at the request-cost-derived gap"
+    );
+    assert_eq!(
+        large_counting.get_count(),
+        1 + 1 + expected_runs,
+        "probe(1) + coalesced front-meta(1) + block runs({expected_runs})"
+    );
+}
+
+/// The coverage crossover is the backstop that keeps a large coalescing gap from
+/// silently turning a genuinely narrow read into a whole-object one: coverage is
+/// measured on the real candidate bytes (gap-independent), so a narrow candidate
+/// set stays under the crossover and on the ranged path no matter how large the
+/// gap coalesces its runs, while a set that genuinely covers most of the object
+/// still crosses over. This is what stops the item-3 gap widening from undoing
+/// the item-2 whole-object decision.
+///
+/// Prove-the-test: if coverage were instead measured on the post-coalesce run
+/// bytes, the huge gap would inflate the narrow read's run to nearly the whole
+/// object and `!narrow_stats.whole_object` would fail. It holds because the
+/// crossover's numerator is the candidate extents' own bytes.
+#[tokio::test]
+async fn a_large_coalesce_gap_does_not_cross_a_narrow_read_over_to_whole_object() {
+    const REQUEST_COST: u64 = 140 * 1024;
+    let (records, bytes) = large_object();
+    let total = bytes.len() as u64;
+    let (_blocks_offset, blocks_len, tail) = layout(&bytes);
+    let mem = Arc::new(MemoryStore::new());
+    mem.put("logs/gap.rlog", bytes.clone().into(), PutOptions::default())
+        .await
+        .expect("put");
+    let seg = seg_ref("logs/gap.rlog", total, &records);
+
+    // A gap as large as the whole object: every candidate run would fuse.
+    let make = |store: Arc<dyn ObjectStoreBackend>| {
+        BlockRangeFetcher::new(store)
+            .with_request_cost_bytes(REQUEST_COST)
+            .with_suffix_len(tail)
+            .with_coalesce_gap(total)
+    };
+
+    // Narrow: a two-block ts window. Its candidate bytes are a small fraction of
+    // BLOCKS, so coverage is far under the 0.75 crossover.
+    let (narrow_min, narrow_max) = (2, 3);
+    let narrow_cands = candidate_extents(&bytes, narrow_min, narrow_max);
+    let narrow_bytes: u64 = narrow_cands.iter().map(|(_, l, _)| *l).sum();
+    let narrow_coverage = narrow_bytes as f64 / blocks_len as f64;
+    assert!(
+        narrow_coverage < ravel_query::DEFAULT_LOG_COVERAGE_THRESHOLD,
+        "the narrow set must be genuinely under the coverage crossover, got {narrow_coverage}"
+    );
+    let narrow_counting = Arc::new(CountingStore::new(mem.clone()));
+    let (_buf, narrow_stats) = make(narrow_counting.clone())
+        .fetch_object(
+            &seg,
+            TENANT,
+            narrow_min,
+            narrow_max,
+            &QueryAccounting::new(),
+        )
+        .await
+        .expect("narrow fetch");
+    assert!(
+        !narrow_stats.whole_object,
+        "a genuinely narrow read stays ranged even at a whole-object-sized gap"
+    );
+    assert_eq!(
+        narrow_stats.candidate_blocks,
+        narrow_cands.len() as u64,
+        "the candidate set is the narrow ts window's blocks"
+    );
+    assert_eq!(
+        narrow_stats.block_range_gets, 1,
+        "the huge gap fuses the narrow candidates into exactly one run"
+    );
+
+    // Wide control: every block a candidate. Coverage reaches ~1.0, so the SAME
+    // configuration crosses over to one whole-object GET -- the crossover tracks
+    // genuine coverage, not the gap.
+    let wide_counting = Arc::new(CountingStore::new(mem));
+    let (_buf, wide_stats) = make(wide_counting)
+        .fetch_object(&seg, TENANT, i64::MIN, i64::MAX, &QueryAccounting::new())
+        .await
+        .expect("wide fetch");
+    assert!(
+        wide_stats.whole_object,
+        "a read whose candidates cover the object still crosses over to whole-object"
+    );
+}

--- a/crates/ravel-query/tests/log_block_range.rs
+++ b/crates/ravel-query/tests/log_block_range.rs
@@ -1372,8 +1372,8 @@ async fn page_decode_accounting_is_a_separate_axis_from_wire_bytes() {
 // The whole-object-vs-ranged decision is driven from one configurable quantity,
 // the request cost (a latency-bandwidth product; `BlockRangeFetcher::
 // with_request_cost_bytes`), not from a byte-only size threshold. Test 10 pins
-// that by reading an object the byte-only rule would range-fetch whole, because
-// the request cost says so; test 11 pins that a large coalescing gap (also
+// that by reading whole an object the byte-only rule would have range-fetched,
+// because the request cost says so; test 11 pins that a large coalescing gap (also
 // driven from the request cost) never turns a genuinely narrow read into a
 // whole-object one.
 
@@ -1506,6 +1506,60 @@ async fn whole_object_vs_ranged_is_driven_by_the_request_cost() {
         large_counting.get_count(),
         1 + 1 + expected_runs,
         "probe(1) + coalesced front-meta(1) + block runs({expected_runs})"
+    );
+
+    // Medium side (the discriminator): the ONLY fixture inside the interval where
+    // the two rules disagree, [DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD, break_even) =
+    // [512 KiB, 700 KiB). Under the request-cost rule its size is below the
+    // break-even, so it is read whole in one GET; under the byte-only 512 KiB
+    // rule it is above the floor and would take the ranged path. Both bounds are
+    // asserted (mirroring `small_total < break_even`) so a fixture-generation
+    // change that drifted its encoded size out of the window would fail here
+    // rather than silently restoring the vacuity this test exists to remove. The
+    // ts window is narrow ([2, 11] of 27 blocks, coverage under the crossover) so
+    // that reverting the size rule to byte-only genuinely sends it ranged and the
+    // coverage backstop does not route it back to a whole-object read.
+    let (medium_recs, medium_bytes) = medium_object();
+    let medium_total = medium_bytes.len() as u64;
+    assert!(
+        medium_total > ravel_query::DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
+        "medium fixture {medium_total} must sit above the {} B byte-only threshold",
+        ravel_query::DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD
+    );
+    assert!(
+        medium_total < break_even,
+        "medium fixture {medium_total} must sit below the {break_even} B break-even"
+    );
+    let medium_mem = Arc::new(MemoryStore::new());
+    medium_mem
+        .put(
+            "logs/medium.rlog",
+            medium_bytes.clone().into(),
+            PutOptions::default(),
+        )
+        .await
+        .expect("put medium");
+    let medium_seg = seg_ref("logs/medium.rlog", medium_total, &medium_recs);
+    let medium_counting = Arc::new(CountingStore::new(medium_mem));
+    let medium_store: Arc<dyn ObjectStoreBackend> = medium_counting.clone();
+    let (_medium_buf, medium_stats) = BlockRangeFetcher::new(medium_store)
+        .with_request_cost_bytes(REQUEST_COST)
+        .fetch_object(&medium_seg, TENANT, 2, 11, &QueryAccounting::new())
+        .await
+        .expect("medium fetch");
+    assert!(
+        medium_stats.whole_object,
+        "an object inside [byte-only threshold, break-even) is read whole under \
+         the request-cost rule"
+    );
+    assert_eq!(
+        medium_counting.get_count(),
+        1,
+        "the whole-object read is exactly one GET"
+    );
+    assert_eq!(
+        medium_stats.block_range_gets, 0,
+        "a whole-object read issues no ranged block GETs"
     );
 }
 

--- a/crates/ravel-query/tests/log_page_dir_fetch.rs
+++ b/crates/ravel-query/tests/log_page_dir_fetch.rs
@@ -452,8 +452,13 @@ async fn version_4_projected_read_fetches_one_range_per_group_and_column() {
     // to move this number, not just keep two derivations agreeing.
     assert_eq!(stats.block_range_gets, 9, "G*k chunk ranges");
     assert_eq!(stats.block_range_gets, runs.len() as u64);
-    // STREAM_DIR and FIELD_DIR sit at the object's front; no suffix probe of
-    // any length reaches them, so they are one GET each on every ranged read.
+    // STREAM_DIR and FIELD_DIR sit at the object's front; no suffix probe of any
+    // length reaches them. On this narrow-projection path FIELD_DIR is fetched
+    // early (before the coverage crossover, to resolve the projection) on its own
+    // per-section key, and STREAM_DIR follows after the crossover, so the two are
+    // one GET each here -- the front-section coalescing (deliverable 4) applies
+    // to the all-columns path where both arrive cold together (see
+    // `tests/log_block_range.rs`'s GET-count test).
     assert_eq!(stats.metadata_gets, 2, "the two front sections");
     assert_eq!(
         recording.gets(),


### PR DESCRIPTION
perf(ravel-query): drive log fetch range decisions from a request cost

Log fetch decided between ranged reads and a whole-object read on byte
size alone. On this store a request is the expensive unit, not a byte:
measured GET latency is 20.95 ms and roughly 95% of a small read's cost
is latency, which puts the exchange rate at about 1.8 MB per request.
A byte-only rule therefore trades one request for many and calls it a
saving.

This drives the range decision from a request cost model instead, so
coalescing and whole-object promotion are chosen against what they
actually cost.

Gated as part of a combined tree with the ADR-0850 column-statistics
work (tree 86e7c05f): full workspace gates plus the sql and flight-sql
feature lanes, 6782 tests, all green. Split back out on its own here
because the other half is held behind a checkpoint finding that does
not touch this change; the adversarial review of the combined tree
found no correctness coupling between them.

Refs: #680
