### PR TITLE
feat(catalog): carry declared-column stamps onto SegmentRef

### DIFF
--- a/crates/ravel-bench/src/spans_scan.rs
+++ b/crates/ravel-bench/src/spans_scan.rs
@@ -316,6 +316,7 @@ async fn build_corpus(config: &SpansScanConfig) -> (Vec<SegmentRef>, usize) {
             created_unix_ns: 0,
             level: SegmentLevel::L0,
             segment_format_version: u32::from(ravel_rspan::footer::VERSION),
+            declared_column_stats: Default::default(),
         });
     }
     let objects = segments.len();

--- a/crates/ravel-catalog/src/catalog.rs
+++ b/crates/ravel-catalog/src/catalog.rs
@@ -3291,11 +3291,12 @@ fn build_rewrite_l1_segment_ref(
             part_index: part.part_index,
         },
         segment_format_version: part.segment_format_version,
-        // ADR-0873 decision 4: a listed L1 part carries its own stamps
-        // (CompactionPart field 12), gated against the part's row count.
-        declared_column_stats: DeclaredColumnStats::from_validated(
-            &ravel_commit::declared_stats::read_compaction_part(part),
-        ),
+        // NEVER carried for a rewrite output (ADR-0873 decision 3): the
+        // rewrite dropped rows, so a stamp computed before the drop is stale
+        // for the surviving rows. Rewrite writers emit empty stamps today;
+        // forcing empty here also refuses a stamped rewrite part from a buggy
+        // or future writer until the recompute path lands with its own tests.
+        declared_column_stats: DeclaredColumnStats::default(),
     })
 }
 

--- a/crates/ravel-catalog/src/catalog.rs
+++ b/crates/ravel-catalog/src/catalog.rs
@@ -28,6 +28,7 @@ use uuid::Uuid;
 use crate::cache::{CompactionRecordCache, HeadCache, PartCache, PostingsCache, RecordCache};
 use crate::column_stats_resolve::{self, LoadColumnStatsError, LoadedColumnStats};
 use crate::config::CatalogConfig;
+use crate::declared_stats::DeclaredColumnStats;
 use crate::error::CatalogError;
 use crate::provisioning::ShardGeneration;
 use crate::snapshot::{SegmentLevel, SegmentOrigin, SegmentOrigins, SegmentRef, Snapshot};
@@ -3218,6 +3219,11 @@ fn build_l1_segment_ref(
             part_index: part.part_index,
         },
         segment_format_version: part.segment_format_version,
+        // ADR-0873 decision 4: a listed L1 part carries its own stamps
+        // (CompactionPart field 12), gated against the part's row count.
+        declared_column_stats: DeclaredColumnStats::from_validated(
+            &ravel_commit::declared_stats::read_compaction_part(part),
+        ),
     })
 }
 
@@ -3285,6 +3291,11 @@ fn build_rewrite_l1_segment_ref(
             part_index: part.part_index,
         },
         segment_format_version: part.segment_format_version,
+        // ADR-0873 decision 4: a listed L1 part carries its own stamps
+        // (CompactionPart field 12), gated against the part's row count.
+        declared_column_stats: DeclaredColumnStats::from_validated(
+            &ravel_commit::declared_stats::read_compaction_part(part),
+        ),
     })
 }
 
@@ -3442,6 +3453,13 @@ fn build_segment_ref(key: &str, record: &CommitRecord) -> Result<SegmentRef, Cat
         created_unix_ns: record.created_unix_ns,
         level: SegmentLevel::L0,
         segment_format_version: record.segment_format_version,
+        // ADR-0873 decision 4: a listed or token-resolved L0 segment carries
+        // the stamps of the very record this resolve already read, which is
+        // what covers the live tail no fold-built object can reach. The gated
+        // read binds the row-count clauses against the record's sample_count.
+        declared_column_stats: DeclaredColumnStats::from_validated(
+            &ravel_commit::declared_stats::read_commit_record(record),
+        ),
     })
 }
 

--- a/crates/ravel-catalog/src/column_stats_build.rs
+++ b/crates/ravel-catalog/src/column_stats_build.rs
@@ -729,6 +729,7 @@ mod tests {
             series_count: 0,
             segment_format_version: 2,
             created_unix_ns: 0,
+            declared_column_stats: Vec::new(),
         }
     }
 
@@ -770,6 +771,7 @@ mod tests {
             series_count: 0,
             segment_format_version: 1,
             created_unix_ns: 0,
+            declared_column_stats: Vec::new(),
         }
     }
 

