### PR TITLE
perf(logseg): resolve scan columns once per block via per-column cursors

### DIFF
--- a/crates/ravel-logseg/src/block.rs
+++ b/crates/ravel-logseg/src/block.rs
@@ -34,6 +34,18 @@ const MAX_RECORDS: u64 = 1 << 24;
 /// derives its own per-group caps from this (ADR-0699 decision 2).
 pub const MAX_PAGES: u64 = 4096;
 
+/// Cap on a decoded page's `column_id`, matching the field-directory cap
+/// [`crate::reader::MAX_FIELDS`] that bounds how many fields an object may
+/// declare.
+///
+/// Column ids index a dense slot vector in [`ColMap`], so the allocation is a
+/// function of the LARGEST id seen, not of how many columns a block actually
+/// carries. A page descriptor is read from the object, which is untrusted
+/// input: without this cap a single corrupt or hostile block declaring a
+/// `column_id` near `u32::MAX` would resize that vector to billions of slots
+/// and exhaust memory before any pool limit could observe it.
+const MAX_COLUMN_ID: u64 = 1 << 20;
+
 /// A cheap multiplicative mix (FxHash-style) for column ids, in place of
 /// std's default SipHash. Column ids are dense, small (a real schema tops out
 /// around a hundred, capped at [`crate::writer::RlogConfig::max_dynamic_columns`])
@@ -823,6 +835,15 @@ impl<T> ColMap<T> {
     fn values(&self) -> impl Iterator<Item = &T> {
         self.cols.iter().flatten()
     }
+
+    /// Bytes held by the slot vector itself, excluding whatever the slots point
+    /// at. The vector is sized by the largest column id in the block rather
+    /// than by how many columns it carries, so a sparse block charges more here
+    /// than its column count suggests; leaving it out under-reports resident
+    /// memory and lets a pool limit over-admit decoded blocks.
+    fn slot_bytes(&self) -> usize {
+        self.cols.capacity() * std::mem::size_of::<Option<T>>()
+    }
 }
 
 /// A byte-valued column resolved once by id: a string column (plain or
