### PR TITLE
perf(sql): skip the ADR-0850 column-stats load when no path can use it

### DIFF
--- a/crates/ravel-catalog/src/catalog.rs
+++ b/crates/ravel-catalog/src/catalog.rs
@@ -137,6 +137,21 @@ fn clone_store_error(err: &StoreError) -> StoreError {
     }
 }
 
+/// One tenant/signal's last-resolved column-statistics object, cached so a
+/// repeated eligible plan reuses it instead of re-fetching the same object
+/// (ADR-0850, issue #888). Keyed for validity by the object's own content hash
+/// (`stats_blake3`) AND the folded HEAD's covered part set (`part_blake3`):
+/// the stats object is bound to the CURRENT folded HEAD, not the pinned query
+/// snapshot, so a fold that changes either value must re-resolve. Every load
+/// still reads HEAD (one GET) to learn the current `(blake3, parts)`, so a
+/// changed fold is always detected; the cache only ever avoids the SECOND GET,
+/// the stats-object fetch, and only when both keys still match.
+struct CachedColumnStats {
+    stats_blake3: [u8; 32],
+    part_blake3: Vec<[u8; 32]>,
+    stats: Arc<LoadedColumnStats>,
+}
+
 /// Listing-based catalog over an object store backend (Phase 1, ADR-0003).
 /// A future compaction phase folds commit records into immutable snapshot
 /// objects behind a CAS'd HEAD pointer; this type's public API does not
@@ -231,6 +246,13 @@ pub struct Catalog {
     /// backwards across callers with skewed clocks, which only ever delays an
     /// eviction, never causes a wrong one.
     tenant_activity: Mutex<HashMap<TenantHash, i64>>,
+    /// Last-resolved column-statistics object per `(tenant, signal)` (ADR-0850,
+    /// issue #888). Consulted in [`Catalog::load_column_stats`] after the HEAD
+    /// GET and before the stats-object GET, so a repeated eligible plan against
+    /// an unchanged folded HEAD reuses the decoded object instead of
+    /// re-fetching it. Swept per tenant by [`Catalog::evict_idle_tenants`]
+    /// alongside the other re-derivable per-tenant caches.
+    column_stats_cache: Mutex<HashMap<(TenantHash, Signal), CachedColumnStats>>,
 }
 
 /// Adapts [`Catalog::guarded_get`] to the provisioning module's
@@ -292,6 +314,7 @@ impl Catalog {
             enforce_provisioning: false,
             provisioning_checked: Mutex::new(HashSet::new()),
             tenant_activity: Mutex::new(HashMap::new()),
+            column_stats_cache: Mutex::new(HashMap::new()),
         })
     }
 
@@ -761,7 +784,45 @@ impl Catalog {
             catalog: self,
             accounting,
         };
-        column_stats_resolve::load_column_stats(&getter, tenant, signal).await
+        // Always read HEAD (one GET): the stats object is bound to the CURRENT
+        // folded HEAD, not the pinned snapshot, so this is the only way to
+        // detect a fold that superseded a cached object (ADR-0850, issue #888).
+        let Some(resolved) =
+            column_stats_resolve::resolve_stats_ref(&getter, tenant, signal).await?
+        else {
+            return Ok(None);
+        };
+        // Reuse the cached object only when its content hash AND the HEAD's
+        // covered part set both still match `resolved`: a changed fold produces
+        // a different `blake3` (a rebuilt object) or a different part set (the
+        // binding a stale object fails), and either misses. This skips the
+        // second GET, the stats-object fetch, and nothing else.
+        let cache_hit = {
+            let cache = self.column_stats_cache.lock();
+            cache.get(&(*tenant, signal)).and_then(|cached| {
+                (cached.stats_blake3 == resolved.blake3
+                    && cached.part_blake3 == resolved.expected_part_blake3)
+                    .then(|| Arc::clone(&cached.stats))
+            })
+        };
+        if let Some(stats) = cache_hit {
+            return Ok(Some((*stats).clone()));
+        }
+        let Some(loaded) =
+            column_stats_resolve::fetch_stats_object(&getter, tenant, &resolved).await?
+        else {
+            return Ok(None);
+        };
+        let stats = Arc::new(loaded);
+        self.column_stats_cache.lock().insert(
+            (*tenant, signal),
+            CachedColumnStats {
+                stats_blake3: resolved.blake3,
+                part_blake3: resolved.expected_part_blake3,
+                stats: Arc::clone(&stats),
+            },
+        );
+        Ok(Some((*stats).clone()))
     }
 
     /// Evict every per-tenant cache outer-map entry for tenants last touched
@@ -806,6 +867,11 @@ impl Catalog {
             self.head_cache.evict_tenant(tenant);
             self.part_cache.evict_tenant(tenant);
             self.postings_cache.evict_tenant(tenant);
+        }
+        if !idle.is_empty() {
+            self.column_stats_cache
+                .lock()
+                .retain(|(tenant, _), _| !idle.contains(tenant));
         }
         idle.len()
     }
