### PR TITLE
feat(metricsbench): add pinned comparator deployments

### DIFF
--- a/deploy/metricsbench/README.md
+++ b/deploy/metricsbench/README.md
@@ -48,9 +48,18 @@ lives outside these files.
 docker compose -f deploy/metricsbench/docker-compose.yml up -d
 ```
 
-Every image is pinned to an immutable `@sha256:` digest (see below), so this
-brings up the exact same bytes on every host. Each comparator is given identical
-CPU (2.0) and memory (4g) limits so no engine wins on hardware.
+Every image is pinned to an immutable `@sha256:` digest (see below). Each
+comparator is given identical CPU (2.0) and memory (4g) limits so no engine
+wins on hardware.
+
+**The digest pins the manifest, not the platform.** These are multi-architecture
+manifest-list digests, so the same digest resolves to different image bytes on
+`linux/amd64` than on `linux/arm64`. A pinned digest therefore makes a run
+reproducible *per platform*, not across platforms. Any run whose numbers are
+reported must record the platform it resolved on, and a cross-host comparison
+is only valid between hosts of the same architecture. Two hosts with the same
+digest and different architectures are running different binaries, which is
+exactly the kind of difference that reads as an engine result.
 
 Tear down (and drop the local volumes):
 

--- a/deploy/metricsbench/README.md
+++ b/deploy/metricsbench/README.md
@@ -1,0 +1,108 @@
+# MetricsBench comparator deployments
+
+Checked-in, digest-pinned deployments of the cross-engine comparators for the
+MetricsBench metrics benchmark (ADR-0927, issue #934). These are the systems the
+MetricsBench harness (`crates/ravel-bench`) measures Ravel against in the
+**portable lane**: Prometheus Remote Write 1.0 for ingest, the Prometheus HTTP
+query API for reads. Every system here receives the same logical samples and the
+same queries; no Ravel-only instrumentation is ever folded into a cross-engine
+score (ADR-0927 decision 1).
+
+Ravel itself is not in this file. It is the system under test and is launched
+separately (`deploy/docker-compose/ravel.yml`). This directory holds only the
+comparators.
+
+## The comparators
+
+| Service | What it is | Durability / storage | Remote Write 1.0 endpoint | PromQL query endpoint |
+|---|---|---|---|---|
+| `prometheus` | Reference PromQL engine, pinned to v3.13.1 (the same version ADR-0927 uses as the correctness oracle) | **Local-disk TSDB.** Ack = in-memory head + on-disk WAL. Not object storage. | `http://127.0.0.1:9090/api/v1/write` | `http://127.0.0.1:9090/api/v1/query` |
+| `victoriametrics` | Single-node VictoriaMetrics, accepts Prometheus remote write natively | **Local-disk storage.** Ack = local storage write. Not object storage. | `http://127.0.0.1:8428/api/v1/write` | `http://127.0.0.1:8428/prometheus/api/v1/query` |
+| `mimir` | Grafana Mimir monolithic (`-target=all`); the ADR-0927 object-storage-native PromQL system | **Object storage (S3).** Ack = local WAL; blocks ship to S3 (MinIO here) later. See caveat below. | `http://127.0.0.1:9009/api/v1/push` | `http://127.0.0.1:9009/prometheus/api/v1/query` |
+
+Supporting services: `minio` (S3 backend for Mimir) and `createbuckets` (a
+one-shot that creates Mimir's buckets and then exits).
+
+### Storage architecture is not interchangeable
+
+Prometheus and VictoriaMetrics persist to **local disk**. Mimir is
+**object-storage-native** and writes its durable blocks to S3 — but in this stack
+S3 is provided by **MinIO**, which is local-disk-backed and charges no
+per-request fees. Per ADR-0927 decision 10 (ADR-0075 decision 3), a MinIO result
+is valid for correctness and CI only and is **never a publishable performance or
+cost result**; a real-S3 substrate is required for that, exactly as Ravel's own
+publishable numbers require real S3. Each service block in
+`docker-compose.yml` states its own durability next to its configuration so this
+distinction is readable without this README or the ADR open.
+
+Every backend-specific behaviour that transforms, delays, or ages the stored data
+— Prometheus' 2h head-block compaction and 45d retention, VictoriaMetrics'
+background merges and disabled deduplication, Mimir's delayed block upload to S3
+and its compactor — is disclosed in a comment next to the setting that causes it,
+in `docker-compose.yml` or `config/mimir.yaml`. No behaviour-changing tuning
+lives outside these files.
+
+## Launch the set
+
+```sh
+docker compose -f deploy/metricsbench/docker-compose.yml up -d
+```
+
+Every image is pinned to an immutable `@sha256:` digest (see below), so this
+brings up the exact same bytes on every host. Each comparator is given identical
+CPU (2.0) and memory (4g) limits so no engine wins on hardware.
+
+Tear down (and drop the local volumes):
+
+```sh
+docker compose -f deploy/metricsbench/docker-compose.yml down -v
+```
+
+## Verify the pins
+
+```sh
+deploy/metricsbench/tests/every_comparator_pins_an_image_digest.sh
+```
+
+Exit 0 means every image reference in the deployment carries an `@sha256:`
+digest, every ADR-0927-required comparator is present, and the number of image
+references equals the expected count. Any unpinned reference, any missing
+required comparator, or a reference count that drifts from the expected number
+fails the check with a non-zero exit. The script prints what it checked and how
+many references it found.
+
+This check is **not yet run by CI**. Wiring it into `scripts/gates.sh` or a CI
+workflow is a deliberate follow-up: those are shared files outside issue #934's
+scope.
+
+## Pinned image digests
+
+Every digest below is the multi-arch manifest-list digest reported by the Docker
+Hub registry v2 API for the named tag, resolved with:
+
+```sh
+curl -sI -H "Authorization: Bearer $TOKEN" \
+  -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json" \
+  https://registry-1.docker.io/v2/<repo>/manifests/<tag> \
+  | grep -i docker-content-digest
+```
+
+| Image | Tag | Digest |
+|---|---|---|
+| `prom/prometheus` | `v3.13.1` | `sha256:3c42b892cf723fa54d2f262c37a0e1f80aa8c8ddb1da7b9b0df9455a35a7f893` |
+| `victoriametrics/victoria-metrics` | `v1.115.0` | `sha256:d8ac3a1776c8a9beead8bbd42a489c82249b1bfe9071dfd4813f34ebe36354bb` |
+| `grafana/mimir` | `2.14.2` | `sha256:2d3912435771d356ec03ae4729fb584b4d76a5f035d9dda40b563a55bb6760e3` |
+| `minio/minio` | `RELEASE.2025-04-08T15-41-24Z` | `sha256:8834ae47a2de3509b83e0e70da9369c24bbbc22de42f2a2eddc530eee88acd1b` |
+| `minio/mc` | `RELEASE.2025-04-08T15-39-49Z` | `sha256:7e3efb09c22c0882fbf341b9d99f61f94ae6c4c20a06f2f1a2b20ea8993d8952` |
+
+The tag is kept in each `image:` reference alongside the digest for human
+readability; the digest is what pins the run.
+
+## Note on the acceptance check name
+
+Issue #934 names the acceptance test
+`metricsbench::deploy::tests::every_comparator_pins_an_image_digest`, a Rust test
+path. That contradicts the issue's own scope line ("touches no crate"), and the
+crate it would live in is being edited by a parallel task. The check is therefore
+implemented as the dependency-free script
+`tests/every_comparator_pins_an_image_digest.sh`, preserving the name exactly.

--- a/deploy/metricsbench/config/mimir.yaml
+++ b/deploy/metricsbench/config/mimir.yaml
@@ -1,0 +1,97 @@
+# Grafana Mimir configuration for the MetricsBench object-storage-native
+# comparator (ADR-0927). Monolithic (-target=all) single-instance deployment.
+#
+# Every setting that changes what data a query sees, when it becomes durable, or
+# how long it is kept is disclosed in a comment next to the setting (ADR-0927
+# deliverable: no unpublished tuning, no undisclosed transformation).
+
+# Single-tenant benchmark: no per-request X-Scope-OrgID header required. The
+# harness sends the same Remote Write stream it sends every other comparator,
+# with no Mimir-specific auth header, so the portable lane stays uniform.
+multitenancy_enabled: false
+
+server:
+  http_listen_port: 9009
+  grpc_listen_port: 9095
+  # Raise gRPC message ceilings above the defaults: high-cardinality remote-write
+  # batches from the ADR-0927 cardinality profile (1,000,000 series) otherwise
+  # trip Mimir's default 4 MiB message limit. This is COMMITTED, EXPLAINED tuning
+  # to let the benchmark's own load through, not a performance optimisation.
+  grpc_server_max_recv_msg_size: 104857600
+  grpc_server_max_send_msg_size: 104857600
+
+# Single connection to MinIO shared by every S3-backed storage below. DURABILITY:
+# this points Mimir's durable state at S3 (MinIO in this stack). See the
+# durability note beside the mimir service in docker-compose.yml and ADR-0927
+# decision 10: a MinIO result is a correctness result, not a publishable one.
+common:
+  storage:
+    backend: s3
+    s3:
+      endpoint: minio:9000
+      insecure: true
+      access_key_id: mimir
+      secret_access_key: mimir-dev-secret
+
+blocks_storage:
+  s3:
+    bucket_name: mimir-blocks
+  tsdb:
+    dir: /data/tsdb
+    # DELAYED OBJECT-STORAGE VISIBILITY / MATERIALISED STATE (disclosed): the
+    # ingester keeps recent samples in a local head block plus WAL under this
+    # dir and only ships a compacted TSDB block to S3 after each 2h head range
+    # closes. So an ack is durable on the local WAL, and the S3 copy the
+    # store-gateway serves appears later. Left at the 2h default: shortening it
+    # would be undisclosed tuning that changes the ack-to-object-storage timing
+    # the benchmark is measuring.
+    retention_period: 25h
+  bucket_store:
+    sync_dir: /data/tsdb-sync
+
+compactor:
+  data_dir: /data/compactor
+  # COMPACTION / MATERIALISED STATE (disclosed): the compactor merges shipped
+  # blocks in object storage. NO DOWNSAMPLING: Mimir does not downsample blocks
+  # (unlike Thanos' optional downsampling), so stored resolution is never
+  # silently reduced. Left at defaults; no unpublished tuning.
+  sharding_ring:
+    kvstore:
+      store: memberlist
+
+ingester:
+  ring:
+    # Single-instance benchmark deployment: one replica, no cross-node
+    # replication. A real Mimir cluster runs replication_factor 3; this is a
+    # DISCLOSED single-node topology, comparable to the single-node Prometheus
+    # and VictoriaMetrics comparators, not to a replicated production cluster.
+    replication_factor: 1
+    kvstore:
+      store: memberlist
+
+store_gateway:
+  sharding_ring:
+    replication_factor: 1
+    kvstore:
+      store: memberlist
+
+ruler_storage:
+  s3:
+    bucket_name: mimir-ruler
+
+alertmanager_storage:
+  s3:
+    bucket_name: mimir-alertmanager
+
+limits:
+  # Raise ingestion ceilings so the ADR-0927 profiles' sample and series volume
+  # is admitted rather than rejected. A silent rejection would violate the
+  # "ingested == generated minus reported rejections" acceptance gate (ADR-0927
+  # bands, clause 4). COMMITTED, EXPLAINED tuning: it enlarges capacity to fit
+  # the declared load, it does not make queries faster.
+  max_global_series_per_user: 0        # 0 = unlimited active series
+  ingestion_rate: 5000000              # samples/sec
+  ingestion_burst_size: 20000000       # samples
+  # Query lookback must cover the history profile (30d); default is fine but
+  # pinned so a future default change cannot silently shorten the queryable range.
+  compactor_blocks_retention_period: 45d

--- a/deploy/metricsbench/config/prometheus.yml
+++ b/deploy/metricsbench/config/prometheus.yml
@@ -1,0 +1,13 @@
+# Prometheus configuration for the MetricsBench comparator (ADR-0927).
+#
+# Deliberately minimal. In the MetricsBench portable lane Prometheus receives
+# its samples over Remote Write 1.0 (enabled by --web.enable-remote-write-receiver
+# in docker-compose.yml), NOT by scraping, so there are no scrape_configs. Adding
+# a scrape job would inject samples the other comparators never see and break the
+# "every system receives the same logical samples" contract (ADR-0927 decision 1).
+global:
+  # Present only because Prometheus requires a global block; it does not scrape
+  # anything here. No evaluation_interval / rule_files: recording and alerting
+  # rules are out of scope for MetricsBench v1 (ADR-0927 decision 6).
+  scrape_interval: 15s
+  evaluation_interval: 15s

--- a/deploy/metricsbench/docker-compose.yml
+++ b/deploy/metricsbench/docker-compose.yml
@@ -1,0 +1,198 @@
+# MetricsBench comparator set (ADR-0927, issue #934).
+#
+# Launches every cross-engine comparator required by the MetricsBench portable
+# lane, each pinned to an immutable image DIGEST and each given identical CPU and
+# memory limits so no comparator wins on hardware. Bring the set up with:
+#
+#   docker compose -f deploy/metricsbench/docker-compose.yml up -d
+#
+# The MetricsBench harness (crates/ravel-bench, sibling task M1) drives every
+# comparator here over Prometheus Remote Write 1.0 for ingest and the Prometheus
+# HTTP query API for reads. ADR-0927 decision 1: the portable lane is the only
+# basis for cross-engine comparison, and every participating system receives the
+# same logical samples and the same queries. Remote Read (/api/v1/read) is NOT
+# used by the harness (ADR-0927 decision 2) and none of these systems is
+# configured to rely on it.
+#
+# PINS. Every `image:` below carries both a human-readable tag AND an
+# `@sha256:` manifest digest. The digest is authoritative; the tag is kept only
+# so a reader sees the version without resolving the hash. A tag alone is a
+# moving reference and would make a run unreproducible, so
+# tests/every_comparator_pins_an_image_digest.sh fails the set if any reference
+# loses its digest. Digest provenance is recorded in README.md.
+#
+# DURABILITY AND STORAGE ARCHITECTURE differ per system and are NOT
+# interchangeable. Prometheus and VictoriaMetrics here persist to a local-disk
+# TSDB. Mimir is object-storage-native and writes its blocks to S3 (backed by
+# MinIO in this stack). Per ADR-0927 decision 10 (ADR-0075 decision 3), MinIO
+# removes per-request fees and is therefore valid ONLY for correctness and CI,
+# never for a publishable performance or cost claim. A local-disk or MinIO
+# result here is never an S3-equivalent result; each service block below states
+# its own durability so the distinction is readable without the ADR open.
+#
+# SECURITY: every credential here is a fixed local-development value and every
+# published port binds loopback (127.0.0.1) only. Nothing here is for a
+# network-reachable deployment.
+
+services:
+  # --- Prometheus --------------------------------------------------------
+  # The reference PromQL engine. ADR-0927 decision 4 pins Prometheus v3.13.1 as
+  # the correctness oracle (crates/ravel-promql-difftest), so the comparator
+  # Prometheus is pinned to the SAME version: a comparator on a different
+  # Prometheus than the oracle would compare two Prometheus builds, not the
+  # engine under test against the oracle.
+  #
+  # DURABILITY: local-disk TSDB at /prometheus. A 2xx on remote write means the
+  # sample is in the in-memory head block and the write-ahead log on local disk.
+  # This is NOT an object-storage durability guarantee and must never be placed
+  # in the same column as Ravel's durable-on-ack S3 result (ADR-0927 decision 3).
+  prometheus:
+    image: prom/prometheus:v3.13.1@sha256:3c42b892cf723fa54d2f262c37a0e1f80aa8c8ddb1da7b9b0df9455a35a7f893
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      # Remote Write 1.0 receiver. Without this flag /api/v1/write returns 404
+      # and Prometheus cannot participate in the portable ingest lane.
+      - "--web.enable-remote-write-receiver"
+      - "--storage.tsdb.path=/prometheus"
+      # RETENTION (disclosed transformation): Prometheus deletes blocks older
+      # than 30d. Set generously above every ADR-0927 profile duration (history
+      # is 30d) so retention never silently drops benchmark samples mid-run.
+      - "--storage.tsdb.retention.time=45d"
+      # DELAYED COMPACTION / MATERIALISED STATE (disclosed): Prometheus holds
+      # incoming samples in an in-memory head block and only cuts a persistent,
+      # compacted on-disk block every 2h (fixed head-chunk range, not tunable).
+      # A query issued seconds after ingest reads the head, not a compacted
+      # block; a query issued later reads compacted, deduplicated blocks. The
+      # storage state a query sees therefore depends on wall-clock age of the
+      # data. Tuning here is limited to the flags above; no unpublished tuning.
+    ports:
+      - "127.0.0.1:9090:9090"
+    volumes:
+      - ./config/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+    deploy:
+      resources:
+        limits:
+          # Identical envelope across all three engines (see victoriametrics and
+          # mimir): equal CPU and memory is a portable-lane fairness precondition.
+          cpus: "2.0"
+          memory: 4g
+
+  # --- VictoriaMetrics ---------------------------------------------------
+  # Single-node VictoriaMetrics. Accepts Prometheus Remote Write 1.0 natively at
+  # /api/v1/write and serves the Prometheus query API under /prometheus.
+  #
+  # DURABILITY: local-disk storage at /victoria-metrics-data. An ack means the
+  # sample is written to VictoriaMetrics' local storage; like Prometheus this is
+  # a local-disk guarantee, not an object-storage one.
+  victoriametrics:
+    image: victoriametrics/victoria-metrics:v1.115.0@sha256:d8ac3a1776c8a9beead8bbd42a489c82249b1bfe9071dfd4813f34ebe36354bb
+    command:
+      - "-storageDataPath=/victoria-metrics-data"
+      # RETENTION (disclosed): drop data older than 45d, above the history
+      # profile's 30d, so retention never silently drops benchmark samples.
+      - "-retentionPeriod=45d"
+      # DEDUPLICATION (disclosed, OFF): -dedup.minScrapeInterval defaults to 0
+      # (disabled). Set explicitly to 0 so no sample is silently coalesced; the
+      # portable lane sends each logical sample once and expects each stored once.
+      - "-dedup.minScrapeInterval=0"
+      # DOWNSAMPLING (disclosed, ABSENT): downsampling is a VictoriaMetrics
+      # Enterprise feature and does not exist in this OSS single-node image, so
+      # no automatic resolution reduction occurs. Stated here so its absence is
+      # a recorded fact, not an assumption.
+      #
+      # BACKGROUND MERGES / MATERIALISED STATE (disclosed): VictoriaMetrics
+      # continuously merges its on-disk parts (LSM-style). Like Prometheus'
+      # block compaction this means recently ingested data and older data may
+      # live in differently-merged parts; the merge cadence is internal and not
+      # tuned here. No unpublished tuning: every flag that changes behaviour is
+      # on this command line.
+    ports:
+      - "127.0.0.1:8428:8428"
+    volumes:
+      - victoriametrics-data:/victoria-metrics-data
+    deploy:
+      resources:
+        limits:
+          cpus: "2.0"
+          memory: 4g
+
+  # --- Object storage for the object-storage-native comparator -----------
+  # MinIO backing Mimir's S3 blocks storage. NOTE (ADR-0927 decision 10): MinIO
+  # is local-disk-backed and free of per-request fees, so any Mimir figure taken
+  # against this MinIO is a correctness/functional result, NOT a publishable
+  # cost or performance result. A real-S3 substrate is required for that, exactly
+  # as Ravel's own publishable lane requires real S3.
+  minio:
+    image: minio/minio:RELEASE.2025-04-08T15-41-24Z@sha256:8834ae47a2de3509b83e0e70da9369c24bbbc22de42f2a2eddc530eee88acd1b
+    command: server /data --console-address ":9001"
+    ports:
+      - "127.0.0.1:9101:9001"
+    environment:
+      MINIO_ROOT_USER: mimir
+      MINIO_ROOT_PASSWORD: mimir-dev-secret
+    volumes:
+      - minio-data:/data
+    deploy:
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: 2g
+
+  createbuckets:
+    image: minio/mc:RELEASE.2025-04-08T15-39-49Z@sha256:7e3efb09c22c0882fbf341b9d99f61f94ae6c4c20a06f2f1a2b20ea8993d8952
+    depends_on: [minio]
+    # Mimir's `all` target opens blocks, ruler and alertmanager storage; create
+    # all three buckets so a fresh MinIO does not stall Mimir startup. The
+    # until-loop is the readiness wait: this one-shot exits 0 only once the
+    # buckets exist, which mimir depends_on below.
+    entrypoint: >
+      /bin/sh -c "
+      until mc alias set local http://minio:9000 mimir mimir-dev-secret; do
+        echo 'waiting for minio'; sleep 1;
+      done &&
+      mc mb -p local/mimir-blocks local/mimir-ruler local/mimir-alertmanager"
+
+  # --- Mimir (object-storage-native PromQL system) -----------------------
+  # Grafana Mimir in monolithic mode (-target=all): a single process running the
+  # distributor (Remote Write receiver), ingester, querier, store-gateway and
+  # compactor. Chosen as the ADR-0927 object-storage-native comparator because,
+  # like Ravel, its durable state lives in S3 rather than on local disk.
+  #
+  # DURABILITY AND STORAGE ARCHITECTURE: the distributor accepts Remote Write at
+  # /api/v1/push; the ingester holds recent samples in an in-memory head with a
+  # local write-ahead log, then the compactor ships compacted TSDB blocks to S3
+  # (MinIO here). So an ack is a local-WAL guarantee and the S3 copy appears
+  # LATER, after block upload. This ack-vs-object-storage-visibility gap is a
+  # material difference from Ravel's strict-mode Remote Write, where a 2xx means
+  # the data object and commit record are already durable in object storage
+  # (ADR-0927 decision 3). Do not compare Mimir's ack latency against Ravel's on
+  # the same row without this distinction.
+  mimir:
+    image: grafana/mimir:2.14.2@sha256:2d3912435771d356ec03ae4729fb584b4d76a5f035d9dda40b563a55bb6760e3
+    depends_on:
+      createbuckets:
+        condition: service_completed_successfully
+    command:
+      - "-config.file=/etc/mimir/mimir.yaml"
+      # Monolithic: every Mimir component in one process. The alternative
+      # (microservices) would spread the comparator across many containers with
+      # per-component limits and make the equal-envelope fairness rule above
+      # meaningless.
+      - "-target=all"
+    ports:
+      - "127.0.0.1:9009:9009"
+    volumes:
+      - ./config/mimir.yaml:/etc/mimir/mimir.yaml:ro
+      - mimir-data:/data
+    deploy:
+      resources:
+        limits:
+          cpus: "2.0"
+          memory: 4g
+
+volumes:
+  prometheus-data:
+  victoriametrics-data:
+  minio-data:
+  mimir-data:

--- a/deploy/metricsbench/tests/every_comparator_pins_an_image_digest.sh
+++ b/deploy/metricsbench/tests/every_comparator_pins_an_image_digest.sh
@@ -25,7 +25,12 @@ set -u
 
 # Resolve the deployment directory from this script's own location so the check
 # runs correctly from any working directory.
+# `CDPATH= cd` clears CDPATH for that one command, so a user's CDPATH cannot
+# make `cd` resolve somewhere else and print the directory it chose. The empty
+# assignment is the point, not a typo; SC1007 cannot tell the two apart.
+# shellcheck disable=SC1007
 SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+# shellcheck disable=SC1007
 DEPLOY_DIR=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
 COMPOSE_FILE="$DEPLOY_DIR/docker-compose.yml"
 
@@ -65,17 +70,24 @@ image_count=$(printf '%s\n' "$IMAGE_REFS" | grep -c .)
 
 echo "  image references found: $image_count (expected $EXPECTED_IMAGE_COUNT)"
 echo "  references:"
-# Check every reference carries an @sha256: digest.
+# A pinned reference ends in `@sha256:` followed by exactly 64 hex digits.
+# Matching the bare substring `@sha256:` is not enough: `repo:tag@sha256:` with
+# an empty or truncated digest would satisfy it while pinning nothing, which is
+# the failure this check exists to catch.
+DIGEST_RE='@sha256:[0-9a-f]\{64\}$'
+
+# Check every reference carries a complete digest.
 printf '%s\n' "$IMAGE_REFS" | while IFS= read -r ref; do
-  case "$ref" in
-    *@sha256:*) echo "    [pinned]   $ref" ;;
-    *)          echo "    [UNPINNED] $ref" ;;
-  esac
+  if printf '%s\n' "$ref" | grep -q "$DIGEST_RE"; then
+    echo "    [pinned]   $ref"
+  else
+    echo "    [UNPINNED] $ref"
+  fi
 done
 
 # The digest check drives the exit code from the parent shell (the while loop
 # above runs in a subshell and cannot set `fail`). Recount unpinned refs here.
