### PR TITLE
feat(ravel-catalog): build and publish part-bound column statistics

### DIFF
--- a/crates/ravel-catalog/src/column_stats_build.rs
+++ b/crates/ravel-catalog/src/column_stats_build.rs
@@ -12,12 +12,16 @@
 //! meaningful notion of "partially built", while column statistics are
 //! naturally per-segment and independently useful.
 //!
-//! Only L0 entries carry real writer identity (`fold.rs`'s
-//! `build_l1_snapshot_entry`: an L1 entry's writer_id/writer_epoch slots are
-//! repurposed for input_set_hash/part_index), so column-stats coverage is
-//! restricted to `entry.level == 0`. An L1 segment simply has no
-//! `ColumnStatsSegment` entry and its queries fall back to scanning, exactly
-//! like any other segment lacking stats.
+//! ADR-0942 extends coverage to L1: [`fetch_segment_column_stats`] builds a
+//! tally for an L0 or an L1 entry, reconstructing the L1 part key from the
+//! writer_id/writer_epoch slots an L1 entry repurposes for
+//! input_set_hash/part_index (`fold.rs`'s `build_l1_snapshot_entry`). The
+//! returned [`ColumnStatsSegment`] carries the five-field identity tuple as the
+//! builder saw it (`writer_id` is the entry's own writer_id). The fold's frozen
+//! v1 (field-11) publish path uses it unchanged, so a v1 object stays
+//! byte-for-byte as before; the v2 (field-13, part-keyed) publish path
+//! overwrites `writer_id` with the covered part's content hash (the v2 join
+//! key) before encoding.
 
 use ravel_logseg::{ColumnSelection, FieldType, LogSegError, Predicate, RlogConfig, RlogReader};
 use ravel_object_store::{GetRange, ObjectStoreBackend, StoreError};
@@ -41,8 +45,12 @@ pub(crate) enum ColumnStatsBuildError {
     LogSeg(#[from] LogSegError),
     #[error("entry content_hash must be 32 bytes, got {0}")]
     BadContentHashLen(usize),
-    #[error("entry writer_id must be 16 bytes, got {0}")]
+    #[error("L0 entry writer_id must be 16 bytes, got {0}")]
     BadWriterIdLen(usize),
+    #[error("L1 entry writer_id (input_set_hash) must be 32 bytes, got {0}")]
+    BadInputSetHashLen(usize),
+    #[error("L1 entry writer_epoch (part_index) does not fit u32: {0}")]
+    BadPartIndex(u64),
     #[error("column {name:?} declared Str but stored bytes are not valid UTF-8")]
     NonUtf8StrValue { name: String },
 }
@@ -348,11 +356,11 @@ impl ColumnTally {
     }
 }
 
-/// Fetches one L0 logs segment and tallies exact per-column statistics for
-/// every column in `typed_columns`, over every row in the object (no content
-/// filter: `Predicate::And(vec![])` is vacuously true, matching the
-/// full-object scan `LogsScanExec`'s metadata-only path already relies on
-/// for `COUNT(*)`).
+/// Fetches one logs segment (L0 or L1, ADR-0942) and tallies exact per-column
+/// statistics for every column in `typed_columns`, over every row in the
+/// object (no content filter: `Predicate::And(vec![])` is vacuously true,
+/// matching the full-object scan `LogsScanExec`'s metadata-only path already
+/// relies on for `COUNT(*)`).
 ///
 /// A configured column absent from this object's `FIELD_DIR` -- because no
 /// row ever set it, or because it overflowed into `attrs_raw` (the overflow