@@ -5353,6 +5419,201 @@ mod tests {
             catalog.request_semaphore.available_permits(),
             MAX_CONCURRENT_REQUESTS,
             "every acquired permit was released"
+        );
+    }
+
+    /// Write a folded HEAD plus its `.cstat` object for `Signal::Logs`, whose
+    /// one segment carries a single I64 `status` column with the exact value
+    /// `value` (min == max == `value`, one non-null row). `part_hash` binds the
+    /// HEAD's part set to the stats object; reusing the same `part_hash` across
+    /// calls keeps the part binding fixed so a re-resolve is driven purely by
+    /// the stats object's content hash changing with `value`.
+    async fn install_logs_stats(store: &MemoryStore, part_hash: [u8; 32], value: i64) {
+        let signal = Signal::Logs;
+        let signal_num = signal::to_proto(signal) as u32;
+
+        let segments = vec![ravel_proto::catalog::v1::ColumnStatsSegment {
+            ingest_hour_bucket: 1,
+            shard: 0,
+            writer_id: vec![0xAA; 16],
+            writer_epoch: 1,
+            writer_seq: 1,
+            columns: vec![ravel_proto::catalog::v1::ColumnStat {
+                name: "status".to_string(),
+                declared_type: 2,
+                non_null_count: 1,
+                null_count: 0,
+                min: Some(ravel_proto::catalog::v1::ColumnValue {
+                    kind: Some(ravel_proto::catalog::v1::column_value::Kind::I64(value)),
+                }),
+                max: Some(ravel_proto::catalog::v1::ColumnValue {
+                    kind: Some(ravel_proto::catalog::v1::column_value::Kind::I64(value)),
+                }),
+                dictionary_present: true,
+                dictionary: vec![ravel_proto::catalog::v1::DictEntry {
+                    value: Some(ravel_proto::catalog::v1::ColumnValue {
+                        kind: Some(ravel_proto::catalog::v1::column_value::Kind::I64(value)),
+                    }),
+                    count: 1,
+                }],
+            }],
+        }];
+        let stats_bytes = crate::snapshot_format::encode_column_stats(
+            tenant().0,
+            signal_num,
+            vec![part_hash.to_vec()],
+            &segments,
+        )
+        .expect("encode column stats");
+        let stats_hash = *blake3::hash(&stats_bytes).as_bytes();
+        let stats_key = format!("t/{}/catalog/l/cstat/one.cstat", tenant().to_hex());
+        store
+            .put(
+                &stats_key,
+                Bytes::from(stats_bytes.clone()),
+                PutOptions::default(),
+            )
+            .await
+            .expect("put stats");
+
+        let head = ravel_proto::catalog::v1::SnapshotHead {
+            format_version: crate::snapshot_format::HEAD_FORMAT_VERSION,
+            tenant_hash: tenant().0.to_vec(),
+            signal: signal_num,
+            shard_count: 8,
+            watermark_hour: 10,
+            parts: vec![ravel_proto::catalog::v1::SnapshotPartRef {
+                key: format!("t/{}/catalog/l/snap/empty.csnap", tenant().to_hex()),
+                blake3: part_hash.to_vec(),
+                size: 1,
+                entry_count: 0,
+                watermark_hour: 10,
+                min_hour: 0,
+            }],
+            folder_id: Uuid::new_v4().into_bytes().to_vec(),
+            created_unix_ns: 0,
+            postings: None,
+            shard_generation_count: 1,
+            column_stats: Some(ravel_proto::catalog::v1::SnapshotColumnStatsRef {
+                key: stats_key,
+                blake3: stats_hash.to_vec(),
+                size: stats_bytes.len() as u64,
+                segment_count: 1,
+                part_blake3: vec![part_hash.to_vec()],
+            }),
+        };
+        let head_bytes = crate::snapshot_format::encode_head(&head).expect("encode head");
+        store
+            .put(
+                &crate::fold::head_object_key(&tenant(), signal),
+                Bytes::from(head_bytes),
+                PutOptions::default(),
+            )
+            .await
+            .expect("put head");
+    }
+
+    /// The exact I64 `status` value carried by the one segment of a loaded
+    /// column-stats object built by [`install_logs_stats`].
+    fn loaded_value(loaded: &LoadedColumnStats) -> i64 {
+        let segment = loaded.segments.values().next().expect("one segment");
+        match &segment.columns[0].min.as_ref().expect("min present").kind {
+            Some(ravel_proto::catalog::v1::column_value::Kind::I64(v)) => *v,
+            other => panic!("expected an I64 min, got {other:?}"),
+        }
+    }
+
+    /// Issue #888, deliverable 2: two consecutive loads against an UNCHANGED
+    /// folded HEAD resolve the stats object exactly once. The first load pays
+    /// both GETs (HEAD + `.cstat`); the second re-reads HEAD (one GET, to
+    /// detect a fold) and serves the cached object, skipping the second GET.
+    /// Both return the same statistics.
+    ///
+    /// Pre-cache demonstration: without the cache the second load also fetches
+    /// the stats object, so its accounted GET count is 2, not 1.
+    #[tokio::test]
+    async fn load_column_stats_reuses_cache_on_unchanged_head() {
+        let store = Arc::new(MemoryStore::new());
+        let part_hash = *blake3::hash(b"part-0").as_bytes();
+        install_logs_stats(&store, part_hash, 42).await;
+
+        let catalog = Catalog::new(store.clone(), config(8)).expect("catalog");
+
+        let acc1 = QueryAccounting::new();
+        let first = catalog
+            .load_column_stats(&tenant(), Signal::Logs, &acc1)
+            .await
+            .expect("load ok")
+            .expect("stats present");
+        assert_eq!(
+            acc1.snapshot().s3_requests(AccountedOp::Get),
+            2,
+            "first load pays the HEAD GET and the column-stats GET"
+        );
+
+        let acc2 = QueryAccounting::new();
+        let second = catalog
+            .load_column_stats(&tenant(), Signal::Logs, &acc2)
+            .await
+            .expect("load ok")
+            .expect("stats present");
+        assert_eq!(
+            acc2.snapshot().s3_requests(AccountedOp::Get),
+            1,
+            "unchanged HEAD: only the HEAD GET, the stats object is served from cache"
+        );
+
+        assert_eq!(loaded_value(&first), 42);
+        assert_eq!(
+            loaded_value(&second),
+            42,
+            "the cached object is the same one"
+        );
+    }
+
+    /// Issue #888, deliverable 2: a fold that changes the folded HEAD must
+    /// re-resolve, never serve the superseded object. Because the stats object
+    /// is keyed by its own content hash (not the pinned snapshot), a rewritten
+    /// object gets a new `blake3`, misses the cache, and is re-fetched. The
+    /// reload pays both GETs again and returns the NEW statistics.
+    ///
+    /// A cache keyed by anything a fold does not change (the pinned snapshot,
+    /// say) would return the stale `42` here.
+    #[tokio::test]
+    async fn load_column_stats_rereleases_after_head_change() {
+        let store = Arc::new(MemoryStore::new());
+        let part_hash = *blake3::hash(b"part-0").as_bytes();
+        install_logs_stats(&store, part_hash, 42).await;
+
+        let catalog = Catalog::new(store.clone(), config(8)).expect("catalog");
+
+        let acc1 = QueryAccounting::new();
+        let first = catalog
+            .load_column_stats(&tenant(), Signal::Logs, &acc1)
+            .await
+            .expect("load ok")
+            .expect("stats present");
+        assert_eq!(loaded_value(&first), 42);
+
+        // A new fold: same part set, but the stats object's content changes, so
+        // HEAD now references a different `blake3`.
+        install_logs_stats(&store, part_hash, 99).await;
+
+        let acc2 = QueryAccounting::new();
+        let second = catalog
+            .load_column_stats(&tenant(), Signal::Logs, &acc2)
+            .await
+            .expect("load ok")
+            .expect("stats present");
+        assert_eq!(
+            acc2.snapshot().s3_requests(AccountedOp::Get),
+            2,
+            "a changed HEAD re-resolves: HEAD GET plus a fresh column-stats GET"
+        );
+        assert_eq!(
+            loaded_value(&second),
+            99,
+            "the reload returns the new object, never the cached stale one"
         );
     }
 }

--- a/crates/ravel-catalog/src/catalog.rs
+++ b/crates/ravel-catalog/src/catalog.rs
@@ -775,7 +775,7 @@ impl Catalog {
         tenant: &TenantHash,
         signal: Signal,
         accounting: &QueryAccounting,
-    ) -> Result<Option<LoadedColumnStats>, LoadColumnStatsError> {
+    ) -> Result<Option<Arc<LoadedColumnStats>>, LoadColumnStatsError> {
         // Route every GET through the same semaphore-bounded, accounted funnel
         // (`guarded_get`) every other query read uses, so this path's requests
         // and bytes are credited to `accounting` under `AccountedOp::Get` and
@@ -806,7 +806,7 @@ impl Catalog {
             })
         };
         if let Some(stats) = cache_hit {
-            return Ok(Some((*stats).clone()));
+            return Ok(Some(stats));
         }
         let Some(loaded) =
             column_stats_resolve::fetch_stats_object(&getter, tenant, &resolved).await?
@@ -822,7 +822,7 @@ impl Catalog {
                 stats: Arc::clone(&stats),
             },
         );
-        Ok(Some((*stats).clone()))
+        Ok(Some(stats))
     }
 
     /// Evict every per-tenant cache outer-map entry for tenants last touched