--- a/crates/ravel-catalog/src/declared_stats.rs
+++ b/crates/ravel-catalog/src/declared_stats.rs
@@ -1,0 +1,494 @@
+//! Declared-column min/max stamps on the catalog side (ADR-0873 decision 4):
+//! `SnapshotEntry.declared_column_stats` (field 15) and the shared list a
+//! resolved [`SegmentRef`](crate::SegmentRef) carries.
+//!
+//! Three rules govern this layer, all from the ADR:
+//!
+//! - **The fold copies validated stamps only.** A commit record's or
+//!   compaction part's entries reach a `SnapshotEntry` through
+//!   [`ravel_commit::declared_stats::read_commit_record`] /
+//!   [`ravel_commit::declared_stats::read_compaction_part`], the wave-2 gated
+//!   read whose row-count clauses bind against the source record's own
+//!   `sample_count`. A defective entry is dropped at the fold and never
+//!   reaches a sealed part, where it would outlive the record that carried it.
+//! - **Absence is permanent and legal.** An empty list means the segment is
+//!   uncovered for every declared column: every entry a pre-ADR-0873 fold
+//!   wrote, every metrics/spans entry, and every entry folded from an
+//!   unstamped record is in that state forever. Nothing here treats absence as
+//!   an error.
+//! - **Coverage is unconstructable without the predicate.** The only way to
+//!   put a non-empty [`DeclaredColumnStats`] on a `SegmentRef` is
+//!   [`DeclaredColumnStats::from_validated`], which takes a
+//!   [`ValidatedDeclaredStats`] -- a type whose sole producers are the three
+//!   carrier reads (the two in `ravel-commit`, plus [`read_snapshot_entry`]
+//!   here, which supplies the entry's own row count). A caller holding raw
+//!   decoded entries has no route to coverage.
+
+use std::sync::Arc;
+
+use ravel_commit::declared_stats::{self as commit_stats, ValidatedDeclaredStats};
+use ravel_proto::catalog::v1::{
+    DeclaredColumnMinMax, DeclaredColumnStatValue, SnapshotEntry, declared_column_stat_value::Kind,
+};
+use ravel_proto::commit::v1 as commit_pb;
+use ravel_types::declared_stats::DeclaredColumnStat;
+
+/// The declared-column stamps of one resolved segment (ADR-0873 decision 1),
+/// shared rather than owned per ref.
+///
+/// A `SegmentRef` is cloned per query, per plan partition, and per fetch, so
+/// the payload sits behind an `Arc` and a clone is a refcount bump. The
+/// overwhelmingly common state is "no stamps at all" -- every pre-ADR-0873
+/// record, every metrics or spans segment -- and that state holds no
+/// allocation at all, which is why the empty case is `None` rather than an
+/// empty `Arc<[_]>`: it is on the resolve path for every segment of every
+/// query. Building one normalises an empty list to that same `None`, so two
+/// uncovered refs always compare equal.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DeclaredColumnStats(Option<Arc<[DeclaredColumnStat]>>);
+
+impl DeclaredColumnStats {
+    /// The stamps a carrier read validated, shared for the refs built from it.
+    ///
+    /// Taking the validated form rather than a slice of entries is the point:
+    /// possessing a [`ValidatedDeclaredStats`] is proof the full statistics
+    /// validity predicate ran, row-count clauses included, and this is the only
+    /// public constructor that yields a non-empty list (ADR-0873 decision 2,
+    /// "where the predicate binds").
+    pub fn from_validated(validated: &ValidatedDeclaredStats) -> Self {
+        let covered = validated.covered();
+        if covered.is_empty() {
+            return DeclaredColumnStats(None);
+        }
+        DeclaredColumnStats(Some(Arc::from(covered)))
+    }
+
+    /// The covered columns, in the carrier's entry order. Empty when the
+    /// segment is uncovered, which is a legal permanent state.
+    pub fn as_slice(&self) -> &[DeclaredColumnStat] {
+        match &self.0 {
+            Some(stats) => stats,
+            None => &[],
+        }
+    }
+
+    /// Whether this segment is uncovered for every declared column.
+    pub fn is_empty(&self) -> bool {
+        self.as_slice().is_empty()
+    }
+
+    /// Number of covered columns.
+    pub fn len(&self) -> usize {
+        self.as_slice().len()
+    }
+
+    /// One covered column's statistics by name, or `None` when this segment is
+    /// uncovered for it.
+    pub fn column(&self, name: &str) -> Option<&DeclaredColumnStat> {
+        self.as_slice().iter().find(|stat| stat.name() == name)
+    }
+}
+
+fn value_to_proto(value: &commit_pb::DeclaredColumnStatValue) -> DeclaredColumnStatValue {
+    let kind = value.kind.as_ref().map(|kind| match kind {
+        commit_pb::declared_column_stat_value::Kind::I64(v) => Kind::I64(*v),
+        commit_pb::declared_column_stat_value::Kind::B(b) => Kind::B(*b),
+    });
+    DeclaredColumnStatValue { kind }
+}
+
+fn value_to_commit(value: &DeclaredColumnStatValue) -> commit_pb::DeclaredColumnStatValue {
+    let kind = value.kind.as_ref().map(|kind| match kind {
+        Kind::I64(v) => commit_pb::declared_column_stat_value::Kind::I64(*v),
+        Kind::B(b) => commit_pb::declared_column_stat_value::Kind::B(*b),
+    });
+    commit_pb::DeclaredColumnStatValue { kind }
+}
+
+/// One commit-side entry as its catalog-side mirror. Total and lossless: the
+/// two messages are field-for-field identical by construction (ADR-0873
+/// decision 1), including the value kinds and a present-but-empty value
+/// message, which is a defect the reader must still see rather than one this
+/// conversion may quietly normalise away.
+fn entry_to_proto(entry: &commit_pb::DeclaredColumnMinMax) -> DeclaredColumnMinMax {
+    DeclaredColumnMinMax {
+        name: entry.name.clone(),
+        declared_type: entry.declared_type,
+        min: entry.min.as_ref().map(value_to_proto),
+        max: entry.max.as_ref().map(value_to_proto),
+        null_count: entry.null_count,
+    }
+}
+
+/// The same conversion in the read direction.
+fn entry_to_commit(entry: &DeclaredColumnMinMax) -> commit_pb::DeclaredColumnMinMax {
+    commit_pb::DeclaredColumnMinMax {
+        name: entry.name.clone(),
+        declared_type: entry.declared_type,
+        min: entry.min.as_ref().map(value_to_commit),
+        max: entry.max.as_ref().map(value_to_commit),
+        null_count: entry.null_count,
+    }
+}
+
+/// Encode validated stamps for the catalog wire.
+///
+/// Takes the validated form, not a slice of [`DeclaredColumnStat`]: what the
+/// fold writes into a sealed part is exactly what the source record's own
+/// predicate pass admitted, and nothing else can be written by accident.
+fn encode_validated(validated: &ValidatedDeclaredStats) -> Vec<DeclaredColumnMinMax> {
+    validated
+        .covered()
+        .iter()
+        .map(|stat| entry_to_proto(&commit_stats::encode(stat)))
+        .collect()
+}
+
+/// The stamps a fold carries from one L0 commit record onto its
+/// [`SnapshotEntry`] (ADR-0873 decision 4).
+///
+/// The record is read through the wave-2 gated path, so only entries that
+/// passed the full predicate against the record's own `sample_count` (field
+/// 11) are carried; the dropped ones simply leave their column uncovered for
+/// this segment. Returns an empty list for an unstamped record, which is the
+/// permanent state of every record written before ADR-0873.
+pub(crate) fn carry_commit_record(record: &commit_pb::CommitRecord) -> Vec<DeclaredColumnMinMax> {
+    encode_validated(&commit_stats::read_commit_record(record))
+}
+
+/// The same carriage for one compaction or erasure-rewrite output part, whose
+/// row count is `CompactionPart.sample_count` (field 6).
+pub(crate) fn carry_compaction_part(part: &commit_pb::CompactionPart) -> Vec<DeclaredColumnMinMax> {
+    encode_validated(&commit_stats::read_compaction_part(part))
+}
+
+/// Read a snapshot entry's stamps, reconciled against the entry's own row
+/// count (`sample_count`, field 11).
+///
+/// This is the third producer of a [`ValidatedDeclaredStats`], and it binds
+/// the predicate exactly where the other two do: at a carrier that knows how
+/// many rows the segment holds. A snapshot entry is a copy of a record's
+/// stamps, so its entries get the same treatment as the originals rather than
+/// being trusted because a fold once wrote them -- a part sealed by a fold
+/// whose copy was wrong is still an untrusted object.
+///
+/// The predicate itself is not reimplemented here. The catalog-side messages
+/// are a field-for-field mirror of the commit-side pair (ADR-0873 decision 1),
+/// so the entries are converted to their twins and read through
+/// [`ravel_commit::declared_stats::read_commit_record`] against the entry's row
+/// count, which is the same quantity clauses 4 and 5 are stated over. A second
+/// implementation of the predicate is a second thing to keep in agreement, and
+/// the ADR's reader-agreement rule exists because that divergence has already
+/// shipped once.
+pub fn read_snapshot_entry(entry: &SnapshotEntry) -> ValidatedDeclaredStats {
+    let twin = commit_pb::CommitRecord {
+        sample_count: entry.sample_count,
+        declared_column_stats: entry
+            .declared_column_stats
+            .iter()
+            .map(entry_to_commit)
+            .collect(),
+        ..Default::default()
+    };
+    commit_stats::read_commit_record(&twin)
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+    use ravel_commit::declared_stats::{DeclaredStatDefect, stamp_commit_record};
+    use ravel_types::declared_stats::{
+        DeclaredStatError, DeclaredStatType, DeclaredStatValue, TYPED_ATTR_COLUMN_TYPE_F64,
+        TYPED_ATTR_COLUMN_TYPE_STR,
+    };
+
+    fn i64_stat(name: &str, min: i64, max: i64, null_count: u64) -> DeclaredColumnStat {
+        DeclaredColumnStat::new(
+            name,
+            DeclaredStatType::I64,
+            Some(DeclaredStatValue::I64(min)),
+            Some(DeclaredStatValue::I64(max)),
+            null_count,
+        )
+        .expect("valid i64 stat")
+    }
+
+    fn bool_stat(name: &str, min: bool, max: bool, null_count: u64) -> DeclaredColumnStat {
+        DeclaredColumnStat::new(
+            name,
+            DeclaredStatType::Bool,
+            Some(DeclaredStatValue::Bool(min)),
+            Some(DeclaredStatValue::Bool(max)),
+            null_count,
+        )
+        .expect("valid bool stat")
+    }
+
+    fn entry(sample_count: u64, stats: Vec<DeclaredColumnMinMax>) -> SnapshotEntry {
+        SnapshotEntry {
+            level: 0,
+            shard: 0,
+            ingest_hour_bucket: 500_000,
+            writer_id: vec![0xAA; 16],
+            writer_epoch: 1,
+            writer_seq: 1,
+            content_hash: vec![0xBB; 32],
+            object_size: 4_096,
+            min_event_ts_ns: 0,
+            max_event_ts_ns: 100,
+            sample_count,
+            series_count: 1,
+            segment_format_version: 4,
+            created_unix_ns: 1_000,
+            declared_column_stats: stats,
+        }
+    }
+
+    fn commit_record(sample_count: u64, stats: &[DeclaredColumnStat]) -> commit_pb::CommitRecord {
+        let mut record = commit_pb::CommitRecord {
+            sample_count,
+            ..Default::default()
+        };
+        stamp_commit_record(&mut record, stats);
+        record
+    }
+
+    #[test]
+    fn a_commit_records_validated_stamps_are_carried_verbatim() {
+        let stats = vec![
+            i64_stat("EventDate", -5, 19_000, 12),
+            bool_stat("IsRefresh", false, true, 0),
+        ];
+        let carried = carry_commit_record(&commit_record(1_000, &stats));
+        let read = read_snapshot_entry(&entry(1_000, carried));
+        assert!(read.dropped().is_empty());
+        assert_eq!(read.covered().to_vec(), stats);
+    }
+
+    #[test]
+    fn a_compaction_parts_validated_stamps_are_carried_verbatim() {
+        let stats = vec![i64_stat("EventDate", 3, 4, 1)];
+        let mut part = commit_pb::CompactionPart {
+            sample_count: 10,
+            ..Default::default()
+        };
+        ravel_commit::declared_stats::stamp_compaction_part(&mut part, &stats);
+        let read = read_snapshot_entry(&entry(10, carry_compaction_part(&part)));
+        assert!(read.dropped().is_empty());
+        assert_eq!(read.covered().to_vec(), stats);
+    }
+
+    #[test]
+    fn an_unstamped_record_carries_an_empty_list_not_a_placeholder() {
+        let carried = carry_commit_record(&commit_record(1_000, &[]));
+        assert_eq!(carried.len(), 0);
+        let read = read_snapshot_entry(&entry(1_000, carried));
+        assert_eq!(read.covered().len(), 0);
+        assert_eq!(read.dropped().len(), 0);
+        assert_eq!(read.column("EventDate"), None);
+        assert!(DeclaredColumnStats::from_validated(&read).is_empty());
+    }
+
+    #[test]
+    fn a_stamp_that_fails_a_row_count_clause_is_not_carried() {
+        // Eight NULLs in a seven-row object (clause 4) beside a valid entry.
+        // The invalid one must not reach the entry at all: it would otherwise
+        // outlive the record whose row count convicts it.
+        let valid = i64_stat("EventDate", 1, 2, 6);
+        let mut record = commit_record(7, std::slice::from_ref(&valid));
+        record
+            .declared_column_stats
+            .push(commit_stats::encode(&i64_stat("Status", 200, 500, 8)));
+        let carried = carry_commit_record(&record);
+        assert_eq!(carried.len(), 1);
+        assert_eq!(carried[0].name, "EventDate");
+        let read = read_snapshot_entry(&entry(7, carried));
+        assert_eq!(read.covered().to_vec(), vec![valid]);
+        assert_eq!(read.column("Status"), None);
+    }
+
+    #[test]
+    fn the_entrys_own_row_count_binds_clauses_four_and_five() {
+        // The same entries, read against two row counts. The predicate is not
+        // carried over from the fold: it re-binds against the entry's own
+        // sample_count (field 11), so a copy whose row count disagrees with
+        // its stamps is dropped here even though some earlier reader accepted
+        // it.
+        let stamps = vec![entry_to_proto(&commit_stats::encode(&i64_stat(
+            "EventDate",
+            1,
+            2,
+            6,
+        )))];
+        let honest = read_snapshot_entry(&entry(7, stamps.clone()));
+        assert_eq!(honest.covered().len(), 1);
+        assert!(honest.dropped().is_empty());
+
+        let lying = read_snapshot_entry(&entry(6, stamps));
+        assert_eq!(lying.covered().len(), 0);
+        assert_eq!(lying.dropped().len(), 1);
+        assert_eq!(
+            lying.dropped()[0].reason,
+            DeclaredStatDefect::PresenceDisagreesWithNullCount {
+                name: "EventDate".to_string(),
+                extrema: "present",
+                null_count: 6,
+                sample_count: 6,
+            }
+        );
+        assert!(DeclaredColumnStats::from_validated(&lying).is_empty());
+    }
+
+    #[test]
+    fn ineligible_and_malformed_entries_on_an_entry_are_dropped_per_entry() {
+        let stats = vec![
+            DeclaredColumnMinMax {
+                name: "URL".to_string(),
+                declared_type: TYPED_ATTR_COLUMN_TYPE_STR,
+                min: None,
+                max: None,
+                null_count: 7,
+            },
+            DeclaredColumnMinMax {
+                name: "Ratio".to_string(),
+                declared_type: TYPED_ATTR_COLUMN_TYPE_F64,
+                min: None,
+                max: None,
+                null_count: 7,
+            },
+            // Present value message with no kind set.
+            DeclaredColumnMinMax {
+                name: "Empty".to_string(),
+                declared_type: DeclaredStatType::I64.tag(),
+                min: Some(DeclaredColumnStatValue { kind: None }),
+                max: Some(DeclaredColumnStatValue { kind: None }),
+                null_count: 0,
+            },
+            entry_to_proto(&commit_stats::encode(&i64_stat("EventDate", 1, 2, 0))),
+        ];
+        let read = read_snapshot_entry(&entry(7, stats));
+        assert_eq!(
+            read.covered().to_vec(),
+            vec![i64_stat("EventDate", 1, 2, 0)]
+        );
+        assert_eq!(read.dropped().len(), 3);
+        assert_eq!(
+            read.dropped()[0].reason,
+            DeclaredStatDefect::Invalid(DeclaredStatError::IneligibleType {
+                tag: TYPED_ATTR_COLUMN_TYPE_STR
+            })
+        );
+        assert_eq!(
+            read.dropped()[1].reason,
+            DeclaredStatDefect::Invalid(DeclaredStatError::IneligibleType {
+                tag: TYPED_ATTR_COLUMN_TYPE_F64
+            })
+        );
+        assert_eq!(
+            read.dropped()[2].reason,
+            DeclaredStatDefect::EmptyValueKind {
+                name: "Empty".to_string(),
+                which: "min",
+            }
+        );
+        let shared = DeclaredColumnStats::from_validated(&read);
+        assert_eq!(shared.len(), 1);
+        assert_eq!(shared.column("URL"), None);
+        assert_eq!(shared.column("Ratio"), None);
+        assert_eq!(
+            shared.column("EventDate").map(|s| s.max()),
+            Some(Some(DeclaredStatValue::I64(2)))
+        );
+    }
+
+    #[test]
+    fn an_empty_shared_list_holds_no_allocation_and_compares_equal() {
+        let empty = DeclaredColumnStats::default();
+        assert!(empty.is_empty());
+        assert_eq!(empty.len(), 0);
+        assert_eq!(empty.as_slice(), &[]);
+        // Built from a read that covered nothing: the same value, so two
+        // uncovered refs are equal whichever route produced them.
+        let read = read_snapshot_entry(&entry(1_000, Vec::new()));
+        assert_eq!(DeclaredColumnStats::from_validated(&read), empty);
+    }
+
+    #[test]
+    fn cloning_the_shared_list_shares_one_allocation() {
+        let stats = vec![i64_stat("EventDate", 1, 2, 0)];
+        let read = read_snapshot_entry(&entry(7, carry_commit_record(&commit_record(7, &stats))));
+        let shared = DeclaredColumnStats::from_validated(&read);
+        let cloned = shared.clone();
+        assert_eq!(shared, cloned);
+        // A clone is a refcount bump, not a copy of the entries: the two lists
+        // are the same allocation. `SegmentRef` is cloned per query, which is
+        // why the field is shared at all.
+        assert!(std::ptr::eq(shared.as_slice(), cloned.as_slice()));
+    }
+
+    fn arb_value() -> impl Strategy<Value = Option<DeclaredColumnStatValue>> {
+        prop_oneof![
+            Just(None),
+            Just(Some(DeclaredColumnStatValue { kind: None })),
+            any::<i64>().prop_map(|v| Some(DeclaredColumnStatValue {
+                kind: Some(Kind::I64(v))
+            })),
+            any::<bool>().prop_map(|b| Some(DeclaredColumnStatValue {
+                kind: Some(Kind::B(b))
+            })),
+        ]
+    }
+
+    fn arb_entry_message() -> impl Strategy<Value = DeclaredColumnMinMax> {
+        (".{0,8}", 0u32..8, arb_value(), arb_value(), any::<u64>()).prop_map(
+            |(name, declared_type, min, max, null_count)| DeclaredColumnMinMax {
+                name,
+                declared_type,
+                min,
+                max,
+                null_count,
+            },
+        )
+    }
+
+    proptest! {
+        /// The mirror conversion is lossless in both directions, for every
+        /// shape the wire can hold including the defective ones. It has to be:
+        /// the read path converts a catalog entry to its commit twin to run
+        /// one shared predicate, so a conversion that normalised anything
+        /// would make the two carriers disagree about the same bytes.
+        #[test]
+        fn mirror_conversion_round_trips(entry in arb_entry_message()) {
+            let there_and_back = entry_to_proto(&entry_to_commit(&entry));
+            prop_assert_eq!(there_and_back, entry);
+        }
+
+        /// Whatever the entries, the read is total: it never panics, every
+        /// covered entry is self-consistent, and covered plus dropped accounts
+        /// for every entry exactly once.
+        #[test]
+        fn reading_arbitrary_entries_never_panics(
+            stats in prop::collection::vec(arb_entry_message(), 0..6),
+            sample_count in any::<u64>(),
+        ) {
+            let count = stats.len();
+            let read = read_snapshot_entry(&entry(sample_count, stats));
+            prop_assert_eq!(read.covered().len() + read.dropped().len(), count);
+            for stat in read.covered() {
+                prop_assert!(!stat.name().is_empty());
+                prop_assert!(stat.null_count() <= sample_count);
+                match (stat.min(), stat.max()) {
+                    (Some(min), Some(max)) => {
+                        prop_assert_eq!(min.stat_type(), stat.declared_type());
+                        prop_assert_eq!(max.stat_type(), stat.declared_type());
+                        prop_assert!(stat.null_count() < sample_count);
+                    }
+                    (None, None) => prop_assert_eq!(stat.null_count(), sample_count),
+                    _ => prop_assert!(false, "a one-sided pair is never covered"),
+                }
+            }
+        }
+    }
+}

--- a/crates/ravel-catalog/src/fold.rs
+++ b/crates/ravel-catalog/src/fold.rs
@@ -484,10 +484,13 @@ fn build_rewrite_l1_snapshot_entry(
         series_count: part.series_count,
         segment_format_version: part.segment_format_version,
         created_unix_ns: record.created_unix_ns,
-        // The part's own stamps (CompactionPart field 12), gated against the
-        // part's own row count exactly as the L0 path gates a commit record's
-        // (ADR-0873 decision 4).
-        declared_column_stats: declared_stats::carry_compaction_part(part),
+        // NEVER carried for a rewrite output (ADR-0873 decision 3): the
+        // rewrite dropped rows, so a stamp computed before the drop is stale
+        // for the surviving rows. Every rewrite writer emits empty stamps
+        // today; forcing empty here also refuses a stamped rewrite part from
+        // a buggy or future writer until the recompute path lands with its
+        // own tests and flips this line deliberately.
+        declared_column_stats: Vec::new(),
     })
 }
 

--- a/crates/ravel-catalog/src/fold.rs
+++ b/crates/ravel-catalog/src/fold.rs
@@ -36,6 +36,7 @@ use uuid::Uuid;
 use crate::catalog::Catalog;
 use crate::column_stats_build;
 use crate::config::CatalogConfig;
+use crate::declared_stats;
 use crate::error::CatalogError;
 use crate::provisioning::{DEFAULT_SCAN_SLACK_HOURS, ShardGeneration, scan_count};
 use crate::snapshot_format::{
@@ -377,6 +378,12 @@ fn build_snapshot_entry(key: &str, record: &CommitRecord) -> Result<SnapshotEntr
         series_count: record.series_count,
         segment_format_version: record.segment_format_version,
         created_unix_ns: record.created_unix_ns,
+        // ADR-0873 decision 4: the stamps are copied from the record the fold
+        // is already reading, through the gated read that binds the row-count
+        // clauses against this record's own sample_count. A defective entry is
+        // dropped here rather than sealed into a part that outlives the record
+        // proving it wrong.
+        declared_column_stats: declared_stats::carry_commit_record(record),
     })
 }
 
@@ -426,6 +433,10 @@ fn build_l1_snapshot_entry(
         series_count: part.series_count,
         segment_format_version: part.segment_format_version,
         created_unix_ns: record.created_unix_ns,
+        // The part's own stamps (CompactionPart field 12), gated against the
+        // part's own row count exactly as the L0 path gates a commit record's
+        // (ADR-0873 decision 4).
+        declared_column_stats: declared_stats::carry_compaction_part(part),
     })
 }
 
@@ -473,6 +484,10 @@ fn build_rewrite_l1_snapshot_entry(
         series_count: part.series_count,
         segment_format_version: part.segment_format_version,
         created_unix_ns: record.created_unix_ns,
+        // The part's own stamps (CompactionPart field 12), gated against the
+        // part's own row count exactly as the L0 path gates a commit record's
+        // (ADR-0873 decision 4).
+        declared_column_stats: declared_stats::carry_compaction_part(part),
     })
 }
 

