### PR TITLE
perf(logs): route the whole-segment fast path on projection width

### DIFF
--- a/crates/ravel-bench/src/spans_scan.rs
+++ b/crates/ravel-bench/src/spans_scan.rs
@@ -315,6 +315,7 @@ async fn build_corpus(config: &SpansScanConfig) -> (Vec<SegmentRef>, usize) {
             writer_seq,
             created_unix_ns: 0,
             level: SegmentLevel::L0,
+            segment_format_version: u32::from(ravel_rspan::footer::VERSION),
         });
     }
     let objects = segments.len();

--- a/crates/ravel-catalog/src/catalog.rs
+++ b/crates/ravel-catalog/src/catalog.rs
@@ -2917,6 +2917,7 @@ fn build_l1_segment_ref(
             input_set_hash,
             part_index: part.part_index,
         },
+        segment_format_version: part.segment_format_version,
     })
 }
 
@@ -2983,6 +2984,7 @@ fn build_rewrite_l1_segment_ref(
             input_set_hash,
             part_index: part.part_index,
         },
+        segment_format_version: part.segment_format_version,
     })
 }
 
@@ -3139,6 +3141,7 @@ fn build_segment_ref(key: &str, record: &CommitRecord) -> Result<SegmentRef, Cat
         writer_seq: record.writer_seq,
         created_unix_ns: record.created_unix_ns,
         level: SegmentLevel::L0,
+        segment_format_version: record.segment_format_version,
     })
 }
 

--- a/crates/ravel-catalog/src/snapshot.rs
+++ b/crates/ravel-catalog/src/snapshot.rs
@@ -63,6 +63,19 @@ pub struct SegmentRef {
     /// resolution"). Determines how a reader verifies the segment footer
     /// and how the ref sorts into the mixed-level snapshot order.
     pub level: SegmentLevel,
+    /// On-object format version, carried from the commit/compaction record or
+    /// folded snapshot entry (the proto `segment_format_version`). It is the
+    /// RLOG trailer version for a logs segment and the RSEG version for a
+    /// samples segment. The reader still verifies the fetched footer's own
+    /// version against the object, so this is a routing hint, not the trusted
+    /// version: it lets a scan decide a version-dependent read shape before it
+    /// opens the object. The whole-segment fast path uses it to keep the ranged
+    /// column-chunk read on RLOG v4 objects, where the `ColumnSelection` is a
+    /// fetch selection (ADR-0699 decision 5), and off the N-1 v3 objects the
+    /// reader window still accepts (ADR-0066 decision 1), where that selection
+    /// is a decode choice only and the ranged route would pay a probe to fetch
+    /// the same whole-object bytes (issue #862).
+    pub segment_format_version: u32,
 }
 
 /// A pinned, immutable set of segments for one `resolve` call (MVCC).

--- a/crates/ravel-catalog/src/snapshot_resolve.rs
+++ b/crates/ravel-catalog/src/snapshot_resolve.rs
@@ -1000,6 +1000,7 @@ fn build_segment_ref_from_entry(
                 input_set_hash,
                 part_index,
             },
+            segment_format_version: entry.segment_format_version,
         });
     }
 
@@ -1039,6 +1040,7 @@ fn build_segment_ref_from_entry(
         writer_seq: entry.writer_seq,
         created_unix_ns: entry.created_unix_ns,
         level: SegmentLevel::L0,
+        segment_format_version: entry.segment_format_version,
     })
 }
 

--- a/crates/ravel-query/benches/fetch_soa_vs_fetch.rs
+++ b/crates/ravel-query/benches/fetch_soa_vs_fetch.rs
@@ -88,6 +88,7 @@ async fn build_store() -> (Arc<MemoryStore>, TenantHash, SegmentRef) {
         writer_seq: 1,
         created_unix_ns: 42,
         level: ravel_catalog::SegmentLevel::L0,
+        segment_format_version: u32::from(ravel_segment::SUPPORTED_VERSIONS.newest()),
     };
     (store, tenant_hash, seg_ref)
 }

--- a/crates/ravel-query/src/cache_correctness.rs
+++ b/crates/ravel-query/src/cache_correctness.rs
@@ -315,7 +315,10 @@ async fn write_rlog_segment_under(tenant: TenantHash) -> (Arc<MemoryStore>, Segm
         writer_seq: 1,
         created_unix_ns: 0,
         level: SegmentLevel::L0,
-        segment_format_version: u32::from(ravel_logseg::footer::VERSION),
+        // 3, matching the bytes `finish_v3_for_tests` wrote above. Declaring
+        // the current version here is what the comment on that call warns
+        // against: the fixture would take the whole-object fallback.
+        segment_format_version: 3,
     };
     (store, seg_ref)
 }

--- a/crates/ravel-query/src/cache_correctness.rs
+++ b/crates/ravel-query/src/cache_correctness.rs
@@ -230,6 +230,7 @@ async fn write_rseg_segment_under(tenant: TenantHash) -> (Arc<MemoryStore>, Segm
         writer_seq: 1,
         created_unix_ns: 123,
         level: SegmentLevel::L0,
+        segment_format_version: u32::from(ravel_segment::SUPPORTED_VERSIONS.newest()),
     };
     (store, seg_ref)
 }
@@ -314,6 +315,7 @@ async fn write_rlog_segment_under(tenant: TenantHash) -> (Arc<MemoryStore>, Segm
         writer_seq: 1,
         created_unix_ns: 0,
         level: SegmentLevel::L0,
+        segment_format_version: u32::from(ravel_logseg::footer::VERSION),
     };
     (store, seg_ref)
 }
@@ -1502,6 +1504,7 @@ async fn write_span_segment_under(tenant: TenantHash) -> (Arc<MemoryStore>, Segm
         writer_seq: 1,
         created_unix_ns: 0,
         level: SegmentLevel::L0,
+        segment_format_version: u32::from(ravel_rspan::footer::VERSION),
     };
     (store, seg_ref)
 }

--- a/crates/ravel-query/src/distrib/codec.rs
+++ b/crates/ravel-query/src/distrib/codec.rs
@@ -3021,6 +3021,7 @@ mod tests {
                 input_set_hash: [6u8; 32],
                 part_index: 4,
             },
+            segment_format_version: u32::from(ravel_segment::SUPPORTED_VERSIONS.newest()),
         };
         let identity = encode_segment_identity(&seg);
         assert_eq!(identity.level, 1);
@@ -3068,6 +3069,7 @@ mod tests {
             writer_seq: 1,
             created_unix_ns: 0,
             level: SegmentLevel::L0,
+            segment_format_version: u32::from(ravel_segment::SUPPORTED_VERSIONS.newest()),
         };
         let stamped = encode_segment_identity(&seg).segment_format_version;
         assert_eq!(

--- a/crates/ravel-query/src/distrib/partition.rs
+++ b/crates/ravel-query/src/distrib/partition.rs
@@ -162,6 +162,7 @@ mod tests {
             writer_seq: seq,
             created_unix_ns: 0,
             level: SegmentLevel::L0,
+            segment_format_version: u32::from(ravel_segment::SUPPORTED_VERSIONS.newest()),
         }
     }
 

--- a/crates/ravel-query/src/distrib/pushdown.rs
+++ b/crates/ravel-query/src/distrib/pushdown.rs
@@ -165,6 +165,7 @@ mod tests {
             writer_seq: 0,
             created_unix_ns: 0,
             level: SegmentLevel::L0,
+            segment_format_version: u32::from(ravel_segment::SUPPORTED_VERSIONS.newest()),
         }
     }
 

--- a/crates/ravel-query/src/distrib/tests.rs
+++ b/crates/ravel-query/src/distrib/tests.rs
@@ -172,6 +172,7 @@ async fn write_segment_prov(
         writer_seq,
         created_unix_ns,
         level: SegmentLevel::L0,
+        segment_format_version: u32::from(ravel_segment::SUPPORTED_VERSIONS.newest()),
     }
 }
 
@@ -621,6 +622,7 @@ async fn write_l1_merged_provenance(store: &MemoryStore) -> SegmentRef {
             input_set_hash,
             part_index: 0,
         },
+        segment_format_version: u32::from(ravel_segment::SUPPORTED_VERSIONS.newest()),
     }
 }
 
@@ -1978,6 +1980,7 @@ fn histogram_series_distributed_equals_local_bitwise() {
             writer_seq: 0,
             created_unix_ns: 0,
             level: SegmentLevel::L0,
+            segment_format_version: u32::from(ravel_segment::SUPPORTED_VERSIONS.newest()),
         };
         let snapshot = Snapshot {
             segments: vec![seg.clone()],
@@ -2124,6 +2127,7 @@ fn erased_histogram_series_is_dropped_before_the_wire() {
             writer_seq: 0,
             created_unix_ns: 0,
             level: SegmentLevel::L0,
+            segment_format_version: u32::from(ravel_segment::SUPPORTED_VERSIONS.newest()),
         };
         let snapshot = Snapshot {
             segments: vec![seg.clone()],
@@ -2286,6 +2290,9 @@ async fn write_log_segment(
         writer_seq: key,
         created_unix_ns: 0,
         level: SegmentLevel::L0,
+        // RLOG and RSPAN are both on trailer version 4; this helper's segment
+        // set is format-agnostic to the distributed path under test.
+        segment_format_version: 4,
     }
 }
 
@@ -2985,6 +2992,9 @@ async fn write_span_segment(
         writer_seq: key,
         created_unix_ns: 0,
         level: SegmentLevel::L0,
+        // RLOG and RSPAN are both on trailer version 4; this helper's segment
+        // set is format-agnostic to the distributed path under test.
+        segment_format_version: 4,
     }
 }
 
@@ -4805,6 +4815,7 @@ fn native_histogram_pushdown_refusal_reports_real_accounting() {
             writer_seq: 0,
             created_unix_ns: 0,
             level: SegmentLevel::L0,
+            segment_format_version: u32::from(ravel_segment::SUPPORTED_VERSIONS.newest()),
         };
         let segments = vec![seg];
 

--- a/crates/ravel-query/src/fetcher.rs
+++ b/crates/ravel-query/src/fetcher.rs
@@ -2653,6 +2653,7 @@ mod tests {
             writer_seq: 1,
             created_unix_ns: 42,
             level: ravel_catalog::SegmentLevel::L0,
+            segment_format_version: u32::from(ravel_segment::SUPPORTED_VERSIONS.newest()),
         };
         (store, tenant_hash, seg_ref)
     }
@@ -2819,6 +2820,7 @@ mod tests {
             writer_seq: 1,
             created_unix_ns: 42,
             level: ravel_catalog::SegmentLevel::L0,
+            segment_format_version: u32::from(ravel_segment::SUPPORTED_VERSIONS.newest()),
         };
         (store, tenant_hash, seg_ref)
     }
@@ -3001,6 +3003,7 @@ mod tests {
                 input_set_hash,
                 part_index: 0,
             },
+            segment_format_version: u32::from(ravel_segment::SUPPORTED_VERSIONS.newest()),
         };
         (store, seg_ref)
     }
@@ -3045,6 +3048,7 @@ mod tests {
             writer_seq: 1,
             created_unix_ns,
             level: SegmentLevel::L0,
+            segment_format_version: u32::from(ravel_segment::SUPPORTED_VERSIONS.newest()),
         };
         (store, seg_ref)
     }
@@ -3352,6 +3356,7 @@ mod tests {
             writer_seq: 1,
             created_unix_ns: 77,
             level: ravel_catalog::SegmentLevel::L0,
+            segment_format_version: u32::from(ravel_segment::SUPPORTED_VERSIONS.newest()),
         };
         (store, tenant_hash, seg_ref)
     }
@@ -3451,6 +3456,7 @@ mod tests {
             writer_seq: 1,
             created_unix_ns: 99,
             level: ravel_catalog::SegmentLevel::L0,
+            segment_format_version: u32::from(ravel_segment::SUPPORTED_VERSIONS.newest()),
         };
         (written.bytes, tenant_hash, seg_ref)
     }

--- a/crates/ravel-query/src/log_fetcher.rs
+++ b/crates/ravel-query/src/log_fetcher.rs
@@ -659,6 +659,48 @@ impl LogSegmentFetcher {
         self.block_range_threshold
     }
 
+    /// Whether the probe-and-range path is worth its extra round trips on an
+    /// object of `object_size` bytes whose projection is expected to read
+    /// `projected_fraction` of them (`0.0` = one column out of many, `1.0` =
+    /// every column). Answered from the catalog summary and the resolved
+    /// projection alone, with no I/O, so a scan can route a segment before it
+    /// opens it (issue #862).
+    ///
+    /// The arbiter is the request-cost model this module already runs on
+    /// ([`DEFAULT_LOG_REQUEST_COST_BYTES`]), not a second threshold. A saved
+    /// request is worth `request_cost_bytes` saved bytes; the ranged protocol
+    /// adds [`WHOLE_OBJECT_REQUEST_MULTIPLE`] round trips over one whole-object
+    /// GET; so it pays exactly when it saves more than
+    /// `WHOLE_OBJECT_REQUEST_MULTIPLE * request_cost_bytes` bytes. That product
+    /// is `BlockRangeFetcher::effective_whole_object_threshold`, which the fetch
+    /// layer already compares the WHOLE object size against -- the same question
+    /// at `projected_fraction == 0.0`. A narrower projection changes what the
+    /// ranged path SAVES, never what it costs, so the same threshold generalizes
+    /// by moving the projection into the saving.
+    ///
+    /// At or below [`Self::block_range_threshold`] the answer is always false:
+    /// there [`tenant_bytes`](Self::tenant_bytes) reads the whole object
+    /// whichever entry point opens it, so routing buys nothing and would only
+    /// add a probe.
+    ///
+    /// `projected_fraction` is an estimate, deliberately: the exact projected
+    /// byte volume is not known until PAGE_DIR is read. The byte-exact decision
+    /// still happens one layer down, in the coverage crossover
+    /// ([`DEFAULT_LOG_COVERAGE_THRESHOLD`]), which falls back to a single
+    /// whole-object GET when the projected pages turn out to cover the object
+    /// after all. This call decides only whether it is worth reading the
+    /// directory to ask. A non-finite fraction fails closed to the whole-object
+    /// read.
+    #[must_use]
+    pub fn ranged_projection_pays(&self, object_size: u64, projected_fraction: f64) -> bool {
+        if object_size <= self.block_range_threshold || !projected_fraction.is_finite() {
+            return false;
+        }
+        let fraction = projected_fraction.clamp(0.0, 1.0);
+        let saved = object_size as f64 * (1.0 - fraction);
+        saved > self.block_range.effective_whole_object_threshold() as f64
+    }
+
     /// Per-object relevance from the catalog summary alone, with no object
     /// read: true iff the segment's event-ts span (`SegmentRef`'s
     /// `min_event_ts_ns..=max_event_ts_ns`, the same bounds the footer carries)
