### PR TITLE
feat(types): store cost profile and the data-objects-touched counter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5192,7 +5192,9 @@ dependencies = [
  "blake3",
  "hex",
  "proptest",
+ "serde",
  "thiserror",
+ "toml",
  "uuid",
 ]
 

--- a/crates/ravel-query/src/distrib/codec.rs
+++ b/crates/ravel-query/src/distrib/codec.rs
@@ -1426,18 +1426,21 @@ pub fn decode_accounting(snap: pb::QueryAccountingSnapshot) -> QueryAccountingSn
         segments_pruned: snap.segments_pruned,
         series_matched: snap.series_matched,
         bytes_reused: snap.bytes_reused,
-        // `page_bytes_fetched`/`page_bytes_decoded` (ADR-0107 decision 4) and
-        // `logs_whole_object_opens`/`logs_ranged_opens` (ADR-0904 decision 5)
+        // `page_bytes_fetched`/`page_bytes_decoded` (ADR-0107 decision 4),
+        // `logs_whole_object_opens`/`logs_ranged_opens` (ADR-0904 decision 5),
+        // and `data_objects_touched` (ADR-0996 decision 3)
         // are process-local accounting and are NOT carried on this wire form:
         // `pb::QueryAccountingSnapshot` is a frozen proto schema, and adding a
         // field to it is an ADR-gated change out of these counters' scope. The
         // ADR-0071 fan-out coordinator therefore does not aggregate a remote
-        // worker's page-byte or opens-by-shape totals; single-process queries
-        // account them in full. Decoded back as zero below.
+        // worker's page-byte, opens-by-shape, or object-touch totals;
+        // single-process queries account them in full. Decoded back as zero
+        // below.
         page_bytes_fetched: 0,
         page_bytes_decoded: 0,
         logs_whole_object_opens: 0,
         logs_ranged_opens: 0,
+        data_objects_touched: 0,
         peak_intermediate_bytes: snap.peak_intermediate_bytes,
     }
 }
@@ -2979,12 +2982,14 @@ mod tests {
             bytes_reused: 256,
             // Non-zero on purpose: these are process-local counters deliberately
             // NOT carried on the frozen wire proto (page bytes: ADR-0107
-            // decision 4; opens-by-shape: ADR-0904 decision 5), so they must
-            // decode back as zero, unlike every other field which round-trips.
+            // decision 4; opens-by-shape: ADR-0904 decision 5; object touches:
+            // ADR-0996 decision 3), so they must decode back as zero, unlike
+            // every other field which round-trips.
             page_bytes_fetched: 900,
             page_bytes_decoded: 300,
             logs_whole_object_opens: 6,
             logs_ranged_opens: 9,
+            data_objects_touched: 11,
             peak_intermediate_bytes: 512,
         };
         let round = decode_accounting(encode_accounting(&snap));
@@ -2999,12 +3004,17 @@ mod tests {
         );
         assert_eq!(round.logs_ranged_opens, 0);
         assert_eq!(
+            round.data_objects_touched, 0,
+            "the object-touch denominator is not on the wire proto"
+        );
+        assert_eq!(
             round,
             QueryAccountingSnapshot {
                 page_bytes_fetched: 0,
                 page_bytes_decoded: 0,
                 logs_whole_object_opens: 0,
                 logs_ranged_opens: 0,
+                data_objects_touched: 0,
                 ..snap
             },
             "every other field round-trips unchanged"

--- a/crates/ravel-query/src/distrib/codec.rs
+++ b/crates/ravel-query/src/distrib/codec.rs
@@ -2984,11 +2984,11 @@ mod tests {
             segments_pruned: 64,
             series_matched: 128,
             bytes_reused: 256,
-            // Non-zero on purpose: these are process-local counters deliberately
-            // NOT carried on the frozen wire proto (page bytes: ADR-0107
-            // decision 4; opens-by-shape: ADR-0904 decision 5; object touches:
-            // ADR-0996 decision 3), so they must decode back as zero, unlike
-            // every other field which round-trips.
+            // Non-zero on purpose: page bytes (ADR-0107 decision 4) and
+            // opens-by-shape (ADR-0904 decision 5) are process-local counters
+            // deliberately NOT carried on the wire proto, so they must decode
+            // back as zero. `data_objects_touched` IS carried (field 16,
+            // ADR-0996 decision 3) and round-trips like every other field.
             page_bytes_fetched: 900,
             page_bytes_decoded: 300,
             logs_whole_object_opens: 6,

--- a/crates/ravel-query/src/distrib/codec.rs
+++ b/crates/ravel-query/src/distrib/codec.rs
@@ -1400,6 +1400,7 @@ pub fn encode_accounting(snap: &QueryAccountingSnapshot) -> pb::QueryAccountingS
         segments_pruned: snap.segments_pruned,
         series_matched: snap.series_matched,
         bytes_reused: snap.bytes_reused,
+        data_objects_touched: snap.data_objects_touched,
         peak_intermediate_bytes: snap.peak_intermediate_bytes,
     }
 }
@@ -1426,21 +1427,24 @@ pub fn decode_accounting(snap: pb::QueryAccountingSnapshot) -> QueryAccountingSn
         segments_pruned: snap.segments_pruned,
         series_matched: snap.series_matched,
         bytes_reused: snap.bytes_reused,
-        // `page_bytes_fetched`/`page_bytes_decoded` (ADR-0107 decision 4),
-        // `logs_whole_object_opens`/`logs_ranged_opens` (ADR-0904 decision 5),
-        // and `data_objects_touched` (ADR-0996 decision 3)
-        // are process-local accounting and are NOT carried on this wire form:
-        // `pb::QueryAccountingSnapshot` is a frozen proto schema, and adding a
-        // field to it is an ADR-gated change out of these counters' scope. The
-        // ADR-0071 fan-out coordinator therefore does not aggregate a remote
-        // worker's page-byte, opens-by-shape, or object-touch totals;
-        // single-process queries account them in full. Decoded back as zero
-        // below.
+        // `page_bytes_fetched`/`page_bytes_decoded` (ADR-0107 decision 4) and
+        // `logs_whole_object_opens`/`logs_ranged_opens` (ADR-0904 decision 5)
+        // are process-local accounting and are NOT carried on this wire form;
+        // adding them would be its own ADR-gated change. The ADR-0071 fan-out
+        // coordinator therefore does not aggregate a remote worker's page-byte
+        // or opens-by-shape totals; single-process queries account them in
+        // full. Decoded back as zero below.
+        //
+        // `data_objects_touched` IS carried (field 16, the ADR-0996 decision-3
+        // additive change): slices partition by shard, so slice object sets
+        // are disjoint and the coordinator's sum is an exact distinct count.
+        // An old peer omits the field, prost decodes 0, and the merged figure
+        // degrades to the coordinator's own count -- never inflated.
         page_bytes_fetched: 0,
         page_bytes_decoded: 0,
         logs_whole_object_opens: 0,
         logs_ranged_opens: 0,
