### PR TITLE
feat(maintain): release part bytes at PUT, verify AlreadyExists after publish

### DIFF
--- a/crates/ravel-maintain/src/build.rs
+++ b/crates/ravel-maintain/src/build.rs
@@ -106,11 +106,46 @@ pub const OUTPUT_FORMAT_VERSION: u32 = ravel_segment::SUPPORTED_VERSIONS.newest(
 
 /// One built (not yet published) L1 part: its content-addressed key, its
 /// bytes, and the [`CompactionPart`] describing it for the record.
+///
+/// `bytes` is `Option<Bytes>` (ADR-0979 decision 3): a caller that retains the
+/// encoded bytes for its own publish path (the erasure rewrite, and for now the
+/// RSEG/RSPAN codecs) carries `Some`; the bounded RLOG compaction path releases
+/// them the moment the part's PUT succeeds and carries `None`, so the
+/// retained-parts memory term goes to zero instead of scaling with the bucket's
+/// whole L1 output. A `None`-bytes part cannot be re-PUT by the convergence
+/// repair path, which is sound on the compaction path because every part is PUT
+/// (content-addressed) before the record is; see
+/// [`crate::publish::resolve_already_exists`].
+///
+/// `put_already_existed` records that this part's `CreateIfAbsent` PUT answered
+/// `AlreadyExists` (the content-addressed key was already present from an
+/// abandoned run). Such a part's stored `last_modified` is the abandoned run's,
+/// so it can be inside the unreferenced-part sweep's age gate and a racing
+/// tenant tombstone can delete it between our PUT and our record PUT. The
+/// bounded compaction path drops its bytes anyway (retaining them for every
+/// `AlreadyExists` part would recreate the whole-output term D3 exists to kill,
+/// in exactly the abandoned-run-retry case) and instead HEAD-verifies these
+/// parts after the record PUT succeeds
+/// ([`crate::publish::verify_already_existed_parts`]). The flag is only set on
+/// the bounded RLOG compaction path; every other constructor leaves it `false`.
 #[derive(Debug, Clone)]
 pub struct BuiltPart {
     pub key: String,
-    pub bytes: Bytes,
+    pub bytes: Option<Bytes>,
     pub part: CompactionPart,
+    pub put_already_existed: bool,
+}
+
+/// The outcome of a part's `CreateIfAbsent` PUT: whether it created the object
+/// or found the content-addressed key already present (an abandoned run's
+/// byte-identical part). [`put_part`] returns it so the bounded compaction path
+/// can flag an `AlreadyExists` part for post-publish HEAD verification (ADR-0979
+/// decision 3); most callers discard it (they retain bytes and repair from
+/// them, so the distinction does not change their behaviour).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PartPut {
+    Created,
+    AlreadyExisted,
 }
 
 /// Merge all inputs into size-capped run-merged RSEG v7 parts. `catalogs` MUST
@@ -1078,26 +1113,40 @@ fn flush_part(
     };
     Ok(BuiltPart {
         key,
-        bytes: written.bytes,
+        bytes: Some(written.bytes),
         part,
+        put_already_existed: false,
     })
 }
 
 /// PUT one part `CreateIfAbsent`; `AlreadyExists` is idempotent success (the
 /// key embeds the content hash, so the stored bytes are identical by