@@ -6230,5 +6272,133 @@ mod plan_block_stats_tests {
             .expect("plan_segment_block_stats");
         assert!(got.is_none(), "ts-irrelevant segment");
         assert_eq!(store.get_count(), 0);
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod ranged_projection_cost_tests {
+    //! The arithmetic behind [`LogSegmentFetcher::ranged_projection_pays`]
+    //! (issue #862), pinned at its break-even rather than at a convenient
+    //! distance from it.
+    //!
+    //! The break-even is the fetch layer's existing whole-object crossover,
+    //! `WHOLE_OBJECT_REQUEST_MULTIPLE * request_cost_bytes`, applied to the
+    //! bytes the projection SKIPS rather than to the object's whole size. Every
+    //! case below states the saving it produces and which side of that figure it
+    //! falls on.
+    //!
+    //! Note which crossover is in effect. `with_block_range_threshold` sets the
+    //! funnel's routing threshold AND the block-range fetcher's size crossover
+    //! to the same value, so a caller that sets it (every production caller does,
+    //! at `EngineConfig::logs_block_range_threshold`, 512 KiB by default) pins
+    //! the break-even to that figure rather than to the request-cost-derived
+    //! one. The tests below cover both configurations, because both ship.
+
+    use super::*;
+    use ravel_object_store::memory::MemoryStore;
+
+    /// A fetcher at the DERIVED break-even: request cost 200,000 bytes, so the
+    /// crossover is `5 * 200,000 = 1,000,000` saved bytes (above the 512 KiB
+    /// floor, which would otherwise mask the multiple). The routing threshold is
+    /// left at its 512 KiB default.
+    fn derived() -> LogSegmentFetcher {
+        let store = Arc::new(MemoryStore::new());
+        let block_range = BlockRangeFetcher::new(store.clone()).with_request_cost_bytes(200_000);
+        LogSegmentFetcher::new(store).with_block_range(block_range)
+    }
+
+    /// The routing threshold takes precedence: at or below it every entry point
+    /// reads the whole object anyway, so a probe would buy nothing.
+    #[test]
+    fn at_or_below_the_routing_threshold_never_ranges() {
+        let f = derived();
+        assert_eq!(
+            f.block_range_threshold(),
+            DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD
+        );
+        assert!(
+            !f.ranged_projection_pays(DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD, 0.0),
+            "at the threshold"
+        );
+        assert!(!f.ranged_projection_pays(0, 0.0), "a sizeless object");
+    }
+
+    /// A projection reading everything saves nothing, at any object size.
+    #[test]
+    fn a_full_projection_never_ranges() {
+        let f = derived();
+        assert!(!f.ranged_projection_pays(1_000_000_000, 1.0));
+        // Out-of-range and non-finite fractions fail closed the same way.
+        assert!(!f.ranged_projection_pays(1_000_000_000, 1.5));
+        assert!(!f.ranged_projection_pays(1_000_000_000, f64::NAN));
+    }
+
+    /// The derived break-even itself, from both sides. A 2,000,000-byte object
+    /// at a fraction of 0.5 saves exactly 1,000,000 bytes, which IS the
+    /// break-even and therefore not a win (the comparison is strict); one more
+    /// byte of saving is.
+    #[test]
+    fn the_break_even_is_five_request_costs_of_saving() {
+        let f = derived();
+        assert!(
+            !f.ranged_projection_pays(2_000_000, 0.5),
+            "saving exactly 1,000,000 bytes does not beat a 1,000,000-byte break-even"
+        );
+        assert!(
+            f.ranged_projection_pays(2_000_002, 0.5),
+            "saving 1,000,001 bytes does"
+        );
+    }
+
+    /// Raising the request cost raises the break-even proportionally: the same
+    /// object and projection that paid at a cost of 200,000 does not at
+    /// 2,000,000. This is what makes recalibrating the store recalibrate the
+    /// routing rather than needing a second knob.
+    #[test]
+    fn the_request_cost_moves_the_break_even() {
+        let store = Arc::new(MemoryStore::new());
+        let dear = LogSegmentFetcher::new(store.clone())
+            .with_block_range(BlockRangeFetcher::new(store).with_request_cost_bytes(2_000_000));
+        assert!(derived().ranged_projection_pays(2_000_002, 0.5));
+        assert!(!dear.ranged_projection_pays(2_000_002, 0.5));
+    }
+
+    /// The shipped production configuration: `with_block_range_threshold` pins
+    /// both crossovers, so the break-even is that figure and NOT the derived
+    /// one. At the 512 KiB default a 3.5 MB object -- the ClickBench reference
+    /// tenant's average after L1 compaction -- ranges for a narrow projection
+    /// and does not for a projection reading nine tenths of its columns.
+    #[test]
+    fn an_explicit_block_range_threshold_is_the_break_even() {
+        let store = Arc::new(MemoryStore::new());
+        let f = LogSegmentFetcher::new(store)
+            .with_block_range_threshold(DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD);
+        let object = 3_500_000u64;
+        assert!(
+            f.ranged_projection_pays(object, 3.0 / 115.0),
+            "a three-of-115-column projection saves ~3.4 MB, past a 512 KiB break-even"
+        );
+        assert!(
+            !f.ranged_projection_pays(object, 0.9),
+            "a nine-tenths projection saves 350 KB, short of it"
+        );
+    }
+
+    /// An explicit whole-object threshold overrides the derived break-even, so a
+    /// test fixture pinning one gets exactly the break-even it pinned. `0` makes
+    /// any nonzero saving a win.
+    #[test]
+    fn an_explicit_threshold_is_the_break_even() {
+        let store = Arc::new(MemoryStore::new());
+        let f = LogSegmentFetcher::new(store).with_block_range_threshold(0);
+        assert!(
+            f.ranged_projection_pays(1, 0.0),
+            "at a break-even of zero, any saving wins"
+        );
+        assert!(
+            !f.ranged_projection_pays(1, 1.0),
+            "a full projection still saves nothing"
+        );
     }
 }

--- a/crates/ravel-query/src/log_fetcher.rs
+++ b/crates/ravel-query/src/log_fetcher.rs
@@ -4675,6 +4675,7 @@ mod plan_fast_path_tests {
             writer_seq: 1,
             created_unix_ns: 0,
             level: SegmentLevel::L0,
+            segment_format_version: u32::from(ravel_logseg::footer::VERSION),
         }
     }
 
@@ -5023,6 +5024,7 @@ mod whole_segment_projection_tests {
             writer_seq: 1,
             created_unix_ns: 0,
             level: SegmentLevel::L0,
+            segment_format_version: u32::from(ravel_logseg::footer::VERSION),
         }
     }
 
@@ -5226,6 +5228,7 @@ mod plan_skip_decidable_span_tests {
             writer_seq: 1,
             created_unix_ns: 0,
             level: SegmentLevel::L0,
+            segment_format_version: u32::from(ravel_logseg::footer::VERSION),
         }
     }
 
@@ -5723,6 +5726,7 @@ mod plan_block_stats_tests {
             writer_seq: 1,
             created_unix_ns: 0,
             level: SegmentLevel::L0,
+            segment_format_version: u32::from(ravel_logseg::footer::VERSION),
         }
     }
 

--- a/crates/ravel-query/src/span_fetcher.rs
+++ b/crates/ravel-query/src/span_fetcher.rs
@@ -1206,6 +1206,7 @@ mod tests {
             writer_seq: key,
             created_unix_ns: 0,
             level: SegmentLevel::L0,
+            segment_format_version: u32::from(ravel_rspan::footer::VERSION),
         }
     }
 

--- a/crates/ravel-query/tests/e2e.rs
+++ b/crates/ravel-query/tests/e2e.rs
@@ -544,6 +544,7 @@ async fn write_log_segment_for_span_test() -> (Arc<MemoryStore>, SegmentRef) {
         writer_seq: 1,
         created_unix_ns: 0,
         level: SegmentLevel::L0,
+        segment_format_version: u32::from(ravel_logseg::footer::VERSION),
     };
     (store, seg_ref)
 }

--- a/crates/ravel-query/tests/erasure_cross_surface.rs
+++ b/crates/ravel-query/tests/erasure_cross_surface.rs
@@ -548,6 +548,7 @@ async fn write_log_object(store: &MemoryStore, key: &str, records: &[LogRecord])
         writer_seq: 1,
         created_unix_ns: 0,
         level: SegmentLevel::L0,
+        segment_format_version: u32::from(ravel_logseg::footer::VERSION),
     }
 }
 

--- a/crates/ravel-query/tests/fetch_multi_get.rs
+++ b/crates/ravel-query/tests/fetch_multi_get.rs
@@ -101,6 +101,7 @@ fn build_multi_series_segment() -> (Bytes, TenantHash, SegmentRef) {
         writer_seq: 1,
         created_unix_ns: 42,
         level: ravel_catalog::SegmentLevel::L0,
+        segment_format_version: u32::from(ravel_segment::SUPPORTED_VERSIONS.newest()),
     };
     (written.bytes, tenant_hash, seg_ref)
 }

--- a/crates/ravel-query/tests/fetch_soa_matcher_superset.rs
+++ b/crates/ravel-query/tests/fetch_soa_matcher_superset.rs
@@ -107,6 +107,7 @@ async fn segment_with_three_jobs() -> (SegmentFetcher, TenantHash, SegmentRef) {
         writer_seq: 1,
         created_unix_ns: 42,
         level: ravel_catalog::SegmentLevel::L0,
+        segment_format_version: u32::from(ravel_segment::SUPPORTED_VERSIONS.newest()),
     };
     let backend: Arc<dyn ObjectStoreBackend> = store;
     (SegmentFetcher::new(backend), tenant_hash, seg_ref)

--- a/crates/ravel-query/tests/log_block_range.rs
+++ b/crates/ravel-query/tests/log_block_range.rs
@@ -151,6 +151,7 @@ fn seg_ref(key: &str, size: u64, records: &[LogRecord]) -> SegmentRef {
         writer_seq: 1,
         created_unix_ns: 0,
         level: SegmentLevel::L0,
+        segment_format_version: u32::from(ravel_logseg::footer::VERSION),
     }
 }
 

--- a/crates/ravel-query/tests/log_fetcher.rs
+++ b/crates/ravel-query/tests/log_fetcher.rs
@@ -197,6 +197,7 @@ async fn write_object(store: &MemoryStore, key: &str, records: &[LogRecord]) -> 
         writer_seq: 1,
         created_unix_ns: 0,
         level: SegmentLevel::L0,
+        segment_format_version: u32::from(ravel_logseg::footer::VERSION),
     }
 }
 
@@ -616,6 +617,7 @@ async fn write_indexed_object(
         writer_seq: 1,
         created_unix_ns: 0,
         level: SegmentLevel::L0,
+        segment_format_version: u32::from(ravel_logseg::footer::VERSION),
     }
 }
 

--- a/crates/ravel-query/tests/log_footer_carry.rs
+++ b/crates/ravel-query/tests/log_footer_carry.rs
@@ -123,6 +123,7 @@ fn seg_ref(size: u64) -> SegmentRef {
         writer_seq: 1,
         created_unix_ns: 0,
         level: SegmentLevel::L0,
+        segment_format_version: u32::from(ravel_logseg::footer::VERSION),
     }
 }
 

--- a/crates/ravel-query/tests/log_page_dir_fetch.rs
+++ b/crates/ravel-query/tests/log_page_dir_fetch.rs
@@ -169,6 +169,7 @@ fn seg_ref(size: u64, records: &[LogRecord]) -> SegmentRef {
         writer_seq: 1,
         created_unix_ns: 0,
         level: SegmentLevel::L0,
+        segment_format_version: u32::from(ravel_logseg::footer::VERSION),
     }
 }
 

--- a/crates/ravel-sql/benches/logs_scan.rs
+++ b/crates/ravel-sql/benches/logs_scan.rs
@@ -129,6 +129,7 @@ async fn build() -> (Arc<dyn ObjectStoreBackend>, Vec<SegmentRef>) {
         writer_seq: 1,
         created_unix_ns: 0,
         level: SegmentLevel::L0,
+        segment_format_version: u32::from(ravel_logseg::footer::VERSION),
     };
     (Arc::new(store), vec![seg])
 }

--- a/crates/ravel-sql/benches/samples_scan.rs
+++ b/crates/ravel-sql/benches/samples_scan.rs
@@ -114,6 +114,7 @@ async fn build(specs: &[SegSpec]) -> (Arc<dyn ObjectStoreBackend>, Snapshot) {
             writer_seq: spec.writer_seq,
             created_unix_ns: spec.created_unix_ns,
             level: SegmentLevel::L0,
+            segment_format_version: u32::from(ravel_segment::SUPPORTED_VERSIONS.newest()),
         });
     }
     segments.sort_by_key(|s| (s.created_unix_ns, s.writer_epoch, s.writer_seq, s.shard));

--- a/crates/ravel-sql/src/flight_ticket.rs
+++ b/crates/ravel-sql/src/flight_ticket.rs
@@ -226,6 +226,18 @@
 //! never reinterpreted under the v6 layout. Consistent with every earlier
 //! extension, this is a version bump on an ephemeral MAC'd blob, not a `.proto`
 //! schema change and not an ADR of its own.
+//!
+//! Version 7 (issue #862) carries each segment's on-object format version
+//! ([`SegmentPin::segment_format_version`], mirroring the field added to
+//! [`SegmentRef`]). The whole-segment fast path routes the ranged column-chunk
+//! read on that version -- it is a v4 capability (ADR-0699 decision 5) -- so a
+//! worker reconstructing the snapshot from the ticket must see each segment's
+//! real version, or it would misroute a v3 logs segment onto the ranged path
+//! and pay a probe to fetch the same whole-object bytes. A v6 (or earlier)
+//! ticket is rejected with [`FlightTicketError::UnsupportedVersion`], never
+//! reinterpreted under the v7 layout. Consistent with every earlier extension,
+//! this is a version bump on an ephemeral MAC'd blob, not a `.proto` schema
+//! change and not an ADR of its own.
 
 use ravel_catalog::{SegmentLevel, SegmentRef};
 use ravel_proto::commit::v1::{ErasurePredicateMatcher, ErasureRequest};
@@ -241,7 +253,7 @@ use crate::declared::{DeclaredColumn, DeclaredType};
 pub const MAX_STATEMENT_LEN: usize = 64 * 1024;
 
 const MAGIC: [u8; 4] = *b"RFT1";
-const VERSION: u8 = 6;
+const VERSION: u8 = 7;
 
 /// Length in bytes of the trailing keyed-MAC tag ([`mac`]).
 const MAC_LEN: usize = 32;
