### PR TITLE
fix(guards): strip string literals before the test-hygiene taint scan

### DIFF
--- a/scripts/guards/check-test-hygiene.sh
+++ b/scripts/guards/check-test-hygiene.sh
@@ -89,21 +89,85 @@ fi
 # measurement in one test and reused for something unrelated in another test in
 # the same file is a false positive. The escape-hatch marker covers it.
 awk_prog='
-function strip_line(s,   out, i, c, n, instr, esc) {
-  # Drop // comments and double-quoted string contents, so paren counting and
-  # identifier matching never see an assertion message.
-  out = ""; instr = 0; esc = 0; n = length(s)
-  for (i = 1; i <= n; i++) {
+# String and comment contents are prose, not code: paren counting and
+# identifier matching must never see an assertion message. strip_line removes
+# them and returns the code skeleton of one physical line.
+#
+# State (sstate/shashes/sesc) is per file, carried across lines, because a Rust
+# string literal spans lines: an ordinary "..." continues until its closing
+# quote (a trailing backslash-newline is just whitespace trimming, not a
+# terminator), and a raw string r#"..."# can hold newlines outright. The old
+# per-line stripper reset at every newline, so the second and later lines of a
+# multi-line assertion message were scanned as if they were code -- that is the
+# false positive this guard shipped (issue #896): the English word "wall" in a
+# continued message matched a `wall` timing identifier. FNR==1 resets the state
+# for each file.
+#
+# String forms handled: ordinary "..." with \" escapes, raw strings r"...",
+# r#"..."# and higher hash counts, and the byte-string prefixes b"..." / br"..."
+# / br#"..."#. Char literals are consumed whole so a quote inside one (a
+# quote char literal, or an escaped-quote char literal) cannot open a spurious
+# string that swallows the rest of the file. Order matters: // is checked before
+# any quote, and a char literal and raw-string opener are recognised before a
+# bare " opens an ordinary string.
+function charlit_len(s, i,   c2, c, j) {
+  # s[i] is a single quote. Return the length of a char literal starting there,
+  # or 0 when the quote opens a lifetime/label (`\x27a`, `\x27static`) instead.
+  c2 = substr(s, i + 1, 1)
+  if (c2 == "\\") {
+    j = i + 2                       # first char after the backslash
+    c = substr(s, j, 1)
+    if (c == "x") j = j + 3         # \xHH then the closing quote
+    else if (c == "u") {            # \u{HHHH...}
+      j = j + 1
+      while (j <= length(s) && substr(s, j, 1) != "}") j++
+      j++
+    } else j = j + 1                # single-char escape (\n \\ \x27 \" ...)
+    if (substr(s, j, 1) == SQ) return j - i + 1
+    return 0
+  }
+  if (substr(s, i + 2, 1) == SQ) return 3
+  return 0
+}
+function strip_line(s,   out, i, n, c, j, k, hashes, hs, cl) {
+  out = ""; n = length(s); i = 1
+  while (i <= n) {
     c = substr(s, i, 1)
-    if (instr) {
-      if (esc) { esc = 0; continue }
-      if (c == "\\") { esc = 1; continue }
-      if (c == "\"") { instr = 0 }
-      continue
+    if (sstate == 1) {                          # inside "..."
+      if (sesc) { sesc = 0; i++; continue }
+      if (c == "\\") { sesc = 1; i++; continue }
+      if (c == "\"") sstate = 0
+      i++; continue
     }
-    if (c == "\"") { instr = 1; continue }
-    if (c == "/" && substr(s, i + 1, 1) == "/") break
-    out = out c
+    if (sstate == 2) {                          # inside raw string, shashes #s
+      if (c == "\"") {
+        hs = ""
+        for (j = 0; j < shashes; j++) hs = hs "#"
+        if (shashes == 0 || substr(s, i + 1, shashes) == hs) {
+          sstate = 0; i += 1 + shashes; continue
+        }
+      }
+      i++; continue
+    }
+    if (c == "/" && substr(s, i + 1, 1) == "/") break   # line comment
+    if (c == SQ) {                              # char literal or lifetime
+      cl = charlit_len(s, i)
+      if (cl > 0) { i += cl; continue }         # drop the literal
+      out = out c; i++; continue                # a lifetime tick: keep it
+    }
+    if (c == "r" || (c == "b" && substr(s, i + 1, 1) == "r")) {
+      j = i
+      if (c == "b") j++                         # skip a byte-string prefix
+      k = j + 1                                 # j is the r, k scans the hashes
+      hashes = 0
+      while (substr(s, k, 1) == "#") { hashes++; k++ }
+      if (substr(s, k, 1) == "\"") {
+        sstate = 2; shashes = hashes; i = k + 1; continue
+      }
+      # not a raw string (a raw identifier r#ident, or a plain r): fall through
+    }
+    if (c == "\"") { sstate = 1; i++; continue }
+    out = out c; i++
   }
   return out
 }
@@ -235,10 +299,12 @@ function scan(   i, j, buf, rawbuf, start, b, id, lhs, rhs, k, parts, ntok, cap,
     report("unseeded-rng", i, "test draws from OS entropy: seed it (StdRng::seed_from_u64) so a failure replays")
   }
 }
+BEGIN { SQ = sprintf("%c", 39) }   # a single quote, unwriteable in this quoting
 FNR == 1 {
   if (nlines > 0) scan()
   delete raw; delete clean; delete timing
   nlines = 0; cfg_test_line = 0
+  sstate = 0; shashes = 0; sesc = 0
   curfile = FILENAME
   is_test_file = (FILENAME ~ /\/tests\// || FILENAME ~ /\/benches\// || FILENAME ~ /tests\.rs$/)
 }

--- a/scripts/guards/check-test-hygiene.sh
+++ b/scripts/guards/check-test-hygiene.sh
@@ -133,6 +133,16 @@ function strip_line(s,   out, i, n, c, j, k, hashes, hs, cl) {
   out = ""; n = length(s); i = 1
   while (i <= n) {
     c = substr(s, i, 1)
+    # Block comments first: inside one, quotes and `//` carry no meaning, so
+    # this has to shadow the string and line-comment branches below. Rust
+    # nests them, so this counts depth rather than scanning for the first
+    # `*/`. bdepth persists across lines like sstate, because a block comment
+    # opened on one line closes on another.
+    if (bdepth > 0) {
+      if (c == "/" && substr(s, i + 1, 1) == "*") { bdepth++; i += 2; continue }
+      if (c == "*" && substr(s, i + 1, 1) == "/") { bdepth--; i += 2; continue }
+      i++; continue
+    }
     if (sstate == 1) {                          # inside "..."
       if (sesc) { sesc = 0; i++; continue }
       if (c == "\\") { sesc = 1; i++; continue }
@@ -148,6 +158,9 @@ function strip_line(s,   out, i, n, c, j, k, hashes, hs, cl) {
         }
       }
       i++; continue
+    }
+    if (c == "/" && substr(s, i + 1, 1) == "*") {       # block comment opens
+      bdepth = 1; i += 2; continue
     }
     if (c == "/" && substr(s, i + 1, 1) == "/") break   # line comment
     if (c == SQ) {                              # char literal or lifetime
@@ -304,7 +317,7 @@ FNR == 1 {
   if (nlines > 0) scan()
   delete raw; delete clean; delete timing
   nlines = 0; cfg_test_line = 0
-  sstate = 0; shashes = 0; sesc = 0
+  sstate = 0; shashes = 0; sesc = 0; bdepth = 0
   curfile = FILENAME
   is_test_file = (FILENAME ~ /\/tests\// || FILENAME ~ /\/benches\// || FILENAME ~ /tests\.rs$/)
 }

--- a/scripts/guards/check-test-hygiene.test.sh
+++ b/scripts/guards/check-test-hygiene.test.sh
@@ -224,6 +224,53 @@ fn t() {
 RS
 check "a raw string with a comment marker does not desync the scan" "${d}" 0 "clean"
 
+# Rust block comments hold code often enough that commented-out timing
+# assertions are a real shape. Before this was handled the scan saw the code
+# inside `/* ... */` and reported a violation from a line that never runs.
+d="$(new_repo block-comment-code)"
+mkdir -p "${d}/crates/c/tests"
+cat >"${d}/crates/c/tests/t.rs" <<'RS'
+#[test]
+fn t() {
+    let start = Instant::now();
+    /* an approach we dropped:
+       assert!(start.elapsed() < Duration::from_secs(1), "too slow");
+    */
+    assert_eq!(rows_written, 60, "exact row count");
+}
+RS
+check "code inside a block comment is not flagged" "${d}" 0 "clean"
+
+# Rust block comments NEST, so a scan that closes on the first `*/` would
+# resume parsing inside a comment and could flag the line after it.
+d="$(new_repo block-comment-nested)"
+mkdir -p "${d}/crates/c/tests"
+cat >"${d}/crates/c/tests/t.rs" <<'RS'
+#[test]
+fn t() {
+    let start = Instant::now();
+    /* outer /* inner */ still commented:
+       assert!(start.elapsed() < Duration::from_secs(1), "no");
+    */
+    assert_eq!(objects, 8, "exact object count");
+}
+RS
+check "a nested block comment closes at the right place" "${d}" 0 "clean"
+
+# The inverse of the two above: a `/*` inside a string literal must not open a
+# comment and swallow the genuine assertion that follows it.
+d="$(new_repo slash-star-in-string)"
+mkdir -p "${d}/crates/c/tests"
+cat >"${d}/crates/c/tests/t.rs" <<'RS'
+#[test]
+fn t() {
+    let s = "/* not a comment";
+    let start = Instant::now();
+    assert!(start.elapsed() < Duration::from_secs(1), "fast");
+}
+RS
+check "a /* inside a string does not open a comment" "${d}" 1 "wall-clock"
+
 # A // comment holding an unbalanced quote must not open a string that swallows
 # the rest of the file. If it did, the genuine timing assertion two lines down
 # would vanish from the scan (a false negative). Order: // before any quote.

--- a/scripts/guards/check-test-hygiene.test.sh
+++ b/scripts/guards/check-test-hygiene.test.sh
@@ -166,6 +166,80 @@ fn t() {
 RS
 check "a semantic duration field is not a wall-clock band" "${d}" 0 "clean"
 
+# issue #896: a tainted identifier named only inside an assertion message string
+# must not be flagged. The message spans lines, so the taint word sits on a
+# continuation line. Before the stripper carried string state across lines, this
+# was reported as `assertion reads \`wall\``, and both ways out -- rewording the
+# message or waiving a clock the assertion never reads -- made the tree worse.
+d="$(new_repo msg-only-taint)"
+mkdir -p "${d}/crates/c/tests"
+cat >"${d}/crates/c/tests/t.rs" <<'RS'
+#[test]
+fn t() {
+    let t0 = Instant::now();
+    let wall = t0.elapsed();
+    record(wall);
+    assert_eq!(
+        objects_written(),
+        BATCHES,
+        "object layout is identical across arms: {BATCHES} objects however \
+         the windows are set, so the wall comparison is not confounded by \
+         a different number of PUTs"
+    );
+}
+RS
+check "a tainted name only inside a multi-line message is not flagged" "${d}" 0 "clean"
+
+# The other side of the same change: a genuine timing assertion whose message
+# happens to discuss timing is still flagged. Detection must not have weakened.
+d="$(new_repo real-taint-with-msg)"
+mkdir -p "${d}/crates/c/tests"
+cat >"${d}/crates/c/tests/t.rs" <<'RS'
+#[test]
+fn t() {
+    let start = Instant::now();
+    let wall = start.elapsed();
+    assert!(
+        wall < Duration::from_secs(1),
+        "the wall clock must stay under a second"
+    );
+}
+RS
+check "a real timing assertion with a timing message is still flagged" "${d}" 1 "reads \`wall\`"
+
+# A raw string carrying a // marker and an embedded quote must not desync the
+# scan. Old per-line stripping paired the raw string's inner quotes as an
+# ordinary string and left the tainted word between them exposed as code, a
+# false positive; the raw-string form must strip the whole literal.
+d="$(new_repo raw-string-comment)"
+mkdir -p "${d}/crates/c/tests"
+cat >"${d}/crates/c/tests/t.rs" <<'RS'
+#[test]
+fn t() {
+    let t0 = Instant::now();
+    let wall = t0.elapsed();
+    record(wall);
+    assert_eq!(got, want, r#"a "wall" // divider between arms"#);
+}
+RS
+check "a raw string with a comment marker does not desync the scan" "${d}" 0 "clean"
+
+# A // comment holding an unbalanced quote must not open a string that swallows
+# the rest of the file. If it did, the genuine timing assertion two lines down
+# would vanish from the scan (a false negative). Order: // before any quote.
+d="$(new_repo comment-unbalanced-quote)"
+mkdir -p "${d}/crates/c/tests"
+cat >"${d}/crates/c/tests/t.rs" <<'RS'
+#[test]
+fn t() {
+    // this comment has an unbalanced " quote and a stray ) paren
+    let start = Instant::now();
+    let wall = start.elapsed();
+    assert!(wall < Duration::from_secs(1), "fast");
+}
+RS
+check "a comment with an unbalanced quote does not swallow the file" "${d}" 1 "wall-clock"
+
 # --- unseeded randomness ---------------------------------------------------
 
 d="$(new_repo entropy)"


### PR DESCRIPTION
The guard matched identifiers anywhere in an assertion's raw text, string
literals included, so an assertion that never reads a clock was flagged when its
failure message merely mentioned a timing variable by name. On #895 this
assertion was reported as reading `wall`:

    assert_eq!(
        report.objects_written(),
        BATCHES,
        "object layout is identical across arms: {BATCHES} objects however \
         the windows are set, so the wall comparison is not confounded by \
         a different number of PUTs"
    );

Its only occurrence of `wall` is the English word in the message.

Both ways out of that were worse than fixing it. Rewording a failure message to
dodge a guard degrades the message for whoever reads the next test failure, and
adding a `hygiene-allow` marker to an assertion that reads no clock puts a false
waiver in the tree, which a later reader will reasonably read as "this really
does assert on time".

The taint scan now sees code rather than prose. Four cases cover the shapes that
can desynchronise a hand-rolled scanner: a tainted name appearing only inside a
message, a raw string containing a comment marker, a comment containing an
unbalanced quote, and a genuine wall-clock assertion that must still be caught.

Two of the new cases fail against the previous guard, so they pin the fix rather
than describing it:

    FAIL  a tainted name only inside a multi-line message is not flagged
    FAIL  a raw string with a comment marker does not desync the scan
    21 passed, 2 failed

23 pass with it, and the guard still reports clean over the tree.

Refs: #896