--- a/crates/ravel-catalog/src/lib.rs
+++ b/crates/ravel-catalog/src/lib.rs
@@ -11,6 +11,7 @@ mod column_stats_build;
 mod column_stats_resolve;
 mod config;
 mod covering_postings;
+mod declared_stats;
 mod error;
 mod fold;
 mod key_epoch;
@@ -43,6 +44,7 @@ pub use config::{
     DEFAULT_PROTECTION_HORIZON_NS, DEFAULT_SNAPSHOT_CACHE_PARTS,
 };
 pub use covering_postings::{LoadPostingsError, LoadedCoveringPostings, load_covering_postings};
+pub use declared_stats::{DeclaredColumnStats, read_snapshot_entry};
 pub use error::CatalogError;
 pub use fold::{FoldReport, PostingsBuildError, Transaction, fetch_segment_names};
 pub use key_epoch::{

--- a/crates/ravel-catalog/src/snapshot.rs
+++ b/crates/ravel-catalog/src/snapshot.rs
@@ -4,6 +4,8 @@
 use ravel_proto::commit::v1::ErasureRequest;
 use uuid::Uuid;
 
+use crate::declared_stats::DeclaredColumnStats;
+
 /// Which storage level a [`SegmentRef`] names
 /// (docs/catalog-and-mvcc.md "Snapshot resolution").
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -76,6 +78,23 @@ pub struct SegmentRef {
     /// is a decode choice only and the ranged route would pay a probe to fetch
     /// the same whole-object bytes (issue #862).
     pub segment_format_version: u32,
+    /// Exact whole-object min/max and null count per stamp-eligible declared
+    /// typed attribute column, from whichever record this ref was resolved
+    /// through (ADR-0873 decision 4): a listed or token-resolved
+    /// `CommitRecord`, a `CompactionPart`, or a folded `SnapshotEntry`. Every
+    /// entry here passed the statistics validity predicate against that
+    /// carrier's own row count; a defective one is absent, leaving its column
+    /// uncovered for this segment.
+    ///
+    /// Empty is the normal permanent state for a segment whose record predates
+    /// ADR-0873, for every metrics and spans segment, and for a column
+    /// declared after the segment's flush opened. A reader that finds a column
+    /// uncovered here falls back to scanning; absence is never an error.
+    ///
+    /// Shared, not owned: a `SegmentRef` is cloned per query and per plan
+    /// partition, so cloning this field is a refcount bump and the empty case
+    /// costs no allocation.
+    pub declared_column_stats: DeclaredColumnStats,
 }
 
 /// A pinned, immutable set of segments for one `resolve` call (MVCC).

--- a/crates/ravel-catalog/src/snapshot.rs
+++ b/crates/ravel-catalog/src/snapshot.rs
@@ -30,6 +30,12 @@ pub enum SegmentLevel {
 }
 
 /// One immutable segment reference in a resolved snapshot.
+///
+/// The derived equality includes `declared_column_stats`, so two views of one
+/// segment with different coverage compare unequal -- in particular a
+/// Flight-pin-rebuilt ref (always uncovered) versus a catalog-resolved one.
+/// No production path compares `SegmentRef`s across routes; the derive stays
+/// because weakening it would let a carriage bug hide behind test equality.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SegmentRef {
     /// Data-object key, reconstructed from identity fields, never a stored

--- a/crates/ravel-catalog/src/snapshot_format/mod.rs
+++ b/crates/ravel-catalog/src/snapshot_format/mod.rs
@@ -303,6 +303,7 @@ mod tests {
             series_count: 1,
             segment_format_version: 1,
             created_unix_ns: 1_000,
+            declared_column_stats: Vec::new(),
         };
         let part =
             encode_part([0x11; 16], 1, 8, 5, std::slice::from_ref(&entry)).expect("encode part");
@@ -335,6 +336,7 @@ mod tests {
             series_count: 1,
             segment_format_version: 1,
             created_unix_ns: 1_000,
+            declared_column_stats: Vec::new(),
         };
 
         // Level 0 accepts exactly the 16-byte flush writer uuid.

--- a/crates/ravel-catalog/src/snapshot_resolve.rs
+++ b/crates/ravel-catalog/src/snapshot_resolve.rs
@@ -26,6 +26,7 @@ use ravel_types::{Signal, TenantHash, TimeRange};
 use uuid::Uuid;
 
 use crate::catalog::Catalog;
+use crate::declared_stats::{self, DeclaredColumnStats};
 use crate::error::CatalogError;
 use crate::fold::head_object_key;
 use crate::provisioning::{ShardGeneration, shard_ceiling};
@@ -1001,6 +1002,12 @@ fn build_segment_ref_from_entry(
                 part_index,
             },
             segment_format_version: entry.segment_format_version,
+            // ADR-0873 decision 4: the stamps the fold copied off the
+            // compaction part, re-validated against this entry's own row count
+            // rather than trusted because a fold wrote them.
+            declared_column_stats: DeclaredColumnStats::from_validated(
+                &declared_stats::read_snapshot_entry(entry),
+            ),
         });
     }
 
@@ -1041,6 +1048,11 @@ fn build_segment_ref_from_entry(
         created_unix_ns: entry.created_unix_ns,
         level: SegmentLevel::L0,
         segment_format_version: entry.segment_format_version,
+        // ADR-0873 decision 4: the stamps the fold copied off the commit
+        // record, re-validated against this entry's own row count.
+        declared_column_stats: DeclaredColumnStats::from_validated(
+            &declared_stats::read_snapshot_entry(entry),
+        ),
     })
 }
 