-        data_objects_touched: 0,
+        data_objects_touched: snap.data_objects_touched,
         peak_intermediate_bytes: snap.peak_intermediate_bytes,
     }
 }
@@ -3004,8 +3008,9 @@ mod tests {
         );
         assert_eq!(round.logs_ranged_opens, 0);
         assert_eq!(
-            round.data_objects_touched, 0,
-            "the object-touch denominator is not on the wire proto"
+            round.data_objects_touched, 11,
+            "the object-touch denominator round-trips on the wire (field 16, \
+             ADR-0996 decision 3): shard-disjoint slice sets sum exactly"
         );
         assert_eq!(
             round,
@@ -3014,7 +3019,6 @@ mod tests {
                 page_bytes_decoded: 0,
                 logs_whole_object_opens: 0,
                 logs_ranged_opens: 0,
-                data_objects_touched: 0,
                 ..snap
             },
             "every other field round-trips unchanged"

--- a/crates/ravel-types/Cargo.toml
+++ b/crates/ravel-types/Cargo.toml
@@ -8,6 +8,10 @@ rust-version.workspace = true
 [dependencies]
 blake3 = { workspace = true }
 thiserror = { workspace = true }
+# Config-document only (the store cost profile, ADR-0996 decision 1), never an
+# on-object format.
+serde = { workspace = true }
+toml = "1"
 uuid = { workspace = true }
 base64 = { workspace = true }
 hex = { workspace = true }

--- a/crates/ravel-types/src/accounting.rs
+++ b/crates/ravel-types/src/accounting.rs
@@ -137,6 +137,10 @@ struct Inner {
     /// Logs-scan segment opens that read the object by column-chunk ranges
     /// instead of one whole-object GET (ADR-0904 decision 5).
     logs_ranged_opens: AtomicU64,
+    /// Distinct DATA objects whose BLOCKS bytes this query fetched, counted
+    /// once per object (ADR-0996 decision 3). See the snapshot field of the
+    /// same name for the exact contract, including what it excludes.
+    data_objects_touched: AtomicU64,
     /// Recorded as a running maximum (compare-and-swap loop), never a sum;
     /// see [`QueryAccounting::observe_intermediate_bytes`].
     peak_intermediate_bytes: AtomicU64,
@@ -282,6 +286,24 @@ impl QueryAccounting {
         self.0.logs_ranged_opens.fetch_add(count, Ordering::Relaxed);
     }
 
+    /// Add to the count of distinct data objects this query fetched blocks
+    /// bytes from (ADR-0996 decision 3). This handle only accumulates: the
+    /// caller owes the distinctness, so it must call this exactly once per
+    /// object per query, at the point the object is first admitted to the
+    /// fetch, and never again for the same object even if the query issues
+    /// several ranged GETs against it.
+    ///
+    /// This is the denominator of `range_amplification = data_GET_requests /
+    /// data_objects_touched`, which is why the numerator's exclusions are the
+    /// counter's contract and not a detail: see the snapshot field
+    /// [`QueryAccountingSnapshot::data_objects_touched`] for exactly what
+    /// counts.
+    pub fn add_data_objects_touched(&self, count: u64) {
+        self.0
+            .data_objects_touched
+            .fetch_add(count, Ordering::Relaxed);
+    }
+
     /// Update the peak intermediate byte high-water mark. This is a
     /// maximum, never a sum: call it with the current intermediate size at
     /// each point it might grow, and the counter keeps the largest value
@@ -337,6 +359,7 @@ impl QueryAccounting {
             other.logs_whole_object_opens,
         );
         saturating_fetch_add(&self.0.logs_ranged_opens, other.logs_ranged_opens);
+        saturating_fetch_add(&self.0.data_objects_touched, other.data_objects_touched);
         self.observe_intermediate_bytes(other.peak_intermediate_bytes);
     }
 
@@ -366,6 +389,7 @@ impl QueryAccounting {
             page_bytes_decoded: self.0.page_bytes_decoded.load(Ordering::Relaxed),
             logs_whole_object_opens: self.0.logs_whole_object_opens.load(Ordering::Relaxed),
             logs_ranged_opens: self.0.logs_ranged_opens.load(Ordering::Relaxed),
+            data_objects_touched: self.0.data_objects_touched.load(Ordering::Relaxed),
             peak_intermediate_bytes: self.0.peak_intermediate_bytes.load(Ordering::Relaxed),
         }
     }
@@ -412,6 +436,36 @@ pub struct QueryAccountingSnapshot {
     /// instead of one whole-object GET (ADR-0904 decision 5). See
     /// [`Self::logs_whole_object_opens`].
     pub logs_ranged_opens: u64,
+    /// Distinct **data** objects whose **blocks** bytes this query fetched,
+    /// counted once per object no matter how many GETs the query issued
+    /// against it (ADR-0996 decision 3).
+    ///
+    /// This is the denominator of `range_amplification = data_GET_requests /
+    /// data_objects_touched`, so its exclusions are the contract:
+    ///
+    /// - A footer or index probe does **not** count. A probe reads the
+    ///   object's trailer to decide what to fetch; if the query then decides
+    ///   to fetch no blocks from that object, the object was never touched in
+    ///   this sense.
+    /// - A catalog, manifest, or commit-record object does **not** count.
+    ///   Those are resolve-phase reads of a different object kind, and folding
+    ///   them in would deflate range amplification by inflating the
+    ///   denominator with objects the scan phase never ranged over.
+    /// - A block read served entirely from cache **does** count: the counter
+    ///   measures the query's object working set, not its cache misses (the
+    ///   same rule [`Self::logs_whole_object_opens`] follows).
+    /// - Several ranged GETs against one object count **once**. That is the
+    ///   whole point: the ratio to scan-phase GETs is exactly the range
+    ///   amplification.
+    ///
+    /// Distinctness is per handle, so a merge sums: the ADR-0071 slices this
+    /// folds together scan disjoint segment sets, so their touch counts add
+    /// exactly. Two sub-queries that legitimately overlap on one object (the
+    /// multi-`match[]` metadata endpoints under
+    /// [`Self::saturating_add`]) would count it twice, which inflates the
+    /// denominator and therefore *understates* range amplification; a report
+    /// combining selectors must say so rather than claim a distinct count.
+    pub data_objects_touched: u64,
     pub peak_intermediate_bytes: u64,
 }
 