@@ -369,28 +377,55 @@ pub(crate) async fn fetch_segment_column_stats(
     entry: &ravel_proto::catalog::v1::SnapshotEntry,
     typed_columns: &[DeclaredTypedColumn],
 ) -> Result<ColumnStatsSegment, ColumnStatsBuildError> {
-    debug_assert_eq!(entry.level, 0, "column stats are only built for L0 entries");
-
     let content_hash: [u8; 32] = entry
         .content_hash
         .as_slice()
         .try_into()
         .map_err(|_| ColumnStatsBuildError::BadContentHashLen(entry.content_hash.len()))?;
-    let writer_id_bytes: [u8; 16] = entry
-        .writer_id
-        .as_slice()
-        .try_into()
-        .map_err(|_| ColumnStatsBuildError::BadWriterIdLen(entry.writer_id.len()))?;
-    let writer_id = Uuid::from_bytes(writer_id_bytes);
-    let data_key = ravel_commit::keys::data_key(
-        tenant,
-        signal,
-        entry.shard,
-        writer_id,
-        entry.writer_epoch,
-        entry.writer_seq,
-        &content_hash,
-    )?;
+    // ADR-0942: both L0 and L1 entries are covered. An L0 entry carries the
+    // 16-byte flush writer uuid and addresses its RLOG object by the L0 data
+    // key; an L1 (compaction/rewrite output) entry repurposes the writer_*
+    // slots (`fold::build_l1_snapshot_entry`) to carry the 32-byte
+    // input_set_hash and the part_index, and addresses its RLOG part object by
+    // the reconstructed L1 part key. Both object shapes are RLOG and decode
+    // through the same reader below, so the tally path that follows is
+    // level-agnostic.
+    let data_key = if entry.level == 0 {
+        let writer_id_bytes: [u8; 16] = entry
+            .writer_id
+            .as_slice()
+            .try_into()
+            .map_err(|_| ColumnStatsBuildError::BadWriterIdLen(entry.writer_id.len()))?;
+        let writer_id = Uuid::from_bytes(writer_id_bytes);
+        ravel_commit::keys::data_key(
+            tenant,
+            signal,
+            entry.shard,
+            writer_id,
+            entry.writer_epoch,
+            entry.writer_seq,
+            &content_hash,
+        )?
+    } else {
+        let input_set_hash: [u8; 32] = entry
+            .writer_id
+            .as_slice()
+            .try_into()
+            .map_err(|_| ColumnStatsBuildError::BadInputSetHashLen(entry.writer_id.len()))?;
+        let part_index = u32::try_from(entry.writer_epoch)
+            .map_err(|_| ColumnStatsBuildError::BadPartIndex(entry.writer_epoch))?;
+        let input_set_hash16 = hex::encode(&input_set_hash[..8]);
+        let hash16 = hex::encode(&content_hash[..8]);
+        ravel_commit::keys::l1_part_key(
+            tenant,
+            signal,
+            entry.shard,
+            entry.ingest_hour_bucket,
+            &input_set_hash16,
+            part_index,
+            &hash16,
+        )?
+    };
     let got = store.get(&data_key, GetRange::Full).await?;
 
     let cfg = RlogConfig::default();
@@ -527,6 +562,73 @@ mod tests {
 
     fn i64_attr(key: &str, v: i64) -> (String, AttrValue) {
         (key.to_string(), AttrValue::I64(v))
+    }
+
+    /// Write `records` as a real L1 RLOG part object at its reconstructed L1
+    /// part key (`keys::l1_part_key`), and return the matching L1
+    /// [`SnapshotEntry`] in exactly the shape `fold::build_l1_snapshot_entry`
+    /// produces: `writer_id` holds the 32-byte `input_set_hash`, `writer_epoch`
+    /// holds the `part_index`. An L1 compaction output carries nil writer
+    /// identity in its own footer.
+    async fn write_l1(
+        store: &dyn ObjectStoreBackend,
+        ingest_hour_bucket: u32,
+        input_set_hash: [u8; 32],
+        part_index: u32,
+        records: &[LogRecord],
+    ) -> SnapshotEntry {
+        let cfg = RlogConfig {
+            block_target_records: 3,
+            ..RlogConfig::default()
+        };
+        let mut w = RlogWriter::new(
+            cfg,
+            ObjectIdentity {
+                tenant_hash: TENANT.0,
+                shard: 0,
+                writer_id: *Uuid::nil().as_bytes(),
+                writer_epoch: 0,
+                writer_seq: 0,
+            },
+        );
+        for r in records {
+            w.push(r.clone()).expect("push");
+        }
+        let bytes = w.finish().expect("finish");
+        let content_hash = *blake3::hash(&bytes).as_bytes();
+        let input_set_hash16 = hex::encode(&input_set_hash[..8]);
+        let hash16 = hex::encode(&content_hash[..8]);
+        let key = ravel_commit::keys::l1_part_key(
+            &TENANT,
+            Signal::Logs,
+            0,
+            ingest_hour_bucket,
+            &input_set_hash16,
+            part_index,
+            &hash16,
+        )
+        .expect("l1 part key");
+        store
+            .put(&key, bytes::Bytes::from(bytes), PutOptions::default())
+            .await
+            .expect("put");
+
+        SnapshotEntry {
+            level: 1,
+            shard: 0,
+            ingest_hour_bucket,
+            writer_id: input_set_hash.to_vec(),
+            writer_epoch: u64::from(part_index),
+            writer_seq: 0,
+            content_hash: content_hash.to_vec(),
+            object_size: 0,
+            min_event_ts_ns: 0,
+            max_event_ts_ns: 0,
+            sample_count: records.len() as u64,
+            series_count: 0,
+            segment_format_version: 2,
+            created_unix_ns: 0,
+        }
     }
 
     /// Write `records` as a real L0 RLOG object onto `store` at its true
@@ -672,5 +774,100 @@ mod tests {
         assert_eq!(flag.declared_type, 3, "Bool stats tag");
         assert_eq!(flag.non_null_count, 3);
         assert_eq!(flag.sum, None, "a Bool column carries no integer sum");
+    }
+
+    /// ADR-0942: `fetch_segment_column_stats` builds exact statistics for an L1
+    /// (compaction-output) entry, reconstructing the L1 part key from the
+    /// 32-byte `input_set_hash` and `part_index` the entry carries in its
+    /// writer_* slots, and reading the same RLOG grammar an L0 object uses.
+    ///
+    /// Prove-the-test (deliverable 5): this test fails against the pre-ADR-0942
+    /// builder. The exact line flipped is the data-key construction in
+    /// [`fetch_segment_column_stats`]: it used to be the unconditional
+    /// `let writer_id_bytes: [u8; 16] = entry.writer_id.as_slice().try_into()
+    /// .map_err(|_| ColumnStatsBuildError::BadWriterIdLen(entry.writer_id.len()))?;`
+    /// (plus a `debug_assert_eq!(entry.level, 0)` above it). Against that code
+    /// this L1 entry's 32-byte `writer_id` makes the `try_into` fail, the call
+    /// returns `Err(BadWriterIdLen(32))`, and the `.expect("build stats")` below
+    /// panics before any value is checked.
+    #[tokio::test]
+    async fn fetch_segment_column_stats_covers_l1_entry() {
+        let store = MemoryStore::new();
+        let input_set_hash = [0x33u8; 32];
+        let records = vec![
+            record(1, &[i64_attr("status", 200)]),
+            record(2, &[i64_attr("status", 404)]),
+            record(3, &[i64_attr("status", 200)]),
+            record(4, &[i64_attr("status", 500)]),
+        ];
+        let entry = write_l1(&store, 7, input_set_hash, 0, &records).await;
+
+        let typed = vec![declared("status", DeclaredColumnType::I64)];
+        let seg = fetch_segment_column_stats(&store, &TENANT, Signal::Logs, &entry, &typed)
+            .await
+            .expect("build stats");
+
+        assert_eq!(seg.columns.len(), 1, "only `status` is declared");
+        let status = &seg.columns[0];
+        assert_eq!(status.non_null_count, 4);
+        assert_eq!(status.null_count, 0);
+        assert_eq!(i64_kind(status.min.as_ref().expect("min")), 200);
+        assert_eq!(i64_kind(status.max.as_ref().expect("max")), 500);
+        assert_eq!(status.sum, Some(1304), "200+404+200+500");
+        let dict: Vec<(i64, u64)> = status
+            .dictionary
+            .iter()
+            .map(|e| (i64_kind(e.value.as_ref().expect("value")), e.count))
+            .collect();
+        assert_eq!(dict, vec![(200, 2), (404, 1), (500, 1)]);
+        // The builder passes the entry's identity tuple through unchanged:
+        // writer_id is the L1 entry's 32-byte input_set_hash. The fold's v2
+        // publish path overwrites writer_id with the part content hash (the v2
+        // join key); the builder itself does not.
+        assert_eq!(
+            seg.writer_id,
+            input_set_hash.to_vec(),
+            "builder leaves writer_id as the entry carried it"
+        );
+    }
+
+    /// ADR-0942 safety lemma at the build boundary: a part-bound (v2) object
+    /// whose covered-part binding does not match the parts asked for is a typed,
+    /// graceful mismatch. The fold turns it into "rebuild the baseline"; it is
+    /// never a hard error and never a decode of wrong data. (The query-time
+    /// reader join, task A3, applies the same rule per segment: a resolved
+    /// segment whose content_hash matches no record simply has no stats and the
+    /// query scans it.)
+    #[test]
+    fn decode_previous_column_stats_mismatched_part_binding_is_graceful() {
+        // A v2 record carries the covered part content hash in writer_id.
+        let seg = ColumnStatsSegment {
+            ingest_hour_bucket: 1,
+            shard: 0,
+            writer_id: vec![0xCC; 32],
+            writer_epoch: 0,
+            writer_seq: 0,
+            columns: vec![],
+        };
+        let part_a = [0x0Au8; 32];
+        let part_b = [0x0Bu8; 32];
+        let bytes = crate::snapshot_format::encode_column_stats_v2(
+            TENANT.0,
+            3,
+            vec![part_a.to_vec()],
+            std::slice::from_ref(&seg),
+        )
+        .expect("v2 encodes");
+        let limits = crate::snapshot_format::ColumnStatsLimits::default();
+
+        // Asked for part B: the binding does not match -> typed graceful error.
+        let err = decode_previous_column_stats(&bytes, &[part_b], &limits)
+            .expect_err("mismatched part binding is rejected");
+        assert_eq!(err, SnapshotFormatError::ColumnStatsPartBindingMismatch);
+
+        // Asked for the true binding: decodes, record is content-hash keyed.
+        let ok = decode_previous_column_stats(&bytes, &[part_a], &limits).expect("binding matches");
+        assert_eq!(ok.len(), 1);
+        assert_eq!(ok[0].writer_id, vec![0xCC; 32]);
     }
 }

--- a/crates/ravel-catalog/src/fold.rs
+++ b/crates/ravel-catalog/src/fold.rs
@@ -239,6 +239,19 @@ impl HeadState {
     }
 }
 
+/// Orders v2 column-statistics records by their join key (the covered part's
+/// content hash, carried in `writer_id`) and collapses repeats.
+///
+/// `encode_column_stats_v2` rejects a repeated key outright, and the fold
+/// treats that error as "no field 13 this time", so one repeat would strip the
+/// tenant's part-bound statistics on this and every later fold. A repeated key
+/// means two entries cover a byte-identical part, so their records carry the
+/// same statistics and keeping one is exact rather than a narrowing.
+fn sort_and_dedup_part_segments(segments: &mut Vec<ColumnStatsSegment>) {
+    segments.sort_by(|a, b| a.writer_id.cmp(&b.writer_id));
+    segments.dedup_by(|a, b| a.writer_id == b.writer_id);
+}
+
 /// Greatest ingest-hour bucket sealed at `now_ns` (docs/catalog-and-mvcc.md,
 /// ADR-0020 "Sealed-hour watermark"): the greatest `H` such that
 /// `now_ns >= end(H) + max_flush_lifetime + clock_skew_allowance +
@@ -1742,7 +1755,15 @@ impl Catalog {
                         }
                     }
                     // v2 records sort by their content hash (in writer_id).