@@ -344,6 +356,13 @@ pub struct SegmentPin {
     /// L1 part as if it were L0 (or vice versa) and read it against the wrong
     /// footer contract.
     pub level: SegmentLevel,
+    /// On-object format version, mirrored from
+    /// [`SegmentRef::segment_format_version`]. Pinned so `DoGet` reconstructs
+    /// the same read-shape routing the coordinator's snapshot carried: the
+    /// whole-segment fast path keeps the ranged column-chunk read on RLOG v4
+    /// objects and off v3 (issue #862). Without it a worker would reconstruct
+    /// every segment at a default version and misroute a v3 logs segment.
+    pub segment_format_version: u32,
 }
 
 impl SegmentPin {
@@ -364,6 +383,7 @@ impl SegmentPin {
             writer_seq: seg.writer_seq,
             created_unix_ns: seg.created_unix_ns,
             level: seg.level.clone(),
+            segment_format_version: seg.segment_format_version,
         }
     }
 
@@ -388,6 +408,7 @@ impl SegmentPin {
             writer_seq: self.writer_seq,
             created_unix_ns: self.created_unix_ns,
             level: self.level.clone(),
+            segment_format_version: self.segment_format_version,
         }
     }
 }
@@ -488,6 +509,7 @@ impl FlightTicket {
             buf.extend_from_slice(seg.writer_id.as_bytes());
             write_len_prefixed(&mut buf, seg.data_object_key.as_bytes())?;
             write_segment_level(&mut buf, &seg.level);
+            write_u32(&mut buf, seg.segment_format_version);
         }
 
         write_u32(&mut buf, u32_len(self.pending_erasure.len())?);
@@ -574,6 +596,7 @@ impl FlightTicket {
             let data_object_key =
                 std::str::from_utf8(key).map_err(|_| FlightTicketError::InvalidUtf8)?;
             let level = read_segment_level(&mut cur)?;
+            let segment_format_version = cur.read_u32()?;
             segments.push(SegmentPin {
                 data_object_key: data_object_key.to_owned(),
                 object_size,
@@ -589,6 +612,7 @@ impl FlightTicket {
                 writer_seq,
                 created_unix_ns,
                 level,
+                segment_format_version,
             });
         }
 
@@ -993,6 +1017,7 @@ mod tests {
             writer_seq: seed * 1_000 + 9,
             created_unix_ns: seed as i64 * 1_000 + 10,
             level,
+            segment_format_version: seed as u32 + 12,
         }
     }
 
@@ -1057,6 +1082,7 @@ mod tests {
                 writer_seq: 4_294_967_296,
                 created_unix_ns: 1_699_999_999_999_999_999,
                 level: level.clone(),
+                segment_format_version: 4,
             };
             let pin = SegmentPin::from_segment_ref(&seg);
             assert_eq!(pin.to_segment_ref(), seg);
@@ -1539,7 +1565,7 @@ mod tests {
             any::<u128>(),
             (any::<u64>(), any::<u64>(), any::<i64>(), any::<u64>()),
             (any::<i64>(), any::<i64>(), any::<u64>(), any::<u64>()),
-            (any::<u32>(), any::<u32>()),
+            (any::<u32>(), any::<u32>(), any::<u32>()),
             segment_level_strategy(),
         )
             .prop_map(
@@ -1549,7 +1575,7 @@ mod tests {
                     writer_id,
                     (writer_epoch, writer_seq, created_unix_ns, object_size),
                     (min_event_ts_ns, max_event_ts_ns, sample_count, series_count),
-                    (ingest_hour_bucket, shard),
+                    (ingest_hour_bucket, shard, segment_format_version),
                     level,
                 )| SegmentPin {
                     data_object_key,
@@ -1566,6 +1592,7 @@ mod tests {
                     writer_seq,
                     created_unix_ns,
                     level,
+                    segment_format_version,
                 },
             )
     }

--- a/crates/ravel-sql/src/logs_provider.rs
+++ b/crates/ravel-sql/src/logs_provider.rs
@@ -497,6 +497,7 @@ mod tests {
             writer_seq: 1,
             created_unix_ns: 0,
             level: SegmentLevel::L0,
+            segment_format_version: u32::from(ravel_logseg::footer::VERSION),
         }
     }
 

--- a/crates/ravel-sql/src/logs_scan.rs
+++ b/crates/ravel-sql/src/logs_scan.rs
@@ -80,11 +80,20 @@
 //!   window fully contains every relevant segment, and there are at least
 //!   `target_partitions` of them, the plan phase is skipped entirely
 //!   ([`LogsScanExec::whole_segment_fast_path`]): whole segments are assigned
-//!   round-robin (the same rule the un-cached path uses), and each is read in one
+//!   round-robin (the same rule the un-cached path uses), with no plan phase and
+//!   no suffix probe from it. How each assigned segment is then READ is a
+//!   separate, per-segment decision (#862, [`PartitionCtx::open_by_column_chunk`]):
+//!   a projection wide enough to want most of the object's bytes takes the one
 //!   whole-object GET ([`LogSegmentFetcher::scan_whole_accounted_with_tenant`]),
-//!   so the request count is exactly one GET per relevant segment, zero suffix
-//!   probes. Object size does not enter into it: a segment at or below the
-//!   block-range threshold is read whole by both entries, on the same
+//!   and a narrow one takes the probe-and-range path
+//!   ([`LogSegmentFetcher::scan_accounted_with_tenant`]), which brings one
+//!   coalesced range per surviving `(row group, projected column)`. Every block
+//!   surviving is what the fast path's conjuncts prove; under RLOG v4 that no
+//!   longer implies every byte is needed. The arbiter is the fetch layer's
+//!   request-cost model ([`LogSegmentFetcher::ranged_projection_pays`]), so the
+//!   ranged path is taken only where the bytes it skips outweigh the round trips
+//!   it adds. Object size does not enter into the ASSIGNMENT: a segment at or
+//!   below the block-range threshold is read whole by both entries, on the same
 //!   `(0, object_size)` cache key, so it joins the assignment without changing
 //!   what is read (#739 -- as a query-wide conjunct the threshold let one small
 //!   tail object per `(shard, hour)` veto an entire 8,424-object snapshot).
@@ -212,7 +221,7 @@
 //! the key to the record's value, which wins). The merged column and the
 //! residual are the whole correctness story.
 
-use std::collections::{HashMap, VecDeque};
+use std::collections::{BTreeSet, HashMap, VecDeque};
 use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
@@ -311,6 +320,58 @@ fn attr_value_memory(v: &AttrValue) -> usize {
     }
 }
 
+/// Block columns every RLOG object carries whatever the tenant declares: the
+/// ten fixed columns of `ravel_logseg::record` (`ts`, `observed_ts`,
+/// `stream_ref`, `severity_num`, `severity_text`, `body`, `trace_id`, `span_id`,
+/// `flags`, `attrs_raw`). The denominator of [`ResolvedColumns::fraction_of`],
+/// alongside the tenant's declared attribute columns.
+const FIXED_OBJECT_COLUMNS: usize = 10;
+
+/// Object columns a [`ColumnSelection`] decodes whatever it names: `ts` (the
+/// exact ts re-check) and `stream_ref` (stream identity). See
+/// `ravel_logseg::columns`.
+const IMPLICIT_OBJECT_COLUMNS: usize = 2;
+
+/// The column selection one query resolves to, and how wide it is.
+///
+/// The width is what makes the whole-segment fast path's routing decision
+/// possible (issue #862): whether reading a segment by column chunk beats
+/// reading it whole is a question about how much of the object the projection
+/// wants, and `ColumnSelection` itself exposes no count. Both come out of one
+/// walk over the projection in [`resolve_columns`], so they cannot disagree.
+struct ResolvedColumns {
+    /// What the reader decodes, and on a version-4 object what the fetch brings
+    /// (ADR-0699 decision 5).
+    selection: ColumnSelection,
+    /// Distinct object columns the selection names, or `None` when it names
+    /// every column (`SELECT *`, any reference to the merged `attrs` map, or
+    /// the fail-open widening).
+    width: Option<usize>,
+}
+
+impl ResolvedColumns {
+    /// The share of an object's bytes this selection is expected to read, as a
+    /// column-count ratio over the object's column population (the fixed
+    /// columns plus `declared_columns` dynamic ones).
+    ///
+    /// A ratio of counts, not of bytes: per-column byte volumes are not known
+    /// until PAGE_DIR is read, and the point of this figure is to be available
+    /// with no I/O at all. It feeds
+    /// [`LogSegmentFetcher::ranged_projection_pays`], whose threshold is an
+    /// order of magnitude away from the borderline cases, and the byte-exact
+    /// decision still runs one layer down in the fetcher's coverage crossover.
+    /// A tenant carrying dynamic attributes it never declared has more object
+    /// columns than this denominator counts, which over-states the fraction and
+    /// so errs toward the unchanged whole-object read.
+    fn fraction_of(&self, declared_columns: usize) -> f64 {
+        let Some(width) = self.width else {
+            return 1.0;
+        };
+        let total = FIXED_OBJECT_COLUMNS + declared_columns;
+        (width as f64 / total as f64).min(1.0)
+    }
+}
+
 /// The block columns one query needs decoded (ADR-0087 decision 3, extended by
 /// ADR-0090 decision 4).
 ///
@@ -357,22 +418,33 @@ fn resolve_columns(
     content: &[Predicate],
     erasure: &[ErasurePredicate],
     declared: &[DeclaredColumn],
-) -> ColumnSelection {
-    let mut sel = ColumnSelection::fixed_only();
+) -> ResolvedColumns {
+    // Accumulated as sets first, and turned into a `ColumnSelection` below, so
+    // the same walk that decides what to decode also counts how many distinct
+    // object columns that is. Counting from the finished selection is not an
+    // option (it exposes no width), and a second walk beside this one would be
+    // free to drift from it.
+    let mut all = false;
+    let mut all_attrs = false;
+    let mut fixed: BTreeSet<usize> = BTreeSet::new();
+    let mut attrs: BTreeSet<String> = BTreeSet::new();
+
     for &i in projection {
-        sel = match i {
+        match i {
             // `ts` is always decoded; naming it changes nothing.
-            LOG_COL_TS => sel,
-            LOG_COL_OBSERVED_TS => sel.with_observed_ts(),
-            LOG_COL_SEVERITY_NUM => sel.with_severity_num(),
-            LOG_COL_SEVERITY_TEXT => sel.with_severity_text(),
-            LOG_COL_BODY => sel.with_body(),
-            LOG_COL_TRACE_ID => sel.with_trace_id(),
-            LOG_COL_SPAN_ID => sel.with_span_id(),
-            LOG_COL_FLAGS => sel.with_flags(),
+            LOG_COL_TS => {}
+            LOG_COL_OBSERVED_TS
+            | LOG_COL_SEVERITY_NUM
+            | LOG_COL_SEVERITY_TEXT
+            | LOG_COL_BODY
+            | LOG_COL_TRACE_ID
+            | LOG_COL_SPAN_ID
+            | LOG_COL_FLAGS => {
+                fixed.insert(i);
+            }
             // The merged `attrs` map exposes every key, so referencing it at
             // all means every dynamic column plus the overflow.
-            LOG_COL_ATTRS => sel.with_all_attrs(),
+            LOG_COL_ATTRS => all_attrs = true,
             // A declared typed attribute column (index >= FIRST_DECLARED_COL):
             // decode exactly that key's dynamic column, the same per-key path
             // an erasure predicate uses. `i` here is never a fixed index
@@ -384,35 +456,78 @@ fn resolve_columns(
                 .checked_sub(FIRST_DECLARED_COL)
                 .and_then(|k| declared.get(k))
             {
-                Some(dc) => sel.with_attr(dc.key.clone()),
-                None => ColumnSelection::all(),
+                Some(dc) => {
+                    attrs.insert(dc.key.clone());
+                }
+                None => all = true,
             },
-        };
+        }
     }
     for p in content {
-        sel = content_columns(p, sel);
+        content_columns(p, &mut fixed, &mut attrs);
     }
     for p in erasure {
         for (key, _) in p.matchers() {
-            sel = sel.with_attr(key);
+            attrs.insert(key.clone());
         }
     }
-    sel
+
+    let selection = if all {
+        ColumnSelection::all()
+    } else {
+        let mut sel = ColumnSelection::fixed_only();
+        for &i in &fixed {
+            sel = match i {
+                LOG_COL_OBSERVED_TS => sel.with_observed_ts(),
+                LOG_COL_SEVERITY_NUM => sel.with_severity_num(),
+                LOG_COL_SEVERITY_TEXT => sel.with_severity_text(),
+                LOG_COL_BODY => sel.with_body(),
+                LOG_COL_TRACE_ID => sel.with_trace_id(),
+                LOG_COL_SPAN_ID => sel.with_span_id(),
+                // `fixed` is only ever filled from the arm above, which admits
+                // exactly the seven names matched here; `flags` is the last.
+                _ => sel.with_flags(),
+            };
+        }
+        if all_attrs {
+            sel = sel.with_all_attrs();
+        }
+        for key in &attrs {
+            sel = sel.with_attr(key.clone());
+        }
+        sel
+    };
+    let width = if all || all_attrs {
+        None
+    } else {
+        Some(IMPLICIT_OBJECT_COLUMNS + fixed.len() + attrs.len())
+    };
+    ResolvedColumns { selection, width }
 }
 
 /// Add every column an exact content predicate reads. `TsRange` and `StreamIn`
 /// need only the two always-decoded fixed columns.
-fn content_columns(pred: &Predicate, sel: ColumnSelection) -> ColumnSelection {
+fn content_columns(pred: &Predicate, fixed: &mut BTreeSet<usize>, attrs: &mut BTreeSet<String>) {
     match pred {
-        Predicate::And(arms) => arms.iter().fold(sel, |acc, a| content_columns(a, acc)),
+        Predicate::And(arms) => {
+            for a in arms {
+                content_columns(a, fixed, attrs);
+            }
+        }
         // `NumRange` is prune-only (ADR-0095 decision 6): it never reaches the
         // exact content channel, so it reads no columns, same as ts/stream. The
         // planner-side pushdown that would emit it is #278's job.
-        Predicate::TsRange { .. } | Predicate::StreamIn(_) | Predicate::NumRange { .. } => sel,
+        Predicate::TsRange { .. } | Predicate::StreamIn(_) | Predicate::NumRange { .. } => {}
         Predicate::HasWord { field, .. } | Predicate::Equals { field, .. } => match field {
-            FieldSel::Body => sel.with_body(),
-            FieldSel::SeverityText => sel.with_severity_text(),
-            FieldSel::Attr(name) => sel.with_attr(name.clone()),
+            FieldSel::Body => {
+                fixed.insert(LOG_COL_BODY);
+            }
+            FieldSel::SeverityText => {
+                fixed.insert(LOG_COL_SEVERITY_TEXT);
+            }
+            FieldSel::Attr(name) => {
+                attrs.insert(name.clone());
+            }
         },
     }
 }
@@ -545,6 +660,12 @@ pub struct LogsScanExec {
     /// `projection`, `content`, `erasure`, and `declared` (see
     /// [`resolve_columns`]).
     columns: ColumnSelection,
+    /// The share of an object's bytes `columns` is expected to read
+    /// ([`ResolvedColumns::fraction_of`]), resolved once beside it. This is what
+    /// the whole-segment fast path routes on (issue #862): it is the only input
+    /// [`LogSegmentFetcher::ranged_projection_pays`] needs that the catalog
+    /// summary does not already carry.
+    projected_fraction: f64,
     /// The tenant's declared typed attribute columns (ADR-0090), in schema-
     /// append order. Index `k` here is schema index `FIRST_DECLARED_COL + k`.
     /// Empty for a zero-declaration query, which is byte-identical to the
@@ -678,6 +799,14 @@ struct BlockMetrics {
     /// Published once by partition 0, so a report can tell a fully-skip-planned
     /// query from one still paying the plan-phase read.
     plan_full_reads: Count,
+    /// Whole-segment fast-path segments this partition opened with one
+    /// whole-object GET, and the ones it opened by column chunk instead (issue
+    /// #862). Which way the request-cost model routed a statement is otherwise
+    /// invisible short of counting store requests, and the two together are this
+    /// partition's fast-path segment count, so a report can see both the split
+    /// and that nothing fell through it.
+    fast_path_whole_object_segments: Count,
+    fast_path_ranged_segments: Count,
 }
 
 impl BlockMetrics {
@@ -692,6 +821,21 @@ impl BlockMetrics {
             columnar_batches: MetricBuilder::new(metrics).counter("columnar_batches", partition),
             rowpath_batches: MetricBuilder::new(metrics).counter("rowpath_batches", partition),
             plan_full_reads: MetricBuilder::new(metrics).counter("plan_full_reads", partition),
+            fast_path_whole_object_segments: MetricBuilder::new(metrics)
+                .counter("fast_path_whole_object_segments", partition),
+            fast_path_ranged_segments: MetricBuilder::new(metrics)
+                .counter("fast_path_ranged_segments", partition),
+        }
+    }
+
+    /// Records which way the whole-segment fast path routed one segment (issue
+    /// #862). Called once per segment, at its first open; an `attrs_raw`
+    /// fallback re-opens the same segment the same way and does not re-count.
+    fn record_fast_path_route(&self, by_column_chunk: bool) {
+        if by_column_chunk {
+            self.fast_path_ranged_segments.add(1);
+        } else {
+            self.fast_path_whole_object_segments.add(1);
         }
     }
 
@@ -923,7 +1067,9 @@ impl LogsScanExec {
                 )));
             }
         }
