### PR TITLE
feat(bench): make the logs request-cost knob settable from sql_latency_bench

### DIFF
--- a/crates/ravel-bench/src/bin/sql_latency_bench.rs
+++ b/crates/ravel-bench/src/bin/sql_latency_bench.rs
@@ -178,9 +178,14 @@ struct Args {
     /// The logs per-request byte budget (ADR-0904), the same knob as
     /// `ravel-server --logs-request-cost-bytes`: the byte cost the logs planner
     /// charges each object against when deciding whether a scan routes through
-    /// the ranged probe-then-fetch path instead of a whole-object read. Raising
-    /// it makes the planner willing to spend more requests on a scan. Defaults
-    /// to ravel-query's compiled-in value, the one every earlier run used;
+    /// the ranged probe-then-fetch path instead of a whole-object read. The
+    /// value is how many transferred bytes one saved round trip is worth, so
+    /// RAISING it makes each request more expensive and the planner spends
+    /// FEWER of them: reads coalesce and lean toward whole objects, request
+    /// count falls and bytes rise. Lowering it does the reverse. Measured on
+    /// the ClickBench corpus at ratio 0, raising it from the default to 8 MiB
+    /// moved 763,288 GETs to 724,016 and 194 GB to 306 GB. Defaults to
+    /// ravel-query's compiled-in value, the one every earlier run used;
     /// recorded in the report header and provenance.
     #[arg(long, value_name = "BYTES", default_value_t = ravel_query::DEFAULT_LOG_REQUEST_COST_BYTES)]
     logs_request_cost_bytes: u64,
@@ -489,8 +494,16 @@ fn provenance_header(p: &Provenance, d: &DatasetInfo) -> String {
     ));
     out.push_str(&format!("  fetch conc : {}\n", p.fetch_concurrency));
     out.push_str(&format!(
-        "  req cost   : {} bytes\n",
-        p.logs_request_cost_bytes
+        "  req cost   : requested={} bytes  effective={}\n",
+        p.logs_request_cost_bytes_requested,
+        match p.logs_request_cost_bytes_effective {
+            Some(v) => format!("{v} bytes"),
+            // A Flight run does not send the knob to the server; the routing
+            // was governed by the server's own config, which this process
+            // cannot name. Printing the requested value here would make a
+            // Flight pass look like it ran at a setting it never applied.
+            None => "unknown (server config)".to_string(),
+        }
     ));
     out.push_str(&format!(
         "  query max  : requested={} bytes  effective={}\n",
@@ -783,7 +796,8 @@ mod tests {
             cache_bytes: 0,
             deadline_secs: 30,
             fetch_concurrency: ravel_query::DEFAULT_FETCH_CONCURRENCY,
-            logs_request_cost_bytes: cost,
+            logs_request_cost_bytes_requested: cost,
+            logs_request_cost_bytes_effective: Some(cost),
             sql_max_query_bytes_requested: DEFAULT_MAX_QUERY_BYTES,
             sql_max_query_bytes_effective: Some(DEFAULT_MAX_QUERY_BYTES),
             tenant_max_bytes: 1 << 30,
@@ -806,15 +820,45 @@ mod tests {
         let cost = 4_242_424;
         let d = dataset("pre-compaction", None);
         let header = provenance_header(&provenance_with_cost(cost), &d);
-        let line = format!("  req cost   : {cost} bytes");
+        let line = format!("  req cost   : requested={cost} bytes  effective={cost} bytes");
         assert!(
             header.contains(&line),
             "header must stamp the configured request cost verbatim; got:\n{header}"
         );
         assert_eq!(
             header.matches(&format!("{cost}")).count(),
+            2,
+            "the request-cost value appears exactly twice, as requested and as \
+             effective; got:\n{header}"
+        );
+    }
+
+    /// A Flight run does not send the knob to the server, so the effective
+    /// value is the server's own and this process cannot name it. The header
+    /// must say so rather than repeating the requested value: a stamp that
+    /// names a setting which did not govern is worse than no stamp, because it
+    /// makes two Flight passes taken at different `--logs-request-cost-bytes`
+    /// values look like a controlled comparison.
+    #[test]
+    fn header_does_not_claim_a_flight_run_applied_the_requested_request_cost() {
+        let cost = 4_242_424;
+        let d = dataset("pre-compaction", None);
+        let mut p = provenance_with_cost(cost);
+        p.source = "flight".to_string();
+        p.logs_request_cost_bytes_effective = None;
+        let header = provenance_header(&p, &d);
+        assert!(
+            header.contains(&format!(
+                "  req cost   : requested={cost} bytes  effective=unknown (server config)"
+            )),
+            "a Flight run must report the effective request cost as server-controlled; \
+             got:\n{header}"
+        );
+        assert_eq!(
+            header.matches(&format!("{cost}")).count(),
             1,
-            "the request-cost value must be stamped exactly once; got:\n{header}"
+            "the requested value appears once and is NOT repeated as effective; \
+             got:\n{header}"
         );
     }
 
@@ -829,7 +873,8 @@ mod tests {
             &d,
         );
         let line = format!(
-            "  req cost   : {} bytes",
+            "  req cost   : requested={} bytes  effective={} bytes",
+            ravel_query::DEFAULT_LOG_REQUEST_COST_BYTES,
             ravel_query::DEFAULT_LOG_REQUEST_COST_BYTES
         );
         assert!(

--- a/crates/ravel-bench/src/bin/sql_latency_bench.rs
+++ b/crates/ravel-bench/src/bin/sql_latency_bench.rs
@@ -26,8 +26,8 @@ use clap::Parser;
 use ravel_bench::harness::{StoreKind, store_from_env};
 use ravel_bench::sql_corpus::{checked_default_corpus, load_external_corpus};
 use ravel_bench::sql_latency::{
-    Compaction, DatasetInfo, FlightTarget, GenerateConfig, RunAccounting, SqlLatencyReport,
-    TenantConfigInput, run_generated, run_tenant,
+    Compaction, DatasetInfo, FlightTarget, GenerateConfig, Provenance, RunAccounting,
+    SqlLatencyReport, TenantConfigInput, run_generated, run_tenant,
 };
 use ravel_sql::DEFAULT_MAX_QUERY_BYTES;
 use ravel_types::TimeRange;
@@ -175,6 +175,15 @@ struct Args {
     /// earlier run used; recorded in the report's provenance.
     #[arg(long, default_value_t = ravel_query::DEFAULT_FETCH_CONCURRENCY)]
     fetch_concurrency: usize,
+    /// The logs per-request byte budget (ADR-0904), the same knob as
+    /// `ravel-server --logs-request-cost-bytes`: the byte cost the logs planner
+    /// charges each object against when deciding whether a scan routes through
+    /// the ranged probe-then-fetch path instead of a whole-object read. Raising
+    /// it makes the planner willing to spend more requests on a scan. Defaults
+    /// to ravel-query's compiled-in value, the one every earlier run used;
+    /// recorded in the report header and provenance.
+    #[arg(long, value_name = "BYTES", default_value_t = ravel_query::DEFAULT_LOG_REQUEST_COST_BYTES)]
+    logs_request_cost_bytes: u64,
     /// Append one JSON line per finished statement to this file as the run
     /// goes (`{"outcome":"measured"|"skipped"|"failed", ...}`), flushed per
     /// line. The full report still goes to stdout at the end; this is what
@@ -362,6 +371,7 @@ async fn run(args: &Args) -> Result<SqlLatencyReport, ravel_bench::sql_latency::
                 deadline: Duration::from_secs(args.deadline_secs),
                 continue_on_error: args.continue_on_error,
                 fetch_concurrency: args.fetch_concurrency,
+                logs_request_cost_bytes: args.logs_request_cost_bytes,
                 progress_jsonl: args.progress_jsonl.clone(),
                 tenant_max_bytes: args.sql_tenant_max_bytes,
                 parallel_final_aggregation: args.sql_parallel_final_aggregation,
@@ -399,6 +409,7 @@ async fn run(args: &Args) -> Result<SqlLatencyReport, ravel_bench::sql_latency::
                 deadline: Duration::from_secs(args.deadline_secs),
                 continue_on_error: args.continue_on_error,
                 fetch_concurrency: args.fetch_concurrency,
+                logs_request_cost_bytes: args.logs_request_cost_bytes,
                 progress_jsonl: args.progress_jsonl.clone(),
                 tenant_max_bytes: args.sql_tenant_max_bytes,
                 parallel_final_aggregation: args.sql_parallel_final_aggregation,
@@ -443,27 +454,46 @@ fn dataset_line(d: &DatasetInfo) -> String {
     line
 }
 
-fn print_human_table(report: &SqlLatencyReport) {
-    let p = &report.provenance;
-    let d = &report.dataset;
-    println!("\nsql_latency_bench report");
-    println!(
-        "  backend    : {} (region={}, endpoint={})",
-        p.store_backend, p.region, p.endpoint
-    );
-    println!("  host       : {} logical cores", p.host_logical_cores);
-    println!("  source     : {}  dataset={}", p.source, p.dataset_id);
-    if let Some(flight) = &p.flight_endpoint {
-        println!("  flight sql : {flight} (scan diagnostics are not on the wire)");
-    }
-    println!("  dataset    : {}", dataset_line(d));
-    println!("  runs/query : {}", p.runs);
-    println!("  deadline   : {} s per statement", p.deadline_secs);
-    println!("  fetch conc : {}", p.fetch_concurrency);
+/// The report's provenance header, as the block of `  key : value` lines the
+/// human table prints above the per-statement rows. Built as a string rather
+/// than printed inline so a test can assert a stamped figure is present and
+/// present exactly once: a knob whose value the header drops, or stamps twice,
+/// leaves a run that cannot say which setting produced it.
+fn provenance_header(p: &Provenance, d: &DatasetInfo) -> String {
     let effective =
         parallel_final_aggregation_effective_label(p.parallel_final_aggregation_effective);
-    println!(
-        "  query max  : requested={} bytes  effective={}",
+    let mut out = String::new();
+    out.push_str("\nsql_latency_bench report\n");
+    out.push_str(&format!(
+        "  backend    : {} (region={}, endpoint={})\n",
+        p.store_backend, p.region, p.endpoint
+    ));
+    out.push_str(&format!(
+        "  host       : {} logical cores\n",
+        p.host_logical_cores
+    ));
+    out.push_str(&format!(
+        "  source     : {}  dataset={}\n",
+        p.source, p.dataset_id
+    ));
+    if let Some(flight) = &p.flight_endpoint {
+        out.push_str(&format!(
+            "  flight sql : {flight} (scan diagnostics are not on the wire)\n"
+        ));
+    }
+    out.push_str(&format!("  dataset    : {}\n", dataset_line(d)));
+    out.push_str(&format!("  runs/query : {}\n", p.runs));
+    out.push_str(&format!(
+        "  deadline   : {} s per statement\n",
+        p.deadline_secs
+    ));
+    out.push_str(&format!("  fetch conc : {}\n", p.fetch_concurrency));
+    out.push_str(&format!(
+        "  req cost   : {} bytes\n",
+        p.logs_request_cost_bytes
+    ));
+    out.push_str(&format!(
+        "  query max  : requested={} bytes  effective={}\n",
         p.sql_max_query_bytes_requested,
         match p.sql_max_query_bytes_effective {
             Some(v) => format!("{v} bytes"),
@@ -471,17 +501,17 @@ fn print_human_table(report: &SqlLatencyReport) {
             // effective value is the server's own.
             None => "unknown (server config)".to_string(),
         }
-    );
-    println!(
-        "  tenant max : {} bytes  parallel final agg: requested={} effective={}",
+    ));
+    out.push_str(&format!(
+        "  tenant max : {} bytes  parallel final agg: requested={} effective={}\n",
         p.tenant_max_bytes, p.parallel_final_aggregation_requested, effective
-    );
-    println!(
-        "  max segs   : {}  explain: {}",
+    ));
+    out.push_str(&format!(
+        "  max segs   : {}  explain: {}\n",
         p.sql_max_segments, p.explain
-    );
-    println!(
-        "  warm cat   : {}",
+    ));
+    out.push_str(&format!(
+        "  warm cat   : {}\n",
         match p.warm_catalog {
             Some(true) =>
                 "true (resolve phase warm after the first statement, as a server's would be)",
@@ -491,16 +521,25 @@ fn print_human_table(report: &SqlLatencyReport) {
             // governed nothing on the wire (issue #857 review).
             None => "n/a (Flight lane; the server governs resolve caching)",
         }
-    );
+    ));
     if p.cache_bytes > 0 {
-        println!("  read cache : {} bytes", p.cache_bytes);
+        out.push_str(&format!("  read cache : {} bytes\n", p.cache_bytes));
     } else {
-        println!("  read cache : off");
+        out.push_str("  read cache : off\n");
     }
     match p.logs_suffix_len {
-        Some(n) => println!("  suffix len : {n} bytes (pinned; overrides per-object derivation)"),
-        None => println!("  suffix len : per-object derivation"),
+        Some(n) => out.push_str(&format!(
+            "  suffix len : {n} bytes (pinned; overrides per-object derivation)\n"
+        )),
+        None => out.push_str("  suffix len : per-object derivation\n"),
     }
+    out
+}
+
+fn print_human_table(report: &SqlLatencyReport) {
+    let p = &report.provenance;
+    let d = &report.dataset;
+    print!("{}", provenance_header(p, d));
     println!();
     // `get` is the cold run's object-store GETs; the `w_` columns are the warm
     // run's (run 1) GETs, store bytes, and fetch-cache hits, so a reader can see
@@ -726,6 +765,76 @@ mod tests {
         assert_eq!(
             parallel_final_aggregation_effective_label(Some(false)),
             "false"
+        );
+    }
+
+    /// A provenance with `logs_request_cost_bytes` set to `cost` and every
+    /// other field at a plausible fixed value, for exercising the header stamp
+    /// in isolation.
+    fn provenance_with_cost(cost: u64) -> Provenance {
+        Provenance {
+            store_backend: "memory".to_string(),
+            region: "n/a".to_string(),
+            endpoint: "n/a".to_string(),
+            host_logical_cores: 4,
+            source: "generate".to_string(),
+            dataset_id: "t".to_string(),
+            runs: 3,
+            cache_bytes: 0,
+            deadline_secs: 30,
+            fetch_concurrency: ravel_query::DEFAULT_FETCH_CONCURRENCY,
+            logs_request_cost_bytes: cost,
+            sql_max_query_bytes_requested: DEFAULT_MAX_QUERY_BYTES,
+            sql_max_query_bytes_effective: Some(DEFAULT_MAX_QUERY_BYTES),
+            tenant_max_bytes: 1 << 30,
+            sql_max_segments: ravel_query::DEFAULT_MAX_SEGMENTS,
+            parallel_final_aggregation_requested: true,
+            parallel_final_aggregation_effective: Some(true),
+            explain: false,
+            warm_catalog: Some(false),
+            logs_suffix_len: None,
+            flight_endpoint: None,
+        }
+    }
+
+    /// The header stamps the configured request-cost value, in bytes, exactly
+    /// once. A distinctive value is used so the exactly-once count cannot be
+    /// satisfied by a coincidental match against another field, and the line is
+    /// asserted verbatim so a dropped `bytes` unit or a changed value fails.
+    #[test]
+    fn header_stamps_configured_request_cost_once() {
+        let cost = 4_242_424;
+        let d = dataset("pre-compaction", None);
+        let header = provenance_header(&provenance_with_cost(cost), &d);
+        let line = format!("  req cost   : {cost} bytes");
+        assert!(
+            header.contains(&line),
+            "header must stamp the configured request cost verbatim; got:\n{header}"
+        );
+        assert_eq!(
+            header.matches(&format!("{cost}")).count(),
+            1,
+            "the request-cost value must be stamped exactly once; got:\n{header}"
+        );
+    }
+
+    /// With the flag absent, the value reaching the header is
+    /// `ravel_query::DEFAULT_LOG_REQUEST_COST_BYTES`, so the stamp shows the
+    /// constant, not a hardcoded literal that could drift from the engine.
+    #[test]
+    fn header_stamps_default_request_cost_when_absent() {
+        let d = dataset("pre-compaction", None);
+        let header = provenance_header(
+            &provenance_with_cost(ravel_query::DEFAULT_LOG_REQUEST_COST_BYTES),
+            &d,
+        );
+        let line = format!(
+            "  req cost   : {} bytes",
+            ravel_query::DEFAULT_LOG_REQUEST_COST_BYTES
+        );
+        assert!(
+            header.contains(&line),
+            "an unspecified run stamps the engine default; got:\n{header}"
         );
     }
 

--- a/crates/ravel-bench/src/bin/sql_latency_bench.rs
+++ b/crates/ravel-bench/src/bin/sql_latency_bench.rs
@@ -184,9 +184,16 @@ struct Args {
     /// FEWER of them: reads coalesce and lean toward whole objects, request
     /// count falls and bytes rise. Lowering it does the reverse. Measured on
     /// the ClickBench corpus at ratio 0, raising it from the default to 8 MiB
-    /// moved 763,288 GETs to 724,016 and 194 GB to 306 GB. Defaults to
-    /// ravel-query's compiled-in value, the one every earlier run used;
-    /// recorded in the report header and provenance.
+    /// moved 763,288 GETs to 724,016 and 194 GB to 306 GB.
+    ///
+    /// IGNORED WITH `--flight`. It is not a Flight header, so it never leaves
+    /// this process and the server's own config governs the routing. Setting
+    /// it on a Flight run does not make that run a measurement of this knob;
+    /// the report records the effective value as unknown there for exactly
+    /// that reason.
+    ///
+    /// Defaults to ravel-query's compiled-in value, the one every earlier run
+    /// used; recorded in the report header and provenance.
     #[arg(long, value_name = "BYTES", default_value_t = ravel_query::DEFAULT_LOG_REQUEST_COST_BYTES)]
     logs_request_cost_bytes: u64,
     /// Append one JSON line per finished statement to this file as the run

--- a/crates/ravel-bench/src/sql_latency.rs
+++ b/crates/ravel-bench/src/sql_latency.rs
@@ -58,9 +58,9 @@ use ravel_logseg::{
 };
 use ravel_object_store::{ObjectStoreBackend, PutOptions};
 use ravel_query::{
-    CacheFetchError, DEFAULT_FETCH_CONCURRENCY, DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
-    DEFAULT_MAX_SEGMENTS, EngineConfig, LogSegmentFetcher, PhaseWireByteCounter,
-    PhaseWireByteCounts, ProbeMissCounter, QueryPhase, SegmentFetcher,
+    CacheFetchError, DEFAULT_FETCH_CONCURRENCY, DEFAULT_LOG_REQUEST_COST_BYTES,
+    DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD, DEFAULT_MAX_SEGMENTS, EngineConfig, LogSegmentFetcher,
+    PhaseWireByteCounter, PhaseWireByteCounts, ProbeMissCounter, QueryPhase, SegmentFetcher,
 };
 use ravel_sql::{
     DEFAULT_MAX_QUERY_BYTES, DeclaredColumn, DeclaredType, SpanSegmentFetcher, SqlConfig,
@@ -218,6 +218,15 @@ pub struct Provenance {
     /// full-scan statement is latency-bound and moves nearly linearly with it.
     #[serde(default = "default_fetch_concurrency")]
     pub fetch_concurrency: usize,
+    /// The logs per-request byte budget this run configured
+    /// (`--logs-request-cost-bytes`, ADR-0904), the value fed to
+    /// [`EngineConfig::logs_request_cost_bytes`]. Recorded because it governs
+    /// whether a logs scan routes through the ranged probe-then-fetch path, so a
+    /// pass comparing knob settings is uninterpretable without it. A report
+    /// written before this field existed deserializes to
+    /// [`ravel_query::DEFAULT_LOG_REQUEST_COST_BYTES`].
+    #[serde(default = "default_logs_request_cost_bytes")]
+    pub logs_request_cost_bytes: u64,
     /// The per-query DataFusion memory-pool ceiling this run ASKED for
     /// (`--sql-max-query-bytes`, ADR-0088). A report written before this field
     /// existed deserializes to [`ravel_sql::DEFAULT_MAX_QUERY_BYTES`].
@@ -344,6 +353,13 @@ fn default_max_segments() -> usize {
 /// what a report written before the field existed deserializes to.
 fn default_fetch_concurrency() -> usize {
     DEFAULT_FETCH_CONCURRENCY
+}
+
+/// The logs per-request byte budget every run used before the knob was
+/// reachable from the bench (ADR-0904); also what a report written before the
+/// field existed deserializes to.
+fn default_logs_request_cost_bytes() -> u64 {
+    DEFAULT_LOG_REQUEST_COST_BYTES
 }
 
 /// The deadline every run used before it became configurable (issue #688);
@@ -756,6 +772,12 @@ pub struct GenerateConfig {
     /// flag corresponds to it: this is the seam a probe sweep sets the window
     /// through.
     pub logs_suffix_len: Option<u64>,
+    /// Logs per-request byte budget (`--logs-request-cost-bytes`, ADR-0904),
+    /// fed to [`ExecutorSettings::logs_request_cost_bytes`] and so
+    /// [`EngineConfig::logs_request_cost_bytes`]. Defaults to
+    /// [`ravel_query::DEFAULT_LOG_REQUEST_COST_BYTES`], so an unset flag leaves
+    /// logs-scan routing byte-for-byte unchanged.
+    pub logs_request_cost_bytes: u64,
 }
 
 /// Where the Flight lane sends its statements.
@@ -879,6 +901,13 @@ pub struct TenantConfigInput {
     /// through. Reaches the in-process fetcher only; the Flight lane never
     /// applies it (the setting is not on the Flight wire).
     pub logs_suffix_len: Option<u64>,
+    /// Logs per-request byte budget (`--logs-request-cost-bytes`, ADR-0904),
+    /// fed to [`ExecutorSettings::logs_request_cost_bytes`] and so
+    /// [`EngineConfig::logs_request_cost_bytes`]. Reaches the in-process
+    /// executor only; the Flight lane never applies it (no Flight header, and
+    /// the server's own config governs there). Defaults to
+    /// [`ravel_query::DEFAULT_LOG_REQUEST_COST_BYTES`].
+    pub logs_request_cost_bytes: u64,
 }
 
 fn percentile(sorted_ns: &[u64], pct: f64) -> u64 {
@@ -998,6 +1027,13 @@ pub struct ExecutorSettings {
     /// move it is to sweep the window against measured probe misses first, which
     /// is what this knob exists for.
     pub logs_suffix_len: Option<u64>,
+    /// Per-request byte budget the logs planner charges each object against when
+    /// deciding whether to route a scan through the ranged probe-then-fetch path
+    /// (ADR-0904), the same knob as `ravel-server --logs-request-cost-bytes`.
+    /// Reaches [`EngineConfig::logs_request_cost_bytes`]. Defaults to
+    /// [`ravel_query::DEFAULT_LOG_REQUEST_COST_BYTES`], so an unset flag leaves
+    /// routing byte-for-byte unchanged.
+    pub logs_request_cost_bytes: u64,
 }
 
 impl Default for ExecutorSettings {
@@ -1011,6 +1047,7 @@ impl Default for ExecutorSettings {
             max_segments: DEFAULT_MAX_SEGMENTS,
             logs_block_range_threshold: DEFAULT_LOG_WHOLE_OBJECT_THRESHOLD,
             logs_suffix_len: None,
+            logs_request_cost_bytes: DEFAULT_LOG_REQUEST_COST_BYTES,
         }
     }
 }
@@ -1046,6 +1083,7 @@ fn cold_executor(
         max_segments,
         logs_block_range_threshold,
         logs_suffix_len,
+        logs_request_cost_bytes,
     } = settings;
     let catalog = Arc::new(Catalog::new(
         Arc::clone(store),
@@ -1083,6 +1121,7 @@ fn cold_executor(
             engine: EngineConfig {
                 fetch_concurrency: fetch_concurrency.max(1),
                 max_segments,
+                logs_request_cost_bytes,
                 ..EngineConfig::default()
             },
             parallel_final_aggregation,
@@ -1659,6 +1698,7 @@ pub async fn run_generated(cfg: &GenerateConfig) -> Result<SqlLatencyReport, Err
         parallel_final_aggregation: cfg.parallel_final_aggregation,
         max_segments: cfg.max_segments,
         logs_suffix_len: cfg.logs_suffix_len,
+        logs_request_cost_bytes: cfg.logs_request_cost_bytes,
         ..ExecutorSettings::default()
     };
     let (entries, skipped, failed) = measure_corpus(
@@ -1691,6 +1731,7 @@ pub async fn run_generated(cfg: &GenerateConfig) -> Result<SqlLatencyReport, Err
             cache_bytes: cfg.cache_bytes,
             deadline_secs: cfg.deadline.as_secs(),
             fetch_concurrency: cfg.fetch_concurrency.max(1),
+            logs_request_cost_bytes: cfg.logs_request_cost_bytes,
             sql_max_query_bytes_requested: cfg.max_query_bytes,
             // In-process lane: the requested ceiling reaches the executor's
             // `SqlConfig`, so it is also the effective one.
@@ -1738,6 +1779,7 @@ fn tenant_executor_settings(cfg: &TenantConfigInput, shard_count: u32) -> Execut
         parallel_final_aggregation: cfg.parallel_final_aggregation,
         max_segments: cfg.max_segments,
         logs_suffix_len: cfg.logs_suffix_len,
+        logs_request_cost_bytes: cfg.logs_request_cost_bytes,
         ..ExecutorSettings::default()
     }
 }
@@ -1840,6 +1882,7 @@ pub async fn run_tenant(cfg: &TenantConfigInput) -> Result<SqlLatencyReport, Err
             cache_bytes: cfg.cache_bytes,
             deadline_secs: cfg.deadline.as_secs(),
             fetch_concurrency: cfg.fetch_concurrency.max(1),
+            logs_request_cost_bytes: cfg.logs_request_cost_bytes,
             sql_max_query_bytes_requested: cfg.max_query_bytes,
             // `settings` is passed only on the in-process arm of the match
             // above, so on the Flight lane this ceiling never left the process
@@ -2200,6 +2243,7 @@ mod tests {
             flight: None,
             warm_catalog: false,
             logs_suffix_len: None,
+            logs_request_cost_bytes: DEFAULT_LOG_REQUEST_COST_BYTES,
         }
     }
 
@@ -3205,6 +3249,49 @@ mod tests {
             1,
             "a zero is clamped to one partition, never a zero-partition plan"
         );
+    }
+
+    /// `ExecutorSettings::default()` (an unspecified `--logs-request-cost-bytes`)
+    /// must reach `EngineConfig::logs_request_cost_bytes` as the engine's own
+    /// compiled-in default, not some literal the bench keeps in sync by hand.
+    /// Asserting the constant, not a number, means a change to
+    /// `DEFAULT_LOG_REQUEST_COST_BYTES` cannot silently desynchronise the bench
+    /// from the engine.
+    #[test]
+    fn cold_executor_defaults_logs_request_cost_to_engine_default() {
+        let store = empty_store();
+        let executor = cold_executor(&store, &[], None, ExecutorSettings::default())
+            .expect("build executor")
+            .executor;
+        assert_eq!(
+            executor.config().engine.logs_request_cost_bytes,
+            DEFAULT_LOG_REQUEST_COST_BYTES
+        );
+    }
+
+    /// `--logs-request-cost-bytes` must land on
+    /// `EngineConfig::logs_request_cost_bytes`, not stop at a parsed field.
+    /// Dropping the `logs_request_cost_bytes` line from `cold_executor`'s
+    /// `EngineConfig` (leaving it at `EngineConfig::default()`) makes the config
+    /// read back `DEFAULT_LOG_REQUEST_COST_BYTES` and fail this exact-value
+    /// assertion.
+    #[test]
+    fn cold_executor_threads_logs_request_cost_override() {
+        let store = empty_store();
+        let custom = DEFAULT_LOG_REQUEST_COST_BYTES * 3 + 7;
+        assert_ne!(custom, DEFAULT_LOG_REQUEST_COST_BYTES);
+        let executor = cold_executor(
+            &store,
+            &[],
+            None,
+            ExecutorSettings {
+                logs_request_cost_bytes: custom,
+                ..ExecutorSettings::default()
+            },
+        )
+        .expect("build executor")
+        .executor;
+        assert_eq!(executor.config().engine.logs_request_cost_bytes, custom);
     }
 
     /// A one-object, cache-wired fixture measured twice. Accounting is recorded
@@ -4414,6 +4501,7 @@ mod tests {
             explain_dir: None,
             warm_catalog: false,
             logs_suffix_len: None,
+            logs_request_cost_bytes: DEFAULT_LOG_REQUEST_COST_BYTES,
         };
         let gen_report = run_generated(&gen_cfg).await.expect("generated lane runs");
         let load_ms = gen_report

--- a/crates/ravel-bench/src/sql_latency.rs
+++ b/crates/ravel-bench/src/sql_latency.rs
@@ -218,15 +218,25 @@ pub struct Provenance {
     /// full-scan statement is latency-bound and moves nearly linearly with it.
     #[serde(default = "default_fetch_concurrency")]
     pub fetch_concurrency: usize,
-    /// The logs per-request byte budget this run configured
-    /// (`--logs-request-cost-bytes`, ADR-0904), the value fed to
-    /// [`EngineConfig::logs_request_cost_bytes`]. Recorded because it governs
-    /// whether a logs scan routes through the ranged probe-then-fetch path, so a
-    /// pass comparing knob settings is uninterpretable without it. A report
-    /// written before this field existed deserializes to
+    /// The logs per-request byte budget this run ASKED for
+    /// (`--logs-request-cost-bytes`, ADR-0904). A report written before this
+    /// field existed deserializes to
     /// [`ravel_query::DEFAULT_LOG_REQUEST_COST_BYTES`].
     #[serde(default = "default_logs_request_cost_bytes")]
-    pub logs_request_cost_bytes: u64,
+    pub logs_request_cost_bytes_requested: u64,
+    /// The budget that actually governed execution, or `None` when this process
+    /// cannot know it. Same split, and same reason, as
+    /// [`Self::sql_max_query_bytes_effective`]: the Flight lane does not send
+    /// this setting to the server, so the server's own config governed there.
+    ///
+    /// Recording the requested value as effective would be worse than recording
+    /// nothing. The whole point of stamping the knob is that a pass comparing
+    /// settings is uninterpretable without it; a stamp that names a value which
+    /// did not govern makes two Flight passes taken at different
+    /// `--logs-request-cost-bytes` values look like a controlled comparison
+    /// when both ran under the same server config.
+    #[serde(default)]
+    pub logs_request_cost_bytes_effective: Option<u64>,
     /// The per-query DataFusion memory-pool ceiling this run ASKED for
     /// (`--sql-max-query-bytes`, ADR-0088). A report written before this field
     /// existed deserializes to [`ravel_sql::DEFAULT_MAX_QUERY_BYTES`].
@@ -1731,7 +1741,10 @@ pub async fn run_generated(cfg: &GenerateConfig) -> Result<SqlLatencyReport, Err
             cache_bytes: cfg.cache_bytes,
             deadline_secs: cfg.deadline.as_secs(),
             fetch_concurrency: cfg.fetch_concurrency.max(1),
-            logs_request_cost_bytes: cfg.logs_request_cost_bytes,
+            logs_request_cost_bytes_requested: cfg.logs_request_cost_bytes,
+            // In-process lane, same as the ceiling below: the requested budget
+            // reaches the engine, so it is also the effective one.
+            logs_request_cost_bytes_effective: Some(cfg.logs_request_cost_bytes),
             sql_max_query_bytes_requested: cfg.max_query_bytes,
             // In-process lane: the requested ceiling reaches the executor's
             // `SqlConfig`, so it is also the effective one.
@@ -1882,7 +1895,16 @@ pub async fn run_tenant(cfg: &TenantConfigInput) -> Result<SqlLatencyReport, Err
             cache_bytes: cfg.cache_bytes,
             deadline_secs: cfg.deadline.as_secs(),
             fetch_concurrency: cfg.fetch_concurrency.max(1),
-            logs_request_cost_bytes: cfg.logs_request_cost_bytes,
+            logs_request_cost_bytes_requested: cfg.logs_request_cost_bytes,
+            // `settings` is passed only on the in-process arm of the match
+            // above, so on the Flight lane this budget never left the process
+            // and the server's own config governed the routing. Stamping the
+            // requested value as effective here would make two Flight passes
+            // at different knob settings look like a controlled comparison.
+            logs_request_cost_bytes_effective: match &cfg.flight {
+                Some(_) => None,
+                None => Some(cfg.logs_request_cost_bytes),
+            },
             sql_max_query_bytes_requested: cfg.max_query_bytes,
             // `settings` is passed only on the in-process arm of the match
             // above, so on the Flight lane this ceiling never left the process

--- a/crates/ravel-bench/tests/sql_latency_flight_smoke.rs
+++ b/crates/ravel-bench/tests/sql_latency_flight_smoke.rs
@@ -151,6 +151,7 @@ async fn publish_dataset(store: Arc<dyn ObjectStoreBackend>) -> TenantId {
         explain_dir: None,
         warm_catalog: false,
         logs_suffix_len: None,
+        logs_request_cost_bytes: ravel_query::DEFAULT_LOG_REQUEST_COST_BYTES,
     })
     .await
     .expect("generated lane publishes the dataset");
@@ -250,6 +251,7 @@ fn flight_cfg(
         flight: Some(flight),
         warm_catalog: false,
         logs_suffix_len: None,
+        logs_request_cost_bytes: ravel_query::DEFAULT_LOG_REQUEST_COST_BYTES,
     }
 }
 

--- a/crates/ravel-bench/tests/sql_latency_object_count_invariant.rs
+++ b/crates/ravel-bench/tests/sql_latency_object_count_invariant.rs
@@ -103,6 +103,7 @@ async fn l0_object_count_equals_distinct_data_object_keys() {
         explain_dir: None,
         warm_catalog: false,
         logs_suffix_len: None,
+        logs_request_cost_bytes: ravel_query::DEFAULT_LOG_REQUEST_COST_BYTES,
     };
     let report = run_generated(&cfg).await.expect("generated lane runs");
 

--- a/crates/ravel-bench/tests/sql_latency_smoke.rs
+++ b/crates/ravel-bench/tests/sql_latency_smoke.rs
@@ -60,6 +60,7 @@ fn small_generate_config(store: Arc<dyn ObjectStoreBackend>, runs: usize) -> Gen
         explain_dir: None,
         warm_catalog: false,
         logs_suffix_len: None,
+        logs_request_cost_bytes: ravel_query::DEFAULT_LOG_REQUEST_COST_BYTES,
     }
 }
 


### PR DESCRIPTION
ADR-0904's knob reached EngineConfig and ravel-server but not the
benchmark. sql_latency_bench built its engine config with
..EngineConfig::default(), so every pass ran at the compiled default
and the identifier appeared nowhere under ravel-bench. Epic #904's
measurement task is a pass at a raised knob, which was not runnable at
all: the knob shipped without the one caller that measures it.

The flag defaults to ravel_query::DEFAULT_LOG_REQUEST_COST_BYTES, so a
run that does not pass it behaves exactly as before, and the default is
taken from the constant rather than restated, so the bench cannot
drift from the engine.

The run header stamps the configured value beside the cache regime. A
pass comparing knob settings is worthless if the report does not record
which setting produced it, and a measurement whose configuration has to
be reconstructed from someone's notes is not reproducible. A test
asserts the value appears exactly once, since a figure emitted twice is
as wrong as one emitted incorrectly.

Refs: #904
