### PR TITLE
feat(object-store): count billed HTTP requests below the retry loop

### DIFF
--- a/crates/ravel-bench/src/report_schema.rs
+++ b/crates/ravel-bench/src/report_schema.rs
@@ -66,13 +66,22 @@ pub const SCHEMA_VERSION: u32 = 1;
 /// The retry-blindness caveat every cost estimate carries (ADR-0927 decision 8,
 /// issue #928). `object_store` retries below `InstrumentedStore` with
 /// `max_retries = 10`, so one logical `get()` that retried nine times records
-/// one request while S3 bills ten. Every request figure in this repository is a
-/// logical-call count, not a billed-request count, and under throttling the
-/// real bill exceeds every counted number. This lives in the rendered output,
-/// not only in a doc.
-pub const RETRY_CAVEAT: &str = "request counts are logical-call counts, not billed requests: \
+/// one request while S3 bills ten. Every request figure in *this bench report*
+/// is a logical-call count, not a billed-request count, and under throttling the
+/// real bill exceeds every counted number.
+///
+/// The gap is no longer unmeasured: issue #928 added a per-operation `attempts`
+/// counter (`StoreMetrics::record_attempt`, surfaced as `ravel_store_attempts_total`
+/// at the server's `/metrics`) that the S3 adapter's counting HTTP connector fills
+/// in below the retry loop, so `attempts - calls` is the billed retry overhead.
+/// This bench harness does not install that connector, so its own request figures
+/// stay logical-call counts; the caveat says so rather than implying the gap is
+/// unmeasurable anywhere. This lives in the rendered output, not only in a doc.
+pub const RETRY_CAVEAT: &str = "request counts here are logical-call counts, not billed requests: \
     object_store retries below InstrumentedStore (max_retries=10), so under throttling the real \
-    bill exceeds every counted number and nothing here measures the gap (ADR-0927 decision 8, #928)";
+    bill exceeds every counted number. This bench does not install the counting HTTP connector; \
+    the billed-request count is measured separately as attempts (ravel_store_attempts_total) \
+    (ADR-0927 decision 8, #928)";
 
 /// The statuses ADR-0927 decision 6 fixes. Every outcome has exactly one, and
 /// only [`ResultStatus::Ok`] is admissible in a timing table. Kept as a typed

--- a/crates/ravel-object-store/src/instrument.rs
+++ b/crates/ravel-object-store/src/instrument.rs
@@ -29,6 +29,26 @@
 //!   never double counted and no call is missed. A call cancelled by drop
 //!   before the inner future resolves records nothing at all, so `calls` is
 //!   completions, not attempts.
+//! - `attempts` counts billed HTTP requests, retries included, and is the one
+//!   figure this decorator does **not** record itself: the retry loop it would
+//!   need to see runs *below* the [`ObjectStoreBackend`] boundary, inside
+//!   `object_store`'s S3 client (`RetryConfig`, default `max_retries = 10`), so
+//!   one `get()` that retried nine times is a single completed `calls`/`get`
+//!   here while the provider bills ten requests (issue #928, ADR-0927
+//!   decision 8). The gap is one-directional: the real bill is never below
+//!   `calls` and, under throttling, is strictly above it. `attempts` is filled
+//!   in from the layer that *can* see each retry --- the S3 adapter's counting
+//!   HTTP connector ([`crate::s3`]) records one attempt per HTTP request it
+//!   issues via [`StoreMetrics::record_attempt`], into the same per-op block, so
+//!   `attempts >= calls` always and `attempts - calls` is the retry (billed)
+//!   overhead. A backend that issues no HTTP requests (for example
+//!   [`crate::memory::MemoryStore`]) leaves `attempts` at zero: there is no bill
+//!   and nothing retried. Because a single logical read may fan a whole-object
+//!   `GetRange::Full` into several bounded ranged GETs, `attempts` can exceed
+//!   `calls` for `get` even with no retry at all; each ranged request is a real
+//!   billed request. `attempts` for `put` likewise counts every request a
+//!   multipart upload issues (create, each part, complete), not one per logical
+//!   `put`.
 //! - `errors[class]` is indexed by [`StoreErrorClass`], one slot per
 //!   [`StoreError`] variant. `AlreadyExists` under `CreateIfAbsent` is a
 //!   protocol signal rather than a failure (ADR-0002), so a healthy commit
@@ -272,11 +292,20 @@ pub struct OpMetrics {
     ok: AtomicU64,
     errors: [AtomicU64; STORE_ERROR_CLASS_COUNT],
     bytes: AtomicU64,
+    /// Billed HTTP requests, retries included. Recorded by the S3 adapter's
+    /// counting connector, never by this decorator; see the [module docs](self).
+    attempts: AtomicU64,
     latency_micros_buckets: [AtomicU64; LATENCY_BUCKET_COUNT],
     latency_nanos_total: AtomicU64,
 }
 
 impl OpMetrics {
+    /// One billed HTTP request (an attempt, retries included). Separate from
+    /// [`record`](Self::record), which counts one completed logical call.
+    fn record_attempt(&self) {
+        self.attempts.fetch_add(1, Ordering::Relaxed);
+    }
+
     fn record(&self, elapsed_nanos: u64, bytes: u64, err: Option<&StoreError>) {
         self.calls.fetch_add(1, Ordering::Relaxed);
         match err {
@@ -312,6 +341,7 @@ impl OpMetrics {
             ok: self.ok.load(Ordering::Relaxed),
             errors,
             bytes: self.bytes.load(Ordering::Relaxed),
+            attempts: self.attempts.load(Ordering::Relaxed),
             latency_micros_buckets,
             latency_nanos_total: self.latency_nanos_total.load(Ordering::Relaxed),
         }
@@ -330,6 +360,11 @@ pub struct OpMetricsSnapshot {
     pub errors: [u64; STORE_ERROR_CLASS_COUNT],
     /// Bytes returned (`get`) or offered (`put`); zero for every other op.
     pub bytes: u64,
+    /// Billed HTTP requests, retries included (issue #928). Always `>= calls`
+    /// for a backend that issues HTTP; `attempts - calls` is the retry (billed)
+    /// overhead `calls` alone hides. Zero for a non-HTTP backend. See the
+    /// [module docs](self) for why this decorator does not record it itself.
+    pub attempts: u64,
     /// Fixed histogram over [`LATENCY_BUCKET_BOUNDS_MICROS`] plus overflow.
     pub latency_micros_buckets: [u64; LATENCY_BUCKET_COUNT],
     /// Summed latency of every completed call, for an exact mean the buckets
@@ -367,6 +402,18 @@ impl StoreMetrics {
     /// returned data length for a successful `get`, and 0 otherwise.
     fn record(&self, op: StoreOp, elapsed_nanos: u64, bytes: u64, err: Option<&StoreError>) {
         self.op(op).record(elapsed_nanos, bytes, err);
+    }
+
+    /// Record one billed HTTP request (an attempt, retries included) for `op`,
+    /// into the same per-op block [`snapshot`](Self::snapshot) reads as
+    /// `attempts`. This is the seam the S3 adapter's counting HTTP connector
+    /// ([`crate::s3`]) records through: it fires once per HTTP request it issues,
+    /// so `attempts` sees `object_store`'s internal retries that a completed
+    /// `calls` never does (issue #928). It touches no other counter, so a caller
+    /// that records attempts and a decorator that records completions never
+    /// contend on the same field. See the [module docs](self).
+    pub fn record_attempt(&self, op: StoreOp) {
+        self.op(op).record_attempt();
     }
 
     /// Record one completed call from outside this module, using the same
@@ -457,9 +504,30 @@ impl<S: ObjectStoreBackend> InstrumentedStore<S> {
 
     /// Wrap `inner` with an injected clock, for deterministic latency tests.
     pub fn with_clock(inner: S, clock: Arc<dyn MonotonicClock>) -> Self {
+        Self::with_clock_and_metrics(inner, clock, Arc::new(StoreMetrics::default()))
+    }
+
+    /// Wrap `inner` recording into a caller-supplied [`StoreMetrics`], so the
+    /// `attempts` counter the S3 adapter's counting connector fills in
+    /// ([`StoreMetrics::record_attempt`], issue #928) and the `calls` counter
+    /// this decorator fills in land in one shared block, read by a single
+    /// [`snapshot`](StoreMetrics::snapshot). Build the `Arc` first, hand a clone
+    /// to `S3Store` so its connector records attempts into it, and pass the same
+    /// `Arc` here; [`metrics`](Self::metrics) then returns it. `new`/`with_clock`
+    /// keep their own private block (no attempts source), unchanged.
+    pub fn with_metrics(inner: S, metrics: Arc<StoreMetrics>) -> Self {
+        Self::with_clock_and_metrics(inner, Arc::new(InstantClock::new()), metrics)
+    }
+
+    /// Wrap `inner` with both an injected clock and a shared [`StoreMetrics`].
+    pub fn with_clock_and_metrics(
+        inner: S,
+        clock: Arc<dyn MonotonicClock>,
+        metrics: Arc<StoreMetrics>,
+    ) -> Self {
         InstrumentedStore {
             inner,
-            metrics: Arc::new(StoreMetrics::default()),
+            metrics,
             clock,
         }
     }
@@ -675,6 +743,34 @@ mod tests {
         assert_eq!(snap.get.errors_total(), snap.get.calls - snap.get.ok);
         assert_eq!(snap.get.latency_nanos_total, 150_000);
         assert_eq!(snap.put, OpMetricsSnapshot::default(), "no put recorded");
+    }
+
+    #[test]
+    fn attempts_are_separate_from_calls_and_do_not_touch_other_counters() {
+        // A get() that the backend retried twice below the trait boundary: the
+        // connector records three billed attempts, the decorator one completion.
+        // `attempts` must read 3 and `calls` 1, so `attempts - calls` is exactly
+        // the retry overhead #928 exists to expose, and no other counter moves.
+        let metrics = StoreMetrics::default();
+        metrics.record_attempt(StoreOp::Get);
+        metrics.record_attempt(StoreOp::Get);
+        metrics.record_attempt(StoreOp::Get);
+        metrics.record(StoreOp::Get, 10_000, 42, None);
+
+        let snap = metrics.snapshot();
+        assert_eq!(snap.get.attempts, 3, "three billed HTTP requests");
+        assert_eq!(snap.get.calls, 1, "one completed logical call");
+        assert_eq!(snap.get.ok, 1);
+        assert_eq!(snap.get.bytes, 42);
+        assert_eq!(
+            snap.get.errors_total(),
+            0,
+            "recording attempts must not move any error class"
+        );
+        // A quiet op with no attempts recorded reads exactly zero, so the figure
+        // never drifts on a backend that issues no HTTP (e.g. MemoryStore).
+        assert_eq!(snap.put.attempts, 0);
+        assert_eq!(snap.head.attempts, 0);
     }
 
     #[test]

--- a/crates/ravel-object-store/src/instrument.rs
+++ b/crates/ravel-object-store/src/instrument.rs
@@ -40,8 +40,16 @@
 //!   in from the layer that *can* see each retry --- the S3 adapter's counting
 //!   HTTP connector ([`crate::s3`]) records one attempt per HTTP request it
 //!   issues via [`StoreMetrics::record_attempt`], into the same per-op block, so
-//!   `attempts >= calls` always and `attempts - calls` is the retry (billed)
-//!   overhead. A backend that issues no HTTP requests (for example
+//!   `attempts - calls` is the retry (billed) overhead. `attempts >= calls`
+//!   holds exactly when every store this decorator counts a `calls` on records
+//!   its attempts into the same handle: an [`InstrumentedStore::with_metrics`]
+//!   wrapping an [`S3Store`](crate::s3::S3Store) built with
+//!   [`S3Store::new`](crate::s3::S3Store::new) (no handle) would count
+//!   `calls` while recording no `attempts`, so the relation is a property of the
+//!   wiring, not a guarantee of this type. The server wires the whole S3 chain
+//!   --- the base store and, under `--tenant-kms-config`, every per-tenant
+//!   KMS-routed store (see [`crate::KmsRoutingStore::new`]) --- onto one handle,
+//!   so it holds there (issue #928). A backend that issues no HTTP requests (for example
 //!   [`crate::memory::MemoryStore`]) leaves `attempts` at zero: there is no bill
 //!   and nothing retried. Because a single logical read may fan a whole-object
 //!   `GetRange::Full` into several bounded ranged GETs, `attempts` can exceed
@@ -360,8 +368,9 @@ pub struct OpMetricsSnapshot {
     pub errors: [u64; STORE_ERROR_CLASS_COUNT],
     /// Bytes returned (`get`) or offered (`put`); zero for every other op.
     pub bytes: u64,
-    /// Billed HTTP requests, retries included (issue #928). Always `>= calls`
-    /// for a backend that issues HTTP; `attempts - calls` is the retry (billed)
+    /// Billed HTTP requests, retries included (issue #928). `>= calls` when
+    /// every store the decorator counts shares this handle (the wiring the
+    /// module docs describe); `attempts - calls` is then the retry (billed)
     /// overhead `calls` alone hides. Zero for a non-HTTP backend. See the
     /// [module docs](self) for why this decorator does not record it itself.
     pub attempts: u64,

--- a/crates/ravel-object-store/src/kms_routing.rs
+++ b/crates/ravel-object-store/src/kms_routing.rs
@@ -53,7 +53,7 @@ use parking_lot::Mutex;
 use crate::s3::{S3Config, S3Store};
 use crate::{
     Capabilities, DelimitedList, GetOutcome, GetRange, ListPage, MultipartUpload, ObjectMeta,
-    ObjectStoreBackend, PageToken, PutOptions, PutOutcome, StoreError,
+    ObjectStoreBackend, PageToken, PutOptions, PutOutcome, StoreError, StoreMetrics,
 };
 
 /// Builds a per-tenant backend from a fully-configured [`S3Config`] (the
@@ -61,7 +61,9 @@ use crate::{
 /// inject a fake that records the config it was built with instead of a real
 /// [`S3Store`], which has no live endpoint under test. The default
 /// implementation (see [`KmsRoutingStore::new`]) builds an [`S3Store`] the same
-/// way the default store was built.
+/// way the default store was built, against the SAME [`StoreMetrics`] handle so
+/// its billed HTTP requests land in the one snapshot the whole chain shares
+/// (issue #928).
 type TenantStoreBuilder =
     Box<dyn Fn(&S3Config) -> Result<Box<dyn ObjectStoreBackend>, StoreError> + Send + Sync>;
 
@@ -140,13 +142,29 @@ pub fn routes_through_tenant_key(key: &str) -> bool {
 impl KmsRoutingStore {
     /// Wrap `default` (the deployment-default store) and build per-tenant stores
     /// by cloning `default_config`, overriding only `kms_key_id`, and calling
-    /// [`S3Store::new`] --- the same construction path the default store used.
-    pub fn new(default: Arc<dyn ObjectStoreBackend>, default_config: S3Config) -> Self {
+    /// [`S3Store::with_metrics`] against `metrics` --- the same construction path
+    /// the default store used, against the same metrics handle.
+    ///
+    /// `metrics` must be the very handle the base [`S3Store`] and the outer
+    /// [`InstrumentedStore`](crate::InstrumentedStore) already share, so every store the decorator counts a
+    /// `calls` on also records its billed HTTP requests (`attempts`) into that
+    /// one block. Using [`S3Store::new`] here (no metrics handle) would count a
+    /// routed write's `calls` while dropping its `attempts` on the floor, making
+    /// `ravel_store_attempts_total` under-report to zero for per-tenant traffic
+    /// (issue #928).
+    pub fn new(
+        default: Arc<dyn ObjectStoreBackend>,
+        default_config: S3Config,
+        metrics: Arc<StoreMetrics>,
+    ) -> Self {
         Self::with_builder(
             default,
             default_config,
-            Box::new(|config: &S3Config| {
-                Ok(Box::new(S3Store::new(config.clone())?) as Box<dyn ObjectStoreBackend>)
+            Box::new(move |config: &S3Config| {
+                Ok(
+                    Box::new(S3Store::with_metrics(config.clone(), Arc::clone(&metrics))?)
+                        as Box<dyn ObjectStoreBackend>,
+                )
             }),
         )
     }

--- a/crates/ravel-object-store/src/s3.rs
+++ b/crates/ravel-object-store/src/s3.rs
@@ -95,6 +95,11 @@ use credentials::FileCredentialProvider;
 mod instance_role;
 use instance_role::{DEFAULT_IMDS_ENDPOINT, InstanceRoleCredentialProvider};
 
+mod attempts;
+use attempts::AttemptCountingConnector;
+
+use crate::instrument::{StoreMetrics, StoreOp};
+
 /// Default entries per `ListPage`, chosen to line up with S3's own
 /// `ListObjectsV2` page size. Overridable per instance via
 /// [`S3Store::with_page_size`].
@@ -506,7 +511,52 @@ impl S3Store {
     /// client tuning (#851). Exists so an unusual deployment or a test can set
     /// a non-default timeout and have it reach the constructed client.
     pub fn with_http_config(config: S3Config, http: S3HttpConfig) -> Result<Self, StoreError> {
-        let (builder, credential_provider, instance_role_provider) = Self::builder(&config, &http)?;
+        Self::build(config, http, None)
+    }
+
+    /// Build recording billed HTTP requests (attempts, retries included) into
+    /// the shared `metrics`, using the default HTTP tuning (issue #928).
+    ///
+    /// This installs a counting HTTP connector *below* `object_store`'s retry
+    /// loop, so `metrics`'s `attempts` counter sees every retry a completed
+    /// [`InstrumentedStore`](crate::InstrumentedStore) `calls` count hides. Pass
+    /// the same `Arc` to
+    /// [`InstrumentedStore::with_metrics`](crate::InstrumentedStore::with_metrics)
+    /// so `attempts` and `calls` share one snapshot. `new`/`with_http_config`
+    /// install no connector and record no attempts, byte-for-byte the historical
+    /// build path.
+    pub fn with_metrics(config: S3Config, metrics: Arc<StoreMetrics>) -> Result<Self, StoreError> {
+        Self::build(config, S3HttpConfig::default(), Some(metrics))
+    }
+
+    /// Build with an explicit [`S3HttpConfig`] and an attempt-metrics sink.
+    pub fn with_http_config_and_metrics(
+        config: S3Config,
+        http: S3HttpConfig,
+        metrics: Arc<StoreMetrics>,
+    ) -> Result<Self, StoreError> {
+        Self::build(config, http, Some(metrics))
+    }
+
+    /// The shared build path. When `attempt_metrics` is `Some`, an
+    /// [`AttemptCountingConnector`] is installed so every HTTP request the
+    /// client issues is counted; when `None`, the default `object_store`
+    /// connector is used and no attempts are recorded.
+    fn build(
+        config: S3Config,
+        http: S3HttpConfig,
+        attempt_metrics: Option<Arc<StoreMetrics>>,
+    ) -> Result<Self, StoreError> {
+        let (mut builder, credential_provider, instance_role_provider) =
+            Self::builder(&config, &http)?;
+        // Count billed HTTP requests below `object_store`'s retry loop (#928).
+        // The connector wraps the default reqwest client and delegates unchanged,
+        // so this changes what is measured, never how a request runs; `retry`/
+        // `RetryConfig` stay at `object_store`'s defaults. Absent a sink, the
+        // default connector is used and no attempts are recorded.
+        if let Some(metrics) = attempt_metrics {
+            builder = builder.with_http_connector(AttemptCountingConnector::new(metrics));
+        }
         let store = builder
             .build()
             .map_err(|e| StoreError::Permanent(format!("failed to build S3 client: {e}")))?;
@@ -1353,42 +1403,45 @@ impl ObjectStoreBackend for S3Store {
         data: Bytes,
         opts: PutOptions,
     ) -> Result<PutOutcome, StoreError> {
-        preflight_checksum(&data, opts.checksum)?;
-        // Large payloads go out as a multipart upload, but only under
-        // `Overwrite`: `object_store` 0.14 has no conditional
-        // `CompleteMultipartUpload` (`PutMultipartOptions` carries tags and
-        // attributes, no `PutMode`), so routing a conditional put through
-        // multipart would silently drop the precondition the commit protocol
-        // depends on. A `CreateIfAbsent`/`CasVersion` put therefore stays on
-        // the single-PUT path at every size (S3's 5 GiB single-request limit
-        // is the ceiling there). See docs/object-store-contract.md,
-        // "Multipart upload".
-        if matches!(opts.mode, PutMode::Overwrite) && data.len() > MULTIPART_THRESHOLD {
-            return self.put_via_multipart(key, data).await;
-        }
-        let os_mode = match &opts.mode {
-            PutMode::Overwrite => OsPutMode::Overwrite,
-            PutMode::CreateIfAbsent => OsPutMode::Create,
-            PutMode::CasVersion(version) => OsPutMode::Update(UpdateVersion {
-                e_tag: Some(version.0.clone()),
-                version: Some(version.0.clone()),
-            }),
-        };
-        let path = path_of(key);
-        let payload = PutPayload::from(data);
-        let result = self
-            .store
-            .put_opts(
-                &path,
-                payload,
-                OsPutOptions {
-                    mode: os_mode,
-                    ..Default::default()
-                },
-            )
-            .await
-            .map_err(|e| map_put_error(e, &opts.mode))?;
-        outcome_of(key, result)
+        attempts::scope(StoreOp::Put, async move {
+            preflight_checksum(&data, opts.checksum)?;
+            // Large payloads go out as a multipart upload, but only under
+            // `Overwrite`: `object_store` 0.14 has no conditional
+            // `CompleteMultipartUpload` (`PutMultipartOptions` carries tags and
+            // attributes, no `PutMode`), so routing a conditional put through
+            // multipart would silently drop the precondition the commit protocol
+            // depends on. A `CreateIfAbsent`/`CasVersion` put therefore stays on
+            // the single-PUT path at every size (S3's 5 GiB single-request limit
+            // is the ceiling there). See docs/object-store-contract.md,
+            // "Multipart upload".
+            if matches!(opts.mode, PutMode::Overwrite) && data.len() > MULTIPART_THRESHOLD {
+                return self.put_via_multipart(key, data).await;
+            }
+            let os_mode = match &opts.mode {
+                PutMode::Overwrite => OsPutMode::Overwrite,
+                PutMode::CreateIfAbsent => OsPutMode::Create,
+                PutMode::CasVersion(version) => OsPutMode::Update(UpdateVersion {
+                    e_tag: Some(version.0.clone()),
+                    version: Some(version.0.clone()),
+                }),
+            };
+            let path = path_of(key);
+            let payload = PutPayload::from(data);
+            let result = self
+                .store
+                .put_opts(
+                    &path,
+                    payload,
+                    OsPutOptions {
+                        mode: os_mode,
+                        ..Default::default()
+                    },
+                )
+                .await
+                .map_err(|e| map_put_error(e, &opts.mode))?;
+            outcome_of(key, result)
+        })
+        .await
     }
 
     async fn put_multipart<'a>(
@@ -1410,62 +1463,71 @@ impl ObjectStoreBackend for S3Store {
     }
 
     async fn get(&self, key: &str, range: GetRange) -> Result<GetOutcome, StoreError> {
-        let os_range = match range {
-            // The one request whose size the caller does not choose, so the one
-            // that has to be bounded here to stay inside
-            // `S3HttpConfig::request_timeout`.
-            GetRange::Full => return self.get_whole_object(key).await,
-            GetRange::Range(start, end) => {
-                if start >= end {
-                    return Err(StoreError::InvalidRange(format!(
-                        "empty or inverted range [{start}, {end})"
-                    )));
+        attempts::scope(StoreOp::Get, async move {
+            let os_range = match range {
+                // The one request whose size the caller does not choose, so the one
+                // that has to be bounded here to stay inside
+                // `S3HttpConfig::request_timeout`.
+                GetRange::Full => return self.get_whole_object(key).await,
+                GetRange::Range(start, end) => {
+                    if start >= end {
+                        return Err(StoreError::InvalidRange(format!(
+                            "empty or inverted range [{start}, {end})"
+                        )));
+                    }
+                    Some(OsGetRange::Bounded(start..end))
                 }
-                Some(OsGetRange::Bounded(start..end))
-            }
-            GetRange::Suffix(0) => {
-                return Err(StoreError::InvalidRange("zero-length suffix".into()));
-            }
-            GetRange::Suffix(n) => Some(OsGetRange::Suffix(n)),
-        };
-        let chunk = self.get_one(key, os_range, None).await?;
-        Ok(GetOutcome {
-            data: chunk.data,
-            etag: Etag(chunk.etag.clone()),
-            version: Version(chunk.etag),
-            total_size: chunk.total_size,
+                GetRange::Suffix(0) => {
+                    return Err(StoreError::InvalidRange("zero-length suffix".into()));
+                }
+                GetRange::Suffix(n) => Some(OsGetRange::Suffix(n)),
+            };
+            let chunk = self.get_one(key, os_range, None).await?;
+            Ok(GetOutcome {
+                data: chunk.data,
+                etag: Etag(chunk.etag.clone()),
+                version: Version(chunk.etag),
+                total_size: chunk.total_size,
+            })
         })
+        .await
     }
 
     async fn head(&self, key: &str) -> Result<ObjectMeta, StoreError> {
-        let path = path_of(key);
-        let meta = self.store.head(&path).await.map_err(map_error_common)?;
-        map_meta(meta)
+        attempts::scope(StoreOp::Head, async move {
+            let path = path_of(key);
+            let meta = self.store.head(&path).await.map_err(map_error_common)?;
+            map_meta(meta)
+        })
+        .await
     }
 
     async fn list(&self, prefix: &str, page: Option<PageToken>) -> Result<ListPage, StoreError> {
-        let prefix_path = prefix_of(prefix);
-        let mut stream = match &page {
-            Some(PageToken(after)) => {
-                let offset = Path::from(after.as_str());
-                self.store.list_with_offset(prefix_path.as_ref(), &offset)
+        attempts::scope(StoreOp::List, async move {
+            let prefix_path = prefix_of(prefix);
+            let mut stream = match &page {
+                Some(PageToken(after)) => {
+                    let offset = Path::from(after.as_str());
+                    self.store.list_with_offset(prefix_path.as_ref(), &offset)
+                }
+                None => self.store.list(prefix_path.as_ref()),
+            };
+            let mut out = Vec::with_capacity(self.page_size.min(1024));
+            while out.len() < self.page_size {
+                match stream.next().await {
+                    Some(Ok(meta)) => out.push(map_meta(meta)?),
+                    Some(Err(e)) => return Err(map_error_common(e)),
+                    None => break,
+                }
             }
-            None => self.store.list(prefix_path.as_ref()),
-        };
-        let mut out = Vec::with_capacity(self.page_size.min(1024));
-        while out.len() < self.page_size {
-            match stream.next().await {
-                Some(Ok(meta)) => out.push(map_meta(meta)?),
-                Some(Err(e)) => return Err(map_error_common(e)),
-                None => break,
-            }
-        }
-        let next = if out.len() == self.page_size {
-            out.last().map(|m| PageToken(m.key.clone()))
-        } else {
-            None
-        };
-        Ok(ListPage { objects: out, next })
+            let next = if out.len() == self.page_size {
+                out.last().map(|m| PageToken(m.key.clone()))
+            } else {
+                None
+            };
+            Ok(ListPage { objects: out, next })
+        })
+        .await
     }
 
     async fn list_after(
@@ -1474,69 +1536,78 @@ impl ObjectStoreBackend for S3Store {
         start_after: Option<&str>,
         page: Option<PageToken>,
     ) -> Result<ListPage, StoreError> {
-        let prefix_path = prefix_of(prefix);
-        // A page token resumes strictly after the previous page's last key;
-        // on the first page `start_after` plays the same role. Both map to
-        // `object_store`'s `list_with_offset`, whose offset is exclusive
-        // (ListObjectsV2 `start-after`), so keys equal to the offset are
-        // skipped server-side and never transferred. A present page token is
-        // always past `start_after`, so it takes precedence.
-        let offset = match (&page, start_after) {
-            (Some(PageToken(after)), _) => Some(Path::from(after.as_str())),
-            (None, Some(after)) => Some(Path::from(after)),
-            (None, None) => None,
-        };
-        let mut stream = match &offset {
-            Some(offset) => self.store.list_with_offset(prefix_path.as_ref(), offset),
-            None => self.store.list(prefix_path.as_ref()),
-        };
-        let mut out = Vec::with_capacity(self.page_size.min(1024));
-        while out.len() < self.page_size {
-            match stream.next().await {
-                Some(Ok(meta)) => out.push(map_meta(meta)?),
-                Some(Err(e)) => return Err(map_error_common(e)),
-                None => break,
+        attempts::scope(StoreOp::List, async move {
+            let prefix_path = prefix_of(prefix);
+            // A page token resumes strictly after the previous page's last key;
+            // on the first page `start_after` plays the same role. Both map to
+            // `object_store`'s `list_with_offset`, whose offset is exclusive
+            // (ListObjectsV2 `start-after`), so keys equal to the offset are
+            // skipped server-side and never transferred. A present page token is
+            // always past `start_after`, so it takes precedence.
+            let offset = match (&page, start_after) {
+                (Some(PageToken(after)), _) => Some(Path::from(after.as_str())),
+                (None, Some(after)) => Some(Path::from(after)),
+                (None, None) => None,
+            };
+            let mut stream = match &offset {
+                Some(offset) => self.store.list_with_offset(prefix_path.as_ref(), offset),
+                None => self.store.list(prefix_path.as_ref()),
+            };
+            let mut out = Vec::with_capacity(self.page_size.min(1024));
+            while out.len() < self.page_size {
+                match stream.next().await {
+                    Some(Ok(meta)) => out.push(map_meta(meta)?),
+                    Some(Err(e)) => return Err(map_error_common(e)),
+                    None => break,
+                }
             }
-        }
-        let next = if out.len() == self.page_size {
-            out.last().map(|m| PageToken(m.key.clone()))
-        } else {
-            None
-        };
-        Ok(ListPage { objects: out, next })
+            let next = if out.len() == self.page_size {
+                out.last().map(|m| PageToken(m.key.clone()))
+            } else {
+                None
+            };
+            Ok(ListPage { objects: out, next })
+        })
+        .await
     }
 
     async fn list_delimited(&self, prefix: &str) -> Result<DelimitedList, StoreError> {
-        let prefix_path = prefix_of(prefix);
-        let result = self
-            .store
-            .list_with_delimiter(prefix_path.as_ref())
-            .await
-            .map_err(map_error_common)?;
-        let objects = result
-            .objects
-            .into_iter()
-            .map(map_meta)
-            .collect::<Result<Vec<_>, _>>()?;
-        let common_prefixes = result
-            .common_prefixes
-            .into_iter()
-            .map(|p| format!("{p}/"))
-            .collect();
-        Ok(DelimitedList {
-            objects,
-            common_prefixes,
+        attempts::scope(StoreOp::ListDelimited, async move {
+            let prefix_path = prefix_of(prefix);
+            let result = self
+                .store
+                .list_with_delimiter(prefix_path.as_ref())
+                .await
+                .map_err(map_error_common)?;
+            let objects = result
+                .objects
+                .into_iter()
+                .map(map_meta)
+                .collect::<Result<Vec<_>, _>>()?;
+            let common_prefixes = result
+                .common_prefixes
+                .into_iter()
+                .map(|p| format!("{p}/"))
+                .collect();
+            Ok(DelimitedList {
+                objects,
+                common_prefixes,
+            })
         })
+        .await
     }
 
     async fn delete(&self, key: &str) -> Result<(), StoreError> {
-        let path = path_of(key);
-        match self.store.delete(&path).await {
-            Ok(()) => Ok(()),
-            // Idempotent per the contract: deleting a missing key succeeds.
-            Err(object_store::Error::NotFound { .. }) => Ok(()),
-            Err(e) => Err(map_error_common(e)),
-        }
+        attempts::scope(StoreOp::Delete, async move {
+            let path = path_of(key);
+            match self.store.delete(&path).await {
+                Ok(()) => Ok(()),
+                // Idempotent per the contract: deleting a missing key succeeds.
+                Err(object_store::Error::NotFound { .. }) => Ok(()),
+                Err(e) => Err(map_error_common(e)),
+            }
+        })
+        .await
     }
 
     fn capabilities(&self) -> Capabilities {

--- a/crates/ravel-object-store/src/s3/attempts.rs
+++ b/crates/ravel-object-store/src/s3/attempts.rs
@@ -1,0 +1,114 @@
+//! Billed-request (attempt) counting at the HTTP layer, below
+//! `object_store`'s retry loop (issue #928, ADR-0927 decision 8).
+//!
+//! `object_store` runs its own retry loop *inside* each logical S3 operation
+//! (`RetryConfig`, default `max_retries = 10`), so one `get()` that retried
+//! nine times is a single completed call at the [`ObjectStoreBackend`] boundary
+//! while the provider bills ten HTTP requests. The
+//! [`InstrumentedStore`](crate::InstrumentedStore) decorator sits above that
+//! boundary and counts completions (`calls`), so it cannot see the retries: the
+//! divergence is one-directional and, under throttling, unbounded.
+//!
+//! The retries *are* observable, without forking the dependency, from the one
+//! layer they all pass through: `object_store`'s retry loop dispatches every
+//! attempt through its [`HttpClient`], whose backing [`HttpService`] is
+//! swappable via `AmazonS3Builder::with_http_connector`. Each `HttpService`
+//! `call()` is exactly one HTTP request on the wire --- one billed request ---
+//! so wrapping the connector counts attempts including every retry, with zero
+//! change to retry behaviour: [`AttemptCountingService`] records, then
+//! delegates the request unchanged.
+//!
+//! [`ObjectStoreBackend`]: crate::ObjectStoreBackend
+//!
+//! # Attributing an attempt to its operation
+//!
+//! An `HttpService::call` sees an [`HttpRequest`] (method, URI), not the
+//! [`StoreOp`] that issued it. Classifying by HTTP verb is lossy (an S3 `LIST`
+//! is a `GET`, an `UploadPart` is a `PUT`) and would re-implement request
+//! shapes `object_store` owns. Instead the S3 adapter names the operation at
+//! its own call site with [`scope`], a `tokio` task-local set around each
+//! logical op; the counting service reads it. `object_store`'s retry loop and
+//! the default [`ReqwestConnector`] both run the request inline on the task
+//! that awaited the op (no [`SpawnedReqwestConnector`]), so the task-local is in
+//! scope for every attempt, including a whole-object read's concurrent ranged
+//! GETs. A request issued with no scope in effect (a credential-provider
+//! refresh, say) simply records nothing --- it is not an S3 data request.
+//!
+//! [`SpawnedReqwestConnector`]: object_store::client::SpawnedReqwestConnector
+
+use std::future::Future;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use object_store::ClientOptions;
+use object_store::client::{
+    HttpClient, HttpConnector, HttpError, HttpRequest, HttpResponse, HttpService, ReqwestConnector,
+};
+
+use crate::instrument::{StoreMetrics, StoreOp};
+
+tokio::task_local! {
+    /// The [`StoreOp`] the S3 adapter is currently executing, read by
+    /// [`AttemptCountingService`] to attribute each billed HTTP request. Unset
+    /// outside a [`scope`].
+    static CURRENT_OP: StoreOp;
+}
+
+/// Run `fut` with `op` installed as the current operation, so every HTTP
+/// request `object_store` issues while polling it is counted under `op`. A
+/// no-op on attribution when no [`AttemptCountingConnector`] is installed (the
+/// task-local is set either way, but nothing reads it), so the S3 adapter can
+/// scope unconditionally.
+pub(crate) async fn scope<F: Future>(op: StoreOp, fut: F) -> F::Output {
+    CURRENT_OP.scope(op, fut).await
+}
+
+/// An [`HttpConnector`] that wraps the default [`ReqwestConnector`] and counts
+/// every HTTP request the client it builds issues, into a shared
+/// [`StoreMetrics`] via [`StoreMetrics::record_attempt`].
+#[derive(Debug)]
+pub(crate) struct AttemptCountingConnector {
+    metrics: Arc<StoreMetrics>,
+    inner: ReqwestConnector,
+}
+
+impl AttemptCountingConnector {
+    pub(crate) fn new(metrics: Arc<StoreMetrics>) -> Self {
+        AttemptCountingConnector {
+            metrics,
+            inner: ReqwestConnector::default(),
+        }
+    }
+}
+
+impl HttpConnector for AttemptCountingConnector {
+    fn connect(&self, options: &ClientOptions) -> object_store::Result<HttpClient> {
+        let inner = self.inner.connect(options)?;
+        Ok(HttpClient::new(AttemptCountingService {
+            metrics: Arc::clone(&self.metrics),
+            inner,
+        }))
+    }
+}
+
+/// The [`HttpService`] [`AttemptCountingConnector`] builds: record one attempt
+/// for the scoped [`StoreOp`], then delegate the request unchanged. Delegation
+/// is byte-for-byte the default reqwest path, so counting adds no behaviour.
+#[derive(Debug)]
+struct AttemptCountingService {
+    metrics: Arc<StoreMetrics>,
+    inner: HttpClient,
+}
+
+#[async_trait]
+impl HttpService for AttemptCountingService {
+    async fn call(&self, req: HttpRequest) -> Result<HttpResponse, HttpError> {
+        // Count before dispatch: the request is about to go on the wire and be
+        // billed whether or not the response ever arrives. A request issued
+        // outside any `scope` (e.g. a credential refresh) records nothing.
+        if let Ok(op) = CURRENT_OP.try_with(|op| *op) {
+            self.metrics.record_attempt(op);
+        }
+        self.inner.execute(req).await
+    }
+}

--- a/crates/ravel-object-store/tests/contract.rs
+++ b/crates/ravel-object-store/tests/contract.rs
@@ -24,7 +24,7 @@ use ravel_object_store::s3::{MULTIPART_THRESHOLD, S3Config, S3Store};
 use ravel_object_store::{
     Capabilities, DelimitedList, GetOutcome, GetRange, InstrumentedStore, ListPage,
     MULTIPART_MIN_PART_SIZE, ObjectMeta, ObjectStoreBackend, PageToken, PutMode, PutOptions,
-    PutOutcome, StoreError, UploadChecksum, list_all,
+    PutOutcome, StoreError, StoreMetrics, UploadChecksum, list_all,
 };
 use std::sync::Arc;
 
@@ -1095,7 +1095,11 @@ async fn fault_store_empty_plan_contract() {
 /// tenant has opted into per-tenant SSE-KMS.
 #[tokio::test]
 async fn kms_routing_store_contract_with_no_configured_tenants() {
-    let store = KmsRoutingStore::new(Arc::new(MemoryStore::new()), test_s3_config());
+    let store = KmsRoutingStore::new(
+        Arc::new(MemoryStore::new()),
+        test_s3_config(),
+        Arc::new(StoreMetrics::default()),
+    );
     run_contract_suite(&store, "kms-routing-unconfigured").await;
 }
 

--- a/crates/ravel-object-store/tests/s3_http_faults.rs
+++ b/crates/ravel-object-store/tests/s3_http_faults.rs
@@ -55,7 +55,9 @@ use axum::response::Response;
 use bytes::Bytes;
 use parking_lot::Mutex;
 use ravel_object_store::s3::{MULTIPART_THRESHOLD, S3Config, S3HttpConfig, S3Store};
-use ravel_object_store::{GetRange, ObjectStoreBackend, PutOptions, StoreError};
+use ravel_object_store::{
+    GetRange, InstrumentedStore, ObjectStoreBackend, PutOptions, StoreError, StoreMetrics,
+};
 
 /// Bucket name the fake serves. Path-style requests put it in the first path
 /// segment (`/{bucket}/{key}`), which is what `force_path_style: true` makes
@@ -225,6 +227,16 @@ impl FakeS3 {
     /// the same field a MinIO deployment sets.
     fn store(&self) -> S3Store {
         S3Store::new(self.config()).expect("a fake-endpoint S3Store must build")
+    }
+
+    /// An [`S3Store`] pointed at this endpoint that records billed HTTP requests
+    /// (attempts, retries included) into `metrics` via its counting connector
+    /// (issue #928). The same `Arc` is shared with an
+    /// [`InstrumentedStore::with_metrics`] in the tests, so `attempts` and
+    /// `calls` land in one snapshot.
+    fn store_with_metrics(&self, metrics: Arc<StoreMetrics>) -> S3Store {
+        S3Store::with_metrics(self.config(), metrics)
+            .expect("a fake-endpoint S3Store must build with attempt metrics")
     }
 
     /// The same store under an explicit [`S3HttpConfig`]. Used by the bounded
@@ -1425,5 +1437,200 @@ async fn slow_down_in_a_200_body_retries_complete_multipart() {
         fake.object("fault/slow-complete").as_deref(),
         Some(&b"one small part"[..]),
         "the completed object must hold the uploaded part"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Billed-request (attempt) counting below the retry loop (issue #928)
+// ---------------------------------------------------------------------------
+//
+// `InstrumentedStore` counts completed logical calls; below it, `object_store`
+// retries each call, so one `get()` that retried is one `calls` but several
+// billed HTTP requests. The counting HTTP connector (`S3Store::with_metrics`)
+// records those requests as `attempts`. These tests drive `object_store`'s real
+// retry loop over the fake endpoint and assert `attempts` against the count the
+// *server* saw, so the figure is the true billed-request count, not an artifact.
+//
+// The fault-injection here is at the HTTP layer, not the `FaultStore`
+// (`ObjectStoreBackend`) decorator the issue text names: `FaultStore` sits
+// *above* `object_store`, so it returns one error per call and cannot exercise
+// the retry loop *below* the trait boundary that creates the gap. This fake
+// endpoint is the fault store for that layer, and `fake.count(op)` is its
+// fired-fault counter (asserted below), the same role `FaultStore::fault_count`
+// plays one layer up.
+
+/// A GET retried three times records four billed attempts but one completed
+/// call: `attempts - calls` is exactly the retry count, and it equals the
+/// requests the server saw, so the counter is the true billed-request count.
+///
+/// To watch this assertion fail: change `record_attempt` in
+/// `crates/ravel-object-store/src/s3/attempts.rs` from firing once per
+/// `HttpService::call` to firing once per `connect` (or delete the call
+/// entirely) and `attempts` collapses to 0 (or 1), so the
+/// `attempts - calls == 3` line below fails.
+#[tokio::test]
+async fn attempts_exceed_calls_by_the_exact_retry_count() {
+    let fake = FakeS3::start().await;
+    let metrics = Arc::new(StoreMetrics::default());
+    let store = InstrumentedStore::with_metrics(
+        fake.store_with_metrics(Arc::clone(&metrics)),
+        Arc::clone(&metrics),
+    );
+    fake.seed("attempts/get", b"served after three throttles");
+    fake.script(
+        Op::Get,
+        [
+            Fault::ServiceUnavailable,
+            Fault::TooManyRequests,
+            Fault::SlowDown,
+        ],
+    );
+
+    store
+        .get("attempts/get", GetRange::Full)
+        .await
+        .expect("three retryable faults must not fail the get");
+
+    let snap = metrics.snapshot();
+    // The fault store fired: three faults served, four GETs on the wire.
+    assert_eq!(
+        fake.count(Op::Get),
+        4,
+        "the endpoint must see one GET per attempt: three faulted, one served"
+    );
+    assert_eq!(
+        fake.requests(Op::Get)
+            .iter()
+            .filter(|seen| seen.fault.is_some())
+            .count(),
+        3,
+        "all three scripted faults must have fired"
+    );
+    // The new figure is the billed-request count, exact.
+    assert_eq!(
+        snap.get.attempts, 4,
+        "attempts count every billed HTTP request, retries included"
+    );
+    assert_eq!(snap.get.calls, 1, "exactly one logical get completed");
+    assert_eq!(
+        snap.get.attempts - snap.get.calls,
+        3,
+        "attempts exceed calls by exactly the retry count, not merely by > 0"
+    );
+    assert_eq!(
+        snap.get.attempts,
+        fake.count(Op::Get) as u64,
+        "attempts equal the server-observed billed requests"
+    );
+    // Per-operation attribution: a get's retries do not leak onto another op.
+    assert_eq!(snap.put.attempts, 0, "no put was issued");
+    assert_eq!(snap.head.attempts, 0, "no head was issued");
+    assert_eq!(snap.delete.attempts, 0, "no delete was issued");
+}
+
+/// With no fault injected, one logical call is exactly one billed request:
+/// `attempts == calls`, so the figure does not drift on a quiet path.
+///
+/// To watch this assertion fail: make `AttemptCountingService::call` record two
+/// attempts per request (a stray double `record_attempt`) and the
+/// `attempts == calls` lines below fail with 2 != 1.
+#[tokio::test]
+async fn attempts_equal_calls_with_no_faults() {
+    let fake = FakeS3::start().await;
+    let metrics = Arc::new(StoreMetrics::default());
+    let store = InstrumentedStore::with_metrics(
+        fake.store_with_metrics(Arc::clone(&metrics)),
+        Arc::clone(&metrics),
+    );
+    fake.seed("attempts/quiet", b"served on the first try");
+
+    store
+        .get("attempts/quiet", GetRange::Full)
+        .await
+        .expect("a healthy get must succeed");
+    store
+        .head("attempts/quiet")
+        .await
+        .expect("a healthy head must succeed");
+
+    let snap = metrics.snapshot();
+    // No fault fired: exactly one request per op on the wire.
+    assert_eq!(fake.count(Op::Get), 1, "a quiet get is one GET");
+    assert_eq!(fake.count(Op::Head), 1, "a quiet head is one HEAD");
+    assert_eq!(
+        fake.requests(Op::Get)
+            .iter()
+            .filter(|seen| seen.fault.is_some())
+            .count(),
+        0,
+        "no fault may have fired on the quiet path"
+    );
+    assert_eq!(snap.get.attempts, 1);
+    assert_eq!(snap.get.calls, 1);
+    assert_eq!(
+        snap.get.attempts, snap.get.calls,
+        "no retry: attempts equal calls on the get"
+    );
+    assert_eq!(snap.head.attempts, 1);
+    assert_eq!(snap.head.calls, 1);
+    assert_eq!(
+        snap.head.attempts, snap.head.calls,
+        "no retry: attempts equal calls on the head"
+    );
+}
+
+/// Attribution is per operation kind (the axis `FaultStore` injects on): a
+/// retried PUT charges its retries to `put`, by the exact fault count, and to no
+/// other op.
+///
+/// To watch this assertion fail: drop the `attempts::scope(StoreOp::Put, ..)`
+/// wrapper from `S3Store::put` so the connector sees no scoped op for the
+/// request; `snap.put.attempts` then reads 0 and the `== 3` line fails.
+#[tokio::test]
+async fn attempts_are_attributed_to_the_issuing_operation() {
+    let fake = FakeS3::start().await;
+    let metrics = Arc::new(StoreMetrics::default());
+    let store = InstrumentedStore::with_metrics(
+        fake.store_with_metrics(Arc::clone(&metrics)),
+        Arc::clone(&metrics),
+    );
+    fake.script(Op::Put, [Fault::ServiceUnavailable, Fault::SlowDown]);
+
+    store
+        .put(
+            "attempts/put",
+            Bytes::from_static(b"payload that outlives two throttles"),
+            PutOptions::default(),
+        )
+        .await
+        .expect("two retryable throttles must not fail the put");
+
+    let snap = metrics.snapshot();
+    assert_eq!(
+        fake.count(Op::Put),
+        3,
+        "two faults + one success = three PUTs on the wire"
+    );
+    assert_eq!(
+        fake.requests(Op::Put)
+            .iter()
+            .filter(|seen| seen.fault.is_some())
+            .count(),
+        2,
+        "both scripted PUT faults must have fired"
+    );
+    assert_eq!(
+        snap.put.attempts, 3,
+        "billed PUT requests include the two retries"
+    );
+    assert_eq!(snap.put.calls, 1, "exactly one logical put completed");
+    assert_eq!(
+        snap.put.attempts - snap.put.calls,
+        2,
+        "attempts exceed calls by exactly the retry count"
+    );
+    assert_eq!(
+        snap.get.attempts, 0,
+        "a put's retries must not be charged to get"
     );
 }

--- a/crates/ravel-types/src/accounting.rs
+++ b/crates/ravel-types/src/accounting.rs
@@ -172,9 +172,17 @@ impl QueryAccounting {
     /// runs below this crate and holds no [`QueryAccounting`] handle (this type
     /// is passed explicitly, never via a task-local; see the [module docs](self)),
     /// so a per-query billed count is not reachable from the layer that sees the
-    /// retries. A budget that must bound billed rather than logical requests
-    /// therefore reads the process-global figure, or needs the attempt count
-    /// threaded up through the fetch return path first.
+    /// retries.
+    ///
+    /// The process-global figure is therefore for observability, not for
+    /// enforcement: it answers what the deployment was billed, and it cannot
+    /// answer what one query was billed. A budget that must bound billed rather
+    /// than logical requests, such as ADR-0075's `max_s3_requests`, cannot be
+    /// served by it at all, because a per-query ceiling needs a per-query count.
+    /// Enforcing on billed requests needs the attempt count threaded up through
+    /// the fetch return path first; until then that budget bounds logical calls
+    /// and a throttled query can spend several times its ceiling at the
+    /// provider while passing the check.
     pub fn record_s3_request(&self, op: AccountedOp) {
         self.0.ops[op.index()]
             .requests

--- a/crates/ravel-types/src/accounting.rs
+++ b/crates/ravel-types/src/accounting.rs
@@ -159,6 +159,22 @@ impl QueryAccounting {
     }
 
     /// Record one completed store request of kind `op`.
+    ///
+    /// This is a **logical-call** count, not a billed-request count: it fires
+    /// once per store operation the query funnels through, so the `object_store`
+    /// retry loop *below* the object-store trait boundary (default
+    /// `max_retries = 10`) is invisible here --- one throttled `get` that retried
+    /// nine times is one request here while the provider bills ten (issue #928).
+    /// The billed count is measured process-globally as `attempts` on
+    /// `ravel_object_store::instrument::StoreMetrics` (surfaced as
+    /// `ravel_store_attempts_total`), filled in by the S3 adapter's counting HTTP
+    /// connector. It is deliberately *not* mirrored per query here: the connector
+    /// runs below this crate and holds no [`QueryAccounting`] handle (this type
+    /// is passed explicitly, never via a task-local; see the [module docs](self)),
+    /// so a per-query billed count is not reachable from the layer that sees the
+    /// retries. A budget that must bound billed rather than logical requests
+    /// therefore reads the process-global figure, or needs the attempt count
+    /// threaded up through the fetch return path first.
     pub fn record_s3_request(&self, op: AccountedOp) {
         self.0.ops[op.index()]
             .requests

--- a/docs/adrs/0927-metricsbench-benchmark-contract.md
+++ b/docs/adrs/0927-metricsbench-benchmark-contract.md
@@ -242,8 +242,14 @@ One `get()` that retried nine times records one request while S3 bills ten.
 
 Every request figure in this repository is therefore a logical-call count, not
 a billed-request count. Under throttling the real bill exceeds every counted
-number and **nothing currently measures the gap**. Every cost estimate in a
-MetricsBench report carries this caveat next to the figure, not in a footnote.
+number. Issue #928 closed the measurement gap this decision named: a
+per-operation `attempts` counter (`StoreMetrics::record_attempt`, surfaced as
+`ravel_store_attempts_total` at `/metrics`) is filled in by the S3 adapter's
+counting HTTP connector *below* `object_store`'s retry loop, so `attempts -
+calls` is the billed retry overhead. The MetricsBench harness itself does not
+install that connector, so its own request figures stay logical-call counts and
+every cost estimate in a MetricsBench report carries this caveat next to the
+figure, not in a footnote.
 
 The existing honest representation is reused rather than reinvented:
 `RequestCounts::backend_bills_requests` already distinguishes "these counts
@@ -431,10 +437,13 @@ from precedent, not an extension of it.
 lane, credentials and a bucket. Correctness, CI and MinIO diagnostic runs do
 not.
 
-**Retry blindness is now a recorded, unclosed gap.** Naming it here does not
-fix it. A follow-up may add a retry counter below `InstrumentedStore`; until
-then every published request count and every derived cost figure, including
-those already published for ClickBench, under-reports by the retry factor.
+**Retry blindness was a recorded gap, closed by #928.** Naming it here did not
+fix it; the follow-up this ADR anticipated ("a retry counter below
+`InstrumentedStore`") landed as the per-operation `attempts` counter
+(`ravel_store_attempts_total`). A published request count that was taken as a
+logical-call count (this bench, and ClickBench figures published before #928)
+still under-reports by the retry factor; the billed count is now observable
+wherever the S3 counting connector is installed (the server's `/metrics`).
 
 **One known defect will corrupt a lane if ignored.** Flight SQL records a
 statement's cost into the `/metrics` aggregator twice, pinned at

--- a/docs/object-store-contract.md
+++ b/docs/object-store-contract.md
@@ -639,6 +639,24 @@ the wrapped backend's own declaration. `ravel-server`'s `build_store` wraps
 whichever backend it built, unconditionally in every mode, and the contract
 suite runs its full assertion set through the decorator to prove transparency.
 
+`calls` is completions, not attempts: it counts one per logical operation, so
+the `object_store` retry loop that runs *below* this decorator (`RetryConfig`,
+default `max_retries = 10`) is invisible to it --- one `get()` that retried nine
+times is one `calls`/`get` while the provider bills ten HTTP requests (issue
+#928). The billed count is carried in a separate per-operation `attempts`
+counter on the same `StoreMetrics` block, filled in by the S3 adapter's counting
+HTTP connector (`S3Store::with_metrics`, installed via
+`AmazonS3Builder::with_http_connector`), which records one attempt per HTTP
+request `object_store` issues, retries included. `attempts >= calls` always;
+`attempts - calls` is the billed retry overhead, and `attempts` can exceed
+`calls` for `get`/`put` even with no retry, because a whole-object read and a
+multipart write each issue several HTTP requests per logical call. The connector
+wraps the default reqwest client and delegates unchanged, so `RetryConfig` and
+every retry behavior above stay exactly as documented: this observes the loop,
+it does not alter it. A backend that issues no HTTP (`MemoryStore`) leaves
+`attempts` at zero. `ravel-server` exports it as `ravel_store_attempts_total`
+beside `ravel_store_calls_total`.
+
 The contract suite in `crates/ravel-object-store/tests/contract.rs` runs
 against all three, multipart included (`assert_multipart_upload` is part of
 `run_contract_suite`, written against the trait so it holds for the oracle, the

--- a/docs/object-store-contract.md
+++ b/docs/object-store-contract.md
@@ -647,7 +647,16 @@ times is one `calls`/`get` while the provider bills ten HTTP requests (issue
 counter on the same `StoreMetrics` block, filled in by the S3 adapter's counting
 HTTP connector (`S3Store::with_metrics`, installed via
 `AmazonS3Builder::with_http_connector`), which records one attempt per HTTP
-request `object_store` issues, retries included. `attempts >= calls` always.
+request `object_store` issues, retries included. `attempts >= calls` holds
+exactly when every store the decorator counts a `calls` on records its attempts
+into the same `StoreMetrics` handle: a store built with `S3Store::new` (no
+handle) wrapped in `InstrumentedStore::with_metrics` would count `calls` while
+recording no `attempts`, so the relation is a property of the wiring, not of the
+decorator. `ravel-server` establishes it for the whole S3 chain by handing one
+handle to the base `S3Store` and, under `--tenant-kms-config`, to every
+per-tenant KMS-routed store (`KmsRoutingStore::new`); a store built without the
+handle would make `ravel_store_attempts_total` under-report for the traffic it
+serves (issue #928).
 
 `attempts` is the billed HTTP request count, not a retry counter. Retries are
 one reason it exceeds `calls`, and not the only one: a whole-object read and a

--- a/docs/object-store-contract.md
+++ b/docs/object-store-contract.md
@@ -641,16 +641,20 @@ suite runs its full assertion set through the decorator to prove transparency.
 
 `calls` is completions, not attempts: it counts one per logical operation, so
 the `object_store` retry loop that runs *below* this decorator (`RetryConfig`,
-default `max_retries = 10`) is invisible to it --- one `get()` that retried nine
+default `max_retries = 10`) is invisible to it: one `get()` that retried nine
 times is one `calls`/`get` while the provider bills ten HTTP requests (issue
 #928). The billed count is carried in a separate per-operation `attempts`
 counter on the same `StoreMetrics` block, filled in by the S3 adapter's counting
 HTTP connector (`S3Store::with_metrics`, installed via
 `AmazonS3Builder::with_http_connector`), which records one attempt per HTTP
-request `object_store` issues, retries included. `attempts >= calls` always;
-`attempts - calls` is the billed retry overhead, and `attempts` can exceed
-`calls` for `get`/`put` even with no retry, because a whole-object read and a
-multipart write each issue several HTTP requests per logical call. The connector
+request `object_store` issues, retries included. `attempts >= calls` always.
+
+`attempts` is the billed HTTP request count, not a retry counter. Retries are
+one reason it exceeds `calls`, and not the only one: a whole-object read and a
+multipart write each issue several HTTP requests per logical call, so `attempts`
+exceeds `calls` for `get`/`put` even when nothing retried. Read `attempts` as
+what the provider bills, and do not read `attempts - calls` as retry overhead;
+isolating retries specifically would need a separate counter this does not add. The connector
 wraps the default reqwest client and delegates unchanged, so `RetryConfig` and
 every retry behavior above stay exactly as documented: this observes the loop,
 it does not alter it. A backend that issues no HTTP (`MemoryStore`) leaves

--- a/services/ravel-server/src/metrics.rs
+++ b/services/ravel-server/src/metrics.rs
@@ -484,11 +484,14 @@ fn render_store_family(out: &mut String, mode: Mode, snapshot: &StoreMetricsSnap
     write_header(
         out,
         "ravel_store_attempts_total",
-        "Billed HTTP requests, by operation (issue #928). Always >= \
-         ravel_store_calls_total for an HTTP backend. Retries are one reason it \
-         exceeds the call count and not the only one: a whole-object read and a \
-         multipart write each issue several HTTP requests per logical call, so \
-         the difference is not a retry count. Zero for a non-HTTP backend.",
+        "Billed HTTP requests, by operation (issue #928). >= \
+         ravel_store_calls_total when every store the call counter sees shares \
+         this metrics handle, which the server wires up: the base S3 store and \
+         every per-tenant KMS-routed store record attempts into one block. \
+         Retries are one reason it exceeds the call count and not the only one: \
+         a whole-object read and a multipart write each issue several HTTP \
+         requests per logical call, so the difference is not a retry count. Zero \
+         for a non-HTTP backend.",
         "counter",
     );
     for op in StoreOp::ALL {

--- a/services/ravel-server/src/metrics.rs
+++ b/services/ravel-server/src/metrics.rs
@@ -484,10 +484,11 @@ fn render_store_family(out: &mut String, mode: Mode, snapshot: &StoreMetricsSnap
     write_header(
         out,
         "ravel_store_attempts_total",
-        "Billed HTTP requests including retries, by operation (issue #928). \
-         Always >= ravel_store_calls_total for an HTTP backend; the difference \
-         is the retry overhead object_store's loop hides below the call count. \
-         Zero for a non-HTTP backend.",
+        "Billed HTTP requests, by operation (issue #928). Always >= \
+         ravel_store_calls_total for an HTTP backend. Retries are one reason it \
+         exceeds the call count and not the only one: a whole-object read and a \
+         multipart write each issue several HTTP requests per logical call, so \
+         the difference is not a retry count. Zero for a non-HTTP backend.",
         "counter",
     );
     for op in StoreOp::ALL {

--- a/services/ravel-server/src/metrics.rs
+++ b/services/ravel-server/src/metrics.rs
@@ -483,6 +483,24 @@ fn render_store_family(out: &mut String, mode: Mode, snapshot: &StoreMetricsSnap
 
     write_header(
         out,
+        "ravel_store_attempts_total",
+        "Billed HTTP requests including retries, by operation (issue #928). \
+         Always >= ravel_store_calls_total for an HTTP backend; the difference \
+         is the retry overhead object_store's loop hides below the call count. \
+         Zero for a non-HTTP backend.",
+        "counter",
+    );
+    for op in StoreOp::ALL {
+        write_sample(
+            out,
+            "ravel_store_attempts_total",
+            &[Label::Mode(mode), Label::Op(op)],
+            snapshot.op(op).attempts,
+        );
+    }
+
+    write_header(
+        out,
         "ravel_store_ok_total",
         "Object-store calls that returned Ok, by operation.",
         "counter",
@@ -3595,6 +3613,8 @@ mod tests {
             ok: 5,
             errors,
             bytes: 4096,
+            // Above calls: the retry (billed) overhead #928 exposes.
+            attempts: 9,
             latency_micros_buckets,
             latency_nanos_total: 900_000,
         };
@@ -3638,6 +3658,10 @@ mod tests {
         assert!(
             body.contains("ravel_store_calls_total{mode=\"all\",op=\"get\"} 7"),
             "missing calls sample:\n{body}"
+        );
+        assert!(
+            body.contains("ravel_store_attempts_total{mode=\"all\",op=\"get\"} 9"),
+            "missing attempts sample (billed requests incl. retries, #928):\n{body}"
         );
         assert!(
             body.contains("ravel_store_ok_total{mode=\"all\",op=\"get\"} 5"),

--- a/services/ravel-server/src/store.rs
+++ b/services/ravel-server/src/store.rs
@@ -408,9 +408,15 @@ pub fn build_store(cli: &Cli) -> anyhow::Result<BuiltStore> {
             // decision 2): off by default. Without --tenant-kms-config this builds exactly
             // today's store, byte-for-byte, no KmsRoutingStore in the chain.
             if cli.tenant_kms_config.is_some() {
+                // Thread the SAME metrics handle into the per-tenant store
+                // factory: each KMS-routed S3Store records its billed HTTP
+                // requests (attempts) into the one block the base store and the
+                // InstrumentedStore below already share, so a routed write's
+                // attempts are counted, not dropped (issue #928).
                 let kms = Arc::new(KmsRoutingStore::new(
                     Arc::new(store) as Arc<dyn ObjectStoreBackend>,
                     config,
+                    Arc::clone(&metrics),
                 ));
                 let instrumented = InstrumentedStore::with_metrics(
                     SharedKmsStore(kms.clone()),
@@ -826,6 +832,177 @@ mod tests {
         );
     }
 
+    /// A path-style mock S3, a `--tenant-kms-config` build, and one registered
+    /// tenant key, so a `t/<hash>/...` write routes to a per-tenant KMS store.
+    /// Returns the parsed CLI, the built store bundle, and the mock so a test
+    /// can drive a routed (or unrouted) write and read both the metrics handle
+    /// and the requests the endpoint served.
+    async fn kms_routed_build(
+        tenant_hash: &str,
+    ) -> (Arc<dyn ObjectStoreBackend>, Arc<StoreMetrics>, Arc<MockS3>) {
+        use clap::Parser;
+        use std::io::Write;
+
+        let (s3_endpoint, mock) = spawn_mock_s3().await;
+
+        let mut file = tempfile::NamedTempFile::new().expect("create temp tenant-kms-config file");
+        file.write_all(
+            br#"
+                [tenants]
+                acme = "arn:aws:kms:us-east-1:111122223333:key/acme"
+            "#,
+        )
+        .expect("write temp file");
+
+        let cli = Cli::try_parse_from([
+            "ravel-server",
+            "--store",
+            "s3",
+            "--s3-bucket",
+            "ravel-test",
+            "--s3-endpoint",
+            &s3_endpoint,
+            "--s3-access-key",
+            "test",
+            "--s3-secret-key",
+            "test",
+            "--tenant-kms-config",
+            file.path().to_str().expect("temp path is valid utf-8"),
+        ])
+        .expect("flags parse");
+
+        let BuiltStore {
+            foreground: store,
+            metrics,
+            kms,
+            ..
+        } = build_store(&cli).expect("dummy S3 config must build without network access");
+        let kms = kms.expect("--tenant-kms-config must yield a KmsRoutingStore handle");
+
+        // `build_store` leaves the tenant-key map empty (main.rs installs it
+        // later, once the tenant-hash scheme is up), so register one here. The
+        // hash text is arbitrary: routing keys on the exact `t/<hash>/` segment.
+        kms.set_tenant_key(
+            tenant_hash.to_string(),
+            "arn:aws:kms:us-east-1:111122223333:key/acme".to_string(),
+        );
+
+        (store, metrics, mock)
+    }
+
+    /// A KMS-routed write's billed HTTP requests are counted into the SAME
+    /// metrics handle the base store and the outer `InstrumentedStore` share
+    /// (issue #928). Before the fix, `KmsRoutingStore` built its per-tenant
+    /// stores with `S3Store::new` (no metrics handle), so a routed write's
+    /// `attempts` were dropped on the floor while its `calls` were still
+    /// counted, making `ravel_store_attempts_total` under-report to zero for
+    /// exactly the per-tenant traffic.
+    ///
+    /// The count is pinned EXACTLY to what the mock endpoint served, not `> 0`:
+    /// a fraction of the truth passes a `> 0` assertion, which is the very
+    /// failure being fixed. Reverting the per-tenant factory in
+    /// `KmsRoutingStore::new` from `S3Store::with_metrics` back to
+    /// `S3Store::new` turns this red: the routed put's store then records no
+    /// attempt, so `put.attempts` reads 0 while the mock still served a PUT.
+    #[tokio::test]
+    async fn kms_routed_write_counts_attempts_into_shared_metrics() {
+        use std::sync::atomic::Ordering;
+
+        let tenant_hash = "00112233445566778899aabbccddeeff";
+        let (store, metrics, mock) = kms_routed_build(tenant_hash).await;
+
+        assert_eq!(
+            metrics.snapshot().put.attempts,
+            0,
+            "precondition: no attempt recorded before any write"
+        );
+
+        let key = format!("t/{tenant_hash}/seg/0001");
+        store
+            .put(&key, Bytes::from_static(b"payload"), PutOptions::default())
+            .await
+            .expect("routed put through the per-tenant KMS store");
+
+        // Ground truth: the number of PUTs that reached the wire.
+        let served = mock.put_count.load(Ordering::SeqCst) as u64;
+        assert!(
+            served >= 1,
+            "the mock must have served the routed PUT (proves the per-tenant path ran)"
+        );
+        assert!(
+            mock.objects
+                .lock()
+                .expect("objects lock")
+                .contains_key(&key),
+            "the routed object must have landed under its tenant key"
+        );
+
+        let snap = metrics.snapshot();
+        assert_eq!(
+            snap.put.attempts, served,
+            "every billed HTTP request the per-tenant store issued is counted into the shared \
+             handle, exactly as many as the mock saw"
+        );
+        assert_eq!(
+            snap.put.calls, 1,
+            "the outer decorator counts exactly one logical put call"
+        );
+    }
+
+    /// The relation the `ravel_store_attempts_total` help text claims ---
+    /// `attempts >= calls` when every store in the chain shares the metrics
+    /// handle --- pinned across BOTH branches of `KmsRoutingStore`: an unrouted
+    /// write handled by the base store, and a routed write handled by a
+    /// per-tenant store. One snapshot covers the whole chain, so `put.attempts`
+    /// sees both stores' billed requests. Reverting the per-tenant factory to
+    /// `S3Store::new` turns this red: the routed write then records no attempt,
+    /// so `attempts` (1) falls below `calls` (2), the exact regression the help
+    /// text would otherwise only describe.
+    #[tokio::test]
+    async fn attempts_stay_at_or_above_calls_across_the_kms_chain() {
+        use std::sync::atomic::Ordering;
+
+        let tenant_hash = "ffeeddccbbaa99887766554433221100";
+        let (store, metrics, mock) = kms_routed_build(tenant_hash).await;
+
+        // Unrouted: `sys/` is never tenant-scoped, so this goes to the base
+        // store. Routed: `t/<hash>/` routes to the per-tenant store.
+        store
+            .put("sys/base", Bytes::from_static(b"a"), PutOptions::default())
+            .await
+            .expect("unrouted put through the base store");
+        store
+            .put(
+                &format!("t/{tenant_hash}/seg/0001"),
+                Bytes::from_static(b"b"),
+                PutOptions::default(),
+            )
+            .await
+            .expect("routed put through the per-tenant store");
+
+        let served = mock.put_count.load(Ordering::SeqCst) as u64;
+        assert_eq!(
+            served, 2,
+            "both writes must reach the wire (base and per-tenant)"
+        );
+
+        let snap = metrics.snapshot();
+        assert_eq!(
+            snap.put.calls, 2,
+            "two logical put calls were counted by the outer decorator"
+        );
+        assert_eq!(
+            snap.put.attempts, served,
+            "both stores record their billed requests into the one shared handle"
+        );
+        assert!(
+            snap.put.attempts >= snap.put.calls,
+            "attempts ({}) must stay >= calls ({}) once every store shares the handle",
+            snap.put.attempts,
+            snap.put.calls,
+        );
+    }
+
     /// `build_store`'s error text, panicking with `context` if it succeeded.
     /// `BuiltStore` is not `Debug`, so `expect_err` is unavailable.
     fn build_store_error(cli: &Cli, context: &str) -> String {
@@ -874,6 +1051,10 @@ mod tests {
     struct MockS3 {
         objects: std::sync::Mutex<std::collections::HashMap<String, Bytes>>,
         signed_with: std::sync::Mutex<Option<(String, String)>>,
+        /// Count of PUT requests the endpoint actually served, so a test can
+        /// pin `attempts` to the exact number of billed requests on the wire
+        /// rather than to `> 0` (issue #928).
+        put_count: std::sync::atomic::AtomicUsize,
     }
 
     async fn spawn_mock_s3() -> (String, Arc<MockS3>) {
@@ -900,6 +1081,9 @@ mod tests {
                 header_text("authorization"),
                 header_text("x-amz-security-token"),
             ));
+            state
+                .put_count
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             state
                 .objects
                 .lock()

--- a/services/ravel-server/src/store.rs
+++ b/services/ravel-server/src/store.rs
@@ -393,7 +393,15 @@ pub fn build_store(cli: &Cli) -> anyhow::Result<BuiltStore> {
                 auth,
                 instance_metadata_endpoint: cli.s3_instance_metadata_endpoint.clone(),
             };
-            let store = S3Store::new(config.clone())
+            // One shared metrics block for the whole S3 chain: the counting HTTP
+            // connector inside `S3Store` records billed HTTP requests (attempts,
+            // retries included) into it below `object_store`'s retry loop, and
+            // the `InstrumentedStore` decorator records completed calls into the
+            // same block, so `ravel_store_attempts_total` and
+            // `ravel_store_calls_total` come from one snapshot (issue #928). Built
+            // before the store so the connector and the decorator share it.
+            let metrics = Arc::new(StoreMetrics::default());
+            let store = S3Store::with_metrics(config.clone(), Arc::clone(&metrics))
                 .map_err(|err| anyhow::anyhow!("failed to build S3 store: {err}"))?;
 
             // Per-tenant SSE-KMS routing (ADR-0062 decision 1, ADR-0072
@@ -404,12 +412,13 @@ pub fn build_store(cli: &Cli) -> anyhow::Result<BuiltStore> {
                     Arc::new(store) as Arc<dyn ObjectStoreBackend>,
                     config,
                 ));
-                let instrumented = InstrumentedStore::new(SharedKmsStore(kms.clone()));
-                let metrics = instrumented.metrics();
+                let instrumented = InstrumentedStore::with_metrics(
+                    SharedKmsStore(kms.clone()),
+                    Arc::clone(&metrics),
+                );
                 (Arc::new(instrumented), metrics, Some(kms))
             } else {
-                let instrumented = InstrumentedStore::new(store);
-                let metrics = instrumented.metrics();
+                let instrumented = InstrumentedStore::with_metrics(store, Arc::clone(&metrics));
                 (Arc::new(instrumented), metrics, None)
             }
         }


### PR DESCRIPTION
feat(object-store): count billed HTTP requests below the retry loop

Every request count in this repository was a logical-call count. object_store
runs its own retry loop below the ObjectStoreBackend boundary (RetryConfig,
default max_retries 10), so one get() that retried nine times recorded one
StoreOp::Get while the provider billed ten requests. InstrumentedStore counts
completions, so the divergence was invisible: one-directional, and under
throttling unbounded above the counted number. Nothing measured the gap.

Add a separate per-operation attempts counter alongside the existing calls
counter, without redefining it. attempts is filled in by a counting HTTP
connector installed on the S3 client via AmazonS3Builder::with_http_connector,
below object_store's retry loop: it records one attempt per HTTP request the
client issues, retries included, so attempts - calls is the billed retry
overhead. The connector wraps the default reqwest client and delegates the
request unchanged, so retry behavior is byte-for-byte as before; this observes
the loop, it does not replace it. Each attempt is attributed to the operation
that issued it through a tokio task-local the S3 adapter sets around every op,
so the figure keeps the per-operation split and never pools. A backend that
issues no HTTP (MemoryStore) leaves attempts at zero.

InstrumentedStore::with_metrics lets S3Store's connector and the decorator share
one StoreMetrics block, so attempts and calls come from a single snapshot.
ravel-server builds the S3 chain around one shared block and exports the figure
as ravel_store_attempts_total beside ravel_store_calls_total.

Tests drive object_store's real retry loop over the existing fake S3 endpoint
and assert attempts against the count the server saw: a GET faulted three times
records four attempts and one call (attempts - calls == 3, exact), a quiet path
records attempts == calls, and a retried PUT charges its retries to put and no
other op. The fault injection is at the HTTP layer, not the ObjectStoreBackend
FaultStore the issue text names: FaultStore sits above object_store and returns
one error per call, so it cannot exercise the retry loop below the trait
boundary that creates the gap. The fake endpoint is the fault store for that
layer and its per-op request counter is the ground-truth billed count.

ADR-0075's max_s3_requests bounds logical calls per query (QueryAccounting), so
a query throttled into ten attempts per call still spends ten times its budget
at the provider while passing the check. This change makes the billed count
observable process-globally but not per query: the connector runs below the
query layer and holds no QueryAccounting handle (accounting is passed
explicitly, never via a task-local), so per-query enforcement on billed
requests would need the attempt count threaded up through the fetch return path
first. The budget's semantics are unchanged here.

Refs: #928
Signed-off-by: Panagiotis Moustafellos <pmoust@nofire.ai>

