### PR TITLE
feat(maintain): attribute compaction peak memory by phase

### DIFF
--- a/crates/ravel-maintain/src/config.rs
+++ b/crates/ravel-maintain/src/config.rs
@@ -28,7 +28,7 @@ use uuid::Uuid;
 /// would grow with its size and the recorded high-water would break the
 /// test's bound.
 ///
-/// Two high-water marks are kept:
+/// Two combined high-water marks are kept:
 ///
 /// - [`Self::peak_transient_bytes`]: `fetched + decoded`, the merge's *own*
 ///   decode-side buffers. This is the quantity these merges bound: at most
@@ -47,8 +47,40 @@ use uuid::Uuid;
 ///   also close a part earlier on the stored-size target `max_l1_part_bytes`
 ///   (issue #872), which only lowers this term.
 ///
+/// # Phase-attributed peaks (issue #977)
+///
+/// The two combined marks above pool bytes of different kinds (raw fetched,
+/// decoded heap, writer heap) into one figure and omit the two terms that
+/// actually dominate a large-bucket compaction: the closed parts retained in
+/// [`crate::rlog::PartSink`] and the per-input catalog directories. So the
+/// tracker also records a peak PER PHASE, read back as a [`MergePhasePeaks`]
+/// via [`Self::phase_peaks`], each field naming which bytes it counts:
+///
+/// - catalog load ([`Self::add_catalog_directory_bytes`]): encoded
+///   directory-section bytes retained per input.
+/// - merge and cursors ([`Self::peak_transient_bytes`]): the decode-side
+///   buffers above.
+/// - in-progress part writer ([`Self::peak_writer_bytes`]): the current part's
+///   accumulated records, decoded heap.
+/// - retained closed parts ([`Self::add_retained_part_bytes`]): the encoded
+///   bytes of every part already PUT but still held until publish. This is the
+///   term the issue existed to expose; it was invisible before.
+/// - finish and publish ([`Self::set_publish_record_bytes`]): the encoded
+///   compaction-record payload, the only allocation the publish phase adds on
+///   top of the retained parts.
+///
+/// Two fields of different byte kinds (encoded vs decoded heap) must never be
+/// summed (the repo measurement rule). The tracker is one PER COMPACTION RUN:
+/// the retained-parts and catalog terms accumulate and are not released within
+/// a run, so reusing one tracker across buckets would sum their peaks.
+///
 /// Production never installs one (`CompactorConfig::merge_memory_tracker` is
 /// `None`), so the hooks compile to a single `Option` check and add nothing.
