### PR TITLE
chore(release): prepare 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,82 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.11.0]
+
+The log segment format moves to RLOG v4 and the logs query path becomes
+columnar end to end. Measured on the ClickBench `hits` corpus (12.03 GB, 99.99M
+rows, 42 timed statements on an r6a.4xlarge against in-region S3), the hot total
+falls from 96.40 s to 72.52 s and the cold total from 320.18 s to 222.19 s.
+
+### Added
+
+- **Typed column statistics for logs** (ADR-0850). The fold writes exact
+  per-object statistics for declared columns, and `MIN`/`MAX` over a declared
+  column can be answered from the catalog without opening a segment.
+- **SQL surface**: a fail-closed scalar and window function registry
+  (ADR-0097), `LIKE`/`NOT LIKE` on the logs table with substring pruning
+  (ADR-0105), and typed predicate pushdown for declared logs columns. Functions
+  outside the registry now produce a typed error rather than a late failure.
+- **Aggregation pushdown** for order-insensitive aggregates (ADR-0103), and a
+  metadata-only rewrite that answers predicate-free `COUNT(*)` shapes with zero
+  object-store GETs.
+- **Native histograms through range evaluation** (ADR-0108): range counter and
+  `_over_time` functions carry native histograms, and they distribute over the
+  fan-out path for the first time.
+- **Operator surfaces**: `--cache-dir` attaches the ADR-0046 disk cache tier end
+  to end; `--s3-auth` and the S3 credential flags add an instance-role
+  credential source (ADR-0106); `ravel-cli maintain compact-tenant` compacts a
+  whole tenant and can seal sooner for measurement.
+- **Intra-segment scan partitioning and a spill policy** for logs (ADR-0102),
+  and late materialization for wide `TopK` projections (ADR-0774) so a sort
+  reads the narrow set and fetches the rest only for surviving rows.
+
+### Changed
+
+- **RLOG bumped to v4** (ADR-0699): row groups plus a `PAGE_DIR` section, which
+  makes per-column extents individually addressable. A narrow projection over a
+  v4 object can fetch only the columns it needs instead of the whole object.
+  The reader accepts v3 and v4; writers emit v4.
+- **Columnar decode to Arrow** (ADR-0099). Logs and metrics scans build batches
+  from a borrowed columnar block view, and declared string columns keep their
+  dictionary form end to end rather than being materialized per row.
+- **Pruning-proportional logs fetch** (ADR-0107): the fetch layer issues block
+  ranges proportional to what pruning actually selected, and the whole-segment
+  fast path now consults projection width before choosing a whole-object read.
+- **Distributed query protocol bumped to version 4**, adding a
+  `PartialAggregate` wire frame so pushed-down aggregates cross the fan-out
+  boundary. Version 3 (ADR-0096) added per-sample dedup provenance and resolved
+  0.10.0's run-merged limitation below.
+- **Clustered compaction and object pruning** (ADR-0815), and a bulk-load
+  columnar fast path with revised write-concurrency defaults (ADR-0109,
+  ADR-0807).
+
 ### Fixed
 
 - The 0.10.0 known limitation on run-merged series and the distributed query
-  path is resolved. `ravel.queryfrag.v1` (bumped to protocol version 3,
-  ADR-0096) now carries per-sample dedup provenance on the wire, native
-  histograms distribute for the first time, and both the run-merged and
-  histogram refusals are removed. A distributed query over either shape now
-  returns results bit-identical to the same query run locally.
+  path is resolved. `ravel.queryfrag.v1` (protocol version 3, ADR-0096) carries
+  per-sample dedup provenance on the wire, native histograms distribute for the
+  first time, and both the run-merged and histogram refusals are removed. A
+  distributed query over either shape now returns results bit-identical to the
+  same query run locally.
+- Native histograms were being silently dropped in three PromQL paths; they now
+  carry through. `histogram_rate`/`sum_histograms` no longer panic on a schema
+  mismatch, and `irate`/`idelta` had their reset direction corrected.
+- Query text is guarded against a parser stack overflow.
+- A fold lifetime whose seal margin would overflow is refused rather than
+  accepted and silently sealing nothing.
+
+### Known limitations
+
+- Query latency still depends on the tenant's working set fitting in the read
+  cache. When it does not, every full-scan statement re-reads its objects from
+  object storage on each run: the eviction policy is scan-resistant (S3-FIFO,
+  ADR-0046) but cannot create reuse that a scan-everything access pattern does
+  not have. The published ClickBench figures above were measured with a cache
+  larger than the corpus and do not characterize a tenant whose data greatly
+  exceeds its cache. Removing the full-scan floor is tracked in #849.
+- One ClickBench statement (`q33`) fails on connection-pool exhaustion (#837),
+  so the totals above are over 42 of the suite's 43 statements.
 
 ## [0.10.0]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4468,14 +4468,14 @@ dependencies = [
 
 [[package]]
 name = "ravel-affinity"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "blake3",
 ]
 
 [[package]]
 name = "ravel-alerting"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "blake3",
  "hex",
