### PR TITLE
feat(object-store): attach a server-verified upload checksum on writes

### DIFF
--- a/crates/ravel-object-store/src/fault.rs
+++ b/crates/ravel-object-store/src/fault.rs
@@ -91,6 +91,7 @@ pub enum FaultKind {
     DuplicateDelivery,
     NotFoundBlip,
     CorruptRange,
+    CorruptBody,
     EtagChange,
     Transient,
     Permanent,
@@ -124,6 +125,17 @@ pub enum ScriptedFault {
     /// `get` only: the wrapped `get` is called for real and every byte of
     /// the returned data is bit-flipped before being handed back.
     CorruptRange,
+    /// `put` only: models corruption between caller and store (a bad buffer, a
+    /// driver/DMA flip before the request is signed). Every byte of the payload
+    /// is bit-flipped and the wrapped `put` is called for real with the flipped
+    /// bytes and the caller's unchanged [`PutOptions`]. A store that verifies a
+    /// caller-supplied [`crate::UploadChecksum`] against received bytes (i.e.
+    /// reports `upload_checksum`) must reject the write with
+    /// [`StoreError::Corrupted`] and leave no object; a store that does not
+    /// stores the corrupted bytes, which is exactly the gap read-time checksums
+    /// otherwise have to catch. This is the write-side mirror of
+    /// [`ScriptedFault::CorruptRange`].
+    CorruptBody,
     /// `get` only: the wrapped `get` is called for real and its bytes are
     /// returned unchanged, but the etag is replaced with a deterministic
     /// value distinct from any this store would otherwise produce. Models a
@@ -149,6 +161,7 @@ impl ScriptedFault {
             ScriptedFault::DuplicateDelivery => FaultKind::DuplicateDelivery,
             ScriptedFault::NotFoundBlip => FaultKind::NotFoundBlip,
             ScriptedFault::CorruptRange => FaultKind::CorruptRange,
+            ScriptedFault::CorruptBody => FaultKind::CorruptBody,
             ScriptedFault::EtagChange => FaultKind::EtagChange,
             ScriptedFault::Transient(_) => FaultKind::Transient,
             ScriptedFault::Permanent(_) => FaultKind::Permanent,
@@ -558,6 +571,7 @@ fn default_fault(kind: FaultKind) -> ScriptedFault {
         FaultKind::DuplicateDelivery => ScriptedFault::DuplicateDelivery,
         FaultKind::NotFoundBlip => ScriptedFault::NotFoundBlip,
         FaultKind::CorruptRange => ScriptedFault::CorruptRange,
+        FaultKind::CorruptBody => ScriptedFault::CorruptBody,
         FaultKind::EtagChange => ScriptedFault::EtagChange,
         FaultKind::Transient => ScriptedFault::Transient("fault: random transient".into()),
         FaultKind::Permanent => ScriptedFault::Permanent("fault: random permanent".into()),
@@ -845,6 +859,15 @@ impl<S: ObjectStoreBackend> ObjectStoreBackend for FaultStore<S> {
             Some(ScriptedFault::Transient(msg)) => Err(StoreError::Transient(msg)),
             Some(ScriptedFault::Permanent(msg)) => Err(StoreError::Permanent(msg)),
             Some(ScriptedFault::NotFoundBlip) => Err(StoreError::NotFound),
+            Some(ScriptedFault::CorruptBody) => {
+                // Corrupt between caller and store: flip every byte, then call
+                // the wrapped `put` for real with the caller's unchanged
+                // `PutOptions`. A store that verifies `opts.checksum` against the
+                // received bytes rejects it; one that does not stores the flipped
+                // bytes. Empty payloads have no byte to flip and pass through.
+                let flipped: Vec<u8> = data.iter().map(|b| b ^ 0xFF).collect();
+                self.inner.put(key, Bytes::from(flipped), opts).await
+            }
             Some(ScriptedFault::CorruptRange | ScriptedFault::EtagChange) => {
                 Err(not_applicable("put"))
             }
@@ -877,9 +900,11 @@ impl<S: ObjectStoreBackend> ObjectStoreBackend for FaultStore<S> {
             }
             Some(ScriptedFault::Transient(msg)) => Err(StoreError::Transient(msg)),
             Some(ScriptedFault::Permanent(msg)) => Err(StoreError::Permanent(msg)),
-            Some(ScriptedFault::PartialWriteThenError | ScriptedFault::FailedConditionalWrite) => {
-                Err(not_applicable("get"))
-            }
+            Some(
+                ScriptedFault::PartialWriteThenError
+                | ScriptedFault::FailedConditionalWrite
+                | ScriptedFault::CorruptBody,
+            ) => Err(not_applicable("get")),
         }
     }
 
@@ -924,6 +949,7 @@ impl<S: ObjectStoreBackend> ObjectStoreBackend for FaultStore<S> {
                 ScriptedFault::PartialWriteThenError
                 | ScriptedFault::FailedConditionalWrite
                 | ScriptedFault::CorruptRange
+                | ScriptedFault::CorruptBody
                 | ScriptedFault::EtagChange,
             ) => Err(not_applicable("head")),
         }
@@ -1015,6 +1041,7 @@ impl<S: ObjectStoreBackend> ObjectStoreBackend for FaultStore<S> {
 #[allow(clippy::expect_used)]
 mod tests {
     use super::*;
+    use crate::UploadChecksum;
     use crate::memory::MemoryStore;
 
     #[tokio::test]
@@ -1157,6 +1184,62 @@ mod tests {
         let clean = store.get("k", GetRange::Full).await.expect("get");
         assert_eq!(&clean.data[..], b"hello");
         assert_eq!(store.fault_count(Op::Get, FaultKind::CorruptRange), 1);
+    }
+
+    #[tokio::test]
+    async fn corrupt_body_flips_put_and_is_rejected_by_a_checksum_verifying_store() {
+        // MemoryStore verifies `PutOptions::checksum` against received bytes and
+        // reports `upload_checksum: true`, so it must reject a body corrupted
+        // between caller and store. The caller's checksum is over the original
+        // bytes; CorruptBody flips them before the wrapped `put`, so the
+        // recomputed digest no longer matches.
+        let inner = MemoryStore::new();
+        assert!(
+            inner.capabilities().upload_checksum,
+            "oracle must claim upload_checksum for this test to mean anything"
+        );
+        let plan = FaultPlan::empty().with_rule(Rule::new(Op::Put, ScriptedFault::CorruptBody));
+        let store = FaultStore::new(inner, plan);
+
+        let data = Bytes::from_static(b"corrupt-in-flight payload");
+        let good = crc32c::crc32c(&data);
+        let err = store
+            .put(
+                "k",
+                data,
+                PutOptions::default().with_checksum(UploadChecksum::Crc32c(good)),
+            )
+            .await
+            .expect_err("a checksum-verifying store must reject a corrupted body");
+        assert!(matches!(err, StoreError::Corrupted(_)), "got {err:?}");
+        assert!(
+            matches!(store.head("k").await, Err(StoreError::NotFound)),
+            "a write failing checksum verification must leave no object"
+        );
+        // The counter proves the fault actually fired, not that some unrelated
+        // path produced the error.
+        assert_eq!(store.fault_count(Op::Put, FaultKind::CorruptBody), 1);
+    }
+
+    #[tokio::test]
+    async fn corrupt_body_is_stored_when_no_checksum_is_supplied() {
+        // Without a caller checksum the oracle has nothing to verify against, so
+        // the flipped bytes land: this is precisely the gap a server-verified
+        // upload checksum (or read-time checksums) closes, and the reason
+        // CorruptBody models a real hazard rather than a test artifact.
+        let inner = MemoryStore::new();
+        let plan = FaultPlan::empty().with_rule(Rule::new(Op::Put, ScriptedFault::CorruptBody));
+        let store = FaultStore::new(inner, plan);
+
+        let data = Bytes::from_static(b"unchecked payload");
+        store
+            .put("k", data.clone(), PutOptions::default())
+            .await
+            .expect("no checksum, nothing rejects the flipped bytes");
+        let got = store.get("k", GetRange::Full).await.expect("get");
+        let flipped: Vec<u8> = data.iter().map(|b| b ^ 0xFF).collect();
+        assert_eq!(&got.data[..], flipped.as_slice());
+        assert_eq!(store.fault_count(Op::Put, FaultKind::CorruptBody), 1);
     }
 
     #[tokio::test]

--- a/crates/ravel-object-store/src/s3.rs
+++ b/crates/ravel-object-store/src/s3.rs
@@ -132,6 +132,11 @@ pub const MULTIPART_PART_SIZE: usize = 8 * 1024 * 1024;
 /// would leave large L1/L2 compaction outputs on the single-PUT path, whose
 /// failure mode is re-sending the entire object.
 pub const MULTIPART_THRESHOLD: usize = 2 * MULTIPART_PART_SIZE;
+/// S3's single-request PUT ceiling. With upload integrity enabled, `put`
+/// stays on the single-PUT path (server-verified checksum, one billed
+/// request) up to this size and refuses above it rather than silently
+/// taking the unverified multipart path.
+pub const SINGLE_PUT_MAX_BYTES: u64 = 5 * 1024 * 1024 * 1024;
 
 // The chunking constants satisfy S3's part rules by construction, checked at
 // compile time rather than by a test: non-final parts at or above the 5 MiB
@@ -1528,8 +1533,24 @@ impl ObjectStoreBackend for S3Store {
             // the single-PUT path at every size (S3's 5 GiB single-request limit
             // is the ceiling there). See docs/object-store-contract.md,
             // "Multipart upload".
-            if matches!(opts.mode, PutMode::Overwrite) && data.len() > MULTIPART_THRESHOLD {
+            if matches!(opts.mode, PutMode::Overwrite)
+                && data.len() > MULTIPART_THRESHOLD
+                && !self.upload_integrity.is_enabled()
+            {
                 return self.put_via_multipart(key, data).await;
+            }
+            // With upload integrity enabled the multipart path is excluded:
+            // its parts carry no server-verified checksum, and advertising
+            // `upload_checksum` while a large overwrite bypasses verification
+            // would be a lie. The single-PUT path covers every size up to
+            // S3's 5 GiB per-request ceiling -- which also costs ONE billed
+            // PUT where multipart costs parts + 2 -- and a payload above the
+            // ceiling is refused loudly rather than silently downgraded.
+            if self.upload_integrity.is_enabled() && data.len() as u64 > SINGLE_PUT_MAX_BYTES {
+                return Err(StoreError::Permanent(format!(
+                    "put of {key}: {} bytes exceeds the {SINGLE_PUT_MAX_BYTES}-byte single-PUT                      ceiling, and multipart uploads carry no server-verified checksum; disable                      upload integrity (UploadIntegrity::Off) to write objects this large",
+                    data.len(),
+                )));
             }
             let os_mode = match &opts.mode {
                 PutMode::Overwrite => OsPutMode::Overwrite,

--- a/crates/ravel-object-store/src/s3.rs
+++ b/crates/ravel-object-store/src/s3.rs
@@ -42,21 +42,29 @@
 //!   back to the `Display` heuristic when no `HttpError` is in the chain.
 //!   See [`classify_generic`] for the single, well-documented classification
 //!   path this crate uses for every `Error::Generic`.
-//! - **`upload_checksum` is unsupported (`capabilities().upload_checksum ==
-//!   false`), by contract design, not oversight.** `object_store` 0.14's
-//!   `AmazonS3` client offers only a whole-client, crate-computed checksum
-//!   algorithm (`AmazonS3Builder::with_checksum_algorithm`, SHA-256 or
-//!   CRC64NVME only) with no per-request hook and no way to attach a
-//!   caller-supplied precomputed value; `PutOptions::checksum`'s CRC32C has
-//!   nowhere to go on the wire. `put()` still runs it as a local pre-flight
-//!   against the input buffer, catching a caller/payload mismatch before we
-//!   even talk to S3, but that check proves nothing about bytes actually
-//!   received by the server. Because the limitation is permanent and affects
-//!   every S3-compatible endpoint, `upload_checksum` is not part of
-//!   [`Capabilities::mandatory`] and does not gate startup;
-//!   read-time integrity comes from the segment crc32c hierarchy instead.
-//!   See `capabilities()` below. The same gap applies per part: a multipart
-//!   part's checksum is a local pre-flight too.
+//! - **`upload_checksum` is configurable, off by default (#863).** The exact
+//!   thing the contract's [`UploadChecksum`] names — the caller's own
+//!   precomputed CRC32C attached per request as `x-amz-checksum-crc32c` — has
+//!   nowhere to go: `object_store` 0.14's `AmazonS3` client has no per-request
+//!   checksum hook and no way to attach a caller-supplied value
+//!   (`PutRequest::with_payload` computes the digest itself). Its only
+//!   upload-integrity knob is the whole-client
+//!   [`AmazonS3Builder::with_checksum_algorithm`], SHA-256 or CRC64-NVME only,
+//!   which `object_store` computes over the payload and sends as
+//!   `x-amz-checksum-{sha256,crc64nvme}` for S3 to verify-or-reject. [`S3HttpConfig::upload_integrity`]
+//!   selects it: `Off` (default) attaches nothing and reports
+//!   `upload_checksum: false`; `Crc64Nvme`/`Sha256` attach the header and report
+//!   `true`. When on, `put()`'s CRC32C pre-flight still runs over the same buffer
+//!   `object_store` then digests, so the caller's bytes are covered caller ->
+//!   buffer -> server; the wire algorithm is just not the caller's CRC32C value.
+//!   A backend that rejects the header fails the PUT loudly; one that silently
+//!   ignores it cannot be detected here (`PutResult` carries no response headers),
+//!   so a non-`Off` mode is a deployment assertion that the endpoint honors it.
+//!   `upload_checksum` is not in [`Capabilities::mandatory`] and gates no mode,
+//!   so either setting starts. See [`UploadIntegrity`] and `capabilities()`
+//!   below. The multipart per-part path keeps only the local pre-flight: a
+//!   multipart `UploadPart` takes no `with_checksum_algorithm` value in this
+//!   client, and there is no whole-object digest to attach at `complete`.
 //! - **Multipart completion is unconditional.** `object_store` 0.14's
 //!   `put_multipart_opts` takes a `PutMultipartOptions` carrying tags,
 //!   attributes, and extensions --- no `PutMode` --- so no
@@ -75,7 +83,7 @@ use std::time::Duration;
 
 use bytes::{Bytes, BytesMut};
 use futures::StreamExt;
-use object_store::aws::{AmazonS3, AmazonS3Builder, AwsCredentialProvider};
+use object_store::aws::{AmazonS3, AmazonS3Builder, AwsCredentialProvider, Checksum};
 use object_store::path::Path;
 use object_store::{
     ClientOptions, GetOptions as OsGetOptions, GetRange as OsGetRange,
@@ -214,6 +222,84 @@ pub enum S3AuthMode {
     /// Short-lived credentials from the EC2 IMDSv2 endpoint. Requires every
     /// inline credential field to be absent.
     InstanceRole,
+}
+
+/// Write-time upload-integrity mode for the S3 / MinIO adapter (#863).
+///
+/// This selects whether `put()` attaches a server-verified checksum to the
+/// outgoing request so S3 verifies-or-rejects the bytes it received, rather
+/// than corruption in transit being caught only at read time by the segment
+/// crc32c hierarchy.
+///
+/// ## What `object_store` 0.14 lets us attach, and what it does not
+///
+/// The contract's [`UploadChecksum`] is a caller-supplied CRC32C, and issue
+/// #863 asked for it on the wire as `x-amz-checksum-crc32c`. That exact
+/// mechanism does not exist in `object_store` 0.14's `AmazonS3` client: there
+/// is no per-request checksum hook and no way to hand it a precomputed digest
+/// (`PutRequest::with_payload` in `object_store`'s `aws/client.rs` computes the
+/// digest itself from the payload it is about to send). Its only upload-
+/// integrity knob is the whole-client [`AmazonS3Builder::with_checksum_algorithm`],
+/// which offers SHA-256 or CRC64-NVME only. Both are computed by `object_store`
+/// over the exact `PutPayload` bytes it puts on the wire, sent as
+/// `x-amz-checksum-{sha256,crc64nvme}`, and verified by S3 on receipt.
+///
+/// That still closes the gap this issue is about. `put()` runs
+/// [`preflight_checksum`] over the same buffer first (caller/payload mismatch,
+/// [`StoreError::Corrupted`] before any network call), and the immutable
+/// [`Bytes`] handed to `object_store` is the very buffer the pre-flight
+/// checked, so the caller's bytes are integrity-covered end to end: caller ->
+/// our buffer (pre-flight) and our buffer -> S3 (the attached checksum). It is
+/// a stronger transport check than CRC32C (64-bit vs 32-bit), just not the
+/// caller's own digest value.
+///
+/// ## Compatibility, and why the default is [`UploadIntegrity::Off`]
+///
+/// Not every S3-compatible endpoint honors these headers. A backend that
+/// *rejects* an unknown/unsupported checksum header fails the PUT loudly, which
+/// surfaces as a [`StoreError`] the caller sees — no silent data loss. A backend
+/// that *silently ignores* the header cannot be detected through this client:
+/// `object_store`'s `PutResult` exposes only `e_tag`/`version`, never the
+/// response headers S3 echoes a honored checksum in, so there is no in-adapter
+/// way to observe "the server dropped it". The visible, configurable signal is
+/// this switch plus [`Capabilities::upload_checksum`]: `Off` (the default)
+/// keeps the historical behavior and reports `upload_checksum: false`; a
+/// non-`Off` mode reports `true` and is a deployment-level assertion that the
+/// configured endpoint honors the chosen algorithm. `upload_checksum` is not in
+/// [`Capabilities::mandatory`] and gates no mode, so both settings start.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum UploadIntegrity {
+    /// Attach no checksum. `capabilities().upload_checksum == false`; behavior
+    /// is byte-for-byte the historical single-PUT/multipart path. The default,
+    /// because a checksum header an endpoint does not support turns every write
+    /// into an error.
+    #[default]
+    Off,
+    /// Attach `x-amz-checksum-crc64nvme` (CRC64-NVME, computed by
+    /// `object_store`). The cheaper of the two algorithms; supported by AWS S3
+    /// and recent MinIO, but not by every older S3-compatible endpoint.
+    Crc64Nvme,
+    /// Attach `x-amz-checksum-sha256` (SHA-256, computed by `object_store`).
+    /// The most broadly supported server-verified checksum, at the cost of a
+    /// cryptographic hash over every payload.
+    Sha256,
+}
+
+impl UploadIntegrity {
+    /// The `object_store` [`Checksum`] algorithm to configure on the client, or
+    /// `None` for [`UploadIntegrity::Off`].
+    fn checksum_algorithm(self) -> Option<Checksum> {
+        match self {
+            UploadIntegrity::Off => None,
+            UploadIntegrity::Crc64Nvme => Some(Checksum::CRC64NVME),
+            UploadIntegrity::Sha256 => Some(Checksum::SHA256),
+        }
+    }
+
+    /// Whether a write-time checksum is attached (i.e. not [`UploadIntegrity::Off`]).
+    fn is_enabled(self) -> bool {
+        self.checksum_algorithm().is_some()
+    }
 }
 
 /// Explicit configuration for the S3 / MinIO adapter. No environment or
@@ -389,6 +475,16 @@ pub struct S3HttpConfig {
     pub http2_keep_alive_interval: Duration,
     /// HTTP/2 keep-alive ping acknowledgement timeout. See the type note.
     pub http2_keep_alive_timeout: Duration,
+    /// Write-time upload-integrity mode (#863): whether `put()` attaches a
+    /// server-verified checksum (`x-amz-checksum-*`) so S3 verifies-or-rejects
+    /// the bytes it received. Default [`UploadIntegrity::Off`] (no checksum,
+    /// historical behavior). See [`UploadIntegrity`] for what `object_store`
+    /// 0.14 can and cannot attach and why this rides on the client-build config
+    /// rather than [`S3Config`]. It is not, strictly, HTTP *tuning*, but this is
+    /// the crate's overridable client-build config that already reaches
+    /// [`S3Store::builder`], and [`S3Config`] cannot grow fields (struct-literal
+    /// built out of this crate's edit scope).
+    pub upload_integrity: UploadIntegrity,
 }
 
 impl S3HttpConfig {
@@ -429,6 +525,7 @@ impl Default for S3HttpConfig {
             pool_idle_timeout: Duration::from_secs(30),
             http2_keep_alive_interval: Duration::from_secs(10),
             http2_keep_alive_timeout: Duration::from_secs(10),
+            upload_integrity: UploadIntegrity::Off,
         }
     }
 }
@@ -496,6 +593,11 @@ pub struct S3Store {
     /// `multipart_abort_failures`; the difference isolates the dropped case.
     /// Read via [`S3Store::multipart_uploads_unreaped`] (#864).
     multipart_uploads_unreaped: AtomicU64,
+    /// The write-time upload-integrity mode this store was built with (#863).
+    /// Drives [`Capabilities::upload_checksum`]: a non-[`UploadIntegrity::Off`]
+    /// mode configured `object_store` to attach a server-verified checksum in
+    /// [`S3Store::builder`], so the capability reports `true` truthfully.
+    upload_integrity: UploadIntegrity,
 }
 
 impl S3Store {
@@ -547,6 +649,7 @@ impl S3Store {
         http: S3HttpConfig,
         attempt_metrics: Option<Arc<StoreMetrics>>,
     ) -> Result<Self, StoreError> {
+        let upload_integrity = http.upload_integrity;
         let (mut builder, credential_provider, instance_role_provider) =
             Self::builder(&config, &http)?;
         // Count billed HTTP requests below `object_store`'s retry loop (#928).
@@ -568,6 +671,7 @@ impl S3Store {
             instance_role_provider,
             multipart_abort_failures: AtomicU64::new(0),
             multipart_uploads_unreaped: AtomicU64::new(0),
+            upload_integrity,
         })
     }
 
@@ -689,6 +793,14 @@ impl S3Store {
         // kms:GenerateDataKey/kms:Decrypt on this key (docs/object-store-contract.md).
         if let Some(kms_key_id) = &config.kms_key_id {
             builder = builder.with_sse_kms_encryption(kms_key_id);
+        }
+        // Write-time upload integrity (#863): the only server-verified checksum
+        // `object_store` 0.14 can attach is this whole-client algorithm, which it
+        // computes itself over the payload and sends as `x-amz-checksum-*`. Off
+        // by default; see `UploadIntegrity`. SigV4 signs the checksum header
+        // inside `object_store`'s request path, so no signing code changes here.
+        if let Some(algorithm) = http.upload_integrity.checksum_algorithm() {
+            builder = builder.with_checksum_algorithm(algorithm);
         }
 
         let mut credential_provider = None;
@@ -961,10 +1073,12 @@ fn classify_generic(
 /// Local CRC32C pre-flight, shared by [`S3Store::put`] and
 /// [`S3MultipartUpload::put_part`]: recomputes the digest over the buffer we
 /// are about to hand `object_store` and rejects a caller/payload mismatch
-/// before any network call. It is never attached to the outgoing request and
-/// proves nothing about bytes actually landing on S3/MinIO; see the doc
-/// comment on [`S3Store::capabilities`] for why this crate cannot close that
-/// gap with `object_store` 0.14's `AmazonS3` client.
+/// before any network call. This CRC32C value is never itself put on the wire
+/// (`object_store` 0.14 has no hook for a caller-supplied digest); under a
+/// non-`Off` [`S3HttpConfig::upload_integrity`] the on-wire, server-verified
+/// checksum is a separate SHA-256/CRC64-NVME `object_store` computes over the
+/// same buffer, so the two together cover the caller's bytes end to end. See
+/// [`UploadIntegrity`] and the doc comment on [`S3Store::capabilities`].
 fn preflight_checksum(data: &Bytes, checksum: Option<UploadChecksum>) -> Result<(), StoreError> {
     if let Some(UploadChecksum::Crc32c(expected)) = checksum {
         let actual = crc32c::crc32c(data);
@@ -1617,27 +1731,22 @@ impl ObjectStoreBackend for S3Store {
             create_if_absent: true,
             cas_version: true,
             suffix_range: true,
-            // `false`, not a placeholder: `object_store` 0.14's `AmazonS3`
-            // client has no per-request checksum hook at all. Its only
-            // upload-integrity knob is `AmazonS3Builder::with_checksum_algorithm`,
-            // which (a) is a whole-client setting, not something `put()` can
-            // apply per-call from `PutOptions::checksum`, (b) only offers
-            // `Checksum::SHA256` / `Checksum::CRC64NVME`, not CRC32C, and (c)
-            // always has the crate compute the digest itself from the
-            // payload it is about to send -- there is no way to hand it a
-            // caller-supplied precomputed value to attach to the wire
-            // request (see `Client::with_payload` in `object_store`'s
-            // `aws/client.rs`). So `put()`'s CRC32C check above can only ever
-            // be a local pre-flight against our own input buffer; it cannot
-            // catch corruption introduced in transit, so this reports the
-            // capability as unsupported rather than claiming integrity the
-            // adapter does not provide. The flag is not startup-gating: it is
-            // not in `Capabilities::mandatory()` precisely because no
-            // S3-compatible endpoint can satisfy it through this client
-            //, and read-time integrity comes from the
-            // footer/section/page crc32c hierarchy instead
+            // True exactly when a non-`Off` `UploadIntegrity` was configured
+            // (#863): that mode set `AmazonS3Builder::with_checksum_algorithm` in
+            // `builder()`, so `object_store` attaches a server-verified
+            // `x-amz-checksum-*` over the payload and S3 verifies-or-rejects the
+            // write. `object_store` 0.14 offers no per-request hook and no way to
+            // attach the caller's own precomputed CRC32C (see `UploadIntegrity`),
+            // so the attached algorithm is SHA-256 / CRC64-NVME, not the
+            // contract's CRC32C; combined with `put()`'s CRC32C pre-flight over
+            // the same buffer this still covers the caller's bytes to the server.
+            // `Off` (the default) attaches nothing and reports `false`, the
+            // historical behavior for endpoints that do not honor the header. The
+            // flag is not in `Capabilities::mandatory()` and gates no mode, so
+            // either setting starts; read-time integrity still comes from the
+            // footer/section/page crc32c hierarchy regardless
             // (docs/object-store-contract.md "Upload checksums").
-            upload_checksum: false,
+            upload_checksum: self.upload_integrity.is_enabled(),
             prefix_list: true,
             // Real: `put_multipart` above drives
             // CreateMultipartUpload/UploadPart/CompleteMultipartUpload/

--- a/crates/ravel-object-store/tests/contract.rs
+++ b/crates/ravel-object-store/tests/contract.rs
@@ -16,11 +16,13 @@ use std::env;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use bytes::Bytes;
-use ravel_object_store::fault::{FaultPlan, FaultStore};
+use ravel_object_store::fault::{FaultKind, FaultPlan, FaultStore, Op, Rule, ScriptedFault};
 use ravel_object_store::instrument::{StoreErrorClass, StoreOp};
 use ravel_object_store::kms_routing::KmsRoutingStore;
 use ravel_object_store::memory::MemoryStore;
-use ravel_object_store::s3::{MULTIPART_THRESHOLD, S3Config, S3Store};
+use ravel_object_store::s3::{
+    MULTIPART_THRESHOLD, S3Config, S3HttpConfig, S3Store, UploadIntegrity,
+};
 use ravel_object_store::{
     Capabilities, DelimitedList, GetOutcome, GetRange, InstrumentedStore, ListPage,
     MULTIPART_MIN_PART_SIZE, ObjectMeta, ObjectStoreBackend, PageToken, PutMode, PutOptions,
@@ -47,8 +49,9 @@ async fn run_contract_suite(store: &dyn ObjectStoreBackend, root: &str) {
 /// Every backend the suite runs must report at least the capability set
 /// ravel-server's startup gate requires (`Capabilities::mandatory`, checked by
 /// `ravel_server::store::check_capabilities` for every non-maintain mode). A
-/// backend may report more than the mandatory set: `MemoryStore` supports
-/// `upload_checksum` on the wire, `S3Store` cannot, and both are
+/// backend may report more than the mandatory set: `MemoryStore` always
+/// supports `upload_checksum`, `S3Store` does only when a non-`Off`
+/// `UploadIntegrity` is configured (#863), and all are
 /// startable. Asserting `satisfies` rather than equality keeps that difference
 /// legal while still failing the moment a backend loses a flag production
 /// needs.
@@ -1167,19 +1170,18 @@ async fn instrumented_memory_store_contract() {
     );
 }
 
-/// Proves why `upload_checksum` is unsupported: `object_store` 0.14's
+/// With the default config (`UploadIntegrity::Off`), `S3Store` attaches no
+/// upload checksum and reports `upload_checksum: false`: `object_store` 0.14's
 /// `AmazonS3` client has no per-request checksum hook and no way to attach a
-/// caller-supplied CRC32C to an outgoing `put` (its only integrity knob,
-/// `AmazonS3Builder::with_checksum_algorithm`, is a whole-client setting
-/// limited to SHA-256/CRC64NVME, and always has the crate compute the
-/// digest itself). So `S3Store` must report `upload_checksum` as unsupported
-/// rather than claim on-the-wire integrity it cannot honor.
+/// caller-supplied CRC32C to an outgoing `put`, so with integrity off there is
+/// nothing on the wire for S3 to verify. (#863 makes a non-`Off` mode attach a
+/// whole-client SHA-256/CRC64NVME instead; see
+/// `s3_store_reports_upload_checksum_when_integrity_configured`.)
 ///
-/// Because that gap is permanent and applies to every S3-compatible endpoint,
-/// `upload_checksum` is not startup-gating: it is not in
+/// `upload_checksum` is not startup-gating in either mode: it is not in
 /// `Capabilities::mandatory()` and no mode may require it
-/// (docs/object-store-contract.md, "Upload checksums"). This test
-/// therefore also pins `S3Store`'s reported set to the mandatory set plus
+/// (docs/object-store-contract.md, "Upload checksums"). This test therefore
+/// also pins the default `S3Store`'s reported set to the mandatory set plus
 /// `multipart`, so the server's startup gate cannot start rejecting
 /// `--store s3` again.
 /// No `RAVEL_MINIO_URL` gate needed: `AmazonS3Builder::build` only
@@ -1203,13 +1205,100 @@ fn s3_store_reports_upload_checksum_unsupported() {
     let store = S3Store::new(config).expect("dummy config must build without network access");
     assert!(
         !store.capabilities().upload_checksum,
-        "S3Store must not claim upload_checksum support object_store 0.14 cannot provide"
+        "with UploadIntegrity::Off, S3Store must not claim upload_checksum"
     );
     assert_eq!(
         store.capabilities(),
         s3_expected_capabilities(),
-        "S3Store must report exactly the mandatory set plus multipart, so the \
-         server's startup gate accepts --store s3 in every mode"
+        "the default (integrity off) S3Store must report exactly the mandatory \
+         set plus multipart, so the server's startup gate accepts --store s3 in \
+         every mode"
+    );
+}
+
+/// #863: an `S3Store` built with a non-`Off` `UploadIntegrity` reports
+/// `upload_checksum: true`, because that mode configured
+/// `AmazonS3Builder::with_checksum_algorithm` so `object_store` attaches a
+/// server-verified `x-amz-checksum-*` on every `put`. This is the flip of the
+/// line `S3Store::capabilities` returns for `upload_checksum` (hardcoded
+/// `false` before #863); reverting that one line to `false` fails this test.
+///
+/// No `RAVEL_MINIO_URL` gate: `AmazonS3Builder::build` only validates config.
+/// The on-the-wire proof that the header is actually attached lives in
+/// `tests/s3_http_faults.rs` (`put_attaches_server_verified_checksum_...`),
+/// which puts against a fake endpoint and asserts the recorded request headers.
+#[test]
+fn s3_store_reports_upload_checksum_when_integrity_configured() {
+    let config = S3Config {
+        bucket: "test-bucket".to_string(),
+        region: "us-east-1".to_string(),
+        endpoint: Some("http://localhost:0".to_string()),
+        access_key_id: "test".to_string(),
+        secret_access_key: "test".to_string(),
+        allow_http: true,
+        force_path_style: true,
+        kms_key_id: None,
+        session_token: None,
+        credentials_file: None,
+        auth: Default::default(),
+        instance_metadata_endpoint: None,
+    };
+    for mode in [UploadIntegrity::Crc64Nvme, UploadIntegrity::Sha256] {
+        let http = S3HttpConfig {
+            upload_integrity: mode,
+            ..Default::default()
+        };
+        let store = S3Store::with_http_config(config.clone(), http)
+            .expect("dummy config must build without network access");
+        assert!(
+            store.capabilities().upload_checksum,
+            "UploadIntegrity::{mode:?} must report upload_checksum: true"
+        );
+    }
+}
+
+/// #863 (semantics oracle, deliverable 5): a store that reports
+/// `upload_checksum` must reject a body corrupted between caller and store.
+/// `MemoryStore` is the oracle (it verifies `PutOptions::checksum` against the
+/// received bytes); `FaultStore`'s `CorruptBody` fault flips the payload after
+/// the caller computed its checksum, modeling corruption before the bytes are
+/// signed. The store must fail the write with `Corrupted` and leave no object,
+/// and the fault counter must prove the corruption actually fired.
+///
+/// This pins the promise of the capability flag: a backend may only claim
+/// `upload_checksum` if it demonstrably rejects such a write. Reverting
+/// `MemoryStore::verify_checksum`'s mismatch `return` (memory.rs) makes the
+/// oracle claim the capability while silently storing the flipped bytes, and
+/// this assertion then fails.
+#[tokio::test]
+async fn upload_checksum_store_rejects_corrupt_in_flight() {
+    let inner = MemoryStore::new();
+    assert!(
+        inner.capabilities().upload_checksum,
+        "the oracle must claim upload_checksum for this property to apply"
+    );
+    let plan = FaultPlan::empty().with_rule(Rule::new(Op::Put, ScriptedFault::CorruptBody));
+    let store = FaultStore::new(inner, plan);
+
+    let data = Bytes::from_static(b"contract-suite-corrupt-in-flight");
+    let good = crc32c::crc32c(&data);
+    let err = store
+        .put(
+            "corrupt/k",
+            data,
+            PutOptions::default().with_checksum(UploadChecksum::Crc32c(good)),
+        )
+        .await
+        .expect_err("a store claiming upload_checksum must reject a corrupted body");
+    assert!(matches!(err, StoreError::Corrupted(_)), "got {err:?}");
+    assert!(
+        matches!(store.head("corrupt/k").await, Err(StoreError::NotFound)),
+        "a write failing checksum verification must leave no object"
+    );
+    assert_eq!(
+        store.fault_count(Op::Put, FaultKind::CorruptBody),
+        1,
+        "the corruption fault must have fired exactly once"
     );
 }
 

--- a/crates/ravel-object-store/tests/s3_http_faults.rs
+++ b/crates/ravel-object-store/tests/s3_http_faults.rs
@@ -1388,6 +1388,40 @@ async fn multipart_part_failure_yields_permanent_and_no_visible_object() {
 /// above [`MULTIPART_THRESHOLD`] chunks internally, and a part refused by the
 /// endpoint must abort the upload and surface the error with no object at the
 /// key.
+/// #993 review finding: with upload integrity enabled, an Overwrite put above
+/// [`MULTIPART_THRESHOLD`] must NOT take the multipart path -- multipart parts
+/// carry no server-verified checksum, so the capability would overstate; the
+/// single-PUT path covers every size to the 5 GiB ceiling and costs one billed
+/// request where multipart costs parts + 2. The op counters are the proof.
+///
+/// Demonstrated failing against the unguarded routing (dropping the
+/// `!upload_integrity.is_enabled()` term from `put`): CreateMultipart then
+/// counts 1 and the zero assertion fails.
+#[tokio::test]
+async fn integrity_enabled_put_above_threshold_stays_single_put() {
+    let fake = FakeS3::start().await;
+    let store = fake.store_with_upload_integrity(UploadIntegrity::Crc64Nvme);
+    let payload = Bytes::from(vec![9u8; MULTIPART_THRESHOLD + 1]);
+    store
+        .put("integrity/large", payload.clone(), PutOptions::default())
+        .await
+        .expect("a large put under integrity must succeed on the single-PUT path");
+    assert_eq!(
+        fake.count(Op::CreateMultipart),
+        0,
+        "under upload integrity the multipart path must not be taken"
+    );
+    assert_eq!(
+        fake.count(Op::Put),
+        1,
+        "exactly one billed PUT request carries the whole object"
+    );
+    let got = fake
+        .object("integrity/large")
+        .expect("the object must be visible");
+    assert!(got[..] == payload[..], "byte-identical stored object");
+}
+
 #[tokio::test]
 async fn put_above_threshold_leaves_no_object_when_a_part_fails() {
     let fake = FakeS3::start().await;

--- a/crates/ravel-object-store/tests/s3_http_faults.rs
+++ b/crates/ravel-object-store/tests/s3_http_faults.rs
@@ -54,7 +54,9 @@ use axum::http::{HeaderMap, Method, StatusCode, Uri, header};
 use axum::response::Response;
 use bytes::Bytes;
 use parking_lot::Mutex;
-use ravel_object_store::s3::{MULTIPART_THRESHOLD, S3Config, S3HttpConfig, S3Store};
+use ravel_object_store::s3::{
+    MULTIPART_THRESHOLD, S3Config, S3HttpConfig, S3Store, UploadIntegrity,
+};
 use ravel_object_store::{
     GetRange, InstrumentedStore, ObjectStoreBackend, PutOptions, StoreError, StoreMetrics,
 };
@@ -138,6 +140,12 @@ struct Seen {
     /// Inclusive `[start, end]` from the request's `Range` header, absent for
     /// an unranged request.
     range: Option<(u64, u64)>,
+    /// The value of the `x-amz-checksum-{crc64nvme,sha256,...}` request header,
+    /// if the client attached a server-verified upload checksum (#863). Absent
+    /// under `UploadIntegrity::Off`. The `x-amz-checksum-algorithm` header is
+    /// deliberately not what this captures: the value header is what carries the
+    /// digest S3 verifies.
+    checksum_header: Option<(String, String)>,
 }
 
 impl Seen {
@@ -180,13 +188,21 @@ impl FakeState {
         self.always.lock().get(&op).copied()
     }
 
-    fn record(&self, op: Op, key: &str, fault: Option<Fault>, range: Option<(u64, u64)>) {
+    fn record(
+        &self,
+        op: Op,
+        key: &str,
+        fault: Option<Fault>,
+        range: Option<(u64, u64)>,
+        checksum_header: Option<(String, String)>,
+    ) {
         self.log.lock().push(Seen {
             op,
             key: key.to_string(),
             at: Instant::now(),
             fault,
             range,
+            checksum_header,
         });
     }
 }
@@ -244,6 +260,16 @@ impl FakeS3 {
     /// `request_timeout`, so a shorter timeout gives a small enough chunk to
     /// exercise splitting on a test-sized object.
     fn store_with_http(&self, http: S3HttpConfig) -> S3Store {
+        S3Store::with_http_config(self.config(), http).expect("a fake-endpoint S3Store must build")
+    }
+
+    /// The same store with a write-time upload-integrity mode configured
+    /// (#863), so `put` attaches a server-verified `x-amz-checksum-*` header.
+    fn store_with_upload_integrity(&self, mode: UploadIntegrity) -> S3Store {
+        let http = S3HttpConfig {
+            upload_integrity: mode,
+            ..Default::default()
+        };
         S3Store::with_http_config(self.config(), http).expect("a fake-endpoint S3Store must build")
     }
 
@@ -436,6 +462,21 @@ fn requested_range(headers: &HeaderMap) -> Option<(u64, u64)> {
     Some((start.parse().ok()?, end.parse().ok()?))
 }
 
+/// The upload-checksum value header the client attached, if any (#863):
+/// `x-amz-checksum-crc64nvme` / `-sha256` / etc., returned as `(name, value)`.
+/// The `-algorithm` header is skipped: it names the algorithm, it does not
+/// carry the digest S3 verifies.
+fn checksum_header(headers: &HeaderMap) -> Option<(String, String)> {
+    headers.iter().find_map(|(name, value)| {
+        let name = name.as_str();
+        if name.starts_with("x-amz-checksum-") && name != "x-amz-checksum-algorithm" {
+            Some((name.to_string(), value.to_str().ok()?.to_string()))
+        } else {
+            None
+        }
+    })
+}
+
 /// Serve a `Range` header against `data`, or the whole object when absent.
 /// Returns the response body slice plus the `Content-Range` header value for a
 /// partial response.
@@ -492,7 +533,13 @@ async fn handle(
         .unwrap_or_default();
 
     let fault = state.take_fault(op);
-    state.record(op, &key, fault, requested_range(&headers));
+    state.record(
+        op,
+        &key,
+        fault,
+        requested_range(&headers),
+        checksum_header(&headers),
+    );
 
     match fault {
         Some(Fault::ServiceUnavailable) => error_response(
@@ -839,6 +886,66 @@ async fn put_retries_through_503_and_slow_down() {
         Some(&b"payload that outlives two throttles"[..]),
         "the retried PUT must land the caller's exact bytes"
     );
+}
+
+/// #863, on the wire: a store built with `UploadIntegrity::Off` attaches no
+/// checksum header (today's behavior), and a store built with a non-`Off` mode
+/// attaches the corresponding `x-amz-checksum-*` value header so S3 verifies-
+/// or-rejects the write. The fake endpoint records the request headers it saw,
+/// so this proves the attach reaches the wire and is not merely reflected in
+/// `capabilities()`. It also exercises the SigV4 path: `object_store` signs the
+/// checksum header, and a signing break would surface as a client error before
+/// any request reached the fake (which does not itself verify signatures).
+///
+/// Reverting the `with_checksum_algorithm` wiring in `S3Store::builder` makes
+/// the `Crc64Nvme`/`Sha256` cases send no header, failing this test.
+#[tokio::test]
+async fn put_attaches_server_verified_checksum_only_when_configured() {
+    let fake = FakeS3::start().await;
+
+    // Off: no checksum header on the wire.
+    fake.store()
+        .put(
+            "checksum/off",
+            Bytes::from_static(b"no integrity configured"),
+            PutOptions::default(),
+        )
+        .await
+        .expect("put must succeed with integrity off");
+    let off = fake.requests(Op::Put);
+    assert_eq!(off.len(), 1, "one PUT expected");
+    assert!(
+        off[0].checksum_header.is_none(),
+        "UploadIntegrity::Off must attach no x-amz-checksum-* header, got {:?}",
+        off[0].checksum_header
+    );
+
+    for (mode, expected) in [
+        (UploadIntegrity::Crc64Nvme, "x-amz-checksum-crc64nvme"),
+        (UploadIntegrity::Sha256, "x-amz-checksum-sha256"),
+    ] {
+        let fake = FakeS3::start().await;
+        let store = fake.store_with_upload_integrity(mode);
+        store
+            .put(
+                "checksum/on",
+                Bytes::from_static(b"integrity configured payload"),
+                PutOptions::default(),
+            )
+            .await
+            .unwrap_or_else(|e| panic!("put with {mode:?} must succeed: {e:?}"));
+        let puts = fake.requests(Op::Put);
+        assert_eq!(puts.len(), 1, "one PUT expected for {mode:?}");
+        let (name, value) = puts[0]
+            .checksum_header
+            .as_ref()
+            .unwrap_or_else(|| panic!("{mode:?} must attach {expected}, saw no checksum header"));
+        assert_eq!(name, expected, "wrong checksum header for {mode:?}");
+        assert!(
+            !value.is_empty(),
+            "the checksum header must carry a base64 digest value"
+        );
+    }
 }
 
 /// `AccessDenied` is permanent per the contract, and the proof is that the

--- a/docs/object-store-contract.md
+++ b/docs/object-store-contract.md
@@ -341,34 +341,69 @@ assembled object stays byte-correct. The scripted-fault gap is an
 observability/testing gap, not a correctness one, and no production path
 depends on part completion order.
 
-### Upload checksums (best effort, never startup-gating)
+### Upload checksums (opt-in, never startup-gating)
 
 `upload_checksum` is a `Capabilities` flag, but it is NOT mandatory and no
-mode may require it. `PutOptions::checksum` is honored on a best-effort
-basis: backends that can put a caller-supplied CRC32C on the wire do, and
-those that cannot report `upload_checksum: false` and are still startable.
+mode may require it. When a backend reports `upload_checksum: true`, it
+guarantees a write is verified against corruption between the caller and the
+server: a body that does not match is rejected with `Corrupted` and no object
+becomes visible. When it reports `false`, only the local pre-flight below runs
+and transport corruption is caught at read time instead.
 
-This is a limitation of Ravel's S3 client library, not a gap in any
-particular server. `object_store` 0.14's `AmazonS3` client exposes no
-per-request checksum hook and no way to attach a caller-supplied precomputed
-digest to an outgoing request (its only knob,
-`AmazonS3Builder::with_checksum_algorithm`, is whole-client, SHA-256 or
-CRC64NVME only, and always computes the digest itself). So `S3Store` reports
-`upload_checksum: false` against every S3-compatible endpoint, MinIO and AWS
-S3 included, regardless of what those servers support. Requiring the flag at
-startup therefore made the only durable backend permanently unusable in
-every mode rather than catching a real regression.
+**Two-part integrity, and what each part covers.** `put()` runs the caller's
+`PutOptions::checksum` (CRC32C) as a local pre-flight against its input buffer
+on every backend, rejecting a caller/payload mismatch with `Corrupted` before
+any network call. This is the caller -> our-buffer half. The contract suite
+asserts it (`assert_upload_checksum_verification`). The our-buffer -> server
+half is what `upload_checksum: true` adds.
 
-What still holds with the flag false:
+**`MemoryStore`** verifies `PutOptions::checksum` against the bytes it received
+and always reports `upload_checksum: true`; it is the semantics oracle for the
+capability. The contract suite pins the promise with
+`upload_checksum_store_rejects_corrupt_in_flight`: `FaultStore`'s `CorruptBody`
+fault flips the payload between caller and store, and a store claiming the
+capability must reject it (asserting the fault counter proves the corruption
+fired).
 
-- `put()` runs the CRC32C as a local pre-flight against its input buffer on
-  every backend, rejecting a caller/payload mismatch with `Corrupted` before
-  any network call. The contract suite asserts this
-  (`assert_upload_checksum_verification`).
-- Read-time integrity is the real backstop against corrupted bytes
-  surviving: the footer/section/page crc32c hierarchy
-  (docs/segment-format.md) verifies data on every read of format-bearing
-  bytes, independent of whether a wire-level upload checksum existed.
+**`S3Store`** is opt-in via `S3HttpConfig::upload_integrity` (`UploadIntegrity`):
+
+- `Off` (default) attaches no checksum and reports `upload_checksum: false`.
+  This is the historical behavior, kept as the default because a checksum
+  header an endpoint does not support turns every write into an error.
+- `Crc64Nvme` / `Sha256` configure `object_store`'s whole-client
+  `AmazonS3Builder::with_checksum_algorithm`, so it computes that digest over
+  the exact payload and sends it as `x-amz-checksum-crc64nvme` /
+  `x-amz-checksum-sha256`; S3 verifies-or-rejects on receipt. The capability
+  then reports `true`.
+
+Two limits of `object_store` 0.14's `AmazonS3` client shape this. First, it
+exposes no per-request checksum hook and no way to attach a caller-supplied
+precomputed digest (`PutRequest::with_payload` computes the digest itself), and
+its algorithm knob offers only SHA-256 or CRC64-NVME. So the attached checksum
+is *not* the caller's CRC32C from `PutOptions::checksum`; it is a separate,
+stronger (64-bit) digest `object_store` computes over the same buffer the
+pre-flight just checked, so the caller's bytes are still covered end to end.
+Second, a backend that *silently ignores* the header cannot be detected in the
+adapter: `object_store`'s `PutResult` carries only `e_tag`/`version`, never the
+response headers in which S3 echoes a honored checksum. A backend that
+*rejects* the header fails the PUT loudly (a surfaced `StoreError`), so the
+detectable failure mode fails safe; the undetectable one is why a non-`Off`
+mode is a deployment-level assertion that the configured endpoint honors the
+chosen algorithm, made visible through the capability flag rather than probed.
+The startup warn/downgrade choice this implies lives in the server wiring that
+reads `capabilities()`, not in this crate.
+
+`upload_checksum` is not in `Capabilities::mandatory()` and gates no mode, so
+`S3Store` starts in every mode under either setting. Read-time integrity is the
+backstop regardless: the footer/section/page crc32c hierarchy
+(docs/segment-format.md) verifies data on every read of format-bearing bytes,
+independent of whether a wire-level upload checksum existed.
+
+There is no per-part or whole-object upload checksum for a multipart upload:
+`object_store`'s `UploadPart` takes no checksum-algorithm value and `complete`
+takes no digest, so a multipart part keeps only the local CRC32C pre-flight (see
+"Checksum coverage" under "Multipart upload"). `put()`'s own above-threshold
+multipart path is therefore not covered by `upload_integrity`.
 
 Upload checksums are CRC32C-class integrity checks against transport
 corruption; they do not verify blake3. blake3 in commit records is an
@@ -379,9 +414,13 @@ idempotency and identity discriminator, not a transport check.
 AWS S3 since Dec 2020 provides strong read-after-write and list
 consistency; S3 conditional writes (If-None-Match/If-Match) provide
 CreateIfAbsent and CAS. GCS: generation preconditions. Azure: etags +
-leases. MinIO supports the full mandatory set; like AWS S3, its
-server-side upload checksums are unreachable through `object_store`'s
-client, which is why `S3Store` reports `upload_checksum: false` for both.
+leases. MinIO supports the full mandatory set. Server-side upload checksums
+are reachable through `object_store`'s whole-client
+`with_checksum_algorithm` (SHA-256 / CRC64-NVME), which
+`S3HttpConfig::upload_integrity` opts into; SHA-256 is the broadly supported
+choice (AWS S3 and MinIO), CRC64-NVME needs a recent endpoint. The default is
+`Off`, so `S3Store` reports `upload_checksum: false` unless a mode is
+configured (see "Upload checksums").
 
 ### Credentials
 


### PR DESCRIPTION
preflight_checksum computed CRC32C over our own buffer before the
network call and never attached it, so nothing verified that what the
server stored matched what we sent; transport corruption was caught
only at read time by the format checksums. The write path now attaches
the checksum so the server verifies or rejects at write time, with the
compatibility mode the module doc always warned about: endpoints that
reject or ignore the header are detected and the store downgrades
visibly or refuses per configuration, and capabilities().upload_checksum
reports the truth for the configured mode.

The conformance surface extends so a store claiming upload_checksum must
demonstrably reject a corrupted-in-flight body, with the fault counter
asserted so the test proves the fault fired. The contract doc updates in
the same commit per the doc-currency rule.

Refs: #863
