### PR TITLE
feat(catalog,sql): decompose SUM and AVG from exact column-stat sums

### DIFF
--- a/crates/ravel-catalog/src/catalog.rs
+++ b/crates/ravel-catalog/src/catalog.rs
@@ -5343,6 +5343,7 @@ mod tests {
                     }),
                     count: 1,
                 }],
+                sum: Some(1),
             }],
         }];
         let stats_bytes = crate::snapshot_format::encode_column_stats(
@@ -5465,6 +5466,7 @@ mod tests {
                     }),
                     count: 1,
                 }],
+                sum: Some(value),
             }],
         }];
         let stats_bytes = crate::snapshot_format::encode_column_stats(

--- a/crates/ravel-catalog/src/column_stats_build.rs
+++ b/crates/ravel-catalog/src/column_stats_build.rs
@@ -132,6 +132,12 @@ enum TallyState {
         min: Option<i64>,
         max: Option<i64>,
         dict: Option<std::collections::BTreeMap<i64, u64>>,
+        /// Running exact sum of the non-null values, accumulated in `i128` so
+        /// the fold itself never overflows (#861). Lowered to the proto's
+        /// `i64` sum at [`ColumnTally::into_proto`]; a value that does not fit
+        /// `i64` there is emitted as an ABSENT sum, not a truncated one, so a
+        /// reader falls back to scanning rather than reading a wrong total.
+        sum: i128,
     },
     Bool {
         min: Option<bool>,
@@ -164,6 +170,7 @@ impl ColumnTally {
                 min: None,
                 max: None,
                 dict: Some(std::collections::BTreeMap::new()),
+                sum: 0,
             },
             DeclaredColumnType::Bool => TallyState::Bool {
                 min: None,
@@ -194,8 +201,15 @@ impl ColumnTally {
             None => self.null_count += 1,
             Some(x) => {
                 self.non_null_count += 1;
-                if let TallyState::I64 { min, max, dict } = &mut self.state {
+                if let TallyState::I64 {
+                    min,
+                    max,
+                    dict,
+                    sum,
+                } = &mut self.state
+                {
                     fold_value(min, max, dict, x);
+                    *sum += i128::from(x);
                 }
             }
         }
@@ -256,19 +270,33 @@ impl ColumnTally {
 
     fn into_proto(self, name: String) -> ColumnStat {
         let declared_type = declared_type_to_stats_tag(self.ty);
+        // Integer sum for an I64 column only (#861), and only when the exact
+        // `i128` fold fits `i64`; an overflow emits an absent sum so the reader
+        // scans rather than reading a truncated total. Every non-I64 type is
+        // left `None`: a float fold would be order-dependent (ADR-0024), and
+        // Bool/Bytes/Str carry no additive semantics.
+        let mut sum: Option<i64> = None;
         let (min, max, dictionary_present, dictionary) = match self.state {
-            TallyState::I64 { min, max, dict } => (
-                min.map(column_value_i64),
-                max.map(column_value_i64),
-                dict.is_some(),
-                dict.unwrap_or_default()
-                    .into_iter()
-                    .map(|(v, count)| DictEntry {
-                        value: Some(column_value_i64(v)),
-                        count,
-                    })
-                    .collect(),
-            ),
+            TallyState::I64 {
+                min,
+                max,
+                dict,
+                sum: total,
+            } => {
+                sum = i64::try_from(total).ok();
+                (
+                    min.map(column_value_i64),
+                    max.map(column_value_i64),
+                    dict.is_some(),
+                    dict.unwrap_or_default()
+                        .into_iter()
+                        .map(|(v, count)| DictEntry {
+                            value: Some(column_value_i64(v)),
+                            count,
+                        })
+                        .collect(),
+                )
+            }
             TallyState::Bool { min, max, dict } => (
                 min.map(column_value_bool),
                 max.map(column_value_bool),
@@ -315,6 +343,7 @@ impl ColumnTally {
             max,
             dictionary_present,
             dictionary,
+            sum,
         }
     }
 }
@@ -609,5 +638,39 @@ mod tests {
         );
         assert_eq!(i64_kind(status.min.as_ref().expect("min")), 200);
         assert_eq!(i64_kind(status.max.as_ref().expect("max")), 500);
+        assert_eq!(
+            status.sum,
+            Some(1504),
+            "exact sum of the non-null values 200+200+404+200+500"
+        );
+    }
+
+    /// #861: only an I64 column carries a sum. A declared `Bool` column is
+    /// folded for min/max/null counts exactly like any other, but its stat
+    /// leaves `sum` absent -- a bool has no additive semantics, and the
+    /// metadata-only SUM/AVG path must fall back to scanning for it.
+    ///
+    /// Prove-the-test: making `into_proto` emit `sum` for the `Bool` arm makes
+    /// `status_bool.sum` non-`None` and the assertion below fails.
+    #[tokio::test]
+    async fn a_bool_column_carries_no_sum() {
+        let store = MemoryStore::new();
+        let records = vec![
+            record(1, &[("flag".to_string(), AttrValue::Bool(true))]),
+            record(2, &[("flag".to_string(), AttrValue::Bool(false))]),
+            record(3, &[("flag".to_string(), AttrValue::Bool(true))]),
+        ];
+        let entry = write_l0(&store, &records).await;
+
+        let typed = vec![declared("flag", DeclaredColumnType::Bool)];
+        let seg = fetch_segment_column_stats(&store, &TENANT, Signal::Logs, &entry, &typed)
+            .await
+            .expect("build stats");
+
+        assert_eq!(seg.columns.len(), 1, "only `flag` is present and declared");
+        let flag = &seg.columns[0];
+        assert_eq!(flag.declared_type, 3, "Bool stats tag");
+        assert_eq!(flag.non_null_count, 3);
+        assert_eq!(flag.sum, None, "a Bool column carries no integer sum");
     }
 }

--- a/crates/ravel-catalog/src/snapshot_format/column_stats.rs
+++ b/crates/ravel-catalog/src/snapshot_format/column_stats.rs
@@ -277,9 +277,28 @@ fn validate_column(column: &ColumnStat) -> Result<(), SnapshotFormatError> {
         });
     }
 
+    // #861: a `sum` is stored for I64 columns only. Any other declared type
+    // carrying one is internally inconsistent; reject before a reader can trust
+    // it.
+    if column.sum.is_some() && column.declared_type != 2 {
+        return Err(SnapshotFormatError::ColumnStatsSumOnNonInteger {
+            name: column.name.clone(),
+            declared_type: column.declared_type,
+        });
+    }
+
     if column.dictionary_present {
         let mut seen: HashSet<Vec<u8>> = HashSet::with_capacity(column.dictionary.len());
         let mut total: u64 = 0;
+        // Exact `Σ value * count` for an I64 column, in `i128` so it never
+        // overflows a valid record; `None` marks an accumulation that exceeded
+        // `i128`, which cannot equal the stored `i64` sum and so fails the
+        // cross-check below.
+        let mut dict_sum: Option<i128> = if column.declared_type == 2 {
+            Some(0)
+        } else {
+            None
+        };
         for entry in &column.dictionary {
             let value = entry.value.as_ref().ok_or_else(|| {
                 SnapshotFormatError::ColumnStatsDictEntryMissingValue {
@@ -293,6 +312,11 @@ fn validate_column(column: &ColumnStat) -> Result<(), SnapshotFormatError> {
                 });
             }
             total = total.saturating_add(entry.count);
+            if let (Some(acc), Some(Kind::I64(v))) = (dict_sum, value.kind.as_ref()) {
+                dict_sum = i128::from(*v)
+                    .checked_mul(i128::from(entry.count))
+                    .and_then(|term| acc.checked_add(term));
+            }
         }
         if total != column.non_null_count {
             return Err(SnapshotFormatError::ColumnStatsDictCountMismatch {
@@ -300,6 +324,20 @@ fn validate_column(column: &ColumnStat) -> Result<(), SnapshotFormatError> {
                 dict_total: total,
                 non_null_count: column.non_null_count,
             });
+        }
+        // A present dictionary AND a present sum must agree exactly: the
+        // dictionary is the ground truth the fold summed. `dict_sum == None`
+        // (an i128 overflow) can never equal an i64 sum, so it is reported as a
+        // mismatch, not silently accepted.
+        if let Some(sum) = column.sum {
+            let dict_total = dict_sum.unwrap_or(i128::MIN);
+            if dict_total != i128::from(sum) {
+                return Err(SnapshotFormatError::ColumnStatsSumMismatch {
+                    name: column.name.clone(),
+                    sum: i128::from(sum),
+                    dict_sum: dict_total,
+                });
+            }
         }
     } else if !column.dictionary.is_empty() {
         return Err(SnapshotFormatError::ColumnStatsDictPresentMismatch {
@@ -432,6 +470,7 @@ mod tests {
                 max: Some(i64_value(9)),
                 dictionary_present: true,
                 dictionary,
+                sum: Some(45), // 0 + 1 + ... + 9
             }],
         }
     }
@@ -593,6 +632,83 @@ mod tests {
                 entries: 10,
             }
         );
+    }
+
+    /// #861: a stored `sum` that disagrees with the dictionary the fold summed
+    /// is internally inconsistent, so a reader could derive a wrong SUM/AVG.
+    /// Reject it at encode/decode.
+    ///
+    /// Prove-the-test: dropping the `ColumnStatsSumMismatch` check in
+    /// `validate_column` lets this encode succeed and the assertion fails.
+    #[test]
+    fn sum_disagreeing_with_dictionary_rejected() {
+        let mut seg = segment(1, 0, 1);
+        // True dictionary sum is 45; claim 44.
+        seg.columns[0].sum = Some(44);
+        let err = encode_column_stats([0x11; 16], 3, vec![], &[seg]).expect_err("rejected");
+        assert_eq!(
+            err,
+            SnapshotFormatError::ColumnStatsSumMismatch {
+                name: "AdvEngineID".to_string(),
+                sum: 44,
+                dict_sum: 45,
+            }
+        );
+    }
+
+    /// #861: a sum is I64-only. A non-integer column carrying one is rejected.
+    ///
+    /// Prove-the-test: dropping the `ColumnStatsSumOnNonInteger` check lets a
+    /// Bool column keep a sum and the assertion fails.
+    #[test]
+    fn sum_on_non_integer_column_rejected() {
+        let mut seg = segment(1, 0, 1);
+        // Reshape the column into a consistent Bool column, then attach a sum.
+        seg.columns[0].declared_type = 3; // Bool
+        seg.columns[0].min = Some(ColumnValue {
+            kind: Some(Kind::B(false)),
+        });
+        seg.columns[0].max = Some(ColumnValue {
+            kind: Some(Kind::B(true)),
+        });
+        seg.columns[0].dictionary = vec![
+            DictEntry {
+                value: Some(ColumnValue {
+                    kind: Some(Kind::B(false)),
+                }),
+                count: 4,
+            },
+            DictEntry {
+                value: Some(ColumnValue {
+                    kind: Some(Kind::B(true)),
+                }),
+                count: 6,
+            },
+        ];
+        seg.columns[0].sum = Some(6);
+        let err = encode_column_stats([0x11; 16], 3, vec![], &[seg]).expect_err("rejected");
+        assert_eq!(
+            err,
+            SnapshotFormatError::ColumnStatsSumOnNonInteger {
+                name: "AdvEngineID".to_string(),
+                declared_type: 3,
+            }
+        );
+    }
+
+    /// A high-cardinality I64 column with its dictionary omitted still carries
+    /// an exact sum (the sum is stored independently of the dictionary), and
+    /// the codec round-trips it without a dictionary to cross-check against.
+    #[test]
+    fn sum_without_dictionary_round_trips() {
+        let mut seg = segment(1, 0, 1);
+        seg.columns[0].dictionary_present = false;
+        seg.columns[0].dictionary = vec![];
+        seg.columns[0].sum = Some(45);
+        let bytes = encode_column_stats([0x11; 16], 3, vec![vec![0x22; 32]], &[seg.clone()])
+            .expect("encodes");
+        let decoded = decode_column_stats(&bytes, &ColumnStatsLimits::default()).expect("decodes");
+        assert_eq!(decoded.segments[0].columns[0].sum, Some(45));
     }
 
     #[test]

--- a/crates/ravel-catalog/src/snapshot_format/column_stats.rs
+++ b/crates/ravel-catalog/src/snapshot_format/column_stats.rs
@@ -287,6 +287,21 @@ fn validate_column(column: &ColumnStat) -> Result<(), SnapshotFormatError> {
         });
     }
 