@@ -4487,14 +4487,14 @@ dependencies = [
 
 [[package]]
 name = "ravel-analytics"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "ravel-bench"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "arrow 59.1.0",
  "arrow-flight",
@@ -4542,7 +4542,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-cache"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "bytes",
  "crc32c",
@@ -4553,7 +4553,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-catalog"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "blake3",
@@ -4580,7 +4580,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-cli"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "arrow 59.1.0",
@@ -4622,7 +4622,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-codec"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "blake3",
  "crc32c",
@@ -4632,7 +4632,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-commit"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "blake3",
  "bytes",
@@ -4654,7 +4654,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-failure-tests"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "bytes",
  "futures",
@@ -4675,7 +4675,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-fleet"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "blake3",
  "futures",
@@ -4692,7 +4692,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-ingest"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "blake3",
@@ -4722,7 +4722,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-ingest-router"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4749,7 +4749,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-logseg"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "blake3",
  "crc32c",
@@ -4766,7 +4766,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-maintain"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "blake3",
@@ -4794,7 +4794,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-object-store"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -4815,7 +4815,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-operator"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "clap",
  "futures",
@@ -4839,7 +4839,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-otap"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "arrow 59.1.0",
  "arrow-ipc 59.1.0",
@@ -4865,7 +4865,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-otlp"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "blake3",
  "criterion",
@@ -4884,7 +4884,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-promql"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "blake3",
  "promql-parser",
@@ -4897,7 +4897,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-promql-difftest"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "axum",
  "bytes",
@@ -4925,7 +4925,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-proto"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "prost",
  "prost-build",
@@ -4934,7 +4934,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-query"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -4977,7 +4977,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-remote-write"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "bytes",
  "hex",
@@ -4995,7 +4995,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-rspan"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "crc32c",
  "proptest",
@@ -5009,7 +5009,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-segment"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "blake3",
  "bytes",
@@ -5028,7 +5028,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-server"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "arrow 59.1.0",
@@ -5092,7 +5092,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-sim"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5113,7 +5113,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-sql"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -5153,7 +5153,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-tenant-resolve"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "axum",
  "base64 0.23.0",
@@ -5168,7 +5168,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-tracing-export"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
@@ -5184,7 +5184,7 @@ dependencies = [
 
 [[package]]
 name = "ravel-types"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "base64 0.23.0",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*", "services/*"]
 
 [workspace.package]
-version = "0.10.0"
+version = "0.11.0"
 edition = "2024"
 license = "Apache-2.0"
 rust-version = "1.97"
@@ -26,29 +26,29 @@ expect_used = "warn"
 # Version fields pin each path dependency so cargo-deny does not count them as
 # wildcards. allow-wildcard-paths is not usable here because these
 # crates are not marked publish = false, so it does not exempt them.
-ravel-types = { path = "crates/ravel-types", version = "0.10.0" }
-ravel-tenant-resolve = { path = "crates/ravel-tenant-resolve", version = "0.10.0" }
-ravel-proto = { path = "crates/ravel-proto", version = "0.10.0" }
-ravel-codec = { path = "crates/ravel-codec", version = "0.10.0" }
-ravel-object-store = { path = "crates/ravel-object-store", version = "0.10.0" }
-ravel-segment = { path = "crates/ravel-segment", version = "0.10.0" }
-ravel-logseg = { path = "crates/ravel-logseg", version = "0.10.0" }
-ravel-rspan = { path = "crates/ravel-rspan", version = "0.10.0" }
-ravel-commit = { path = "crates/ravel-commit", version = "0.10.0" }
-ravel-catalog = { path = "crates/ravel-catalog", version = "0.10.0" }
-ravel-cache = { path = "crates/ravel-cache", version = "0.10.0" }
-ravel-maintain = { path = "crates/ravel-maintain", version = "0.10.0" }
-ravel-fleet = { path = "crates/ravel-fleet", version = "0.10.0" }
-ravel-otlp = { path = "crates/ravel-otlp", version = "0.10.0" }
-ravel-otap = { path = "crates/ravel-otap", version = "0.10.0" }
-ravel-remote-write = { path = "crates/ravel-remote-write", version = "0.10.0" }
-ravel-alerting = { path = "crates/ravel-alerting", version = "0.10.0" }
-ravel-ingest = { path = "crates/ravel-ingest", version = "0.10.0" }
-ravel-promql = { path = "crates/ravel-promql", version = "0.10.0" }
-ravel-query = { path = "crates/ravel-query", version = "0.10.0" }
-ravel-analytics = { path = "crates/ravel-analytics", version = "0.10.0" }
-ravel-tracing-export = { path = "crates/ravel-tracing-export", version = "0.10.0" }
-ravel-affinity = { path = "crates/ravel-affinity", version = "0.10.0" }
+ravel-types = { path = "crates/ravel-types", version = "0.11.0" }
+ravel-tenant-resolve = { path = "crates/ravel-tenant-resolve", version = "0.11.0" }
+ravel-proto = { path = "crates/ravel-proto", version = "0.11.0" }
+ravel-codec = { path = "crates/ravel-codec", version = "0.11.0" }
+ravel-object-store = { path = "crates/ravel-object-store", version = "0.11.0" }
+ravel-segment = { path = "crates/ravel-segment", version = "0.11.0" }
+ravel-logseg = { path = "crates/ravel-logseg", version = "0.11.0" }
+ravel-rspan = { path = "crates/ravel-rspan", version = "0.11.0" }
+ravel-commit = { path = "crates/ravel-commit", version = "0.11.0" }
+ravel-catalog = { path = "crates/ravel-catalog", version = "0.11.0" }
+ravel-cache = { path = "crates/ravel-cache", version = "0.11.0" }
+ravel-maintain = { path = "crates/ravel-maintain", version = "0.11.0" }
+ravel-fleet = { path = "crates/ravel-fleet", version = "0.11.0" }
+ravel-otlp = { path = "crates/ravel-otlp", version = "0.11.0" }
+ravel-otap = { path = "crates/ravel-otap", version = "0.11.0" }
+ravel-remote-write = { path = "crates/ravel-remote-write", version = "0.11.0" }
+ravel-alerting = { path = "crates/ravel-alerting", version = "0.11.0" }
+ravel-ingest = { path = "crates/ravel-ingest", version = "0.11.0" }
+ravel-promql = { path = "crates/ravel-promql", version = "0.11.0" }
+ravel-query = { path = "crates/ravel-query", version = "0.11.0" }
+ravel-analytics = { path = "crates/ravel-analytics", version = "0.11.0" }
+ravel-tracing-export = { path = "crates/ravel-tracing-export", version = "0.11.0" }
+ravel-affinity = { path = "crates/ravel-affinity", version = "0.11.0" }
 
 # async runtime / rpc / http
 tokio = { version = "1.53", features = ["rt-multi-thread", "macros", "sync", "time", "signal", "net", "io-util"] }

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ GitHub Container Registry on every `vX.Y.Z` release tag, built from the root
 (see [ADR-0037](docs/adrs/0037-container-image-ci-registry.md)). Both
 `linux/amd64` and `linux/arm64` are published.
 Each published object is an OCI image index that carries an SBOM and full build
-provenance. The quickstart pins `ghcr.io/nofireai/ravel-server:0.10.0`. Override
+provenance. The quickstart pins `ghcr.io/nofireai/ravel-server:0.11.0`. Override
 it with `RAVEL_IMAGE`.
 
 ```sh

--- a/crates/ravel-bench/Cargo.toml
+++ b/crates/ravel-bench/Cargo.toml
@@ -65,7 +65,7 @@ futures = { workspace = true, optional = true }
 # ravel-sql is an internal path crate not yet listed in the workspace
 # `[workspace.dependencies]`, so it is named by path here; every other dep
 # below reuses a workspace pin.
-ravel-sql = { path = "../ravel-sql", version = "0.10.0", optional = true, features = ["flight-sql"] }
+ravel-sql = { path = "../ravel-sql", version = "0.11.0", optional = true, features = ["flight-sql"] }
 # Gated behind `sql-latency`. The spans-scan bench lane (`src/spans_scan.rs`)
 # writes its RSPAN corpus with the real span writer and drives `SpansScanExec`
 # directly, so it needs the writer/record types (`RspanWriter`, `SpanRecord`,

--- a/crates/ravel-ingest/Cargo.toml
+++ b/crates/ravel-ingest/Cargo.toml
@@ -30,7 +30,7 @@ ravel-catalog = { workspace = true }
 # [workspace.dependencies]; the root Cargo.toml is out of this task's scope, so
 # this is a version-pinned path dependency (the pin keeps cargo-deny from
 # counting it as a wildcard, matching the workspace's path-dep convention).
-ravel-rspan = { path = "../ravel-rspan", version = "0.10.0" }
+ravel-rspan = { path = "../ravel-rspan", version = "0.11.0" }
 # The router live switch (ADR-0052) decodes the provisioning record read for a
 # generation refresh; prost's Message trait provides `decode`.
 prost = { workspace = true }

--- a/crates/ravel-otlp/Cargo.toml
+++ b/crates/ravel-otlp/Cargo.toml
@@ -16,7 +16,7 @@ ravel-logseg = { workspace = true }
 # Used for the span record's StatusCode and the frozen resource+scope+span
 # attribute merge rule, so trace normalization and the RSPAN writer cannot
 # drift apart on either.
-ravel-rspan = { path = "../ravel-rspan", version = "0.10.0" }
+ravel-rspan = { path = "../ravel-rspan", version = "0.11.0" }
 opentelemetry-proto = { workspace = true }
 # Span events and links are stored as an opaque serialized blob in RSPAN v1
 # (ADR-0041 decision 4), which needs prost's own length-delimited encoding.

--- a/crates/ravel-query/Cargo.toml
+++ b/crates/ravel-query/Cargo.toml
@@ -95,7 +95,7 @@ ravel-cache = { workspace = true }
 # proof (tests/differential_compaction.rs) drives P4's real compactor to
 # produce write_v4 L1 parts. ravel-maintain does not depend on ravel-query,
 # so this is acyclic.
-ravel-maintain = { path = "../ravel-maintain", version = "0.10.0" }
+ravel-maintain = { path = "../ravel-maintain", version = "0.11.0" }
 proptest = { workspace = true }
 # The ADR-0046 disk cache tier (crates/ravel-query/src/cache_correctness.rs)
 # needs a real on-disk directory to construct a `ravel_cache::DiskCache`; the

--- a/deploy/docker-compose/ravel.yml
+++ b/deploy/docker-compose/ravel.yml
@@ -50,7 +50,7 @@ services:
   # already-qualified bucket it reports the existing record and exits 0, so this
   # tolerates a populated `minio-data/` across runs.
   qualify:
-    image: ${RAVEL_IMAGE:-ghcr.io/nofireai/ravel-server:0.10.0}
+    image: ${RAVEL_IMAGE:-ghcr.io/nofireai/ravel-server:0.11.0}
     depends_on:
       createbucket:
         condition: service_completed_successfully
@@ -72,7 +72,7 @@ services:
   # container boundary forbids, so the demo authenticates with a real bearer
   # token against a real tenant map, exactly as a deployment does.
   ravel-server:
-    image: ${RAVEL_IMAGE:-ghcr.io/nofireai/ravel-server:0.10.0}
+    image: ${RAVEL_IMAGE:-ghcr.io/nofireai/ravel-server:0.11.0}
     depends_on:
       qualify:
         condition: service_completed_successfully

--- a/services/ravel-cli/Cargo.toml
+++ b/services/ravel-cli/Cargo.toml
@@ -92,7 +92,7 @@ toml = "1"
 # `LogsTableProvider` logs path is in ravel-sql's default build (the
 # `flight-sql` feature only gates the Flight transport), so no feature is
 # needed here.
-ravel-sql = { path = "../../crates/ravel-sql", version = "0.10.0" }
+ravel-sql = { path = "../../crates/ravel-sql", version = "0.11.0" }
 # The reachability test builds a SqlExecutor's segment fetchers from ravel-query
 # (SegmentFetcher/LogSegmentFetcher/SpanSegmentFetcher); ravel-catalog is
 # already a normal dependency. Workspace pin, test construction only.
@@ -109,7 +109,7 @@ async-trait = { workspace = true }
 # ravel-server is a workspace path crate not listed in
 # `[workspace.dependencies]`, so it is named by path with a pinned version here,
 # exactly as ravel-sql above is; no new external crate enters Cargo.lock.
-ravel-server = { path = "../ravel-server", version = "0.10.0", features = ["sql"] }
+ravel-server = { path = "../ravel-server", version = "0.11.0", features = ["sql"] }
 # The reachability test's axum request/response plumbing (the same shape
 # ravel-server's own endpoint tests use). Already resolved in this workspace's
 # dependency graph; test-only.

--- a/services/ravel-server/Cargo.toml
+++ b/services/ravel-server/Cargo.toml
@@ -154,14 +154,14 @@ reqwest = { version = "0.13", features = ["json"] }
 # ravel-rspan below are: the workspace root Cargo.toml is outside this task's
 # scope. The pin keeps cargo-deny from counting it as a wildcard path
 # dependency.
-ravel-alerting = { path = "../../crates/ravel-alerting", version = "0.10.0" }
+ravel-alerting = { path = "../../crates/ravel-alerting", version = "0.11.0" }
 
 # ravel-sql is declared here as a path dependency rather than through
 # `[workspace.dependencies]` because the workspace root Cargo.toml is outside
 # this task's scope. The version is pinned so cargo-deny does not count it as
 # a wildcard path dependency, matching how every other
 # internal crate is pinned.
-ravel-sql = { path = "../../crates/ravel-sql", version = "0.10.0", optional = true }
+ravel-sql = { path = "../../crates/ravel-sql", version = "0.11.0", optional = true }
 
 # Flight service codegen for the `flight-sql` feature. This is arrow 58's
 # arrow-flight, a different arrow major than the `arrow` dev-dependency below;
@@ -208,7 +208,7 @@ tokio = { workspace = true, features = ["test-util"] }
 # listed in the workspace [workspace.dependencies]; the root Cargo.toml is out
 # of this task's scope, so this is a version-pinned path dependency (the pin
 # keeps cargo-deny from counting it as a wildcard).
-ravel-rspan = { path = "../../crates/ravel-rspan", version = "0.10.0" }
+ravel-rspan = { path = "../../crates/ravel-rspan", version = "0.11.0" }
 uuid = { workspace = true }
 # Real-authn end-to-end test (tests/real_authn_e2e.rs): mint a JWT and build a
 # local oct (HMAC) JWKS so the OIDC resolver runs through a real HTTP request


### PR DESCRIPTION
Version bump and changelog for 0.11.0. Same file set as the 0.10.0 release commit: workspace version and every path-dependency pin, the four crate manifests and two service manifests carrying a version literal, the docker-compose image tags, the README quickstart pin, `Cargo.lock`, and `CHANGELOG.md`.

**Why a minor bump.** RLOG moved from v3 to v4 (row groups plus a page directory, ADR-0699) and the logs query path became columnar end to end. A persistent format change earns a minor bump while the project is pre-1.0, the same reasoning 0.10.0 used for RSEG v7.

**Measured.** Over 42 timed ClickBench statements on the `hits` corpus, hot falls 96.40 s to 72.52 s and cold 320.18 s to 222.19 s. Both endpoints come from pinned report files, not from memory.

**The changelog states a known limitation rather than burying it.** Query latency still depends on the tenant's working set fitting in the read cache; when it does not, every full-scan statement re-reads from object storage each run. The eviction policy is scan-resistant (S3-FIFO) but cannot manufacture reuse that a scan-everything pattern does not have, and the figures above were measured with a cache larger than the corpus — so they do not characterize a tenant whose data greatly exceeds its cache. Tracked in #849.

`q33` still fails on pool exhaustion (#837), so the totals are over 42 of 43 statements, and the changelog says so next to the figures.

Tagging `v0.11.0` is a separate step after this merges: the tag push is what triggers `publish-images.yml` and, gated on the per-target merge jobs, the GitHub Release (ADR-0086).