@@ -1822,6 +1834,7 @@ mod tests {
             series_count: 1,
             segment_format_version: 1,
             created_unix_ns: 0,
+            declared_column_stats: Vec::new(),
         };
         let part0 = Arc::new(DecodedPart {
             header: SnapshotPartHeader::default(),

--- a/crates/ravel-catalog/tests/declared_stats_carriage.rs
+++ b/crates/ravel-catalog/tests/declared_stats_carriage.rs
@@ -1,0 +1,644 @@
+//! ADR-0873 wave 3: the declared-column stamps a writer put on a commit
+//! record or a compaction part must arrive, unchanged, on the `SegmentRef` a
+//! resolve returns -- through the fold, the `.csnap` part, and snapshot
+//! resolution -- and must be identical whether the segment is resolved from a
+//! live listing above the fold watermark or from a sealed snapshot entry.
+//!
+//! Every assertion here is on the exact stamp struct (name, declared type,
+//! both extrema, null count), never on a length or a "some coverage exists"
+//! predicate: a carriage bug that swaps two columns, drops an extremum, or
+//! defaults a null count to zero passes every count-shaped assertion, and a
+//! defaulted null count silently turns "every row is NULL" into "no NULLs"
+//! with `Precision::Exact` attached.
+//!
+//! Resolution never fetches segment bytes, and the fold's postings build is
+//! allowed to fail without failing the fold, so these tests publish commit and
+//! compaction records only -- no data objects.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::sync::Arc;
+
+use prost::Message;
+use ravel_catalog::{
+    Catalog, CatalogConfig, DEFAULT_CLOCK_SKEW_ALLOWANCE_NS, DEFAULT_FOLD_SAFETY_MARGIN_NS,
+    DEFAULT_MAX_FLUSH_LIFETIME_NS, PartLimits, SegmentLevel, SegmentRef, decode_part, encode_part,
+    read_snapshot_entry,
+};
+use ravel_commit::declared_stats::{stamp_commit_record, stamp_compaction_part};
+use ravel_commit::record::{self, NewCommitRecord};
+use ravel_commit::{keys, signal};
+use ravel_object_store::memory::MemoryStore;
+use ravel_object_store::{GetRange, ObjectStoreBackend, PutOptions};
+use ravel_proto::catalog::v1::SnapshotEntry;
+use ravel_proto::commit::v1::{
+    CommitRecord, CompactionInputIdentity, CompactionPart, CompactionRecord,
+};
+use ravel_segment::VERSION_V7;
+use ravel_types::declared_stats::{DeclaredColumnStat, DeclaredStatType, DeclaredStatValue};
+use ravel_types::{Signal, TenantHash, TimeRange};
+use uuid::Uuid;
+
+const NS_PER_HOUR: i64 = 3_600_000_000_000;
+const MARGIN_NS: i64 =
+    DEFAULT_MAX_FLUSH_LIFETIME_NS + DEFAULT_CLOCK_SKEW_ALLOWANCE_NS + DEFAULT_FOLD_SAFETY_MARGIN_NS;
+const SIGNAL: Signal = Signal::Logs;
+
+fn tenant() -> TenantHash {
+    TenantHash([0x7a; 16])
+}
+
+fn config() -> CatalogConfig {
+    CatalogConfig {
+        shard_count: 1,
+        ..Default::default()
+    }
+}
+
+/// `now_ns` at which ingest hour `hour` has just sealed under default margins.
+fn now_at_seal(hour: u32) -> i64 {
+    (i64::from(hour) + 1) * NS_PER_HOUR + MARGIN_NS
+}
+
+fn i64_stat(name: &str, min: i64, max: i64, null_count: u64) -> DeclaredColumnStat {
+    DeclaredColumnStat::new(
+        name,
+        DeclaredStatType::I64,
+        Some(DeclaredStatValue::I64(min)),
+        Some(DeclaredStatValue::I64(max)),
+        null_count,
+    )
+    .expect("valid i64 stat")
+}
+
+fn bool_stat(name: &str, min: bool, max: bool, null_count: u64) -> DeclaredColumnStat {
+    DeclaredColumnStat::new(
+        name,
+        DeclaredStatType::Bool,
+        Some(DeclaredStatValue::Bool(min)),
+        Some(DeclaredStatValue::Bool(max)),
+        null_count,
+    )
+    .expect("valid bool stat")
+}
+
+/// Content hash of the record `l0_record` builds for `seq`, so a test can find
+/// one segment among several without depending on snapshot order.
+fn l0_hash_byte(seq: u64) -> u8 {
+    seq as u8 ^ 0x5a
+}
+
+/// A self-consistent L0 commit record of `sample_count` rows, stamped with
+/// `stats` exactly as the writer that computed them would stamp it.
+fn l0_record(seq: u64, hour: u32, sample_count: u64, stats: &[DeclaredColumnStat]) -> CommitRecord {
+    let event = i64::from(hour) * NS_PER_HOUR + 60_000_000_000;
+    let mut rec = record::build(NewCommitRecord {
+        tenant_hash: tenant(),
+        signal: SIGNAL,
+        shard: 0,
+        writer_id: Uuid::from_u128(u128::from(seq) + 1),
+        writer_epoch: 1,
+        writer_seq: seq,
+        object_size: 100,
+        content_hash: [l0_hash_byte(seq); 32],
+        sample_count,
+        series_count: 1,
+        min_event_ts_ns: event,
+        max_event_ts_ns: event + 100,
+        min_ingest_ts_ns: event,
+        max_ingest_ts_ns: event + 100,
+        segment_format_version: u32::from(VERSION_V7),
+        created_unix_ns: event,
+        ingest_hour_bucket: hour,
+    })
+    .expect("valid record");
+    stamp_commit_record(&mut rec, stats);
+    rec
+}
+
+async fn put_l0(store: &dyn ObjectStoreBackend, rec: &CommitRecord) {
+    let key = keys::commit_key_for_record(rec).expect("commit key");
+    store
+        .put(&key, record::encode(rec), PutOptions::create_if_absent())
+        .await
+        .expect("put commit record");
+}
+
+fn part(
+    part_index: u32,
+    hour: u32,
+    seed: u8,
+    sample_count: u64,
+    stats: &[DeclaredColumnStat],
+) -> CompactionPart {
+    let event = i64::from(hour) * NS_PER_HOUR + 60_000_000_000;
+    let mut part = CompactionPart {
+        part_index,
+        first_series_id: vec![0u8; 16],
+        last_series_id: vec![0xff; 16],
+        content_hash: vec![seed; 32],
+        object_size: 4096,
+        sample_count,
+        series_count: 2,
+        run_count: 3,
+        min_event_ts_ns: event,
+        max_event_ts_ns: event + 100,
+        segment_format_version: u32::from(VERSION_V7),
+        declared_column_stats: Vec::new(),
+    };
+    stamp_compaction_part(&mut part, stats);
+    part
+}
+
+async fn put_compaction_record(
+    store: &dyn ObjectStoreBackend,
+    hour: u32,
+    inputs: &[&CommitRecord],
+    parts: Vec<CompactionPart>,
+) {
+    let input_set_hash = *blake3::hash(b"declared-stats-carriage").as_bytes();
+    let rec = CompactionRecord {
+        format_version: 1,
+        tenant_hash: tenant().0.to_vec(),
+        signal: signal::to_proto(SIGNAL) as i32,
+        shard: 0,
+        ingest_hour_bucket: hour,
+        level: 1,
+        inputs: inputs
+            .iter()
+            .map(|r| CompactionInputIdentity {
+                writer_id: r.writer_id.clone(),
+                writer_epoch: r.writer_epoch,
+                writer_seq: r.writer_seq,
+            })
+            .collect(),
+        input_set_hash: input_set_hash.to_vec(),
+        parts,
+        created_unix_ns: i64::from(hour) * NS_PER_HOUR + 120_000_000_000,
+    };
+    let hash16: String = input_set_hash[..8]
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect();
+    let key =
+        keys::compaction_record_key(&tenant(), SIGNAL, 0, hour, &hash16).expect("compaction key");
+    store
+        .put(
+            &key,
+            rec.encode_to_vec().into(),
+            PutOptions::create_if_absent(),
+        )
+        .await
+        .expect("put compaction record");
+}
+
+/// Fold, then return the sealed snapshot entries the fold wrote, decoded from
+/// the `.csnap` part itself.
+///
+/// Reading the part is what makes the fold's copy observable on its own: a
+/// resolve re-validates every entry it reads, so a `SegmentRef` alone cannot
+/// distinguish "the fold refused to copy it" from "the resolve dropped it".
+async fn fold_and_read_entries(
+    store: &Arc<MemoryStore>,
+    catalog: &Catalog,
+    now_ns: i64,
+) -> Vec<SnapshotEntry> {
+    let report = catalog
+        .fold(&tenant(), SIGNAL, Uuid::new_v4(), now_ns, &[], None)
+        .await
+        .expect("fold");
+    assert!(!report.no_op, "the fold sealed at least one hour");
+
+    let prefix = format!(
+        "t/{}/catalog/{}/snap/",
+        tenant().to_hex(),
+        SIGNAL.key_prefix()
+    );
+    let page = store
+        .list(&prefix, None)
+        .await
+        .expect("list snapshot parts");
+    assert_eq!(page.objects.len(), 1, "one fold, one part");
+    let bytes = store
+        .get(&page.objects[0].key, GetRange::Full)
+        .await
+        .expect("get snapshot part")
+        .data;
+    decode_part(&bytes, &PartLimits::default())
+        .expect("snapshot part decodes")
+        .entries
+}
+
+async fn resolve_all(catalog: &Catalog, from_hour: u32, now_ns: i64) -> Vec<SegmentRef> {
+    let range = TimeRange {
+        start_ns: i64::from(from_hour) * NS_PER_HOUR,
+        end_ns: now_ns,
+    };
+    catalog
+        .resolve(&tenant(), SIGNAL, range, &[], now_ns)
+        .await
+        .expect("resolve")
+        .segments
+}
+
+fn segment_with_hash(segments: &[SegmentRef], first_byte: u8) -> &SegmentRef {
+    segments
+        .iter()
+        .find(|s| s.content_hash[0] == first_byte)
+        .expect("segment present in the snapshot")
+}
+
+fn entry_with_hash(entries: &[SnapshotEntry], first_byte: u8) -> &SnapshotEntry {
+    entries
+        .iter()
+        .find(|e| e.content_hash[0] == first_byte)
+        .expect("entry present in the part")
+}
+
+/// Test 1, the round trip: two commit records, each stamped for two declared
+/// columns of different eligible types, fold into `.csnap` entries and resolve
+/// into `SegmentRef`s whose stamps equal the input stamps exactly -- and the
+/// listing path above the watermark produces exactly the same stamps as the
+/// sealed path below it.
+#[tokio::test]
+async fn folded_stamps_reach_the_resolved_segment_ref_unchanged() {
+    let store = Arc::new(MemoryStore::new());
+    let hour = 500_000u32;
+    let now = now_at_seal(hour);
+
+    let a_stats = vec![
+        i64_stat("EventDate", -5, 19_000, 12),
+        bool_stat("IsRefresh", false, true, 0),
+    ];
+    let b_stats = vec![
+        // A degenerate span (min == max), and an all-NULL column: both extrema
+        // absent with null_count equal to the row count is an exact statement,
+        // and it is the shape a "fill in a default" bug destroys.
+        i64_stat("EventDate", 7, 7, 3),
+        DeclaredColumnStat::new("IsRefresh", DeclaredStatType::Bool, None, None, 100)
+            .expect("all-null bool stat"),
+    ];
+    let a = l0_record(1, hour, 100, &a_stats);
+    let b = l0_record(2, hour, 100, &b_stats);
+    put_l0(store.as_ref(), &a).await;
+    put_l0(store.as_ref(), &b).await;
+
+    // Above the watermark: the live tail, resolved by listing the commit
+    // records directly. This is the population no fold-built object ever
+    // covers (ADR-0873 context), so it is asserted first.
+    let listing_catalog = Catalog::new(store.clone(), config()).expect("catalog");
+    let listed = resolve_all(&listing_catalog, hour, now).await;
+    assert_eq!(listed.len(), 2);
+    assert_eq!(
+        segment_with_hash(&listed, l0_hash_byte(1))
+            .declared_column_stats
+            .as_slice(),
+        a_stats.as_slice()
+    );
+    assert_eq!(
+        segment_with_hash(&listed, l0_hash_byte(2))
+            .declared_column_stats
+            .as_slice(),
+        b_stats.as_slice()
+    );
+
+    // The fold copies each record's validated stamps onto its sealed entry.
+    let catalog = Catalog::new(store.clone(), config()).expect("catalog");
+    let entries = fold_and_read_entries(&store, &catalog, now).await;
+    assert_eq!(entries.len(), 2);
+    for (seq, expected) in [(1u64, &a_stats), (2u64, &b_stats)] {
+        let entry = entry_with_hash(&entries, l0_hash_byte(seq));
+        assert_eq!(entry.declared_column_stats.len(), expected.len());
+        let read = read_snapshot_entry(entry);
+        assert!(read.dropped().is_empty(), "seq {seq}");
+        assert_eq!(read.covered().to_vec(), *expected, "seq {seq}");
+    }
+
+    // Below the watermark: the same segments, now served from the snapshot
+    // part, carry byte-identical stamps.
+    let sealed = resolve_all(&catalog, hour, now).await;
+    assert_eq!(sealed.len(), 2);
+    for (seq, expected) in [(1u64, &a_stats), (2u64, &b_stats)] {
+        let seg = segment_with_hash(&sealed, l0_hash_byte(seq));
+        assert_eq!(seg.declared_column_stats.as_slice(), expected.as_slice());
+        // Field by field on one column, so a bug that preserved the list but
+        // corrupted a value cannot hide behind a whole-struct comparison of
+        // two equally-wrong values.
+        let event_date = seg
+            .declared_column_stats
+            .column("EventDate")
+            .expect("EventDate covered");
+        assert_eq!(event_date.declared_type(), DeclaredStatType::I64);
+        assert_eq!(event_date.min(), expected[0].min());
+        assert_eq!(event_date.max(), expected[0].max());
+        assert_eq!(event_date.null_count(), expected[0].null_count());
+    }
+    let all_null = segment_with_hash(&sealed, l0_hash_byte(2))
+        .declared_column_stats
+        .column("IsRefresh")
+        .expect("IsRefresh covered");
+    assert_eq!(all_null.min(), None);
+    assert_eq!(all_null.max(), None);
+    assert_eq!(all_null.null_count(), 100);
+
+    // The listing and sealed paths agree, which is the property that makes the
+    // stamp a single carrier rather than two.
+    for seq in [1u64, 2] {
+        assert_eq!(
+            segment_with_hash(&listed, l0_hash_byte(seq)).declared_column_stats,
+            segment_with_hash(&sealed, l0_hash_byte(seq)).declared_column_stats
+        );
+    }
+}
+
+/// Test 2a, absence: an unstamped record folds to an entry and resolves to a
+/// ref with no stamps at all -- not a placeholder entry, not an error.
+#[tokio::test]
+async fn an_unstamped_record_folds_and_resolves_to_no_coverage() {
+    let store = Arc::new(MemoryStore::new());
+    let hour = 500_100u32;
+    let now = now_at_seal(hour);
+    put_l0(store.as_ref(), &l0_record(1, hour, 100, &[])).await;
+
+    let catalog = Catalog::new(store.clone(), config()).expect("catalog");
+    let listed = resolve_all(&catalog, hour, now).await;
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].declared_column_stats.len(), 0);
+    assert!(listed[0].declared_column_stats.is_empty());
+    assert_eq!(listed[0].declared_column_stats.column("EventDate"), None);
+
+    let entries = fold_and_read_entries(&store, &catalog, now).await;
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].declared_column_stats.len(), 0);
+    let read = read_snapshot_entry(&entries[0]);
+    assert_eq!(read.covered().len(), 0);
+    assert_eq!(read.dropped().len(), 0);
+
+    let sealed = resolve_all(&catalog, hour, now).await;
+    assert_eq!(sealed.len(), 1);
+    assert!(sealed[0].declared_column_stats.is_empty());
+    // Uncovered from either path is one value, so a reader cannot tell the two
+    // apart and no code can come to depend on the difference.
+    assert_eq!(
+        listed[0].declared_column_stats,
+        sealed[0].declared_column_stats
+    );
+}
+
+/// A `SnapshotEntry` as a fold that predates ADR-0873 encodes it: fields 1-14
+/// and no field 15 in the schema at all, so its bytes cannot carry the new
+/// field even accidentally.
+#[derive(Clone, PartialEq, prost::Message)]
+struct LegacySnapshotEntry {
+    #[prost(uint32, tag = "1")]
+    level: u32,
+    #[prost(uint32, tag = "2")]
+    shard: u32,
+    #[prost(uint32, tag = "3")]
+    ingest_hour_bucket: u32,
+    #[prost(bytes = "vec", tag = "4")]
+    writer_id: Vec<u8>,
+    #[prost(uint64, tag = "5")]
+    writer_epoch: u64,
+    #[prost(uint64, tag = "6")]
+    writer_seq: u64,
+    #[prost(bytes = "vec", tag = "7")]
+    content_hash: Vec<u8>,
+    #[prost(uint64, tag = "8")]
+    object_size: u64,
+    #[prost(sint64, tag = "9")]
+    min_event_ts_ns: i64,
+    #[prost(sint64, tag = "10")]
+    max_event_ts_ns: i64,
+    #[prost(uint64, tag = "11")]
+    sample_count: u64,
+    #[prost(uint64, tag = "12")]
+    series_count: u64,
+    #[prost(uint32, tag = "13")]
+    segment_format_version: u32,
+    #[prost(sint64, tag = "14")]
+    created_unix_ns: i64,
+}
+
+fn stamp_free_entry() -> SnapshotEntry {
+    SnapshotEntry {
+        level: 0,
+        shard: 0,
+        ingest_hour_bucket: 500_200,
+        writer_id: vec![0xAA; 16],
+        writer_epoch: 3,
+        writer_seq: 4,
+        content_hash: vec![0xBB; 32],
+        object_size: 4_096,
+        min_event_ts_ns: 10,
+        max_event_ts_ns: 20,
+        sample_count: 7,
+        series_count: 2,
+        segment_format_version: u32::from(VERSION_V7),
+        created_unix_ns: 1_000,
+        declared_column_stats: Vec::new(),
+    }
+}
+
+/// Test 2b, the old-reader path: a snapshot part written before field 15
+/// existed decodes with empty stamps, never an error.
+///
+/// The part is the legacy part, not an imitation of one: a repeated field with
+/// no elements occupies no bytes in proto3, so the entry a current encoder
+/// writes with no stamps is byte-for-byte the entry the pre-ADR-0873 schema
+/// wrote, and the envelope is a pure function of those bytes. The first
+/// assertion is that byte identity; without it the rest of this test would only
+/// prove that an empty list round-trips.
+#[test]
+fn a_snapshot_part_written_before_field_fifteen_decodes_with_no_stamps() {
+    let entry = stamp_free_entry();
+    let legacy = LegacySnapshotEntry {
+        level: entry.level,
+        shard: entry.shard,
+        ingest_hour_bucket: entry.ingest_hour_bucket,
+        writer_id: entry.writer_id.clone(),
+        writer_epoch: entry.writer_epoch,
+        writer_seq: entry.writer_seq,
+        content_hash: entry.content_hash.clone(),
+        object_size: entry.object_size,
+        min_event_ts_ns: entry.min_event_ts_ns,
+        max_event_ts_ns: entry.max_event_ts_ns,
+        sample_count: entry.sample_count,
+        series_count: entry.series_count,
+        segment_format_version: entry.segment_format_version,
+        created_unix_ns: entry.created_unix_ns,
+    };
+    assert_eq!(
+        entry.encode_length_delimited_to_vec(),
+        legacy.encode_length_delimited_to_vec(),
+        "an unstamped entry is byte-identical to the pre-field-15 schema's"
+    );
+
+    let encoded = encode_part(
+        [0x11; 16],
+        1,
+        8,
+        entry.ingest_hour_bucket,
+        std::slice::from_ref(&entry),
+    )
+    .expect("encode legacy-shaped part");
+    let decoded = decode_part(&encoded, &PartLimits::default()).expect("legacy part decodes");
+    assert_eq!(decoded.entries.len(), 1);
+    assert_eq!(decoded.entries[0].declared_column_stats.len(), 0);
+    assert_eq!(decoded.entries[0], entry);
+    let read = read_snapshot_entry(&decoded.entries[0]);
+    assert_eq!(read.covered().len(), 0);
+    assert_eq!(read.dropped().len(), 0);
+    assert_eq!(read.column("EventDate"), None);
+}
+
+/// Test 3, the validation binding: a stamp that fails a row-count clause of
+/// the wave-2 predicate never reaches the `SnapshotEntry`, while its valid
+/// sibling on the same record survives.
+///
+/// Per-entry, not all-or-nothing: ADR-0873 decision 2's granularity split
+/// makes the stamp entry-granular precisely so one broken writer's entry
+/// cannot uncover the columns its siblings describe.
+#[tokio::test]
+async fn a_stamp_failing_a_row_count_clause_never_reaches_the_snapshot_entry() {
+    let store = Arc::new(MemoryStore::new());
+    let hour = 500_300u32;
+    let now = now_at_seal(hour);
+
+    let valid = i64_stat("EventDate", 1, 2, 6);
+    // Eight NULLs in a seven-row object: clause 4. The entry is well-formed on
+    // its own, which is why the predicate has to bind where a row count is
+    // known.
+    let invalid = i64_stat("Status", 200, 500, 8);
+    let record = l0_record(1, hour, 7, &[valid.clone(), invalid]);
+    // The record itself carries both: the drop happens on the copy, not by
+    // refusing to publish or to decode.
+    assert_eq!(record.declared_column_stats.len(), 2);
+    put_l0(store.as_ref(), &record).await;
+
+    // The listing path drops it too, before any fold has run: the same
+    // predicate against the same row count, whichever carrier a resolve reads.
+    let listing_catalog = Catalog::new(store.clone(), config()).expect("catalog");
+    let listed = resolve_all(&listing_catalog, hour, now).await;
+
+    let catalog = Catalog::new(store.clone(), config()).expect("catalog");
+    let entries = fold_and_read_entries(&store, &catalog, now).await;
+    assert_eq!(entries.len(), 1);
+    // The invalid entry is absent from the sealed part outright. Asserting on
+    // the raw repeated field, not on a re-read of it: a copy that carried the
+    // entry through and left it to the reader to drop would keep a convicted
+    // stamp on an immutable object that outlives the record convicting it.
+    assert_eq!(entries[0].declared_column_stats.len(), 1);
+    assert_eq!(entries[0].declared_column_stats[0].name, "EventDate");
+    let read = read_snapshot_entry(&entries[0]);
+    assert_eq!(read.covered().to_vec(), vec![valid.clone()]);
+    assert!(read.dropped().is_empty());
+    assert_eq!(read.column("Status"), None);
+
+    for segments in [listed, resolve_all(&catalog, hour, now).await] {
+        assert_eq!(segments.len(), 1);
+        let stats = &segments[0].declared_column_stats;
+        assert_eq!(stats.as_slice(), [valid.clone()].as_slice());
+        assert_eq!(stats.column("Status"), None);
+        assert_eq!(
+            stats.column("EventDate").map(|s| s.null_count()),
+            Some(6),
+            "the surviving column keeps its exact null count"
+        );
+    }
+}
+
+/// Test 4: a compaction record's parts carry their own stamps
+/// (`CompactionPart` field 12) through the same fold and resolve, gated
+/// against the part's own row count.
+#[tokio::test]
+async fn compaction_part_stamps_fold_exactly_as_commit_record_stamps_do() {
+    let store = Arc::new(MemoryStore::new());
+    let hour = 500_400u32;
+    let now = now_at_seal(hour);
+
+    let input_a = l0_record(1, hour, 100, &[i64_stat("EventDate", -5, 19_000, 12)]);
+    let input_b = l0_record(2, hour, 100, &[i64_stat("EventDate", 0, 1, 0)]);
+    put_l0(store.as_ref(), &input_a).await;
+    put_l0(store.as_ref(), &input_b).await;
+
+    // Recomputed over the rows each part holds, never merged from the inputs
+    // (ADR-0873 decision 3), so the part stamps deliberately differ from both
+    // input stamps.
+    let p0_stats = vec![
+        i64_stat("EventDate", -5, 19_000, 4),
+        bool_stat("IsRefresh", true, true, 0),
+    ];
+    let p1_stats = vec![
+        DeclaredColumnStat::new("EventDate", DeclaredStatType::I64, None, None, 10)
+            .expect("all-null i64 stat"),
+    ];
+    put_compaction_record(
+        store.as_ref(),
+        hour,
+        &[&input_a, &input_b],
+        vec![
+            part(0, hour, 0x11, 10, &p0_stats),
+            part(1, hour, 0x22, 10, &p1_stats),
+        ],
+    )
+    .await;
+
+    // Listing path: the compaction record and its parts, read live.
+    let listing_catalog = Catalog::new(store.clone(), config()).expect("catalog");
+    let listed = resolve_all(&listing_catalog, hour, now).await;
+    assert_eq!(listed.len(), 2, "both inputs superseded by the two parts");
+    for seg in &listed {
+        assert!(matches!(seg.level, SegmentLevel::L1 { .. }));
+    }
+    assert_eq!(
+        segment_with_hash(&listed, 0x11)
+            .declared_column_stats
+            .as_slice(),
+        p0_stats.as_slice()
+    );
+    assert_eq!(
+        segment_with_hash(&listed, 0x22)
+            .declared_column_stats
+            .as_slice(),
+        p1_stats.as_slice()
+    );
+
+    // Sealed path: the fold copies the part's stamps onto the level-1 entry.
+    let catalog = Catalog::new(store.clone(), config()).expect("catalog");
+    let entries = fold_and_read_entries(&store, &catalog, now).await;
+    assert_eq!(entries.len(), 2);
+    for (seed, expected) in [(0x11u8, &p0_stats), (0x22u8, &p1_stats)] {
+        let entry = entry_with_hash(&entries, seed);
+        assert_eq!(entry.level, 1);
+        assert_eq!(entry.declared_column_stats.len(), expected.len());
+        let read = read_snapshot_entry(entry);
+        assert!(read.dropped().is_empty(), "part {seed:#x}");
+        assert_eq!(read.covered().to_vec(), *expected, "part {seed:#x}");
+    }
+
+    let sealed = resolve_all(&catalog, hour, now).await;
+    assert_eq!(sealed.len(), 2);
+    for (seed, expected) in [(0x11u8, &p0_stats), (0x22u8, &p1_stats)] {
+        assert_eq!(
+            segment_with_hash(&sealed, seed)
+                .declared_column_stats
+                .as_slice(),
+            expected.as_slice()
+        );
+        assert_eq!(
+            segment_with_hash(&sealed, seed).declared_column_stats,
+            segment_with_hash(&listed, seed).declared_column_stats
+        );
+    }
+    // The all-NULL part keeps both extrema absent with the exact null count:
+    // the statement "this part has ten rows and none of them has EventDate",
+    // which is not the same statement as "no coverage".
+    let all_null = segment_with_hash(&sealed, 0x22)
+        .declared_column_stats
+        .column("EventDate")
+        .expect("EventDate covered");
+    assert_eq!(all_null.min(), None);
+    assert_eq!(all_null.max(), None);
+    assert_eq!(all_null.null_count(), 10);
+}