-                    part_segments.sort_by(|a, b| a.writer_id.cmp(&b.writer_id));
+                    // Two entries can carry the same content hash: one bucket
+                    // can hold compaction records with different input sets and
+                    // a rewrite record that all reference a byte-identical
+                    // output part. `encode_column_stats_v2` rejects the whole
+                    // artifact on a repeated key, which would drop field 13 for
+                    // the tenant on this and every later fold, so collapse the
+                    // repeats first. A shared content hash means a byte-identical
+                    // part, so the records are equal and keeping one is exact.
+                    sort_and_dedup_part_segments(&mut part_segments);
 
                     match snapshot_format::encode_column_stats_v2(
                         tenant.0,
@@ -3319,6 +3340,59 @@ mod tests {
         // Neither collapsed onto the other: exact, per-part values.
         assert_status_column(rec0, 4, 0, 200, 500, &[(200, 2), (404, 1), (500, 1)], 1304);
         assert_status_column(rec1, 3, 0, 200, 500, &[(200, 1), (500, 2)], 1200);
+    }
+
+    /// ADR-0942: one bucket can hold two entries that cover a byte-identical
+    /// output part, so they carry the same content hash under different
+    /// identity tuples (compaction records with different input sets, plus a
+    /// rewrite record's own parts). `encode_column_stats_v2` rejects a repeated
+    /// key for the WHOLE artifact, and the fold's error arm only logs, so a
+    /// single repeat would strip field 13 for that tenant on this and every
+    /// later fold. Sorting alone does not prevent it; the repeat is collapsed.
+    #[test]
+    fn duplicate_part_content_hashes_are_collapsed_before_encoding() {
+        let shared = vec![7u8; 32];
+        let other = vec![9u8; 32];
+        let seg = |hash: &Vec<u8>| ColumnStatsSegment {
+            writer_id: hash.clone(),
+            ..Default::default()
+        };
+
+        // What the pre-fix code produced: sorted, but still carrying the repeat.
+        let mut sorted_only = vec![seg(&other), seg(&shared), seg(&shared)];
+        sorted_only.sort_by(|a, b| a.writer_id.cmp(&b.writer_id));
+        let err = snapshot_format::encode_column_stats_v2(
+            [0u8; 16],
+            signal::to_proto(Signal::Logs) as u32,
+            Vec::new(),
+            &sorted_only,
+        )
+        .expect_err("a repeated key is rejected for the whole artifact");
+        assert!(
+            matches!(
+                err,
+                crate::snapshot_format::SnapshotFormatError::ColumnStatsDuplicateSegment
+            ),
+            "expected ColumnStatsDuplicateSegment, got {err:?}"
+        );
+
+        // With the collapse the artifact encodes, and the distinct part survives.
+        let mut segments = vec![seg(&other), seg(&shared), seg(&shared)];
+        sort_and_dedup_part_segments(&mut segments);
+        assert_eq!(
+            segments.len(),
+            2,
+            "the repeat collapsed to one, the distinct part kept"
+        );
+        assert_eq!(segments[0].writer_id, shared, "sorted by content hash");
+        assert_eq!(segments[1].writer_id, other);
+        snapshot_format::encode_column_stats_v2(
+            [0u8; 16],
+            signal::to_proto(Signal::Logs) as u32,
+            Vec::new(),
+            &segments,
+        )
+        .expect("encodes once the repeat is collapsed");
     }
 
     /// ADR-0942 (deliverable 2): the fold DUAL-PUBLISHES. After a fold over an

--- a/crates/ravel-catalog/src/fold.rs
+++ b/crates/ravel-catalog/src/fold.rs
@@ -24,8 +24,8 @@ use ravel_object_store::{
     Version, list_all,
 };
 use ravel_proto::catalog::v1::{
-    ColumnStatsSegment, SnapshotColumnStatsRef, SnapshotEntry, SnapshotHead, SnapshotPartRef,
-    SnapshotPostingsRef,
+    ColumnStatsSegment, SnapshotColumnStatsPartRef, SnapshotColumnStatsRef, SnapshotEntry,
+    SnapshotHead, SnapshotPartRef, SnapshotPostingsRef,
 };
 use ravel_proto::commit::v1::{CommitRecord, CompactionPart, CompactionRecord, RewriteRecord};
 use ravel_segment::{ExpectedIdentity, ReaderLimits, SegmentError};
@@ -147,6 +147,18 @@ pub struct FoldReport {
     /// Encoded size of the column-stats object, in bytes. `0` when
     /// `column_stats_built` is `false`.
     pub column_stats_bytes: u64,
+    /// `true` if this fold successfully built and attached the part-hash-keyed
+    /// (v2) column-statistics object under `SnapshotHead.column_stats_part`
+    /// (field 13, ADR-0942). Covers L0 and L1 uniformly. `false` carries the
+    /// same three-way ambiguity as [`Self::column_stats_built`]: no configured
+    /// typed columns, a no-op fold, or a build/PUT failure the fold proceeded
+    /// past. Independent of [`Self::column_stats_built`]: during the
+    /// dual-publish window both the v1 (field 11) and v2 (field 13) objects are
+    /// written each fold.
+    pub column_stats_part_built: bool,
+    /// Encoded size of the v2 part-hash-keyed column-stats object, in bytes.
+    /// `0` when `column_stats_part_built` is `false`.
+    pub column_stats_part_bytes: u64,
     /// Number of commit-bucket entries this fold skipped rather than
     /// aborting on: an unrecognized bucket-key shape, or a commit record
     /// whose identity duplicates one already folded. Both are layout drift
@@ -1619,6 +1631,185 @@ impl Catalog {
                 }
             };
 
+            // ADR-0942 part-hash-keyed column statistics (envelope v2, HEAD
+            // field 13). This is a DUAL PUBLISH, not a replacement: the v1
+            // (field-11) block above still runs and writes its L0-tuple-keyed
+            // object unchanged. This block additionally covers BOTH L0 and L1
+            // entries, binding each record to its covered part's `content_hash`
+            // so two L1 parts of one (shard, hour) bucket -- which collapse to
+            // one nil-writer tuple on the reader side -- get two distinct
+            // records. Retiring field 11 is a separate, floor-citing change
+            // (ADR-0066 decision 1); dropping it here would silently take L0
+            // coverage from any reader predating field 13.
+            //
+            // A v2 record carries its covered part's content hash in the
+            // writer_id slot (the join key; ADR-0942, the record shape is
+            // frozen so no new field is added). The baseline is joined by that
+            // content hash (a segment's exact statistics never change once its
+            // content-addressed object is written), reused from the previous
+            // fold's v2 object, and bound to the previous HEAD's parts exactly
+            // as the v1 baseline is. On the first upgraded fold there is no
+            // field-13 baseline, so every entry is fetched once; thereafter
+            // only genuinely new parts are.
+            let (column_stats_part_built, column_stats_part_size, column_stats_part_ref) =
+                if typed_attr_columns.is_empty() {
+                    (false, 0u64, None)
+                } else {
+                    let v2_baseline: HashMap<Vec<u8>, ColumnStatsSegment> = if rebuilt {
+                        HashMap::new()
+                    } else if let HeadState::Valid { head, .. } = &head_state
+                        && let Some(stats_ref) = &head.column_stats_part
+                    {
+                        match self.store().get(&stats_ref.key, GetRange::Full).await {
+                            Ok(got) => {
+                                counters.get_requests += 1;
+                                let expected_part_blake3: Vec<[u8; 32]> = head
+                                    .parts
+                                    .iter()
+                                    .map(|p| <[u8; 32]>::try_from(p.blake3.as_slice()))
+                                    .collect::<Result<_, _>>()
+                                    .unwrap_or_default();
+                                match column_stats_build::decode_previous_column_stats(
+                                    &got.data,
+                                    &expected_part_blake3,
+                                    &crate::snapshot_format::ColumnStatsLimits::default(),
+                                ) {
+                                    Ok(segments) => segments
+                                        .into_iter()
+                                        // v2 records carry the part content hash
+                                        // in writer_id; key the reuse map by it.
+                                        .map(|segment| (segment.writer_id.clone(), segment))
+                                        .collect(),
+                                    Err(err) => {
+                                        tracing::warn!(
+                                            error = %err,
+                                            tenant = %tenant.to_hex(),
+                                            "previous part-bound column-stats object failed to decode or bind to this fold's parts; rebuilding every segment's statistics"
+                                        );
+                                        HashMap::new()
+                                    }
+                                }
+                            }
+                            Err(err) => {
+                                tracing::warn!(
+                                    error = %err,
+                                    tenant = %tenant.to_hex(),
+                                    "previous part-bound column-stats object GET failed; rebuilding every segment's statistics"
+                                );
+                                HashMap::new()
+                            }
+                        }
+                    } else {
+                        HashMap::new()
+                    };
+
+                    let mut part_segments: Vec<ColumnStatsSegment> = Vec::new();
+                    for entry in entries.iter() {
+                        if let Some(existing) = v2_baseline.get(&entry.content_hash) {
+                            part_segments.push(existing.clone());
+                            continue;
+                        }
+                        match column_stats_build::fetch_segment_column_stats(
+                            self.store(),
+                            tenant,
+                            signal,
+                            entry,
+                            &typed_attr_columns,
+                        )
+                        .await
+                        {
+                            Ok(mut segment) => {
+                                counters.get_requests += 1;
+                                // The v2 join key: bind the record to its
+                                // covered part's content hash (== the reader's
+                                // `SegmentRef.content_hash`), uniform for L0 and
+                                // L1 and unique per part, carried in writer_id.
+                                // This overwrites the tuple's writer_id, which
+                                // is only informational in a v2 record.
+                                segment.writer_id = entry.content_hash.clone();
+                                part_segments.push(segment);
+                            }
+                            Err(err) => {
+                                tracing::warn!(
+                                    error = %err,
+                                    tenant = %tenant.to_hex(),
+                                    ingest_hour_bucket = entry.ingest_hour_bucket,
+                                    shard = entry.shard,
+                                    level = entry.level,
+                                    "part-bound column-stats build failed for one segment; it has no stats entry and queries over it fall back to scanning"
+                                );
+                            }
+                        }
+                    }
+                    // v2 records sort by their content hash (in writer_id).
+                    part_segments.sort_by(|a, b| a.writer_id.cmp(&b.writer_id));
+
+                    match snapshot_format::encode_column_stats_v2(
+                        tenant.0,
+                        signal_num,
+                        part_hashes.iter().map(|h| h.to_vec()).collect(),
+                        &part_segments,
+                    ) {
+                        Ok(stats_bytes) => {
+                            let stats_crc = crc32c::crc32c(&stats_bytes);
+                            let stats_hash = blake3::hash(&stats_bytes);
+                            let stats_hash16 = &stats_hash.to_hex()[..16];
+                            let stats_key = column_stats_object_key(
+                                tenant,
+                                signal,
+                                watermark_hour,
+                                stats_hash16,
+                            );
+                            let size = stats_bytes.len() as u64;
+                            let segment_count = part_segments.len() as u32;
+                            match self
+                                .store()
+                                .put(
+                                    &stats_key,
+                                    Bytes::from(stats_bytes),
+                                    PutOptions::create_if_absent()
+                                        .with_checksum(UploadChecksum::Crc32c(stats_crc)),
+                                )
+                                .await
+                            {
+                                Ok(_) | Err(StoreError::AlreadyExists) => {
+                                    counters.put_requests += 1;
+                                    (
+                                        true,
+                                        size,
+                                        Some(SnapshotColumnStatsPartRef {
+                                            key: stats_key,
+                                            blake3: stats_hash.as_bytes().to_vec(),
+                                            size,
+                                            segment_count,
+                                            part_blake3: part_hashes
+                                                .iter()
+                                                .map(|h| h.to_vec())
+                                                .collect(),
+                                        }),
+                                    )
+                                }
+                                Err(err) => {
+                                    tracing::warn!(
+                                        error = %err,
+                                        tenant = %tenant.to_hex(),
+                                        "part-bound column-stats PUT failed, folding without a field-13 ref"
+                                    );
+                                    (false, 0, None)
+                                }
+                            }
+                        }
+                        Err(err) => {
+                            tracing::warn!(
+                                error = %err,
+                                tenant = %tenant.to_hex(),
+                                "part-bound column-stats encode failed, folding without a field-13 ref"
+                            );
+                            (false, 0, None)
+                        }
+                    }
+                };
+
             let new_head = SnapshotHead {
                 format_version: HEAD_FORMAT_VERSION,
                 tenant_hash: tenant.0.to_vec(),
@@ -1633,9 +1824,11 @@ impl Catalog {
                 parts: part_refs.clone(),
                 postings: postings_ref,
                 column_stats: column_stats_ref,
-                // ADR-0942 A1: additive field 13, not written by any path yet.
-                // Absent (None) keeps HEAD encoding byte-for-byte identical.
-                column_stats_part: None,
+                // ADR-0942 A2: the part-hash-keyed (v2) column-stats object,
+                // covering L0 and L1. Absent (None) when the tenant has no
+                // configured typed columns or the build/PUT failed; a reader
+                // treats absence as fall-back-to-scan, never an error.
+                column_stats_part: column_stats_part_ref,
                 folder_id: folder_id.into_bytes().to_vec(),
                 created_unix_ns: now_ns,
                 shard_generation_count,
@@ -1690,6 +1883,8 @@ impl Catalog {
                         postings_bytes: postings_size,
                         column_stats_built,
                         column_stats_bytes: column_stats_size,
+                        column_stats_part_built,
+                        column_stats_part_bytes: column_stats_part_size,
                         layout_drift_count,
                         frontier_hours_reconciled,
                         frontier_hours_deferred,
@@ -2425,6 +2620,8 @@ fn no_op_report(watermark_hour: Option<u32>, counters: RequestCounters) -> FoldR
         postings_bytes: 0,
         column_stats_built: false,
         column_stats_bytes: 0,
+        column_stats_part_built: false,
+        column_stats_part_bytes: 0,
         layout_drift_count: 0,
         frontier_hours_reconciled: 0,
         frontier_hours_deferred: 0,
@@ -2862,6 +3059,388 @@ mod tests {
             loaded.segments.len(),
             3,
             "the reused baseline plus the new segment cover all three"
+        );
+    }
+
+    /// Declare `status` as an I64 typed logs column so the fold builds column
+    /// statistics for a (tenant, Logs) pair.
+    async fn set_status_column_config(store: &dyn ObjectStoreBackend) {
+        let cfg = crate::tenant_config::TenantConfig {
+            typed_attr_columns: Some(vec![crate::tenant_config::DeclaredTypedColumn {
+                key: "status".to_string(),
+                ty: crate::tenant_config::DeclaredColumnType::I64,
+            }]),
+            ..crate::tenant_config::TenantConfig::new(
+                crate::tenant_config::TenantLifecycleState::Active,
+            )
+        };
+        crate::tenant_config::set_tenant_config(store, &tenant(), &cfg, 1)
+            .await
+            .expect("write tenant config");
+    }
+
+    async fn read_logs_head(store: &dyn ObjectStoreBackend) -> SnapshotHead {
+        let got = store
+            .get(&head_object_key(&tenant(), Signal::Logs), GetRange::Full)
+            .await
+            .expect("head present");
+        snapshot_format::decode_head(&got.data).expect("head decodes")
+    }
+
+    /// Publish a compaction record for `(shard, ingest_hour_bucket)` whose parts
+    /// are REAL L1 RLOG objects, each carrying the `status` I64 column. `parts`
+    /// gives the status values per part; part `i` becomes CompactionPart
+    /// `part_index = i`. Both the part objects (at their reconstructed L1 keys)
+    /// and the compaction record are written, so a fold over the hour produces
+    /// one L1 `SnapshotEntry` per part and ADR-0942 builds part-bound stats for
+    /// each. Returns the record (its `parts[i].content_hash` is the v2 join key
+    /// for part `i`).
+    async fn publish_logs_l1(
+        store: &dyn ObjectStoreBackend,
+        shard: u32,
+        ingest_hour_bucket: u32,
+        input_set_seed: &str,
+        parts: &[&[i64]],
+    ) -> CompactionRecord {
+        use ravel_logseg::writer::ObjectIdentity;
+        use ravel_logseg::{LogRecord, RlogConfig, RlogWriter, stream_attrs_bytes};
+        use ravel_types::logstream::{AttrValue, log_stream_id};
+
+        let resource = vec![(
+            "service.name".to_string(),
+            AttrValue::Str("api".to_string()),
+        )];
+        let input_set_hash = *blake3::hash(input_set_seed.as_bytes()).as_bytes();
+        let base_ts = i64::from(ingest_hour_bucket) * NS_PER_HOUR + 60_000_000_000;
+
+        let mut compaction_parts: Vec<CompactionPart> = Vec::new();
+        let mut part_bytes: Vec<Vec<u8>> = Vec::new();
+        let mut max_ts_all = i64::MIN;
+        for (part_index, statuses) in parts.iter().enumerate() {
+            let mut w = RlogWriter::new(
+                RlogConfig::default(),
+                ObjectIdentity {
+                    tenant_hash: tenant().0,
+                    shard,
+                    writer_id: *Uuid::nil().as_bytes(),
+                    writer_epoch: 0,
+                    writer_seq: 0,
+                },
+            );
+            let mut min_ts = i64::MAX;
+            let mut max_ts = i64::MIN;
+            for (i, status) in statuses.iter().enumerate() {
+                let ts = base_ts + (part_index as i64) * 1_000_000 + i as i64;
+                min_ts = min_ts.min(ts);
+                max_ts = max_ts.max(ts);
+                w.push(LogRecord {
+                    stream_id: log_stream_id(&resource, "scope", "1.0", &[]),
+                    stream_attrs: stream_attrs_bytes(&resource, "scope", "1.0", &[]),
+                    ts_ns: ts,
+                    observed_ts_ns: ts,
+                    severity_num: 9,
+                    severity_text: "INFO".into(),
+                    body: format!("row {part_index}-{i}"),
+                    trace_id: None,
+                    span_id: None,
+                    flags: 0,
+                    attrs: vec![("status".to_string(), AttrValue::I64(*status))],
+                })
+                .expect("push");
+            }
+            let bytes = w.finish().expect("finish");
+            let content_hash = *blake3::hash(&bytes).as_bytes();
+            max_ts_all = max_ts_all.max(max_ts);
+            compaction_parts.push(CompactionPart {
+                part_index: part_index as u32,
+                first_series_id: vec![0u8; 16],
+                last_series_id: vec![0xffu8; 16],
+                content_hash: content_hash.to_vec(),
+                object_size: bytes.len() as u64,
+                sample_count: statuses.len() as u64,
+                series_count: 1,
+                run_count: 1,
+                min_event_ts_ns: min_ts,
+                max_event_ts_ns: max_ts,
+                segment_format_version: 2,
+            });
+            part_bytes.push(bytes);
+        }
+
+        let record = CompactionRecord {
+            format_version: 1,
+            tenant_hash: tenant().0.to_vec(),
+            signal: signal::to_proto(Signal::Logs).into(),
+            shard,
+            ingest_hour_bucket,
+            level: 1,
+            inputs: Vec::new(),
+            input_set_hash: input_set_hash.to_vec(),
+            parts: compaction_parts,
+            created_unix_ns: max_ts_all,
+        };
+        for (part, bytes) in record.parts.iter().zip(part_bytes) {
+            let key = keys::reconstruct_l1_part_key(&record, part).expect("l1 part key");
+            publish::put_data_object(store, &key, Bytes::from(bytes))
+                .await
+                .expect("put l1 part object");
+        }
+        let ckey = keys::compaction_record_key_for(&record).expect("compaction key");
+        store
+            .put(
+                &ckey,
+                Bytes::from(record.encode_to_vec()),
+                PutOptions::create_if_absent(),
+            )
+            .await
+            .expect("put compaction record");
+        record
+    }
+
+    /// Assert the single declared `status` I64 column of a decoded segment has
+    /// exactly the given statistics.
+    fn assert_status_column(
+        seg: &ColumnStatsSegment,
+        non_null: u64,
+        null: u64,
+        min: i64,
+        max: i64,
+        dict: &[(i64, u64)],
+        sum: i64,
+    ) {
+        use ravel_proto::catalog::v1::ColumnValue;
+        use ravel_proto::catalog::v1::column_value::Kind;
+        let unwrap_i64 = |v: &ColumnValue| match &v.kind {
+            Some(Kind::I64(x)) => *x,
+            other => panic!("expected I64 column value, got {other:?}"),
+        };
+        assert_eq!(seg.columns.len(), 1, "only status is declared");
+        let col = &seg.columns[0];
+        assert_eq!(col.name, "status");
+        assert_eq!(col.declared_type, 2, "I64 stats tag");
+        assert_eq!(col.non_null_count, non_null);
+        assert_eq!(col.null_count, null);
+        assert_eq!(unwrap_i64(col.min.as_ref().expect("min")), min);
+        assert_eq!(unwrap_i64(col.max.as_ref().expect("max")), max);
+        assert!(col.dictionary_present, "cardinality under the ceiling");
+        let got: Vec<(i64, u64)> = col
+            .dictionary
+            .iter()
+            .map(|e| (unwrap_i64(e.value.as_ref().expect("value")), e.count))
+            .collect();
+        assert_eq!(got, dict, "exact per-value counts, ascending");
+        assert_eq!(col.sum, Some(sum));
+    }
+
+    /// ADR-0942 (deliverables 1 & 3): a fold over an L1-COMPACTED fixture builds
+    /// part-bound (v2, field 13) records for the L1 entries, with EXACT expected
+    /// values, and two L1 parts of one (shard, hour) bucket -- the collision the
+    /// old five-field tuple key could not represent, because a reconstructed L1
+    /// SegmentRef carries writer_id nil / epoch 0 / seq 0 -- produce two DISTINCT
+    /// records keyed by their distinct content hashes, neither overwriting the
+    /// other.
+    #[tokio::test]
+    async fn l1_compacted_fold_builds_part_bound_records_with_exact_values() {
+        let store = Arc::new(MemoryStore::new());
+        set_status_column_config(store.as_ref()).await;
+
+        // One compaction record, two L1 parts, both in (shard 0, hour 10).
+        let record = publish_logs_l1(
+            store.as_ref(),
+            0,
+            10,
+            "input-set-seed",
+            &[&[200, 404, 200, 500], &[500, 500, 200]],
+        )
+        .await;
+
+        let catalog = Catalog::new(store.clone(), config(1)).expect("catalog");
+        let report = catalog
+            .fold(
+                &tenant(),
+                Signal::Logs,
+                Uuid::new_v4(),
+                now_at_seal(10),
+                &[],
+                None,
+            )
+            .await
+            .expect("fold");
+        assert!(report.rebuilt, "first fold rebuilds from the commit layout");
+        assert_eq!(report.entry_count, 2, "two L1 parts folded");
+        assert!(
+            report.column_stats_part_built,
+            "the part-bound (field 13) object is built over the L1 entries"
+        );
+
+        let head = read_logs_head(store.as_ref()).await;
+        // Both L1 entries really are level 1 in the folded snapshot.
+        let entries = collect_head_entries(store.as_ref(), &head).await;
+        assert_eq!(entries.len(), 2);
+        assert!(entries.iter().all(|e| e.level == 1), "genuinely L1 fixture");
+
+        let stats_ref = head
+            .column_stats_part
+            .clone()
+            .expect("field 13 present after folding L1 parts");
+        let got = store
+            .get(&stats_ref.key, GetRange::Full)
+            .await
+            .expect("v2 object present");
+        let decoded = snapshot_format::decode_column_stats(
+            &got.data,
+            &crate::snapshot_format::ColumnStatsLimits::default(),
+        )
+        .expect("v2 decodes");
+        assert_eq!(
+            decoded.header.format_version, 2,
+            "part-bound object is envelope v2"
+        );
+        assert_eq!(
+            decoded.segments.len(),
+            2,
+            "two L1 parts of one bucket -> two records"
+        );
+
+        let ch0 = record.parts[0].content_hash.clone();
+        let ch1 = record.parts[1].content_hash.clone();
+        assert_ne!(ch0, ch1, "distinct parts have distinct content hashes");
+        // A v2 record is keyed by the part content hash carried in writer_id.
+        let rec0 = decoded
+            .segments
+            .iter()
+            .find(|s| s.writer_id == ch0)
+            .expect("part 0's record is present, keyed by its content hash");
+        let rec1 = decoded
+            .segments
+            .iter()
+            .find(|s| s.writer_id == ch1)
+            .expect("part 1's record is present, keyed by its content hash");
+        // Neither collapsed onto the other: exact, per-part values.
+        assert_status_column(rec0, 4, 0, 200, 500, &[(200, 2), (404, 1), (500, 1)], 1304);
+        assert_status_column(rec1, 3, 0, 200, 500, &[(200, 1), (500, 2)], 1200);
+    }
+
+    /// ADR-0942 (deliverable 2): the fold DUAL-PUBLISHES. After a fold over an
+    /// L0 fixture, HEAD carries both the v1 field-11 object and the v2 field-13
+    /// object, and the field-11 object is byte-for-byte identical to what the
+    /// pre-change fold wrote for the same input (reconstructed here from the
+    /// canonical v1 encoder over the same L0 segment stats).
+    #[tokio::test]
+    async fn fold_dual_publishes_v1_and_v2_and_v1_object_is_byte_identical() {
+        let store = Arc::new(MemoryStore::new());
+        set_status_column_config(store.as_ref()).await;
+
+        publish_logs_segment(store.as_ref(), 1, 10, &[200, 404, 200]).await;
+        publish_logs_segment(store.as_ref(), 2, 10, &[500, 200]).await;
+
+        let catalog = Catalog::new(store.clone(), config(1)).expect("catalog");
+        let report = catalog
+            .fold(
+                &tenant(),
+                Signal::Logs,
+                Uuid::new_v4(),
+                now_at_seal(10),
+                &[],
+                None,
+            )
+            .await
+            .expect("fold");
+        assert!(report.column_stats_built, "field 11 (v1) built");
+        assert!(report.column_stats_part_built, "field 13 (v2) built");
+
+        let head = read_logs_head(store.as_ref()).await;
+        let v1_ref = head.column_stats.clone().expect("field 11 present");
+        let v2_ref = head.column_stats_part.clone().expect("field 13 present");
+        assert_ne!(v1_ref.key, v2_ref.key, "v1 and v2 are distinct objects");
+
+        // Reconstruct the canonical v1 object over the same L0 segment stats and
+        // the same part set, exactly as the pre-change fold did.
+        let entries = collect_head_entries(store.as_ref(), &head).await;
+        let typed = vec![crate::tenant_config::DeclaredTypedColumn {
+            key: "status".to_string(),
+            ty: crate::tenant_config::DeclaredColumnType::I64,
+        }];
+        let mut l0: Vec<ColumnStatsSegment> = Vec::new();
+        for entry in entries.iter().filter(|e| e.level == 0) {
+            let seg = column_stats_build::fetch_segment_column_stats(
+                store.as_ref(),
+                &tenant(),
+                Signal::Logs,
+                entry,
+                &typed,
+            )
+            .await
+            .expect("l0 stats");
+            l0.push(seg);
+        }
+        l0.sort_by(|a, b| {
+            (
+                a.ingest_hour_bucket,
+                a.shard,
+                a.writer_id.as_slice(),
+                a.writer_epoch,
+                a.writer_seq,
+            )
+                .cmp(&(
+                    b.ingest_hour_bucket,
+                    b.shard,
+                    b.writer_id.as_slice(),
+                    b.writer_epoch,
+                    b.writer_seq,
+                ))
+        });
+        let part_blake3: Vec<Vec<u8>> = head.parts.iter().map(|p| p.blake3.clone()).collect();
+        let signal_num = signal::to_proto(Signal::Logs) as u32;
+        let expected_v1 =
+            snapshot_format::encode_column_stats(tenant().0, signal_num, part_blake3, &l0)
+                .expect("canonical v1 encodes");
+
+        let got_v1 = store
+            .get(&v1_ref.key, GetRange::Full)
+            .await
+            .expect("v1 object present")
+            .data;
+        assert_eq!(
+            got_v1.as_ref(),
+            expected_v1.as_slice(),
+            "field-11 v1 object is byte-identical to the canonical v1 encode"
+        );
+        assert_eq!(got_v1[4], 1, "field-11 object is envelope v1");
+
+        // The two objects differ only in keying: v1 records key by the tuple
+        // with a 16-byte writer_id uuid; v2 records key by the 32-byte part
+        // content hash carried in writer_id.
+        let limits = crate::snapshot_format::ColumnStatsLimits::default();
+        let dec_v1 = snapshot_format::decode_column_stats(&got_v1, &limits).expect("v1 decodes");
+        assert!(
+            dec_v1.segments.iter().all(|s| s.writer_id.len() == 16),
+            "v1 records carry the 16-byte writer uuid"
+        );
+        let got_v2 = store
+            .get(&v2_ref.key, GetRange::Full)
+            .await
+            .expect("v2 object present")
+            .data;
+        assert_eq!(got_v2[4], 2, "field-13 object is envelope v2");
+        let dec_v2 = snapshot_format::decode_column_stats(&got_v2, &limits).expect("v2 decodes");
+        assert_eq!(dec_v2.segments.len(), 2, "v2 covers both L0 segments");
+        assert!(
+            dec_v2.segments.iter().all(|s| s.writer_id.len() == 32),
+            "every v2 record is keyed by a 32-byte part content hash"
+        );
+        // Each v2 record's key is exactly the L0 entry's content hash.
+        let entry_hashes: std::collections::HashSet<Vec<u8>> = entries
+            .iter()
+            .filter(|e| e.level == 0)
+            .map(|e| e.content_hash.clone())
+            .collect();
+        assert!(
+            dec_v2
+                .segments
+                .iter()
+                .all(|s| entry_hashes.contains(&s.writer_id)),
+            "v2 keys are the covered L0 parts' content hashes"
         );
     }
 

--- a/crates/ravel-catalog/src/snapshot_format/column_stats.rs
+++ b/crates/ravel-catalog/src/snapshot_format/column_stats.rs
@@ -3,7 +3,7 @@
 //!
 //! ```text
 //! magic           "RCST" (4 bytes)
-//! version         u8 = 1
+//! version         u8 = 1 (ADR-0850, L0-tuple keyed) or 2 (ADR-0942, part-keyed)
 //! reserved        u8[3] = 0
 //! header_len      u32 LE
 //! header          protobuf ravel.catalog.v1.ColumnStatsHeader
@@ -11,10 +11,21 @@
 //! body            zstd(segments)  segments = length-delimited protobuf
 //!                                 ravel.catalog.v1.ColumnStatsSegment,
 //!                                 sorted by (ingest_hour_bucket, shard,
-//!                                 writer_id, writer_epoch, writer_seq)
+//!                                 writer_id, writer_epoch, writer_seq) in v1,
+//!                                 by writer_id (the part content hash) in v2
 //! body_crc32c     u32 LE          over the compressed body bytes
 //! header_crc32c   u32 LE          over magic..header inclusive
 //! ```
+//!
+//! Two envelope versions coexist during the ADR-0942 dual-publish window. The
+//! `ColumnStatsSegment` record shape is frozen and shared; the key model is the
+//! version's. v1 keys each record by the five-field identity tuple (writer_id is
+//! the 16-byte flush-writer uuid) and covers L0 only. v2 keys by the covered
+//! part's content hash, which the writer carries in the `writer_id` slot as 32
+//! bytes (the same slot an L1 `SnapshotEntry` already repurposes for a 32-byte
+//! hash), and covers L0 and L1 uniformly. The keying is self-describing in the
+//! version byte, so an object read outside its head ref declares which key
+//! model it carries.
 //!
 //! Deliberately reuses `part.rs`'s plain length-delimited-protobuf body
 //! convention rather than `postings.rs`'s hand-rolled varint dictionary:
@@ -41,11 +52,33 @@ pub struct DecodedColumnStats {
     pub segments: Vec<ColumnStatsSegment>,
 }
 
-/// Encodes a column-statistics object. Validates `segments` against the same
-/// rules `decode_column_stats` enforces (sort order, no duplicate identity),
-/// mirroring `encode_part`'s defensive-validation precedent: an object this
-/// function writes can never fail its own decode.
+/// Encodes a **v1** (ADR-0850, L0-tuple-keyed) column-statistics object, the
+/// `SnapshotHead.column_stats` (field 11) artifact. Validates `segments`
+/// against the same rules `decode_column_stats` enforces for v1 (writer_id
+/// width, tuple sort order, no duplicate identity), mirroring `encode_part`'s
+/// defensive-validation precedent: an object this function writes can never
+/// fail its own decode.
+///
+/// Stamps envelope version 1 explicitly, NOT [`COLUMN_STATS_WRITE_VERSION`]:
+/// the ADR-0942 dual-publish window keeps writing the v1 object byte-for-byte
+/// as before even after the write version moves to 2. The v2 (part-keyed)
+/// artifact is written by [`encode_column_stats_v2`].
 pub fn encode_column_stats(
+    tenant_hash: [u8; 16],
+    signal: u32,
+    part_blake3: Vec<Vec<u8>>,
+    segments: &[ColumnStatsSegment],
+) -> Result<Vec<u8>, SnapshotFormatError> {
+    encode_column_stats_versioned(1, tenant_hash, signal, part_blake3, segments)
+}
+
+/// Encodes a **v2** (ADR-0942, part-hash-keyed) column-statistics object, the
+/// `SnapshotHead.column_stats_part` (field 13) artifact. Each segment record
+/// must carry its covered part's content hash (blake3) in its `writer_id` slot
+/// as 32 bytes; records are sorted and deduplicated by that hash, not the
+/// five-field identity tuple, so L0 and L1 parts are named uniformly and two L1
+/// parts of one bucket never collide. Stamps [`COLUMN_STATS_WRITE_VERSION`].
+pub fn encode_column_stats_v2(
     tenant_hash: [u8; 16],
     signal: u32,
     part_blake3: Vec<Vec<u8>>,
@@ -60,12 +93,11 @@ pub fn encode_column_stats(
     )
 }
 
-/// Envelope framing shared by the public writer and the tests. Parameterised on
-/// `version` so a test can construct a v2 object (ADR-0942) without a v2 writer:
-/// production only ever reaches it through [`encode_column_stats`] with
-/// [`COLUMN_STATS_WRITE_VERSION`], so nothing writes a v2 object yet. Stamps
-/// `version` into both the envelope version byte and the header
-/// `format_version`, so the two always agree by construction.
+/// Envelope framing shared by the public writers and the tests. Parameterised
+/// on `version`, which selects both the stamped version byte and the segment
+/// key model `validate_segments` enforces (v1: five-field tuple; v2:
+/// `content_hash`). Stamps `version` into both the envelope version byte and
+/// the header `format_version`, so the two always agree by construction.
 fn encode_column_stats_versioned(
     version: u8,
     tenant_hash: [u8; 16],
@@ -73,7 +105,7 @@ fn encode_column_stats_versioned(
     part_blake3: Vec<Vec<u8>>,
     segments: &[ColumnStatsSegment],
 ) -> Result<Vec<u8>, SnapshotFormatError> {
-    validate_segments(segments)?;
+    validate_segments(segments, version)?;
 
     let mut segments_raw = Vec::new();
     for segment in segments {
@@ -211,29 +243,56 @@ pub fn decode_column_stats(
             actual: segments.len() as u64,
         });
     }
-    validate_segments(&segments)?;
+    validate_segments(&segments, version)?;
 
     Ok(DecodedColumnStats { header, segments })
 }
 
-/// Sort/uniqueness/field validation shared by `encode_column_stats`
-/// (defensive check of caller input) and `decode_column_stats` (untrusted-
-/// bytes check). Beyond segment identity this also validates every
-/// `ColumnStat`'s internal semantics (ADR-0850): a record the metadata-only
-/// query path could read (`declared_not_equal_count`/`declared_group_counts`)
-/// is rejected here before it can ever be loaded, so those paths can never
-/// derive a wrong answer from an internally-inconsistent record. Fail closed.
-fn validate_segments(segments: &[ColumnStatsSegment]) -> Result<(), SnapshotFormatError> {
+/// Sort/uniqueness/field validation shared by the encoders (defensive check of
+/// caller input) and `decode_column_stats` (untrusted-bytes check). Beyond
+/// segment identity this also validates every `ColumnStat`'s internal
+/// semantics (ADR-0850): a record the metadata-only query path could read
+/// (`declared_not_equal_count`/`declared_group_counts`) is rejected here before
+/// it can ever be loaded, so those paths can never derive a wrong answer from
+/// an internally-inconsistent record. Fail closed.
+///
+/// `version` selects the segment key model (ADR-0942). Both models key on
+/// `writer_id` (field 3), differing in width and meaning:
+/// - v1 (`version < 2`): the 16-byte flush-writer uuid, one component of the
+///   five-field identity tuple the records are sorted and deduplicated by.
+/// - v2 (`version >= 2`): the covered part's 32-byte content hash (blake3),
+///   which the writer carries in the same slot an L1 `SnapshotEntry` already
+///   repurposes for a 32-byte hash. Records are sorted and deduplicated by that
+///   hash alone; the remaining tuple fields are informational.
+///
+/// Requiring the exact width per version is what makes a v1 object encountered
+/// under field 13, or a v2 object under field 11, self-evidently wrong to a
+/// reader that has already established which version it expects.
+fn validate_segments(
+    segments: &[ColumnStatsSegment],
+    version: u8,
+) -> Result<(), SnapshotFormatError> {
+    let part_keyed = version >= 2;
+    let expected_writer_id_len = if part_keyed { 32 } else { 16 };
     for (i, segment) in segments.iter().enumerate() {
-        if segment.writer_id.len() != 16 {
+        if segment.writer_id.len() != expected_writer_id_len {
             return Err(SnapshotFormatError::ColumnStatsBadFieldLen {
                 field: "writer_id",
-                expected: 16,
+                expected: expected_writer_id_len,
                 actual: segment.writer_id.len(),
             });
         }
         if i > 0 {
-            match segment_key(&segments[i - 1]).cmp(&segment_key(segment)) {
+            let ordering = if part_keyed {
+                // v2: the whole key is the content hash carried in writer_id.
+                segments[i - 1]
+                    .writer_id
+                    .as_slice()
+                    .cmp(segment.writer_id.as_slice())
+            } else {
+                segment_key(&segments[i - 1]).cmp(&segment_key(segment))
+            };
+            match ordering {
                 std::cmp::Ordering::Less => {}
                 std::cmp::Ordering::Equal => {
                     return Err(SnapshotFormatError::ColumnStatsDuplicateSegment);
@@ -851,7 +910,10 @@ mod tests {
     /// `ColumnStatsUnsupportedVersion(2)`.
     #[test]
     fn v2_stamped_object_decodes() {
-        let seg = segment(1, 0, 1);
+        // A v2 record is keyed by its covered part's content hash, carried in
+        // writer_id as 32 bytes.
+        let mut seg = segment(1, 0, 1);
+        seg.writer_id = vec![0x77; 32];
         let bytes = encode_column_stats_versioned(
             2,
             [0x11; 16],
@@ -867,12 +929,82 @@ mod tests {
         assert_eq!(decoded.segments, vec![seg]);
     }
 
+    /// v2 keys by the content hash carried in writer_id, not the rest of the
+    /// tuple: two records sharing every other tuple field but carrying distinct
+    /// content hashes are a valid v2 object with two distinct records (the
+    /// collision the v1 tuple key could not represent for L1, where the reader
+    /// side has no distinguishing writer identity). Codec-level analogue of the
+    /// fold test's "two L1 parts of one bucket produce two distinct records".
+    #[test]
+    fn v2_distinct_content_hash_round_trips() {
+        let mut a = segment(1, 0, 1);
+        a.writer_id = vec![0xA0; 32];
+        let mut b = segment(1, 0, 1); // identical remaining tuple to `a`
+        b.writer_id = vec![0xB0; 32]; // sorts after `a`
+        let bytes =
+            encode_column_stats_v2([0x11; 16], 3, vec![vec![0x22; 32]], &[a.clone(), b.clone()])
+                .expect("two distinct-part records encode under v2");
+        let decoded = decode_column_stats(&bytes, &ColumnStatsLimits::default()).expect("decodes");
+        assert_eq!(decoded.segments, vec![a, b]);
+        assert_eq!(decoded.header.format_version, 2);
+    }
+
+    /// A v2 record whose writer_id is not the 32-byte content hash (here the
+    /// 16-byte v1 uuid width) is fail-closed rejected: a reader could not bind
+    /// it, and a v1 object mislabeled v2 must not pass.
+    #[test]
+    fn v2_record_with_v1_width_writer_id_rejected() {
+        let seg = segment(1, 0, 1); // writer_id is the 16-byte v1 uuid
+        let err = encode_column_stats_v2([0x11; 16], 3, vec![vec![0x22; 32]], &[seg])
+            .expect_err("a v2 record with a 16-byte writer_id is rejected");
+        assert_eq!(
+            err,
+            SnapshotFormatError::ColumnStatsBadFieldLen {
+                field: "writer_id",
+                expected: 32,
+                actual: 16,
+            }
+        );
+    }
+
+    /// Two v2 records with the identical content hash are a duplicate part
+    /// binding, rejected the same way a v1 duplicate tuple is.
+    #[test]
+    fn v2_duplicate_content_hash_rejected() {
+        let mut a = segment(1, 0, 1);
+        a.writer_id = vec![0xC0; 32];
+        let mut b = segment(2, 0, 9); // different remaining tuple, same hash
+        b.writer_id = vec![0xC0; 32];
+        let err = encode_column_stats_v2([0x11; 16], 3, vec![vec![0x22; 32]], &[a, b])
+            .expect_err("duplicate content hash rejected");
+        assert_eq!(err, SnapshotFormatError::ColumnStatsDuplicateSegment);
+    }
+
+    /// v2 records not sorted by their content hash are rejected (the encoder
+    /// sorts; the decoder enforces).
+    #[test]
+    fn v2_unsorted_by_content_hash_rejected() {
+        let mut a = segment(1, 0, 1);
+        a.writer_id = vec![0xF0; 32];
+        let mut b = segment(1, 0, 2);
+        b.writer_id = vec![0x10; 32]; // sorts before `a`
+        let err = encode_column_stats_v2([0x11; 16], 3, vec![vec![0x22; 32]], &[a, b])
+            .expect_err("unsorted-by-content-hash rejected");
+        assert_eq!(err, SnapshotFormatError::ColumnStatsSegmentsUnsorted);
+    }
+
     /// A version outside the accepted set is refused with the specific typed
     /// error carrying the offending version, not merely "an error occurred".
     #[test]
     fn version_outside_accepted_set_rejected() {
         for bad in [0u8, 3, 255] {
-            let seg = segment(1, 0, 1);
+            // A bad version selects the v2 (part) key model in the framing
+            // helper (version >= 2 for 3/255) or the v1 model (0), so use a
+            // 32-byte writer_id: it satisfies v2's width check for 3/255. 0 is
+            // v1 mode (needs 16), handled by its own case below.
+            let writer_id_len = if bad >= 2 { 32 } else { 16 };
+            let mut seg = segment(1, 0, 1);
+            seg.writer_id = vec![0x44; writer_id_len];
             let bytes =
                 encode_column_stats_versioned(bad, [0x11; 16], 3, vec![vec![0x22; 32]], &[seg])
                     .expect("framing encodes any version byte");
@@ -894,7 +1026,13 @@ mod tests {
     #[test]
     fn accepted_read_set_is_exactly_v1_and_v2() {
         for version in 0u8..=255 {
-            let seg = segment(1, 0, 1);
+            // The framing helper validates in the version's key model, so give
+            // writer_id the width that model requires (v1: 16, v2+: 32).
+            // Acceptance is then decided by the decode version gate, which this
+            // test pins.
+            let writer_id_len = if version >= 2 { 32 } else { 16 };
+            let mut seg = segment(1, 0, 1);
+            seg.writer_id = vec![0x44; writer_id_len];
             let bytes =
                 encode_column_stats_versioned(version, [0x11; 16], 3, vec![vec![0x22; 32]], &[seg])
                     .expect("framing encodes any version byte");
@@ -962,7 +1100,8 @@ mod tests {
     /// wrong data: every prefix of a well-formed v2 object is rejected.
     #[test]
     fn truncated_v2_envelope_is_typed_error() {
-        let seg = segment(1, 0, 1);
+        let mut seg = segment(1, 0, 1);
+        seg.writer_id = vec![0x77; 32];
         let bytes = encode_column_stats_versioned(2, [0x11; 16], 3, vec![vec![0x22; 32]], &[seg])
             .expect("v2 framing encodes");
         for len in 0..bytes.len() {
@@ -979,7 +1118,8 @@ mod tests {
     /// error rather than a decode of wrong data.
     #[test]
     fn corrupt_v2_body_is_typed_error() {
-        let seg = segment(1, 0, 1);
+        let mut seg = segment(1, 0, 1);
+        seg.writer_id = vec![0x77; 32];
         let mut bytes =
             encode_column_stats_versioned(2, [0x11; 16], 3, vec![vec![0x22; 32]], &[seg])
                 .expect("v2 framing encodes");

--- a/crates/ravel-catalog/src/snapshot_format/mod.rs
+++ b/crates/ravel-catalog/src/snapshot_format/mod.rs
@@ -10,7 +10,9 @@ mod head;
 mod part;
 mod postings;
 
-pub use column_stats::{DecodedColumnStats, decode_column_stats, encode_column_stats};
+pub use column_stats::{
+    DecodedColumnStats, decode_column_stats, encode_column_stats, encode_column_stats_v2,
+};
 pub use error::SnapshotFormatError;
 pub use head::{HEAD_FORMAT_VERSION, decode_head, encode_head};
 pub use part::{DecodedPart, decode_part, encode_part, encode_part_ranged};
@@ -91,11 +93,15 @@ impl Default for PostingsLimits {
 pub const COLUMN_STATS_MAGIC: [u8; 4] = *b"RCST";
 
 /// Column-statistics envelope WRITE version: the version the fold stamps into
-/// every `.cstat` object it writes. It stays 1 in this change; ADR-0942's A2
-/// step raises it to 2 when the writer begins emitting part-hash-keyed
-/// objects. Single source for the stamped version so that later bump edits one
-/// literal.
-pub const COLUMN_STATS_WRITE_VERSION: u8 = 1;
+/// every part-hash-keyed (v2) `.cstat` object it writes (ADR-0942 A2). Single
+/// source for the stamped v2 version so a later bump edits one literal.
+///
+/// The field-11 v1 object is NOT stamped from this constant: during the
+/// ADR-0942 dual-publish window the fold keeps writing a v1 (L0-tuple-keyed)
+/// `.cstat` under `SnapshotHead.column_stats` byte-for-byte as before, so
+/// [`column_stats::encode_column_stats`] stamps envelope version 1 explicitly.
+/// This constant governs only the new field-13 v2 object.
+pub const COLUMN_STATS_WRITE_VERSION: u8 = 2;
 
 /// Column-statistics envelope ACCEPTED READ SET: the versions
 /// `decode_column_stats` accepts. v1 is ADR-0850's L0-tuple keying; v2 is
@@ -390,7 +396,7 @@ mod tests {
         assert_eq!(POSTINGS_RESERVED, [0, 0, 0]);
         assert_eq!(DEFAULT_MAX_POSTINGS_BYTES, 256 << 20);
         assert_eq!(COLUMN_STATS_MAGIC, *b"RCST");
-        assert_eq!(COLUMN_STATS_WRITE_VERSION, 1);
+        assert_eq!(COLUMN_STATS_WRITE_VERSION, 2);
         assert_eq!(COLUMN_STATS_ACCEPTED_READ_VERSIONS, [1, 2]);
         assert_eq!(COLUMN_STATS_RESERVED, [0, 0, 0]);
         assert_eq!(DEFAULT_MAX_COLUMN_STATS_BYTES, 256 << 20);


### PR DESCRIPTION
Task A2 of ADR-0942. The fold now builds column statistics for L1 entries as
well as L0, keyed so that a reader can actually find them, and publishes them as
a v2 object under SnapshotHead field 13 while continuing to publish the field-11
v1 object unchanged.

build_column_stats_segment previously converted entry.writer_id into [u8; 16]
and returned BadWriterIdLen for anything else. An L1 entry's slot holds a
32-byte hash, so a fold over L1 failed there before a record existed. That
conversion is now version-aware.

The join key diverges from ADR-0942 as published, deliberately and with the ADR
being corrected separately. The ADR says bind to the covered part's
SnapshotPartRef.blake3. A SnapshotPartRef is a snapshot part covering an hour
range and containing many segments, so two L1 parts of one bucket share one
blake3, and binding to it would re-create the many-segments-to-one-key collision
this ADR exists to remove. The key implemented here is the data object's content
hash, SnapshotEntry.content_hash, equal to the reader's
SegmentRef.content_hash, which is the only per-segment content-addressed
identity a reader can compute from a resolved SegmentRef. That is what the ADR's
own justification argues for; only the identifier it named was wrong.

The 32-byte hash rides in the existing ColumnStatsSegment writer_id slot rather
than a new proto field, because this task's scope excluded proto/ and because
ravel-sql constructs ColumnStatsSegment literals that a new field would break.
Encoder and decoder validate and sort by writer_id per version: a 16-byte tuple
component for v1, a 32-byte content hash for v2. Documenting that overload in
proto/ is a follow-up, and A3 must join on SegmentRef.content_hash.

Field 11 is still written and is byte-identical to a fresh canonical v1 encode
over the same L0 stats and part set. This is a dual-publish window, not a swap:
retiring field 11 is a separate change citing every bucket's format floor, per
ADR-0066 decision 1, because an older reader that finds no field 11 silently
falls back to scanning every segment.

The L1 test folds two L1 parts of one (shard 0, hour 10) bucket and asserts two
distinct records with exact per-record values, which is the collision case the
old key could not express. Restoring the 16-byte conversion makes both L1 tests
fail, one with BadWriterIdLen(32) and one with zero records where two are
expected.

Nothing reads the new object yet; that is A3.

Refs: #949, #942
