### PR TITLE
docs(cost-model): document the logs request-cost knob

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -74,8 +74,13 @@ Start here to run Ravel, ingest into it, or query it.
 - [guides/cost-model.md](guides/cost-model.md): the PUTs/day formula
   (ADR-0076) and how tenant count, signal mix, shard count, replica
   affinity, and flush cadence each move it, with a measured before/after of
-  the flush-cadence default change. Read this to predict the S3 request
-  bill before deploying.
+  the flush-cadence default change; plus the read-side counterpart, where
+  `--logs-request-cost-bytes` sets how many transferred bytes one saved
+  object-store round trip is worth and so how often a logs scan reads whole
+  objects instead of ranges (ADR-0904, with list-price dollar modelling for
+  request-billed and egress-billed backends). Read this to predict the S3
+  request bill before deploying, and to decide whether your read path is
+  tuned for latency or for cost.
 - [guides/disaster-recovery.md](guides/disaster-recovery.md): recovering a
   deployment from object storage alone -- what state is reconstructable, the
   commit-record and catalog rebuild path, and the operator steps. Read this

--- a/docs/guides/cost-model.md
+++ b/docs/guides/cost-model.md
@@ -5,7 +5,9 @@ modeled 100-tenant, 1 TB/day workload, ADR-0076 estimated roughly $7-8k/month
 of request fees against roughly $100-150/month of storage, and at a
 single-tenant deployment request fees run over 98% of the total bill. This
 guide gives an operator the formula and the levers to predict and control
-that bill before deploying, not after the first invoice.
+that bill before deploying, not after the first invoice. The write path sets
+most of it and comes first; the read path adds a request count the engine
+itself chooses, and one flag moves it.
 
 ## The formula
 
@@ -103,3 +105,140 @@ Two ceilings this guide's levers do not remove:
   shard count or raising flush delay also lowers the per-query request
   budget on the read side — cheaper writes and cheaper reads move together,
   not independently.
