### PR TITLE
Reproduce a disputed figure before filing, and quote the reproduction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -536,6 +536,18 @@ mechanical.
   down the expected figures and the band that would count as a miss, on
   the tracking issue. A result that only gets a prediction after the
   fact cannot surprise you, and surprise is the signal.
+- Reproduce before you dispute, and quote the reproduction. A claim that
+  a published figure is wrong, unreconstructable, or computed on the
+  wrong basis is filed only after grepping the publishing document for
+  its own stated basis and running `scripts/reproduce-figure.sh`, with
+  that output quoted in the filing. Quoting is the mechanism, not the
+  running: an omitted quote is visible on the page, an omitted mental
+  step is not. The same applies to a mechanism claim, which carries its
+  count-check inline beside it. A published headline was once disputed
+  as unreconstructable while the epic body stated the rule outright and
+  a single-statement drop reproduced the total to the cent; the
+  correction moved a planning target twice. An overcorrection is a claim
+  too, and needs the same evidence as the claim it replaces.
 - A measurement has preconditions on state, not only on code: the
   catalog folded to the last write (a fold seals an ingest hour only
   `max_flush_lifetime + clock_skew_allowance + fold_safety_margin` after

--- a/scripts/reproduce-figure.sh
+++ b/scripts/reproduce-figure.sh
@@ -174,12 +174,20 @@ def is_metric(v):
             and math.isfinite(v))
 
 
+# Every *_ms key that is PRESENT must be a valid metric. Checking only values
+# that are already int/float would miss a string or null timing entirely: those
+# are not int/float, so they would be dropped from `present` in silence and the
+# remaining statements could still print EXACT -- a total over a quietly smaller
+# set, which is the mistake this script exists to prevent. A statement that
+# failed omits its *_ms keys altogether (verified against the reference report),
+# so this rejects corruption without rejecting a legitimate failure.
 for _sid, _r in rows.items():
     for _k, _v in _r.items():
