### PR TITLE
feat(ravel-cli): make compact-tenant memory observable and its knobs reachable

### DIFF
--- a/services/ravel-cli/src/main.rs
+++ b/services/ravel-cli/src/main.rs
@@ -762,6 +762,24 @@ enum MaintainCommand {
         #[arg(long, value_name = "DURATION",
               value_parser = parse_max_flush_lifetime_ns)]
         max_flush_lifetime: Option<i64>,
+        /// Bound the decoded record-heap a merge holds before it closes an L1
+        /// part (the memory split target). Lower it to cap compactor peak memory
+        /// on a small host; raise it for fewer, larger parts. Refused at 0.
+        /// Default 256 MiB (the compactor default).
+        #[arg(long, value_name = "BYTES")]
+        l1_part_memory_target_bytes: Option<u64>,
+        /// Bound the encoded/on-object bytes a merge writes before it closes an
+        /// L1 part (the stored-size target). A part closes on whichever of this
+        /// and --l1-part-memory-target-bytes is reached first. Refused at 0.
+        /// Default 256 MiB (the compactor default).
+        #[arg(long, value_name = "BYTES")]
+        max_l1_part_bytes: Option<u64>,
+        /// Number of per-input reads a compaction keeps in flight at once (the
+        /// commit-record GET and catalog load per input). Raise it to hide store
+        /// round-trip latency on a many-input bucket; it never changes output
+        /// bytes. Default 8 (the compactor default); values below 1 act as 1.
+        #[arg(long, value_name = "N")]
+        input_read_concurrency: Option<usize>,
     },
     /// Run one sweep pass (orphan GC, superseded, unreferenced parts) over a shard.
     Sweep {
@@ -1055,6 +1073,9 @@ async fn main() -> anyhow::Result<()> {
                     to_hour,
                     dry_run,
                     max_flush_lifetime,
+                    l1_part_memory_target_bytes,
+                    max_l1_part_bytes,
+                    input_read_concurrency,
                 },
         } => maintain::compact_tenant(
             store::build_store(&cli.store)?,
@@ -1065,6 +1086,9 @@ async fn main() -> anyhow::Result<()> {
             to_hour,
             dry_run,
             max_flush_lifetime,
+            l1_part_memory_target_bytes,
+            max_l1_part_bytes,
+            input_read_concurrency,
             now_ns()?,
         )
         .await
@@ -2335,6 +2359,142 @@ mod tests {
             max_inflight_flushes,
             ravel_cli::load::DEFAULT_MAX_INFLIGHT_FLUSHES,
             "--max-inflight-flushes must default to DEFAULT_MAX_INFLIGHT_FLUSHES"
+        );
+    }
+
+    use ravel_cli::maintain::{self, CompactorKnobError};
+
+    /// Destructure a parsed `maintain compact-tenant` invocation into the three
+    /// new memory knobs plus dry-run/flush overrides, panicking on any other
+    /// subcommand. Keeps each reachability test to the assertion it is about.
+    #[allow(clippy::type_complexity)]
+    fn compact_tenant_knobs(
+        cli: Cli,
+    ) -> (bool, Option<i64>, Option<u64>, Option<u64>, Option<usize>) {
+        let Command::Maintain {
+            command:
+                super::MaintainCommand::CompactTenant {
+                    dry_run,
+                    max_flush_lifetime,
+                    l1_part_memory_target_bytes,
+                    max_l1_part_bytes,
+                    input_read_concurrency,
+                    ..
+                },
+        } = cli.command
+        else {
+            panic!("expected the maintain compact-tenant subcommand");
+        };
+        (
+            dry_run,
+            max_flush_lifetime,
+            l1_part_memory_target_bytes,
+            max_l1_part_bytes,
+            input_read_concurrency,
+        )
+    }
+
+    /// Each new memory knob, given on a real `compact-tenant` argument vector,
+    /// arrives verbatim in the built `CompactorConfig`, and a fresh
+    /// `MergeMemoryTracker` is installed (so the per-phase peak-memory event
+    /// `rewrite_and_publish` emits fires for each bucket).
+    ///
+    /// Distinct values (12345 / 67890 / 7) so a crossed-wire mapping cannot pass.
+    ///
+    /// Non-vacuity (prove-the-test), each flip named:
+    /// - Drop `l1_part_memory_target_bytes` from the `build_compactor_config`
+    ///   call (pass `None`): the 12345 assertion fails against the 256 MiB
+    ///   default.
+    /// - Same for `max_l1_part_bytes` (67890) and `input_read_concurrency` (7).
+    /// - Revert `merge_memory_tracker` to `None` in `build_compactor_config`:
+    ///   the `is_some()` assertion fails.
+    #[test]
+    fn compact_tenant_memory_knobs_reach_the_built_config() {
+        let cli = Cli::try_parse_from([
+            "ravel",
+            "maintain",
+            "compact-tenant",
+            "--tenant",
+            "acme",
+            "--signal",
+            "logs",
+            "--l1-part-memory-target-bytes",
+            "12345",
+            "--max-l1-part-bytes",
+            "67890",
+            "--input-read-concurrency",
+            "7",
+        ])
+        .expect("a compact-tenant invocation with the memory knobs parses");
+
+        let (dry_run, max_flush, mem_target, max_bytes, concurrency) = compact_tenant_knobs(cli);
+
+        let config = maintain::build_compactor_config(
+            dry_run,
+            max_flush,
+            mem_target,
+            max_bytes,
+            concurrency,
+        )
+        .expect("nonzero knobs build a config");
+
+        assert_eq!(
+            config.l1_part_memory_target_bytes, 12345,
+            "--l1-part-memory-target-bytes must arrive in the config"
+        );
+        assert_eq!(
+            config.max_l1_part_bytes, 67890,
+            "--max-l1-part-bytes must arrive in the config"
+        );
+        assert_eq!(
+            config.input_read_concurrency, 7,
+            "--input-read-concurrency must arrive in the config"
+        );
+        assert!(
+            config.merge_memory_tracker.is_some(),
+            "a fresh MergeMemoryTracker must be installed so the phase-split event fires"
+        );
+    }
+
+    /// A zero part-split byte target is refused with its typed error, per each
+    /// field's own doc (the byte budget a part is closed at; zero closes a part
+    /// before anything accumulates).
+    ///
+    /// Non-vacuity (prove-the-test), each flip named:
+    /// - Remove the `if bytes == 0 { return Err(...) }` guard for
+    ///   `l1_part_memory_target_bytes` in `build_compactor_config`: this
+    ///   `ZeroL1PartMemoryTarget` assertion fails (it builds `Ok`).
+    /// - Remove the matching guard for `max_l1_part_bytes`: the
+    ///   `ZeroMaxL1PartBytes` assertion fails.
+    #[test]
+    fn compact_tenant_zero_byte_targets_are_refused() {
+        assert_eq!(
+            maintain::build_compactor_config(false, None, Some(0), None, None)
+                .expect_err("--l1-part-memory-target-bytes 0 must be refused"),
+            CompactorKnobError::ZeroL1PartMemoryTarget,
+        );
+        assert_eq!(
+            maintain::build_compactor_config(false, None, None, Some(0), None)
+                .expect_err("--max-l1-part-bytes 0 must be refused"),
+            CompactorKnobError::ZeroMaxL1PartBytes,
+        );
+    }
+
+    /// `--input-read-concurrency 0` is NOT refused: its config-field doc states
+    /// "Values below 1 are treated as 1," so the CLI passes zero through rather
+    /// than enforcing more than the doc states (the merge itself clamps with
+    /// `.max(1)`). This pins that deliberate asymmetry with the byte targets.
+    ///
+    /// Non-vacuity (prove-the-test): add an `input_read_concurrency == 0` guard
+    /// to `build_compactor_config` returning an error, and this `Ok` assertion
+    /// fails.
+    #[test]
+    fn compact_tenant_zero_input_read_concurrency_is_allowed() {
+        let config = maintain::build_compactor_config(false, None, None, None, Some(0))
+            .expect("zero input-read-concurrency is tolerated, not refused");
+        assert_eq!(
+            config.input_read_concurrency, 0,
+            "zero passes through unchanged; the merge clamps below-1 to 1 itself"
         );
     }
 