-        let columns = resolve_columns(&projection, &content, &erasure, &declared);
+        let resolved = resolve_columns(&projection, &content, &erasure, &declared);
+        let projected_fraction = resolved.fraction_of(declared.len());
+        let columns = resolved.selection;
         let projected = full.project(&projection)?;
         // The row-ref column is synthesized per row from the scan's own cursor
         // position, not decoded, so it contributes nothing to `columns` and
@@ -951,6 +1097,7 @@ impl LogsScanExec {
             erasure,
             projection: Arc::new(projection),
             columns,
+            projected_fraction,
             declared,
             column_stats: None,
             full_schema: full,
@@ -1326,6 +1473,19 @@ impl LogsScanExec {
     /// state. So a sub-threshold segment reads identically whichever entry opens
     /// it, and it can join the whole-segment assignment while the above-threshold
     /// segments around it keep the probe the fast path removes.
+    ///
+    /// # This decides the assignment, not the read (issue #862)
+    ///
+    /// Every conjunct here is about which BLOCKS survive, and the answer it
+    /// establishes is always "all of them" -- which is what lets the plan phase
+    /// go. None of them is about which COLUMNS the projection wants, and under
+    /// RLOG v4 those are independent questions: reading every block no longer
+    /// means needing every byte. So the read shape is chosen per segment at open
+    /// time by [`PartitionCtx::open_by_column_chunk`], and a narrow projection
+    /// takes the probe-and-range path from inside this fast path rather than
+    /// falling out of it. Rejecting here instead would be strictly worse: the
+    /// plan-then-stripe path it falls to adds a whole plan pass per segment, so
+    /// a narrow statement would pay MORE requests to move fewer bytes.
     fn whole_segment_fast_path(&self, query: &LogQuery) -> Result<usize, FastPathRejection> {
         // Checked ahead of `is_block_predicate_free` (which folds erasure in)
         // only so the recorded reason names erasure rather than the generic
@@ -1730,6 +1890,7 @@ impl ExecutionPlan for LogsScanExec {
             tenant_hash: self.tenant_hash,
             query,
             columns: self.columns.clone(),
+            projected_fraction: self.projected_fraction,
             accounting: self.accounting.clone(),
         });
 
@@ -2039,7 +2200,36 @@ struct PartitionCtx {
     tenant_hash: TenantHash,
     query: LogQuery,
     columns: ColumnSelection,
+    /// [`LogsScanExec::projected_fraction`], carried so the whole-segment fast
+    /// path can route each segment as it opens it (issue #862).
+    projected_fraction: f64,
     accounting: QueryAccounting,
+}
+
+impl PartitionCtx {
+    /// Whether the whole-segment fast path should open `seg` by column chunk
+    /// rather than with one whole-object GET (issue #862).
+    ///
+    /// The fast path's own conjuncts ([`LogsScanExec::whole_segment_fast_path`])
+    /// prove every block of `seg` survives, which is why the whole-object read
+    /// was unconditionally optimal under RLOG v3: reading every block meant
+    /// needing every byte. Under v4 it does not. Every block surviving says
+    /// nothing about how many COLUMNS the projection wants, and the ranged entry
+    /// point ([`open_segment_ranged`]) already fetches one coalesced range per
+    /// surviving `(row group, projected column)` from the very same
+    /// [`ColumnSelection`] (ADR-0699 decision 5), so a narrow projection can
+    /// leave most of the object unread.
+    ///
+    /// The arbiter is the fetch layer's request-cost model, not a threshold
+    /// invented here: the ranged path pays only when the bytes the projection
+    /// skips outweigh the round trips the protocol adds. That keeps a wide
+    /// projection (`SELECT *`, or any reference to the merged `attrs` map) on
+    /// the unchanged whole-object read, where it belongs -- the ranged path
+    /// would fetch the same bytes and pay a probe on top.
+    fn open_by_column_chunk(&self, seg: &SegmentRef) -> bool {
+        self.fetcher
+            .ranged_projection_pays(seg.object_size, self.projected_fraction)
+    }
 }
 
 type OpenFuture = Pin<Box<dyn Future<Output = DFResult<Option<LogSegmentScan>>> + Send>>;
@@ -2077,7 +2267,9 @@ fn open_segment_subset(
 /// column-projected scan over all of its blocks (#693 part 3, deliverable 1).
 /// Used only on the predicate-free full-window whole-segment path, where the
 /// segment is assigned to exactly one partition and every block survives, so a
-/// whole-object read is optimal and no plan phase or suffix probe is needed.
+/// whole-object read is optimal for a projection wide enough to want most of
+/// the object's bytes ([`PartitionCtx::open_by_column_chunk`]) and no plan phase
+/// or suffix probe is needed.
 fn open_segment_whole(ctx: Arc<PartitionCtx>, seg: SegmentRef) -> OpenFuture {
     Box::pin(async move {
         let scan = ctx
@@ -2093,6 +2285,45 @@ fn open_segment_whole(ctx: Arc<PartitionCtx>, seg: SegmentRef) -> OpenFuture {
             .map_err(SqlError::from)?;
         Ok(scan)
     })
+}
+
+/// The whole-segment fast path's other entry point (issue #862): open the same
+/// whole segment through the probe-and-range protocol, which brings one
+/// coalesced range per surviving `(row group, projected column)` instead of
+/// every byte of the object.
+///
+/// Taken when [`PartitionCtx::open_by_column_chunk`] judges the skipped bytes
+/// worth the extra round trips. It passes the SAME [`ColumnSelection`] the
+/// decode uses, which is what ADR-0699 decision 5 requires of a version-4 fetch,
+/// and no block-index subset: the fast path's conjuncts already proved every
+/// block of this segment survives, so the ranged read's candidate set is the
+/// whole segment and the rows it yields are the rows
+/// [`open_segment_whole`] would have yielded.
+fn open_segment_ranged(ctx: Arc<PartitionCtx>, seg: SegmentRef) -> OpenFuture {
+    Box::pin(async move {
+        let scan = ctx
+            .fetcher
+            .scan_accounted_with_tenant(
+                &seg,
+                ctx.tenant_hash,
+                &ctx.query,
+                &ctx.columns,
+                &ctx.accounting,
+            )
+            .await
+            .map_err(SqlError::from)?;
+        Ok(scan)
+    })
+}
+
+/// One segment's open on the whole-segment fast path, routed by
+/// [`PartitionCtx::open_by_column_chunk`].
+fn open_segment_fast(ctx: Arc<PartitionCtx>, seg: SegmentRef, by_column_chunk: bool) -> OpenFuture {
+    if by_column_chunk {
+        open_segment_ranged(ctx, seg)
+    } else {
+        open_segment_whole(ctx, seg)
+    }
 }
 
 enum LogScanState {
@@ -2247,10 +2478,11 @@ struct LogScanStream {
     stripe_blocks: bool,
     /// The predicate-free full-window whole-segment fast path (#693 part 3,
     /// deliverable 1). When set, `work` was filled by [`owned_whole_segments`]
-    /// with no plan phase, each segment is opened with one whole-object GET
-    /// ([`open_segment_whole`]), and the segment's whole-segment prune totals are
-    /// recorded per segment at exhaustion (each segment has one owner, so no
-    /// double count) instead of by partition 0 during planning.
+    /// with no plan phase, each segment is opened through [`open_segment_fast`]
+    /// (one whole-object GET, or the ranged path when the projection is narrow
+    /// enough to pay for it -- #862), and the segment's whole-segment prune
+    /// totals are recorded per segment at exhaustion (each segment has one owner,
+    /// so no double count) instead of by partition 0 during planning.
     fast_whole_segment: bool,
     /// Every segment in the snapshot, snapshot order, shared with the exec. The
     /// owned-work computation indexes this by segment position.
@@ -2524,10 +2756,18 @@ impl Stream for LogScanStream {
                         this.seg_columnar_blocks = 0;
                         this.block_cursor = 0;
                         // Whole-segment fast path reads the object in one GET
-                        // (#693 part 3); the striped path opens only this
-                        // partition's subset, reusing the plan footer if any.
+                        // (#693 part 3), or by column chunk when the projection
+                        // is narrow enough to pay for the extra round trips
+                        // (#862); the striped path opens only this partition's
+                        // subset, reusing the plan footer if any.
                         this.state = if this.fast_whole_segment {
-                            LogScanState::Opening(open_segment_whole(Arc::clone(&this.ctx), seg))
+                            let by_chunk = this.ctx.open_by_column_chunk(&seg);
+                            this.blocks.record_fast_path_route(by_chunk);
+                            LogScanState::Opening(open_segment_fast(
+                                Arc::clone(&this.ctx),
+                                seg,
+                                by_chunk,
+                            ))
                         } else {
                             LogScanState::Opening(open_segment_subset(
                                 Arc::clone(&this.ctx),
@@ -2688,8 +2928,13 @@ impl Stream for LogScanStream {
                                     ));
                                 }
                             };
+                            // Re-opened through the same routing decision the
+                            // first open took (#862), and deliberately not
+                            // re-counted: the route metric counts segments, not
+                            // opens.
                             let fut = if this.fast_whole_segment {
-                                open_segment_whole(Arc::clone(&this.ctx), seg)
+                                let by_chunk = this.ctx.open_by_column_chunk(&seg);
+                                open_segment_fast(Arc::clone(&this.ctx), seg, by_chunk)
                             } else {
                                 open_segment_subset(
                                     Arc::clone(&this.ctx),
@@ -3698,5 +3943,112 @@ mod columnar_lookup_tests {
             assert!(ints.is_valid(i), "row {i} is non-null");
             assert_eq!(ints.value(i), want, "row {i}");
         }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod projection_width_tests {
+    //! [`ResolvedColumns::width`] and the fraction it feeds the whole-segment
+    //! fast path's routing decision (issue #862).
+    //!
+    //! The width counts DISTINCT OBJECT COLUMNS, which is not the length of the
+    //! projection: `ts` and `stream_ref` are always decoded and never named, a
+    //! declared column and an erasure matcher on the same key are one column,
+    //! and the merged `attrs` map is every dynamic column at once.
+
+    use super::*;
+
+    /// Ten declared columns, so the object's column population is
+    /// `FIXED_OBJECT_COLUMNS + 10 = 20`, the denominator every case below uses.
+    fn declared() -> Vec<DeclaredColumn> {
+        (0..10)
+            .map(|k| DeclaredColumn::new(format!("d{k:02}"), DeclaredType::Str))
+            .collect()
+    }
+
+    fn resolve(projection: &[usize]) -> ResolvedColumns {
+        resolve_columns(projection, &[], &[], &declared())
+    }
+
+    /// `ts` plus one declared column: three object columns, the q07 shape.
+    #[test]
+    fn a_single_declared_column_is_three_object_columns() {
+        let r = resolve(&[LOG_COL_TS, FIRST_DECLARED_COL]);
+        assert_eq!(r.width, Some(3));
+        assert_eq!(r.fraction_of(10), 3.0 / 20.0);
+        assert!(!r.selection.is_all());
+        assert!(!r.selection.wants_all_attrs());
+    }
+
+    /// Naming `ts` alone adds nothing: it is decoded either way.
+    #[test]
+    fn ts_alone_is_the_two_implicit_columns() {
+        let r = resolve(&[LOG_COL_TS]);
+        assert_eq!(r.width, Some(IMPLICIT_OBJECT_COLUMNS));
+        assert_eq!(r.fraction_of(10), 2.0 / 20.0);
+    }
+
+    /// The merged `attrs` map means every dynamic column plus the overflow, so
+    /// the width is unknown-and-wide and the fraction saturates. This is the
+    /// `SELECT *` case, which must keep the whole-object read.
+    #[test]
+    fn the_attrs_map_widens_to_every_column() {
+        let r = resolve(&[LOG_COL_TS, LOG_COL_BODY, LOG_COL_ATTRS]);
+        assert_eq!(r.width, None);
+        assert_eq!(r.fraction_of(10), 1.0);
+        assert!(r.selection.wants_all_attrs());
+    }
+
+    /// Every fixed column and every declared column, but not `attrs`: nineteen
+    /// of twenty, which is wide by arithmetic rather than by the `attrs`
+    /// shortcut.
+    #[test]
+    fn every_column_but_attrs_is_nineteen_of_twenty() {
+        let mut projection: Vec<usize> = (0..LOG_COL_ATTRS).collect();
+        projection.extend((0..10).map(|k| FIRST_DECLARED_COL + k));
+        let r = resolve(&projection);
+        assert_eq!(r.width, Some(19));
+        assert_eq!(r.fraction_of(10), 19.0 / 20.0);
+    }
+
+    /// A repeated key counts once, whichever contributor names it: the declared
+    /// projection and an erasure matcher on the same attribute resolve to the
+    /// same object column.
+    #[test]
+    fn a_key_named_twice_counts_once() {
+        let erasure = vec![ErasurePredicate::windowless(vec![(
+            "d00".to_string(),
+            "v".to_string(),
+        )])];
+        let r = resolve_columns(
+            &[LOG_COL_TS, FIRST_DECLARED_COL],
+            &[],
+            &erasure,
+            &declared(),
+        );
+        assert_eq!(r.width, Some(3));
+    }
+
+    /// A content predicate contributes its column to both the selection and the
+    /// width, so a residual filter's column is never counted as free.
+    #[test]
+    fn a_content_predicate_widens_the_count() {
+        let content = vec![Predicate::HasWord {
+            field: FieldSel::Body,
+            word: "x".to_string(),
+        }];
+        let r = resolve_columns(&[LOG_COL_TS], &content, &[], &declared());
+        assert_eq!(r.width, Some(3), "ts, stream_ref, body");
+    }
+
+    /// A tenant with no declared columns has a ten-column object population, so
+    /// the same two-column selection is a larger share of it. The denominator is
+    /// the tenant's, not a constant.
+    #[test]
+    fn the_denominator_follows_the_declared_set() {
+        let r = resolve_columns(&[LOG_COL_TS], &[], &[], &[]);
+        assert_eq!(r.width, Some(2));
+        assert_eq!(r.fraction_of(0), 2.0 / 10.0);
     }
 }

--- a/crates/ravel-sql/src/logs_scan.rs
+++ b/crates/ravel-sql/src/logs_scan.rs
@@ -2226,9 +2226,24 @@ impl PartitionCtx {
     /// projection (`SELECT *`, or any reference to the merged `attrs` map) on
     /// the unchanged whole-object read, where it belongs -- the ranged path
     /// would fetch the same bytes and pay a probe on top.
+    ///
+    /// The route is available only on an RLOG v4 object. The column-chunk fetch
+    /// is a v4 capability (ADR-0699 decision 5): only a v4 object stores pages
+    /// column-major with a PAGE_DIR, so only there does the `ColumnSelection`
+    /// select which chunks are FETCHED. On a v3 object `fetch_object_with_footer`
+    /// ignores the selection for fetch purposes and reads whole blocks
+    /// (`log_fetcher::LogSegmentFetcher::fetch_object_with_footer` docs), so
+    /// routing an above-threshold v3 segment ranged would pay a SKIP_IDX probe,
+    /// find every block surviving, and then issue the same whole-object GET
+    /// anyway -- more requests, identical bytes. The N/N-1 reader window keeps
+    /// v3 objects legitimately readable (ADR-0066 decision 1), so the version
+    /// must be consulted, not assumed. `SegmentRef::segment_format_version`
+    /// carries it from the snapshot without a per-segment lookup at open time.
     fn open_by_column_chunk(&self, seg: &SegmentRef) -> bool {
-        self.fetcher
-            .ranged_projection_pays(seg.object_size, self.projected_fraction)
+        seg.segment_format_version >= u32::from(ravel_logseg::footer::VERSION)
+            && self
+                .fetcher
+                .ranged_projection_pays(seg.object_size, self.projected_fraction)
     }
 }
 

--- a/crates/ravel-sql/src/spans_scan.rs
+++ b/crates/ravel-sql/src/spans_scan.rs
@@ -1373,6 +1373,7 @@ mod tests {
             writer_seq: 1,
             created_unix_ns: 0,
             level: SegmentLevel::L0,
+            segment_format_version: u32::from(ravel_rspan::footer::VERSION),
         };
 
         let store: Arc<dyn ObjectStoreBackend> = Arc::new(store);
@@ -1602,6 +1603,7 @@ mod tests {
             writer_seq: 1,
             created_unix_ns: 0,
             level: SegmentLevel::L0,
+            segment_format_version: u32::from(ravel_rspan::footer::VERSION),
         };
 
         let store: Arc<dyn ObjectStoreBackend> = Arc::new(store);

--- a/crates/ravel-sql/tests/alerts_provider.rs
+++ b/crates/ravel-sql/tests/alerts_provider.rs
@@ -152,6 +152,7 @@ async fn write_object(store: &MemoryStore, key: &str, records: &[LogRecord]) -> 
         writer_seq: 1,
         created_unix_ns: 0,
         level: SegmentLevel::L0,
+        segment_format_version: u32::from(ravel_logseg::footer::VERSION),
     }
 }
 
@@ -494,6 +495,7 @@ async fn real_ravel_alerting_record_decodes_identically() {
         writer_seq: 1,
         created_unix_ns: 0,
         level: SegmentLevel::L0,
+        segment_format_version: u32::from(ravel_logseg::footer::VERSION),
     };
 
     let provider = provider(store, vec![seg]);

--- a/crates/ravel-sql/tests/audit_provider.rs
+++ b/crates/ravel-sql/tests/audit_provider.rs
@@ -121,6 +121,7 @@ async fn write_object(store: &MemoryStore, key: &str, records: &[LogRecord]) -> 
         writer_seq: 1,
         created_unix_ns: 0,
         level: SegmentLevel::L0,
+        segment_format_version: u32::from(ravel_logseg::footer::VERSION),
     }
 }
 

--- a/crates/ravel-sql/tests/flight_distributed.rs
+++ b/crates/ravel-sql/tests/flight_distributed.rs
@@ -202,6 +202,7 @@ async fn write_segment(
         writer_seq,
         created_unix_ns,
         level: SegmentLevel::L0,
+        segment_format_version: u32::from(ravel_segment::SUPPORTED_VERSIONS.newest()),
     }
 }
 
@@ -1468,6 +1469,7 @@ async fn write_rlog_segment(
         writer_seq,
         created_unix_ns,
         level: SegmentLevel::L0,
+        segment_format_version: u32::from(ravel_logseg::footer::VERSION),
     }
 }
 
@@ -2163,6 +2165,7 @@ async fn write_rspan_segment(
         writer_seq,
         created_unix_ns,
         level: SegmentLevel::L0,
+        segment_format_version: u32::from(ravel_rspan::footer::VERSION),
     }
 }
 

--- a/crates/ravel-sql/tests/logs_columnar.rs
+++ b/crates/ravel-sql/tests/logs_columnar.rs
@@ -337,6 +337,7 @@ async fn put_object(
         writer_seq: 1,
         created_unix_ns: 0,
         level: SegmentLevel::L0,
+        segment_format_version: u32::from(ravel_logseg::footer::VERSION),
     }
 }
 

--- a/crates/ravel-sql/tests/logs_count_from_stats.rs
+++ b/crates/ravel-sql/tests/logs_count_from_stats.rs
@@ -131,6 +131,7 @@ async fn write_object(
         writer_seq: 1,
         created_unix_ns: 0,
         level: SegmentLevel::L0,
+        segment_format_version: u32::from(ravel_logseg::footer::VERSION),
     }
 }
 