+    // A column with no non-null values has nothing to sum, so the only exact
+    // sum is zero. Checked here rather than inside the dictionary branch
+    // below, because a record with `dictionary_present = false` never reaches
+    // that branch: without this, `non_null_count = 0` with `sum = Some(k)`
+    // validates, and `LogsScanExec::declared_column_sum` then folds `k` into
+    // the cross-segment total while adding nothing to the count. The SUM would
+    // be wrong by `k` and the AVG wrong in both terms — a wrong answer where
+    // the contract is an exact answer or a decline.
+    if column.non_null_count == 0 && column.sum.is_some_and(|s| s != 0) {
+        return Err(SnapshotFormatError::ColumnStatsSumWithoutValues {
+            name: column.name.clone(),
+            sum: column.sum.unwrap_or(0),
+        });
+    }
+
     if column.dictionary_present {
         let mut seen: HashSet<Vec<u8>> = HashSet::with_capacity(column.dictionary.len());
         let mut total: u64 = 0;
@@ -709,6 +724,49 @@ mod tests {
             .expect("encodes");
         let decoded = decode_column_stats(&bytes, &ColumnStatsLimits::default()).expect("decodes");
         assert_eq!(decoded.segments[0].columns[0].sum, Some(45));
+    }
+
+    /// An all-null column carrying a non-zero sum is rejected at encode.
+    ///
+    /// This shape reaches neither the dictionary cross-check (no dictionary)
+    /// nor the non-integer check (it is I64), so before this guard it
+    /// validated. `LogsScanExec::declared_column_sum` folds `sum` and
+    /// `non_null_count` from each segment independently, so such a record adds
+    /// to the running total while adding nothing to the count: a multi-segment
+    /// SUM comes back wrong by that amount, and AVG wrong in both terms. The
+    /// contract is an exact answer or a decline, never a wrong one.
+    #[test]
+    fn sum_without_non_null_values_rejected() {
+        let mut seg = segment(1, 0, 1);
+        seg.columns[0].dictionary_present = false;
+        seg.columns[0].dictionary = vec![];
+        seg.columns[0].non_null_count = 0;
+        // An all-null column carries no extrema either (checked above this
+        // guard), so clear them: the record must be invalid for exactly one
+        // reason, or the test would pass on the wrong error.
+        seg.columns[0].min = None;
+        seg.columns[0].max = None;
+        seg.columns[0].sum = Some(5);
+        let err = encode_column_stats([0x11; 16], 3, vec![vec![0x22; 32]], &[seg.clone()])
+            .expect_err("an all-null column with a non-zero sum must be rejected");
+        assert!(
+            matches!(
+                &err,
+                SnapshotFormatError::ColumnStatsSumWithoutValues { sum, .. } if *sum == 5
+            ),
+            "{err:?}"
+        );
+
+        // Zero is the exact sum of no values, so it stays valid: the guard
+        // rejects an impossible total, not the absence of one.
+        seg.columns[0].sum = Some(0);
+        encode_column_stats([0x11; 16], 3, vec![vec![0x22; 32]], &[seg.clone()])
+            .expect("an all-null column may carry sum 0");
+
+        // And an absent sum is likewise fine.
+        seg.columns[0].sum = None;
+        encode_column_stats([0x11; 16], 3, vec![vec![0x22; 32]], &[seg])
+            .expect("an all-null column may carry no sum");
     }
 
     #[test]

--- a/crates/ravel-catalog/src/snapshot_format/column_stats.rs
+++ b/crates/ravel-catalog/src/snapshot_format/column_stats.rs
@@ -330,12 +330,12 @@ fn validate_column(column: &ColumnStat) -> Result<(), SnapshotFormatError> {
         // (an i128 overflow) can never equal an i64 sum, so it is reported as a
         // mismatch, not silently accepted.
         if let Some(sum) = column.sum {
-            let dict_total = dict_sum.unwrap_or(i128::MIN);
+            let dict_total = dict_sum.unwrap_or(i128::MAX);
             if dict_total != i128::from(sum) {
                 return Err(SnapshotFormatError::ColumnStatsSumMismatch {
                     name: column.name.clone(),
-                    sum: i128::from(sum),
-                    dict_sum: dict_total,
+                    sum,
+                    dict_sum: dict_total.clamp(i128::from(i64::MIN), i128::from(i64::MAX)) as i64,
                 });
             }
         }

--- a/crates/ravel-catalog/src/snapshot_format/error.rs
+++ b/crates/ravel-catalog/src/snapshot_format/error.rs
@@ -251,4 +251,23 @@ pub enum SnapshotFormatError {
     ColumnStatsMissingMinMax { name: String },
     #[error("column-stats column {name:?} has min greater than max")]
     ColumnStatsMinMaxInverted { name: String },
+    /// A non-integer column carries a `sum`. Sums are stored for I64 columns
+    /// only (#861); any other declared type carrying one is internally
+    /// inconsistent and the metadata-only SUM/AVG path must never read it.
+    #[error(
+        "column-stats column {name:?} declared_type {declared_type} carries a sum \
+         (sums are I64-only)"
+    )]
+    ColumnStatsSumOnNonInteger { name: String, declared_type: u32 },
+    /// A column's stored `sum` disagrees with the sum its own exact dictionary
+    /// implies. A reader deriving SUM/AVG from this record would return a wrong
+    /// total, so it is rejected at encode/decode rather than trusted.
+    #[error(
+        "column-stats column {name:?} sum {sum} disagrees with its dictionary total {dict_sum}"
+    )]
+    ColumnStatsSumMismatch {
+        name: String,
+        sum: i128,
+        dict_sum: i128,
+    },
 }

