### PR TITLE
feat(bench): stamp cost profile and model request cost in reports

### DIFF
--- a/crates/ravel-bench/src/bin/bench_report.rs
+++ b/crates/ravel-bench/src/bin/bench_report.rs
@@ -21,6 +21,7 @@ use std::process::Command;
 use clap::Parser;
 use ravel_bench::harness::{StoreKind, store_and_metrics_from_env};
 use ravel_bench::report::{ReportRunConfig, WorkloadShape, run};
+use ravel_types::cost_profile::StoreCostProfile;
 
 #[derive(Parser, Debug)]
 #[command(about = "Emit a machine-readable ravel benchmark report as JSON")]
@@ -117,6 +118,9 @@ async fn main() {
         ack_timeout_secs: args.ack_timeout_secs,
         git_commit: git_commit(),
         toolchain: toolchain(),
+        // The reference profile prices this run; epic #996 task 996-5 owns the
+        // CLI surface that would override it.
+        store_cost_profile: StoreCostProfile::reference(),
     };
 
     let report = run(&config).await;

--- a/crates/ravel-bench/src/bin/sql_latency_bench.rs
+++ b/crates/ravel-bench/src/bin/sql_latency_bench.rs
@@ -35,6 +35,7 @@ use ravel_bench::sql_latency::{
 };
 use ravel_sql::DEFAULT_MAX_QUERY_BYTES;
 use ravel_types::TimeRange;
+use ravel_types::cost_profile::StoreCostProfile;
 
 #[derive(Parser, Debug)]
 #[command(about = "Per-query SQL latency over the ADR-0100 corpus (cold/warm, min/median/max)")]
@@ -403,6 +404,9 @@ async fn run(args: &Args) -> Result<SqlLatencyReport, ravel_bench::sql_latency::
                             .filter(|t| !t.is_empty())
                     }),
                 }),
+                // The reference profile prices this pass; epic #996 task 996-5
+                // owns the CLI surface that would override it.
+                store_cost_profile: StoreCostProfile::reference(),
             };
             run_tenant(&cfg).await
         }
@@ -433,6 +437,9 @@ async fn run(args: &Args) -> Result<SqlLatencyReport, ravel_bench::sql_latency::
                 explain_dir: explain_dir.clone(),
                 warm_catalog: args.warm_catalog,
                 logs_suffix_len: args.logs_suffix_len,
+                // The reference profile prices this pass; epic #996 task 996-5
+                // owns the CLI surface that would override it.
+                store_cost_profile: StoreCostProfile::reference(),
             };
             run_generated(&cfg).await
         }
@@ -844,6 +851,8 @@ mod tests {
             logs_suffix_len: None,
             flight_endpoint: None,
             allocator: ravel_bench::allocator::Allocator::System,
+            store_cost_profile_requested: StoreCostProfile::reference(),
+            store_cost_profile_effective: Some(StoreCostProfile::reference()),
         }
     }
 

--- a/crates/ravel-bench/src/report.rs
+++ b/crates/ravel-bench/src/report.rs
@@ -43,6 +43,7 @@ use ravel_ingest::{Clock, IngestConfig, IngestRouter, SystemClock, WriteMode};
 use ravel_object_store::{InstrumentedStore, ObjectStoreBackend, StoreMetricsSnapshot};
 use ravel_promql::Value;
 use ravel_query::{EngineConfig, QueryEngine};
+use ravel_types::cost_profile::StoreCostProfile;
 use ravel_types::{Signal, TenantId, TimeRange};
 use serde::{Deserialize, Serialize};
 
