### PR TITLE
feat(ravel-catalog): split .cstat version and add SnapshotHead field 13

### DIFF
--- a/crates/ravel-catalog/src/cache.rs
+++ b/crates/ravel-catalog/src/cache.rs
@@ -700,6 +700,7 @@ mod tests {
             created_unix_ns: 0,
             shard_generation_count: 1,
             column_stats: None,
+            column_stats_part: None,
         }
     }
 

--- a/crates/ravel-catalog/src/catalog.rs
+++ b/crates/ravel-catalog/src/catalog.rs
@@ -3466,6 +3466,7 @@ mod tests {
             created_unix_ns: 0,
             shard_generation_count: 1,
             column_stats: None,
+            column_stats_part: None,
         }
     }
 
@@ -3963,6 +3964,7 @@ mod tests {
             postings: None,
             shard_generation_count: 1,
             column_stats: None,
+            column_stats_part: None,
         };
         let head_bytes = crate::snapshot_format::encode_head(&head).expect("encode head");
         store
@@ -4061,6 +4063,7 @@ mod tests {
             postings: None,
             shard_generation_count: 2,
             column_stats: None,
+            column_stats_part: None,
         };
         let head_bytes = crate::snapshot_format::encode_head(&head).expect("encode head");
         inner
@@ -5389,6 +5392,7 @@ mod tests {
                 segment_count: 1,
                 part_blake3: vec![part_hash.to_vec()],
             }),
+            column_stats_part: None,
         };
         let head_bytes = crate::snapshot_format::encode_head(&head).expect("encode head");
         store
@@ -5512,6 +5516,7 @@ mod tests {
                 segment_count: 1,
                 part_blake3: vec![part_hash.to_vec()],
             }),
+            column_stats_part: None,
         };
         let head_bytes = crate::snapshot_format::encode_head(&head).expect("encode head");
         store