--- a/crates/ravel-sql/tests/logs_differential.rs
+++ b/crates/ravel-sql/tests/logs_differential.rs
@@ -393,6 +393,7 @@ async fn write_object(
         writer_seq: seq,
         created_unix_ns: 0,
         level: SegmentLevel::L0,
+        segment_format_version: u32::from(ravel_logseg::footer::VERSION),
     }
 }
 

--- a/crates/ravel-sql/tests/logs_fast_path_projection_routing.rs
+++ b/crates/ravel-sql/tests/logs_fast_path_projection_routing.rs
@@ -1,0 +1,616 @@
+//! Regression fixture for issue #862: the predicate-free full-window
+//! whole-segment fast path must route on PROJECTION WIDTH, not only on which
+//! blocks survive.
+//!
+//! The mechanism (`ravel_sql::logs_scan`, `ravel_query::log_fetcher`):
+//!
+//! - `LogsScanExec::whole_segment_fast_path` proves, with zero I/O, that every
+//!   block of every relevant segment survives, so the plan phase can go and each
+//!   segment can be assigned whole to one partition. Every conjunct it tests is
+//!   about BLOCKS; none is about COLUMNS.
+//! - Before #862 that assignment implied the read: each segment went to
+//!   `LogSegmentFetcher::scan_whole_accounted_with_tenant`, one whole-object GET,
+//!   however narrow the projection. That was right under RLOG v3, where reading
+//!   every block meant needing every byte. Under v4 a block's pages sit one per
+//!   column chunk inside its row group, and the ranged entry already fetches one
+//!   coalesced range per surviving `(row group, projected column)` from the same
+//!   `ColumnSelection` (ADR-0699 decision 5), so reading every block no longer
+//!   means reading every byte.
+//! - After #862 the read shape is a per-segment decision at open time
+//!   (`PartitionCtx::open_by_column_chunk`), arbitrated by
+//!   `LogSegmentFetcher::ranged_projection_pays`: the ranged path is taken only
+//!   when the bytes the projection skips outweigh the round trips the protocol
+//!   adds, measured against the fetch layer's own request-cost break-even.
+//!
+//! The acceptance criterion is NOT fewer bytes. On this store a request is the
+//! expensive unit, so each test below pins BOTH the exact request count and the
+//! exact bytes for its shape, and the wide shapes are pinned as tightly as the
+//! narrow one: a routing change that only ever moves one way is a change that
+//! cannot be caught over-applying.
+//!
+//! Two fetcher settings this fixture pins deliberately, for the reasons
+//! `logs_selective_scan_amplification.rs` states at greater length:
+//!
+//! - `SUFFIX_LEN` is sized to the object tail. At the production 256 KiB default
+//!   one probe would swallow this fixture's whole object and there would be no
+//!   byte figure left to read.
+//! - `with_coalesce_gap(0)`. Under version 4 the hole between two wanted pages
+//!   of one column is the other blocks' pages of that column, so a nonzero gap
+//!   fuses the whole BLOCKS section into one range and puts the narrow shape
+//!   back at full-object bytes.
+//!
+//! The block-range threshold is NOT pinned to zero here, unlike most fixtures in
+//! this crate. Zero would make the arbiter degenerate (every saving beats a
+//! break-even of nothing), and then the wide shapes would pass for the wrong
+//! reason. `THRESHOLD_DIVISOR` sets it to half an object instead, so the cost
+//! model has to actually decide.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::collections::BTreeSet;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use async_trait::async_trait;
+use datafusion::arrow::array::{Array, StringArray, TimestampNanosecondArray};
+use datafusion::arrow::compute::cast;
+use datafusion::arrow::datatypes::DataType;
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::catalog::TableProvider;
+use datafusion::execution::TaskContext;
+use datafusion::physical_plan::{ExecutionPlan, collect};
+use datafusion::prelude::{SessionConfig, SessionContext};
+use ravel_cache::{Cache, CacheLimits};
+use ravel_catalog::{SegmentLevel, SegmentRef, Snapshot};
+use ravel_logseg::writer::ObjectIdentity;
+use ravel_logseg::{AttrValue, LogRecord, RlogConfig, RlogWriter, stream_attrs_bytes};
+use ravel_object_store::memory::MemoryStore;
+use ravel_object_store::{
+    Capabilities, DelimitedList, GetOutcome, GetRange, ListPage, ObjectMeta, ObjectStoreBackend,
+    PageToken, PutOptions, PutOutcome, StoreError,
+};
+use ravel_query::{BlockRangeFetcher, CacheFetchError, LogSegmentFetcher};
+use ravel_sql::{
+    DeclaredColumn, DeclaredType, FIRST_DECLARED_COL, LOG_COL_ATTRS, LOG_COL_TS, LogsTableProvider,
+};
+use ravel_types::TenantHash;
+use ravel_types::accounting::QueryAccounting;
+use uuid::Uuid;
+
+const TENANT: [u8; 16] = [7u8; 16];
+
+/// Segments in the fixture, and the partitions requested. Equal so a
+/// predicate-free full-window statement clears the fast path's
+/// `relevant_segments >= target_partitions` conjunct.
+const SEGMENTS: usize = 4;
+const PARTS: usize = 4;
+/// Blocks per segment (one record per block).
+const BLOCKS_PER_SEG: usize = 6;
+
+/// Declared typed attribute columns the tenant carries, `d00`..`d09`. Ten of
+/// them so a single-column projection is genuinely narrow (three object columns
+/// out of twenty: `ts` and `stream_ref` are always decoded), the ClickBench q07
+/// shape at fixture scale.
+const DECLARED_COLUMNS: usize = 10;
+
+/// Filler bytes in each declared column's value, per record. This is where the
+/// object's bytes are: a narrow projection that reads one declared column skips
+/// the other nine, which is the saving the routing decision exists to capture.
+const DECLARED_BYTES: usize = 2048;
+
+/// Suffix probe length for the ranged path, sized to this fixture's object tail
+/// rather than to production objects. See the header.
+const SUFFIX_LEN: u64 = 8192;
+
+/// The block-range threshold, as a divisor of the smallest object in the
+/// fixture: an object is above the threshold (so it can be ranged at all), and
+/// the ranged path must save more than half an object before the cost model
+/// judges it worth the extra round trips. A projection reading nine tenths of
+/// the columns therefore stays on the whole-object read, and one reading three
+/// twentieths does not.
+const THRESHOLD_DIVISOR: u64 = 2;
+
+fn identity(seq: u64) -> ObjectIdentity {
+    ObjectIdentity {
+        tenant_hash: TENANT,
+        shard: 0,
+        writer_id: [2u8; 16],
+        writer_epoch: 1,
+        writer_seq: seq,
+    }
+}
+
+fn one_record_blocks() -> RlogConfig {
+    RlogConfig {
+        block_target_records: 1,
+        ..RlogConfig::default()
+    }
+}
+
+/// Pseudo-random printable filler so the writer's compression cannot shrink the
+/// object back under the threshold this fixture sets (the same generator
+/// `logs_selective_scan_amplification.rs` uses).
+fn filler(seed: u64, len: usize) -> String {
+    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+    let mut state = seed;
+    let mut out = String::with_capacity(len);
+    for _ in 0..len {
+        state = state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = state;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^= z >> 31;
+        out.push(ALPHABET[(z & 63) as usize] as char);
+    }
+    out
+}
+
+fn declared_key(k: usize) -> String {
+    format!("d{k:02}")
+}
+
+fn declared_columns() -> Vec<DeclaredColumn> {
+    (0..DECLARED_COLUMNS)
+        .map(|k| DeclaredColumn::new(declared_key(k), DeclaredType::Str))
+        .collect()
+}
+
+fn record(seg: usize, blk: usize) -> LogRecord {
+    let resource = vec![(
+        "service.name".to_string(),
+        AttrValue::Str("svc".to_string()),
+    )];
+    let ts = (seg * 1_000_000 + blk) as i64;
+    let attrs = (0..DECLARED_COLUMNS)
+        .map(|k| {
+            let seed = (seg as u64) << 40 | (blk as u64) << 20 | k as u64;
+            (
+                declared_key(k),
+                AttrValue::Str(filler(seed, DECLARED_BYTES)),
+            )
+        })
+        .collect();
+    LogRecord {
+        stream_id: ravel_types::logstream::log_stream_id(&resource, "scope", "1.0", &[]),
+        stream_attrs: stream_attrs_bytes(&resource, "scope", "1.0", &[]),
+        ts_ns: ts,
+        observed_ts_ns: ts,
+        severity_num: 9,
+        severity_text: "INFO".into(),
+        body: format!("s{seg}-b{blk}"),
+        trace_id: None,
+        span_id: None,
+        flags: 0,
+        attrs,
+    }
+}
+
+async fn write_segment(store: &dyn ObjectStoreBackend, seg: usize) -> SegmentRef {
+    let recs: Vec<LogRecord> = (0..BLOCKS_PER_SEG).map(|b| record(seg, b)).collect();
+    let mut w = RlogWriter::new(one_record_blocks(), identity((seg + 1) as u64));
+    for r in &recs {
+        w.push(r.clone()).expect("push");
+    }
+    let bytes = w.finish().expect("finish");
+    let size = bytes.len() as u64;
+    let key = format!("logs/seg{seg}.rlog");
+    let content_hash = *blake3::hash(&bytes).as_bytes();
+    store
+        .put(&key, bytes::Bytes::from(bytes), PutOptions::default())
+        .await
+        .expect("put");
+    let min = recs.iter().map(|r| r.ts_ns).min().unwrap();
+    let max = recs.iter().map(|r| r.ts_ns).max().unwrap();
+    SegmentRef {
+        data_object_key: key,
+        object_size: size,
+        min_event_ts_ns: min,
+        max_event_ts_ns: max,
+        ingest_hour_bucket: 0,
+        sample_count: recs.len() as u64,
+        series_count: 0,
+        shard: 0,
+        content_hash,
+        writer_id: Uuid::from_u128(1),
+        writer_epoch: 1,
+        writer_seq: (seg + 1) as u64,
+        created_unix_ns: 0,
+        level: SegmentLevel::L0,
+    }
+}
+
+async fn build_snapshot(store: &dyn ObjectStoreBackend) -> Snapshot {
+    let mut segments = Vec::with_capacity(SEGMENTS);
+    for s in 0..SEGMENTS {
+        segments.push(write_segment(store, s).await);
+    }
+    Snapshot {
+        segments,
+        segments_pruned: 0,
+        pending_erasure: Vec::new(),
+    }
+}
+
+/// Total stored bytes of the fixture: what a whole-object read of every segment
+/// moves, and the figure every narrow-shape byte assertion is measured against.
+fn snapshot_bytes(snapshot: &Snapshot) -> u64 {
+    snapshot.segments.iter().map(|s| s.object_size).sum()
+}
+
+fn smallest_object(snapshot: &Snapshot) -> u64 {
+    snapshot
+        .segments
+        .iter()
+        .map(|s| s.object_size)
+        .min()
+        .expect("a non-empty fixture")
+}
+
+// ---- byte- and shape-counting store --------------------------------------
+
+/// Counts store `get` calls by `GetRange` shape and sums the bytes each
+/// returned, so a test reads the exact wire cost of a shape.
+struct CountingStore {
+    inner: Arc<MemoryStore>,
+    full: AtomicU64,
+    suffix: AtomicU64,
+    range: AtomicU64,
+    bytes: AtomicU64,
+}
+
+impl CountingStore {
+    fn new(inner: Arc<MemoryStore>) -> Arc<Self> {
+        Arc::new(CountingStore {
+            inner,
+            full: AtomicU64::new(0),
+            suffix: AtomicU64::new(0),
+            range: AtomicU64::new(0),
+            bytes: AtomicU64::new(0),
+        })
+    }
+}
+
+#[async_trait]
+impl ObjectStoreBackend for CountingStore {
+    async fn put(
+        &self,
+        key: &str,
+        data: bytes::Bytes,
+        opts: PutOptions,
+    ) -> Result<PutOutcome, StoreError> {
+        self.inner.put(key, data, opts).await
+    }
+    async fn get(&self, key: &str, range: GetRange) -> Result<GetOutcome, StoreError> {
+        match range {
+            GetRange::Full => self.full.fetch_add(1, Ordering::SeqCst),
+            GetRange::Suffix(_) => self.suffix.fetch_add(1, Ordering::SeqCst),
+            GetRange::Range(_, _) => self.range.fetch_add(1, Ordering::SeqCst),
+        };
+        let got = self.inner.get(key, range).await?;
+        self.bytes
+            .fetch_add(got.data.len() as u64, Ordering::SeqCst);
+        Ok(got)
+    }
+    async fn head(&self, key: &str) -> Result<ObjectMeta, StoreError> {
+        self.inner.head(key).await
+    }
+    async fn list(&self, prefix: &str, page: Option<PageToken>) -> Result<ListPage, StoreError> {
+        self.inner.list(prefix, page).await
+    }
+    async fn list_delimited(&self, prefix: &str) -> Result<DelimitedList, StoreError> {
+        self.inner.list_delimited(prefix).await
+    }
+    async fn delete(&self, key: &str) -> Result<(), StoreError> {
+        self.inner.delete(key).await
+    }
+    fn capabilities(&self) -> Capabilities {
+        Capabilities {
+            multipart: false,
+            ..self.inner.capabilities()
+        }
+    }
+}
+
+fn read_cache() -> Arc<Cache<CacheFetchError>> {
+    let bytes = 64 << 20;
+    Arc::new(Cache::new(CacheLimits::new(
+        bytes,
+        (bytes / 4096) as usize,
+        bytes,
+    )))
+}
+
+/// The fixture's fetcher, with the block-range threshold set to `threshold`.
+/// Both the funnel's routing threshold and the block-range fetcher's own
+/// size crossover take that value (`with_block_range_threshold` sets the pair),
+/// which is also the break-even the projection has to beat.
+fn fetcher(store: Arc<dyn ObjectStoreBackend>, threshold: u64) -> LogSegmentFetcher {
+    let block_range = BlockRangeFetcher::new(Arc::clone(&store))
+        .with_suffix_len(SUFFIX_LEN)
+        .with_coalesce_gap(0);
+    LogSegmentFetcher::new(store)
+        .with_block_range(block_range)
+        .with_cache(read_cache())
+        .with_block_range_threshold(threshold)
+}
+
+fn provider(snapshot: Snapshot, fetcher: LogSegmentFetcher) -> LogsTableProvider {
+    LogsTableProvider::new(
+        snapshot,
+        TenantHash(TENANT),
+        fetcher,
+        QueryAccounting::new(),
+    )
+    .with_declared_columns(declared_columns())
+}
+
+fn find_scan(plan: &Arc<dyn ExecutionPlan>) -> Arc<dyn ExecutionPlan> {
+    fn walk(plan: &Arc<dyn ExecutionPlan>) -> Option<Arc<dyn ExecutionPlan>> {
+        if plan.name() == "LogsScanExec" {
+            return Some(Arc::clone(plan));
+        }
+        plan.children().iter().find_map(|c| walk(c))
+    }
+    walk(plan).expect("a LogsScanExec leaf")
+}
+
+fn sum_metric(plan: &Arc<dyn ExecutionPlan>, name: &str) -> usize {
+    let set = find_scan(plan).metrics().expect("metrics");
+    set.iter()
+        .filter(|m| m.value().name() == name)
+        .map(|m| m.value().as_usize())
+        .sum()
+}
+
+/// Projection over the resolved full schema: `ts` plus the FIRST declared
+/// column. Three object columns of twenty (`ts` and `stream_ref` come free), the
+/// q07 shape.
+fn narrow_projection() -> Vec<usize> {
+    vec![LOG_COL_TS, FIRST_DECLARED_COL]
+}
+
+/// Every fixed column and every declared column, but NOT the merged `attrs`
+/// map: nineteen object columns of twenty. Wide without being `SELECT *`, so
+/// the wide case is pinned by the cost model's arithmetic rather than by the
+/// `attrs`-means-everything shortcut.
+fn wide_projection() -> Vec<usize> {
+    let mut proj: Vec<usize> = (0..LOG_COL_ATTRS).collect();
+    proj.extend((0..DECLARED_COLUMNS).map(|k| FIRST_DECLARED_COL + k));
+    proj
+}
+
+/// What one executed shape cost and returned.
+struct Shape {
+    full_gets: u64,
+    suffix_gets: u64,
+    range_gets: u64,
+    bytes: u64,
+    rows: usize,
+    ranged_segments: usize,
+    whole_object_segments: usize,
+    /// Every `(ts, d00)` pair the shape emitted, for the cross-path row
+    /// comparison. Only populated for projections carrying both.
+    pairs: BTreeSet<(i64, String)>,
+}
+
+/// Plan and run one projection against a fresh fixture at `threshold`, and
+/// report its exact wire cost.
+async fn measure(projection: Option<Vec<usize>>, threshold_divisor: Option<u64>) -> Shape {
+    let base = Arc::new(MemoryStore::new());
+    let snapshot = build_snapshot(base.as_ref()).await;
+    let threshold = match threshold_divisor {
+        Some(d) => smallest_object(&snapshot) / d,
+        // No divisor: a break-even larger than any object in the fixture, so
+        // nothing can beat it and every segment keeps the whole-object read.
+        None => snapshot_bytes(&snapshot),
+    };
+    let counting = CountingStore::new(base);
+    let store: Arc<dyn ObjectStoreBackend> = Arc::clone(&counting) as Arc<dyn ObjectStoreBackend>;
+    let prov = Arc::new(provider(snapshot, fetcher(store, threshold)));
+
+    let ctx = SessionContext::new_with_config(SessionConfig::new().with_target_partitions(PARTS));
+    let plan = TableProvider::scan(prov.as_ref(), &ctx.state(), projection.as_ref(), &[], None)
+        .await
+        .expect("scan");
+    let batches = collect(Arc::clone(&plan), Arc::new(TaskContext::default()))
+        .await
+        .expect("collect");
+
+    Shape {
+        full_gets: counting.full.load(Ordering::SeqCst),
+        suffix_gets: counting.suffix.load(Ordering::SeqCst),
+        range_gets: counting.range.load(Ordering::SeqCst),
+        bytes: counting.bytes.load(Ordering::SeqCst),
+        rows: batches.iter().map(RecordBatch::num_rows).sum(),
+        ranged_segments: sum_metric(&plan, "fast_path_ranged_segments"),
+        whole_object_segments: sum_metric(&plan, "fast_path_whole_object_segments"),
+        pairs: ts_and_first_declared(&batches),
+    }
+}
+
+/// The `(ts, d00)` pairs in a result whose first column is `ts` and whose LAST
+/// column is `d00`, or is `d00` at the first declared index. Both projections
+/// this file compares carry `ts` at output position 0; `d00` is at position 1
+/// for the narrow projection and at `LOG_COL_ATTRS` for the wide one, so it is
+/// located by name.
+fn ts_and_first_declared(batches: &[RecordBatch]) -> BTreeSet<(i64, String)> {
+    let mut out = BTreeSet::new();
+    for batch in batches {
+        let Some(d0) = batch.schema().index_of(&declared_key(0)).ok() else {
+            continue;
+        };
+        let ts = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<TimestampNanosecondArray>()
+            .expect("ts at output position 0");
+        // A declared `Str` column is a `Dictionary(Int32, Utf8)`; flatten it so
+        // the comparison is over values, not over dictionary layout (the two
+        // paths decode the same pages but need not build the same dictionary).
+        let flat = cast(batch.column(d0), &DataType::Utf8).expect("d00 casts to Utf8");
+        let vals = flat
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("cast to Utf8 yields a StringArray");
+        for i in 0..batch.num_rows() {
+            let v = if vals.is_null(i) {
+                String::new()
+            } else {
+                vals.value(i).to_string()
+            };
+            out.insert((ts.value(i), v));
+        }
+    }
+    out
+}
+
+const TOTAL_ROWS: usize = SEGMENTS * BLOCKS_PER_SEG;
+
+/// A narrow projection over fast-path-eligible segments takes the RANGED path:
+/// exact request count, exact bytes.
+///
+/// Before #862 this whole shape was `SEGMENTS` whole-object GETs moving every
+/// stored byte, whatever the projection: `LogsScanExec::execute`'s fast-path arm
+/// called `open_segment_whole` unconditionally. Flipping that one call site back
+/// (`open_segment_fast(.., by_chunk)` -> `open_segment_whole(..)`) fails this
+/// test on all four counters below.
+#[tokio::test]
+async fn narrow_projection_reads_column_chunks_not_whole_objects() {
+    let base = Arc::new(MemoryStore::new());
+    let snapshot = build_snapshot(base.as_ref()).await;
+    let stored = snapshot_bytes(&snapshot);
+    drop(snapshot);
+
+    let shape = measure(Some(narrow_projection()), Some(THRESHOLD_DIVISOR)).await;
+
+    // Exact request law: one suffix probe and five byte-range GETs per segment
+    // (front sections, then one coalesced run per projected column chunk), and
+    // NO whole-object GET.
+    assert_eq!(
+        (shape.full_gets, shape.suffix_gets, shape.range_gets),
+        (0, SEGMENTS as u64, 5 * SEGMENTS as u64),
+        "exact request shape per segment: 0 full, 1 suffix probe, 5 ranges"
+    );
+
+    // Exact bytes: the projection reads three object columns of twenty, so the
+    // wire cost is a fraction of the stored bytes rather than all of them.
+    assert_eq!(
+        (shape.bytes, stored),
+        (71_554, 411_444),
+        "exact wire bytes for the narrow shape, against the fixture's stored bytes"
+    );
+
+    // Routing: every segment took the ranged entry, none the whole-object one.
+    assert_eq!(
+        (shape.ranged_segments, shape.whole_object_segments),
+        (SEGMENTS, 0),
+        "a narrow projection routes every fast-path segment by column chunk"
+    );
+
+    assert_eq!(shape.rows, TOTAL_ROWS, "every row is still returned");
+}
+
+/// The same fast-path-eligible segments under a WIDE projection keep the
+/// whole-object GET: exact request count, exact bytes.
+///
+/// This is the direction that catches over-application. Nineteen object columns
+/// of twenty leaves nothing worth ranging for, and the ranged path would pay a
+/// probe and a section GET per segment to fetch the same bytes. Deleting the
+/// `ranged_projection_pays` guard (returning `true` unconditionally from
+/// `LogSegmentFetcher::ranged_projection_pays`) fails this test.
+#[tokio::test]
+async fn wide_projection_keeps_the_whole_object_read() {
+    let base = Arc::new(MemoryStore::new());
+    let snapshot = build_snapshot(base.as_ref()).await;
+    let stored = snapshot_bytes(&snapshot);
+    drop(snapshot);
+
+    let shape = measure(Some(wide_projection()), Some(THRESHOLD_DIVISOR)).await;
+
+    assert_eq!(
+        (shape.full_gets, shape.suffix_gets, shape.range_gets),
+        (SEGMENTS as u64, 0, 0),
+        "exact request shape per segment: one whole-object GET, no probe, no ranges"
+    );
+    assert_eq!(
+        (shape.bytes, stored),
+        (411_444, 411_444),
+        "a whole-object read moves exactly the stored bytes"
+    );
+    assert_eq!(
+        (shape.ranged_segments, shape.whole_object_segments),
+        (0, SEGMENTS),
+        "a wide projection keeps every fast-path segment on the whole-object read"
+    );
+    assert_eq!(shape.rows, TOTAL_ROWS, "every row is still returned");
+}
+
+/// `SELECT *` (the q24 shape) is the widest projection there is and must be
+/// untouched by #862: one whole-object GET per segment, every stored byte.
+#[tokio::test]
+async fn select_star_is_unchanged() {
+    let base = Arc::new(MemoryStore::new());
+    let snapshot = build_snapshot(base.as_ref()).await;
+    let stored = snapshot_bytes(&snapshot);
+    drop(snapshot);
+
+    let shape = measure(None, Some(THRESHOLD_DIVISOR)).await;
+
+    assert_eq!(
+        (shape.full_gets, shape.suffix_gets, shape.range_gets),
+        (SEGMENTS as u64, 0, 0),
+        "SELECT * issues exactly one whole-object GET per segment"
+    );
+    assert_eq!(
+        (shape.bytes, stored),
+        (411_444, 411_444),
+        "SELECT * moves exactly the stored bytes"
+    );
+    assert_eq!(
+        (shape.ranged_segments, shape.whole_object_segments),
+        (0, SEGMENTS),
+        "SELECT * keeps every fast-path segment on the whole-object read"
+    );
+    assert_eq!(shape.rows, TOTAL_ROWS, "every row is still returned");
+}
+
+/// The property that matters most: the two paths return the SAME rows for the
+/// same query. Only the arbiter differs between the two runs -- one fixture, one
+/// projection, one break-even raised past any object in it -- so any difference
+/// in the result is the routing change and nothing else.
+#[tokio::test]
+async fn both_paths_return_identical_rows() {
+    let ranged = measure(Some(narrow_projection()), Some(THRESHOLD_DIVISOR)).await;
+    let whole = measure(Some(narrow_projection()), None).await;
+
+    // The two runs really did take different paths.
+    assert_eq!(
+        (ranged.ranged_segments, ranged.whole_object_segments),
+        (SEGMENTS, 0),
+        "the first run took the ranged path"
+    );
+    assert_eq!(
+        (whole.ranged_segments, whole.whole_object_segments),
+        (0, SEGMENTS),
+        "the second run took the whole-object path"
+    );
+    assert_eq!(
+        (whole.full_gets, whole.suffix_gets, whole.range_gets),
+        (SEGMENTS as u64, 0, 0),
+        "the whole-object run issues one full GET per segment"
+    );
+
+    assert_eq!(
+        ranged.rows, whole.rows,
+        "both paths return the same number of rows"
+    );
+    assert_eq!(
+        ranged.pairs.len(),
+        TOTAL_ROWS,
+        "the compared row set is the whole fixture, not a subset that happens to match"
+    );
+    assert_eq!(
+        ranged.pairs, whole.pairs,
+        "both paths return identical (ts, d00) rows"
+    );
+}

