### PR TITLE
fix(scripts): count CodeRabbit outside-diff findings in review bodies

### DIFF
--- a/scripts/lib/coderabbit-outside-diff.jq
+++ b/scripts/lib/coderabbit-outside-diff.jq
@@ -1,0 +1,55 @@
+# Counts the findings CodeRabbit reports in a REVIEW BODY rather than as an
+# inline comment, for the commit in $sha. Input is the array from
+# `gh api repos/<repo>/pulls/<pr>/reviews`. Shared by pr-review-status.sh and
+# its test so the two cannot drift apart.
+#
+# When a finding falls outside the diff range GitHub will accept an inline
+# comment on, the bot cannot post it inline, so it folds it into the review
+# body under a heading like:
+#
+#   > <details>
+#   > <summary>⚠️ Outside diff range comments (1)</summary>
+#
+# Nothing in the inline-comment count sees those.
+#
+# Two conditions, both required:
+#
+#   the review's own commit_id equals $sha -- the same head discipline the
+#   review count uses, and stricter than a body-text sha match, since a body
+#   on a superseded commit describes code that no longer exists;
+#
+#   the literal heading text appears in the body. The pattern is the heading
+#   phrase and nothing looser on purpose: the verdict filter beside this one
+#   had to be tightened after keying on a loose signal (a bare sha) produced a
+#   false CLEAR on #788, and the same direction is the danger here. Keying on
+#   "the body is non-empty" would count every summary and walkthrough as a
+#   finding, which trains an operator to pass --confirm-addressed reflexively
+#   and puts us back where #908 started.
+#
+# The pattern requires "Outside diff range" and, on the SAME line, the word
+# "comment"/"comments". That is the shape of every emitted heading, including
+# the older "Outside diff range and nitpick comments (N)" variant, and it does
+# not fire on prose that merely uses the phrase across a sentence.
+#
+# Counting rule: the heading carries the number of findings in the block in
+# parentheses, so a heading with a count contributes that count, and a heading
+# without one contributes 1. Multiple headings in one body, and multiple
+# reviews at the same head, sum.
+def outside_diff_count:
+  [
+    match("Outside diff range[^\\n]*comments?[^\\n]*"; "g")
+    | .string
+    | ((capture("\\((?<n>[0-9]+)\\)") | .n | tonumber) // 1)
+  ]
+  | add // 0;
+
+[
+  .[]?
+  | select(
+      .user.login == "coderabbitai[bot]"
+      and .commit_id == $sha
+    )
+  | (.body // "")
+  | outside_diff_count
+]
+| add // 0

--- a/scripts/lib/coderabbit-outside-diff.jq
+++ b/scripts/lib/coderabbit-outside-diff.jq
@@ -26,10 +26,23 @@
 #   finding, which trains an operator to pass --confirm-addressed reflexively
 #   and puts us back where #908 started.
 #
-# The pattern requires "Outside diff range" and, on the SAME line, the word
-# "comment"/"comments". That is the shape of every emitted heading, including
-# the older "Outside diff range and nitpick comments (N)" variant, and it does
-# not fire on prose that merely uses the phrase across a sentence.
+# The pattern requires the emitted <summary> ELEMENT, not the phrase. The bot
+# writes the heading as
+#
+#   > <summary>⚠️ Outside diff range comments (1)</summary>
+#
+# so the match is anchored on <summary> ... </summary> with "Outside diff
+# range" and "comment"/"comments" inside it, on one line. Matching the phrase
+# alone was wrong in a way that is easy to reproduce: a review that QUOTES the
+# heading in ordinary prose -- discussing this very mechanism, for instance --
+# contains the phrase and the word on one line and would be counted as a
+# finding, blocking a clean PR. That is a false block rather than the false
+# clear #908 was about, but a checker that cries wolf while discussing itself
+# trains the operator to pass --confirm-addressed reflexively, which lands back
+# at the same place.
+#
+# The older "Outside diff range and nitpick comments (N)" variant is emitted in
+# the same element and is still matched.
 #
 # Counting rule: the heading carries the number of findings in the block in
 # parentheses, so a heading with a count contributes that count, and a heading
@@ -37,7 +50,7 @@
 # reviews at the same head, sum.
 def outside_diff_count:
   [
-    match("Outside diff range[^\\n]*comments?[^\\n]*"; "g")
+    match("<summary>[^\\n]*Outside diff range[^\\n]*comments?[^\\n]*</summary>"; "g")
     | .string
     | ((capture("\\((?<n>[0-9]+)\\)") | .n | tonumber) // 1)
   ]

--- a/scripts/lib/coderabbit-outside-diff.jq
+++ b/scripts/lib/coderabbit-outside-diff.jq
@@ -62,7 +62,14 @@
 # reviews at the same head, sum.
 def outside_diff_count:
   [
-    match("<summary>[^\\n]*Outside diff range[^\\n]*comments?[^\\n]*</summary>"; "g")
+    # `[^<\n]*` rather than `[^\n]*`: excluding `<` bounds each match to ONE
+    # element. With the greedy `[^\n]*` two qualifying <summary> elements on a
+    # single line collapsed into one match, and the count capture below then
+    # read only the first number -- two findings reported as one. The verdict
+    # was unaffected (any nonzero blocks), so this was an accuracy bug rather
+    # than a safety one, but the bound costs nothing. Verified: two-on-one-line
+    # returned 1, now returns 3.
+    match("<summary>[^<\\n]*Outside diff range[^<\\n]*comments?[^<\\n]*</summary>"; "g")
     | .string
     | ((capture("\\((?<n>[0-9]+)\\)") | .n | tonumber) // 1)
   ]

--- a/scripts/lib/coderabbit-outside-diff.jq
+++ b/scripts/lib/coderabbit-outside-diff.jq
@@ -44,6 +44,18 @@
 # The older "Outside diff range and nitpick comments (N)" variant is emitted in
 # the same element and is still matched.
 #
+# KNOWN LIMIT, accepted deliberately: a body that quotes the COMPLETE element
+# verbatim still counts. Tightening further (requiring the "> " blockquote
+# prefix the bot currently emits, say) would exclude that case, but it couples
+# this check to a formatting detail of the bot's output -- and if that detail
+# ever changes, real findings stop being counted and the gate goes quiet. That
+# is a false CLEAR, the failure this whole check exists to prevent, traded for
+# a false BLOCK that costs one read of the body. The asymmetry decides it: an
+# over-count makes a human look, an under-count ships unfixed findings. Verified
+# not to fire in practice -- run against the live review bodies on PR #915 at
+# head 88f60210, including the review that raised this exact concern, the count
+# is 0.
+#
 # Counting rule: the heading carries the number of findings in the block in
 # parentheses, so a heading with a count contributes that count, and a heading
 # without one contributes 1. Multiple headings in one body, and multiple

--- a/scripts/pr-review-status.sh
+++ b/scripts/pr-review-status.sh
@@ -7,13 +7,14 @@
 # Usage: pr-review-status.sh <pr-number> [--confirm-addressed]
 #
 # --confirm-addressed: the operator's explicit statement that every
-# CodeRabbit inline comment on the PR has been read and each one fixed or
-# answered. The REST API has no resolved/unresolved field (see below), so
+# CodeRabbit finding on the PR has been read and each one fixed or
+# answered, both the inline comments and the outside-diff findings in the
+# review body. The REST API has no resolved/unresolved field (see below), so
 # once a PR has ever had a finding its comment count never returns to zero
 # and the clean branch below could otherwise never fire again (issue #764:
 # PR #754 had 13 addressed comments across 4 fix rounds and no way to get
-# the SHA-pinned merge command). The flag skips ONLY the comment-count
-# conjunct; CI, the current-head review, and the mergeState checks still
+# the SHA-pinned merge command). The flag skips ONLY the finding-count
+# conjuncts; CI, the current-head review, and the mergeState checks still
 # gate exactly as without it.
 set -euo pipefail
 
@@ -113,6 +114,17 @@ cr_walkthroughs=$(echo "${issue_comments_json}" | jq --arg sha "${head_sha}" \
 comments_json="$(gh api "repos/${repo}/pulls/${pr}/comments" --paginate | jq -s 'add')"
 cr_comments=$(echo "${comments_json}" | jq '[.[] | select(.user.login=="coderabbitai[bot]")] | length')
 
+# A finding that falls outside the range GitHub accepts an inline comment on
+# goes into the review BODY instead, under an "Outside diff range comments (N)"
+# heading. It leaves no entry on the review-comments endpoint above, so nothing
+# read so far can see it. On #908 the two inline comments were pinned to a
+# superseded commit and had already been fixed, so `inline_comments=2` read as
+# "two stale findings, nothing new" while an unaddressed body finding sat at
+# the current head -- the exact shape this script exists to prevent. Head
+# discipline is the review's own commit_id, matching cr_reviews above.
+cr_outside_diff=$(echo "${reviews_json}" | jq --arg sha "${head_sha}" \
+  -f "$(dirname "$0")/lib/coderabbit-outside-diff.jq")
+
 summary="PR #${pr} @ ${head_sha}: state=${state} mergeState=${merge_state} CI=${success} pass/${pending} pending/${failing} fail"
 if [[ "${other}" != "0" ]]; then
   summary="${summary}/${other} unrecognized"
@@ -121,6 +133,14 @@ if [[ "${failing}" != "0" ]]; then
   summary="${summary} (${failing_names})"
 fi
 summary="${summary} | CodeRabbit: reviews@head=${cr_reviews} walkthroughs@head=${cr_walkthroughs} last=${cr_last_state} inline_comments=${cr_comments}"
+# Appended only when nonzero, so a PR with no body findings prints exactly the
+# line it printed before this field existed. The name says body_findings rather
+# than anything with "comment" in it: these are not inline comments and are not
+# fetched from the comments endpoint, and an operator who reads the two counts
+# as one number is back to the #908 failure.
+if [[ "${cr_outside_diff}" != "0" ]]; then
+  summary="${summary} outside_diff_body_findings@head=${cr_outside_diff}"
+fi
 echo "${summary}"
 
 if [[ "${state}" != "OPEN" ]]; then
@@ -139,11 +159,17 @@ elif [[ "${pending}" != "0" ]]; then
   echo "  -> CI still running; wait"
 elif [[ "${cr_comments}" != "0" && "${confirm_addressed}" != "1" ]]; then
   echo "  -> ${cr_comments} CodeRabbit inline comment(s); read them, then re-run with --confirm-addressed once each is fixed or answered (the API cannot tell; see the header comment)"
+elif [[ "${cr_outside_diff}" != "0" && "${confirm_addressed}" != "1" ]]; then
+  echo "  -> ${cr_outside_diff} CodeRabbit outside-diff finding(s) in the review BODY at head, not inline; read the body with \`gh api repos/${repo}/pulls/${pr}/reviews --jq '.[] | select(.commit_id==\"${head_sha}\") | .body'\`, then re-run with --confirm-addressed once each is fixed or answered"
 elif [[ "${merge_state}" != "CLEAN" && "${merge_state}" != "UNSTABLE" ]]; then
   echo "  -> every check and review looks clean, but mergeState is ${merge_state} (not CLEAN/UNSTABLE); verify by hand before merging"
 else
-  if [[ "${cr_comments}" != "0" ]]; then
+  if [[ "${cr_comments}" != "0" && "${cr_outside_diff}" != "0" ]]; then
+    echo "  -> clean (operator confirmed all ${cr_comments} inline comment(s) and ${cr_outside_diff} outside-diff body finding(s) addressed): CI green, CodeRabbit reviewed the current head"
+  elif [[ "${cr_comments}" != "0" ]]; then
     echo "  -> clean (operator confirmed all ${cr_comments} inline comment(s) addressed): CI green, CodeRabbit reviewed the current head"
+  elif [[ "${cr_outside_diff}" != "0" ]]; then
+    echo "  -> clean (operator confirmed all ${cr_outside_diff} outside-diff body finding(s) addressed): CI green, CodeRabbit reviewed the current head"
   else
     echo "  -> clean: CI green, CodeRabbit reviewed the current head with zero inline comments"
   fi

--- a/scripts/pr-review-status.test.sh
+++ b/scripts/pr-review-status.test.sh
@@ -162,6 +162,23 @@ check_outside "bot review quoting the marker in prose is NOT counted" 0 "$(cat <
 EOF
 )"
 
+# Two qualifying elements on ONE line must count as two headings, not one. A
+# greedy [^\n]* between the tags let the first match swallow both, and the
+# count capture then read only the first number: 1 + 2 reported as 1.
+check_outside "two summaries on one line count separately" 3 "$(cat <<EOF
+[{"user":{"login":"coderabbitai[bot]"},"commit_id":"${SHA}",
+  "body":"> <summary>⚠️ Outside diff range comments (1)</summary><summary>⚠️ Outside diff range comments (2)</summary>"}]
+EOF
+)"
+
+# The emitted form puts <blockquote> immediately after </summary> on the same
+# line. Bounding the match with [^<\n]* must not break that.
+check_outside "emitted form with a trailing blockquote still counts" 1 "$(cat <<EOF
+[{"user":{"login":"coderabbitai[bot]"},"commit_id":"${SHA}",
+  "body":"> <summary>⚠️ Outside diff range comments (1)</summary><blockquote>\n>\n> <details>\n> <summary>scripts/foo.sh (1)</summary><blockquote>"}]
+EOF
+)"
+
 # Backticked inline code is the same shape and must not count either.
 check_outside "bot review with the marker in inline code is NOT counted" 0 "$(cat <<EOF
 [{"user":{"login":"coderabbitai[bot]"},"commit_id":"${SHA}",

--- a/scripts/pr-review-status.test.sh
+++ b/scripts/pr-review-status.test.sh
@@ -1,24 +1,28 @@
 #!/usr/bin/env bash
-# Cases for scripts/lib/coderabbit-verdict.jq, the filter that decides whether
-# CodeRabbit has actually reviewed a PR's current head.
+# Cases for the two filters behind scripts/pr-review-status.sh:
+# lib/coderabbit-verdict.jq, which decides whether CodeRabbit has actually
+# reviewed a PR's current head, and lib/coderabbit-outside-diff.jq, which
+# counts the findings the bot reports in a review BODY instead of inline.
 #
-# Fixtures only: no network, no gh. Each case is a comment shape observed on a
-# real PR, named with the PR it came from.
+# Fixtures only: no network, no gh. Each case is a comment or review shape
+# observed on a real PR, named with the PR it came from.
 #
 # Exit 0 all pass, 1 on a failure.
 set -uo pipefail
 
 FILTER="$(dirname "$0")/lib/coderabbit-verdict.jq"
 [[ -r "${FILTER}" ]] || { echo "missing ${FILTER}" >&2; exit 64; }
+OUTSIDE_FILTER="$(dirname "$0")/lib/coderabbit-outside-diff.jq"
+[[ -r "${OUTSIDE_FILTER}" ]] || { echo "missing ${OUTSIDE_FILTER}" >&2; exit 64; }
 
 SHA="0c65a3d3983384d663189257a25cc2d40ca95d32"
 OTHER="1111111111111111111111111111111111111111"
 passes=0
 fails=0
 
-check() {
-  local name="$1" want="$2" json="$3" got
-  got="$(printf '%s' "${json}" | jq --arg sha "${SHA}" -f "${FILTER}")" || got="ERROR"
+run_case() {
+  local filter="$1" name="$2" want="$3" json="$4" got
+  got="$(printf '%s' "${json}" | jq --arg sha "${SHA}" -f "${filter}")" || got="ERROR"
   if [[ "${got}" == "${want}" ]]; then
     printf 'ok    %s\n' "${name}"
     passes=$((passes + 1))
@@ -27,6 +31,9 @@ check() {
     fails=$((fails + 1))
   fi
 }
+
+check() { run_case "${FILTER}" "$@"; }
+check_outside() { run_case "${OUTSIDE_FILTER}" "$@"; }
 
 # The clean case (#893): zero findings, reported as an issue comment, no formal
 # review filed at all. This is what used to be missed, holding a reviewed PR
@@ -73,6 +80,170 @@ EOF
 check "null body is tolerated" 0 '[{"user":{"login":"coderabbitai[bot]"},"body":null}]'
 
 check "no comments at all" 0 '[]'
+
+# --- lib/coderabbit-outside-diff.jq --------------------------------------
+#
+# Input is the pulls/<pr>/reviews array, so head discipline is the review's own
+# commit_id, not a sha quoted in the body.
+#
+# Counting rule (asserted below): the heading carries the number of findings in
+# the block in parentheses, so a heading WITH a count contributes that count and
+# a heading WITHOUT one contributes 1; headings sum across a body and across
+# reviews at the same head.
+
+# The #908 shape: an unaddressed finding the bot could not post inline, folded
+# into the review body at the current head. Nothing else in the script sees it.
+check_outside "outside-diff block at head is counted" 1 "$(cat <<EOF
+[{"user":{"login":"coderabbitai[bot]"},"commit_id":"${SHA}",
+  "body":"> [!CAUTION]\n> Some comments are outside the diff and can't be posted inline due to platform limitations.\n>\n> <details>\n> <summary>⚠️ Outside diff range comments (1)</summary>\n>\n> scripts/foo.sh line 12: the guard is inverted.\n"}]
+EOF
+)"
+
+# Summary/walkthrough prose is not a finding. Counting a non-empty body would
+# make every reviewed PR look like it carried findings, which trains the
+# operator to pass --confirm-addressed without reading anything.
+check_outside "walkthrough-only body at head is NOT counted" 0 "$(cat <<EOF
+[{"user":{"login":"coderabbitai[bot]"},"commit_id":"${SHA}",
+  "body":"Actionable comments posted: 0\n\n<details>\n<summary>Walkthrough</summary>\n\nThe change adds a guard to the merge script.\n</details>"}]
+EOF
+)"
+
+# A body on a superseded commit describes code that no longer exists on the
+# branch, exactly as a stale formal review does.
+check_outside "outside-diff block on a superseded commit is NOT counted" 0 "$(cat <<EOF
+[{"user":{"login":"coderabbitai[bot]"},"commit_id":"${OTHER}",
+  "body":"> <summary>⚠️ Outside diff range comments (2)</summary>"}]
+EOF
+)"
+
+# 3 from the counted heading plus 1 for the heading with no count: 4.
+check_outside "multiple findings sum per heading count" 4 "$(cat <<EOF
+[{"user":{"login":"coderabbitai[bot]"},"commit_id":"${SHA}",
+  "body":"> <summary>⚠️ Outside diff range comments (3)</summary>\n\nprose\n\n> <summary>⚠️ Outside diff range and nitpick comments</summary>"}]
+EOF
+)"
+
+check_outside "null review body is tolerated" 0 "$(cat <<EOF
+[{"user":{"login":"coderabbitai[bot]"},"commit_id":"${SHA}","body":null}]
+EOF
+)"
+
+check_outside "absent body key is tolerated" 0 "$(cat <<EOF
+[{"user":{"login":"coderabbitai[bot]"},"commit_id":"${SHA}"}]
+EOF
+)"
+
+check_outside "no reviews at all" 0 '[]'
+
+# The false-CLEAR direction, the same one that forced the verdict filter to be
+# tightened on #788: a bot comment that quotes the sha but reports no findings
+# must not be counted as one.
+check_outside "rate-limit notice quoting the sha is NOT counted" 0 "$(cat <<EOF
+[{"user":{"login":"coderabbitai[bot]"},"commit_id":"${SHA}",
+  "body":"⚠️ Rate limit exceeded\n\n@user has exceeded the limit. Please wait before requesting another review.\n\nCommits: reviewed up to ${SHA}."}]
+EOF
+)"
+
+# Only the bot's own reviews count.
+check_outside "human review quoting the marker is NOT counted" 0 "$(cat <<EOF
+[{"user":{"login":"pmoust"},"commit_id":"${SHA}",
+  "body":"CodeRabbit reported ⚠️ Outside diff range comments (1) earlier, already fixed."}]
+EOF
+)"
+
+# --- end-to-end verdict, pr-review-status.sh ------------------------------
+#
+# The count above only matters if it flips the verdict. These run the real
+# script against fixtures with a stand-in `gh` on PATH: no network, no token.
+
+E2E_DIR="$(mktemp -d)"
+trap 'rm -rf "${E2E_DIR}"' EXIT
+mkdir -p "${E2E_DIR}/bin"
+cat >"${E2E_DIR}/bin/gh" <<'SHIM'
+#!/usr/bin/env bash
+# Fixture-backed stand-in for gh, dispatching on the endpoint in the args.
+# The /pulls/*/reviews case must precede /pulls/*/comments: both are pulls.
+case "$*" in
+  *"pr view"*)              cat "${FIXTURES}/pr-view.json" ;;
+  *"/pulls/"*"/reviews"*)   cat "${FIXTURES}/reviews.json" ;;
+  *"/issues/"*"/comments"*) cat "${FIXTURES}/issue-comments.json" ;;
+  *"/pulls/"*"/comments"*)  cat "${FIXTURES}/review-comments.json" ;;
+  *) echo "unexpected gh call: $*" >&2; exit 90 ;;
+esac
+SHIM
+chmod +x "${E2E_DIR}/bin/gh"
+
+# Everything except the review body is held constant and clean: CI green,
+# mergeState CLEAN, one COMMENTED review at head, zero inline comments. So the
+# only thing that can move the verdict is the body.
+e2e() {
+  local review_body="$1"
+  shift
+  local fx="${E2E_DIR}/fx"
+  rm -rf "${fx}"
+  mkdir -p "${fx}"
+  printf '{"state":"OPEN","mergeStateStatus":"CLEAN","statusCheckRollup":[{"name":"ci","status":"COMPLETED","conclusion":"SUCCESS"}],"headRefOid":"%s"}\n' \
+    "${SHA}" >"${fx}/pr-view.json"
+  printf '[{"user":{"login":"coderabbitai[bot]"},"state":"COMMENTED","commit_id":"%s","body":%s}]\n' \
+    "${SHA}" "${review_body}" >"${fx}/reviews.json"
+  printf '[]\n' >"${fx}/issue-comments.json"
+  printf '[]\n' >"${fx}/review-comments.json"
+  FIXTURES="${fx}" PATH="${E2E_DIR}/bin:${PATH}" \
+    bash "$(dirname "$0")/pr-review-status.sh" 908 "$@"
+}
+
+check_eq() {
+  local name="$1" want="$2" got="$3"
+  if [[ "${got}" == "${want}" ]]; then
+    printf 'ok    %s\n' "${name}"
+    passes=$((passes + 1))
+  else
+    printf 'FAIL  %s:\n  want: %s\n  got:  %s\n' "${name}" "${want}" "${got}"
+    fails=$((fails + 1))
+  fi
+}
+
+CLEAN_BODY_JSON='"Actionable comments posted: 0\n\n<details>\n<summary>Walkthrough</summary>\n\nAdds a guard.\n</details>"'
+FINDING_BODY_JSON="$(cat <<'EOF'
+"**Actionable comments posted: 2**\n\n> [!CAUTION]\n> Some comments are outside the diff and can't be posted inline due to platform limitations.\n>\n> <details>\n> <summary>⚠️ Outside diff range comments (1)</summary>\n>\n> `scripts/foo.sh` line 12: the guard is inverted.\n>\n> </details>"
+EOF
+)"
+
+clean_out="$(e2e "${CLEAN_BODY_JSON}")"
+finding_out="$(e2e "${FINDING_BODY_JSON}")"
+confirmed_out="$(e2e "${FINDING_BODY_JSON}" --confirm-addressed)"
+
+# A body with no findings prints exactly what it printed before this field
+# existed: no extra summary field, and the unchanged clean verdict.
+check_eq "walkthrough-only body: summary line carries no outside-diff field" \
+  "PR #908 @ ${SHA}: state=OPEN mergeState=CLEAN CI=1 pass/0 pending/0 fail | CodeRabbit: reviews@head=1 walkthroughs@head=0 last=COMMENTED inline_comments=0" \
+  "$(printf '%s\n' "${clean_out}" | sed -n 1p)"
+check_eq "walkthrough-only body: verdict is unchanged clean" \
+  "  -> clean: CI green, CodeRabbit reviewed the current head with zero inline comments" \
+  "$(printf '%s\n' "${clean_out}" | sed -n 2p)"
+check_eq "walkthrough-only body: merge command still printed" \
+  "  -> gh pr merge 908 --rebase --delete-branch --match-head-commit ${SHA}" \
+  "$(printf '%s\n' "${clean_out}" | sed -n 3p)"
+
+# The #908 regression: same PR, same green CI, same zero inline comments, one
+# outside-diff finding in the body. It must be visible and it must block.
+check_eq "outside-diff body finding: counted on the summary line" \
+  "PR #908 @ ${SHA}: state=OPEN mergeState=CLEAN CI=1 pass/0 pending/0 fail | CodeRabbit: reviews@head=1 walkthroughs@head=0 last=COMMENTED inline_comments=0 outside_diff_body_findings@head=1" \
+  "$(printf '%s\n' "${finding_out}" | sed -n 1p)"
+check_eq "outside-diff body finding: verdict is not clean" \
+  "  -> 1 CodeRabbit outside-diff finding(s) in the review BODY at head, not inline; read the body with \`gh api repos/NOFireAI/ravel/pulls/908/reviews --jq '.[] | select(.commit_id==\"${SHA}\") | .body'\`, then re-run with --confirm-addressed once each is fixed or answered" \
+  "$(printf '%s\n' "${finding_out}" | sed -n 2p)"
+check_eq "outside-diff body finding: no merge command offered" \
+  "" \
+  "$(printf '%s\n' "${finding_out}" | sed -n 3p)"
+
+# --confirm-addressed overrides it, in the same shape as the inline branch.
+check_eq "outside-diff body finding: --confirm-addressed clears it" \
+  "  -> clean (operator confirmed all 1 outside-diff body finding(s) addressed): CI green, CodeRabbit reviewed the current head" \
+  "$(printf '%s\n' "${confirmed_out}" | sed -n 2p)"
+check_eq "outside-diff body finding: --confirm-addressed prints the merge command" \
+  "  -> gh pr merge 908 --rebase --delete-branch --match-head-commit ${SHA}" \
+  "$(printf '%s\n' "${confirmed_out}" | sed -n 3p)"
 
 printf '\n%d passed, %d failed\n' "${passes}" "${fails}"
 [[ "${fails}" -eq 0 ]]