--- a/crates/ravel-catalog/tests/erasure_resolution.rs
+++ b/crates/ravel-catalog/tests/erasure_resolution.rs
@@ -1172,3 +1172,61 @@ async fn sibling_rewrites_alarm_on_the_folded_snapshot_path_too() {
          snapshot never reaches process_bucket, so nothing else would"
     );
 }
+
+/// A rewrite output part carrying declared-column stamps resolves to a
+/// SegmentRef with EMPTY coverage (PR #1009 review; ADR-0873 decision 3): the
+/// rewrite dropped rows, so a pre-drop stamp is stale for the surviving rows.
+/// Rewrite writers emit empty stamps today; this pins the reader-side refusal
+/// against a buggy or future writer until the recompute path lands and flips
+/// it deliberately with its own tests.
+///
+/// Non-vacuity: revert build_rewrite_l1_segment_ref to carry
+/// read_compaction_part(part) and the empty assertion fails with the stamp
+/// present.
+#[tokio::test]
+async fn rewrite_part_stamps_are_never_carried_onto_the_ref() {
+    let store = Arc::new(MemoryStore::new());
+    let catalog = Catalog::new(store.clone(), config(1)).expect("catalog");
+    let (range, now) = hour_range_and_now();
+    let start = range.start_ns;
+
+    let a = l0_record(Uuid::new_v4(), 0, 1, HOUR, now, start, start + 100);
+    put_l0(store.as_ref(), &a).await;
+
+    let mut stamped_part = part(0, start, start + 100, 1);
+    ravel_commit::declared_stats::stamp_compaction_part(
+        &mut stamped_part,
+        &[ravel_types::declared_stats::DeclaredColumnStat::new(
+            "EventDate",
+            ravel_types::declared_stats::DeclaredStatType::I64,
+            Some(ravel_types::declared_stats::DeclaredStatValue::I64(1)),
+            Some(ravel_types::declared_stats::DeclaredStatValue::I64(2)),
+            0,
+        )
+        .expect("valid stat")],
+    );
+    let rw = build_rewrite(
+        0,
+        HOUR,
+        &[&a],
+        None,
+        vec![stamped_part],
+        &[Uuid::new_v4()],
+        now,
+    );
+    put_rewrite(store.as_ref(), &rw).await;
+
+    let snapshot = catalog
+        .resolve(&tenant(), Signal::Metrics, range, &[], now)
+        .await
+        .expect("resolve");
+    assert_eq!(snapshot.segments.len(), 1, "the one rewrite output part");
+    assert!(
+        snapshot.segments[0]
+            .declared_column_stats
+            .as_slice()
+            .is_empty(),
+        "a rewrite part's stamps are never carried: got {:?}",
+        snapshot.segments[0].declared_column_stats
+    );
+}

--- a/crates/ravel-catalog/tests/snapshot_format_corrupt.rs
+++ b/crates/ravel-catalog/tests/snapshot_format_corrupt.rs
@@ -429,7 +429,10 @@ fn truncation_never_panics_at_any_boundary() {
 /// Entries carrying ADR-0873 declared-column stamps (field 15).
 fn stamped_entries() -> Vec<SnapshotEntry> {
     let mut entries = base_entries();
-    entries[0].declared_column_stats = vec![DeclaredColumnMinMax {
+    // Stamp the LAST entry: the tail truncation below then lands inside the
+    // stamp's field-15 submessage, not in a trailing unstamped entry.
+    let last = entries.len() - 1;
+    entries[last].declared_column_stats = vec![DeclaredColumnMinMax {
         name: "EventDate".to_string(),
         declared_type: 2,
         min: Some(DeclaredColumnStatValue {
@@ -458,8 +461,8 @@ fn a_truncated_declared_stat_submessage_is_a_typed_entry_decode_error() {
         full.len() > stamp_free.len(),
         "the stamp occupies bytes on the wire"
     );
-    // Cut inside the stamp: the first entry's length prefix still promises the
-    // stamped length, so the entry stream ends mid-submessage.
+    // Cut inside the stamp: the stamped (last) entry's length prefix still
+    // promises the stamped length, so the entry stream ends mid-submessage.
     let raw = full[..full.len() - (full.len() - stamp_free.len()) / 2].to_vec();
     let header = base_header(&entries, raw.len() as u64);
     let bytes = assemble(&header, &raw, None, None);
@@ -485,7 +488,8 @@ fn truncating_a_stamped_part_never_panics() {
     // about panics, this is the positive control that the corpus is stamped.
     let decoded = decode_part(&full, &PartLimits::default()).expect("stamped part decodes");
     assert_eq!(decoded.entries, entries);
-    assert_eq!(decoded.entries[0].declared_column_stats.len(), 1);
+    let stamped = decoded.entries.last().expect("entries nonempty");
+    assert_eq!(stamped.declared_column_stats.len(), 1);
 }
 
 // --- HEAD ---

--- a/crates/ravel-catalog/tests/snapshot_format_corrupt.rs
+++ b/crates/ravel-catalog/tests/snapshot_format_corrupt.rs
@@ -11,7 +11,8 @@ use ravel_catalog::{
 };
 use ravel_proto::catalog::v1::SnapshotPostingsHeader;
 use ravel_proto::catalog::v1::{
-    SnapshotEntry, SnapshotHead, SnapshotPartHeader, SnapshotPartRef, SnapshotPostingsRef,
+    DeclaredColumnMinMax, DeclaredColumnStatValue, SnapshotEntry, SnapshotHead, SnapshotPartHeader,
+    SnapshotPartRef, SnapshotPostingsRef, declared_column_stat_value::Kind,
 };
 
 fn base_entries() -> Vec<SnapshotEntry> {
@@ -31,6 +32,7 @@ fn base_entries() -> Vec<SnapshotEntry> {
             series_count: 1,
             segment_format_version: 1,
             created_unix_ns: 1_000,
+            declared_column_stats: Vec::new(),
         },
         SnapshotEntry {
             level: 0,
@@ -47,6 +49,7 @@ fn base_entries() -> Vec<SnapshotEntry> {
             series_count: 1,
             segment_format_version: 1,
             created_unix_ns: 1_000,
+            declared_column_stats: Vec::new(),
         },
     ]
 }
@@ -421,6 +424,68 @@ fn truncation_never_panics_at_any_boundary() {
         // Must return a typed error, never panic.
         let _ = decode_part(&full[..len], &PartLimits::default());
     }
+}
+
+/// Entries carrying ADR-0873 declared-column stamps (field 15).
+fn stamped_entries() -> Vec<SnapshotEntry> {
+    let mut entries = base_entries();
+    entries[0].declared_column_stats = vec![DeclaredColumnMinMax {
+        name: "EventDate".to_string(),
+        declared_type: 2,
+        min: Some(DeclaredColumnStatValue {
+            kind: Some(Kind::I64(-5)),
+        }),
+        max: Some(DeclaredColumnStatValue {
+            kind: Some(Kind::I64(19_000)),
+        }),
+        null_count: 0,
+    }];
+    entries
+}
+
+/// A stamped entry whose field-15 submessage is cut short inside the body is a
+/// typed decode error, never a panic and never a half-read stat.
+///
+/// The cut is made in the uncompressed entry stream and the envelope is then
+/// assembled around it, so the CRCs are consistent and the failure is forced to
+/// surface at the protobuf layer rather than at the checksum.
+#[test]
+fn a_truncated_declared_stat_submessage_is_a_typed_entry_decode_error() {
+    let entries = stamped_entries();
+    let full = encode_entries_raw(&entries);
+    let stamp_free = encode_entries_raw(&base_entries());
+    assert!(
+        full.len() > stamp_free.len(),
+        "the stamp occupies bytes on the wire"
+    );
+    // Cut inside the stamp: the first entry's length prefix still promises the
+    // stamped length, so the entry stream ends mid-submessage.
+    let raw = full[..full.len() - (full.len() - stamp_free.len()) / 2].to_vec();
+    let header = base_header(&entries, raw.len() as u64);
+    let bytes = assemble(&header, &raw, None, None);
+    let err = decode_part(&bytes, &PartLimits::default()).expect_err("decode must fail");
+    assert!(
+        matches!(err, SnapshotFormatError::EntryDecode(_)),
+        "got {err:?}"
+    );
+}
+
+/// Truncation at every byte boundary of a stamped part is a typed error or a
+/// clean decode, never a panic.
+#[test]
+fn truncating_a_stamped_part_never_panics() {
+    let entries = stamped_entries();
+    let raw = encode_entries_raw(&entries);
+    let header = base_header(&entries, raw.len() as u64);
+    let full = assemble(&header, &raw, None, None);
+    for len in 0..full.len() {
+        let _ = decode_part(&full[..len], &PartLimits::default());
+    }
+    // The untruncated part still decodes, stamps intact: the loop above is
+    // about panics, this is the positive control that the corpus is stamped.
+    let decoded = decode_part(&full, &PartLimits::default()).expect("stamped part decodes");
+    assert_eq!(decoded.entries, entries);
+    assert_eq!(decoded.entries[0].declared_column_stats.len(), 1);
 }
 
 // --- HEAD ---

--- a/crates/ravel-catalog/tests/snapshot_format_roundtrip.rs
+++ b/crates/ravel-catalog/tests/snapshot_format_roundtrip.rs
@@ -9,7 +9,8 @@ use ravel_catalog::{
     encode_head, encode_part, encode_postings,
 };
 use ravel_proto::catalog::v1::{
-    SnapshotColumnStatsRef, SnapshotEntry, SnapshotHead, SnapshotPartRef, SnapshotPostingsRef,
+    DeclaredColumnMinMax, DeclaredColumnStatValue, SnapshotColumnStatsRef, SnapshotEntry,
+    SnapshotHead, SnapshotPartRef, SnapshotPostingsRef, declared_column_stat_value::Kind,
 };
 
 fn entry_key(e: &SnapshotEntry) -> (u32, u32, Vec<u8>, u64, u64) {
@@ -19,6 +20,33 @@ fn entry_key(e: &SnapshotEntry) -> (u32, u32, Vec<u8>, u64, u64) {
         e.writer_id.clone(),
         e.writer_epoch,
         e.writer_seq,
+    )
+}
+
+/// One `declared_column_stats` entry (ADR-0873 field 15), generated over the
+/// whole wire domain rather than over valid stamps only: the codec's contract
+/// is that it transports entries unchanged, and dropping an invalid one is the
+/// reader's job at the point of use. A codec that quietly normalised anything
+/// here would hide a writer defect from the predicate that must convict it.
+fn arb_declared_stat() -> impl Strategy<Value = DeclaredColumnMinMax> {
+    let value = prop_oneof![
+        Just(None),
+        Just(Some(DeclaredColumnStatValue { kind: None })),
+        any::<i64>().prop_map(|v| Some(DeclaredColumnStatValue {
+            kind: Some(Kind::I64(v))
+        })),
+        any::<bool>().prop_map(|b| Some(DeclaredColumnStatValue {
+            kind: Some(Kind::B(b))
+        })),
+    ];
+    (".{0,12}", 0u32..8, value.clone(), value, any::<u64>()).prop_map(
+        |(name, declared_type, min, max, null_count)| DeclaredColumnMinMax {
+            name,
+            declared_type,
+            min,
+            max,
+            null_count,
+        },
     )
 }
 
@@ -41,6 +69,7 @@ fn arb_entry(watermark_hour: u32) -> impl Strategy<Value = SnapshotEntry> {
             0u32..4,
             any::<i64>(),
         ),
+        prop::collection::vec(arb_declared_stat(), 0..4),
     )
         .prop_map(
             |(
@@ -61,6 +90,7 @@ fn arb_entry(watermark_hour: u32) -> impl Strategy<Value = SnapshotEntry> {
                     segment_format_version,
                     created_unix_ns,
                 ),
+                declared_column_stats,
             )| SnapshotEntry {
                 level: 0,
                 shard,
@@ -76,6 +106,7 @@ fn arb_entry(watermark_hour: u32) -> impl Strategy<Value = SnapshotEntry> {
                 series_count,
                 segment_format_version,
                 created_unix_ns,
+                declared_column_stats,
             },
         )
 }
@@ -311,6 +342,7 @@ fn mixed_l0_l1_part_roundtrips() {
         series_count: 1,
         segment_format_version: 5,
         created_unix_ns: 1_000,
+        declared_column_stats: Vec::new(),
     };
     let l1 = SnapshotEntry {
         level: 1,
@@ -329,6 +361,7 @@ fn mixed_l0_l1_part_roundtrips() {
         series_count: 2,
         segment_format_version: 5,
         created_unix_ns: 2_000,
+        declared_column_stats: Vec::new(),
     };
     // Sorted by (hour, shard, writer_id bytes, ...): the 16-byte L0 writer_id
     // sorts before the 32-byte L1 one.

--- a/crates/ravel-maintain/src/scrub.rs
+++ b/crates/ravel-maintain/src/scrub.rs
@@ -673,6 +673,7 @@ mod tests {
             series_count: record.series_count,
             segment_format_version: record.segment_format_version,
             created_unix_ns: record.created_unix_ns,
+            declared_column_stats: Vec::new(),
         }
     }
 

--- a/crates/ravel-query/benches/fetch_soa_vs_fetch.rs
+++ b/crates/ravel-query/benches/fetch_soa_vs_fetch.rs
@@ -89,6 +89,7 @@ async fn build_store() -> (Arc<MemoryStore>, TenantHash, SegmentRef) {
         created_unix_ns: 42,
         level: ravel_catalog::SegmentLevel::L0,
         segment_format_version: u32::from(ravel_segment::SUPPORTED_VERSIONS.newest()),
+        declared_column_stats: Default::default(),
     };
     (store, tenant_hash, seg_ref)
 }

--- a/crates/ravel-query/src/cache_correctness.rs
+++ b/crates/ravel-query/src/cache_correctness.rs
@@ -231,6 +231,7 @@ async fn write_rseg_segment_under(tenant: TenantHash) -> (Arc<MemoryStore>, Segm
         created_unix_ns: 123,
         level: SegmentLevel::L0,
         segment_format_version: u32::from(ravel_segment::SUPPORTED_VERSIONS.newest()),
+        declared_column_stats: Default::default(),
     };
     (store, seg_ref)
 }
@@ -311,6 +312,7 @@ async fn write_rlog_segment_under(tenant: TenantHash) -> (Arc<MemoryStore>, Segm
         created_unix_ns: 0,
         level: SegmentLevel::L0,
         segment_format_version: u32::from(ravel_logseg::footer::VERSION),
+        declared_column_stats: Default::default(),
     };
     (store, seg_ref)
 }
@@ -1500,6 +1502,7 @@ async fn write_span_segment_under(tenant: TenantHash) -> (Arc<MemoryStore>, Segm
         created_unix_ns: 0,
         level: SegmentLevel::L0,
         segment_format_version: u32::from(ravel_rspan::footer::VERSION),
+        declared_column_stats: Default::default(),
     };
     (store, seg_ref)
 }

--- a/crates/ravel-query/src/distrib/codec.rs
+++ b/crates/ravel-query/src/distrib/codec.rs
@@ -3048,6 +3048,7 @@ mod tests {
                 part_index: 4,
             },
             segment_format_version: u32::from(ravel_segment::SUPPORTED_VERSIONS.newest()),
+            declared_column_stats: Default::default(),
         };
         let identity = encode_segment_identity(&seg);
         assert_eq!(identity.level, 1);
@@ -3096,6 +3097,7 @@ mod tests {
             created_unix_ns: 0,
             level: SegmentLevel::L0,
             segment_format_version: u32::from(ravel_segment::SUPPORTED_VERSIONS.newest()),
+            declared_column_stats: Default::default(),
         };
         let stamped = encode_segment_identity(&seg).segment_format_version;
         assert_eq!(

--- a/crates/ravel-query/src/distrib/partition.rs
+++ b/crates/ravel-query/src/distrib/partition.rs
@@ -163,6 +163,7 @@ mod tests {
             created_unix_ns: 0,
             level: SegmentLevel::L0,
             segment_format_version: u32::from(ravel_segment::SUPPORTED_VERSIONS.newest()),
+            declared_column_stats: Default::default(),
         }
     }
 

--- a/crates/ravel-query/src/distrib/pushdown.rs
+++ b/crates/ravel-query/src/distrib/pushdown.rs
@@ -166,6 +166,7 @@ mod tests {
             created_unix_ns: 0,
             level: SegmentLevel::L0,
             segment_format_version: u32::from(ravel_segment::SUPPORTED_VERSIONS.newest()),
+            declared_column_stats: Default::default(),
         }
     }
 