@@ -489,6 +543,9 @@ impl QueryAccountingSnapshot {
             logs_ranged_opens: self
                 .logs_ranged_opens
                 .saturating_add(other.logs_ranged_opens),
+            data_objects_touched: self
+                .data_objects_touched
+                .saturating_add(other.data_objects_touched),
             peak_intermediate_bytes: self
                 .peak_intermediate_bytes
                 .max(other.peak_intermediate_bytes),
@@ -1064,5 +1121,73 @@ mod tests {
         let merged = a.snapshot().saturating_merge(&b.snapshot());
         assert_eq!(merged.logs_whole_object_opens, 11);
         assert_eq!(merged.logs_ranged_opens, 22);
+    }
+
+    #[test]
+    fn data_objects_touched_snapshot_and_merge_round_trip_is_exact() {
+        // The denominator of range_amplification (ADR-0996 decision 3), so it
+        // must be exact, never indicative: a fresh handle reads zero, a
+        // recorded handle reads exactly what was added, the value survives the
+        // snapshot as a value type, and folding slice snapshots sums it. The
+        // recording sites (ravel-query) owe the per-object distinctness; this
+        // asserts the plumbing carries whatever they record without loss.
+        assert_eq!(QueryAccounting::new().snapshot().data_objects_touched, 0);
+
+        let acc = QueryAccounting::new();
+        acc.add_data_objects_touched(3);
+        acc.add_data_objects_touched(1);
+        let snap = acc.snapshot();
+        assert_eq!(snap.data_objects_touched, 4, "touches accumulate exactly");
+        acc.add_data_objects_touched(10);
+        assert_eq!(
+            snap.data_objects_touched, 4,
+            "an already-taken snapshot is a value, unaffected by later touches"
+        );
+        assert_eq!(acc.snapshot().data_objects_touched, 14);
+
+        // Two slices over disjoint segment sets, folded into a coordinator's
+        // live handle and through both snapshot combiners.
+        let s1 = QueryAccounting::new();
+        s1.add_data_objects_touched(7);
+        let s2 = QueryAccounting::new();
+        s2.add_data_objects_touched(5);
+
+        let agg = QueryAccounting::new();
+        agg.merge_snapshot(&s1.snapshot());
+        agg.merge_snapshot(&s2.snapshot());
+        assert_eq!(
+            agg.snapshot().data_objects_touched,
+            12,
+            "merge_snapshot sums disjoint slices' touches"
+        );
+        assert_eq!(
+            s1.snapshot()
+                .saturating_add(&s2.snapshot())
+                .data_objects_touched,
+            12
+        );
+        assert_eq!(
+            s1.snapshot()
+                .saturating_merge(&s2.snapshot())
+                .data_objects_touched,
+            12
+        );
+    }
+
+    #[test]
+    fn data_objects_touched_saturates_instead_of_wrapping() {
+        // A wrapped-low denominator would fabricate an enormous range
+        // amplification out of a fine query; clamp instead (the same rule
+        // every other merged counter follows).
+        let agg = QueryAccounting::new();
+        agg.merge_snapshot(&QueryAccountingSnapshot {
+            data_objects_touched: u64::MAX - 1,
+            ..QueryAccountingSnapshot::default()
+        });
+        agg.merge_snapshot(&QueryAccountingSnapshot {
+            data_objects_touched: 10,
+            ..QueryAccountingSnapshot::default()
+        });
+        assert_eq!(agg.snapshot().data_objects_touched, u64::MAX);
     }
 }

--- a/crates/ravel-types/src/accounting.rs
+++ b/crates/ravel-types/src/accounting.rs
@@ -458,13 +458,32 @@ pub struct QueryAccountingSnapshot {
     ///   whole point: the ratio to scan-phase GETs is exactly the range
     ///   amplification.
     ///
-    /// Distinctness is per handle, so a merge sums: the ADR-0071 slices this
-    /// folds together scan disjoint segment sets, so their touch counts add
-    /// exactly. Two sub-queries that legitimately overlap on one object (the
-    /// multi-`match[]` metadata endpoints under
-    /// [`Self::saturating_add`]) would count it twice, which inflates the
-    /// denominator and therefore *understates* range amplification; a report
-    /// combining selectors must say so rather than claim a distinct count.
+    /// Distinctness is per handle, and the merge is ADDITION, which is exact
+    /// only over disjoint object sets. Two merges exist and only one is safe
+    /// unconditionally:
+    ///
+    /// - **ADR-0071 slice merge (wire, `queryfrag.proto` field 16): exact.**
+    ///   Slices partition by `(tenant, signal, shard)` and an object belongs
+    ///   to exactly one shard, so slice object sets are disjoint by
+    ///   construction and their counts add to a true distinct count. An old
+    ///   peer omits the field and contributes zero, degrading the merged
+    ///   figure low, never inflating it.
+    /// - **Same-process combination (the multi-`match[]` metadata endpoints
+    ///   under [`Self::saturating_add`]): NOT distinct.** Two sub-queries
+    ///   that overlap on one object count it twice, inflating the
+    ///   denominator and *understating* range amplification -- the flattering
+    ///   direction. A report combining selectors must label the figure a sum
+    ///   of per-selector counts, never a distinct count.
+    ///
+    /// The RECORDING contract is designated-recorder, not
+    /// record-where-you-fetch: several partitions stripe one segment's
+    /// blocks (`ravel-sql` `logs_scan.rs`), so a per-partition recording
+    /// site would multiply the count exactly as per-partition
+    /// whole-segment totals would -- the same problem ADR-0102's
+    /// partition-0-at-planning rule already solves for
+    /// `record_segment_totals`, and the same rule binds every future
+    /// recording site of this counter, including a fast path that has no
+    /// plan phase, which must pick its single recorder explicitly.
     pub data_objects_touched: u64,
     pub peak_intermediate_bytes: u64,
 }

