### PR TITLE
feat(query): render the per-phase query cost split in stats JSON

### DIFF
--- a/crates/ravel-query/src/http/json.rs
+++ b/crates/ravel-query/src/http/json.rs
@@ -942,6 +942,306 @@ mod tests {
         );
     }
 
+    /// A `QueryStats` whose four phase handles carry a distinct, exactly known
+    /// figure in every counter `stats.phases` renders, so a test can name the
+    /// expected number per phase per field and a swapped or pooled phase is a
+    /// failing assertion rather than a plausible-looking total.
+    ///
+    /// Each phase gets its own value for every field, and no two phases share
+    /// a value in the same field, so an off-by-one in `QueryPhase::index` or a
+    /// mis-wired `snapshot.phase(..)` lookup cannot pass.
+    fn stats_with_distinct_phase_counters() -> crate::QueryStats {
+        use crate::phase_accounting::PhaseAccounting;
+        use ravel_types::accounting::AccountedOp;
+
+        let phases = PhaseAccounting::new();
+
+        // resolve: catalog LISTs and commit-record GETs.
+        for _ in 0..3 {
+            phases.resolve().record_s3_request(AccountedOp::Get);
+        }
+        phases.resolve().add_s3_bytes(AccountedOp::Get, 1_000);
+        for _ in 0..2 {
+            phases.resolve().record_s3_request(AccountedOp::List);
+        }
+        phases.resolve().record_cache_hit();
+        for _ in 0..2 {
+            phases.resolve().record_cache_miss();
+        }
+        phases.resolve().add_cache_bytes(11);
+
+        // plan: footer and skip-index probes.
+        for _ in 0..5 {
+            phases.plan().record_s3_request(AccountedOp::Get);
+        }
+        phases.plan().add_s3_bytes(AccountedOp::Get, 2_000);
+        for _ in 0..3 {
+            phases.plan().record_cache_hit();
+        }
+        for _ in 0..4 {
+            phases.plan().record_cache_miss();
+        }
+        phases.plan().add_cache_bytes(22);
+        phases.plan().add_segments_opened(6);
+
+        // probe: segment catalog fetch.
+        for _ in 0..7 {
+            phases.probe().record_s3_request(AccountedOp::Get);
+        }
+        phases.probe().add_s3_bytes(AccountedOp::Get, 4_000);
+        for _ in 0..8 {
+            phases.probe().record_cache_hit();
+        }
+        for _ in 0..9 {
+            phases.probe().record_cache_miss();
+        }
+        phases.probe().add_cache_bytes(33);
+        phases.probe().add_series_matched(12);
+
+        // scan: block and page data reads, plus decode's own byte figures.
+        for _ in 0..11 {
+            phases.scan().record_s3_request(AccountedOp::Get);
+        }
+        phases.scan().add_s3_bytes(AccountedOp::Get, 8_000);
+        for _ in 0..13 {
+            phases.scan().record_cache_hit();
+        }
+        for _ in 0..14 {
+            phases.scan().record_cache_miss();
+        }
+        phases.scan().add_cache_bytes(44);
+        phases.scan().add_decompressed_bytes(5_000);
+        phases.scan().add_bytes_reused(640);
+        phases.scan().add_segments_opened(15);
+        phases.scan().add_series_matched(16);
+
+        let snapshot = phases.snapshot();
+        crate::QueryStats {
+            // `accounting` is the pooled sum in production
+            // (`QueryStats::new`); keep that relationship here so the
+            // sums-back-to-pooled assertions test the renderer, not a
+            // hand-built inconsistency.
+            accounting: snapshot.pooled(),
+            phase_accounting: snapshot,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn phase_accounting_renders_all_four_phases_exactly_once() {
+        // ACCEPTANCE TEST (issue #935). `PhaseAccounting` splits every
+        // `QueryAccounting` counter four ways on every PromQL query, and until
+        // this field existed the split reached no reader outside the engine's
+        // own unit tests. This pins the rendered shape: the exact phase names,
+        // in `QueryPhase::ALL` order, each appearing exactly once, with every
+        // figure at its exact expected value.
+        //
+        // Flip-line proof: in `phase_costs`, change `QueryPhase::ALL.iter()` to
+        // `QueryPhase::ALL.iter().take(3)` and the count/name assertions fail;
+        // hand the mapping `snapshot.phase(QueryPhase::Resolve)` instead of
+        // `snapshot.phase(*phase)` and the per-phase value assertions fail.
+        let json = QueryStatsJson::from(stats_with_distinct_phase_counters());
+        let value = serde_json::to_value(&json).expect("serializes");
+
+        let phases = value["phases"].as_array().expect("phases is an array");
+        assert_eq!(phases.len(), 4, "four phases, no more and no fewer");
+
+        // The exact names, in order. Not a set comparison: the order is
+        // `QueryPhase::ALL`'s, and a report that pairs a phase name with the
+        // wrong row is exactly what an unordered check would miss.
+        let names: Vec<&str> = phases
+            .iter()
+            .map(|p| p["phase"].as_str().expect("phase name is a string"))
+            .collect();
+        assert_eq!(names, vec!["resolve", "plan", "probe", "scan"]);
+
+        // Each name appears exactly once. A figure emitted twice is as much a
+        // defect as one emitted wrong: a consumer summing the array would
+        // double-count that phase.
+        for want in ["resolve", "plan", "probe", "scan"] {
+            assert_eq!(
+                names.iter().filter(|n| **n == want).count(),
+                1,
+                "phase {want} must appear exactly once"
+            );
+        }
+
+        // Every figure, per phase, at its exact expected value.
+        let expected: [(&str, u64, u64, u64, u64, u64, u64, u64, u64, u64, u64); 4] = [
+            // phase, gets, wire bytes, lists, hits, misses, cache bytes,
+            // decompressed, reused, opened, matched
+            ("resolve", 3, 1_000, 2, 1, 2, 11, 0, 0, 0, 0),
+            ("plan", 5, 2_000, 0, 3, 4, 22, 0, 0, 6, 0),
+            ("probe", 7, 4_000, 0, 8, 9, 33, 0, 0, 0, 12),
+            ("scan", 11, 8_000, 0, 13, 14, 44, 5_000, 640, 15, 16),
+        ];
+        for (i, want) in expected.iter().enumerate() {
+            let got = &phases[i];
+            let (
+                name,
+                gets,
+                wire_bytes,
+                lists,
+                hits,
+                misses,
+                cache_bytes,
+                decompressed,
+                reused,
+                opened,
+                matched,
+            ) = *want;
+            assert_eq!(got["phase"], name);
+            assert_eq!(got["s3GetRequests"], gets, "{name} s3GetRequests");
+            assert_eq!(got["s3GetWireBytes"], wire_bytes, "{name} s3GetWireBytes");
+            assert_eq!(got["s3ListRequests"], lists, "{name} s3ListRequests");
+            assert_eq!(got["cacheHits"], hits, "{name} cacheHits");
+            assert_eq!(got["cacheMisses"], misses, "{name} cacheMisses");
+            assert_eq!(
+                got["cacheServedBytes"], cache_bytes,
+                "{name} cacheServedBytes"
+            );
+            assert_eq!(
+                got["decompressedOutputBytes"], decompressed,
+                "{name} decompressedOutputBytes"
+            );
+            assert_eq!(got["reusedRegionBytes"], reused, "{name} reusedRegionBytes");
+            assert_eq!(got["segmentsOpened"], opened, "{name} segmentsOpened");
+            assert_eq!(got["seriesMatched"], matched, "{name} seriesMatched");
+        }
+    }
+
+    #[test]
+    fn phase_figures_sum_back_to_the_pooled_accounting_block() {
+        // The split is additive to `stats.accounting`, not a replacement: a
+        // consumer reading only the pooled block sees the same numbers as
+        // before `phases` existed. Asserted as exact equality per counter, so a
+        // phase whose bytes land nowhere (or twice) fails here even if the
+        // per-phase assertions above pass.
+        let json = QueryStatsJson::from(stats_with_distinct_phase_counters());
+        let value = serde_json::to_value(&json).expect("serializes");
+        let phases = value["phases"].as_array().expect("phases is an array");
+
+        let sum = |field: &str| -> u64 {
+            phases
+                .iter()
+                .map(|p| p[field].as_u64().expect("figure is an unsigned integer"))
+                .sum()
+        };
+
+        assert_eq!(sum("s3GetRequests"), 3 + 5 + 7 + 11);
+        assert_eq!(value["accounting"]["s3GetRequests"], 26);
+        assert_eq!(sum("s3GetWireBytes"), 1_000 + 2_000 + 4_000 + 8_000);
+        assert_eq!(value["accounting"]["s3GetBytes"], 15_000);
+        assert_eq!(sum("s3ListRequests"), 2);
+        assert_eq!(value["accounting"]["s3ListRequests"], 2);
+        assert_eq!(sum("cacheHits"), 1 + 3 + 8 + 13);
+        assert_eq!(value["accounting"]["cacheHits"], 25);
+        assert_eq!(sum("cacheMisses"), 2 + 4 + 9 + 14);
+        assert_eq!(value["accounting"]["cacheMisses"], 29);
+        assert_eq!(sum("cacheServedBytes"), 11 + 22 + 33 + 44);
+        assert_eq!(value["accounting"]["cacheBytes"], 110);
+        assert_eq!(sum("decompressedOutputBytes"), 5_000);
+        assert_eq!(value["accounting"]["decompressedBytes"], 5_000);
+        assert_eq!(sum("reusedRegionBytes"), 640);
+        assert_eq!(value["accounting"]["bytesReused"], 640);
+        assert_eq!(sum("segmentsOpened"), 6 + 15);
+        assert_eq!(value["accounting"]["segmentsOpened"], 21);
+        assert_eq!(sum("seriesMatched"), 12 + 16);
+        assert_eq!(value["accounting"]["seriesMatched"], 28);
+    }
+
+    #[test]
+    fn phases_render_every_phase_queryphase_all_names() {
+        // The enforcement for "a phase added to `QueryPhase::ALL` cannot be
+        // silently dropped": the renderer iterates `ALL`, and this test derives
+        // its expectation from `ALL` too, so a fifth variant added to the enum
+        // and to `ALL` must appear in the response or this fails. A test that
+        // hard-coded four names could not tell a dropped fifth phase from a
+        // correct render.
+        use crate::phase_accounting::QueryPhase;
+
+        let json = QueryStatsJson::from(crate::QueryStats::default());
+        let value = serde_json::to_value(&json).expect("serializes");
+        let phases = value["phases"].as_array().expect("phases is an array");
+
+        assert_eq!(
+            phases.len(),
+            QueryPhase::ALL.len(),
+            "one rendered entry per QueryPhase::ALL variant"
+        );
+        let names: Vec<&str> = phases
+            .iter()
+            .map(|p| p["phase"].as_str().expect("phase name is a string"))
+            .collect();
+        let want: Vec<&str> = QueryPhase::ALL.iter().map(|p| p.name()).collect();
+        assert_eq!(names, want, "rendered names are QueryPhase::ALL, in order");
+    }
+
+    #[test]
+    fn phases_carry_no_field_for_a_structurally_dead_counter() {
+        // ADR-0927 decision 7: `AccountedOp::Head`, `s3_bytes[List]`,
+        // `segments_pruned`, and `peak_intermediate_bytes` are never recorded
+        // on a PromQL query. A per-phase zero for one of them would read as a
+        // measurement, so the per-phase block has no field for it. The pooled
+        // `accounting` block keeps its own pre-existing fields untouched, which
+        // the second half of this test pins.
+        let json = QueryStatsJson::from(stats_with_distinct_phase_counters());
+        let value = serde_json::to_value(&json).expect("serializes");
+
+        for phase in value["phases"].as_array().expect("phases is an array") {
+            for dead in [
+                "s3HeadRequests",
+                "s3HeadBytes",
+                "s3ListBytes",
+                "peakIntermediateBytes",
+                "segmentsPruned",
+            ] {
+                assert!(
+                    phase.get(dead).is_none(),
+                    "per-phase block must not render the dead counter {dead}"
+                );
+            }
+        }
+
+        // The pooled block is unchanged: every field it rendered before this
+        // change is still there, dead ones included.
+        for kept in [
+            "s3GetRequests",
+            "s3GetBytes",
+            "s3ListRequests",
+            "s3ListBytes",
+            "s3HeadRequests",
+            "s3HeadBytes",
+            "cacheHits",
+            "cacheMisses",
+            "cacheBytes",
+            "decompressedBytes",
+            "segmentsOpened",
+            "seriesMatched",
+            "bytesReused",
+            "peakIntermediateBytes",
+            "rawF64Pages",
+            "rawF64Bytes",
+        ] {
+            assert!(
+                value["accounting"].get(kept).is_some(),
+                "pooled accounting field {kept} must not be removed"
+            );
+        }
+        assert!(
+            value.get("segmentsFetched").is_some(),
+            "segmentsFetched must not be removed"
+        );
+        assert!(
+            value.get("segmentsPruned").is_some(),
+            "segmentsPruned must not be removed"
+        );
+        assert!(
+            value.get("estimate").is_some(),
+            "estimate must not be removed"
+        );
+    }
+
     #[test]
     fn instant_vector_renders_native_histogram_element() {
         // A native-histogram vector element renders under Prometheus'

--- a/crates/ravel-query/src/http/json.rs
+++ b/crates/ravel-query/src/http/json.rs
@@ -8,6 +8,7 @@ use ravel_types::{LabelSet, SeriesId};
 use serde::{Serialize, Serializer};
 
 use crate::http::error::ApiError;
+use crate::phase_accounting::{PhaseAccountingSnapshot, QueryPhase};
 
 #[derive(Serialize)]
 #[serde(tag = "status")]
@@ -98,6 +99,20 @@ pub struct QueryStatsJson {
     #[serde(rename = "segmentsPruned")]
     pub segments_pruned: u64,
     pub accounting: QueryAccountingJson,
+    /// The same GETs and bytes `accounting` pools, split across the four
+    /// phases of a query's object-store cost (issue #935, ADR-0927 decision 7;
+    /// the split itself is issue #796's `PhaseAccounting`, which until now
+    /// reached no reader outside the engine's own unit tests). One entry per
+    /// [`QueryPhase`], in [`QueryPhase::ALL`] order, each phase exactly once:
+    /// `resolve`, `plan`, `probe`, `scan`.
+    ///
+    /// Additive to `accounting`, never a replacement: every per-phase counter
+    /// here sums back to its pooled counterpart there, so a consumer reading
+    /// only `accounting` sees exactly the numbers it saw before this field
+    /// existed. The phases are what make a cost attributable -- a pooled GET
+    /// count cannot say whether a query spent its requests resolving the
+    /// catalog snapshot or scanning pages.
+    pub phases: Vec<PhaseCostJson>,
     pub estimate: CostEstimateJson,
     /// True when at least one federated remote cluster was skipped because it
     /// was unavailable and its `skip_unavailable` opt-in was set
@@ -121,6 +136,7 @@ impl From<crate::QueryStats> for QueryStatsJson {
             segments_fetched: stats.segments_fetched,
             segments_pruned: stats.segments_pruned,
             accounting: QueryAccountingJson::from_snapshot(&stats.accounting, &stats.page_stats),
+            phases: phase_costs(&stats.phase_accounting),
             estimate: stats.estimate.into(),
             partial: stats.partial,
             warnings: stats.warnings.clone(),
@@ -200,6 +216,121 @@ impl QueryAccountingJson {
             raw_f64_bytes: page_stats.raw_f64_bytes,
         }
     }
+}
+
+/// One [`QueryPhase`]'s share of a query's cost, rendered as one element of
+/// `stats.phases` (issue #935).
+///
+/// # Which bytes each byte figure counts
+///
+/// Every byte field names its own kind, because figures of different kinds
+/// cannot be compared with each other or summed together: wire bytes are what
+/// the network moved, cache-served bytes never crossed the wire at all, and
+/// decompressed bytes are a decode-time output size that no request paid for.
+/// Each field's doc comment below names its kind, whether retries and range
+/// reads are included, and its pooled counterpart under `stats.accounting`.
+///
+/// # Which counters are here, and which are deliberately absent
+///
+/// `stats.accounting` renders four counters this per-phase block does not,
+/// because they are structurally dead on a PromQL query and a per-phase zero
+/// would read as a measurement rather than as an absence (ADR-0927 decision
+/// 7): `s3HeadRequests`/`s3HeadBytes` (`AccountedOp::Head` is recorded
+/// nowhere on this path), `s3ListBytes` (`Catalog::guarded_list_all` counts
+/// the LIST request but no bytes for it), and `peakIntermediateBytes` (SQL
+/// executor only). They keep their pooled fields; they gain no phase fields.
+#[derive(Debug, Serialize)]
+pub struct PhaseCostJson {
+    /// The phase, as [`QueryPhase::name`] spells it: `resolve` (catalog
+    /// snapshot resolve), `plan` (footer and skip-index probing to build a
+    /// fetch plan), `probe` (segment catalog fetch), or `scan` (block, page,
+    /// and chunk data reads). See `crate::phase_accounting`'s module docs for
+    /// the full phase boundaries.
+    pub phase: &'static str,
+    /// GET requests this phase issued. A LOGICAL call count, not a billed
+    /// request count: `object_store` retries beneath `InstrumentedStore`, so
+    /// one GET that retried nine times counts once here while S3 bills ten
+    /// (ADR-0927 decision 8). Pooled counterpart: `accounting.s3GetRequests`.
+    #[serde(rename = "s3GetRequests")]
+    pub s3_get_requests: u64,
+    /// WIRE bytes this phase's GETs transferred: the byte length of each
+    /// successful response body, summed. Range reads are included and count
+    /// only the bytes their range returned; a coalesced run's unwanted
+    /// in-between bytes are included, because the wire carried them. A retried
+    /// GET's failed attempts are NOT included -- the counter is written once,
+    /// from the response that succeeded. Never stored bytes, never
+    /// decompressed bytes, never cache-served bytes. Pooled counterpart:
+    /// `accounting.s3GetBytes`.
+    #[serde(rename = "s3GetWireBytes")]
+    pub s3_get_wire_bytes: u64,
+    /// LIST requests this phase issued, on the same logical-call basis as
+    /// [`Self::s3_get_requests`]. Pooled counterpart:
+    /// `accounting.s3ListRequests`. There is deliberately no per-phase LIST
+    /// byte figure: nothing records LIST bytes.
+    #[serde(rename = "s3ListRequests")]
+    pub s3_list_requests: u64,
+    /// In-process cache lookups this phase served from cache.
+    #[serde(rename = "cacheHits")]
+    pub cache_hits: u64,
+    /// In-process cache lookups this phase had to fetch.
+    #[serde(rename = "cacheMisses")]
+    pub cache_misses: u64,
+    /// Bytes this phase's cache hits served. These bytes NEVER crossed the
+    /// wire, so they are not part of [`Self::s3_get_wire_bytes`] and must not
+    /// be added to it: a warm query moves cache-served bytes and no wire
+    /// bytes. Pooled counterpart: `accounting.cacheBytes`.
+    #[serde(rename = "cacheServedBytes")]
+    pub cache_served_bytes: u64,
+    /// DECOMPRESSED bytes: the typed-output footprint of every sample this
+    /// phase decoded, whatever the encoding. A decode-time output size that no
+    /// request paid for, so it is comparable neither with
+    /// [`Self::s3_get_wire_bytes`] nor with [`Self::cache_served_bytes`]. By
+    /// convention this lands on the `scan` phase, since decode always follows
+    /// a scan in this crate's fetch pipelines. Pooled counterpart:
+    /// `accounting.decompressedBytes`.
+    #[serde(rename = "decompressedOutputBytes")]
+    pub decompressed_output_bytes: u64,
+    /// Bytes this phase served from a region the fetcher had ALREADY fetched,
+    /// without issuing a second GET. Wire bytes that were avoided, not wire
+    /// bytes that were moved: they are absent from
+    /// [`Self::s3_get_wire_bytes`] by construction (no request carried them)
+    /// and adding the two would double-count the first fetch. Pooled
+    /// counterpart: `accounting.bytesReused`.
+    #[serde(rename = "reusedRegionBytes")]
+    pub reused_region_bytes: u64,
+    /// Segments this phase opened.
+    #[serde(rename = "segmentsOpened")]
+    pub segments_opened: u64,
+    /// Series this phase's catalog decode matched.
+    #[serde(rename = "seriesMatched")]
+    pub series_matched: u64,
+}
+
+/// One entry per [`QueryPhase`], in [`QueryPhase::ALL`] order, each phase
+/// exactly once. Driven off `ALL` rather than a hand-written list of four so a
+/// phase added to the enum cannot be silently dropped from the response, the
+/// same reason `ravel-bench`'s `sql_latency::phase_wire_bytes` is built this
+/// way (issue #913).
+fn phase_costs(snapshot: &PhaseAccountingSnapshot) -> Vec<PhaseCostJson> {
+    QueryPhase::ALL
+        .iter()
+        .map(|phase| {
+            let s = snapshot.phase(*phase);
+            PhaseCostJson {
+                phase: phase.name(),
+                s3_get_requests: s.s3_requests(AccountedOp::Get),
+                s3_get_wire_bytes: s.s3_bytes(AccountedOp::Get),
+                s3_list_requests: s.s3_requests(AccountedOp::List),
+                cache_hits: s.cache_hits,
+                cache_misses: s.cache_misses,
+                cache_served_bytes: s.cache_bytes,
+                decompressed_output_bytes: s.decompressed_bytes,
+                reused_region_bytes: s.bytes_reused,
+                segments_opened: s.segments_opened,
+                series_matched: s.series_matched,
+            }
+        })
+        .collect()
 }
 
 /// Upper-envelope cost estimate (ADR-0044 decision 3), rendered under

--- a/crates/ravel-query/src/http/json.rs
+++ b/crates/ravel-query/src/http/json.rs
@@ -942,6 +942,22 @@ mod tests {
         );
     }
 
+    /// One phase's expected rendered figures, named rather than positional so a
+    /// row of eleven numbers cannot be read against the wrong field.
+    struct ExpectedPhase {
+        phase: &'static str,
+        gets: u64,
+        wire_bytes: u64,
+        lists: u64,
+        hits: u64,
+        misses: u64,
+        cache_bytes: u64,
+        decompressed: u64,
+        reused: u64,
+        opened: u64,
+        matched: u64,
+    }
+
     /// A `QueryStats` whose four phase handles carry a distinct, exactly known
     /// figure in every counter `stats.phases` renders, so a test can name the
     /// expected number per phase per field and a swapped or pooled phase is a
@@ -1067,46 +1083,85 @@ mod tests {
         }
 
         // Every figure, per phase, at its exact expected value.
-        let expected: [(&str, u64, u64, u64, u64, u64, u64, u64, u64, u64, u64); 4] = [
-            // phase, gets, wire bytes, lists, hits, misses, cache bytes,
-            // decompressed, reused, opened, matched
-            ("resolve", 3, 1_000, 2, 1, 2, 11, 0, 0, 0, 0),
-            ("plan", 5, 2_000, 0, 3, 4, 22, 0, 0, 6, 0),
-            ("probe", 7, 4_000, 0, 8, 9, 33, 0, 0, 0, 12),
-            ("scan", 11, 8_000, 0, 13, 14, 44, 5_000, 640, 15, 16),
+        let expected = [
+            ExpectedPhase {
+                phase: "resolve",
+                gets: 3,
+                wire_bytes: 1_000,
+                lists: 2,
+                hits: 1,
+                misses: 2,
+                cache_bytes: 11,
+                decompressed: 0,
+                reused: 0,
+                opened: 0,
+                matched: 0,
+            },
+            ExpectedPhase {
+                phase: "plan",
+                gets: 5,
+                wire_bytes: 2_000,
+                lists: 0,
+                hits: 3,
+                misses: 4,
+                cache_bytes: 22,
+                decompressed: 0,
+                reused: 0,
+                opened: 6,
+                matched: 0,
+            },
+            ExpectedPhase {
+                phase: "probe",
+                gets: 7,
+                wire_bytes: 4_000,
+                lists: 0,
+                hits: 8,
+                misses: 9,
+                cache_bytes: 33,
+                decompressed: 0,
+                reused: 0,
+                opened: 0,
+                matched: 12,
+            },
+            ExpectedPhase {
+                phase: "scan",
+                gets: 11,
+                wire_bytes: 8_000,
+                lists: 0,
+                hits: 13,
+                misses: 14,
+                cache_bytes: 44,
+                decompressed: 5_000,
+                reused: 640,
+                opened: 15,
+                matched: 16,
+            },
         ];
-        for (i, want) in expected.iter().enumerate() {
-            let got = &phases[i];
-            let (
-                name,
-                gets,
-                wire_bytes,
-                lists,
-                hits,
-                misses,
-                cache_bytes,
-                decompressed,
-                reused,
-                opened,
-                matched,
-            ) = *want;
+        for (got, want) in phases.iter().zip(expected) {
+            let name = want.phase;
             assert_eq!(got["phase"], name);
-            assert_eq!(got["s3GetRequests"], gets, "{name} s3GetRequests");
-            assert_eq!(got["s3GetWireBytes"], wire_bytes, "{name} s3GetWireBytes");
-            assert_eq!(got["s3ListRequests"], lists, "{name} s3ListRequests");
-            assert_eq!(got["cacheHits"], hits, "{name} cacheHits");
-            assert_eq!(got["cacheMisses"], misses, "{name} cacheMisses");
+            assert_eq!(got["s3GetRequests"], want.gets, "{name} s3GetRequests");
             assert_eq!(
-                got["cacheServedBytes"], cache_bytes,
+                got["s3GetWireBytes"], want.wire_bytes,
+                "{name} s3GetWireBytes"
+            );
+            assert_eq!(got["s3ListRequests"], want.lists, "{name} s3ListRequests");
+            assert_eq!(got["cacheHits"], want.hits, "{name} cacheHits");
+            assert_eq!(got["cacheMisses"], want.misses, "{name} cacheMisses");
+            assert_eq!(
+                got["cacheServedBytes"], want.cache_bytes,
                 "{name} cacheServedBytes"
             );
             assert_eq!(
-                got["decompressedOutputBytes"], decompressed,
+                got["decompressedOutputBytes"], want.decompressed,
                 "{name} decompressedOutputBytes"
             );
-            assert_eq!(got["reusedRegionBytes"], reused, "{name} reusedRegionBytes");
-            assert_eq!(got["segmentsOpened"], opened, "{name} segmentsOpened");
-            assert_eq!(got["seriesMatched"], matched, "{name} seriesMatched");
+            assert_eq!(
+                got["reusedRegionBytes"], want.reused,
+                "{name} reusedRegionBytes"
+            );
+            assert_eq!(got["segmentsOpened"], want.opened, "{name} segmentsOpened");
+            assert_eq!(got["seriesMatched"], want.matched, "{name} seriesMatched");
         }
     }
 

--- a/crates/ravel-query/src/http/mod.rs
+++ b/crates/ravel-query/src/http/mod.rs
@@ -244,6 +244,22 @@ mod tests {
         }
     }
 
+    /// One phase's expected rendered figures, named rather than positional so a
+    /// row of eleven numbers cannot be read against the wrong field.
+    struct ExpectedPhase {
+        phase: &'static str,
+        gets: u64,
+        wire_bytes: u64,
+        lists: u64,
+        hits: u64,
+        misses: u64,
+        cache_bytes: u64,
+        decompressed: u64,
+        reused: u64,
+        opened: u64,
+        matched: u64,
+    }
+
     /// Publishes one RSEG segment carrying a single scalar series with two
     /// samples (at `now - 4min` and `now - 2min`) and returns a router serving
     /// it, plus the tenant's bearer token. The per-phase cost of a query over
@@ -389,44 +405,87 @@ mod tests {
         // and decompressed bytes are four different quantities here and the
         // rows keep them apart.
         let want = [
-            // phase, gets, wire bytes, lists, hits, misses, cache bytes,
-            // decompressed, reused, opened, matched
-            ("resolve", 2, 288, 2, 1, 2, 288, 0, 0, 0, 0),
-            ("plan", 1, 341, 0, 0, 0, 0, 0, 0, 1, 0),
-            ("probe", 0, 0, 0, 0, 0, 0, 0, 102, 0, 1),
-            ("scan", 0, 0, 0, 0, 0, 0, 32, 25, 0, 0),
+            ExpectedPhase {
+                phase: "resolve",
+                gets: 2,
+                wire_bytes: 288,
+                lists: 2,
+                hits: 1,
+                misses: 2,
+                cache_bytes: 288,
+                decompressed: 0,
+                reused: 0,
+                opened: 0,
+                matched: 0,
+            },
+            ExpectedPhase {
+                phase: "plan",
+                gets: 1,
+                wire_bytes: 341,
+                lists: 0,
+                hits: 0,
+                misses: 0,
+                cache_bytes: 0,
+                decompressed: 0,
+                reused: 0,
+                opened: 1,
+                matched: 0,
+            },
+            ExpectedPhase {
+                phase: "probe",
+                gets: 0,
+                wire_bytes: 0,
+                lists: 0,
+                hits: 0,
+                misses: 0,
+                cache_bytes: 0,
+                decompressed: 0,
+                reused: 102,
+                opened: 0,
+                matched: 1,
+            },
+            ExpectedPhase {
+                phase: "scan",
+                gets: 0,
+                wire_bytes: 0,
+                lists: 0,
+                hits: 0,
+                misses: 0,
+                cache_bytes: 0,
+                decompressed: 32,
+                reused: 25,
+                opened: 0,
+                matched: 0,
+            },
         ];
         for (row, expect) in phases.iter().zip(want) {
-            let (
-                name,
-                gets,
-                wire_bytes,
-                lists,
-                hits,
-                misses,
-                cache_bytes,
-                decompressed,
-                reused,
-                opened,
-                matched,
-            ) = expect;
+            let name = expect.phase;
             assert_eq!(row["phase"], name);
-            assert_eq!(row["s3GetRequests"], gets, "{name} s3GetRequests");
-            assert_eq!(row["s3GetWireBytes"], wire_bytes, "{name} s3GetWireBytes");
-            assert_eq!(row["s3ListRequests"], lists, "{name} s3ListRequests");
-            assert_eq!(row["cacheHits"], hits, "{name} cacheHits");
-            assert_eq!(row["cacheMisses"], misses, "{name} cacheMisses");
+            assert_eq!(row["s3GetRequests"], expect.gets, "{name} s3GetRequests");
             assert_eq!(
-                row["cacheServedBytes"], cache_bytes,
+                row["s3GetWireBytes"], expect.wire_bytes,
+                "{name} s3GetWireBytes"
+            );
+            assert_eq!(row["s3ListRequests"], expect.lists, "{name} s3ListRequests");
+            assert_eq!(row["cacheHits"], expect.hits, "{name} cacheHits");
+            assert_eq!(row["cacheMisses"], expect.misses, "{name} cacheMisses");
+            assert_eq!(
+                row["cacheServedBytes"], expect.cache_bytes,
                 "{name} cacheServedBytes"
             );
             assert_eq!(
-                row["decompressedOutputBytes"], decompressed,
+                row["decompressedOutputBytes"], expect.decompressed,
                 "{name} decompressedOutputBytes"
             );
-            assert_eq!(row["reusedRegionBytes"], reused, "{name} reusedRegionBytes");
-            assert_eq!(row["segmentsOpened"], opened, "{name} segmentsOpened");
-            assert_eq!(row["seriesMatched"], matched, "{name} seriesMatched");
+            assert_eq!(
+                row["reusedRegionBytes"], expect.reused,
+                "{name} reusedRegionBytes"
+            );
+            assert_eq!(
+                row["segmentsOpened"], expect.opened,
+                "{name} segmentsOpened"
+            );
+            assert_eq!(row["seriesMatched"], expect.matched, "{name} seriesMatched");
         }
 
         // The pooled block a pre-#935 consumer reads is unchanged and is

--- a/crates/ravel-query/src/http/mod.rs
+++ b/crates/ravel-query/src/http/mod.rs
@@ -171,6 +171,11 @@ mod tests {
     //! `tower::ServiceExt::oneshot`, and the rendered `histograms` field is
     //! asserted in full. A unit test on the encoder alone cannot show that a
     //! range request actually reaches it; this does.
+    //!
+    //! The per-phase cost split (issue #935) is proven the same way: a scalar
+    //! segment is published, queried through the same router, and every phase's
+    //! every figure is asserted at the exact value the fixture produces, on both
+    //! endpoints that render a stats block.
     use std::collections::HashMap;
     use std::sync::Arc;
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -186,9 +191,9 @@ mod tests {
     use ravel_object_store::memory::MemoryStore;
     use ravel_segment::{
         HistogramCounts, HistogramSample, HistogramSpan, HistogramValue, IngestBounds, ResetHint,
-        SegmentIdentity, SegmentWriter, SeriesInputV3, SeriesValues, WrittenSegment,
+        SegmentIdentity, SegmentWriter, SeriesInput, SeriesInputV3, SeriesValues, WrittenSegment,
     };
-    use ravel_types::{Label, LabelSet, SeriesId, Signal, TenantId};
+    use ravel_types::{Label, LabelSet, Sample, SeriesId, Signal, TenantId};
     use serde_json::Value as JsonValue;
     use tower::ServiceExt;
     use uuid::Uuid;
@@ -237,6 +242,245 @@ mod tests {
             },
             reset_hint: ResetHint::Unknown,
         }
+    }
+
+    /// Publishes one RSEG segment carrying a single scalar series with two
+    /// samples (at `now - 4min` and `now - 2min`) and returns a router serving
+    /// it, plus the tenant's bearer token. The per-phase cost of a query over
+    /// this fixture is deterministic: one segment, one series, one shard, so
+    /// every phase's request count is a fixed number the caller can name.
+    async fn scalar_fixture_router(tenant: &str, metric: &str, now: i64) -> Router {
+        let store = Arc::new(MemoryStore::new());
+        let tenant_id = TenantId::new(tenant.to_string());
+        let tenant_hash = tenant_id.hash();
+        let hour_bucket = u32::try_from(now / NS_PER_HOUR).expect("hour bucket");
+
+        let labels = LabelSet::new(vec![Label {
+            name: "__name__".to_string(),
+            value: metric.to_string(),
+        }])
+        .expect("valid labels");
+        let series_id = SeriesId::compute(&tenant_id, metric, &labels).expect("series id");
+        let series = vec![SeriesInput {
+            series_id,
+            labels,
+            samples: vec![
+                Sample {
+                    ts_ns: now - 4 * NS_PER_MIN,
+                    value: 1.0,
+                },
+                Sample {
+                    ts_ns: now - 2 * NS_PER_MIN,
+                    value: 2.0,
+                },
+            ],
+        }];
+
+        let writer_id = Uuid::new_v4();
+        let identity = SegmentIdentity {
+            tenant_hash: tenant_hash.0,
+            shard: 0,
+            writer_id: writer_id.to_string(),
+            writer_epoch: 1,
+            writer_seq: 1,
+        };
+        let bounds = IngestBounds {
+            min_ingest_ts_ns: 0,
+            max_ingest_ts_ns: 0,
+        };
+        let written: WrittenSegment =
+            SegmentWriter::write(series, identity, bounds).expect("write segment");
+
+        let new_record = NewCommitRecord {
+            tenant_hash,
+            signal: Signal::Metrics,
+            shard: 0,
+            writer_id,
+            writer_epoch: 1,
+            writer_seq: 1,
+            object_size: written.bytes.len() as u64,
+            content_hash: written.summary.blake3,
+            sample_count: written.summary.sample_count,
+            series_count: written.summary.series_count,
+            min_event_ts_ns: written.summary.min_event_ts_ns,
+            max_event_ts_ns: written.summary.max_event_ts_ns,
+            min_ingest_ts_ns: written.summary.min_event_ts_ns,
+            max_ingest_ts_ns: written.summary.max_event_ts_ns,
+            segment_format_version: 1,
+            created_unix_ns: now,
+            ingest_hour_bucket: hour_bucket,
+        };
+        let rec = record::build(new_record).expect("valid commit record");
+        let data_key = keys::reconstruct_data_key(&rec).expect("data key");
+        let backend: Arc<dyn ObjectStoreBackend> = store.clone();
+        publish::put_data_object(backend.as_ref(), &data_key, written.bytes)
+            .await
+            .expect("put data object");
+        publish::publish(backend.as_ref(), &rec, &RetryPolicy::default())
+            .await
+            .expect("publish");
+
+        let mut tokens = HashMap::new();
+        tokens.insert("secret-phases".to_string(), tenant_id);
+        let catalog =
+            Arc::new(Catalog::new(backend.clone(), CatalogConfig::default()).expect("catalog"));
+        let engine = Arc::new(QueryEngine::new(catalog, backend, EngineConfig::default()));
+        let state = AppState::new(engine, Arc::new(StaticBearerTokenResolver::new(tokens)));
+        router(state)
+    }
+
+    async fn get_json(app: Router, uri: &str) -> (StatusCode, JsonValue) {
+        let request = Request::builder()
+            .method("GET")
+            .uri(uri)
+            .header("authorization", "Bearer secret-phases")
+            .body(Body::empty())
+            .expect("build request");
+        let response = match app.oneshot(request).await {
+            Ok(response) => response,
+            Err(never) => match never {},
+        };
+        let status = response.status();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let json: JsonValue = serde_json::from_slice(&body).expect("parse json");
+        (status, json)
+    }
+
+    #[tokio::test]
+    async fn instant_query_endpoint_serves_the_per_phase_cost_split() {
+        // Endpoint-level reachability proof for issue #935: the per-phase cost
+        // split is not merely renderable, it is what a caller of the production
+        // router actually receives on `/api/v1/query`. Every figure is pinned to
+        // an exact expected value: over this one-segment, one-series, one-shard
+        // fixture each phase's request count is a fixed number.
+        let now = (now_ns() / NS_PER_MIN) * NS_PER_MIN;
+        let app = scalar_fixture_router("tenant-phases", "bench_gauge", now).await;
+        let time = (now - 2 * NS_PER_MIN) / NS_PER_SEC;
+        let (status, json) =
+            get_json(app, &format!("/api/v1/query?query=bench_gauge&time={time}")).await;
+        assert_eq!(status, StatusCode::OK, "body: {json}");
+        assert_eq!(json["status"], "success", "body: {json}");
+        // The query returned the sample, so the phases below describe a real
+        // read and not an empty result that touched nothing.
+        assert_eq!(json["data"]["resultType"], "vector", "body: {json}");
+        assert_eq!(
+            json["data"]["result"][0]["value"],
+            serde_json::json!([time, "2"]),
+            "body: {json}"
+        );
+
+        let stats = &json["data"]["stats"];
+        let phases = stats["phases"].as_array().expect("phases array present");
+        assert_eq!(phases.len(), 4, "four phases, body: {json}");
+        let names: Vec<&str> = phases
+            .iter()
+            .map(|p| p["phase"].as_str().expect("phase name"))
+            .collect();
+        assert_eq!(names, vec!["resolve", "plan", "probe", "scan"]);
+
+        // Every phase's every figure, at the exact value this fixture produces.
+        // What the split buys is visible in these rows and in no pooled total:
+        // the two catalog GETs are `resolve`, the segment's one whole-object
+        // read is `plan`, and `probe`/`scan` issue no request at all because
+        // they are served from the region the plan read already fetched
+        // (`reusedRegionBytes`). Wire bytes, cache-served bytes, reused bytes,
+        // and decompressed bytes are four different quantities here and the
+        // rows keep them apart.
+        let want = [
+            // phase, gets, wire bytes, lists, hits, misses, cache bytes,
+            // decompressed, reused, opened, matched
+            ("resolve", 2, 288, 2, 1, 2, 288, 0, 0, 0, 0),
+            ("plan", 1, 341, 0, 0, 0, 0, 0, 0, 1, 0),
+            ("probe", 0, 0, 0, 0, 0, 0, 0, 102, 0, 1),
+            ("scan", 0, 0, 0, 0, 0, 0, 32, 25, 0, 0),
+        ];
+        for (row, expect) in phases.iter().zip(want) {
+            let (
+                name,
+                gets,
+                wire_bytes,
+                lists,
+                hits,
+                misses,
+                cache_bytes,
+                decompressed,
+                reused,
+                opened,
+                matched,
+            ) = expect;
+            assert_eq!(row["phase"], name);
+            assert_eq!(row["s3GetRequests"], gets, "{name} s3GetRequests");
+            assert_eq!(row["s3GetWireBytes"], wire_bytes, "{name} s3GetWireBytes");
+            assert_eq!(row["s3ListRequests"], lists, "{name} s3ListRequests");
+            assert_eq!(row["cacheHits"], hits, "{name} cacheHits");
+            assert_eq!(row["cacheMisses"], misses, "{name} cacheMisses");
+            assert_eq!(
+                row["cacheServedBytes"], cache_bytes,
+                "{name} cacheServedBytes"
+            );
+            assert_eq!(
+                row["decompressedOutputBytes"], decompressed,
+                "{name} decompressedOutputBytes"
+            );
+            assert_eq!(row["reusedRegionBytes"], reused, "{name} reusedRegionBytes");
+            assert_eq!(row["segmentsOpened"], opened, "{name} segmentsOpened");
+            assert_eq!(row["seriesMatched"], matched, "{name} seriesMatched");
+        }
+
+        // The pooled block a pre-#935 consumer reads is unchanged and is
+        // exactly the sum of the rows above: 2 + 1 GETs, 288 + 341 wire bytes.
+        assert_eq!(stats["accounting"]["s3GetRequests"], 3);
+        assert_eq!(stats["accounting"]["s3GetBytes"], 629);
+        assert_eq!(stats["accounting"]["s3ListRequests"], 2);
+        assert_eq!(stats["accounting"]["bytesReused"], 127);
+        assert_eq!(stats["accounting"]["decompressedBytes"], 32);
+        assert_eq!(stats["segmentsFetched"], 1);
+    }
+
+    #[tokio::test]
+    async fn range_query_endpoint_also_serves_the_per_phase_cost_split() {
+        // The split rides on `QueryStatsJson`, so it reaches both endpoints
+        // that render a stats block. Same fixture, same exact figures: a range
+        // query over the same single segment reads it the same way, so a
+        // divergence here would mean one endpoint renders the split and the
+        // other does not.
+        let now = (now_ns() / NS_PER_MIN) * NS_PER_MIN;
+        let app = scalar_fixture_router("tenant-phases", "bench_gauge", now).await;
+        let start = (now - 4 * NS_PER_MIN) / NS_PER_SEC;
+        let end = (now - 2 * NS_PER_MIN) / NS_PER_SEC;
+        let (status, json) = get_json(
+            app,
+            &format!("/api/v1/query_range?query=bench_gauge&start={start}&end={end}&step=60s"),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "body: {json}");
+        assert_eq!(json["data"]["resultType"], "matrix", "body: {json}");
+
+        let phases = json["data"]["stats"]["phases"]
+            .as_array()
+            .expect("phases array present");
+        let rendered: Vec<(&str, u64, u64)> = phases
+            .iter()
+            .map(|p| {
+                (
+                    p["phase"].as_str().expect("phase name"),
+                    p["s3GetRequests"].as_u64().expect("gets"),
+                    p["s3GetWireBytes"].as_u64().expect("wire bytes"),
+                )
+            })
+            .collect();
+        assert_eq!(
+            rendered,
+            vec![
+                ("resolve", 2, 288),
+                ("plan", 1, 341),
+                ("probe", 0, 0),
+                ("scan", 0, 0),
+            ],
+            "body: {json}"
+        );
     }
 
     #[tokio::test]

--- a/docs/query-engine.md
+++ b/docs/query-engine.md
@@ -1380,8 +1380,8 @@ label), the same allowlist ADR-0044 sets for `/metrics` labels.
 
 ### JSON response shape
 
-`GET /api/v1/query` and `/query_range`'s `stats` object gains two new
-fields alongside the existing `segmentsFetched`/`segmentsPruned`:
+`GET /api/v1/query` and `/query_range`'s `stats` object carries these
+cost fields alongside the existing `segmentsFetched`/`segmentsPruned`:
 
 - `stats.accounting` — the `QueryAccountingSnapshot`, split by op for the
   S3 counters (`s3GetRequests`/`s3GetBytes`, `s3ListRequests`/
@@ -1396,6 +1396,36 @@ fields alongside the existing `segmentsFetched`/`segmentsPruned`:
 - `stats.estimate` — the `CostEstimate`: `estimatedRequests`,
   `estimatedStoreBytes`, `estimatedDecompressedBytes`, `segments`,
   `series`.
+- `stats.phases` — the same GETs and bytes `stats.accounting` pools, split
+  by phase (issue #935 exposing issue #796's `PhaseAccounting`; ADR-0927
+  decision 7). An array of one object per `QueryPhase`, in
+  `QueryPhase::ALL` order, each phase exactly once: `resolve` (catalog
+  snapshot resolve), `plan` (footer and skip-index probing), `probe`
+  (segment catalog fetch), `scan` (block and page data reads). The
+  rendering iterates `QueryPhase::ALL`, so a phase added to the enum
+  cannot be silently dropped. Per-phase fields: `phase`,
+  `s3GetRequests`, `s3GetWireBytes`, `s3ListRequests`, `cacheHits`,
+  `cacheMisses`, `cacheServedBytes`, `decompressedOutputBytes`,
+  `reusedRegionBytes`, `segmentsOpened`, `seriesMatched`.
+
+  Additive to `stats.accounting`, which is unchanged: every per-phase
+  counter sums back to its pooled counterpart there. Each byte field
+  names its own kind because the four are different quantities that
+  cannot be compared or summed with each other: `s3GetWireBytes` is what
+  the wire carried (range reads and a coalesced run's unwanted in-between
+  bytes included; a retried GET's failed attempts not, since the counter
+  is written once from the response that succeeded, and request counts are
+  logical calls rather than billed requests per ADR-0927 decision 8),
+  `cacheServedBytes` never crossed the wire, `decompressedOutputBytes` is
+  a decode-time output size no request paid for, and `reusedRegionBytes`
+  is wire bytes avoided by reusing an already-fetched region rather than
+  wire bytes moved.
+
+  Four counters the pooled block renders have no per-phase field, because
+  they are never recorded on a PromQL query and a per-phase zero would
+  read as a measurement rather than an absence (ADR-0927 decision 7):
+  `s3HeadRequests`/`s3HeadBytes`, `s3ListBytes`, and
+  `peakIntermediateBytes` (SQL executor only).
 
 ## PromQL conformance (ADR-0035)
 

--- a/services/ravel-server/tests/distributed_query_e2e.rs
+++ b/services/ravel-server/tests/distributed_query_e2e.rs
@@ -358,9 +358,31 @@ async fn distributed_query_http_equals_local_http() {
     );
     // The core ADR-0071 guarantee: fanned-out results are byte-identical to
     // local. This equality is what flips if the distributed path diverges.
+    //
+    // `stats.phases` is excluded, and only that field. The per-phase cost split
+    // (issue #935) is a diagnostic attribution, not part of the result: a
+    // distributed query's segment reads happen inside a remote worker, which
+    // returns one pooled `QueryAccountingSnapshot` with no phase breakdown, so
+    // the coordinator charges the whole remote fetch to the `scan` phase by
+    // construction (`QueryStats::phase_accounting`'s own doc comment states
+    // this convention). The local path splits the same reads across `plan`,
+    // `probe`, and `scan`. Every other field of `data`, including the pooled
+    // `stats.accounting` totals those phases sum to, is still compared
+    // byte-for-byte, so a real divergence in the fanned-out result still flips
+    // this assertion.
+    let strip_phases = |body: &serde_json::Value| -> serde_json::Value {
+        let mut data = body["data"].clone();
+        data["stats"]
+            .as_object_mut()
+            .expect("stats is an object")
+            .remove("phases")
+            .expect("stats carries the per-phase cost split");
+        data
+    };
     assert_eq!(
-        distributed_body["data"], local_body["data"],
-        "distributed `data` must be byte-identical to local:\n  distributed={distributed_body}\n  local={local_body}"
+        strip_phases(&distributed_body),
+        strip_phases(&local_body),
+        "distributed `data` must be byte-identical to local outside the per-phase cost attribution:\n  distributed={distributed_body}\n  local={local_body}"
     );
     // Sanity: the query actually returned the published series, so the equality
     // above is not the trivial equality of two empty results.


### PR DESCRIPTION
PhaseAccounting splits every QueryAccounting counter across resolve, plan,
probe and scan, and it is constructed on every PromQL query, but it reached
nothing: QueryStatsJson read the pooled stats.accounting and never
stats.phase_accounting, so the per-phase object-store cost the diagnostic lane
needs was measured on every query and thrown away. This exposes it. Nothing
about what is measured, or where it is recorded, changes.

The rendering is driven off QueryPhase::ALL rather than a hand-written list, so
a phase added later cannot be silently dropped from the output, following the
same construction sql_latency.rs's phase_wire_bytes() uses for the same reason.
Each phase appears exactly once; a figure emitted twice is as wrong as one
emitted with the wrong value, and the test asserts the exact phase names and
their multiplicity rather than their presence.

The change is additive at the response boundary. No existing QueryStatsJson
field is renamed, removed, or redefined, so a consumer parsing today's shape
keeps working.

Scope deviation, deliberate and reported: the task was scoped to
crates/ravel-query, and one file outside it changed. Adding a field to the
stats object broke distributed_query_e2e's byte-identical comparison of
distributed against local results, because that assertion covers the whole data
object. The fix excludes stats.phases and only that field, and it is not a
blanket exclusion: the removal uses expect(), so the test fails if the field is
absent, and every other field including the pooled stats.accounting totals the
phases sum to is still compared byte-for-byte.

That exclusion is correct rather than convenient. A distributed query's segment
reads happen inside a remote worker, which returns one pooled accounting
snapshot with no phase breakdown, so the coordinator charges the whole remote
fetch to the scan phase by construction while the local path splits the same
reads across plan, probe and scan. The two are genuinely different attributions
of identical work, which is a limitation of the split worth knowing before
anyone reads a distributed run's phase numbers as if they were local ones.

docs/query-engine.md is updated in the same commit, per the doc-currency rule.

Fixes: #935
Refs: #927