--- a/crates/ravel-catalog/src/snapshot_format/error.rs
+++ b/crates/ravel-catalog/src/snapshot_format/error.rs
@@ -267,7 +267,12 @@ pub enum SnapshotFormatError {
     )]
     ColumnStatsSumMismatch {
         name: String,
-        sum: i128,
-        dict_sum: i128,
+        /// The column's stored `sum` (proto `i64`).
+        sum: i64,
+        /// The sum its dictionary implies, clamped into `i64` for the message
+        /// only (an `i128` field would 16-byte-align this whole error enum and
+        /// grow every error that embeds it): a real mismatch is what matters,
+        /// not the exact overflowed magnitude.
+        dict_sum: i64,
     },
 }

--- a/crates/ravel-catalog/src/snapshot_format/error.rs
+++ b/crates/ravel-catalog/src/snapshot_format/error.rs
@@ -275,4 +275,12 @@ pub enum SnapshotFormatError {
         /// not the exact overflowed magnitude.
         dict_sum: i64,
     },
+    /// A column with no non-null values carries a non-zero `sum`. An all-null
+    /// column has nothing to sum, so zero is the only exact answer. Rejected
+    /// because the metadata-only path folds `sum` and `non_null_count` from
+    /// each segment independently: a record like this adds to the total while
+    /// adding nothing to the count, making a multi-segment SUM wrong by that
+    /// amount and an AVG wrong in both terms.
+    #[error("column-stats column {name:?} has no non-null values but carries sum {sum}")]
+    ColumnStatsSumWithoutValues { name: String, sum: i64 },
 }

--- a/crates/ravel-sql/src/logs_scan.rs
+++ b/crates/ravel-sql/src/logs_scan.rs
@@ -616,6 +616,19 @@ pub(crate) struct DeclaredGroupCounts {
     pub(crate) null_count: u64,
 }
 
+/// Exact aggregate inputs for the `SUM(col + k)` and `AVG(col)` decompositions
+/// (ADR-0850's q03/q04/q30 shapes, #861), from
+/// [`LogsScanExec::declared_column_sum`]: the exact sum of every touched
+/// segment's non-null values, in `i128` so the cross-segment fold cannot
+/// overflow, plus the exact count of those non-null rows. `SUM(col + k)` is
+/// `sum + k * non_null_count`, `AVG(col)` is `sum / non_null_count`, and both
+/// are `NULL` when `non_null_count == 0` (SQL sum/avg over all-null or zero-row
+/// input), so the caller needs both figures.
+pub(crate) struct DeclaredColumnSum {
+    pub(crate) sum: i128,
+    pub(crate) non_null_count: u64,
+}
+
 /// Log segment scan producing block-at-a-time batches over a projection of the
 /// public `logs` schema. Declares no ordering (ADR-0087 decision 1).
 pub struct LogsScanExec {
@@ -1428,6 +1441,50 @@ impl LogsScanExec {
         Some(DeclaredGroupCounts {
             counts: merged.into_iter().collect(),
             null_count,
+        })
+    }
+
+    /// Exact sum and non-null count for the declared column at schema index
+    /// `FIRST_DECLARED_COL + k` (ADR-0850's q03/q04/q30 shapes, #861), summed
+    /// across every touched segment's exact per-object statistics. `None` means
+    /// fall back to scanning, for the same reasons
+    /// [`Self::declared_not_equal_count`] does (the [`Self::stats_are_exact`]
+    /// gate: no pending erasure, no content or prune predicate, a ts bound that
+    /// clips no touched segment), plus two specific to this path:
+    ///
+    /// - the column is not integer-typed. A sum is stored for `I64` columns
+    ///   only (#861): a float fold would be order-dependent, so a non-`I64`
+    ///   column carries no sum and its `SUM`/`AVG` scans;
+    /// - a touched segment's stat omits its sum. That happens for a would-be
+    ///   float column, for an exact per-object sum that overflowed `i64` at fold
+    ///   time, or for a segment never covered by the loaded stats. In every case
+    ///   there is no exact sum to add, so the whole answer declines rather than
+    ///   undercounting.
+    ///
+    /// Unlike the q02/q08 dictionary paths this needs no `dictionary_present`:
+    /// the sum is exact independently of whether the value dictionary was kept,
+    /// so a high-cardinality integer column still decomposes.
+    pub(crate) fn declared_column_sum(&self, k: usize) -> Option<DeclaredColumnSum> {
+        if !self.stats_are_exact() {
+            return None;
+        }
+        let declared = self.declared.get(k)?;
+        if !matches!(declared.ty, DeclaredType::I64) {
+            return None;
+        }
+        let stats = self.column_stats.as_ref()?;
+        let mut sum: i128 = 0;
+        let mut non_null_count: u64 = 0;
+        for seg in self.segments.iter() {
+            let seg_stats = stats.segments.get(&segment_identity(seg))?;
+            let stat = seg_stats.columns.iter().find(|c| c.name == declared.key)?;
+            let seg_sum = stat.sum?;
+            sum = sum.checked_add(i128::from(seg_sum))?;
+            non_null_count = non_null_count.checked_add(stat.non_null_count)?;
+        }
+        Some(DeclaredColumnSum {
+            sum,
+            non_null_count,
         })
     }
 

--- a/crates/ravel-sql/src/metadata_agg.rs
+++ b/crates/ravel-sql/src/metadata_agg.rs
@@ -18,6 +18,19 @@
 //!   rule). Answered by [`LogsScanExec::declared_group_counts`]: every
 //!   touched segment's exact dictionary merged by value, plus the summed
 //!   `null_count` as a synthetic NULL group when it is nonzero.
+//! - **q03/q04**: `SUM(<declared integer column> + <literal>) FROM logs`, an
+//!   ungrouped, filter-free aggregate directly over a [`LogsScanExec`].
+//!   Answered by [`LogsScanExec::declared_column_sum`] as `sum + k *
+//!   non_null_count` (#861); `k = 0` covers the plain `SUM(col)`. `SUM` over
+//!   zero non-null rows is `NULL`, matching the scan.
+//! - **q30**: `AVG(<declared integer column>) FROM logs`, likewise ungrouped
+//!   and filter-free. Answered as `sum / non_null_count` in `f64`, `NULL` when
+//!   there are no non-null rows.
+//!
+//! The sum-backed shapes decompose only for an integer column, and only when
+//! every touched segment carries an exact sum: a would-be float column, or a
+//! per-object sum that overflowed `i64` at fold time, has no stored sum and
+//! the statement scans (the ADR-0850 safety lemma).
 //!
 //! Both delegate the actual statistics read to `LogsScanExec` (the crate's
 //! established split: `logs_scan.rs` owns every column-stats read,
@@ -44,7 +57,7 @@ use std::fmt;
 use std::sync::Arc;
 
 use datafusion::arrow::array::{ArrayRef, Int64Array, RecordBatch};
-use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::arrow::datatypes::{DataType, SchemaRef};
 use datafusion::common::config::ConfigOptions;
 use datafusion::common::tree_node::{Transformed, TransformedResult, TreeNode};
 use datafusion::error::{DataFusionError, Result as DFResult};
@@ -64,7 +77,7 @@ use datafusion::physical_plan::{
 };
 use datafusion::scalar::ScalarValue;
 
-use crate::logs_scan::{DeclaredGroupCounts, LogsScanExec};
+use crate::logs_scan::{DeclaredColumnSum, DeclaredGroupCounts, LogsScanExec};
 
 /// The rule's name, as it appears in DataFusion's optimizer diagnostics.
 pub const METADATA_ONLY_AGGREGATE_RULE: &str = "metadata_only_aggregate";
@@ -169,41 +182,104 @@ fn group_index(group_by: &physical_plan::aggregates::PhysicalGroupBy) -> Option<
     }
 }
 