--- a/crates/ravel-types/src/cost_profile.rs
+++ b/crates/ravel-types/src/cost_profile.rs
@@ -179,16 +179,26 @@ impl StoreCostProfile {
     /// [`CostProfileError`]; nothing here panics on malformed input.
     pub fn from_toml_str(toml_str: &str) -> Result<StoreCostProfile, CostProfileError> {
         let profile: StoreCostProfile = toml::from_str(toml_str)?;
-        if profile.name.trim().is_empty() {
-            return Err(CostProfileError::EmptyName);
-        }
+        profile.validate_name()?;
         Ok(profile)
     }
 
     /// Render this profile as a TOML document, for a config file or a
-    /// provenance stamp that carries the profile verbatim.
+    /// provenance stamp that carries the profile verbatim. Refuses the same
+    /// blank name the loader refuses: a rendered document that the loader
+    /// would reject is a round-trip trap, and an anonymous profile cannot
+    /// legally be stamped into provenance.
     pub fn to_toml_string(&self) -> Result<String, CostProfileError> {
+        self.validate_name()?;
         Ok(toml::to_string(self)?)
+    }
+
+    /// The one name rule both directions share: non-empty after trimming.
+    fn validate_name(&self) -> Result<(), CostProfileError> {
+        if self.name.trim().is_empty() {
+            return Err(CostProfileError::EmptyName);
+        }
+        Ok(())
     }
 
     /// Nanodollars per request under `class`.
@@ -538,5 +548,19 @@ retrieval_nanodollars_per_gib = 0
 "#;
         let err = StoreCostProfile::from_toml_str(doc).expect_err("blank name must be refused");
         assert!(matches!(err, CostProfileError::EmptyName), "got {err:?}");
+
+        // The renderer shares the rule: a profile the loader would reject
+        // cannot be rendered, so a blank-named stamp cannot exist.
+        let anon = StoreCostProfile {
+            name: "   ".to_string(),
+            ..StoreCostProfile::reference()
+        };
+        let render_err = anon
+            .to_toml_string()
+            .expect_err("blank name must not render");
+        assert!(
+            matches!(render_err, CostProfileError::EmptyName),
+            "got {render_err:?}"
+        );
     }
 }

