### PR TITLE
feat(query): add EngineConfig::logs_request_cost_bytes

### DIFF
--- a/crates/ravel-query/src/config.rs
+++ b/crates/ravel-query/src/config.rs
@@ -167,6 +167,24 @@ pub struct EngineConfig {
     /// mitigation for an operator who hits a regression on the block-range path;
     /// `0` sends every object through it.
     pub logs_block_range_threshold: u64,
+    /// Cost of one object-store round trip, denominated in transfer bytes: a
+    /// saved request is worth this many saved bytes (ADR-0904 decision 1). Like
+    /// `logs_block_range_threshold` this is not an engine limit; it rides here
+    /// because this is the config the server folds its query flags into and
+    /// hands to every fetcher it builds.
+    ///
+    /// A property of the store and the instance (round-trip latency and
+    /// single-stream bandwidth at the fetch concurrency in use), not of the
+    /// RLOG format, which is why it is configurable rather than frozen. One
+    /// value drives three derived decisions in the logs fetch layer, so
+    /// recalibrating the store recalibrates all of them at once: the coalescing
+    /// gap, the pre-probe whole-object crossover, and the projection routing of
+    /// the whole-segment fast path (#887).
+    ///
+    /// Defaults to [`crate::DEFAULT_LOG_REQUEST_COST_BYTES`], whose doc comment
+    /// carries the derivation. Raising it above the largest object a deployment
+    /// writes collapses all three decisions to whole-object reads.
+    pub logs_request_cost_bytes: u64,
 }
 
 impl Default for EngineConfig {
@@ -184,6 +202,25 @@ impl Default for EngineConfig {
             fetch_concurrency: DEFAULT_FETCH_CONCURRENCY,
             default_evaluation_interval: DEFAULT_EVALUATION_INTERVAL,
             logs_block_range_threshold: crate::DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
+            logs_request_cost_bytes: crate::DEFAULT_LOG_REQUEST_COST_BYTES,
         }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_request_cost_is_the_compiled_constant() {
+        assert_eq!(
+            EngineConfig::default().logs_request_cost_bytes,
+            crate::DEFAULT_LOG_REQUEST_COST_BYTES
+        );
+        // The constant itself, not merely "nonzero": the knob ships with the
+        // measured q20 latency break-even and no behavior change (ADR-0904
+        // decision 5).
+        assert_eq!(crate::DEFAULT_LOG_REQUEST_COST_BYTES, 1_887_437);
     }
 }

--- a/crates/ravel-query/src/lib.rs
+++ b/crates/ravel-query/src/lib.rs
@@ -30,10 +30,11 @@ pub use fetcher::{
 pub use log_fetcher::{
     AssemblyBufferStats, BlockRangeFetcher, BlockRangeStats, BlockStatsReport, CarriedFooter,
     ColumnarBlockOutcome, DEFAULT_LOG_COALESCE_GAP, DEFAULT_LOG_COVERAGE_THRESHOLD,
-    DEFAULT_LOG_MAX_CONCURRENT_GETS, DEFAULT_LOG_SUFFIX_LEN, DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
-    LOG_SUFFIX_FLOOR_BYTES, LOG_SUFFIX_SIZE_DIVISOR, LogFetchError, LogFetchOutput, LogQuery,
-    LogSegmentFetcher, LogSegmentScan, ProbeMissCounter, ProbeMissCounts, ProbePhase,
-    StreamAttrEquals, WHOLE_OBJECT_REQUEST_MULTIPLE, derive_suffix_len,
+    DEFAULT_LOG_MAX_CONCURRENT_GETS, DEFAULT_LOG_REQUEST_COST_BYTES, DEFAULT_LOG_SUFFIX_LEN,
+    DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD, LOG_SUFFIX_FLOOR_BYTES, LOG_SUFFIX_SIZE_DIVISOR,
+    LogFetchError, LogFetchOutput, LogQuery, LogSegmentFetcher, LogSegmentScan, ProbeMissCounter,
+    ProbeMissCounts, ProbePhase, StreamAttrEquals, WHOLE_OBJECT_REQUEST_MULTIPLE,
+    derive_suffix_len,
 };
 pub use phase_accounting::{PhaseAccounting, PhaseAccountingSnapshot, QueryPhase};
 pub use query_admission::{


### PR DESCRIPTION
ADR-0904 exposes the logs fetch layer's request-cost constant as an
operator knob, so a deployment can trade object-store GET requests for
transfer bytes according to what its store actually bills. This is the
first of that epic's tasks: the config field only.

DEFAULT_LOG_REQUEST_COST_BYTES (1,887,437, about 1.8 MiB) is the exchange
rate between the two things a range-versus-whole-object decision trades.
It is derived from q20 on in-region S3 from an r6a.4xlarge: 20.95 ms of
occupied permit time per GET, of which about 1.01 ms is payload transfer
at about 90 MB/s, so roughly 95% of each request is round-trip latency.
That makes it a property of the store and the instance rather than of the
RLOG format, which is why it belongs in configuration.

One value drives three derived decisions in the fetch layer: the
coalescing gap, the pre-probe whole-object crossover, and the projection
routing of the whole-segment fast path. They cannot disagree, because
they already read one field.

The field has no caller yet and that is deliberate. Both builders already
carry with_request_cost_bytes and no production code reaches either one;
ADR-0904 keeps the capability and its wiring in separate tasks so the
reachability claim is made by the task that can actually demonstrate it.
The flag that reaches this field lands in 904-3. Nothing in this commit
changes behavior: the default is the compiled constant, so every existing
path computes exactly what it computed before.

The test pins the constant's value rather than asserting it is nonzero,
so a silent change to the shipped default fails here.

Refs: #904