@@ -946,6 +967,12 @@ impl DecodedBlock {
     /// against the cells.
     pub fn decoded_heap_bytes(&self) -> usize {
         let mut total = 0usize;
+        // The slot vectors themselves, before the columns they hold.
+        total += self.i64_cols.slot_bytes();
+        total += self.f64_cols.slot_bytes();
+        total += self.bool_cols.slot_bytes();
+        total += self.str_cols.slot_bytes();
+        total += self.fixed_cols.slot_bytes();
         for v in self.i64_cols.values() {
             total += v.capacity() * std::mem::size_of::<Option<i64>>();
         }
@@ -1186,6 +1213,11 @@ pub fn read_block_columns(
     let mut descs: Vec<PageDesc> = Vec::with_capacity(page_count.min(MAX_PAGES as usize));
     for _ in 0..page_count {
         let column_id = get_uvarint(bytes, &mut pos)?;
+        if column_id > MAX_COLUMN_ID {
+            return Err(LogSegError::Corrupted(format!(
+                "column_id {column_id} over cap {MAX_COLUMN_ID}"
+            )));
+        }
         let column_id = u32::try_from(column_id)
             .map_err(|_| LogSegError::Corrupted("column id out of range".into()))?;
         let enc = Enc::from_u8(
@@ -1431,6 +1463,95 @@ fn decode_columns(
 #[allow(clippy::expect_used)]
 mod tests {
     use super::*;
+
+    /// A page descriptor's `column_id` is read from the object, and `ColMap`
+    /// indexes a dense slot vector by it, so the allocation follows the largest
+    /// id rather than the column count. Without a cap a single block claiming a
+    /// `column_id` near `u32::MAX` resizes that vector to billions of slots and
+    /// exhausts memory before any pool limit can see it.
+    ///
+    /// This must fail as a typed `Corrupted` error. Deleting the `MAX_COLUMN_ID`
+    /// check makes this test attempt a multi-gigabyte allocation instead of
+    /// returning, which is how it was demonstrated failing.
+    #[test]
+    fn a_column_id_over_the_cap_is_rejected_before_it_allocates() {
+        // record_count, page_count, then one descriptor whose column_id is far
+        // past the cap: enc, comp, len, uncomp_len follow it.
+        let mut block = Vec::new();
+        put_uvarint(&mut block, 1); // record_count
+        put_uvarint(&mut block, 1); // page_count
+        put_uvarint(&mut block, u64::from(u32::MAX)); // column_id, wildly over cap
+        block.push(0); // enc
+        block.push(0); // comp
+        put_uvarint(&mut block, 0); // len
+        put_uvarint(&mut block, 0); // uncomp_len
+        let crc = crc32c::crc32c(&block);
+
+        match read_block_columns(&block, crc, &[], 1 << 20, None) {
+            Err(LogSegError::Corrupted(msg)) => assert!(
+                msg.contains("column_id") && msg.contains("over cap"),
+                "expected a column_id cap error naming the value, got: {msg}"
+            ),
+            Err(other) => panic!("expected Corrupted, got {other:?}"),
+            Ok(_) => panic!("a column_id over the cap must be rejected, not decoded"),
+        }
+    }
+
+    /// The slot vector is sized by the largest column id, not by how many
+    /// columns the block carries, so a block with one high-id column charges far
+    /// more than one column's worth. Leaving it out of `decoded_heap_bytes`
+    /// under-reports resident memory and lets a memory pool over-admit.
+    ///
+    /// This asserts through `decoded_heap_bytes`, the function that is actually
+    /// relied on, NOT through `ColMap::slot_bytes` directly. A first version of
+    /// this test called `slot_bytes` and passed with the charge removed from
+    /// `decoded_heap_bytes` entirely -- it pinned the helper while the caller
+    /// stayed broken.
+    ///
+    /// Pins a magnitude rather than non-emptiness: the reported figure must
+    /// cover the slot vector the sparse id forces into existence, on top of the
+    /// two payload columns, which are identical in both blocks.
+    #[test]
+    fn decoded_heap_bytes_charges_the_slot_vector() {
+        fn block_with(ids: [u32; 2]) -> DecodedBlock {
+            let mut i64_cols: ColMap<Vec<Option<i64>>> = ColMap::new();
+            i64_cols.insert(ids[0], vec![Some(1i64); 4]);
+            i64_cols.insert(ids[1], vec![Some(2i64); 4]);
+            DecodedBlock {
+                record_count: 4,
+                i64_cols,
+                f64_cols: ColMap::new(),
+                bool_cols: ColMap::new(),
+                str_cols: ColMap::new(),
+                fixed_cols: ColMap::new(),
+                col_lookups: Cell::new(0),
+                attrs_raw_page: false,
+                pages_decoded: 2,
+                pages_skipped: 0,
+                page_bytes_fetched: 0,
+                page_bytes_decoded: 0,
+            }
+        }
+
+        // Same two columns, same payloads; only the second id differs.
+        let dense = block_with([0, 1]).decoded_heap_bytes();
+        let sparse = block_with([0, 1000]).decoded_heap_bytes();
+
+        // The gap the id 1000 opens. Floored below 999 slots because `Vec`
+        // growth rounds the dense block's capacity up (2 slots requested, 4
+        // allocated), so the exact difference is a few slots short of the id
+        // gap. 900 still pins the magnitude: an implementation that charged
+        // only the two columns actually present would show a difference of
+        // roughly zero here, not of 900 slots.
+        let slot = std::mem::size_of::<Option<Vec<Option<i64>>>>();
+        let forced = 900 * slot;
+        assert!(
+            sparse >= dense + forced,
+            "a block whose largest column id is 1000 must charge at least \
+             {forced} B more than the same columns at ids 0 and 1: \
+             sparse={sparse} dense={dense}"
+        );
+    }
 
     fn row(stream_ref: u32, ts: i64) -> ResolvedRow {
         ResolvedRow {

--- a/crates/ravel-logseg/src/block.rs
+++ b/crates/ravel-logseg/src/block.rs
@@ -8,6 +8,7 @@
 //! SKIP_IDX level-0 entry, not inline; [`read_block`] verifies it before
 //! decoding anything.
 
+use std::cell::Cell;
 use std::collections::HashMap;
 use std::hash::{BuildHasherDefault, Hasher};
 
@@ -755,7 +756,7 @@ pub fn write_block_columnar(
 /// ids instead of materializing one owned `Vec<u8>` per row; a plain page keeps
 /// the per-row values. Both are addressed by block row position and carry
 /// presence separately: an absent row reads `None` either way.
-enum StrColumn {
+pub(crate) enum StrColumn {
     /// Per-row values, `None` for an absent row. What a plain page decodes to.
     Plain(Vec<Option<Vec<u8>>>),
     /// The distinct values plus one id per block row: `Some(id)` indexes `dict`,
@@ -789,6 +790,64 @@ impl StrColumn {
     }
 }
 
+/// A block's decoded columns of one storage kind, addressed by column id.
+///
+/// Column ids are dense and small (fixed 0..=9, dynamic from
+/// [`FIRST_DYNAMIC_COL`] up to the block's dynamic-column budget), so a `Vec`
+/// slot per id resolves a column with one bounds-checked index and no hashing.
+/// SipHash over a `&u32` key was 6% of warm-pass self time on the scan's hot
+/// loop; there is no HashDoS surface on an internal, per-block map (#875).
+struct ColMap<T> {
+    /// One slot per column id; `None` where the block carries no such column
+    /// (absent from every row, or projected away by the scan's column filter).
+    cols: Vec<Option<T>>,
+}
+
+impl<T> ColMap<T> {
+    fn new() -> Self {
+        ColMap { cols: Vec::new() }
+    }
+
+    fn get(&self, column_id: u32) -> Option<&T> {
+        self.cols.get(column_id as usize).and_then(Option::as_ref)
+    }
+
+    fn insert(&mut self, column_id: u32, value: T) {
+        let idx = column_id as usize;
+        if idx >= self.cols.len() {
+            self.cols.resize_with(idx + 1, || None);
+        }
+        self.cols[idx] = Some(value);
+    }
+
+    fn values(&self) -> impl Iterator<Item = &T> {
+        self.cols.iter().flatten()
+    }
+}
+
+/// A byte-valued column resolved once by id: a string column (plain or
+/// dictionary) or a fixed-width id column. A given column id is only ever one of
+/// the two, so [`DecodedBlock::bytes_col`] resolves it with a single lookup and
+/// [`ColumnarBlockView::bytes_cursor`](crate::ColumnarBlockView) walks it per row
+/// with none. It yields cell bytes, never the storage vector, so ADR-0099
+/// decision 4's string-storage change stays invisible to callers.
+pub(crate) enum BytesColRef<'a> {
+    Str(&'a StrColumn),
+    Fixed(&'a [Option<Vec<u8>>]),
+}
+
+impl<'a> BytesColRef<'a> {
+    /// The bytes at block row `row`, or `None` for an absent row. Borrowed from
+    /// the block for `'a`, not from the [`BytesColRef`], so a cursor can hand out
+    /// a cell that outlives the transient cursor.
+    pub(crate) fn cell(&self, row: usize) -> Option<&'a [u8]> {
+        match self {
+            BytesColRef::Str(s) => s.cell(row),
+            BytesColRef::Fixed(v) => v.get(row)?.as_deref(),
+        }
+    }
+}
+
 /// A decoded block: per-column, per-row values. Every column vector has length
 /// `record_count`; `None` marks a row where the column has no value.
 ///
@@ -800,11 +859,18 @@ impl StrColumn {
 /// the same nothing).
 pub struct DecodedBlock {
     record_count: usize,
-    i64_cols: HashMap<u32, Vec<Option<i64>>>,
-    f64_cols: HashMap<u32, Vec<Option<u64>>>,
-    bool_cols: HashMap<u32, Vec<Option<bool>>>,
-    str_cols: HashMap<u32, StrColumn>,
-    fixed_cols: HashMap<u32, Vec<Option<Vec<u8>>>>,
+    i64_cols: ColMap<Vec<Option<i64>>>,
+    f64_cols: ColMap<Vec<Option<u64>>>,
+    bool_cols: ColMap<Vec<Option<bool>>>,
+    str_cols: ColMap<StrColumn>,
+    fixed_cols: ColMap<Vec<Option<Vec<u8>>>>,
+    /// Count of column resolutions by id (`i64_col`, `bytes_col`, ... ), for
+    /// tests that pin the scan does O(columns) resolutions per block, not
+    /// O(rows x columns) (#875). A per-cell accessor bumps it once per cell; a
+    /// cursor bumps it once per column and then indexes the resolved slice with
+    /// no further bump. `Cell`, not atomic: a block is read by one thread and
+    /// this must not add a barrier to the hot per-cell path.
+    col_lookups: Cell<u64>,
     /// Whether any page descriptor in this block named [`COL_ATTRS_RAW`], read
     /// off the header and independent of the column filter (see
     /// [`DecodedBlock::has_attrs_raw_page`]).
@@ -919,14 +985,27 @@ impl DecodedBlock {
         }
         total
     }
+    /// Column resolutions by id since decode: see [`Self::col_lookups`].
+    pub fn column_lookups(&self) -> u64 {
+        self.col_lookups.get()
+    }
+
+    #[inline]
+    fn bump_lookup(&self) {
+        self.col_lookups.set(self.col_lookups.get() + 1);
+    }
+
     pub fn i64_col(&self, column_id: u32) -> Option<&[Option<i64>]> {
-        self.i64_cols.get(&column_id).map(Vec::as_slice)
+        self.bump_lookup();
+        self.i64_cols.get(column_id).map(Vec::as_slice)
     }
     pub fn f64_col(&self, column_id: u32) -> Option<&[Option<u64>]> {
-        self.f64_cols.get(&column_id).map(Vec::as_slice)
+        self.bump_lookup();
+        self.f64_cols.get(column_id).map(Vec::as_slice)
     }
     pub fn bool_col(&self, column_id: u32) -> Option<&[Option<bool>]> {
-        self.bool_cols.get(&column_id).map(Vec::as_slice)
+        self.bump_lookup();
+        self.bool_cols.get(column_id).map(Vec::as_slice)
     }
 
     /// The bytes of string column `column_id` at block row `row`, or `None` when
@@ -934,7 +1013,23 @@ impl DecodedBlock {
     /// the plain and dictionary storage shapes read through here, so a caller
     /// never learns which one the column is (ADR-0099 decision 4).
     pub(crate) fn str_at(&self, column_id: u32, row: usize) -> Option<&[u8]> {
-        self.str_cols.get(&column_id)?.cell(row)
+        self.bump_lookup();
+        self.str_cols.get(column_id)?.cell(row)
+    }
+
+    /// Resolve a byte-valued column (string or fixed-width) by id once, for a
+    /// cursor that then walks it per row with no further lookup. `None` when the
+    /// block carries no such column (absent or projected away). One lookup even
+    /// though a byte column can live in either the string or the fixed map: a
+    /// given id is only ever one of the two.
+    pub(crate) fn bytes_col(&self, column_id: u32) -> Option<BytesColRef<'_>> {
+        self.bump_lookup();
+        if let Some(s) = self.str_cols.get(column_id) {
+            return Some(BytesColRef::Str(s));
+        }
+        self.fixed_cols
+            .get(column_id)
+            .map(|v| BytesColRef::Fixed(v.as_slice()))
     }
 
     /// The dictionary form of string column `column_id`: its distinct values and
@@ -942,14 +1037,16 @@ impl DecodedBlock {
     /// absent, projected away, or stored in plain form -- a plain page is read
     /// through [`Self::str_at`], never forced into a dictionary here.
     pub(crate) fn str_dict(&self, column_id: u32) -> Option<StrDictRef<'_>> {
-        match self.str_cols.get(&column_id)? {
+        self.bump_lookup();
+        match self.str_cols.get(column_id)? {
             StrColumn::Dict { dict, ids } => Some((dict, ids)),
             StrColumn::Plain(_) => None,
         }
     }
 
     pub fn fixed_col(&self, column_id: u32) -> Option<&[Option<Vec<u8>>]> {
-        self.fixed_cols.get(&column_id).map(Vec::as_slice)
+        self.bump_lookup();
+        self.fixed_cols.get(column_id).map(Vec::as_slice)
     }
 
     /// Test-only fused view of a string column, `None` when the column is absent.
@@ -957,7 +1054,7 @@ impl DecodedBlock {
     /// assertions read unchanged regardless of the storage shape.
     #[cfg(test)]
     fn str_col_fused(&self, column_id: u32) -> Option<Vec<Option<Vec<u8>>>> {
-        let _ = self.str_cols.get(&column_id)?;
+        let _ = self.str_cols.get(column_id)?;
         Some(
             (0..self.record_count)
                 .map(|row| self.str_at(column_id, row).map(<[u8]>::to_vec))
@@ -1255,11 +1352,12 @@ fn decode_columns(
 
     let mut out = DecodedBlock {
         record_count,
-        i64_cols: HashMap::new(),
-        f64_cols: HashMap::new(),
-        bool_cols: HashMap::new(),
-        str_cols: HashMap::new(),
-        fixed_cols: HashMap::new(),
+        i64_cols: ColMap::new(),
+        f64_cols: ColMap::new(),
+        bool_cols: ColMap::new(),
+        str_cols: ColMap::new(),
+        fixed_cols: ColMap::new(),
+        col_lookups: Cell::new(0),
         attrs_raw_page: descs.iter().any(|d| d.column_id == COL_ATTRS_RAW),
         pages_decoded: counters.decoded,
         pages_skipped: counters.skipped,

--- a/crates/ravel-logseg/src/block.rs
+++ b/crates/ravel-logseg/src/block.rs
@@ -2174,10 +2174,19 @@ mod tests {
 
         // New (dict) footprint: one id per row + the distinct set once.
         let dict_figure = N * opt_u32 + DISTINCT * vec_spine + DISTINCT * LEN;
+        // Plus the slot vector `str_cols` allocates to hold that one column.
+        // It is sized by the largest column id present, so decoding column 10
+        // alone still forces 11 slots; charging it is what stops a sparse block
+        // under-reporting its resident memory. The oracle carries it rather
+        // than the assertion loosening to an inequality: an exact figure is
+        // available here, and a `>=` would stop pinning the dictionary
+        // footprint this test exists to check.
+        let slots = 11 * std::mem::size_of::<Option<StrColumn>>();
         assert_eq!(
             dec.decoded_heap_bytes(),
-            dict_figure,
-            "decoded_heap_bytes must report the dictionary footprint"
+            dict_figure + slots,
+            "decoded_heap_bytes must report the dictionary footprint plus the \
+             slot vector its column id forces"
         );
 
         // Old (fused) footprint the code must no longer report: one owned buffer

--- a/crates/ravel-logseg/src/columnar.rs
+++ b/crates/ravel-logseg/src/columnar.rs
@@ -31,7 +31,7 @@
 //! cell whose column is absent from the block or was projected away by the
 //! scan's [`ColumnSelection`](crate::ColumnSelection).
 
-use crate::block::DecodedBlock;
+use crate::block::{BytesColRef, DecodedBlock};
 use crate::field_dir::FieldDir;
 use crate::record::{
     COL_BODY, COL_FLAGS, COL_OBSERVED_TS, COL_SEVERITY_NUM, COL_SEVERITY_TEXT, COL_SPAN_ID,
@@ -107,6 +107,121 @@ impl<'a> StrDictColumn<'a> {
     pub fn value_at(&self, i: usize) -> Option<&'a [u8]> {
         let id = self.id_at(i)? as usize;
         self.dict.get(id).map(Vec::as_slice)
+    }
+}
+
+/// A single column resolved once for the whole block, walked per surviving row.
+///
+/// The scan's row loop read one cell with one `HashMap<u32, _>` lookup per cell
+/// (`i64_at` was 7% of warm-pass self time, its `RandomState` hashing another
+/// 6%); a cursor resolves the column's storage once, then indexes the resolved
+/// slice per row with no lookup at all (#875). It preserves ADR-0099 decision
+/// 4: like every accessor here it hands out a *value* per surviving row and
+/// never the storage vector, so the string-storage change decision 4 makes stays
+/// invisible to callers -- the string cursor is [`BytesCursor`], which yields
+/// cell bytes through the same opaque [`BytesColRef`] the plain and dictionary
+/// shapes both read through.
+///
+/// A cursor's `at` distinguishes an absent column from a present column whose
+/// cell is null the same way the per-cell accessor did -- both read as `None` at
+/// the value level, byte-identical to the prior path -- while
+/// [`is_column_present`](I64Cursor::is_column_present) exposes which case it is
+/// for a caller that needs to tell them apart.
+macro_rules! value_cursor {
+    ($name:ident, $val:ty, $doc:literal) => {
+        #[doc = $doc]
+        pub struct $name<'a> {
+            /// The resolved column slice, one entry per block row, or `None` when
+            /// the block carries no such column (absent or projected away).
+            col: Option<&'a [Option<$val>]>,
+            /// Block row positions of the surviving rows (the view's `rows`).
+            rows: &'a [usize],
+        }
+
+        impl<'a> $name<'a> {
+            /// The cell at surviving row `i`, or `None` when `i` is out of range,
+            /// the column is absent, or the cell is null.
+            #[inline]
+            pub fn at(&self, i: usize) -> Option<$val> {
+                let row = *self.rows.get(i)?;
+                self.col?.get(row).copied().flatten()
+            }
+
+            /// Whether the block carries this column at all, distinct from a
+            /// present column whose cell at some row is null: both read as `None`
+            /// from [`at`](Self::at), this tells them apart.
+            pub fn is_column_present(&self) -> bool {
+                self.col.is_some()
+            }
+
+            /// Number of surviving rows the cursor ranges over.
+            pub fn len(&self) -> usize {
+                self.rows.len()
+            }
+
+            /// Whether no row survives.
+            pub fn is_empty(&self) -> bool {
+                self.rows.is_empty()
+            }
+        }
+    };
+}
+
+value_cursor!(
+    I64Cursor,
+    i64,
+    "An i64 column resolved once per block (a fixed i64 column or an I64 attribute)."
+);
+value_cursor!(
+    F64BitsCursor,
+    u64,
+    "An f64 column resolved once per block, yielding `to_bits` patterns so NaN \
+     payloads and `-0.0` stay bit-exact (see \
+     [`ColumnarBlockView::f64_bits_at`])."
+);
+value_cursor!(BoolCursor, bool, "A bool column resolved once per block.");
+
+/// A byte-valued column (string or fixed-width id) resolved once per block,
+/// walked per surviving row. Yields cell bytes through [`BytesColRef`], never the
+/// storage vector, so it satisfies ADR-0099 decision 4 exactly as
+/// [`ColumnarBlockView::bytes_at`] does.
+pub struct BytesCursor<'a> {
+    col: Option<BytesColRef<'a>>,
+    rows: &'a [usize],
+}
+
+impl<'a> BytesCursor<'a> {
+    /// The bytes at surviving row `i`, or `None` when `i` is out of range, the
+    /// column is absent, or the cell is null.
+    #[inline]
+    pub fn at(&self, i: usize) -> Option<&'a [u8]> {
+        let row = *self.rows.get(i)?;
+        self.col.as_ref()?.cell(row)
+    }
+
+    /// The bytes at surviving row `i` as `&str`, or `None` when the cell is
+    /// absent **or** its bytes are not UTF-8. Treating invalid UTF-8 as no value
+    /// matches the row path (`String::from_utf8(..).ok()`), which lets a
+    /// resource/scope fallback show through for that row.
+    #[inline]
+    pub fn str_at(&self, i: usize) -> Option<&'a str> {
+        std::str::from_utf8(self.at(i)?).ok()
+    }
+
+    /// Whether the block carries this column at all (see
+    /// [`I64Cursor::is_column_present`]).
+    pub fn is_column_present(&self) -> bool {
+        self.col.is_some()
+    }
+
+    /// Number of surviving rows the cursor ranges over.
+    pub fn len(&self) -> usize {
+        self.rows.len()
+    }
+
+    /// Whether no row survives.
+    pub fn is_empty(&self) -> bool {
+        self.rows.is_empty()
     }
 }
 
@@ -342,6 +457,102 @@ impl<'a> ColumnarBlockView<'a> {
                 },
             )
         })
+    }
+
+    // --- per-column cursors -------------------------------------------------
+
+    /// Resolve column `column_id` as an i64 column once, for a cursor that walks
+    /// the surviving rows with no further lookup (#875). The resolution is the
+    /// one `HashMap`/`Vec` lookup the per-cell [`i64_at`](Self::i64_at) did on
+    /// every cell.
+    pub fn i64_cursor(&self, column_id: u32) -> I64Cursor<'a> {
+        I64Cursor {
+            col: self.block.i64_col(column_id),
+            rows: self.rows,
+        }
+    }
+
+    /// Resolve column `column_id` as an f64 column once (bits form, see
+    /// [`f64_bits_at`](Self::f64_bits_at)).
+    pub fn f64_bits_cursor(&self, column_id: u32) -> F64BitsCursor<'a> {
+        F64BitsCursor {
+            col: self.block.f64_col(column_id),
+            rows: self.rows,
+        }
+    }
+
+    /// Resolve column `column_id` as a bool column once.
+    pub fn bool_cursor(&self, column_id: u32) -> BoolCursor<'a> {
+        BoolCursor {
+            col: self.block.bool_col(column_id),
+            rows: self.rows,
+        }
+    }
+
+    /// Resolve column `column_id` as a byte-valued column once (a string column
+    /// or a fixed-width id column; see [`bytes_at`](Self::bytes_at)).
+    pub fn bytes_cursor(&self, column_id: u32) -> BytesCursor<'a> {
+        BytesCursor {
+            col: self.block.bytes_col(column_id),
+            rows: self.rows,
+        }
+    }
+
+    /// A cursor over the event-timestamp column.
+    pub fn ts_cursor(&self) -> I64Cursor<'a> {
+        self.i64_cursor(COL_TS)
+    }
+
+    /// A cursor over the observed-timestamp column.
+    pub fn observed_ts_cursor(&self) -> I64Cursor<'a> {
+        self.i64_cursor(COL_OBSERVED_TS)
+    }
+
+    /// A cursor over the severity-number column.
+    pub fn severity_num_cursor(&self) -> I64Cursor<'a> {
+        self.i64_cursor(COL_SEVERITY_NUM)
+    }
+
+    /// A cursor over the flags column.
+    pub fn flags_cursor(&self) -> I64Cursor<'a> {
+        self.i64_cursor(COL_FLAGS)
+    }
+
+    /// A cursor over the dense STREAM_DIR reference column, as its stored i64
+    /// (the caller narrows to `u32`, exactly as [`stream_ref`](Self::stream_ref)
+    /// does).
+    pub fn stream_ref_cursor(&self) -> I64Cursor<'a> {
+        self.i64_cursor(COL_STREAM_REF)
+    }
+
+    /// A cursor over the severity-text column (stored bytes, not UTF-8 validated;
+    /// see [`severity_text`](Self::severity_text)).
+    pub fn severity_text_cursor(&self) -> BytesCursor<'a> {
+        self.bytes_cursor(COL_SEVERITY_TEXT)
+    }
+
+    /// A cursor over the body column.
+    pub fn body_cursor(&self) -> BytesCursor<'a> {
+        self.bytes_cursor(COL_BODY)
+    }
+
+    /// A cursor over the trace-id column.
+    pub fn trace_id_cursor(&self) -> BytesCursor<'a> {
+        self.bytes_cursor(COL_TRACE_ID)
+    }
+
+    /// A cursor over the span-id column.
+    pub fn span_id_cursor(&self) -> BytesCursor<'a> {
+        self.bytes_cursor(COL_SPAN_ID)
+    }
+
+    /// Column resolutions by id since this block was decoded (see
+    /// [`DecodedBlock::column_lookups`](crate::block::DecodedBlock::column_lookups)).
+    /// A cursor bumps this once per column; a per-cell accessor bumps it once
+    /// per cell. Exposed so a test can pin that the scan resolves O(columns) per
+    /// block, not O(rows x columns).
+    pub fn column_lookups(&self) -> u64 {
+        self.block.column_lookups()
     }
 
     // --- by column id -------------------------------------------------------