-        if _k.endswith("_ms") and isinstance(_v, (int, float)) and not is_metric(_v):
+        if _k.endswith("_ms") and not is_metric(_v):
             abort(f"statement {_sid} has a non-numeric or non-finite {_k}: {_v!r}.",
-                  "A boolean or non-finite timing would corrupt every total that",
-                  "includes it, and the corruption would surface as exit 1.")
+                  "A statement that did not run omits its timing keys entirely; a",
+                  "present-but-unusable value is corruption, and dropping it would",
+                  "compute a total over a quietly smaller set of statements.")
 
 available = sorted({
     k for r in rows.values() for k, v in r.items()

--- a/scripts/reproduce-figure.sh
+++ b/scripts/reproduce-figure.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# Reproduce a published total from the bench report it came from.
+#
+# Exists because a published headline was disputed as "unreconstructable" when
+# it was reconstructable: the run measured 42 statements and the headline quoted
+# 41, and dropping one statement reproduced the published cold total to the cent.
+# The reconstruction takes seconds; the wrong dispute cost a filing, a
+# correction, and a planning target that moved the wrong way for two turns.
+#
+# So: run this BEFORE claiming a figure is wrong, and QUOTE ITS OUTPUT in
+# whatever you file. The quote is the point. An omitted quote is visible on the
+# page; an omitted mental step is not.
+#
+# It answers one question: under what subset of the report's statements does the
+# claimed total hold? It searches the full set and every single-statement drop,
+# for each available per-statement metric, and prints the residual for each so a
+# near-miss is distinguishable from a hit.
+#
+# It does NOT decide whether a basis is legitimate. A subset that reproduces the
+# number tells you the number is arithmetically sound on THAT basis; whether the
+# basis is the right one to publish is a judgement, and the answer usually lives
+# in the publishing document. Hence the reminder this prints at the end: grep the
+# publishing document for its own stated basis before concluding anything.
+#
+# Usage:
+#   scripts/reproduce-figure.sh <report.json> <field> <claimed-total-seconds> [expected-count]
+#
+#   report.json  bench report, JSON-LINES (one document per line, or a stream of
+#                concatenated documents -- both are parsed)
+#   field        per-statement key to sum: min_ms, cold_ms, median_ms, max_ms,
+#                or `auto` to try every numeric *_ms key present
+#   claimed      the published total, in SECONDS
+#   count        optional: the statement count the headline claims, which is
+#                usually the strongest hint at the subset rule
+#
+# Example (the case this was built from):
+#   scripts/reproduce-figure.sh bench-v23-runs3.json cold_ms 310.97 41
+#     -> EXACT: drop q29_referer_length_by_host  (42 -> 41 statements)
+set -uo pipefail
+
+REPORT="${1:?usage: reproduce-figure.sh <report.json> <field|auto> <claimed-seconds> [expected-count]}"
+FIELD="${2:?usage: reproduce-figure.sh <report.json> <field|auto> <claimed-seconds> [expected-count]}"
+CLAIMED="${3:?usage: reproduce-figure.sh <report.json> <field|auto> <claimed-seconds> [expected-count]}"
+EXPECT_N="${4:-}"
+
+[ -r "$REPORT" ] || { echo "reproduce-figure: cannot read $REPORT" >&2; exit 2; }
+
+REPORT="$REPORT" FIELD="$FIELD" CLAIMED="$CLAIMED" EXPECT_N="$EXPECT_N" python3 - <<'PY'
+import json, os, sys
+
+report = os.environ["REPORT"]
+field = os.environ["FIELD"]
+claimed = float(os.environ["CLAIMED"])
+expect_n = os.environ.get("EXPECT_N") or ""
+expect_n = int(expect_n) if expect_n.strip() else None
+
+# Bench output is JSON-LINES. json.load() on the whole file raises "Extra data"
+# on the second document, which has cost real time in this repo more than once.
+docs, buf = [], ""
+for line in open(report, errors="replace"):
+    buf += line
+    try:
+        docs.append(json.loads(buf))
+        buf = ""
+    except Exception:
+        pass
+if not docs:
+    print("ABORT: no parseable JSON documents in the report.")
+    sys.exit(3)
+
+
+def walk(o):
+    if isinstance(o, dict):
+        yield o
+        for v in o.values():
+            yield from walk(v)
+    elif isinstance(o, list):
+        for v in o:
+            yield from walk(v)
+
+
+rows = {}
+for d in docs:
+    for n in walk(d):
+        sid = n.get("id")
+        if isinstance(sid, str) and sid[:1] == "q":
+            rows[sid] = n
+
+if not rows:
+    print("ABORT: no statement nodes (objects with a string `id` starting 'q').")
+    sys.exit(3)
+
+# Which metrics can we sum? A statement missing the field is excluded from that
+# metric's search rather than silently counted as zero -- a zero here would
+# reproduce a lower total for the wrong reason, which is the exact class of
+# mistake this script exists to prevent.
+if field == "auto":
+    fields = sorted({
+        k for r in rows.values() for k, v in r.items()
+        if k.endswith("_ms") and isinstance(v, (int, float))
+    })
+    if not fields:
+        print("ABORT: no numeric *_ms keys found on any statement.")
+        sys.exit(3)
+else:
+    fields = [field]
+
+print(f"report        : {report}")
+print(f"statements    : {len(rows)}")
+print(f"claimed total : {claimed:.2f} s")
+if expect_n is not None:
+    print(f"claimed count : {expect_n}  (report has {len(rows)}, so the basis drops {len(rows) - expect_n})")
+print()
+
+TOL = 0.02  # seconds; an exact match on a figure published to 2 decimals
+found_any = False
+
+for f in fields:
+    present = {k: v for k, v in rows.items() if isinstance(v.get(f), (int, float))}
+    missing = sorted(set(rows) - set(present))
+    if not present:
+        continue
+    total = sum(present[k][f] for k in present) / 1000.0
+
+    print(f"--- field {f}  ({len(present)} statements carry it"
+          + (f"; missing on {missing}" if missing else "") + ")")
+    print(f"    full set ({len(present)}): {total:8.2f} s   residual {total - claimed:+8.2f}")
+
+    if abs(total - claimed) <= TOL:
+        print(f"    EXACT: the claimed total is the FULL set under {f}. No subset rule needed.")
+        found_any = True
+
+    # Single-statement drops, ranked by how close they land.
+    cands = []
+    for k in present:
+        t = (sum(present[j][f] for j in present if j != k)) / 1000.0
+        cands.append((abs(t - claimed), k, t))
+    cands.sort()
+
+    hits = [c for c in cands if c[0] <= TOL]
+    for d, k, t in hits:
+        note = ""
+        if expect_n is not None and len(present) - 1 != expect_n:
+            note = f"  [WARNING: yields {len(present)-1} statements, headline claims {expect_n}]"
+        print(f"    EXACT: drop {k:34} -> {t:8.2f} s  ({len(present)} -> {len(present)-1}){note}")
+        found_any = True
+
+    if not hits:
+        print("    no single-statement drop reproduces it. Nearest three:")
+        for d, k, t in cands[:3]:
+            print(f"      drop {k:34} -> {t:8.2f} s   residual {t - claimed:+8.2f}")
+    print()
+
+print("=" * 72)
+if found_any:
+    print("A basis that reproduces the figure was FOUND. The number is")
+    print("arithmetically sound on that basis. Whether that basis is the right one")
+    print("to publish is a separate judgement -- and the answer is usually written")
+    print("down: grep the publishing document (epic body, ADR, report header) for")
+    print("its own stated basis BEFORE filing anything.")
+    sys.exit(0)
+
+print("No single-statement basis reproduces the figure.")
+print("That is NOT yet evidence the figure is wrong. Before filing, still:")
+print("  1. grep the publishing document for its own stated basis -- it may name")
+print("     a rule this script does not search (a matched set across systems, a")
+print("     different metric, a different pass);")
+print("  2. try `auto` for the field if you have not;")
+print("  3. consider multi-statement drops, which this deliberately does not")
+print("     search because the combinations are large and a coincidental match")
+print("     would be worse than no answer.")
+print()
+print("If you file after this, QUOTE THIS OUTPUT in the filing.")
+sys.exit(1)
+PY

--- a/scripts/reproduce-figure.sh
+++ b/scripts/reproduce-figure.sh
@@ -22,7 +22,7 @@
 # in the publishing document. Hence the reminder printed at the end: grep the
 # publishing document for its own stated basis before concluding anything.
 #
-# EXIT CODES ARE LOad-BEARING, because this script's output is meant to be
+# EXIT CODES ARE LOAD-BEARING, because this script's output is meant to be
 # quoted as evidence:
 #   0  a basis reproducing the figure was found
 #   1  no single-statement basis reproduces it -- a real negative result
@@ -57,7 +57,7 @@ EXPECT_N="${4:-}"
 [ -r "$REPORT" ] || { echo "reproduce-figure: cannot read $REPORT" >&2; exit 2; }
 
 REPORT="$REPORT" FIELD="$FIELD" CLAIMED="$CLAIMED" EXPECT_N="$EXPECT_N" python3 - <<'PY'
-import json, os, sys
+import json, math, os, sys
 
 ABORT = 3
 
@@ -81,6 +81,12 @@ try:
 except ValueError:
     abort(f"claimed total {raw_claimed!r} is not a number.",
           "Pass the published total in SECONDS, e.g. 310.97")
+if not math.isfinite(claimed):
+    # nan compares False against everything, so a nan claim would sail past the
+    # matching loop and exit 1 -- "no basis reproduces the figure", the one
+    # output meant to be quoted as evidence. Same trap as a misspelled field.
+    abort(f"claimed total {raw_claimed!r} is not finite.",
+          "A non-finite claim matches nothing and would read as a real negative result.")
 
 raw_expect = (os.environ.get("EXPECT_N") or "").strip()
 expect_n = None
@@ -89,6 +95,8 @@ if raw_expect:
         expect_n = int(raw_expect)
     except ValueError:
         abort(f"expected-count {raw_expect!r} is not an integer.")
+    if expect_n < 0:
+        abort(f"expected-count {expect_n} is negative.")
 
 # Bench output is JSON-LINES. json.load() over the whole file raises "Extra
 # data" on the second document, which has cost real time in this repo. Use
@@ -159,9 +167,23 @@ if not rows:
 # Every numeric *_ms key any statement carries. Used both for `auto` and to
 # validate an explicit field, so a typo aborts instead of masquerading as a
 # negative result.
+def is_metric(v):
+    # bool is a subclass of int, so `"min_ms": true` would otherwise sum as 1;
+    # a non-finite value would poison the total into nan and reach exit 1.
+    return (isinstance(v, (int, float)) and not isinstance(v, bool)
+            and math.isfinite(v))
+
+
+for _sid, _r in rows.items():
+    for _k, _v in _r.items():
+        if _k.endswith("_ms") and isinstance(_v, (int, float)) and not is_metric(_v):
+            abort(f"statement {_sid} has a non-numeric or non-finite {_k}: {_v!r}.",
+                  "A boolean or non-finite timing would corrupt every total that",
+                  "includes it, and the corruption would surface as exit 1.")
+
 available = sorted({
     k for r in rows.values() for k, v in r.items()
-    if k.endswith("_ms") and isinstance(v, (int, float))
+    if k.endswith("_ms") and is_metric(v)
 })
 
 if field == "auto":
@@ -202,7 +224,7 @@ def count_note(surviving):
 
 
 for f in fields:
-    present = {k: v for k, v in rows.items() if isinstance(v.get(f), (int, float))}
+    present = {k: v for k, v in rows.items() if is_metric(v.get(f))}
     missing = sorted(set(rows) - set(present))
     if not present:
         # Unreachable for an explicit field (validated above) and for `auto`

--- a/scripts/reproduce-figure.sh
+++ b/scripts/reproduce-figure.sh
@@ -2,10 +2,10 @@
 # Reproduce a published total from the bench report it came from.
 #
 # Exists because a published headline was disputed as "unreconstructable" when
-# it was reconstructable: the run measured 42 statements and the headline quoted
-# 41, and dropping one statement reproduced the published cold total to the cent.
-# The reconstruction takes seconds; the wrong dispute cost a filing, a
-# correction, and a planning target that moved the wrong way for two turns.
+# it was reconstructable: the run measured 42 timed statements and the headline
+# quoted 41, and dropping one statement reproduced the published cold total to
+# the cent. The reconstruction takes seconds; the wrong dispute cost a filing, a
+# correction, and a planning target that moved the wrong way twice.
 #
 # So: run this BEFORE claiming a figure is wrong, and QUOTE ITS OUTPUT in
 # whatever you file. The quote is the point. An omitted quote is visible on the
@@ -19,8 +19,19 @@
 # It does NOT decide whether a basis is legitimate. A subset that reproduces the
 # number tells you the number is arithmetically sound on THAT basis; whether the
 # basis is the right one to publish is a judgement, and the answer usually lives
-# in the publishing document. Hence the reminder this prints at the end: grep the
+# in the publishing document. Hence the reminder printed at the end: grep the
 # publishing document for its own stated basis before concluding anything.
+#
+# EXIT CODES ARE LOad-BEARING, because this script's output is meant to be
+# quoted as evidence:
+#   0  a basis reproducing the figure was found
+#   1  no single-statement basis reproduces it -- a real negative result
+#   2  the report could not be read
+#   3  ABORT: the question was malformed (bad field, bad claimed value,
+#      unparseable or empty report). NEVER conflated with 1: an exit 1 can be
+#      quoted in a filing as evidence a figure is wrong, so a typo in the field
+#      name must not be able to produce it. That failure would be this script
+#      committing the exact mistake it exists to prevent.
 #
 # Usage:
 #   scripts/reproduce-figure.sh <report.json> <field> <claimed-total-seconds> [expected-count]
@@ -48,25 +59,80 @@ EXPECT_N="${4:-}"
 REPORT="$REPORT" FIELD="$FIELD" CLAIMED="$CLAIMED" EXPECT_N="$EXPECT_N" python3 - <<'PY'
 import json, os, sys
 
+ABORT = 3
+
+
+def abort(msg, *extra):
+    print(f"ABORT: {msg}")
+    for line in extra:
+        print(f"  {line}")
+    print()
+    print("This is a malformed question, NOT a negative result. Do not quote it")
+    print("as evidence that a figure is wrong.")
+    sys.exit(ABORT)
+
+
 report = os.environ["REPORT"]
 field = os.environ["FIELD"]
-claimed = float(os.environ["CLAIMED"])
-expect_n = os.environ.get("EXPECT_N") or ""
-expect_n = int(expect_n) if expect_n.strip() else None
 
-# Bench output is JSON-LINES. json.load() on the whole file raises "Extra data"
-# on the second document, which has cost real time in this repo more than once.
-docs, buf = [], ""
-for line in open(report, errors="replace"):
-    buf += line
+raw_claimed = os.environ["CLAIMED"]
+try:
+    claimed = float(raw_claimed)
+except ValueError:
+    abort(f"claimed total {raw_claimed!r} is not a number.",
+          "Pass the published total in SECONDS, e.g. 310.97")
+
+raw_expect = (os.environ.get("EXPECT_N") or "").strip()
+expect_n = None
+if raw_expect:
     try:
-        docs.append(json.loads(buf))
-        buf = ""
-    except Exception:
-        pass
+        expect_n = int(raw_expect)
+    except ValueError:
+        abort(f"expected-count {raw_expect!r} is not an integer.")
+
+# Bench output is JSON-LINES. json.load() over the whole file raises "Extra
+# data" on the second document, which has cost real time in this repo. Use
+# raw_decode so concatenated documents on one line parse too (the usage text
+# above promises that form), and account for every byte: text that never parses
+# must be REPORTED, never silently dropped. Silently dropping a truncated tail
+# would sum a subset and print a residual as if the report were complete --
+# manufacturing exactly the false "unreconstructable" verdict this script
+# exists to prevent.
+decoder = json.JSONDecoder()
+text = open(report, errors="replace").read()
+docs, narration_bytes, i, n = [], 0, 0, len(text)
+while i < n:
+    while i < n and text[i] in " \t\r\n":
+        i += 1
+    if i >= n:
+        break
+    if text[i] not in "{[":
+        # Narration. These reports carry a human-readable summary alongside the
+        # JSON, so non-JSON text is expected -- but it is COUNTED and reported
+        # rather than silently dropped.
+        nxt = min((p for p in (text.find("{", i), text.find("[", i)) if p != -1),
+                  default=-1)
+        stop = n if nxt == -1 else nxt
+        narration_bytes += stop - i
+        i = stop
+        continue
+    try:
+        doc, end = decoder.raw_decode(text, i)
+    except ValueError:
+        # This region STARTS like a JSON value and does not decode, so it is
+        # truncation or corruption, not narration. Summing what came before it
+        # would print a residual as if the report were complete -- which is the
+        # false "unreconstructable" verdict this script exists to prevent.
+        abort(f"malformed JSON in {report} at byte offset {i}.",
+              f"first 80 chars: {text[i:i+80]!r}",
+              "A truncated or corrupt report would otherwise sum a subset and",
+              "print a residual as if it were complete.")
+    docs.append(doc)
+    i = end
+
 if not docs:
-    print("ABORT: no parseable JSON documents in the report.")
-    sys.exit(3)
+    abort(f"no parseable JSON documents in {report}.",
+          f"{narration_bytes} bytes of non-JSON text were skipped.")
 
 
 def walk(o):
@@ -81,45 +147,67 @@ def walk(o):
 
 rows = {}
 for d in docs:
-    for n in walk(d):
-        sid = n.get("id")
+    for node in walk(d):
+        sid = node.get("id")
         if isinstance(sid, str) and sid[:1] == "q":
-            rows[sid] = n
+            rows[sid] = node
 
 if not rows:
-    print("ABORT: no statement nodes (objects with a string `id` starting 'q').")
-    sys.exit(3)
+    abort("no statement nodes found",
+          "(expected objects with a string `id` beginning 'q').")
 
-# Which metrics can we sum? A statement missing the field is excluded from that
-# metric's search rather than silently counted as zero -- a zero here would
-# reproduce a lower total for the wrong reason, which is the exact class of
-# mistake this script exists to prevent.
+# Every numeric *_ms key any statement carries. Used both for `auto` and to
+# validate an explicit field, so a typo aborts instead of masquerading as a
+# negative result.
+available = sorted({
+    k for r in rows.values() for k, v in r.items()
+    if k.endswith("_ms") and isinstance(v, (int, float))
+})
+
 if field == "auto":
-    fields = sorted({
-        k for r in rows.values() for k, v in r.items()
-        if k.endswith("_ms") and isinstance(v, (int, float))
-    })
-    if not fields:
-        print("ABORT: no numeric *_ms keys found on any statement.")
-        sys.exit(3)
+    if not available:
+        abort("no numeric *_ms keys on any statement, so `auto` has nothing to sum.")
+    fields = available
 else:
+    if field not in available:
+        abort(f"field {field!r} is not a numeric metric on any statement.",
+              f"available: {', '.join(available) if available else '(none)'}",
+              "A misspelled field would otherwise report 'no basis reproduces",
+              "it', which reads as evidence the figure is wrong.")
     fields = [field]
 
 print(f"report        : {report}")
 print(f"statements    : {len(rows)}")
 print(f"claimed total : {claimed:.2f} s")
 if expect_n is not None:
-    print(f"claimed count : {expect_n}  (report has {len(rows)}, so the basis drops {len(rows) - expect_n})")
+    delta = len(rows) - expect_n
+    if delta > 0:
+        shape = f"the basis drops {delta}"
+    elif delta == 0:
+        shape = "same count, so the basis is the full set if it reproduces at all"
+    else:
+        shape = (f"the headline claims {-delta} MORE than the report holds, so it "
+                 "cannot be a subset of this report")
+    print(f"claimed count : {expect_n}  (report has {len(rows)}, {shape})")
 print()
 
 TOL = 0.02  # seconds; an exact match on a figure published to 2 decimals
 found_any = False
 
+
+def count_note(surviving):
+    if expect_n is None or surviving == expect_n:
+        return ""
+    return f"  [WARNING: yields {surviving} statements, headline claims {expect_n}]"
+
+
 for f in fields:
     present = {k: v for k, v in rows.items() if isinstance(v.get(f), (int, float))}
     missing = sorted(set(rows) - set(present))
     if not present:
-        continue
+        # Unreachable for an explicit field (validated above) and for `auto`
+        # (drawn from the same set), but keep it explicit rather than silent.
+        abort(f"field {f!r} is present on no statement.")
     total = sum(present[k][f] for k in present) / 1000.0
 
     print(f"--- field {f}  ({len(present)} statements carry it"
@@ -127,10 +215,12 @@ for f in fields:
     print(f"    full set ({len(present)}): {total:8.2f} s   residual {total - claimed:+8.2f}")
 
     if abs(total - claimed) <= TOL:
-        print(f"    EXACT: the claimed total is the FULL set under {f}. No subset rule needed.")
+        print(f"    EXACT: the claimed total is the FULL set under {f}."
+              f"{count_note(len(present))}")
+        if not count_note(len(present)):
+            print("           No subset rule needed.")
         found_any = True
 
-    # Single-statement drops, ranked by how close they land.
     cands = []
     for k in present:
         t = (sum(present[j][f] for j in present if j != k)) / 1000.0
@@ -138,16 +228,14 @@ for f in fields:
     cands.sort()
 
     hits = [c for c in cands if c[0] <= TOL]
-    for d, k, t in hits:
-        note = ""
-        if expect_n is not None and len(present) - 1 != expect_n:
-            note = f"  [WARNING: yields {len(present)-1} statements, headline claims {expect_n}]"
-        print(f"    EXACT: drop {k:34} -> {t:8.2f} s  ({len(present)} -> {len(present)-1}){note}")
+    for _d, k, t in hits:
+        print(f"    EXACT: drop {k:34} -> {t:8.2f} s  "
+              f"({len(present)} -> {len(present)-1}){count_note(len(present)-1)}")
         found_any = True
 
     if not hits:
         print("    no single-statement drop reproduces it. Nearest three:")
-        for d, k, t in cands[:3]:
+        for _d, k, t in cands[:3]:
             print(f"      drop {k:34} -> {t:8.2f} s   residual {t - claimed:+8.2f}")
     print()
 

--- a/scripts/reproduce-figure.test.sh
+++ b/scripts/reproduce-figure.test.sh
@@ -125,5 +125,18 @@ check "boolean timing aborts" 3 "non-numeric or non-finite" "$TMP/boolmetric.jso
 printf '{"id":"qA","min_ms":1e999}\n{"id":"qB","min_ms":1000.0}\n' > "$TMP/infmetric.json"
 check "non-finite timing aborts" 3 "non-numeric or non-finite" "$TMP/infmetric.json" min_ms 1.00
 
+# A string or null timing is NOT int/float, so a guard that only inspects
+# already-numeric values skips it: the statement is dropped from the metric in
+# silence and the survivors can still print EXACT over a smaller set. That is a
+# total computed on a basis nobody chose.
+printf '{"id":"qA","min_ms":"fast"}\n{"id":"qB","min_ms":1000.0}\n' > "$TMP/strmetric.json"
+check "string timing aborts"  3 "non-numeric or non-finite" "$TMP/strmetric.json" min_ms 1.00
+printf '{"id":"qA","min_ms":null}\n{"id":"qB","min_ms":1000.0}\n' > "$TMP/nullmetric.json"
+check "null timing aborts"    3 "non-numeric or non-finite" "$TMP/nullmetric.json" min_ms 1.00
+
+# The regression it prevents, stated as its own case: without the guard the
+# string report above reports EXACT at 1.00 s over one statement.
+check "string timing does not yield a spurious EXACT" 3 "non-numeric or non-finite" "$TMP/strmetric.json" auto 1.00
+
 if [ "$fails" -ne 0 ]; then echo; echo "$fails case(s) failed"; exit 1; fi
 echo; echo "all reproduce-figure cases passed"

--- a/scripts/reproduce-figure.test.sh
+++ b/scripts/reproduce-figure.test.sh
@@ -108,5 +108,22 @@ check "auto with no numeric metrics aborts" 3 "has nothing to sum" "$TMP/nometri
 printf '{"id":"qA","min_ms":1000.0}{"id":"qB","min_ms":3000.0}\n' > "$TMP/concat.json"
 check "concatenated docs on one line parse" 0 "EXACT: drop qB" "$TMP/concat.json" min_ms 1.00
 
+# Non-finite and out-of-range inputs must ABORT, not reach the matching loop.
+# nan compares False against everything, so a nan claim would exit 1 -- the one
+# output meant to be quoted as evidence that a figure is wrong. Same trap as the
+# misspelled field, surviving in a different form.
+check "nan claimed aborts"       3 "is not finite" "$TMP/report.json" min_ms nan
+check "inf claimed aborts"       3 "is not finite" "$TMP/report.json" min_ms inf
+check "-inf claimed aborts"      3 "is not finite" "$TMP/report.json" min_ms -inf
+check "negative count aborts"    3 "is negative"   "$TMP/report.json" min_ms 4.00 -3
+
+# bool is a subclass of int in Python, so an unguarded isinstance check sums
+# `true` as 1 and reports a total that is quietly wrong.
+printf '{"id":"qA","min_ms":true}\n{"id":"qB","min_ms":1000.0}\n' > "$TMP/boolmetric.json"
+check "boolean timing aborts" 3 "non-numeric or non-finite" "$TMP/boolmetric.json" min_ms 1.00
+
+printf '{"id":"qA","min_ms":1e999}\n{"id":"qB","min_ms":1000.0}\n' > "$TMP/infmetric.json"
+check "non-finite timing aborts" 3 "non-numeric or non-finite" "$TMP/infmetric.json" min_ms 1.00
+
 if [ "$fails" -ne 0 ]; then echo; echo "$fails case(s) failed"; exit 1; fi
 echo; echo "all reproduce-figure cases passed"

--- a/scripts/reproduce-figure.test.sh
+++ b/scripts/reproduce-figure.test.sh
@@ -56,10 +56,57 @@ check "auto finds the cold_ms basis" 0 "EXACT: drop qB_beta" "$TMP/report.json" 
 
 # A headline count that disagrees with the surviving set is flagged rather than
 # silently accepted: reproducing the number on the wrong-sized basis is a
-# near-miss dressed as a hit.
-check "count mismatch is flagged" 0 "WARNING: yields 2 statements, headline claims 7" "$TMP/report.json" min_ms 4.00 7
+# near-miss dressed as a hit. This applies to the FULL-SET branch too, which is
+# the easier one to forget -- a full-set hit on a wrong-sized basis otherwise
+# prints "No subset rule needed" with nothing flagged.
+check "count mismatch is flagged on a drop"     0 "WARNING: yields 2 statements, headline claims 7" "$TMP/report.json" min_ms 4.00 7
+check "count mismatch is flagged on full set"   0 "WARNING: yields 3 statements, headline claims 7" "$TMP/report.json" min_ms 6.00 7
+
+# A headline claiming MORE statements than the report holds is a different
+# situation from a subset, and saying "the basis drops -3" is nonsense.
+check "headline larger than report reads sensibly" 0 "cannot be a subset of this report" "$TMP/report.json" min_ms 6.00 7
 
 check "unreadable report exits 2" 2 "cannot read" "$TMP/nonexistent.json" min_ms 1.0
+
+# --- ABORT paths (exit 3) -------------------------------------------------
+# These matter more than they look. Exit 1 means "no basis reproduces the
+# figure", which is quotable in a filing as evidence a number is wrong. Every
+# malformed-question path must therefore be exit 3 and must SAY it is not a
+# negative result. A typo in the field name producing a quotable exit 1 would be
+# this script committing the exact mistake it exists to prevent.
+check "misspelled field aborts, not exit 1" 3 "is not a numeric metric on any statement" "$TMP/report.json" min_msec 4.00
+check "misspelled field names alternatives"  3 "available: cold_ms, min_ms"              "$TMP/report.json" min_msec 4.00
+check "abort says it is not a negative result" 3 "Do not quote it"                       "$TMP/report.json" min_msec 4.00
+check "non-numeric claimed aborts"          3 "is not a number"                          "$TMP/report.json" min_ms notanumber
+check "non-integer count aborts"            3 "is not an integer"                        "$TMP/report.json" min_ms 4.00 many
+
+# All-narration input: no JSON at all. Aborts, and says how much text it skipped.
+printf 'not json at all\n' > "$TMP/garbage.json"
+check "narration-only report aborts"  3 "no parseable JSON documents" "$TMP/garbage.json" min_ms 1.0
+check "narration bytes are reported"  3 "bytes of non-JSON text were skipped" "$TMP/garbage.json" min_ms 1.0
+
+# Narration AFTER the JSON is the real report format (a human-readable summary
+# follows the document), so it must parse, not abort. Getting this wrong made
+# the script refuse the very report it was built from.
+printf '{"id":"qA","min_ms":1000.0}\n{"id":"qB","min_ms":3000.0}\nsql_latency_bench report\n  backend : s3\n' > "$TMP/trailing.json"
+check "trailing narration still parses" 0 "EXACT: drop qB" "$TMP/trailing.json" min_ms 1.00
+
+# A truncated tail must abort rather than silently summing a subset and printing
+# a residual as if the report were complete -- that would manufacture the false
+# "unreconstructable" verdict this whole script exists to prevent.
+printf '{"id":"qA","min_ms":1000.0}\n{"id":"qB","min_' > "$TMP/truncated.json"
+check "truncated tail aborts" 3 "malformed JSON" "$TMP/truncated.json" min_ms 1.00
+
+printf '{"nothing":"here"}\n' > "$TMP/nostmts.json"
+check "no statement nodes aborts" 3 "no statement nodes found" "$TMP/nostmts.json" min_ms 1.0
+
+printf '{"id":"qA","note":"no numeric metrics"}\n' > "$TMP/nometrics.json"
+check "auto with no numeric metrics aborts" 3 "has nothing to sum" "$TMP/nometrics.json" auto 1.0
+
+# Concatenated documents on one line: the usage text promises this form parses,
+# so it must, rather than being absorbed into the buffer and dropped.
+printf '{"id":"qA","min_ms":1000.0}{"id":"qB","min_ms":3000.0}\n' > "$TMP/concat.json"
+check "concatenated docs on one line parse" 0 "EXACT: drop qB" "$TMP/concat.json" min_ms 1.00
 
 if [ "$fails" -ne 0 ]; then echo; echo "$fails case(s) failed"; exit 1; fi
 echo; echo "all reproduce-figure cases passed"

--- a/scripts/reproduce-figure.test.sh
+++ b/scripts/reproduce-figure.test.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Cases for reproduce-figure.sh. Add a case here before changing a behaviour,
+# the way .claude/guards/pretooluse.test.sh works for the hook.
+#
+# The fixture is the shape that motivated the script: a run measuring N
+# statements, one of which failed and carries no timings, and a headline quoting
+# a total over N-1.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$HERE/reproduce-figure.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fails=0
+check() { # check <name> <expected-exit> <expected-substring> <args...>
+  local name="$1" want_rc="$2" want_sub="$3"; shift 3
+  local out rc=0
+  out="$("$SCRIPT" "$@" 2>&1)" || rc=$?
+  if [ "$rc" != "$want_rc" ]; then
+    echo "FAIL $name: exit $rc, wanted $want_rc"; echo "$out" | sed 's/^/    /'; fails=$((fails+1)); return
+  fi
+  case "$out" in
+    *"$want_sub"*) echo "ok   $name" ;;
+    *) echo "FAIL $name: output missing '$want_sub'"; echo "$out" | sed 's/^/    /'; fails=$((fails+1)) ;;
+  esac
+}
+
+# JSON-LINES on purpose: a single json.load() over this file raises "Extra data",
+# which is the parsing bug this repo keeps rediscovering.
+cat > "$TMP/report.json" <<'JSON'
+{"id":"qA_alpha","min_ms":1000.0,"cold_ms":5000.0}
+{"id":"qB_beta","min_ms":2000.0,"cold_ms":6000.0}
+{"id":"qC_gamma","min_ms":3000.0,"cold_ms":7000.0}
+{"id":"qD_failed","error":"pool exhausted"}
+JSON
+
+# Full set is 6.00 s of min_ms; dropping qB leaves 4.00 s.
+check "exact on a single drop" 0 "EXACT: drop qB_beta" "$TMP/report.json" min_ms 4.00 2
+check "exact on the full set"  0 "the claimed total is the FULL set" "$TMP/report.json" min_ms 6.00
+check "no basis reproduces it" 1 "No single-statement basis reproduces" "$TMP/report.json" min_ms 4.44
+check "unreachable total still refuses to guess" 1 "QUOTE THIS OUTPUT" "$TMP/report.json" cold_ms 99.00
+
+# A failed statement must be excluded from the metric, never counted as zero:
+# counting it as zero would reproduce a lower total for the wrong reason, which
+# is precisely the class of mistake this script exists to prevent.
+check "failed statement excluded, not zeroed" 0 "missing on ['qD_failed']" "$TMP/report.json" min_ms 6.00
+
+# The node count and the metric count are reported separately, because a
+# statement present-but-untimed is not the same as a statement absent, and
+# conflating them produced a wrong claim in the incident that motivated this.
+check "counts nodes and metrics separately" 0 "statements    : 4" "$TMP/report.json" min_ms 6.00
+
+# auto tries every numeric *_ms key, so a caller who does not know which metric
+# the headline used still gets an answer.
+check "auto finds the cold_ms basis" 0 "EXACT: drop qB_beta" "$TMP/report.json" auto 12.00
+
+# A headline count that disagrees with the surviving set is flagged rather than
+# silently accepted: reproducing the number on the wrong-sized basis is a
+# near-miss dressed as a hit.
+check "count mismatch is flagged" 0 "WARNING: yields 2 statements, headline claims 7" "$TMP/report.json" min_ms 4.00 7
+
+check "unreadable report exits 2" 2 "cannot read" "$TMP/nonexistent.json" min_ms 1.0
+
+if [ "$fails" -ne 0 ]; then echo; echo "$fails case(s) failed"; exit 1; fi
+echo; echo "all reproduce-figure cases passed"


### PR DESCRIPTION
Reproduce a disputed figure before filing, and quote the reproduction

Adds `scripts/reproduce-figure.sh` plus its test cases, and one rule to
CLAUDE.md's measurement section.

The prompt was a mistake I made today. I filed an issue claiming a published
ClickBench headline (91.79 s over 41 statements) could not be reconstructed from
the run's own artifacts. It could. The epic body stated the basis outright -- the
41 statements Ravel measured and all three competitors answered non-null -- and
dropping one statement reproduces the published cold total exactly:

    --- field cold_ms  (42 statements carry it; missing on ['q33_watch_ip_aggregates_all'])
        full set (42):   320.18 s   residual    +9.21
        EXACT: drop q29_referer_length_by_host         ->   310.97 s  (42 -> 41)

I had partially read the document that answered it and filed anyway, then told
the user the real gap was 1.21x when it is 1.15x. The overcorrection was worse
than the original error, because planning had already moved against it.

A prose rule would not have helped: the standing instruction to check a claim
against the counts already in hand was in force at the time, and a separate
mechanism claim went out the same day contradicted by a measurement I was
holding. So this splits the problem.

The mechanizable half is disputing a number, and that is now a script. Given a
report and a claimed total it searches the full set and every single-statement
drop, across one metric or all numeric ones, printing residuals so a near miss
is distinguishable from a hit. It refuses to search multi-statement drops: the
combinations are large and a coincidental match would be worse than no answer.

The half that cannot be mechanized is a mechanism claim contradicted by evidence
already in hand -- no script knows which artifact falsifies an arbitrary claim.
The seam that catches both is the same, and it is quoting the check's output in
the filing rather than merely running it. An omitted quote is visible on the
page; an omitted mental step is not. There is already accidental proof in this
repo: a PR body describing the wrong ticket was caught because a closing-keyword
check printed NONE directly beside a claim naming one.

No guard case was added. Every rule in `.claude/guards/pretooluse.mjs` is
high-precision, and a fuzzy dispute-language matcher would erode that file's
credibility and train escape-hatch habits.

On first real use the script corrected me again: the report carries 43 statement
nodes, not the 42 I had reported, because the failed q33 is present but untimed.
The script counts nodes and metrics separately for that reason, and the test
pins it -- against a version that zeroes a missing metric instead of excluding
it, the suite reports `EXACT: drop qD_failed`, a coincidental match dressed as a
hit. Both new tests were demonstrated failing against that deliberately broken
version before this was committed.

Scripts and docs only; no Rust touched.

Refs: #879
