### PR TITLE
fix(scripts): fold fixup!/squash! commits before the authorship rewrite

### DIFF
--- a/scripts/fleet-result-merge.sh
+++ b/scripts/fleet-result-merge.sh
@@ -219,6 +219,78 @@ fleet_rewrite_history() {
   git rev-parse HEAD
 }
 
+# True if <sha>'s subject is an autosquash directive (`fixup!`, `squash!`, or
+# `amend!`), i.e. content git rebase --autosquash must fold into a named
+# target commit rather than land on its own.
+is_autosquash_commit() {
+  local subject
+  subject="$(git log -1 --format=%s "$1")"
+  [[ "${subject}" == "fixup! "* || "${subject}" == "squash! "* \
+     || "${subject}" == "amend! "* ]]
+}
+
+# Fold every `fixup!`/`squash!`/`amend!` commit in <base>..<result-sha> into
+# the commit it names, using git's own autosquash matching, and print the
+# resulting sha. Progress goes to stderr so the sha is the only thing on
+# stdout. Leaves HEAD on <fold-branch>.
+#
+# Unlike a wip: or a whitespace-only fmt commit, an autosquash commit carries
+# real content that belongs in the commit it names; dropping it loses work and
+# keeping it standalone lands that content under a meaningless `fixup!` subject
+# (exactly what reached main in #929). git rebase --autosquash reorders each
+# directive next to its target and squashes it in, identifying the target from
+# the subject text after the marker.
+#
+# A directive whose target is NOT on the branch is an orphan: autosquash leaves
+# it in place with its `fixup!`/`squash!` subject intact. This function detects
+# any such survivor and FAILS (return 3), naming it, rather than letting its
+# content land under that subject. A directive that git cannot fold because the
+# reorder conflicts with an intervening commit stops the rebase; that is
+# reported as a distinct failure (return 1) rather than resolved silently.
+fold_fixup_commits() {
+  local base="$1" result_sha="$2" fold_branch="$3"
+  local sha subj rc=0
+  {
+    git checkout -q -B "${fold_branch}" "${result_sha}"
+    # GIT_SEQUENCE_EDITOR=: accepts the autosquash-arranged todo list as-is;
+    # GIT_EDITOR=: accepts the default combined message a squash!/amend! yields.
+    GIT_SEQUENCE_EDITOR=: GIT_EDITOR=: \
+      git rebase -i --autosquash "${base}" || rc=$?
+    if [[ ${rc} -ne 0 ]]; then
+      git rebase --abort 2>/dev/null || true
+    fi
+  } >&2
+  if [[ ${rc} -ne 0 ]]; then
+    echo "fold_fixup_commits: autosquash rebase failed (rc=${rc}); a fixup" >&2
+    echo "  reorder likely conflicts with an intervening commit. Resolve the" >&2
+    echo "  fold on the result branch and re-run." >&2
+    return 1
+  fi
+
+  # Any autosquash directive still present after the rebase found no target:
+  # its content is now a standalone commit under a `fixup!`/`squash!` subject.
+  local -a orphans=()
+  while IFS= read -r sha; do
+    [[ -z "${sha}" ]] && continue
+    if is_autosquash_commit "${sha}"; then
+      subj="$(git log -1 --format=%s "${sha}")"
+      orphans+=("${sha:0:12} ${subj}")
+    fi
+  done < <(git rev-list --reverse "${base}..${fold_branch}")
+  if [[ ${#orphans[@]} -gt 0 ]]; then
+    {
+      echo "fold_fixup_commits: fixup!/squash! commit(s) name no commit on this branch:"
+      printf '  %s\n' "${orphans[@]}"
+      echo "  Autosquash could not fold them, so their content would land under a"
+      echo "  meaningless 'fixup!'/'squash!' subject. Rebase each onto its intended"
+      echo "  target (or drop it) on the result branch and re-run."
+    } >&2
+    return 3
+  fi
+
+  git rev-parse HEAD
+}
+
 # Sourced rather than executed: stop here, with the helpers above defined and
 # nothing run. Everything below this line performs a merge.
 if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
@@ -252,6 +324,7 @@ dry_run="${FLEET_MERGE_DRY_RUN:-0}"
 # restores the ref the script started on, and drops the temp rewrite branch.
 start_checkout=""
 rewrite_branch=""
+fold_branch=""
 _cleaned=0
 cleanup() {
   [[ ${_cleaned} -eq 1 ]] && return
@@ -265,6 +338,7 @@ cleanup() {
   if [[ -n "${gp}" && -f "${gp}" ]]; then git cherry-pick --abort 2>/dev/null || true; fi
   if [[ -n "${start_checkout}" ]]; then git checkout -q "${start_checkout}" 2>/dev/null || true; fi
   if [[ -n "${rewrite_branch}" ]]; then git branch -D "${rewrite_branch}" 2>/dev/null || true; fi
+  if [[ -n "${fold_branch}" ]]; then git branch -D "${fold_branch}" 2>/dev/null || true; fi
 }
 trap cleanup EXIT
 trap cleanup ERR
@@ -315,6 +389,35 @@ if [[ -n "$(git rev-list --merges "${base}..${result_sha}")" ]]; then
   exit 65
 fi
 
+# --- Fold fixup!/squash! commits into their targets ----------------------
+# Autosquash directives carry real content that belongs in a named commit, so
+# (unlike a wip:/fmt commit) they are folded IN, not dropped. This runs before
+# the wip/fmt and authorship rewrites. Ordering is deliberate: the authorship
+# rewrite must be the LAST pass over the range, because assert-clean-authorship
+# validates the exact history that gets pushed. Autosquash reorders commits;
+# running it AFTER the authorship rewrite would re-author only the pre-reorder
+# set and let a reordered fold escape the rewrite. So fold first, then rewrite
+# authorship over the folded result. The fold FAILS LOUDLY on an orphan
+# directive rather than letting its content land under a `fixup!` subject.
+work_ref="${result_sha}"
+need_fold=0
+while IFS= read -r c; do
+  if is_autosquash_commit "${c}"; then
+    need_fold=1
+  fi
+done < <(git rev-list --reverse "${base}..${result_sha}")
+
+if [[ ${need_fold} -eq 1 ]]; then
+  echo "==> Folding fixup!/squash! commits into their targets"
+  fold_branch="_fleet_fold_${task_id//\//_}"
+  if ! work_ref="$(fold_fixup_commits "${base}" "${result_sha}" "${fold_branch}")"; then
+    echo "fleet-result-merge.sh: could not fold fixup!/squash! commits (see above)." >&2
+    exit 65
+  fi
+  git checkout -q "${start_checkout}"
+fi
+# --- end fixup fold ------------------------------------------------------
+
 # --- Squash wip:/formatting-fixup commits out of the result branch -------
 # The detection heuristic and the fold rules are documented on
 # is_flagged_commit and fleet_rewrite_history at the top of this file.
@@ -323,14 +426,14 @@ while IFS= read -r c; do
   if is_flagged_commit "${c}"; then
     need_rewrite=1
   fi
-done < <(git rev-list --reverse "${base}..${result_sha}")
+done < <(git rev-list --reverse "${base}..${work_ref}")
 
-clean_ref="${result_sha}"
+clean_ref="${work_ref}"
 
 if [[ ${need_rewrite} -eq 1 ]]; then
   echo "==> Squashing wip:/formatting-fixup commits out of the result branch"
   rewrite_branch="_fleet_rewrite_${task_id//\//_}"
-  clean_ref="$(fleet_rewrite_history "${base}" "${result_sha}" "${rewrite_branch}" "${task_id}")"
+  clean_ref="$(fleet_rewrite_history "${base}" "${work_ref}" "${rewrite_branch}" "${task_id}")"
   git checkout -q "${start_checkout}"
 fi
 # --- end squash step -----------------------------------------------------
@@ -382,6 +485,12 @@ git checkout -q "${start_checkout}"
 # have been re-authored onto the authorship branch.
 if [[ -n "${prev_rewrite_branch}" && "${prev_rewrite_branch}" != "${authorship_branch}" ]]; then
   git branch -D "${prev_rewrite_branch}" 2>/dev/null || true
+fi
+# The fixup-fold temp branch's commits have likewise been re-authored onto the
+# authorship branch; drop it too.
+if [[ -n "${fold_branch}" ]]; then
+  git branch -D "${fold_branch}" 2>/dev/null || true
+  fold_branch=""
 fi
 
 # Prove the rewrite worked before anything is pushed: a fleet-executor

--- a/scripts/tests/fleet-result-merge-squash.test.sh
+++ b/scripts/tests/fleet-result-merge-squash.test.sh
@@ -164,6 +164,131 @@ deliverable.txt
 followup.txt
 notes.txt" 3
 
+# (e) A whitespace-only fmt fixup still squashes away (unchanged behavior; the
+# fixup!-fold work must not disturb it). A `cargo fmt` reindent whose diff is
+# empty under `git diff -w` is dropped, folded into the deliverable before it.
+dir="${tmproot}/fmt-fixup"
+new_repo "${dir}"
+commit_in "${dir}" deliverable.txt "feat(scratch): add the deliverable" "The real change." "${DELIVERABLE_AUTHOR}"
+# A reindent-only change to the same file: content identical under `git diff -w`.
+printf 'deliverable.txt\n' >"${dir}/deliverable.txt"
+printf '    deliverable.txt\n' >"${dir}/deliverable.txt"  # leading whitespace only
+git -C "${dir}" add -A
+git -C "${dir}" commit -q -s --author="${DELIVERABLE_AUTHOR}" -m "style: cargo fmt"
+run_case "feat + fmt-fixup" "${dir}" \
+  "feat(scratch): add the deliverable | ${DELIVERABLE_AUTHOR}" \
+  "${SIGNOFF}" \
+  "README.md
+deliverable.txt" 2
+
+# --- fixup!/squash! autosquash fold (issue #931) -------------------------
+# fold_fixup_commits folds each fixup!/squash! commit into the commit it names,
+# using git's autosquash, and fails loudly on an orphan whose target is absent.
+
+# fold_at <dir> <base>: run fold_fixup_commits over <base>..HEAD in <dir>,
+# print the resulting sha, git chatter + errors to <dir>/fold.log.
+fold_at() {
+  local dir="$1" base="$2"
+  (
+    cd "${dir}" || exit 1
+    set -e
+    fold_fixup_commits "${base}" "$(git rev-parse HEAD)" "_fold_test"
+  ) 2>"${dir}/fold.log"
+}
+
+subjects_of() { git -C "$1" log --reverse --format='%s' "$2..$3"; }
+
+# run_fold_case <label> <dir> <want-subjects> <want-files> <depth>: assert a
+# successful fold's resulting subjects (oldest first) and tree files.
+run_fold_case() {
+  local label="$1" dir="$2" want_subjects="$3" want_files="$4" depth="$5"
+  local base clean code=0
+  base="$(git -C "${dir}" rev-parse "HEAD~${depth}")"
+  clean="$(fold_at "${dir}" "${base}")" || code=$?
+  if [[ ${code} -ne 0 || -z "${clean}" ]]; then
+    fail=$((fail + 1))
+    printf 'FAIL  %s: fold exited %s\n' "${label}" "${code}"
+    cat "${dir}/fold.log"
+    return
+  fi
+  printf '\n--- %s ---\n' "${label}"
+  git -C "${dir}" log --reverse --format='commit %h  %s' "${base}..${clean}"
+  check_eq "${label}: subjects" "${want_subjects}" "$(subjects_of "${dir}" "${base}" "${clean}")"
+  check_eq "${label}: files" "${want_files}" "$(files_of "${dir}" "${clean}")"
+}
+
+# (f) A fixup! naming an earlier commit on the same branch folds its content in;
+# no fixup! subject survives.
+dir="${tmproot}/fixup-adjacent"
+new_repo "${dir}"
+printf 'v1\n' >"${dir}/feature.txt"; git -C "${dir}" add -A
+git -C "${dir}" commit -q -s --author="${DELIVERABLE_AUTHOR}" -m "feat(scratch): add the feature"
+printf 'v1\nv2\n' >"${dir}/feature.txt"; git -C "${dir}" add -A
+git -C "${dir}" commit -q -s --author="${DELIVERABLE_AUTHOR}" -m "fixup! feat(scratch): add the feature"
+run_fold_case "fixup adjacent folds in" "${dir}" \
+  "feat(scratch): add the feature" \
+  "README.md
+feature.txt" 2
+check_eq "fixup adjacent: content folded" "v1
+v2" "$(git -C "${dir}" show HEAD:feature.txt 2>/dev/null || cat "${dir}/feature.txt")"
+
+# (g) A squash! naming an earlier commit folds the same way.
+dir="${tmproot}/squash-adjacent"
+new_repo "${dir}"
+printf 'a\n' >"${dir}/s.txt"; git -C "${dir}" add -A
+git -C "${dir}" commit -q -s --author="${DELIVERABLE_AUTHOR}" -m "feat(scratch): add s"
+printf 'a\nb\n' >"${dir}/s.txt"; git -C "${dir}" add -A
+git -C "${dir}" commit -q -s --author="${DELIVERABLE_AUTHOR}" -m "squash! feat(scratch): add s"
+run_fold_case "squash adjacent folds in" "${dir}" \
+  "feat(scratch): add s" \
+  "README.md
+s.txt" 2
+
+# (h) THE #929 SHAPE: fixup! as the LAST commit, naming the FIRST, with two
+# substantive commits in between. Autosquash reorders it next to its target.
+# A test that only covered adjacent commits would pass while this one failed.
+dir="${tmproot}/fixup-pr929"
+new_repo "${dir}"
+printf 'base\n' >"${dir}/stats.txt"; git -C "${dir}" add -A
+git -C "${dir}" commit -q -s --author="${DELIVERABLE_AUTHOR}" \
+  -m "feat(catalog): carry an exact per-object integer sum in column stats"
+commit_in "${dir}" two.txt "feat(scratch): second commit" "" "${DELIVERABLE_AUTHOR}"
+commit_in "${dir}" three.txt "feat(scratch): third commit" "" "${DELIVERABLE_AUTHOR}"
+printf 'base\nfolded\n' >"${dir}/stats.txt"; git -C "${dir}" add -A
+git -C "${dir}" commit -q -s --author="${DELIVERABLE_AUTHOR}" \
+  -m "fixup! feat(catalog): carry an exact per-object integer sum in column stats"
+run_fold_case "#929 fixup last names first" "${dir}" \
+  "feat(catalog): carry an exact per-object integer sum in column stats
+feat(scratch): second commit
+feat(scratch): third commit" \
+  "README.md
+stats.txt
+three.txt
+two.txt" 4
+check_eq "#929: fixup content folded into first commit" "base
+folded" "$(git -C "${dir}" show HEAD:stats.txt 2>/dev/null || true)"
+
+# (i) An ORPHAN fixup! (target not on the branch) must FAIL, naming the commit.
+dir="${tmproot}/fixup-orphan"
+new_repo "${dir}"
+commit_in "${dir}" real.txt "feat(scratch): a real commit" "" "${DELIVERABLE_AUTHOR}"
+commit_in "${dir}" orphan.txt "fixup! feat(scratch): a commit that is not on this branch" "" "${DELIVERABLE_AUTHOR}"
+orphan_sha="$(git -C "${dir}" rev-parse HEAD)"
+base="$(git -C "${dir}" rev-parse HEAD~2)"
+orphan_out="$(fold_at "${dir}" "${base}")"; orphan_rc=$?
+if [[ ${orphan_rc} -ne 0 ]]; then
+  pass=$((pass + 1)); printf 'ok    orphan fixup: fold failed (rc=%s)\n' "${orphan_rc}"
+else
+  fail=$((fail + 1)); printf 'FAIL  orphan fixup: fold succeeded, want failure (sha=%s)\n' "${orphan_out}"
+fi
+if grep -q "${orphan_sha:0:12}" "${dir}/fold.log" \
+   && grep -qi 'name no commit on this branch' "${dir}/fold.log"; then
+  pass=$((pass + 1)); printf 'ok    orphan fixup: error names the commit\n'
+else
+  fail=$((fail + 1)); printf 'FAIL  orphan fixup: error does not name the commit\n'
+  cat "${dir}/fold.log"
+fi
+
 printf '\n%d passed, %d failed\n' "${pass}" "${fail}"
 if [[ ${fail} -ne 0 ]]; then
   exit 1


### PR DESCRIPTION
A `fixup!` commit reached protected main through PR #929. The cleaner
knew two classes: a `wip:` subject, and a formatting fixup whose diff is
empty under `git diff -w`. `fixup!`, which is what `git commit --fixup`
produces, matched neither.

It is not a third subject heuristic. A `wip:` commit is reworded and
kept, a whitespace-only commit is squashed away because its content is
nothing, and a `fixup!` carries real content belonging to the commit it
names. Dropping it loses work; keeping it standalone lands content under
a meaningless subject, which is what happened.

`git rebase -i --autosquash` does the fold, and it runs before the
authorship rewrite rather than after. Autosquash reorders commits, so
running it second would leave a branch whose authorship rewrite had
skipped the reordered commits, with assert-clean-authorship.sh as the
only thing between that and main.

Three outcomes are distinguished rather than collapsed. A clean fold
proceeds. A directive whose target is absent leaves a standalone commit
under a `fixup!` subject, which is the original defect, so the script
fails and names it. A reorder that conflicts with an intervening commit
aborts the rebase and reports separately, rather than resolving
silently.

The test covers the shape that actually escaped: `fixup!` as the last
commit naming the first, with two commits between them. A case using
adjacent commits would have passed while the real one failed.

Fixes: #931
