### PR TITLE
feat(bench): reconcile bench report provenance and add MetricsBench renderer

### DIFF
--- a/crates/ravel-bench/Cargo.toml
+++ b/crates/ravel-bench/Cargo.toml
@@ -221,6 +221,15 @@ name = "metricsbench_gen"
 path = "src/bin/metricsbench_gen.rs"
 bench = false
 
+# MetricsBench report tool (ADR-0927, issue #936): validates and renders the
+# reconciled report artifact, and stamps its provenance. In the default feature
+# set on purpose: it is the entry point that makes the report_schema validation
+# reachable from a real caller, so a malformed artifact fails through it.
+[[bin]]
+name = "metricsbench_report"
+path = "src/bin/metricsbench_report.rs"
+bench = false
+
 [[bin]]
 name = "segment_alloc_profile"
 path = "src/bin/segment_alloc_profile.rs"
@@ -393,6 +402,14 @@ bench = false
 [[test]]
 name = "metricsbench_artifacts"
 path = "tests/metricsbench_artifacts.rs"
+bench = false
+
+# Reachability for the reconciled report schema (issue #936): a malformed report
+# artifact must fail through the shipping `metricsbench_report` binary, not only
+# through a direct `report_schema::validate` call.
+[[test]]
+name = "metricsbench_report"
+path = "tests/metricsbench_report.rs"
 bench = false
 
 [[test]]

--- a/crates/ravel-bench/src/bin/metricsbench_report.rs
+++ b/crates/ravel-bench/src/bin/metricsbench_report.rs
@@ -103,37 +103,73 @@ fn command_stdout(program: &str, args: &[&str]) -> Option<String> {
 }
 
 /// The commit these numbers describe. `GITHUB_SHA` (set by CI) wins so a report