+/// Wiring the service to install one (a one-line
+/// `merge_memory_tracker: Some(MergeMemoryTracker::new())` where it builds the
+/// [`CompactorConfig`]) is what surfaces [`Self::phase_peaks`] to an operator
+/// through the `tracing::info!` event `rewrite_and_publish` emits when a
+/// tracker is present.
 #[derive(Clone, Debug, Default)]
 pub struct MergeMemoryTracker {
     inner: Arc<MergeMemoryInner>,
@@ -72,6 +104,52 @@ struct MergeMemoryInner {
     /// Parts closed because the encoded-bytes estimate reached
     /// `max_l1_part_bytes` (the stored-size target fired).
     stored_target_flushes: AtomicU64,
+    /// Live sum of the encoded/on-object bytes of closed parts still retained in
+    /// [`crate::rlog::PartSink::parts`] (PUT already, not yet dropped).
+    /// Monotonic within a run: parts are held until publish, so this never
+    /// decrements before the run ends.
+    retained_parts: AtomicU64,
+    /// High-water of `retained_parts`.
+    peak_retained_parts: AtomicU64,
+    /// Live sum of encoded directory-section bytes (STREAM_DIR + FIELD_DIR +
+    /// SKIP_IDX + PAGE_DIR) retained per input during catalog load.
+    catalog_directory: AtomicU64,
+    /// High-water of `catalog_directory`.
+    peak_catalog_directory: AtomicU64,
+    /// High-water of the in-progress part writer term ALONE (decoded heap),
+    /// separate from `peak_total`, which pools it with the cursor terms.
+    peak_writer: AtomicU64,
+    /// High-water of the published compaction record's encoded protobuf payload.
+    peak_publish_record: AtomicU64,
+}
+
+/// A compaction merge's peak resident memory split by the phase that caused it
+/// (issue #977). Each field NAMES which bytes it counts; two fields of
+/// different byte kinds (encoded vs decoded heap) must never be summed (the
+/// repo measurement rule). Read from a [`MergeMemoryTracker`] via
+/// [`MergeMemoryTracker::phase_peaks`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct MergePhasePeaks {
+    /// Input read / catalog load: high-water of the encoded directory-section
+    /// bytes (STREAM_DIR + FIELD_DIR + SKIP_IDX + PAGE_DIR) retained across all
+    /// inputs' catalogs. Encoded/on-object bytes.
+    pub catalog_directory_encoded_bytes: u64,
+    /// Merge and cursors: high-water of the k-way merge's own decode-side
+    /// buffers, one raw fetched unit plus one decoded block per input
+    /// (`fetched + decoded`, the existing [`MergeMemoryTracker::peak_transient_bytes`]).
+    /// Mixed raw-encoded plus decoded heap.
+    pub cursor_bytes: u64,
+    /// In-progress part writer: high-water of the current part builder's
+    /// accumulated records. Decoded heap bytes.
+    pub writer_heap_bytes: u64,
+    /// Retained closed parts: high-water of the encoded bytes of parts already
+    /// PUT but still held in [`crate::rlog::PartSink::parts`] until publish.
+    /// Encoded/on-object bytes. The term issue #977 made visible.
+    pub retained_part_encoded_bytes: u64,
+    /// Finish and publish: the published compaction record's encoded protobuf
+    /// payload, the only allocation the publish phase adds on top of the
+    /// retained parts. Encoded bytes.
+    pub publish_record_encoded_bytes: u64,
 }
 
 impl MergeMemoryTracker {
@@ -120,6 +198,49 @@ impl MergeMemoryTracker {
             .peak_transient
             .fetch_max(transient, Ordering::Relaxed);
         self.inner.peak_total.fetch_max(total, Ordering::Relaxed);
+        self.inner.peak_writer.fetch_max(writer, Ordering::Relaxed);
+    }
+
+    /// Account `bytes` of encoded part bytes retained in
+    /// [`crate::rlog::PartSink::parts`] when a closed part is pushed there. The
+    /// part was already PUT; it stays resident until publish, so this is never
+    /// released within a run and its high-water is the retained-parts plateau a
+    /// large-bucket compaction sits at. Encoded/on-object bytes, not heap; it is
+    /// deliberately a separate term from the writer's decoded-heap bytes so a
+    /// report never folds the two together.
+    pub fn add_retained_part_bytes(&self, bytes: u64) {
+        let updated = self
+            .inner
+            .retained_parts
+            .fetch_add(bytes, Ordering::Relaxed)
+            .saturating_add(bytes);
+        self.inner
+            .peak_retained_parts
+            .fetch_max(updated, Ordering::Relaxed);
+    }
+
+    /// Account `bytes` of encoded directory-section bytes (STREAM_DIR +
+    /// FIELD_DIR + SKIP_IDX + PAGE_DIR) retained for one input's catalog, called
+    /// once per input as its catalog is loaded. Accumulates across inputs and is
+    /// not released within a run.
+    pub fn add_catalog_directory_bytes(&self, bytes: u64) {
+        let updated = self
+            .inner
+            .catalog_directory
+            .fetch_add(bytes, Ordering::Relaxed)
+            .saturating_add(bytes);
+        self.inner
+            .peak_catalog_directory
+            .fetch_max(updated, Ordering::Relaxed);
+    }
+
+    /// Record the encoded protobuf payload size of the published compaction
+    /// record: the finish/publish phase's own allocation on top of the retained
+    /// parts. Encoded bytes.
+    pub fn set_publish_record_bytes(&self, bytes: u64) {
+        self.inner
+            .peak_publish_record
+            .fetch_max(bytes, Ordering::Relaxed);
     }
 
     /// High-water of the merge's decode-side buffers (`fetched + decoded`).
@@ -133,6 +254,41 @@ impl MergeMemoryTracker {
     /// in-progress part's writer buffer.
     pub fn peak_total_bytes(&self) -> u64 {
         self.inner.peak_total.load(Ordering::Relaxed)
+    }
+
+    /// High-water of the retained closed parts (encoded/on-object bytes held in
+    /// [`crate::rlog::PartSink::parts`] until publish).
+    pub fn peak_retained_part_bytes(&self) -> u64 {
+        self.inner.peak_retained_parts.load(Ordering::Relaxed)
+    }
+
+    /// High-water of the per-input catalog directory bytes (encoded STREAM_DIR +
+    /// FIELD_DIR + SKIP_IDX + PAGE_DIR, summed over the inputs held at once).
+    pub fn peak_catalog_directory_bytes(&self) -> u64 {
+        self.inner.peak_catalog_directory.load(Ordering::Relaxed)
+    }
+
+    /// High-water of the in-progress part writer term alone (decoded heap),
+    /// unmixed with the cursor terms that [`Self::peak_total_bytes`] pools in.
+    pub fn peak_writer_bytes(&self) -> u64 {
+        self.inner.peak_writer.load(Ordering::Relaxed)
+    }
+
+    /// High-water of the published compaction record's encoded payload bytes.
+    pub fn peak_publish_record_bytes(&self) -> u64 {
+        self.inner.peak_publish_record.load(Ordering::Relaxed)
+    }
+
+    /// The full phase split, each term naming its byte kind. See
+    /// [`MergePhasePeaks`]; do not sum fields of different kinds.
+    pub fn phase_peaks(&self) -> MergePhasePeaks {
+        MergePhasePeaks {
+            catalog_directory_encoded_bytes: self.peak_catalog_directory_bytes(),
+            cursor_bytes: self.peak_transient_bytes(),
+            writer_heap_bytes: self.peak_writer_bytes(),
+            retained_part_encoded_bytes: self.peak_retained_part_bytes(),
+            publish_record_encoded_bytes: self.peak_publish_record_bytes(),
+        }
     }
 
     /// Record that a part was closed by the memory split target (its decoded

--- a/crates/ravel-maintain/src/config.rs
+++ b/crates/ravel-maintain/src/config.rs
@@ -70,9 +70,13 @@ use uuid::Uuid;
 ///   top of the retained parts.
 ///
 /// Two fields of different byte kinds (encoded vs decoded heap) must never be
-/// summed (the repo measurement rule). The tracker is one PER COMPACTION RUN:
-/// the retained-parts and catalog terms accumulate and are not released within
-/// a run, so reusing one tracker across buckets would sum their peaks.
+/// summed (the repo measurement rule). The tracker is one PER CONCURRENT
+/// COMPACTION RUN: the retained-parts and catalog terms accumulate and are
+/// not released within a run. SERIAL reuse across buckets is repaired
+/// mechanically -- `rewrite_and_publish` calls [`Self::reset_for_run`] before
+/// any accounting, so each bucket's figures are its own -- but two runs
+/// sharing one tracker CONCURRENTLY still combine, and that contract is the
+/// installer's to keep.
 ///
 /// Production never installs one (`CompactorConfig::merge_memory_tracker` is
 /// `None`), so the hooks compile to a single `Option` check and add nothing.
@@ -279,6 +283,34 @@ impl MergeMemoryTracker {
     /// High-water of the published compaction record's encoded payload bytes.
     pub fn peak_publish_record_bytes(&self) -> u64 {
         self.inner.peak_publish_record.load(Ordering::Relaxed)
+    }
+
+    /// Clear every counter and high-water term for a NEW run. Called at the
+    /// start of each bucket's rewrite, so a tracker left installed in a
+    /// long-lived [`CompactorConfig`] reports each bucket's own peaks under
+    /// that bucket's identity instead of a cumulative maximum, and every
+    /// post-run read (the emission, a test, a future CLI surface) stays
+    /// valid. Wrong to call mid-run; CONCURRENT runs sharing one tracker
+    /// still produce combined figures, and that contract is the installer's
+    /// to keep (one tracker per concurrent run).
+    pub fn reset_for_run(&self) {
+        for field in [
+            &self.inner.fetched,
+            &self.inner.decoded,
+            &self.inner.writer,
+            &self.inner.peak_transient,
+            &self.inner.peak_total,
+            &self.inner.memory_target_flushes,
+            &self.inner.stored_target_flushes,
+            &self.inner.retained_parts,
+            &self.inner.peak_retained_parts,
+            &self.inner.catalog_directory,
+            &self.inner.peak_catalog_directory,
+            &self.inner.peak_writer,
+            &self.inner.peak_publish_record,
+        ] {
+            field.store(0, Ordering::Relaxed);
+        }
     }
 
     /// The full phase split, each term naming its byte kind. See

--- a/crates/ravel-maintain/src/config.rs
+++ b/crates/ravel-maintain/src/config.rs
@@ -56,8 +56,8 @@ use uuid::Uuid;
 /// tracker also records a peak PER PHASE, read back as a [`MergePhasePeaks`]
 /// via [`Self::phase_peaks`], each field naming which bytes it counts:
 ///
-/// - catalog load ([`Self::add_catalog_directory_bytes`]): encoded
-///   directory-section bytes retained per input.
+/// - catalog load ([`Self::add_catalog_directory_bytes`]): decoded
+///   directory-section payload bytes retained per input.
 /// - merge and cursors ([`Self::peak_transient_bytes`]): the decode-side
 ///   buffers above.
 /// - in-progress part writer ([`Self::peak_writer_bytes`]): the current part's
@@ -130,10 +130,12 @@ struct MergeMemoryInner {
 /// [`MergeMemoryTracker::phase_peaks`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct MergePhasePeaks {
-    /// Input read / catalog load: high-water of the encoded directory-section
-    /// bytes (STREAM_DIR + FIELD_DIR + SKIP_IDX + PAGE_DIR) retained across all
-    /// inputs' catalogs. Encoded/on-object bytes.
-    pub catalog_directory_encoded_bytes: u64,
+    /// Input read / catalog load: high-water of the decoded directory-section
+    /// payload bytes (STREAM_DIR + FIELD_DIR + SKIP_IDX + PAGE_DIR, after
+    /// section decompression) retained across all inputs' catalogs. Decoded
+    /// payload bytes, NOT on-object encoded lengths: the reader retains the
+    /// decoded form, and this is a residency figure.
+    pub catalog_directory_decoded_bytes: u64,
     /// Merge and cursors: high-water of the k-way merge's own decode-side
     /// buffers, one raw fetched unit plus one decoded block per input
     /// (`fetched + decoded`, the existing [`MergeMemoryTracker::peak_transient_bytes`]).
@@ -283,7 +285,7 @@ impl MergeMemoryTracker {
     /// [`MergePhasePeaks`]; do not sum fields of different kinds.
     pub fn phase_peaks(&self) -> MergePhasePeaks {
         MergePhasePeaks {
-            catalog_directory_encoded_bytes: self.peak_catalog_directory_bytes(),
+            catalog_directory_decoded_bytes: self.peak_catalog_directory_bytes(),
             cursor_bytes: self.peak_transient_bytes(),
             writer_heap_bytes: self.peak_writer_bytes(),
             retained_part_encoded_bytes: self.peak_retained_part_bytes(),

--- a/crates/ravel-maintain/src/lib.rs
+++ b/crates/ravel-maintain/src/lib.rs
@@ -72,8 +72,8 @@ pub use clock::{Clock, FixedClock};
 pub use codec::{RsegCodec, SegmentCodec};
 pub use compact::{CompactionOutcome, compact_bucket};
 pub use config::{
-    AuditMode, AuditPipelineConfig, CompactorConfig, MergeMemoryTracker, RetentionConfig,
-    RetentionConfigError, RetentionPolicy,
+    AuditMode, AuditPipelineConfig, CompactorConfig, MergeMemoryTracker, MergePhasePeaks,
+    RetentionConfig, RetentionConfigError, RetentionPolicy,
 };
 pub use discover::discover_tenants;
 pub use erasure_rewrite::{

--- a/crates/ravel-maintain/src/publish.rs
+++ b/crates/ravel-maintain/src/publish.rs
@@ -183,6 +183,13 @@ pub async fn publish_record_with_conservation(
 
     let record_key = keys::compaction_record_key_for(&record)?;
     let payload = record.encode_to_vec();
+    // Finish/publish phase (issue #977): the encoded record payload is the only
+    // allocation this phase adds on top of the parts still retained in the
+    // merge's `PartSink`. Recording it here lets a report show the publish phase
+    // is small next to the retained-parts plateau, not the source of a spike.
+    if let Some(t) = config.merge_memory_tracker.as_ref() {
+        t.set_publish_record_bytes(payload.len() as u64);
+    }
     let checksum = UploadChecksum::Crc32c(crc32c::crc32c(&payload));
     let opts = PutOptions::create_if_absent().with_checksum(checksum);
 

--- a/crates/ravel-maintain/src/rewrite.rs
+++ b/crates/ravel-maintain/src/rewrite.rs
@@ -141,6 +141,30 @@ pub async fn rewrite_and_publish<C: SegmentCodec>(
     )
     .await?;
 
+    // Issue #977: surface the compaction's peak memory split by phase. Every
+    // term is populated by now (catalog load before build_parts, cursor/writer/
+    // retained during build_parts, publish record during publish), and `parts`
+    // is still alive so the retained high-water reflects the whole set. Each
+    // field names its byte kind; they are NOT summable across kinds. Only fires
+    // when a tracker is installed (never in production today, see
+    // `MergeMemoryTracker`); installing one is the one-line service change that
+    // makes this visible to an operator.
+    if let Some(t) = config.merge_memory_tracker.as_ref() {
+        let peaks = t.phase_peaks();
+        tracing::info!(
+            signal = ?bucket.signal,
+            shard = bucket.shard,
+            ingest_hour_bucket = bucket.ingest_hour_bucket,
+            parts = parts.len(),
+            catalog_directory_encoded_bytes = peaks.catalog_directory_encoded_bytes,
+            cursor_bytes = peaks.cursor_bytes,
+            writer_heap_bytes = peaks.writer_heap_bytes,
+            retained_part_encoded_bytes = peaks.retained_part_encoded_bytes,
+            publish_record_encoded_bytes = peaks.publish_record_encoded_bytes,
+            "compaction peak memory by phase (byte kinds differ per term; do not sum)"
+        );
+    }
+
     Ok(RewriteOutcome {
         parts: parts.len(),
         publish,

--- a/crates/ravel-maintain/src/rewrite.rs
+++ b/crates/ravel-maintain/src/rewrite.rs
@@ -156,7 +156,7 @@ pub async fn rewrite_and_publish<C: SegmentCodec>(
             shard = bucket.shard,
             ingest_hour_bucket = bucket.ingest_hour_bucket,
             parts = parts.len(),
-            catalog_directory_encoded_bytes = peaks.catalog_directory_encoded_bytes,
+            catalog_directory_decoded_bytes = peaks.catalog_directory_decoded_bytes,
             cursor_bytes = peaks.cursor_bytes,
             writer_heap_bytes = peaks.writer_heap_bytes,
             retained_part_encoded_bytes = peaks.retained_part_encoded_bytes,

--- a/crates/ravel-maintain/src/rewrite.rs
+++ b/crates/ravel-maintain/src/rewrite.rs
@@ -102,6 +102,13 @@ pub async fn rewrite_and_publish<C: SegmentCodec>(
     conservation: impl ConservationPredicate,
     start_ns: i64,
 ) -> Result<RewriteOutcome> {
+    // A new run's accounting starts from zero: a tracker left installed in a
+    // long-lived config would otherwise carry the previous bucket's peaks
+    // into this bucket's emission (serial reuse; concurrent sharing is the
+    // installer's contract to avoid).
+    if let Some(t) = config.merge_memory_tracker.as_ref() {
+        t.reset_for_run();
+    }
     let inputs = load_inputs(store, bucket, commit_keys, config.input_read_concurrency).await?;
     C::validate_rewrite_inputs(&inputs)?;
     let hash = input_set_hash(&inputs);

--- a/crates/ravel-maintain/src/rlog.rs
+++ b/crates/ravel-maintain/src/rlog.rs
@@ -366,8 +366,9 @@ pub(crate) async fn load_catalog_from_object(
     };
     // Input read / catalog load phase (issue #977): the reader below retains a
     // decoded form of these directory sections for the whole merge. Charge the
-    // encoded section bytes as a per-input proxy; the block/bloom bytes are NOT
-    // held here (the merge streams them by range), so they are not charged.
+    // decoded section payload lengths (what `fetch_section` returns after
+    // decompression, the retained form); the block/bloom bytes are NOT held
+    // here (the merge streams them by range), so they are not charged.
     if let Some(t) = config.merge_memory_tracker.as_ref() {
         let dir_bytes = stream_dir_raw.len() as u64
             + field_dir_raw.len() as u64

--- a/crates/ravel-maintain/src/rlog.rs
+++ b/crates/ravel-maintain/src/rlog.rs
@@ -364,6 +364,17 @@ pub(crate) async fn load_catalog_from_object(
         Some(_) => Some(fetch_section(store, &object_key, &ftr, kind::PAGE_DIR, &cfg).await?),
         None => None,
     };
+    // Input read / catalog load phase (issue #977): the reader below retains a
+    // decoded form of these directory sections for the whole merge. Charge the
+    // encoded section bytes as a per-input proxy; the block/bloom bytes are NOT
+    // held here (the merge streams them by range), so they are not charged.
+    if let Some(t) = config.merge_memory_tracker.as_ref() {
+        let dir_bytes = stream_dir_raw.len() as u64
+            + field_dir_raw.len() as u64
+            + skip_idx_raw.len() as u64
+            + page_dir_raw.as_ref().map(|d| d.len() as u64).unwrap_or(0);
+        t.add_catalog_directory_bytes(dir_bytes);
+    }
     let record_count = ftr.record_count;
     let reader = RlogRangeReader::from_sections_with_page_dir(
         &ftr,
@@ -642,9 +653,15 @@ impl PartSink<'_> {
                     self.dry_run,
                 )
                 .await?;
+            let retained = built.bytes.len() as u64;
             self.parts.push(built);
             self.part_index += 1;
             if let Some(t) = self.tracker {
+                // The part is PUT but its encoded bytes stay resident in
+                // `self.parts` until publish. Charge the retained-parts term
+                // (encoded bytes) and clear the writer term (its decoded-heap
+                // records were handed to the writer and released on encode).
+                t.add_retained_part_bytes(retained);
                 t.set_writer_bytes(0);
             }
         }

--- a/crates/ravel-maintain/tests/memory.rs
+++ b/crates/ravel-maintain/tests/memory.rs
@@ -297,7 +297,7 @@ async fn retained_parts_are_attributed_to_their_own_phase() {
         "the in-progress writer term must have been driven"
     );
     assert!(
-        peaks.catalog_directory_encoded_bytes > 0,
+        peaks.catalog_directory_decoded_bytes > 0,
         "the catalog-load term must have been driven"
     );
     assert!(
@@ -306,12 +306,12 @@ async fn retained_parts_are_attributed_to_their_own_phase() {
     );
     println!(
         "[memory:rlog:977] parts={} retained_part_encoded_bytes={} writer_heap_bytes={} \
-         cursor_bytes={} catalog_directory_encoded_bytes={} publish_record_encoded_bytes={}",
+         cursor_bytes={} catalog_directory_decoded_bytes={} publish_record_encoded_bytes={}",
         record.parts.len(),
         peaks.retained_part_encoded_bytes,
         peaks.writer_heap_bytes,
         peaks.cursor_bytes,
-        peaks.catalog_directory_encoded_bytes,
+        peaks.catalog_directory_decoded_bytes,
         peaks.publish_record_encoded_bytes,
     );
 }

--- a/crates/ravel-maintain/tests/memory.rs
+++ b/crates/ravel-maintain/tests/memory.rs
@@ -17,7 +17,9 @@
 mod common;
 
 use common::*;
-use ravel_maintain::{CompactionOutcome, CompactorConfig, FixedClock, compact_bucket};
+use ravel_maintain::{
+    CompactionOutcome, CompactorConfig, FixedClock, MergeMemoryTracker, compact_bucket,
+};
 use ravel_object_store::memory::MemoryStore;
 use uuid::Uuid;
 
@@ -189,4 +191,127 @@ async fn peak_memory_on_rlog_input_bucket() {
             println!("[memory:rlog] /proc/self/status unavailable; skipping RSS assertion");
         }
     }
+}
+
+/// Issue #977: the retained closed parts are attributed to their OWN phase term
+/// and are NOT folded into the writer term.
+///
+/// A logs compaction under a small stored-size target closes many L1 parts.
+/// Every closed part is PUT but its encoded bytes stay resident in
+/// `PartSink::parts` until publish; that retained residency is the plateau a
+/// large-bucket compaction sits at, and before this ticket it was invisible in
+/// the [`MergeMemoryTracker`]. This drives a compaction that closes at least
+/// three parts and asserts the tracker's retained-parts high-water equals the
+/// EXACT sum of those parts' encoded object sizes (read back from the published
+/// record's `object_size`, which `finalize_part` sets to the same bytes it
+/// retains). The value is derivable, so it is pinned exactly, not bounded.
+///
+/// Non-vacuity / flip proof: the retained bytes are charged at `rlog.rs`'s
+/// `PartSink::flush`, in the line `t.add_retained_part_bytes(retained);`.
+/// Deleting that line (attributing nothing to the retained phase, i.e. leaving
+/// the bytes accounted only through the writer term that `set_writer_bytes`
+/// drives) makes `peak_retained_part_bytes()` stay 0, and the exact-equality
+/// assertion below fails `0 != <sum>`. Rerouting it to `t.set_writer_bytes(
+/// retained)` (folding the retained bytes into the writer phase, the bug this
+/// test exists to catch) fails the same way. Verified failing both ways before
+/// restoring.
+#[tokio::test]
+async fn retained_parts_are_attributed_to_their_own_phase() {
+    const INPUTS: usize = 24;
+    const STREAMS: u32 = 4;
+    const RECORDS_PER_STREAM: usize = 4;
+
+    let store = MemoryStore::new();
+    // A body long enough that a handful of records exceeds the tiny stored-size
+    // target below, so the merge closes many parts rather than one.
+    let body: String = "log-line-".repeat(24);
+    for i in 0..INPUTS {
+        let mut records = Vec::new();
+        for s in 0..STREAMS {
+            for r in 0..RECORDS_PER_STREAM {
+                let ts = 1_000 + (i * RECORDS_PER_STREAM + r) as i64;
+                records.push(log_record(s, ts, &format!("{body}-{s}-{i}-{r}")));
+            }
+        }
+        seed_rlog_input(
+            &store,
+            Uuid::from_u128(i as u128 + 1),
+            1,
+            i as u64 + 1,
+            &records,
+        )
+        .await;
+    }
+
+    let tracker = MergeMemoryTracker::new();
+    let config = CompactorConfig {
+        // Small stored-size target so parts close often; this changes only where
+        // records split into parts, never their bytes.
+        max_l1_part_bytes: 2048,
+        merge_memory_tracker: Some(tracker.clone()),
+        ..CompactorConfig::default()
+    };
+    let clock = FixedClock::new(sealed_now_ns());
+    let bucket = logs_bucket();
+    let outcome = compact_bucket(&store, &clock, &config, &bucket)
+        .await
+        .expect("compact rlog bucket");
+    assert!(matches!(outcome, CompactionOutcome::Compacted { .. }));
+
+    let record = fetch_compaction_record(&store, &bucket).await;
+    assert!(
+        record.parts.len() >= 3,
+        "the small stored target must close at least three parts, got {}",
+        record.parts.len()
+    );
+
+    // The retained-parts phase term equals the exact encoded size of every part
+    // the merge held: each `object_size` is the byte length `finalize_part`
+    // retained in `PartSink::parts`, and every closed part is retained until
+    // publish, so the high-water is their sum.
+    let expected_retained: u64 = record.parts.iter().map(|p| p.object_size).sum();
+    assert_eq!(
+        tracker.peak_retained_part_bytes(),
+        expected_retained,
+        "retained-parts high-water must equal the exact sum of the parts' encoded sizes"
+    );
+
+    // The retained term is its own phase, not the writer term. The writer term
+    // is decoded Rust heap of one in-progress part at a time; the retained term
+    // is the encoded bytes of every closed part at once. Read them back from the
+    // phase split and confirm the split reports the retained sum under the
+    // retained field, and the writer field is a different (heap) quantity that
+    // does not carry the retained bytes.
+    let peaks = tracker.phase_peaks();
+    assert_eq!(
+        peaks.retained_part_encoded_bytes, expected_retained,
+        "phase_peaks must carry the retained sum in its retained field"
+    );
+    assert_ne!(
+        peaks.retained_part_encoded_bytes, peaks.writer_heap_bytes,
+        "retained (encoded, all parts) must not be folded into writer (heap, one part)"
+    );
+    // Sanity: the merge really exercised the other phases too.
+    assert!(
+        peaks.writer_heap_bytes > 0,
+        "the in-progress writer term must have been driven"
+    );
+    assert!(
+        peaks.catalog_directory_encoded_bytes > 0,
+        "the catalog-load term must have been driven"
+    );
+    assert!(
+        peaks.publish_record_encoded_bytes > 0,
+        "the finish/publish term must have been driven"
+    );
+    println!(
+        "[memory:rlog:977] parts={} retained_part_encoded_bytes={} writer_heap_bytes={} \
+         cursor_bytes={} catalog_directory_encoded_bytes={} publish_record_encoded_bytes={}",
+        record.parts.len(),
+        peaks.retained_part_encoded_bytes,
+        peaks.writer_heap_bytes,
+        peaks.cursor_bytes,
+        peaks.catalog_directory_encoded_bytes,
+        peaks.publish_record_encoded_bytes,
+    );
 }

--- a/crates/ravel-maintain/tests/memory.rs
+++ b/crates/ravel-maintain/tests/memory.rs
@@ -315,3 +315,34 @@ async fn retained_parts_are_attributed_to_their_own_phase() {
         peaks.publish_record_encoded_bytes,
     );
 }
+
+/// A tracker left installed across SERIAL runs reports each run's own peaks:
+/// `rewrite_and_publish` calls `reset_for_run` before any accounting, so the
+/// second bucket's figures are its own. Pinned here at the tracker level
+/// (accumulate, reset, accumulate less, read exactly the smaller figure);
+/// demonstrated failing by dropping the `reset_for_run` call, which reads
+/// 700, not 300.
+#[test]
+#[allow(clippy::expect_used)]
+fn reset_for_run_scopes_peaks_to_one_run() {
+    use ravel_maintain::MergeMemoryTracker;
+    let t = MergeMemoryTracker::new();
+    t.add_retained_part_bytes(700);
+    t.add_catalog_directory_bytes(50);
+    let first = t.phase_peaks();
+    assert_eq!(first.retained_part_encoded_bytes, 700);
+    assert_eq!(first.catalog_directory_decoded_bytes, 50);
+
+    t.reset_for_run();
+    let cleared = t.phase_peaks();
+    assert_eq!(cleared.retained_part_encoded_bytes, 0, "reset clears");
+    assert_eq!(cleared.catalog_directory_decoded_bytes, 0, "reset clears");
+
+    t.add_retained_part_bytes(300);
+    let second = t.phase_peaks();
+    assert_eq!(
+        second.retained_part_encoded_bytes, 300,
+        "the second run reports only its own bytes; without the reset this reads 700"
+    );
+    assert_eq!(second.catalog_directory_decoded_bytes, 0);
+}


### PR DESCRIPTION
A 7,233-object logs tenant compacts past 29.2 GB on a 30 GB box and the
pooled peak figure cannot say which phase is responsible. Two candidate
explanations pointed at different fixes: the retained closed-parts vector
in PartSink, and the per-stream cursor set the merge opens across every
input carrying the stream. Measurement settled the first at 0.92 GB of
the 29.2, so the split has to be mechanical before any fix is aimed.

MergeMemoryTracker grows a MergePhasePeaks struct with one high-water
term per phase, each naming the byte kind it counts, encoded and decoded
heap never summed: catalog load (encoded directory sections retained per
input), merge and cursors (the existing fetched-plus-decoded transient),
the in-progress writer (unpooled from peak_total), retained closed parts
(encoded bytes still held after their PUT, previously invisible), and
finish/publish (the encoded compaction-record payload).

rewrite_and_publish emits the split as a tracing event when a tracker is
installed. Production installs none today; wiring one line where the CLI
builds CompactorConfig is a follow-up, reported on the issue rather than
smuggled into this change.

The test drives a compaction that closes 43 parts and pins the retained
term to the exact sum of their object sizes (26,770 bytes), demonstrated
failing by attributing retained bytes to the writer phase and watching
the equality fail. No behavioural change: no cap, no bytes dropped, no
flush timing moved; the publish repair path is untouched.

Refs: #977
