### PR TITLE
feat(query,bench): measure fetch amplification per phase

### DIFF
--- a/crates/ravel-bench/src/bin/sql_latency_bench.rs
+++ b/crates/ravel-bench/src/bin/sql_latency_bench.rs
@@ -26,8 +26,8 @@ use clap::Parser;
 use ravel_bench::harness::{StoreKind, store_from_env};
 use ravel_bench::sql_corpus::{checked_default_corpus, load_external_corpus};
 use ravel_bench::sql_latency::{
-    Compaction, DatasetInfo, FlightTarget, GenerateConfig, SqlLatencyReport, TenantConfigInput,
-    run_generated, run_tenant,
+    Compaction, DatasetInfo, FlightTarget, GenerateConfig, RunAccounting, SqlLatencyReport,
+    TenantConfigInput, run_generated, run_tenant,
 };
 use ravel_sql::DEFAULT_MAX_QUERY_BYTES;
 use ravel_types::TimeRange;
@@ -581,6 +581,7 @@ fn print_human_table(report: &SqlLatencyReport) {
             warm_hits,
         );
     }
+    print_fetch_amplification(report);
     if !report.skipped.is_empty() {
         println!("\n  skipped (unsatisfied declared column):");
         for s in &report.skipped {
@@ -592,6 +593,71 @@ fn print_human_table(report: &SqlLatencyReport) {
         for f in &report.failed {
             println!("    {:<32} run {}: {}", f.id, f.run, f.error);
         }
+    }
+}
+
+/// The cold run's fetch amplification and the per-phase wire bytes behind it
+/// (issue #913).
+///
+/// Every label spells out which of the two byte kinds it is, because the block
+/// carries both and they cannot be summed or compared: `wire_bytes_*` is what
+/// the object store transferred (coalescing holes and retries included), and
+/// `page_stored_bytes_decoded` is the post-compression length of the pages the
+/// decode kept, as they sit in the object.
+fn print_fetch_amplification(report: &SqlLatencyReport) {
+    let rows: Vec<(&str, &RunAccounting)> = report
+        .entries
+        .iter()
+        .filter_map(|e| match e.per_run_accounting.as_deref() {
+            Some([cold, ..]) => Some((e.id.as_str(), cold)),
+            _ => None,
+        })
+        .collect();
+    if rows.is_empty() {
+        return;
+    }
+    println!(
+        "\n  fetch amplification, cold run: scan-phase WIRE bytes per STORED page byte decoded."
+    );
+    println!(
+        "  Probe, PAGE_DIR, SKIP_IDX and directory bytes are the plan/probe phases, not the numerator."
+    );
+    println!(
+        "  Not the same quantity as page_bytes_fetched / page_bytes_decoded, which is stored over stored."
+    );
+    println!(
+        "  {:<32} | {:>16} | {:>16} | {:>16} | {:>16} | {:>16} | {:>25} | {:>13}",
+        "id",
+        "wire_bytes_scan",
+        "wire_bytes_probe",
+        "wire_bytes_plan",
+        "wire_bytes_resolve",
+        "wire_bytes_unattr",
+        "page_stored_bytes_decoded",
+        "amplification",
+    );
+    println!(
+        "  {:-<32}-+-{:-<16}-+-{:-<16}-+-{:-<16}-+-{:-<16}-+-{:-<16}-+-{:-<25}-+-{:-<13}",
+        "", "", "", "", "", "", "", ""
+    );
+    let phase = |acc: &RunAccounting, name: &str| {
+        acc.wire_bytes_by_phase
+            .iter()
+            .find(|p| p.phase == name)
+            .map_or("-".to_string(), |p| p.wire_bytes.to_string())
+    };
+    for (id, acc) in rows {
+        println!(
+            "  {:<32} | {:>16} | {:>16} | {:>16} | {:>16} | {:>16} | {:>25} | {:>13.3}",
+            id,
+            phase(acc, "scan"),
+            phase(acc, "probe"),
+            phase(acc, "plan"),
+            phase(acc, "resolve"),
+            acc.wire_bytes_unattributed,
+            acc.page_stored_bytes_decoded,
+            acc.fetch_amplification,
+        );
     }
 }
 

--- a/crates/ravel-bench/src/sql_latency.rs
+++ b/crates/ravel-bench/src/sql_latency.rs
@@ -59,7 +59,8 @@ use ravel_logseg::{
 use ravel_object_store::{ObjectStoreBackend, PutOptions};
 use ravel_query::{
     CacheFetchError, DEFAULT_FETCH_CONCURRENCY, DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
-    DEFAULT_MAX_SEGMENTS, EngineConfig, LogSegmentFetcher, ProbeMissCounter, SegmentFetcher,
+    DEFAULT_MAX_SEGMENTS, EngineConfig, LogSegmentFetcher, PhaseWireByteCounter,
+    PhaseWireByteCounts, ProbeMissCounter, QueryPhase, SegmentFetcher,
 };
 use ravel_sql::{
     DEFAULT_MAX_QUERY_BYTES, DeclaredColumn, DeclaredType, SpanSegmentFetcher, SqlConfig,
@@ -452,6 +453,90 @@ pub struct RunAccounting {
     /// the run's total is the two summed.
     #[serde(default)]
     pub probe_misses_scan: u64,
+    /// WIRE bytes this run transferred, split by the query phase that issued
+    /// the request, one entry per `ravel_query::QueryPhase` and no phase twice
+    /// (issue #913). Read off `LogSegmentFetcher`'s per-phase counter, so a
+    /// phase the RLOG read path does not issue (`resolve`, the catalog's own
+    /// commit-record GETs) reports zero here even though those bytes are in
+    /// [`Self::object_store_bytes`]; the difference is
+    /// [`Self::wire_bytes_unattributed`].
+    ///
+    /// Wire bytes only: what the store transferred, coalescing holes and
+    /// retries included. Never comparable with, and never summable with,
+    /// [`Self::page_stored_bytes_decoded`], which is stored page bytes.
+    #[serde(default)]
+    pub wire_bytes_by_phase: Vec<PhaseWireBytes>,
+    /// WIRE bytes in [`Self::object_store_bytes`] that no phase-attributing
+    /// funnel claimed, i.e. `object_store_bytes` minus the sum of
+    /// [`Self::wire_bytes_by_phase`]. Derived by difference, not measured: the
+    /// catalog snapshot resolve issues its commit-record GETs through
+    /// `ravel-catalog`, which records them on the query's pooled
+    /// `QueryAccounting` and has no per-phase channel. Treat it as "resolve and
+    /// anything else outside the log read path", not as a checked figure.
+    #[serde(default)]
+    pub wire_bytes_unattributed: u64,
+    /// STORED page bytes this run's decode consumed after column projection:
+    /// `QueryAccounting::page_bytes_decoded`, the sum of `PageDesc::len` over
+    /// the pages the projection kept. Post-compression bytes as they sit in the
+    /// object, NOT bytes transferred and NOT decompressed bytes.
+    ///
+    /// This is the denominator of [`Self::fetch_amplification`].
+    #[serde(default)]
+    pub page_stored_bytes_decoded: u64,
+    /// Fetch amplification: scan-phase WIRE bytes divided by
+    /// [`Self::page_stored_bytes_decoded`] STORED bytes. How many bytes the
+    /// store actually moved for each byte of page the statement went on to
+    /// decode.
+    ///
+    /// The numerator is the `scan` entry of [`Self::wire_bytes_by_phase`]: the
+    /// BLOCKS-section data ranges, with a coalesced run's unwanted bytes
+    /// included because they crossed the wire. Probe, PAGE_DIR, SKIP_IDX and
+    /// directory bytes are NOT in it; they are the `probe`/`plan` entries.
+    ///
+    /// Not the same quantity as `page_bytes_fetched / page_bytes_decoded`,
+    /// which compares two STORED page-byte figures and describes a pre-version-4
+    /// logical block: on an RLOG v4 object a page the query does not want is
+    /// never fetched, so that pair overstates amplification by exactly the
+    /// bytes v4 avoids.
+    ///
+    /// `0.0` when the run decoded no page.
+    #[serde(default)]
+    pub fetch_amplification: f64,
+}
+
+/// One phase's share of a run's WIRE bytes (issue #913).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct PhaseWireBytes {
+    /// The phase, as `ravel_query::QueryPhase::name` spells it: `resolve`,
+    /// `plan`, `probe`, or `scan`.
+    pub phase: String,
+    /// Bytes the object store transferred for this phase's requests, coalescing
+    /// holes and retries included. WIRE bytes; never stored or decompressed
+    /// bytes.
+    pub wire_bytes: u64,
+}
+
+/// One entry per `QueryPhase`, in `QueryPhase::ALL` order, each phase exactly
+/// once. Driven off `ALL` rather than a hand-written list so a new phase cannot
+/// be silently dropped from the report (issue #913).
+fn phase_wire_bytes(counts: &PhaseWireByteCounts) -> Vec<PhaseWireBytes> {
+    QueryPhase::ALL
+        .iter()
+        .map(|phase| PhaseWireBytes {
+            phase: phase.name().to_string(),
+            wire_bytes: counts.phase(*phase),
+        })
+        .collect()
+}
+
+/// Scan-phase WIRE bytes over STORED decoded page bytes. `0.0` when nothing was
+/// decoded, so a statement that read no page reports no ratio rather than an
+/// infinity that would poison any aggregate over the report.
+fn amplification(scan_wire_bytes: u64, page_stored_bytes_decoded: u64) -> f64 {
+    if page_stored_bytes_decoded == 0 {
+        return 0.0;
+    }
+    scan_wire_bytes as f64 / page_stored_bytes_decoded as f64
 }
 
 /// One measured statement.
@@ -920,6 +1005,10 @@ impl Default for ExecutorSettings {
 struct ColdExecutor {
     executor: SqlExecutor,
     probe_misses: ProbeMissCounter,
+    /// Per-phase WIRE bytes of the same log fetcher (#913), cloned out for the
+    /// same reason as `probe_misses`: `SqlOutcome` carries only a pooled
+    /// `QueryAccountingSnapshot`, which has no per-phase byte field.
+    wire_bytes: PhaseWireByteCounter,
 }
 
 fn cold_executor(
@@ -963,6 +1052,7 @@ fn cold_executor(
     // them, but taking the handle last keeps that a local fact rather than an
     // ordering the reader has to verify.
     let probe_misses = log_fetcher.probe_miss_counter();
+    let wire_bytes = log_fetcher.phase_wire_byte_counter();
     let executor = SqlExecutor::new(
         catalog,
         SegmentFetcher::new(Arc::clone(store)),
@@ -984,6 +1074,7 @@ fn cold_executor(
     Ok(ColdExecutor {
         executor,
         probe_misses,
+        wire_bytes,
     })
 }
 
@@ -1124,6 +1215,9 @@ pub async fn measure_corpus(
         // that run, so a shared executor attributes each statement's misses to
         // that statement and never to the ones before it.
         let probe_misses = &built.probe_misses;
+        // #913: the same accumulate-and-difference treatment for the per-phase
+        // wire bytes, and for the same reason.
+        let wire_bytes = &built.wire_bytes;
         let req = SqlRequest {
             sql: entry.sql.clone(),
             window,
@@ -1169,6 +1263,7 @@ pub async fn measure_corpus(
             // Taken here, after the EXPLAIN side artifact above, so a plan
             // written for `--explain-dir` is not charged to run 0.
             let probe_misses_before = probe_misses.snapshot();
+            let wire_bytes_before = wire_bytes.snapshot();
             let start = Instant::now();
             let outcome = match executor.execute(tenant_hash, &req).await {
                 Ok(outcome) => outcome,
@@ -1202,6 +1297,9 @@ pub async fn measure_corpus(
             // costs are already in `object_store_get_requests` above; this says
             // how many of them the probe window is responsible for.
             let run_probe_misses = probe_misses.snapshot().saturating_sub(&probe_misses_before);
+            // #913: this run's WIRE bytes per phase, and the amplification they
+            // and the run's STORED decoded page bytes form.
+            let run_wire = wire_bytes.snapshot().saturating_sub(&wire_bytes_before);
             per_run_accounting.push(RunAccounting {
                 object_store_get_requests: acc.s3_requests(AccountedOp::Get),
                 object_store_list_requests: acc.s3_requests(AccountedOp::List),
@@ -1211,6 +1309,13 @@ pub async fn measure_corpus(
                 cache_bytes: acc.cache_bytes,
                 probe_misses_plan: run_probe_misses.plan,
                 probe_misses_scan: run_probe_misses.scan,
+                wire_bytes_by_phase: phase_wire_bytes(&run_wire),
+                wire_bytes_unattributed: acc.total_s3_bytes().saturating_sub(run_wire.total()),
+                page_stored_bytes_decoded: acc.page_bytes_decoded,
+                fetch_amplification: amplification(
+                    run_wire.phase(QueryPhase::Scan),
+                    acc.page_bytes_decoded,
+                ),
             });
             if run == 0 {
                 // The cold run's block counters and rows go into `scan`; its
@@ -3359,6 +3464,187 @@ mod tests {
                 "run {run}: the derived probe covered every scan-phase tail section"
             );
         }
+    }
+
+    // ---- Fetch amplification (#913) ---------------------------------------
+
+    /// The per-phase WIRE bytes, the STORED decoded page bytes, and the
+    /// amplification they form reach `per_run_accounting` and the report JSON,
+    /// on every run.
+    ///
+    /// Same fixture and same ranged path as the probe-miss tests above (at the
+    /// default threshold this object is read whole in one GET, which is a real
+    /// but uninteresting amplification shape and would exercise none of the
+    /// per-phase split), and with the read cache OFF. With a cache, this
+    /// statement's plan-phase whole-object fallback admits `(0, object_size)`
+    /// and the scan that follows is served entirely from it, so the scan phase
+    /// correctly reports zero wire bytes and the numerator this test is about
+    /// is never exercised.
+    ///
+    /// What is pinned exactly:
+    ///
+    /// - Every `QueryPhase` appears exactly once, in `QueryPhase::ALL` order,
+    ///   in the struct AND in the serialized report.
+    /// - The phases plus `wire_bytes_unattributed` equal `object_store_bytes`
+    ///   exactly, and the attributed part never exceeds it. A call site that
+    ///   recorded a GET into two phases would push the attributed sum above the
+    ///   pooled total and clamp the unattributed residual to zero, which the
+    ///   second assertion catches.
+    /// - `fetch_amplification` is exactly the scan-phase wire bytes over the
+    ///   stored decoded page bytes, from the two fields beside it.
+    ///
+    /// The byte totals themselves are not pinned to literals here: they are a
+    /// property of the generated corpus, not of this plumbing, and
+    /// `tests/log_page_dir_fetch.rs` pins the exact numerator, denominator and
+    /// ratio on a fixture whose page geometry is known.
+    ///
+    /// Prove-the-test: demonstrated failing during development by charging the
+    /// version-4 chunk ranges to `phases.metadata` instead of `phases.blocks`
+    /// in `fetch_object_v4` (the scan phase reads 0 and the amplification with
+    /// it), and by dropping the `self.wire_bytes.record(...)` line from
+    /// `BlockRangeFetcher::store_get` (the phase sum falls below
+    /// `object_store_bytes` and the residual absorbs it).
+    #[tokio::test]
+    async fn wire_bytes_and_amplification_reach_per_run_accounting() {
+        let store = empty_store();
+        let tenant = TenantId::new("amplification-tenant");
+        let objects = write_shard_objects(&store, &tenant, 0, 1).await;
+        let suffix = suffix_just_past_skip_idx(&objects[0]);
+        let window = TimeRange {
+            start_ns: 0,
+            end_ns: NOW_NS,
+        };
+        let (measured, skipped, failed) = measure_corpus(
+            &store,
+            tenant.hash(),
+            &[entry("q", PROBE_MISS_SQL)],
+            &[],
+            2,
+            window,
+            NOW_NS,
+            0,
+            Duration::from_secs(30),
+            false,
+            None,
+            ExecutorSettings {
+                logs_block_range_threshold: 0,
+                logs_suffix_len: Some(suffix),
+                ..ExecutorSettings::default()
+            },
+            false,
+            None,
+        )
+        .await
+        .expect("run");
+        assert!(skipped.is_empty() && failed.is_empty());
+        let acc = measured[0]
+            .per_run_accounting
+            .as_ref()
+            .expect("an in-process lane records per-run accounting");
+        assert_eq!(acc.len(), 2, "one accounting entry per run");
+
+        let names: Vec<&str> = QueryPhase::ALL.iter().map(|p| p.name()).collect();
+        for (run, entry) in acc.iter().enumerate() {
+            let phases: Vec<&str> = entry
+                .wire_bytes_by_phase
+                .iter()
+                .map(|p| p.phase.as_str())
+                .collect();
+            assert_eq!(
+                phases, names,
+                "run {run}: every phase exactly once, in QueryPhase::ALL order"
+            );
+
+            let attributed: u64 = entry.wire_bytes_by_phase.iter().map(|p| p.wire_bytes).sum();
+            assert!(
+                attributed <= entry.object_store_bytes,
+                "run {run}: attributed wire bytes {attributed} exceed the pooled \
+                 {}, so a GET was charged twice",
+                entry.object_store_bytes
+            );
+            assert_eq!(
+                attributed + entry.wire_bytes_unattributed,
+                entry.object_store_bytes,
+                "run {run}: the phases plus the residual are the pooled total"
+            );
+            assert_eq!(
+                entry.fetch_amplification,
+                amplification(
+                    entry.wire_bytes_by_phase[QueryPhase::Scan.index()].wire_bytes,
+                    entry.page_stored_bytes_decoded,
+                ),
+                "run {run}: the ratio is the two fields beside it, not a third figure"
+            );
+        }
+
+        // Cold run: this statement reads pages, and the split is not degenerate.
+        let cold = &acc[0];
+        assert!(
+            cold.page_stored_bytes_decoded > 0,
+            "the statement projects `body` and decodes its pages"
+        );
+        assert_eq!(
+            cold.wire_bytes_by_phase[QueryPhase::Resolve.index()].wire_bytes,
+            0,
+            "the RLOG read path issues no resolve request"
+        );
+        assert!(
+            cold.wire_bytes_by_phase[QueryPhase::Scan.index()].wire_bytes > 0,
+            "a data read moved BLOCKS-section bytes"
+        );
+        assert!(
+            cold.wire_bytes_by_phase[QueryPhase::Plan.index()].wire_bytes > 0,
+            "this statement is not skip-decidable, so it pays a planning read"
+        );
+        assert!(
+            cold.fetch_amplification > 0.0,
+            "a run that decoded pages has a ratio"
+        );
+
+        // What a measurement pass actually reads: the figures have to be in the
+        // report JSON, once per phase per run.
+        let v: serde_json::Value = serde_json::to_value(&measured[0]).expect("serialize entry");
+        let per_run = v["per_run_accounting"]
+            .as_array()
+            .expect("per_run_accounting is a JSON array");
+        for run in 0..2 {
+            let by_phase = per_run[run]["wire_bytes_by_phase"]
+                .as_array()
+                .expect("wire_bytes_by_phase is a JSON array");
+            assert_eq!(by_phase.len(), 4, "run {run}: four phases, no phase twice");
+            let serialized: Vec<&str> = by_phase
+                .iter()
+                .map(|p| p["phase"].as_str().expect("phase name"))
+                .collect();
+            assert_eq!(serialized, names, "run {run}: JSON phase names and order");
+            assert_eq!(
+                per_run[run]["page_stored_bytes_decoded"], acc[run].page_stored_bytes_decoded,
+                "run {run}: the denominator is in the JSON"
+            );
+        }
+    }
+
+    /// An older report, written before #913 added these fields, still
+    /// deserializes: every new field carries `#[serde(default)]`, as the
+    /// `probe_misses_*` pair does.
+    #[test]
+    fn a_pre_913_run_accounting_still_deserializes() {
+        let older = serde_json::json!({
+            "object_store_get_requests": 3,
+            "object_store_list_requests": 1,
+            "object_store_bytes": 836,
+            "cache_hits": 0,
+            "cache_misses": 2,
+            "cache_bytes": 0,
+            "probe_misses_plan": 1,
+            "probe_misses_scan": 1,
+        });
+        let acc: RunAccounting = serde_json::from_value(older).expect("older report deserializes");
+        assert_eq!(acc.object_store_bytes, 836);
+        assert!(acc.wire_bytes_by_phase.is_empty());
+        assert_eq!(acc.wire_bytes_unattributed, 0);
+        assert_eq!(acc.page_stored_bytes_decoded, 0);
+        assert_eq!(acc.fetch_amplification, 0.0);
     }
 
     // ---- The `--logs-suffix-len` seam (#883) -------------------------------

--- a/crates/ravel-query/src/lib.rs
+++ b/crates/ravel-query/src/lib.rs
@@ -33,10 +33,12 @@ pub use log_fetcher::{
     DEFAULT_LOG_MAX_CONCURRENT_GETS, DEFAULT_LOG_REQUEST_COST_BYTES, DEFAULT_LOG_SUFFIX_LEN,
     DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD, LOG_SUFFIX_FLOOR_BYTES, LOG_SUFFIX_SIZE_DIVISOR,
     LogFetchError, LogFetchOutput, LogQuery, LogSegmentFetcher, LogSegmentScan, ProbeMissCounter,
-    ProbeMissCounts, ProbePhase, StreamAttrEquals, WHOLE_OBJECT_REQUEST_MULTIPLE,
+    ProbeMissCounts, ProbePhase, ReadPhases, StreamAttrEquals, WHOLE_OBJECT_REQUEST_MULTIPLE,
     derive_suffix_len,
 };
-pub use phase_accounting::{PhaseAccounting, PhaseAccountingSnapshot, QueryPhase};
+pub use phase_accounting::{
+    PhaseAccounting, PhaseAccountingSnapshot, PhaseWireByteCounter, PhaseWireByteCounts, QueryPhase,
+};
 pub use query_admission::{
     QueryAdmissionController, QueryConcurrencyLimit, QueryPermit, QueryRejected,
     query_admission_snapshot_key, reconcile_query_admission_once,

--- a/crates/ravel-query/src/log_fetcher.rs
+++ b/crates/ravel-query/src/log_fetcher.rs
@@ -52,7 +52,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::erasure::ErasurePredicate;
 use crate::fetcher::ReadCache;
-use crate::phase_accounting::{PhaseAccounting, QueryPhase};
+use crate::phase_accounting::{PhaseAccounting, PhaseWireByteCounter, QueryPhase};
 use bytes::Bytes;
 use ravel_cache::{CacheKey, SingleFlightError, Source};
 use ravel_catalog::SegmentRef;
@@ -542,18 +542,45 @@ pub struct LogSegmentFetcher {
     /// served (#883). Shared by every clone, like `block_range`'s GET semaphore,
     /// and read through [`probe_miss_counter`](Self::probe_miss_counter).
     probe_misses: ProbeMissCounter,
+    /// Per-phase WIRE bytes across every read this fetcher has served (#913).
+    /// Shared by every clone, and pushed into `block_range` by every builder
+    /// below so this fetcher's own whole-object GETs and the block-range
+    /// fetcher's ranged GETs accumulate into one set of totals. Read through
+    /// [`phase_wire_byte_counter`](Self::phase_wire_byte_counter).
+    wire_bytes: PhaseWireByteCounter,
 }
 
 impl LogSegmentFetcher {
     pub fn new(store: Arc<dyn ObjectStoreBackend>) -> Self {
+        let wire_bytes = PhaseWireByteCounter::new();
         LogSegmentFetcher {
             store: store.clone(),
             cfg: RlogConfig::default(),
             cache: None,
             block_range_threshold: DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
-            block_range: BlockRangeFetcher::new(store),
+            block_range: BlockRangeFetcher::new(store).with_wire_byte_counter(wire_bytes.clone()),
             probe_misses: ProbeMissCounter::new(),
+            wire_bytes,
         }
+    }
+
+    /// This fetcher's accumulating per-phase WIRE byte counter (#913): the
+    /// numerator channel of fetch amplification. Clone it out before handing
+    /// the fetcher to whatever will own it, then read
+    /// [`PhaseWireByteCounter::snapshot`] on each side of an execution to
+    /// attribute that execution's bytes; the counter itself never resets.
+    ///
+    /// Every figure it holds is WIRE bytes, never stored or decompressed
+    /// bytes. The denominator of fetch amplification is
+    /// `QueryAccountingSnapshot::page_bytes_decoded`, which counts STORED page
+    /// bytes; the two are different quantities and must never be summed.
+    ///
+    /// Survives every builder below, including
+    /// [`with_block_range`](Self::with_block_range), which replaces the
+    /// `BlockRangeFetcher` but re-attaches this counter to the replacement.
+    #[must_use]
+    pub fn phase_wire_byte_counter(&self) -> PhaseWireByteCounter {
+        self.wire_bytes.clone()
     }
 
     /// This fetcher's accumulating per-phase probe-miss counter (#883). Clone it
@@ -660,9 +687,14 @@ impl LogSegmentFetcher {
     /// instance's `block_range_threshold`; pair it with
     /// [`with_block_range_threshold`](Self::with_block_range_threshold) to route
     /// small fixtures through it.
+    ///
+    /// The replacement is re-attached to this instance's per-phase WIRE byte
+    /// counter (#913), so a caller that took the handle from
+    /// [`phase_wire_byte_counter`](Self::phase_wire_byte_counter) before or
+    /// after this call reads the same totals either way.
     #[must_use]
     pub fn with_block_range(mut self, block_range: BlockRangeFetcher) -> Self {
-        self.block_range = block_range;
+        self.block_range = block_range.with_wire_byte_counter(self.wire_bytes.clone());
         self
     }
 
@@ -923,6 +955,10 @@ impl LogSegmentFetcher {
             .await?;
             accounting.record_s3_request(AccountedOp::Get);
             accounting.add_s3_bytes(AccountedOp::Get, got.data.len() as u64);
+            // #913: a data read, so the whole object's wire bytes are the
+            // scan phase's (`ReadPhases::SCAN.blocks`).
+            self.wire_bytes
+                .record(ReadPhases::SCAN.blocks, got.data.len() as u64);
             // This funnel issues exactly one whole-object GET per call.
             fetch_span.record("s3_requests", 1u64);
             fetch_span.record("s3_bytes", got.data.len() as u64);
@@ -1112,7 +1148,7 @@ impl LogSegmentFetcher {
             return Ok(None);
         }
         let bytes = self
-            .whole_object_bytes(seg_ref, tenant_hash, accounting)
+            .whole_object_bytes(seg_ref, tenant_hash, ReadPhases::SCAN.blocks, accounting)
             .await?;
         let key = &seg_ref.data_object_key;
         let span = decode_span();
@@ -1669,6 +1705,11 @@ impl LogSegmentFetcher {
             return Ok(None);
         }
 
+        // #913: which phase this read's metadata GETs and its BLOCKS-section
+        // GETs charge their wire bytes to. The caller already named the phase
+        // it reads on, so the split is derived here rather than passed again.
+        let phases = phase.read_phases();
+
         // ADR-0107: an object above the block-range threshold is fetched by
         // reading only the blocks skip-index pruning proved relevant, not the
         // whole object. Small objects (all current fixtures, RLOG's typical
@@ -1710,6 +1751,7 @@ impl LogSegmentFetcher {
                         &query.prune,
                         columns,
                         carried,
+                        phases,
                         accounting,
                     )
                     .await
@@ -1727,7 +1769,7 @@ impl LogSegmentFetcher {
         }
 
         Ok(Some(
-            self.whole_object_bytes(seg_ref, tenant_hash, accounting)
+            self.whole_object_bytes(seg_ref, tenant_hash, phases.blocks, accounting)
                 .await?,
         ))
     }
@@ -1741,10 +1783,17 @@ impl LogSegmentFetcher {
     /// predicate-free full-window whole-segment path
     /// ([`scan_whole_accounted_with_tenant`](Self::scan_whole_accounted_with_tenant),
     /// #693 part 3), which reads the whole object in one GET regardless of size.
+    ///
+    /// `phase` is the [`QueryPhase`] the GET's WIRE bytes are charged to
+    /// (#913). This read exists to obtain block data, so its caller passes
+    /// [`ReadPhases::blocks`]: on a scan that is [`QueryPhase::Scan`], and on
+    /// `plan_segment`'s whole-object fallback it is [`QueryPhase::Plan`], which
+    /// keeps a planning read out of the scan-phase numerator.
     async fn whole_object_bytes(
         &self,
         seg_ref: &SegmentRef,
         tenant_hash: TenantHash,
+        phase: QueryPhase,
         accounting: &QueryAccounting,
     ) -> Result<Bytes, LogFetchError> {
         let key = &seg_ref.data_object_key;
@@ -1780,6 +1829,7 @@ impl LogSegmentFetcher {
             .await?;
             accounting.record_s3_request(AccountedOp::Get);
             accounting.add_s3_bytes(AccountedOp::Get, got.data.len() as u64);
+            self.wire_bytes.record(phase, got.data.len() as u64);
             fetch_span.record("s3_requests", 1u64);
             fetch_span.record("s3_bytes", got.data.len() as u64);
             return Ok(got.data);
@@ -1795,6 +1845,7 @@ impl LogSegmentFetcher {
                     let got = self.store.get(key, GetRange::Full).await?;
                     accounting.record_s3_request(AccountedOp::Get);
                     accounting.add_s3_bytes(AccountedOp::Get, got.data.len() as u64);
+                    self.wire_bytes.record(phase, got.data.len() as u64);
                     Ok(got.data)
                 })
                 .await
@@ -2231,12 +2282,67 @@ impl ProbePhase {
         }
     }
 
+    /// The [`ReadPhases`] a read issued on this phase's behalf charges its
+    /// wire bytes to.
+    #[must_use]
+    pub fn read_phases(self) -> ReadPhases {
+        match self {
+            ProbePhase::Plan => ReadPhases::PLAN,
+            ProbePhase::Scan => ReadPhases::SCAN,
+        }
+    }
+
     /// Lower-case, stable name for a report column or a JSON key, identical to
     /// [`QueryPhase::name`] for the same phase.
     #[must_use]
     pub fn name(self) -> &'static str {
         self.query_phase().name()
     }
+}
+
+/// Which [`QueryPhase`] each of one RLOG read's two GET kinds charges its WIRE
+/// bytes to (issue #913).
+///
+/// A single read of one object issues two kinds of request and they answer
+/// different questions. The metadata GETs -- the suffix probe, a footer chase,
+/// SKIP_IDX, PAGE_DIR, the front directories, BLOOM/POSTINGS, and the object's
+/// trailing bytes -- are what it costs to find out where the data is. The
+/// BLOCKS-section GETs are the data. Charging both to one phase makes fetch
+/// amplification unmeasurable: the numerator would carry directory bytes that
+/// have nothing to do with how much of a block a projection wanted.
+///
+/// The split is on the request, not on the byte: a whole-object GET a data read
+/// issued to obtain block data is charged in full to
+/// [`Self::blocks`], directory bytes included, because those bytes are exactly
+/// the amplification such a read pays. A planning read fetches no block data at
+/// all, so both of its kinds are [`QueryPhase::Plan`] and its whole-object
+/// fallback never lands in a scan figure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReadPhases {
+    /// Phase for every GET that is not BLOCKS-section data.
+    pub metadata: QueryPhase,
+    /// Phase for BLOCKS-section data ranges, and for a whole-object GET issued
+    /// to obtain block data.
+    pub blocks: QueryPhase,
+}
+
+impl ReadPhases {
+    /// A data read: its metadata GETs are [`QueryPhase::Probe`] and its block
+    /// data is [`QueryPhase::Scan`]. The `scan` figure this produces is the
+    /// numerator of fetch amplification.
+    pub const SCAN: ReadPhases = ReadPhases {
+        metadata: QueryPhase::Probe,
+        blocks: QueryPhase::Scan,
+    };
+
+    /// A planning read ([`LogSegmentFetcher::plan_segment`] and
+    /// [`LogSegmentFetcher::plan_segment_block_stats`]). It decodes no block, so
+    /// everything it moves -- including its whole-object fallback -- is
+    /// [`QueryPhase::Plan`].
+    pub const PLAN: ReadPhases = ReadPhases {
+        metadata: QueryPhase::Plan,
+        blocks: QueryPhase::Plan,
+    };
 }
 
 /// Per-phase tail-section probe misses ([`BlockRangeStats::probe_misses`])
@@ -2731,6 +2837,12 @@ pub struct BlockRangeFetcher {
     /// `LogSegmentFetcher` pools across every read of the process rather than
     /// per query.
     assembly_pool: Arc<AssemblyBufferPool>,
+    /// Per-phase WIRE bytes across every read this fetcher has served (#913).
+    /// Written at [`Self::store_get`], the single GET funnel here, beside the
+    /// `QueryAccounting` write of the same bytes. Shared by every clone, and by
+    /// the owning [`LogSegmentFetcher`], which sets its own counter here so one
+    /// execution's whole-object and ranged reads land in the same totals.
+    wire_bytes: PhaseWireByteCounter,
 }
 
 impl BlockRangeFetcher {
@@ -2746,7 +2858,26 @@ impl BlockRangeFetcher {
             request_cost_bytes: DEFAULT_LOG_REQUEST_COST_BYTES,
             get_semaphore: Arc::new(Semaphore::new(DEFAULT_LOG_MAX_CONCURRENT_GETS)),
             assembly_pool: Arc::new(AssemblyBufferPool::default()),
+            wire_bytes: PhaseWireByteCounter::new(),
         }
+    }
+
+    /// Records this fetcher's WIRE bytes into `counter` instead of its own
+    /// (#913). [`LogSegmentFetcher`] calls this so its direct whole-object GETs
+    /// and this fetcher's ranged GETs accumulate into one counter a measurement
+    /// pass can read.
+    #[must_use]
+    pub fn with_wire_byte_counter(mut self, counter: PhaseWireByteCounter) -> Self {
+        self.wire_bytes = counter;
+        self
+    }
+
+    /// This fetcher's accumulating per-phase WIRE byte counter (#913). Cloned
+    /// out before the fetcher is handed away, then read with a
+    /// [`PhaseWireByteCounter::snapshot`] on each side of an execution.
+    #[must_use]
+    pub fn phase_wire_byte_counter(&self) -> PhaseWireByteCounter {
+        self.wire_bytes.clone()
     }
 
     /// This fetcher's assembly-buffer reuse counters (issue #894): how many
@@ -2878,10 +3009,16 @@ impl BlockRangeFetcher {
     /// segment maps to the existing `SnapshotInvalidated` retry path
     /// (ADR-0107 decision 1; `ravel_sql::SqlError::is_segment_not_found`) without
     /// a second mapping.
+    ///
+    /// `phase` is the [`QueryPhase`] this request's WIRE bytes are charged to
+    /// on [`Self::phase_wire_byte_counter`] (#913). Every GET this fetcher
+    /// issues passes through here, so the per-phase totals and the
+    /// `QueryAccounting` GET total are written from one place and cannot drift.
     async fn store_get(
         &self,
         key: &str,
         range: GetRange,
+        phase: QueryPhase,
         accounting: &QueryAccounting,
     ) -> Result<GetOutcome, LogFetchError> {
         let _permit = self
@@ -2902,6 +3039,7 @@ impl BlockRangeFetcher {
             })?;
         accounting.record_s3_request(AccountedOp::Get);
         accounting.add_s3_bytes(AccountedOp::Get, got.data.len() as u64);
+        self.wire_bytes.record(phase, got.data.len() as u64);
         Ok(got)
     }
 
@@ -2914,10 +3052,11 @@ impl BlockRangeFetcher {
         &self,
         key: &str,
         range: GetRange,
+        phase: QueryPhase,
         pin: &EtagPin,
         accounting: &QueryAccounting,
     ) -> Result<GetOutcome, LogFetchError> {
-        let got = self.store_get(key, range, accounting).await?;
+        let got = self.store_get(key, range, phase, accounting).await?;
         pin.check(key, &got.etag)?;
         Ok(got)
     }
@@ -2944,6 +3083,10 @@ impl BlockRangeFetcher {
     /// caller's in-flight GET reports true as well: the same attribution
     /// convention `tenant_bytes` documents, which bounds this call's own cost
     /// and never under-counts the query total.
+    ///
+    /// `phase` is the [`QueryPhase`] a LIVE fetch's wire bytes are charged to
+    /// (#913). A cache hit crossed no network and is charged nothing: its bytes
+    /// are `QueryAccounting::cache_bytes`, a different quantity.
     #[allow(clippy::too_many_arguments)]
     async fn cached_extent(
         &self,
@@ -2952,12 +3095,15 @@ impl BlockRangeFetcher {
         start: u64,
         len: u64,
         range: GetRange,
+        phase: QueryPhase,
         pin: &EtagPin,
         accounting: &QueryAccounting,
     ) -> Result<(Bytes, bool), LogFetchError> {
         let key = seg_ref.data_object_key.as_str();
         let Some(cache) = &self.cache else {
-            let got = self.store_get_pinned(key, range, pin, accounting).await?;
+            let got = self
+                .store_get_pinned(key, range, phase, pin, accounting)
+                .await?;
             check_extent_len(key, got.data.len(), len)?;
             return Ok((got.data, true));
         };
@@ -2969,7 +3115,7 @@ impl BlockRangeFetcher {
         let (bytes, source) = cache
             .get_or_fetch(cache_key, || async move {
                 let got = self
-                    .store_get_pinned(key, range, pin, accounting)
+                    .store_get_pinned(key, range, phase, pin, accounting)
                     .await
                     .map_err(to_cache_error)?;
                 check_extent_len(key, got.data.len(), len).map_err(to_cache_error)?;
@@ -3031,8 +3177,17 @@ impl BlockRangeFetcher {
     ) -> Result<(footer::LogFooter, BlockRangeStats), LogFetchError> {
         let mut stats = BlockRangeStats::default();
         let pin = EtagPin::default();
+        // A planning read moves no BLOCKS-section data, so every byte it
+        // transfers is `Plan` wire bytes (#913, `ReadPhases::PLAN`).
         let (footer, _resident) = self
-            .probe_footer(seg_ref, tenant_hash, &pin, accounting, &mut stats)
+            .probe_footer(
+                seg_ref,
+                tenant_hash,
+                ReadPhases::PLAN.metadata,
+                &pin,
+                accounting,
+                &mut stats,
+            )
             .await?;
         Ok((footer, stats))
     }
@@ -3048,10 +3203,16 @@ impl BlockRangeFetcher {
     /// which is the same "already covered" short circuit
     /// [`place_section`](Self::place_section) gets from [`ObjectAssembler`]
     /// without materializing an object-sized buffer for a directory-only read.
+    ///
+    /// `phase` is the metadata phase of the read this probe belongs to
+    /// ([`ReadPhases::metadata`], #913): the probe and its chase read no
+    /// BLOCKS-section data.
+    #[allow(clippy::too_many_arguments)]
     async fn probe_footer(
         &self,
         seg_ref: &SegmentRef,
         tenant_hash: TenantHash,
+        phase: QueryPhase,
         pin: &EtagPin,
         accounting: &QueryAccounting,
         stats: &mut BlockRangeStats,
@@ -3068,6 +3229,7 @@ impl BlockRangeFetcher {
                 probe_start,
                 suffix,
                 GetRange::Suffix(suffix),
+                phase,
                 pin,
                 accounting,
             )
@@ -3094,6 +3256,7 @@ impl BlockRangeFetcher {
                         offset,
                         len,
                         GetRange::Range(offset, offset + len),
+                        phase,
                         pin,
                         accounting,
                     )
@@ -3152,8 +3315,9 @@ impl BlockRangeFetcher {
         let key = seg_ref.data_object_key.as_str();
         let mut stats = BlockRangeStats::default();
         let pin = EtagPin::default();
+        let phase = ReadPhases::PLAN.metadata;
         let (footer, mut resident) = self
-            .probe_footer(seg_ref, tenant_hash, &pin, accounting, &mut stats)
+            .probe_footer(seg_ref, tenant_hash, phase, &pin, accounting, &mut stats)
             .await?;
 
         let skip_desc = *footer
@@ -3170,6 +3334,7 @@ impl BlockRangeFetcher {
             tenant_hash,
             &footer,
             &[kind::SKIP_IDX],
+            phase,
             &mut resident,
             &pin,
             accounting,
@@ -3182,6 +3347,7 @@ impl BlockRangeFetcher {
                 tenant_hash,
                 &skip_desc,
                 &resident,
+                phase,
                 &pin,
                 accounting,
                 &mut stats,
@@ -3208,6 +3374,7 @@ impl BlockRangeFetcher {
         tenant_hash: TenantHash,
         footer: &footer::LogFooter,
         kinds: &[u32],
+        phase: QueryPhase,
         resident: &mut Vec<(u64, Bytes)>,
         pin: &EtagPin,
         accounting: &QueryAccounting,
@@ -3238,6 +3405,7 @@ impl BlockRangeFetcher {
                     run.abs_start,
                     run.len,
                     GetRange::Range(run.abs_start, run.abs_end()),
+                    phase,
                     pin,
                     accounting,
                 )
@@ -3264,6 +3432,7 @@ impl BlockRangeFetcher {
         tenant_hash: TenantHash,
         desc: &SectionDesc,
         resident: &[(u64, Bytes)],
+        phase: QueryPhase,
         pin: &EtagPin,
         accounting: &QueryAccounting,
         stats: &mut BlockRangeStats,
@@ -3280,6 +3449,7 @@ impl BlockRangeFetcher {
                         desc.offset,
                         desc.len,
                         GetRange::Range(start, end),
+                        phase,
                         pin,
                         accounting,
                     )
@@ -3317,8 +3487,9 @@ impl BlockRangeFetcher {
         let key = seg_ref.data_object_key.as_str();
         let mut stats = BlockRangeStats::default();
         let pin = EtagPin::default();
+        let phase = ReadPhases::PLAN.metadata;
         let (footer, mut resident) = self
-            .probe_footer(seg_ref, tenant_hash, &pin, accounting, &mut stats)
+            .probe_footer(seg_ref, tenant_hash, phase, &pin, accounting, &mut stats)
             .await?;
 
         let skip_desc = *footer
@@ -3335,6 +3506,7 @@ impl BlockRangeFetcher {
             tenant_hash,
             &footer,
             &[kind::SKIP_IDX, kind::PAGE_DIR],
+            phase,
             &mut resident,
             &pin,
             accounting,
@@ -3347,6 +3519,7 @@ impl BlockRangeFetcher {
                 tenant_hash,
                 &skip_desc,
                 &resident,
+                phase,
                 &pin,
                 accounting,
                 &mut stats,
@@ -3364,6 +3537,7 @@ impl BlockRangeFetcher {
                 tenant_hash,
                 &field_desc,
                 &resident,
+                phase,
                 &pin,
                 accounting,
                 &mut stats,
@@ -3384,6 +3558,9 @@ impl BlockRangeFetcher {
     /// selection here; stream/POSTINGS/bloom/numeric pruning still runs at decode
     /// inside the reader over the assembled buffer (it can only narrow the
     /// candidate set further, so every survivor block is fetched).
+    ///
+    /// A data read, so its wire bytes are charged under [`ReadPhases::SCAN`]
+    /// (#913).
     pub async fn fetch_object(
         &self,
         seg_ref: &SegmentRef,
@@ -3400,6 +3577,7 @@ impl BlockRangeFetcher {
             &[],
             &ColumnSelection::all(),
             None,
+            ReadPhases::SCAN,
             accounting,
         )
         .await
@@ -3429,6 +3607,7 @@ impl BlockRangeFetcher {
             &[],
             columns,
             None,
+            ReadPhases::SCAN,
             accounting,
         )
         .await
@@ -3468,6 +3647,12 @@ impl BlockRangeFetcher {
     /// selects which column chunks are fetched as well as which are decoded
     /// (ADR-0699 decision 5); on a version-3 object it is ignored by the fetch,
     /// which reads whole blocks.
+    ///
+    /// `phases` splits this read's WIRE bytes between the phase that pays for
+    /// finding the data and the phase that pays for the data (#913). A caller
+    /// scanning passes [`ReadPhases::SCAN`]; `plan_segment`'s whole-object
+    /// fallback passes [`ReadPhases::PLAN`], which keeps a planning read's
+    /// bytes out of the scan-phase numerator.
     #[allow(clippy::too_many_arguments)]
     pub async fn fetch_object_with_footer(
         &self,
@@ -3478,6 +3663,7 @@ impl BlockRangeFetcher {
         prune: &[Predicate],
         columns: &ColumnSelection,
         plan_footer: Option<CarriedFooter<'_>>,
+        phases: ReadPhases,
         accounting: &QueryAccounting,
     ) -> Result<(Bytes, BlockRangeStats), LogFetchError> {
         let key = seg_ref.data_object_key.as_str();
@@ -3505,7 +3691,9 @@ impl BlockRangeFetcher {
         // cache key, is derived from that size. Read it whole, uncached (the
         // cache key would have to claim a length too).
         if seg_ref.object_size == 0 {
-            let got = self.store_get(key, GetRange::Full, accounting).await?;
+            let got = self
+                .store_get(key, GetRange::Full, phases.blocks, accounting)
+                .await?;
             stats.probe_gets = 1;
             stats.whole_object = true;
             stats.block_bytes_fetched = got.data.len() as u64;
@@ -3529,6 +3717,7 @@ impl BlockRangeFetcher {
                     0,
                     seg_ref.object_size,
                     GetRange::Full,
+                    phases.blocks,
                     &pin,
                     accounting,
                 )
@@ -3573,6 +3762,7 @@ impl BlockRangeFetcher {
                         probe_start,
                         suffix,
                         GetRange::Suffix(suffix),
+                        phases.metadata,
                         &pin,
                         accounting,
                     )
@@ -3600,6 +3790,7 @@ impl BlockRangeFetcher {
                                 offset,
                                 len,
                                 GetRange::Range(offset, offset + len),
+                                phases.metadata,
                                 &pin,
                                 accounting,
                             )
@@ -3649,6 +3840,7 @@ impl BlockRangeFetcher {
                     count_tail_misses,
                     asm,
                     &pin,
+                    phases,
                     accounting,
                     stats,
                 )
@@ -3690,6 +3882,7 @@ impl BlockRangeFetcher {
             seg_ref,
             tenant_hash,
             skip_desc,
+            phases.metadata,
             &pin,
             &mut asm,
             accounting,
@@ -3727,6 +3920,7 @@ impl BlockRangeFetcher {
                     seg_ref,
                     tenant_hash,
                     &footer,
+                    phases.metadata,
                     &pin,
                     &mut asm,
                     accounting,
@@ -3770,6 +3964,7 @@ impl BlockRangeFetcher {
                     0,
                     total_size,
                     GetRange::Full,
+                    phases.blocks,
                     &pin,
                     accounting,
                 )
@@ -3811,6 +4006,7 @@ impl BlockRangeFetcher {
                         tail_start,
                         total_size - tail_start,
                         GetRange::Range(tail_start, total_size),
+                        phases.metadata,
                         &pin,
                         accounting,
                     )
@@ -3829,6 +4025,7 @@ impl BlockRangeFetcher {
             seg_ref,
             tenant_hash,
             &footer,
+            phases.metadata,
             &pin,
             &mut asm,
             accounting,
@@ -3851,6 +4048,7 @@ impl BlockRangeFetcher {
                 seg_ref,
                 tenant_hash,
                 section,
+                phases.metadata,
                 &pin,
                 &mut asm,
                 accounting,
@@ -3864,6 +4062,7 @@ impl BlockRangeFetcher {
             tenant_hash,
             &pin,
             &extents,
+            phases.blocks,
             &mut asm,
             accounting,
             &mut stats,
@@ -3917,6 +4116,7 @@ impl BlockRangeFetcher {
         count_tail_misses: bool,
         mut asm: ObjectAssembler,
         pin: &EtagPin,
+        phases: ReadPhases,
         accounting: &QueryAccounting,
         mut stats: BlockRangeStats,
     ) -> Result<(Bytes, BlockRangeStats), LogFetchError> {
@@ -3966,6 +4166,7 @@ impl BlockRangeFetcher {
                     probe_start,
                     suffix,
                     GetRange::Range(probe_start, total_size),
+                    phases.metadata,
                     pin,
                     accounting,
                 )
@@ -3987,6 +4188,7 @@ impl BlockRangeFetcher {
             seg_ref,
             tenant_hash,
             &[skip_desc, page_desc],
+            phases.metadata,
             pin,
             &mut asm,
             accounting,
@@ -4016,6 +4218,7 @@ impl BlockRangeFetcher {
                     seg_ref,
                     tenant_hash,
                     footer,
+                    phases.metadata,
                     pin,
                     &mut asm,
                     accounting,
@@ -4062,6 +4265,7 @@ impl BlockRangeFetcher {
                     0,
                     total_size,
                     GetRange::Full,
+                    phases.blocks,
                     pin,
                     accounting,
                 )
@@ -4098,6 +4302,7 @@ impl BlockRangeFetcher {
                         tail_start,
                         total_size - tail_start,
                         GetRange::Range(tail_start, total_size),
+                        phases.metadata,
                         pin,
                         accounting,
                     )
@@ -4117,6 +4322,7 @@ impl BlockRangeFetcher {
             seg_ref,
             tenant_hash,
             footer,
+            phases.metadata,
             pin,
             &mut asm,
             accounting,
@@ -4139,6 +4345,7 @@ impl BlockRangeFetcher {
                 seg_ref,
                 tenant_hash,
                 section,
+                phases.metadata,
                 pin,
                 &mut asm,
                 accounting,
@@ -4152,6 +4359,7 @@ impl BlockRangeFetcher {
             tenant_hash,
             pin,
             &wanted,
+            phases.blocks,
             &mut asm,
             accounting,
             &mut stats,
@@ -4167,6 +4375,11 @@ impl BlockRangeFetcher {
     /// identical runs and collapse onto one real request each rather than one
     /// per partition (ADR-0102 decision 1's premise), and the etag pin holds
     /// across the sequence.
+    ///
+    /// These are the BLOCKS-section data ranges, so `phase` is the read's
+    /// [`ReadPhases::blocks`] and the WIRE bytes recorded here are the
+    /// numerator of fetch amplification (#913). A run's coalescing holes are
+    /// included, because the store transferred them.
     #[allow(clippy::too_many_arguments)]
     async fn fetch_chunk_ranges(
         &self,
@@ -4174,6 +4387,7 @@ impl BlockRangeFetcher {
         tenant_hash: TenantHash,
         pin: &EtagPin,
         wanted: &[ByteExtent],
+        phase: QueryPhase,
         asm: &mut ObjectAssembler,
         accounting: &QueryAccounting,
         stats: &mut BlockRangeStats,
@@ -4193,6 +4407,7 @@ impl BlockRangeFetcher {
                     run.abs_start,
                     run.len,
                     GetRange::Range(run.abs_start, run.abs_end()),
+                    phase,
                     pin,
                     accounting,
                 )
@@ -4226,6 +4441,7 @@ impl BlockRangeFetcher {
         seg_ref: &SegmentRef,
         tenant_hash: TenantHash,
         sections: &[SectionDesc],
+        phase: QueryPhase,
         pin: &EtagPin,
         asm: &mut ObjectAssembler,
         accounting: &QueryAccounting,
@@ -4248,6 +4464,7 @@ impl BlockRangeFetcher {
                     run.abs_start,
                     run.len,
                     GetRange::Range(run.abs_start, run.abs_end()),
+                    phase,
                     pin,
                     accounting,
                 )
@@ -4340,6 +4557,7 @@ impl BlockRangeFetcher {
         seg_ref: &SegmentRef,
         tenant_hash: TenantHash,
         footer: &footer::LogFooter,
+        phase: QueryPhase,
         pin: &EtagPin,
         asm: &mut ObjectAssembler,
         accounting: &QueryAccounting,
@@ -4368,6 +4586,7 @@ impl BlockRangeFetcher {
                 start,
                 end - start,
                 GetRange::Range(start, end),
+                phase,
                 pin,
                 accounting,
             )
@@ -4400,6 +4619,7 @@ impl BlockRangeFetcher {
         seg_ref: &SegmentRef,
         tenant_hash: TenantHash,
         footer: &footer::LogFooter,
+        phase: QueryPhase,
         pin: &EtagPin,
         asm: &mut ObjectAssembler,
         accounting: &QueryAccounting,
@@ -4409,8 +4629,17 @@ impl BlockRangeFetcher {
         let desc = *footer
             .section(kind::FIELD_DIR)
             .ok_or_else(|| corrupt(key, LogSegError::Corrupted("missing FIELD_DIR".into())))?;
-        self.place_section(seg_ref, tenant_hash, &desc, pin, asm, accounting, stats)
-            .await?;
+        self.place_section(
+            seg_ref,
+            tenant_hash,
+            &desc,
+            phase,
+            pin,
+            asm,
+            accounting,
+            stats,
+        )
+        .await?;
         let stored = asm.slice(key, desc.offset, desc.len)?;
         let raw =
             decode_section(stored, &desc, &self.cfg).map_err(|source| corrupt(key, source))?;
@@ -4429,6 +4658,7 @@ impl BlockRangeFetcher {
         seg_ref: &SegmentRef,
         tenant_hash: TenantHash,
         section: &SectionDesc,
+        phase: QueryPhase,
         pin: &EtagPin,
         asm: &mut ObjectAssembler,
         accounting: &QueryAccounting,
@@ -4446,6 +4676,7 @@ impl BlockRangeFetcher {
                 section.offset,
                 section.len,
                 GetRange::Range(start, end),
+                phase,
                 pin,
                 accounting,
             )
@@ -4470,6 +4701,7 @@ impl BlockRangeFetcher {
         tenant_hash: TenantHash,
         pin: &EtagPin,
         extents: &[BlockExtent],
+        phase: QueryPhase,
         asm: &mut ObjectAssembler,
         accounting: &QueryAccounting,
         stats: &mut BlockRangeStats,
@@ -4524,7 +4756,7 @@ impl BlockRangeFetcher {
                 .copied()
                 .filter(|e| e.abs_start >= run.abs_start && e.abs_end() <= run.abs_end())
                 .collect();
-            self.fetch_run(seg_ref, tenant_hash, pin, *run, blocks, accounting)
+            self.fetch_run(seg_ref, tenant_hash, pin, *run, blocks, phase, accounting)
         }))
         .await;
         for outcome in outcomes {
@@ -4554,6 +4786,7 @@ impl BlockRangeFetcher {
     /// blocks resident and issues no GET of its own. A follower that still
     /// misses one -- evicted in the meantime, or larger than the cache's
     /// single-entry cap -- fetches that block alone, still single-flighted.
+    #[allow(clippy::too_many_arguments)]
     async fn fetch_run(
         &self,
         seg_ref: &SegmentRef,
@@ -4561,12 +4794,15 @@ impl BlockRangeFetcher {
         pin: &EtagPin,
         run: BlockExtent,
         blocks: Vec<BlockExtent>,
+        phase: QueryPhase,
         accounting: &QueryAccounting,
     ) -> Result<RunOutcome, LogFetchError> {
         let key = seg_ref.data_object_key.as_str();
         let range = GetRange::Range(run.abs_start, run.abs_end());
         let Some(cache) = &self.cache else {
-            let got = self.store_get_pinned(key, range, pin, accounting).await?;
+            let got = self
+                .store_get_pinned(key, range, phase, pin, accounting)
+                .await?;
             let blocks = split_run(key, run.abs_start, &got.data, &blocks)?;
             return Ok(RunOutcome {
                 blocks,
@@ -4603,7 +4839,7 @@ impl BlockRangeFetcher {
         let lead_bytes = cache
             .fetch_peeked(lead_key, || async {
                 let got = self
-                    .store_get_pinned(key, range, pin, accounting)
+                    .store_get_pinned(key, range, phase, pin, accounting)
                     .await
                     .map_err(to_cache_error)?;
                 let split =
@@ -4664,6 +4900,7 @@ impl BlockRangeFetcher {
                         .store_get_pinned(
                             key,
                             GetRange::Range(ext.abs_start, ext.abs_end()),
+                            phase,
                             pin,
                             accounting,
                         )

--- a/crates/ravel-query/src/phase_accounting.rs
+++ b/crates/ravel-query/src/phase_accounting.rs
@@ -36,6 +36,9 @@
 //! crate's fetch pipelines -- and are never summed into a phase's request or
 //! wire-byte totals.
 
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
 use ravel_types::accounting::{QueryAccounting, QueryAccountingSnapshot};
 
 /// The phases a query's object-store cost is split across (issue #796). See
@@ -71,6 +74,130 @@ impl QueryPhase {
             QueryPhase::Probe => "probe",
             QueryPhase::Scan => "scan",
         }
+    }
+
+    /// This phase's position in [`Self::ALL`], which is also its slot in
+    /// [`PhaseWireByteCounter`]'s array.
+    #[must_use]
+    pub fn index(self) -> usize {
+        match self {
+            QueryPhase::Resolve => 0,
+            QueryPhase::Plan => 1,
+            QueryPhase::Probe => 2,
+            QueryPhase::Scan => 3,
+        }
+    }
+}
+
+/// Accumulating per-[`QueryPhase`] count of WIRE bytes -- bytes a store GET
+/// actually transferred -- across every read one fetcher served (issue #913).
+///
+/// # Why this is not a field on `QueryAccounting`
+///
+/// `QueryAccounting` already totals wire bytes per operation kind, but it is
+/// one pooled handle per query: `ravel-sql`'s executor creates a single
+/// `QueryAccounting` per attempt and hands the same handle to the catalog
+/// resolve, the plan reads, and the scan reads alike, so the pooled total
+/// cannot say which phase moved the bytes. [`PhaseAccounting`] solves that by
+/// handing each phase its own handle, but only the callers that already thread
+/// one can use it, and the SQL read path threads the pooled handle instead.
+/// This counter is the channel that reaches a caller which cannot change that
+/// threading: it is owned by the fetcher, shared by every clone, and read the
+/// same way `ravel_query::ProbeMissCounter` is -- [`snapshot`](Self::snapshot)
+/// before and after one execution, then
+/// [`PhaseWireByteCounts::saturating_sub`].
+///
+/// # What lands where
+///
+/// The phase a byte is charged to is the phase of the request that moved it,
+/// decided at the GET call site. For the RLOG read path
+/// (`ravel_query::ReadPhases`):
+///
+/// - [`QueryPhase::Plan`]: every GET a planning read issues -- the footer probe,
+///   the footer chase, SKIP_IDX/PAGE_DIR/FIELD_DIR, and the whole-object plan
+///   fallback. A planning read fetches no block data, so all of its bytes are
+///   plan bytes.
+/// - [`QueryPhase::Probe`]: the metadata GETs of a DATA read -- its suffix
+///   probe, footer chase, SKIP_IDX, PAGE_DIR, the front directories, BLOOM and
+///   POSTINGS, and the object's trailing bytes.
+/// - [`QueryPhase::Scan`]: the BLOCKS-section data ranges of a data read, and a
+///   whole-object GET a data read issued to obtain block data.
+/// - [`QueryPhase::Resolve`]: never written by the RLOG read path. The catalog
+///   snapshot resolve's commit-record GETs are issued by `ravel-catalog`, which
+///   has no handle on this counter.
+///
+/// Cache hits move no bytes over the wire and are recorded here as nothing at
+/// all; they stay on `QueryAccounting::cache_bytes`, which is a different
+/// quantity from every figure in this type.
+#[derive(Debug, Clone, Default)]
+pub struct PhaseWireByteCounter(Arc<PhaseWireByteInner>);
+
+#[derive(Debug, Default)]
+struct PhaseWireByteInner {
+    /// One slot per [`QueryPhase`], indexed by [`QueryPhase::index`].
+    phases: [AtomicU64; 4],
+}
+
+impl PhaseWireByteCounter {
+    /// New counter with every phase at zero.
+    #[must_use]
+    pub fn new() -> Self {
+        PhaseWireByteCounter::default()
+    }
+
+    /// Add `bytes` wire bytes to `phase`. Called from the same place the same
+    /// bytes are recorded onto a `QueryAccounting` handle, so the two channels
+    /// cannot drift: every byte this counter holds is also in that handle's
+    /// GET total, and the per-phase figures sum back to it.
+    pub fn record(&self, phase: QueryPhase, bytes: u64) {
+        self.0.phases[phase.index()].fetch_add(bytes, Ordering::Relaxed);
+    }
+
+    /// Point-in-time copy of every phase's total.
+    #[must_use]
+    pub fn snapshot(&self) -> PhaseWireByteCounts {
+        let mut out = PhaseWireByteCounts::default();
+        for phase in QueryPhase::ALL {
+            out.phases[phase.index()] = self.0.phases[phase.index()].load(Ordering::Relaxed);
+        }
+        out
+    }
+}
+
+/// Point-in-time copy of a [`PhaseWireByteCounter`]'s per-phase totals
+/// (issue #913). Every figure is WIRE bytes: what a store GET transferred,
+/// including a coalesced run's unwanted bytes and any retry. Never stored
+/// bytes, never decompressed bytes, and never cache-served bytes.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct PhaseWireByteCounts {
+    /// One slot per [`QueryPhase`], indexed by [`QueryPhase::index`].
+    phases: [u64; 4],
+}
+
+impl PhaseWireByteCounts {
+    /// Wire bytes charged to `phase`.
+    #[must_use]
+    pub fn phase(&self, phase: QueryPhase) -> u64 {
+        self.phases[phase.index()]
+    }
+
+    /// Field-wise difference `self - earlier`: the wire bytes one measured
+    /// execution added to a counter that keeps accumulating. Saturating, so a
+    /// snapshot pair read out of order reports zero rather than wrapping.
+    #[must_use]
+    pub fn saturating_sub(&self, earlier: &PhaseWireByteCounts) -> PhaseWireByteCounts {
+        let mut out = PhaseWireByteCounts::default();
+        for phase in QueryPhase::ALL {
+            out.phases[phase.index()] =
+                self.phases[phase.index()].saturating_sub(earlier.phases[phase.index()]);
+        }
+        out
+    }
+
+    /// Wire bytes across every phase.
+    #[must_use]
+    pub fn total(&self) -> u64 {
+        self.phases.iter().fold(0u64, |a, b| a.saturating_add(*b))
     }
 }
 
@@ -244,6 +371,54 @@ mod tests {
             pooled.peak_intermediate_bytes, 160,
             "a field-wise sum of the peaks would report memory never held"
         );
+    }
+
+    #[test]
+    fn wire_byte_counter_keeps_each_phase_separate_and_sums_to_the_total() {
+        let wire = PhaseWireByteCounter::new();
+        wire.record(QueryPhase::Probe, 7_000);
+        wire.record(QueryPhase::Scan, 30);
+        wire.record(QueryPhase::Scan, 12);
+
+        let snap = wire.snapshot();
+        assert_eq!(snap.phase(QueryPhase::Resolve), 0);
+        assert_eq!(snap.phase(QueryPhase::Plan), 0);
+        assert_eq!(snap.phase(QueryPhase::Probe), 7_000);
+        assert_eq!(snap.phase(QueryPhase::Scan), 42);
+        assert_eq!(snap.total(), 7_042);
+    }
+
+    #[test]
+    fn wire_byte_delta_is_one_executions_share_of_an_accumulator() {
+        let wire = PhaseWireByteCounter::new();
+        wire.record(QueryPhase::Scan, 100);
+        let before = wire.snapshot();
+        wire.record(QueryPhase::Scan, 30);
+        wire.record(QueryPhase::Probe, 7_000);
+
+        let delta = wire.snapshot().saturating_sub(&before);
+        assert_eq!(delta.phase(QueryPhase::Scan), 30, "the second read only");
+        assert_eq!(delta.phase(QueryPhase::Probe), 7_000);
+        assert_eq!(delta.total(), 7_030);
+
+        // Read out of order: zero rather than a wrapped enormous figure that
+        // would present as a catastrophic amplification.
+        assert_eq!(before.saturating_sub(&wire.snapshot()).total(), 0);
+    }
+
+    #[test]
+    fn every_phase_has_its_own_wire_byte_slot() {
+        // A `QueryPhase::index` collision would silently pool two phases; this
+        // fails on the pooled figure rather than on a name.
+        let wire = PhaseWireByteCounter::new();
+        for (i, phase) in QueryPhase::ALL.iter().enumerate() {
+            wire.record(*phase, 1 << i);
+        }
+        let snap = wire.snapshot();
+        for (i, phase) in QueryPhase::ALL.iter().enumerate() {
+            assert_eq!(snap.phase(*phase), 1 << i, "{} slot", phase.name());
+        }
+        assert_eq!(snap.total(), 15);
     }
 
     #[test]

--- a/crates/ravel-query/tests/log_block_range.rs
+++ b/crates/ravel-query/tests/log_block_range.rs
@@ -46,7 +46,7 @@ use ravel_object_store::{
 };
 use ravel_query::{
     AssemblyBufferStats, BlockRangeFetcher, CarriedFooter, LogFetchError, LogQuery,
-    LogSegmentFetcher,
+    LogSegmentFetcher, ReadPhases,
 };
 use ravel_types::TenantHash;
 use ravel_types::accounting::{AccountedOp, QueryAccounting};
@@ -2131,7 +2131,17 @@ async fn a_version_3_tail_miss_is_counted_once_by_whoever_probed() {
 
     // Case 1: this read issues the probe.
     let (_bytes, own) = fetcher
-        .fetch_object_with_footer(&seg, TENANT, i64::MIN, i64::MAX, &[], &all, None, &acc)
+        .fetch_object_with_footer(
+            &seg,
+            TENANT,
+            i64::MIN,
+            i64::MAX,
+            &[],
+            &all,
+            None,
+            ReadPhases::SCAN,
+            &acc,
+        )
         .await
         .expect("unprompted fetch");
     assert_eq!(own.probe_gets, 1, "the probe covered the footer, no chase");
@@ -2161,6 +2171,7 @@ async fn a_version_3_tail_miss_is_counted_once_by_whoever_probed() {
                 footer: &planned_footer,
                 tail_misses_counted: true,
             }),
+            ReadPhases::SCAN,
             &acc,
         )
         .await
@@ -2196,6 +2207,7 @@ async fn a_version_3_tail_miss_is_counted_once_by_whoever_probed() {
                 footer: &bare_footer,
                 tail_misses_counted: false,
             }),
+            ReadPhases::SCAN,
             &acc,
         )
         .await

--- a/crates/ravel-query/tests/log_page_dir_fetch.rs
+++ b/crates/ravel-query/tests/log_page_dir_fetch.rs
@@ -55,9 +55,10 @@ use ravel_object_store::{
 };
 use ravel_query::{
     BlockRangeFetcher, CacheFetchError, CarriedFooter, LogFetchError, LogQuery, LogSegmentFetcher,
+    PhaseWireByteCounts, QueryPhase, ReadPhases,
 };
 use ravel_types::TenantHash;
-use ravel_types::accounting::{AccountedOp, QueryAccounting};
+use ravel_types::accounting::{AccountedOp, QueryAccounting, QueryAccountingSnapshot};
 use uuid::Uuid;
 
 const TENANT: TenantHash = TenantHash([7u8; 16]);
@@ -527,7 +528,17 @@ async fn version_4_prune_reads_ranges_in_the_surviving_group_only() {
     let seg = seg_ref(bytes.len() as u64, &recs);
     let acc = QueryAccounting::new();
     let (_got, stats) = ranged(store, &bytes)
-        .fetch_object_with_footer(&seg, TENANT, i64::MIN, i64::MAX, &prune, &sel, None, &acc)
+        .fetch_object_with_footer(
+            &seg,
+            TENANT,
+            i64::MIN,
+            i64::MAX,
+            &prune,
+            &sel,
+            None,
+            ReadPhases::SCAN,
+            &acc,
+        )
         .await
         .expect("pruned fetch");
 
@@ -1235,6 +1246,7 @@ async fn a_scan_that_probed_counts_its_own_tail_misses() {
             &[],
             &ColumnSelection::all(),
             None,
+            ReadPhases::SCAN,
             &acc,
         )
         .await
@@ -1296,6 +1308,7 @@ async fn a_carried_footer_that_counted_nothing_leaves_the_scan_to_count() {
                 footer: &footer,
                 tail_misses_counted: false,
             }),
+            ReadPhases::SCAN,
             &acc,
         )
         .await
@@ -1358,6 +1371,7 @@ async fn a_carried_footer_that_already_counted_is_not_counted_again() {
                 footer: &footer,
                 tail_misses_counted: true,
             }),
+            ReadPhases::SCAN,
             &acc,
         )
         .await
@@ -1371,5 +1385,284 @@ async fn a_carried_footer_that_already_counted_is_not_counted_again() {
         plan_stats.probe_misses + stats.probe_misses,
         2,
         "exactly once across the plan and the scan, not twice"
+    );
+}
+
+// ---- 5. fetch amplification: WIRE bytes over STORED decoded page bytes ----
+//
+// Issue #913 T1. Two quantities appear below and they are not comparable:
+//
+//   WIRE bytes    what a store GET transferred, from
+//                 `PhaseWireByteCounts` (`QueryPhase::Scan` is the
+//                 BLOCKS-section data ranges).
+//   STORED bytes  post-compression page lengths from PAGE_DIR, from
+//                 `QueryAccountingSnapshot::page_bytes_decoded`.
+//
+// Fetch amplification is the first divided by the second. Nothing here sums
+// one with the other.
+
+/// Coalescing gap wide enough to fuse every projected chunk of the fixture into
+/// one run, so the run spans the unwanted columns' pages lying between them.
+/// Those bytes crossed the wire and belong in the numerator.
+const HOLE_GAP: u64 = 1 << 20;
+
+/// Sum of the STORED page lengths a projection decodes: an independent walk of
+/// PAGE_DIR, in the same units `DecodedBlock::page_bytes_decoded` reports.
+/// This is the denominator of fetch amplification.
+fn expected_stored_page_bytes(
+    bytes: &[u8],
+    blocks: &[usize],
+    selected: Option<&HashSet<u32>>,
+) -> u64 {
+    let dir = page_dir_of(bytes);
+    let mut total = 0u64;
+    for group in &dir.groups {
+        for chunk in &group.chunks {
+            if !selected.is_none_or(|s| s.contains(&chunk.column_id)) {
+                continue;
+            }
+            for p in &chunk.pages {
+                let whole = group.first_block as usize + p.block as usize;
+                if blocks.contains(&whole) {
+                    total += p.len;
+                }
+            }
+        }
+    }
+    total
+}
+
+/// Sum of the STORED page lengths of EVERY page present in the decoded blocks,
+/// whatever the projection: the quantity `page_bytes_fetched` reports. On a
+/// version-4 object no read moves these bytes, which is the whole point.
+fn expected_present_page_bytes(bytes: &[u8], blocks: &[usize]) -> u64 {
+    expected_stored_page_bytes(bytes, blocks, None)
+}
+
+/// One narrow-projection scan of the fixture, drained to exhaustion, with the
+/// block-range fetcher's coalescing gap pinned to `gap`.
+///
+/// Returns this execution's per-phase WIRE bytes, its accounting snapshot
+/// (whose `page_bytes_*` are STORED page bytes), and the rows it decoded.
+async fn amplification_scan(
+    bytes: &[u8],
+    recs: &[LogRecord],
+    sel: &ColumnSelection,
+    gap: u64,
+) -> (PhaseWireByteCounts, QueryAccountingSnapshot, usize) {
+    let store: Arc<dyn ObjectStoreBackend> = store_with(bytes).await;
+    let block_range = BlockRangeFetcher::new(Arc::clone(&store))
+        .with_whole_object_threshold(0)
+        .with_suffix_len(tail_len(bytes))
+        .with_coalesce_gap(gap);
+    let fetcher = LogSegmentFetcher::new(store)
+        .with_block_range(block_range)
+        .with_block_range_threshold(0);
+    let wire = fetcher.phase_wire_byte_counter();
+    let before = wire.snapshot();
+
+    let seg = seg_ref(bytes.len() as u64, recs);
+    let acc = QueryAccounting::new();
+    let query = LogQuery::new(i64::MIN, i64::MAX);
+    let mut scan = fetcher
+        .scan_accounted_with_tenant(&seg, TENANT, &query, sel, &acc)
+        .await
+        .expect("scan")
+        .expect("the segment overlaps the query window");
+    let mut rows = 0usize;
+    while let Some(block) = scan.next_block().expect("decode") {
+        rows += block.len();
+    }
+    drop(scan);
+    (
+        wire.snapshot().saturating_sub(&before),
+        acc.snapshot(),
+        rows,
+    )
+}
+
+/// The exact numerator, denominator and ratio of fetch amplification on a
+/// fixture whose page geometry is known from PAGE_DIR.
+///
+/// Two gaps, because the numerator is a transfer count and not a page-length
+/// sum. At gap 0 each projected chunk is its own GET and the wire bytes equal
+/// the stored bytes the decode consumed exactly, so the ratio is exactly 1.0.
+/// At [`HOLE_GAP`] the fetcher fuses those chunks into one run that reads
+/// through the unwanted columns' pages, and the numerator grows by exactly
+/// those bytes while the denominator does not move at all.
+///
+/// Non-vacuity: computing the numerator as the sum of `PageDesc::len` over
+/// every page present in the decoded blocks (the pre-version-4 counterfactual
+/// `page_bytes_fetched` still reports) makes the gap-0 case read the
+/// `page_bytes_fetched` total instead of the transferred total, and the exact
+/// equality below fails.
+#[tokio::test]
+async fn fetch_amplification_pins_exact_wire_and_stored_page_bytes() {
+    let recs = records();
+    let bytes = build_object(&recs);
+    let sel = ColumnSelection::fixed_only().with_flags();
+    let ids = resolved(&bytes, &sel).expect("a projection, not all columns");
+    let all_blocks: Vec<usize> = (0..BLOCKS).collect();
+
+    // Denominator oracle: the stored page bytes the projection decodes. The
+    // decode reads every block (the query carries no predicate).
+    let stored_decoded = expected_stored_page_bytes(&bytes, &all_blocks, Some(&ids));
+
+    // ---- gap 0: one GET per projected chunk, no holes -------------------
+    let runs = expected_runs(&bytes, &all_blocks, Some(&ids), 0);
+    let wire_oracle: u64 = runs.iter().map(|(_, len)| len).sum();
+    let (wire, acc, rows) = amplification_scan(&bytes, &recs, &sel, 0).await;
+    assert_eq!(rows, RECORDS, "every record decoded");
+
+    let numerator = wire.phase(QueryPhase::Scan);
+    let denominator = acc.page_bytes_decoded;
+    assert_eq!(
+        numerator, wire_oracle,
+        "scan-phase WIRE bytes are the coalesced projected page runs"
+    );
+    assert_eq!(
+        numerator, 30,
+        "exact BLOCKS-section wire bytes for this fixture and projection"
+    );
+    assert_eq!(
+        denominator, stored_decoded,
+        "the denominator is the STORED bytes of the decoded projected pages"
+    );
+    assert_eq!(
+        denominator, 30,
+        "exact stored decoded page bytes for this fixture and projection"
+    );
+    assert_eq!(
+        numerator as f64 / denominator as f64,
+        1.0,
+        "with each chunk its own GET, a version-4 read transfers exactly what it decodes"
+    );
+
+    // ---- HOLE_GAP: one fused run per contiguous span, holes included ----
+    let hole_runs = expected_runs(&bytes, &all_blocks, Some(&ids), HOLE_GAP);
+    let hole_oracle: u64 = hole_runs.iter().map(|(_, len)| len).sum();
+    let (hole_wire, hole_acc, hole_rows) = amplification_scan(&bytes, &recs, &sel, HOLE_GAP).await;
+    assert_eq!(hole_rows, RECORDS);
+
+    let hole_numerator = hole_wire.phase(QueryPhase::Scan);
+    assert_eq!(
+        hole_numerator, hole_oracle,
+        "a coalesced run's unwanted bytes crossed the wire and are counted"
+    );
+    assert_eq!(
+        hole_numerator, 74_319,
+        "exact BLOCKS-section wire bytes once the projected chunks fuse"
+    );
+    assert_eq!(
+        hole_acc.page_bytes_decoded, stored_decoded,
+        "the coalescing gap moves the numerator only; the decode is unchanged"
+    );
+    assert_eq!(
+        hole_numerator as f64 / hole_acc.page_bytes_decoded as f64,
+        74_319.0 / 30.0,
+        "exact amplification once a run reads through unwanted pages"
+    );
+}
+
+/// Every WIRE byte an execution moved is charged to exactly one phase, and the
+/// phases sum to the pooled `QueryAccounting` GET total. A call site that
+/// records into the counter without recording into the accounting handle (or
+/// twice into either) breaks this equality.
+///
+/// The metadata GETs of a data read are `Probe`, its BLOCKS-section ranges are
+/// `Scan`, and neither `Resolve` (the catalog's, which this fetcher never
+/// issues) nor `Plan` (no planning read here) is written at all.
+#[tokio::test]
+async fn per_phase_wire_bytes_sum_to_the_pooled_object_store_bytes() {
+    let recs = records();
+    let bytes = build_object(&recs);
+    let sel = ColumnSelection::fixed_only().with_flags();
+    let (wire, acc, _rows) = amplification_scan(&bytes, &recs, &sel, 0).await;
+
+    assert_eq!(
+        wire.total(),
+        acc.s3_bytes(AccountedOp::Get),
+        "the per-phase split neither drops nor double-counts a wire byte"
+    );
+    assert_eq!(
+        wire.total(),
+        acc.total_s3_bytes(),
+        "this read issues GETs only, so the pooled total is the GET total"
+    );
+
+    assert_eq!(
+        wire.phase(QueryPhase::Resolve),
+        0,
+        "the catalog resolve is not this fetcher's traffic"
+    );
+    assert_eq!(
+        wire.phase(QueryPhase::Plan),
+        0,
+        "a scan funnel issues no planning read"
+    );
+
+    // The probe is a suffix of exactly the object tail, plus the two front
+    // sections no suffix reaches.
+    let footer = footer_of(&bytes);
+    let front: u64 = [kind::STREAM_DIR, kind::FIELD_DIR]
+        .iter()
+        .map(|k| footer.section(*k).expect("front section").len)
+        .sum();
+    assert_eq!(
+        wire.phase(QueryPhase::Probe),
+        tail_len(&bytes) + front,
+        "probe-phase wire bytes are the tail probe and the two front sections"
+    );
+    assert_eq!(
+        wire.phase(QueryPhase::Probe) + wire.phase(QueryPhase::Scan),
+        wire.total(),
+        "no third phase carries any of this read's bytes"
+    );
+}
+
+/// The property this metric exists to expose: on a narrow projection over a
+/// version-4 object the new ratio is strictly below the legacy
+/// `page_bytes_fetched / page_bytes_decoded` ratio, and the gap is exactly the
+/// bytes the mandatory PAGE_DIR lets the read never fetch.
+///
+/// Equality would mean either the fetcher is not narrowing as
+/// docs/log-segment-format.md claims, or the numerator is being computed from
+/// page descriptors rather than from transfers.
+#[tokio::test]
+async fn narrow_projection_amplification_is_below_the_legacy_page_byte_ratio() {
+    let recs = records();
+    let bytes = build_object(&recs);
+    let sel = ColumnSelection::fixed_only().with_flags();
+    let all_blocks: Vec<usize> = (0..BLOCKS).collect();
+    let (wire, acc, _rows) = amplification_scan(&bytes, &recs, &sel, 0).await;
+
+    // Legacy pair, unchanged in meaning: both sides are STORED page bytes, and
+    // `page_bytes_fetched` counts every page descriptor in a decoded block
+    // whether or not the read retrieved it.
+    assert_eq!(
+        acc.page_bytes_fetched,
+        expected_present_page_bytes(&bytes, &all_blocks),
+        "the legacy numerator is every present page's stored length"
+    );
+    assert_eq!(acc.page_bytes_fetched, 74_321);
+    assert_eq!(acc.page_bytes_decoded, 30);
+
+    let legacy = acc.page_bytes_fetched as f64 / acc.page_bytes_decoded as f64;
+    let measured = wire.phase(QueryPhase::Scan) as f64 / acc.page_bytes_decoded as f64;
+    assert_eq!(legacy, 74_321.0 / 30.0, "exact legacy ratio");
+    assert_eq!(measured, 1.0, "exact measured ratio");
+    assert!(
+        measured < legacy,
+        "measured amplification {measured} must be strictly below the legacy {legacy}"
+    );
+
+    // The gap is not incidental: it is exactly the stored bytes of the pages
+    // the projection dropped, which a version-4 read never asks the store for.
+    let never_fetched = acc.page_bytes_fetched - acc.page_bytes_decoded;
+    assert_eq!(never_fetched, 74_291);
+    assert_eq!(
+        acc.page_bytes_fetched - wire.phase(QueryPhase::Scan),
+        never_fetched,
+        "the legacy numerator overstates by exactly the bytes version 4 avoids"
     );
 }


### PR DESCRIPTION
Epic #913's T1. The ClickBench report gains actual wire amplification,
split by QueryPhase, so a statement's fetch cost can be read against the
bytes it decoded rather than against a counterfactual.

The metric this replaces was already in the tree and looked ready:
QueryAccounting carries page_bytes_fetched and page_bytes_decoded
(ADR-0107 decision 4), both are recorded on the logs and spans paths,
and spans_scan_bench already prints them. They measure the wrong thing
for this purpose. page_bytes_fetched sums every page descriptor present
in a decoded block, whether or not the read retrieved it, and its own
doc says so: decode-time accounting, not wire bytes. RLOG v4 has a
mandatory PAGE_DIR and fetches page ranges from the query's
ColumnSelection, so a page a query does not want is never read at all.
The pair therefore describes a pre-v4 counterfactual.

On a fixture with known page geometry the difference is three orders of
magnitude:

  legacy   74,321 / 30 = 2,477.4x
  measured      30 / 30 =     1.0
  never fetched  74,291 bytes

A test asserts the overstatement is exactly the bytes version 4 avoids,
so the gap is pinned rather than described.

The reported figure is BLOCKS-section range bytes transferred over
stored bytes of projected pages decoded, with retries and coalescing
holes in the numerator. Probe, PAGE_DIR and index bytes are reported in
their own phases; folding them into the numerator would reintroduce the
same category error in a different form.

Per-phase attribution uses the existing QueryPhase axis rather than a
new vocabulary. The legacy pair keeps its meaning and its callers.

Refs: #913
