### PR TITLE
feat(ingest): surface per-trigger flush counts in the load report

### DIFF
--- a/crates/ravel-ingest/src/lib.rs
+++ b/crates/ravel-ingest/src/lib.rs
@@ -56,7 +56,7 @@ pub use lifecycle::{
     overlay_admission_limits, refresh_tenant_limits_once,
 };
 pub use log_error::LogWriteError;
-pub use log_metrics::{LogIngestMetrics, LogIngestMetricsSnapshot};
+pub use log_metrics::{FlushTriggerMix, LogIngestMetrics, LogIngestMetricsSnapshot};
 pub use log_router::{LogIndexedFields, LogIngestRouter, LogWriteReceipt, NoIndexedFields};
 pub use metrics::{FlushTrigger, IngestMetrics, IngestMetricsSnapshot, ShardSkewStats};
 pub use metrics_meta_sink::{

--- a/crates/ravel-ingest/src/log_metrics.rs
+++ b/crates/ravel-ingest/src/log_metrics.rs
@@ -151,6 +151,19 @@ pub struct LogIngestMetrics {
     /// gauge with a per-shard dimension, unlike everything else here; read it
     /// via [`LogIngestMetrics::in_flight_flushes_by_shard`].
     in_flight_flushes: Mutex<HashMap<u32, i64>>,
+    /// Per-shard flush counts split by the trigger that opened each flush
+    /// (issue #983), so two loads of the same input can be compared honestly:
+    /// object count is not a function of the command line (input order
+    /// concentrates consecutive rows on one shard, and the wall-clock age
+    /// trigger makes host speed change the layout), but the trigger mix that
+    /// produced it is. Recorded at flush open on the actor, alongside the
+    /// process-wide `flushes_by_*` counters, from the `FlushTrigger` the
+    /// decision site passed; the cause is never inferred after the fact. Carries
+    /// a per-shard dimension like `in_flight_flushes`, so it is read via
+    /// [`LogIngestMetrics::flush_trigger_mix_by_shard`] rather than folded into
+    /// the flat snapshot. A shard that never flushed is simply absent,
+    /// equivalent to an all-zero [`FlushTriggerMix`].
+    flush_trigger_mix: Mutex<HashMap<u32, FlushTriggerMix>>,
     /// Per-shard ingest-skew accounting (issue #865), the log-pipeline
     /// counterpart of [`crate::IngestMetrics`]'s own: message throughput and the
     /// on-actor / flush-permit-wait / off-actor time split. Same accumulator
@@ -202,6 +215,36 @@ pub struct LogIngestMetricsSnapshot {
     pub dynamic_columns_used_total: u64,
     pub dynamic_columns_overflowed_total: u64,
     pub dynamic_columns_used_max: u64,
+}
+
+/// One shard's flush count split by the trigger that opened each flush (issue
+/// #983). The three causes are disjoint and every flush lands in exactly one,
+/// so [`FlushTriggerMix::total`] equals the shard's flushes-opened count. Read
+/// via [`LogIngestMetrics::flush_trigger_mix_by_shard`].
+///
+/// Attempt-time, like the process-wide `flushes_by_*` counters: a flush is
+/// counted here when it is opened, so one later abandoned still counts. On a
+/// load that abandons nothing, the per-shard total equals the objects the shard
+/// wrote, and the sum across shards equals the load's object count.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct FlushTriggerMix {
+    /// Flushes opened because the tenant buffer reached `target_bytes`
+    /// ([`FlushTrigger::Size`]).
+    pub size: u64,
+    /// Flushes opened because the tenant buffer aged past `max_flush_delay`
+    /// ([`FlushTrigger::Age`], and the metrics-only [`FlushTrigger::AgeAdaptive`]
+    /// the log actor never raises).
+    pub age: u64,
+    /// Flushes opened by the final drain at close: a [`FlushTrigger::Manual`]
+    /// shutdown drain, channel-close drain, or explicit flush request.
+    pub final_drain: u64,
+}
+
+impl FlushTriggerMix {
+    /// The shard's flushes-opened count, the sum of the three disjoint causes.
+    pub fn total(&self) -> u64 {
+        self.size + self.age + self.final_drain
+    }
 }
 
 impl LogIngestMetrics {
@@ -261,7 +304,7 @@ impl LogIngestMetrics {
         self.shard_skew.by_shard()
     }
 
-    pub(crate) fn record_flush(&self, trigger: FlushTrigger) {
+    pub(crate) fn record_flush(&self, shard: u32, trigger: FlushTrigger) {
         let counter = match trigger {
             FlushTrigger::Size => &self.flushes_by_size,
             // The log shard actor has no adaptive-delay trigger of its own
@@ -272,6 +315,33 @@ impl LogIngestMetrics {
             FlushTrigger::Manual => &self.flushes_manual,
         };
         counter.fetch_add(1, Ordering::Relaxed);
+
+        // Per-shard split (issue #983), from the same `trigger` the process-wide
+        // counter above used, so the two can never disagree on the cause.
+        let mut map = self
+            .flush_trigger_mix
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let entry = map.entry(shard).or_default();
+        match trigger {
+            FlushTrigger::Size => entry.size += 1,
+            FlushTrigger::Age | FlushTrigger::AgeAdaptive => entry.age += 1,
+            FlushTrigger::Manual => entry.final_drain += 1,
+        }
+    }
+
+    /// Point-in-time per-shard flush trigger mix, sorted by shard index (issue
+    /// #983). A shard that never flushed is absent, equivalent to an all-zero
+    /// [`FlushTriggerMix`]. This is the honest comparison basis between two
+    /// loads of the same input, which the raw object count is not.
+    pub fn flush_trigger_mix_by_shard(&self) -> Vec<(u32, FlushTriggerMix)> {
+        let map = self
+            .flush_trigger_mix
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let mut mix: Vec<(u32, FlushTriggerMix)> = map.iter().map(|(&s, &m)| (s, m)).collect();
+        mix.sort_unstable_by_key(|&(shard, _)| shard);
+        mix
     }
 
     /// Attribute one completed flush's PUTs to `tenant` (success-time,
@@ -472,21 +542,21 @@ mod tests {
     #[test]
     fn each_record_method_increments_only_its_own_counter() {
         assert_only(
-            |m| m.record_flush(FlushTrigger::Size),
+            |m| m.record_flush(0, FlushTrigger::Size),
             LogIngestMetricsSnapshot {
                 flushes_by_size: 1,
                 ..Default::default()
             },
         );
         assert_only(
-            |m| m.record_flush(FlushTrigger::Age),
+            |m| m.record_flush(0, FlushTrigger::Age),
             LogIngestMetricsSnapshot {
                 flushes_by_age: 1,
                 ..Default::default()
             },
         );
         assert_only(
-            |m| m.record_flush(FlushTrigger::Manual),
+            |m| m.record_flush(0, FlushTrigger::Manual),
             LogIngestMetricsSnapshot {
                 flushes_manual: 1,
                 ..Default::default()
@@ -600,8 +670,8 @@ mod tests {
     #[test]
     fn counters_accumulate_across_calls() {
         let metrics = LogIngestMetrics::default();
-        metrics.record_flush(FlushTrigger::Age);
-        metrics.record_flush(FlushTrigger::Age);
+        metrics.record_flush(0, FlushTrigger::Age);
+        metrics.record_flush(0, FlushTrigger::Age);
         metrics.record_buffered(10, 1);
         metrics.record_buffered(5, 2);
 
@@ -609,6 +679,79 @@ mod tests {
         assert_eq!(snap.flushes_by_age, 2);
         assert_eq!(snap.buffered_bytes_total, 15);
         assert_eq!(snap.buffered_records_total, 3);
+    }
+
+    #[test]
+    fn flush_trigger_mix_splits_by_shard_and_cause() {
+        let metrics = LogIngestMetrics::default();
+        // Shard 0: two size, one age, one final. Shard 3: one final only.
+        metrics.record_flush(0, FlushTrigger::Size);
+        metrics.record_flush(0, FlushTrigger::Size);
+        metrics.record_flush(0, FlushTrigger::Age);
+        metrics.record_flush(0, FlushTrigger::Manual);
+        metrics.record_flush(3, FlushTrigger::Manual);
+
+        let mix = metrics.flush_trigger_mix_by_shard();
+        assert_eq!(
+            mix,
+            vec![
+                (
+                    0,
+                    FlushTriggerMix {
+                        size: 2,
+                        age: 1,
+                        final_drain: 1,
+                    }
+                ),
+                (
+                    3,
+                    FlushTriggerMix {
+                        size: 0,
+                        age: 0,
+                        final_drain: 1,
+                    }
+                ),
+            ],
+            "each cause lands in its own field, keyed by the flushing shard, sorted by shard index"
+        );
+        // total() is the shard's flushes-opened count.
+        assert_eq!(mix[0].1.total(), 4);
+        assert_eq!(mix[1].1.total(), 1);
+        // The process-wide flat counters equal the mix summed across shards.
+        let snap = metrics.snapshot();
+        assert_eq!(snap.flushes_by_size, 2);
+        assert_eq!(snap.flushes_by_age, 1);
+        assert_eq!(snap.flushes_manual, 2);
+    }
+
+    #[test]
+    fn adaptive_age_folds_into_the_age_cause() {
+        // The log actor never raises AgeAdaptive, but the shared enum has it;
+        // if a call ever does, it must count as age, not silently vanish.
+        let metrics = LogIngestMetrics::default();
+        metrics.record_flush(1, FlushTrigger::AgeAdaptive);
+        let mix = metrics.flush_trigger_mix_by_shard();
+        assert_eq!(
+            mix,
+            vec![(
+                1,
+                FlushTriggerMix {
+                    size: 0,
+                    age: 1,
+                    final_drain: 0
+                }
+            )]
+        );
+    }
+
+    #[test]
+    fn fresh_flush_trigger_mix_is_empty() {
+        assert!(
+            LogIngestMetrics::default()
+                .flush_trigger_mix_by_shard()
+                .is_empty(),
+            "a router that never flushed reports no shards, not zeroed ones"
+        );
     }
 
     #[test]

--- a/crates/ravel-ingest/src/log_shard.rs
+++ b/crates/ravel-ingest/src/log_shard.rs
@@ -1182,7 +1182,7 @@ impl LogShardActor {
                 FlushPayload::Columnar(batches)
             }
         };
-        self.metrics.record_flush(trigger);
+        self.metrics.record_flush(self.shard, trigger);
 
         let tenant_hash = tenant.hash();
         let seq = self.next_seq;
@@ -1303,6 +1303,7 @@ mod tests {
 
     use super::*;
     use crate::budget::{IngestByteBudget, IngestByteBudgetLimit};
+    use crate::log_metrics::FlushTriggerMix;
 
     const BASE_NS: i64 = 1_700_000_000_000_000_000;
 
@@ -1372,6 +1373,10 @@ mod tests {
             shard_count: 1,
             target_bytes: 8 * 1024 * 1024,
             max_flush_delay,
+            // Age a buffer with no strict waiter on the same clock, so a
+            // buffered (no-ack) fixture ages deterministically rather than
+            // waiting out the much longer idle threshold.
+            max_flush_delay_idle: max_flush_delay,
             flush_tick: Duration::from_millis(10),
             put_retry_base_delay: Duration::from_millis(1),
             put_retry_max_delay: Duration::from_millis(5),
@@ -1427,6 +1432,37 @@ mod tests {
             let _ = self.tx.send(LogShardMsg::Shutdown { done: done_tx }).await;
             let _ = done_rx.await;
             let _ = self.task.await;
+        }
+
+        /// This single-shard harness's trigger mix for shard 0, or an all-zero
+        /// mix if it never flushed.
+        fn shard0_mix(&self) -> crate::log_metrics::FlushTriggerMix {
+            self.metrics
+                .flush_trigger_mix_by_shard()
+                .into_iter()
+                .find(|(shard, _)| *shard == 0)
+                .map(|(_, mix)| mix)
+                .unwrap_or_default()
+        }
+
+        /// Buffered (no-ack) write of one record for `tenant`. The record only
+        /// reaches the store via an age or shutdown flush, never a size one on
+        /// the `no_size_flush` config.
+        async fn buffer_one(&self, tenant: &TenantId, body: &str) {
+            self.tx
+                .send(LogShardMsg::Write {
+                    tenant: tenant.clone(),
+                    records: vec![norm_record(
+                        &[("service.name", "api")],
+                        "scope",
+                        1_000,
+                        body,
+                    )],
+                    ack: None,
+                    charge: None,
+                })
+                .await
+                .expect("send buffered write");
         }
     }
 
@@ -1594,6 +1630,183 @@ mod tests {
             "the shutdown drain stored a commit record"
         );
         assert_eq!(metrics.snapshot().flushes_manual, 1);
+    }
+
+    /// Count the RLOG data objects (`/l0/`) durable in the store: one per flush
+    /// that reached a commit, the ground truth the trigger mix must sum to.
+    async fn data_object_count(store: &dyn ObjectStoreBackend) -> u64 {
+        let objects = list_all(store, "t/").await.expect("list");
+        objects.iter().filter(|o| o.key.contains("/l0/")).count() as u64
+    }
+
+    /// Test 1a (issue #983): a shard filled to the size target records exactly
+    /// one size-triggered flush per write and zero age flushes. `flush_on_first`
+    /// sets `target_bytes: 1`, so each Strict write flushes inside its own
+    /// `handle_write`; N writes are N size flushes, and nothing is left to age
+    /// or drain at close.
+    #[tokio::test]
+    async fn size_flushes_record_exact_count_and_no_age() {
+        const N: u64 = 3;
+        let h = Harness::spawn(flush_on_first());
+        let tenant = TenantId::new("acme");
+        for i in 0..N {
+            let (ack_tx, ack_rx) = oneshot::channel();
+            h.tx.send(LogShardMsg::Write {
+                tenant: tenant.clone(),
+                records: vec![norm_record(&[("service.name", "api")], "scope", 1_000, "x")],
+                ack: Some(ack_tx),
+                charge: None,
+            })
+            .await
+            .expect("send write");
+            ack_rx
+                .await
+                .expect("ack sender not dropped")
+                .unwrap_or_else(|_| panic!("size flush {i} commits"));
+        }
+
+        let mix = h.shard0_mix();
+        assert_eq!(
+            mix,
+            FlushTriggerMix {
+                size: N,
+                age: 0,
+                final_drain: 0,
+            },
+            "each of the N size-target writes is one size flush, none age or drain"
+        );
+        // Every flush already committed before shutdown, so the drain adds none.
+        h.shutdown().await;
+    }
+
+    /// Test 1b (issue #983): buffers that trickle below the size target and are
+    /// released only when the injected clock passes `max_flush_delay` record
+    /// exactly M age flushes, zero size flushes. M distinct tenants buffer one
+    /// record each (no size flush can fire on `no_size_flush`'s huge target),
+    /// then a single clock advance ages all M at once. Time is injected, never
+    /// slept.
+    #[tokio::test]
+    async fn age_flushes_record_exact_count() {
+        const M: u64 = 3;
+        let h = Harness::spawn(no_size_flush(Duration::from_millis(50)));
+        let tenants: Vec<TenantId> = (0..M).map(|i| TenantId::new(format!("t{i}"))).collect();
+        for t in &tenants {
+            h.buffer_one(t, "x").await;
+        }
+        // All M records buffered before the clock moves, so their arrival is the
+        // pre-advance time and one advance ages every one of them.
+        while h.metrics.snapshot().buffered_records_total < M {
+            tokio::task::yield_now().await;
+        }
+        h.clock.advance_ns(100_000_000);
+        while h.shard0_mix().age < M {
+            tokio::task::yield_now().await;
+        }
+
+        let mix = h.shard0_mix();
+        assert_eq!(
+            mix,
+            FlushTriggerMix {
+                size: 0,
+                age: M,
+                final_drain: 0,
+            },
+            "each of the M aged buffers is one age flush, none by size"
+        );
+        h.shutdown().await;
+    }
+
+    /// Test 1c (issue #983): the final drain at close records exactly the
+    /// buffered-tenant count as final flushes. `no_size_flush` with an hour-long
+    /// delay means neither size nor age can fire; only the shutdown drain
+    /// flushes, once per buffered tenant.
+    #[tokio::test]
+    async fn close_records_exact_final_drain_count() {
+        const K: u64 = 3;
+        let h = Harness::spawn(no_size_flush(Duration::from_secs(3600)));
+        let tenants: Vec<TenantId> = (0..K).map(|i| TenantId::new(format!("t{i}"))).collect();
+        for t in &tenants {
+            h.buffer_one(t, "x").await;
+        }
+        while h.metrics.snapshot().buffered_records_total < K {
+            tokio::task::yield_now().await;
+        }
+
+        let store = Arc::clone(&h.store);
+        let metrics = Arc::clone(&h.metrics);
+        h.shutdown().await;
+
+        let mix = metrics
+            .flush_trigger_mix_by_shard()
+            .into_iter()
+            .find(|(shard, _)| *shard == 0)
+            .map(|(_, mix)| mix)
+            .unwrap_or_default();
+        assert_eq!(
+            mix,
+            FlushTriggerMix {
+                size: 0,
+                age: 0,
+                final_drain: K,
+            },
+            "the shutdown drain flushes each buffered tenant once, as final"
+        );
+        assert_eq!(data_object_count(store.as_ref()).await, K);
+    }
+
+    /// Test 2 (issue #983): the sum invariant on known geometry. Two tenants age
+    /// out, a third drains at close; size never fires. The per-cause counts are
+    /// exactly (0, 2, 1), and `size + age + final == total == objects written`
+    /// holds as exact equality, not a lower bound.
+    #[tokio::test]
+    async fn trigger_mix_sum_equals_total_and_objects_written() {
+        let h = Harness::spawn(no_size_flush(Duration::from_millis(50)));
+        let aged = [TenantId::new("aged0"), TenantId::new("aged1")];
+        for t in &aged {
+            h.buffer_one(t, "x").await;
+        }
+        while h.metrics.snapshot().buffered_records_total < 2 {
+            tokio::task::yield_now().await;
+        }
+        h.clock.advance_ns(100_000_000);
+        while h.shard0_mix().age < 2 {
+            tokio::task::yield_now().await;
+        }
+
+        // A third tenant buffered after the advance: its arrival is now, the
+        // clock does not move again, so it cannot age and drains at close.
+        let drained = TenantId::new("drained");
+        h.buffer_one(&drained, "x").await;
+        while h.metrics.snapshot().buffered_records_total < 3 {
+            tokio::task::yield_now().await;
+        }
+
+        let store = Arc::clone(&h.store);
+        let metrics = Arc::clone(&h.metrics);
+        h.shutdown().await;
+
+        let mix = metrics
+            .flush_trigger_mix_by_shard()
+            .into_iter()
+            .find(|(shard, _)| *shard == 0)
+            .map(|(_, m)| m)
+            .unwrap_or_default();
+        assert_eq!(
+            mix,
+            FlushTriggerMix {
+                size: 0,
+                age: 2,
+                final_drain: 1,
+            }
+        );
+        let objects = data_object_count(store.as_ref()).await;
+        assert_eq!(mix.size + mix.age + mix.final_drain, mix.total());
+        assert_eq!(mix.total(), 3, "known geometry: two aged, one drained");
+        assert_eq!(
+            mix.total(),
+            objects,
+            "every counted flush wrote exactly one object; the sum is the object count"
+        );
     }
 
     #[tokio::test]

--- a/docs/guides/clickbench.md
+++ b/docs/guides/clickbench.md
@@ -255,9 +255,23 @@ working set from 3 to 6 batches, roughly `2x` on the same geometry. That is the
 memory the default spends.
 
 The loader prints a completion summary to stdout — `rows processed`,
-`objects written`, and `elapsed` (the load wall-time ClickBench reports). It also
+`objects written`, `elapsed` (the load wall-time ClickBench reports), and a
+`flush triggers` breakdown. It also
 prints a stderr warning if any object crossed, or came within 90% of, the
-per-object dynamic-column budget of 1000. The `hits` schema is 104 attribute
+per-object dynamic-column budget of 1000.
+
+`objects written` is not reproducible across runs of the same command, and is
+not a function of the command line alone (issue #983): input order concentrates
+consecutive rows on one shard, and the 2-second `max_flush_delay` age trigger
+means a slower host ages more buffers out before they reach `--target-bytes`,
+changing the layout. Two loads of the same file can therefore write different
+object counts and still be correct. The comparison basis that *is* stable is the
+`flush triggers` line, which states how many flushes each cause opened: `size`
+(a buffer reached `--target-bytes`), `age` (a buffer aged past `max_flush_delay`),
+and `final` (the drain at load close), per shard and as load totals. The three
+causes are disjoint and sum to the objects written, so a mix that shifts from
+`size` toward `age` between two runs explains an object-count difference that the
+count alone cannot. Compare the mix, not the raw count. The `hits` schema is 104 attribute
 columns (see step 3), far under that budget, so a clean load prints no such
 warning; one appearing means a per-object attribute set is wider than the schema
 suggests (stray per-record keys), which is worth investigating before trusting

--- a/services/ravel-cli/src/load.rs
+++ b/services/ravel-cli/src/load.rs
@@ -34,8 +34,8 @@ use ravel_catalog::{AbsentPolicy, validate_or_adopt};
 #[cfg(feature = "stage-timing")]
 use ravel_ingest::LogStageSnapshot;
 use ravel_ingest::{
-    Clock, IngestConfig, LogIngestMetricsSnapshot, LogIngestRouter, LogWriteError, LogWriteReceipt,
-    SystemClock, WriteMode,
+    Clock, FlushTriggerMix, IngestConfig, LogIngestMetricsSnapshot, LogIngestRouter, LogWriteError,
+    LogWriteReceipt, SystemClock, WriteMode,
 };
 use ravel_logseg::{
     Bitmap, ColumnarLogBatch, DynColumn, FieldType, StrColumnDict, stream_attrs_bytes,
@@ -45,7 +45,7 @@ use ravel_otlp::NormalizedLogRecord;
 use ravel_otlp::logs_limits::LogIngestLimits;
 use ravel_types::logstream::{AttrValue, LogStreamId, log_stream_id};
 use ravel_types::{CommitToken, Signal, TenantId};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// Per-record attribute cap for the loader (ADR-0089 relaxation of the
 /// `ravel-otlp` 128-per-record network cap).
@@ -540,8 +540,39 @@ fn print_summary(report: &LoadReport) {
     println!("  rows/sec         : {rows_per_sec:.0}");
     println!("  objects written  : {}", report.objects_written());
     println!("  elapsed          : {secs:.3}s");
+    print_flush_mix(report);
     #[cfg(feature = "stage-timing")]
     print_stage_timings(report);
+}
+
+/// Print the per-shard flush trigger mix (issue #983) under the summary totals.
+/// Object count is not a function of the command line, so the mix that produced
+/// it is what makes two loads of the same input comparable. A load whose
+/// metrics carry no per-shard mix (a router that never flushed) prints nothing
+/// rather than a zeroed line.
+fn print_flush_mix(report: &LoadReport) {
+    let mix = report.flush_mix_report();
+    if mix.shards.is_empty() {
+        return;
+    }
+    let t = &mix.totals;
+    println!(
+        "  flush triggers   : size {}, age {}, final {} (total {})",
+        t.size,
+        t.age,
+        t.final_drain,
+        t.total(),
+    );
+    for s in &mix.shards {
+        println!(
+            "    shard {:>3}      : size {}, age {}, final {} (total {})",
+            s.shard,
+            s.counts.size,
+            s.counts.age,
+            s.counts.final_drain,
+            s.counts.total(),
+        );
+    }
 }
 
 /// Print the logs pipeline's per-stage timing breakdown (ADR-0104 decision 1)
@@ -645,6 +676,15 @@ pub struct LoadReport {
     /// return path for a per-load signal (`LogIngestRouter::metrics()` is only
     /// reachable by whoever constructed the router, which is `load` itself).
     pub metrics: LogIngestMetricsSnapshot,
+    /// Per-shard flush counts split by trigger cause (size / age / final drain),
+    /// snapshotted with `metrics` once the load finished (issue #983). This is
+    /// the honest basis for comparing two loads of the same input: the raw
+    /// object count is not a function of the command line (input order
+    /// concentrates consecutive rows on one shard, and the 2-second age trigger
+    /// makes host speed change the layout), but the trigger mix that produced it
+    /// is. Sorted by shard index; a shard that never flushed is absent. Empty on
+    /// a tenant loaded before this change, which is not an error.
+    pub flush_trigger_mix: Vec<(u32, FlushTriggerMix)>,
     /// The early shard-skew warning (issue #560), set at most once, the first
     /// time the check at [`SKEW_CHECK_AFTER_BATCHES`] data batches finds the
     /// spread at or below the [`SKEW_WARN_DENOMINATOR`] threshold. `None` when
@@ -676,6 +716,77 @@ impl LoadReport {
             .filter(|t| seen.insert(t.encode()))
             .count()
     }
+
+    /// The machine-readable per-shard flush trigger mix plus its totals (issue
+    /// #983), the serializable projection of [`LoadReport::flush_trigger_mix`].
+    /// Empty `shards` on a tenant loaded before this change, which is not an
+    /// error.
+    pub fn flush_mix_report(&self) -> FlushMixReport {
+        let shards: Vec<ShardFlushMix> = self
+            .flush_trigger_mix
+            .iter()
+            .map(|(shard, mix)| ShardFlushMix {
+                shard: *shard,
+                counts: FlushMixCounts {
+                    size: mix.size,
+                    age: mix.age,
+                    final_drain: mix.final_drain,
+                },
+            })
+            .collect();
+        let mut totals = FlushMixCounts::default();
+        for s in &shards {
+            totals.size += s.counts.size;
+            totals.age += s.counts.age;
+            totals.final_drain += s.counts.final_drain;
+        }
+        FlushMixReport { shards, totals }
+    }
+}
+
+/// Flush counts split by trigger cause: how many flushes each of the three
+/// disjoint triggers opened (issue #983). The serializable counterpart of
+/// [`ravel_ingest::FlushTriggerMix`], carried per shard and as load totals. The
+/// `final` drain is serialized under that name (a Rust keyword, so the field is
+/// `final_drain`).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FlushMixCounts {
+    /// Flushes opened because a shard buffer reached `--target-bytes`.
+    pub size: u64,
+    /// Flushes opened because a shard buffer aged past `max_flush_delay`.
+    pub age: u64,
+    /// Flushes opened by the final drain at load close.
+    #[serde(rename = "final")]
+    pub final_drain: u64,
+}
+
+impl FlushMixCounts {
+    /// The flushes-opened count, the sum of the three disjoint causes. On a load
+    /// that abandons nothing this equals the objects written.
+    pub fn total(&self) -> u64 {
+        self.size + self.age + self.final_drain
+    }
+}
+
+/// One shard's flush trigger mix, keyed by shard index (issue #983).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ShardFlushMix {
+    pub shard: u32,
+    #[serde(flatten)]
+    pub counts: FlushMixCounts,
+}
+
+/// The load's per-shard flush trigger mix and its totals (issue #983), the
+/// machine-readable form of the same figures [`print_summary`] prints. Object
+/// count is not a function of the command line, so this states the trigger mix
+/// that produced it, which is comparable between two loads of the same input.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FlushMixReport {
+    /// One row per shard that flushed, sorted by shard index. Empty on a tenant
+    /// loaded before issue #983, which is not an error.
+    pub shards: Vec<ShardFlushMix>,
+    /// The size / age / final counts summed across every shard.
+    pub totals: FlushMixCounts,
 }
 
 /// A load failure. Every variant that can occur after some data is already
@@ -1249,6 +1360,7 @@ async fn load_instrumented(
     // reads the dynamic-column figures to warn on overflow or near-cap pressure
     // (ADR-0100 decision 1).
     report.metrics = router.metrics().snapshot();
+    report.flush_trigger_mix = router.metrics().flush_trigger_mix_by_shard();
     #[cfg(feature = "stage-timing")]
     {
         report.stage_timings = router.stage_timings().snapshot();
@@ -3675,6 +3787,99 @@ type = "i64"
         )
         .await
         .expect("load succeeds")
+    }
+
+    /// Reachability (issue #983): a real `load` run carries the per-shard flush
+    /// trigger mix in the same report the objects-written figure lives in, and
+    /// the mix sums to the object count. One row routes to one shard and flushes
+    /// by size at the default target, so this asserts an exact (size 1, age 0,
+    /// final 0) on a single shard rather than `> 0`.
+    #[tokio::test]
+    async fn load_report_carries_the_flush_trigger_mix() {
+        let report = run_wide_load(4).await;
+        assert!(
+            !report.flush_trigger_mix.is_empty(),
+            "a real load records at least one shard's flushes"
+        );
+        let mix = report.flush_mix_report();
+        assert_eq!(mix.shards.len(), 1, "one row routes to exactly one shard");
+        assert_eq!(
+            mix.shards[0].counts,
+            FlushMixCounts {
+                size: 1,
+                age: 0,
+                final_drain: 0,
+            },
+            "the single row flushes by size, nothing ages or drains"
+        );
+        assert_eq!(
+            mix.totals,
+            FlushMixCounts {
+                size: 1,
+                age: 0,
+                final_drain: 0,
+            }
+        );
+        assert_eq!(
+            mix.totals.total(),
+            report.objects_written() as u64,
+            "the mix sums to the objects the same report reports"
+        );
+    }
+
+    /// Round-trip (issue #983): the machine-readable flush mix serializes and
+    /// deserializes without changing the counts, and the final drain is keyed
+    /// `final` in the serialized form (the Rust field is `final_drain`, since
+    /// `final` is a keyword). Test 3's serialize/deserialize half.
+    #[test]
+    fn flush_mix_report_round_trips_through_json() {
+        let report = LoadReport {
+            flush_trigger_mix: vec![
+                (
+                    0,
+                    FlushTriggerMix {
+                        size: 5,
+                        age: 2,
+                        final_drain: 1,
+                    },
+                ),
+                (
+                    2,
+                    FlushTriggerMix {
+                        size: 0,
+                        age: 0,
+                        final_drain: 3,
+                    },
+                ),
+            ],
+            ..LoadReport::default()
+        };
+        let mix = report.flush_mix_report();
+        assert_eq!(
+            mix.totals,
+            FlushMixCounts {
+                size: 5,
+                age: 2,
+                final_drain: 4,
+            },
+            "totals sum each cause across shards"
+        );
+
+        let json = serde_json::to_string(&mix).expect("serialize");
+        assert!(
+            json.contains("\"final\":"),
+            "the drain is keyed `final` in the serialized form: {json}"
+        );
+        let back: FlushMixReport = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(
+            back, mix,
+            "the round trip preserves the exact per-shard counts and totals"
+        );
+        // The per-shard rows survive keyed by shard, not reordered or merged.
+        assert_eq!(back.shards[0].shard, 0);
+        assert_eq!(back.shards[0].counts.size, 5);
+        assert_eq!(back.shards[1].shard, 2);
+        assert_eq!(back.shards[1].counts.final_drain, 3);
     }
 
     /// A real `load --parquet` run wires and records every stage of the logs


### PR DESCRIPTION
Object count is not a function of the command line: input order
concentrates consecutive rows on one shard, and the 2-second age
trigger makes host speed change the layout, so two correct loads of the
same file can differ in objects written. The load report now states its
per-shard trigger mix (size/age/final flush counts) plus totals beside
the objects-written figure, with a serializable FlushMixReport for the
machine-readable form. The cause is the FlushTrigger the decision site
already passes, incremented once per flush, never inferred afterward;
the three causes are disjoint and sum to the shard's flushes.

The clickbench guide's completion-summary note points at the trigger
mix as the stable comparison basis between runs.

Local gate note: executor ran workspace clippy and affected tests; full
workspace gates run in this PR's required CI.

Fixes: #983
Refs: #996