@@ -105,6 +106,12 @@ pub struct ReportRunConfig {
     pub ack_timeout_secs: u64,
     pub git_commit: String,
     pub toolchain: String,
+    /// The active store cost profile this run is priced at (ADR-0996 decision
+    /// 1). Stamped verbatim into the environment block and used to model the
+    /// pass's request/transfer/retrieval cost. Defaults to
+    /// [`StoreCostProfile::reference`]; no CLI flag sets it here (epic #996
+    /// task 996-5 owns the server/CLI surface).
+    pub store_cost_profile: StoreCostProfile,
 }
 
 fn percentile(sorted_ns: &[u64], pct: f64) -> u64 {
@@ -136,6 +143,12 @@ pub struct BenchReport {
     pub query: QuerySection,
     pub s3_requests: RequestCounts,
     pub bytes: BytesSection,
+    /// Modeled object-store cost of the whole workload at the stamped profile
+    /// (ADR-0996 decision 3). Defaulted on read so a report written before it
+    /// existed still deserializes; every leaf is optional and absence is never
+    /// a zero.
+    #[serde(default)]
+    pub modeled_cost: ModeledCost,
 }
 
 /// The provenance block. A number without this is not evidence.
@@ -151,6 +164,91 @@ pub struct Environment {
     pub workload: WorkloadShape,
     pub git_commit: String,
     pub toolchain: String,
+    /// The active store cost profile this report was priced at (ADR-0996
+    /// decision 1): name and all price fields, verbatim, so a modeled-cost
+    /// figure can be reconciled against the exact prices that produced it. A
+    /// figure without this stamp is not a result (the allocator lesson).
+    ///
+    /// Named `requested`/`effective` to match the split the SQL-latency report
+    /// needs on its Flight lane, where a foreign server's own profile governs.
+    /// This report always prices in process, so the requested profile is also
+    /// the effective one and `store_cost_profile_effective` is always `Some`.
+    #[serde(default = "default_store_cost_profile")]
+    pub store_cost_profile_requested: StoreCostProfile,
+    /// The profile that actually governed pricing, or `None` on a lane that
+    /// cannot know it. Always `Some` on this in-process report; the field
+    /// exists so the schema matches the SQL-latency stamp rule. Skipped in JSON
+    /// when `None`, keeping the no-null contract.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub store_cost_profile_effective: Option<StoreCostProfile>,
+}
+
+/// The profile a report written before the cost stamp existed deserializes to,
+/// and the default a run uses when no profile was chosen: the reference profile.
+fn default_store_cost_profile() -> StoreCostProfile {
+    StoreCostProfile::reference()
+}
+
+/// Modeled object-store cost of a pass at the active cost profile (ADR-0996
+/// decision 3). Every figure is integer nanodollars, and every figure is
+/// optional: an absent figure is ABSENT, never a zero.
+///
+/// - `modeled_request_cost_nanodollars` prices BILLED ATTEMPTS per class through
+///   the profile (PUT-class = PUT + LIST, GET-class = GET). `None` when the
+///   backend has no attempt source: the request cost is never modeled from
+///   completed CALLS, which would understate a retrying backend and read as a
+///   real bill instead of a model.
+/// - `modeled_transfer_cost_nanodollars` / `modeled_retrieval_cost_nanodollars`
+///   are present ONLY when the stamped profile carries a nonzero transfer /
+///   retrieval per-GiB price, priced from the wire-byte counters and NEVER
+///   folded into the request term (ADR-0996 decision 3: a profile with byte
+///   prices must not stamp them while reporting request fees alone).
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct ModeledCost {
+    /// Requests priced per class from BILLED ATTEMPTS. `None` when attempts are
+    /// absent (no attempt source). Skipped in JSON when absent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub modeled_request_cost_nanodollars: Option<u64>,
+    /// Transfer (egress) cost from the wire-byte counter. `None` unless the
+    /// profile's transfer price is nonzero. Never folded into the request term.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub modeled_transfer_cost_nanodollars: Option<u64>,
+    /// Retrieval cost from the wire-byte counter. `None` unless the profile's
+    /// retrieval price is nonzero. Never folded into the request term.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub modeled_retrieval_cost_nanodollars: Option<u64>,
+}
+
+impl ModeledCost {
+    /// Model a pass's cost at `profile`.
+    ///
+    /// `put_class_attempts`/`get_class_attempts` are BILLED ATTEMPTS already
+    /// folded into their billing class (PUT-class carries LIST, since S3 bills a
+    /// LIST as a PUT). Either being `None` means the backend has no attempt
+    /// source, so the request term is `None` rather than a cost modeled from
+    /// calls. `transfer_bytes`/`retrieval_bytes` are wire-byte counters; each
+    /// byte term appears only when its per-GiB price is nonzero.
+    pub fn model(
+        profile: &StoreCostProfile,
+        put_class_attempts: Option<u64>,
+        get_class_attempts: Option<u64>,
+        transfer_bytes: u64,
+        retrieval_bytes: u64,
+    ) -> ModeledCost {
+        let modeled_request_cost_nanodollars = match (put_class_attempts, get_class_attempts) {
+            (Some(puts), Some(gets)) => Some(profile.modeled_nanodollars(puts, gets, 0)),
+            _ => None,
+        };
+        let modeled_transfer_cost_nanodollars = (profile.transfer_nanodollars_per_gib > 0)
+            .then(|| profile.modeled_nanodollars(0, 0, transfer_bytes));
+        let modeled_retrieval_cost_nanodollars = (profile.retrieval_nanodollars_per_gib > 0)
+            .then(|| profile.retrieval_nanodollars(retrieval_bytes));
+        ModeledCost {
+            modeled_request_cost_nanodollars,
+            modeled_transfer_cost_nanodollars,
+            modeled_retrieval_cost_nanodollars,
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -321,6 +419,16 @@ impl RequestCounts {
             counts.assert_calls_le_attempts();
         }
         counts
+    }
+
+    /// Billed attempts in the PUT billing class: `put_attempts + list_attempts`
+    /// (S3 bills a LIST as a PUT). `None` exactly when attempts are unwired, so
+    /// the modeled request cost is absent rather than a cost from calls.
+    pub fn put_class_attempts(&self) -> Option<u64> {
+        match (self.put_attempts, self.list_attempts) {
+            (Some(put), Some(list)) => Some(put.saturating_add(list)),
+            _ => None,
+        }
     }
 
     /// The ADR-0996 decision-3 reconciliation: billed `attempts` never
@@ -608,6 +716,18 @@ pub async fn run(config: &ReportRunConfig) -> BenchReport {
         RequestCounts::from_metrics(&snapshot, config.backend_bills_requests, attempts_wired);
     let bytes_written = snapshot.put.bytes;
     let bytes_read = snapshot.get.bytes;
+    // Model the pass at the active profile. The request term prices BILLED
+    // ATTEMPTS per class, so it is absent on a backend with no attempt source
+    // (MemoryStore) rather than a cost read off free calls. The transfer and
+    // retrieval terms price the GET wire bytes moved (`bytes_read`), and appear
+    // only when the profile carries a nonzero byte price.
+    let modeled_cost = ModeledCost::model(
+        &config.store_cost_profile,
+        request_counts.put_class_attempts(),
+        request_counts.get_attempts,
+        bytes_read,
+        bytes_read,
+    );
     let write_amplification = if logical_bytes == 0 {
         0.0
     } else {
@@ -623,6 +743,10 @@ pub async fn run(config: &ReportRunConfig) -> BenchReport {
             workload: w.clone(),
             git_commit: config.git_commit.clone(),
             toolchain: config.toolchain.clone(),
+            store_cost_profile_requested: config.store_cost_profile.clone(),
+            // In process: the requested profile priced the run, so it is also
+            // the effective one.
+            store_cost_profile_effective: Some(config.store_cost_profile.clone()),
         },
         ingest: IngestSection {
             strict_ack_latency_ms: latency_report(ack_latencies_ns),
@@ -640,6 +764,7 @@ pub async fn run(config: &ReportRunConfig) -> BenchReport {
             written: bytes_written,
             read: bytes_read,
         },
+        modeled_cost,
     }
 }
 
@@ -893,6 +1018,7 @@ mod tests {
             ack_timeout_secs: 5,
             git_commit: "0000000000000000000000000000000000000000".to_string(),
             toolchain: "rustc 0.0.0-test".to_string(),
+            store_cost_profile: StoreCostProfile::reference(),
         }
     }
 
@@ -981,11 +1107,235 @@ mod tests {
         assert!(report.bytes.written > 0, "bytes written must be > 0");
         assert!(report.bytes.read > 0, "bytes read must be > 0");
 
+        // Cost profile stamp: the reference profile, verbatim, present exactly
+        // once, with `effective` populated (this report always prices in
+        // process). A MemoryStore run has no attempt source, so the modeled
+        // request cost is ABSENT (never a zero modeled from calls), and the
+        // reference profile's byte prices are zero, so the transfer/retrieval
+        // terms are absent too.
+        assert_eq!(
+            report.environment.store_cost_profile_requested,
+            StoreCostProfile::reference()
+        );
+        assert_eq!(
+            report.environment.store_cost_profile_effective,
+            Some(StoreCostProfile::reference()),
+            "in-process run: the requested profile is also the effective one"
+        );
+        assert_eq!(
+            report.modeled_cost.modeled_request_cost_nanodollars, None,
+            "MemoryStore has no attempt source: modeled request cost is absent, not zero"
+        );
+        assert_eq!(report.modeled_cost.modeled_transfer_cost_nanodollars, None);
+        assert_eq!(report.modeled_cost.modeled_retrieval_cost_nanodollars, None);
+
         // The whole thing serializes to JSON with no null anywhere.
         let json = serde_json::to_value(&report).expect("serialize report");
         assert!(
             !json_has_null(&json),
             "report JSON must contain no null: {json}"
+        );
+        // The profile stamp appears exactly once (one requested, one effective).
+        assert_eq!(
+            count_keys(&json, "store_cost_profile_requested"),
+            1,
+            "the requested profile stamp must appear exactly once"
+        );
+        assert_eq!(
+            count_keys(&json, "store_cost_profile_effective"),
+            1,
+            "the effective profile stamp must appear exactly once"
+        );
+        // Absent modeled figures are SKIPPED, not null: the no-null contract is
+        // kept by omission, so the modeled_cost object carries no cost key here.
+        assert_eq!(
+            count_keys(&json, "modeled_request_cost_nanodollars"),
+            0,
+            "an absent modeled request cost is skipped, never serialized as a zero or null"
+        );
+    }
+
+    /// Count how many times `key` appears as an object key anywhere in `v`.
+    /// Used to assert a stamp is present *exactly once*, which a bare
+    /// serialize-and-check-non-null cannot (ADR-0996's present-exactly-once
+    /// discipline).
+    fn count_keys(v: &serde_json::Value, key: &str) -> usize {
+        match v {
+            serde_json::Value::Array(a) => a.iter().map(|e| count_keys(e, key)).sum(),
+            serde_json::Value::Object(o) => {
+                let here = o.contains_key(key) as usize;
+                here + o.values().map(|e| count_keys(e, key)).sum::<usize>()
+            }
+            _ => 0,
+        }
+    }
+
+    /// A `RequestCounts` with billed attempts wired: `put`/`get`/`list` calls
+    /// and their attempts, so the modeled request cost can be pinned to the
+    /// nanodollar. `list` bills PUT-class, so PUT-class attempts are
+    /// `put_attempts + list_attempts`.
+    fn counts_with_attempts(
+        put_attempts: u64,
+        get_attempts: u64,
+        list_attempts: u64,
+    ) -> RequestCounts {
+        RequestCounts {
+            backend_bills_requests: true,
+            put: put_attempts,
+            get: get_attempts,
+            list: list_attempts,
+            put_attempts: Some(put_attempts),
+            get_attempts: Some(get_attempts),
+            list_attempts: Some(list_attempts),
+            put_retry_overhead: Some(0),
+            get_retry_overhead: Some(0),
+            list_retry_overhead: Some(0),
+        }
+    }
+
+    #[test]
+    fn modeled_request_cost_is_attempts_times_profile_to_the_nanodollar() {
+        // 3 PUT + 2 LIST attempts = 5 PUT-class attempts; 7 GET-class attempts.
+        // At the reference profile (PUT $5/M = 5_000, GET $0.40/M = 400):
+        //   5 * 5_000 + 7 * 400 = 25_000 + 2_800 = 27_800 nanodollars.
+        let counts = counts_with_attempts(3, 7, 2);
+        assert_eq!(
+            counts.put_class_attempts(),
+            Some(5),
+            "PUT-class folds LIST in: 3 PUT + 2 LIST"
+        );
+        let profile = StoreCostProfile::reference();
+        let cost = ModeledCost::model(
+            &profile,
+            counts.put_class_attempts(),
+            counts.get_attempts,
+            0,
+            0,
+        );
+        assert_eq!(cost.modeled_request_cost_nanodollars, Some(27_800));
+        // Derived from the prices, not a repeated literal: 5 PUT-class at the
+        // PUT price plus 7 GET at the GET price, nothing else.
+        assert_eq!(
+            cost.modeled_request_cost_nanodollars,
+            Some(5 * profile.put_class_nanodollars + 7 * profile.get_class_nanodollars)
+        );
+        // Reference profile has zero byte prices, so no byte term is modeled
+        // even though bytes moved.
+        assert_eq!(cost.modeled_transfer_cost_nanodollars, None);
+        assert_eq!(cost.modeled_retrieval_cost_nanodollars, None);
+    }
+
+    #[test]
+    fn absent_attempts_give_an_absent_modeled_request_cost() {
+        // No attempt source: the request term is ABSENT, never a zero modeled
+        // from the (real, free) call counts. Skipped in JSON, keeping no-null.
+        let profile = StoreCostProfile::reference();
+        let cost = ModeledCost::model(&profile, None, None, 4096, 4096);
+        assert_eq!(
+            cost.modeled_request_cost_nanodollars, None,
+            "attempts absent => request cost absent, not zero"
+        );
+        let json = serde_json::to_value(&cost).expect("serialize");
+        assert!(
+            json.get("modeled_request_cost_nanodollars").is_none(),
+            "an absent request cost must be skipped, not null: {json}"
+        );
+        assert!(!json_has_null(&json), "no null anywhere: {json}");
+    }
+
+    #[test]
+    fn nonzero_byte_prices_add_labelled_terms_without_moving_the_request_term() {
+        // A profile that bills transfer and retrieval. The request term is
+        // computed from attempts exactly as at the reference profile (the byte
+        // prices must NOT fold into it); the two byte terms appear, each
+        // labelled, priced from the wire-byte counters.
+        let profile = StoreCostProfile {
+            name: "egress-and-retrieval".to_string(),
+            put_class_nanodollars: 5_000,
+            get_class_nanodollars: 400,
+            delete_class_nanodollars: 0,
+            transfer_nanodollars_per_gib: 90_000_000, // $0.09/GiB
+            retrieval_nanodollars_per_gib: 10_000_000, // $0.01/GiB
+        };
+        let counts = counts_with_attempts(3, 7, 2);
+        let two_gib: u64 = 2 * 1024 * 1024 * 1024;
+        let cost = ModeledCost::model(
+            &profile,
+            counts.put_class_attempts(),
+            counts.get_attempts,
+            two_gib,
+            two_gib,
+        );
+        // Request term unchanged from the reference-profile figure above: byte
+        // prices do not touch it.
+        assert_eq!(
+            cost.modeled_request_cost_nanodollars,
+            Some(27_800),
+            "the request term is priced from attempts alone, never folded with byte prices"
+        );
+        // Byte terms present and labelled: 2 GiB at each per-GiB price.
+        assert_eq!(cost.modeled_transfer_cost_nanodollars, Some(2 * 90_000_000));
+        assert_eq!(
+            cost.modeled_retrieval_cost_nanodollars,
+            Some(2 * 10_000_000)
+        );
+
+        // A profile that bills only transfer omits the retrieval term entirely.
+        let transfer_only = StoreCostProfile {
+            retrieval_nanodollars_per_gib: 0,
+            ..profile.clone()
+        };
+        let cost = ModeledCost::model(
+            &transfer_only,
+            counts.put_class_attempts(),
+            counts.get_attempts,
+            two_gib,
+            two_gib,
+        );
+        assert_eq!(cost.modeled_transfer_cost_nanodollars, Some(2 * 90_000_000));
+        assert_eq!(
+            cost.modeled_retrieval_cost_nanodollars, None,
+            "a zero retrieval price omits the retrieval term, not a zero"
+        );
+        assert_eq!(cost.modeled_request_cost_nanodollars, Some(27_800));
+    }
+
+    #[test]
+    fn the_profile_moves_the_modeled_figure_from_identical_counts() {
+        // Same attempt counts, two profiles: the modeled cost must differ. This
+        // is the redundant-figure check ADR-0996 wants -- a price change with an
+        // unchanged count still moves the reported cost.
+        let counts = counts_with_attempts(3, 7, 2);
+        let reference = StoreCostProfile::reference();
+        let custom = StoreCostProfile::from_toml_str(
+            "name = \"s3-cross-region\"\n\
+             put_class_nanodollars = 5500\n\
+             get_class_nanodollars = 440\n\
+             transfer_nanodollars_per_gib = 0\n\
+             retrieval_nanodollars_per_gib = 0\n",
+        )
+        .expect("parse custom profile");
+
+        let ref_cost = ModeledCost::model(
+            &reference,
+            counts.put_class_attempts(),
+            counts.get_attempts,
+            0,
+            0,
+        );
+        let custom_cost = ModeledCost::model(
+            &custom,
+            counts.put_class_attempts(),
+            counts.get_attempts,
+            0,
+            0,
+        );
+        // Reference: 5*5000 + 7*400 = 27_800. Custom: 5*5500 + 7*440 = 30_580.
+        assert_eq!(ref_cost.modeled_request_cost_nanodollars, Some(27_800));
+        assert_eq!(custom_cost.modeled_request_cost_nanodollars, Some(30_580));
+        assert_ne!(
+            ref_cost.modeled_request_cost_nanodollars, custom_cost.modeled_request_cost_nanodollars,
+            "identical counts under different profiles must model different costs"
         );
     }
 

--- a/crates/ravel-bench/src/sql_latency.rs
+++ b/crates/ravel-bench/src/sql_latency.rs
@@ -942,11 +942,23 @@ fn total_get_wire_bytes(entries: &[EntryReport]) -> u64 {
         })
 }
 
-/// Model the pass's cost at `profile`. This harness has no attempt source, so
-/// the request term is always absent (the ABSENT-attempts contract, never a
-/// cost from calls); the byte terms price `entries`' GET wire bytes and appear
-/// only when `profile` carries a nonzero byte price.
-fn model_pass_cost(profile: &StoreCostProfile, entries: &[EntryReport]) -> ModeledCost {
+/// Model the pass's cost at `profile`, or model nothing on the Flight lane.
+///
+/// This harness has no attempt source, so the request term is always absent
+/// (the ABSENT-attempts contract, never a cost from calls); the byte terms
+/// price `entries`' GET wire bytes and appear only when `profile` carries a
+/// nonzero byte price. The Flight lane has no effective profile AND no
+/// wire-byte accounting in this process, so modeling it from the requested
+/// profile would price zero recorded bytes and emit `Some(0)` byte terms —
+/// an unknown cost dressed as a known zero. Every term stays absent instead.
+fn model_pass_cost(
+    is_flight: bool,
+    profile: &StoreCostProfile,
+    entries: &[EntryReport],
+) -> ModeledCost {
+    if is_flight {
+        return ModeledCost::default();
+    }
     let wire_bytes = total_get_wire_bytes(entries);
     ModeledCost::model(profile, None, None, wire_bytes, wire_bytes)
 }
@@ -2057,7 +2069,8 @@ pub async fn run_generated(cfg: &GenerateConfig) -> Result<SqlLatencyReport, Err
             store_cost_profile_effective: Some(cfg.store_cost_profile.clone()),
         },
         dataset,
-        modeled_cost: model_pass_cost(&cfg.store_cost_profile, &entries),
+        // Generate is always in process (never Flight).
+        modeled_cost: model_pass_cost(false, &cfg.store_cost_profile, &entries),
         entries,
         skipped,
         failed,
@@ -2247,10 +2260,10 @@ pub async fn run_tenant(cfg: &TenantConfigInput) -> Result<SqlLatencyReport, Err
             },
         },
         dataset,