--- a/scripts/pr-review-status.test.sh
+++ b/scripts/pr-review-status.test.sh
@@ -151,6 +151,24 @@ check_outside "human review quoting the marker is NOT counted" 0 "$(cat <<EOF
 EOF
 )"
 
+# The bot itself quotes the heading when it discusses this mechanism, and a
+# quote is not a finding. This is the case the user filter above does NOT
+# cover: same phrase, same line, bot author, current head -- and no <summary>
+# element, because nothing was actually reported. Matching the phrase rather
+# than the emitted element counted this and blocked a clean PR.
+check_outside "bot review quoting the marker in prose is NOT counted" 0 "$(cat <<EOF
+[{"user":{"login":"coderabbitai[bot]"},"commit_id":"${SHA}",
+  "body":"Line 40 counts any same-line prose containing Outside diff range comments (1), which is a false positive."}]
+EOF
+)"
+
+# Backticked inline code is the same shape and must not count either.
+check_outside "bot review with the marker in inline code is NOT counted" 0 "$(cat <<EOF
+[{"user":{"login":"coderabbitai[bot]"},"commit_id":"${SHA}",
+  "body":"Match the emitted \`⚠️ Outside diff range comments (1)\` summary marker instead of the phrase."}]
+EOF
+)"
+
 # --- end-to-end verdict, pr-review-status.sh ------------------------------
 #
 # The count above only matters if it flips the verdict. These run the real


