### PR TITLE
fix(ravel-sql): refuse invalid column stats on the exact MIN/MAX path

### DIFF
--- a/crates/ravel-catalog/src/column_stats_resolve.rs
+++ b/crates/ravel-catalog/src/column_stats_resolve.rs
@@ -55,6 +55,35 @@ pub struct LoadedColumnStats {
     pub part_blake3: Vec<[u8; 32]>,
 }
 
+/// The entry for column `name` in `segment`, and only when the segment carries
+/// EXACTLY one such entry. `None` covers both "no entry" (the ordinary
+/// not-covered case: the fold never built this column, so the reader declines
+/// and the scan answers) and "more than one entry", which is a malformed
+/// record: `decode_column_stats` refuses an object carrying a duplicate column
+/// name outright, so a record reaching a reader with two entries under one name
+/// arrived through some other carrier and no rule could pick the right one.
+///
+/// Duplicates cannot be resolved silently by position, because the two shapes
+/// of "silently" disagree with each other: an `iter().find()` lookup keeps the
+/// FIRST entry while collecting the same list into a by-name map keeps the
+/// LAST, so one malformed record answers one query two ways depending on which
+/// reader ran. Fail closed instead; the column is simply uncovered.
+pub fn unique_column_stat<'a>(
+    segment: &'a ColumnStatsSegment,
+    name: &str,
+) -> Option<&'a ravel_proto::catalog::v1::ColumnStat> {
+    let mut found = None;
+    for column in &segment.columns {
+        if column.name == name {
+            if found.is_some() {
+                return None;
+            }
+            found = Some(column);
+        }
+    }
+    found
+}
+
 /// The column-stats object the current folded HEAD points at, resolved from
 /// HEAD alone (one GET) without yet fetching the object itself. Splitting the
 /// load in two lets a caller consult a reuse cache keyed by what actually

--- a/crates/ravel-catalog/src/lib.rs
+++ b/crates/ravel-catalog/src/lib.rs
@@ -31,7 +31,7 @@ pub use auth_token_map::{
 };
 pub use catalog::Catalog;
 pub use catalog::resolve_rewrite_supersession;
-pub use column_stats_resolve::{LoadColumnStatsError, LoadedColumnStats};
+pub use column_stats_resolve::{LoadColumnStatsError, LoadedColumnStats, unique_column_stat};
 pub use config::{
     CatalogConfig, DEFAULT_BYTE_CACHE_MAX_BYTES, DEFAULT_BYTE_CACHE_MAX_ENTRIES,
     DEFAULT_BYTE_CACHE_MAX_ENTRY_BYTES, DEFAULT_CACHE_CAPACITY_PER_TENANT,
@@ -72,7 +72,7 @@ pub use snapshot_format::{
     DEFAULT_MAX_POSTINGS_BYTES, DEFAULT_MAX_SNAPSHOT_PART_BYTES, DecodedColumnStats, DecodedPart,
     DecodedPostings, HEAD_FORMAT_VERSION, MAGIC, NamePostings, PartLimits, PostingsLimits,
     SnapshotFormatError, VERSION, decode_column_stats, decode_head, decode_part, decode_postings,
-    encode_column_stats, encode_head, encode_part, encode_postings,
+    encode_column_stats, encode_head, encode_part, encode_postings, validate_min_max_presence,
 };
 pub use tenant_config::{
     DeclaredColumnType, DeclaredTypedColumn, FIXED_LOGS_SQL_COLUMNS,

--- a/crates/ravel-catalog/src/snapshot_format/column_stats.rs
+++ b/crates/ravel-catalog/src/snapshot_format/column_stats.rs
@@ -106,7 +106,22 @@ fn encode_column_stats_versioned(
     segments: &[ColumnStatsSegment],
 ) -> Result<Vec<u8>, SnapshotFormatError> {
     validate_segments(segments, version)?;
+    frame_column_stats(version, tenant_hash, signal, part_blake3, segments)
+}
 
+/// Envelope framing with NO validation: the byte layout only. Split out of
+/// [`encode_column_stats_versioned`] so a test can build a well-framed object
+/// carrying a record that `validate_segments` would refuse, which is the only
+/// way to reach `decode_column_stats`'s own validation call with hostile input
+/// (every public writer validates first, so an encoder-side test proves
+/// nothing about the decoder).
+fn frame_column_stats(
+    version: u8,
+    tenant_hash: [u8; 16],
+    signal: u32,
+    part_blake3: Vec<Vec<u8>>,
+    segments: &[ColumnStatsSegment],
+) -> Result<Vec<u8>, SnapshotFormatError> {
     let mut segments_raw = Vec::new();
     for segment in segments {
         segments_raw.extend_from_slice(&segment.encode_length_delimited_to_vec());
@@ -339,19 +354,7 @@ fn validate_column(column: &ColumnStat) -> Result<(), SnapshotFormatError> {
         });
     }
 
-    if column.non_null_count == 0 && (column.min.is_some() || column.max.is_some()) {
-        return Err(SnapshotFormatError::ColumnStatsUnexpectedMinMax {
-            name: column.name.clone(),
-        });
-    }
-    // The symmetric case: non-null rows must carry both extrema. A record with
-    // rows but no min/max cannot support a MIN/MAX answer, and a reader that
-    // trusted it would report the extremum of non-null data as exactly NULL.
-    if column.non_null_count > 0 && (column.min.is_none() || column.max.is_none()) {
-        return Err(SnapshotFormatError::ColumnStatsMissingMinMax {
-            name: column.name.clone(),
-        });
-    }
+    validate_min_max_presence(column)?;
     if let Some(min) = &column.min {
         check_value_kind(column, min, "min")?;
     }
@@ -450,6 +453,37 @@ fn validate_column(column: &ColumnStat) -> Result<(), SnapshotFormatError> {
         });
     }
 