-/// construction).
-pub async fn put_part(store: &dyn ObjectStoreBackend, part: &BuiltPart) -> Result<()> {
+/// construction). Returns [`PartPut`] naming which of the two happened, so the
+/// bounded compaction path can flag an `AlreadyExists` part for post-publish
+/// verification (ADR-0979 decision 3).
+///
+/// The part's bytes must still be present: this is only ever called at PUT
+/// time, before any release, so a `None` here is an internal invariant breach
+/// rather than a store fault.
+pub async fn put_part(store: &dyn ObjectStoreBackend, part: &BuiltPart) -> Result<PartPut> {
     use ravel_object_store::{PutOptions, StoreError, UploadChecksum};
-    let checksum = UploadChecksum::Crc32c(crc32c::crc32c(&part.bytes));
+    let bytes = part.bytes.as_ref().ok_or_else(|| {
+        MaintainError::Invariant(format!(
+            "put_part called on part {} whose bytes were already released",
+            part.key
+        ))
+    })?;
+    let checksum = UploadChecksum::Crc32c(crc32c::crc32c(bytes));
     match store
         .put(
             &part.key,
-            part.bytes.clone(),
+            bytes.clone(),
             PutOptions::create_if_absent().with_checksum(checksum),
         )
         .await
     {
-        Ok(_) | Err(StoreError::AlreadyExists) => Ok(()),
+        Ok(_) => Ok(PartPut::Created),
+        Err(StoreError::AlreadyExists) => Ok(PartPut::AlreadyExisted),
         Err(e) => Err(MaintainError::Store(e)),
     }
 }

--- a/crates/ravel-maintain/src/config.rs
+++ b/crates/ravel-maintain/src/config.rs
@@ -63,8 +63,10 @@ use uuid::Uuid;
 /// - in-progress part writer ([`Self::peak_writer_bytes`]): the current part's
 ///   accumulated records, decoded heap.
 /// - retained closed parts ([`Self::add_retained_part_bytes`]): the encoded
-///   bytes of every part already PUT but still held until publish. This is the
-///   term the issue existed to expose; it was invisible before.
+///   bytes of every closed part still held resident until publish. Since
+///   ADR-0979 decision 3 the bounded RLOG compaction path releases each part's
+///   bytes at PUT, so this term is ZERO there; it is nonzero only for a path
+///   that defers its PUTs and keeps the bytes (the erasure rewrite).
 /// - finish and publish ([`Self::set_publish_record_bytes`]): the encoded
 ///   compaction-record payload, the only allocation the publish phase adds on
 ///   top of the retained parts.
@@ -109,9 +111,10 @@ struct MergeMemoryInner {
     /// `max_l1_part_bytes` (the stored-size target fired).
     stored_target_flushes: AtomicU64,
     /// Live sum of the encoded/on-object bytes of closed parts still retained in
-    /// [`crate::rlog::PartSink::parts`] (PUT already, not yet dropped).
-    /// Monotonic within a run: parts are held until publish, so this never
-    /// decrements before the run ends.
+    /// [`crate::rlog::PartSink::parts`] after PUT. Zero on the bounded RLOG
+    /// compaction path, which releases each part's bytes at PUT (ADR-0979
+    /// decision 3); nonzero and monotonic within a run only for a path that
+    /// keeps the bytes until its own deferred publish (the erasure rewrite).
     retained_parts: AtomicU64,
     /// High-water of `retained_parts`.
     peak_retained_parts: AtomicU64,
@@ -148,9 +151,11 @@ pub struct MergePhasePeaks {
     /// In-progress part writer: high-water of the current part builder's
     /// accumulated records. Decoded heap bytes.
     pub writer_heap_bytes: u64,
-    /// Retained closed parts: high-water of the encoded bytes of parts already
-    /// PUT but still held in [`crate::rlog::PartSink::parts`] until publish.
-    /// Encoded/on-object bytes. The term issue #977 made visible.
+    /// Retained closed parts: high-water of the encoded bytes of closed parts
+    /// still held in [`crate::rlog::PartSink::parts`] until publish.
+    /// Encoded/on-object bytes. Zero on the bounded compaction path, which
+    /// releases each part's bytes at PUT (ADR-0979 decision 3); nonzero only for
+    /// a deferred-PUT path that keeps them (the erasure rewrite).
     pub retained_part_encoded_bytes: u64,
     /// Finish and publish: the published compaction record's encoded protobuf
     /// payload, the only allocation the publish phase adds on top of the
@@ -207,13 +212,14 @@ impl MergeMemoryTracker {
         self.inner.peak_writer.fetch_max(writer, Ordering::Relaxed);
     }
 
-    /// Account `bytes` of encoded part bytes retained in
-    /// [`crate::rlog::PartSink::parts`] when a closed part is pushed there. The
-    /// part was already PUT; it stays resident until publish, so this is never
-    /// released within a run and its high-water is the retained-parts plateau a
-    /// large-bucket compaction sits at. Encoded/on-object bytes, not heap; it is
-    /// deliberately a separate term from the writer's decoded-heap bytes so a
-    /// report never folds the two together.
+    /// Account `bytes` of encoded part bytes still resident in
+    /// [`crate::rlog::PartSink::parts`] after a closed part is PUT. On the
+    /// bounded compaction path `bytes` is 0, because the part's bytes were
+    /// released at PUT (ADR-0979 decision 3), so this term stays flat at zero;
+    /// on a deferred-PUT path (the erasure rewrite) `bytes` is the part's encoded
+    /// size and the high-water is the retained-parts plateau. Encoded/on-object
+    /// bytes, not heap; it is deliberately a separate term from the writer's
+    /// decoded-heap bytes so a report never folds the two together.
     pub fn add_retained_part_bytes(&self, bytes: u64) {
         let updated = self
             .inner

--- a/crates/ravel-maintain/src/erasure_rewrite.rs
+++ b/crates/ravel-maintain/src/erasure_rewrite.rs
@@ -1150,8 +1150,12 @@ fn build_rewrite_part(
     };
     Ok(BuiltPart {
         key,
-        bytes: written.bytes,
+        // The erasure rewrite retains part bytes until its own publish path PUTs
+        // them (ADR-0979 decision 3); it never routes through the drop-at-PUT
+        // compaction path, so `put_already_existed` stays false.
+        bytes: Some(written.bytes),
         part,
+        put_already_existed: false,
     })
 }
 
@@ -1250,6 +1254,10 @@ pub async fn build_rewrite_logs(
         &catalogs,
         input_set_hash,
         Vec::new(),
+        true,
+        // retain_bytes: true -- the erasure rewrite keeps each closed part's
+        // bytes resident because `publish_rewrite_record` is what PUTs them,
+        // after the conservation gate passes (ADR-0979 decision 3).
         true,
         &mut |record| match first_dropping_log_request(requests, &record.attrs, record.ts_ns) {
             Some(i) => {

--- a/crates/ravel-maintain/src/error.rs
+++ b/crates/ravel-maintain/src/error.rs
@@ -81,6 +81,14 @@ pub enum MaintainError {
         /// independent authority the decode tally is checked against.
         footer_record_count: u64,
     },
+    #[error(
+        "compaction part {part_key:?} answered AlreadyExists at PUT (an abandoned run had already uploaded it) but was gone when HEAD-verified after the record PUT: a tenant tombstone or the unreferenced-part sweep deleted it in the window between our existence check and our record PUT, and the bounded compactor released its bytes so it cannot be re-PUT from RAM (ADR-0979 decision 3). Re-run the compaction: the rerun rebuilds the byte-identical part and its PUT of the now-absent key is a fresh put that restores it before the record resolves, so the rerun converges with nothing to repair"
+    )]
+    AlreadyExistsPartVanished {
+        /// Object key of the part that answered `AlreadyExists` at PUT but was
+        /// absent at post-publish HEAD verification.
+        part_key: String,
+    },
     #[error("compaction invariant breach: {0}")]
     Invariant(String),
     #[error(

--- a/crates/ravel-maintain/src/error.rs
+++ b/crates/ravel-maintain/src/error.rs
@@ -89,6 +89,14 @@ pub enum MaintainError {
         /// absent at post-publish HEAD verification.
         part_key: String,
     },
+    #[error(
+        "compaction converged on a prior record that references part {part_key:?}, which is absent and cannot be repaired from this run (its bytes were released at PUT under bounded compaction, or this run never built it). Reporting convergence here would leave a published record pointing at a hole that later L0 cleanup turns into data loss. Re-run the compaction: the rerun rebuilds the byte-identical part and its PUT of the now-absent key is a fresh put that restores it before the record resolves"
+    )]
+    ConvergedWinnerPartMissing {
+        /// Object key the winner record references that answered NotFound at
+        /// convergence HEAD verification and could not be re-PUT from RAM.
+        part_key: String,
+    },
     #[error("compaction invariant breach: {0}")]
     Invariant(String),
     #[error(

--- a/crates/ravel-maintain/src/publish.rs
+++ b/crates/ravel-maintain/src/publish.rs
@@ -23,7 +23,11 @@ pub enum PublishOutcome {
     /// This run's `CreateIfAbsent` landed the record; we are the winner.
     Published,
     /// A prior or racing run already published an equivalent record (same
-    /// `input_set_hash`); we HEAD-and-repaired its parts and converged.
+    /// `input_set_hash`); we HEAD-verified its parts, re-PUT any we could,
+    /// and every referenced part is present. A part that is missing and not
+    /// repairable from this run is a typed
+    /// [`crate::MaintainError::ConvergedWinnerPartMissing`], never this
+    /// variant: `Converged` means whole, not merely resolved.
     Converged { parts_repaired: usize },
     /// The `max_compaction_lifetime` deadline passed before the record PUT;
     /// the run abandoned and did NOT publish. Its parts
@@ -265,7 +269,10 @@ fn checked_sample_sum(counts: impl Iterator<Item = u64>) -> Result<u64> {
 
 /// GET the record that beat us. Same `input_set_hash`: HEAD every part it
 /// references and re-PUT any our-built part that is missing (content-addressed
-/// keys make this safe), then report convergence. Different `input_set_hash`:
+/// keys make this safe), then report convergence. A missing part this run
+/// cannot re-PUT (bytes released at PUT, or never built here) is a typed
+/// [`MaintainError::ConvergedWinnerPartMissing`], never a silent convergence:
+/// the record would reference an absent object. Different `input_set_hash`:
 /// a sealed bucket cannot legitimately hold two input sets, so alarm and stop
 /// without deleting anything.
 async fn resolve_already_exists(
@@ -305,20 +312,16 @@ async fn resolve_already_exists(
                         crate::build::put_part(store, ours).await?;
                         repaired += 1;
                     }
-                    Some(_) => {
-                        tracing::warn!(
-                            key = %part_key,
-                            "winner references a part this run built but whose bytes were released \
-                             at PUT (bounded compaction); cannot repair from RAM. Re-run the \
-                             compaction to rebuild and re-PUT it"
-                        );
-                    }
-                    None => {
-                        tracing::warn!(
-                            key = %part_key,
-                            "winner references a part this run did not build; cannot repair. \
-                             Re-run the compaction to rebuild and re-PUT it"
-                        );
+                    // Cannot repair (bytes released at PUT, or a part this run
+                    // never built): fail closed. Returning Converged here would
+                    // hand the driver a whole bucket over a record that
+                    // references an absent object, and later L0 cleanup turns
+                    // that hole into data loss. The typed error carries the
+                    // remedy (re-run; the rerun's fresh PUT restores the key),
+                    // matching the fresh-record arm's
+                    // AlreadyExistsPartVanished loudness.
+                    Some(_) | None => {
+                        return Err(MaintainError::ConvergedWinnerPartMissing { part_key });
                     }
                 }
             }

--- a/crates/ravel-maintain/src/publish.rs
+++ b/crates/ravel-maintain/src/publish.rs
@@ -204,6 +204,14 @@ pub async fn publish_record_with_conservation(
 
     match store.put(&record_key, payload.into(), opts).await {
         Ok(_) => {
+            // The tombstone race is closed by verification, not retention
+            // (ADR-0979 decision 3): a part that answered `AlreadyExists` at PUT
+            // carries an abandoned run's age and could have been swept between
+            // our existence check and this record PUT. HEAD-verify exactly those
+            // parts now that the record is durable; a missing one fails loud with
+            // a re-runnable typed error rather than leaving the record pointing
+            // at a part the bounded compactor can no longer repair.
+            verify_already_existed_parts(store, parts).await?;
             tracing::info!(key = %record_key, parts = parts.len(), "compaction record published");
             Ok(PublishOutcome::Published)
         }
@@ -212,6 +220,34 @@ pub async fn publish_record_with_conservation(
         }
         Err(e) => Err(MaintainError::Store(e)),
     }
+}
+
+/// HEAD every part whose PUT answered `AlreadyExists` (ADR-0979 decision 3),
+/// after the compaction record that references them has been published. A
+/// fresh-PUT part is age-zero and unreachable by the unreferenced-part sweep
+/// for the run's whole duration, so it needs no check; an `AlreadyExists` part
+/// carries an abandoned run's `last_modified` and can be inside the sweep's age
+/// gate, so a tenant tombstone landing mid-run can delete it. If one is missing,
+/// the run failed to make the record whole and cannot repair from RAM (the
+/// bytes were released), so it fails loud with
+/// [`MaintainError::AlreadyExistsPartVanished`]; the re-run converges by
+/// re-PUTting the byte-identical part before the record resolves.
+async fn verify_already_existed_parts(
+    store: &dyn ObjectStoreBackend,
+    parts: &[BuiltPart],
+) -> Result<()> {
+    for part in parts.iter().filter(|p| p.put_already_existed) {
+        match store.head(&part.key).await {
+            Ok(_) => {}
+            Err(StoreError::NotFound) => {
+                return Err(MaintainError::AlreadyExistsPartVanished {
+                    part_key: part.key.clone(),
+                });
+            }
+            Err(e) => return Err(MaintainError::Store(e)),
+        }
+    }
+    Ok(())
 }
 
 /// Sum `sample_count`s in u64 with checked addition; an overflowing sum is
@@ -259,14 +295,31 @@ async fn resolve_already_exists(
         match store.head(&part_key).await {
             Ok(_) => {}
             Err(StoreError::NotFound) => {
-                if let Some(ours) = our_parts.iter().find(|p| p.key == part_key) {
-                    crate::build::put_part(store, ours).await?;
-                    repaired += 1;
-                } else {
-                    tracing::warn!(
-                        key = %part_key,
-                        "winner references a part this run did not build; cannot repair"
-                    );
+                // Re-PUT only a part whose bytes we still hold. A bounded
+                // compaction loser released its bytes at PUT (ADR-0979 decision
+                // 3, `bytes` is `None`), so it takes the cannot-repair arm; the
+                // record is still the truth and re-running the compaction from
+                // scratch rebuilds and re-PUTs the byte-identical part.
+                match our_parts.iter().find(|p| p.key == part_key) {
+                    Some(ours) if ours.bytes.is_some() => {
+                        crate::build::put_part(store, ours).await?;
+                        repaired += 1;
+                    }
+                    Some(_) => {
+                        tracing::warn!(
+                            key = %part_key,
+                            "winner references a part this run built but whose bytes were released \
+                             at PUT (bounded compaction); cannot repair from RAM. Re-run the \
+                             compaction to rebuild and re-PUT it"
+                        );
+                    }
+                    None => {
+                        tracing::warn!(
+                            key = %part_key,
+                            "winner references a part this run did not build; cannot repair. \
+                             Re-run the compaction to rebuild and re-PUT it"
+                        );
+                    }
                 }
             }
             Err(e) => return Err(MaintainError::Store(e)),
@@ -327,7 +380,8 @@ mod tests {
     fn part(index: u32, sample_count: u64) -> BuiltPart {
         BuiltPart {
             key: format!("part/{index}"),
-            bytes: bytes::Bytes::new(),
+            bytes: Some(bytes::Bytes::new()),
+            put_already_existed: false,
             part: CompactionPart {
                 part_index: index,
                 content_hash: vec![0u8; 32],

--- a/crates/ravel-maintain/src/rewrite.rs
+++ b/crates/ravel-maintain/src/rewrite.rs
@@ -954,7 +954,8 @@ mod tests {
         // irrelevant to the publish gate, which reads `part.sample_count`.
         let part = BuiltPart {
             key: "l1/synthetic".to_string(),
-            bytes: Bytes::new(),
+            bytes: Some(Bytes::new()),
+            put_already_existed: false,
             part: CompactionPart {
                 part_index: 0,
                 content_hash: vec![0u8; 32],

--- a/crates/ravel-maintain/src/rlog.rs
+++ b/crates/ravel-maintain/src/rlog.rs
@@ -289,6 +289,11 @@ impl SegmentCodec for RlogCodec {
             input_set_hash,
             indexed_fields,
             config.dry_run,
+            // Compaction releases each part's bytes at PUT (ADR-0979 decision 3):
+            // the retained-parts memory term goes to zero, and an `AlreadyExists`
+            // part is HEAD-verified after the record PUT instead of repaired from
+            // RAM.
+            false,
             &mut |_| Ok(true),
         )
         .await?;
@@ -447,6 +452,14 @@ pub(crate) struct MergeOutput {
 /// `dry_run` decides whether each part is PUT as it closes: compaction PUTs
 /// here, while the erasure rewrite defers every PUT to its own publish path,
 /// which writes parts only after its conservation gate passes.
+///
+/// `retain_bytes` decides whether each closed part keeps its encoded bytes
+/// resident until publish (ADR-0979 decision 3). Compaction passes `false` and
+/// releases them at PUT (the retained-parts memory term goes to zero); the
+/// erasure rewrite passes `true` because its deferred publish path is what PUTs
+/// them. When compaction's part PUT answers `AlreadyExists`, the returned
+/// [`BuiltPart::put_already_existed`] flags it for the caller's post-publish
+/// HEAD verification, since a dropped-bytes part cannot be repaired from RAM.
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn merge_catalogs(
     store: &dyn ObjectStoreBackend,
@@ -456,6 +469,7 @@ pub(crate) async fn merge_catalogs(
     input_set_hash: &[u8; 32],
     indexed_fields: Vec<String>,
     dry_run: bool,
+    retain_bytes: bool,
     keep: &mut (dyn FnMut(&LogRecord) -> Result<bool> + Send),
 ) -> Result<MergeOutput> {
     // Global stream_ref remap + cross-object stream-identity check. The
@@ -500,6 +514,7 @@ pub(crate) async fn merge_catalogs(
         indexed_fields,
         tracker,
         dry_run,
+        retain_bytes,
         current: None,
         parts: Vec::new(),
         part_index: 0,
@@ -594,6 +609,12 @@ struct PartSink<'a> {
     /// writes them only after its conservation gate passes) while running with
     /// a config whose `dry_run` is false.
     dry_run: bool,
+    /// Whether each closed part keeps its encoded bytes resident until publish
+    /// (ADR-0979 decision 3). Compaction releases them at PUT (`false`), so the
+    /// retained-parts memory term is zero; the erasure rewrite keeps them
+    /// (`true`) because its own publish path PUTs them after its conservation
+    /// gate.
+    retain_bytes: bool,
     current: Option<PartBuilder>,
     parts: Vec<BuiltPart>,
     part_index: u32,
@@ -652,15 +673,21 @@ impl PartSink<'_> {
                     self.input_set_hash,
                     self.part_index,
                     self.dry_run,
+                    self.retain_bytes,
                 )
                 .await?;
-            let retained = built.bytes.len() as u64;
+            // Only bytes actually retained past PUT count toward the
+            // retained-parts term. On the compaction path (`retain_bytes =
+            // false`) `finalize_part` released them at PUT, so this is 0 and the
+            // term stays flat at zero (ADR-0979 decision 3); the erasure rewrite
+            // (`retain_bytes = true`) still charges each closed part's encoded
+            // size, unchanged.
+            let retained = built.bytes.as_ref().map_or(0, |b| b.len() as u64);
             self.parts.push(built);
             self.part_index += 1;
             if let Some(t) = self.tracker {
-                // The part is PUT but its encoded bytes stay resident in
-                // `self.parts` until publish. Charge the retained-parts term
-                // (encoded bytes) and clear the writer term (its decoded-heap
+                // Charge whatever encoded bytes remain resident in `self.parts`
+                // until publish, and clear the writer term (its decoded-heap
                 // records were handed to the writer and released on encode).
                 t.add_retained_part_bytes(retained);
                 t.set_writer_bytes(0);
@@ -760,6 +787,7 @@ impl PartBuilder {
 
     /// Encode and PUT the part through the shared writer pipeline. See
     /// [`finalize_part`] for the encode/summary/PUT detail this reuses.
+    #[allow(clippy::too_many_arguments)]
     async fn finish(
         self,
         store: &dyn ObjectStoreBackend,
@@ -767,6 +795,7 @@ impl PartBuilder {
         input_set_hash: &[u8; 32],
         part_index: u32,
         dry_run: bool,
+        retain_bytes: bool,
     ) -> Result<BuiltPart> {
         finalize_part(
             store,
@@ -777,6 +806,7 @@ impl PartBuilder {
             input_set_hash,
             part_index,
             dry_run,
+            retain_bytes,
         )
         .await
     }
@@ -1160,6 +1190,7 @@ pub(crate) async fn finalize_part(
     input_set_hash: &[u8; 32],
     part_index: u32,
     dry_run: bool,
+    retain_bytes: bool,
 ) -> Result<BuiltPart> {
     let (object, stats) =
         writer.finish_compacted_with_stats(1, input_set_hash.to_vec(), part_index)?;
@@ -1204,13 +1235,31 @@ pub(crate) async fn finalize_part(
         segment_format_version: OUTPUT_FORMAT_VERSION,
         declared_column_stats: Vec::new(),
     };
-    let built = BuiltPart {
+    let mut built = BuiltPart {
         key,
-        bytes: object,
+        bytes: Some(object),
         part,
+        put_already_existed: false,
     };
     if !dry_run {
-        put_part(store, &built).await?;
+        match put_part(store, &built).await? {
+            crate::build::PartPut::Created => {}
+            crate::build::PartPut::AlreadyExisted => built.put_already_existed = true,
+        }
+    }
+    // Release the encoded bytes unless the caller retains them for its own
+    // deferred publish path (ADR-0979 decision 3). Compaction passes
+    // `retain_bytes = false`: a fresh PUT's part is age-zero and unreachable by
+    // the unreferenced-part sweep, so its in-RAM copy was belt-and-braces, not a
+    // correctness dependency; an `AlreadyExists` part is instead HEAD-verified
+    // after the record PUT (its bytes are dropped here too, since retaining
+    // every such part on an abandoned-run retry would recreate the whole-output
+    // term this decision removes). Under `dry_run` nothing is ever PUT, so the
+    // drop happens at close. The erasure rewrite passes `retain_bytes = true`:
+    // it defers every PUT to its own post-conservation-gate publish path, so the
+    // bytes are the product itself.
+    if !retain_bytes {
+        built.bytes = None;
     }
     Ok(built)
 }

--- a/crates/ravel-maintain/src/rspan_codec.rs
+++ b/crates/ravel-maintain/src/rspan_codec.rs
@@ -761,10 +761,15 @@ pub(crate) async fn finalize_part(
         segment_format_version: OUTPUT_FORMAT_VERSION,
         declared_column_stats: Vec::new(),
     };
+    // RSPAN keeps its current retention behaviour (ADR-0979 decision 3 wraps the
+    // bytes in `Some` mechanically; the bounded-memory fix for this codec is a
+    // follow-up, #982), so `put_already_existed` stays false and the bytes are
+    // never released here.
     let built = BuiltPart {
         key,
-        bytes: object,
+        bytes: Some(object),
         part,
+        put_already_existed: false,
     };
     if !dry_run {
         put_part(store, &built).await?;

--- a/crates/ravel-maintain/tests/memory.rs
+++ b/crates/ravel-maintain/tests/memory.rs
@@ -193,30 +193,31 @@ async fn peak_memory_on_rlog_input_bucket() {
     }
 }
 
-/// Issue #977: the retained closed parts are attributed to their OWN phase term
-/// and are NOT folded into the writer term.
+/// ADR-0979 decision 3: on the RLOG compaction path the retained-parts memory
+/// term is ZERO, because each closed part's encoded bytes are released the
+/// moment its PUT succeeds rather than held in `PartSink::parts` until publish.
 ///
-/// A logs compaction under a small stored-size target closes many L1 parts.
-/// Every closed part is PUT but its encoded bytes stay resident in
-/// `PartSink::parts` until publish; that retained residency is the plateau a
-/// large-bucket compaction sits at, and before this ticket it was invisible in
-/// the [`MergeMemoryTracker`]. This drives a compaction that closes at least
-/// three parts and asserts the tracker's retained-parts high-water equals the
-/// EXACT sum of those parts' encoded object sizes (read back from the published
-/// record's `object_size`, which `finalize_part` sets to the same bytes it
-/// retains). The value is derivable, so it is pinned exactly, not bounded.
+/// This is the update to the #977 test that used to pin the retained-parts
+/// high-water to the EXACT sum of the parts' encoded object sizes: that sum was
+/// the plateau a large-bucket compaction sat at, and D3 removes it. The new
+/// truth is the exact figure the charge site now produces. `finalize_part`
+/// releases `built.bytes` at PUT under `retain_bytes = false` (compaction), so
+/// `PartSink::flush` reads `built.bytes.as_ref().map_or(0, ..)` == 0 and charges
+/// `t.add_retained_part_bytes(0)` for every part; the high-water never leaves
+/// zero. It is pinned exactly (== 0), not bounded, and derived from the charge
+/// site, not the fixture's byte totals -- the parts still carry real bytes
+/// (their `object_size` is nonzero), and the point is that none of those bytes
+/// stay resident.
 ///
-/// Non-vacuity / flip proof: the retained bytes are charged at `rlog.rs`'s
-/// `PartSink::flush`, in the line `t.add_retained_part_bytes(retained);`.
-/// Deleting that line (attributing nothing to the retained phase, i.e. leaving
-/// the bytes accounted only through the writer term that `set_writer_bytes`
-/// drives) makes `peak_retained_part_bytes()` stay 0, and the exact-equality
-/// assertion below fails `0 != <sum>`. Rerouting it to `t.set_writer_bytes(
-/// retained)` (folding the retained bytes into the writer phase, the bug this
-/// test exists to catch) fails the same way. Verified failing both ways before
-/// restoring.
+/// Non-vacuity / flip proof: against the pre-D3 code (where `finalize_part`
+/// returned `bytes: object` and never released it, and `PartSink::flush` charged
+/// `built.bytes.len()`), `peak_retained_part_bytes()` equals the nonzero sum of
+/// the parts' `object_size`, so the `== 0` assertion below fails
+/// `<sum> != 0`. The flip is the exact behaviour D3 changes: retention at PUT
+/// vs release at PUT. The other phases are still asserted driven, so a merge
+/// that silently did nothing would fail here too.
 #[tokio::test]
-async fn retained_parts_are_attributed_to_their_own_phase() {
+async fn compaction_retains_no_part_bytes() {
     const INPUTS: usize = 24;
     const STREAMS: u32 = 4;
     const RECORDS_PER_STREAM: usize = 4;
@@ -264,34 +265,28 @@ async fn retained_parts_are_attributed_to_their_own_phase() {
         "the small stored target must close at least three parts, got {}",
         record.parts.len()
     );
+    // The parts really do carry bytes; the point is none of them stay resident.
+    let part_bytes_sum: u64 = record.parts.iter().map(|p| p.object_size).sum();
+    assert!(
+        part_bytes_sum > 0,
+        "the parts must carry real encoded bytes for the release to be meaningful"
+    );
 
-    // The retained-parts phase term equals the exact encoded size of every part
-    // the merge held: each `object_size` is the byte length `finalize_part`
-    // retained in `PartSink::parts`, and every closed part is retained until
-    // publish, so the high-water is their sum.
-    let expected_retained: u64 = record.parts.iter().map(|p| p.object_size).sum();
+    // The exact new truth: the retained-parts high-water is zero, because every
+    // part's bytes were released at PUT (D3), not held until publish.
     assert_eq!(
         tracker.peak_retained_part_bytes(),
-        expected_retained,
-        "retained-parts high-water must equal the exact sum of the parts' encoded sizes"
+        0,
+        "compaction must retain no part bytes; each is released at PUT (ADR-0979 D3)"
     );
 
-    // The retained term is its own phase, not the writer term. The writer term
-    // is decoded Rust heap of one in-progress part at a time; the retained term
-    // is the encoded bytes of every closed part at once. Read them back from the
-    // phase split and confirm the split reports the retained sum under the
-    // retained field, and the writer field is a different (heap) quantity that
-    // does not carry the retained bytes.
     let peaks = tracker.phase_peaks();
     assert_eq!(
-        peaks.retained_part_encoded_bytes, expected_retained,
-        "phase_peaks must carry the retained sum in its retained field"
+        peaks.retained_part_encoded_bytes, 0,
+        "phase_peaks must report zero retained bytes on the compaction path"
     );
-    assert_ne!(
-        peaks.retained_part_encoded_bytes, peaks.writer_heap_bytes,
-        "retained (encoded, all parts) must not be folded into writer (heap, one part)"
-    );
-    // Sanity: the merge really exercised the other phases too.
+    // Sanity: the merge really exercised the other phases too, so the zero above
+    // is a real release, not an inert run.
     assert!(
         peaks.writer_heap_bytes > 0,
         "the in-progress writer term must have been driven"
@@ -305,7 +300,8 @@ async fn retained_parts_are_attributed_to_their_own_phase() {
         "the finish/publish term must have been driven"
     );
     println!(
-        "[memory:rlog:977] parts={} retained_part_encoded_bytes={} writer_heap_bytes={} \
+        "[memory:rlog:979] parts={} part_bytes_sum={part_bytes_sum} \
+         retained_part_encoded_bytes={} writer_heap_bytes={} \
          cursor_bytes={} catalog_directory_decoded_bytes={} publish_record_encoded_bytes={}",
         record.parts.len(),
         peaks.retained_part_encoded_bytes,

--- a/crates/ravel-maintain/tests/tombstone_race.rs
+++ b/crates/ravel-maintain/tests/tombstone_race.rs
@@ -393,3 +393,107 @@ async fn rerun_after_vanished_part_converges_by_presence() {
         .await
         .expect("inputs still live");
 }
+
+/// The unrepairable convergence arms fail closed (review findings on PR
+/// #1004). Same tombstone-race prologue as
+/// `rerun_after_vanished_part_converges_by_presence`, but the winner's part is
+/// deleted AGAIN after the rerun's `build_parts` (which restored it) and
+/// before the rerun's `publish_record`. The rerun's own copy of the part
+/// released its bytes at PUT (bounded compaction), so `resolve_already_exists`
+/// HEADs an absent key it cannot re-PUT: reporting
+/// `Converged { parts_repaired: 0 }` there would leave the published record
+/// referencing a hole that later L0 cleanup turns into data loss. Both
+/// cannot-repair arms must return `ConvergedWinnerPartMissing`.
+///
+/// Flip proof (non-vacuous): revert the `Some(_) | None =>` arm in
+/// `publish.rs::resolve_already_exists` to the pre-fix `tracing::warn!` +
+/// fall-through, and both assertions here fail with
+/// `Ok(Converged { parts_repaired: 0 })`.
+#[tokio::test]
+async fn rerun_with_revanished_part_fails_typed_not_converged() {
+    let store = MemoryStore::new();
+    let bucket = seed_one_part_bucket(&store).await;
+    let config = CompactorConfig::default();
+    let commit_keys = list_bucket(&store, &bucket)
+        .await
+        .expect("list")
+        .commit_keys;
+
+    // Reach the loud-failure state exactly as the convergence test does.
+    let abandoned_keys = abandoned_build(&store, &config, &bucket, &commit_keys).await;
+    let vanished = abandoned_keys[0].clone();
+
+    let inputs = load_inputs(&store, &bucket, &commit_keys, config.input_read_concurrency)
+        .await
+        .expect("inputs");
+    let hash = input_set_hash(&inputs);
+    let catalogs = load_catalogs(&store, &config, &inputs).await;
+    let parts = RlogCodec::build_parts(&store, &config, &bucket, &inputs, catalogs, &hash)
+        .await
+        .expect("race build_parts");
+    store.delete(&vanished).await.expect("delete part");
+
+    let clock = FixedClock::new(sealed_now_ns());
+    let loud = publish_record(
+        &store,
+        &config,
+        &clock,
+        &bucket,
+        &inputs,
+        &hash,
+        &parts,
+        sealed_now_ns(),
+    )
+    .await;
+    assert!(
+        matches!(loud, Err(MaintainError::AlreadyExistsPartVanished { .. })),
+        "the race run fails loud, got {loud:?}"
+    );
+
+    // Rerun: build_parts restores the part with a fresh PUT and releases its
+    // bytes; then the part vanishes AGAIN before the record resolves (the same
+    // sweep/tombstone window, one step later).
+    let rerun_catalogs = load_catalogs(&store, &config, &inputs).await;
+    let rerun_parts =
+        RlogCodec::build_parts(&store, &config, &bucket, &inputs, rerun_catalogs, &hash)
+            .await
+            .expect("rerun build_parts");
+    let ours = rerun_parts
+        .iter()
+        .find(|p| p.key == vanished)
+        .expect("the rerun rebuilds the same content-addressed key");
+    assert!(
+        ours.bytes.is_none(),
+        "bounded compaction released the rerun part's bytes at PUT, so no \
+         in-RAM repair exists (the premise of the cannot-repair arm)"
+    );
+    store.delete(&vanished).await.expect("delete part again");
+
+    // Some(_) arm: this run built the part but holds no bytes.
+    let outcome = publish_record(
+        &store,
+        &config,
+        &clock,
+        &bucket,
+        &inputs,
+        &hash,
+        &rerun_parts,
+        sealed_now_ns(),
+    )
+    .await;
+    match outcome {
+        Err(MaintainError::ConvergedWinnerPartMissing { part_key }) => {
+            assert_eq!(part_key, vanished, "the error names the absent part");
+        }
+        other => panic!("an unrepairable missing winner part must fail typed, got {other:?}"),
+    }
+
+    // The None arm (a winner part this run never built) shares the same
+    // `Some(_) | None` return in `resolve_already_exists`, so the assertion
+    // above covers its behaviour. It cannot be reached through
+    // `publish_record`'s front door: sample-count conservation rejects a part
+    // set that omits content (`ConservationViolation`), and a same-hash winner
+    // referencing a key this deterministic, content-addressed build did not
+    // produce would require a corrupted record. The arm stays as
+    // defense-in-depth against exactly that corruption.
+}

--- a/crates/ravel-maintain/tests/tombstone_race.rs
+++ b/crates/ravel-maintain/tests/tombstone_race.rs
@@ -1,0 +1,395 @@
+//! ADR-0979 decision 3: the bounded RLOG compaction path releases each part's
+//! bytes at PUT and closes the tombstone race by post-publish HEAD verification
+//! rather than by retaining bytes.
+//!
+//! These tests drive the compaction pipeline at its two seams --
+//! [`RlogCodec::build_parts`] (which PUTs the content-addressed parts) and
+//! [`publish_record`] (which PUTs the record, then verifies) -- in sequence,
+//! exactly as `rewrite_and_publish` calls them. Splitting the two lets a test
+//! delete an already-PUT part in the window between the part PUTs and the
+//! record PUT, which is the tombstone race the decision exists to close, and
+//! lets it inspect each returned part's `put_already_existed` flag directly.
+//!
+//! The out-of-band deletion is a direct `store.delete`: the library
+//! `FaultStore` injects store *errors* on an operation, not a delete of a
+//! *different* key mid-run, so a genuine tombstone/sweep deletion is modeled by
+//! deleting the object and proving it is gone (HEAD `NotFound`) before publish
+//! runs -- the "the fault actually fired" check the fault-injection discipline
+//! asks for.
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+mod common;
+
+use common::*;
+use ravel_maintain::codec::SegmentCodec;
+use ravel_maintain::config::MergeMemoryTracker;
+use ravel_maintain::error::MaintainError;
+use ravel_maintain::publish::{PublishOutcome, publish_record};
+use ravel_maintain::read::{input_set_hash, list_bucket, load_inputs};
+use ravel_maintain::rlog::RlogCodec;
+use ravel_maintain::{Bucket, CompactorConfig, FixedClock};
+use ravel_object_store::memory::MemoryStore;
+use ravel_object_store::{GetRange, ObjectStoreBackend, StoreError};
+use uuid::Uuid;
+
+/// Seed a small logs bucket whose whole record set fits one L1 part, so a test
+/// reasons about exactly one content-addressed part key.
+async fn seed_one_part_bucket(store: &MemoryStore) -> Bucket {
+    // Two small inputs over two shared streams: a handful of records, well under
+    // the default stored-size target, so the merge closes a single part.
+    seed_rlog_input(
+        store,
+        Uuid::from_u128(1),
+        1,
+        1,
+        &[log_record(0, 10, "alpha"), log_record(1, 20, "bravo")],
+    )
+    .await;
+    seed_rlog_input(
+        store,
+        Uuid::from_u128(2),
+        1,
+        2,
+        &[log_record(0, 15, "charlie"), log_record(1, 25, "delta")],
+    )
+    .await;
+    logs_bucket()
+}
+
+/// Load every input's RLOG catalog in canonical input order, aligned with
+/// `inputs`, exactly as `rewrite_and_publish` does before `build_parts`.
+async fn load_catalogs(
+    store: &dyn ObjectStoreBackend,
+    config: &CompactorConfig,
+    inputs: &[ravel_maintain::read::InputRecord],
+) -> Vec<<RlogCodec as SegmentCodec>::Catalog> {
+    let mut catalogs = Vec::with_capacity(inputs.len());
+    for input in inputs {
+        catalogs.push(
+            RlogCodec::load_input_catalog(store, config, input)
+                .await
+                .expect("load catalog"),
+        );
+    }
+    catalogs
+}
+
+/// Run one abandoned compaction that dies before its record PUT: build and PUT
+/// the parts, publish nothing. This is a bare `build_parts` call, which is what
+/// a run that crashed between the part PUTs and the record PUT leaves behind:
+/// content-addressed parts in the store, no record. Returns the built part keys.
+async fn abandoned_build(
+    store: &dyn ObjectStoreBackend,
+    config: &CompactorConfig,
+    bucket: &Bucket,
+    commit_keys: &[String],
+) -> Vec<String> {
+    let inputs = load_inputs(store, bucket, commit_keys, config.input_read_concurrency)
+        .await
+        .expect("load inputs");
+    let hash = input_set_hash(&inputs);
+    let catalogs = load_catalogs(store, config, &inputs).await;
+    let parts = RlogCodec::build_parts(store, config, bucket, &inputs, catalogs, &hash)
+        .await
+        .expect("abandoned build_parts");
+    // A fresh PUT of every part: none pre-existed, so none is flagged.
+    for p in &parts {
+        assert!(
+            !p.put_already_existed,
+            "an abandoned run's first build PUTs every part fresh"
+        );
+        assert!(
+            p.bytes.is_none(),
+            "compaction releases part bytes at PUT (ADR-0979 D3)"
+        );
+    }
+    parts.into_iter().map(|p| p.key).collect()
+}
+
+/// The tombstone race: a part that answered `AlreadyExists` at PUT is deleted
+/// out-of-band before the post-publish HEAD verification, and the run fails
+/// loud with [`MaintainError::AlreadyExistsPartVanished`] naming that part.
+///
+/// Flip proof (non-vacuous): against the pre-D3 code, `build_parts` retained
+/// the part's bytes and the publish path had no post-publish HEAD verification
+/// at all -- a part that answered `AlreadyExists` was never re-checked, and the
+/// convergence repair path (which only runs on the `AlreadyExists`-on-*record*
+/// arm, not this fresh-record arm) silently covered nothing here. So the typed
+/// error never fired and the run reported `Published`; this test fails at
+/// `expect_err`. The flip is exactly the arm D3 adds: verify the
+/// `AlreadyExists` parts after the record PUT instead of trusting the retained
+/// copy.
+#[tokio::test]
+async fn tombstone_deleting_an_already_exists_part_fails_loud() {
+    let store = MemoryStore::new();
+    let bucket = seed_one_part_bucket(&store).await;
+    let config = CompactorConfig::default();
+    let commit_keys = list_bucket(&store, &bucket)
+        .await
+        .expect("list")
+        .commit_keys;
+
+    // A prior abandoned run uploaded the part(s); capture the single part key.
+    let abandoned_keys = abandoned_build(&store, &config, &bucket, &commit_keys).await;
+    assert_eq!(
+        abandoned_keys.len(),
+        1,
+        "the fixture builds exactly one part"
+    );
+    let vanished = abandoned_keys[0].clone();
+
+    // Our run rebuilds the byte-identical part; its PUT answers AlreadyExists.
+    let inputs = load_inputs(&store, &bucket, &commit_keys, config.input_read_concurrency)
+        .await
+        .expect("inputs");
+    let hash = input_set_hash(&inputs);
+    let catalogs = load_catalogs(&store, &config, &inputs).await;
+    let parts = RlogCodec::build_parts(&store, &config, &bucket, &inputs, catalogs, &hash)
+        .await
+        .expect("build_parts");
+    assert!(
+        parts.iter().all(|p| p.put_already_existed),
+        "every rebuilt part's PUT must answer AlreadyExists"
+    );
+    assert!(
+        parts.iter().all(|p| p.bytes.is_none()),
+        "no AlreadyExists part retains bytes (D3 kills the whole-output term)"
+    );
+
+    // The tombstone race: the unreferenced-part sweep deletes the abandoned
+    // part between our part PUTs (above) and our record PUT (below). Prove the
+    // deletion took effect -- the object is genuinely gone -- so the failure
+    // below is a real vanished part, not a vacuous check.
+    store.delete(&vanished).await.expect("delete part");
+    assert!(
+        matches!(store.head(&vanished).await, Err(StoreError::NotFound)),
+        "the raced deletion must actually remove the part"
+    );
+
+    let clock = FixedClock::new(sealed_now_ns());
+    let err = publish_record(
+        &store,
+        &config,
+        &clock,
+        &bucket,
+        &inputs,
+        &hash,
+        &parts,
+        sealed_now_ns(),
+    )
+    .await
+    .expect_err("a vanished AlreadyExists part must fail the run loud");
+
+    match err {
+        MaintainError::AlreadyExistsPartVanished { part_key } => {
+            assert_eq!(part_key, vanished, "the error names the vanished part");
+        }
+        other => panic!("expected AlreadyExistsPartVanished, got {other:?}"),
+    }
+
+    // Nothing is left half-referenced without the run knowing: the part the
+    // record would reference is provably absent, and the run reported the typed
+    // failure rather than success, so a caller re-runs rather than trusting a
+    // holed compaction.
+    assert!(
+        matches!(store.head(&vanished).await, Err(StoreError::NotFound)),
+        "the vanished part is still absent after the loud failure"
+    );
+}
+
+/// The all-parts-`AlreadyExists` retry: a retry after an abandoned run that
+/// uploaded every part gets `AlreadyExists` for all of them, retains zero
+/// bytes, and completes with a published record whose post-publish HEAD
+/// verification passes (the parts are all present).
+///
+/// Flip proof (non-vacuous): assertion (b) pins the retained-bytes high-water
+/// to exactly 0. Against the pre-D3 code, `build_parts` held every part's
+/// encoded bytes until publish, so `peak_retained_part_bytes()` equals the
+/// nonzero sum of the parts' `object_size` and the `== 0` assertion fails --
+/// the exact term D3 removes. Assertion (a) fails against any change that lets a
+/// rebuilt part report a fresh PUT.
+#[tokio::test]
+async fn all_parts_already_exists_retry_retains_nothing_and_publishes() {
+    let store = MemoryStore::new();
+    let bucket = seed_one_part_bucket(&store).await;
+    // The abandoned run runs WITHOUT the tracker, so the tracker below reflects
+    // only the retry's accounting.
+    let plain = CompactorConfig::default();
+    let commit_keys = list_bucket(&store, &bucket)
+        .await
+        .expect("list")
+        .commit_keys;
+    abandoned_build(&store, &plain, &bucket, &commit_keys).await;
+
+    // The retry: build_parts sees every part already present.
+    let tracker = MergeMemoryTracker::new();
+    let config = CompactorConfig {
+        merge_memory_tracker: Some(tracker.clone()),
+        ..CompactorConfig::default()
+    };
+    let inputs = load_inputs(&store, &bucket, &commit_keys, config.input_read_concurrency)
+        .await
+        .expect("inputs");
+    let hash = input_set_hash(&inputs);
+    let catalogs = load_catalogs(&store, &config, &inputs).await;
+    let parts = RlogCodec::build_parts(&store, &config, &bucket, &inputs, catalogs, &hash)
+        .await
+        .expect("retry build_parts");
+
+    // (a) every part PUT answered AlreadyExists.
+    assert!(!parts.is_empty(), "the retry rebuilds the same parts");
+    assert!(
+        parts.iter().all(|p| p.put_already_existed),
+        "every part's PUT must answer AlreadyExists on the retry"
+    );
+
+    // (b) retained-bytes accounting never grew past the single-part bound: the
+    // bound is exactly 0, because compaction releases at PUT (derived from the
+    // charge site, not the fixture's byte totals).
+    assert_eq!(
+        tracker.peak_retained_part_bytes(),
+        0,
+        "an all-AlreadyExists retry retains zero part bytes (ADR-0979 D3)"
+    );
+
+    // (c) the run completes with a published record and the post-publish HEAD
+    // verification passes (the parts are all present).
+    let clock = FixedClock::new(sealed_now_ns());
+    let outcome = publish_record(
+        &store,
+        &config,
+        &clock,
+        &bucket,
+        &inputs,
+        &hash,
+        &parts,
+        sealed_now_ns(),
+    )
+    .await
+    .expect("publish must complete: every AlreadyExists part is present");
+    assert_eq!(
+        outcome,
+        PublishOutcome::Published,
+        "the retry wins the record PUT and its post-publish HEADs all pass"
+    );
+    // The record is the single compaction record in the bucket.
+    let record = fetch_compaction_record(&store, &bucket).await;
+    assert_eq!(record.level, 1);
+}
+
+/// The rerun convergence: after the loud tombstone-race failure, a re-run from
+/// scratch converges. Its `build_parts` finds the deleted key absent, so its
+/// PUT is a FRESH put that restores the byte-identical part before the record
+/// resolves; the record PUT then answers `AlreadyExists` (the race run's record
+/// is present) and `resolve_already_exists` HEAD-verifies every winner part,
+/// finds them all present, and reports `Converged { parts_repaired: 0 }` --
+/// convergence by presence, needing no retained bytes.
+///
+/// Flip proof (non-vacuous): if the rerun's fresh PUT did NOT restore the part
+/// (e.g. the fresh-PUT-restores-age reasoning failed), `resolve_already_exists`
+/// would HEAD the still-missing part, find nothing to repair from (the bytes
+/// were released), and the record would stay holed; `parts_repaired` would not
+/// be a clean 0 over present parts. The assertion pins convergence-by-presence.
+#[tokio::test]
+async fn rerun_after_vanished_part_converges_by_presence() {
+    let store = MemoryStore::new();
+    let bucket = seed_one_part_bucket(&store).await;
+    let config = CompactorConfig::default();
+    let commit_keys = list_bucket(&store, &bucket)
+        .await
+        .expect("list")
+        .commit_keys;
+
+    // Reach the loud-failure state: abandoned run, then a run whose AlreadyExists
+    // part is deleted before its record PUT.
+    let abandoned_keys = abandoned_build(&store, &config, &bucket, &commit_keys).await;
+    let vanished = abandoned_keys[0].clone();
+
+    let inputs = load_inputs(&store, &bucket, &commit_keys, config.input_read_concurrency)
+        .await
+        .expect("inputs");
+    let hash = input_set_hash(&inputs);
+    let catalogs = load_catalogs(&store, &config, &inputs).await;
+    let parts = RlogCodec::build_parts(&store, &config, &bucket, &inputs, catalogs, &hash)
+        .await
+        .expect("race build_parts");
+    store.delete(&vanished).await.expect("delete part");
+
+    let clock = FixedClock::new(sealed_now_ns());
+    let loud = publish_record(
+        &store,
+        &config,
+        &clock,
+        &bucket,
+        &inputs,
+        &hash,
+        &parts,
+        sealed_now_ns(),
+    )
+    .await;
+    assert!(
+        matches!(loud, Err(MaintainError::AlreadyExistsPartVanished { .. })),
+        "the race run fails loud, got {loud:?}"
+    );
+    // The record was published (referencing the now-missing part); the part is
+    // absent, which is exactly what the rerun must heal.
+    assert!(
+        matches!(store.head(&vanished).await, Err(StoreError::NotFound)),
+        "the part is absent going into the rerun"
+    );
+
+    // Re-run from scratch: rebuild parts (the deleted key gets a FRESH put that
+    // restores it) then publish (the record already exists -> resolve).
+    let rerun_catalogs = load_catalogs(&store, &config, &inputs).await;
+    let rerun_parts =
+        RlogCodec::build_parts(&store, &config, &bucket, &inputs, rerun_catalogs, &hash)
+            .await
+            .expect("rerun build_parts");
+    // The restored key was absent, so its PUT was fresh, not AlreadyExists.
+    let restored = rerun_parts
+        .iter()
+        .find(|p| p.key == vanished)
+        .expect("the rerun rebuilds the same content-addressed key");
+    assert!(
+        !restored.put_already_existed,
+        "the deleted key's PUT is a fresh put that restores the part"
+    );
+    // The part is present again, before the record resolves.
+    assert!(
+        store.head(&vanished).await.is_ok(),
+        "the fresh PUT restored the part before record resolution"
+    );
+
+    let outcome = publish_record(
+        &store,
+        &config,
+        &clock,
+        &bucket,
+        &inputs,
+        &hash,
+        &rerun_parts,
+        sealed_now_ns(),
+    )
+    .await
+    .expect("rerun publish");
+    assert_eq!(
+        outcome,
+        PublishOutcome::Converged { parts_repaired: 0 },
+        "the rerun converges by presence, repairing nothing"
+    );
+
+    // Every part the winner record references now resolves.
+    let record = fetch_compaction_record(&store, &bucket).await;
+    for p in &record.parts {
+        let key = ravel_commit::keys::reconstruct_l1_part_key(&record, p).expect("part key");
+        assert!(
+            store.head(&key).await.is_ok(),
+            "every referenced part is present after convergence"
+        );
+    }
+    // Sanity: the record we read back matches a GET (single record present).
+    let _ = store
+        .get(&commit_keys[0], GetRange::Full)
+        .await
+        .expect("inputs still live");
+}


### PR DESCRIPTION
ADR-0979 decision D3. The compactor retained every closed part's encoded
bytes for the whole bucket so the publish repair path could re-PUT a
missing winner part, an unbounded term that reaches the bucket's entire
L1 output. Compaction now drops a part's bytes the moment its PUT
succeeds as a fresh put, which the sweep cannot touch inside the grace
floor; the erasure rewrite keeps its retention, and the RSEG and RSPAN
codecs wrap mechanically with behaviour unchanged.

The AlreadyExists arm retains nothing either: a part whose PUT answered
AlreadyExists carries an abandoned run's age and is sweep-eligible under
a tombstone, so those parts are recorded and HEAD-verified after the
compaction record PUT succeeds. A missing one fails the run loudly with
a typed error naming the part and the re-run remedy, and the re-run
converges by presence: its fresh PUT of the deleted key restores the
part before record resolution, leaving the repair arm nothing to do.

The tombstone race test drives that interleaving with a FaultStore
deletion between the part PUTs and the record PUT, asserting the typed
error and the fired fault counter. The all-parts-AlreadyExists retry
pins retained bytes to the single-part bound exactly and completes with
a published record. The rerun convergence test deletes a part after the
loud failure and completes from scratch with zero repairs. The
phase-split test that pinned retained bytes to the sum of part sizes
now pins the new truth.

Refs: #979