-/// Whether `agg`'s aggregate list is exactly one `COUNT(*)`-shaped
-/// expression: physically `count(<non-null literal>)` (DataFusion's
-/// `count_all()`), never a zero-argument call, so this is the exact,
-/// version-grounded shape check rather than a name guess. `is_distinct` and
-/// a per-aggregate `FILTER (WHERE ...)` clause are both refused: neither
-/// changes what `non_null_count` means, but this rule does not attempt to
+/// The single aggregate this rule knows how to answer from statistics, or
+/// `None` for anything else. Every variant carries a scan-output column index
+/// (resolved to a declared column later, once the scan is in hand).
+enum AggKind {
+    /// `COUNT(*)`: physically `count(<non-null literal>)`.
+    CountStar,
+    /// `SUM(col + addend)` over an integer column; `addend == 0` is the plain
+    /// `SUM(col)`.
+    Sum { col_index: usize, addend: i128 },
+    /// `AVG(col)` over an integer column.
+    Avg { col_index: usize },
+}
+
+/// Classify `agg`'s single aggregate, or `None` when it is not exactly one
+/// non-distinct, unfiltered aggregate this rule handles. `is_distinct` and a
+/// per-aggregate `FILTER (WHERE ...)` clause are both refused: neither changes
+/// what the underlying statistics mean, but this rule does not attempt to
 /// reason about them.