--- a/crates/ravel-types/src/cost_profile.rs
+++ b/crates/ravel-types/src/cost_profile.rs
@@ -1,0 +1,525 @@
+//! Store cost profile: the deployment's object-store prices, in one place
+//! (ADR-0996 decision 1).
+//!
+//! The reference deployment is intra-region, where transfer is free and the
+//! bill is requests only. Under that shape a column-range GET spends a billed
+//! request to save bytes that cost nothing, so the read path's economics
+//! depend on prices that are a **deployment property, not a constant**: they
+//! belong in configuration, read once, stamped into every report that carries
+//! a request or modeled-cost figure.
+//!
+//! # Integer nanodollars, never floats
+//!
+//! Prices are exact decimal contract figures ($5.00 per million requests, not
+//! a measured quantity), and the repo's float-comparison discipline exists
+//! because floats are inexact. One nanodollar is 1e-9 USD, so $5/M requests is
+//! `5_000` nanodollars per request and $0.40/M is `400`. Every figure derived
+//! from a profile stays in `u64` nanodollars with saturating arithmetic, so a
+//! modeled cost can be compared, summed, and pinned in a test exactly.
+//!
+//! # Layering: prices live here and are never read by the fetch layer
+//!
+//! ADR-0904's rule is preserved (ADR-0996 decision 1, "Layering"): this module
+//! is data. The server config and `ravel-bench` read it; the server derives a
+//! byte-denominated exchange rate from the profile's ratio and hands the query
+//! engine only byte quantities. Nothing in the fetch path learns a price.
+
+use serde::{Deserialize, Serialize};
+
+use crate::accounting::AccountedOp;
+
+/// Bytes in one GiB, the unit both per-GiB prices are quoted in.
+const BYTES_PER_GIB: u128 = 1 << 30;
+
+/// The billing class a store operation falls under. S3 prices requests in two
+/// tiers plus a free tier, and the profile carries one price per tier rather
+/// than one field per operation (ADR-0996 decision 1): a new operation kind
+/// maps to an existing class instead of growing the config surface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum StoreOpClass {
+    /// PUT/COPY/POST/LIST class, the expensive tier. LIST bills here on S3
+    /// despite being a read, which is why a per-op price table would be a
+    /// trap: listing costs 12.5 GETs at the reference prices.
+    Put,
+    /// GET/SELECT class, the cheap tier. HEAD bills here: it is a GET request
+    /// that returns no body.
+    Get,
+    /// Not billed per request. DELETE (and multi-object delete) is free on S3;
+    /// a class rather than a zero price so a caller reading the profile cannot
+    /// mistake "free by contract" for "priced at zero in this config".
+    Free,
+}
+
+/// Store operations a cost profile can price. Mirrors
+/// `ravel_object_store::instrument::StoreOp` variant for variant so that crate
+/// can map its own op into a class, without this dependency-light crate
+/// depending on it (the dependency runs the other way; see [`AccountedOp`]'s
+/// own note on the same constraint).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CostedStoreOp {
+    Put,
+    Get,
+    Head,
+    List,
+    ListDelimited,
+    Delete,
+}
+
+impl CostedStoreOp {
+    /// Every variant, for exhaustive mapping tests.
+    pub const ALL: [CostedStoreOp; 6] = [
+        CostedStoreOp::Put,
+        CostedStoreOp::Get,
+        CostedStoreOp::Head,
+        CostedStoreOp::List,
+        CostedStoreOp::ListDelimited,
+        CostedStoreOp::Delete,
+    ];
+
+    /// The billing class this operation bills under on S3-compatible storage.
+    ///
+    /// The two mappings that are not the obvious ones, and the reason this
+    /// function exists rather than a price per op: **LIST is PUT-class** (both
+    /// `List` and `ListDelimited`, which are the same `ListObjectsV2` request
+    /// with and without a delimiter), and **HEAD is GET-class**.
+    pub fn class(self) -> StoreOpClass {
+        match self {
+            CostedStoreOp::Put => StoreOpClass::Put,
+            CostedStoreOp::List | CostedStoreOp::ListDelimited => StoreOpClass::Put,
+            CostedStoreOp::Get | CostedStoreOp::Head => StoreOpClass::Get,
+            CostedStoreOp::Delete => StoreOpClass::Free,
+        }
+    }
+}
+
+impl From<AccountedOp> for CostedStoreOp {
+    /// Widens a query-path op into the full billed set. [`AccountedOp`] carries
+    /// only the three kinds a query can issue; every one of them has an exact
+    /// counterpart here.
+    fn from(op: AccountedOp) -> Self {
+        match op {
+            AccountedOp::Get => CostedStoreOp::Get,
+            AccountedOp::List => CostedStoreOp::List,
+            AccountedOp::Head => CostedStoreOp::Head,
+        }
+    }
+}
+
+/// The active deployment's object-store prices (ADR-0996 decision 1).
+///
+/// Ships with a reference profile ([`StoreCostProfile::reference`], named
+/// [`StoreCostProfile::S3_INTRA_REGION_2026`]) and is overridable from a TOML
+/// document ([`StoreCostProfile::from_toml_str`]), so the bench, the server,
+/// and any cost-based planner read one artifact.
+///
+/// Serialization is TOML config only, never an on-object format: this type is
+/// not part of any frozen persistent contract and carries no version domain.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct StoreCostProfile {
+    /// Profile identity as it appears in a provenance stamp, e.g.
+    /// `"s3-intra-region-2026"`. Stamped beside every request or modeled-cost
+    /// figure so two reports can be compared only when they priced the same
+    /// way.
+    pub name: String,
+    /// Nanodollars per PUT-class request (PUT/COPY/POST/LIST).
+    pub put_class_nanodollars: u64,
+    /// Nanodollars per GET-class request (GET/SELECT/HEAD).
+    pub get_class_nanodollars: u64,
+    /// Nanodollars per GiB transferred out. `0` on an intra-region deployment,
+    /// which is what makes request-minimal fetching the cost-preferring shape
+    /// there.
+    pub transfer_nanodollars_per_gib: u64,
+    /// Nanodollars per GiB retrieved, for storage classes that bill retrieval
+    /// separately from transfer. `0` on the standard class.
+    pub retrieval_nanodollars_per_gib: u64,
+}
+
+/// Prices of the reference profile, carrying an empty name: a `String` cannot
+/// be built in a `const`, and a public constant whose name field is blank
+/// would be a profile that cannot legally be stamped. So the prices live here
+/// once, and [`StoreCostProfile::reference`] is the only way to obtain the
+/// profile, always named.
+const S3_INTRA_REGION_2026_PRICES: StoreCostProfile = StoreCostProfile {
+    name: String::new(),
+    put_class_nanodollars: 5_000,
+    get_class_nanodollars: 400,
+    transfer_nanodollars_per_gib: 0,
+    retrieval_nanodollars_per_gib: 0,
+};
+
+impl StoreCostProfile {
+    /// Name of the reference profile, as it appears in a provenance stamp.
+    pub const S3_INTRA_REGION_2026: &'static str = "s3-intra-region-2026";
+
+    /// The reference profile: S3 standard, intra-region, 2026 list prices.
+    /// PUT-class $5.00 per million requests (`5_000` nanodollars), GET-class
+    /// $0.40 per million (`400`), transfer and retrieval free. One PUT costs
+    /// 12.5 GETs, the ratio ADR-0996 reasons from.
+    pub fn reference() -> StoreCostProfile {
+        StoreCostProfile {
+            name: StoreCostProfile::S3_INTRA_REGION_2026.to_string(),
+            ..S3_INTRA_REGION_2026_PRICES
+        }
+    }
+
+    /// Parse a profile from a TOML document.
+    ///
+    /// Unknown fields are refused rather than ignored: a misspelled price key
+    /// would otherwise leave the default silently in force, which is exactly
+    /// the "a variable that moves results and is absent from provenance"
+    /// failure this profile exists to close. Every error is a typed
+    /// [`CostProfileError`]; nothing here panics on malformed input.
+    pub fn from_toml_str(toml_str: &str) -> Result<StoreCostProfile, CostProfileError> {
+        let profile: StoreCostProfile = toml::from_str(toml_str)?;
+        if profile.name.trim().is_empty() {
+            return Err(CostProfileError::EmptyName);
+        }
+        Ok(profile)
+    }
+
+    /// Render this profile as a TOML document, for a config file or a
+    /// provenance stamp that carries the profile verbatim.
+    pub fn to_toml_string(&self) -> Result<String, CostProfileError> {
+        Ok(toml::to_string(self)?)
+    }
+
+    /// Nanodollars per request under `class`.
+    pub fn class_nanodollars(&self, class: StoreOpClass) -> u64 {
+        match class {
+            StoreOpClass::Put => self.put_class_nanodollars,
+            StoreOpClass::Get => self.get_class_nanodollars,
+            StoreOpClass::Free => 0,
+        }
+    }
+
+    /// Nanodollars for one request of `op`, through [`CostedStoreOp::class`].
+    /// Takes anything that converts, so a query-path [`AccountedOp`] prices
+    /// without the caller naming the class.
+    pub fn op_nanodollars(&self, op: impl Into<CostedStoreOp>) -> u64 {
+        self.class_nanodollars(op.into().class())
+    }
+
+    /// Modeled cost of a pass, in nanodollars: requests priced per class plus
+    /// transferred bytes priced per GiB.
+    ///
+    /// `transfer_bytes` is bytes, not GiB, because a fractional GiB has no
+    /// exact `u64` representation and money here never touches a float: the
+    /// per-GiB price is prorated as `bytes * price / 2^30` in `u128` and
+    /// truncated toward zero, so the result is reproducible bit for bit and
+    /// never rounds a bill up.
+    ///
+    /// Every step saturates at `u64::MAX`. This is an observability figure, so
+    /// a saturated value reads as "at least this much" rather than wrapping to
+    /// a small number that would read as cheap.
+    ///
+    /// Retrieval is priced separately by [`Self::retrieval_nanodollars`]: it
+    /// applies to the bytes a restore-class read pulls out of storage, which is
+    /// not the same quantity as the bytes a pass transfers out.
+    pub fn modeled_nanodollars(
+        &self,
+        put_class_requests: u64,
+        get_class_requests: u64,
+        transfer_bytes: u64,
+    ) -> u64 {
+        let puts = put_class_requests.saturating_mul(self.put_class_nanodollars);
+        let gets = get_class_requests.saturating_mul(self.get_class_nanodollars);
+        puts.saturating_add(gets)
+            .saturating_add(per_gib_nanodollars(
+                transfer_bytes,
+                self.transfer_nanodollars_per_gib,
+            ))
+    }
+
+    /// Nanodollars for `retrieval_bytes` pulled from a retrieval-billed storage
+    /// class, prorated from [`Self::retrieval_nanodollars_per_gib`] the same
+    /// exact way [`Self::modeled_nanodollars`] prorates transfer.
+    pub fn retrieval_nanodollars(&self, retrieval_bytes: u64) -> u64 {
+        per_gib_nanodollars(retrieval_bytes, self.retrieval_nanodollars_per_gib)
+    }
+}
+
+/// `bytes * nanodollars_per_gib / 2^30`, truncated toward zero, saturating at
+/// `u64::MAX`. The product is formed in `u128` so a large byte count times a
+/// large price cannot lose the low bits before the division.
+fn per_gib_nanodollars(bytes: u64, nanodollars_per_gib: u64) -> u64 {
+    let total = u128::from(bytes) * u128::from(nanodollars_per_gib) / BYTES_PER_GIB;
+    u64::try_from(total).unwrap_or(u64::MAX)
+}
+
+/// Why a store cost profile could not be loaded or rendered. A malformed
+/// document is always one of these, never a panic.
+#[derive(Debug, thiserror::Error)]
+pub enum CostProfileError {
+    /// The document is not valid TOML, is missing a required price, or carries
+    /// a field the profile does not define (unknown fields are refused, so a
+    /// misspelled key fails loudly instead of leaving a default in force).
+    #[error("invalid store cost profile TOML: {0}")]
+    Toml(#[from] toml::de::Error),
+    /// The profile carries no name, so nothing could identify it in a
+    /// provenance stamp.
+    #[error("store cost profile name must not be empty")]
+    EmptyName,
+    /// The profile could not be rendered back to TOML.
+    #[error("could not render store cost profile as TOML: {0}")]
+    Render(#[from] toml::ser::Error),
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reference_profile_prices_are_pinned_exactly() {
+        // These are contract figures, not measurements: $5.00 and $0.40 per
+        // million requests, in nanodollars ($1 = 1e9). A change here changes
+        // every modeled-cost figure the ledger publishes, so it is pinned to
+        // the arithmetic rather than to a repeated literal.
+        let p = StoreCostProfile::reference();
+        assert_eq!(p.name, "s3-intra-region-2026");
+        assert_eq!(
+            p.put_class_nanodollars * 1_000_000,
+            5_000_000_000,
+            "PUT class is exactly $5.00 per million requests"
+        );
+        assert_eq!(
+            p.get_class_nanodollars * 1_000_000,
+            400_000_000,
+            "GET class is exactly $0.40 per million requests"
+        );
+        assert_eq!(
+            p.transfer_nanodollars_per_gib, 0,
+            "intra-region transfer is free"
+        );
+        assert_eq!(
+            p.retrieval_nanodollars_per_gib, 0,
+            "standard-class retrieval is free"
+        );
+    }
+
+    #[test]
+    fn reference_profile_put_get_ratio_is_exactly_twelve_and_a_half() {
+        // The 12.5:1 ratio is the fact ADR-0996 reasons from: one PUT costs
+        // 12.5 GETs, so trading a request for bytes inverts the read path's
+        // economics. Asserted in exact integers (12.5 has no exact u64 form,
+        // 25/2 does), never as a float division.
+        let p = StoreCostProfile::reference();
+        assert_eq!(
+            p.put_class_nanodollars * 2,
+            p.get_class_nanodollars * 25,
+            "PUT/GET is exactly 25/2 = 12.5; a drift in either price breaks this \
+             before it silently reprices every modeled figure"
+        );
+    }
+
+    #[test]
+    fn op_classes_put_list_and_get_head_as_s3_bills_them() {
+        // The two non-obvious mappings, which are the whole reason a class
+        // function exists instead of a price per op.
+        assert_eq!(CostedStoreOp::List.class(), StoreOpClass::Put);
+        assert_eq!(CostedStoreOp::ListDelimited.class(), StoreOpClass::Put);
+        assert_eq!(CostedStoreOp::Head.class(), StoreOpClass::Get);
+        assert_eq!(CostedStoreOp::Put.class(), StoreOpClass::Put);
+        assert_eq!(CostedStoreOp::Get.class(), StoreOpClass::Get);
+        assert_eq!(CostedStoreOp::Delete.class(), StoreOpClass::Free);
+
+        let p = StoreCostProfile::reference();
+        assert_eq!(
+            p.op_nanodollars(CostedStoreOp::List),
+            5_000,
+            "a LIST costs a PUT, not a GET"
+        );
+        assert_eq!(p.op_nanodollars(CostedStoreOp::Head), 400);
+        assert_eq!(p.op_nanodollars(CostedStoreOp::Delete), 0);
+
+        // Every variant prices at exactly its class rate, so a new op added to
+        // the mirror of `StoreOp` cannot end up priced by some other path.
+        for op in CostedStoreOp::ALL {
+            assert_eq!(
+                p.op_nanodollars(op),
+                p.class_nanodollars(op.class()),
+                "{op:?} must price at its class rate"
+            );
+        }
+    }
+
+    #[test]
+    fn accounted_op_prices_through_the_same_class_mapping() {
+        // The query path counts AccountedOp; pricing must not need a second
+        // mapping table that could drift from CostedStoreOp::class.
+        let p = StoreCostProfile::reference();
+        assert_eq!(p.op_nanodollars(AccountedOp::Get), 400);
+        assert_eq!(p.op_nanodollars(AccountedOp::Head), 400);
+        assert_eq!(
+            p.op_nanodollars(AccountedOp::List),
+            5_000,
+            "a query's LIST is billed PUT-class like any other"
+        );
+        for op in AccountedOp::ALL {
+            assert_eq!(
+                p.op_nanodollars(op),
+                p.class_nanodollars(CostedStoreOp::from(op).class()),
+                "every AccountedOp prices through CostedStoreOp::class"
+            );
+        }
+    }
+
+    #[test]
+    fn modeled_cost_of_the_cold_pass_fixture_is_exact() {
+        // 149_167 GET-class requests at the reference profile:
+        //   149_167 * 400 = 59_666_800 nanodollars = $0.0596668.
+        // Cross-checked against the price definition rather than the literal:
+        // 149_167 requests at $0.40 per million is 149_167 * 4 / 10 microdollars
+        // = 59_666.8 microdollars = 59_666_800 nanodollars.
+        let p = StoreCostProfile::reference();
+        let modeled = p.modeled_nanodollars(0, 149_167, 0);
+        assert_eq!(modeled, 59_666_800);
+        assert_eq!(
+            modeled,
+            149_167 * p.get_class_nanodollars,
+            "the fixture figure is requests times the GET-class price, nothing else"
+        );
+        assert_eq!(
+            p.modeled_nanodollars(0, 1_000_000, 0),
+            400_000_000,
+            "a million GETs is $0.40 exactly"
+        );
+        assert_eq!(
+            p.modeled_nanodollars(1_000_000, 0, 0),
+            5_000_000_000,
+            "a million PUTs is $5.00 exactly"
+        );
+    }
+
+    #[test]
+    fn modeled_cost_sums_both_classes_and_transfer() {
+        let p = StoreCostProfile {
+            name: "egress-billed".to_string(),
+            put_class_nanodollars: 5_000,
+            get_class_nanodollars: 400,
+            transfer_nanodollars_per_gib: 90_000_000, // $0.09/GiB
+            retrieval_nanodollars_per_gib: 10_000_000,
+        };
+        // 3 PUTs + 7 GETs + exactly 2 GiB transferred.
+        let two_gib = 2 * 1024 * 1024 * 1024;
+        assert_eq!(
+            p.modeled_nanodollars(3, 7, two_gib),
+            15_000 + 2_800 + 180_000_000
+        );
+        assert_eq!(p.retrieval_nanodollars(two_gib), 20_000_000);
+    }
+
+    #[test]
+    fn transfer_proration_truncates_and_never_uses_a_float() {
+        let p = StoreCostProfile {
+            name: "prorate".to_string(),
+            put_class_nanodollars: 0,
+            get_class_nanodollars: 0,
+            transfer_nanodollars_per_gib: 1_000_000_000, // $1/GiB
+            retrieval_nanodollars_per_gib: 0,
+        };
+        // Half a GiB is half a dollar, exactly.
+        assert_eq!(p.modeled_nanodollars(0, 0, 512 * 1024 * 1024), 500_000_000);
+        // One byte is 1e9/2^30 nanodollars = 0.93..., truncated to 0. A bill is
+        // never rounded up by the model.
+        assert_eq!(p.modeled_nanodollars(0, 0, 1), 0);
+        // Two bytes is 1.86..., still truncated to 1.
+        assert_eq!(p.modeled_nanodollars(0, 0, 2), 1);
+    }
+
+    #[test]
+    fn modeled_cost_saturates_instead_of_wrapping() {
+        let p = StoreCostProfile {
+            name: "absurd".to_string(),
+            put_class_nanodollars: u64::MAX,
+            get_class_nanodollars: u64::MAX,
+            transfer_nanodollars_per_gib: u64::MAX,
+            retrieval_nanodollars_per_gib: u64::MAX,
+        };
+        assert_eq!(
+            p.modeled_nanodollars(u64::MAX, u64::MAX, u64::MAX),
+            u64::MAX,
+            "a saturated modeled cost reads as at-least, never wrapping to cheap"
+        );
+        assert_eq!(p.retrieval_nanodollars(u64::MAX), u64::MAX);
+    }
+
+    #[test]
+    fn toml_round_trip_preserves_every_field() {
+        let original = StoreCostProfile {
+            name: "s3-cross-region-test".to_string(),
+            put_class_nanodollars: 5_500,
+            get_class_nanodollars: 440,
+            transfer_nanodollars_per_gib: 20_000_000,
+            retrieval_nanodollars_per_gib: 1_234,
+        };
+        let rendered = original.to_toml_string().expect("render");
+        let parsed = StoreCostProfile::from_toml_str(&rendered).expect("parse");
+        assert_eq!(parsed, original);
+    }
+
+    #[test]
+    fn toml_loads_a_hand_written_document() {
+        let doc = r#"
+name = "s3-intra-region-2026"
+put_class_nanodollars = 5000
+get_class_nanodollars = 400
+transfer_nanodollars_per_gib = 0
+retrieval_nanodollars_per_gib = 0
+"#;
+        let parsed = StoreCostProfile::from_toml_str(doc).expect("parse");
+        assert_eq!(parsed, StoreCostProfile::reference());
+    }
+
+    #[test]
+    fn unknown_field_is_a_typed_error_not_a_silent_default() {
+        // A misspelled price key must fail loudly: accepted-and-ignored would
+        // leave the reference price in force while the report stamps the
+        // operator's file, which is the provenance failure this type prevents.
+        let doc = r#"
+name = "typo"
+put_class_nanodollars = 5000
+get_class_nanodollars = 400
+transfer_nanodollars_per_gib = 0
+retrieval_nanodollars_per_gib = 0
+get_class_nanodollar = 1
+"#;
+        let err = StoreCostProfile::from_toml_str(doc).expect_err("unknown field must be refused");
+        assert!(
+            matches!(err, CostProfileError::Toml(_)),
+            "unknown field is a typed TOML error, got {err:?}"
+        );
+        assert!(
+            err.to_string().contains("get_class_nanodollar"),
+            "the error names the offending key: {err}"
+        );
+    }
+
+    #[test]
+    fn missing_price_and_wrong_type_are_typed_errors() {
+        let missing = StoreCostProfile::from_toml_str("name = \"x\"\n")
+            .expect_err("a missing price must be refused");
+        assert!(matches!(missing, CostProfileError::Toml(_)));
+
+        let float_price = StoreCostProfile::from_toml_str(
+            "name = \"x\"\nput_class_nanodollars = 5000.0\nget_class_nanodollars = 400\n\
+             transfer_nanodollars_per_gib = 0\nretrieval_nanodollars_per_gib = 0\n",
+        )
+        .expect_err("a float price must be refused: nanodollars are integers");
+        assert!(matches!(float_price, CostProfileError::Toml(_)));
+    }
+
+    #[test]
+    fn empty_name_is_refused_so_a_stamp_can_never_be_anonymous() {
+        let doc = r#"
+name = "   "
+put_class_nanodollars = 5000
+get_class_nanodollars = 400
+transfer_nanodollars_per_gib = 0
+retrieval_nanodollars_per_gib = 0
+"#;
+        let err = StoreCostProfile::from_toml_str(doc).expect_err("blank name must be refused");
+        assert!(matches!(err, CostProfileError::EmptyName), "got {err:?}");
+    }
+}

--- a/crates/ravel-types/src/cost_profile.rs
+++ b/crates/ravel-types/src/cost_profile.rs
@@ -44,10 +44,11 @@ pub enum StoreOpClass {
     /// GET/SELECT class, the cheap tier. HEAD bills here: it is a GET request
     /// that returns no body.
     Get,
-    /// Not billed per request. DELETE (and multi-object delete) is free on S3;
-    /// a class rather than a zero price so a caller reading the profile cannot
-    /// mistake "free by contract" for "priced at zero in this config".
-    Free,
+    /// DELETE class, priced by its own field. Zero on the reference S3
+    /// profile, but a PRICED class rather than a hardcoded free tier: prices
+    /// are a deployment property, and an S3-compatible provider that bills
+    /// deletes gets a field to say so instead of a silent zero.
+    Delete,
 }
 
 /// Store operations a cost profile can price. Mirrors
@@ -87,7 +88,7 @@ impl CostedStoreOp {
             CostedStoreOp::Put => StoreOpClass::Put,
             CostedStoreOp::List | CostedStoreOp::ListDelimited => StoreOpClass::Put,
             CostedStoreOp::Get | CostedStoreOp::Head => StoreOpClass::Get,
-            CostedStoreOp::Delete => StoreOpClass::Free,
+            CostedStoreOp::Delete => StoreOpClass::Delete,
         }
     }
 }
