### PR TITLE
ci: add llvm-tools component for cargo-llvm-cov coverage job

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "1.97.1"
-components = ["rustfmt", "clippy"]
+components = ["rustfmt", "clippy", "llvm-tools"]


### PR DESCRIPTION
The coverage lane (`cargo llvm-cov`) requires the `llvm-tools` component.
Without it the job fails with exit 101.

Fixes the failure observed in run 33336791511 / job 99325401920.