### PR TITLE
feat(ravel-sql): bounded ephemeral spill for exactness-eligible operators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5143,6 +5143,7 @@ dependencies = [
  "ravel-types",
  "serde_json",
  "stats_alloc",
+ "tempfile",
  "thiserror",
  "tokio",
  "tonic",

--- a/crates/ravel-sql/Cargo.toml
+++ b/crates/ravel-sql/Cargo.toml
@@ -193,6 +193,11 @@ crc32c = { workspace = true }
 # heuristic fails the dict-page tests loudly instead of silently. Already a
 # workspace pin (ravel-logseg depends on it); no new supply-chain surface.
 ravel-codec = { workspace = true }
+# Dev-only: the spill tests (tests/spill.rs, crate::spill's own unit tests)
+# need a real, writable directory to configure as the spill root and a
+# read-only one to prove the `spill_unavailable` refusal. Already a workspace
+# pin, and already in the lockfile as a datafusion dependency.
+tempfile = { workspace = true }
 
 [[bench]]
 name = "samples_scan"

--- a/crates/ravel-sql/src/config.rs
+++ b/crates/ravel-sql/src/config.rs
@@ -265,6 +265,12 @@ pub struct SqlConfig {
     /// disabled disk manager and today's typed refusal, whatever this is set
     /// to.
     ///
+    /// A query that IS granted spill runs its final aggregation
+    /// single-partitioned even when [`SqlConfig::parallel_final_aggregation`]
+    /// is on: the eligibility predicate classifies logical nodes, and an
+    /// enabled disk manager would also let the `RepartitionExec` that knob
+    /// introduces spill unclassified. See `crate::session`'s module doc.
+    ///
     /// This field is the source of truth. [`SqlConfig::with_spill_from_env`]
     /// fills it from [`ENV_SPILL_DIR`]/[`ENV_SPILL_MAX_BYTES`] only when it is
     /// still `None`, so an explicit setting is never overridden by the

--- a/crates/ravel-sql/src/config.rs
+++ b/crates/ravel-sql/src/config.rs
@@ -14,6 +14,7 @@
 //! footprint is cardinality-dependent once labels materialize as columns, so a
 //! sample cap cannot stand in for a byte cap.
 
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use datafusion::execution::memory_pool::MemoryPool;
@@ -100,9 +101,94 @@ const GROUP_VALUES_FIXED_OVERHEAD_BYTES: usize = 16;
 const GROUP_VALUES_FIXED_OVERHEAD_CEILING: usize =
     (GROUP_VALUES_FIXED_OVERHEAD_BYTES as f64 * GROUP_VALUES_RESIZE_TRANSIENT_FACTOR) as usize + 1;
 
+/// Environment variable naming the directory under which a query may create
+/// its ephemeral spill scratch (ADR-0954). Read only through
+/// [`SpillConfig::from_env`]; the [`SqlConfig::spill`] field is the source of
+/// truth and this only supplies its default when the caller left it unset.
+pub const ENV_SPILL_DIR: &str = "RAVEL_SQL_SPILL_DIR";
+
+/// Environment variable carrying the per-query scratch byte quota, a positive
+/// decimal integer. See [`ENV_SPILL_DIR`].
+pub const ENV_SPILL_MAX_BYTES: &str = "RAVEL_SQL_SPILL_MAX_BYTES";
+
+/// Both halves of the spill configuration. Spill is enabled for a query only
+/// when this whole struct is present AND the query's plan is exactness-eligible
+/// (`crate::executor`'s spill eligibility predicate); either half missing means
+/// [`DiskManagerMode::Disabled`](datafusion::execution::disk_manager::DiskManagerMode::Disabled)
+/// and today's behavior byte for byte.
+///
+/// A directory alone would leave the 100 GB DataFusion default ceiling in
+/// place, and a quota alone has nowhere to write, so neither is admitted on its
+/// own: the two are one value, not two independent knobs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SpillConfig {
+    /// Directory under which each query creates, and removes, its own scratch
+    /// subdirectory. It must already exist and be writable; a query that finds
+    /// otherwise fails with [`crate::SqlError::SpillUnavailable`] rather than
+    /// creating anything outside it.
+    pub dir: PathBuf,
+    /// Ceiling, in bytes, on the scratch this one query may hold on disk at
+    /// once. Enforced by DataFusion's disk manager
+    /// (`max_temp_directory_size`), which counts bytes written to spill files,
+    /// not bytes decoded from them. Exceeding it is
+    /// [`crate::SqlError::SpillBudgetExhausted`], never a partial result.
+    pub max_bytes: u64,
+}
+
+/// A [`SpillConfig`] could not be read from the environment. Loud on purpose:
+/// a half-set or unparseable spill configuration silently selects a different
+/// execution behavior than the operator asked for, and this codebase does not
+/// let a default that selects which resources a query touches stay silent.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum SpillConfigError {
+    /// One of the two variables is set and the other is not.
+    #[error(
+        "RAVEL_SQL_SPILL_DIR and RAVEL_SQL_SPILL_MAX_BYTES must both be set to enable \
+         SQL spill, or both be unset to disable it; only one of the two is set"
+    )]
+    Incomplete,
+    /// `RAVEL_SQL_SPILL_MAX_BYTES` is not a positive decimal integer.
+    #[error("RAVEL_SQL_SPILL_MAX_BYTES must be a positive decimal number of bytes, got {value:?}")]
+    BadQuota { value: String },
+    /// `RAVEL_SQL_SPILL_DIR` is set to an empty string.
+    #[error("RAVEL_SQL_SPILL_DIR must name a directory, but is set to an empty string")]
+    EmptyDir,
+}
+
+impl SpillConfig {
+    /// Read both variables. `Ok(None)` when neither is set, which is the
+    /// no-spill deployment profile and the compiled-in default.
+    ///
+    /// Set-but-invalid is an error, not a fall back to `None`: turning a typo
+    /// in a deployment's spill quota into "spill silently stays off" is exactly
+    /// the silent-default failure the measurement-discipline rules forbid.
+    pub fn from_env() -> Result<Option<SpillConfig>, SpillConfigError> {
+        let dir = std::env::var_os(ENV_SPILL_DIR);
+        let quota = std::env::var_os(ENV_SPILL_MAX_BYTES);
+        let (dir, quota) = match (dir, quota) {
+            (None, None) => return Ok(None),
+            (Some(dir), Some(quota)) => (dir, quota),
+            _ => return Err(SpillConfigError::Incomplete),
+        };
+        if dir.is_empty() {
+            return Err(SpillConfigError::EmptyDir);
+        }
+        let quota = quota.to_string_lossy().trim().to_string();
+        let max_bytes: u64 = quota
+            .parse()
+            .ok()
+            .filter(|bytes| *bytes > 0)
+            .ok_or(SpillConfigError::BadQuota { value: quota })?;
+        Ok(Some(SpillConfig {
+            dir: PathBuf::from(dir),
+            max_bytes,
+        }))
+    }
+}
+
 /// Per-query ravel-sql configuration: the shared engine budgets plus the
 /// SQL-only per-query memory-pool byte budget.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SqlConfig {
     /// Series/segment/sample/deadline budgets shared with the PromQL path.
     pub engine: EngineConfig,
@@ -164,6 +250,26 @@ pub struct SqlConfig {
     /// surviving rows instead of for every row. So this is a cost knob, never
     /// a correctness one.
     pub late_materialization_extra_columns: Option<usize>,
+    /// Bounded ephemeral spill scratch (ADR-0954). `None`, the default, means
+    /// the disk manager stays
+    /// [`Disabled`](datafusion::execution::disk_manager::DiskManagerMode::Disabled)
+    /// exactly as ADR-0102 decision 3 left it: a query over its memory budget
+    /// fails typed, nothing is written to local disk, and this crate behaves
+    /// byte for byte as it did before spill existed. That is the no-spill
+    /// deployment profile, and it is the compiled-in default so this whole
+    /// mechanism is inert until an operator opts in.
+    ///
+    /// `Some` arms spill, but does not by itself grant it to a query: the
+    /// query's plan must also pass the exactness eligibility predicate
+    /// (`crate::executor::plan_is_spill_eligible`). An ineligible plan gets the
+    /// disabled disk manager and today's typed refusal, whatever this is set
+    /// to.
+    ///
+    /// This field is the source of truth. [`SqlConfig::with_spill_from_env`]
+    /// fills it from [`ENV_SPILL_DIR`]/[`ENV_SPILL_MAX_BYTES`] only when it is
+    /// still `None`, so an explicit setting is never overridden by the
+    /// environment.
+    pub spill: Option<SpillConfig>,
 }
 
 impl Default for SqlConfig {
@@ -174,6 +280,10 @@ impl Default for SqlConfig {
             parallel_final_aggregation: true,
             skip_partial_aggregation: true,
             late_materialization_extra_columns: Some(DEFAULT_LATE_MATERIALIZATION_EXTRA_COLUMNS),
+            // Spill off. See the field doc: this is requirement 9 of #954 (a
+            // no-spill deployment profile) and it is what makes enabling spill
+            // an operator decision rather than a version upgrade.
+            spill: None,
         }
     }
 }
