### PR TITLE
fix(scripts): reclaim rebase-merged worktrees in disk-reap

### DIFF
--- a/scripts/disk-reap.sh
+++ b/scripts/disk-reap.sh
@@ -36,7 +36,9 @@
 #   DISK_REAP_TMP_ROOTS   space-separated roots to scan for orphaned targets
 #   DISK_REAP_BUILD_STATE force the build-activity probe to `idle` or `busy`
 #                         so both branches of the orphaned-target scan are
-#                         testable; unset runs the real probe
+#                         testable. Honoured ONLY when DISK_REAP_REPO_ROOT is
+#                         set as well, so it cannot disable a safety check on
+#                         a real run; unset runs the real probe
 set -uo pipefail
 
 apply=0
@@ -238,11 +240,34 @@ done <"${cand_file}"
 # scan never runs, and a test asserting a reap fails for a reason that has
 # nothing to do with the code under test.
 build_is_running() {
-  case "${DISK_REAP_BUILD_STATE:-}" in
-  idle) return 1 ;;
-  busy) return 0 ;;
-  *) pgrep -x cargo >/dev/null 2>&1 || pgrep -x rustc >/dev/null 2>&1 ;;
-  esac
+  # The forced state is honoured only when DISK_REAP_REPO_ROOT is set too, so
+  # it cannot bypass the probe on a real run: that variable is what points the
+  # script at a throwaway test repo in the first place.
+  if [[ -n "${DISK_REAP_REPO_ROOT:-}" ]]; then
+    case "${DISK_REAP_BUILD_STATE:-}" in
+    idle) return 1 ;;
+    busy) return 0 ;;
+    esac
+  fi
+  # pgrep exits 0 when it matches, 1 when it does not, and something else when
+  # the probe itself failed (127 when pgrep is not installed, for one). Only
+  # exit 1 means "no build running". Anything else means the probe is unusable,
+  # and an unusable probe must not read as permission to delete a target dir a
+  # live build may be writing to.
+  local probe rc
+  for probe in cargo rustc; do
+    rc=0
+    pgrep -x "${probe}" >/dev/null 2>&1 || rc=$?
+    case "${rc}" in
+    0) return 0 ;;
+    1) ;;
+    *)
+      echo "warn: pgrep ${probe} exited ${rc}; assuming a build is running" >&2
+      return 0
+      ;;
+    esac
+  done
+  return 1
 }
 
 echo "==> orphaned cargo target dirs"
@@ -259,8 +284,17 @@ else
     find "${root}" -maxdepth 1 -type d -name 'wt-*-target' -mmin +120 2>/dev/null >>"${target_file}"
     find "${root}" -maxdepth 6 -type d -name target -path '*claude-*' -mmin +120 2>/dev/null >>"${target_file}"
   done
+  # Re-check before each removal, not once for the whole list. The find scan
+  # and the removals are not instantaneous, and a build starting in between
+  # would otherwise have its cache deleted out from under it by a decision
+  # taken before it existed. pgrep is cheap next to an rm -rf of a target dir.
   while read -r d; do
     [[ -n "${d}" && -d "${d}" ]] || continue
+    if build_is_running; then
+      echo "skip (a build started during the scan): ${d}"
+      skipped_count=$((skipped_count + 1))
+      continue
+    fi
     kb="$(dir_kb "${d}")"
     echo "reap ($(human_kb "${kb}")): ${d}"
     act rm -rf "${d}"

--- a/scripts/disk-reap.sh
+++ b/scripts/disk-reap.sh
@@ -11,23 +11,42 @@
 #   scripts/disk-reap.sh -y     # apply
 #
 # What it reaps:
-#   1. Worktrees of this repo that are clean and fully merged
-#      (HEAD is an ancestor of origin/main). Locked worktrees are skipped
-#      and reported, never removed.
-#   2. Orphaned cargo target dirs matching /tmp/wt-*-target and
-#      target/ dirs under /private/tmp/claude-*, when no cargo or rustc
-#      process is running. A live build skips this class entirely.
+#   1. Worktrees of this repo that are clean and provably landed on
+#      origin/main. `main` is protected and merged with REBASE-merge, so a
+#      landed branch's commits are rewritten and its HEAD is never an
+#      ancestor of origin/main. Ancestry is therefore only one of the ways a
+#      worktree can qualify; patch equivalence (`git cherry`) is the one that
+#      actually fires on this repo. Locked worktrees are skipped and
+#      reported, never removed.
+#   2. Orphaned cargo target dirs matching wt-*-target and target/ dirs under
+#      claude-* scratchpads, when no cargo or rustc process is running. A live
+#      build skips this class entirely.
 #
-# Never reaps: the primary checkout, dirty or unmerged worktrees, locked
-# worktrees, anything while cargo/rustc runs.
-set -euo pipefail
+# Never reaps: the primary checkout, dirty worktrees, worktrees carrying any
+# commit not already on origin/main, worktrees with an operation in progress,
+# locked worktrees, anything while cargo/rustc runs.
+#
+# Fail closed: deleting an unmerged worktree destroys work that exists
+# nowhere else, which is far worse than failing to reclaim disk. Every branch
+# below that cannot positively prove a worktree is reclaimable skips it and
+# says why.
+#
+# Test hooks (used only by scripts/disk-reap.test.sh, never in normal runs):
+#   DISK_REAP_REPO_ROOT  operate on this repo instead of the script's own
+#   DISK_REAP_TMP_ROOTS  space-separated roots to scan for orphaned targets
+set -uo pipefail
 
 apply=0
 if [[ "${1:-}" == "-y" ]]; then
   apply=1
 fi
 
-repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+repo_root="${DISK_REAP_REPO_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+tmp_roots="${DISK_REAP_TMP_ROOTS:-/tmp /private/tmp}"
+
+reclaimed_kb=0
+reaped_count=0
+skipped_count=0
 
 act() {
   if [[ ${apply} -eq 1 ]]; then
@@ -37,37 +56,114 @@ act() {
   fi
 }
 
+# Size of a directory in KiB, 0 when it cannot be measured. Always taken
+# before the removal: after it there is nothing left to measure.
+dir_kb() {
+  local d="$1" out
+  out="$(du -sk "${d}" 2>/dev/null | awk 'NR==1 {print $1}')"
+  case "${out}" in
+    ''|*[!0-9]*) echo 0 ;;
+    *) echo "${out}" ;;
+  esac
+}
+
+human_kb() {
+  local kb="$1"
+  awk -v kb="${kb}" 'BEGIN {
+    if (kb >= 1048576) printf "%.1f GiB", kb / 1048576
+    else if (kb >= 1024) printf "%.1f MiB", kb / 1024
+    else printf "%d KiB", kb
+  }'
+}
+
+note_reaped() { # note_reaped <kb>
+  reclaimed_kb=$((reclaimed_kb + $1))
+  reaped_count=$((reaped_count + 1))
+}
+
+# An operation in progress leaves state that `status --porcelain` can report
+# as clean while a half-finished rebase or merge still holds the only copy of
+# a conflict resolution.
+operation_in_progress() { # operation_in_progress <worktree>
+  local wt="$1" p
+  for p in rebase-merge rebase-apply MERGE_HEAD CHERRY_PICK_HEAD REVERT_HEAD BISECT_LOG; do
+    local resolved
+    resolved="$(git -C "${wt}" rev-parse --git-path "${p}" 2>/dev/null || true)"
+    if [[ -n "${resolved}" && -e "${wt}/${resolved}" ]] || [[ -n "${resolved}" && -e "${resolved}" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# The merged test that survives a sha change.
+#
+# `git cherry <upstream> <head>` lists each commit reachable from <head> but
+# not from <upstream>, prefixed `-` when an equivalent patch (same patch-id)
+# is already upstream and `+` when it is not. A rebase-merge rewrites commit
+# shas but replays the same patches, so every landed commit comes back `-`.
+# Empty output means <head> has no commits of its own at all.
+#
+# Reclaimable means: no `+` lines. Any `+` is a commit whose content is not
+# on origin/main, so the worktree may hold the only copy and is skipped.
+#
+# Merge commits are excluded from `git cherry`'s view, so a merge commit
+# carrying content of its own would not be reported. The caller refuses any
+# worktree with a merge commit in the range rather than reasoning about it.
+patch_equivalent() { # patch_equivalent <head-sha>
+  local head="$1" out
+  out="$(git -C "${repo_root}" cherry "${main_sha}" "${head}" 2>/dev/null)" || return 1
+  printf '%s\n' "${out}" | grep -q '^+' && return 1
+  return 0
+}
+
+has_merge_commits() { # has_merge_commits <head-sha>
+  local head="$1" out
+  out="$(git -C "${repo_root}" rev-list --merges "${main_sha}..${head}" 2>/dev/null)" || return 0
+  [[ -n "${out}" ]]
+}
+
 echo "==> free space before"
 df -h / | tail -1
 
 echo "==> pruning worktree records for deleted directories"
 act git -C "${repo_root}" worktree prune
 
-git -C "${repo_root}" fetch origin main --quiet || true
-main_sha="$(git -C "${repo_root}" rev-parse origin/main)"
+git -C "${repo_root}" fetch origin main --quiet 2>/dev/null || true
+# --verify --quiet, not a bare rev-parse: a bare `rev-parse origin/main` echoes
+# the string "origin/main" on stdout when the ref does not exist, which reads as
+# a resolved sha to every check below.
+main_sha="$(git -C "${repo_root}" rev-parse --verify --quiet origin/main^{commit} 2>/dev/null || true)"
+if [[ ! "${main_sha}" =~ ^[0-9a-f]{40,64}$ ]]; then
+  echo "FATAL: cannot resolve origin/main; refusing to judge any worktree" >&2
+  exit 1
+fi
 # The primary checkout is never a candidate, whatever its state. (git
 # refuses to remove a main working tree, but do not rely on that.)
 main_wt="$(dirname "$(git -C "${repo_root}" rev-parse --path-format=absolute --git-common-dir)")"
-# owner/name for the PR-state fallback below, derived from the remote rather
-# than hardcoded. Empty is fine: the fallback treats an unresolvable repo the
-# same as an absent gh and keeps the conservative skip.
-gh_repo="$(git -C "${repo_root}" remote get-url origin 2>/dev/null |
-  sed -E 's#^(https://[^/]+/|git@[^:]+:)##; s#\.git$##')"
 
-echo "==> merged, clean worktrees"
-# Parse `worktree list --porcelain` blocks; macOS ships bash 3.2, so no
-# associative arrays here.
+echo "==> landed, clean worktrees"
+# Parse `worktree list --porcelain` blocks into a file first: piping straight
+# into the loop would put the accumulators in a subshell and lose the
+# reclaimed byte total, which is the number this run has to report.
+# macOS ships bash 3.2, so no associative arrays here.
+cand_file="$(mktemp)"
+trap 'rm -f "${cand_file}"' EXIT
 git -C "${repo_root}" worktree list --porcelain | awk '
   /^worktree / { wt = substr($0, 10) }
   /^locked/    { print "LOCKED\t" wt; wt = "" }
   /^$/         { if (wt != "") print "CAND\t" wt; wt = "" }
   END          { if (wt != "") print "CAND\t" wt }
-' | while IFS=$'\t' read -r kind wt; do
+' >"${cand_file}"
+
+while IFS=$'\t' read -r kind wt; do
+  [[ -n "${wt}" ]] || continue
   if [[ "${wt}" == "${repo_root}" || "${wt}" == "${main_wt}" ]]; then
     continue
   fi
   if [[ "${kind}" == "LOCKED" ]]; then
     echo "skip (locked): ${wt}"
+    skipped_count=$((skipped_count + 1))
     continue
   fi
   if [[ ! -d "${wt}" ]]; then
@@ -75,84 +171,81 @@ git -C "${repo_root}" worktree list --porcelain | awk '
   fi
   if [[ -n "$(git -C "${wt}" status --porcelain 2>/dev/null)" ]]; then
     echo "skip (dirty): ${wt}"
+    skipped_count=$((skipped_count + 1))
     continue
   fi
-  head_sha="$(git -C "${wt}" rev-parse HEAD 2>/dev/null || true)"
-  if [[ -z "${head_sha}" ]]; then
+  if operation_in_progress "${wt}"; then
+    echo "skip (rebase/merge in progress): ${wt}"
+    skipped_count=$((skipped_count + 1))
+    continue
+  fi
+  head_sha="$(git -C "${wt}" rev-parse --verify --quiet HEAD 2>/dev/null || true)"
+  if [[ ! "${head_sha}" =~ ^[0-9a-f]{40,64}$ ]]; then
     echo "skip (no HEAD): ${wt}"
+    skipped_count=$((skipped_count + 1))
     continue
   fi
-  if git -C "${repo_root}" merge-base --is-ancestor "${head_sha}" "${main_sha}"; then
+  if has_merge_commits "${head_sha}"; then
+    echo "skip (merge commit not on origin/main, cannot prove its content landed): ${wt}"
+    skipped_count=$((skipped_count + 1))
+    continue
+  fi
+  if patch_equivalent "${head_sha}"; then # PROVE-FLIP: ancestry-only regression
+    kb="$(dir_kb "${wt}")"
+    echo "reap ($(human_kb "${kb}"), every commit already on origin/main): ${wt}"
     act git -C "${repo_root}" worktree remove --force "${wt}"
+    note_reaped "${kb}"
     continue
   fi
-  # Ancestry is necessary but not sufficient on this repo: `main` is
-  # protected and merges are REBASE-only, so a merged branch's commits are
-  # rewritten and its HEAD is never an ancestor of main. Ancestry alone
-  # therefore refuses every merged worktree forever -- six were sitting in
-  # that state, all with merged PRs, and this script would never have
-  # touched any of them.
-  #
-  # So fall back to the PR state, which is the authoritative signal for
-  # "has this landed". Two conditions, both required, because a merged PR
-  # does not by itself mean the worktree is disposable:
-  #   - a PR whose head is this branch is MERGED, and
-  #   - the worktree's HEAD is still exactly that PR's head commit, so any
-  #     commit added after the merge blocks the reap rather than being
-  #     silently discarded.
-  # Any uncertainty (no gh, not authenticated, no PR, a mismatched sha)
-  # keeps the old conservative skip: this script must never be the reason
-  # work disappears.
-  branch="$(git -C "${wt}" symbolic-ref --quiet --short HEAD 2>/dev/null || true)"
-  if [[ -z "${branch}" ]]; then
-    echo "skip (detached, not an ancestor of main): ${wt}"
-    continue
-  fi
-  if ! command -v gh >/dev/null 2>&1; then
-    echo "skip (not an ancestor of main; gh absent, cannot check PR state): ${wt}"
-    continue
-  fi
-  pr_head=""
-  pr_num=""
-  pr_line="$(gh pr list --repo "${gh_repo}" --head "${branch}" --state merged \
-    --limit 1 --json number,headRefOid \
-    --jq '.[0] | select(.number) | "\(.number)\t\(.headRefOid)"' 2>/dev/null || true)"
-  if [[ -n "${pr_line}" ]]; then
-    pr_num="${pr_line%%$'\t'*}"
-    pr_head="${pr_line##*$'\t'}"
-  fi
-  if [[ -z "${pr_num}" ]]; then
-    echo "skip (not an ancestor of main, no merged PR for ${branch}): ${wt}"
-    continue
-  fi
-  if [[ "${pr_head}" != "${head_sha}" ]]; then
-    echo "skip (PR #${pr_num} merged but ${wt} has moved past its head): ${wt}"
-    continue
-  fi
-  echo "reap (PR #${pr_num} merged, rebase-merged so not an ancestor): ${wt}"
-  act git -C "${repo_root}" worktree remove --force "${wt}"
-done
+  unlanded="$(git -C "${repo_root}" cherry "${main_sha}" "${head_sha}" 2>/dev/null |
+    grep -c '^+' || true)"
+  echo "skip (${unlanded:-?} commit(s) not on origin/main): ${wt}"
+  skipped_count=$((skipped_count + 1))
+done <"${cand_file}"
 
 echo "==> orphaned cargo target dirs"
 if pgrep -x cargo >/dev/null 2>&1 || pgrep -x rustc >/dev/null 2>&1; then
   echo "skip (cargo or rustc is running): target dirs left alone"
 else
   # Both patterns come from real incidents: land worktrees write
-  # /tmp/wt-<name>-land-target, and session scratchpads accumulate
-  # target/ dirs after their worktrees are gone. Only dirs idle for
-  # more than 2 hours are candidates.
-  find /tmp -maxdepth 1 -type d -name 'wt-*-target' -mmin +120 2>/dev/null \
-    | while read -r d; do
-        act rm -rf "${d}"
-      done
-  find /private/tmp -maxdepth 6 -type d -name target -path '*claude-*' -mmin +120 2>/dev/null \
-    | while read -r d; do
-        act rm -rf "${d}"
-      done
+  # wt-<name>-land-target, and session scratchpads accumulate target/ dirs
+  # after their worktrees are gone. Only dirs idle for more than 2 hours are
+  # candidates.
+  target_file="$(mktemp)"
+  for root in ${tmp_roots}; do
+    [[ -d "${root}" ]] || continue
+    find "${root}" -maxdepth 1 -type d -name 'wt-*-target' -mmin +120 2>/dev/null >>"${target_file}"
+    find "${root}" -maxdepth 6 -type d -name target -path '*claude-*' -mmin +120 2>/dev/null >>"${target_file}"
+  done
+  while read -r d; do
+    [[ -n "${d}" && -d "${d}" ]] || continue
+    kb="$(dir_kb "${d}")"
+    echo "reap ($(human_kb "${kb}")): ${d}"
+    act rm -rf "${d}"
+    note_reaped "${kb}"
+  done <"${target_file}"
+  rm -f "${target_file}"
 fi
 
 echo "==> free space after"
 df -h / | tail -1
-if [[ ${apply} -eq 0 ]]; then
+
+# The failure this reporting exists for: a run that skipped 70 worktrees and
+# freed nothing still printed a tidy summary and read as success. State the
+# number, and state a zero as a zero.
+if [[ ${apply} -eq 1 ]]; then
+  if [[ ${reaped_count} -eq 0 && ${skipped_count} -eq 0 ]]; then
+    echo "RECLAIMED NOTHING: there was nothing to reap."
+  elif [[ ${reaped_count} -eq 0 ]]; then
+    echo "RECLAIMED NOTHING: 0 of ${skipped_count} candidate(s) removed; every one was skipped for the reason printed above."
+  else
+    echo "RECLAIMED: $(human_kb "${reclaimed_kb}") from ${reaped_count} dir(s); ${skipped_count} skipped."
+  fi
+else
+  if [[ ${reaped_count} -eq 0 ]]; then
+    echo "WOULD RECLAIM NOTHING: 0 of ${skipped_count} candidate(s) are reclaimable."
+  else
+    echo "WOULD RECLAIM: $(human_kb "${reclaimed_kb}") from ${reaped_count} dir(s); ${skipped_count} skipped."
+  fi
   echo "Dry run only. Re-run with -y to apply."
 fi

--- a/scripts/disk-reap.sh
+++ b/scripts/disk-reap.sh
@@ -140,7 +140,18 @@ if [[ ! "${main_sha}" =~ ^[0-9a-f]{40,64}$ ]]; then
 fi
 # The primary checkout is never a candidate, whatever its state. (git
 # refuses to remove a main working tree, but do not rely on that.)
-main_wt="$(dirname "$(git -C "${repo_root}" rev-parse --path-format=absolute --git-common-dir)")"
+#
+# Validate the result before trusting it as a guard. If the rev-parse fails,
+# `dirname` of an empty string is ".", which matches no worktree path, so the
+# guard would silently stop guarding while every message still looked normal.
+# This script deletes directories, so an unverifiable guard is a stop, not a
+# warning.
+main_common_dir="$(git -C "${repo_root}" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
+main_wt="$(dirname "${main_common_dir}")"
+if [[ -z "${main_common_dir}" || "${main_wt}" != /* || ! -d "${main_wt}" ]]; then
+  echo "FATAL: cannot resolve the primary checkout path; refusing to remove anything" >&2
+  exit 1
+fi
 
 echo "==> landed, clean worktrees"
 # Parse `worktree list --porcelain` blocks into a file first: piping straight
@@ -148,7 +159,10 @@ echo "==> landed, clean worktrees"
 # reclaimed byte total, which is the number this run has to report.
 # macOS ships bash 3.2, so no associative arrays here.
 cand_file="$(mktemp)"
-trap 'rm -f "${cand_file}"' EXIT
+# target_file is created later, in the orphaned-target section. Name it in the
+# trap now so an early exit between here and there cannot leak it.
+target_file=""
+trap 'rm -f "${cand_file}" "${target_file}"' EXIT
 git -C "${repo_root}" worktree list --porcelain | awk '
   /^worktree / { wt = substr($0, 10) }
   /^locked/    { print "LOCKED\t" wt; wt = "" }
@@ -197,9 +211,20 @@ while IFS=$'\t' read -r kind wt; do
     note_reaped "${kb}"
     continue
   fi
-  unlanded="$(git -C "${repo_root}" cherry "${main_sha}" "${head_sha}" 2>/dev/null |
-    grep -c '^+' || true)"
-  echo "skip (${unlanded:-?} commit(s) not on origin/main): ${wt}"
+  # Report the real reason. `git cherry` failing produces no output, which
+  # `grep -c` turns into 0, so the old message read "0 commit(s) not on
+  # origin/main" -- a count that means the opposite of what it says. The
+  # outcome is a skip either way (fail closed), but a wrong reason sends the
+  # next reader looking in the wrong place.
+  cherry_out=""
+  cherry_rc=0
+  cherry_out="$(git -C "${repo_root}" cherry "${main_sha}" "${head_sha}" 2>&1)" || cherry_rc=$?
+  if [[ "${cherry_rc}" -ne 0 ]]; then
+    echo "skip (cannot compare against origin/main, git cherry exited ${cherry_rc}): ${wt}"
+  else
+    unlanded="$(printf '%s\n' "${cherry_out}" | grep -c '^+' || true)"
+    echo "skip (${unlanded} commit(s) not on origin/main): ${wt}"
+  fi
   skipped_count=$((skipped_count + 1))
 done <"${cand_file}"
 

--- a/scripts/disk-reap.sh
+++ b/scripts/disk-reap.sh
@@ -32,8 +32,11 @@
 # says why.
 #
 # Test hooks (used only by scripts/disk-reap.test.sh, never in normal runs):
-#   DISK_REAP_REPO_ROOT  operate on this repo instead of the script's own
-#   DISK_REAP_TMP_ROOTS  space-separated roots to scan for orphaned targets
+#   DISK_REAP_REPO_ROOT   operate on this repo instead of the script's own
+#   DISK_REAP_TMP_ROOTS   space-separated roots to scan for orphaned targets
+#   DISK_REAP_BUILD_STATE force the build-activity probe to `idle` or `busy`
+#                         so both branches of the orphaned-target scan are
+#                         testable; unset runs the real probe
 set -uo pipefail
 
 apply=0
@@ -228,8 +231,22 @@ while IFS=$'\t' read -r kind wt; do
   skipped_count=$((skipped_count + 1))
 done <"${cand_file}"
 
+# Whether a build is running. Reaping a target dir out from under a live
+# cargo would destroy that build's cache mid-run, so the scan is skipped
+# entirely while one is active. Wrapped in a function with a forced-state
+# override because otherwise neither branch is testable: on a busy machine the
+# scan never runs, and a test asserting a reap fails for a reason that has
+# nothing to do with the code under test.
+build_is_running() {
+  case "${DISK_REAP_BUILD_STATE:-}" in
+  idle) return 1 ;;
+  busy) return 0 ;;
+  *) pgrep -x cargo >/dev/null 2>&1 || pgrep -x rustc >/dev/null 2>&1 ;;
+  esac
+}
+
 echo "==> orphaned cargo target dirs"
-if pgrep -x cargo >/dev/null 2>&1 || pgrep -x rustc >/dev/null 2>&1; then
+if build_is_running; then
   echo "skip (cargo or rustc is running): target dirs left alone"
 else
   # Both patterns come from real incidents: land worktrees write

--- a/scripts/disk-reap.test.sh
+++ b/scripts/disk-reap.test.sh
@@ -313,7 +313,8 @@ mkdir -p "$fakebin"
 printf '#!/bin/sh\nexit 2\n' >"$fakebin/pgrep"
 chmod +x "$fakebin/pgrep"
 
-out11="$(PATH="$fakebin:$PATH" DISK_REAP_TMP_ROOTS="$base11/scratch" \
+out11="$(PATH="$fakebin:$PATH" DISK_REAP_REPO_ROOT="$base11/repo" \
+  DISK_REAP_TMP_ROOTS="$base11/scratch" \
   bash "$SCRIPT" -y 2>&1)"
 if [ -d "$probe_target" ] && case "$out11" in *"assuming a build is running"*) true ;; *) false ;; esac; then
   pass "a failing pgrep probe is treated as a running build"
@@ -330,11 +331,19 @@ mkdir -p "$override_target"
 echo stale >"$override_target/blob"
 touch -t 202001010000 "$override_target/blob" "$override_target"
 
-# DISK_REAP_BUILD_STATE=idle WITHOUT DISK_REAP_REPO_ROOT: the real probe runs.
-# A broken pgrep alongside it must still win, proving the override was ignored.
+# DISK_REAP_BUILD_STATE=idle WITHOUT DISK_REAP_REPO_ROOT: the real probe runs,
+# and a broken pgrep alongside it must still win.
+#
+# This case cannot set DISK_REAP_REPO_ROOT -- its whole point is the absence of
+# that hook -- so the script would operate on the REAL repository. It therefore
+# runs WITHOUT -y and asserts on the output: a dry run enumerates and reports
+# but removes nothing. Asserting "the directory survives" would be vacuous here
+# for the same reason, so the assertion is that the scan was skipped and no
+# reap line was printed for this path.
 out12="$(PATH="$fakebin:$PATH" DISK_REAP_BUILD_STATE=idle \
-  DISK_REAP_TMP_ROOTS="$base12/scratch" bash "$SCRIPT" -y 2>&1)"
-if [ -d "$override_target" ]; then
+  DISK_REAP_TMP_ROOTS="$base12/scratch" bash "$SCRIPT" 2>&1)"
+if case "$out12" in *"assuming a build is running"*) true ;; *) false ;; esac &&
+  case "$out12" in *"reap"*"$override_target"*) false ;; *) true ;; esac; then
   pass "forced build state is ignored without the repo-root test hook"
 else
   fail "forced build state is ignored without the repo-root test hook" "override bypassed the probe"

--- a/scripts/disk-reap.test.sh
+++ b/scripts/disk-reap.test.sh
@@ -245,6 +245,34 @@ else
   printf '%s\n' "$out8" | sed 's/^/    /'
 fi
 
+# Orphaned cargo target dirs: an idle one is reaped, a fresh one is not.
+# The age rule matters as much as the pattern -- reaping a target dir a live
+# build is still writing to would destroy that build's cache mid-run, which is
+# why the script requires 2 hours of idleness.
+base9="$(new_repo case9)"
+old_target="$base9/scratch/wt-stale-target"
+new_target="$base9/scratch/wt-fresh-target"
+mkdir -p "$old_target" "$new_target"
+echo stale >"$old_target/blob"
+echo fresh >"$new_target/blob"
+# Backdate the stale one well past the 120-minute floor. touch -t is the form
+# both GNU and BSD touch accept.
+touch -t 202001010000 "$old_target/blob" "$old_target"
+
+out9="$(run_reap "$base9")"
+if [ ! -d "$old_target" ]; then
+  pass "idle orphaned target dir is reaped"
+else
+  fail "idle orphaned target dir is reaped" "stale target dir survived"
+  printf '%s\n' "$out9" | sed 's/^/    /'
+fi
+if [ -d "$new_target" ]; then
+  pass "recently-touched target dir is left alone"
+else
+  fail "recently-touched target dir is left alone" "fresh target dir was deleted"
+  printf '%s\n' "$out9" | sed 's/^/    /'
+fi
+
 echo
 if [ "$fails" != 0 ]; then
   echo "$fails failing case(s)"

--- a/scripts/disk-reap.test.sh
+++ b/scripts/disk-reap.test.sh
@@ -42,7 +42,11 @@ new_repo() { # new_repo <case-name>
 run_reap() { # run_reap <base> [script-override]
   local base="$1"
   local script="${2:-$SCRIPT}"
+  # BUILD_STATE is forwarded explicitly rather than inherited: a `VAR=x
+  # run_reap ...` prefix sets a shell variable in this function, not an
+  # exported one, so it would never reach the child bash running the script.
   DISK_REAP_REPO_ROOT="$base/repo" DISK_REAP_TMP_ROOTS="$base/scratch" \
+    DISK_REAP_BUILD_STATE="${BUILD_STATE:-}" \
     bash "$script" -y 2>&1
 }
 
@@ -259,7 +263,10 @@ echo fresh >"$new_target/blob"
 # both GNU and BSD touch accept.
 touch -t 202001010000 "$old_target/blob" "$old_target"
 
-out9="$(run_reap "$base9")"
+# Force the build probe idle. Without this the case is flaky by construction:
+# the scan is skipped entirely while any cargo or rustc is running, so on a
+# busy machine this would fail for a reason unrelated to the code under test.
+out9="$(BUILD_STATE=idle run_reap "$base9")"
 if [ ! -d "$old_target" ]; then
   pass "idle orphaned target dir is reaped"
 else
@@ -271,6 +278,23 @@ if [ -d "$new_target" ]; then
 else
   fail "recently-touched target dir is left alone" "fresh target dir was deleted"
   printf '%s\n' "$out9" | sed 's/^/    /'
+fi
+
+# While a build is running, the orphaned-target scan does not run at all, even
+# for a dir old enough to qualify. This is the branch that protects a live
+# cargo's cache from being deleted mid-run, so it is asserted, not assumed.
+base10="$(new_repo case10)"
+busy_target="$base10/scratch/wt-stale-target"
+mkdir -p "$busy_target"
+echo stale >"$busy_target/blob"
+touch -t 202001010000 "$busy_target/blob" "$busy_target"
+
+out10="$(BUILD_STATE=busy run_reap "$base10")"
+if [ -d "$busy_target" ] && case "$out10" in *"cargo or rustc is running"*) true ;; *) false ;; esac; then
+  pass "a running build stops the target scan"
+else
+  fail "a running build stops the target scan" "target dir removed or no skip line"
+  printf '%s\n' "$out10" | sed 's/^/    /'
 fi
 
 echo

--- a/scripts/disk-reap.test.sh
+++ b/scripts/disk-reap.test.sh
@@ -297,6 +297,50 @@ else
   printf '%s\n' "$out10" | sed 's/^/    /'
 fi
 
+# A broken build probe must read as "a build is running", never as "idle".
+# pgrep exits 1 for no-match but something else when the probe itself failed
+# (127 when it is not installed). Treating that like no-match would delete a
+# target dir a live build may be writing to, on the strength of a check that
+# did not actually run.
+base11="$(new_repo case11)"
+probe_target="$base11/scratch/wt-stale-target"
+mkdir -p "$probe_target"
+echo stale >"$probe_target/blob"
+touch -t 202001010000 "$probe_target/blob" "$probe_target"
+
+fakebin="$base11/fakebin"
+mkdir -p "$fakebin"
+printf '#!/bin/sh\nexit 2\n' >"$fakebin/pgrep"
+chmod +x "$fakebin/pgrep"
+
+out11="$(PATH="$fakebin:$PATH" DISK_REAP_TMP_ROOTS="$base11/scratch" \
+  bash "$SCRIPT" -y 2>&1)"
+if [ -d "$probe_target" ] && case "$out11" in *"assuming a build is running"*) true ;; *) false ;; esac; then
+  pass "a failing pgrep probe is treated as a running build"
+else
+  fail "a failing pgrep probe is treated as a running build" "target dir removed or no warning"
+  printf '%s\n' "$out11" | sed 's/^/    /'
+fi
+
+# The forced build state must not be honoured on a real run: it is a test seam,
+# not a way to switch off a safety check in production.
+base12="$(new_repo case12)"
+override_target="$base12/scratch/wt-stale-target"
+mkdir -p "$override_target"
+echo stale >"$override_target/blob"
+touch -t 202001010000 "$override_target/blob" "$override_target"
+
+# DISK_REAP_BUILD_STATE=idle WITHOUT DISK_REAP_REPO_ROOT: the real probe runs.
+# A broken pgrep alongside it must still win, proving the override was ignored.
+out12="$(PATH="$fakebin:$PATH" DISK_REAP_BUILD_STATE=idle \
+  DISK_REAP_TMP_ROOTS="$base12/scratch" bash "$SCRIPT" -y 2>&1)"
+if [ -d "$override_target" ]; then
+  pass "forced build state is ignored without the repo-root test hook"
+else
+  fail "forced build state is ignored without the repo-root test hook" "override bypassed the probe"
+  printf '%s\n' "$out12" | sed 's/^/    /'
+fi
+
 echo
 if [ "$fails" != 0 ]; then
   echo "$fails failing case(s)"

--- a/scripts/disk-reap.test.sh
+++ b/scripts/disk-reap.test.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+# Cases for disk-reap.sh. Add a case here before changing a behaviour, the way
+# .claude/guards/pretooluse.test.sh works for the hook.
+#
+# SAFETY: every case builds a throwaway repo under its own mktemp -d and points
+# the script at it with DISK_REAP_REPO_ROOT. DISK_REAP_TMP_ROOTS is pinned to a
+# scratch dir inside the same temp tree, so the orphaned-target scan can never
+# see the real /tmp. Nothing here reads or writes the real checkout, the real
+# worktree list, or any path outside $TMP.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$HERE/disk-reap.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fails=0
+pass() { echo "ok   $1"; }
+fail() { echo "FAIL $1: $2"; fails=$((fails + 1)); }
+
+git_q() { git -c init.defaultBranch=main -c user.email=t@example.com -c user.name=Test "$@" >/dev/null 2>&1; }
+
+# Builds a fresh origin+clone pair and returns the clone path on stdout.
+# Layout: $TMP/<case>/origin (bare), $TMP/<case>/repo (primary checkout),
+# $TMP/<case>/wt (worktrees), $TMP/<case>/scratch (fake tmp roots).
+new_repo() { # new_repo <case-name>
+  local name="$1"
+  local base="$TMP/$name"
+  mkdir -p "$base/wt" "$base/scratch"
+  git_q init --bare "$base/origin"
+  git_q clone "$base/origin" "$base/repo"
+  git_q -C "$base/repo" config user.email t@example.com
+  git_q -C "$base/repo" config user.name Test
+  echo base >"$base/repo/base.txt"
+  git_q -C "$base/repo" add base.txt
+  git_q -C "$base/repo" commit -m "base"
+  git_q -C "$base/repo" push origin main
+  echo "$base"
+}
+
+# Runs the script against a case repo with -y and echoes its output.
+run_reap() { # run_reap <base> [script-override]
+  local base="$1"
+  local script="${2:-$SCRIPT}"
+  DISK_REAP_REPO_ROOT="$base/repo" DISK_REAP_TMP_ROOTS="$base/scratch" \
+    bash "$script" -y 2>&1
+}
+
+assert_gone() { # assert_gone <name> <dir> <output>
+  if [ -d "$2" ]; then
+    fail "$1" "worktree still present, should have been reclaimed"
+    printf '%s\n' "$3" | sed 's/^/    /'
+  else
+    pass "$1"
+  fi
+}
+
+assert_kept() { # assert_kept <name> <dir> <output> <want-substring>
+  if [ ! -d "$2" ]; then
+    fail "$1" "worktree was DELETED, should have been skipped"
+    printf '%s\n' "$3" | sed 's/^/    /'
+    return
+  fi
+  case "$3" in
+    *"$4"*) pass "$1" ;;
+    *)
+      fail "$1" "kept, but output missing '$4'"
+      printf '%s\n' "$3" | sed 's/^/    /'
+      ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# Case 1: a worktree whose commits landed via REBASE-merge.
+#
+# This is the bug. origin/main gained an unrelated commit and then a cherry-pick
+# of the branch commit: same patch, different sha, so the worktree's HEAD is NOT
+# an ancestor of origin/main. The old ancestry-only check refused it forever,
+# which is how wt-adr927 sat on 105 GB.
+# ---------------------------------------------------------------------------
+setup_rebase_merged() { # setup_rebase_merged <base>
+  local base="$1"
+  local repo="$base/repo"
+  git_q -C "$repo" checkout -b feature
+  echo feature >"$repo/feature.txt"
+  git_q -C "$repo" add feature.txt
+  git_q -C "$repo" commit -m "feat: add feature.txt"
+  local feature_sha
+  feature_sha="$(git -C "$repo" rev-parse HEAD)"
+  git_q -C "$repo" checkout main
+  # main moves on, so the branch cannot be replayed at the same sha.
+  echo other >"$repo/other.txt"
+  git_q -C "$repo" add other.txt
+  git_q -C "$repo" commit -m "chore: unrelated"
+  # The rebase-merge: same patch, new sha.
+  git_q -C "$repo" cherry-pick "$feature_sha"
+  git_q -C "$repo" push origin main
+  git_q -C "$repo" branch -D feature
+  # Fleet worktrees are detached, which is what short-circuited the old script
+  # before it ever reached its PR fallback.
+  git_q -C "$repo" worktree add --detach "$base/wt/wt-rebased" "$feature_sha"
+  echo "$base/wt/wt-rebased"
+}
+
+base1="$(new_repo case1)"
+wt1="$(setup_rebase_merged "$base1")"
+# Guard the fixture itself: if HEAD were an ancestor of main, the case would be
+# testing ordinary ancestry and would pass for the wrong reason.
+if git -C "$base1/repo" merge-base --is-ancestor \
+  "$(git -C "$wt1" rev-parse HEAD)" "$(git -C "$base1/repo" rev-parse origin/main)"; then
+  fail "fixture: rebase-merged HEAD is not an ancestor of main" "it is an ancestor"
+else
+  pass "fixture: rebase-merged HEAD is not an ancestor of main"
+fi
+out1="$(run_reap "$base1")"
+assert_gone "rebase-merged worktree is reclaimed" "$wt1" "$out1"
+case "$out1" in
+  *"RECLAIMED: "*) pass "a -y run that freed something prints the total" ;;
+  *)
+    fail "a -y run that freed something prints the total" "no RECLAIMED line"
+    printf '%s\n' "$out1" | sed 's/^/    /'
+    ;;
+esac
+
+# Proof that case 1 pins the fix rather than passing anyway: flip the single
+# reclaimability line (marked PROVE-FLIP in disk-reap.sh) to `if false`, which
+# leaves only the ancestry path, and the same fixture must now be kept.
+flipped="$TMP/disk-reap-ancestry-only.sh"
+sed 's/^  if patch_equivalent "${head_sha}"; then.*$/  if false; then/' "$SCRIPT" >"$flipped"
+chmod +x "$flipped"
+if grep -q '^  if false; then$' "$flipped"; then
+  pass "prove: PROVE-FLIP line found and flipped"
+else
+  fail "prove: PROVE-FLIP line found and flipped" "sed did not match the marked line"
+fi
+base1b="$(new_repo case1b)"
+wt1b="$(setup_rebase_merged "$base1b")"
+out1b="$(run_reap "$base1b" "$flipped")"
+assert_kept "prove: ancestry-only build fails this case" "$wt1b" "$out1b" "commit(s) not on origin/main"
+
+# ---------------------------------------------------------------------------
+# Case 2: genuinely unpushed, unmerged commits. Nothing on origin/main carries
+# this patch, so the worktree may hold the only copy.
+# ---------------------------------------------------------------------------
+base2="$(new_repo case2)"
+repo2="$base2/repo"
+git_q -C "$repo2" worktree add -b work "$base2/wt/wt-unmerged"
+git_q -C "$base2/wt/wt-unmerged" config user.email t@example.com
+git_q -C "$base2/wt/wt-unmerged" config user.name Test
+echo secret >"$base2/wt/wt-unmerged/only-here.txt"
+git_q -C "$base2/wt/wt-unmerged" add only-here.txt
+git_q -C "$base2/wt/wt-unmerged" commit -m "feat: work that exists nowhere else"
+out2="$(run_reap "$base2")"
+assert_kept "unmerged commits are not reclaimed" "$base2/wt/wt-unmerged" "$out2" \
+  "1 commit(s) not on origin/main"
+case "$out2" in
+  *"RECLAIMED NOTHING"*) pass "a run that freed nothing says so plainly" ;;
+  *)
+    fail "a run that freed nothing says so plainly" "no RECLAIMED NOTHING line"
+    printf '%s\n' "$out2" | sed 's/^/    /'
+    ;;
+esac
+
+# ---------------------------------------------------------------------------
+# Case 3: a dirty worktree. Its HEAD is landed (ancestor of main), so only the
+# dirty check can save it.
+# ---------------------------------------------------------------------------
+base3="$(new_repo case3)"
+git_q -C "$base3/repo" worktree add --detach "$base3/wt/wt-dirty" \
+  "$(git -C "$base3/repo" rev-parse origin/main)"
+echo "uncommitted edit" >>"$base3/wt/wt-dirty/base.txt"
+out3="$(run_reap "$base3")"
+assert_kept "dirty worktree is not reclaimed" "$base3/wt/wt-dirty" "$out3" "skip (dirty)"
+
+# Untracked-file dirt counts too: a scratch file nobody committed is still the
+# only copy of itself.
+base3b="$(new_repo case3b)"
+git_q -C "$base3b/repo" worktree add --detach "$base3b/wt/wt-untracked" \
+  "$(git -C "$base3b/repo" rev-parse origin/main)"
+echo notes >"$base3b/wt/wt-untracked/notes.md"
+out3b="$(run_reap "$base3b")"
+assert_kept "untracked files count as dirty" "$base3b/wt/wt-untracked" "$out3b" "skip (dirty)"
+
+# ---------------------------------------------------------------------------
+# Case 4: fast-forward merge, the case the ancestry check already handled. No
+# regression: still reclaimed.
+# ---------------------------------------------------------------------------
+base4="$(new_repo case4)"
+repo4="$base4/repo"
+git_q -C "$repo4" checkout -b ff
+echo ff >"$repo4/ff.txt"
+git_q -C "$repo4" add ff.txt
+git_q -C "$repo4" commit -m "feat: fast-forwarded"
+ff_sha="$(git -C "$repo4" rev-parse HEAD)"
+git_q -C "$repo4" push origin ff:main
+git_q -C "$repo4" checkout main
+git_q -C "$repo4" branch -D ff
+git_q -C "$repo4" worktree add --detach "$base4/wt/wt-ff" "$ff_sha"
+out4="$(run_reap "$base4")"
+assert_gone "fast-forward-merged worktree is still reclaimed" "$base4/wt/wt-ff" "$out4"
+
+# ---------------------------------------------------------------------------
+# Fail-closed extras.
+# ---------------------------------------------------------------------------
+# A locked worktree is never removed, landed or not.
+base5="$(new_repo case5)"
+git_q -C "$base5/repo" worktree add --detach "$base5/wt/wt-locked" \
+  "$(git -C "$base5/repo" rev-parse origin/main)"
+git_q -C "$base5/repo" worktree lock "$base5/wt/wt-locked"
+out5="$(run_reap "$base5")"
+assert_kept "locked worktree is not reclaimed" "$base5/wt/wt-locked" "$out5" "skip (locked)"
+
+# The primary checkout is never a candidate.
+base6="$(new_repo case6)"
+out6="$(run_reap "$base6")"
+if [ -d "$base6/repo" ] && [ -f "$base6/repo/base.txt" ]; then
+  pass "primary checkout is never touched"
+else
+  fail "primary checkout is never touched" "primary checkout damaged"
+  printf '%s\n' "$out6" | sed 's/^/    /'
+fi
+
+# An unresolvable origin/main means every judgement is unsound, so the script
+# must refuse rather than guess.
+base7="$(new_repo case7)"
+git_q -C "$base7/repo" update-ref -d refs/remotes/origin/main
+git_q -C "$base7/repo" remote remove origin
+rc7=0
+out7="$(DISK_REAP_REPO_ROOT="$base7/repo" DISK_REAP_TMP_ROOTS="$base7/scratch" bash "$SCRIPT" -y 2>&1)" || rc7=$?
+if [ "$rc7" != 0 ] && case "$out7" in *"cannot resolve origin/main"*) true ;; *) false ;; esac; then
+  pass "missing origin/main refuses to judge anything"
+else
+  fail "missing origin/main refuses to judge anything" "exit $rc7"
+  printf '%s\n' "$out7" | sed 's/^/    /'
+fi
+
+# Dry run must not delete a reclaimable worktree.
+base8="$(new_repo case8)"
+wt8="$(setup_rebase_merged "$base8")"
+out8="$(DISK_REAP_REPO_ROOT="$base8/repo" DISK_REAP_TMP_ROOTS="$base8/scratch" bash "$SCRIPT" 2>&1)"
+if [ -d "$wt8" ] && case "$out8" in *"WOULD RECLAIM"*) true ;; *) false ;; esac; then
+  pass "dry run reports without deleting"
+else
+  fail "dry run reports without deleting" "worktree gone or no WOULD RECLAIM line"
+  printf '%s\n' "$out8" | sed 's/^/    /'
+fi
+
+echo
+if [ "$fails" != 0 ]; then
+  echo "$fails failing case(s)"
+  exit 1
+fi
+echo "all cases passed"


### PR DESCRIPTION
fix(scripts): reclaim rebase-merged worktrees in disk-reap

`main` is protected and merged with rebase-merge, so a landed branch's
commits are replayed under new shas and its original HEAD is never an
ancestor of origin/main. disk-reap.sh judged merged-ness with
`git merge-base --is-ancestor` and, for anything detached, gave up
before its PR fallback:

    echo "skip (detached, not an ancestor of main): ${wt}"

Fleet result worktrees are detached, so that branch answered "not
merged" for essentially every worktree this repo produces. A run with
22 GiB free on a 460 GiB volume skipped more than 70 worktrees and
freed nothing while printing a tidy summary; one of them held 105 GB
of a commit that had already landed.

Judge landed-ness with `git cherry origin/main HEAD` instead. It
compares patch ids, so a rewritten sha still reports its commit as
already applied, and a worktree qualifies only when no commit comes
back with a `+` prefix. Ancestry is now the trivial case of that test
rather than the whole test.

The script still fails closed. Dirty worktrees, untracked files, an
operation in progress, a merge commit not on origin/main (which
`git cherry` does not examine), a locked worktree, an unresolvable
origin/main, and any commit whose patch is not upstream all skip with
the reason printed. Two rev-parse calls gained `--verify --quiet`,
because a bare `rev-parse origin/main` echoes the string "origin/main"
on stdout when the ref is missing, which read as a resolved sha to
every check downstream.

Reporting states the outcome as a number: every removal is measured
with du before it happens, and a run that reclaims nothing says
"RECLAIMED NOTHING" rather than ending on a clean-looking summary.

scripts/disk-reap.test.sh is new. Each case builds a throwaway repo
under mktemp and points the script at it with DISK_REAP_REPO_ROOT,
with DISK_REAP_TMP_ROOTS pinned inside the same temp tree so the
orphaned-target scan cannot see the real /tmp. It covers the
rebase-merge case, unpushed commits, a dirty worktree, untracked
files, a fast-forward merge, a locked worktree, a missing origin/main,
and dry-run behaviour. The rebase-merge case is proved: the test
rewrites the marked reclaimability line to `if false` and asserts the
resulting ancestry-only build keeps the worktree.

Fixes: #941

