### PR TITLE
feat(bench): add the MetricsBench workload and PromQL corpus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4523,6 +4523,7 @@ dependencies = [
  "ravel-object-store",
  "ravel-otlp",
  "ravel-promql",
+ "ravel-promql-difftest",
  "ravel-proto",
  "ravel-query",
  "ravel-rspan",

--- a/benchmarks/metrics/README.md
+++ b/benchmarks/metrics/README.md
@@ -1,0 +1,93 @@
+# MetricsBench artifacts
+
+The versioned inputs to MetricsBench (ADR-0927). Two files, both loaded and
+gated by code rather than read by hand:
+
+| File | What it is | Loader and gate |
+|---|---|---|
+| `workload.json` | The workload manifest: seed, generator configuration, metric families, label distributions, and the four profiles | `ravel_bench::metrics_workload::load_workload` |
+| `metrics.corpus.json` | The PromQL query corpus: 24 queries, each with stable id, typed cost class, and the registry constructs it exercises | `ravel_bench::promql_corpus::load_corpus` |
+
+Both gates run before the first sample is generated:
+
+```sh
+cargo run -p ravel-bench --bin metricsbench_gen -- --profile ci --steps 20
+```
+
+That command loads and gates both artifacts, checks the bands they imply
+(every cost class populated, every entry classed, every metric a query selects
+actually emitted by the manifest), generates the profile, and prints one JSON
+document with the workload summary, the corpus summary, and the generation
+report. It exits non-zero on any gate or band failure, so exit 0 means the work
+happened.
+
+`--profile` has no default. The profile selects which data the run touches and
+every alternative is plausible on any target, so a silent default is refused.
+
+## Profiles
+
+ADR-0927 decision 11. Cardinality, history and churn vary one axis each and pin
+the others; collapsing them into a single scale factor would make a regression
+unattributable.
+
+| profile | active series | samples/series | scrape | duration | churn | total samples |
+|---|---|---|---|---|---|---|
+| `cardinality` | 1,000,000 | 360 | 15 s | 90 m | none | 360,000,000 |
+| `history` | 10,000 | 172,800 | 15 s | 30 d | none | 1,728,000,000 |
+| `churn` | 50,000 concurrent | 8,640 | 15 s | 36 h | 20%/h | 432,000,000 |
+| `ci` | 1,000 | 120 | 15 s | 30 m | 5%/h | 120,000 |
+
+The `ci` profile is marked non-comparable **in the artifact**, as a typed
+`comparability` field carrying the reason:
+
+```json
+"comparability": {"non_comparable": {"reason": "..."}}
+```
+
+A reader that loads the manifest can therefore refuse to publish a `ci` figure
+without knowing the rule. `metricsbench_gen --require-comparable` is that
+refusal: it exits non-zero for a non-comparable profile, and also for a run
+that covers only part of a comparable profile, because a truncated run is not
+that profile. The gate refuses a manifest that marks `ci` comparable at all.
+
+## Determinism
+
+One seed (`927000933`) drives everything. Every value and every injected
+anomaly is a pure function of `(seed, family, instance, step)`, so the same seed
+and manifest write byte-identical output; float payloads are encoded as
+`f64::to_bits` hex so a `-0.0` or a NaN survives the stream. `--out <path>`
+writes the stream; without it the stream is still encoded, counted and hashed.
+
+The generator emits gauges, monotonic counters, classic histograms, native
+histograms, staleness markers, counter resets, missing samples, out-of-order
+samples, and hour-boundary churn. Anomaly precedence is fixed (missing beats
+staleness beats the timestamp shift; a counter reset is independent) and
+documented on `ravel_bench::metrics_gen`.
+
+Every generation run reports exact figures, and `emitted_samples +
+omitted_missing_samples` must equal `steps * active_series` or the run fails
+rather than reporting a silent drop (ADR-0927's band 4).
+
+## Query corpus
+
+24 queries, three in each of the eight cost classes ADR-0927 decision 5 fixes:
+`metadata_only`, `single_series`, `selective_multi_series`, `high_fan_out`,
+`full_range`, `join`, `histogram`, `long_range`. The class is a typed enum on
+the entry, not a comment.
+
+Each entry names the constructs it exercises exactly as
+`ravel_promql_difftest::scoring::REGISTRY` names them. The gate checks
+membership in the registry, not membership in its supported subset: ADR-0927
+decision 6 keeps queries Ravel refuses or does not implement in the corpus,
+reported with their status and still counted in the corpus denominator, so a
+supported-only gate would delete exactly those entries.
+
+Three `long_range` entries restrict themselves to the profiles that generate
+enough data for their window (`profiles: ["history"]`, and `["history",
+"churn"]` for the 6-hour one). An entry with no `profiles` list runs under every
+profile.
+
+Adding a query means adding an entry here; nothing about the corpus lives in
+code. `crates/ravel-bench/tests/metricsbench_artifacts.rs` pins the counts, so
+an addition that skews the class balance or names an unknown construct fails
+there.

--- a/benchmarks/metrics/metrics.corpus.json
+++ b/benchmarks/metrics/metrics.corpus.json
@@ -1,0 +1,340 @@
+{
+  "version": 1,
+  "entries": [
+    {
+      "id": "mb_absent_instant",
+      "class": "metadata_only",
+      "promql": "absent(metricsbench_absent_metric)",
+      "eval": "instant",
+      "constructs": ["function call", "absent", "vector selector"]
+    },
+    {
+      "id": "mb_absent_over_time_window",
+      "class": "metadata_only",
+      "promql": "absent_over_time(metricsbench_absent_metric[1h])",
+      "eval": "instant",
+      "constructs": [
+        "function call",
+        "absent_over_time",
+        "matrix selector",
+        "vector selector"
+      ]
+    },
+    {
+      "id": "mb_absent_selective_labels",
+      "class": "metadata_only",
+      "promql": "absent(metricsbench_absent_metric{job=\"metricsbench-api\",region=\"eu-west-1\"})",
+      "eval": "instant",
+      "constructs": [
+        "function call",
+        "absent",
+        "vector selector",
+        "label matcher ="
+      ]
+    },
+    {
+      "id": "mb_single_gauge_instant",
+      "class": "single_series",
+      "promql": "metricsbench_gauge_cpu_percent{job=\"metricsbench-api\",region=\"eu-west-1\",instance=\"metricsbench-instance-0\"}",
+      "eval": "instant",
+      "constructs": ["vector selector", "label matcher ="]
+    },
+    {
+      "id": "mb_single_counter_rate",
+      "class": "single_series",
+      "promql": "rate(metricsbench_requests_total{job=\"metricsbench-api\",method=\"GET\",status=\"200\",instance=\"metricsbench-instance-0\"}[5m])",
+      "eval": "range",
+      "constructs": [
+        "function call",
+        "rate",
+        "matrix selector",
+        "vector selector",
+        "label matcher ="
+      ]
+    },
+    {
+      "id": "mb_single_gauge_delta",
+      "class": "single_series",
+      "promql": "delta(metricsbench_gauge_cpu_percent{job=\"metricsbench-api\",region=\"eu-west-1\",instance=\"metricsbench-instance-0\"}[15m])",
+      "eval": "instant",
+      "constructs": [
+        "function call",
+        "delta",
+        "matrix selector",
+        "vector selector",
+        "label matcher ="
+      ]
+    },
+    {
+      "id": "mb_selective_job_rate_sum",
+      "class": "selective_multi_series",
+      "promql": "sum by (job) (rate(metricsbench_requests_total{job=\"metricsbench-api\"}[5m]))",
+      "eval": "range",
+      "constructs": [
+        "aggregate expression",
+        "sum",
+        "by",
+        "paren expression",
+        "function call",
+        "rate",
+        "matrix selector",
+        "vector selector",
+        "label matcher ="
+      ]
+    },
+    {
+      "id": "mb_selective_region_avg",
+      "class": "selective_multi_series",
+      "promql": "avg by (region) (metricsbench_gauge_cpu_percent{region=~\"eu-.*\"})",
+      "eval": "instant",
+      "constructs": [
+        "aggregate expression",
+        "avg",
+        "by",
+        "paren expression",
+        "vector selector",
+        "label matcher =~"
+      ]
+    },
+    {
+      "id": "mb_selective_error_ratio",
+      "class": "selective_multi_series",
+      "promql": "sum(rate(metricsbench_requests_total{status=\"500\"}[5m])) / sum(rate(metricsbench_requests_total{status!=\"500\"}[5m]))",
+      "eval": "range",
+      "constructs": [
+        "binary expression",
+        "/",
+        "aggregate expression",
+        "sum",
+        "function call",
+        "rate",
+        "matrix selector",
+        "vector selector",
+        "label matcher =",
+        "label matcher !="
+      ]
+    },
+    {
+      "id": "mb_fanout_total_rate",
+      "class": "high_fan_out",
+      "promql": "sum(rate(metricsbench_requests_total[5m]))",
+      "eval": "range",
+      "constructs": [
+        "aggregate expression",
+        "sum",
+        "function call",
+        "rate",
+        "matrix selector",
+        "vector selector"
+      ]
+    },
+    {
+      "id": "mb_fanout_topk_instances",
+      "class": "high_fan_out",
+      "promql": "topk(25, metricsbench_gauge_cpu_percent)",
+      "eval": "instant",
+      "constructs": [
+        "aggregate expression",
+        "topk",
+        "number literal",
+        "vector selector"
+      ]
+    },
+    {
+      "id": "mb_fanout_count_by_instance",
+      "class": "high_fan_out",
+      "promql": "count by (instance) (metricsbench_gauge_cpu_percent)",
+      "eval": "instant",
+      "constructs": [
+        "aggregate expression",
+        "count",
+        "by",
+        "paren expression",
+        "vector selector"
+      ]
+    },
+    {
+      "id": "mb_full_range_avg_over_time",
+      "class": "full_range",
+      "promql": "avg_over_time(metricsbench_gauge_cpu_percent[30m])",
+      "eval": "range",
+      "constructs": [
+        "function call",
+        "avg_over_time",
+        "matrix selector",
+        "vector selector"
+      ]
+    },
+    {
+      "id": "mb_full_range_max_by_job",
+      "class": "full_range",
+      "promql": "max by (job) (max_over_time(metricsbench_gauge_cpu_percent[30m]))",
+      "eval": "instant",
+      "constructs": [
+        "aggregate expression",
+        "max",
+        "by",
+        "paren expression",
+        "function call",
+        "max_over_time",
+        "matrix selector",
+        "vector selector"
+      ]
+    },
+    {
+      "id": "mb_full_range_counter_increase",
+      "class": "full_range",
+      "promql": "sum(increase(metricsbench_requests_total[30m]))",
+      "eval": "instant",
+      "constructs": [
+        "aggregate expression",
+        "sum",
+        "function call",
+        "increase",
+        "matrix selector",
+        "vector selector"
+      ]
+    },
+    {
+      "id": "mb_join_cpu_on_build_version",
+      "class": "join",
+      "promql": "metricsbench_gauge_cpu_percent * on (job, instance) group_left (version) metricsbench_build_info",
+      "eval": "instant",
+      "constructs": [
+        "binary expression",
+        "*",
+        "on",
+        "group_left",
+        "vector selector"
+      ]
+    },
+    {
+      "id": "mb_join_saturated_and_busy",
+      "class": "join",
+      "promql": "metricsbench_gauge_cpu_percent{region=\"eu-west-1\"} > 80 and on (job, instance) rate(metricsbench_requests_total[5m]) > 10",
+      "eval": "instant",
+      "constructs": [
+        "binary expression",
+        "and",
+        "on",
+        ">",
+        "number literal",
+        "function call",
+        "rate",
+        "matrix selector",
+        "vector selector",
+        "label matcher ="
+      ]
+    },
+    {
+      "id": "mb_join_unless_quiet_instances",
+      "class": "join",
+      "promql": "metricsbench_gauge_cpu_percent unless on (job, instance) (rate(metricsbench_requests_total[5m]) > 0)",
+      "eval": "instant",
+      "constructs": [
+        "binary expression",
+        "unless",
+        "on",
+        "paren expression",
+        ">",
+        "number literal",
+        "function call",
+        "rate",
+        "matrix selector",
+        "vector selector"
+      ]
+    },
+    {
+      "id": "mb_histogram_classic_p99",
+      "class": "histogram",
+      "promql": "histogram_quantile(0.99, sum by (le) (rate(metricsbench_request_duration_seconds_bucket[5m])))",
+      "eval": "range",
+      "constructs": [
+        "function call",
+        "histogram_quantile",
+        "number literal",
+        "aggregate expression",
+        "sum",
+        "by",
+        "paren expression",
+        "rate",
+        "matrix selector",
+        "vector selector"
+      ]
+    },
+    {
+      "id": "mb_histogram_native_p95",
+      "class": "histogram",
+      "promql": "histogram_quantile(0.95, metricsbench_latency_native)",
+      "eval": "instant",
+      "constructs": [
+        "function call",
+        "histogram_quantile",
+        "number literal",
+        "vector selector"
+      ]
+    },
+    {
+      "id": "mb_histogram_native_fraction",
+      "class": "histogram",
+      "promql": "histogram_fraction(0, 0.5, rate(metricsbench_latency_native[5m]))",
+      "eval": "instant",
+      "constructs": [
+        "function call",
+        "histogram_fraction",
+        "number literal",
+        "rate",
+        "matrix selector",
+        "vector selector"
+      ]
+    },
+    {
+      "id": "mb_long_range_7d_avg",
+      "class": "long_range",
+      "promql": "avg_over_time(metricsbench_gauge_cpu_percent{job=\"metricsbench-api\"}[7d])",
+      "eval": "instant",
+      "profiles": ["history"],
+      "constructs": [
+        "function call",
+        "avg_over_time",
+        "matrix selector",
+        "vector selector",
+        "label matcher ="
+      ]
+    },
+    {
+      "id": "mb_long_range_subquery_max",
+      "class": "long_range",
+      "promql": "max_over_time(sum(rate(metricsbench_requests_total[5m]))[1d:5m])",
+      "eval": "instant",
+      "profiles": ["history"],
+      "constructs": [
+        "subquery",
+        "function call",
+        "max_over_time",
+        "aggregate expression",
+        "sum",
+        "rate",
+        "matrix selector",
+        "vector selector"
+      ]
+    },
+    {
+      "id": "mb_long_range_predict_linear",
+      "class": "long_range",
+      "promql": "predict_linear(metricsbench_gauge_cpu_percent{job=\"metricsbench-api\"}[6h], 4 * 3600)",
+      "eval": "instant",
+      "profiles": ["history", "churn"],
+      "constructs": [
+        "function call",
+        "predict_linear",
+        "matrix selector",
+        "vector selector",
+        "label matcher =",
+        "number literal",
+        "binary expression",
+        "*"
+      ]
+    }
+  ]
+}

--- a/benchmarks/metrics/workload.json
+++ b/benchmarks/metrics/workload.json
@@ -111,7 +111,7 @@
       "samples_per_series": 120,
       "scrape_interval_secs": 15,
       "duration_secs": 1800,
-      "churn_basis_points_per_hour": 500,
+      "churn_basis_points_per_hour": 0,
       "total_samples": 120000,
       "comparability": {
         "non_comparable": {

--- a/benchmarks/metrics/workload.json
+++ b/benchmarks/metrics/workload.json
@@ -1,0 +1,123 @@
+{
+  "version": 1,
+  "seed": 927000933,
+  "generator": {
+    "scaling_label": "instance",
+    "scaling_label_value_prefix": "metricsbench-instance-",
+    "classic_histogram_bounds": [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5],
+    "native_histogram_schema": 2,
+    "native_histogram_buckets": 8,
+    "absent_metric_name": "metricsbench_absent_metric",
+    "anomalies": {
+      "missing_sample_one_in": 500,
+      "stale_marker_one_in": 900,
+      "counter_reset_one_in": 1200,
+      "out_of_order_one_in": 800
+    }
+  },
+  "label_dimensions": [
+    {
+      "name": "job",
+      "values": [
+        "metricsbench-api",
+        "metricsbench-web",
+        "metricsbench-worker",
+        "metricsbench-db"
+      ]
+    },
+    {
+      "name": "region",
+      "values": ["eu-west-1", "us-east-1", "ap-south-1"]
+    },
+    {
+      "name": "method",
+      "values": ["GET", "POST", "PUT", "DELETE"]
+    },
+    {
+      "name": "status",
+      "values": ["200", "204", "404", "500"]
+    },
+    {
+      "name": "version",
+      "values": ["1.24.0", "1.25.0"]
+    }
+  ],
+  "families": [
+    {
+      "name": "metricsbench_gauge_cpu_percent",
+      "kind": "gauge",
+      "labels": ["job", "region"],
+      "series_permille": 400
+    },
+    {
+      "name": "metricsbench_requests_total",
+      "kind": "counter",
+      "labels": ["job", "method", "status"],
+      "series_permille": 300
+    },
+    {
+      "name": "metricsbench_request_duration_seconds",
+      "kind": "classic_histogram",
+      "labels": ["job"],
+      "series_permille": 150
+    },
+    {
+      "name": "metricsbench_latency_native",
+      "kind": "native_histogram",
+      "labels": ["job"],
+      "series_permille": 100
+    },
+    {
+      "name": "metricsbench_build_info",
+      "kind": "gauge",
+      "labels": ["job", "version"],
+      "series_permille": 50
+    }
+  ],
+  "profiles": [
+    {
+      "name": "cardinality",
+      "active_series": 1000000,
+      "samples_per_series": 360,
+      "scrape_interval_secs": 15,
+      "duration_secs": 5400,
+      "churn_basis_points_per_hour": 0,
+      "total_samples": 360000000,
+      "comparability": "comparable"
+    },
+    {
+      "name": "history",
+      "active_series": 10000,
+      "samples_per_series": 172800,
+      "scrape_interval_secs": 15,
+      "duration_secs": 2592000,
+      "churn_basis_points_per_hour": 0,
+      "total_samples": 1728000000,
+      "comparability": "comparable"
+    },
+    {
+      "name": "churn",
+      "active_series": 50000,
+      "samples_per_series": 8640,
+      "scrape_interval_secs": 15,
+      "duration_secs": 129600,
+      "churn_basis_points_per_hour": 2000,
+      "total_samples": 432000000,
+      "comparability": "comparable"
+    },
+    {
+      "name": "ci",
+      "active_series": 1000,
+      "samples_per_series": 120,
+      "scrape_interval_secs": 15,
+      "duration_secs": 1800,
+      "churn_basis_points_per_hour": 500,
+      "total_samples": 120000,
+      "comparability": {
+        "non_comparable": {
+          "reason": "1,000 series over 30 minutes exercises the same code paths as the three measured profiles and measures none of them: it is sized to fit a CI job, not a workload. ADR-0927 decision 11 forbids presenting it as a performance result, and this field is why a reader that loads the artifact can refuse to publish it rather than having to know the rule."
+        }
+      }
+    }
+  ]
+}

--- a/crates/ravel-bench/Cargo.toml
+++ b/crates/ravel-bench/Cargo.toml
@@ -19,6 +19,17 @@ ravel-catalog = { workspace = true }
 ravel-commit = { workspace = true }
 ravel-maintain = { workspace = true }
 ravel-promql = { workspace = true }
+# The MetricsBench PromQL corpus gate (ADR-0927 decision 5) checks every named
+# construct against `ravel_promql_difftest::scoring::REGISTRY`, the PromQL
+# analog of `ravel_sql::conformance::registry()`. A NEW dependency edge from
+# ravel-bench, and a path dependency: ravel-promql-difftest is not listed in the
+# workspace `[workspace.dependencies]`, so it is named by path and version here
+# exactly as the optional `ravel-sql` entry below is. Not optional and not a
+# dev-dependency: the corpus loads in the default build, and the generator bin
+# (`metricsbench_gen`) runs the gate, which a dev-dependency would be invisible
+# to. It is already a workspace member, so a `--workspace` build compiled it
+# before this edge existed too.
+ravel-promql-difftest = { path = "../ravel-promql-difftest", version = "0.11.0" }
 prost = { workspace = true }
 ravel-query = { workspace = true }
 tokio = { workspace = true }
@@ -201,6 +212,15 @@ name = "pushdown_crossover_bench"
 path = "src/bin/pushdown_crossover_bench.rs"
 bench = false
 
+# MetricsBench (ADR-0927, issue #933): gates the checked-in workload manifest
+# and PromQL corpus, then generates a profile's samples deterministically. In
+# the default feature set on purpose: it is the entry point that makes both
+# artifact gates reachable from a real caller.
+[[bin]]
+name = "metricsbench_gen"
+path = "src/bin/metricsbench_gen.rs"
+bench = false
+
 [[bin]]
 name = "segment_alloc_profile"
 path = "src/bin/segment_alloc_profile.rs"
@@ -364,6 +384,15 @@ bench = false
 name = "clickbench_corpus"
 path = "tests/clickbench_corpus.rs"
 required-features = ["sql-latency"]
+bench = false
+
+# Gate test for the checked-in MetricsBench artifacts (issue #933) under
+# `benchmarks/metrics/`, and the reachability proof that a corrupt artifact
+# fails through the `metricsbench_gen` binary rather than only through a direct
+# `gate_corpus` call.
+[[test]]
+name = "metricsbench_artifacts"
+path = "tests/metricsbench_artifacts.rs"
 bench = false
 
 [[test]]

--- a/crates/ravel-bench/src/bin/metricsbench_gen.rs
+++ b/crates/ravel-bench/src/bin/metricsbench_gen.rs
@@ -1,0 +1,298 @@
+//! MetricsBench workload generator and artifact gate (ADR-0927, issue #933).
+//!
+//! This is the entry point that makes both MetricsBench gates reachable from a
+//! real caller rather than only from unit tests: it loads
+//! `benchmarks/metrics/workload.json` through
+//! [`ravel_bench::metrics_workload::load_workload`] and
+//! `benchmarks/metrics/metrics.corpus.json` through
+//! [`ravel_bench::promql_corpus::load_corpus`], both of which gate what they
+//! return, and refuses to run when either artifact is corrupt.
+//!
+//! It then generates the profile's sample stream deterministically and prints
+//! one JSON document with the workload summary, the corpus summary, and the
+//! generation report. Every figure it prints is checked against a stated band
+//! and the process exits non-zero outside it, so "exit 0" means the work
+//! happened rather than that the tool ran.
+//!
+//! `--profile` has no default: the profile selects which data the run touches,
+//! and every alternative is plausible on any target, so a silent default is
+//! refused (CLAUDE.md, measurement discipline).
+//!
+//! `--require-comparable` is how a caller refuses to publish a figure it must
+//! not: the `ci` profile carries its non-comparability in the artifact
+//! (ADR-0927 decision 11), and a truncated run of any profile is not that
+//! profile.
+
+use std::io::Write;
+use std::path::PathBuf;
+
+use clap::Parser;
+use ravel_bench::metrics_gen::Generator;
+use ravel_bench::metrics_workload::{WorkloadFile, load_workload};
+use ravel_bench::promql_corpus::{CorpusEntry, class_counts, load_corpus};
+
+/// Where the checked-in artifacts live, relative to this crate's manifest dir.
+const DEFAULT_WORKLOAD: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../benchmarks/metrics/workload.json"
+);
+/// The checked-in query corpus.
+const DEFAULT_CORPUS: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../benchmarks/metrics/metrics.corpus.json"
+);
+
+#[derive(Parser, Debug)]
+#[command(
+    about = "Gate the MetricsBench artifacts and generate a profile's workload deterministically"
+)]
+struct Args {
+    /// The workload manifest to load and gate.
+    #[arg(long, default_value = DEFAULT_WORKLOAD)]
+    workload: PathBuf,
+    /// The PromQL query corpus to load and gate.
+    #[arg(long, default_value = DEFAULT_CORPUS)]
+    corpus: PathBuf,
+    /// Which profile to generate. No default: the choice selects which data the
+    /// run touches.
+    #[arg(long)]
+    profile: String,
+    /// Scrapes to generate. Defaults to the profile's full
+    /// `samples_per_series`.
+    #[arg(long)]
+    steps: Option<u64>,
+    /// Timestamp of the first scrape, in milliseconds. Time is a parameter so a
+    /// run is reproducible.
+    #[arg(long, default_value_t = 0)]
+    base_ts_ms: i64,
+    /// Write the generated stream here. Omitted, the stream is still encoded,
+    /// counted and hashed, but discarded.
+    #[arg(long)]
+    out: Option<PathBuf>,
+    /// Exit non-zero unless this run's figures may be published: the profile is
+    /// comparable and the run covers the whole profile.
+    #[arg(long, default_value_t = false)]
+    require_comparable: bool,
+}
+
+/// A band violation. Separate from the artifact and generator errors so a
+/// reader can tell "the artifacts are wrong" from "the run measured something
+/// outside what was pre-registered".
+#[derive(Debug, thiserror::Error)]
+enum BandError {
+    #[error(
+        "cost class `{class}` has {found} corpus entries, expected at least 1: every ADR-0927 \
+         cost class must be represented, or the corpus cannot attribute a cost to a shape"
+    )]
+    EmptyCostClass { class: &'static str, found: usize },
+    #[error(
+        "corpus entry `{entry_id}` carries no cost class; ADR-0927 decision 5 classes every entry"
+    )]
+    UnclassedEntry { entry_id: String },
+    #[error(
+        "no corpus entry runs under profile `{profile}`, so the run would time nothing; a \
+         profile with no queries is a hole in the corpus, not an empty result"
+    )]
+    NoEntriesForProfile { profile: String },
+    #[error(
+        "corpus entry `{entry_id}` selects metric `{metric}`, which the workload manifest does \
+         not emit; the corpus and the generator would measure different data"
+    )]
+    UnknownMetric { entry_id: String, metric: String },
+    #[error("profile `{profile}` is not comparable ({reason}), so its figures cannot be published")]
+    NotComparable { profile: String, reason: String },
+    #[error(
+        "this run generated {steps} of profile `{profile}`'s {expected} steps, so it is not that \
+         profile and its figures cannot be published"
+    )]
+    TruncatedRun {
+        profile: String,
+        steps: u64,
+        expected: u64,
+    },
+}
+
+/// Every `metricsbench_`-prefixed identifier a query selects. A deliberately
+/// small scan rather than a PromQL parse: the corpus only ever names metrics
+/// with that prefix, and a name that is not a declared family is the drift this
+/// catches.
+fn selected_metrics(promql: &str, prefix: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let bytes: Vec<char> = promql.chars().collect();
+    let mut i = 0usize;
+    while i < bytes.len() {
+        let start = i;
+        if bytes[i].is_ascii_alphabetic() || bytes[i] == '_' {
+            while i < bytes.len() && (bytes[i].is_ascii_alphanumeric() || bytes[i] == '_') {
+                i += 1;
+            }
+            let word: String = bytes[start..i].iter().collect();
+            if word.starts_with(prefix) && !out.contains(&word) {
+                out.push(word);
+            }
+        } else {
+            i += 1;
+        }
+    }
+    out
+}
+
+/// The checks whose bands are stated here rather than left to a reader.
+fn check_bands(
+    workload: &WorkloadFile,
+    entries: &[CorpusEntry],
+    profile: &str,
+) -> Result<(), BandError> {
+    for (class, found) in class_counts(entries) {
+        if found == 0 {
+            return Err(BandError::EmptyCostClass {
+                class: class.slug(),
+                found,
+            });
+        }
+    }
+    for entry in entries {
+        if entry.class.is_none() {
+            return Err(BandError::UnclassedEntry {
+                entry_id: entry.id.clone(),
+            });
+        }
+    }
+    if !entries.iter().any(|e| e.runs_under(profile)) {
+        return Err(BandError::NoEntriesForProfile {
+            profile: profile.to_string(),
+        });
+    }
+    let emitted = workload.emitted_metric_names();
+    let absent = &workload.generator.absent_metric_name;
+    // Every family name shares this prefix, and so does the absent sentinel, so
+    // it is the one string the scan needs.
+    let prefix = "metricsbench_";
+    for entry in entries {
+        for metric in selected_metrics(&entry.promql, prefix) {
+            if &metric != absent && !emitted.contains(&metric) {
+                return Err(BandError::UnknownMetric {
+                    entry_id: entry.id.clone(),
+                    metric,
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+fn run() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::parse();
+    let workload = load_workload(&args.workload)?;
+    let entries = load_corpus(&args.corpus)?;
+    check_bands(&workload, &entries, &args.profile)?;
+
+    let mut generator = Generator::new(&workload, &args.profile, args.base_ts_ms)?;
+    let expected_steps = generator.profile().samples_per_series;
+    let steps = args.steps.unwrap_or(expected_steps);
+    let comparability = generator.profile().comparability.clone();
+
+    let mut sink: Box<dyn Write> = match &args.out {
+        Some(path) => Box::new(std::io::BufWriter::new(std::fs::File::create(path)?)),
+        None => Box::new(std::io::sink()),
+    };
+    let report = generator.generate_into(steps, &mut sink)?;
+    drop(sink);
+
+    let per_class: Vec<serde_json::Value> = class_counts(&entries)
+        .into_iter()
+        .map(|(class, n)| {
+            serde_json::json!({
+                "class": class.slug(),
+                "entries": n,
+                "entries_in_profile": entries
+                    .iter()
+                    .filter(|e| e.class == Some(class) && e.runs_under(&args.profile))
+                    .count(),
+            })
+        })
+        .collect();
+    let document = serde_json::json!({
+        "workload": {
+            "path": args.workload,
+            "version": workload.version,
+            "seed": workload.seed,
+            "families": workload.families.len(),
+            "label_dimensions": workload.label_dimensions.len(),
+            "profiles": workload.profiles.iter().map(|p| p.name.clone()).collect::<Vec<_>>(),
+        },
+        "corpus": {
+            "path": args.corpus,
+            "entries": entries.len(),
+            "entries_in_profile": entries.iter().filter(|e| e.runs_under(&args.profile)).count(),
+            "cost_classes": per_class,
+        },
+        "generation": report,
+        "run": {
+            "steps_requested": steps,
+            "steps_in_full_profile": expected_steps,
+            "covers_whole_profile": steps == expected_steps,
+            "base_ts_ms": args.base_ts_ms,
+            "out": args.out,
+        },
+    });
+    println!("{}", serde_json::to_string_pretty(&document)?);
+
+    if args.require_comparable {
+        if let Some(reason) = comparability.reason() {
+            return Err(Box::new(BandError::NotComparable {
+                profile: args.profile.clone(),
+                reason: reason.to_string(),
+            }));
+        }
+        if steps != expected_steps {
+            return Err(Box::new(BandError::TruncatedRun {
+                profile: args.profile.clone(),
+                steps,
+                expected: expected_steps,
+            }));
+        }
+    }
+    Ok(())
+}
+
+fn main() {
+    if let Err(err) = run() {
+        eprintln!("metricsbench_gen: {err}");
+        let mut source = err.source();
+        while let Some(cause) = source {
+            eprintln!("  caused by: {cause}");
+            source = cause.source();
+        }
+        std::process::exit(1);
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn selected_metrics_finds_every_prefixed_identifier_once() {
+        let found = selected_metrics(
+            "histogram_quantile(0.99, sum by (le) (rate(metricsbench_dur_seconds_bucket[5m]))) \
+             + metricsbench_gauge + metricsbench_gauge",
+            "metricsbench_",
+        );
+        assert_eq!(
+            found,
+            vec![
+                "metricsbench_dur_seconds_bucket".to_string(),
+                "metricsbench_gauge".to_string()
+            ]
+        );
+        // A label value that merely contains the prefix inside quotes is still
+        // an identifier to this scan, which is the conservative direction: it
+        // would be reported as an unknown metric rather than silently accepted.
+        assert_eq!(
+            selected_metrics("rate(other_total[5m])", "metricsbench_"),
+            Vec::<String>::new()
+        );
+    }
+}

--- a/crates/ravel-bench/src/bin/metricsbench_gen.rs
+++ b/crates/ravel-bench/src/bin/metricsbench_gen.rs
@@ -197,6 +197,10 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         None => Box::new(std::io::sink()),
     };
     let report = generator.generate_into(steps, &mut sink)?;
+    // Flush at the call site and propagate: a BufWriter dropped without a flush
+    // swallows the error and can lose the tail of the artifact while the process
+    // still exits zero.
+    sink.flush()?;
     drop(sink);
 
     let per_class: Vec<serde_json::Value> = class_counts(&entries)

--- a/crates/ravel-bench/src/lib.rs
+++ b/crates/ravel-bench/src/lib.rs
@@ -15,7 +15,10 @@ pub mod harness;
 pub mod ingest;
 #[cfg(feature = "sql-latency")]
 pub mod logs_scan_scaling;
+pub mod metrics_gen;
+pub mod metrics_workload;
 pub mod profiling;
+pub mod promql_corpus;
 pub mod pushdown_crossover;
 pub mod query_latency;
 #[cfg(feature = "parquet-baseline")]

--- a/crates/ravel-bench/src/metrics_gen.rs
+++ b/crates/ravel-bench/src/metrics_gen.rs
@@ -95,7 +95,9 @@ pub struct NativeHistogram {
     pub count: u64,
     /// Sum of observations.
     pub sum: f64,
-    /// Positive-bucket counts as deltas, Prometheus' own wire shape.
+    /// Positive-bucket counts in Prometheus' own wire shape: each element is
+    /// the difference against the previous bucket of this same sample, so a
+    /// decoder prefix-sums the vector to recover the absolute counts.
     pub positive_deltas: Vec<i64>,
 }
 
@@ -741,17 +743,22 @@ impl<'a> Generator<'a> {
                         count: 0,
                     };
                 }
-                // A native histogram carries counter semantics: emit the
-                // per-step GROWTH as positive deltas and accumulate the
-                // absolutes, so `count` and `sum` only rise apart from an
-                // injected reset (which zeroes the state before this step).
+                // Two different axes meet here. ACROSS STEPS the buckets
+                // accumulate, because a native histogram carries counter
+                // semantics: `count` and `sum` only rise apart from an injected
+                // reset (which zeroes the state before this step). WITHIN one
+                // sample the wire format carries `positive_deltas[i] =
+                // accumulated[i] - accumulated[i - 1]`, differences between
+                // neighbouring buckets that a decoder prefix-sums back to the
+                // absolute counts. Emitting the per-step growth here instead
+                // would type-check and stay non-negative while decoding to a
+                // bucket vector that disagrees with this sample's `count`.
                 let (positive_deltas, sum, count) = match entry {
                     InstanceState::Native {
                         buckets,
                         sum,
                         count,
                     } => {
-                        let mut deltas = Vec::with_capacity(buckets.len());
                         for (b, bucket) in buckets.iter_mut().enumerate() {
                             let growth =
                                 mix(seed, &[TAG_VALUE, fam_id, global, step, b as u64]) % 8;
@@ -762,7 +769,13 @@ impl<'a> Generator<'a> {
                                 1,
                                 12,
                             ) * growth as f64;
-                            deltas.push(growth as i64);
+                        }
+                        let mut deltas = Vec::with_capacity(buckets.len());
+                        let mut previous = 0i64;
+                        for bucket in buckets.iter() {
+                            let absolute = *bucket as i64;
+                            deltas.push(absolute - previous);
+                            previous = absolute;
                         }
                         (deltas, *sum, *count)
                     }
@@ -1258,6 +1271,117 @@ mod tests {
         assert!(
             expected_resets >= native_resets.len() as u64,
             "the total reset count must include the native resets"
+        );
+    }
+
+    /// Parse the single native series' `(count, positive_deltas)` per step, in
+    /// stream order, from a generated text stream.
+    fn native_samples(text: &str) -> Vec<(u64, Vec<i64>)> {
+        text.lines()
+            .filter(|l| l.contains("\tmb_native{"))
+            .map(|line| {
+                let payload = line.split('\t').nth(2).expect("payload");
+                let count: u64 = payload
+                    .split("count=")
+                    .nth(1)
+                    .and_then(|s| s.split(' ').next())
+                    .and_then(|s| s.parse().ok())
+                    .expect("count field");
+                let deltas: Vec<i64> = payload
+                    .split("deltas=")
+                    .nth(1)
+                    .expect("deltas field")
+                    .split(',')
+                    .map(|d| d.parse().expect("integer delta"))
+                    .collect();
+                (count, deltas)
+            })
+            .collect()
+    }
+
+    #[test]
+    fn native_histogram_positive_deltas_prefix_sum_to_the_accumulated_buckets() {
+        // `positive_deltas` is the wire encoding of the buckets WITHIN one
+        // sample: a decoder prefix-sums it across neighbouring buckets to
+        // recover the absolute per-bucket counts, exactly as
+        // `int_side_counts` does in ravel-remote-write's normalize.rs. That
+        // axis is not the across-steps accumulation the same sample's `count`
+        // and `sum` carry. Encoding the per-step GROWTH of each bucket into
+        // `positive_deltas` type-checks and stays non-negative, so nothing but
+        // this round trip catches it: prefix-summing growths yields a vector
+        // whose total is one step's observations while `count` reports the
+        // run's, and the two disagree at every step past the first.
+        //
+        // The oracle is recomputed here from the same `mix` the generator
+        // draws from, so the assertion is against the accumulated buckets a
+        // reader can derive by hand, not against whatever the encoder emitted.
+        let reset_rate = 8u64;
+        let w = workload(
+            0x5EED_0001,
+            AnomalyRates {
+                missing_sample_one_in: 0,
+                stale_marker_one_in: 0,
+                counter_reset_one_in: reset_rate,
+                out_of_order_one_in: 0,
+            },
+        );
+        gate_workload(&w).expect("manifest gates clean");
+        let steps = 80u64;
+        let (bytes, _report) = Generator::new(&w, "cardinality", 0)
+            .expect("generator builds")
+            .generate_bytes(steps)
+            .expect("generates");
+        let text = String::from_utf8(bytes).expect("utf8");
+        let samples = native_samples(&text);
+        assert_eq!(samples.len(), steps as usize, "one native sample per step");
+
+        // Family index 3, global 0: 50 permille of 20 active series is one
+        // native instance. A reset drops the accumulated state before the step
+        // it fires on, so the step is included in the walk rather than skipped.
+        let seed = w.seed;
+        let native_fam = 3u64;
+        let nbuckets = w.generator.native_histogram_buckets as usize;
+        let mut accumulated = vec![0u64; nbuckets];
+        let mut reset_steps = 0u64;
+        for (step, (count, deltas)) in samples.iter().enumerate() {
+            let step = step as u64;
+            if fires(reset_rate, seed, TAG_RESET, native_fam, 0, step) {
+                accumulated = vec![0u64; nbuckets];
+                reset_steps += 1;
+            }
+            for (b, bucket) in accumulated.iter_mut().enumerate() {
+                *bucket += mix(seed, &[TAG_VALUE, native_fam, 0, step, b as u64]) % 8;
+            }
+
+            assert_eq!(
+                deltas.len(),
+                nbuckets,
+                "step {step}: one delta per declared positive bucket"
+            );
+            let mut decoded = Vec::with_capacity(nbuckets);
+            let mut running = 0i64;
+            for d in deltas {
+                running += *d;
+                assert!(
+                    running >= 0,
+                    "step {step}: a prefix sum of positive_deltas went negative: {deltas:?}"
+                );
+                decoded.push(running as u64);
+            }
+            assert_eq!(
+                decoded, accumulated,
+                "step {step}: prefix-summing positive_deltas must recover the \
+                 accumulated bucket counts"
+            );
+            let decoded_total: u64 = decoded.iter().sum();
+            assert_eq!(
+                decoded_total, *count,
+                "step {step}: the decoded buckets must total the sample's count"
+            );
+        }
+        assert_eq!(
+            reset_steps, 7,
+            "this seed must cover reset steps in the walk"
         );
     }
 

--- a/crates/ravel-bench/src/metrics_gen.rs
+++ b/crates/ravel-bench/src/metrics_gen.rs
@@ -1,0 +1,1358 @@
+//! The deterministic MetricsBench workload generator (ADR-0927 decision 11).
+//!
+//! Given a gated [`WorkloadFile`] and a profile name, this produces the sample
+//! stream the portable lane ingests over Remote Write 1.0: gauges, monotonic
+//! counters, classic histograms, native histograms, staleness markers, counter
+//! resets, missing samples, out-of-order samples, and hour-boundary churn.
+//!
+//! Determinism is structural, not a convention. Every value and every injected
+//! anomaly is a pure function of `(seed, family, instance, step)` through
+//! [`splitmix64`]: there is no RNG state carried between samples, no clock
+//! read, and no iteration over a hash map. Two runs of the same seed and
+//! manifest therefore write byte-identical output, which
+//! `same_seed_produces_byte_identical_output` proves rather than asserting in
+//! prose.
+//!
+//! Float values are built as an integer over a power of two
+//! ([`unit_scaled`]), so a value is exactly representable and reproduces bit
+//! for bit; the encoder writes float payloads as their `f64::to_bits` hex, so
+//! a NaN or a `-0.0` is distinguishable in the stream rather than collapsed by
+//! decimal formatting.
+//!
+//! ## Anomaly precedence
+//!
+//! An instance-step can be selected by more than one anomaly, so the order is
+//! fixed rather than left to whichever check runs first:
+//!
+//! 1. **missing** wins outright: the instance emits nothing for that step, and
+//!    every series it would have written counts as omitted.
+//! 2. **staleness** replaces a gauge's value with a marker. Counters and
+//!    histograms are left alone so a reset stays unambiguous.
+//! 3. **out-of-order** shifts the timestamp two scrape intervals earlier,
+//!    independently of what value was chosen, and only from step 2 on so the
+//!    shifted sample really does follow a newer one in the stream.
+//! 4. **counter reset** zeroes a counter or histogram instance before that
+//!    step's increment, independently of the three above.
+
+use std::collections::BTreeMap;
+use std::io::Write;
+
+use serde::Serialize;
+
+use crate::metrics_workload::{CHURN_EPOCH_SECS, FamilyKind, MetricFamily, Profile, WorkloadFile};
+
+/// Hash-domain tags, so two derivations from the same `(family, instance,
+/// step)` triple never collide.
+const TAG_VALUE: u64 = 0x01;
+const TAG_MISSING: u64 = 0x11;
+const TAG_STALE: u64 = 0x12;
+const TAG_RESET: u64 = 0x13;
+const TAG_OUT_OF_ORDER: u64 = 0x14;
+
+/// SplitMix64's finalizer, the whole source of variation in this generator: a
+/// pure function, so nothing depends on iteration or call order.
+pub fn splitmix64(x: u64) -> u64 {
+    let mut z = x.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    z ^ (z >> 31)
+}
+
+/// Mixes a seed and a coordinate tuple into one value.
+pub fn mix(seed: u64, coords: &[u64]) -> u64 {
+    let mut h = splitmix64(seed);
+    for c in coords {
+        h = splitmix64(h ^ splitmix64(*c));
+    }
+    h
+}
+
+/// `h` reduced to `[0, range)` over a power-of-two denominator, so the result
+/// is an exactly representable `f64` and reproduces bit for bit.
+pub fn unit_scaled(h: u64, range_numerator: u64, denominator_pow2: u32) -> f64 {
+    let denom = 1u64 << denominator_pow2;
+    (h % (range_numerator * denom)) as f64 / denom as f64
+}
+
+/// What one series carries at one timestamp.
+#[derive(Clone, Debug, PartialEq)]
+pub enum SampleValue {
+    /// A float sample.
+    Float(f64),
+    /// A Prometheus staleness marker: the series is explicitly absent from this
+    /// scrape rather than merely missing from it.
+    StaleMarker,
+    /// A native histogram (ADR-0108).
+    NativeHistogram(NativeHistogram),
+}
+
+/// A native histogram sample.
+#[derive(Clone, Debug, PartialEq)]
+pub struct NativeHistogram {
+    /// The bucket-layout schema.
+    pub schema: i32,
+    /// Total observations.
+    pub count: u64,
+    /// Sum of observations.
+    pub sum: f64,
+    /// Positive-bucket counts as deltas, Prometheus' own wire shape.
+    pub positive_deltas: Vec<i64>,
+}
+
+/// One generated sample: a series identity, a timestamp, and a value.
+#[derive(Clone, Debug, PartialEq)]
+pub struct GeneratedSample {
+    /// Milliseconds since the epoch.
+    pub ts_ms: i64,
+    /// The metric name, including any classic-histogram suffix.
+    pub metric: String,
+    /// The labels, sorted by name.
+    pub labels: Vec<(String, String)>,
+    /// The value.
+    pub value: SampleValue,
+}
+
+impl GeneratedSample {
+    /// The canonical one-line encoding: `<ts_ms>\t<series>\t<payload>\n`.
+    ///
+    /// Floats are written as `f64::to_bits` hex rather than decimal so the
+    /// stream distinguishes `-0.0` from `0.0` and carries a NaN payload
+    /// unchanged.
+    pub fn encode(&self, out: &mut Vec<u8>) {
+        out.clear();
+        let mut line = format!("{}\t{}{{", self.ts_ms, self.metric);
+        for (i, (k, v)) in self.labels.iter().enumerate() {
+            if i > 0 {
+                line.push(',');
+            }
+            line.push_str(k);
+            line.push_str("=\"");
+            line.push_str(v);
+            line.push('"');
+        }
+        line.push_str("}\t");
+        match &self.value {
+            SampleValue::Float(v) => {
+                line.push_str(&format!("f 0x{:016x}", v.to_bits()));
+            }
+            SampleValue::StaleMarker => line.push_str("stale"),
+            SampleValue::NativeHistogram(h) => {
+                line.push_str(&format!(
+                    "h schema={} count={} sum=0x{:016x} deltas=",
+                    h.schema,
+                    h.count,
+                    h.sum.to_bits()
+                ));
+                for (i, d) in h.positive_deltas.iter().enumerate() {
+                    if i > 0 {
+                        line.push(',');
+                    }
+                    line.push_str(&d.to_string());
+                }
+            }
+        }
+        line.push('\n');
+        out.extend_from_slice(line.as_bytes());
+    }
+}
+
+/// Everything a generation run reports. Every figure is exact: a reader gates
+/// on these rather than on the absence of a complaint (ADR-0927's band 4:
+/// ingested must equal generated minus explicitly reported rejections).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct GenerationReport {
+    /// The profile generated.
+    pub profile: String,
+    /// The seed the manifest declared.
+    pub seed: u64,
+    /// Whether this profile's figures may be published (ADR-0927 decision 11).
+    pub publishable: bool,
+    /// Why not, when they may not.
+    pub non_comparable_reason: Option<String>,
+    /// Steps generated. Equals the profile's `samples_per_series` for a full
+    /// run and less for a bounded one.
+    pub steps: u64,
+    /// Series alive at any one step.
+    pub active_series: u64,
+    /// Distinct series created across the run, including churned-in cohorts.
+    pub total_series_created: u64,
+    /// `steps * active_series`: samples a run with no anomalies would write.
+    pub nominal_samples: u64,
+    /// Samples actually written.
+    pub emitted_samples: u64,
+    /// Float samples among them.
+    pub float_samples: u64,
+    /// Staleness markers among them.
+    pub stale_markers: u64,
+    /// Native-histogram samples among them.
+    pub native_histogram_samples: u64,
+    /// Samples not written because their scrape was dropped. Plus
+    /// `emitted_samples`, this equals `nominal_samples`.
+    pub omitted_missing_samples: u64,
+    /// Counter and histogram instances reset to zero mid-run.
+    pub counter_reset_events: u64,
+    /// Samples stamped two intervals early.
+    pub out_of_order_samples: u64,
+    /// Bytes written.
+    pub bytes: u64,
+    /// BLAKE3 of the byte stream, so two runs are compared by one field.
+    pub digest: String,
+}
+
+/// Everything that can go wrong generating a workload.
+#[derive(Debug, thiserror::Error)]
+pub enum GeneratorError {
+    /// The manifest declares no profile by that name.
+    #[error("workload manifest declares no profile `{name}`; it declares {available:?}")]
+    UnknownProfile {
+        /// The name asked for.
+        name: String,
+        /// The names the manifest declares.
+        available: Vec<String>,
+    },
+    /// Writing the stream failed.
+    #[error("writing the generated stream failed: {source}")]
+    Write {
+        /// The underlying I/O failure.
+        #[source]
+        source: std::io::Error,
+    },
+    /// The run's own accounting does not close. A silent drop is exactly what
+    /// ADR-0927's band 4 fails a run for, so it is a hard error here rather
+    /// than a figure a reader has to notice.
+    #[error(
+        "generated sample accounting does not close for profile `{profile}`: {emitted} emitted \
+         plus {omitted} omitted is {sum}, but {steps} steps over {active_series} active series \
+         is {nominal}"
+    )]
+    AccountingMismatch {
+        /// The profile generated.
+        profile: String,
+        /// Samples written.
+        emitted: u64,
+        /// Samples omitted.
+        omitted: u64,
+        /// Their sum.
+        sum: u64,
+        /// Steps generated.
+        steps: u64,
+        /// Series alive per step.
+        active_series: u64,
+        /// The nominal total.
+        nominal: u64,
+    },
+}
+
+/// Per-instance accumulated state for the monotonic families.
+#[derive(Clone, Debug)]
+enum InstanceState {
+    /// A counter's running total, in whole units.
+    Counter { total: u64 },
+    /// A classic histogram's cumulative per-bucket counts (the last entry is
+    /// `+Inf`), observation sum, and observation count.
+    Classic {
+        buckets: Vec<u64>,
+        sum: f64,
+        count: u64,
+    },
+}
+
+/// One family's generation plan under one profile.
+#[derive(Debug)]
+struct FamilyPlan {
+    /// Index into [`WorkloadFile::families`].
+    index: usize,
+    /// Instances alive at any one step.
+    instances: u64,
+    /// Series one instance emits.
+    series_per_instance: u64,
+    /// Instances replaced at each churn-epoch boundary.
+    churned_per_epoch: u64,
+    /// `(cardinality, stride)` for each fixed label, in declaration order.
+    fixed: Vec<(u64, u64)>,
+    /// Product of the fixed cardinalities: the instance ordinal's divisor.
+    fixed_product: u64,
+    /// Accumulated state, keyed by global instance index. Pruned at each epoch
+    /// boundary so a long churn run does not grow without bound.
+    state: BTreeMap<u64, InstanceState>,
+}
+
+/// What one instance needs to emit its samples at one step. A struct rather
+/// than seven positional parameters, which the argument-count lint refuses and
+/// a reader miscounts.
+#[derive(Debug, Clone, Copy)]
+struct EmitContext<'l> {
+    /// Index into [`Generator::plans`].
+    plan_idx: usize,
+    /// The instance's global index, which carries its churn cohort.
+    global: u64,
+    /// The scrape step.
+    step: u64,
+    /// The timestamp to stamp, already shifted if this step is out-of-order.
+    ts_ms: i64,
+    /// The instance's label set, sorted by name.
+    labels: &'l [(String, String)],
+    /// Whether a gauge emits a staleness marker instead of a value.
+    stale_now: bool,
+}
+
+/// The deterministic generator.
+#[derive(Debug)]
+pub struct Generator<'a> {
+    workload: &'a WorkloadFile,
+    profile: &'a Profile,
+    base_ts_ms: i64,
+    plans: Vec<FamilyPlan>,
+}
+
+impl<'a> Generator<'a> {
+    /// Build a generator for `profile_name`, with the first step stamped at
+    /// `base_ts_ms`. Time is a parameter, never a clock read, so a run is
+    /// reproducible.
+    pub fn new(
+        workload: &'a WorkloadFile,
+        profile_name: &str,
+        base_ts_ms: i64,
+    ) -> Result<Self, GeneratorError> {
+        let profile =
+            workload
+                .profile(profile_name)
+                .ok_or_else(|| GeneratorError::UnknownProfile {
+                    name: profile_name.to_string(),
+                    available: workload.profiles.iter().map(|p| p.name.clone()).collect(),
+                })?;
+        let mut plans = Vec::with_capacity(workload.families.len());
+        for (index, family) in workload.families.iter().enumerate() {
+            let instances = workload.family_instances(profile, family);
+            let mut fixed = Vec::with_capacity(family.labels.len());
+            let mut stride = 1u64;
+            for label in &family.labels {
+                // `gate_workload` already refused a family naming an
+                // undeclared dimension, so an absent one here would be a
+                // manifest that never passed the gate; treat it as a
+                // single-valued dimension rather than panicking.
+                let card = workload
+                    .dimension(label)
+                    .map(|d| d.values.len() as u64)
+                    .unwrap_or(1)
+                    .max(1);
+                fixed.push((card, stride));
+                stride *= card;
+            }
+            plans.push(FamilyPlan {
+                index,
+                instances,
+                series_per_instance: workload.series_per_instance(family.kind),
+                churned_per_epoch: instances * profile.churn_basis_points_per_hour / 10_000,
+                fixed,
+                fixed_product: stride,
+                state: BTreeMap::new(),
+            });
+        }
+        Ok(Generator {
+            workload,
+            profile,
+            base_ts_ms,
+            plans,
+        })
+    }
+
+    /// The profile this generator runs.
+    pub fn profile(&self) -> &Profile {
+        self.profile
+    }
+
+    /// Distinct series the plans create over `steps`, counting churned-in
+    /// cohorts. Computed from the plans rather than from the profile's own
+    /// arithmetic, so a disagreement between the two is visible.
+    pub fn total_series_created(&self, steps: u64) -> u64 {
+        let epochs = self.epochs_spanned(steps);
+        self.plans
+            .iter()
+            .map(|p| (p.instances + (epochs - 1) * p.churned_per_epoch) * p.series_per_instance)
+            .sum()
+    }
+
+    /// Churn epochs `steps` spans, at least one.
+    fn epochs_spanned(&self, steps: u64) -> u64 {
+        if steps == 0 {
+            return 1;
+        }
+        let last_secs = (steps - 1) * self.profile.scrape_interval_secs;
+        last_secs / CHURN_EPOCH_SECS + 1
+    }
+
+    /// Generate `steps` scrapes into `sink`, returning the run's exact figures.
+    pub fn generate_into<W: Write>(
+        &mut self,
+        steps: u64,
+        sink: &mut W,
+    ) -> Result<GenerationReport, GeneratorError> {
+        let interval_ms = (self.profile.scrape_interval_secs * 1_000) as i64;
+        let seed = self.workload.seed;
+        let anomalies = self.workload.generator.anomalies;
+        let mut hasher = blake3::Hasher::new();
+        let mut line = Vec::with_capacity(256);
+        let mut samples: Vec<GeneratedSample> = Vec::new();
+
+        let mut emitted = 0u64;
+        let mut floats = 0u64;
+        let mut stale = 0u64;
+        let mut native = 0u64;
+        let mut omitted = 0u64;
+        let mut resets = 0u64;
+        let mut out_of_order = 0u64;
+        let mut bytes = 0u64;
+
+        for step in 0..steps {
+            let step_secs = step * self.profile.scrape_interval_secs;
+            let epoch = step_secs / CHURN_EPOCH_SECS;
+            let step_ts = self.base_ts_ms + (step as i64) * interval_ms;
+
+            for plan_idx in 0..self.plans.len() {
+                let family = self.workload.families[self.plans[plan_idx].index].clone();
+                let base = self.plans[plan_idx].churned_per_epoch * epoch;
+                if base > 0 {
+                    self.plans[plan_idx].state.retain(|k, _| *k >= base);
+                }
+                let instances = self.plans[plan_idx].instances;
+                for local in 0..instances {
+                    let global = base + local;
+                    let fam_id = self.plans[plan_idx].index as u64;
+                    let per_instance = self.plans[plan_idx].series_per_instance;
+
+                    if fires(
+                        anomalies.missing_sample_one_in,
+                        seed,
+                        TAG_MISSING,
+                        fam_id,
+                        global,
+                        step,
+                    ) {
+                        omitted += per_instance;
+                        continue;
+                    }
+
+                    let mut ts = step_ts;
+                    let shifted = step >= 2
+                        && fires(
+                            anomalies.out_of_order_one_in,
+                            seed,
+                            TAG_OUT_OF_ORDER,
+                            fam_id,
+                            global,
+                            step,
+                        );
+                    if shifted {
+                        ts -= 2 * interval_ms;
+                    }
+
+                    let reset = matches!(
+                        family.kind,
+                        FamilyKind::Counter | FamilyKind::ClassicHistogram
+                    ) && fires(
+                        anomalies.counter_reset_one_in,
+                        seed,
+                        TAG_RESET,
+                        fam_id,
+                        global,
+                        step,
+                    );
+                    if reset {
+                        self.plans[plan_idx].state.remove(&global);
+                        resets += 1;
+                    }
+
+                    let stale_now = family.kind == FamilyKind::Gauge
+                        && fires(
+                            anomalies.stale_marker_one_in,
+                            seed,
+                            TAG_STALE,
+                            fam_id,
+                            global,
+                            step,
+                        );
+
+                    samples.clear();
+                    let labels = self.labels_for(plan_idx, &family, global);
+                    let emit = EmitContext {
+                        plan_idx,
+                        global,
+                        step,
+                        ts_ms: ts,
+                        labels: &labels,
+                        stale_now,
+                    };
+                    self.emit_instance(&emit, &family, &mut samples);
+
+                    if shifted {
+                        out_of_order += samples.len() as u64;
+                    }
+                    for sample in &samples {
+                        match &sample.value {
+                            SampleValue::Float(_) => floats += 1,
+                            SampleValue::StaleMarker => stale += 1,
+                            SampleValue::NativeHistogram(_) => native += 1,
+                        }
+                        sample.encode(&mut line);
+                        hasher.update(&line);
+                        sink.write_all(&line)
+                            .map_err(|source| GeneratorError::Write { source })?;
+                        bytes += line.len() as u64;
+                        emitted += 1;
+                    }
+                }
+            }
+        }
+        sink.flush()
+            .map_err(|source| GeneratorError::Write { source })?;
+
+        let nominal = steps * self.profile.active_series;
+        if emitted + omitted != nominal {
+            return Err(GeneratorError::AccountingMismatch {
+                profile: self.profile.name.clone(),
+                emitted,
+                omitted,
+                sum: emitted + omitted,
+                steps,
+                active_series: self.profile.active_series,
+                nominal,
+            });
+        }
+
+        Ok(GenerationReport {
+            profile: self.profile.name.clone(),
+            seed,
+            publishable: self.profile.is_publishable(),
+            non_comparable_reason: self.profile.comparability.reason().map(|r| r.to_string()),
+            steps,
+            active_series: self.profile.active_series,
+            total_series_created: self.total_series_created(steps),
+            nominal_samples: nominal,
+            emitted_samples: emitted,
+            float_samples: floats,
+            stale_markers: stale,
+            native_histogram_samples: native,
+            omitted_missing_samples: omitted,
+            counter_reset_events: resets,
+            out_of_order_samples: out_of_order,
+            bytes,
+            digest: hasher.finalize().to_hex().to_string(),
+        })
+    }
+
+    /// Generate `steps` scrapes into memory. Convenience over
+    /// [`Self::generate_into`], through the same single encoding path.
+    pub fn generate_bytes(
+        &mut self,
+        steps: u64,
+    ) -> Result<(Vec<u8>, GenerationReport), GeneratorError> {
+        let mut buf: Vec<u8> = Vec::new();
+        let report = self.generate_into(steps, &mut buf)?;
+        Ok((buf, report))
+    }
+
+    /// The label set for one instance: its fixed dimensions decomposed from the
+    /// global instance index, plus the scaling label carrying the ordinal.
+    /// Sorted by name, so a series identity has one spelling.
+    fn labels_for(
+        &self,
+        plan_idx: usize,
+        family: &MetricFamily,
+        global: u64,
+    ) -> Vec<(String, String)> {
+        let plan = &self.plans[plan_idx];
+        let mut labels: Vec<(String, String)> = Vec::with_capacity(family.labels.len() + 1);
+        for (i, label) in family.labels.iter().enumerate() {
+            let (card, stride) = plan.fixed[i];
+            let value = self
+                .workload
+                .dimension(label)
+                .and_then(|d| d.values.get(((global / stride) % card) as usize).cloned())
+                .unwrap_or_default();
+            labels.push((label.clone(), value));
+        }
+        labels.push((
+            self.workload.generator.scaling_label.clone(),
+            format!(
+                "{}{}",
+                self.workload.generator.scaling_label_value_prefix,
+                global / plan.fixed_product
+            ),
+        ));
+        labels.sort();
+        labels
+    }
+
+    /// Append every sample one instance writes at one step.
+    fn emit_instance(
+        &mut self,
+        emit: &EmitContext<'_>,
+        family: &MetricFamily,
+        out: &mut Vec<GeneratedSample>,
+    ) {
+        let EmitContext {
+            plan_idx,
+            global,
+            step,
+            ts_ms,
+            labels,
+            stale_now,
+        } = *emit;
+        let seed = self.workload.seed;
+        let fam_id = self.plans[plan_idx].index as u64;
+        let h = mix(seed, &[TAG_VALUE, fam_id, global, step]);
+        match family.kind {
+            FamilyKind::Gauge => {
+                let value = if stale_now {
+                    SampleValue::StaleMarker
+                } else {
+                    SampleValue::Float(unit_scaled(h, 100, 10))
+                };
+                out.push(GeneratedSample {
+                    ts_ms,
+                    metric: family.name.clone(),
+                    labels: labels.to_vec(),
+                    value,
+                });
+            }
+            FamilyKind::Counter => {
+                let entry = self.plans[plan_idx]
+                    .state
+                    .entry(global)
+                    .or_insert(InstanceState::Counter { total: 0 });
+                let total = match entry {
+                    InstanceState::Counter { total } => {
+                        *total += h % 16;
+                        *total
+                    }
+                    // A family's kind never changes mid-run, so this arm is
+                    // unreachable in practice; restarting the accumulator is
+                    // the recoverable answer either way.
+                    InstanceState::Classic { .. } => {
+                        *entry = InstanceState::Counter { total: h % 16 };
+                        h % 16
+                    }
+                };
+                out.push(GeneratedSample {
+                    ts_ms,
+                    metric: family.name.clone(),
+                    labels: labels.to_vec(),
+                    value: SampleValue::Float(total as f64),
+                });
+            }
+            FamilyKind::ClassicHistogram => {
+                let bounds = self.workload.generator.classic_histogram_bounds.clone();
+                let bucket_count = bounds.len() + 1;
+                let entry =
+                    self.plans[plan_idx]
+                        .state
+                        .entry(global)
+                        .or_insert(InstanceState::Classic {
+                            buckets: vec![0; bucket_count],
+                            sum: 0.0,
+                            count: 0,
+                        });
+                if !matches!(entry, InstanceState::Classic { .. }) {
+                    *entry = InstanceState::Classic {
+                        buckets: vec![0; bucket_count],
+                        sum: 0.0,
+                        count: 0,
+                    };
+                }
+                let (buckets, sum, count) = match entry {
+                    InstanceState::Classic {
+                        buckets,
+                        sum,
+                        count,
+                    } => {
+                        for (b, bucket) in buckets.iter_mut().enumerate() {
+                            let observed =
+                                mix(seed, &[TAG_VALUE, fam_id, global, step, b as u64]) % 8;
+                            *bucket += observed;
+                            *count += observed;
+                            *sum += unit_scaled(
+                                mix(seed, &[TAG_VALUE + 1, fam_id, global, step, b as u64]),
+                                1,
+                                12,
+                            ) * observed as f64;
+                        }
+                        (buckets.clone(), *sum, *count)
+                    }
+                    InstanceState::Counter { .. } => (vec![0; bucket_count], 0.0, 0),
+                };
+                // Cumulative counts, ascending by `le`, then `_sum`, then
+                // `_count`: the order a Prometheus scrape presents them in.
+                let mut cumulative = 0u64;
+                for (b, bucket) in buckets.iter().enumerate() {
+                    cumulative += *bucket;
+                    let le = match bounds.get(b) {
+                        Some(bound) => format!("{bound}"),
+                        None => "+Inf".to_string(),
+                    };
+                    let mut bucket_labels = labels.to_vec();
+                    bucket_labels.push(("le".to_string(), le));
+                    bucket_labels.sort();
+                    out.push(GeneratedSample {
+                        ts_ms,
+                        metric: format!("{}_bucket", family.name),
+                        labels: bucket_labels,
+                        value: SampleValue::Float(cumulative as f64),
+                    });
+                }
+                out.push(GeneratedSample {
+                    ts_ms,
+                    metric: format!("{}_sum", family.name),
+                    labels: labels.to_vec(),
+                    value: SampleValue::Float(sum),
+                });
+                out.push(GeneratedSample {
+                    ts_ms,
+                    metric: format!("{}_count", family.name),
+                    labels: labels.to_vec(),
+                    value: SampleValue::Float(count as f64),
+                });
+            }
+            FamilyKind::NativeHistogram => {
+                let buckets = self.workload.generator.native_histogram_buckets;
+                let mut positive_deltas = Vec::with_capacity(buckets as usize);
+                let mut previous = 0i64;
+                let mut count = 0u64;
+                for b in 0..buckets {
+                    let absolute =
+                        (mix(seed, &[TAG_VALUE, fam_id, global, step, b as u64]) % 32) as i64;
+                    positive_deltas.push(absolute - previous);
+                    previous = absolute;
+                    count += absolute as u64;
+                }
+                out.push(GeneratedSample {
+                    ts_ms,
+                    metric: family.name.clone(),
+                    labels: labels.to_vec(),
+                    value: SampleValue::NativeHistogram(NativeHistogram {
+                        schema: self.workload.generator.native_histogram_schema,
+                        count,
+                        sum: unit_scaled(h, 4, 12),
+                        positive_deltas,
+                    }),
+                });
+            }
+        }
+    }
+}
+
+/// Whether an anomaly with rate "one in `one_in`" fires for this coordinate. A
+/// rate of zero disables the anomaly, which is how a profile ADR-0927 marks
+/// churn-free stays clean.
+fn fires(one_in: u64, seed: u64, tag: u64, family: u64, instance: u64, step: u64) -> bool {
+    one_in != 0 && mix(seed, &[tag, family, instance, step]).is_multiple_of(one_in)
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::metrics_workload::{
+        AnomalyRates, Comparability, GeneratorConfig, LabelDimension, WORKLOAD_FORMAT_VERSION,
+        gate_workload,
+    };
+
+    /// A four-family manifest at the `ci` scale, small enough that every figure
+    /// below is a number a reader can check by hand: 20 active series, 10 of
+    /// them the ten series of one classic-histogram instance.
+    fn workload(seed: u64, anomalies: AnomalyRates) -> WorkloadFile {
+        let profile = |name: &str, churn_bp: u64, comparability: Comparability| Profile {
+            name: name.to_string(),
+            active_series: 20,
+            samples_per_series: 240,
+            scrape_interval_secs: 15,
+            duration_secs: 3_600,
+            churn_basis_points_per_hour: churn_bp,
+            total_samples: 4_800,
+            comparability,
+        };
+        WorkloadFile {
+            version: WORKLOAD_FORMAT_VERSION,
+            seed,
+            generator: GeneratorConfig {
+                scaling_label: "instance".to_string(),
+                scaling_label_value_prefix: "mb-instance-".to_string(),
+                classic_histogram_bounds: vec![0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5],
+                native_histogram_schema: 2,
+                native_histogram_buckets: 4,
+                absent_metric_name: "mb_absent".to_string(),
+                anomalies,
+            },
+            label_dimensions: vec![
+                LabelDimension {
+                    name: "job".to_string(),
+                    values: vec!["api".to_string(), "web".to_string()],
+                },
+                LabelDimension {
+                    name: "region".to_string(),
+                    values: vec!["eu".to_string(), "us".to_string()],
+                },
+            ],
+            families: vec![
+                MetricFamily {
+                    name: "mb_gauge".to_string(),
+                    kind: FamilyKind::Gauge,
+                    labels: vec!["job".to_string(), "region".to_string()],
+                    series_permille: 300,
+                },
+                MetricFamily {
+                    name: "mb_counter".to_string(),
+                    kind: FamilyKind::Counter,
+                    labels: vec!["job".to_string()],
+                    series_permille: 150,
+                },
+                MetricFamily {
+                    name: "mb_classic".to_string(),
+                    kind: FamilyKind::ClassicHistogram,
+                    labels: vec!["job".to_string()],
+                    series_permille: 500,
+                },
+                MetricFamily {
+                    name: "mb_native".to_string(),
+                    kind: FamilyKind::NativeHistogram,
+                    labels: vec!["job".to_string()],
+                    series_permille: 50,
+                },
+            ],
+            profiles: vec![
+                profile("cardinality", 0, Comparability::Comparable),
+                profile("history", 0, Comparability::Comparable),
+                profile("churn", 2_500, Comparability::Comparable),
+                profile(
+                    "ci",
+                    0,
+                    Comparability::NonComparable {
+                        reason: "too small to measure".to_string(),
+                    },
+                ),
+            ],
+        }
+    }
+
+    fn clean() -> AnomalyRates {
+        AnomalyRates {
+            missing_sample_one_in: 0,
+            stale_marker_one_in: 0,
+            counter_reset_one_in: 0,
+            out_of_order_one_in: 0,
+        }
+    }
+
+    /// The generator's own definition of determinism: the same seed and
+    /// manifest produce byte-identical output, and a different seed does not.
+    /// Proven on a stream that carries every value shape and every anomaly, so
+    /// a nondeterministic anomaly path cannot hide behind a clean run.
+    #[test]
+    fn same_seed_produces_byte_identical_output() {
+        let noisy = AnomalyRates {
+            missing_sample_one_in: 7,
+            stale_marker_one_in: 5,
+            counter_reset_one_in: 6,
+            out_of_order_one_in: 4,
+        };
+        let w = workload(0xABCD_1234, noisy);
+        gate_workload(&w).expect("test manifest gates clean");
+
+        let (first_bytes, first) = Generator::new(&w, "churn", 1_700_000_000_000)
+            .expect("generator builds")
+            .generate_bytes(200)
+            .expect("first run generates");
+        let (second_bytes, second) = Generator::new(&w, "churn", 1_700_000_000_000)
+            .expect("generator builds")
+            .generate_bytes(200)
+            .expect("second run generates");
+
+        assert_eq!(
+            first_bytes, second_bytes,
+            "the same seed must produce byte-identical output"
+        );
+        assert_eq!(
+            first, second,
+            "the same seed must produce identical figures"
+        );
+        // The run really exercised every shape and every anomaly, so the
+        // equality above is not equality of two empty streams.
+        assert!(first.bytes > 0, "the run wrote nothing");
+        assert_eq!(first.emitted_samples + first.omitted_missing_samples, 4_000);
+        for (what, n) in [
+            ("float samples", first.float_samples),
+            ("stale markers", first.stale_markers),
+            ("native histograms", first.native_histogram_samples),
+            ("omitted samples", first.omitted_missing_samples),
+            ("counter resets", first.counter_reset_events),
+            ("out-of-order samples", first.out_of_order_samples),
+        ] {
+            assert!(n > 0, "the determinism run produced no {what}");
+        }
+
+        // A different seed produces a different stream, so the equality above
+        // is a property of the seed rather than of a generator that ignores it.
+        let other = workload(0xABCD_1235, noisy);
+        let (other_bytes, other_report) = Generator::new(&other, "churn", 1_700_000_000_000)
+            .expect("generator builds")
+            .generate_bytes(200)
+            .expect("third run generates");
+        assert_ne!(
+            other_bytes, first_bytes,
+            "a different seed must produce a different stream"
+        );
+        assert_ne!(other_report.digest, first.digest);
+        // The accounting is seed-independent even though the bytes are not.
+        assert_eq!(other_report.nominal_samples, first.nominal_samples);
+    }
+
+    #[test]
+    fn a_clean_run_emits_exactly_one_sample_per_series_per_step() {
+        let w = workload(11, clean());
+        gate_workload(&w).expect("manifest gates clean");
+        let (bytes, report) = Generator::new(&w, "cardinality", 0)
+            .expect("generator builds")
+            .generate_bytes(10)
+            .expect("generates");
+
+        // 20 active series over 10 steps, with no anomalies enabled.
+        assert_eq!(report.nominal_samples, 200);
+        assert_eq!(report.emitted_samples, 200);
+        assert_eq!(report.omitted_missing_samples, 0);
+        assert_eq!(report.stale_markers, 0);
+        assert_eq!(report.counter_reset_events, 0);
+        assert_eq!(report.out_of_order_samples, 0);
+        // 6 gauge + 3 counter + 10 classic + 1 native series per step.
+        assert_eq!(report.float_samples, 190);
+        assert_eq!(report.native_histogram_samples, 10);
+        assert_eq!(report.total_series_created, 20);
+        assert_eq!(
+            bytes.iter().filter(|b| **b == b'\n').count(),
+            200,
+            "one line per emitted sample"
+        );
+        assert_eq!(report.bytes, bytes.len() as u64);
+    }
+
+    #[test]
+    fn the_series_set_is_exactly_the_declared_cardinality() {
+        let w = workload(11, clean());
+        let (bytes, report) = Generator::new(&w, "cardinality", 0)
+            .expect("generator builds")
+            .generate_bytes(4)
+            .expect("generates");
+        let text = String::from_utf8(bytes).expect("utf8");
+        let series: std::collections::BTreeSet<&str> =
+            text.lines().filter_map(|l| l.split('\t').nth(1)).collect();
+        assert_eq!(
+            series.len(),
+            report.active_series as usize,
+            "distinct series must equal the profile's active-series count"
+        );
+        // The 6 gauge series are exactly job x region x instance over
+        // 2 x 2 x 2 (6 series is 1.5 instance-blocks of the 4 fixed combos, so
+        // instances 0..5 span instance ordinals 0 and 1).
+        let gauge: std::collections::BTreeSet<&str> = series
+            .iter()
+            .filter(|s| s.starts_with("mb_gauge{"))
+            .copied()
+            .collect();
+        assert_eq!(gauge.len(), 6);
+        assert!(gauge.contains("mb_gauge{instance=\"mb-instance-0\",job=\"api\",region=\"eu\"}"));
+        assert!(gauge.contains("mb_gauge{instance=\"mb-instance-1\",job=\"web\",region=\"eu\"}"));
+        // Labels are sorted by name in the rendered identity, so a series has
+        // exactly one spelling.
+        for s in &gauge {
+            assert!(
+                s.contains("{instance="),
+                "labels must be sorted by name: {s}"
+            );
+        }
+    }
+
+    #[test]
+    fn counters_are_monotonic_between_resets_and_reset_exactly_when_selected() {
+        let w = workload(
+            99,
+            AnomalyRates {
+                missing_sample_one_in: 0,
+                stale_marker_one_in: 0,
+                counter_reset_one_in: 9,
+                out_of_order_one_in: 0,
+            },
+        );
+        let (bytes, report) = Generator::new(&w, "cardinality", 0)
+            .expect("generator builds")
+            .generate_bytes(60)
+            .expect("generates");
+        let text = String::from_utf8(bytes).expect("utf8");
+
+        // Per-series value history for one counter series, in stream order.
+        let mut drops = 0usize;
+        let mut last: BTreeMap<String, f64> = BTreeMap::new();
+        for line in text.lines() {
+            let mut parts = line.split('\t');
+            let _ts = parts.next();
+            let series = parts.next().unwrap_or_default();
+            let payload = parts.next().unwrap_or_default();
+            if !series.starts_with("mb_counter{") {
+                continue;
+            }
+            let bits = payload
+                .strip_prefix("f 0x")
+                .and_then(|h| u64::from_str_radix(h, 16).ok())
+                .expect("counter payload is hex float bits");
+            let value = f64::from_bits(bits);
+            if let Some(previous) = last.insert(series.to_string(), value)
+                && value < previous
+            {
+                drops += 1;
+            }
+        }
+        // Resets fire on the counter and the classic-histogram families, and a
+        // reset is observable as a drop only when the post-reset increment is
+        // smaller than the pre-reset total, so the counter-only observed-drop
+        // count is a strict subset of the reported reset count. Both figures are
+        // pinned: a generator that stopped resetting, or one that reset without
+        // reporting it, moves one of them.
+        assert_eq!(report.counter_reset_events, 20);
+        assert_eq!(
+            drops, 14,
+            "counter series must fall only at the resets the report counts"
+        );
+        assert!(
+            (drops as u64) <= report.counter_reset_events,
+            "a counter cannot drop more often than it is reset"
+        );
+    }
+
+    #[test]
+    fn classic_histogram_buckets_are_cumulative_and_carry_every_bound() {
+        let w = workload(3, clean());
+        let (bytes, _) = Generator::new(&w, "cardinality", 0)
+            .expect("generator builds")
+            .generate_bytes(3)
+            .expect("generates");
+        let text = String::from_utf8(bytes).expect("utf8");
+
+        let bucket_lines: Vec<&str> = text
+            .lines()
+            .filter(|l| l.contains("mb_classic_bucket{"))
+            .collect();
+        // 8 buckets (7 bounds plus +Inf) for the one instance, over 3 steps.
+        assert_eq!(bucket_lines.len(), 24);
+        for le in [
+            "0.005", "0.01", "0.025", "0.05", "0.1", "0.25", "0.5", "+Inf",
+        ] {
+            assert_eq!(
+                bucket_lines
+                    .iter()
+                    .filter(|l| l.contains(&format!("le=\"{le}\"")))
+                    .count(),
+                3,
+                "every step must carry the le={le} bucket exactly once"
+            );
+        }
+        assert_eq!(
+            text.lines()
+                .filter(|l| l.contains("mb_classic_sum{"))
+                .count(),
+            3
+        );
+        assert_eq!(
+            text.lines()
+                .filter(|l| l.contains("mb_classic_count{"))
+                .count(),
+            3
+        );
+
+        // Within one step the cumulative counts never decrease, and +Inf is the
+        // largest.
+        let step_one: Vec<f64> = bucket_lines
+            .iter()
+            .take(8)
+            .map(|l| {
+                let payload = l.split('\t').nth(2).unwrap_or_default();
+                let bits = payload
+                    .strip_prefix("f 0x")
+                    .and_then(|h| u64::from_str_radix(h, 16).ok())
+                    .expect("bucket payload is hex float bits");
+                f64::from_bits(bits)
+            })
+            .collect();
+        assert_eq!(step_one.len(), 8);
+        for pair in step_one.windows(2) {
+            assert!(
+                pair[1] >= pair[0],
+                "classic histogram buckets must be cumulative: {step_one:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn native_histograms_carry_the_declared_schema_and_bucket_count() {
+        let w = workload(5, clean());
+        let (bytes, report) = Generator::new(&w, "cardinality", 0)
+            .expect("generator builds")
+            .generate_bytes(5)
+            .expect("generates");
+        let text = String::from_utf8(bytes).expect("utf8");
+        let native: Vec<&str> = text.lines().filter(|l| l.contains("\th schema=")).collect();
+        assert_eq!(native.len(), 5);
+        assert_eq!(report.native_histogram_samples, 5);
+        for line in &native {
+            assert!(line.contains("h schema=2 "), "wrong schema: {line}");
+            let deltas = line
+                .split("deltas=")
+                .nth(1)
+                .expect("deltas present")
+                .split(',')
+                .count();
+            assert_eq!(deltas, 4, "four positive buckets were declared: {line}");
+        }
+    }
+
+    #[test]
+    fn a_missing_sample_omits_the_whole_instance_and_the_accounting_closes() {
+        let w = workload(
+            21,
+            AnomalyRates {
+                missing_sample_one_in: 5,
+                stale_marker_one_in: 0,
+                counter_reset_one_in: 0,
+                out_of_order_one_in: 0,
+            },
+        );
+        let (bytes, report) = Generator::new(&w, "cardinality", 0)
+            .expect("generator builds")
+            .generate_bytes(20)
+            .expect("generates");
+        assert_eq!(report.nominal_samples, 400);
+        assert_eq!(report.emitted_samples, 328);
+        assert_eq!(report.omitted_missing_samples, 72);
+        assert_eq!(
+            report.emitted_samples + report.omitted_missing_samples,
+            report.nominal_samples,
+            "generated must equal emitted plus explicitly reported omissions"
+        );
+        assert_eq!(
+            bytes.iter().filter(|b| **b == b'\n').count() as u64,
+            report.emitted_samples
+        );
+        // A dropped classic-histogram scrape omits all ten of its series, so the
+        // omission count is not a multiple of one.
+        assert_ne!(report.omitted_missing_samples % 10, 0);
+    }
+
+    #[test]
+    fn staleness_markers_replace_gauge_values_only() {
+        let w = workload(
+            33,
+            AnomalyRates {
+                missing_sample_one_in: 0,
+                stale_marker_one_in: 4,
+                counter_reset_one_in: 0,
+                out_of_order_one_in: 0,
+            },
+        );
+        let (bytes, report) = Generator::new(&w, "cardinality", 0)
+            .expect("generator builds")
+            .generate_bytes(20)
+            .expect("generates");
+        let text = String::from_utf8(bytes).expect("utf8");
+        assert_eq!(report.nominal_samples, 400);
+        assert_eq!(report.stale_markers, 30);
+        assert_eq!(report.float_samples, 350);
+        assert_eq!(report.native_histogram_samples, 20);
+        assert_eq!(
+            report.float_samples + report.stale_markers + report.native_histogram_samples,
+            report.emitted_samples
+        );
+        for line in text.lines().filter(|l| l.ends_with("stale")) {
+            assert!(
+                line.contains("\tmb_gauge{"),
+                "only gauges carry staleness markers: {line}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_shifted_sample_lands_at_or_before_a_timestamp_already_in_the_stream() {
+        let w = workload(
+            44,
+            AnomalyRates {
+                missing_sample_one_in: 0,
+                stale_marker_one_in: 0,
+                counter_reset_one_in: 0,
+                out_of_order_one_in: 4,
+            },
+        );
+        let (bytes, report) = Generator::new(&w, "cardinality", 0)
+            .expect("generator builds")
+            .generate_bytes(20)
+            .expect("generates");
+        let text = String::from_utf8(bytes).expect("utf8");
+        assert_eq!(report.out_of_order_samples, 66);
+
+        // Per series, count the samples whose timestamp is older than one
+        // already seen on that series: that is what "out of order in the
+        // stream" means to an ingester.
+        let mut newest: BTreeMap<String, i64> = BTreeMap::new();
+        let mut regressions = 0u64;
+        for line in text.lines() {
+            let mut parts = line.split('\t');
+            let ts: i64 = parts
+                .next()
+                .and_then(|t| t.parse().ok())
+                .expect("line starts with a timestamp");
+            let series = parts.next().unwrap_or_default().to_string();
+            match newest.get(&series) {
+                Some(previous) if ts <= *previous => regressions += 1,
+                _ => {
+                    newest.insert(series, ts);
+                }
+            }
+        }
+        // 62 of the 66 shifted samples land at or before a timestamp already
+        // written for their series. The other 4 follow two consecutive shifted
+        // steps on the same series, where a two-interval shift still lands
+        // ahead of everything written so far, so they are shifted but not
+        // out-of-order to an ingester. Both figures are pinned: a generator
+        // that stopped shifting moves the first, and one that shifted by the
+        // wrong amount moves the second.
+        assert_eq!(regressions, 62);
+        assert!(
+            regressions < report.out_of_order_samples,
+            "a shift can only ever be at most as visible as the shifts applied"
+        );
+        // Steps 0 and 1 are never shifted, so the first two scrapes are clean.
+        let interval_ms = 15_000i64;
+        for line in text.lines() {
+            let ts: i64 = line
+                .split('\t')
+                .next()
+                .and_then(|t| t.parse().ok())
+                .expect("timestamp");
+            assert!(ts >= 0, "no sample is stamped before the base timestamp");
+            assert_eq!(ts % interval_ms, 0, "timestamps stay on the scrape grid");
+        }
+    }
+
+    #[test]
+    fn churn_creates_a_new_cohort_at_each_hour_boundary() {
+        let w = workload(77, clean());
+        // 240 steps at 15 s is one hour exactly, so step 240 is the first step
+        // of epoch 1: 241 steps span two epochs.
+        let mut gen_one_hour = Generator::new(&w, "churn", 0).expect("generator builds");
+        let (_, one_hour) = gen_one_hour.generate_bytes(240).expect("generates");
+        assert_eq!(one_hour.total_series_created, 20, "one epoch, no churn yet");
+
+        let mut gen_two_epochs = Generator::new(&w, "churn", 0).expect("generator builds");
+        let (bytes, two_epochs) = gen_two_epochs.generate_bytes(241).expect("generates");
+        // 25%/h of each family's instances: gauge 6 -> 1, counter 3 -> 0,
+        // classic 1 -> 0, native 1 -> 0. Only the gauge family is large enough
+        // for a whole instance to churn at this scale, and one gauge instance is
+        // one series.
+        assert_eq!(two_epochs.total_series_created, 21);
+        assert_eq!(
+            two_epochs.active_series, 20,
+            "churn replaces series, it does not change how many are alive"
+        );
+        assert_eq!(two_epochs.nominal_samples, 241 * 20);
+        assert_eq!(two_epochs.emitted_samples, 241 * 20);
+
+        let text = String::from_utf8(bytes).expect("utf8");
+        let series: std::collections::BTreeSet<&str> =
+            text.lines().filter_map(|l| l.split('\t').nth(1)).collect();
+        assert_eq!(
+            series.len(),
+            21,
+            "the churned-in cohort must be a new series identity, not a renamed one"
+        );
+    }
+
+    #[test]
+    fn an_unknown_profile_is_a_typed_error_naming_what_is_available() {
+        let w = workload(1, clean());
+        let err = Generator::new(&w, "nope", 0).expect_err("an unknown profile must fail");
+        match &err {
+            GeneratorError::UnknownProfile { name, available } => {
+                assert_eq!(name, "nope");
+                assert_eq!(
+                    available,
+                    &vec![
+                        "cardinality".to_string(),
+                        "history".to_string(),
+                        "churn".to_string(),
+                        "ci".to_string()
+                    ]
+                );
+            }
+            other => panic!("wrong error variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn the_report_carries_the_profiles_publishability() {
+        let w = workload(1, clean());
+        let (_, ci) = Generator::new(&w, "ci", 0)
+            .expect("generator builds")
+            .generate_bytes(2)
+            .expect("generates");
+        assert!(!ci.publishable);
+        assert_eq!(
+            ci.non_comparable_reason.as_deref(),
+            Some("too small to measure")
+        );
+
+        let (_, cardinality) = Generator::new(&w, "cardinality", 0)
+            .expect("generator builds")
+            .generate_bytes(2)
+            .expect("generates");
+        assert!(cardinality.publishable);
+        assert_eq!(cardinality.non_comparable_reason, None);
+    }
+
+    #[test]
+    fn float_payloads_are_written_as_bit_patterns() {
+        // A value whose decimal formatting would lose the distinction, encoded
+        // through the shipping encoder rather than a stand-in.
+        let sample = GeneratedSample {
+            ts_ms: 5,
+            metric: "mb_gauge".to_string(),
+            labels: vec![("job".to_string(), "api".to_string())],
+            value: SampleValue::Float(-0.0),
+        };
+        let mut out = Vec::new();
+        sample.encode(&mut out);
+        assert_eq!(
+            String::from_utf8(out).expect("utf8"),
+            "5\tmb_gauge{job=\"api\"}\tf 0x8000000000000000\n"
+        );
+
+        let positive = GeneratedSample {
+            value: SampleValue::Float(0.0),
+            ..sample
+        };
+        let mut out = Vec::new();
+        positive.encode(&mut out);
+        assert_eq!(
+            String::from_utf8(out).expect("utf8"),
+            "5\tmb_gauge{job=\"api\"}\tf 0x0000000000000000\n"
+        );
+    }
+
+    #[test]
+    fn mixing_is_a_pure_function_of_its_coordinates() {
+        assert_eq!(mix(1, &[2, 3]), mix(1, &[2, 3]));
+        assert_ne!(mix(1, &[2, 3]), mix(1, &[3, 2]));
+        assert_ne!(mix(1, &[2, 3]), mix(2, &[2, 3]));
+        // The scaled value stays inside its declared range and is exactly
+        // representable, so a float value reproduces bit for bit.
+        for i in 0..64u64 {
+            let v = unit_scaled(mix(9, &[i]), 100, 10);
+            assert!((0.0..100.0).contains(&v), "{v} out of range");
+            assert_eq!(v, f64::from_bits(v.to_bits()));
+        }
+    }
+}

--- a/crates/ravel-bench/src/metrics_gen.rs
+++ b/crates/ravel-bench/src/metrics_gen.rs
@@ -255,6 +255,15 @@ enum InstanceState {
         sum: f64,
         count: u64,
     },
+    /// A native histogram's cumulative per-bucket counts, observation sum, and
+    /// observation count. A native histogram carries counter semantics
+    /// (ADR-0108): `count` and `sum` only increase apart from an injected reset,
+    /// so the absolutes are accumulated here rather than recomputed per step.
+    Native {
+        buckets: Vec<u64>,
+        sum: f64,
+        count: u64,
+    },
 }
 
 /// One family's generation plan under one profile.
@@ -272,6 +281,10 @@ struct FamilyPlan {
     fixed: Vec<(u64, u64)>,
     /// Product of the fixed cardinalities: the instance ordinal's divisor.
     fixed_product: u64,
+    /// The classic-histogram `le` bounds, cloned once at plan build so a sample
+    /// does not re-clone the generator's bounds on every emit. Carried on every
+    /// plan; only the classic-histogram branch reads it.
+    classic_bounds: Vec<f64>,
     /// Accumulated state, keyed by global instance index. Pruned at each epoch
     /// boundary so a long churn run does not grow without bound.
     state: BTreeMap<u64, InstanceState>,
@@ -346,6 +359,7 @@ impl<'a> Generator<'a> {
                 churned_per_epoch: instances * profile.churn_basis_points_per_hour / 10_000,
                 fixed,
                 fixed_product: stride,
+                classic_bounds: workload.generator.classic_histogram_bounds.clone(),
                 state: BTreeMap::new(),
             });
         }
@@ -449,7 +463,9 @@ impl<'a> Generator<'a> {
 
                     let reset = matches!(
                         family.kind,
-                        FamilyKind::Counter | FamilyKind::ClassicHistogram
+                        FamilyKind::Counter
+                            | FamilyKind::ClassicHistogram
+                            | FamilyKind::NativeHistogram
                     ) && fires(
                         anomalies.counter_reset_one_in,
                         seed,
@@ -629,7 +645,7 @@ impl<'a> Generator<'a> {
                     // A family's kind never changes mid-run, so this arm is
                     // unreachable in practice; restarting the accumulator is
                     // the recoverable answer either way.
-                    InstanceState::Classic { .. } => {
+                    _ => {
                         *entry = InstanceState::Counter { total: h % 16 };
                         h % 16
                     }
@@ -642,17 +658,13 @@ impl<'a> Generator<'a> {
                 });
             }
             FamilyKind::ClassicHistogram => {
-                let bounds = self.workload.generator.classic_histogram_bounds.clone();
-                let bucket_count = bounds.len() + 1;
-                let entry =
-                    self.plans[plan_idx]
-                        .state
-                        .entry(global)
-                        .or_insert(InstanceState::Classic {
-                            buckets: vec![0; bucket_count],
-                            sum: 0.0,
-                            count: 0,
-                        });
+                let plan = &mut self.plans[plan_idx];
+                let bucket_count = plan.classic_bounds.len() + 1;
+                let entry = plan.state.entry(global).or_insert(InstanceState::Classic {
+                    buckets: vec![0; bucket_count],
+                    sum: 0.0,
+                    count: 0,
+                });
                 if !matches!(entry, InstanceState::Classic { .. }) {
                     *entry = InstanceState::Classic {
                         buckets: vec![0; bucket_count],
@@ -679,14 +691,14 @@ impl<'a> Generator<'a> {
                         }
                         (buckets.clone(), *sum, *count)
                     }
-                    InstanceState::Counter { .. } => (vec![0; bucket_count], 0.0, 0),
+                    _ => (vec![0; bucket_count], 0.0, 0),
                 };
                 // Cumulative counts, ascending by `le`, then `_sum`, then
                 // `_count`: the order a Prometheus scrape presents them in.
                 let mut cumulative = 0u64;
                 for (b, bucket) in buckets.iter().enumerate() {
                     cumulative += *bucket;
-                    let le = match bounds.get(b) {
+                    let le = match plan.classic_bounds.get(b) {
                         Some(bound) => format!("{bound}"),
                         None => "+Inf".to_string(),
                     };
@@ -714,25 +726,56 @@ impl<'a> Generator<'a> {
                 });
             }
             FamilyKind::NativeHistogram => {
-                let buckets = self.workload.generator.native_histogram_buckets;
-                let mut positive_deltas = Vec::with_capacity(buckets as usize);
-                let mut previous = 0i64;
-                let mut count = 0u64;
-                for b in 0..buckets {
-                    let absolute =
-                        (mix(seed, &[TAG_VALUE, fam_id, global, step, b as u64]) % 32) as i64;
-                    positive_deltas.push(absolute - previous);
-                    previous = absolute;
-                    count += absolute as u64;
+                let schema = self.workload.generator.native_histogram_schema;
+                let nbuckets = self.workload.generator.native_histogram_buckets as usize;
+                let plan = &mut self.plans[plan_idx];
+                let entry = plan.state.entry(global).or_insert(InstanceState::Native {
+                    buckets: vec![0; nbuckets],
+                    sum: 0.0,
+                    count: 0,
+                });
+                if !matches!(entry, InstanceState::Native { .. }) {
+                    *entry = InstanceState::Native {
+                        buckets: vec![0; nbuckets],
+                        sum: 0.0,
+                        count: 0,
+                    };
                 }
+                // A native histogram carries counter semantics: emit the
+                // per-step GROWTH as positive deltas and accumulate the
+                // absolutes, so `count` and `sum` only rise apart from an
+                // injected reset (which zeroes the state before this step).
+                let (positive_deltas, sum, count) = match entry {
+                    InstanceState::Native {
+                        buckets,
+                        sum,
+                        count,
+                    } => {
+                        let mut deltas = Vec::with_capacity(buckets.len());
+                        for (b, bucket) in buckets.iter_mut().enumerate() {
+                            let growth =
+                                mix(seed, &[TAG_VALUE, fam_id, global, step, b as u64]) % 8;
+                            *bucket += growth;
+                            *count += growth;
+                            *sum += unit_scaled(
+                                mix(seed, &[TAG_VALUE + 1, fam_id, global, step, b as u64]),
+                                1,
+                                12,
+                            ) * growth as f64;
+                            deltas.push(growth as i64);
+                        }
+                        (deltas, *sum, *count)
+                    }
+                    _ => (vec![0i64; nbuckets], 0.0, 0),
+                };
                 out.push(GeneratedSample {
                     ts_ms,
                     metric: family.name.clone(),
                     labels: labels.to_vec(),
                     value: SampleValue::NativeHistogram(NativeHistogram {
-                        schema: self.workload.generator.native_histogram_schema,
+                        schema,
                         count,
-                        sum: unit_scaled(h, 4, 12),
+                        sum,
                         positive_deltas,
                     }),
                 });
@@ -1009,13 +1052,14 @@ mod tests {
                 drops += 1;
             }
         }
-        // Resets fire on the counter and the classic-histogram families, and a
-        // reset is observable as a drop only when the post-reset increment is
-        // smaller than the pre-reset total, so the counter-only observed-drop
-        // count is a strict subset of the reported reset count. Both figures are
-        // pinned: a generator that stopped resetting, or one that reset without
-        // reporting it, moves one of them.
-        assert_eq!(report.counter_reset_events, 20);
+        // Resets fire on the counter, classic-histogram and native-histogram
+        // families, and a reset is observable as a drop on a plain counter only
+        // when the post-reset increment is smaller than the pre-reset total, so
+        // the counter-only observed-drop count is a strict subset of the
+        // reported reset count. Both figures are pinned: a generator that
+        // stopped resetting, or one that reset without reporting it, moves one
+        // of them.
+        assert_eq!(report.counter_reset_events, 24);
         assert_eq!(
             drops, 14,
             "counter series must fall only at the resets the report counts"
@@ -1110,6 +1154,111 @@ mod tests {
                 .count();
             assert_eq!(deltas, 4, "four positive buckets were declared: {line}");
         }
+    }
+
+    #[test]
+    fn native_histogram_count_and_sum_rise_except_at_reported_resets() {
+        // A native histogram carries counter semantics (ADR-0108): `count` and
+        // `sum` only increase apart from a reset. A stateless generator that
+        // recomputes absolute bucket counts per step makes both fall at roughly
+        // half the steps, and an ingester reads every fall as an unreported
+        // reset. This walks the single native series across every step and
+        // asserts monotonicity off the injected-reset steps, and that every
+        // injected native reset is counted in `counter_reset_events`.
+        let reset_rate = 8u64;
+        let w = workload(
+            0x5EED_0001,
+            AnomalyRates {
+                missing_sample_one_in: 0,
+                stale_marker_one_in: 0,
+                counter_reset_one_in: reset_rate,
+                out_of_order_one_in: 0,
+            },
+        );
+        gate_workload(&w).expect("manifest gates clean");
+        let steps = 80u64;
+        let (bytes, report) = Generator::new(&w, "cardinality", 0)
+            .expect("generator builds")
+            .generate_bytes(steps)
+            .expect("generates");
+        let text = String::from_utf8(bytes).expect("utf8");
+
+        // Recompute, from the same fires() the generator uses, exactly which
+        // steps inject a reset for the single native instance (family index 3,
+        // global 0: 50 permille of 20 active series is one native instance).
+        let seed = w.seed;
+        let native_fam = 3u64;
+        let mut native_resets: std::collections::BTreeSet<u64> = std::collections::BTreeSet::new();
+        for step in 0..steps {
+            if fires(reset_rate, seed, TAG_RESET, native_fam, 0, step) {
+                native_resets.insert(step);
+            }
+        }
+        assert!(
+            !native_resets.is_empty(),
+            "this seed must inject at least one native-histogram reset"
+        );
+
+        // Per-step count and sum for the one native series, in stream order.
+        let mut counts: Vec<u64> = Vec::new();
+        let mut sums: Vec<f64> = Vec::new();
+        for line in text.lines().filter(|l| l.contains("\tmb_native{")) {
+            let payload = line.split('\t').nth(2).expect("payload");
+            let count: u64 = payload
+                .split("count=")
+                .nth(1)
+                .and_then(|s| s.split(' ').next())
+                .and_then(|s| s.parse().ok())
+                .expect("count field");
+            let sum_bits = payload
+                .split("sum=0x")
+                .nth(1)
+                .and_then(|s| s.split(' ').next())
+                .and_then(|s| u64::from_str_radix(s, 16).ok())
+                .expect("sum field");
+            counts.push(count);
+            sums.push(f64::from_bits(sum_bits));
+        }
+        assert_eq!(counts.len(), steps as usize, "one native sample per step");
+
+        // Every non-reset step is non-decreasing in both count and sum. This is
+        // the assertion the stateless generator fails.
+        for step in 1..steps as usize {
+            if native_resets.contains(&(step as u64)) {
+                continue;
+            }
+            assert!(
+                counts[step] >= counts[step - 1],
+                "native count fell at step {step} with no injected reset: {counts:?}"
+            );
+            assert!(
+                sums[step] >= sums[step - 1],
+                "native sum fell at step {step} with no injected reset: {sums:?}"
+            );
+        }
+
+        // Every injected reset, native included, is counted. Reconstruct the
+        // full reset total across every reset-eligible instance (counter x3,
+        // classic x1, native x1) and assert the report equals it: a native reset
+        // that fired but went uncounted drops the report below this total.
+        let mut expected_resets = 0u64;
+        for (fam, instances) in [(1u64, 3u64), (2u64, 1u64), (3u64, 1u64)] {
+            for inst in 0..instances {
+                for step in 0..steps {
+                    if fires(reset_rate, seed, TAG_RESET, fam, inst, step) {
+                        expected_resets += 1;
+                    }
+                }
+            }
+        }
+        assert_eq!(
+            report.counter_reset_events, expected_resets,
+            "every injected reset, native included, must be counted"
+        );
+        assert!(
+            expected_resets >= native_resets.len() as u64,
+            "the total reset count must include the native resets"
+        );
     }
 
     #[test]

--- a/crates/ravel-bench/src/metrics_workload.rs
+++ b/crates/ravel-bench/src/metrics_workload.rs
@@ -1,0 +1,1078 @@
+//! The MetricsBench workload manifest (ADR-0927 decision 11).
+//!
+//! One versioned artifact, `benchmarks/metrics/workload.json`, declaring
+//! everything the deterministic generator needs and everything a report has to
+//! restate: the seed, the generator configuration, the metric families, the
+//! label distributions, and the four profiles. It is loaded and gated exactly
+//! as the query corpus is ([`crate::promql_corpus`]), so a manifest that no
+//! longer describes what the generator would produce is a loud typed error
+//! rather than a silently different workload.
+//!
+//! The `ci` profile's non-comparability is a typed field on the profile
+//! ([`Comparability`]), not a sentence in a README: ADR-0927 decision 11 says
+//! it "cannot be presented as a performance result", and a reader that loads
+//! the artifact can only refuse to publish it if the refusal is in the data.
+//! [`Profile::is_publishable`] is that check, and [`gate_workload`] refuses a
+//! manifest that marks `ci` comparable at all.
+
+use std::collections::{BTreeSet, HashSet};
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+/// The manifest format version this module reads and writes.
+pub const WORKLOAD_FORMAT_VERSION: u32 = 1;
+
+/// The profile names ADR-0927 decision 11 fixes. A manifest declaring a
+/// different set is refused: a run over a different profile set is not
+/// comparable to a run over this one, and decision 11's whole point is that the
+/// three axes vary independently.
+pub const REQUIRED_PROFILES: &[&str] = &["cardinality", "history", "churn", "ci"];
+
+/// The profiles ADR-0927 decision 11 marks non-comparable. Checked against the
+/// artifact rather than assumed, so a manifest that quietly promotes `ci` to a
+/// publishable profile fails the gate.
+pub const NON_COMPARABLE_PROFILES: &[&str] = &["ci"];
+
+/// Seconds in one churn epoch. Churn is specified per hour (ADR-0927 decision
+/// 11), so the generator retires and creates series on hour boundaries.
+pub const CHURN_EPOCH_SECS: u64 = 3600;
+
+/// Whether a profile's figures may appear in a performance or cost table.
+///
+/// A typed field rather than prose. `Comparable` is a positive claim, and
+/// `NonComparable` carries the reason a reader is shown when a publish is
+/// refused.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Comparability {
+    /// The profile's figures may be compared, subject to the substrate rule
+    /// (ADR-0927 decision 10: only the real-S3 lane publishes).
+    Comparable,
+    /// The profile exercises the code paths but its figures are not a
+    /// performance result.
+    NonComparable {
+        /// Why the profile's figures cannot be published.
+        reason: String,
+    },
+}
+
+impl Comparability {
+    /// Whether figures from this profile may be published.
+    pub fn is_comparable(&self) -> bool {
+        matches!(self, Comparability::Comparable)
+    }
+
+    /// The stated reason, or `None` for a comparable profile.
+    pub fn reason(&self) -> Option<&str> {
+        match self {
+            Comparability::Comparable => None,
+            Comparability::NonComparable { reason } => Some(reason),
+        }
+    }
+}
+
+/// One workload profile: one axis varied, the others pinned.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Profile {
+    /// The profile name, one of [`REQUIRED_PROFILES`].
+    pub name: String,
+    /// Series alive at any one instant.
+    pub active_series: u64,
+    /// Samples each series receives over the profile's duration.
+    pub samples_per_series: u64,
+    /// Seconds between scrapes.
+    pub scrape_interval_secs: u64,
+    /// Total wall-clock span the generated data covers.
+    pub duration_secs: u64,
+    /// Percent of the active set retired and replaced each
+    /// [`CHURN_EPOCH_SECS`], in basis points (2000 = 20%/h) so the value is
+    /// exact rather than a float that cannot represent it.
+    pub churn_basis_points_per_hour: u64,
+    /// Total samples the profile nominally generates, restated here so the
+    /// artifact carries the figure a report quotes. [`gate_workload`] recomputes
+    /// it from `active_series * samples_per_series` and refuses a mismatch.
+    pub total_samples: u64,
+    /// Whether the profile's figures may be published.
+    pub comparability: Comparability,
+}
+
+impl Profile {
+    /// Whether this profile's figures may appear in a performance or cost
+    /// table. A caller that publishes a figure checks this first.
+    pub fn is_publishable(&self) -> bool {
+        self.comparability.is_comparable()
+    }
+
+    /// Churn epochs the profile spans, counting the first (partial) one.
+    ///
+    /// Measured from the last sample's offset rather than from `duration_secs`,
+    /// because that is the step the generator actually reaches: a 240-step run
+    /// at 15 s covers 3600 s of wall clock but its last sample lands at 3585 s,
+    /// inside the first epoch.
+    pub fn churn_epochs(&self) -> u64 {
+        if self.samples_per_series == 0 {
+            return 1;
+        }
+        (self.samples_per_series - 1) * self.scrape_interval_secs / CHURN_EPOCH_SECS + 1
+    }
+
+    /// Series retired and replaced at each epoch boundary. Truncating, so the
+    /// figure is exact and reproducible rather than rounded differently by two
+    /// readers.
+    pub fn churned_series_per_epoch(&self) -> u64 {
+        self.active_series * self.churn_basis_points_per_hour / 10_000
+    }
+
+    /// Distinct series the profile creates over its whole duration: the active
+    /// set plus one replacement cohort per epoch boundary crossed.
+    pub fn total_series_created(&self) -> u64 {
+        self.active_series + (self.churn_epochs() - 1) * self.churned_series_per_epoch()
+    }
+}
+
+/// What a metric family emits.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FamilyKind {
+    /// A float that moves up and down.
+    Gauge,
+    /// A float that only increases, apart from injected resets.
+    Counter,
+    /// A Prometheus classic histogram: `_bucket{le}` per bound plus `+Inf`,
+    /// `_sum`, and `_count`, all monotonic.
+    ClassicHistogram,
+    /// A native histogram (ADR-0108): one series carrying schema, count, sum,
+    /// and bucket deltas.
+    NativeHistogram,
+}
+
+/// One metric family: its name, what it emits, which label dimensions it
+/// carries, and its share of the active-series budget.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MetricFamily {
+    /// The metric name, as PromQL selects it.
+    pub name: String,
+    /// What the family emits.
+    pub kind: FamilyKind,
+    /// The fixed label dimensions, by [`LabelDimension::name`]. The scaling
+    /// label ([`GeneratorConfig::scaling_label`]) is added by the generator and
+    /// must not appear here.
+    pub labels: Vec<String>,
+    /// The family's share of a profile's active series, in permille. The shares
+    /// across all families sum to exactly 1000.
+    pub series_permille: u64,
+}
+
+/// One label dimension and the exact values it takes.
+///
+/// Values are listed rather than generated from a prefix so the corpus can
+/// select on a literal (`job="metricsbench-api"`) and a test can prove the
+/// literal exists in the workload.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LabelDimension {
+    /// The label name.
+    pub name: String,
+    /// Every value the label takes, in the order the generator assigns them.
+    pub values: Vec<String>,
+}
+
+/// How often an injected anomaly fires, as "one series-step in N". Zero
+/// disables that anomaly, which is how the `cardinality` and `history` profiles
+/// stay clean where ADR-0927 decision 11 says "churn: none".
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AnomalyRates {
+    /// One series-step in N is omitted entirely (a missed scrape).
+    pub missing_sample_one_in: u64,
+    /// One series-step in N emits a staleness marker instead of a value.
+    pub stale_marker_one_in: u64,
+    /// One series-step in N resets a counter or histogram instance to zero.
+    pub counter_reset_one_in: u64,
+    /// One series-step in N is stamped two intervals early, so it reaches the
+    /// stream after a sample that is newer than it.
+    pub out_of_order_one_in: u64,
+}
+
+/// Everything the generator needs beyond the families and the profiles.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GeneratorConfig {
+    /// The label whose value scales with the series count. Every family carries
+    /// it, and the generator assigns it, so it is declared once here.
+    pub scaling_label: String,
+    /// The prefix the scaling label's values carry; the generator appends the
+    /// instance ordinal. A corpus entry selecting one series names a literal
+    /// built from this, so it is data rather than a format string in code.
+    pub scaling_label_value_prefix: String,
+    /// The `le` bounds of every classic histogram, ascending. `+Inf` is implied
+    /// and not listed.
+    pub classic_histogram_bounds: Vec<f64>,
+    /// The native-histogram schema every native histogram declares (ADR-0108).
+    pub native_histogram_schema: i32,
+    /// Positive bucket count every native histogram emits.
+    pub native_histogram_buckets: u32,
+    /// A metric name no family uses, for the corpus' metadata-only entries: a
+    /// selector that resolves to nothing reads no sample values, which is what
+    /// makes those entries metadata-only rather than merely cheap.
+    pub absent_metric_name: String,
+    /// The injected anomaly rates.
+    pub anomalies: AnomalyRates,
+}
+
+/// The parsed manifest.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkloadFile {
+    /// The format version, which must equal [`WORKLOAD_FORMAT_VERSION`].
+    pub version: u32,
+    /// The one seed every generated figure derives from. The same seed and the
+    /// same manifest produce byte-identical output.
+    pub seed: u64,
+    /// Generator configuration.
+    pub generator: GeneratorConfig,
+    /// The label dimensions families draw from.
+    pub label_dimensions: Vec<LabelDimension>,
+    /// The metric families.
+    pub families: Vec<MetricFamily>,
+    /// The four profiles.
+    pub profiles: Vec<Profile>,
+}
+
+impl WorkloadFile {
+    /// The profile named `name`, or `None`.
+    pub fn profile(&self, name: &str) -> Option<&Profile> {
+        self.profiles.iter().find(|p| p.name == name)
+    }
+
+    /// The label dimension named `name`, or `None`.
+    pub fn dimension(&self, name: &str) -> Option<&LabelDimension> {
+        self.label_dimensions.iter().find(|d| d.name == name)
+    }
+
+    /// Time series one instance of `kind` emits: one for a gauge, a counter, or
+    /// a native histogram, and one per `le` bound plus `+Inf`, `_sum`, and
+    /// `_count` for a classic histogram.
+    pub fn series_per_instance(&self, kind: FamilyKind) -> u64 {
+        match kind {
+            FamilyKind::Gauge | FamilyKind::Counter | FamilyKind::NativeHistogram => 1,
+            FamilyKind::ClassicHistogram => {
+                self.generator.classic_histogram_bounds.len() as u64 + 3
+            }
+        }
+    }
+
+    /// Time series `family` emits under `profile`.
+    pub fn family_series(&self, profile: &Profile, family: &MetricFamily) -> u64 {
+        profile.active_series * family.series_permille / 1000
+    }
+
+    /// Instances (histograms, or plain series) `family` emits under `profile`.
+    pub fn family_instances(&self, profile: &Profile, family: &MetricFamily) -> u64 {
+        self.family_series(profile, family) / self.series_per_instance(family.kind)
+    }
+
+    /// Every metric name the manifest implies, including the classic-histogram
+    /// suffixes. A corpus entry may select any of these and nothing else.
+    pub fn emitted_metric_names(&self) -> BTreeSet<String> {
+        let mut out = BTreeSet::new();
+        for family in &self.families {
+            match family.kind {
+                FamilyKind::ClassicHistogram => {
+                    for suffix in ["_bucket", "_sum", "_count"] {
+                        out.insert(format!("{}{suffix}", family.name));
+                    }
+                }
+                _ => {
+                    out.insert(family.name.clone());
+                }
+            }
+        }
+        out
+    }
+}
+
+/// Everything that can go wrong loading or gating a manifest. Every variant
+/// names what is at fault and, where a figure disagrees, both figures.
+#[derive(Debug, thiserror::Error)]
+pub enum WorkloadError {
+    /// The manifest could not be read.
+    #[error("workload manifest {path}: {source}")]
+    Read {
+        /// The path that was read.
+        path: PathBuf,
+        /// The underlying I/O failure.
+        #[source]
+        source: std::io::Error,
+    },
+    /// The manifest is not a valid manifest document.
+    #[error("workload manifest {path} is not a valid JSON manifest document: {source}")]
+    Parse {
+        /// The path that was parsed.
+        path: PathBuf,
+        /// The underlying `serde_json` failure.
+        #[source]
+        source: serde_json::Error,
+    },
+    /// The document declares a format version this module does not read.
+    #[error(
+        "workload manifest {path} declares format version {found}, but this build reads \
+         version {expected}"
+    )]
+    UnsupportedVersion {
+        /// The path that was parsed.
+        path: PathBuf,
+        /// The version the document declared.
+        found: u32,
+        /// The version this build reads.
+        expected: u32,
+    },
+    /// The profile set is not the one ADR-0927 decision 11 fixes.
+    #[error(
+        "workload manifest declares profiles {found:?}, but ADR-0927 decision 11 fixes them at \
+         {expected:?}; a run over a different profile set is not comparable to one over this set"
+    )]
+    ProfileSetMismatch {
+        /// The profile names the manifest declared, sorted.
+        found: Vec<String>,
+        /// The names ADR-0927 decision 11 fixes, sorted.
+        expected: Vec<String>,
+    },
+    /// A profile whose sample grid does not close: the samples, the scrape
+    /// interval, and the duration disagree.
+    #[error(
+        "profile `{profile}` declares {samples_per_series} samples at {scrape_interval_secs}s \
+         over {duration_secs}s, but {samples_per_series} * {scrape_interval_secs} = {computed}"
+    )]
+    SampleGridMismatch {
+        /// The offending profile.
+        profile: String,
+        /// Its declared samples per series.
+        samples_per_series: u64,
+        /// Its declared scrape interval.
+        scrape_interval_secs: u64,
+        /// Its declared duration.
+        duration_secs: u64,
+        /// The duration the other two figures imply.
+        computed: u64,
+    },
+    /// A profile's declared total does not equal the total its own figures
+    /// imply.
+    #[error(
+        "profile `{profile}` declares total_samples {declared}, but active_series * \
+         samples_per_series = {computed}"
+    )]
+    TotalSamplesMismatch {
+        /// The offending profile.
+        profile: String,
+        /// The declared total.
+        declared: u64,
+        /// The computed total.
+        computed: u64,
+    },
+    /// A profile ADR-0927 marks non-comparable is marked comparable here.
+    #[error(
+        "profile `{profile}` is marked comparable, but ADR-0927 decision 11 marks it \
+         non-comparable: its figures cannot be presented as a performance result, and the \
+         refusal has to live in the artifact so a reader that loads it can refuse to publish"
+    )]
+    MustBeNonComparable {
+        /// The offending profile.
+        profile: String,
+    },
+    /// A non-comparable profile states no reason, so a refusal to publish has
+    /// nothing to show the reader.
+    #[error(
+        "profile `{profile}` is marked non-comparable with an empty reason; a refusal to \
+         publish must state why"
+    )]
+    BlankNonComparableReason {
+        /// The offending profile.
+        profile: String,
+    },
+    /// The family shares do not partition the active-series budget.
+    #[error("metric family series_permille values sum to {total}, not 1000")]
+    SeriesShareNotThousand {
+        /// The sum the manifest declares.
+        total: u64,
+    },
+    /// Two families share a name.
+    #[error("metric family `{name}` is declared more than once")]
+    DuplicateFamily {
+        /// The duplicated name.
+        name: String,
+    },
+    /// Two label dimensions share a name.
+    #[error("label dimension `{name}` is declared more than once")]
+    DuplicateDimension {
+        /// The duplicated name.
+        name: String,
+    },
+    /// A label dimension carries no values, so it cannot be assigned.
+    #[error("label dimension `{name}` declares no values")]
+    EmptyDimension {
+        /// The offending dimension.
+        name: String,
+    },
+    /// A family names a dimension the manifest does not declare.
+    #[error("metric family `{family}` names label dimension `{label}`, which is not declared")]
+    UnknownDimension {
+        /// The offending family.
+        family: String,
+        /// The undeclared dimension it named.
+        label: String,
+    },
+    /// The scaling label is declared or listed as an ordinary dimension. It is
+    /// assigned by the generator, so a second source for it would collide.
+    #[error(
+        "the scaling label `{label}` is declared as an ordinary label dimension or listed on a \
+         family; the generator assigns it, so it must appear in neither place"
+    )]
+    ScalingLabelDeclared {
+        /// The scaling label.
+        label: String,
+    },
+    /// A family's share of a profile's active series is not a whole number of
+    /// series.
+    #[error(
+        "family `{family}` takes {series_permille} permille of profile `{profile}`'s \
+         {active_series} active series, which is not a whole number of series; ADR-0927 \
+         decision 11 requires an exact active-series count"
+    )]
+    InexactSeriesBudget {
+        /// The offending profile.
+        profile: String,
+        /// The offending family.
+        family: String,
+        /// The profile's active-series count.
+        active_series: u64,
+        /// The family's share.
+        series_permille: u64,
+    },
+    /// A family's series budget is not a whole number of instances.
+    #[error(
+        "family `{family}` gets {series} series under profile `{profile}`, which is not a whole \
+         number of {series_per_instance}-series instances"
+    )]
+    InexactInstanceBudget {
+        /// The offending profile.
+        profile: String,
+        /// The offending family.
+        family: String,
+        /// The family's series budget.
+        series: u64,
+        /// Series one instance emits.
+        series_per_instance: u64,
+    },
+    /// The classic-histogram bounds are empty or not strictly ascending.
+    #[error(
+        "classic_histogram_bounds must be a non-empty, strictly ascending list of finite \
+         bounds; got {bounds:?}"
+    )]
+    BadHistogramBounds {
+        /// The bounds the manifest declared.
+        bounds: Vec<f64>,
+    },
+    /// A native histogram would carry no buckets.
+    #[error("native_histogram_buckets is 0; a native histogram must carry at least one bucket")]
+    NoNativeBuckets,
+    /// The scaling label's value prefix is blank, so every instance would carry
+    /// a bare ordinal.
+    #[error("scaling_label_value_prefix is blank; the scaling label's values need a prefix")]
+    BlankScalingPrefix,
+    /// The absent-metric sentinel collides with a real family name.
+    #[error(
+        "absent_metric_name `{name}` collides with an emitted metric name; the metadata-only \
+         corpus entries select it precisely because nothing emits it"
+    )]
+    AbsentMetricCollides {
+        /// The colliding name.
+        name: String,
+    },
+}
+
+/// Apply every structural check to a manifest, identically for the checked-in
+/// artifact and for an external file.
+pub fn gate_workload(workload: &WorkloadFile) -> Result<(), WorkloadError> {
+    let scaling = workload.generator.scaling_label.as_str();
+
+    // Generator configuration.
+    let bounds = &workload.generator.classic_histogram_bounds;
+    let ascending = bounds
+        .windows(2)
+        .all(|w| w[0] < w[1] && w[0].is_finite() && w[1].is_finite());
+    if bounds.is_empty() || !ascending || bounds.iter().any(|b| !b.is_finite()) {
+        return Err(WorkloadError::BadHistogramBounds {
+            bounds: bounds.clone(),
+        });
+    }
+    if workload.generator.native_histogram_buckets == 0 {
+        return Err(WorkloadError::NoNativeBuckets);
+    }
+    if workload
+        .generator
+        .scaling_label_value_prefix
+        .trim()
+        .is_empty()
+    {
+        return Err(WorkloadError::BlankScalingPrefix);
+    }
+
+    // Label dimensions.
+    let mut seen_dims: HashSet<&str> = HashSet::new();
+    for dim in &workload.label_dimensions {
+        if dim.name == scaling {
+            return Err(WorkloadError::ScalingLabelDeclared {
+                label: scaling.to_string(),
+            });
+        }
+        if !seen_dims.insert(dim.name.as_str()) {
+            return Err(WorkloadError::DuplicateDimension {
+                name: dim.name.clone(),
+            });
+        }
+        if dim.values.is_empty() {
+            return Err(WorkloadError::EmptyDimension {
+                name: dim.name.clone(),
+            });
+        }
+    }
+
+    // Families.
+    let mut seen_families: HashSet<&str> = HashSet::new();
+    let mut permille_total = 0u64;
+    for family in &workload.families {
+        if !seen_families.insert(family.name.as_str()) {
+            return Err(WorkloadError::DuplicateFamily {
+                name: family.name.clone(),
+            });
+        }
+        for label in &family.labels {
+            if label == scaling {
+                return Err(WorkloadError::ScalingLabelDeclared {
+                    label: scaling.to_string(),
+                });
+            }
+            if workload.dimension(label).is_none() {
+                return Err(WorkloadError::UnknownDimension {
+                    family: family.name.clone(),
+                    label: label.clone(),
+                });
+            }
+        }
+        permille_total += family.series_permille;
+    }
+    if permille_total != 1000 {
+        return Err(WorkloadError::SeriesShareNotThousand {
+            total: permille_total,
+        });
+    }
+    if workload
+        .emitted_metric_names()
+        .contains(&workload.generator.absent_metric_name)
+    {
+        return Err(WorkloadError::AbsentMetricCollides {
+            name: workload.generator.absent_metric_name.clone(),
+        });
+    }
+
+    // Profiles.
+    let found: Vec<String> = {
+        let mut v: Vec<String> = workload.profiles.iter().map(|p| p.name.clone()).collect();
+        v.sort();
+        v
+    };
+    let expected: Vec<String> = {
+        let mut v: Vec<String> = REQUIRED_PROFILES.iter().map(|s| (*s).to_string()).collect();
+        v.sort();
+        v
+    };
+    if found != expected {
+        return Err(WorkloadError::ProfileSetMismatch { found, expected });
+    }
+    for profile in &workload.profiles {
+        let computed = profile.samples_per_series * profile.scrape_interval_secs;
+        if computed != profile.duration_secs {
+            return Err(WorkloadError::SampleGridMismatch {
+                profile: profile.name.clone(),
+                samples_per_series: profile.samples_per_series,
+                scrape_interval_secs: profile.scrape_interval_secs,
+                duration_secs: profile.duration_secs,
+                computed,
+            });
+        }
+        let computed = profile.active_series * profile.samples_per_series;
+        if computed != profile.total_samples {
+            return Err(WorkloadError::TotalSamplesMismatch {
+                profile: profile.name.clone(),
+                declared: profile.total_samples,
+                computed,
+            });
+        }
+        let must_be_non_comparable = NON_COMPARABLE_PROFILES.contains(&profile.name.as_str());
+        match &profile.comparability {
+            Comparability::Comparable if must_be_non_comparable => {
+                return Err(WorkloadError::MustBeNonComparable {
+                    profile: profile.name.clone(),
+                });
+            }
+            Comparability::NonComparable { reason } if reason.trim().is_empty() => {
+                return Err(WorkloadError::BlankNonComparableReason {
+                    profile: profile.name.clone(),
+                });
+            }
+            _ => {}
+        }
+        for family in &workload.families {
+            if profile.active_series * family.series_permille % 1000 != 0 {
+                return Err(WorkloadError::InexactSeriesBudget {
+                    profile: profile.name.clone(),
+                    family: family.name.clone(),
+                    active_series: profile.active_series,
+                    series_permille: family.series_permille,
+                });
+            }
+            let series = workload.family_series(profile, family);
+            let per_instance = workload.series_per_instance(family.kind);
+            if !series.is_multiple_of(per_instance) {
+                return Err(WorkloadError::InexactInstanceBudget {
+                    profile: profile.name.clone(),
+                    family: family.name.clone(),
+                    series,
+                    series_per_instance: per_instance,
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Read a manifest, parse it, and gate it.
+pub fn load_workload(path: impl AsRef<Path>) -> Result<WorkloadFile, WorkloadError> {
+    let path = path.as_ref();
+    let text = std::fs::read_to_string(path).map_err(|source| WorkloadError::Read {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let workload: WorkloadFile =
+        serde_json::from_str(&text).map_err(|source| WorkloadError::Parse {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    if workload.version != WORKLOAD_FORMAT_VERSION {
+        return Err(WorkloadError::UnsupportedVersion {
+            path: path.to_path_buf(),
+            found: workload.version,
+            expected: WORKLOAD_FORMAT_VERSION,
+        });
+    }
+    gate_workload(&workload)?;
+    Ok(workload)
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    /// A manifest small enough to read, shaped exactly like the checked-in one:
+    /// the same families and shares, and the four required profiles reduced to
+    /// the `ci` scale so a test can name every figure.
+    fn fixture() -> WorkloadFile {
+        let profile = |name: &str, comparability: Comparability| Profile {
+            name: name.to_string(),
+            active_series: 1_000,
+            samples_per_series: 120,
+            scrape_interval_secs: 15,
+            duration_secs: 1_800,
+            churn_basis_points_per_hour: 0,
+            total_samples: 120_000,
+            comparability,
+        };
+        WorkloadFile {
+            version: WORKLOAD_FORMAT_VERSION,
+            seed: 7,
+            generator: GeneratorConfig {
+                scaling_label: "instance".to_string(),
+                scaling_label_value_prefix: "mb-instance-".to_string(),
+                classic_histogram_bounds: vec![0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5],
+                native_histogram_schema: 2,
+                native_histogram_buckets: 8,
+                absent_metric_name: "metricsbench_absent_metric".to_string(),
+                anomalies: AnomalyRates {
+                    missing_sample_one_in: 500,
+                    stale_marker_one_in: 900,
+                    counter_reset_one_in: 700,
+                    out_of_order_one_in: 600,
+                },
+            },
+            label_dimensions: vec![
+                LabelDimension {
+                    name: "job".to_string(),
+                    values: vec!["a".to_string(), "b".to_string()],
+                },
+                LabelDimension {
+                    name: "region".to_string(),
+                    values: vec!["r1".to_string()],
+                },
+            ],
+            families: vec![
+                MetricFamily {
+                    name: "mb_gauge".to_string(),
+                    kind: FamilyKind::Gauge,
+                    labels: vec!["job".to_string(), "region".to_string()],
+                    series_permille: 450,
+                },
+                MetricFamily {
+                    name: "mb_counter".to_string(),
+                    kind: FamilyKind::Counter,
+                    labels: vec!["job".to_string()],
+                    series_permille: 300,
+                },
+                MetricFamily {
+                    name: "mb_classic".to_string(),
+                    kind: FamilyKind::ClassicHistogram,
+                    labels: vec!["job".to_string()],
+                    series_permille: 150,
+                },
+                MetricFamily {
+                    name: "mb_native".to_string(),
+                    kind: FamilyKind::NativeHistogram,
+                    labels: vec!["job".to_string()],
+                    series_permille: 100,
+                },
+            ],
+            profiles: vec![
+                profile("cardinality", Comparability::Comparable),
+                profile("history", Comparability::Comparable),
+                profile("churn", Comparability::Comparable),
+                profile(
+                    "ci",
+                    Comparability::NonComparable {
+                        reason: "1,000 series over 30 minutes exercises the code paths and \
+                                 measures nothing"
+                            .to_string(),
+                    },
+                ),
+            ],
+        }
+    }
+
+    #[test]
+    fn the_fixture_manifest_gates_clean_and_its_derived_figures_are_exact() {
+        let w = fixture();
+        gate_workload(&w).expect("fixture manifest gates clean");
+        let ci = w.profile("ci").expect("ci profile present");
+        // 7 declared bounds plus +Inf, _sum and _count: 10 series per classic
+        // histogram instance.
+        assert_eq!(w.series_per_instance(FamilyKind::ClassicHistogram), 10);
+        assert_eq!(w.series_per_instance(FamilyKind::Gauge), 1);
+        assert_eq!(w.series_per_instance(FamilyKind::NativeHistogram), 1);
+        let series: Vec<u64> = w.families.iter().map(|f| w.family_series(ci, f)).collect();
+        assert_eq!(series, vec![450, 300, 150, 100]);
+        assert_eq!(series.iter().sum::<u64>(), ci.active_series);
+        let instances: Vec<u64> = w
+            .families
+            .iter()
+            .map(|f| w.family_instances(ci, f))
+            .collect();
+        assert_eq!(instances, vec![450, 300, 15, 100]);
+        assert_eq!(
+            w.emitted_metric_names().into_iter().collect::<Vec<_>>(),
+            vec![
+                "mb_classic_bucket".to_string(),
+                "mb_classic_count".to_string(),
+                "mb_classic_sum".to_string(),
+                "mb_counter".to_string(),
+                "mb_gauge".to_string(),
+                "mb_native".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn a_comparable_ci_profile_is_refused() {
+        let mut w = fixture();
+        for p in &mut w.profiles {
+            if p.name == "ci" {
+                p.comparability = Comparability::Comparable;
+            }
+        }
+        let err = gate_workload(&w).expect_err("a comparable ci profile must fail");
+        assert!(
+            matches!(&err, WorkloadError::MustBeNonComparable { profile } if profile == "ci"),
+            "wrong error variant: {err:?}"
+        );
+        assert!(err.to_string().contains("refuse to publish"), "{err}");
+    }
+
+    #[test]
+    fn a_blank_non_comparable_reason_is_refused() {
+        let mut w = fixture();
+        for p in &mut w.profiles {
+            if p.name == "ci" {
+                p.comparability = Comparability::NonComparable {
+                    reason: "  ".to_string(),
+                };
+            }
+        }
+        let err = gate_workload(&w).expect_err("a blank reason must fail");
+        assert!(
+            matches!(&err, WorkloadError::BlankNonComparableReason { profile } if profile == "ci"),
+            "wrong error variant: {err:?}"
+        );
+    }
+
+    #[test]
+    fn a_missing_or_extra_profile_is_refused() {
+        let mut w = fixture();
+        w.profiles.retain(|p| p.name != "churn");
+        let err = gate_workload(&w).expect_err("a missing profile must fail");
+        match &err {
+            WorkloadError::ProfileSetMismatch { found, expected } => {
+                assert_eq!(
+                    found,
+                    &vec![
+                        "cardinality".to_string(),
+                        "ci".to_string(),
+                        "history".to_string()
+                    ]
+                );
+                assert_eq!(
+                    expected,
+                    &vec![
+                        "cardinality".to_string(),
+                        "churn".to_string(),
+                        "ci".to_string(),
+                        "history".to_string()
+                    ]
+                );
+            }
+            other => panic!("wrong error variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_sample_grid_that_does_not_close_is_refused() {
+        let mut w = fixture();
+        w.profiles[0].duration_secs = 1_801;
+        let err = gate_workload(&w).expect_err("an inconsistent grid must fail");
+        match &err {
+            WorkloadError::SampleGridMismatch {
+                profile, computed, ..
+            } => {
+                assert_eq!(profile, "cardinality");
+                assert_eq!(*computed, 1_800);
+            }
+            other => panic!("wrong error variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_restated_total_that_disagrees_with_its_own_figures_is_refused() {
+        let mut w = fixture();
+        w.profiles[1].total_samples = 119_999;
+        let err = gate_workload(&w).expect_err("a wrong total must fail");
+        assert!(
+            matches!(&err, WorkloadError::TotalSamplesMismatch { profile, declared, computed }
+                if profile == "history" && *declared == 119_999 && *computed == 120_000),
+            "wrong error variant: {err:?}"
+        );
+    }
+
+    #[test]
+    fn shares_that_do_not_partition_the_budget_are_refused() {
+        let mut w = fixture();
+        w.families[0].series_permille = 400;
+        let err = gate_workload(&w).expect_err("shares summing to 950 must fail");
+        assert!(
+            matches!(&err, WorkloadError::SeriesShareNotThousand { total } if *total == 950),
+            "wrong error variant: {err:?}"
+        );
+    }
+
+    #[test]
+    fn an_inexact_series_or_instance_budget_is_refused() {
+        // 500 * 451 / 1000 is not a whole number of series.
+        let mut w = fixture();
+        w.profiles[0].active_series = 500;
+        w.profiles[0].total_samples = 60_000;
+        w.families[0].series_permille = 451;
+        w.families[1].series_permille = 299;
+        let err = gate_workload(&w).expect_err("an inexact series budget must fail");
+        assert!(
+            matches!(&err, WorkloadError::InexactSeriesBudget { family, .. } if family == "mb_gauge"),
+            "wrong error variant: {err:?}"
+        );
+
+        // 150 series over 11-series instances (8 bounds) does not divide.
+        let mut w = fixture();
+        w.generator.classic_histogram_bounds.push(1.0);
+        let err = gate_workload(&w).expect_err("an inexact instance budget must fail");
+        assert!(
+            matches!(&err, WorkloadError::InexactInstanceBudget { family, series, series_per_instance, .. }
+                if family == "mb_classic" && *series == 150 && *series_per_instance == 11),
+            "wrong error variant: {err:?}"
+        );
+    }
+
+    #[test]
+    fn a_family_naming_an_undeclared_dimension_is_refused() {
+        let mut w = fixture();
+        w.families[1].labels.push("method".to_string());
+        let err = gate_workload(&w).expect_err("an undeclared dimension must fail");
+        assert!(
+            matches!(&err, WorkloadError::UnknownDimension { family, label }
+                if family == "mb_counter" && label == "method"),
+            "wrong error variant: {err:?}"
+        );
+    }
+
+    #[test]
+    fn declaring_the_scaling_label_twice_is_refused() {
+        let mut w = fixture();
+        w.label_dimensions.push(LabelDimension {
+            name: "instance".to_string(),
+            values: vec!["i0".to_string()],
+        });
+        let err = gate_workload(&w).expect_err("a declared scaling label must fail");
+        assert!(
+            matches!(&err, WorkloadError::ScalingLabelDeclared { label } if label == "instance"),
+            "wrong error variant: {err:?}"
+        );
+
+        let mut w = fixture();
+        w.families[0].labels.push("instance".to_string());
+        let err = gate_workload(&w).expect_err("a family listing the scaling label must fail");
+        assert!(
+            matches!(&err, WorkloadError::ScalingLabelDeclared { .. }),
+            "wrong error variant: {err:?}"
+        );
+    }
+
+    #[test]
+    fn an_absent_metric_name_that_collides_is_refused() {
+        let mut w = fixture();
+        w.generator.absent_metric_name = "mb_classic_sum".to_string();
+        let err = gate_workload(&w).expect_err("a colliding sentinel must fail");
+        assert!(
+            matches!(&err, WorkloadError::AbsentMetricCollides { name } if name == "mb_classic_sum"),
+            "wrong error variant: {err:?}"
+        );
+    }
+
+    #[test]
+    fn bad_histogram_bounds_and_zero_native_buckets_are_refused() {
+        let mut w = fixture();
+        w.generator.classic_histogram_bounds = vec![0.1, 0.05];
+        assert!(
+            matches!(
+                gate_workload(&w),
+                Err(WorkloadError::BadHistogramBounds { .. })
+            ),
+            "descending bounds must fail"
+        );
+
+        let mut w = fixture();
+        w.generator.classic_histogram_bounds = Vec::new();
+        assert!(
+            matches!(
+                gate_workload(&w),
+                Err(WorkloadError::BadHistogramBounds { .. })
+            ),
+            "empty bounds must fail"
+        );
+
+        let mut w = fixture();
+        w.generator.native_histogram_buckets = 0;
+        assert!(
+            matches!(gate_workload(&w), Err(WorkloadError::NoNativeBuckets)),
+            "zero native buckets must fail"
+        );
+    }
+
+    #[test]
+    fn churn_arithmetic_is_exact_per_profile() {
+        let mut w = fixture();
+        // The ADR-0927 churn profile: 50,000 concurrent, 36 h, 20%/h.
+        let churn = w
+            .profiles
+            .iter_mut()
+            .find(|p| p.name == "churn")
+            .expect("churn profile");
+        churn.active_series = 50_000;
+        churn.samples_per_series = 8_640;
+        churn.duration_secs = 129_600;
+        churn.total_samples = 432_000_000;
+        churn.churn_basis_points_per_hour = 2_000;
+        gate_workload(&w).expect("the real churn figures gate clean");
+        let churn = w.profile("churn").expect("churn profile");
+        assert_eq!(churn.churn_epochs(), 36);
+        assert_eq!(churn.churned_series_per_epoch(), 10_000);
+        // 50,000 alive at once, plus a 10,000-series cohort at each of the 35
+        // epoch boundaries the 36-hour run crosses.
+        assert_eq!(churn.total_series_created(), 400_000);
+        // Churn does not change the sample count: exactly `active_series` series
+        // are alive at every step.
+        assert_eq!(churn.total_samples, 8_640 * 50_000);
+
+        // A profile shorter than one epoch crosses no boundary, so it creates
+        // exactly its active set however high its churn rate is.
+        let ci = w.profile("ci").expect("ci profile");
+        assert_eq!(ci.churn_epochs(), 1);
+        assert_eq!(ci.total_series_created(), 1_000);
+    }
+
+    #[test]
+    fn an_unknown_manifest_key_is_a_deserialization_error() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("workload.json");
+        let mut doc = serde_json::to_value(fixture()).expect("fixture serializes");
+        doc.as_object_mut()
+            .expect("object")
+            .insert("sed".to_string(), serde_json::json!(11));
+        std::fs::write(&path, doc.to_string()).expect("write fixture");
+        let err = load_workload(&path).expect_err("an unknown key must fail");
+        assert!(matches!(&err, WorkloadError::Parse { .. }), "{err:?}");
+        assert!(err.to_string().contains("sed"), "{err}");
+    }
+
+    #[test]
+    fn a_manifest_round_trips_and_an_unknown_version_is_refused() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("workload.json");
+        let w = fixture();
+        std::fs::write(
+            &path,
+            serde_json::to_string_pretty(&w).expect("fixture serializes"),
+        )
+        .expect("write fixture");
+        let back = load_workload(&path).expect("the round-tripped manifest loads and gates");
+        assert_eq!(back, w);
+
+        let mut doc = serde_json::to_value(&w).expect("serializes");
+        doc.as_object_mut()
+            .expect("object")
+            .insert("version".to_string(), serde_json::json!(9));
+        std::fs::write(&path, doc.to_string()).expect("write fixture");
+        let err = load_workload(&path).expect_err("an unknown version must fail");
+        assert!(
+            matches!(err, WorkloadError::UnsupportedVersion { found: 9, .. }),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn a_missing_manifest_is_a_read_error_naming_the_path() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let missing = dir.path().join("nope.json");
+        let err = load_workload(&missing).expect_err("a missing manifest must fail");
+        assert!(
+            matches!(&err, WorkloadError::Read { path, .. } if path == &missing),
+            "{err:?}"
+        );
+    }
+}

--- a/crates/ravel-bench/src/promql_corpus.rs
+++ b/crates/ravel-bench/src/promql_corpus.rs
@@ -1,0 +1,775 @@
+//! The MetricsBench PromQL query corpus (ADR-0927 decision 5).
+//!
+//! A versioned set of workload-shaped PromQL queries against the metric
+//! families `benchmarks/metrics/workload.json` declares. Each entry carries the
+//! constructs it exercises, named exactly as
+//! [`ravel_promql_difftest::scoring::REGISTRY`] names them, and the cost class
+//! it falls into. The gate reproduces the five ordered checks
+//! [`crate::sql_corpus::gate_corpus`] applies to the ClickBench corpus, in the
+//! same order, against the PromQL registry instead of the SQL one:
+//!
+//! 1. all-or-none classification,
+//! 2. unique ids,
+//! 3. non-empty construct list,
+//! 4. non-blank modification reason,
+//! 5. every named construct known to the registry.
+//!
+//! Check 5 differs from the SQL corpus in one deliberate way. The SQL gate
+//! requires each construct to be `SupportedAndCovered`; ADR-0927 decision 5
+//! requires each construct to be *known to the registry*, because ADR-0927
+//! decision 6 keeps queries Ravel refuses or does not implement in the corpus,
+//! reported as `unsupported_construct` or `refused` and still counted in the
+//! corpus denominator. A supported-only gate would delete exactly the entries
+//! ADR-0927's rejected-alternatives section says must stay.
+//!
+//! This module is data plus its gate. It never executes a query: running the
+//! corpus against an engine is the harness's job (ADR-0927 decision 1).
+//!
+//! [`Modification`] restates [`crate::sql_corpus::Modification`] rather than
+//! reusing it: that module is behind the `sql-latency` feature, which pulls
+//! datafusion, and this corpus loads in the default build.
+//!
+//! ## Corpus file format
+//!
+//! JSON, one document per corpus:
+//!
+//! ```json
+//! {
+//!   "version": 1,
+//!   "entries": [
+//!     {
+//!       "id": "mb_fanout_total_rate",
+//!       "class": "high_fan_out",
+//!       "promql": "sum(rate(metricsbench_requests_total[5m]))",
+//!       "eval": "range",
+//!       "constructs": ["aggregate expression", "sum", "rate"],
+//!       "profiles": ["cardinality", "ci"],
+//!       "upstream_id": null,
+//!       "modified": {"modified": {"reason": "..."}}
+//!     }
+//!   ]
+//! }
+//! ```
+//!
+//! `eval`, `profiles`, `upstream_id`, and `modified` may be omitted; they
+//! default to [`EvalKind::Instant`], every profile, no upstream id, and
+//! [`Modification::Verbatim`].
+
+use std::collections::{BTreeSet, HashSet};
+use std::path::{Path, PathBuf};
+
+use ravel_promql_difftest::scoring::REGISTRY;
+use serde::{Deserialize, Serialize};
+
+/// The corpus format version this module reads and writes. A file declaring any
+/// other version is rejected rather than parsed optimistically: the field exists
+/// so a future format change is a loud error, not a silently misread document.
+pub const CORPUS_FORMAT_VERSION: u32 = 1;
+
+/// Whether a query was rewritten in a way that changes what it computes.
+///
+/// A disclosure obligation, so it is a typed field rather than a comment:
+/// re-pointing a query at Ravel's metric names is *not* a modification,
+/// changing the computed result is, and a modified query cannot exist without a
+/// stated reason.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Modification {
+    /// The query computes what its upstream original computes.
+    #[default]
+    Verbatim,
+    /// The query was rewritten in a way that changes its result.
+    Modified {
+        /// What the rewrite changed about the computation, and why.
+        reason: String,
+    },
+}
+
+impl Modification {
+    /// Whether this query computes something other than its upstream original.
+    pub fn is_modified(&self) -> bool {
+        matches!(self, Modification::Modified { .. })
+    }
+
+    /// The stated reason, or `None` for a verbatim query.
+    pub fn reason(&self) -> Option<&str> {
+        match self {
+            Modification::Verbatim => None,
+            Modification::Modified { reason } => Some(reason),
+        }
+    }
+}
+
+/// Which Prometheus HTTP query endpoint an entry is run against.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvalKind {
+    /// `/api/v1/query`: one evaluation timestamp.
+    #[default]
+    Instant,
+    /// `/api/v1/query_range`: a start/end/step grid. The step is a property of
+    /// the profile being run, not of the query, so it is not carried here.
+    Range,
+}
+
+/// The physical work a query is expected to do (ADR-0927 decision 5).
+///
+/// A typed enum, not a bare string and not a comment. [`CorpusEntry`] carries
+/// `deny_unknown_fields`, so the two halves of the hole are closed separately:
+/// a misspelled class VALUE (`"high_fanout"`) fails this deserializer naming
+/// the bad value, and a misspelled class KEY (`"clas"`) fails the entry's
+/// deserializer naming the bad field. Without the second, a corpus where every
+/// entry carried the same key typo would class nothing and pass the
+/// all-or-none check by having nothing left to check.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CostClass {
+    /// Answerable from series metadata alone: the selector resolves and no
+    /// sample values are read.
+    MetadataOnly,
+    /// A fully qualified selector matching exactly one series.
+    SingleSeries,
+    /// A selective label predicate matching a small fraction of the series.
+    SelectiveMultiSeries,
+    /// An unrestricted selector over a whole metric family.
+    HighFanOut,
+    /// Reads every sample of the matched series across the profile's whole
+    /// generated range.
+    FullRange,
+    /// Vector matching between two selectors (`on`/`ignoring`, with or without
+    /// `group_left`/`group_right`).
+    Join,
+    /// Reads classic or native histogram data.
+    Histogram,
+    /// A window or subquery spanning multiple days, so it crosses far more
+    /// stored objects than a scrape-scale window.
+    LongRange,
+}
+
+impl CostClass {
+    /// Every cost class, in declaration order. A reader that groups a report by
+    /// class iterates this rather than re-listing the variants, so a new class
+    /// cannot be silently dropped from a table.
+    pub const ALL: &'static [CostClass] = &[
+        CostClass::MetadataOnly,
+        CostClass::SingleSeries,
+        CostClass::SelectiveMultiSeries,
+        CostClass::HighFanOut,
+        CostClass::FullRange,
+        CostClass::Join,
+        CostClass::Histogram,
+        CostClass::LongRange,
+    ];
+
+    /// The slug this class serializes as, for report keys and log lines.
+    pub fn slug(self) -> &'static str {
+        match self {
+            CostClass::MetadataOnly => "metadata_only",
+            CostClass::SingleSeries => "single_series",
+            CostClass::SelectiveMultiSeries => "selective_multi_series",
+            CostClass::HighFanOut => "high_fan_out",
+            CostClass::FullRange => "full_range",
+            CostClass::Join => "join",
+            CostClass::Histogram => "histogram",
+            CostClass::LongRange => "long_range",
+        }
+    }
+}
+
+/// One corpus query and everything a reader needs to judge it.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CorpusEntry {
+    /// A stable short identifier, unique within a corpus. Report rows are keyed
+    /// by it, so it must not change when the query is edited in place.
+    pub id: String,
+    /// The query text, as it will be handed to the engine.
+    pub promql: String,
+    /// The constructs the query exercises, named exactly as
+    /// [`ravel_promql_difftest::scoring::Construct::name`] names them.
+    pub constructs: Vec<String>,
+    /// The cost class, or `None` for a corpus that predates cost classes. A
+    /// corpus that classes *any* entry must class *every* entry, which
+    /// [`gate_corpus`] enforces, so an unclassified entry can never silently
+    /// read as some default class where the classes are consumed.
+    #[serde(default)]
+    pub class: Option<CostClass>,
+    /// Which endpoint the query runs against.
+    #[serde(default)]
+    pub eval: EvalKind,
+    /// The workload profiles this query belongs to, by
+    /// [`crate::metrics_workload::Profile::name`]. Empty means every profile:
+    /// most queries are profile-independent, and only the ones that need a
+    /// range no shorter profile generates (a 7-day window) restrict themselves.
+    #[serde(default)]
+    pub profiles: Vec<String>,
+    /// The id this query carries in the external suite it came from, so it can
+    /// be diffed against its original.
+    #[serde(default)]
+    pub upstream_id: Option<String>,
+    /// Whether the query was rewritten in a way that changes what it computes.
+    #[serde(default)]
+    pub modified: Modification,
+}
+
+impl CorpusEntry {
+    /// Whether this entry runs under the profile named `profile`.
+    pub fn runs_under(&self, profile: &str) -> bool {
+        self.profiles.is_empty() || self.profiles.iter().any(|p| p == profile)
+    }
+}
+
+/// A parsed corpus document: a format version plus its entries.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CorpusFile {
+    /// The format version, which must equal [`CORPUS_FORMAT_VERSION`].
+    pub version: u32,
+    /// The queries, in the order the harness runs them.
+    pub entries: Vec<CorpusEntry>,
+}
+
+/// Everything that can go wrong loading or gating a corpus. Every variant names
+/// the entry (and where applicable the construct) at fault: the message is the
+/// signal a reader acts on, so it is part of the contract.
+#[derive(Debug, thiserror::Error)]
+pub enum CorpusError {
+    /// The corpus file could not be read.
+    #[error("promql corpus file {path}: {source}")]
+    Read {
+        /// The path that was read.
+        path: PathBuf,
+        /// The underlying I/O failure.
+        #[source]
+        source: std::io::Error,
+    },
+    /// The corpus file is not a valid corpus document.
+    #[error("promql corpus file {path} is not a valid JSON corpus document: {source}")]
+    Parse {
+        /// The path that was parsed.
+        path: PathBuf,
+        /// The underlying `serde_json` failure, which carries the line, column,
+        /// and what was expected there.
+        #[source]
+        source: serde_json::Error,
+    },
+    /// The document declares a format version this module does not read.
+    #[error(
+        "promql corpus file {path} declares format version {found}, but this build reads \
+         version {expected}"
+    )]
+    UnsupportedVersion {
+        /// The path that was parsed.
+        path: PathBuf,
+        /// The version the document declared.
+        found: u32,
+        /// The version this build reads ([`CORPUS_FORMAT_VERSION`]).
+        expected: u32,
+    },
+    /// A corpus that classifies some entries left this one unclassified. A
+    /// corpus uses cost classes for every entry or for none: a mix would let an
+    /// unclassified entry read as a default class where the classes are
+    /// consumed.
+    #[error(
+        "promql corpus entry `{entry_id}` has no cost class, but other entries in this corpus \
+         do; a corpus that classes any entry must class every entry"
+    )]
+    UnclassifiedEntry {
+        /// The id of the unclassified entry.
+        entry_id: String,
+    },
+    /// Two entries share an id, so their report rows would collide.
+    #[error("promql corpus entry id `{entry_id}` appears more than once; ids must be unique")]
+    DuplicateId {
+        /// The duplicated id.
+        entry_id: String,
+    },
+    /// An entry names no constructs at all, so the gate would pass it
+    /// vacuously.
+    #[error(
+        "promql corpus entry `{entry_id}` names no constructs; every entry must name at \
+         least one"
+    )]
+    NoConstructs {
+        /// The id of the offending entry.
+        entry_id: String,
+    },
+    /// An entry is flagged modified with an empty reason, which discloses
+    /// nothing.
+    #[error(
+        "promql corpus entry `{entry_id}` is flagged as a modified query with an empty reason; \
+         a modified query must state what its rewrite changed about the computation"
+    )]
+    EmptyModificationReason {
+        /// The id of the offending entry.
+        entry_id: String,
+    },
+    /// An entry names a construct the PromQL conformance registry does not
+    /// carry. This is the misspelling and drift signal ADR-0927 decision 5
+    /// exists to produce, so it names both the construct and the entry.
+    #[error(
+        "promql corpus entry `{entry_id}` names construct `{construct}`, which is not in \
+         ravel_promql_difftest::scoring::REGISTRY: no registry construct carries that name. \
+         Either the construct name is misspelled, or it names something outside the scored \
+         PromQL surface, which the registry deliberately does not enumerate."
+    )]
+    UnknownConstruct {
+        /// The id of the entry that named it.
+        entry_id: String,
+        /// The construct name the registry does not carry.
+        construct: String,
+    },
+}
+
+/// Every construct name the PromQL conformance registry carries, in any state.
+///
+/// ADR-0927 decision 5's check is membership in the registry, not membership in
+/// its supported subset: a corpus entry naming an intentionally-rejected or
+/// unclassified construct is exactly the entry the report records as
+/// `unsupported_construct` or `refused`, and it stays in the corpus
+/// denominator.
+pub fn known_construct_names() -> BTreeSet<&'static str> {
+    REGISTRY.iter().map(|c| c.name).collect()
+}
+
+/// Apply the five ordered checks to a corpus, identically for the checked-in
+/// artifact and for an external file.
+pub fn gate_corpus(entries: &[CorpusEntry]) -> Result<(), CorpusError> {
+    let known = known_construct_names();
+    // A corpus either classes every entry or none. If it classes any, an
+    // unclassified entry is a hard error here where the classes are consumed,
+    // not a silent fall-through to a default class.
+    let uses_cost_classes = entries.iter().any(|e| e.class.is_some());
+    let mut seen_ids: HashSet<&str> = HashSet::new();
+    for entry in entries {
+        if uses_cost_classes && entry.class.is_none() {
+            return Err(CorpusError::UnclassifiedEntry {
+                entry_id: entry.id.clone(),
+            });
+        }
+        if !seen_ids.insert(entry.id.as_str()) {
+            return Err(CorpusError::DuplicateId {
+                entry_id: entry.id.clone(),
+            });
+        }
+        if entry.constructs.is_empty() {
+            return Err(CorpusError::NoConstructs {
+                entry_id: entry.id.clone(),
+            });
+        }
+        if let Modification::Modified { reason } = &entry.modified
+            && reason.trim().is_empty()
+        {
+            return Err(CorpusError::EmptyModificationReason {
+                entry_id: entry.id.clone(),
+            });
+        }
+        for construct in &entry.constructs {
+            if !known.contains(construct.as_str()) {
+                return Err(CorpusError::UnknownConstruct {
+                    entry_id: entry.id.clone(),
+                    construct: construct.clone(),
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Read a corpus document, parse it, and gate it. A malformed file is a typed
+/// error naming what failed to parse; it is never a panic and never a silently
+/// skipped entry.
+pub fn load_corpus(path: impl AsRef<Path>) -> Result<Vec<CorpusEntry>, CorpusError> {
+    let path = path.as_ref();
+    let text = std::fs::read_to_string(path).map_err(|source| CorpusError::Read {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let file: CorpusFile = serde_json::from_str(&text).map_err(|source| CorpusError::Parse {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    if file.version != CORPUS_FORMAT_VERSION {
+        return Err(CorpusError::UnsupportedVersion {
+            path: path.to_path_buf(),
+            found: file.version,
+            expected: CORPUS_FORMAT_VERSION,
+        });
+    }
+    gate_corpus(&file.entries)?;
+    Ok(file.entries)
+}
+
+/// How many corpus entries fall in each cost class, over every class rather
+/// than only the ones present, so an empty class reads as `0` instead of being
+/// absent from the table.
+pub fn class_counts(entries: &[CorpusEntry]) -> Vec<(CostClass, usize)> {
+    CostClass::ALL
+        .iter()
+        .map(|class| {
+            let n = entries.iter().filter(|e| e.class == Some(*class)).count();
+            (*class, n)
+        })
+        .collect()
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn write_corpus(dir: &tempfile::TempDir, name: &str, body: &str) -> PathBuf {
+        let path = dir.path().join(name);
+        std::fs::write(&path, body).expect("write corpus fixture");
+        path
+    }
+
+    fn entry(id: &str, class: Option<CostClass>) -> CorpusEntry {
+        CorpusEntry {
+            id: id.to_string(),
+            promql: "sum(rate(metricsbench_requests_total[5m]))".to_string(),
+            constructs: vec!["sum".to_string(), "rate".to_string()],
+            class,
+            eval: EvalKind::Instant,
+            profiles: Vec::new(),
+            upstream_id: None,
+            modified: Modification::Verbatim,
+        }
+    }
+
+    /// ACCEPTANCE TEST (issue #933): a corpus that classes some entries and
+    /// leaves one unclassified is refused, naming the unclassified entry. This
+    /// is check 1 of the five, and the check that stops a partially classed
+    /// corpus from reading as "no classes here" downstream.
+    #[test]
+    fn gate_rejects_an_unclassified_corpus() {
+        let classed = entry("classed", Some(CostClass::HighFanOut));
+        let unclassed = entry("unclassed", None);
+        let err = gate_corpus(&[classed.clone(), unclassed])
+            .expect_err("a mix of classed and unclassed entries must fail");
+        assert!(
+            matches!(&err, CorpusError::UnclassifiedEntry { entry_id } if entry_id == "unclassed"),
+            "wrong error variant: {err:?}"
+        );
+        assert!(
+            err.to_string().contains("unclassed"),
+            "the error must name the unclassified entry: {err}"
+        );
+        // The same corpus with every entry classed gates clean, so the check
+        // rejects the mix rather than rejecting classes.
+        gate_corpus(&[classed, entry("also_classed", Some(CostClass::Join))])
+            .expect("a fully classed corpus gates clean");
+        // And a corpus with no classes at all gates clean too: the all-or-none
+        // rule triggers only once one entry carries a class.
+        gate_corpus(&[entry("a", None), entry("b", None)])
+            .expect("a fully unclassed corpus gates clean");
+    }
+
+    #[test]
+    fn gate_rejects_a_duplicate_id_naming_it() {
+        let base = entry("dup", Some(CostClass::SingleSeries));
+        let err = gate_corpus(&[base.clone(), base]).expect_err("duplicate ids must fail");
+        assert!(
+            matches!(&err, CorpusError::DuplicateId { entry_id } if entry_id == "dup"),
+            "wrong error variant: {err:?}"
+        );
+        assert!(err.to_string().contains("must be unique"), "{err}");
+    }
+
+    #[test]
+    fn gate_rejects_an_entry_naming_no_constructs() {
+        let mut bare = entry("bare", Some(CostClass::MetadataOnly));
+        bare.constructs.clear();
+        let err = gate_corpus(&[bare]).expect_err("an entry naming no constructs must fail");
+        assert!(
+            matches!(&err, CorpusError::NoConstructs { entry_id } if entry_id == "bare"),
+            "wrong error variant: {err:?}"
+        );
+    }
+
+    #[test]
+    fn gate_rejects_a_modified_entry_with_a_blank_reason() {
+        let mut modified = entry("blank_reason", Some(CostClass::FullRange));
+        modified.modified = Modification::Modified {
+            reason: "   \t ".to_string(),
+        };
+        let err = gate_corpus(&[modified]).expect_err("a blank modification reason must fail");
+        assert!(
+            matches!(&err, CorpusError::EmptyModificationReason { entry_id }
+                if entry_id == "blank_reason"),
+            "wrong error variant: {err:?}"
+        );
+
+        // A stated reason passes, so the check rejects the blank rather than
+        // the flag.
+        let mut disclosed = entry("disclosed", Some(CostClass::FullRange));
+        disclosed.modified = Modification::Modified {
+            reason: "widened from 5m to 1h: the ci profile generates 30 minutes of data"
+                .to_string(),
+        };
+        gate_corpus(&[disclosed]).expect("a modified entry with a reason gates clean");
+    }
+
+    #[test]
+    fn gate_rejects_a_construct_the_registry_does_not_carry() {
+        let mut bad = entry("unknown_construct", Some(CostClass::HighFanOut));
+        // `limitk` is a real Prometheus aggregator, deliberately outside the
+        // scored surface (it is experimental), so the registry does not carry
+        // it. That makes it the exact shape this check catches: a plausible
+        // name that is not a registry construct.
+        bad.constructs = vec!["sum".to_string(), "limitk".to_string()];
+        let err = gate_corpus(&[bad]).expect_err("an unknown construct must fail");
+        assert!(
+            matches!(&err, CorpusError::UnknownConstruct { entry_id, construct }
+                if entry_id == "unknown_construct" && construct == "limitk"),
+            "wrong error variant: {err:?}"
+        );
+        let message = err.to_string();
+        assert!(
+            message.contains("limitk"),
+            "error must name the construct: {message}"
+        );
+        assert!(
+            message.contains("unknown_construct"),
+            "error must name the entry id: {message}"
+        );
+        assert!(
+            message.contains("REGISTRY"),
+            "error must say which registry was consulted: {message}"
+        );
+    }
+
+    #[test]
+    fn the_registry_check_admits_a_construct_ravel_refuses() {
+        // ADR-0927 decision 6 keeps queries Ravel does not implement in the
+        // corpus, reported `unsupported_construct` and still counted in the
+        // corpus denominator. `histogram_stddev` is registered
+        // IntentionallyRejected, so a supported-only gate (the SQL corpus'
+        // rule) would delete this entry; the registry-membership gate admits
+        // it.
+        let mut refused = entry("native_hist_stddev", Some(CostClass::Histogram));
+        refused.promql = "histogram_stddev(metricsbench_latency_native)".to_string();
+        refused.constructs = vec!["histogram_stddev".to_string(), "function call".to_string()];
+        gate_corpus(&[refused])
+            .expect("a registered but unsupported construct stays in the corpus");
+    }
+
+    #[test]
+    fn a_misspelled_class_key_is_a_deserialization_error_not_an_unclassified_entry() {
+        // The typed enum catches a bad class VALUE. It cannot catch a bad class
+        // KEY: without `deny_unknown_fields`, `"clas"` is dropped and the entry
+        // reads as unclassified, and a corpus where every entry carries the
+        // same typo classes nothing and sails through check 1 by seeing "none".
+        let typo = serde_json::json!({
+            "id": "a",
+            "promql": "up",
+            "constructs": ["vector selector"],
+            "clas": "high_fan_out",
+        });
+        let err = serde_json::from_value::<CorpusEntry>(typo)
+            .expect_err("a misspelled class key must fail to deserialize");
+        assert!(
+            err.to_string().contains("clas"),
+            "the error must name the offending field, got: {err}"
+        );
+
+        // The bad VALUE, caught by the typed enum rather than by the field set.
+        let bad_value = serde_json::json!({
+            "id": "a",
+            "promql": "up",
+            "constructs": ["vector selector"],
+            "class": "high_fanout",
+        });
+        let err = serde_json::from_value::<CorpusEntry>(bad_value)
+            .expect_err("a misspelled class value must fail to deserialize");
+        assert!(
+            err.to_string().contains("high_fanout"),
+            "the error must name the offending value, got: {err}"
+        );
+
+        // The correct spelling parses, so the guards reject typos rather than
+        // rejecting the field.
+        let ok = serde_json::json!({
+            "id": "a",
+            "promql": "up",
+            "constructs": ["vector selector"],
+            "class": "high_fan_out",
+        });
+        let parsed: CorpusEntry = serde_json::from_value(ok).expect("the correct spelling parses");
+        assert_eq!(parsed.class, Some(CostClass::HighFanOut));
+        assert_eq!(parsed.eval, EvalKind::Instant);
+        assert_eq!(parsed.profiles, Vec::<String>::new());
+        assert!(!parsed.modified.is_modified());
+    }
+
+    #[test]
+    fn an_unknown_top_level_key_is_a_deserialization_error() {
+        // The same hole one level up: a document carrying `"entires"` would
+        // otherwise parse as a corpus with zero entries, and a zero-entry
+        // corpus passes all five checks vacuously.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = write_corpus(&dir, "typo.json", r#"{"version": 1, "entires": []}"#);
+        let err = load_corpus(&path).expect_err("a misspelled `entries` key must fail");
+        assert!(matches!(&err, CorpusError::Parse { .. }), "{err:?}");
+        assert!(err.to_string().contains("entires"), "{err}");
+    }
+
+    #[test]
+    fn a_malformed_corpus_is_a_typed_parse_error() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = write_corpus(
+            &dir,
+            "corpus.json",
+            "{\"version\": 1, \"entries\": [{\"id\":",
+        );
+        let err = load_corpus(&path).expect_err("malformed JSON must fail");
+        match &err {
+            CorpusError::Parse { path: p, source } => {
+                assert_eq!(p, &path);
+                assert!(
+                    source.to_string().contains("line"),
+                    "parse error should locate the failure: {source}"
+                );
+            }
+            other => panic!("wrong error variant: {other:?}"),
+        }
+        assert!(err.to_string().contains("not a valid JSON corpus document"));
+    }
+
+    #[test]
+    fn a_missing_corpus_is_a_read_error_naming_the_path() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let missing = dir.path().join("absent.json");
+        let err = load_corpus(&missing).expect_err("a missing file must fail");
+        assert!(
+            matches!(&err, CorpusError::Read { path, .. } if path == &missing),
+            "{err:?}"
+        );
+        assert!(err.to_string().contains("absent.json"), "{err}");
+    }
+
+    #[test]
+    fn an_unknown_format_version_is_rejected() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = write_corpus(&dir, "corpus.json", r#"{"version": 7, "entries": []}"#);
+        let err = load_corpus(&path).expect_err("an unknown version must fail");
+        assert!(
+            matches!(
+                err,
+                CorpusError::UnsupportedVersion {
+                    found: 7,
+                    expected: 1,
+                    ..
+                }
+            ),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn the_loader_gates_what_it_returns() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = write_corpus(
+            &dir,
+            "corpus.json",
+            r#"{
+              "version": 1,
+              "entries": [
+                {
+                  "id": "mb_a",
+                  "class": "single_series",
+                  "promql": "metricsbench_gauge_cpu_percent{instance=\"metricsbench-instance-0\"}",
+                  "eval": "instant",
+                  "constructs": ["vector selector", "label matcher ="]
+                },
+                {
+                  "id": "mb_b",
+                  "class": "long_range",
+                  "promql": "avg_over_time(metricsbench_gauge_cpu_percent[7d])",
+                  "eval": "range",
+                  "profiles": ["history"],
+                  "constructs": ["avg_over_time", "matrix selector"],
+                  "modified": {"modified": {"reason": "window widened to 7d; the 30m ci profile has no 7 day range"}}
+                }
+              ]
+            }"#,
+        );
+        let entries = load_corpus(&path).expect("the fixture corpus loads and gates");
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].eval, EvalKind::Instant);
+        assert_eq!(entries[1].eval, EvalKind::Range);
+        assert_eq!(entries[1].profiles, vec!["history".to_string()]);
+        assert!(entries[1].runs_under("history"));
+        assert!(!entries[1].runs_under("ci"));
+        assert!(
+            entries[0].runs_under("ci"),
+            "an empty profile list is every profile"
+        );
+        assert!(
+            entries[1]
+                .modified
+                .reason()
+                .expect("modified entry states a reason")
+                .contains("7d")
+        );
+
+        // The loader really gated what it returned: the identical corpus with
+        // one construct renamed to a name the registry does not carry is
+        // refused. Without this pair, a loader that skipped the gate would
+        // still pass this test.
+        gate_corpus(&entries).expect("loaded entries gate clean");
+        let mut tampered = entries.clone();
+        tampered[0].constructs[0] = "vector selektor".to_string();
+        assert!(
+            matches!(
+                gate_corpus(&tampered),
+                Err(CorpusError::UnknownConstruct { .. })
+            ),
+            "the gate must refuse an unknown construct"
+        );
+    }
+
+    #[test]
+    fn class_counts_reports_every_class_including_the_empty_ones() {
+        let entries = vec![
+            entry("a", Some(CostClass::Join)),
+            entry("b", Some(CostClass::Join)),
+            entry("c", Some(CostClass::MetadataOnly)),
+        ];
+        let counts = class_counts(&entries);
+        assert_eq!(
+            counts.len(),
+            8,
+            "all eight ADR-0927 cost classes must appear in the table"
+        );
+        let lookup = |class: CostClass| -> usize {
+            counts
+                .iter()
+                .find(|(c, _)| *c == class)
+                .map(|(_, n)| *n)
+                .unwrap_or_else(|| panic!("class {} missing from the table", class.slug()))
+        };
+        assert_eq!(lookup(CostClass::Join), 2);
+        assert_eq!(lookup(CostClass::MetadataOnly), 1);
+        assert_eq!(lookup(CostClass::HighFanOut), 0);
+        assert_eq!(lookup(CostClass::LongRange), 0);
+        assert_eq!(counts.iter().map(|(_, n)| *n).sum::<usize>(), 3);
+    }
+
+    #[test]
+    fn every_cost_class_slug_round_trips_through_serde() {
+        // The slug a report keys by and the slug the artifact stores must be
+        // the same string, or a class renamed in one place reads as a different
+        // class in the other.
+        for class in CostClass::ALL {
+            let json = serde_json::to_string(class).expect("class serializes");
+            assert_eq!(
+                json,
+                format!("\"{}\"", class.slug()),
+                "slug and serde name disagree for {class:?}"
+            );
+            let back: CostClass = serde_json::from_str(&json).expect("class round-trips");
+            assert_eq!(back, *class);
+        }
+    }
+}

--- a/crates/ravel-bench/src/promql_corpus.rs
+++ b/crates/ravel-bench/src/promql_corpus.rs
@@ -73,7 +73,7 @@ pub const CORPUS_FORMAT_VERSION: u32 = 1;
 /// changing the computed result is, and a modified query cannot exist without a
 /// stated reason.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
 pub enum Modification {
     /// The query computes what its upstream original computes.
     #[default]
@@ -336,27 +336,48 @@ pub fn known_construct_names() -> BTreeSet<&'static str> {
 /// artifact and for an external file.
 pub fn gate_corpus(entries: &[CorpusEntry]) -> Result<(), CorpusError> {
     let known = known_construct_names();
-    // A corpus either classes every entry or none. If it classes any, an
-    // unclassified entry is a hard error here where the classes are consumed,
-    // not a silent fall-through to a default class.
+
+    // Each check runs across the WHOLE corpus before the next begins, in the
+    // order the module contract states. Sharing one loop lets a later check on
+    // an earlier entry win over an earlier check on a later entry (a duplicate
+    // id at entry 1 reported ahead of an unclassified entry at entry 5),
+    // contradicting the stated precedence.
+
+    // 1. All-or-none classification. A corpus either classes every entry or
+    //    none; a mix would let an unclassified entry read as a default class
+    //    where the classes are consumed.
     let uses_cost_classes = entries.iter().any(|e| e.class.is_some());
+    if uses_cost_classes {
+        for entry in entries {
+            if entry.class.is_none() {
+                return Err(CorpusError::UnclassifiedEntry {
+                    entry_id: entry.id.clone(),
+                });
+            }
+        }
+    }
+
+    // 2. Unique ids.
     let mut seen_ids: HashSet<&str> = HashSet::new();
     for entry in entries {
-        if uses_cost_classes && entry.class.is_none() {
-            return Err(CorpusError::UnclassifiedEntry {
-                entry_id: entry.id.clone(),
-            });
-        }
         if !seen_ids.insert(entry.id.as_str()) {
             return Err(CorpusError::DuplicateId {
                 entry_id: entry.id.clone(),
             });
         }
+    }
+
+    // 3. Non-empty construct list.
+    for entry in entries {
         if entry.constructs.is_empty() {
             return Err(CorpusError::NoConstructs {
                 entry_id: entry.id.clone(),
             });
         }
+    }
+
+    // 4. Non-blank modification reason.
+    for entry in entries {
         if let Modification::Modified { reason } = &entry.modified
             && reason.trim().is_empty()
         {
@@ -364,6 +385,10 @@ pub fn gate_corpus(entries: &[CorpusEntry]) -> Result<(), CorpusError> {
                 entry_id: entry.id.clone(),
             });
         }
+    }
+
+    // 5. Every named construct known to the registry.
+    for entry in entries {
         for construct in &entry.constructs {
             if !known.contains(construct.as_str()) {
                 return Err(CorpusError::UnknownConstruct {
@@ -463,6 +488,55 @@ mod tests {
         // rule triggers only once one entry carries a class.
         gate_corpus(&[entry("a", None), entry("b", None)])
             .expect("a fully unclassed corpus gates clean");
+    }
+
+    #[test]
+    fn the_classification_check_runs_across_the_whole_corpus_before_the_id_check() {
+        // A corpus with an EARLIER duplicate id and a LATER unclassified entry
+        // is invalid two ways. The contract (module docs, checks 1..5) runs the
+        // all-or-none classification check across the whole corpus first, so the
+        // classification failure must win regardless of entry order. A shared
+        // loop that checks id-then-class per entry returns DuplicateId instead,
+        // contradicting the stated order.
+        let a = entry("dup", Some(CostClass::HighFanOut));
+        let b = entry("dup", Some(CostClass::Join)); // duplicate id, earlier
+        let c = entry("later", None); // unclassified, later
+        let err = gate_corpus(&[a, b, c]).expect_err("the corpus is invalid two ways");
+        assert!(
+            matches!(&err, CorpusError::UnclassifiedEntry { entry_id } if entry_id == "later"),
+            "classification must be checked across the whole corpus before the id check, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn a_modification_with_an_unknown_field_is_a_deserialization_error() {
+        // The nested-struct instance of the deny_unknown_fields hole the
+        // top-level `CorpusEntry`/`CorpusFile` already close: without the
+        // attribute on `Modification`, `{"reason":"x","reasno":"x"}` drops
+        // `reasno` silently and the entry reads as a disclosed modification with
+        // the wrong intent recorded.
+        let typo = serde_json::json!({
+            "id": "a",
+            "promql": "up",
+            "constructs": ["vector selector"],
+            "modified": {"modified": {"reason": "x", "reasno": "x"}}
+        });
+        let err = serde_json::from_value::<CorpusEntry>(typo)
+            .expect_err("an unknown field inside `modified` must fail to deserialize");
+        assert!(
+            err.to_string().contains("reasno"),
+            "the error must name the offending field, got: {err}"
+        );
+
+        // The same entry without the typo parses and records the modification.
+        let ok = serde_json::json!({
+            "id": "a",
+            "promql": "up",
+            "constructs": ["vector selector"],
+            "modified": {"modified": {"reason": "x"}}
+        });
+        let parsed: CorpusEntry = serde_json::from_value(ok).expect("the correct shape parses");
+        assert!(parsed.modified.is_modified());
     }
 
     #[test]

--- a/crates/ravel-bench/tests/metricsbench_artifacts.rs
+++ b/crates/ravel-bench/tests/metricsbench_artifacts.rs
@@ -428,13 +428,59 @@ fn the_ci_profile_generates_its_exact_declared_sample_count() {
         report.float_samples + report.stale_markers + report.native_histogram_samples,
         report.emitted_samples
     );
-    // The injected anomalies all fired: a run that produced none of them would
-    // pass every count above while generating a workload the ADR does not
-    // describe.
-    assert!(report.stale_markers > 0, "no staleness markers");
-    assert!(report.omitted_missing_samples > 0, "no missing samples");
-    assert!(report.counter_reset_events > 0, "no counter resets");
-    assert!(report.out_of_order_samples > 0, "no out-of-order samples");
+    // The injected anomalies all fired at their designed rate: a run that
+    // produced one marker where the profile designs for dozens would pass every
+    // count above while generating a workload the ADR does not describe. The
+    // generator is deterministic on this seed and profile, so each figure is
+    // exact. Each is also checked against the nominal count its own one-in rate
+    // implies, so a constant that stops tracking the design is visible as more
+    // than a changed number.
+    let anomalies = workload.generator.anomalies;
+    let steps = ci.samples_per_series;
+    // Instances scraped per step, from the family shares of the 1,000 active
+    // series: 400 cpu gauge, 300 counter, 15 classic histogram (10 series
+    // each), 100 native, 50 build_info gauge. Staleness applies to gauges only
+    // and resets to counters and classic histograms only.
+    let gauge_scrapes = 450 * steps;
+    let counter_scrapes = (300 + 15) * steps;
+    let instance_scrapes = 865 * steps;
+    // The omission and out-of-order figures count series rather than instances,
+    // so their nominals are instance-rate approximations; a factor of two
+    // absorbs the per-instance series weighting without admitting a fraction of
+    // the designed rate.
+    for (label, observed, nominal) in [
+        (
+            "stale markers",
+            report.stale_markers,
+            gauge_scrapes / anomalies.stale_marker_one_in,
+        ),
+        (
+            "missing samples",
+            report.omitted_missing_samples,
+            instance_scrapes / anomalies.missing_sample_one_in,
+        ),
+        (
+            "counter resets",
+            report.counter_reset_events,
+            counter_scrapes / anomalies.counter_reset_one_in,
+        ),
+        (
+            "out-of-order samples",
+            report.out_of_order_samples,
+            instance_scrapes / anomalies.out_of_order_one_in,
+        ),
+    ] {
+        assert!(
+            observed >= nominal / 2 && observed <= nominal * 2,
+            "{label}: {observed} is not within a factor of two of the {nominal} \
+             the profile's own rate designs for"
+        );
+    }
+    // The exact figures this seed produces.
+    assert_eq!(report.stale_markers, 62, "staleness markers");
+    assert_eq!(report.omitted_missing_samples, 225, "missing samples");
+    assert_eq!(report.counter_reset_events, 34, "counter resets");
+    assert_eq!(report.out_of_order_samples, 182, "out-of-order samples");
 }
 
 /// The `metricsbench_gen` binary, resolved the way an integration test can.

--- a/crates/ravel-bench/tests/metricsbench_artifacts.rs
+++ b/crates/ravel-bench/tests/metricsbench_artifacts.rs
@@ -1,0 +1,762 @@
+//! Gate tests for the checked-in MetricsBench artifacts (ADR-0927, issue #933)
+//! under `benchmarks/metrics/`, plus the reachability proof the task requires:
+//! a corrupt artifact fails through the shipping `metricsbench_gen` binary, not
+//! only through a direct `gate_corpus` call.
+//!
+//! Everything here is an exact expected value. Where a figure would move with
+//! an encoding change it is bounded against something known (per profile, per
+//! family), never against a flat floor.
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+use std::process::Command;
+
+use ravel_bench::metrics_gen::Generator;
+use ravel_bench::metrics_workload::{
+    Comparability, FamilyKind, NON_COMPARABLE_PROFILES, REQUIRED_PROFILES, load_workload,
+};
+use ravel_bench::promql_corpus::{
+    CostClass, EvalKind, class_counts, known_construct_names, load_corpus,
+};
+
+/// The checked-in artifacts, relative to this crate's manifest dir.
+fn workload_path() -> PathBuf {
+    PathBuf::from(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../benchmarks/metrics/workload.json"
+    ))
+}
+
+fn corpus_path() -> PathBuf {
+    PathBuf::from(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../benchmarks/metrics/metrics.corpus.json"
+    ))
+}
+
+/// The corpus holds three queries in each of the eight ADR-0927 cost classes.
+const ENTRIES_PER_CLASS: usize = 3;
+/// Eight classes at three each.
+const CORPUS_SIZE: usize = 24;
+
+#[test]
+fn the_checked_in_artifacts_load_and_pass_their_gates() {
+    let workload = load_workload(workload_path()).expect("the workload manifest loads and gates");
+    let entries = load_corpus(corpus_path()).expect("the query corpus loads and gates");
+    assert_eq!(workload.version, 1);
+    assert_eq!(workload.seed, 927_000_933);
+    assert_eq!(entries.len(), CORPUS_SIZE);
+}
+
+#[test]
+fn the_manifest_declares_exactly_the_four_adr_0927_profiles_with_their_exact_figures() {
+    let workload = load_workload(workload_path()).expect("manifest loads");
+    let names: Vec<&str> = workload.profiles.iter().map(|p| p.name.as_str()).collect();
+    assert_eq!(names, REQUIRED_PROFILES);
+
+    // ADR-0927 decision 11's table, restated as exact values. Each row:
+    // (name, active series, samples/series, scrape, duration, churn bp/h,
+    // total samples).
+    let expected: &[(&str, u64, u64, u64, u64, u64, u64)] = &[
+        ("cardinality", 1_000_000, 360, 15, 5_400, 0, 360_000_000),
+        ("history", 10_000, 172_800, 15, 2_592_000, 0, 1_728_000_000),
+        ("churn", 50_000, 8_640, 15, 129_600, 2_000, 432_000_000),
+        ("ci", 1_000, 120, 15, 1_800, 500, 120_000),
+    ];
+    for (name, active, samples, scrape, duration, churn_bp, total) in expected {
+        let p = workload.profile(name).expect("profile present");
+        assert_eq!(p.active_series, *active, "{name} active_series");
+        assert_eq!(p.samples_per_series, *samples, "{name} samples_per_series");
+        assert_eq!(p.scrape_interval_secs, *scrape, "{name} scrape_interval");
+        assert_eq!(p.duration_secs, *duration, "{name} duration");
+        assert_eq!(
+            p.churn_basis_points_per_hour, *churn_bp,
+            "{name} churn rate"
+        );
+        assert_eq!(p.total_samples, *total, "{name} total_samples");
+    }
+}
+
+#[test]
+fn only_the_ci_profile_is_marked_non_comparable_and_it_states_why() {
+    let workload = load_workload(workload_path()).expect("manifest loads");
+    for profile in &workload.profiles {
+        let must_refuse = NON_COMPARABLE_PROFILES.contains(&profile.name.as_str());
+        assert_eq!(
+            profile.is_publishable(),
+            !must_refuse,
+            "profile `{}` publishability disagrees with ADR-0927 decision 11",
+            profile.name
+        );
+        match &profile.comparability {
+            Comparability::Comparable => assert!(!must_refuse),
+            Comparability::NonComparable { reason } => {
+                assert!(must_refuse);
+                // The refusal has to be usable: a reader shows this string.
+                assert!(
+                    reason.contains("ADR-0927"),
+                    "the ci profile's refusal must cite the rule: {reason}"
+                );
+                assert!(reason.len() > 80, "the refusal must be a real reason");
+            }
+        }
+    }
+    assert_eq!(
+        workload
+            .profiles
+            .iter()
+            .filter(|p| !p.is_publishable())
+            .count(),
+        1,
+        "exactly one profile is non-comparable"
+    );
+}
+
+#[test]
+fn the_family_shares_partition_every_profiles_active_series_exactly() {
+    let workload = load_workload(workload_path()).expect("manifest loads");
+    assert_eq!(workload.families.len(), 5);
+    assert_eq!(workload.label_dimensions.len(), 5);
+
+    // The declared shares, in permille, summing to 1000.
+    let expected: &[(&str, FamilyKind, u64, usize)] = &[
+        ("metricsbench_gauge_cpu_percent", FamilyKind::Gauge, 400, 2),
+        ("metricsbench_requests_total", FamilyKind::Counter, 300, 3),
+        (
+            "metricsbench_request_duration_seconds",
+            FamilyKind::ClassicHistogram,
+            150,
+            1,
+        ),
+        (
+            "metricsbench_latency_native",
+            FamilyKind::NativeHistogram,
+            100,
+            1,
+        ),
+        ("metricsbench_build_info", FamilyKind::Gauge, 50, 2),
+    ];
+    for (i, (name, kind, permille, labels)) in expected.iter().enumerate() {
+        let f = &workload.families[i];
+        assert_eq!(&f.name, name);
+        assert_eq!(f.kind, *kind, "{name} kind");
+        assert_eq!(f.series_permille, *permille, "{name} share");
+        assert_eq!(f.labels.len(), *labels, "{name} label count");
+    }
+    assert_eq!(
+        workload
+            .families
+            .iter()
+            .map(|f| f.series_permille)
+            .sum::<u64>(),
+        1000
+    );
+
+    // Seven declared bounds plus +Inf, _sum and _count: ten series per classic
+    // histogram instance.
+    assert_eq!(
+        workload.series_per_instance(FamilyKind::ClassicHistogram),
+        10
+    );
+
+    // Per profile, the per-family series counts sum to exactly the profile's
+    // active-series count, and each divides into whole instances. Bounded
+    // against the profile's own figure rather than a flat floor.
+    for profile in &workload.profiles {
+        let mut total = 0u64;
+        for family in &workload.families {
+            let series = workload.family_series(profile, family);
+            let per_instance = workload.series_per_instance(family.kind);
+            assert_eq!(
+                series % per_instance,
+                0,
+                "family `{}` under `{}` does not divide into whole instances",
+                family.name,
+                profile.name
+            );
+            assert_eq!(
+                workload.family_instances(profile, family) * per_instance,
+                series
+            );
+            total += series;
+        }
+        assert_eq!(
+            total, profile.active_series,
+            "the family shares must partition profile `{}`'s active series",
+            profile.name
+        );
+    }
+}
+
+#[test]
+fn churn_figures_are_exact_per_profile_and_the_generator_agrees_with_the_profile() {
+    let workload = load_workload(workload_path()).expect("manifest loads");
+    let expected: &[(&str, u64, u64, u64)] = &[
+        // (profile, epochs, churned series per epoch, total series created)
+        ("cardinality", 2, 0, 1_000_000),
+        ("history", 720, 0, 10_000),
+        ("churn", 36, 10_000, 400_000),
+        ("ci", 1, 50, 1_000),
+    ];
+    for (name, epochs, churned, created) in expected {
+        let p = workload.profile(name).expect("profile present");
+        assert_eq!(p.churn_epochs(), *epochs, "{name} epochs");
+        assert_eq!(p.churned_series_per_epoch(), *churned, "{name} cohort");
+        assert_eq!(p.total_series_created(), *created, "{name} series created");
+
+        // The generator computes the same figure from its own per-family plans.
+        // Arithmetic only: nothing is generated here, so the 1.7 billion-sample
+        // profile costs nothing to check.
+        let generator = Generator::new(&workload, name, 0).expect("generator builds");
+        assert_eq!(
+            generator.total_series_created(p.samples_per_series),
+            *created,
+            "the generator's plans and profile `{name}`'s own arithmetic disagree"
+        );
+    }
+}
+
+#[test]
+fn every_corpus_entry_is_classed_and_the_classes_are_evenly_covered() {
+    let entries = load_corpus(corpus_path()).expect("corpus loads");
+    let counts = class_counts(&entries);
+    assert_eq!(counts.len(), 8, "eight cost classes");
+    for (class, n) in &counts {
+        assert_eq!(
+            *n,
+            ENTRIES_PER_CLASS,
+            "cost class `{}` holds {n} entries, expected {ENTRIES_PER_CLASS}",
+            class.slug()
+        );
+    }
+    assert_eq!(
+        counts.iter().map(|(_, n)| *n).sum::<usize>(),
+        CORPUS_SIZE,
+        "every entry is classed exactly once"
+    );
+
+    // Ids are unique (the gate proves it) and stable-looking: every entry is
+    // prefixed `mb_`, so a report row cannot be confused with a SQL corpus row.
+    let ids: BTreeSet<&str> = entries.iter().map(|e| e.id.as_str()).collect();
+    assert_eq!(ids.len(), CORPUS_SIZE);
+    for id in &ids {
+        assert!(id.starts_with("mb_"), "unexpected id shape: {id}");
+    }
+}
+
+#[test]
+fn the_corpus_splits_exactly_six_range_queries_from_eighteen_instant_ones() {
+    let entries = load_corpus(corpus_path()).expect("corpus loads");
+    let range = entries.iter().filter(|e| e.eval == EvalKind::Range).count();
+    let instant = entries
+        .iter()
+        .filter(|e| e.eval == EvalKind::Instant)
+        .count();
+    assert_eq!(range, 6);
+    assert_eq!(instant, 18);
+    assert_eq!(range + instant, CORPUS_SIZE);
+}
+
+#[test]
+fn only_the_long_range_entries_restrict_themselves_to_a_profile() {
+    let entries = load_corpus(corpus_path()).expect("corpus loads");
+    let restricted: Vec<&str> = entries
+        .iter()
+        .filter(|e| !e.profiles.is_empty())
+        .map(|e| e.id.as_str())
+        .collect();
+    // Exactly the three long-range entries: only `history` (30 days) and, for
+    // the 6-hour window, `churn` (36 hours) generate enough data for them.
+    assert_eq!(
+        restricted,
+        vec![
+            "mb_long_range_7d_avg",
+            "mb_long_range_subquery_max",
+            "mb_long_range_predict_linear"
+        ]
+    );
+    for entry in entries.iter().filter(|e| !e.profiles.is_empty()) {
+        assert_eq!(entry.class, Some(CostClass::LongRange), "{}", entry.id);
+        assert!(entry.runs_under("history"), "{}", entry.id);
+        assert!(!entry.runs_under("cardinality"), "{}", entry.id);
+    }
+
+    // Per profile, the exact number of entries that run.
+    let counted = |profile: &str| entries.iter().filter(|e| e.runs_under(profile)).count();
+    assert_eq!(counted("history"), 24);
+    assert_eq!(counted("churn"), 22);
+    assert_eq!(counted("cardinality"), 21);
+    assert_eq!(counted("ci"), 21);
+}
+
+#[test]
+fn every_named_construct_is_in_the_promql_registry_and_the_corpus_names_a_known_number_of_them() {
+    let entries = load_corpus(corpus_path()).expect("corpus loads");
+    let known = known_construct_names();
+    let named: BTreeSet<&str> = entries
+        .iter()
+        .flat_map(|e| e.constructs.iter().map(String::as_str))
+        .collect();
+    for construct in &named {
+        assert!(
+            known.contains(construct),
+            "construct `{construct}` is not in the PromQL conformance registry"
+        );
+    }
+    // The corpus is a workload sample, not a conformance suite: it names 34 of
+    // the registry's 133 constructs. Pinned exactly so adding an entry that
+    // names nothing new, or dropping the only entry that names a construct, is
+    // visible.
+    assert_eq!(named.len(), 34);
+    assert_eq!(known.len(), 133);
+
+    // Every entry names at least two constructs, so no entry passes the
+    // non-empty check on a single generic name.
+    for entry in &entries {
+        assert!(
+            entry.constructs.len() >= 2,
+            "entry `{}` names only {} construct(s)",
+            entry.id,
+            entry.constructs.len()
+        );
+    }
+}
+
+#[test]
+fn every_metric_and_label_literal_the_corpus_selects_exists_in_the_workload() {
+    let workload = load_workload(workload_path()).expect("manifest loads");
+    let entries = load_corpus(corpus_path()).expect("corpus loads");
+    let emitted = workload.emitted_metric_names();
+    // Five families: three suffixed series for the classic histogram, one name
+    // each for the other four.
+    assert_eq!(emitted.len(), 7);
+
+    let absent = &workload.generator.absent_metric_name;
+    let mut selected: BTreeSet<String> = BTreeSet::new();
+    for entry in &entries {
+        for word in entry
+            .promql
+            .split(|c: char| !c.is_ascii_alphanumeric() && c != '_')
+        {
+            if word.starts_with("metricsbench_") {
+                selected.insert(word.to_string());
+            }
+        }
+    }
+    for metric in &selected {
+        assert!(
+            metric == absent || emitted.contains(metric),
+            "corpus selects `{metric}`, which the workload does not emit"
+        );
+    }
+    // Every emitted metric except the two the corpus has no query for is
+    // actually selected; pinned as an exact set so a family added to the
+    // manifest without a query is visible.
+    let expected_selected: BTreeSet<String> = [
+        "metricsbench_absent_metric",
+        "metricsbench_build_info",
+        "metricsbench_gauge_cpu_percent",
+        "metricsbench_latency_native",
+        "metricsbench_request_duration_seconds_bucket",
+        "metricsbench_requests_total",
+    ]
+    .into_iter()
+    .map(String::from)
+    .collect();
+    assert_eq!(selected, expected_selected);
+
+    // Label literals the corpus selects on must be values the manifest
+    // declares, or every one of those queries matches nothing.
+    for (label, value) in [
+        ("job", "metricsbench-api"),
+        ("region", "eu-west-1"),
+        ("method", "GET"),
+        ("status", "200"),
+    ] {
+        let dim = workload.dimension(label).expect("dimension declared");
+        assert!(
+            dim.values.iter().any(|v| v == value),
+            "corpus selects {label}=\"{value}\", which the manifest does not declare"
+        );
+    }
+    assert_eq!(
+        workload.generator.scaling_label_value_prefix, "metricsbench-instance-",
+        "the single-series entries select an instance literal built from this prefix"
+    );
+}
+
+#[test]
+fn the_ci_profile_generates_its_exact_declared_sample_count() {
+    let workload = load_workload(workload_path()).expect("manifest loads");
+    let ci = workload.profile("ci").expect("ci profile");
+    let mut generator = Generator::new(&workload, "ci", 0).expect("generator builds");
+    let (bytes, report) = generator
+        .generate_bytes(ci.samples_per_series)
+        .expect("the ci profile generates");
+
+    assert_eq!(report.nominal_samples, ci.total_samples);
+    assert_eq!(report.nominal_samples, 120_000);
+    assert_eq!(
+        report.emitted_samples + report.omitted_missing_samples,
+        report.nominal_samples,
+        "generated must equal emitted plus explicitly reported omissions"
+    );
+    assert_eq!(report.active_series, 1_000);
+    assert_eq!(report.total_series_created, 1_000);
+    assert!(!report.publishable);
+    assert!(report.non_comparable_reason.is_some());
+
+    // One line per emitted sample, and the report's byte count is the stream's.
+    assert_eq!(
+        bytes.iter().filter(|b| **b == b'\n').count() as u64,
+        report.emitted_samples
+    );
+    assert_eq!(report.bytes, bytes.len() as u64);
+
+    // Native-histogram samples: exactly one per native instance per step. 100
+    // instances (100 permille of 1,000 series, one series each) over 120 steps,
+    // less those whose scrape was dropped. Bounded against the family's own
+    // nominal count rather than a flat floor.
+    let native_nominal = 100 * ci.samples_per_series;
+    assert!(
+        report.native_histogram_samples <= native_nominal,
+        "{} native samples exceeds the family's nominal {native_nominal}",
+        report.native_histogram_samples
+    );
+    assert_eq!(
+        report.float_samples + report.stale_markers + report.native_histogram_samples,
+        report.emitted_samples
+    );
+    // The injected anomalies all fired: a run that produced none of them would
+    // pass every count above while generating a workload the ADR does not
+    // describe.
+    assert!(report.stale_markers > 0, "no staleness markers");
+    assert!(report.omitted_missing_samples > 0, "no missing samples");
+    assert!(report.counter_reset_events > 0, "no counter resets");
+    assert!(report.out_of_order_samples > 0, "no out-of-order samples");
+}
+
+/// The `metricsbench_gen` binary, resolved the way an integration test can.
+fn bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_metricsbench_gen"))
+}
+
+fn run_bin(args: &[&str]) -> std::process::Output {
+    Command::new(bin())
+        .args(args)
+        .output()
+        .expect("spawn metricsbench_gen")
+}
+
+#[test]
+fn the_shipping_binary_gates_the_checked_in_artifacts_and_reports_exact_figures() {
+    let out = run_bin(&["--profile", "ci", "--steps", "20"]);
+    assert!(
+        out.status.success(),
+        "metricsbench_gen failed on the checked-in artifacts: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let document: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("the bin prints one JSON document");
+    assert_eq!(document["corpus"]["entries"], 24);
+    assert_eq!(document["corpus"]["entries_in_profile"], 21);
+    assert_eq!(document["workload"]["seed"], 927_000_933u64);
+    assert_eq!(document["workload"]["families"], 5);
+    assert_eq!(document["generation"]["profile"], "ci");
+    assert_eq!(document["generation"]["nominal_samples"], 20_000);
+    assert_eq!(document["generation"]["publishable"], false);
+    assert_eq!(document["run"]["covers_whole_profile"], false);
+    let classes = document["corpus"]["cost_classes"]
+        .as_array()
+        .expect("cost class table");
+    assert_eq!(classes.len(), 8);
+    for row in classes {
+        assert_eq!(row["entries"], 3, "class row {row}");
+    }
+}
+
+#[test]
+fn the_binary_refuses_to_publish_a_non_comparable_profile_or_a_truncated_run() {
+    // The `ci` profile carries its refusal in the artifact, and the binary acts
+    // on that field rather than on a hardcoded profile name.
+    let out = run_bin(&["--profile", "ci", "--steps", "5", "--require-comparable"]);
+    assert!(!out.status.success(), "a non-comparable profile must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("not comparable") && stderr.contains("ADR-0927"),
+        "the refusal must quote the artifact's reason: {stderr}"
+    );
+
+    // A comparable profile still refuses when the run does not cover it.
+    let out = run_bin(&[
+        "--profile",
+        "cardinality",
+        "--steps",
+        "1",
+        "--require-comparable",
+    ]);
+    assert!(!out.status.success(), "a truncated run must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("1 of profile `cardinality`'s 360 steps"),
+        "the refusal must name both step counts: {stderr}"
+    );
+}
+
+/// Copy the checked-in corpus with one JSON mutation applied, so the corruption
+/// is the only difference from an artifact that passes.
+fn corrupt_corpus(
+    dir: &tempfile::TempDir,
+    name: &str,
+    mutate: impl Fn(&mut serde_json::Value),
+) -> PathBuf {
+    let text = std::fs::read_to_string(corpus_path()).expect("read the real corpus");
+    let mut doc: serde_json::Value = serde_json::from_str(&text).expect("the real corpus is JSON");
+    mutate(&mut doc);
+    let path = dir.path().join(name);
+    std::fs::write(&path, doc.to_string()).expect("write the corrupt corpus");
+    path
+}
+
+#[test]
+fn a_corrupt_corpus_fails_through_the_binary_not_only_through_gate_corpus() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let workload = workload_path();
+    let workload = workload.to_str().expect("utf8 path").to_string();
+
+    // 1. An unclassified entry in an otherwise classed corpus: the acceptance
+    //    test's check, reached through the shipping binary.
+    let path = corrupt_corpus(&dir, "unclassified.json", |doc| {
+        doc["entries"][3]
+            .as_object_mut()
+            .expect("entry object")
+            .remove("class");
+    });
+    let out = run_bin(&[
+        "--workload",
+        &workload,
+        "--corpus",
+        path.to_str().expect("utf8 path"),
+        "--profile",
+        "ci",
+        "--steps",
+        "1",
+    ]);
+    assert!(!out.status.success(), "an unclassified entry must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("mb_single_gauge_instant") && stderr.contains("no cost class"),
+        "the binary must name the unclassified entry: {stderr}"
+    );
+
+    // 2. A construct the registry does not carry.
+    let path = corrupt_corpus(&dir, "unknown_construct.json", |doc| {
+        doc["entries"][0]["constructs"][1] = serde_json::json!("absent_over_tyme");
+    });
+    let out = run_bin(&[
+        "--workload",
+        &workload,
+        "--corpus",
+        path.to_str().expect("utf8 path"),
+        "--profile",
+        "ci",
+        "--steps",
+        "1",
+    ]);
+    assert!(!out.status.success(), "an unknown construct must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("absent_over_tyme") && stderr.contains("REGISTRY"),
+        "the binary must name the unknown construct: {stderr}"
+    );
+
+    // 3. A misspelled KEY, which a typed class enum alone cannot catch.
+    let path = corrupt_corpus(&dir, "typo_key.json", |doc| {
+        let entry = doc["entries"][0].as_object_mut().expect("entry object");
+        let class = entry.remove("class").expect("class present");
+        entry.insert("clas".to_string(), class);
+    });
+    let out = run_bin(&[
+        "--workload",
+        &workload,
+        "--corpus",
+        path.to_str().expect("utf8 path"),
+        "--profile",
+        "ci",
+        "--steps",
+        "1",
+    ]);
+    assert!(!out.status.success(), "a misspelled class key must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("clas"),
+        "the binary must name the offending field: {stderr}"
+    );
+
+    // 4. A duplicate id.
+    let path = corrupt_corpus(&dir, "duplicate.json", |doc| {
+        let first = doc["entries"][0].clone();
+        doc["entries"]
+            .as_array_mut()
+            .expect("entry list")
+            .push(first);
+    });
+    let out = run_bin(&[
+        "--workload",
+        &workload,
+        "--corpus",
+        path.to_str().expect("utf8 path"),
+        "--profile",
+        "ci",
+        "--steps",
+        "1",
+    ]);
+    assert!(!out.status.success(), "a duplicate id must fail");
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("appears more than once"),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // 5. A query selecting a metric the workload does not emit. This one is not
+    //    a corpus-gate check at all: it is the band the binary adds on top, and
+    //    it is only reachable through the binary.
+    let path = corrupt_corpus(&dir, "unknown_metric.json", |doc| {
+        doc["entries"][9]["promql"] = serde_json::json!("sum(rate(metricsbench_ghost_total[5m]))");
+    });
+    let out = run_bin(&[
+        "--workload",
+        &workload,
+        "--corpus",
+        path.to_str().expect("utf8 path"),
+        "--profile",
+        "ci",
+        "--steps",
+        "1",
+    ]);
+    assert!(!out.status.success(), "an unknown metric must fail");
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("metricsbench_ghost_total"),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn a_corrupt_workload_manifest_fails_through_the_binary() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let text = std::fs::read_to_string(workload_path()).expect("read the real manifest");
+    let mut doc: serde_json::Value =
+        serde_json::from_str(&text).expect("the real manifest is JSON");
+    // Promote the ci profile to comparable: the exact edit ADR-0927 decision 11
+    // forbids, and the one a reader would make to publish a CI number.
+    doc["profiles"][3]["comparability"] = serde_json::json!("comparable");
+    let path = dir.path().join("comparable_ci.json");
+    std::fs::write(&path, doc.to_string()).expect("write the corrupt manifest");
+
+    let out = run_bin(&[
+        "--workload",
+        path.to_str().expect("utf8 path"),
+        "--profile",
+        "ci",
+        "--steps",
+        "1",
+    ]);
+    assert!(!out.status.success(), "a comparable ci profile must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("refuse to publish"),
+        "the binary must refuse a manifest that promotes ci: {stderr}"
+    );
+}
+
+#[test]
+fn the_binary_refuses_an_unknown_profile_rather_than_defaulting() {
+    let out = run_bin(&["--profile", "smoke", "--steps", "1"]);
+    assert!(!out.status.success(), "an unknown profile must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("declares no profile `smoke`"), "{stderr}");
+
+    // And `--profile` has no default at all: the choice selects which data the
+    // run touches, so it cannot be silent.
+    let out = run_bin(&["--steps", "1"]);
+    assert!(!out.status.success(), "a missing --profile must fail");
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("--profile"),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn the_binary_writes_the_same_stream_twice_for_the_same_seed() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let first = dir.path().join("first.stream");
+    let second = dir.path().join("second.stream");
+    let digest = |out: &std::process::Output| -> String {
+        let document: serde_json::Value =
+            serde_json::from_slice(&out.stdout).expect("JSON document");
+        document["generation"]["digest"]
+            .as_str()
+            .expect("digest field")
+            .to_string()
+    };
+
+    let a = run_bin(&[
+        "--profile",
+        "ci",
+        "--steps",
+        "10",
+        "--base-ts-ms",
+        "1700000000000",
+        "--out",
+        first.to_str().expect("utf8 path"),
+    ]);
+    assert!(a.status.success(), "{}", String::from_utf8_lossy(&a.stderr));
+    let b = run_bin(&[
+        "--profile",
+        "ci",
+        "--steps",
+        "10",
+        "--base-ts-ms",
+        "1700000000000",
+        "--out",
+        second.to_str().expect("utf8 path"),
+    ]);
+    assert!(b.status.success(), "{}", String::from_utf8_lossy(&b.stderr));
+
+    let first_bytes = std::fs::read(&first).expect("read first stream");
+    let second_bytes = std::fs::read(&second).expect("read second stream");
+    assert_eq!(
+        first_bytes, second_bytes,
+        "the shipping binary must write byte-identical output for one seed"
+    );
+    assert_eq!(digest(&a), digest(&b));
+    assert!(!first_bytes.is_empty());
+    // 10 steps over 1,000 active series, less the dropped scrapes.
+    let lines = first_bytes.iter().filter(|b| **b == b'\n').count();
+    assert!(
+        lines <= 10_000 && lines > 9_000,
+        "{lines} lines is outside the 10-step nominal 10,000 less its dropped scrapes"
+    );
+
+    // A different base timestamp is a different stream, so the equality above
+    // is not a stream that ignores its inputs.
+    let shifted = dir.path().join("shifted.stream");
+    let c = run_bin(&[
+        "--profile",
+        "ci",
+        "--steps",
+        "10",
+        "--base-ts-ms",
+        "1700000015000",
+        "--out",
+        shifted.to_str().expect("utf8 path"),
+    ]);
+    assert!(c.status.success(), "{}", String::from_utf8_lossy(&c.stderr));
+    assert_ne!(
+        std::fs::read(&shifted).expect("read shifted stream"),
+        first_bytes
+    );
+}

--- a/crates/ravel-bench/tests/metricsbench_artifacts.rs
+++ b/crates/ravel-bench/tests/metricsbench_artifacts.rs
@@ -62,7 +62,7 @@ fn the_manifest_declares_exactly_the_four_adr_0927_profiles_with_their_exact_fig
         ("cardinality", 1_000_000, 360, 15, 5_400, 0, 360_000_000),
         ("history", 10_000, 172_800, 15, 2_592_000, 0, 1_728_000_000),
         ("churn", 50_000, 8_640, 15, 129_600, 2_000, 432_000_000),
-        ("ci", 1_000, 120, 15, 1_800, 500, 120_000),
+        ("ci", 1_000, 120, 15, 1_800, 0, 120_000),
     ];
     for (name, active, samples, scrape, duration, churn_bp, total) in expected {
         let p = workload.profile(name).expect("profile present");
@@ -197,7 +197,7 @@ fn churn_figures_are_exact_per_profile_and_the_generator_agrees_with_the_profile
         ("cardinality", 2, 0, 1_000_000),
         ("history", 720, 0, 10_000),
         ("churn", 36, 10_000, 400_000),
-        ("ci", 1, 50, 1_000),
+        ("ci", 1, 0, 1_000),
     ];
     for (name, epochs, churned, created) in expected {
         let p = workload.profile(name).expect("profile present");
@@ -214,6 +214,76 @@ fn churn_figures_are_exact_per_profile_and_the_generator_agrees_with_the_profile
             *created,
             "the generator's plans and profile `{name}`'s own arithmetic disagree"
         );
+    }
+}
+
+#[test]
+fn every_declared_anomaly_rate_is_actually_delivered_by_the_run() {
+    // A declared anomaly rate that the run never realizes is an inert claim: the
+    // ci profile once declared 500 bp of churn over a 30-minute run that spans
+    // one churn epoch, so `churn_epochs()` was 1, no cohort was ever retired,
+    // and the profile claimed coverage it could not deliver. This pins declared
+    // == delivered for churn (arithmetic over every profile) and for every
+    // generator-level anomaly rate (a full ci run).
+    let workload = load_workload(workload_path()).expect("manifest loads");
+
+    // Churn: a nonzero rate must retire at least one cohort over the profile's
+    // own duration, and a zero rate must retire none.
+    for p in &workload.profiles {
+        let declares_churn = p.churn_basis_points_per_hour > 0;
+        let delivers_churn = p.total_series_created() > p.active_series;
+        assert_eq!(
+            declares_churn,
+            delivers_churn,
+            "profile `{}` declares {} bp of churn but {} retire a cohort: a nonzero rate over a \
+             run that never crosses an epoch boundary is an inert anomaly",
+            p.name,
+            p.churn_basis_points_per_hour,
+            if delivers_churn { "does" } else { "does not" }
+        );
+    }
+
+    // Every generator anomaly rate: a nonzero rate delivers events on the full
+    // ci run, a zero rate delivers none.
+    let ci = workload.profile("ci").expect("ci profile");
+    let mut generator = Generator::new(&workload, "ci", 0).expect("generator builds");
+    let (_, report) = generator
+        .generate_bytes(ci.samples_per_series)
+        .expect("the ci profile generates");
+    let anomalies = workload.generator.anomalies;
+    for (label, rate, delivered) in [
+        (
+            "missing samples",
+            anomalies.missing_sample_one_in,
+            report.omitted_missing_samples,
+        ),
+        (
+            "stale markers",
+            anomalies.stale_marker_one_in,
+            report.stale_markers,
+        ),
+        (
+            "counter resets",
+            anomalies.counter_reset_one_in,
+            report.counter_reset_events,
+        ),
+        (
+            "out-of-order samples",
+            anomalies.out_of_order_one_in,
+            report.out_of_order_samples,
+        ),
+    ] {
+        if rate > 0 {
+            assert!(
+                delivered > 0,
+                "{label}: rate one-in-{rate} is declared but the run delivered none"
+            );
+        } else {
+            assert_eq!(
+                delivered, 0,
+                "{label}: rate is 0 but the run delivered {delivered}"
+            );
+        }
     }
 }
 
@@ -304,12 +374,22 @@ fn every_named_construct_is_in_the_promql_registry_and_the_corpus_names_a_known_
             "construct `{construct}` is not in the PromQL conformance registry"
         );
     }
-    // The corpus is a workload sample, not a conformance suite: it names 34 of
-    // the registry's 133 constructs. Pinned exactly so adding an entry that
+    // The corpus is a workload sample, not a conformance suite. It owns how many
+    // distinct constructs it names (34, pinned exactly so adding an entry that
     // names nothing new, or dropping the only entry that names a construct, is
-    // visible.
+    // visible), and the relationship that every construct it names is a member
+    // of the registry. It does NOT own the registry's own size: a construct
+    // added to `ravel_promql_difftest::REGISTRY` is a change to that crate, not
+    // to this corpus, and must not fail a MetricsBench artifact test.
     assert_eq!(named.len(), 34);
-    assert_eq!(known.len(), 133);
+    assert!(
+        named.is_subset(&known),
+        "every construct the corpus names must be in the PromQL registry"
+    );
+    assert!(
+        named.len() <= known.len(),
+        "the corpus cannot name more distinct constructs than the registry carries"
+    );
 
     // Every entry names at least two constructs, so no entry passes the
     // non-empty check on a single generic name.
@@ -439,10 +519,11 @@ fn the_ci_profile_generates_its_exact_declared_sample_count() {
     let steps = ci.samples_per_series;
     // Instances scraped per step, from the family shares of the 1,000 active
     // series: 400 cpu gauge, 300 counter, 15 classic histogram (10 series
-    // each), 100 native, 50 build_info gauge. Staleness applies to gauges only
-    // and resets to counters and classic histograms only.
+    // each), 100 native, 50 build_info gauge. Staleness applies to gauges only;
+    // resets apply to counters, classic histograms and native histograms, which
+    // all carry counter semantics.
     let gauge_scrapes = 450 * steps;
-    let counter_scrapes = (300 + 15) * steps;
+    let counter_scrapes = (300 + 15 + 100) * steps;
     let instance_scrapes = 865 * steps;
     // The omission and out-of-order figures count series rather than instances,
     // so their nominals are instance-rate approximations; a factor of two
@@ -479,7 +560,7 @@ fn the_ci_profile_generates_its_exact_declared_sample_count() {
     // The exact figures this seed produces.
     assert_eq!(report.stale_markers, 62, "staleness markers");
     assert_eq!(report.omitted_missing_samples, 225, "missing samples");
-    assert_eq!(report.counter_reset_events, 34, "counter resets");
+    assert_eq!(report.counter_reset_events, 43, "counter resets");
     assert_eq!(report.out_of_order_samples, 182, "out-of-order samples");
 }
 


### PR DESCRIPTION
MetricsBench needs a workload and query corpus that a later run can be checked
against, so this adds the versioned artifacts under benchmarks/metrics/ and the
generator and corpus gate in ravel-bench, following the ClickBench corpus
contract rather than inventing a second one.

The corpus artifact is CorpusFile-shaped: a version, deny_unknown_fields,
stable ids, and a gate whose five ordered checks are all-or-none
classification, unique ids, a non-empty construct list, a non-blank
modification reason, and every construct known to the registry. Constructs are
checked against ravel-promql-difftest's REGISTRY, which is a new dependency
edge from ravel-bench; the SQL corpus gets its registry for free through
ravel-sql, the PromQL one does not.

Every query carries a typed cost class rather than a comment, so a query whose
class is missing or misspelled fails the gate instead of being silently
counted. Both halves of that hole are closed separately: a typed class catches
a bad value, deny_unknown_fields catches a bad key, and a corpus where every
entry carries the same typo would otherwise pass a class gate by having nothing
left to check.

The generator is deterministic on a fixed seed and produces gauges, monotonic
counters, classic and native histograms, staleness markers, counter resets,
missing samples, out-of-order samples, and controlled churn, across the four
ADR-0927 profiles. The ci profile is marked non-comparable in the artifact
itself, not only in prose, so a reader that loads it can refuse to publish it
as a result.

The second commit pins the injected anomaly counts. They were first asserted
with `> 0`, which proves one marker fired rather than that the anomalies fired
at their designed rate: a generator emitting a single staleness marker where
the profile designs for dozens would pass. Each now carries both an exact value
and a check against the nominal count its own one-in rate implies, so a rate
constant that stops tracking the design is visible as more than a changed
number. The determinism test's non-empty guard is deliberately left as is; it
stops the byte-identity comparison passing on two empty outputs.

Fixes: #933
Refs: #927