-unpinned=$(printf '%s\n' "$IMAGE_REFS" | grep -vc '@sha256:')
+unpinned=$(printf '%s\n' "$IMAGE_REFS" | grep -vc "$DIGEST_RE")
 if [ "$unpinned" -ne 0 ]; then
   echo "FAIL: $unpinned image reference(s) lack an @sha256: digest"
   fail=1

--- a/deploy/metricsbench/tests/every_comparator_pins_an_image_digest.sh
+++ b/deploy/metricsbench/tests/every_comparator_pins_an_image_digest.sh
@@ -1,0 +1,107 @@
+#!/bin/sh
+# every_comparator_pins_an_image_digest.sh (issue #934, ADR-0927).
+#
+# Acceptance check for the MetricsBench comparator deployment. Issue #934 names
+# this check `metricsbench::deploy::tests::every_comparator_pins_an_image_digest`,
+# a Rust test path, but its own scope line says the task touches no crate, and
+# the crate that path would live in (crates/ravel-bench) is edited by the
+# parallel M1 task. This is that check implemented instead as a dependency-free
+# script under deploy/metricsbench/, preserving the name exactly. The deviation
+# is recorded in the task report and in README.md.
+#
+# It enforces, over the deployment files:
+#   1. every image reference is pinned by an `@sha256:` digest (a tag alone, or a
+#      tag with no digest, fails: a moving tag makes a run unreproducible);
+#   2. every comparator ADR-0927 requires is present (deleting a system cannot
+#      make the check pass);
+#   3. the number of image references equals the exact expected count (a check
+#      that scanned zero files and exited zero is the failure this guards
+#      against).
+# Exit 0 only when all three hold.
+#
+# POSIX sh, no external dependencies beyond grep/sed. Fails closed.
+
+set -u
+
+# Resolve the deployment directory from this script's own location so the check
+# runs correctly from any working directory.
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+DEPLOY_DIR=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
+COMPOSE_FILE="$DEPLOY_DIR/docker-compose.yml"
+
+# The comparators ADR-0927 requires in the portable cross-engine lane. Each must
+# appear as a service in the compose file. Prometheus and VictoriaMetrics are
+# named directly; "mimir" is the object-storage-native PromQL system (ADR-0927
+# permits Mimir or Thanos Receive) chosen for this deployment.
+REQUIRED_COMPARATORS="prometheus victoriametrics mimir"
+
+# Exact number of `image:` references the committed deployment must contain:
+# prometheus, victoriametrics, minio, createbuckets, mimir. If a service is added
+# or removed, update this number deliberately in the same change.
+EXPECTED_IMAGE_COUNT=5
+
+fail=0
+
+if [ ! -f "$COMPOSE_FILE" ]; then
+  echo "FAIL: compose file not found at $COMPOSE_FILE"
+  exit 1
+fi
+
+echo "MetricsBench image-pin check"
+echo "  deployment file: $COMPOSE_FILE"
+
+# Collect image references. Match indented `image:` keys only, strip the key and
+# surrounding whitespace to leave the bare reference.
+IMAGE_REFS=$(grep -E '^[[:space:]]*image:[[:space:]]*' "$COMPOSE_FILE" \
+  | sed -E 's/^[[:space:]]*image:[[:space:]]*//; s/[[:space:]]*$//')
+
+if [ -z "$IMAGE_REFS" ]; then
+  echo "FAIL: no image references found; the check must never scan zero images"
+  exit 1
+fi
+
+# Count references. `grep -c` counts matching lines, which is one per image key.
+image_count=$(printf '%s\n' "$IMAGE_REFS" | grep -c .)
+
+echo "  image references found: $image_count (expected $EXPECTED_IMAGE_COUNT)"
+echo "  references:"
+# Check every reference carries an @sha256: digest.
+printf '%s\n' "$IMAGE_REFS" | while IFS= read -r ref; do
+  case "$ref" in
+    *@sha256:*) echo "    [pinned]   $ref" ;;
+    *)          echo "    [UNPINNED] $ref" ;;
+  esac
+done
+
+# The digest check drives the exit code from the parent shell (the while loop
+# above runs in a subshell and cannot set `fail`). Recount unpinned refs here.
+unpinned=$(printf '%s\n' "$IMAGE_REFS" | grep -vc '@sha256:')
+if [ "$unpinned" -ne 0 ]; then
+  echo "FAIL: $unpinned image reference(s) lack an @sha256: digest"
+  fail=1
+fi
+
+if [ "$image_count" -ne "$EXPECTED_IMAGE_COUNT" ]; then
+  echo "FAIL: found $image_count image references, expected exactly $EXPECTED_IMAGE_COUNT"
+  fail=1
+fi
+
+# Every ADR-0927-required comparator must be present as a service. A service key
+# is a two-space-indented `name:` under `services:`. Matching that indentation
+# avoids a false positive from a bucket name or a comment mentioning the word.
+for svc in $REQUIRED_COMPARATORS; do
+  if grep -Eq "^  ${svc}:[[:space:]]*\$" "$COMPOSE_FILE"; then
+    echo "  comparator present: $svc"
+  else
+    echo "FAIL: required comparator '$svc' is missing from the deployment set"
+    fail=1
+  fi
+done
+
+if [ "$fail" -ne 0 ]; then
+  echo "RESULT: FAIL"
+  exit 1
+fi
+
+echo "RESULT: PASS ($image_count image references, all pinned; comparators: $REQUIRED_COMPARATORS)"
+exit 0