--- a/crates/ravel-sql/tests/logs_fast_path_projection_routing.rs
+++ b/crates/ravel-sql/tests/logs_fast_path_projection_routing.rs
@@ -185,13 +185,37 @@ fn record(seg: usize, blk: usize) -> LogRecord {
     }
 }
 
-async fn write_segment(store: &dyn ObjectStoreBackend, seg: usize) -> SegmentRef {
+/// Which RLOG trailer version the fixture writes. The column-chunk ranged read
+/// is a v4 capability (ADR-0699 decision 5): only a v4 object stores pages
+/// column-major with a PAGE_DIR that turns the `ColumnSelection` into a fetch
+/// selection. A v3 object ignores the selection for fetch and reads whole
+/// blocks, so an above-threshold v3 segment must keep the whole-object read
+/// however narrow the projection (issue #862). Production never writes v3, but
+/// the N/N-1 reader window (ADR-0066 decision 1) keeps stored v3 objects
+/// readable, so a real tenant can hold them.
+#[derive(Clone, Copy)]
+enum RlogVersion {
+    V3,
+    V4,
+}
+
+async fn write_segment(
+    store: &dyn ObjectStoreBackend,
+    seg: usize,
+    version: RlogVersion,
+) -> SegmentRef {
     let recs: Vec<LogRecord> = (0..BLOCKS_PER_SEG).map(|b| record(seg, b)).collect();
     let mut w = RlogWriter::new(one_record_blocks(), identity((seg + 1) as u64));
     for r in &recs {
         w.push(r.clone()).expect("push");
     }
-    let bytes = w.finish().expect("finish");
+    let (bytes, format_version) = match version {
+        RlogVersion::V4 => (w.finish().expect("finish"), ravel_logseg::footer::VERSION),
+        RlogVersion::V3 => (
+            w.finish_v3_for_tests().expect("finish v3"),
+            ravel_logseg::footer::VERSION - 1,
+        ),
+    };
     let size = bytes.len() as u64;
     let key = format!("logs/seg{seg}.rlog");
     let content_hash = *blake3::hash(&bytes).as_bytes();
@@ -216,13 +240,14 @@ async fn write_segment(store: &dyn ObjectStoreBackend, seg: usize) -> SegmentRef
         writer_seq: (seg + 1) as u64,
         created_unix_ns: 0,
         level: SegmentLevel::L0,
+        segment_format_version: u32::from(format_version),
     }
 }
 
