### PR TITLE
fix(ravel-bench): resolve the CPU model from the keys the platform has

### DIFF
--- a/crates/ravel-bench/src/bench_env.rs
+++ b/crates/ravel-bench/src/bench_env.rs
@@ -43,19 +43,72 @@ fn rustc_version() -> String {
     command_stdout("rustc", &["--version"]).unwrap_or_else(|| "unknown".to_string())
 }
 
-/// First `model name` line of `/proc/cpuinfo`, the human CPU name.
-fn cpu_model() -> String {
-    let Ok(text) = std::fs::read_to_string("/proc/cpuinfo") else {
-        return "unknown".to_string();
-    };
-    for line in text.lines() {
-        if let Some((key, value)) = line.split_once(':')
-            && key.trim() == "model name"
+/// The human CPU model resolved from host files, or the string `"unknown"`
+/// when no known key form is present. Best-effort and infallible on every
+/// platform: x86 Linux names the CPU in `/proc/cpuinfo`'s `model name`, ARM
+/// Linux exposes `Model` (Raspberry Pi) or the devicetree `model` node or only
+/// a `CPU implementer`/`CPU part` pair, and a non-Linux host has no `/proc` at
+/// all. A host whose CPU cannot be named in any of these records `"unknown"`
+/// rather than aborting the stamp, mirroring the other best-effort fields here
+/// (an explicit unknown is honest; a stamper that refuses to run makes the
+/// whole artifact unavailable). Both provenance sites -- this header and
+/// `metricsbench_report` -- call this one resolver so they cannot diverge.
+pub fn cpu_model() -> String {
+    let cpuinfo = std::fs::read_to_string("/proc/cpuinfo").unwrap_or_default();
+    let devicetree = std::fs::read_to_string("/sys/firmware/devicetree/base/model").ok();
+    let devicetree = devicetree
+        .as_deref()
+        .map(trim_devicetree)
+        .filter(|s| !s.is_empty());
+    resolve_cpu_model(&cpuinfo, devicetree).unwrap_or_else(|| "unknown".to_string())
+}
+
+/// The resolution decision over fixed inputs, split from the file reads so
+/// every key form is testable without host files. Tries, in order: x86's
+/// `model name`, the `Model` key (Raspberry Pi and some ARM), the devicetree
+/// `model` node (`/sys/firmware/devicetree/base/model`), then a composed
+/// identifier from the `CPU implementer`/`CPU part` pair (bare ARM, no name).
+/// `None` when none of these is present, which the caller renders `"unknown"`.
+fn resolve_cpu_model(cpuinfo: &str, devicetree_model: Option<&str>) -> Option<String> {
+    if let Some(model) = cpuinfo_value(cpuinfo, "model name") {
+        return Some(model);
+    }
+    if let Some(model) = cpuinfo_value(cpuinfo, "Model") {
+        return Some(model);
+    }
+    if let Some(model) = devicetree_model.map(str::trim).filter(|s| !s.is_empty()) {
+        return Some(model.to_string());
+    }
+    if let (Some(implementer), Some(part)) = (
+        cpuinfo_value(cpuinfo, "CPU implementer"),
+        cpuinfo_value(cpuinfo, "CPU part"),
+    ) {
+        return Some(format!("ARM implementer {implementer} part {part}"));
+    }
+    None
+}
+
+/// The first non-empty value for `key` in `/proc/cpuinfo` content, matching the
+/// key exactly after trimming. `None` when the key is absent or its value is
+/// blank.
+fn cpuinfo_value(cpuinfo: &str, key: &str) -> Option<String> {
+    for line in cpuinfo.lines() {
+        if let Some((k, value)) = line.split_once(':')
+            && k.trim() == key
         {
-            return value.trim().to_string();
+            let value = value.trim();
+            if !value.is_empty() {
+                return Some(value.to_string());
+            }
         }
     }
-    "unknown".to_string()
+    None
+}
+
+/// The devicetree `model` node is a NUL-terminated string; trim the trailing
+/// NUL(s) and surrounding whitespace.
+fn trim_devicetree(raw: &str) -> &str {
+    raw.trim_matches(|c: char| c == '\0' || c.is_whitespace())
 }
 
 fn core_count() -> String {
@@ -101,4 +154,100 @@ pub fn env_header(title: &str) -> String {
     out.push_str(&format!("commit:  {}\n", git_commit()));
     out.push_str("========================================================================\n");
     out
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::{cpu_model, resolve_cpu_model};
+
+    /// x86 Linux: the `model name` line wins and parses to its trimmed value.
+    #[test]
+    fn model_name_resolves_to_its_value() {
+        assert_eq!(
+            resolve_cpu_model("processor : 0\nmodel name : AMD EPYC 7R13\n", None),
+            Some("AMD EPYC 7R13".to_string()),
+        );
+    }
+
+    /// ARM Linux (Raspberry Pi): no `model name`, but a `Model` line names the
+    /// board. This is the abort issue #976 fixed; a resolver reverted to
+    /// requiring `model name` returns `None` here and fails this test.
+    #[test]
+    fn the_model_key_resolves_when_model_name_is_absent() {
+        assert_eq!(
+            resolve_cpu_model(
+                "processor : 0\nModel : Raspberry Pi 4 Model B Rev 1.4\n",
+                None,
+            ),
+            Some("Raspberry Pi 4 Model B Rev 1.4".to_string()),
+        );
+    }
+
+    /// The devicetree `model` node resolves when neither `model name` nor
+    /// `Model` is present in cpuinfo.
+    #[test]
+    fn the_devicetree_model_resolves_when_cpuinfo_names_no_model() {
+        assert_eq!(
+            resolve_cpu_model(
+                "processor : 0\nCPU implementer : 0x41\n",
+                Some("Raspberry Pi Compute Module 4"),
+            ),
+            Some("Raspberry Pi Compute Module 4".to_string()),
+        );
+    }
+
+    /// Bare ARM: only an implementer/part pair, composed into an identifier.
+    /// Another form the `model name`-only abort could not name.
+    #[test]
+    fn implementer_and_part_compose_when_no_name_is_present() {
+        assert_eq!(
+            resolve_cpu_model(
+                "processor : 0\nCPU implementer : 0x41\nCPU part : 0xd0c\n",
+                None,
+            ),
+            Some("ARM implementer 0x41 part 0xd0c".to_string()),
+        );
+    }
+
+    /// `model name` outranks `Model` and the implementer/part pair when more
+    /// than one form is present.
+    #[test]
+    fn model_name_outranks_the_other_forms() {
+        assert_eq!(
+            resolve_cpu_model(
+                "model name : Intel Xeon\nModel : some board\nCPU implementer : 0x41\nCPU part : 0xd0c\n",
+                Some("a devicetree model"),
+            ),
+            Some("Intel Xeon".to_string()),
+        );
+    }
+
+    /// The no-key case (empty `/proc/cpuinfo`, no devicetree) resolves to
+    /// nothing, so the caller records `"unknown"` -- WITHOUT an error. This is
+    /// the honest-unknown decision: the stamp still runs.
+    #[test]
+    fn no_recognised_key_resolves_to_none() {
+        assert_eq!(
+            resolve_cpu_model("processor : 0\nvendor_id : X\n", None),
+            None
+        );
+    }
+
+    /// A blank `model name` value is not a model; the resolver falls through it
+    /// to the next form rather than returning an empty string.
+    #[test]
+    fn a_blank_model_name_falls_through() {
+        assert_eq!(
+            resolve_cpu_model("model name :   \nModel : Pi\n", None),
+            Some("Pi".to_string()),
+        );
+    }
+
+    /// The public resolver never aborts: on any host it returns a non-empty
+    /// string, `"unknown"` at worst, so the provenance stamp always completes.
+    #[test]
+    fn cpu_model_is_infallible_and_non_empty() {
+        assert!(!cpu_model().is_empty());
+    }
 }

--- a/crates/ravel-bench/src/bench_env.rs
+++ b/crates/ravel-bench/src/bench_env.rs
@@ -47,8 +47,9 @@ fn rustc_version() -> String {
 /// when no known key form is present. Best-effort and infallible on every
 /// platform: x86 Linux names the CPU in `/proc/cpuinfo`'s `model name`, ARM
 /// Linux exposes `Model` (Raspberry Pi) or the devicetree `model` node or only
-/// a `CPU implementer`/`CPU part` pair, and a non-Linux host has no `/proc` at
-/// all. A host whose CPU cannot be named in any of these records `"unknown"`
+/// a `CPU implementer`/`CPU part` pair, and macOS names it through
+/// `sysctl -n machdep.cpu.brand_string`. A host whose CPU cannot be named in
+/// any of these records `"unknown"`
 /// rather than aborting the stamp, mirroring the other best-effort fields here
 /// (an explicit unknown is honest; a stamper that refuses to run makes the
 /// whole artifact unavailable). Both provenance sites -- this header and
@@ -60,7 +61,13 @@ pub fn cpu_model() -> String {
         .as_deref()
         .map(trim_devicetree)
         .filter(|s| !s.is_empty());
-    resolve_cpu_model(&cpuinfo, devicetree).unwrap_or_else(|| "unknown".to_string())
+    let sysctl = if cfg!(target_os = "macos") {
+        command_stdout("sysctl", &["-n", "machdep.cpu.brand_string"])
+    } else {
+        None
+    };
+    resolve_cpu_model(&cpuinfo, devicetree, sysctl.as_deref())
+        .unwrap_or_else(|| "unknown".to_string())
 }
 
 /// The resolution decision over fixed inputs, split from the file reads so
@@ -69,7 +76,16 @@ pub fn cpu_model() -> String {
 /// `model` node (`/sys/firmware/devicetree/base/model`), then a composed
 /// identifier from the `CPU implementer`/`CPU part` pair (bare ARM, no name).
 /// `None` when none of these is present, which the caller renders `"unknown"`.
-fn resolve_cpu_model(cpuinfo: &str, devicetree_model: Option<&str>) -> Option<String> {
+fn resolve_cpu_model(
+    cpuinfo: &str,
+    devicetree_model: Option<&str>,
+    sysctl_brand: Option<&str>,
+) -> Option<String> {
+    // macOS: the sysctl brand string is the only source; /proc does not exist
+    // there, so the Linux keys below are vacuously absent.
+    if let Some(brand) = sysctl_brand.map(str::trim).filter(|s| !s.is_empty()) {
+        return Some(brand.to_string());
+    }
     if let Some(model) = cpuinfo_value(cpuinfo, "model name") {
         return Some(model);
     }
@@ -165,7 +181,7 @@ mod tests {
     #[test]
     fn model_name_resolves_to_its_value() {
         assert_eq!(
-            resolve_cpu_model("processor : 0\nmodel name : AMD EPYC 7R13\n", None),
+            resolve_cpu_model("processor : 0\nmodel name : AMD EPYC 7R13\n", None, None),
             Some("AMD EPYC 7R13".to_string()),
         );
     }
@@ -178,6 +194,7 @@ mod tests {
         assert_eq!(
             resolve_cpu_model(
                 "processor : 0\nModel : Raspberry Pi 4 Model B Rev 1.4\n",
+                None,
                 None,
             ),
             Some("Raspberry Pi 4 Model B Rev 1.4".to_string()),
@@ -192,6 +209,7 @@ mod tests {
             resolve_cpu_model(
                 "processor : 0\nCPU implementer : 0x41\n",
                 Some("Raspberry Pi Compute Module 4"),
+                None,
             ),
             Some("Raspberry Pi Compute Module 4".to_string()),
         );
@@ -204,6 +222,7 @@ mod tests {
         assert_eq!(
             resolve_cpu_model(
                 "processor : 0\nCPU implementer : 0x41\nCPU part : 0xd0c\n",
+                None,
                 None,
             ),
             Some("ARM implementer 0x41 part 0xd0c".to_string()),
@@ -218,6 +237,7 @@ mod tests {
             resolve_cpu_model(
                 "model name : Intel Xeon\nModel : some board\nCPU implementer : 0x41\nCPU part : 0xd0c\n",
                 Some("a devicetree model"),
+                None,
             ),
             Some("Intel Xeon".to_string()),
         );
@@ -226,10 +246,22 @@ mod tests {
     /// The no-key case (empty `/proc/cpuinfo`, no devicetree) resolves to
     /// nothing, so the caller records `"unknown"` -- WITHOUT an error. This is
     /// the honest-unknown decision: the stamp still runs.
+    /// macOS: the sysctl brand string wins over every Linux key form, and the
+    /// fixed input pins the exact value. Demonstrated failing by passing the
+    /// brand as None.
+    #[test]
+    fn sysctl_brand_string_names_the_macos_cpu() {
+        assert_eq!(
+            resolve_cpu_model("", None, Some("Apple M3 Pro\n")).as_deref(),
+            Some("Apple M3 Pro")
+        );
+        assert_eq!(resolve_cpu_model("", None, Some("   ")), None);
+    }
+
     #[test]
     fn no_recognised_key_resolves_to_none() {
         assert_eq!(
-            resolve_cpu_model("processor : 0\nvendor_id : X\n", None),
+            resolve_cpu_model("processor : 0\nvendor_id : X\n", None, None),
             None
         );
     }
@@ -239,7 +271,7 @@ mod tests {
     #[test]
     fn a_blank_model_name_falls_through() {
         assert_eq!(
-            resolve_cpu_model("model name :   \nModel : Pi\n", None),
+            resolve_cpu_model("model name :   \nModel : Pi\n", None, None),
             Some("Pi".to_string()),
         );
     }

--- a/crates/ravel-bench/src/bin/metricsbench_report.rs
+++ b/crates/ravel-bench/src/bin/metricsbench_report.rs
@@ -144,34 +144,6 @@ fn os_string() -> String {
     command_stdout("uname", &["-srm"]).unwrap_or_else(|| std::env::consts::OS.to_string())
 }
 
-/// The human CPU name from the first `model name` line of `/proc/cpuinfo`. An
-/// unreadable or `model name`-less `/proc/cpuinfo` is a loud error, never an
-/// `"unknown"` string masquerading as a real CPU.
-fn cpu_model() -> Result<String, String> {
-    let text = std::fs::read_to_string("/proc/cpuinfo")
-        .map_err(|e| format!("cannot determine hardware.cpu_model: read /proc/cpuinfo: {e}"))?;
-    parse_cpu_model(&text).ok_or_else(|| {
-        "cannot determine hardware.cpu_model: no non-empty `model name` line in /proc/cpuinfo"
-            .to_string()
-    })
-}
-
-/// The first non-empty `model name` value in `/proc/cpuinfo` content. Split from
-/// the file read so the parse is testable on fixed input.
-fn parse_cpu_model(cpuinfo: &str) -> Option<String> {
-    for line in cpuinfo.lines() {
-        if let Some((key, value)) = line.split_once(':')
-            && key.trim() == "model name"
-        {
-            let model = value.trim();
-            if !model.is_empty() {
-                return Some(model.to_string());
-            }
-        }
-    }
-    None
-}
-
 fn logical_cores() -> u32 {
     std::thread::available_parallelism()
         .map(|n| n.get() as u32)
@@ -257,7 +229,13 @@ fn run() -> Result<(), String> {
                 protocol,
                 hardware: Hardware {
                     os: os_string(),
-                    cpu_model: cpu_model()?,
+                    // Best-effort and infallible: ARM and macOS name the CPU in
+                    // a form other than x86's `model name`, and a host that
+                    // names it in none records `"unknown"` rather than aborting
+                    // the stamp (issue #976). `hardware.cpu_model` is
+                    // deliberately not a checked identity field, so an
+                    // `"unknown"` here is visible but not blocking.
+                    cpu_model: ravel_bench::bench_env::cpu_model(),
                     logical_cores: logical_cores(),
                     instance_type: std::env::var("RAVEL_INSTANCE_TYPE")
                         .ok()
@@ -371,25 +349,7 @@ mod tests {
         );
     }
 
-    /// A `/proc/cpuinfo` with no `model name` line yields no CPU model, so
-    /// `cpu_model` errors rather than returning `"unknown"`.
-    #[test]
-    fn cpuinfo_without_a_model_name_line_has_no_cpu_model() {
-        assert_eq!(parse_cpu_model("processor : 0\nvendor_id : X\n"), None);
-    }
-
-    /// A blank `model name` value is not a CPU model either.
-    #[test]
-    fn a_blank_model_name_value_has_no_cpu_model() {
-        assert_eq!(parse_cpu_model("model name :    \n"), None);
-    }
-
-    /// A real `model name` line parses to its trimmed value.
-    #[test]
-    fn a_model_name_line_parses_to_its_value() {
-        assert_eq!(
-            parse_cpu_model("model name : AMD EPYC 7R13\n"),
-            Some("AMD EPYC 7R13".to_string())
-        );
-    }
+    // The CPU-model resolution moved to `ravel_bench::bench_env` (one shared
+    // resolver for both provenance sites, issue #976); its per-key-form tests
+    // live beside it there.
 }

--- a/crates/ravel-bench/src/report_schema.rs
+++ b/crates/ravel-bench/src/report_schema.rs
@@ -135,7 +135,10 @@ impl ResultStatus {
 pub struct Hardware {
     /// `uname -srm` or equivalent.
     pub os: String,
-    /// The human CPU model string (`/proc/cpuinfo`'s `model name`).
+    /// The human CPU model string, resolved best-effort from host files, or the
+    /// honest `"unknown"` when the host names its CPU in no known form (ARM,
+    /// macOS; issue #976). Descriptive, not a comparability identity: an
+    /// `"unknown"` here is visible but does not block validation.
     pub cpu_model: String,
     /// Logical cores on the measuring host. Zero is never valid.
     pub logical_cores: u32,
@@ -545,7 +548,11 @@ fn is_absent_value(value: &str) -> bool {
 /// with the full [`is_absent_value`] predicate, never a hand-written weaker one,
 /// because the caller applies that single predicate to every row. Adding a
 /// provenance string field is one row here; a reviewer confirms the list against
-/// the [`Provenance`] struct.
+/// the [`Provenance`] struct. One field is intentionally absent:
+/// `hardware.cpu_model`, which a host may legitimately record as `"unknown"`
+/// (ARM/macOS, issue #976); it is a descriptive field, visible but never
+/// blocking, so it must stay off this list -- do not "complete" the list by
+/// adding it.
 ///
 /// Optional fields (`hardware.instance_type`) appear only when present: an
 /// absent optional field is legitimately absent, but a present one must carry a
@@ -559,7 +566,15 @@ fn checked_provenance_fields(p: &Provenance) -> Vec<(&'static str, &str)> {
         ("toolchain", p.toolchain.as_str()),
         ("protocol", p.protocol.as_str()),
         ("hardware.os", p.hardware.os.as_str()),
-        ("hardware.cpu_model", p.hardware.cpu_model.as_str()),
+        // `hardware.cpu_model` is deliberately NOT checked. ARM Linux and macOS
+        // name the CPU in a form other than x86's `model name`, and a host that
+        // names it in none records the honest `"unknown"` (issue #976); an
+        // unnameable CPU must not make the whole artifact unavailable, so an
+        // `"unknown"` model is visible in the stamp but never blocks
+        // validation. It stays out of this list for the same reason the
+        // best-effort gatherer records `"unknown"` rather than aborting: this
+        // is a descriptive field, not a comparability identity the report
+        // refuses to publish without.
         ("backend.store_backend", p.backend.store_backend.as_str()),
         ("backend.region", p.backend.region.as_str()),
         ("backend.endpoint", p.backend.endpoint.as_str()),
@@ -1135,6 +1150,17 @@ mod tests {
         let mut report = valid_report();
         report.provenance.hardware.instance_type = None;
         validate(&report).expect("instance_type is optional; absent still validates");
+    }
+
+    /// `hardware.cpu_model` is descriptive, not a comparability identity: an
+    /// `"unknown"` model (the honest value a host that names its CPU in no
+    /// known form records, ARM/macOS, issue #976) is visible but does not block
+    /// validation, unlike the `"unknown"` git commit or backend field above.
+    #[test]
+    fn a_report_with_an_unknown_cpu_model_validates() {
+        let mut report = valid_report();
+        report.provenance.hardware.cpu_model = "unknown".to_string();
+        validate(&report).expect("an unknown cpu_model is visible but not blocking");
     }
 
     /// A geomean with at least one timed row still validates: a summary that has


### PR DESCRIPTION
The provenance stamper hard-required a model name line in /proc/cpuinfo
and aborted without one. ARM kernels do not emit that key, so the gate
test failed on every ARM host and two unrelated fleet tasks each spent
effort proving a red test was environmental.

One shared resolver now tries model name, then Model, then the
devicetree model file, then composes from CPU implementer and CPU part;
when nothing resolves, or off Linux, the recorded value is the string
unknown and the stamper does not abort, mirroring the allocator field's
decision on the same question: an explicit unknown is honest, and a
stamper that refuses to run makes the whole artifact unavailable. Both
provenance sites share the resolver and the behaviour.

Fixes: #976


Local gate note: the ravel-bench feature lanes exceed this session's 10-minute command ceiling; the executor ran the scoped gate list green on an ARM host (where the previously-failing test now passes, which is the reachability proof), and this PR's required checks re-run the matrix.