--- a/crates/ravel-catalog/src/fold.rs
+++ b/crates/ravel-catalog/src/fold.rs
@@ -1633,6 +1633,9 @@ impl Catalog {
                 parts: part_refs.clone(),
                 postings: postings_ref,
                 column_stats: column_stats_ref,
+                // ADR-0942 A1: additive field 13, not written by any path yet.
+                // Absent (None) keeps HEAD encoding byte-for-byte identical.
+                column_stats_part: None,
                 folder_id: folder_id.into_bytes().to_vec(),
                 created_unix_ns: now_ns,
                 shard_generation_count,

--- a/crates/ravel-catalog/src/snapshot_format/column_stats.rs
+++ b/crates/ravel-catalog/src/snapshot_format/column_stats.rs
@@ -29,8 +29,8 @@ use ravel_proto::catalog::v1::{ColumnStat, ColumnStatsHeader, ColumnStatsSegment
 
 use super::error::SnapshotFormatError;
 use super::{
-    COLUMN_STATS_MAGIC, COLUMN_STATS_RESERVED, COLUMN_STATS_VERSION, MIN_COLUMN_STATS_ENVELOPE_LEN,
-    ZSTD_LEVEL,
+    COLUMN_STATS_MAGIC, COLUMN_STATS_RESERVED, COLUMN_STATS_WRITE_VERSION,
+    MIN_COLUMN_STATS_ENVELOPE_LEN, ZSTD_LEVEL, column_stats_version_accepted,
 };
 use crate::snapshot_format::ColumnStatsLimits;
 
@@ -51,6 +51,28 @@ pub fn encode_column_stats(
     part_blake3: Vec<Vec<u8>>,
     segments: &[ColumnStatsSegment],
 ) -> Result<Vec<u8>, SnapshotFormatError> {
+    encode_column_stats_versioned(
+        COLUMN_STATS_WRITE_VERSION,
+        tenant_hash,
+        signal,
+        part_blake3,
+        segments,
+    )
+}
+
+/// Envelope framing shared by the public writer and the tests. Parameterised on
+/// `version` so a test can construct a v2 object (ADR-0942) without a v2 writer:
+/// production only ever reaches it through [`encode_column_stats`] with
+/// [`COLUMN_STATS_WRITE_VERSION`], so nothing writes a v2 object yet. Stamps
+/// `version` into both the envelope version byte and the header
+/// `format_version`, so the two always agree by construction.
+fn encode_column_stats_versioned(
+    version: u8,
+    tenant_hash: [u8; 16],
+    signal: u32,
+    part_blake3: Vec<Vec<u8>>,
+    segments: &[ColumnStatsSegment],
+) -> Result<Vec<u8>, SnapshotFormatError> {
     validate_segments(segments)?;
 
     let mut segments_raw = Vec::new();
@@ -63,7 +85,7 @@ pub fn encode_column_stats(
         .map_err(|e| SnapshotFormatError::Compress(e.to_string()))?;
 
     let header = ColumnStatsHeader {
-        format_version: u32::from(COLUMN_STATS_VERSION),
+        format_version: u32::from(version),
         tenant_hash: tenant_hash.to_vec(),
         signal,
         part_blake3,
@@ -77,7 +99,7 @@ pub fn encode_column_stats(
     let mut out =
         Vec::with_capacity(MIN_COLUMN_STATS_ENVELOPE_LEN + header_bytes.len() + body.len());
     out.extend_from_slice(&COLUMN_STATS_MAGIC);
-    out.push(COLUMN_STATS_VERSION);
+    out.push(version);
     out.extend_from_slice(&COLUMN_STATS_RESERVED);
     out.extend_from_slice(&header_len.to_le_bytes());
     out.extend_from_slice(&header_bytes);
@@ -112,7 +134,10 @@ pub fn decode_column_stats(
         return Err(SnapshotFormatError::ColumnStatsBadMagic);
     }
     let version = take_bytes(bytes, &mut pos, 1)?[0];
-    if version != COLUMN_STATS_VERSION {
+    // Membership in the accepted read set, not equality against the write
+    // version (ADR-0942): a v1 object must keep decoding after A2 bumps the
+    // write version to 2, or the L0 reader path loses coverage.
+    if !column_stats_version_accepted(version) {
         return Err(SnapshotFormatError::ColumnStatsUnsupportedVersion(version));
     }
     let reserved = take_array::<3>(bytes, &mut pos)?;
@@ -141,10 +166,15 @@ pub fn decode_column_stats(
 
     let header = ColumnStatsHeader::decode(header_bytes)
         .map_err(|e| SnapshotFormatError::ColumnStatsHeaderDecode(e.to_string()))?;
-    if header.format_version != u32::from(COLUMN_STATS_VERSION) {
+    // The header's self-declared version must agree with the accepted envelope
+    // version byte. The byte already passed the membership gate above, so this
+    // accepts any object in the read set while still rejecting a header that
+    // disagrees with its own envelope (the ADR-0942 self-describing-state rule:
+    // a v1 header under a v2 envelope, or vice versa, subtracts coverage).
+    if header.format_version != u32::from(version) {
         return Err(SnapshotFormatError::ColumnStatsHeaderVersionMismatch {
             header: header.format_version,
-            envelope: COLUMN_STATS_VERSION,
+            envelope: version,
         });
     }
     if header.tenant_hash.len() != 16 {
@@ -767,6 +797,209 @@ mod tests {
         seg.columns[0].sum = None;
         encode_column_stats([0x11; 16], 3, vec![vec![0x22; 32]], &[seg])
             .expect("an all-null column may carry no sum");
+    }
+
+    /// The regression that matters for ADR-0942 A1: the existing L0 path must
+    /// stay byte-for-byte readable after the version split. A v1 object decodes
+    /// with EXACT expected field values, not merely `is_ok()`.
+    #[test]
+    fn v1_object_decodes_with_exact_field_values() {
+        let seg = segment(1, 0, 1);
+        let bytes = encode_column_stats(
+            [0x11; 16],
+            3,
+            vec![vec![0x22; 32]],
+            std::slice::from_ref(&seg),
+        )
+        .expect("v1 encodes");
+        // The public writer stamps the write version, which is 1 in A1.
+        assert_eq!(bytes[4], 1, "envelope version byte is the v1 write version");
+        let decoded =
+            decode_column_stats(&bytes, &ColumnStatsLimits::default()).expect("v1 decodes");
+        assert_eq!(decoded.header.format_version, 1);
+        assert_eq!(decoded.header.tenant_hash, vec![0x11; 16]);
+        assert_eq!(decoded.header.signal, 3);
+        assert_eq!(decoded.header.part_blake3, vec![vec![0x22; 32]]);
+        assert_eq!(decoded.header.segment_count, 1);
+        assert_eq!(decoded.segments.len(), 1);
+        let out = &decoded.segments[0];
+        assert_eq!(out.ingest_hour_bucket, 1);
+        assert_eq!(out.shard, 0);
+        assert_eq!(out.writer_id, vec![0xAA; 16]);
+        assert_eq!(out.writer_epoch, 1);
+        assert_eq!(out.writer_seq, 1);
+        assert_eq!(out.columns.len(), 1);
+        let col = &out.columns[0];
+        assert_eq!(col.name, "AdvEngineID");
+        assert_eq!(col.declared_type, 2);
+        assert_eq!(col.non_null_count, 10);
+        assert_eq!(col.null_count, 0);
+        assert_eq!(col.min, Some(i64_value(0)));
+        assert_eq!(col.max, Some(i64_value(9)));
+        assert!(col.dictionary_present);
+        assert_eq!(col.dictionary.len(), 10);
+        assert_eq!(col.sum, Some(45));
+    }
+
+    /// ADR-0942: a v2-stamped object must decode today, even though nothing
+    /// writes one, so A2's writer and this decoder cannot disagree the moment
+    /// v2 first appears. Constructed directly via the versioned framing helper
+    /// (no v2 writer needed). This is also the test the "prove-the-test"
+    /// demonstration flips the decoder to break: change the `:115`
+    /// `column_stats_version_accepted(version)` membership check back to
+    /// `version != COLUMN_STATS_WRITE_VERSION` and this fails with
+    /// `ColumnStatsUnsupportedVersion(2)`.
+    #[test]
+    fn v2_stamped_object_decodes() {
+        let seg = segment(1, 0, 1);
+        let bytes = encode_column_stats_versioned(
+            2,
+            [0x11; 16],
+            3,
+            vec![vec![0x22; 32]],
+            std::slice::from_ref(&seg),
+        )
+        .expect("v2 framing encodes");
+        assert_eq!(bytes[4], 2, "envelope version byte is v2");
+        let decoded =
+            decode_column_stats(&bytes, &ColumnStatsLimits::default()).expect("v2 decodes");
+        assert_eq!(decoded.header.format_version, 2);
+        assert_eq!(decoded.segments, vec![seg]);
+    }
+
+    /// A version outside the accepted set is refused with the specific typed
+    /// error carrying the offending version, not merely "an error occurred".
+    #[test]
+    fn version_outside_accepted_set_rejected() {
+        for bad in [0u8, 3, 255] {
+            let seg = segment(1, 0, 1);
+            let bytes =
+                encode_column_stats_versioned(bad, [0x11; 16], 3, vec![vec![0x22; 32]], &[seg])
+                    .expect("framing encodes any version byte");
+            let err = decode_column_stats(&bytes, &ColumnStatsLimits::default())
+                .expect_err("version outside the accepted set is rejected");
+            assert_eq!(
+                err,
+                SnapshotFormatError::ColumnStatsUnsupportedVersion(bad),
+                "version {bad} must be refused with its own version"
+            );
+        }
+    }
+
+    /// The accepted read set is exactly {1, 2} and nothing else across the whole
+    /// u8 domain. The expectation is a hardcoded `1 | 2`, deliberately NOT
+    /// `COLUMN_STATS_ACCEPTED_READ_VERSIONS.contains(..)`: adding a version to
+    /// the constant later cannot silently widen what is accepted without this
+    /// literal changing too.
+    #[test]
+    fn accepted_read_set_is_exactly_v1_and_v2() {
+        for version in 0u8..=255 {
+            let seg = segment(1, 0, 1);
+            let bytes =
+                encode_column_stats_versioned(version, [0x11; 16], 3, vec![vec![0x22; 32]], &[seg])
+                    .expect("framing encodes any version byte");
+            let decoded = decode_column_stats(&bytes, &ColumnStatsLimits::default());
+            let expected_accept = matches!(version, 1 | 2);
+            assert_eq!(
+                decoded.is_ok(),
+                expected_accept,
+                "version {version} acceptance must match the hardcoded {{1, 2}} set"
+            );
+            if !expected_accept {
+                assert_eq!(
+                    decoded.expect_err("rejected"),
+                    SnapshotFormatError::ColumnStatsUnsupportedVersion(version)
+                );
+            }
+        }
+    }
+
+    /// A header whose self-declared `format_version` disagrees with its accepted
+    /// envelope version byte is rejected: a v2 envelope must not carry a v1
+    /// header. Built by decoding a v2 object, rewriting only the header's
+    /// `format_version` to 1, and re-stamping both CRCs so the object is
+    /// otherwise well-formed and the version disagreement is the sole defect.
+    #[test]
+    fn header_envelope_version_disagreement_rejected() {
+        let seg = segment(1, 0, 1);
+        // Encode a v2 object, then rebuild the envelope with the header claiming
+        // v1 while the envelope byte stays v2.
+        let header = ColumnStatsHeader {
+            format_version: 1, // disagrees with the v2 envelope byte below
+            tenant_hash: vec![0x11; 16],
+            signal: 3,
+            part_blake3: vec![vec![0x22; 32]],
+            segment_count: 1,
+            body_uncompressed_len: seg.encode_length_delimited_to_vec().len() as u64,
+        };
+        let header_bytes = header.encode_to_vec();
+        let segments_raw = seg.encode_length_delimited_to_vec();
+        let body = zstd::bulk::compress(&segments_raw, ZSTD_LEVEL).expect("compress");
+        let mut out = Vec::new();
+        out.extend_from_slice(&COLUMN_STATS_MAGIC);
+        out.push(2); // v2 envelope
+        out.extend_from_slice(&COLUMN_STATS_RESERVED);
+        out.extend_from_slice(&(header_bytes.len() as u32).to_le_bytes());
+        out.extend_from_slice(&header_bytes);
+        let header_crc = crc32c::crc32c(&out);
+        out.extend_from_slice(&(body.len() as u64).to_le_bytes());
+        out.extend_from_slice(&body);
+        out.extend_from_slice(&crc32c::crc32c(&body).to_le_bytes());
+        out.extend_from_slice(&header_crc.to_le_bytes());
+
+        let err = decode_column_stats(&out, &ColumnStatsLimits::default())
+            .expect_err("header/envelope version disagreement is rejected");
+        assert_eq!(
+            err,
+            SnapshotFormatError::ColumnStatsHeaderVersionMismatch {
+                header: 1,
+                envelope: 2,
+            }
+        );
+    }
+
+    /// A truncated v2 envelope produces a typed error, never a panic and never
+    /// wrong data: every prefix of a well-formed v2 object is rejected.
+    #[test]
+    fn truncated_v2_envelope_is_typed_error() {
+        let seg = segment(1, 0, 1);
+        let bytes = encode_column_stats_versioned(2, [0x11; 16], 3, vec![vec![0x22; 32]], &[seg])
+            .expect("v2 framing encodes");
+        for len in 0..bytes.len() {
+            // Must return a typed error rather than panic; the whole object at
+            // full length is covered by `v2_stamped_object_decodes`.
+            let _: SnapshotFormatError =
+                decode_column_stats(&bytes[..len], &ColumnStatsLimits::default()).expect_err(
+                    "a truncated envelope must be a typed error, not Ok and not a panic",
+                );
+        }
+    }
+
+    /// A corrupted body under a v2 envelope is caught by the body CRC, a typed
+    /// error rather than a decode of wrong data.
+    #[test]
+    fn corrupt_v2_body_is_typed_error() {
+        let seg = segment(1, 0, 1);
+        let mut bytes =
+            encode_column_stats_versioned(2, [0x11; 16], 3, vec![vec![0x22; 32]], &[seg])
+                .expect("v2 framing encodes");
+        // Flip a byte inside the compressed body region (past the header,
+        // before the trailing CRCs).
+        let mid = bytes.len() / 2;
+        bytes[mid] ^= 0xFF;
+        let err = decode_column_stats(&bytes, &ColumnStatsLimits::default())
+            .expect_err("a corrupted body is rejected");
+        assert!(
+            matches!(
+                err,
+                SnapshotFormatError::ColumnStatsBodyCrcMismatch
+                    | SnapshotFormatError::ColumnStatsHeaderCrcMismatch
+                    | SnapshotFormatError::Decompress(_)
+                    | SnapshotFormatError::ColumnStatsDecompressedLenMismatch { .. }
+                    | SnapshotFormatError::ColumnStatsSegmentDecode(_)
+            ),
+            "unexpected error variant: {err:?}"
+        );
     }
 
     #[test]

--- a/crates/ravel-catalog/src/snapshot_format/mod.rs
+++ b/crates/ravel-catalog/src/snapshot_format/mod.rs
@@ -90,8 +90,28 @@ impl Default for PostingsLimits {
 /// (ADR-0850).
 pub const COLUMN_STATS_MAGIC: [u8; 4] = *b"RCST";
 
-/// Column-statistics envelope format version. This is the v1 layout.
-pub const COLUMN_STATS_VERSION: u8 = 1;
+/// Column-statistics envelope WRITE version: the version the fold stamps into
+/// every `.cstat` object it writes. It stays 1 in this change; ADR-0942's A2
+/// step raises it to 2 when the writer begins emitting part-hash-keyed
+/// objects. Single source for the stamped version so that later bump edits one
+/// literal.
+pub const COLUMN_STATS_WRITE_VERSION: u8 = 1;
+
+/// Column-statistics envelope ACCEPTED READ SET: the versions
+/// `decode_column_stats` accepts. v1 is ADR-0850's L0-tuple keying; v2 is
+/// ADR-0942's part-hash keying. The decoder checks MEMBERSHIP against this set,
+/// never equality against [`COLUMN_STATS_WRITE_VERSION`]: bumping the write
+/// version must not make the decoder reject the v1 objects the ADR-0942 L0
+/// reader rule still depends on. Single source for the accepted set so a later
+/// version is added in one place. v2 is accepted before anything writes one, so
+/// A2's writer and this decoder cannot disagree the moment v2 first appears.
+pub const COLUMN_STATS_ACCEPTED_READ_VERSIONS: [u8; 2] = [1, 2];
+
+/// Whether `version` is an accepted `.cstat` envelope read version. Membership,
+/// not equality against the write version (ADR-0942).
+pub fn column_stats_version_accepted(version: u8) -> bool {
+    COLUMN_STATS_ACCEPTED_READ_VERSIONS.contains(&version)
+}
 
 /// Reserved column-statistics envelope bytes; must always be zero in v1.
 pub const COLUMN_STATS_RESERVED: [u8; 3] = [0, 0, 0];
@@ -159,6 +179,7 @@ mod tests {
             created_unix_ns: 0,
             shard_generation_count: 1,
             column_stats: None,
+            column_stats_part: None,
         }
     }
 
@@ -369,7 +390,8 @@ mod tests {
         assert_eq!(POSTINGS_RESERVED, [0, 0, 0]);
         assert_eq!(DEFAULT_MAX_POSTINGS_BYTES, 256 << 20);
         assert_eq!(COLUMN_STATS_MAGIC, *b"RCST");
-        assert_eq!(COLUMN_STATS_VERSION, 1);
+        assert_eq!(COLUMN_STATS_WRITE_VERSION, 1);
+        assert_eq!(COLUMN_STATS_ACCEPTED_READ_VERSIONS, [1, 2]);
         assert_eq!(COLUMN_STATS_RESERVED, [0, 0, 0]);
         assert_eq!(DEFAULT_MAX_COLUMN_STATS_BYTES, 256 << 20);
         assert_eq!(DEFAULT_MAX_COLUMN_DICTIONARY_ENTRIES, 10_000);

--- a/crates/ravel-catalog/src/snapshot_resolve.rs
+++ b/crates/ravel-catalog/src/snapshot_resolve.rs
@@ -1127,6 +1127,7 @@ mod tests {
             postings: None,
             shard_generation_count: 1,
             column_stats: None,
+            column_stats_part: None,
         }
     }
 
@@ -1272,6 +1273,7 @@ mod tests {
             postings: None,
             shard_generation_count: 1,
             column_stats: None,
+            column_stats_part: None,
         };
         let head_bytes = snapshot_format::encode_head(&head).expect("encode head");
         let head_key = head_object_key(&tenant, Signal::Metrics);

--- a/crates/ravel-catalog/tests/resharding.rs
+++ b/crates/ravel-catalog/tests/resharding.rs
@@ -406,6 +406,7 @@ async fn head_ahead_of_reader_fails_closed() {
         created_unix_ns: 0,
         shard_generation_count: 2,
         column_stats: None,
+        column_stats_part: None,
     };
     store
         .put(

--- a/crates/ravel-catalog/tests/snapshot_format_corrupt.rs
+++ b/crates/ravel-catalog/tests/snapshot_format_corrupt.rs
@@ -445,6 +445,7 @@ fn base_head() -> SnapshotHead {
         created_unix_ns: 1_000,
         shard_generation_count: 1,
         column_stats: None,
+        column_stats_part: None,
     }
 }
 

--- a/crates/ravel-catalog/tests/snapshot_format_roundtrip.rs
+++ b/crates/ravel-catalog/tests/snapshot_format_roundtrip.rs
@@ -217,6 +217,7 @@ fn arb_head() -> impl Strategy<Value = SnapshotHead> {
                         created_unix_ns,
                         shard_generation_count: 1,
                         column_stats,
+                        column_stats_part: None,
                     }
                 },
             )

--- a/crates/ravel-maintain/src/sweep.rs
+++ b/crates/ravel-maintain/src/sweep.rs
@@ -2179,6 +2179,7 @@ mod tests {
             created_unix_ns: 0,
             postings,
             column_stats: None,
+            column_stats_part: None,
             shard_generation_count: 1,
         };
         let bytes = ravel_catalog::encode_head(&head).expect("valid HEAD encodes");
@@ -2657,6 +2658,7 @@ mod tests {
                 created_unix_ns: 0,
                 postings: None,
                 column_stats: None,
+                column_stats_part: None,
                 shard_generation_count: 1,
             };
             Bytes::from(ravel_catalog::encode_head(&head).expect("valid swapped HEAD"))

--- a/crates/ravel-sql/tests/logs_stats_load.rs
+++ b/crates/ravel-sql/tests/logs_stats_load.rs
@@ -201,6 +201,7 @@ async fn install_head_and_stats(store: &dyn ObjectStoreBackend, segments: &[Colu
             segment_count: segments.len() as u32,
             part_blake3: vec![part_hash.to_vec()],
         }),
+        column_stats_part: None,
     };
     let head_bytes = encode_head(&head).expect("encode head");
     store

--- a/proto/ravel/catalog.proto
+++ b/proto/ravel/catalog.proto
@@ -70,6 +70,16 @@ message SnapshotHead {
   // failed; readers must never treat absence as an error, and must fall
   // back to scanning for any statistic this ref does not cover.
   SnapshotColumnStatsRef column_stats = 11;
+  // Additive, ADR-0942 (re-key .cstat column statistics to snapshot-part
+  // binding). Points at a part-hash-keyed .cstat (envelope v2), joined to a
+  // resolved segment by the covered part's SnapshotPartRef.blake3 rather than
+  // the ADR-0850 five-field identity tuple field 11 carries. Field 12 is
+  // deliberately skipped: ADR-0913 has claimed it for
+  // SnapshotMaterializationRef. Absent means no part-bound statistics have
+  // been built; readers must never treat absence as an error, and must fall
+  // back to scanning for any statistic this ref does not cover. Field 11 is
+  // neither renumbered nor redefined and keeps its ADR-0850 meaning.
+  SnapshotColumnStatsPartRef column_stats_part = 13;
 }
 
 message SnapshotPartRef {
@@ -115,6 +125,22 @@ message SnapshotPostingsHeader {
 // SnapshotPostingsRef binds a name-postings object: a column-stats object is
 // only trustworthy against the parts whose blake3 hashes it names here.
 message SnapshotColumnStatsRef {
+  string key = 1;              // full object key of the column-stats object
+  bytes blake3 = 2;             // 32, of the column-stats object's full bytes
+  uint64 size = 3;
+  uint32 segment_count = 4;     // number of segments with an entry in this object
+  repeated bytes part_blake3 = 5;  // covered parts' blake3, same order as parts
+}
+
+// Reference to a part-hash-keyed column-statistics object (RCST envelope,
+// v2), ADR-0942. Mirrors SnapshotColumnStatsRef (field 11) field-for-field;
+// the difference is semantic, not structural: the covered .cstat binds its
+// per-segment statistics to a part's blake3 rather than to the ADR-0850
+// five-field identity tuple, so it covers L1 (and rewrite-output) segments
+// that the tuple key cannot name uniquely. Like SnapshotColumnStatsRef it is
+// bound to the exact set of parts it was built from: it is only trustworthy
+// against the parts whose blake3 hashes it names here.
+message SnapshotColumnStatsPartRef {
   string key = 1;              // full object key of the column-stats object
   bytes blake3 = 2;             // 32, of the column-stats object's full bytes
   uint64 size = 3;

--- a/services/ravel-cli/src/catalog.rs
+++ b/services/ravel-cli/src/catalog.rs
@@ -405,6 +405,7 @@ mod tests {
             created_unix_ns: 0,
             postings: None,
             column_stats: None,
+            column_stats_part: None,
             shard_generation_count: 1,
         };
         let head_bytes = ravel_catalog::encode_head(&head).expect("encode head");

--- a/services/ravel-server/src/maintain.rs
+++ b/services/ravel-server/src/maintain.rs
@@ -2649,6 +2649,7 @@ mod tests {
             created_unix_ns: 0,
             postings: None,
             column_stats: None,
+            column_stats_part: None,
             shard_generation_count: 1,
         };
         store


### PR DESCRIPTION
Task A1 of ADR-0942. This lands the format groundwork the re-key needs and
deliberately changes no behaviour: nothing writes v2, nothing reads field 13,
and the existing L0 path is byte-for-byte identical.

COLUMN_STATS_VERSION did two jobs at once. The writer stamped it and the
decoder equality-checked it, so bumping the single constant to 2 would have
made decode_column_stats reject every v1 object, including the field-11 objects
ADR-0942's reader rule still depends on for L0 coverage. It is now a write
version, which stays 1 until A2 raises it, and an accepted read set of {1, 2}
that the decoder checks membership against. Both are single-sourced, so a later
version is added in one place rather than in mirrored literals.

v2 is accepted before anything writes one on purpose: A2's writer and this
decoder then cannot disagree at the moment v2 first appears.

SnapshotHead gains field 13, SnapshotColumnStatsPartRef, additive. Field 11
keeps its ADR-0850 meaning and is neither renumbered nor redefined. Field 12
is absent from the proto but claimed by ADR-0913 for SnapshotMaterializationRef,
so 13 is the lowest number claimed by neither.

Several files outside ravel-catalog gain one line each, all
`column_stats_part: None`. Adding a field to SnapshotHead forces every
exhaustive construction site to name it, and absent keeps the encoded HEAD
identical to what the current fold writes.

Fixes nothing on its own by design. A2 makes the fold build and publish
part-bound records, A3 makes the reader join on the part hash, and A4 adds the
backfill pass without which none of it moves a byte on an already-compacted
tenant.

Refs: #949, #942