+    Ok(())
+}
+
+/// The min/max presence clause of the column-statistics validity predicate:
+/// `min` and `max` are BOTH present when `non_null_count > 0` and BOTH absent
+/// when it is zero. Both directions are wrong answers on a path that reports
+/// `Precision::Exact`, in mirror-image ways:
+///
+/// - non-null rows with no recorded extremum makes the extremum of non-null
+///   data read as exactly NULL;
+/// - `non_null_count == 0` with extrema present describes no live row at all,
+///   so an all-NULL column contributes a value to a MIN/MAX the scan would
+///   answer NULL for.
+///
+/// Public because [`crate::LoadedColumnStats`] has public fields, so a reader
+/// can receive `ColumnStat` records from a carrier that never passed through
+/// [`decode_column_stats`] (an in-process construction, a cache, a test
+/// fixture). Such a reader enforces this clause by calling this function
+/// rather than restating it, so the decode boundary and the read site cannot
+/// drift into disagreeing about what a usable entry is.
+pub fn validate_min_max_presence(column: &ColumnStat) -> Result<(), SnapshotFormatError> {
+    if column.non_null_count == 0 && (column.min.is_some() || column.max.is_some()) {
+        return Err(SnapshotFormatError::ColumnStatsUnexpectedMinMax {
+            name: column.name.clone(),
+        });
+    }
+    if column.non_null_count > 0 && (column.min.is_none() || column.max.is_none()) {
+        return Err(SnapshotFormatError::ColumnStatsMissingMinMax {
+            name: column.name.clone(),
+        });
+    }
     Ok(())
 }
 
