### PR TITLE
feat(sql): answer q02/q08 and MIN/MAX from folded column statistics (ADR-0850)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4566,6 +4566,7 @@ dependencies = [
  "prost",
  "ravel-cache",
  "ravel-commit",
+ "ravel-logseg",
  "ravel-object-store",
  "ravel-proto",
  "ravel-segment",

--- a/crates/ravel-catalog/Cargo.toml
+++ b/crates/ravel-catalog/Cargo.toml
@@ -11,6 +11,7 @@ ravel-proto = { workspace = true }
 ravel-commit = { workspace = true }
 ravel-object-store = { workspace = true }
 ravel-segment = { workspace = true }
+ravel-logseg = { workspace = true }
 ravel-cache = { workspace = true }
 prost = { workspace = true }
 uuid = { workspace = true }

--- a/crates/ravel-catalog/src/cache.rs
+++ b/crates/ravel-catalog/src/cache.rs
@@ -699,6 +699,7 @@ mod tests {
             folder_id: uuid::Uuid::new_v4().into_bytes().to_vec(),
             created_unix_ns: 0,
             shard_generation_count: 1,
+            column_stats: None,
         }
     }
 

--- a/crates/ravel-catalog/src/catalog.rs
+++ b/crates/ravel-catalog/src/catalog.rs
@@ -751,8 +751,17 @@ impl Catalog {
         &self,
         tenant: &TenantHash,
         signal: Signal,
+        accounting: &QueryAccounting,
     ) -> Result<Option<LoadedColumnStats>, LoadColumnStatsError> {
-        column_stats_resolve::load_column_stats(self.store(), tenant, signal).await
+        // Route every GET through the same semaphore-bounded, accounted funnel
+        // (`guarded_get`) every other query read uses, so this path's requests
+        // and bytes are credited to `accounting` under `AccountedOp::Get` and
+        // bounded by the request semaphore (issue #850).
+        let getter = GuardedRecordGet {
+            catalog: self,
+            accounting,
+        };
+        column_stats_resolve::load_column_stats(&getter, tenant, signal).await
     }
 
     /// Evict every per-tenant cache outer-map entry for tenants last touched
@@ -5202,5 +5211,145 @@ mod tests {
             other => panic!("expected tenant_hash FieldMismatch, got {other:?}"),
         }
         assert_eq!(catalog.isolation_breaches(), 2);
+    }
+
+    /// Issue #850, Finding 1: `load_column_stats` routes every GET through the
+    /// accounted, semaphore-bounded funnel (`guarded_get`), so the caller's
+    /// `QueryAccounting` counts them under `AccountedOp::Get`. The exact charge
+    /// is TWO GETs -- the HEAD and the one column-stats object -- and no snapshot
+    /// part is fetched (Finding 2). A regression that re-added the raw
+    /// `store.get` path would credit zero requests; one that re-added the
+    /// per-part GET would credit three. Both fail this assertion.
+    #[tokio::test]
+    async fn load_column_stats_charges_exactly_two_accounted_gets() {
+        let store = Arc::new(MemoryStore::new());
+        let signal = Signal::Logs;
+        let signal_num = signal::to_proto(signal) as u32;
+
+        // One empty snapshot part.
+        let part_bytes =
+            crate::snapshot_format::encode_part(tenant().0, signal_num, 8, 10, &[]).expect("part");
+        let part_hash = *blake3::hash(&part_bytes).as_bytes();
+        let part_key = format!("t/{}/catalog/l/snap/empty.csnap", tenant().to_hex());
+        store
+            .put(
+                &part_key,
+                Bytes::from(part_bytes.clone()),
+                PutOptions::default(),
+            )
+            .await
+            .expect("put part");
+
+        // A consistent single-segment column-stats object bound to that part.
+        let segments = vec![ravel_proto::catalog::v1::ColumnStatsSegment {
+            ingest_hour_bucket: 1,
+            shard: 0,
+            writer_id: vec![0xAA; 16],
+            writer_epoch: 1,
+            writer_seq: 1,
+            columns: vec![ravel_proto::catalog::v1::ColumnStat {
+                name: "status".to_string(),
+                declared_type: 2,
+                non_null_count: 1,
+                null_count: 0,
+                min: Some(ravel_proto::catalog::v1::ColumnValue {
+                    kind: Some(ravel_proto::catalog::v1::column_value::Kind::I64(1)),
+                }),
+                max: Some(ravel_proto::catalog::v1::ColumnValue {
+                    kind: Some(ravel_proto::catalog::v1::column_value::Kind::I64(1)),
+                }),
+                dictionary_present: true,
+                dictionary: vec![ravel_proto::catalog::v1::DictEntry {
+                    value: Some(ravel_proto::catalog::v1::ColumnValue {
+                        kind: Some(ravel_proto::catalog::v1::column_value::Kind::I64(1)),
+                    }),
+                    count: 1,
+                }],
+            }],
+        }];
+        let stats_bytes = crate::snapshot_format::encode_column_stats(
+            tenant().0,
+            signal_num,
+            vec![part_hash.to_vec()],
+            &segments,
+        )
+        .expect("encode column stats");
+        let stats_hash = *blake3::hash(&stats_bytes).as_bytes();
+        let stats_key = format!("t/{}/catalog/l/cstat/one.cstat", tenant().to_hex());
+        store
+            .put(
+                &stats_key,
+                Bytes::from(stats_bytes.clone()),
+                PutOptions::default(),
+            )
+            .await
+            .expect("put stats");
+
+        let head = ravel_proto::catalog::v1::SnapshotHead {
+            format_version: crate::snapshot_format::HEAD_FORMAT_VERSION,
+            tenant_hash: tenant().0.to_vec(),
+            signal: signal_num,
+            shard_count: 8,
+            watermark_hour: 10,
+            parts: vec![ravel_proto::catalog::v1::SnapshotPartRef {
+                key: part_key,
+                blake3: part_hash.to_vec(),
+                size: part_bytes.len() as u64,
+                entry_count: 0,
+                watermark_hour: 10,
+                min_hour: 0,
+            }],
+            folder_id: Uuid::new_v4().into_bytes().to_vec(),
+            created_unix_ns: 0,
+            postings: None,
+            shard_generation_count: 1,
+            column_stats: Some(ravel_proto::catalog::v1::SnapshotColumnStatsRef {
+                key: stats_key,
+                blake3: stats_hash.to_vec(),
+                size: stats_bytes.len() as u64,
+                segment_count: 1,
+                part_blake3: vec![part_hash.to_vec()],
+            }),
+        };
+        let head_bytes = crate::snapshot_format::encode_head(&head).expect("encode head");
+        store
+            .put(
+                &crate::fold::head_object_key(&tenant(), signal),
+                Bytes::from(head_bytes),
+                PutOptions::default(),
+            )
+            .await
+            .expect("put head");
+
+        let catalog = Catalog::new(store.clone(), config(8)).expect("catalog");
+        let acc = QueryAccounting::new();
+        let loaded = catalog
+            .load_column_stats(&tenant(), signal, &acc)
+            .await
+            .expect("load ok")
+            .expect("stats present");
+        assert_eq!(loaded.segments.len(), 1, "the one segment's stats loaded");
+
+        let snap = acc.snapshot();
+        assert_eq!(
+            snap.s3_requests(AccountedOp::Get),
+            2,
+            "exactly the HEAD GET and the column-stats GET, no per-part GET"
+        );
+        assert_eq!(
+            snap.s3_requests(AccountedOp::List),
+            0,
+            "no listing on this path"
+        );
+        assert_eq!(
+            snap.s3_requests(AccountedOp::Head),
+            0,
+            "no HEAD op on this path"
+        );
+        assert_eq!(
+            catalog.request_semaphore.available_permits(),
+            MAX_CONCURRENT_REQUESTS,
+            "every acquired permit was released"
+        );
     }
 }

--- a/crates/ravel-catalog/src/catalog.rs
+++ b/crates/ravel-catalog/src/catalog.rs
@@ -26,6 +26,7 @@ use tracing::Instrument;
 use uuid::Uuid;
 
 use crate::cache::{CompactionRecordCache, HeadCache, PartCache, PostingsCache, RecordCache};
+use crate::column_stats_resolve::{self, LoadColumnStatsError, LoadedColumnStats};
 use crate::config::CatalogConfig;
 use crate::error::CatalogError;
 use crate::provisioning::ShardGeneration;
@@ -735,6 +736,23 @@ impl Catalog {
     /// `pub(crate)`: lets `snapshot_resolve` share the decoded-part cache.
     pub(crate) fn part_cache(&self) -> &PartCache {
         &self.part_cache
+    }
+
+    /// Resolve exact per-segment column statistics for `(tenant, signal)`
+    /// from the current folded snapshot HEAD (ADR-0850), for a query engine
+    /// to join against its own resolved snapshot by identity. `Ok(None)`
+    /// means no usable column-stats object exists right now (nothing folded
+    /// yet, no configured typed columns, or the last fold's column-stats
+    /// build/PUT failed): the caller must fall back to scanning, never treat
+    /// this as "zero columns configured means zero rows". See
+    /// [`column_stats_resolve::load_column_stats`] for the full
+    /// degrade-to-`Ok(None)` contract.
+    pub async fn load_column_stats(
+        &self,
+        tenant: &TenantHash,
+        signal: Signal,
+    ) -> Result<Option<LoadedColumnStats>, LoadColumnStatsError> {
+        column_stats_resolve::load_column_stats(self.store(), tenant, signal).await
     }
 
     /// Evict every per-tenant cache outer-map entry for tenants last touched

--- a/crates/ravel-catalog/src/catalog.rs
+++ b/crates/ravel-catalog/src/catalog.rs
@@ -3360,6 +3360,7 @@ mod tests {
             folder_id: Uuid::new_v4().into_bytes().to_vec(),
             created_unix_ns: 0,
             shard_generation_count: 1,
+            column_stats: None,
         }
     }
 
@@ -3856,6 +3857,7 @@ mod tests {
             created_unix_ns: 0,
             postings: None,
             shard_generation_count: 1,
+            column_stats: None,
         };
         let head_bytes = crate::snapshot_format::encode_head(&head).expect("encode head");
         store
@@ -3953,6 +3955,7 @@ mod tests {
             created_unix_ns: 0,
             postings: None,
             shard_generation_count: 2,
+            column_stats: None,
         };
         let head_bytes = crate::snapshot_format::encode_head(&head).expect("encode head");
         inner

--- a/crates/ravel-catalog/src/column_stats_build.rs
+++ b/crates/ravel-catalog/src/column_stats_build.rs
@@ -488,7 +488,7 @@ mod tests {
             observed_ts_ns: ts,
             severity_num: 9,
             severity_text: "INFO".into(),
-            body: format!("body {ts}").into(),
+            body: format!("body {ts}"),
             trace_id: None,
             span_id: None,
             flags: 0,

--- a/crates/ravel-catalog/src/column_stats_build.rs
+++ b/crates/ravel-catalog/src/column_stats_build.rs
@@ -448,3 +448,166 @@ pub(crate) fn decode_previous_column_stats(
     }
     Ok(decoded.segments)
 }
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use ravel_logseg::writer::ObjectIdentity;
+    use ravel_logseg::{LogRecord, RlogConfig, RlogWriter, stream_attrs_bytes};
+    use ravel_object_store::memory::MemoryStore;
+    use ravel_object_store::{ObjectStoreBackend, PutOptions};
+    use ravel_proto::catalog::v1::SnapshotEntry;
+    use ravel_proto::catalog::v1::column_value::Kind;
+    use ravel_types::logstream::{AttrValue, log_stream_id};
+
+    const TENANT: TenantHash = TenantHash([0x5a; 16]);
+    const WRITER: u128 = 0x1111_2222_3333_4444_5555_6666_7777_8888;
+
+    fn identity() -> ObjectIdentity {
+        ObjectIdentity {
+            tenant_hash: TENANT.0,
+            shard: 0,
+            writer_id: *Uuid::from_u128(WRITER).as_bytes(),
+            writer_epoch: 1,
+            writer_seq: 1,
+        }
+    }
+
+    /// One log record on the single `service.name = api` stream carrying the
+    /// given dynamic attributes.
+    fn record(ts: i64, attrs: &[(String, AttrValue)]) -> LogRecord {
+        let resource = vec![(
+            "service.name".to_string(),
+            AttrValue::Str("api".to_string()),
+        )];
+        LogRecord {
+            stream_id: log_stream_id(&resource, "scope", "1.0", &[]),
+            stream_attrs: stream_attrs_bytes(&resource, "scope", "1.0", &[]),
+            ts_ns: ts,
+            observed_ts_ns: ts,
+            severity_num: 9,
+            severity_text: "INFO".into(),
+            body: format!("body {ts}").into(),
+            trace_id: None,
+            span_id: None,
+            flags: 0,
+            attrs: attrs.to_vec(),
+        }
+    }
+
+    fn i64_attr(key: &str, v: i64) -> (String, AttrValue) {
+        (key.to_string(), AttrValue::I64(v))
+    }
+
+    /// Write `records` as a real L0 RLOG object onto `store` at its true
+    /// `data_key`, and return the matching L0 [`SnapshotEntry`]. Blocks are cut
+    /// every 3 records so the tally spans several blocks.
+    async fn write_l0(store: &dyn ObjectStoreBackend, records: &[LogRecord]) -> SnapshotEntry {
+        let cfg = RlogConfig {
+            block_target_records: 3,
+            ..RlogConfig::default()
+        };
+        let mut w = RlogWriter::new(cfg, identity());
+        for r in records {
+            w.push(r.clone()).expect("push");
+        }
+        let bytes = w.finish().expect("finish");
+        let content_hash = *blake3::hash(&bytes).as_bytes();
+        let writer_id = Uuid::from_u128(WRITER);
+        let key =
+            ravel_commit::keys::data_key(&TENANT, Signal::Logs, 0, writer_id, 1, 1, &content_hash)
+                .expect("data key");
+        store
+            .put(&key, bytes::Bytes::from(bytes), PutOptions::default())
+            .await
+            .expect("put");
+
+        SnapshotEntry {
+            level: 0,
+            shard: 0,
+            ingest_hour_bucket: 0,
+            writer_id: writer_id.into_bytes().to_vec(),
+            writer_epoch: 1,
+            writer_seq: 1,
+            content_hash: content_hash.to_vec(),
+            object_size: 0,
+            min_event_ts_ns: 0,
+            max_event_ts_ns: 0,
+            sample_count: records.len() as u64,
+            series_count: 0,
+            segment_format_version: 1,
+            created_unix_ns: 0,
+        }
+    }
+
+    fn declared(key: &str, ty: DeclaredColumnType) -> DeclaredTypedColumn {
+        DeclaredTypedColumn {
+            key: key.to_string(),
+            ty,
+        }
+    }
+
+    fn i64_kind(v: &ColumnValue) -> i64 {
+        match &v.kind {
+            Some(Kind::I64(x)) => *x,
+            other => panic!("expected I64 column value, got {other:?}"),
+        }
+    }
+
+    /// The statistics a segment gets are the exact values its rows imply: a
+    /// six-row object where `status` is 200,200,404,200,<absent>,500 yields
+    /// non_null_count 5, null_count 1, the exact per-value dictionary, and
+    /// min/max 200/500. A declared column no row sets (`absent`) gets no entry
+    /// at all, and a dynamic attribute that is not declared (`extra`) is never
+    /// tallied.
+    #[tokio::test]
+    async fn segment_stats_are_the_exact_values_the_rows_imply() {
+        let store = MemoryStore::new();
+        let records = vec![
+            record(1, &[i64_attr("status", 200), i64_attr("extra", 7)]),
+            record(2, &[i64_attr("status", 200)]),
+            record(3, &[i64_attr("status", 404)]),
+            record(4, &[i64_attr("status", 200)]),
+            record(5, &[]), // no status: one null
+            record(6, &[i64_attr("status", 500)]),
+        ];
+        let entry = write_l0(&store, &records).await;
+
+        let typed = vec![
+            declared("status", DeclaredColumnType::I64),
+            declared("absent", DeclaredColumnType::I64),
+        ];
+        let seg = fetch_segment_column_stats(&store, &TENANT, Signal::Logs, &entry, &typed)
+            .await
+            .expect("build stats");
+
+        assert_eq!(
+            seg.columns.len(),
+            1,
+            "only `status` is present and declared"
+        );
+        let status = &seg.columns[0];
+        assert_eq!(status.name, "status");
+        assert_eq!(status.declared_type, 2, "I64 stats tag");
+        assert_eq!(status.non_null_count, 5, "five rows set status");
+        assert_eq!(status.null_count, 1, "row 5 left status absent");
+        assert!(
+            status.dictionary_present,
+            "cardinality is well under the ceiling"
+        );
+
+        let dict: Vec<(i64, u64)> = status
+            .dictionary
+            .iter()
+            .map(|e| (i64_kind(e.value.as_ref().expect("value")), e.count))
+            .collect();
+        assert_eq!(
+            dict,
+            vec![(200, 3), (404, 1), (500, 1)],
+            "exact per-value counts, ascending"
+        );
+        assert_eq!(i64_kind(status.min.as_ref().expect("min")), 200);
+        assert_eq!(i64_kind(status.max.as_ref().expect("max")), 500);
+    }
+}

