### PR TITLE
docs: correct ADR-0064's lifecycle-rule cross-reference to required

### DIFF
--- a/docs/adrs/0064-selective-subject-erasure.md
+++ b/docs/adrs/0064-selective-subject-erasure.md
@@ -520,8 +520,10 @@ contract:
    retention (ADR-0019) is the only sanctioned age-out mechanism.
    Instant-access storage-class transitions (e.g. to IA) are permitted.
 3. **Exactly two sanctioned lifecycle rules**:
-   `AbortIncompleteMultipartUpload` (recommended, 7 days — this also
-   converts an undocumented dependency into a documented one), and
+   `AbortIncompleteMultipartUpload` (required with a cleanup period of 7
+   days or less per docs/object-store-contract.md, because nothing in Ravel
+   reaps abandoned multipart parts — this also converts an undocumented
+   dependency into a documented one), and
    the noncurrent-version expiration of point 1 when versioning is on.
 4. **Object Lock**: bucket-default retention is supported but extends the
    erasure bound per §6; scoped legal holds (ADR-0042) are the recommended


### PR DESCRIPTION
ADR-0064 described the AbortIncompleteMultipartUpload lifecycle rule as
recommended. Under #864 the object-store contract made it required: a
bucket Ravel writes multipart uploads to must configure it with a
cleanup period of 7 days or less, because nothing in Ravel reaps
abandoned parts, and the conformance probe already enforces it. This is
a factual cross-reference correction, not an amendment to the ADR's
decision.

Fixes: #870