### PR DESCRIPTION
MetricsBench needs every comparator to launch from a configuration that is
reproducible months later, so a benchmark result can be re-derived rather than
remembered. This adds deploy/metricsbench/ with Prometheus, VictoriaMetrics and
Mimir, each on a pinned image digest with equal CPU and memory limits, plus
MinIO and a bucket one-shot as Mimir's object store.

Every behaviour that changes what a comparator measures is disclosed next to the
setting that causes it, not in a separate document: Prometheus head compaction
and retention, VictoriaMetrics deduplication, and Mimir's delayed block upload.
Durability and storage architecture are recorded per system, so a local-disk
result is never read as an S3-equivalent one.

MinIO is present only as Mimir's S3 endpoint. Per ADR-0927 decision 10, itself
citing ADR-0075 decision 3, a MinIO-backed run is never a publishable
performance or cost result; that is stated in the README next to the service
rather than left to a reader's memory.

The acceptance check ships as a POSIX shell script,
deploy/metricsbench/tests/every_comparator_pins_an_image_digest.sh. Issue #934
names it as a Rust test path, which contradicts its own scope line that the task
touches no crate, and the crate that path implies is being changed in parallel
by the M1 task. The name is preserved exactly and the deviation is recorded in
the script header and the README.

The check fails closed on three conditions: any image reference without an
@sha256 digest, a required comparator missing from the deployment set, and an
image-reference count other than the exact expected number. The third exists so
that a check which scanned nothing cannot pass by finding nothing wrong.

Nothing runs the script automatically yet. Wiring it into the gates is a
follow-up, deliberately left out of this change because the gate script is
shared with other in-flight work.

Fixes: #934
Refs: #927
