### PR TITLE
feat(ravel-bench): record active allocator in report provenance

### DIFF
--- a/crates/ravel-bench/src/allocator.rs
+++ b/crates/ravel-bench/src/allocator.rs
@@ -147,16 +147,35 @@ fn allocator_from_maps(maps: &str) -> Allocator {
 /// entries, none naming an allocator, so the system allocator) from
 /// unrecognizable text (no entries, so unknown).
 fn is_maps_entry(line: &str) -> bool {
-    let Some(range) = line.split_whitespace().next() else {
+    let mut fields = line.split_whitespace();
+    let Some(range) = fields.next() else {
         return false;
     };
     let Some((start, end)) = range.split_once('-') else {
         return false;
     };
-    !start.is_empty()
+    let range_ok = !start.is_empty()
         && !end.is_empty()
         && start.bytes().all(|b| b.is_ascii_hexdigit())
-        && end.bytes().all(|b| b.is_ascii_hexdigit())
+        && end.bytes().all(|b| b.is_ascii_hexdigit());
+    if !range_ok {
+        return false;
+    }
+    // A hex range alone is not a maps record: `7f-80 not-a-maps-record` must
+    // read as unrecognizable text (Unknown), never as evidence of a readable
+    // maps (System). Require the mandatory columns too: a permissions field of
+    // exactly four bytes from the maps alphabet, then offset, dev, and inode.
+    let Some(perms) = fields.next() else {
+        return false;
+    };
+    let perms_ok = perms.len() == 4
+        && perms.bytes().zip(*b"rwxp").all(|(got, kind)| match kind {
+            b'r' => got == b'r' || got == b'-',
+            b'w' => got == b'w' || got == b'-',
+            b'x' => got == b'x' || got == b'-',
+            _ => got == b'p' || got == b's',
+        });
+    perms_ok && fields.next().is_some() && fields.next().is_some() && fields.next().is_some()
 }
 
 /// The pathname field of a maps entry (the file backing the mapping): the sixth
@@ -171,6 +190,16 @@ fn maps_line_pathname(line: &str) -> Option<&str> {
 mod tests {
     use super::*;
 
+    #[test]
+    fn a_near_miss_line_is_not_a_maps_entry_and_reads_unknown() {
+        // The mandatory columns (perms, offset, dev, inode) are what separate
+        // a maps record from text that merely starts with a hex range; without
+        // them the probe must answer Unknown, never a guessed System.
+        assert_eq!(allocator_from_maps(NEAR_MISS_MAPS), Allocator::Unknown);
+        // And a real record still parses: the fixture set stays recognized.
+        assert_eq!(allocator_from_maps(SYSTEM_MAPS), Allocator::System);
+    }
+
     /// A maps blob with tcmalloc preloaded, shaped like a real one: the
     /// executable, the preloaded allocator, and libc.
     const TCMALLOC_MAPS: &str = "\
@@ -184,6 +213,15 @@ mod tests {
 55a1c0000000-55a1c0021000 r--p 00000000 08:01 100 /usr/bin/ravel-bench
 7f2a10000000-7f2a10025000 r-xp 00000000 08:01 200 /usr/lib/x86_64-linux-gnu/libjemalloc.so.2
 7f2a20000000-7f2a20030000 r-xp 00000000 08:01 201 /usr/lib/x86_64-linux-gnu/libc.so.6
+";
+
+    /// Near-miss text: a hex range followed by junk is NOT a maps record.
+    /// Before the column validation, `7f-80 not-a-maps-record` set `saw_entry`
+    /// and the probe answered `System` for unrecognizable text -- a guessed
+    /// allocator, the exact thing this module must never produce.
+    const NEAR_MISS_MAPS: &str = "\
+7f-80 not-a-maps-record
+deadbeef-cafebabe junk junk
 ";
 
     /// A readable maps with no allocator library mapped: only the executable,

--- a/crates/ravel-bench/src/allocator.rs
+++ b/crates/ravel-bench/src/allocator.rs
@@ -1,0 +1,184 @@
+//! Which heap allocator is actually loaded, resolved at runtime.
+//!
+//! A benchmark's peak RSS moves by about 2x between the system allocator (glibc)
+//! and a memory-returning allocator (tcmalloc/jemalloc), so an RSS figure
+//! without the allocator recorded beside it is not comparable
+//! (docs/guides/clickbench.md). The allocator can arrive via `LD_PRELOAD`, which
+//! a compile-time `cfg!` cannot see, so this reads the process's own mapped
+//! libraries from `/proc/self/maps` and reports what is there, `LD_PRELOAD`
+//! included. When the probe cannot answer (a platform without `/proc`, an
+//! unreadable or unrecognizable maps) it reports [`ALLOCATOR_UNKNOWN`] rather
+//! than guessing: a wrong provenance value reads as verified, which is worse
+//! than an explicit absent one.
+
+/// A memory-returning allocator mapped as `libtcmalloc`.
+pub const ALLOCATOR_TCMALLOC: &str = "tcmalloc";
+/// A memory-returning allocator mapped as `libjemalloc`.
+pub const ALLOCATOR_JEMALLOC: &str = "jemalloc";
+/// A memory-returning allocator mapped as `libmimalloc`.
+pub const ALLOCATOR_MIMALLOC: &str = "mimalloc";
+/// No known allocator library is mapped: the process runs on the system
+/// allocator (glibc/musl `malloc`). This is a positive finding read off a
+/// readable maps, not a guess.
+pub const ALLOCATOR_SYSTEM: &str = "system";
+/// The probe could not answer: `/proc/self/maps` was unreadable, empty, or
+/// unrecognizable. Reported instead of defaulting to a concrete allocator, which
+/// would read as verified while being unproven.
+pub const ALLOCATOR_UNKNOWN: &str = "unknown";
+
+/// The allocator this process is actually running under, read from
+/// `/proc/self/maps`. Returns [`ALLOCATOR_UNKNOWN`] when the maps cannot be read
+/// (a platform without `/proc`, or a read error), never a guessed allocator.
+pub fn active_allocator() -> String {
+    match std::fs::read_to_string("/proc/self/maps") {
+        Ok(maps) => allocator_from_maps(&maps),
+        Err(_) => ALLOCATOR_UNKNOWN.to_string(),
+    }
+}
+
+/// Resolve the allocator from the text of a `/proc/self/maps`, split out from
+/// the `/proc` read so the parsing is testable against fixture text without a
+/// real `/proc`. A mapped `libtcmalloc`/`libjemalloc`/`libmimalloc` wins; a
+/// readable maps with recognizable entries but none of them is the system
+/// allocator; text with no recognizable maps entry (empty or malformed) is
+/// [`ALLOCATOR_UNKNOWN`], never a guess.
+fn allocator_from_maps(maps: &str) -> String {
+    let mut saw_entry = false;
+    for line in maps.lines() {
+        if !is_maps_entry(line) {
+            continue;
+        }
+        saw_entry = true;
+        if let Some(path) = maps_line_pathname(line) {
+            if path.contains("libtcmalloc") {
+                return ALLOCATOR_TCMALLOC.to_string();
+            }
+            if path.contains("libjemalloc") {
+                return ALLOCATOR_JEMALLOC.to_string();
+            }
+            if path.contains("libmimalloc") {
+                return ALLOCATOR_MIMALLOC.to_string();
+            }
+        }
+    }
+    if saw_entry {
+        ALLOCATOR_SYSTEM.to_string()
+    } else {
+        ALLOCATOR_UNKNOWN.to_string()
+    }
+}
+
+/// Whether `line` is a `/proc/self/maps` entry: its first field is a
+/// `start-end` hex address range. This is what separates a readable maps (has
+/// entries, none naming an allocator, so the system allocator) from
+/// unrecognizable text (no entries, so unknown).
+fn is_maps_entry(line: &str) -> bool {
+    let Some(range) = line.split_whitespace().next() else {
+        return false;
+    };
+    let Some((start, end)) = range.split_once('-') else {
+        return false;
+    };
+    !start.is_empty()
+        && !end.is_empty()
+        && start.bytes().all(|b| b.is_ascii_hexdigit())
+        && end.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+/// The pathname field of a maps entry (the file backing the mapping): the sixth
+/// whitespace-separated field, `address perms offset dev inode pathname`. `None`
+/// for an anonymous mapping, which has no pathname.
+fn maps_line_pathname(line: &str) -> Option<&str> {
+    line.split_whitespace().nth(5)
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    /// A maps blob with tcmalloc preloaded, shaped like a real one: the
+    /// executable, the preloaded allocator, and libc.
+    const TCMALLOC_MAPS: &str = "\
+55a1c0000000-55a1c0021000 r--p 00000000 08:01 100 /usr/bin/ravel-bench
+7f2a10000000-7f2a10025000 r-xp 00000000 08:01 200 /usr/lib/x86_64-linux-gnu/libtcmalloc.so.4.5.9
+7f2a20000000-7f2a20030000 r-xp 00000000 08:01 201 /usr/lib/x86_64-linux-gnu/libc.so.6
+";
+
+    /// The same shape with jemalloc mapped instead.
+    const JEMALLOC_MAPS: &str = "\
+55a1c0000000-55a1c0021000 r--p 00000000 08:01 100 /usr/bin/ravel-bench
+7f2a10000000-7f2a10025000 r-xp 00000000 08:01 200 /usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+7f2a20000000-7f2a20030000 r-xp 00000000 08:01 201 /usr/lib/x86_64-linux-gnu/libc.so.6
+";
+
+    /// A readable maps with no allocator library mapped: only the executable,
+    /// libc, and an anonymous mapping. This is the system allocator.
+    const SYSTEM_MAPS: &str = "\
+55a1c0000000-55a1c0021000 r--p 00000000 08:01 100 /usr/bin/ravel-bench
+7f2a20000000-7f2a20030000 r-xp 00000000 08:01 201 /usr/lib/x86_64-linux-gnu/libc.so.6
+7f2a30000000-7f2a30001000 rw-p 00000000 00:00 0
+";
+
+    /// A mapped tcmalloc is reported as `tcmalloc`.
+    ///
+    /// To watch it fail: delete the `if path.contains("libtcmalloc")` return arm
+    /// in `allocator_from_maps`. The blob then falls through to the system
+    /// allocator and the assertion reads `tcmalloc == system`.
+    #[test]
+    fn a_mapped_tcmalloc_is_reported_as_tcmalloc() {
+        assert_eq!(allocator_from_maps(TCMALLOC_MAPS), ALLOCATOR_TCMALLOC);
+    }
+
+    /// A mapped jemalloc is reported as `jemalloc`.
+    ///
+    /// To watch it fail: delete the `if path.contains("libjemalloc")` return arm
+    /// in `allocator_from_maps`.
+    #[test]
+    fn a_mapped_jemalloc_is_reported_as_jemalloc() {
+        assert_eq!(allocator_from_maps(JEMALLOC_MAPS), ALLOCATOR_JEMALLOC);
+    }
+
+    /// A mapped mimalloc is reported as `mimalloc`.
+    ///
+    /// To watch it fail: delete the `if path.contains("libmimalloc")` return arm
+    /// in `allocator_from_maps`.
+    #[test]
+    fn a_mapped_mimalloc_is_reported_as_mimalloc() {
+        let maps =
+            "7f2a10000000-7f2a10025000 r-xp 00000000 08:01 200 /usr/lib/libmimalloc.so.2.1\n";
+        assert_eq!(allocator_from_maps(maps), ALLOCATOR_MIMALLOC);
+    }
+
+    /// A readable maps naming no known allocator is the system allocator, not
+    /// unknown: the probe answered.
+    ///
+    /// To watch it fail: change the final `if saw_entry` block to return
+    /// `ALLOCATOR_UNKNOWN` unconditionally. The assertion then reads
+    /// `system == unknown`.
+    #[test]
+    fn maps_without_a_known_allocator_is_the_system_allocator() {
+        assert_eq!(allocator_from_maps(SYSTEM_MAPS), ALLOCATOR_SYSTEM);
+    }
+
+    /// Empty maps is the explicit unknown, never a guessed allocator.
+    ///
+    /// To watch it fail: change the final `else` arm of `allocator_from_maps` to
+    /// return `ALLOCATOR_SYSTEM`. The assertion then reads `unknown == system`.
+    #[test]
+    fn empty_maps_is_unknown_not_a_guess() {
+        assert_eq!(allocator_from_maps(""), ALLOCATOR_UNKNOWN);
+    }
+
+    /// Text that is not a maps at all is the explicit unknown: no entry parses,
+    /// so the probe cannot answer and must not fall back to the system
+    /// allocator.
+    ///
+    /// To watch it fail: change the final `else` arm of `allocator_from_maps` to
+    /// return `ALLOCATOR_SYSTEM`.
+    #[test]
+    fn malformed_maps_is_unknown_not_a_guess() {
+        let maps = "this is not /proc/self/maps\njust some random text\n";
+        assert_eq!(allocator_from_maps(maps), ALLOCATOR_UNKNOWN);
+    }
+}

--- a/crates/ravel-bench/src/allocator.rs
+++ b/crates/ravel-bench/src/allocator.rs
@@ -7,32 +7,69 @@
 //! a compile-time `cfg!` cannot see, so this reads the process's own mapped
 //! libraries from `/proc/self/maps` and reports what is there, `LD_PRELOAD`
 //! included. When the probe cannot answer (a platform without `/proc`, an
-//! unreadable or unrecognizable maps) it reports [`ALLOCATOR_UNKNOWN`] rather
+//! unreadable or unrecognizable maps) it reports [`Allocator::Unknown`] rather
 //! than guessing: a wrong provenance value reads as verified, which is worse
 //! than an explicit absent one.
 
-/// A memory-returning allocator mapped as `libtcmalloc`.
-pub const ALLOCATOR_TCMALLOC: &str = "tcmalloc";
-/// A memory-returning allocator mapped as `libjemalloc`.
-pub const ALLOCATOR_JEMALLOC: &str = "jemalloc";
-/// A memory-returning allocator mapped as `libmimalloc`.
-pub const ALLOCATOR_MIMALLOC: &str = "mimalloc";
-/// No known allocator library is mapped: the process runs on the system
-/// allocator (glibc/musl `malloc`). This is a positive finding read off a
-/// readable maps, not a guess.
-pub const ALLOCATOR_SYSTEM: &str = "system";
-/// The probe could not answer: `/proc/self/maps` was unreadable, empty, or
-/// unrecognizable. Reported instead of defaulting to a concrete allocator, which
-/// would read as verified while being unproven.
-pub const ALLOCATOR_UNKNOWN: &str = "unknown";
+/// The heap allocator a benchmark process ran under, resolved at runtime from
+/// its mapped libraries. This is the one value domain the two provenance schemas
+/// share (issue #972): a typed enum makes an out-of-domain allocator
+/// unrepresentable rather than merely rejected, so a provenance value in this
+/// slot can be trusted to be exactly one the probe can produce. Its serde
+/// representation is the lowercase variant name (`"tcmalloc"`, `"jemalloc"`,
+/// `"mimalloc"`, `"system"`, `"unknown"`), and an unrecognized string in a
+/// serialized report is rejected at deserialize (serde's default for an enum
+/// with no catch-all variant): a garbage value laundered into `Unknown` would
+/// read as the honest "the probe ran and could not answer", the confusion the
+/// field exists to avoid.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Allocator {
+    /// A memory-returning allocator mapped as `libtcmalloc`.
+    Tcmalloc,
+    /// A memory-returning allocator mapped as `libjemalloc`.
+    Jemalloc,
+    /// A memory-returning allocator mapped as `libmimalloc`.
+    Mimalloc,
+    /// No known allocator library is mapped: the process runs on the system
+    /// allocator (glibc/musl `malloc`). This is a positive finding read off a
+    /// readable maps, not a guess.
+    System,
+    /// The probe could not answer: `/proc/self/maps` was unreadable, empty, or
+    /// unrecognizable, or a report predates the field. Recorded instead of
+    /// defaulting to a concrete allocator, which would read as verified while
+    /// being unproven.
+    Unknown,
+}
+
+impl Allocator {
+    /// The serialized form: the lowercase variant name, matching the serde
+    /// representation. Used to render provenance without going through JSON.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Allocator::Tcmalloc => "tcmalloc",
+            Allocator::Jemalloc => "jemalloc",
+            Allocator::Mimalloc => "mimalloc",
+            Allocator::System => "system",
+            Allocator::Unknown => "unknown",
+        }
+    }
+}
+
+impl std::fmt::Display for Allocator {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
 
 /// The allocator this process is actually running under, read from
-/// `/proc/self/maps`. Returns [`ALLOCATOR_UNKNOWN`] when the maps cannot be read
-/// (a platform without `/proc`, or a read error), never a guessed allocator.
-pub fn active_allocator() -> String {
+/// `/proc/self/maps`. Returns [`Allocator::Unknown`] when the maps cannot be
+/// read (a platform without `/proc`, or a read error), never a guessed
+/// allocator.
+pub fn active_allocator() -> Allocator {
     match std::fs::read_to_string("/proc/self/maps") {
         Ok(maps) => allocator_from_maps(&maps),
-        Err(_) => ALLOCATOR_UNKNOWN.to_string(),
+        Err(_) => Allocator::Unknown,
     }
 }
 
@@ -41,8 +78,8 @@ pub fn active_allocator() -> String {
 /// real `/proc`. A mapped `libtcmalloc`/`libjemalloc`/`libmimalloc` wins; a
 /// readable maps with recognizable entries but none of them is the system
 /// allocator; text with no recognizable maps entry (empty or malformed) is
-/// [`ALLOCATOR_UNKNOWN`], never a guess.
-fn allocator_from_maps(maps: &str) -> String {
+/// [`Allocator::Unknown`], never a guess.
+fn allocator_from_maps(maps: &str) -> Allocator {
     let mut saw_entry = false;
     for line in maps.lines() {
         if !is_maps_entry(line) {
@@ -51,20 +88,20 @@ fn allocator_from_maps(maps: &str) -> String {
         saw_entry = true;
         if let Some(path) = maps_line_pathname(line) {
             if path.contains("libtcmalloc") {
-                return ALLOCATOR_TCMALLOC.to_string();
+                return Allocator::Tcmalloc;
             }
             if path.contains("libjemalloc") {
-                return ALLOCATOR_JEMALLOC.to_string();
+                return Allocator::Jemalloc;
             }
             if path.contains("libmimalloc") {
-                return ALLOCATOR_MIMALLOC.to_string();
+                return Allocator::Mimalloc;
             }
         }
     }
     if saw_entry {
-        ALLOCATOR_SYSTEM.to_string()
+        Allocator::System
     } else {
-        ALLOCATOR_UNKNOWN.to_string()
+        Allocator::Unknown
     }
 }
 
@@ -127,7 +164,7 @@ mod tests {
     /// allocator and the assertion reads `tcmalloc == system`.
     #[test]
     fn a_mapped_tcmalloc_is_reported_as_tcmalloc() {
-        assert_eq!(allocator_from_maps(TCMALLOC_MAPS), ALLOCATOR_TCMALLOC);
+        assert_eq!(allocator_from_maps(TCMALLOC_MAPS), Allocator::Tcmalloc);
     }
 
     /// A mapped jemalloc is reported as `jemalloc`.
@@ -136,7 +173,7 @@ mod tests {
     /// in `allocator_from_maps`.
     #[test]
     fn a_mapped_jemalloc_is_reported_as_jemalloc() {
-        assert_eq!(allocator_from_maps(JEMALLOC_MAPS), ALLOCATOR_JEMALLOC);
+        assert_eq!(allocator_from_maps(JEMALLOC_MAPS), Allocator::Jemalloc);
     }
 
     /// A mapped mimalloc is reported as `mimalloc`.
@@ -147,27 +184,27 @@ mod tests {
     fn a_mapped_mimalloc_is_reported_as_mimalloc() {
         let maps =
             "7f2a10000000-7f2a10025000 r-xp 00000000 08:01 200 /usr/lib/libmimalloc.so.2.1\n";
-        assert_eq!(allocator_from_maps(maps), ALLOCATOR_MIMALLOC);
+        assert_eq!(allocator_from_maps(maps), Allocator::Mimalloc);
     }
 
     /// A readable maps naming no known allocator is the system allocator, not
     /// unknown: the probe answered.
     ///
     /// To watch it fail: change the final `if saw_entry` block to return
-    /// `ALLOCATOR_UNKNOWN` unconditionally. The assertion then reads
+    /// `Allocator::Unknown` unconditionally. The assertion then reads
     /// `system == unknown`.
     #[test]
     fn maps_without_a_known_allocator_is_the_system_allocator() {
-        assert_eq!(allocator_from_maps(SYSTEM_MAPS), ALLOCATOR_SYSTEM);
+        assert_eq!(allocator_from_maps(SYSTEM_MAPS), Allocator::System);
     }
 
     /// Empty maps is the explicit unknown, never a guessed allocator.
     ///
     /// To watch it fail: change the final `else` arm of `allocator_from_maps` to
-    /// return `ALLOCATOR_SYSTEM`. The assertion then reads `unknown == system`.
+    /// return `Allocator::System`. The assertion then reads `unknown == system`.
     #[test]
     fn empty_maps_is_unknown_not_a_guess() {
-        assert_eq!(allocator_from_maps(""), ALLOCATOR_UNKNOWN);
+        assert_eq!(allocator_from_maps(""), Allocator::Unknown);
     }
 
     /// Text that is not a maps at all is the explicit unknown: no entry parses,
@@ -175,10 +212,10 @@ mod tests {
     /// allocator.
     ///
     /// To watch it fail: change the final `else` arm of `allocator_from_maps` to
-    /// return `ALLOCATOR_SYSTEM`.
+    /// return `Allocator::System`.
     #[test]
     fn malformed_maps_is_unknown_not_a_guess() {
         let maps = "this is not /proc/self/maps\njust some random text\n";
-        assert_eq!(allocator_from_maps(maps), ALLOCATOR_UNKNOWN);
+        assert_eq!(allocator_from_maps(maps), Allocator::Unknown);
     }
 }

--- a/crates/ravel-bench/src/allocator.rs
+++ b/crates/ravel-bench/src/allocator.rs
@@ -7,9 +7,10 @@
 //! a compile-time `cfg!` cannot see, so this reads the process's own mapped
 //! libraries from `/proc/self/maps` and reports what is there, `LD_PRELOAD`
 //! included. When the probe cannot answer (a platform without `/proc`, an
-//! unreadable or unrecognizable maps) it reports [`Allocator::Unknown`] rather
-//! than guessing: a wrong provenance value reads as verified, which is worse
-//! than an explicit absent one.
+//! unreadable or unrecognizable maps, or two different allocator libraries
+//! mapped at once) it reports [`Allocator::Unknown`] rather than guessing: a
+//! wrong provenance value reads as verified, which is worse than an explicit
+//! absent one.
 
 /// The heap allocator a benchmark process ran under, resolved at runtime from
 /// its mapped libraries. This is the one value domain the two provenance schemas
@@ -73,35 +74,71 @@ pub fn active_allocator() -> Allocator {
     }
 }
 
+/// The allocator libraries the probe recognizes, each paired with the substring
+/// a maps pathname carries when that library is mapped. One table rather than a
+/// chain of tests, so the scan below cannot acquire a precedence order between
+/// them: there is no order in which reporting one of two mapped allocators is
+/// correct.
+const RECOGNIZED_LIBRARIES: &[(&str, Allocator)] = &[
+    ("libtcmalloc", Allocator::Tcmalloc),
+    ("libjemalloc", Allocator::Jemalloc),
+    ("libmimalloc", Allocator::Mimalloc),
+];
+
 /// Resolve the allocator from the text of a `/proc/self/maps`, split out from
 /// the `/proc` read so the parsing is testable against fixture text without a
-/// real `/proc`. A mapped `libtcmalloc`/`libjemalloc`/`libmimalloc` wins; a
-/// readable maps with recognizable entries but none of them is the system
-/// allocator; text with no recognizable maps entry (empty or malformed) is
-/// [`Allocator::Unknown`], never a guess.
+/// real `/proc`.
+///
+/// The whole text is scanned and the DISTINCT recognized allocator libraries are
+/// collected before anything is decided, because the recognized set, not the
+/// first match, is what the answer depends on:
+///
+/// - exactly one distinct recognized allocator: that allocator;
+/// - two or more distinct recognized allocators: [`Allocator::Unknown`], because
+///   the probe cannot say which of them governs allocation. A process started
+///   with `LD_PRELOAD=libjemalloc.so` can also have `libtcmalloc.so` mapped as
+///   some other library's transitive dependency, and a first-match scan in a
+///   fixed library order would report tcmalloc as fact;
+/// - no recognized allocator but at least one well-formed maps entry: the system
+///   allocator, a positive finding read off a readable maps;
+/// - no well-formed maps entry at all (empty or malformed text):
+///   [`Allocator::Unknown`], never a guess.
+///
+/// Distinct libraries, not matching lines: a maps file lists several segments
+/// per mapped object (`r--p`, `r-xp`, `rw-p`), so one preloaded allocator
+/// normally matches three or more lines and counting lines would report every
+/// single-allocator process as ambiguous.
 fn allocator_from_maps(maps: &str) -> Allocator {
     let mut saw_entry = false;
+    let mut recognized: Option<Allocator> = None;
+    let mut ambiguous = false;
     for line in maps.lines() {
         if !is_maps_entry(line) {
             continue;
         }
         saw_entry = true;
-        if let Some(path) = maps_line_pathname(line) {
-            if path.contains("libtcmalloc") {
-                return Allocator::Tcmalloc;
+        let Some(path) = maps_line_pathname(line) else {
+            continue;
+        };
+        for &(library, allocator) in RECOGNIZED_LIBRARIES {
+            if !path.contains(library) {
+                continue;
             }
-            if path.contains("libjemalloc") {
-                return Allocator::Jemalloc;
-            }
-            if path.contains("libmimalloc") {
-                return Allocator::Mimalloc;
+            match recognized {
+                // The same library across its several segments is one allocator.
+                Some(seen) if seen == allocator => {}
+                Some(_) => ambiguous = true,
+                None => recognized = Some(allocator),
             }
         }
     }
-    if saw_entry {
-        Allocator::System
-    } else {
-        Allocator::Unknown
+    if ambiguous {
+        return Allocator::Unknown;
+    }
+    match recognized {
+        Some(allocator) => allocator,
+        None if saw_entry => Allocator::System,
+        None => Allocator::Unknown,
     }
 }
 
@@ -159,8 +196,8 @@ mod tests {
 
     /// A mapped tcmalloc is reported as `tcmalloc`.
     ///
-    /// To watch it fail: delete the `if path.contains("libtcmalloc")` return arm
-    /// in `allocator_from_maps`. The blob then falls through to the system
+    /// To watch it fail: delete the `("libtcmalloc", Allocator::Tcmalloc)` row
+    /// from `RECOGNIZED_LIBRARIES`. The blob then falls through to the system
     /// allocator and the assertion reads `tcmalloc == system`.
     #[test]
     fn a_mapped_tcmalloc_is_reported_as_tcmalloc() {
@@ -169,8 +206,8 @@ mod tests {
 
     /// A mapped jemalloc is reported as `jemalloc`.
     ///
-    /// To watch it fail: delete the `if path.contains("libjemalloc")` return arm
-    /// in `allocator_from_maps`.
+    /// To watch it fail: delete the `("libjemalloc", Allocator::Jemalloc)` row
+    /// from `RECOGNIZED_LIBRARIES`.
     #[test]
     fn a_mapped_jemalloc_is_reported_as_jemalloc() {
         assert_eq!(allocator_from_maps(JEMALLOC_MAPS), Allocator::Jemalloc);
@@ -178,8 +215,8 @@ mod tests {
 
     /// A mapped mimalloc is reported as `mimalloc`.
     ///
-    /// To watch it fail: delete the `if path.contains("libmimalloc")` return arm
-    /// in `allocator_from_maps`.
+    /// To watch it fail: delete the `("libmimalloc", Allocator::Mimalloc)` row
+    /// from `RECOGNIZED_LIBRARIES`.
     #[test]
     fn a_mapped_mimalloc_is_reported_as_mimalloc() {
         let maps =
@@ -190,9 +227,9 @@ mod tests {
     /// A readable maps naming no known allocator is the system allocator, not
     /// unknown: the probe answered.
     ///
-    /// To watch it fail: change the final `if saw_entry` block to return
-    /// `Allocator::Unknown` unconditionally. The assertion then reads
-    /// `system == unknown`.
+    /// To watch it fail: change the `None if saw_entry => Allocator::System` arm
+    /// of the final `match recognized` to `Allocator::Unknown`. The assertion
+    /// then reads `system == unknown`.
     #[test]
     fn maps_without_a_known_allocator_is_the_system_allocator() {
         assert_eq!(allocator_from_maps(SYSTEM_MAPS), Allocator::System);
@@ -200,8 +237,9 @@ mod tests {
 
     /// Empty maps is the explicit unknown, never a guessed allocator.
     ///
-    /// To watch it fail: change the final `else` arm of `allocator_from_maps` to
-    /// return `Allocator::System`. The assertion then reads `unknown == system`.
+    /// To watch it fail: change the final `None => Allocator::Unknown` arm of
+    /// `allocator_from_maps` to `Allocator::System`. The assertion then reads
+    /// `unknown == system`.
     #[test]
     fn empty_maps_is_unknown_not_a_guess() {
         assert_eq!(allocator_from_maps(""), Allocator::Unknown);
@@ -211,11 +249,79 @@ mod tests {
     /// so the probe cannot answer and must not fall back to the system
     /// allocator.
     ///
-    /// To watch it fail: change the final `else` arm of `allocator_from_maps` to
-    /// return `Allocator::System`.
+    /// To watch it fail: change the final `None => Allocator::Unknown` arm of
+    /// `allocator_from_maps` to `Allocator::System`.
     #[test]
     fn malformed_maps_is_unknown_not_a_guess() {
         let maps = "this is not /proc/self/maps\njust some random text\n";
         assert_eq!(allocator_from_maps(maps), Allocator::Unknown);
+    }
+
+    /// Two DIFFERENT allocator libraries mapped at once is the honest unknown,
+    /// not whichever one a fixed scan order names first. The realistic shape:
+    /// `LD_PRELOAD=libjemalloc.so` governs allocation while `libtcmalloc.so`
+    /// rides in as another library's transitive dependency. Asserted in both
+    /// mapping orders, so a scan that resolved the tie by position rather than
+    /// refusing it fails on one of the two.
+    ///
+    /// To watch it fail: change the `Some(_) => ambiguous = true` arm in
+    /// `allocator_from_maps` to `Some(_) => {}`. That is the pre-change
+    /// first-match behaviour, and the assertions then read
+    /// `tcmalloc == unknown` and `jemalloc == unknown`.
+    #[test]
+    fn two_distinct_mapped_allocators_are_unknown_not_a_first_match_guess() {
+        let tcmalloc_first = "\
+55a1c0000000-55a1c0021000 r--p 00000000 08:01 100 /usr/bin/ravel-bench
+7f2a10000000-7f2a10025000 r-xp 00000000 08:01 200 /usr/lib/x86_64-linux-gnu/libtcmalloc.so.4.5.9
+7f2a18000000-7f2a18025000 r-xp 00000000 08:01 210 /usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+7f2a20000000-7f2a20030000 r-xp 00000000 08:01 201 /usr/lib/x86_64-linux-gnu/libc.so.6
+";
+        let jemalloc_first = "\
+55a1c0000000-55a1c0021000 r--p 00000000 08:01 100 /usr/bin/ravel-bench
+7f2a10000000-7f2a10025000 r-xp 00000000 08:01 210 /usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+7f2a18000000-7f2a18025000 r-xp 00000000 08:01 200 /usr/lib/x86_64-linux-gnu/libtcmalloc.so.4.5.9
+7f2a20000000-7f2a20030000 r-xp 00000000 08:01 201 /usr/lib/x86_64-linux-gnu/libc.so.6
+";
+        assert_eq!(
+            allocator_from_maps(tcmalloc_first),
+            Allocator::Unknown,
+            "two mapped allocators cannot resolve to the one listed first"
+        );
+        assert_eq!(
+            allocator_from_maps(jemalloc_first),
+            Allocator::Unknown,
+            "the answer does not depend on the mapping order either"
+        );
+    }
+
+    /// ONE allocator library mapped across its several segments is that
+    /// allocator, not the ambiguous unknown. This is the normal shape of a real
+    /// `/proc/self/maps`: the loader maps each object as an `r--p`/`r-xp`/`rw-p`
+    /// run of segments, so a single preloaded jemalloc matches four lines here,
+    /// beside an unrelated library mapped exactly the same way. This is the
+    /// regression guard for the naive "count the matching lines" reading of the
+    /// ambiguity rule, which would report Unknown for every single-allocator
+    /// process: a worse defect than the first-match bug it replaced.
+    ///
+    /// To watch it fail: change the `Some(seen) if seen == allocator => {}` arm
+    /// in `allocator_from_maps` to `Some(_seen) if false => {}`, which drops the
+    /// distinct-library guard and leaves the scan counting matching lines. The
+    /// assertion then reads `unknown == jemalloc`.
+    #[test]
+    fn one_allocator_across_several_segments_is_that_allocator() {
+        let maps = "\
+55a1c0000000-55a1c0021000 r--p 00000000 08:01 100 /usr/bin/ravel-bench
+55a1c0021000-55a1c0089000 r-xp 00021000 08:01 100 /usr/bin/ravel-bench
+7f2a10000000-7f2a10004000 r--p 00000000 08:01 210 /usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+7f2a10004000-7f2a10060000 r-xp 00004000 08:01 210 /usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+7f2a10060000-7f2a10062000 rw-p 00060000 08:01 210 /usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+7f2a10062000-7f2a10063000 ---p 00062000 08:01 210 /usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+7f2a20000000-7f2a20004000 r--p 00000000 08:01 220 /usr/lib/x86_64-linux-gnu/libssl.so.3
+7f2a20004000-7f2a20050000 r-xp 00004000 08:01 220 /usr/lib/x86_64-linux-gnu/libssl.so.3
+7f2a20050000-7f2a20052000 rw-p 00050000 08:01 220 /usr/lib/x86_64-linux-gnu/libssl.so.3
+7f2a30000000-7f2a30030000 r-xp 00000000 08:01 201 /usr/lib/x86_64-linux-gnu/libc.so.6
+7f2a40000000-7f2a40001000 rw-p 00000000 00:00 0
+";
+        assert_eq!(allocator_from_maps(maps), Allocator::Jemalloc);
     }
 }

--- a/crates/ravel-bench/src/bin/metricsbench_report.rs
+++ b/crates/ravel-bench/src/bin/metricsbench_report.rs
@@ -273,6 +273,7 @@ fn run() -> Result<(), String> {
                 generator_digest: file_digest(&workload)?,
                 corpus_digest: file_digest(&corpus)?,
                 config,
+                allocator: ravel_bench::allocator::active_allocator(),
             };
             // Prove the stamp we emit is one a report would accept: a producer
             // that pasted this block into a report and then failed validation on

--- a/crates/ravel-bench/src/bin/sql_latency_bench.rs
+++ b/crates/ravel-bench/src/bin/sql_latency_bench.rs
@@ -488,6 +488,7 @@ fn provenance_header(p: &Provenance, d: &DatasetInfo) -> String {
         "  host       : {} logical cores\n",
         p.host_logical_cores
     ));
+    out.push_str(&format!("  allocator  : {}\n", p.allocator));
     out.push_str(&format!(
         "  source     : {}  dataset={}\n",
         p.source, p.dataset_id
@@ -827,6 +828,7 @@ mod tests {
             warm_catalog: Some(false),
             logs_suffix_len: None,
             flight_endpoint: None,
+            allocator: ravel_bench::allocator::ALLOCATOR_SYSTEM.to_string(),
         }
     }
 

--- a/crates/ravel-bench/src/bin/sql_latency_bench.rs
+++ b/crates/ravel-bench/src/bin/sql_latency_bench.rs
@@ -828,7 +828,7 @@ mod tests {
             warm_catalog: Some(false),
             logs_suffix_len: None,
             flight_endpoint: None,
-            allocator: ravel_bench::allocator::ALLOCATOR_SYSTEM.to_string(),
+            allocator: ravel_bench::allocator::Allocator::System,
         }
     }
 

--- a/crates/ravel-bench/src/lib.rs
+++ b/crates/ravel-bench/src/lib.rs
@@ -1,6 +1,7 @@
 //! Benchmark harness for Ravel. Report-only: this crate never changes library
 //! behavior, it only measures it.
 
+pub mod allocator;
 pub mod bench_env;
 pub mod codecs;
 #[cfg(feature = "parquet-baseline")]

--- a/crates/ravel-bench/src/report_schema.rs
+++ b/crates/ravel-bench/src/report_schema.rs
@@ -225,6 +225,26 @@ pub struct Provenance {
     /// The complete non-default configuration.
     #[serde(default)]
     pub config: Vec<ConfigEntry>,
+    /// The heap allocator the measuring process actually ran under, resolved at
+    /// runtime from its mapped libraries (`crate::allocator::active_allocator`):
+    /// `"tcmalloc"`, `"jemalloc"`, `"mimalloc"`, `"system"` (glibc/musl), or
+    /// `"unknown"` when the probe could not answer. Peak RSS moves by about 2x
+    /// between the system allocator and a memory-returning one, and the allocator
+    /// can arrive via `LD_PRELOAD` a compile-time `cfg!` cannot see, so it is read
+    /// off `/proc/self/maps` (issue #972). Unlike the identity fields above,
+    /// `"unknown"` is a legitimate recorded value here (the probe ran and could
+    /// not answer), so it is deliberately NOT in [`checked_provenance_fields`]:
+    /// an explicit unknown is honest, and a guessed allocator that read as
+    /// verified would be the defect this closes. A report written before this
+    /// field existed deserializes to [`crate::allocator::ALLOCATOR_UNKNOWN`].
+    #[serde(default = "default_allocator")]
+    pub allocator: String,
+}
+
+/// What a report written before the allocator was recorded (issue #972)
+/// deserializes to: the explicit unknown, never a guessed allocator.
+fn default_allocator() -> String {
+    crate::allocator::ALLOCATOR_UNKNOWN.to_string()
 }
 
 /// One figure a measurement reports, named so the report is self-describing and
@@ -864,6 +884,7 @@ pub fn render(report: &MetricsBenchReport) -> Result<String, RenderError> {
             None => String::new(),
         }
     );
+    let _ = writeln!(out, "  allocator : {}", p.allocator);
     if p.comparators.is_empty() {
         out.push_str("  comparators: none (Ravel-only diagnostic run)\n");
     } else {
@@ -1035,6 +1056,7 @@ mod tests {
                 key: "max_flush_delay_ms".to_string(),
                 value: "2000".to_string(),
             }],
+            allocator: crate::allocator::ALLOCATOR_TCMALLOC.to_string(),
         }
     }
 
@@ -1530,6 +1552,39 @@ mod tests {
         let back: MetricsBenchReport = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(report, back);
         validate(&back).expect("the round-tripped report validates");
+    }
+
+    /// The allocator is serialized into provenance with its exact value, and a
+    /// report written before the field existed deserializes to the explicit
+    /// unknown rather than a guessed allocator (issue #972).
+    ///
+    /// To watch the serialization half fail: change `valid_provenance`'s
+    /// `allocator` to `ALLOCATOR_JEMALLOC`; the exact-value assertion then reads
+    /// `jemalloc == tcmalloc`. To watch the back-compat half fail: change
+    /// `default_allocator` to return `"system"`; the field-stripped report then
+    /// deserializes to `system` and the last assertion reads `system == unknown`.
+    #[test]
+    fn provenance_records_the_allocator_and_defaults_it_to_unknown() {
+        let report = valid_report();
+        let value = serde_json::to_value(&report).expect("serialize");
+        assert_eq!(
+            value["provenance"]["allocator"], "tcmalloc",
+            "the allocator serializes with its exact value: {value}"
+        );
+
+        // A report written before the field existed omits it, and deserializes
+        // to the explicit unknown, never a guessed allocator.
+        let mut doc = value;
+        doc["provenance"]
+            .as_object_mut()
+            .expect("provenance object")
+            .remove("allocator");
+        let back: MetricsBenchReport =
+            serde_json::from_value(doc).expect("deserialize a report with no allocator field");
+        assert_eq!(
+            back.provenance.allocator,
+            crate::allocator::ALLOCATOR_UNKNOWN
+        );
     }
 
     // --- FINDING 1: configuration entries are validated, not merely present. ---

--- a/crates/ravel-bench/src/report_schema.rs
+++ b/crates/ravel-bench/src/report_schema.rs
@@ -58,11 +58,92 @@ use serde::{Deserialize, Serialize};
 use crate::allocator::Allocator;
 use crate::promql_corpus::CostClass;
 
-/// The report schema version. A report declaring any other version is refused
+/// The report schema version every writer stamps: the newest version this build
+/// emits. A report declaring a version outside [`SUPPORTED_VERSIONS`] is refused
 /// rather than parsed optimistically (the same contract
 /// [`crate::promql_corpus::CORPUS_FORMAT_VERSION`] carries): the field exists so
-/// a future schema change is a loud error, not a silently misread document.
-pub const SCHEMA_VERSION: u32 = 1;
+/// a schema change is a loud error, not a silently misread document.
+///
+/// Version 2 adds `Provenance::allocator` (issue #972). Two document shapes
+/// under one version number would defeat the field: a reader built before the
+/// allocator existed would accept a version-1 document it cannot fully read, and
+/// nothing would tell a consumer which shape it holds.
+pub const SCHEMA_VERSION: u32 = 2;
+
+/// The set of report schema versions this build reads. Writers always stamp
+/// [`SCHEMA_VERSION`]; readers accept that version and the immediately preceding
+/// one, so a report emitted before version 2 added the allocator field still
+/// parses (its absent `allocator` takes [`Allocator::Unknown`] from the serde
+/// default) instead of being refused for a field it could not have carried.
+///
+/// The shape follows the persistent-format crates' `SUPPORTED_VERSIONS`
+/// (`ravel_segment::format`, `ravel_logseg::footer`) so a reviewer reads one
+/// idiom everywhere: a window at most two versions wide, never accepting
+/// anything below its floor, and the single source both [`validate`] and the
+/// error message read.
+pub const SUPPORTED_VERSIONS: SupportedVersions = SupportedVersions::n_and_prev(SCHEMA_VERSION);
+
+/// A window of accepted schema versions, the report-schema counterpart of the
+/// persistent-format crates' type of the same name. `u32` here because
+/// `schema_version` is a JSON number field rather than a packed trailer field.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SupportedVersions {
+    newest: u32,
+    oldest: u32,
+}
+
+impl SupportedVersions {
+    /// A window accepting exactly one version. The shape to return to once the
+    /// version-1 reader is retired.
+    pub const fn single(version: u32) -> Self {
+        Self {
+            newest: version,
+            oldest: version,
+        }
+    }
+
+    /// The N/N-1 window: accept `newest` and the immediately preceding version.
+    /// The shape today, so a version-1 report (no `allocator` key) still parses.
+    pub const fn n_and_prev(newest: u32) -> Self {
+        // `newest` is always a real schema version (>= 1), so the predecessor
+        // never underflows.
+        Self {
+            newest,
+            oldest: newest - 1,
+        }
+    }
+
+    /// The newest (always-written) version.
+    pub const fn newest(&self) -> u32 {
+        self.newest
+    }
+
+    /// The oldest accepted version, the window floor.
+    pub const fn oldest(&self) -> u32 {
+        self.oldest
+    }
+
+    /// Whether `version` is inside the accepted window.
+    pub const fn contains(&self, version: u32) -> bool {
+        version >= self.oldest && version <= self.newest
+    }
+}
+
+impl std::fmt::Display for SupportedVersions {
+    /// Renders every accepted version as a set (`{1, 2}`). A window is a set of
+    /// versions, and an error message that printed one number while several are
+    /// accepted would send a reader looking for the wrong mismatch.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("{")?;
+        for (position, version) in (self.oldest..=self.newest).enumerate() {
+            if position > 0 {
+                f.write_str(", ")?;
+            }
+            write!(f, "{version}")?;
+        }
+        f.write_str("}")
+    }
+}
 
 /// The retry-blindness caveat every cost estimate carries (ADR-0927 decision 8,
 /// issue #928). `object_store` retries below `InstrumentedStore` with
@@ -196,7 +277,8 @@ pub struct ConfigEntry {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Provenance {
-    /// The report schema version, which must equal [`SCHEMA_VERSION`].
+    /// The report schema version, which must be one of [`SUPPORTED_VERSIONS`].
+    /// A writer always stamps [`SCHEMA_VERSION`].
     pub schema_version: u32,
     /// The Ravel git commit the numbers describe.
     pub ravel_git_commit: String,
@@ -239,9 +321,11 @@ pub struct Provenance {
     /// (the probe ran and could not answer), so it is deliberately NOT in
     /// [`checked_provenance_fields`]: an explicit unknown is honest, and a
     /// guessed allocator that read as verified would be the defect this closes.
-    /// A report written before this field existed deserializes to
-    /// [`Allocator::Unknown`]; a report carrying an unrecognized allocator
-    /// string is rejected at deserialize.
+    /// Added at schema version 2, so a version-1 report (which cannot carry the
+    /// key) deserializes to [`Allocator::Unknown`]; a version-2 report that omits
+    /// the key reads as `Unknown` too, which is the same honest answer rather
+    /// than a defect. A report carrying an unrecognized allocator string is
+    /// rejected at deserialize.
     #[serde(default = "default_allocator")]
     pub allocator: Allocator,
 }
@@ -347,16 +431,18 @@ pub struct MetricsBenchReport {
 /// acts on.
 #[derive(Debug, Clone, PartialEq, thiserror::Error)]
 pub enum ValidationError {
-    /// The report declares a schema version this build does not read.
+    /// The report declares a schema version this build does not read. The error
+    /// names the whole accepted set, not one number: several versions are
+    /// readable, and reporting a single one would misdescribe the mismatch.
     #[error(
-        "report declares schema version {found}, but this build reads version {expected}; a \
+        "report declares schema version {found}, but this build reads versions {expected}; a \
          schema change is a version bump, never a silently misread document"
     )]
-    SchemaVersionMismatch {
+    UnsupportedSchemaVersion {
         /// The version the document declared.
         found: u32,
-        /// The version this build reads ([`SCHEMA_VERSION`]).
-        expected: u32,
+        /// The versions this build reads ([`SUPPORTED_VERSIONS`]).
+        expected: SupportedVersions,
     },
     /// A required provenance field is absent (an empty string, the `"unknown"`
     /// sentinel, an empty digest, zero logical cores). An absent field is not
@@ -610,14 +696,15 @@ fn is_content_digest(value: &str) -> bool {
 
 /// Validate the provenance block, fail-closed. Every present identity field must
 /// carry a real value (not blank, not the `"unknown"` sentinel), the schema
-/// version must match, the hardware must name at least one logical core, every
-/// named comparator must be completely pinned by a real content digest, and the
-/// configuration must carry no blank or duplicate key.
+/// version must be one this build reads ([`SUPPORTED_VERSIONS`]), the hardware
+/// must name at least one logical core, every named comparator must be
+/// completely pinned by a real content digest, and the configuration must carry
+/// no blank or duplicate key.
 fn validate_provenance(p: &Provenance) -> Result<(), ValidationError> {
-    if p.schema_version != SCHEMA_VERSION {
-        return Err(ValidationError::SchemaVersionMismatch {
+    if !SUPPORTED_VERSIONS.contains(p.schema_version) {
+        return Err(ValidationError::UnsupportedSchemaVersion {
             found: p.schema_version,
-            expected: SCHEMA_VERSION,
+            expected: SUPPORTED_VERSIONS,
         });
     }
     for (field, value) in checked_provenance_fields(p) {
@@ -1374,11 +1461,119 @@ mod tests {
         let err = validate(&report).expect_err("a wrong schema version must fail");
         assert_eq!(
             err,
-            ValidationError::SchemaVersionMismatch {
+            ValidationError::UnsupportedSchemaVersion {
                 found: SCHEMA_VERSION + 7,
-                expected: SCHEMA_VERSION,
+                expected: SUPPORTED_VERSIONS,
             }
         );
+    }
+
+    /// The supported-version window is the shape the rest of this module assumes:
+    /// the writer stamps the newest version, the previous one is still read, and
+    /// nothing below the floor or above the newest is accepted.
+    #[test]
+    fn the_supported_version_window_accepts_exactly_1_and_2() {
+        assert_eq!(SCHEMA_VERSION, 2, "the writer stamps version 2");
+        assert_eq!(SUPPORTED_VERSIONS.newest(), SCHEMA_VERSION);
+        assert_eq!(SUPPORTED_VERSIONS.oldest(), 1);
+        assert!(SUPPORTED_VERSIONS.contains(1));
+        assert!(SUPPORTED_VERSIONS.contains(2));
+        assert!(!SUPPORTED_VERSIONS.contains(0));
+        assert!(!SUPPORTED_VERSIONS.contains(3));
+        // The one-version shape this returns to once the version-1 reader is
+        // retired accepts only its own version.
+        let single = SupportedVersions::single(SCHEMA_VERSION);
+        assert!(single.contains(SCHEMA_VERSION));
+        assert!(!single.contains(SCHEMA_VERSION - 1));
+        assert_eq!(single.to_string(), "{2}");
+    }
+
+    /// A version-1 document carries NO `allocator` key (the field did not exist
+    /// at version 1) and must keep validating, reading as the explicit unknown.
+    /// This is the whole reason the exact-equality check became a window: a
+    /// version bump that refused every already-emitted report would break the
+    /// artifacts it was supposed to disambiguate.
+    ///
+    /// To watch it fail: change `SUPPORTED_VERSIONS` to
+    /// `SupportedVersions::single(SCHEMA_VERSION)`. Version 1 leaves the window,
+    /// `validate` returns `UnsupportedSchemaVersion`, and `expect` panics.
+    #[test]
+    fn a_version_1_report_without_an_allocator_key_still_validates_as_unknown() {
+        let mut doc = serde_json::to_value(valid_report()).expect("serialize");
+        let provenance = doc["provenance"]
+            .as_object_mut()
+            .expect("provenance object");
+        provenance.insert("schema_version".to_string(), serde_json::json!(1));
+        provenance
+            .remove("allocator")
+            .expect("the version-2 fixture carried an allocator key to remove");
+        let report: MetricsBenchReport =
+            serde_json::from_value(doc).expect("a version-1 document deserializes");
+        assert_eq!(report.provenance.schema_version, 1);
+        assert_eq!(
+            report.provenance.allocator,
+            Allocator::Unknown,
+            "an absent allocator is the explicit unknown, never a guess"
+        );
+        validate(&report).expect("a version-1 report still validates");
+    }
+
+    /// A version-2 document carrying an allocator validates and round-trips the
+    /// exact value: the bump is what makes the allocator's presence readable from
+    /// the version number alone.
+    ///
+    /// To watch it fail against the pre-change validator: change the version
+    /// check in `validate_provenance` from
+    /// `if !SUPPORTED_VERSIONS.contains(p.schema_version)` to
+    /// `if p.schema_version != 1`, which is the exact-equality check against the
+    /// old `SCHEMA_VERSION`. A version-2 document is then refused and the first
+    /// `expect` panics.
+    #[test]
+    fn a_version_2_report_with_an_allocator_validates_and_round_trips() {
+        let mut report = valid_report();
+        report.provenance.schema_version = 2;
+        report.provenance.allocator = Allocator::Jemalloc;
+        validate(&report).expect("a version-2 report validates");
+
+        let doc = serde_json::to_value(&report).expect("serialize");
+        assert_eq!(doc["provenance"]["schema_version"], 2);
+        assert_eq!(doc["provenance"]["allocator"], "jemalloc");
+        let back: MetricsBenchReport = serde_json::from_value(doc).expect("deserialize");
+        assert_eq!(back.provenance.schema_version, 2);
+        assert_eq!(back.provenance.allocator, Allocator::Jemalloc);
+        assert_eq!(back, report, "the version-2 document round-trips exactly");
+        validate(&back).expect("the round-tripped version-2 report validates");
+    }
+
+    /// A version outside the window is still refused, above and below, and the
+    /// message names the accepted SET rather than one number: a reader told
+    /// "reads version 2" would go looking for the wrong mismatch when 1 is also
+    /// accepted.
+    ///
+    /// To watch it fail: widen the window wrongly, with
+    /// `SUPPORTED_VERSIONS = SupportedVersions { newest: 99, oldest: 0 }`. Every
+    /// version this test tries is then inside the window, `validate` returns
+    /// `Ok(())`, and `expect_err` panics.
+    #[test]
+    fn a_report_with_an_unsupported_schema_version_is_refused_naming_the_set() {
+        for unsupported in [0, 3, 99] {
+            let mut report = valid_report();
+            report.provenance.schema_version = unsupported;
+            let err = validate(&report).expect_err("an unsupported version must be refused");
+            assert_eq!(
+                err,
+                ValidationError::UnsupportedSchemaVersion {
+                    found: unsupported,
+                    expected: SUPPORTED_VERSIONS,
+                },
+                "version {unsupported} must be refused by the version check"
+            );
+            let message = err.to_string();
+            assert!(
+                message.contains("versions {1, 2}"),
+                "the message must name the supported set, got: {message}"
+            );
+        }
     }
 
     /// Failure class: duplicate measurement id.

--- a/crates/ravel-bench/src/report_schema.rs
+++ b/crates/ravel-bench/src/report_schema.rs
@@ -55,6 +55,7 @@ use std::fmt::Write as _;
 
 use serde::{Deserialize, Serialize};
 
+use crate::allocator::Allocator;
 use crate::promql_corpus::CostClass;
 
 /// The report schema version. A report declaring any other version is refused
@@ -231,20 +232,24 @@ pub struct Provenance {
     /// `"unknown"` when the probe could not answer. Peak RSS moves by about 2x
     /// between the system allocator and a memory-returning one, and the allocator
     /// can arrive via `LD_PRELOAD` a compile-time `cfg!` cannot see, so it is read
-    /// off `/proc/self/maps` (issue #972). Unlike the identity fields above,
-    /// `"unknown"` is a legitimate recorded value here (the probe ran and could
-    /// not answer), so it is deliberately NOT in [`checked_provenance_fields`]:
-    /// an explicit unknown is honest, and a guessed allocator that read as
-    /// verified would be the defect this closes. A report written before this
-    /// field existed deserializes to [`crate::allocator::ALLOCATOR_UNKNOWN`].
+    /// off `/proc/self/maps` (issue #972). Typed as [`Allocator`] so the value
+    /// domain is shared with `sql_latency::Provenance` and an out-of-domain
+    /// value is unrepresentable rather than merely rejected. Unlike the identity
+    /// fields above, [`Allocator::Unknown`] is a legitimate recorded value here
+    /// (the probe ran and could not answer), so it is deliberately NOT in
+    /// [`checked_provenance_fields`]: an explicit unknown is honest, and a
+    /// guessed allocator that read as verified would be the defect this closes.
+    /// A report written before this field existed deserializes to
+    /// [`Allocator::Unknown`]; a report carrying an unrecognized allocator
+    /// string is rejected at deserialize.
     #[serde(default = "default_allocator")]
-    pub allocator: String,
+    pub allocator: Allocator,
 }
 
 /// What a report written before the allocator was recorded (issue #972)
 /// deserializes to: the explicit unknown, never a guessed allocator.
-fn default_allocator() -> String {
-    crate::allocator::ALLOCATOR_UNKNOWN.to_string()
+fn default_allocator() -> Allocator {
+    Allocator::Unknown
 }
 
 /// One figure a measurement reports, named so the report is self-describing and
@@ -1056,7 +1061,7 @@ mod tests {
                 key: "max_flush_delay_ms".to_string(),
                 value: "2000".to_string(),
             }],
-            allocator: crate::allocator::ALLOCATOR_TCMALLOC.to_string(),
+            allocator: Allocator::Tcmalloc,
         }
     }
 
@@ -1558,10 +1563,10 @@ mod tests {
     /// report written before the field existed deserializes to the explicit
     /// unknown rather than a guessed allocator (issue #972).
     ///
-    /// To watch the serialization half fail: change `valid_provenance`'s
-    /// `allocator` to `ALLOCATOR_JEMALLOC`; the exact-value assertion then reads
+    /// To watch the serialization half fail: change `valid_report`'s provenance
+    /// `allocator` to `Allocator::Jemalloc`; the exact-value assertion then reads
     /// `jemalloc == tcmalloc`. To watch the back-compat half fail: change
-    /// `default_allocator` to return `"system"`; the field-stripped report then
+    /// `default_allocator` to return `Allocator::System`; the field-stripped report then
     /// deserializes to `system` and the last assertion reads `system == unknown`.
     #[test]
     fn provenance_records_the_allocator_and_defaults_it_to_unknown() {
@@ -1581,10 +1586,45 @@ mod tests {
             .remove("allocator");
         let back: MetricsBenchReport =
             serde_json::from_value(doc).expect("deserialize a report with no allocator field");
-        assert_eq!(
-            back.provenance.allocator,
-            crate::allocator::ALLOCATOR_UNKNOWN
-        );
+        assert_eq!(back.provenance.allocator, Allocator::Unknown);
+    }
+
+    /// Every allocator the probe can produce round-trips through provenance by
+    /// exact value, and an unrecognized allocator string is rejected at
+    /// deserialize rather than laundered into `unknown` (issue #972): a garbage
+    /// value in this slot would read as the honest "the probe could not answer".
+    ///
+    /// To watch the round-trip half fail: change any arm of `Allocator::as_str`
+    /// (or the `rename_all`) so a variant serializes to a different string; the
+    /// exact-value assertion for that variant then mismatches. To watch the
+    /// reject half fail: add `#[serde(other)] Unknown` semantics (a catch-all)
+    /// to `Allocator`; the unrecognized string then deserializes to `unknown`
+    /// and `expect_err` panics.
+    #[test]
+    fn allocator_round_trips_by_value_and_rejects_an_unrecognized_string() {
+        for (variant, text) in [
+            (Allocator::Tcmalloc, "tcmalloc"),
+            (Allocator::Jemalloc, "jemalloc"),
+            (Allocator::Mimalloc, "mimalloc"),
+            (Allocator::System, "system"),
+            (Allocator::Unknown, "unknown"),
+        ] {
+            let mut report = valid_report();
+            report.provenance.allocator = variant;
+            let value = serde_json::to_value(&report).expect("serialize");
+            assert_eq!(
+                value["provenance"]["allocator"], text,
+                "{variant} serializes to its exact value"
+            );
+            let back: MetricsBenchReport =
+                serde_json::from_value(value).expect("deserialize a valid allocator");
+            assert_eq!(back.provenance.allocator, variant);
+        }
+
+        let mut doc = serde_json::to_value(valid_report()).expect("serialize");
+        doc["provenance"]["allocator"] = serde_json::json!("bogus-allocator");
+        serde_json::from_value::<MetricsBenchReport>(doc)
+            .expect_err("an unrecognized allocator string is rejected");
     }
 
     // --- FINDING 1: configuration entries are validated, not merely present. ---

--- a/crates/ravel-bench/src/sql_latency.rs
+++ b/crates/ravel-bench/src/sql_latency.rs
@@ -72,6 +72,7 @@ use ravel_types::{Signal, TenantHash, TenantId, TimeRange};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use crate::allocator::Allocator;
 use crate::sql_corpus::CorpusEntry;
 
 /// A frozen query clock, bounding the catalog resolve's ingest-hour fan-out.
@@ -333,18 +334,21 @@ pub struct Provenance {
     /// between the system allocator and a memory-returning one, and the allocator
     /// can arrive via `LD_PRELOAD` that a compile-time `cfg!` cannot see, so it is
     /// read off `/proc/self/maps` and recorded here rather than left to a caption
-    /// (issue #972). A report written before this field existed deserializes to
-    /// [`crate::allocator::ALLOCATOR_UNKNOWN`]: a wrong value reads as verified,
-    /// worse than an explicit absent one.
+    /// (issue #972). Typed as [`Allocator`] so the value domain is shared with
+    /// `report_schema::Provenance` and an out-of-domain value is unrepresentable
+    /// rather than merely rejected. A report written before this field existed
+    /// deserializes to [`Allocator::Unknown`]: a wrong value reads as verified,
+    /// worse than an explicit absent one. A report carrying an unrecognized
+    /// allocator string is rejected at deserialize.
     #[serde(default = "default_allocator")]
-    pub allocator: String,
+    pub allocator: Allocator,
 }
 
 /// What a report written before the allocator was recorded (issue #972)
 /// deserializes to. The explicit unknown, never a guessed allocator: an old
 /// report did not measure it, so it cannot claim one.
-fn default_allocator() -> String {
-    crate::allocator::ALLOCATOR_UNKNOWN.to_string()
+fn default_allocator() -> Allocator {
+    Allocator::Unknown
 }
 
 /// The `warm_catalog` regime a report should record. `--warm-catalog` reuses
@@ -2181,8 +2185,8 @@ mod tests {
     /// explicit unknown rather than a guessed allocator (issue #972).
     ///
     /// To watch the back-compat half fail: change `default_allocator` to return
-    /// `"system".to_string()`. The `without`-field report then deserializes to
-    /// `"system"` and the final assertion reads `system == unknown`. To watch
+    /// `Allocator::System`. The `without`-field report then deserializes to
+    /// `system` and the final assertion reads `system == unknown`. To watch
     /// the serialization half fail: drop `"allocator"` from the round-tripped
     /// value's expected key.
     #[test]
@@ -2201,7 +2205,7 @@ mod tests {
             "allocator": "tcmalloc"
         });
         let p: Provenance = serde_json::from_value(with).expect("deserialize");
-        assert_eq!(p.allocator, crate::allocator::ALLOCATOR_TCMALLOC);
+        assert_eq!(p.allocator, Allocator::Tcmalloc);
         let round = serde_json::to_value(&p).expect("serialize");
         assert_eq!(round["allocator"], "tcmalloc");
 
@@ -2218,7 +2222,61 @@ mod tests {
             "cache_bytes": 0
         });
         let p: Provenance = serde_json::from_value(without).expect("deserialize");
-        assert_eq!(p.allocator, crate::allocator::ALLOCATOR_UNKNOWN);
+        assert_eq!(p.allocator, Allocator::Unknown);
+    }
+
+    /// Every allocator the probe can produce round-trips through provenance by
+    /// exact value, and an unrecognized allocator string is rejected at
+    /// deserialize rather than laundered into `unknown` (issue #972): a garbage
+    /// value in this slot would read as the honest "the probe could not answer".
+    ///
+    /// To watch the round-trip half fail: change any arm of `Allocator::as_str`
+    /// (or the `rename_all`) so a variant serializes to a different string; the
+    /// exact-value assertion for that variant then mismatches. To watch the
+    /// reject half fail: give `Allocator` a `#[serde(other)]` catch-all variant;
+    /// the unrecognized string then deserializes to it and `expect_err` panics.
+    #[test]
+    fn allocator_round_trips_by_value_and_rejects_an_unrecognized_string() {
+        for (variant, text) in [
+            (Allocator::Tcmalloc, "tcmalloc"),
+            (Allocator::Jemalloc, "jemalloc"),
+            (Allocator::Mimalloc, "mimalloc"),
+            (Allocator::System, "system"),
+            (Allocator::Unknown, "unknown"),
+        ] {
+            let doc = serde_json::json!({
+                "store_backend": "s3",
+                "region": "us-east-1",
+                "endpoint": "n/a",
+                "host_logical_cores": 8,
+                "source": "generate",
+                "dataset_id": "t",
+                "runs": 3,
+                "cache_bytes": 0,
+                "allocator": text
+            });
+            let p: Provenance = serde_json::from_value(doc).expect("deserialize a valid allocator");
+            assert_eq!(p.allocator, variant);
+            let round = serde_json::to_value(&p).expect("serialize");
+            assert_eq!(
+                round["allocator"], text,
+                "{variant} serializes to its exact value"
+            );
+        }
+
+        let bogus = serde_json::json!({
+            "store_backend": "s3",
+            "region": "us-east-1",
+            "endpoint": "n/a",
+            "host_logical_cores": 8,
+            "source": "generate",
+            "dataset_id": "t",
+            "runs": 3,
+            "cache_bytes": 0,
+            "allocator": "bogus-allocator"
+        });
+        serde_json::from_value::<Provenance>(bogus)
+            .expect_err("an unrecognized allocator string is rejected");
     }
 
     /// Write `objects` RLOG objects (one record each) on `shard` for `tenant`,

--- a/crates/ravel-bench/src/sql_latency.rs
+++ b/crates/ravel-bench/src/sql_latency.rs
@@ -326,6 +326,25 @@ pub struct Provenance {
     /// machines in any deployment worth measuring.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub flight_endpoint: Option<String>,
+    /// The heap allocator this run actually executed under, resolved at runtime
+    /// from the process's mapped libraries (`crate::allocator::active_allocator`):
+    /// `"tcmalloc"`, `"jemalloc"`, `"mimalloc"`, `"system"` (glibc/musl), or
+    /// `"unknown"` when the probe could not answer. Peak RSS moves by about 2x
+    /// between the system allocator and a memory-returning one, and the allocator
+    /// can arrive via `LD_PRELOAD` that a compile-time `cfg!` cannot see, so it is
+    /// read off `/proc/self/maps` and recorded here rather than left to a caption
+    /// (issue #972). A report written before this field existed deserializes to
+    /// [`crate::allocator::ALLOCATOR_UNKNOWN`]: a wrong value reads as verified,
+    /// worse than an explicit absent one.
+    #[serde(default = "default_allocator")]
+    pub allocator: String,
+}
+
+/// What a report written before the allocator was recorded (issue #972)
+/// deserializes to. The explicit unknown, never a guessed allocator: an old
+/// report did not measure it, so it cannot claim one.
+fn default_allocator() -> String {
+    crate::allocator::ALLOCATOR_UNKNOWN.to_string()
 }
 
 /// The `warm_catalog` regime a report should record. `--warm-catalog` reuses
@@ -1763,6 +1782,7 @@ pub async fn run_generated(cfg: &GenerateConfig) -> Result<SqlLatencyReport, Err
             // reaches the fetcher, so the requested value is the effective one.
             logs_suffix_len: cfg.logs_suffix_len,
             flight_endpoint: None,
+            allocator: crate::allocator::active_allocator(),
         },
         dataset,
         entries,
@@ -1939,6 +1959,10 @@ pub async fn run_tenant(cfg: &TenantConfigInput) -> Result<SqlLatencyReport, Err
                 None => cfg.logs_suffix_len,
             },
             flight_endpoint: cfg.flight.as_ref().map(|t| t.endpoint.clone()),
+            // Read off this process's own maps regardless of lane: the allocator
+            // governs the benchmark process's RSS, and on the Flight lane the
+            // server's allocator is its own concern, not recorded here.
+            allocator: crate::allocator::active_allocator(),
         },
         dataset,
         entries,
@@ -2150,6 +2174,51 @@ mod tests {
 
     fn empty_store() -> Arc<dyn ObjectStoreBackend> {
         Arc::new(MemoryStore::new())
+    }
+
+    /// The allocator is stamped into provenance and serializes with its exact
+    /// value, and a report written before the field existed deserializes to the
+    /// explicit unknown rather than a guessed allocator (issue #972).
+    ///
+    /// To watch the back-compat half fail: change `default_allocator` to return
+    /// `"system".to_string()`. The `without`-field report then deserializes to
+    /// `"system"` and the final assertion reads `system == unknown`. To watch
+    /// the serialization half fail: drop `"allocator"` from the round-tripped
+    /// value's expected key.
+    #[test]
+    fn provenance_records_the_allocator_and_defaults_it_to_unknown() {
+        // A report written after this field exists carries it verbatim, and it
+        // round-trips through JSON with its exact value.
+        let with = serde_json::json!({
+            "store_backend": "s3",
+            "region": "us-east-1",
+            "endpoint": "n/a",
+            "host_logical_cores": 8,
+            "source": "generate",
+            "dataset_id": "t",
+            "runs": 3,
+            "cache_bytes": 0,
+            "allocator": "tcmalloc"
+        });
+        let p: Provenance = serde_json::from_value(with).expect("deserialize");
+        assert_eq!(p.allocator, crate::allocator::ALLOCATOR_TCMALLOC);
+        let round = serde_json::to_value(&p).expect("serialize");
+        assert_eq!(round["allocator"], "tcmalloc");
+
+        // A report written before the field existed omits it, and deserializes
+        // to the explicit unknown, never a guessed allocator.
+        let without = serde_json::json!({
+            "store_backend": "s3",
+            "region": "us-east-1",
+            "endpoint": "n/a",
+            "host_logical_cores": 8,
+            "source": "generate",
+            "dataset_id": "t",
+            "runs": 3,
+            "cache_bytes": 0
+        });
+        let p: Provenance = serde_json::from_value(without).expect("deserialize");
+        assert_eq!(p.allocator, crate::allocator::ALLOCATOR_UNKNOWN);
     }
 
     /// Write `objects` RLOG objects (one record each) on `shard` for `tenant`,

--- a/crates/ravel-bench/tests/metricsbench_report.rs
+++ b/crates/ravel-bench/tests/metricsbench_report.rs
@@ -48,6 +48,7 @@ fn valid_report() -> MetricsBenchReport {
             generator_digest: "blake3:1111".to_string(),
             corpus_digest: "blake3:2222".to_string(),
             config: vec![],
+            allocator: ravel_bench::allocator::ALLOCATOR_SYSTEM.to_string(),
         },
         measurements: vec![Measurement {
             id: "mb_fanout_total_rate".to_string(),

--- a/crates/ravel-bench/tests/metricsbench_report.rs
+++ b/crates/ravel-bench/tests/metricsbench_report.rs
@@ -48,7 +48,7 @@ fn valid_report() -> MetricsBenchReport {
             generator_digest: "blake3:1111".to_string(),
             corpus_digest: "blake3:2222".to_string(),
             config: vec![],
-            allocator: ravel_bench::allocator::ALLOCATOR_SYSTEM.to_string(),
+            allocator: ravel_bench::allocator::Allocator::System,
         },
         measurements: vec![Measurement {
             id: "mb_fanout_total_rate".to_string(),

--- a/docs/guides/clickbench.md
+++ b/docs/guides/clickbench.md
@@ -567,8 +567,13 @@ Tick every line before putting two reports side by side.
   not recorded here, so the two runs are comparable on it only if you know both
   servers were configured the same.
 - Same allocator. An `LD_PRELOAD` of tcmalloc against the default glibc changes
-  peak RSS by about 2x, and the allocator is not in the provenance, so it goes
-  in the report's caption.
+  peak RSS by about 2x. The allocator is in the provenance (the `allocator`
+  field, resolved at runtime by reading the process's mapped libraries from
+  `/proc/self/maps`, so an `LD_PRELOAD` shows up as `tcmalloc`/`jemalloc`/
+  `mimalloc` and a plain run as `system`), so compare on that field, not on a
+  caption. A run whose allocator could not be probed records `unknown`; two
+  reports are comparable on peak RSS only if both name the same allocator and
+  neither is `unknown`.
 - Same dataset stanza: object count, rows, and the layout label from
   `--compaction`.
 


### PR DESCRIPTION
feat(ravel-bench): record active allocator in report provenance

Peak RSS moves by about 2x between the system allocator (glibc) and a
memory-returning one (tcmalloc/jemalloc), yet the allocator was not in
any bench report's provenance. The clickbench runbook told the reader to
put it in the report's caption instead, and a caption is a human
remembering: the peak-RSS figures on #968 were measured under glibc with
no LD_PRELOAD while the runbook requires tcmalloc, and nothing in the
artifact could have told a reader that.

Add an `allocator` field to the run provenance, resolved at runtime from
the process's mapped libraries in /proc/self/maps. Reading the maps
reports the truth including when the allocator arrived via LD_PRELOAD,
which a compile-time cfg! cannot see. The parsing is split from the
/proc read (crate::allocator::allocator_from_maps) so it is testable
against fixture text. When the probe cannot answer (no /proc, an
unreadable or unrecognizable maps) the field is "unknown" rather than a
guessed allocator: a wrong provenance value reads as verified, which is
worse than an explicit absent one. A readable maps naming no known
allocator is "system".

The field is populated on the real paths: both sql_latency Provenance
construction sites (the clickbench report, whose caption this closes) and
the metricsbench_report provenance stamp. Old reports without the field
deserialize to "unknown". The clickbench guide now points the reader at
the field instead of a caption.

This does not add an allocator dependency, a #[global_allocator], or
change which allocator anything uses; it only makes the current
situation visible.

Refs: #972

