### PR TITLE
Run the test-hygiene guard in gates.sh

### DIFF
--- a/scripts/gates.sh
+++ b/scripts/gates.sh
@@ -54,6 +54,14 @@ fi
 echo "==> cargo --locked fmt --all --check"
 cargo --locked fmt --all --check
 
+# The test-hygiene shapes CLAUDE.md names under "Testing patterns": a
+# wall-clock assertion, an unseeded rng, an untracked proptest seed. Each
+# costs a gate rerun after the rule was already written down, so it is a
+# check rather than another paragraph. A source scan, no build, so it runs
+# ahead of the expensive lanes and fails at authoring time.
+echo "==> scripts/guards/check-test-hygiene.sh"
+"$(dirname "$0")/guards/check-test-hygiene.sh"
+
 # Match CI's `check` job: it runs `cargo nextest run --workspace
 # --cargo-profile ci`. Use nextest when it is installed so a local run
 # warms the same `ci`-profile artifacts CI reuses; fall back to `cargo


### PR DESCRIPTION
CI's check job runs `scripts/guards/check-test-hygiene.sh`, and so does the Makefile, but `gates.sh` did not. Since `gates.sh` is documented as the local equivalent of the merge gates, a green local run did not imply a green CI run for the three hygiene shapes it detects.

It is a source scan rather than a build, so it runs directly after the format check and ahead of the expensive lanes, and it runs in scoped (`-p`) mode too: the shapes it catches are not confined to the crates a given run names.

Clean on the current tree at 752 Rust sources. Path resolution verified under both a repo-relative and an absolute invocation.