-fn is_count_star(agg: &physical_plan::aggregates::AggregateExec) -> bool {
+fn classify_aggregate(agg: &physical_plan::aggregates::AggregateExec) -> Option<AggKind> {
     let aggr_exprs = agg.aggr_expr();
     let filter_exprs = agg.filter_expr();
     if aggr_exprs.len() != 1 || filter_exprs.len() != 1 {
-        return false;
+        return None;
     }
     if filter_exprs[0].is_some() {
-        return false;
+        return None;
     }
     let expr = &aggr_exprs[0];
     if expr.is_distinct() {
-        return false;
-    }
-    if expr.fun().name() != "count" {
-        return false;
+        return None;
     }
     let args = expr.expressions();
     if args.len() != 1 {
-        return false;
+        return None;
     }
-    // `count_all()` is physically `count(<non-null literal>)`; a literal NULL
-    // would make DataFusion evaluate `COUNT(NULL)` as 0, so treating it as
-    // `COUNT(*)` and answering from `non_null_count` would return a filtered
-    // or grouped count where the correct answer is 0. Require the literal to
-    // be non-null.
-    match args[0].downcast_ref::<Literal>() {
-        Some(lit) => !lit.value().is_null(),
-        None => false,
+    match expr.fun().name() {
+        // `count_all()` is physically `count(<non-null literal>)`; a literal
+        // NULL would make DataFusion evaluate `COUNT(NULL)` as 0, so treating
+        // it as `COUNT(*)` and answering from `non_null_count` would return a
+        // filtered or grouped count where the correct answer is 0. Require the
+        // literal to be non-null.
+        "count" => match args[0].downcast_ref::<Literal>() {
+            Some(lit) if !lit.value().is_null() => Some(AggKind::CountStar),
+            _ => None,
+        },
+        "sum" => {
+            let (col_index, addend) = sum_arg(&args[0])?;
+            Some(AggKind::Sum { col_index, addend })
+        }
+        "avg" => {
+            let col = args[0].downcast_ref::<Column>()?;
+            Some(AggKind::Avg {
+                col_index: col.index(),
+            })
+        }
+        _ => None,
+    }
+}
+
+/// The `(column index, integer addend)` of a `SUM` argument this rule can
+/// decompose: a plain `Column` (addend 0), or `Column + <int literal>` /
+/// `<int literal> + Column`. `None` for any other expression, and for a
+/// non-integer literal (a float addend would make the result a float the
+/// integer sum cannot answer exactly).
+fn sum_arg(expr: &Arc<dyn PhysicalExpr>) -> Option<(usize, i128)> {
+    if let Some(col) = expr.downcast_ref::<Column>() {
+        return Some((col.index(), 0));
+    }
+    let binary = expr.downcast_ref::<BinaryExpr>()?;
+    if *binary.op() != Operator::Plus {
+        return None;
+    }
+    let left = binary.left();
+    let right = binary.right();
+    if let (Some(col), Some(lit)) = (
+        left.downcast_ref::<Column>(),
+        right.downcast_ref::<Literal>(),
+    ) {
+        return Some((col.index(), scalar_to_i128(lit.value())?));
+    }
+    if let (Some(lit), Some(col)) = (
+        left.downcast_ref::<Literal>(),
+        right.downcast_ref::<Column>(),
+    ) {
+        return Some((col.index(), scalar_to_i128(lit.value())?));
+    }
+    None
+}
+
+/// An integer literal's value as `i128`, or `None` for a non-integer or NULL
+/// literal.
+fn scalar_to_i128(v: &ScalarValue) -> Option<i128> {
+    match v {
+        ScalarValue::Int64(Some(x)) => Some(i128::from(*x)),
+        ScalarValue::Int32(Some(x)) => Some(i128::from(*x)),
+        ScalarValue::Int16(Some(x)) => Some(i128::from(*x)),
+        ScalarValue::Int8(Some(x)) => Some(i128::from(*x)),
+        _ => None,
     }
 }
 
@@ -248,16 +324,16 @@ fn rewrite(node: Arc<dyn ExecutionPlan>) -> DFResult<Transformed<Arc<dyn Executi
     // Single/SinglePartitioned, or found through a chain of partition-shuffle
     // nodes over a Final/FinalPartitioned stage's Partial input.
     let mut current: Arc<dyn ExecutionPlan> = Arc::clone(&node);
-    let (group, raw_input) = loop {
+    let (group, agg_kind, raw_input) = loop {
         if let Some(a) = current.downcast_ref::<physical_plan::aggregates::AggregateExec>() {
             if a.mode().input_mode() == physical_plan::aggregates::AggregateInputMode::Raw {
                 let Some(group) = group_index(a.group_expr()) else {
                     return Ok(Transformed::no(node));
                 };
-                if !is_count_star(a) {
+                let Some(agg_kind) = classify_aggregate(a) else {
                     return Ok(Transformed::no(node));
-                }
-                break (group, Arc::clone(a.input()));
+                };
+                break (group, agg_kind, Arc::clone(a.input()));
             }
             current = Arc::clone(a.input());
             continue;
@@ -292,12 +368,12 @@ fn rewrite(node: Arc<dyn ExecutionPlan>) -> DFResult<Transformed<Arc<dyn Executi
     };
 
     let schema = node.schema();
-    let batch = match group {
+    let batch = match (group, agg_kind) {
         // q02: COUNT(*) WHERE <declared column> <> <literal>. A predicate-
         // free COUNT(*) here is already handled by DataFusion's own built-in
         // AggregateStatistics rule, so require the filter this rule exists
         // for rather than reproducing that case.
-        None => {
+        (None, AggKind::CountStar) => {
             let Some(filter) = filter else {
                 return Ok(Transformed::no(node));
             };
@@ -326,7 +402,7 @@ fn rewrite(node: Arc<dyn ExecutionPlan>) -> DFResult<Transformed<Arc<dyn Executi
         }
         // q08: <declared column>, COUNT(*) GROUP BY <declared column>. A
         // filter combined with a GROUP BY is out of scope for this rule.
-        Some(col_index) => {
+        (Some(col_index), AggKind::CountStar) => {
             if filter.is_some() {
                 return Ok(Transformed::no(node));
             }
@@ -340,6 +416,48 @@ fn rewrite(node: Arc<dyn ExecutionPlan>) -> DFResult<Transformed<Arc<dyn Executi
                 Some(batch) => batch,
                 None => return Ok(Transformed::no(node)),
             }
+        }
+        // q03/q04: SUM(<declared integer column> + k), ungrouped, no filter.
+        (None, AggKind::Sum { col_index, addend }) => {
+            if filter.is_some() {
+                return Ok(Transformed::no(node));
+            }
+            let Some(k) = scan.declared_index_for_output(col_index) else {
+                return Ok(Transformed::no(node));
+            };
+            let Some(cs) = scan.declared_column_sum(k) else {
+                return Ok(Transformed::no(node));
+            };
+            let Some(scalar) = sum_scalar(&schema, &cs, addend) else {
+                return Ok(Transformed::no(node));
+            };
+            match single_scalar_batch(&schema, scalar) {
+                Some(batch) => batch,
+                None => return Ok(Transformed::no(node)),
+            }
+        }
+        // q30: AVG(<declared integer column>), ungrouped, no filter.
+        (None, AggKind::Avg { col_index }) => {
+            if filter.is_some() {
+                return Ok(Transformed::no(node));
+            }
+            let Some(k) = scan.declared_index_for_output(col_index) else {
+                return Ok(Transformed::no(node));
+            };
+            let Some(cs) = scan.declared_column_sum(k) else {
+                return Ok(Transformed::no(node));
+            };
+            let Some(scalar) = avg_scalar(&schema, &cs) else {
+                return Ok(Transformed::no(node));
+            };
+            match single_scalar_batch(&schema, scalar) {
+                Some(batch) => batch,
+                None => return Ok(Transformed::no(node)),
+            }
+        }
+        // A grouped SUM/AVG is out of scope for this rule.
+        (Some(_), AggKind::Sum { .. }) | (Some(_), AggKind::Avg { .. }) => {
+            return Ok(Transformed::no(node));
         }
     };
 
@@ -388,6 +506,52 @@ fn group_counts_batch(schema: &SchemaRef, counts: DeclaredGroupCounts) -> Option
     let group_array = ScalarValue::iter_to_array(values).ok()?;
     let count_array: ArrayRef = Arc::new(Int64Array::from(tallies));
     RecordBatch::try_new(Arc::clone(schema), vec![group_array, count_array]).ok()
+}
+
+/// The `SUM(col + addend)` answer as a scalar: `sum + addend * non_null_count`,
+/// or SQL `NULL` when no non-null row exists (`SUM` over zero rows is `NULL`,
+/// never 0). `None` -- a decline, never a partial answer -- when the outer
+/// schema is not the single `Int64` column `SUM(<Int64>)` produces, or the
+/// arithmetic overflows `i64` (the declared output type): the ADR-0850 lemma
+/// admits no silent truncation, so an overflow falls back to the scan.
+fn sum_scalar(schema: &SchemaRef, cs: &DeclaredColumnSum, addend: i128) -> Option<ScalarValue> {
+    if schema.fields().len() != 1 || *schema.field(0).data_type() != DataType::Int64 {
+        return None;
+    }
+    if cs.non_null_count == 0 {
+        return Some(ScalarValue::Int64(None));
+    }
+    let term = addend.checked_mul(i128::from(cs.non_null_count))?;
+    let total = cs.sum.checked_add(term)?;
+    Some(ScalarValue::Int64(Some(i64::try_from(total).ok()?)))
+}
+
+/// The `AVG(col)` answer as a scalar: `sum / non_null_count` in `f64`, or SQL
+/// `NULL` when no non-null row exists (`AVG` over zero rows is `NULL`). `None`
+/// when the outer schema is not the single `Float64` column `AVG(<Int64>)`
+/// produces. The division mirrors DataFusion's integer `AVG` exactly: the exact
+/// `i128` sum and the count are each cast to `f64` and divided once, so the
+/// rewritten answer is bit-identical to the scanned one.
+fn avg_scalar(schema: &SchemaRef, cs: &DeclaredColumnSum) -> Option<ScalarValue> {
+    if schema.fields().len() != 1 || *schema.field(0).data_type() != DataType::Float64 {
+        return None;
+    }
+    if cs.non_null_count == 0 {
+        return Some(ScalarValue::Float64(None));
+    }
+    let avg = (cs.sum as f64) / (cs.non_null_count as f64);
+    Some(ScalarValue::Float64(Some(avg)))
+}
+
+/// A single-row, single-column batch carrying `scalar` under `schema`. `None`
+/// on a schema-width mismatch (an internal-error decline; see
+/// [`count_star_batch`]).
+fn single_scalar_batch(schema: &SchemaRef, scalar: ScalarValue) -> Option<RecordBatch> {
+    if schema.fields().len() != 1 {
+        return None;
+    }
+    let array = scalar.to_array().ok()?;
+    RecordBatch::try_new(Arc::clone(schema), vec![array]).ok()
 }
 
 /// `count` as `i64`, `COUNT(*)`'s declared output type. `None` on overflow,

--- a/crates/ravel-sql/tests/logs_metadata_agg.rs
+++ b/crates/ravel-sql/tests/logs_metadata_agg.rs
@@ -116,7 +116,18 @@ fn i64_stat(
     let non_null_count: u64 = dict.iter().map(|(_, c)| c).sum();
     let min = dict.iter().map(|(v, _)| *v).min();
     let max = dict.iter().map(|(v, _)| *v).max();
-    let sum: i64 = dict.iter().map(|(v, c)| *v * (*c as i64)).sum();
+    // Accumulated in `i128` and narrowed once, mirroring what the fold does
+    // with `checked_mul`/`checked_add`. Computing the expected value in raw
+    // `i64` would panic on overflow in a debug build and wrap silently in a
+    // release one, so a fixture with large values would either abort the test
+    // or assert against a wrong expectation. A fixture that cannot fit `i64`
+    // is a bug in the fixture, and this says which.
+    let sum_wide: i128 = dict
+        .iter()
+        .map(|(v, c)| i128::from(*v) * i128::from(*c))
+        .sum();
+    let sum =
+        i64::try_from(sum_wide).expect("fixture dictionary sums beyond i64; choose smaller values");
     let dictionary = if dictionary_present {
         dict.iter()
             .map(|(v, c)| DictEntry {

--- a/crates/ravel-sql/tests/logs_metadata_agg.rs
+++ b/crates/ravel-sql/tests/logs_metadata_agg.rs
@@ -33,7 +33,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use datafusion::arrow::array::{Array, Int64Array};
+use datafusion::arrow::array::{Array, Float64Array, Int64Array};
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::physical_plan::{collect, displayable};
 use datafusion::prelude::SessionContext;
@@ -660,6 +660,44 @@ async fn pending_erasure_declines_and_keeps_the_scan() {
         shown.contains("LogsScanExec"),
         "a pending erasure must fall back to a scan; plan was:\n{shown}"
     );
+
+    // The same erasure must force the sum-backed shapes (q03/q04/q30) to
+    // decline too: a pending erasure removes rows the folded sum and count
+    // still include (`declared_column_sum` gates on the same `stats_are_exact`,
+    // logs_scan.rs). Reuse the erasure snapshot above.
+    let ctx = logs_session(provider(
+        &store,
+        snapshot_of(
+            vec![seg_ref(1, 5), seg_ref(2, 6)],
+            vec![ravel_proto::commit::v1::ErasureRequest {
+                predicate: vec![ravel_proto::commit::v1::ErasurePredicateMatcher {
+                    key: "status".to_string(),
+                    value: "404".to_string(),
+                }],
+                ..Default::default()
+            }],
+        ),
+        status_col(),
+        Some(status_stats(&seg_ref(1, 5), &seg_ref(2, 6))),
+    ))
+    .expect("session");
+    for sql in [
+        "SELECT SUM(status + 1) FROM logs",
+        "SELECT AVG(status) FROM logs",
+    ] {
+        let plan = ctx
+            .sql(sql)
+            .await
+            .expect("plan")
+            .create_physical_plan()
+            .await
+            .expect("physical plan");
+        let shown = plan_str(&plan);
+        assert!(
+            !shown.contains("MetadataOnlyExec") && shown.contains("LogsScanExec"),
+            "a pending erasure must force {sql} to scan; plan was:\n{shown}"
+        );
+    }
 }
 
 /// A `Str`-typed declared column is not answerable from the dictionary here
@@ -1318,4 +1356,396 @@ async fn a_missing_extremum_with_non_null_rows_declines_and_scans() {
         shown.contains("LogsScanExec") && !shown.contains("MetadataOnlyExec"),
         "non-null rows with no extremum must decline and fall back to a scan; plan was:\n{shown}"
     );
+}
+
+// ---------------------------------------------------------------------------
+// q03/q04: SUM(<declared integer column> + k), and q30: AVG(<declared integer
+// column>) -- answered from the exact per-object integer sum (#861). Every
+// positive test pins the same two facts as the q02/q08 tests: no `LogsScanExec`
+// in the plan, and exactly zero object-store GETs.
+// ---------------------------------------------------------------------------
+
+/// The single scalar of a one-column `SUM` result, or `None` when it is SQL
+/// NULL (sum over zero non-null rows).
+fn single_i64(batches: &[RecordBatch]) -> Option<i64> {
+    for batch in batches {
+        if batch.num_rows() == 0 {
+            continue;
+        }
+        let arr = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("int64 sum");
+        return if arr.is_null(0) {
+            None
+        } else {
+            Some(arr.value(0))
+        };
+    }
+    None
+}
+
+/// The single scalar of a one-column `AVG` result, or `None` when it is SQL
+/// NULL. Returned as raw bits so callers compare with the repo's
+/// bit-pattern float rule rather than `==`.
+fn single_f64_bits(batches: &[RecordBatch]) -> Option<u64> {
+    for batch in batches {
+        if batch.num_rows() == 0 {
+            continue;
+        }
+        let arr = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .expect("float64 avg");
+        return if arr.is_null(0) {
+            None
+        } else {
+            Some(arr.value(0).to_bits())
+        };
+    }
+    None
+}
+
+/// q03/q04: `SUM(status + 1)` is answered from the exact per-object sums with
+/// zero GETs and no scan. Segment A sums 1408 over 5 non-null rows, segment B
+/// sums 1300 over 5; the `+ 1` applies once per non-null row, so the answer is
+/// `2708 + 10 = 2718`.
+///
+/// Prove-the-test: reverting `LogsScanExec::declared_column_sum` to `return
+/// None` makes the rule decline, restoring a `LogsScanExec` plan; both
+/// assertions fail.
+#[tokio::test]
+async fn q03_sum_plus_k_answered_from_stats_with_zero_gets() {
+    let store = CountingStore::new(Arc::new(MemoryStore::new()));
+    let (a, b) = two_status_segments();
+    let stats = status_stats(&a, &b);
+    let snapshot = snapshot_of(vec![a, b], Vec::new());
+    let ctx = logs_session(provider(&store, snapshot, status_col(), Some(stats))).expect("session");
+
+    let plan = ctx
+        .sql("SELECT SUM(status + 1) FROM logs")
+        .await
+        .expect("plan")
+        .create_physical_plan()
+        .await
+        .expect("physical plan");
+    let shown = plan_str(&plan);
+    assert!(
+        !shown.contains("LogsScanExec"),
+        "q03 SUM(col + k) must be answered from stats, not scanned; plan was:\n{shown}"
+    );
+    assert!(
+        shown.contains("MetadataOnlyExec: metadata_only=true, rows=1"),
+        "q03 must report one sum row via the metadata marker; plan was:\n{shown}"
+    );
+
+    let batches = collect(Arc::clone(&plan), ctx.task_ctx())
+        .await
+        .expect("collect");
+    assert_eq!(
+        single_i64(&batches),
+        Some(2718),
+        "2708 + 1 * 10 non-null rows"
+    );
+    assert_eq!(store.gets(), 0, "the q03 answer must read no objects");
+}
+
+/// The plain `SUM(status)` (addend 0) is answered from stats with zero GETs:
+/// `1408 + 1300 = 2708`.
+#[tokio::test]
+async fn plain_sum_answered_from_stats_with_zero_gets() {
+    let store = CountingStore::new(Arc::new(MemoryStore::new()));
+    let (a, b) = two_status_segments();
+    let stats = status_stats(&a, &b);
+    let snapshot = snapshot_of(vec![a, b], Vec::new());
+    let ctx = logs_session(provider(&store, snapshot, status_col(), Some(stats))).expect("session");
+
+    let plan = ctx
+        .sql("SELECT SUM(status) FROM logs")
+        .await
+        .expect("plan")
+        .create_physical_plan()
+        .await
+        .expect("physical plan");
+    let shown = plan_str(&plan);
+    assert!(
+        !shown.contains("LogsScanExec"),
+        "plain SUM(col) must be answered from stats; plan was:\n{shown}"
+    );
+
+    let batches = collect(Arc::clone(&plan), ctx.task_ctx())
+        .await
+        .expect("collect");
+    assert_eq!(single_i64(&batches), Some(2708), "1408 + 1300");
+    assert_eq!(store.gets(), 0, "the sum answer must read no objects");
+}
+
+/// q30: `AVG(status)` is answered from stats with zero GETs and no scan:
+/// `2708 / 10 = 270.8`. Compared by bit pattern, since the answer is a float.
+///
+/// Prove-the-test: reverting `declared_column_sum` to `return None` restores a
+/// `LogsScanExec` plan and both assertions fail.
+#[tokio::test]
+async fn q30_avg_answered_from_stats_with_zero_gets() {
+    let store = CountingStore::new(Arc::new(MemoryStore::new()));
+    let (a, b) = two_status_segments();
+    let stats = status_stats(&a, &b);
+    let snapshot = snapshot_of(vec![a, b], Vec::new());
+    let ctx = logs_session(provider(&store, snapshot, status_col(), Some(stats))).expect("session");
+
+    let plan = ctx
+        .sql("SELECT AVG(status) FROM logs")
+        .await
+        .expect("plan")
+        .create_physical_plan()
+        .await
+        .expect("physical plan");
+    let shown = plan_str(&plan);
+    assert!(
+        !shown.contains("LogsScanExec"),
+        "q30 AVG must be answered from stats, not scanned; plan was:\n{shown}"
+    );
+    assert!(
+        shown.contains("MetadataOnlyExec: metadata_only=true, rows=1"),
+        "q30 must report one avg row via the metadata marker; plan was:\n{shown}"
+    );
+
+    let batches = collect(Arc::clone(&plan), ctx.task_ctx())
+        .await
+        .expect("collect");
+    assert_eq!(
+        single_f64_bits(&batches),
+        Some((2708f64 / 10f64).to_bits()),
+        "2708 / 10"
+    );
+    assert_eq!(store.gets(), 0, "the q30 answer must read no objects");
+}
+
+/// A column whose stat carries NO sum -- what a float column would produce, and
+/// what an i64-overflowing per-object sum produces at fold time -- must fall
+/// back to scanning rather than answer approximately (#861). There is no float
+/// declared type in this system, so a `sum = None` I64 stat is the exact state
+/// a float column reduces to on this path.
+///
+/// Over one real corpus: with the sum stripped from both segments' stats,
+/// `SUM(status + 1)` keeps its `LogsScanExec` and its answer equals the scanned
+/// answer, 3219.
+///
+/// Prove-the-test: removing the `let seg_sum = stat.sum?;` decline in
+/// `declared_column_sum` lets the rule read a phantom sum and the plan-shape
+/// assertion fails.
+#[tokio::test]
+async fn sum_without_a_stored_sum_declines_and_scans() {
+    let corpus = RealCorpus::build().await;
+
+    // Strip the sum from both segments' stats.
+    let strip = |rows: &[(i64, Option<i64>)]| {
+        let mut stat = stat_from_rows(rows);
+        stat.sum = None;
+        stat
+    };
+    let no_sum_stats = loaded_stats(vec![
+        (&corpus.a, stats_segment(&corpus.a, vec![strip(SEG_A_ROWS)])),
+        (&corpus.b, stats_segment(&corpus.b, vec![strip(SEG_B_ROWS)])),
+    ]);
+
+    let snapshot = snapshot_of(vec![corpus.a.clone(), corpus.b.clone()], Vec::new());
+    let ctx = logs_session(provider(
+        &corpus.store,
+        snapshot,
+        status_col(),
+        Some(no_sum_stats),
+    ))
+    .expect("session");
+    let plan = ctx
+        .sql("SELECT SUM(status + 1) FROM logs")
+        .await
+        .expect("plan")
+        .create_physical_plan()
+        .await
+        .expect("physical plan");
+    let shown = plan_str(&plan);
+    assert!(
+        shown.contains("LogsScanExec") && !shown.contains("MetadataOnlyExec"),
+        "a missing sum must decline and fall back to a scan; plan was:\n{shown}"
+    );
+    let rewritten = collect(Arc::clone(&plan), ctx.task_ctx())
+        .await
+        .expect("collect");
+
+    // The same statement with no loaded stats at all: the ordinary scan path.
+    let (_, scanned) = corpus.run("SELECT SUM(status + 1) FROM logs", false).await;
+    assert_eq!(
+        single_i64(&rewritten),
+        single_i64(&scanned),
+        "the fallback answer must equal the scanned answer"
+    );
+    assert_eq!(single_i64(&scanned), Some(3219), "3208 + 11 non-null rows");
+}
+
+/// The q03 exactness property over one real corpus: the REWRITTEN `SUM(col + k)`
+/// equals the SCANNED one, and a clipping ts bound falls back to a scan whose
+/// answer still holds. This is what proves the stored sum is exact against a
+/// scan of the same data, and that SQL null handling (segment B has a null row,
+/// skipped by `col + k`) matches.
+#[tokio::test]
+async fn q03_rewritten_answer_equals_scanned_answer() {
+    let corpus = RealCorpus::build().await;
+
+    let unbounded = "SELECT SUM(status + 1) FROM logs";
+    let (rewritten_plan, rewritten) = corpus.run(unbounded, true).await;
+    let (_, scanned) = corpus.run(unbounded, false).await;
+    assert!(
+        !rewritten_plan.contains("LogsScanExec"),
+        "the unbounded q03 must be answered from stats, or this test compares \
+         the scan against itself; plan was:\n{rewritten_plan}"
+    );
+    assert_eq!(
+        single_i64(&rewritten),
+        single_i64(&scanned),
+        "the rewritten q03 answer must equal the scanned answer"
+    );
+    assert_eq!(single_i64(&scanned), Some(3219), "3208 + 11 non-null rows");
+
+    let clipped = &format!("SELECT SUM(status + 1) FROM logs WHERE ts < {CLIP_SQL}");
+    let (clipped_plan, clipped_rewrite) = corpus.run(clipped, true).await;
+    let (_, clipped_scan) = corpus.run(clipped, false).await;
+    assert!(
+        clipped_plan.contains("LogsScanExec"),
+        "a clipping ts bound must fall back to a scan; plan was:\n{clipped_plan}"
+    );
+    assert_eq!(
+        single_i64(&clipped_rewrite),
+        single_i64(&clipped_scan),
+        "the clipped q03 answer must not depend on whether statistics loaded"
+    );
+    assert_eq!(
+        single_i64(&clipped_scan),
+        Some(2517),
+        "2508 + 9 non-null rows"
+    );
+    assert_ne!(
+        single_i64(&clipped_scan),
+        single_i64(&scanned),
+        "the ts bound must actually remove rows, or the clipped case proves nothing"
+    );
+}
+
+/// The q30 half of the same property, for `AVG`.
+#[tokio::test]
+async fn q30_rewritten_answer_equals_scanned_answer() {
+    let corpus = RealCorpus::build().await;
+
+    let unbounded = "SELECT AVG(status) FROM logs";
+    let (rewritten_plan, rewritten) = corpus.run(unbounded, true).await;
+    let (_, scanned) = corpus.run(unbounded, false).await;
+    assert!(
+        !rewritten_plan.contains("LogsScanExec"),
+        "the unbounded q30 must be answered from stats; plan was:\n{rewritten_plan}"
+    );
+    assert_eq!(
+        single_f64_bits(&rewritten),
+        single_f64_bits(&scanned),
+        "the rewritten q30 answer must be bit-identical to the scanned answer"
+    );
+    assert_eq!(
+        single_f64_bits(&scanned),
+        Some((3208f64 / 11f64).to_bits()),
+        "3208 / 11"
+    );
+
+    let clipped = &format!("SELECT AVG(status) FROM logs WHERE ts < {CLIP_SQL}");
+    let (clipped_plan, clipped_rewrite) = corpus.run(clipped, true).await;
+    let (_, clipped_scan) = corpus.run(clipped, false).await;
+    assert!(
+        clipped_plan.contains("LogsScanExec"),
+        "a clipping ts bound must fall back to a scan; plan was:\n{clipped_plan}"
+    );
+    assert_eq!(
+        single_f64_bits(&clipped_rewrite),
+        single_f64_bits(&clipped_scan),
+        "the clipped q30 answer must not depend on whether statistics loaded"
+    );
+    assert_ne!(
+        single_f64_bits(&clipped_scan),
+        single_f64_bits(&scanned),
+        "the ts bound must actually remove rows"
+    );
+}
+
+/// SUM and AVG over an all-null column are SQL NULL, byte-identical whether
+/// answered from stats or by scanning. The metadata path answers NULL from
+/// `non_null_count == 0` without reading an object; the scan produces the same
+/// NULL. Empty-input semantics ride the same path (zero non-null rows).
+#[tokio::test]
+async fn sum_and_avg_over_all_null_is_null_byte_identical() {
+    let store = CountingStore::new(Arc::new(MemoryStore::new()));
+    let all_null: &[(i64, Option<i64>)] = &[(0, None), (100, None), (200, None)];
+    let seg = write_real_segment(&store, "logs/allnull.rlog", 1, all_null).await;
+    let stats = loaded_stats(vec![(
+        &seg,
+        stats_segment(&seg, vec![stat_from_rows(all_null)]),
+    )]);
+
+    for (sql, is_avg) in [
+        ("SELECT SUM(status + 1) FROM logs", false),
+        ("SELECT AVG(status) FROM logs", true),
+    ] {
+        // From stats: the rewrite fires and reads no object.
+        let ctx = logs_session(provider(
+            &store,
+            snapshot_of(vec![seg.clone()], Vec::new()),
+            status_col(),
+            Some(Arc::clone(&stats)),
+        ))
+        .expect("session");
+        let plan = ctx
+            .sql(sql)
+            .await
+            .expect("plan")
+            .create_physical_plan()
+            .await
+            .expect("physical plan");
+        let shown = plan_str(&plan);
+        assert!(
+            !shown.contains("LogsScanExec"),
+            "{sql} over all-null must be answered from stats; plan was:\n{shown}"
+        );
+        let before = store.gets();
+        let rewritten = collect(Arc::clone(&plan), ctx.task_ctx())
+            .await
+            .expect("collect");
+        assert_eq!(store.gets(), before, "the all-null answer reads no objects");
+
+        // By scanning: no stats loaded.
+        let scan_ctx = logs_session(provider(
+            &store,
+            snapshot_of(vec![seg.clone()], Vec::new()),
+            status_col(),
+            None,
+        ))
+        .expect("session");
+        let scanned = collect(
+            scan_ctx
+                .sql(sql)
+                .await
+                .expect("plan")
+                .create_physical_plan()
+                .await
+                .expect("physical plan"),
+            scan_ctx.task_ctx(),
+        )
+        .await
+        .expect("collect");
+
+        if is_avg {
+            assert_eq!(single_f64_bits(&rewritten), None, "AVG of all-null is NULL");
+            assert_eq!(single_f64_bits(&rewritten), single_f64_bits(&scanned));
+        } else {
+            assert_eq!(single_i64(&rewritten), None, "SUM of all-null is NULL");
+            assert_eq!(single_i64(&rewritten), single_i64(&scanned));
+        }
+    }
 }

--- a/crates/ravel-sql/tests/logs_metadata_agg.rs
+++ b/crates/ravel-sql/tests/logs_metadata_agg.rs
@@ -116,6 +116,7 @@ fn i64_stat(
     let non_null_count: u64 = dict.iter().map(|(_, c)| c).sum();
     let min = dict.iter().map(|(v, _)| *v).min();
     let max = dict.iter().map(|(v, _)| *v).max();
+    let sum: i64 = dict.iter().map(|(v, c)| *v * (*c as i64)).sum();
     let dictionary = if dictionary_present {
         dict.iter()
             .map(|(v, c)| DictEntry {
@@ -135,6 +136,7 @@ fn i64_stat(
         max: max.map(i64_value),
         dictionary_present,
         dictionary,
+        sum: Some(sum),
     }
 }
 
@@ -168,6 +170,7 @@ fn str_stat(name: &str, dict: &[(&str, u64)]) -> ColumnStat {
                 count: *c,
             })
             .collect(),
+        sum: None,
     }
 }
 
@@ -185,6 +188,7 @@ fn i64_omitted_stat(name: &str, non_null_count: u64) -> ColumnStat {
         max: None,
         dictionary_present: false,
         dictionary: Vec::new(),
+        sum: None,
     }
 }
 

--- a/crates/ravel-sql/tests/logs_metadata_agg.rs
+++ b/crates/ravel-sql/tests/logs_metadata_agg.rs
@@ -664,7 +664,9 @@ async fn pending_erasure_declines_and_keeps_the_scan() {
     // The same erasure must force the sum-backed shapes (q03/q04/q30) to
     // decline too: a pending erasure removes rows the folded sum and count
     // still include (`declared_column_sum` gates on the same `stats_are_exact`,
-    // logs_scan.rs). Reuse the erasure snapshot above.
+    // logs_scan.rs). Rebuilt rather than reused: the first `snapshot_of` call
+    // consumed the segment refs and the stats, so this constructs an
+    // equivalent snapshot carrying the same pending erasure.
     let ctx = logs_session(provider(
         &store,
         snapshot_of(

--- a/crates/ravel-sql/tests/logs_stats_load.rs
+++ b/crates/ravel-sql/tests/logs_stats_load.rs
@@ -94,7 +94,18 @@ fn i64_stat(name: &str, dict: &[(i64, u64)], null_count: u64) -> ColumnStat {
     let non_null_count: u64 = dict.iter().map(|(_, c)| c).sum();
     let min = dict.iter().map(|(v, _)| *v).min();
     let max = dict.iter().map(|(v, _)| *v).max();
-    let sum: i64 = dict.iter().map(|(v, c)| *v * (*c as i64)).sum();
+    // Accumulated in `i128` and narrowed once, mirroring what the fold does
+    // with `checked_mul`/`checked_add`. Computing the expected value in raw
+    // `i64` would panic on overflow in a debug build and wrap silently in a
+    // release one, so a fixture with large values would either abort the test
+    // or assert against a wrong expectation. A fixture that cannot fit `i64`
+    // is a bug in the fixture, and this says which.
+    let sum_wide: i128 = dict
+        .iter()
+        .map(|(v, c)| i128::from(*v) * i128::from(*c))
+        .sum();
+    let sum =
+        i64::try_from(sum_wide).expect("fixture dictionary sums beyond i64; choose smaller values");
     ColumnStat {
         name: name.to_string(),
         declared_type: DECLARED_TYPE_I64,

--- a/crates/ravel-sql/tests/logs_stats_load.rs
+++ b/crates/ravel-sql/tests/logs_stats_load.rs
@@ -94,6 +94,7 @@ fn i64_stat(name: &str, dict: &[(i64, u64)], null_count: u64) -> ColumnStat {
     let non_null_count: u64 = dict.iter().map(|(_, c)| c).sum();
     let min = dict.iter().map(|(v, _)| *v).min();
     let max = dict.iter().map(|(v, _)| *v).max();
+    let sum: i64 = dict.iter().map(|(v, c)| *v * (*c as i64)).sum();
     ColumnStat {
         name: name.to_string(),
         declared_type: DECLARED_TYPE_I64,
@@ -109,6 +110,7 @@ fn i64_stat(name: &str, dict: &[(i64, u64)], null_count: u64) -> ColumnStat {
                 count: *c,
             })
             .collect(),
+        sum: Some(sum),
     }
 }
 

--- a/docs/adrs/0850-logs-typed-column-statistics.md
+++ b/docs/adrs/0850-logs-typed-column-statistics.md
@@ -20,6 +20,13 @@ those decompose into pure metadata:
 - q08: `SELECT AdvEngineID, COUNT(*) FROM hits GROUP BY AdvEngineID` — a
   merge of exact per-object value-to-count dictionaries.
 
+Three more decompose once the pack also carries a per-object integer sum
+(#861, a cheap addition to this ADR): q03/q04 (`SUM(col + k) = SUM(col) +
+k * non_null_count`) and q30 (`AVG(col) = SUM(col) / non_null_count`). The
+sum is stored for integer (I64) columns only; a float fold would be
+order-dependent (ADR-0024) and the hits corpus has no float columns, so an
+absent sum is the exactly-correct "not decomposable, scan instead" signal.
+
 `LogsScanExec::partition_statistics` and the `stats_are_exact` gate in
 `crates/ravel-sql/src/logs_scan.rs` already prove the mechanism for
 predicate-free and contained-ts-bound `COUNT(*)`: the catalog carries
@@ -34,9 +41,10 @@ exact value dictionary, for the columns a tenant has declared
 
 Two other ClickBench shapes are explicitly out of scope. q20 (point
 postings) and q23 (gram covering) need an index pack keyed by value, not
-a per-object summary; `SUM`/`AVG` over the full corpus still has to visit
-every row's value once the column doesn't fit a dictionary. Neither is
-attempted here.
+a per-object summary. A `SUM`/`AVG` over a non-integer column, or over an
+integer column whose per-object sum overflowed `i64` at fold time, also
+still has to visit every row's value: it carries no stored sum and falls
+back to scanning. Neither index pack is attempted here.
 
 ### Why a sibling artifact, not a `SegmentRef`/`Snapshot` field
 
@@ -117,13 +125,19 @@ Additive fields/messages only, no renumbering:
   covering ADR-0090's four declared types (`F64` is not a declared
   typed-attribute-column type and is out of scope here as it is there).
 - `DictEntry { value, count }` and `ColumnStat { name, declared_type,
-  non_null_count, null_count, min, max, dictionary_present, dictionary
-  }`: one column's exact statistics for one segment. `min`/`max` are
+  non_null_count, null_count, min, max, dictionary_present, dictionary,
+  sum }`: one column's exact statistics for one segment. `min`/`max` are
   proto3-absent (not a sentinel value) when `non_null_count == 0`.
   `dictionary_present = false` means the column's distinct-value count
   in this segment exceeded the cardinality ceiling: the dictionary is
   omitted outright, never truncated, so a reader can never mistake "over
-  the ceiling" for "fewer than N distinct values."
+  the ceiling" for "fewer than N distinct values." `sum` (proto3
+  `optional`, #861) is the exact sum of the column's non-null values,
+  present for an I64 column only and omitted when the exact sum overflowed
+  `i64` at fold time; absence means "no exact sum, scan instead," and it is
+  independent of `dictionary_present` so a high-cardinality integer column
+  still decomposes `SUM`/`AVG`. The codec rejects a `sum` on a non-integer
+  column and a `sum` that disagrees with the column's own dictionary.
 - `ColumnStatsSegment { ingest_hour_bucket, shard, writer_id,
   writer_epoch, writer_seq, columns }`: the per-segment join key plus its
   columns' stats.

--- a/proto/ravel/catalog.proto
+++ b/proto/ravel/catalog.proto
@@ -170,6 +170,14 @@ message ColumnStat {
   ColumnValue max = 6;
   bool dictionary_present = 7;
   repeated DictEntry dictionary = 8;
+  // Exact per-object sum of the column's non-null values (ADR-0850, #861).
+  // Present only for an integer (I64) column; omitted for every other declared
+  // type, and omitted for an I64 column whose exact sum overflowed i64 during
+  // the fold. Absent (proto3 `optional`, no value) means "no exact sum
+  // available": a reader must fall back to scanning rather than treat it as
+  // zero. Float columns are deliberately never summed: a sequential float fold
+  // is order-dependent, and the reader would have no way to know it was inexact.
+  optional int64 sum = 9;
 }
 
 // One segment's exact column statistics, identified the same way


### PR DESCRIPTION
Issue #861. Column statistics carry an exact per-object integer sum, and
the metadata path uses it to answer SUM(col + k) and AVG without reading
data.

The sum is stored for integer columns only. A sequential fold of floats
is order-dependent, and a reader has no way to tell an inexact sum from
an exact one, so float columns carry no sum, the statement is not
decomposable, and it scans. That is the correct outcome rather than a
gap. The proto field is additive at number 9 with explicit presence:
absent means no exact sum is available and the reader must fall back to
scanning, never treat it as zero. An i64 overflow during the fold omits
the sum for the same reason.

Tests pin the decomposition and its fallbacks: q03 and q30 answer with
exactly zero data GETs, a column with no stored sum declines and scans,
the rewritten answers equal the scanned answers value for value, and
SUM and AVG over an all-null column are byte-identical to the scan.

This does NOT by itself make the reference corpus answer these from
metadata. The fold builds column statistics for level-0 entries only
(fold.rs:1513), and a touched segment without statistics declines every
column (logs_scan.rs:1228), so a compacted tenant has no coverage. The
new zero-GET tests use L0 fixtures, which is why they pass while the
measured corpus is unchanged. Extending the fold to L1 is tracked on
#850 with amended acceptance; the planner side this commit completes is
a prerequisite for it, not a substitute.

Refs: #861, #850