-        // The request term is absent on every lane (no attempt source); the
-        // byte terms price this pass's GET wire bytes, which the Flight lane
-        // does not record, so a Flight pass models no byte cost either.
-        modeled_cost: model_pass_cost(&cfg.store_cost_profile, &entries),
+        // The request term is absent on every lane (no attempt source). The
+        // Flight lane models nothing at all: it records no wire bytes, so a
+        // nonzero byte price would produce Some(0), a fake known-zero.
+        modeled_cost: model_pass_cost(cfg.flight.is_some(), &cfg.store_cost_profile, &entries),
         entries,
         skipped,
         failed,
@@ -4530,6 +4543,63 @@ mod tests {
             suffix,
             objects[0].clone(),
         )
+    }
+
+    // ---- Lane-aware modeled cost (PR #1008 review) -------------------------
+
+    /// The Flight lane models NOTHING: it has no effective profile and no
+    /// wire-byte accounting in this process, so pricing zero recorded bytes at
+    /// a nonzero byte price would emit `Some(0)` byte terms -- an unknown cost
+    /// dressed as a known zero. The in-process lane over the SAME entries and
+    /// the SAME priced profile emits both byte terms at exactly
+    /// `price x wire_bytes / GiB` (floor), proving the suppression is the lane,
+    /// not an accident of empty accounting.
+    ///
+    /// Non-vacuity (prove-the-test): make `model_pass_cost` ignore `is_flight`
+    /// and the Flight assertion fails with `Some(0)` transfer/retrieval terms.
+    #[tokio::test]
+    async fn flight_lane_models_no_cost_even_at_nonzero_byte_prices() {
+        let (entry_report, _, _, _) = probe_miss_fixture_run().await;
+        let entries = vec![entry_report];
+        let wire = total_get_wire_bytes(&entries);
+        assert!(
+            wire > 0,
+            "fixture precondition: the fixture run must record wire bytes"
+        );
+        let profile = ravel_types::cost_profile::StoreCostProfile {
+            name: "egress-and-retrieval".to_string(),
+            put_class_nanodollars: 5_000,
+            get_class_nanodollars: 400,
+            delete_class_nanodollars: 0,
+            transfer_nanodollars_per_gib: 90_000_000,
+            retrieval_nanodollars_per_gib: 10_000_000,
+        };
+
+        let flight = model_pass_cost(true, &profile, &entries);
+        assert_eq!(
+            flight,
+            crate::report::ModeledCost::default(),
+            "every Flight term is absent, never Some(0)"
+        );
+
+        let in_process = model_pass_cost(false, &profile, &entries);
+        const GIB: u128 = 1024 * 1024 * 1024;
+        let expect_transfer = u64::try_from(90_000_000u128 * wire as u128 / GIB).expect("fits");
+        let expect_retrieval = u64::try_from(10_000_000u128 * wire as u128 / GIB).expect("fits");
+        assert_eq!(
+            in_process.modeled_transfer_cost_nanodollars,
+            Some(expect_transfer),
+            "in-process transfer term prices the recorded wire bytes exactly"
+        );
+        assert_eq!(
+            in_process.modeled_retrieval_cost_nanodollars,
+            Some(expect_retrieval),
+            "in-process retrieval term prices the recorded wire bytes exactly"
+        );
+        assert_eq!(
+            in_process.modeled_request_cost_nanodollars, None,
+            "no attempt source on this harness, so the request term stays absent"
+        );
     }
 
     // ---- Logs-scan opens by read shape (#904) ------------------------------