--- a/crates/ravel-catalog/src/catalog.rs
+++ b/crates/ravel-catalog/src/catalog.rs
@@ -250,8 +250,17 @@ pub struct Catalog {
     /// issue #888). Consulted in [`Catalog::load_column_stats`] after the HEAD
     /// GET and before the stats-object GET, so a repeated eligible plan against
     /// an unchanged folded HEAD reuses the decoded object instead of
-    /// re-fetching it. Swept per tenant by [`Catalog::evict_idle_tenants`]
-    /// alongside the other re-derivable per-tenant caches.
+    /// re-fetching it.
+    ///
+    /// Reclamation, stated precisely because the two dimensions differ.
+    /// ENTRY COUNT is bounded by (tenants x signals) and
+    /// [`Catalog::evict_idle_tenants`] removes a tenant's entry once it passes
+    /// the idle TTL. ENTRY SIZE has no budget: a `LoadedColumnStats` holds one
+    /// `ColumnStatsSegment` per live segment, so an ACTIVE tenant's entry grows
+    /// with that tenant and is never reclaimed while it stays active.
+    /// `cache_capacity_per_tenant`, which bounds the sibling decoded caches,
+    /// cannot express this: it is documented in entries and this map holds
+    /// exactly one entry per key. Issue #905 carries the byte budget.
     column_stats_cache: Mutex<HashMap<(TenantHash, Signal), CachedColumnStats>>,
 }
 

--- a/crates/ravel-catalog/src/column_stats_resolve.rs
+++ b/crates/ravel-catalog/src/column_stats_resolve.rs
@@ -55,8 +55,29 @@ pub struct LoadedColumnStats {
     pub part_blake3: Vec<[u8; 32]>,
 }
 
+/// The column-stats object the current folded HEAD points at, resolved from
+/// HEAD alone (one GET) without yet fetching the object itself. Splitting the
+/// load in two lets a caller consult a reuse cache keyed by what actually
+/// identifies the resolved object -- its content hash (`blake3`) plus the
+/// HEAD's covered part set (`expected_part_blake3`, the binding a stale stats
+/// object fails) -- and skip the second GET when both still match a cached
+/// entry. A changed fold produces a different HEAD, hence a different `blake3`
+/// or part set, so it always misses and re-resolves (issue #888).
+#[derive(Clone, Debug)]
+pub(crate) struct ResolvedStatsRef {
+    /// Object key of the `.cstat` object HEAD references.
+    pub key: String,
+    /// Content hash of the referenced object (`SnapshotColumnStatsRef.blake3`),
+    /// the fetch's blake3 gate and the cache's primary key.
+    pub blake3: [u8; 32],
+    /// The covered parts' blake3 hashes, in `SnapshotHead.parts` order. The
+    /// binding this HEAD imposes on the stats object; a fetch (or a cache hit)
+    /// is valid only against this exact part set.
+    pub expected_part_blake3: Vec<[u8; 32]>,
+}
+
 /// A genuinely unparseable HEAD, or an isolation breach, encountered while