--- a/crates/ravel-query/src/distrib/tests.rs
+++ b/crates/ravel-query/src/distrib/tests.rs
@@ -173,6 +173,7 @@ async fn write_segment_prov(
         created_unix_ns,
         level: SegmentLevel::L0,
         segment_format_version: u32::from(ravel_segment::SUPPORTED_VERSIONS.newest()),
+        declared_column_stats: Default::default(),
     }
 }
 
@@ -623,6 +624,7 @@ async fn write_l1_merged_provenance(store: &MemoryStore) -> SegmentRef {
             part_index: 0,
         },
         segment_format_version: u32::from(ravel_segment::SUPPORTED_VERSIONS.newest()),
+        declared_column_stats: Default::default(),
     }
 }
 
@@ -1981,6 +1983,7 @@ fn histogram_series_distributed_equals_local_bitwise() {
             created_unix_ns: 0,
             level: SegmentLevel::L0,
             segment_format_version: u32::from(ravel_segment::SUPPORTED_VERSIONS.newest()),
+            declared_column_stats: Default::default(),
         };
         let snapshot = Snapshot {
             segments: vec![seg.clone()],
@@ -2128,6 +2131,7 @@ fn erased_histogram_series_is_dropped_before_the_wire() {
             created_unix_ns: 0,
             level: SegmentLevel::L0,
             segment_format_version: u32::from(ravel_segment::SUPPORTED_VERSIONS.newest()),
+            declared_column_stats: Default::default(),
         };
         let snapshot = Snapshot {
             segments: vec![seg.clone()],
@@ -2293,6 +2297,7 @@ async fn write_log_segment(
         // RLOG and RSPAN are both on trailer version 4; this helper's segment
         // set is format-agnostic to the distributed path under test.
         segment_format_version: 4,
+        declared_column_stats: Default::default(),
     }
 }
 
@@ -2995,6 +3000,7 @@ async fn write_span_segment(
         // RLOG and RSPAN are both on trailer version 4; this helper's segment
         // set is format-agnostic to the distributed path under test.
         segment_format_version: 4,
+        declared_column_stats: Default::default(),
     }
 }
 
@@ -4816,6 +4822,7 @@ fn native_histogram_pushdown_refusal_reports_real_accounting() {
             created_unix_ns: 0,
             level: SegmentLevel::L0,
             segment_format_version: u32::from(ravel_segment::SUPPORTED_VERSIONS.newest()),
+            declared_column_stats: Default::default(),
         };
         let segments = vec![seg];
 

--- a/crates/ravel-query/src/fetcher.rs
+++ b/crates/ravel-query/src/fetcher.rs
@@ -2654,6 +2654,7 @@ mod tests {
             created_unix_ns: 42,
             level: ravel_catalog::SegmentLevel::L0,
             segment_format_version: u32::from(ravel_segment::SUPPORTED_VERSIONS.newest()),
+            declared_column_stats: Default::default(),
         };
         (store, tenant_hash, seg_ref)
     }
@@ -2821,6 +2822,7 @@ mod tests {
             created_unix_ns: 42,
             level: ravel_catalog::SegmentLevel::L0,
             segment_format_version: u32::from(ravel_segment::SUPPORTED_VERSIONS.newest()),
+            declared_column_stats: Default::default(),
         };
         (store, tenant_hash, seg_ref)
     }
@@ -3004,6 +3006,7 @@ mod tests {
                 part_index: 0,
             },
             segment_format_version: u32::from(ravel_segment::SUPPORTED_VERSIONS.newest()),
+            declared_column_stats: Default::default(),
         };
         (store, seg_ref)
     }
@@ -3049,6 +3052,7 @@ mod tests {
             created_unix_ns,
             level: SegmentLevel::L0,
             segment_format_version: u32::from(ravel_segment::SUPPORTED_VERSIONS.newest()),
+            declared_column_stats: Default::default(),
         };
         (store, seg_ref)
     }
@@ -3357,6 +3361,7 @@ mod tests {
             created_unix_ns: 77,
             level: ravel_catalog::SegmentLevel::L0,
             segment_format_version: u32::from(ravel_segment::SUPPORTED_VERSIONS.newest()),
+            declared_column_stats: Default::default(),
         };
         (store, tenant_hash, seg_ref)
     }
@@ -3457,6 +3462,7 @@ mod tests {
             created_unix_ns: 99,
             level: ravel_catalog::SegmentLevel::L0,
             segment_format_version: u32::from(ravel_segment::SUPPORTED_VERSIONS.newest()),
+            declared_column_stats: Default::default(),
         };
         (written.bytes, tenant_hash, seg_ref)
     }

--- a/crates/ravel-query/src/log_fetcher.rs
+++ b/crates/ravel-query/src/log_fetcher.rs
@@ -5352,6 +5352,7 @@ mod plan_fast_path_tests {
             created_unix_ns: 0,
             level: SegmentLevel::L0,
             segment_format_version: u32::from(ravel_logseg::footer::VERSION),
+            declared_column_stats: Default::default(),
         }
     }
 
@@ -5701,6 +5702,7 @@ mod whole_segment_projection_tests {
             created_unix_ns: 0,
             level: SegmentLevel::L0,
             segment_format_version: u32::from(ravel_logseg::footer::VERSION),
+            declared_column_stats: Default::default(),
         }
     }
 
@@ -5905,6 +5907,7 @@ mod plan_skip_decidable_span_tests {
             created_unix_ns: 0,
             level: SegmentLevel::L0,
             segment_format_version: u32::from(ravel_logseg::footer::VERSION),
+            declared_column_stats: Default::default(),
         }
     }
 
@@ -6403,6 +6406,7 @@ mod plan_block_stats_tests {
             created_unix_ns: 0,
             level: SegmentLevel::L0,
             segment_format_version: u32::from(ravel_logseg::footer::VERSION),
+            declared_column_stats: Default::default(),
         }
     }
 

--- a/crates/ravel-query/src/span_fetcher.rs
+++ b/crates/ravel-query/src/span_fetcher.rs
@@ -1207,6 +1207,7 @@ mod tests {
             created_unix_ns: 0,
             level: SegmentLevel::L0,
             segment_format_version: u32::from(ravel_rspan::footer::VERSION),
+            declared_column_stats: Default::default(),
         }
     }
 

--- a/crates/ravel-query/tests/e2e.rs
+++ b/crates/ravel-query/tests/e2e.rs
@@ -545,6 +545,7 @@ async fn write_log_segment_for_span_test() -> (Arc<MemoryStore>, SegmentRef) {
         created_unix_ns: 0,
         level: SegmentLevel::L0,
         segment_format_version: u32::from(ravel_logseg::footer::VERSION),
+        declared_column_stats: Default::default(),
     };
     (store, seg_ref)
 }

--- a/crates/ravel-query/tests/erasure_cross_surface.rs
+++ b/crates/ravel-query/tests/erasure_cross_surface.rs
@@ -549,6 +549,7 @@ async fn write_log_object(store: &MemoryStore, key: &str, records: &[LogRecord])
         created_unix_ns: 0,
         level: SegmentLevel::L0,
         segment_format_version: u32::from(ravel_logseg::footer::VERSION),
+        declared_column_stats: Default::default(),
     }
 }
 

--- a/crates/ravel-query/tests/fetch_multi_get.rs
+++ b/crates/ravel-query/tests/fetch_multi_get.rs
@@ -102,6 +102,7 @@ fn build_multi_series_segment() -> (Bytes, TenantHash, SegmentRef) {
         created_unix_ns: 42,
         level: ravel_catalog::SegmentLevel::L0,
         segment_format_version: u32::from(ravel_segment::SUPPORTED_VERSIONS.newest()),
+        declared_column_stats: Default::default(),
     };
     (written.bytes, tenant_hash, seg_ref)
 }

--- a/crates/ravel-query/tests/fetch_soa_matcher_superset.rs
+++ b/crates/ravel-query/tests/fetch_soa_matcher_superset.rs
@@ -108,6 +108,7 @@ async fn segment_with_three_jobs() -> (SegmentFetcher, TenantHash, SegmentRef) {
         created_unix_ns: 42,
         level: ravel_catalog::SegmentLevel::L0,
         segment_format_version: u32::from(ravel_segment::SUPPORTED_VERSIONS.newest()),
+        declared_column_stats: Default::default(),
     };
     let backend: Arc<dyn ObjectStoreBackend> = store;
     (SegmentFetcher::new(backend), tenant_hash, seg_ref)