--- a/crates/ravel-bench/src/sql_latency.rs
+++ b/crates/ravel-bench/src/sql_latency.rs
@@ -67,12 +67,14 @@ use ravel_sql::{
     SqlExecutor, SqlRequest, StaticDeclaredColumns,
 };
 use ravel_types::accounting::{AccountedOp, QueryAccounting};
+use ravel_types::cost_profile::StoreCostProfile;
 use ravel_types::logstream::log_stream_id;
 use ravel_types::{Signal, TenantHash, TenantId, TimeRange};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::allocator::Allocator;
+use crate::report::ModeledCost;
 use crate::sql_corpus::CorpusEntry;
 
 /// A frozen query clock, bounding the catalog resolve's ingest-hour fan-out.
@@ -342,6 +344,31 @@ pub struct Provenance {
     /// allocator string is rejected at deserialize.
     #[serde(default = "default_allocator")]
     pub allocator: Allocator,
+    /// The active store cost profile this run ASKED to price at (ADR-0996
+    /// decision 1): name and all price fields, verbatim, so a modeled-cost
+    /// figure is reconcilable against the exact prices that produced it. A
+    /// report written before the stamp existed deserializes to
+    /// [`StoreCostProfile::reference`].
+    #[serde(default = "default_store_cost_profile")]
+    pub store_cost_profile_requested: StoreCostProfile,
+    /// The profile that actually governed pricing, or `None` when this process
+    /// cannot know it. `Some` for an in-process lane (`generate`/`tenant`),
+    /// which prices with the profile it was handed; `None` for the Flight lane,
+    /// whose statements ran against a foreign server whose own
+    /// `--store-cost-profile` governed -- exactly the requested/effective split
+    /// the `logs_request_cost_bytes` fields use, and for the same reason:
+    /// stamping the requested value as effective would make two Flight passes at
+    /// different profiles look like a controlled comparison. Skipped in JSON
+    /// when `None`, keeping the no-null contract.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub store_cost_profile_effective: Option<StoreCostProfile>,
+}
+
+/// The profile a report written before the cost stamp existed deserializes to,
+/// and the default a run prices at when no profile was chosen: the reference
+/// profile (ADR-0996 decision 1).
+fn default_store_cost_profile() -> StoreCostProfile {
+    StoreCostProfile::reference()
 }
 
 /// What a report written before the allocator was recorded (issue #972)