--- a/services/ravel-cli/src/main.rs
+++ b/services/ravel-cli/src/main.rs
@@ -762,9 +762,11 @@ enum MaintainCommand {
         #[arg(long, value_name = "DURATION",
               value_parser = parse_max_flush_lifetime_ns)]
         max_flush_lifetime: Option<i64>,
-        /// Bound the decoded record-heap a merge holds before it closes an L1
-        /// part (the memory split target). Lower it to cap compactor peak memory
-        /// on a small host; raise it for fewer, larger parts. Refused at 0.
+        /// The decoded record-heap size at which a merge closes an in-progress
+        /// L1 part (a split target, not a peak-memory bound: a merge can
+        /// overshoot it, e.g. by a whole trace on the RSPAN path, so size the
+        /// host for path-specific overshoot). Lower it for smaller parts on a
+        /// small host; raise it for fewer, larger parts. Refused at 0.
         /// Default 256 MiB (the compactor default).
         #[arg(long, value_name = "BYTES")]
         l1_part_memory_target_bytes: Option<u64>,

--- a/services/ravel-cli/src/maintain.rs
+++ b/services/ravel-cli/src/maintain.rs
@@ -332,11 +332,9 @@ pub async fn compact_tenant(
     let sig = signal.to_signal();
     let now_hour = u32::try_from(now_ns / ravel_maintain::config::NS_PER_HOUR)
         .map_err(|_| anyhow::anyhow!("current ingest hour {now_ns} ns does not fit u32"))?;
-    let shard_count =
-        resolve_shard_count(store.as_ref(), &tenant_hash, tenant, sig, shards, now_hour).await?;
-    let last_hour = to_hour.unwrap_or(now_hour);
-    let first_hour = from_hour.unwrap_or(0);
-
+    // Knob validation runs before any store access: a zero byte target must
+    // surface as its CompactorKnobError even on a tenant with no provisioning
+    // record, not be masked by NoProvisioningRecord.
     let config = build_compactor_config(
         dry_run,
         max_flush_lifetime_ns,
@@ -344,6 +342,10 @@ pub async fn compact_tenant(
         max_l1_part_bytes,
         input_read_concurrency,
     )?;
+    let shard_count =
+        resolve_shard_count(store.as_ref(), &tenant_hash, tenant, sig, shards, now_hour).await?;
+    let last_hour = to_hour.unwrap_or(now_hour);
+    let first_hour = from_hour.unwrap_or(0);
     let clock = FixedClock::new(now_ns);
     let mut report = CompactTenantReport {
         shards: shard_count,

--- a/services/ravel-cli/src/maintain.rs
+++ b/services/ravel-cli/src/maintain.rs
@@ -12,8 +12,8 @@ use prost::Message;
 use ravel_commit::keys;
 use ravel_maintain::{
     Bucket, CompactionOutcome, CompactorConfig, FamilyMigrateReport, FixedClock, LegalHoldCheck,
-    MigrateBudget, PublishOutcome, SweepReport, Verification, compact_bucket, migrate_family,
-    sweep_shard,
+    MergeMemoryTracker, MigrateBudget, PublishOutcome, SweepReport, Verification, compact_bucket,
+    migrate_family, sweep_shard,
 };
 use ravel_object_store::conformance::NoncurrentVersionSource;
 use ravel_object_store::{GetRange, ObjectStoreBackend, StoreError, list_all};
@@ -47,19 +47,78 @@ fn wall_clock() -> anyhow::Result<FixedClock> {
     Ok(FixedClock::new(crate::now_ns()?))
 }
 
+/// An operator override of a memory-relevant compactor knob was rejected. Typed
+/// so the message names the flag and why zero is refused, rather than surfacing
+/// as a downstream merge misbehaviour. Only the two part-split byte targets
+/// carry a floor here: their config-field docs
+/// ([`CompactorConfig::l1_part_memory_target_bytes`],
+/// [`CompactorConfig::max_l1_part_bytes`]) frame each as the byte budget an
+/// in-progress part is *closed at*, which zero cannot express (a part would be
+/// closed before any record accumulates). `input_read_concurrency` is
+/// deliberately absent: its own field doc states "Values below 1 are treated as
+/// 1," so the CLI passes a zero through unchanged rather than enforcing more
+/// than that doc states.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum CompactorKnobError {
+    #[error(
+        "--l1-part-memory-target-bytes must be greater than 0: it is the decoded record-heap \
+         budget an in-progress L1 part is closed at, and 0 would close a part before any record \
+         is buffered"
+    )]
+    ZeroL1PartMemoryTarget,
+    #[error(
+        "--max-l1-part-bytes must be greater than 0: it is the encoded/on-object byte budget an \
+         in-progress L1 part is closed at, and 0 would close a part before any bytes are written"
+    )]
+    ZeroMaxL1PartBytes,
+}
+
 /// The compactor config a `compact-bucket` / `compact-tenant` invocation runs
