### PR TITLE
perf(query): size the log trailer probe from the object

### DIFF
--- a/crates/ravel-query/src/lib.rs
+++ b/crates/ravel-query/src/lib.rs
@@ -30,8 +30,9 @@ pub use fetcher::{
 pub use log_fetcher::{
     BlockRangeFetcher, BlockRangeStats, BlockStatsReport, ColumnarBlockOutcome,
     DEFAULT_LOG_COALESCE_GAP, DEFAULT_LOG_COVERAGE_THRESHOLD, DEFAULT_LOG_MAX_CONCURRENT_GETS,
-    DEFAULT_LOG_SUFFIX_LEN, DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD, LogFetchError, LogFetchOutput,
-    LogQuery, LogSegmentFetcher, LogSegmentScan, StreamAttrEquals, WHOLE_OBJECT_REQUEST_MULTIPLE,
+    DEFAULT_LOG_SUFFIX_LEN, DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD, LOG_SUFFIX_FLOOR_BYTES,
+    LOG_SUFFIX_SIZE_DIVISOR, LogFetchError, LogFetchOutput, LogQuery, LogSegmentFetcher,
+    LogSegmentScan, StreamAttrEquals, WHOLE_OBJECT_REQUEST_MULTIPLE, derive_suffix_len,
 };
 pub use phase_accounting::{PhaseAccounting, PhaseAccountingSnapshot, QueryPhase};
 pub use query_admission::{

--- a/crates/ravel-query/src/lib.rs
+++ b/crates/ravel-query/src/lib.rs
@@ -28,7 +28,7 @@ pub use fetcher::{
     SamplePriority, SegmentFetcher,
 };
 pub use log_fetcher::{
-    BlockRangeFetcher, BlockRangeStats, BlockStatsReport, ColumnarBlockOutcome,
+    BlockRangeFetcher, BlockRangeStats, BlockStatsReport, CarriedFooter, ColumnarBlockOutcome,
     DEFAULT_LOG_COALESCE_GAP, DEFAULT_LOG_COVERAGE_THRESHOLD, DEFAULT_LOG_MAX_CONCURRENT_GETS,
     DEFAULT_LOG_SUFFIX_LEN, DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD, LOG_SUFFIX_FLOOR_BYTES,
     LOG_SUFFIX_SIZE_DIVISOR, LogFetchError, LogFetchOutput, LogQuery, LogSegmentFetcher,

--- a/crates/ravel-query/src/log_fetcher.rs
+++ b/crates/ravel-query/src/log_fetcher.rs
@@ -3104,7 +3104,15 @@ impl BlockRangeFetcher {
         // a property of the derived probe length and this object's shape. A
         // window too short to reach SKIP_IDX forces the section GET below, which
         // is exactly the extra request a too-small derivation would cost.
-        if !probe_window_covers(skip_desc, total_size, self.effective_suffix_len(total_size)) {
+        // Only when THIS read issued the probe. With a carried plan footer the
+        // plan phase already probed and already recorded its own misses, so
+        // counting a hypothetical window here would double-count the same
+        // object. That matters because `probe_misses` is the figure that gates
+        // any future tightening of the floor: a metric that over-reports makes
+        // the derived probe look more dangerous than it is.
+        if plan_footer.is_none()
+            && !probe_window_covers(skip_desc, total_size, self.effective_suffix_len(total_size))
+        {
             stats.probe_misses += 1;
         }
 
@@ -3373,10 +3381,16 @@ impl BlockRangeFetcher {
         // to locate pages through, counted against the probe WINDOW rather than
         // against cache residency, so the figure reports what the probe length
         // costs on this object's shape.
+        // Same gate as the version-3 path above: only a read that actually
+        // issued the probe can miss it. A carried footer means the plan phase
+        // probed and counted, and the coverage crossover below can still decide
+        // to read the whole object, which is not a probe miss either.
         let suffix = self.effective_suffix_len(total_size);
-        for desc in [&skip_desc, &page_desc] {
-            if !probe_window_covers(desc, total_size, suffix) {
-                stats.probe_misses += 1;
+        if probed {
+            for desc in [&skip_desc, &page_desc] {
+                if !probe_window_covers(desc, total_size, suffix) {
+                    stats.probe_misses += 1;
+                }
             }
         }
 

--- a/crates/ravel-query/src/log_fetcher.rs
+++ b/crates/ravel-query/src/log_fetcher.rs
@@ -1550,6 +1550,23 @@ impl LogSegmentFetcher {
                 s3_bytes = tracing::field::Empty,
                 probe_misses = tracing::field::Empty,
             );
+            // What the plan read that produced this footer already counted
+            // (#883, issue #885 review). `plan_segment` has exactly two
+            // footer-carrying branches and they are mutually exclusive on the
+            // same predicate this asks: the fast path requires
+            // `is_block_predicate_free` (an empty `prune`), while
+            // `plan_skip_decidable` requires a non-empty all-NumRange `prune`.
+            // So a footer carried for this (segment, query) pair came from
+            // `fetch_plan_sections`, which counted the tail sections, exactly
+            // when `plan_skip_decidable` holds, and from `fetch_footer`, which
+            // counted nothing about them, otherwise. Asking the predicate
+            // `plan_segment` itself branches on keeps the two from drifting
+            // apart, and any answer this cannot place falls to `false`, the
+            // direction that counts a miss rather than hiding one.
+            let carried = footer.map(|f| CarriedFooter {
+                footer: f,
+                tail_misses_counted: Self::plan_skip_decidable(query),
+            });
             let (bytes, stats) = async {
                 self.block_range
                     .fetch_object_with_footer(
@@ -1559,7 +1576,7 @@ impl LogSegmentFetcher {
                         query.ts_max_ns,
                         &query.prune,
                         columns,
-                        footer,
+                        carried,
                         accounting,
                     )
                     .await
@@ -2050,6 +2067,28 @@ pub struct BlockRangeStats {
     pub probe_misses: u64,
 }
 
+/// A [`footer::LogFooter`] a prior plan read produced for this exact (immutable)
+/// object, carried into a scan read so it can skip its own suffix probe (#693
+/// part 3), together with what that plan read already counted.
+///
+/// `tail_misses_counted` exists because the plan phase has TWO footer-carrying
+/// reads and they differ in exactly that. [`BlockRangeFetcher::fetch_plan_sections`]
+/// runs `ensure_tail_plan_sections`, which counts this object's tail-section
+/// probe misses into the plan phase's own [`BlockRangeStats`];
+/// [`BlockRangeFetcher::fetch_footer`] reads the footer alone and counts nothing
+/// about SKIP_IDX or PAGE_DIR. A scan handed a bare footer cannot tell the two
+/// apart, so it either counts the first object twice or drops the second
+/// object's real miss (#883, issue #885 review).
+#[derive(Clone, Copy, Debug)]
+pub struct CarriedFooter<'a> {
+    /// The footer the plan read parsed, valid for this exact object.
+    pub footer: &'a footer::LogFooter,
+    /// True when the plan read that produced [`Self::footer`] already counted
+    /// this object's tail-section probe misses
+    /// ([`BlockRangeStats::probe_misses`]).
+    pub tail_misses_counted: bool,
+}
+
 /// One candidate block's absolute byte extent in the object and its stored crc,
 /// resolved from a `SkipIndex` level-0 entry (`block_offset`/`block_len`/
 /// `block_crc32c`). The extent start is absolute: `blocks_offset + block_offset`
@@ -2480,6 +2519,14 @@ impl BlockRangeFetcher {
     /// instead of saving one. A zero object size cannot be range-probed either
     /// (every extent, starting with the probe's cache key, is derived from it),
     /// which the same threshold guard rules out.
+    ///
+    /// This reads the footer and nothing else, so the only `probe_misses` it can
+    /// report is a footer chase. It counts NO tail-section miss: SKIP_IDX and
+    /// PAGE_DIR are not read here, and the read that does go on to locate blocks
+    /// through them is the one that pays for a window too short to reach them.
+    /// A footer carried out of here must therefore travel as a
+    /// [`CarriedFooter`] with `tail_misses_counted: false`, or that read's miss
+    /// is counted by nobody.
     pub async fn fetch_footer(
         &self,
         seg_ref: &SegmentRef,
@@ -2896,7 +2943,8 @@ impl BlockRangeFetcher {
     /// (immutable) object (#693 part 3, deliverable 2).
     ///
     /// When `plan_footer` is `Some`, the etag-establishing suffix probe is
-    /// skipped: the carried footer already gives every section's offset and
+    /// skipped: the carried [`CarriedFooter::footer`] already gives every
+    /// section's offset and
     /// length, so the read goes straight to fetching SKIP_IDX, the remaining
     /// directory sections, and the candidate blocks. The [`EtagPin`] is then
     /// established on the FIRST of those live GETs
@@ -2908,6 +2956,10 @@ impl BlockRangeFetcher {
     /// different object fails its stored `crc32c`, a hard [`LogFetchError::Corrupt`]).
     /// Either way the fetch errors rather than assembling bytes from two object
     /// states. `None` keeps the probe-first behavior unchanged.
+    ///
+    /// [`CarriedFooter::tail_misses_counted`] says whether the plan read that
+    /// produced the footer already counted this object's tail-section probe
+    /// misses; see the invariant stated at `count_tail_misses` below.
     ///
     /// `prune` carries the query's prune-only predicates (#761). Its NumRange
     /// arms are resolved against this object's FIELD_DIR and applied to the
@@ -2929,12 +2981,28 @@ impl BlockRangeFetcher {
         ts_max_ns: i64,
         prune: &[Predicate],
         columns: &ColumnSelection,
-        plan_footer: Option<&footer::LogFooter>,
+        plan_footer: Option<CarriedFooter<'_>>,
         accounting: &QueryAccounting,
     ) -> Result<(Bytes, BlockRangeStats), LogFetchError> {
         let key = seg_ref.data_object_key.as_str();
         let mut stats = BlockRangeStats::default();
         let pin = EtagPin::default();
+
+        // The invariant behind every `probe_misses` site: a tail-section miss is
+        // counted exactly once per object per read path, by whichever layer
+        // actually issued the probe. This read issued it when no footer was
+        // carried, so it counts its own. A carried footer names a plan read that
+        // issued the probe instead, and `tail_misses_counted` says whether that
+        // read already counted the tail sections (`fetch_plan_sections`, via
+        // `ensure_tail_plan_sections`) or read the footer alone and counted
+        // nothing (`fetch_footer`). Both directions are real defects and they do
+        // not cancel: counting a `fetch_plan_sections` object again double-reports
+        // it, and skipping a `fetch_footer` object drops a miss that costs this
+        // read a real extra request. Under-reporting is the worse of the two,
+        // because `probe_misses` is the figure that gates any future tightening
+        // of the derived probe floor and a metric that hides misses makes the
+        // probe look safer than it is.
+        let count_tail_misses = !plan_footer.is_some_and(|carried| carried.tail_misses_counted);
 
         // An object whose commit record carries no size cannot be range-planned
         // at all: every range in this protocol, starting with the probe's own
@@ -2998,7 +3066,7 @@ impl BlockRangeFetcher {
         // section/block GET instead; the carried footer's per-section crc still
         // catches a replaced object (see the method doc).
         let footer = match plan_footer {
-            Some(f) => f.clone(),
+            Some(carried) => carried.footer.clone(),
             None => {
                 let suffix = self.effective_suffix_len(total_size);
                 let probe_start = total_size - suffix;
@@ -3082,6 +3150,7 @@ impl BlockRangeFetcher {
                     columns,
                     &footer,
                     plan_footer.is_none(),
+                    count_tail_misses,
                     asm,
                     &pin,
                     accounting,
@@ -3104,13 +3173,9 @@ impl BlockRangeFetcher {
         // a property of the derived probe length and this object's shape. A
         // window too short to reach SKIP_IDX forces the section GET below, which
         // is exactly the extra request a too-small derivation would cost.
-        // Only when THIS read issued the probe. With a carried plan footer the
-        // plan phase already probed and already recorded its own misses, so
-        // counting a hypothetical window here would double-count the same
-        // object. That matters because `probe_misses` is the figure that gates
-        // any future tightening of the floor: a metric that over-reports makes
-        // the derived probe look more dangerous than it is.
-        if plan_footer.is_none()
+        // Counted here only when no earlier layer already counted it for this
+        // object, per the invariant at `count_tail_misses` above.
+        if count_tail_misses
             && !probe_window_covers(skip_desc, total_size, self.effective_suffix_len(total_size))
         {
             stats.probe_misses += 1;
@@ -3360,6 +3425,7 @@ impl BlockRangeFetcher {
         columns: &ColumnSelection,
         footer: &footer::LogFooter,
         probed: bool,
+        count_tail_misses: bool,
         mut asm: ObjectAssembler,
         pin: &EtagPin,
         accounting: &QueryAccounting,
@@ -3381,12 +3447,11 @@ impl BlockRangeFetcher {
         // to locate pages through, counted against the probe WINDOW rather than
         // against cache residency, so the figure reports what the probe length
         // costs on this object's shape.
-        // Same gate as the version-3 path above: only a read that actually
-        // issued the probe can miss it. A carried footer means the plan phase
-        // probed and counted, and the coverage crossover below can still decide
-        // to read the whole object, which is not a probe miss either.
+        // Same gate as the version-3 path: `count_tail_misses` is false only
+        // when the plan read that carried the footer already counted these two
+        // sections, per the invariant `fetch_object_with_footer` states.
         let suffix = self.effective_suffix_len(total_size);
-        if probed {
+        if count_tail_misses {
             for desc in [&skip_desc, &page_desc] {
                 if !probe_window_covers(desc, total_size, suffix) {
                     stats.probe_misses += 1;
@@ -5037,6 +5102,10 @@ mod plan_skip_decidable_span_tests {
     //! wrapped it at all, so a trace over a query taking this branch showed
     //! no `page_fetch` phase, only the ones plan_segment's other branches
     //! open.
+    //!
+    //! The same span capture pins the other figure those spans carry across the
+    //! plan/scan boundary: `probe_misses`, which must count a tail-section miss
+    //! exactly once per object per read path (#883, issue #885 review).
 
     use super::*;
     use ravel_catalog::SegmentLevel;
@@ -5143,6 +5212,7 @@ mod plan_skip_decidable_span_tests {
         signal: Option<String>,
         s3_requests: Option<u64>,
         s3_bytes: Option<u64>,
+        probe_misses: Option<u64>,
     }
 
     struct FieldVisitor<'a>(&'a mut Captured);
@@ -5152,6 +5222,7 @@ mod plan_skip_decidable_span_tests {
             match field.name() {
                 "s3_requests" => self.0.s3_requests = Some(value),
                 "s3_bytes" => self.0.s3_bytes = Some(value),
+                "probe_misses" => self.0.probe_misses = Some(value),
                 _ => {}
             }
         }
@@ -5298,6 +5369,135 @@ mod plan_skip_decidable_span_tests {
              Empty), got {:?}",
             span.s3_bytes
         );
+    }
+
+    /// A suffix probe pinned to start exactly at PAGE_DIR's end: it covers the
+    /// footer and the trailer, so no plan read chases the footer, but neither of
+    /// the two tail sections a version-4 scan locates pages through. Whichever
+    /// layer probes this object therefore owes exactly two tail-section misses.
+    fn suffix_missing_both_tail_sections(bytes: &[u8]) -> u64 {
+        let total = bytes.len() as u64;
+        let f = footer::open(bytes).expect("footer");
+        let skip = f.section(kind::SKIP_IDX).expect("SKIP_IDX");
+        let page = f.section(kind::PAGE_DIR).expect("PAGE_DIR");
+        let suffix = total - (page.offset + page.len);
+        assert!(
+            skip.offset < total - suffix && page.offset < total - suffix,
+            "the pinned probe must reach neither tail section"
+        );
+        suffix
+    }
+
+    fn fetcher_with_suffix(store: Arc<MemoryStore>, suffix: u64) -> LogSegmentFetcher {
+        LogSegmentFetcher::new(store.clone())
+            .with_block_range_threshold(0)
+            .with_block_range(
+                BlockRangeFetcher::new(store)
+                    .with_whole_object_threshold(0)
+                    .with_suffix_len(suffix),
+            )
+    }
+
+    /// End to end over the two phases: `plan_segment` reads a footer, hands it to
+    /// a subset scan, and the object's tail-section probe misses are counted
+    /// exactly once across the pair -- by the plan phase when the plan read
+    /// located those sections, and by the scan when it did not.
+    ///
+    /// This is what pins the derivation in `tenant_bytes_with_footer`, which is
+    /// the only place that decides which of the two a carried footer came from.
+    /// The fetcher-level tests in `tests/log_block_range.rs` and
+    /// `tests/log_page_dir_fetch.rs` construct the [`CarriedFooter`] by hand and
+    /// so cannot catch a wrong flag here.
+    ///
+    /// Prove-the-test: inverting that derivation to
+    /// `tail_misses_counted: !Self::plan_skip_decidable(query)` swaps both
+    /// halves -- the predicate-free scan reads 0 against the expected 2, and the
+    /// NumRange scan reads 2 against the expected 0. Hardcoding it to `true`
+    /// (the previous commit's `plan_footer.is_some()` gate) fails the
+    /// predicate-free half alone; hardcoding it to `false` (no gate at all)
+    /// fails the NumRange half alone.
+    #[tokio::test]
+    async fn a_carried_footer_is_counted_once_across_plan_and_scan() {
+        // (query, plan-phase misses, scan-phase misses). The predicate-free
+        // query takes `plan_segment_fast`, whose `fetch_footer` reads no tail
+        // section and counts nothing, leaving both misses to the scan. The
+        // NumRange query takes the skip-decidable branch, whose
+        // `fetch_plan_sections` reads both tail sections and counts them, so the
+        // scan must count neither. Either way the total is 2.
+        let cases = [
+            (LogQuery::new(i64::MIN, i64::MAX), 0u64, 2u64),
+            (
+                LogQuery::new(i64::MIN, i64::MAX).with_prune(Predicate::NumRange {
+                    field: FieldSel::Attr("code".into()),
+                    ty: FieldType::I64,
+                    min: Some(0i64 as u64),
+                    max: Some(1_000i64 as u64),
+                }),
+                2,
+                0,
+            ),
+        ];
+
+        for (query, want_plan, want_scan) in cases {
+            let collector = PageFetchCollector::default();
+            let subscriber = tracing_subscriber::registry().with(collector.clone());
+            let _guard = subscriber.set_default();
+
+            const N: usize = 6;
+            let records: Vec<LogRecord> = (0..N as i64).map(|ts| record(ts, 500)).collect();
+            let bytes = build_object(&records);
+            let suffix = suffix_missing_both_tail_sections(&bytes);
+            let seg = seg_ref(bytes.len() as u64, &records);
+            let store = store_with_object(bytes).await;
+            let f = fetcher_with_suffix(store, suffix);
+            let acc = QueryAccounting::new();
+
+            let (count, _stats, footer) = f
+                .plan_segment(&seg, TENANT, &query, &acc)
+                .await
+                .expect("plan_segment")
+                .expect("relevant segment");
+            assert!(footer.is_some(), "both branches carry their footer forward");
+
+            let indices: Vec<usize> = (0..count).collect();
+            let scan = f
+                .scan_accounted_with_tenant_subset(
+                    &seg,
+                    TENANT,
+                    &query,
+                    &ColumnSelection::all(),
+                    &indices,
+                    footer.as_ref(),
+                    &acc,
+                )
+                .await
+                .expect("subset scan")
+                .expect("relevant segment");
+            drop(scan);
+
+            let closed = collector.closed.lock().expect("lock");
+            assert_eq!(
+                closed.len(),
+                2,
+                "one page_fetch span for the plan read and one for the scan read"
+            );
+            assert_eq!(
+                closed[0].probe_misses,
+                Some(want_plan),
+                "plan phase misses for {query:?}"
+            );
+            assert_eq!(
+                closed[1].probe_misses,
+                Some(want_scan),
+                "scan phase misses for {query:?}"
+            );
+            assert_eq!(
+                closed[0].probe_misses.unwrap_or_default()
+                    + closed[1].probe_misses.unwrap_or_default(),
+                2,
+                "one count per missed tail section, whichever phase issued the probe"
+            );
+        }
     }
 }
 

--- a/crates/ravel-query/src/log_fetcher.rs
+++ b/crates/ravel-query/src/log_fetcher.rs
@@ -1139,6 +1139,7 @@ impl LogSegmentFetcher {
                     signal = "logs",
                     s3_requests = tracing::field::Empty,
                     s3_bytes = tracing::field::Empty,
+                    probe_misses = tracing::field::Empty,
                 );
                 let (footer, skip, field_dir, stats) = async {
                     self.block_range
@@ -1150,6 +1151,11 @@ impl LogSegmentFetcher {
                 let requests = stats.probe_gets + stats.metadata_gets + stats.block_range_gets;
                 fetch_span.record("s3_requests", requests);
                 fetch_span.record("s3_bytes", stats.block_bytes_fetched);
+                // Probe misses (#883): tail sections the derived probe window did
+                // not cover, reported alongside the request and byte counts for
+                // this plan phase. A nonzero value here is the extra request a
+                // too-small derivation costs.
+                fetch_span.record("probe_misses", stats.probe_misses);
 
                 let refs: Vec<&Predicate> = query.prune.iter().collect();
                 let numeric = field_dir.numeric_range_arms(&refs);
@@ -1273,6 +1279,7 @@ impl LogSegmentFetcher {
             signal = "logs",
             s3_requests = tracing::field::Empty,
             s3_bytes = tracing::field::Empty,
+            probe_misses = tracing::field::Empty,
         );
         let (footer, stats) = async {
             self.block_range
@@ -1284,6 +1291,9 @@ impl LogSegmentFetcher {
         let requests = stats.probe_gets + stats.metadata_gets + stats.block_range_gets;
         fetch_span.record("s3_requests", requests);
         fetch_span.record("s3_bytes", stats.block_bytes_fetched);
+        // Probe misses (#883): a footer chase here is a probe too short to reach
+        // even the footer, reported per phase beside the request/byte counts.
+        fetch_span.record("probe_misses", stats.probe_misses);
 
         let n = usize::try_from(footer.block_count).map_err(|_| LogFetchError::Corrupt {
             key: seg_ref.data_object_key.clone(),
@@ -1378,6 +1388,7 @@ impl LogSegmentFetcher {
             signal = "logs",
             s3_requests = tracing::field::Empty,
             s3_bytes = tracing::field::Empty,
+            probe_misses = tracing::field::Empty,
         );
         let (skip, stats) = async {
             self.block_range
@@ -1389,6 +1400,9 @@ impl LogSegmentFetcher {
         let requests = stats.probe_gets + stats.metadata_gets + stats.block_range_gets;
         fetch_span.record("s3_requests", requests);
         fetch_span.record("s3_bytes", stats.block_bytes_fetched);
+        // Probe misses (#883): SKIP_IDX not covered by the derived probe window,
+        // reported per phase beside the request/byte counts.
+        fetch_span.record("probe_misses", stats.probe_misses);
 
         let (ts_min, ts_max) = (query.ts_min_ns, query.ts_max_ns);
         let mut record_count = 0u64;
@@ -1534,6 +1548,7 @@ impl LogSegmentFetcher {
                 signal = "logs",
                 s3_requests = tracing::field::Empty,
                 s3_bytes = tracing::field::Empty,
+                probe_misses = tracing::field::Empty,
             );
             let (bytes, stats) = async {
                 self.block_range
@@ -1554,6 +1569,10 @@ impl LogSegmentFetcher {
             let requests = stats.probe_gets + stats.metadata_gets + stats.block_range_gets;
             fetch_span.record("s3_requests", requests);
             fetch_span.record("s3_bytes", stats.block_bytes_fetched);
+            // Probe misses (#883): SKIP_IDX/PAGE_DIR (and any footer chase) not
+            // covered by the derived probe window on this scan-phase read,
+            // reported beside the request/byte counts.
+            fetch_span.record("probe_misses", stats.probe_misses);
             return Ok(Some(bytes));
         }
 
@@ -1849,8 +1868,69 @@ impl LogSegmentFetcher {
 /// object it can dominate the column chunks themselves. It is cache-routed and
 /// shared by every partition and by the plan and scan phases of one statement,
 /// which is what keeps that cost to once per object per query rather than once
-/// per read. `BlockRangeFetcher::with_suffix_len` overrides it.
+/// per read. `BlockRangeFetcher::with_suffix_len` pins it explicitly.
+///
+/// Since #883 this 256 KiB is the CEILING of a per-object derivation
+/// ([`derive_suffix_len`]), not a flat default: the fixed 256 KiB was sized for
+/// objects with far more blocks than the reference ClickBench tenant carries
+/// (mean object 3.47 MB, ~4 blocks), where it reads 7.6% of an entire object to
+/// locate a tail of tens of KB and costs a ~0.91 GB plan-phase floor across a
+/// full-corpus pass. The derivation shrinks the probe for a small object while
+/// keeping this ceiling for a wide one whose tail genuinely approaches it. The
+/// ceiling stays 256 KiB because the widest object measured (a 105-column,
+/// 128-block object, issue #766) needs a probe this large to carry footer +
+/// SKIP_IDX + PAGE_DIR past the BLOOM section between them in one GET; beyond it
+/// a longer probe is pure over-read.
 pub const DEFAULT_LOG_SUFFIX_LEN: u64 = 256 * 1024;
+
+/// Floor of the per-object suffix-probe derivation ([`derive_suffix_len`], issue
+/// #883): the smallest probe issued for any object above the whole-object
+/// threshold. The plan and scan probes must reach SKIP_IDX (and, on a version-4
+/// object, PAGE_DIR), which sit BEFORE the BLOOM section in the object, so a
+/// suffix probe reaches them only by spanning BLOOM too. On the reference
+/// ClickBench tenant BLOOM averages 86 KB (issue #766); 128 KiB covers that
+/// average plus the adjacent PAGE_DIR/SKIP_IDX/POSTINGS/footer with headroom, so
+/// a floor-sized probe still captures the plan sections of a low-block-count
+/// object in ONE request. Sized deliberately above the pre-#766 64 KiB probe,
+/// which missed SKIP_IDX on 68.8% of above-threshold objects: a miss costs a
+/// second round trip, and at ~1.8 MiB per request (`DEFAULT_LOG_REQUEST_COST\
+/// _BYTES`) trading 64 KiB of over-read for an extra GET is a large net loss.
+/// The floor is what enforces "fewer bytes at NO more requests": lowering it
+/// trades bytes for miss risk and must be validated against the per-phase
+/// [`BlockRangeStats::probe_misses`] on a real corpus first.
+pub const LOG_SUFFIX_FLOOR_BYTES: u64 = 128 * 1024;
+
+/// Divisor of the per-object suffix-probe derivation ([`derive_suffix_len`],
+/// issue #883): the probe targets `object_size / LOG_SUFFIX_SIZE_DIVISOR`,
+/// clamped to `[LOG_SUFFIX_FLOOR_BYTES, DEFAULT_LOG_SUFFIX_LEN]`. The tail a
+/// probe must reach (footer, POSTINGS, BLOOM, PAGE_DIR, SKIP_IDX) grows with the
+/// block and column count that also drives object size, so for a fixed schema
+/// the tail is a roughly constant fraction of the object and a fraction of the
+/// size is a sound proxy for it. `32` places the ceiling break-even at
+/// `DEFAULT_LOG_SUFFIX_LEN * 32` = 8 MiB (an object at or above 8 MiB probes the
+/// full 256 KiB) and the floor break-even at `LOG_SUFFIX_FLOOR_BYTES * 32` = 4
+/// MiB (an object at or below 4 MiB probes the 128 KiB floor). The reference
+/// tenant's 3.47 MB mean object therefore probes the floor, 128 KiB rather than
+/// 256 KiB: half the plan-phase probe bytes for the same one request.
+pub const LOG_SUFFIX_SIZE_DIVISOR: u64 = 32;
+
+/// The suffix-probe length for an object of `total_size` bytes when no explicit
+/// probe is pinned (issue #883): `total_size / LOG_SUFFIX_SIZE_DIVISOR` clamped
+/// to `[LOG_SUFFIX_FLOOR_BYTES, DEFAULT_LOG_SUFFIX_LEN]`. The result is not
+/// capped to `total_size` here (a probe longer than the object is a well-formed
+/// suffix GET the store returns whole); callers that need the effective,
+/// object-capped value go through [`BlockRangeFetcher::effective_suffix_len`].
+///
+/// See [`LOG_SUFFIX_FLOOR_BYTES`], [`LOG_SUFFIX_SIZE_DIVISOR`], and
+/// [`DEFAULT_LOG_SUFFIX_LEN`] for the reasoning behind each bound. A too-small
+/// result costs a second request on a probe miss, which is the exchange rate
+/// this derivation is calibrated against, so it is pinned by a test
+/// (`derives_probe_from_object_size`) and reported per phase via
+/// [`BlockRangeStats::probe_misses`].
+#[must_use]
+pub fn derive_suffix_len(total_size: u64) -> u64 {
+    (total_size / LOG_SUFFIX_SIZE_DIVISOR).clamp(LOG_SUFFIX_FLOOR_BYTES, DEFAULT_LOG_SUFFIX_LEN)
+}
 
 /// Default cost of one store request, expressed as a latency-bandwidth product:
 /// the byte volume whose transfer time (at the store's single-stream bandwidth)
@@ -2105,7 +2185,10 @@ pub struct BlockRangeFetcher {
     /// section. `None` sends every GET to the store. Either tier configuration
     /// (see [`ReadCache`]); every production caller builds the RAM variant.
     cache: Option<ReadCache>,
-    suffix_len: u64,
+    /// Suffix-probe length. `None` derives it per object from the object size
+    /// ([`derive_suffix_len`], issue #883); `Some(n)` pins it, which the tests
+    /// use to force an exact probe window. See [`Self::effective_suffix_len`].
+    suffix_len: Option<u64>,
     /// Coalescing gap. `None` derives it from `request_cost_bytes` (the
     /// principled default); `Some(n)` pins it, which the tests use to force an
     /// exact run count. See [`Self::effective_coalesce_gap`].
@@ -2131,7 +2214,7 @@ impl BlockRangeFetcher {
             store,
             cfg: RlogConfig::default(),
             cache: None,
-            suffix_len: DEFAULT_LOG_SUFFIX_LEN,
+            suffix_len: None,
             coalesce_gap: None,
             whole_object_threshold: None,
             coverage_threshold: DEFAULT_LOG_COVERAGE_THRESHOLD,
@@ -2152,10 +2235,29 @@ impl BlockRangeFetcher {
         self
     }
 
+    /// Pins the suffix-probe length explicitly, overriding the per-object
+    /// derivation ([`derive_suffix_len`], issue #883). The tests use this to
+    /// force an exact probe window; production callers leave it unset so each
+    /// object is probed proportionally to its size.
     #[must_use]
     pub fn with_suffix_len(mut self, n: u64) -> Self {
-        self.suffix_len = n.max(1);
+        self.suffix_len = Some(n.max(1));
         self
+    }
+
+    /// The suffix-probe length in effect for an object of `total_size` bytes: an
+    /// explicit [`Self::with_suffix_len`] override when set, else the per-object
+    /// derivation [`derive_suffix_len`] (issue #883). Capped to `total_size` (a
+    /// probe cannot read more than the object) and floored at 1 (a zero-length
+    /// suffix is not a valid GET; a zero-size object is handled before any
+    /// probe). This is the single place every probe site computes its window, so
+    /// the derivation, the [`BlockRangeStats::probe_misses`] window check, and
+    /// the cache key all agree on one length per object.
+    fn effective_suffix_len(&self, total_size: u64) -> u64 {
+        let want = self
+            .suffix_len
+            .unwrap_or_else(|| derive_suffix_len(total_size));
+        want.min(total_size).max(1)
     }
 
     #[must_use]
@@ -2414,7 +2516,7 @@ impl BlockRangeFetcher {
         let key = seg_ref.data_object_key.as_str();
         let total_size = seg_ref.object_size;
 
-        let suffix = self.suffix_len.min(total_size);
+        let suffix = self.effective_suffix_len(total_size);
         let probe_start = total_size - suffix;
         let (probe_bytes, probe_live) = self
             .cached_extent(
@@ -2437,6 +2539,11 @@ impl BlockRangeFetcher {
         {
             SuffixOutcome::Ready(footer) => footer,
             SuffixOutcome::NeedRange { offset, len } => {
+                // The probe suffix did not even reach the footer: a probe miss
+                // that forces a follow-up request (#883). Counted against the
+                // window, so it fires whether or not this call's chase GET was a
+                // cache hit, matching the tail-section miss accounting.
+                stats.probe_misses += 1;
                 let (bytes, live) = self
                     .cached_extent(
                         seg_ref,
@@ -2564,7 +2671,7 @@ impl BlockRangeFetcher {
         stats: &mut BlockRangeStats,
     ) -> Result<(), LogFetchError> {
         let total_size = seg_ref.object_size;
-        let suffix = self.suffix_len.min(total_size);
+        let suffix = self.effective_suffix_len(total_size);
         let mut missing: Vec<ByteExtent> = Vec::new();
         for &k in kinds {
             let Some(desc) = footer.section(k) else {
@@ -2893,7 +3000,7 @@ impl BlockRangeFetcher {
         let footer = match plan_footer {
             Some(f) => f.clone(),
             None => {
-                let suffix = self.suffix_len.min(total_size);
+                let suffix = self.effective_suffix_len(total_size);
                 let probe_start = total_size - suffix;
                 let (probe_bytes, probe_live) = self
                     .cached_extent(
@@ -2918,6 +3025,10 @@ impl BlockRangeFetcher {
                 {
                     SuffixOutcome::Ready(footer) => footer,
                     SuffixOutcome::NeedRange { offset, len } => {
+                        // The probe suffix did not reach the footer: a probe
+                        // miss forcing a follow-up request (#883), counted
+                        // against the window like the tail-section misses below.
+                        stats.probe_misses += 1;
                         let (bytes, live) = self
                             .cached_extent(
                                 seg_ref,
@@ -2985,6 +3096,17 @@ impl BlockRangeFetcher {
         let blocks_desc = footer
             .section(kind::BLOCKS)
             .ok_or_else(|| corrupt(key, LogSegError::Corrupted("missing BLOCKS".into())))?;
+
+        // Residual miss rate for the version-3 scan path (#883, mirroring the
+        // version-4 path and `ensure_tail_plan_sections`): SKIP_IDX is the tail
+        // section this read locates candidate blocks through, counted against
+        // the probe WINDOW rather than against cache residency, so the figure is
+        // a property of the derived probe length and this object's shape. A
+        // window too short to reach SKIP_IDX forces the section GET below, which
+        // is exactly the extra request a too-small derivation would cost.
+        if !probe_window_covers(skip_desc, total_size, self.effective_suffix_len(total_size)) {
+            stats.probe_misses += 1;
+        }
 
         // SKIP_IDX first, and nothing the candidate set does not need. The
         // coverage crossover below can decide the whole object is cheaper than
@@ -3251,7 +3373,7 @@ impl BlockRangeFetcher {
         // to locate pages through, counted against the probe WINDOW rather than
         // against cache residency, so the figure reports what the probe length
         // costs on this object's shape.
-        let suffix = self.suffix_len.min(total_size);
+        let suffix = self.effective_suffix_len(total_size);
         for desc in [&skip_desc, &page_desc] {
             if !probe_window_covers(desc, total_size, suffix) {
                 stats.probe_misses += 1;

--- a/crates/ravel-query/tests/log_block_range.rs
+++ b/crates/ravel-query/tests/log_block_range.rs
@@ -37,14 +37,14 @@ use ravel_logseg::footer::{self, kind};
 use ravel_logseg::skip_index::SkipIndex;
 use ravel_logseg::writer::ObjectIdentity;
 use ravel_logseg::{
-    AttrValue, LogRecord, RlogConfig, RlogWriter, read_section, stream_attrs_bytes,
+    AttrValue, ColumnSelection, LogRecord, RlogConfig, RlogWriter, read_section, stream_attrs_bytes,
 };
 use ravel_object_store::memory::MemoryStore;
 use ravel_object_store::{
     Capabilities, DelimitedList, Etag, GetOutcome, GetRange, ListPage, ObjectMeta,
     ObjectStoreBackend, PageToken, PutOptions, PutOutcome, StoreError,
 };
-use ravel_query::{BlockRangeFetcher, LogFetchError, LogQuery, LogSegmentFetcher};
+use ravel_query::{BlockRangeFetcher, CarriedFooter, LogFetchError, LogQuery, LogSegmentFetcher};
 use ravel_types::TenantHash;
 use ravel_types::accounting::{AccountedOp, QueryAccounting};
 use uuid::Uuid;
@@ -1882,5 +1882,164 @@ async fn a_trailer_larger_than_the_probe_costs_one_extra_counted_request() {
         skip_shape(&skip),
         skip_shape(&oracle_skip(&bytes)),
         "the index is decoded correctly despite the probe miss"
+    );
+}
+
+// ---- One miss, one count: the three-way carried-footer state (#883) --------
+
+/// A probe pinned to start exactly at SKIP_IDX's end on the version-3 fixture:
+/// it covers the footer and every tail section after SKIP_IDX (so there is no
+/// footer chase) but not SKIP_IDX itself, the one section a version-3 read has
+/// to locate candidate blocks through. Returns the records, the object bytes,
+/// and that suffix.
+fn probe_missing_skip_idx() -> (Vec<LogRecord>, Vec<u8>, u64) {
+    let (records, bytes) = large_object();
+    let total = bytes.len() as u64;
+    let footer = footer::open(&bytes).expect("footer");
+    let skip_desc = footer.section(kind::SKIP_IDX).expect("SKIP_IDX");
+    let suffix = total - (skip_desc.offset + skip_desc.len);
+    assert!(
+        footer.section(kind::PAGE_DIR).is_none(),
+        "this fixture must be version 3, so the version-3 miss site is the one \
+         under test"
+    );
+    assert!(
+        skip_desc.offset < total - suffix,
+        "the pinned probe must not reach SKIP_IDX's start"
+    );
+    (records, bytes, suffix)
+}
+
+async fn ranged_v3(bytes: &[u8], suffix: u64) -> BlockRangeFetcher {
+    let mem = Arc::new(MemoryStore::new());
+    mem.put(
+        "logs/three-way.rlog",
+        bytes::Bytes::copy_from_slice(bytes),
+        PutOptions::default(),
+    )
+    .await
+    .expect("put");
+    let store: Arc<dyn ObjectStoreBackend> = mem;
+    BlockRangeFetcher::new(store)
+        .with_whole_object_threshold(0)
+        .with_suffix_len(suffix)
+}
+
+/// The version-3 scan's tail-section miss is counted exactly once per object,
+/// by whichever layer issued the probe, across all three states a read can be
+/// in.
+///
+/// 1. No carried footer: this read probed, so it counts its own miss.
+/// 2. A footer carried by `fetch_plan_sections`, which already counted the miss
+///    into the plan phase's own stats: the scan counts nothing, and the total
+///    across the two phases is one, not two.
+/// 3. A footer carried by `fetch_footer`, which read the footer alone and
+///    counted nothing about SKIP_IDX: the scan counts the miss, because it is
+///    the read that pays for it and no other layer has.
+///
+/// All three counts are exact rather than bounds, so each fails in both
+/// directions.
+///
+/// Prove-the-test, per case, against
+/// `crates/ravel-query/src/log_fetcher.rs`'s `if count_tail_misses` in
+/// `fetch_object_with_footer`'s version-3 branch:
+///
+/// - case 1 fails (0 against 1) with the whole `stats.probe_misses += 1` under
+///   that gate deleted;
+/// - case 2 fails (2 against the expected total of 1) with the gate deleted so
+///   the site counts unconditionally, which is the double-count the previous
+///   commit fixed;
+/// - case 3 fails (0 against 1) with the gate restored to the previous commit's
+///   `plan_footer.is_none()`, which is false here even though the carried
+///   footer's read counted nothing. That is the under-count this test exists
+///   for.
+#[tokio::test]
+async fn a_version_3_tail_miss_is_counted_once_by_whoever_probed() {
+    let (records, bytes, suffix) = probe_missing_skip_idx();
+    let total = bytes.len() as u64;
+    let seg = seg_ref("logs/three-way.rlog", total, &records);
+    let fetcher = ranged_v3(&bytes, suffix).await;
+    let acc = QueryAccounting::new();
+    let all = ColumnSelection::all();
+
+    // Case 1: this read issues the probe.
+    let (_bytes, own) = fetcher
+        .fetch_object_with_footer(&seg, TENANT, i64::MIN, i64::MAX, &[], &all, None, &acc)
+        .await
+        .expect("unprompted fetch");
+    assert_eq!(own.probe_gets, 1, "the probe covered the footer, no chase");
+    assert_eq!(
+        own.probe_misses, 1,
+        "this read probed and SKIP_IDX fell outside its window"
+    );
+
+    // Case 2: the plan read counted, so the scan must not.
+    let (planned_footer, _skip, _fd, plan_counted) = fetcher
+        .fetch_plan_sections(&seg, TENANT, &acc)
+        .await
+        .expect("plan sections");
+    assert_eq!(
+        plan_counted.probe_misses, 1,
+        "ensure_tail_plan_sections counts the SKIP_IDX the window missed"
+    );
+    let (_bytes, after_counted) = fetcher
+        .fetch_object_with_footer(
+            &seg,
+            TENANT,
+            i64::MIN,
+            i64::MAX,
+            &[],
+            &all,
+            Some(CarriedFooter {
+                footer: &planned_footer,
+                tail_misses_counted: true,
+            }),
+            &acc,
+        )
+        .await
+        .expect("scan on a counted footer");
+    assert_eq!(
+        after_counted.probe_misses, 0,
+        "the plan phase already counted this object"
+    );
+    assert_eq!(
+        plan_counted.probe_misses + after_counted.probe_misses,
+        1,
+        "one miss, one count across the plan and the scan"
+    );
+
+    // Case 3: the plan read the footer alone and counted nothing.
+    let (bare_footer, footer_only) = fetcher
+        .fetch_footer(&seg, TENANT, &acc)
+        .await
+        .expect("footer-only plan read");
+    assert_eq!(
+        footer_only.probe_misses, 0,
+        "fetch_footer reads no tail section, so it counts no tail miss"
+    );
+    let (_bytes, after_bare) = fetcher
+        .fetch_object_with_footer(
+            &seg,
+            TENANT,
+            i64::MIN,
+            i64::MAX,
+            &[],
+            &all,
+            Some(CarriedFooter {
+                footer: &bare_footer,
+                tail_misses_counted: false,
+            }),
+            &acc,
+        )
+        .await
+        .expect("scan on an uncounted footer");
+    assert_eq!(
+        after_bare.probe_misses, 1,
+        "nobody counted this object's SKIP_IDX miss yet, so this read does"
+    );
+    assert_eq!(
+        footer_only.probe_misses + after_bare.probe_misses,
+        1,
+        "one miss, one count across the plan and the scan"
     );
 }

--- a/crates/ravel-query/tests/log_block_range.rs
+++ b/crates/ravel-query/tests/log_block_range.rs
@@ -775,7 +775,10 @@ fn expected_segment_gets(bytes: &[u8], ts_min: i64, ts_max: i64) -> u64 {
         total > ravel_query::DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
         "fixture must be above the production threshold, got {total} bytes"
     );
-    let suffix = ravel_query::DEFAULT_LOG_SUFFIX_LEN;
+    // The probe window is the size-derived suffix (#883), not a flat 256 KiB:
+    // this fixture's tail exceeds the derived probe, so the uncovered tail
+    // sections it leaves are part of the expected per-segment GET count.
+    let suffix = ravel_query::derive_suffix_len(total);
     let cands = candidate_extents(bytes, ts_min, ts_max);
     assert!(
         cands.len() > 1 && cands.len() < 40,
@@ -1645,5 +1648,239 @@ async fn a_large_coalesce_gap_does_not_cross_a_narrow_read_over_to_whole_object(
     assert!(
         wide_stats.whole_object,
         "a read whose candidates cover the object still crosses over to whole-object"
+    );
+}
+
+// ---- Object-size-derived suffix probe (issue #883) ------------------------
+
+/// An object above the 512 KiB threshold whose TAIL is small: a few blocks of
+/// many records each, inflated by high-entropy NUMERIC columns (which land in
+/// BLOCKS and in compact per-block SKIP_IDX stats, never in BLOOM) with a
+/// one-token body (so BLOOM stays tiny). This is the ClickBench shape -- few
+/// blocks, structured columns -- rather than `large_object`'s one-record,
+/// high-entropy-text blocks whose per-block BLOOM alone makes the tail exceed
+/// the derived floor. Returns the records and the object bytes.
+fn small_tail_object() -> (Vec<LogRecord>, Vec<u8>) {
+    const COLUMNS: usize = 12;
+    const RECORDS: i64 = 12_288; // three full 4096-record blocks
+    let cfg = RlogConfig {
+        block_target_records: 4096,
+        ..RlogConfig::default()
+    };
+    let mut w = RlogWriter::new(cfg, identity());
+    let resource = vec![("service.name".to_string(), AttrValue::Str("api".into()))];
+    let mut state: u64 = 0x1234_5678_9abc_def0;
+    let mut records = Vec::with_capacity(RECORDS as usize);
+    for ts in 0..RECORDS {
+        let attrs: Vec<(String, AttrValue)> = (0..COLUMNS)
+            .map(|c| {
+                state = state
+                    .wrapping_mul(6364136223846793005)
+                    .wrapping_add(1442695040888963407);
+                (format!("n{c:02}"), AttrValue::I64(state as i64))
+            })
+            .collect();
+        let r = LogRecord {
+            stream_id: ravel_types::logstream::log_stream_id(&resource, "scope", "1.0", &[]),
+            stream_attrs: stream_attrs_bytes(&resource, "scope", "1.0", &[]),
+            ts_ns: ts,
+            observed_ts_ns: ts,
+            severity_num: 9,
+            severity_text: "INFO".into(),
+            body: "x".into(),
+            trace_id: None,
+            span_id: None,
+            flags: 0,
+            attrs,
+        };
+        w.push(r.clone()).expect("push");
+        records.push(r);
+    }
+    let bytes = w.finish_v3_for_tests().expect("finish v3");
+    (records, bytes)
+}
+
+/// The l0 shape of a decoded skip index, `(block_offset, block_len,
+/// block_crc32c)` per block: the byte-level oracle a ranged read must reproduce
+/// no matter how short its probe was.
+fn skip_shape(skip: &SkipIndex) -> Vec<(u64, u64, u32)> {
+    skip.l0
+        .iter()
+        .map(|e| (e.block_offset, e.block_len, e.block_crc32c))
+        .collect()
+}
+
+/// The SKIP_IDX decoded straight from the object bytes, the oracle for the
+/// fetcher's own decode.
+fn oracle_skip(bytes: &[u8]) -> SkipIndex {
+    let footer = footer::open(bytes).expect("footer");
+    let skip_desc = footer.section(kind::SKIP_IDX).expect("SKIP_IDX");
+    let raw = read_section(bytes, skip_desc, &RlogConfig::default()).expect("skip raw");
+    SkipIndex::decode(&raw, 1 << 24).expect("skip decode")
+}
+
+/// The probe length is chosen from the object size, not a flat 256 KiB (issue
+/// #883): `object_size / LOG_SUFFIX_SIZE_DIVISOR`, floored at
+/// `LOG_SUFFIX_FLOOR_BYTES` and ceilinged at `DEFAULT_LOG_SUFFIX_LEN`. This pins
+/// the derivation at representative sizes so a later change to the constants or
+/// the formula fails loudly rather than drifting the probe.
+///
+/// Prove-the-test: changing `LOG_SUFFIX_SIZE_DIVISOR` (e.g. 32 -> 16) or
+/// `LOG_SUFFIX_FLOOR_BYTES` moves these expected values, and the `assert_eq!`s
+/// fire. Demonstrated failing during development by setting the divisor to 16
+/// (the 6 MiB case then derives 393216, not 196608).
+#[test]
+fn derives_probe_from_object_size() {
+    // The three constants the formula is built from.
+    assert_eq!(ravel_query::LOG_SUFFIX_FLOOR_BYTES, 128 * 1024);
+    assert_eq!(ravel_query::DEFAULT_LOG_SUFFIX_LEN, 256 * 1024);
+    assert_eq!(ravel_query::LOG_SUFFIX_SIZE_DIVISOR, 32);
+
+    let d = ravel_query::derive_suffix_len;
+
+    // The reference ClickBench tenant's 3.47 MB mean object probes the FLOOR,
+    // 128 KiB rather than the old flat 256 KiB: half the plan-phase probe bytes.
+    assert_eq!(d(3_500_000), 128 * 1024, "3.47 MB mean -> floor");
+
+    // Floor break-even: at 4 MiB the raw fraction equals the floor exactly.
+    assert_eq!(d(4 * 1024 * 1024), 128 * 1024, "4 MiB -> floor exactly");
+
+    // Between the two break-evens the size-proportional value is used verbatim.
+    assert_eq!(d(6 * 1024 * 1024), 192 * 1024, "6 MiB -> 6 MiB / 32");
+
+    // Ceiling break-even: at 8 MiB the fraction equals the ceiling exactly.
+    assert_eq!(d(8 * 1024 * 1024), 256 * 1024, "8 MiB -> ceiling exactly");
+
+    // Above the ceiling break-even the probe is capped at the ceiling: a large
+    // object never probes more than the widest measured object needs.
+    assert_eq!(d(64 * 1024 * 1024), 256 * 1024, "64 MiB -> ceiling");
+
+    // Just above the whole-object threshold: still the floor, never a sliver.
+    assert_eq!(d(600 * 1024), 128 * 1024, "600 KiB -> floor");
+}
+
+/// An object whose trailer FITS inside the derived probe is read in exactly ONE
+/// request: the size-derived suffix (the 128 KiB floor for this ~1 MB fixture)
+/// covers footer + SKIP_IDX, so a plan-phase `fetch_skip_index` issues the probe
+/// GET and nothing else, and reports zero probe misses. The decoded index is
+/// byte-identical to the oracle.
+///
+/// Prove-the-test: this pins the exact GET count (1) and `probe_misses == 0`,
+/// which a too-small derivation breaks. Demonstrated failing during development
+/// by setting `LOG_SUFFIX_FLOOR_BYTES` to 4 KiB: the derived probe then misses
+/// SKIP_IDX, the count becomes 2 and `probe_misses` becomes 1.
+#[tokio::test]
+async fn derived_probe_covering_the_trailer_reads_in_one_request() {
+    let (records, bytes) = small_tail_object();
+    let total = bytes.len() as u64;
+    let (_blocks_offset, _blocks_len, tail) = layout(&bytes);
+
+    // Fixture precondition: above the whole-object threshold, and its tail sits
+    // inside the derived floor so the probe covers SKIP_IDX in one GET. A
+    // fixture-generation change that violated either would fail here, not
+    // silently pass a weaker property.
+    assert!(
+        total > ravel_query::DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
+        "fixture must be above the whole-object threshold, got {total}"
+    );
+    let derived = ravel_query::derive_suffix_len(total);
+    assert!(
+        tail < derived,
+        "the trailer ({tail} B) must fit inside the derived probe ({derived} B)"
+    );
+
+    let mem = Arc::new(MemoryStore::new());
+    mem.put("logs/fit.rlog", bytes.clone().into(), PutOptions::default())
+        .await
+        .expect("put");
+    let counting = Arc::new(CountingStore::new(mem));
+    let store: Arc<dyn ObjectStoreBackend> = counting.clone();
+    let seg = seg_ref("logs/fit.rlog", total, &records);
+
+    // Default suffix: no `with_suffix_len`, so the probe is derived from size.
+    let (skip, stats) = BlockRangeFetcher::new(store)
+        .fetch_skip_index(&seg, TENANT, &QueryAccounting::new())
+        .await
+        .expect("fetch skip index");
+
+    assert_eq!(stats.probe_gets, 1, "one etag-establishing suffix probe");
+    assert_eq!(stats.metadata_gets, 0, "no follow-up section GET");
+    assert_eq!(stats.probe_misses, 0, "the derived probe covered SKIP_IDX");
+    assert_eq!(
+        counting.get_count(),
+        1,
+        "a trailer that fits the derived probe is read in exactly one request"
+    );
+    assert_eq!(
+        skip_shape(&skip),
+        skip_shape(&oracle_skip(&bytes)),
+        "the decoded skip index is byte-identical to the oracle"
+    );
+}
+
+/// An object whose trailer EXCEEDS the probe is still read correctly, and the
+/// miss costs exactly one extra request that the per-object accounting counts.
+/// The probe is pinned just past SKIP_IDX's end (a deliberately-too-small
+/// window, standing in for an under-sized derivation) so it covers the footer
+/// but not SKIP_IDX: the read then pays the probe plus one follow-up section
+/// GET, `probe_misses` is 1, and the decoded index still matches the oracle.
+///
+/// Prove-the-test: this pins the exact GET count (2) and `probe_misses == 1`. A
+/// miss that silently cost an extra round trip on every object would be a
+/// regression wearing a byte win; the count assertion is what catches it.
+/// Demonstrated failing during development by removing `stats.probe_misses +=
+/// 1` from `ensure_tail_plan_sections` (the `probe_misses == 1` assertion then
+/// reads 0), and by widening the pinned suffix to cover SKIP_IDX (the count
+/// drops to 1).
+#[tokio::test]
+async fn a_trailer_larger_than_the_probe_costs_one_extra_counted_request() {
+    let (records, bytes) = large_object();
+    let total = bytes.len() as u64;
+    let footer = footer::open(&bytes).expect("footer");
+    let skip_desc = footer.section(kind::SKIP_IDX).expect("SKIP_IDX");
+    let skip_end = skip_desc.offset + skip_desc.len;
+
+    // A probe that starts exactly at SKIP_IDX's end: it covers everything after
+    // SKIP_IDX (BLOOM/POSTINGS and the footer, so no footer chase) but not
+    // SKIP_IDX itself, which is the section the plan phase must decode.
+    let suffix = total - skip_end;
+    assert!(
+        suffix < total - skip_desc.offset,
+        "the pinned probe must not reach SKIP_IDX's start"
+    );
+
+    let mem = Arc::new(MemoryStore::new());
+    mem.put(
+        "logs/exceed.rlog",
+        bytes.clone().into(),
+        PutOptions::default(),
+    )
+    .await
+    .expect("put");
+    let counting = Arc::new(CountingStore::new(mem));
+    let store: Arc<dyn ObjectStoreBackend> = counting.clone();
+    let seg = seg_ref("logs/exceed.rlog", total, &records);
+
+    let (skip, stats) = BlockRangeFetcher::new(store)
+        .with_suffix_len(suffix)
+        .fetch_skip_index(&seg, TENANT, &QueryAccounting::new())
+        .await
+        .expect("fetch skip index");
+
+    assert_eq!(stats.probe_gets, 1, "one etag-establishing suffix probe");
+    assert_eq!(
+        stats.metadata_gets, 1,
+        "one follow-up GET for the missed SKIP_IDX"
+    );
+    assert_eq!(stats.probe_misses, 1, "the probe missed SKIP_IDX");
+    assert_eq!(
+        counting.get_count(),
+        2,
+        "a trailer larger than the probe costs exactly one extra request"
+    );
+    assert_eq!(
+        skip_shape(&skip),
+        skip_shape(&oracle_skip(&bytes)),
+        "the index is decoded correctly despite the probe miss"
     );
 }

--- a/crates/ravel-query/tests/log_page_dir_fetch.rs
+++ b/crates/ravel-query/tests/log_page_dir_fetch.rs
@@ -22,6 +22,8 @@
 //! 7. The default suffix probe covers the plan sections (footer, SKIP_IDX,
 //!    PAGE_DIR) of a wide, full-row-group object, so #766's second GET is gone.
 //! 8. What a chunk read decodes is what a whole-object read decodes.
+//! 9. A tail-section probe miss is counted exactly once per object per read
+//!    path, by whichever layer issued the probe (#883, issue #885 review).
 //!
 //! The oracle for 1-3 is PAGE_DIR itself, walked here independently of the
 //! fetcher's own walk, plus an exact literal so a silent change in either shows
@@ -51,7 +53,9 @@ use ravel_object_store::{
     Capabilities, DelimitedList, GetOutcome, GetRange, ListPage, ObjectMeta, ObjectStoreBackend,
     PageToken, PutOptions, PutOutcome, StoreError,
 };
-use ravel_query::{BlockRangeFetcher, CacheFetchError, LogFetchError, LogQuery, LogSegmentFetcher};
+use ravel_query::{
+    BlockRangeFetcher, CacheFetchError, CarriedFooter, LogFetchError, LogQuery, LogSegmentFetcher,
+};
 use ravel_types::TenantHash;
 use ravel_types::accounting::{AccountedOp, QueryAccounting};
 use uuid::Uuid;
@@ -1170,4 +1174,201 @@ async fn version_4_chunk_read_decodes_what_a_whole_object_read_decodes() {
             );
         }
     }
+}
+
+// ---- 9. a tail miss is counted once, by whoever issued the probe ----------
+
+/// A probe pinned to start exactly at PAGE_DIR's end: it covers the footer and
+/// the trailer (so there is no footer chase) but neither of the two tail
+/// sections a version-4 read locates pages through, so the derived window costs
+/// this object one extra request and `probe_misses` must report exactly 2.
+///
+/// Returns the object bytes and that suffix.
+fn probe_missing_both_tail_sections() -> (Vec<u8>, u64) {
+    let bytes = build_object(&records());
+    let total = bytes.len() as u64;
+    let f = footer_of(&bytes);
+    let skip = f.section(kind::SKIP_IDX).expect("SKIP_IDX");
+    let page = f.section(kind::PAGE_DIR).expect("PAGE_DIR");
+    let suffix = total - (page.offset + page.len);
+    let probe_start = total - suffix;
+    assert!(
+        skip.offset < probe_start && page.offset < probe_start,
+        "the pinned probe must reach neither SKIP_IDX ({}) nor PAGE_DIR ({}), \
+         but starts at {probe_start}",
+        skip.offset,
+        page.offset
+    );
+    (bytes, suffix)
+}
+
+/// A scan that issued its own probe counts its own tail misses: no footer is
+/// carried, so this read is the only layer that probed the object and the two
+/// uncovered tail sections are its own.
+///
+/// This is case 1 of the three-way, and it is the case the gates never changed.
+/// It is here as the control for the two below: if this ever stops reporting 2,
+/// the fixture stopped reaching the miss-counting site and the other two tests
+/// are vacuous rather than passing.
+///
+/// Prove-the-test: the count is exact, so it fails in both directions. Widening
+/// the pinned suffix to `tail_len(&bytes)` (a probe that covers both sections)
+/// drops it to 0; deleting either `stats.probe_misses += 1` in
+/// `fetch_object_v4` drops it to 1.
+#[tokio::test]
+async fn a_scan_that_probed_counts_its_own_tail_misses() {
+    let (bytes, suffix) = probe_missing_both_tail_sections();
+    let mem = store_with(&bytes).await;
+    let store: Arc<dyn ObjectStoreBackend> = mem;
+    let seg = seg_ref(bytes.len() as u64, &records());
+    let acc = QueryAccounting::new();
+
+    let (_got, stats) = BlockRangeFetcher::new(store)
+        .with_whole_object_threshold(0)
+        .with_suffix_len(suffix)
+        .fetch_object_with_footer(
+            &seg,
+            TENANT,
+            i64::MIN,
+            i64::MAX,
+            &[],
+            &ColumnSelection::all(),
+            None,
+            &acc,
+        )
+        .await
+        .expect("fetch");
+
+    assert_eq!(
+        stats.probe_gets, 1,
+        "the probe covered the footer, no chase"
+    );
+    assert_eq!(
+        stats.probe_misses, 2,
+        "this read probed, so it counts SKIP_IDX and PAGE_DIR itself"
+    );
+}
+
+/// A scan handed a footer whose plan read counted NOTHING about the tail
+/// sections still counts them: `plan_segment_fast` calls `fetch_footer`, which
+/// reads the footer alone, so the probe that was too short to reach SKIP_IDX and
+/// PAGE_DIR costs THIS read the extra request and no other layer has counted it.
+///
+/// This is case 3, the one the previous commit's `plan_footer.is_none()` /
+/// `probed` gates silently dropped.
+///
+/// Prove-the-test: demonstrated failing against the pre-fix code by restoring
+/// the gate at `crates/ravel-query/src/log_fetcher.rs`'s `if count_tail_misses`
+/// in `fetch_object_v4` to `if probed`, which is `plan_footer.is_none()` and so
+/// false here: `probe_misses` then reads 0 against the expected 2.
+#[tokio::test]
+async fn a_carried_footer_that_counted_nothing_leaves_the_scan_to_count() {
+    let (bytes, suffix) = probe_missing_both_tail_sections();
+    let mem = store_with(&bytes).await;
+    let store: Arc<dyn ObjectStoreBackend> = mem;
+    let seg = seg_ref(bytes.len() as u64, &records());
+    let acc = QueryAccounting::new();
+
+    // What `plan_segment_fast` does: read the footer and nothing else. It
+    // reports no tail miss, which is the whole reason the scan must.
+    let fetcher = BlockRangeFetcher::new(store)
+        .with_whole_object_threshold(0)
+        .with_suffix_len(suffix);
+    let (footer, plan_stats) = fetcher
+        .fetch_footer(&seg, TENANT, &acc)
+        .await
+        .expect("footer-only plan read");
+    assert_eq!(
+        plan_stats.probe_misses, 0,
+        "fetch_footer reads no tail section, so it counts no tail miss"
+    );
+
+    let (_got, stats) = fetcher
+        .fetch_object_with_footer(
+            &seg,
+            TENANT,
+            i64::MIN,
+            i64::MAX,
+            &[],
+            &ColumnSelection::all(),
+            Some(CarriedFooter {
+                footer: &footer,
+                tail_misses_counted: false,
+            }),
+            &acc,
+        )
+        .await
+        .expect("fetch");
+
+    assert_eq!(
+        stats.probe_misses, 2,
+        "nobody counted these two sections yet, so this read does"
+    );
+    assert_eq!(
+        plan_stats.probe_misses + stats.probe_misses,
+        2,
+        "exactly once across the plan and the scan"
+    );
+}
+
+/// A scan handed a footer whose plan read ALREADY counted the tail sections
+/// counts nothing: `fetch_plan_sections` runs `ensure_tail_plan_sections`, which
+/// counted both, and counting them again here would report one object's
+/// too-short probe as two.
+///
+/// This is case 2. The sum across the two phases is the assertion that matters:
+/// it is 2 whether the counting happens in the plan or in the scan, and it is 4
+/// if both count.
+///
+/// Prove-the-test: demonstrated failing by deleting the `count_tail_misses`
+/// gate at `crates/ravel-query/src/log_fetcher.rs`'s `if count_tail_misses` in
+/// `fetch_object_v4` (the double-count the previous commit fixed): the scan
+/// then reports 2 and the sum reads 4.
+#[tokio::test]
+async fn a_carried_footer_that_already_counted_is_not_counted_again() {
+    let (bytes, suffix) = probe_missing_both_tail_sections();
+    let mem = store_with(&bytes).await;
+    let store: Arc<dyn ObjectStoreBackend> = mem;
+    let seg = seg_ref(bytes.len() as u64, &records());
+    let acc = QueryAccounting::new();
+
+    let fetcher = BlockRangeFetcher::new(store)
+        .with_whole_object_threshold(0)
+        .with_suffix_len(suffix);
+    let (footer, _skip, _fd, plan_stats) = fetcher
+        .fetch_plan_sections(&seg, TENANT, &acc)
+        .await
+        .expect("plan sections");
+    assert_eq!(
+        plan_stats.probe_misses, 2,
+        "the plan read located both tail sections through a window that reached \
+         neither, and counted them"
+    );
+
+    let (_got, stats) = fetcher
+        .fetch_object_with_footer(
+            &seg,
+            TENANT,
+            i64::MIN,
+            i64::MAX,
+            &[],
+            &ColumnSelection::all(),
+            Some(CarriedFooter {
+                footer: &footer,
+                tail_misses_counted: true,
+            }),
+            &acc,
+        )
+        .await
+        .expect("fetch");
+
+    assert_eq!(
+        stats.probe_misses, 0,
+        "the plan phase already counted this object's tail misses"
+    );
+    assert_eq!(
+        plan_stats.probe_misses + stats.probe_misses,
+        2,
+        "exactly once across the plan and the scan, not twice"
+    );
 }

--- a/crates/ravel-query/tests/log_page_dir_fetch.rs
+++ b/crates/ravel-query/tests/log_page_dir_fetch.rs
@@ -953,13 +953,17 @@ async fn concurrent_partitions_reading_one_chunk_collapse_onto_one_get() {
 
 // ---- 7. the probe covers the plan sections -------------------------------
 
-/// The default suffix probe covers footer + SKIP_IDX + PAGE_DIR on a
-/// full-row-group, wide object, so a predicated statement pays one probe per
-/// object and no second GET for the plan sections (issue #766).
+/// The ceiling suffix probe (`DEFAULT_LOG_SUFFIX_LEN`) covers footer + SKIP_IDX
+/// + PAGE_DIR on a full-row-group, wide object, so a predicated statement over a
+/// production-sized object of this width (where the #883 derivation reaches the
+/// ceiling) pays one probe per object and no second GET for the plan sections
+/// (issue #766).
 ///
-/// The measured section sizes are printed, because the probe length is chosen
-/// from them: this test is the measurement that justifies
-/// `DEFAULT_LOG_SUFFIX_LEN`, not only a guard on it.
+/// The measured section sizes are printed, because the ceiling is chosen from
+/// them: this test is the measurement that justifies `DEFAULT_LOG_SUFFIX_LEN` as
+/// the derivation's ceiling, not only a guard on it. The end-to-end read pins
+/// the ceiling because the cheap fixture is byte-small (its size-derived probe
+/// would be the floor); see the comment at that call site.
 ///
 /// Non-vacuity: reverting `DEFAULT_LOG_SUFFIX_LEN` to the 64 KiB it was before
 /// #766 makes the tail exceed the probe and both the `tail <= suffix` assertion
@@ -1050,8 +1054,16 @@ async fn probe_covers_the_plan_sections_on_a_wide_row_group_object() {
         ravel_query::DEFAULT_LOG_SUFFIX_LEN,
     );
 
-    // And end to end: a plan-phase read of this object at production defaults
-    // reports no probe miss.
+    // And end to end: a plan-phase read of this object at the CEILING probe
+    // reports no probe miss. Since #883 the default suffix is derived from the
+    // object size (`derive_suffix_len`), and this fixture is deliberately
+    // byte-small but section-wide (2-record blocks), so its size-derived probe
+    // is the floor, not the ceiling this test is about. A production wide object
+    // of this width carries far more records per block and so is many MB, where
+    // the derivation reaches `DEFAULT_LOG_SUFFIX_LEN`; the pin below reproduces
+    // that ceiling on the cheap fixture, which is what makes the `tail <=
+    // DEFAULT_LOG_SUFFIX_LEN` measurement above an end-to-end no-miss guarantee
+    // rather than a bare byte comparison.
     let mem = store_with(&bytes).await;
     let recording = RecordingStore::new(mem);
     let store: Arc<dyn ObjectStoreBackend> = Arc::clone(&recording) as Arc<dyn ObjectStoreBackend>;
@@ -1067,13 +1079,14 @@ async fn probe_covers_the_plan_sections_on_a_wide_row_group_object() {
     let acc = QueryAccounting::new();
     let (_footer, _skip, _fd, stats) = BlockRangeFetcher::new(store)
         .with_whole_object_threshold(0)
+        .with_suffix_len(ravel_query::DEFAULT_LOG_SUFFIX_LEN)
         .fetch_plan_sections(&seg, TENANT, &acc)
         .await
         .expect("plan sections");
     assert_eq!(stats.probe_gets, 1, "one probe");
     assert_eq!(
         stats.probe_misses, 0,
-        "the default probe covered SKIP_IDX and PAGE_DIR"
+        "the ceiling probe covered SKIP_IDX and PAGE_DIR"
     );
     assert!(
         recording.ranges().len() <= 1,


### PR DESCRIPTION
perf(query): size the log trailer probe from the object

The trailer probe was a flat 256 KiB. On the reference tenant the mean
object is 3.47 MB, so the probe read 7.6% of an entire object merely to
locate its tail, and cost a 0.91 GB plan-phase floor across a full-corpus
pass, when the tail it must reach is tens of KB.

The probe is now derived per object: object_size / 32, clamped to
[128 KiB, 256 KiB]. The tail a probe must reach (footer, POSTINGS, BLOOM,
PAGE_DIR, SKIP_IDX) grows with the block and column count that also drives
object size, so a fraction of the size is a sound proxy for it. Object size
is already known at every probe site via SegmentRef.object_size, so no HEAD
request is added -- buying a round trip to save bytes would invert the point
of the change.

What this is worth, stated against the floor rather than the headline: at
3.47 MB the derived length is 106 KiB, which is BELOW the 128 KiB floor, so
reference-tenant objects probe at the floor. The saving is therefore
0.91 GB -> 0.45 GB, a halving rather than the order of magnitude the raw
7.6% figure suggests. That lands inside the 0.4-0.8 GB band pre-registered
on #883.

The floor is what makes the change safe rather than merely smaller. It is
sized above the reference tenant's 86 KB mean BLOOM plus the adjacent plan
sections, so a floor-sized probe still captures SKIP_IDX and PAGE_DIR in one
request. A probe that misses costs a second round trip, and at roughly
1.8 MB per request on this store that is a large net loss -- the same trade
that made an earlier byte-reduction change 1.96x slower on two statements,
and that leaves q20 the worst cold statement in the suite at 7x fewer bytes
and 5.5x more requests. The acceptance criterion here was never fewer bytes;
it was fewer bytes at no more requests.

So the figure that gates any future tightening of the floor is now counted.
BlockRangeStats::probe_misses covers a footer range-chase and the version-3
scan path's SKIP_IDX miss, and the per-phase page_fetch spans record it
beside their existing s3_requests and s3_bytes, so a derived probe that
starts costing a follow-up request is visible where the request and byte
accounting already lives.

Tests pin the derivation at representative sizes, that a trailer inside the
derived probe reads in exactly one request with zero misses, and that a
trailer larger than the probe is still read correctly at the cost of exactly
one extra counted request. Exact counts, not bounds. The wide-object
probe-coverage test now pins the ceiling explicitly, since its byte-small
but section-wide fixture would otherwise derive the floor, and the
per-segment GET oracle derives the probe length rather than assuming a flat
256 KiB.

Verified locally on the merged tree: ravel-query 360 lib tests plus every
integration target.

Refs: #883