@@ -890,6 +917,38 @@ pub struct SqlLatencyReport {
     pub skipped: Vec<SkippedEntry>,
     #[serde(default)]
     pub failed: Vec<FailedEntry>,
+    /// Modeled object-store cost of the whole pass at the stamped profile
+    /// (ADR-0996 decision 3). The request term prices BILLED ATTEMPTS per class;
+    /// this harness has no attempt source (the in-process lanes count CALLS
+    /// through `QueryAccounting`, the Flight lane carries no accounting at all),
+    /// so the request term is ABSENT here, never a cost modeled from calls. The
+    /// transfer and retrieval terms price the pass's GET wire bytes and appear
+    /// only when the profile carries a nonzero byte price. Defaulted on read so
+    /// a report written before it existed still deserializes.
+    #[serde(default)]
+    pub modeled_cost: ModeledCost,
+}
+
+/// Total GET wire bytes the pass moved: summed over every recorded run of every
+/// measured statement (`RunAccounting::object_store_get_bytes`, WIRE bytes). The
+/// Flight lane records no per-run accounting, so its entries contribute zero;
+/// combined with its `None` effective profile, a Flight pass models no byte cost.
+fn total_get_wire_bytes(entries: &[EntryReport]) -> u64 {
+    entries
+        .iter()
+        .flat_map(|e| e.per_run_accounting.iter().flatten())
+        .fold(0u64, |acc, run| {
+            acc.saturating_add(run.object_store_get_bytes)
+        })
+}
+
+/// Model the pass's cost at `profile`. This harness has no attempt source, so
+/// the request term is always absent (the ABSENT-attempts contract, never a
+/// cost from calls); the byte terms price `entries`' GET wire bytes and appear
+/// only when `profile` carries a nonzero byte price.
+fn model_pass_cost(profile: &StoreCostProfile, entries: &[EntryReport]) -> ModeledCost {
+    let wire_bytes = total_get_wire_bytes(entries);
+    ModeledCost::model(profile, None, None, wire_bytes, wire_bytes)
 }
 
 /// Inputs for the generated lane.
