### PR TITLE
test: sweep for wall-clock bands, unpinned randomness and missing proptest seeds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,9 @@ jobs:
   # docs/query-engine.md must still be checked, which a docs_only skip would
   # miss. It is one lightweight runner, not a workspace compile.
   doc-scripts:
+    # The guard only reads the checkout; nothing here needs write scope.
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,12 @@ jobs:
   #     already slipped through once) fails CI instead of merging silently.
   #   - `make test-python` runs the stdlib unittest suite for
   #     scripts/process_metrics.py, which previously had no runner at all.
-  # Both exit non-zero on drift/failure, which fails this job.
+  #   - scripts/guards/check-test-hygiene.sh greps the test sources for the
+  #     three shapes that produce a test which cannot fail: an assertion on
+  #     elapsed real time, an entropy draw with no seed, and a proptest
+  #     regression seed left untracked. Its own cases run first, so a guard
+  #     broken into always-passing fails here rather than going quiet.
+  # All exit non-zero on drift/failure, which fails this job.
   #
   # Deliberately not gated on docs_only and not `needs: changes`: it uses no
   # cargo toolchain and no build, so it is seconds either way, and the
@@ -175,6 +180,10 @@ jobs:
         run: scripts/check-doc-drift.sh
       - name: Check workspace version drift (ADR-0086 D8)
         run: scripts/check-workspace-versions.sh