-/// with: defaults, plus the dry-run switch and the optional operator override
-/// of `max_flush_lifetime_ns` (which moves the seal margin, see
-/// [`crate::parse_max_flush_lifetime_ns`]).
-fn compactor_config(dry_run: bool, max_flush_lifetime_ns: Option<i64>) -> CompactorConfig {
+/// with: defaults, plus the dry-run switch and the optional operator overrides.
+///
+/// A FRESH [`MergeMemoryTracker`] is installed on every call, so the per-phase
+/// peak-memory event `ravel_maintain::rewrite_and_publish` emits fires for each
+/// bucket this invocation compacts (the tracker's `reset_for_run` runs at each
+/// bucket's start, so one tracker per CLI invocation reports each bucket's own
+/// peaks; never a shared static). `max_flush_lifetime_ns` moves the seal margin
+/// (see [`crate::parse_max_flush_lifetime_ns`]); the three part-split /
+/// concurrency knobs each replace their config default when given.
+///
+/// The two byte-target overrides are validated: zero is refused with a typed
+/// [`CompactorKnobError`] because each field's own doc frames it as the byte
+/// budget a part is closed at. `input_read_concurrency` is not floored here:
+/// its field doc already states below-1 is treated as 1.
+pub fn build_compactor_config(
+    dry_run: bool,
+    max_flush_lifetime_ns: Option<i64>,
+    l1_part_memory_target_bytes: Option<u64>,
+    max_l1_part_bytes: Option<u64>,
+    input_read_concurrency: Option<usize>,
+) -> Result<CompactorConfig, CompactorKnobError> {
     let mut config = CompactorConfig {
         dry_run,
+        merge_memory_tracker: Some(MergeMemoryTracker::new()),
         ..CompactorConfig::default()
     };
     if let Some(ns) = max_flush_lifetime_ns {
         config.max_flush_lifetime_ns = ns;
     }
-    config
+    if let Some(bytes) = l1_part_memory_target_bytes {
+        if bytes == 0 {
+            return Err(CompactorKnobError::ZeroL1PartMemoryTarget);
+        }
+        config.l1_part_memory_target_bytes = bytes;
+    }
+    if let Some(bytes) = max_l1_part_bytes {
+        if bytes == 0 {
+            return Err(CompactorKnobError::ZeroMaxL1PartBytes);
+        }
+        config.max_l1_part_bytes = bytes;
+    }
+    if let Some(n) = input_read_concurrency {
+        config.input_read_concurrency = n;
+    }
+    Ok(config)
 }
 
 /// `maintain compact-bucket`: run one compaction pass over a single bucket.
@@ -74,7 +133,7 @@ pub async fn compact(
 ) -> anyhow::Result<()> {
     let tenant_hash = TenantId::new(tenant).hash();
     let bucket = Bucket::new(tenant_hash, signal.to_signal(), shard, hour);
-    let config = compactor_config(dry_run, max_flush_lifetime_ns);
+    let config = build_compactor_config(dry_run, max_flush_lifetime_ns, None, None, None)?;
     let clock = wall_clock()?;
 
     let outcome = compact_bucket(store.as_ref(), &clock, &config, &bucket)
@@ -263,6 +322,9 @@ pub async fn compact_tenant(
     to_hour: Option<u32>,
     dry_run: bool,
     max_flush_lifetime_ns: Option<i64>,
+    l1_part_memory_target_bytes: Option<u64>,
+    max_l1_part_bytes: Option<u64>,
+    input_read_concurrency: Option<usize>,
     now_ns: i64,
 ) -> anyhow::Result<CompactTenantReport> {
     let started = std::time::Instant::now();
@@ -275,7 +337,13 @@ pub async fn compact_tenant(
     let last_hour = to_hour.unwrap_or(now_hour);
     let first_hour = from_hour.unwrap_or(0);
 
-    let config = compactor_config(dry_run, max_flush_lifetime_ns);
+    let config = build_compactor_config(
+        dry_run,
+        max_flush_lifetime_ns,
+        l1_part_memory_target_bytes,
+        max_l1_part_bytes,
+        input_read_concurrency,
+    )?;
     let clock = FixedClock::new(now_ns);
     let mut report = CompactTenantReport {
         shards: shard_count,
@@ -287,6 +355,12 @@ pub async fn compact_tenant(
     println!("shards: {shard_count}");
     println!("hour_range: [{first_hour}, {last_hour}]");
     println!("max_flush_lifetime_ns: {}", config.max_flush_lifetime_ns);
+    println!(
+        "l1_part_memory_target_bytes: {}",
+        config.l1_part_memory_target_bytes
+    );
+    println!("max_l1_part_bytes: {}", config.max_l1_part_bytes);
+    println!("input_read_concurrency: {}", config.input_read_concurrency);
     println!("dry_run: {dry_run}");
 
     for shard in 0..shard_count {

--- a/services/ravel-cli/tests/compact_tenant.rs
+++ b/services/ravel-cli/tests/compact_tenant.rs
@@ -202,6 +202,9 @@ async fn compact_tenant_compacts_only_the_sealed_hour_of_every_shard() {
         None,
         false,
         None,
+        None,
+        None,
+        None,
         now_ns(),
     )
     .await
@@ -248,9 +251,12 @@ async fn max_flush_lifetime_zero_seals_and_compacts_every_hour() {
         // collapses to the 5m clock-skew allowance, so the hour that ended ten
         // minutes ago is sealed too. Ignoring this argument (dropping the
         // `config.max_flush_lifetime_ns = ns` assignment in
-        // `maintain::compactor_config`) flips `report.compacted` back to 2 and
-        // fails this assertion.
+        // `maintain::build_compactor_config`) flips `report.compacted` back to 2
+        // and fails this assertion.
         Some(0),
+        None,
+        None,
+        None,
         now_ns(),
     )
     .await
@@ -288,6 +294,9 @@ async fn dry_run_reports_the_same_plan_and_writes_nothing() {
         None,
         true,
         None,
+        None,
+        None,
+        None,
         now_ns(),
     )
     .await
@@ -316,6 +325,9 @@ async fn dry_run_reports_the_same_plan_and_writes_nothing() {
         None,
         false,
         None,
+        None,
+        None,
+        None,
         now_ns(),
     )
     .await
@@ -335,6 +347,9 @@ async fn missing_shards_and_no_provisioning_record_is_a_typed_error_naming_the_t
         None,
         None,
         true,
+        None,
+        None,
+        None,
         None,
         now_ns(),
     )
@@ -372,6 +387,9 @@ async fn from_hour_and_to_hour_bound_the_walk() {
         Some(HOUR_OLD + 1),
         false,
         Some(0),
+        None,
+        None,
+        None,
         now_ns(),
     )
     .await

--- a/services/ravel-cli/tests/compact_tenant.rs
+++ b/services/ravel-cli/tests/compact_tenant.rs
@@ -409,3 +409,40 @@ async fn from_hour_and_to_hour_bound_the_walk() {
         );
     }
 }
+
+/// Knob validation precedes shard resolution: a zero byte target on a tenant
+/// with NO provisioning record surfaces as its `CompactorKnobError`, never
+/// masked by `NoProvisioningRecord` (review finding on PR #1005).
+///
+/// Non-vacuity (prove-the-test): move the `build_compactor_config` call in
+/// `maintain::compact_tenant` back below `resolve_shard_count` and this
+/// downcast fails with `CompactTenantError::NoProvisioningRecord` instead.
+#[tokio::test]
+async fn zero_knob_is_refused_before_shard_resolution() {
+    let store = seed_tenant().await;
+
+    let err = compact_tenant(
+        store,
+        TENANT,
+        SignalArg::Logs,
+        None,
+        None,
+        None,
+        true,
+        None,
+        Some(0),
+        None,
+        None,
+        now_ns(),
+    )
+    .await
+    .expect_err("a zero byte target must be refused before any store access");
+
+    let typed = err
+        .downcast_ref::<ravel_cli::maintain::CompactorKnobError>()
+        .expect("typed CompactorKnobError, not NoProvisioningRecord");
+    assert_eq!(
+        *typed,
+        ravel_cli::maintain::CompactorKnobError::ZeroL1PartMemoryTarget
+    );
+}


### PR DESCRIPTION
compact-tenant built its CompactorConfig with no MergeMemoryTracker, so
the per-phase peak-memory event rewrite_and_publish emits never fired
and the phase split issue #984 describes was invisible to operators. A
fresh tracker is now installed per invocation; reset_for_run at each
bucket's start keeps per-bucket peaks separate.

The three memory-relevant compactor knobs (--l1-part-memory-target-bytes,
--max-l1-part-bytes, --input-read-concurrency) are now reachable from
the CLI. The two byte targets refuse zero with a typed error, because
each field's doc frames it as the byte budget a part is closed at;
input-read-concurrency deliberately passes zero through because the
merge itself clamps below-1 to 1.

Tests pin each flag arriving verbatim in the built config (distinct
values so a crossed mapping cannot pass), the tracker being installed,
both zero refusals, and the deliberate zero-tolerance asymmetry. Each
test documents the exact flipped line that makes it fail.

Local gate note: scoped to ravel-cli; full workspace gates run in this
PR's required CI checks.

Fixes: #984
Refs: #979