@@ -983,6 +1042,11 @@ pub struct GenerateConfig {
     /// [`ravel_query::DEFAULT_LOG_REQUEST_COST_BYTES`], so an unset flag leaves
     /// logs-scan routing byte-for-byte unchanged.
     pub logs_request_cost_bytes: u64,
+    /// The store cost profile the pass is priced at (ADR-0996 decision 1),
+    /// stamped verbatim into provenance and used to model the pass's cost.
+    /// Defaults to [`StoreCostProfile::reference`]; no CLI flag sets it here
+    /// (epic #996 task 996-5 owns the server/CLI surface).
+    pub store_cost_profile: StoreCostProfile,
 }
 
 /// Where the Flight lane sends its statements.
@@ -1113,6 +1177,14 @@ pub struct TenantConfigInput {
     /// the server's own config governs there). Defaults to
     /// [`ravel_query::DEFAULT_LOG_REQUEST_COST_BYTES`].
     pub logs_request_cost_bytes: u64,
+    /// The store cost profile the pass is priced at (ADR-0996 decision 1),
+    /// stamped verbatim into provenance and used to model the pass's cost. On
+    /// the Flight lane it is stamped as the REQUESTED profile only; the
+    /// effective profile is `None`, because the foreign server's own
+    /// `--store-cost-profile` governed there. Defaults to
+    /// [`StoreCostProfile::reference`]; no CLI flag sets it here (epic #996
+    /// task 996-5 owns the server/CLI surface).
+    pub store_cost_profile: StoreCostProfile,
 }
 
 fn percentile(sorted_ns: &[u64], pct: f64) -> u64 {
@@ -1979,8 +2051,13 @@ pub async fn run_generated(cfg: &GenerateConfig) -> Result<SqlLatencyReport, Err
             logs_suffix_len: cfg.logs_suffix_len,
             flight_endpoint: None,
             allocator: crate::allocator::active_allocator(),
+            store_cost_profile_requested: cfg.store_cost_profile.clone(),
+            // Generate is always in process: the requested profile priced the
+            // run, so it is also the effective one.
+            store_cost_profile_effective: Some(cfg.store_cost_profile.clone()),
         },
         dataset,