+      - name: Test-hygiene guard cases
+        run: bash scripts/guards/check-test-hygiene.test.sh
+      - name: Test-hygiene guard (issue #778)
+        run: scripts/guards/check-test-hygiene.sh
       - name: Python script unit tests
         run: make test-python
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: check fmt clippy test test-python doc-drift build minio minio-down demo quickstart quickstart-down kind-up kind-demo kind-down bench audit difftest archmap
+.PHONY: check fmt clippy test test-python test-hygiene doc-drift build minio minio-down demo quickstart quickstart-down kind-up kind-demo kind-down bench audit difftest archmap
 
 check: fmt clippy test
 
@@ -18,6 +18,13 @@ test:
 # `from process_metrics import ...` resolves without a package layout.
 test-python:
 	cd scripts && python3 -m unittest discover -p 'test_*.py' -v
+
+# Grep-shaped hygiene guard over the test sources (issue #778): wall-clock
+# assertions, unseeded randomness, untracked proptest regression seeds. Build
+# free, so run it before a commit that touches tests. Its own cases run first.
+test-hygiene:
+	bash scripts/guards/check-test-hygiene.test.sh
+	./scripts/guards/check-test-hygiene.sh
 
 # Derived counts in docs/query-engine.md's generated conformance block
 # (ADR-0053 decision 6). No build, so it is cheap enough to run before a

--- a/crates/ravel-bench/tests/encode_bench_clone_exclusion.rs
+++ b/crates/ravel-bench/tests/encode_bench_clone_exclusion.rs
@@ -96,6 +96,12 @@ fn clone_is_in_encode_timed_region() {
     // where the writer is far slower and the clone's relative share shrinks;
     // in a `--release` run on aarch64 it was ~12-13%, which the printed line
     // above shows directly.
+    //
+    // hygiene-allow: wall-clock -- the subject of this probe IS the ratio of
+    // two real durations inside criterion's timed region, so there is no
+    // injected-clock form of the claim. It is #[ignore]d and never runs in the
+    // gate, and the threshold is a floor: a slow or loaded host inflates both
+    // measurements together rather than pushing the ratio under it.
     assert!(
         clone_fraction >= 0.005,
         "clone should be a measurable fraction of the timed region, got {:.2}%",
@@ -138,6 +144,10 @@ fn iter_batched_excludes_clone() {
         current_ns as f64 / 1e6,
         fixed_ns as f64 / 1e6
     );
+    // hygiene-allow: wall-clock -- same as the probe above: the claim is that
+    // one measured region is shorter than another, which only real time can
+    // express. #[ignore]d, and both figures are best-of-three over the same
+    // fixture on the same host, so host speed cancels.
     assert!(
         fixed_ns < current_ns,
         "excluding the clone must lower the measured time"

--- a/crates/ravel-cache/Cargo.toml
+++ b/crates/ravel-cache/Cargo.toml
@@ -14,6 +14,10 @@ tokio = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+# test-util for `#[tokio::test(start_paused = true)]`: the single-flight
+# collapse test orders two concurrent fetches by timer, which is deterministic
+# only on a paused clock.
+tokio = { workspace = true, features = ["test-util"] }
 
 [lints]
 workspace = true

--- a/crates/ravel-cache/src/lib.rs
+++ b/crates/ravel-cache/src/lib.rs
@@ -486,7 +486,14 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    /// `start_paused`: the single-flight half below orders two `get_or_fetch`
+    /// calls with `tokio::time::sleep`. On a real clock that ordering is only
+    /// probable -- the second call has to reach the cache inside the first
+    /// call's 15 ms fetch, and a loaded host can starve the task past it, at
+    /// which point the collapse never happens and the count is 0. Paused time
+    /// advances only when every task is idle, so the 1 ms timer always fires
+    /// before the 15 ms one and the interleaving is fixed.
+    #[tokio::test(start_paused = true)]
     async fn counters_match_hand_computed_sequence() {
         let limits = CacheLimits::new(1024 * 1024, 1, 1024 * 1024);
         let cache: Cache<&'static str> = Cache::new(limits);

--- a/crates/ravel-tracing-export/src/tests.rs
+++ b/crates/ravel-tracing-export/src/tests.rs
@@ -317,6 +317,13 @@ async fn an_unreachable_collector_never_blocks_or_errors_the_caller() {
         let _entered = span.enter();
     }
     let emit_elapsed = start.elapsed();
+    // hygiene-allow: wall-clock -- "the caller is not blocked" is a claim about
+    // real time and has no injected-clock form: the timing belongs to the OTel
+    // SDK's BatchSpanProcessor and its HTTP client, neither of which takes a
+    // clock from us. The defect being ruled out is a synchronous connect to the
+    // refused port, which costs seconds; a non-blocking emit costs microseconds,
+    // so the 1 s ceiling sits three orders of magnitude away from both and
+    // scheduling noise cannot flip it either way.
     assert!(
         emit_elapsed < Duration::from_secs(1),
         "emitting a span with an unreachable collector added latency: {emit_elapsed:?}"

--- a/scripts/guards/check-test-hygiene.sh
+++ b/scripts/guards/check-test-hygiene.sh
@@ -250,7 +250,7 @@ FNR == 1 {
 }
 END { if (nlines > 0) scan() }
 '
-xargs -a "${sources_file}" awk "${awk_prog}" >"${findings_file}"
+xargs awk "${awk_prog}" <"${sources_file}" >"${findings_file}"
 
 # --- rule 3 ----------------------------------------------------------------
 #
@@ -285,7 +285,7 @@ done <"${sources_file}"
 # A `failure_persistence` override can switch seed writing off entirely, and
 # then rule 3 has no file to find. Flag every occurrence: there is no
 # legitimate use of it here.
-xargs -a "${sources_file}" grep -Hn 'failure_persistence' 2>/dev/null \
+xargs grep -Hn 'failure_persistence' <"${sources_file}" 2>/dev/null \
   | sed 's/^\([^:]*:[0-9]*\):.*$/\1: proptest-seed: failure_persistence override can disable seed writing; the caught case is then lost/' \
     >>"${findings_file}"
 

--- a/scripts/guards/check-test-hygiene.sh
+++ b/scripts/guards/check-test-hygiene.sh
@@ -1,0 +1,300 @@
+#!/usr/bin/env bash
+# Test-hygiene guard: the three defect shapes CLAUDE.md names under "Testing
+# patterns" as ones that bit twice and therefore become a check rather than
+# another paragraph.
+#
+#   wall-clock    an assertion whose subject is elapsed real time. Flaky on a
+#                 loaded box, vacuous on a fast one. Library logic takes a
+#                 Clock or a now_ns parameter so tests are deterministic.
+#   unseeded-rng  a test drawing from OS entropy. Fails once in a hundred runs
+#                 and is then re-run until green, which is how a real defect
+#                 gets attributed to flakiness.
+#   proptest-seed a proptest regression seed that exists on disk but is not
+#                 tracked by git. proptest writes one when it catches a case;
+#                 uncommitted, the default test command never replays it and
+#                 the same defect is found again at gate time by someone else.
+#
+# Usage:
+#   scripts/guards/check-test-hygiene.sh [path ...]   # default: crates services
+#
+# Exit 0 clean, 1 on findings, 64 on bad usage. Findings print as
+# `file:line: rule: explanation`.
+#
+# Escape hatch, per finding, on the flagged line or anywhere in the comment
+# block immediately above it:
+#
+#   // hygiene-allow: wall-clock -- <reason>
+#   // hygiene-allow: unseeded-rng -- <reason>
+#
+# The reason is for the next reader; the guard only looks for the marker. Use
+# it for a case that genuinely cannot be converted (an #[ignore]d measurement
+# probe whose whole subject is wall time), not to quiet a test that could take
+# an injected clock.
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "${repo_root}" || exit 1
+
+roots=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h | --help)
+      sed -n '2,32p' "$0"
+      exit 0
+      ;;
+    -*)
+      echo "check-test-hygiene.sh: unknown option: $1" >&2
+      exit 64
+      ;;
+    *)
+      roots+=("$1")
+      shift
+      ;;
+  esac
+done
+if [[ ${#roots[@]} -eq 0 ]]; then
+  roots=(crates services)
+fi
+
+findings_file="$(mktemp "${TMPDIR:-/tmp}/ravel-test-hygiene.XXXXXX")"
+sources_file="$(mktemp "${TMPDIR:-/tmp}/ravel-test-hygiene-src.XXXXXX")"
+trap 'rm -f "${findings_file}" "${sources_file}"' EXIT
+
+find "${roots[@]}" -type f -name '*.rs' \
+  -not -path '*/target/*' \
+  -not -path '*/node_modules/*' \
+  | sort >"${sources_file}"
+
+if [[ ! -s "${sources_file}" ]]; then
+  echo "check-test-hygiene.sh: no Rust sources under ${roots[*]}" >&2
+  exit 64
+fi
+
+# --- rules 1 and 2 ---------------------------------------------------------
+#
+# Both need whole-file context, so they share one awk pass per file.
+#
+# The wall-clock rule propagates through assignment: `let d = t0.elapsed();`
+# makes `d` a timing identifier, `let share = d / total;` makes `share` one too,
+# and an assertion naming either is a wall-clock assertion even though it never
+# says `elapsed` itself. That is the usual shape -- the measurement and the
+# assertion sit twenty lines apart with a ratio in between.
+#
+# Both the measurement and the assertion must be in test code for the rule to
+# fire. Production timing code shares identifier names with the report fields a
+# test later asserts the mere presence of, and tainting those names repo-wide
+# turns a presence check into a reported timing band.
+#
+# Propagation is by name within a file, not by scope: a name bound from a
+# measurement in one test and reused for something unrelated in another test in
+# the same file is a false positive. The escape-hatch marker covers it.
+awk_prog='
+function strip_line(s,   out, i, c, n, instr, esc) {
+  # Drop // comments and double-quoted string contents, so paren counting and
+  # identifier matching never see an assertion message.
+  out = ""; instr = 0; esc = 0; n = length(s)
+  for (i = 1; i <= n; i++) {
+    c = substr(s, i, 1)
+    if (instr) {
+      if (esc) { esc = 0; continue }
+      if (c == "\\") { esc = 1; continue }
+      if (c == "\"") { instr = 0 }
+      continue
+    }
+    if (c == "\"") { instr = 1; continue }
+    if (c == "/" && substr(s, i + 1, 1) == "/") break
+    out = out c
+  }
+  return out
+}
+function balance(s,   i, n, c, b) {
+  b = 0; n = length(s)
+  for (i = 1; i <= n; i++) {
+    c = substr(s, i, 1)
+    if (c == "(") b++
+    else if (c == ")") b--
+  }
+  return b
+}
+function has_word(s, w) {
+  return s ~ ("(^|[^A-Za-z0-9_])" w "([^A-Za-z0-9_]|$)")
+}
+function allowed(rule, line,   i) {
+  # The marker sits on the flagged line, or anywhere in the contiguous comment
+  # block immediately above it. Walking the block rather than a fixed number of
+  # lines is what lets the reason be as long as it needs to be.
+  if (index(raw[line], "hygiene-allow: " rule) > 0) return 1
+  for (i = line - 1; i >= 1; i--) {
+    if (raw[i] !~ /^[ \t]*\/\//) return 0
+    if (index(raw[i], "hygiene-allow: " rule) > 0) return 1
+  }
+  return 0
+}
+function report(rule, line, why) {
+  printf "%s:%d: %s: %s\n", curfile, line, rule, why
+}
+function in_test(line) {
+  # Test code: a file under tests/ or benches/, a tests.rs module file, or
+  # anything below the first #[cfg(test)] in a source file (test modules sit at
+  # the bottom by convention here).
+  return is_test_file || (cfg_test_line > 0 && line >= cfg_test_line)
+}
+function scan(   i, j, buf, rawbuf, start, b, id, lhs, rhs, k, parts, ntok, cap, hit, changed, rounds, src) {
+  # Pass A: identifiers holding a wall-clock measurement. Test regions only:
+  # production timing code (a stage timer, a latency histogram feed) shares
+  # names with the fields a test later asserts the mere presence of, and
+  # tainting those names repo-wide flags a presence check as a timing band.
+  for (i = 1; i <= nlines; i++) {
+    if (!in_test(i)) continue
+    if (index(clean[i], ".elapsed()") == 0) continue
+    if (index(clean[i], "=") == 0) continue
+    lhs = substr(clean[i], 1, index(clean[i], "=") - 1)
+    if (lhs ~ /[!<>=]$/) continue          # a comparison, not an assignment
+    gsub(/[^A-Za-z0-9_]+/, " ", lhs)
+    ntok = split(lhs, parts, " ")
+    id = ""
+    if (ntok >= 1 && parts[1] == "let") {
+      for (k = 2; k <= ntok; k++) {
+        if (parts[k] == "mut") continue
+        id = parts[k]
+        break
+      }
+    } else if (ntok >= 1) {
+      id = parts[ntok]
+    }
+    if (id != "" && id !~ /^[0-9]/) timing[id] = 1
+  }
+  # Pass A2: propagate the taint through derived bindings, to a fixpoint. A
+  # measurement is usually not asserted on raw; it is turned into a ratio or a
+  # difference first (`let share = clone_ns / total;`) and that is what the
+  # assertion names.
+  changed = 1
+  rounds = 0
+  while (changed && rounds < 8) {
+    changed = 0; rounds++
+    for (i = 1; i <= nlines; i++) {
+      if (!in_test(i)) continue
+      if (clean[i] !~ /^[ \t]*let[ \t]/) continue
+      if (index(clean[i], "=") == 0) continue
+      lhs = substr(clean[i], 1, index(clean[i], "=") - 1)
+      rhs = substr(clean[i], index(clean[i], "=") + 1)
+      if (lhs ~ /[!<>=]$/) continue
+      gsub(/[^A-Za-z0-9_]+/, " ", lhs)
+      ntok = split(lhs, parts, " ")
+      id = ""
+      for (k = 2; k <= ntok; k++) {
+        if (parts[k] == "mut") continue
+        id = parts[k]
+        break
+      }
+      if (id == "" || id in timing) continue
+      for (src in timing) {
+        if (has_word(rhs, src)) { timing[id] = 1; changed = 1; break }
+      }
+    }
+  }
+  # Pass B: assertion blocks.
+  for (i = 1; i <= nlines; i++) {
+    if (!in_test(i)) continue
+    if (clean[i] !~ /assert[a-z_]*!/) continue
+    if (index(clean[i], "(") == 0) continue
+    start = i
+    buf = substr(clean[i], index(clean[i], "assert"))
+    rawbuf = raw[i]
+    b = balance(buf)
+    cap = 0
+    j = i
+    # An unbalanced capture (a raw string carrying a stray paren, a macro split
+    # oddly) is abandoned rather than guessed at: no finding beats a wrong one.
+    while (b > 0 && cap < 40 && j < nlines) {
+      j++; cap++
+      buf = buf " " clean[j]
+      rawbuf = rawbuf "\n" raw[j]
+      b = balance(buf)
+    }
+    if (b != 0) continue
+    i = j
+    if (index(rawbuf, "hygiene-allow: wall-clock") > 0 || allowed("wall-clock", start)) continue
+    if (index(buf, ".elapsed()") > 0) {
+      report("wall-clock", start, "assertion reads .elapsed(): assert on injected time, or state why real time is the subject")
+      continue
+    }
+    hit = ""
+    for (id in timing) {
+      if (has_word(buf, id)) { hit = id; break }
+    }
+    if (hit != "") {
+      report("wall-clock", start, "assertion reads `" hit "`, which holds a .elapsed() measurement")
+    }
+  }
+  # Pass C: entropy draws in test code.
+  for (i = 1; i <= nlines; i++) {
+    if (!in_test(i)) continue
+    if (clean[i] !~ /rand::rng\(\)|rand::random|thread_rng\(\)|OsRng|from_entropy\(\)|SystemRandom::new\(\)|getrandom/) continue
+    if (allowed("unseeded-rng", i)) continue
+    report("unseeded-rng", i, "test draws from OS entropy: seed it (StdRng::seed_from_u64) so a failure replays")
+  }
+}
+FNR == 1 {
+  if (nlines > 0) scan()
+  delete raw; delete clean; delete timing
+  nlines = 0; cfg_test_line = 0
+  curfile = FILENAME
+  is_test_file = (FILENAME ~ /\/tests\// || FILENAME ~ /\/benches\// || FILENAME ~ /tests\.rs$/)
+}
+{
+  nlines++
+  raw[nlines] = $0
+  clean[nlines] = strip_line($0)
+  if (cfg_test_line == 0 && $0 ~ /#\[cfg\(test\)\]/) cfg_test_line = nlines
+}
+END { if (nlines > 0) scan() }
+'
+xargs -a "${sources_file}" awk "${awk_prog}" >"${findings_file}"
+
+# --- rule 3 ----------------------------------------------------------------
+#
+# proptest's default persistence writes a caught seed next to the source:
+# `<crate>/proptest-regressions/<path under src>.txt` for a property test in
+# `src/`, and `<dir>/<name>.proptest-regressions` for one under `tests/`. Both
+# forms exist in this repo. A seed that exists but is untracked, or that a
+# .gitignore covers, is never replayed by `cargo test`.
+while IFS= read -r src; do
+  grep -q 'proptest!' "${src}" || continue
+  case "${src}" in
+    */src/*)
+      crate_root="${src%%/src/*}"
+      rel="${src#"${crate_root}"/src/}"
+      seed="${crate_root}/proptest-regressions/${rel%.rs}.txt"
+      ;;
+    *)
+      seed="${src%.rs}.proptest-regressions"
+      ;;
+  esac
+  [[ -e "${seed}" ]] || continue
+  # --no-index on purpose: without it git reports nothing for a file already in
+  # the index, so a rule that will silently swallow the NEXT seed written here
+  # stays invisible until it does.
+  if git check-ignore --no-index -q "${seed}" 2>/dev/null; then
+    echo "${seed}:1: proptest-seed: a .gitignore rule covers this path; regression seeds must be committable" >>"${findings_file}"
+  elif ! git ls-files --error-unmatch "${seed}" >/dev/null 2>&1; then
+    echo "${seed}:1: proptest-seed: exists on disk but is untracked; git add it or ${src}'s caught case is never replayed" >>"${findings_file}"
+  fi
+done <"${sources_file}"
+
+# A `failure_persistence` override can switch seed writing off entirely, and
+# then rule 3 has no file to find. Flag every occurrence: there is no
+# legitimate use of it here.
+xargs -a "${sources_file}" grep -Hn 'failure_persistence' 2>/dev/null \
+  | sed 's/^\([^:]*:[0-9]*\):.*$/\1: proptest-seed: failure_persistence override can disable seed writing; the caught case is then lost/' \
+    >>"${findings_file}"
+
+count=$(grep -c '' "${findings_file}")
+if [[ "${count}" -eq 0 ]]; then
+  echo "check-test-hygiene.sh: clean ($(grep -c '' "${sources_file}") Rust sources)"
+  exit 0
+fi
+
+sort -t: -k1,1 -k2,2n "${findings_file}"
+echo "check-test-hygiene.sh: ${count} finding(s)" >&2
+exit 1

--- a/scripts/guards/check-test-hygiene.sh
+++ b/scripts/guards/check-test-hygiene.sh
@@ -293,26 +293,29 @@ done <"${sources_file}"
 # then rule 3 has no file to find. Flag every occurrence: there is no
 # legitimate use of it here.
 persistence_hits="$(mktemp "${TMPDIR:-/tmp}/ravel-test-hygiene-fp.XXXXXX")"
-persistence_status=0
-xargs -0 grep -Hn 'failure_persistence' <"${sources_file}" >"${persistence_hits}" \
-  || persistence_status=$?
-# Exit codes here are genuinely ambiguous and differ between implementations.
-# GNU xargs reports 123 when the utility exited 1-125 on any input, mapping
-# grep's "no match" (1) and its "read error" (2) to one code; BSD xargs was
-# observed propagating grep's own 1 instead. So neither 1 nor 123 identifies a
-# clean result on its own, and treating either as failure breaks the common
-# case of simply finding nothing.
-#
-# What IS unambiguous: 0, 1 and 123 all mean the scan ran. Anything else --
-# a signal, a missing utility, an unreadable list -- means it did not, and the
-# guard must refuse rather than read an empty hit file as clean.
-if [[ "${persistence_status}" -ne 0 \
-   && "${persistence_status}" -ne 1 \
-   && "${persistence_status}" -ne 123 ]]; then
-  echo "check-test-hygiene.sh: the failure_persistence scan failed (exit ${persistence_status})." >&2
-  rm -f "${persistence_hits}"
-  exit 70
-fi
+# grep's own status separates the three outcomes that matter here: 0 matched,
+# 1 nothing matched, 2 could not read. xargs destroys exactly that distinction,
+# because GNU xargs maps every utility exit from 1 to 125 onto a single 123, so
+# an unreadable source is indistinguishable from a clean scan. Call grep
+# directly, in batches to stay under the argument limit, and read its status.
+persistence_sources=()
+while IFS= read -r -d '' persistence_src; do
+  persistence_sources+=("${persistence_src}")
+done <"${sources_file}"
+
+persistence_batch=0
+while [[ "${persistence_batch}" -lt "${#persistence_sources[@]}" ]]; do
+  persistence_status=0
+  grep -Hn 'failure_persistence' \
+    "${persistence_sources[@]:${persistence_batch}:500}" \
+    >>"${persistence_hits}" || persistence_status=$?
+  if [[ "${persistence_status}" -ne 0 && "${persistence_status}" -ne 1 ]]; then
+    echo "check-test-hygiene.sh: the failure_persistence scan failed (grep exit ${persistence_status})." >&2
+    rm -f "${persistence_hits}"
+    exit 70
+  fi
+  persistence_batch=$(( persistence_batch + 500 ))
+done
 sed 's/^\([^:]*:[0-9]*\):.*$/\1: proptest-seed: failure_persistence override can disable seed writing; the caught case is then lost/' \
   <"${persistence_hits}" >>"${findings_file}"
 rm -f "${persistence_hits}"

--- a/scripts/guards/check-test-hygiene.sh
+++ b/scripts/guards/check-test-hygiene.sh
@@ -63,7 +63,7 @@ trap 'rm -f "${findings_file}" "${sources_file}"' EXIT
 find "${roots[@]}" -type f -name '*.rs' \
   -not -path '*/target/*' \
   -not -path '*/node_modules/*' \
-  | sort >"${sources_file}"
+  -print0 | sort -z >"${sources_file}"
 
 if [[ ! -s "${sources_file}" ]]; then
   echo "check-test-hygiene.sh: no Rust sources under ${roots[*]}" >&2
@@ -250,7 +250,14 @@ FNR == 1 {
 }
 END { if (nlines > 0) scan() }
 '
-xargs awk "${awk_prog}" <"${sources_file}" >"${findings_file}"
+scan_status=0
+xargs -0 awk "${awk_prog}" <"${sources_file}" >"${findings_file}" || scan_status=$?
+if [[ "${scan_status}" -ne 0 ]]; then
+  echo "check-test-hygiene.sh: the source scan failed (exit ${scan_status})." >&2
+  echo "  Refusing to report a result: an empty findings file after a failed" >&2
+  echo "  scan is indistinguishable from a clean tree." >&2
+  exit 70
+fi
 
 # --- rule 3 ----------------------------------------------------------------
 #
@@ -259,7 +266,7 @@ xargs awk "${awk_prog}" <"${sources_file}" >"${findings_file}"
 # `src/`, and `<dir>/<name>.proptest-regressions` for one under `tests/`. Both
 # forms exist in this repo. A seed that exists but is untracked, or that a
 # .gitignore covers, is never replayed by `cargo test`.
-while IFS= read -r src; do
+while IFS= read -r -d '' src; do
   grep -q 'proptest!' "${src}" || continue
   case "${src}" in
     */src/*)
@@ -285,13 +292,34 @@ done <"${sources_file}"
 # A `failure_persistence` override can switch seed writing off entirely, and
 # then rule 3 has no file to find. Flag every occurrence: there is no
 # legitimate use of it here.
-xargs grep -Hn 'failure_persistence' <"${sources_file}" 2>/dev/null \
-  | sed 's/^\([^:]*:[0-9]*\):.*$/\1: proptest-seed: failure_persistence override can disable seed writing; the caught case is then lost/' \
-    >>"${findings_file}"
+persistence_hits="$(mktemp "${TMPDIR:-/tmp}/ravel-test-hygiene-fp.XXXXXX")"
+persistence_status=0
+xargs -0 grep -Hn 'failure_persistence' <"${sources_file}" >"${persistence_hits}" \
+  || persistence_status=$?
+# Exit codes here are genuinely ambiguous and differ between implementations.
+# GNU xargs reports 123 when the utility exited 1-125 on any input, mapping
+# grep's "no match" (1) and its "read error" (2) to one code; BSD xargs was
+# observed propagating grep's own 1 instead. So neither 1 nor 123 identifies a
+# clean result on its own, and treating either as failure breaks the common
+# case of simply finding nothing.
+#
+# What IS unambiguous: 0, 1 and 123 all mean the scan ran. Anything else --
+# a signal, a missing utility, an unreadable list -- means it did not, and the
+# guard must refuse rather than read an empty hit file as clean.
+if [[ "${persistence_status}" -ne 0 \
+   && "${persistence_status}" -ne 1 \
+   && "${persistence_status}" -ne 123 ]]; then
+  echo "check-test-hygiene.sh: the failure_persistence scan failed (exit ${persistence_status})." >&2
+  rm -f "${persistence_hits}"
+  exit 70
+fi
+sed 's/^\([^:]*:[0-9]*\):.*$/\1: proptest-seed: failure_persistence override can disable seed writing; the caught case is then lost/' \
+  <"${persistence_hits}" >>"${findings_file}"
+rm -f "${persistence_hits}"
 
 count=$(grep -c '' "${findings_file}")
 if [[ "${count}" -eq 0 ]]; then
-  echo "check-test-hygiene.sh: clean ($(grep -c '' "${sources_file}") Rust sources)"
+  echo "check-test-hygiene.sh: clean ($(tr -cd '\0' <"${sources_file}" | wc -c | tr -d ' ') Rust sources)"
   exit 0
 fi
 

--- a/scripts/guards/check-test-hygiene.test.sh
+++ b/scripts/guards/check-test-hygiene.test.sh
@@ -9,6 +9,14 @@
 # Run: bash scripts/guards/check-test-hygiene.test.sh
 set -uo pipefail
 
+# A developer's ambient git config can change what this suite measures: the
+# guard runs `git check-ignore --no-index` before `git ls-files`, so a global
+# core.excludesFile rule can make the tracked-seed case report a finding that
+# has nothing to do with the fixture. Pin the fixtures to no system or global
+# config so the cases assert the guard, not the host.
+export GIT_CONFIG_NOSYSTEM=1
+export GIT_CONFIG_GLOBAL=/dev/null
+
 HERE="$(cd "$(dirname "$0")" && pwd)"
 GUARD="${HERE}/check-test-hygiene.sh"
 TMP="$(mktemp -d "${TMPDIR:-/tmp}/check-test-hygiene-test.XXXXXX")"
@@ -303,6 +311,30 @@ if [[ "${rc}" == "64" && "${out}" == *"unknown option"* ]]; then
   passes=$((passes + 1))
 else
   printf 'FAIL  an unknown option exits 64: got %s / %s\n' "${rc}" "${out}"
+  fails=$((fails + 1))
+fi
+
+# The two remaining documented usage paths. Both are behaviours the Makefile
+# and CI depend on, and neither was asserted.
+out="$(cd "${d}" && bash scripts/guards/check-test-hygiene.sh --help 2>&1)"
+rc=$?
+if [[ "${rc}" == "0" && "${out}" == *"test-hygiene"* ]]; then
+  printf 'ok    --help prints the header and exits 0\n'
+  passes=$((passes + 1))
+else
+  printf 'FAIL  --help prints the header and exits 0: got %s / %s\n' "${rc}" "${out}"
+  fails=$((fails + 1))
+fi
+
+empty="$(new_repo empty_root)"
+mkdir -p "${empty}/crates"
+out="$(cd "${empty}" && bash scripts/guards/check-test-hygiene.sh crates 2>&1)"
+rc=$?
+if [[ "${rc}" == "64" && "${out}" == *"no Rust sources"* ]]; then
+  printf 'ok    a root with no Rust source exits 64\n'
+  passes=$((passes + 1))
+else
+  printf 'FAIL  a root with no Rust source exits 64: got %s / %s\n' "${rc}" "${out}"
   fails=$((fails + 1))
 fi
 

--- a/scripts/guards/check-test-hygiene.test.sh
+++ b/scripts/guards/check-test-hygiene.test.sh
@@ -1,0 +1,310 @@
+#!/usr/bin/env bash
+# Cases for check-test-hygiene.sh. Add a case here before changing a rule, the
+# way .claude/guards/pretooluse.test.sh works for the hook.
+#
+# Each case builds a throwaway repo under $TMPDIR with the guard copied into
+# its scripts/guards/, so the guard's own `cd repo_root` lands on the fixture
+# and nothing here touches the real checkout.
+#
+# Run: bash scripts/guards/check-test-hygiene.test.sh
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+GUARD="${HERE}/check-test-hygiene.sh"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/check-test-hygiene-test.XXXXXX")"
+trap 'rm -rf "${TMP}"' EXIT
+
+fails=0
+passes=0
+
+# new_repo <name>: a scratch repo with the guard installed. Prints its path.
+new_repo() {
+  local dir="${TMP}/$1"
+  mkdir -p "${dir}/scripts/guards"
+  cp "${GUARD}" "${dir}/scripts/guards/check-test-hygiene.sh"
+  git -C "${dir}" init -q 2>/dev/null
+  git -C "${dir}" config user.email t@example.com
+  git -C "${dir}" config user.name Test
+  printf '%s\n' "${dir}"
+}
+
+# check <name> <repo> <want-exit> <want-substring-or-empty>
+check() {
+  local name="$1" dir="$2" want_rc="$3" want_sub="${4:-}"
+  local out rc=0
+  out="$(cd "${dir}" && bash scripts/guards/check-test-hygiene.sh crates 2>&1)" || rc=$?
+  if [[ "${rc}" != "${want_rc}" ]]; then
+    printf 'FAIL  %s: exit %s, wanted %s\n' "${name}" "${rc}" "${want_rc}"
+    printf '%s\n' "${out}" | sed 's/^/      /'
+    fails=$((fails + 1))
+    return
+  fi
+  if [[ -n "${want_sub}" && "${out}" != *"${want_sub}"* ]]; then
+    printf 'FAIL  %s: output missing %s\n' "${name}" "${want_sub}"
+    printf '%s\n' "${out}" | sed 's/^/      /'
+    fails=$((fails + 1))
+    return
+  fi
+  printf 'ok    %s\n' "${name}"
+  passes=$((passes + 1))
+}
+
+# --- wall-clock ------------------------------------------------------------
+
+d="$(new_repo direct)"
+mkdir -p "${d}/crates/c/tests"
+cat >"${d}/crates/c/tests/t.rs" <<'RS'
+#[test]
+fn t() {
+    let start = Instant::now();
+    work();
+    assert!(start.elapsed() < Duration::from_secs(1), "too slow");
+}
+RS
+check "flags an assert reading .elapsed() directly" "${d}" 1 "tests/t.rs:5: wall-clock"
+
+d="$(new_repo derived)"
+mkdir -p "${d}/crates/c/tests"
+cat >"${d}/crates/c/tests/t.rs" <<'RS'
+#[test]
+fn t() {
+    let t0 = Instant::now();
+    let a = t0.elapsed();
+    let t1 = Instant::now();
+    let b = t1.elapsed();
+    let ratio = a.as_secs_f64() / b.as_secs_f64();
+    assert!(ratio > 2.0, "the fast path must be faster");
+}
+RS
+check "flags an assert on a value derived from a measurement" "${d}" 1 "reads \`ratio\`"
+
+d="$(new_repo allowed)"
+mkdir -p "${d}/crates/c/tests"
+cat >"${d}/crates/c/tests/t.rs" <<'RS'
+#[test]
+fn t() {
+    let start = Instant::now();
+    // hygiene-allow: wall-clock -- an #[ignore]d probe whose subject is wall time
+    assert!(start.elapsed() < Duration::from_secs(1));
+}
+RS
+check "an allow marker on the line above suppresses the finding" "${d}" 0 "clean"
+
+d="$(new_repo allowed-block)"
+mkdir -p "${d}/crates/c/tests"
+cat >"${d}/crates/c/tests/t.rs" <<'RS'
+#[test]
+fn t() {
+    let start = Instant::now();
+    let took = start.elapsed();
+    // hygiene-allow: wall-clock -- the reason runs to several lines, because
+    // the case genuinely cannot take an injected clock: the timing belongs to
+    // a third-party client that accepts no clock from us, and the ceiling is
+    // three orders of magnitude away from both outcomes.
+    assert!(took < Duration::from_secs(1));
+}
+RS
+check "an allow marker earlier in the same comment block suppresses it" "${d}" 0 "clean"
+
+d="$(new_repo allowed-detached)"
+mkdir -p "${d}/crates/c/tests"
+cat >"${d}/crates/c/tests/t.rs" <<'RS'
+#[test]
+fn t() {
+    // hygiene-allow: wall-clock -- detached from the assertion by real code
+    let start = Instant::now();
+    let took = start.elapsed();
+    assert!(took < Duration::from_secs(1));
+}
+RS
+check "a marker separated from the assertion by code does not suppress" "${d}" 1 "wall-clock"
+
+# The regression that made the first draft of this guard noisy: production code
+# times something into a report field, and a test asserts the field's presence.
+# That is not a timing band and must not be flagged.
+d="$(new_repo prod-field)"
+mkdir -p "${d}/crates/c/src"
+cat >"${d}/crates/c/src/lane.rs" <<'RS'
+pub fn run() -> Report {
+    let started = Instant::now();
+    let out = work();
+    let load_wall_ms = started.elapsed().as_secs_f64() * 1000.0;
+    Report { out, load_wall_ms: Some(load_wall_ms) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_load_reports_none() {
+        let report = Report::default();
+        assert_eq!(report.load_wall_ms, None, "no load ran in this invocation");
+    }
+}
+RS
+check "a presence check on a production timing field is not a finding" "${d}" 0 "clean"
+
+# A duration that is data, not elapsed real time.
+d="$(new_repo semantic)"
+mkdir -p "${d}/crates/c/tests"
+cat >"${d}/crates/c/tests/t.rs" <<'RS'
+#[test]
+fn t() {
+    let span = decode();
+    assert_eq!(span.duration_ns, 50, "duration_ns is end - start");
+    assert!(elapsed_ns == 2 * SLOW.as_nanos() as u64);
+}
+RS
+check "a semantic duration field is not a wall-clock band" "${d}" 0 "clean"
+
+# --- unseeded randomness ---------------------------------------------------
+
+d="$(new_repo entropy)"
+mkdir -p "${d}/crates/c/tests"
+cat >"${d}/crates/c/tests/t.rs" <<'RS'
+#[test]
+fn t() {
+    let mut rng = rand::rng();
+    assert!(rng.random::<u64>() > 0);
+}
+RS
+check "flags an entropy draw in a test file" "${d}" 1 "unseeded-rng"
+
+d="$(new_repo seeded)"
+mkdir -p "${d}/crates/c/tests"
+cat >"${d}/crates/c/tests/t.rs" <<'RS'
+#[test]
+fn t() {
+    let mut rng = StdRng::seed_from_u64(0xC0FFEE);
+    assert!(rng.random::<u64>() > 0);
+}
+RS
+check "a seeded rng is clean" "${d}" 0 "clean"
+
+# The sanctioned production seam: entropy above the test module in a src file.
+d="$(new_repo prod-seam)"
+mkdir -p "${d}/crates/c/src"
+cat >"${d}/crates/c/src/rng.rs" <<'RS'
+impl RngSource for SystemRng {
+    fn jitter_ms(&self, max_ms: u64) -> u64 {
+        rand::rng().random_range(0..=max_ms)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn t() {
+        assert_eq!(SystemRng.jitter_ms(0), 0);
+    }
+}
+RS
+check "production entropy above the test module is not a finding" "${d}" 0 "clean"
+
+# --- proptest seeds --------------------------------------------------------
+
+d="$(new_repo seed-untracked)"
+mkdir -p "${d}/crates/c/src" "${d}/crates/c/proptest-regressions"
+cat >"${d}/crates/c/src/codec.rs" <<'RS'
+proptest! {
+    #[test]
+    fn roundtrip(v in any::<u64>()) {
+        prop_assert_eq!(decode(encode(v)), v);
+    }
+}
+RS
+printf 'cc 0102030405060708 # shrinks to v = 0\n' \
+  >"${d}/crates/c/proptest-regressions/codec.txt"
+check "flags a src/ regression seed that is not tracked" "${d}" 1 "proptest-seed"
+
+d="$(new_repo seed-tracked)"
+mkdir -p "${d}/crates/c/src" "${d}/crates/c/proptest-regressions"
+cat >"${d}/crates/c/src/codec.rs" <<'RS'
+proptest! {
+    #[test]
+    fn roundtrip(v in any::<u64>()) {
+        prop_assert_eq!(decode(encode(v)), v);
+    }
+}
+RS
+printf 'cc 0102030405060708 # shrinks to v = 0\n' \
+  >"${d}/crates/c/proptest-regressions/codec.txt"
+git -C "${d}" add -A >/dev/null 2>&1
+git -C "${d}" commit -qm seed >/dev/null 2>&1
+check "a tracked src/ regression seed is clean" "${d}" 0 "clean"
+
+d="$(new_repo seed-tests-dir)"
+mkdir -p "${d}/crates/c/tests"
+cat >"${d}/crates/c/tests/differential.rs" <<'RS'
+proptest! {
+    #[test]
+    fn same(v in any::<u64>()) {
+        prop_assert_eq!(a(v), b(v));
+    }
+}
+RS
+printf 'cc 0102030405060708 # shrinks to v = 0\n' \
+  >"${d}/crates/c/tests/differential.proptest-regressions"
+check "flags an untracked tests/<name>.proptest-regressions" "${d}" 1 \
+  "tests/differential.proptest-regressions"
+
+d="$(new_repo seed-ignored)"
+mkdir -p "${d}/crates/c/tests"
+cat >"${d}/crates/c/tests/differential.rs" <<'RS'
+proptest! {
+    #[test]
+    fn same(v in any::<u64>()) {
+        prop_assert_eq!(a(v), b(v));
+    }
+}
+RS
+printf 'cc 0102030405060708\n' \
+  >"${d}/crates/c/tests/differential.proptest-regressions"
+printf '*.proptest-regressions\n' >"${d}/.gitignore"
+git -C "${d}" add -Af crates .gitignore >/dev/null 2>&1
+git -C "${d}" commit -qm seed >/dev/null 2>&1
+check "flags a tracked-but-gitignored seed" "${d}" 1 "gitignore"
+
+d="$(new_repo no-seed-yet)"
+mkdir -p "${d}/crates/c/src"
+cat >"${d}/crates/c/src/codec.rs" <<'RS'
+proptest! {
+    #[test]
+    fn roundtrip(v in any::<u64>()) {
+        prop_assert_eq!(decode(encode(v)), v);
+    }
+}
+RS
+check "a proptest that has never caught anything is clean" "${d}" 0 "clean"
+
+d="$(new_repo persistence-off)"
+mkdir -p "${d}/crates/c/src"
+cat >"${d}/crates/c/src/codec.rs" <<'RS'
+proptest! {
+    #![proptest_config(ProptestConfig { failure_persistence: None, ..Default::default() })]
+    #[test]
+    fn roundtrip(v in any::<u64>()) {
+        prop_assert_eq!(decode(encode(v)), v);
+    }
+}
+RS
+check "flags a failure_persistence override" "${d}" 1 "failure_persistence"
+
+# --- usage -----------------------------------------------------------------
+
+d="$(new_repo usage)"
+mkdir -p "${d}/crates/c/src"
+: >"${d}/crates/c/src/lib.rs"
+out="$(cd "${d}" && bash scripts/guards/check-test-hygiene.sh --nope 2>&1)"
+rc=$?
+if [[ "${rc}" == "64" && "${out}" == *"unknown option"* ]]; then
+  printf 'ok    an unknown option exits 64\n'
+  passes=$((passes + 1))
+else
+  printf 'FAIL  an unknown option exits 64: got %s / %s\n' "${rc}" "${out}"
+  fails=$((fails + 1))
+fi
+
+printf '\n%d passed, %d failed\n' "${passes}" "${fails}"
+[[ "${fails}" -eq 0 ]]


### PR DESCRIPTION
test: sweep for wall-clock bands, unpinned randomness and missing proptest seeds

CLAUDE.md says a test-hygiene rule that bites twice becomes a check rather
than another paragraph, and names three shapes. This sweeps for them and
then makes the check.

The sweep found one real defect. `counters_match_hand_computed_sequence` in
ravel-cache ordered two concurrent `get_or_fetch` calls with real timers --
a 15 ms fetch racing a 1 ms delayed second caller -- and then asserted
`single_flight_collapses == 1`. That ordering was only probable: a host that
starved the task past 15 ms let the first fetch finish before the second
caller arrived, no collapse happened, and the count was 0. The test asserted
an interleaving the scheduler chose. It now runs under
`#[tokio::test(start_paused = true)]`, where the clock advances only when
every task is idle, so the 1 ms timer always fires inside the 15 ms one and
the interleaving is one the runtime guarantees.

Three assertions genuinely take elapsed real time as their subject and are
annotated with the reason rather than converted -- two `#[ignore]`d
measurement probes whose whole claim is a ratio between two timed regions on
one host, and one asserting that emitting a span with an unreachable
collector does not block the caller, where the timing belongs to the OTel
SDK rather than to any clock we inject.

The guard is `scripts/guards/check-test-hygiene.sh`, with its own case file,
run in CI's build-free job and from `make test-hygiene`. The wall-clock rule
propagates taint from `.elapsed()` through assignment to a fixpoint, so
`let share = clone_ns / total;` followed by `assert!(share >= 0.005)` is
caught even though the assertion never mentions elapsed time. Known false
positives are documented and carry a `// hygiene-allow: <rule> -- <reason>`
escape hatch, and an earlier draft that flagged
`assert_eq!(report.load_wall_ms, None)` was corrected by requiring both the
measurement and the assertion to be in test code.

One fix on top of the sweep, and it is the sort of thing this whole issue is
about. The guard used `xargs -a FILE`, a GNU extension. BSD xargs -- what
macOS ships -- rejects it, prints its usage banner, and exits without running
the utility, so the guard scanned nothing and reported "clean (752 Rust
sources)". Its own case file caught it, five of seventeen cases, but only
when run on such a machine; CI is Linux, where the GNU form works, so it
would have shipped as a working guard and been dead exactly where
authoring-time catching is worth the most. Reading the list from stdin works
on both. All 17 cases pass and the tree is genuinely clean rather than
vacuously clean.

Refs: #778
