### PR TITLE
feat(bench): surface per-phase probe misses in per-run accounting

### DIFF
--- a/crates/ravel-bench/src/bin/sql_latency_bench.rs
+++ b/crates/ravel-bench/src/bin/sql_latency_bench.rs
@@ -488,8 +488,15 @@ fn print_human_table(report: &SqlLatencyReport) {
     // whether the second execution dropped to plan reads only or still fetched
     // objects (issue #767). The warm columns are `-` for a single-run report or
     // the Flight lane (no per-run accounting on the wire).
+    //
+    // `pmiss` is the cold run's tail-section probe misses, plan phase plus scan
+    // phase (issue #883). It sits next to `get` because it is part of it: each
+    // miss is one of those GETs, spent because the derived suffix probe did not
+    // reach SKIP_IDX/PAGE_DIR. A `get` column that rises with `pmiss` is a probe
+    // too short; one that rises without it is not. The per-phase split is in the
+    // report JSON's `per_run_accounting`.
     println!(
-        "  {:<32} | {:>9} | {:>9} | {:>9} | {:>9} | {:>7} | {:>7} | {:>7} | {:>7} | {:>7} | {:>9} | {:>7}",
+        "  {:<32} | {:>9} | {:>9} | {:>9} | {:>9} | {:>7} | {:>7} | {:>7} | {:>7} | {:>7} | {:>7} | {:>9} | {:>7}",
         "id",
         "min ms",
         "med ms",
@@ -499,13 +506,14 @@ fn print_human_table(report: &SqlLatencyReport) {
         "blk_tot",
         "blk_scn",
         "get",
+        "pmiss",
         "w_get",
         "w_bytes",
         "w_hit"
     );
     println!(
-        "  {:-<32}-+-{:-<9}-+-{:-<9}-+-{:-<9}-+-{:-<9}-+-{:-<7}-+-{:-<7}-+-{:-<7}-+-{:-<7}-+-{:-<7}-+-{:-<9}-+-{:-<7}",
-        "", "", "", "", "", "", "", "", "", "", "", ""
+        "  {:-<32}-+-{:-<9}-+-{:-<9}-+-{:-<9}-+-{:-<9}-+-{:-<7}-+-{:-<7}-+-{:-<7}-+-{:-<7}-+-{:-<7}-+-{:-<7}-+-{:-<9}-+-{:-<7}",
+        "", "", "", "", "", "", "", "", "", "", "", "", ""
     );
     for e in &report.entries {
         // The Flight lane has no scan diagnostics to print (they are executor
@@ -529,8 +537,14 @@ fn print_human_table(report: &SqlLatencyReport) {
             ),
             _ => ("-".to_string(), "-".to_string(), "-".to_string()),
         };
+        // The cold run is run index 0, so this needs no minimum run count, only
+        // the per-run array the Flight lane does not carry.
+        let probe_misses = match e.per_run_accounting.as_deref() {
+            Some([cold, ..]) => (cold.probe_misses_plan + cold.probe_misses_scan).to_string(),
+            _ => "-".to_string(),
+        };
         println!(
-            "  {:<32} | {:>9.3} | {:>9.3} | {:>9.3} | {:>9.3} | {:>7} | {:>7} | {:>7} | {:>7} | {:>7} | {:>9} | {:>7}",
+            "  {:<32} | {:>9.3} | {:>9.3} | {:>9.3} | {:>9.3} | {:>7} | {:>7} | {:>7} | {:>7} | {:>7} | {:>7} | {:>9} | {:>7}",
             e.id,
             e.min_ms,
             e.median_ms,
@@ -540,6 +554,7 @@ fn print_human_table(report: &SqlLatencyReport) {
             blocks_total,
             blocks_scanned,
             gets,
+            probe_misses,
             warm_gets,
             warm_bytes,
             warm_hits,

--- a/crates/ravel-bench/src/bin/sql_latency_bench.rs
+++ b/crates/ravel-bench/src/bin/sql_latency_bench.rs
@@ -489,12 +489,14 @@ fn print_human_table(report: &SqlLatencyReport) {
     // objects (issue #767). The warm columns are `-` for a single-run report or
     // the Flight lane (no per-run accounting on the wire).
     //
-    // `pmiss` is the cold run's tail-section probe misses, plan phase plus scan
-    // phase (issue #883). It sits next to `get` because it is part of it: each
-    // miss is one of those GETs, spent because the derived suffix probe did not
-    // reach SKIP_IDX/PAGE_DIR. A `get` column that rises with `pmiss` is a probe
-    // too short; one that rises without it is not. The per-phase split is in the
-    // report JSON's `per_run_accounting`.
+    // `pmiss` is the cold run's uncovered tail SECTIONS, plan phase plus scan
+    // phase (issue #883) -- not a GET count. A short version-4 probe can miss
+    // SKIP_IDX and PAGE_DIR both and count twice while the fetcher coalesces
+    // their adjacent ranges into one GET, so it bounds the extra requests from
+    // above. It sits next to `get` to be read against it: a `get` column that
+    // rises alongside `pmiss` is a probe too short; one that rises with `pmiss`
+    // flat is not. The per-phase split is in the report JSON's
+    // `per_run_accounting`.
     println!(
         "  {:<32} | {:>9} | {:>9} | {:>9} | {:>9} | {:>7} | {:>7} | {:>7} | {:>7} | {:>7} | {:>7} | {:>9} | {:>7}",
         "id",

--- a/crates/ravel-bench/src/sql_latency.rs
+++ b/crates/ravel-bench/src/sql_latency.rs
@@ -58,8 +58,8 @@ use ravel_logseg::{
 };
 use ravel_object_store::{ObjectStoreBackend, PutOptions};
 use ravel_query::{
-    CacheFetchError, DEFAULT_FETCH_CONCURRENCY, DEFAULT_MAX_SEGMENTS, EngineConfig,
-    LogSegmentFetcher, SegmentFetcher,
+    CacheFetchError, DEFAULT_FETCH_CONCURRENCY, DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
+    DEFAULT_MAX_SEGMENTS, EngineConfig, LogSegmentFetcher, ProbeMissCounter, SegmentFetcher,
 };
 use ravel_sql::{
     DEFAULT_MAX_QUERY_BYTES, DeclaredColumn, DeclaredType, SpanSegmentFetcher, SqlConfig,
@@ -412,6 +412,27 @@ pub struct RunAccounting {
     pub cache_misses: u64,
     /// Bytes served from the fetch cache on this run.
     pub cache_bytes: u64,
+    /// Tail sections (SKIP_IDX, and PAGE_DIR on a version-4 object) that this
+    /// run's PLAN-phase probes failed to reach, charged to the phase that issued
+    /// the probe (`ravel_query::ProbePhase::Plan`): the footer/skip-index reads
+    /// `plan_segment` and `plan_segment_block_stats` issue, plus the whole-object
+    /// plan fallback for a predicate the skip index cannot decide.
+    ///
+    /// Each miss costs one extra GET, so this is the request half of the trade a
+    /// shorter probe makes and belongs beside
+    /// [`Self::object_store_get_requests`]: a probe floor can only be tightened
+    /// against these numbers (issue #883, `ravel_query::LOG_SUFFIX_FLOOR_BYTES`).
+    /// It is measured against the probe WINDOW, not against cache residency, so
+    /// a warm run reports the same value as the cold one even though its GETs
+    /// fall.
+    #[serde(default)]
+    pub probe_misses_plan: u64,
+    /// Tail sections this run's SCAN-phase probes failed to reach, charged to
+    /// `ravel_query::ProbePhase::Scan`: the block/page/chunk data reads. Same
+    /// units and same window-not-cache semantics as [`Self::probe_misses_plan`];
+    /// the run's total is the two summed.
+    #[serde(default)]
+    pub probe_misses_scan: u64,
 }
 
 /// One measured statement.
@@ -798,10 +819,13 @@ fn build_read_cache(cache_bytes: u64) -> Arc<Cache<CacheFetchError>> {
 /// for every hour (ravel_catalog docs on `read_scan_generations`); the tenant
 /// lane resolves that count before calling here so a multi-shard tenant is no
 /// longer measured over shard 0 alone.
-/// The executor knobs a run configures, every one of them a flag that
-/// `ravel-server` also has. They travel together because they are only
-/// meaningful together: a statement refused by one ceiling says nothing about
-/// the others, and a table is comparable only when all of them match.
+/// The executor knobs a run configures. They travel together because they are
+/// only meaningful together: a statement refused by one ceiling says nothing
+/// about the others, and a table is comparable only when all of them match.
+///
+/// Every field but [`Self::logs_suffix_len`] is a flag `ravel-server` also has.
+/// That one is a measurement knob with no server equivalent, for the reason its
+/// own doc gives.
 // issue #720: carries `--sql-max-segments` and `--explain`.
 #[derive(Clone, Copy, Debug)]
 pub struct ExecutorSettings {
@@ -820,6 +844,19 @@ pub struct ExecutorSettings {
     /// Sealed, below-watermark segments a statement may fan out over
     /// (`--max-segments`), ADR-0073 decision 2.
     pub max_segments: usize,
+    /// Object size above which a logs read fetches only the pruning-relevant
+    /// parts instead of the whole object (ADR-0107), `ravel-server`'s
+    /// `logs_block_range_threshold`. `0` routes every object through the ranged
+    /// probe-then-fetch path, which is the only path that probes at all: at or
+    /// below the threshold an object is read whole in one GET with no suffix
+    /// probe and therefore no probe miss.
+    pub logs_block_range_threshold: u64,
+    /// Suffix-probe length to pin, or `None` for the per-object derivation
+    /// ([`ravel_query::derive_suffix_len`], #883). No server flag corresponds to
+    /// it: the probe floor is a calibrated constant, and the only sound way to
+    /// move it is to sweep the window against measured probe misses first, which
+    /// is what this knob exists for.
+    pub logs_suffix_len: Option<u64>,
 }
 
 impl Default for ExecutorSettings {
@@ -831,8 +868,22 @@ impl Default for ExecutorSettings {
             tenant_max_bytes: DEFAULT_TENANT_MAX_BYTES,
             parallel_final_aggregation: true,
             max_segments: DEFAULT_MAX_SEGMENTS,
+            logs_block_range_threshold: DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
+            logs_suffix_len: None,
         }
     }
+}
+
+/// The executor plus the probe-miss counter of the log fetcher inside it
+/// (#883). The counter has to be cloned out here, before the fetcher is moved
+/// into the executor, because nothing downstream hands it back: `SqlOutcome`
+/// carries a `QueryAccountingSnapshot`, which has no probe-miss field, and
+/// widening that type would change the distributed accounting protobuf, a frozen
+/// contract. See [`measure_corpus`] for how a per-run figure is taken from an
+/// accumulating counter.
+struct ColdExecutor {
+    executor: SqlExecutor,
+    probe_misses: ProbeMissCounter,
 }
 
 fn cold_executor(
@@ -840,7 +891,7 @@ fn cold_executor(
     declared: &[DeclaredColumn],
     cache: Option<Arc<Cache<CacheFetchError>>>,
     settings: ExecutorSettings,
-) -> Result<SqlExecutor, Error> {
+) -> Result<ColdExecutor, Error> {
     let ExecutorSettings {
         max_query_bytes,
         shard_count,
@@ -848,6 +899,8 @@ fn cold_executor(
         tenant_max_bytes,
         parallel_final_aggregation,
         max_segments,
+        logs_block_range_threshold,
+        logs_suffix_len,
     } = settings;
     let catalog = Arc::new(Catalog::new(
         Arc::clone(store),
@@ -861,11 +914,20 @@ fn cold_executor(
     // more partitions than that queues on it, so the bench would measure a
     // ceiling the flag cannot move.
     let mut log_fetcher = LogSegmentFetcher::new(Arc::clone(store))
-        .with_max_concurrent_gets(fetch_concurrency.max(1));
+        .with_max_concurrent_gets(fetch_concurrency.max(1))
+        .with_block_range_threshold(logs_block_range_threshold);
+    if let Some(n) = logs_suffix_len {
+        log_fetcher = log_fetcher.with_suffix_len(n);
+    }
     if let Some(cache) = cache {
         log_fetcher = log_fetcher.with_cache(cache);
     }
-    Ok(SqlExecutor::new(
+    // Cloned after every builder, because `with_block_range_threshold` and the
+    // rest rebuild the inner `BlockRangeFetcher`; the counter itself survives
+    // them, but taking the handle last keeps that a local fact rather than an
+    // ordering the reader has to verify.
+    let probe_misses = log_fetcher.probe_miss_counter();
+    let executor = SqlExecutor::new(
         catalog,
         SegmentFetcher::new(Arc::clone(store)),
         log_fetcher,
@@ -882,7 +944,11 @@ fn cold_executor(
         },
         tenant_max_bytes.max(1),
     )
-    .with_declared_column_source(Arc::new(StaticDeclaredColumns::new(declared.to_vec()))))
+    .with_declared_column_source(Arc::new(StaticDeclaredColumns::new(declared.to_vec())));
+    Ok(ColdExecutor {
+        executor,
+        probe_misses,
+    })
 }
 
 /// The physical plan for `sql`, rendered as the indented text `--explain`
@@ -1007,7 +1073,7 @@ pub async fn measure_corpus(
         // `owned_executor` holds it alive for the run loop below. The warm path
         // borrows the one `shared_executor` instead and leaves this unused.
         let owned_executor;
-        let executor: &SqlExecutor = match &shared_executor {
+        let built: &ColdExecutor = match &shared_executor {
             Some(shared) => shared,
             None => {
                 let cache = (cache_bytes > 0).then(|| build_read_cache(cache_bytes));
@@ -1015,6 +1081,13 @@ pub async fn measure_corpus(
                 &owned_executor
             }
         };
+        let executor: &SqlExecutor = &built.executor;
+        // #883: the log fetcher's probe-miss counter accumulates for the life of
+        // the fetcher, which under `--warm-catalog` is the whole corpus. Every
+        // per-run figure below is a difference of two snapshots taken around
+        // that run, so a shared executor attributes each statement's misses to
+        // that statement and never to the ones before it.
+        let probe_misses = &built.probe_misses;
         let req = SqlRequest {
             sql: entry.sql.clone(),
             window,
@@ -1057,6 +1130,9 @@ pub async fn measure_corpus(
         };
 
         for run in 0..runs {
+            // Taken here, after the EXPLAIN side artifact above, so a plan
+            // written for `--explain-dir` is not charged to run 0.
+            let probe_misses_before = probe_misses.snapshot();
             let start = Instant::now();
             let outcome = match executor.execute(tenant_hash, &req).await {
                 Ok(outcome) => outcome,
@@ -1086,6 +1162,10 @@ pub async fn measure_corpus(
             // reads only or still fetches objects, and that is unreadable from
             // the cold figures alone (issue #767).
             let acc = &outcome.accounting;
+            // #883: this run's share of an accumulating counter. The GETs a miss
+            // costs are already in `object_store_get_requests` above; this says
+            // how many of them the probe window is responsible for.
+            let run_probe_misses = probe_misses.snapshot().saturating_sub(&probe_misses_before);
             per_run_accounting.push(RunAccounting {
                 object_store_get_requests: acc.s3_requests(AccountedOp::Get),
                 object_store_list_requests: acc.s3_requests(AccountedOp::List),
@@ -1093,6 +1173,8 @@ pub async fn measure_corpus(
                 cache_hits: acc.cache_hits,
                 cache_misses: acc.cache_misses,
                 cache_bytes: acc.cache_bytes,
+                probe_misses_plan: run_probe_misses.plan,
+                probe_misses_scan: run_probe_misses.scan,
             });
             if run == 0 {
                 // The cold run's block counters and rows go into `scan`; its
@@ -1408,6 +1490,7 @@ pub async fn run_generated(cfg: &GenerateConfig) -> Result<SqlLatencyReport, Err
         tenant_max_bytes: cfg.tenant_max_bytes,
         parallel_final_aggregation: cfg.parallel_final_aggregation,
         max_segments: cfg.max_segments,
+        ..ExecutorSettings::default()
     };
     let (entries, skipped, failed) = measure_corpus(
         &cfg.store,
@@ -1531,6 +1614,7 @@ pub async fn run_tenant(cfg: &TenantConfigInput) -> Result<SqlLatencyReport, Err
         tenant_max_bytes: cfg.tenant_max_bytes,
         parallel_final_aggregation: cfg.parallel_final_aggregation,
         max_segments: cfg.max_segments,
+        ..ExecutorSettings::default()
     };
     // The two lanes measure the same statements over the same dataset stanza
     // and the same declared-column set; they differ only in what executes the
@@ -1821,18 +1905,22 @@ mod tests {
         tenant: &TenantId,
         shard: u32,
         objects: usize,
-    ) {
-        write_records_as_objects(store, tenant, shard, &build_records(objects.max(1), 0)).await;
+    ) -> Vec<Vec<u8>> {
+        write_records_as_objects(store, tenant, shard, &build_records(objects.max(1), 0)).await
     }
 
     /// One RLOG object per record in `records`, each with its own commit
-    /// record, on `shard`.
+    /// record, on `shard`. Returns the object bytes in write order, so a test
+    /// that needs the object's own layout (section offsets, total size) reads it
+    /// from what was written rather than rebuilding a second copy that could
+    /// drift from it.
     async fn write_records_as_objects(
         store: &Arc<dyn ObjectStoreBackend>,
         tenant: &TenantId,
         shard: u32,
         records: &[LogRecord],
-    ) {
+    ) -> Vec<Vec<u8>> {
+        let mut written = Vec::with_capacity(records.len());
         let writer_id = Uuid::from_u128(0x5100_0100 + u128::from(shard));
         for (obj_idx, rec) in records.iter().enumerate() {
             let writer_seq = (obj_idx + 1) as u64;
@@ -1868,13 +1956,19 @@ mod tests {
             let built = record::build(new_record).expect("build commit record");
             let data_key = keys::reconstruct_data_key(&built).expect("data key");
             store
-                .put(&data_key, bytes::Bytes::from(bytes), PutOptions::default())
+                .put(
+                    &data_key,
+                    bytes::Bytes::from(bytes.clone()),
+                    PutOptions::default(),
+                )
                 .await
                 .expect("put object");
             publish::publish(store.as_ref(), &built, &RetryPolicy::default())
                 .await
                 .expect("publish commit record");
+            written.push(bytes);
         }
+        written
     }
 
     /// A tenant-lane config for the shard/cache tests: memory provenance, no
@@ -2207,10 +2301,12 @@ mod tests {
                 ..ExecutorSettings::default()
             },
         )
-        .expect("build executor");
+        .expect("build executor")
+        .executor;
         assert_eq!(executor.config().engine.max_segments, custom);
-        let executor =
-            cold_executor(&store, &[], None, ExecutorSettings::default()).expect("build executor");
+        let executor = cold_executor(&store, &[], None, ExecutorSettings::default())
+            .expect("build executor")
+            .executor;
         assert_eq!(
             executor.config().engine.max_segments,
             DEFAULT_MAX_SEGMENTS,
@@ -2440,15 +2536,17 @@ mod tests {
                 ..ExecutorSettings::default()
             },
         )
-        .expect("build executor");
+        .expect("build executor")
+        .executor;
         assert_eq!(executor.max_tenant_bytes(), custom_tenant);
         assert!(
             !executor.config().parallel_final_aggregation,
             "the false opt-out must reach the executor"
         );
 
-        let executor =
-            cold_executor(&store, &[], None, ExecutorSettings::default()).expect("build executor");
+        let executor = cold_executor(&store, &[], None, ExecutorSettings::default())
+            .expect("build executor")
+            .executor;
         assert_eq!(executor.max_tenant_bytes(), DEFAULT_TENANT_MAX_BYTES);
         assert!(
             executor.config().parallel_final_aggregation,
@@ -2842,14 +2940,16 @@ mod tests {
         // fetcher cache), one run.
         let cache = build_read_cache(64 << 20);
         let cached = cold_executor(&store, &[], Some(cache), ExecutorSettings::default())
-            .expect("build cached executor");
+            .expect("build cached executor")
+            .executor;
         let on = cached.execute(th, &req).await.expect("cached run");
 
         // Fetcher cache OFF: a fresh executor (identical cold catalog byte cache,
         // no fetcher cache), one run. The catalog contribution is the same in
         // both, so any delta is the fetcher cache alone.
         let uncached = cold_executor(&store, &[], None, ExecutorSettings::default())
-            .expect("build uncached executor");
+            .expect("build uncached executor")
+            .executor;
         let off = uncached.execute(th, &req).await.expect("uncached run");
 
         let get_on = on.accounting.s3_requests(AccountedOp::Get);
@@ -2893,7 +2993,8 @@ mod tests {
                 ..ExecutorSettings::default()
             },
         )
-        .expect("build executor");
+        .expect("build executor")
+        .executor;
         assert_eq!(executor.config().engine.fetch_concurrency, custom);
         let executor = cold_executor(
             &store,
@@ -2904,7 +3005,8 @@ mod tests {
                 ..ExecutorSettings::default()
             },
         )
-        .expect("build executor");
+        .expect("build executor")
+        .executor;
         assert_eq!(
             executor.config().engine.fetch_concurrency,
             1,
@@ -3005,6 +3107,199 @@ mod tests {
         assert_eq!(scan.cache_hits, acc[0].cache_hits);
     }
 
+    // ---- Probe misses in the per-run accounting (#883) ---------------------
+
+    /// The suffix-probe length that just fails to reach SKIP_IDX in `object`: it
+    /// starts exactly at SKIP_IDX's end, so it covers the footer (no footer
+    /// chase) and every tail section the writer emits after SKIP_IDX (PAGE_DIR
+    /// on a version-4 object), leaving SKIP_IDX -- the one section a read has to
+    /// locate blocks through -- as the only thing outside the window. Stands in
+    /// for an under-sized probe derivation on an object whose trailer exceeds it.
+    fn suffix_just_past_skip_idx(object: &[u8]) -> u64 {
+        let total = object.len() as u64;
+        let footer = ravel_logseg::footer::open(object).expect("footer");
+        let skip = *footer
+            .section(ravel_logseg::footer::kind::SKIP_IDX)
+            .expect("SKIP_IDX");
+        let suffix = total - (skip.offset + skip.len);
+        assert!(
+            suffix < total - skip.offset,
+            "the probe must not reach SKIP_IDX's start"
+        );
+        suffix
+    }
+
+    /// The `has_word` statement the probe-miss tests measure. It is deliberately
+    /// not skip-decidable: `plan_segment` falls back to a whole-object plan read
+    /// and hands no footer forward, so the scan probes the object a second time
+    /// on its own. That is what makes both phases counted, which is the split
+    /// the two `probe_misses_*` fields exist to show.
+    const PROBE_MISS_SQL: &str = "SELECT body FROM logs WHERE has_word(body, 'timeout')";
+
+    /// A trailer that EXCEEDS the probe is reported in the per-run accounting,
+    /// per phase, on every run.
+    ///
+    /// The fixture is one RLOG object read through the ranged path
+    /// (`logs_block_range_threshold: 0`, the whole-object crossover disabled --
+    /// at the default threshold this object is read whole in one GET and never
+    /// probes at all, so none of the miss-counting sites is reached and the test
+    /// would be vacuous). The probe is pinned to start at SKIP_IDX's end, so
+    /// each read that has to locate blocks through SKIP_IDX misses exactly one
+    /// tail section: one in the plan phase (`plan_segment`'s whole-object
+    /// fallback) and one in the scan phase (the data read, which re-probes
+    /// because the fallback carried no footer).
+    ///
+    /// Both runs report the same figures even though the warm run's store GETs
+    /// fall: a miss is measured against the probe WINDOW, not against what the
+    /// read cache happened to hold.
+    ///
+    /// Prove-the-test: pinned exact values, never `> 0`. Demonstrated failing
+    /// during development by deleting the
+    /// `self.probe_misses.record(phase, stats.probe_misses)` line from
+    /// `LogSegmentFetcher::record_probe_misses` in `ravel-query` (reads 0
+    /// against the expected 1), and by deleting `stats.probe_misses += 1` from
+    /// `fetch_object_v4`'s tail-section loop, the counting site this version-4
+    /// fixture actually reaches (same result, from the other end of the
+    /// plumbing). Deleting the version-3 site in `fetch_object_with_footer`
+    /// instead leaves it green, which is what says the fixture is version 4.
+    #[tokio::test]
+    async fn probe_misses_reach_per_run_accounting_when_the_trailer_exceeds_the_probe() {
+        let store = empty_store();
+        let tenant = TenantId::new("probe-miss-tenant");
+        let objects = write_shard_objects(&store, &tenant, 0, 1).await;
+        let suffix = suffix_just_past_skip_idx(&objects[0]);
+        let window = TimeRange {
+            start_ns: 0,
+            end_ns: NOW_NS,
+        };
+        let (measured, skipped, failed) = measure_corpus(
+            &store,
+            tenant.hash(),
+            &[entry("q", PROBE_MISS_SQL)],
+            &[],
+            2,
+            window,
+            NOW_NS,
+            64 << 20,
+            Duration::from_secs(30),
+            false,
+            None,
+            ExecutorSettings {
+                logs_block_range_threshold: 0,
+                logs_suffix_len: Some(suffix),
+                ..ExecutorSettings::default()
+            },
+            false,
+            None,
+        )
+        .await
+        .expect("run");
+        assert!(skipped.is_empty() && failed.is_empty());
+        let acc = measured[0]
+            .per_run_accounting
+            .as_ref()
+            .expect("an in-process lane records per-run accounting");
+        assert_eq!(acc.len(), 2, "one accounting entry per run");
+
+        assert_eq!(
+            acc[0].probe_misses_plan, 1,
+            "cold run: the plan-phase read missed SKIP_IDX exactly once"
+        );
+        assert_eq!(
+            acc[0].probe_misses_scan, 1,
+            "cold run: the scan-phase read missed SKIP_IDX exactly once"
+        );
+        assert_eq!(
+            acc[1].probe_misses_plan, 1,
+            "warm run: the same window misses the same section"
+        );
+        assert_eq!(
+            acc[1].probe_misses_scan, 1,
+            "warm run: a miss is a property of the probe window, not of the cache"
+        );
+
+        // What a measurement pass actually reads: the figure has to be in the
+        // report JSON, per statement per run, not only in the in-memory struct.
+        let v: serde_json::Value = serde_json::to_value(&measured[0]).expect("serialize entry");
+        let per_run = v["per_run_accounting"]
+            .as_array()
+            .expect("per_run_accounting is a JSON array");
+        assert_eq!(per_run[0]["probe_misses_plan"], 1);
+        assert_eq!(per_run[0]["probe_misses_scan"], 1);
+        assert_eq!(per_run[1]["probe_misses_plan"], 1);
+        assert_eq!(per_run[1]["probe_misses_scan"], 1);
+    }
+
+    /// A trailer that FITS inside the derived probe reports exactly zero, on
+    /// both phases and both runs.
+    ///
+    /// Same fixture and same ranged path as the exceeding case, with the probe
+    /// left at the per-object derivation: this object is far below
+    /// `LOG_SUFFIX_FLOOR_BYTES`, so the derived window is the whole object and
+    /// covers every tail section. Paired with the exceeding case so a plumbing
+    /// change that reported a constant zero could not pass both.
+    ///
+    /// Prove-the-test: pinned to 0, never `>= 0`. Demonstrated failing during
+    /// development by making `probe_window_covers` in `ravel-query` return
+    /// `false` unconditionally: every counting read then reports its tail
+    /// sections as missed and the first assertion reads 2 (SKIP_IDX and
+    /// PAGE_DIR) against the expected 0.
+    #[tokio::test]
+    async fn probe_misses_are_zero_when_the_derived_probe_covers_the_trailer() {
+        let store = empty_store();
+        let tenant = TenantId::new("probe-fit-tenant");
+        let objects = write_shard_objects(&store, &tenant, 0, 1).await;
+        let total = objects[0].len() as u64;
+        assert!(
+            ravel_query::derive_suffix_len(total) >= total,
+            "fixture precondition: the derived probe ({} B) must cover the whole \
+             object ({total} B), or this test would be measuring a miss",
+            ravel_query::derive_suffix_len(total)
+        );
+        let window = TimeRange {
+            start_ns: 0,
+            end_ns: NOW_NS,
+        };
+        let (measured, skipped, failed) = measure_corpus(
+            &store,
+            tenant.hash(),
+            &[entry("q", PROBE_MISS_SQL)],
+            &[],
+            2,
+            window,
+            NOW_NS,
+            64 << 20,
+            Duration::from_secs(30),
+            false,
+            None,
+            ExecutorSettings {
+                logs_block_range_threshold: 0,
+                logs_suffix_len: None,
+                ..ExecutorSettings::default()
+            },
+            false,
+            None,
+        )
+        .await
+        .expect("run");
+        assert!(skipped.is_empty() && failed.is_empty());
+        let acc = measured[0]
+            .per_run_accounting
+            .as_ref()
+            .expect("an in-process lane records per-run accounting");
+        assert_eq!(acc.len(), 2, "one accounting entry per run");
+        for (run, entry) in acc.iter().enumerate() {
+            assert_eq!(
+                entry.probe_misses_plan, 0,
+                "run {run}: the derived probe covered every plan-phase tail section"
+            );
+            assert_eq!(
+                entry.probe_misses_scan, 0,
+                "run {run}: the derived probe covered every scan-phase tail section"
+            );
+        }
+    }
+
     /// The report JSON keeps its existing shape and gains the per-run array.
     /// A cold accounting field under `scan` is unchanged (pinned), and
     /// `per_run_accounting` is an array whose length equals `runs`.
@@ -3068,7 +3363,8 @@ mod tests {
                 ..ExecutorSettings::default()
             },
         )
-        .expect("build executor");
+        .expect("build executor")
+        .executor;
         assert_eq!(executor.config().max_query_bytes, custom);
     }
 
@@ -3079,8 +3375,9 @@ mod tests {
     #[test]
     fn cold_executor_defaults_to_compiled_in_budget() {
         let store = empty_store();
-        let executor =
-            cold_executor(&store, &[], None, ExecutorSettings::default()).expect("build executor");
+        let executor = cold_executor(&store, &[], None, ExecutorSettings::default())
+            .expect("build executor")
+            .executor;
         assert_eq!(executor.config().max_query_bytes, DEFAULT_MAX_QUERY_BYTES);
     }
 

--- a/crates/ravel-bench/src/sql_latency.rs
+++ b/crates/ravel-bench/src/sql_latency.rs
@@ -418,10 +418,15 @@ pub struct RunAccounting {
     /// `plan_segment` and `plan_segment_block_stats` issue, plus the whole-object
     /// plan fallback for a predicate the skip index cannot decide.
     ///
-    /// Each miss costs one extra GET, so this is the request half of the trade a
-    /// shorter probe makes and belongs beside
-    /// [`Self::object_store_get_requests`]: a probe floor can only be tightened
-    /// against these numbers (issue #883, `ravel_query::LOG_SUFFIX_FLOOR_BYTES`).
+    /// Counts uncovered tail SECTIONS, not GETs. A short version-4 probe can
+    /// miss both SKIP_IDX and PAGE_DIR and increment twice while the fetcher
+    /// coalesces their adjacent ranges into a single GET, so this is an upper
+    /// bound on the extra requests, never a one-to-one count. Reading it as
+    /// GETs overstates the cost of a short probe by up to a factor of two,
+    /// which matters because this is the number a probe floor is tightened
+    /// against (issue #883, `ravel_query::LOG_SUFFIX_FLOOR_BYTES`). Compare it
+    /// with [`Self::object_store_get_requests`] rather than substituting for
+    /// it.
     /// It is measured against the probe WINDOW, not against cache residency, so
     /// a warm run reports the same value as the cold one even though its GETs
     /// fall.

--- a/crates/ravel-query/src/lib.rs
+++ b/crates/ravel-query/src/lib.rs
@@ -32,7 +32,8 @@ pub use log_fetcher::{
     DEFAULT_LOG_COALESCE_GAP, DEFAULT_LOG_COVERAGE_THRESHOLD, DEFAULT_LOG_MAX_CONCURRENT_GETS,
     DEFAULT_LOG_SUFFIX_LEN, DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD, LOG_SUFFIX_FLOOR_BYTES,
     LOG_SUFFIX_SIZE_DIVISOR, LogFetchError, LogFetchOutput, LogQuery, LogSegmentFetcher,
-    LogSegmentScan, StreamAttrEquals, WHOLE_OBJECT_REQUEST_MULTIPLE, derive_suffix_len,
+    LogSegmentScan, ProbeMissCounter, ProbeMissCounts, ProbePhase, StreamAttrEquals,
+    WHOLE_OBJECT_REQUEST_MULTIPLE, derive_suffix_len,
 };
 pub use phase_accounting::{PhaseAccounting, PhaseAccountingSnapshot, QueryPhase};
 pub use query_admission::{

--- a/crates/ravel-query/src/log_fetcher.rs
+++ b/crates/ravel-query/src/log_fetcher.rs
@@ -48,10 +48,11 @@
 
 use std::collections::HashSet;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::erasure::ErasurePredicate;
 use crate::fetcher::ReadCache;
-use crate::phase_accounting::PhaseAccounting;
+use crate::phase_accounting::{PhaseAccounting, QueryPhase};
 use bytes::Bytes;
 use ravel_cache::{CacheKey, SingleFlightError, Source};
 use ravel_catalog::SegmentRef;
@@ -537,6 +538,10 @@ pub struct LogSegmentFetcher {
     /// The block-range fetcher used for objects above `block_range_threshold`.
     /// Kept in sync with `store`/`cfg`/`cache` by the builders.
     block_range: BlockRangeFetcher,
+    /// Per-phase tail-section probe misses across every read this fetcher has
+    /// served (#883). Shared by every clone, like `block_range`'s GET semaphore,
+    /// and read through [`probe_miss_counter`](Self::probe_miss_counter).
+    probe_misses: ProbeMissCounter,
 }
 
 impl LogSegmentFetcher {
@@ -547,7 +552,36 @@ impl LogSegmentFetcher {
             cache: None,
             block_range_threshold: DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
             block_range: BlockRangeFetcher::new(store),
+            probe_misses: ProbeMissCounter::new(),
         }
+    }
+
+    /// This fetcher's accumulating per-phase probe-miss counter (#883). Clone it
+    /// out before handing the fetcher to whatever will own it, then read
+    /// [`ProbeMissCounter::snapshot`] around each execution to attribute misses
+    /// to that execution; the counter itself never resets.
+    ///
+    /// Survives every builder below, including
+    /// [`with_block_range`](Self::with_block_range), which replaces the
+    /// `BlockRangeFetcher` but not this.
+    #[must_use]
+    pub fn probe_miss_counter(&self) -> ProbeMissCounter {
+        self.probe_misses.clone()
+    }
+
+    /// Record one block-range read's probe misses on both channels that report
+    /// them: the `page_fetch` span field, beside the `s3_requests`/`s3_bytes`
+    /// the same read produced, and this fetcher's [`ProbeMissCounter`] under
+    /// `phase`. Written by one call so the span and the counter cannot drift
+    /// apart into two accounting channels that disagree.
+    fn record_probe_misses(
+        &self,
+        span: &tracing::Span,
+        stats: &BlockRangeStats,
+        phase: ProbePhase,
+    ) {
+        span.record("probe_misses", stats.probe_misses);
+        self.probe_misses.record(phase, stats.probe_misses);
     }
 
     /// Overrides the [`RlogConfig`] used for section-size caps when decoding.
@@ -594,6 +628,18 @@ impl LogSegmentFetcher {
     #[must_use]
     pub fn with_max_concurrent_gets(mut self, n: usize) -> Self {
         self.block_range = self.block_range.with_max_concurrent_gets(n);
+        self
+    }
+
+    /// Pins the block-range fetcher's suffix-probe length
+    /// ([`BlockRangeFetcher::with_suffix_len`]), overriding the per-object
+    /// derivation ([`derive_suffix_len`], #883). This is the seam a measurement
+    /// pass sweeps the probe length through: the probe floor can only be
+    /// tightened against measured [`BlockRangeStats::probe_misses`], and a sweep
+    /// needs to set the window from outside the fetcher.
+    #[must_use]
+    pub fn with_suffix_len(mut self, n: u64) -> Self {
+        self.block_range = self.block_range.with_suffix_len(n);
         self
     }
 
@@ -890,7 +936,14 @@ impl LogSegmentFetcher {
         let all = ColumnSelection::all();
         let result = async {
             let Some(bytes) = self
-                .tenant_bytes(seg_ref, tenant_hash, query, &all, accounting)
+                .tenant_bytes(
+                    seg_ref,
+                    tenant_hash,
+                    query,
+                    &all,
+                    ProbePhase::Scan,
+                    accounting,
+                )
                 .await?
             else {
                 return Ok(None);
@@ -952,7 +1005,14 @@ impl LogSegmentFetcher {
         accounting: &QueryAccounting,
     ) -> Result<Option<LogSegmentScan>, LogFetchError> {
         let Some(bytes) = self
-            .tenant_bytes(seg_ref, tenant_hash, query, columns, accounting)
+            .tenant_bytes(
+                seg_ref,
+                tenant_hash,
+                query,
+                columns,
+                ProbePhase::Scan,
+                accounting,
+            )
             .await?
         else {
             return Ok(None);
@@ -1155,7 +1215,7 @@ impl LogSegmentFetcher {
                 // not cover, reported alongside the request and byte counts for
                 // this plan phase. A nonzero value here is the extra request a
                 // too-small derivation costs.
-                fetch_span.record("probe_misses", stats.probe_misses);
+                self.record_probe_misses(&fetch_span, &stats, ProbePhase::Plan);
 
                 let refs: Vec<&Predicate> = query.prune.iter().collect();
                 let numeric = field_dir.numeric_range_arms(&refs);
@@ -1189,7 +1249,14 @@ impl LogSegmentFetcher {
             // report can see which queries still pay it.
             let all = ColumnSelection::all();
             let Some(bytes) = self
-                .tenant_bytes(seg_ref, tenant_hash, query, &all, accounting)
+                .tenant_bytes(
+                    seg_ref,
+                    tenant_hash,
+                    query,
+                    &all,
+                    ProbePhase::Plan,
+                    accounting,
+                )
                 .await?
             else {
                 return Ok(None);
@@ -1293,7 +1360,7 @@ impl LogSegmentFetcher {
         fetch_span.record("s3_bytes", stats.block_bytes_fetched);
         // Probe misses (#883): a footer chase here is a probe too short to reach
         // even the footer, reported per phase beside the request/byte counts.
-        fetch_span.record("probe_misses", stats.probe_misses);
+        self.record_probe_misses(&fetch_span, &stats, ProbePhase::Plan);
 
         let n = usize::try_from(footer.block_count).map_err(|_| LogFetchError::Corrupt {
             key: seg_ref.data_object_key.clone(),
@@ -1402,7 +1469,7 @@ impl LogSegmentFetcher {
         fetch_span.record("s3_bytes", stats.block_bytes_fetched);
         // Probe misses (#883): SKIP_IDX not covered by the derived probe window,
         // reported per phase beside the request/byte counts.
-        fetch_span.record("probe_misses", stats.probe_misses);
+        self.record_probe_misses(&fetch_span, &stats, ProbePhase::Plan);
 
         let (ts_min, ts_max) = (query.ts_min_ns, query.ts_max_ns);
         let mut record_count = 0u64;
@@ -1470,7 +1537,15 @@ impl LogSegmentFetcher {
         accounting: &QueryAccounting,
     ) -> Result<Option<LogSegmentScan>, LogFetchError> {
         let Some(bytes) = self
-            .tenant_bytes_with_footer(seg_ref, tenant_hash, query, columns, footer, accounting)
+            .tenant_bytes_with_footer(
+                seg_ref,
+                tenant_hash,
+                query,
+                columns,
+                footer,
+                ProbePhase::Scan,
+                accounting,
+            )
             .await?
         else {
             return Ok(None);
@@ -1494,16 +1569,31 @@ impl LogSegmentFetcher {
     /// the `page_fetch` span and the accounting both entry points share.
     /// `Ok(None)` means the catalog summary proved the object irrelevant and no
     /// GET was issued.
+    ///
+    /// `phase` is which of the caller's phases this read belongs to, for the
+    /// probe-miss charge (#883). It is a parameter rather than a constant
+    /// because this funnel serves both: the scan funnels below reach it as a
+    /// data read, and [`plan_segment`](Self::plan_segment)'s fallback reaches it
+    /// as a planning read for a predicate the skip index cannot decide.
     async fn tenant_bytes(
         &self,
         seg_ref: &SegmentRef,
         tenant_hash: TenantHash,
         query: &LogQuery,
         columns: &ColumnSelection,
+        phase: ProbePhase,
         accounting: &QueryAccounting,
     ) -> Result<Option<Bytes>, LogFetchError> {
-        self.tenant_bytes_with_footer(seg_ref, tenant_hash, query, columns, None, accounting)
-            .await
+        self.tenant_bytes_with_footer(
+            seg_ref,
+            tenant_hash,
+            query,
+            columns,
+            None,
+            phase,
+            accounting,
+        )
+        .await
     }
 
     /// [`tenant_bytes`](Self::tenant_bytes), optionally carrying a plan-phase
@@ -1530,6 +1620,7 @@ impl LogSegmentFetcher {
         query: &LogQuery,
         columns: &ColumnSelection,
         footer: Option<&footer::LogFooter>,
+        phase: ProbePhase,
         accounting: &QueryAccounting,
     ) -> Result<Option<Bytes>, LogFetchError> {
         if !Self::ts_range_relevant(seg_ref, query.ts_min_ns, query.ts_max_ns) {
@@ -1587,9 +1678,9 @@ impl LogSegmentFetcher {
             fetch_span.record("s3_requests", requests);
             fetch_span.record("s3_bytes", stats.block_bytes_fetched);
             // Probe misses (#883): SKIP_IDX/PAGE_DIR (and any footer chase) not
-            // covered by the derived probe window on this scan-phase read,
-            // reported beside the request/byte counts.
-            fetch_span.record("probe_misses", stats.probe_misses);
+            // covered by the derived probe window on this read, reported beside
+            // the request/byte counts and charged to the caller's phase.
+            self.record_probe_misses(&fetch_span, &stats, phase);
             return Ok(Some(bytes));
         }
 
@@ -2065,6 +2156,137 @@ pub struct BlockRangeStats {
     /// one per section: the missed tail sections are adjacent in the object and
     /// are fetched as one coalesced range.
     pub probe_misses: u64,
+}
+
+/// The query phase a tail-section probe miss is charged to (#883).
+///
+/// Only two of [`QueryPhase`]'s four can issue a suffix probe: `Resolve` reads
+/// commit records and `Probe` is the RSEG segment-catalog fetch, neither of
+/// which touches an RLOG object's tail. Naming the two that can, rather than
+/// taking a `QueryPhase` with two impossible arms, keeps the charge total: every
+/// value here maps to a real phase, so a miss can never be recorded against a
+/// phase that issued no request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ProbePhase {
+    /// A probe issued to build a fetch plan: [`LogSegmentFetcher::plan_segment`]
+    /// and [`LogSegmentFetcher::plan_segment_block_stats`], which read the
+    /// footer, SKIP_IDX, and FIELD_DIR and no block byte.
+    Plan,
+    /// A probe issued by a data read: the block/page/chunk fetch behind
+    /// [`LogSegmentFetcher::fetch_accounted_with_tenant`] and
+    /// [`LogSegmentFetcher::scan_accounted_with_tenant`].
+    Scan,
+}
+
+impl ProbePhase {
+    /// This phase in [`QueryPhase`]'s vocabulary, which is what
+    /// `docs/query-engine.md` and the per-phase request and byte counters use.
+    #[must_use]
+    pub fn query_phase(self) -> QueryPhase {
+        match self {
+            ProbePhase::Plan => QueryPhase::Plan,
+            ProbePhase::Scan => QueryPhase::Scan,
+        }
+    }
+
+    /// Lower-case, stable name for a report column or a JSON key, identical to
+    /// [`QueryPhase::name`] for the same phase.
+    #[must_use]
+    pub fn name(self) -> &'static str {
+        self.query_phase().name()
+    }
+}
+
+/// Per-phase tail-section probe misses ([`BlockRangeStats::probe_misses`])
+/// accumulated across every read one [`LogSegmentFetcher`] served (#883).
+///
+/// `BlockRangeStats` reports one read's misses and is dropped at the fetch
+/// boundary, so a caller that measures whole statements -- the SQL latency bench
+/// -- never sees the figure: it reaches `ravel-sql` only as a `tracing` span
+/// field, and nothing aggregates spans into a report. This is the same number on
+/// a channel a caller can read, so a measurement pass can put probe misses
+/// beside the request and byte counts they explain, which is what gates any
+/// tightening of the probe floor ([`LOG_SUFFIX_FLOOR_BYTES`]).
+///
+/// It is an accumulator, not a per-query handle: the counters only ever grow, so
+/// a caller measuring one execution takes a [`snapshot`](Self::snapshot) before
+/// and after and reads [`ProbeMissCounts::saturating_sub`] of the two. Cheap to
+/// clone (one `Arc`), and every clone of the owning `LogSegmentFetcher` shares
+/// the same counters, exactly as its GET semaphore does.
+#[derive(Debug, Clone, Default)]
+pub struct ProbeMissCounter(Arc<ProbeMissInner>);
+
+#[derive(Debug, Default)]
+struct ProbeMissInner {
+    plan: AtomicU64,
+    scan: AtomicU64,
+}
+
+impl ProbeMissCounter {
+    /// New counter with both phases at zero.
+    #[must_use]
+    pub fn new() -> Self {
+        ProbeMissCounter::default()
+    }
+
+    /// Add one read's probe misses to `phase`. `n` is
+    /// [`BlockRangeStats::probe_misses`] verbatim, including zero: a read that
+    /// missed nothing must not be skipped, or the counter would only be written
+    /// on the paths that already have a problem.
+    fn record(&self, phase: ProbePhase, n: u64) {
+        let cell = match phase {
+            ProbePhase::Plan => &self.0.plan,
+            ProbePhase::Scan => &self.0.scan,
+        };
+        cell.fetch_add(n, Ordering::Relaxed);
+    }
+
+    /// Point-in-time copy of both phases' totals.
+    #[must_use]
+    pub fn snapshot(&self) -> ProbeMissCounts {
+        ProbeMissCounts {
+            plan: self.0.plan.load(Ordering::Relaxed),
+            scan: self.0.scan.load(Ordering::Relaxed),
+        }
+    }
+}
+
+/// Point-in-time copy of a [`ProbeMissCounter`]'s per-phase totals (#883).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ProbeMissCounts {
+    /// Misses charged to [`ProbePhase::Plan`].
+    pub plan: u64,
+    /// Misses charged to [`ProbePhase::Scan`].
+    pub scan: u64,
+}
+
+impl ProbeMissCounts {
+    /// Field-wise difference `self - earlier`, the misses one measured
+    /// execution added to a counter that keeps accumulating across executions.
+    /// Saturating: a snapshot pair read out of order reports zero rather than
+    /// wrapping to a huge count that would read as a catastrophic probe miss.
+    #[must_use]
+    pub fn saturating_sub(&self, earlier: &ProbeMissCounts) -> ProbeMissCounts {
+        ProbeMissCounts {
+            plan: self.plan.saturating_sub(earlier.plan),
+            scan: self.scan.saturating_sub(earlier.scan),
+        }
+    }
+
+    /// Misses across both phases.
+    #[must_use]
+    pub fn total(&self) -> u64 {
+        self.plan.saturating_add(self.scan)
+    }
+
+    /// One phase's total, named through [`ProbePhase`] rather than by field.
+    #[must_use]
+    pub fn phase(&self, phase: ProbePhase) -> u64 {
+        match phase {
+            ProbePhase::Plan => self.plan,
+            ProbePhase::Scan => self.scan,
+        }
+    }
 }
 
 /// A [`footer::LogFooter`] a prior plan read produced for this exact (immutable)

--- a/docs/guides/clickbench.md
+++ b/docs/guides/clickbench.md
@@ -539,10 +539,12 @@ warm one. It carries the same object-store and cache figures as `scan` plus
 PAGE_DIR on a version-4 object) that the run's suffix probe did not reach,
 split by the phase that issued the probe.
 
-Read them against `object_store_get_requests`. Each miss is one of those GETs,
-spent because the derived probe was too short for that object's trailer, so a
-run whose GETs rose along with its probe misses paid for the probe length, and
-one whose GETs rose with probe misses flat did not. This is the number that
+Read them against `object_store_get_requests`, and read them as uncovered tail
+SECTIONS rather than as GETs. A short version-4 probe can miss SKIP_IDX and
+PAGE_DIR both, incrementing twice, while the fetcher coalesces their adjacent
+ranges into a single GET -- so the count bounds the extra requests from above
+and never maps one-to-one. A run whose GETs rose alongside its probe misses
+paid for the probe length; one whose GETs rose with probe misses flat did not. This is the number that
 gates any tightening of the probe floor (`LOG_SUFFIX_FLOOR_BYTES`): a change
 that trades probe bytes for requests is a win only if these stay where they
 were. They are measured against the probe window rather than against the read

--- a/docs/guides/clickbench.md
+++ b/docs/guides/clickbench.md
@@ -530,6 +530,27 @@ column paid. A full-window statement over an N-object tenant reads every
 object, because the plan phase reads the whole dataset; issues #693 and #699
 are the two open changes to that. So the figure to compare across runs is bytes
 per second at the reported `host_logical_cores`, not the statement's row count.
+
+### The per-statement `per_run_accounting` block
+
+One entry per run, in run order, so index 0 is the cold run and index 1 the
+warm one. It carries the same object-store and cache figures as `scan` plus
+`probe_misses_plan` and `probe_misses_scan`: tail sections (SKIP_IDX, and
+PAGE_DIR on a version-4 object) that the run's suffix probe did not reach,
+split by the phase that issued the probe.
+
+Read them against `object_store_get_requests`. Each miss is one of those GETs,
+spent because the derived probe was too short for that object's trailer, so a
+run whose GETs rose along with its probe misses paid for the probe length, and
+one whose GETs rose with probe misses flat did not. This is the number that
+gates any tightening of the probe floor (`LOG_SUFFIX_FLOOR_BYTES`): a change
+that trades probe bytes for requests is a win only if these stay where they
+were. They are measured against the probe window rather than against the read
+cache, so the warm run reports the same counts as the cold one; a difference
+between the two runs means the plan shape changed, not that the cache helped.
+The `pmiss` column in the bench's text table is the cold run's two phases
+summed.
+
 ## 6. Through the server (Flight SQL)
 
 Everything above measures the SQL executor as a library, in the bench's own

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -313,7 +313,17 @@ The pieces, and why each is where it is:
   68.8% of above-threshold objects and cost 4,415 extra GETs per predicated
   statement. A probe that still falls short costs one extra GET, not one per
   section: SKIP_IDX and PAGE_DIR are adjacent and are fetched as one range, and
-  `BlockRangeStats::probe_misses` reports the residual rate.
+  `BlockRangeStats::probe_misses` reports the residual rate. That per-read
+  figure is also accumulated per phase on the `LogSegmentFetcher` that served
+  the read (`LogSegmentFetcher::probe_miss_counter`, issue #883), which is how
+  it reaches a caller that measures whole statements: `BlockRangeStats` is
+  dropped at the fetch boundary, and the `page_fetch` span field beside
+  `s3_requests`/`s3_bytes` is not aggregated anywhere. The SQL latency bench
+  reports the difference across one execution under `per_run_accounting` as
+  `probe_misses_plan` and `probe_misses_scan`, so a measurement pass can say
+  which phase's probe spent the extra requests. A miss is measured against the
+  probe *window*, not against cache residency, so a warm run reports the same
+  count as a cold one.
 - STREAM_DIR and FIELD_DIR sit at the object's *front*, so no suffix probe of
   any length reaches them. FIELD_DIR is read only when the query needs it (a
   NumRange arm to resolve, or a projection narrower than every column), and it


### PR DESCRIPTION
feat(bench): surface per-phase probe misses in per-run accounting

`BlockRangeStats::probe_misses` counts tail sections the derived suffix
probe failed to reach, so a probe too small to do its job shows up as the
extra request it costs. It was recorded only into a tracing span, and
nothing aggregates spans into a report, so a measurement pass could not
read it.

That gap has a concrete cost. The v24 pass measured a regression on q37
through q43 -- roughly 1,500 extra GETs each to save ~0.30 GB, about
10,490 requests spent to save 2.1 GB, which at this store's measured
~1.8 MB-per-request exchange rate is a net loss near 9x. `probe_misses`
is precisely the number that says whether the 128 KiB floor is the cause,
and the report did not contain it. A counter living in a span nobody
aggregates is not a measurement.

The figure is now accumulated per phase in an Arc-backed counter a caller
clones before the fetcher moves into an executor, with one helper writing
both the span field and the counter so the two cannot drift into
disagreeing channels. The phase charged is the one that issued the probe:
Plan for the planning reads, Scan for the data reads, and `tenant_bytes`
takes it as a parameter because a whole-object fallback from planning
reaches the same funnel.

It deliberately does NOT travel on the existing `QueryAccounting` funnel,
which is where I first asked for it. Widening that changes
`QueryAccountingSnapshot`, which the distributed read protocol encodes as
a protobuf message -- a frozen contract under CLAUDE.md that would need an
ADR and a version bump. Taking the side channel here is the narrower
change, and the reason is recorded rather than left to be rediscovered.

`ExecutorSettings` also gains `logs_block_range_threshold` and
`logs_suffix_len`, so a pass can sweep the probe window against measured
misses. That is what a change to the floor now has to be validated
against, rather than against bytes alone.

Two bench-level tests pin the counter end to end on exact values, both
with the whole-object crossover disabled so the ranged path's counting is
actually reached -- a fetcher left at its default threshold returns from
the size crossover before those sites run, which made two earlier attempts
at a related test vacuous. Verified they discriminate: neutralising the
recording helper fails the nonzero case with

    cold run: the plan-phase read missed SKIP_IDX exactly once
      left: 0   right: 1

while the zero case correctly still passes.

Verified locally: ravel-bench on the feature lane CLAUDE.md requires
(sql-latency,profiling,flight-lane) plus ravel-query, 79 lib tests and
every integration target.

Refs: #883, #876, #680