--- a/crates/ravel-query/tests/log_block_range.rs
+++ b/crates/ravel-query/tests/log_block_range.rs
@@ -124,6 +124,7 @@ fn seg_ref(key: &str, size: u64, records: &[LogRecord]) -> SegmentRef {
         created_unix_ns: 0,
         level: SegmentLevel::L0,
         segment_format_version: u32::from(ravel_logseg::footer::VERSION),
+        declared_column_stats: Default::default(),
     }
 }
 

--- a/crates/ravel-query/tests/log_fetcher.rs
+++ b/crates/ravel-query/tests/log_fetcher.rs
@@ -198,6 +198,7 @@ async fn write_object(store: &MemoryStore, key: &str, records: &[LogRecord]) -> 
         created_unix_ns: 0,
         level: SegmentLevel::L0,
         segment_format_version: u32::from(ravel_logseg::footer::VERSION),
+        declared_column_stats: Default::default(),
     }
 }
 
@@ -618,6 +619,7 @@ async fn write_indexed_object(
         created_unix_ns: 0,
         level: SegmentLevel::L0,
         segment_format_version: u32::from(ravel_logseg::footer::VERSION),
+        declared_column_stats: Default::default(),
     }
 }
 

--- a/crates/ravel-query/tests/log_footer_carry.rs
+++ b/crates/ravel-query/tests/log_footer_carry.rs
@@ -106,6 +106,7 @@ fn seg_ref(size: u64) -> SegmentRef {
         created_unix_ns: 0,
         level: SegmentLevel::L0,
         segment_format_version: u32::from(ravel_logseg::footer::VERSION),
+        declared_column_stats: Default::default(),
     }
 }
 

--- a/crates/ravel-query/tests/log_page_dir_fetch.rs
+++ b/crates/ravel-query/tests/log_page_dir_fetch.rs
@@ -171,6 +171,7 @@ fn seg_ref(size: u64, records: &[LogRecord]) -> SegmentRef {
         created_unix_ns: 0,
         level: SegmentLevel::L0,
         segment_format_version: u32::from(ravel_logseg::footer::VERSION),
+        declared_column_stats: Default::default(),
     }
 }
 

--- a/crates/ravel-sql/benches/logs_scan.rs
+++ b/crates/ravel-sql/benches/logs_scan.rs
@@ -130,6 +130,7 @@ async fn build() -> (Arc<dyn ObjectStoreBackend>, Vec<SegmentRef>) {
         created_unix_ns: 0,
         level: SegmentLevel::L0,
         segment_format_version: u32::from(ravel_logseg::footer::VERSION),
+        declared_column_stats: Default::default(),
     };
     (Arc::new(store), vec![seg])
 }

--- a/crates/ravel-sql/benches/samples_scan.rs
+++ b/crates/ravel-sql/benches/samples_scan.rs
@@ -115,6 +115,7 @@ async fn build(specs: &[SegSpec]) -> (Arc<dyn ObjectStoreBackend>, Snapshot) {
             created_unix_ns: spec.created_unix_ns,
             level: SegmentLevel::L0,
             segment_format_version: u32::from(ravel_segment::SUPPORTED_VERSIONS.newest()),
+            declared_column_stats: Default::default(),
         });
     }
     segments.sort_by_key(|s| (s.created_unix_ns, s.writer_epoch, s.writer_seq, s.shard));

--- a/crates/ravel-sql/src/flight_ticket.rs
+++ b/crates/ravel-sql/src/flight_ticket.rs
@@ -389,9 +389,14 @@ impl SegmentPin {
 
     /// Rebuild the [`SegmentRef`] this pin was projected from.
     ///
-    /// Total and lossless: version 2 carries every `SegmentRef` field, which
-    /// is what lets `DoGet` reconstruct the resolved `Snapshot` without a
-    /// second `Catalog::resolve`.
+    /// Version 2 carries every identity, pruning, and routing field, which is
+    /// what lets `DoGet` reconstruct the resolved `Snapshot` without a second
+    /// `Catalog::resolve`. It does not carry
+    /// [`SegmentRef::declared_column_stats`] (ADR-0873): the pin's wire layout
+    /// has its own version byte, so adding them is a ticket format change of
+    /// its own. A rebuilt ref is therefore uncovered for every declared
+    /// column, which costs `DoGet` the statistics shortcut and never a wrong
+    /// answer.
     pub fn to_segment_ref(&self) -> SegmentRef {
         SegmentRef {
             data_object_key: self.data_object_key.clone(),
@@ -409,6 +414,9 @@ impl SegmentPin {
             created_unix_ns: self.created_unix_ns,
             level: self.level.clone(),
             segment_format_version: self.segment_format_version,
+            // Not carried by the pin's wire layout (see this method's docs):
+            // uncovered, which is a legal permanent state for any segment.
+            declared_column_stats: Default::default(),
         }
     }
 }
@@ -1083,6 +1091,7 @@ mod tests {
                 created_unix_ns: 1_699_999_999_999_999_999,
                 level: level.clone(),
                 segment_format_version: 4,
+                declared_column_stats: Default::default(),
             };
             let pin = SegmentPin::from_segment_ref(&seg);
             assert_eq!(pin.to_segment_ref(), seg);

--- a/crates/ravel-sql/src/logs_provider.rs
+++ b/crates/ravel-sql/src/logs_provider.rs
@@ -498,6 +498,7 @@ mod tests {
             created_unix_ns: 0,
             level: SegmentLevel::L0,
             segment_format_version: u32::from(ravel_logseg::footer::VERSION),
+            declared_column_stats: Default::default(),
         }
     }
 

--- a/crates/ravel-sql/src/spans_scan.rs
+++ b/crates/ravel-sql/src/spans_scan.rs
@@ -1374,6 +1374,7 @@ mod tests {
             created_unix_ns: 0,
             level: SegmentLevel::L0,
             segment_format_version: u32::from(ravel_rspan::footer::VERSION),
+            declared_column_stats: Default::default(),
         };
 
         let store: Arc<dyn ObjectStoreBackend> = Arc::new(store);
@@ -1605,6 +1606,7 @@ mod tests {
             created_unix_ns: 0,
             level: SegmentLevel::L0,
             segment_format_version: u32::from(ravel_rspan::footer::VERSION),
+            declared_column_stats: Default::default(),
         };
 
         let store: Arc<dyn ObjectStoreBackend> = Arc::new(store);

--- a/crates/ravel-sql/tests/alerts_provider.rs
+++ b/crates/ravel-sql/tests/alerts_provider.rs
@@ -153,6 +153,7 @@ async fn write_object(store: &MemoryStore, key: &str, records: &[LogRecord]) -> 
         created_unix_ns: 0,
         level: SegmentLevel::L0,
         segment_format_version: u32::from(ravel_logseg::footer::VERSION),
+        declared_column_stats: Default::default(),
     }
 }
 
@@ -496,6 +497,7 @@ async fn real_ravel_alerting_record_decodes_identically() {
         created_unix_ns: 0,
         level: SegmentLevel::L0,
         segment_format_version: u32::from(ravel_logseg::footer::VERSION),
+        declared_column_stats: Default::default(),
     };
 
     let provider = provider(store, vec![seg]);

--- a/crates/ravel-sql/tests/audit_provider.rs
+++ b/crates/ravel-sql/tests/audit_provider.rs
@@ -122,6 +122,7 @@ async fn write_object(store: &MemoryStore, key: &str, records: &[LogRecord]) -> 
         created_unix_ns: 0,
         level: SegmentLevel::L0,
         segment_format_version: u32::from(ravel_logseg::footer::VERSION),
+        declared_column_stats: Default::default(),
     }
 }
 

--- a/crates/ravel-sql/tests/flight_distributed.rs
+++ b/crates/ravel-sql/tests/flight_distributed.rs
@@ -203,6 +203,7 @@ async fn write_segment(
         created_unix_ns,
         level: SegmentLevel::L0,
         segment_format_version: u32::from(ravel_segment::SUPPORTED_VERSIONS.newest()),
+        declared_column_stats: Default::default(),
     }
 }
 
@@ -1470,6 +1471,7 @@ async fn write_rlog_segment(
         created_unix_ns,
         level: SegmentLevel::L0,
         segment_format_version: u32::from(ravel_logseg::footer::VERSION),
+        declared_column_stats: Default::default(),
     }
 }
 
@@ -2166,6 +2168,7 @@ async fn write_rspan_segment(
         created_unix_ns,
         level: SegmentLevel::L0,
         segment_format_version: u32::from(ravel_rspan::footer::VERSION),
+        declared_column_stats: Default::default(),
     }
 }
 

--- a/crates/ravel-sql/tests/logs_columnar.rs
+++ b/crates/ravel-sql/tests/logs_columnar.rs
@@ -338,6 +338,7 @@ async fn put_object(
         created_unix_ns: 0,
         level: SegmentLevel::L0,
         segment_format_version: u32::from(ravel_logseg::footer::VERSION),
+        declared_column_stats: Default::default(),
     }
 }
 

--- a/crates/ravel-sql/tests/logs_count_from_stats.rs
+++ b/crates/ravel-sql/tests/logs_count_from_stats.rs
@@ -132,6 +132,7 @@ async fn write_object(
         created_unix_ns: 0,
         level: SegmentLevel::L0,
         segment_format_version: u32::from(ravel_logseg::footer::VERSION),
+        declared_column_stats: Default::default(),
     }
 }
 

--- a/crates/ravel-sql/tests/logs_differential.rs
+++ b/crates/ravel-sql/tests/logs_differential.rs
@@ -394,6 +394,7 @@ async fn write_object(
         created_unix_ns: 0,
         level: SegmentLevel::L0,
         segment_format_version: u32::from(ravel_logseg::footer::VERSION),
+        declared_column_stats: Default::default(),
     }
 }
 

--- a/crates/ravel-sql/tests/logs_fast_path_projection_routing.rs
+++ b/crates/ravel-sql/tests/logs_fast_path_projection_routing.rs
@@ -257,6 +257,7 @@ async fn write_segment(
         created_unix_ns: 0,
         level: SegmentLevel::L0,
         segment_format_version: u32::from(format_version),
+        declared_column_stats: Default::default(),
     }
 }
 

--- a/crates/ravel-sql/tests/logs_metadata_agg.rs
+++ b/crates/ravel-sql/tests/logs_metadata_agg.rs
@@ -84,6 +84,7 @@ fn seg_ref(seq: u64, sample_count: u64) -> SegmentRef {
         created_unix_ns: 0,
         level: SegmentLevel::L0,
         segment_format_version: u32::from(ravel_logseg::footer::VERSION),
+        declared_column_stats: Default::default(),
     }
 }
 
@@ -1086,6 +1087,7 @@ async fn write_real_segment(
         created_unix_ns: 0,
         level: SegmentLevel::L0,
         segment_format_version: u32::from(ravel_logseg::footer::VERSION),
+        declared_column_stats: Default::default(),
     }
 }
 

--- a/crates/ravel-sql/tests/logs_plan_concurrency.rs
+++ b/crates/ravel-sql/tests/logs_plan_concurrency.rs
@@ -103,6 +103,7 @@ async fn write_object(store: &MemoryStore, key: &str, records: &[LogRecord]) -> 
         created_unix_ns: 0,
         level: SegmentLevel::L0,
         segment_format_version: u32::from(ravel_logseg::footer::VERSION),
+        declared_column_stats: Default::default(),
     }
 }
 

--- a/crates/ravel-sql/tests/logs_provider.rs
+++ b/crates/ravel-sql/tests/logs_provider.rs
@@ -137,6 +137,7 @@ async fn write_object(store: &MemoryStore, key: &str, records: &[LogRecord]) -> 
         created_unix_ns: 0,
         level: SegmentLevel::L0,
         segment_format_version: u32::from(ravel_logseg::footer::VERSION),
+        declared_column_stats: Default::default(),
     }
 }
 

--- a/crates/ravel-sql/tests/logs_request_cost_knob_routing.rs
+++ b/crates/ravel-sql/tests/logs_request_cost_knob_routing.rs
@@ -223,6 +223,7 @@ async fn write_segment(store: &dyn ObjectStoreBackend, seg: usize) -> SegmentRef
         created_unix_ns: 0,
         level: SegmentLevel::L0,
         segment_format_version: u32::from(ravel_logseg::footer::VERSION),
+        declared_column_stats: Default::default(),
     }
 }
 

--- a/crates/ravel-sql/tests/logs_scan_allocations.rs
+++ b/crates/ravel-sql/tests/logs_scan_allocations.rs
@@ -135,6 +135,7 @@ async fn fixture() -> (Arc<dyn ObjectStoreBackend>, Vec<SegmentRef>) {
         created_unix_ns: 0,
         level: SegmentLevel::L0,
         segment_format_version: u32::from(ravel_logseg::footer::VERSION),
+        declared_column_stats: Default::default(),
     };
     (Arc::new(store), vec![seg])
 }

--- a/crates/ravel-sql/tests/logs_selective_scan_amplification.rs
+++ b/crates/ravel-sql/tests/logs_selective_scan_amplification.rs
@@ -230,6 +230,7 @@ async fn write_segment(store: &dyn ObjectStoreBackend, seg: usize) -> SegmentRef
         created_unix_ns: 0,
         level: SegmentLevel::L0,
         segment_format_version: u32::from(ravel_logseg::footer::VERSION),
+        declared_column_stats: Default::default(),
     }
 }
 

--- a/crates/ravel-sql/tests/logs_stats_load.rs
+++ b/crates/ravel-sql/tests/logs_stats_load.rs
@@ -78,6 +78,7 @@ fn seg_ref(seq: u64, sample_count: u64) -> SegmentRef {
         // other ravel-sql fixtures, rather than a literal that would be a lie
         // if anything later did read it.
         segment_format_version: u32::from(ravel_logseg::footer::VERSION),
+        declared_column_stats: Default::default(),
     }
 }
 

--- a/crates/ravel-sql/tests/logs_topk_late_materialization.rs
+++ b/crates/ravel-sql/tests/logs_topk_late_materialization.rs
@@ -217,6 +217,7 @@ async fn write_segment(store: &dyn ObjectStoreBackend, seg: usize, tied: bool) -
         created_unix_ns: 0,
         level: SegmentLevel::L0,
         segment_format_version: u32::from(ravel_logseg::footer::VERSION),