+        modeled_cost: model_pass_cost(&cfg.store_cost_profile, &entries),
         entries,
         skipped,
         failed,
@@ -2159,8 +2236,21 @@ pub async fn run_tenant(cfg: &TenantConfigInput) -> Result<SqlLatencyReport, Err
             // governs the benchmark process's RSS, and on the Flight lane the
             // server's allocator is its own concern, not recorded here.
             allocator: crate::allocator::active_allocator(),
+            store_cost_profile_requested: cfg.store_cost_profile.clone(),
+            // The Flight lane's statements ran against a foreign server whose
+            // own `--store-cost-profile` governed pricing, unknown to this
+            // process: stamp `None`. An in-process tenant run prices with the
+            // profile it was handed, so it is effective.
+            store_cost_profile_effective: match &cfg.flight {
+                Some(_) => None,
+                None => Some(cfg.store_cost_profile.clone()),
+            },
         },
         dataset,
+        // The request term is absent on every lane (no attempt source); the
+        // byte terms price this pass's GET wire bytes, which the Flight lane
+        // does not record, so a Flight pass models no byte cost either.
+        modeled_cost: model_pass_cost(&cfg.store_cost_profile, &entries),
         entries,
         skipped,
         failed,
@@ -2585,6 +2675,7 @@ mod tests {
             warm_catalog: false,
             logs_suffix_len: None,
             logs_request_cost_bytes: DEFAULT_LOG_REQUEST_COST_BYTES,
+            store_cost_profile: StoreCostProfile::reference(),
         }
     }
 
@@ -5182,6 +5273,7 @@ mod tests {
             warm_catalog: false,
             logs_suffix_len: None,
             logs_request_cost_bytes: DEFAULT_LOG_REQUEST_COST_BYTES,
+            store_cost_profile: StoreCostProfile::reference(),
         };
         let gen_report = run_generated(&gen_cfg).await.expect("generated lane runs");
         let load_ms = gen_report

--- a/crates/ravel-bench/tests/sql_latency_flight_smoke.rs
+++ b/crates/ravel-bench/tests/sql_latency_flight_smoke.rs
@@ -40,6 +40,7 @@ use ravel_sql::{
     SpanSegmentFetcher, SqlConfig, SqlExecutor,
 };
 use ravel_types::accounting::NoopQueryCostRecorder;
+use ravel_types::cost_profile::StoreCostProfile;
 use ravel_types::{CommitToken, TenantHash, TenantId, TimeRange};
 use tonic::metadata::MetadataMap;
 use tonic::transport::Server;
@@ -154,6 +155,7 @@ async fn publish_dataset(store: Arc<dyn ObjectStoreBackend>) -> TenantId {
         warm_catalog: false,
         logs_suffix_len: None,
         logs_request_cost_bytes: ravel_query::DEFAULT_LOG_REQUEST_COST_BYTES,
+        store_cost_profile: StoreCostProfile::reference(),
     })
     .await
     .expect("generated lane publishes the dataset");
@@ -254,6 +256,7 @@ fn flight_cfg(
         warm_catalog: false,
         logs_suffix_len: None,
         logs_request_cost_bytes: ravel_query::DEFAULT_LOG_REQUEST_COST_BYTES,
+        store_cost_profile: StoreCostProfile::reference(),
     }
 }
 
@@ -364,6 +367,27 @@ async fn flight_lane_measures_every_statement_over_the_wire_without_scan_diagnos
         report.provenance.sql_max_query_bytes_effective, None,
         "a Flight run does not send the ceiling, so the effective value is unknown"
     );
+    // The cost profile stamp follows the same requested/effective split: the
+    // Flight lane stamps the profile it ASKED for, but its effective profile is
+    // None because the foreign server's own --store-cost-profile governed
+    // pricing (ADR-0996 decision 1). The stamp is present exactly once each.
+    assert_eq!(
+        report.provenance.store_cost_profile_requested,
+        StoreCostProfile::reference(),
+        "the requested field carries this run's profile (flight_cfg's default)"
+    );
+    assert_eq!(
+        report.provenance.store_cost_profile_effective, None,
+        "a Flight run cannot know the server's profile, so the effective value is unknown"
+    );
+    // The Flight lane carries no per-run accounting, so it models no cost: the
+    // request term is absent (no attempt source) and no byte term is present.
+    assert_eq!(
+        report.modeled_cost.modeled_request_cost_nanodollars, None,
+        "no attempt source on the Flight lane: the modeled request cost is absent"
+    );
+    assert_eq!(report.modeled_cost.modeled_transfer_cost_nanodollars, None);
+    assert_eq!(report.modeled_cost.modeled_retrieval_cost_nanodollars, None);
     // The dataset stanza is still resolved from the store directly: a Flight
     // client cannot read the catalog.
     assert_eq!(report.dataset.object_count, 3);

--- a/crates/ravel-bench/tests/sql_latency_object_count_invariant.rs
+++ b/crates/ravel-bench/tests/sql_latency_object_count_invariant.rs
@@ -104,6 +104,7 @@ async fn l0_object_count_equals_distinct_data_object_keys() {
         warm_catalog: false,
         logs_suffix_len: None,
         logs_request_cost_bytes: ravel_query::DEFAULT_LOG_REQUEST_COST_BYTES,
+        store_cost_profile: ravel_types::cost_profile::StoreCostProfile::reference(),
     };
     let report = run_generated(&cfg).await.expect("generated lane runs");
 

