### PR TITLE
Count CodeRabbit's zero-finding walkthrough as a review

### DIFF
--- a/scripts/lib/coderabbit-verdict.jq
+++ b/scripts/lib/coderabbit-verdict.jq
@@ -1,0 +1,26 @@
+# Counts CodeRabbit issue comments that constitute a completed review of the
+# commit in $sha. Shared by pr-review-status.sh and its test so the two cannot
+# drift apart.
+#
+# Two conditions, both required:
+#
+#   the head sha appears in the body -- the walkthrough names the exact commit
+#   range it reviewed, so this is as strict as matching a review's commit_id,
+#   and a walkthrough from before the last push does not count;
+#
+#   a verdict marker appears -- one of the two lines the bot emits only when a
+#   review actually completed. Without this, any bot comment quoting a commit
+#   counts, and a rate-limit notice is not a review. On #788 those notices
+#   carry two 40-hex shas and no verdict marker, and would otherwise clear the
+#   review gate for a PR the bot never reviewed.
+[
+  .[]
+  | select(
+      .user.login == "coderabbitai[bot]"
+      and ((.body // "") | contains($sha))
+      and ((.body // "")
+           | (contains("No actionable comments were generated")
+              or contains("Actionable comments posted")))
+    )
+]
+| length

--- a/scripts/pr-review-status.sh
+++ b/scripts/pr-review-status.sh
@@ -81,6 +81,18 @@ cr_reviews=$(echo "${reviews_json}" | jq --arg sha "${head_sha}" \
 cr_last_state=$(echo "${reviews_json}" | jq -r --arg sha "${head_sha}" \
   '[.[] | select(.user.login=="coderabbitai[bot]" and .commit_id==$sha)] | last | .state // "none"')
 
+# When CodeRabbit finds nothing it posts an ISSUE comment ("No actionable
+# comments were generated in the recent review") and files no formal review at
+# all, so the review count above stays 0 for a PR that was reviewed and came
+# back clean. Counting only reviews therefore held a clean PR indefinitely,
+# which is how a wait-for-the-bot rule gets bypassed rather than followed.
+# The walkthrough names the exact commit range it reviewed, so requiring the
+# head sha in the body keeps this as strict as the commit_id match above: a
+# stale walkthrough from before the last push does not count.
+issue_comments_json="$(gh api "repos/${repo}/issues/${pr}/comments" --paginate | jq -s 'add')"
+cr_walkthroughs=$(echo "${issue_comments_json}" | jq --arg sha "${head_sha}" \
+  '[.[] | select(.user.login=="coderabbitai[bot]" and (.body | contains($sha)))] | length')
+
 # The REST review-comments endpoint carries no resolved/unresolved field
 # (resolution is a review-THREAD concept, GraphQL-only) -- this reports the
 # raw inline-comment count. A nonzero count needs a human/session read of
@@ -99,16 +111,16 @@ fi
 if [[ "${failing}" != "0" ]]; then
   summary="${summary} (${failing_names})"
 fi
-summary="${summary} | CodeRabbit: reviews@head=${cr_reviews} last=${cr_last_state} inline_comments=${cr_comments}"
+summary="${summary} | CodeRabbit: reviews@head=${cr_reviews} walkthroughs@head=${cr_walkthroughs} last=${cr_last_state} inline_comments=${cr_comments}"
 echo "${summary}"
 
 if [[ "${state}" != "OPEN" ]]; then
   echo "  -> PR is ${state}, not open; nothing to merge"
 elif [[ "${merge_state}" == "DIRTY" || "${merge_state}" == "DRAFT" || "${merge_state}" == "BEHIND" ]]; then
   echo "  -> mergeState is ${merge_state}; not mergeable regardless of CI/CodeRabbit state below"
-elif [[ "${cr_reviews}" == "0" ]]; then
+elif [[ "${cr_reviews}" == "0" && "${cr_walkthroughs}" == "0" ]]; then
   echo "  -> no CodeRabbit review against the current head commit yet; do not merge until one lands"
-elif [[ "${cr_last_state}" != "APPROVED" && "${cr_last_state}" != "COMMENTED" ]]; then
+elif [[ "${cr_reviews}" != "0" && "${cr_last_state}" != "APPROVED" && "${cr_last_state}" != "COMMENTED" ]]; then
   echo "  -> CodeRabbit's current-head review state is ${cr_last_state} (need APPROVED or COMMENTED); not clean"
 elif [[ "${failing}" != "0" ]]; then
   echo "  -> CI has failing/cancelled checks; not clean to merge"

--- a/scripts/pr-review-status.sh
+++ b/scripts/pr-review-status.sh
@@ -89,9 +89,18 @@ cr_last_state=$(echo "${reviews_json}" | jq -r --arg sha "${head_sha}" \
 # The walkthrough names the exact commit range it reviewed, so requiring the
 # head sha in the body keeps this as strict as the commit_id match above: a
 # stale walkthrough from before the last push does not count.
+#
+# The sha alone is NOT enough. The bot posts other comment kinds that quote a
+# commit without being a review at all -- a rate-limit notice is the one that
+# bit: on #788 those comments carry two 40-hex shas and zero verdict markers,
+# so keying on the sha alone would have cleared the review gate for a PR the
+# bot had not reviewed. That is the false-CLEAR direction, which is worse than
+# the false-block this whole change set out to fix. So also require a verdict
+# marker: one of the two lines the bot emits only when a review actually
+# completed, whether it found something or nothing.
 issue_comments_json="$(gh api "repos/${repo}/issues/${pr}/comments" --paginate | jq -s 'add')"
 cr_walkthroughs=$(echo "${issue_comments_json}" | jq --arg sha "${head_sha}" \
-  '[.[] | select(.user.login=="coderabbitai[bot]" and (.body | contains($sha)))] | length')
+  -f "$(dirname "$0")/lib/coderabbit-verdict.jq")
 
 # The REST review-comments endpoint carries no resolved/unresolved field
 # (resolution is a review-THREAD concept, GraphQL-only) -- this reports the

--- a/scripts/pr-review-status.test.sh
+++ b/scripts/pr-review-status.test.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Cases for scripts/lib/coderabbit-verdict.jq, the filter that decides whether
+# CodeRabbit has actually reviewed a PR's current head.
+#
+# Fixtures only: no network, no gh. Each case is a comment shape observed on a
+# real PR, named with the PR it came from.
+#
+# Exit 0 all pass, 1 on a failure.
+set -uo pipefail
+
+FILTER="$(dirname "$0")/lib/coderabbit-verdict.jq"
+[[ -r "${FILTER}" ]] || { echo "missing ${FILTER}" >&2; exit 64; }
+
+SHA="0c65a3d3983384d663189257a25cc2d40ca95d32"
+OTHER="1111111111111111111111111111111111111111"
+passes=0
+fails=0
+
+check() {
+  local name="$1" want="$2" json="$3" got
+  got="$(printf '%s' "${json}" | jq --arg sha "${SHA}" -f "${FILTER}")" || got="ERROR"
+  if [[ "${got}" == "${want}" ]]; then
+    printf 'ok    %s\n' "${name}"
+    passes=$((passes + 1))
+  else
+    printf 'FAIL  %s: want %s, got %s\n' "${name}" "${want}" "${got}"
+    fails=$((fails + 1))
+  fi
+}
+
+# The clean case (#893): zero findings, reported as an issue comment, no formal
+# review filed at all. This is what used to be missed, holding a reviewed PR
+# forever.
+check "zero-finding walkthrough at head counts" 1 "$(cat <<EOF
+[{"user":{"login":"coderabbitai[bot]"},
+  "body":"Reviewing files that changed between abc and ${SHA}.\n\nNo actionable comments were generated in the recent review."}]
+EOF
+)"
+
+# A review that DID find things still counts as a review; its findings are
+# gated separately by the inline-comment check.
+check "walkthrough reporting findings counts" 1 "$(cat <<EOF
+[{"user":{"login":"coderabbitai[bot]"},
+  "body":"Actionable comments posted: 6\n\nReviewed up to ${SHA}."}]
+EOF
+)"
+
+# The regression this file exists for (#788): a rate-limit notice quotes the
+# commit but is not a review. Keying on the sha alone counted it and cleared
+# the review gate for a PR the bot never reviewed -- the false-CLEAR direction.
+check "rate-limit notice quoting the sha does NOT count" 0 "$(cat <<EOF
+[{"user":{"login":"coderabbitai[bot]"},
+  "body":"⚠️ Rate limit exceeded\n\n@user has exceeded the limit. Please wait before requesting another review.\n\nCommits: reviewed up to ${SHA}."}]
+EOF
+)"
+
+# A verdict for a DIFFERENT commit is a stale review of code that is no longer
+# the head, exactly as a stale formal review would be.
+check "verdict naming another commit does NOT count" 0 "$(cat <<EOF
+[{"user":{"login":"coderabbitai[bot]"},
+  "body":"Reviewed up to ${OTHER}.\n\nNo actionable comments were generated in the recent review."}]
+EOF
+)"
+
+# Only the bot's own verdicts count; a human quoting the marker does not.
+check "human comment quoting the marker does NOT count" 0 "$(cat <<EOF
+[{"user":{"login":"pmoust"},
+  "body":"CodeRabbit said: No actionable comments were generated, at ${SHA}."}]
+EOF
+)"
+
+# A body-less comment must not blow up the filter.
+check "null body is tolerated" 0 '[{"user":{"login":"coderabbitai[bot]"},"body":null}]'
+
+check "no comments at all" 0 '[]'
+
+printf '\n%d passed, %d failed\n' "${passes}" "${fails}"
+[[ "${fails}" -eq 0 ]]


### PR DESCRIPTION
When CodeRabbit finds nothing it posts an issue comment ("No actionable comments were generated in the recent review") and files no formal review. `pr-review-status.sh` counted only formal reviews at the head commit, so a reviewed-and-clean PR reported `reviews@head=0 -> do not merge until one lands`, permanently.

#893 sat on that signal across several checks while the bot had reviewed its exact head sha two minutes after it opened and found nothing.

The failure direction matters here: this script is the mechanism behind the standing wait-for-CodeRabbit rule, so a state it can never clear doesn't make anyone wait longer — it makes the script the thing to skip.

Detection is keyed on the head sha appearing in the walkthrough body, which names the exact commit range reviewed, so it stays as strict as the existing `commit_id` match. The review-state gate now applies only when a formal review exists. If the walkthrough format ever changes, this reverts to "not reviewed yet", which is the safe direction.

Verified against both shapes: #893 (`walkthroughs@head=1`, clean path) and #895 (`reviews@head=1 last=COMMENTED inline_comments=6`, formal-review path still gated correctly).