+
+## The read side: buying bytes with requests
+
+The formula above counts writes, where the request rate follows from
+configuration an operator sets once. Reads are different: the engine decides,
+per segment, whether to fetch an object in one whole-object GET or as a probe
+plus a small number of ranged GETs that move fewer bytes. That decision is a
+request count nobody configured directly, and on a request-billed backend it
+is money.
+
+One number arbitrates it:
+
+```
+avoiding k requests to move b extra bytes is a win exactly when
+b < k * request_cost
+```
+
+`--logs-request-cost-bytes <BYTES>` on `ravel-server` is that `request_cost`:
+one saved object-store round trip is worth this many saved transfer bytes.
+Unset, it takes `ravel_query::DEFAULT_LOG_REQUEST_COST_BYTES` (1,887,437 bytes,
+about 1.8 MiB), so an unset deployment behaves exactly as it did before the
+flag existed. The derivation of that number — a latency-bandwidth product
+measured on one in-region S3 configuration, one instance type, one fetch-permit
+count — lives in the constant's doc comment in
+`crates/ravel-query/src/log_fetcher.rs`; read it there rather than assuming the
+default was tuned for your deployment, because it was tuned for that one.
+
+Raising the value makes the engine value a request more: fewer statements take
+the ranged route, more read whole objects, request count falls and bytes rise.
+Lowering it does the reverse.
+
+The setting never changes a query's answer. It selects which read path fetches
+the bytes; the rows returned are identical at every value, and only request
+counts, byte counts, and timing differ (ADR-0904 decision 4, pinned by a
+whole-vs-ranged row-equality test).
+
+### Why one knob and not three
+
+The value drives three decisions in the logs fetch layer, all of them the same
+question asked about different inputs:
+
+1. **The coalescing gap**: two wanted extents separated by less than one
+   request cost fuse into a single GET.
+2. **The pre-probe whole-object crossover**: an object at or below five
+   request costs is read whole, because the ranged protocol adds roughly that
+   many round trips and cannot save enough bytes below that size to pay for
+   them.
+3. **Projection routing on the whole-segment fast path**: a predicate-free
+   scan opens by column chunk only when the bytes its projection skips clear
+   that same crossover.
+
+Deriving all three from one field is what makes recalibrating the store
+recalibrate the read path coherently, instead of leaving three thresholds to
+disagree. Two floors bound the low end (a 64 KiB coalescing gap and a 512 KiB
+whole-object crossover), so a very small value clamps rather than producing a
+one-block GET storm.
+
+Two properties follow from what the number is:
+
+- It is a property of the **store and the instance** — round-trip latency and
+  single-stream bandwidth at the fetch concurrency in use — not of the RLOG
+  format. A different store, a cross-region bucket, or a different
+  `--fetch-concurrency` has a different right value, and changing fetch
+  concurrency changes this break-even along with it.
+- The `logs-` prefix is literal. Metric (RSEG) reads use fixed gap and
+  crossover constants that are not request-cost-derived, and do not respond to
+  this flag.
+
+### What the trade costs, in modelled dollars
+
+Every dollar figure in this section is list-price modelling, not a measured
+bill: the amounts are computed from counted requests and counted bytes against
+published us-east-1 list prices, never read off an invoice. The absolute
+amounts for a single benchmark pass are small, so they matter as a rate at
+production query volume, not as cents.
+
+The measured example is the ClickBench corpus (42 statements, cold, reference
+box; recorded on issue #680 and quoted in `docs/adrs/0904`, with the pass
+procedure in [clickbench-aws-runbook.md](clickbench-aws-runbook.md)). Turning
+on projection routing moved:
+
+```
+cold requests   203,243 -> 751,409    (+270%)
+cold bytes       403.97 -> 194.19 GB  (-52%)
+cold time        324.79 -> 222.19 s   (-31.6%)
+```
+
+Half the bytes, 3.7x the requests, 31.6% faster. Modelled at us-east-1 list
+prices that pass costs about 2.2x more in request charges than it did before,
+and it is faster.
+
+Both of those can be true at once because of an asymmetry in the price sheet:
+same-region S3-to-EC2 transfer is not billed, so on that deployment shape
+trading bytes for requests spends a billed resource to save a free one. Where
+transfer is billed — cross-region, internet-facing, or an object store that
+charges egress — the sign flips: at list egress near $0.09/GB against GETs near
+$0.0004/1000, the dollar break-even lands around 4.4 KB per request, three
+orders of magnitude below the 1.8 MiB latency break-even, so the shipped
+default is already the cost-preferring setting there. The right value depends
+on the deployment's billing shape, which is why this is a flag and not a
+constant.
+
+### Choosing a value, cheapest lever first
+
+1. **Leave it unset** (prefer latency). Costs nothing, changes nothing, and is
+   correct for any deployment whose read path is latency-bound.
+2. **Leave it unset on an egress-billed backend** too. The default already
+   sits far above that deployment's dollar break-even, so there is no lower
+   value worth inventing.
+3. **Raise it on a request-billed, transfer-free backend** (same-region S3).
+   Set it at or above the largest segment object *any* tenant this process
+   serves writes: the flag is process-wide, so a single tenant's largest object
+   is the wrong unit, and any tenant holding bigger objects keeps routing
+   ranged. There is no format-level object-size cap to read this from; object
+   size comes from `--batch-rows` and `--target-bytes` at write time and is
+   observable per tenant, so measure it and round up. Overshooting costs
+   nothing, because all three decisions saturate once the value exceeds the
+   largest object: every candidate segment becomes one GET. What it costs is
+   the other column of the table above, roughly twice the bytes and the cold
+   latency win given back.
+
+The flag is read at startup only, like the other read-path knobs in
+[query.md](query.md#operator-configurable-budgets-server-flags), and it sits
+inside `--logs-block-range-threshold`, which selects which fetcher entry point
+an object takes before this value governs how that fetch behaves.
+
+To see which way your queries are actually routing, read the logs scan's
+`fast_path_whole_object_segments` and `fast_path_ranged_segments` plan metrics
+from an `EXPLAIN ANALYZE`, beside the per-operation request and byte counts. A
+large ranged-open share on statements that move few bytes, on a backend that
+bills requests, is the signal that this value is set for the wrong objective.
+
+The cost-preferring setting has no published ClickBench triple yet: the figures
+above measured the routing change, not this flag, and a high value also
+collapses ranged reads on the predicate path that were active on both sides of
+that comparison. Requests should land at or below 203,243 and bytes at or above
+403.97 GB; the measurement, not this guide, gets to say where.

--- a/docs/guides/cost-model.md
+++ b/docs/guides/cost-model.md
@@ -117,7 +117,7 @@ is money.
 
 One number arbitrates it:
 
-```
+```text
 avoiding k requests to move b extra bytes is a win exactly when
 b < k * request_cost
 ```
@@ -132,9 +132,12 @@ count — lives in the constant's doc comment in
 `crates/ravel-query/src/log_fetcher.rs`; read it there rather than assuming the
 default was tuned for your deployment, because it was tuned for that one.
 
-Raising the value makes the engine value a request more: fewer statements take
-the ranged route, more read whole objects, request count falls and bytes rise.
-Lowering it does the reverse.
+Raising the value makes the engine value a request more: fewer segment fetches
+take the ranged route, more read whole objects, request count falls and bytes
+rise. Lowering it does the reverse. The decision is per segment, so one
+statement spanning many segments can take both routes within a single query --
+the counters report opens by shape rather than statements by shape for exactly
+that reason.
 
 The setting never changes a query's answer. It selects which read path fetches
 the bytes; the rows returned are identical at every value, and only request
@@ -186,7 +189,7 @@ box; recorded on issue #680 and quoted in `docs/adrs/0904`, with the pass
 procedure in [clickbench-aws-runbook.md](clickbench-aws-runbook.md)). Turning
 on projection routing moved:
 
-```
+```text
 cold requests   203,243 -> 751,409    (+270%)
 cold bytes       403.97 -> 194.19 GB  (-52%)
 cold time        324.79 -> 222.19 s   (-31.6%)
@@ -209,8 +212,12 @@ constant.
 
 ### Choosing a value, cheapest lever first
 
-1. **Leave it unset** (prefer latency). Costs nothing, changes nothing, and is
-   correct for any deployment whose read path is latency-bound.
+1. **Leave it unset** (prefer latency). Costs nothing and changes nothing. It
+   is the right starting point for a latency-bound read path on a store whose
+   round-trip latency and single-stream bandwidth resemble the configuration
+   the default was measured on. A different store, region, or fetch
+   concurrency has a different break-even, so treat unset as a default to
+   measure against rather than one known to be correct everywhere.
 2. **Leave it unset on an egress-billed backend** too. The default already
    sits far above that deployment's dollar break-even, so there is no lower
    value worth inventing.


### PR DESCRIPTION
Task 904-5 of epic #904. `docs/guides/cost-model.md` was write-path only — the PUTs/day formula, shard count, replica affinity, flush cadence. This adds the read-side counterpart now that `--logs-request-cost-bytes` actually ships (#919).

**Every dollar figure is labelled as modelling, which was the task's defining requirement:**

> Every dollar figure in this section is list-price modelling, not a measured bill.

The figures come from counted requests and bytes at published us-east-1 list prices, never read off an invoice, and the guide says the absolute numbers matter as a *rate* at production query volume rather than as cents per pass.

**It states plainly that the knob does not change answers:**

> The setting never changes a query's answer. It selects which read path fetches the bytes; the rows returned are identical at every value, and only request counts, byte counts, and timing differ.

That distinction is the one an operator most needs, because a knob that trades requests against bytes reads like it might trade accuracy too. It doesn't.

**The asymmetry that makes this a flag rather than a constant** is documented: same-region S3-to-EC2 transfer is not billed, so on that shape the knob trades a free resource for a billed one. Where transfer *is* billed — cross-region, internet-facing, an object store charging egress — the sign flips, at list egress near \$0.09/GB against GETs near \$0.0004/1k. The right setting is therefore a property of the deployment, not something we can pick centrally.

The default is unchanged and cited to `DEFAULT_LOG_REQUEST_COST_BYTES`'s own doc comment rather than restated, so the derivation has one home. Also refreshed `docs/README.md`'s entry, which described the file as the PUTs/day formula only.

Docs only. All four cross-links verified to resolve in-tree.

Refs: #904