### PR DESCRIPTION
`pr-review-status.sh` decides whether a PR is clean to merge. It counted reviews at head, walkthrough verdicts, and **inline** comments — but never read a review's *body*, where CodeRabbit puts findings that fall outside the diff range.

This is not hypothetical. On #908 the script reported `inline_comments=2`, both pinned to a superseded commit and already fixed, so the honest reading was "two stale findings, nothing new". A genuine unaddressed finding was sitting in the review body at the current head. Only reading the body by hand caught it — which is exactly the failure the script exists to prevent.

The fix adds a body scan at the **current head commit** (a body on a superseded commit describes code that no longer exists), surfaces the count beside `inline_comments=`, and blocks the clean verdict until `--confirm-addressed`, matching how inline comments already behave.

The matching rule got deliberate care in the direction that has bitten before: the verdict filter was previously tightened because a loose signal produced a **false CLEAR**, which is worse than a false block. So this matches the outside-diff marker specifically rather than "body is non-empty" — a summary or walkthrough body must not count as a finding. The predicate lives in `scripts/lib/coderabbit-outside-diff.jq`, beside the existing `coderabbit-verdict.jq`, so the rule has one home and is testable on its own.

`scripts/pr-review-status.test.sh` grows from its existing cases to **24 passing**, covering: a body with an outside-diff block at head, a body with only summary prose, a block on a superseded commit, an empty body, a rate-limit-style bot comment quoting a sha (the false-CLEAR case), and the `--confirm-addressed` override in both directions.

Verified locally: `./scripts/pr-review-status.test.sh` → `24 passed, 0 failed`.

Refs: #908