--- a/crates/ravel-catalog/src/column_stats_build.rs
+++ b/crates/ravel-catalog/src/column_stats_build.rs
@@ -1,0 +1,450 @@
+//! Fold-time exact per-object column statistics for configured typed logs
+//! attribute columns (ADR-0850). Sibling artifact to the name-postings index
+//! (`fold.rs`'s `build_postings`/`fetch_segment_names`): same identity model,
+//! deliberately different failure discipline.
+//!
+//! A single segment's fetch, decode, or tally failure drops ONLY that
+//! segment from the output (it simply gets no `ColumnStatsSegment` entry,
+//! which the query-time reader treats as "no stats for this segment, force
+//! scan fallback") -- never aborts the whole fold's column-stats artifact.
+//! This is the opposite of `build_postings`'s all-or-nothing discipline, by
+//! design: a name-postings index is one flat cross-segment structure with no
+//! meaningful notion of "partially built", while column statistics are
+//! naturally per-segment and independently useful.
+//!
+//! Only L0 entries carry real writer identity (`fold.rs`'s
+//! `build_l1_snapshot_entry`: an L1 entry's writer_id/writer_epoch slots are
+//! repurposed for input_set_hash/part_index), so column-stats coverage is
+//! restricted to `entry.level == 0`. An L1 segment simply has no
+//! `ColumnStatsSegment` entry and its queries fall back to scanning, exactly
+//! like any other segment lacking stats.
+
+use ravel_logseg::{ColumnSelection, FieldType, LogSegError, Predicate, RlogConfig, RlogReader};
+use ravel_object_store::{GetRange, ObjectStoreBackend, StoreError};
+use ravel_proto::catalog::v1::{ColumnStat, ColumnStatsSegment, ColumnValue, DictEntry};
+use ravel_types::{Signal, TenantHash};
+use uuid::Uuid;
+
+use crate::snapshot_format::{DEFAULT_MAX_COLUMN_DICTIONARY_ENTRIES, SnapshotFormatError};
+use crate::tenant_config::{DeclaredColumnType, DeclaredTypedColumn};
+
+/// A failure building one segment's column statistics. Every variant is
+/// caught by the caller, logged, and turned into "this segment has no
+/// column-stats entry" -- never surfaced as a [`crate::error::CatalogError`].
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum ColumnStatsBuildError {
+    #[error("store error: {0}")]
+    Store(#[from] StoreError),
+    #[error("key error: {0}")]
+    Key(#[from] ravel_commit::keys::KeyError),
+    #[error("log segment error: {0}")]
+    LogSeg(#[from] LogSegError),
+    #[error("entry content_hash must be 32 bytes, got {0}")]
+    BadContentHashLen(usize),
+    #[error("entry writer_id must be 16 bytes, got {0}")]
+    BadWriterIdLen(usize),
+    #[error("column {name:?} declared Str but stored bytes are not valid UTF-8")]
+    NonUtf8StrValue { name: String },
+}
+
+/// Maps [`DeclaredColumnType`] to the `ravel.sys.v1.TypedAttrColumnType`
+/// proto tag `ColumnStat.declared_type` stores (same convention as
+/// `SnapshotPartHeader.signal`: an i32 tag with no cross-file proto import).
+/// `DeclaredColumnType::to_proto` in `tenant_config.rs` is module-private, so
+/// this duplicates its match arms rather than reusing it. Kept strictly
+/// distinct from [`declared_type_to_field_type`]: the two enums this
+/// function and that one map to are numbered differently (BOOL=3/BYTES=4
+/// here vs. Bool=4/Bytes=5 there) and must never be conflated.
+fn declared_type_to_stats_tag(ty: DeclaredColumnType) -> u32 {
+    match ty {
+        DeclaredColumnType::Str => 1,
+        DeclaredColumnType::I64 => 2,
+        DeclaredColumnType::Bool => 3,
+        DeclaredColumnType::Bytes => 4,
+    }
+}
+
+/// Maps [`DeclaredColumnType`] to the [`ravel_logseg::FieldType`] used to
+/// resolve a configured column against a logs object's `FIELD_DIR` via
+/// [`ravel_logseg::ColumnarBlockView::resolve_attr`]. See
+/// [`declared_type_to_stats_tag`] for why this is a separate mapping.
+fn declared_type_to_field_type(ty: DeclaredColumnType) -> FieldType {
+    match ty {
+        DeclaredColumnType::Str => FieldType::Str,
+        DeclaredColumnType::I64 => FieldType::I64,
+        DeclaredColumnType::Bool => FieldType::Bool,
+        DeclaredColumnType::Bytes => FieldType::Bytes,
+    }
+}
+
+fn column_value_i64(v: i64) -> ColumnValue {
+    ColumnValue {
+        kind: Some(ravel_proto::catalog::v1::column_value::Kind::I64(v)),
+    }
+}
+
+fn column_value_bool(v: bool) -> ColumnValue {
+    ColumnValue {
+        kind: Some(ravel_proto::catalog::v1::column_value::Kind::B(v)),
+    }
+}
+
+fn column_value_str(v: String) -> ColumnValue {
+    ColumnValue {
+        kind: Some(ravel_proto::catalog::v1::column_value::Kind::StrUtf8(v)),
+    }
+}
+
+fn column_value_bytes(v: Vec<u8>) -> ColumnValue {
+    ColumnValue {
+        kind: Some(ravel_proto::catalog::v1::column_value::Kind::BytesVal(v)),
+    }
+}
+
+/// Folds `value` into `min`/`max` (exact, always tracked) and into `dict`
+/// (exact up to [`DEFAULT_MAX_COLUMN_DICTIONARY_ENTRIES`] distinct values,
+/// after which `dict` is permanently cleared to `None` -- never truncated to
+/// a partial, silently-wrong-looking dictionary).
+fn fold_value<T: Ord + Clone>(
+    min: &mut Option<T>,
+    max: &mut Option<T>,
+    dict: &mut Option<std::collections::BTreeMap<T, u64>>,
+    value: T,
+) {
+    match min {
+        Some(m) if *m <= value => {}
+        _ => *min = Some(value.clone()),
+    }
+    match max {
+        Some(m) if *m >= value => {}
+        _ => *max = Some(value.clone()),
+    }
+    if let Some(map) = dict {
+        *map.entry(value).or_insert(0) += 1;
+        if map.len() > DEFAULT_MAX_COLUMN_DICTIONARY_ENTRIES {
+            *dict = None;
+        }
+    }
+}
+
+enum TallyState {
+    I64 {
+        min: Option<i64>,
+        max: Option<i64>,
+        dict: Option<std::collections::BTreeMap<i64, u64>>,
+    },
+    Bool {
+        min: Option<bool>,
+        max: Option<bool>,
+        dict: Option<std::collections::BTreeMap<bool, u64>>,
+    },
+    Str {
+        min: Option<String>,
+        max: Option<String>,
+        dict: Option<std::collections::BTreeMap<String, u64>>,
+    },
+    Bytes {
+        min: Option<Vec<u8>>,
+        max: Option<Vec<u8>>,
+        dict: Option<std::collections::BTreeMap<Vec<u8>, u64>>,
+    },
+}
+
+struct ColumnTally {
+    ty: DeclaredColumnType,
+    non_null_count: u64,
+    null_count: u64,
+    state: TallyState,
+}
+
+impl ColumnTally {
+    fn new(ty: DeclaredColumnType) -> Self {
+        let state = match ty {
+            DeclaredColumnType::I64 => TallyState::I64 {
+                min: None,
+                max: None,
+                dict: Some(std::collections::BTreeMap::new()),
+            },
+            DeclaredColumnType::Bool => TallyState::Bool {
+                min: None,
+                max: None,
+                dict: Some(std::collections::BTreeMap::new()),
+            },
+            DeclaredColumnType::Str => TallyState::Str {
+                min: None,
+                max: None,
+                dict: Some(std::collections::BTreeMap::new()),
+            },
+            DeclaredColumnType::Bytes => TallyState::Bytes {
+                min: None,
+                max: None,
+                dict: Some(std::collections::BTreeMap::new()),
+            },
+        };
+        Self {
+            ty,
+            non_null_count: 0,
+            null_count: 0,
+            state,
+        }
+    }
+
+    fn observe_i64(&mut self, v: Option<i64>) {
+        match v {
+            None => self.null_count += 1,
+            Some(x) => {
+                self.non_null_count += 1;
+                if let TallyState::I64 { min, max, dict } = &mut self.state {
+                    fold_value(min, max, dict, x);
+                }
+            }
+        }
+    }
+
+    fn observe_bool(&mut self, v: Option<bool>) {
+        match v {
+            None => self.null_count += 1,
+            Some(x) => {
+                self.non_null_count += 1;
+                if let TallyState::Bool { min, max, dict } = &mut self.state {
+                    fold_value(min, max, dict, x);
+                }
+            }
+        }
+    }
+
+    fn observe_bytes(&mut self, v: Option<&[u8]>) {
+        match v {
+            None => self.null_count += 1,
+            Some(x) => {
+                self.non_null_count += 1;
+                if let TallyState::Bytes { min, max, dict } = &mut self.state {
+                    fold_value(min, max, dict, x.to_vec());
+                }
+            }
+        }
+    }
+
+    /// Str columns are stored the same way Bytes columns are
+    /// (`ColumnarBlockView::bytes_at` unifies string-dictionary and
+    /// fixed-bytes storage), so the raw cell is validated as UTF-8 here
+    /// before folding. A configured Str column whose stored bytes are not
+    /// valid UTF-8 indicates the object's declared type disagrees with what
+    /// was actually written; this aborts just this segment's build (the
+    /// caller drops it entirely), never emits a lossy or reinterpreted
+    /// value.
+    fn observe_str(&mut self, v: Option<&[u8]>, name: &str) -> Result<(), ColumnStatsBuildError> {
+        match v {
+            None => {
+                self.null_count += 1;
+                Ok(())
+            }
+            Some(x) => {
+                let s = std::str::from_utf8(x)
+                    .map_err(|_| ColumnStatsBuildError::NonUtf8StrValue {
+                        name: name.to_string(),
+                    })?
+                    .to_string();
+                self.non_null_count += 1;
+                if let TallyState::Str { min, max, dict } = &mut self.state {
+                    fold_value(min, max, dict, s);
+                }
+                Ok(())
+            }
+        }
+    }
+
+    fn into_proto(self, name: String) -> ColumnStat {
+        let declared_type = declared_type_to_stats_tag(self.ty);
+        let (min, max, dictionary_present, dictionary) = match self.state {
+            TallyState::I64 { min, max, dict } => (
+                min.map(column_value_i64),
+                max.map(column_value_i64),
+                dict.is_some(),
+                dict.unwrap_or_default()
+                    .into_iter()
+                    .map(|(v, count)| DictEntry {
+                        value: Some(column_value_i64(v)),
+                        count,
+                    })
+                    .collect(),
+            ),
+            TallyState::Bool { min, max, dict } => (
+                min.map(column_value_bool),
+                max.map(column_value_bool),
+                dict.is_some(),
+                dict.unwrap_or_default()
+                    .into_iter()
+                    .map(|(v, count)| DictEntry {
+                        value: Some(column_value_bool(v)),
+                        count,
+                    })
+                    .collect(),
+            ),
+            TallyState::Str { min, max, dict } => (
+                min.map(column_value_str),
+                max.map(column_value_str),
+                dict.is_some(),
+                dict.unwrap_or_default()
+                    .into_iter()
+                    .map(|(v, count)| DictEntry {
+                        value: Some(column_value_str(v)),
+                        count,
+                    })
+                    .collect(),
+            ),
+            TallyState::Bytes { min, max, dict } => (
+                min.map(column_value_bytes),
+                max.map(column_value_bytes),
+                dict.is_some(),
+                dict.unwrap_or_default()
+                    .into_iter()
+                    .map(|(v, count)| DictEntry {
+                        value: Some(column_value_bytes(v)),
+                        count,
+                    })
+                    .collect(),
+            ),
+        };
+        ColumnStat {
+            name,
+            declared_type,
+            non_null_count: self.non_null_count,
+            null_count: self.null_count,
+            min,
+            max,
+            dictionary_present,
+            dictionary,
+        }
+    }
+}
+
+/// Fetches one L0 logs segment and tallies exact per-column statistics for
+/// every column in `typed_columns`, over every row in the object (no content
+/// filter: `Predicate::And(vec![])` is vacuously true, matching the
+/// full-object scan `LogsScanExec`'s metadata-only path already relies on
+/// for `COUNT(*)`).
+///
+/// A configured column absent from this object's `FIELD_DIR` -- because no
+/// row ever set it, or because it overflowed into `attrs_raw` (the overflow
+/// decision is made once per `(name, type)` for the whole object, so the two
+/// cases are indistinguishable from here) -- gets no entry in the returned
+/// segment's `columns` list at all, never a zero-filled stand-in: the reader
+/// treats a missing column entry as "no stats for this segment, force
+/// fallback," which is the only safe answer when overflow can't be ruled
+/// out.
+pub(crate) async fn fetch_segment_column_stats(
+    store: &dyn ObjectStoreBackend,
+    tenant: &TenantHash,
+    signal: Signal,
+    entry: &ravel_proto::catalog::v1::SnapshotEntry,
+    typed_columns: &[DeclaredTypedColumn],
+) -> Result<ColumnStatsSegment, ColumnStatsBuildError> {
+    debug_assert_eq!(entry.level, 0, "column stats are only built for L0 entries");
+
+    let content_hash: [u8; 32] = entry
+        .content_hash
+        .as_slice()
+        .try_into()
+        .map_err(|_| ColumnStatsBuildError::BadContentHashLen(entry.content_hash.len()))?;
+    let writer_id_bytes: [u8; 16] = entry
+        .writer_id
+        .as_slice()
+        .try_into()
+        .map_err(|_| ColumnStatsBuildError::BadWriterIdLen(entry.writer_id.len()))?;
+    let writer_id = Uuid::from_bytes(writer_id_bytes);
+    let data_key = ravel_commit::keys::data_key(
+        tenant,
+        signal,
+        entry.shard,
+        writer_id,
+        entry.writer_epoch,
+        entry.writer_seq,
+        &content_hash,
+    )?;
+    let got = store.get(&data_key, GetRange::Full).await?;
+
+    let cfg = RlogConfig::default();
+    let reader = RlogReader::new(&got.data, &cfg)?;
+
+    let mut selection = ColumnSelection::fixed_only();
+    for col in typed_columns {
+        selection = selection.with_attr(col.key.clone());
+    }
+
+    let mut tallies: std::collections::BTreeMap<String, ColumnTally> =
+        std::collections::BTreeMap::new();
+    let mut scan = reader.scan_blocks(&Predicate::And(vec![]), &[], &selection)?;
+    while let Some(view) = scan.next_block_columnar(&got.data)? {
+        for col in typed_columns {
+            let field_ty = declared_type_to_field_type(col.ty);
+            let Some(attr) = view.resolve_attr(&col.key, field_ty) else {
+                continue;
+            };
+            let tally = tallies
+                .entry(col.key.clone())
+                .or_insert_with(|| ColumnTally::new(col.ty));
+            match col.ty {
+                DeclaredColumnType::I64 => {
+                    for v in view.iter_i64(attr.column_id) {
+                        tally.observe_i64(v);
+                    }
+                }
+                DeclaredColumnType::Bool => {
+                    for v in view.iter_bool(attr.column_id) {
+                        tally.observe_bool(v);
+                    }
+                }
+                DeclaredColumnType::Str => {
+                    for v in view.iter_bytes(attr.column_id) {
+                        tally.observe_str(v, &col.key)?;
+                    }
+                }
+                DeclaredColumnType::Bytes => {
+                    for v in view.iter_bytes(attr.column_id) {
+                        tally.observe_bytes(v);
+                    }
+                }
+            }
+        }
+    }
+
+    let columns = tallies
+        .into_iter()
+        .map(|(name, tally)| tally.into_proto(name))
+        .collect();
+
+    Ok(ColumnStatsSegment {
+        ingest_hour_bucket: entry.ingest_hour_bucket,
+        shard: entry.shard,
+        writer_id: entry.writer_id.clone(),
+        writer_epoch: entry.writer_epoch,
+        writer_seq: entry.writer_seq,
+        columns,
+    })
+}
+
+/// Decodes and part-binding-checks the previous fold's column-stats
+/// baseline. An `Err` here means "reuse nothing, rebuild every segment's
+/// stats from scratch" -- the same fallback discipline `load_previous_postings`
+/// applies, just without a cache layer (column stats have no
+/// `postings_cache()`-equivalent: they are fetched fresh from the store every
+/// fold).
+pub(crate) fn decode_previous_column_stats(
+    bytes: &[u8],
+    expected_part_blake3: &[[u8; 32]],
+    limits: &crate::snapshot_format::ColumnStatsLimits,
+) -> Result<Vec<ColumnStatsSegment>, SnapshotFormatError> {
+    let decoded = crate::snapshot_format::decode_column_stats(bytes, limits)?;
+    let actual: Result<Vec<[u8; 32]>, _> = decoded
+        .header
+        .part_blake3
+        .iter()
+        .map(|h| <[u8; 32]>::try_from(h.as_slice()))
+        .collect();
+    let actual = actual.map_err(|_| SnapshotFormatError::ColumnStatsPartBindingMismatch)?;
+    if actual != expected_part_blake3 {
+        return Err(SnapshotFormatError::ColumnStatsPartBindingMismatch);
+    }
+    Ok(decoded.segments)
+}

--- a/crates/ravel-catalog/src/column_stats_resolve.rs
+++ b/crates/ravel-catalog/src/column_stats_resolve.rs
@@ -1,0 +1,200 @@
+//! Column-statistics load for the query-time metadata-only path (ADR-0850).
+//! Mirrors [`crate::covering_postings::load_covering_postings`] exactly:
+//! fetch HEAD, follow its `column_stats` ref, GET/blake3-verify/tenant-check/
+//! decode. A query engine (`ravel-sql`'s `LogsScanExec`) consumes the result
+//! by joining its own resolved snapshot's live segments against
+//! [`LoadedColumnStats::segments`] by identity; a segment with no entry there
+//! (never built, build failed, or the segment postdates this stats object)
+//! has no exact statistics and the query must fall back to scanning it.
+//!
+//! # Degrade-to-`None`, one loud exception
+//!
+//! Same discipline as postings: every failure short of an isolation breach
+//! degrades to `Ok(None)` (no HEAD yet, no column-stats ref, any GET error, a
+//! blake3 mismatch, a decode error, a part-binding mismatch against the
+//! current HEAD's parts). `decode_column_stats` does not itself check
+//! part-binding against a caller-supplied part list (unlike
+//! `decode_postings`, which takes the expected part_blake3 as an argument);
+//! this loader performs that check itself, exactly as
+//! [`crate::column_stats_build::decode_previous_column_stats`] does on the
+//! fold side. A genuinely unparseable HEAD or part is a real catalog defect,
+//! surfaced the same way `load_covering_postings` surfaces one; a
+//! column-stats object declaring a foreign `tenant_hash` is an ADR-0050 §2
+//! isolation breach, never absorbed into a silent degrade.
+
+use std::collections::HashMap;
+
+use ravel_object_store::{GetRange, ObjectStoreBackend};
+use ravel_proto::catalog::v1::ColumnStatsSegment;
+use ravel_types::{Signal, TenantHash};
+
+use crate::EntryIdentity;
+use crate::snapshot_format::{
+    ColumnStatsLimits, PartLimits, SnapshotFormatError, decode_column_stats, decode_head,
+    decode_part,
+};
+
+/// The owned column-statistics inputs a query-time metadata-only plan needs:
+/// exact per-segment statistics keyed by the same
+/// `(ingest_hour_bucket, shard, writer_id, writer_epoch, writer_seq)`
+/// identity `fold::entry_identity` uses, so a resolved snapshot's live
+/// segments can be looked up directly with no ordinal bookkeeping.
+#[derive(Clone, Debug)]
+pub struct LoadedColumnStats {
+    /// Every segment this column-stats object carries an entry for, keyed by
+    /// identity. A live segment absent from this map has no exact
+    /// statistics.
+    pub segments: HashMap<EntryIdentity, ColumnStatsSegment>,
+    /// The covered parts' blake3 hashes, in `SnapshotHead.parts` order (the
+    /// binding this loader verifies before returning `Some`).
+    pub part_blake3: Vec<[u8; 32]>,
+}
+
+/// A genuinely unparseable HEAD/part, or an isolation breach, encountered
+/// while loading column statistics: the only conditions
+/// [`load_column_stats`] surfaces as an error rather than degrading to
+/// `Ok(None)`.
+#[derive(Debug, thiserror::Error)]
+pub enum LoadColumnStatsError {
+    #[error("HEAD at {key} is corrupt: {source}")]
+    HeadCorrupt {
+        key: String,
+        #[source]
+        source: SnapshotFormatError,
+    },
+    #[error("snapshot part {key} is corrupt: {source}")]
+    PartCorrupt {
+        key: String,
+        #[source]
+        source: SnapshotFormatError,
+    },
+    /// The column-stats object declares a `tenant_hash` naming a different
+    /// tenant (ADR-0050 §2 isolation breach): a hard error, never a silent
+    /// degrade.
+    #[error(
+        "column-stats object {key} declares tenant_hash {actual}, expected {expected} \
+         (ADR-0050 §2 isolation breach)"
+    )]
+    TenantHashMismatch {
+        key: String,
+        expected: String,
+        actual: String,
+    },
+}
+
+/// HEAD object key (docs/catalog-and-mvcc.md key layout, frozen format).
+/// Duplicated the same way [`crate::covering_postings`] and
+/// [`crate::seal_divergence`] duplicate it.
+fn head_key(tenant: &TenantHash, signal: Signal) -> String {
+    format!("t/{}/catalog/{}/HEAD", tenant.to_hex(), signal.key_prefix())
+}
+
+/// Resolve exact per-segment column statistics for `(tenant, signal)` from
+/// the current folded snapshot HEAD, or `Ok(None)` when no usable
+/// column-stats object exists right now (nothing folded yet, no configured
+/// typed columns, or the last fold's column-stats build/PUT failed).
+///
+/// Metadata-cost: reads the HEAD and the one column-stats object, never a
+/// data segment or a snapshot part (unlike `load_covering_postings`, this
+/// loader does not need the covered-entry universe -- callers already have
+/// their own resolved snapshot to join against). See the [module
+/// docs](self) for the full degrade-to-`Ok(None)` contract.
+pub async fn load_column_stats(
+    store: &dyn ObjectStoreBackend,
+    tenant: &TenantHash,
+    signal: Signal,
+) -> Result<Option<LoadedColumnStats>, LoadColumnStatsError> {
+    let key = head_key(tenant, signal);
+
+    let head_bytes = match store.get(&key, GetRange::Full).await {
+        Ok(got) => got.data,
+        Err(_) => return Ok(None),
+    };
+    let head = decode_head(&head_bytes).map_err(|source| LoadColumnStatsError::HeadCorrupt {
+        key: key.clone(),
+        source,
+    })?;
+
+    let Some(stats_ref) = head.column_stats.clone() else {
+        return Ok(None);
+    };
+
+    let part_limits = PartLimits::default();
+    let mut expected_part_blake3: Vec<[u8; 32]> = Vec::with_capacity(head.parts.len());
+    for part_ref in &head.parts {
+        let Ok(blake3) = <[u8; 32]>::try_from(part_ref.blake3.as_slice()) else {
+            return Ok(None);
+        };
+        expected_part_blake3.push(blake3);
+        // Parts are fetched only to prove liveness/decodability of the HEAD
+        // this stats ref is bound to, mirroring `load_covering_postings`'s
+        // hard-error-on-corrupt-part precedent; their entries are not needed
+        // here.
+        let got = match store.get(&part_ref.key, GetRange::Full).await {
+            Ok(got) => got,
+            Err(_) => return Ok(None),
+        };
+        if let Err(source) = decode_part(&got.data, &part_limits) {
+            return Err(LoadColumnStatsError::PartCorrupt {
+                key: part_ref.key.clone(),
+                source,
+            });
+        }
+    }
+
+    let data = match store.get(&stats_ref.key, GetRange::Full).await {
+        Ok(got) => got.data,
+        Err(_) => return Ok(None),
+    };
+    let digest = blake3::hash(&data);
+    if digest.as_bytes().as_slice() != stats_ref.blake3.as_slice() {
+        return Ok(None);
+    }
+
+    let limits = ColumnStatsLimits::default();
+    let decoded = match decode_column_stats(&data, &limits) {
+        Ok(decoded) => decoded,
+        Err(_) => return Ok(None),
+    };
+
+    if decoded.header.tenant_hash != tenant.0.to_vec() {
+        return Err(LoadColumnStatsError::TenantHashMismatch {
+            key: stats_ref.key.clone(),
+            expected: tenant.to_hex(),
+            actual: hex::encode(&decoded.header.tenant_hash),
+        });
+    }
+
+    let actual_part_blake3: Result<Vec<[u8; 32]>, _> = decoded
+        .header
+        .part_blake3
+        .iter()
+        .map(|h| <[u8; 32]>::try_from(h.as_slice()))
+        .collect();
+    let Ok(actual_part_blake3) = actual_part_blake3 else {
+        return Ok(None);
+    };
+    if actual_part_blake3 != expected_part_blake3 {
+        return Ok(None);
+    }
+
+    let mut segments = HashMap::with_capacity(decoded.segments.len());
+    for segment in decoded.segments {
+        let Ok(writer_id) = <[u8; 16]>::try_from(segment.writer_id.as_slice()) else {
+            continue;
+        };
+        let identity: EntryIdentity = (
+            segment.ingest_hour_bucket,
+            segment.shard,
+            writer_id,
+            segment.writer_epoch,
+            segment.writer_seq,
+        );
+        segments.insert(identity, segment);
+    }
+
+    Ok(Some(LoadedColumnStats {
+        segments,
+        part_blake3: expected_part_blake3,
+    }))
+}

--- a/crates/ravel-catalog/src/column_stats_resolve.rs
+++ b/crates/ravel-catalog/src/column_stats_resolve.rs
@@ -1,37 +1,42 @@
 //! Column-statistics load for the query-time metadata-only path (ADR-0850).
-//! Mirrors [`crate::covering_postings::load_covering_postings`] exactly:
-//! fetch HEAD, follow its `column_stats` ref, GET/blake3-verify/tenant-check/
-//! decode. A query engine (`ravel-sql`'s `LogsScanExec`) consumes the result
-//! by joining its own resolved snapshot's live segments against
+//! Like [`crate::covering_postings::load_covering_postings`] it fetches HEAD,
+//! follows its `column_stats` ref, and GET/blake3-verifies/tenant-checks/
+//! decodes the object, but it fetches NO snapshot part: it needs only each
+//! part's blake3 (already carried in `SnapshotHead.parts`) to bind the stats
+//! object to this HEAD's part set. Every GET runs through the caller's
+//! accounted, semaphore-bounded funnel (issue #850), so the two GETs this
+//! path issues are counted and rate-limited exactly like every other query
+//! read. A query engine (`ravel-sql`'s `LogsScanExec`) consumes the result by
+//! joining its own resolved snapshot's live segments against
 //! [`LoadedColumnStats::segments`] by identity; a segment with no entry there
 //! (never built, build failed, or the segment postdates this stats object)
 //! has no exact statistics and the query must fall back to scanning it.
 //!
 //! # Degrade-to-`None`, one loud exception
 //!
-//! Same discipline as postings: every failure short of an isolation breach
-//! degrades to `Ok(None)` (no HEAD yet, no column-stats ref, any GET error, a
-//! blake3 mismatch, a decode error, a part-binding mismatch against the
-//! current HEAD's parts). `decode_column_stats` does not itself check
-//! part-binding against a caller-supplied part list (unlike
-//! `decode_postings`, which takes the expected part_blake3 as an argument);
-//! this loader performs that check itself, exactly as
+//! Column statistics are an OPTIONAL metadata artifact, so every failure
+//! short of an isolation breach degrades to `Ok(None)` and the query scans:
+//! no HEAD yet, no column-stats ref, any GET error, a blake3 mismatch, a
+//! decode error, or a part-binding mismatch against the current HEAD's parts.
+//! `decode_column_stats` does not itself check part-binding against a
+//! caller-supplied part list (unlike `decode_postings`, which takes the
+//! expected part_blake3 as an argument); this loader performs that check
+//! itself, exactly as
 //! [`crate::column_stats_build::decode_previous_column_stats`] does on the
-//! fold side. A genuinely unparseable HEAD or part is a real catalog defect,
-//! surfaced the same way `load_covering_postings` surfaces one; a
-//! column-stats object declaring a foreign `tenant_hash` is an ADR-0050 §2
-//! isolation breach, never absorbed into a silent degrade.
+//! fold side. The only two loud exceptions are a genuinely unparseable HEAD
+//! (a real catalog defect, not an optional artifact) and a column-stats
+//! object declaring a foreign `tenant_hash` (an ADR-0050 §2 isolation
+//! breach): neither is absorbed into a silent degrade.
 
 use std::collections::HashMap;
 
-use ravel_object_store::{GetRange, ObjectStoreBackend};
 use ravel_proto::catalog::v1::ColumnStatsSegment;
 use ravel_types::{Signal, TenantHash};
 
 use crate::EntryIdentity;
+use crate::provisioning::AccountedRecordGet;
 use crate::snapshot_format::{
-    ColumnStatsLimits, PartLimits, SnapshotFormatError, decode_column_stats, decode_head,
-    decode_part,
+    ColumnStatsLimits, SnapshotFormatError, decode_column_stats, decode_head,
 };
 
 /// The owned column-statistics inputs a query-time metadata-only plan needs:
@@ -50,20 +55,13 @@ pub struct LoadedColumnStats {
     pub part_blake3: Vec<[u8; 32]>,
 }
 
-/// A genuinely unparseable HEAD/part, or an isolation breach, encountered
-/// while loading column statistics: the only conditions
-/// [`load_column_stats`] surfaces as an error rather than degrading to
-/// `Ok(None)`.
+/// A genuinely unparseable HEAD, or an isolation breach, encountered while
+/// loading column statistics: the only conditions [`load_column_stats`]
+/// surfaces as an error rather than degrading to `Ok(None)`.
 #[derive(Debug, thiserror::Error)]
 pub enum LoadColumnStatsError {
     #[error("HEAD at {key} is corrupt: {source}")]
     HeadCorrupt {
-        key: String,
-        #[source]
-        source: SnapshotFormatError,
-    },
-    #[error("snapshot part {key} is corrupt: {source}")]
-    PartCorrupt {
         key: String,
         #[source]
         source: SnapshotFormatError,
@@ -94,19 +92,25 @@ fn head_key(tenant: &TenantHash, signal: Signal) -> String {
 /// column-stats object exists right now (nothing folded yet, no configured
 /// typed columns, or the last fold's column-stats build/PUT failed).
 ///
-/// Metadata-cost: reads the HEAD and the one column-stats object, never a
-/// data segment or a snapshot part (unlike `load_covering_postings`, this
-/// loader does not need the covered-entry universe -- callers already have
-/// their own resolved snapshot to join against). See the [module
-/// docs](self) for the full degrade-to-`Ok(None)` contract.
-pub async fn load_column_stats(
-    store: &dyn ObjectStoreBackend,
+/// Every GET is issued through `getter`, so it is credited to the caller's
+/// [`QueryAccounting`](ravel_types::accounting::QueryAccounting) and bounded
+/// by the catalog request semaphore, the same funnel every other query read
+/// path uses (issue #850). The requests charge to `AccountedOp::Get`.
+///
+/// Metadata-cost: exactly two GETs -- the HEAD and the one column-stats
+/// object. Unlike `load_covering_postings`, this loader fetches no snapshot
+/// part: it needs only each part's blake3 (already carried in
+/// `SnapshotHead.parts`) for the binding check, and callers join against
+/// their own resolved snapshot rather than a rebuilt covered-entry universe.
+/// See the [module docs](self) for the full degrade-to-`Ok(None)` contract.
+pub(crate) async fn load_column_stats(
+    getter: &impl AccountedRecordGet,
     tenant: &TenantHash,
     signal: Signal,
 ) -> Result<Option<LoadedColumnStats>, LoadColumnStatsError> {
     let key = head_key(tenant, signal);
 
-    let head_bytes = match store.get(&key, GetRange::Full).await {
+    let head_bytes = match getter.accounted_get_full(&key).await {
         Ok(got) => got.data,
         Err(_) => return Ok(None),
     };
@@ -119,30 +123,20 @@ pub async fn load_column_stats(
         return Ok(None);
     };
 
-    let part_limits = PartLimits::default();
+    // The parts are NOT fetched: this loader needs only their blake3 (which
+    // HEAD already carries) to bind the stats object to this HEAD's part set.
+    // A per-part GET here would GET every snapshot part in full only to
+    // discard it, and would turn a fault in an optional metadata artifact into
+    // a hard error on the logs query path.
     let mut expected_part_blake3: Vec<[u8; 32]> = Vec::with_capacity(head.parts.len());
     for part_ref in &head.parts {
         let Ok(blake3) = <[u8; 32]>::try_from(part_ref.blake3.as_slice()) else {
             return Ok(None);
         };
         expected_part_blake3.push(blake3);
-        // Parts are fetched only to prove liveness/decodability of the HEAD
-        // this stats ref is bound to, mirroring `load_covering_postings`'s
-        // hard-error-on-corrupt-part precedent; their entries are not needed
-        // here.
-        let got = match store.get(&part_ref.key, GetRange::Full).await {
-            Ok(got) => got,
-            Err(_) => return Ok(None),
-        };
-        if let Err(source) = decode_part(&got.data, &part_limits) {
-            return Err(LoadColumnStatsError::PartCorrupt {
-                key: part_ref.key.clone(),
-                source,
-            });
-        }
     }
 
-    let data = match store.get(&stats_ref.key, GetRange::Full).await {
+    let data = match getter.accounted_get_full(&stats_ref.key).await {
         Ok(got) => got.data,
         Err(_) => return Ok(None),
     };

--- a/crates/ravel-catalog/src/fold.rs
+++ b/crates/ravel-catalog/src/fold.rs
@@ -1450,7 +1450,24 @@ impl Catalog {
                     match self.store().get(&stats_ref.key, GetRange::Full).await {
                         Ok(got) => {
                             counters.get_requests += 1;
-                            let expected_part_blake3: Vec<[u8; 32]> = part_hashes.clone();
+                            // The previous fold's `.cstat` header is bound to
+                            // the parts THAT fold recorded on this HEAD, not to
+                            // the parts this fold just encoded (`part_hashes`).
+                            // Any incremental fold that appends entries rewrites
+                            // at least the tail part's hash, so binding against
+                            // `part_hashes` would reject the baseline on every
+                            // append and recompute every L0 segment. Bind
+                            // against `head.parts`, exactly as
+                            // `load_previous_postings` does. A malformed part
+                            // blake3 (never for a validated HEAD) yields an
+                            // empty expected set, so the binding check below
+                            // fails and the baseline is dropped -- fail safe.
+                            let expected_part_blake3: Vec<[u8; 32]> = head
+                                .parts
+                                .iter()
+                                .map(|p| <[u8; 32]>::try_from(p.blake3.as_slice()))
+                                .collect::<Result<_, _>>()
+                                .unwrap_or_default();
                             match column_stats_build::decode_previous_column_stats(
                                 &got.data,
                                 &expected_part_blake3,
@@ -2572,6 +2589,277 @@ mod tests {
             .await
             .expect("publish");
         record
+    }
+
+    /// A MemoryStore wrapper that records the key of every `get`, so a test can
+    /// assert exactly which objects a fold read.
+    struct RecordingStore {
+        inner: MemoryStore,
+        get_keys: std::sync::Mutex<Vec<String>>,
+    }
+
+    impl RecordingStore {
+        fn new() -> Self {
+            RecordingStore {
+                inner: MemoryStore::new(),
+                get_keys: std::sync::Mutex::new(Vec::new()),
+            }
+        }
+
+        fn clear_gets(&self) {
+            self.get_keys.lock().expect("lock").clear();
+        }
+
+        fn count_gets_of(&self, key: &str) -> usize {
+            self.get_keys
+                .lock()
+                .expect("lock")
+                .iter()
+                .filter(|k| k.as_str() == key)
+                .count()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ObjectStoreBackend for RecordingStore {
+        async fn put(
+            &self,
+            key: &str,
+            data: Bytes,
+            opts: PutOptions,
+        ) -> Result<ravel_object_store::PutOutcome, StoreError> {
+            self.inner.put(key, data, opts).await
+        }
+
+        async fn get(
+            &self,
+            key: &str,
+            range: GetRange,
+        ) -> Result<ravel_object_store::GetOutcome, StoreError> {
+            self.get_keys.lock().expect("lock").push(key.to_string());
+            self.inner.get(key, range).await
+        }
+
+        async fn head(&self, key: &str) -> Result<ravel_object_store::ObjectMeta, StoreError> {
+            self.inner.head(key).await
+        }
+
+        async fn list(
+            &self,
+            prefix: &str,
+            page: Option<ravel_object_store::PageToken>,
+        ) -> Result<ravel_object_store::ListPage, StoreError> {
+            self.inner.list(prefix, page).await
+        }
+
+        async fn list_delimited(
+            &self,
+            prefix: &str,
+        ) -> Result<ravel_object_store::DelimitedList, StoreError> {
+            self.inner.list_delimited(prefix).await
+        }
+
+        async fn delete(&self, key: &str) -> Result<(), StoreError> {
+            self.inner.delete(key).await
+        }
+
+        fn capabilities(&self) -> ravel_object_store::Capabilities {
+            self.inner.capabilities()
+        }
+    }
+
+    /// Publish one real L0 RLOG logs segment carrying an I64 `status` attribute
+    /// on every row, plus its commit record, exactly as ingest would. Returns
+    /// the record so the caller can reconstruct its data-object key.
+    async fn publish_logs_segment(
+        store: &dyn ObjectStoreBackend,
+        writer_seq: u64,
+        ingest_hour_bucket: u32,
+        statuses: &[i64],
+    ) -> CommitRecord {
+        use ravel_logseg::writer::ObjectIdentity;
+        use ravel_logseg::{LogRecord, RlogConfig, RlogWriter, stream_attrs_bytes};
+        use ravel_types::logstream::{AttrValue, log_stream_id};
+
+        let writer_id = Uuid::from_u128(u128::from(writer_seq));
+        let resource = vec![(
+            "service.name".to_string(),
+            AttrValue::Str("api".to_string()),
+        )];
+        let mut w = RlogWriter::new(
+            RlogConfig::default(),
+            ObjectIdentity {
+                tenant_hash: tenant().0,
+                shard: 0,
+                writer_id: *writer_id.as_bytes(),
+                writer_epoch: 1,
+                writer_seq,
+            },
+        );
+        let base_ts = i64::from(ingest_hour_bucket) * NS_PER_HOUR + 60_000_000_000;
+        let mut min_ts = i64::MAX;
+        let mut max_ts = i64::MIN;
+        for (i, status) in statuses.iter().enumerate() {
+            let ts = base_ts + i as i64;
+            min_ts = min_ts.min(ts);
+            max_ts = max_ts.max(ts);
+            w.push(LogRecord {
+                stream_id: log_stream_id(&resource, "scope", "1.0", &[]),
+                stream_attrs: stream_attrs_bytes(&resource, "scope", "1.0", &[]),
+                ts_ns: ts,
+                observed_ts_ns: ts,
+                severity_num: 9,
+                severity_text: "INFO".into(),
+                body: format!("row {i}"),
+                trace_id: None,
+                span_id: None,
+                flags: 0,
+                attrs: vec![("status".to_string(), AttrValue::I64(*status))],
+            })
+            .expect("push");
+        }
+        let bytes = w.finish().expect("finish");
+        let content_hash = *blake3::hash(&bytes).as_bytes();
+        let record = record::build(NewCommitRecord {
+            tenant_hash: tenant(),
+            signal: Signal::Logs,
+            shard: 0,
+            writer_id,
+            writer_epoch: 1,
+            writer_seq,
+            object_size: bytes.len() as u64,
+            content_hash,
+            sample_count: statuses.len() as u64,
+            series_count: 1,
+            min_event_ts_ns: min_ts,
+            max_event_ts_ns: max_ts,
+            min_ingest_ts_ns: min_ts,
+            max_ingest_ts_ns: max_ts,
+            segment_format_version: 1,
+            created_unix_ns: max_ts,
+            ingest_hour_bucket,
+        })
+        .expect("valid record");
+        let data_key = keys::reconstruct_data_key(&record).expect("data key");
+        publish::put_data_object(store, &data_key, Bytes::from(bytes))
+            .await
+            .expect("put data object");
+        publish::publish(store, &record, &RetryPolicy::default())
+            .await
+            .expect("publish");
+        record
+    }
+
+    /// Issue #850, Finding 3: an incremental fold that appends entries must
+    /// REUSE the previous fold's column-statistics baseline for the segments it
+    /// already covered, re-fetching only the genuinely new segment. The reuse
+    /// binding is checked against the parts the baseline was actually built with
+    /// (the previous HEAD's parts), not the parts this fold just encoded.
+    ///
+    /// Asserted by a count of OBJECTS READ: after the second fold, the two
+    /// first-fold segment data objects are never GET again (reuse), while the
+    /// new segment is. Against the pre-fix code (`expected_part_blake3 =
+    /// part_hashes`), the append changes the tail part's hash, the baseline is
+    /// rejected, and both old segments are re-fetched, so `count_gets_of` for
+    /// each old data key is 1 and this test fails.
+    #[tokio::test]
+    async fn incremental_fold_reuses_column_stats_baseline() {
+        let store = Arc::new(RecordingStore::new());
+
+        // Declare `status` as an I64 typed logs column so the fold builds
+        // column statistics.
+        let cfg = crate::tenant_config::TenantConfig {
+            typed_attr_columns: Some(vec![crate::tenant_config::DeclaredTypedColumn {
+                key: "status".to_string(),
+                ty: crate::tenant_config::DeclaredColumnType::I64,
+            }]),
+            ..crate::tenant_config::TenantConfig::new(
+                crate::tenant_config::TenantLifecycleState::Active,
+            )
+        };
+        crate::tenant_config::set_tenant_config(store.as_ref(), &tenant(), &cfg, 1)
+            .await
+            .expect("write tenant config");
+
+        // Two segments in hour 10.
+        let rec_a = publish_logs_segment(store.as_ref(), 1, 10, &[200, 404, 200]).await;
+        let rec_b = publish_logs_segment(store.as_ref(), 2, 10, &[500, 200]).await;
+        let key_a = keys::reconstruct_data_key(&rec_a).expect("key a");
+        let key_b = keys::reconstruct_data_key(&rec_b).expect("key b");
+
+        let catalog = Catalog::new(store.clone(), config(1)).expect("catalog");
+
+        let first = catalog
+            .fold(
+                &tenant(),
+                Signal::Logs,
+                Uuid::new_v4(),
+                now_at_seal(10),
+                &[],
+                None,
+            )
+            .await
+            .expect("first fold");
+        assert!(first.rebuilt, "first fold rebuilds from the commit layout");
+        assert!(
+            first.column_stats_built,
+            "the first fold builds column statistics over both hour-10 segments"
+        );
+
+        // A new segment in a later hour, then an incremental second fold.
+        let rec_c = publish_logs_segment(store.as_ref(), 3, 11, &[200, 200]).await;
+        let key_c = keys::reconstruct_data_key(&rec_c).expect("key c");
+
+        store.clear_gets();
+        let second = catalog
+            .fold(
+                &tenant(),
+                Signal::Logs,
+                Uuid::new_v4(),
+                now_at_seal(11),
+                &[],
+                None,
+            )
+            .await
+            .expect("second fold");
+        assert!(!second.rebuilt, "the second fold is incremental");
+        assert!(
+            second.column_stats_built,
+            "the second fold rebuilds the artifact"
+        );
+
+        // The reuse assertion, by objects read. Segment B is the clean
+        // discriminator: on the second fold it is fetched ONLY if the
+        // column-stats baseline was rejected and B recomputed. With reuse it is
+        // never read; with the pre-fix `part_hashes` binding it is read once.
+        //
+        // (Segment A is read once regardless, by the name-postings pass, which
+        // aborts on the first L0 entry because a logs RLOG object is not a
+        // metrics RSEG -- unrelated to column-stats reuse, so it is not asserted
+        // on. `key_a` is bound only to document that.)
+        let _ = &key_a;
+        assert_eq!(
+            store.count_gets_of(&key_b),
+            0,
+            "segment B's stats were reused, not recomputed"
+        );
+        assert!(
+            store.count_gets_of(&key_c) >= 1,
+            "the new hour-11 segment must be fetched to build its stats"
+        );
+
+        // Reuse still produced a complete artifact covering all three segments.
+        let acc = QueryAccounting::new();
+        let loaded = catalog
+            .load_column_stats(&tenant(), Signal::Logs, &acc)
+            .await
+            .expect("load ok")
+            .expect("stats present");
+        assert_eq!(
+            loaded.segments.len(),
+            3,
+            "the reused baseline plus the new segment cover all three"
+        );
     }
 
     #[test]

--- a/crates/ravel-catalog/src/fold.rs
+++ b/crates/ravel-catalog/src/fold.rs
@@ -188,8 +188,12 @@ struct RequestCounters {
 /// HEAD as read at the top of one fold attempt.
 enum HeadState {
     Absent,
+    /// `head` is boxed so this large variant does not inflate every
+    /// `HeadState` value (`clippy::large_enum_variant`): `SnapshotHead` grew
+    /// past 300 bytes when ADR-0850 added `column_stats`, while the other
+    /// variants are tiny.
     Valid {
-        head: SnapshotHead,
+        head: Box<SnapshotHead>,
         version: Version,
     },
     /// HEAD object exists but failed to decode: logged loudly by
@@ -1700,7 +1704,7 @@ impl Catalog {
                 counters.get_requests += 1;
                 match snapshot_format::decode_head(&got.data) {
                     Ok(head) => Ok(HeadState::Valid {
-                        head,
+                        head: Box::new(head),
                         version: got.version,
                     }),
                     // A HEAD whose `format_version` this process does not

--- a/crates/ravel-catalog/src/fold.rs
+++ b/crates/ravel-catalog/src/fold.rs
@@ -23,7 +23,10 @@ use ravel_object_store::{
     GetRange, ObjectMeta, ObjectStoreBackend, PutMode, PutOptions, StoreError, UploadChecksum,
     Version, list_all,
 };
-use ravel_proto::catalog::v1::{SnapshotEntry, SnapshotHead, SnapshotPartRef, SnapshotPostingsRef};
+use ravel_proto::catalog::v1::{
+    ColumnStatsSegment, SnapshotColumnStatsRef, SnapshotEntry, SnapshotHead, SnapshotPartRef,
+    SnapshotPostingsRef,
+};
 use ravel_proto::commit::v1::{CommitRecord, CompactionPart, CompactionRecord, RewriteRecord};
 use ravel_segment::{ExpectedIdentity, ReaderLimits, SegmentError};
 use ravel_types::accounting::{AccountedOp, QueryAccounting};
@@ -31,12 +34,14 @@ use ravel_types::{METRIC_NAME_LABEL, Signal, TenantHash};
 use uuid::Uuid;
 
 use crate::catalog::Catalog;
+use crate::column_stats_build;
 use crate::config::CatalogConfig;
 use crate::error::CatalogError;
 use crate::provisioning::{DEFAULT_SCAN_SLACK_HOURS, ShardGeneration, scan_count};
 use crate::snapshot_format::{
     self, HEAD_FORMAT_VERSION, NamePostings, PartLimits, SnapshotFormatError,
 };
+use crate::tenant_config::DeclaredTypedColumn;
 
 /// RSEG section kinds needed to decode a segment's catalog
 /// (docs/segment-format.md `SectionKind`). Kinds 1/2 are v1
@@ -133,6 +138,15 @@ pub struct FoldReport {
     /// Encoded size of the postings object, in bytes. `0` when
     /// `postings_built` is `false`.
     pub postings_bytes: u64,
+    /// `true` if this fold successfully built and attached a column-statistics
+    /// object (ADR-0850). `false` covers "the tenant has no configured typed
+    /// attribute columns" (nothing to build), a no-op fold, and "the build
+    /// failed and the fold proceeded without a column-stats ref" -- exactly
+    /// the same three-way ambiguity `postings_built` already accepts.
+    pub column_stats_built: bool,
+    /// Encoded size of the column-stats object, in bytes. `0` when
+    /// `column_stats_built` is `false`.
+    pub column_stats_bytes: u64,
     /// Number of commit-bucket entries this fold skipped rather than
     /// aborting on: an unrecognized bucket-key shape, or a commit record
     /// whose identity duplicates one already folded. Both are layout drift
@@ -256,6 +270,21 @@ fn postings_object_key(
 ) -> String {
     format!(
         "t/{}/catalog/{}/idx/{}.{}.npost",
+        tenant.to_hex(),
+        signal.key_prefix(),
+        keys::ingest_hour_string(watermark_hour),
+        hash16
+    )
+}
+
+fn column_stats_object_key(
+    tenant: &TenantHash,
+    signal: Signal,
+    watermark_hour: u32,
+    hash16: &str,
+) -> String {
+    format!(
+        "t/{}/catalog/{}/idx/{}.{}.cstat",
         tenant.to_hex(),
         signal.key_prefix(),
         keys::ingest_hour_string(watermark_hour),
@@ -798,23 +827,32 @@ impl Catalog {
         // reconcile (nothing is being retired). The fold's index role is a pure
         // optimization and the sweep's HEAD-reachability gate is the durable
         // delete blocker, so a config-read fault never fails the fold.
-        let tenant_retention_ns: Option<i64> = match crate::tenant_config::read_config_values(
-            self.store(),
-            tenant,
-        )
-        .await
+        let tenant_config = match crate::tenant_config::read_config_values(self.store(), tenant)
+            .await
         {
-            Ok(Some(cfg)) => cfg.retention_ns.or(default_retention_ns),
-            Ok(None) => default_retention_ns,
+            Ok(cfg) => cfg,
             Err(err) => {
                 tracing::warn!(
                     error = %err,
                     tenant = %tenant.to_hex(),
-                    "tenant config read failed; falling back to deployment-default retention for frontier reconcile"
+                    "tenant config read failed; falling back to deployment-default retention and no typed attribute columns"
                 );
-                default_retention_ns
+                None
             }
         };
+        let tenant_retention_ns: Option<i64> = tenant_config
+            .as_ref()
+            .and_then(|cfg| cfg.retention_ns)
+            .or(default_retention_ns);
+        // ADR-0850: the tenant's configured typed logs attribute columns, if
+        // any. `None`/absent config/a read failure all mean "no configured
+        // columns" -- unlike `retention_ns`, `typed_attr_columns` has no
+        // deployment-wide default threaded through `fold` (ravel-bench's own
+        // consumer of this field treats absence the same way), so a fold
+        // simply builds no column-stats artifact for that tenant.
+        let typed_attr_columns: Vec<DeclaredTypedColumn> = tenant_config
+            .and_then(|cfg| cfg.typed_attr_columns)
+            .unwrap_or_default();
         // Count the tenant-config record GET. `read_config_values` issues one
         // raw `store.get` per fold on every outcome (hit, absent, or error) and
         // takes neither a counters nor an accounting handle, so it is otherwise
@@ -1365,6 +1403,201 @@ impl Catalog {
                 None => None,
             };
 
+            // Column statistics (ADR-0850): exact per-object statistics for
+            // the tenant's configured typed logs attribute columns. Unlike
+            // postings, the baseline is joined by identity
+            // (`entry_identity`), not ordinal position: a segment's exact
+            // statistics never change once written, so any L0 entry present
+            // in both the previous fold's column-stats object and this
+            // fold's entry set is reused verbatim with no re-fetch, and only
+            // a genuinely new L0 entry is fetched and scanned. This also
+            // makes the `reconciled`/`rebuilt` ordinal-invalidation concern
+            // that forces postings to restart from scratch moot here: a
+            // selective-erasure rewrite or a compaction excludes its
+            // superseded L0 entries from `entries` entirely (replacing them
+            // with an L1 entry under an unrelated identity,
+            // `classify_bucket`'s supersession handling above), so an erased
+            // entry's identity simply stops appearing in `entries` and its
+            // stale baseline statistics are never carried forward -- not
+            // because this code checks for erasure, but because the entry it
+            // would apply to is no longer in the set being folded.
+            //
+            // Column stats are restricted to level-0 entries: an L1 entry's
+            // writer_id/writer_epoch slots are repurposed
+            // (`build_l1_snapshot_entry`) and carry no real writer identity,
+            // so it is excluded here the same way `fetch_segment_column_stats`
+            // asserts on its own input.
+            //
+            // A single segment's fetch/decode/tally failure never aborts the
+            // whole column-stats artifact (`column_stats_build`'s module
+            // docs): that segment is simply absent from `column_segments`,
+            // which the query-time reader already treats as "no stats here,
+            // fall back to scanning."
+            let (column_stats_built, column_stats_size, column_stats_ref) = if typed_attr_columns
+                .is_empty()
+            {
+                (false, 0u64, None)
+            } else {
+                let baseline: HashMap<EntryIdentity, ColumnStatsSegment> = if rebuilt {
+                    HashMap::new()
+                } else if let HeadState::Valid { head, .. } = &head_state
+                    && let Some(stats_ref) = &head.column_stats
+                {
+                    match self.store().get(&stats_ref.key, GetRange::Full).await {
+                        Ok(got) => {
+                            counters.get_requests += 1;
+                            let expected_part_blake3: Vec<[u8; 32]> = part_hashes.clone();
+                            match column_stats_build::decode_previous_column_stats(
+                                &got.data,
+                                &expected_part_blake3,
+                                &crate::snapshot_format::ColumnStatsLimits::default(),
+                            ) {
+                                Ok(segments) => segments
+                                    .into_iter()
+                                    .map(|segment| {
+                                        let identity: EntryIdentity = (
+                                            segment.ingest_hour_bucket,
+                                            segment.shard,
+                                            segment.writer_id.clone(),
+                                            segment.writer_epoch,
+                                            segment.writer_seq,
+                                        );
+                                        (identity, segment)
+                                    })
+                                    .collect(),
+                                Err(err) => {
+                                    tracing::warn!(
+                                        error = %err,
+                                        tenant = %tenant.to_hex(),
+                                        "previous column-stats object failed to decode or bind to this fold's parts; rebuilding every segment's statistics"
+                                    );
+                                    HashMap::new()
+                                }
+                            }
+                        }
+                        Err(err) => {
+                            tracing::warn!(
+                                error = %err,
+                                tenant = %tenant.to_hex(),
+                                "previous column-stats object GET failed; rebuilding every segment's statistics"
+                            );
+                            HashMap::new()
+                        }
+                    }
+                } else {
+                    HashMap::new()
+                };
+
+                let mut column_segments: Vec<ColumnStatsSegment> = Vec::new();
+                for entry in entries.iter().filter(|e| e.level == 0) {
+                    let identity = entry_identity(entry);
+                    if let Some(existing) = baseline.get(&identity) {
+                        column_segments.push(existing.clone());
+                        continue;
+                    }
+                    match column_stats_build::fetch_segment_column_stats(
+                        self.store(),
+                        tenant,
+                        signal,
+                        entry,
+                        &typed_attr_columns,
+                    )
+                    .await
+                    {
+                        Ok(segment) => {
+                            counters.get_requests += 1;
+                            column_segments.push(segment);
+                        }
+                        Err(err) => {
+                            tracing::warn!(
+                                error = %err,
+                                tenant = %tenant.to_hex(),
+                                ingest_hour_bucket = entry.ingest_hour_bucket,
+                                shard = entry.shard,
+                                "column-stats build failed for one segment; it has no stats entry and queries over it fall back to scanning"
+                            );
+                        }
+                    }
+                }
+                column_segments.sort_by(|a, b| {
+                    (
+                        a.ingest_hour_bucket,
+                        a.shard,
+                        a.writer_id.as_slice(),
+                        a.writer_epoch,
+                        a.writer_seq,
+                    )
+                        .cmp(&(
+                            b.ingest_hour_bucket,
+                            b.shard,
+                            b.writer_id.as_slice(),
+                            b.writer_epoch,
+                            b.writer_seq,
+                        ))
+                });
+
+                match snapshot_format::encode_column_stats(
+                    tenant.0,
+                    signal_num,
+                    part_hashes.iter().map(|h| h.to_vec()).collect(),
+                    &column_segments,
+                ) {
+                    Ok(stats_bytes) => {
+                        let stats_crc = crc32c::crc32c(&stats_bytes);
+                        let stats_hash = blake3::hash(&stats_bytes);
+                        let stats_hash16 = &stats_hash.to_hex()[..16];
+                        let stats_key =
+                            column_stats_object_key(tenant, signal, watermark_hour, stats_hash16);
+                        let size = stats_bytes.len() as u64;
+                        let segment_count = column_segments.len() as u32;
+                        match self
+                            .store()
+                            .put(
+                                &stats_key,
+                                Bytes::from(stats_bytes),
+                                PutOptions::create_if_absent()
+                                    .with_checksum(UploadChecksum::Crc32c(stats_crc)),
+                            )
+                            .await
+                        {
+                            Ok(_) | Err(StoreError::AlreadyExists) => {
+                                counters.put_requests += 1;
+                                (
+                                    true,
+                                    size,
+                                    Some(SnapshotColumnStatsRef {
+                                        key: stats_key,
+                                        blake3: stats_hash.as_bytes().to_vec(),
+                                        size,
+                                        segment_count,
+                                        part_blake3: part_hashes
+                                            .iter()
+                                            .map(|h| h.to_vec())
+                                            .collect(),
+                                    }),
+                                )
+                            }
+                            Err(err) => {
+                                tracing::warn!(
+                                    error = %err,
+                                    tenant = %tenant.to_hex(),
+                                    "column-stats PUT failed, folding without a column-stats ref"
+                                );
+                                (false, 0, None)
+                            }
+                        }
+                    }
+                    Err(err) => {
+                        tracing::warn!(
+                            error = %err,
+                            tenant = %tenant.to_hex(),
+                            "column-stats encode failed, folding without a column-stats ref"
+                        );
+                        (false, 0, None)
+                    }
+                }
+            };
+
             let new_head = SnapshotHead {
                 format_version: HEAD_FORMAT_VERSION,
                 tenant_hash: tenant.0.to_vec(),
@@ -1378,6 +1611,7 @@ impl Catalog {
                 // `validate_head` enforces for a multi-part head.
                 parts: part_refs.clone(),
                 postings: postings_ref,
+                column_stats: column_stats_ref,
                 folder_id: folder_id.into_bytes().to_vec(),
                 created_unix_ns: now_ns,
                 shard_generation_count,
@@ -1430,6 +1664,8 @@ impl Catalog {
                         put_requests: counters.put_requests,
                         postings_built,
                         postings_bytes: postings_size,
+                        column_stats_built,
+                        column_stats_bytes: column_stats_size,
                         layout_drift_count,
                         frontier_hours_reconciled,
                         frontier_hours_deferred,
@@ -2163,6 +2399,8 @@ fn no_op_report(watermark_hour: Option<u32>, counters: RequestCounters) -> FoldR
         put_requests: counters.put_requests,
         postings_built: false,
         postings_bytes: 0,
+        column_stats_built: false,
+        column_stats_bytes: 0,
         layout_drift_count: 0,
         frontier_hours_reconciled: 0,
         frontier_hours_deferred: 0,

--- a/crates/ravel-catalog/src/lib.rs
+++ b/crates/ravel-catalog/src/lib.rs
@@ -7,6 +7,8 @@
 mod auth_token_map;
 mod cache;
 mod catalog;
+mod column_stats_build;
+mod column_stats_resolve;
 mod config;
 mod covering_postings;
 mod error;
@@ -29,6 +31,7 @@ pub use auth_token_map::{
 };
 pub use catalog::Catalog;
 pub use catalog::resolve_rewrite_supersession;
+pub use column_stats_resolve::{LoadColumnStatsError, LoadedColumnStats, load_column_stats};
 pub use config::{
     CatalogConfig, DEFAULT_BYTE_CACHE_MAX_BYTES, DEFAULT_BYTE_CACHE_MAX_ENTRIES,
     DEFAULT_BYTE_CACHE_MAX_ENTRY_BYTES, DEFAULT_CACHE_CAPACITY_PER_TENANT,
@@ -65,9 +68,11 @@ pub use seal_divergence::{
 };
 pub use snapshot::{SegmentLevel, SegmentOrigin, SegmentOrigins, SegmentRef, Snapshot};
 pub use snapshot_format::{
-    DEFAULT_MAX_POSTINGS_BYTES, DEFAULT_MAX_SNAPSHOT_PART_BYTES, DecodedPart, DecodedPostings,
-    HEAD_FORMAT_VERSION, MAGIC, NamePostings, PartLimits, PostingsLimits, SnapshotFormatError,
-    VERSION, decode_head, decode_part, decode_postings, encode_head, encode_part, encode_postings,
+    ColumnStatsLimits, DEFAULT_MAX_COLUMN_DICTIONARY_ENTRIES, DEFAULT_MAX_COLUMN_STATS_BYTES,
+    DEFAULT_MAX_POSTINGS_BYTES, DEFAULT_MAX_SNAPSHOT_PART_BYTES, DecodedColumnStats, DecodedPart,
+    DecodedPostings, HEAD_FORMAT_VERSION, MAGIC, NamePostings, PartLimits, PostingsLimits,
+    SnapshotFormatError, VERSION, decode_column_stats, decode_head, decode_part, decode_postings,
+    encode_column_stats, encode_head, encode_part, encode_postings,
 };
 pub use tenant_config::{
     DeclaredColumnType, DeclaredTypedColumn, FIXED_LOGS_SQL_COLUMNS,

--- a/crates/ravel-catalog/src/lib.rs
+++ b/crates/ravel-catalog/src/lib.rs
@@ -31,7 +31,7 @@ pub use auth_token_map::{
 };
 pub use catalog::Catalog;
 pub use catalog::resolve_rewrite_supersession;
-pub use column_stats_resolve::{LoadColumnStatsError, LoadedColumnStats, load_column_stats};
+pub use column_stats_resolve::{LoadColumnStatsError, LoadedColumnStats};
 pub use config::{
     CatalogConfig, DEFAULT_BYTE_CACHE_MAX_BYTES, DEFAULT_BYTE_CACHE_MAX_ENTRIES,
     DEFAULT_BYTE_CACHE_MAX_ENTRY_BYTES, DEFAULT_CACHE_CAPACITY_PER_TENANT,

--- a/crates/ravel-catalog/src/snapshot_format/column_stats.rs
+++ b/crates/ravel-catalog/src/snapshot_format/column_stats.rs
@@ -1,0 +1,324 @@
+//! Column-statistics envelope: whole-object read, no per-section access
+//! protocol. ADR-0850.
+//!
+//! ```text
+//! magic           "RCST" (4 bytes)
+//! version         u8 = 1
+//! reserved        u8[3] = 0
+//! header_len      u32 LE
+//! header          protobuf ravel.catalog.v1.ColumnStatsHeader
+//! body_len        u64 LE
+//! body            zstd(segments)  segments = length-delimited protobuf
+//!                                 ravel.catalog.v1.ColumnStatsSegment,
+//!                                 sorted by (ingest_hour_bucket, shard,
+//!                                 writer_id, writer_epoch, writer_seq)
+//! body_crc32c     u32 LE          over the compressed body bytes
+//! header_crc32c   u32 LE          over magic..header inclusive
+//! ```
+//!
+//! Deliberately reuses `part.rs`'s plain length-delimited-protobuf body
+//! convention rather than `postings.rs`'s hand-rolled varint dictionary:
+//! that dictionary earns its complexity for a huge flat cross-segment name
+//! space, which per-segment column statistics don't have.
+
+use prost::Message;
+use ravel_proto::catalog::v1::{ColumnStatsHeader, ColumnStatsSegment};
+
+use super::error::SnapshotFormatError;
+use super::{
+    COLUMN_STATS_MAGIC, COLUMN_STATS_RESERVED, COLUMN_STATS_VERSION, MIN_COLUMN_STATS_ENVELOPE_LEN,
+    ZSTD_LEVEL,
+};
+use crate::snapshot_format::ColumnStatsLimits;
+
+/// A decoded, fully validated column-statistics object.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DecodedColumnStats {
+    pub header: ColumnStatsHeader,
+    pub segments: Vec<ColumnStatsSegment>,
+}
+
+/// Encodes a column-statistics object. Validates `segments` against the same
+/// rules `decode_column_stats` enforces (sort order, no duplicate identity),
+/// mirroring `encode_part`'s defensive-validation precedent: an object this
+/// function writes can never fail its own decode.
+pub fn encode_column_stats(
+    tenant_hash: [u8; 16],
+    signal: u32,
+    part_blake3: Vec<Vec<u8>>,
+    segments: &[ColumnStatsSegment],
+) -> Result<Vec<u8>, SnapshotFormatError> {
+    validate_segments(segments)?;
+
+    let mut segments_raw = Vec::new();
+    for segment in segments {
+        segments_raw.extend_from_slice(&segment.encode_length_delimited_to_vec());
+    }
+    let body_uncompressed_len = segments_raw.len() as u64;
+
+    let body = zstd::bulk::compress(&segments_raw, ZSTD_LEVEL)
+        .map_err(|e| SnapshotFormatError::Compress(e.to_string()))?;
+
+    let header = ColumnStatsHeader {
+        format_version: u32::from(COLUMN_STATS_VERSION),
+        tenant_hash: tenant_hash.to_vec(),
+        signal,
+        part_blake3,
+        segment_count: segments.len() as u64,
+        body_uncompressed_len,
+    };
+    let header_bytes = header.encode_to_vec();
+    let header_len =
+        u32::try_from(header_bytes.len()).map_err(|_| SnapshotFormatError::HeaderTooLarge)?;
+
+    let mut out =
+        Vec::with_capacity(MIN_COLUMN_STATS_ENVELOPE_LEN + header_bytes.len() + body.len());
+    out.extend_from_slice(&COLUMN_STATS_MAGIC);
+    out.push(COLUMN_STATS_VERSION);
+    out.extend_from_slice(&COLUMN_STATS_RESERVED);
+    out.extend_from_slice(&header_len.to_le_bytes());
+    out.extend_from_slice(&header_bytes);
+
+    let header_crc = crc32c::crc32c(&out);
+
+    let body_len = body.len() as u64;
+    out.extend_from_slice(&body_len.to_le_bytes());
+    out.extend_from_slice(&body);
+
+    let body_crc = crc32c::crc32c(&body);
+
+    out.extend_from_slice(&body_crc.to_le_bytes());
+    out.extend_from_slice(&header_crc.to_le_bytes());
+
+    Ok(out)
+}
+
+/// Decodes and fully validates a column-statistics object. Every byte is
+/// untrusted; every failure is a typed error, never a panic.
+pub fn decode_column_stats(
+    bytes: &[u8],
+    limits: &ColumnStatsLimits,
+) -> Result<DecodedColumnStats, SnapshotFormatError> {
+    if bytes.len() < MIN_COLUMN_STATS_ENVELOPE_LEN {
+        return Err(SnapshotFormatError::ColumnStatsTooSmall { size: bytes.len() });
+    }
+
+    let mut pos = 0usize;
+    let magic = take_array::<4>(bytes, &mut pos)?;
+    if magic != COLUMN_STATS_MAGIC {
+        return Err(SnapshotFormatError::ColumnStatsBadMagic);
+    }
+    let version = take_bytes(bytes, &mut pos, 1)?[0];
+    if version != COLUMN_STATS_VERSION {
+        return Err(SnapshotFormatError::ColumnStatsUnsupportedVersion(version));
+    }
+    let reserved = take_array::<3>(bytes, &mut pos)?;
+    if reserved != COLUMN_STATS_RESERVED {
+        return Err(SnapshotFormatError::ColumnStatsReservedNonZero);
+    }
+    let header_len = take_u32_le(bytes, &mut pos)?;
+    let header_bytes = take_bytes(bytes, &mut pos, to_usize(header_len)?)?;
+    let header_end = pos;
+    let header_crc_expected = crc32c::crc32c(&bytes[..header_end]);
+
+    let body_len = take_u64_le(bytes, &mut pos)?;
+    let body = take_bytes(bytes, &mut pos, to_usize(body_len)?)?;
+    let body_crc_stored = take_u32_le(bytes, &mut pos)?;
+    let header_crc_stored = take_u32_le(bytes, &mut pos)?;
+
+    if pos != bytes.len() {
+        return Err(SnapshotFormatError::ColumnStatsTrailingBytes);
+    }
+    if header_crc_stored != header_crc_expected {
+        return Err(SnapshotFormatError::ColumnStatsHeaderCrcMismatch);
+    }
+    if body_crc_stored != crc32c::crc32c(body) {
+        return Err(SnapshotFormatError::ColumnStatsBodyCrcMismatch);
+    }
+
+    let header = ColumnStatsHeader::decode(header_bytes)
+        .map_err(|e| SnapshotFormatError::ColumnStatsHeaderDecode(e.to_string()))?;
+    if header.format_version != u32::from(COLUMN_STATS_VERSION) {
+        return Err(SnapshotFormatError::ColumnStatsHeaderVersionMismatch {
+            header: header.format_version,
+            envelope: COLUMN_STATS_VERSION,
+        });
+    }
+    if header.tenant_hash.len() != 16 {
+        return Err(SnapshotFormatError::ColumnStatsBadTenantHashLen(
+            header.tenant_hash.len(),
+        ));
+    }
+    if header.body_uncompressed_len > limits.max_column_stats_bytes {
+        return Err(SnapshotFormatError::ColumnStatsDecompressedTooLarge {
+            declared: header.body_uncompressed_len,
+            cap: limits.max_column_stats_bytes,
+        });
+    }
+    let capacity = to_usize(header.body_uncompressed_len)?;
+    let decompressed = zstd::bulk::decompress(body, capacity)
+        .map_err(|e| SnapshotFormatError::Decompress(e.to_string()))?;
+    if decompressed.len() as u64 != header.body_uncompressed_len {
+        return Err(SnapshotFormatError::ColumnStatsDecompressedLenMismatch {
+            expected: header.body_uncompressed_len,
+            actual: decompressed.len() as u64,
+        });
+    }
+
+    let mut segments = Vec::new();
+    let mut cursor: &[u8] = &decompressed[..];
+    while !cursor.is_empty() {
+        let segment = ColumnStatsSegment::decode_length_delimited(&mut cursor)
+            .map_err(|e| SnapshotFormatError::ColumnStatsSegmentDecode(e.to_string()))?;
+        segments.push(segment);
+    }
+    if segments.len() as u64 != header.segment_count {
+        return Err(SnapshotFormatError::ColumnStatsSegmentCountMismatch {
+            expected: header.segment_count,
+            actual: segments.len() as u64,
+        });
+    }
+    validate_segments(&segments)?;
+
+    Ok(DecodedColumnStats { header, segments })
+}
+
+/// Sort/uniqueness/field validation shared by `encode_column_stats`
+/// (defensive check of caller input) and `decode_column_stats` (untrusted-
+/// bytes check).
+fn validate_segments(segments: &[ColumnStatsSegment]) -> Result<(), SnapshotFormatError> {
+    for (i, segment) in segments.iter().enumerate() {
+        if segment.writer_id.len() != 16 {
+            return Err(SnapshotFormatError::ColumnStatsBadFieldLen {
+                field: "writer_id",
+                expected: 16,
+                actual: segment.writer_id.len(),
+            });
+        }
+        if i > 0 {
+            match segment_key(&segments[i - 1]).cmp(&segment_key(segment)) {
+                std::cmp::Ordering::Less => {}
+                std::cmp::Ordering::Equal => {
+                    return Err(SnapshotFormatError::ColumnStatsDuplicateSegment);
+                }
+                std::cmp::Ordering::Greater => {
+                    return Err(SnapshotFormatError::ColumnStatsSegmentsUnsorted);
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn segment_key(segment: &ColumnStatsSegment) -> (u32, u32, &[u8], u64, u64) {
+    (
+        segment.ingest_hour_bucket,
+        segment.shard,
+        segment.writer_id.as_slice(),
+        segment.writer_epoch,
+        segment.writer_seq,
+    )
+}
+
+fn to_usize<T: TryInto<usize>>(v: T) -> Result<usize, SnapshotFormatError> {
+    v.try_into().map_err(|_| SnapshotFormatError::Truncated)
+}
+
+fn take_bytes<'a>(
+    bytes: &'a [u8],
+    pos: &mut usize,
+    n: usize,
+) -> Result<&'a [u8], SnapshotFormatError> {
+    let end = pos.checked_add(n).ok_or(SnapshotFormatError::Truncated)?;
+    let slice = bytes.get(*pos..end).ok_or(SnapshotFormatError::Truncated)?;
+    *pos = end;
+    Ok(slice)
+}
+
+fn take_array<const N: usize>(
+    bytes: &[u8],
+    pos: &mut usize,
+) -> Result<[u8; N], SnapshotFormatError> {
+    let slice = take_bytes(bytes, pos, N)?;
+    slice.try_into().map_err(|_| SnapshotFormatError::Truncated)
+}
+
+fn take_u32_le(bytes: &[u8], pos: &mut usize) -> Result<u32, SnapshotFormatError> {
+    Ok(u32::from_le_bytes(take_array::<4>(bytes, pos)?))
+}
+
+fn take_u64_le(bytes: &[u8], pos: &mut usize) -> Result<u64, SnapshotFormatError> {
+    Ok(u64::from_le_bytes(take_array::<8>(bytes, pos)?))
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use ravel_proto::catalog::v1::{ColumnStat, ColumnStatsSegment, ColumnValue};
+
+    use super::*;
+
+    fn segment(hour: u32, shard: u32, seq: u64) -> ColumnStatsSegment {
+        ColumnStatsSegment {
+            ingest_hour_bucket: hour,
+            shard,
+            writer_id: vec![0xAA; 16],
+            writer_epoch: 1,
+            writer_seq: seq,
+            columns: vec![ColumnStat {
+                name: "AdvEngineID".to_string(),
+                declared_type: 2,
+                non_null_count: 10,
+                null_count: 0,
+                min: Some(ColumnValue {
+                    kind: Some(ravel_proto::catalog::v1::column_value::Kind::I64(0)),
+                }),
+                max: Some(ColumnValue {
+                    kind: Some(ravel_proto::catalog::v1::column_value::Kind::I64(9)),
+                }),
+                dictionary_present: true,
+                dictionary: vec![],
+            }],
+        }
+    }
+
+    #[test]
+    fn round_trips() {
+        let segments = vec![segment(1, 0, 1), segment(1, 0, 2), segment(2, 0, 1)];
+        let bytes =
+            encode_column_stats([0x11; 16], 3, vec![vec![0x22; 32]], &segments).expect("encodes");
+        let decoded = decode_column_stats(&bytes, &ColumnStatsLimits::default()).expect("decodes");
+        assert_eq!(decoded.segments, segments);
+        assert_eq!(decoded.header.segment_count, 3);
+    }
+
+    #[test]
+    fn unsorted_segments_rejected() {
+        let segments = vec![segment(2, 0, 1), segment(1, 0, 1)];
+        let err =
+            encode_column_stats([0x11; 16], 3, vec![], &segments).expect_err("unsorted rejected");
+        assert_eq!(err, SnapshotFormatError::ColumnStatsSegmentsUnsorted);
+    }
+
+    #[test]
+    fn duplicate_identity_rejected() {
+        let segments = vec![segment(1, 0, 1), segment(1, 0, 1)];
+        let err =
+            encode_column_stats([0x11; 16], 3, vec![], &segments).expect_err("duplicate rejected");
+        assert_eq!(err, SnapshotFormatError::ColumnStatsDuplicateSegment);
+    }
+
+    #[test]
+    fn oversized_declared_length_rejected_before_decompress() {
+        let segments = vec![segment(1, 0, 1)];
+        let bytes = encode_column_stats([0x11; 16], 3, vec![], &segments).expect("encodes");
+        let tiny_limit = ColumnStatsLimits {
+            max_column_stats_bytes: 1,
+        };
+        let err = decode_column_stats(&bytes, &tiny_limit).expect_err("rejected");
+        assert!(matches!(
+            err,
+            SnapshotFormatError::ColumnStatsDecompressedTooLarge { .. }
+        ));
+    }
+}

--- a/crates/ravel-catalog/src/snapshot_format/column_stats.rs
+++ b/crates/ravel-catalog/src/snapshot_format/column_stats.rs
@@ -21,8 +21,11 @@
 //! that dictionary earns its complexity for a huge flat cross-segment name
 //! space, which per-segment column statistics don't have.
 
+use std::collections::HashSet;
+
 use prost::Message;
-use ravel_proto::catalog::v1::{ColumnStatsHeader, ColumnStatsSegment};
+use ravel_proto::catalog::v1::column_value::Kind;
+use ravel_proto::catalog::v1::{ColumnStat, ColumnStatsHeader, ColumnStatsSegment, ColumnValue};
 
 use super::error::SnapshotFormatError;
 use super::{
@@ -185,7 +188,11 @@ pub fn decode_column_stats(
 
 /// Sort/uniqueness/field validation shared by `encode_column_stats`
 /// (defensive check of caller input) and `decode_column_stats` (untrusted-
-/// bytes check).
+/// bytes check). Beyond segment identity this also validates every
+/// `ColumnStat`'s internal semantics (ADR-0850): a record the metadata-only
+/// query path could read (`declared_not_equal_count`/`declared_group_counts`)
+/// is rejected here before it can ever be loaded, so those paths can never
+/// derive a wrong answer from an internally-inconsistent record. Fail closed.
 fn validate_segments(segments: &[ColumnStatsSegment]) -> Result<(), SnapshotFormatError> {
     for (i, segment) in segments.iter().enumerate() {
         if segment.writer_id.len() != 16 {
@@ -206,8 +213,137 @@ fn validate_segments(segments: &[ColumnStatsSegment]) -> Result<(), SnapshotForm
                 }
             }
         }
+        validate_columns(&segment.columns)?;
     }
     Ok(())
+}
+
+/// Per-segment column-list validation: no duplicate column name, and every
+/// column internally consistent.
+fn validate_columns(columns: &[ColumnStat]) -> Result<(), SnapshotFormatError> {
+    let mut names: HashSet<&str> = HashSet::with_capacity(columns.len());
+    for column in columns {
+        if !names.insert(column.name.as_str()) {
+            return Err(SnapshotFormatError::ColumnStatsDuplicateColumnName {
+                name: column.name.clone(),
+            });
+        }
+        validate_column(column)?;
+    }
+    Ok(())
+}
+
+/// One column's internal-consistency rules (ADR-0850). A record failing any
+/// of these could make the metadata-only path answer a query wrong, so it is
+/// a typed rejection, never silently trusted:
+///
+/// - `declared_type` names a known typed-attribute type;
+/// - every `min`/`max`/dictionary value's kind matches `declared_type`;
+/// - `min`/`max` are absent when `non_null_count == 0` and `min <= max`;
+/// - a present dictionary has no duplicate value and its counts sum to
+///   exactly `non_null_count`; an absent dictionary carries no entries.
+fn validate_column(column: &ColumnStat) -> Result<(), SnapshotFormatError> {
+    if !(1..=4).contains(&column.declared_type) {
+        return Err(SnapshotFormatError::ColumnStatsUnknownDeclaredType {
+            name: column.name.clone(),
+            declared_type: column.declared_type,
+        });
+    }
+
+    if column.non_null_count == 0 && (column.min.is_some() || column.max.is_some()) {
+        return Err(SnapshotFormatError::ColumnStatsUnexpectedMinMax {
+            name: column.name.clone(),
+        });
+    }
+    if let Some(min) = &column.min {
+        check_value_kind(column, min, "min")?;
+    }
+    if let Some(max) = &column.max {
+        check_value_kind(column, max, "max")?;
+    }
+    if let (Some(min), Some(max)) = (&column.min, &column.max)
+        && compare_values(min, max) == Some(std::cmp::Ordering::Greater)
+    {
+        return Err(SnapshotFormatError::ColumnStatsMinMaxInverted {
+            name: column.name.clone(),
+        });
+    }
+
+    if column.dictionary_present {
+        let mut seen: HashSet<Vec<u8>> = HashSet::with_capacity(column.dictionary.len());
+        let mut total: u64 = 0;
+        for entry in &column.dictionary {
+            let value = entry.value.as_ref().ok_or_else(|| {
+                SnapshotFormatError::ColumnStatsDictEntryMissingValue {
+                    name: column.name.clone(),
+                }
+            })?;
+            check_value_kind(column, value, "dictionary")?;
+            if !seen.insert(value.encode_to_vec()) {
+                return Err(SnapshotFormatError::ColumnStatsDuplicateDictValue {
+                    name: column.name.clone(),
+                });
+            }
+            total = total.saturating_add(entry.count);
+        }
+        if total != column.non_null_count {
+            return Err(SnapshotFormatError::ColumnStatsDictCountMismatch {
+                name: column.name.clone(),
+                dict_total: total,
+                non_null_count: column.non_null_count,
+            });
+        }
+    } else if !column.dictionary.is_empty() {
+        return Err(SnapshotFormatError::ColumnStatsDictPresentMismatch {
+            name: column.name.clone(),
+            entries: column.dictionary.len(),
+        });
+    }
+
+    Ok(())
+}
+
+/// Whether `value`'s wire kind matches the `ColumnStat.declared_type` tag
+/// (1=Str, 2=I64, 3=Bool, 4=Bytes; the `declared_type_to_stats_tag` mapping
+/// the fold writes with).
+fn value_kind_matches(declared_type: u32, value: &ColumnValue) -> bool {
+    matches!(
+        (declared_type, value.kind.as_ref()),
+        (1, Some(Kind::StrUtf8(_)))
+            | (2, Some(Kind::I64(_)))
+            | (3, Some(Kind::B(_)))
+            | (4, Some(Kind::BytesVal(_)))
+    )
+}
+
+fn check_value_kind(
+    column: &ColumnStat,
+    value: &ColumnValue,
+    field: &'static str,
+) -> Result<(), SnapshotFormatError> {
+    if value_kind_matches(column.declared_type, value) {
+        Ok(())
+    } else {
+        Err(SnapshotFormatError::ColumnStatsValueTypeMismatch {
+            name: column.name.clone(),
+            field,
+            declared_type: column.declared_type,
+        })
+    }
+}
+
+/// Total order over two same-kind values. `None` when the kinds differ (the
+/// caller has already kind-checked both against `declared_type`, so this
+/// never happens for a valid record); a `None` never triggers the inverted
+/// check, keeping the failure attributable to the kind rule instead.
+fn compare_values(a: &ColumnValue, b: &ColumnValue) -> Option<std::cmp::Ordering> {
+    match (a.kind.as_ref(), b.kind.as_ref()) {
+        (Some(Kind::I64(x)), Some(Kind::I64(y))) => Some(x.cmp(y)),
+        (Some(Kind::B(x)), Some(Kind::B(y))) => Some(x.cmp(y)),
+        (Some(Kind::StrUtf8(x)), Some(Kind::StrUtf8(y))) => Some(x.cmp(y)),
+        (Some(Kind::BytesVal(x)), Some(Kind::BytesVal(y))) => Some(x.cmp(y)),
+        _ => None,
+    }
 }
 
 fn segment_key(segment: &ColumnStatsSegment) -> (u32, u32, &[u8], u64, u64) {
@@ -254,11 +390,25 @@ fn take_u64_le(bytes: &[u8], pos: &mut usize) -> Result<u64, SnapshotFormatError
 #[cfg(test)]
 #[allow(clippy::expect_used)]
 mod tests {
-    use ravel_proto::catalog::v1::{ColumnStat, ColumnStatsSegment, ColumnValue};
+    use ravel_proto::catalog::v1::{ColumnStat, ColumnStatsSegment, ColumnValue, DictEntry};
 
     use super::*;
 
+    fn i64_value(v: i64) -> ColumnValue {
+        ColumnValue {
+            kind: Some(ravel_proto::catalog::v1::column_value::Kind::I64(v)),
+        }
+    }
+
     fn segment(hour: u32, shard: u32, seq: u64) -> ColumnStatsSegment {
+        // A consistent I64 column: values 0..=9, each seen once, so the
+        // dictionary counts sum to non_null_count and min/max bracket it.
+        let dictionary: Vec<DictEntry> = (0..10)
+            .map(|v| DictEntry {
+                value: Some(i64_value(v)),
+                count: 1,
+            })
+            .collect();
         ColumnStatsSegment {
             ingest_hour_bucket: hour,
             shard,
@@ -270,14 +420,10 @@ mod tests {
                 declared_type: 2,
                 non_null_count: 10,
                 null_count: 0,
-                min: Some(ColumnValue {
-                    kind: Some(ravel_proto::catalog::v1::column_value::Kind::I64(0)),
-                }),
-                max: Some(ColumnValue {
-                    kind: Some(ravel_proto::catalog::v1::column_value::Kind::I64(9)),
-                }),
+                min: Some(i64_value(0)),
+                max: Some(i64_value(9)),
                 dictionary_present: true,
-                dictionary: vec![],
+                dictionary,
             }],
         }
     }
@@ -306,6 +452,139 @@ mod tests {
         let err =
             encode_column_stats([0x11; 16], 3, vec![], &segments).expect_err("duplicate rejected");
         assert_eq!(err, SnapshotFormatError::ColumnStatsDuplicateSegment);
+    }
+
+    /// Finding 4's exact example: a column claiming `non_null_count = 10`
+    /// with `dictionary_present = true` but an empty dictionary is internally
+    /// inconsistent (the metadata-only path would treat all 10 rows as
+    /// not-equal to any literal). It must be rejected at encode/decode, not
+    /// trusted.
+    #[test]
+    fn empty_dictionary_with_nonzero_non_null_rejected() {
+        let mut seg = segment(1, 0, 1);
+        seg.columns[0].dictionary = vec![];
+        let err = encode_column_stats([0x11; 16], 3, vec![], &[seg]).expect_err("rejected");
+        assert_eq!(
+            err,
+            SnapshotFormatError::ColumnStatsDictCountMismatch {
+                name: "AdvEngineID".to_string(),
+                dict_total: 0,
+                non_null_count: 10,
+            }
+        );
+    }
+
+    #[test]
+    fn dictionary_counts_not_summing_to_non_null_rejected() {
+        let mut seg = segment(1, 0, 1);
+        // Drop one entry so the counts total 9 but non_null_count stays 10.
+        seg.columns[0].dictionary.pop();
+        let err = encode_column_stats([0x11; 16], 3, vec![], &[seg]).expect_err("rejected");
+        assert_eq!(
+            err,
+            SnapshotFormatError::ColumnStatsDictCountMismatch {
+                name: "AdvEngineID".to_string(),
+                dict_total: 9,
+                non_null_count: 10,
+            }
+        );
+    }
+
+    #[test]
+    fn wrong_value_kind_rejected() {
+        let mut seg = segment(1, 0, 1);
+        seg.columns[0].dictionary[0].value = Some(ColumnValue {
+            kind: Some(ravel_proto::catalog::v1::column_value::Kind::B(true)),
+        });
+        let err = encode_column_stats([0x11; 16], 3, vec![], &[seg]).expect_err("rejected");
+        assert_eq!(
+            err,
+            SnapshotFormatError::ColumnStatsValueTypeMismatch {
+                name: "AdvEngineID".to_string(),
+                field: "dictionary",
+                declared_type: 2,
+            }
+        );
+    }
+
+    #[test]
+    fn duplicate_dictionary_value_rejected() {
+        let mut seg = segment(1, 0, 1);
+        // Two entries with the same value; total still 10.
+        seg.columns[0].dictionary = vec![
+            DictEntry {
+                value: Some(i64_value(0)),
+                count: 5,
+            },
+            DictEntry {
+                value: Some(i64_value(0)),
+                count: 5,
+            },
+        ];
+        let err = encode_column_stats([0x11; 16], 3, vec![], &[seg]).expect_err("rejected");
+        assert_eq!(
+            err,
+            SnapshotFormatError::ColumnStatsDuplicateDictValue {
+                name: "AdvEngineID".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn duplicate_column_name_rejected() {
+        let mut seg = segment(1, 0, 1);
+        let dup = seg.columns[0].clone();
+        seg.columns.push(dup);
+        let err = encode_column_stats([0x11; 16], 3, vec![], &[seg]).expect_err("rejected");
+        assert_eq!(
+            err,
+            SnapshotFormatError::ColumnStatsDuplicateColumnName {
+                name: "AdvEngineID".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn min_greater_than_max_rejected() {
+        let mut seg = segment(1, 0, 1);
+        seg.columns[0].min = Some(i64_value(9));
+        seg.columns[0].max = Some(i64_value(0));
+        let err = encode_column_stats([0x11; 16], 3, vec![], &[seg]).expect_err("rejected");
+        assert_eq!(
+            err,
+            SnapshotFormatError::ColumnStatsMinMaxInverted {
+                name: "AdvEngineID".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn min_max_present_with_zero_non_null_rejected() {
+        let mut seg = segment(1, 0, 1);
+        seg.columns[0].non_null_count = 0;
+        seg.columns[0].dictionary = vec![];
+        // min/max still populated: inconsistent with an all-null column.
+        let err = encode_column_stats([0x11; 16], 3, vec![], &[seg]).expect_err("rejected");
+        assert_eq!(
+            err,
+            SnapshotFormatError::ColumnStatsUnexpectedMinMax {
+                name: "AdvEngineID".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn dictionary_entries_without_present_flag_rejected() {
+        let mut seg = segment(1, 0, 1);
+        seg.columns[0].dictionary_present = false;
+        let err = encode_column_stats([0x11; 16], 3, vec![], &[seg]).expect_err("rejected");
+        assert_eq!(
+            err,
+            SnapshotFormatError::ColumnStatsDictPresentMismatch {
+                name: "AdvEngineID".to_string(),
+                entries: 10,
+            }
+        );
     }
 
     #[test]

--- a/crates/ravel-catalog/src/snapshot_format/column_stats.rs
+++ b/crates/ravel-catalog/src/snapshot_format/column_stats.rs
@@ -255,6 +255,14 @@ fn validate_column(column: &ColumnStat) -> Result<(), SnapshotFormatError> {
             name: column.name.clone(),
         });
     }
+    // The symmetric case: non-null rows must carry both extrema. A record with
+    // rows but no min/max cannot support a MIN/MAX answer, and a reader that
+    // trusted it would report the extremum of non-null data as exactly NULL.
+    if column.non_null_count > 0 && (column.min.is_none() || column.max.is_none()) {
+        return Err(SnapshotFormatError::ColumnStatsMissingMinMax {
+            name: column.name.clone(),
+        });
+    }
     if let Some(min) = &column.min {
         check_value_kind(column, min, "min")?;
     }

--- a/crates/ravel-catalog/src/snapshot_format/error.rs
+++ b/crates/ravel-catalog/src/snapshot_format/error.rs
@@ -243,6 +243,12 @@ pub enum SnapshotFormatError {
         "column-stats column {name:?} carries min/max but non_null_count is zero (must be absent)"
     )]
     ColumnStatsUnexpectedMinMax { name: String },
+    /// A column reports non-null rows but omits `min` or `max`, so it cannot
+    /// support a MIN/MAX answer.
+    #[error(
+        "column-stats column {name:?} has non_null_count > 0 but omits min or max (both required)"
+    )]
+    ColumnStatsMissingMinMax { name: String },
     #[error("column-stats column {name:?} has min greater than max")]
     ColumnStatsMinMaxInverted { name: String },
 }

--- a/crates/ravel-catalog/src/snapshot_format/error.rs
+++ b/crates/ravel-catalog/src/snapshot_format/error.rs
@@ -148,4 +148,67 @@ pub enum SnapshotFormatError {
     PostingsPartBindingMismatch,
     #[error("malformed varint in postings body")]
     PostingsBadVarint,
+
+    #[error("head column-stats ref blake3 must be 32 bytes, got {0}")]
+    BadColumnStatsRefBlake3Len(usize),
+    #[error("head column-stats ref has an empty key")]
+    EmptyColumnStatsKey,
+    #[error("head column-stats ref part_blake3[{index}] must be 32 bytes, got {actual}")]
+    BadColumnStatsRefPartBlake3Len { index: usize, actual: usize },
+    #[error("head column-stats ref names {stats_parts} parts but head has {head_parts} parts")]
+    ColumnStatsRefPartCountMismatch {
+        stats_parts: usize,
+        head_parts: usize,
+    },
+    #[error("head column-stats ref part_blake3[{index}] does not match parts[{index}].blake3")]
+    ColumnStatsRefPartBlake3Mismatch { index: usize },
+
+    #[error("column-stats object is smaller than the minimum envelope prefix: {size} bytes")]
+    ColumnStatsTooSmall { size: usize },
+    #[error("bad column-stats magic bytes")]
+    ColumnStatsBadMagic,
+    #[error("unsupported column-stats format version {0}")]
+    ColumnStatsUnsupportedVersion(u8),
+    #[error("column-stats reserved envelope bytes are non-zero")]
+    ColumnStatsReservedNonZero,
+    #[error("column-stats data has trailing bytes past the declared structure")]
+    ColumnStatsTrailingBytes,
+    #[error("column-stats header_crc32c mismatch")]
+    ColumnStatsHeaderCrcMismatch,
+    #[error("column-stats header protobuf failed to decode: {0}")]
+    ColumnStatsHeaderDecode(String),
+    #[error(
+        "column-stats header format_version {header} does not match envelope version {envelope}"
+    )]
+    ColumnStatsHeaderVersionMismatch { header: u32, envelope: u8 },
+    #[error("column-stats header tenant_hash must be 16 bytes, got {0}")]
+    ColumnStatsBadTenantHashLen(usize),
+    #[error("column-stats body_crc32c mismatch")]
+    ColumnStatsBodyCrcMismatch,
+    #[error(
+        "declared decompressed column-stats body length {declared} exceeds configured cap {cap}"
+    )]
+    ColumnStatsDecompressedTooLarge { declared: u64, cap: u64 },
+    #[error(
+        "decompressed column-stats body length {actual} does not match header's declared {expected}"
+    )]
+    ColumnStatsDecompressedLenMismatch { expected: u64, actual: u64 },
+    #[error("column-stats segment protobuf failed to decode: {0}")]
+    ColumnStatsSegmentDecode(String),
+    #[error("column-stats segment_count {actual} does not match header's declared {expected}")]
+    ColumnStatsSegmentCountMismatch { expected: u64, actual: u64 },
+    #[error(
+        "column-stats segments are not strictly sorted by (ingest_hour_bucket, shard, writer_id, writer_epoch, writer_seq)"
+    )]
+    ColumnStatsSegmentsUnsorted,
+    #[error("duplicate segment identity in column-stats segment set")]
+    ColumnStatsDuplicateSegment,
+    #[error("column-stats segment {field} must be {expected} bytes, got {actual}")]
+    ColumnStatsBadFieldLen {
+        field: &'static str,
+        expected: usize,
+        actual: usize,
+    },
+    #[error("column-stats header part_blake3 does not match the expected covered parts")]
+    ColumnStatsPartBindingMismatch,
 }

--- a/crates/ravel-catalog/src/snapshot_format/error.rs
+++ b/crates/ravel-catalog/src/snapshot_format/error.rs
@@ -211,4 +211,38 @@ pub enum SnapshotFormatError {
     },
     #[error("column-stats header part_blake3 does not match the expected covered parts")]
     ColumnStatsPartBindingMismatch,
+    #[error("column-stats segment carries duplicate column name {name:?}")]
+    ColumnStatsDuplicateColumnName { name: String },
+    #[error("column-stats column {name:?} has an unknown declared_type {declared_type}")]
+    ColumnStatsUnknownDeclaredType { name: String, declared_type: u32 },
+    #[error(
+        "column-stats column {name:?} carries a {field} value whose kind does not match its declared_type {declared_type}"
+    )]
+    ColumnStatsValueTypeMismatch {
+        name: String,
+        field: &'static str,
+        declared_type: u32,
+    },
+    #[error("column-stats column {name:?} carries a dictionary entry with no value")]
+    ColumnStatsDictEntryMissingValue { name: String },
+    #[error("column-stats column {name:?} carries duplicate dictionary value")]
+    ColumnStatsDuplicateDictValue { name: String },
+    #[error(
+        "column-stats column {name:?} dictionary counts total {dict_total} but non_null_count is {non_null_count}"
+    )]
+    ColumnStatsDictCountMismatch {
+        name: String,
+        dict_total: u64,
+        non_null_count: u64,
+    },
+    #[error(
+        "column-stats column {name:?} has dictionary_present=false but carries {entries} dictionary entries"
+    )]
+    ColumnStatsDictPresentMismatch { name: String, entries: usize },
+    #[error(
+        "column-stats column {name:?} carries min/max but non_null_count is zero (must be absent)"
+    )]
+    ColumnStatsUnexpectedMinMax { name: String },
+    #[error("column-stats column {name:?} has min greater than max")]
+    ColumnStatsMinMaxInverted { name: String },
 }

--- a/crates/ravel-catalog/src/snapshot_format/head.rs
+++ b/crates/ravel-catalog/src/snapshot_format/head.rs
@@ -134,5 +134,38 @@ fn validate_head(head: &SnapshotHead) -> Result<(), SnapshotFormatError> {
             }
         }
     }
+
+    if let Some(column_stats) = &head.column_stats {
+        if column_stats.blake3.len() != 32 {
+            return Err(SnapshotFormatError::BadColumnStatsRefBlake3Len(
+                column_stats.blake3.len(),
+            ));
+        }
+        if column_stats.key.is_empty() {
+            return Err(SnapshotFormatError::EmptyColumnStatsKey);
+        }
+        if column_stats.part_blake3.len() != head.parts.len() {
+            return Err(SnapshotFormatError::ColumnStatsRefPartCountMismatch {
+                stats_parts: column_stats.part_blake3.len(),
+                head_parts: head.parts.len(),
+            });
+        }
+        for (index, (stats_hash, part)) in column_stats
+            .part_blake3
+            .iter()
+            .zip(head.parts.iter())
+            .enumerate()
+        {
+            if stats_hash.len() != 32 {
+                return Err(SnapshotFormatError::BadColumnStatsRefPartBlake3Len {
+                    index,
+                    actual: stats_hash.len(),
+                });
+            }
+            if stats_hash != &part.blake3 {
+                return Err(SnapshotFormatError::ColumnStatsRefPartBlake3Mismatch { index });
+            }
+        }
+    }
     Ok(())
 }

--- a/crates/ravel-catalog/src/snapshot_format/mod.rs
+++ b/crates/ravel-catalog/src/snapshot_format/mod.rs
@@ -4,11 +4,13 @@
 //! phase 2/3's job). Kept in one place so writer and reader can't drift
 //! apart, mirroring `ravel-segment`'s `format.rs` convention.
 
+mod column_stats;
 mod error;
 mod head;
 mod part;
 mod postings;
 
+pub use column_stats::{DecodedColumnStats, decode_column_stats, encode_column_stats};
 pub use error::SnapshotFormatError;
 pub use head::{HEAD_FORMAT_VERSION, decode_head, encode_head};
 pub use part::{DecodedPart, decode_part, encode_part, encode_part_ranged};
@@ -84,6 +86,46 @@ impl Default for PostingsLimits {
     }
 }
 
+/// Envelope magic, first 4 bytes of every column-statistics object
+/// (ADR-0850).
+pub const COLUMN_STATS_MAGIC: [u8; 4] = *b"RCST";
+
+/// Column-statistics envelope format version. This is the v1 layout.
+pub const COLUMN_STATS_VERSION: u8 = 1;
+
+/// Reserved column-statistics envelope bytes; must always be zero in v1.
+pub const COLUMN_STATS_RESERVED: [u8; 3] = [0, 0, 0];
+
+/// Minimum possible column-statistics envelope size: every fixed-width
+/// field present, with a zero-length header and zero-length body.
+pub(crate) const MIN_COLUMN_STATS_ENVELOPE_LEN: usize = 4 + 1 + 3 + 4 + 8 + 4 + 4;
+
+/// Default resource cap for a column-stats object's declared decompressed
+/// body size, applied before decompression allocates a buffer.
+pub const DEFAULT_MAX_COLUMN_STATS_BYTES: u64 = 256 << 20;
+
+/// Fold-time cardinality ceiling: the most distinct values one segment's
+/// dictionary for one column may hold before the dictionary is omitted
+/// outright (ADR-0850 decision 3). Chosen to comfortably cover legitimate
+/// per-segment categorical columns while bounding one segment's dictionary
+/// size; never used to truncate, only to gate presence.
+pub const DEFAULT_MAX_COLUMN_DICTIONARY_ENTRIES: usize = 10_000;
+
+/// Decode-time resource bound, checked before a column-stats object's body
+/// is decompressed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ColumnStatsLimits {
+    pub max_column_stats_bytes: u64,
+}
+
+impl Default for ColumnStatsLimits {
+    fn default() -> Self {
+        ColumnStatsLimits {
+            max_column_stats_bytes: DEFAULT_MAX_COLUMN_STATS_BYTES,
+        }
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::expect_used)]
 mod tests {
@@ -116,6 +158,7 @@ mod tests {
             folder_id: vec![0x33; 16],
             created_unix_ns: 0,
             shard_generation_count: 1,
+            column_stats: None,
         }
     }
 
@@ -325,5 +368,10 @@ mod tests {
         assert_eq!(POSTINGS_VERSION, 1);
         assert_eq!(POSTINGS_RESERVED, [0, 0, 0]);
         assert_eq!(DEFAULT_MAX_POSTINGS_BYTES, 256 << 20);
+        assert_eq!(COLUMN_STATS_MAGIC, *b"RCST");
+        assert_eq!(COLUMN_STATS_VERSION, 1);
+        assert_eq!(COLUMN_STATS_RESERVED, [0, 0, 0]);
+        assert_eq!(DEFAULT_MAX_COLUMN_STATS_BYTES, 256 << 20);
+        assert_eq!(DEFAULT_MAX_COLUMN_DICTIONARY_ENTRIES, 10_000);
     }
 }

--- a/crates/ravel-catalog/src/snapshot_resolve.rs
+++ b/crates/ravel-catalog/src/snapshot_resolve.rs
@@ -1124,6 +1124,7 @@ mod tests {
             created_unix_ns: 0,
             postings: None,
             shard_generation_count: 1,
+            column_stats: None,
         }
     }
 
@@ -1268,6 +1269,7 @@ mod tests {
             created_unix_ns: 0,
             postings: None,
             shard_generation_count: 1,
+            column_stats: None,
         };
         let head_bytes = snapshot_format::encode_head(&head).expect("encode head");
         let head_key = head_object_key(&tenant, Signal::Metrics);

--- a/crates/ravel-catalog/tests/resharding.rs
+++ b/crates/ravel-catalog/tests/resharding.rs
@@ -405,6 +405,7 @@ async fn head_ahead_of_reader_fails_closed() {
         folder_id: vec![0x22; 16],
         created_unix_ns: 0,
         shard_generation_count: 2,
+        column_stats: None,
     };
     store
         .put(

--- a/crates/ravel-catalog/tests/snapshot_format_corrupt.rs
+++ b/crates/ravel-catalog/tests/snapshot_format_corrupt.rs
@@ -444,6 +444,7 @@ fn base_head() -> SnapshotHead {
         folder_id: vec![0x33; 16],
         created_unix_ns: 1_000,
         shard_generation_count: 1,
+        column_stats: None,
     }
 }
 

--- a/crates/ravel-catalog/tests/snapshot_format_roundtrip.rs
+++ b/crates/ravel-catalog/tests/snapshot_format_roundtrip.rs
@@ -8,7 +8,9 @@ use ravel_catalog::{
     NamePostings, PartLimits, PostingsLimits, decode_head, decode_part, decode_postings,
     encode_head, encode_part, encode_postings,
 };
-use ravel_proto::catalog::v1::{SnapshotEntry, SnapshotHead, SnapshotPartRef, SnapshotPostingsRef};
+use ravel_proto::catalog::v1::{
+    SnapshotColumnStatsRef, SnapshotEntry, SnapshotHead, SnapshotPartRef, SnapshotPostingsRef,
+};
 
 fn entry_key(e: &SnapshotEntry) -> (u32, u32, Vec<u8>, u64, u64) {
     (
@@ -137,6 +139,30 @@ fn arb_postings_ref(
     ]
 }
 
+fn arb_column_stats_ref(
+    parts: &[SnapshotPartRef],
+) -> impl Strategy<Value = Option<SnapshotColumnStatsRef>> + use<> {
+    let part_blake3: Vec<Vec<u8>> = parts.iter().map(|p| p.blake3.clone()).collect();
+    prop_oneof![
+        Just(None),
+        (
+            "[a-z0-9/]{1,40}",
+            prop::collection::vec(any::<u8>(), 32),
+            any::<u64>(),
+            any::<u32>(),
+        )
+            .prop_map(move |(key, blake3, size, segment_count)| {
+                Some(SnapshotColumnStatsRef {
+                    key,
+                    blake3,
+                    size,
+                    segment_count,
+                    part_blake3: part_blake3.clone(),
+                })
+            }),
+    ]
+}
+
 fn arb_head() -> impl Strategy<Value = SnapshotHead> {
     // Each raw part carries a (gap, span) plus its arbitrary content fields.
     // `arb_head` folds the gaps/spans into ascending, strictly-disjoint hour
@@ -176,22 +202,24 @@ fn arb_head() -> impl Strategy<Value = SnapshotHead> {
                     }
                 })
                 .collect();
-            arb_postings_ref(&parts).prop_map(move |postings| {
-                let watermark_hour = parts.iter().map(|p| p.watermark_hour).max().unwrap_or(0);
-                SnapshotHead {
-                    format_version: 1,
-                    tenant_hash: vec![0x33u8; 16],
-                    signal: 1,
-                    shard_count: 8,
-                    watermark_hour,
-                    parts: parts.clone(),
-                    postings,
-                    folder_id: folder_id.clone(),
-                    created_unix_ns,
-                    shard_generation_count: 1,
-                    column_stats: None,
-                }
-            })
+            (arb_postings_ref(&parts), arb_column_stats_ref(&parts)).prop_map(
+                move |(postings, column_stats)| {
+                    let watermark_hour = parts.iter().map(|p| p.watermark_hour).max().unwrap_or(0);
+                    SnapshotHead {
+                        format_version: 1,
+                        tenant_hash: vec![0x33u8; 16],
+                        signal: 1,
+                        shard_count: 8,
+                        watermark_hour,
+                        parts: parts.clone(),
+                        postings,
+                        folder_id: folder_id.clone(),
+                        created_unix_ns,
+                        shard_generation_count: 1,
+                        column_stats,
+                    }
+                },
+            )
         })
 }
 

--- a/crates/ravel-catalog/tests/snapshot_format_roundtrip.rs
+++ b/crates/ravel-catalog/tests/snapshot_format_roundtrip.rs
@@ -189,6 +189,7 @@ fn arb_head() -> impl Strategy<Value = SnapshotHead> {
                     folder_id: folder_id.clone(),
                     created_unix_ns,
                     shard_generation_count: 1,
+                    column_stats: None,
                 }
             })
         })

--- a/crates/ravel-maintain/src/retention.rs
+++ b/crates/ravel-maintain/src/retention.rs
@@ -140,8 +140,11 @@ enum HeadLoad {
     /// HEAD is present but undecodable (or a newer format this build cannot
     /// read): fail-closed, every bucket is blocked.
     Unreadable,
-    /// HEAD is present and decoded.
-    Present(SnapshotHead),
+    /// HEAD is present and decoded. Boxed so this large variant does not
+    /// inflate every `HeadLoad` (`clippy::large_enum_variant`): `SnapshotHead`
+    /// grew past 300 bytes when ADR-0850 added `column_stats`, while the other
+    /// variants are unit-sized.
+    Present(Box<SnapshotHead>),
 }
 
 /// The result of gating one bucket on HEAD reachability.
@@ -232,7 +235,7 @@ impl SnapshotReachability {
             let head_key = catalog_head_key(tenant, signal);
             let load = match store.get(&head_key, GetRange::Full).await {
                 Ok(got) => match decode_head(got.data.as_ref()) {
-                    Ok(head) => HeadLoad::Present(head),
+                    Ok(head) => HeadLoad::Present(Box::new(head)),
                     Err(err) => {
                         // Present but undecodable/newer: fail-closed. Cannot
                         // prove non-reachability from a HEAD we cannot read.

--- a/crates/ravel-maintain/src/sweep.rs
+++ b/crates/ravel-maintain/src/sweep.rs
@@ -2178,6 +2178,7 @@ mod tests {
             folder_id: vec![0u8; 16],
             created_unix_ns: 0,
             postings,
+            column_stats: None,
             shard_generation_count: 1,
         };
         let bytes = ravel_catalog::encode_head(&head).expect("valid HEAD encodes");
@@ -2655,6 +2656,7 @@ mod tests {
                 folder_id: vec![0u8; 16],
                 created_unix_ns: 0,
                 postings: None,
+                column_stats: None,
                 shard_generation_count: 1,
             };
             Bytes::from(ravel_catalog::encode_head(&head).expect("valid swapped HEAD"))

--- a/crates/ravel-sql/Cargo.toml
+++ b/crates/ravel-sql/Cargo.toml
@@ -93,11 +93,6 @@ arrow-flight = { workspace = true, optional = true }
 #    workspace pin, used the same way `content_hash` fields are hashed
 #    elsewhere in the workspace, just keyed here instead of unkeyed.
 #  - `rand` generates the ticket's in-process MAC key once at construction.
-#  - `ravel-proto` supplies `ErasureRequest`/`ErasurePredicateMatcher`
-#    (ADR-0064 decision 3): `flight_ticket::FlightTicket::snapshot`
-#    adapts the ticket's carried `pending_erasure` predicates into these types
-#    to populate `Snapshot.pending_erasure`, the same proto types the
-#    dev-only fixtures below already use.
 tonic = { workspace = true, optional = true }
 prost = { workspace = true, optional = true }
 bytes = { workspace = true, optional = true }
@@ -105,13 +100,21 @@ uuid = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }
 blake3 = { workspace = true, optional = true }
 rand = { workspace = true, optional = true }
-ravel-proto = { workspace = true, optional = true }
 
 tokio = { workspace = true }
 futures = { workspace = true }
 async-trait = { workspace = true }
 thiserror = { workspace = true }
 serde_json = { workspace = true }
+# `ravel-proto` is a hard dependency, not gated behind `flight-sql`: ADR-0850's
+# metadata-only aggregate path (`logs_scan`/`metadata_agg`) reads
+# `ravel_catalog::LoadedColumnStats`, whose per-segment entries are the raw
+# `ravel_proto::catalog::v1::{ColumnStat, ColumnStatsSegment, ColumnValue}`
+# types, in the base (non-flight) build. When `flight-sql` is also on,
+# `flight_ticket::FlightTicket::snapshot` reuses this same dependency for
+# `ErasureRequest`/`ErasurePredicateMatcher` (ADR-0064 decision 3); that need
+# does not make this entry conditional, it is simply a second consumer.
+ravel-proto = { workspace = true }
 
 [features]
 # Flight SQL transport. Off by default: it links arrow-flight and tonic on top
@@ -136,7 +139,6 @@ flight-sql = [
     "dep:blake3",
     "dep:rand",
     "dep:ravel-maintain",
-    "dep:ravel-proto",
 ]
 
 [dev-dependencies]
@@ -165,14 +167,6 @@ ravel-commit = { workspace = true }
 # type) is caught here rather than only discovered once both are wired
 # together at runtime.
 ravel-alerting = { workspace = true }
-# Dev-only, unconditional: the ADR-0064 selective-erasure regression tests
-# build `Snapshot.pending_erasure` fixtures directly with the
-# real commit proto types, and these tests run whether or not `flight-sql` is
-# enabled. `ravel-proto` also appears above as an optional `flight-sql` main
-# dependency (`flight_ticket::FlightTicket::snapshot`'s predicate adapter);
-# that is a separate, feature-gated need and does not make this entry
-# redundant.
-ravel-proto = { workspace = true }
 # Dev-only: the metric-scan cache-warm test wires a real ADR-0046 read cache
 # into `SegmentFetcher` to prove exclusion still fires on cache-served bytes.
 # Already a workspace pin used elsewhere (ravel-query depends on it);

--- a/crates/ravel-sql/src/error.rs
+++ b/crates/ravel-sql/src/error.rs
@@ -32,7 +32,7 @@
 //! errors (which carry only counts and limits an operator needs).
 
 use datafusion::error::DataFusionError;
-use ravel_catalog::CatalogError;
+use ravel_catalog::{CatalogError, LoadColumnStatsError};
 use ravel_query::{FetchError, LogFetchError};
 
 use crate::spans_fetcher::SpanFetchError;
@@ -128,6 +128,17 @@ pub enum SqlError {
     /// Snapshot resolution failed.
     #[error("snapshot resolution failed: {0}")]
     Catalog(#[from] CatalogError),
+
+    /// Loading the ADR-0850 column-statistics object for the metadata-only
+    /// aggregate path failed. Every ordinary miss (nothing folded yet, no
+    /// column-stats ref, a GET error, a decode error) already degrades to
+    /// `Ok(None)` inside [`ravel_catalog::Catalog::load_column_stats`] and
+    /// never reaches here; only a genuinely unparseable HEAD/part or an
+    /// ADR-0050 §2 tenant-hash isolation breach surfaces as this variant,
+    /// so it is treated as the same class of fault as
+    /// [`SqlError::Catalog`], not silently absorbed into "no statistics".
+    #[error("column statistics load failed: {0}")]
+    ColumnStats(#[from] LoadColumnStatsError),
 
     /// A segment fetch or decode failed mid-scan.
     #[error("segment fetch failed: {0}")]
@@ -297,6 +308,7 @@ impl SqlError {
             // into the transient-unavailable redaction.
             SqlError::Catalog(CatalogError::WindowTooWide { .. }) => ErrorClass::Unsupported,
             SqlError::Catalog(_)
+            | SqlError::ColumnStats(_)
             | SqlError::Fetch(_)
             | SqlError::LogFetch(_)
             | SqlError::SpanFetch(_)
@@ -335,6 +347,10 @@ impl SqlError {
             // treatment as the budget errors below.
             SqlError::Catalog(catalog @ CatalogError::WindowTooWide { .. }) => catalog.to_string(),
             SqlError::Catalog(catalog) => redact_catalog(catalog).to_string(),
+            // A tenant-hash mismatch would otherwise embed both hashes and
+            // an object key in its `Display`; corrupt HEAD/part errors embed
+            // a key and the decode failure. Neither reaches the client.
+            SqlError::ColumnStats(_) => MSG_CORRUPT.to_string(),
             SqlError::Fetch(fetch) => match fetch {
                 FetchError::Corrupt { .. } => MSG_CORRUPT.to_string(),
                 FetchError::Store { .. } | FetchError::EtagChanged { .. } => {

--- a/crates/ravel-sql/src/executor.rs
+++ b/crates/ravel-sql/src/executor.rs
@@ -661,10 +661,18 @@ impl SqlExecutor {
                 // last fold's build/PUT failed -- reproduces the
                 // pre-ADR-0850 provider exactly; every metadata-only path
                 // keyed off it degrades to scanning on a `None`.
-                let column_stats = self
-                    .catalog
-                    .load_column_stats(&tenant_hash, Signal::Logs)
-                    .await?;
+                let column_stats = if extras.declared.is_empty() {
+                    // No configured typed columns: no metadata-only column path
+                    // can ever apply, so skip the HEAD GET load_column_stats
+                    // would issue. This keeps a predicate-free COUNT(*) on a
+                    // tenant with no declared columns reading zero objects, and
+                    // reproduces the pre-ADR-0850 provider exactly.
+                    None
+                } else {
+                    self.catalog
+                        .load_column_stats(&tenant_hash, Signal::Logs)
+                        .await?
+                };
                 SessionTable::Logs(Arc::new(
                     LogsTableProvider::new(
                         snapshot,

--- a/crates/ravel-sql/src/executor.rs
+++ b/crates/ravel-sql/src/executor.rs
@@ -670,7 +670,7 @@ impl SqlExecutor {
                     None
                 } else {
                     self.catalog
-                        .load_column_stats(&tenant_hash, Signal::Logs)
+                        .load_column_stats(&tenant_hash, Signal::Logs, accounting)
                         .await?
                 };
                 SessionTable::Logs(Arc::new(

--- a/crates/ravel-sql/src/executor.rs
+++ b/crates/ravel-sql/src/executor.rs
@@ -653,15 +653,29 @@ impl SqlExecutor {
             // plan are installed on the logs provider here; they widen the
             // table's schema and are consumed only by this provider. A metrics-
             // or spans-target query leaves `extras.declared` unused.
-            TargetSignal::Logs => SessionTable::Logs(Arc::new(
-                LogsTableProvider::new(
-                    snapshot,
-                    tenant_hash,
-                    self.log_fetcher.clone(),
-                    accounting.clone(),
-                )
-                .with_declared_columns(extras.declared),
-            )),
+            TargetSignal::Logs => {
+                // ADR-0850: resolved once per plan from the current folded
+                // catalog HEAD, independently of `snapshot` (a different
+                // object, not versioned against the pinned snapshot). `None`
+                // -- nothing folded yet, no configured typed columns, or the
+                // last fold's build/PUT failed -- reproduces the
+                // pre-ADR-0850 provider exactly; every metadata-only path
+                // keyed off it degrades to scanning on a `None`.
+                let column_stats = self
+                    .catalog
+                    .load_column_stats(&tenant_hash, Signal::Logs)
+                    .await?;
+                SessionTable::Logs(Arc::new(
+                    LogsTableProvider::new(
+                        snapshot,
+                        tenant_hash,
+                        self.log_fetcher.clone(),
+                        accounting.clone(),
+                    )
+                    .with_declared_columns(extras.declared)
+                    .with_column_stats(column_stats.map(Arc::new)),
+                ))
+            }
             // The spans provider drives `SpanSegmentFetcher::fetch_accounted`
             // for every scanned segment: `accounting` is cloned in so each
             // span GET is recorded against this query, and the fetch is

--- a/crates/ravel-sql/src/lib.rs
+++ b/crates/ravel-sql/src/lib.rs
@@ -71,6 +71,7 @@ mod logs_schema;
 mod logs_udf;
 mod map_field_planner;
 mod memory;
+mod metadata_agg;
 mod minmax;
 mod output;
 mod provider;
@@ -145,6 +146,7 @@ pub use logs_schema::{
 };
 pub use logs_udf::{HAS_WORD_UDF, has_word_udf};
 pub use memory::{CeilingBreach, TenantDelegatingPool, TenantMemoryAccountant};
+pub use metadata_agg::{METADATA_ONLY_AGGREGATE_RULE, MetadataOnlyAggregate, MetadataOnlyExec};
 pub use output::QueryOutput;
 pub use provider::RavelTableProvider;
 pub use pushdown::Pushdown;

--- a/crates/ravel-sql/src/logs_provider.rs
+++ b/crates/ravel-sql/src/logs_provider.rs
@@ -35,7 +35,7 @@ use datafusion::physical_expr::expressions::col;
 use datafusion::physical_plan::ExecutionPlan;
 #[cfg(feature = "flight-sql")]
 use datafusion::physical_plan::projection::ProjectionExec;
-use ravel_catalog::{SegmentRef, Snapshot};
+use ravel_catalog::{LoadedColumnStats, SegmentRef, Snapshot};
 #[cfg(feature = "flight-sql")]
 use ravel_query::ByteLimit;
 use ravel_query::LogSegmentFetcher;
@@ -76,6 +76,12 @@ pub struct LogsTableProvider {
     /// exactly. The provider's advertised [`Self::schema`] and every
     /// `LogsScanExec` it builds are derived from this list.
     declared: Arc<Vec<DeclaredColumn>>,
+    /// Exact per-segment column statistics for the tenant's declared columns
+    /// (ADR-0850), resolved once per plan by `SqlExecutor` and installed with
+    /// [`LogsTableProvider::with_column_stats`]. `None` -- the default -- is
+    /// byte-identical to the pre-ADR-0850 provider: every metadata-only path
+    /// degrades to scanning.
+    column_stats: Option<Arc<LoadedColumnStats>>,
     /// The coordinator-side distributed fan-out (ADR-0071; #326), if this
     /// provider is acting as a distributed coordinator. `None` -- the default,
     /// and every non-Flight build -- is the local scan path unchanged.
@@ -103,6 +109,7 @@ impl LogsTableProvider {
             accounting,
             erasure,
             declared: Arc::new(Vec::new()),
+            column_stats: None,
             #[cfg(feature = "flight-sql")]
             distributed: None,
         }
@@ -179,6 +186,16 @@ impl LogsTableProvider {
         self
     }
 
+    /// Install this plan's loaded column statistics (ADR-0850), resolved once
+    /// by `SqlExecutor` via `Catalog::load_column_stats` and threaded down. A
+    /// builder method for the same reason [`Self::with_declared_columns`] is
+    /// one: `LogsTableProvider::new` stays source-compatible, and `None` (the
+    /// default) reproduces the pre-ADR-0850 provider exactly.
+    pub fn with_column_stats(mut self, column_stats: Option<Arc<LoadedColumnStats>>) -> Self {
+        self.column_stats = column_stats;
+        self
+    }
+
     /// Build the scan over every segment in the snapshot with no pushdown and
     /// no projection (every column). Exposed (like the metrics provider's
     /// `plan`) so tests can execute the scan without a SQL front-end.
@@ -229,7 +246,8 @@ impl LogsTableProvider {
             self.accounting.clone(),
             Arc::clone(&self.schema),
             Arc::clone(&self.declared),
-        )?;
+        )?
+        .with_column_stats(self.column_stats.clone());
         Ok(Arc::new(scan))
     }
 

--- a/crates/ravel-sql/src/logs_scan.rs
+++ b/crates/ravel-sql/src/logs_scan.rs
@@ -464,7 +464,7 @@ fn segment_identity(seg: &SegmentRef) -> ravel_catalog::EntryIdentity {
 /// Decode `value` as the Arrow scalar `ty` projects to, or `None` when
 /// `value`'s oneof kind does not match `ty` (a corrupt or version-mismatched
 /// stat). `Str` is unreachable here: callers check for it before ever calling
-/// this (see [`LogsScanExec::declared_min_max`]).
+/// this (see [`LogsScanExec::declared_min_max_all`]).
 fn declared_scalar(ty: DeclaredType, value: &ColumnValue) -> Option<ScalarValue> {
     match (ty, value.kind.as_ref()) {
         (DeclaredType::I64, Some(ColumnValueKind::I64(v))) => Some(ScalarValue::Int64(Some(*v))),
@@ -1028,37 +1028,124 @@ impl LogsScanExec {
     /// answer, not a fallback: every covered segment's column was entirely
     /// null, or there are zero segments, and SQL `MIN`/`MAX` over all-NULL or
     /// zero-row input is `NULL`.
-    fn declared_min_max(&self, k: usize) -> Option<(ScalarValue, ScalarValue)> {
-        let declared = self.declared.get(k)?;
-        if matches!(declared.ty, DeclaredType::Str) {
-            return None;
+    /// Exact MIN/MAX for every declared column at once, indexed by `k`
+    /// (`FIRST_DECLARED_COL + k`), resolved in a SINGLE pass over the touched
+    /// segments (ADR-0850). `result[k]` is `None` with the same meaning the
+    /// per-column form would give -- the safety lemma requires falling back to
+    /// scanning for that column: no loaded column-stats object, an unsupported
+    /// declared type (`Str`), a relevant segment with no entry in the loaded
+    /// stats, or a segment whose stat for this column is missing or decodes to
+    /// a value of the wrong kind.
+    ///
+    /// `Some((min, max))` with both a `None`-valued scalar is still exact, not
+    /// a fallback: every covered segment's column was entirely null, or there
+    /// are zero segments, and SQL `MIN`/`MAX` over all-NULL or zero-row input
+    /// is `NULL`.
+    ///
+    /// Resolving every column in one segment walk (with a per-segment
+    /// name->stat map) instead of one full walk per column keeps
+    /// `partition_statistics` cost at `O(segments x columns_per_segment)`
+    /// rather than `O(segments x declared x columns_per_segment)`; DataFusion
+    /// may call `partition_statistics` several times per plan, so the per-call
+    /// cost matters.
+    fn declared_min_max_all(&self) -> Vec<Option<(ScalarValue, ScalarValue)>> {
+        let n = self.declared.len();
+        let mut result: Vec<Option<(ScalarValue, ScalarValue)>> = vec![None; n];
+        let Some(stats) = self.column_stats.as_ref() else {
+            return result;
+        };
+
+        // Per-column running extrema plus a "declined" flag: a column declines
+        // its whole answer the moment any touched segment lacks its entry or
+        // carries a wrong-kind value, exactly as the per-column form does. A
+        // `Str` column declines up front.
+        struct Acc {
+            declined: bool,
+            min: Option<ScalarValue>,
+            max: Option<ScalarValue>,
         }
-        let stats = self.column_stats.as_ref()?;
-        let mut min: Option<ScalarValue> = None;
-        let mut max: Option<ScalarValue> = None;
+        let mut acc: Vec<Acc> = self
+            .declared
+            .iter()
+            .map(|d| Acc {
+                declined: matches!(d.ty, DeclaredType::Str),
+                min: None,
+                max: None,
+            })
+            .collect();
+
         for seg in self.segments.iter() {
-            let seg_stats = stats.segments.get(&segment_identity(seg))?;
-            let stat = seg_stats.columns.iter().find(|c| c.name == declared.key)?;
-            if let Some(min_val) = stat.min.as_ref() {
-                let v = declared_scalar(declared.ty, min_val)?;
-                min = Some(match min {
-                    Some(cur) if v.partial_cmp(&cur) != Some(std::cmp::Ordering::Less) => cur,
-                    _ => v,
-                });
-            }
-            if let Some(max_val) = stat.max.as_ref() {
-                let v = declared_scalar(declared.ty, max_val)?;
-                max = Some(match max {
-                    Some(cur) if v.partial_cmp(&cur) != Some(std::cmp::Ordering::Greater) => cur,
-                    _ => v,
-                });
+            let Some(seg_stats) = stats.segments.get(&segment_identity(seg)) else {
+                // A touched segment with no stats: every column must decline.
+                for a in acc.iter_mut() {
+                    a.declined = true;
+                }
+                break;
+            };
+            let by_name: HashMap<&str, &ravel_proto::catalog::v1::ColumnStat> = seg_stats
+                .columns
+                .iter()
+                .map(|c| (c.name.as_str(), c))
+                .collect();
+            for (k, a) in acc.iter_mut().enumerate() {
+                if a.declined {
+                    continue;
+                }
+                let declared = &self.declared[k];
+                let Some(stat) = by_name.get(declared.key.as_str()) else {
+                    a.declined = true;
+                    continue;
+                };
+                if let Some(min_val) = stat.min.as_ref() {
+                    match declared_scalar(declared.ty, min_val) {
+                        Some(v) => {
+                            a.min = Some(match a.min.take() {
+                                Some(cur)
+                                    if v.partial_cmp(&cur) != Some(std::cmp::Ordering::Less) =>
+                                {
+                                    cur
+                                }
+                                _ => v,
+                            });
+                        }
+                        None => {
+                            a.declined = true;
+                            continue;
+                        }
+                    }
+                }
+                if let Some(max_val) = stat.max.as_ref() {
+                    match declared_scalar(declared.ty, max_val) {
+                        Some(v) => {
+                            a.max = Some(match a.max.take() {
+                                Some(cur)
+                                    if v.partial_cmp(&cur) != Some(std::cmp::Ordering::Greater) =>
+                                {
+                                    cur
+                                }
+                                _ => v,
+                            });
+                        }
+                        None => {
+                            a.declined = true;
+                            continue;
+                        }
+                    }
+                }
             }
         }
-        let null_scalar = declared_null_scalar(declared.ty);
-        Some((
-            min.unwrap_or_else(|| null_scalar.clone()),
-            max.unwrap_or(null_scalar),
-        ))
+
+        for (k, a) in acc.into_iter().enumerate() {
+            if a.declined {
+                continue;
+            }
+            let null_scalar = declared_null_scalar(self.declared[k].ty);
+            result[k] = Some((
+                a.min.unwrap_or_else(|| null_scalar.clone()),
+                a.max.unwrap_or(null_scalar),
+            ));
+        }
+        result
     }
 
     /// Exact count of rows whose declared column at schema index
@@ -1066,7 +1153,7 @@ impl LogsScanExec {
     /// (ADR-0850's q02 shape: `COUNT(*) WHERE <declared column> <> <literal>`,
     /// which per SQL three-valued logic excludes NULL rows the same way the
     /// scan path's per-row `<>` evaluation would). `None` means fall back to
-    /// scanning, for every reason [`Self::declared_min_max`] does at its call
+    /// scanning, for every reason [`Self::declared_min_max_all`] does at its call
     /// site ([`Self::stats_are_exact`]: no pending erasure, no content or
     /// prune predicate, and a ts bound that clips no touched segment) plus no
     /// `Str` support, a loaded column-stats object covering every touched
@@ -1101,12 +1188,21 @@ impl LogsScanExec {
                 return None;
             }
             let mut matching: u64 = 0;
+            let mut dict_total: u64 = 0;
             for entry in &stat.dictionary {
                 let value = entry.value.as_ref()?;
                 let v = declared_scalar(declared.ty, value)?;
                 if v == *literal {
                     matching += entry.count;
                 }
+                dict_total = dict_total.checked_add(entry.count)?;
+            }
+            // Fail closed: an internally-inconsistent record (dictionary
+            // counts that do not sum to `non_null_count`) is rejected at load
+            // by `decode_column_stats`, but decline here too rather than
+            // subtract from a count this dictionary cannot account for.
+            if dict_total != stat.non_null_count {
+                return None;
             }
             total += stat.non_null_count.checked_sub(matching)?;
         }
@@ -1157,12 +1253,19 @@ impl LogsScanExec {
             if !stat.dictionary_present {
                 return None;
             }
-            null_count += stat.null_count;
+            let mut dict_total: u64 = 0;
             for entry in &stat.dictionary {
                 let value = entry.value.as_ref()?;
                 let v = declared_scalar(declared.ty, value)?;
+                dict_total = dict_total.checked_add(entry.count)?;
                 *merged.entry(v).or_insert(0) += entry.count;
             }
+            // Fail closed on an internally-inconsistent record, as in
+            // `declared_not_equal_count`: rejected at load, declined here too.
+            if dict_total != stat.non_null_count {
+                return None;
+            }
+            null_count += stat.null_count;
         }
         Some(DeclaredGroupCounts {
             counts: merged.into_iter().collect(),
@@ -1571,15 +1674,17 @@ impl ExecutionPlan for LogsScanExec {
 
             // ADR-0850: the same gate widens to a declared column's exact
             // min/max, joined against `self.column_stats` by identity rather
-            // than ordinal position. `declared_min_max` itself enforces the
-            // per-column fallback (an uncovered segment, a corrupt/type-
-            // mismatched stat, or an unsupported declared type all report
-            // `None` here, leaving the column `Absent`); this loop only
-            // decides which output index to fill.
-            for k in 0..self.declared.len() {
+            // than ordinal position. `declared_min_max_all` resolves every
+            // declared column in one segment walk and enforces the per-column
+            // fallback (an uncovered segment, a corrupt/type-mismatched stat,
+            // or an unsupported declared type all report `None`, leaving the
+            // column `Absent`); this loop only decides which output index to
+            // fill.
+            let declared_min_max = self.declared_min_max_all();
+            for (k, min_max) in declared_min_max.into_iter().enumerate() {
                 let schema_idx = FIRST_DECLARED_COL + k;
                 if let Some(out_idx) = self.projection.iter().position(|&i| i == schema_idx)
-                    && let Some((min, max)) = self.declared_min_max(k)
+                    && let Some((min, max)) = min_max
                 {
                     let col = &mut stats.column_statistics[out_idx];
                     col.min_value = Precision::Exact(min);

--- a/crates/ravel-sql/src/logs_scan.rs
+++ b/crates/ravel-sql/src/logs_scan.rs
@@ -1096,6 +1096,15 @@ impl LogsScanExec {
                     a.declined = true;
                     continue;
                 };
+                // Non-null rows with no recorded extremum cannot answer MIN/MAX.
+                // Without this the accumulator stays `None` and the loop below
+                // substitutes a NULL scalar, which is then reported as
+                // `Precision::Exact` -- claiming the extremum of non-null data is
+                // exactly NULL. Fail closed and let the scan answer instead.
+                if stat.non_null_count > 0 && (stat.min.is_none() || stat.max.is_none()) {
+                    a.declined = true;
+                    continue;
+                }
                 if let Some(min_val) = stat.min.as_ref() {
                     match declared_scalar(declared.ty, min_val) {
                         Some(v) => {

--- a/crates/ravel-sql/src/logs_scan.rs
+++ b/crates/ravel-sql/src/logs_scan.rs
@@ -241,12 +241,14 @@ use datafusion::physical_plan::{
 };
 use datafusion::scalar::ScalarValue;
 use futures::{Stream, StreamExt, TryStreamExt};
-use ravel_catalog::SegmentRef;
+use ravel_catalog::{LoadedColumnStats, SegmentRef};
 use ravel_logseg::footer::LogFooter;
 use ravel_logseg::{
     AttrColumn, BoolCursor, BytesCursor, ColumnSelection, ColumnarBlockView, F64BitsCursor,
     FieldSel, FieldType, I64Cursor, LogRecord, Predicate, ScanStats,
 };
+use ravel_proto::catalog::v1::ColumnValue;
+use ravel_proto::catalog::v1::column_value::Kind as ColumnValueKind;
 use ravel_query::erasure::ErasurePredicate;
 use ravel_query::{ColumnarBlockOutcome, LogQuery, LogSegmentFetcher, LogSegmentScan};
 use ravel_types::TenantHash;
@@ -442,6 +444,50 @@ fn columnar_static_eligible(projection: &[usize], erasure: &[ErasurePredicate]) 
     erasure.is_empty() && projection.iter().all(|&i| i != LOG_COL_ATTRS)
 }
 
+/// The identity tuple `fold::entry_identity` uses for `seg`, so a column-
+/// stats lookup joins by identity rather than ordinal position (ADR-0850).
+/// An L1 (compacted) segment's `writer_id` is `Uuid::nil()` by convention
+/// ([`SegmentRef::writer_id`]'s doc); column stats are only ever built for L0
+/// entries (a fold-time filter, not enforced here), so an L1 segment's
+/// identity simply never matches an entry in the loaded stats and the lookup
+/// falls back to scanning it, with no special case needed.
+fn segment_identity(seg: &SegmentRef) -> ravel_catalog::EntryIdentity {
+    (
+        seg.ingest_hour_bucket,
+        seg.shard,
+        *seg.writer_id.as_bytes(),
+        seg.writer_epoch,
+        seg.writer_seq,
+    )
+}
+
+/// Decode `value` as the Arrow scalar `ty` projects to, or `None` when
+/// `value`'s oneof kind does not match `ty` (a corrupt or version-mismatched
+/// stat). `Str` is unreachable here: callers check for it before ever calling
+/// this (see [`LogsScanExec::declared_min_max`]).
+fn declared_scalar(ty: DeclaredType, value: &ColumnValue) -> Option<ScalarValue> {
+    match (ty, value.kind.as_ref()) {
+        (DeclaredType::I64, Some(ColumnValueKind::I64(v))) => Some(ScalarValue::Int64(Some(*v))),
+        (DeclaredType::Bool, Some(ColumnValueKind::B(v))) => Some(ScalarValue::Boolean(Some(*v))),
+        (DeclaredType::Bytes, Some(ColumnValueKind::BytesVal(v))) => {
+            Some(ScalarValue::Binary(Some(v.clone())))
+        }
+        _ => None,
+    }
+}
+
+/// The `None`-valued Arrow scalar `ty` projects to, for a declared column
+/// whose exact MIN/MAX is `NULL` (every covered segment's column entirely
+/// null, or zero segments). `Str` is unreachable, matching [`declared_scalar`].
+fn declared_null_scalar(ty: DeclaredType) -> ScalarValue {
+    match ty {
+        DeclaredType::I64 => ScalarValue::Int64(None),
+        DeclaredType::Bool => ScalarValue::Boolean(None),
+        DeclaredType::Bytes => ScalarValue::Binary(None),
+        DeclaredType::Str => ScalarValue::Utf8(None),
+    }
+}
+
 /// Log segment scan producing block-at-a-time batches over a projection of the
 /// public `logs` schema. Declares no ordering (ADR-0087 decision 1).
 pub struct LogsScanExec {
@@ -493,6 +539,15 @@ pub struct LogsScanExec {
     /// Empty for a zero-declaration query, which is byte-identical to the
     /// pre-ADR-0090 scan.
     declared: Arc<Vec<DeclaredColumn>>,
+    /// Exact per-segment column statistics for the tenant's declared columns
+    /// (ADR-0850), loaded once per plan and threaded down from
+    /// [`crate::executor::SqlExecutor`]. `None` when no usable column-stats
+    /// object exists (nothing folded yet, no configured typed columns, or the
+    /// last fold's build/PUT failed): every metadata-only path degrades to
+    /// scanning in that case. A live segment absent from
+    /// `LoadedColumnStats::segments` has no exact statistics either, checked
+    /// per column at the point of use rather than here.
+    column_stats: Option<Arc<LoadedColumnStats>>,
     /// The resolved full `logs` schema this scan projects, i.e.
     /// `logs_schema_with_declared(&declared)`. Kept so [`Self::reproject`] can
     /// build a narrower sibling scan over the same table without re-deriving
@@ -776,6 +831,21 @@ impl LogsScanExec {
             Arc::clone(&self.declared),
             row_refs,
         )
+        .map(|scan| scan.with_column_stats(self.column_stats.clone()))
+    }
+
+    /// Attach this plan's loaded column statistics (ADR-0850), resolved once
+    /// per plan by [`crate::executor::SqlExecutor`] and threaded down through
+    /// [`crate::logs_provider::LogsTableProvider::with_column_stats`]. A
+    /// builder method rather than a constructor parameter for the same reason
+    /// [`crate::logs_provider::LogsTableProvider::with_declared_columns`] is
+    /// one: every existing call site of [`Self::new`] stays source-compatible.
+    pub(crate) fn with_column_stats(
+        mut self,
+        column_stats: Option<Arc<LoadedColumnStats>>,
+    ) -> Self {
+        self.column_stats = column_stats;
+        self
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -871,6 +941,7 @@ impl LogsScanExec {
             projection: Arc::new(projection),
             columns,
             declared,
+            column_stats: None,
             full_schema: full,
             schema,
             row_refs,
@@ -929,6 +1000,54 @@ impl LogsScanExec {
                 .segments
                 .iter()
                 .all(|seg| self.ts_min <= seg.min_event_ts_ns && seg.max_event_ts_ns <= self.ts_max)
+    }
+
+    /// Exact MIN/MAX for the declared column at schema index
+    /// `FIRST_DECLARED_COL + k` over every segment this scan touches
+    /// (ADR-0850), joined against `self.column_stats` by identity. `None`
+    /// means the safety lemma from #849 requires falling back to scanning:
+    /// no loaded column-stats object at all, an unsupported declared type
+    /// (`Str`, projected as `Dictionary(Int32, Utf8)`; not implemented here),
+    /// a relevant segment with no entry in the loaded stats (never built, or
+    /// postdates the fold that built them), or a segment whose stat for this
+    /// column has no entry or decodes to a value of the wrong kind (a
+    /// corrupt/version-mismatched stat).
+    ///
+    /// `Some((min, max))` with both a `None`-valued scalar is still an exact
+    /// answer, not a fallback: every covered segment's column was entirely
+    /// null, or there are zero segments, and SQL `MIN`/`MAX` over all-NULL or
+    /// zero-row input is `NULL`.
+    fn declared_min_max(&self, k: usize) -> Option<(ScalarValue, ScalarValue)> {
+        let declared = self.declared.get(k)?;
+        if matches!(declared.ty, DeclaredType::Str) {
+            return None;
+        }
+        let stats = self.column_stats.as_ref()?;
+        let mut min: Option<ScalarValue> = None;
+        let mut max: Option<ScalarValue> = None;
+        for seg in self.segments.iter() {
+            let seg_stats = stats.segments.get(&segment_identity(seg))?;
+            let stat = seg_stats.columns.iter().find(|c| c.name == declared.key)?;
+            if let Some(min_val) = stat.min.as_ref() {
+                let v = declared_scalar(declared.ty, min_val)?;
+                min = Some(match min {
+                    Some(cur) if v.partial_cmp(&cur) != Some(std::cmp::Ordering::Less) => cur,
+                    _ => v,
+                });
+            }
+            if let Some(max_val) = stat.max.as_ref() {
+                let v = declared_scalar(declared.ty, max_val)?;
+                max = Some(match max {
+                    Some(cur) if v.partial_cmp(&cur) != Some(std::cmp::Ordering::Greater) => cur,
+                    _ => v,
+                });
+            }
+        }
+        let null_scalar = declared_null_scalar(declared.ty);
+        Some((
+            min.unwrap_or_else(|| null_scalar.clone()),
+            max.unwrap_or(null_scalar),
+        ))
     }
 
     /// Whether this scan can take the predicate-free full-window whole-segment
@@ -1328,6 +1447,24 @@ impl ExecutionPlan for LogsScanExec {
                 let col = &mut stats.column_statistics[ts_idx];
                 col.min_value = Precision::Exact(ScalarValue::TimestampNanosecond(Some(min), None));
                 col.max_value = Precision::Exact(ScalarValue::TimestampNanosecond(Some(max), None));
+            }
+
+            // ADR-0850: the same gate widens to a declared column's exact
+            // min/max, joined against `self.column_stats` by identity rather
+            // than ordinal position. `declared_min_max` itself enforces the
+            // per-column fallback (an uncovered segment, a corrupt/type-
+            // mismatched stat, or an unsupported declared type all report
+            // `None` here, leaving the column `Absent`); this loop only
+            // decides which output index to fill.
+            for k in 0..self.declared.len() {
+                let schema_idx = FIRST_DECLARED_COL + k;
+                if let Some(out_idx) = self.projection.iter().position(|&i| i == schema_idx)
+                    && let Some((min, max)) = self.declared_min_max(k)
+                {
+                    let col = &mut stats.column_statistics[out_idx];
+                    col.min_value = Precision::Exact(min);
+                    col.max_value = Precision::Exact(max);
+                }
             }
         }
         Ok(Arc::new(stats))

--- a/crates/ravel-sql/src/logs_scan.rs
+++ b/crates/ravel-sql/src/logs_scan.rs
@@ -488,6 +488,17 @@ fn declared_null_scalar(ty: DeclaredType) -> ScalarValue {
     }
 }
 
+/// Exact `GROUP BY <declared column>, COUNT(*)` result from
+/// [`LogsScanExec::declared_group_counts`] (ADR-0850's q08 shape): one exact
+/// count per distinct non-null value, plus the count of NULL rows kept
+/// separately so a caller can decide whether SQL's NULL group applies (it
+/// does when `null_count > 0`, and a zero-segment or all-null scan still
+/// answers correctly with `counts` empty and `null_count` set accordingly).
+pub(crate) struct DeclaredGroupCounts {
+    pub(crate) counts: Vec<(ScalarValue, u64)>,
+    pub(crate) null_count: u64,
+}
+
 /// Log segment scan producing block-at-a-time batches over a projection of the
 /// public `logs` schema. Declares no ordering (ADR-0087 decision 1).
 pub struct LogsScanExec {
@@ -1048,6 +1059,85 @@ impl LogsScanExec {
             min.unwrap_or_else(|| null_scalar.clone()),
             max.unwrap_or(null_scalar),
         ))
+    }
+
+    /// Exact count of rows whose declared column at schema index
+    /// `FIRST_DECLARED_COL + k` is non-null and not equal to `literal`
+    /// (ADR-0850's q02 shape: `COUNT(*) WHERE <declared column> <> <literal>`,
+    /// which per SQL three-valued logic excludes NULL rows the same way the
+    /// scan path's per-row `<>` evaluation would). `None` means fall back to
+    /// scanning, for every reason [`Self::declared_min_max`] does (no pending
+    /// erasure allowed, no `Str` support, needs a loaded column-stats object
+    /// covering every touched segment), plus one specific to this path: any
+    /// covered segment whose dictionary is absent because its distinct-value
+    /// count exceeded the fold's cardinality ceiling (ADR-0850 decision 3) has
+    /// no exact per-value count to subtract, so a count derived from it could
+    /// be wrong outright, not merely unavailable.
+    pub(crate) fn declared_not_equal_count(&self, k: usize, literal: &ScalarValue) -> Option<u64> {
+        if !self.erasure.is_empty() {
+            return None;
+        }
+        let declared = self.declared.get(k)?;
+        if matches!(declared.ty, DeclaredType::Str) {
+            return None;
+        }
+        let stats = self.column_stats.as_ref()?;
+        let mut total: u64 = 0;
+        for seg in self.segments.iter() {
+            let seg_stats = stats.segments.get(&segment_identity(seg))?;
+            let stat = seg_stats.columns.iter().find(|c| c.name == declared.key)?;
+            if !stat.dictionary_present {
+                return None;
+            }
+            let mut matching: u64 = 0;
+            for entry in &stat.dictionary {
+                let value = entry.value.as_ref()?;
+                let v = declared_scalar(declared.ty, value)?;
+                if v == *literal {
+                    matching += entry.count;
+                }
+            }
+            total += stat.non_null_count.checked_sub(matching)?;
+        }
+        Some(total)
+    }
+
+    /// Exact GROUP BY value -> COUNT(*) for the declared column at schema
+    /// index `FIRST_DECLARED_COL + k` (ADR-0850's q08 shape), merging every
+    /// touched segment's exact dictionary. `None` means fall back to
+    /// scanning, for the same reasons [`Self::declared_not_equal_count`]
+    /// does. `ScalarValue`'s `Eq`/`Hash` are used directly as the merge key:
+    /// `DeclaredType` has no floating-point variant, so the NaN/-0.0 hazards
+    /// that motivate this repo's bit-pattern float-comparison rule elsewhere
+    /// never arise for a declared column's value domain.
+    pub(crate) fn declared_group_counts(&self, k: usize) -> Option<DeclaredGroupCounts> {
+        if !self.erasure.is_empty() {
+            return None;
+        }
+        let declared = self.declared.get(k)?;
+        if matches!(declared.ty, DeclaredType::Str) {
+            return None;
+        }
+        let stats = self.column_stats.as_ref()?;
+        let mut merged: HashMap<ScalarValue, u64> = HashMap::new();
+        let mut null_count: u64 = 0;
+        for seg in self.segments.iter() {
+            let seg_stats = stats.segments.get(&segment_identity(seg))?;
+            let stat = seg_stats.columns.iter().find(|c| c.name == declared.key)?;
+            if !stat.dictionary_present {
+                return None;
+            }
+            null_count += stat.null_count;
+            for entry in &stat.dictionary {
+                let value = entry.value.as_ref()?;
+                let v = declared_scalar(declared.ty, value)?;
+                *merged.entry(v).or_insert(0) += entry.count;
+            }
+        }
+        Some(DeclaredGroupCounts {
+            counts: merged.into_iter().collect(),
+            null_count,
+        })
     }
 
     /// Whether this scan can take the predicate-free full-window whole-segment

--- a/crates/ravel-sql/src/logs_scan.rs
+++ b/crates/ravel-sql/src/logs_scan.rs
@@ -1066,15 +1066,26 @@ impl LogsScanExec {
     /// (ADR-0850's q02 shape: `COUNT(*) WHERE <declared column> <> <literal>`,
     /// which per SQL three-valued logic excludes NULL rows the same way the
     /// scan path's per-row `<>` evaluation would). `None` means fall back to
-    /// scanning, for every reason [`Self::declared_min_max`] does (no pending
-    /// erasure allowed, no `Str` support, needs a loaded column-stats object
-    /// covering every touched segment), plus one specific to this path: any
-    /// covered segment whose dictionary is absent because its distinct-value
-    /// count exceeded the fold's cardinality ceiling (ADR-0850 decision 3) has
-    /// no exact per-value count to subtract, so a count derived from it could
-    /// be wrong outright, not merely unavailable.
+    /// scanning, for every reason [`Self::declared_min_max`] does at its call
+    /// site ([`Self::stats_are_exact`]: no pending erasure, no content or
+    /// prune predicate, and a ts bound that clips no touched segment) plus no
+    /// `Str` support, a loaded column-stats object covering every touched
+    /// segment, and one reason specific to this path: any covered segment
+    /// whose dictionary is absent because its distinct-value count exceeded
+    /// the fold's cardinality ceiling (ADR-0850 decision 3) has no exact
+    /// per-value count to subtract, so a count derived from it could be wrong
+    /// outright, not merely unavailable.
+    ///
+    /// The [`Self::stats_are_exact`] gate is what makes a clipping ts bound
+    /// safe. Segments are resolved on OVERLAP, and a pure `ts` bound is
+    /// reported `Exact` by `LogsTableProvider::supports_filters_pushdown`, so
+    /// the `FilterExec` that carried it is deleted and the bound survives only
+    /// as `self.ts_min`/`self.ts_max`. A per-segment dictionary carries no
+    /// intra-segment time distribution, so a clipped segment's contribution
+    /// cannot be derived from it at all; summing its whole-segment counts
+    /// would answer a different query than the one asked.
     pub(crate) fn declared_not_equal_count(&self, k: usize, literal: &ScalarValue) -> Option<u64> {
-        if !self.erasure.is_empty() {
+        if !self.stats_are_exact() {
             return None;
         }
         let declared = self.declared.get(k)?;
@@ -1121,12 +1132,16 @@ impl LogsScanExec {
     /// index `FIRST_DECLARED_COL + k` (ADR-0850's q08 shape), merging every
     /// touched segment's exact dictionary. `None` means fall back to
     /// scanning, for the same reasons [`Self::declared_not_equal_count`]
-    /// does. `ScalarValue`'s `Eq`/`Hash` are used directly as the merge key:
+    /// does, including the [`Self::stats_are_exact`] gate: this shape carries
+    /// no `FilterExec` at all, so a `WHERE ts < ...` bound that clips a
+    /// touched segment reaches here purely as `self.ts_min`/`self.ts_max` and
+    /// nothing else in the plan would refuse for it.
+    /// `ScalarValue`'s `Eq`/`Hash` are used directly as the merge key:
     /// `DeclaredType` has no floating-point variant, so the NaN/-0.0 hazards
     /// that motivate this repo's bit-pattern float-comparison rule elsewhere
     /// never arise for a declared column's value domain.
     pub(crate) fn declared_group_counts(&self, k: usize) -> Option<DeclaredGroupCounts> {
-        if !self.erasure.is_empty() {
+        if !self.stats_are_exact() {
             return None;
         }
         let declared = self.declared.get(k)?;

--- a/crates/ravel-sql/src/logs_scan.rs
+++ b/crates/ravel-sql/src/logs_scan.rs
@@ -1102,6 +1102,21 @@ impl LogsScanExec {
         Some(total)
     }
 
+    /// The declared-column index (into `self.declared`) that this scan's
+    /// output column `output_col` projects, or `None` when that output column
+    /// is not a declared typed column. The metadata-only aggregate rule
+    /// receives filter and group-key column indices in this scan's *output*
+    /// space (projection pushdown has already rewritten them by the time the
+    /// rule fires), so it resolves them through `self.projection` before
+    /// indexing `self.declared`; passing a raw output index straight into
+    /// [`Self::declared_not_equal_count`]/[`Self::declared_group_counts`]
+    /// would consult the wrong column whenever the scan is projected.
+    pub(crate) fn declared_index_for_output(&self, output_col: usize) -> Option<usize> {
+        let full = *self.projection.get(output_col)?;
+        full.checked_sub(FIRST_DECLARED_COL)
+            .filter(|k| *k < self.declared.len())
+    }
+
     /// Exact GROUP BY value -> COUNT(*) for the declared column at schema
     /// index `FIRST_DECLARED_COL + k` (ADR-0850's q08 shape), merging every
     /// touched segment's exact dictionary. `None` means fall back to

--- a/crates/ravel-sql/src/metadata_agg.rs
+++ b/crates/ravel-sql/src/metadata_agg.rs
@@ -193,7 +193,18 @@ fn is_count_star(agg: &physical_plan::aggregates::AggregateExec) -> bool {
         return false;
     }
     let args = expr.expressions();
-    args.len() == 1 && args[0].downcast_ref::<Literal>().is_some()
+    if args.len() != 1 {
+        return false;
+    }
+    // `count_all()` is physically `count(<non-null literal>)`; a literal NULL
+    // would make DataFusion evaluate `COUNT(NULL)` as 0, so treating it as
+    // `COUNT(*)` and answering from `non_null_count` would return a filtered
+    // or grouped count where the correct answer is 0. Require the literal to
+    // be non-null.
+    match args[0].downcast_ref::<Literal>() {
+        Some(lit) => !lit.value().is_null(),
+        None => false,
+    }
 }
 
 /// A `<declared column> <> <literal>` (or reversed) predicate's column

--- a/crates/ravel-sql/src/metadata_agg.rs
+++ b/crates/ravel-sql/src/metadata_agg.rs
@@ -64,8 +64,8 @@ use datafusion::physical_plan::{
 };
 use datafusion::scalar::ScalarValue;
 
-use crate::logs_schema::FIRST_DECLARED_COL;
 use crate::logs_scan::{DeclaredGroupCounts, LogsScanExec};
+use crate::logs_schema::FIRST_DECLARED_COL;
 
 /// The rule's name, as it appears in DataFusion's optimizer diagnostics.
 pub const METADATA_ONLY_AGGREGATE_RULE: &str = "metadata_only_aggregate";
@@ -292,7 +292,8 @@ fn rewrite(node: Arc<dyn ExecutionPlan>) -> DFResult<Transformed<Arc<dyn Executi
             if col_index < FIRST_DECLARED_COL || literal.is_null() {
                 return Ok(Transformed::no(node));
             }
-            let Some(count) = scan.declared_not_equal_count(col_index - FIRST_DECLARED_COL, &literal)
+            let Some(count) =
+                scan.declared_not_equal_count(col_index - FIRST_DECLARED_COL, &literal)
             else {
                 return Ok(Transformed::no(node));
             };
@@ -462,10 +463,12 @@ impl ExecutionPlan for MetadataOnlyExec {
     }
 
     fn partition_statistics(&self, _partition: Option<usize>) -> DFResult<Arc<Statistics>> {
-        Ok(Arc::new(physical_plan::common::compute_record_batch_statistics(
-            &[vec![self.batch.clone()]],
-            &self.schema,
-            None,
-        )))
+        Ok(Arc::new(
+            physical_plan::common::compute_record_batch_statistics(
+                &[vec![self.batch.clone()]],
+                &self.schema,
+                None,
+            ),
+        ))
     }
 }

--- a/crates/ravel-sql/src/metadata_agg.rs
+++ b/crates/ravel-sql/src/metadata_agg.rs
@@ -1,0 +1,471 @@
+//! Answer two more ClickBench aggregate shapes straight from ADR-0850's
+//! per-object column statistics, with zero data-block GETs (issue #850, item
+//! 2 of epic #849; the first shape, predicate-free/ts-contained `COUNT(*)`
+//! and `MIN`/`MAX`, is [`crate::logs_scan::LogsScanExec::partition_statistics`]
+//! feeding DataFusion's own built-in `AggregateStatistics` physical optimizer
+//! rule -- that rule requires zero `GROUP BY` and zero residual filter, so it
+//! can never fire for either shape here and this rule is additive, not
+//! competing):
+//!
+//! - **q02**: `COUNT(*) FROM logs WHERE <declared column> <> <literal>`, one
+//!   residual `FilterExec` over a [`LogsScanExec`], no `GROUP BY`. Answered by
+//!   [`LogsScanExec::declared_not_equal_count`]: `non_null_count -
+//!   count(value = literal)`, summed across every touched segment's exact
+//!   dictionary.
+//! - **q08**: `<declared column>, COUNT(*) FROM logs GROUP BY <declared
+//!   column>`, a plain column group key directly over a [`LogsScanExec`], no
+//!   filter (a filter combined with a `GROUP BY` is out of scope for this
+//!   rule). Answered by [`LogsScanExec::declared_group_counts`]: every
+//!   touched segment's exact dictionary merged by value, plus the summed
+//!   `null_count` as a synthetic NULL group when it is nonzero.
+//!
+//! Both delegate the actual statistics read to `LogsScanExec` (the crate's
+//! established split: `logs_scan.rs` owns every column-stats read,
+//! sibling optimizer-rule modules only match plan shape and splice in a
+//! replacement, the same way [`crate::late_materialization`] calls
+//! `scan.late_materialization_candidate()` rather than reaching into
+//! `LogsScanExec`'s fields). A `None` from either method means the ADR-0850
+//! safety lemma requires falling back to scanning (no loaded column-stats
+//! object, an unsupported declared type, a segment outside the loaded stats,
+//! a pending selective erasure, or -- specific to this path -- a segment
+//! whose dictionary was omitted for exceeding the cardinality ceiling): this
+//! rule simply declines the rewrite and the unmodified plan runs, scanning
+//! exactly as it would have without ADR-0850.
+//!
+//! [`MetadataOnlyExec`] is the observable marker (issue #850 deliverable 3):
+//! a purpose-named leaf `ExecutionPlan` whose `EXPLAIN` line always reads
+//! `MetadataOnlyExec: metadata_only=true, rows=<n>`, distinct from the
+//! generic `PlaceholderRowExec`/`ProjectionExec` pair DataFusion's own
+//! built-in rule (and any future one) produces, so a test can assert this
+//! specific optimization fired by matching that exact string rather than a
+//! node type multiple rules could have produced.
+
+use std::fmt;
+use std::sync::Arc;
+
+use datafusion::arrow::array::{ArrayRef, Int64Array, RecordBatch};
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::common::config::ConfigOptions;
+use datafusion::common::tree_node::{Transformed, TransformedResult, TreeNode};
+use datafusion::error::{DataFusionError, Result as DFResult};
+use datafusion::execution::TaskContext;
+use datafusion::logical_expr::Operator;
+use datafusion::physical_expr::expressions::{BinaryExpr, Column, Literal};
+use datafusion::physical_expr::{EquivalenceProperties, PhysicalExpr};
+use datafusion::physical_optimizer::PhysicalOptimizerRule;
+use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
+use datafusion::physical_plan::coop::CooperativeExec;
+use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
+use datafusion::physical_plan::filter::FilterExec;
+use datafusion::physical_plan::repartition::RepartitionExec;
+use datafusion::physical_plan::{
+    self, DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties,
+    SendableRecordBatchStream, Statistics,
+};
+use datafusion::scalar::ScalarValue;
+
+use crate::logs_schema::FIRST_DECLARED_COL;
+use crate::logs_scan::{DeclaredGroupCounts, LogsScanExec};
+
+/// The rule's name, as it appears in DataFusion's optimizer diagnostics.
+pub const METADATA_ONLY_AGGREGATE_RULE: &str = "metadata_only_aggregate";
+
+/// Rewrites the q02 (`COUNT(*) WHERE <declared column> <> <literal>`) and q08
+/// (`GROUP BY <declared column>, COUNT(*)`) aggregate shapes into a
+/// [`MetadataOnlyExec`] over ADR-0850 statistics, when it can prove the
+/// answer exact. See the module docs for the shapes and every fallback
+/// condition.
+#[derive(Debug, Default)]
+pub struct MetadataOnlyAggregate;
+
+impl PhysicalOptimizerRule for MetadataOnlyAggregate {
+    fn optimize(
+        &self,
+        plan: Arc<dyn ExecutionPlan>,
+        _config: &ConfigOptions,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        plan.transform_down(rewrite).data()
+    }
+
+    fn name(&self) -> &str {
+        METADATA_ONLY_AGGREGATE_RULE
+    }
+
+    fn schema_check(&self) -> bool {
+        // The replacement batch is built directly from the outer aggregate's
+        // own schema, but let DataFusion assert that rather than trusting it.
+        true
+    }
+}
+
+/// A pass-through node between the aggregate stages, or between the raw
+/// aggregate and the scan: partition shuffles the rewrite walks through
+/// without needing to remap anything, since the whole subtree above the scan
+/// is about to be discarded wholesale rather than rebuilt in place. Unlike
+/// [`crate::late_materialization`]'s allowlist, a hash repartition is
+/// admitted here for exactly that reason: the standard two-stage `GROUP BY`
+/// plan hash-repartitions by the group key between the partial and final
+/// aggregate, and this rule has no expression to remap across it.
+fn shuffle_child(plan: &Arc<dyn ExecutionPlan>) -> Option<Arc<dyn ExecutionPlan>> {
+    if plan.fetch().is_some() {
+        return None;
+    }
+    if plan.is::<CoalescePartitionsExec>() || plan.is::<CooperativeExec>() {
+        return plan.children().first().map(|c| Arc::clone(c));
+    }
+    if plan.downcast_ref::<RepartitionExec>().is_some() {
+        return plan.children().first().map(|c| Arc::clone(c));
+    }
+    None
+}
+
+/// A pass-through node between the raw aggregate and the scan, in top-down
+/// order: at most one residual filter, plus the same opaque whitelist
+/// [`shuffle_child`] admits.
+enum ScanChainStep {
+    Filter(Arc<FilterExec>),
+    Opaque,
+}
+
+fn classify_scan_chain(plan: &Arc<dyn ExecutionPlan>) -> Option<ScanChainStep> {
+    if plan.fetch().is_some() {
+        return None;
+    }
+    if let Some(filter) = plan.downcast_ref::<FilterExec>() {
+        if filter.projection().is_some() {
+            return None;
+        }
+        return Some(ScanChainStep::Filter(Arc::new(filter.clone())));
+    }
+    if plan.is::<CoalescePartitionsExec>() || plan.is::<CooperativeExec>() {
+        return Some(ScanChainStep::Opaque);
+    }
+    if plan.downcast_ref::<RepartitionExec>().is_some() {
+        return Some(ScanChainStep::Opaque);
+    }
+    None
+}
+
+/// `Some(None)` for a bare `COUNT(*)` (q02 shape candidate), `Some(Some(k))`
+/// for a single plain-`Column` group key at schema index `k` (q08 shape
+/// candidate), `None` for anything else this rule does not attempt: a
+/// grouping set, a null-expr placeholder, more than one group column, or a
+/// group expression that is not a plain column reference.
+fn group_index(group_by: &physical_plan::aggregates::PhysicalGroupBy) -> Option<Option<usize>> {
+    if group_by.has_grouping_set() || !group_by.null_expr().is_empty() {
+        return None;
+    }
+    match group_by.expr() {
+        [] => Some(None),
+        [(expr, _)] => {
+            let column = expr.downcast_ref::<Column>()?;
+            Some(Some(column.index()))
+        }
+        _ => None,
+    }
+}
+
+/// Whether `agg`'s aggregate list is exactly one `COUNT(*)`-shaped
+/// expression: physically `count(<non-null literal>)` (DataFusion's
+/// `count_all()`), never a zero-argument call, so this is the exact,
+/// version-grounded shape check rather than a name guess. `is_distinct` and
+/// a per-aggregate `FILTER (WHERE ...)` clause are both refused: neither
+/// changes what `non_null_count` means, but this rule does not attempt to
+/// reason about them.
+fn is_count_star(agg: &physical_plan::aggregates::AggregateExec) -> bool {
+    let aggr_exprs = agg.aggr_expr();
+    let filter_exprs = agg.filter_expr();
+    if aggr_exprs.len() != 1 || filter_exprs.len() != 1 {
+        return false;
+    }
+    if filter_exprs[0].is_some() {
+        return false;
+    }
+    let expr = &aggr_exprs[0];
+    if expr.is_distinct() {
+        return false;
+    }
+    if expr.fun().name() != "count" {
+        return false;
+    }
+    let args = expr.expressions();
+    args.len() == 1 && args[0].downcast_ref::<Literal>().is_some()
+}
+
+/// A `<declared column> <> <literal>` (or reversed) predicate's column
+/// index and literal value, or `None` for any other shape.
+fn not_equal_literal(predicate: &Arc<dyn PhysicalExpr>) -> Option<(usize, ScalarValue)> {
+    let binary = predicate.downcast_ref::<BinaryExpr>()?;
+    if *binary.op() != Operator::NotEq {
+        return None;
+    }
+    let left = binary.left();
+    let right = binary.right();
+    if let (Some(col), Some(lit)) = (
+        left.downcast_ref::<Column>(),
+        right.downcast_ref::<Literal>(),
+    ) {
+        return Some((col.index(), lit.value().clone()));
+    }
+    if let (Some(lit), Some(col)) = (
+        left.downcast_ref::<Literal>(),
+        right.downcast_ref::<Column>(),
+    ) {
+        return Some((col.index(), lit.value().clone()));
+    }
+    None
+}
+
+/// Try to rewrite one node. Returns it unchanged unless it is a Final-output
+/// `COUNT(*)` aggregate, with or without a single declared-column group key,
+/// reachable down to a [`LogsScanExec`] in one of the two shapes the module
+/// docs describe, AND [`LogsScanExec::declared_not_equal_count`] /
+/// [`LogsScanExec::declared_group_counts`] can prove the answer exact.
+fn rewrite(node: Arc<dyn ExecutionPlan>) -> DFResult<Transformed<Arc<dyn ExecutionPlan>>> {
+    let Some(agg) = node.downcast_ref::<physical_plan::aggregates::AggregateExec>() else {
+        return Ok(Transformed::no(node));
+    };
+    if agg.mode().output_mode() != physical_plan::aggregates::AggregateOutputMode::Final {
+        return Ok(Transformed::no(node));
+    }
+
+    // Descend to the Raw-input-mode aggregate: `agg` itself when it is
+    // Single/SinglePartitioned, or found through a chain of partition-shuffle
+    // nodes over a Final/FinalPartitioned stage's Partial input.
+    let mut current: Arc<dyn ExecutionPlan> = Arc::clone(&node);
+    let (group, raw_input) = loop {
+        if let Some(a) = current.downcast_ref::<physical_plan::aggregates::AggregateExec>() {
+            if a.mode().input_mode() == physical_plan::aggregates::AggregateInputMode::Raw {
+                let Some(group) = group_index(a.group_expr()) else {
+                    return Ok(Transformed::no(node));
+                };
+                if !is_count_star(a) {
+                    return Ok(Transformed::no(node));
+                }
+                break (group, Arc::clone(a.input()));
+            }
+            current = Arc::clone(a.input());
+            continue;
+        }
+        let Some(child) = shuffle_child(&current) else {
+            return Ok(Transformed::no(node));
+        };
+        current = child;
+    };
+
+    // Walk down from the raw stage's input to the scan, admitting at most one
+    // residual filter.
+    let mut current = raw_input;
+    let mut filter: Option<Arc<FilterExec>> = None;
+    let scan = loop {
+        if let Some(scan) = current.downcast_ref::<LogsScanExec>() {
+            break scan;
+        }
+        let Some(step) = classify_scan_chain(&current) else {
+            return Ok(Transformed::no(node));
+        };
+        if let ScanChainStep::Filter(f) = &step {
+            if filter.is_some() {
+                return Ok(Transformed::no(node));
+            }
+            filter = Some(Arc::clone(f));
+        }
+        let Some(child) = current.children().first().map(|c| Arc::clone(c)) else {
+            return Ok(Transformed::no(node));
+        };
+        current = child;
+    };
+
+    let schema = node.schema();
+    let batch = match group {
+        // q02: COUNT(*) WHERE <declared column> <> <literal>. A predicate-
+        // free COUNT(*) here is already handled by DataFusion's own built-in
+        // AggregateStatistics rule, so require the filter this rule exists
+        // for rather than reproducing that case.
+        None => {
+            let Some(filter) = filter else {
+                return Ok(Transformed::no(node));
+            };
+            let Some((col_index, literal)) = not_equal_literal(filter.predicate()) else {
+                return Ok(Transformed::no(node));
+            };
+            if col_index < FIRST_DECLARED_COL || literal.is_null() {
+                return Ok(Transformed::no(node));
+            }
+            let Some(count) = scan.declared_not_equal_count(col_index - FIRST_DECLARED_COL, &literal)
+            else {
+                return Ok(Transformed::no(node));
+            };
+            let Some(count) = count_to_i64(count) else {
+                return Ok(Transformed::no(node));
+            };
+            match count_star_batch(&schema, count) {
+                Some(batch) => batch,
+                None => return Ok(Transformed::no(node)),
+            }
+        }
+        // q08: <declared column>, COUNT(*) GROUP BY <declared column>. A
+        // filter combined with a GROUP BY is out of scope for this rule.
+        Some(col_index) => {
+            if filter.is_some() || col_index < FIRST_DECLARED_COL {
+                return Ok(Transformed::no(node));
+            }
+            let Some(counts) = scan.declared_group_counts(col_index - FIRST_DECLARED_COL) else {
+                return Ok(Transformed::no(node));
+            };
+            match group_counts_batch(&schema, counts) {
+                Some(batch) => batch,
+                None => return Ok(Transformed::no(node)),
+            }
+        }
+    };
+
+    Ok(Transformed::new(
+        Arc::new(MetadataOnlyExec::new(schema, batch)) as Arc<dyn ExecutionPlan>,
+        true,
+        datafusion::common::tree_node::TreeNodeRecursion::Jump,
+    ))
+}
+
+/// `count` as the single-row, single-column `COUNT(*)` result batch under
+/// `schema`. `None` when `schema` is not the one-column shape this rewrite
+/// expects (an internal-error case: the raw stage's `COUNT(*)` shape check
+/// already passed, so a schema of any other width would mean this rule's own
+/// assumptions about the plan are wrong), which the caller treats as a
+/// decline rather than a panic.
+fn count_star_batch(schema: &SchemaRef, count: i64) -> Option<RecordBatch> {
+    if schema.fields().len() != 1 {
+        return None;
+    }
+    let array: ArrayRef = Arc::new(Int64Array::from(vec![count]));
+    RecordBatch::try_new(Arc::clone(schema), vec![array]).ok()
+}
+
+/// `counts` as the two-column `<declared column>, COUNT(*)` result batch
+/// under `schema` (group value column, then count column), with a synthetic
+/// NULL group row appended when `counts.null_count > 0`. `None` on a schema
+/// shape mismatch (see [`count_star_batch`]) or a per-group count that does
+/// not fit `i64` (`COUNT(*)`'s declared output type): both are declines, not
+/// partial answers, since the ADR-0850 safety lemma is exactness or
+/// fallback, never a truncated result.
+fn group_counts_batch(schema: &SchemaRef, counts: DeclaredGroupCounts) -> Option<RecordBatch> {
+    if schema.fields().len() != 2 {
+        return None;
+    }
+    let mut values: Vec<ScalarValue> = Vec::with_capacity(counts.counts.len() + 1);
+    let mut tallies: Vec<i64> = Vec::with_capacity(counts.counts.len() + 1);
+    for (value, count) in counts.counts {
+        values.push(value);
+        tallies.push(count_to_i64(count)?);
+    }
+    if counts.null_count > 0 {
+        values.push(ScalarValue::try_from(schema.field(0).data_type()).ok()?);
+        tallies.push(count_to_i64(counts.null_count)?);
+    }
+    let group_array = ScalarValue::iter_to_array(values).ok()?;
+    let count_array: ArrayRef = Arc::new(Int64Array::from(tallies));
+    RecordBatch::try_new(Arc::clone(schema), vec![group_array, count_array]).ok()
+}
+
+/// `count` as `i64`, `COUNT(*)`'s declared output type. `None` on overflow,
+/// which the caller treats as a decline (see [`group_counts_batch`]'s doc):
+/// astronomically unlikely for a real row count, but exactness-or-fallback
+/// admits no silent truncation.
+fn count_to_i64(count: u64) -> Option<i64> {
+    i64::try_from(count).ok()
+}
+
+/// A single fixed [`RecordBatch`] answer to a metadata-only aggregate,
+/// produced entirely from ADR-0850 catalog statistics with zero data-block
+/// GETs. The `EXPLAIN` marker issue #850 deliverable 3 requires: `name()`
+/// and [`DisplayAs`] both read `MetadataOnlyExec`, distinct from the generic
+/// nodes DataFusion's own built-in statistics rule produces, so a test can
+/// attribute a plan specifically to this optimization.
+#[derive(Debug)]
+pub struct MetadataOnlyExec {
+    schema: SchemaRef,
+    batch: RecordBatch,
+    properties: Arc<PlanProperties>,
+}
+
+impl MetadataOnlyExec {
+    fn new(schema: SchemaRef, batch: RecordBatch) -> Self {
+        let properties = Arc::new(PlanProperties::new(
+            EquivalenceProperties::new(Arc::clone(&schema)),
+            Partitioning::UnknownPartitioning(1),
+            EmissionType::Incremental,
+            Boundedness::Bounded,
+        ));
+        MetadataOnlyExec {
+            schema,
+            batch,
+            properties,
+        }
+    }
+}
+
+impl DisplayAs for MetadataOnlyExec {
+    fn fmt_as(&self, t: DisplayFormatType, f: &mut fmt::Formatter) -> fmt::Result {
+        match t {
+            DisplayFormatType::Default | DisplayFormatType::Verbose => {
+                write!(
+                    f,
+                    "MetadataOnlyExec: metadata_only=true, rows={}",
+                    self.batch.num_rows()
+                )
+            }
+            DisplayFormatType::TreeRender => Ok(()),
+        }
+    }
+}
+
+impl ExecutionPlan for MetadataOnlyExec {
+    fn name(&self) -> &'static str {
+        "MetadataOnlyExec"
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        if !children.is_empty() {
+            return Err(DataFusionError::Internal(
+                "MetadataOnlyExec: expected zero children".to_string(),
+            ));
+        }
+        Ok(self)
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        _context: Arc<TaskContext>,
+    ) -> DFResult<SendableRecordBatchStream> {
+        if partition != 0 {
+            return Err(DataFusionError::Internal(format!(
+                "MetadataOnlyExec: invalid partition {partition}, expected 0"
+            )));
+        }
+        Ok(Box::pin(physical_plan::memory::MemoryStream::try_new(
+            vec![self.batch.clone()],
+            Arc::clone(&self.schema),
+            None,
+        )?))
+    }
+
+    fn partition_statistics(&self, _partition: Option<usize>) -> DFResult<Arc<Statistics>> {
+        Ok(Arc::new(physical_plan::common::compute_record_batch_statistics(
+            &[vec![self.batch.clone()]],
+            &self.schema,
+            None,
+        )))
+    }
+}

--- a/crates/ravel-sql/src/metadata_agg.rs
+++ b/crates/ravel-sql/src/metadata_agg.rs
@@ -65,7 +65,6 @@ use datafusion::physical_plan::{
 use datafusion::scalar::ScalarValue;
 
 use crate::logs_scan::{DeclaredGroupCounts, LogsScanExec};
-use crate::logs_schema::FIRST_DECLARED_COL;
 
 /// The rule's name, as it appears in DataFusion's optimizer diagnostics.
 pub const METADATA_ONLY_AGGREGATE_RULE: &str = "metadata_only_aggregate";
@@ -132,9 +131,14 @@ fn classify_scan_chain(plan: &Arc<dyn ExecutionPlan>) -> Option<ScanChainStep> {
         return None;
     }
     if let Some(filter) = plan.downcast_ref::<FilterExec>() {
-        if filter.projection().is_some() {
-            return None;
-        }
+        // A `FilterExec` projection only reshapes what flows UP out of the
+        // filter; `filter.predicate()` is always expressed over the filter's
+        // INPUT schema (this scan's output space), which is the only thing the
+        // q02 branch reads it for. The q08 branch declines outright when any
+        // filter is present, so a projected filter can never coexist with a
+        // group-key index that would be desynced by it. A COUNT(*) filter in
+        // particular carries `projection=[]` (nothing flows up), so rejecting a
+        // projected filter here would refuse the primary q02 shape entirely.
         return Some(ScanChainStep::Filter(Arc::new(filter.clone())));
     }
     if plan.is::<CoalescePartitionsExec>() || plan.is::<CooperativeExec>() {
@@ -289,12 +293,16 @@ fn rewrite(node: Arc<dyn ExecutionPlan>) -> DFResult<Transformed<Arc<dyn Executi
             let Some((col_index, literal)) = not_equal_literal(filter.predicate()) else {
                 return Ok(Transformed::no(node));
             };
-            if col_index < FIRST_DECLARED_COL || literal.is_null() {
+            // `col_index` is in the scan's output space (projection pushdown
+            // has already run by the time this rule fires); resolve it to a
+            // declared-column index before reading statistics.
+            let Some(k) = scan.declared_index_for_output(col_index) else {
+                return Ok(Transformed::no(node));
+            };
+            if literal.is_null() {
                 return Ok(Transformed::no(node));
             }
-            let Some(count) =
-                scan.declared_not_equal_count(col_index - FIRST_DECLARED_COL, &literal)
-            else {
+            let Some(count) = scan.declared_not_equal_count(k, &literal) else {
                 return Ok(Transformed::no(node));
             };
             let Some(count) = count_to_i64(count) else {
@@ -308,10 +316,13 @@ fn rewrite(node: Arc<dyn ExecutionPlan>) -> DFResult<Transformed<Arc<dyn Executi
         // q08: <declared column>, COUNT(*) GROUP BY <declared column>. A
         // filter combined with a GROUP BY is out of scope for this rule.
         Some(col_index) => {
-            if filter.is_some() || col_index < FIRST_DECLARED_COL {
+            if filter.is_some() {
                 return Ok(Transformed::no(node));
             }
-            let Some(counts) = scan.declared_group_counts(col_index - FIRST_DECLARED_COL) else {
+            let Some(k) = scan.declared_index_for_output(col_index) else {
+                return Ok(Transformed::no(node));
+            };
+            let Some(counts) = scan.declared_group_counts(k) else {
                 return Ok(Transformed::no(node));
             };
             match group_counts_batch(&schema, counts) {

--- a/crates/ravel-sql/src/session.rs
+++ b/crates/ravel-sql/src/session.rs
@@ -111,6 +111,7 @@ use crate::late_materialization::TopKLateMaterialization;
 use crate::logs_provider::LogsTableProvider;
 use crate::logs_udf::has_word_udf;
 use crate::map_field_planner::map_field_access_planner;
+use crate::metadata_agg::MetadataOnlyAggregate;
 use crate::minmax::{total_order_max_udaf, total_order_min_udaf};
 use crate::provider::RavelTableProvider;
 use crate::spans_provider::SpansTableProvider;
@@ -522,7 +523,15 @@ pub fn build_session(
         .with_config(session_config(config, exact_typed_aggregates))
         .with_runtime_env(runtime)
         .with_default_features()
-        .with_physical_optimizer_rule(Arc::new(DictionaryGroupKeysAsViews));
+        .with_physical_optimizer_rule(Arc::new(DictionaryGroupKeysAsViews))
+        // ADR-0850 item 2: answer `COUNT(*) WHERE <declared column> <>
+        // <literal>` and `GROUP BY <declared column>, COUNT(*)` from exact
+        // per-object column statistics, with zero data-block GETs, when the
+        // loaded statistics can prove the answer exact. Appended after the
+        // default rules for the same reason `DictionaryGroupKeysAsViews` is:
+        // it must see the final partial/final aggregation split
+        // `EnforceDistribution` chose. See `crate::metadata_agg`.
+        .with_physical_optimizer_rule(Arc::new(MetadataOnlyAggregate));
     // ADR-0774: split a wide `logs` TopK into a narrow scan carrying row refs
     // and a `k`-row block fetch. Appended after `DictionaryGroupKeysAsViews`
     // for the same reason that one is appended after the defaults: it must see

--- a/crates/ravel-sql/tests/logs_metadata_agg.rs
+++ b/crates/ravel-sql/tests/logs_metadata_agg.rs
@@ -14,10 +14,19 @@
 //! or an omitted dictionary) the rule declines and the plan keeps its
 //! `LogsScanExec`.
 //!
-//! These build the loaded statistics by hand and inject them with
+//! Most of these build the loaded statistics by hand and inject them with
 //! `LogsTableProvider::with_column_stats`, so no fold runs: the object under
 //! test is the query-side rewrite, and a hand-built `LoadedColumnStats` is the
 //! exact input the resolver would have threaded down.
+//!
+//! The equivalence tests at the end of the file are the exception, and they
+//! carry the property the whole optimization rests on: over one real RLOG
+//! corpus, the REWRITTEN answer equals the SCANNED answer for the same query.
+//! They write real objects, derive the statistics from those same records, and
+//! run each statement twice -- once with statistics loaded (rewrite eligible)
+//! and once with none (rewrite ineligible, so the scan runs) -- asserting the
+//! two agree. An assertion over fabricated statistics alone cannot catch a
+//! rewrite that answers a different question than the one asked.
 
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
@@ -29,8 +38,10 @@ use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::physical_plan::{collect, displayable};
 use datafusion::prelude::SessionContext;
 use ravel_catalog::{EntryIdentity, LoadedColumnStats, SegmentLevel, SegmentRef, Snapshot};
-use ravel_object_store::ObjectStoreBackend;
+use ravel_logseg::writer::ObjectIdentity;
+use ravel_logseg::{AttrValue, LogRecord, RlogConfig, RlogWriter, stream_attrs_bytes};
 use ravel_object_store::memory::MemoryStore;
+use ravel_object_store::{ObjectStoreBackend, PutOptions};
 use ravel_proto::catalog::v1::{ColumnStat, ColumnStatsSegment, ColumnValue, DictEntry};
 use ravel_query::LogSegmentFetcher;
 use ravel_sql::{
@@ -39,6 +50,7 @@ use ravel_sql::{
 };
 use ravel_types::TenantHash;
 use ravel_types::accounting::QueryAccounting;
+use ravel_types::logstream::log_stream_id;
 use uuid::Uuid;
 
 mod util;
@@ -499,6 +511,158 @@ async fn non_declared_column_declines_and_keeps_the_scan() {
     );
 }
 
+/// A `ts` bound that CLIPS a touched segment invalidates every folded
+/// whole-segment figure, so q02 must decline.
+///
+/// This is the non-obvious reachable case (#850 wave-0 checkpoint): segments
+/// are resolved on OVERLAP, and `LogsTableProvider::supports_filters_pushdown`
+/// reports a pure `ts` bound `Exact`, so DataFusion deletes the ts
+/// `FilterExec` outright and the bound survives only inside the scan's
+/// `ts_min`/`ts_max`. The surviving `status <> 404` filter is then the single
+/// `FilterExec` the rule admits, and the rewrite fires over segments whose
+/// dictionaries describe rows the query excludes.
+///
+/// Both fixture segments span ts 0..=1_000, so `ts < 500` clips both. Before
+/// the fix `declared_not_equal_count` consulted only `erasure` and returned 8,
+/// the whole-segment total: byte-for-byte the answer to the query WITHOUT the
+/// ts bound. A per-segment dictionary carries no intra-segment time
+/// distribution, so the clipped count cannot be derived from it and declining
+/// is the only exact option.
+#[tokio::test]
+async fn q02_clipping_ts_bound_declines_and_keeps_the_scan() {
+    let store = CountingStore::new(Arc::new(MemoryStore::new()));
+    let (a, b) = two_status_segments();
+    let stats = status_stats(&a, &b);
+    let snapshot = snapshot_of(vec![a, b], Vec::new());
+    let ctx = logs_session(provider(&store, snapshot, status_col(), Some(stats))).expect("session");
+
+    let plan = ctx
+        .sql(
+            "SELECT COUNT(*) FROM logs WHERE status <> 404 \
+             AND ts < TIMESTAMP '1970-01-01 00:00:00.000000500'",
+        )
+        .await
+        .expect("plan")
+        .create_physical_plan()
+        .await
+        .expect("physical plan");
+    let shown = plan_str(&plan);
+    assert!(
+        !shown.contains("MetadataOnlyExec"),
+        "a clipping ts bound must decline the rewrite; plan was:\n{shown}"
+    );
+    assert!(
+        shown.contains("LogsScanExec"),
+        "a clipping ts bound must fall back to a scan; plan was:\n{shown}"
+    );
+}
+
+/// The q08 half of the same hole. This shape carries no `FilterExec` at all,
+/// so nothing but `declared_group_counts` itself can refuse for a clipping ts
+/// bound. Before the fix it returned the same map as the unbounded query
+/// (`{200: 7, 404: 2, 500: 1, NULL: 1}`), ignoring `ts < 500` entirely.
+#[tokio::test]
+async fn q08_clipping_ts_bound_declines_and_keeps_the_scan() {
+    let store = CountingStore::new(Arc::new(MemoryStore::new()));
+    let (a, b) = two_status_segments();
+    let stats = status_stats(&a, &b);
+    let snapshot = snapshot_of(vec![a, b], Vec::new());
+    let ctx = logs_session(provider(&store, snapshot, status_col(), Some(stats))).expect("session");
+
+    let plan = ctx
+        .sql(
+            "SELECT status, COUNT(*) FROM logs \
+             WHERE ts < TIMESTAMP '1970-01-01 00:00:00.000000500' GROUP BY status",
+        )
+        .await
+        .expect("plan")
+        .create_physical_plan()
+        .await
+        .expect("physical plan");
+    let shown = plan_str(&plan);
+    assert!(
+        !shown.contains("MetadataOnlyExec"),
+        "a clipping ts bound must decline the rewrite; plan was:\n{shown}"
+    );
+    assert!(
+        shown.contains("LogsScanExec"),
+        "a clipping ts bound must fall back to a scan; plan was:\n{shown}"
+    );
+}
+
+/// A `has_word` content predicate is the second hole of the same shape, and
+/// it reaches the rule the same way a clipping ts bound does: `has_word` is
+/// also reported `Exact` by `LogsTableProvider::supports_filters_pushdown`
+/// (crates/ravel-sql/src/logs_provider.rs:288-304), so its `FilterExec` is
+/// deleted and the predicate survives only as `LogsScanExec::content`, where
+/// the reader evaluates it per row. Nothing in `classify_scan_chain`
+/// (crates/ravel-sql/src/metadata_agg.rs:129-151) looks at `content`, so the
+/// `status <> 404` filter is again the single admitted `FilterExec` and the
+/// rewrite fires over dictionaries that count rows the content predicate
+/// removes.
+#[tokio::test]
+async fn content_predicate_declines_and_keeps_the_scan() {
+    let store = CountingStore::new(Arc::new(MemoryStore::new()));
+    let (a, b) = two_status_segments();
+    let stats = status_stats(&a, &b);
+    let snapshot = snapshot_of(vec![a, b], Vec::new());
+    let ctx = logs_session(provider(&store, snapshot, status_col(), Some(stats))).expect("session");
+
+    let plan = ctx
+        .sql("SELECT COUNT(*) FROM logs WHERE status <> 404 AND has_word(body, 'needle')")
+        .await
+        .expect("plan")
+        .create_physical_plan()
+        .await
+        .expect("physical plan");
+    let shown = plan_str(&plan);
+    assert!(
+        !shown.contains("MetadataOnlyExec"),
+        "a content predicate must decline the rewrite; plan was:\n{shown}"
+    );
+    assert!(
+        shown.contains("LogsScanExec"),
+        "a content predicate must fall back to a scan; plan was:\n{shown}"
+    );
+}
+
+/// A `ts` bound that CONTAINS every touched segment removes no row, so the
+/// folded figures stay exact and the rewrite must still fire. Without this the
+/// two tests above would be satisfied by a guard that refuses any ts bound at
+/// all, which would silently retire the optimization for every windowed query.
+#[tokio::test]
+async fn q02_containing_ts_bound_still_answers_from_stats() {
+    let store = CountingStore::new(Arc::new(MemoryStore::new()));
+    let (a, b) = two_status_segments();
+    let stats = status_stats(&a, &b);
+    let snapshot = snapshot_of(vec![a, b], Vec::new());
+    let ctx = logs_session(provider(&store, snapshot, status_col(), Some(stats))).expect("session");
+
+    // Both segments span 0..=1_000, so this bound contains them exactly.
+    let plan = ctx
+        .sql(
+            "SELECT COUNT(*) FROM logs WHERE status <> 404 \
+             AND ts BETWEEN TIMESTAMP '1970-01-01 00:00:00.000000000' \
+             AND TIMESTAMP '1970-01-01 00:00:00.000001000'",
+        )
+        .await
+        .expect("plan")
+        .create_physical_plan()
+        .await
+        .expect("physical plan");
+    let shown = plan_str(&plan);
+    assert!(
+        !shown.contains("LogsScanExec"),
+        "a containing ts bound must still answer from stats; plan was:\n{shown}"
+    );
+
+    let batches = collect(Arc::clone(&plan), ctx.task_ctx())
+        .await
+        .expect("collect");
+    assert_eq!(count_scalar(&batches), 8, "(5-2) + (5-0), nulls excluded");
+    assert_eq!(store.gets(), 0, "a contained window must read no objects");
+}
+
 /// A segment whose dictionary was omitted (distinct-value count exceeded the
 /// fold's cardinality ceiling, `dictionary_present = false`) carries no exact
 /// per-value counts, so a q02/q08 answer derived from it could be wrong
@@ -538,5 +702,280 @@ async fn omitted_dictionary_declines_and_keeps_the_scan() {
     assert!(
         shown.contains("LogsScanExec"),
         "an omitted dictionary must fall back to a scan; plan was:\n{shown}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Rewrite-equals-scan equivalence over a real corpus
+// ---------------------------------------------------------------------------
+
+/// `(ts_ns, status)` for the first real segment. `None` means the record
+/// carries no `status` attribute at all, so the declared column reads NULL.
+const SEG_A_ROWS: &[(i64, Option<i64>)] = &[
+    (0, Some(200)),
+    (100, Some(200)),
+    (200, Some(404)),
+    (300, Some(200)),
+    (400, Some(404)),
+    (500, Some(500)),
+];
+
+/// `(ts_ns, status)` for the second real segment.
+const SEG_B_ROWS: &[(i64, Option<i64>)] = &[
+    (50, Some(200)),
+    (150, Some(500)),
+    (250, Some(200)),
+    (350, None),
+    (450, Some(200)),
+    (550, Some(200)),
+];
+
+/// The clipping bound both equivalence tests use. Segment A spans 0..=500 and
+/// segment B spans 50..=550, so `ts < 500` clips both: it drops A's last row
+/// and B's last row while leaving each segment overlapping the window, which
+/// is exactly the shape segment resolution keeps and whole-segment statistics
+/// cannot describe.
+const CLIP_SQL: &str = "TIMESTAMP '1970-01-01 00:00:00.000000500'";
+
+fn eq_record(ts: i64, status: Option<i64>) -> LogRecord {
+    let resource: Vec<(String, AttrValue)> = vec![(
+        "service.name".to_string(),
+        AttrValue::Str("api".to_string()),
+    )];
+    let attrs = match status {
+        Some(v) => vec![("status".to_string(), AttrValue::I64(v))],
+        None => Vec::new(),
+    };
+    LogRecord {
+        stream_id: log_stream_id(&resource, "scope", "1.0", &[]),
+        stream_attrs: stream_attrs_bytes(&resource, "scope", "1.0", &[]),
+        ts_ns: ts,
+        observed_ts_ns: ts,
+        severity_num: 9,
+        severity_text: "INFO".to_string(),
+        body: format!("row at {ts}"),
+        trace_id: None,
+        span_id: None,
+        flags: 0,
+        attrs,
+    }
+}
+
+/// Write `rows` as one real RLOG object under `key` and return the
+/// `SegmentRef` describing it, with the ts span and sample count taken from
+/// the records actually written.
+async fn write_real_segment(
+    store: &Arc<CountingStore>,
+    key: &str,
+    seq: u64,
+    rows: &[(i64, Option<i64>)],
+) -> SegmentRef {
+    let mut w = RlogWriter::new(
+        RlogConfig::default(),
+        ObjectIdentity {
+            tenant_hash: TENANT.0,
+            shard: 0,
+            writer_id: [2u8; 16],
+            writer_epoch: 1,
+            writer_seq: seq,
+        },
+    );
+    for (ts, status) in rows {
+        w.push(eq_record(*ts, *status)).expect("push");
+    }
+    let bytes = w.finish().expect("finish");
+    let object_size = bytes.len() as u64;
+    store
+        .put(key, bytes::Bytes::from(bytes), PutOptions::default())
+        .await
+        .expect("put");
+    SegmentRef {
+        data_object_key: key.to_string(),
+        object_size,
+        min_event_ts_ns: rows.iter().map(|(ts, _)| *ts).min().expect("nonempty"),
+        max_event_ts_ns: rows.iter().map(|(ts, _)| *ts).max().expect("nonempty"),
+        ingest_hour_bucket: 0,
+        sample_count: rows.len() as u64,
+        series_count: 0,
+        shard: 0,
+        content_hash: [0u8; 32],
+        writer_id: writer(),
+        writer_epoch: 1,
+        writer_seq: seq,
+        created_unix_ns: 0,
+        level: SegmentLevel::L0,
+    }
+}
+
+/// The exact `status` statistics for `rows`: what a correct fold over that
+/// object produces. Derived from the same constants the object is written
+/// from, so the statistics and the data cannot drift apart.
+fn stat_from_rows(rows: &[(i64, Option<i64>)]) -> ColumnStat {
+    let mut dict: Vec<(i64, u64)> = Vec::new();
+    let mut null_count = 0u64;
+    for (_, status) in rows {
+        match status {
+            Some(v) => match dict.iter_mut().find(|(dv, _)| dv == v) {
+                Some(entry) => entry.1 += 1,
+                None => dict.push((*v, 1)),
+            },
+            None => null_count += 1,
+        }
+    }
+    dict.sort_unstable();
+    i64_stat("status", &dict, null_count, true)
+}
+
+/// One real corpus plus its exact statistics, reusable across both eligibility
+/// settings so the two runs read byte-identical data.
+struct RealCorpus {
+    store: Arc<CountingStore>,
+    a: SegmentRef,
+    b: SegmentRef,
+    stats: Arc<LoadedColumnStats>,
+}
+
+impl RealCorpus {
+    async fn build() -> RealCorpus {
+        let store = CountingStore::new(Arc::new(MemoryStore::new()));
+        let a = write_real_segment(&store, "logs/eq-a.rlog", 1, SEG_A_ROWS).await;
+        let b = write_real_segment(&store, "logs/eq-b.rlog", 2, SEG_B_ROWS).await;
+        let stats = loaded_stats(vec![
+            (&a, stats_segment(&a, vec![stat_from_rows(SEG_A_ROWS)])),
+            (&b, stats_segment(&b, vec![stat_from_rows(SEG_B_ROWS)])),
+        ]);
+        RealCorpus { store, a, b, stats }
+    }
+
+    /// Run `sql` over this corpus. `with_stats` decides whether the rewrite is
+    /// eligible at all: with no loaded statistics the rule always declines, so
+    /// the same statement is forced down the ordinary scan path.
+    async fn run(&self, sql: &str, with_stats: bool) -> (String, Vec<RecordBatch>) {
+        let stats = with_stats.then(|| Arc::clone(&self.stats));
+        let snapshot = snapshot_of(vec![self.a.clone(), self.b.clone()], Vec::new());
+        let ctx =
+            logs_session(provider(&self.store, snapshot, status_col(), stats)).expect("session");
+        let plan = ctx
+            .sql(sql)
+            .await
+            .expect("plan")
+            .create_physical_plan()
+            .await
+            .expect("physical plan");
+        let shown = plan_str(&plan);
+        let batches = collect(plan, ctx.task_ctx()).await.expect("collect");
+        (shown, batches)
+    }
+}
+
+/// The q02 equivalence property, and the regression the wave-0 checkpoint
+/// found. Over one real corpus:
+///
+/// - unbounded, the rewrite fires (no `LogsScanExec` in the plan) and its
+///   count equals the scanned count, 9;
+/// - under `ts < 500`, which clips both segments, the true count is 7. The
+///   rewrite must decline, and the fallback answer must still be 7.
+///
+/// The clipped and unbounded answers differ (7 vs 9), so the ts bound provably
+/// removes rows: a rewrite that ignores it returns 9 for both. That is exactly
+/// what the pre-fix tree did, because `declared_not_equal_count` consulted
+/// only `erasure` and summed whole-segment dictionary totals.
+#[tokio::test]
+async fn q02_rewritten_answer_equals_scanned_answer() {
+    let corpus = RealCorpus::build().await;
+
+    let unbounded = "SELECT COUNT(*) FROM logs WHERE status <> 404";
+    let (rewritten_plan, rewritten) = corpus.run(unbounded, true).await;
+    let (_, scanned) = corpus.run(unbounded, false).await;
+    assert!(
+        !rewritten_plan.contains("LogsScanExec"),
+        "the unbounded q02 must be answered from stats, or this test compares \
+         the scan against itself; plan was:\n{rewritten_plan}"
+    );
+    assert_eq!(
+        count_scalar(&rewritten),
+        count_scalar(&scanned),
+        "the rewritten q02 answer must equal the scanned answer"
+    );
+    assert_eq!(
+        count_scalar(&scanned),
+        9,
+        "4 from segment A, 5 from segment B"
+    );
+
+    let clipped = &format!("SELECT COUNT(*) FROM logs WHERE status <> 404 AND ts < {CLIP_SQL}");
+    let (clipped_plan, clipped_rewrite) = corpus.run(clipped, true).await;
+    let (_, clipped_scan) = corpus.run(clipped, false).await;
+    assert!(
+        clipped_plan.contains("LogsScanExec"),
+        "a clipping ts bound must fall back to a scan; plan was:\n{clipped_plan}"
+    );
+    assert_eq!(
+        count_scalar(&clipped_rewrite),
+        count_scalar(&clipped_scan),
+        "the clipped q02 answer must not depend on whether statistics loaded"
+    );
+    assert_eq!(
+        count_scalar(&clipped_scan),
+        7,
+        "3 from segment A, 4 from segment B once ts < 500 drops one row each"
+    );
+    assert_ne!(
+        count_scalar(&clipped_scan),
+        count_scalar(&scanned),
+        "the ts bound must actually remove rows, or the clipped case proves nothing"
+    );
+}
+
+/// The q08 half of the same property. Unbounded, the merged dictionary is
+/// `{200: 7, 404: 2, 500: 2, NULL: 1}`; under `ts < 500` the true grouping is
+/// `{200: 6, 404: 2, 500: 1, NULL: 1}`. This shape carries no `FilterExec` at
+/// all, so `declared_group_counts` is the only thing that can refuse for the
+/// clipping bound.
+#[tokio::test]
+async fn q08_rewritten_answer_equals_scanned_answer() {
+    let corpus = RealCorpus::build().await;
+
+    let unbounded = "SELECT status, COUNT(*) FROM logs GROUP BY status";
+    let (rewritten_plan, rewritten) = corpus.run(unbounded, true).await;
+    let (_, scanned) = corpus.run(unbounded, false).await;
+    assert!(
+        !rewritten_plan.contains("LogsScanExec"),
+        "the unbounded q08 must be answered from stats, or this test compares \
+         the scan against itself; plan was:\n{rewritten_plan}"
+    );
+    assert_eq!(
+        group_counts(&rewritten),
+        group_counts(&scanned),
+        "the rewritten q08 groups must equal the scanned groups"
+    );
+    assert_eq!(
+        group_counts(&scanned),
+        HashMap::from([(Some(200), 7), (Some(404), 2), (Some(500), 2), (None, 1)]),
+        "the whole corpus, 12 rows over four groups"
+    );
+
+    let clipped =
+        &format!("SELECT status, COUNT(*) FROM logs WHERE ts < {CLIP_SQL} GROUP BY status");
+    let (clipped_plan, clipped_rewrite) = corpus.run(clipped, true).await;
+    let (_, clipped_scan) = corpus.run(clipped, false).await;
+    assert!(
+        clipped_plan.contains("LogsScanExec"),
+        "a clipping ts bound must fall back to a scan; plan was:\n{clipped_plan}"
+    );
+    assert_eq!(
+        group_counts(&clipped_rewrite),
+        group_counts(&clipped_scan),
+        "the clipped q08 groups must not depend on whether statistics loaded"
+    );
+    assert_eq!(
+        group_counts(&clipped_scan),
+        HashMap::from([(Some(200), 6), (Some(404), 2), (Some(500), 1), (None, 1)]),
+        "ts < 500 drops one 200 row and one 500 row"
+    );
+    assert_ne!(
+        group_counts(&clipped_scan),
+        group_counts(&scanned),
+        "the ts bound must actually remove rows, or the clipped case proves nothing"
     );
 }

--- a/crates/ravel-sql/tests/logs_metadata_agg.rs
+++ b/crates/ravel-sql/tests/logs_metadata_agg.rs
@@ -1260,3 +1260,56 @@ async fn inconsistent_record_declines_at_use_and_scans_correct_answer() {
         "the scan returns the true count, unaffected by the corrupt stat"
     );
 }
+
+/// A column with non-null rows but no recorded extremum cannot answer MIN/MAX.
+/// Before the fix the accumulator stayed `None` and the caller substituted a
+/// NULL scalar reported as `Precision::Exact`, so the plan claimed the minimum
+/// of non-null data was exactly NULL. That is a wrong answer, not a missing
+/// optimisation, and it is the third defect of this shape on this path: the
+/// scan's ts window was ignored, a dictionary could be empty while rows were
+/// counted, and now an extremum can be absent while rows exist.
+///
+/// Asserts the SCANNED answer, not merely that a decline happened: a test that
+/// only checked for the decline would pass against an implementation that
+/// declines on everything and silently deletes the optimisation.
+///
+/// Prove-the-test: removing the `stat.non_null_count > 0 && (min.is_none() ||
+/// max.is_none())` decline in `declared_min_max_all` makes the plan report
+/// MetadataOnlyExec and the assertion below fails on the plan shape.
+#[tokio::test]
+async fn a_missing_extremum_with_non_null_rows_declines_and_scans() {
+    let corpus = RealCorpus::build().await;
+
+    // Segment A keeps its row count but loses both extrema.
+    let mut bad_a = stat_from_rows(SEG_A_ROWS);
+    bad_a.min = None;
+    bad_a.max = None;
+    let bad_stats = loaded_stats(vec![
+        (&corpus.a, stats_segment(&corpus.a, vec![bad_a])),
+        (
+            &corpus.b,
+            stats_segment(&corpus.b, vec![stat_from_rows(SEG_B_ROWS)]),
+        ),
+    ]);
+
+    let snapshot = snapshot_of(vec![corpus.a.clone(), corpus.b.clone()], Vec::new());
+    let ctx = logs_session(provider(
+        &corpus.store,
+        snapshot,
+        status_col(),
+        Some(bad_stats),
+    ))
+    .expect("session");
+    let plan = ctx
+        .sql("SELECT MIN(status), MAX(status) FROM logs")
+        .await
+        .expect("plan")
+        .create_physical_plan()
+        .await
+        .expect("physical plan");
+    let shown = plan_str(&plan);
+    assert!(
+        shown.contains("LogsScanExec") && !shown.contains("MetadataOnlyExec"),
+        "non-null rows with no extremum must decline and fall back to a scan; plan was:\n{shown}"
+    );
+}

--- a/crates/ravel-sql/tests/logs_metadata_agg.rs
+++ b/crates/ravel-sql/tests/logs_metadata_agg.rs
@@ -1,0 +1,542 @@
+//! Integration tests for the ADR-0850 metadata-only aggregate rewrite (issue
+//! #850): the two ClickBench shapes `MetadataOnlyAggregate` answers straight
+//! from exact per-object column statistics with zero data-block GETs.
+//!
+//! - q02: `COUNT(*) FROM logs WHERE <declared column> <> <literal>`
+//! - q08: `SELECT <declared column>, COUNT(*) FROM logs GROUP BY <declared
+//!   column>`
+//!
+//! Every positive test pins BOTH halves as exact facts: the physical plan
+//! carries no `LogsScanExec` (the scan was elided, not merely pruned) and the
+//! executor issues exactly zero object-store GETs. The decline tests pin the
+//! correctness constraint from #849's safety lemma: whenever exactness cannot
+//! be proven (a pending erasure, a `Str`-typed column, a non-declared column,
+//! or an omitted dictionary) the rule declines and the plan keeps its
+//! `LogsScanExec`.
+//!
+//! These build the loaded statistics by hand and inject them with
+//! `LogsTableProvider::with_column_stats`, so no fold runs: the object under
+//! test is the query-side rewrite, and a hand-built `LoadedColumnStats` is the
+//! exact input the resolver would have threaded down.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use datafusion::arrow::array::{Array, Int64Array};
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::physical_plan::{collect, displayable};
+use datafusion::prelude::SessionContext;
+use ravel_catalog::{EntryIdentity, LoadedColumnStats, SegmentLevel, SegmentRef, Snapshot};
+use ravel_object_store::ObjectStoreBackend;
+use ravel_object_store::memory::MemoryStore;
+use ravel_proto::catalog::v1::{ColumnStat, ColumnStatsSegment, ColumnValue, DictEntry};
+use ravel_query::LogSegmentFetcher;
+use ravel_sql::{
+    DeclaredColumn, DeclaredType, LogsTableProvider, SessionTable, SqlConfig,
+    TenantMemoryAccountant, build_session,
+};
+use ravel_types::TenantHash;
+use ravel_types::accounting::QueryAccounting;
+use uuid::Uuid;
+
+mod util;
+use util::CountingStore;
+
+const TENANT: TenantHash = TenantHash([7u8; 16]);
+
+/// The one writer identity every fabricated segment shares; only `writer_seq`
+/// varies between segments, so `segment_identity` stays deterministic.
+fn writer() -> Uuid {
+    Uuid::from_u128(1)
+}
+
+/// A fabricated L0 [`SegmentRef`]. The metadata path never fetches the object,
+/// so `data_object_key` need not name a real object; the identity fields are
+/// what join it to the injected statistics.
+fn seg_ref(seq: u64, sample_count: u64) -> SegmentRef {
+    SegmentRef {
+        data_object_key: format!("logs/seg-{seq}.rlog"),
+        object_size: 1,
+        min_event_ts_ns: 0,
+        max_event_ts_ns: 1_000,
+        ingest_hour_bucket: 0,
+        sample_count,
+        series_count: 0,
+        shard: 0,
+        content_hash: [0u8; 32],
+        writer_id: writer(),
+        writer_epoch: 1,
+        writer_seq: seq,
+        created_unix_ns: 0,
+        level: SegmentLevel::L0,
+    }
+}
+
+/// The identity `LogsScanExec::segment_identity` derives for `seg`.
+fn identity_of(seg: &SegmentRef) -> EntryIdentity {
+    (
+        seg.ingest_hour_bucket,
+        seg.shard,
+        *seg.writer_id.as_bytes(),
+        seg.writer_epoch,
+        seg.writer_seq,
+    )
+}
+
+fn i64_value(v: i64) -> ColumnValue {
+    ColumnValue {
+        kind: Some(ravel_proto::catalog::v1::column_value::Kind::I64(v)),
+    }
+}
+
+/// An exact I64 `ColumnStat` from a value->count dictionary. `min`/`max` are
+/// the dictionary's extremes; `non_null_count` is the summed dictionary
+/// counts. `dictionary_present` mirrors the fold's decision.
+fn i64_stat(
+    name: &str,
+    dict: &[(i64, u64)],
+    null_count: u64,
+    dictionary_present: bool,
+) -> ColumnStat {
+    let non_null_count: u64 = dict.iter().map(|(_, c)| c).sum();
+    let min = dict.iter().map(|(v, _)| *v).min();
+    let max = dict.iter().map(|(v, _)| *v).max();
+    let dictionary = if dictionary_present {
+        dict.iter()
+            .map(|(v, c)| DictEntry {
+                value: Some(i64_value(*v)),
+                count: *c,
+            })
+            .collect()
+    } else {
+        Vec::new()
+    };
+    ColumnStat {
+        name: name.to_string(),
+        declared_type: 2, // ravel.sys.v1.TypedAttrColumnType::I64
+        non_null_count,
+        null_count,
+        min: min.map(i64_value),
+        max: max.map(i64_value),
+        dictionary_present,
+        dictionary,
+    }
+}
+
+fn stats_segment(seg: &SegmentRef, columns: Vec<ColumnStat>) -> ColumnStatsSegment {
+    ColumnStatsSegment {
+        ingest_hour_bucket: seg.ingest_hour_bucket,
+        shard: seg.shard,
+        writer_id: seg.writer_id.as_bytes().to_vec(),
+        writer_epoch: seg.writer_epoch,
+        writer_seq: seg.writer_seq,
+        columns,
+    }
+}
+
+fn loaded_stats(entries: Vec<(&SegmentRef, ColumnStatsSegment)>) -> Arc<LoadedColumnStats> {
+    let mut segments = HashMap::new();
+    for (seg, stat) in entries {
+        segments.insert(identity_of(seg), stat);
+    }
+    Arc::new(LoadedColumnStats {
+        segments,
+        part_blake3: Vec::new(),
+    })
+}
+
+fn snapshot_of(
+    segments: Vec<SegmentRef>,
+    erasure: Vec<ravel_proto::commit::v1::ErasureRequest>,
+) -> Snapshot {
+    Snapshot {
+        segments,
+        segments_pruned: 0,
+        pending_erasure: erasure,
+    }
+}
+
+/// A logs session over `provider`, built exactly as `SqlExecutor` builds one
+/// (`build_session`, so the default physical optimizer chain, including
+/// `MetadataOnlyAggregate`, is in force).
+fn logs_session(provider: LogsTableProvider) -> datafusion::error::Result<SessionContext> {
+    let config = SqlConfig::default();
+    let tenant = TenantMemoryAccountant::new(1 << 30);
+    let (pool, _breach) = config.query_pool(tenant, QueryAccounting::new());
+    build_session(&config, pool, SessionTable::Logs(Arc::new(provider)), false)
+}
+
+fn provider(
+    store: &Arc<CountingStore>,
+    snapshot: Snapshot,
+    declared: Vec<DeclaredColumn>,
+    stats: Option<Arc<LoadedColumnStats>>,
+) -> LogsTableProvider {
+    let backend: Arc<dyn ObjectStoreBackend> = Arc::clone(store) as Arc<dyn ObjectStoreBackend>;
+    LogsTableProvider::new(
+        snapshot,
+        TENANT,
+        LogSegmentFetcher::new(backend),
+        QueryAccounting::new(),
+    )
+    .with_declared_columns(declared)
+    .with_column_stats(stats)
+}
+
+fn status_col() -> Vec<DeclaredColumn> {
+    vec![DeclaredColumn::new("status", DeclaredType::I64)]
+}
+
+/// The two segments both q02 and q08 read: `status` dictionaries
+/// {200:3, 404:2} (no nulls) and {200:4, 500:1} (one null row).
+fn two_status_segments() -> (SegmentRef, SegmentRef) {
+    (seg_ref(1, 5), seg_ref(2, 6))
+}
+
+fn status_stats(a: &SegmentRef, b: &SegmentRef) -> Arc<LoadedColumnStats> {
+    loaded_stats(vec![
+        (
+            a,
+            stats_segment(a, vec![i64_stat("status", &[(200, 3), (404, 2)], 0, true)]),
+        ),
+        (
+            b,
+            stats_segment(b, vec![i64_stat("status", &[(200, 4), (500, 1)], 1, true)]),
+        ),
+    ])
+}
+
+fn plan_str(plan: &Arc<dyn datafusion::physical_plan::ExecutionPlan>) -> String {
+    displayable(plan.as_ref()).indent(true).to_string()
+}
+
+/// The single scalar of a `COUNT(*)` result.
+fn count_scalar(batches: &[RecordBatch]) -> i64 {
+    let mut out = 0;
+    for batch in batches {
+        if batch.num_rows() == 0 {
+            continue;
+        }
+        let arr = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("int64 count");
+        out = arr.value(0);
+    }
+    out
+}
+
+/// `(status value or NULL) -> count` from a q08 result: column 0 is the group
+/// key (nullable Int64), column 1 the count.
+fn group_counts(batches: &[RecordBatch]) -> HashMap<Option<i64>, i64> {
+    let mut out = HashMap::new();
+    for batch in batches {
+        let keys = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("int64 group key");
+        let counts = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("int64 count");
+        for row in 0..batch.num_rows() {
+            let key = if keys.is_null(row) {
+                None
+            } else {
+                Some(keys.value(row))
+            };
+            out.insert(key, counts.value(row));
+        }
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// q02: COUNT(*) WHERE <declared column> <> <literal>
+// ---------------------------------------------------------------------------
+
+/// Deliverable: the q02 shape is answered from statistics with zero GETs and
+/// no scan. `status <> 404` counts every non-null row that is not 404:
+/// segment A contributes 5 - 2 = 3, segment B contributes 5 - 0 = 5 (its one
+/// null row is excluded by SQL three-valued logic), for exactly 8.
+///
+/// Pre-change proof: reverting `declared_not_equal_count` to `return None`
+/// (line noted in the report) makes the rule decline, restoring a
+/// `FilterExec`-over-`LogsScanExec` plan; both assertions below then fail.
+#[tokio::test]
+async fn q02_not_equal_count_answered_from_stats_with_zero_gets() {
+    let store = CountingStore::new(Arc::new(MemoryStore::new()));
+    let (a, b) = two_status_segments();
+    let stats = status_stats(&a, &b);
+    let snapshot = snapshot_of(vec![a, b], Vec::new());
+    let ctx = logs_session(provider(&store, snapshot, status_col(), Some(stats))).expect("session");
+
+    let plan = ctx
+        .sql("SELECT COUNT(*) FROM logs WHERE status <> 404")
+        .await
+        .expect("plan")
+        .create_physical_plan()
+        .await
+        .expect("physical plan");
+    let shown = plan_str(&plan);
+    assert!(
+        !shown.contains("LogsScanExec"),
+        "q02 must be answered from stats, not scanned; plan was:\n{shown}"
+    );
+
+    let batches = collect(Arc::clone(&plan), ctx.task_ctx())
+        .await
+        .expect("collect");
+    assert_eq!(count_scalar(&batches), 8, "(5-2) + (5-0), nulls excluded");
+    assert_eq!(store.gets(), 0, "the q02 answer must read no objects");
+}
+
+// ---------------------------------------------------------------------------
+// q08: SELECT <declared column>, COUNT(*) GROUP BY <declared column>
+// ---------------------------------------------------------------------------
+
+/// Deliverable: the q08 shape is answered from statistics with zero GETs and
+/// no scan. The merged dictionary is {200: 3+4, 404: 2, 500: 1} plus a NULL
+/// group of 1 (segment B's null row), for four groups totalling 11 rows.
+///
+/// Pre-change proof: reverting `declared_group_counts` to `return None` (line
+/// noted in the report) makes the rule decline; the plan then contains
+/// `LogsScanExec` and issues GETs, so both assertions fail.
+#[tokio::test]
+async fn q08_group_counts_answered_from_stats_with_zero_gets() {
+    let store = CountingStore::new(Arc::new(MemoryStore::new()));
+    let (a, b) = two_status_segments();
+    let stats = status_stats(&a, &b);
+    let snapshot = snapshot_of(vec![a, b], Vec::new());
+    let ctx = logs_session(provider(&store, snapshot, status_col(), Some(stats))).expect("session");
+
+    let plan = ctx
+        .sql("SELECT status, COUNT(*) FROM logs GROUP BY status")
+        .await
+        .expect("plan")
+        .create_physical_plan()
+        .await
+        .expect("physical plan");
+    let shown = plan_str(&plan);
+    assert!(
+        !shown.contains("LogsScanExec"),
+        "q08 must be answered from stats, not scanned; plan was:\n{shown}"
+    );
+
+    let batches = collect(Arc::clone(&plan), ctx.task_ctx())
+        .await
+        .expect("collect");
+    let counts = group_counts(&batches);
+    let expected: HashMap<Option<i64>, i64> =
+        HashMap::from([(Some(200), 7), (Some(404), 2), (Some(500), 1), (None, 1)]);
+    assert_eq!(counts, expected, "merged dictionary plus the NULL group");
+    assert_eq!(store.gets(), 0, "the q08 answer must read no objects");
+}
+
+// ---------------------------------------------------------------------------
+// Observable marker (deliverable 3)
+// ---------------------------------------------------------------------------
+
+/// The rewrite installs a purpose-named `MetadataOnlyExec` leaf whose EXPLAIN
+/// line reads `MetadataOnlyExec: metadata_only=true, rows=<n>`, distinct from
+/// the generic nodes DataFusion's own statistics rule produces. q02 yields a
+/// single count row (rows=1); q08 yields one row per group plus the NULL group
+/// (rows=4).
+#[tokio::test]
+async fn metadata_only_exec_marker_reports_row_count() {
+    let store = CountingStore::new(Arc::new(MemoryStore::new()));
+    let (a, b) = two_status_segments();
+
+    let q02_ctx = logs_session(provider(
+        &store,
+        snapshot_of(vec![a.clone(), b.clone()], Vec::new()),
+        status_col(),
+        Some(status_stats(&a, &b)),
+    ))
+    .expect("session");
+    let q02_plan = q02_ctx
+        .sql("SELECT COUNT(*) FROM logs WHERE status <> 404")
+        .await
+        .expect("plan")
+        .create_physical_plan()
+        .await
+        .expect("physical plan");
+    assert!(
+        plan_str(&q02_plan).contains("MetadataOnlyExec: metadata_only=true, rows=1"),
+        "q02 marker must report one count row; plan was:\n{}",
+        plan_str(&q02_plan)
+    );
+
+    let q08_ctx = logs_session(provider(
+        &store,
+        snapshot_of(vec![a.clone(), b.clone()], Vec::new()),
+        status_col(),
+        Some(status_stats(&a, &b)),
+    ))
+    .expect("session");
+    let q08_plan = q08_ctx
+        .sql("SELECT status, COUNT(*) FROM logs GROUP BY status")
+        .await
+        .expect("plan")
+        .create_physical_plan()
+        .await
+        .expect("physical plan");
+    assert!(
+        plan_str(&q08_plan).contains("MetadataOnlyExec: metadata_only=true, rows=4"),
+        "q08 marker must report four group rows; plan was:\n{}",
+        plan_str(&q08_plan)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Decline paths (safety lemma): each keeps the LogsScanExec and never rewrites.
+// ---------------------------------------------------------------------------
+
+/// A pending selective erasure means the committed dictionary counts still
+/// include rows the erasure removes, so the metadata path must decline. The
+/// same q02 statement over the same stats, but with a pending erasure in the
+/// snapshot, keeps its scan.
+#[tokio::test]
+async fn pending_erasure_declines_and_keeps_the_scan() {
+    let store = CountingStore::new(Arc::new(MemoryStore::new()));
+    let (a, b) = two_status_segments();
+    let stats = status_stats(&a, &b);
+    let erasure = ravel_proto::commit::v1::ErasureRequest {
+        predicate: vec![ravel_proto::commit::v1::ErasurePredicateMatcher {
+            key: "status".to_string(),
+            value: "404".to_string(),
+        }],
+        ..Default::default()
+    };
+    let snapshot = snapshot_of(vec![a, b], vec![erasure]);
+    let ctx = logs_session(provider(&store, snapshot, status_col(), Some(stats))).expect("session");
+
+    let plan = ctx
+        .sql("SELECT COUNT(*) FROM logs WHERE status <> 404")
+        .await
+        .expect("plan")
+        .create_physical_plan()
+        .await
+        .expect("physical plan");
+    let shown = plan_str(&plan);
+    assert!(
+        !shown.contains("MetadataOnlyExec"),
+        "a pending erasure must decline the rewrite; plan was:\n{shown}"
+    );
+    assert!(
+        shown.contains("LogsScanExec"),
+        "a pending erasure must fall back to a scan; plan was:\n{shown}"
+    );
+}
+
+/// A `Str`-typed declared column is not answerable from the dictionary here
+/// (its Arrow projection is a dictionary array the reader does not decode into
+/// a `ScalarValue` for this path), so q02 over a `Str` column declines. The
+/// literal is a string so the plan is well-typed; the rule still refuses.
+#[tokio::test]
+async fn str_typed_column_declines_and_keeps_the_scan() {
+    let store = CountingStore::new(Arc::new(MemoryStore::new()));
+    let (a, b) = two_status_segments();
+    // The stats carry a `region` entry, but its declared type is Str, which
+    // `declared_not_equal_count` refuses before reading the dictionary.
+    let stats = loaded_stats(vec![
+        (&a, stats_segment(&a, Vec::new())),
+        (&b, stats_segment(&b, Vec::new())),
+    ]);
+    let snapshot = snapshot_of(vec![a, b], Vec::new());
+    let declared = vec![DeclaredColumn::new("region", DeclaredType::Str)];
+    let ctx = logs_session(provider(&store, snapshot, declared, Some(stats))).expect("session");
+
+    let plan = ctx
+        .sql("SELECT COUNT(*) FROM logs WHERE region <> 'us'")
+        .await
+        .expect("plan")
+        .create_physical_plan()
+        .await
+        .expect("physical plan");
+    let shown = plan_str(&plan);
+    assert!(
+        !shown.contains("MetadataOnlyExec"),
+        "a Str-typed column must decline the rewrite; plan was:\n{shown}"
+    );
+    assert!(
+        shown.contains("LogsScanExec"),
+        "a Str-typed column must fall back to a scan; plan was:\n{shown}"
+    );
+}
+
+/// A predicate over a non-declared column (`body`, a fixed column below
+/// `FIRST_DECLARED_COL`) has no per-value statistics at all, so the rule
+/// declines before consulting any dictionary.
+#[tokio::test]
+async fn non_declared_column_declines_and_keeps_the_scan() {
+    let store = CountingStore::new(Arc::new(MemoryStore::new()));
+    let (a, b) = two_status_segments();
+    let stats = status_stats(&a, &b);
+    let snapshot = snapshot_of(vec![a, b], Vec::new());
+    let ctx = logs_session(provider(&store, snapshot, status_col(), Some(stats))).expect("session");
+
+    let plan = ctx
+        .sql("SELECT COUNT(*) FROM logs WHERE body <> 'x'")
+        .await
+        .expect("plan")
+        .create_physical_plan()
+        .await
+        .expect("physical plan");
+    let shown = plan_str(&plan);
+    assert!(
+        !shown.contains("MetadataOnlyExec"),
+        "a non-declared column must decline the rewrite; plan was:\n{shown}"
+    );
+    assert!(
+        shown.contains("LogsScanExec"),
+        "a non-declared column must fall back to a scan; plan was:\n{shown}"
+    );
+}
+
+/// A segment whose dictionary was omitted (distinct-value count exceeded the
+/// fold's cardinality ceiling, `dictionary_present = false`) carries no exact
+/// per-value counts, so a q02/q08 answer derived from it could be wrong
+/// outright, not merely unavailable. The rule must decline. Segment A has a
+/// present dictionary; segment B's is omitted, which alone forces fallback.
+#[tokio::test]
+async fn omitted_dictionary_declines_and_keeps_the_scan() {
+    let store = CountingStore::new(Arc::new(MemoryStore::new()));
+    let (a, b) = two_status_segments();
+    let stats = loaded_stats(vec![
+        (
+            &a,
+            stats_segment(&a, vec![i64_stat("status", &[(200, 3), (404, 2)], 0, true)]),
+        ),
+        (
+            &b,
+            // dictionary_present = false: the fold dropped this column's
+            // dictionary for exceeding the cardinality ceiling.
+            stats_segment(&b, vec![i64_stat("status", &[], 5, false)]),
+        ),
+    ]);
+    let snapshot = snapshot_of(vec![a, b], Vec::new());
+    let ctx = logs_session(provider(&store, snapshot, status_col(), Some(stats))).expect("session");
+
+    let plan = ctx
+        .sql("SELECT status, COUNT(*) FROM logs GROUP BY status")
+        .await
+        .expect("plan")
+        .create_physical_plan()
+        .await
+        .expect("physical plan");
+    let shown = plan_str(&plan);
+    assert!(
+        !shown.contains("MetadataOnlyExec"),
+        "an omitted dictionary must decline the rewrite; plan was:\n{shown}"
+    );
+    assert!(
+        shown.contains("LogsScanExec"),
+        "an omitted dictionary must fall back to a scan; plan was:\n{shown}"
+    );
+}

--- a/crates/ravel-sql/tests/logs_metadata_agg.rs
+++ b/crates/ravel-sql/tests/logs_metadata_agg.rs
@@ -137,6 +137,56 @@ fn i64_stat(
     }
 }
 
+fn str_value(v: &str) -> ColumnValue {
+    ColumnValue {
+        kind: Some(ravel_proto::catalog::v1::column_value::Kind::StrUtf8(
+            v.to_string(),
+        )),
+    }
+}
+
+/// An exact `Str` `ColumnStat` from a value->count dictionary, mirroring
+/// [`i64_stat`]. Used to prove a `Str`-declared column declines even when its
+/// statistics ARE present.
+fn str_stat(name: &str, dict: &[(&str, u64)]) -> ColumnStat {
+    let non_null_count: u64 = dict.iter().map(|(_, c)| c).sum();
+    let min = dict.iter().map(|(v, _)| v.to_string()).min();
+    let max = dict.iter().map(|(v, _)| v.to_string()).max();
+    ColumnStat {
+        name: name.to_string(),
+        declared_type: 1, // ravel.sys.v1.TypedAttrColumnType::Str
+        non_null_count,
+        null_count: 0,
+        min: min.as_deref().map(str_value),
+        max: max.as_deref().map(str_value),
+        dictionary_present: true,
+        dictionary: dict
+            .iter()
+            .map(|(v, c)| DictEntry {
+                value: Some(str_value(v)),
+                count: *c,
+            })
+            .collect(),
+    }
+}
+
+/// An I64 `ColumnStat` whose dictionary was OMITTED (`dictionary_present =
+/// false`) for exceeding the fold's cardinality ceiling, while
+/// `non_null_count` still reflects the real non-null rows. This is the state
+/// a q02/q08 answer cannot be derived from, so the rule must decline.
+fn i64_omitted_stat(name: &str, non_null_count: u64) -> ColumnStat {
+    ColumnStat {
+        name: name.to_string(),
+        declared_type: 2,
+        non_null_count,
+        null_count: 0,
+        min: None,
+        max: None,
+        dictionary_present: false,
+        dictionary: Vec::new(),
+    }
+}
+
 fn stats_segment(seg: &SegmentRef, columns: Vec<ColumnStat>) -> ColumnStatsSegment {
     ColumnStatsSegment {
         ingest_hour_bucket: seg.ingest_hour_bucket,
@@ -172,12 +222,31 @@ fn snapshot_of(
 
 /// A logs session over `provider`, built exactly as `SqlExecutor` builds one
 /// (`build_session`, so the default physical optimizer chain, including
-/// `MetadataOnlyAggregate`, is in force).
+/// `MetadataOnlyAggregate`, is in force). Single-stage aggregate:
+/// `exact_typed_aggregates = false`.
 fn logs_session(provider: LogsTableProvider) -> datafusion::error::Result<SessionContext> {
+    logs_session_with(provider, false)
+}
+
+/// A logs session with an explicit `exact_typed_aggregates` flag. With `true`
+/// (the production default for a query the classifier admits, ADR-0094), a
+/// `GROUP BY` becomes the two-stage `Partial -> RepartitionExec(Hash) ->
+/// FinalPartitioned` plan, which the rewrite must descend through
+/// (`shuffle_child` admits the hash repartition) just as it does the
+/// single-stage plan.
+fn logs_session_with(
+    provider: LogsTableProvider,
+    exact_typed_aggregates: bool,
+) -> datafusion::error::Result<SessionContext> {
     let config = SqlConfig::default();
     let tenant = TenantMemoryAccountant::new(1 << 30);
     let (pool, _breach) = config.query_pool(tenant, QueryAccounting::new());
-    build_session(&config, pool, SessionTable::Logs(Arc::new(provider)), false)
+    build_session(
+        &config,
+        pool,
+        SessionTable::Logs(Arc::new(provider)),
+        exact_typed_aggregates,
+    )
 }
 
 fn provider(
@@ -405,6 +474,148 @@ async fn metadata_only_exec_marker_reports_row_count() {
     );
 }
 
+/// `COUNT(NULL)` is 0 by SQL semantics, NOT `COUNT(*)`. The rule must not
+/// treat a literal-NULL count argument as `COUNT(*)` and answer it from
+/// `non_null_count`: with the pre-fix `is_count_star` this statement rewrote
+/// to the metadata count of non-404 rows and returned it; it must return 0.
+///
+/// Run over the real corpus so the declined statement can execute its scan
+/// (a fabricated segment has no object to read). With statistics loaded the
+/// rule is eligible but declines on the NULL literal, so the scan runs and
+/// returns 0.
+#[tokio::test]
+async fn count_null_is_zero_not_rewritten() {
+    let corpus = RealCorpus::build().await;
+    let (shown, batches) = corpus
+        .run("SELECT COUNT(NULL) FROM logs WHERE status <> 404", true)
+        .await;
+    assert!(
+        !shown.contains("MetadataOnlyExec"),
+        "COUNT(NULL) must not be rewritten as COUNT(*); plan was:\n{shown}"
+    );
+    assert_eq!(
+        count_scalar(&batches),
+        0,
+        "COUNT(NULL) is 0, not the row count"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Parallel final aggregation (ADR-0094, the shipped default): the rewrite must
+// fire over the two-stage Partial -> RepartitionExec(Hash) -> FinalPartitioned
+// plan, not only the single-stage aggregate.
+// ---------------------------------------------------------------------------
+
+/// q08 with `exact_typed_aggregates = true` (production's default for a query
+/// the classifier admits). The scan path proves the plan shape is the
+/// two-stage parallel one; with statistics loaded the rewrite descends through
+/// the hash repartition and answers from metadata with zero GETs.
+#[tokio::test]
+async fn q08_parallel_final_answered_from_stats() {
+    let store = CountingStore::new(Arc::new(MemoryStore::new()));
+    let (a, b) = two_status_segments();
+
+    // No stats: the rule declines, so the ordinary exact-typed plan survives
+    // and we can assert it really is Partial -> RepartitionExec(Hash) ->
+    // FinalPartitioned.
+    let scan_ctx = logs_session_with(
+        provider(
+            &store,
+            snapshot_of(vec![a.clone(), b.clone()], Vec::new()),
+            status_col(),
+            None,
+        ),
+        true,
+    )
+    .expect("session");
+    let scan_plan = scan_ctx
+        .sql("SELECT status, COUNT(*) FROM logs GROUP BY status")
+        .await
+        .expect("plan")
+        .create_physical_plan()
+        .await
+        .expect("physical plan");
+    let scan_shown = plan_str(&scan_plan);
+    assert!(
+        scan_shown.contains("RepartitionExec")
+            && scan_shown.contains("mode=FinalPartitioned")
+            && scan_shown.contains("mode=Partial"),
+        "exact_typed_aggregates must produce the two-stage parallel plan; plan was:\n{scan_shown}"
+    );
+
+    // Stats loaded: the rewrite fires over that same shape.
+    let stats = status_stats(&a, &b);
+    let ctx = logs_session_with(
+        provider(
+            &store,
+            snapshot_of(vec![a, b], Vec::new()),
+            status_col(),
+            Some(stats),
+        ),
+        true,
+    )
+    .expect("session");
+    let plan = ctx
+        .sql("SELECT status, COUNT(*) FROM logs GROUP BY status")
+        .await
+        .expect("plan")
+        .create_physical_plan()
+        .await
+        .expect("physical plan");
+    let shown = plan_str(&plan);
+    assert!(
+        !shown.contains("LogsScanExec") && shown.contains("MetadataOnlyExec"),
+        "the rewrite must fire over the parallel-final plan; plan was:\n{shown}"
+    );
+    let batches = collect(Arc::clone(&plan), ctx.task_ctx())
+        .await
+        .expect("collect");
+    let expected: HashMap<Option<i64>, i64> =
+        HashMap::from([(Some(200), 7), (Some(404), 2), (Some(500), 1), (None, 1)]);
+    assert_eq!(
+        group_counts(&batches),
+        expected,
+        "merged dictionary plus NULL"
+    );
+    assert_eq!(store.gets(), 0, "answered from stats, no objects read");
+}
+
+/// q02 with `exact_typed_aggregates = true`: the count aggregate is still
+/// order/partition-independent, so the rewrite must fire and read no objects.
+#[tokio::test]
+async fn q02_parallel_final_answered_from_stats() {
+    let store = CountingStore::new(Arc::new(MemoryStore::new()));
+    let (a, b) = two_status_segments();
+    let stats = status_stats(&a, &b);
+    let ctx = logs_session_with(
+        provider(
+            &store,
+            snapshot_of(vec![a, b], Vec::new()),
+            status_col(),
+            Some(stats),
+        ),
+        true,
+    )
+    .expect("session");
+    let plan = ctx
+        .sql("SELECT COUNT(*) FROM logs WHERE status <> 404")
+        .await
+        .expect("plan")
+        .create_physical_plan()
+        .await
+        .expect("physical plan");
+    let shown = plan_str(&plan);
+    assert!(
+        !shown.contains("LogsScanExec") && shown.contains("MetadataOnlyExec"),
+        "the rewrite must fire under exact_typed_aggregates; plan was:\n{shown}"
+    );
+    let batches = collect(Arc::clone(&plan), ctx.task_ctx())
+        .await
+        .expect("collect");
+    assert_eq!(count_scalar(&batches), 8, "(5-2) + (5-0), nulls excluded");
+    assert_eq!(store.gets(), 0, "answered from stats, no objects read");
+}
+
 // ---------------------------------------------------------------------------
 // Decline paths (safety lemma): each keeps the LogsScanExec and never rewrites.
 // ---------------------------------------------------------------------------
@@ -454,11 +665,20 @@ async fn pending_erasure_declines_and_keeps_the_scan() {
 async fn str_typed_column_declines_and_keeps_the_scan() {
     let store = CountingStore::new(Arc::new(MemoryStore::new()));
     let (a, b) = two_status_segments();
-    // The stats carry a `region` entry, but its declared type is Str, which
-    // `declared_not_equal_count` refuses before reading the dictionary.
+    // The stats DO carry a `region` entry with a real present dictionary, so a
+    // missing-column decline cannot mask the reason under test: the sole cause
+    // is that `region` is declared `Str`, which `declared_not_equal_count`
+    // refuses (logs_scan.rs, the `matches!(declared.ty, DeclaredType::Str)`
+    // gate, reinforced by `declared_scalar` having no `Str` arm).
     let stats = loaded_stats(vec![
-        (&a, stats_segment(&a, Vec::new())),
-        (&b, stats_segment(&b, Vec::new())),
+        (
+            &a,
+            stats_segment(&a, vec![str_stat("region", &[("us", 3), ("eu", 2)])]),
+        ),
+        (
+            &b,
+            stats_segment(&b, vec![str_stat("region", &[("us", 4), ("eu", 2)])]),
+        ),
     ]);
     let snapshot = snapshot_of(vec![a, b], Vec::new());
     let declared = vec![DeclaredColumn::new("region", DeclaredType::Str)];
@@ -667,7 +887,10 @@ async fn q02_containing_ts_bound_still_answers_from_stats() {
 /// fold's cardinality ceiling, `dictionary_present = false`) carries no exact
 /// per-value counts, so a q02/q08 answer derived from it could be wrong
 /// outright, not merely unavailable. The rule must decline. Segment A has a
-/// present dictionary; segment B's is omitted, which alone forces fallback.
+/// present dictionary; segment B's is omitted while still declaring 5 non-null
+/// rows, so dropping the `!dictionary_present` gate (logs_scan.rs) would
+/// undercount by exactly those 5 rows -- the gate is the only thing that can
+/// cause the decline here.
 #[tokio::test]
 async fn omitted_dictionary_declines_and_keeps_the_scan() {
     let store = CountingStore::new(Arc::new(MemoryStore::new()));
@@ -679,9 +902,10 @@ async fn omitted_dictionary_declines_and_keeps_the_scan() {
         ),
         (
             &b,
-            // dictionary_present = false: the fold dropped this column's
-            // dictionary for exceeding the cardinality ceiling.
-            stats_segment(&b, vec![i64_stat("status", &[], 5, false)]),
+            // dictionary_present = false with 5 real non-null rows: the fold
+            // dropped this column's dictionary for exceeding the cardinality
+            // ceiling.
+            stats_segment(&b, vec![i64_omitted_stat("status", 5)]),
         ),
     ]);
     let snapshot = snapshot_of(vec![a, b], Vec::new());
@@ -977,5 +1201,62 @@ async fn q08_rewritten_answer_equals_scanned_answer() {
         group_counts(&clipped_scan),
         group_counts(&scanned),
         "the ts bound must actually remove rows, or the clipped case proves nothing"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Fail-closed on an internally-inconsistent record (Finding 4, read side)
+// ---------------------------------------------------------------------------
+
+/// An internally-inconsistent `ColumnStat` (dictionary counts that do not sum
+/// to `non_null_count`) is rejected at LOAD by `decode_column_stats`, so the
+/// real path can never hand one to the query. Injected by hand here (bypassing
+/// decode), the READ side must still fail closed: `declared_not_equal_count`
+/// declines rather than subtracting from a dictionary that cannot account for
+/// the claimed rows, and the query returns the correct SCANNED answer.
+#[tokio::test]
+async fn inconsistent_record_declines_at_use_and_scans_correct_answer() {
+    let corpus = RealCorpus::build().await;
+
+    // Corrupt segment A's stat: claim 100 more non-null rows than its
+    // dictionary accounts for.
+    let mut bad_a = stat_from_rows(SEG_A_ROWS);
+    bad_a.non_null_count += 100;
+    let bad_stats = loaded_stats(vec![
+        (&corpus.a, stats_segment(&corpus.a, vec![bad_a])),
+        (
+            &corpus.b,
+            stats_segment(&corpus.b, vec![stat_from_rows(SEG_B_ROWS)]),
+        ),
+    ]);
+
+    let snapshot = snapshot_of(vec![corpus.a.clone(), corpus.b.clone()], Vec::new());
+    let ctx = logs_session(provider(
+        &corpus.store,
+        snapshot,
+        status_col(),
+        Some(bad_stats),
+    ))
+    .expect("session");
+    let plan = ctx
+        .sql("SELECT COUNT(*) FROM logs WHERE status <> 404")
+        .await
+        .expect("plan")
+        .create_physical_plan()
+        .await
+        .expect("physical plan");
+    let shown = plan_str(&plan);
+    assert!(
+        shown.contains("LogsScanExec") && !shown.contains("MetadataOnlyExec"),
+        "an inconsistent record must decline at use and fall back to a scan; plan was:\n{shown}"
+    );
+
+    let batches = collect(Arc::clone(&plan), ctx.task_ctx())
+        .await
+        .expect("collect");
+    assert_eq!(
+        count_scalar(&batches),
+        9,
+        "the scan returns the true count, unaffected by the corrupt stat"
     );
 }

--- a/docs/adrs/0850-logs-typed-column-statistics.md
+++ b/docs/adrs/0850-logs-typed-column-statistics.md
@@ -1,0 +1,352 @@
+# ADR-0850: exact per-object statistics for declared logs columns
+
+Status: Accepted. Builds on ADR-0090 (declared typed attribute columns)
+and ADR-0093 (their pushdown). Sibling artifact to ADR-0049's name
+postings (phase P5a), same `SnapshotHead` sibling-ref pattern. Extends
+the metadata-only execution path proved by
+`crates/ravel-sql/tests/logs_count_from_stats.rs`. Issue #850, epic #849.
+
+## Context
+
+The ClickBench corpus: 34 of 41 statements read all 3,469 objects (12.03
+GB, roughly a 1.2 s floor) because the query needs an answer a full scan
+happens to produce, not because the query needs every row. Three of
+those decompose into pure metadata:
+
+- q07: `SELECT MIN(EventDate), MAX(EventDate) FROM hits` — the min/max of
+  per-object minima/maxima.
+- q02: `SELECT COUNT(*) FROM hits WHERE AdvEngineID <> 0` — non-null
+  count minus the exact count of the value 0.
+- q08: `SELECT AdvEngineID, COUNT(*) FROM hits GROUP BY AdvEngineID` — a
+  merge of exact per-object value-to-count dictionaries.
+
+`LogsScanExec::partition_statistics` and the `stats_are_exact` gate in
+`crates/ravel-sql/src/logs_scan.rs` already prove the mechanism for
+predicate-free and contained-ts-bound `COUNT(*)`: the catalog carries
+`sample_count` on every `SegmentRef` today, DataFusion's stock
+`AggregateStatistics` physical-optimizer rule rewrites the aggregate to a
+literal when every resolved segment's statistics are exact, and
+`LogsScanExec` never gets built. This ADR widens the same mechanism to
+cover q02/q07/q08's aggregates by adding the per-object statistics that
+`sample_count` doesn't carry: null-aware counts, min/max, and a bounded
+exact value dictionary, for the columns a tenant has declared
+(`TenantConfig::typed_attr_columns`, ADR-0090).
+
+Two other ClickBench shapes are explicitly out of scope. q20 (point
+postings) and q23 (gram covering) need an index pack keyed by value, not
+a per-object summary; `SUM`/`AVG` over the full corpus still has to visit
+every row's value once the column doesn't fit a dictionary. Neither is
+attempted here.
+
+### Why a sibling artifact, not a `SegmentRef`/`Snapshot` field
+
+`SegmentRef` has over 120 construction call sites and `Snapshot` has
+about 47, spanning crates outside this task's scope
+(`ravel-sql`/`ravel-catalog`/`ravel-logseg`). Adding fields to either
+means touching every one of those sites for a feature most of them don't
+care about. ADR-0049 already solved the identical problem for name
+postings by putting `SnapshotPostingsRef` on `SnapshotHead` as an
+optional sibling pointing at a separately fetched, separately encoded
+object, joined back to the covered parts by content hash. This ADR
+copies that shape for column statistics: `SnapshotColumnStatsRef` (field
+11 on `SnapshotHead`, additive) points at a `.cstat` object holding one
+`ColumnStatsSegment` per covered L0 segment.
+
+The join key differs from the postings precedent on purpose. Name
+postings bind ordinals to `SnapshotHead.parts` position, which is fine
+because postings are one structure spanning the whole snapshot with no
+natural per-segment identity. Column statistics are inherently
+per-segment, so `ColumnStatsSegment` carries the same five-field identity
+tuple `fold::entry_identity` already uses to key a `SnapshotEntry`
+(`ingest_hour_bucket, shard, writer_id, writer_epoch, writer_seq`) and a
+reader joins by that tuple, not by ordinal position. This is more robust
+than ordinal binding (survives a snapshot's segment list being
+reordered, filtered, or partially stale by one entry) at the cost of one
+hash-map build per query, which is negligible next to a network GET.
+
+### `attrs_raw` overflow does not threaten exactness
+
+`RlogWriter` gives each object a fixed dynamic-column budget
+(`crates/ravel-logseg/src/writer.rs`); a (name, type) pair either gets a
+FIELD_DIR column slot for the whole object or it doesn't
+(`column_lookup(&column_of, name, type)` is computed once per object and
+consulted per row purely to route that row's value to the columnar page
+or into `attrs_raw`; it never flips mid-object). So there is no row-level
+partial-overflow case where some of a column's values land in a
+dedicated column and others land in `attrs_raw` for the same object: a
+configured column is either fully present as a FIELD_DIR column (every
+occurrence in that object decodes through it) or entirely absent from
+FIELD_DIR (every occurrence, if any, is in `attrs_raw`, unreachable
+short of a full record re-decode). The fold-time stats builder therefore
+only needs `FieldDir::column(name, declared_type)` to resolve: `None`
+means "no exact statistic available for this column in this segment,"
+which is exactly the existing "live object lacking statistics" fallback
+gate from the safety lemma below, not a new special case.
+
+### L1 segments are not covered
+
+`build_l1_snapshot_entry`/`build_rewrite_l1_snapshot_entry`
+(`crates/ravel-catalog/src/fold.rs`) reuse the `writer_id`/`writer_epoch`
+slots on a compacted entry to carry `input_set_hash`/`part_index`, not a
+genuine writer identity, so the identity tuple this ADR joins on doesn't
+mean the same thing for L1 as it does for L0. Computing and joining
+statistics for L1 is deferred; this cut computes `ColumnStatsSegment`
+records for L0 entries only. This is automatically safe under the same
+gate: a snapshot containing an L1 segment simply has no matching
+`ColumnStatsSegment`, so any query touching that segment's queried
+column falls back to scanning it. It is a coverage gap (a snapshot with
+compacted history answers fewer queries from metadata alone), not a
+correctness gap, and is called out here as a known limitation for a
+follow-up rather than silently worked around.
+
+## Decision
+
+### 1. New protobuf types (`proto/ravel/catalog.proto`)
+
+Additive fields/messages only, no renumbering:
+
+- `SnapshotHead.column_stats` (field 11, `SnapshotColumnStatsRef`):
+  mirrors `SnapshotPostingsRef`'s shape (key, blake3, size, a count,
+  covered `part_blake3` list). Absent whenever the tenant has no
+  declared typed columns, no L0 segment has been folded, or the last
+  fold's stats build failed for any reason — readers must treat absence
+  as "fall back to scanning," never as an error.
+- `ColumnStatsHeader`: the envelope header, mirrors
+  `SnapshotPostingsHeader`.
+- `ColumnValue`: a `oneof` over `i64`/`bool`/`str_utf8`/`bytes_val`,
+  covering ADR-0090's four declared types (`F64` is not a declared
+  typed-attribute-column type and is out of scope here as it is there).
+- `DictEntry { value, count }` and `ColumnStat { name, declared_type,
+  non_null_count, null_count, min, max, dictionary_present, dictionary
+  }`: one column's exact statistics for one segment. `min`/`max` are
+  proto3-absent (not a sentinel value) when `non_null_count == 0`.
+  `dictionary_present = false` means the column's distinct-value count
+  in this segment exceeded the cardinality ceiling: the dictionary is
+  omitted outright, never truncated, so a reader can never mistake "over
+  the ceiling" for "fewer than N distinct values."
+- `ColumnStatsSegment { ingest_hour_bucket, shard, writer_id,
+  writer_epoch, writer_seq, columns }`: the per-segment join key plus its
+  columns' stats.
+
+`declared_type` is a plain `uint32` carrying
+`ravel.sys.v1.TypedAttrColumnType` as `i32`, the same convention
+`SnapshotPartHeader.signal` already uses for a foreign enum domain: this
+repository has zero cross-file proto imports (verified against every
+file under `proto/ravel/`), and this ADR does not introduce the first
+one.
+
+### 2. Envelope and body format: `.cstat`, magic `RCST`, version 1
+
+New `crates/ravel-catalog/src/snapshot_format/column_stats.rs`, modeled
+directly on `part.rs` rather than `postings.rs`: `postings.rs`'s
+hand-rolled varint name dictionary exists to make prefix lookup cheap
+over a huge flat name space, which per-segment column statistics don't
+need. The body reuses `part.rs`'s simpler convention instead: zstd
+compressed, length-delimited `ColumnStatsSegment` protobuf messages
+(`encode_length_delimited_to_vec`/`decode_length_delimited`), sorted by
+the identity tuple for deterministic byte output. The envelope is magic
+(`RCST`) + version (`1u8`) + reserved bytes + `ColumnStatsHeader` +
+zstd body + trailing crc32c, matching `part.rs`'s framing. A
+`format_constants_are_pinned`-style test locks the new magic/version the
+same way the existing envelopes are locked.
+
+Decode enforces a size ceiling (`ColumnStatsLimits`, mirroring
+`PartLimits`) before inflating the zstd body, so a corrupt or hostile
+`size`/header field cannot force an unbounded allocation.
+
+### 3. Cardinality ceiling: 10,000 distinct values per (segment, column)
+
+Chosen per segment, not per tenant-wide column, because the dictionary
+is built and stored per segment: a segment holds one ingest hour's worth
+of one shard's records, so 10,000 distinct values comfortably covers
+legitimate categorical/enum-shaped columns (status codes, country codes,
+`AdvEngineID`-style small-int dimensions) while bounding one segment's
+dictionary to at most 10,000 `DictEntry` messages — small next to the
+segment sizes in the corpus this feature targets. A column whose
+distinct count exceeds the ceiling in a given segment (a synthetic ID
+column, for instance) gets `dictionary_present = false` for that
+segment; queries needing that segment's exact per-value counts fall back
+to scanning it, while `non_null_count`/`null_count`/`min`/`max` (which
+cost nothing extra to keep exact regardless of cardinality) remain
+usable. The ceiling is a fold-time constant
+(`DEFAULT_MAX_COLUMN_DICTIONARY_ENTRIES` in `column_stats.rs`), not
+tenant-configurable in this cut. 10,000 also matches the existing
+precedent `RlogConfig::postings_max_distinct` already sets for a
+different per-object dictionary (the write-time POSTINGS term cap,
+ADR-0049 decision 4); reusing the same order of magnitude rather than
+inventing a new one is a deliberate choice, not a coincidence.
+
+### 4. Fold-time build (`crates/ravel-catalog/src/fold.rs`)
+
+A new `build_column_stats` function, structured like `build_postings`
+(baseline carried forward for already-computed entries, freshly
+decoded from `decode_start` onward, restricted to L0 entries) but with
+one deliberate divergence: `build_postings` is documented all-or-nothing
+because postings share one cross-entry ordinal space, so one entry's
+decode failure poisons the whole rebuild. Column statistics are
+independent per-segment records with no shared ordinal space, so a
+single segment's decode failure (object missing, corrupt, or with no
+FIELD_DIR entry for a configured column) drops only that segment's
+`ColumnStatsSegment` — or, when it lacks a column entirely, that column
+within it — rather than failing the whole build. This is strictly safer
+than all-or-nothing here: it maximizes how much of a fold's work still
+answers metadata-only queries instead of forcing every segment back to
+full scans because one segment was awkward.
+
+For each L0 entry, for each tenant-declared column: resolve
+`FieldDir::column(name, declared_type)`; if absent, emit no `ColumnStat`
+for that column in that segment (safe fallback, not a build failure).
+If present, run one `RlogReader::scan_blocks` pass with an always-true
+content predicate (`Predicate::And(vec![])`) and a `ColumnSelection`
+covering every resolved declared column at once — one decode pass
+computes every declared column's statistics together, rather than
+mixing FIELD_DIR's null counts, SKIP_IDX's block min/max, and a separate
+dictionary pass, which would risk the three quietly disagreeing. Tally
+row count, non-null/null counts, min/max (by bit pattern for floats —
+not applicable to the four declared types, but the same discipline
+applies to any future extension), and a distinct-value histogram capped
+at the cardinality ceiling, using the type-appropriate `iter_i64`/
+`iter_bool`/`iter_bytes` accessor.
+
+The tenant-config read at `fold.rs`'s existing config-values match
+gains `typed_attr_columns` alongside what it already reads. The
+attach sequence mirrors the postings block exactly: load the previous
+column-stats baseline (any load failure is a graceful `None`, never a
+fold failure), call `build_column_stats`, and on `Some` encode + hash +
+`PutOptions::create_if_absent()`; on any encode/PUT failure,
+`tracing::warn!` and fold without a stats ref, same as postings do
+without a postings ref.
+
+### 5. Reader side (`ravel-catalog` → `ravel-sql`)
+
+A new `Catalog` method fetches, validates (hash match, part-binding
+match against the resolved `Snapshot`'s parts, format version), and
+decodes the referenced `.cstat` object, returning a structure joined
+against `Snapshot.segments` by identity tuple. `ravel-sql` fetches this
+alongside the existing async `Snapshot` resolution, before physical
+planning, and threads the (optional) result synchronously through
+`LogsTableProvider`/`LogsScanExec` construction the same way `Snapshot`
+itself already flows through the test harness's `provider_over`. This
+is required because DataFusion's optimizer rules and
+`ExecutionPlan::partition_statistics` are synchronous, while the new
+catalog object needs an async GET.
+
+Two DataFusion mechanisms carry the three statements:
+
+- q07 needs no new optimizer rule. It reuses the same stock
+  `AggregateStatistics` rewrite the existing predicate-free `COUNT(*)`
+  shortcut already relies on: `LogsScanExec::partition_statistics`
+  reports exact `ColumnStatistics::min_value`/`max_value` for a declared
+  column once every resolved segment has an exact `ColumnStat` for it.
+- q02 and q08 need one new physical optimizer rule
+  (`LogsMetadataAggregateRule`), because DataFusion's stock `Statistics`
+  type has no value-to-count structure and no rewrite from statistics
+  for a filtered or grouped `COUNT(*)`. The rule matches `AggregateExec
+  [COUNT(*), optional single-column GROUP BY]` over an optional
+  `FilterExec[col <> lit | col = lit]` over `LogsScanExec`, and replaces
+  the whole subtree with a literal-values plan only when every resolved
+  segment's dictionary for the relevant column both exists
+  (`dictionary_present`) and is otherwise valid per the safety lemma
+  below; any segment failing either check leaves the original plan
+  untouched.
+
+### 6. Observability: `metadata_only` marker
+
+For q02/q08, the rule's literal-replacement output is wrapped in a new
+`MetadataOnlyExec` leaf so a test can assert `plan_str.contains(
+"MetadataOnlyExec")`. For q07, no new wrapper is introduced: the marker
+is the pre-existing precedent already used by the predicate-free
+`COUNT(*)` tests in `logs_count_from_stats.rs` — the absence of
+`LogsScanExec` from the displayed plan. This ADR does not force q07
+through `MetadataOnlyExec` for uniformity, since doing so would mean
+diverging from a stock DataFusion rewrite path for no functional gain;
+the two markers are deliberately non-uniform and this is called out
+explicitly rather than papered over.
+
+## Safety lemma
+
+Absent, stale, corrupt, or version-mismatched statistics degrade to
+scanning; they never produce a wrong answer. Concretely, every one of
+these forces the affected segment (or the whole query, where the
+condition is snapshot-wide) back to the scan path:
+
+- `SnapshotHead.column_stats` is absent, or its referenced object is
+  missing, fails its blake3 check, fails to decode, or reports a format
+  version this reader doesn't understand.
+- `SnapshotColumnStatsRef.part_blake3` doesn't match the resolved
+  snapshot's covered parts (a stale stats object bound to a superseded
+  part set).
+- A live segment in the resolved snapshot has no matching
+  `ColumnStatsSegment` (L1 segment, or an L0 segment folded before
+  stats existed, or a segment the builder skipped after a decode
+  failure), or has a matching segment with no `ColumnStat` for the
+  queried column (never declared for that tenant at the time, or the
+  column overflowed to `attrs_raw` for the whole object, per the
+  `attrs_raw` analysis above).
+- The queried column's dictionary is needed (q02/q08) but
+  `dictionary_present` is false for any relevant segment (cardinality
+  ceiling exceeded) — q02 in particular must never approximate: an
+  inexact count of the literal being excluded is worse than a scan.
+- A pending selective-erasure predicate (ADR-0064) touches the queried
+  tenant/column: erasure invalidates precomputed counts for any segment
+  it could affect, so the corresponding segment's stats are treated as
+  absent for the duration the erasure is pending.
+- The snapshot's pinned commit token (MVCC) admits a segment the
+  resolved `Snapshot.segments` list didn't have when column stats were
+  last folded (an uncovered segment): coverage is judged against the
+  snapshot actually being queried, not the snapshot at fold time.
+
+Each of these is a fallback to the existing scan path already exercised
+by `logs_count_from_stats.rs`, not a new code path: this ADR adds ways
+to short-circuit into metadata-only execution, never a new way to
+answer incorrectly.
+
+## Rejected alternatives
+
+- **Fields directly on `SegmentRef`/`Snapshot`.** Rejected: 120+ and 47+
+  construction call sites respectively, most outside this task's scope
+  and none of them caring about per-column statistics.
+- **Reusing the name-postings hand-rolled varint body encoding.**
+  Rejected: that encoding earns its complexity for a huge flat
+  cross-segment name space; per-segment column statistics are naturally
+  segment-scoped protobuf records, and `part.rs`'s plain
+  length-delimited convention is simpler and just as adequate.
+- **Ordinal-position join to `SnapshotHead.parts`, matching the postings
+  precedent.** Rejected in favor of the identity-tuple join: column
+  statistics are per-segment, not one cross-snapshot structure, and the
+  identity tuple survives snapshot segment-list reordering or partial
+  staleness that an ordinal position would not.
+- **All-or-nothing build, matching `build_postings` exactly.** Rejected:
+  column statistics have no shared ordinal space across segments, so
+  failing the whole build over one awkward segment throws away
+  otherwise-usable statistics for every other segment in the fold.
+- **Approximate/truncated dictionaries above the cardinality ceiling.**
+  Rejected outright by the task's exactness invariant: q02 needs the
+  exact count of one literal value, and a truncated dictionary could
+  silently omit it.
+- **Covering L1 segments in this cut.** Rejected for now: L1 entries
+  reuse the `writer_id`/`writer_epoch` slots for compaction bookkeeping,
+  so the identity-tuple join needs a different key for L1, which is
+  real additional design work for a coverage gap that degrades safely
+  (fallback to scan) rather than incorrectly. Deferred to a follow-up.
+
+## Consequences
+
+- q02, q07, and q08 answer from catalog metadata alone against a fully
+  folded snapshot with declared columns and no pending erasure, cutting
+  their object-store GETs to zero, matching the existing predicate-free
+  `COUNT(*)` shortcut's shape.
+- Every fold that has declared typed columns configured does one extra
+  decode pass per L0 entry (bounded to the declared columns only) and
+  one extra small object PUT; a tenant with no declared columns pays
+  nothing new (the build produces no ref instead of an empty one).
+- The catalog format gains one more additive `SnapshotHead` field and
+  one more object kind per signal per fold; existing readers ignore it
+  as required by proto3 field-addition semantics.
+- L1-covered snapshots (any compacted history) fall back to scanning
+  the L1 segments' contribution to a metadata-only query; this is a
+  known, intentional coverage gap, not a silent wrong answer.
+- `ravel-catalog` gains a new dependency on `ravel-logseg` (for
+  `RlogReader`/`ColumnSelection`/`FieldDir` at fold time) — a new edge
+  in the crate graph, verified acyclic (`ravel-logseg` has no dependency
+  back on `ravel-catalog`).

--- a/docs/adrs/0850-logs-typed-column-statistics.md
+++ b/docs/adrs/0850-logs-typed-column-statistics.md
@@ -239,16 +239,25 @@ Two DataFusion mechanisms carry the three statements:
   reports exact `ColumnStatistics::min_value`/`max_value` for a declared
   column once every resolved segment has an exact `ColumnStat` for it.
 - q02 and q08 need one new physical optimizer rule
-  (`LogsMetadataAggregateRule`), because DataFusion's stock `Statistics`
+  (`MetadataOnlyAggregate`, registered under the name
+  `metadata_only_aggregate`), because DataFusion's stock `Statistics`
   type has no value-to-count structure and no rewrite from statistics
   for a filtered or grouped `COUNT(*)`. The rule matches `AggregateExec
-  [COUNT(*), optional single-column GROUP BY]` over an optional
-  `FilterExec[col <> lit | col = lit]` over `LogsScanExec`, and replaces
-  the whole subtree with a literal-values plan only when every resolved
-  segment's dictionary for the relevant column both exists
+  [COUNT(*), optional single-column GROUP BY]` over `LogsScanExec`, and
+  replaces the whole subtree with a literal-values plan only when every
+  resolved segment's dictionary for the relevant column both exists
   (`dictionary_present`) and is otherwise valid per the safety lemma
   below; any segment failing either check leaves the original plan
-  untouched.
+  untouched. Two branch contracts constrain when it fires:
+  - **q02** (bare `COUNT(*)`) requires a residual filter, and that
+    filter must be `col <> lit`: `not_equal_literal` accepts only
+    `Operator::NotEq`, so `col = lit` (equality) declines. A
+    predicate-free `COUNT(*)` also declines here, because DataFusion's
+    own `AggregateStatistics` rule already answers it from
+    `partition_statistics` (the q07 path above).
+  - **q08** (single-column `GROUP BY`) declines outright when any filter
+    is present: a filter combined with a `GROUP BY` is out of scope for
+    this rule.
 
 ### 6. Observability: `metadata_only` marker
 
@@ -287,10 +296,12 @@ condition is snapshot-wide) back to the scan path:
   `dictionary_present` is false for any relevant segment (cardinality
   ceiling exceeded) — q02 in particular must never approximate: an
   inexact count of the literal being excluded is worse than a scan.
-- A pending selective-erasure predicate (ADR-0064) touches the queried
-  tenant/column: erasure invalidates precomputed counts for any segment
-  it could affect, so the corresponding segment's stats are treated as
-  absent for the duration the erasure is pending.
+- A pending selective-erasure predicate (ADR-0064) is present on the
+  resolved snapshot: erasure invalidates precomputed counts, so the
+  metadata-only path is rejected for the ENTIRE query (not merely the
+  affected segment) while any erasure is pending. `stats_are_exact`
+  refuses whenever `self.erasure` is non-empty, so q02/q08 fall back to
+  a full scan.
 - The snapshot's pinned commit token (MVCC) admits a segment the
   resolved `Snapshot.segments` list didn't have when column stats were
   last folded (an uncovered segment): coverage is judged against the

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -174,15 +174,39 @@ resolves it through the scan's projection before reading statistics.
 
 The rule declines -- leaving the plan's `LogsScanExec` in place to answer by
 scanning, exactly as it would have without ADR-0850 -- whenever exactness
-cannot be proven. It declines whenever ANY selective erasure is pending in the
-snapshot (ADR-0064): the committed dictionary counts still include rows the
-erasure removes, so no metadata-only answer can be exact until the erasure is
-applied. It also declines for a `Str`-typed declared column, a predicate or
-group key over a non-declared column, a segment with no loaded statistics, and
-a segment whose per-value dictionary the fold omitted for exceeding the
-cardinality ceiling (ADR-0850 decision 3) -- an omitted dictionary carries no
-exact per-value counts, so a derived count could be wrong outright, not merely
-unavailable.
+cannot be proven. The full set of decline conditions:
+
+- ANY selective erasure is pending in the snapshot (ADR-0064): the committed
+  dictionary counts still include rows the erasure removes, so no metadata-only
+  answer can be exact until the erasure is applied.
+- A `ts` bound CLIPS any touched segment. Segments resolve on OVERLAP, and a
+  pure `ts` bound is reported `Exact` by
+  `LogsTableProvider::supports_filters_pushdown`, so its `FilterExec` is
+  deleted and the bound survives only as the scan's `ts_min`/`ts_max`. A
+  per-segment dictionary carries no intra-segment time distribution, so a
+  clipped segment's contribution cannot be derived from it; summing its
+  whole-segment counts would answer a different query. Conversely, a `ts` bound
+  that FULLY CONTAINS every touched segment removes no row and REMAINS
+  eligible: the optimisation still fires for a windowed query whose window
+  brackets the data, so a time filter does not by itself retire it.
+- A non-empty `content` predicate (e.g. `has_word`) or a non-empty `prune`
+  channel is present: both also survive pushdown as `Exact` (deleted
+  `FilterExec`, evaluated per row inside the scan), and neither is reflected in
+  the whole-segment dictionary counts.
+- A `Str`-typed declared column, a predicate or group key over a non-declared
+  column, or a segment with no loaded statistics.
+- A segment whose per-value dictionary the fold omitted for exceeding the
+  cardinality ceiling (ADR-0850 decision 3) -- an omitted dictionary carries no
+  exact per-value counts, so a derived count could be wrong outright, not
+  merely unavailable.
+- A segment carrying an internally-inconsistent `ColumnStat` (its dictionary
+  counts do not sum to `non_null_count`). Such a record is rejected at load by
+  `decode_column_stats`, but `declared_not_equal_count`/`declared_group_counts`
+  decline on it too, failing closed rather than computing from it.
+
+The ts/content/prune declines are gated by `LogsScanExec::stats_are_exact`,
+which requires no pending erasure, an empty `content`, an empty `prune`, and a
+`ts` bound that contains every touched segment.
 
 ## Predicate-free full-window logs scan: request count
 

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -143,6 +143,47 @@ partially credited. A distributed coordinator (ADR-0071) also reports
 every filter `Inexact`, since its fan-out pushes no filter to the workers
 and needs each one back as a residual.
 
+## Logs aggregates from exact per-object column statistics
+
+Two further aggregate shapes are answered entirely from ADR-0850's exact
+per-object column statistics, with zero data-block GETs and no `LogsScanExec`
+in the plan. The statistics are built at fold time (one exact decode pass per
+L0 object over each configured typed attribute column, stored in an RCST1
+object bound to the covered part set) and loaded once per query by
+`Catalog::load_column_stats`; the query-side rewrite is `MetadataOnlyAggregate`
+(crates/ravel-sql/src/metadata_agg.rs), which replaces the aggregate subtree
+with a `MetadataOnlyExec` leaf whose `EXPLAIN` line reads
+`MetadataOnlyExec: metadata_only=true, rows=<n>`. The two shapes are:
+
+- **q02** — `SELECT COUNT(*) FROM logs WHERE <declared column> <> <literal>`,
+  one residual filter over the scan and no `GROUP BY`. Answered as
+  `sum over segments of (non_null_count - count(value = literal))`, read from
+  each segment's exact dictionary. NULL rows are excluded, matching SQL
+  three-valued logic for `<>`.
+- **q08** — `SELECT <declared column>, COUNT(*) FROM logs GROUP BY <declared
+  column>`, a plain declared-column group key directly over the scan and no
+  filter. Answered by merging every touched segment's exact dictionary by
+  value, plus the summed `null_count` as a synthetic NULL group when nonzero.
+
+Both are additive to DataFusion's built-in `AggregateStatistics` rule (which
+handles the predicate-free `COUNT(*)` above and can never fire for either
+shape here, since it requires no `GROUP BY` and no residual filter). The
+column index a filter or group key carries is in the scan's output space by
+the time the rule runs (projection pushdown has already run), so the rule
+resolves it through the scan's projection before reading statistics.
+
+The rule declines -- leaving the plan's `LogsScanExec` in place to answer by
+scanning, exactly as it would have without ADR-0850 -- whenever exactness
+cannot be proven. It declines whenever ANY selective erasure is pending in the
+snapshot (ADR-0064): the committed dictionary counts still include rows the
+erasure removes, so no metadata-only answer can be exact until the erasure is
+applied. It also declines for a `Str`-typed declared column, a predicate or
+group key over a non-declared column, a segment with no loaded statistics, and
+a segment whose per-value dictionary the fold omitted for exceeding the
+cardinality ceiling (ADR-0850 decision 3) -- an omitted dictionary carries no
+exact per-value counts, so a derived count could be wrong outright, not merely
+unavailable.
+
 ## Predicate-free full-window logs scan: request count
 
 Every OTHER predicate-free, full-window logs statement — `SUM`, `AVG`,

--- a/proto/ravel/catalog.proto
+++ b/proto/ravel/catalog.proto
@@ -64,6 +64,12 @@ message SnapshotHead {
   // record view. Absent/0 = pre-reshard head; readers must never treat
   // absence as an error.
   uint32 shard_generation_count = 10;
+  // Additive, ADR-0850 (logs typed-column statistics). Absent when the
+  // tenant has no configured typed columns (ADR-0090), no eligible L0
+  // segment has been folded yet, or the last fold's column-stats build
+  // failed; readers must never treat absence as an error, and must fall
+  // back to scanning for any statistic this ref does not cover.
+  SnapshotColumnStatsRef column_stats = 11;
 }
 
 message SnapshotPartRef {
@@ -102,4 +108,79 @@ message SnapshotPostingsHeader {
   uint64 entry_count = 5;      // total entries across the covered parts
   uint32 name_count = 6;
   uint64 body_uncompressed_len = 7;
+}
+
+// Reference to a column-statistics object (RCST1 envelope), ADR-0850. Bound
+// to the exact set of parts it was built from, the same way
+// SnapshotPostingsRef binds a name-postings object: a column-stats object is
+// only trustworthy against the parts whose blake3 hashes it names here.
+message SnapshotColumnStatsRef {
+  string key = 1;              // full object key of the column-stats object
+  bytes blake3 = 2;             // 32, of the column-stats object's full bytes
+  uint64 size = 3;
+  uint32 segment_count = 4;     // number of segments with an entry in this object
+  repeated bytes part_blake3 = 5;  // covered parts' blake3, same order as parts
+}
+
+message ColumnStatsHeader {
+  uint32 format_version = 1;  // 1; must match envelope version
+  bytes tenant_hash = 2;      // 16
+  uint32 signal = 3;
+  repeated bytes part_blake3 = 4;  // covered parts' blake3, binds this
+                                    // object to an exact part set
+  uint64 segment_count = 5;
+  uint64 body_uncompressed_len = 6;
+}
+
+// A single dynamic-type scalar: exactly one of the typed-column value
+// domains (ADR-0090: Str, I64, Bool, Bytes). `str_utf8` and `bytes_val` are
+// distinct so a Str column's dictionary/min/max round-trip as UTF-8 text
+// even though both are wire-encoded as `bytes`.
+message ColumnValue {
+  oneof kind {
+    int64 i64 = 1;
+    bool b = 2;
+    string str_utf8 = 3;
+    bytes bytes_val = 4;
+  }
+}
+
+message DictEntry {
+  ColumnValue value = 1;
+  uint64 count = 2;
+}
+
+// Exact per-object statistics for one configured typed-attribute column,
+// computed by a genuine fold-time decode pass over the segment's declared
+// column (ADR-0850). `dictionary_present` false means the column's distinct
+// value count in this segment exceeded the fold's cardinality ceiling: the
+// dictionary is omitted outright, never truncated, and a reader must treat
+// this exactly as "no exact per-value counts available", not as "zero
+// distinct values".
+message ColumnStat {
+  string name = 1;
+  // ravel.sys.v1.TypedAttrColumnType as i32 (no cross-file proto import in
+  // this repo; same convention as SnapshotPartHeader.signal).
+  uint32 declared_type = 2;
+  uint64 non_null_count = 3;
+  uint64 null_count = 4;
+  // Present only when non_null_count > 0; absent (proto3 default) for an
+  // all-null or entirely-absent column in this segment.
+  ColumnValue min = 5;
+  ColumnValue max = 6;
+  bool dictionary_present = 7;
+  repeated DictEntry dictionary = 8;
+}
+
+// One segment's exact column statistics, identified the same way
+// `fold::entry_identity` identifies a `SnapshotEntry`, so a reader can join
+// this record back onto a resolved `SegmentRef` without relying on ordinal
+// position.
+message ColumnStatsSegment {
+  uint32 ingest_hour_bucket = 1;
+  uint32 shard = 2;
+  bytes writer_id = 3;
+  uint64 writer_epoch = 4;
+  uint64 writer_seq = 5;
+  repeated ColumnStat columns = 6;
 }

--- a/services/ravel-cli/src/catalog.rs
+++ b/services/ravel-cli/src/catalog.rs
@@ -404,6 +404,7 @@ mod tests {
             folder_id: vec![0u8; 16],
             created_unix_ns: 0,
             postings: None,
+            column_stats: None,
             shard_generation_count: 1,
         };
         let head_bytes = ravel_catalog::encode_head(&head).expect("encode head");

--- a/services/ravel-server/src/maintain.rs
+++ b/services/ravel-server/src/maintain.rs
@@ -2648,6 +2648,7 @@ mod tests {
             folder_id: vec![0u8; 16],
             created_unix_ns: 0,
             postings: None,
+            column_stats: None,
             shard_generation_count: 1,
         };
         store


### PR DESCRIPTION
feat(sql): answer q02/q08 and MIN/MAX from folded column statistics (ADR-0850)

Folds exact per-object column statistics in ravel-catalog and answers
MIN/MAX over a declared column, plus the ClickBench q02 and q08 COUNT
shapes, from those statistics instead of scanning. On the reference
tenant each covered statement drops from roughly 1.2 s of hot time and
3,469 GETs to zero object-store work.

Includes the fix for a silent wrong-answer defect the wave-0 adversarial
checkpoint found. `declared_not_equal_count` and `declared_group_counts`
carried over only the erasure condition from `stats_are_exact`, and
consulted neither the scan's time window nor its content and prune
predicates. Since segments resolve on OVERLAP rather than containment, a
time-bounded query over a partially covered segment returned that
segment's whole-segment totals: a wrong count that failed OPEN.

That path was reachable in a way worth stating, because it is why the
rewrite could not decline on its own: `logs_provider.rs` reports a pure
ts bound as Exact, so DataFusion deletes the ts FilterExec and folds the
bound into the scan. By the time the rewrite runs there is no filter left
for it to notice. It now routes through the same predicate
`stats_are_exact` already encodes, rather than a second copy of the
condition list -- duplicating that list is how the two drifted apart.

Rebased onto the per-block column cursors rather than merged beside them.
Both change logs_scan.rs, and a textually clean merge across a rewritten
file has broken a build in this repo before, so the seam was verified by
running it rather than by the pick applying cleanly: ravel-sql 248 lib
tests plus every integration target, ravel-logseg and ravel-catalog 278
plus theirs. The two tests that pin the seam both pass --
`cursor_resolves_each_column_once_per_block` for the cursor work, and
`q02_clipping_ts_bound_declines_and_keeps_the_scan` with its positive
control `q02_containing_ts_bound_still_answers_from_stats` for the
window fix, so the rewrite declines when clipped and still answers when
contained.

The fetch-cost half of the original batch is omitted: it landed
separately as #877.

Refs: #850, #849, #680