--- a/crates/ravel-bench/tests/sql_latency_smoke.rs
+++ b/crates/ravel-bench/tests/sql_latency_smoke.rs
@@ -28,6 +28,7 @@ use ravel_bench::sql_latency::{GenerateConfig, measure_corpus, run_generated};
 use ravel_object_store::ObjectStoreBackend;
 use ravel_object_store::memory::MemoryStore;
 use ravel_sql::DEFAULT_MAX_QUERY_BYTES;
+use ravel_types::cost_profile::StoreCostProfile;
 use ravel_types::{TenantId, TimeRange};
 
 /// The frozen query clock the generated lane uses (`4h` in ns); the generated
@@ -61,6 +62,7 @@ fn small_generate_config(store: Arc<dyn ObjectStoreBackend>, runs: usize) -> Gen
         warm_catalog: false,
         logs_suffix_len: None,
         logs_request_cost_bytes: ravel_query::DEFAULT_LOG_REQUEST_COST_BYTES,
+        store_cost_profile: StoreCostProfile::reference(),
     }
 }
 
@@ -366,4 +368,73 @@ fn the_stdout_artifact_is_one_complete_json_document_with_no_trailing_bytes() {
         stderr.contains("sql_latency_bench report"),
         "the human summary must be on stderr: {stderr}"
     );
+}
+
+/// The generated (in-process) lane stamps the active cost profile and models
+/// the pass's cost (ADR-0996 decision 1 and 3). The stamp is present exactly
+/// once with `effective` populated (this lane prices in process); the modeled
+/// REQUEST cost is ABSENT, because this harness has no attempt source and a
+/// request cost is never modeled from calls; and the reference profile's zero
+/// byte prices leave the transfer/retrieval terms absent too. Absence is by
+/// omission, so the report still carries no null.
+#[tokio::test]
+async fn generated_lane_stamps_the_cost_profile_and_models_absent_request_cost() {
+    let store: Arc<dyn ObjectStoreBackend> = Arc::new(MemoryStore::new());
+    let report = run_generated(&small_generate_config(Arc::clone(&store), 2))
+        .await
+        .expect("generated lane runs");
+
+    assert_eq!(
+        report.provenance.store_cost_profile_requested,
+        StoreCostProfile::reference()
+    );
+    assert_eq!(
+        report.provenance.store_cost_profile_effective,
+        Some(StoreCostProfile::reference()),
+        "in-process lane: the requested profile is also the effective one"
+    );
+    assert_eq!(
+        report.modeled_cost.modeled_request_cost_nanodollars, None,
+        "no attempt source: the modeled request cost is absent, never a zero from calls"
+    );
+    assert_eq!(report.modeled_cost.modeled_transfer_cost_nanodollars, None);
+    assert_eq!(report.modeled_cost.modeled_retrieval_cost_nanodollars, None);
+
+    // Present exactly once, and no null anywhere: the absent modeled figures
+    // are skipped, not serialized as zero or null.
+    let json = serde_json::to_value(&report).expect("serialize report");
+    assert_eq!(
+        count_keys(&json, "store_cost_profile_requested"),
+        1,
+        "the requested profile stamp appears exactly once"
+    );
+    assert_eq!(count_keys(&json, "store_cost_profile_effective"), 1);
+    // The modeled cost object carries no request-cost key: an absent figure is
+    // skipped, not serialized as a zero. (The report as a whole does carry
+    // nulls in unrelated optional fields such as `logs_suffix_len`, so a
+    // report-wide no-null assertion does not belong here; the modeled-cost and
+    // stamp fields keep the contract by omission, checked above.)
+    assert_eq!(
+        count_keys(&json, "modeled_request_cost_nanodollars"),
+        0,
+        "an absent modeled request cost is skipped entirely"
+    );
+    assert_eq!(
+        count_keys(&json, "modeled_transfer_cost_nanodollars"),
+        0,
+        "a zero transfer price omits the transfer term entirely"
+    );
+    assert_eq!(count_keys(&json, "modeled_retrieval_cost_nanodollars"), 0);
+}
+
+/// Count how many times `key` appears as an object key anywhere in `v`.
+fn count_keys(v: &serde_json::Value, key: &str) -> usize {
+    match v {
+        serde_json::Value::Array(a) => a.iter().map(|e| count_keys(e, key)).sum(),
+        serde_json::Value::Object(o) => {
+            let here = o.contains_key(key) as usize;
+            here + o.values().map(|e| count_keys(e, key)).sum::<usize>()
+        }
+        _ => 0,
+    }
 }


### PR DESCRIPTION
Bench reports now carry a modeled request cost derived from billed
attempts and the active StoreCostProfile, plus a provenance stamp with
the requested and effective profile split (the Flight lane stamps
effective None because a foreign server's profile governs).

Absent attempts produce an absent modeled cost, never a zero derived
from call counts. LIST attempts fold into the PUT class as S3 bills
them. Nonzero byte prices add separately labelled transfer and
retrieval terms without moving the request term.

Tests pin the arithmetic to the nanodollar (27,800 from 5 PUT-class and
7 GET attempts at the reference profile), pin that two profiles move
the figure from identical counts, and pin the stamp appearing exactly
once. No CLI flags in this change; 996-5 owns those.

Local gate note: executor ran workspace clippy and the ravel-bench
feature lanes; full workspace gates run in this PR's required CI.

Refs: #996