@@ -188,6 +298,19 @@ impl From<EngineConfig> for SqlConfig {
 }
 
 impl SqlConfig {
+    /// Fill [`SqlConfig::spill`] from the environment when it is still `None`,
+    /// so a deployment can turn spill on without a code change while an
+    /// explicit in-process setting still wins.
+    ///
+    /// Call once at process startup, next to the other startup-only knobs on
+    /// this struct; nothing here live-reloads.
+    pub fn with_spill_from_env(mut self) -> Result<Self, SpillConfigError> {
+        if self.spill.is_none() {
+            self.spill = SpillConfig::from_env()?;
+        }
+        Ok(self)
+    }
+
     /// Build the query's DataFusion memory pool: a [`TenantDelegatingPool`]
     /// capped at `max_query_bytes` that forwards every grow/shrink to
     /// `tenant`. Install it on the query's `RuntimeEnv` via
@@ -221,6 +344,7 @@ impl SqlConfig {
 }
 
 #[cfg(test)]
+#[allow(clippy::expect_used)]
 mod tests {
     use super::*;
 
@@ -253,6 +377,50 @@ mod tests {
     /// ClickBench shapes finish at all (`SELECT * ... ORDER BY ts LIMIT 10`
     /// exceeded a 900 s deadline without it) and belongs in the same change as
     /// this assertion, not discovered broken elsewhere.
+    /// ADR-0954: spill is off unless an operator configures both halves. A
+    /// change that flips this default is a change to every deployment's disk
+    /// behavior and to the ADR-0102 decision 3 refusal path, so it belongs in
+    /// the same change as this assertion.
+    #[test]
+    fn spill_defaults_to_off() {
+        assert_eq!(SqlConfig::default().spill, None);
+    }
+
+    /// Both halves are required. A directory with no quota would leave
+    /// DataFusion's 100 GB default ceiling in place, and a quota with no
+    /// directory has nowhere to write; neither is a valid enable.
+    #[test]
+    fn a_half_set_environment_is_an_error_not_a_silent_disable() {
+        assert_eq!(
+            SpillConfigError::Incomplete.to_string(),
+            "RAVEL_SQL_SPILL_DIR and RAVEL_SQL_SPILL_MAX_BYTES must both be set to enable \
+             SQL spill, or both be unset to disable it; only one of the two is set"
+        );
+        let bad = SpillConfigError::BadQuota {
+            value: "1 GiB".to_string(),
+        };
+        assert!(bad.to_string().contains("positive decimal"));
+    }
+
+    /// The explicit field wins over the environment: `with_spill_from_env`
+    /// fills only an unset field, so a process that configured spill in code
+    /// cannot have it silently redirected by a stray variable.
+    #[test]
+    fn an_explicit_spill_config_is_not_overridden_by_the_environment() {
+        let explicit = SpillConfig {
+            dir: PathBuf::from("/explicit"),
+            max_bytes: 4096,
+        };
+        let config = SqlConfig {
+            spill: Some(explicit.clone()),
+            ..SqlConfig::default()
+        };
+        let after = config
+            .with_spill_from_env()
+            .expect("an already-set field reads no environment");
+        assert_eq!(after.spill, Some(explicit));
+    }
+
     #[test]
     fn late_materialization_defaults_to_eight_extra_columns() {
         assert_eq!(

--- a/crates/ravel-sql/src/error.rs
+++ b/crates/ravel-sql/src/error.rs
@@ -90,6 +90,30 @@ pub const MSG_INTERNAL: &str = "internal query engine error";
 /// rewrites it from the pool's own occupancy at the moment of refusal.
 pub const MSG_SPILL_DISABLED_MARKER: &str = "DiskManager is disabled";
 
+/// Substring DataFusion embeds in the `ResourcesExhausted` its disk manager
+/// raises when a spill file's growth pushes the query's scratch past
+/// `max_temp_directory_size` (`RefCountedTempFile::update_disk_usage`,
+/// datafusion-execution 54.1.0). Ravel sets that ceiling from
+/// [`SpillConfig::max_bytes`](crate::SpillConfig), so this marker is how the
+/// per-query scratch quota's own trip is told apart from a memory-pool
+/// exhaustion that happens to reach the same DataFusion variant.
+///
+/// The upstream text ends by suggesting the caller raise
+/// `datafusion.runtime.max_temp_directory_size`, a knob no Ravel client can
+/// reach, so the message is replaced rather than echoed
+/// ([`SqlError::spill_budget_exhausted`]).
+pub const MSG_SPILL_QUOTA_MARKER: &str =
+    "The used disk space during the spilling process has exceeded";
+
+/// Stable client message for a spill scratch area that could not be used: the
+/// configured directory is missing, is not a directory, is unwritable, or the
+/// volume behind it is full. The server-side detail names the path, which is
+/// deployment layout a client never sees, so only this fixed string is
+/// returned (the same treatment [`MSG_UNAVAILABLE`] gets, for the same
+/// reason).
+pub const MSG_SPILL_UNAVAILABLE: &str =
+    "query scratch storage is unavailable; the query was not run to a partial result";
+
 /// The client-visible class of a [`SqlError`]. The HTTP layer maps this to
 /// a status code and an error-type tag; it never inspects the error itself.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -220,6 +244,29 @@ pub enum SqlError {
     #[error("query memory budget exhausted: {0}")]
     ResourcesExhausted(String),
 
+    /// The query's per-query scratch (spill) quota was exhausted (ADR-0954).
+    /// A sibling of [`SqlError::ResourcesExhausted`] rather than a reuse of it:
+    /// the memory budget and the scratch budget are independently enforced, and
+    /// an operator reading "this query needed more disk than it was allowed"
+    /// must not have to guess which of the two limits it was. Carries only
+    /// byte counts and the configured quota, so it echoes verbatim like the
+    /// other budget errors.
+    #[error("query scratch budget exhausted: {0}")]
+    SpillBudgetExhausted(String),
+
+    /// Spill was configured and the query was eligible for it, but the scratch
+    /// area could not be used: the directory is missing, is not a directory, is
+    /// unwritable, or the volume behind it is out of space (ADR-0954). The
+    /// detail names the configured path and is logged server-side only; the
+    /// client sees [`MSG_SPILL_UNAVAILABLE`].
+    ///
+    /// Distinct from [`SqlError::SpillBudgetExhausted`]: that is the query
+    /// asking for more scratch than its quota allows, this is the scratch not
+    /// being there at all. Both fail the query outright; neither returns a
+    /// partial result.
+    #[error("spill scratch unavailable: {0}")]
+    SpillUnavailable(String),
+
     /// DataFusion could not plan the query. The payload is the full
     /// DataFusion message, kept for the server-side log only; it can carry
     /// schema and column detail and is never returned to a client.
@@ -296,6 +343,24 @@ impl SqlError {
         }
     }
 
+    /// The typed per-query scratch-quota error, built from the query's own
+    /// figures rather than DataFusion's text (ADR-0954).
+    ///
+    /// `written` is the bytes this query had written to its spill files when
+    /// the disk manager refused the next write, read from the disk manager's
+    /// own `used_disk_space` gauge: bytes as they sit in the spill files (Arrow
+    /// IPC, after whatever spill compression the session configured), not
+    /// decoded Arrow bytes and not bytes moved over the network. `quota` is
+    /// [`SpillConfig::max_bytes`](crate::SpillConfig::max_bytes), the same
+    /// figure that ceiling was configured from.
+    pub fn spill_budget_exhausted(written: u64, quota: u64) -> Self {
+        SqlError::SpillBudgetExhausted(format!(
+            "{written} of {quota} bytes of scratch already written to this query's spill \
+             files when it asked for more (spill-file bytes on disk, not decoded bytes); \
+             no partial result was returned"
+        ))
+    }
+
     /// The client-visible class, for HTTP status selection.
     pub fn class(&self) -> ErrorClass {
         match self {
@@ -321,6 +386,12 @@ impl SqlError {
             | SqlError::TooManyBytesScanned { .. }
             | SqlError::RequestBudgetExceeded { .. }
             | SqlError::ResourcesExhausted(_)
+            // Both spill failures are budget/resource refusals of a
+            // well-formed request, the same 422 class as the memory pool's
+            // own exhaustion. Neither is a storage fault: object storage,
+            // the only durable backend, is untouched by a scratch failure.
+            | SqlError::SpillBudgetExhausted(_)
+            | SqlError::SpillUnavailable(_)
             | SqlError::Plan(_)
             | SqlError::Execution(_)
             | SqlError::Internal(_)
@@ -380,7 +451,14 @@ impl SqlError {
             | SqlError::TooManySeries { .. }
             | SqlError::TooManyBytesScanned { .. }
             | SqlError::RequestBudgetExceeded { .. }
-            | SqlError::ResourcesExhausted(_) => self.to_string(),
+            | SqlError::ResourcesExhausted(_)
+            // Counts and a configured quota only, built by
+            // `spill_budget_exhausted` from this query's own figures; no path,
+            // no object key, no tenant identity.
+            | SqlError::SpillBudgetExhausted(_) => self.to_string(),
+            // The detail names the configured scratch path, which is
+            // deployment filesystem layout. Redacted like a storage fault.
+            SqlError::SpillUnavailable(_) => MSG_SPILL_UNAVAILABLE.to_string(),
             SqlError::Plan(_) => MSG_PLAN.to_string(),
             SqlError::Execution(_) => MSG_EXECUTION.to_string(),
             SqlError::Internal(_) | SqlError::OperatorPanic(_) => MSG_INTERNAL.to_string(),

--- a/crates/ravel-sql/src/executor.rs
+++ b/crates/ravel-sql/src/executor.rs
@@ -667,9 +667,6 @@ impl SqlExecutor {
             } else {
                 None
             };
-        // Fail CLOSED, unchanged: an unbuildable plan is not exact-typed.
-        let exact_typed_aggregates = self.config.parallel_final_aggregation
-            && analyzed.as_ref().is_some_and(plan_is_exact_typed);
         // ADR-0954: spill needs BOTH an operator-configured scratch area and a
         // plan whose every aggregate is exact under a changed folding order.
         // Fail closed the same way: an unbuildable plan is not eligible, so it
@@ -685,6 +682,19 @@ impl SqlExecutor {
             }
             _ => None,
         };
+        // Fail CLOSED, unchanged: an unbuildable plan is not exact-typed.
+        //
+        // A spill-enabled query is planned repartition-free whatever this says:
+        // `session_config` forces `repartition_aggregations` off (and
+        // round-robin repartitioning with it) for a `SpillDecision::Enabled`
+        // session, because the eligibility predicate above classified LOGICAL
+        // nodes while an enabled disk manager grants spill to every operator in
+        // the PHYSICAL plan, `RepartitionExec` included. The classification is
+        // still computed here so the two decisions stay independent and the
+        // override lives in exactly one place (`crate::session::
+        // repartition_free`).
+        let exact_typed_aggregates = self.config.parallel_final_aggregation
+            && analyzed.as_ref().is_some_and(plan_is_exact_typed);
         // Build the one table the query targets over the snapshot resolved for
         // its signal. `resolve` already resolved `snapshot` against exactly
         // this signal, so the provider and the snapshot always agree.
@@ -2045,6 +2055,14 @@ fn plan_is_exact_typed(plan: &LogicalPlan) -> bool {
 /// an aggregate that is not an `AggregateFunction`, an unknown plan node -- is
 /// ineligible. Fail closed: the cost of a false negative is today's typed
 /// refusal, and the cost of a false positive is a silently wrong answer.
+///
+/// This predicate reasons about the logical plan, but the permission it leads
+/// to (an enabled disk manager) is held by every operator in the physical plan
+/// the session goes on to build. Only physical nodes that correspond to the
+/// shapes above may therefore be admitted, which is why an eligible query is
+/// also planned repartition-free (`crate::session::repartition_free`): a
+/// `RepartitionExec` appears in no logical plan, so nothing here classifies it,
+/// and it spills.
 fn plan_is_spill_eligible(plan: &LogicalPlan) -> bool {
     if !plan_nodes_are_spill_classifiable(plan) {
         return false;

--- a/crates/ravel-sql/src/executor.rs
+++ b/crates/ravel-sql/src/executor.rs
@@ -70,7 +70,7 @@ use std::collections::{HashMap, HashSet};
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use datafusion::arrow::array::RecordBatch;
 use datafusion::arrow::datatypes::SchemaRef;
@@ -80,6 +80,7 @@ use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion};
 use datafusion::dataframe::DataFrame;
 use datafusion::error::DataFusionError;
 use datafusion::execution::SendableRecordBatchStream;
+use datafusion::execution::disk_manager::DiskManager;
 use datafusion::execution::memory_pool::{MemoryLimit, MemoryPool, UnboundedMemoryPool};
 use datafusion::logical_expr::{Aggregate, Distinct, Expr, ExprSchemable, LogicalPlan};
 use datafusion::physical_plan::{ExecutionPlan, execute_stream};
@@ -101,9 +102,12 @@ use crate::memory::{CeilingBreach, TenantMemoryAccountant};
 use crate::output::QueryOutput;
 use crate::provider::RavelTableProvider;
 use crate::pushdown::extract;
-use crate::session::{LOGS_TABLE, SAMPLES_TABLE, SPANS_TABLE, SessionTable, build_session};
+use crate::session::{
+    LOGS_TABLE, SAMPLES_TABLE, SPANS_TABLE, SessionTable, SpillDecision, build_session,
+};
 use crate::spans_fetcher::SpanSegmentFetcher;
 use crate::spans_provider::SpansTableProvider;
+use crate::spill::{OperatorSpill, SpillCounts, SpillScratch, accumulate_spill_counts};
 use crate::validate::{referenced_base_tables, validate};
 
 /// Which of the three v1 tables (and thus which `Signal`) a query targets.
@@ -195,6 +199,16 @@ pub struct SqlStats {
     pub blocks_total: u64,
     pub blocks_scanned: u64,
     pub blocks_pruned_by_postings: u64,
+    /// This query's spill totals (ADR-0954), read off the executed plan's own
+    /// DataFusion counters after the stream stopped, the same way the block
+    /// counters above are. All zero on the default configuration, where the
+    /// disk manager is disabled and no query can spill at all.
+    ///
+    /// The totals live here because they are operator metrics; the
+    /// per-operator attribution that makes a spill traceable to the operator
+    /// that wrote it lives on [`SqlOutcome::spill_by_operator`], which does not
+    /// have to stay `Copy`.
+    pub spill: SpillCounts,
 }
 
 /// The `LogsScanExec` block counters, summed over a plan tree.
@@ -236,6 +250,13 @@ pub struct SqlOutcome {
     /// The pre-execution cost estimate (ADR-0044 "3."), from the same
     /// successful attempt's resolve.
     pub estimate: CostEstimate,
+    /// Which operator wrote this query's spill, and how much (ADR-0954). Empty
+    /// for a query that did not spill, which is every query on the default
+    /// configuration. The totals are on [`SqlStats::spill`]; this is the
+    /// attribution, because "the aggregate spilled 4 files" and "the exchange
+    /// spilled 4 files" are different findings that a pooled total cannot tell
+    /// apart.
+    pub spill_by_operator: Vec<OperatorSpill>,
 }
 
 /// Executes SQL for any tenant against one catalog and object store.
@@ -466,10 +487,15 @@ impl SqlExecutor {
             stats.attempts += 1;
             stats.segments = snapshot.segments.len();
 
-            let (result, emitted, blocks) = self
+            let (result, emitted, blocks, spill, spill_by_operator) = self
                 .attempt(tenant_hash, req, snapshot, &accounting, &declared)
                 .await;
             stats.batches_emitted += emitted;
+            // Recorded for the failing attempt too: a spill that happened
+            // before the failure is a fact about this query, and a retried
+            // attempt overwrites it with its own, matching how the block
+            // counters and `QueryAccounting` treat a discarded attempt.
+            stats.spill = spill;
 
             match result {
                 Ok(output) => {
@@ -481,6 +507,7 @@ impl SqlExecutor {
                         stats,
                         accounting: accounting.snapshot(),
                         estimate,
+                        spill_by_operator,
                     });
                 }
                 Err(err) => match retry_decision(err.is_segment_not_found(), emitted, attempt) {
@@ -629,15 +656,35 @@ impl SqlExecutor {
         // once. The build happens only when a consumer will read it.
         let wants_stats_gate = matches!(Self::target_signal(sql), Ok(TargetSignal::Logs))
             && !extras.declared.is_empty();
-        let analyzed = if self.config.parallel_final_aggregation || wants_stats_gate {
-            self.analyzed_classification_plan(tenant_hash, sql, &extras.declared)
-                .await
-        } else {
-            None
-        };
+        // ADR-0954: the spill eligibility predicate reads the same analyzed
+        // plan, so a configured-spill deployment is a third consumer of it
+        // rather than a second analyze pass.
+        let wants_spill_gate = self.config.spill.is_some();
+        let analyzed =
+            if self.config.parallel_final_aggregation || wants_stats_gate || wants_spill_gate {
+                self.analyzed_classification_plan(tenant_hash, sql, &extras.declared)
+                    .await
+            } else {
+                None
+            };
         // Fail CLOSED, unchanged: an unbuildable plan is not exact-typed.
         let exact_typed_aggregates = self.config.parallel_final_aggregation
             && analyzed.as_ref().is_some_and(plan_is_exact_typed);
+        // ADR-0954: spill needs BOTH an operator-configured scratch area and a
+        // plan whose every aggregate is exact under a changed folding order.
+        // Fail closed the same way: an unbuildable plan is not eligible, so it
+        // gets the disabled disk manager and today's typed refusal.
+        //
+        // The scratch directory is created here, before planning, so a missing
+        // or unwritable spill area is a typed `SpillUnavailable` raised with
+        // nothing written and no operator started, rather than an opaque IO
+        // failure from inside a spilling operator half way through a query.
+        let scratch = match &self.config.spill {
+            Some(spill) if analyzed.as_ref().is_some_and(plan_is_spill_eligible) => {
+                Some((SpillScratch::create(spill)?, spill.max_bytes))
+            }
+            _ => None,
+        };
         // Build the one table the query targets over the snapshot resolved for
         // its signal. `resolve` already resolved `snapshot` against exactly
         // this signal, so the provider and the snapshot always agree.
@@ -648,7 +695,7 @@ impl SqlExecutor {
                     snapshot,
                     tenant_hash,
                     self.fetcher.clone(),
-                    self.config,
+                    self.config.clone(),
                     accounting.clone(),
                 );
                 // Install the distributed samples scan for this query only, when
@@ -720,8 +767,15 @@ impl SqlExecutor {
             ))),
         };
 
-        let ctx =
-            build_session(&self.config, pool, table, exact_typed_aggregates).map_err(plan_error)?;
+        let decision = match &scratch {
+            Some((scratch, max_bytes)) => SpillDecision::Enabled {
+                dir: scratch.dir(),
+                max_bytes: *max_bytes,
+            },
+            None => SpillDecision::Disabled,
+        };
+        let ctx = build_session(&self.config, pool, table, exact_typed_aggregates, decision)
+            .map_err(plan_error)?;
         let frame = ctx.sql(sql).await.map_err(plan_error)?;
         let schema = frame.schema().inner().clone();
         Ok(PinnedQuery {
@@ -729,6 +783,7 @@ impl SqlExecutor {
             frame,
             schema,
             breach,
+            scratch: scratch.map(|(scratch, _)| scratch),
         })
     }
 
@@ -794,7 +849,7 @@ impl SqlExecutor {
             snapshot,
             tenant_hash,
             self.fetcher.clone(),
-            self.config,
+            self.config.clone(),
             accounting.clone(),
         ));
         let plan = provider
@@ -803,11 +858,15 @@ impl SqlExecutor {
         // ADR-0094 decision 2: the worker fragment plans no new SQL and runs no
         // aggregation of its own, so it never repartitions -- always `false`,
         // never through the classification check.
+        // The worker fragment plans no SQL and runs no aggregation, so it never
+        // spills: the disk manager stays disabled regardless of the deployment's
+        // spill configuration.
         let ctx = build_session(
             &self.config,
             pool,
             SessionTable::Metrics(Arc::clone(&provider)),
             false,
+            SpillDecision::Disabled,
         )
         .map_err(plan_error)?;
         let schema = plan.schema();
@@ -911,7 +970,16 @@ impl SqlExecutor {
         // executes, so nothing is reserved against it and it never touches the
         // tenant accountant.
         let pool: Arc<dyn MemoryPool> = Arc::new(UnboundedMemoryPool::default());
-        let ctx = build_session(&self.config, pool, table, false).ok()?;
+        // Plan-inspection only: this throwaway session never executes, so it
+        // never spills whatever the query's own session was granted.
+        let ctx = build_session(
+            &self.config,
+            pool,
+            table,
+            false,
+            crate::session::SpillDecision::Disabled,
+        )
+        .ok()?;
         let plan = ctx.state().create_logical_plan(sql).await.ok()?;
         let mut predicates = Vec::new();
         collect_filter_predicates(&plan, &mut predicates);
@@ -982,7 +1050,16 @@ impl SqlExecutor {
         let pool: Arc<dyn MemoryPool> = Arc::new(UnboundedMemoryPool::default());
         // `exact_typed_aggregates` is irrelevant to a plan we only inspect; the
         // classification decides the real session's value, not this throwaway.
-        let ctx = build_session(&self.config, pool, table, false).ok()?;
+        // Plan-inspection only: this throwaway session never executes, so it
+        // never spills whatever the query's own session was granted.
+        let ctx = build_session(
+            &self.config,
+            pool,
+            table,
+            false,
+            crate::session::SpillDecision::Disabled,
+        )
+        .ok()?;
         let state = ctx.state();
         let plan = state.create_logical_plan(sql).await.ok()?;
         let config_options = Arc::clone(state.config_options());
@@ -1088,7 +1165,7 @@ impl SqlExecutor {
                 empty_snapshot(),
                 tenant_hash,
                 self.fetcher.clone(),
-                self.config,
+                self.config.clone(),
                 QueryAccounting::new(),
             ))),
             TargetSignal::Logs => SessionTable::Logs(Arc::new(
@@ -1164,19 +1241,41 @@ impl SqlExecutor {
         snapshot: Snapshot,
         accounting: &QueryAccounting,
         declared: &[DeclaredColumn],
-    ) -> (Result<QueryOutput, SqlError>, usize, BlockCounts) {
+    ) -> (
+        Result<QueryOutput, SqlError>,
+        usize,
+        BlockCounts,
+        SpillCounts,
+        Vec<OperatorSpill>,
+    ) {
         let planned = match self
             .plan_pinned(tenant_hash, snapshot, &req.sql, accounting, declared)
             .await
         {
             Ok(planned) => planned,
-            Err(e) => return (Err(e), 0, BlockCounts::default()),
+            Err(e) => {
+                return (
+                    Err(e),
+                    0,
+                    BlockCounts::default(),
+                    SpillCounts::default(),
+                    Vec::new(),
+                );
+            }
         };
         let schema = planned.schema();
 
         let mut stream = match planned.execute().await {
             Ok(stream) => stream,
-            Err(e) => return (Err(e), 0, BlockCounts::default()),
+            Err(e) => {
+                return (
+                    Err(e),
+                    0,
+                    BlockCounts::default(),
+                    SpillCounts::default(),
+                    Vec::new(),
+                );
+            }
         };
 
         let mut batches = Vec::new();
@@ -1189,15 +1288,27 @@ impl SqlExecutor {
                 }
                 // The scan's block counters are final only after a clean drain,
                 // so a mid-stream error reports none: a partial prune ratio
-                // would misattribute.
-                Err(e) => return (Err(e), emitted, BlockCounts::default()),
+                // would misattribute. The spill counters are different: they
+                // record what was written, and what was written before a
+                // failure was still written, so they are read on both paths.
+                Err(e) => {
+                    let (spill, by_operator) = stream.spill_counts();
+                    return (Err(e), emitted, BlockCounts::default(), spill, by_operator);
+                }
             }
         }
 
         // The stream drained cleanly: the plan's LogsScanExec counters are now
         // final, so read them off the plan we kept.
         let blocks = stream.block_counts();
-        (Ok(QueryOutput::new(schema, batches)), emitted, blocks)
+        let (spill, by_operator) = stream.spill_counts();
+        (
+            Ok(QueryOutput::new(schema, batches)),
+            emitted,
+            blocks,
+            spill,
+            by_operator,
+        )
     }
 }
 
@@ -1215,6 +1326,12 @@ pub struct PinnedQuery {
     /// The best-effort memory ceiling's abort flag, tripped by the pool's
     /// `grow` and moved into the [`PinnedStream`] on execute.
     breach: Arc<CeilingBreach>,
+    /// This query's spill scratch directory (ADR-0954), present only when
+    /// spill is configured AND this plan passed the eligibility predicate.
+    /// Declared after `ctx` so it drops after the session that owns the files
+    /// inside it, and moved into the [`PinnedStream`] on execute so a query
+    /// abandoned mid-stream still removes its scratch.
+    scratch: Option<SpillScratch>,
 }
 
 impl PinnedQuery {
@@ -1244,6 +1361,7 @@ impl PinnedQuery {
             frame,
             schema,
             breach,
+            scratch,
         } = self;
         // Build the physical plan explicitly rather than through
         // `frame.execute_stream()` (which does the same two steps internally)
@@ -1252,7 +1370,7 @@ impl PinnedQuery {
         // are equivalent: `execute_stream` is `create_physical_plan` then
         // `execute_stream(plan, task_ctx)`.
         let plan = frame.create_physical_plan().await.map_err(plan_error)?;
-        PinnedStream::start(ctx, plan, schema, breach)
+        PinnedStream::start_with_scratch(ctx, plan, schema, breach, scratch)
     }
 }
 
@@ -1289,6 +1407,35 @@ pub struct PinnedStream {
     /// against. Derived from `ctx` in [`Self::start`] rather than threaded in
     /// separately, so no caller of `start` changes.
     pool: Arc<dyn MemoryPool>,
+    /// Spill bookkeeping for this query (ADR-0954), `None` whenever the
+    /// session's disk manager is disabled -- which is every query on the
+    /// default configuration, so the default path pays nothing for this.
+    spill: Option<SpillState>,
+    /// This query's scratch directory. Declared LAST so it drops after `_ctx`:
+    /// the session's `RuntimeEnv` owns the spill files inside it and must
+    /// release them first. Removing the directory here is what makes cleanup
+    /// hold on the completion, error, AND cancellation paths alike -- all
+    /// three end with this value dropping.
+    _scratch: Option<SpillScratch>,
+}
+
+/// The live spill bookkeeping [`PinnedStream`] keeps while a query with an
+/// enabled disk manager runs.
+struct SpillState {
+    /// The session's disk manager, for its `spilling_progress()` gauge: the
+    /// bytes currently written across this query's spill files, and how many
+    /// of those files are open.
+    disk_manager: Arc<DiskManager>,
+    /// The configured per-query scratch ceiling, echoed in
+    /// [`SqlError::spill_budget_exhausted`]. Read from the disk manager rather
+    /// than threaded in, so it is the ceiling actually installed.
+    quota: u64,
+    /// Set while the last poll observed at least one open spill file; `None`
+    /// otherwise. See [`SpillCounts::duration`] for exactly what the resulting
+    /// figure measures.
+    active_since: Option<Instant>,
+    /// Accumulated spill window across every open/close cycle so far.
+    elapsed: Duration,
 }
 
 impl PinnedStream {
@@ -1306,12 +1453,37 @@ impl PinnedStream {
         schema: SchemaRef,
         breach: Arc<CeilingBreach>,
     ) -> Result<Self, SqlError> {
+        PinnedStream::start_with_scratch(ctx, plan, schema, breach, None)
+    }
+
+    /// [`Self::start`] with this query's spill scratch directory attached
+    /// (ADR-0954), so the directory outlives the stream and is removed when the
+    /// stream drops. `None` is byte-identical to [`Self::start`].
+    pub fn start_with_scratch(
+        ctx: SessionContext,
+        plan: Arc<dyn ExecutionPlan>,
+        schema: SchemaRef,
+        breach: Arc<CeilingBreach>,
+        scratch: Option<SpillScratch>,
+    ) -> Result<Self, SqlError> {
         // The same pool `build_session` installed on `ctx`'s `RuntimeEnv`
         // (`crate::session`), read back here rather than passed in: every
         // `ResourcesExhausted` this stream maps needs it, and deriving it from
         // `ctx` keeps every `start` caller (the local path, the Flight SQL
         // worker fragment, and the panic-boundary test) unchanged.
         let pool = Arc::clone(&ctx.runtime_env().memory_pool);
+        // Same derivation for the disk manager: whether this query can spill
+        // at all is a property of the session `build_session` built, not
+        // something a caller of this constructor should be able to disagree
+        // with. `tmp_files_enabled()` is false for every `SpillDecision::
+        // Disabled` session, which is every session on the default config.
+        let disk_manager = Arc::clone(&ctx.runtime_env().disk_manager);
+        let spill = disk_manager.tmp_files_enabled().then(|| SpillState {
+            quota: disk_manager.max_temp_directory_size(),
+            disk_manager,
+            active_since: None,
+            elapsed: Duration::ZERO,
+        });
         let inner = execute_stream(Arc::clone(&plan), ctx.task_ctx()).map_err(plan_error)?;
         Ok(PinnedStream {
             _ctx: ctx,
@@ -1321,6 +1493,8 @@ impl PinnedStream {
             plan,
             panicked: false,
             pool,
+            spill,
+            _scratch: scratch,
         })
     }
 
@@ -1337,6 +1511,134 @@ impl PinnedStream {
         let mut counts = BlockCounts::default();
         accumulate_block_counts(&self.plan, &mut counts);
         counts
+    }
+
+    /// This query's spill totals and their per-operator attribution
+    /// (ADR-0954), read off the plan's own DataFusion counters the same way
+    /// [`Self::block_counts`] reads the scan's.
+    ///
+    /// Meaningful once the stream has stopped producing, whether it drained or
+    /// failed: a spill that happened before a failure is still a fact about the
+    /// query. All zero, with no operators listed, for a query that did not
+    /// spill.
+    fn spill_counts(&self) -> (SpillCounts, Vec<OperatorSpill>) {
+        let mut totals = SpillCounts::default();
+        let mut by_operator = Vec::new();
+        accumulate_spill_counts(&self.plan, &mut totals, &mut by_operator);
+        totals.duration = self
+            .spill
+            .as_ref()
+            .map_or(Duration::ZERO, SpillState::window);
+        (totals, by_operator)
+    }
+
+    /// Sample the disk manager's open-spill-file gauge and fold the interval
+    /// since the previous sample into the spill window. Called on every poll
+    /// of a spill-enabled query and never on any other, so the default path
+    /// runs none of it.
+    fn sample_spill_window(&mut self) {
+        let Some(spill) = self.spill.as_mut() else {
+            return;
+        };
+        let active = spill.disk_manager.spilling_progress().active_files_count > 0;
+        match (active, spill.active_since) {
+            (true, None) => spill.active_since = Some(Instant::now()),
+            (false, Some(since)) => {
+                spill.elapsed = spill.elapsed.saturating_add(since.elapsed());
+                spill.active_since = None;
+            }
+            _ => {}
+        }
+    }
+
+    /// Map an execution error, classifying the two spill-specific failures
+    /// first (ADR-0954). Kept here rather than inside [`execution_error`]
+    /// because only the stream holds the disk manager the figures come from.
+    ///
+    /// Runs only for a query whose disk manager is enabled, so a query on the
+    /// default configuration reaches `execution_error` by exactly the path it
+    /// did before spill existed.
+    fn map_execution_error(&self, err: DataFusionError) -> SqlError {
+        if let Some(spill) = self.spill.as_ref()
+            && let Some(failure) = spill_failure_kind(&err)
+        {
+            return match failure {
+                // DataFusion raises the scratch-quota trip as a plain
+                // `ResourcesExhausted`, the same variant a memory-pool refusal
+                // uses, with text telling the caller to raise a DataFusion
+                // option no Ravel client can reach. The memory and scratch
+                // budgets are independently enforced, so they stay
+                // independently reportable: re-typed here, with the figures
+                // restated from the disk manager's own gauge.
+                SpillFailure::Quota => SqlError::spill_budget_exhausted(
+                    spill.disk_manager.used_disk_space(),
+                    spill.quota,
+                ),
+                // A filesystem error reaching this stream while spill is
+                // enabled is a scratch failure: every read of durable data
+                // goes through this crate's own fetchers, which surface as
+                // `SqlError::Fetch`/`LogFetch`/`SpanFetch`, never as a bare
+                // DataFusion IO error. The commonest cause is the scratch
+                // volume filling mid-write.
+                SpillFailure::Io(detail) => SqlError::SpillUnavailable(format!(
+                    "spill file write failed while the query held \
+                     {} of {} scratch bytes: {detail}",
+                    spill.disk_manager.used_disk_space(),
+                    spill.quota
+                )),
+            };
+        }
+        execution_error(err, &self.pool)
+    }
+}
+
+/// The two spill-specific failures, told apart from every other execution
+/// error.
+enum SpillFailure {
+    /// The per-query scratch quota was exceeded.
+    Quota,
+    /// The scratch area could not be written; the payload is the IO detail,
+    /// logged server-side only.
+    Io(String),
+}
+
+/// Find a spill failure at any wrapper depth, mirroring
+/// [`take_sql_error`]'s unwrapping but by reference: the error is still needed
+/// intact if this returns `None`.
+fn spill_failure_kind(err: &DataFusionError) -> Option<SpillFailure> {
+    match err {
+        DataFusionError::ResourcesExhausted(msg)
+            if msg.contains(crate::error::MSG_SPILL_QUOTA_MARKER) =>
+        {
+            Some(SpillFailure::Quota)
+        }
+        DataFusionError::IoError(io) => Some(SpillFailure::Io(io.to_string())),
+        DataFusionError::Context(_, inner) | DataFusionError::Diagnostic(_, inner) => {
+            spill_failure_kind(inner)
+        }
+        DataFusionError::Shared(inner) => spill_failure_kind(inner),
+        DataFusionError::External(boxed) => boxed
+            .downcast_ref::<DataFusionError>()
+            .and_then(spill_failure_kind),
+        DataFusionError::ArrowError(arrow, _) => match arrow.as_ref() {
+            ArrowError::ExternalError(boxed) => boxed
+                .downcast_ref::<DataFusionError>()
+                .and_then(spill_failure_kind),
+            _ => None,
+        },
+        DataFusionError::Collection(errors) => errors.iter().find_map(spill_failure_kind),
+        _ => None,
+    }
+}
+
+impl SpillState {
+    /// The spill window so far, including an interval still open at the moment
+    /// of the call.
+    fn window(&self) -> Duration {
+        match self.active_since {
+            Some(since) => self.elapsed.saturating_add(since.elapsed()),
+            None => self.elapsed,
+        }
     }
 }
 
@@ -1383,8 +1685,19 @@ impl Stream for PinnedStream {
         }));
         match polled {
             Ok(next) => {
-                let pool = Arc::clone(&self.pool);
-                next.map(|next| next.map(|batch| batch.map_err(|e| execution_error(e, &pool))))
+                // ADR-0954's spill window, sampled once per poll and only for
+                // a query whose disk manager is enabled. See
+                // `SpillCounts::duration` for what the resulting figure is and
+                // is not.
+                self.sample_spill_window();
+                match next {
+                    Poll::Ready(Some(Err(err))) => {
+                        Poll::Ready(Some(Err(self.map_execution_error(err))))
+                    }
+                    Poll::Ready(Some(Ok(batch))) => Poll::Ready(Some(Ok(batch))),
+                    Poll::Ready(None) => Poll::Ready(None),
+                    Poll::Pending => Poll::Pending,
+                }
             }
             Err(payload) => {
                 self.panicked = true;
@@ -1698,6 +2011,200 @@ fn plan_is_exact_typed(plan: &LogicalPlan) -> bool {
     let mut distincts = Vec::new();
     collect_aggregate_exprs(plan, &mut aggregates, &mut distincts);
     aggregates.iter().all(aggregate_node_is_exact) && distincts.iter().all(distinct_node_is_exact)
+}
+
+/// Whether `plan` (analyzed/type-coerced) may spill (ADR-0954).
+///
+/// This is a predicate over the plan's shape and its aggregate expressions'
+/// resolved types, deliberately NOT an operator-name allowlist: what is at
+/// stake is exactness, and "this operator can spill" says nothing about
+/// whether spilling changes its answer. Spilling a grouped aggregation makes
+/// DataFusion emit partial group state, sort it, write it, and re-merge it, so
+/// the aggregate's folding order changes. An aggregate whose merge is exact
+/// under any order is unaffected; one whose merge is order-dependent is not,
+/// and this repo's exactness invariant is the thing the spill would trade
+/// away.
+///
+/// A plan is eligible when ALL of the following hold:
+///
+/// - it contains at least one [`LogicalPlan::Aggregate`]. With no aggregate
+///   there is nothing whose exactness this predicate has reasoned about, so
+///   enabling spill could only benefit an operator it never classified.
+/// - every node is one of the shapes below. This is an allowlist, so a
+///   DataFusion release that adds a `LogicalPlan` variant makes plans using it
+///   ineligible rather than silently spillable. `Sort` is deliberately outside
+///   it: an external merge sort returns the same rows, but this ADR has no
+///   proof its tie order equals the in-memory sort's, and row order is part of
+///   an `ORDER BY` result. `Join` and `Window` are outside it for the same
+///   reason, one level up: nothing here has classified their spill behavior.
+/// - every aggregate expression is exactness-preserving under spill
+///   ([`aggregate_expr_is_spill_exact`]) and no GROUP BY or DISTINCT key is a
+///   float ([`aggregate_node_is_spill_exact`], [`distinct_node_is_exact`]).
+///
+/// Anything this predicate cannot classify -- an unresolvable expression type,
+/// an aggregate that is not an `AggregateFunction`, an unknown plan node -- is
+/// ineligible. Fail closed: the cost of a false negative is today's typed
+/// refusal, and the cost of a false positive is a silently wrong answer.
+fn plan_is_spill_eligible(plan: &LogicalPlan) -> bool {
+    if !plan_nodes_are_spill_classifiable(plan) {
+        return false;
+    }
+    let mut aggregates = Vec::new();
+    let mut distincts = Vec::new();
+    collect_aggregate_exprs(plan, &mut aggregates, &mut distincts);
+    !aggregates.is_empty()
+        && aggregates.iter().all(aggregate_node_is_spill_exact)
+        && distincts.iter().all(distinct_node_is_exact)
+}
+
+/// Whether every node in `plan` is a shape [`plan_is_spill_eligible`] has
+/// classified. Walks inputs and embedded subquery plans with the same reach
+/// [`collect_aggregate_exprs`] uses, so a `Sort` hidden inside a scalar
+/// subquery disqualifies the query exactly as a top-level one does.
+fn plan_nodes_are_spill_classifiable(plan: &LogicalPlan) -> bool {
+    let classifiable = matches!(
+        plan,
+        LogicalPlan::Projection(_)
+            | LogicalPlan::Filter(_)
+            | LogicalPlan::Aggregate(_)
+            | LogicalPlan::Distinct(_)
+            | LogicalPlan::TableScan(_)
+            | LogicalPlan::SubqueryAlias(_)
+            | LogicalPlan::Limit(_)
+            | LogicalPlan::EmptyRelation(_)
+            | LogicalPlan::Values(_)
+    );
+    if !classifiable {
+        return false;
+    }
+    if !plan
+        .inputs()
+        .iter()
+        .all(|input| plan_nodes_are_spill_classifiable(input))
+    {
+        return false;
+    }
+    for expr in plan.expressions() {
+        let mut ok = true;
+        // Never errors: the closure only inspects and returns a recursion verb.
+        let _ = expr.apply(|node| {
+            let nested = match node {
+                Expr::ScalarSubquery(subquery) => Some(&subquery.subquery),
+                Expr::InSubquery(in_subquery) => Some(&in_subquery.subquery.subquery),
+                Expr::Exists(exists) => Some(&exists.subquery.subquery),
+                _ => None,
+            };
+            if let Some(nested) = nested
+                && !plan_nodes_are_spill_classifiable(nested)
+            {
+                ok = false;
+                return Ok(TreeNodeRecursion::Stop);
+            }
+            Ok(TreeNodeRecursion::Continue)
+        });
+        if !ok {
+            return false;
+        }
+    }
+    true
+}
+
+/// Classify one [`Aggregate`] node for spill (ADR-0954): every GROUP BY key
+/// non-float, every aggregate expression exact under a changed folding order.
+///
+/// A float GROUP BY key disqualifies for the same reason it disqualifies
+/// ADR-0094's repartition classification: `-0.0` and NaN payloads are
+/// significant here, and nothing proves the sort DataFusion applies to the
+/// spilled group state picks a merge-order-stable representative bit pattern.
+fn aggregate_node_is_spill_exact(aggregate: &Aggregate) -> bool {
+    let schema = aggregate.input.schema().as_ref();
+    for key in &aggregate.group_expr {
+        match key.get_type(schema) {
+            Ok(ty) if crate::minmax::is_float(&ty) => return false,
+            Ok(_) => {}
+            // Fail closed: a key whose type will not resolve is not admitted.
+            Err(_) => return false,
+        }
+    }
+    aggregate
+        .aggr_expr
+        .iter()
+        .all(|expr| aggregate_expr_is_spill_exact(expr, schema))
+}
+
+/// Whether one aggregate expression keeps its exact answer when the spill path
+/// changes the order its partial states are folded in (ADR-0954):
+///
+/// - `count(...)` / `count(DISTINCT ...)`: eligible. Its accumulator is an
+///   integer and its merge is integer addition (a distinct count merges sets),
+///   neither of which depends on order, whatever the counted expression's type
+///   is.
+/// - `sum` over a resolved integer input: eligible. Integer addition is
+///   associative, so partial sums merged in any order give the same total.
+/// - `avg`/`mean` over a resolved `Int64` input: eligible. That is
+///   `crate::avg`'s exact integer path, an `i128` numerator with checked
+///   addition and an integer count (ADR-0825 decision 2); the analyzer coerces
+///   every admitted integer width to `Int64`, so a resolved `Int64` argument is
+///   the whole of that path.
+///
+/// Everything else is ineligible, including `sum` over a float (order-dependent
+/// IEEE addition), `avg` over a float (the same fold), `min`/`max` of any type,
+/// `sum` over a Decimal, and any expression that is not an aggregate function
+/// call. `min`/`max` are excluded because ADR-0954's core cut enumerates three
+/// eligible families and this predicate implements exactly those; admitting
+/// more is a widening that needs its own evidence, and the cost of leaving them
+/// out is today's typed refusal, not a wrong answer.
+fn aggregate_expr_is_spill_exact(expr: &Expr, schema: &DFSchema) -> bool {
+    // `aggr_expr` entries are either an `AggregateFunction` or an `Alias`
+    // wrapping one; unwrap a single alias layer.
+    let inner = match expr {
+        Expr::Alias(alias) => alias.expr.as_ref(),
+        other => other,
+    };
+    let Expr::AggregateFunction(aggregate_function) = inner else {
+        // Not an aggregate function where one is required: fail closed.
+        return false;
+    };
+    let arg_type =
+        |wanted: fn(&datafusion::arrow::datatypes::DataType) -> bool| match aggregate_function
+            .params
+            .args
+            .first()
+        {
+            Some(arg) => match arg.get_type(schema) {
+                Ok(ty) => wanted(&ty),
+                Err(_) => false,
+            },
+            None => false,
+        };
+    match aggregate_function.func.name().to_ascii_lowercase().as_str() {
+        "count" => true,
+        "sum" => arg_type(is_exact_integer),
+        "avg" | "mean" => {
+            arg_type(|ty| matches!(ty, datafusion::arrow::datatypes::DataType::Int64))
+        }
+        _ => false,
+    }
+}
+
+/// The integer types whose addition is exact and associative, so a partial sum
+/// merged in any order is the same total. Deliberately narrower than "not a
+/// float": `Decimal128`/`Decimal256` addition is exact too but can overflow
+/// into a different error depending on where the split falls, and neither is
+/// reachable on the v1 surface, so both fail closed here.
+fn is_exact_integer(ty: &datafusion::arrow::datatypes::DataType) -> bool {
+    use datafusion::arrow::datatypes::DataType;
+    matches!(
+        ty,
+        DataType::Int8
+            | DataType::Int16
+            | DataType::Int32
+            | DataType::Int64
+            | DataType::UInt8
+            | DataType::UInt16
+            | DataType::UInt32
+            | DataType::UInt64
+    )
 }
 
 /// Whether `plan` (analyzed) has any [`LogicalPlan::Aggregate`] node (issue

--- a/crates/ravel-sql/src/lib.rs
+++ b/crates/ravel-sql/src/lib.rs
@@ -86,6 +86,7 @@ mod spans_provider;
 mod spans_pushdown;
 mod spans_scan;
 mod spans_schema;
+pub mod spill;
 mod udf;
 mod validate;
 
@@ -101,9 +102,10 @@ pub use audit_schema::{
     AUDIT_COL_ATTRS, AUDIT_COL_BODY, AUDIT_COL_SEVERITY_TEXT, AUDIT_COL_TS, audit_schema,
 };
 pub use config::{
-    DEFAULT_LATE_MATERIALIZATION_EXTRA_COLUMNS, DEFAULT_MAX_QUERY_BYTES,
-    GROUP_VALUES_CEILING_COMPENSATION, GROUP_VALUES_RESIZE_TRANSIENT_FACTOR,
-    GROUP_VALUES_UNDERCOUNT_FACTOR, SqlConfig, compensated_group_values_ceiling,
+    DEFAULT_LATE_MATERIALIZATION_EXTRA_COLUMNS, DEFAULT_MAX_QUERY_BYTES, ENV_SPILL_DIR,
+    ENV_SPILL_MAX_BYTES, GROUP_VALUES_CEILING_COMPENSATION, GROUP_VALUES_RESIZE_TRANSIENT_FACTOR,
+    GROUP_VALUES_UNDERCOUNT_FACTOR, SpillConfig, SpillConfigError, SqlConfig,
+    compensated_group_values_ceiling,
 };
 pub use declared::{DeclaredColumn, DeclaredColumnSource, DeclaredType, StaticDeclaredColumns};
 #[cfg(feature = "flight-sql")]
@@ -120,7 +122,7 @@ pub use distributed_rlog::{
 };
 pub use error::{
     ErrorClass, MSG_CORRUPT, MSG_EXECUTION, MSG_INTERNAL, MSG_PLAN, MSG_SPILL_DISABLED_MARKER,
-    MSG_UNAVAILABLE, MSG_UNSATISFIABLE, SqlError,
+    MSG_SPILL_QUOTA_MARKER, MSG_SPILL_UNAVAILABLE, MSG_UNAVAILABLE, MSG_UNSATISFIABLE, SqlError,
 };
 pub use executor::{PinnedQuery, PinnedStream, SqlExecutor, SqlOutcome, SqlRequest, SqlStats};
 #[cfg(feature = "flight-sql")]
@@ -156,7 +158,7 @@ pub use session::{
     ADMITTED_SCALARS, ADMITTED_TABLE_FUNCTIONS, ADMITTED_WINDOWS, EXCLUDED_SCALARS,
     EXCLUDED_TABLE_FUNCTIONS, EXCLUDED_WINDOWS, EmptyObjectStoreRegistry, LOGS_TABLE,
     SAMPLES_TABLE, SKIP_PARTIAL_AGGREGATION_PROBE_RATIO, SKIP_PARTIAL_AGGREGATION_PROBE_ROWS,
-    SPANS_TABLE, SessionTable, build_session, session_config,
+    SPANS_TABLE, SessionTable, SpillDecision, build_session, session_config,
 };
 pub use spans_fetcher::{SpanFetchError, SpanFetchOutput, SpanRow, SpanSegmentFetcher};
 pub use spans_provider::SpansTableProvider;
@@ -167,6 +169,7 @@ pub use spans_schema::{
     SPAN_COL_SERVICE_NAME, SPAN_COL_SPAN_ID, SPAN_COL_START_TS, SPAN_COL_STATUS_CODE,
     SPAN_COL_STATUS_MESSAGE, SPAN_COL_TRACE_ID, spans_schema,
 };
+pub use spill::{OperatorSpill, SpillCounts, SpillScratch};
 pub use udf::{label_match_udf, label_udf};
 pub use validate::{ValidationError, validate};
 

--- a/crates/ravel-sql/src/logs_provider.rs
+++ b/crates/ravel-sql/src/logs_provider.rs
@@ -509,7 +509,13 @@ mod tests {
         let config = SqlConfig::default();
         let tenant = TenantMemoryAccountant::new(1 << 30);
         let (pool, _breach) = config.query_pool(tenant, QueryAccounting::new());
-        build_session(&config, pool, SessionTable::Logs(Arc::new(provider)), false)
+        build_session(
+            &config,
+            pool,
+            SessionTable::Logs(Arc::new(provider)),
+            false,
+            crate::session::SpillDecision::Disabled,
+        )
     }
 
     /// Every test here selects exactly `SELECT ts, body FROM logs WHERE ...`,

--- a/crates/ravel-sql/src/session.rs
+++ b/crates/ravel-sql/src/session.rs
@@ -90,6 +90,12 @@
 //! cannot change a result -- the final stage sees the same rows and computes
 //! the same groups either way -- so it is orthogonal to the determinism rules
 //! above.
+//!
+//! Spill (ADR-0954): the disk manager is configured explicitly in both
+//! directions, never left to DataFusion's default. [`build_session`] takes a
+//! per-query [`SpillDecision`]; `Disabled` is ADR-0102 decision 3 unchanged,
+//! and `Enabled` names one directory and one byte ceiling. See
+//! [`disk_manager_builder`].
 
 use std::sync::Arc;
 
@@ -436,6 +442,57 @@ impl ObjectStoreRegistry for EmptyObjectStoreRegistry {
     }
 }
 
+/// Whether THIS query may spill, and where (ADR-0954). Decided per query by
+/// the caller ([`crate::SqlExecutor`]), never inferred here: spill needs both
+/// an operator-configured [`SpillConfig`](crate::SpillConfig) and a plan whose
+/// every aggregate is exactness-preserving under spill, and only the caller
+/// has the plan.
+#[derive(Debug, Clone, Copy)]
+pub enum SpillDecision<'a> {
+    /// No spill. Identical to the pre-ADR-0954 behavior in every respect: an
+    /// operator that wants to spill gets DataFusion's own
+    /// `"... (DiskManager is disabled)"` `ResourcesExhausted`, which
+    /// [`SqlError::resources_exhausted_reattributed`](crate::SqlError::resources_exhausted_reattributed)
+    /// then re-attributes to the pool that actually filled. This is what an
+    /// unconfigured deployment gets, and what an ineligible plan gets on a
+    /// configured one.
+    Disabled,
+    /// Spill into `dir`, capped at `max_bytes` for this query.
+    Enabled {
+        /// This query's own scratch directory (a
+        /// [`SpillScratch`](crate::spill::SpillScratch) subdirectory, not the
+        /// operator-configured root). DataFusion creates its own temporary
+        /// directory inside it and removes that on `RuntimeEnv` drop.
+        dir: &'a std::path::Path,
+        /// The per-query scratch ceiling, in spill-file bytes on disk.
+        max_bytes: u64,
+    },
+}
+
+/// The disk manager for one query.
+///
+/// [`SpillDecision::Disabled`] is `DiskManagerMode::Disabled`, unchanged from
+/// ADR-0102 decision 3 and for its reasons: budget exhaustion is a typed error,
+/// never a partial result, and no durability may depend on local disk. Leaving
+/// the disk manager unconfigured instead would restore DataFusion's
+/// `OsTmpDirectory` default with a 100 GB ceiling, which routes around the
+/// pool's `try_grow` enforcement entirely; that default is never reachable from
+/// this crate, in either arm.
+///
+/// [`SpillDecision::Enabled`] names exactly one directory and one ceiling.
+/// Both are explicit: a directory with DataFusion's default ceiling would be
+/// the same unbounded behavior in a different place.
+fn disk_manager_builder(spill: SpillDecision<'_>) -> DiskManagerBuilder {
+    match spill {
+        SpillDecision::Disabled => {
+            DiskManagerBuilder::default().with_mode(DiskManagerMode::Disabled)
+        }
+        SpillDecision::Enabled { dir, max_bytes } => DiskManagerBuilder::default()
+            .with_mode(DiskManagerMode::Directories(vec![dir.to_path_buf()]))
+            .with_max_temp_directory_size(max_bytes),
+    }
+}
+
 /// Build the per-query `SessionConfig`. Separated from [`build_session`] so
 /// the invariants above can be asserted without constructing a provider.
 ///
@@ -494,20 +551,12 @@ pub fn build_session(
     pool: Arc<dyn MemoryPool>,
     table: SessionTable,
     exact_typed_aggregates: bool,
+    spill: SpillDecision<'_>,
 ) -> DFResult<SessionContext> {
     let runtime = RuntimeEnvBuilder::new()
         .with_memory_pool(pool)
         .with_object_store_registry(Arc::new(EmptyObjectStoreRegistry))
-        // ADR-0102 decision 3: disable spill so a query over the memory budget
-        // fails as a typed `ResourcesExhausted` error instead of silently
-        // spilling to local disk (which ADR-0013 forbids: budget exhaustion is
-        // an error, never a partial result, and no durability may depend on
-        // local disk). Without this the disk manager defaults to
-        // `OsTmpDirectory` with a 100 GB ceiling and routes around the pool's
-        // `try_grow` enforcement.
-        .with_disk_manager_builder(
-            DiskManagerBuilder::default().with_mode(DiskManagerMode::Disabled),
-        )
+        .with_disk_manager_builder(disk_manager_builder(spill))
         .build_arc()?;
 
     // `SessionContext::new_with_config_rt` with one extra physical optimizer
@@ -735,6 +784,7 @@ mod tests {
             test_pool(),
             SessionTable::Spans(Arc::new(provider)),
             false,
+            SpillDecision::Disabled,
         )
         .expect("spans session builds");
 
@@ -1052,8 +1102,14 @@ mod tests {
             ("logs", logs_table(&store), set(["has_word"].iter())),
             ("spans", spans_table(&store), empty.clone()),
         ] {
-            let ctx = build_session(&SqlConfig::default(), test_pool(), table, false)
-                .expect("session builds");
+            let ctx = build_session(
+                &SqlConfig::default(),
+                test_pool(),
+                table,
+                false,
+                SpillDecision::Disabled,
+            )
+            .expect("session builds");
             let state = ctx.state();
             let reg_scalars = keys(state.scalar_functions().keys().cloned());
             let reg_windows = keys(state.window_functions().keys().cloned());
@@ -1130,6 +1186,7 @@ mod tests {
             test_pool(),
             logs_table(&store),
             false,
+            SpillDecision::Disabled,
         )
         .expect("logs session builds");
         assert!(
@@ -1142,6 +1199,7 @@ mod tests {
             test_pool(),
             metrics_table(&store),
             false,
+            SpillDecision::Disabled,
         )
         .expect("metrics session builds");
         let metrics_state = metrics.state();

--- a/crates/ravel-sql/src/session.rs
+++ b/crates/ravel-sql/src/session.rs
@@ -96,6 +96,15 @@
 //! per-query [`SpillDecision`]; `Disabled` is ADR-0102 decision 3 unchanged,
 //! and `Enabled` names one directory and one byte ceiling. See
 //! [`disk_manager_builder`].
+//!
+//! A `SpillDecision::Enabled` query is also repartition-free: [`session_config`]
+//! forces `repartition_aggregations` off for it, whatever the ADR-0094
+//! classification said, and disables DataFusion's round-robin repartitioning
+//! too. The reason is a scope mismatch, not a determinism one: the spill
+//! eligibility predicate classifies LOGICAL plan nodes, while an enabled disk
+//! manager is a permission held by every operator in the session's PHYSICAL
+//! plan, and `RepartitionExec` -- which appears in no logical plan -- spills in
+//! DataFusion 54. See [`repartition_free`].
 
 use std::sync::Arc;
 
@@ -496,18 +505,29 @@ fn disk_manager_builder(spill: SpillDecision<'_>) -> DiskManagerBuilder {
 /// Build the per-query `SessionConfig`. Separated from [`build_session`] so
 /// the invariants above can be asserted without constructing a provider.
 ///
-/// `exact_typed_aggregates` (ADR-0094 decision 2) is the one per-query input:
+/// `exact_typed_aggregates` (ADR-0094 decision 2) is one per-query input:
 /// `true` only when the caller's classification proved the query's aggregates
 /// and GROUP BY keys are order/partition-independent, allowing DataFusion to
 /// fan the final aggregation across partitions. `false` for every other query,
 /// which reproduces the old single-partition plan exactly.
-pub fn session_config(config: &SqlConfig, exact_typed_aggregates: bool) -> SessionConfig {
+///
+/// `spill` is the other, and it OVERRIDES the first: a
+/// [`SpillDecision::Enabled`] query gets no `RepartitionExec` at all, so
+/// `repartition_aggregations` is forced off and DataFusion's round-robin
+/// repartitioning is disabled with it. See [`repartition_free`] for why.
+pub fn session_config(
+    config: &SqlConfig,
+    exact_typed_aggregates: bool,
+    spill: SpillDecision<'_>,
+) -> SessionConfig {
+    let repartition_free = repartition_free(spill);
     let mut session = SessionConfig::new()
         .with_information_schema(false)
         .with_target_partitions(config.engine.fetch_concurrency.max(1))
         // ADR-0094: the only knob that is ever true, and only for a query whose
         // aggregates and group keys are all exact-typed. See the module docs.
-        .with_repartition_aggregations(exact_typed_aggregates)
+        // ADR-0954 takes it back for a spill-enabled query.
+        .with_repartition_aggregations(exact_typed_aggregates && !repartition_free)
         .with_repartition_joins(false)
         .with_repartition_sorts(false)
         .with_repartition_windows(false)
@@ -527,7 +547,51 @@ pub fn session_config(config: &SqlConfig, exact_typed_aggregates: bool) -> Sessi
             .skip_partial_aggregation_probe_ratio_threshold = SKIP_PARTIAL_AGGREGATION_PROBE_RATIO;
     }
 
+    if repartition_free {
+        // The `repartition_*` knobs above do not cover DataFusion's round-robin
+        // fan-out, which `EnforceDistribution` inserts on its own whenever an
+        // operator's input has fewer partitions than `target_partitions`. It
+        // has no fluent setter either, so it is written as a typed field for
+        // the same reason.
+        session
+            .options_mut()
+            .optimizer
+            .enable_round_robin_repartition = false;
+    }
+
     session
+}
+
+/// Whether this query's plan must contain no `RepartitionExec` (ADR-0954).
+///
+/// True for exactly a [`SpillDecision::Enabled`] query, and it is the second
+/// half of the spill mechanism's fail-closed argument. The eligibility
+/// predicate that produced the decision (`executor::plan_is_spill_eligible`)
+/// classifies LOGICAL plan nodes, and it fails closed on anything it cannot
+/// classify. The permission the decision grants is not logical and not per
+/// node: an enabled disk manager lets EVERY operator in the session's physical
+/// plan spill.
+///
+/// `RepartitionExec` is the gap between those two scopes. It exists in no
+/// logical plan, so the predicate never sees it, and it spills in DataFusion 54:
+/// each output channel that the memory pool refuses falls back to a `SpillPool`
+/// channel (`datafusion::physical_plan::repartition`, whose disabled-disk-manager
+/// error is the `SpillPool (DiskManager is disabled)` message
+/// [`MSG_SPILL_DISABLED_MARKER`](crate::MSG_SPILL_DISABLED_MARKER) matches).
+/// Nothing in this crate has classified an exchange spill's exactness, so the
+/// conservative order is to remove the node rather than grant it the
+/// permission: both knobs that can introduce one are turned off for a
+/// spill-enabled query.
+///
+/// The cost is parallelism, on queries that today are refused outright, and it
+/// is bounded: `RsegScanExec` still scans its objects in parallel, and the
+/// grouped aggregate that spill exists for still spills. What is given up is
+/// the fan-out ABOVE the merged, deduplicated stream.
+fn repartition_free(spill: SpillDecision<'_>) -> bool {
+    match spill {
+        SpillDecision::Enabled { .. } => true,
+        SpillDecision::Disabled => false,
+    }
 }
 
 /// Build a fresh, single-tenant `SessionContext` around `table` with `pool`
@@ -569,7 +633,7 @@ pub fn build_session(
     // puts it: the rewrite must see the final partial/final aggregation split
     // that `EnforceDistribution` chose.
     let mut builder = SessionStateBuilder::new()
-        .with_config(session_config(config, exact_typed_aggregates))
+        .with_config(session_config(config, exact_typed_aggregates, spill))
         .with_runtime_env(runtime)
         .with_default_features()
         .with_physical_optimizer_rule(Arc::new(DictionaryGroupKeysAsViews))
@@ -820,7 +884,7 @@ mod tests {
 
     #[test]
     fn information_schema_is_disabled_and_repartitioning_is_off() {
-        let config = session_config(&SqlConfig::default(), false);
+        let config = session_config(&SqlConfig::default(), false, SpillDecision::Disabled);
         let options = config.options();
         assert!(
             !options.catalog.information_schema,
@@ -838,7 +902,7 @@ mod tests {
     /// unconditionally off, and `information_schema` stays disabled.
     #[test]
     fn exact_typed_aggregates_flips_only_repartition_aggregations() {
-        let config = session_config(&SqlConfig::default(), true);
+        let config = session_config(&SqlConfig::default(), true, SpillDecision::Disabled);
         let options = config.options();
         assert!(!options.catalog.information_schema);
         assert!(
@@ -849,6 +913,57 @@ mod tests {
         assert!(!options.optimizer.repartition_sorts);
         assert!(!options.optimizer.repartition_windows);
         assert!(!options.optimizer.repartition_file_scans);
+    }
+
+    /// ADR-0954: a spill-enabled session is repartition-free. The spill
+    /// decision overrides the ADR-0094 classification (`exact_typed_aggregates
+    /// = true` here, the case that would otherwise turn the hash exchange on),
+    /// and it also turns off the round-robin fan-out `EnforceDistribution`
+    /// inserts on its own -- no `repartition_*` knob covers that one, and it is
+    /// how a `RepartitionExec` reached a spill-enabled plan even with every
+    /// repartition knob off.
+    ///
+    /// Both are here because an enabled disk manager is a session-wide
+    /// permission and `RepartitionExec` spills: it is the node the logical
+    /// eligibility predicate cannot classify. See [`repartition_free`].
+    #[test]
+    fn a_spill_enabled_session_is_repartition_free() {
+        let dir = std::path::PathBuf::from("/tmp/does-not-need-to-exist");
+        let spill = SpillDecision::Enabled {
+            dir: dir.as_path(),
+            max_bytes: 1 << 20,
+        };
+        let config = session_config(&SqlConfig::default(), true, spill);
+        let options = config.options();
+        assert!(
+            !options.optimizer.repartition_aggregations,
+            "a spill-enabled query must not repartition its final aggregation, \
+             whatever the exact-typed classification said (ADR-0954)"
+        );
+        assert!(
+            !options.optimizer.enable_round_robin_repartition,
+            "a spill-enabled query must not get the round-robin fan-out either: \
+             no repartition_* knob covers it and RepartitionExec spills"
+        );
+        assert!(!options.optimizer.repartition_joins);
+        assert!(!options.optimizer.repartition_sorts);
+        assert!(!options.optimizer.repartition_windows);
+        assert!(!options.optimizer.repartition_file_scans);
+
+        // The override is the spill decision's, not a new unconditional
+        // default: the same config with spill off keeps both.
+        let without_spill = session_config(&SqlConfig::default(), true, SpillDecision::Disabled);
+        assert!(
+            without_spill.options().optimizer.repartition_aggregations,
+            "spill off must leave the ADR-0094 knob exactly as it was"
+        );
+        assert!(
+            without_spill
+                .options()
+                .optimizer
+                .enable_round_robin_repartition,
+            "spill off must leave DataFusion's round-robin default alone"
+        );
     }
 
     /// Issue #680: a default session tightens both skip-partial-aggregation
@@ -862,7 +977,7 @@ mod tests {
     /// promises.
     #[test]
     fn skip_partial_aggregation_sets_both_probe_thresholds() {
-        let on = session_config(&SqlConfig::default(), false);
+        let on = session_config(&SqlConfig::default(), false, SpillDecision::Disabled);
         assert_eq!(
             on.options()
                 .execution
@@ -898,6 +1013,7 @@ mod tests {
                 ..SqlConfig::default()
             },
             false,
+            SpillDecision::Disabled,
         );
         assert_eq!(
             off.options()

--- a/crates/ravel-sql/src/spans_scan.rs
+++ b/crates/ravel-sql/src/spans_scan.rs
@@ -1404,6 +1404,7 @@ mod tests {
             pool,
             SessionTable::Spans(Arc::new(provider)),
             false,
+            crate::session::SpillDecision::Disabled,
         )
         .expect("spans session builds");
 

--- a/crates/ravel-sql/src/spill.rs
+++ b/crates/ravel-sql/src/spill.rs
@@ -1,0 +1,300 @@
+//! Bounded ephemeral spill scratch: the per-query directory, its lifetime, and
+//! its accounting (ADR-0954).
+//!
+//! Spill here is per-query ephemeral execution state. It is never committed, is
+//! never read back by any process other than the one that wrote it, and is
+//! never a recovery source: object storage stays the only durable backend
+//! (ADR-0013). Everything in this module is therefore scoped to one query and
+//! removed when that query's session drops, whether it completed, failed, or
+//! was cancelled.
+//!
+//! # Directory layout
+//!
+//! [`SpillScratch::create`] makes `<configured dir>/ravel-spill-<pid>-<n>` and
+//! hands only that subdirectory to DataFusion's disk manager, which in turn
+//! creates its own `datafusion-*` temporary directory inside it. Two nested
+//! guards then both have to fail for anything to survive the query: DataFusion's
+//! `TempDir` drops with the `RuntimeEnv`, and [`SpillScratch`]'s own `Drop`
+//! removes the subdirectory whole. The configured directory itself is never
+//! created, moved, or removed by this crate; a query that finds it missing or
+//! unwritable fails with [`SqlError::SpillUnavailable`] rather than creating
+//! one, so a typo in the configuration cannot silently scatter scratch across
+//! a node's filesystem.
+//!
+//! Cleaning up scratch left by a process that died mid-query is explicitly NOT
+//! done here (no startup sweep, no node-wide or per-tenant scratch quota):
+//! those need an owner outside a single query's lifetime and are follow-up
+//! work.
+//!
+//! # What the figures count
+//!
+//! [`SpillCounts`] names each figure's unit because two of them are bytes of
+//! different kinds and must never be summed or compared:
+//!
+//! - `bytes_written` is bytes as they sit in the spill files: Arrow IPC, after
+//!   whatever spill compression the session configured. Not decoded Arrow
+//!   bytes, not wire bytes, not bytes charged to the memory pool.
+//! - `bytes_read` would be bytes streamed back from those files. DataFusion
+//!   54's `SpillMetrics` carries `spill_count`/`spilled_bytes`/`spilled_rows`
+//!   and no read-side counter, and its `SpillManager::read_spill_as_stream`
+//!   records nothing, so this crate cannot source it: it is `None`, meaning
+//!   "not measured", never `0`, which would claim nothing was read.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use datafusion::physical_plan::ExecutionPlan;
+
+use crate::config::SpillConfig;
+use crate::error::SqlError;
+
+/// Distinguishes the scratch directories of queries running concurrently in one
+/// process. Paired with the process id so two processes sharing a configured
+/// directory cannot collide either.
+static SCRATCH_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+/// One query's scratch subdirectory, removed when this value drops.
+///
+/// Held by the query's [`PinnedQuery`](crate::PinnedQuery) and moved into its
+/// [`PinnedStream`](crate::PinnedStream), declared last there so it drops after
+/// the `SessionContext` that owns the files inside it.
+#[derive(Debug)]
+pub struct SpillScratch {
+    dir: PathBuf,
+}
+
+impl SpillScratch {
+    /// Create this query's scratch subdirectory under `config.dir`.
+    ///
+    /// The configured directory must already exist and be a writable
+    /// directory. All three checks are one `create_dir` on the subdirectory
+    /// plus a `metadata` on the parent: a missing parent, a parent that is a
+    /// regular file, a read-only parent, and a full volume each surface as
+    /// [`SqlError::SpillUnavailable`] here, before any operator has run, rather
+    /// than as an opaque IO error from deep inside a spilling operator.
+    pub(crate) fn create(config: &SpillConfig) -> Result<SpillScratch, SqlError> {
+        let root = config.dir.as_path();
+        let metadata = std::fs::metadata(root).map_err(|err| {
+            SqlError::SpillUnavailable(format!(
+                "configured spill directory {} cannot be read: {err}",
+                root.display()
+            ))
+        })?;
+        if !metadata.is_dir() {
+            return Err(SqlError::SpillUnavailable(format!(
+                "configured spill directory {} is not a directory",
+                root.display()
+            )));
+        }
+        let sequence = SCRATCH_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        let dir = root.join(format!("ravel-spill-{}-{sequence}", std::process::id()));
+        std::fs::create_dir(&dir).map_err(|err| {
+            SqlError::SpillUnavailable(format!(
+                "spill scratch directory {} could not be created: {err}",
+                dir.display()
+            ))
+        })?;
+        Ok(SpillScratch { dir })
+    }
+
+    /// The directory handed to DataFusion's disk manager.
+    pub(crate) fn dir(&self) -> &Path {
+        &self.dir
+    }
+}
+
+impl Drop for SpillScratch {
+    fn drop(&mut self) {
+        // Best effort by necessity: `Drop` cannot fail, and a scratch
+        // directory that survives a crashed process is a follow-up's problem
+        // (see the module doc). Nothing downstream reads it, so a failure to
+        // remove costs disk, never correctness.
+        let _ = std::fs::remove_dir_all(&self.dir);
+    }
+}
+
+/// One query's spill totals, read off the executed plan's own DataFusion
+/// counters after the stream drains, the way
+/// [`SqlStats`](crate::SqlStats)'s block counters already are.
+///
+/// Every figure is zero (and `bytes_read` is `None`) for a query that did not
+/// spill, which is every query on the default configuration.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SpillCounts {
+    /// Spill files this query created, summed over every operator that spilled
+    /// (DataFusion's `spill_count`).
+    pub files: u64,
+    /// Bytes written into those files: spill-file bytes on disk (Arrow IPC,
+    /// after the session's spill compression). NOT decoded Arrow bytes and NOT
+    /// wire bytes; see the module doc.
+    pub bytes_written: u64,
+    /// Rows written into those files (DataFusion's `spilled_rows`). For a
+    /// grouped aggregation these are partial-aggregate state rows, not input
+    /// rows.
+    pub rows_written: u64,
+    /// Bytes streamed back from spill files, or `None` when unmeasured.
+    /// Always `None` on DataFusion 54, which exposes no read-side spill
+    /// counter (module doc). `None` rather than `0` so a reader cannot mistake
+    /// "not measured" for "nothing was read".
+    pub bytes_read: Option<u64>,
+    /// Wall-clock time this query held at least one spill file open, sampled at
+    /// each poll of the query's output stream
+    /// ([`PinnedStream`](crate::PinnedStream)). A sampled window, not the
+    /// operators' in-spill CPU time: it includes whatever else ran between two
+    /// polls that both observed an open spill file, and it is exactly
+    /// [`Duration::ZERO`] for a query that never spilled.
+    pub duration: Duration,
+}
+
+impl SpillCounts {
+    /// Whether this query spilled at all.
+    pub fn spilled(&self) -> bool {
+        self.files > 0 || self.bytes_written > 0 || self.rows_written > 0
+    }
+}
+
+/// One spilling operator's share of [`SpillCounts`], which is what makes a
+/// spill attributable: "the aggregate spilled 4 files" and "the exchange
+/// spilled 4 files" are different findings, and a pooled total cannot tell
+/// them apart.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OperatorSpill {
+    /// The operator's `ExecutionPlan::name()`, e.g. `AggregateExec`.
+    pub operator: String,
+    /// Spill files this operator created.
+    pub files: u64,
+    /// Spill-file bytes on disk this operator wrote (see
+    /// [`SpillCounts::bytes_written`]).
+    pub bytes_written: u64,
+    /// Rows this operator wrote to spill files.
+    pub rows_written: u64,
+}
+
+/// Sum the spill counters over `plan` and its descendants, and record each
+/// operator that contributed a nonzero one.
+///
+/// Reads the counters DataFusion's spilling operators already maintain rather
+/// than counting anything a second time, and reaches every operator by walking
+/// `children()`, so a spill under a coalesce or a repartition is attributed to
+/// the operator that wrote it however the optimizer nested it.
+pub(crate) fn accumulate_spill_counts(
+    plan: &Arc<dyn ExecutionPlan>,
+    totals: &mut SpillCounts,
+    by_operator: &mut Vec<OperatorSpill>,
+) {
+    if let Some(metrics) = plan.metrics() {
+        // Spill figures are typed `MetricValue::SpillCount`/`SpilledBytes`/
+        // `SpilledRows` variants, not named `Count`s. DataFusion 54.1.0's
+        // `MetricsSet::sum_by_name` matches only named metrics and returns
+        // `false` for every spill variant, so reading them by name always
+        // yields zero even for a query that spilled; the typed accessors are
+        // the only way to read them.
+        let files = metrics.spill_count().unwrap_or(0) as u64;
+        let bytes_written = metrics.spilled_bytes().unwrap_or(0) as u64;
+        let rows_written = metrics.spilled_rows().unwrap_or(0) as u64;
+        if files > 0 || bytes_written > 0 || rows_written > 0 {
+            totals.files += files;
+            totals.bytes_written += bytes_written;
+            totals.rows_written += rows_written;
+            by_operator.push(OperatorSpill {
+                operator: plan.name().to_string(),
+                files,
+                bytes_written,
+                rows_written,
+            });
+        }
+    }
+    for child in plan.children() {
+        accumulate_spill_counts(child, totals, by_operator);
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    /// The guard removes its own subdirectory and nothing else: the configured
+    /// directory, and anything else already in it, survive.
+    #[test]
+    fn the_scratch_guard_removes_only_its_own_subdirectory() {
+        let root = tempfile::tempdir().expect("temp root");
+        let sibling = root.path().join("not-ours");
+        std::fs::create_dir(&sibling).expect("sibling dir");
+
+        let config = SpillConfig {
+            dir: root.path().to_path_buf(),
+            max_bytes: 1 << 20,
+        };
+        let scratch = SpillScratch::create(&config).expect("scratch created");
+        let dir = scratch.dir().to_path_buf();
+        std::fs::write(dir.join("spill-0"), b"payload").expect("write into scratch");
+        assert!(dir.is_dir());
+
+        drop(scratch);
+        assert!(!dir.exists(), "the scratch subdirectory must be removed");
+        assert!(sibling.is_dir(), "an unrelated sibling must survive");
+        assert!(root.path().is_dir(), "the configured root must survive");
+    }
+
+    /// Two concurrent queries under one configured directory get distinct
+    /// scratch directories, so one query's cleanup cannot delete another's
+    /// in-flight spill files.
+    #[test]
+    fn concurrent_queries_get_distinct_scratch_directories() {
+        let root = tempfile::tempdir().expect("temp root");
+        let config = SpillConfig {
+            dir: root.path().to_path_buf(),
+            max_bytes: 1 << 20,
+        };
+        let first = SpillScratch::create(&config).expect("first scratch");
+        let second = SpillScratch::create(&config).expect("second scratch");
+        assert_ne!(first.dir(), second.dir());
+        assert!(first.dir().is_dir() && second.dir().is_dir());
+    }
+
+    /// A missing configured directory is refused, not created. The check runs
+    /// before any operator, so the query fails with nothing written anywhere.
+    #[test]
+    fn a_missing_configured_directory_is_refused_and_not_created() {
+        let root = tempfile::tempdir().expect("temp root");
+        let missing = root.path().join("absent");
+        let config = SpillConfig {
+            dir: missing.clone(),
+            max_bytes: 1 << 20,
+        };
+        let err = SpillScratch::create(&config).expect_err("a missing directory must be refused");
+        assert!(matches!(err, SqlError::SpillUnavailable(_)));
+        assert!(
+            !missing.exists(),
+            "the configured directory must never be created by this crate"
+        );
+    }
+
+    /// A configured path that is a regular file, not a directory, is refused.
+    #[test]
+    fn a_configured_path_that_is_a_file_is_refused() {
+        let root = tempfile::tempdir().expect("temp root");
+        let file = root.path().join("a-file");
+        std::fs::write(&file, b"not a directory").expect("write file");
+        let config = SpillConfig {
+            dir: file,
+            max_bytes: 1 << 20,
+        };
+        let err = SpillScratch::create(&config).expect_err("a file must be refused");
+        assert!(matches!(err, SqlError::SpillUnavailable(_)));
+    }
+
+    #[test]
+    fn zeroed_counts_report_no_spill_and_no_measured_read() {
+        let counts = SpillCounts::default();
+        assert!(!counts.spilled());
+        assert_eq!(counts.duration, Duration::ZERO);
+        assert_eq!(
+            counts.bytes_read, None,
+            "unmeasured must stay distinguishable from zero"
+        );
+    }
+}

--- a/crates/ravel-sql/src/spill.rs
+++ b/crates/ravel-sql/src/spill.rs
@@ -10,7 +10,8 @@
 //!
 //! # Directory layout
 //!
-//! [`SpillScratch::create`] makes `<configured dir>/ravel-spill-<pid>-<n>` and
+//! [`SpillScratch::create`] makes
+//! `<configured dir>/ravel-spill-<pid>-<nonce>-<n>` and
 //! hands only that subdirectory to DataFusion's disk manager, which in turn
 //! creates its own `datafusion-*` temporary directory inside it. Two nested
 //! guards then both have to fail for anything to survive the query: DataFusion's
@@ -40,9 +41,11 @@
 //!   records nothing, so this crate cannot source it: it is `None`, meaning
 //!   "not measured", never `0`, which would claim nothing was read.
 
+use std::hash::{BuildHasher, RandomState};
+use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use datafusion::physical_plan::ExecutionPlan;
@@ -54,6 +57,49 @@ use crate::error::SqlError;
 /// process. Paired with the process id so two processes sharing a configured
 /// directory cannot collide either.
 static SCRATCH_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+/// Per-process random component of a scratch directory name.
+///
+/// The process id and the sequence counter are both reconstructible: a process
+/// that crashes leaves its scratch behind by design (module doc), and after the
+/// OS reuses its process id the next process starts its own sequence at 0 and
+/// would rebuild the identical name. `create_dir` then fails `AlreadyExists`
+/// and a perfectly usable spill root refuses the first eligible query. This
+/// makes the name unpredictable instead, so a stale directory cannot be named
+/// by a later process at all.
+///
+/// Not a liveness probe on purpose: ADR-0954 rejects process liveness as proof
+/// of scratch ownership (a reused pid is live and owns nothing of the dead
+/// process's), so the fix is a name that does not collide, never a decision
+/// about whether the stale directory is abandoned.
+///
+/// `RandomState`'s keys are seeded from the OS once per process, which is
+/// exactly the property needed here and needs no dependency and no clock (this
+/// crate's library logic takes no `SystemTime::now`).
+static SCRATCH_NONCE: OnceLock<u64> = OnceLock::new();
+
+/// Attempts [`SpillScratch::create`] makes before it gives up on a colliding
+/// name. Each attempt draws a fresh sequence number, so reaching this bound
+/// means every one of them collided: not a name clash any more, but a scratch
+/// root that cannot be written, which is a [`SqlError::SpillUnavailable`].
+const SCRATCH_NAME_ATTEMPTS: u32 = 8;
+
+/// This process's scratch nonce, computed once.
+fn scratch_nonce() -> u64 {
+    *SCRATCH_NONCE.get_or_init(|| RandomState::new().hash_one(std::process::id()))
+}
+
+/// The name of the next scratch subdirectory: process id, this process's
+/// nonce, and a fresh in-process sequence number, so two queries in one process
+/// never collide and no other process can reconstruct the name.
+fn next_scratch_name() -> String {
+    let sequence = SCRATCH_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    format!(
+        "ravel-spill-{}-{:016x}-{sequence}",
+        std::process::id(),
+        scratch_nonce()
+    )
+}
 
 /// One query's scratch subdirectory, removed when this value drops.
 ///
@@ -74,6 +120,12 @@ impl SpillScratch {
     /// regular file, a read-only parent, and a full volume each surface as
     /// [`SqlError::SpillUnavailable`] here, before any operator has run, rather
     /// than as an opaque IO error from deep inside a spilling operator.
+    ///
+    /// A name that is already taken is the one IO failure that is not a
+    /// refusal: it is retried with a fresh name (see [`next_scratch_name`] and
+    /// [`SpillScratch::create_named`]), because scratch left behind by a
+    /// crashed process must not make a usable spill root refuse the next
+    /// query.
     pub(crate) fn create(config: &SpillConfig) -> Result<SpillScratch, SqlError> {
         let root = config.dir.as_path();
         let metadata = std::fs::metadata(root).map_err(|err| {
@@ -88,15 +140,51 @@ impl SpillScratch {
                 root.display()
             )));
         }
-        let sequence = SCRATCH_SEQUENCE.fetch_add(1, Ordering::Relaxed);
-        let dir = root.join(format!("ravel-spill-{}-{sequence}", std::process::id()));
-        std::fs::create_dir(&dir).map_err(|err| {
-            SqlError::SpillUnavailable(format!(
-                "spill scratch directory {} could not be created: {err}",
-                dir.display()
-            ))
-        })?;
-        Ok(SpillScratch { dir })
+        Self::create_named(root, next_scratch_name)
+    }
+
+    /// Create the first of up to [`SCRATCH_NAME_ATTEMPTS`] names `name` yields
+    /// that is not already taken under `root`.
+    ///
+    /// Only `AlreadyExists` is retried. Every other error -- a read-only
+    /// parent, a parent removed between the check and here, a full volume --
+    /// surfaces as [`SqlError::SpillUnavailable`] on the spot, with no further
+    /// attempt: those say the scratch root is unusable, and retrying a
+    /// different name under it would only repeat the same failure.
+    ///
+    /// Takes the name generator as an argument so a test can hand it a
+    /// deliberately colliding name; production passes
+    /// [`next_scratch_name`].
+    fn create_named(
+        root: &Path,
+        mut name: impl FnMut() -> String,
+    ) -> Result<SpillScratch, SqlError> {
+        let mut collided = Vec::new();
+        for _ in 0..SCRATCH_NAME_ATTEMPTS {
+            let dir = root.join(name());
+            match std::fs::create_dir(&dir) {
+                Ok(()) => return Ok(SpillScratch { dir }),
+                Err(err) if err.kind() == ErrorKind::AlreadyExists => {
+                    collided.push(dir);
+                }
+                Err(err) => {
+                    return Err(SqlError::SpillUnavailable(format!(
+                        "spill scratch directory {} could not be created: {err}",
+                        dir.display()
+                    )));
+                }
+            }
+        }
+        Err(SqlError::SpillUnavailable(format!(
+            "no spill scratch directory could be created under {}: \
+             all {SCRATCH_NAME_ATTEMPTS} candidate names already exist ({})",
+            root.display(),
+            collided
+                .iter()
+                .map(|dir| dir.display().to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        )))
     }
 
     /// The directory handed to DataFusion's disk manager.
@@ -270,6 +358,108 @@ mod tests {
         assert!(
             !missing.exists(),
             "the configured directory must never be created by this crate"
+        );
+    }
+
+    /// A stale scratch directory whose name collides with the one this query
+    /// would pick does not fail the query: the next name is tried, and the
+    /// stale directory is left exactly where it is (nothing here decides
+    /// whether it is abandoned, which is what ADR-0954 rejects).
+    #[test]
+    fn a_colliding_stale_directory_is_retried_not_refused() {
+        let root = tempfile::tempdir().expect("temp root");
+        let stale = root.path().join("ravel-spill-stale");
+        std::fs::create_dir(&stale).expect("stale dir");
+        std::fs::write(stale.join("left-behind"), b"from a crashed process")
+            .expect("stale contents");
+
+        let mut names = ["ravel-spill-stale", "ravel-spill-fresh"].into_iter();
+        let scratch = SpillScratch::create_named(root.path(), || {
+            names.next().expect("two names offered").to_string()
+        })
+        .expect("a taken name must be retried, not refused");
+
+        assert_eq!(
+            scratch.dir(),
+            root.path().join("ravel-spill-fresh"),
+            "create must move on to the next candidate name"
+        );
+        assert!(
+            stale.join("left-behind").is_file(),
+            "the stale directory and its contents must be left untouched"
+        );
+    }
+
+    /// Exhausting every candidate name is a `SpillUnavailable`, not a retry
+    /// loop: at that point the root is unusable, which the query must be told.
+    #[test]
+    fn every_candidate_name_taken_is_spill_unavailable() {
+        let root = tempfile::tempdir().expect("temp root");
+        std::fs::create_dir(root.path().join("ravel-spill-taken")).expect("taken dir");
+
+        let mut attempts = 0u32;
+        let err = SpillScratch::create_named(root.path(), || {
+            attempts += 1;
+            "ravel-spill-taken".to_string()
+        })
+        .expect_err("every name taken must be refused");
+
+        assert!(matches!(err, SqlError::SpillUnavailable(_)), "got {err:?}");
+        assert_eq!(
+            attempts, SCRATCH_NAME_ATTEMPTS,
+            "create must try exactly {SCRATCH_NAME_ATTEMPTS} names before refusing"
+        );
+    }
+
+    /// A name a dead process left behind cannot be reconstructed by a later
+    /// process, whatever process id the OS hands it: the nonce is per-process
+    /// and the pid-and-sequence part of the name is not sufficient to build it.
+    ///
+    /// This is the property that keeps the retry above from being the only
+    /// defense. The pre-fix name was `ravel-spill-<pid>-<sequence>` with the
+    /// sequence starting at 0 in every process, so the name below is exactly
+    /// what a crashed process with this pid would have left, and exactly what
+    /// the first eligible query of the reusing process would have asked for.
+    #[test]
+    fn a_scratch_name_cannot_be_reconstructed_from_the_process_id_alone() {
+        let root = tempfile::tempdir().expect("temp root");
+        let reused_pid_name = format!("ravel-spill-{}-0", std::process::id());
+        std::fs::create_dir(root.path().join(&reused_pid_name)).expect("stale dir");
+
+        let config = SpillConfig {
+            dir: root.path().to_path_buf(),
+            max_bytes: 1 << 20,
+        };
+        let scratch = SpillScratch::create(&config).expect("scratch created");
+        let name = scratch
+            .dir()
+            .file_name()
+            .and_then(|name| name.to_str())
+            .expect("a utf-8 scratch name")
+            .to_string();
+
+        assert_ne!(
+            name, reused_pid_name,
+            "the name must carry more than the process id and the sequence"
+        );
+        let nonce = name
+            .strip_prefix(&format!("ravel-spill-{}-", std::process::id()))
+            .and_then(|rest| rest.split('-').next())
+            .expect("the name is ravel-spill-<pid>-<nonce>-<sequence>")
+            .to_string();
+        assert_eq!(
+            nonce.len(),
+            16,
+            "the nonce is 16 hex digits of per-process randomness; got {nonce:?}"
+        );
+        assert!(
+            nonce.chars().all(|c| c.is_ascii_hexdigit()),
+            "the nonce is hex; got {nonce:?}"
+        );
+        assert_eq!(
+            nonce,
+            format!("{:016x}", scratch_nonce()),
+            "one nonce per process, stable across queries"
         );
     }
 

--- a/crates/ravel-sql/tests/ceiling_breach.rs
+++ b/crates/ravel-sql/tests/ceiling_breach.rs
@@ -66,6 +66,8 @@ async fn a_join_that_overruns_the_query_ceiling_aborts_and_frees_the_tenant_budg
         // ADR-0774's rewrite is a `SqlConfig` field now; keep this
         // fixture's plan shape as it was by not installing the rule.
         late_materialization_extra_columns: None,
+        // ADR-0954: spill off, as on the shipped default.
+        spill: None,
     };
     let fixture = Fixture::build(
         Arc::new(MemoryStore::new()),

--- a/crates/ravel-sql/tests/flight_distributed.rs
+++ b/crates/ravel-sql/tests/flight_distributed.rs
@@ -346,7 +346,7 @@ impl WorkerSliceClient for InProcessWorker {
             snapshot,
             TENANT,
             self.fetcher.clone(),
-            self.config,
+            self.config.clone(),
             QueryAccounting::new(),
         );
         let plan = provider.worker_fragment(segments.len().max(1), &segments)?;

--- a/crates/ravel-sql/tests/logs_count_from_stats.rs
+++ b/crates/ravel-sql/tests/logs_count_from_stats.rs
@@ -28,7 +28,7 @@ use ravel_object_store::memory::MemoryStore;
 use ravel_object_store::{ObjectStoreBackend, PutOptions};
 use ravel_query::{LogSegmentFetcher, SegmentFetcher};
 use ravel_sql::{
-    LogsTableProvider, SessionTable, SpanSegmentFetcher, SqlConfig, SqlExecutor,
+    LogsTableProvider, SessionTable, SpanSegmentFetcher, SpillDecision, SqlConfig, SqlExecutor,
     TenantMemoryAccountant, build_session,
 };
 use ravel_types::TenantHash;
@@ -174,7 +174,13 @@ fn logs_session(provider: LogsTableProvider) -> datafusion::error::Result<Sessio
     let config = SqlConfig::default();
     let tenant = TenantMemoryAccountant::new(1 << 30);
     let (pool, _breach) = config.query_pool(tenant, QueryAccounting::new());
-    build_session(&config, pool, SessionTable::Logs(Arc::new(provider)), false)
+    build_session(
+        &config,
+        pool,
+        SessionTable::Logs(Arc::new(provider)),
+        false,
+        SpillDecision::Disabled,
+    )
 }
 
 fn provider_over(store: Arc<CountingStore>, snapshot: Snapshot) -> LogsTableProvider {

--- a/crates/ravel-sql/tests/logs_metadata_agg.rs
+++ b/crates/ravel-sql/tests/logs_metadata_agg.rs
@@ -45,7 +45,7 @@ use ravel_object_store::{ObjectStoreBackend, PutOptions};
 use ravel_proto::catalog::v1::{ColumnStat, ColumnStatsSegment, ColumnValue, DictEntry};
 use ravel_query::LogSegmentFetcher;
 use ravel_sql::{
-    DeclaredColumn, DeclaredType, LogsTableProvider, SessionTable, SqlConfig,
+    DeclaredColumn, DeclaredType, LogsTableProvider, SessionTable, SpillDecision, SqlConfig,
     TenantMemoryAccountant, build_session,
 };
 use ravel_types::TenantHash;
@@ -262,6 +262,7 @@ fn logs_session_with(
         pool,
         SessionTable::Logs(Arc::new(provider)),
         exact_typed_aggregates,
+        SpillDecision::Disabled,
     )
 }
 

--- a/crates/ravel-sql/tests/logs_provider.rs
+++ b/crates/ravel-sql/tests/logs_provider.rs
@@ -598,6 +598,7 @@ fn logs_session(
         pool,
         ravel_sql::SessionTable::Logs(Arc::new(provider)),
         false,
+        ravel_sql::SpillDecision::Disabled,
     )
 }
 

--- a/crates/ravel-sql/tests/logs_topk_late_materialization.rs
+++ b/crates/ravel-sql/tests/logs_topk_late_materialization.rs
@@ -74,8 +74,8 @@ use ravel_object_store::{
 };
 use ravel_query::{CacheFetchError, LogSegmentFetcher};
 use ravel_sql::{
-    CeilingBreach, DeclaredColumn, DeclaredType, LogsTableProvider, SessionTable, SqlConfig,
-    TenantDelegatingPool, TenantMemoryAccountant, build_session,
+    CeilingBreach, DeclaredColumn, DeclaredType, LogsTableProvider, SessionTable, SpillDecision,
+    SqlConfig, TenantDelegatingPool, TenantMemoryAccountant, build_session,
 };
 use ravel_types::TenantHash;
 use ravel_types::accounting::{AccountedOp, QueryAccounting};
@@ -353,8 +353,14 @@ fn session(provider: LogsTableProvider, config: &SqlConfig) -> SessionContext {
         CeilingBreach::new(),
         QueryAccounting::new(),
     ));
-    build_session(config, pool, SessionTable::Logs(Arc::new(provider)), false)
-        .expect("session builds")
+    build_session(
+        config,
+        pool,
+        SessionTable::Logs(Arc::new(provider)),
+        false,
+        SpillDecision::Disabled,
+    )
+    .expect("session builds")
 }
 
 fn metric(plan: &Arc<dyn ExecutionPlan>, node: &str, name: &str) -> usize {

--- a/crates/ravel-sql/tests/memory_accounting.rs
+++ b/crates/ravel-sql/tests/memory_accounting.rs
@@ -34,8 +34,8 @@ use ravel_object_store::memory::MemoryStore;
 use ravel_object_store::{ObjectStoreBackend, PutOptions};
 use ravel_query::{LogSegmentFetcher, SegmentFetcher};
 use ravel_sql::{
-    LogsTableProvider, RavelTableProvider, SessionTable, SqlConfig, TenantMemoryAccountant,
-    build_session,
+    LogsTableProvider, RavelTableProvider, SessionTable, SpillDecision, SqlConfig,
+    TenantMemoryAccountant, build_session,
 };
 use ravel_types::TenantId;
 use ravel_types::accounting::QueryAccounting;
@@ -80,6 +80,7 @@ async fn drain(
         Arc::clone(&pool),
         SessionTable::Metrics(provider),
         false,
+        SpillDecision::Disabled,
     )
     .expect("session");
 
@@ -270,6 +271,8 @@ async fn a_query_that_outgrows_its_pool_still_releases_tenant_bytes() {
         // ADR-0774's rewrite is a `SqlConfig` field now; keep this
         // fixture's plan shape as it was by not installing the rule.
         late_materialization_extra_columns: None,
+        // ADR-0954: spill off, as on the shipped default.
+        spill: None,
     };
     let accountant = TenantMemoryAccountant::new(1 << 30);
     let (pool, _breach) = config.query_pool(Arc::clone(&accountant), QueryAccounting::new());
@@ -279,7 +282,7 @@ async fn a_query_that_outgrows_its_pool_still_releases_tenant_bytes() {
         snapshot,
         tenant.hash(),
         SegmentFetcher::new(Arc::clone(&fixture.store)),
-        config,
+        config.clone(),
         QueryAccounting::new(),
     ));
     let ctx = build_session(
@@ -287,6 +290,7 @@ async fn a_query_that_outgrows_its_pool_still_releases_tenant_bytes() {
         Arc::clone(&pool),
         SessionTable::Metrics(provider),
         false,
+        SpillDecision::Disabled,
     )
     .expect("session");
     let mut stream = ctx
@@ -487,6 +491,7 @@ async fn drain_logs(
         Arc::clone(&pool),
         SessionTable::Logs(provider),
         false,
+        SpillDecision::Disabled,
     )
     .expect("session");
 

--- a/crates/ravel-sql/tests/memory_ceiling_and_budget_errors.rs
+++ b/crates/ravel-sql/tests/memory_ceiling_and_budget_errors.rs
@@ -16,8 +16,8 @@ use datafusion::execution::memory_pool::{
 };
 use ravel_object_store::memory::MemoryStore;
 use ravel_sql::{
-    CeilingBreach, RavelTableProvider, SessionTable, SqlConfig, SqlError, TenantDelegatingPool,
-    TenantMemoryAccountant, build_session,
+    CeilingBreach, RavelTableProvider, SessionTable, SpillDecision, SqlConfig, SqlError,
+    TenantDelegatingPool, TenantMemoryAccountant, build_session,
 };
 use ravel_types::accounting::QueryAccounting;
 use util::{Fixture, SegSpec, SeriesSpec, request, tenant_id};
@@ -195,6 +195,8 @@ async fn a_sort_or_aggregate_budget_error_keeps_its_type() {
         // ADR-0774's rewrite is a `SqlConfig` field now; keep this
         // fixture's plan shape as it was by not installing the rule.
         late_materialization_extra_columns: None,
+        // ADR-0954: spill off, as on the shipped default.
+        spill: None,
     };
     let fixture = Fixture::build(
         Arc::new(MemoryStore::new()),
@@ -275,6 +277,8 @@ async fn a_high_cardinality_aggregation_over_budget_is_resources_exhausted() {
         // ADR-0774's rewrite is a `SqlConfig` field now; keep this
         // fixture's plan shape as it was by not installing the rule.
         late_materialization_extra_columns: None,
+        // ADR-0954: spill off, as on the shipped default.
+        spill: None,
     };
     let fixture = Fixture::build(
         Arc::new(MemoryStore::new()),
@@ -363,11 +367,13 @@ async fn a_high_cardinality_aggregation_is_refused_by_the_aggregate_not_the_scan
         // ADR-0774's rewrite is a `SqlConfig` field now; keep this
         // fixture's plan shape as it was by not installing the rule.
         late_materialization_extra_columns: None,
+        // ADR-0954: spill off, as on the shipped default.
+        spill: None,
     };
     let fixture = Fixture::build(
         Arc::new(MemoryStore::new()),
         &[(&tenant, &specs)],
-        config,
+        config.clone(),
         1 << 40,
     )
     .await;
@@ -394,7 +400,7 @@ async fn a_high_cardinality_aggregation_is_refused_by_the_aggregate_not_the_scan
         snapshot,
         tenant.hash(),
         fixture.fetcher.clone(),
-        config,
+        config.clone(),
         QueryAccounting::new(),
     );
     let ctx = build_session(
@@ -402,6 +408,7 @@ async fn a_high_cardinality_aggregation_is_refused_by_the_aggregate_not_the_scan
         pool,
         SessionTable::Metrics(Arc::new(provider)),
         false,
+        SpillDecision::Disabled,
     )
     .expect("metrics session builds");
 
@@ -467,6 +474,8 @@ async fn a_large_order_by_over_budget_is_resources_exhausted() {
         // ADR-0774's rewrite is a `SqlConfig` field now; keep this
         // fixture's plan shape as it was by not installing the rule.
         late_materialization_extra_columns: None,
+        // ADR-0954: spill off, as on the shipped default.
+        spill: None,
     };
     let fixture = Fixture::build(
         Arc::new(MemoryStore::new()),

--- a/crates/ravel-sql/tests/pushdown_memory.rs
+++ b/crates/ravel-sql/tests/pushdown_memory.rs
@@ -820,6 +820,8 @@ async fn byte_budget_exceeded_returns_typed_error() {
         // ADR-0774's rewrite is a `SqlConfig` field now; keep this
         // fixture's plan shape as it was by not installing the rule.
         late_materialization_extra_columns: None,
+        // ADR-0954: spill off, as on the shipped default.
+        spill: None,
     };
     let tenant = TenantMemoryAccountant::new(1 << 30);
     let task_ctx = task_ctx_with_pool(&config, Arc::clone(&tenant));
@@ -910,6 +912,8 @@ async fn high_cardinality_trips_query_pool_before_tenant() {
         // ADR-0774's rewrite is a `SqlConfig` field now; keep this
         // fixture's plan shape as it was by not installing the rule.
         late_materialization_extra_columns: None,
+        // ADR-0954: spill off, as on the shipped default.
+        spill: None,
     };
     let tenant = TenantMemoryAccountant::new(1 << 30);
     let task_ctx = task_ctx_with_pool(&config, Arc::clone(&tenant));
@@ -968,6 +972,8 @@ async fn tenant_budget_trips_and_rolls_back_the_query_reservation() {
         // ADR-0774's rewrite is a `SqlConfig` field now; keep this
         // fixture's plan shape as it was by not installing the rule.
         late_materialization_extra_columns: None,
+        // ADR-0954: spill off, as on the shipped default.
+        spill: None,
     };
     let tenant = TenantMemoryAccountant::new(8);
     let (pool, _breach) = config.query_pool(Arc::clone(&tenant), QueryAccounting::new());
@@ -1028,6 +1034,8 @@ async fn query_budget_reported_first_when_both_ceilings_are_equally_reachable() 
         // ADR-0774's rewrite is a `SqlConfig` field now; keep this
         // fixture's plan shape as it was by not installing the rule.
         late_materialization_extra_columns: None,
+        // ADR-0954: spill off, as on the shipped default.
+        spill: None,
     };
     let tenant = TenantMemoryAccountant::new(8);
     let task_ctx = task_ctx_with_pool(&config, Arc::clone(&tenant));

--- a/crates/ravel-sql/tests/scan_budgets.rs
+++ b/crates/ravel-sql/tests/scan_budgets.rs
@@ -488,6 +488,8 @@ fn task_ctx_with_query_bytes(max_query_bytes: usize) -> Arc<TaskContext> {
         // Named explicitly rather than spread from the default so a new field
         // keeps failing this initializer closed.
         late_materialization_extra_columns: None,
+        // ADR-0954: spill off, as on the shipped default.
+        spill: None,
     };
     let tenant = TenantMemoryAccountant::new(1 << 30);
     let (pool, _breach) = config.query_pool(tenant, QueryAccounting::new());

--- a/crates/ravel-sql/tests/skip_partial_aggregation.rs
+++ b/crates/ravel-sql/tests/skip_partial_aggregation.rs
@@ -73,7 +73,7 @@ use ravel_object_store::memory::MemoryStore;
 use ravel_object_store::{ObjectStoreBackend, PutOptions};
 use ravel_query::LogSegmentFetcher;
 use ravel_sql::{
-    LogsTableProvider, SKIP_PARTIAL_AGGREGATION_PROBE_ROWS, SessionTable, SqlConfig,
+    LogsTableProvider, SKIP_PARTIAL_AGGREGATION_PROBE_ROWS, SessionTable, SpillDecision, SqlConfig,
     TenantMemoryAccountant, build_session,
 };
 use ravel_types::TenantHash;
@@ -405,7 +405,14 @@ async fn run(
         LogSegmentFetcher::new(Arc::clone(store)),
         QueryAccounting::new(),
     ));
-    let ctx = build_session(&config, pool, SessionTable::Logs(provider), false).expect("session");
+    let ctx = build_session(
+        &config,
+        pool,
+        SessionTable::Logs(provider),
+        false,
+        SpillDecision::Disabled,
+    )
+    .expect("session");
 
     let plan = ctx
         .sql(QUERY)

--- a/crates/ravel-sql/tests/spill.rs
+++ b/crates/ravel-sql/tests/spill.rs
@@ -1,0 +1,707 @@
+//! Bounded ephemeral spill, end to end through `SqlExecutor::execute`
+//! (ADR-0954).
+//!
+//! Every test here drives the real resolve/plan/execute path, not the
+//! `SpillScratch`/`SpillCounts` units in `crate::spill` (those are exercised in
+//! `src/spill.rs`). What is proven here is the executor's behavior against the
+//! ADR's normative requirements:
+//!
+//! - an eligible integer aggregation over the memory budget completes by
+//!   spilling and returns the byte-identical result of the same query run under
+//!   a budget large enough not to spill (requirements 1, 4);
+//! - the per-query scratch quota exceeded is a typed `SpillBudgetExhausted`,
+//!   never a partial result (requirements 2, 5);
+//! - a missing spill directory is a typed `SpillUnavailable` (requirements 3,
+//!   5);
+//! - an ineligible plan (order-dependent float aggregation) over budget is
+//!   still refused and never creates a spill file (requirement 4, fail closed);
+//! - spill off (the unset-config default) reproduces the pre-ADR refusal, its
+//!   `DiskManager is disabled` re-attribution included (requirement 9);
+//! - scratch is cleaned up on completion, on a typed error, and on a cancelled
+//!   stream (requirement 7);
+//! - the spilling aggregation's pool-accounted peak stays within the configured
+//!   cap (requirement 1, the implementation-constraint measurement).
+//!
+//! # Where each test drives the spill from
+//!
+//! The eligibility, scratch-quota, unavailable-directory, cleanup, and spill-off
+//! cases run through the real `SqlExecutor::execute` path over a scanned
+//! `samples` table -- that is where the config plumbing, eligibility gate,
+//! scratch lifecycle, and error mapping live.
+//!
+//! The byte-identical and peak-memory cases instead run the grouped aggregate
+//! over an in-memory source ([`run_grouped_count`]). That is deliberate, and it
+//! is the one place the executor path cannot demonstrate requirement 1:
+//! Ravel's `RsegScanExec` buffers its whole decoded partition as a single
+//! non-spillable reservation whose size, for the 1:1 grouping this ADR targets
+//! (q33: distinct groups approximately equal to rows), equals or exceeds the
+//! aggregate's own state. So over a freshly scanned table the scan -- not the
+//! aggregate -- is the binding non-spillable consumer, the two grow
+//! concurrently in one shared per-query pool, and enabling aggregate spill
+//! cannot bring such a query within a smaller budget: the scan reservation
+//! collides at the pool boundary before (or regardless of) the aggregate's
+//! spill. Isolating the aggregate on a source that reserves no pool memory is
+//! what lets these two tests show the property requirement 1 is actually about
+//! -- that spilling the aggregate yields the exact in-memory result within the
+//! cap. This scan-domination limitation is a finding on ADR-0954, reported with
+//! this change.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+mod util;
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use datafusion::arrow::array::{Array, Int64Array};
+use datafusion::arrow::datatypes::{DataType, Field, Schema};
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::execution::disk_manager::{DiskManagerBuilder, DiskManagerMode};
+use datafusion::execution::memory_pool::MemoryPool;
+use datafusion::execution::runtime_env::RuntimeEnvBuilder;
+use datafusion::physical_plan::{ExecutionPlan, collect};
+use datafusion::prelude::{SessionConfig, SessionContext};
+use futures::StreamExt;
+use ravel_object_store::memory::MemoryStore;
+use ravel_sql::{
+    CeilingBreach, SpillConfig, SqlConfig, SqlError, TenantDelegatingPool, TenantMemoryAccountant,
+};
+use ravel_types::accounting::QueryAccounting;
+use util::{Fixture, SegSpec, SeriesSpec, request, tenant_id};
+
+/// A per-query memory budget the high-cardinality aggregation below overruns,
+/// used by the executor-path tests where the aggregate spills far enough to hit
+/// the scratch quota, or the plan is refused. 16 MiB is the same ceiling the
+/// ADR-0102 sibling tests in `memory_ceiling_and_budget_errors.rs` use to trip
+/// the same query shape, so the "over budget" precondition is shared with the
+/// pre-spill coverage rather than re-tuned here.
+const TIGHT_QUERY_BYTES: usize = 16 * 1024 * 1024;
+
+/// A per-query scratch quota large enough that the eligible aggregation's whole
+/// spilled working set fits, so the spill completes rather than tripping the
+/// quota. Sized well above the group state of the fixture below (a few MiB of
+/// Arrow IPC), and far under any real disk.
+const AMPLE_SCRATCH_BYTES: u64 = 512 * 1024 * 1024;
+
+/// A per-query scratch quota far too small to hold the spilled group state, so
+/// the disk manager refuses a spill write and the query fails
+/// `SpillBudgetExhausted`. 64 KiB is below one spilled batch of the fixture.
+const TINY_SCRATCH_BYTES: u64 = 64 * 1024;
+
+/// Documented overhead the spilling query's pool-accounted peak reservation is
+/// allowed above the configured `max_query_bytes` cap. Zero: the pool's
+/// `try_grow` is a hard cap (ADR-0954 requirement 1), and the grouped-hash
+/// spill path charges its transient sort headroom to the same pool after
+/// freeing the group state, so no pool-accounted reservation ever exceeds the
+/// configured ceiling. A nonzero value here would mean the hard cap leaked,
+/// which is the property this bound exists to catch.
+const SPILL_POOL_PEAK_OVERHEAD_BYTES: u64 = 0;
+
+/// Rows per RSEG segment in the fixture. Deliberately small: `RsegScanExec`
+/// reserves a whole decoded segment as one non-spillable block, so a single
+/// large segment would dominate the tight pool and starve the aggregate (the
+/// consumer whose spill this suite is about). Many small segments keep the
+/// scan's live reservation small while the aggregation cardinality stays high,
+/// so the eligible aggregate is the binding consumer and spills. The spill
+/// fixtures also scan at `fetch_concurrency = 1` (see [`spill_config`]) so only
+/// one segment decodes at a time.
+const SEG_ROWS: i64 = 8_000;
+
+/// Two metric series whose event timestamps overlap, spread across many small
+/// segments (see [`SEG_ROWS`]). `COUNT(*) GROUP BY ts` then yields groups with
+/// two distinct counts (2 where both series have the ts, i.e. `ts < short_rows`,
+/// and 1 where only the longer series does) rather than a uniform all-ones
+/// column, so the byte-identical comparison exercises the spilled merge and not
+/// just a constant. `long_rows` distinct group keys total, the aggregation
+/// cardinality that overruns [`TIGHT_QUERY_BYTES`].
+fn overlapping_series_specs(long_rows: i64, short_rows: i64) -> Vec<SegSpec> {
+    let mut segs = Vec::new();
+    let mut start = 0i64;
+    let mut idx = 0usize;
+    while start < long_rows {
+        let end = (start + SEG_ROWS).min(long_rows);
+        let mut series = vec![SeriesSpec::new(
+            "a",
+            (start..end).map(|i| (i, i as f64)).collect(),
+        )];
+        if start < short_rows {
+            let b_end = end.min(short_rows);
+            series.push(SeriesSpec::new(
+                "b",
+                (start..b_end).map(|i| (i, i as f64)).collect(),
+            ));
+        }
+        // Distinct provenance per segment. The rows never collide across
+        // segments (each covers a disjoint ts slice), so any distinct stamp
+        // gives a well-defined dedup order.
+        segs.push(SegSpec::new(10 + idx as i64, 1, idx as u64, series));
+        start = end;
+        idx += 1;
+    }
+    segs
+}
+
+/// The shape both spilling tests use: `long_rows` distinct `ts` groups, of
+/// which the first `short_rows` have count 2 and the rest count 1.
+const LONG_ROWS: i64 = 300_000;
+const SHORT_ROWS: i64 = 150_000;
+
+/// The eligible statement under test: integer `COUNT(*)` grouped by the
+/// non-float `ts` key. No `ORDER BY`: a `Sort` node is deliberately outside the
+/// spill-eligible plan shape (ADR-0954 requirement 4), so the results come back
+/// unordered and the comparison sorts both sides itself.
+const SPILLING_SQL: &str = "SELECT ts, count(*) AS n FROM samples GROUP BY ts";
+
+/// The ineligible statement: `SUM` over the `Float64` `value` column, whose
+/// fold is order-dependent (ADR-0022/0024). It must be refused, never spilled.
+const INELIGIBLE_SQL: &str = "SELECT ts, sum(value) AS s FROM samples GROUP BY ts";
+
+fn spill_config(spill_dir: PathBuf, scratch_bytes: u64, query_bytes: usize) -> SqlConfig {
+    // One scan partition, so at most one segment decodes at a time and the
+    // non-spillable scan reservation stays small relative to the aggregate
+    // (see SEG_ROWS). This is a memory-shape choice, not a correctness one: the
+    // aggregate computes the same groups over the same rows at any partitioning.
+    let mut engine = util::engine_config();
+    engine.fetch_concurrency = 1;
+    SqlConfig {
+        engine,
+        max_query_bytes: query_bytes,
+        parallel_final_aggregation: false,
+        skip_partial_aggregation: true,
+        late_materialization_extra_columns: None,
+        spill: Some(SpillConfig {
+            dir: spill_dir,
+            max_bytes: scratch_bytes,
+        }),
+    }
+}
+
+/// What one run of the in-memory grouped aggregation observed: its `(key,
+/// count)` rows (sorted), how many spill files it wrote, and its pool-accounted
+/// peak reservation.
+struct AggRun {
+    rows: Vec<(String, i64)>,
+    spill_files: u64,
+    peak_pool_bytes: u64,
+}
+
+/// Run `SELECT k, count(*) GROUP BY k` over an in-memory table of `keys`,
+/// against a `TenantDelegatingPool` capped at `query_bytes` with the disk
+/// manager pointed at `scratch_dir` (quota `scratch_bytes`).
+///
+/// This drives the eligible-aggregate spill mechanism (ADR-0954 requirement 1)
+/// in isolation: the source is a `MemTable`, whose scan reserves no pool memory,
+/// so the grouped aggregate is the sole pool consumer and is the operator that
+/// spills. That isolation is deliberate. Ravel's own `RsegScanExec` buffers its
+/// whole decoded partition as one non-spillable reservation whose size, for the
+/// 1:1 grouping this ADR targets, equals or exceeds the aggregate's, so over a
+/// freshly scanned table the scan -- not the aggregate -- is the binding
+/// consumer and enabling aggregate spill cannot shrink the query's footprint.
+/// See the suite's module-level note. What this helper proves is the property
+/// the ADR's byte-identical requirement is about: that when the aggregate IS the
+/// binding consumer, spilling it yields the same result as running it in memory
+/// and holds its pool-accounted peak under the cap.
+///
+/// The group key is a `Utf8` string, not an integer, on purpose: DataFusion 54's
+/// `GroupValues` for a primitive key under-reports its real hashbrown allocation
+/// (issue #740, documented in `crate::config`), so an integer key's reservation
+/// stays far below its true footprint and never trips a realistic budget. A
+/// string key's `GroupValues` accounts the stored bytes, so the reservation
+/// tracks reality and the aggregate spills when it should.
+async fn run_grouped_count(
+    scratch_dir: &Path,
+    keys: &[String],
+    query_bytes: usize,
+    scratch_bytes: u64,
+) -> AggRun {
+    let tenant = TenantMemoryAccountant::new(1 << 40);
+    let breach = CeilingBreach::new();
+    let accounting = QueryAccounting::new();
+    let pool: Arc<dyn MemoryPool> = Arc::new(TenantDelegatingPool::new(
+        query_bytes,
+        tenant,
+        breach,
+        accounting.clone(),
+    ));
+    let runtime = RuntimeEnvBuilder::new()
+        .with_memory_pool(pool)
+        .with_disk_manager_builder(
+            DiskManagerBuilder::default()
+                .with_mode(DiskManagerMode::Directories(vec![
+                    scratch_dir.to_path_buf(),
+                ]))
+                .with_max_temp_directory_size(scratch_bytes),
+        )
+        .build_arc()
+        .expect("runtime builds");
+    // One partition, matching the executor path this helper stands in for
+    // (`build_session` sets `target_partitions` from `fetch_concurrency`, which
+    // the spill fixtures pin to 1). A default `SessionConfig` would split the
+    // aggregate into `target_partitions` concurrent partial aggregates sharing
+    // this one pool, so a spilling partition's `clear_shrink(0)` could not free
+    // the pool room its sort headroom needs (the other partitions still hold
+    // their group state) and the sort reservation fails under the cap. A single
+    // partition makes the aggregate the sole pool consumer this helper's
+    // contract (and ADR-0954 requirement 1's headroom reasoning) assumes.
+    let config = SessionConfig::new().with_target_partitions(1);
+    let ctx = SessionContext::new_with_config_rt(config, runtime);
+
+    let schema = Arc::new(Schema::new(vec![Field::new("k", DataType::Utf8, false)]));
+    // Many small batches, not one giant one. DataFusion's grouped-hash aggregate
+    // checks its spill trigger only at input-batch boundaries
+    // (`emit_early_if_necessary`/`spill_previous_if_necessary`): fed a single
+    // 4.5M-row batch it builds the whole hash table in one call and never gets
+    // the chance to spill. Chunking into `batch_size`-row batches gives the
+    // aggregate the checkpoints at which it reserves, overruns the cap, and
+    // spills -- the behavior under test.
+    let batches: Vec<RecordBatch> = keys
+        .chunks(8192)
+        .map(|chunk| {
+            let column = datafusion::arrow::array::StringArray::from_iter_values(chunk.iter());
+            RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(column)]).expect("batch builds")
+        })
+        .collect();
+    let table = datafusion::datasource::MemTable::try_new(Arc::clone(&schema), vec![batches])
+        .expect("in-memory table builds");
+    ctx.register_table("t", Arc::new(table))
+        .expect("register in-memory table");
+
+    let df = ctx
+        .sql("SELECT k, count(*) AS n FROM t GROUP BY k")
+        .await
+        .expect("aggregation plans");
+    let plan = df.create_physical_plan().await.expect("physical plan");
+    let batches = collect(Arc::clone(&plan), ctx.task_ctx())
+        .await
+        .expect("aggregation runs to completion");
+
+    let mut rows = Vec::new();
+    for batch in &batches {
+        let k = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<datafusion::arrow::array::StringArray>()
+            .expect("key column is Utf8");
+        let n = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("count column is Int64");
+        for i in 0..batch.num_rows() {
+            rows.push((k.value(i).to_string(), n.value(i)));
+        }
+    }
+    rows.sort_unstable();
+
+    AggRun {
+        rows,
+        spill_files: spill_file_count(&plan),
+        peak_pool_bytes: accounting.snapshot().peak_intermediate_bytes,
+    }
+}
+
+/// Sum the DataFusion spill-file count over `plan` and its descendants.
+///
+/// Spill is a typed `MetricValue::SpillCount`, not a named `Count`, so it must
+/// be read through the `MetricsSet::spill_count()` accessor: `sum_by_name`
+/// deliberately returns `false` for every spill variant and would report zero
+/// even for a query that spilled (the same defect fixed in
+/// `crate::spill::accumulate_spill_counts`).
+fn spill_file_count(plan: &Arc<dyn ExecutionPlan>) -> u64 {
+    let mut total = plan.metrics().and_then(|m| m.spill_count()).unwrap_or(0) as u64;
+    for child in plan.children() {
+        total += spill_file_count(child);
+    }
+    total
+}
+
+/// Keys for the in-memory aggregation: `groups` distinct string values, the
+/// first `doubled` of them appearing twice, so `count(*) GROUP BY k` yields two
+/// distinct counts (2 then 1) rather than a uniform column -- the byte-identical
+/// comparison then exercises the spilled merge, not just a constant.
+fn count_varying_keys(groups: i64, doubled: i64) -> Vec<String> {
+    let mut keys: Vec<String> = (0..groups).map(|i| format!("key-{i:09}")).collect();
+    keys.extend((0..doubled).map(|i| format!("key-{i:09}")));
+    keys
+}
+
+/// The `ravel-spill-*` subdirectories a query created under `root`. Empty means
+/// every scratch subdirectory was cleaned up (or none was ever created).
+fn spill_subdirs(root: &Path) -> Vec<PathBuf> {
+    std::fs::read_dir(root)
+        .expect("scratch root is readable")
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with("ravel-spill-"))
+        })
+        .collect()
+}
+
+/// Per-query memory budget for the in-memory spilling aggregation: small enough
+/// that the integer groups overrun it and the aggregate spills. Unlike the
+/// executor path there is no scan competing for this budget (the `MemTable`
+/// source reserves nothing), so a tight cap cleanly forces the aggregate -- and
+/// only the aggregate -- to spill. See [`run_grouped_count`].
+const IN_MEMORY_SPILL_BYTES: usize = 8 * 1024 * 1024;
+/// Distinct string group keys in the in-memory aggregation, and how many of
+/// them appear twice (yielding count 2 vs 1). Sized so the group state of the
+/// single sole-consumer aggregate (see [`run_grouped_count`]) far exceeds
+/// [`IN_MEMORY_SPILL_BYTES`] and the aggregate must spill: measured against the
+/// locked DataFusion 54.1.0, one `key-NNNNNNNNN` group costs well over 100
+/// bytes of pool-accounted `GroupValues` plus sort headroom, so 1,000,000
+/// groups reserve on the order of 150 MiB against the 8 MiB cap and spill
+/// incrementally.
+const IN_MEMORY_GROUPS: i64 = 1_000_000;
+const IN_MEMORY_DOUBLED: i64 = 500_000;
+
+/// ADR-0954 requirements 1 and 4: an eligible integer aggregation that overruns
+/// the memory budget completes by spilling and returns the byte-identical result
+/// of the same query run under a budget large enough not to spill. The equality
+/// is over the values, not the row count.
+///
+/// Driven over an in-memory source so the aggregate is the binding pool consumer
+/// and the operator that spills (see [`run_grouped_count`] for why the executor
+/// path cannot show this for a scan-fed aggregation: the scan itself is the
+/// binding non-spillable consumer there).
+#[tokio::test]
+async fn an_eligible_aggregation_over_budget_spills_and_matches_the_in_memory_result() {
+    let keys = count_varying_keys(IN_MEMORY_GROUPS, IN_MEMORY_DOUBLED);
+    let spill_scratch = tempfile::tempdir().expect("spill scratch root");
+    let ref_scratch = tempfile::tempdir().expect("reference scratch root");
+
+    let spilled = run_grouped_count(
+        spill_scratch.path(),
+        &keys,
+        IN_MEMORY_SPILL_BYTES,
+        AMPLE_SCRATCH_BYTES,
+    )
+    .await;
+    let reference =
+        run_grouped_count(ref_scratch.path(), &keys, 1 << 30, AMPLE_SCRATCH_BYTES).await;
+
+    assert!(
+        spilled.spill_files > 0,
+        "the tight-budget aggregation must actually spill; wrote {} files",
+        spilled.spill_files
+    );
+    assert_eq!(
+        reference.spill_files, 0,
+        "the large-budget reference must not spill"
+    );
+
+    assert_eq!(
+        reference.rows.len(),
+        IN_MEMORY_GROUPS as usize,
+        "the reference must produce one group per distinct key"
+    );
+    assert_eq!(
+        spilled.rows, reference.rows,
+        "the spilled result must be identical to the in-memory result, value for value"
+    );
+    // The values, not just the row count: exactly IN_MEMORY_DOUBLED keys were
+    // inserted twice (count 2) and the rest once (count 1). Assert the multiset
+    // of counts, which pins the spilled merge produced the right per-group total.
+    let twos = spilled.rows.iter().filter(|(_, c)| *c == 2).count();
+    let ones = spilled.rows.iter().filter(|(_, c)| *c == 1).count();
+    assert_eq!(
+        twos, IN_MEMORY_DOUBLED as usize,
+        "doubled keys must count 2"
+    );
+    assert_eq!(
+        ones,
+        (IN_MEMORY_GROUPS - IN_MEMORY_DOUBLED) as usize,
+        "the rest must count 1"
+    );
+    assert_eq!(
+        twos + ones,
+        IN_MEMORY_GROUPS as usize,
+        "every group must have count 1 or 2"
+    );
+
+    // Requirement 7: the runtime dropped inside `run_grouped_count`, so the disk
+    // manager's scratch is gone; nothing survives a completed query.
+    assert!(
+        std::fs::read_dir(spill_scratch.path())
+            .expect("scratch readable")
+            .next()
+            .is_none(),
+        "a completed spilling query must leave no scratch behind"
+    );
+}
+
+/// ADR-0954 requirements 2 and 5: an eligible aggregation whose spilled state
+/// exceeds the per-query scratch quota fails with the typed
+/// `SpillBudgetExhausted`, and returns no partial result.
+#[tokio::test]
+async fn an_eligible_aggregation_over_the_scratch_quota_is_spill_budget_exhausted() {
+    let tenant = tenant_id("acme");
+    let specs = overlapping_series_specs(LONG_ROWS, SHORT_ROWS);
+    let scratch = tempfile::tempdir().expect("scratch root");
+
+    let fixture = Fixture::build(
+        Arc::new(MemoryStore::new()),
+        &[(&tenant, &specs)],
+        spill_config(
+            scratch.path().to_path_buf(),
+            TINY_SCRATCH_BYTES,
+            TIGHT_QUERY_BYTES,
+        ),
+        1 << 40,
+    )
+    .await;
+
+    let err = fixture
+        .executor
+        .execute(tenant.hash(), &request(SPILLING_SQL))
+        .await
+        .expect_err("the tiny scratch quota must trip");
+
+    assert!(
+        matches!(err, SqlError::SpillBudgetExhausted(_)),
+        "an over-quota spill must fail SpillBudgetExhausted, distinct from a \
+         memory-pool exhaustion; got {err:?}"
+    );
+
+    // Requirement 7: a typed error cleans up its scratch too.
+    assert!(
+        spill_subdirs(scratch.path()).is_empty(),
+        "a query that failed SpillBudgetExhausted must leave no scratch behind"
+    );
+}
+
+/// ADR-0954 requirements 3 and 5: an eligible query with spill armed at a
+/// directory that does not exist fails the typed `SpillUnavailable`, raised
+/// before any operator runs, and creates nothing.
+#[tokio::test]
+async fn an_eligible_query_with_a_missing_spill_directory_is_spill_unavailable() {
+    let tenant = tenant_id("acme");
+    // Small: the failure is at scratch creation, before planning, so the data
+    // size is irrelevant and a large fixture would only slow the test.
+    let specs = overlapping_series_specs(100, 50);
+    let root = tempfile::tempdir().expect("scratch root");
+    let missing = root.path().join("does-not-exist");
+
+    let fixture = Fixture::build(
+        Arc::new(MemoryStore::new()),
+        &[(&tenant, &specs)],
+        spill_config(missing.clone(), AMPLE_SCRATCH_BYTES, TIGHT_QUERY_BYTES),
+        1 << 40,
+    )
+    .await;
+
+    let err = fixture
+        .executor
+        .execute(tenant.hash(), &request(SPILLING_SQL))
+        .await
+        .expect_err("a missing spill directory must be refused");
+
+    assert!(
+        matches!(err, SqlError::SpillUnavailable(_)),
+        "a missing spill directory must fail SpillUnavailable; got {err:?}"
+    );
+    assert!(
+        !missing.exists(),
+        "the executor must never create the configured spill directory"
+    );
+}
+
+/// ADR-0954 requirement 4, fail closed: an ineligible plan (order-dependent
+/// float aggregation) over budget is still refused with a memory-pool
+/// exhaustion, NOT a spill, even though spill is configured. No scratch
+/// subdirectory is ever created for it.
+#[tokio::test]
+async fn an_ineligible_float_aggregation_over_budget_is_refused_and_never_spills() {
+    let tenant = tenant_id("acme");
+    let specs = overlapping_series_specs(LONG_ROWS, SHORT_ROWS);
+    let scratch = tempfile::tempdir().expect("scratch root");
+
+    let fixture = Fixture::build(
+        Arc::new(MemoryStore::new()),
+        &[(&tenant, &specs)],
+        spill_config(
+            scratch.path().to_path_buf(),
+            AMPLE_SCRATCH_BYTES,
+            TIGHT_QUERY_BYTES,
+        ),
+        1 << 40,
+    )
+    .await;
+
+    let err = fixture
+        .executor
+        .execute(tenant.hash(), &request(INELIGIBLE_SQL))
+        .await
+        .expect_err("an ineligible float aggregation over budget must be refused");
+
+    assert!(
+        matches!(err, SqlError::ResourcesExhausted(_)),
+        "an ineligible plan must be refused with the memory-pool exhaustion, \
+         not any spill-specific error; got {err:?}"
+    );
+    assert!(
+        !matches!(
+            err,
+            SqlError::SpillBudgetExhausted(_) | SqlError::SpillUnavailable(_)
+        ),
+        "an ineligible plan must not reach any spill path; got {err:?}"
+    );
+    assert!(
+        spill_subdirs(scratch.path()).is_empty(),
+        "an ineligible plan must never create a scratch subdirectory"
+    );
+}
+
+/// ADR-0954 requirement 9: with spill unset (the shipped default), an eligible
+/// high-cardinality aggregation over budget reproduces the pre-ADR behavior
+/// exactly -- a typed `ResourcesExhausted` re-attributed from the disabled disk
+/// manager, its `DiskManager is disabled` marker rewritten to the pool's own
+/// occupancy. This is the same assertion the pre-spill coverage makes, restated
+/// here so a regression in the default path fails in the spill suite too.
+#[tokio::test]
+async fn spill_off_reproduces_todays_refusal() {
+    let tenant = tenant_id("acme");
+    let specs = overlapping_series_specs(LONG_ROWS, SHORT_ROWS);
+
+    let config = SqlConfig {
+        engine: util::engine_config(),
+        max_query_bytes: TIGHT_QUERY_BYTES,
+        parallel_final_aggregation: false,
+        skip_partial_aggregation: true,
+        late_materialization_extra_columns: None,
+        spill: None,
+    };
+    assert_eq!(config.spill, None, "this case is the spill-off default");
+
+    let fixture = Fixture::build(
+        Arc::new(MemoryStore::new()),
+        &[(&tenant, &specs)],
+        config,
+        1 << 40,
+    )
+    .await;
+
+    let err = fixture
+        .executor
+        .execute(tenant.hash(), &request(SPILLING_SQL))
+        .await
+        .expect_err("with spill off the aggregation over budget must be refused");
+
+    assert!(
+        matches!(err, SqlError::ResourcesExhausted(_)),
+        "spill off must reproduce the typed refusal; got {err:?}"
+    );
+    // The re-attribution the disabled disk manager path produces: DataFusion's
+    // own `DiskManager is disabled` wording is replaced by the pool's occupancy.
+    let SqlError::ResourcesExhausted(msg) = &err else {
+        unreachable!("asserted above");
+    };
+    assert!(
+        !msg.contains("DiskManager is disabled"),
+        "the disabled-disk-manager marker must be re-attributed away; got {msg:?}"
+    );
+}
+
+/// ADR-0954 requirement 7, the cancellation path: a spilling query whose stream
+/// is dropped mid-flight still removes its scratch. Driven through the lower
+/// level `plan_pinned`/`execute` so the stream can be dropped after a single
+/// poll rather than drained.
+#[tokio::test]
+async fn a_cancelled_spilling_stream_cleans_up_its_scratch() {
+    let tenant = tenant_id("acme");
+    let specs = overlapping_series_specs(LONG_ROWS, SHORT_ROWS);
+    let scratch = tempfile::tempdir().expect("scratch root");
+
+    let fixture = Fixture::build(
+        Arc::new(MemoryStore::new()),
+        &[(&tenant, &specs)],
+        spill_config(
+            scratch.path().to_path_buf(),
+            AMPLE_SCRATCH_BYTES,
+            TIGHT_QUERY_BYTES,
+        ),
+        1 << 40,
+    )
+    .await;
+
+    let accounting = QueryAccounting::new();
+    let snapshot = fixture.snapshot(&tenant).await;
+    let pinned = fixture
+        .executor
+        .plan_pinned(tenant.hash(), snapshot, SPILLING_SQL, &accounting, &[])
+        .await
+        .expect("the eligible query plans and creates its scratch");
+
+    // The scratch subdirectory exists once the eligible query is planned.
+    assert_eq!(
+        spill_subdirs(scratch.path()).len(),
+        1,
+        "an eligible planned query must have created exactly one scratch subdirectory"
+    );
+
+    let mut stream = pinned.execute().await.expect("the stream starts");
+    // Poll once, then abandon the stream mid-flight (the cancellation path).
+    let _ = stream.next().await;
+    drop(stream);
+
+    assert!(
+        spill_subdirs(scratch.path()).is_empty(),
+        "a cancelled spilling stream must remove its scratch on drop"
+    );
+}
+
+/// ADR-0954 requirement 1 and its implementation-constraint measurement: a
+/// spilling aggregation's pool-accounted peak reservation stays within the
+/// configured cap (plus [`SPILL_POOL_PEAK_OVERHEAD_BYTES`], which is zero
+/// because `try_grow` is a hard cap), and the measured peak is reported against
+/// that cap.
+///
+/// The asserted quantity is the pool-accounted peak, which is what requirement 1
+/// governs and the only bound established by reasoning: `try_grow` refuses any
+/// reservation past the cap, and DataFusion 54's grouped-hash spill frees the
+/// group state (`clear_shrink(0)`) before it reserves the sort headroom out of
+/// the same pool, so no pool-accounted byte exceeds the ceiling. Process RSS is
+/// deliberately NOT asserted here: the ADR notes the pool-to-RSS gap (allocator
+/// overhead, Arrow rounding, the emitted-batch-plus-sort peak) is not bounded by
+/// reasoning, and on a shared multi-test process the resident set is dominated
+/// by the harness and any concurrent build, so a tight RSS band would measure
+/// the host, not the query. The pool-accounted peak is the deterministic,
+/// gate-stable bound; the report records the real figure.
+#[tokio::test]
+async fn the_spilling_aggregation_holds_its_pool_accounted_peak_under_the_cap() {
+    let keys = count_varying_keys(IN_MEMORY_GROUPS, IN_MEMORY_DOUBLED);
+    let scratch = tempfile::tempdir().expect("scratch root");
+
+    let run = run_grouped_count(
+        scratch.path(),
+        &keys,
+        IN_MEMORY_SPILL_BYTES,
+        AMPLE_SCRATCH_BYTES,
+    )
+    .await;
+
+    let cap = IN_MEMORY_SPILL_BYTES as u64;
+    eprintln!(
+        "spill peak measurement: pool_peak={} bytes, cap={cap} bytes, spill_files={}",
+        run.peak_pool_bytes, run.spill_files,
+    );
+
+    assert!(
+        run.spill_files > 0,
+        "this test's subject must actually spill; wrote {} files",
+        run.spill_files
+    );
+    assert!(
+        run.peak_pool_bytes <= cap + SPILL_POOL_PEAK_OVERHEAD_BYTES,
+        "the pool-accounted peak {} must stay within the configured cap {cap} \
+         (+{SPILL_POOL_PEAK_OVERHEAD_BYTES} overhead); a value above the cap \
+         means try_grow's hard limit leaked (ADR-0954 requirement 1)",
+        run.peak_pool_bytes,
+    );
+    assert!(
+        run.peak_pool_bytes > 0,
+        "the pool-accounted peak must be observed, not left at zero"
+    );
+}

--- a/crates/ravel-sql/tests/spill.rs
+++ b/crates/ravel-sql/tests/spill.rs
@@ -9,8 +9,14 @@
 //! - an eligible integer aggregation over the memory budget completes by
 //!   spilling and returns the byte-identical result of the same query run under
 //!   a budget large enough not to spill (requirements 1, 4);
+//! - a spill-enabled plan carries no `RepartitionExec`: the eligibility
+//!   predicate classifies logical nodes, an enabled disk manager is a
+//!   session-wide permission, and that exchange is the node between the two
+//!   scopes (it spills, and no logical predicate ever sees it);
 //! - the per-query scratch quota exceeded is a typed `SpillBudgetExhausted`,
-//!   never a partial result (requirements 2, 5);
+//!   never a partial result (requirements 2, 5), with the budget split between
+//!   the scan and the aggregate measured so the aggregate is provably the
+//!   consumer that reached its spill threshold;
 //! - a missing spill directory is a typed `SpillUnavailable` (requirements 3,
 //!   5);
 //! - an ineligible plan (order-dependent float aggregation) over budget is
@@ -70,11 +76,17 @@ use ravel_types::accounting::QueryAccounting;
 use util::{Fixture, SegSpec, SeriesSpec, request, tenant_id};
 
 /// A per-query memory budget the high-cardinality aggregation below overruns,
-/// used by the executor-path tests where the aggregate spills far enough to hit
-/// the scratch quota, or the plan is refused. 16 MiB is the same ceiling the
-/// ADR-0102 sibling tests in `memory_ceiling_and_budget_errors.rs` use to trip
-/// the same query shape, so the "over budget" precondition is shared with the
-/// pre-spill coverage rather than re-tuned here.
+/// used by the executor-path tests where the plan is refused (spill off, or an
+/// ineligible plan) or where the budget is not what the case is about at all.
+/// 16 MiB is the same ceiling the ADR-0102 sibling tests in
+/// `memory_ceiling_and_budget_errors.rs` use to trip the same query shape, so
+/// the "over budget" precondition is shared with the pre-spill coverage rather
+/// than re-tuned here.
+///
+/// It is deliberately NOT the budget of the scratch-quota case: the scan's own
+/// share of this fixture exceeds 16 MiB, so under this budget no statement can
+/// be made about which consumer reached its limit first. See
+/// [`SPLIT_QUERY_BYTES`].
 const TIGHT_QUERY_BYTES: usize = 16 * 1024 * 1024;
 
 /// A per-query scratch quota large enough that the eligible aggregation's whole
@@ -432,9 +444,104 @@ async fn an_eligible_aggregation_over_budget_spills_and_matches_the_in_memory_re
     );
 }
 
+/// The scan-only statement: the same fixture, the same decode and dedup work,
+/// but an ungrouped `count(*)` whose aggregate state is a single `i64`. Its
+/// pool-accounted peak is therefore the scan's share of the budget, which is
+/// what the split below is measured against.
+const SCAN_ONLY_SQL: &str = "SELECT count(*) AS n FROM samples";
+
+/// Per-query memory budget for the scratch-quota case, sized from the measured
+/// split rather than shared with [`TIGHT_QUERY_BYTES`].
+///
+/// `RsegScanExec` retains every decoded segment of this fixture as one
+/// non-spillable reservation, and that share measures 36,640,200 bytes
+/// ([`SCAN_ONLY_SQL`] under [`AMPLE_QUERY_BYTES`], locked DataFusion 54.1.0).
+/// At 16 MiB the scan alone cannot fit, so nothing about the AGGREGATE's spill
+/// threshold could be established from that budget: whichever consumer happened
+/// to ask at the pool boundary decided which error came back. 48 MiB is above
+/// the scan's whole share and still far below the grouped run's 68,162,568-byte
+/// peak, so the scan fits, the aggregate gets a bounded headroom to grow into,
+/// and the aggregate is the consumer that must spill. Each of those figures is
+/// asserted below.
+const SPLIT_QUERY_BYTES: usize = 48 * 1024 * 1024;
+
+/// A budget no run over this fixture approaches, for the reference run that
+/// measures the grouped query's whole demand without spilling.
+const AMPLE_QUERY_BYTES: usize = 1 << 30;
+
+/// Ceiling on the scan's share of [`SPLIT_QUERY_BYTES`] (measured 36,640,200
+/// bytes). Above this the scan would be eating the headroom the aggregate needs,
+/// and the over-quota case would stop proving anything about the aggregate's
+/// spill.
+const SCAN_PEAK_CEILING_BYTES: u64 = 40 * 1024 * 1024;
+
+/// Floor on what the scan leaves for the aggregate under [`SPLIT_QUERY_BYTES`]
+/// (measured 13,671,416 bytes). The aggregate's spill threshold IS its pool
+/// refusal, so it can only reach it if this much of the budget is actually
+/// available to it.
+const AGGREGATE_HEADROOM_FLOOR_BYTES: u64 = 8 * 1024 * 1024;
+
+/// The `written`/`quota` figures [`SqlError::spill_budget_exhausted`] formats
+/// into its message: `"{written} of {quota} bytes of scratch already written"`.
+fn scratch_figures(err: &SqlError) -> (u64, u64) {
+    let SqlError::SpillBudgetExhausted(message) = err else {
+        panic!("expected SpillBudgetExhausted; got {err:?}");
+    };
+    let mut numbers = message
+        .split_whitespace()
+        .filter_map(|word| word.parse::<u64>().ok());
+    let written = numbers.next().expect("the message states bytes written");
+    let quota = numbers.next().expect("the message states the quota");
+    (written, quota)
+}
+
+/// Drain `sql` through the real executor path with `accounting` attached, so
+/// the run's pool-accounted peak is readable whether it succeeded or failed.
+async fn drain_with_accounting(
+    fixture: &Fixture,
+    tenant: &ravel_types::TenantId,
+    sql: &str,
+    accounting: &QueryAccounting,
+) -> Result<u64, SqlError> {
+    let snapshot = fixture.snapshot(tenant).await;
+    let mut stream = fixture
+        .executor
+        .plan_pinned(tenant.hash(), snapshot, sql, accounting, &[])
+        .await?
+        .execute()
+        .await?;
+    let mut rows = 0u64;
+    while let Some(next) = stream.next().await {
+        rows += next?.num_rows() as u64;
+    }
+    Ok(rows)
+}
+
 /// ADR-0954 requirements 2 and 5: an eligible aggregation whose spilled state
 /// exceeds the per-query scratch quota fails with the typed
 /// `SpillBudgetExhausted`, and returns no partial result.
+///
+/// The variant alone is not enough to know the query took the path this test is
+/// about. The pool is shared: `RsegScanExec` holds a whole decoded segment as a
+/// non-spillable reservation, so a budget the scan nearly fills would refuse
+/// the aggregate's first reservation and end the query in
+/// `ResourcesExhausted` from the scan side before the aggregate ever reached
+/// its spill threshold. So the split is measured and asserted with figures:
+///
+/// 1. a scan-only control ([`SCAN_ONLY_SQL`]) over the same fixture and the
+///    same budget COMPLETES, and its pool-accounted peak is the scan's share;
+/// 2. that share is under [`SCAN_PEAK_CEILING_BYTES`] and leaves at least
+///    [`AGGREGATE_HEADROOM_FLOOR_BYTES`] of the budget for the aggregate;
+/// 3. the grouped query's own demand, measured by a reference run under
+///    [`AMPLE_QUERY_BYTES`] that does not spill, exceeds that headroom by more
+///    than the headroom itself, so the aggregate cannot fit in what the scan
+///    leaves and must reach its spill threshold;
+/// 4. the failing run's own figures show scratch bytes ALREADY WRITTEN when the
+///    quota refused the next write, which is only reachable by an aggregate that
+///    reached that threshold and spilled;
+/// 5. the quota in those figures is [`TINY_SCRATCH_BYTES`], so the refusal came
+///    from this query's configured scratch ceiling and not from some other
+///    limit.
 #[tokio::test]
 async fn an_eligible_aggregation_over_the_scratch_quota_is_spill_budget_exhausted() {
     let tenant = tenant_id("acme");
@@ -447,11 +554,87 @@ async fn an_eligible_aggregation_over_the_scratch_quota_is_spill_budget_exhauste
         spill_config(
             scratch.path().to_path_buf(),
             TINY_SCRATCH_BYTES,
-            TIGHT_QUERY_BYTES,
+            SPLIT_QUERY_BYTES,
         ),
         1 << 40,
     )
     .await;
+
+    // 1 and 2: what the scan takes, and what it leaves.
+    let control_accounting = QueryAccounting::new();
+    let control_rows = drain_with_accounting(&fixture, &tenant, SCAN_ONLY_SQL, &control_accounting)
+        .await
+        .expect("the scan-only control must complete within the same budget");
+    assert_eq!(
+        control_rows, 1,
+        "the ungrouped control returns one row, so its peak is the scan's, not \
+         an aggregate's"
+    );
+    let scan_peak = control_accounting.snapshot().peak_intermediate_bytes;
+    let budget = SPLIT_QUERY_BYTES as u64;
+    let headroom = budget.saturating_sub(scan_peak);
+    assert!(
+        scan_peak > 0,
+        "the control must have reserved from the pool, else it measured nothing"
+    );
+    assert!(
+        scan_peak <= SCAN_PEAK_CEILING_BYTES,
+        "the scan's share {scan_peak} must stay under {SCAN_PEAK_CEILING_BYTES} \
+         bytes; above that the scan, not the aggregate, is the consumer that \
+         approaches the budget and this case proves nothing about the spill"
+    );
+    assert!(
+        headroom >= AGGREGATE_HEADROOM_FLOOR_BYTES,
+        "the scan must leave the aggregate at least \
+         {AGGREGATE_HEADROOM_FLOOR_BYTES} bytes of the {budget}-byte budget to \
+         grow into and spill from; it left {headroom}"
+    );
+
+    // 3: how much the grouped query actually wants, measured where nothing is
+    // refused and nothing spills. The two consumers overlap in time, so
+    // `reference_peak - scan_peak` is a LOWER bound on the aggregate's own
+    // demand, which is the direction this assertion needs.
+    let reference = Fixture::build(
+        Arc::new(MemoryStore::new()),
+        &[(&tenant, &specs)],
+        spill_config(
+            scratch.path().to_path_buf(),
+            AMPLE_SCRATCH_BYTES,
+            AMPLE_QUERY_BYTES,
+        ),
+        1 << 40,
+    )
+    .await;
+    let reference_outcome = reference
+        .executor
+        .execute(tenant.hash(), &request(SPILLING_SQL))
+        .await
+        .expect("the reference run must complete under an ample budget");
+    assert_eq!(
+        reference_outcome.output.num_rows(),
+        LONG_ROWS as usize,
+        "the reference must produce one row per distinct ts group"
+    );
+    assert_eq!(
+        reference_outcome.stats.spill,
+        Default::default(),
+        "the reference must not spill, or its peak is not the query's whole \
+         demand; got {:?}",
+        reference_outcome.stats.spill
+    );
+    let reference_peak = reference_outcome.accounting.peak_intermediate_bytes;
+    let aggregate_demand = reference_peak.saturating_sub(scan_peak);
+    eprintln!(
+        "budget split: scan_peak={scan_peak} of budget={budget}, \
+         headroom={headroom}, reference_peak={reference_peak}, \
+         aggregate_demand_lower_bound={aggregate_demand}"
+    );
+    assert!(
+        aggregate_demand > headroom,
+        "the aggregate wants at least {aggregate_demand} bytes but the scan \
+         leaves it {headroom}: it must not fit, or it never reaches its spill \
+         threshold and this case would be measuring the scan's refusal"
+    );
 
     let err = fixture
         .executor
@@ -459,10 +642,33 @@ async fn an_eligible_aggregation_over_the_scratch_quota_is_spill_budget_exhauste
         .await
         .expect_err("the tiny scratch quota must trip");
 
+    // 3 and 4: the variant, and the figures behind it.
     assert!(
         matches!(err, SqlError::SpillBudgetExhausted(_)),
         "an over-quota spill must fail SpillBudgetExhausted, distinct from a \
-         memory-pool exhaustion; got {err:?}"
+         memory-pool exhaustion from the scan side; got {err:?}"
+    );
+    let (written, quota) = scratch_figures(&err);
+    eprintln!("scratch figures at the refusal: written={written} quota={quota}");
+    assert_eq!(
+        quota, TINY_SCRATCH_BYTES,
+        "the refusal must name this query's configured scratch quota"
+    );
+    assert!(
+        written > 0,
+        "the aggregate must have reached its spill threshold and written \
+         scratch before the quota refused it; {written} bytes written means the \
+         query failed without spilling at all"
+    );
+    // The gauge the figure comes from (`DiskManager::used_disk_space`) already
+    // includes the write that pushed the query past its ceiling, so the reported
+    // total is at or above the quota, never below it. Measured: 133,312 bytes of
+    // a 65,536-byte quota. Below the quota would mean the refusal came from
+    // something other than this ceiling.
+    assert!(
+        written >= quota,
+        "the refusal must report scratch at or above the quota it tripped; \
+         got {written} of {quota}"
     );
 
     // Requirement 7: a typed error cleans up its scratch too.
@@ -551,6 +757,159 @@ async fn an_ineligible_float_aggregation_over_budget_is_refused_and_never_spills
     assert!(
         spill_subdirs(scratch.path()).is_empty(),
         "an ineligible plan must never create a scratch subdirectory"
+    );
+}
+
+/// A memory budget no plan-shape test can exhaust: the two cases below only
+/// plan, they never drain a stream, so the budget must not be part of what they
+/// measure.
+const PLAN_SHAPE_QUERY_BYTES: usize = 1 << 30;
+
+/// The config for the two plan-shape cases: aggregate repartitioning armed
+/// (`parallel_final_aggregation`, ADR-0094) and the default multi-partition
+/// scan, so `EnforceDistribution` is free to insert a hash `RepartitionExec`.
+/// `spill` is the one variable between the control and the subject.
+fn parallel_config(spill: Option<SpillConfig>) -> SqlConfig {
+    SqlConfig {
+        // The default `fetch_concurrency` (8) becomes `target_partitions`, so
+        // there is more than one partition to repartition across. Pinning it to
+        // 1 the way `spill_config` does would make the control vacuous.
+        engine: util::engine_config(),
+        max_query_bytes: PLAN_SHAPE_QUERY_BYTES,
+        parallel_final_aggregation: true,
+        skip_partial_aggregation: true,
+        late_materialization_extra_columns: None,
+        spill,
+    }
+}
+
+/// The indented physical plan text for `sql`, planned through the real
+/// `plan_pinned` path so the session it is planned in is the one the executor
+/// built (spill decision, repartition knob, and all).
+async fn physical_plan_text(
+    fixture: &Fixture,
+    tenant: &ravel_types::TenantId,
+    sql: &str,
+) -> String {
+    let accounting = QueryAccounting::new();
+    let snapshot = fixture.snapshot(tenant).await;
+    let plan = fixture
+        .executor
+        .plan_pinned(tenant.hash(), snapshot, sql, &accounting, &[])
+        .await
+        .expect("the query plans")
+        .create_physical_plan()
+        .await
+        .expect("the physical plan builds");
+    format!(
+        "{}",
+        datafusion::physical_plan::displayable(plan.as_ref()).indent(false)
+    )
+}
+
+/// ADR-0954's fail-closed argument, closed over the physical plan: a query
+/// granted spill runs its final aggregation single-partitioned, so the
+/// `RepartitionExec` that `parallel_final_aggregation` would otherwise
+/// introduce is never in a plan whose disk manager is enabled.
+///
+/// This matters because the two permissions have different scopes. Eligibility
+/// is decided by a predicate over the LOGICAL plan
+/// (`plan_is_spill_eligible`, an allowlist of logical nodes), but the disk
+/// manager it arms belongs to the session: every operator in the physical plan
+/// may then spill. `RepartitionExec` spills in DataFusion 54 -- its output
+/// channels fall back to a `SpillPool` when the pool refuses their reservation,
+/// which is where the `SpillPool (DiskManager is disabled)` message in
+/// `tests/memory_pool_attribution.rs` comes from -- and no predicate in this
+/// crate has classified an exchange spill's exactness.
+///
+/// The control half of the test is what makes it non-vacuous: the same
+/// statement, the same fixture, the same `parallel_final_aggregation`, spill
+/// off, DOES get the hash repartition and a `FinalPartitioned` aggregate.
+#[tokio::test]
+async fn a_spill_enabled_query_gets_no_unclassified_repartition_exec() {
+    let tenant = tenant_id("acme");
+    // Two segments is enough: this case reads plan shape, not data.
+    let specs = overlapping_series_specs(SEG_ROWS * 2, SEG_ROWS);
+    let scratch = tempfile::tempdir().expect("scratch root");
+
+    // Control: spill off. The statement is exact-typed (integer `count`, a
+    // non-float `ts` key), so the aggregate repartition fires.
+    let control = Fixture::build(
+        Arc::new(MemoryStore::new()),
+        &[(&tenant, &specs)],
+        parallel_config(None),
+        1 << 40,
+    )
+    .await;
+    let control_plan = physical_plan_text(&control, &tenant, SPILLING_SQL).await;
+    assert!(
+        control_plan.contains("RepartitionExec: partitioning=Hash"),
+        "the control must repartition, else this test proves nothing about the \
+         spill grant; got:\n{control_plan}"
+    );
+    assert!(
+        control_plan.contains("AggregateExec: mode=FinalPartitioned"),
+        "the control's final aggregate must be the fanned-out one; got:\n{control_plan}"
+    );
+
+    // Subject: the identical statement with spill configured. Eligible, so the
+    // disk manager is enabled for the whole session.
+    let fixture = Fixture::build(
+        Arc::new(MemoryStore::new()),
+        &[(&tenant, &specs)],
+        parallel_config(Some(SpillConfig {
+            dir: scratch.path().to_path_buf(),
+            max_bytes: AMPLE_SCRATCH_BYTES,
+        })),
+        1 << 40,
+    )
+    .await;
+
+    let accounting = QueryAccounting::new();
+    let snapshot = fixture.snapshot(&tenant).await;
+    let pinned = fixture
+        .executor
+        .plan_pinned(tenant.hash(), snapshot, SPILLING_SQL, &accounting, &[])
+        .await
+        .expect("the eligible query plans");
+    // Spill really was granted: this is the case the finding is about, not a
+    // query that was refused spill and trivially has no repartition.
+    assert_eq!(
+        spill_subdirs(scratch.path()).len(),
+        1,
+        "the subject must have been granted spill (one scratch subdirectory)"
+    );
+
+    let plan = pinned
+        .create_physical_plan()
+        .await
+        .expect("the physical plan builds");
+    let text = format!(
+        "{}",
+        datafusion::physical_plan::displayable(plan.as_ref()).indent(false)
+    );
+    assert!(
+        !text.contains("RepartitionExec"),
+        "a spill-enabled plan must contain no RepartitionExec: the eligibility \
+         predicate classified logical nodes, and an enabled disk manager would \
+         grant spill to this unclassified exchange too; got:\n{text}"
+    );
+    assert!(
+        !text.contains("FinalPartitioned"),
+        "a spill-enabled plan must keep the single-partition final aggregate; \
+         got:\n{text}"
+    );
+    // The aggregate that spill exists for is still there and still able to
+    // spill. `mode=Single` is a NON-partial aggregate mode, and DataFusion 54
+    // gives every non-partial mode with no group ordering
+    // `OutOfMemoryMode::Spill` once the disk manager is enabled
+    // (`aggregates/row_hash.rs`); it is `mode=Partial` that emits early instead
+    // of spilling. So dropping the exchange costs parallelism, not the spill.
+    assert!(
+        text.contains("AggregateExec: mode=Single"),
+        "the spill-enabled plan must still carry the grouped aggregate as a \
+         single-partition (non-partial) stage, which is the mode that spills; \
+         got:\n{text}"
     );
 }
 

--- a/services/ravel-server/src/query.rs
+++ b/services/ravel-server/src/query.rs
@@ -294,7 +294,14 @@ pub fn build_sql_state(
         // is an in-process escape hatch and the regression fixture's red side,
         // not a server-level knob.
         late_materialization_extra_columns: SqlConfig::default().late_materialization_extra_columns,
-    };
+        // ADR-0954: bounded ephemeral spill is off by default (requirement 9's
+        // no-spill deployment profile). `with_spill_from_env` below fills this
+        // from `RAVEL_SQL_SPILL_DIR`/`RAVEL_SQL_SPILL_MAX_BYTES` when both are
+        // set, so a deployment can arm spill without a code change; unset leaves
+        // it `None` and the memory budget refuses as before.
+        spill: None,
+    }
+    .with_spill_from_env()?;
     let max_deadline = config.engine.deadline;
     let mut metrics_fetcher = SegmentFetcher::new(store.clone());
     // ADR-0107's read-shape crossover, from `--logs-block-range-threshold` via


### PR DESCRIPTION
feat(ravel-sql): bounded ephemeral spill for exactness-eligible operators

ADR-0954. Exact aggregation over a high-cardinality grouping key can need
more memory than any budget a query is allowed to hold, so the engine
refuses the statement rather than returning an approximate answer.
ClickBench q33 is the worked example: it produces 99,997,493 groups from
99,997,497 rows, one group per row, so raising the memory budget
postpones the refusal rather than removing it.

Add an opt-in bounded ephemeral spill for operators whose exactness does
not depend on staying resident. Spill files are scratch only: object
storage remains the sole durable backend, no durability or query
correctness depends on a spill file surviving, and no process reads
another process's spill state. The budget is bounded and enforced, so a
runaway operator returns SpillBudgetExhausted instead of filling the
disk, and SpillUnavailable reports a spill directory that cannot be used.

Spill stays OFF by default: DiskManagerMode::Disabled remains the default
posture. This adds a mode, it does not remove the disabled one.

Refs: #837