@@ -719,6 +753,81 @@ mod tests {
         assert_eq!(
             err,
             SnapshotFormatError::ColumnStatsUnexpectedMinMax {
+                name: "AdvEngineID".to_string(),
+            }
+        );
+    }
+
+    /// #970: the DECODER refuses a duplicate column name, not merely the
+    /// encoder. Every test above reaches `validate_columns` through
+    /// `encode_column_stats`, so none of them would fail if
+    /// `decode_column_stats` stopped calling `validate_segments` -- and it is
+    /// the decode path that faces bytes a reader did not write. Framed here
+    /// without validation so the malformed record is what decode actually
+    /// receives.
+    ///
+    /// Prove-the-test: delete the `validate_segments(&segments, version)?;`
+    /// call in `decode_column_stats` and this decode succeeds, so
+    /// `expect_err` panics.
+    #[test]
+    fn decode_refuses_duplicate_column_name_in_unvalidated_bytes() {
+        let mut seg = segment(1, 0, 1);
+        let dup = seg.columns[0].clone();
+        seg.columns.push(dup);
+        let bytes = frame_column_stats(1, [0x11; 16], 3, vec![], &[seg]).expect("frames");
+        let err =
+            decode_column_stats(&bytes, &ColumnStatsLimits::default()).expect_err("decode refuses");
+        assert_eq!(
+            err,
+            SnapshotFormatError::ColumnStatsDuplicateColumnName {
+                name: "AdvEngineID".to_string(),
+            }
+        );
+    }
+
+    /// #970, the mirror of the presence clause at the decode boundary: an
+    /// all-NULL column (`non_null_count == 0`) carrying extrema describes no
+    /// live row, and a reader that trusted it would report a value for a
+    /// MIN/MAX whose true answer is NULL.
+    ///
+    /// Prove-the-test: delete the `validate_segments(&segments, version)?;`
+    /// call in `decode_column_stats` and this decode succeeds.
+    #[test]
+    fn decode_refuses_min_max_with_zero_non_null_in_unvalidated_bytes() {
+        let mut seg = segment(1, 0, 1);
+        seg.columns[0].non_null_count = 0;
+        seg.columns[0].null_count = 10;
+        seg.columns[0].dictionary = vec![];
+        seg.columns[0].dictionary_present = false;
+        seg.columns[0].sum = None;
+        // min/max still populated: inconsistent with an all-null column.
+        let bytes = frame_column_stats(1, [0x11; 16], 3, vec![], &[seg]).expect("frames");
+        let err =
+            decode_column_stats(&bytes, &ColumnStatsLimits::default()).expect_err("decode refuses");
+        assert_eq!(
+            err,
+            SnapshotFormatError::ColumnStatsUnexpectedMinMax {
+                name: "AdvEngineID".to_string(),
+            }
+        );
+    }
+
+    /// The other direction of the same clause, also through decode: non-null
+    /// rows with no recorded extremum.
+    ///
+    /// Prove-the-test: delete the `validate_segments(&segments, version)?;`
+    /// call in `decode_column_stats` and this decode succeeds.
+    #[test]
+    fn decode_refuses_missing_min_max_with_non_null_rows_in_unvalidated_bytes() {
+        let mut seg = segment(1, 0, 1);
+        seg.columns[0].min = None;
+        seg.columns[0].max = None;
+        let bytes = frame_column_stats(1, [0x11; 16], 3, vec![], &[seg]).expect("frames");
+        let err =
+            decode_column_stats(&bytes, &ColumnStatsLimits::default()).expect_err("decode refuses");
+        assert_eq!(
+            err,
+            SnapshotFormatError::ColumnStatsMissingMinMax {
                 name: "AdvEngineID".to_string(),
             }
         );

--- a/crates/ravel-catalog/src/snapshot_format/mod.rs
+++ b/crates/ravel-catalog/src/snapshot_format/mod.rs
@@ -12,6 +12,7 @@ mod postings;
 
 pub use column_stats::{
     DecodedColumnStats, decode_column_stats, encode_column_stats, encode_column_stats_v2,
+    validate_min_max_presence,
 };
 pub use error::SnapshotFormatError;
 pub use head::{HEAD_FORMAT_VERSION, decode_head, encode_head};

--- a/crates/ravel-sql/src/logs_scan.rs
+++ b/crates/ravel-sql/src/logs_scan.rs
@@ -250,7 +250,7 @@ use datafusion::physical_plan::{
 };
 use datafusion::scalar::ScalarValue;
 use futures::{Stream, StreamExt, TryStreamExt};
-use ravel_catalog::{LoadedColumnStats, SegmentRef};
+use ravel_catalog::{LoadedColumnStats, SegmentRef, unique_column_stat, validate_min_max_presence};
 use ravel_logseg::footer::LogFooter;
 use ravel_logseg::{
     AttrColumn, BoolCursor, BytesCursor, ColumnSelection, ColumnarBlockView, F64BitsCursor,
@@ -1196,8 +1196,10 @@ impl LogsScanExec {
     /// per-column form would give -- the safety lemma requires falling back to
     /// scanning for that column: no loaded column-stats object, an unsupported
     /// declared type (`Str`), a relevant segment with no entry in the loaded
-    /// stats, or a segment whose stat for this column is missing or decodes to
-    /// a value of the wrong kind.
+    /// stats, or a segment whose stat for this column is missing, invalid
+    /// (#970: two entries under one name, or `min`/`max` presence disagreeing
+    /// with `non_null_count` in either direction), or decodes to a value of the
+    /// wrong kind.
     ///
     /// `Some((min, max))` with both a `None`-valued scalar is still exact, not
     /// a fallback: every covered segment's column was entirely null, or there
@@ -1244,26 +1246,45 @@ impl LogsScanExec {
                 }
                 break;
             };
-            let by_name: HashMap<&str, &ravel_proto::catalog::v1::ColumnStat> = seg_stats
-                .columns
-                .iter()
-                .map(|c| (c.name.as_str(), c))
-                .collect();
+            // One entry per name, and a name carrying more than one entry maps
+            // to `None`: collecting the pairs straight into a map would keep
+            // the LAST duplicate and answer from it, while the dictionary
+            // readers below resolve the same list with `find` and would keep
+            // the FIRST. A duplicate name is malformed either way
+            // (`decode_column_stats` refuses an object carrying one), and no
+            // rule could pick the right entry, so the name is poisoned and its
+            // column declines. Still one walk of the segment's columns.
+            let mut by_name: HashMap<&str, Option<&ravel_proto::catalog::v1::ColumnStat>> =
+                HashMap::with_capacity(seg_stats.columns.len());
+            for c in seg_stats.columns.iter() {
+                by_name
+                    .entry(c.name.as_str())
+                    .and_modify(|slot| *slot = None)
+                    .or_insert(Some(c));
+            }
             for (k, a) in acc.iter_mut().enumerate() {
                 if a.declined {
                     continue;
                 }
                 let declared = &self.declared[k];
-                let Some(stat) = by_name.get(declared.key.as_str()) else {
+                let Some(Some(stat)) = by_name.get(declared.key.as_str()) else {
+                    // No entry (the ordinary not-covered case) or a poisoned
+                    // one (a duplicate name).
                     a.declined = true;
                     continue;
                 };
-                // Non-null rows with no recorded extremum cannot answer MIN/MAX.
-                // Without this the accumulator stays `None` and the loop below
-                // substitutes a NULL scalar, which is then reported as
-                // `Precision::Exact` -- claiming the extremum of non-null data is
-                // exactly NULL. Fail closed and let the scan answer instead.
-                if stat.non_null_count > 0 && (stat.min.is_none() || stat.max.is_none()) {
+                // `min`/`max` presence must agree with `non_null_count` in both
+                // directions, or this path reports a wrong extremum as
+                // `Precision::Exact`: non-null rows with no recorded extremum
+                // leave the accumulator `None` and the loop below substitutes a
+                // NULL scalar, claiming the extremum of non-null data is exactly
+                // NULL, while an all-null column carrying extrema contributes a
+                // value describing no live row. `decode_column_stats` refuses
+                // either shape, and this calls the same clause it enforces
+                // rather than restating it, because `LoadedColumnStats` has
+                // public fields and can be populated by a carrier that never
+                // decoded an object. Fail closed and let the scan answer.
+                if validate_min_max_presence(stat).is_err() {
                     a.declined = true;
                     continue;
                 }
@@ -1354,7 +1375,7 @@ impl LogsScanExec {
         let mut total: u64 = 0;
         for seg in self.segments.iter() {
             let seg_stats = stats.segments.get(&segment_identity(seg))?;
-            let stat = seg_stats.columns.iter().find(|c| c.name == declared.key)?;
+            let stat = unique_column_stat(seg_stats, &declared.key)?;
             if !stat.dictionary_present {
                 return None;
             }
@@ -1420,7 +1441,7 @@ impl LogsScanExec {
         let mut null_count: u64 = 0;
         for seg in self.segments.iter() {
             let seg_stats = stats.segments.get(&segment_identity(seg))?;
-            let stat = seg_stats.columns.iter().find(|c| c.name == declared.key)?;
+            let stat = unique_column_stat(seg_stats, &declared.key)?;
             if !stat.dictionary_present {
                 return None;
             }
@@ -1477,7 +1498,7 @@ impl LogsScanExec {
         let mut non_null_count: u64 = 0;
         for seg in self.segments.iter() {
             let seg_stats = stats.segments.get(&segment_identity(seg))?;
-            let stat = seg_stats.columns.iter().find(|c| c.name == declared.key)?;
+            let stat = unique_column_stat(seg_stats, &declared.key)?;
             let seg_sum = stat.sum?;
             sum = sum.checked_add(i128::from(seg_sum))?;
             non_null_count = non_null_count.checked_add(stat.non_null_count)?;

--- a/crates/ravel-sql/tests/logs_metadata_agg.rs
+++ b/crates/ravel-sql/tests/logs_metadata_agg.rs
@@ -1372,6 +1372,174 @@ async fn a_missing_extremum_with_non_null_rows_declines_and_scans() {
     );
 }
 
+/// An I64 `ColumnStat` with no value dictionary: `non_null_count` non-null
+/// rows bracketed by `min`/`max`. Used to fabricate the two malformed shapes
+/// of #970, so the assertions turn on the presence rules alone and not on a
+/// dictionary the MIN/MAX path never reads.
+fn flat_i64_stat(
+    name: &str,
+    non_null_count: u64,
+    null_count: u64,
+    min: Option<i64>,
+    max: Option<i64>,
+) -> ColumnStat {
+    ColumnStat {
+        name: name.to_string(),
+        declared_type: 2,
+        non_null_count,
+        null_count,
+        min: min.map(i64_value),
+        max: max.map(i64_value),
+        dictionary_present: false,
+        dictionary: Vec::new(),
+        sum: None,
+    }
+}
+
+/// `(min, max)` from a two-column `SELECT MIN(col), MAX(col)` result; a
+/// component is `None` when that aggregate is SQL NULL.
+fn min_max_i64(batches: &[RecordBatch]) -> (Option<i64>, Option<i64>) {
+    for batch in batches {
+        if batch.num_rows() == 0 {
+            continue;
+        }
+        let col = |i: usize| {
+            let arr = batch
+                .column(i)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .expect("int64 aggregate");
+            if arr.is_null(0) {
+                None
+            } else {
+                Some(arr.value(0))
+            }
+        };
+        return (col(0), col(1));
+    }
+    (None, None)
+}
+
+/// Run `SELECT MIN(status), MAX(status) FROM logs` over `corpus`'s two real
+/// segments with `stats` injected, returning the plan text and the answer.
+async fn min_max_over(
+    corpus: &RealCorpus,
+    stats: Arc<LoadedColumnStats>,
+) -> (String, (Option<i64>, Option<i64>)) {
+    let snapshot = snapshot_of(vec![corpus.a.clone(), corpus.b.clone()], Vec::new());
+    let ctx = logs_session(provider(&corpus.store, snapshot, status_col(), Some(stats)))
+        .expect("session");
+    let plan = ctx
+        .sql("SELECT MIN(status), MAX(status) FROM logs")
+        .await
+        .expect("plan")
+        .create_physical_plan()
+        .await
+        .expect("physical plan");
+    let shown = plan_str(&plan);
+    let batches = collect(Arc::clone(&plan), ctx.task_ctx())
+        .await
+        .expect("collect");
+    (shown, min_max_i64(&batches))
+}
+
+/// #970 defect 1: two `ColumnStat` entries under one name in a single segment.
+/// A duplicate name is malformed -- `decode_column_stats` refuses an object
+/// carrying one -- but the join had resolved it silently by collecting the
+/// column list into a by-name map, which keeps the LAST entry. So the answer
+/// was whichever duplicate happened to sit later in the list, reported with
+/// `Precision::Exact` and with the scan deleted by `AggregateStatistics`.
+///
+/// The test runs both orderings of the same pair of duplicates and requires
+/// the identical outcome from each, which is what makes it a test rather than
+/// a coincidence: a resolution that picks one entry cannot satisfy both runs.
+/// Pre-fix each ordering answered from the duplicate that sat second, so
+/// `MIN(status)` came back as 9 in the first ordering and 1 in the second,
+/// against a true minimum of 200 over the real corpus.
+///
+/// Prove-the-test: replace the poisoned-entry map build in
+/// `declared_min_max_all` with the previous
+/// `.map(|c| (c.name.as_str(), c)).collect()` and both orderings report
+/// `MIN(status)` from a duplicate (9, then 1) with no `LogsScanExec` in the
+/// plan; the plan assertion fails first.
+#[tokio::test]
+async fn duplicate_column_name_declines_in_either_order_and_scans() {
+    for (first, second) in [(1i64, 9i64), (9i64, 1i64)] {
+        let corpus = RealCorpus::build().await;
+        let bad_stats = loaded_stats(vec![
+            (
+                &corpus.a,
+                stats_segment(
+                    &corpus.a,
+                    vec![
+                        flat_i64_stat("status", 1, 0, Some(first), Some(first)),
+                        flat_i64_stat("status", 1, 0, Some(second), Some(second)),
+                    ],
+                ),
+            ),
+            (
+                &corpus.b,
+                stats_segment(&corpus.b, vec![stat_from_rows(SEG_B_ROWS)]),
+            ),
+        ]);
+
+        let (shown, answer) = min_max_over(&corpus, bad_stats).await;
+        assert!(
+            shown.contains("LogsScanExec") && !shown.contains("MetadataOnlyExec"),
+            "a duplicate column name must decline and fall back to a scan \
+             (order {first},{second}); plan was:\n{shown}"
+        );
+        assert_eq!(
+            answer,
+            (Some(200), Some(500)),
+            "the scan answers the true MIN/MAX over the real corpus, \
+             unaffected by either duplicate (order {first},{second})"
+        );
+    }
+}
+
+/// #970 defect 2, the mirror of the missing-extremum decline above: a column
+/// reporting `non_null_count == 0` while carrying `min`/`max`. Those extrema
+/// describe no live row, so trusting them contributes a value to a MIN/MAX
+/// whose true answer over that segment is NULL. The extrema here sit OUTSIDE
+/// the real corpus range (-1 and 999) precisely so a pre-fix answer cannot
+/// coincide with the correct one.
+///
+/// Prove-the-test: delete the `stat.non_null_count == 0 && (min.is_some() ||
+/// max.is_some())` decline (the `validate_min_max_presence` call) in
+/// `declared_min_max_all` and the plan loses its `LogsScanExec` while the
+/// answer becomes `(-1, 999)`; both assertions fail.
+#[tokio::test]
+async fn all_null_column_carrying_extrema_declines_and_scans() {
+    let corpus = RealCorpus::build().await;
+    let bad_stats = loaded_stats(vec![
+        (
+            &corpus.a,
+            stats_segment(
+                &corpus.a,
+                // All six of segment A's rows NULL, yet extrema recorded.
+                vec![flat_i64_stat("status", 0, 6, Some(-1), Some(999))],
+            ),
+        ),
+        (
+            &corpus.b,
+            stats_segment(&corpus.b, vec![stat_from_rows(SEG_B_ROWS)]),
+        ),
+    ]);
+
+    let (shown, answer) = min_max_over(&corpus, bad_stats).await;
+    assert!(
+        shown.contains("LogsScanExec") && !shown.contains("MetadataOnlyExec"),
+        "an all-null column carrying extrema must decline and fall back to a scan; \
+         plan was:\n{shown}"
+    );
+    assert_eq!(
+        answer,
+        (Some(200), Some(500)),
+        "the scan answers the true MIN/MAX over the real corpus, not the fabricated extrema"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // q03/q04: SUM(<declared integer column> + k), and q30: AVG(<declared integer
 // column>) -- answered from the exact per-object integer sum (#861). Every


### PR DESCRIPTION
fix(ravel-sql): refuse invalid column stats on the exact MIN/MAX path

Two shapes of malformed `.cstat` `ColumnStat` entry reached
`LogsScanExec::declared_min_max_all` and produced a value carrying
`Precision::Exact`. DataFusion's `AggregateStatistics` rule rewrites
MIN/MAX into a literal, so each was a wrong query result with no scan
left to correct it.

First, two entries under one name in a segment were resolved silently.
The join collected the column list into a by-name map, which keeps the
last pair for a repeated key, so the answer was whichever duplicate sat
later in the list. The three dictionary and sum readers of the same
records resolve them with `find`, which keeps the first, so one
malformed record answered one query two ways depending on which reader
ran. The map build now poisons a repeated name and its column declines,
and the other three readers go through `unique_column_stat`, which
returns an entry only when the segment carries exactly one under that
name.

Second, the presence check ran in one direction only. It refused
non-null rows with no recorded extremum, but accepted
`non_null_count == 0` with min/max present, an all-NULL column whose
extrema describe no live row. Both directions are now one predicate,
`validate_min_max_presence`, called by the decoder's `validate_column`
and by the read site, so the decode boundary and the join cannot drift
into disagreeing about what a usable entry is.

`decode_column_stats` already refused both shapes, but no test reached
that validation through decode: every case went through
`encode_column_stats`, which validates its own input first, so deleting
the decoder's `validate_segments` call broke nothing. Framing is now
split from validation so three tests can hand a well-framed object
carrying a refused record to the decoder.

A column that legitimately has no entry still declines and the scan
answers, and the per-segment single walk that keeps
`partition_statistics` at O(segments x columns_per_segment) is
unchanged.

Fixes: #970