-async fn build_snapshot(store: &dyn ObjectStoreBackend) -> Snapshot {
+async fn build_snapshot(store: &dyn ObjectStoreBackend, version: RlogVersion) -> Snapshot {
     let mut segments = Vec::with_capacity(SEGMENTS);
     for s in 0..SEGMENTS {
-        segments.push(write_segment(store, s).await);
+        segments.push(write_segment(store, s, version).await);
     }
     Snapshot {
         segments,
@@ -396,8 +421,19 @@ struct Shape {
 /// Plan and run one projection against a fresh fixture at `threshold`, and
 /// report its exact wire cost.
 async fn measure(projection: Option<Vec<usize>>, threshold_divisor: Option<u64>) -> Shape {
+    measure_versioned(projection, threshold_divisor, RlogVersion::V4).await
+}
+
+/// [`measure`] over a fixture written at an explicit RLOG version, so the
+/// version gate on the ranged route (issue #862) can be exercised on both v3
+/// and v4 objects.
+async fn measure_versioned(
+    projection: Option<Vec<usize>>,
+    threshold_divisor: Option<u64>,
+    version: RlogVersion,
+) -> Shape {
     let base = Arc::new(MemoryStore::new());
-    let snapshot = build_snapshot(base.as_ref()).await;
+    let snapshot = build_snapshot(base.as_ref(), version).await;
     let threshold = match threshold_divisor {
         Some(d) => smallest_object(&snapshot) / d,
         // No divisor: a break-even larger than any object in the fixture, so
@@ -477,7 +513,7 @@ const TOTAL_ROWS: usize = SEGMENTS * BLOCKS_PER_SEG;
 #[tokio::test]
 async fn narrow_projection_reads_column_chunks_not_whole_objects() {
     let base = Arc::new(MemoryStore::new());
-    let snapshot = build_snapshot(base.as_ref()).await;
+    let snapshot = build_snapshot(base.as_ref(), RlogVersion::V4).await;
     let stored = snapshot_bytes(&snapshot);
     drop(snapshot);
 
@@ -521,7 +557,7 @@ async fn narrow_projection_reads_column_chunks_not_whole_objects() {
 #[tokio::test]
 async fn wide_projection_keeps_the_whole_object_read() {
     let base = Arc::new(MemoryStore::new());
-    let snapshot = build_snapshot(base.as_ref()).await;
+    let snapshot = build_snapshot(base.as_ref(), RlogVersion::V4).await;
     let stored = snapshot_bytes(&snapshot);
     drop(snapshot);
 
@@ -550,7 +586,7 @@ async fn wide_projection_keeps_the_whole_object_read() {
 #[tokio::test]
 async fn select_star_is_unchanged() {
     let base = Arc::new(MemoryStore::new());
-    let snapshot = build_snapshot(base.as_ref()).await;
+    let snapshot = build_snapshot(base.as_ref(), RlogVersion::V4).await;
     let stored = snapshot_bytes(&snapshot);
     drop(snapshot);
 
@@ -613,4 +649,64 @@ async fn both_paths_return_identical_rows() {
         ranged.pairs, whole.pairs,
         "both paths return identical (ts, d00) rows"
     );
+}
+
+/// The version gate (issue #862): the SAME narrow projection over the SAME
+/// above-threshold segments, written at RLOG v3 instead of v4, must keep the
+/// whole-object read. The column-chunk ranged read is a v4 capability (ADR-0699
+/// decision 5): on a v3 object `fetch_object_with_footer` ignores the
+/// `ColumnSelection` for fetch and reads whole blocks, so routing ranged would
+/// pay a SKIP_IDX suffix probe, find every block surviving (the fast path's
+/// precondition), and then issue the same whole-object GET anyway -- more
+/// requests, identical bytes.
+///
+/// This is the exact asymmetry the suite is built to catch, run the other way:
+/// `narrow_projection_reads_column_chunks_not_whole_objects` pins the v4 narrow
+/// shape at `(0 full, SEGMENTS suffix, 5*SEGMENTS ranges)`; here the same
+/// projection at v3 must be `(SEGMENTS full, 0 suffix, 0 ranges)`.
+///
+/// Fails on the pre-fix code: without the version gate in
+/// `PartitionCtx::open_by_column_chunk`, `ranged_projection_pays` returns true
+/// for this above-threshold narrow shape and the v3 segments route ranged, so
+/// the suffix-probe counter is `SEGMENTS`, not 0, and `ranged_segments` is
+/// `SEGMENTS`, not 0.
+#[tokio::test]
+async fn narrow_projection_over_v3_segment_keeps_the_whole_object_read() {
+    let base = Arc::new(MemoryStore::new());
+    let snapshot = build_snapshot(base.as_ref(), RlogVersion::V3).await;
+    let stored = snapshot_bytes(&snapshot);
+    drop(snapshot);
+
+    let shape = measure_versioned(
+        Some(narrow_projection()),
+        Some(THRESHOLD_DIVISOR),
+        RlogVersion::V3,
+    )
+    .await;
+
+    // Exact request law: one whole-object GET per segment, no probe, no ranges.
+    // The v3 object cannot fetch by column chunk, so the narrow projection reads
+    // the whole object exactly as a wide one would.
+    assert_eq!(
+        (shape.full_gets, shape.suffix_gets, shape.range_gets),
+        (SEGMENTS as u64, 0, 0),
+        "a v3 segment keeps the whole-object read however narrow the projection"
+    );
+
+    // A whole-object read moves exactly the stored bytes, the same equality the
+    // wide-shape v4 guards assert.
+    assert_eq!(
+        (shape.bytes, stored),
+        (stored, stored),
+        "the v3 narrow read moves every stored byte, not a column-chunk subset"
+    );
+
+    // Routing: every segment took the whole-object entry, none the ranged one.
+    assert_eq!(
+        (shape.ranged_segments, shape.whole_object_segments),
+        (0, SEGMENTS),
+        "a v3 segment is never routed by column chunk, whatever the projection"
+    );
+
+    assert_eq!(shape.rows, TOTAL_ROWS, "every row is still returned");
 }

--- a/crates/ravel-sql/tests/logs_metadata_agg.rs
+++ b/crates/ravel-sql/tests/logs_metadata_agg.rs
@@ -83,6 +83,7 @@ fn seg_ref(seq: u64, sample_count: u64) -> SegmentRef {
         writer_seq: seq,
         created_unix_ns: 0,
         level: SegmentLevel::L0,
+        segment_format_version: u32::from(ravel_logseg::footer::VERSION),
     }
 }
 
@@ -1028,6 +1029,7 @@ async fn write_real_segment(
         writer_seq: seq,
         created_unix_ns: 0,
         level: SegmentLevel::L0,
+        segment_format_version: u32::from(ravel_logseg::footer::VERSION),
     }
 }
 

--- a/crates/ravel-sql/tests/logs_plan_concurrency.rs
+++ b/crates/ravel-sql/tests/logs_plan_concurrency.rs
@@ -102,6 +102,7 @@ async fn write_object(store: &MemoryStore, key: &str, records: &[LogRecord]) -> 
         writer_seq: 1,
         created_unix_ns: 0,
         level: SegmentLevel::L0,
+        segment_format_version: u32::from(ravel_logseg::footer::VERSION),
     }
 }
 

--- a/crates/ravel-sql/tests/logs_provider.rs
+++ b/crates/ravel-sql/tests/logs_provider.rs
@@ -136,6 +136,7 @@ async fn write_object(store: &MemoryStore, key: &str, records: &[LogRecord]) -> 
         writer_seq: 1,
         created_unix_ns: 0,
         level: SegmentLevel::L0,
+        segment_format_version: u32::from(ravel_logseg::footer::VERSION),
     }
 }
 

--- a/crates/ravel-sql/tests/logs_scan_allocations.rs
+++ b/crates/ravel-sql/tests/logs_scan_allocations.rs
@@ -134,6 +134,7 @@ async fn fixture() -> (Arc<dyn ObjectStoreBackend>, Vec<SegmentRef>) {
         writer_seq: 1,
         created_unix_ns: 0,
         level: SegmentLevel::L0,
+        segment_format_version: u32::from(ravel_logseg::footer::VERSION),
     };
     (Arc::new(store), vec![seg])
 }

--- a/crates/ravel-sql/tests/logs_selective_scan_amplification.rs
+++ b/crates/ravel-sql/tests/logs_selective_scan_amplification.rs
@@ -229,6 +229,7 @@ async fn write_segment(store: &dyn ObjectStoreBackend, seg: usize) -> SegmentRef
         writer_seq: (seg + 1) as u64,
         created_unix_ns: 0,
         level: SegmentLevel::L0,
+        segment_format_version: u32::from(ravel_logseg::footer::VERSION),
     }
 }
 

--- a/crates/ravel-sql/tests/logs_topk_late_materialization.rs
+++ b/crates/ravel-sql/tests/logs_topk_late_materialization.rs
@@ -216,6 +216,7 @@ async fn write_segment(store: &dyn ObjectStoreBackend, seg: usize, tied: bool) -
         writer_seq: (seg + 1) as u64,
         created_unix_ns: 0,
         level: SegmentLevel::L0,
+        segment_format_version: u32::from(ravel_logseg::footer::VERSION),
     }
 }
 