-/// from a detached HEAD still names the branch tip; otherwise ask git.
-fn git_commit() -> String {
-    if let Ok(sha) = std::env::var("GITHUB_SHA")
-        && !sha.trim().is_empty()
+/// from a detached HEAD still names the branch tip; otherwise ask git. A build
+/// whose commit cannot be identified is a loud error at stamp time, never a
+/// sentinel that reads like data (ADR-0927: a figure without its provenance is
+/// not evidence).
+fn git_commit() -> Result<String, String> {
+    resolve_git_commit(
+        std::env::var("GITHUB_SHA").ok(),
+        command_stdout("git", &["rev-parse", "HEAD"]),
+    )
+}
+
+/// The decision `git_commit` makes, split out so it is testable without a git
+/// checkout: `from_git` is exactly what `command_stdout` yields, i.e. `None`
+/// when the git command is absent or fails.
+fn resolve_git_commit(env_sha: Option<String>, from_git: Option<String>) -> Result<String, String> {
+    if let Some(sha) = env_sha
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
     {
-        return sha.trim().to_string();
+        return Ok(sha);
     }
-    command_stdout("git", &["rev-parse", "HEAD"]).unwrap_or_else(|| "unknown".to_string())
+    from_git.ok_or_else(|| {
+        "cannot determine ravel_git_commit: GITHUB_SHA is unset and `git rev-parse HEAD` produced \
+         no output (run on a git checkout with git installed, or set GITHUB_SHA)"
+            .to_string()
+    })
 }
 
-fn toolchain() -> String {
-    command_stdout("rustc", &["--version"]).unwrap_or_else(|| "unknown".to_string())
+fn toolchain() -> Result<String, String> {
+    command_stdout("rustc", &["--version"]).ok_or_else(|| {
+        "cannot determine toolchain: `rustc --version` produced no output (is rustc on PATH?)"
+            .to_string()
+    })
 }
 
+/// `uname -srm`, falling back to the compile-time OS constant. This is a genuine
+/// OS identifier, not a missing-data sentinel, so it stays infallible.
 fn os_string() -> String {
     command_stdout("uname", &["-srm"]).unwrap_or_else(|| std::env::consts::OS.to_string())
 }
 
-/// First `model name` line of `/proc/cpuinfo`, the human CPU name.
-fn cpu_model() -> String {
-    let Ok(text) = std::fs::read_to_string("/proc/cpuinfo") else {
-        return "unknown".to_string();
-    };
-    for line in text.lines() {
+/// The human CPU name from the first `model name` line of `/proc/cpuinfo`. An
+/// unreadable or `model name`-less `/proc/cpuinfo` is a loud error, never an
+/// `"unknown"` string masquerading as a real CPU.
+fn cpu_model() -> Result<String, String> {
+    let text = std::fs::read_to_string("/proc/cpuinfo")
+        .map_err(|e| format!("cannot determine hardware.cpu_model: read /proc/cpuinfo: {e}"))?;
+    parse_cpu_model(&text).ok_or_else(|| {
+        "cannot determine hardware.cpu_model: no non-empty `model name` line in /proc/cpuinfo"
+            .to_string()
+    })
+}
+
+/// The first non-empty `model name` value in `/proc/cpuinfo` content. Split from
+/// the file read so the parse is testable on fixed input.
+fn parse_cpu_model(cpuinfo: &str) -> Option<String> {
+    for line in cpuinfo.lines() {
         if let Some((key, value)) = line.split_once(':')
             && key.trim() == "model name"
         {
-            return value.trim().to_string();
+            let model = value.trim();
+            if !model.is_empty() {
+                return Some(model.to_string());
+            }
         }
     }
-    "unknown".to_string()
+    None
 }
 
 fn logical_cores() -> u32 {
@@ -216,12 +252,12 @@ fn run() -> Result<(), String> {
                 .collect::<Result<Vec<_>, _>>()?;
             let provenance = Provenance {
                 schema_version: SCHEMA_VERSION,
-                ravel_git_commit: git_commit(),
-                toolchain: toolchain(),
+                ravel_git_commit: git_commit()?,
+                toolchain: toolchain()?,
                 protocol,
                 hardware: Hardware {
                     os: os_string(),
-                    cpu_model: cpu_model(),
+                    cpu_model: cpu_model()?,
                     logical_cores: logical_cores(),
                     instance_type: std::env::var("RAVEL_INSTANCE_TYPE")
                         .ok()
@@ -296,5 +332,64 @@ fn main() -> ExitCode {
             eprintln!("metricsbench_report: {err}");
             ExitCode::FAILURE
         }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    /// A git command that produces nothing (what `command_stdout` returns when
+    /// git is absent or fails) is an ERROR that names the missing field, not a
+    /// sentinel. `from_git = None` is exactly the failing-command case.
+    #[test]
+    fn a_failed_git_command_is_an_error_naming_the_field() {
+        let err = resolve_git_commit(None, None)
+            .expect_err("no GITHUB_SHA and a failed git command must error");
+        assert!(
+            err.contains("ravel_git_commit"),
+            "the error must name the missing field, got: {err}"
+        );
+    }
+
+    /// `GITHUB_SHA` wins over git and is trimmed.
+    #[test]
+    fn github_sha_is_used_and_trimmed() {
+        assert_eq!(
+            resolve_git_commit(Some("  abc123  ".to_string()), None).unwrap(),
+            "abc123"
+        );
+    }
+
+    /// A blank `GITHUB_SHA` falls through to git.
+    #[test]
+    fn a_blank_github_sha_falls_through_to_git() {
+        assert_eq!(
+            resolve_git_commit(Some("   ".to_string()), Some("deadbeef".to_string())).unwrap(),
+            "deadbeef"
+        );
+    }
+
+    /// A `/proc/cpuinfo` with no `model name` line yields no CPU model, so
+    /// `cpu_model` errors rather than returning `"unknown"`.
+    #[test]
+    fn cpuinfo_without_a_model_name_line_has_no_cpu_model() {
+        assert_eq!(parse_cpu_model("processor : 0\nvendor_id : X\n"), None);
+    }
+
+    /// A blank `model name` value is not a CPU model either.
+    #[test]
+    fn a_blank_model_name_value_has_no_cpu_model() {
+        assert_eq!(parse_cpu_model("model name :    \n"), None);
+    }
+
+    /// A real `model name` line parses to its trimmed value.
+    #[test]
+    fn a_model_name_line_parses_to_its_value() {
+        assert_eq!(
+            parse_cpu_model("model name : AMD EPYC 7R13\n"),
+            Some("AMD EPYC 7R13".to_string())
+        );
     }
 }

--- a/crates/ravel-bench/src/bin/metricsbench_report.rs
+++ b/crates/ravel-bench/src/bin/metricsbench_report.rs
@@ -1,0 +1,300 @@
+//! MetricsBench report tool (ADR-0927, issue #936).
+//!
+//! This is the entry point that makes the reconciled report schema
+//! ([`ravel_bench::report_schema`]) reachable from a real caller, in both
+//! directions:
+//!
+//! - `render --report <path>` reads a report artifact, runs
+//!   [`ravel_bench::report_schema::validate`] over it, and only then renders the
+//!   table with [`ravel_bench::report_schema::render`]. A malformed artifact
+//!   fails through this binary (a non-zero exit and the specific error on
+//!   stderr), not only through a direct call to the validator, so the
+//!   fail-closed contract is enforced where a consumer actually runs it. The
+//!   renderer derives its table entirely from the artifact; it is never
+//!   hand-maintained.
+//! - `provenance` gathers the reconciled provenance a producer stamps on a
+//!   report: the Ravel git commit, the toolchain, the hardware, the object-store
+//!   backend, and the content digests of the workload manifest and PromQL
+//!   corpus. The subprocess and `/proc` reads live here, off the library's
+//!   deterministic path, exactly as `bench_report` and `bench_env` do. It emits
+//!   the [`ravel_bench::report_schema::Provenance`] shape, so the emit and the
+//!   consume sides speak one type.
+//!
+//! The measurement-producing harness (ADR-0927 decision 1) is separate work;
+//! this tool checks and renders the artifact it produces, and stamps the
+//! provenance it carries.
+#![allow(clippy::expect_used)]
+
+use std::path::PathBuf;
+use std::process::{Command, ExitCode};
+
+use clap::{Parser, Subcommand};
+use ravel_bench::report_schema::{
+    Backend, Comparator, ConfigEntry, Hardware, MetricsBenchReport, Provenance, SCHEMA_VERSION,
+    render, validate,
+};
+
+#[derive(Parser, Debug)]
+#[command(about = "Validate and render a MetricsBench report, or stamp its provenance (ADR-0927)")]
+struct Args {
+    #[command(subcommand)]
+    command: CommandKind,
+}
+
+#[derive(Subcommand, Debug)]
+enum CommandKind {
+    /// Validate a report artifact and render its table. A report that fails
+    /// validation exits non-zero with the specific error, before any table or
+    /// summary is produced.
+    Render {
+        /// The report artifact to validate and render.
+        #[arg(long)]
+        report: PathBuf,
+    },
+    /// Gather and print the reconciled provenance block a producer stamps on a
+    /// report. The digests are the content digests of the two named artifacts.
+    Provenance {
+        /// The workload manifest whose content digest becomes `generator_digest`.
+        #[arg(long)]
+        workload: PathBuf,
+        /// The PromQL corpus whose content digest becomes `corpus_digest`.
+        #[arg(long)]
+        corpus: PathBuf,
+        /// The ingest/query protocol the run drove.
+        #[arg(long, default_value = "remote_write_1.0")]
+        protocol: String,
+        /// The object-store backend name.
+        #[arg(long, default_value = "memory")]
+        store_backend: String,
+        /// The backend region, or the `"n/a"` sentinel.
+        #[arg(long, default_value = "n/a")]
+        region: String,
+        /// The backend endpoint, or the `"n/a"` sentinel.
+        #[arg(long, default_value = "n/a")]
+        endpoint: String,
+        /// Whether the backend bills requests (true only for the real-S3 lane,
+        /// ADR-0927 decision 10).
+        #[arg(long, default_value_t = false)]
+        bills_requests: bool,
+        /// A comparator pin, `name=version=image_digest`, repeatable. Omitted for
+        /// a Ravel-only diagnostic run.
+        #[arg(long = "comparator", value_name = "NAME=VERSION=DIGEST")]
+        comparators: Vec<String>,
+        /// A non-default configuration entry, `key=value`, repeatable.
+        #[arg(long = "config", value_name = "KEY=VALUE")]
+        config: Vec<String>,
+    },
+}
+
+/// Trimmed stdout of `program args`, or `None` on any failure. Provenance must
+/// never be a silent wrong value, so the caller decides the fallback.
+fn command_stdout(program: &str, args: &[&str]) -> Option<String> {
+    let output = Command::new(program).args(args).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let text = String::from_utf8(output.stdout).ok()?;
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+/// The commit these numbers describe. `GITHUB_SHA` (set by CI) wins so a report
+/// from a detached HEAD still names the branch tip; otherwise ask git.
+fn git_commit() -> String {
+    if let Ok(sha) = std::env::var("GITHUB_SHA")
+        && !sha.trim().is_empty()
+    {
+        return sha.trim().to_string();
+    }
+    command_stdout("git", &["rev-parse", "HEAD"]).unwrap_or_else(|| "unknown".to_string())
+}
+
+fn toolchain() -> String {
+    command_stdout("rustc", &["--version"]).unwrap_or_else(|| "unknown".to_string())
+}
+
+fn os_string() -> String {
+    command_stdout("uname", &["-srm"]).unwrap_or_else(|| std::env::consts::OS.to_string())
+}
+
+/// First `model name` line of `/proc/cpuinfo`, the human CPU name.
+fn cpu_model() -> String {
+    let Ok(text) = std::fs::read_to_string("/proc/cpuinfo") else {
+        return "unknown".to_string();
+    };
+    for line in text.lines() {
+        if let Some((key, value)) = line.split_once(':')
+            && key.trim() == "model name"
+        {
+            return value.trim().to_string();
+        }
+    }
+    "unknown".to_string()
+}
+
+fn logical_cores() -> u32 {
+    std::thread::available_parallelism()
+        .map(|n| n.get() as u32)
+        .unwrap_or(1)
+}
+
+/// The content digest of a file, `blake3:<hex>`, or an error naming the path.
+fn file_digest(path: &std::path::Path) -> Result<String, String> {
+    let bytes = std::fs::read(path).map_err(|e| format!("read {}: {e}", path.display()))?;
+    Ok(format!("blake3:{}", blake3::hash(&bytes).to_hex()))
+}
+
+/// Parse a `name=version=digest` comparator pin.
+fn parse_comparator(spec: &str) -> Result<Comparator, String> {
+    let parts: Vec<&str> = spec.splitn(3, '=').collect();
+    if parts.len() != 3 || parts.iter().any(|p| p.is_empty()) {
+        return Err(format!(
+            "comparator `{spec}` must be name=version=image_digest with all three present"
+        ));
+    }
+    Ok(Comparator {
+        name: parts[0].to_string(),
+        version: parts[1].to_string(),
+        image_digest: parts[2].to_string(),
+    })
+}
+
+/// Parse a `key=value` config entry.
+fn parse_config(spec: &str) -> Result<ConfigEntry, String> {
+    let (key, value) = spec
+        .split_once('=')
+        .ok_or_else(|| format!("config `{spec}` must be key=value"))?;
+    if key.is_empty() {
+        return Err(format!("config `{spec}` has an empty key"));
+    }
+    Ok(ConfigEntry {
+        key: key.to_string(),
+        value: value.to_string(),
+    })
+}
+
+fn run() -> Result<(), String> {
+    let args = Args::parse();
+    match args.command {
+        CommandKind::Render { report } => {
+            let text = std::fs::read_to_string(&report)
+                .map_err(|e| format!("read report {}: {e}", report.display()))?;
+            let doc: MetricsBenchReport = serde_json::from_str(&text).map_err(|e| {
+                format!(
+                    "report {} is not a valid MetricsBench report: {e}",
+                    report.display()
+                )
+            })?;
+            // `render` runs `validate` first; a malformed artifact fails here,
+            // through this binary, not only through a direct validator call.
+            let rendered = render(&doc).map_err(|e| e.to_string())?;
+            print!("{rendered}");
+            Ok(())
+        }
+        CommandKind::Provenance {
+            workload,
+            corpus,
+            protocol,
+            store_backend,
+            region,
+            endpoint,
+            bills_requests,
+            comparators,
+            config,
+        } => {
+            let comparators = comparators
+                .iter()
+                .map(|s| parse_comparator(s))
+                .collect::<Result<Vec<_>, _>>()?;
+            let config = config
+                .iter()
+                .map(|s| parse_config(s))
+                .collect::<Result<Vec<_>, _>>()?;
+            let provenance = Provenance {
+                schema_version: SCHEMA_VERSION,
+                ravel_git_commit: git_commit(),
+                toolchain: toolchain(),
+                protocol,
+                hardware: Hardware {
+                    os: os_string(),
+                    cpu_model: cpu_model(),
+                    logical_cores: logical_cores(),
+                    instance_type: std::env::var("RAVEL_INSTANCE_TYPE")
+                        .ok()
+                        .filter(|t| !t.trim().is_empty()),
+                },
+                backend: Backend {
+                    store_backend,
+                    region,
+                    endpoint,
+                    backend_bills_requests: bills_requests,
+                },
+                comparators,
+                generator_digest: file_digest(&workload)?,
+                corpus_digest: file_digest(&corpus)?,
+                config,
+            };
+            // Prove the stamp we emit is one a report would accept: a producer
+            // that pasted this block into a report and then failed validation on
+            // it would be a silent contract break.
+            if let Err(err) = validate_provenance_only(&provenance) {
+                return Err(format!("gathered provenance does not validate: {err}"));
+            }
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&provenance)
+                    .map_err(|e| format!("serialize provenance: {e}"))?
+            );
+            Ok(())
+        }
+    }
+}
+
+/// Validate just the provenance, by validating a minimal report built around it.
+/// `report_schema::validate` is the whole-report entry point, so the provenance
+/// stamp is checked through the same code a consumer runs, with one dummy timed
+/// measurement standing in for the harness's rows.
+fn validate_provenance_only(
+    p: &Provenance,
+) -> Result<(), ravel_bench::report_schema::ValidationError> {
+    use ravel_bench::promql_corpus::CostClass;
+    use ravel_bench::report_schema::{Figure, Measurement, ResultStatus};
+    let probe = MetricsBenchReport {
+        provenance: p.clone(),
+        measurements: vec![Measurement {
+            id: "provenance_probe".to_string(),
+            class: CostClass::MetadataOnly,
+            status: ResultStatus::Ok,
+            figures: vec![
+                Figure {
+                    name: "min_ms".to_string(),
+                    value: 0.0,
+                },
+                Figure {
+                    name: "median_ms".to_string(),
+                    value: 0.0,
+                },
+                Figure {
+                    name: "max_ms".to_string(),
+                    value: 0.0,
+                },
+            ],
+        }],
+        geomean_ms: None,
+    };
+    validate(&probe)
+}
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(err) => {
+            eprintln!("metricsbench_report: {err}");
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/crates/ravel-bench/src/bin/sql_latency_bench.rs
+++ b/crates/ravel-bench/src/bin/sql_latency_bench.rs
@@ -3,7 +3,11 @@
 //! Thin wrapper around `ravel_bench::sql_latency`: it parses the dataset source
 //! (`--generate` or `--tenant <id>`) and the store flag, classifies the backend
 //! for the report's provenance, drives the measurement core, and prints the
-//! report as JSON plus a human table.
+//! machine-readable report as JSON on stdout and the human-readable summary on
+//! stderr. The two streams are kept separate on purpose (issue #936): stdout is
+//! the artifact alone, so it parses as one complete JSON document with nothing
+//! appended, and a check over it (`jq -e '.'`) cannot break on a trailing
+//! summary line.
 //!
 //! Gated behind the `sql-latency` feature so the default build never compiles
 //! ravel-sql/datafusion/arrow or this bin.
@@ -556,11 +560,17 @@ fn provenance_header(p: &Provenance, d: &DatasetInfo) -> String {
     out
 }
 
+/// Print the human-readable summary to STDERR, keeping stdout the
+/// machine-readable JSON artifact alone (issue #936). Writing a valid JSON
+/// document to stdout and then appending this table to the same stream left the
+/// artifact unparseable (`jq -e '.' report.json` failed at the first summary
+/// line), so nothing could assert on it. The two streams are separated here: the
+/// JSON is the only thing on stdout, and this diagnostic table goes to stderr.
 fn print_human_table(report: &SqlLatencyReport) {
     let p = &report.provenance;
     let d = &report.dataset;
-    print!("{}", provenance_header(p, d));
-    println!();
+    eprint!("{}", provenance_header(p, d));
+    eprintln!();
     // `get` is the cold run's object-store GETs; the `w_` columns are the warm
     // run's (run 1) GETs, store bytes, and fetch-cache hits, so a reader can see
     // whether the second execution dropped to plan reads only or still fetched
@@ -575,7 +585,7 @@ fn print_human_table(report: &SqlLatencyReport) {
     // rises alongside `pmiss` is a probe too short; one that rises with `pmiss`
     // flat is not. The per-phase split is in the report JSON's
     // `per_run_accounting`.
-    println!(
+    eprintln!(
         "  {:<32} | {:>9} | {:>9} | {:>9} | {:>9} | {:>7} | {:>7} | {:>7} | {:>7} | {:>7} | {:>7} | {:>9} | {:>7}",
         "id",
         "min ms",
@@ -591,7 +601,7 @@ fn print_human_table(report: &SqlLatencyReport) {
         "w_bytes",
         "w_hit"
     );
-    println!(
+    eprintln!(
         "  {:-<32}-+-{:-<9}-+-{:-<9}-+-{:-<9}-+-{:-<9}-+-{:-<7}-+-{:-<7}-+-{:-<7}-+-{:-<7}-+-{:-<7}-+-{:-<7}-+-{:-<9}-+-{:-<7}",
         "", "", "", "", "", "", "", "", "", "", "", "", ""
     );
@@ -623,7 +633,7 @@ fn print_human_table(report: &SqlLatencyReport) {
             Some([cold, ..]) => (cold.probe_misses_plan + cold.probe_misses_scan).to_string(),
             _ => "-".to_string(),
         };
-        println!(
+        eprintln!(
             "  {:<32} | {:>9.3} | {:>9.3} | {:>9.3} | {:>9.3} | {:>7} | {:>7} | {:>7} | {:>7} | {:>7} | {:>7} | {:>9} | {:>7}",
             e.id,
             e.min_ms,
@@ -643,15 +653,15 @@ fn print_human_table(report: &SqlLatencyReport) {
     print_open_shapes(report);
     print_fetch_amplification(report);
     if !report.skipped.is_empty() {
-        println!("\n  skipped (unsatisfied declared column):");
+        eprintln!("\n  skipped (unsatisfied declared column):");
         for s in &report.skipped {
-            println!("    {:<32} missing `{}`: {}", s.id, s.missing_key, s.reason);
+            eprintln!("    {:<32} missing `{}`: {}", s.id, s.missing_key, s.reason);
         }
     }
     if !report.failed.is_empty() {
-        println!("\n  failed (executed, no number):");
+        eprintln!("\n  failed (executed, no number):");
         for f in &report.failed {
-            println!("    {:<32} run {}: {}", f.id, f.run, f.error);
+            eprintln!("    {:<32} run {}: {}", f.id, f.run, f.error);
         }
     }
 }
@@ -680,18 +690,20 @@ fn print_open_shapes(report: &SqlLatencyReport) {
     if rows.is_empty() {
         return;
     }
-    println!("\n  logs-scan fast-path opens, cold run: SEGMENT opens by read shape, not requests.");
-    println!(
+    eprintln!(
+        "\n  logs-scan fast-path opens, cold run: SEGMENT opens by read shape, not requests."
+    );
+    eprintln!(
         "  One statement can take both routes; a ranged open issues several GETs, so these are"
     );
-    println!("  not the `get` column above and cannot be summed with it.");
-    println!(
+    eprintln!("  not the `get` column above and cannot be summed with it.");
+    eprintln!(
         "  {:<32} | {:>18} | {:>12}",
         "id", "whole_object_opens", "ranged_opens",
     );
-    println!("  {:-<32}-+-{:-<18}-+-{:-<12}", "", "", "");
+    eprintln!("  {:-<32}-+-{:-<18}-+-{:-<12}", "", "", "");
     for (id, acc) in rows {
-        println!(
+        eprintln!(
             "  {:<32} | {:>18} | {:>12}",
             id, acc.logs_whole_object_opens, acc.logs_ranged_opens,
         );
@@ -718,16 +730,16 @@ fn print_fetch_amplification(report: &SqlLatencyReport) {
     if rows.is_empty() {
         return;
     }
-    println!(
+    eprintln!(
         "\n  fetch amplification, cold run: scan-phase WIRE bytes per STORED page byte decoded."
     );
-    println!(
+    eprintln!(
         "  Probe, PAGE_DIR, SKIP_IDX and directory bytes are the plan/probe phases, not the numerator."
     );
-    println!(
+    eprintln!(
         "  Not the same quantity as page_bytes_fetched / page_bytes_decoded, which is stored over stored."
     );
-    println!(
+    eprintln!(
         "  {:<32} | {:>16} | {:>16} | {:>16} | {:>16} | {:>16} | {:>25} | {:>13}",
         "id",
         "wire_bytes_scan",
@@ -738,7 +750,7 @@ fn print_fetch_amplification(report: &SqlLatencyReport) {
         "page_stored_bytes_decoded",
         "amplification",
     );
-    println!(
+    eprintln!(
         "  {:-<32}-+-{:-<16}-+-{:-<16}-+-{:-<16}-+-{:-<16}-+-{:-<16}-+-{:-<25}-+-{:-<13}",
         "", "", "", "", "", "", "", ""
     );
@@ -749,7 +761,7 @@ fn print_fetch_amplification(report: &SqlLatencyReport) {
             .map_or("-".to_string(), |p| p.wire_bytes.to_string())
     };
     for (id, acc) in rows {
-        println!(
+        eprintln!(
             "  {:<32} | {:>16} | {:>16} | {:>16} | {:>16} | {:>16} | {:>25} | {:>13.3}",
             id,
             phase(acc, "scan"),

--- a/crates/ravel-bench/src/lib.rs
+++ b/crates/ravel-bench/src/lib.rs
@@ -24,6 +24,7 @@ pub mod query_latency;
 #[cfg(feature = "parquet-baseline")]
 pub mod read_accounting;
 pub mod report;
+pub mod report_schema;
 pub mod section_accounting;
 pub mod segment_support;
 #[cfg(feature = "sql-latency")]

--- a/crates/ravel-bench/src/report_schema.rs
+++ b/crates/ravel-bench/src/report_schema.rs
@@ -312,8 +312,9 @@ pub enum ValidationError {
         /// The version this build reads ([`SCHEMA_VERSION`]).
         expected: u32,
     },
-    /// A required provenance field is absent (an empty string, an empty digest,
-    /// zero logical cores). An absent field is not evidence.
+    /// A required provenance field is absent (an empty string, the `"unknown"`
+    /// sentinel, an empty digest, zero logical cores). An absent field is not
+    /// evidence.
     #[error(
         "required provenance field `{field}` is missing or blank; a figure without its \
          provenance is not evidence (ADR-0927)"
@@ -408,6 +409,19 @@ pub enum ValidationError {
         /// The offending value.
         value: f64,
     },
+    /// The report carries a geometric mean but not one measurement is timed. A
+    /// summary figure with no per-query row behind it is not a result: per-query
+    /// results are the source of truth and a geomean may accompany them but never
+    /// stands in for them (ADR-0927).
+    #[error(
+        "report carries geomean_ms {value} but no measurement is timed; a summary figure with no \
+         per-query row behind it is not a result (per-query results are the source of truth, \
+         ADR-0927)"
+    )]
+    GeomeanWithoutTimedRow {
+        /// The geomean value that had nothing behind it.
+        value: f64,
+    },
 }
 
 /// One required provenance string field, paired with the human name a
@@ -439,7 +453,12 @@ fn validate_provenance(p: &Provenance) -> Result<(), ValidationError> {
         });
     }
     for (field, value) in required_provenance_fields(p) {
-        if value.trim().is_empty() {
+        // A blank field is missing; so is the `"unknown"` sentinel a gatherer on
+        // a host without git or rustc used to emit. Rejecting it here pins the
+        // validator independently of any gatherer, so a future gatherer
+        // regression that reintroduces the sentinel cannot self-validate.
+        let trimmed = value.trim();
+        if trimmed.is_empty() || trimmed.eq_ignore_ascii_case("unknown") {
             return Err(ValidationError::MissingProvenanceField { field });
         }
     }
@@ -562,10 +581,16 @@ pub fn validate(report: &MetricsBenchReport) -> Result<(), ValidationError> {
         }
         validate_measurement(m)?;
     }
-    if let Some(g) = report.geomean_ms
-        && !(g.is_finite() && g > 0.0)
-    {
-        return Err(ValidationError::BadGeomean { value: g });
+    if let Some(g) = report.geomean_ms {
+        if !(g.is_finite() && g > 0.0) {
+            return Err(ValidationError::BadGeomean { value: g });
+        }
+        // A geomean summarizes the timed medians; a report whose rows are all
+        // timeout/error/refused has no timed median behind it, so the geomean
+        // summarizes nothing.
+        if !report.measurements.iter().any(|m| m.status.is_timed()) {
+            return Err(ValidationError::GeomeanWithoutTimedRow { value: g });
+        }
     }
     Ok(())
 }
@@ -868,6 +893,78 @@ mod tests {
             },
             "the error must name the missing field, got {err:?}"
         );
+    }
+
+    /// The validator rejects the `"unknown"` sentinel a gatherer on a host
+    /// without git used to emit, independently of the gatherer. This test pins
+    /// the validator even after the gatherer can no longer produce the sentinel:
+    /// a future gatherer regression that reintroduces it cannot slip a report
+    /// carrying `ravel_git_commit: "unknown"` past `validate`.
+    #[test]
+    fn a_report_with_an_unknown_sentinel_git_commit_fails_validation() {
+        let mut report = valid_report();
+        report.provenance.ravel_git_commit = "unknown".to_string();
+        let err = validate(&report).expect_err("an `unknown` sentinel git commit must fail");
+        assert_eq!(
+            err,
+            ValidationError::MissingProvenanceField {
+                field: "ravel_git_commit"
+            },
+            "the sentinel is treated as a missing field, got {err:?}"
+        );
+    }
+
+    /// `instance_type` is optional: a report with it absent (not a sentinel)
+    /// still validates. An explicit absence is not a defect; a sentinel string
+    /// standing in for one would be.
+    #[test]
+    fn a_report_with_instance_type_absent_validates() {
+        let mut report = valid_report();
+        report.provenance.hardware.instance_type = None;
+        validate(&report).expect("instance_type is optional; absent still validates");
+    }
+
+    /// A geomean with at least one timed row still validates: a summary that has
+    /// per-query rows behind it is admissible.
+    #[test]
+    fn a_geomean_with_a_timed_row_validates() {
+        let report = valid_report();
+        assert!(
+            report.measurements.iter().any(|m| m.status.is_timed()),
+            "the fixture has a timed row"
+        );
+        assert!(report.geomean_ms.is_some(), "the fixture has a geomean");
+        validate(&report).expect("a geomean with a timed row validates");
+    }
+
+    /// A geomean with zero timed rows fails with the distinct typed variant: a
+    /// summary figure with no per-query row behind it is not a result (ADR-0927).
+    /// The error says the geomean had nothing behind it, not that its value was
+    /// malformed.
+    ///
+    /// This test fails against the pre-fix validator, whose geomean check was
+    ///     if let Some(g) = report.geomean_ms && !(g.is_finite() && g > 0.0) {
+    ///         return Err(ValidationError::BadGeomean { value: g });
+    ///     }
+    /// (report_schema.rs, the `geomean_ms` block near the end of `validate`): a
+    /// finite positive geomean over all-untimed rows returned `Ok(())`, so
+    /// `expect_err` found `Ok` and the test failed. The fix adds the
+    /// `GeomeanWithoutTimedRow` arm beside `BadGeomean`.
+    #[test]
+    fn a_geomean_with_no_timed_row_fails_validation() {
+        let mut report = valid_report();
+        // The only measurement becomes untimed; a non-ok row must carry no
+        // timing figures, so strip them. The geomean stays present.
+        report.measurements[0].status = ResultStatus::Timeout;
+        report.measurements[0].figures.clear();
+        assert!(
+            !report.measurements.iter().any(|m| m.status.is_timed()),
+            "no row is timed after this mutation"
+        );
+        assert_eq!(report.geomean_ms, Some(12.5));
+        let err =
+            validate(&report).expect_err("a geomean over zero timed rows must fail validation");
+        assert_eq!(err, ValidationError::GeomeanWithoutTimedRow { value: 12.5 });
     }
 
     /// Failure class: a schema version this build does not read.

--- a/crates/ravel-bench/src/report_schema.rs
+++ b/crates/ravel-bench/src/report_schema.rs
@@ -1,0 +1,1079 @@
+//! The reconciled MetricsBench report schema (ADR-0927, issue #936, task T7).
+//!
+//! Two provenance types existed before this module, and ADR-0927's Consequences
+//! section names the trap directly: `sql_latency::Provenance` records the
+//! object-store backend and a long list of executor knobs but no git commit,
+//! toolchain, digest or hardware identification, while `report::Environment`
+//! records the git commit and toolchain but no object-store accounting.
+//! "T7 must reconcile them; extending one in ignorance of the other produces a
+//! third shape."
+//!
+//! This module is that reconciliation: one [`Provenance`] carrying everything
+//! either type recorded, plus everything ADR-0927 requires that neither had (a
+//! schema version, the toolchain and git commit *together with* the backend and
+//! its accounting, comparator versions and image digests, generator and corpus
+//! digests, the protocol, the hardware, and the complete non-default
+//! configuration). It does not grow a third bespoke flat struct that copies
+//! forty named fields: the two existing types' bench-specific knobs live in the
+//! generic [`ConfigEntry`] list (`store_backend`/`region` become named
+//! [`Backend`] fields, `shard_count`/`max_flush_delay_ms`/the SQL executor
+//! ceilings become config entries), so every field either type recorded is
+//! representable here without duplicating its shape.
+//!
+//! The two existing types are the serialization of two already-shipped
+//! benchmarks (`SqlLatencyReport`, `BenchReport`) and carry `#[serde(default)]`
+//! fields precisely so old reports still deserialize; nesting them under a
+//! shared core would break that back-compatibility, so they are left in place
+//! and this is the single shape MetricsBench and any bench that adopts it
+//! converge on.
+//!
+//! ## What this module guarantees
+//!
+//! - **Fail-closed validation** ([`validate`]): a missing, duplicate,
+//!   non-finite, negative, or malformed measurement all fail, and an
+//!   absent-but-expected figure fails exactly like an out-of-band one
+//!   (ADR-0927's "Bands pre-registered" decision 5). "Exit 0" from a consumer
+//!   means the report was checked and stood, not merely that the tool ran.
+//! - **A renderer** ([`render`]) that derives its table FROM the artifact and
+//!   is never hand-maintained. It follows the ClickBench runbook script's proven
+//!   design: integrity is asserted by identity before any band is applied, the
+//!   bands are named constants in one block, and a stated gap is a loud SKIP
+//!   rather than a silently unasserted figure.
+//! - **Per-query results are the source of truth.** A geometric mean may be
+//!   included but never replaces the per-query rows, and the renderer cannot
+//!   print a summary line without the rows behind it.
+//! - **Every cost estimate carries the retry caveat** ([`RETRY_CAVEAT`],
+//!   ADR-0927 decision 8, issue #928): request counts are logical-call counts,
+//!   not billed requests, and the caveat is in the rendered output rather than
+//!   only in a doc.
+//!
+//! Report-only, like the rest of `ravel-bench`: this never changes library
+//! behaviour, it only describes and checks a measurement.
+
+use std::collections::BTreeSet;
+use std::fmt::Write as _;
+
+use serde::{Deserialize, Serialize};
+
+use crate::promql_corpus::CostClass;
+
+/// The report schema version. A report declaring any other version is refused
+/// rather than parsed optimistically (the same contract
+/// [`crate::promql_corpus::CORPUS_FORMAT_VERSION`] carries): the field exists so
+/// a future schema change is a loud error, not a silently misread document.
+pub const SCHEMA_VERSION: u32 = 1;
+
+/// The retry-blindness caveat every cost estimate carries (ADR-0927 decision 8,
+/// issue #928). `object_store` retries below `InstrumentedStore` with
+/// `max_retries = 10`, so one logical `get()` that retried nine times records
+/// one request while S3 bills ten. Every request figure in this repository is a
+/// logical-call count, not a billed-request count, and under throttling the
+/// real bill exceeds every counted number. This lives in the rendered output,
+/// not only in a doc.
+pub const RETRY_CAVEAT: &str = "request counts are logical-call counts, not billed requests: \
+    object_store retries below InstrumentedStore (max_retries=10), so under throttling the real \
+    bill exceeds every counted number and nothing here measures the gap (ADR-0927 decision 8, #928)";
+
+/// The statuses ADR-0927 decision 6 fixes. Every outcome has exactly one, and
+/// only [`ResultStatus::Ok`] is admissible in a timing table. Kept as a typed
+/// enum rather than a bare string so a status the harness cannot spell is a
+/// deserialization error, not a silently dropped row.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ResultStatus {
+    /// Answered, and the oracle agrees. The only status that is timed.
+    Ok,
+    /// Answered, but the oracle disagrees.
+    Incorrect,
+    /// Answered from an incomplete result set, and correct as far as it goes.
+    Partial,
+    /// No answer within the per-query deadline.
+    Timeout,
+    /// A transport or server error that is none of the above.
+    Error,
+    /// The engine does not implement the query.
+    UnsupportedConstruct,
+    /// The engine implements it and deliberately declined, returning no result.
+    Refused,
+}
+
+impl ResultStatus {
+    /// Whether a latency from a measurement with this status is admissible in a
+    /// performance table. Only `ok` is timed (ADR-0927 decision 6).
+    pub fn is_timed(self) -> bool {
+        matches!(self, ResultStatus::Ok)
+    }
+
+    /// The slug this status renders as.
+    pub fn slug(self) -> &'static str {
+        match self {
+            ResultStatus::Ok => "ok",
+            ResultStatus::Incorrect => "incorrect",
+            ResultStatus::Partial => "partial",
+            ResultStatus::Timeout => "timeout",
+            ResultStatus::Error => "error",
+            ResultStatus::UnsupportedConstruct => "unsupported_construct",
+            ResultStatus::Refused => "refused",
+        }
+    }
+}
+
+/// The hardware a run measured on. `instance_type` is `Option` because it is
+/// knowable on a cloud host and not on a laptop; ADR-0927 asks for it "where
+/// knowable" and a sentinel string would read as a real instance type.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Hardware {
+    /// `uname -srm` or equivalent.
+    pub os: String,
+    /// The human CPU model string (`/proc/cpuinfo`'s `model name`).
+    pub cpu_model: String,
+    /// Logical cores on the measuring host. Zero is never valid.
+    pub logical_cores: u32,
+    /// The cloud instance type, when the host can name it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub instance_type: Option<String>,
+}
+
+/// The object-store backend a run measured against, and whether its requests
+/// are billed. Reconciles `sql_latency::Provenance`'s
+/// `store_backend`/`region`/`endpoint` with `report::Environment`'s
+/// `store_backend`/`region` and `RequestCounts::backend_bills_requests`, so the
+/// honest "these counts are real but free" (`MemoryStore`) versus "these counts
+/// are billable" (S3) distinction rides beside the backend (ADR-0927 decision
+/// 8, ADR-0075 decision 3).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Backend {
+    /// `"memory"`, `"minio"`, or `"s3"`.
+    pub store_backend: String,
+    /// Backend region, or the sentinel `"n/a"` for a backend with none, keeping
+    /// the no-null contract.
+    pub region: String,
+    /// Backend endpoint, or `"n/a"` when the backend has none.
+    pub endpoint: String,
+    /// Whether a request against this backend is billed. `false` for
+    /// `MemoryStore` (real counts, but free); `true` for S3. Only the real-S3
+    /// lane produces a publishable cost claim (ADR-0927 decision 10).
+    pub backend_bills_requests: bool,
+}
+
+/// One comparator engine a portable-lane run was measured against, pinned by
+/// version and image digest (ADR-0927 decision 4). A Ravel-only diagnostic run
+/// carries an empty comparator list; a portable-lane run that names a comparator
+/// must name it completely, which [`validate`] enforces.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Comparator {
+    /// The engine name, e.g. `"prometheus"`, `"victoriametrics"`.
+    pub name: String,
+    /// The engine version, e.g. `"3.13.1"`.
+    pub version: String,
+    /// The container image digest the deployment was pinned to.
+    pub image_digest: String,
+}
+
+/// One non-default configuration setting the run applied. The complete
+/// non-default configuration (ADR-0927 decision requirement) is carried as a
+/// list of these rather than as a fixed set of named fields, so both
+/// `report::Environment`'s `shard_count`/`max_flush_delay_ms` and
+/// `sql_latency::Provenance`'s executor ceilings map into one shape without this
+/// type having to grow a named field per knob of every bench that adopts it.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ConfigEntry {
+    /// The setting name, as the CLI flag or config key spells it.
+    pub key: String,
+    /// The value it was set to, rendered as a string so heterogeneous knobs
+    /// share one shape.
+    pub value: String,
+}
+
+/// The reconciled provenance block: everything a MetricsBench figure needs
+/// beside it to be evidence, and a schema version so the shape cannot change
+/// silently.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Provenance {
+    /// The report schema version, which must equal [`SCHEMA_VERSION`].
+    pub schema_version: u32,
+    /// The Ravel git commit the numbers describe.
+    pub ravel_git_commit: String,
+    /// The Rust toolchain that built the measuring binary (`rustc --version`).
+    pub toolchain: String,
+    /// The ingest/query protocol the run drove, e.g. `"remote_write_1.0"` for
+    /// the portable lane or `"in_process_promql"` for a diagnostic run. Named
+    /// because a Remote Write 1.0 figure is never comparable with a 2.0 or OTLP
+    /// figure (ADR-0927 decision 2).
+    pub protocol: String,
+    /// The measuring host.
+    pub hardware: Hardware,
+    /// The object-store backend and its billing status.
+    pub backend: Backend,
+    /// The comparator engines, pinned by version and image digest. Empty for a
+    /// Ravel-only diagnostic run.
+    #[serde(default)]
+    pub comparators: Vec<Comparator>,
+    /// A digest identifying the deterministic generator, so a report names
+    /// exactly which samples it measured: the `generation.digest`
+    /// `metricsbench_gen` stamps on a real run, or the workload manifest's
+    /// content digest a provenance stamp uses before a run exists.
+    pub generator_digest: String,
+    /// The content digest of the PromQL corpus the run measured, so a report
+    /// names exactly which queries it ran.
+    pub corpus_digest: String,
+    /// The complete non-default configuration.
+    #[serde(default)]
+    pub config: Vec<ConfigEntry>,
+}
+
+/// One figure a measurement reports, named so the report is self-describing and
+/// a consumer can find a figure by name rather than by position.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Figure {
+    /// The figure name, e.g. `"median_ms"`, `"object_store_get_requests"`.
+    pub name: String,
+    /// The value. Validated finite and non-negative: a benchmark reports no
+    /// negative latency or byte count, and a NaN would make every band
+    /// comparison against it read as MET (the exact trap the runbook's
+    /// `byte_count` guards against).
+    pub value: f64,
+}
+
+/// One measured corpus query: its id, cost class, per-engine status, and the
+/// figures behind it. Per-query results are the source of truth (ADR-0927): the
+/// report-level geometric mean is derived from these and never replaces them.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Measurement {
+    /// The corpus entry id (`CorpusEntry::id`). Report rows are keyed by it, so
+    /// it must be unique within a report.
+    pub id: String,
+    /// The cost class the entry falls into (ADR-0927 decision 5).
+    pub class: CostClass,
+    /// The outcome status (ADR-0927 decision 6). Only [`ResultStatus::Ok`] is
+    /// timed.
+    pub status: ResultStatus,
+    /// The figures this measurement reports. An `ok` measurement must carry the
+    /// timing figures in [`REQUIRED_TIMED_FIGURES`]; a non-`ok` measurement is
+    /// not timed and carries none of them.
+    #[serde(default)]
+    pub figures: Vec<Figure>,
+}
+
+impl Measurement {
+    /// The value of the figure named `name`, or `None` if absent.
+    pub fn figure(&self, name: &str) -> Option<f64> {
+        self.figures
+            .iter()
+            .find(|f| f.name == name)
+            .map(|f| f.value)
+    }
+}
+
+/// The timing figures every `ok` (timed) measurement must carry. An `ok`
+/// measurement missing any of them fails validation exactly like an out-of-band
+/// figure (ADR-0927 decision 5: "absent-but-expected fails identically to
+/// out-of-band"). Non-`ok` measurements must carry none of them, because only
+/// `ok` is timed.
+pub const REQUIRED_TIMED_FIGURES: &[&str] = &["min_ms", "median_ms", "max_ms"];
+
+/// The full reconciled report: the provenance, the per-query measurements, and
+/// an optional report-level geometric mean.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MetricsBenchReport {
+    /// The provenance block.
+    pub provenance: Provenance,
+    /// The per-query measurements, the source of truth.
+    pub measurements: Vec<Measurement>,
+    /// A report-level geometric mean of the timed medians, if the producer
+    /// computed one. It may be included but never replaces the per-query rows;
+    /// [`render`] cannot print it without them.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub geomean_ms: Option<f64>,
+}
+
+/// Everything [`validate`] can reject, one variant per failure class the task
+/// enumerates. Each names what is at fault and, where a figure is involved,
+/// which measurement and which figure, so the message is the signal a consumer
+/// acts on.
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
+pub enum ValidationError {
+    /// The report declares a schema version this build does not read.
+    #[error(
+        "report declares schema version {found}, but this build reads version {expected}; a \
+         schema change is a version bump, never a silently misread document"
+    )]
+    SchemaVersionMismatch {
+        /// The version the document declared.
+        found: u32,
+        /// The version this build reads ([`SCHEMA_VERSION`]).
+        expected: u32,
+    },
+    /// A required provenance field is absent (an empty string, an empty digest,
+    /// zero logical cores). An absent field is not evidence.
+    #[error(
+        "required provenance field `{field}` is missing or blank; a figure without its \
+         provenance is not evidence (ADR-0927)"
+    )]
+    MissingProvenanceField {
+        /// The field that was missing or blank.
+        field: &'static str,
+    },
+    /// A comparator was named without a complete pin. A portable-lane comparator
+    /// that cannot be reproduced is worse than none.
+    #[error(
+        "comparator at index {index} is missing its `{field}`; ADR-0927 decision 4 pins every \
+         comparator by version and image digest"
+    )]
+    IncompleteComparator {
+        /// The comparator's index in the list.
+        index: usize,
+        /// The field that was missing or blank.
+        field: &'static str,
+    },
+    /// The report carries no measurements. Per-query results are the source of
+    /// truth, and a report with none measures nothing.
+    #[error("report carries no measurements; per-query results are the source of truth")]
+    NoMeasurements,
+    /// Two measurements share an id. A later row silently overwriting an earlier
+    /// one keeps the count correct while changing which figures are checked (the
+    /// runbook's duplicate-id trap).
+    #[error(
+        "measurement id `{id}` appears more than once; a duplicate row would overwrite an \
+         earlier one and change which figures are checked"
+    )]
+    DuplicateMeasurement {
+        /// The duplicated id.
+        id: String,
+    },
+    /// A measurement is structurally malformed: a blank figure name, or an `ok`
+    /// row with no figures, or a non-`ok` row carrying a timing figure it must
+    /// not.
+    #[error("measurement `{id}` is malformed: {reason}")]
+    MalformedMeasurement {
+        /// The offending measurement id.
+        id: String,
+        /// What is wrong with it.
+        reason: String,
+    },
+    /// A figure value is not finite. A NaN is the worst case: every band
+    /// comparison against it is False, so a malformed report would read as a
+    /// pass (the runbook's `byte_count` trap).
+    #[error(
+        "measurement `{id}` figure `{figure}` is not finite ({value}); a NaN or infinity would \
+         make a band comparison read as met"
+    )]
+    NonFiniteFigure {
+        /// The offending measurement id.
+        id: String,
+        /// The offending figure name.
+        figure: String,
+        /// The value that was not finite.
+        value: f64,
+    },
+    /// A figure value is negative. A benchmark reports no negative latency or
+    /// byte count, and a negative would drag a total toward a passing figure.
+    #[error(
+        "measurement `{id}` figure `{figure}` is negative ({value}); no benchmark figure is \
+         negative and one would drag a total toward a passing value"
+    )]
+    NegativeFigure {
+        /// The offending measurement id.
+        id: String,
+        /// The offending figure name.
+        figure: String,
+        /// The negative value.
+        value: f64,
+    },
+    /// A timed (`ok`) measurement is missing a figure it is required to carry.
+    /// An absent-but-expected figure fails identically to an out-of-band one
+    /// (ADR-0927 decision 5).
+    #[error(
+        "timed measurement `{id}` is missing required figure `{figure}`; an absent-but-expected \
+         figure fails identically to an out-of-band one (ADR-0927 decision 5)"
+    )]
+    MissingExpectedFigure {
+        /// The offending measurement id.
+        id: String,
+        /// The figure that was expected and absent.
+        figure: &'static str,
+    },
+    /// The report-level geometric mean is present but not finite and positive. A
+    /// summary figure that is a NaN or non-positive is not a summary.
+    #[error("report geomean_ms is present but not finite and positive ({value})")]
+    BadGeomean {
+        /// The offending value.
+        value: f64,
+    },
+}
+
+/// One required provenance string field, paired with the human name a
+/// [`ValidationError::MissingProvenanceField`] reports. Held in a table so the
+/// check iterates rather than repeating the same `if blank` block per field: a
+/// new required field is one row here.
+fn required_provenance_fields(p: &Provenance) -> [(&'static str, &str); 8] {
+    [
+        ("ravel_git_commit", p.ravel_git_commit.as_str()),
+        ("toolchain", p.toolchain.as_str()),
+        ("protocol", p.protocol.as_str()),
+        ("hardware.os", p.hardware.os.as_str()),
+        ("hardware.cpu_model", p.hardware.cpu_model.as_str()),
+        ("backend.store_backend", p.backend.store_backend.as_str()),
+        ("generator_digest", p.generator_digest.as_str()),
+        ("corpus_digest", p.corpus_digest.as_str()),
+    ]
+}
+
+/// Validate the provenance block, fail-closed. Every required identity field
+/// must be present, the schema version must match, the hardware must name at
+/// least one logical core, and every named comparator must be completely
+/// pinned.
+fn validate_provenance(p: &Provenance) -> Result<(), ValidationError> {
+    if p.schema_version != SCHEMA_VERSION {
+        return Err(ValidationError::SchemaVersionMismatch {
+            found: p.schema_version,
+            expected: SCHEMA_VERSION,
+        });
+    }
+    for (field, value) in required_provenance_fields(p) {
+        if value.trim().is_empty() {
+            return Err(ValidationError::MissingProvenanceField { field });
+        }
+    }
+    // `region`/`endpoint` carry a `"n/a"` sentinel rather than being empty, so a
+    // blank one is still a missing field.
+    if p.backend.region.trim().is_empty() {
+        return Err(ValidationError::MissingProvenanceField {
+            field: "backend.region",
+        });
+    }
+    if p.backend.endpoint.trim().is_empty() {
+        return Err(ValidationError::MissingProvenanceField {
+            field: "backend.endpoint",
+        });
+    }
+    if p.hardware.logical_cores == 0 {
+        return Err(ValidationError::MissingProvenanceField {
+            field: "hardware.logical_cores",
+        });
+    }
+    for (index, c) in p.comparators.iter().enumerate() {
+        for (field, value) in [
+            ("name", c.name.as_str()),
+            ("version", c.version.as_str()),
+            ("image_digest", c.image_digest.as_str()),
+        ] {
+            if value.trim().is_empty() {
+                return Err(ValidationError::IncompleteComparator { index, field });
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Validate one measurement's figures and status shape, fail-closed.
+fn validate_measurement(m: &Measurement) -> Result<(), ValidationError> {
+    for f in &m.figures {
+        if f.name.trim().is_empty() {
+            return Err(ValidationError::MalformedMeasurement {
+                id: m.id.clone(),
+                reason: "a figure has a blank name".to_string(),
+            });
+        }
+        if !f.value.is_finite() {
+            return Err(ValidationError::NonFiniteFigure {
+                id: m.id.clone(),
+                figure: f.name.clone(),
+                value: f.value,
+            });
+        }
+        if f.value < 0.0 {
+            return Err(ValidationError::NegativeFigure {
+                id: m.id.clone(),
+                figure: f.name.clone(),
+                value: f.value,
+            });
+        }
+    }
+    // A figure named twice is malformed: a consumer that looks it up by name
+    // would silently read the first and ignore the second.
+    let mut seen: BTreeSet<&str> = BTreeSet::new();
+    for f in &m.figures {
+        if !seen.insert(f.name.as_str()) {
+            return Err(ValidationError::MalformedMeasurement {
+                id: m.id.clone(),
+                reason: format!("figure `{}` appears more than once", f.name),
+            });
+        }
+    }
+    if m.status.is_timed() {
+        // A timed row carries the full timing figure set. An absent one fails
+        // exactly like an out-of-band one.
+        if m.figures.is_empty() {
+            return Err(ValidationError::MalformedMeasurement {
+                id: m.id.clone(),
+                reason: "an ok (timed) measurement carries no figures".to_string(),
+            });
+        }
+        for figure in REQUIRED_TIMED_FIGURES {
+            if m.figure(figure).is_none() {
+                return Err(ValidationError::MissingExpectedFigure {
+                    id: m.id.clone(),
+                    figure,
+                });
+            }
+        }
+    } else {
+        // Only `ok` is timed (ADR-0927 decision 6). A non-`ok` row carrying a
+        // timing figure would let an untimed outcome sneak a latency into a
+        // performance table.
+        for figure in REQUIRED_TIMED_FIGURES {
+            if m.figure(figure).is_some() {
+                return Err(ValidationError::MalformedMeasurement {
+                    id: m.id.clone(),
+                    reason: format!(
+                        "status `{}` is not timed, but the row carries timing figure `{figure}` \
+                         (only ok is timed, ADR-0927 decision 6)",
+                        m.status.slug()
+                    ),
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Validate a whole report, fail-closed. This is the one entry point a consumer
+/// (and the renderer) runs before trusting any figure: a missing, duplicate,
+/// non-finite, negative, or malformed measurement all fail here, and an
+/// absent-but-expected figure fails exactly like an out-of-band one.
+pub fn validate(report: &MetricsBenchReport) -> Result<(), ValidationError> {
+    validate_provenance(&report.provenance)?;
+    if report.measurements.is_empty() {
+        return Err(ValidationError::NoMeasurements);
+    }
+    let mut seen: BTreeSet<&str> = BTreeSet::new();
+    for m in &report.measurements {
+        if !seen.insert(m.id.as_str()) {
+            return Err(ValidationError::DuplicateMeasurement { id: m.id.clone() });
+        }
+        validate_measurement(m)?;
+    }
+    if let Some(g) = report.geomean_ms
+        && !(g.is_finite() && g > 0.0)
+    {
+        return Err(ValidationError::BadGeomean { value: g });
+    }
+    Ok(())
+}
+
+// --- Renderer bands (ADR-0927 decision 5). Re-register a band by editing
+// exactly one line in this block, exactly as the ClickBench runbook script
+// does. Each band is `None` until a reference run pre-registers it, and a
+// `None` band is a loud SKIP, never a silent pass. ------------------------------
+
+/// The band on how many of the report's measurements must be timed (`ok`),
+/// registered per reference run. `None` until pre-registered, so the renderer
+/// prints a loud SKIP rather than asserting nothing. A tuple is `(lo, hi)`
+/// inclusive.
+pub const TIMED_FRACTION_BAND: Option<(f64, f64)> = None;
+
+/// The band on the report-level geometric mean, in milliseconds, registered per
+/// reference run and regime. `None` until pre-registered.
+pub const GEOMEAN_MS_BAND: Option<(f64, f64)> = None;
+
+/// Everything [`render`] can fail on: a report that does not validate, or a
+/// pre-registered band a real run missed.
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
+pub enum RenderError {
+    /// The report did not validate. Integrity is asserted by identity before any
+    /// band is applied, so a band verdict is never computed over a report whose
+    /// figures cannot be trusted.
+    #[error("report failed validation before any band could be applied: {0}")]
+    Invalid(#[from] ValidationError),
+    /// A pre-registered band was missed.
+    #[error("{0}")]
+    BandViolation(String),
+}
+
+/// Render the report as the human-readable table, derived entirely from the
+/// artifact. The table is never hand-maintained: every row and every figure is
+/// read off `report`.
+///
+/// The order is the runbook's proven one: validate (integrity by identity)
+/// first, then the provenance header, then the retry caveat, then the per-query
+/// rows, then the per-class distribution, then the pre-registered bands (each a
+/// loud SKIP when not registered), and only then the optional geometric mean,
+/// which cannot appear without the per-query rows above it.
+pub fn render(report: &MetricsBenchReport) -> Result<String, RenderError> {
+    validate(report)?;
+
+    let mut out = String::new();
+    let p = &report.provenance;
+    out.push_str("metricsbench report (schema v");
+    let _ = writeln!(out, "{})", p.schema_version);
+    let _ = writeln!(out, "  commit    : {}", p.ravel_git_commit);
+    let _ = writeln!(out, "  toolchain : {}", p.toolchain);
+    let _ = writeln!(out, "  protocol  : {}", p.protocol);
+    let _ = writeln!(
+        out,
+        "  backend   : {} (region={}, endpoint={}, bills_requests={})",
+        p.backend.store_backend,
+        p.backend.region,
+        p.backend.endpoint,
+        p.backend.backend_bills_requests
+    );
+    let _ = writeln!(
+        out,
+        "  hardware  : {} | {} | {} logical cores{}",
+        p.hardware.os,
+        p.hardware.cpu_model,
+        p.hardware.logical_cores,
+        match &p.hardware.instance_type {
+            Some(t) => format!(" | {t}"),
+            None => String::new(),
+        }
+    );
+    if p.comparators.is_empty() {
+        out.push_str("  comparators: none (Ravel-only diagnostic run)\n");
+    } else {
+        for c in &p.comparators {
+            let _ = writeln!(
+                out,
+                "  comparator: {} {} @ {}",
+                c.name, c.version, c.image_digest
+            );
+        }
+    }
+    let _ = writeln!(out, "  generator : {}", p.generator_digest);
+    let _ = writeln!(out, "  corpus    : {}", p.corpus_digest);
+    for c in &p.config {
+        let _ = writeln!(out, "  config    : {} = {}", c.key, c.value);
+    }
+    // The retry caveat rides in the rendered output, not only in a doc.
+    let _ = writeln!(out, "  NOTE: {RETRY_CAVEAT}");
+
+    // Per-query rows: the source of truth, always printed before any summary.
+    out.push('\n');
+    let _ = writeln!(
+        out,
+        "  {:<32} | {:<22} | {:<12} | {:>10} | {:>10} | {:>10}",
+        "id", "class", "status", "min_ms", "median_ms", "max_ms"
+    );
+    let _ = writeln!(
+        out,
+        "  {:-<32}-+-{:-<22}-+-{:-<12}-+-{:-<10}-+-{:-<10}-+-{:-<10}",
+        "", "", "", "", "", ""
+    );
+    let fig = |m: &Measurement, name: &str| {
+        m.figure(name)
+            .map_or_else(|| "-".to_string(), |v| format!("{v:.3}"))
+    };
+    for m in &report.measurements {
+        let _ = writeln!(
+            out,
+            "  {:<32} | {:<22} | {:<12} | {:>10} | {:>10} | {:>10}",
+            m.id,
+            m.class.slug(),
+            m.status.slug(),
+            fig(m, "min_ms"),
+            fig(m, "median_ms"),
+            fig(m, "max_ms"),
+        );
+    }
+
+    // Per-class distribution, derived from the rows. Every class is listed,
+    // including the empty ones, so a class with no measurement is visible rather
+    // than dropped.
+    out.push('\n');
+    out.push_str("  measurements by cost class (timed = status ok):\n");
+    for class in CostClass::ALL {
+        let in_class: Vec<&Measurement> = report
+            .measurements
+            .iter()
+            .filter(|m| m.class == *class)
+            .collect();
+        let timed = in_class.iter().filter(|m| m.status.is_timed()).count();
+        let _ = writeln!(
+            out,
+            "    {:<22} {} measured, {} timed",
+            class.slug(),
+            in_class.len(),
+            timed
+        );
+    }
+
+    // Pre-registered bands. Integrity above already stood; a band is applied
+    // only now, and a band that is not pre-registered is a loud SKIP, never a
+    // silent pass.
+    out.push('\n');
+    let total = report.measurements.len();
+    let timed = report
+        .measurements
+        .iter()
+        .filter(|m| m.status.is_timed())
+        .count();
+    let timed_fraction = timed as f64 / total as f64;
+    match TIMED_FRACTION_BAND {
+        None => {
+            let _ = writeln!(
+                out,
+                "  SKIP timed-fraction band: not pre-registered for this run (measured {timed}/{total} = {timed_fraction:.3})"
+            );
+        }
+        Some((lo, hi)) => {
+            let _ = writeln!(
+                out,
+                "  timed fraction {timed_fraction:.3} (band {lo:.3}..={hi:.3})"
+            );
+            if !(lo..=hi).contains(&timed_fraction) {
+                return Err(RenderError::BandViolation(format!(
+                    "timed fraction {timed_fraction:.3} outside band {lo:.3}..={hi:.3}"
+                )));
+            }
+        }
+    }
+
+    // The geometric mean is a summary and never a replacement: it is printed
+    // last, after the per-query rows it derives from, and only when the producer
+    // computed one. A report without those rows never reaches here (validation
+    // refuses an empty measurement list above).
+    match report.geomean_ms {
+        None => {
+            out.push_str(
+                "  geomean: not computed (per-query rows above are the source of truth)\n",
+            );
+        }
+        Some(g) => {
+            let _ = writeln!(
+                out,
+                "  geomean {g:.3} ms over {timed} timed of {total} measured rows"
+            );
+            match GEOMEAN_MS_BAND {
+                None => {
+                    out.push_str("  SKIP geomean band: not pre-registered for this run\n");
+                }
+                Some((lo, hi)) => {
+                    if !(lo..=hi).contains(&g) {
+                        return Err(RenderError::BandViolation(format!(
+                            "geomean {g:.3} ms outside band {lo:.3}..={hi:.3}"
+                        )));
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(out)
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    /// A provenance block that validates clean, for a test to mutate one field
+    /// of.
+    fn valid_provenance() -> Provenance {
+        Provenance {
+            schema_version: SCHEMA_VERSION,
+            ravel_git_commit: "9fc85f421590d360e7979ee167eb38e166b45462".to_string(),
+            toolchain: "rustc 1.90.0".to_string(),
+            protocol: "remote_write_1.0".to_string(),
+            hardware: Hardware {
+                os: "Linux 6.8.0 x86_64".to_string(),
+                cpu_model: "AMD EPYC 7R13".to_string(),
+                logical_cores: 8,
+                instance_type: Some("c6a.2xlarge".to_string()),
+            },
+            backend: Backend {
+                store_backend: "s3".to_string(),
+                region: "us-east-1".to_string(),
+                endpoint: "n/a".to_string(),
+                backend_bills_requests: true,
+            },
+            comparators: vec![Comparator {
+                name: "prometheus".to_string(),
+                version: "3.13.1".to_string(),
+                image_digest: "sha256:abc123".to_string(),
+            }],
+            generator_digest: "blake3:1111".to_string(),
+            corpus_digest: "blake3:2222".to_string(),
+            config: vec![ConfigEntry {
+                key: "max_flush_delay_ms".to_string(),
+                value: "2000".to_string(),
+            }],
+        }
+    }
+
+    /// One timed (`ok`) measurement carrying the full required timing figure
+    /// set.
+    fn timed_measurement(id: &str) -> Measurement {
+        Measurement {
+            id: id.to_string(),
+            class: CostClass::HighFanOut,
+            status: ResultStatus::Ok,
+            figures: vec![
+                Figure {
+                    name: "min_ms".to_string(),
+                    value: 10.0,
+                },
+                Figure {
+                    name: "median_ms".to_string(),
+                    value: 12.5,
+                },
+                Figure {
+                    name: "max_ms".to_string(),
+                    value: 20.0,
+                },
+            ],
+        }
+    }
+
+    fn valid_report() -> MetricsBenchReport {
+        MetricsBenchReport {
+            provenance: valid_provenance(),
+            measurements: vec![timed_measurement("mb_fanout_total_rate")],
+            geomean_ms: Some(12.5),
+        }
+    }
+
+    /// The whole point of the fixtures: a report built from them validates
+    /// clean, so every failure test below isolates exactly one defect.
+    #[test]
+    fn the_fixture_report_validates_clean() {
+        validate(&valid_report()).expect("the fixture report validates");
+    }
+
+    /// ACCEPTANCE TEST (issue #936). A report whose provenance is missing a
+    /// required field fails validation, naming the field.
+    ///
+    /// To watch this test fail against a report that HAS the field, keep the
+    /// commit populated instead of blanking it: change the
+    /// `report.provenance.ravel_git_commit = String::new();` line below to
+    /// `report.provenance.ravel_git_commit = "deadbeef".to_string();`. The
+    /// report then validates, `expect_err` finds `Ok(())`, and the test fails.
+    #[test]
+    fn a_report_missing_a_required_provenance_field_fails_validation() {
+        let mut report = valid_report();
+        report.provenance.ravel_git_commit = String::new();
+        let err = validate(&report).expect_err("a blank git commit must fail validation");
+        assert_eq!(
+            err,
+            ValidationError::MissingProvenanceField {
+                field: "ravel_git_commit"
+            },
+            "the error must name the missing field, got {err:?}"
+        );
+    }
+
+    /// Failure class: a schema version this build does not read.
+    #[test]
+    fn a_wrong_schema_version_fails_validation() {
+        let mut report = valid_report();
+        report.provenance.schema_version = SCHEMA_VERSION + 7;
+        let err = validate(&report).expect_err("a wrong schema version must fail");
+        assert_eq!(
+            err,
+            ValidationError::SchemaVersionMismatch {
+                found: SCHEMA_VERSION + 7,
+                expected: SCHEMA_VERSION,
+            }
+        );
+    }
+
+    /// Failure class: duplicate measurement id.
+    #[test]
+    fn a_duplicate_measurement_id_fails_validation() {
+        let mut report = valid_report();
+        report
+            .measurements
+            .push(timed_measurement("mb_fanout_total_rate"));
+        let err = validate(&report).expect_err("a duplicate id must fail");
+        assert_eq!(
+            err,
+            ValidationError::DuplicateMeasurement {
+                id: "mb_fanout_total_rate".to_string()
+            }
+        );
+    }
+
+    /// Failure class: a non-finite figure value.
+    #[test]
+    fn a_non_finite_figure_fails_validation() {
+        let mut report = valid_report();
+        report.measurements[0].figures[1].value = f64::NAN;
+        let err = validate(&report).expect_err("a NaN figure must fail");
+        match err {
+            ValidationError::NonFiniteFigure { id, figure, value } => {
+                assert_eq!(id, "mb_fanout_total_rate");
+                assert_eq!(figure, "median_ms");
+                assert!(value.is_nan(), "the reported value is the NaN itself");
+            }
+            other => panic!("wrong error variant: {other:?}"),
+        }
+    }
+
+    /// Failure class: a negative figure value.
+    #[test]
+    fn a_negative_figure_fails_validation() {
+        let mut report = valid_report();
+        report.measurements[0].figures[0].value = -1.5;
+        let err = validate(&report).expect_err("a negative figure must fail");
+        assert_eq!(
+            err,
+            ValidationError::NegativeFigure {
+                id: "mb_fanout_total_rate".to_string(),
+                figure: "min_ms".to_string(),
+                value: -1.5,
+            }
+        );
+    }
+
+    /// Failure class: a malformed measurement (a blank figure name).
+    #[test]
+    fn a_blank_figure_name_is_a_malformed_measurement() {
+        let mut report = valid_report();
+        report.measurements[0].figures[0].name = "   ".to_string();
+        let err = validate(&report).expect_err("a blank figure name must fail");
+        assert_eq!(
+            err,
+            ValidationError::MalformedMeasurement {
+                id: "mb_fanout_total_rate".to_string(),
+                reason: "a figure has a blank name".to_string(),
+            }
+        );
+    }
+
+    /// An absent-but-expected timing figure fails exactly like an out-of-band
+    /// one (ADR-0927 decision 5): an `ok` row that drops `median_ms` is refused,
+    /// naming the missing figure, not accepted with a hole.
+    #[test]
+    fn an_ok_measurement_missing_a_timing_figure_fails_validation() {
+        let mut report = valid_report();
+        report.measurements[0]
+            .figures
+            .retain(|f| f.name != "median_ms");
+        let err = validate(&report).expect_err("a missing required figure must fail");
+        assert_eq!(
+            err,
+            ValidationError::MissingExpectedFigure {
+                id: "mb_fanout_total_rate".to_string(),
+                figure: "median_ms",
+            }
+        );
+    }
+
+    /// Only `ok` is timed: a non-`ok` row carrying a timing figure is malformed,
+    /// so an untimed outcome cannot smuggle a latency into a performance table.
+    #[test]
+    fn a_non_ok_measurement_carrying_a_timing_figure_is_malformed() {
+        let mut report = valid_report();
+        report.measurements[0].status = ResultStatus::Refused;
+        // Leaves the timing figures on a refused row.
+        let err = validate(&report).expect_err("a timed figure on a refused row must fail");
+        match err {
+            ValidationError::MalformedMeasurement { id, reason } => {
+                assert_eq!(id, "mb_fanout_total_rate");
+                assert!(reason.contains("only ok is timed"), "{reason}");
+            }
+            other => panic!("wrong error variant: {other:?}"),
+        }
+    }
+
+    /// A named comparator missing its image digest fails: a comparator that
+    /// cannot be reproduced is worse than none (ADR-0927 decision 4).
+    #[test]
+    fn an_incompletely_pinned_comparator_fails_validation() {
+        let mut report = valid_report();
+        report.provenance.comparators[0].image_digest = String::new();
+        let err = validate(&report).expect_err("an unpinned comparator must fail");
+        assert_eq!(
+            err,
+            ValidationError::IncompleteComparator {
+                index: 0,
+                field: "image_digest",
+            }
+        );
+    }
+
+    /// A report with no measurements is refused: per-query results are the
+    /// source of truth, and a report with none measures nothing.
+    #[test]
+    fn a_report_with_no_measurements_fails_validation() {
+        let mut report = valid_report();
+        report.measurements.clear();
+        report.geomean_ms = None;
+        let err = validate(&report).expect_err("an empty report must fail");
+        assert_eq!(err, ValidationError::NoMeasurements);
+    }
+
+    /// The renderer derives its table from the artifact and carries the retry
+    /// caveat in its output, not only in a doc (ADR-0927 decision 8).
+    #[test]
+    fn the_renderer_derives_the_table_and_carries_the_retry_caveat() {
+        let report = valid_report();
+        let text = render(&report).expect("the fixture report renders");
+        // Every per-query row is derived from the artifact.
+        assert!(text.contains("mb_fanout_total_rate"), "{text}");
+        assert!(text.contains("high_fan_out"), "{text}");
+        assert!(
+            text.contains("12.500"),
+            "the median figure is rendered: {text}"
+        );
+        // The retry caveat is in the output.
+        assert!(
+            text.contains(RETRY_CAVEAT),
+            "the retry caveat must be rendered: {text}"
+        );
+        assert!(text.contains("logical-call counts"), "{text}");
+        // A gap with no pre-registered band is a loud SKIP, never a silent pass.
+        assert!(
+            text.contains("SKIP timed-fraction band: not pre-registered"),
+            "an unregistered band must render a loud SKIP: {text}"
+        );
+    }
+
+    /// The renderer cannot print a summary without the per-query rows behind it:
+    /// a report that fails validation (here, an empty measurement list) is
+    /// refused before any geomean line is produced.
+    #[test]
+    fn the_renderer_refuses_to_summarize_a_report_that_does_not_validate() {
+        let mut report = valid_report();
+        report.measurements.clear();
+        let err = render(&report).expect_err("an invalid report must not render");
+        assert!(
+            matches!(err, RenderError::Invalid(ValidationError::NoMeasurements)),
+            "wrong error: {err:?}"
+        );
+    }
+
+    /// The report round-trips through JSON unchanged: this is the emission
+    /// contract a producer serializes and a consumer (the renderer binary)
+    /// reads back.
+    #[test]
+    fn a_report_round_trips_through_json() {
+        let report = valid_report();
+        let json = serde_json::to_string_pretty(&report).expect("serialize");
+        let back: MetricsBenchReport = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(report, back);
+        validate(&back).expect("the round-tripped report validates");
+    }
+
+    /// An unknown key in a report is a deserialization error, not a silently
+    /// ignored field: the schema is a frozen contract.
+    #[test]
+    fn an_unknown_report_key_is_a_deserialization_error() {
+        let report = valid_report();
+        let mut doc = serde_json::to_value(&report).expect("serialize");
+        doc.as_object_mut()
+            .expect("object")
+            .insert("measrements".to_string(), serde_json::json!([]));
+        let err = serde_json::from_value::<MetricsBenchReport>(doc)
+            .expect_err("an unknown key must fail to deserialize");
+        assert!(err.to_string().contains("measrements"), "{err}");
+    }
+}

--- a/crates/ravel-bench/src/report_schema.rs
+++ b/crates/ravel-bench/src/report_schema.rs
@@ -460,6 +460,55 @@ pub enum ValidationError {
         /// The value recomputed from the timed medians.
         computed: f64,
     },
+    /// A configuration entry has a blank key or value, or two entries share a
+    /// key. A blank key or value is unrecorded configuration masquerading as
+    /// recorded; two entries for one key make the applied value ambiguous. Both
+    /// leave the run unreproducible while the block reads as complete, which is
+    /// worse than an obviously missing field.
+    #[error(
+        "configuration entry at index {index} is invalid: {reason}; a blank or duplicated setting \
+         is unreproducible configuration masquerading as complete"
+    )]
+    InvalidConfigEntry {
+        /// The entry's index in the config list.
+        index: usize,
+        /// What is wrong with it.
+        reason: String,
+    },
+    /// A timed measurement's timing figures are not ordered
+    /// `min_ms <= median_ms <= max_ms`. An impossible latency range (a min above
+    /// its median, or a median above its max) is a self-contradicting row; the
+    /// error carries all three so the impossible triple is visible, not just the
+    /// row id.
+    #[error(
+        "timed measurement `{id}` has timing figures out of order: min_ms {min_ms}, median_ms \
+         {median_ms}, max_ms {max_ms}; a timed row requires min_ms <= median_ms <= max_ms"
+    )]
+    TimingOutOfOrder {
+        /// The offending measurement id.
+        id: String,
+        /// The reported minimum.
+        min_ms: f64,
+        /// The reported median.
+        median_ms: f64,
+        /// The reported maximum.
+        max_ms: f64,
+    },
+    /// A comparator's `image_digest` is present but not a content digest: a
+    /// mutable tag (`latest`) or a truncated or upper-case hex string pins no
+    /// bytes. A digest that does not pin bytes defeats the reason a digest is
+    /// recorded, the same defect as a missing pin one layer out.
+    #[error(
+        "comparator at index {index} has image_digest `{value}`, which is not a content digest; a \
+         digest must be `sha256:` followed by 64 lower-case hex characters, or a moving tag pins \
+         nothing"
+    )]
+    InvalidImageDigest {
+        /// The comparator's index in the list.
+        index: usize,
+        /// The value that was not a valid digest.
+        value: String,
+    },
 }
 
 /// Whether a *present* provenance value is an absent-value sentinel rather than
@@ -514,10 +563,31 @@ fn checked_provenance_fields(p: &Provenance) -> Vec<(&'static str, &str)> {
     fields
 }
 
+/// Whether `value` is a content digest that pins bytes, rather than a mutable
+/// tag: `sha256:` followed by exactly 64 lower-case hex characters. This is the
+/// same notion `deploy/metricsbench/tests/every_comparator_pins_an_image_digest.sh`
+/// enforces on the deployment side (`@sha256:` + 64 `[0-9a-f]`), minus the `@`
+/// that belongs to a full `repo:tag@digest` image reference: this field carries
+/// the bare digest, not a whole reference. Only `sha256` is accepted: it is the
+/// only algorithm the comparator images are published under, and an open-ended
+/// `algo:hex` pattern would readmit a truncated or upper-case string that pins
+/// nothing. Upper-case hex is rejected deliberately, matching the deploy check's
+/// lower-case-only class, so the two cannot disagree on the same digest.
+fn is_content_digest(value: &str) -> bool {
+    let Some(hex) = value.strip_prefix("sha256:") else {
+        return false;
+    };
+    hex.len() == 64
+        && hex
+            .bytes()
+            .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+}
+
 /// Validate the provenance block, fail-closed. Every present identity field must
 /// carry a real value (not blank, not the `"unknown"` sentinel), the schema
-/// version must match, the hardware must name at least one logical core, and
-/// every named comparator must be completely pinned.
+/// version must match, the hardware must name at least one logical core, every
+/// named comparator must be completely pinned by a real content digest, and the
+/// configuration must carry no blank or duplicate key.
 fn validate_provenance(p: &Provenance) -> Result<(), ValidationError> {
     if p.schema_version != SCHEMA_VERSION {
         return Err(ValidationError::SchemaVersionMismatch {
@@ -548,6 +618,41 @@ fn validate_provenance(p: &Provenance) -> Result<(), ValidationError> {
             if is_absent_value(value) {
                 return Err(ValidationError::IncompleteComparator { index, field });
             }
+        }
+        // Presence is not enough: a mutable tag (`latest`) or a truncated or
+        // upper-case hex string is a digest field that pins no bytes, defeating
+        // the reason a digest is recorded.
+        if !is_content_digest(&c.image_digest) {
+            return Err(ValidationError::InvalidImageDigest {
+                index,
+                value: c.image_digest.clone(),
+            });
+        }
+    }
+    // Configuration entries: a blank key or value is unrecorded configuration
+    // masquerading as recorded, and two entries for one key make the applied
+    // value ambiguous. A duplicate key is rejected even when both values match:
+    // the gatherer emitted the same setting twice, and one copy may later
+    // diverge, so the shape is wrong now regardless of the current values.
+    let mut seen: BTreeSet<&str> = BTreeSet::new();
+    for (index, c) in p.config.iter().enumerate() {
+        if c.key.trim().is_empty() {
+            return Err(ValidationError::InvalidConfigEntry {
+                index,
+                reason: "a blank key".to_string(),
+            });
+        }
+        if c.value.trim().is_empty() {
+            return Err(ValidationError::InvalidConfigEntry {
+                index,
+                reason: format!("key `{}` has a blank value", c.key),
+            });
+        }
+        if !seen.insert(c.key.as_str()) {
+            return Err(ValidationError::InvalidConfigEntry {
+                index,
+                reason: format!("key `{}` appears more than once", c.key),
+            });
         }
     }
     Ok(())
@@ -604,6 +709,22 @@ fn validate_measurement(m: &Measurement) -> Result<(), ValidationError> {
                     figure,
                 });
             }
+        }
+        // Every required timing figure is present (just checked), finite, and
+        // non-negative (checked above), so the three unwraps are total and the
+        // comparison is meaningful. An impossible range (a min above its median,
+        // or a median above its max) is a self-contradicting row. `min == median
+        // == max` is legal: a single-run measurement collapses the three.
+        let min_ms = m.figure("min_ms").unwrap_or_default();
+        let median_ms = m.figure("median_ms").unwrap_or_default();
+        let max_ms = m.figure("max_ms").unwrap_or_default();
+        if !(min_ms <= median_ms && median_ms <= max_ms) {
+            return Err(ValidationError::TimingOutOfOrder {
+                id: m.id.clone(),
+                min_ms,
+                median_ms,
+                max_ms,
+            });
         }
     } else {
         // Only `ok` is timed (ADR-0927 decision 6). A non-`ok` row carrying a
@@ -904,7 +1025,9 @@ mod tests {
             comparators: vec![Comparator {
                 name: "prometheus".to_string(),
                 version: "3.13.1".to_string(),
-                image_digest: "sha256:abc123".to_string(),
+                image_digest:
+                    "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                        .to_string(),
             }],
             generator_digest: "blake3:1111".to_string(),
             corpus_digest: "blake3:2222".to_string(),
@@ -1049,8 +1172,9 @@ mod tests {
     }
 
     /// One timed (`ok`) row whose `median_ms` is `median`; `min`/`max` are set to
-    /// the same value because only `median_ms` feeds the geomean recomputation
-    /// and the ordering of the three is not validated.
+    /// the same value so the row satisfies the `min <= median <= max` ordering
+    /// rule (a single-run collapse of the three) while feeding `median` to the
+    /// geomean recomputation.
     fn timed_with_median(id: &str, median: f64) -> Measurement {
         Measurement {
             id: id.to_string(),
@@ -1406,6 +1530,310 @@ mod tests {
         let back: MetricsBenchReport = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(report, back);
         validate(&back).expect("the round-tripped report validates");
+    }
+
+    // --- FINDING 1: configuration entries are validated, not merely present. ---
+
+    /// A multi-entry configuration map with distinct non-blank keys and values
+    /// validates: the rule rejects blanks and duplicates, not a legitimate map.
+    #[test]
+    fn a_valid_config_map_validates() {
+        let mut report = valid_report();
+        report.provenance.config = vec![
+            ConfigEntry {
+                key: "max_flush_delay_ms".to_string(),
+                value: "2000".to_string(),
+            },
+            ConfigEntry {
+                key: "shard_count".to_string(),
+                value: "8".to_string(),
+            },
+        ];
+        validate(&report).expect("a distinct-key, non-blank config map validates");
+    }
+
+    /// A blank configuration key is refused: an unnamed setting is unrecorded
+    /// configuration masquerading as recorded.
+    #[test]
+    fn a_blank_config_key_fails_validation() {
+        let mut report = valid_report();
+        report.provenance.config = vec![ConfigEntry {
+            key: "   ".to_string(),
+            value: "2000".to_string(),
+        }];
+        let err = validate(&report).expect_err("a blank config key must fail");
+        assert_eq!(
+            err,
+            ValidationError::InvalidConfigEntry {
+                index: 0,
+                reason: "a blank key".to_string(),
+            }
+        );
+    }
+
+    /// A blank configuration value is refused: a named setting with no value
+    /// records nothing about how the run was configured.
+    #[test]
+    fn a_blank_config_value_fails_validation() {
+        let mut report = valid_report();
+        report.provenance.config = vec![ConfigEntry {
+            key: "max_flush_delay_ms".to_string(),
+            value: "  ".to_string(),
+        }];
+        let err = validate(&report).expect_err("a blank config value must fail");
+        assert_eq!(
+            err,
+            ValidationError::InvalidConfigEntry {
+                index: 0,
+                reason: "key `max_flush_delay_ms` has a blank value".to_string(),
+            }
+        );
+    }
+
+    /// Two entries for one key with DIFFERENT values are refused: the applied
+    /// value is ambiguous, so the block reads as complete while recording an
+    /// unreproducible setting.
+    #[test]
+    fn duplicate_config_keys_with_different_values_fail_validation() {
+        let mut report = valid_report();
+        report.provenance.config = vec![
+            ConfigEntry {
+                key: "max_flush_delay_ms".to_string(),
+                value: "2000".to_string(),
+            },
+            ConfigEntry {
+                key: "max_flush_delay_ms".to_string(),
+                value: "3000".to_string(),
+            },
+        ];
+        let err = validate(&report).expect_err("duplicate config keys must fail");
+        assert_eq!(
+            err,
+            ValidationError::InvalidConfigEntry {
+                index: 1,
+                reason: "key `max_flush_delay_ms` appears more than once".to_string(),
+            }
+        );
+    }
+
+    /// Two entries for one key with the SAME value are also refused: the gatherer
+    /// emitted the setting twice and one copy may later diverge, so the shape is
+    /// wrong now regardless of the current values.
+    #[test]
+    fn duplicate_config_keys_with_the_same_value_fail_validation() {
+        let mut report = valid_report();
+        report.provenance.config = vec![
+            ConfigEntry {
+                key: "shard_count".to_string(),
+                value: "8".to_string(),
+            },
+            ConfigEntry {
+                key: "shard_count".to_string(),
+                value: "8".to_string(),
+            },
+        ];
+        let err = validate(&report).expect_err("same-value duplicate config keys must fail");
+        assert_eq!(
+            err,
+            ValidationError::InvalidConfigEntry {
+                index: 1,
+                reason: "key `shard_count` appears more than once".to_string(),
+            }
+        );
+    }
+
+    // --- FINDING 2: timed rows require min_ms <= median_ms <= max_ms. ---
+
+    /// A timed row with `min_ms` above its median is refused, and the error
+    /// carries all three values so the impossible triple is visible.
+    ///
+    /// To watch this test FAIL against the pre-fix validator, delete the ordering
+    /// block in `validate_measurement` (the `let min_ms = ...` line through the
+    /// `TimingOutOfOrder` return, inside the `if m.status.is_timed()` arm). The
+    /// pre-fix code did not check order, so `validate` returned `Ok(())`,
+    /// `expect_err` found `Ok`, and the test failed. This was confirmed by
+    /// commenting that block out and running this test before committing.
+    #[test]
+    fn a_timed_row_with_min_above_median_fails_validation() {
+        let mut report = valid_report();
+        // min_ms = 20, median_ms = 12.5, max_ms = 10: an impossible range.
+        report.measurements[0].figures = vec![
+            Figure {
+                name: "min_ms".to_string(),
+                value: 20.0,
+            },
+            Figure {
+                name: "median_ms".to_string(),
+                value: 12.5,
+            },
+            Figure {
+                name: "max_ms".to_string(),
+                value: 10.0,
+            },
+        ];
+        // The geomean would summarize the median 12.5; keep it consistent so the
+        // ordering error is what fails, not a geomean mismatch.
+        report.geomean_ms = Some(12.5);
+        let err = validate(&report).expect_err("an out-of-order timed row must fail");
+        assert_eq!(
+            err,
+            ValidationError::TimingOutOfOrder {
+                id: "mb_fanout_total_rate".to_string(),
+                min_ms: 20.0,
+                median_ms: 12.5,
+                max_ms: 10.0,
+            }
+        );
+    }
+
+    /// A timed row whose median exceeds its max is refused, error carrying the
+    /// triple. This exercises the second half of the `min <= median <= max`
+    /// conjunction independently of the first.
+    #[test]
+    fn a_timed_row_with_median_above_max_fails_validation() {
+        let mut report = valid_report();
+        report.measurements[0].figures = vec![
+            Figure {
+                name: "min_ms".to_string(),
+                value: 5.0,
+            },
+            Figure {
+                name: "median_ms".to_string(),
+                value: 30.0,
+            },
+            Figure {
+                name: "max_ms".to_string(),
+                value: 20.0,
+            },
+        ];
+        report.geomean_ms = Some(30.0);
+        let err = validate(&report).expect_err("a median above max must fail");
+        assert_eq!(
+            err,
+            ValidationError::TimingOutOfOrder {
+                id: "mb_fanout_total_rate".to_string(),
+                min_ms: 5.0,
+                median_ms: 30.0,
+                max_ms: 20.0,
+            }
+        );
+    }
+
+    /// A single-run measurement (`min == median == max`) is legal and must not be
+    /// rejected by an over-strict comparison: the three collapse to one value.
+    #[test]
+    fn a_timed_row_with_equal_timings_validates() {
+        let mut report = valid_report();
+        report.measurements[0].figures = vec![
+            Figure {
+                name: "min_ms".to_string(),
+                value: 7.0,
+            },
+            Figure {
+                name: "median_ms".to_string(),
+                value: 7.0,
+            },
+            Figure {
+                name: "max_ms".to_string(),
+                value: 7.0,
+            },
+        ];
+        report.geomean_ms = Some(7.0);
+        validate(&report).expect("min == median == max is a legal single-run measurement");
+    }
+
+    /// The ordering rule applies only to timed statuses: a non-timed row carries
+    /// no timing figures, so there is nothing to order and it still validates.
+    #[test]
+    fn a_non_timed_row_with_absent_timings_validates() {
+        let mut report = valid_report();
+        // A timed row exists so the geomean still has a row behind it.
+        report.measurements = vec![
+            timed_measurement("mb_fanout_total_rate"),
+            Measurement {
+                id: "mb_refused_row".to_string(),
+                class: CostClass::HighFanOut,
+                status: ResultStatus::Refused,
+                figures: vec![],
+            },
+        ];
+        validate(&report).expect("a non-timed row with no timings validates");
+    }
+
+    // --- FINDING 3: image_digest must be a content digest, not a mutable tag. ---
+
+    /// A correct `sha256:` + 64 lower-case hex digest validates.
+    #[test]
+    fn a_correct_sha256_image_digest_validates() {
+        let mut report = valid_report();
+        report.provenance.comparators[0].image_digest =
+            "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".to_string();
+        validate(&report).expect("a sha256 + 64 lower-case hex digest validates");
+    }
+
+    /// A mutable tag masquerading as a digest is refused.
+    #[test]
+    fn a_mutable_tag_image_digest_fails_validation() {
+        let mut report = valid_report();
+        report.provenance.comparators[0].image_digest = "latest".to_string();
+        let err = validate(&report).expect_err("a `latest` tag is not a digest");
+        assert_eq!(
+            err,
+            ValidationError::InvalidImageDigest {
+                index: 0,
+                value: "latest".to_string(),
+            }
+        );
+    }
+
+    /// A free-form string with no digest structure is refused.
+    #[test]
+    fn a_non_digest_image_digest_fails_validation() {
+        let mut report = valid_report();
+        report.provenance.comparators[0].image_digest = "not-a-digest".to_string();
+        let err = validate(&report).expect_err("`not-a-digest` is not a digest");
+        assert_eq!(
+            err,
+            ValidationError::InvalidImageDigest {
+                index: 0,
+                value: "not-a-digest".to_string(),
+            }
+        );
+    }
+
+    /// A digest one hex character short is refused: 63 hex characters is a
+    /// truncated digest that pins nothing.
+    #[test]
+    fn a_63_character_hex_image_digest_fails_validation() {
+        let mut report = valid_report();
+        let short = format!("sha256:{}", "a".repeat(63));
+        report.provenance.comparators[0].image_digest = short.clone();
+        let err = validate(&report).expect_err("a 63-char hex digest must fail");
+        assert_eq!(
+            err,
+            ValidationError::InvalidImageDigest {
+                index: 0,
+                value: short,
+            }
+        );
+    }
+
+    /// An upper-case hex digest is refused, matching the deploy check's
+    /// lower-case-only class so the two notions of "digest" agree.
+    #[test]
+    fn an_uppercase_hex_image_digest_fails_validation() {
+        let mut report = valid_report();
+        let upper =
+            "sha256:0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF".to_string();
+        report.provenance.comparators[0].image_digest = upper.clone();
+        let err = validate(&report).expect_err("an upper-case hex digest must fail");
+        assert_eq!(
+            err,
+            ValidationError::InvalidImageDigest {
+                index: 0,
+                value: upper,
+            }
+        );
     }
 
     /// An unknown key in a report is a deserialization error, not a silently

--- a/crates/ravel-bench/src/report_schema.rs
+++ b/crates/ravel-bench/src/report_schema.rs
@@ -279,6 +279,27 @@ impl Measurement {
 /// `ok` is timed.
 pub const REQUIRED_TIMED_FIGURES: &[&str] = &["min_ms", "median_ms", "max_ms"];
 
+/// The relative tolerance the report-level `geomean_ms` is checked against the
+/// geometric mean recomputed from the timed rows' `median_ms`. A supplied value
+/// farther than this fraction from the recomputed one is rejected as a mismatch
+/// ([`ValidationError::GeomeanMismatch`]): "present but unverified" is the weaker
+/// half of the guarantee, so the value is checked against the rows it claims to
+/// summarize, not merely required to exist.
+///
+/// Relative, not absolute: the geomean scales with the medians, and a regime can
+/// range from microseconds to seconds (six orders of magnitude), so a fixed
+/// millisecond slop that is tight for one regime is meaningless for another.
+///
+/// The value is `1e-9`. Recomputing `exp(mean(ln median))` accumulates f64
+/// rounding error on the order of `n * f64::EPSILON` (about `1e-14` relative for
+/// dozens of rows), and a producer that computes the geomean by a
+/// different-but-valid method (a scaled product rather than a log-sum) adds a
+/// little more; `1e-9` sits several orders above that floor, so a faithfully
+/// computed value always passes. A real disagreement (a stale or hand-typed
+/// summary, or a geomean that summarizes the wrong rows) is a multiplicative
+/// factor far larger than `1e-9` and is always caught.
+pub const GEOMEAN_REL_TOLERANCE: f64 = 1e-9;
+
 /// The full reconciled report: the provenance, the per-query measurements, and
 /// an optional report-level geometric mean.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -422,29 +443,81 @@ pub enum ValidationError {
         /// The geomean value that had nothing behind it.
         value: f64,
     },
+    /// The report-level geometric mean disagrees with the geometric mean
+    /// recomputed from the timed rows' `median_ms`, beyond
+    /// [`GEOMEAN_REL_TOLERANCE`]. A summary that contradicts the rows it claims
+    /// to summarize is two results, not one; the error carries both so the
+    /// disagreement is visible, not just the field name.
+    #[error(
+        "report geomean_ms {supplied} disagrees with the geometric mean {computed} recomputed \
+         from the timed medians (relative tolerance {tolerance:e}); a summary that contradicts \
+         its rows is not a result",
+        tolerance = GEOMEAN_REL_TOLERANCE
+    )]
+    GeomeanMismatch {
+        /// The value the report supplied.
+        supplied: f64,
+        /// The value recomputed from the timed medians.
+        computed: f64,
+    },
 }
 
-/// One required provenance string field, paired with the human name a
-/// [`ValidationError::MissingProvenanceField`] reports. Held in a table so the
-/// check iterates rather than repeating the same `if blank` block per field: a
-/// new required field is one row here.
-fn required_provenance_fields(p: &Provenance) -> [(&'static str, &str); 8] {
-    [
+/// Whether a *present* provenance value is an absent-value sentinel rather than
+/// real data: blank (after trimming), or the `"unknown"` marker a gatherer on a
+/// host without git or rustc used to emit. Every present provenance string flows
+/// through this one predicate so the check cannot regress to a weaker
+/// blank-only test on any single field (the exact defect this function closes:
+/// eight fields rejected the sentinel while comparators and populated backend or
+/// hardware fields rejected only blanks).
+///
+/// `"n/a"` is deliberately NOT a sentinel here: on `backend.region` /
+/// `backend.endpoint` it is a real value meaning "this backend has none", not
+/// missing data, so a field that legitimately carries it still passes. This
+/// predicate governs the value of a field that IS present; a legitimately
+/// optional field (`hardware.instance_type`) is exempt by being absent, never by
+/// carrying a sentinel.
+fn is_absent_value(value: &str) -> bool {
+    let trimmed = value.trim();
+    trimmed.is_empty() || trimmed.eq_ignore_ascii_case("unknown")
+}
+
+/// Every provenance string field whose presence must be real, paired with the
+/// name a [`ValidationError::MissingProvenanceField`] reports. Coverage is by
+/// construction: a field is checked once it is listed here, and it is checked
+/// with the full [`is_absent_value`] predicate, never a hand-written weaker one,
+/// because the caller applies that single predicate to every row. Adding a
+/// provenance string field is one row here; a reviewer confirms the list against
+/// the [`Provenance`] struct.
+///
+/// Optional fields (`hardware.instance_type`) appear only when present: an
+/// absent optional field is legitimately absent, but a present one must carry a
+/// real value, not a sentinel. `backend.region` / `backend.endpoint` are
+/// included because [`is_absent_value`] treats their legitimate `"n/a"` as real
+/// data, so listing them rejects blank and `"unknown"` without breaking the
+/// no-endpoint case.
+fn checked_provenance_fields(p: &Provenance) -> Vec<(&'static str, &str)> {
+    let mut fields = vec![
         ("ravel_git_commit", p.ravel_git_commit.as_str()),
         ("toolchain", p.toolchain.as_str()),
         ("protocol", p.protocol.as_str()),
         ("hardware.os", p.hardware.os.as_str()),
         ("hardware.cpu_model", p.hardware.cpu_model.as_str()),
         ("backend.store_backend", p.backend.store_backend.as_str()),
+        ("backend.region", p.backend.region.as_str()),
+        ("backend.endpoint", p.backend.endpoint.as_str()),
         ("generator_digest", p.generator_digest.as_str()),
         ("corpus_digest", p.corpus_digest.as_str()),
-    ]
+    ];
+    if let Some(instance_type) = p.hardware.instance_type.as_deref() {
+        fields.push(("hardware.instance_type", instance_type));
+    }
+    fields
 }
 
-/// Validate the provenance block, fail-closed. Every required identity field
-/// must be present, the schema version must match, the hardware must name at
-/// least one logical core, and every named comparator must be completely
-/// pinned.
+/// Validate the provenance block, fail-closed. Every present identity field must
+/// carry a real value (not blank, not the `"unknown"` sentinel), the schema
+/// version must match, the hardware must name at least one logical core, and
+/// every named comparator must be completely pinned.
 fn validate_provenance(p: &Provenance) -> Result<(), ValidationError> {
     if p.schema_version != SCHEMA_VERSION {
         return Err(ValidationError::SchemaVersionMismatch {
@@ -452,27 +525,10 @@ fn validate_provenance(p: &Provenance) -> Result<(), ValidationError> {
             expected: SCHEMA_VERSION,
         });
     }
-    for (field, value) in required_provenance_fields(p) {
-        // A blank field is missing; so is the `"unknown"` sentinel a gatherer on
-        // a host without git or rustc used to emit. Rejecting it here pins the
-        // validator independently of any gatherer, so a future gatherer
-        // regression that reintroduces the sentinel cannot self-validate.
-        let trimmed = value.trim();
-        if trimmed.is_empty() || trimmed.eq_ignore_ascii_case("unknown") {
+    for (field, value) in checked_provenance_fields(p) {
+        if is_absent_value(value) {
             return Err(ValidationError::MissingProvenanceField { field });
         }
-    }
-    // `region`/`endpoint` carry a `"n/a"` sentinel rather than being empty, so a
-    // blank one is still a missing field.
-    if p.backend.region.trim().is_empty() {
-        return Err(ValidationError::MissingProvenanceField {
-            field: "backend.region",
-        });
-    }
-    if p.backend.endpoint.trim().is_empty() {
-        return Err(ValidationError::MissingProvenanceField {
-            field: "backend.endpoint",
-        });
     }
     if p.hardware.logical_cores == 0 {
         return Err(ValidationError::MissingProvenanceField {
@@ -480,12 +536,16 @@ fn validate_provenance(p: &Provenance) -> Result<(), ValidationError> {
         });
     }
     for (index, c) in p.comparators.iter().enumerate() {
+        // A named comparator is a populated field, so its pins reject the
+        // sentinel too, not just blanks: a comparator recorded as
+        // `prometheus=unknown=unknown` is an unreproducible pin masquerading as
+        // one, the same defect one layer out.
         for (field, value) in [
             ("name", c.name.as_str()),
             ("version", c.version.as_str()),
             ("image_digest", c.image_digest.as_str()),
         ] {
-            if value.trim().is_empty() {
+            if is_absent_value(value) {
                 return Err(ValidationError::IncompleteComparator { index, field });
             }
         }
@@ -588,8 +648,29 @@ pub fn validate(report: &MetricsBenchReport) -> Result<(), ValidationError> {
         // A geomean summarizes the timed medians; a report whose rows are all
         // timeout/error/refused has no timed median behind it, so the geomean
         // summarizes nothing.
-        if !report.measurements.iter().any(|m| m.status.is_timed()) {
+        let timed_medians: Vec<f64> = report
+            .measurements
+            .iter()
+            .filter(|m| m.status.is_timed())
+            .filter_map(|m| m.figure("median_ms"))
+            .collect();
+        if timed_medians.is_empty() {
             return Err(ValidationError::GeomeanWithoutTimedRow { value: g });
+        }
+        // Requiring a timed row to exist without checking the value is "present
+        // but unverified": recompute the geometric mean from the timed medians
+        // and reject a supplied value that disagrees. `exp(mean(ln))` rather than
+        // an nth root of a product, which would overflow over dozens of
+        // millisecond medians. Every timed row carries `median_ms`
+        // (`validate_measurement` above enforced it), so the count and the sum
+        // cover the same rows.
+        let sum_ln: f64 = timed_medians.iter().map(|m| m.ln()).sum();
+        let computed = (sum_ln / timed_medians.len() as f64).exp();
+        if (g - computed).abs() > GEOMEAN_REL_TOLERANCE * computed {
+            return Err(ValidationError::GeomeanMismatch {
+                supplied: g,
+                computed,
+            });
         }
     }
     Ok(())
@@ -965,6 +1046,173 @@ mod tests {
         let err =
             validate(&report).expect_err("a geomean over zero timed rows must fail validation");
         assert_eq!(err, ValidationError::GeomeanWithoutTimedRow { value: 12.5 });
+    }
+
+    /// One timed (`ok`) row whose `median_ms` is `median`; `min`/`max` are set to
+    /// the same value because only `median_ms` feeds the geomean recomputation
+    /// and the ordering of the three is not validated.
+    fn timed_with_median(id: &str, median: f64) -> Measurement {
+        Measurement {
+            id: id.to_string(),
+            class: CostClass::HighFanOut,
+            status: ResultStatus::Ok,
+            figures: vec![
+                Figure {
+                    name: "min_ms".to_string(),
+                    value: median,
+                },
+                Figure {
+                    name: "median_ms".to_string(),
+                    value: median,
+                },
+                Figure {
+                    name: "max_ms".to_string(),
+                    value: median,
+                },
+            ],
+        }
+    }
+
+    /// The comparator sentinel defect one layer out: a pin recorded as
+    /// `prometheus=unknown=unknown` used to validate, because the comparator
+    /// fields rejected only blanks. It now fails, naming the first sentinel pin.
+    #[test]
+    fn a_comparator_pinned_with_the_unknown_sentinel_fails_validation() {
+        let mut report = valid_report();
+        report.provenance.comparators[0] = Comparator {
+            name: "prometheus".to_string(),
+            version: "unknown".to_string(),
+            image_digest: "unknown".to_string(),
+        };
+        let err = validate(&report).expect_err("an `unknown` comparator pin must fail");
+        assert_eq!(
+            err,
+            ValidationError::IncompleteComparator {
+                index: 0,
+                field: "version",
+            }
+        );
+    }
+
+    /// A populated backend field carrying the sentinel fails: `region = "unknown"`
+    /// is a sentinel that reads like data, refused the same as a blank.
+    #[test]
+    fn a_populated_backend_field_with_the_unknown_sentinel_fails_validation() {
+        let mut report = valid_report();
+        report.provenance.backend.region = "unknown".to_string();
+        let err = validate(&report).expect_err("an `unknown` region must fail");
+        assert_eq!(
+            err,
+            ValidationError::MissingProvenanceField {
+                field: "backend.region",
+            }
+        );
+    }
+
+    /// A populated optional hardware field carrying the sentinel fails: an absent
+    /// `instance_type` is legitimate, but a present one that is `"unknown"` is a
+    /// sentinel standing in for a real value.
+    #[test]
+    fn a_populated_instance_type_with_the_unknown_sentinel_fails_validation() {
+        let mut report = valid_report();
+        report.provenance.hardware.instance_type = Some("unknown".to_string());
+        let err = validate(&report).expect_err("an `unknown` instance_type must fail");
+        assert_eq!(
+            err,
+            ValidationError::MissingProvenanceField {
+                field: "hardware.instance_type",
+            }
+        );
+    }
+
+    /// The regression the sentinel fix could easily introduce: `region` and
+    /// `endpoint` carrying the legitimate `"n/a"` value (a backend with no
+    /// region/endpoint) still VALIDATE. `"n/a"` is real data, not a sentinel.
+    #[test]
+    fn backend_region_and_endpoint_carrying_n_a_still_validate() {
+        let mut report = valid_report();
+        report.provenance.backend.region = "n/a".to_string();
+        report.provenance.backend.endpoint = "n/a".to_string();
+        validate(&report).expect("`n/a` on region/endpoint is a real value and validates");
+    }
+
+    /// FINDING 2. A geomean that disagrees with the timed medians fails with the
+    /// distinct `GeomeanMismatch` variant, and the error carries both the
+    /// supplied value and the value recomputed from the rows. One timed row of
+    /// `median_ms = 12.5` and a supplied `geomean_ms = 1.0` are two contradictory
+    /// results.
+    ///
+    /// To watch this test FAIL against the pre-fix validator, delete the
+    /// recomputation block in `validate` (the `let sum_ln: f64 = ...` line
+    /// through the `GeomeanMismatch` return, in the `if let Some(g) =
+    /// report.geomean_ms` block). The pre-fix validator required only that a
+    /// timed row EXIST, so `validate` returned `Ok(())` for a disagreeing
+    /// geomean, `expect_err` found `Ok`, and the test failed.
+    #[test]
+    fn a_geomean_disagreeing_with_the_timed_medians_fails_validation() {
+        let mut report = valid_report();
+        // The fixture's single timed row has median_ms = 12.5.
+        assert_eq!(report.measurements[0].figure("median_ms"), Some(12.5));
+        report.geomean_ms = Some(1.0);
+        let err = validate(&report).expect_err("a geomean disagreeing with the medians must fail");
+        match err {
+            ValidationError::GeomeanMismatch { supplied, computed } => {
+                assert_eq!(
+                    supplied, 1.0,
+                    "the error carries the supplied value verbatim"
+                );
+                // The geomean of the single median 12.5 is that median, to within
+                // the `exp(ln)` round-trip error the tolerance itself allows.
+                assert!(
+                    (computed - 12.5).abs() <= GEOMEAN_REL_TOLERANCE * 12.5,
+                    "the error carries the recomputed geomean of the medians, got {computed}"
+                );
+            }
+            other => panic!("wrong error variant: {other:?}"),
+        }
+    }
+
+    /// A geomean computed correctly from the timed medians validates, over enough
+    /// rows that the `exp(mean(ln))` accumulation is non-trivial, so the
+    /// tolerance is exercised rather than assumed. The same computation is fed as
+    /// the supplied value; the recomputation is bit-identical, so it passes well
+    /// inside [`GEOMEAN_REL_TOLERANCE`].
+    #[test]
+    fn a_geomean_matching_the_timed_medians_validates_over_many_rows() {
+        let medians: Vec<f64> = (1..=40).map(|i| 5.0 + f64::from(i) * 0.37).collect();
+        let n = medians.len() as f64;
+        let geomean = (medians.iter().map(|m| m.ln()).sum::<f64>() / n).exp();
+
+        let mut report = valid_report();
+        report.provenance.comparators.clear();
+        report.measurements = medians
+            .iter()
+            .enumerate()
+            .map(|(i, &m)| timed_with_median(&format!("mb_row_{i}"), m))
+            .collect();
+        report.geomean_ms = Some(geomean);
+        validate(&report).expect("a faithfully computed geomean validates");
+
+        // A value just outside the tolerance is rejected, proving the tolerance
+        // is a real check rather than an always-true one.
+        report.geomean_ms = Some(geomean * (1.0 + 2.0 * GEOMEAN_REL_TOLERANCE));
+        let err = validate(&report).expect_err("a geomean outside the tolerance must fail");
+        match err {
+            ValidationError::GeomeanMismatch { supplied, computed } => {
+                assert_eq!(supplied, geomean * (1.0 + 2.0 * GEOMEAN_REL_TOLERANCE));
+                assert_eq!(computed, geomean);
+            }
+            other => panic!("wrong error variant: {other:?}"),
+        }
+    }
+
+    /// A report with no geomean at all still validates: the geomean is optional
+    /// and the per-query rows stand on their own.
+    #[test]
+    fn a_report_with_no_geomean_validates() {
+        let mut report = valid_report();
+        report.geomean_ms = None;
+        validate(&report).expect("a report without a geomean validates");
     }
 
     /// Failure class: a schema version this build does not read.

--- a/crates/ravel-bench/tests/metricsbench_report.rs
+++ b/crates/ravel-bench/tests/metricsbench_report.rs
@@ -41,7 +41,9 @@ fn valid_report() -> MetricsBenchReport {
             comparators: vec![Comparator {
                 name: "prometheus".to_string(),
                 version: "3.13.1".to_string(),
-                image_digest: "sha256:abc".to_string(),
+                image_digest:
+                    "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                        .to_string(),
             }],
             generator_digest: "blake3:1111".to_string(),
             corpus_digest: "blake3:2222".to_string(),

--- a/crates/ravel-bench/tests/metricsbench_report.rs
+++ b/crates/ravel-bench/tests/metricsbench_report.rs
@@ -1,0 +1,239 @@
+//! Reachability tests for the reconciled MetricsBench report schema (ADR-0927,
+//! issue #936): a malformed artifact must fail through the shipping
+//! `metricsbench_report` binary, not only through a direct
+//! `report_schema::validate` call. The unit tests in `report_schema` prove the
+//! validator; these prove the binary that runs it is the fail-closed gate a
+//! consumer actually hits.
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::path::PathBuf;
+use std::process::{Command, Output};
+
+use ravel_bench::promql_corpus::CostClass;
+use ravel_bench::report_schema::{
+    Backend, Comparator, Figure, Hardware, Measurement, MetricsBenchReport, Provenance,
+    ResultStatus, SCHEMA_VERSION,
+};
+
+fn bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_metricsbench_report"))
+}
+
+fn valid_report() -> MetricsBenchReport {
+    MetricsBenchReport {
+        provenance: Provenance {
+            schema_version: SCHEMA_VERSION,
+            ravel_git_commit: "9fc85f421590d360e7979ee167eb38e166b45462".to_string(),
+            toolchain: "rustc 1.90.0".to_string(),
+            protocol: "remote_write_1.0".to_string(),
+            hardware: Hardware {
+                os: "Linux 6.8.0 x86_64".to_string(),
+                cpu_model: "AMD EPYC 7R13".to_string(),
+                logical_cores: 8,
+                instance_type: None,
+            },
+            backend: Backend {
+                store_backend: "s3".to_string(),
+                region: "us-east-1".to_string(),
+                endpoint: "n/a".to_string(),
+                backend_bills_requests: true,
+            },
+            comparators: vec![Comparator {
+                name: "prometheus".to_string(),
+                version: "3.13.1".to_string(),
+                image_digest: "sha256:abc".to_string(),
+            }],
+            generator_digest: "blake3:1111".to_string(),
+            corpus_digest: "blake3:2222".to_string(),
+            config: vec![],
+        },
+        measurements: vec![Measurement {
+            id: "mb_fanout_total_rate".to_string(),
+            class: CostClass::HighFanOut,
+            status: ResultStatus::Ok,
+            figures: vec![
+                Figure {
+                    name: "min_ms".to_string(),
+                    value: 10.0,
+                },
+                Figure {
+                    name: "median_ms".to_string(),
+                    value: 12.5,
+                },
+                Figure {
+                    name: "max_ms".to_string(),
+                    value: 20.0,
+                },
+            ],
+        }],
+        geomean_ms: Some(12.5),
+    }
+}
+
+/// Write a report artifact and run `metricsbench_report render` over it.
+fn render_report(dir: &tempfile::TempDir, name: &str, report: &MetricsBenchReport) -> Output {
+    let path = dir.path().join(name);
+    std::fs::write(
+        &path,
+        serde_json::to_string_pretty(report).expect("serialize"),
+    )
+    .expect("write");
+    Command::new(bin())
+        .args(["render", "--report", path.to_str().expect("utf8 path")])
+        .output()
+        .expect("spawn metricsbench_report")
+}
+
+#[test]
+fn a_valid_report_renders_through_the_binary_with_the_retry_caveat() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let out = render_report(&dir, "valid.json", &valid_report());
+    assert!(
+        out.status.success(),
+        "a valid report must render: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    // The table is derived from the artifact.
+    assert!(stdout.contains("mb_fanout_total_rate"), "{stdout}");
+    assert!(stdout.contains("high_fan_out"), "{stdout}");
+    assert!(
+        stdout.contains("12.500"),
+        "the median figure is rendered: {stdout}"
+    );
+    // The retry caveat is in the rendered output, not only in a doc.
+    assert!(
+        stdout.contains("logical-call counts") && stdout.contains("#928"),
+        "the retry caveat must be rendered: {stdout}"
+    );
+    // A gap with no pre-registered band is a loud SKIP.
+    assert!(
+        stdout.contains("SKIP"),
+        "an unregistered band must render a loud SKIP: {stdout}"
+    );
+}
+
+#[test]
+fn a_report_missing_a_provenance_field_fails_through_the_binary() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut report = valid_report();
+    report.provenance.ravel_git_commit = String::new();
+    let out = render_report(&dir, "missing_field.json", &report);
+    assert!(
+        !out.status.success(),
+        "a blank git commit must fail through the binary"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("ravel_git_commit"),
+        "the binary must name the missing field: {stderr}"
+    );
+}
+
+#[test]
+fn a_non_finite_figure_fails_through_the_binary() {
+    // serde_json cannot represent a non-finite number: it serializes NaN as
+    // `null` and rejects an out-of-range literal like `1e999` at parse time. So
+    // a non-finite figure can never reach the validator through a parsed
+    // artifact -- the parser is itself fail-closed against it, which is the
+    // property this proves through the binary. (The validator's own
+    // `NonFiniteFigure` path, reachable when a producer builds the struct
+    // in-process before serializing, is pinned by the `report_schema` unit
+    // test.)
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut report = valid_report();
+    report.geomean_ms = None;
+    // A distinctive sentinel so the textual swap below hits exactly the median
+    // figure and nothing else.
+    report.measurements[0].figures[1].value = 424_242.0;
+    let json = serde_json::to_string_pretty(&report)
+        .expect("serialize")
+        .replace("424242.0", "1e999");
+    let path = dir.path().join("non_finite.json");
+    std::fs::write(&path, json).expect("write");
+    let out = Command::new(bin())
+        .args(["render", "--report", path.to_str().expect("utf8 path")])
+        .output()
+        .expect("spawn");
+    assert!(
+        !out.status.success(),
+        "a non-finite figure must fail through the binary"
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("not a valid MetricsBench report"),
+        "the binary must reject the out-of-range figure at parse: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn an_unparseable_artifact_fails_through_the_binary() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("garbage.json");
+    std::fs::write(&path, "{ this is not json ]").expect("write");
+    let out = Command::new(bin())
+        .args(["render", "--report", path.to_str().expect("utf8 path")])
+        .output()
+        .expect("spawn");
+    assert!(!out.status.success(), "an unparseable artifact must fail");
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("not a valid MetricsBench report"),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn the_provenance_subcommand_stamps_a_block_a_report_accepts() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    // Any two files: the subcommand digests their contents.
+    let workload = dir.path().join("workload.json");
+    let corpus = dir.path().join("corpus.json");
+    std::fs::write(&workload, r#"{"version":1}"#).expect("write");
+    std::fs::write(&corpus, r#"{"version":1,"entries":[]}"#).expect("write");
+    let out = Command::new(bin())
+        .args([
+            "provenance",
+            "--workload",
+            workload.to_str().expect("utf8 path"),
+            "--corpus",
+            corpus.to_str().expect("utf8 path"),
+            "--store-backend",
+            "s3",
+            "--region",
+            "us-east-1",
+            "--bills-requests",
+            "--config",
+            "max_flush_delay_ms=2000",
+        ])
+        .output()
+        .expect("spawn");
+    assert!(
+        out.status.success(),
+        "provenance must gather and self-validate: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let p: Provenance = serde_json::from_slice(&out.stdout).expect("emitted provenance is JSON");
+    assert_eq!(p.schema_version, SCHEMA_VERSION);
+    assert_eq!(p.backend.store_backend, "s3");
+    assert!(p.backend.backend_bills_requests);
+    assert!(p.generator_digest.starts_with("blake3:"));
+    assert!(p.corpus_digest.starts_with("blake3:"));
+    assert_eq!(p.config.len(), 1);
+    assert_eq!(p.config[0].key, "max_flush_delay_ms");
+    // A different corpus content is a different digest, so the stamp is not
+    // ignoring its inputs.
+    std::fs::write(&corpus, r#"{"version":1,"entries":[1]}"#).expect("rewrite");
+    let out2 = Command::new(bin())
+        .args([
+            "provenance",
+            "--workload",
+            workload.to_str().expect("utf8 path"),
+            "--corpus",
+            corpus.to_str().expect("utf8 path"),
+        ])
+        .output()
+        .expect("spawn");
+    let p2: Provenance = serde_json::from_slice(&out2.stdout).expect("JSON");
+    assert_ne!(p.corpus_digest, p2.corpus_digest);
+}

--- a/crates/ravel-bench/tests/sql_latency_smoke.rs
+++ b/crates/ravel-bench/tests/sql_latency_smoke.rs
@@ -310,3 +310,60 @@ async fn runs_1_reports_a_cold_number_and_equal_min_median_max() {
         );
     }
 }
+
+/// The stdout artifact parses as exactly one complete JSON document with no
+/// trailing bytes (issue #936). The bin used to write the JSON report to stdout
+/// and then append the human summary to the same stream, so `jq -e '.'` failed
+/// at the first summary line and nothing could assert on the artifact. This
+/// drives the shipping `sql_latency_bench` binary and proves stdout is the JSON
+/// alone: `serde_json::from_slice` refuses trailing non-whitespace, so a summary
+/// line leaking back onto stdout fails this test.
+#[test]
+fn the_stdout_artifact_is_one_complete_json_document_with_no_trailing_bytes() {
+    let out = std::process::Command::new(env!("CARGO_BIN_EXE_sql_latency_bench"))
+        .args([
+            "--generate",
+            "--store",
+            "memory",
+            "--runs",
+            "1",
+            "--records",
+            "60",
+            "--records-per-object",
+            "20",
+            "--extra-attrs",
+            "4",
+        ])
+        .output()
+        .expect("spawn sql_latency_bench");
+    assert!(
+        out.status.success(),
+        "sql_latency_bench exited non-zero: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // `from_slice` consumes the WHOLE slice as one value and errors on trailing
+    // non-whitespace, so this is the single-document-with-no-trailing-bytes
+    // assertion in one call: an appended human line makes it fail with "trailing
+    // characters".
+    let doc: serde_json::Value = serde_json::from_slice(&out.stdout)
+        .expect("stdout must be exactly one complete JSON document with no trailing bytes");
+
+    // And it is the report, not some other JSON value.
+    assert!(
+        doc.get("provenance").is_some(),
+        "artifact carries provenance"
+    );
+    assert!(doc.get("entries").is_some(), "artifact carries entries");
+    assert!(
+        doc.get("dataset").is_some(),
+        "artifact carries the dataset block"
+    );
+
+    // The human summary went somewhere: it is on stderr, not stdout.
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("sql_latency_bench report"),
+        "the human summary must be on stderr: {stderr}"
+    );
+}


### PR DESCRIPTION
Two report types existed with disjoint content: SqlLatencyReport's Provenance
carried store backend, region, endpoint, cores, run count and the
requested/effective config pairs but no git commit, toolchain, corpus digest,
OS, CPU model or instance type; report.rs's Environment carried git commit and
toolchain and no object-store accounting. Extending either in ignorance of the
other would have produced a third shape, so this reconciles them and adds the
schema version ADR-0927 requires.

The renderer is new. Post-hoc analysis was a Python script embedded in the
ClickBench runbook, and this departs from that deliberately: the rendered table
is derived from the artifact and never hand-maintained. It reuses the runbook
script's proven design, with bands as named constants in one block, integrity
asserted by identity before any band is applied, an absent-but-expected figure
failing exactly like an out-of-band one, and a stated gap kept as a loud SKIP
rather than silently unasserted.

Validation fails closed on missing, duplicate, non-finite, negative or
malformed measurements. Per-query results stay the source of truth; a geometric
mean may be included but cannot replace them. Every cost estimate carries the
retry caveat that request counts are logical-call counts rather than billed
requests.

It also separates the report's two streams, which was a real defect rather than
a design preference. sql_latency_bench wrote its JSON document to stdout and
then appended the human-readable summary to the same stream, so a real run's
artifact failed to parse: `jq -e '.' report.json` reported `Invalid numeric
literal at line 92`, the first line of the appended table. Any automated check
over the artifact either broke or had to guess where the JSON ended, which
defeats the requirement that reported figures be machine-checkable. The JSON is
now alone on stdout and the summary goes to stderr.

Fixes: #936
Refs: #927, #928