+        declared_column_stats: Default::default(),
     }
 }
 

--- a/crates/ravel-sql/tests/logs_uncached_assignment.rs
+++ b/crates/ravel-sql/tests/logs_uncached_assignment.rs
@@ -135,6 +135,7 @@ async fn write_object(
         created_unix_ns: 0,
         level: SegmentLevel::L0,
         segment_format_version: u32::from(ravel_logseg::footer::VERSION),
+        declared_column_stats: Default::default(),
     }
 }
 

--- a/crates/ravel-sql/tests/logs_whole_segment_fast_path.rs
+++ b/crates/ravel-sql/tests/logs_whole_segment_fast_path.rs
@@ -133,6 +133,7 @@ async fn write_object(
         created_unix_ns: 0,
         level: SegmentLevel::L0,
         segment_format_version: u32::from(ravel_logseg::footer::VERSION),
+        declared_column_stats: Default::default(),
     }
 }
 

--- a/crates/ravel-sql/tests/memory_accounting.rs
+++ b/crates/ravel-sql/tests/memory_accounting.rs
@@ -442,6 +442,7 @@ async fn write_logs(
             created_unix_ns: 0,
             level: SegmentLevel::L0,
             segment_format_version: u32::from(ravel_logseg::footer::VERSION),
+            declared_column_stats: Default::default(),
         }],
         segments_pruned: 0,
         pending_erasure: erasure,

--- a/crates/ravel-sql/tests/pipeline.rs
+++ b/crates/ravel-sql/tests/pipeline.rs
@@ -134,6 +134,7 @@ async fn write_segment(
         created_unix_ns: spec.created_unix_ns,
         level: SegmentLevel::L0,
         segment_format_version: u32::from(ravel_segment::SUPPORTED_VERSIONS.newest()),
+        declared_column_stats: Default::default(),
     }
 }
 

--- a/crates/ravel-sql/tests/pushdown_memory.rs
+++ b/crates/ravel-sql/tests/pushdown_memory.rs
@@ -235,6 +235,7 @@ async fn write_segment(
         created_unix_ns: spec.created_unix_ns,
         level: SegmentLevel::L0,
         segment_format_version: u32::from(ravel_segment::SUPPORTED_VERSIONS.newest()),
+        declared_column_stats: Default::default(),
     }
 }
 

--- a/crates/ravel-sql/tests/scan_batch_allocations.rs
+++ b/crates/ravel-sql/tests/scan_batch_allocations.rs
@@ -123,6 +123,7 @@ async fn fixture() -> (Arc<dyn ObjectStoreBackend>, Snapshot) {
             created_unix_ns: 1,
             level: SegmentLevel::L0,
             segment_format_version: u32::from(ravel_segment::SUPPORTED_VERSIONS.newest()),
+            declared_column_stats: Default::default(),
         }],
         segments_pruned: 0,
         pending_erasure: Vec::new(),

--- a/crates/ravel-sql/tests/scan_budgets.rs
+++ b/crates/ravel-sql/tests/scan_budgets.rs
@@ -178,6 +178,7 @@ async fn write_segment(
         created_unix_ns: spec.created_unix_ns,
         level: SegmentLevel::L0,
         segment_format_version: u32::from(ravel_segment::SUPPORTED_VERSIONS.newest()),
+        declared_column_stats: Default::default(),
     }
 }
 

--- a/crates/ravel-sql/tests/scan_soa_adoption.rs
+++ b/crates/ravel-sql/tests/scan_soa_adoption.rs
@@ -168,6 +168,7 @@ async fn write_segment(
         created_unix_ns: spec.created_unix_ns,
         level: SegmentLevel::L0,
         segment_format_version: u32::from(ravel_segment::SUPPORTED_VERSIONS.newest()),
+        declared_column_stats: Default::default(),
     }
 }
 

--- a/crates/ravel-sql/tests/skip_partial_aggregation.rs
+++ b/crates/ravel-sql/tests/skip_partial_aggregation.rs
@@ -266,6 +266,7 @@ async fn write_high_cardinality_logs(store: &Arc<dyn ObjectStoreBackend>) -> Sna
             created_unix_ns: 0,
             level: SegmentLevel::L0,
             segment_format_version: u32::from(ravel_logseg::footer::VERSION),
+            declared_column_stats: Default::default(),
         });
     }
 

--- a/crates/ravel-sql/tests/spans_columnar.rs
+++ b/crates/ravel-sql/tests/spans_columnar.rs
@@ -148,6 +148,7 @@ async fn write_object(store: &MemoryStore, key: &str, records: &[SpanRecord]) ->
         created_unix_ns: 0,
         level: SegmentLevel::L0,
         segment_format_version: u32::from(ravel_rspan::footer::VERSION),
+        declared_column_stats: Default::default(),
     }
 }
 

--- a/crates/ravel-sql/tests/spans_differential.rs
+++ b/crates/ravel-sql/tests/spans_differential.rs
@@ -301,6 +301,7 @@ async fn write_object(store: &MemoryStore, key: &str, records: &[SpanRecord]) ->
         created_unix_ns: 0,
         level: SegmentLevel::L0,
         segment_format_version: u32::from(ravel_rspan::footer::VERSION),
+        declared_column_stats: Default::default(),
     }
 }
 

--- a/crates/ravel-sql/tests/spans_provider.rs
+++ b/crates/ravel-sql/tests/spans_provider.rs
@@ -120,6 +120,7 @@ async fn write_object(store: &MemoryStore, key: &str, records: &[SpanRecord]) ->
         created_unix_ns: 0,
         level: SegmentLevel::L0,
         segment_format_version: u32::from(ravel_rspan::footer::VERSION),
+        declared_column_stats: Default::default(),
     }
 }
 

--- a/docs/catalog-and-mvcc.md
+++ b/docs/catalog-and-mvcc.md
@@ -958,10 +958,15 @@ pinning are unchanged:
    token sources, sort by the dedup total order ("Cross-segment duplicate
    samples" below), return the pinned `Snapshot`.
 
-`SegmentRef.declared_column_stats` is filled on every one of those routes
+`SegmentRef.declared_column_stats` is filled on every catalog route
 (ADR-0873 decision 4): from the commit record for a listed or token-resolved
-segment, from the compaction/rewrite part for a listed L1 part, and from
-`SnapshotEntry.declared_column_stats` (field 15) for a sealed entry. The
+segment, from the compaction part for a listed L1 part, and from
+`SnapshotEntry.declared_column_stats` (field 15) for a sealed entry. Two
+routes are deliberately always empty: a rewrite output's parts (the rewrite
+dropped rows, so a pre-drop stamp is stale; ADR-0873 decision 3), and a
+`SegmentRef` rebuilt from a Flight `SegmentPin` (its wire layout does not
+carry the field yet), so a segment covered in the catalog reads as uncovered
+after a pin round trip -- costing the shortcut there, never an answer. The
 listing routes are what cover the always-unsealed recent tail and
 token-resolved segments, which no fold-built sibling object reaches. The
 entries are re-validated against the carrier's own row count wherever they are

--- a/docs/catalog-and-mvcc.md
+++ b/docs/catalog-and-mvcc.md
@@ -482,7 +482,22 @@ carries two entry levels: a level-0 L0 commit entry, whose `writer_id` is the
 `writer_*` slots, and `snapshot_format::part` `validate_entries` enforces the
 width per level: 16 for level 0, 32 for level 1). Every producer of a snapshot
 entry MUST honour that per-level width; a mismatch is a format violation, not a
-value to widen the reader around. `verify_seal_divergence`
+value to widen the reader around.
+
+An entry also carries `declared_column_stats` (field 15, ADR-0873), the
+per-declared-column exact min, max, and null count the fold copies from the
+record it folds: `CommitRecord.declared_column_stats` (field 20) for a level-0
+entry, `CompactionPart.declared_column_stats` (field 12) for a level-1 part.
+Only entries that passed the statistics validity predicate against the source
+record's own row count are copied, so a defective stamp never outlives the
+record that convicts it. The field is additive and permanently optional, and
+neither the `.csnap` envelope version nor `SnapshotPartHeader.format_version`
+is bumped for it: absence costs a reader the statistics shortcut and never
+yields a wrong answer, which is the same reasoning ADR-0063 applied to
+`SnapshotPartHeader.min_hour`. Entries grow by roughly `name_len + 25` bytes
+per stamped column, so a part's `entries_uncompressed_len` and the resolve
+path's per-record cache sizing note below grow by that order for a tenant with
+declared columns. `verify_seal_divergence`
 (`crates/ravel-catalog/src/seal_divergence.rs`) therefore compares only the
 level-0 entries against the L0 commit history, and mirrors the fold's
 supersession exclusion on the ground-truth side: an L0 commit record named in a
@@ -942,6 +957,18 @@ pinning are unchanged:
    records (ADR-0010 §7); dedup by data key across the snapshot/listing/
    token sources, sort by the dedup total order ("Cross-segment duplicate
    samples" below), return the pinned `Snapshot`.
+
+`SegmentRef.declared_column_stats` is filled on every one of those routes
+(ADR-0873 decision 4): from the commit record for a listed or token-resolved
+segment, from the compaction/rewrite part for a listed L1 part, and from
+`SnapshotEntry.declared_column_stats` (field 15) for a sealed entry. The
+listing routes are what cover the always-unsealed recent tail and
+token-resolved segments, which no fold-built sibling object reaches. The
+entries are re-validated against the carrier's own row count wherever they are
+read, so a stamp is never trusted because some earlier reader accepted it, and
+an entry that fails leaves its column uncovered without affecting the rest of
+the record. An empty list means the segment is uncovered for every declared
+column and is never an error; a reader that finds a column uncovered scans.
 
 Every LIST call on the resolve path, in both phases, asserts that each
 returned key begins with the requesting tenant's prefix (per ADR-0050 §2,

--- a/proto/ravel/catalog.proto
+++ b/proto/ravel/catalog.proto
@@ -40,6 +40,64 @@ message SnapshotEntry {
   uint64 series_count = 12;
   uint32 segment_format_version = 13;
   sint64 created_unix_ns = 14;
+  // Exact whole-object min/max and null count per stamp-eligible declared
+  // typed attribute column, copied by the fold from the record it folds
+  // (ADR-0873 decision 4): CommitRecord.declared_column_stats (field 20) for
+  // a level-0 entry, CompactionPart.declared_column_stats (field 12) for a
+  // level-1 compaction or rewrite part. Only entries that passed the
+  // statistics validity predicate against the source record's own row count
+  // are copied, so a defective stamp never reaches a sealed part.
+  // Additive and permanently optional: an empty list means this segment is
+  // uncovered for every declared column, which is a normal state forever
+  // (every record written before ADR-0873, every metrics/spans entry, any
+  // column declared after the flush opened, and every part an older fold
+  // wrote), never an error and never a value to guess at.
+  // Neither the .csnap envelope version nor SnapshotPartHeader.format_version
+  // is bumped: an addition an old reader can safely ignore costs it the
+  // statistics shortcut and never a wrong answer, so raising the reader floor
+  // would force a flag day for a field whose absence is a permanently legal
+  // state (ADR-0873 decision 1; SnapshotPartHeader.min_hour, field 8, is the
+  // in-file precedent for an additive entry-side change with no bump).
+  repeated DeclaredColumnMinMax declared_column_stats = 15;
+}
+
+// The min or max of one declared column's non-null values in one object: a
+// same-file mirror of ravel.commit.v1.DeclaredColumnStatValue (ADR-0873
+// decision 1). This repository has no cross-file proto imports, so the
+// commit-side pair is redeclared here rather than imported, the same
+// convention ColumnStat.declared_type follows for the sys enum. The two
+// declarations are field-for-field identical and must stay so: a reader
+// converts one to the other to run the single shared validity predicate.
+//
+// ColumnValue (above) is deliberately NOT reused: its oneof admits
+// str_utf8/bytes_val, which are not stamp-eligible (ADR-0873 decision 2), and
+// a narrower value type makes an ineligible stamp unrepresentable rather than
+// merely rejected. A new eligible type adds a oneof arm here, additively.
+message DeclaredColumnStatValue {
+  oneof kind {
+    sint64 i64 = 1;
+    bool b = 2;
+  }
+}
+
+// Exact whole-object min/max (and null count) for one declared typed
+// attribute column (ADR-0090), as computed by the writer that encoded the
+// object and carried here verbatim by the fold. Mirror of
+// ravel.commit.v1.DeclaredColumnMinMax. min/max are message-typed for
+// presence: both absent means the column had zero non-null values in this
+// object, which is still an exact statement.
+message DeclaredColumnMinMax {
+  string name = 1;
+  // ravel.sys.v1.TypedAttrColumnType as i32 (no cross-file proto import in
+  // this repo; same convention as ColumnStat.declared_type). Only I64 (2) and
+  // BOOL (3) are stamp-eligible; any other tag is dropped by the reader.
+  uint32 declared_type = 2;
+  DeclaredColumnStatValue min = 3;
+  DeclaredColumnStatValue max = 4;
+  // Rows in this object where the declared column reads NULL (name absent, or
+  // the stored variant mismatches declared_type). non_null = the entry's
+  // sample_count (field 11) minus this.
+  uint64 null_count = 5;
 }
 
 message SnapshotHead {


### PR DESCRIPTION
ADR-0873 wave 3. The validated per-declared-column min/max/null stamps
that waves 1 and 2 put on commit records and compaction parts now
travel through the fold onto SnapshotEntry (additive proto field 15,
mirrored narrow messages, no version bump per the ADR's stated
reasoning) and out to every resolved SegmentRef as an Arc-backed shared
list. All four resolution routes fill the field through the wave-2
validated reader; erasure and rewrite outputs stay unstamped
(uncovered, never stale). The Flight SegmentPin route stays uncovered
and its doc says so; extending its wire layout is its own ticket.

Tests pin the exact round trip, byte-identity of a pre-field-15 encode
with a current unstamped encode, per-entry drop of a stamp failing a
row-count clause, the compaction-part path, proptest coverage of the
new field over the wire domain, and truncation of the stamp submessage
as a typed error (the fixture stamps the last entry so the tail cut
genuinely lands inside field 15).

An adversarial checkpoint reviewed the result; both its findings are
fixed in the second commit (a missing mechanical default that broke the
sql-latency feature lane, and the truncation fixture cutting an
unstamped entry).

Local gate note: catalog suites and the sql-latency compile verified
locally; full workspace gates run in this PR's required CI.

Refs: #873