--- a/crates/ravel-sql/tests/logs_uncached_assignment.rs
+++ b/crates/ravel-sql/tests/logs_uncached_assignment.rs
@@ -134,6 +134,7 @@ async fn write_object(
         writer_seq: 1,
         created_unix_ns: 0,
         level: SegmentLevel::L0,
+        segment_format_version: u32::from(ravel_logseg::footer::VERSION),
     }
 }
 

--- a/crates/ravel-sql/tests/logs_whole_segment_fast_path.rs
+++ b/crates/ravel-sql/tests/logs_whole_segment_fast_path.rs
@@ -132,6 +132,7 @@ async fn write_object(
         writer_seq: 1,
         created_unix_ns: 0,
         level: SegmentLevel::L0,
+        segment_format_version: u32::from(ravel_logseg::footer::VERSION),
     }
 }
 

--- a/crates/ravel-sql/tests/memory_accounting.rs
+++ b/crates/ravel-sql/tests/memory_accounting.rs
@@ -437,6 +437,7 @@ async fn write_logs(
             writer_seq: 1,
             created_unix_ns: 0,
             level: SegmentLevel::L0,
+            segment_format_version: u32::from(ravel_logseg::footer::VERSION),
         }],
         segments_pruned: 0,
         pending_erasure: erasure,

--- a/crates/ravel-sql/tests/pipeline.rs
+++ b/crates/ravel-sql/tests/pipeline.rs
@@ -133,6 +133,7 @@ async fn write_segment(
         writer_seq: spec.writer_seq,
         created_unix_ns: spec.created_unix_ns,
         level: SegmentLevel::L0,
+        segment_format_version: u32::from(ravel_segment::SUPPORTED_VERSIONS.newest()),
     }
 }
 

--- a/crates/ravel-sql/tests/pushdown_memory.rs
+++ b/crates/ravel-sql/tests/pushdown_memory.rs
@@ -234,6 +234,7 @@ async fn write_segment(
         writer_seq: spec.writer_seq,
         created_unix_ns: spec.created_unix_ns,
         level: SegmentLevel::L0,
+        segment_format_version: u32::from(ravel_segment::SUPPORTED_VERSIONS.newest()),
     }
 }
 

--- a/crates/ravel-sql/tests/scan_batch_allocations.rs
+++ b/crates/ravel-sql/tests/scan_batch_allocations.rs
@@ -122,6 +122,7 @@ async fn fixture() -> (Arc<dyn ObjectStoreBackend>, Snapshot) {
             writer_seq: 1,
             created_unix_ns: 1,
             level: SegmentLevel::L0,
+            segment_format_version: u32::from(ravel_segment::SUPPORTED_VERSIONS.newest()),
         }],
         segments_pruned: 0,
         pending_erasure: Vec::new(),

--- a/crates/ravel-sql/tests/scan_budgets.rs
+++ b/crates/ravel-sql/tests/scan_budgets.rs
@@ -177,6 +177,7 @@ async fn write_segment(
         writer_seq: spec.writer_seq,
         created_unix_ns: spec.created_unix_ns,
         level: SegmentLevel::L0,
+        segment_format_version: u32::from(ravel_segment::SUPPORTED_VERSIONS.newest()),
     }
 }
 

--- a/crates/ravel-sql/tests/scan_soa_adoption.rs
+++ b/crates/ravel-sql/tests/scan_soa_adoption.rs
@@ -167,6 +167,7 @@ async fn write_segment(
         writer_seq: spec.writer_seq,
         created_unix_ns: spec.created_unix_ns,
         level: SegmentLevel::L0,
+        segment_format_version: u32::from(ravel_segment::SUPPORTED_VERSIONS.newest()),
     }
 }
 

--- a/crates/ravel-sql/tests/skip_partial_aggregation.rs
+++ b/crates/ravel-sql/tests/skip_partial_aggregation.rs
@@ -265,6 +265,7 @@ async fn write_high_cardinality_logs(store: &Arc<dyn ObjectStoreBackend>) -> Sna
             writer_seq: object as u64 + 1,
             created_unix_ns: 0,
             level: SegmentLevel::L0,
+            segment_format_version: u32::from(ravel_logseg::footer::VERSION),
         });
     }
 

--- a/crates/ravel-sql/tests/spans_columnar.rs
+++ b/crates/ravel-sql/tests/spans_columnar.rs
@@ -147,6 +147,7 @@ async fn write_object(store: &MemoryStore, key: &str, records: &[SpanRecord]) ->
         writer_seq: 1,
         created_unix_ns: 0,
         level: SegmentLevel::L0,
+        segment_format_version: u32::from(ravel_rspan::footer::VERSION),
     }
 }
 

--- a/crates/ravel-sql/tests/spans_differential.rs
+++ b/crates/ravel-sql/tests/spans_differential.rs
@@ -300,6 +300,7 @@ async fn write_object(store: &MemoryStore, key: &str, records: &[SpanRecord]) ->
         writer_seq: 1,
         created_unix_ns: 0,
         level: SegmentLevel::L0,
+        segment_format_version: u32::from(ravel_rspan::footer::VERSION),
     }
 }
 

--- a/crates/ravel-sql/tests/spans_provider.rs
+++ b/crates/ravel-sql/tests/spans_provider.rs
@@ -119,6 +119,7 @@ async fn write_object(store: &MemoryStore, key: &str, records: &[SpanRecord]) ->
         writer_seq: 1,
         created_unix_ns: 0,
         level: SegmentLevel::L0,
+        segment_format_version: u32::from(ravel_rspan::footer::VERSION),
     }
 }
 

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -233,6 +233,50 @@ so it joins the assignment rather than vetoing it (ADR-0102 amendment
 2026-08-26, #739 -- as a query-wide conjunct the threshold let one small tail
 object per `(shard, hour)` disqualify an entire 8,424-object snapshot).
 
+### Which read shape each assigned segment takes (#862)
+
+The conjuncts above decide the ASSIGNMENT: no plan phase, one owner per
+segment. They say nothing about the read, because every one of them is about
+which BLOCKS survive and none is about which COLUMNS the projection wants.
+Under RLOG v3 those were the same question — reading every block meant needing
+every byte — and the fast path read every segment whole regardless of
+projection. Under v4 they are independent: a block's pages sit one per column
+chunk inside its row group, so a statement projecting one column of 105 can
+read every block and still leave most of the object untouched.
+
+So the read shape is a per-segment decision taken at open time, arbitrated by
+`LogSegmentFetcher::ranged_projection_pays`:
+
+- **Wide projection** (`SELECT *`, any reference to the merged `attrs` map, or
+  simply enough columns): one whole-object `GetRange::Full`, unchanged. The
+  ranged path would fetch the same bytes and pay a probe and a section GET per
+  object on top.
+- **Narrow projection**: the probe-and-range entry
+  (`scan_accounted_with_tenant`), which brings one coalesced range per surviving
+  `(row group, projected column)` from the same `ColumnSelection` the decode
+  uses (ADR-0699 decision 5).
+
+The arbiter is the fetch layer's existing request-cost model, not a second
+threshold. A saved request is worth `request_cost_bytes` saved bytes
+(`DEFAULT_LOG_REQUEST_COST_BYTES`, ~1.8 MiB, a latency-bandwidth product of the
+store and instance); the ranged protocol adds `WHOLE_OBJECT_REQUEST_MULTIPLE`
+round trips over one whole-object GET; so it pays exactly when it saves more
+than their product. That product is the size crossover the fetch layer already
+compares whole object sizes against, and this is the same comparison with the
+projection moved into the saving: at a projected fraction of 0 the two are the
+same test. Note that `--logs-block-range-threshold` pins BOTH the funnel's
+routing threshold and that crossover, so at its 512 KiB default the effective
+break-even is 512 KiB of saving, not the request-cost-derived 8.9 MiB.
+
+The projected fraction is estimated from column counts (the selection's width
+over the object's column population), because the exact projected byte volume
+is not known until PAGE_DIR is read. It only decides whether reading the
+directory is worth it; the byte-exact call is still the 75% coverage crossover
+one layer down, which falls back to a single whole-object GET when the projected
+pages turn out to cover the object after all. `LogsScanExec` publishes
+`fast_path_ranged_segments` and `fast_path_whole_object_segments` so
+`EXPLAIN ANALYZE` shows the split without counting store requests.
+
 ## Selective (predicated) logs scan: request count
 
 A statement with a block-level predicate — a declared-column or `attrs`
@@ -1842,11 +1886,16 @@ was what measured whether block-level pruning alone captured enough before
 PAGE_DIR shrank the wire fetch to columns.
 
 The predicate-free full-window whole-segment fast path (#693 part 3, above)
-is the one shape where the two axes never move together, by design (#790).
-It issues exactly one whole-object `GetRange::Full` GET per segment
-regardless of projection -- that request count is the fast path's entire
-reason to exist, and #790 does not change it -- so `page_bytes_fetched`
-always equals the object's full stored page bytes, on every projection.
+was, until #862, the one shape where the two axes never moved together, by
+design (#790). It issued exactly one whole-object `GetRange::Full` GET per
+segment regardless of projection, so `page_bytes_fetched` always equalled the
+object's full stored page bytes, on every projection. Since #862 that holds
+only for the projections the fast path still routes to the whole-object read
+(a wide one; see "Which read shape each assigned segment takes" above). A
+narrow projection now takes the ranged entry from inside the fast path, and
+the two axes move together there exactly as they do on every other ranged
+read. The paragraphs below describe the whole-object branch.
+
 What #790 fixed is `page_bytes_decoded`: `scan_whole_accounted_with_tenant`
 already threaded the caller's `ColumnSelection` into the same
 `decode_v4_block` page-level skip every other read path uses, so a one-column
@@ -1867,10 +1916,13 @@ bytes -- those stay exactly where the #693-part-3 fast path already put them. Th
 read cache serves it with zero store requests and zero wire bytes, as the
 tracing section states.
 Reachable from any predicate-free, fully-contained, narrow-projection
-statement that takes the fast path. `SELECT ts, body FROM logs` is the
+statement whose segments the fast path still routes to the whole-object read
+-- since #862 that means one whose saving does not clear the request-cost
+break-even, typically a small object. `SELECT ts, body FROM logs` is the
 worked example below: two selected SQL columns, and the reader also decodes
 the required `stream_ref`, which is why three pages per block survive and not
-one.
+one. The same page-level narrowing applies unchanged on the ranged branch,
+where it also shrinks the wire fetch.
 Object size does not gate it: since #739 the fast path is chosen for a
 segment at or below the block-range threshold too, which is what the
 request-count paragraph above already states.


### PR DESCRIPTION
perf(logs): route the whole-segment fast path on projection width

33 of 42 ClickBench statements each read all 3,469 objects and the entire
12.03 GB corpus -- 397 GB of the pass's 405.3 GB -- whatever they project.
q07 is MIN/MAX over one column and reads 12.03 GB. q02 is COUNT(*) over one
predicate column and reads 12.03 GB.

The projection was never lost. resolve_columns builds the ColumnSelection,
it is threaded to the fetch layer, and on a version-4 object it is already
the FETCH selection as well as the decode one (ADR-0699 decision 5). What
was missing is the routing: every conjunct whole_segment_fast_path tests is
about which blocks survive, and none is about which columns the projection
wants. Under RLOG v3 those were the same question, because reading every
block meant needing every byte. Under v4 they are independent.

The read shape is now a per-segment decision taken inside the fast path
rather than by falling out of it. That is a deliberate departure from the
obvious fix: rejecting the fast path for a narrow projection would be
strictly worse, because the plan-then-stripe path it falls to adds a plan
pass per segment, so a narrow statement would pay MORE requests to move
fewer bytes.

The arbiter is the fetch layer's existing request-cost model, not a second
threshold. A saved request is worth request_cost_bytes of saved bytes, and
the ranged protocol adds WHOLE_OBJECT_REQUEST_MULTIPLE round trips over one
whole-object GET, so ranging pays exactly when it saves more than their
product -- which is already the size crossover the fetch layer applies.
ranged_projection_pays is that same comparison with the projection moved
into the saving, and at a projected fraction of zero the two are identical.

Why this is not the change that was blocked before: an earlier attempt was
held on arithmetic showing it would make q07 and q02 1.96x SLOWER. That was
correct for the v3 shape, one small GET per block and 12,000+ GETs per
column. The as-built v4 chunk fetch scales requests with objects x projected
columns, about one row group per object on this corpus, so the regression it
feared does not exist here. The acceptance criterion is still not "fewer
bytes" -- q20 prunes bytes 7x, pays 5.5x the requests, and is the worst cold
statement in the suite at 11.5 s.

The projected fraction is estimated from column counts, because the exact
projected byte volume is unknown until PAGE_DIR is read. resolve_columns
returns that width beside the selection from the same walk, so the two
cannot drift, and the byte-exact decision still happens one layer down at
the 75% coverage crossover, which falls back to a single whole-object GET
when the projected pages turn out to cover the object anyway.

fast_path_ranged_segments and fast_path_whole_object_segments are published
so EXPLAIN ANALYZE shows the split rather than leaving it to be inferred.

Tests assert the exact request shape per segment, not a bound, and cover
both directions: a narrow projection reads column chunks, a wide projection
keeps the whole-object read, SELECT * is unchanged, and both paths return
identical rows. Verified they discriminate -- forcing ranged_projection_pays
to false fails the two narrow-path tests with

    exact request shape per segment: 0 full, 1 suffix probe, 5 ranges
      left: (4, 0, 0)   right: (0, 4, 20)

while the two wide-path guards still pass, which is the asymmetry a
bidirectional suite should show.

Rebased onto main after ADR-0850 landed. Verified locally: ravel-sql and
ravel-query, 367 lib tests plus every integration target.

NOT YET MEASURED on the reference tenant. The pre-registered expectation on
issue #862 is bytes down roughly an order of magnitude for narrow
statements, requests up roughly 3x and acceptable at this exchange rate, and
SELECT * unchanged. A wall-clock pass decides it; a CPU or byte figure alone
does not.

Refs: #862, #680