--- a/crates/ravel-logseg/src/lib.rs
+++ b/crates/ravel-logseg/src/lib.rs
@@ -39,7 +39,9 @@ pub use ravel_codec::{bloom, bloom_section, encoding, tokenizer};
 // deliberately NOT re-exported: the view is the whole public surface over a
 // decoded block, so decision 4 can change how columns are stored without
 // touching a caller.
-pub use columnar::{AttrColumn, ColumnarBlockView, StrDictColumn};
+pub use columnar::{
+    AttrColumn, BoolCursor, BytesCursor, ColumnarBlockView, F64BitsCursor, I64Cursor, StrDictColumn,
+};
 pub use columnar_batch::{Bitmap, ColumnarLogBatch, DynColumn, StrColumnDict, VarBytes};
 pub use columns::ColumnSelection;
 pub use error::LogSegError;

--- a/crates/ravel-logseg/src/reader.rs
+++ b/crates/ravel-logseg/src/reader.rs
@@ -884,13 +884,27 @@ impl BlockScan {
         let Some(decoded) = self.current.as_ref() else {
             return Err(LogSegError::Corrupted("block not decoded".into()));
         };
+        // Resolve stream_ref and ts once for the whole block, not once per
+        // surviving row (#875): the per-row body then only indexes the resolved
+        // slices, and the error text stays identical to the per-cell `i64_at`.
+        let stream_refs = decoded.i64_col(COL_STREAM_REF);
+        let ts = decoded.i64_col(COL_TS);
+        let entries = self.stream_dir.entries();
         for &row in &self.surviving {
-            let sref = u32::try_from(i64_at(decoded, COL_STREAM_REF, row)?)
+            let raw = stream_refs
+                .and_then(|c| c.get(row).copied())
+                .flatten()
+                .ok_or_else(|| {
+                    LogSegError::Corrupted(format!("missing i64 col {COL_STREAM_REF}"))
+                })?;
+            let sref = u32::try_from(raw)
                 .map_err(|_| LogSegError::Corrupted("stream_ref range".into()))?;
-            if self.stream_dir.entries().get(sref as usize).is_none() {
+            if entries.get(sref as usize).is_none() {
                 return Err(LogSegError::Corrupted("stream_ref out of range".into()));
             }
-            i64_at(decoded, COL_TS, row)?;
+            ts.and_then(|c| c.get(row).copied())
+                .flatten()
+                .ok_or_else(|| LogSegError::Corrupted(format!("missing i64 col {COL_TS}")))?;
         }
         Ok(Some(ColumnarBlockView::new(
             &self.stream_dir,

--- a/crates/ravel-logseg/src/reader.rs
+++ b/crates/ravel-logseg/src/reader.rs
@@ -4067,6 +4067,219 @@ mod tests {
         );
     }
 
+    /// A four-row single-block fixture whose rows all match `keep`, carrying one
+    /// column of every declared attribute type. Used by the cursor tests below.
+    fn cursor_fixture() -> Vec<u8> {
+        let cfg = RlogConfig {
+            block_target_records: 16,
+            max_dynamic_columns: 8,
+            ..RlogConfig::default()
+        };
+        let recs = vec![
+            rec_attrs(
+                0,
+                100,
+                "keep a",
+                vec![
+                    attr("b_int", AttrValue::I64(1)),
+                    attr("c_f64", AttrValue::F64(1.0)),
+                    attr("d_bool", AttrValue::Bool(true)),
+                    attr("a_str", AttrValue::Str("p".into())),
+                    attr("e_bytes", AttrValue::Bytes(vec![1])),
+                ],
+            ),
+            rec_attrs(0, 101, "keep b", vec![attr("b_int", AttrValue::I64(2))]),
+            rec_attrs(0, 102, "keep c", vec![attr("c_f64", AttrValue::F64(3.0))]),
+            // Row 3 sets no attribute at all: every dynamic column has a null
+            // cell here.
+            rec_attrs(0, 103, "keep d", Vec::new()),
+        ];
+        build(cfg, recs)
+    }
+
+    fn cursor_reader_cfg() -> RlogConfig {
+        RlogConfig {
+            block_target_records: 16,
+            max_dynamic_columns: 8,
+            ..RlogConfig::default()
+        }
+    }
+
+    /// Deliverable 1 (#875): a cursor resolves its column once per block, so the
+    /// scan does O(columns) resolutions, never O(rows x columns). Pins the exact
+    /// count for a known 4-row, single-block fixture. The per-cell accessor --
+    /// the pre-change path -- is shown resolving the column on every cell (R per
+    /// column), so the exact-count assertion here fails against it: flipping the
+    /// cursor loop's `cur.at(i)` back to `view.i64_at(col, i)` turns 6 into
+    /// 6 * R.
+    #[test]
+    fn cursor_resolves_each_column_once_per_block() {
+        let obj = cursor_fixture();
+        let cfg = cursor_reader_cfg();
+        let reader = RlogReader::new(&obj, &cfg).expect("open object");
+        let pred = Predicate::And(Vec::new());
+        let mut cursor = reader
+            .scan_blocks(&pred, &[], &ColumnSelection::all())
+            .expect("open cursor");
+        let view = cursor
+            .next_block_columnar(&obj)
+            .expect("columnar exit")
+            .expect("one block");
+        let rows = view.surviving_count();
+        assert_eq!(rows, 4, "match-all keeps every row of the single block");
+
+        // Resolving these does not touch the block's column maps (FIELD_DIR
+        // lookups), so they do not move the counter.
+        let b_int = view.resolve_attr("b_int", FieldType::I64).expect("b_int");
+        let c_f64 = view.resolve_attr("c_f64", FieldType::F64).expect("c_f64");
+        let d_bool = view
+            .resolve_attr("d_bool", FieldType::Bool)
+            .expect("d_bool");
+        let a_str = view.resolve_attr("a_str", FieldType::Str).expect("a_str");
+        let e_bytes = view
+            .resolve_attr("e_bytes", FieldType::Bytes)
+            .expect("e_bytes");
+
+        let base = view.column_lookups();
+        // ts plus one column of every declared type: six distinct columns.
+        let cur_ts = view.ts_cursor();
+        let cur_bi = view.i64_cursor(b_int.column_id);
+        let cur_cf = view.f64_bits_cursor(c_f64.column_id);
+        let cur_db = view.bool_cursor(d_bool.column_id);
+        let cur_as = view.bytes_cursor(a_str.column_id);
+        let cur_eb = view.bytes_cursor(e_bytes.column_id);
+        const COLUMNS: u64 = 6;
+        // Walking every surviving row through the cursors adds no resolution.
+        for i in 0..rows {
+            let _ = (
+                cur_ts.at(i),
+                cur_bi.at(i),
+                cur_cf.at(i),
+                cur_db.at(i),
+                cur_as.at(i),
+                cur_eb.at(i),
+            );
+        }
+        let cursor_lookups = view.column_lookups() - base;
+        assert_eq!(
+            cursor_lookups, COLUMNS,
+            "one resolution per column, independent of the {rows} rows"
+        );
+
+        // The pre-change shape: the per-cell accessor resolves the column on
+        // every cell. Over the two i64 columns (ts, b_int) that is exactly 2 per
+        // row -- O(rows x columns), the cost this change deletes.
+        let before = view.column_lookups();
+        for i in 0..rows {
+            let _ = view.i64_at(COL_TS, i);
+            let _ = view.i64_at(b_int.column_id, i);
+        }
+        let per_cell = view.column_lookups() - before;
+        assert_eq!(
+            per_cell,
+            2 * rows as u64,
+            "per-cell accessor resolves once per cell"
+        );
+        assert!(
+            per_cell > COLUMNS,
+            "the pre-change per-cell path fails the O(columns) bound"
+        );
+    }
+
+    /// Deliverable 1 correctness bar (#875): a cursor keeps an absent column and
+    /// a present-but-null cell distinguishable, both directions. Both read as
+    /// `None` at the value level -- byte-identical to the per-cell accessor the
+    /// scan used before -- while `is_column_present` tells the two apart.
+    #[test]
+    fn cursor_distinguishes_absent_column_from_null_cell() {
+        let obj = cursor_fixture();
+        let cfg = cursor_reader_cfg();
+        let reader = RlogReader::new(&obj, &cfg).expect("open object");
+        let pred = Predicate::And(Vec::new());
+        let mut cursor = reader
+            .scan_blocks(&pred, &[], &ColumnSelection::all())
+            .expect("open cursor");
+        let view = cursor
+            .next_block_columnar(&obj)
+            .expect("columnar exit")
+            .expect("one block");
+        let b_int = view.resolve_attr("b_int", FieldType::I64).expect("b_int");
+
+        // Present column, null cell: b_int is decoded but row 3 sets no value.
+        let bi = view.i64_cursor(b_int.column_id);
+        assert!(bi.is_column_present(), "b_int is a decoded column");
+        assert_eq!(bi.at(0), Some(1), "row 0 sets b_int");
+        assert_eq!(bi.at(3), None, "row 3 has a null b_int cell");
+
+        // Absent column: b_int has no f64 storage, so an f64 cursor over its id
+        // resolves to no column at all.
+        let bi_as_f64 = view.f64_bits_cursor(b_int.column_id);
+        assert!(
+            !bi_as_f64.is_column_present(),
+            "there is no f64 column for b_int"
+        );
+        assert_eq!(bi_as_f64.at(0), None, "an absent column reads None");
+
+        // Both directions read None as a value, and the two are still
+        // distinguishable through `is_column_present`.
+        assert_eq!(bi.at(3), None, "null cell reads None");
+        assert_eq!(bi_as_f64.at(0), None, "absent column reads None");
+        assert_ne!(
+            bi.is_column_present(),
+            bi_as_f64.is_column_present(),
+            "null cell and absent column stay distinguishable"
+        );
+    }
+
+    /// Deliverable correctness bar (#875): the f64 cursor round-trips the exact
+    /// stored bit pattern, so `-0.0` stays distinct from `+0.0` and a NaN payload
+    /// survives. `f64_bits_at`/the cursor return bits for exactly this reason.
+    #[test]
+    fn f64_cursor_preserves_exact_bit_pattern() {
+        let cfg = RlogConfig {
+            block_target_records: 16,
+            max_dynamic_columns: 8,
+            ..RlogConfig::default()
+        };
+        let nan_payload = f64::from_bits(f64::NAN.to_bits() | 0x7);
+        let recs = vec![
+            rec_attrs(0, 100, "keep a", vec![attr("v", AttrValue::F64(-0.0))]),
+            rec_attrs(0, 101, "keep b", vec![attr("v", AttrValue::F64(0.0))]),
+            rec_attrs(
+                0,
+                102,
+                "keep c",
+                vec![attr("v", AttrValue::F64(nan_payload))],
+            ),
+            rec_attrs(0, 103, "keep d", vec![attr("v", AttrValue::F64(1.5))]),
+        ];
+        let obj = build(cfg, recs);
+        let reader = RlogReader::new(&obj, &cfg).expect("open object");
+        let pred = Predicate::And(Vec::new());
+        let mut cursor = reader
+            .scan_blocks(&pred, &[], &ColumnSelection::all())
+            .expect("open cursor");
+        let view = cursor
+            .next_block_columnar(&obj)
+            .expect("columnar exit")
+            .expect("one block");
+        let v = view.resolve_attr("v", FieldType::F64).expect("v col");
+        let cur = view.f64_bits_cursor(v.column_id);
+        assert_eq!(cur.at(0), Some((-0.0f64).to_bits()), "-0.0 bit pattern");
+        assert_eq!(cur.at(1), Some(0.0f64.to_bits()), "+0.0 bit pattern");
+        assert_ne!(
+            cur.at(0),
+            cur.at(1),
+            "-0.0 and +0.0 are distinct bit patterns"
+        );
+        assert_eq!(
+            cur.at(2),
+            Some(nan_payload.to_bits()),
+            "NaN payload preserved"
+        );
+        assert_eq!(cur.at(3), Some(1.5f64.to_bits()));
+    }
+
     /// Both exits reject a corrupt block with the same typed error, and neither
     /// panics. The flipped byte is inside block 0's stored extent, so its
     /// crc32c no longer matches its SKIP_IDX entry.

--- a/crates/ravel-sql/src/logs_scan.rs
+++ b/crates/ravel-sql/src/logs_scan.rs
@@ -244,8 +244,8 @@ use futures::{Stream, StreamExt, TryStreamExt};
 use ravel_catalog::SegmentRef;
 use ravel_logseg::footer::LogFooter;
 use ravel_logseg::{
-    AttrColumn, ColumnSelection, ColumnarBlockView, FieldSel, FieldType, LogRecord, Predicate,
-    ScanStats,
+    AttrColumn, BoolCursor, BytesCursor, ColumnSelection, ColumnarBlockView, F64BitsCursor,
+    FieldSel, FieldType, I64Cursor, LogRecord, Predicate, ScanStats,
 };
 use ravel_query::erasure::ErasurePredicate;
 use ravel_query::{ColumnarBlockOutcome, LogQuery, LogSegmentFetcher, LogSegmentScan};
@@ -2632,21 +2632,117 @@ fn declared_column_array(dc: &DeclaredColumn, merged: &[Vec<(String, AttrValue)>
 // Columnar fast path (ADR-0099 decision 2)
 // ---------------------------------------------------------------------------
 
-/// One declared column's FIELD_DIR resolution for a block, done once via
-/// [`ColumnarBlockView::resolve_attr`] rather than per row via
-/// [`find_attr`] (ADR-0099 decision 2).
-struct DeclaredPlan<'d> {
+/// A FIELD_DIR column of a declared key, resolved once for the whole block into
+/// a per-column cursor (#875). The scan's row loop read one cell with one
+/// `HashMap<u32, _>` lookup per cell; the cursor resolves the column's storage
+/// once and then indexes the resolved slice per row with no lookup.
+enum DeclaredCursor<'a> {
+    Str(BytesCursor<'a>),
+    Bytes(BytesCursor<'a>),
+    I64(I64Cursor<'a>),
+    F64(F64BitsCursor<'a>),
+    Bool(BoolCursor<'a>),
+}
+
+impl<'a> DeclaredCursor<'a> {
+    fn resolve(view: &ColumnarBlockView<'a>, col: AttrColumn) -> Self {
+        match col.ty {
+            FieldType::Str => DeclaredCursor::Str(view.bytes_cursor(col.column_id)),
+            FieldType::Bytes => DeclaredCursor::Bytes(view.bytes_cursor(col.column_id)),
+            FieldType::I64 => DeclaredCursor::I64(view.i64_cursor(col.column_id)),
+            FieldType::F64 => DeclaredCursor::F64(view.f64_bits_cursor(col.column_id)),
+            FieldType::Bool => DeclaredCursor::Bool(view.bool_cursor(col.column_id)),
+        }
+    }
+
+    /// Whether the record sets the key in this column at surviving row `i`, with
+    /// the same "readable" rule the row path uses: an invalid-UTF-8 `Str` cell is
+    /// not a value (matches [`read_str_cell`]), so it must not suppress the
+    /// resource/scope fallback.
+    fn present_at(&self, i: usize) -> bool {
+        match self {
+            DeclaredCursor::Str(c) => c.str_at(i).is_some(),
+            DeclaredCursor::Bytes(c) => c.at(i).is_some(),
+            DeclaredCursor::I64(c) => c.at(i).is_some(),
+            DeclaredCursor::F64(c) => c.at(i).is_some(),
+            DeclaredCursor::Bool(c) => c.at(i).is_some(),
+        }
+    }
+
+    /// The cell at surviving row `i` as an [`AttrValue`], or `None` when NULL (or,
+    /// for `Str`, not UTF-8). Used for the non-`Str` builders and to compare a
+    /// record value's variant against the declared type; the `Str` builder reads
+    /// `&str` directly so it never allocates a throwaway `String` (#875).
+    fn value_at(&self, i: usize) -> Option<AttrValue> {
+        match self {
+            DeclaredCursor::Str(c) => c.str_at(i).map(|s| AttrValue::Str(s.to_string())),
+            DeclaredCursor::Bytes(c) => c.at(i).map(|b| AttrValue::Bytes(b.to_vec())),
+            DeclaredCursor::I64(c) => c.at(i).map(AttrValue::I64),
+            DeclaredCursor::F64(c) => c.at(i).map(|bits| AttrValue::F64(f64::from_bits(bits))),
+            DeclaredCursor::Bool(c) => c.at(i).map(AttrValue::Bool),
+        }
+    }
+}
+
+/// One declared column's FIELD_DIR resolution for a block, done once rather than
+/// per row (ADR-0099 decision 2). Every FIELD_DIR column of the key is resolved
+/// to a cursor once when the plan is built; the row loop then reads through the
+/// cursors with no per-cell column lookup (#875).
+struct DeclaredPlan<'d, 'a> {
     dc: &'d DeclaredColumn,
-    /// The FIELD_DIR column carrying this key at the declared type, if any. A
-    /// record row whose value lives here reads that value; a row whose value
-    /// lives in a different-typed column of the same key reads NULL (record
-    /// wins, wrong variant), matching the row path exactly.
-    matching: Option<AttrColumn>,
-    /// Every FIELD_DIR column for this key, across all stored types. Used only
-    /// to answer "does this record set the key at all" so record-wins precedence
-    /// matches the merged view: if the record sets the key (any type), the
-    /// resource/scope fallback is not consulted.
-    all_cols: Vec<AttrColumn>,
+    /// The raw FIELD_DIR columns of this key, across all stored types. Kept
+    /// because [`ColumnarBlockView::str_dict`] resolves by column id.
+    cols: Vec<AttrColumn>,
+    /// Cursors parallel to [`Self::cols`], resolved once for the block.
+    cursors: Vec<DeclaredCursor<'a>>,
+    /// Index into [`Self::cols`]/[`Self::cursors`] of the declared-type column,
+    /// if the key has one. A record row whose value lives here reads that value;
+    /// a row whose value lives in a different-typed column of the same key reads
+    /// NULL (record wins, wrong variant), matching the row path exactly.
+    matching_idx: Option<usize>,
+}
+
+impl<'d, 'a> DeclaredPlan<'d, 'a> {
+    fn build(view: &ColumnarBlockView<'a>, dc: &'d DeclaredColumn) -> DeclaredPlan<'d, 'a> {
+        let cols: Vec<AttrColumn> = view.attr_columns_for(&dc.key).collect();
+        let declared_ty = declared_field_type(dc.ty);
+        let matching_idx = cols.iter().position(|c| c.ty == declared_ty);
+        let cursors = cols
+            .iter()
+            .map(|&c| DeclaredCursor::resolve(view, c))
+            .collect();
+        DeclaredPlan {
+            dc,
+            cols,
+            cursors,
+            matching_idx,
+        }
+    }
+
+    /// The declared-type FIELD_DIR column, if the key has one.
+    fn matching_col(&self) -> Option<AttrColumn> {
+        self.matching_idx.map(|k| self.cols[k])
+    }
+
+    /// The cursor over the declared-type column, if any.
+    fn matching_cursor(&self) -> Option<&DeclaredCursor<'a>> {
+        self.matching_idx.map(|k| &self.cursors[k])
+    }
+
+    /// True when the key's only FIELD_DIR column is the declared-type one, so a
+    /// single cursor read is both the presence answer and the value: the
+    /// double read (`attr_present` then `read_typed_cell`) collapses to one
+    /// (deliverable 2, #875).
+    fn single_matching(&self) -> bool {
+        self.cursors.len() == 1 && self.matching_idx == Some(0)
+    }
+
+    /// Whether the record sets the key in any of its FIELD_DIR columns at
+    /// surviving row `i`. Only consulted in the multi-column case; the fused case
+    /// gets the same answer from the single matching read.
+    fn record_sets_key(&self, i: usize) -> bool {
+        self.cursors.iter().any(|c| c.present_at(i))
+    }
 }
 
 /// The [`FieldType`] a declared column resolves its FIELD_DIR column at. A
@@ -2658,23 +2754,6 @@ fn declared_field_type(ty: DeclaredType) -> FieldType {
         DeclaredType::I64 => FieldType::I64,
         DeclaredType::Bool => FieldType::Bool,
         DeclaredType::Bytes => FieldType::Bytes,
-    }
-}
-
-/// Whether a FIELD_DIR column carries a *readable* value at surviving row `i`.
-///
-/// "Readable" is what makes this agree with the row path: a `Str` cell holding
-/// bytes that are not UTF-8 is not a value there
-/// (`get_attr_value`/`read_typed_cell`), so it must not count as the record
-/// setting the key either -- otherwise it would suppress the resource/scope
-/// fallback the row path applies.
-fn attr_present(view: &ColumnarBlockView<'_>, col: AttrColumn, i: usize) -> bool {
-    match col.ty {
-        FieldType::Str => read_str_cell(view, col.column_id, i).is_some(),
-        FieldType::Bytes => view.bytes_at(col.column_id, i).is_some(),
-        FieldType::I64 => view.i64_at(col.column_id, i).is_some(),
-        FieldType::F64 => view.f64_bits_at(col.column_id, i).is_some(),
-        FieldType::Bool => view.bool_at(col.column_id, i).is_some(),
     }
 }
 
@@ -2714,54 +2793,30 @@ fn resource_attrs<'c>(
 /// [`AttrValue`] whose variant the caller checks against the declared type.
 fn declared_merged_value(
     view: &ColumnarBlockView<'_>,
-    plan: &DeclaredPlan<'_>,
+    plan: &DeclaredPlan<'_, '_>,
     i: usize,
     cache: &mut HashMap<u32, Arc<Vec<(String, AttrValue)>>>,
 ) -> DFResult<Option<AttrValue>> {
-    let record_sets_key = plan.all_cols.iter().any(|&c| attr_present(view, c, i));
-    if record_sets_key {
-        let Some(mc) = plan.matching else {
-            return Ok(None);
-        };
-        return Ok(read_typed_cell(view, mc, i));
+    if plan.single_matching() {
+        // Fused: the one matching-column read is both the presence test and the
+        // value (deliverable 2, #875). `value_at` is `Some` exactly when the
+        // record sets the key at the declared type; `None` (absent, or a `Str`
+        // cell that is not UTF-8) falls through to the resource/scope value,
+        // matching the row path.
+        if let Some(v) = plan.matching_cursor().and_then(|c| c.value_at(i)) {
+            return Ok(Some(v));
+        }
+    } else if plan.record_sets_key(i) {
+        // Record wins. Its value is the declared-type column's cell, or NULL when
+        // the record set the key only in a different-typed column (ADR-0090
+        // decision 7); either way the resource/scope fallback is not consulted.
+        return Ok(plan.matching_cursor().and_then(|c| c.value_at(i)));
     }
     let Some(stream_ref) = view.stream_ref(i) else {
         return Ok(None);
     };
     let resource = resource_attrs(view, cache, stream_ref)?;
     Ok(find_attr(resource, &plan.dc.key).cloned())
-}
-
-/// A `Str`-typed FIELD_DIR cell at surviving row `i`, as `&str`: `None` when the
-/// cell is NULL **or** when its bytes are not UTF-8.
-///
-/// Treating invalid UTF-8 as no value is what the row path does
-/// (`get_attr_value`'s `String::from_utf8(b).ok()`, `ravel-logseg`'s
-/// `reader.rs`), which makes the attribute absent for that record and lets the
-/// resource/scope value show through. Substituting U+FFFD instead would both
-/// invent a value and suppress that fallback, and this crate's rule is exact
-/// semantics by default.
-fn read_str_cell<'v>(view: &ColumnarBlockView<'v>, column_id: u32, i: usize) -> Option<&'v str> {
-    std::str::from_utf8(view.bytes_at(column_id, i)?).ok()
-}
-
-/// Read the value of a FIELD_DIR column at surviving row `i` as an
-/// [`AttrValue`], or `None` when the cell is NULL (or, for `Str`, not UTF-8;
-/// see [`read_str_cell`]).
-fn read_typed_cell(view: &ColumnarBlockView<'_>, col: AttrColumn, i: usize) -> Option<AttrValue> {
-    match col.ty {
-        FieldType::Str => {
-            read_str_cell(view, col.column_id, i).map(|s| AttrValue::Str(s.to_string()))
-        }
-        FieldType::I64 => view.i64_at(col.column_id, i).map(AttrValue::I64),
-        FieldType::F64 => view
-            .f64_bits_at(col.column_id, i)
-            .map(|bits| AttrValue::F64(f64::from_bits(bits))),
-        FieldType::Bool => view.bool_at(col.column_id, i).map(AttrValue::Bool),
-        FieldType::Bytes => view
-            .bytes_at(col.column_id, i)
-            .map(|b| AttrValue::Bytes(b.to_vec())),
-    }
 }
 
 /// Build one declared typed attribute column for surviving rows `start..end`
@@ -2775,7 +2830,7 @@ fn read_typed_cell(view: &ColumnarBlockView<'_>, col: AttrColumn, i: usize) -> O
 /// future declared `f64` slots in as one arm on both paths.
 fn build_declared_columnar_array(
     view: &ColumnarBlockView<'_>,
-    plan: &DeclaredPlan<'_>,
+    plan: &DeclaredPlan<'_, '_>,
     start: usize,
     end: usize,
     cache: &mut HashMap<u32, Arc<Vec<(String, AttrValue)>>>,
@@ -2843,19 +2898,20 @@ fn build_declared_columnar_array(
 ///   the page).
 /// - **Plain page** (`str_dict` returns `None`, or the key has no `Str`
 ///   FIELD_DIR column at all): a degenerate identity dictionary, one entry per
-///   non-null surviving row with keys `0..`, built from [`declared_merged_value`]
-///   exactly as the pre-dictionary code did. No hashing and no dedup pass, so
-///   this case stays exactly as expensive as it was.
+///   non-null surviving row with keys `0..`. The record's own `Str` value is read
+///   as `&str` straight from the [`BytesCursor`] into the builder, so no
+///   throwaway `String` is allocated per cell (deliverable 3, #875). No hashing
+///   and no dedup pass, so this case stays exactly as expensive as it was.
 fn build_declared_str_columnar(
     view: &ColumnarBlockView<'_>,
-    plan: &DeclaredPlan<'_>,
+    plan: &DeclaredPlan<'_, '_>,
     start: usize,
     end: usize,
     cache: &mut HashMap<u32, Arc<Vec<(String, AttrValue)>>>,
 ) -> DFResult<ArrayRef> {
     let n = end - start;
     Ok(
-        match plan.matching.and_then(|mc| view.str_dict(mc.column_id)) {
+        match plan.matching_col().and_then(|mc| view.str_dict(mc.column_id)) {
             Some(col) => {
                 // Dictionary values start as the page's distinct byte values,
                 // decoded to UTF-8; a non-UTF-8 entry becomes a NULL value. Ids
@@ -2874,12 +2930,12 @@ fn build_declared_str_columnar(
                 })?;
                 let mut keys: Vec<Option<i32>> = Vec::with_capacity(n);
                 for i in start..end {
-                    if plan.all_cols.iter().any(|&c| attr_present(view, c, i)) {
+                    if plan.record_sets_key(i) {
                         // Record wins. `id_at` is `Some` only when the record's
                         // `Str` column has a value at this row; `None` (record set
                         // the key in another-typed column) is a NULL cell. An `id`
                         // pointing at a non-UTF-8 (NULL) dictionary value also reads
-                        // NULL, matching `read_str_cell`.
+                        // NULL, matching the UTF-8 rule on the `Str` cursor.
                         match col.id_at(i) {
                             Some(id) => keys.push(Some(i32::try_from(id).map_err(|_| {
                                 DataFusionError::Internal(
@@ -2910,18 +2966,61 @@ fn build_declared_str_columnar(
                 Arc::new(dict)
             }
             None => {
-                // Identity dictionary: one entry per non-null row, no dedup.
+                // Identity dictionary: one entry per non-null row, no dedup. The
+                // record's own value is appended as `&str` straight from the
+                // cursor -- no per-cell `String` (deliverable 3, #875).
                 let mut values = StringBuilder::new();
                 let mut keys: Vec<Option<i32>> = Vec::with_capacity(n);
                 let mut next = 0i32;
+                // The declared-type (`Str`) column's cursor, when the key has a
+                // plain-page `Str` column; `None` when it has no `Str` column at
+                // all (then only the resource/scope fallback yields a value).
+                let matching_str = match plan.matching_cursor() {
+                    Some(DeclaredCursor::Str(c)) => Some(c),
+                    _ => None,
+                };
                 for i in start..end {
-                    match declared_merged_value(view, plan, i, cache)? {
-                        Some(AttrValue::Str(s)) => {
-                            values.append_value(&s);
+                    // `appended` == "this row is decided, do not consult the
+                    // resource/scope fallback" (record wins over resource).
+                    let mut appended = false;
+                    if plan.single_matching() {
+                        // Fused: one cursor read is both presence and value.
+                        if let Some(s) = matching_str.and_then(|c| c.str_at(i)) {
+                            values.append_value(s);
                             keys.push(Some(next));
                             next += 1;
+                            appended = true;
                         }
-                        _ => keys.push(None),
+                        // A `None` here (absent, or not UTF-8) falls through to
+                        // the fallback, matching the row path.
+                    } else if plan.record_sets_key(i) {
+                        // Record wins: its declared-type `Str` cell, or NULL when
+                        // it set the key only in a different-typed column.
+                        match matching_str.and_then(|c| c.str_at(i)) {
+                            Some(s) => {
+                                values.append_value(s);
+                                keys.push(Some(next));
+                                next += 1;
+                            }
+                            None => keys.push(None),
+                        }
+                        appended = true;
+                    }
+                    if appended {
+                        continue;
+                    }
+                    if let Some(stream_ref) = view.stream_ref(i) {
+                        let resource = resource_attrs(view, cache, stream_ref)?;
+                        match find_attr(resource, &plan.dc.key) {
+                            Some(AttrValue::Str(s)) => {
+                                values.append_value(s);
+                                keys.push(Some(next));
+                                next += 1;
+                            }
+                            _ => keys.push(None),
+                        }
+                    } else {
+                        keys.push(None);
                     }
                 }
                 let dict = DictionaryArray::<Int32Type>::try_new(
@@ -2957,21 +3056,15 @@ fn build_columnar_batches(
     row_refs: Option<RowRefRange>,
 ) -> DFResult<Vec<RecordBatch>> {
     let n = view.surviving_count();
-    // Resolve each projected declared column's FIELD_DIR column once for the
-    // whole block (ADR-0099 decision 2), not per row and not per chunk.
-    let mut plans: HashMap<usize, DeclaredPlan> = HashMap::new();
+    // Resolve each projected declared column's FIELD_DIR columns to cursors once
+    // for the whole block (ADR-0099 decision 2, #875), not per row and not per
+    // chunk: the row loop then reads through the cursors with no column lookup.
+    let mut plans: HashMap<usize, DeclaredPlan<'_, '_>> = HashMap::new();
     for &idx in projection {
         if idx >= FIRST_DECLARED_COL
             && let Some(dc) = declared.get(idx - FIRST_DECLARED_COL)
         {
-            plans.insert(
-                idx,
-                DeclaredPlan {
-                    dc,
-                    matching: view.resolve_attr(&dc.key, declared_field_type(dc.ty)),
-                    all_cols: view.attr_columns_for(&dc.key).collect(),
-                },
-            );
+            plans.insert(idx, DeclaredPlan::build(view, dc));
         }
     }
     let mut cache: HashMap<u32, Arc<Vec<(String, AttrValue)>>> = HashMap::new();
@@ -3006,7 +3099,7 @@ fn build_columnar_batch(
     view: &ColumnarBlockView<'_>,
     schema: &SchemaRef,
     projection: &[usize],
-    plans: &HashMap<usize, DeclaredPlan<'_>>,
+    plans: &HashMap<usize, DeclaredPlan<'_, '_>>,
     cache: &mut HashMap<u32, Arc<Vec<(String, AttrValue)>>>,
     start: usize,
     end: usize,
@@ -3015,25 +3108,35 @@ fn build_columnar_batch(
     let mut columns: Vec<ArrayRef> = Vec::with_capacity(projection.len());
     for &idx in projection {
         let array: ArrayRef = match idx {
-            LOG_COL_TS => Arc::new(TimestampNanosecondArray::from(
-                (start..end)
-                    .map(|i| view.ts(i).unwrap_or_default())
-                    .collect::<Vec<_>>(),
-            )),
-            LOG_COL_OBSERVED_TS => Arc::new(TimestampNanosecondArray::from(
-                (start..end)
-                    .map(|i| view.observed_ts(i).unwrap_or_default())
-                    .collect::<Vec<_>>(),
-            )),
-            LOG_COL_SEVERITY_NUM => Arc::new(UInt8Array::from(
-                (start..end)
-                    .map(|i| view.severity_num(i).unwrap_or_default() as u8)
-                    .collect::<Vec<_>>(),
-            )),
+            LOG_COL_TS => {
+                let cur = view.ts_cursor();
+                Arc::new(TimestampNanosecondArray::from(
+                    (start..end)
+                        .map(|i| cur.at(i).unwrap_or_default())
+                        .collect::<Vec<_>>(),
+                ))
+            }
+            LOG_COL_OBSERVED_TS => {
+                let cur = view.observed_ts_cursor();
+                Arc::new(TimestampNanosecondArray::from(
+                    (start..end)
+                        .map(|i| cur.at(i).unwrap_or_default())
+                        .collect::<Vec<_>>(),
+                ))
+            }
+            LOG_COL_SEVERITY_NUM => {
+                let cur = view.severity_num_cursor();
+                Arc::new(UInt8Array::from(
+                    (start..end)
+                        .map(|i| cur.at(i).unwrap_or_default() as u8)
+                        .collect::<Vec<_>>(),
+                ))
+            }
             LOG_COL_SEVERITY_TEXT => {
+                let cur = view.severity_text_cursor();
                 let mut b = StringBuilder::new();
                 for i in start..end {
-                    match view.severity_text(i) {
+                    match cur.at(i) {
                         Some(bytes) => b.append_value(view_str(bytes)?),
                         None => b.append_value(""),
                     }
@@ -3041,9 +3144,10 @@ fn build_columnar_batch(
                 Arc::new(b.finish())
             }
             LOG_COL_BODY => {
+                let cur = view.body_cursor();
                 let mut b = StringBuilder::new();
                 for i in start..end {
-                    match view.body(i) {
+                    match cur.at(i) {
                         Some(bytes) => b.append_value(view_str(bytes)?),
                         None => b.append_value(""),
                     }
@@ -3051,9 +3155,10 @@ fn build_columnar_batch(
                 Arc::new(b.finish())
             }
             LOG_COL_TRACE_ID => {
+                let cur = view.trace_id_cursor();
                 let mut b = FixedSizeBinaryBuilder::with_capacity(end - start, TRACE_ID_WIDTH);
                 for i in start..end {
-                    match view.trace_id(i) {
+                    match cur.at(i) {
                         Some(id) => b.append_value(id).map_err(|e| {
                             SqlError::Internal(format!("trace_id array build: {e}"))
                         })?,
@@ -3063,9 +3168,10 @@ fn build_columnar_batch(
                 Arc::new(b.finish())
             }
             LOG_COL_SPAN_ID => {
+                let cur = view.span_id_cursor();
                 let mut b = FixedSizeBinaryBuilder::with_capacity(end - start, SPAN_ID_WIDTH);
                 for i in start..end {
-                    match view.span_id(i) {
+                    match cur.at(i) {
                         Some(id) => b
                             .append_value(id)
                             .map_err(|e| SqlError::Internal(format!("span_id array build: {e}")))?,
@@ -3074,11 +3180,14 @@ fn build_columnar_batch(
                 }
                 Arc::new(b.finish())
             }
-            LOG_COL_FLAGS => Arc::new(UInt32Array::from(
-                (start..end)
-                    .map(|i| view.flags(i).unwrap_or_default() as u32)
-                    .collect::<Vec<_>>(),
-            )),
+            LOG_COL_FLAGS => {
+                let cur = view.flags_cursor();
+                Arc::new(UInt32Array::from(
+                    (start..end)
+                        .map(|i| cur.at(i).unwrap_or_default() as u32)
+                        .collect::<Vec<_>>(),
+                ))
+            }
             // Ruled out by `columnar_static_eligible`; a projection reaching the
             // fast path never carries the `attrs` map.
             LOG_COL_ATTRS => {

--- a/crates/ravel-sql/src/logs_scan.rs
+++ b/crates/ravel-sql/src/logs_scan.rs
@@ -2911,7 +2911,10 @@ fn build_declared_str_columnar(
 ) -> DFResult<ArrayRef> {
     let n = end - start;
     Ok(
-        match plan.matching_col().and_then(|mc| view.str_dict(mc.column_id)) {
+        match plan
+            .matching_col()
+            .and_then(|mc| view.str_dict(mc.column_id))
+        {
             Some(col) => {
                 // Dictionary values start as the page's distinct byte values,
                 // decoded to UTF-8; a non-UTF-8 entry becomes a NULL value. Ids
@@ -3215,4 +3218,114 @@ fn build_columnar_batch(
     let options = RecordBatchOptions::new().with_row_count(Some(end - start));
     RecordBatch::try_new_with_options(Arc::clone(schema), columns, &options)
         .map_err(DataFusionError::from)
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod columnar_lookup_tests {
+    use super::*;
+    use datafusion::arrow::array::{Array, Int64Array};
+    use ravel_logseg::record::stream_attrs_bytes;
+    use ravel_logseg::{
+        ColumnSelection, LogRecord, ObjectIdentity, Predicate, RlogConfig, RlogReader, RlogWriter,
+    };
+    use ravel_types::logstream::LogStreamId;
+
+    fn sid(n: u8) -> LogStreamId {
+        let mut a = [0u8; 16];
+        a[0] = n;
+        LogStreamId(a)
+    }
+
+    fn rec_k(ts: i64, k: Option<i64>) -> LogRecord {
+        LogRecord {
+            stream_id: sid(0),
+            stream_attrs: stream_attrs_bytes(
+                &[("service.name".into(), AttrValue::Str("svc".into()))],
+                "scope",
+                "1",
+                &[],
+            ),
+            ts_ns: ts,
+            observed_ts_ns: ts,
+            severity_num: 9,
+            severity_text: "INFO".into(),
+            body: "keep".into(),
+            trace_id: None,
+            span_id: None,
+            flags: 0,
+            attrs: k
+                .map(|v| vec![("k".to_string(), AttrValue::I64(v))])
+                .unwrap_or_default(),
+        }
+    }
+
+    /// Deliverable 2 (#875): for a single-matching-column declared scan the
+    /// presence test and the value read fuse to one cursor read, so the block's
+    /// declared column is resolved exactly once. The pre-change path ran
+    /// `attr_present` and then `read_typed_cell` -- two full cell reads, each
+    /// resolving the column by id -- for `2 * rows` resolutions per block.
+    /// Flipping the fused read back to that double read makes the count below
+    /// `2 * rows` instead of `1`.
+    #[test]
+    fn single_matching_declared_scan_reads_each_cell_once() {
+        let cfg = RlogConfig {
+            block_target_records: 16,
+            max_dynamic_columns: 8,
+            ..RlogConfig::default()
+        };
+        let mut w = RlogWriter::new(
+            cfg,
+            ObjectIdentity {
+                tenant_hash: [0; 16],
+                shard: 0,
+                writer_id: [0; 16],
+                writer_epoch: 0,
+                writer_seq: 0,
+            },
+        );
+        // Every row sets `k`, so the record always wins and no resource/scope
+        // fallback (which would resolve `stream_ref` per row) is consulted: the
+        // count isolates the declared column's own resolution.
+        for (ts, v) in [(100i64, 10i64), (101, 20), (102, 30), (103, 40)] {
+            w.push(rec_k(ts, Some(v))).expect("push");
+        }
+        let obj = w.finish().expect("finish");
+        let reader = RlogReader::new(&obj, &cfg).expect("open");
+        let mut scan = reader
+            .scan_blocks(&Predicate::And(Vec::new()), &[], &ColumnSelection::all())
+            .expect("scan");
+        let view = scan
+            .next_block_columnar(&obj)
+            .expect("columnar exit")
+            .expect("one block");
+        let rows = view.surviving_count();
+        assert_eq!(rows, 4);
+
+        let dc = DeclaredColumn::new("k", DeclaredType::I64);
+        let base = view.column_lookups();
+        let plan = DeclaredPlan::build(&view, &dc);
+        assert!(
+            plan.single_matching(),
+            "the key has exactly one FIELD_DIR column, of the declared type"
+        );
+        let mut cache = HashMap::new();
+        let arr = build_declared_columnar_array(&view, &plan, 0, rows, &mut cache)
+            .expect("declared array");
+        let lookups = view.column_lookups() - base;
+        assert_eq!(
+            lookups, 1,
+            "the declared column is resolved once per block, not 2*rows (the pre-change double read)"
+        );
+
+        let ints = arr
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("declared I64 array");
+        assert_eq!(ints.len(), 4);
+        for (i, want) in [10i64, 20, 30, 40].into_iter().enumerate() {
+            assert!(ints.is_valid(i), "row {i} is non-null");
+            assert_eq!(ints.value(i), want, "row {i}");
+        }
+    }
 }


### PR DESCRIPTION
perf(logseg): resolve scan columns once per block via per-column cursors

The columnar accessors resolved a column on every value. `i64_at` called
`block.i64_col(column_id)` per cell, and `DecodedBlock` stores its columns
in `HashMap<u32, _>` on std's default hasher, so a scan of N rows over one
column performed N SipHash lookups that all returned the same slice. A
block holds a handful of columns; the map is tiny and the hash dominated
the lookup entirely.

This resolves each column once per block and hands the scan a cursor, and
fuses the declared-attribute read that previously touched every declared
cell twice, once as a presence test and again to read it.

On the measurement that motivated this, `hash_one::<&u32>` was the single
largest self frame at 16.34%, with `sip::Hasher::write` a further 4.04%,
and the two `i64_at` variants immediately below them at 7.79% and 6.27%.

What that figure does NOT establish, stated plainly because the campaign
has already retracted one projection built this way: it was measured over
FOUR statements worth 7.8% of the hot total, so it does not license a
claim about the whole pass. A full-corpus frame-pointer profile is
pre-registered on #876 with bands, and the payoff needs a wall-clock
figure from a full pass, not a CPU share. This PR is offered on the
mechanism and its tests, not on a predicted speedup.

An earlier attempt at this area (#847) targeted column-id membership in
decode and doubted its own effect, citing that only 178 of 20,310 SipHash
samples resolved to a ravel_* frame. That ratio was DWARF unwind failure,
not evidence: rebuilding with frame pointers takes the unattributed share
from 33.95% to 0.00% and the hash resolves to these accessors.

Refs: #876, #680