-/// loading column statistics: the only conditions [`load_column_stats`]
+/// loading column statistics: the only conditions this path
 /// surfaces as an error rather than degrading to `Ok(None)`.
 #[derive(Debug, thiserror::Error)]
 pub enum LoadColumnStatsError {
@@ -87,27 +108,28 @@ fn head_key(tenant: &TenantHash, signal: Signal) -> String {
     format!("t/{}/catalog/{}/HEAD", tenant.to_hex(), signal.key_prefix())
 }
 
-/// Resolve exact per-segment column statistics for `(tenant, signal)` from
-/// the current folded snapshot HEAD, or `Ok(None)` when no usable
-/// column-stats object exists right now (nothing folded yet, no configured
-/// typed columns, or the last fold's column-stats build/PUT failed).
+/// Read the current folded snapshot HEAD for `(tenant, signal)` and return the
+/// column-stats object it points at, or `Ok(None)` when none exists right now
+/// (nothing folded yet, no configured typed columns, or the last fold's
+/// column-stats build/PUT failed). The first of the two-GET load: it issues
+/// the HEAD GET only, and never fetches the stats object -- that is
+/// [`fetch_stats_object`], so a caller can consult a reuse cache in between.
 ///
-/// Every GET is issued through `getter`, so it is credited to the caller's
+/// The HEAD GET is issued through `getter`, so it is credited to the caller's
 /// [`QueryAccounting`](ravel_types::accounting::QueryAccounting) and bounded
 /// by the catalog request semaphore, the same funnel every other query read
-/// path uses (issue #850). The requests charge to `AccountedOp::Get`.
+/// path uses (issue #850). It charges to `AccountedOp::Get`.
 ///
-/// Metadata-cost: exactly two GETs -- the HEAD and the one column-stats
-/// object. Unlike `load_covering_postings`, this loader fetches no snapshot
-/// part: it needs only each part's blake3 (already carried in
-/// `SnapshotHead.parts`) for the binding check, and callers join against
-/// their own resolved snapshot rather than a rebuilt covered-entry universe.
-/// See the [module docs](self) for the full degrade-to-`Ok(None)` contract.
-pub(crate) async fn load_column_stats(
+/// Unlike `load_covering_postings`, this path fetches no snapshot part: it
+/// needs only each part's blake3 (already carried in `SnapshotHead.parts`) for
+/// the binding check, and callers join against their own resolved snapshot
+/// rather than a rebuilt covered-entry universe. See the [module docs](self)
+/// for the full degrade-to-`Ok(None)` contract.
+pub(crate) async fn resolve_stats_ref(
     getter: &impl AccountedRecordGet,
     tenant: &TenantHash,
     signal: Signal,
-) -> Result<Option<LoadedColumnStats>, LoadColumnStatsError> {
+) -> Result<Option<ResolvedStatsRef>, LoadColumnStatsError> {
     let key = head_key(tenant, signal);
 
     let head_bytes = match getter.accounted_get_full(&key).await {
@@ -122,6 +144,9 @@ pub(crate) async fn load_column_stats(
     let Some(stats_ref) = head.column_stats.clone() else {
         return Ok(None);
     };
+    let Ok(blake3) = <[u8; 32]>::try_from(stats_ref.blake3.as_slice()) else {
+        return Ok(None);
+    };
 
     // The parts are NOT fetched: this loader needs only their blake3 (which
     // HEAD already carries) to bind the stats object to this HEAD's part set.
@@ -130,18 +155,37 @@ pub(crate) async fn load_column_stats(
     // a hard error on the logs query path.
     let mut expected_part_blake3: Vec<[u8; 32]> = Vec::with_capacity(head.parts.len());
     for part_ref in &head.parts {
-        let Ok(blake3) = <[u8; 32]>::try_from(part_ref.blake3.as_slice()) else {
+        let Ok(part_blake3) = <[u8; 32]>::try_from(part_ref.blake3.as_slice()) else {
             return Ok(None);
         };
-        expected_part_blake3.push(blake3);
+        expected_part_blake3.push(part_blake3);
     }
 
-    let data = match getter.accounted_get_full(&stats_ref.key).await {
+    Ok(Some(ResolvedStatsRef {
+        key: stats_ref.key,
+        blake3,
+        expected_part_blake3,
+    }))
+}
+
+/// GET, blake3-verify, tenant-check, part-bind, and decode the object named by
+/// `resolved`. The second GET of the two-GET load; kept separate from
+/// [`resolve_stats_ref`] so a caller can skip it on a reuse-cache hit. Every
+/// degrade-to-`Ok(None)` case from the [module docs](self) is enforced here
+/// against `resolved`'s content hash and part binding, so a cache that keys on
+/// those two values and skips this call gets the identical answer this call
+/// would have produced.
+pub(crate) async fn fetch_stats_object(
+    getter: &impl AccountedRecordGet,
+    tenant: &TenantHash,
+    resolved: &ResolvedStatsRef,
+) -> Result<Option<LoadedColumnStats>, LoadColumnStatsError> {
+    let data = match getter.accounted_get_full(&resolved.key).await {
         Ok(got) => got.data,
         Err(_) => return Ok(None),
     };
     let digest = blake3::hash(&data);
-    if digest.as_bytes().as_slice() != stats_ref.blake3.as_slice() {
+    if *digest.as_bytes() != resolved.blake3 {
         return Ok(None);
     }
 
@@ -153,7 +197,7 @@ pub(crate) async fn load_column_stats(
 
     if decoded.header.tenant_hash != tenant.0.to_vec() {
         return Err(LoadColumnStatsError::TenantHashMismatch {
-            key: stats_ref.key.clone(),
+            key: resolved.key.clone(),
             expected: tenant.to_hex(),
             actual: hex::encode(&decoded.header.tenant_hash),
         });
@@ -168,7 +212,7 @@ pub(crate) async fn load_column_stats(
     let Ok(actual_part_blake3) = actual_part_blake3 else {
         return Ok(None);
     };
-    if actual_part_blake3 != expected_part_blake3 {
+    if actual_part_blake3 != resolved.expected_part_blake3 {
         return Ok(None);
     }
 
@@ -189,6 +233,6 @@ pub(crate) async fn load_column_stats(
 
     Ok(Some(LoadedColumnStats {
         segments,
-        part_blake3: expected_part_blake3,
+        part_blake3: resolved.expected_part_blake3.clone(),
     }))
 }

--- a/crates/ravel-sql/src/executor.rs
+++ b/crates/ravel-sql/src/executor.rs
@@ -622,12 +622,22 @@ impl SqlExecutor {
         // pass costs nothing when the feature is disabled. Classified against
         // `extras.declared` (the same declared columns the real logs provider
         // installs), before it is moved into the table below.
-        let exact_typed_aggregates = if self.config.parallel_final_aggregation {
-            self.classify_exact_typed(tenant_hash, sql, &extras.declared)
+        //
+        // ONE analyzed plan serves both consumers below. Each of them used to
+        // build its own throwaway session and analyze the same SQL, so a logs
+        // query with declared columns planned three times before executing
+        // once. The build happens only when a consumer will read it.
+        let wants_stats_gate = matches!(Self::target_signal(sql), Ok(TargetSignal::Logs))
+            && !extras.declared.is_empty();
+        let analyzed = if self.config.parallel_final_aggregation || wants_stats_gate {
+            self.analyzed_classification_plan(tenant_hash, sql, &extras.declared)
                 .await
         } else {
-            false
+            None
         };
+        // Fail CLOSED, unchanged: an unbuildable plan is not exact-typed.
+        let exact_typed_aggregates = self.config.parallel_final_aggregation
+            && analyzed.as_ref().is_some_and(plan_is_exact_typed);
         // Build the one table the query targets over the snapshot resolved for
         // its signal. `resolve` already resolved `snapshot` against exactly
         // this signal, so the provider and the snapshot always agree.
@@ -669,10 +679,11 @@ impl SqlExecutor {
                     // tenant with no declared columns reading zero objects, and
                     // reproduces the pre-ADR-0850 provider exactly.
                     None
-                } else if !self
-                    .logs_column_stats_eligible(tenant_hash, &snapshot, sql, &extras.declared)
-                    .await
-                {
+                } else if !self.logs_column_stats_eligible(
+                    &snapshot,
+                    analyzed.as_ref(),
+                    &extras.declared,
+                ) {
                     // Issue #888: no metadata-only column path can fire for this
                     // plan (decided from the plan and the resolved snapshot
                     // alone, ahead of the load), so skip the two GETs
@@ -694,7 +705,7 @@ impl SqlExecutor {
                         accounting.clone(),
                     )
                     .with_declared_columns(extras.declared)
-                    .with_column_stats(column_stats.map(Arc::new)),
+                    .with_column_stats(column_stats),
                 ))
             }
             // The spans provider drives `SpanSegmentFetcher::fetch_accounted`
@@ -927,6 +938,13 @@ impl SqlExecutor {
     /// classifies the query as NOT exact, because wrongly admitting an
     /// unclassifiable query could repartition an aggregate this check never
     /// verified.
+    // Test-only since the shared-plan change: the production path composes the
+    // same two pieces inline (`analyzed_classification_plan` then
+    // `plan_is_exact_typed`) against the plan it shares with the column-stats
+    // gate, rather than building a second throwaway session. This composition
+    // is identical to prod's, so the ADR-0094 cases below still exercise the
+    // shipped classification.
+    #[cfg(test)]
     async fn classify_exact_typed(
         &self,
         tenant_hash: TenantHash,
@@ -991,11 +1009,10 @@ impl SqlExecutor {
     /// all are aggregates referencing a declared column. This mirrors exactly
     /// those necessary conditions; anything they cannot prove is left to
     /// decline downstream and still loads here.
-    async fn logs_column_stats_eligible(
+    fn logs_column_stats_eligible(
         &self,
-        tenant_hash: TenantHash,
         snapshot: &Snapshot,
-        sql: &str,
+        analyzed: Option<&LogicalPlan>,
         declared: &[DeclaredColumn],
     ) -> bool {
         // Pending selective erasure (ADR-0064) rejects the ENTIRE query for
@@ -1008,17 +1025,17 @@ impl SqlExecutor {
         // The analyzed logical plan carries both the aggregate shape and the
         // filter conjuncts this check needs. If it cannot be built, fall back
         // to loading (the pre-hoist behavior always loaded).
-        let Some(plan) = self
-            .analyzed_classification_plan(tenant_hash, sql, declared)
-            .await
-        else {
+        // Fail OPEN, unchanged: no plan means keep the load. The caller shares
+        // one analyzed plan with the exact-typed classification rather than
+        // building a second throwaway session for the same SQL.
+        let Some(plan) = analyzed else {
             return true;
         };
         // Every path is an aggregate over a declared column. A non-aggregate
         // (a raw select, a top-N) or an aggregate touching no declared column
         // (a predicate-free `COUNT(*)`, answered from `sample_count` with no
         // column stats) can never consume the loaded object.
-        if !plan_has_aggregate(&plan) || !plan_references_declared(&plan, declared) {
+        if !plan_has_aggregate(plan) || !plan_references_declared(plan, declared) {
             return false;
         }
         // Re-derive the reader pushdown from the plan's filter conjuncts with
@@ -1028,7 +1045,7 @@ impl SqlExecutor {
         // fewer such predicates than the scan ultimately sees, so a match here
         // is real and skipping is safe, while a miss merely loads.
         let mut filters = Vec::new();
-        collect_filter_predicates(&plan, &mut filters);
+        collect_filter_predicates(plan, &mut filters);
         let pushdown = extract_logs(&filters, declared);
         if !pushdown.content.is_empty() || !pushdown.prune.is_empty() {
             return false;

--- a/crates/ravel-sql/src/executor.rs
+++ b/crates/ravel-sql/src/executor.rs
@@ -66,7 +66,7 @@
 //! reserved bytes (crate::memory); partial state is discarded,
 //! never returned (docs/query-engine.md "Budgets").
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
@@ -96,6 +96,7 @@ use crate::cost::{estimate_logs_cost, estimate_metrics_cost, estimate_spans_cost
 use crate::declared::{DeclaredColumn, DeclaredColumnSource, default_declared_source};
 use crate::error::SqlError;
 use crate::logs_provider::LogsTableProvider;
+use crate::logs_pushdown::extract_logs;
 use crate::memory::{CeilingBreach, TenantMemoryAccountant};
 use crate::output::QueryOutput;
 use crate::provider::RavelTableProvider;
@@ -668,6 +669,18 @@ impl SqlExecutor {
                     // tenant with no declared columns reading zero objects, and
                     // reproduces the pre-ADR-0850 provider exactly.
                     None
+                } else if !self
+                    .logs_column_stats_eligible(tenant_hash, &snapshot, sql, &extras.declared)
+                    .await
+                {
+                    // Issue #888: no metadata-only column path can fire for this
+                    // plan (decided from the plan and the resolved snapshot
+                    // alone, ahead of the load), so skip the two GETs
+                    // load_column_stats would issue. A `None` here reproduces
+                    // the pre-ADR-0850 provider exactly, the same as an absent
+                    // stats object would, so every failing-open behavior is
+                    // preserved.
+                    None
                 } else {
                     self.catalog
                         .load_column_stats(&tenant_hash, Signal::Logs, accounting)
@@ -959,6 +972,82 @@ impl SqlExecutor {
             .analyzer()
             .execute_and_check(plan, &config_options, |_, _| {})
             .ok()
+    }
+
+    /// Whether any ADR-0850 metadata-only column-statistics path could fire for
+    /// this logs plan, decided from the plan and the resolved snapshot alone,
+    /// BEFORE the two-GET `load_column_stats` (issue #888). `false` means every
+    /// path is provably out of reach, so the load is pure waste and is skipped;
+    /// the query then answers exactly as an absent stats object would (the
+    /// pre-ADR-0850 provider).
+    ///
+    /// Every branch fails OPEN (returns `true`, keeping the load) on any
+    /// uncertainty, because a false `false` would turn ADR-0850 off for a plan
+    /// that could have used it. The three metadata-only paths -- q07
+    /// `MIN`/`MAX(declared)`, q02 `COUNT(*)` with a residual `declared <> lit`
+    /// filter, q08 `COUNT(*) GROUP BY declared` -- all gate downstream on
+    /// [`crate::logs_scan`]'s `stats_are_exact` (no pending erasure, no content
+    /// or prune predicate, and a ts bound that clips no touched segment) and
+    /// all are aggregates referencing a declared column. This mirrors exactly
+    /// those necessary conditions; anything they cannot prove is left to
+    /// decline downstream and still loads here.
+    async fn logs_column_stats_eligible(
+        &self,
+        tenant_hash: TenantHash,
+        snapshot: &Snapshot,
+        sql: &str,
+        declared: &[DeclaredColumn],
+    ) -> bool {
+        // Pending selective erasure (ADR-0064) rejects the ENTIRE query for
+        // every metadata-only path (safety lemma): a pending erasure removes
+        // rows the precomputed counts/extrema still include. Snapshot-only and
+        // certain, so it is checked first and without building a plan.
+        if !snapshot.pending_erasure.is_empty() {
+            return false;
+        }
+        // The analyzed logical plan carries both the aggregate shape and the
+        // filter conjuncts this check needs. If it cannot be built, fall back
+        // to loading (the pre-hoist behavior always loaded).
+        let Some(plan) = self
+            .analyzed_classification_plan(tenant_hash, sql, declared)
+            .await
+        else {
+            return true;
+        };
+        // Every path is an aggregate over a declared column. A non-aggregate
+        // (a raw select, a top-N) or an aggregate touching no declared column
+        // (a predicate-free `COUNT(*)`, answered from `sample_count` with no
+        // column stats) can never consume the loaded object.
+        if !plan_has_aggregate(&plan) || !plan_references_declared(&plan, declared) {
+            return false;
+        }
+        // Re-derive the reader pushdown from the plan's filter conjuncts with
+        // the SAME extractor the scan uses, so the content/prune/ts decisions
+        // match `stats_are_exact` exactly. A content or prune predicate makes
+        // every path decline; the analyzed (pre-optimizer) plan can only carry
+        // fewer such predicates than the scan ultimately sees, so a match here
+        // is real and skipping is safe, while a miss merely loads.
+        let mut filters = Vec::new();
+        collect_filter_predicates(&plan, &mut filters);
+        let pushdown = extract_logs(&filters, declared);
+        if !pushdown.content.is_empty() || !pushdown.prune.is_empty() {
+            return false;
+        }
+        // A ts bound that clips even one touched segment makes `stats_are_exact`
+        // fail closed. The touched set is the ts-overlapping subset the provider
+        // resolves (`pruned_segments`); a segment fully outside the bound is
+        // pruned away and never reaches the containment check, so it must not
+        // count as a clip here either.
+        let (ts_min, ts_max) = (pushdown.ts_min(), pushdown.ts_max());
+        let clips = snapshot
+            .segments
+            .iter()
+            .filter(|s| LogSegmentFetcher::ts_range_relevant(s, ts_min, ts_max))
+            .any(|s| !(ts_min <= s.min_event_ts_ns && s.max_event_ts_ns <= ts_max));
+        if clips {
+            return false;
+        }
+        true
     }
 
     /// A throwaway [`SessionTable`] over an empty snapshot for `target`,
@@ -1592,6 +1681,55 @@ fn plan_is_exact_typed(plan: &LogicalPlan) -> bool {
     let mut distincts = Vec::new();
     collect_aggregate_exprs(plan, &mut aggregates, &mut distincts);
     aggregates.iter().all(aggregate_node_is_exact) && distincts.iter().all(distinct_node_is_exact)
+}
+
+/// Whether `plan` (analyzed) has any [`LogicalPlan::Aggregate`] node (issue
+/// #888). Every ADR-0850 metadata-only path replaces an `AggregateExec`, so a
+/// plan with no aggregate can never consume column statistics. Reuses
+/// [`collect_aggregate_exprs`]'s reach (inputs plus embedded subquery plans),
+/// so it fails open: an aggregate anywhere counts, even one the metadata rule
+/// would not ultimately match.
+fn plan_has_aggregate(plan: &LogicalPlan) -> bool {
+    let mut aggregates = Vec::new();
+    let mut distincts = Vec::new();
+    collect_aggregate_exprs(plan, &mut aggregates, &mut distincts);
+    !aggregates.is_empty()
+}
+
+/// Whether `plan` references at least one of `declared`'s columns by name
+/// (issue #888). Every ADR-0850 metadata-only path names a declared column: a
+/// `MIN`/`MAX` argument (q07), a `GROUP BY` key (q08), or the `col <> lit`
+/// filter column (q02). A plan naming none can never consume column
+/// statistics -- a predicate-free `COUNT(*)`, for instance, is answered from
+/// `sample_count` with no column stats at all. Recurses inputs the same way
+/// [`collect_filter_predicates`] does; matching by unqualified column name is
+/// intentionally broad (fail open), since a false negative would turn ADR-0850
+/// off for a plan that could use it.
+fn plan_references_declared(plan: &LogicalPlan, declared: &[DeclaredColumn]) -> bool {
+    let names: HashSet<&str> = declared.iter().map(|d| d.key.as_str()).collect();
+    plan_references_names(plan, &names)
+}
+
+fn plan_references_names(plan: &LogicalPlan, names: &HashSet<&str>) -> bool {
+    for expr in plan.expressions() {
+        let mut found = false;
+        // Never errors: the closure only inspects and returns a recursion verb.
+        let _ = expr.apply(|node| {
+            if let Expr::Column(column) = node
+                && names.contains(column.name.as_str())
+            {
+                found = true;
+                return Ok(TreeNodeRecursion::Stop);
+            }
+            Ok(TreeNodeRecursion::Continue)
+        });
+        if found {
+            return true;
+        }
+    }
+    plan.inputs()
+        .iter()
+        .any(|input| plan_references_names(input, names))
 }
 
 /// Classify a DISTINCT node's implicit group keys (ADR-0094 decision 1): a

--- a/crates/ravel-sql/src/executor.rs
+++ b/crates/ravel-sql/src/executor.rs
@@ -1721,6 +1721,24 @@ fn plan_references_names(plan: &LogicalPlan, names: &HashSet<&str>) -> bool {
                 found = true;
                 return Ok(TreeNodeRecursion::Stop);
             }
+            // A subquery's plan hangs off the expression, not off
+            // `plan.inputs()`, so the input recursion below never reaches it.
+            // `collect_aggregate_exprs` descends these three for the same
+            // reason; without the matching descent here the two walks disagree,
+            // and `SELECT (SELECT MIN(status) FROM logs)` would be judged to
+            // name no declared column while being judged to hold an aggregate.
+            let nested = match node {
+                Expr::ScalarSubquery(subquery) => Some(&subquery.subquery),
+                Expr::InSubquery(in_subquery) => Some(&in_subquery.subquery.subquery),
+                Expr::Exists(exists) => Some(&exists.subquery.subquery),
+                _ => None,
+            };
+            if let Some(plan) = nested
+                && plan_references_names(plan, names)
+            {
+                found = true;
+                return Ok(TreeNodeRecursion::Stop);
+            }
             Ok(TreeNodeRecursion::Continue)
         });
         if found {

--- a/crates/ravel-sql/tests/logs_stats_load.rs
+++ b/crates/ravel-sql/tests/logs_stats_load.rs
@@ -1,0 +1,409 @@
+//! Integration tests for the ADR-0850 column-statistics LOAD gate in
+//! `SqlExecutor` (issue #888).
+//!
+//! `plan_pinned` used to issue the two-GET `Catalog::load_column_stats` on
+//! every logs plan with declared typed columns, even ones no metadata-only
+//! path could ever consume. These tests pin the hoisted eligibility decision
+//! by EXACT object-store GET counts through a real [`SqlExecutor`]:
+//!
+//! - a plan that cannot use statistics (no declared column referenced, or a
+//!   content predicate present) issues ZERO GETs: the load is skipped;
+//! - a plan that CAN use statistics still resolves them (exactly the HEAD GET
+//!   and the one column-stats GET) and still answers from catalog metadata
+//!   with no scan. This is the regression the hoist must not cause: skipping
+//!   an eligible plan would silently turn ADR-0850 off.
+//!
+//! The HEAD and `.cstat` objects are built directly with the public
+//! `encode_head`/`encode_column_stats` codecs (no fold runs), exactly as
+//! `ravel-catalog`'s own `load_column_stats` test builds them. The metadata
+//! path never fetches a snapshot part or a data object, so neither needs to
+//! exist: the only reads a metadata-answered eligible query makes are the two
+//! stats GETs.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::sync::Arc;
+
+use datafusion::arrow::array::{Array, Int64Array};
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::physical_plan::displayable;
+use futures::StreamExt;
+use ravel_catalog::{
+    Catalog, CatalogConfig, HEAD_FORMAT_VERSION, SegmentLevel, SegmentRef, Snapshot,
+    encode_column_stats, encode_head,
+};
+use ravel_object_store::memory::MemoryStore;
+use ravel_object_store::{ObjectStoreBackend, PutOptions};
+use ravel_proto::catalog::v1::{
+    ColumnStat, ColumnStatsSegment, ColumnValue, DictEntry, SnapshotColumnStatsRef, SnapshotHead,
+    SnapshotPartRef,
+};
+use ravel_query::{LogSegmentFetcher, SegmentFetcher};
+use ravel_sql::{DeclaredColumn, DeclaredType, SpanSegmentFetcher, SqlConfig, SqlExecutor};
+use ravel_types::accounting::QueryAccounting;
+use ravel_types::{Signal, TenantHash};
+use uuid::Uuid;
+
+mod util;
+use util::CountingStore;
+
+const TENANT: TenantHash = TenantHash([7u8; 16]);
+
+/// The `TypedAttrColumnType::I64` discriminant (`ravel.sys.v1`), carried in
+/// `ColumnStat.declared_type` as `i32`, matching the fold-side convention.
+const DECLARED_TYPE_I64: u32 = 2;
+
+/// A fabricated L0 [`SegmentRef`]; the metadata path never fetches the object,
+/// so `data_object_key` need not name a real object. Only the identity fields
+/// join it to the injected `ColumnStatsSegment`.
+fn seg_ref(seq: u64, sample_count: u64) -> SegmentRef {
+    SegmentRef {
+        data_object_key: format!("logs/seg-{seq}.rlog"),
+        object_size: 1,
+        min_event_ts_ns: 0,
+        max_event_ts_ns: 1_000,
+        ingest_hour_bucket: 0,
+        sample_count,
+        series_count: 0,
+        shard: 0,
+        content_hash: [0u8; 32],
+        writer_id: Uuid::from_u128(1),
+        writer_epoch: 1,
+        writer_seq: seq,
+        created_unix_ns: 0,
+        level: SegmentLevel::L0,
+    }
+}
+
+fn i64_value(v: i64) -> ColumnValue {
+    ColumnValue {
+        kind: Some(ravel_proto::catalog::v1::column_value::Kind::I64(v)),
+    }
+}
+
+/// An exact I64 `ColumnStat` from a value->count dictionary, mirroring the
+/// fold's output: `min`/`max` the dictionary extremes, `non_null_count` the
+/// summed counts, dictionary present.
+fn i64_stat(name: &str, dict: &[(i64, u64)], null_count: u64) -> ColumnStat {
+    let non_null_count: u64 = dict.iter().map(|(_, c)| c).sum();
+    let min = dict.iter().map(|(v, _)| *v).min();
+    let max = dict.iter().map(|(v, _)| *v).max();
+    ColumnStat {
+        name: name.to_string(),
+        declared_type: DECLARED_TYPE_I64,
+        non_null_count,
+        null_count,
+        min: min.map(i64_value),
+        max: max.map(i64_value),
+        dictionary_present: true,
+        dictionary: dict
+            .iter()
+            .map(|(v, c)| DictEntry {
+                value: Some(i64_value(*v)),
+                count: *c,
+            })
+            .collect(),
+    }
+}
+
+fn stats_segment(seg: &SegmentRef, columns: Vec<ColumnStat>) -> ColumnStatsSegment {
+    ColumnStatsSegment {
+        ingest_hour_bucket: seg.ingest_hour_bucket,
+        shard: seg.shard,
+        writer_id: seg.writer_id.as_bytes().to_vec(),
+        writer_epoch: seg.writer_epoch,
+        writer_seq: seg.writer_seq,
+        columns,
+    }
+}
+
+fn snapshot_of(segments: Vec<SegmentRef>) -> Snapshot {
+    Snapshot {
+        segments,
+        segments_pruned: 0,
+        pending_erasure: Vec::new(),
+    }
+}
+
+fn head_key() -> String {
+    format!(
+        "t/{}/catalog/{}/HEAD",
+        TENANT.to_hex(),
+        Signal::Logs.key_prefix()
+    )
+}
+
+/// Write a folded HEAD plus its `.cstat` object into `store`, binding the two
+/// by a shared (arbitrary) part hash, so a subsequent `load_column_stats`
+/// resolves `segments`' statistics. Returns nothing: the objects live in the
+/// store at their canonical keys. No snapshot part or data object is written;
+/// the metadata path fetches neither.
+async fn install_head_and_stats(store: &dyn ObjectStoreBackend, segments: &[ColumnStatsSegment]) {
+    let signal_num = ravel_commit::signal::to_proto(Signal::Logs) as u32;
+    // An arbitrary part hash the HEAD and the stats object agree on. The part
+    // object itself is never fetched by the load, so it is not written.
+    let part_hash = *blake3::hash(b"part-0").as_bytes();
+
+    let stats_bytes = encode_column_stats(TENANT.0, signal_num, vec![part_hash.to_vec()], segments)
+        .expect("encode column stats");
+    let stats_hash = *blake3::hash(&stats_bytes).as_bytes();
+    let stats_key = format!("t/{}/catalog/l/cstat/one.cstat", TENANT.to_hex());
+    store
+        .put(
+            &stats_key,
+            bytes::Bytes::from(stats_bytes.clone()),
+            PutOptions::default(),
+        )
+        .await
+        .expect("put stats");
+
+    let head = SnapshotHead {
+        format_version: HEAD_FORMAT_VERSION,
+        tenant_hash: TENANT.0.to_vec(),
+        signal: signal_num,
+        shard_count: 1,
+        watermark_hour: 10,
+        parts: vec![SnapshotPartRef {
+            key: format!("t/{}/catalog/l/snap/part.csnap", TENANT.to_hex()),
+            blake3: part_hash.to_vec(),
+            size: 1,
+            entry_count: 0,
+            watermark_hour: 10,
+            min_hour: 0,
+        }],
+        folder_id: Uuid::new_v4().into_bytes().to_vec(),
+        created_unix_ns: 0,
+        postings: None,
+        shard_generation_count: 1,
+        column_stats: Some(SnapshotColumnStatsRef {
+            key: stats_key,
+            blake3: stats_hash.to_vec(),
+            size: stats_bytes.len() as u64,
+            segment_count: segments.len() as u32,
+            part_blake3: vec![part_hash.to_vec()],
+        }),
+    };
+    let head_bytes = encode_head(&head).expect("encode head");
+    store
+        .put(
+            &head_key(),
+            bytes::Bytes::from(head_bytes),
+            PutOptions::default(),
+        )
+        .await
+        .expect("put head");
+}
+
+fn executor(store: &Arc<CountingStore>) -> SqlExecutor {
+    let backend: Arc<dyn ObjectStoreBackend> = Arc::clone(store) as Arc<dyn ObjectStoreBackend>;
+    let catalog =
+        Arc::new(Catalog::new(Arc::clone(&backend), CatalogConfig::default()).expect("catalog"));
+    SqlExecutor::new(
+        catalog,
+        SegmentFetcher::new(Arc::clone(&backend)),
+        LogSegmentFetcher::new(Arc::clone(&backend)),
+        SpanSegmentFetcher::new(Arc::clone(&backend)),
+        SqlConfig::default(),
+        1 << 30,
+    )
+}
+
+fn status_col() -> Vec<DeclaredColumn> {
+    vec![DeclaredColumn::new("status", DeclaredType::I64)]
+}
+
+/// The single scalar of a one-column, one-row result batch.
+fn scalar(batches: &[RecordBatch], column: usize) -> Option<i64> {
+    for batch in batches {
+        if batch.num_rows() == 0 {
+            continue;
+        }
+        let arr = batch
+            .column(column)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("int64 column");
+        return if arr.is_null(0) {
+            None
+        } else {
+            Some(arr.value(0))
+        };
+    }
+    None
+}
+
+async fn run(
+    executor: &SqlExecutor,
+    snapshot: Snapshot,
+    sql: &str,
+    declared: &[DeclaredColumn],
+) -> (String, Vec<RecordBatch>) {
+    let accounting = QueryAccounting::new();
+    let pinned = executor
+        .plan_pinned(TENANT, snapshot, sql, &accounting, declared)
+        .await
+        .expect("plan");
+    let plan = pinned.create_physical_plan().await.expect("physical plan");
+    let plan_str = displayable(plan.as_ref()).indent(true).to_string();
+    let mut stream = pinned.execute().await.expect("execute");
+    let mut batches = Vec::new();
+    while let Some(next) = stream.next().await {
+        batches.push(next.expect("batch"));
+    }
+    (plan_str, batches)
+}
+
+/// Deliverable 1, exact ZERO. A predicate-free `COUNT(*)` names no declared
+/// column, so no ADR-0850 path can consume statistics. With `status` declared,
+/// the pre-#888 executor still issued the HEAD GET `load_column_stats` begins
+/// with; the hoist skips the load entirely, so the store sees zero GETs.
+///
+/// Pre-fix demonstration: making `logs_column_stats_eligible` return `true`
+/// unconditionally (equivalently, deleting the `|| !plan_references_declared(
+/// &plan, declared)` clause) fires the load and this becomes 1.
+#[tokio::test]
+async fn ineligible_no_declared_reference_issues_zero_gets() {
+    let store = CountingStore::new(Arc::new(MemoryStore::new()));
+    let executor = executor(&store);
+
+    let (_plan, batches) = run(
+        &executor,
+        snapshot_of(Vec::new()),
+        "SELECT COUNT(*) FROM logs",
+        &status_col(),
+    )
+    .await;
+
+    assert_eq!(
+        scalar(&batches, 0),
+        Some(0),
+        "empty snapshot counts zero rows"
+    );
+    assert_eq!(
+        store.gets(),
+        0,
+        "no metadata-only path can consume stats, so the load must not fire"
+    );
+}
+
+/// Deliverable 1, exact ZERO. A content predicate (`has_word`) makes every
+/// ADR-0850 path decline at `stats_are_exact`, so the hoist skips the load even
+/// though the aggregate names the declared `status` column.
+///
+/// Pre-fix demonstration: deleting the `if !pushdown.content.is_empty() ||
+/// !pushdown.prune.is_empty()` guard fires the load and this becomes 1.
+#[tokio::test]
+async fn ineligible_content_predicate_issues_zero_gets() {
+    let store = CountingStore::new(Arc::new(MemoryStore::new()));
+    let executor = executor(&store);
+
+    let (_plan, _batches) = run(
+        &executor,
+        snapshot_of(Vec::new()),
+        "SELECT min(status) FROM logs WHERE has_word(body, 'timeout')",
+        &status_col(),
+    )
+    .await;
+
+    assert_eq!(
+        store.gets(),
+        0,
+        "a content predicate declines every stats path, so the load must not fire"
+    );
+}
+
+/// Deliverable 1 regression, exact TWO. `MIN`/`MAX(status)` (q07) over a
+/// segment with exact statistics must still resolve the stats (the HEAD GET and
+/// the one `.cstat` GET, exactly two) and still answer from catalog metadata:
+/// the plan carries no `LogsScanExec` and no data object is read.
+///
+/// Pre-fix demonstration: making `logs_column_stats_eligible` return `false`
+/// skips the load, the provider gets no statistics, `partition_statistics`
+/// cannot report exact min/max, and `LogsScanExec` stays in the plan (and the
+/// GET count is not 2).
+#[tokio::test]
+async fn eligible_min_max_answers_from_metadata_with_two_gets() {
+    let store = CountingStore::new(Arc::new(MemoryStore::new()));
+    let seg = seg_ref(1, 5);
+    install_head_and_stats(
+        &*store,
+        &[stats_segment(
+            &seg,
+            vec![i64_stat("status", &[(200, 3), (404, 2)], 0)],
+        )],
+    )
+    .await;
+    let executor = executor(&store);
+
+    let (plan, batches) = run(
+        &executor,
+        snapshot_of(vec![seg]),
+        "SELECT min(status), max(status) FROM logs",
+        &status_col(),
+    )
+    .await;
+
+    assert!(
+        !plan.contains("LogsScanExec"),
+        "min/max must answer from stats, not a scan; plan was:\n{plan}"
+    );
+    assert_eq!(scalar(&batches, 0), Some(200), "min(status)");
+    assert_eq!(scalar(&batches, 1), Some(404), "max(status)");
+    assert_eq!(
+        store.gets(),
+        2,
+        "exactly the HEAD GET and the one column-stats GET; no scan"
+    );
+}
+
+/// Deliverable 1 regression, exact TWO. q02 (`COUNT(*) WHERE status <> 200`)
+/// keeps its `status <> 200` residual filter -- `<>` is NEVER pushed to the
+/// prune channel (`int_range_bounds` declines `NotEq`), so the hoist must not
+/// mistake it for a prune predicate and skip the load. The load fires (two
+/// GETs) and the answer comes from the dictionary with no scan.
+///
+/// Answer: `non_null_count(5) - count(200)(3) = 2`.
+///
+/// Pre-fix demonstration: making `logs_column_stats_eligible` return `false`
+/// leaves `MetadataOnlyExec` out of the plan and re-adds `LogsScanExec`.
+#[tokio::test]
+async fn eligible_not_equal_count_answers_from_metadata_with_two_gets() {
+    let store = CountingStore::new(Arc::new(MemoryStore::new()));
+    let seg = seg_ref(1, 5);
+    install_head_and_stats(
+        &*store,
+        &[stats_segment(
+            &seg,
+            vec![i64_stat("status", &[(200, 3), (404, 2)], 0)],
+        )],
+    )
+    .await;
+    let executor = executor(&store);
+
+    let (plan, batches) = run(
+        &executor,
+        snapshot_of(vec![seg]),
+        "SELECT COUNT(*) FROM logs WHERE status <> 200",
+        &status_col(),
+    )
+    .await;
+
+    assert!(
+        plan.contains("MetadataOnlyExec"),
+        "q02 must answer from the dictionary; plan was:\n{plan}"
+    );
+    assert!(
+        !plan.contains("LogsScanExec"),
+        "q02 must not scan; plan was:\n{plan}"
+    );
+    assert_eq!(
+        scalar(&batches, 0),
+        Some(2),
+        "5 non-null minus 3 with value 200"
+    );
+    assert_eq!(
+        store.gets(),
+        2,
+        "exactly the HEAD GET and the one column-stats GET; no scan"
+    );
+}

--- a/crates/ravel-sql/tests/logs_stats_load.rs
+++ b/crates/ravel-sql/tests/logs_stats_load.rs
@@ -72,6 +72,12 @@ fn seg_ref(seq: u64, sample_count: u64) -> SegmentRef {
         writer_seq: seq,
         created_unix_ns: 0,
         level: SegmentLevel::L0,
+        // The metadata path under test never opens the object, so nothing here
+        // routes on this. Declared as the current logs version anyway, matching
+        // the writer a real ref of this shape would have come from and the
+        // other ravel-sql fixtures, rather than a literal that would be a lie
+        // if anything later did read it.
+        segment_format_version: u32::from(ravel_logseg::footer::VERSION),
     }
 }
 
@@ -349,6 +355,46 @@ async fn eligible_min_max_answers_from_metadata_with_two_gets() {
     );
     assert_eq!(scalar(&batches, 0), Some(200), "min(status)");
     assert_eq!(scalar(&batches, 1), Some(404), "max(status)");
+    assert_eq!(
+        store.gets(),
+        2,
+        "exactly the HEAD GET and the one column-stats GET; no scan"
+    );
+}
+
+/// The declared reference can sit inside a subquery expression rather than the
+/// outer plan. A subquery's plan hangs off the expression, not off
+/// `plan.inputs()`, so an eligibility walk that only recurses inputs misses it
+/// and skips the stats load -- which fails open (the nested aggregate falls
+/// back to scanning) but throws away exactly the case ADR-0850 exists for.
+#[tokio::test]
+async fn eligible_min_max_inside_a_scalar_subquery_still_answers_from_metadata() {
+    let store = CountingStore::new(Arc::new(MemoryStore::new()));
+    let seg = seg_ref(1, 5);
+    install_head_and_stats(
+        &*store,
+        &[stats_segment(
+            &seg,
+            vec![i64_stat("status", &[(200, 3), (404, 2)], 0)],
+        )],
+    )
+    .await;
+    let executor = executor(&store);
+
+    let (plan, batches) = run(
+        &executor,
+        snapshot_of(vec![seg]),
+        "SELECT (SELECT min(status) FROM logs)",
+        &status_col(),
+    )
+    .await;
+
+    assert!(
+        !plan.contains("LogsScanExec"),
+        "a min() inside a scalar subquery must still answer from stats, not a \
+         scan; plan was:\n{plan}"
+    );
+    assert_eq!(scalar(&batches, 0), Some(200), "min(status) via subquery");
     assert_eq!(
         store.gets(),
         2,


### PR DESCRIPTION
The column-statistics load fired on every logs plan with declared typed
columns, issuing two object-store GETs (the folded HEAD and the `.cstat`
object) even on plans no metadata-only path could consume. A 42-statement
ClickBench pass measured a flat 2 GETs and 384 bytes on every warm statement,
including a predicate-free COUNT(*) answered entirely from `sample_count`. The
cost does not scale with rows, bytes, segments or projection: it is fixed
per-plan waste, and it lands hardest on the cheap statements ADR-0850 exists to
make cheap. At the measured 20.95 ms per GET it is about 1.8 s inside the hot
total, and it is what stops that total being the pure-CPU figure earlier
baselines were.

Eligibility is now decided before the load is issued. `SqlExecutor` inspects the
analyzed logical plan and the resolved snapshot and skips when no metadata-only
path can apply: a pending selective erasure, a non-aggregate plan or one naming
no declared column, or a content or prune predicate or a clipping ts bound, all
of which make `stats_are_exact` fail downstream anyway. The reader pushdown is
re-derived with the same `extract_logs` the scan uses, so those decisions match
`stats_are_exact` rather than approximating it. Every branch fails open, keeping
the load on any uncertainty, so an eligible plan still loads and still answers
from metadata and a `None` result reproduces the pre-ADR-0850 provider exactly.

Repeated eligible plans no longer re-resolve the same object. The catalog caches
the last-resolved statistics object per (tenant, signal), keyed by the object's
content hash and the folded HEAD's covered part set. Every load still reads HEAD
to learn the current key, so a fold that supersedes the object is always
detected and re-resolves; the cache only ever skips the second GET. Keying by
the pinned snapshot instead would serve stale statistics after a fold, which is
why it is keyed by what identifies the resolved object rather than by the
snapshot the query pinned.

Tests assert exact request counts: an ineligible plan issues zero GETs; an
eligible plan resolves both and answers from metadata with no scan; two
consecutive loads against an unchanged HEAD resolve the object once, the second
paying only the HEAD GET; and a changed HEAD re-resolves and returns the new
object.

Refs: #888
