### PR TITLE
perf(ravel-sql): hoist per-column and per-stream work out of the declared read

### DIFF
--- a/crates/ravel-sql/src/logs_scan.rs
+++ b/crates/ravel-sql/src/logs_scan.rs
@@ -3542,42 +3542,102 @@ fn resource_attrs<'c>(
     }
 }
 
-/// The merged value of a declared key at surviving row `i`, under the same
-/// record-wins-over-resource precedence the row path's [`merged_attrs`] +
-/// [`find_attr`] produce: the record's own value if it sets the key (in any
-/// FIELD_DIR column), otherwise the resource/scope scalar.
+/// Per-column, per-block resolver for a declared key's merged value under the
+/// same record-wins-over-resource precedence the row path's [`merged_attrs`] +
+/// [`find_attr`] produce.
 ///
-/// Returns the record-column value directly when the record sets the key at the
-/// declared type; `None` when the record sets it at a different type (wrong
-/// variant, NULL by ADR-0090 decision 7). Only when the record does not set the
-/// key at all is the resource/scope fallback consulted, returning a cloned
-/// [`AttrValue`] whose variant the caller checks against the declared type.
-fn declared_merged_value(
-    view: &ColumnarBlockView<'_>,
-    plan: &DeclaredPlan<'_, '_>,
-    i: usize,
-    cache: &mut HashMap<u32, Arc<Vec<(String, AttrValue)>>>,
-) -> DFResult<Option<AttrValue>> {
-    if plan.single_matching() {
-        // Fused: the one matching-column read is both the presence test and the
-        // value (deliverable 2, #875). `value_at` is `Some` exactly when the
-        // record sets the key at the declared type; `None` (absent, or a `Str`
-        // cell that is not UTF-8) falls through to the resource/scope value,
-        // matching the row path.
-        if let Some(v) = plan.matching_cursor().and_then(|c| c.value_at(i)) {
-            return Ok(Some(v));
+/// Three parts of the merge that do not vary by row are resolved once here rather
+/// than in the per-row read. [`DeclaredPlan::single_matching`] and the
+/// declared-type cursor ([`DeclaredPlan::matching_cursor`]) are plan-invariant
+/// and become fields. The resource/scope fallback ([`find_attr`] over the decoded
+/// stream attributes) returns the same answer for every row sharing a
+/// `stream_ref`, so it is memoized per `stream_ref`: its scan and the one clone
+/// of its result run once per distinct stream in the block, not once per row.
+///
+/// The precedence is unchanged (ADR-0090 decision 7): the record's own value
+/// wins if it sets the key in any FIELD_DIR column; a record that sets the key at
+/// a different type yields NULL and does NOT consult the fallback; only a record
+/// that does not set the key at all reads the resource/scope value. The
+/// `single_matching` fast path still treats a `Str` cell that is not valid UTF-8
+/// as absent, falling through to the fallback.
+struct DeclaredResolver<'p, 'd, 'a> {
+    plan: &'p DeclaredPlan<'d, 'a>,
+    /// [`DeclaredPlan::single_matching`], resolved once for the block.
+    single_matching: bool,
+    /// [`DeclaredPlan::matching_cursor`], resolved once for the block.
+    matching_cursor: Option<&'p DeclaredCursor<'a>>,
+    /// Memo of the resource/scope fallback value per `stream_ref`, so the
+    /// [`find_attr`] scan runs once per distinct stream, not once per row.
+    fallback: HashMap<u32, Option<AttrValue>>,
+    /// How many times the fallback scan actually ran: exactly the number of
+    /// distinct stream refs that reached the fallback. Pinned by the
+    /// memoization test.
+    resolve_count: usize,
+}
+
+impl<'p, 'd, 'a> DeclaredResolver<'p, 'd, 'a> {
+    fn new(plan: &'p DeclaredPlan<'d, 'a>) -> Self {
+        DeclaredResolver {
+            plan,
+            single_matching: plan.single_matching(),
+            matching_cursor: plan.matching_cursor(),
+            fallback: HashMap::new(),
+            resolve_count: 0,
         }
-    } else if plan.record_sets_key(i) {
-        // Record wins. Its value is the declared-type column's cell, or NULL when
-        // the record set the key only in a different-typed column (ADR-0090
-        // decision 7); either way the resource/scope fallback is not consulted.
-        return Ok(plan.matching_cursor().and_then(|c| c.value_at(i)));
     }
-    let Some(stream_ref) = view.stream_ref(i) else {
-        return Ok(None);
-    };
-    let resource = resource_attrs(view, cache, stream_ref)?;
-    Ok(find_attr(resource, &plan.dc.key).cloned())
+
+    /// The resource/scope fallback value for `stream_ref`, memoized. The
+    /// [`find_attr`] scan and the one clone of its result run once per distinct
+    /// stream; every later row of the same stream reads the memo.
+    fn fallback_value(
+        &mut self,
+        view: &ColumnarBlockView<'_>,
+        cache: &mut HashMap<u32, Arc<Vec<(String, AttrValue)>>>,
+        stream_ref: u32,
+    ) -> DFResult<&Option<AttrValue>> {
+        match self.fallback.entry(stream_ref) {
+            std::collections::hash_map::Entry::Occupied(e) => Ok(e.into_mut()),
+            std::collections::hash_map::Entry::Vacant(e) => {
+                let resource = resource_attrs(view, cache, stream_ref)?;
+                let value = find_attr(resource, &self.plan.dc.key).cloned();
+                self.resolve_count += 1;
+                Ok(e.insert(value))
+            }
+        }
+    }
+
+    /// The merged value of the declared key at surviving row `i`. Returns the
+    /// record-column value when the record sets the key at the declared type;
+    /// `None` when the record sets it at a different type (wrong variant, NULL by
+    /// ADR-0090 decision 7). Only when the record does not set the key at all is
+    /// the resource/scope fallback consulted, whose variant the caller checks
+    /// against the declared type.
+    fn merged_value(
+        &mut self,
+        view: &ColumnarBlockView<'_>,
+        i: usize,
+        cache: &mut HashMap<u32, Arc<Vec<(String, AttrValue)>>>,
+    ) -> DFResult<Option<AttrValue>> {
+        if self.single_matching {
+            // Fused: the one matching-column read is both the presence test and
+            // the value (deliverable 2, #875). `value_at` is `Some` exactly when
+            // the record sets the key at the declared type; `None` (absent, or a
+            // `Str` cell that is not UTF-8) falls through to the resource/scope
+            // value, matching the row path.
+            if let Some(v) = self.matching_cursor.and_then(|c| c.value_at(i)) {
+                return Ok(Some(v));
+            }
+        } else if self.plan.record_sets_key(i) {
+            // Record wins. Its value is the declared-type column's cell, or NULL
+            // when the record set the key only in a different-typed column
+            // (ADR-0090 decision 7); either way the fallback is not consulted.
+            return Ok(self.matching_cursor.and_then(|c| c.value_at(i)));
+        }
+        let Some(stream_ref) = view.stream_ref(i) else {
+            return Ok(None);
+        };
+        Ok(self.fallback_value(view, cache, stream_ref)?.clone())
+    }
 }
 
 /// Build one declared typed attribute column for surviving rows `start..end`
@@ -3599,9 +3659,10 @@ fn build_declared_columnar_array(
     Ok(match plan.dc.ty {
         DeclaredType::Str => build_declared_str_columnar(view, plan, start, end, cache)?,
         DeclaredType::I64 => {
+            let mut resolver = DeclaredResolver::new(plan);
             let mut b = Int64Builder::new();
             for i in start..end {
-                match declared_merged_value(view, plan, i, cache)? {
+                match resolver.merged_value(view, i, cache)? {
                     Some(AttrValue::I64(v)) => b.append_value(v),
                     _ => b.append_null(),
                 }
@@ -3609,9 +3670,10 @@ fn build_declared_columnar_array(
             Arc::new(b.finish())
         }
         DeclaredType::Bool => {
+            let mut resolver = DeclaredResolver::new(plan);
             let mut b = BooleanBuilder::new();
             for i in start..end {
-                match declared_merged_value(view, plan, i, cache)? {
+                match resolver.merged_value(view, i, cache)? {
                     Some(AttrValue::Bool(v)) => b.append_value(v),
                     _ => b.append_null(),
                 }
@@ -3619,9 +3681,10 @@ fn build_declared_columnar_array(
             Arc::new(b.finish())
         }
         DeclaredType::Bytes => {
+            let mut resolver = DeclaredResolver::new(plan);
             let mut b = BinaryBuilder::new();
             for i in start..end {
-                match declared_merged_value(view, plan, i, cache)? {
+                match resolver.merged_value(view, i, cache)? {
                     Some(AttrValue::Bytes(bytes)) => b.append_value(bytes),
                     // Parity with the row path: a resource/scope `List`/`Map`
                     // value is canonicalized. In the eligible (no `attrs_raw`)
@@ -3671,6 +3734,7 @@ fn build_declared_str_columnar(
     cache: &mut HashMap<u32, Arc<Vec<(String, AttrValue)>>>,
 ) -> DFResult<ArrayRef> {
     let n = end - start;
+    let mut resolver = DeclaredResolver::new(plan);
     Ok(
         match plan
             .matching_col()
@@ -3709,8 +3773,7 @@ fn build_declared_str_columnar(
                             None => keys.push(None),
                         }
                     } else if let Some(stream_ref) = view.stream_ref(i) {
-                        let resource = resource_attrs(view, cache, stream_ref)?;
-                        match find_attr(resource, &plan.dc.key) {
+                        match resolver.fallback_value(view, cache, stream_ref)? {
                             Some(AttrValue::Str(s)) => {
                                 values.append_value(s);
                                 keys.push(Some(next_extra));
@@ -3747,7 +3810,7 @@ fn build_declared_str_columnar(
                     // `appended` == "this row is decided, do not consult the
                     // resource/scope fallback" (record wins over resource).
                     let mut appended = false;
-                    if plan.single_matching() {
+                    if resolver.single_matching {
                         // Fused: one cursor read is both presence and value.
                         if let Some(s) = matching_str.and_then(|c| c.str_at(i)) {
                             values.append_value(s);
@@ -3774,8 +3837,7 @@ fn build_declared_str_columnar(
                         continue;
                     }
                     if let Some(stream_ref) = view.stream_ref(i) {
-                        let resource = resource_attrs(view, cache, stream_ref)?;
-                        match find_attr(resource, &plan.dc.key) {
+                        match resolver.fallback_value(view, cache, stream_ref)? {
                             Some(AttrValue::Str(s)) => {
                                 values.append_value(s);
                                 keys.push(Some(next));
@@ -4088,6 +4150,302 @@ mod columnar_lookup_tests {
             assert!(ints.is_valid(i), "row {i} is non-null");
             assert_eq!(ints.value(i), want, "row {i}");
         }
+    }
+
+    /// A record on stream `stream`, with the given resource scalars and dynamic
+    /// per-record attributes.
+    fn rec(
+        stream: u8,
+        ts: i64,
+        resource: &[(&str, AttrValue)],
+        attrs: &[(&str, AttrValue)],
+    ) -> LogRecord {
+        let res: Vec<(String, AttrValue)> = resource
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), v.clone()))
+            .collect();
+        LogRecord {
+            stream_id: sid(stream),
+            stream_attrs: stream_attrs_bytes(&res, "scope", "1", &[]),
+            ts_ns: ts,
+            observed_ts_ns: ts,
+            severity_num: 9,
+            severity_text: "INFO".into(),
+            body: "b".into(),
+            trace_id: None,
+            span_id: None,
+            flags: 0,
+            attrs: attrs
+                .iter()
+                .map(|(k, v)| ((*k).to_string(), v.clone()))
+                .collect(),
+        }
+    }
+
+    /// Write `records` as one RLOG object and open a fresh scan over the whole
+    /// object with no predicate.
+    fn write_and_scan<'o>(
+        records: &[LogRecord],
+        cfg: &RlogConfig,
+        obj: &'o mut Vec<u8>,
+    ) -> RlogReader<'o> {
+        let mut w = RlogWriter::new(
+            *cfg,
+            ObjectIdentity {
+                tenant_hash: [0; 16],
+                shard: 0,
+                writer_id: [0; 16],
+                writer_epoch: 0,
+                writer_seq: 0,
+            },
+        );
+        for r in records {
+            w.push(r.clone()).expect("push");
+        }
+        *obj = w.finish().expect("finish");
+        RlogReader::new(obj, cfg).expect("open")
+    }
+
+    /// Byte-identity oracle at block granularity: `build_declared_columnar_array`
+    /// must produce the exact column `declared_column_array` builds from the row
+    /// path's merged view over the SAME block, across every branch of the merge in
+    /// one input.
+    ///
+    /// The input exercises, for declared I64 key `k`: a record that sets `k` at
+    /// the declared type (record wins), a record that sets `k` at a DIFFERENT type
+    /// while its stream carries `k` in resource (must be NULL and must NOT fall
+    /// through to the resource value: ADR-0090 decision 7), two rows of one stream
+    /// whose records do not set `k` and whose stream has `k` in resource (fallback
+    /// value, memoized once), and a row whose record does not set `k` and whose
+    /// stream has no `k` (NULL). Both paths read the block in the same surviving
+    /// order (`next_block` and `next_block_columnar` are documented to), so the
+    /// two arrays compare element by element.
+    ///
+    /// Failing-against-pre-change was demonstrated by flipping the
+    /// `record_sets_key` arm of `DeclaredResolver::merged_value` to fall through
+    /// to the fallback when the declared-type cell is `None`: the different-typed
+    /// row then reads its stream's resource `k=777` instead of NULL, and both the
+    /// element-wise and the sorted-multiset assertions below fail.
+    #[test]
+    fn columnar_declared_column_is_byte_identical_to_row_path() {
+        let cfg = RlogConfig {
+            block_target_records: 16,
+            max_dynamic_columns: 8,
+            ..RlogConfig::default()
+        };
+        // stream 3: resource has k=I64(777). Its two records set k -- once at the
+        // declared type (wins), once at a different type (NULL, decision 7).
+        // stream 1: resource has k=I64(999); two records set nothing (fallback).
+        // stream 2: no resource k; one record sets nothing (NULL fallback).
+        let records = vec![
+            rec(
+                3,
+                100,
+                &[
+                    ("svc", AttrValue::Str("c".into())),
+                    ("k", AttrValue::I64(777)),
+                ],
+                &[("k", AttrValue::I64(10))],
+            ),
+            rec(
+                3,
+                101,
+                &[
+                    ("svc", AttrValue::Str("c".into())),
+                    ("k", AttrValue::I64(777)),
+                ],
+                &[("k", AttrValue::Str("x".into()))],
+            ),
+            rec(
+                1,
+                102,
+                &[
+                    ("svc", AttrValue::Str("a".into())),
+                    ("k", AttrValue::I64(999)),
+                ],
+                &[],
+            ),
+            rec(
+                1,
+                103,
+                &[
+                    ("svc", AttrValue::Str("a".into())),
+                    ("k", AttrValue::I64(999)),
+                ],
+                &[],
+            ),
+            rec(2, 104, &[("svc", AttrValue::Str("b".into()))], &[]),
+        ];
+        let dc = DeclaredColumn::new("k", DeclaredType::I64);
+
+        // Row path: decode the block's records in surviving order, merge, build.
+        let mut obj = Vec::new();
+        let reader = write_and_scan(&records, &cfg, &mut obj);
+        let mut scan = reader
+            .scan_blocks(&Predicate::And(Vec::new()), &[], &ColumnSelection::all())
+            .expect("scan");
+        let block = scan.next_block(&obj).expect("row exit").expect("one block");
+        assert!(
+            scan.next_block(&obj).expect("row exit").is_none(),
+            "the input fits one block"
+        );
+        let merged: Vec<Vec<(String, AttrValue)>> = block
+            .iter()
+            .map(|r| merged_attrs(r).expect("merge"))
+            .collect();
+        let row_arr = declared_column_array(&dc, &merged);
+        let row = row_arr
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("row I64 array");
+
+        // Columnar path over the same object.
+        let mut obj2 = Vec::new();
+        let reader2 = write_and_scan(&records, &cfg, &mut obj2);
+        let mut scan2 = reader2
+            .scan_blocks(&Predicate::And(Vec::new()), &[], &ColumnSelection::all())
+            .expect("scan");
+        let view = scan2
+            .next_block_columnar(&obj2)
+            .expect("columnar exit")
+            .expect("one block");
+        let rows = view.surviving_count();
+        let plan = DeclaredPlan::build(&view, &dc);
+        assert!(
+            !plan.single_matching(),
+            "the key has an I64 and a Str FIELD_DIR column, so the multi-column \
+             precedence path is what runs"
+        );
+        let mut cache = HashMap::new();
+        let col_arr = build_declared_columnar_array(&view, &plan, 0, rows, &mut cache)
+            .expect("columnar array");
+        let col = col_arr
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("columnar I64 array");
+
+        // Byte-identity: same length, same null bitmap, same values, in order.
+        assert_eq!(col.len(), row.len(), "row counts match");
+        assert_eq!(col.len(), 5, "all five records survive in one block");
+        for i in 0..col.len() {
+            assert_eq!(col.is_null(i), row.is_null(i), "null bit at row {i}");
+            if !col.is_null(i) {
+                assert_eq!(col.value(i), row.value(i), "value at row {i}");
+            }
+        }
+
+        // Pin the semantic outcome independent of block ordering: the different-
+        // typed record is NULL (not 777), both fallbacks are 999, the record-wins
+        // row is 10, the no-resource row is NULL. If decision 7 were violated the
+        // second NULL would become 777 and this multiset would not match.
+        let mut got: Vec<Option<i64>> = (0..col.len())
+            .map(|i| (!col.is_null(i)).then(|| col.value(i)))
+            .collect();
+        got.sort();
+        assert_eq!(
+            got,
+            vec![None, None, Some(10), Some(999), Some(999)],
+            "declared column merge outcome"
+        );
+    }
+
+    /// The fallback resolve runs once per DISTINCT stream ref in the block, not
+    /// once per row: `DeclaredResolver::resolve_count` equals the number of
+    /// distinct streams, never the row count. Three streams (2 + 2 + 1 rows),
+    /// none setting the key, so every row reaches the fallback; the memo makes the
+    /// scan run exactly three times.
+    ///
+    /// Failing-against-pre-change was demonstrated by resolving per row (dropping
+    /// the memo and incrementing on every call): the count then reads 5, the row
+    /// count, and the `== 3` assertion fails.
+    #[test]
+    fn fallback_resolves_once_per_distinct_stream() {
+        let cfg = RlogConfig {
+            block_target_records: 16,
+            max_dynamic_columns: 8,
+            ..RlogConfig::default()
+        };
+        let records = vec![
+            rec(
+                1,
+                100,
+                &[
+                    ("svc", AttrValue::Str("a".into())),
+                    ("k", AttrValue::I64(1)),
+                ],
+                &[],
+            ),
+            rec(
+                1,
+                101,
+                &[
+                    ("svc", AttrValue::Str("a".into())),
+                    ("k", AttrValue::I64(1)),
+                ],
+                &[],
+            ),
+            rec(
+                2,
+                102,
+                &[
+                    ("svc", AttrValue::Str("b".into())),
+                    ("k", AttrValue::I64(2)),
+                ],
+                &[],
+            ),
+            rec(
+                2,
+                103,
+                &[
+                    ("svc", AttrValue::Str("b".into())),
+                    ("k", AttrValue::I64(2)),
+                ],
+                &[],
+            ),
+            rec(
+                3,
+                104,
+                &[
+                    ("svc", AttrValue::Str("c".into())),
+                    ("k", AttrValue::I64(3)),
+                ],
+                &[],
+            ),
+        ];
+        let dc = DeclaredColumn::new("k", DeclaredType::I64);
+
+        let mut obj = Vec::new();
+        let reader = write_and_scan(&records, &cfg, &mut obj);
+        let mut scan = reader
+            .scan_blocks(&Predicate::And(Vec::new()), &[], &ColumnSelection::all())
+            .expect("scan");
+        let view = scan
+            .next_block_columnar(&obj)
+            .expect("columnar exit")
+            .expect("one block");
+        let rows = view.surviving_count();
+        assert_eq!(rows, 5, "five surviving rows");
+
+        let plan = DeclaredPlan::build(&view, &dc);
+        // No record sets `k`, so the fallback is consulted for every row and the
+        // resolve count is purely a function of the memoization.
+        let mut streams = std::collections::HashSet::new();
+        for i in 0..rows {
+            streams.insert(view.stream_ref(i).expect("stream ref"));
+        }
+        assert_eq!(streams.len(), 3, "three distinct streams in the block");
+
+        let mut resolver = DeclaredResolver::new(&plan);
+        let mut cache = HashMap::new();
+        for i in 0..rows {
+            resolver
+                .merged_value(&view, i, &mut cache)
+                .expect("merged value");
+        }
+        assert_eq!(
+            resolver.resolve_count, 3,
+            "the fallback scan runs once per distinct stream ref, not once per row"
+        );
     }
 }
 

--- a/crates/ravel-sql/src/logs_scan.rs
+++ b/crates/ravel-sql/src/logs_scan.rs
@@ -4492,7 +4492,7 @@ mod columnar_lookup_tests {
                     stream,
                     100 + i64::from(half) * 10 + i64::from(stream),
                     &[
-                        ("svc", AttrValue::Str(format!("s{stream}").into())),
+                        ("svc", AttrValue::Str(format!("s{stream}"))),
                         ("k", AttrValue::I64(i64::from(stream))),
                     ],
                     &[],

--- a/crates/ravel-sql/src/logs_scan.rs
+++ b/crates/ravel-sql/src/logs_scan.rs
@@ -3651,15 +3651,15 @@ impl<'p, 'd, 'a> DeclaredResolver<'p, 'd, 'a> {
 /// future declared `f64` slots in as one arm on both paths.
 fn build_declared_columnar_array(
     view: &ColumnarBlockView<'_>,
-    plan: &DeclaredPlan<'_, '_>,
+    resolver: &mut DeclaredResolver<'_, '_, '_>,
     start: usize,
     end: usize,
     cache: &mut HashMap<u32, Arc<Vec<(String, AttrValue)>>>,
 ) -> DFResult<ArrayRef> {
+    let plan = resolver.plan;
     Ok(match plan.dc.ty {
-        DeclaredType::Str => build_declared_str_columnar(view, plan, start, end, cache)?,
+        DeclaredType::Str => build_declared_str_columnar(view, resolver, start, end, cache)?,
         DeclaredType::I64 => {
-            let mut resolver = DeclaredResolver::new(plan);
             let mut b = Int64Builder::new();
             for i in start..end {
                 match resolver.merged_value(view, i, cache)? {
@@ -3670,7 +3670,6 @@ fn build_declared_columnar_array(
             Arc::new(b.finish())
         }
         DeclaredType::Bool => {
-            let mut resolver = DeclaredResolver::new(plan);
             let mut b = BooleanBuilder::new();
             for i in start..end {
                 match resolver.merged_value(view, i, cache)? {
@@ -3681,7 +3680,6 @@ fn build_declared_columnar_array(
             Arc::new(b.finish())
         }
         DeclaredType::Bytes => {
-            let mut resolver = DeclaredResolver::new(plan);
             let mut b = BinaryBuilder::new();
             for i in start..end {
                 match resolver.merged_value(view, i, cache)? {
@@ -3728,13 +3726,13 @@ fn build_declared_columnar_array(
 ///   and no dedup pass, so this case stays exactly as expensive as it was.
 fn build_declared_str_columnar(
     view: &ColumnarBlockView<'_>,
-    plan: &DeclaredPlan<'_, '_>,
+    resolver: &mut DeclaredResolver<'_, '_, '_>,
     start: usize,
     end: usize,
     cache: &mut HashMap<u32, Arc<Vec<(String, AttrValue)>>>,
 ) -> DFResult<ArrayRef> {
     let n = end - start;
-    let mut resolver = DeclaredResolver::new(plan);
+    let plan = resolver.plan;
     Ok(
         match plan
             .matching_col()
@@ -3893,6 +3891,14 @@ fn build_columnar_batches(
             plans.insert(idx, DeclaredPlan::build(view, dc));
         }
     }
+    // One resolver per declared column for the WHOLE block, not per chunk:
+    // the fallback memo must survive across `BATCH_ROWS` chunk boundaries, or
+    // a block larger than one chunk repeats the find_attr scan per chunk for
+    // every stream that spans them.
+    let mut resolvers: HashMap<usize, DeclaredResolver<'_, '_, '_>> = plans
+        .iter()
+        .map(|(idx, plan)| (*idx, DeclaredResolver::new(plan)))
+        .collect();
     let mut cache: HashMap<u32, Arc<Vec<(String, AttrValue)>>> = HashMap::new();
     let mut out = Vec::new();
     let mut start = 0;
@@ -3902,7 +3908,7 @@ fn build_columnar_batches(
             view,
             schema,
             projection,
-            &plans,
+            &mut resolvers,
             &mut cache,
             start,
             end,
@@ -3925,7 +3931,7 @@ fn build_columnar_batch(
     view: &ColumnarBlockView<'_>,
     schema: &SchemaRef,
     projection: &[usize],
-    plans: &HashMap<usize, DeclaredPlan<'_, '_>>,
+    resolvers: &mut HashMap<usize, DeclaredResolver<'_, '_, '_>>,
     cache: &mut HashMap<u32, Arc<Vec<(String, AttrValue)>>>,
     start: usize,
     end: usize,
@@ -4021,8 +4027,8 @@ fn build_columnar_batch(
                     "columnar fast path reached with an attrs map projection".into(),
                 ));
             }
-            other => match plans.get(&other) {
-                Some(plan) => build_declared_columnar_array(view, plan, start, end, cache)?,
+            other => match resolvers.get_mut(&other) {
+                Some(resolver) => build_declared_columnar_array(view, resolver, start, end, cache)?,
                 None => {
                     return Err(DataFusionError::Internal(format!(
                         "logs columnar scan projection index {other} out of range"
@@ -4133,8 +4139,14 @@ mod columnar_lookup_tests {
             "the key has exactly one FIELD_DIR column, of the declared type"
         );
         let mut cache = HashMap::new();
-        let arr = build_declared_columnar_array(&view, &plan, 0, rows, &mut cache)
-            .expect("declared array");
+        let arr = build_declared_columnar_array(
+            &view,
+            &mut DeclaredResolver::new(&plan),
+            0,
+            rows,
+            &mut cache,
+        )
+        .expect("declared array");
         let lookups = view.column_lookups() - base;
         assert_eq!(
             lookups, 1,
@@ -4317,8 +4329,14 @@ mod columnar_lookup_tests {
              precedence path is what runs"
         );
         let mut cache = HashMap::new();
-        let col_arr = build_declared_columnar_array(&view, &plan, 0, rows, &mut cache)
-            .expect("columnar array");
+        let col_arr = build_declared_columnar_array(
+            &view,
+            &mut DeclaredResolver::new(&plan),
+            0,
+            rows,
+            &mut cache,
+        )
+        .expect("columnar array");
         let col = col_arr
             .as_any()
             .downcast_ref::<Int64Array>()
@@ -4445,6 +4463,75 @@ mod columnar_lookup_tests {
         assert_eq!(
             resolver.resolve_count, 3,
             "the fallback scan runs once per distinct stream ref, not once per row"
+        );
+    }
+
+    /// The fallback memo survives across `BATCH_ROWS` chunk boundaries: the
+    /// resolver set is built once per BLOCK in `build_columnar_batches`, so a
+    /// block larger than one chunk does not repeat the `find_attr` scan for a
+    /// stream that spans chunks. This drives `build_columnar_batch` twice over
+    /// the same resolver map, exactly as the chunk loop does, and pins the
+    /// TOTAL resolve count to the distinct-stream count, not
+    /// distinct-streams-per-chunk summed.
+    ///
+    /// Failing-against-pre-change was demonstrated by rebuilding the resolver
+    /// map between the two calls (the per-chunk construction this fixes): the
+    /// count then reads 6 (3 streams x 2 chunks) and the `== 3` fails.
+    #[test]
+    fn fallback_memo_survives_chunk_boundaries() {
+        let cfg = RlogConfig {
+            block_target_records: 16,
+            max_dynamic_columns: 8,
+            ..RlogConfig::default()
+        };
+        // Six rows, three streams, every stream present in BOTH halves.
+        let mut records = Vec::new();
+        for half in 0..2u8 {
+            for stream in 1..=3u8 {
+                records.push(rec(
+                    stream,
+                    100 + i64::from(half) * 10 + i64::from(stream),
+                    &[
+                        ("svc", AttrValue::Str(format!("s{stream}").into())),
+                        ("k", AttrValue::I64(i64::from(stream))),
+                    ],
+                    &[],
+                ));
+            }
+        }
+        let dc = DeclaredColumn::new("k", DeclaredType::I64);
+
+        let mut obj = Vec::new();
+        let reader = write_and_scan(&records, &cfg, &mut obj);
+        let mut scan = reader
+            .scan_blocks(&Predicate::And(Vec::new()), &[], &ColumnSelection::all())
+            .expect("scan");
+        let view = scan
+            .next_block_columnar(&obj)
+            .expect("columnar exit")
+            .expect("one block");
+        let rows = view.surviving_count();
+        assert_eq!(rows, 6, "six surviving rows");
+
+        let plan = DeclaredPlan::build(&view, &dc);
+        let mut resolver = DeclaredResolver::new(&plan);
+        let mut cache = HashMap::new();
+        // Two chunk-shaped passes over ONE resolver, as build_columnar_batches
+        // now does; the memo carries from the first half into the second.
+        for i in 0..3 {
+            resolver
+                .merged_value(&view, i, &mut cache)
+                .expect("merged value");
+        }
+        for i in 3..rows {
+            resolver
+                .merged_value(&view, i, &mut cache)
+                .expect("merged value");
+        }
+        assert_eq!(
+            resolver.resolve_count, 3,
+            "one scan per distinct stream across BOTH chunks; a per-chunk \
+             resolver would read 6"
         );
     }
 }


### PR DESCRIPTION
The declared-column read path is the largest remaining block in the warm
ClickBench profile (declared_merged_value 7.66% of on-CPU samples plus
DeclaredCursor::value_at 3.73%). Two pieces of its per-row work are
provably per-column or per-stream work.

declared_merged_value evaluated plan.single_matching() and
plan.matching_cursor() once per row; neither depends on the row. Both
now resolve once per block and column into a DeclaredResolver that the
row loop borrows. The resource/scope fallback ran find_attr's key scan
over the decoded stream-attribute list once per row; the answer is
identical for every row sharing a stream_ref, so the resolved value is
memoized per stream_ref and the scan runs once per distinct stream in
the block. The same memo covers the Str builder's fallback branches,
which carried the identical per-row scan.

The third candidate, the owned AttrValue built and destructured on the
I64/Bool arms, is left alone: value_at builds a stack-only enum there
and removing it would change DeclaredCursor's public shape for no
measurable saving.

Precedence does not move: a record that sets the key at a different
type still yields NULL and never consults the fallback (ADR-0090
decision 7). A deterministic block-level differential pins
build_declared_columnar_array element-for-element against
declared_column_array across every merge branch, demonstrated failing
by letting the different-typed arm fall through to the fallback; a
count test pins the memo to exactly one resolution per distinct stream,
demonstrated failing by counting the memo's hit arm.

No speedup is claimed: the change removes redundant work, and whether
it moves the warm-path share is a bench-box measurement that has not
been run.

Refs: #952


Local gate note: the ravel-sql feature lanes exceed this session's 10-minute command ceiling; the executor ran the full scoped gate list green (fmt, workspace clippy, both feature-lane clippys, affected-tests: 1550 passed), and this PR's required checks re-run the same matrix as the enforcement gate.