@@ -126,6 +127,11 @@ pub struct StoreCostProfile {
     pub put_class_nanodollars: u64,
     /// Nanodollars per GET-class request (GET/SELECT/HEAD).
     pub get_class_nanodollars: u64,
+    /// Nanodollars per DELETE-class request. `0` on the reference S3 profile
+    /// (DELETE is free there); a field rather than a constant because other
+    /// providers bill it.
+    #[serde(default)]
+    pub delete_class_nanodollars: u64,
     /// Nanodollars per GiB transferred out. `0` on an intra-region deployment,
     /// which is what makes request-minimal fetching the cost-preferring shape
     /// there.
@@ -144,6 +150,7 @@ const S3_INTRA_REGION_2026_PRICES: StoreCostProfile = StoreCostProfile {
     name: String::new(),
     put_class_nanodollars: 5_000,
     get_class_nanodollars: 400,
+    delete_class_nanodollars: 0,
     transfer_nanodollars_per_gib: 0,
     retrieval_nanodollars_per_gib: 0,
 };
@@ -189,7 +196,7 @@ impl StoreCostProfile {
         match class {
             StoreOpClass::Put => self.put_class_nanodollars,
             StoreOpClass::Get => self.get_class_nanodollars,
-            StoreOpClass::Free => 0,
+            StoreOpClass::Delete => self.delete_class_nanodollars,
         }
     }
 
@@ -322,7 +329,13 @@ mod tests {
         assert_eq!(CostedStoreOp::Head.class(), StoreOpClass::Get);
         assert_eq!(CostedStoreOp::Put.class(), StoreOpClass::Put);
         assert_eq!(CostedStoreOp::Get.class(), StoreOpClass::Get);
-        assert_eq!(CostedStoreOp::Delete.class(), StoreOpClass::Free);
+        assert_eq!(CostedStoreOp::Delete.class(), StoreOpClass::Delete);
+        // Priced class, zero PRICE on the reference profile: a provider that
+        // bills deletes overrides the field, never a hardcoded free tier.
+        assert_eq!(
+            StoreCostProfile::reference().op_nanodollars(CostedStoreOp::Delete),
+            0
+        );
 
         let p = StoreCostProfile::reference();
         assert_eq!(
@@ -398,6 +411,7 @@ mod tests {
             name: "egress-billed".to_string(),
             put_class_nanodollars: 5_000,
             get_class_nanodollars: 400,
+            delete_class_nanodollars: 0,
             transfer_nanodollars_per_gib: 90_000_000, // $0.09/GiB
             retrieval_nanodollars_per_gib: 10_000_000,
         };
@@ -416,6 +430,7 @@ mod tests {
             name: "prorate".to_string(),
             put_class_nanodollars: 0,
             get_class_nanodollars: 0,
+            delete_class_nanodollars: 0,
             transfer_nanodollars_per_gib: 1_000_000_000, // $1/GiB
             retrieval_nanodollars_per_gib: 0,
         };
@@ -434,6 +449,7 @@ mod tests {
             name: "absurd".to_string(),
             put_class_nanodollars: u64::MAX,
             get_class_nanodollars: u64::MAX,
+            delete_class_nanodollars: u64::MAX,
             transfer_nanodollars_per_gib: u64::MAX,
             retrieval_nanodollars_per_gib: u64::MAX,
         };
@@ -451,6 +467,7 @@ mod tests {
             name: "s3-cross-region-test".to_string(),
             put_class_nanodollars: 5_500,
             get_class_nanodollars: 440,
+            delete_class_nanodollars: 0,
             transfer_nanodollars_per_gib: 20_000_000,
             retrieval_nanodollars_per_gib: 1_234,
         };

--- a/crates/ravel-types/src/lib.rs
+++ b/crates/ravel-types/src/lib.rs
@@ -7,6 +7,7 @@
 //! string, never an in-place edit.
 
 pub mod accounting;
+pub mod cost_profile;
 pub mod declared_stats;
 pub mod exemplar;
 pub mod logstream;

--- a/proto/ravel/queryfrag.proto
+++ b/proto/ravel/queryfrag.proto
@@ -543,4 +543,11 @@ message QueryAccountingSnapshot {
   uint64 series_matched = 13;
   uint64 bytes_reused = 14;
   uint64 peak_intermediate_bytes = 15;
+  // Distinct data objects whose BLOCKS bytes this slice fetched (ADR-0996
+  // decision 3, the range-amplification denominator). Additive field: slices
+  // partition by (tenant, signal, shard), an object belongs to exactly one
+  // shard, so slice object sets are disjoint and summation is exact. An old
+  // peer omits it and it decodes as 0, degrading the merged figure to the
+  // coordinator's own count, never inflating it.
+  uint64 data_objects_touched = 16;
 }


### PR DESCRIPTION
Epic #996 task 996-1. StoreCostProfile carries the request-class prices
as integer nanodollars with an exhaustive op-class mapping (DELETE its
own priced class, zero on the reference profile), a TOML loader that
refuses unknown fields, and a saturating modeled-cost helper; the
reference profile pins $5/M PUT-class, $0.40/M GET-class, and the
12.5:1 ratio as its own test. QueryAccounting gains
data_objects_touched, the range-amplification denominator, counted once
per distinct data object whose BLOCKS bytes a query fetched.

Refs: #996
